### PR TITLE
fix: CI Python 3.13 only, fix all ruff lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
           cache: 'pip'
 
       - name: Install dependencies
@@ -43,10 +40,10 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y castxml zlib1g-dev
 
-      - name: Set up Python
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: 'pip'
 
       - name: Install package

--- a/abi_check/checker.py
+++ b/abi_check/checker.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Tuple
 
-from .model import AbiSnapshot, Function, RecordType, Variable, Visibility
+from .model import AbiSnapshot, Function, Visibility
 
 
 class ChangeKind(str, Enum):
@@ -83,8 +82,8 @@ class Change:
     kind: ChangeKind
     symbol: str               # mangled name or type name
     description: str          # human-readable
-    old_value: Optional[str] = None
-    new_value: Optional[str] = None
+    old_value: str | None = None
+    new_value: str | None = None
 
 
 @dataclass
@@ -92,28 +91,28 @@ class DiffResult:
     old_version: str
     new_version: str
     library: str
-    changes: List[Change] = field(default_factory=list)
+    changes: list[Change] = field(default_factory=list)
     verdict: Verdict = Verdict.NO_CHANGE
 
     @property
-    def breaking(self) -> List[Change]:
+    def breaking(self) -> list[Change]:
         return [c for c in self.changes if c.kind in _BREAKING_KINDS]
 
     @property
-    def source_breaks(self) -> List[Change]:
+    def source_breaks(self) -> list[Change]:
         return [c for c in self.changes if c.kind in _SOURCE_BREAK_KINDS]
 
     @property
-    def compatible(self) -> List[Change]:
+    def compatible(self) -> list[Change]:
         return [c for c in self.changes if c.kind in _COMPATIBLE_KINDS]
 
 
-def _public(funcs) -> List[Function]:
+def _public(funcs) -> list[Function]:
     return [f for f in funcs if f.visibility == Visibility.PUBLIC]
 
 
-def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> List[Change]:
-    changes: List[Change] = []
+def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
     old_map = {f.mangled: f for f in _public(old.functions)}
     new_map = {f.mangled: f for f in _public(new.functions)}
 
@@ -186,8 +185,8 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> List[Change]:
     return changes
 
 
-def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> List[Change]:
-    changes: List[Change] = []
+def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
     old_map = {v.mangled: v for v in old.variables if v.visibility == Visibility.PUBLIC}
     new_map = {v.mangled: v for v in new.variables if v.visibility == Visibility.PUBLIC}
 
@@ -216,8 +215,8 @@ def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> List[Change]:
     return changes
 
 
-def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> List[Change]:
-    changes: List[Change] = []
+def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
     old_map = {t.name: t for t in old.types}
     new_map = {t.name: t for t in new.types}
 
@@ -311,7 +310,7 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> List[Change]:
     return changes
 
 
-def _compute_verdict(changes: List[Change]) -> Verdict:
+def _compute_verdict(changes: list[Change]) -> Verdict:
     if not changes:
         return Verdict.NO_CHANGE
     kinds = {c.kind for c in changes}
@@ -324,7 +323,7 @@ def _compute_verdict(changes: List[Change]) -> Verdict:
 
 def compare(old: AbiSnapshot, new: AbiSnapshot) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict."""
-    changes: List[Change] = []
+    changes: list[Change] = []
     changes.extend(_diff_functions(old, new))
     changes.extend(_diff_variables(old, new))
     changes.extend(_diff_types(old, new))

--- a/abi_check/cli.py
+++ b/abi_check/cli.py
@@ -1,17 +1,15 @@
 """CLI — abi-check dump | compare | scan."""
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
-from typing import List, Optional
 
 import click
 
 from .checker import compare
 from .dumper import dump
 from .reporter import to_json, to_markdown
-from .serialization import load_snapshot, save_snapshot
+from .serialization import load_snapshot
 
 
 @click.group()
@@ -32,7 +30,7 @@ def main():
 @click.option("-o", "--output", "output", type=click.Path(path_type=Path), default=None,
               help="Output JSON file. Defaults to stdout.")
 def dump_cmd(so_path: Path, headers: tuple, includes: tuple,
-             version: str, compiler: str, output: Optional[Path]):
+             version: str, compiler: str, output: Path | None):
     """Dump ABI snapshot of a shared library to JSON.
 
     \b
