### PR TITLE
feat: ELF_ONLY tracking, vtable reorder, alignment detection, castxml cache

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1,6 +1,7 @@
 """Checker — diff two AbiSnapshots, classify changes, produce a verdict."""
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -24,6 +25,7 @@ class ChangeKind(str, Enum):
 
     # Type changes
     TYPE_SIZE_CHANGED = "type_size_changed"      # struct/class layout change → BREAKING
+    TYPE_ALIGNMENT_CHANGED = "type_alignment_changed"  # alignment change → BREAKING
     TYPE_FIELD_REMOVED = "type_field_removed"    # → BREAKING
     TYPE_FIELD_ADDED = "type_field_added"        # if in non-final class, may be BREAKING
     TYPE_FIELD_OFFSET_CHANGED = "type_field_offset_changed"  # → BREAKING
@@ -54,6 +56,7 @@ _BREAKING_KINDS = {
     ChangeKind.VAR_REMOVED,
     ChangeKind.VAR_TYPE_CHANGED,
     ChangeKind.TYPE_SIZE_CHANGED,
+    ChangeKind.TYPE_ALIGNMENT_CHANGED,
     ChangeKind.TYPE_FIELD_REMOVED,
     ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
     ChangeKind.TYPE_FIELD_TYPE_CHANGED,
@@ -108,13 +111,13 @@ class DiffResult:
 
 
 def _public(funcs) -> list[Function]:
-    return [f for f in funcs if f.visibility == Visibility.PUBLIC]
+    return [f for f in funcs if f.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)]
 
 
 def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
-    old_map = {f.mangled: f for f in _public(old.functions)}
-    new_map = {f.mangled: f for f in _public(new.functions)}
+    old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+    new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
 
     for mangled, f_old in old_map.items():
         if mangled not in new_map:
@@ -187,8 +190,8 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
-    old_map = {v.mangled: v for v in old.variables if v.visibility == Visibility.PUBLIC}
-    new_map = {v.mangled: v for v in new.variables if v.visibility == Visibility.PUBLIC}
+    old_map = {k: v for k, v in old.variable_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+    new_map = {k: v for k, v in new.variable_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
 
     for mangled, v_old in old_map.items():
         if mangled not in new_map:
@@ -238,6 +241,16 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     description=f"Size changed: {name} ({t_old.size_bits} → {t_new.size_bits} bits)",
                     old_value=str(t_old.size_bits),
                     new_value=str(t_new.size_bits),
+                ))
+
+        if t_old.alignment_bits is not None and t_new.alignment_bits is not None:
+            if t_old.alignment_bits != t_new.alignment_bits:
+                changes.append(Change(
+                    kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
+                    symbol=name,
+                    description=f"Alignment changed: {name} ({t_old.alignment_bits} → {t_new.alignment_bits} bits)",
+                    old_value=str(t_old.alignment_bits),
+                    new_value=str(t_new.alignment_bits),
                 ))
 
         old_fields = {f.name: f for f in t_old.fields}
@@ -291,12 +304,33 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 description=f"Base classes changed: {name}",
                 old_value=str(t_old.bases), new_value=str(t_new.bases),
             ))
+        else:
+            # Detect non-virtual base promoted to virtual (changes VTT layout).
+            # Only runs when bases/virtual_bases are unchanged as sets but virtualness differs.
+            old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
+            new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
+            if old_all_bases == new_all_bases:
+                old_virt = set(t_old.virtual_bases)
+                new_virt = set(t_new.virtual_bases)
+                if old_virt != new_virt:
+                    changes.append(Change(
+                        kind=ChangeKind.TYPE_BASE_CHANGED,
+                        symbol=name,
+                        description=f"Virtual inheritance changed: {name} (affects VTT layout)",
+                        old_value=f"virtual={sorted(old_virt)}",
+                        new_value=f"virtual={sorted(new_virt)}",
+                    ))
 
         if t_old.vtable != t_new.vtable:
