### PR TITLE
feat: Sprint 2 ELF-only ABI detectors (case28-32 foundation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: ruff check abicheck/ tests/
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short -m "not integration"
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,4 +77,7 @@ jobs:
 
       - name: mypy
         # strict mode is configured in pyproject.toml [tool.mypy]
-        run: mypy abicheck/ --ignore-missing-imports
+        run: mypy abicheck/ --ignore-missing-imports --show-error-codes --show-traceback || true
+
+      - name: mypy strict (fail)
+        run: mypy abicheck/ --ignore-missing-imports --show-error-codes

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,7 +77,4 @@ jobs:
 
       - name: mypy
         # strict mode is configured in pyproject.toml [tool.mypy]
-        run: mypy abicheck/ --ignore-missing-imports --show-error-codes --show-traceback || true
-
-      - name: mypy strict (fail)
-        run: mypy abicheck/ --ignore-missing-imports --show-error-codes
+        run: mypy abicheck/ --ignore-missing-imports

--- a/GOALS.md
+++ b/GOALS.md
@@ -1,0 +1,86 @@
+# Project Goals — abicheck
+
+> **Context:** abi-compliance-checker (ABICC) and libabigail are no longer actively maintained.
+> `abicheck` is their modern Python successor — drop-in compatible first, then better.
+
+---
+
+## Goal 1 — Drop-In Replacement for ABICC
+Support everything ABICC currently does so existing users/pipelines can migrate without changes:
+- Same detection coverage (C/C++ ABI breaks: symbols, types, vtables, enums, layout)
+- CLI interface compatible with ABICC inputs (XML descriptors, headers+libs)
+- JSON/HTML/Markdown reports with equivalent verdict semantics
+- Support for suppression files
+
+**Done:** Sprint 1 closes 13 detection gaps; Sprint 2 adds ELF-only layer ABICC lacks.
+**TODO:** Audit ABICC feature list → gap matrix → fill remaining items.
+
+---
+
+## Goal 2 — Close Known Gaps + Extend
+Fix known ABICC / libabigail limitations and add new detection capability:
+- Toolchain/flag drift detection (`DW_AT_producer`, `-fshort-enums`, `-fpack-struct`)
+- DWARF-aware layout analysis (calling convention, packing, RTTI/visibility boundaries)
+- Header/API surface diff (AST-based, macro contracts, inline/template changes)
+- Confidence/evidence tiers in output (ELF_ONLY / DWARF_AWARE / HEADER_AWARE)
+
+**Roadmap:** Sprint 3 = DWARF-aware tier; Sprint 4 = header/AST tier.
+
+---
+
+## Goal 3 — Pass libabigail Test Suite
+Run `abicheck` against libabigail's own regression test cases and reach 100% pass rate:
+- Mirror libabigail's `tests/` corpus as integration examples
+- Add per-case expected verdicts to CI
+- Use as the compatibility regression gate before each release
+
+**TODO:** Clone libabigail test suite, map to `examples/caseXX_*`, run in CI.
+
+---
+
+## Goal 4 — Agent-Friendly Design
+Make the tool convenient for AI agents and automation pipelines:
+- Structured JSON output (machine-readable, no scraping)
+- Clear exit codes (0=no change, 1=breaking, 2=compatible additions, 3=error)
+- Python API (`from abicheck import compare, dump`) — not just CLI
+- `--format json/markdown/sarif` output modes
+- MCP / tool-use compatible JSON schema for change entries
+- Snapshot files for offline/async workflows (`abicheck dump` → `.abi.json`)
+
+**Partially done:** JSON output, snapshot format. **TODO:** SARIF output, Python API docs, MCP schema.
+
+---
+
+## Goal 5 — Compatibility Break Encyclopedia
+For each break type: what it is, how it appears in the real world, and which tool detects it:
+- `examples/caseXX_*/` — minimal compilable C/C++ examples
+- Per-case `README.md` with: scenario → what breaks → which tools detect → severity
+- Comparison table: `abicheck` vs `abicc` vs `libabigail` vs `nm`-only
+- Coverage matrix showing evidence tier required (ELF-only / DWARF / Header / Runtime)
+
+**In progress:** cases 01–24 done. **TODO:** v2 cases 25–32, libabigail-parity cases.
+
+---
+
+## Goal 6 — GitHub Pages Documentation Site
+Public documentation at `https://napetrov.github.io/abicheck/`:
+- Getting started / installation
+- CLI reference
+- ABI break catalog (rendered from `examples/`)
+- Tool comparison table
+- Architecture overview
+
+**TODO:** Set up `docs/` Jekyll/MkDocs site, GitHub Actions publish workflow.
+
+---
+
+## Status Summary
+
+| Goal | Status |
+|------|--------|
+| G1: ABICC drop-in | 🟡 In progress — Sprint 1+2 close major gaps |
+| G2: Known gaps | 🟡 In progress — Sprint 2 ELF done, Sprint 3 DWARF next |
+| G3: libabigail tests | 🔴 Not started |
+| G4: Agent-friendly | 🟡 Partial — JSON/snapshot done, SARIF/MCP TODO |
+| G5: Break encyclopedia | 🟡 In progress — cases 01–24 done |
+| G6: GitHub Pages | 🔴 Not started |

--- a/abicheck.egg-info/PKG-INFO
+++ b/abicheck.egg-info/PKG-INFO
@@ -9,6 +9,7 @@ License-File: NOTICE.md
 Requires-Dist: click>=8.0
 Requires-Dist: pyyaml>=6.0
 Requires-Dist: defusedxml>=0.7.1
+Requires-Dist: pyelftools>=0.29
 Provides-Extra: dev
 Requires-Dist: pytest>=7.0; extra == "dev"
 Requires-Dist: pytest-cov; extra == "dev"

--- a/abicheck.egg-info/SOURCES.txt
+++ b/abicheck.egg-info/SOURCES.txt
@@ -6,6 +6,7 @@ abicheck/__init__.py
 abicheck/checker.py
 abicheck/cli.py
 abicheck/dumper.py
+abicheck/elf_metadata.py
 abicheck/model.py
 abicheck/reporter.py
 abicheck/serialization.py
@@ -21,4 +22,5 @@ tests/test_checker.py
 tests/test_reporter.py
 tests/test_serialization.py
 tests/test_sprint1.py
+tests/test_sprint2_elf.py
 tests/test_suppression.py

--- a/abicheck.egg-info/requires.txt
+++ b/abicheck.egg-info/requires.txt
@@ -1,6 +1,7 @@
 click>=8.0
 pyyaml>=6.0
 defusedxml>=0.7.1
+pyelftools>=0.29
 
 [dev]
 pytest>=7.0

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -67,6 +67,27 @@ class ChangeKind(str, Enum):
     # Bitfield changes
     FIELD_BITFIELD_CHANGED = "field_bitfield_changed"
 
+    # ── ELF-only (Sprint 2) ──────────────────────────────────────────────
+    # Dynamic section contract
+    SONAME_CHANGED           = "soname_changed"
+    NEEDED_ADDED             = "needed_added"            # new DT_NEEDED dep
+    NEEDED_REMOVED           = "needed_removed"          # dep dropped
+    RPATH_CHANGED            = "rpath_changed"
+    RUNPATH_CHANGED          = "runpath_changed"
+
+    # Symbol metadata drift (ELF .dynsym)
+    SYMBOL_BINDING_CHANGED   = "symbol_binding_changed"  # GLOBAL ↔ WEAK
+    SYMBOL_TYPE_CHANGED      = "symbol_type_changed"     # FUNC→OBJECT, etc.
+    SYMBOL_SIZE_CHANGED      = "symbol_size_changed"     # st_size changed
+    IFUNC_INTRODUCED         = "ifunc_introduced"        # → STT_GNU_IFUNC
+    IFUNC_REMOVED            = "ifunc_removed"           # STT_GNU_IFUNC →
+    COMMON_SYMBOL_RISK       = "common_symbol_risk"      # STT_COMMON exported
+
+    # Symbol versioning contract
+    SYMBOL_VERSION_DEFINED_REMOVED   = "symbol_version_defined_removed"
+    SYMBOL_VERSION_REQUIRED_ADDED    = "symbol_version_required_added"   # new GLIBC_X
+    SYMBOL_VERSION_REQUIRED_REMOVED  = "symbol_version_required_removed"
+
 
 class Verdict(str, Enum):
     NO_CHANGE = "NO_CHANGE"         # identical ABI
@@ -109,6 +130,24 @@ _BREAKING_KINDS = {
     ChangeKind.TYPEDEF_BASE_CHANGED,
     ChangeKind.TYPEDEF_REMOVED,
     ChangeKind.FIELD_BITFIELD_CHANGED,
+    # ELF Sprint 2
+    ChangeKind.SONAME_CHANGED,
+    ChangeKind.NEEDED_ADDED,
+    ChangeKind.SYMBOL_BINDING_CHANGED,
+    ChangeKind.SYMBOL_TYPE_CHANGED,
+    ChangeKind.SYMBOL_SIZE_CHANGED,
+    ChangeKind.IFUNC_INTRODUCED,
+    ChangeKind.IFUNC_REMOVED,
+    ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+}
+
+_COMPATIBLE_KINDS: set[ChangeKind] = {
+    ChangeKind.NEEDED_REMOVED,       # removing a dep is compatible (but deployment risk)
+    ChangeKind.RUNPATH_CHANGED,      # search path drift — warn only
+    ChangeKind.RPATH_CHANGED,
+    ChangeKind.COMMON_SYMBOL_RISK,   # STT_COMMON — risk, not proven break
+    ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
 }
 
 _SOURCE_BREAK_KINDS: set[ChangeKind] = set()  # reserved for future source-only breaks
@@ -615,6 +654,148 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 
 
+def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    """ELF-only detectors (Sprint 2): no debug info required."""
+    from .elf_metadata import ElfMetadata, SymbolType
+
+    o: ElfMetadata = getattr(old, "elf", None) or ElfMetadata()
+    n: ElfMetadata = getattr(new, "elf", None) or ElfMetadata()
+    changes: list[Change] = []
+
+    # ── Dynamic section ─────────────────────────────────────────────────
+    if o.soname and n.soname and o.soname != n.soname:
+        changes.append(Change(
+            kind=ChangeKind.SONAME_CHANGED,
+            symbol="DT_SONAME",
+            description=f"SONAME changed: {o.soname!r} → {n.soname!r}",
+            old_value=o.soname, new_value=n.soname,
+        ))
+
+    old_needed = set(o.needed)
+    new_needed = set(n.needed)
+    for lib in sorted(new_needed - old_needed):
+        changes.append(Change(
+            kind=ChangeKind.NEEDED_ADDED,
+            symbol="DT_NEEDED",
+            description=f"New dependency added: {lib}",
+            new_value=lib,
+        ))
+    for lib in sorted(old_needed - new_needed):
+        changes.append(Change(
+            kind=ChangeKind.NEEDED_REMOVED,
+            symbol="DT_NEEDED",
+            description=f"Dependency removed: {lib}",
+            old_value=lib,
+        ))
+
+    if o.rpath != n.rpath:
+        changes.append(Change(
+            kind=ChangeKind.RPATH_CHANGED,
+            symbol="DT_RPATH",
+            description=f"RPATH changed: {o.rpath!r} → {n.rpath!r}",
+            old_value=o.rpath, new_value=n.rpath,
+        ))
+    if o.runpath != n.runpath:
+        changes.append(Change(
+            kind=ChangeKind.RUNPATH_CHANGED,
+            symbol="DT_RUNPATH",
+            description=f"RUNPATH changed: {o.runpath!r} → {n.runpath!r}",
+            old_value=o.runpath, new_value=n.runpath,
+        ))
+
+    # ── Symbol versioning ────────────────────────────────────────────────
+    old_def = set(o.versions_defined)
+    new_def = set(n.versions_defined)
+    for ver in sorted(old_def - new_def):
+        changes.append(Change(
+            kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+            symbol=ver,
+            description=f"Symbol version removed: {ver}",
+            old_value=ver,
+        ))
+
+    # Required version drift (e.g. new GLIBC_2.34 requirement)
+    for lib, new_vers in n.versions_required.items():
+        old_vers = set(o.versions_required.get(lib, []))
+        for ver in sorted(set(new_vers) - old_vers):
+            changes.append(Change(
+                kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+                symbol=ver,
+                description=f"New symbol version requirement: {ver} (from {lib})",
+                new_value=f"{lib}:{ver}",
+            ))
+        for ver in sorted(old_vers - set(new_vers)):
+            changes.append(Change(
+                kind=ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
+                symbol=ver,
+                description=f"Symbol version requirement removed: {ver} (from {lib})",
+                old_value=f"{lib}:{ver}",
+            ))
+
+    # ── Per-symbol metadata ──────────────────────────────────────────────
+    old_syms = o.symbol_map
+    new_syms = n.symbol_map
+
+    for sym_name, s_old in old_syms.items():
+        if sym_name not in new_syms:
+            continue
+        s_new = new_syms[sym_name]
+
+        # IFUNC introduced/removed
+        if s_old.sym_type != SymbolType.IFUNC and s_new.sym_type == SymbolType.IFUNC:
+            changes.append(Change(
+                kind=ChangeKind.IFUNC_INTRODUCED,
+                symbol=sym_name,
+                description=f"Symbol became GNU_IFUNC: {sym_name}",
+                old_value=s_old.sym_type.value, new_value="ifunc",
+            ))
+        elif s_old.sym_type == SymbolType.IFUNC and s_new.sym_type != SymbolType.IFUNC:
+            changes.append(Change(
+                kind=ChangeKind.IFUNC_REMOVED,
+                symbol=sym_name,
+                description=f"Symbol no longer GNU_IFUNC: {sym_name}",
+                old_value="ifunc", new_value=s_new.sym_type.value,
+            ))
+        elif s_old.sym_type != s_new.sym_type:
+            changes.append(Change(
+                kind=ChangeKind.SYMBOL_TYPE_CHANGED,
+                symbol=sym_name,
+                description=f"Symbol type changed: {sym_name} ({s_old.sym_type.value} → {s_new.sym_type.value})",
+                old_value=s_old.sym_type.value, new_value=s_new.sym_type.value,
+            ))
+
+        # Binding drift
+        if s_old.binding != s_new.binding:
+            changes.append(Change(
+                kind=ChangeKind.SYMBOL_BINDING_CHANGED,
+                symbol=sym_name,
+                description=f"Symbol binding changed: {sym_name} ({s_old.binding.value} → {s_new.binding.value})",
+                old_value=s_old.binding.value, new_value=s_new.binding.value,
+            ))
+
+        # Size drift (non-zero old size to detect false positives on notype/0)
+        if s_old.size > 0 and s_new.size > 0 and s_old.size != s_new.size:
+            changes.append(Change(
+                kind=ChangeKind.SYMBOL_SIZE_CHANGED,
+                symbol=sym_name,
+                description=f"Symbol size changed: {sym_name} ({s_old.size} → {s_new.size} bytes)",
+                old_value=str(s_old.size), new_value=str(s_new.size),
+            ))
+
+    # STT_COMMON risk: any new COMMON symbols in exported API
+    for sym_name, s_new in new_syms.items():
+        if s_new.sym_type == SymbolType.COMMON:
+            old_common = old_syms.get(sym_name)
+            if old_common is None or old_common.sym_type != SymbolType.COMMON:
+                changes.append(Change(
+                    kind=ChangeKind.COMMON_SYMBOL_RISK,
+                    symbol=sym_name,
+                    description=f"Exported STT_COMMON symbol: {sym_name} (resolution depends on linker/loader)",
+                ))
+
+    return changes
+
+
 def _compute_verdict(changes: list[Change]) -> Verdict:
     if not changes:
         return Verdict.NO_CHANGE
@@ -623,6 +804,9 @@ def _compute_verdict(changes: list[Change]) -> Verdict:
         return Verdict.BREAKING
     if kinds & _SOURCE_BREAK_KINDS:
         return Verdict.SOURCE_BREAK
+    # Only COMPATIBLE_KINDS changes (ELF warnings, deployment risks)
+    if kinds - _COMPATIBLE_KINDS == set():
+        return Verdict.COMPATIBLE
     return Verdict.COMPATIBLE
 
 
@@ -641,6 +825,7 @@ def compare(
     changes.extend(_diff_method_qualifiers(old, new))
     changes.extend(_diff_unions(old, new))
     changes.extend(_diff_typedefs(old, new))
+    changes.extend(_diff_elf(old, new))
 
     suppressed: list[Change] = []
     if suppression is not None:

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from .elf_metadata import SymbolBinding, SymbolType
 from .model import AbiSnapshot, EnumType, Function, Visibility
 
 if TYPE_CHECKING:
@@ -76,7 +77,8 @@ class ChangeKind(str, Enum):
     RUNPATH_CHANGED          = "runpath_changed"
 
     # Symbol metadata drift (ELF .dynsym)
-    SYMBOL_BINDING_CHANGED   = "symbol_binding_changed"  # GLOBAL ↔ WEAK
+    SYMBOL_BINDING_CHANGED      = "symbol_binding_changed"      # GLOBAL→WEAK (breaking)
+    SYMBOL_BINDING_STRENGTHENED = "symbol_binding_strengthened"  # WEAK→GLOBAL (compatible)
     SYMBOL_TYPE_CHANGED      = "symbol_type_changed"     # FUNC→OBJECT, etc.
     SYMBOL_SIZE_CHANGED      = "symbol_size_changed"     # st_size changed
     IFUNC_INTRODUCED         = "ifunc_introduced"        # → STT_GNU_IFUNC
@@ -142,12 +144,13 @@ _BREAKING_KINDS = {
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
-    ChangeKind.NEEDED_ADDED,         # new dep: may not exist on older systems — warn, not hard-break
-    ChangeKind.NEEDED_REMOVED,       # removing a dep is compatible (but deployment risk)
-    ChangeKind.RUNPATH_CHANGED,      # search path drift — warn only
+    ChangeKind.NEEDED_ADDED,              # new dep: may not exist on older systems — warn, not hard-break
+    ChangeKind.NEEDED_REMOVED,            # removing a dep is compatible (but deployment risk)
+    ChangeKind.RUNPATH_CHANGED,           # search path drift — warn only
     ChangeKind.RPATH_CHANGED,
-    ChangeKind.COMMON_SYMBOL_RISK,   # STT_COMMON — risk, not proven break
+    ChangeKind.COMMON_SYMBOL_RISK,        # STT_COMMON — risk, not proven break
     ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
+    ChangeKind.SYMBOL_BINDING_STRENGTHENED,  # WEAK→GLOBAL: backward-compatible for most consumers
 }
 
 _SOURCE_BREAK_KINDS: set[ChangeKind] = set()  # reserved for future source-only breaks
@@ -714,17 +717,20 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             old_value=ver,
         ))
 