@@ -61,7 +59,7 @@ def dump_cmd(so_path: Path, headers: tuple, includes: tuple,
 @click.option("--format", "fmt", type=click.Choice(["json", "markdown"]),
               default="markdown", show_default=True)
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
-def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Optional[Path]):
+def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path | None):
     """Compare two ABI snapshots and report changes.
 
     \b

--- a/abi_check/dumper.py
+++ b/abi_check/dumper.py
@@ -1,19 +1,22 @@
 """Dumper — headers + .so → AbiSnapshot via castxml."""
 from __future__ import annotations
 
-import json
 import re
 import shutil
 import subprocess
 import tempfile
 import warnings
 from pathlib import Path
-from typing import List, Optional
 from xml.etree import ElementTree as ET
 
 from .model import (
-    AbiSnapshot, Function, Param, ParamKind, RecordType,
-    TypeField, Variable, Visibility,
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
 )
 
 
@@ -53,7 +56,7 @@ def _readelf_exported_symbols(so_path: Path) -> set[str]:
     return exported
 
 
-def _castxml_dump(headers: List[Path], extra_includes: List[Path],
+def _castxml_dump(headers: list[Path], extra_includes: list[Path],
                   compiler: str = "c++") -> ET.Element:
     """Run castxml on headers and return parsed XML root.
 
@@ -115,7 +118,7 @@ class _CastxmlParser:
             if eid:
                 self._id_map[eid] = el
 
-    def _resolve(self, id_: str) -> Optional[ET.Element]:
+    def _resolve(self, id_: str) -> ET.Element | None:
         return self._id_map.get(id_)
 
     def _type_name(self, id_: str, depth: int = 0) -> str:
@@ -142,7 +145,6 @@ class _CastxmlParser:
         if tag == "Typedef":
             return el.get("name", "?")
         if tag == "ArrayType":
-            min_ = el.get("min", "0")
             max_ = el.get("max", "")
             base = self._type_name(el.get("type", ""), depth + 1)
             return f"{base}[{max_}]" if max_ else f"{base}[]"
@@ -156,7 +158,7 @@ class _CastxmlParser:
             return Visibility.PUBLIC
         return Visibility.HIDDEN
 
-    def parse_functions(self) -> List[Function]:
+    def parse_functions(self) -> list[Function]:
         funcs = []
         for el in self._root:
             if el.tag not in ("Function", "Method", "Constructor", "Destructor"):
@@ -201,7 +203,7 @@ class _CastxmlParser:
             ))
         return funcs
 
-    def parse_variables(self) -> List[Variable]:
+    def parse_variables(self) -> list[Variable]:
         variables = []
         for el in self._root:
             if el.tag != "Variable":
@@ -217,7 +219,7 @@ class _CastxmlParser:
             ))
         return variables
 
-    def parse_types(self) -> List[RecordType]:
+    def parse_types(self) -> list[RecordType]:
         types = []
         for el in self._root:
             if el.tag not in ("Struct", "Class", "Union"):
@@ -259,8 +261,8 @@ class _CastxmlParser:
 
 def dump(
     so_path: Path,
-    headers: List[Path],
-    extra_includes: Optional[List[Path]] = None,
+    headers: list[Path],
+    extra_includes: list[Path] | None = None,
     version: str = "unknown",
     compiler: str = "c++",
 ) -> AbiSnapshot:

--- a/abi_check/model.py
+++ b/abi_check/model.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional
 
 
 class Visibility(str, Enum):
@@ -24,7 +23,7 @@ class Param:
     name: str
     type: str
     kind: ParamKind = ParamKind.VALUE