+            if Counter(t_old.vtable) == Counter(t_new.vtable) and t_old.vtable != t_new.vtable:
+                # Same entries, different order — reorder is still BREAKING
+                description = f"vtable reordered: {name}"
+            else:
+                description = f"vtable changed: {name}"
             changes.append(Change(
                 kind=ChangeKind.TYPE_VTABLE_CHANGED,
                 symbol=name,
-                description=f"vtable changed: {name}",
+                description=description,
             ))
 
     for name in new_map:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1,6 +1,8 @@
 """Dumper — headers + .so → AbiSnapshot via castxml."""
 from __future__ import annotations
 
+import hashlib
+import os
 import re
 import shutil
 import subprocess
@@ -24,36 +26,72 @@ def _castxml_available() -> bool:
     return shutil.which("castxml") is not None
 
 
-def _readelf_exported_symbols(so_path: Path) -> set[str]:
-    """Return set of exported (globally visible) mangled symbol names from .so.
+def _readelf_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
+    """Return (exported_dynamic, exported_static) sets of mangled symbol names.
 
-    Includes STV_DEFAULT and STV_PROTECTED symbols (both are exported and
-    ABI-relevant). Raises RuntimeError on readelf failure to prevent silent
-    empty-set bugs that would cause every symbol to appear removed.
+    - exported_dynamic: symbols from --dyn-syms (.dynsym), truly exported via ELF
+    - exported_static: symbols from --syms (all symbols including static)
+
+    Raises RuntimeError on readelf failure.
     """
-    result = subprocess.run(
-        ["readelf", "--wide", "--dyn-syms", str(so_path)],
-        capture_output=True, text=True, check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"readelf failed (exit {result.returncode}) on {so_path}:\n"
-            f"{result.stderr[:1000]}"
+    def _parse_readelf(args: list[str]) -> set[str]:
+        result = subprocess.run(
+            ["readelf", "--wide"] + args + [str(so_path)],
+            capture_output=True, text=True, check=False,
         )
-    exported: set[str] = set()
-    for line in result.stdout.splitlines():
-        parts = line.split()
-        # readelf --dyn-syms output: Num Value Size Type Bind Vis Ndx Name
-        if len(parts) < 8:
-            continue
-        bind = parts[4]
-        vis = parts[5]
-        ndx = parts[6]
-        name = parts[7].split("@")[0]  # strip version suffix (e.g. GLIBC_2.17)
-        # Include DEFAULT and PROTECTED — both are exported and ABI-relevant
-        if bind in ("GLOBAL", "WEAK") and vis in ("DEFAULT", "PROTECTED") and ndx != "UND":
-            exported.add(name)
-    return exported
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"readelf failed (exit {result.returncode}) on {so_path}:\n"
+                f"{result.stderr[:1000]}"
+            )
+        syms: set[str] = set()
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) < 8:
+                continue
+            bind = parts[4]
+            vis = parts[5]
+            ndx = parts[6]
+            name = parts[7].split("@")[0]
+            if bind in ("GLOBAL", "WEAK") and vis in ("DEFAULT", "PROTECTED") and ndx != "UND":
+                syms.add(name)
+        return syms
+
+    exported_dynamic = _parse_readelf(["--dyn-syms"])
+    try:
+        exported_static = _parse_readelf(["--syms"])
+    except RuntimeError:
+        exported_static = set(exported_dynamic)
+    return exported_dynamic, exported_static
+
+
+def _cache_key(headers: list[Path], extra_includes: list[Path], compiler: str) -> str:
+    h = hashlib.sha256()
+    for p in sorted(str(x.resolve()) for x in headers):
+        h.update(p.encode())
+        try:
+            h.update(str(os.path.getmtime(p)).encode())
+        except OSError:
+            pass
+    # Also hash mtimes of files in extra_include dirs (catches most transitive changes)
+    for inc_dir in sorted(str(x) for x in extra_includes):
+        inc_path = Path(inc_dir)
+        h.update(inc_dir.encode())
+        if inc_path.is_dir():
+            for f in sorted(inc_path.rglob("*.h")) + sorted(inc_path.rglob("*.hpp")):
+                try:
+                    h.update(str(f).encode())
+                    h.update(str(f.stat().st_mtime).encode())
+                except OSError:
+                    pass
+    h.update(compiler.encode())
+    return h.hexdigest()
+
+
+def _cache_path(key: str) -> Path:
+    cache_dir = Path.home() / ".cache" / "abi_check" / "castxml"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{key}.xml"
 
 
 def _castxml_dump(headers: list[Path], extra_includes: list[Path],
@@ -68,6 +106,12 @@ def _castxml_dump(headers: list[Path], extra_includes: list[Path],
             "castxml not found in PATH. Install with: apt install castxml  "
             "or  conda install -c conda-forge castxml"
         )
+
+    # Check disk cache
+    key = _cache_key(headers, extra_includes, compiler)
+    cached = _cache_path(key)
+    if cached.exists():
+        return ET.parse(str(cached)).getroot()
 
     # Map logical compiler name → castxml cc flag
     _cc_map = {"c++": "g++", "cc": "gcc", "g++": "g++", "gcc": "gcc",
@@ -97,6 +141,8 @@ def _castxml_dump(headers: list[Path], extra_includes: list[Path],
             raise RuntimeError(
                 f"castxml failed (exit {result.returncode}):\n{result.stderr[:2000]}"
             )
+        # Save to cache
+        shutil.copy2(str(out_xml), str(cached))
         return ET.parse(str(out_xml)).getroot()
     finally:
         agg_path.unlink(missing_ok=True)
@@ -106,9 +152,11 @@ def _castxml_dump(headers: list[Path], extra_includes: list[Path],
 class _CastxmlParser:
     """Parse castxml XML into ABI model objects."""
 
-    def __init__(self, root: ET.Element, exported_symbols: set[str]):
+    def __init__(self, root: ET.Element, exported_dynamic: set[str],
+                 exported_static: set[str]):
         self._root = root
-        self._exported = exported_symbols
+        self._exported_dynamic = exported_dynamic
+        self._exported_static = exported_static
         self._id_map: dict[str, ET.Element] = {}
         self._build_id_map()
 
@@ -151,11 +199,17 @@ class _CastxmlParser:
         return el.get("name", tag)
 
     def _visibility(self, mangled: str, name: str = "") -> Visibility:
-        """Check if symbol is exported: try mangled first, then plain name."""
-        if mangled and mangled in self._exported:
+        """Determine visibility based on ELF symbol tables."""
+        # Check dynamic symbols (.dynsym) — truly exported
+        if mangled and mangled in self._exported_dynamic:
             return Visibility.PUBLIC
-        if name and name in self._exported:
+        if name and name in self._exported_dynamic:
             return Visibility.PUBLIC
+        # Check all symbols (.symtab) — present in ELF but not exported
+        if mangled and mangled in self._exported_static:
+            return Visibility.ELF_ONLY
+        if name and name in self._exported_static:
+            return Visibility.ELF_ONLY
         return Visibility.HIDDEN
 
     def parse_functions(self) -> list[Function]:
@@ -181,6 +235,13 @@ class _CastxmlParser:
             is_virtual = el.get("virtual") == "1"
             noexcept_re = re.search(r"noexcept", el.get("attributes", ""))
 
+            # Detect extern "C": explicit extern attribute OR no mangled name (C linkage)
+            raw_mangled = el.get("mangled", "")
+            is_extern_c = (
+                el.get("extern") == "1"
+                or not raw_mangled  # C functions have no mangled name
+            )
+
             loc_id = el.get("location", "")
             loc_el = self._id_map.get(loc_id)
             source_loc = None
@@ -199,6 +260,7 @@ class _CastxmlParser:
                 visibility=vis,
                 is_virtual=is_virtual,
                 is_noexcept=bool(noexcept_re),
+                is_extern_c=is_extern_c,
                 source_location=source_loc,
             ))
         return funcs
@@ -225,10 +287,17 @@ class _CastxmlParser:
             if el.tag not in ("Struct", "Class", "Union"):
                 continue
             name = el.get("name", "")
-            if not name or name.startswith("_"):
+            # Skip compiler-internal / incomplete / anonymous types
+            if not name or el.get("incomplete") == "1" or el.get("artificial") == "1":
                 continue
+            if name.startswith("__"):  # double-underscore = internal
+                continue
+
             size_str = el.get("size")
             size_bits = int(size_str) if size_str and size_str.isdigit() else None
+
+            align_str = el.get("align")
+            alignment_bits = int(align_str) if align_str and align_str.isdigit() else None
 
             fields = []
             for child in el:
@@ -252,6 +321,7 @@ class _CastxmlParser:
                 name=name,
                 kind=el.tag.lower(),
                 size_bits=size_bits,
+                alignment_bits=alignment_bits,
                 fields=fields,
                 bases=bases,
                 virtual_bases=virtual_bases,
@@ -279,7 +349,7 @@ def dump(
         AbiSnapshot with functions, variables, and types populated.
     """
     extra_includes = extra_includes or []
