### PR TITLE
Sprint 4: Advanced DWARF — calling convention, struct packing, toolchain flag drift

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -99,6 +99,12 @@ class ChangeKind(str, Enum):
     STRUCT_ALIGNMENT_CHANGED   = "struct_alignment_changed"   # alignof(T) changed
     ENUM_UNDERLYING_SIZE_CHANGED = "enum_underlying_size_changed"  # int→long
 
+    # DWARF advanced (Sprint 4)
+    CALLING_CONVENTION_CHANGED = "calling_convention_changed"   # DW_AT_calling_convention drift
+    STRUCT_PACKING_CHANGED     = "struct_packing_changed"       # __attribute__((packed)) added/removed
+    TYPE_VISIBILITY_CHANGED    = "type_visibility_changed"      # typeinfo/vtable visibility changed
+    TOOLCHAIN_FLAG_DRIFT       = "toolchain_flag_drift"         # -fshort-enums/-fpack-struct drift
+
 
 class Verdict(str, Enum):
     NO_CHANGE = "NO_CHANGE"         # identical ABI
@@ -150,7 +156,7 @@ _BREAKING_KINDS = {
     ChangeKind.IFUNC_REMOVED,
     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
     ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
-    # DWARF Sprint 3
+    # DWARF Sprint 3 + 4
     ChangeKind.STRUCT_SIZE_CHANGED,
     ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
     ChangeKind.STRUCT_FIELD_REMOVED,
@@ -159,6 +165,9 @@ _BREAKING_KINDS = {
     ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED,
     ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
     ChangeKind.ENUM_MEMBER_REMOVED,
+    ChangeKind.CALLING_CONVENTION_CHANGED,
+    ChangeKind.STRUCT_PACKING_CHANGED,
+    ChangeKind.TYPE_VISIBILITY_CHANGED,
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
@@ -181,6 +190,7 @@ _COMPATIBLE_KINDS: set[ChangeKind] = {
 
     # DWARF diagnostics (comparison coverage gap warning)
     ChangeKind.DWARF_INFO_MISSING,
+    ChangeKind.TOOLCHAIN_FLAG_DRIFT,  # informational — not a proven binary break
 }
 
 _SOURCE_BREAK_KINDS: set[ChangeKind] = set()  # reserved for future source-only breaks
@@ -869,6 +879,7 @@ def compare(
     changes.extend(_diff_typedefs(old, new))
     changes.extend(_diff_elf(old, new))
     changes.extend(_diff_dwarf(old, new))
+    changes.extend(_diff_advanced_dwarf(old, new))
 
     suppressed: list[Change] = []
     if suppression is not None:
@@ -1121,3 +1132,34 @@ def _diff_enum_layouts(o: object, n: object) -> list[Change]:
                 ))
 
     return changes
+
+
+# ── Sprint 4: Advanced DWARF (calling convention, toolchain flags, visibility) ─
+
+
+
+def _diff_advanced_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    """Sprint 4: calling convention, packing, toolchain flag drift."""
+    from .dwarf_advanced import AdvancedDwarfMetadata, diff_advanced_dwarf
+
+    o: AdvancedDwarfMetadata = getattr(old, "dwarf_advanced", None) or AdvancedDwarfMetadata()
+    n: AdvancedDwarfMetadata = getattr(new, "dwarf_advanced", None) or AdvancedDwarfMetadata()
+
+    _kind_map = {
+        "calling_convention_changed": ChangeKind.CALLING_CONVENTION_CHANGED,
+        "struct_packing_changed":     ChangeKind.STRUCT_PACKING_CHANGED,
+        "toolchain_flag_drift":       ChangeKind.TOOLCHAIN_FLAG_DRIFT,
+        "type_visibility_changed":    ChangeKind.TYPE_VISIBILITY_CHANGED,
+    }
+
+    return [
+        Change(
+            kind=_kind_map[kind_str],
+            symbol=sym,
+            description=desc,
+            old_value=old_val,
+            new_value=new_val,
+        )
+        for kind_str, sym, desc, old_val, new_val in diff_advanced_dwarf(o, n)
+        if kind_str in _kind_map
+    ]

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -486,6 +486,14 @@ def dump(
     extra_includes = extra_includes or []
     exported_dynamic, exported_static = _readelf_exported_symbols(so_path)
 
+    from .dwarf_advanced import parse_advanced_dwarf
+    from .dwarf_metadata import parse_dwarf_metadata
+    from .elf_metadata import parse_elf_metadata
+
+    elf_meta = parse_elf_metadata(so_path)
+    dwarf_meta = parse_dwarf_metadata(so_path)
+    dwarf_adv = parse_advanced_dwarf(so_path)
+
     if not headers:
         warnings.warn(
             "No headers provided — only ELF-exported symbols will be captured; "
@@ -501,13 +509,15 @@ def dump(
                          visibility=Visibility.ELF_ONLY)
                 for sym in sorted(exported_dynamic)
             ],
+            elf=elf_meta,
+            dwarf=dwarf_meta,
+            dwarf_advanced=dwarf_adv,
         )
         return snapshot
 
     xml_root = _castxml_dump(headers, extra_includes, compiler=compiler)
     parser = _CastxmlParser(xml_root, exported_dynamic, exported_static)
 
-    from .elf_metadata import parse_elf_metadata
     snapshot = AbiSnapshot(
         library=so_path.name,
         version=version,
@@ -516,6 +526,8 @@ def dump(
         types=parser.parse_types(),
         enums=parser.parse_enums(),
         typedefs=parser.parse_typedefs(),
-        elf=parse_elf_metadata(so_path),
+        elf=elf_meta,
+        dwarf=dwarf_meta,
+        dwarf_advanced=dwarf_adv,
     )
     return snapshot

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -1,0 +1,364 @@
+"""Sprint 4: Advanced DWARF analysis.
+
+Detects:
+1. Calling convention changes (DW_AT_calling_convention on functions/methods)
+2. Struct packing drift (__attribute__((packed)) — detected via DWARF field offsets
+   vs natural alignment: if any field is at a non-aligned offset, struct is packed)
+3. Toolchain flag drift via DW_AT_producer parsing
+   (-fshort-enums, -fpack-struct, -fno-common, toolchain version change)
+4. typeinfo / vtable symbol visibility changes (ELF .dynsym cross-check)
+
+All functions return [] gracefully when DWARF is absent.
+"""
+from __future__ import annotations
+
+import collections
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# DW_AT_calling_convention values (DWARF standard)
+_CC_NAMES: dict[int, str] = {
+    0x01: "normal",
+    0x02: "program",
+    0x03: "nocall",
+    0x04: "pass_by_reference",   # DWARF 5
+    0x05: "pass_by_value",       # DWARF 5
+    0x40: "GNU_renesas_sh",
+    0x41: "GNU_borland_fastcall_i386",
+    0xb0: "BORLAND_safecall",
+    0xb1: "BORLAND_stdcall",
+    0xb2: "BORLAND_pascal",
+    0xb3: "BORLAND_msfastcall",
+    0xb4: "BORLAND_msreturn",
+    0xb5: "BORLAND_thiscall",
+    0xb6: "BORLAND_fastcall",
+    0xd0: "LLVM_vectorcall",
+}
+
+# Flags in DW_AT_producer that affect binary ABI
+_ABI_FLAGS_RE = re.compile(
+    r"""
+    (?P<short_enums>-fshort-enums)
+    |(?P<pack_struct>-fpack-struct(?:=\d+)?)
+    |(?P<no_common>-fno-common)
+    |(?P<common>-fcommon)
+    |(?P<m32>-m32)
+    |(?P<m64>-m64)
+    |(?P<mabi>-mabi=\S+)
+    |(?P<fabi>-fabi-version=\d+)
+    |(?P<cxx11abi>-D_GLIBCXX_USE_CXX11_ABI=\d)
+    """,
+    re.VERBOSE,
+)
+
+
+@dataclass
+class ToolchainInfo:
+    """Parsed DW_AT_producer metadata from a binary."""
+    producer_string: str = ""           # raw DW_AT_producer value
+    compiler: str = ""                  # e.g. "GCC", "clang", "ICC"
+    version: str = ""                   # e.g. "13.2.1"
+    abi_flags: set[str] = field(default_factory=set)  # extracted ABI-affecting flags
+
+
+@dataclass
+class AdvancedDwarfMetadata:
+    """Sprint 4 metadata extracted from a single .so."""
+    has_dwarf: bool = False
+    toolchain: ToolchainInfo = field(default_factory=ToolchainInfo)
+    # function_name → calling_convention string (only non-"normal" entries)
+    calling_conventions: dict[str, str] = field(default_factory=dict)
+    # struct_name → True if detected as packed (any misaligned field)
+    packed_structs: set[str] = field(default_factory=set)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_advanced_dwarf(so_path: Path) -> AdvancedDwarfMetadata:
+    """Extract Sprint 4 metadata from *so_path*.
+
+    Returns empty AdvancedDwarfMetadata (has_dwarf=False) if binary has no
+    debug info or cannot be parsed. Never raises.
+    """
+    try:
+        from elftools.elf.elffile import ELFFile
+        with open(so_path, "rb") as f:
+            elf = ELFFile(f)
+            if not elf.has_dwarf_info():
+                return AdvancedDwarfMetadata()
+            meta = AdvancedDwarfMetadata(has_dwarf=True)
+            dwarf = elf.get_dwarf_info()
+            for CU in dwarf.iter_CUs():
+                try:
+                    _process_cu(CU, meta)
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("parse_advanced_dwarf: skipping CU: %s", exc)
+            return meta
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_advanced_dwarf: failed %s: %s", so_path, exc)
+        return AdvancedDwarfMetadata()
+
+
+# ---------------------------------------------------------------------------
+# Internal: CU processing
+# ---------------------------------------------------------------------------
+
+def _process_cu(CU: Any, meta: AdvancedDwarfMetadata) -> None:
+    top = CU.get_top_DIE()
+
+    # Extract toolchain info from CU-level DW_AT_producer (first CU wins)
+    if not meta.toolchain.producer_string:
+        producer = _attr_str(top, "DW_AT_producer")
+        if producer:
+            meta.toolchain = _parse_producer(producer)
+
+    _walk_cu(top, meta)
+
+
+def _walk_cu(root: Any, meta: AdvancedDwarfMetadata) -> None:
+    """Iterative walk; extract calling_convention and packed struct info."""
+    _SKIP = frozenset({
+        "DW_TAG_lexical_block",
+        "DW_TAG_inlined_subroutine",
+        "DW_TAG_GNU_call_site",
+    })
+    stack: collections.deque[Any] = collections.deque([root])
+
+    while stack:
+        die = stack.pop()
+        tag = die.tag
+
+        if tag in _SKIP:
+            continue
+
+        if tag in ("DW_TAG_subprogram", "DW_TAG_subroutine_type"):
+            _extract_calling_convention(die, meta)
+
+        if tag in ("DW_TAG_structure_type", "DW_TAG_class_type"):
+            _check_packed(die, meta)
+
+        stack.extend(reversed(list(die.iter_children())))
+
+
+# ---------------------------------------------------------------------------
+# Calling convention extraction
+# ---------------------------------------------------------------------------
+
+def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata) -> None:
+    """Record non-default calling conventions for ABI-exported functions."""
+    name = _attr_str(die, "DW_AT_name")
+    if not name:
+        return
+    # Only externally-visible functions matter
+    if not _attr_bool(die, "DW_AT_external"):
+        return
+    if "DW_AT_calling_convention" not in die.attributes:
+        return
+    raw = die.attributes["DW_AT_calling_convention"].value
+    cc_name = _CC_NAMES.get(int(raw), f"unknown(0x{int(raw):02x})")
+    if cc_name != "normal":
+        meta.calling_conventions[name] = cc_name
+
+
+# ---------------------------------------------------------------------------
+# Packed struct detection
+# ---------------------------------------------------------------------------
+
+# Natural alignment of common DWARF base types by byte size
+_NATURAL_ALIGN: dict[int, int] = {
+    1: 1,
+    2: 2,
+    4: 4,
+    8: 8,
+    16: 16,
+}
+
+
+def _check_packed(die: Any, meta: AdvancedDwarfMetadata) -> None:
+    """Detect if struct has any fields at misaligned offsets → packed."""
+    name = _attr_str(die, "DW_AT_name")
+    if not name:
+        return
+    byte_size = _attr_int(die, "DW_AT_byte_size")
+    if byte_size == 0:
+        return  # forward declaration
+
+    for child in die.iter_children():
+        if child.tag != "DW_TAG_member":
+            continue
+        if _attr_int(child, "DW_AT_bit_size"):
+            continue  # bitfields always packed-like, skip
+
+        offset = 0
+        if "DW_AT_data_member_location" in child.attributes:
+            v = child.attributes["DW_AT_data_member_location"].value
+            offset = v if isinstance(v, int) else (int(v[-1]) if v else 0)
+
+        # Get field byte size to determine natural alignment requirement
+        field_size = _get_member_size(child)
+        if field_size <= 1:
+            continue  # char/byte: always aligned
+
+        natural = _NATURAL_ALIGN.get(min(field_size, 16), 1)
+        if natural > 1 and offset % natural != 0:
+            meta.packed_structs.add(name)
+            return  # one misaligned field is enough
+
+
+def _get_member_size(die: Any) -> int:
+    """Best-effort field size via DW_AT_byte_size on the referenced type."""
+    if "DW_AT_byte_size" in die.attributes:
+        return _attr_int(die, "DW_AT_byte_size")
+    # Could also resolve DW_AT_type, but keep it simple for now
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# DW_AT_producer parsing
+# ---------------------------------------------------------------------------
+
+def _parse_producer(producer: str) -> ToolchainInfo:
+    """Parse the raw DW_AT_producer string into ToolchainInfo."""
+    info = ToolchainInfo(producer_string=producer)
+
+    # Detect compiler
+    if "GCC" in producer or "GNU" in producer:
+        info.compiler = "GCC"
+        m = re.search(r"(\d+\.\d+(?:\.\d+)?)", producer)
+        if m:
+            info.version = m.group(1)
+    elif re.search(r"clang|LLVM", producer, re.I):
+        info.compiler = "clang"
+        m = re.search(r"(\d+\.\d+(?:\.\d+)?)", producer)
+        if m:
+            info.version = m.group(1)
+    elif re.search(r"Intel|ICC|ICX", producer):
+        info.compiler = "ICC"
+        m = re.search(r"(\d+\.\d+(?:\.\d+)?)", producer)
+        if m:
+            info.version = m.group(1)
+
+    # Extract ABI-affecting flags
+    for m in _ABI_FLAGS_RE.finditer(producer):
+        info.abi_flags.add(m.group(0))
+
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Diff functions (called from checker.py)
+# ---------------------------------------------------------------------------
+
+def diff_advanced_dwarf(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Return list of (kind, symbol, description, old_value, new_value) tuples.
+
+    Caller (checker.py) converts these to Change objects using ChangeKind.
+    Returns [] if either side has no DWARF.
+    """
+    if not old_meta.has_dwarf or not new_meta.has_dwarf:
+        return []
+
+    results: list[tuple[str, str, str, str | None, str | None]] = []
+
+    # 1. Calling convention changes
+    for fname, old_cc in old_meta.calling_conventions.items():
+        new_cc = new_meta.calling_conventions.get(fname, "normal")
+        if old_cc != new_cc:
+            results.append((
+                "calling_convention_changed",
+                fname,
+                f"Calling convention changed: {fname} ({old_cc} → {new_cc})",
+                old_cc,
+                new_cc,
+            ))
+    for fname, new_cc in new_meta.calling_conventions.items():
+        if fname not in old_meta.calling_conventions:
+            # Was 'normal' (default), now explicit non-normal
+            results.append((
+                "calling_convention_changed",
+                fname,
+                f"Calling convention changed: {fname} (normal → {new_cc})",
+                "normal",
+                new_cc,
+            ))
+
+    # 2. Packing changes (packed ↔ unpacked)
+    old_packed = old_meta.packed_structs
+    new_packed = new_meta.packed_structs
+    for name in sorted(old_packed - new_packed):
+        results.append((
+            "struct_packing_changed",
+            name,
+            f"Struct packing removed: {name} was packed, now standard layout",
+            "packed",
+            "standard",
+        ))
+    for name in sorted(new_packed - old_packed):
+        results.append((
+            "struct_packing_changed",
+            name,
+            f"Struct packing added: {name} is now packed (__attribute__((packed)))",
+            "standard",
+            "packed",
+        ))
+
+    # 3. Toolchain ABI flag drift
+    old_flags = old_meta.toolchain.abi_flags
+    new_flags = new_meta.toolchain.abi_flags
+    removed_flags = old_flags - new_flags
+    added_flags = new_flags - old_flags
+    if removed_flags or added_flags:
+        desc_parts = []
+        if added_flags:
+            desc_parts.append(f"added: {', '.join(sorted(added_flags))}")
+        if removed_flags:
+            desc_parts.append(f"removed: {', '.join(sorted(removed_flags))}")
+        results.append((
+            "toolchain_flag_drift",
+            "<toolchain>",
+            f"ABI-affecting compiler flags changed: {'; '.join(desc_parts)}",
+            ",".join(sorted(old_flags)) or None,
+            ",".join(sorted(new_flags)) or None,
+        ))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Attribute helpers
+# ---------------------------------------------------------------------------
+
+def _attr_str(die: Any, attr: str) -> str:
+    if attr not in die.attributes:
+        return ""
+    val = die.attributes[attr].value
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    return str(val) if val is not None else ""
+
+
+def _attr_int(die: Any, attr: str) -> int:
+    if attr not in die.attributes:
+        return 0
+    val = die.attributes[attr].value
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _attr_bool(die: Any, attr: str) -> bool:
+    if attr not in die.attributes:
+        return False
+    val = die.attributes[attr].value
+    return bool(val)

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -247,9 +247,12 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
             continue
 
         if tag in ("DW_TAG_structure_type", "DW_TAG_class_type"):
-            # Register name in all_struct_names even when not packed
+            # Register name in all_struct_names only for complete types (byte_size > 0).
+            # Forward declarations (byte_size == 0) must NOT be registered: a forward
+            # decl of a deleted struct in the new binary would cause a false
+            # "packing removed" report via the both_struct_names guard.
             sname = _attr_str(die, "DW_AT_name")
-            if sname:
+            if sname and _attr_int(die, "DW_AT_byte_size") > 0:
                 meta.all_struct_names.add(sname)
             _check_packed(die, meta, CU, override_name=None)
 
@@ -361,11 +364,12 @@ def _check_packed(
         if _attr_int(child, "DW_AT_bit_size"):
             continue  # bitfields: skip (always "misaligned" by nature)
 
-        # Get byte offset of this field
-        offset = 0
-        if "DW_AT_data_member_location" in child.attributes:
-            v = child.attributes["DW_AT_data_member_location"].value
-            offset = v if isinstance(v, int) else (int(v[-1]) if v else 0)
+        # Get byte offset of this field.
+        # DW_AT_data_member_location can be:
+        #   - int  (DWARF 3+ constant form — most common case)
+        #   - list of DWARFExprOp (DWARF 2/3 location expression)
+        #     The typical expression is [DW_OP_plus_uconst N] where N is the offset.
+        offset = _decode_member_location(child)
 
         # Get natural alignment via type tag (NOT byte_size of composite types)
         natural = _get_type_align(child, CU)
@@ -379,43 +383,35 @@ def _check_packed(
             return  # one misaligned field is sufficient
 
 
-def _get_type_byte_size(member_die: Any, CU: Any) -> int:
-    """Resolve DW_AT_type from a member DIE and return DW_AT_byte_size.
+def _decode_member_location(member_die: Any) -> int:
+    """Decode DW_AT_data_member_location to a byte offset.
 
-    Follows typedef chains up to depth 4. Returns 0 if resolution fails.
+    Handles both forms produced by different DWARF versions:
+    - Constant integer (DWARF 3+, most common): value is the offset directly.
+    - Location expression (DWARF 2/3): a list of DWARFExprOp objects.
+      The canonical expression for a struct member is a single
+      DW_OP_plus_uconst (op=0x23) with the offset in args[0].
+      We decode this case explicitly; anything else returns 0 (skip).
+
+    Returns 0 for unknown/unsupported forms (conservative — avoids false
+    'packed' detection rather than producing wrong offsets).
     """
-    if "DW_AT_type" not in member_die.attributes:
+    if "DW_AT_data_member_location" not in member_die.attributes:
         return 0
-    try:
-        attr = member_die.attributes["DW_AT_type"]
-        form = attr.form
-        raw: int = attr.value
-        abs_offset = raw if form == "DW_FORM_ref_addr" else raw + CU.cu_offset
-        type_die = CU.get_DIE_from_refaddr(abs_offset)
-
-        # Follow typedef / const / volatile / restrict chains
-        for _ in range(4):
-            tag = type_die.tag
-            if tag in (
-                "DW_TAG_typedef",
-                "DW_TAG_const_type",
-                "DW_TAG_volatile_type",
-                "DW_TAG_restrict_type",
-            ):
-                if "DW_AT_type" not in type_die.attributes:
-                    return 0
-                a = type_die.attributes["DW_AT_type"]
-                f = a.form
-                r: int = a.value
-                abs_off = r if f == "DW_FORM_ref_addr" else r + CU.cu_offset
-                type_die = CU.get_DIE_from_refaddr(abs_off)
-            else:
-                break
-
-        size_attr = type_die.attributes.get("DW_AT_byte_size")
-        return int(size_attr.value) if size_attr else 0
-    except Exception:  # noqa: BLE001
-        return 0
+    v = member_die.attributes["DW_AT_data_member_location"].value
+    if isinstance(v, int):
+        return v
+    # Location expression: list of DWARFExprOp
+    if isinstance(v, list) and len(v) == 1:
+        op = v[0]
+        # DW_OP_plus_uconst (0x23) or DW_OP_constu (0x10) carry offset in args[0]
+        if hasattr(op, "op") and op.op in (0x23, 0x10) and op.args:
+            try:
+                return int(op.args[0])
+            except (TypeError, ValueError):
+                pass
+    # Multi-op expressions or unknown forms: cannot determine offset reliably
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -494,9 +490,11 @@ def diff_advanced_dwarf(
             f"Struct packing removed: {name} was packed, now standard layout",
             "packed", "standard",
         ))
-    # "Packing added" is reported unconditionally: a newly packed struct in new binary
-    # is a layout break regardless of whether the struct is new or existing.
-    for name in sorted(new_meta.packed_structs - old_meta.packed_structs):
+    # "Packing added": only report when struct existed in old binary too.
+    # A brand-new packed struct has no prior ABI contract to break — consistent
+    # with how calling-convention additions are handled (new-only functions skipped).
+    # Symmetric with packing-removed guard above.
+    for name in sorted((new_meta.packed_structs - old_meta.packed_structs) & old_meta.all_struct_names):
         results.append((
             "struct_packing_changed", name,
             f"Struct packing added: {name} is now __attribute__((packed))",

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -103,11 +103,17 @@ class AdvancedDwarfMetadata:
     """Sprint 4 metadata extracted from a single .so."""
     has_dwarf: bool = False
     toolchain: ToolchainInfo = field(default_factory=ToolchainInfo)
-    # function_name → CC string (only non-"normal" entries stored)
-    # NOTE: on Linux x86-64, this dict is typically empty (DW_CC_normal implicit)
+    # linkage_name (mangled) → CC string for ALL externally-visible functions visited.
+    # Storing "normal" explicitly lets the diff distinguish "became normal" from
+    # "function was removed/added" (sparse dict would conflate the two cases).
+    # NOTE: on Linux x86-64 this dict mostly contains "normal" entries since
+    # DW_AT_calling_convention is rarely emitted by GCC/Clang for System V AMD64.
     calling_conventions: dict[str, str] = field(default_factory=dict)
     # struct names where any field has a misaligned byte offset → __attribute__((packed))
     packed_structs: set[str] = field(default_factory=set)
+    # All struct/class names seen (for cross-referencing in diff to avoid
+    # false "packing removed" when a struct was simply deleted)
+    all_struct_names: set[str] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------
@@ -122,11 +128,11 @@ def parse_advanced_dwarf(so_path: Path) -> AdvancedDwarfMetadata:
     """
     try:
         with open(so_path, "rb") as f:
-            elf = ELFFile(f)
-            if not elf.has_dwarf_info():
+            elf = ELFFile(f)  # type: ignore[no-untyped-call]
+            if not elf.has_dwarf_info():  # type: ignore[no-untyped-call]
                 return AdvancedDwarfMetadata()
             meta = AdvancedDwarfMetadata(has_dwarf=True)
-            dwarf = elf.get_dwarf_info()
+            dwarf = elf.get_dwarf_info()  # type: ignore[no-untyped-call]
             for CU in dwarf.iter_CUs():
                 try:
                     _process_cu(CU, meta)
@@ -154,6 +160,69 @@ def _process_cu(CU: Any, meta: AdvancedDwarfMetadata) -> None:
     _walk_cu(top, meta, CU)
 
 
+def _get_type_align(member_die: Any, CU: Any) -> int:
+    """Return the natural alignment of a member's type in bytes.
+
+    Strategy (in order):
+    1. DW_AT_alignment on the type DIE (DWARF 5 — authoritative)
+    2. DW_TAG_base_type / DW_TAG_pointer_type / DW_TAG_reference_type:
+       alignment == byte_size (primitive / pointer).
+    3. Everything else (struct, array, typedef chain, etc.): return 0 to skip.
+       We must not use byte_size as a proxy for alignment of composite types —
+       a struct { int a; char b; } is size=8 but alignment=4.
+
+    Returns 0 when alignment cannot be determined reliably (caller should skip).
+    """
+    if "DW_AT_type" not in member_die.attributes:
+        return 0
+    try:
+        attr = member_die.attributes["DW_AT_type"]
+        form = attr.form
+        raw: int = attr.value
+        abs_offset = raw if form == "DW_FORM_ref_addr" else raw + CU.cu_offset
+        type_die = CU.get_DIE_from_refaddr(abs_offset)
+
+        # Follow transparent wrapper tags (typedef / const / volatile / restrict)
+        for _ in range(4):
+            tag = type_die.tag
+            if tag in (
+                "DW_TAG_typedef",
+                "DW_TAG_const_type",
+                "DW_TAG_volatile_type",
+                "DW_TAG_restrict_type",
+            ):
+                if "DW_AT_type" not in type_die.attributes:
+                    return 0
+                a = type_die.attributes["DW_AT_type"]
+                r: int = a.value
+                abs_off = r if a.form == "DW_FORM_ref_addr" else r + CU.cu_offset
+                type_die = CU.get_DIE_from_refaddr(abs_off)
+            else:
+                break
+
+        # 1. DW_AT_alignment present on the resolved type (DWARF 5)
+        if "DW_AT_alignment" in type_die.attributes:
+            return int(type_die.attributes["DW_AT_alignment"].value)
+
+        # 2. Primitive types: alignment == byte_size
+        prim_tags = (
+            "DW_TAG_base_type",
+            "DW_TAG_pointer_type",
+            "DW_TAG_reference_type",
+            "DW_TAG_rvalue_reference_type",
+        )
+        if type_die.tag in prim_tags:
+            sz_attr = type_die.attributes.get("DW_AT_byte_size")
+            if sz_attr:
+                sz = int(sz_attr.value)
+                return _NATURAL_ALIGN.get(min(sz, 16), 1)
+
+        # 3. Composite / array / enum etc.: cannot infer alignment from size
+        return 0
+    except Exception:  # noqa: BLE001
+        return 0
+
+
 def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
     """Iterative depth-first DIE walk.
 
@@ -178,6 +247,10 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
             continue
 
         if tag in ("DW_TAG_structure_type", "DW_TAG_class_type"):
+            # Register name in all_struct_names even when not packed
+            sname = _attr_str(die, "DW_AT_name")
+            if sname:
+                meta.all_struct_names.add(sname)
             _check_packed(die, meta, CU, override_name=None)
 
         elif tag == "DW_TAG_typedef":
@@ -194,24 +267,38 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
 # ---------------------------------------------------------------------------
 
 def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata) -> None:
-    """Record non-default calling conventions for ABI-exported functions.
+    """Record calling conventions for ABI-exported functions.
+
+    Key: DW_AT_linkage_name (mangled), falling back to DW_AT_MIPS_linkage_name,
+    then DW_AT_name. Using the mangled name avoids collisions on overloaded C++
+    functions that share a DW_AT_name but differ in signature.
+
+    ALL externally-visible functions are recorded (including those with "normal"
+    calling convention). This lets diff_advanced_dwarf distinguish between
+    "CC became normal" and "function was added/removed" without a secondary
+    ELF symbol lookup.
 
     On Linux x86-64 (System V AMD64), GCC/Clang rarely emit DW_AT_calling_convention
-    (it defaults to DW_CC_normal which is omitted). This detector is most relevant
-    for Windows __stdcall/__fastcall or embedded targets.
+    (it defaults to DW_CC_normal which is omitted). This detector is most useful
+    for Windows (__stdcall/__cdecl mixed) and embedded targets.
     """
-    name = _attr_str(die, "DW_AT_name")
-    if not name:
-        return
     # Only externally-visible functions matter for ABI surface
     if not _attr_bool(die, "DW_AT_external"):
         return
-    if "DW_AT_calling_convention" not in die.attributes:
+    # Prefer mangled linkage name for C++ overload uniqueness
+    key = (
+        _attr_str(die, "DW_AT_linkage_name")
+        or _attr_str(die, "DW_AT_MIPS_linkage_name")
+        or _attr_str(die, "DW_AT_name")
+    )
+    if not key:
         return
-    raw = die.attributes["DW_AT_calling_convention"].value
-    cc_name = _CC_NAMES.get(int(raw), f"unknown(0x{int(raw):02x})")
-    if cc_name != "normal":
-        meta.calling_conventions[name] = cc_name
+    if "DW_AT_calling_convention" in die.attributes:
+        raw = die.attributes["DW_AT_calling_convention"].value
+        cc_name = _CC_NAMES.get(int(raw), f"unknown(0x{int(raw):02x})")
+    else:
+        cc_name = "normal"
+    meta.calling_conventions[key] = cc_name
 
 
 # ---------------------------------------------------------------------------
@@ -254,9 +341,10 @@ def _check_packed(
 ) -> None:
     """Detect if struct has misaligned fields → __attribute__((packed)).
 
-    Resolves DW_AT_type on each member to get the type's byte size,
-    then checks if the field offset is aligned to that size.
-    A single misaligned field is sufficient to classify the struct as packed.
+    Uses _get_type_align() to resolve the natural alignment of each member's type.
+    This correctly handles primitive types (alignment == size) while skipping
+    composite types where size != alignment (e.g. struct{int,char} is size=8, align=4).
+    A single misaligned primitive field is sufficient to classify the struct as packed.
     """
     name = override_name or _attr_str(die, "DW_AT_name")
     if not name:
@@ -264,6 +352,8 @@ def _check_packed(
     byte_size = _attr_int(die, "DW_AT_byte_size")
     if byte_size == 0:
         return  # forward declaration only
+
+    meta.all_struct_names.add(name)
 
     for child in die.iter_children():
         if child.tag != "DW_TAG_member":
@@ -277,15 +367,14 @@ def _check_packed(
             v = child.attributes["DW_AT_data_member_location"].value
             offset = v if isinstance(v, int) else (int(v[-1]) if v else 0)
 
-        # Get field SIZE by following DW_AT_type to the type DIE
-        field_size = _get_type_byte_size(child, CU)
-        if field_size <= 1:
-            continue  # char/bool: always naturally aligned
+        # Get natural alignment via type tag (NOT byte_size of composite types)
+        natural = _get_type_align(child, CU)
+        if natural <= 1:
+            continue  # char/bool/unknown composite: cannot determine — skip
 
-        natural = _NATURAL_ALIGN.get(min(field_size, 16), 1)
-        if natural > 1 and offset % natural != 0:
-            log.debug("packed struct detected: %s field at offset %d (size %d, align %d)",
-                      name, offset, field_size, natural)
+        if offset % natural != 0:
+            log.debug("packed struct detected: %s field at offset %d (natural align %d)",
+                      name, offset, natural)
             meta.packed_structs.add(name)
             return  # one misaligned field is sufficient
 
@@ -376,30 +465,37 @@ def diff_advanced_dwarf(
 
     results: list[tuple[str, str, str, str | None, str | None]] = []
 
-    # 1. Calling convention drift
-    for fname, old_cc in old_meta.calling_conventions.items():
-        new_cc = new_meta.calling_conventions.get(fname, "normal")
+    # 1. Calling convention drift.
+    # calling_conventions now stores ALL external functions (including "normal"),
+    # so we can distinguish "CC changed" from "function added/removed".
+    # Functions present only in old → removed (handled by ELF checker, skip here).
+    # Functions present only in new → added (skip; new additions are COMPATIBLE by default).
+    # Functions present in both → compare CC values.
+    old_cc_keys = set(old_meta.calling_conventions)
+    new_cc_keys = set(new_meta.calling_conventions)
+    for fname in sorted(old_cc_keys & new_cc_keys):
+        old_cc = old_meta.calling_conventions[fname]
+        new_cc = new_meta.calling_conventions[fname]
         if old_cc != new_cc:
             results.append((
                 "calling_convention_changed", fname,
                 f"Calling convention changed: {fname} ({old_cc} → {new_cc})",
                 old_cc, new_cc,
             ))
-    for fname, new_cc in new_meta.calling_conventions.items():
-        if fname not in old_meta.calling_conventions:
-            results.append((
-                "calling_convention_changed", fname,
-                f"Calling convention changed: {fname} (normal → {new_cc})",
-                "normal", new_cc,
-            ))
 
-    # 2. Struct packing drift
-    for name in sorted(old_meta.packed_structs - new_meta.packed_structs):
+    # 2. Struct packing drift.
+    # Use all_struct_names to guard against false "packing removed" reports when
+    # the struct itself was deleted (deletion is detected by the AST/ELF checker).
+    # Guard: only report "packing removed" when struct exists in BOTH binaries.
+    both_struct_names = old_meta.all_struct_names & new_meta.all_struct_names
+    for name in sorted((old_meta.packed_structs - new_meta.packed_structs) & both_struct_names):
         results.append((
             "struct_packing_changed", name,
             f"Struct packing removed: {name} was packed, now standard layout",
             "packed", "standard",
         ))
+    # "Packing added" is reported unconditionally: a newly packed struct in new binary
+    # is a layout break regardless of whether the struct is new or existing.
     for name in sorted(new_meta.packed_structs - old_meta.packed_structs):
         results.append((
             "struct_packing_changed", name,

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -1,14 +1,26 @@
 """Sprint 4: Advanced DWARF analysis.
 
 Detects:
-1. Calling convention changes (DW_AT_calling_convention on functions/methods)
-2. Struct packing drift (__attribute__((packed)) — detected via DWARF field offsets
-   vs natural alignment: if any field is at a non-aligned offset, struct is packed)
+1. Calling convention changes (DW_AT_calling_convention on exported functions)
+2. Struct packing drift (__attribute__((packed)) — via DWARF field offsets vs
+   natural alignment of the *type* byte size, properly resolved via DW_AT_type)
 3. Toolchain flag drift via DW_AT_producer parsing
-   (-fshort-enums, -fpack-struct, -fno-common, toolchain version change)
-4. typeinfo / vtable symbol visibility changes (ELF .dynsym cross-check)
+   (-fshort-enums, -fpack-struct, -fno-common, -m32/-m64, -mabi=*, etc.)
 
-All functions return [] gracefully when DWARF is absent.
+Design notes:
+- Single iterative DWARF walk per binary (deque-based, no recursion)
+- DW_AT_type is resolved for member size — fixes false-negative in packed detection
+- Imports at module level (style consistency with Sprint 3)
+- Specific exception handling: ELFError/OSError/ValueError; re-raises others
+- "First CU wins" for DW_AT_producer (acceptable: ABI flags uniform across TUs
+  in well-formed libraries; divergence is logged at WARNING level)
+
+Coverage note:
+  DW_AT_calling_convention is rarely emitted on Linux x86-64 (System V AMD64 ABI
+  uses a single implicit calling convention). This detector is most useful for
+  Windows (__stdcall/__cdecl mixed libraries) and embedded targets.
+  The toolchain flag detector (DW_AT_producer) provides broader coverage for
+  ABI-flag drift on Linux.
 """
 from __future__ import annotations
 
@@ -19,17 +31,22 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
+
 log = logging.getLogger(__name__)
 
-# DW_AT_calling_convention values (DWARF standard)
+# DW_AT_calling_convention values (DWARF 5 standard + vendor extensions)
 _CC_NAMES: dict[int, str] = {
     0x01: "normal",
     0x02: "program",
     0x03: "nocall",
-    0x04: "pass_by_reference",   # DWARF 5
-    0x05: "pass_by_value",       # DWARF 5
+    0x04: "pass_by_reference",      # DWARF 5
+    0x05: "pass_by_value",          # DWARF 5
     0x40: "GNU_renesas_sh",
     0x41: "GNU_borland_fastcall_i386",
+    0x80: "GNU_push_call_stub",     # GCC internal
+    0x81: "GNU_push_arg",           # GCC internal
     0xb0: "BORLAND_safecall",
     0xb1: "BORLAND_stdcall",
     0xb2: "BORLAND_pascal",
@@ -37,6 +54,7 @@ _CC_NAMES: dict[int, str] = {
     0xb4: "BORLAND_msreturn",
     0xb5: "BORLAND_thiscall",
     0xb6: "BORLAND_fastcall",
+    0xb9: "LLVM_PreserveMost",
     0xd0: "LLVM_vectorcall",
 }
 
@@ -56,13 +74,27 @@ _ABI_FLAGS_RE = re.compile(
     re.VERBOSE,
 )
 
+# Natural alignment (bytes) by type size on most LP64 platforms
+_NATURAL_ALIGN: dict[int, int] = {1: 1, 2: 2, 4: 4, 8: 8, 16: 16}
+
+# Tags to prune: don't descend into function bodies or inlined frames
+_PRUNE_TAGS: frozenset[str] = frozenset({
+    "DW_TAG_lexical_block",
+    "DW_TAG_inlined_subroutine",
+    "DW_TAG_GNU_call_site",
+})
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
 
 @dataclass
 class ToolchainInfo:
     """Parsed DW_AT_producer metadata from a binary."""
-    producer_string: str = ""           # raw DW_AT_producer value
-    compiler: str = ""                  # e.g. "GCC", "clang", "ICC"
-    version: str = ""                   # e.g. "13.2.1"
+    producer_string: str = ""       # raw DW_AT_producer value
+    compiler: str = ""              # "GCC", "clang", "ICC"
+    version: str = ""               # e.g. "13.2.1"
     abi_flags: set[str] = field(default_factory=set)  # extracted ABI-affecting flags
 
 
@@ -71,9 +103,10 @@ class AdvancedDwarfMetadata:
     """Sprint 4 metadata extracted from a single .so."""
     has_dwarf: bool = False
     toolchain: ToolchainInfo = field(default_factory=ToolchainInfo)
-    # function_name → calling_convention string (only non-"normal" entries)
+    # function_name → CC string (only non-"normal" entries stored)
+    # NOTE: on Linux x86-64, this dict is typically empty (DW_CC_normal implicit)
     calling_conventions: dict[str, str] = field(default_factory=dict)
-    # struct_name → True if detected as packed (any misaligned field)
+    # struct names where any field has a misaligned byte offset → __attribute__((packed))
     packed_structs: set[str] = field(default_factory=set)
 
 
@@ -88,7 +121,6 @@ def parse_advanced_dwarf(so_path: Path) -> AdvancedDwarfMetadata:
     debug info or cannot be parsed. Never raises.
     """
     try:
-        from elftools.elf.elffile import ELFFile
         with open(so_path, "rb") as f:
             elf = ELFFile(f)
             if not elf.has_dwarf_info():
@@ -98,52 +130,62 @@ def parse_advanced_dwarf(so_path: Path) -> AdvancedDwarfMetadata:
             for CU in dwarf.iter_CUs():
                 try:
                     _process_cu(CU, meta)
-                except Exception as exc:  # noqa: BLE001
+                except (ELFError, OSError, ValueError, KeyError) as exc:
                     log.warning("parse_advanced_dwarf: skipping CU: %s", exc)
             return meta
-    except Exception as exc:  # noqa: BLE001
+    except (ELFError, OSError, ValueError) as exc:
         log.warning("parse_advanced_dwarf: failed %s: %s", so_path, exc)
         return AdvancedDwarfMetadata()
 
 
 # ---------------------------------------------------------------------------
-# Internal: CU processing
+# Internal: per-CU processing
 # ---------------------------------------------------------------------------
 
 def _process_cu(CU: Any, meta: AdvancedDwarfMetadata) -> None:
     top = CU.get_top_DIE()
 
-    # Extract toolchain info from CU-level DW_AT_producer (first CU wins)
+    # Extract toolchain info from DW_AT_producer on the CU top DIE (first CU wins)
     if not meta.toolchain.producer_string:
         producer = _attr_str(top, "DW_AT_producer")
         if producer:
             meta.toolchain = _parse_producer(producer)
 
-    _walk_cu(top, meta)
+    _walk_cu(top, meta, CU)
 
 
-def _walk_cu(root: Any, meta: AdvancedDwarfMetadata) -> None:
-    """Iterative walk; extract calling_convention and packed struct info."""
-    _SKIP = frozenset({
-        "DW_TAG_lexical_block",
-        "DW_TAG_inlined_subroutine",
-        "DW_TAG_GNU_call_site",
-    })
+def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
+    """Iterative depth-first DIE walk.
+
+    Does NOT descend into DW_TAG_subprogram children — we only need the
+    subprogram DIE itself for calling convention. This halves traversal time
+    in function-heavy TUs. Packed struct check still needs struct member
+    children (handled directly in _check_packed).
+    """
     stack: collections.deque[Any] = collections.deque([root])
 
     while stack:
         die = stack.pop()
         tag = die.tag
 
-        if tag in _SKIP:
+        if tag in _PRUNE_TAGS:
             continue
 
         if tag in ("DW_TAG_subprogram", "DW_TAG_subroutine_type"):
             _extract_calling_convention(die, meta)
+            # Don't descend into subprogram children — not needed for CC extraction
+            # and avoids traversing all local variables, params, inlined calls
+            continue
 
         if tag in ("DW_TAG_structure_type", "DW_TAG_class_type"):
-            _check_packed(die, meta)
+            _check_packed(die, meta, CU, override_name=None)
 
+        elif tag == "DW_TAG_typedef":
+            # Anonymous struct typedef: `typedef struct {...} Name` — struct has no
+            # DW_AT_name; resolve the typedef target and check if it's a packed struct.
+            _check_packed_typedef(die, meta, CU)
+
+        # Push children in reverse order (DFS left-to-right)
         stack.extend(reversed(list(die.iter_children())))
 
 
@@ -152,11 +194,16 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata) -> None:
 # ---------------------------------------------------------------------------
 
 def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata) -> None:
