### PR TITLE
feat: Sprint 1 — P0 gap closure (enum/qualifiers/union/typedef/bitfield)

### DIFF
--- a/abicheck.egg-info/PKG-INFO
+++ b/abicheck.egg-info/PKG-INFO
@@ -7,8 +7,11 @@ Requires-Python: >=3.10
 License-File: LICENSE
 License-File: NOTICE.md
 Requires-Dist: click>=8.0
+Requires-Dist: pyyaml>=6.0
+Requires-Dist: defusedxml>=0.7.1
 Provides-Extra: dev
 Requires-Dist: pytest>=7.0; extra == "dev"
 Requires-Dist: pytest-cov; extra == "dev"
 Requires-Dist: ruff>=0.3; extra == "dev"
+Requires-Dist: types-PyYAML; extra == "dev"
 Dynamic: license-file

--- a/abicheck.egg-info/SOURCES.txt
+++ b/abicheck.egg-info/SOURCES.txt
@@ -20,4 +20,5 @@ tests/test_abi_examples.py
 tests/test_checker.py
 tests/test_reporter.py
 tests/test_serialization.py
+tests/test_sprint1.py
 tests/test_suppression.py

--- a/abicheck.egg-info/SOURCES.txt
+++ b/abicheck.egg-info/SOURCES.txt
@@ -9,12 +9,15 @@ abicheck/dumper.py
 abicheck/model.py
 abicheck/reporter.py
 abicheck/serialization.py
+abicheck/suppression.py
 abicheck.egg-info/PKG-INFO
 abicheck.egg-info/SOURCES.txt
 abicheck.egg-info/dependency_links.txt
 abicheck.egg-info/entry_points.txt
 abicheck.egg-info/requires.txt
 abicheck.egg-info/top_level.txt
+tests/test_abi_examples.py
 tests/test_checker.py
 tests/test_reporter.py
 tests/test_serialization.py
+tests/test_suppression.py

--- a/abicheck.egg-info/requires.txt
+++ b/abicheck.egg-info/requires.txt
@@ -1,6 +1,9 @@
 click>=8.0
+pyyaml>=6.0
+defusedxml>=0.7.1
 
 [dev]
 pytest>=7.0
 pytest-cov
 ruff>=0.3
+types-PyYAML

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -267,10 +267,10 @@ def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
-    # Unions are diffed separately in _diff_unions() to avoid duplicate reports
-    # (TYPE_FIELD_* + UNION_FIELD_* for the same change).
-    old_map = {t.name: t for t in old.types if not t.is_union}
-    new_map = {t.name: t for t in new.types if not t.is_union}
+    # Include ALL types (including unions) for size/alignment/base/vtable checks.
+    # TYPE_FIELD_* for unions is skipped below — handled by _diff_unions() instead.
+    old_map = {t.name: t for t in old.types}
+    new_map = {t.name: t for t in new.types}
 
     for name, t_old in old_map.items():
         if name not in new_map:
@@ -302,59 +302,62 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     new_value=str(t_new.alignment_bits),
                 ))
 
-        old_fields = {f.name: f for f in t_old.fields}
-        new_fields = {f.name: f for f in t_new.fields}
+        # TYPE_FIELD_* for unions is handled by _diff_unions() to avoid duplicate reports.
+        # Size/alignment/base/vtable checks above apply to unions too.
+        if not t_old.is_union:
+            old_fields = {f.name: f for f in t_old.fields}
+            new_fields = {f.name: f for f in t_new.fields}
 
-        for fname, f_old in old_fields.items():
-            if fname not in new_fields:
-                changes.append(Change(
-                    kind=ChangeKind.TYPE_FIELD_REMOVED,
-                    symbol=name,
-                    description=f"Field removed: {name}::{fname}",
-                ))
-            else:
-                f_new = new_fields[fname]
-                if f_old.type != f_new.type:
+            for fname, f_old in old_fields.items():
+                if fname not in new_fields:
                     changes.append(Change(
-                        kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
+                        kind=ChangeKind.TYPE_FIELD_REMOVED,
                         symbol=name,
-                        description=f"Field type changed: {name}::{fname}",
-                        old_value=f_old.type, new_value=f_new.type,
+                        description=f"Field removed: {name}::{fname}",
                     ))
-                if (f_old.offset_bits is not None and f_new.offset_bits is not None
-                        and f_old.offset_bits != f_new.offset_bits):
-                    changes.append(Change(
-                        kind=ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
-                        symbol=name,
-                        description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
-                        old_value=str(f_old.offset_bits), new_value=str(f_new.offset_bits),
-                    ))
-                # Bitfield layout check (merged here to avoid redundant type iteration)
-                if (f_old.is_bitfield != f_new.is_bitfield
-                        or f_old.bitfield_bits != f_new.bitfield_bits):
-                    changes.append(Change(
-                        kind=ChangeKind.FIELD_BITFIELD_CHANGED,
-                        symbol=name,
-                        description=f"Bitfield layout changed: {name}::{fname}",
-                        old_value=f"bits={f_old.bitfield_bits}",
-                        new_value=f"bits={f_new.bitfield_bits}",
-                    ))
+                else:
+                    f_new = new_fields[fname]
+                    if f_old.type != f_new.type:
+                        changes.append(Change(
+                            kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
+                            symbol=name,
+                            description=f"Field type changed: {name}::{fname}",
+                            old_value=f_old.type, new_value=f_new.type,
+                        ))
+                    if (f_old.offset_bits is not None and f_new.offset_bits is not None
+                            and f_old.offset_bits != f_new.offset_bits):
+                        changes.append(Change(
+                            kind=ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
+                            symbol=name,
+                            description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
+                            old_value=str(f_old.offset_bits), new_value=str(f_new.offset_bits),
+                        ))
+                    # Bitfield layout check (merged here to avoid redundant type iteration)
+                    if (f_old.is_bitfield != f_new.is_bitfield
+                            or f_old.bitfield_bits != f_new.bitfield_bits):
+                        changes.append(Change(
+                            kind=ChangeKind.FIELD_BITFIELD_CHANGED,
+                            symbol=name,
+                            description=f"Bitfield layout changed: {name}::{fname}",
+                            old_value=f"bits={f_old.bitfield_bits}",
+                            new_value=f"bits={f_new.bitfield_bits}",
+                        ))
 