-    # Required version drift (e.g. new GLIBC_2.34 requirement)
-    for lib, new_vers in n.versions_required.items():
+    # Required version drift (e.g. new GLIBC_2.34 requirement).
+    # Iterate union of old+new libs to catch libs that disappeared entirely.
+    all_req_libs = set(o.versions_required) | set(n.versions_required)
+    for lib in sorted(all_req_libs):
         old_vers = set(o.versions_required.get(lib, []))
-        for ver in sorted(set(new_vers) - old_vers):
+        new_vers = set(n.versions_required.get(lib, []))
+        for ver in sorted(new_vers - old_vers):
             changes.append(Change(
                 kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
                 symbol=ver,
                 description=f"New symbol version requirement: {ver} (from {lib})",
                 new_value=f"{lib}:{ver}",
             ))
-        for ver in sorted(old_vers - set(new_vers)):
+        for ver in sorted(old_vers - new_vers):
             changes.append(Change(
                 kind=ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
                 symbol=ver,
@@ -764,17 +770,33 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 old_value=s_old.sym_type.value, new_value=s_new.sym_type.value,
             ))
 
-        # Binding drift
+        # Binding drift.
+        # GLOBAL→WEAK: breaking — consumers expecting reliable strong resolution may get
+        # the weak version overridden or missing at link time.
+        # WEAK→GLOBAL: compatible for most consumers (symbol is strengthened). Edge case:
+        # interposing libraries that relied on weak-override semantics will stop working,
+        # but that's an unusual deployment pattern; classified COMPATIBLE per ADR-001.
         if s_old.binding != s_new.binding:
+            is_weakening = (
+                s_old.binding == SymbolBinding.GLOBAL
+                and s_new.binding == SymbolBinding.WEAK
+            )
+            kind = ChangeKind.SYMBOL_BINDING_CHANGED if is_weakening else ChangeKind.SYMBOL_BINDING_STRENGTHENED
             changes.append(Change(
-                kind=ChangeKind.SYMBOL_BINDING_CHANGED,
+                kind=kind,
                 symbol=sym_name,
                 description=f"Symbol binding changed: {sym_name} ({s_old.binding.value} → {s_new.binding.value})",
                 old_value=s_old.binding.value, new_value=s_new.binding.value,
             ))
 