-    default: Optional[str] = None  # has default value (value not preserved)
+    default: str | None = None  # has default value (value not preserved)
 
 
 @dataclass
@@ -32,12 +31,12 @@ class Function:
     name: str                        # demangled
     mangled: str                     # mangled symbol name
     return_type: str
-    params: List[Param] = field(default_factory=list)
+    params: list[Param] = field(default_factory=list)
     visibility: Visibility = Visibility.PUBLIC
     is_virtual: bool = False
     is_noexcept: bool = False
-    vtable_index: Optional[int] = None
-    source_location: Optional[str] = None  # "header.h:42"
+    vtable_index: int | None = None
+    source_location: str | None = None  # "header.h:42"
 
 
 @dataclass
@@ -46,14 +45,14 @@ class Variable:
     mangled: str
     type: str
     visibility: Visibility = Visibility.PUBLIC
-    source_location: Optional[str] = None
+    source_location: str | None = None
 
 
 @dataclass
 class TypeField:
     name: str
     type: str
-    offset_bits: Optional[int] = None
+    offset_bits: int | None = None
 
 
 @dataclass
@@ -61,12 +60,12 @@ class RecordType:
     """struct / class / union."""
     name: str
     kind: str  # "struct" | "class" | "union"
-    size_bits: Optional[int] = None
-    fields: List[TypeField] = field(default_factory=list)
-    bases: List[str] = field(default_factory=list)       # base class names
-    virtual_bases: List[str] = field(default_factory=list)
-    vtable: List[str] = field(default_factory=list)      # ordered vtable entries (mangled)
-    source_location: Optional[str] = None
+    size_bits: int | None = None
+    fields: list[TypeField] = field(default_factory=list)
+    bases: list[str] = field(default_factory=list)       # base class names
+    virtual_bases: list[str] = field(default_factory=list)
+    vtable: list[str] = field(default_factory=list)      # ordered vtable entries (mangled)
+    source_location: str | None = None
 
 
 @dataclass
@@ -74,31 +73,31 @@ class AbiSnapshot:
     """Complete ABI snapshot of one version of a library."""
     library: str                   # e.g. "libfoo.so.1"
     version: str                   # e.g. "1.2.3"
-    functions: List[Function] = field(default_factory=list)
-    variables: List[Variable] = field(default_factory=list)
-    types: List[RecordType] = field(default_factory=list)
+    functions: list[Function] = field(default_factory=list)
+    variables: list[Variable] = field(default_factory=list)
+    types: list[RecordType] = field(default_factory=list)
 
     # Indexes (built lazily)
-    _func_by_mangled: Optional[dict] = field(default=None, repr=False, compare=False)
-    _var_by_mangled: Optional[dict] = field(default=None, repr=False, compare=False)
-    _type_by_name: Optional[dict] = field(default=None, repr=False, compare=False)
+    _func_by_mangled: dict | None = field(default=None, repr=False, compare=False)
+    _var_by_mangled: dict | None = field(default=None, repr=False, compare=False)
+    _type_by_name: dict | None = field(default=None, repr=False, compare=False)
 
     def index(self) -> None:
         self._func_by_mangled = {f.mangled: f for f in self.functions}
         self._var_by_mangled = {v.mangled: v for v in self.variables}
         self._type_by_name = {t.name: t for t in self.types}
 
-    def func_by_mangled(self, mangled: str) -> Optional[Function]:
+    def func_by_mangled(self, mangled: str) -> Function | None:
         if self._func_by_mangled is None:
             self.index()
         return self._func_by_mangled.get(mangled)
 
-    def var_by_mangled(self, mangled: str) -> Optional[Variable]:
+    def var_by_mangled(self, mangled: str) -> Variable | None:
         if self._var_by_mangled is None:
             self.index()
         return self._var_by_mangled.get(mangled)
 