-    exported = _readelf_exported_symbols(so_path)
+    exported_dynamic, exported_static = _readelf_exported_symbols(so_path)
 
     if not headers:
         warnings.warn(
@@ -294,13 +364,13 @@ def dump(
             functions=[
                 Function(name=sym, mangled=sym, return_type="?",
                          visibility=Visibility.ELF_ONLY)
-                for sym in sorted(exported)
+                for sym in sorted(exported_dynamic)
             ],
         )
         return snapshot
 
     xml_root = _castxml_dump(headers, extra_includes, compiler=compiler)
-    parser = _CastxmlParser(xml_root, exported)
+    parser = _CastxmlParser(xml_root, exported_dynamic, exported_static)
 
     snapshot = AbiSnapshot(
         library=so_path.name,

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -35,6 +35,7 @@ class Function:
     visibility: Visibility = Visibility.PUBLIC
     is_virtual: bool = False
     is_noexcept: bool = False
+    is_extern_c: bool = False
     vtable_index: int | None = None
     source_location: str | None = None  # "header.h:42"
 
@@ -61,6 +62,7 @@ class RecordType:
     name: str
     kind: str  # "struct" | "class" | "union"
     size_bits: int | None = None
+    alignment_bits: int | None = None
     fields: list[TypeField] = field(default_factory=list)
     bases: list[str] = field(default_factory=list)       # base class names
     virtual_bases: list[str] = field(default_factory=list)
@@ -87,15 +89,23 @@ class AbiSnapshot:
         self._var_by_mangled = {v.mangled: v for v in self.variables}
         self._type_by_name = {t.name: t for t in self.types}
 
-    def func_by_mangled(self, mangled: str) -> Function | None:
+    @property
+    def function_map(self) -> dict:
         if self._func_by_mangled is None:
             self.index()
-        return self._func_by_mangled.get(mangled)
+        return self._func_by_mangled
 
-    def var_by_mangled(self, mangled: str) -> Variable | None:
+    @property
+    def variable_map(self) -> dict:
         if self._var_by_mangled is None:
             self.index()
-        return self._var_by_mangled.get(mangled)
+        return self._var_by_mangled
+
+    def func_by_mangled(self, mangled: str) -> Function | None:
+        return self.function_map.get(mangled)
+
+    def var_by_mangled(self, mangled: str) -> Variable | None:
+        return self.variable_map.get(mangled)
 
     def type_by_name(self, name: str) -> RecordType | None:
         if self._type_by_name is None:


### PR DESCRIPTION
Clean rebase on main (post-rename+docs merge).

- ELF_ONLY symbols included in export diff
- Counter-based vtable comparison (reorder vs content change)
- TYPE_ALIGNMENT_CHANGED as BREAKING
- castxml XML disk cache with transitive include mtime hashing
- Lazy O(1) index maps on AbiSnapshot
- Guard duplicate TYPE_BASE_CHANGED on virtual inheritance promotion