-        # Size drift (non-zero old size to detect false positives on notype/0)
-        if s_old.size > 0 and s_new.size > 0 and s_old.size != s_new.size:
+        # Size drift — only meaningful for data objects (STT_OBJECT, STT_TLS).
+        # STT_FUNC size = machine-code bytes: changes with every compile/optimization,
+        # is not an ABI contract, and produces massive false positives. Ignored.
+        if (
+            s_old.size > 0 and s_new.size > 0
+            and s_old.size != s_new.size
+            and s_new.sym_type in (SymbolType.OBJECT, SymbolType.COMMON, SymbolType.TLS)
+        ):
             changes.append(Change(
                 kind=ChangeKind.SYMBOL_SIZE_CHANGED,
                 symbol=sym_name,

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from .elf_metadata import SymbolBinding, SymbolType
+from .elf_metadata import SymbolBinding
 from .model import AbiSnapshot, EnumType, Function, Visibility
 
 if TYPE_CHECKING:

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -132,7 +132,6 @@ _BREAKING_KINDS = {
     ChangeKind.FIELD_BITFIELD_CHANGED,
     # ELF Sprint 2
     ChangeKind.SONAME_CHANGED,
-    ChangeKind.NEEDED_ADDED,
     ChangeKind.SYMBOL_BINDING_CHANGED,
     ChangeKind.SYMBOL_TYPE_CHANGED,
     ChangeKind.SYMBOL_SIZE_CHANGED,
@@ -143,6 +142,7 @@ _BREAKING_KINDS = {
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
+    ChangeKind.NEEDED_ADDED,         # new dep: may not exist on older systems — warn, not hard-break
     ChangeKind.NEEDED_REMOVED,       # removing a dep is compatible (but deployment risk)
     ChangeKind.RUNPATH_CHANGED,      # search path drift — warn only
     ChangeKind.RPATH_CHANGED,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -507,6 +507,7 @@ def dump(
     xml_root = _castxml_dump(headers, extra_includes, compiler=compiler)
     parser = _CastxmlParser(xml_root, exported_dynamic, exported_static)
 
+    from .elf_metadata import parse_elf_metadata
     snapshot = AbiSnapshot(
         library=so_path.name,
         version=version,
@@ -515,5 +516,6 @@ def dump(
         types=parser.parse_types(),
         enums=parser.parse_enums(),
         typedefs=parser.parse_typedefs(),
+        elf=parse_elf_metadata(so_path),
     )
     return snapshot

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -1,17 +1,28 @@
 """ELF dynamic-section and symbol-table metadata.
 
-Extracted via ``readelf`` — no debug info required.  Covers:
-- DT_SONAME, DT_NEEDED, DT_RPATH, DT_RUNPATH
-- .gnu.version_d / .gnu.version_r  (defined / required symbol versions)
-- Per-symbol: binding, type, visibility, size  (from .dynsym)
+Uses ``pyelftools`` (pure Python, actively maintained) for robust ELF/DWARF
+parsing instead of text-scraping ``readelf`` output.
+
+See ADR-001 for technology stack rationale.
 """
 from __future__ import annotations
 
-import re
-import subprocess
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
+
+from elftools.common.exceptions import ELFError
+from elftools.elf.dynamic import DynamicSection
+from elftools.elf.elffile import ELFFile
+from elftools.elf.gnuversions import (
+    GNUVerDefSection,
+    GNUVerNeedSection,
+)
+from elftools.elf.sections import SymbolTableSection
+
+log = logging.getLogger(__name__)
 
 
 class SymbolBinding(str, Enum):
@@ -34,163 +45,162 @@ class SymbolType(str, Enum):
 @dataclass
 class ElfSymbol:
     name: str
-    binding: SymbolBinding = SymbolBinding.GLOBAL
-    sym_type: SymbolType   = SymbolType.FUNC
-    size: int              = 0
-    version: str           = ""   # e.g. "GLIBC_2.5" or "" if unversioned
-    is_default: bool       = True  # @@ vs @ (default vs non-default version)
+    binding:  SymbolBinding = SymbolBinding.GLOBAL
+    sym_type: SymbolType    = SymbolType.FUNC
+    size:     int           = 0
+    version:  str           = ""    # e.g. "GLIBC_2.5" or "" if unversioned
+    is_default: bool        = True  # @@ (default) vs @ (non-default)
+    visibility: str         = "default"  # default / hidden / protected / internal
 
 
 @dataclass
 class ElfMetadata:
     """ELF dynamic-section + symbol metadata for one .so."""
-    soname:   str = ""
-    needed:   list[str] = field(default_factory=list)   # DT_NEEDED entries
-    rpath:    str = ""   # DT_RPATH value (or "")
-    runpath:  str = ""   # DT_RUNPATH value (or "")
+    soname:  str = ""
+    needed:  list[str] = field(default_factory=list)
+    rpath:   str = ""
+    runpath: str = ""
 
     # Symbol versions defined by this library (.gnu.version_d)
     versions_defined: list[str] = field(default_factory=list)
     # Symbol versions required from other libraries (.gnu.version_r)
-    # dict: library_soname -> set of version strings
+    # dict: library_soname → list of version strings
     versions_required: dict[str, list[str]] = field(default_factory=dict)
 
-    # Exported symbols (.dynsym, GLOBAL/WEAK, not UND)
+    # Exported symbols (.dynsym, GLOBAL/WEAK, not UND, not hidden)
     symbols: list[ElfSymbol] = field(default_factory=list)
 
-    @property
+    @cached_property
     def symbol_map(self) -> dict[str, ElfSymbol]:
+        """Name → ElfSymbol mapping (cached, built once)."""
         return {s.name: s for s in self.symbols}
 
 
 # ---------------------------------------------------------------------------
-# Parser
+# Internal helpers
 # ---------------------------------------------------------------------------
 
-def _run(cmd: list[str]) -> str:
-    try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout
-    except Exception:
-        return ""
+_BINDING_MAP: dict[str, SymbolBinding] = {
+    "STB_GLOBAL": SymbolBinding.GLOBAL,
+    "STB_WEAK":   SymbolBinding.WEAK,
+    "STB_LOCAL":  SymbolBinding.LOCAL,
+}
+
+_TYPE_MAP: dict[str, SymbolType] = {
+    "STT_FUNC":      SymbolType.FUNC,
+    "STT_OBJECT":    SymbolType.OBJECT,
+    "STT_TLS":       SymbolType.TLS,
+    "STT_GNU_IFUNC": SymbolType.IFUNC,
+    "STT_COMMON":    SymbolType.COMMON,
+    "STT_NOTYPE":    SymbolType.NOTYPE,
+}
+
+_HIDDEN_VISIBILITIES = {"STV_HIDDEN", "STV_INTERNAL"}
 
 
 def parse_elf_metadata(so_path: Path) -> ElfMetadata:
-    """Extract ELF dynamic + symbol metadata from *so_path* using readelf."""
+    """Extract ELF dynamic + symbol metadata from *so_path* using pyelftools."""
+    # Validate input: must be a regular file (not symlink, pipe, etc.)
+    resolved = so_path.resolve()
+    if not resolved.is_file():
+        log.warning("parse_elf_metadata: not a regular file: %s", so_path)
+        return ElfMetadata()
+
+    try:
+        with open(resolved, "rb") as f:
+            return _parse(f)
+    except (ELFError, OSError) as exc:
+        log.warning("parse_elf_metadata: failed to parse %s: %s", so_path, exc)
+        return ElfMetadata()
+
+
+def _parse(f: object) -> ElfMetadata:  # type: ignore[name-defined]
     meta = ElfMetadata()
-    _parse_dynamic(so_path, meta)
-    _parse_version_sections(so_path, meta)
-    _parse_dynsym(so_path, meta)
+    elf = ELFFile(f)
+
+    for section in elf.iter_sections():
+        if isinstance(section, DynamicSection):
+            _parse_dynamic(section, meta)
+        elif isinstance(section, GNUVerDefSection):
+            _parse_version_def(section, meta)
+        elif isinstance(section, GNUVerNeedSection):
+            _parse_version_need(section, meta)
+        elif isinstance(section, SymbolTableSection) and section.name == ".dynsym":
+            _parse_dynsym(section, meta)
+
     return meta
 
 
-def _parse_dynamic(so_path: Path, meta: ElfMetadata) -> None:
-    out = _run(["readelf", "-d", str(so_path)])
-    for line in out.splitlines():
-        line = line.strip()
-        if "(SONAME)" in line:
-            m = re.search(r'Library soname: \[(.+?)\]', line)
-            if m:
-                meta.soname = m.group(1)
-        elif "(NEEDED)" in line:
-            m = re.search(r'Shared library: \[(.+?)\]', line)
-            if m:
-                meta.needed.append(m.group(1))
-        elif "(RPATH)" in line:
-            m = re.search(r'Library rpath: \[(.+?)\]', line)
-            if m:
-                meta.rpath = m.group(1)
-        elif "(RUNPATH)" in line:
-            m = re.search(r'Library runpath: \[(.+?)\]', line)
-            if m:
-                meta.runpath = m.group(1)
+def _parse_dynamic(section: DynamicSection, meta: ElfMetadata) -> None:
+    for tag in section.iter_tags():
+        if tag.entry.d_tag == "DT_SONAME":
+            meta.soname = tag.soname
+        elif tag.entry.d_tag == "DT_NEEDED":
+            meta.needed.append(tag.needed)
+        elif tag.entry.d_tag == "DT_RPATH":
+            meta.rpath = tag.rpath
+        elif tag.entry.d_tag == "DT_RUNPATH":
+            meta.runpath = tag.runpath
 
 
-def _parse_version_sections(so_path: Path, meta: ElfMetadata) -> None:
-    # -V: version definitions + requirements
-    out = _run(["readelf", "-V", str(so_path)])
-    section = ""
-    cur_lib = ""
-    for line in out.splitlines():
-        low = line.strip().lower()
-        if "version definition" in low:
-            section = "def"
-        elif "version needs" in low:
-            section = "req"
-
-        if section == "def":
-            # Lines like:  0x0001  0x0001  2  libfoo_1.0
-            m = re.search(r'\b([A-Za-z_][A-Za-z0-9_.]*)\s*$', line.strip())
-            if m and not line.strip().startswith("0x"):
-                ver = m.group(1)
-                if ver not in ("section", "version", "definition",
-                               "definitions", "needs", "symbols"):
-                    meta.versions_defined.append(ver)
-        elif section == "req":
-            # "  Filename: libstdc++.so.6 (2 needed)"
-            m_lib = re.search(r'Filename:\s+(\S+)', line)
-            if m_lib:
-                cur_lib = m_lib.group(1)
-                if cur_lib not in meta.versions_required:
-                    meta.versions_required[cur_lib] = []
-            # "  0x0d696911  0x00  02  GLIBCXX_3.4"
-            m_ver = re.search(r'\b([A-Z][A-Z0-9_.]+_[\d.]+)\b', line)
-            if m_ver and cur_lib:
-                ver = m_ver.group(1)
-                if ver not in meta.versions_required[cur_lib]:
-                    meta.versions_required[cur_lib].append(ver)
+def _parse_version_def(section: GNUVerDefSection, meta: ElfMetadata) -> None:
+    for verdef, verdaux_iter in section.iter_versions():
+        for verdaux in verdaux_iter:
+            name = verdaux.name
+            if name and name not in meta.versions_defined:
+                meta.versions_defined.append(name)
 
 
-def _parse_dynsym(so_path: Path, meta: ElfMetadata) -> None:
-    out = _run(["readelf", "-s", "--dyn-syms", str(so_path)])
-    _binding_map = {
-        "global": SymbolBinding.GLOBAL,
-        "weak":   SymbolBinding.WEAK,
-        "local":  SymbolBinding.LOCAL,
-    }
-    _type_map = {
-        "func":   SymbolType.FUNC,
-        "object": SymbolType.OBJECT,
-        "tls":    SymbolType.TLS,
-        "gnu_ifunc": SymbolType.IFUNC,
-        "common": SymbolType.COMMON,
-        "notype": SymbolType.NOTYPE,
-    }
-    for line in out.splitlines():
-        # readelf -s line format (GNU):
-        # Num:    Value          Size Type    Bind   Vis      Ndx Name
-        #   1: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __libc_start_main@@GLIBC_2.34
-        parts = line.split()
-        if len(parts) < 8:
+def _parse_version_need(section: GNUVerNeedSection, meta: ElfMetadata) -> None:
+    for verneed, vernaux_iter in section.iter_versions():
+        lib = verneed.name
+        if lib not in meta.versions_required:
+            meta.versions_required[lib] = []
+        for vernaux in vernaux_iter:
+            ver = vernaux.name
+            if ver and ver not in meta.versions_required[lib]:
+                meta.versions_required[lib].append(ver)
+
+
+def _parse_dynsym(section: SymbolTableSection, meta: ElfMetadata) -> None:
+    for sym in section.iter_symbols():
+        # Skip undefined symbols
+        if sym.entry.st_shndx == "SHN_UNDEF":
             continue
-        try:
-            int(parts[0].rstrip(":"))
-        except ValueError:
-            continue
-        size_str, sym_type_str, binding_str, _, ndx, raw_name = (
-            parts[2], parts[3], parts[4], parts[5], parts[6], parts[7]
-        )
-        # Skip undefined / local symbols
-        if ndx == "UND":
-            continue
-        binding = _binding_map.get(binding_str.lower(), SymbolBinding.OTHER)
+
+        binding_str  = sym.entry.st_info.bind
+        type_str     = sym.entry.st_info.type
+        vis_str      = sym.entry.st_other.visibility
+
+        binding = _BINDING_MAP.get(binding_str, SymbolBinding.OTHER)
+
+        # Skip local symbols — not part of public ABI surface
         if binding == SymbolBinding.LOCAL:
             continue
-        sym_type = _type_map.get(sym_type_str.lower(), SymbolType.OTHER)
-        # Parse versioned name:  foo@@VER_1  or  foo@VER_1  or  foo
-        version = ""
+
+        # Skip hidden/internal symbols — not exported from DSO
+        if vis_str in _HIDDEN_VISIBILITIES:
+            continue
+
+        sym_type = _TYPE_MAP.get(type_str, SymbolType.OTHER)
+        name     = sym.name
+
+        # Strip version suffix if present (e.g. "foo@@GLIBC_2.5" → name="foo", version="GLIBC_2.5")
+        version    = ""
         is_default = True
-        name = raw_name
-        if "@@" in raw_name:
-            name, version = raw_name.split("@@", 1)
+        if "@@" in name:
+            name, version = name.split("@@", 1)
             is_default = True
-        elif "@" in raw_name:
-            name, version = raw_name.split("@", 1)
+        elif "@" in name:
+            name, version = name.split("@", 1)
             is_default = False
-        try:
-            size = int(size_str)
-        except ValueError:
-            size = 0
+
         meta.symbols.append(ElfSymbol(
-            name=name, binding=binding, sym_type=sym_type,
-            size=size, version=version, is_default=is_default,
+            name=name,
+            binding=binding,
+            sym_type=sym_type,
+            size=sym.entry.st_size,
+            version=version,
+            is_default=is_default,
+            visibility=vis_str.replace("STV_", "").lower(),
         ))

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -3,15 +3,18 @@
 Uses ``pyelftools`` (pure Python, actively maintained) for robust ELF/DWARF
 parsing instead of text-scraping ``readelf`` output.
 
-See ADR-001 for technology stack rationale.
+See docs/adr/001-technology-stack.md for rationale.
 """
 from __future__ import annotations
 
 import logging
+import os
+import stat
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
+from typing import IO
 
 from elftools.common.exceptions import ELFError
 from elftools.elf.dynamic import DynamicSection
@@ -48,14 +51,18 @@ class ElfSymbol:
     binding:  SymbolBinding = SymbolBinding.GLOBAL
     sym_type: SymbolType    = SymbolType.FUNC
     size:     int           = 0
-    version:  str           = ""    # e.g. "GLIBC_2.5" or "" if unversioned
-    is_default: bool        = True  # @@ (default) vs @ (non-default)
+    version:  str           = ""       # version tag from .gnu.version_d/.gnu.version_r
+    is_default: bool        = True
     visibility: str         = "default"  # default / hidden / protected / internal
 
 
 @dataclass
 class ElfMetadata:
-    """ELF dynamic-section + symbol metadata for one .so."""
+    """ELF dynamic-section + symbol metadata for one .so.
+
+    NOTE: Do NOT add ``frozen=True`` to this dataclass — ``@cached_property``
+    (used by ``symbol_map``) requires a writable instance ``__dict__``.
+    """
     soname:  str = ""
     needed:  list[str] = field(default_factory=list)
     rpath:   str = ""
@@ -67,17 +74,21 @@ class ElfMetadata:
     # dict: library_soname → list of version strings
     versions_required: dict[str, list[str]] = field(default_factory=dict)
 
-    # Exported symbols (.dynsym, GLOBAL/WEAK, not UND, not hidden)
+    # Exported symbols (.dynsym, GLOBAL/WEAK, not UND, not hidden/internal)
     symbols: list[ElfSymbol] = field(default_factory=list)
 
     @cached_property
     def symbol_map(self) -> dict[str, ElfSymbol]:
-        """Name → ElfSymbol mapping (cached, built once)."""
+        """Name → ElfSymbol mapping (built once, cached on first access).
+
+        Thread safety: benign race — both threads compute the same dict;
+        the last write wins. Functionally correct for read-only use.
+        """
         return {s.name: s for s in self.symbols}
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers
+# Internal constants
 # ---------------------------------------------------------------------------
 
 _BINDING_MAP: dict[str, SymbolBinding] = {
@@ -95,38 +106,54 @@ _TYPE_MAP: dict[str, SymbolType] = {
     "STT_NOTYPE":    SymbolType.NOTYPE,
 }
 
-_HIDDEN_VISIBILITIES = {"STV_HIDDEN", "STV_INTERNAL"}
+_HIDDEN_VISIBILITIES = frozenset({"STV_HIDDEN", "STV_INTERNAL"})
 
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def parse_elf_metadata(so_path: Path) -> ElfMetadata:
-    """Extract ELF dynamic + symbol metadata from *so_path* using pyelftools."""
-    # Validate input: must be a regular file (not symlink, pipe, etc.)
-    resolved = so_path.resolve()
-    if not resolved.is_file():
-        log.warning("parse_elf_metadata: not a regular file: %s", so_path)
-        return ElfMetadata()
+    """Extract ELF dynamic + symbol metadata from *so_path* using pyelftools.
 
+    Returns an empty ``ElfMetadata`` on any parse error (logged as WARNING).
+    Uses fstat() after open() to prevent TOCTOU symlink/FIFO attacks.
+    """
     try:
-        with open(resolved, "rb") as f:
-            return _parse(f)
-    except (ELFError, OSError) as exc:
-        log.warning("parse_elf_metadata: failed to parse %s: %s", so_path, exc)
+        with open(so_path, "rb") as f:
+            # Verify it's a regular file *after* open to avoid TOCTOU race.
+            st = os.fstat(f.fileno())
+            if not stat.S_ISREG(st.st_mode):
+                log.warning("parse_elf_metadata: not a regular file: %s", so_path)
+                return ElfMetadata()
+            return _parse(f, so_path)
+    except (ELFError, OSError, ValueError) as exc:
+        log.warning("parse_elf_metadata: failed to open/parse %s: %s", so_path, exc)
         return ElfMetadata()
 
 
-def _parse(f: object) -> ElfMetadata:  # type: ignore[name-defined]
+# ---------------------------------------------------------------------------
+# Internal parsing
+# ---------------------------------------------------------------------------
+
+def _parse(f: IO[bytes], so_path: Path) -> ElfMetadata:
     meta = ElfMetadata()
     elf = ELFFile(f)
 
     for section in elf.iter_sections():
-        if isinstance(section, DynamicSection):
-            _parse_dynamic(section, meta)
-        elif isinstance(section, GNUVerDefSection):
-            _parse_version_def(section, meta)
-        elif isinstance(section, GNUVerNeedSection):
-            _parse_version_need(section, meta)
-        elif isinstance(section, SymbolTableSection) and section.name == ".dynsym":
-            _parse_dynsym(section, meta)
+        try:
+            if isinstance(section, DynamicSection):
+                _parse_dynamic(section, meta)
+            elif isinstance(section, GNUVerDefSection):
+                _parse_version_def(section, meta)
+            elif isinstance(section, GNUVerNeedSection):
+                _parse_version_need(section, meta)
+            elif isinstance(section, SymbolTableSection) and section.name == ".dynsym":
+                _parse_dynsym(section, meta)
+        except Exception as exc:  # noqa: BLE001
+            # Partial-success: log malformed section, keep results from other sections.
+            log.warning("parse_elf_metadata: skipping malformed section %r in %s: %s",
+                        section.name, so_path, exc)
 
     return meta
 
@@ -144,7 +171,7 @@ def _parse_dynamic(section: DynamicSection, meta: ElfMetadata) -> None:
 
 
 def _parse_version_def(section: GNUVerDefSection, meta: ElfMetadata) -> None:
-    for verdef, verdaux_iter in section.iter_versions():
+    for _verdef, verdaux_iter in section.iter_versions():
         for verdaux in verdaux_iter:
             name = verdaux.name
             if name and name not in meta.versions_defined:
@@ -164,13 +191,13 @@ def _parse_version_need(section: GNUVerNeedSection, meta: ElfMetadata) -> None:
 
 def _parse_dynsym(section: SymbolTableSection, meta: ElfMetadata) -> None:
     for sym in section.iter_symbols():
-        # Skip undefined symbols
+        # Skip undefined symbols (imported, not exported)
         if sym.entry.st_shndx == "SHN_UNDEF":
             continue
 
-        binding_str  = sym.entry.st_info.bind
-        type_str     = sym.entry.st_info.type
-        vis_str      = sym.entry.st_other.visibility
+        binding_str = sym.entry.st_info.bind
+        type_str    = sym.entry.st_info.type
+        vis_str     = sym.entry.st_other.visibility
 
         binding = _BINDING_MAP.get(binding_str, SymbolBinding.OTHER)
 
@@ -178,29 +205,25 @@ def _parse_dynsym(section: SymbolTableSection, meta: ElfMetadata) -> None:
         if binding == SymbolBinding.LOCAL:
             continue
 
-        # Skip hidden/internal symbols — not exported from DSO
+        # Skip hidden/internal — not exported from DSO
         if vis_str in _HIDDEN_VISIBILITIES:
             continue
 
         sym_type = _TYPE_MAP.get(type_str, SymbolType.OTHER)
         name     = sym.name
 
-        # Strip version suffix if present (e.g. "foo@@GLIBC_2.5" → name="foo", version="GLIBC_2.5")
-        version    = ""
-        is_default = True
-        if "@@" in name:
-            name, version = name.split("@@", 1)
-            is_default = True
-        elif "@" in name:
-            name, version = name.split("@", 1)
-            is_default = False
+        # NOTE: pyelftools does NOT embed version suffixes (@@/@ notation) in
+        # sym.name — that's a readelf text-output artifact. Symbol version info
+        # comes from the .gnu.version section correlated with .gnu.version_d/r,
+        # which is parsed separately in _parse_version_def/_parse_version_need.
+        # We leave version="" here; callers correlate via versions_defined/required.
 
         meta.symbols.append(ElfSymbol(
             name=name,
             binding=binding,
             sym_type=sym_type,
             size=sym.entry.st_size,
-            version=version,
-            is_default=is_default,
+            version="",
+            is_default=True,
             visibility=vis_str.replace("STV_", "").lower(),
         ))

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -1,0 +1,196 @@
+"""ELF dynamic-section and symbol-table metadata.
+
+Extracted via ``readelf`` — no debug info required.  Covers:
+- DT_SONAME, DT_NEEDED, DT_RPATH, DT_RUNPATH
+- .gnu.version_d / .gnu.version_r  (defined / required symbol versions)
+- Per-symbol: binding, type, visibility, size  (from .dynsym)
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class SymbolBinding(str, Enum):
+    GLOBAL = "global"
+    WEAK   = "weak"
+    LOCAL  = "local"
+    OTHER  = "other"
+
+
+class SymbolType(str, Enum):
+    FUNC   = "func"
+    OBJECT = "object"
+    TLS    = "tls"
+    IFUNC  = "ifunc"   # STT_GNU_IFUNC
+    COMMON = "common"  # STT_COMMON
+    NOTYPE = "notype"
+    OTHER  = "other"
+
+
+@dataclass
+class ElfSymbol:
+    name: str
+    binding: SymbolBinding = SymbolBinding.GLOBAL
+    sym_type: SymbolType   = SymbolType.FUNC
+    size: int              = 0
+    version: str           = ""   # e.g. "GLIBC_2.5" or "" if unversioned
+    is_default: bool       = True  # @@ vs @ (default vs non-default version)
+
+
+@dataclass
+class ElfMetadata:
+    """ELF dynamic-section + symbol metadata for one .so."""
+    soname:   str = ""
+    needed:   list[str] = field(default_factory=list)   # DT_NEEDED entries
+    rpath:    str = ""   # DT_RPATH value (or "")
+    runpath:  str = ""   # DT_RUNPATH value (or "")
+
+    # Symbol versions defined by this library (.gnu.version_d)
+    versions_defined: list[str] = field(default_factory=list)
+    # Symbol versions required from other libraries (.gnu.version_r)
+    # dict: library_soname -> set of version strings
+    versions_required: dict[str, list[str]] = field(default_factory=dict)
+
+    # Exported symbols (.dynsym, GLOBAL/WEAK, not UND)
+    symbols: list[ElfSymbol] = field(default_factory=list)
+
+    @property
+    def symbol_map(self) -> dict[str, ElfSymbol]:
+        return {s.name: s for s in self.symbols}
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+def _run(cmd: list[str]) -> str:
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout
+    except Exception:
+        return ""
+
+
+def parse_elf_metadata(so_path: Path) -> ElfMetadata:
+    """Extract ELF dynamic + symbol metadata from *so_path* using readelf."""
+    meta = ElfMetadata()
+    _parse_dynamic(so_path, meta)
+    _parse_version_sections(so_path, meta)
+    _parse_dynsym(so_path, meta)
+    return meta
+
+
+def _parse_dynamic(so_path: Path, meta: ElfMetadata) -> None:
+    out = _run(["readelf", "-d", str(so_path)])
+    for line in out.splitlines():
+        line = line.strip()
+        if "(SONAME)" in line:
+            m = re.search(r'Library soname: \[(.+?)\]', line)
+            if m:
+                meta.soname = m.group(1)
+        elif "(NEEDED)" in line:
+            m = re.search(r'Shared library: \[(.+?)\]', line)
+            if m:
+                meta.needed.append(m.group(1))
+        elif "(RPATH)" in line:
+            m = re.search(r'Library rpath: \[(.+?)\]', line)
+            if m:
+                meta.rpath = m.group(1)
+        elif "(RUNPATH)" in line:
+            m = re.search(r'Library runpath: \[(.+?)\]', line)
+            if m:
+                meta.runpath = m.group(1)
+
+
+def _parse_version_sections(so_path: Path, meta: ElfMetadata) -> None:
+    # -V: version definitions + requirements
+    out = _run(["readelf", "-V", str(so_path)])
+    section = ""
+    cur_lib = ""
+    for line in out.splitlines():
+        low = line.strip().lower()
+        if "version definition" in low:
+            section = "def"
+        elif "version needs" in low:
+            section = "req"
+
+        if section == "def":
+            # Lines like:  0x0001  0x0001  2  libfoo_1.0
+            m = re.search(r'\b([A-Za-z_][A-Za-z0-9_.]*)\s*$', line.strip())
+            if m and not line.strip().startswith("0x"):
+                ver = m.group(1)
+                if ver not in ("section", "version", "definition",
+                               "definitions", "needs", "symbols"):
+                    meta.versions_defined.append(ver)
+        elif section == "req":
+            # "  Filename: libstdc++.so.6 (2 needed)"
+            m_lib = re.search(r'Filename:\s+(\S+)', line)
+            if m_lib:
+                cur_lib = m_lib.group(1)
+                if cur_lib not in meta.versions_required:
+                    meta.versions_required[cur_lib] = []
+            # "  0x0d696911  0x00  02  GLIBCXX_3.4"
+            m_ver = re.search(r'\b([A-Z][A-Z0-9_.]+_[\d.]+)\b', line)
+            if m_ver and cur_lib:
+                ver = m_ver.group(1)
+                if ver not in meta.versions_required[cur_lib]:
+                    meta.versions_required[cur_lib].append(ver)
+
+
+def _parse_dynsym(so_path: Path, meta: ElfMetadata) -> None:
+    out = _run(["readelf", "-s", "--dyn-syms", str(so_path)])
+    _binding_map = {
+        "global": SymbolBinding.GLOBAL,
+        "weak":   SymbolBinding.WEAK,
+        "local":  SymbolBinding.LOCAL,
+    }
+    _type_map = {
+        "func":   SymbolType.FUNC,
+        "object": SymbolType.OBJECT,
+        "tls":    SymbolType.TLS,
+        "gnu_ifunc": SymbolType.IFUNC,
+        "common": SymbolType.COMMON,
+        "notype": SymbolType.NOTYPE,
+    }
+    for line in out.splitlines():
+        # readelf -s line format (GNU):
+        # Num:    Value          Size Type    Bind   Vis      Ndx Name
+        #   1: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __libc_start_main@@GLIBC_2.34
+        parts = line.split()
+        if len(parts) < 8:
+            continue
+        try:
+            int(parts[0].rstrip(":"))
+        except ValueError:
+            continue
+        size_str, sym_type_str, binding_str, _, ndx, raw_name = (
+            parts[2], parts[3], parts[4], parts[5], parts[6], parts[7]
+        )
+        # Skip undefined / local symbols
+        if ndx == "UND":
+            continue
+        binding = _binding_map.get(binding_str.lower(), SymbolBinding.OTHER)
+        if binding == SymbolBinding.LOCAL:
+            continue
+        sym_type = _type_map.get(sym_type_str.lower(), SymbolType.OTHER)
+        # Parse versioned name:  foo@@VER_1  or  foo@VER_1  or  foo
+        version = ""
+        is_default = True
+        name = raw_name
+        if "@@" in raw_name:
+            name, version = raw_name.split("@@", 1)
+            is_default = True
+        elif "@" in raw_name:
+            name, version = raw_name.split("@", 1)
+            is_default = False
+        try:
+            size = int(size_str)
+        except ValueError:
+            size = 0
+        meta.symbols.append(ElfSymbol(
+            name=name, binding=binding, sym_type=sym_type,
+            size=size, version=version, is_default=is_default,
+        ))

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .elf_metadata import ElfMetadata
 
 
 class Visibility(str, Enum):
@@ -98,6 +102,7 @@ class AbiSnapshot:
     functions: list[Function] = field(default_factory=list)
     variables: list[Variable] = field(default_factory=list)
     types: list[RecordType] = field(default_factory=list)
+    elf: ElfMetadata | None = field(default=None)  # ELF dynamic/symbol metadata
     enums: list[EnumType] = field(default_factory=list)
     typedefs: dict[str, str] = field(default_factory=dict)  # alias -> underlying type name
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -21,8 +21,6 @@ from .model import (
 
 def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     # Reset cache fields to None before asdict() to prevent double-serialization.
-    # asdict() would otherwise recursively serialize the index dicts (containing
-    # Function/Variable objects), bloating the output and corrupting roundtrip.
     snap._func_by_mangled = None
     snap._var_by_mangled = None
     snap._type_by_name = None
@@ -30,6 +28,12 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     d.pop("_func_by_mangled", None)
     d.pop("_var_by_mangled", None)
     d.pop("_type_by_name", None)
+    # Serialize ElfMetadata enums to strings for JSON compatibility
+    if d.get("elf"):
+        elf = d["elf"]
+        for sym in elf.get("symbols", []):
+            sym["binding"]  = sym["binding"] if isinstance(sym["binding"], str) else sym["binding"].value
+            sym["sym_type"] = sym["sym_type"] if isinstance(sym["sym_type"], str) else sym["sym_type"].value
     return d
 
 
@@ -43,6 +47,30 @@ def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:
 
 def snapshot_to_json(snap: AbiSnapshot, indent: int = 2) -> str:
     return json.dumps(snapshot_to_dict(snap), indent=indent)
+
+
+def _elf_from_dict(e: dict[str, Any]) -> Any:
+    from .elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
+    syms = [
+        ElfSymbol(
+            name=s["name"],
+            binding=SymbolBinding(s.get("binding", "global")),
+            sym_type=SymbolType(s.get("sym_type", "func")),
+            size=s.get("size", 0),
+            version=s.get("version", ""),
+            is_default=s.get("is_default", True),
+        )
+        for s in e.get("symbols", [])
+    ]
+    return ElfMetadata(
+        soname=e.get("soname", ""),
+        needed=e.get("needed", []),
+        rpath=e.get("rpath", ""),
+        runpath=e.get("runpath", ""),
+        versions_defined=e.get("versions_defined", []),
+        versions_required=e.get("versions_required", {}),
+        symbols=syms,
+    )
 
 
 def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
@@ -93,10 +121,12 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     ]
     enums = [_enum_type_from_dict(e) for e in d.get("enums", [])]
     typedefs: dict[str, str] = d.get("typedefs", {})
+    elf_data = d.get("elf")
+    elf = _elf_from_dict(elf_data) if isinstance(elf_data, dict) else None
     return AbiSnapshot(
         library=d["library"], version=d["version"],
         functions=funcs, variables=variables, types=types,
-        enums=enums, typedefs=typedefs,
+        enums=enums, typedefs=typedefs, elf=elf,
     )
 
 

--- a/docs/adr/001-technology-stack.md
+++ b/docs/adr/001-technology-stack.md
@@ -1,0 +1,79 @@
+# ADR-001: Technology Stack — Python + pyelftools + castxml
+
+**Date:** 2026-03-07  
+**Status:** Accepted  
+**Decision maker:** Nikolay Petrov
+
+---
+
+## Context
+
+abicheck needs to analyze C/C++ ABI compatibility. Two reference tools exist:
+- **abi-compliance-checker (ABICC)** — no longer maintained
+- **libabigail / abidiff** — no longer maintained
+
+We need a stack that gives long-term sustainability with minimal maintenance burden.
+
+## Options Considered
+
+| Option | Description | Risk |
+|--------|-------------|------|
+| A: Wrap abidiff/ABICC | Parse their output, normalize to our model | HIGH: unmaintained, format changes |
+| **B: Python + pyelftools + castxml** | Pure Python orchestration over maintained libs | **LOW: all deps actively maintained** |
+| C: LLVM tooling | clang AST + llvm-readelf | MEDIUM: heavy dependency (~500MB) |
+
+## Decision
+
+**Option B: Python + pyelftools + castxml + binutils readelf**
+
+### Stack
+
+```
+abicheck (Python)
+├── ELF metadata      → binutils readelf  (GNU, ~30yr stable, part of every distro)
+├── DWARF / type info → pyelftools         (pure Python, actively maintained, used in Ghidra/angr)
+├── C++ header AST    → castxml            (C++ → XML, maintained by Kitware)
+└── Diff + verdict    → our Python code    (thin, testable, no C extension)
+```
+
+### Dependencies
+
+| Library | Role | Why maintained |
+|---------|------|---------------|
+| `pyelftools` | ELF/DWARF parsing | Active PyPI project, 7k+ stars, used by major security tools |
+| `castxml` | C++ header → XML AST | Maintained by Kitware (VTK team) |
+| `readelf` (binutils) | ELF dynamic/symbol metadata | Part of GNU binutils, essentially infrastructure |
+| `defusedxml` | Safe XML parsing | Security hardening for castxml output |
+
+### What we do NOT depend on
+
+- ~~abidiff / libabigail~~ (unmaintained)
+- ~~ABICC~~ (unmaintained)
+- ~~LLVM tooling~~ (too heavy for a dependency)
+
+## Consequences
+
+### Positive
+- No dependency on unmaintained C++ tools
+- Full Python — easy to test, debug, extend, run in CI
+- `pyelftools` gives us DWARF parsing for free (no reimplementing DWARF spec)
+- `castxml` is the industry standard for C++ header parsing
+- Zero C/C++ code to maintain in our repo
+
+### Negative
+- We own the diff logic (but that's the core value anyway)
+- DWARF parsing via pyelftools is slower than native C (acceptable for CI usage)
+
+### abidiff / ABICC role going forward
+- Kept as **optional validation backend** for testing only (`--validate-with-abidiff`)
+- NOT a runtime dependency
+- Used for regression testing: if our verdict differs from abidiff, investigate why
+
+## Implementation Plan
+
+| Sprint | Layer | Technology |
+|--------|-------|-----------|
+| Sprint 1 (done) | castxml-based type/function diff | castxml + our XML parser |
+| Sprint 2 (done) | ELF-only metadata | readelf (binutils) |
+| Sprint 3 | DWARF-aware layout/type diff | **pyelftools** |
+| Sprint 4 | Header/API surface diff | castxml + clang Python bindings |

--- a/docs/adr/001-technology-stack.md
+++ b/docs/adr/001-technology-stack.md
@@ -21,59 +21,132 @@ We need a stack that gives long-term sustainability with minimal maintenance bur
 | A: Wrap abidiff/ABICC | Parse their output, normalize to our model | HIGH: unmaintained, format changes |
 | **B: Python + pyelftools + castxml** | Pure Python orchestration over maintained libs | **LOW: all deps actively maintained** |
 | C: LLVM tooling | clang AST + llvm-readelf | MEDIUM: heavy dependency (~500MB) |
+| D: Rust tooling (goblin, bindgen) | ELF in Rust, requires extension or subprocess | OUT OF SCOPE: defeats pure-Python goal |
+
+Options C and D were rejected: LLVM is too heavy as a CI dependency; Rust tooling
+requires a non-Python build chain and is primarily aimed at Rust FFI, not C/C++ ABI diffing.
 
 ## Decision
 
-**Option B: Python + pyelftools + castxml + binutils readelf**
+**Option B: Python + pyelftools + castxml**
 
 ### Stack
 
 ```
 abicheck (Python)
-├── ELF metadata      → binutils readelf  (GNU, ~30yr stable, part of every distro)
-├── DWARF / type info → pyelftools         (pure Python, actively maintained, used in Ghidra/angr)
-├── C++ header AST    → castxml            (C++ → XML, maintained by Kitware)
-└── Diff + verdict    → our Python code    (thin, testable, no C extension)
+├── ELF metadata + DWARF  → pyelftools   (pure Python ELF/DWARF parser)
+├── C++ header AST        → castxml      (C++ → XML, maintained by Kitware)
+└── Diff + verdict        → our Python   (thin, testable, no C extension)
 ```
+
+`binutils readelf` is NOT used as a runtime dependency. It may be invoked
+as an optional debugging/validation tool (`--debug-readelf`), but the production
+parse path goes through pyelftools only (no subprocess, no text parsing).
 
 ### Dependencies
 
-| Library | Role | Why maintained |
-|---------|------|---------------|
-| `pyelftools` | ELF/DWARF parsing | Active PyPI project, 7k+ stars, used by major security tools |
+| Library | Role | Maintenance status |
+|---------|------|-------------------|
+| `pyelftools` | ELF/DWARF parsing | Active PyPI project, used by angr, pwntools, ROPgadget |
 | `castxml` | C++ header → XML AST | Maintained by Kitware (VTK team) |
-| `readelf` (binutils) | ELF dynamic/symbol metadata | Part of GNU binutils, essentially infrastructure |
 | `defusedxml` | Safe XML parsing | Security hardening for castxml output |
+
+Note: An earlier version of this ADR incorrectly stated pyelftools is used by Ghidra.
+Ghidra is Java-based and uses its own ELF parser. The correct reference projects are
+**angr** and **pwntools** — both production binary-analysis frameworks that rely on pyelftools.
 
 ### What we do NOT depend on
 
 - ~~abidiff / libabigail~~ (unmaintained)
 - ~~ABICC~~ (unmaintained)
-- ~~LLVM tooling~~ (too heavy for a dependency)
+- ~~LLVM tooling~~ (too heavy)
+- ~~readelf subprocess~~ (text parsing, fragile across versions/locales)
 
 ## Consequences
 
 ### Positive
 - No dependency on unmaintained C++ tools
 - Full Python — easy to test, debug, extend, run in CI
-- `pyelftools` gives us DWARF parsing for free (no reimplementing DWARF spec)
-- `castxml` is the industry standard for C++ header parsing
+- `pyelftools` gives ELF/DWARF parsing for free (no reimplementing the spec)
+- `castxml` is the industry standard for C++ header → AST
 - Zero C/C++ code to maintain in our repo
+- `elf_metadata.py` is an explicit abstraction boundary — backend is swappable
 
 ### Negative
 - We own the diff logic (but that's the core value anyway)
-- DWARF parsing via pyelftools is slower than native C (acceptable for CI usage)
+- pyelftools DWARF parsing is slower than native C (~10–50× vs libabigail)
+  — acceptable for CI usage, not for interactive sub-second latency
+- pyelftools DWARF 5 support is partial (string offsets, location lists) — see Scope
 
-### abidiff / ABICC role going forward
+## Scope Limitations (explicit)
+
+The following ABI properties require compiler-level knowledge and are **out of scope
+for Sprints 1–4**:
+
+| Feature | Why hard | Mitigation |
+|---------|----------|-----------|
+| vtable layout | No DWARF standard; reconstructed from `_ZTV*` symbols + `.rodata` | Sprint 4+ |
+| Calling convention changes | Requires ABI spec knowledge per arch/platform | Out of scope |
+| Inline function ABI | Inlined functions leave no `DW_AT_external` in DWARF | Document as gap |
+| EBO (empty base class elimination) | Layout change invisible in headers alone | Document as gap |
+| C++ template specialization graphs | Requires demangling + type-graph resolution | Sprint 3 partial |
+
+## C++ Name Demangling
+
+Sprint 3 (DWARF-aware diff) will require demangling `_ZTV*`, `_ZTI*`, `_ZTS*` and
+template instantiation names. Decision: use **`cxxfilt`** Python wrapper (wraps
+`c++filt` from binutils) for now; evaluate `itanium_abi` pure-Python demangler
+if subprocess overhead becomes a bottleneck.
+
+## Platform Scope
+
+- **Supported:** Linux ELF x86-64, aarch64
+- **Not supported:** Windows PE/COFF, macOS Mach-O (explicit non-goal)
+- **DWARF version:** DWARF 4 (GCC ≤10 default) fully supported; DWARF 5 (GCC 11+ default) partially supported via pyelftools ≥0.29
+
+## pyelftools Maintenance Risk & Mitigation
+
+pyelftools has a small core maintainer team (~3 active contributors as of 2026).
+
+Mitigations:
+1. **Abstraction boundary**: `elf_metadata.py` isolates the pyelftools API. Swapping
+   the backend requires changes only in this one file.
+2. **Fork strategy**: pyelftools is MIT licensed. If abandoned, we fork and maintain
+   only the subset we use (`ELFFile`, `DynamicSection`, `SymbolTableSection`,
+   `GNUVerDefSection`, `GNUVerNeedSection`).
+3. **Fallback**: On `ELFError`, gracefully degrade to empty `ElfMetadata` with a warning.
+4. **Upstream contributions**: File issues/PRs for DWARF 5 gaps as we hit them.
+
+## abidiff / ABICC Role Going Forward
+
 - Kept as **optional validation backend** for testing only (`--validate-with-abidiff`)
 - NOT a runtime dependency
 - Used for regression testing: if our verdict differs from abidiff, investigate why
+
+## ABI Classification Decisions
+
+### `NEEDED_ADDED` → COMPATIBLE
+Adding a DT_NEEDED entry is a load-time concern, not a symbol/type ABI break.
+libabigail/abidiff do not flag DT_NEEDED changes as ABI breaks. Consumers on
+systems lacking the new dep will fail to load — this is a deployment concern,
+reported as COMPATIBLE (with a warning in the output).
+
+### `SYMBOL_BINDING_STRENGTHENED` (WEAK→GLOBAL) → COMPATIBLE
+Strengthening a symbol from WEAK to GLOBAL is backward-compatible for most consumers.
+Edge case: interposing libraries that relied on weak-override semantics will lose
+the interposition. This unusual pattern is documented but the default verdict is COMPATIBLE.
+
+### `SYMBOL_SIZE_CHANGED` — STT_OBJECT only
+Symbol size changes are only ABI-relevant for data objects (`STT_OBJECT`, `STT_TLS`).
+Function (`STT_FUNC`) symbol size = machine-code bytes, which changes with every
+compile/optimization pass and is not an ABI contract. Flagging STT_FUNC size would
+produce massive false positives.
 
 ## Implementation Plan
 
 | Sprint | Layer | Technology |
 |--------|-------|-----------|
 | Sprint 1 (done) | castxml-based type/function diff | castxml + our XML parser |
-| Sprint 2 (done) | ELF-only metadata | readelf (binutils) |
-| Sprint 3 | DWARF-aware layout/type diff | **pyelftools** |
-| Sprint 4 | Header/API surface diff | castxml + clang Python bindings |
+| Sprint 2 (done) | ELF dynamic-section + symbol metadata | **pyelftools** |
+| Sprint 3 | DWARF-aware struct layout / type diff | **pyelftools** DWARF + cxxfilt |
+| Sprint 4 | Header API surface diff + vtable (partial) | castxml + clang Python bindings |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click>=8.0",
     "pyyaml>=6.0",
     "defusedxml>=0.7.1",
+    "pyelftools>=0.29",   # ELF/DWARF parsing — Sprint 2+ (ADR-001)
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ python_version = "3.10"
 strict = true
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+# pyelftools has no type stubs or py.typed marker — all its APIs are untyped.
+# Disabling no-untyped-call for elf_metadata.py avoids false CI failures
+# while keeping strict checking on all other modules.
+module = "abicheck.elf_metadata"
+disallow_untyped_calls = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = ["integration: requires castxml, gcc/g++ installed"]

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -40,7 +40,7 @@ CASES = [
     ("case10_return_type",          "BREAKING",   "v1.c",     "v2.c"),
     # ⚠️ int→long variable type change: castxml parses type from header but
     #    global var definitions in .c may not appear in ELF dynsym reliably → NO_CHANGE
-    ("case11_global_var_type",      "NO_CHANGE",  "v1.c",     "v2.c"),
+    ("case11_global_var_type",      "BREAKING",   "v1.c",     "v2.c"),
     # ✅ Function inlined away → disappears from .so → FUNC_REMOVED → BREAKING
     ("case12_function_removed",     "BREAKING",   "v1.c",     "v2.c"),
     # 📋 Symbol versioning adds @@VER tags; checker strips @-suffix → NO_CHANGE

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -32,7 +32,7 @@ CASES = [
     ("case06_visibility",           "BREAKING",   "bad.c",    "good.c"),
     # ✅ Struct size change detected via castxml → TYPE_SIZE_CHANGED → BREAKING
     ("case07_struct_layout",        "BREAKING",   "v1.c",     "v2.c"),
-    # ⚠️ Enum value changes not tracked (only Struct/Class/Union in parse_types) → NO_CHANGE
+    # ✅ Enum member value changes detected via _diff_enums() → BREAKING
     ("case08_enum_value_change",    "BREAKING",   "v1.c",     "v2.c"),
     # ✅ vtable reorder/change detected → TYPE_VTABLE_CHANGED → BREAKING
     ("case09_cpp_vtable",           "BREAKING",   "v1.cpp",   "v2.cpp"),

--- a/tests/test_elf_parse_integration.py
+++ b/tests/test_elf_parse_integration.py
@@ -13,7 +13,12 @@ from pathlib import Path
 
 import pytest
 
-from abicheck.elf_metadata import ElfMetadata, SymbolBinding, SymbolType, parse_elf_metadata
+from abicheck.elf_metadata import (
+    ElfMetadata,
+    SymbolBinding,
+    SymbolType,
+    parse_elf_metadata,
+)
 
 # ── helpers ────────────────────────────────────────────────────────────────
 

--- a/tests/test_elf_parse_integration.py
+++ b/tests/test_elf_parse_integration.py
@@ -1,0 +1,130 @@
+"""Integration tests for parse_elf_metadata() using real compiled .so files.
+
+These tests compile minimal C shared libraries and verify the full
+pyelftools parse round-trip: compile → parse_elf_metadata → assert fields.
+
+Requires: gcc, available in CI.
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from abicheck.elf_metadata import ElfMetadata, SymbolBinding, SymbolType, parse_elf_metadata
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _compile_so(src: str, name: str, tmp: Path, extra_flags: list[str] | None = None) -> Path:
+    """Compile C source to a shared library; skip test if gcc unavailable."""
+    gcc = ["gcc"] + (extra_flags or []) + ["-shared", "-fPIC", "-o", str(tmp / name), "-x", "c", "-"]
+    result = subprocess.run(gcc, input=src.encode(), capture_output=True)
+    if result.returncode != 0:
+        pytest.skip(f"gcc failed: {result.stderr.decode()[:200]}")
+    return tmp / name
+
+
+# ── tests ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.integration
+def test_parse_basic_so_symbols() -> None:
+    """Real .so with two exported symbols → both appear in ElfMetadata.symbols."""
+    src = """
+    int foo(int x) { return x + 1; }
+    int bar = 42;
+    """
+    with tempfile.TemporaryDirectory() as td:
+        so = _compile_so(src, "libtest.so", Path(td))
+        meta = parse_elf_metadata(so)
+
+    assert isinstance(meta, ElfMetadata)
+    names = {s.name for s in meta.symbols}
+    assert "foo" in names, f"Expected 'foo' in symbols, got: {names}"
+    assert "bar" in names, f"Expected 'bar' in symbols, got: {names}"
+
+    # foo should be STT_FUNC
+    foo_sym = next(s for s in meta.symbols if s.name == "foo")
+    assert foo_sym.sym_type == SymbolType.FUNC
+    assert foo_sym.binding == SymbolBinding.GLOBAL
+
+    # bar should be STT_OBJECT
+    bar_sym = next(s for s in meta.symbols if s.name == "bar")
+    assert bar_sym.sym_type == SymbolType.OBJECT
+    assert bar_sym.size > 0
+
+
+@pytest.mark.integration
+def test_parse_so_with_soname() -> None:
+    """Library compiled with -soname → SONAME captured."""
+    src = "int fn(void) { return 0; }"
+    with tempfile.TemporaryDirectory() as td:
+        so = _compile_so(src, "libsoname.so", Path(td),
+                         extra_flags=["-Wl,-soname,libsoname.so.1"])
+        meta = parse_elf_metadata(so)
+
+    assert meta.soname == "libsoname.so.1", f"Expected soname, got: {meta.soname!r}"
+
+
+@pytest.mark.integration
+def test_parse_stripped_so_returns_metadata() -> None:
+    """Stripped .so (no debug info) must still parse — no crash, symbols present."""
+    src = "int stripped_fn(int x) { return x * 2; }"
+    with tempfile.TemporaryDirectory() as td:
+        so = _compile_so(src, "libstripped.so", Path(td))
+        subprocess.run(["strip", str(so)], capture_output=True)  # strip debug info
+        meta = parse_elf_metadata(so)
+
+    assert isinstance(meta, ElfMetadata)
+    # .dynsym survives strip; debug sections go away
+    names = {s.name for s in meta.symbols}
+    assert "stripped_fn" in names, f"Expected symbol after strip, got: {names}"
+
+
+@pytest.mark.integration
+def test_parse_so_with_needed() -> None:
+    """Library with DT_NEEDED (linked against libc) → needed list non-empty."""
+    src = "#include <stdlib.h>\nvoid* fn(size_t n) { return malloc(n); }"
+    with tempfile.TemporaryDirectory() as td:
+        so = _compile_so(src, "libneeded.so", Path(td), extra_flags=["-lc"])
+        meta = parse_elf_metadata(so)
+
+    # libc.so.6 (or similar) should appear in needed
+    assert len(meta.needed) > 0, "Expected at least one DT_NEEDED entry"
+    assert any("libc" in n for n in meta.needed), f"Expected libc in needed: {meta.needed}"
+
+
+@pytest.mark.integration
+def test_parse_hidden_symbols_excluded() -> None:
+    """Hidden-visibility symbols must NOT appear in ElfMetadata.symbols."""
+    src = """
+    __attribute__((visibility("hidden"))) int hidden_fn(void) { return 1; }
+    __attribute__((visibility("default"))) int public_fn(void) { return 2; }
+    """
+    with tempfile.TemporaryDirectory() as td:
+        so = _compile_so(src, "libvisibility.so", Path(td))
+        meta = parse_elf_metadata(so)
+
+    names = {s.name for s in meta.symbols}
+    assert "public_fn" in names, f"Expected public_fn, got: {names}"
+    assert "hidden_fn" not in names, f"hidden_fn must be excluded, got: {names}"
+
+
+@pytest.mark.integration
+def test_parse_nonexistent_path_returns_empty() -> None:
+    """Non-existent path → empty ElfMetadata, no exception."""
+    meta = parse_elf_metadata(Path("/nonexistent/path/libfoo.so"))
+    assert isinstance(meta, ElfMetadata)
+    assert meta.symbols == []
+    assert meta.soname == ""
+
+
+@pytest.mark.integration
+def test_parse_non_elf_file_returns_empty(tmp_path: Path) -> None:
+    """Non-ELF file (plain text) → empty ElfMetadata, no exception."""
+    bad = tmp_path / "notanelf.so"
+    bad.write_text("this is not an ELF binary\n")
+    meta = parse_elf_metadata(bad)
+    assert isinstance(meta, ElfMetadata)
+    assert meta.symbols == []

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -170,6 +170,25 @@ def test_common_symbol_risk() -> None:
 # No-change negative tests
 # ---------------------------------------------------------------------------
 
+_ELF_CHANGE_KINDS: frozenset[ChangeKind] = frozenset({
+    ChangeKind.SONAME_CHANGED,
+    ChangeKind.NEEDED_ADDED,
+    ChangeKind.NEEDED_REMOVED,
+    ChangeKind.RPATH_CHANGED,
+    ChangeKind.RUNPATH_CHANGED,
+    ChangeKind.SYMBOL_BINDING_CHANGED,
+    ChangeKind.SYMBOL_TYPE_CHANGED,
+    ChangeKind.SYMBOL_SIZE_CHANGED,
+    ChangeKind.IFUNC_INTRODUCED,
+    ChangeKind.IFUNC_REMOVED,
+    ChangeKind.COMMON_SYMBOL_RISK,
+    ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+    ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
+    ChangeKind.SYMBOL_BINDING_STRENGTHENED,
+})
+
+
 def test_no_elf_changes() -> None:
     """Identical ELF metadata → no ELF-related changes."""
     elf = _elf(
@@ -181,18 +200,55 @@ def test_no_elf_changes() -> None:
     old = _snap(elf)
     new = _snap(elf)
     result = compare(old, new)
-    elf_kinds = {c.kind for c in result.changes if "elf" not in c.kind.value
-                 and c.kind.value in {k.value for k in [
-                     ChangeKind.SONAME_CHANGED, ChangeKind.NEEDED_ADDED,
-                     ChangeKind.NEEDED_REMOVED, ChangeKind.RPATH_CHANGED,
-                     ChangeKind.RUNPATH_CHANGED, ChangeKind.SYMBOL_BINDING_CHANGED,
-                     ChangeKind.SYMBOL_TYPE_CHANGED, ChangeKind.SYMBOL_SIZE_CHANGED,
-                     ChangeKind.IFUNC_INTRODUCED, ChangeKind.IFUNC_REMOVED,
-                     ChangeKind.COMMON_SYMBOL_RISK,
-                     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
-                     ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
-                 ]}}
+    elf_kinds = {c.kind for c in result.changes if c.kind in _ELF_CHANGE_KINDS}
+    assert elf_kinds == set(), f"Unexpected ELF changes on identical metadata: {elf_kinds}"
+
+
+def test_both_elf_none_produces_no_changes() -> None:
+    """Both snapshots without ELF metadata → no ELF changes, no crash."""
+    old = _snap(None)
+    new = _snap(None)
+    result = compare(old, new)
+    elf_kinds = {c.kind for c in result.changes if c.kind in _ELF_CHANGE_KINDS}
     assert elf_kinds == set()
+
+
+def test_symbol_size_changed_func_not_flagged() -> None:
+    """STT_FUNC symbol size change must NOT produce SYMBOL_SIZE_CHANGED.
+
+    Function size = machine-code bytes; changes with every compile/opt level.
+    Flagging it would produce massive false positives. Only STT_OBJECT/TLS matter.
+    """
+    old = _snap(_elf(symbols=[_sym("foo", sym_type=SymbolType.FUNC, size=100)]))
+    new = _snap(_elf(symbols=[_sym("foo", sym_type=SymbolType.FUNC, size=200)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_SIZE_CHANGED not in kinds
+
+
+def test_weak_to_global_binding_compatible() -> None:
+    """WEAK→GLOBAL strengthens a symbol — backward-compatible for most consumers.
+
+    Exception: consumers that override via weak interposition lose the override.
+    Classified as COMPATIBLE; document the edge case.
+    """
+    old = _snap(_elf(symbols=[_sym("foo", binding=SymbolBinding.WEAK)]))
+    new = _snap(_elf(symbols=[_sym("foo", binding=SymbolBinding.GLOBAL)]))
+    result = compare(old, new)
+    # SYMBOL_BINDING_CHANGED should still be reported (informational),
+    # but the overall verdict must NOT be BREAKING.
+    assert result.verdict != Verdict.BREAKING
+
+
+def test_versions_required_entire_lib_removed() -> None:
+    """When a lib disappears entirely from versions_required, all its versions are flagged removed."""
+    old = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.17"]}))
+    new = _snap(_elf(versions_required={}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED in kinds
+    removed = [c.symbol for c in result.changes if c.kind == ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED]
+    assert set(removed) == {"GLIBC_2.5", "GLIBC_2.17"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -1,0 +1,224 @@
+"""Sprint 2 ELF-only detector tests.
+
+All tests build AbiSnapshot + ElfMetadata directly — no castxml, no readelf required.
+"""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
+from abicheck.model import AbiSnapshot
+
+
+def _snap(elf: ElfMetadata | None = None, **kwargs: object) -> AbiSnapshot:
+    defaults: dict[str, object] = dict(library="lib.so", version="1.0")
+    defaults.update(kwargs)
+    s = AbiSnapshot(**defaults)  # type: ignore[arg-type]
+    s.elf = elf
+    return s
+
+
+def _elf(**kwargs: object) -> ElfMetadata:
+    defaults: dict[str, object] = dict(soname="libfoo.so.1")
+    defaults.update(kwargs)
+    return ElfMetadata(**defaults)  # type: ignore[arg-type]
+
+
+def _sym(name: str, **kwargs: object) -> ElfSymbol:
+    defaults: dict[str, object] = dict(
+        binding=SymbolBinding.GLOBAL, sym_type=SymbolType.FUNC, size=0
+    )
+    defaults.update(kwargs)
+    return ElfSymbol(name=name, **defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Dynamic section tests
+# ---------------------------------------------------------------------------
+
+def test_soname_changed() -> None:
+    old = _snap(_elf(soname="libfoo.so.1"))
+    new = _snap(_elf(soname="libfoo.so.2"))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SONAME_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_needed_added() -> None:
+    old = _snap(_elf(needed=["libc.so.6"]))
+    new = _snap(_elf(needed=["libc.so.6", "libssl.so.3"]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.NEEDED_ADDED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_needed_removed() -> None:
+    old = _snap(_elf(needed=["libc.so.6", "libm.so.6"]))
+    new = _snap(_elf(needed=["libc.so.6"]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.NEEDED_REMOVED in kinds
+    assert result.verdict == Verdict.COMPATIBLE  # NEEDED_REMOVED is compatible
+
+
+def test_rpath_changed() -> None:
+    old = _snap(_elf(rpath="/opt/old/lib"))
+    new = _snap(_elf(rpath="/opt/new/lib"))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.RPATH_CHANGED in kinds
+
+
+def test_runpath_changed() -> None:
+    old = _snap(_elf(runpath="/opt/old/lib"))
+    new = _snap(_elf(runpath=""))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.RUNPATH_CHANGED in kinds
+
+
+# ---------------------------------------------------------------------------
+# Symbol versioning tests
+# ---------------------------------------------------------------------------
+
+def test_symbol_version_defined_removed() -> None:
+    old = _snap(_elf(versions_defined=["LIBFOO_1.0", "LIBFOO_2.0"]))
+    new = _snap(_elf(versions_defined=["LIBFOO_2.0"]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_symbol_version_required_added() -> None:
+    """New GLIBC_2.34 requirement = breaks on older distros."""
+    old = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]}))
+    new = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_symbol_version_required_removed() -> None:
+    old = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.17"]}))
+    new = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED in kinds
+
+
+# ---------------------------------------------------------------------------
+# Per-symbol metadata tests
+# ---------------------------------------------------------------------------
+
+def test_symbol_binding_global_to_weak() -> None:
+    old = _snap(_elf(symbols=[_sym("foo", binding=SymbolBinding.GLOBAL)]))
+    new = _snap(_elf(symbols=[_sym("foo", binding=SymbolBinding.WEAK)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_BINDING_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_symbol_type_func_to_object() -> None:
+    old = _snap(_elf(symbols=[_sym("bar", sym_type=SymbolType.FUNC)]))
+    new = _snap(_elf(symbols=[_sym("bar", sym_type=SymbolType.OBJECT)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_TYPE_CHANGED in kinds
+
+
+def test_ifunc_introduced() -> None:
+    old = _snap(_elf(symbols=[_sym("dispatch", sym_type=SymbolType.FUNC)]))
+    new = _snap(_elf(symbols=[_sym("dispatch", sym_type=SymbolType.IFUNC)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.IFUNC_INTRODUCED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_ifunc_removed() -> None:
+    old = _snap(_elf(symbols=[_sym("dispatch", sym_type=SymbolType.IFUNC)]))
+    new = _snap(_elf(symbols=[_sym("dispatch", sym_type=SymbolType.FUNC)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.IFUNC_REMOVED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_symbol_size_changed() -> None:
+    old = _snap(_elf(symbols=[_sym("g_state", sym_type=SymbolType.OBJECT, size=8)]))
+    new = _snap(_elf(symbols=[_sym("g_state", sym_type=SymbolType.OBJECT, size=16)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_SIZE_CHANGED in kinds
+
+
+def test_common_symbol_risk() -> None:
+    old = _snap(_elf(symbols=[]))
+    new = _snap(_elf(symbols=[_sym("g_counter", sym_type=SymbolType.COMMON)]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.COMMON_SYMBOL_RISK in kinds
+
+
+# ---------------------------------------------------------------------------
+# No-change negative tests
+# ---------------------------------------------------------------------------
+
+def test_no_elf_changes() -> None:
+    """Identical ELF metadata → no ELF-related changes."""
+    elf = _elf(
+        needed=["libc.so.6"],
+        versions_defined=["LIBFOO_1.0"],
+        versions_required={"libc.so.6": ["GLIBC_2.5"]},
+        symbols=[_sym("foo", binding=SymbolBinding.GLOBAL, sym_type=SymbolType.FUNC, size=32)],
+    )
+    old = _snap(elf)
+    new = _snap(elf)
+    result = compare(old, new)
+    elf_kinds = {c.kind for c in result.changes if "elf" not in c.kind.value
+                 and c.kind.value in {k.value for k in [
+                     ChangeKind.SONAME_CHANGED, ChangeKind.NEEDED_ADDED,
+                     ChangeKind.NEEDED_REMOVED, ChangeKind.RPATH_CHANGED,
+                     ChangeKind.RUNPATH_CHANGED, ChangeKind.SYMBOL_BINDING_CHANGED,
+                     ChangeKind.SYMBOL_TYPE_CHANGED, ChangeKind.SYMBOL_SIZE_CHANGED,
+                     ChangeKind.IFUNC_INTRODUCED, ChangeKind.IFUNC_REMOVED,
+                     ChangeKind.COMMON_SYMBOL_RISK,
+                     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+                     ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+                 ]}}
+    assert elf_kinds == set()
+
+
+# ---------------------------------------------------------------------------
+# Verdict mapping checks
+# ---------------------------------------------------------------------------
+
+def test_elf_breaking_kinds_verdict() -> None:
+    """All BREAKING ELF kinds produce BREAKING verdict."""
+    breaking_cases = [
+        _snap(_elf(soname="libfoo.so.1")),     # SONAME_CHANGED
+        _snap(_elf(needed=["libc.so.6"])),      # NEEDED_ADDED
+        _snap(_elf(versions_defined=["V1"])),   # SYMBOL_VERSION_DEFINED_REMOVED
+        _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]})),  # VER_REQ_ADDED
+        _snap(_elf(symbols=[_sym("f", binding=SymbolBinding.GLOBAL)])),  # BINDING_CHANGED
+        _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.FUNC)])),  # TYPE_CHANGED
+        _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.IFUNC)])),  # IFUNC_INTRODUCED
+    ]
+    new_cases = [
+        _snap(_elf(soname="libfoo.so.2")),
+        _snap(_elf(needed=["libc.so.6", "libssl.so.3"])),
+        _snap(_elf(versions_defined=[])),
+        _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]})),
+        _snap(_elf(symbols=[_sym("f", binding=SymbolBinding.WEAK)])),
+        _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.OBJECT)])),
+        _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.FUNC)])),
+    ]
+    for old, new in zip(breaking_cases, new_cases):
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING, (
+            f"Expected BREAKING, got {result.verdict}: {[c.kind for c in result.changes]}"
+        )

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -45,12 +45,14 @@ def test_soname_changed() -> None:
 
 
 def test_needed_added() -> None:
+    # NEEDED_ADDED is COMPATIBLE (warn only): the new dep may not exist on
+    # older systems but existing consumers keep working if symbols are still present.
     old = _snap(_elf(needed=["libc.so.6"]))
     new = _snap(_elf(needed=["libc.so.6", "libssl.so.3"]))
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.NEEDED_ADDED in kinds
-    assert result.verdict == Verdict.BREAKING
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 def test_needed_removed() -> None:
@@ -201,7 +203,7 @@ def test_elf_breaking_kinds_verdict() -> None:
     """All BREAKING ELF kinds produce BREAKING verdict."""
     breaking_cases = [
         _snap(_elf(soname="libfoo.so.1")),     # SONAME_CHANGED
-        _snap(_elf(needed=["libc.so.6"])),      # NEEDED_ADDED
+        # NEEDED_ADDED is now COMPATIBLE, removed from breaking_cases
         _snap(_elf(versions_defined=["V1"])),   # SYMBOL_VERSION_DEFINED_REMOVED
         _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]})),  # VER_REQ_ADDED
         _snap(_elf(symbols=[_sym("f", binding=SymbolBinding.GLOBAL)])),  # BINDING_CHANGED
@@ -210,7 +212,6 @@ def test_elf_breaking_kinds_verdict() -> None:
     ]
     new_cases = [
         _snap(_elf(soname="libfoo.so.2")),
-        _snap(_elf(needed=["libc.so.6", "libssl.so.3"])),
         _snap(_elf(versions_defined=[])),
         _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]})),
         _snap(_elf(symbols=[_sym("f", binding=SymbolBinding.WEAK)])),


### PR DESCRIPTION
## Summary
Implements Sprint 2 **ELF-only** ABI detection layer (no DWARF required):

- New `abicheck/elf_metadata.py` parser using `readelf` for:
  - `DT_SONAME`, `DT_NEEDED`, `DT_RPATH`, `DT_RUNPATH`
  - `.gnu.version_d` / `.gnu.version_r`
  - `.dynsym` symbol metadata (binding/type/size, IFUNC, COMMON)
- Wires ELF metadata into `AbiSnapshot` (`model.py`, `dumper.py`, `serialization.py`)
- Adds `_diff_elf()` in checker with new ChangeKinds:
  - Dynamic tags: `SONAME_CHANGED`, `NEEDED_ADDED/REMOVED`, `RPATH_CHANGED`, `RUNPATH_CHANGED`
  - Symbol metadata: `SYMBOL_BINDING_CHANGED`, `SYMBOL_TYPE_CHANGED`, `SYMBOL_SIZE_CHANGED`, `IFUNC_INTRODUCED/REMOVED`, `COMMON_SYMBOL_RISK`
  - Versioning: `SYMBOL_VERSION_DEFINED_REMOVED`, `SYMBOL_VERSION_REQUIRED_ADDED/REMOVED`
- Updates verdict mapping for new kinds
- Adds dedicated test suite `tests/test_sprint2_elf.py`
- Updates integration expectation for `case11_global_var_type` (`NO_CHANGE` -> `BREAKING`) due ELF symbol size/type signal

## Validation
- `pytest tests/` → **105 passed, 1 skipped**
- `ruff check abicheck/ tests/` → clean
- `mypy abicheck/ --ignore-missing-imports` → clean

## Notes
This PR intentionally focuses on ELF-only evidence tier. DWARF-aware cases remain for Sprint 3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects ELF dynamic-section and symbol changes (SONAME, NEEDED, RPATH/RUNPATH, symbol binding/type/size, IFUNC, symbol versions, common-symbol risk); ELF metadata is included in snapshots and influences verdicts.

* **Tests**
  * Added comprehensive unit and integration tests for ELF parsing and ELF-aware comparison; updated an ABI example verdict.

* **Documentation**
  * Added GOALS.md and an ADR describing architecture and roadmap.

* **Chores**
  * Added pyelftools runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->