### PR TITLE
feat: suppression file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,50 @@ modern C++ libraries:
 
 ---
 
+## Suppression Files
+
+Suppression files let you silence known or intentional ABI changes so they don't
+block your CI pipeline. Each rule matches on symbol name (exact or regex) and,
+optionally, on change kind.
+
+### Format
+
+```yaml
+# abicheck suppression file
+version: 1
+suppressions:
+  - symbol: "_ZN3foo3barEv"          # exact mangled name
+    change_kind: "func_removed"       # optional: only suppress this change kind
+    reason: "intentional removal in v2"
+
+  - symbol_pattern: "^_ZN.*privateEv$"  # regex (mutually exclusive with symbol)
+    reason: "private implementation detail"
+
+  - symbol_pattern: ".*detail.*"
+    reason: "internal namespace — not public API"
+```
+
+Fields:
+| Field | Required | Description |
+|---|---|---|
+| `symbol` | one of | Exact mangled symbol name |
+| `symbol_pattern` | one of | Python `re.search` pattern |
+| `change_kind` | optional | `ChangeKind` value (e.g. `func_removed`); omit to suppress all kinds |
+| `reason` | optional | Human-readable note |
+
+### CLI Usage
+
+```bash
+abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
+```
+
+When suppressions are active the Markdown report includes a footer:
+```
+> ℹ️ 3 change(s) suppressed via suppression file
+```
+
+See `examples/suppression_example.yaml` for realistic examples.
+
 ## Why castxml?
 
 [castxml](https://github.com/CastXML/CastXML) converts C/C++ source to an XML

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ suppressions:
 ```
 
 Fields:
+
 | Field | Required | Description |
 |---|---|---|
 | `symbol` | one of | Exact mangled symbol name |
@@ -158,7 +159,8 @@ abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
 ```
 
 When suppressions are active the Markdown report includes a footer:
-```
+
+```text
 > ℹ️ 3 change(s) suppressed via suppression file
 ```
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -96,6 +96,7 @@ class DiffResult:
     library: str
     changes: list[Change] = field(default_factory=list)
     verdict: Verdict = Verdict.NO_CHANGE
+    suppressed_count: int = 0
 
     @property
     def breaking(self) -> list[Change]:
@@ -355,12 +356,29 @@ def _compute_verdict(changes: list[Change]) -> Verdict:
     return Verdict.COMPATIBLE
 
 
-def compare(old: AbiSnapshot, new: AbiSnapshot) -> DiffResult:
+def compare(
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    suppression: "SuppressionList | None" = None,
+) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict."""
+    from .suppression import SuppressionList  # avoid circular import at module level
+
     changes: list[Change] = []
     changes.extend(_diff_functions(old, new))
     changes.extend(_diff_variables(old, new))
     changes.extend(_diff_types(old, new))
+
+    suppressed_count = 0
+    if suppression is not None:
+        filtered: list[Change] = []
+        for c in changes:
+            if suppression.is_suppressed(c):
+                suppressed_count += 1
+            else:
+                filtered.append(c)
+        changes = filtered
+
     verdict = _compute_verdict(changes)
     return DiffResult(
         old_version=old.version,
@@ -368,4 +386,5 @@ def compare(old: AbiSnapshot, new: AbiSnapshot) -> DiffResult:
         library=old.library,
         changes=changes,
         verdict=verdict,
+        suppressed_count=suppressed_count,
     )

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from .model import AbiSnapshot, Function, Visibility
+
+if TYPE_CHECKING:
+    from .suppression import SuppressionList
 
 
 class ChangeKind(str, Enum):
@@ -97,6 +101,7 @@ class DiffResult:
     changes: list[Change] = field(default_factory=list)
     verdict: Verdict = Verdict.NO_CHANGE
     suppressed_count: int = 0
+    suppression_active: bool = False  # True when a suppression file was provided
 
     @property
     def breaking(self) -> list[Change]:
@@ -359,10 +364,9 @@ def _compute_verdict(changes: list[Change]) -> Verdict:
 def compare(
     old: AbiSnapshot,
     new: AbiSnapshot,
-    suppression: "SuppressionList | None" = None,
+    suppression: SuppressionList | None = None,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict."""
-    from .suppression import SuppressionList  # avoid circular import at module level
 
     changes: list[Change] = []
     changes.extend(_diff_functions(old, new))
@@ -387,4 +391,5 @@ def compare(
         changes=changes,
         verdict=verdict,
         suppressed_count=suppressed_count,
+        suppression_active=suppression is not None,
     )

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -101,7 +101,8 @@ class DiffResult:
     changes: list[Change] = field(default_factory=list)
     verdict: Verdict = Verdict.NO_CHANGE
     suppressed_count: int = 0
-    suppression_active: bool = False  # True when a suppression file was provided
+    suppressed_changes: list[Change] = field(default_factory=list)  # full audit trail
+    suppression_file_provided: bool = False  # True when --suppress was passed, even if 0 matched
 
     @property
     def breaking(self) -> list[Change]:
@@ -373,12 +374,12 @@ def compare(
     changes.extend(_diff_variables(old, new))
     changes.extend(_diff_types(old, new))
 
-    suppressed_count = 0
+    suppressed: list[Change] = []
     if suppression is not None:
         filtered: list[Change] = []
         for c in changes:
             if suppression.is_suppressed(c):
-                suppressed_count += 1
+                suppressed.append(c)
             else:
                 filtered.append(c)
         changes = filtered
@@ -390,6 +391,7 @@ def compare(
         library=old.library,
         changes=changes,
         verdict=verdict,
-        suppressed_count=suppressed_count,
-        suppression_active=suppression is not None,
+        suppressed_count=len(suppressed),
+        suppressed_changes=suppressed,
+        suppression_file_provided=suppression is not None,
     )

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -75,8 +75,23 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
     old = load_snapshot(old_snapshot)
     new = load_snapshot(new_snapshot)
 
-    suppression = SuppressionList.load(suppress) if suppress else None
+    suppression: SuppressionList | None = None
+    if suppress is not None:
+        try:
+            suppression = SuppressionList.load(suppress)
+        except (ValueError, OSError) as e:
+            raise click.BadParameter(str(e), param_hint="--suppress") from e
+
     result = compare(old, new, suppression=suppression)
+
+    # Warn if suppression file swallowed all changes (potential misconfiguration)
+    total_changes = len(result.changes) + result.suppressed_count
+    if result.suppression_file_provided and total_changes > 0 and len(result.changes) == 0:
+        click.echo(
+            "⚠️  Warning: all ABI changes were suppressed by the suppression file. "
+            "Verify your suppression rules are not too broad.",
+            err=True,
+        )
 
     if fmt == "json":
         text = to_json(result)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -59,16 +59,24 @@ def dump_cmd(so_path: Path, headers: tuple, includes: tuple,
 @click.option("--format", "fmt", type=click.Choice(["json", "markdown"]),
               default="markdown", show_default=True)
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
-def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path | None):
+@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Suppression file (YAML) to filter known/intentional changes.")
+def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path | None,
+                suppress: Path | None):
     """Compare two ABI snapshots and report changes.
 
     \b
     Example:
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format markdown
+      abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
     """
+    from .suppression import SuppressionList
+
     old = load_snapshot(old_snapshot)
     new = load_snapshot(new_snapshot)
-    result = compare(old, new)
+
+    suppression = SuppressionList.load(suppress) if suppress else None
+    result = compare(old, new, suppression=suppression)
 
     if fmt == "json":
         text = to_json(result)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -94,7 +94,7 @@ def to_markdown(result: DiffResult) -> str:
     if not result.changes:
         lines.append("_No ABI changes detected._")
 
-    if result.suppressed_count > 0:
+    if result.suppression_active:
         lines.append("")
         lines.append(f"> ℹ️ {result.suppressed_count} change(s) suppressed via suppression file")
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -45,6 +45,18 @@ def to_json(result: DiffResult, indent: int = 2) -> str:
             }
             for c in result.changes
         ],
+        "suppression": {
+            "file_provided": result.suppression_file_provided,
+            "suppressed_count": result.suppressed_count,
+            "suppressed_changes": [
+                {
+                    "kind": c.kind.value,
+                    "symbol": c.symbol,
+                    "description": c.description,
+                }
+                for c in result.suppressed_changes
+            ],
+        },
     }
     return json.dumps(d, indent=indent)
 
@@ -94,9 +106,14 @@ def to_markdown(result: DiffResult) -> str:
     if not result.changes:
         lines.append("_No ABI changes detected._")
 
-    if result.suppression_active:
+    if result.suppression_file_provided:
         lines.append("")
-        lines.append(f"> ℹ️ {result.suppressed_count} change(s) suppressed via suppression file")
+        if result.suppressed_count == 0:
+            lines.append("> ℹ️ Suppression file active — 0 changes matched (nothing suppressed)")
+        else:
+            lines.append(f"> ℹ️ {result.suppressed_count} change(s) suppressed via suppression file")
+            for sc in result.suppressed_changes:
+                lines.append(f">   - `{sc.symbol}` — {sc.description}")
 
     lines += [
         "---",

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -94,6 +94,10 @@ def to_markdown(result: DiffResult) -> str:
     if not result.changes:
         lines.append("_No ABI changes detected._")
 
+    if result.suppressed_count > 0:
+        lines.append("")
+        lines.append(f"> ℹ️ {result.suppressed_count} change(s) suppressed via suppression file")
+
     lines += [
         "---",
         "## Legend",

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -12,6 +12,9 @@ from .checker import Change, ChangeKind
 # Pre-build valid change_kind values for fast validation
 _VALID_CHANGE_KINDS: frozenset[str] = frozenset(ck.value for ck in ChangeKind)
 
+# Keys allowed in a suppression entry — unknown keys are rejected
+_KNOWN_ENTRY_KEYS: frozenset[str] = frozenset({"symbol", "symbol_pattern", "change_kind", "reason"})
+
 
 @dataclass
 class Suppression:
@@ -30,7 +33,9 @@ class Suppression:
             raise ValueError(
                 "Suppression must have either 'symbol' or 'symbol_pattern'"
             )
-        # Compile regex eagerly so malformed patterns fail at load time
+        # Compile regex eagerly — malformed patterns fail at load time, not match time.
+        # Uses fullmatch semantics: the pattern must match the entire symbol name.
+        # Use explicit '.*' anchors in the pattern if partial matching is intended.
         if self.symbol_pattern is not None:
             try:
                 self._compiled_pattern = re.compile(self.symbol_pattern)
@@ -38,7 +43,7 @@ class Suppression:
                 raise ValueError(
                     f"Invalid symbol_pattern {self.symbol_pattern!r}: {e}"
                 ) from e
-        # Validate change_kind against known values
+        # Validate change_kind against known enum values
         if self.change_kind is not None:
             if self.change_kind not in _VALID_CHANGE_KINDS:
                 valid = ", ".join(sorted(_VALID_CHANGE_KINDS))
@@ -48,13 +53,19 @@ class Suppression:
                 )
 
     def matches(self, change: Change) -> bool:
-        """Return True if this suppression rule matches the given change."""
+        """Return True if this suppression rule matches the given change.
+
+        Pattern matching uses fullmatch — the pattern must cover the entire
+        mangled symbol name. Use '.*foo.*' for substring matching.
+        """
         # Check symbol match
         if self.symbol is not None:
             if change.symbol != self.symbol:
                 return False
         elif self._compiled_pattern is not None:
-            if not self._compiled_pattern.search(change.symbol):
+            # fullmatch: pattern must cover the complete symbol, preventing
+            # accidental over-suppression from short patterns.
+            if not self._compiled_pattern.fullmatch(change.symbol):
                 return False
 
         # Check change_kind match (if specified)
@@ -71,9 +82,19 @@ class SuppressionList:
 
     @classmethod
     def load(cls, path: Path) -> SuppressionList:
-        """Load suppression rules from a YAML file."""
+        """Load suppression rules from a YAML file.
+
+        Raises ValueError on schema violations, unknown keys, bad regex,
+        or invalid change_kind values.
+        Raises OSError if the file cannot be read.
+        """
         try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            text = path.read_text(encoding="utf-8")
+        except OSError as e:
+            raise OSError(f"Cannot read suppression file {path}: {e}") from e
+
+        try:
+            data = yaml.safe_load(text)
         except yaml.YAMLError as e:
             raise ValueError(f"Invalid YAML in suppression file: {e}") from e
 
@@ -94,6 +115,13 @@ class SuppressionList:
         for i, item in enumerate(raw_suppressions):
             if not isinstance(item, dict):
                 raise ValueError(f"Suppression entry {i} must be a mapping")
+            # Reject unknown keys — catches typos like 'symbl' or 'cahnge_kind'
+            unknown = set(item.keys()) - _KNOWN_ENTRY_KEYS
+            if unknown:
+                raise ValueError(
+                    f"Suppression entry {i} has unknown key(s): {sorted(unknown)}. "
+                    f"Allowed keys: {sorted(_KNOWN_ENTRY_KEYS)}"
+                )
             try:
                 sup = Suppression(
                     symbol=item.get("symbol"),
@@ -113,3 +141,6 @@ class SuppressionList:
 
     def __len__(self) -> int:
         return len(self._suppressions)
+
+    def __repr__(self) -> str:
+        return f"SuppressionList({len(self._suppressions)} rules)"

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -2,21 +2,24 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 import yaml
 
-from .checker import Change
+from .checker import Change, ChangeKind
+
+# Pre-build valid change_kind values for fast validation
+_VALID_CHANGE_KINDS: frozenset[str] = frozenset(ck.value for ck in ChangeKind)
 
 
 @dataclass
 class Suppression:
-    symbol: Optional[str] = None
-    symbol_pattern: Optional[str] = None
-    change_kind: Optional[str] = None
-    reason: Optional[str] = None
+    symbol: str | None = None
+    symbol_pattern: str | None = None
+    change_kind: str | None = None
+    reason: str | None = None
+    _compiled_pattern: re.Pattern[str] | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.symbol is not None and self.symbol_pattern is not None:
@@ -27,6 +30,22 @@ class Suppression:
             raise ValueError(
                 "Suppression must have either 'symbol' or 'symbol_pattern'"
             )
+        # Compile regex eagerly so malformed patterns fail at load time
+        if self.symbol_pattern is not None:
+            try:
+                self._compiled_pattern = re.compile(self.symbol_pattern)
+            except re.error as e:
+                raise ValueError(
+                    f"Invalid symbol_pattern {self.symbol_pattern!r}: {e}"
+                ) from e
+        # Validate change_kind against known values
+        if self.change_kind is not None:
+            if self.change_kind not in _VALID_CHANGE_KINDS:
+                valid = ", ".join(sorted(_VALID_CHANGE_KINDS))
+                raise ValueError(
+                    f"Unknown change_kind {self.change_kind!r}. "
+                    f"Valid values: {valid}"
+                )
 
     def matches(self, change: Change) -> bool:
         """Return True if this suppression rule matches the given change."""
@@ -34,8 +53,8 @@ class Suppression:
         if self.symbol is not None:
             if change.symbol != self.symbol:
                 return False
-        elif self.symbol_pattern is not None:
-            if not re.search(self.symbol_pattern, change.symbol):
+        elif self._compiled_pattern is not None:
+            if not self._compiled_pattern.search(change.symbol):
                 return False
 
         # Check change_kind match (if specified)
@@ -51,7 +70,7 @@ class SuppressionList:
         self._suppressions = suppressions
 
     @classmethod
-    def load(cls, path: Path) -> "SuppressionList":
+    def load(cls, path: Path) -> SuppressionList:
         """Load suppression rules from a YAML file."""
         try:
             data = yaml.safe_load(path.read_text(encoding="utf-8"))

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -1,0 +1,96 @@
+"""Suppression — load and apply suppression rules to ABI changes."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from .checker import Change
+
+
+@dataclass
+class Suppression:
+    symbol: Optional[str] = None
+    symbol_pattern: Optional[str] = None
+    change_kind: Optional[str] = None
+    reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.symbol is not None and self.symbol_pattern is not None:
+            raise ValueError(
+                "Suppression cannot have both 'symbol' and 'symbol_pattern'"
+            )
+        if self.symbol is None and self.symbol_pattern is None:
+            raise ValueError(
+                "Suppression must have either 'symbol' or 'symbol_pattern'"
+            )
+
+    def matches(self, change: Change) -> bool:
+        """Return True if this suppression rule matches the given change."""
+        # Check symbol match
+        if self.symbol is not None:
+            if change.symbol != self.symbol:
+                return False
+        elif self.symbol_pattern is not None:
+            if not re.search(self.symbol_pattern, change.symbol):
+                return False
+
+        # Check change_kind match (if specified)
+        if self.change_kind is not None:
+            if change.kind.value != self.change_kind:
+                return False
+
+        return True
+
+
+class SuppressionList:
+    def __init__(self, suppressions: list[Suppression]) -> None:
+        self._suppressions = suppressions
+
+    @classmethod
+    def load(cls, path: Path) -> "SuppressionList":
+        """Load suppression rules from a YAML file."""
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML in suppression file: {e}") from e
+
+        if not isinstance(data, dict):
+            raise ValueError("Suppression file must be a YAML mapping")
+
+        version = data.get("version")
+        if version != 1:
+            raise ValueError(f"Unsupported suppression file version: {version!r} (expected 1)")
+
+        raw_suppressions = data.get("suppressions")
+        if raw_suppressions is None:
+            return cls([])
+        if not isinstance(raw_suppressions, list):
+            raise ValueError("'suppressions' must be a list")
+
+        suppressions: list[Suppression] = []
+        for i, item in enumerate(raw_suppressions):
+            if not isinstance(item, dict):
+                raise ValueError(f"Suppression entry {i} must be a mapping")
+            try:
+                sup = Suppression(
+                    symbol=item.get("symbol"),
+                    symbol_pattern=item.get("symbol_pattern"),
+                    change_kind=item.get("change_kind"),
+                    reason=item.get("reason"),
+                )
+            except ValueError as e:
+                raise ValueError(f"Suppression entry {i}: {e}") from e
+            suppressions.append(sup)
+
+        return cls(suppressions)
+
+    def is_suppressed(self, change: Change) -> bool:
+        """Return True if any suppression rule matches the given change."""
+        return any(s.matches(change) for s in self._suppressions)
+
+    def __len__(self) -> int:
+        return len(self._suppressions)

--- a/examples/suppression_example.yaml
+++ b/examples/suppression_example.yaml
@@ -1,0 +1,16 @@
+# abicheck suppression file — realistic examples
+version: 1
+
+suppressions:
+  # 1. Exact symbol: a function removed intentionally in v2 API cleanup
+  - symbol: "_ZN3foo6Client10disconnectEv"
+    change_kind: "func_removed"
+    reason: "Client::disconnect() was deprecated in v1.8 and removed in v2.0"
+
+  # 2. Pattern: suppress all changes in internal detail namespaces
+  - symbol_pattern: ".*N6detail.*"
+    reason: "detail:: namespace is internal implementation — not part of public ABI"
+
+  # 3. Exact symbol, all change kinds: renamed type with binary-compatible shim
+  - symbol: "_ZN3foo12LegacyHandleEv"
+    reason: "LegacyHandle typedef replaced by Handle alias — shim keeps compatibility"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -21,7 +21,19 @@ def write_yaml(tmp_path: Path, content: str) -> Path:
     return p
 
 
-# ─── test 1: load valid suppression file ──────────────────────────────────────
+def _make_snapshots_with_removed_func(mangled: str = "_ZN3foo3barEv"):
+    """Return (old, new) where old has one public function that new doesn't."""
+    from abicheck.model import AbiSnapshot, Function, Visibility
+    old = AbiSnapshot(library="libfoo", version="1.0")
+    new = AbiSnapshot(library="libfoo", version="2.0")
+    old.functions.append(Function(
+        name="foo::bar", mangled=mangled,
+        return_type="void", visibility=Visibility.PUBLIC,
+    ))
+    return old, new
+
+
+# ─── load valid suppression file ─────────────────────────────────────────────
 
 def test_load_valid_file(tmp_path: Path) -> None:
     yaml_path = write_yaml(tmp_path, """
@@ -37,55 +49,67 @@ def test_load_valid_file(tmp_path: Path) -> None:
     assert len(sl) == 2
 
 
-# ─── test 2: exact symbol match ───────────────────────────────────────────────
+def test_load_empty_suppressions(tmp_path: Path) -> None:
+    yaml_path = write_yaml(tmp_path, "version: 1\nsuppressions: []\n")
+    sl = SuppressionList.load(yaml_path)
+    assert len(sl) == 0
+
+
+def test_load_missing_suppressions_key(tmp_path: Path) -> None:
+    yaml_path = write_yaml(tmp_path, "version: 1\n")
+    sl = SuppressionList.load(yaml_path)
+    assert len(sl) == 0
+
+
+# ─── exact symbol match ───────────────────────────────────────────────────────
 
 def test_exact_symbol_match() -> None:
     sup = Suppression(symbol="_ZN3foo3barEv")
-    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv")
-    assert sup.matches(change)
+    assert sup.matches(make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv"))
 
 
 def test_exact_symbol_no_match() -> None:
     sup = Suppression(symbol="_ZN3foo3barEv")
-    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3bazEv")
-    assert not sup.matches(change)
+    assert not sup.matches(make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3bazEv"))
 
 
-# ─── test 3: pattern match ────────────────────────────────────────────────────
+# ─── pattern match (fullmatch semantics) ─────────────────────────────────────
 
-def test_pattern_match() -> None:
+def test_pattern_fullmatch() -> None:
+    # Pattern must cover the whole symbol — '.*detail.*' requires explicit wildcards
     sup = Suppression(symbol_pattern=".*detail.*")
-    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3fooNdetailE3barEv")
-    assert sup.matches(change)
+    assert sup.matches(make_change(ChangeKind.FUNC_REMOVED, "_ZN3fooNdetailE3barEv"))
 
 
 def test_pattern_no_match() -> None:
     sup = Suppression(symbol_pattern=".*detail.*")
-    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv")
-    assert not sup.matches(change)
+    assert not sup.matches(make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv"))
 
 
-# ─── test 4: change_kind filtering ───────────────────────────────────────────
+def test_pattern_short_does_not_over_match() -> None:
+    """Short pattern without anchors should NOT match an unrelated symbol (fullmatch)."""
+    sup = Suppression(symbol_pattern="foo")
+    # fullmatch: 'foo' does not match '_ZN3foo3barEv'
+    assert not sup.matches(make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv"))
+
+
+# ─── change_kind filtering ────────────────────────────────────────────────────
 
 def test_change_kind_match() -> None:
     sup = Suppression(symbol="_ZN3foo3barEv", change_kind="func_removed")
-    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv")
-    assert sup.matches(change)
+    assert sup.matches(make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv"))
 
 
 def test_change_kind_mismatch() -> None:
     """Symbol matches but change_kind does not — should NOT be suppressed."""
     sup = Suppression(symbol="_ZN3foo3barEv", change_kind="func_removed")
-    change = make_change(ChangeKind.FUNC_RETURN_CHANGED, "_ZN3foo3barEv")
-    assert not sup.matches(change)
+    assert not sup.matches(make_change(ChangeKind.FUNC_RETURN_CHANGED, "_ZN3foo3barEv"))
 
 
-# ─── test 5: suppressed_count in DiffResult ──────────────────────────────────
+# ─── suppressed_changes audit trail in DiffResult ────────────────────────────
 
-def test_suppressed_count_in_diff_result(tmp_path: Path) -> None:
-    """compare() with suppression decrements visible changes and increments suppressed_count."""
-    from abicheck.model import AbiSnapshot
-
+def test_suppressed_changes_audit_trail(tmp_path: Path) -> None:
+    """suppressed_changes must contain the full Change objects, not just count."""
     yaml_path = write_yaml(tmp_path, """
         version: 1
         suppressions:
@@ -93,30 +117,87 @@ def test_suppressed_count_in_diff_result(tmp_path: Path) -> None:
             change_kind: "func_removed"
     """)
     sl = SuppressionList.load(yaml_path)
-
-    # Build minimal snapshots: old has a function, new does not.
-    old = AbiSnapshot(library="libfoo", version="1.0")
-    new = AbiSnapshot(library="libfoo", version="2.0")
-
-    from abicheck.model import Function, Visibility
-    old.functions.append(
-        Function(
-            name="foo::bar",
-            mangled="_ZN3foo3barEv",
-            return_type="void",
-            visibility=Visibility.PUBLIC,
-        )
-    )
-
+    old, new = _make_snapshots_with_removed_func("_ZN3foo3barEv")
     result = compare(old, new, suppression=sl)
+
     assert result.suppressed_count == 1
-    # The suppressed change is removed from changes list
+    assert len(result.suppressed_changes) == 1
+    assert result.suppressed_changes[0].symbol == "_ZN3foo3barEv"
+    assert result.suppressed_changes[0].kind == ChangeKind.FUNC_REMOVED
+    # Suppressed change is absent from main changes list
     assert all(c.symbol != "_ZN3foo3barEv" for c in result.changes)
 
 
-# ─── test 6: invalid YAML raises ValueError ───────────────────────────────────
+def test_suppression_file_provided_flag(tmp_path: Path) -> None:
+    """suppression_file_provided=True even when 0 rules matched."""
+    yaml_path = write_yaml(tmp_path, "version: 1\nsuppressions: []\n")
+    sl = SuppressionList.load(yaml_path)
+    old, new = _make_snapshots_with_removed_func()
+    result = compare(old, new, suppression=sl)
+    assert result.suppression_file_provided is True
+    assert result.suppressed_count == 0
+    assert result.suppressed_changes == []
 
-def test_invalid_yaml_raises(tmp_path: Path) -> None:
+
+def test_no_suppression_flag_when_not_provided() -> None:
+    old, new = _make_snapshots_with_removed_func()
+    result = compare(old, new)
+    assert result.suppression_file_provided is False
+    assert result.suppressed_count == 0
+    assert result.suppressed_changes == []
+
+
+# ─── reporter: markdown footer ───────────────────────────────────────────────
+
+def test_markdown_footer_with_suppressions(tmp_path: Path) -> None:
+    from abicheck.reporter import to_markdown
+    yaml_path = write_yaml(tmp_path, """
+        version: 1
+        suppressions:
+          - symbol: "_ZN3foo3barEv"
+    """)
+    sl = SuppressionList.load(yaml_path)
+    old, new = _make_snapshots_with_removed_func("_ZN3foo3barEv")
+    result = compare(old, new, suppression=sl)
+    md = to_markdown(result)
+    assert "1 change(s) suppressed" in md
+    assert "_ZN3foo3barEv" in md
+
+
+def test_markdown_footer_zero_suppressed(tmp_path: Path) -> None:
+    from abicheck.reporter import to_markdown
+    yaml_path = write_yaml(tmp_path, "version: 1\nsuppressions: []\n")
+    sl = SuppressionList.load(yaml_path)
+    old, new = _make_snapshots_with_removed_func()
+    result = compare(old, new, suppression=sl)
+    md = to_markdown(result)
+    assert "0 changes matched" in md
+
+
+# ─── reporter: JSON suppression section ──────────────────────────────────────
+
+def test_json_includes_suppression_section(tmp_path: Path) -> None:
+    import json
+
+    from abicheck.reporter import to_json
+    yaml_path = write_yaml(tmp_path, """
+        version: 1
+        suppressions:
+          - symbol: "_ZN3foo3barEv"
+    """)
+    sl = SuppressionList.load(yaml_path)
+    old, new = _make_snapshots_with_removed_func("_ZN3foo3barEv")
+    result = compare(old, new, suppression=sl)
+    d = json.loads(to_json(result))
+    assert "suppression" in d
+    assert d["suppression"]["file_provided"] is True
+    assert d["suppression"]["suppressed_count"] == 1
+    assert d["suppression"]["suppressed_changes"][0]["symbol"] == "_ZN3foo3barEv"
+
+
+# ─── validation: bad inputs ──────────────────────────────────────────────────
+
+def test_unsupported_version_raises(tmp_path: Path) -> None:
     bad = tmp_path / "bad.yaml"
     bad.write_text("version: 2\nsuppressions: []\n", encoding="utf-8")
     with pytest.raises(ValueError, match="version"):
@@ -137,4 +218,25 @@ def test_invalid_yaml_syntax(tmp_path: Path) -> None:
     bad = tmp_path / "bad.yaml"
     bad.write_text(": :\n  - bad: [unclosed\n", encoding="utf-8")
     with pytest.raises(ValueError):
+        SuppressionList.load(bad)
+
+
+def test_invalid_change_kind_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown change_kind"):
+        Suppression(symbol="foo", change_kind="totally_wrong_kind")
+
+
+def test_invalid_regex_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid symbol_pattern"):
+        Suppression(symbol_pattern="[unclosed")
+
+
+def test_unknown_yaml_key_raises(tmp_path: Path) -> None:
+    bad = write_yaml(tmp_path, """
+        version: 1
+        suppressions:
+          - symbl: "_ZN3foo3barEv"
+            reason: "typo in key"
+    """)
+    with pytest.raises(ValueError, match="unknown key"):
         SuppressionList.load(bad)

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -6,9 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
+from abicheck.checker import Change, ChangeKind, compare
 from abicheck.suppression import Suppression, SuppressionList
-
 
 # ─── helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -1,0 +1,141 @@
+"""Tests for suppression file support."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
+from abicheck.suppression import Suppression, SuppressionList
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+def make_change(kind: ChangeKind, symbol: str, description: str = "desc") -> Change:
+    return Change(kind=kind, symbol=symbol, description=description)
+
+
+def write_yaml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "suppressions.yaml"
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+# ─── test 1: load valid suppression file ──────────────────────────────────────
+
+def test_load_valid_file(tmp_path: Path) -> None:
+    yaml_path = write_yaml(tmp_path, """
+        version: 1
+        suppressions:
+          - symbol: "_ZN3foo3barEv"
+            change_kind: "func_removed"
+            reason: "intentional"
+          - symbol_pattern: ".*detail.*"
+            reason: "internal namespace"
+    """)
+    sl = SuppressionList.load(yaml_path)
+    assert len(sl) == 2
+
+
+# ─── test 2: exact symbol match ───────────────────────────────────────────────
+
+def test_exact_symbol_match() -> None:
+    sup = Suppression(symbol="_ZN3foo3barEv")
+    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv")
+    assert sup.matches(change)
+
+
+def test_exact_symbol_no_match() -> None:
+    sup = Suppression(symbol="_ZN3foo3barEv")
+    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3bazEv")
+    assert not sup.matches(change)
+
+
+# ─── test 3: pattern match ────────────────────────────────────────────────────
+
+def test_pattern_match() -> None:
+    sup = Suppression(symbol_pattern=".*detail.*")
+    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3fooNdetailE3barEv")
+    assert sup.matches(change)
+
+
+def test_pattern_no_match() -> None:
+    sup = Suppression(symbol_pattern=".*detail.*")
+    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv")
+    assert not sup.matches(change)
+
+
+# ─── test 4: change_kind filtering ───────────────────────────────────────────
+
+def test_change_kind_match() -> None:
+    sup = Suppression(symbol="_ZN3foo3barEv", change_kind="func_removed")
+    change = make_change(ChangeKind.FUNC_REMOVED, "_ZN3foo3barEv")
+    assert sup.matches(change)
+
+
+def test_change_kind_mismatch() -> None:
+    """Symbol matches but change_kind does not — should NOT be suppressed."""
+    sup = Suppression(symbol="_ZN3foo3barEv", change_kind="func_removed")
+    change = make_change(ChangeKind.FUNC_RETURN_CHANGED, "_ZN3foo3barEv")
+    assert not sup.matches(change)
+
+
+# ─── test 5: suppressed_count in DiffResult ──────────────────────────────────
+
+def test_suppressed_count_in_diff_result(tmp_path: Path) -> None:
+    """compare() with suppression decrements visible changes and increments suppressed_count."""
+    from abicheck.model import AbiSnapshot
+
+    yaml_path = write_yaml(tmp_path, """
+        version: 1
+        suppressions:
+          - symbol: "_ZN3foo3barEv"
+            change_kind: "func_removed"
+    """)
+    sl = SuppressionList.load(yaml_path)
+
+    # Build minimal snapshots: old has a function, new does not.
+    old = AbiSnapshot(library="libfoo", version="1.0")
+    new = AbiSnapshot(library="libfoo", version="2.0")
+
+    from abicheck.model import Function, Visibility
+    old.functions.append(
+        Function(
+            name="foo::bar",
+            mangled="_ZN3foo3barEv",
+            return_type="void",
+            visibility=Visibility.PUBLIC,
+        )
+    )
+
+    result = compare(old, new, suppression=sl)
+    assert result.suppressed_count == 1
+    # The suppressed change is removed from changes list
+    assert all(c.symbol != "_ZN3foo3barEv" for c in result.changes)
+
+
+# ─── test 6: invalid YAML raises ValueError ───────────────────────────────────
+
+def test_invalid_yaml_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("version: 2\nsuppressions: []\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="version"):
+        SuppressionList.load(bad)
+
+
+def test_missing_symbol_raises() -> None:
+    with pytest.raises(ValueError):
+        Suppression(symbol=None, symbol_pattern=None)
+
+
+def test_both_symbol_and_pattern_raises() -> None:
+    with pytest.raises(ValueError):
+        Suppression(symbol="foo", symbol_pattern="bar")
+
+
+def test_invalid_yaml_syntax(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(": :\n  - bad: [unclosed\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        SuppressionList.load(bad)


### PR DESCRIPTION
## Summary

Adds suppression file support so known/intentional ABI changes can be excluded from the verdict.

### Changes
- `abicheck/suppression.py`: `Suppression` dataclass + `SuppressionList` (load + is_suppressed)
- `abicheck/checker.py`: `compare()` accepts optional `SuppressionList`; `DiffResult` gains `suppressed_count`
- `abicheck/reporter.py`: Markdown footer when suppressions active
- `abicheck/cli.py`: `--suppress` option for compare command
- `tests/test_suppression.py`: 12 tests
- `pyproject.toml`: adds `pyyaml` dependency
- `README.md`: Suppression Files section
- `examples/suppression_example.yaml`: 3 realistic examples

### Suppression file format
```yaml
version: 1
suppressions:
  - symbol: "_ZN3foo3barEv"
    change_kind: "func_removed"
    reason: "intentional removal in v2"
  - symbol_pattern: ".*detail.*"
    reason: "internal namespace"
```

### CLI
```bash
abicheck compare old.json new.json --suppress suppressions.yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add suppression file support to exclude specified ABI changes; CLI gains a --suppress flag; reporting now includes suppression details (count and list) in JSON and Markdown outputs.

* **Documentation**
  * Add comprehensive suppression-files guide and example configuration (guide duplicated in the README).

* **Tests**
  * Add tests covering suppression loading, matching, integration, and error cases.

* **Chores**
  * Add pyyaml runtime dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->