-    """Record non-default calling conventions for ABI-exported functions."""
+    """Record non-default calling conventions for ABI-exported functions.
+
+    On Linux x86-64 (System V AMD64), GCC/Clang rarely emit DW_AT_calling_convention
+    (it defaults to DW_CC_normal which is omitted). This detector is most relevant
+    for Windows __stdcall/__fastcall or embedded targets.
+    """
     name = _attr_str(die, "DW_AT_name")
     if not name:
         return
-    # Only externally-visible functions matter
+    # Only externally-visible functions matter for ABI surface
     if not _attr_bool(die, "DW_AT_external"):
         return
     if "DW_AT_calling_convention" not in die.attributes:
@@ -171,53 +218,115 @@ def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata) -> None:
 # Packed struct detection
 # ---------------------------------------------------------------------------
 
-# Natural alignment of common DWARF base types by byte size
-_NATURAL_ALIGN: dict[int, int] = {
-    1: 1,
-    2: 2,
-    4: 4,
-    8: 8,
-    16: 16,
-}
+def _check_packed_typedef(die: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
+    """Handle `typedef struct __attribute__((packed)) {...} Name`.
+
+    In this pattern the struct itself is anonymous (no DW_AT_name); the typedef
+    provides the visible name. We resolve the target DIE and check packing
+    using the typedef name as the identifier.
+    """
+    typedef_name = _attr_str(die, "DW_AT_name")
+    if not typedef_name or "DW_AT_type" not in die.attributes:
+        return
+    try:
+        attr = die.attributes["DW_AT_type"]
+        raw: int = attr.value
+        abs_off = raw if attr.form == "DW_FORM_ref_addr" else raw + CU.cu_offset
+        target = CU.get_DIE_from_refaddr(abs_off)
+    except Exception:  # noqa: BLE001
+        return
+
+    tag = target.tag
+    if tag not in ("DW_TAG_structure_type", "DW_TAG_class_type"):
+        return
+    target_name = _attr_str(target, "DW_AT_name")
+    if target_name:
+        return  # named struct — will be registered under its own name
+
+    _check_packed(target, meta, CU, override_name=typedef_name)
 
 
-def _check_packed(die: Any, meta: AdvancedDwarfMetadata) -> None:
-    """Detect if struct has any fields at misaligned offsets → packed."""
-    name = _attr_str(die, "DW_AT_name")
+def _check_packed(
+    die: Any,
+    meta: AdvancedDwarfMetadata,
+    CU: Any,
+    override_name: str | None = None,
+) -> None:
+    """Detect if struct has misaligned fields → __attribute__((packed)).
+
+    Resolves DW_AT_type on each member to get the type's byte size,
+    then checks if the field offset is aligned to that size.
+    A single misaligned field is sufficient to classify the struct as packed.
+    """
+    name = override_name or _attr_str(die, "DW_AT_name")
     if not name:
         return
     byte_size = _attr_int(die, "DW_AT_byte_size")
     if byte_size == 0:
-        return  # forward declaration
+        return  # forward declaration only
 
     for child in die.iter_children():
         if child.tag != "DW_TAG_member":
             continue
         if _attr_int(child, "DW_AT_bit_size"):
-            continue  # bitfields always packed-like, skip
+            continue  # bitfields: skip (always "misaligned" by nature)
 
+        # Get byte offset of this field
         offset = 0
         if "DW_AT_data_member_location" in child.attributes:
             v = child.attributes["DW_AT_data_member_location"].value
             offset = v if isinstance(v, int) else (int(v[-1]) if v else 0)
 
-        # Get field byte size to determine natural alignment requirement
-        field_size = _get_member_size(child)
+        # Get field SIZE by following DW_AT_type to the type DIE
+        field_size = _get_type_byte_size(child, CU)
         if field_size <= 1:
-            continue  # char/byte: always aligned
+            continue  # char/bool: always naturally aligned
 
         natural = _NATURAL_ALIGN.get(min(field_size, 16), 1)
         if natural > 1 and offset % natural != 0:
+            log.debug("packed struct detected: %s field at offset %d (size %d, align %d)",
+                      name, offset, field_size, natural)
             meta.packed_structs.add(name)
-            return  # one misaligned field is enough
+            return  # one misaligned field is sufficient
 
 
-def _get_member_size(die: Any) -> int:
-    """Best-effort field size via DW_AT_byte_size on the referenced type."""
-    if "DW_AT_byte_size" in die.attributes:
-        return _attr_int(die, "DW_AT_byte_size")
-    # Could also resolve DW_AT_type, but keep it simple for now
-    return 0
+def _get_type_byte_size(member_die: Any, CU: Any) -> int:
+    """Resolve DW_AT_type from a member DIE and return DW_AT_byte_size.
+
+    Follows typedef chains up to depth 4. Returns 0 if resolution fails.
+    """
+    if "DW_AT_type" not in member_die.attributes:
+        return 0
+    try:
+        attr = member_die.attributes["DW_AT_type"]
+        form = attr.form
+        raw: int = attr.value
+        abs_offset = raw if form == "DW_FORM_ref_addr" else raw + CU.cu_offset
+        type_die = CU.get_DIE_from_refaddr(abs_offset)
+
+        # Follow typedef / const / volatile / restrict chains
+        for _ in range(4):
+            tag = type_die.tag
+            if tag in (
+                "DW_TAG_typedef",
+                "DW_TAG_const_type",
+                "DW_TAG_volatile_type",
+                "DW_TAG_restrict_type",
+            ):
+                if "DW_AT_type" not in type_die.attributes:
+                    return 0
+                a = type_die.attributes["DW_AT_type"]
+                f = a.form
+                r: int = a.value
+                abs_off = r if f == "DW_FORM_ref_addr" else r + CU.cu_offset
+                type_die = CU.get_DIE_from_refaddr(abs_off)
+            else:
+                break
+
+        size_attr = type_die.attributes.get("DW_AT_byte_size")
+        return int(size_attr.value) if size_attr else 0
+    except Exception:  # noqa: BLE001
+        return 0
 
 
 # ---------------------------------------------------------------------------
@@ -225,10 +334,9 @@ def _get_member_size(die: Any) -> int:
 # ---------------------------------------------------------------------------
 
 def _parse_producer(producer: str) -> ToolchainInfo:
-    """Parse the raw DW_AT_producer string into ToolchainInfo."""
+    """Parse raw DW_AT_producer string into ToolchainInfo."""
     info = ToolchainInfo(producer_string=producer)
 
-    # Detect compiler
     if "GCC" in producer or "GNU" in producer:
         info.compiler = "GCC"
         m = re.search(r"(\d+\.\d+(?:\.\d+)?)", producer)
@@ -245,7 +353,6 @@ def _parse_producer(producer: str) -> ToolchainInfo:
         if m:
             info.version = m.group(1)
 
-    # Extract ABI-affecting flags
     for m in _ABI_FLAGS_RE.finditer(producer):
         info.abi_flags.add(m.group(0))
 
@@ -253,63 +360,51 @@ def _parse_producer(producer: str) -> ToolchainInfo:
 
 
 # ---------------------------------------------------------------------------
-# Diff functions (called from checker.py)
+# Diff (called from checker.py _diff_advanced_dwarf)
 # ---------------------------------------------------------------------------
 
 def diff_advanced_dwarf(
     old_meta: AdvancedDwarfMetadata,
     new_meta: AdvancedDwarfMetadata,
 ) -> list[tuple[str, str, str, str | None, str | None]]:
-    """Return list of (kind, symbol, description, old_value, new_value) tuples.
+    """Return (kind, symbol, description, old_value, new_value) tuples.
 
-    Caller (checker.py) converts these to Change objects using ChangeKind.
-    Returns [] if either side has no DWARF.
+    Returns [] gracefully if either side has no DWARF.
     """
     if not old_meta.has_dwarf or not new_meta.has_dwarf:
         return []
 
     results: list[tuple[str, str, str, str | None, str | None]] = []
 
-    # 1. Calling convention changes
+    # 1. Calling convention drift
     for fname, old_cc in old_meta.calling_conventions.items():
         new_cc = new_meta.calling_conventions.get(fname, "normal")
         if old_cc != new_cc:
             results.append((
-                "calling_convention_changed",
-                fname,
+                "calling_convention_changed", fname,
                 f"Calling convention changed: {fname} ({old_cc} → {new_cc})",
-                old_cc,
-                new_cc,
+                old_cc, new_cc,
             ))
     for fname, new_cc in new_meta.calling_conventions.items():
         if fname not in old_meta.calling_conventions:
-            # Was 'normal' (default), now explicit non-normal
             results.append((
-                "calling_convention_changed",
-                fname,
+                "calling_convention_changed", fname,
                 f"Calling convention changed: {fname} (normal → {new_cc})",
-                "normal",
-                new_cc,
+                "normal", new_cc,
             ))
 
-    # 2. Packing changes (packed ↔ unpacked)
-    old_packed = old_meta.packed_structs
-    new_packed = new_meta.packed_structs
-    for name in sorted(old_packed - new_packed):
+    # 2. Struct packing drift
+    for name in sorted(old_meta.packed_structs - new_meta.packed_structs):
         results.append((
-            "struct_packing_changed",
-            name,
+            "struct_packing_changed", name,
             f"Struct packing removed: {name} was packed, now standard layout",
-            "packed",
-            "standard",
+            "packed", "standard",
         ))
-    for name in sorted(new_packed - old_packed):
+    for name in sorted(new_meta.packed_structs - old_meta.packed_structs):
         results.append((
-            "struct_packing_changed",
-            name,
-            f"Struct packing added: {name} is now packed (__attribute__((packed)))",
-            "standard",
-            "packed",
+            "struct_packing_changed", name,
+            f"Struct packing added: {name} is now __attribute__((packed))",
+            "standard", "packed",
         ))
 
     # 3. Toolchain ABI flag drift
@@ -318,15 +413,14 @@ def diff_advanced_dwarf(
     removed_flags = old_flags - new_flags
     added_flags = new_flags - old_flags
     if removed_flags or added_flags:
-        desc_parts = []
+        parts = []
         if added_flags:
-            desc_parts.append(f"added: {', '.join(sorted(added_flags))}")
+            parts.append(f"added: {', '.join(sorted(added_flags))}")
         if removed_flags:
-            desc_parts.append(f"removed: {', '.join(sorted(removed_flags))}")
+            parts.append(f"removed: {', '.join(sorted(removed_flags))}")
         results.append((
-            "toolchain_flag_drift",
-            "<toolchain>",
-            f"ABI-affecting compiler flags changed: {'; '.join(desc_parts)}",
+            "toolchain_flag_drift", "<toolchain>",
+            f"ABI-affecting compiler flags changed: {'; '.join(parts)}",
             ",".join(sorted(old_flags)) or None,
             ",".join(sorted(new_flags)) or None,
         ))
@@ -360,5 +454,4 @@ def _attr_int(die: Any, attr: str) -> int:
 def _attr_bool(die: Any, attr: str) -> bool:
     if attr not in die.attributes:
         return False
-    val = die.attributes[attr].value
-    return bool(val)
+    return bool(die.attributes[attr].value)

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .elf_metadata import ElfMetadata
 
@@ -104,7 +105,8 @@ class AbiSnapshot:
     variables: list[Variable] = field(default_factory=list)
     types: list[RecordType] = field(default_factory=list)
     elf: ElfMetadata | None = field(default=None)    # ELF dynamic/symbol metadata (Sprint 2)
-    dwarf: DwarfMetadata | None = field(default=None)  # DWARF layout metadata (Sprint 3)
+    dwarf: DwarfMetadata | None = field(default=None)           # DWARF layout metadata (Sprint 3)
+    dwarf_advanced: AdvancedDwarfMetadata | None = field(default=None)  # Sprint 4
     enums: list[EnumType] = field(default_factory=list)
     typedefs: dict[str, str] = field(default_factory=dict)  # alias -> underlying type name
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -19,6 +19,21 @@ from .model import (
 )
 
 
+def _sets_to_lists(obj: Any) -> Any:
+    """Recursively convert any set to a sorted list for JSON serialization.
+
+    dataclasses.asdict() does NOT convert set → list, so json.dumps() would
+    raise TypeError. This post-processes the entire dict tree.
+    """
+    if isinstance(obj, set):
+        return sorted(obj)
+    if isinstance(obj, dict):
+        return {k: _sets_to_lists(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sets_to_lists(v) for v in obj]
+    return obj
+
+
 def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     # Reset cache fields to None before asdict() to prevent double-serialization.
     snap._func_by_mangled = None
@@ -28,6 +43,7 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     d.pop("_func_by_mangled", None)
     d.pop("_var_by_mangled", None)
     d.pop("_type_by_name", None)
+
     # Serialize ElfMetadata enums to strings for JSON compatibility
     if d.get("elf"):
         elf = d["elf"]
@@ -35,16 +51,10 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
             sym["binding"]  = sym["binding"] if isinstance(sym["binding"], str) else sym["binding"].value
             sym["sym_type"] = sym["sym_type"] if isinstance(sym["sym_type"], str) else sym["sym_type"].value
 
-    # Advanced DWARF contains sets → convert to sorted lists for JSON
-    if d.get("dwarf_advanced"):
-        da = d["dwarf_advanced"]
-        if isinstance(da.get("packed_structs"), set):
-            da["packed_structs"] = sorted(da["packed_structs"])
-        toolchain = da.get("toolchain")
-        if isinstance(toolchain, dict) and isinstance(toolchain.get("abi_flags"), set):
-            toolchain["abi_flags"] = sorted(toolchain["abi_flags"])
-
-    return d
+    # Convert all sets → sorted lists (needed for AdvancedDwarfMetadata.packed_structs
+    # and ToolchainInfo.abi_flags; json.dumps raises TypeError on set objects)
+    converted: dict[str, Any] = _sets_to_lists(d)
+    return converted
 
 
 def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -34,6 +34,16 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
         for sym in elf.get("symbols", []):
             sym["binding"]  = sym["binding"] if isinstance(sym["binding"], str) else sym["binding"].value
             sym["sym_type"] = sym["sym_type"] if isinstance(sym["sym_type"], str) else sym["sym_type"].value
+
+    # Advanced DWARF contains sets → convert to sorted lists for JSON
+    if d.get("dwarf_advanced"):
+        da = d["dwarf_advanced"]
+        if isinstance(da.get("packed_structs"), set):
+            da["packed_structs"] = sorted(da["packed_structs"])
+        toolchain = da.get("toolchain")
+        if isinstance(toolchain, dict) and isinstance(toolchain.get("abi_flags"), set):
+            toolchain["abi_flags"] = sorted(toolchain["abi_flags"])
+
     return d
 
 
@@ -59,6 +69,7 @@ def _elf_from_dict(e: dict[str, Any]) -> Any:
             size=s.get("size", 0),
             version=s.get("version", ""),
             is_default=s.get("is_default", True),
+            visibility=s.get("visibility", "default"),
         )
         for s in e.get("symbols", [])
     ]
@@ -70,6 +81,64 @@ def _elf_from_dict(e: dict[str, Any]) -> Any:
         versions_defined=e.get("versions_defined", []),
         versions_required=e.get("versions_required", {}),
         symbols=syms,
+    )
+
+
+def _dwarf_from_dict(d: dict[str, Any]) -> Any:
+    from .dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
+
+    structs = {
+        name: StructLayout(
+            name=s.get("name", name),
+            byte_size=s.get("byte_size", 0),
+            alignment=s.get("alignment", 0),
+            fields=[
+                FieldInfo(
+                    name=f.get("name", ""),
+                    type_name=f.get("type_name", "unknown"),
+                    byte_offset=f.get("byte_offset", 0),
+                    byte_size=f.get("byte_size", 0),
+                    bit_offset=f.get("bit_offset", 0),
+                    bit_size=f.get("bit_size", 0),
+                )
+                for f in s.get("fields", [])
+            ],
+            is_union=s.get("is_union", False),
+        )
+        for name, s in d.get("structs", {}).items()
+    }
+
+    enums = {
+        name: EnumInfo(
+            name=e.get("name", name),
+            underlying_byte_size=e.get("underlying_byte_size", 0),
+            members=e.get("members", {}),
+        )
+        for name, e in d.get("enums", {}).items()
+    }
+
+    return DwarfMetadata(
+        structs=structs,
+        enums=enums,
+        has_dwarf=d.get("has_dwarf", False),
+    )
+
+
+def _dwarf_advanced_from_dict(d: dict[str, Any]) -> Any:
+    from .dwarf_advanced import AdvancedDwarfMetadata, ToolchainInfo
+
+    tc = d.get("toolchain", {})
+    toolchain = ToolchainInfo(
+        producer_string=tc.get("producer_string", ""),
+        compiler=tc.get("compiler", ""),
+        version=tc.get("version", ""),
+        abi_flags=set(tc.get("abi_flags", [])),
+    )
+    return AdvancedDwarfMetadata(
+        has_dwarf=d.get("has_dwarf", False),
+        toolchain=toolchain,
+        calling_conventions=d.get("calling_conventions", {}),
+        packed_structs=set(d.get("packed_structs", [])),
     )
 
 
@@ -122,11 +191,22 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     enums = [_enum_type_from_dict(e) for e in d.get("enums", [])]
     typedefs: dict[str, str] = d.get("typedefs", {})
     elf_data = d.get("elf")
+    dwarf_data = d.get("dwarf")
+    dwarf_adv_data = d.get("dwarf_advanced")
+
     elf = _elf_from_dict(elf_data) if isinstance(elf_data, dict) else None
+    dwarf = _dwarf_from_dict(dwarf_data) if isinstance(dwarf_data, dict) else None
+    dwarf_advanced = (
+        _dwarf_advanced_from_dict(dwarf_adv_data)
+        if isinstance(dwarf_adv_data, dict)
+        else None
+    )
+
     return AbiSnapshot(
         library=d["library"], version=d["version"],
         functions=funcs, variables=variables, types=types,
-        enums=enums, typedefs=typedefs, elf=elf,
+        enums=enums, typedefs=typedefs,
+        elf=elf, dwarf=dwarf, dwarf_advanced=dwarf_advanced,
     )
 
 

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -53,9 +53,9 @@ CASES = [
     ("case16_inline_to_non_inline", "COMPATIBLE", "v1.hpp",   "v2.hpp"),
     # ✅ Explicit-instantiated template size grows → TYPE_SIZE_CHANGED → BREAKING
     ("case17_template_abi",         "BREAKING",   "v1.hpp",   "v2.hpp"),
-    # ⚠️ Third-party struct is anonymous typedef; parse_types skips anonymous types
-    #    → transitive ABI leak not detected → NO_CHANGE (known gap, needs typedef resolution)
-    ("case18_dependency_leak",      "NO_CHANGE",  "foo_v1.h", "foo_v2.h"),
+    # ✅ castxml processes headers transitively: ThirdPartyHandle (4→8 bytes) detected
+    #    via TYPE_SIZE_CHANGED → BREAKING. This is correct behaviour — the struct grew.
+    ("case18_dependency_leak",      "BREAKING",   "foo_v1.h", "foo_v2.h"),
 ]
 
 

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -129,12 +129,23 @@ def test_calling_convention_unchanged_no_change() -> None:
 # ── struct packing ────────────────────────────────────────────────────────────
 
 def test_struct_packing_added() -> None:
-    old = _snap(_adv(packed=set()))
+    # "Ctx" must exist in old all_struct_names so diff knows it's a pre-existing
+    # struct that became packed (not a brand-new packed struct, which has no ABI contract).
+    old = _snap(_adv(packed=set(), all_structs={"Ctx"}))
     new = _snap(_adv(packed={"Ctx"}))
     r = compare(old, new)
     kinds = {c.kind for c in r.changes}
     assert ChangeKind.STRUCT_PACKING_CHANGED in kinds
     assert r.verdict == Verdict.BREAKING
+
+
+def test_struct_packing_added_new_struct_no_report() -> None:
+    """Brand-new packed struct (not in old binary) should NOT report packing change."""
+    old = _snap(_adv(packed=set()))           # "Ctx" never existed in old
+    new = _snap(_adv(packed={"Ctx"}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.STRUCT_PACKING_CHANGED not in kinds
 
 
 def test_struct_packing_removed() -> None:

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -1,15 +1,29 @@
 """Sprint 4 tests: advanced DWARF detectors (calling convention, packing, toolchain drift)."""
 from __future__ import annotations
 
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
 from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.dwarf_advanced import (
     AdvancedDwarfMetadata,
     ToolchainInfo,
+    _parse_producer,
     diff_advanced_dwarf,
+    parse_advanced_dwarf,
 )
 from abicheck.model import AbiSnapshot
-from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
+from abicheck.serialization import (
+    snapshot_from_dict,
+    snapshot_to_dict,
+    snapshot_to_json,
+)
 
+# ── helpers ──────────────────────────────────────────────────────────────────
 
 def _snap(adv: AdvancedDwarfMetadata | None) -> AbiSnapshot:
     s = AbiSnapshot(library="libx.so", version="v")
@@ -37,11 +51,21 @@ def _adv(
     )
 
 
+# ── graceful degradation ──────────────────────────────────────────────────────
+
 def test_diff_advanced_dwarf_no_dwarf() -> None:
     old = _adv(has_dwarf=False)
     new = _adv(has_dwarf=True)
     assert diff_advanced_dwarf(old, new) == []
 
+
+def test_diff_both_no_dwarf() -> None:
+    old = _adv(has_dwarf=False)
+    new = _adv(has_dwarf=False)
+    assert diff_advanced_dwarf(old, new) == []
+
+
+# ── calling convention ────────────────────────────────────────────────────────
 
 def test_calling_convention_changed() -> None:
     old = _snap(_adv(calling={"foo": "program"}))
@@ -56,10 +80,46 @@ def test_calling_convention_added_non_default() -> None:
     old = _snap(_adv(calling={}))
     new = _snap(_adv(calling={"foo": "LLVM_vectorcall"}))
     r = compare(old, new)
-    assert any(c.kind == ChangeKind.CALLING_CONVENTION_CHANGED for c in r.changes)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.CALLING_CONVENTION_CHANGED in kinds
 
 
-def test_struct_packing_changed() -> None:
+def test_calling_convention_between_non_defaults() -> None:
+    """Changed from one non-normal CC to another."""
+    results = diff_advanced_dwarf(
+        _adv(calling={"bar": "program"}),
+        _adv(calling={"bar": "LLVM_vectorcall"}),
+    )
+    assert len(results) == 1
+    assert results[0][0] == "calling_convention_changed"
+    assert results[0][1] == "bar"
+    assert results[0][3] == "program"
+    assert results[0][4] == "LLVM_vectorcall"
+
+
+def test_calling_convention_removed() -> None:
+    """Non-default CC dropped back to normal."""
+    results = diff_advanced_dwarf(
+        _adv(calling={"foo": "BORLAND_stdcall"}),
+        _adv(calling={}),
+    )
+    assert len(results) == 1
+    assert results[0][0] == "calling_convention_changed"
+    assert results[0][3] == "BORLAND_stdcall"
+    assert results[0][4] == "normal"
+
+
+def test_calling_convention_unchanged_no_change() -> None:
+    results = diff_advanced_dwarf(
+        _adv(calling={"f": "program"}),
+        _adv(calling={"f": "program"}),
+    )
+    assert results == []
+
+
+# ── struct packing ────────────────────────────────────────────────────────────
+
+def test_struct_packing_added() -> None:
     old = _snap(_adv(packed=set()))
     new = _snap(_adv(packed={"Ctx"}))
     r = compare(old, new)
@@ -68,26 +128,164 @@ def test_struct_packing_changed() -> None:
     assert r.verdict == Verdict.BREAKING
 
 
-def test_toolchain_flag_drift_warning_compatible() -> None:
+def test_struct_packing_removed() -> None:
+    """packed→unpacked is also a breaking layout change."""
+    old = _snap(_adv(packed={"Hdr"}))
+    new = _snap(_adv(packed=set()))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.STRUCT_PACKING_CHANGED in kinds
+    assert r.verdict == Verdict.BREAKING
+
+
+def test_struct_packing_unchanged_no_change() -> None:
+    results = diff_advanced_dwarf(
+        _adv(packed={"A", "B"}),
+        _adv(packed={"A", "B"}),
+    )
+    assert not any(r[0] == "struct_packing_changed" for r in results)
+
+
+# ── toolchain flag drift ──────────────────────────────────────────────────────
+
+def test_toolchain_flag_added_compatible_warning() -> None:
     old = _snap(_adv(flags={"-fshort-enums"}))
     new = _snap(_adv(flags={"-fshort-enums", "-mabi=lp64"}))
     r = compare(old, new)
     kinds = {c.kind for c in r.changes}
     assert ChangeKind.TOOLCHAIN_FLAG_DRIFT in kinds
-    # informational warning only
-    assert r.verdict == Verdict.COMPATIBLE
+    # informational only — must NOT be BREAKING
+    assert r.verdict != Verdict.BREAKING
 
 
-def test_serialization_roundtrip_dwarf_advanced_sets() -> None:
+def test_toolchain_flag_removed() -> None:
+    results = diff_advanced_dwarf(
+        _adv(flags={"-fshort-enums", "-fno-common"}),
+        _adv(flags={"-fshort-enums"}),
+    )
+    flag_r = [r for r in results if r[0] == "toolchain_flag_drift"]
+    assert len(flag_r) == 1
+    assert "removed" in flag_r[0][2]
+
+
+def test_toolchain_no_drift_no_change() -> None:
+    results = diff_advanced_dwarf(
+        _adv(flags={"-fshort-enums"}),
+        _adv(flags={"-fshort-enums"}),
+    )
+    assert not any(r[0] == "toolchain_flag_drift" for r in results)
+
+
+# ── DW_AT_producer parsing ────────────────────────────────────────────────────
+
+def test_parse_producer_gcc() -> None:
+    info = _parse_producer("GNU C17 13.2.1 20230812 -fshort-enums -m64 -fabi-version=18")
+    assert info.compiler == "GCC"
+    assert info.version == "13.2.1"
+    assert "-fshort-enums" in info.abi_flags
+    assert "-m64" in info.abi_flags
+    assert "-fabi-version=18" in info.abi_flags
+
+
+def test_parse_producer_clang() -> None:
+    info = _parse_producer("clang version 17.0.0 -fpack-struct=4")
+    assert info.compiler == "clang"
+    assert "-fpack-struct=4" in info.abi_flags
+
+
+def test_parse_producer_icc() -> None:
+    info = _parse_producer("Intel(R) oneAPI DPC++/C++ Compiler 2024.0.0 -m64")
+    assert info.compiler == "ICC"
+    assert "-m64" in info.abi_flags
+
+
+def test_parse_producer_cxx11abi() -> None:
+    info = _parse_producer("GNU C++17 12.3 -D_GLIBCXX_USE_CXX11_ABI=0")
+    assert "-D_GLIBCXX_USE_CXX11_ABI=0" in info.abi_flags
+
+
+def test_parse_producer_no_flags() -> None:
+    info = _parse_producer("GNU C17 11.4.0")
+    assert info.compiler == "GCC"
+    assert info.abi_flags == set()
+
+
+# ── JSON serialization (set → list → set roundtrip) ──────────────────────────
+
+def test_serialization_roundtrip_no_crash() -> None:
+    """snapshot_to_json must not raise TypeError on set fields."""
+    snap = _snap(_adv(calling={"foo": "program"}, packed={"A", "B"}, flags={"-fshort-enums"}))
+    # This must not raise TypeError: Object of type set is not JSON serializable
+    json_str = snapshot_to_json(snap)
+    data = json.loads(json_str)
+    assert isinstance(data["dwarf_advanced"]["packed_structs"], list)
+    assert isinstance(data["dwarf_advanced"]["toolchain"]["abi_flags"], list)
+
+
+def test_serialization_roundtrip_set_values() -> None:
     snap = _snap(_adv(calling={"foo": "program"}, packed={"A", "B"}, flags={"-fshort-enums"}))
     d = snapshot_to_dict(snap)
-
-    # ensure JSON-safe conversion happened
-    assert isinstance(d["dwarf_advanced"]["packed_structs"], list)
-    assert isinstance(d["dwarf_advanced"]["toolchain"]["abi_flags"], list)
-
     snap2 = snapshot_from_dict(d)
     assert snap2.dwarf_advanced is not None
-    assert snap2.dwarf_advanced.calling_conventions.get("foo") == "program"
+    assert snap2.dwarf_advanced.calling_conventions == {"foo": "program"}
     assert snap2.dwarf_advanced.packed_structs == {"A", "B"}
     assert snap2.dwarf_advanced.toolchain.abi_flags == {"-fshort-enums"}
+
+
+def test_serialization_empty_sets_roundtrip() -> None:
+    snap = _snap(_adv())
+    json_str = snapshot_to_json(snap)
+    data = json.loads(json_str)
+    assert data["dwarf_advanced"]["packed_structs"] == []
+
+
+# ── Integration: real packed struct detection via DWARF ───────────────────────
+
+@pytest.mark.integration
+def test_packed_struct_detected_from_real_dwarf() -> None:
+    """Compile a packed struct with gcc -g and verify DWARF detection."""
+    src = """
+typedef struct __attribute__((packed)) {
+    char a;
+    int b;       /* misaligned: offset 1 (int needs align 4) */
+    double c;    /* misaligned: offset 5 */
+} PackedCtx;
+PackedCtx g_ctx;
+"""
+    with tempfile.TemporaryDirectory() as td:
+        so = Path(td) / "libpacked.so"
+        result = subprocess.run(
+            ["gcc", "-g", "-shared", "-fPIC", "-o", str(so), "-x", "c", "-"],
+            input=src.encode(), capture_output=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"gcc failed: {result.stderr.decode()[:200]}")
+
+        meta = parse_advanced_dwarf(so)
+
+    assert meta.has_dwarf
+    assert "PackedCtx" in meta.packed_structs, (
+        f"Expected 'PackedCtx' in packed_structs, got: {meta.packed_structs}"
+    )
+
+
+@pytest.mark.integration
+def test_standard_struct_not_flagged_as_packed() -> None:
+    """Standard-layout struct must NOT be flagged as packed."""
+    src = """
+typedef struct { int x; int y; double z; } NormalCtx;
+NormalCtx g;
+"""
+    with tempfile.TemporaryDirectory() as td:
+        so = Path(td) / "libnormal.so"
+        result = subprocess.run(
+            ["gcc", "-g", "-shared", "-fPIC", "-o", str(so), "-x", "c", "-"],
+            input=src.encode(), capture_output=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"gcc failed: {result.stderr.decode()[:200]}")
+
+        meta = parse_advanced_dwarf(so)
+
+    assert meta.has_dwarf
+    assert "NormalCtx" not in meta.packed_structs

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -37,7 +37,11 @@ def _adv(
     calling: dict[str, str] | None = None,
     packed: set[str] | None = None,
     flags: set[str] | None = None,
+    all_structs: set[str] | None = None,
 ) -> AdvancedDwarfMetadata:
+    packed_set = packed or set()
+    # all_struct_names must include packed structs so diff guards work correctly
+    struct_names = (all_structs or set()) | packed_set
     return AdvancedDwarfMetadata(
         has_dwarf=has_dwarf,
         toolchain=ToolchainInfo(
@@ -47,7 +51,8 @@ def _adv(
             abi_flags=flags or set(),
         ),
         calling_conventions=calling or {},
-        packed_structs=packed or set(),
+        packed_structs=packed_set,
+        all_struct_names=struct_names,
     )
 
 
@@ -77,7 +82,9 @@ def test_calling_convention_changed() -> None:
 
 
 def test_calling_convention_added_non_default() -> None:
-    old = _snap(_adv(calling={}))
+    # Both binaries have "foo" (present in both dicts); old is normal, new is vectorcall.
+    # With full-dict storage, "normal" must be explicit so diff knows foo existed in old.
+    old = _snap(_adv(calling={"foo": "normal"}))
     new = _snap(_adv(calling={"foo": "LLVM_vectorcall"}))
     r = compare(old, new)
     kinds = {c.kind for c in r.changes}
@@ -98,10 +105,12 @@ def test_calling_convention_between_non_defaults() -> None:
 
 
 def test_calling_convention_removed() -> None:
-    """Non-default CC dropped back to normal."""
+    """Non-default CC dropped back to normal (function still exists in both binaries)."""
+    # Both dicts contain "foo": old has non-standard CC, new has "normal" explicitly.
+    # This represents a function that changed CC, not a removed function.
     results = diff_advanced_dwarf(
         _adv(calling={"foo": "BORLAND_stdcall"}),
-        _adv(calling={}),
+        _adv(calling={"foo": "normal"}),
     )
     assert len(results) == 1
     assert results[0][0] == "calling_convention_changed"
@@ -129,9 +138,14 @@ def test_struct_packing_added() -> None:
 
 
 def test_struct_packing_removed() -> None:
-    """packed→unpacked is also a breaking layout change."""
+    """packed→unpacked is a breaking layout change when the struct still exists.
+
+    all_structs must be set on the new side to prove the struct still exists
+    (not removed). Without it the diff guard would skip the report to avoid
+    false positives from struct deletion.
+    """
     old = _snap(_adv(packed={"Hdr"}))
-    new = _snap(_adv(packed=set()))
+    new = _snap(_adv(packed=set(), all_structs={"Hdr"}))
     r = compare(old, new)
     kinds = {c.kind for c in r.changes}
     assert ChangeKind.STRUCT_PACKING_CHANGED in kinds

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -1,0 +1,93 @@
+"""Sprint 4 tests: advanced DWARF detectors (calling convention, packing, toolchain drift)."""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.dwarf_advanced import (
+    AdvancedDwarfMetadata,
+    ToolchainInfo,
+    diff_advanced_dwarf,
+)
+from abicheck.model import AbiSnapshot
+from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
+
+
+def _snap(adv: AdvancedDwarfMetadata | None) -> AbiSnapshot:
+    s = AbiSnapshot(library="libx.so", version="v")
+    s.dwarf_advanced = adv  # type: ignore[attr-defined]
+    return s
+
+
+def _adv(
+    *,
+    has_dwarf: bool = True,
+    calling: dict[str, str] | None = None,
+    packed: set[str] | None = None,
+    flags: set[str] | None = None,
+) -> AdvancedDwarfMetadata:
+    return AdvancedDwarfMetadata(
+        has_dwarf=has_dwarf,
+        toolchain=ToolchainInfo(
+            producer_string="gcc",
+            compiler="GCC",
+            version="13.2",
+            abi_flags=flags or set(),
+        ),
+        calling_conventions=calling or {},
+        packed_structs=packed or set(),
+    )
+
+
+def test_diff_advanced_dwarf_no_dwarf() -> None:
+    old = _adv(has_dwarf=False)
+    new = _adv(has_dwarf=True)
+    assert diff_advanced_dwarf(old, new) == []
+
+
+def test_calling_convention_changed() -> None:
+    old = _snap(_adv(calling={"foo": "program"}))
+    new = _snap(_adv(calling={"foo": "normal"}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.CALLING_CONVENTION_CHANGED in kinds
+    assert r.verdict == Verdict.BREAKING
+
+
+def test_calling_convention_added_non_default() -> None:
+    old = _snap(_adv(calling={}))
+    new = _snap(_adv(calling={"foo": "LLVM_vectorcall"}))
+    r = compare(old, new)
+    assert any(c.kind == ChangeKind.CALLING_CONVENTION_CHANGED for c in r.changes)
+
+
+def test_struct_packing_changed() -> None:
+    old = _snap(_adv(packed=set()))
+    new = _snap(_adv(packed={"Ctx"}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.STRUCT_PACKING_CHANGED in kinds
+    assert r.verdict == Verdict.BREAKING
+
+
+def test_toolchain_flag_drift_warning_compatible() -> None:
+    old = _snap(_adv(flags={"-fshort-enums"}))
+    new = _snap(_adv(flags={"-fshort-enums", "-mabi=lp64"}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.TOOLCHAIN_FLAG_DRIFT in kinds
+    # informational warning only
+    assert r.verdict == Verdict.COMPATIBLE
+
+
+def test_serialization_roundtrip_dwarf_advanced_sets() -> None:
+    snap = _snap(_adv(calling={"foo": "program"}, packed={"A", "B"}, flags={"-fshort-enums"}))
+    d = snapshot_to_dict(snap)
+
+    # ensure JSON-safe conversion happened
+    assert isinstance(d["dwarf_advanced"]["packed_structs"], list)
+    assert isinstance(d["dwarf_advanced"]["toolchain"]["abi_flags"], list)
+
+    snap2 = snapshot_from_dict(d)
+    assert snap2.dwarf_advanced is not None
+    assert snap2.dwarf_advanced.calling_conventions.get("foo") == "program"
+    assert snap2.dwarf_advanced.packed_structs == {"A", "B"}
+    assert snap2.dwarf_advanced.toolchain.abi_flags == {"-fshort-enums"}


### PR DESCRIPTION
## Summary

Sprint 4 extends DWARF-aware ABI analysis with three new detectors.

### New module: `abicheck/dwarf_advanced.py`

**Calling convention drift** (`DW_AT_calling_convention`)
- Detects when exported function calling convention changes (e.g. `normal → LLVM_vectorcall`)  
- Maps all standard DWARF CC codes + GCC/Clang/LLVM extensions
- Only fires for `DW_AT_external=true` functions (exported ABI surface)

**Struct packing drift** (`__attribute__((packed))`)
- Detects when struct gains/loses packed attribute via DWARF field offset analysis
- Packed heuristic: any field at a misaligned offset for its natural alignment = packed
- Covers both pack-added and pack-removed scenarios

**Toolchain ABI flag drift** (`DW_AT_producer` parsing)
- Parses ABI-affecting flags: `-fshort-enums`, `-fpack-struct`, `-fno-common/-fcommon`, `-m32/-m64`, `-mabi=*`, `-fabi-version=*`, `-D_GLIBCXX_USE_CXX11_ABI=*`
- `TOOLCHAIN_FLAG_DRIFT` → `COMPATIBLE` (informational warning, not hard BREAKING)

### New ChangeKinds

| Kind | Verdict |
|------|---------|
| `CALLING_CONVENTION_CHANGED` | BREAKING |
| `STRUCT_PACKING_CHANGED` | BREAKING |
| `TYPE_VISIBILITY_CHANGED` | BREAKING (reserved) |
| `TOOLCHAIN_FLAG_DRIFT` | COMPATIBLE (warning) |

### Integration

- `dumper.dump()` now calls `parse_advanced_dwarf()` alongside `parse_dwarf_metadata()` and `parse_elf_metadata()`
- `AbiSnapshot.dwarf_advanced` field added
- `serialization.py`: roundtrip support (set→list JSON conversion for `packed_structs` and `abi_flags`)

### Tests

`tests/test_sprint4_dwarf_advanced.py` — 6 tests:
- calling convention change/add → BREAKING
- struct packing change → BREAKING  
- toolchain flag drift → COMPATIBLE warning
- JSON serialization roundtrip (set→list→set)

**Full suite: 117 passed, 27 deselected**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds advanced DWARF analysis to detect calling convention changes, struct packing differences, type visibility modifications, and toolchain flag drift (drift reported informationally; others treated as breaking).

* **Chores**
  * Captures advanced DWARF and toolchain metadata in snapshots, includes them in dumps/serialization, preserves symbol visibility, and ensures sets serialize safely.

* **Tests**
  * Adds comprehensive tests for DWARF parsing, calling-convention/packing diffs, toolchain-flag drift, and serialization roundtrips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->