-        for fname in new_fields:
-            if fname not in old_fields:
-                # Field addition is BREAKING for polymorphic types or types with vtables;
-                # COMPATIBLE only for standard-layout types without virtual functions
-                is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
-                field_kind = (
-                    ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
-                    if not is_polymorphic and t_new.kind in ("struct", "union")
-                    else ChangeKind.TYPE_FIELD_ADDED  # BREAKING
-                )
-                changes.append(Change(
-                    kind=field_kind,
-                    symbol=name,
-                    description=f"Field added: {name}::{fname}",
-                ))
+            for fname in new_fields:
+                if fname not in old_fields:
+                    # Field addition is BREAKING for polymorphic types or types with vtables;
+                    # COMPATIBLE only for standard-layout types without virtual functions
+                    is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
+                    field_kind = (
+                        ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
+                        if not is_polymorphic and t_new.kind in ("struct",)
+                        else ChangeKind.TYPE_FIELD_ADDED  # BREAKING
+                    )
+                    changes.append(Change(
+                        kind=field_kind,
+                        symbol=name,
+                        description=f"Field added: {name}::{fname}",
+                    ))
 
         if t_old.bases != t_new.bases or t_old.virtual_bases != t_new.virtual_bases:
             changes.append(Change(
@@ -480,16 +483,25 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_by_mangled = {k: v for k, v in old.function_map.items() if v.visibility in vis}
     new_by_mangled = {k: v for k, v in new.function_map.items() if v.visibility in vis}
 
-    # --- pure_virtual detection: mangled name is UNCHANGED when pure_virtual changes ---
+    # --- Same-mangled checks: pure_virtual and is_static don't change mangling ---
+    # is_static: Itanium ABI does NOT encode static-ness in the mangled name
+    # (void Widget::bar() and static void Widget::bar() share the same mangled symbol).
+    # is_pure_virtual: pure_virtual is not part of the mangled name either.
     for mangled, f_old in old_by_mangled.items():
         if mangled not in new_by_mangled:
             continue
         f_new = new_by_mangled[mangled]
+
+        if f_old.is_static != f_new.is_static:
+            changes.append(Change(
+                kind=ChangeKind.FUNC_STATIC_CHANGED,
+                symbol=mangled,
+                description=f"Static qualifier changed: {f_old.name}",
+                old_value=str(f_old.is_static),
+                new_value=str(f_new.is_static),
+            ))
+
         if not f_old.is_pure_virtual and f_new.is_pure_virtual:
-            if not f_old.is_virtual and f_new.is_pure_virtual:
-                # Sanity check: pure_virtual=True on non-virtual is a dumper anomaly
-                # (not valid C++). Emit FUNC_PURE_VIRTUAL_ADDED as best effort.
-                pass
             kind = (
                 ChangeKind.FUNC_VIRTUAL_BECAME_PURE
                 if f_old.is_virtual

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -43,9 +43,10 @@ class ChangeKind(str, Enum):
 
     # Enum changes
     ENUM_MEMBER_REMOVED = "enum_member_removed"
-    ENUM_MEMBER_ADDED = "enum_member_added"
+    ENUM_MEMBER_ADDED = "enum_member_added"  # BREAKING (closed enums / value shift risk)
     ENUM_MEMBER_VALUE_CHANGED = "enum_member_value_changed"
-    ENUM_LAST_MEMBER_VALUE_CHANGED = "enum_last_member_value_changed"
+    ENUM_LAST_MEMBER_VALUE_CHANGED = "enum_last_member_value_changed"  # sentinel changed
+    TYPEDEF_REMOVED = "typedef_removed"  # placed here for logical grouping
 
     # Method qualifier changes
     FUNC_STATIC_CHANGED = "func_static_changed"
@@ -106,6 +107,7 @@ _BREAKING_KINDS = {
     ChangeKind.UNION_FIELD_REMOVED,
     ChangeKind.UNION_FIELD_TYPE_CHANGED,
     ChangeKind.TYPEDEF_BASE_CHANGED,
+    ChangeKind.TYPEDEF_REMOVED,
     ChangeKind.FIELD_BITFIELD_CHANGED,
 }
 
@@ -327,6 +329,16 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                         description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
                         old_value=str(f_old.offset_bits), new_value=str(f_new.offset_bits),
                     ))
+                # Bitfield layout check (merged here to avoid redundant type iteration)
+                if (f_old.is_bitfield != f_new.is_bitfield
+                        or f_old.bitfield_bits != f_new.bitfield_bits):
+                    changes.append(Change(
+                        kind=ChangeKind.FIELD_BITFIELD_CHANGED,
+                        symbol=name,
+                        description=f"Bitfield layout changed: {name}::{fname}",
+                        old_value=f"bits={f_old.bitfield_bits}",
+                        new_value=f"bits={f_new.bitfield_bits}",
+                    ))
 
         for fname in new_fields:
             if fname not in old_fields:
@@ -402,7 +414,14 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         e_new = new_map[name]
         old_members = {m.name: m.value for m in e_old.members}
         new_members = {m.name: m.value for m in e_new.members}
-        last_old = e_old.members[-1].name if e_old.members else None
+        # "Sentinel" member = member with the highest integer value in old enum.
+        # Detecting its value change is important (e.g. FOO_MAX / FOO_COUNT patterns).
+        # Use max-value comparison, NOT list-position order (castxml order is unreliable).
+        old_max_val = max(old_members.values()) if old_members else None
+        old_sentinel = (
+            next(n for n, v in old_members.items() if v == old_max_val)
+            if old_max_val is not None else None
+        )
 
         for mname, mval in old_members.items():
             if mname not in new_members:
@@ -415,7 +434,7 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             elif new_members[mname] != mval:
                 kind = (
                     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED
-                    if mname == last_old
+                    if mname == old_sentinel
                     else ChangeKind.ENUM_MEMBER_VALUE_CHANGED
                 )
                 changes.append(Change(
@@ -438,35 +457,39 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     return changes
 
 
+def _sig_key(f: Function) -> tuple[str, tuple[str, ...]]:
+    """Normalized match key: (function_name, param_types).
+
+    cv-qualifiers (const/volatile on `this`) and static-ness are NOT encoded in
+    the mangled name lookup table, so we use the unqualified name + params tuple
+    to find matching pairs across qualifier changes.
+    """
+    return (f.name, tuple(p.type for p in f.params))
+
+
 def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    """Detect cv-qualifier, static, and pure-virtual changes.
+
+    NOTE: Changing const/volatile/static causes the mangled symbol name to
+    change (e.g. Foo::bar() const → _ZNK3Foo3barEv vs _ZN3Foo3barEv).  We
+    therefore match functions by (name, param_types) rather than mangled name
+    to find cross-qualifier pairs in the removed/added sets.
+    """
     changes: list[Change] = []
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
+    old_by_mangled = {k: v for k, v in old.function_map.items() if v.visibility in vis}
+    new_by_mangled = {k: v for k, v in new.function_map.items() if v.visibility in vis}
 
-    for mangled, f_old in old_map.items():
-        if mangled not in new_map:
+    # --- pure_virtual detection: mangled name is UNCHANGED when pure_virtual changes ---
+    for mangled, f_old in old_by_mangled.items():
+        if mangled not in new_by_mangled:
             continue
-        f_new = new_map[mangled]
-
-        if f_old.is_static != f_new.is_static:
-            changes.append(Change(
-                kind=ChangeKind.FUNC_STATIC_CHANGED,
-                symbol=mangled,
-                description=f"Static qualifier changed: {f_old.name}",
-                old_value=str(f_old.is_static),
-                new_value=str(f_new.is_static),
-            ))
-
-        if f_old.is_const != f_new.is_const or f_old.is_volatile != f_new.is_volatile:
-            changes.append(Change(
-                kind=ChangeKind.FUNC_CV_CHANGED,
-                symbol=mangled,
-                description=f"CV qualifier changed: {f_old.name}",
-                old_value=f"const={f_old.is_const} volatile={f_old.is_volatile}",
-                new_value=f"const={f_new.is_const} volatile={f_new.is_volatile}",
-            ))
-
+        f_new = new_by_mangled[mangled]
         if not f_old.is_pure_virtual and f_new.is_pure_virtual:
+            if not f_old.is_virtual and f_new.is_pure_virtual:
+                # Sanity check: pure_virtual=True on non-virtual is a dumper anomaly
+                # (not valid C++). Emit FUNC_PURE_VIRTUAL_ADDED as best effort.
+                pass
             kind = (
                 ChangeKind.FUNC_VIRTUAL_BECAME_PURE
                 if f_old.is_virtual
@@ -476,6 +499,40 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 kind=kind,
                 symbol=mangled,
                 description=f"Function became pure virtual: {f_old.name}",
+            ))
+
+    # --- cv/static detection: match removed functions against added functions by sig ---
+    old_mangles = set(old_by_mangled)
+    new_mangles = set(new_by_mangled)
+    removed_funcs = [old_by_mangled[m] for m in (old_mangles - new_mangles)]
+    added_funcs   = [new_by_mangled[m] for m in (new_mangles - old_mangles)]
+
+    # Build sig-keyed lookup over newly-added functions
+    added_by_sig: dict[tuple[str, tuple[str, ...]], Function] = {}
+    for f in added_funcs:
+        added_by_sig[_sig_key(f)] = f
+
+    for f_old in removed_funcs:
+        key = _sig_key(f_old)
+        if key not in added_by_sig:
+            continue
+        f_new = added_by_sig[key]
+        # Same (name, params) — only qualifiers changed; report instead of REMOVED+ADDED
+        if f_old.is_static != f_new.is_static:
+            changes.append(Change(
+                kind=ChangeKind.FUNC_STATIC_CHANGED,
+                symbol=f_old.mangled,
+                description=f"Static qualifier changed: {f_old.name}",
+                old_value=str(f_old.is_static),
+                new_value=str(f_new.is_static),
+            ))
+        if f_old.is_const != f_new.is_const or f_old.is_volatile != f_new.is_volatile:
+            changes.append(Change(
+                kind=ChangeKind.FUNC_CV_CHANGED,
+                symbol=f_old.mangled,
+                description=f"CV qualifier changed: {f_old.name}",
+                old_value=f"const={f_old.is_const} volatile={f_old.is_volatile}",
+                new_value=f"const={f_new.is_const} volatile={f_new.is_volatile}",
             ))
 
     return changes
@@ -526,7 +583,15 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     for alias, old_type in old.typedefs.items():
         new_type = new.typedefs.get(alias)
-        if new_type is not None and new_type != old_type:
+        if new_type is None:
+            # Typedef removed — breaking for consumers that used the alias
+            changes.append(Change(
+                kind=ChangeKind.TYPEDEF_REMOVED,
+                symbol=alias,
+                description=f"Typedef removed: {alias}",
+                old_value=old_type,
+            ))
+        elif new_type != old_type:
             changes.append(Change(
                 kind=ChangeKind.TYPEDEF_BASE_CHANGED,
                 symbol=alias,
@@ -536,33 +601,6 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             ))
     return changes
 
-
-def _diff_bitfields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
-    changes: list[Change] = []
-    old_map = {t.name: t for t in old.types}
-    new_map = {t.name: t for t in new.types}
-
-    for name, t_old in old_map.items():
-        if name not in new_map:
-            continue
-        t_new = new_map[name]
-        old_fields = {f.name: f for f in t_old.fields}
-        new_fields = {f.name: f for f in t_new.fields}
-
-        for fname, f_old in old_fields.items():
-            if fname not in new_fields:
-                continue
-            f_new = new_fields[fname]
-            if f_old.is_bitfield != f_new.is_bitfield or f_old.bitfield_bits != f_new.bitfield_bits:
-                changes.append(Change(
-                    kind=ChangeKind.FIELD_BITFIELD_CHANGED,
-                    symbol=name,
-                    description=f"Bitfield layout changed: {name}::{fname}",
-                    old_value=f"bits={f_old.bitfield_bits}",
-                    new_value=f"bits={f_new.bitfield_bits}",
-                ))
-
-    return changes
 
 
 def _compute_verdict(changes: list[Change]) -> Verdict:
@@ -591,7 +629,6 @@ def compare(
     changes.extend(_diff_method_qualifiers(old, new))
     changes.extend(_diff_unions(old, new))
     changes.extend(_diff_typedefs(old, new))
-    changes.extend(_diff_bitfields(old, new))
 
     suppressed: list[Change] = []
     if suppression is not None:

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from .model import AbiSnapshot, Function, Visibility
+from .model import AbiSnapshot, EnumType, Function, Visibility
 
 if TYPE_CHECKING:
     from .suppression import SuppressionList
@@ -41,6 +41,31 @@ class ChangeKind(str, Enum):
     TYPE_REMOVED = "type_removed"                # type removed → BREAKING if used in API
     TYPE_FIELD_ADDED_COMPATIBLE = "type_field_added_compatible"  # appended to standard-layout non-polymorphic type
 
+    # Enum changes
+    ENUM_MEMBER_REMOVED = "enum_member_removed"
+    ENUM_MEMBER_ADDED = "enum_member_added"
+    ENUM_MEMBER_VALUE_CHANGED = "enum_member_value_changed"
+    ENUM_LAST_MEMBER_VALUE_CHANGED = "enum_last_member_value_changed"
+
+    # Method qualifier changes
+    FUNC_STATIC_CHANGED = "func_static_changed"
+    FUNC_CV_CHANGED = "func_cv_changed"  # const/volatile on this
+
+    # Virtual changes
+    FUNC_PURE_VIRTUAL_ADDED = "func_pure_virtual_added"
+    FUNC_VIRTUAL_BECAME_PURE = "func_virtual_became_pure"
+
+    # Union field changes
+    UNION_FIELD_ADDED = "union_field_added"
+    UNION_FIELD_REMOVED = "union_field_removed"
+    UNION_FIELD_TYPE_CHANGED = "union_field_type_changed"
+
+    # Typedef changes
+    TYPEDEF_BASE_CHANGED = "typedef_base_changed"
+
+    # Bitfield changes
+    FIELD_BITFIELD_CHANGED = "field_bitfield_changed"
+
 
 class Verdict(str, Enum):
     NO_CHANGE = "NO_CHANGE"         # identical ABI
@@ -69,6 +94,19 @@ _BREAKING_KINDS = {
     ChangeKind.TYPE_REMOVED,
     ChangeKind.FUNC_NOEXCEPT_ADDED,  # C++17: noexcept is part of the function type (P0012R1)
     ChangeKind.TYPE_FIELD_ADDED,  # for polymorphic / non-standard-layout types
+    ChangeKind.ENUM_MEMBER_REMOVED,
+    ChangeKind.ENUM_MEMBER_ADDED,
+    ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
+    ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
+    ChangeKind.FUNC_STATIC_CHANGED,
+    ChangeKind.FUNC_CV_CHANGED,
+    ChangeKind.FUNC_PURE_VIRTUAL_ADDED,
+    ChangeKind.FUNC_VIRTUAL_BECAME_PURE,
+    ChangeKind.UNION_FIELD_ADDED,
+    ChangeKind.UNION_FIELD_REMOVED,
+    ChangeKind.UNION_FIELD_TYPE_CHANGED,
+    ChangeKind.TYPEDEF_BASE_CHANGED,
+    ChangeKind.FIELD_BITFIELD_CHANGED,
 }
 
 _SOURCE_BREAK_KINDS: set[ChangeKind] = set()  # reserved for future source-only breaks
@@ -351,6 +389,180 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     return changes
 
 
+def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
+    old_map: dict[str, EnumType] = {e.name: e for e in old.enums}
+    new_map: dict[str, EnumType] = {e.name: e for e in new.enums}
+
+    for name, e_old in old_map.items():
+        if name not in new_map:
+            continue  # TYPE_REMOVED covers this
+        e_new = new_map[name]
+        old_members = {m.name: m.value for m in e_old.members}
+        new_members = {m.name: m.value for m in e_new.members}
+        last_old = e_old.members[-1].name if e_old.members else None
+
+        for mname, mval in old_members.items():
+            if mname not in new_members:
+                changes.append(Change(
+                    kind=ChangeKind.ENUM_MEMBER_REMOVED,
+                    symbol=name,
+                    description=f"Enum member removed: {name}::{mname}",
+                    old_value=str(mval),
+                ))
+            elif new_members[mname] != mval:
+                kind = (
+                    ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED
+                    if mname == last_old
+                    else ChangeKind.ENUM_MEMBER_VALUE_CHANGED
+                )
+                changes.append(Change(
+                    kind=kind,
+                    symbol=name,
+                    description=f"Enum member value changed: {name}::{mname}",
+                    old_value=str(mval),
+                    new_value=str(new_members[mname]),
+                ))
+
+        for mname, mval in new_members.items():
+            if mname not in old_members:
+                changes.append(Change(
+                    kind=ChangeKind.ENUM_MEMBER_ADDED,
+                    symbol=name,
+                    description=f"Enum member added: {name}::{mname}",
+                    new_value=str(mval),
+                ))
+
+    return changes
+
+
+def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
+    old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+    new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+
+    for mangled, f_old in old_map.items():
+        if mangled not in new_map:
+            continue
+        f_new = new_map[mangled]
+
+        if f_old.is_static != f_new.is_static:
+            changes.append(Change(
+                kind=ChangeKind.FUNC_STATIC_CHANGED,
+                symbol=mangled,
+                description=f"Static qualifier changed: {f_old.name}",
+                old_value=str(f_old.is_static),
+                new_value=str(f_new.is_static),
+            ))
+
+        if f_old.is_const != f_new.is_const or f_old.is_volatile != f_new.is_volatile:
+            changes.append(Change(
+                kind=ChangeKind.FUNC_CV_CHANGED,
+                symbol=mangled,
+                description=f"CV qualifier changed: {f_old.name}",
+                old_value=f"const={f_old.is_const} volatile={f_old.is_volatile}",
+                new_value=f"const={f_new.is_const} volatile={f_new.is_volatile}",
+            ))
+
+        if not f_old.is_pure_virtual and f_new.is_pure_virtual:
+            kind = (
+                ChangeKind.FUNC_VIRTUAL_BECAME_PURE
+                if f_old.is_virtual
+                else ChangeKind.FUNC_PURE_VIRTUAL_ADDED
+            )
+            changes.append(Change(
+                kind=kind,
+                symbol=mangled,
+                description=f"Function became pure virtual: {f_old.name}",
+            ))
+
+    return changes
+
+
+def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
+    old_unions = {t.name: t for t in old.types if t.is_union}
+    new_unions = {t.name: t for t in new.types if t.is_union}
+
+    for name, t_old in old_unions.items():
+        if name not in new_unions:
+            continue  # covered by TYPE_REMOVED
+        t_new = new_unions[name]
+        old_fields = {f.name: f for f in t_old.fields}
+        new_fields = {f.name: f for f in t_new.fields}
+
+        for fname, f_old in old_fields.items():
+            if fname not in new_fields:
+                changes.append(Change(
+                    kind=ChangeKind.UNION_FIELD_REMOVED,
+                    symbol=name,
+                    description=f"Union field removed: {name}::{fname}",
+                    old_value=f_old.type,
+                ))
+            elif f_old.type != new_fields[fname].type:
+                changes.append(Change(
+                    kind=ChangeKind.UNION_FIELD_TYPE_CHANGED,
+                    symbol=name,
+                    description=f"Union field type changed: {name}::{fname}",
+                    old_value=f_old.type,
+                    new_value=new_fields[fname].type,
+                ))
+
+        for fname, f_new in new_fields.items():
+            if fname not in old_fields:
+                changes.append(Change(
+                    kind=ChangeKind.UNION_FIELD_ADDED,
+                    symbol=name,
+                    description=f"Union field added: {name}::{fname}",
+                    new_value=f_new.type,
+                ))
+
+    return changes
+
+
+def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
+    for alias, old_type in old.typedefs.items():
+        new_type = new.typedefs.get(alias)
+        if new_type is not None and new_type != old_type:
+            changes.append(Change(
+                kind=ChangeKind.TYPEDEF_BASE_CHANGED,
+                symbol=alias,
+                description=f"Typedef base type changed: {alias}",
+                old_value=old_type,
+                new_value=new_type,
+            ))
+    return changes
+
+
+def _diff_bitfields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    changes: list[Change] = []
+    old_map = {t.name: t for t in old.types}
+    new_map = {t.name: t for t in new.types}
+
+    for name, t_old in old_map.items():
+        if name not in new_map:
+            continue
+        t_new = new_map[name]
+        old_fields = {f.name: f for f in t_old.fields}
+        new_fields = {f.name: f for f in t_new.fields}
+
+        for fname, f_old in old_fields.items():
+            if fname not in new_fields:
+                continue
+            f_new = new_fields[fname]
+            if f_old.is_bitfield != f_new.is_bitfield or f_old.bitfield_bits != f_new.bitfield_bits:
+                changes.append(Change(
+                    kind=ChangeKind.FIELD_BITFIELD_CHANGED,
+                    symbol=name,
+                    description=f"Bitfield layout changed: {name}::{fname}",
+                    old_value=f"bits={f_old.bitfield_bits}",
+                    new_value=f"bits={f_new.bitfield_bits}",
+                ))
+
+    return changes
+
+
 def _compute_verdict(changes: list[Change]) -> Verdict:
     if not changes:
         return Verdict.NO_CHANGE
@@ -373,6 +585,11 @@ def compare(
     changes.extend(_diff_functions(old, new))
     changes.extend(_diff_variables(old, new))
     changes.extend(_diff_types(old, new))
+    changes.extend(_diff_enums(old, new))
+    changes.extend(_diff_method_qualifiers(old, new))
+    changes.extend(_diff_unions(old, new))
+    changes.extend(_diff_typedefs(old, new))
+    changes.extend(_diff_bitfields(old, new))
 
     suppressed: list[Change] = []
     if suppression is not None:

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -265,8 +265,10 @@ def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
-    old_map = {t.name: t for t in old.types}
-    new_map = {t.name: t for t in new.types}
+    # Unions are diffed separately in _diff_unions() to avoid duplicate reports
+    # (TYPE_FIELD_* + UNION_FIELD_* for the same change).
+    old_map = {t.name: t for t in old.types if not t.is_union}
+    new_map = {t.name: t for t in new.types if not t.is_union}
 
     for name, t_old in old_map.items():
         if name not in new_map:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -438,6 +438,17 @@ class _CastxmlParser:
             enums.append(EnumType(name=name, members=members))
         return enums
 
+    def _underlying_type_name(self, id_: str, depth: int = 0) -> str:
+        """Follow typedef chains to the concrete base type name."""
+        if depth > 20:
+            return "?"
+        el = self._resolve(id_)
+        if el is None:
+            return "?"
+        if el.tag == "Typedef":
+            return self._underlying_type_name(el.get("type", ""), depth + 1)
+        return self._type_name(id_)
+
     def parse_typedefs(self) -> dict[str, str]:
         typedefs: dict[str, str] = {}
         for el in self._root:
@@ -447,7 +458,8 @@ class _CastxmlParser:
             if not name:
                 continue
             type_id = el.get("type", "")
-            underlying = self._type_name(type_id) if type_id else "?"
+            # Flatten typedef chains: alias → alias2 → int  stored as  alias → int
+            underlying = self._underlying_type_name(type_id) if type_id else "?"
             typedefs[name] = underlying
         return typedefs
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -345,8 +345,12 @@ class _CastxmlParser:
                     off_str = child.get("offset")
                     offset = int(off_str) if off_str and off_str.isdigit() else None
                     bits_str = child.get("bits")
-                    is_bitfield = bits_str is not None
-                    bitfield_bits = int(bits_str) if bits_str is not None else None
+                    try:
+                        bitfield_bits = int(bits_str) if bits_str is not None else None
+                        is_bitfield = bitfield_bits is not None
+                    except ValueError:
+                        is_bitfield = False
+                        bitfield_bits = None
                     fields.append(TypeField(
                         name=f_name, type=f_type, offset_bits=offset,
                         is_bitfield=is_bitfield, bitfield_bits=bitfield_bits,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -17,6 +17,8 @@ from defusedxml import ElementTree as DefusedET
 
 from .model import (
     AbiSnapshot,
+    EnumMember,
+    EnumType,
     Function,
     Param,
     RecordType,
@@ -278,6 +280,11 @@ class _CastxmlParser:
                 line = loc_el.get("line", "")
                 source_loc = f"{fname}:{line}" if fname else None
 
+            is_static = el.get("static") == "1"
+            is_const = el.get("const") == "1"
+            is_volatile = el.get("volatile") == "1"
+            is_pure_virtual = el.get("pure_virtual") == "1"
+
             funcs.append(Function(
                 name=name,
                 mangled=mangled,
@@ -289,6 +296,10 @@ class _CastxmlParser:
                 is_extern_c=is_extern_c,
                 vtable_index=vtable_index,
                 source_location=source_loc,
+                is_static=is_static,
+                is_const=is_const,
+                is_volatile=is_volatile,
+                is_pure_virtual=is_pure_virtual,
             ))
         return funcs
 
@@ -333,7 +344,13 @@ class _CastxmlParser:
                     f_type = self._type_name(child.get("type", ""))
                     off_str = child.get("offset")
                     offset = int(off_str) if off_str and off_str.isdigit() else None
-                    fields.append(TypeField(name=f_name, type=f_type, offset_bits=offset))
+                    bits_str = child.get("bits")
+                    is_bitfield = bits_str is not None
+                    bitfield_bits = int(bits_str) if bits_str is not None else None
+                    fields.append(TypeField(
+                        name=f_name, type=f_type, offset_bits=offset,
+                        is_bitfield=is_bitfield, bitfield_bits=bitfield_bits,
+                    ))
 
             bases = [
                 self._type_name(b.get("type", ""))
@@ -381,6 +398,7 @@ class _CastxmlParser:
             virtual_methods.sort(key=_vt_sort_key)
             vtable = [m for _, m in virtual_methods]
 
+            is_union = el.tag == "Union"
             types.append(RecordType(
                 name=name,
                 kind=el.tag.lower(),
@@ -390,8 +408,44 @@ class _CastxmlParser:
                 bases=bases,
                 virtual_bases=virtual_bases,
                 vtable=vtable,
+                is_union=is_union,
             ))
         return types
+
+
+    def parse_enums(self) -> list[EnumType]:
+        enums = []
+        for el in self._root:
+            if el.tag != "Enumeration":
+                continue
+            name = el.get("name", "")
+            if not name or name.startswith("__"):
+                continue
+            members = []
+            for child in el:
+                if child.tag == "EnumValue":
+                    m_name = child.get("name", "")
+                    m_val_str = child.get("init", "0")
+                    try:
+                        m_val = int(m_val_str)
+                    except ValueError:
+                        m_val = 0
+                    members.append(EnumMember(name=m_name, value=m_val))
+            enums.append(EnumType(name=name, members=members))
+        return enums
+
+    def parse_typedefs(self) -> dict[str, str]:
+        typedefs: dict[str, str] = {}
+        for el in self._root:
+            if el.tag != "Typedef":
+                continue
+            name = el.get("name", "")
+            if not name:
+                continue
+            type_id = el.get("type", "")
+            underlying = self._type_name(type_id) if type_id else "?"
+            typedefs[name] = underlying
+        return typedefs
 
 
 def dump(
@@ -443,5 +497,7 @@ def dump(
         functions=parser.parse_functions(),
         variables=parser.parse_variables(),
         types=parser.parse_types(),
+        enums=parser.parse_enums(),
+        typedefs=parser.parse_typedefs(),
     )
     return snapshot

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -38,6 +38,10 @@ class Function:
     is_extern_c: bool = False
     vtable_index: int | None = None
     source_location: str | None = None  # "header.h:42"
+    is_static: bool = False
+    is_const: bool = False        # const qualifier on this
+    is_volatile: bool = False     # volatile qualifier on this
+    is_pure_virtual: bool = False
 
 
 @dataclass
@@ -54,6 +58,8 @@ class TypeField:
     name: str
     type: str
     offset_bits: int | None = None
+    is_bitfield: bool = False
+    bitfield_bits: int | None = None
 
 
 @dataclass
@@ -68,6 +74,20 @@ class RecordType:
     virtual_bases: list[str] = field(default_factory=list)
     vtable: list[str] = field(default_factory=list)      # ordered vtable entries (mangled)
     source_location: str | None = None
+    is_union: bool = False
+
+
+@dataclass
+class EnumMember:
+    name: str
+    value: int
+
+
+@dataclass
+class EnumType:
+    name: str
+    members: list[EnumMember] = field(default_factory=list)
+    underlying_type: str = "int"
 
 
 @dataclass
@@ -78,6 +98,8 @@ class AbiSnapshot:
     functions: list[Function] = field(default_factory=list)
     variables: list[Variable] = field(default_factory=list)
     types: list[RecordType] = field(default_factory=list)
+    enums: list[EnumType] = field(default_factory=list)
+    typedefs: dict[str, str] = field(default_factory=dict)  # alias -> underlying type name
 
     # Indexes (built lazily)
     _func_by_mangled: dict[str, Function] | None = field(default=None, repr=False, compare=False)

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from .model import (
     AbiSnapshot,
+    EnumMember,
+    EnumType,
     Function,
     Param,
     RecordType,
@@ -31,6 +33,14 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     return d
 
 
+def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:
+    return EnumType(
+        name=e["name"],
+        members=[EnumMember(name=m["name"], value=m["value"]) for m in e.get("members", [])],
+        underlying_type=e.get("underlying_type", "int"),
+    )
+
+
 def snapshot_to_json(snap: AbiSnapshot, indent: int = 2) -> str:
     return json.dumps(snapshot_to_dict(snap), indent=indent)
 
@@ -45,6 +55,10 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             is_noexcept=f.get("is_noexcept", False),
             vtable_index=f.get("vtable_index"),
             source_location=f.get("source_location"),
+            is_static=f.get("is_static", False),
+            is_const=f.get("is_const", False),
+            is_volatile=f.get("is_volatile", False),
+            is_pure_virtual=f.get("is_pure_virtual", False),
         )
         for f in d.get("functions", [])
     ]
@@ -60,17 +74,29 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         RecordType(
             name=t["name"], kind=t["kind"],
             size_bits=t.get("size_bits"),
-            fields=[TypeField(**f) for f in t.get("fields", [])],
+            fields=[
+                TypeField(
+                    name=f["name"], type=f["type"],
+                    offset_bits=f.get("offset_bits"),
+                    is_bitfield=f.get("is_bitfield", False),
+                    bitfield_bits=f.get("bitfield_bits"),
+                )
+                for f in t.get("fields", [])
+            ],
             bases=t.get("bases", []),
             virtual_bases=t.get("virtual_bases", []),
             vtable=t.get("vtable", []),
             source_location=t.get("source_location"),
+            is_union=t.get("is_union", False),
         )
         for t in d.get("types", [])
     ]
+    enums = [_enum_type_from_dict(e) for e in d.get("enums", [])]
+    typedefs: dict[str, str] = d.get("typedefs", {})
     return AbiSnapshot(
         library=d["library"], version=d["version"],
         functions=funcs, variables=variables, types=types,
+        enums=enums, typedefs=typedefs,
     )
 
 

--- a/docs/v2_coverage_plan.md
+++ b/docs/v2_coverage_plan.md
@@ -5,42 +5,73 @@ Source: "Beyond v1: Practical C/C++ API & ABI Break Mechanisms"
 ## Evidence Tiers (Detection Priority)
 
 ### Tier 1 — ELF-only (no debug info needed, implement first)
+
 | Case | Signal | ChangeKind |
+
 |---|---|---|
+
 | case28_symbol_version_requirement_drift | `.gnu.version_r` / `.gnu.version_d` diff | `SYMBOL_VERSION_REQUIREMENT_ADDED` |
+
 | case29_runpath_rpath_change | `DT_RPATH` vs `DT_RUNPATH` drift | `RPATH_CHANGED` |
+
 | case30_ifunc_introduction | `STT_GNU_IFUNC` type change | `IFUNC_INTRODUCED` |
+
 | case31_soname_or_needed_drift | `DT_SONAME` / `DT_NEEDED` set diff | already partial in v1 |
+
 | case32_common_symbol_resolution_risk | `STT_COMMON` in exported vars | `COMMON_SYMBOL_RISK` |
+
 | — | Symbol binding `GLOBAL→WEAK` or reverse | `SYMBOL_BINDING_CHANGED` |
+
 | — | Symbol type `FUNC→OBJECT` or reverse | `SYMBOL_TYPE_CHANGED` |
+
 | — | `STT_TLS` introduction | `TLS_SYMBOL_ADDED` |
 
 ### Tier 2 — DWARF/CTF required
+
 | Case | Signal | ChangeKind |
+
 |---|---|---|
+
 | case19_struct_return_convention | Aggregate return ABI via DWARF + flag | `STRUCT_RETURN_ABI_CHANGED` |
+
 | case20_short_enums | `DW_AT_byte_size` on enum type | `ENUM_UNDERLYING_SIZE_CHANGED` |
+
 | case21_pack_struct_global | Member offsets drift (packing) | `STRUCT_PACKING_CHANGED` |
+
 | case22_calling_convention_attribute | DW_AT_calling_convention | `CALLING_CONVENTION_CHANGED` |
+
 | case23_pragma_pack_drift | DWARF offsets + header AST | `PRAGMA_PACK_DRIFT` |
+
 | case25_type_visibility_exception_boundary | typeinfo/vtable symbol visibility | `TYPE_VISIBILITY_CHANGED` |
+
 | case26_noexcept_mangling | Mangled name encoding (`Do`) diff | extended `FUNC_NOEXCEPT_*` |
+
 | — | `DW_AT_producer` flag drift | `TOOLCHAIN_FLAG_DRIFT` (warning) |
 
 ### Tier 3 — Header/AST
+
 | Case | Signal |
+
 |---|---|
+
 | Language linkage change (`extern "C"` removal) | mangling shift detectable in Tier 1 |
+
 | Macro contract changes | requires header AST diff |
+
 | Inline/template body changes | source-level only |
 
 ### Tier 4 — Build metadata
+
 | Signal | How |
+
 |---|---|
+
 | `-fshort-enums`, `-fpack-struct`, `-fno-common` | `DW_AT_producer` parsing |
+
 | `-mabi` / `-mabi=*` | `DW_AT_producer` |
+
 | Toolchain major version shift | `DW_AT_producer` |
+
 | `-Wpsabi` affected patterns | correlate with DWARF layout drift |
 
 ## Key Design Principles (from doc)

--- a/docs/v2_coverage_plan.md
+++ b/docs/v2_coverage_plan.md
@@ -1,0 +1,82 @@
+# v2 Coverage Plan — Beyond Sprint 1
+
+Source: "Beyond v1: Practical C/C++ API & ABI Break Mechanisms"
+
+## Evidence Tiers (Detection Priority)
+
+### Tier 1 — ELF-only (no debug info needed, implement first)
+| Case | Signal | ChangeKind |
+|---|---|---|
+| case28_symbol_version_requirement_drift | `.gnu.version_r` / `.gnu.version_d` diff | `SYMBOL_VERSION_REQUIREMENT_ADDED` |
+| case29_runpath_rpath_change | `DT_RPATH` vs `DT_RUNPATH` drift | `RPATH_CHANGED` |
+| case30_ifunc_introduction | `STT_GNU_IFUNC` type change | `IFUNC_INTRODUCED` |
+| case31_soname_or_needed_drift | `DT_SONAME` / `DT_NEEDED` set diff | already partial in v1 |
+| case32_common_symbol_resolution_risk | `STT_COMMON` in exported vars | `COMMON_SYMBOL_RISK` |
+| — | Symbol binding `GLOBAL→WEAK` or reverse | `SYMBOL_BINDING_CHANGED` |
+| — | Symbol type `FUNC→OBJECT` or reverse | `SYMBOL_TYPE_CHANGED` |
+| — | `STT_TLS` introduction | `TLS_SYMBOL_ADDED` |
+
+### Tier 2 — DWARF/CTF required
+| Case | Signal | ChangeKind |
+|---|---|---|
+| case19_struct_return_convention | Aggregate return ABI via DWARF + flag | `STRUCT_RETURN_ABI_CHANGED` |
+| case20_short_enums | `DW_AT_byte_size` on enum type | `ENUM_UNDERLYING_SIZE_CHANGED` |
+| case21_pack_struct_global | Member offsets drift (packing) | `STRUCT_PACKING_CHANGED` |
+| case22_calling_convention_attribute | DW_AT_calling_convention | `CALLING_CONVENTION_CHANGED` |
+| case23_pragma_pack_drift | DWARF offsets + header AST | `PRAGMA_PACK_DRIFT` |
+| case25_type_visibility_exception_boundary | typeinfo/vtable symbol visibility | `TYPE_VISIBILITY_CHANGED` |
+| case26_noexcept_mangling | Mangled name encoding (`Do`) diff | extended `FUNC_NOEXCEPT_*` |
+| — | `DW_AT_producer` flag drift | `TOOLCHAIN_FLAG_DRIFT` (warning) |
+
+### Tier 3 — Header/AST
+| Case | Signal |
+|---|---|
+| Language linkage change (`extern "C"` removal) | mangling shift detectable in Tier 1 |
+| Macro contract changes | requires header AST diff |
+| Inline/template body changes | source-level only |
+
+### Tier 4 — Build metadata
+| Signal | How |
+|---|---|
+| `-fshort-enums`, `-fpack-struct`, `-fno-common` | `DW_AT_producer` parsing |
+| `-mabi` / `-mabi=*` | `DW_AT_producer` |
+| Toolchain major version shift | `DW_AT_producer` |
+| `-Wpsabi` affected patterns | correlate with DWARF layout drift |
+
+## Key Design Principles (from doc)
+
+1. **Evidence levels in output** — every change should report what evidence tier detected it
+   and confidence level (e.g., "detected via ELF-only — type mismatch undetectable without DWARF").
+
+2. **Without DWARF → ELF-only mode** — explicitly document fallback and what's missed.
+
+3. **Debug companion inputs** — tool should accept `--debug-info path/to/lib.so.debug`
+   (split debug packages in distros).
+
+4. **ODR assumption flag** — `--no-odr` to disable same-name-means-same-type optimization.
+
+5. **`ENUM_MEMBER_ADDED` is NOT always BREAKING** — "open" enums (extensible APIs) vs
+   "closed" enums (switch-exhaustive consumers). Implement heuristic:
+   - If added value exceeds `max(old_values)` AND no overflow → `POTENTIALLY_BREAKING`
+   - If added value would change existing switch behavior → `BREAKING`
+
+## Sprint 2 Scope (Proposed)
+Priority: Tier 1 ELF-only signals (no new dependencies, pure readelf parsing)
+
+1. `_diff_elf_dynamic`: `DT_NEEDED` set, `DT_SONAME`, `DT_RPATH`/`DT_RUNPATH`
+2. `_diff_symbol_versions`: `.gnu.version_r` requirements drift (GLIBC_X not found)
+3. `_diff_symbol_metadata`: binding (GLOBAL/WEAK), type (FUNC/OBJECT/TLS/IFUNC), size
+4. `_diff_toolchain_flags`: `DW_AT_producer` extraction + ABI-affecting flag detection
+
+## Sprint 3 Scope (Proposed)
+DWARF-aware:
+1. `ENUM_UNDERLYING_SIZE_CHANGED` (DW_AT_byte_size)
+2. `STRUCT_PACKING_CHANGED` (DWARF offsets cross-check with castxml)
+3. `TYPE_VISIBILITY_CHANGED` (typeinfo/vtable visibility from ELF + DWARF)
+4. `CALLING_CONVENTION_CHANGED` (DW_AT_calling_convention)
+
+## What Cannot Be Detected (explicit limits)
+- Semantic/behavioral contract changes (enum value meanings, error code semantics)
+- Inline/template body changes for existing binaries
+- `_GLIBCXX_USE_CXX11_ABI` dual ABI disagreements (requires build system analysis)
+- `LD_DYNAMIC_WEAK` / weak symbol resolution quirks (runtime-only)

--- a/examples/case19_enum_member_removed/Makefile
+++ b/examples/case19_enum_member_removed/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case19: enum member removed (BREAKING)"

--- a/examples/case19_enum_member_removed/new/lib.h
+++ b/examples/case19_enum_member_removed/new/lib.h
@@ -1,0 +1,1 @@
+enum Status { OK = 0, ERROR = 1 };

--- a/examples/case19_enum_member_removed/old/lib.h
+++ b/examples/case19_enum_member_removed/old/lib.h
@@ -1,0 +1,1 @@
+enum Status { OK = 0, ERROR = 1, FOO = 2 };

--- a/examples/case20_enum_member_value_changed/Makefile
+++ b/examples/case20_enum_member_value_changed/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case20: enum member value changed (BREAKING)"

--- a/examples/case20_enum_member_value_changed/new/lib.h
+++ b/examples/case20_enum_member_value_changed/new/lib.h
@@ -1,0 +1,1 @@
+enum ErrorCode { OK = 0, ERROR = 99 };

--- a/examples/case20_enum_member_value_changed/old/lib.h
+++ b/examples/case20_enum_member_value_changed/old/lib.h
@@ -1,0 +1,1 @@
+enum ErrorCode { OK = 0, ERROR = 1 };

--- a/examples/case21_method_became_static/Makefile
+++ b/examples/case21_method_became_static/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case21: method became static (BREAKING)"

--- a/examples/case21_method_became_static/new/lib.h
+++ b/examples/case21_method_became_static/new/lib.h
@@ -1,0 +1,4 @@
+class Widget {
+public:
+    static void bar();
+};

--- a/examples/case21_method_became_static/old/lib.h
+++ b/examples/case21_method_became_static/old/lib.h
@@ -1,0 +1,4 @@
+class Widget {
+public:
+    void bar();
+};

--- a/examples/case22_method_const_changed/Makefile
+++ b/examples/case22_method_const_changed/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case22: method const qualifier removed (BREAKING)"

--- a/examples/case22_method_const_changed/new/lib.h
+++ b/examples/case22_method_const_changed/new/lib.h
@@ -1,0 +1,4 @@
+class Widget {
+public:
+    void get();
+};

--- a/examples/case22_method_const_changed/old/lib.h
+++ b/examples/case22_method_const_changed/old/lib.h
@@ -1,0 +1,4 @@
+class Widget {
+public:
+    void get() const;
+};

--- a/examples/case23_pure_virtual_added/Makefile
+++ b/examples/case23_pure_virtual_added/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case23: virtual became pure virtual (BREAKING)"

--- a/examples/case23_pure_virtual_added/new/lib.h
+++ b/examples/case23_pure_virtual_added/new/lib.h
@@ -1,0 +1,4 @@
+class Processor {
+public:
+    virtual void process() = 0;
+};

--- a/examples/case23_pure_virtual_added/old/lib.h
+++ b/examples/case23_pure_virtual_added/old/lib.h
@@ -1,0 +1,4 @@
+class Processor {
+public:
+    virtual void process();
+};

--- a/examples/case24_union_field_removed/Makefile
+++ b/examples/case24_union_field_removed/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case24: union field removed (BREAKING)"

--- a/examples/case24_union_field_removed/new/lib.h
+++ b/examples/case24_union_field_removed/new/lib.h
@@ -1,0 +1,3 @@
+union Data {
+    int i;
+};

--- a/examples/case24_union_field_removed/old/lib.h
+++ b/examples/case24_union_field_removed/old/lib.h
@@ -1,0 +1,4 @@
+union Data {
+    int i;
+    float f;
+};

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -33,7 +33,6 @@ CASES = [
     # ✅ Struct size change detected via castxml → TYPE_SIZE_CHANGED → BREAKING
     ("case07_struct_layout",        "BREAKING",   "v1.c",     "v2.c"),
     # ⚠️ Enum value changes not tracked (only Struct/Class/Union in parse_types) → NO_CHANGE
-    # ✅ Enum member/value changes now detected via _diff_enums() → BREAKING
     ("case08_enum_value_change",    "BREAKING",   "v1.c",     "v2.c"),
     # ✅ vtable reorder/change detected → TYPE_VTABLE_CHANGED → BREAKING
     ("case09_cpp_vtable",           "BREAKING",   "v1.cpp",   "v2.cpp"),

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -33,7 +33,8 @@ CASES = [
     # ✅ Struct size change detected via castxml → TYPE_SIZE_CHANGED → BREAKING
     ("case07_struct_layout",        "BREAKING",   "v1.c",     "v2.c"),
     # ⚠️ Enum value changes not tracked (only Struct/Class/Union in parse_types) → NO_CHANGE
-    ("case08_enum_value_change",    "NO_CHANGE",  "v1.c",     "v2.c"),
+    # ✅ Enum member/value changes now detected via _diff_enums() → BREAKING
+    ("case08_enum_value_change",    "BREAKING",   "v1.c",     "v2.c"),
     # ✅ vtable reorder/change detected → TYPE_VTABLE_CHANGED → BREAKING
     ("case09_cpp_vtable",           "BREAKING",   "v1.cpp",   "v2.cpp"),
     # ✅ Return type change detected via castxml → FUNC_RETURN_CHANGED → BREAKING

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -1,0 +1,195 @@
+"""Sprint 1 tests — enum/method qualifier/union/typedef/bitfield ABI detection.
+
+All tests build AbiSnapshot objects directly (no castxml required).
+"""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, compare
+from abicheck.model import (
+    AbiSnapshot,
+    EnumMember,
+    EnumType,
+    Function,
+    RecordType,
+    TypeField,
+)
+
+
+def _snap(**kwargs: object) -> AbiSnapshot:
+    defaults: dict[str, object] = dict(library="lib.so", version="1.0")
+    defaults.update(kwargs)
+    return AbiSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Enum tests
+# ---------------------------------------------------------------------------
+
+def test_enum_member_removed() -> None:
+    old = _snap(enums=[EnumType("Status", [EnumMember("OK", 0), EnumMember("FOO", 2)])])
+    new = _snap(enums=[EnumType("Status", [EnumMember("OK", 0)])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_REMOVED in kinds
+
+
+def test_enum_member_value_changed() -> None:
+    # ERROR is not the last member here (LAST is)
+    old = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("ERROR", 1), EnumMember("LAST", 2)])])
+    new = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("ERROR", 99), EnumMember("LAST", 2)])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds
+    assert ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED not in kinds
+
+
+def test_enum_last_member_changed() -> None:
+    old = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("LAST", 10)])])
+    new = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("LAST", 99)])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED in kinds
+
+
+def test_enum_member_added() -> None:
+    old = _snap(enums=[EnumType("Color", [EnumMember("RED", 0)])])
+    new = _snap(enums=[EnumType("Color", [EnumMember("RED", 0), EnumMember("BLUE", 1)])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_ADDED in kinds
+
+
+# ---------------------------------------------------------------------------
+# Method qualifier tests
+# ---------------------------------------------------------------------------
+
+def _func(name: str, mangled: str, **kwargs: object) -> Function:
+    defaults: dict[str, object] = dict(return_type="void")
+    defaults.update(kwargs)
+    return Function(name=name, mangled=mangled, **defaults)  # type: ignore[arg-type]
+
+
+def test_method_became_static() -> None:
+    old = _snap(functions=[_func("bar", "_ZN6Widget3barEv", is_static=False)])
+    new = _snap(functions=[_func("bar", "_ZN6Widget3barEv", is_static=True)])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.FUNC_STATIC_CHANGED in kinds
+
+
+def test_method_const_changed() -> None:
+    old = _snap(functions=[_func("get", "_ZNK6Widget3getEv", is_const=True)])
+    new = _snap(functions=[_func("get", "_ZNK6Widget3getEv", is_const=False)])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.FUNC_CV_CHANGED in kinds
+
+
+def test_method_volatile_changed() -> None:
+    old = _snap(functions=[_func("run", "_ZNV6Widget3runEv", is_volatile=True)])
+    new = _snap(functions=[_func("run", "_ZNV6Widget3runEv", is_volatile=False)])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.FUNC_CV_CHANGED in kinds
+
+
+def test_pure_virtual_added() -> None:
+    """Non-virtual function that gets pure_virtual=True → FUNC_PURE_VIRTUAL_ADDED."""
+    old = _snap(functions=[_func("process", "_ZN9Processor7processEv", is_virtual=False, is_pure_virtual=False)])
+    new = _snap(functions=[_func("process", "_ZN9Processor7processEv", is_virtual=False, is_pure_virtual=True)])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.FUNC_PURE_VIRTUAL_ADDED in kinds
+
+
+def test_virtual_became_pure() -> None:
+    """Virtual function that becomes pure virtual → FUNC_VIRTUAL_BECAME_PURE."""
+    old = _snap(functions=[_func("process", "_ZN9Processor7processEv", is_virtual=True, is_pure_virtual=False)])
+    new = _snap(functions=[_func("process", "_ZN9Processor7processEv", is_virtual=True, is_pure_virtual=True)])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.FUNC_VIRTUAL_BECAME_PURE in kinds
+
+
+# ---------------------------------------------------------------------------
+# Union tests
+# ---------------------------------------------------------------------------
+
+def _union(name: str, fields: list[TypeField]) -> RecordType:
+    return RecordType(name=name, kind="union", fields=fields, is_union=True)
+
+
+def test_union_field_removed() -> None:
+    old = _snap(types=[_union("Data", [TypeField("i", "int"), TypeField("f", "float")])])
+    new = _snap(types=[_union("Data", [TypeField("i", "int")])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.UNION_FIELD_REMOVED in kinds
+
+
+def test_union_field_type_changed() -> None:
+    old = _snap(types=[_union("Data", [TypeField("x", "int")])])
+    new = _snap(types=[_union("Data", [TypeField("x", "double")])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.UNION_FIELD_TYPE_CHANGED in kinds
+
+
+# ---------------------------------------------------------------------------
+# Typedef tests
+# ---------------------------------------------------------------------------
+
+def test_typedef_base_changed() -> None:
+    old = _snap(typedefs={"MyInt": "int"})
+    new = _snap(typedefs={"MyInt": "long"})
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.TYPEDEF_BASE_CHANGED in kinds
+
+
+# ---------------------------------------------------------------------------
+# Bitfield tests
+# ---------------------------------------------------------------------------
+
+def _struct_with_bitfield(name: str, field_name: str, bits: int | None) -> RecordType:
+    f = TypeField(
+        name=field_name, type="int",
+        is_bitfield=bits is not None,
+        bitfield_bits=bits,
+    )
+    return RecordType(name=name, kind="struct", fields=[f])
+
+
+def test_bitfield_changed() -> None:
+    old = _snap(types=[_struct_with_bitfield("Flags", "x", 4)])
+    new = _snap(types=[_struct_with_bitfield("Flags", "x", 8)])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.FIELD_BITFIELD_CHANGED in kinds
+
+
+# ---------------------------------------------------------------------------
+# Verdict checks (all sprint1 changes are BREAKING)
+# ---------------------------------------------------------------------------
+
+def test_sprint1_all_breaking() -> None:
+    """All new change kinds must produce BREAKING verdict."""
+    from abicheck.checker import _BREAKING_KINDS
+    sprint1_kinds = {
+        ChangeKind.ENUM_MEMBER_REMOVED,
+        ChangeKind.ENUM_MEMBER_ADDED,
+        ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
+        ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
+        ChangeKind.FUNC_STATIC_CHANGED,
+        ChangeKind.FUNC_CV_CHANGED,
+        ChangeKind.FUNC_PURE_VIRTUAL_ADDED,
+        ChangeKind.FUNC_VIRTUAL_BECAME_PURE,
+        ChangeKind.UNION_FIELD_ADDED,
+        ChangeKind.UNION_FIELD_REMOVED,
+        ChangeKind.UNION_FIELD_TYPE_CHANGED,
+        ChangeKind.TYPEDEF_BASE_CHANGED,
+        ChangeKind.FIELD_BITFIELD_CHANGED,
+    }
+    assert sprint1_kinds.issubset(_BREAKING_KINDS), (
+        f"Not in _BREAKING_KINDS: {sprint1_kinds - _BREAKING_KINDS}"
+    )

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -70,10 +70,11 @@ def _func(name: str, mangled: str, **kwargs: object) -> Function:
 
 
 def test_method_became_static() -> None:
-    # In real C++, static changes mangling (different symbol names).
-    # Checker matches via (name, params) across removed/added sets.
+    # Itanium ABI: static member functions have the SAME mangled name as non-static
+    # with identical signature (is_static is not encoded in mangling).
+    # Checker detects this via the same-mangled loop.
     old = _snap(functions=[_func("bar", "_ZN6Widget3barEv", is_static=False)])
-    new = _snap(functions=[_func("bar", "_ZN6Widget3barEv_static", is_static=True)])
+    new = _snap(functions=[_func("bar", "_ZN6Widget3barEv", is_static=True)])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.FUNC_STATIC_CHANGED in kinds

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -70,24 +70,29 @@ def _func(name: str, mangled: str, **kwargs: object) -> Function:
 
 
 def test_method_became_static() -> None:
+    # In real C++, static changes mangling (different symbol names).
+    # Checker matches via (name, params) across removed/added sets.
     old = _snap(functions=[_func("bar", "_ZN6Widget3barEv", is_static=False)])
-    new = _snap(functions=[_func("bar", "_ZN6Widget3barEv", is_static=True)])
+    new = _snap(functions=[_func("bar", "_ZN6Widget3barEv_static", is_static=True)])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.FUNC_STATIC_CHANGED in kinds
 
 
 def test_method_const_changed() -> None:
-    old = _snap(functions=[_func("get", "_ZNK6Widget3getEv", is_const=True)])
-    new = _snap(functions=[_func("get", "_ZNK6Widget3getEv", is_const=False)])
+    # const adds K prefix in Itanium mangling: Foo::get() → _ZN3Foo3getEv
+    #                                            Foo::get() const → _ZNK3Foo3getEv
+    old = _snap(functions=[_func("get", "_ZN6Widget3getEv", is_const=False)])
+    new = _snap(functions=[_func("get", "_ZNK6Widget3getEv", is_const=True)])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.FUNC_CV_CHANGED in kinds
 
 
 def test_method_volatile_changed() -> None:
-    old = _snap(functions=[_func("run", "_ZNV6Widget3runEv", is_volatile=True)])
-    new = _snap(functions=[_func("run", "_ZNV6Widget3runEv", is_volatile=False)])
+    # volatile adds V prefix in mangling
+    old = _snap(functions=[_func("run", "_ZN6Widget3runEv", is_volatile=False)])
+    new = _snap(functions=[_func("run", "_ZNV6Widget3runEv", is_volatile=True)])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.FUNC_CV_CHANGED in kinds

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -127,6 +127,14 @@ def test_union_field_removed() -> None:
     assert ChangeKind.UNION_FIELD_REMOVED in kinds
 
 
+def test_union_field_added() -> None:
+    old = _snap(types=[_union("Data", [TypeField("i", "int")])])
+    new = _snap(types=[_union("Data", [TypeField("i", "int"), TypeField("f", "float")])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.UNION_FIELD_ADDED in kinds
+
+
 def test_union_field_type_changed() -> None:
     old = _snap(types=[_union("Data", [TypeField("x", "int")])])
     new = _snap(types=[_union("Data", [TypeField("x", "double")])])


### PR DESCRIPTION
Implements 13 new ChangeKind detectors from gap_report.md Sprint 1.

New detections:
- Enum member removed/added/value changed/last value
- Method static/const/volatile qualifier changes
- Pure virtual added / virtual became pure
- Union field-level changes
- Typedef base type changes
- Bitfield layout changes

Coverage: 47% → ~65%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ABI analysis to detect enum member/value changes, method qualifier changes (static/const/volatile and pure-virtual transitions), union field and typedef changes, and bitfield layout differences.

* **Tests**
  * Added comprehensive tests covering these new detection scenarios and updated expectations for enum-value behavior.

* **Dependencies**
  * Added pyyaml, defusedxml, and types-PyYAML.

* **Documentation**
  * Added a v2 coverage plan outlining detection tiers, principles, and future sprint goals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->