-    def type_by_name(self, name: str) -> Optional[RecordType]:
+    def type_by_name(self, name: str) -> RecordType | None:
         if self._type_by_name is None:
             self.index()
         return self._type_by_name.get(name)

--- a/abi_check/reporter.py
+++ b/abi_check/reporter.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
-from typing import List
 
-from .checker import ChangeKind, DiffResult, Verdict, _BREAKING_KINDS, _SOURCE_BREAK_KINDS
+from .checker import (
+    DiffResult,
+    Verdict,
+)
 
 _VERDICT_EMOJI = {
     Verdict.NO_CHANGE: "✅",
@@ -53,11 +54,11 @@ def to_markdown(result: DiffResult) -> str:
     emoji = _VERDICT_EMOJI[v]
     label = _VERDICT_LABEL[v]
 
-    lines: List[str] = [
+    lines: list[str] = [
         f"# ABI Report: {result.library}",
         "",
-        f"| | |",
-        f"|---|---|",
+        "| | |",
+        "|---|---|",
         f"| **Old version** | `{result.old_version}` |",
         f"| **New version** | `{result.new_version}` |",
         f"| **Verdict** | {emoji} `{label}` |",

--- a/abi_check/serialization.py
+++ b/abi_check/serialization.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Union
 
 from .model import (
-    AbiSnapshot, Function, Param, ParamKind, RecordType,
-    TypeField, Variable, Visibility,
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
 )
 
 
@@ -69,11 +73,11 @@ def snapshot_from_dict(d: dict) -> AbiSnapshot:
     )
 
 
-def load_snapshot(path: Union[str, Path]) -> AbiSnapshot:
+def load_snapshot(path: str | Path) -> AbiSnapshot:
     with open(path, encoding="utf-8") as f:
         return snapshot_from_dict(json.load(f))
 
 
-def save_snapshot(snap: AbiSnapshot, path: Union[str, Path]) -> None:
+def save_snapshot(snap: AbiSnapshot, path: str | Path) -> None:
     with open(path, "w", encoding="utf-8") as f:
         f.write(snapshot_to_json(snap))

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -3,12 +3,16 @@
 All test fixtures are original C++ snippets authored for this project.
 No code or test data is derived from abi-compliance-checker (LGPL-2.1).
 """
-import pytest
 
 from abi_check.checker import ChangeKind, Verdict, compare
 from abi_check.model import (
-    AbiSnapshot, Function, Param, ParamKind, RecordType,
-    TypeField, Variable, Visibility,
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
 )
 
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,8 +1,8 @@
 """Tests for abi_check.reporter — JSON and Markdown output."""
-from abi_check.checker import ChangeKind, DiffResult, Verdict
-from abi_check.checker import Change
-from abi_check.reporter import to_json, to_markdown
 import json
+
+from abi_check.checker import Change, ChangeKind, DiffResult, Verdict
+from abi_check.reporter import to_json, to_markdown
 
 
 def _result(verdict: Verdict, changes=None) -> DiffResult:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,11 +1,13 @@
 """Tests for abi_check.serialization — roundtrip JSON."""
-import json
 import tempfile
 from pathlib import Path
 
 from abi_check.model import AbiSnapshot, Function, Visibility
 from abi_check.serialization import (
-    load_snapshot, save_snapshot, snapshot_from_dict, snapshot_to_dict,
+    load_snapshot,
+    save_snapshot,
+    snapshot_from_dict,
+    snapshot_to_dict,
 )
 
 


### PR DESCRIPTION
- Remove 3-version Python matrix → single Python 3.13
- Fix 84 ruff violations: `typing.List/Tuple` → builtins (UP035), unused imports (F401), etc.
- Fix remaining F841: remove unused `min_` variable in `dumper.py`
- ruff clean, 34/34 tests green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated type annotations across the codebase to align with modern Python 3.10+ syntax conventions for improved code quality and consistency.

* **Chores**
  * Updated the continuous integration workflow to use Python 3.13 as the standard version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->