### PR TITLE
Sprint 3: DWARF layout parser + initial struct/enum ABI detectors

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -90,6 +90,14 @@ class ChangeKind(str, Enum):
     SYMBOL_VERSION_REQUIRED_ADDED    = "symbol_version_required_added"   # new GLIBC_X
     SYMBOL_VERSION_REQUIRED_REMOVED  = "symbol_version_required_removed"
 
+    # DWARF layout (Sprint 3)
+    STRUCT_SIZE_CHANGED        = "struct_size_changed"        # sizeof(T) changed
+    STRUCT_FIELD_OFFSET_CHANGED = "struct_field_offset_changed" # field moved
+    STRUCT_FIELD_REMOVED       = "struct_field_removed"       # field deleted
+    STRUCT_FIELD_TYPE_CHANGED  = "struct_field_type_changed"  # field type/size changed
+    STRUCT_ALIGNMENT_CHANGED   = "struct_alignment_changed"   # alignof(T) changed
+    ENUM_UNDERLYING_SIZE_CHANGED = "enum_underlying_size_changed"  # int→long
+
 
 class Verdict(str, Enum):
     NO_CHANGE = "NO_CHANGE"         # identical ABI
@@ -141,6 +149,15 @@ _BREAKING_KINDS = {
     ChangeKind.IFUNC_REMOVED,
     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
     ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+    # DWARF Sprint 3
+    ChangeKind.STRUCT_SIZE_CHANGED,
+    ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
+    ChangeKind.STRUCT_FIELD_REMOVED,
+    ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+    ChangeKind.STRUCT_ALIGNMENT_CHANGED,
+    ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED,
+    ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
+    ChangeKind.ENUM_MEMBER_REMOVED,
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
@@ -848,6 +865,7 @@ def compare(
     changes.extend(_diff_unions(old, new))
     changes.extend(_diff_typedefs(old, new))
     changes.extend(_diff_elf(old, new))
+    changes.extend(_diff_dwarf(old, new))
 
     suppressed: list[Change] = []
     if suppression is not None:
@@ -870,3 +888,166 @@ def compare(
         suppressed_changes=suppressed,
         suppression_file_provided=suppression is not None,
     )
+
+
+# ── Sprint 3: DWARF-aware layout diff ────────────────────────────────────────
+
+def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    """DWARF-aware struct/enum layout detectors (Sprint 3).
+
+    Requires binaries compiled with -g. If either snapshot has no DWARF info,
+    returns an empty list (graceful degradation, no false positives).
+    """
+    from .dwarf_metadata import DwarfMetadata
+
+    o: DwarfMetadata = getattr(old, "dwarf", None) or DwarfMetadata()
+    n: DwarfMetadata = getattr(new, "dwarf", None) or DwarfMetadata()
+
+    # Skip if neither side has real DWARF info
+    if not o.has_dwarf and not n.has_dwarf:
+        return []
+
+    changes: list[Change] = []
+    changes.extend(_diff_struct_layouts(o, n))
+    changes.extend(_diff_enum_layouts(o, n))
+    return changes
+
+
+def _diff_struct_layouts(o: object, n: object) -> list[Change]:
+    from .dwarf_metadata import StructLayout
+
+    old_structs: dict[str, StructLayout] = getattr(o, "structs", {})
+    new_structs: dict[str, StructLayout] = getattr(n, "structs", {})
+    changes: list[Change] = []
+
+    for name, old_s in old_structs.items():
+        if name not in new_structs:
+            continue  # struct removed — caught by header-layer (castxml)
+
+        new_s = new_structs[name]
+
+        # 1. Total size
+        if old_s.byte_size != new_s.byte_size:
+            changes.append(Change(
+                kind=ChangeKind.STRUCT_SIZE_CHANGED,
+                symbol=name,
+                description=(
+                    f"Struct size changed: {name} "
+                    f"({old_s.byte_size} → {new_s.byte_size} bytes)"
+                ),
+                old_value=str(old_s.byte_size),
+                new_value=str(new_s.byte_size),
+            ))
+
+        # 2. Alignment (only when explicitly present in DWARF 5)
+        if old_s.alignment and new_s.alignment and old_s.alignment != new_s.alignment:
+            changes.append(Change(
+                kind=ChangeKind.STRUCT_ALIGNMENT_CHANGED,
+                symbol=name,
+                description=(
+                    f"Struct alignment changed: {name} "
+                    f"({old_s.alignment} → {new_s.alignment})"
+                ),
+                old_value=str(old_s.alignment),
+                new_value=str(new_s.alignment),
+            ))
+
+        # Build field maps
+        old_fields = {f.name: f for f in old_s.fields}
+        new_fields = {f.name: f for f in new_s.fields}
+
+        # 3. Removed fields
+        for fname in sorted(old_fields.keys() - new_fields.keys()):
+            changes.append(Change(
+                kind=ChangeKind.STRUCT_FIELD_REMOVED,
+                symbol=f"{name}::{fname}",
+                description=f"Struct field removed: {name}::{fname}",
+                old_value=f"{old_fields[fname].type_name}",
+            ))
+
+        # 4. Existing fields: offset and type changes
+        for fname, old_f in old_fields.items():
+            if fname not in new_fields:
+                continue
+            new_f = new_fields[fname]
+
+            if old_f.byte_offset != new_f.byte_offset:
+                changes.append(Change(
+                    kind=ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
+                    symbol=f"{name}::{fname}",
+                    description=(
+                        f"Field offset changed: {name}::{fname} "
+                        f"(+{old_f.byte_offset} → +{new_f.byte_offset})"
+                    ),
+                    old_value=str(old_f.byte_offset),
+                    new_value=str(new_f.byte_offset),
+                ))
+
+            # Type size change (underlying type grew/shrank)
+            if (old_f.byte_size > 0 and new_f.byte_size > 0
+                    and old_f.byte_size != new_f.byte_size):
+                changes.append(Change(
+                    kind=ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+                    symbol=f"{name}::{fname}",
+                    description=(
+                        f"Field type size changed: {name}::{fname} "
+                        f"{old_f.type_name}({old_f.byte_size}B) → "
+                        f"{new_f.type_name}({new_f.byte_size}B)"
+                    ),
+                    old_value=old_f.type_name,
+                    new_value=new_f.type_name,
+                ))
+
+    return changes
+
+
+def _diff_enum_layouts(o: object, n: object) -> list[Change]:
+    from .dwarf_metadata import EnumInfo
+
+    old_enums: dict[str, EnumInfo] = getattr(o, "enums", {})
+    new_enums: dict[str, EnumInfo] = getattr(n, "enums", {})
+    changes: list[Change] = []
+
+    for name, old_e in old_enums.items():
+        if name not in new_enums:
+            continue
+
+        new_e = new_enums[name]
+
+        # 1. Underlying size change (e.g. int8_t → int32_t)
+        if old_e.underlying_byte_size != new_e.underlying_byte_size:
+            changes.append(Change(
+                kind=ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED,
+                symbol=name,
+                description=(
+                    f"Enum underlying type size changed: {name} "
+                    f"({old_e.underlying_byte_size} → {new_e.underlying_byte_size} bytes)"
+                ),
+                old_value=str(old_e.underlying_byte_size),
+                new_value=str(new_e.underlying_byte_size),
+            ))
+
+        # 2. Removed members
+        for mname in sorted(old_e.members.keys() - new_e.members.keys()):
+            changes.append(Change(
+                kind=ChangeKind.ENUM_MEMBER_REMOVED,
+                symbol=f"{name}::{mname}",
+                description=f"Enum member removed: {name}::{mname}",
+                old_value=str(old_e.members[mname]),
+            ))
+
+        # 3. Changed values
+        for mname, old_val in old_e.members.items():
+            if mname in new_e.members and new_e.members[mname] != old_val:
+                changes.append(Change(
+                    kind=ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
+                    symbol=f"{name}::{mname}",
+                    description=(
+                        f"Enum member value changed: {name}::{mname} "
+                        f"({old_val} → {new_e.members[mname]})"
+                    ),
+                    old_value=str(old_val),
+                    new_value=str(new_e.members[mname]),
+                ))
+
+    return changes

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -91,6 +91,7 @@ class ChangeKind(str, Enum):
     SYMBOL_VERSION_REQUIRED_REMOVED  = "symbol_version_required_removed"
 
     # DWARF layout (Sprint 3)
+    DWARF_INFO_MISSING         = "dwarf_info_missing"         # new binary stripped of -g
     STRUCT_SIZE_CHANGED        = "struct_size_changed"        # sizeof(T) changed
     STRUCT_FIELD_OFFSET_CHANGED = "struct_field_offset_changed" # field moved
     STRUCT_FIELD_REMOVED       = "struct_field_removed"       # field deleted
@@ -161,6 +162,15 @@ _BREAKING_KINDS = {
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
+    # Header/API additions
+    ChangeKind.FUNC_ADDED,
+    ChangeKind.VAR_ADDED,
+    ChangeKind.TYPE_ADDED,
+    # TYPE_FIELD_ADDED intentionally omitted: compatible only for standard-layout
+    # non-polymorphic types; context-aware verdict set in _diff_types()
+    ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
+
+    # ELF-only warning/compatible drift
     ChangeKind.NEEDED_ADDED,              # new dep: may not exist on older systems — warn, not hard-break
     ChangeKind.NEEDED_REMOVED,            # removing a dep is compatible (but deployment risk)
     ChangeKind.RUNPATH_CHANGED,           # search path drift — warn only
@@ -168,19 +178,12 @@ _COMPATIBLE_KINDS: set[ChangeKind] = {
     ChangeKind.COMMON_SYMBOL_RISK,        # STT_COMMON — risk, not proven break
     ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
     ChangeKind.SYMBOL_BINDING_STRENGTHENED,  # WEAK→GLOBAL: backward-compatible for most consumers
+
+    # DWARF diagnostics (comparison coverage gap warning)
+    ChangeKind.DWARF_INFO_MISSING,
 }
 
 _SOURCE_BREAK_KINDS: set[ChangeKind] = set()  # reserved for future source-only breaks
-
-
-_COMPATIBLE_KINDS = {
-    ChangeKind.FUNC_ADDED,
-    ChangeKind.VAR_ADDED,
-    ChangeKind.TYPE_ADDED,
-    # TYPE_FIELD_ADDED intentionally omitted: compatible only for standard-layout
-    # non-polymorphic types; context-aware verdict set in _diff_types()
-    ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
-}
 
 
 @dataclass
@@ -895,21 +898,81 @@ def compare(
 def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """DWARF-aware struct/enum layout detectors (Sprint 3).
 
-    Requires binaries compiled with -g. If either snapshot has no DWARF info,
-    returns an empty list (graceful degradation, no false positives).
+    Requires binaries compiled with -g.
+
+    Graceful degradation rules:
+    - Neither side has DWARF → skip silently (no false positives)
+    - Old has DWARF, new is stripped → emit DWARF_INFO_MISSING warning change
+      so callers know the comparison is incomplete (not silently COMPATIBLE)
+    - Only new has DWARF → can't compare without old baseline → skip
+
+    Important: we diff only ABI-reachable types/enums discovered from the
+    header model (castxml layer). This avoids flagging private implementation
+    types present in DWARF but not in the public API surface.
     """
+    import logging as _logging
+
     from .dwarf_metadata import DwarfMetadata
+
+    _log = _logging.getLogger(__name__)
 
     o: DwarfMetadata = getattr(old, "dwarf", None) or DwarfMetadata()
     n: DwarfMetadata = getattr(new, "dwarf", None) or DwarfMetadata()
 
-    # Skip if neither side has real DWARF info
     if not o.has_dwarf and not n.has_dwarf:
-        return []
+        return []  # neither side has DWARF — nothing to compare
+
+    if o.has_dwarf and not n.has_dwarf:
+        _log.warning(
+            "DWARF layout comparison skipped: new binary has no debug info. "
+            "Recompile with -g to enable struct/enum ABI checks."
+        )
+        return [Change(
+            kind=ChangeKind.DWARF_INFO_MISSING,
+            symbol="<dwarf>",
+            description=(
+                "New binary has no DWARF debug info — struct/enum layout "
+                "comparison was skipped. Recompile with -g to enable."
+            ),
+        )]
+
+    def _allow_name(name: str, allowed: set[str]) -> bool:
+        # Match by full name or by unqualified name (last component after ::)
+        return name in allowed or name.split("::")[-1] in allowed
+
+    allowed_structs: set[str] = {
+        t.name for t in old.types
+    } | {
+        t.name for t in new.types
+    }
+    allowed_enums: set[str] = {
+        e.name for e in old.enums
+    } | {
+        e.name for e in new.enums
+    }
+
+    # If the header model is absent (no castxml data), fall back to comparing
+    # all DWARF types — this preserves compatibility when running DWARF-only.
+    if allowed_structs:
+        o_structs = {k: v for k, v in o.structs.items() if _allow_name(k, allowed_structs)}
+        n_structs = {k: v for k, v in n.structs.items() if _allow_name(k, allowed_structs)}
+    else:
+        o_structs = o.structs
+        n_structs = n.structs
+
+    if allowed_enums:
+        o_enums = {k: v for k, v in o.enums.items() if _allow_name(k, allowed_enums)}
+        n_enums = {k: v for k, v in n.enums.items() if _allow_name(k, allowed_enums)}
+    else:
+        o_enums = o.enums
+        n_enums = n.enums
+
+    filtered_old = DwarfMetadata(structs=o_structs, enums=o_enums, has_dwarf=o.has_dwarf)
+    filtered_new = DwarfMetadata(structs=n_structs, enums=n_enums, has_dwarf=n.has_dwarf)
 
     changes: list[Change] = []
-    changes.extend(_diff_struct_layouts(o, n))
-    changes.extend(_diff_enum_layouts(o, n))
+    changes.extend(_diff_struct_layouts(filtered_old, filtered_new))
+    changes.extend(_diff_enum_layouts(filtered_old, filtered_new))
     return changes
 
 
@@ -983,14 +1046,21 @@ def _diff_struct_layouts(o: object, n: object) -> list[Change]:
                     new_value=str(new_f.byte_offset),
                 ))
 
-            # Type size change (underlying type grew/shrank)
-            if (old_f.byte_size > 0 and new_f.byte_size > 0
-                    and old_f.byte_size != new_f.byte_size):
+            # Field type drift:
+            # - catches same-size type substitutions (int→float, Foo*→Bar*)
+            # - still includes explicit size drift when known on both sides
+            type_name_changed = old_f.type_name != new_f.type_name
+            type_size_changed = (
+                old_f.byte_size > 0
+                and new_f.byte_size > 0
+                and old_f.byte_size != new_f.byte_size
+            )
+            if type_name_changed or type_size_changed:
                 changes.append(Change(
                     kind=ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
                     symbol=f"{name}::{fname}",
                     description=(
-                        f"Field type size changed: {name}::{fname} "
+                        f"Field type changed: {name}::{fname} "
                         f"{old_f.type_name}({old_f.byte_size}B) → "
                         f"{new_f.type_name}({new_f.byte_size}B)"
                     ),

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -1,0 +1,399 @@
+"""DWARF-aware type layout extraction via pyelftools.
+
+Reads DWARF debug info from a compiled .so to extract:
+- Struct/class/union sizes and field layouts (offsets, types)
+- Enum underlying types and member values
+- Alignment information
+
+Requires binaries compiled with -g (DWARF debug info).
+If DWARF is absent, returns empty DwarfMetadata gracefully.
+
+See docs/adr/001-technology-stack.md — Sprint 3 layer.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FieldInfo:
+    """One field (member) inside a struct/union/class."""
+    name: str
+    type_name: str      # human-readable type (e.g. "int", "MyStruct *")
+    byte_offset: int    # DW_AT_data_member_location
+    byte_size: int      # size of the field's type (0 if unknown)
+    bit_offset: int = 0 # for bitfields: bit offset within the byte
+    bit_size: int   = 0 # for bitfields: width in bits (0 = not a bitfield)
+
+
+@dataclass
+class StructLayout:
+    """Size and field layout of a struct/class/union."""
+    name: str
+    byte_size: int                         # DW_AT_byte_size
+    alignment: int = 0                     # DW_AT_alignment (DWARF 5; 0 = unknown)
+    fields: list[FieldInfo] = field(default_factory=list)
+    is_union: bool = False
+
+
+@dataclass
+class EnumInfo:
+    """Enum type: underlying integer type + all named members."""
+    name: str
+    underlying_byte_size: int              # size of the underlying type
+    members: dict[str, int] = field(default_factory=dict)  # name → value
+
+
+@dataclass
+class DwarfMetadata:
+    """All DWARF-derived ABI-relevant type information from one .so."""
+    # name → StructLayout  (structs, classes, unions with external linkage)
+    structs: dict[str, StructLayout] = field(default_factory=dict)
+    # name → EnumInfo
+    enums: dict[str, EnumInfo] = field(default_factory=dict)
+    has_dwarf: bool = False   # False = binary had no DWARF info
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_dwarf_metadata(so_path: Path) -> DwarfMetadata:
+    """Extract DWARF type layout metadata from *so_path*.
+
+    Returns empty DwarfMetadata (has_dwarf=False) if the binary has no
+    debug info or cannot be parsed. Never raises.
+    """
+    try:
+        with open(so_path, "rb") as f:
+            st = os.fstat(f.fileno())
+            if not stat.S_ISREG(st.st_mode):
+                log.warning("parse_dwarf_metadata: not a regular file: %s", so_path)
+                return DwarfMetadata()
+            return _parse(f, so_path)
+    except (ELFError, OSError, ValueError) as exc:
+        log.warning("parse_dwarf_metadata: failed to open/parse %s: %s", so_path, exc)
+        return DwarfMetadata()
+
+
+# ---------------------------------------------------------------------------
+# Internal implementation
+# ---------------------------------------------------------------------------
+
+def _parse(f: object, so_path: Path) -> DwarfMetadata:  # noqa: ANN001
+    meta = DwarfMetadata()
+    elf = ELFFile(f)  # type: ignore[no-untyped-call]
+
+    if not elf.has_dwarf_info():  # type: ignore[no-untyped-call]
+        log.debug("parse_dwarf_metadata: no DWARF info in %s", so_path)
+        return meta
+
+    meta.has_dwarf = True
+    dwarf = elf.get_dwarf_info()  # type: ignore[no-untyped-call]
+
+    for CU in dwarf.iter_CUs():  # type: ignore[no-untyped-call]
+        try:
+            _process_cu(CU, meta)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("parse_dwarf_metadata: skipping CU in %s: %s", so_path, exc)
+
+    return meta
+
+
+def _process_cu(CU: object, meta: DwarfMetadata) -> None:  # noqa: ANN001
+    """Walk all DIEs in one Compilation Unit and collect type info."""
+    top_die = CU.get_top_DIE()  # type: ignore[union-attr]
+    _walk_die(top_die, meta, CU)
+
+
+def _walk_die(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+    tag = die.tag  # type: ignore[union-attr]
+
+    if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
+        _process_struct(die, meta, CU)
+    elif tag == "DW_TAG_enumeration_type":
+        _process_enum(die, meta, CU)
+    elif tag == "DW_TAG_typedef":
+        # C typedef: the underlying type may be anonymous.
+        # Resolve the typedef's target and process it with the typedef name.
+        _process_typedef(die, meta, CU)
+
+    for child in die.iter_children():  # type: ignore[union-attr]
+        _walk_die(child, meta, CU)
+
+
+def _process_typedef(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+    """If a typedef points to an anonymous struct/enum, register it under the typedef name."""
+    typedef_name = _attr_str(die, "DW_AT_name")
+    if not typedef_name:
+        return
+    if "DW_AT_type" not in die.attributes:  # type: ignore[union-attr]
+        return
+    try:
+        ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
+        target = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
+    except Exception:  # noqa: BLE001
+        return
+
+    tag = target.tag  # type: ignore[union-attr]
+    target_name = _attr_str(target, "DW_AT_name")
+
+    if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
+        if not target_name and typedef_name not in meta.structs:
+            # Anonymous struct typedef — use typedef name
+            _process_struct_named(target, meta, CU, override_name=typedef_name)
+    elif tag == "DW_TAG_enumeration_type":
+        if not target_name and typedef_name not in meta.enums:
+            _process_enum_named(target, meta, CU, override_name=typedef_name)
+
+
+# ---------------------------------------------------------------------------
+# Struct / class / union
+# ---------------------------------------------------------------------------
+
+def _process_struct(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+    name = _attr_str(die, "DW_AT_name")
+    if not name:
+        return  # anonymous — handled via typedef in _process_typedef
+    _process_struct_named(die, meta, CU, override_name=None)
+
+
+def _process_struct_named(
+    die: object,
+    meta: DwarfMetadata,
+    CU: object,
+    override_name: str | None,
+) -> None:
+    name = override_name or _attr_str(die, "DW_AT_name")
+    if not name:
+        return
+
+    byte_size = _attr_int(die, "DW_AT_byte_size")
+    if byte_size == 0:
+        return  # declaration-only (DW_AT_declaration) — no layout
+
+    is_union = die.tag == "DW_TAG_union_type"  # type: ignore[union-attr]
+    alignment = _attr_int(die, "DW_AT_alignment")  # DWARF 5; 0 if absent
+
+    layout = StructLayout(
+        name=name,
+        byte_size=byte_size,
+        alignment=alignment,
+        is_union=is_union,
+    )
+
+    for child in die.iter_children():  # type: ignore[union-attr]
+        if child.tag == "DW_TAG_member":  # type: ignore[union-attr]
+            fi = _process_member(child, CU)
+            if fi is not None:
+                layout.fields.append(fi)
+
+    # Keep only the first definition (ODR: one definition rule).
+    if name not in meta.structs:
+        meta.structs[name] = layout
+
+
+def _process_member(die: object, CU: object) -> FieldInfo | None:  # noqa: ANN001
+    name = _attr_str(die, "DW_AT_name")
+    if not name:
+        return None  # padding / anonymous member
+
+    # Byte offset — DW_AT_data_member_location can be a simple int or a block expr
+    byte_offset = 0
+    if "DW_AT_data_member_location" in die.attributes:  # type: ignore[union-attr]
+        attr = die.attributes["DW_AT_data_member_location"]  # type: ignore[union-attr]
+        val = attr.value
+        if isinstance(val, int):
+            byte_offset = val
+        elif isinstance(val, list):
+            # DW_OP_plus_uconst expression: [DW_OP_plus_uconst, offset]
+            byte_offset = int(val[-1]) if val else 0
+
+    # Bit fields
+    bit_offset = _attr_int(die, "DW_AT_bit_offset")
+    bit_size   = _attr_int(die, "DW_AT_bit_size")
+
+    # Resolve type name and size
+    type_name, field_byte_size = _resolve_type(die, CU)
+
+    return FieldInfo(
+        name=name,
+        type_name=type_name,
+        byte_offset=byte_offset,
+        byte_size=field_byte_size,
+        bit_offset=bit_offset,
+        bit_size=bit_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum
+# ---------------------------------------------------------------------------
+
+def _process_enum(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+    name = _attr_str(die, "DW_AT_name")
+    if not name:
+        return  # anonymous — handled via typedef in _process_typedef
+    _process_enum_named(die, meta, CU, override_name=None)
+
+
+def _process_enum_named(
+    die: object,
+    meta: DwarfMetadata,
+    CU: object,
+    override_name: str | None,
+) -> None:
+    name = override_name or _attr_str(die, "DW_AT_name")
+    if not name:
+        return
+
+    byte_size = _attr_int(die, "DW_AT_byte_size")
+    if byte_size == 0:
+        return  # declaration-only
+
+    enum = EnumInfo(name=name, underlying_byte_size=byte_size)
+
+    for child in die.iter_children():  # type: ignore[union-attr]
+        if child.tag == "DW_TAG_enumerator":  # type: ignore[union-attr]
+            member_name = _attr_str(child, "DW_AT_name")
+            member_val  = _attr_int(child, "DW_AT_const_value")
+            if member_name:
+                enum.members[member_name] = member_val
+
+    if name not in meta.enums:
+        meta.enums[name] = enum
+
+
+# ---------------------------------------------------------------------------
+# Type resolution helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_type(die: object, CU: object) -> tuple[str, int]:  # noqa: ANN001
+    """Return (type_name, byte_size) for the type referenced by *die*."""
+    if "DW_AT_type" not in die.attributes:  # type: ignore[union-attr]
+        return ("unknown", 0)
+    try:
+        ref_addr = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
+        type_die = CU.get_DIE_from_refaddr(ref_addr)  # type: ignore[union-attr]
+        return _die_to_type_info(type_die, CU, depth=0)
+    except Exception:  # noqa: BLE001
+        return ("unknown", 0)
+
+
+def _die_to_type_info(  # noqa: PLR0911
+    die: object,
+    CU: object,
+    depth: int,
+) -> tuple[str, int]:
+    """Recursively resolve a type DIE to (name, byte_size). depth limit = 8."""
+    if depth > 8:
+        return ("...", 0)
+
+    tag = die.tag  # type: ignore[union-attr]
+
+    if tag == "DW_TAG_base_type":
+        name = _attr_str(die, "DW_AT_name") or "base"
+        size = _attr_int(die, "DW_AT_byte_size")
+        return (name, size)
+
+    if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
+        name = _attr_str(die, "DW_AT_name") or "<anon>"
+        size = _attr_int(die, "DW_AT_byte_size")
+        return (f"struct {name}" if tag == "DW_TAG_structure_type" else name, size)
+
+    if tag == "DW_TAG_enumeration_type":
+        name = _attr_str(die, "DW_AT_name") or "<enum>"
+        size = _attr_int(die, "DW_AT_byte_size")
+        return (f"enum {name}", size)
+
+    if tag == "DW_TAG_pointer_type":
+        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+            try:
+                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
+                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
+                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1)
+                ptr_size = _attr_int(die, "DW_AT_byte_size") or 8
+                return (f"{inner_name} *", ptr_size)
+            except Exception:  # noqa: BLE001
+                pass
+        return ("void *", _attr_int(die, "DW_AT_byte_size") or 8)
+
+    if tag in ("DW_TAG_const_type", "DW_TAG_volatile_type", "DW_TAG_restrict_type"):
+        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+            try:
+                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
+                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
+                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1)
+                qualifier = tag.split("_")[2].lower()  # const/volatile/restrict
+                return (f"{qualifier} {inner_name}", size)
+            except Exception:  # noqa: BLE001
+                pass
+
+    if tag == "DW_TAG_typedef":
+        name = _attr_str(die, "DW_AT_name")
+        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+            try:
+                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
+                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
+                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1)
+                return (name or inner_name, size)
+            except Exception:  # noqa: BLE001
+                pass
+        return (name or "typedef", 0)
+
+    if tag == "DW_TAG_array_type":
+        size = _attr_int(die, "DW_AT_byte_size")
+        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+            try:
+                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
+                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
+                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1)
+                return (f"{inner_name}[]", size)
+            except Exception:  # noqa: BLE001
+                pass
+        return ("array", size)
+
+    # Fallback
+    name = _attr_str(die, "DW_AT_name")
+    size = _attr_int(die, "DW_AT_byte_size")
+    return (name or tag or "unknown", size)
+
+
+# ---------------------------------------------------------------------------
+# Attribute helpers
+# ---------------------------------------------------------------------------
+
+def _attr_str(die: object, attr: str) -> str:
+    """Return string value of a DIE attribute, or ''."""
+    attrs = die.attributes  # type: ignore[union-attr]
+    if attr not in attrs:
+        return ""
+    val = attrs[attr].value
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    return str(val) if val is not None else ""
+
+
+def _attr_int(die: object, attr: str) -> int:
+    """Return integer value of a DIE attribute, or 0."""
+    attrs = die.attributes  # type: ignore[union-attr]
+    if attr not in attrs:
+        return 0
+    val = attrs[attr].value
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return 0

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -9,14 +9,38 @@ Requires binaries compiled with -g (DWARF debug info).
 If DWARF is absent, returns empty DwarfMetadata gracefully.
 
 See docs/adr/001-technology-stack.md — Sprint 3 layer.
+
+## Design notes
+
+### Iterative traversal
+_walk_die_iter uses an explicit collections.deque to avoid Python's
+recursion limit (default 1000). Real C++ DWARF trees with deep namespaces
+and template specializations can exceed 200 DIE levels of nesting.
+
+### CU-relative vs absolute DWARF references
+In DWARF 4, DW_AT_type uses CU-relative offsets (DW_FORM_ref1/2/4/8/udata).
+pyelftools' CompileUnit.cu_offset is the absolute position of the CU header
+in .debug_info. _resolve_ref() handles both forms transparently.
+
+### Type-resolution caching
+_die_to_type_info results are memoized per parse call using a dict keyed by
+(cu_offset, die_offset). This avoids the O(n×m) re-resolution overhead when
+the same base type DIE (e.g. `int`) appears in hundreds of struct members.
+
+### Bitfield offset handling (DWARF 4 vs DWARF 5)
+- DWARF 2/3: DW_AT_bit_offset = bit offset from MSB of the storage unit
+- DWARF 4+: DW_AT_data_bit_offset = bit offset from LSB of the container
+  Both attributes are read; DW_AT_data_bit_offset takes priority when present.
 """
 from __future__ import annotations
 
+import collections
 import logging
 import os
 import stat
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
@@ -35,7 +59,7 @@ class FieldInfo:
     type_name: str      # human-readable type (e.g. "int", "MyStruct *")
     byte_offset: int    # DW_AT_data_member_location
     byte_size: int      # size of the field's type (0 if unknown)
-    bit_offset: int = 0 # for bitfields: bit offset within the byte
+    bit_offset: int = 0 # for bitfields: normalised bit offset from LSB
     bit_size: int   = 0 # for bitfields: width in bits (0 = not a bitfield)
 
 
@@ -43,8 +67,8 @@ class FieldInfo:
 class StructLayout:
     """Size and field layout of a struct/class/union."""
     name: str
-    byte_size: int                         # DW_AT_byte_size
-    alignment: int = 0                     # DW_AT_alignment (DWARF 5; 0 = unknown)
+    byte_size: int                          # DW_AT_byte_size
+    alignment: int = 0                      # DW_AT_alignment (DWARF 5; 0 = unknown)
     fields: list[FieldInfo] = field(default_factory=list)
     is_union: bool = False
 
@@ -53,18 +77,29 @@ class StructLayout:
 class EnumInfo:
     """Enum type: underlying integer type + all named members."""
     name: str
-    underlying_byte_size: int              # size of the underlying type
+    underlying_byte_size: int               # sizeof underlying integer type
     members: dict[str, int] = field(default_factory=dict)  # name → value
 
 
 @dataclass
 class DwarfMetadata:
     """All DWARF-derived ABI-relevant type information from one .so."""
-    # name → StructLayout  (structs, classes, unions with external linkage)
+    # name → StructLayout  (structs, classes, unions)
     structs: dict[str, StructLayout] = field(default_factory=dict)
     # name → EnumInfo
     enums: dict[str, EnumInfo] = field(default_factory=dict)
     has_dwarf: bool = False   # False = binary had no DWARF info
+
+
+# Tags whose subtrees we never descend into (function-local types, inline
+# frames, lexical blocks). Registering function-local structs as ABI
+# surfaces would produce noise and false positives.
+_SKIP_TAGS: frozenset[str] = frozenset({
+    "DW_TAG_subprogram",
+    "DW_TAG_inlined_subroutine",
+    "DW_TAG_lexical_block",
+    "DW_TAG_GNU_call_site",
+})
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +128,7 @@ def parse_dwarf_metadata(so_path: Path) -> DwarfMetadata:
 # Internal implementation
 # ---------------------------------------------------------------------------
 
-def _parse(f: object, so_path: Path) -> DwarfMetadata:  # noqa: ANN001
+def _parse(f: Any, so_path: Path) -> DwarfMetadata:
     meta = DwarfMetadata()
     elf = ELFFile(f)  # type: ignore[no-untyped-call]
 
@@ -104,57 +139,99 @@ def _parse(f: object, so_path: Path) -> DwarfMetadata:  # noqa: ANN001
     meta.has_dwarf = True
     dwarf = elf.get_dwarf_info()  # type: ignore[no-untyped-call]
 
+    # Per-parse type-resolution cache: (cu_offset, die_offset) → (name, byte_size)
+    type_cache: dict[tuple[int, int], tuple[str, int]] = {}
+
     for CU in dwarf.iter_CUs():  # type: ignore[no-untyped-call]
         try:
-            _process_cu(CU, meta)
+            _process_cu(CU, meta, type_cache)
         except Exception as exc:  # noqa: BLE001
             log.warning("parse_dwarf_metadata: skipping CU in %s: %s", so_path, exc)
 
     return meta
 
 
-def _process_cu(CU: object, meta: DwarfMetadata) -> None:  # noqa: ANN001
-    """Walk all DIEs in one Compilation Unit and collect type info."""
-    top_die = CU.get_top_DIE()  # type: ignore[union-attr]
-    _walk_die(top_die, meta, CU)
+def _process_cu(
+    CU: Any,
+    meta: DwarfMetadata,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
+) -> None:
+    """Walk all DIEs in one Compilation Unit (iterative, no recursion)."""
+    top_die = CU.get_top_DIE()
+    _walk_die_iter(top_die, meta, CU, type_cache)
 
 
-def _walk_die(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
-    tag = die.tag  # type: ignore[union-attr]
+def _walk_die_iter(
+    root_die: Any,
+    meta: DwarfMetadata,
+    CU: Any,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
+) -> None:
+    """Iterative depth-first DIE traversal with scope-qualified names.
 
-    if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
-        _process_struct(die, meta, CU)
-    elif tag == "DW_TAG_enumeration_type":
-        _process_enum(die, meta, CU)
-    elif tag == "DW_TAG_typedef":
-        # C typedef: the underlying type may be anonymous.
-        # Resolve the typedef's target and process it with the typedef name.
-        _process_typedef(die, meta, CU)
+    Carries a scope prefix (e.g. "MyNS::MyClass") through the stack so that
+    identically-named types in different namespaces/classes do not collide in
+    meta.structs / meta.enums.
 
-    for child in die.iter_children():  # type: ignore[union-attr]
-        _walk_die(child, meta, CU)
+    Uses an explicit stack to avoid Python's default recursion limit (1000),
+    which can be exceeded by deeply-nested C++ template/namespace DIE trees.
+    Skips subtrees rooted at function-local tags (_SKIP_TAGS).
+    """
+    # Stack items: (die, scope_prefix)
+    stack: collections.deque[tuple[Any, str]] = collections.deque([(root_die, "")])
+
+    while stack:
+        die, scope = stack.pop()
+        tag = die.tag
+
+        if tag in _SKIP_TAGS:
+            continue  # don't descend into function bodies or inlined frames
+
+        # Determine whether this DIE contributes a scope component
+        # (namespaces and named classes extend the scope prefix)
+        die_name = _attr_str(die, "DW_AT_name")
+        next_scope = scope
+
+        if tag == "DW_TAG_namespace" and die_name:
+            next_scope = f"{scope}::{die_name}" if scope else die_name
+        elif tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
+            qualified = f"{scope}::{die_name}" if (scope and die_name) else die_name
+            _process_struct(die, meta, CU, type_cache, scope_prefix=scope)
+            if die_name:
+                next_scope = qualified  # nested types use this as their scope
+        elif tag == "DW_TAG_enumeration_type":
+            _process_enum(die, meta, CU, scope_prefix=scope)
+        elif tag == "DW_TAG_typedef":
+            _process_typedef(die, meta, CU, type_cache)
+
+        # Push children in reverse order so left-to-right DFS order is preserved
+        for child in reversed(list(die.iter_children())):
+            stack.append((child, next_scope))
 
 
-def _process_typedef(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+def _process_typedef(
+    die: Any,
+    meta: DwarfMetadata,
+    CU: Any,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
+) -> None:
     """If a typedef points to an anonymous struct/enum, register it under the typedef name."""
     typedef_name = _attr_str(die, "DW_AT_name")
     if not typedef_name:
         return
-    if "DW_AT_type" not in die.attributes:  # type: ignore[union-attr]
+    if "DW_AT_type" not in die.attributes:
         return
     try:
-        ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
-        target = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
+        target = _resolve_ref(die, "DW_AT_type", CU)
     except Exception:  # noqa: BLE001
         return
 
-    tag = target.tag  # type: ignore[union-attr]
+    tag = target.tag
     target_name = _attr_str(target, "DW_AT_name")
 
     if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
         if not target_name and typedef_name not in meta.structs:
-            # Anonymous struct typedef — use typedef name
-            _process_struct_named(target, meta, CU, override_name=typedef_name)
+            _process_struct_named(target, meta, CU, type_cache, override_name=typedef_name)
     elif tag == "DW_TAG_enumeration_type":
         if not target_name and typedef_name not in meta.enums:
             _process_enum_named(target, meta, CU, override_name=typedef_name)
@@ -164,17 +241,25 @@ def _process_typedef(die: object, meta: DwarfMetadata, CU: object) -> None:  # n
 # Struct / class / union
 # ---------------------------------------------------------------------------
 
-def _process_struct(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+def _process_struct(
+    die: Any,
+    meta: DwarfMetadata,
+    CU: Any,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
+    scope_prefix: str = "",
+) -> None:
     name = _attr_str(die, "DW_AT_name")
     if not name:
         return  # anonymous — handled via typedef in _process_typedef
-    _process_struct_named(die, meta, CU, override_name=None)
+    qualified = f"{scope_prefix}::{name}" if scope_prefix else name
+    _process_struct_named(die, meta, CU, type_cache, override_name=qualified)
 
 
 def _process_struct_named(
-    die: object,
+    die: Any,
     meta: DwarfMetadata,
-    CU: object,
+    CU: Any,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
     override_name: str | None,
 ) -> None:
     name = override_name or _attr_str(die, "DW_AT_name")
@@ -183,9 +268,9 @@ def _process_struct_named(
 
     byte_size = _attr_int(die, "DW_AT_byte_size")
     if byte_size == 0:
-        return  # declaration-only (DW_AT_declaration) — no layout
+        return  # declaration-only (DW_AT_declaration) — no layout info
 
-    is_union = die.tag == "DW_TAG_union_type"  # type: ignore[union-attr]
+    is_union = die.tag == "DW_TAG_union_type"
     alignment = _attr_int(die, "DW_AT_alignment")  # DWARF 5; 0 if absent
 
     layout = StructLayout(
@@ -195,39 +280,111 @@ def _process_struct_named(
         is_union=is_union,
     )
 
-    for child in die.iter_children():  # type: ignore[union-attr]
-        if child.tag == "DW_TAG_member":  # type: ignore[union-attr]
-            fi = _process_member(child, CU)
+    for child in die.iter_children():
+        if child.tag != "DW_TAG_member":
+            continue
+        child_name = _attr_str(child, "DW_AT_name")
+        if not child_name:
+            # Anonymous member — may be an anonymous struct/union; inline its fields
+            anon_offset = 0
+            if "DW_AT_data_member_location" in child.attributes:
+                v = child.attributes["DW_AT_data_member_location"].value
+                anon_offset = v if isinstance(v, int) else (int(v[-1]) if v else 0)
+            layout.fields.extend(
+                _expand_anonymous_member(child, CU, type_cache, anon_offset)
+            )
+        else:
+            fi = _process_member(child, CU, type_cache)
             if fi is not None:
                 layout.fields.append(fi)
 
-    # Keep only the first definition (ODR: one definition rule).
-    if name not in meta.structs:
+    # ODR: keep the first complete definition.
+    if name in meta.structs:
+        existing = meta.structs[name]
+        if existing.byte_size != layout.byte_size:
+            log.debug(
+                "ODR size mismatch for %s: %d vs %d bytes (keeping first)",
+                name, existing.byte_size, layout.byte_size,
+            )
+    else:
         meta.structs[name] = layout
 
 
-def _process_member(die: object, CU: object) -> FieldInfo | None:  # noqa: ANN001
+def _expand_anonymous_member(
+    die: Any,
+    CU: Any,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
+    byte_offset: int,
+) -> list[FieldInfo]:
+    """Inline the fields of an anonymous struct/union member.
+
+    DWARF uses unnamed DW_TAG_member to embed anonymous aggregates.
+    Rather than discarding them, we inline their nested members so that
+    layout changes inside anonymous structs/unions are still detected.
+    """
+    if "DW_AT_type" not in die.attributes:
+        return []
+    try:
+        target = _resolve_ref(die, "DW_AT_type", CU)
+    except Exception:  # noqa: BLE001
+        return []
+    if target.tag not in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
+        return []
+
+    fields: list[FieldInfo] = []
+    for child in target.iter_children():
+        if child.tag != "DW_TAG_member":
+            continue
+        fi = _process_member(child, CU, type_cache)
+        if fi is None:
+            continue
+        # Adjust offset: anonymous member byte_offset + inner field offset
+        fields.append(FieldInfo(
+            name=fi.name,
+            type_name=fi.type_name,
+            byte_offset=byte_offset + fi.byte_offset,
+            byte_size=fi.byte_size,
+            bit_offset=fi.bit_offset,
+            bit_size=fi.bit_size,
+        ))
+    return fields
+
+
+def _process_member(
+    die: Any,
+    CU: Any,
+    type_cache: dict[tuple[int, int], tuple[str, int]],
+) -> FieldInfo | None:
     name = _attr_str(die, "DW_AT_name")
     if not name:
-        return None  # padding / anonymous member
+        return None  # padding — anonymous aggregates handled by caller
 
-    # Byte offset — DW_AT_data_member_location can be a simple int or a block expr
+    # Byte offset — DW_AT_data_member_location can be a simple int or a DW_OP block
     byte_offset = 0
-    if "DW_AT_data_member_location" in die.attributes:  # type: ignore[union-attr]
-        attr = die.attributes["DW_AT_data_member_location"]  # type: ignore[union-attr]
+    if "DW_AT_data_member_location" in die.attributes:
+        attr = die.attributes["DW_AT_data_member_location"]
         val = attr.value
         if isinstance(val, int):
             byte_offset = val
         elif isinstance(val, list):
-            # DW_OP_plus_uconst expression: [DW_OP_plus_uconst, offset]
+            # DW_OP_plus_uconst expression: last element is the offset value
             byte_offset = int(val[-1]) if val else 0
 
-    # Bit fields
-    bit_offset = _attr_int(die, "DW_AT_bit_offset")
-    bit_size   = _attr_int(die, "DW_AT_bit_size")
+    # Bitfield offsets:
+    # DWARF 4+: DW_AT_data_bit_offset = offset from LSB of the container (preferred)
+    # DWARF 2/3: DW_AT_bit_offset = offset from MSB of the storage unit
+    # DW_AT_data_bit_offset takes priority when present.
+    bit_size = _attr_int(die, "DW_AT_bit_size")
+    if bit_size:
+        if "DW_AT_data_bit_offset" in die.attributes:
+            bit_offset = _attr_int(die, "DW_AT_data_bit_offset")  # DWARF 4+
+        else:
+            bit_offset = _attr_int(die, "DW_AT_bit_offset")       # DWARF 2/3
+    else:
+        bit_offset = 0
 
-    # Resolve type name and size
-    type_name, field_byte_size = _resolve_type(die, CU)
+    # Resolve field type
+    type_name, field_byte_size = _resolve_type(die, CU, type_cache)
 
     return FieldInfo(
         name=name,
@@ -243,17 +400,23 @@ def _process_member(die: object, CU: object) -> FieldInfo | None:  # noqa: ANN00
 # Enum
 # ---------------------------------------------------------------------------
 
-def _process_enum(die: object, meta: DwarfMetadata, CU: object) -> None:  # noqa: ANN001
+def _process_enum(
+    die: Any,
+    meta: DwarfMetadata,
+    CU: Any,
+    scope_prefix: str = "",
+) -> None:
     name = _attr_str(die, "DW_AT_name")
     if not name:
         return  # anonymous — handled via typedef in _process_typedef
-    _process_enum_named(die, meta, CU, override_name=None)
+    qualified = f"{scope_prefix}::{name}" if scope_prefix else name
+    _process_enum_named(die, meta, CU, override_name=qualified)
 
 
 def _process_enum_named(
-    die: object,
+    die: Any,
     meta: DwarfMetadata,
-    CU: object,
+    CU: Any,
     override_name: str | None,
 ) -> None:
     name = override_name or _attr_str(die, "DW_AT_name")
@@ -266,9 +429,10 @@ def _process_enum_named(
 
     enum = EnumInfo(name=name, underlying_byte_size=byte_size)
 
-    for child in die.iter_children():  # type: ignore[union-attr]
-        if child.tag == "DW_TAG_enumerator":  # type: ignore[union-attr]
+    for child in die.iter_children():
+        if child.tag == "DW_TAG_enumerator":
             member_name = _attr_str(child, "DW_AT_name")
+            # DW_AT_const_value may be signed (DW_FORM_sdata → negative values)
             member_val  = _attr_int(child, "DW_AT_const_value")
             if member_name:
                 enum.members[member_name] = member_val
@@ -278,31 +442,81 @@ def _process_enum_named(
 
 
 # ---------------------------------------------------------------------------
-# Type resolution helpers
+# DWARF reference resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_type(die: object, CU: object) -> tuple[str, int]:  # noqa: ANN001
+def _resolve_ref(die: Any, attr_name: str, CU: Any) -> Any:
+    """Resolve a DW_AT_type (or similar) reference to the target DIE.
+
+    Handles both CU-relative refs (DW_FORM_ref1/2/4/8/udata) and
+    section-absolute refs (DW_FORM_ref_addr).  pyelftools stores the raw
+    offset in .value; for CU-relative forms we add CU.cu_offset to get
+    the absolute .debug_info position expected by get_DIE_from_refaddr().
+    """
+    attr = die.attributes[attr_name]
+    form = attr.form
+    raw_val: int = attr.value  # type: ignore[assignment]
+
+    if form == "DW_FORM_ref_addr":
+        # Section-relative: already an absolute offset
+        abs_offset = raw_val
+    else:
+        # CU-relative (DW_FORM_ref1/2/4/8/ref_udata): add CU header offset
+        abs_offset = raw_val + CU.cu_offset
+
+    return CU.get_DIE_from_refaddr(abs_offset)
+
+
+# ---------------------------------------------------------------------------
+# Type resolution helpers (with memoisation)
+# ---------------------------------------------------------------------------
+
+def _resolve_type(
+    die: Any,
+    CU: Any,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int]:
     """Return (type_name, byte_size) for the type referenced by *die*."""
-    if "DW_AT_type" not in die.attributes:  # type: ignore[union-attr]
+    if "DW_AT_type" not in die.attributes:
         return ("unknown", 0)
     try:
-        ref_addr = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
-        type_die = CU.get_DIE_from_refaddr(ref_addr)  # type: ignore[union-attr]
-        return _die_to_type_info(type_die, CU, depth=0)
+        type_die = _resolve_ref(die, "DW_AT_type", CU)
+        return _die_to_type_info(type_die, CU, depth=0, cache=cache)
     except Exception:  # noqa: BLE001
         return ("unknown", 0)
 
 
 def _die_to_type_info(  # noqa: PLR0911
-    die: object,
-    CU: object,
+    die: Any,
+    CU: Any,
     depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
 ) -> tuple[str, int]:
-    """Recursively resolve a type DIE to (name, byte_size). depth limit = 8."""
+    """Recursively resolve a type DIE to (name, byte_size).
+
+    Memoised by (CU.cu_offset, die.offset) so each unique type is resolved
+    at most once per parse call, avoiding O(n*m) redundant traversals.
+    Depth limit = 8 guards against pathological typedef chains.
+    """
     if depth > 8:
         return ("...", 0)
 
-    tag = die.tag  # type: ignore[union-attr]
+    cache_key = (CU.cu_offset, die.offset)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    result = _compute_type_info(die, CU, depth, cache)
+    cache[cache_key] = result
+    return result
+
+
+def _compute_type_info(  # noqa: PLR0911
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int]:
+    tag = die.tag
 
     if tag == "DW_TAG_base_type":
         name = _attr_str(die, "DW_AT_name") or "base"
@@ -312,7 +526,8 @@ def _die_to_type_info(  # noqa: PLR0911
     if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
         name = _attr_str(die, "DW_AT_name") or "<anon>"
         size = _attr_int(die, "DW_AT_byte_size")
-        return (f"struct {name}" if tag == "DW_TAG_structure_type" else name, size)
+        prefix = "struct " if tag == "DW_TAG_structure_type" else ""
+        return (f"{prefix}{name}", size)
 
     if tag == "DW_TAG_enumeration_type":
         name = _attr_str(die, "DW_AT_name") or "<enum>"
@@ -320,35 +535,44 @@ def _die_to_type_info(  # noqa: PLR0911
         return (f"enum {name}", size)
 
     if tag == "DW_TAG_pointer_type":
-        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+        ptr_size = _attr_int(die, "DW_AT_byte_size") or 8
+        if "DW_AT_type" in die.attributes:
             try:
-                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
-                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1)
-                ptr_size = _attr_int(die, "DW_AT_byte_size") or 8
+                inner_die = _resolve_ref(die, "DW_AT_type", CU)
+                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (f"{inner_name} *", ptr_size)
             except Exception:  # noqa: BLE001
                 pass
-        return ("void *", _attr_int(die, "DW_AT_byte_size") or 8)
+        return ("void *", ptr_size)
+
+    if tag in ("DW_TAG_reference_type", "DW_TAG_rvalue_reference_type"):
+        ref_size = _attr_int(die, "DW_AT_byte_size") or 8
+        suffix = "&&" if tag == "DW_TAG_rvalue_reference_type" else "&"
+        if "DW_AT_type" in die.attributes:
+            try:
+                inner_die = _resolve_ref(die, "DW_AT_type", CU)
+                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
+                return (f"{inner_name} {suffix}", ref_size)
+            except Exception:  # noqa: BLE001
+                pass
+        return (f"? {suffix}", ref_size)
 
     if tag in ("DW_TAG_const_type", "DW_TAG_volatile_type", "DW_TAG_restrict_type"):
-        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+        if "DW_AT_type" in die.attributes:
             try:
-                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
-                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
-                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1)
-                qualifier = tag.split("_")[2].lower()  # const/volatile/restrict
+                inner_die = _resolve_ref(die, "DW_AT_type", CU)
+                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
+                qualifier = tag.split("_")[2].lower()  # const / volatile / restrict
                 return (f"{qualifier} {inner_name}", size)
             except Exception:  # noqa: BLE001
                 pass
 
     if tag == "DW_TAG_typedef":
         name = _attr_str(die, "DW_AT_name")
-        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+        if "DW_AT_type" in die.attributes:
             try:
-                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
-                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
-                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1)
+                inner_die = _resolve_ref(die, "DW_AT_type", CU)
+                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (name or inner_name, size)
             except Exception:  # noqa: BLE001
                 pass
@@ -356,17 +580,19 @@ def _die_to_type_info(  # noqa: PLR0911
 
     if tag == "DW_TAG_array_type":
         size = _attr_int(die, "DW_AT_byte_size")
-        if "DW_AT_type" in die.attributes:  # type: ignore[union-attr]
+        if "DW_AT_type" in die.attributes:
             try:
-                ref = die.attributes["DW_AT_type"].value  # type: ignore[union-attr]
-                inner_die = CU.get_DIE_from_refaddr(ref)  # type: ignore[union-attr]
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1)
+                inner_die = _resolve_ref(die, "DW_AT_type", CU)
+                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (f"{inner_name}[]", size)
             except Exception:  # noqa: BLE001
                 pass
         return ("array", size)
 
-    # Fallback
+    if tag == "DW_TAG_subroutine_type":
+        return ("fn(...)", _attr_int(die, "DW_AT_byte_size"))
+
+    # Fallback: use whatever name/size we can get from this DIE
     name = _attr_str(die, "DW_AT_name")
     size = _attr_int(die, "DW_AT_byte_size")
     return (name or tag or "unknown", size)
@@ -376,23 +602,24 @@ def _die_to_type_info(  # noqa: PLR0911
 # Attribute helpers
 # ---------------------------------------------------------------------------
 
-def _attr_str(die: object, attr: str) -> str:
+def _attr_str(die: Any, attr: str) -> str:
     """Return string value of a DIE attribute, or ''."""
-    attrs = die.attributes  # type: ignore[union-attr]
-    if attr not in attrs:
+    if attr not in die.attributes:
         return ""
-    val = attrs[attr].value
+    val = die.attributes[attr].value
     if isinstance(val, bytes):
         return val.decode("utf-8", errors="replace")
     return str(val) if val is not None else ""
 
 
-def _attr_int(die: object, attr: str) -> int:
-    """Return integer value of a DIE attribute, or 0."""
-    attrs = die.attributes  # type: ignore[union-attr]
-    if attr not in attrs:
+def _attr_int(die: Any, attr: str) -> int:
+    """Return integer value of a DIE attribute, or 0.
+
+    Handles signed DW_FORM_sdata values correctly (e.g. negative enum consts).
+    """
+    if attr not in die.attributes:
         return 0
-    val = attrs[attr].value
+    val = die.attributes[attr].value
     try:
         return int(val)
     except (TypeError, ValueError):

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .dwarf_metadata import DwarfMetadata
     from .elf_metadata import ElfMetadata
 
 
@@ -102,7 +103,8 @@ class AbiSnapshot:
     functions: list[Function] = field(default_factory=list)
     variables: list[Variable] = field(default_factory=list)
     types: list[RecordType] = field(default_factory=list)
-    elf: ElfMetadata | None = field(default=None)  # ELF dynamic/symbol metadata
+    elf: ElfMetadata | None = field(default=None)    # ELF dynamic/symbol metadata (Sprint 2)
+    dwarf: DwarfMetadata | None = field(default=None)  # DWARF layout metadata (Sprint 3)
     enums: list[EnumType] = field(default_factory=list)
     typedefs: dict[str, str] = field(default_factory=dict)  # alias -> underlying type name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 # pyelftools has no type stubs or py.typed marker — all its APIs are untyped.
-# Disabling no-untyped-call for elf_metadata.py avoids false CI failures
-# while keeping strict checking on all other modules.
-module = "abicheck.elf_metadata"
+# Disable strict checks for modules that directly call pyelftools APIs.
+module = ["abicheck.elf_metadata", "abicheck.dwarf_metadata"]
 disallow_untyped_calls = false
+disable_error_code = ["attr-defined", "unused-ignore"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_sprint3_dwarf.py
+++ b/tests/test_sprint3_dwarf.py
@@ -1,0 +1,272 @@
+"""Unit tests for Sprint 3 DWARF-aware layout diff."""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.dwarf_metadata import (
+    DwarfMetadata,
+    EnumInfo,
+    FieldInfo,
+    StructLayout,
+    parse_dwarf_metadata,
+)
+from abicheck.model import AbiSnapshot
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _snap(dwarf: DwarfMetadata | None) -> AbiSnapshot:
+    snap = AbiSnapshot(library="libtest.so", version="v1")
+    snap.dwarf = dwarf  # type: ignore[attr-defined]
+    return snap
+
+
+def _meta(**kwargs: object) -> DwarfMetadata:
+    m = DwarfMetadata(has_dwarf=True)
+    for k, v in kwargs.items():
+        setattr(m, k, v)
+    return m
+
+
+def _struct(
+    name: str,
+    size: int,
+    fields: list[FieldInfo] | None = None,
+    alignment: int = 0,
+    is_union: bool = False,
+) -> StructLayout:
+    return StructLayout(
+        name=name,
+        byte_size=size,
+        alignment=alignment,
+        fields=fields or [],
+        is_union=is_union,
+    )
+
+
+def _field(name: str, type_name: str, offset: int, size: int) -> FieldInfo:
+    return FieldInfo(name=name, type_name=type_name, byte_offset=offset, byte_size=size)
+
+
+def _enum(name: str, byte_size: int, members: dict[str, int] | None = None) -> EnumInfo:
+    return EnumInfo(name=name, underlying_byte_size=byte_size, members=members or {})
+
+
+# ── no-DWARF graceful degradation ────────────────────────────────────────────
+
+def test_no_dwarf_both_produces_no_changes() -> None:
+    """If neither snapshot has DWARF, no DWARF changes produced."""
+    old = _snap(None)
+    new = _snap(None)
+    result = compare(old, new)
+    dwarf_kinds = {
+        ChangeKind.STRUCT_SIZE_CHANGED,
+        ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
+        ChangeKind.STRUCT_FIELD_REMOVED,
+        ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+        ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED,
+        ChangeKind.ENUM_MEMBER_REMOVED,
+        ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
+    }
+    kinds = {c.kind for c in result.changes}
+    assert kinds & dwarf_kinds == set()
+
+
+def test_no_dwarf_old_produces_no_changes() -> None:
+    """Old has no DWARF, new has → no DWARF changes (can't diff without old baseline)."""
+    old = _snap(None)
+    new = _snap(_meta(structs={"Foo": _struct("Foo", 8)}))
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.STRUCT_SIZE_CHANGED for c in result.changes)
+
+
+# ── struct size ───────────────────────────────────────────────────────────────
+
+def test_struct_size_changed() -> None:
+    old = _snap(_meta(structs={"Foo": _struct("Foo", 16)}))
+    new = _snap(_meta(structs={"Foo": _struct("Foo", 24)}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_SIZE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_struct_size_unchanged_no_change() -> None:
+    s = _struct("Bar", 32)
+    old = _snap(_meta(structs={"Bar": s}))
+    new = _snap(_meta(structs={"Bar": s}))
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.STRUCT_SIZE_CHANGED for c in result.changes)
+
+
+# ── field offset ──────────────────────────────────────────────────────────────
+
+def test_field_offset_changed() -> None:
+    old_s = _struct("Foo", 16, fields=[
+        _field("x", "int", offset=0, size=4),
+        _field("y", "int", offset=4, size=4),
+    ])
+    # padding inserted before y → offset shifts
+    new_s = _struct("Foo", 24, fields=[
+        _field("x", "int", offset=0, size=4),
+        _field("y", "int", offset=8, size=4),
+    ])
+    old = _snap(_meta(structs={"Foo": old_s}))
+    new = _snap(_meta(structs={"Foo": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_FIELD_OFFSET_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+# ── field removed ─────────────────────────────────────────────────────────────
+
+def test_field_removed() -> None:
+    old_s = _struct("Foo", 16, fields=[
+        _field("x", "int", 0, 4),
+        _field("secret", "int", 4, 4),
+    ])
+    new_s = _struct("Foo", 8, fields=[
+        _field("x", "int", 0, 4),
+    ])
+    old = _snap(_meta(structs={"Foo": old_s}))
+    new = _snap(_meta(structs={"Foo": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_FIELD_REMOVED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+# ── field type size changed ───────────────────────────────────────────────────
+
+def test_field_type_size_changed() -> None:
+    # int → long (size 4 → 8)
+    old_s = _struct("Foo", 8, fields=[_field("n", "int", 0, 4)])
+    new_s = _struct("Foo", 16, fields=[_field("n", "long", 0, 8)])
+    old = _snap(_meta(structs={"Foo": old_s}))
+    new = _snap(_meta(structs={"Foo": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds
+
+
+# ── struct alignment ──────────────────────────────────────────────────────────
+
+def test_struct_alignment_changed() -> None:
+    old_s = _struct("Vec", 16, alignment=4)
+    new_s = _struct("Vec", 16, alignment=8)
+    old = _snap(_meta(structs={"Vec": old_s}))
+    new = _snap(_meta(structs={"Vec": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_ALIGNMENT_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+# ── enum underlying size ──────────────────────────────────────────────────────
+
+def test_enum_underlying_size_changed() -> None:
+    old = _snap(_meta(enums={"Color": _enum("Color", byte_size=1)}))
+    new = _snap(_meta(enums={"Color": _enum("Color", byte_size=4)}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_enum_underlying_size_unchanged_no_change() -> None:
+    e = _enum("Status", byte_size=4, members={"OK": 0, "ERR": 1})
+    old = _snap(_meta(enums={"Status": e}))
+    new = _snap(_meta(enums={"Status": e}))
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED for c in result.changes)
+
+
+# ── enum member removed ───────────────────────────────────────────────────────
+
+def test_enum_member_removed() -> None:
+    old = _snap(_meta(enums={
+        "Flags": _enum("Flags", 4, members={"A": 1, "B": 2, "C": 4})
+    }))
+    new = _snap(_meta(enums={
+        "Flags": _enum("Flags", 4, members={"A": 1, "C": 4})  # B removed
+    }))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_REMOVED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+# ── enum member value changed ─────────────────────────────────────────────────
+
+def test_enum_member_value_changed() -> None:
+    old = _snap(_meta(enums={"Code": _enum("Code", 4, members={"OK": 0, "FAIL": 1})}))
+    new = _snap(_meta(enums={"Code": _enum("Code", 4, members={"OK": 0, "FAIL": 2})}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+# ── integration: real .so with -g ─────────────────────────────────────────────
+
+@pytest.mark.integration
+def test_parse_dwarf_real_so() -> None:
+    """Compile a .so with debug info and verify DWARF layout extracted correctly."""
+    src = """
+    typedef struct { int x; double y; char z; } MyStruct;
+    typedef enum { RED=0, GREEN=1, BLUE=2 } Color;
+    int use(MyStruct *s, Color c) { return s->x + c; }
+    """
+    with tempfile.TemporaryDirectory() as td:
+        so = Path(td) / "libtest.so"
+        result = subprocess.run(
+            ["gcc", "-g", "-shared", "-fPIC", "-o", str(so), "-x", "c", "-"],
+            input=src.encode(), capture_output=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"gcc failed: {result.stderr.decode()[:200]}")
+
+        meta = parse_dwarf_metadata(so)
+
+    assert meta.has_dwarf
+    assert "MyStruct" in meta.structs
+    s = meta.structs["MyStruct"]
+    assert s.byte_size == 24
+    field_names = {f.name for f in s.fields}
+    assert {"x", "y", "z"} <= field_names
+
+    assert "Color" in meta.enums
+    e = meta.enums["Color"]
+    assert e.underlying_byte_size == 4
+    assert e.members == {"RED": 0, "GREEN": 1, "BLUE": 2}
+
+
+@pytest.mark.integration
+def test_parse_dwarf_struct_size_regression() -> None:
+    """int → long field: DWARF detects struct size change as BREAKING."""
+    src_v1 = "typedef struct { int n; } Ctx; int use(Ctx *c) { return c->n; }"
+    src_v2 = "typedef struct { long n; } Ctx; int use(Ctx *c) { return (int)c->n; }"
+
+    with tempfile.TemporaryDirectory() as td:
+        for src, name in [(src_v1, "v1.so"), (src_v2, "v2.so")]:
+            r = subprocess.run(
+                ["gcc", "-g", "-shared", "-fPIC", "-o", str(Path(td) / name), "-x", "c", "-"],
+                input=src.encode(), capture_output=True,
+            )
+            if r.returncode != 0:
+                pytest.skip(f"gcc failed: {r.stderr.decode()[:200]}")
+
+        meta1 = parse_dwarf_metadata(Path(td) / "v1.so")
+        meta2 = parse_dwarf_metadata(Path(td) / "v2.so")
+
+    old = _snap(meta1)
+    new = _snap(meta2)
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_SIZE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING

--- a/tests/test_sprint3_dwarf.py
+++ b/tests/test_sprint3_dwarf.py
@@ -84,6 +84,18 @@ def test_no_dwarf_old_produces_no_changes() -> None:
     assert not any(c.kind == ChangeKind.STRUCT_SIZE_CHANGED for c in result.changes)
 
 
+def test_stripped_new_emits_dwarf_info_missing() -> None:
+    """old.has_dwarf=True, new.has_dwarf=False → DWARF_INFO_MISSING diagnostic, not silent COMPATIBLE."""
+    old = _snap(_meta(structs={"Foo": _struct("Foo", 16)}))
+    new_meta = DwarfMetadata(has_dwarf=False)   # stripped binary
+    new = _snap(new_meta)
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.DWARF_INFO_MISSING in kinds
+    # Must NOT silently produce NO_CHANGE or COMPATIBLE with zero dwarf changes
+    assert ChangeKind.STRUCT_SIZE_CHANGED not in kinds  # can't diff without new info
+
+
 # ── struct size ───────────────────────────────────────────────────────────────
 
 def test_struct_size_changed() -> None:
@@ -154,6 +166,18 @@ def test_field_type_size_changed() -> None:
     assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds
 
 
+def test_field_type_name_changed_same_size() -> None:
+    """int → float: same size (4B) but different type — should still be BREAKING."""
+    old_s = _struct("Ctx", 8, fields=[_field("val", "int", 0, 4)])
+    new_s = _struct("Ctx", 8, fields=[_field("val", "float", 0, 4)])
+    old = _snap(_meta(structs={"Ctx": old_s}))
+    new = _snap(_meta(structs={"Ctx": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
 # ── struct alignment ──────────────────────────────────────────────────────────
 
 def test_struct_alignment_changed() -> None:
@@ -212,6 +236,80 @@ def test_enum_member_value_changed() -> None:
     assert result.verdict == Verdict.BREAKING
 
 
+def test_enum_negative_member_value() -> None:
+    """Negative enum constants (DW_FORM_sdata) must be handled correctly."""
+    old = _snap(_meta(enums={"Err": _enum("Err", 4, members={"OK": 0, "ERR": -1})}))
+    new = _snap(_meta(enums={"Err": _enum("Err", 4, members={"OK": 0, "ERR": -2})}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds
+
+
+# ── union ─────────────────────────────────────────────────────────────────────
+
+def test_union_size_changed() -> None:
+    old = _snap(_meta(structs={"U": _struct("U", 4, is_union=True)}))
+    new = _snap(_meta(structs={"U": _struct("U", 8, is_union=True)}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_SIZE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+def test_union_field_offset_always_zero() -> None:
+    """Union members all start at offset 0 — change in member types detected via type_name."""
+    old_s = _struct("U", 4, fields=[_field("i", "int", 0, 4)], is_union=True)
+    new_s = _struct("U", 4, fields=[_field("i", "float", 0, 4)], is_union=True)
+    old = _snap(_meta(structs={"U": old_s}))
+    new = _snap(_meta(structs={"U": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds
+
+
+# ── mid-struct insert ─────────────────────────────────────────────────────────
+
+def test_field_inserted_mid_struct_shifts_offsets() -> None:
+    """Inserting a field between existing fields shifts later fields — detected via offsets."""
+    old_s = _struct("S", 12, fields=[
+        _field("a", "int", 0, 4),
+        _field("b", "int", 4, 4),
+        _field("c", "int", 8, 4),
+    ])
+    new_s = _struct("S", 16, fields=[
+        _field("a", "int", 0, 4),
+        _field("pad", "int", 4, 4),   # new field inserted
+        _field("b", "int", 8, 4),     # b shifted
+        _field("c", "int", 12, 4),    # c shifted
+    ])
+    old = _snap(_meta(structs={"S": old_s}))
+    new = _snap(_meta(structs={"S": new_s}))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    # Size changed AND b/c offsets changed
+    assert ChangeKind.STRUCT_SIZE_CHANGED in kinds
+    assert ChangeKind.STRUCT_FIELD_OFFSET_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
+# ── end-to-end AbiSnapshot pipeline ──────────────────────────────────────────
+
+def test_full_snapshot_pipeline_dwarf_only() -> None:
+    """Full AbiSnapshot with dwarf field set — verifies compare() integration path."""
+    from abicheck.model import AbiSnapshot
+
+    old_snap = AbiSnapshot(library="libfoo.so", version="1.0")
+    old_snap.dwarf = _meta(structs={"Ctx": _struct("Ctx", 8, fields=[_field("n", "int", 0, 4)])})  # type: ignore[attr-defined]
+
+    new_snap = AbiSnapshot(library="libfoo.so", version="2.0")
+    new_snap.dwarf = _meta(structs={"Ctx": _struct("Ctx", 16, fields=[_field("n", "long", 0, 8)])})  # type: ignore[attr-defined]
+
+    result = compare(old_snap, new_snap)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_SIZE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
 # ── integration: real .so with -g ─────────────────────────────────────────────
 
 @pytest.mark.integration
@@ -236,7 +334,9 @@ def test_parse_dwarf_real_so() -> None:
     assert meta.has_dwarf
     assert "MyStruct" in meta.structs
     s = meta.structs["MyStruct"]
-    assert s.byte_size == 24
+    # x=int(4), y=double(8 with align), z=char(1) + padding
+    # x86-64: 24 bytes; 32-bit (arm): 16 bytes
+    assert s.byte_size in (16, 24), f"unexpected byte_size={s.byte_size}"
     field_names = {f.name for f in s.fields}
     assert {"x", "y", "z"} <= field_names
 


### PR DESCRIPTION
## Summary
Sprint 3 foundation for DWARF-aware ABI analysis (Variant 2 stack: pyelftools + castxml).

### Added
- `abicheck/dwarf_metadata.py`
  - parse DWARF types with pyelftools
  - struct/class/union layouts (size, alignment, field offsets/types)
  - enum underlying size + member values
  - handles anonymous struct/enum via typedef resolution
  - graceful degradation when DWARF is missing

- checker integration
  - new `_diff_dwarf()` pass in `compare()`
  - new ChangeKinds:
    - `STRUCT_SIZE_CHANGED`
    - `STRUCT_FIELD_OFFSET_CHANGED`
    - `STRUCT_FIELD_REMOVED`
    - `STRUCT_FIELD_TYPE_CHANGED`
    - `STRUCT_ALIGNMENT_CHANGED`
    - `ENUM_UNDERLYING_SIZE_CHANGED`
    - `ENUM_MEMBER_VALUE_CHANGED`
    - `ENUM_MEMBER_REMOVED`

- model integration
  - `AbiSnapshot.dwarf` field for DWARF metadata

- tests
  - `tests/test_sprint3_dwarf.py` (14 tests)
  - unit + integration checks on real `-g` compiled `.so`

## Local validation
- `pytest tests/test_sprint3_dwarf.py -q` → 14 passed
- `pytest tests/ -q -m "not integration"` → 104 passed, 27 deselected
- `ruff check abicheck/ tests/` → clean
- `mypy abicheck/ --ignore-missing-imports` → clean

## Notes
This PR intentionally focuses on DWARF struct/enum layout signals only.
Vtable/RTTI/calling-convention remain for follow-up Sprint 3/4 work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced ABI compatibility analysis that detects DWARF-aware struct and enum layout changes (size, alignment, field offsets, removals, type changes, and enum underlying size), plus reporting when DWARF info is missing; integrates these layout diffs into compatibility verdicts.
* **Tests**
  * Added comprehensive unit and integration tests covering DWARF parsing, layout diffs, regressions, and verdict outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->