### PR TITLE
feat(sprint5): ABICC drop-in compat layer (XML descriptor, HTML report, compat subcommand)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .venv/
+abicheck.egg-info/

--- a/abicheck.egg-info/SOURCES.txt
+++ b/abicheck.egg-info/SOURCES.txt
@@ -5,8 +5,12 @@ pyproject.toml
 abicheck/__init__.py
 abicheck/checker.py
 abicheck/cli.py
+abicheck/compat.py
 abicheck/dumper.py
+abicheck/dwarf_advanced.py
+abicheck/dwarf_metadata.py
 abicheck/elf_metadata.py
+abicheck/html_report.py
 abicheck/model.py
 abicheck/reporter.py
 abicheck/serialization.py
@@ -19,8 +23,12 @@ abicheck.egg-info/requires.txt
 abicheck.egg-info/top_level.txt
 tests/test_abi_examples.py
 tests/test_checker.py
+tests/test_compat.py
+tests/test_elf_parse_integration.py
 tests/test_reporter.py
 tests/test_serialization.py
 tests/test_sprint1.py
 tests/test_sprint2_elf.py
+tests/test_sprint3_dwarf.py
+tests/test_sprint4_dwarf_advanced.py
 tests/test_suppression.py

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -176,10 +176,10 @@ def compat_cmd(
             err=True,
         )
 
-    old_headers = old.headers[0] if old.headers else None
-    new_headers = new.headers[0] if new.headers else None
+    old_headers = old.headers
+    new_headers = new.headers
 
-    if old_headers is None or new_headers is None:
+    if not old_headers or not new_headers:
         click.echo(
             "Warning: one or both descriptors have no <headers> entry. "
             "Type-level ABI checks (struct layout, enum values, etc.) will be skipped.",
@@ -194,12 +194,8 @@ def compat_cmd(
         sys.exit(2)
 
     try:
-        old_snap = dump(old_so,
-                        headers=[old_headers] if old_headers else [],
-                        version=old.version)
-        new_snap = dump(new_so,
-                        headers=[new_headers] if new_headers else [],
-                        version=new.version)
+        old_snap = dump(old_so, headers=old_headers, version=old.version)
+        new_snap = dump(new_so, headers=new_headers, version=new.version)
     except Exception as exc:  # noqa: BLE001
         click.echo(f"Error during dump: {exc}", err=True)
         sys.exit(2)
@@ -217,11 +213,16 @@ def compat_cmd(
 
     # Determine report output path
     if report_path is None:
+        import re
         ext = fmt.lower()
+
+        def _safe_path(v: str) -> str:
+            return re.sub(r"[^\w.\-]", "_", v)
+
         report_path = (
             Path("compat_reports")
-            / lib_name
-            / f"{old.version}_to_{new.version}"
+            / _safe_path(lib_name)
+            / f"{_safe_path(old.version)}_to_{_safe_path(new.version)}"
             / f"report.{ext}"
         )
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1,4 +1,4 @@
-"""CLI — abicheck dump | compare | scan."""
+"""CLI — abicheck dump | compare | scan | compat."""
 from __future__ import annotations
 
 import sys
@@ -7,7 +7,9 @@ from pathlib import Path
 import click
 
 from .checker import compare
+from .compat import parse_descriptor
 from .dumper import dump
+from .html_report import write_html_report
 from .reporter import to_json, to_markdown
 from .serialization import load_snapshot
 
@@ -108,6 +110,117 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
         sys.exit(4)
     elif result.verdict.value == "SOURCE_BREAK":
         sys.exit(2)
+
+
+@main.command("compat")
+@click.option("-lib", "lib_name", required=True, help="Library name (e.g. libdnnl).")
+@click.option("-old", "old_desc", required=True, type=click.Path(exists=True, path_type=Path),
+              help="Path to old version ABICC XML descriptor.")
+@click.option("-new", "new_desc", required=True, type=click.Path(exists=True, path_type=Path),
+              help="Path to new version ABICC XML descriptor.")
+@click.option("-report-path", "report_path", default=None, type=click.Path(path_type=Path),
+              help="Output report path. Default: compat_reports/<lib>/<old>_to_<new>/report.<fmt>.")
+@click.option("-report-format", "fmt", default="html",
+              type=click.Choice(["html", "json", "md"], case_sensitive=False),
+              help="Report format (default: html).")
+@click.option("--suppress", default=None, type=click.Path(path_type=Path),
+              help="Suppression YAML file (passed through to compare).")
+def compat_cmd(
+    lib_name: str,
+    old_desc: Path,
+    new_desc: Path,
+    report_path: Path | None,
+    fmt: str,
+    suppress: Path | None,
+) -> None:
+    """Drop-in replacement for abi-compliance-checker.
+
+    Reads ABICC-format XML descriptors and produces an ABI compatibility report.
+
+    Exit codes mirror ABICC:
+      0 — compatible or no change
+      1 — breaking ABI change detected
+      2 — error (descriptor parse failure, missing files, etc.)
+
+    Example (replacing an existing ABICC call)::
+
+        # Before:
+        abi-compliance-checker -lib libdnnl -old old.xml -new new.xml -report-path r.html
+
+        # After:
+        abicheck compat -lib libdnnl -old old.xml -new new.xml -report-path r.html
+    """
+    from .suppression import SuppressionList  # local import to avoid circular
+
+    try:
+        old = parse_descriptor(old_desc)
+        new = parse_descriptor(new_desc)
+    except (ValueError, FileNotFoundError, OSError) as exc:
+        click.echo(f"Error parsing descriptor: {exc}", err=True)
+        sys.exit(2)
+
+    # Resolve .so paths — use first lib in each descriptor
+    old_so = old.libs[0]
+    new_so = new.libs[0]
+    old_headers = old.headers[0] if old.headers else None
+    new_headers = new.headers[0] if new.headers else None
+
+    if not old_so.exists():
+        click.echo(f"Error: library not found: {old_so}", err=True)
+        sys.exit(2)
+    if not new_so.exists():
+        click.echo(f"Error: library not found: {new_so}", err=True)
+        sys.exit(2)
+
+    try:
+        old_snap = dump(old_so,
+                        headers=[old_headers] if old_headers else [],
+                        version=old.version)
+        new_snap = dump(new_so,
+                        headers=[new_headers] if new_headers else [],
+                        version=new.version)
+    except Exception as exc:  # noqa: BLE001
+        click.echo(f"Error during dump: {exc}", err=True)
+        sys.exit(2)
+
+    suppression: SuppressionList | None = None
+    if suppress is not None:
+        try:
+            suppression = SuppressionList.load(suppress)
+        except (ValueError, OSError) as exc:
+            click.echo(f"Error loading suppression file: {exc}", err=True)
+            sys.exit(2)
+
+    result = compare(old_snap, new_snap, suppression=suppression)
+    verdict = result.verdict.value if hasattr(result.verdict, "value") else str(result.verdict)
+
+    # Determine report output path
+    if report_path is None:
+        ext = fmt.lower()
+        report_path = (
+            Path("compat_reports")
+            / lib_name
+            / f"{old.version}_to_{new.version}"
+            / f"report.{ext}"
+        )
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if fmt == "html":
+        write_html_report(result, output_path=report_path,
+                          lib_name=lib_name,
+                          old_version=old.version, new_version=new.version)
+    elif fmt == "json":
+        report_path.write_text(to_json(result), encoding="utf-8")
+    else:
+        report_path.write_text(to_markdown(result), encoding="utf-8")
+
+    click.echo(f"Verdict: {verdict}", err=True)
+    click.echo(f"Report:  {report_path}", err=True)
+
+    # Exit codes: 0=compatible/no_change, 1=breaking, 2=error (already handled above)
+    if verdict == "BREAKING":
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -159,11 +159,32 @@ def compat_cmd(
         click.echo(f"Error parsing descriptor: {exc}", err=True)
         sys.exit(2)
 
-    # Resolve .so paths — use first lib in each descriptor
+    # Resolve .so paths — use first lib in each descriptor.
+    # If descriptor contains multiple <libs>, warn and use the first.
     old_so = old.libs[0]
     new_so = new.libs[0]
+    if len(old.libs) > 1:
+        click.echo(
+            f"Warning: descriptor {old_desc.name} has {len(old.libs)} <libs> entries; "
+            f"using only the first: {old_so}",
+            err=True,
+        )
+    if len(new.libs) > 1:
+        click.echo(
+            f"Warning: descriptor {new_desc.name} has {len(new.libs)} <libs> entries; "
+            f"using only the first: {new_so}",
+            err=True,
+        )
+
     old_headers = old.headers[0] if old.headers else None
     new_headers = new.headers[0] if new.headers else None
+
+    if old_headers is None or new_headers is None:
+        click.echo(
+            "Warning: one or both descriptors have no <headers> entry. "
+            "Type-level ABI checks (struct layout, enum values, etc.) will be skipped.",
+            err=True,
+        )
 
     if not old_so.exists():
         click.echo(f"Error: library not found: {old_so}", err=True)

--- a/abicheck/compat.py
+++ b/abicheck/compat.py
@@ -1,0 +1,91 @@
+"""Sprint 5: ABICC drop-in compatibility layer.
+
+Implements:
+- ABICC XML descriptor parsing (defusedxml, XXE-safe)
+- ``CompatDescriptor`` dataclass matching ABICC's -old/-new descriptor format
+- ``parse_descriptor()`` — validates required fields, supports multi-value tags
+
+Typical ABICC descriptor (old.xml):
+    <version>2025.0</version>
+    <headers>/usr/include/dnnl</headers>
+    <libs>/usr/lib/libdnnl.so</libs>
+
+Extended form (multiple headers/libs):
+    <version>2025.0</version>
+    <headers>/usr/include/dnnl</headers>
+    <headers>/usr/include/dnnl/detail</headers>
+    <libs>/usr/lib/libdnnl.so</libs>
+    <libs>/usr/lib/libdnnl_extra.so</libs>
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import defusedxml.ElementTree as ET
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class CompatDescriptor:
+    """Parsed ABICC XML descriptor."""
+    version: str
+    headers: list[Path]
+    libs: list[Path]
+    path: Path = field(default_factory=lambda: Path("."))
+
+
+def parse_descriptor(path: Path) -> CompatDescriptor:
+    """Parse an ABICC XML descriptor file.
+
+    Args:
+        path: Path to the descriptor XML file.
+
+    Returns:
+        Populated CompatDescriptor.
+
+    Raises:
+        ValueError: If required fields (version, libs) are missing or empty.
+        FileNotFoundError: If the descriptor file does not exist.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Descriptor not found: {path}")
+
+    try:
+        tree = ET.parse(str(path))  # defusedxml.ElementTree.parse
+    except ET.ParseError as exc:
+        raise ValueError(f"Invalid XML in descriptor {path}: {exc}") from exc
+
+    root = tree.getroot()
+    base = path.parent
+
+    def _get_all(tag: str) -> list[str]:
+        return [el.text.strip() for el in root.iter(tag) if el.text and el.text.strip()]
+
+    version_vals = _get_all("version")
+    if not version_vals:
+        raise ValueError(f"Descriptor {path}: missing <version> element")
+    version = version_vals[0]
+
+    lib_strs = _get_all("libs")
+    if not lib_strs:
+        raise ValueError(f"Descriptor {path}: missing <libs> element")
+    libs = [_resolve(s, base) for s in lib_strs]
+
+    header_strs = _get_all("headers")
+    headers = [_resolve(s, base) for s in header_strs]
+
+    log.debug("Parsed descriptor %s: version=%s, %d lib(s), %d header dir(s)",
+              path, version, len(libs), len(headers))
+
+    return CompatDescriptor(version=version, headers=headers, libs=libs, path=path)
+
+
+def _resolve(p: str, base: Path) -> Path:
+    """Return absolute path; resolve relative paths against the descriptor's directory."""
+    resolved = Path(p)
+    if not resolved.is_absolute():
+        resolved = (base / resolved).resolve()
+    return resolved

--- a/abicheck/compat.py
+++ b/abicheck/compat.py
@@ -52,6 +52,8 @@ def parse_descriptor(path: Path) -> CompatDescriptor:
     """
     if not path.exists():
         raise FileNotFoundError(f"Descriptor not found: {path}")
+    if not path.is_file():
+        raise ValueError(f"Descriptor path is not a regular file: {path}")
 
     try:
         tree = ET.parse(str(path))  # defusedxml.ElementTree.parse
@@ -62,7 +64,10 @@ def parse_descriptor(path: Path) -> CompatDescriptor:
     base = path.parent
 
     def _get_all(tag: str) -> list[str]:
-        return [el.text.strip() for el in root.iter(tag) if el.text and el.text.strip()]
+        # findall() — direct children only; avoids capturing nested tags
+        # (root.iter() would recurse into sub-elements, silently picking up
+        # nested <version> or <libs> inside other tags)
+        return [el.text.strip() for el in root.findall(tag) if el.text and el.text.strip()]
 
     version_vals = _get_all("version")
     if not version_vals:
@@ -84,8 +89,21 @@ def parse_descriptor(path: Path) -> CompatDescriptor:
 
 
 def _resolve(p: str, base: Path) -> Path:
-    """Return absolute path; resolve relative paths against the descriptor's directory."""
+    """Return absolute path; resolve relative paths against the descriptor's directory.
+
+    Path containment check: relative paths must not escape the base directory
+    (guards against crafted descriptors with '../../' traversal sequences).
+    Absolute paths are accepted as-is (matching ABICC behaviour for system paths).
+    """
     resolved = Path(p)
     if not resolved.is_absolute():
         resolved = (base / resolved).resolve()
+        # Containment check: resolved path must stay within base directory
+        try:
+            resolved.relative_to(base.resolve())
+        except ValueError:
+            raise ValueError(
+                f"Path '{p}' in descriptor escapes the base directory '{base}'. "
+                "Use absolute paths for libraries outside the descriptor directory."
+            ) from None
     return resolved

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -1,0 +1,194 @@
+"""Sprint 5: HTML report generator for ABI comparison results.
+
+Generates a self-contained HTML report (no external CSS/JS dependencies)
+matching the structure of ABICC reports:
+- Verdict banner (BREAKING / COMPATIBLE / NO_CHANGE)
+- Binary Compatibility % metric
+- Changes table (kind, symbol, description, old/new value)
+"""
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .checker import DiffResult as CompareResult
+
+# Verdict colours matching ABICC's visual style
+_VERDICT_STYLE: dict[str, tuple[str, str]] = {
+    "BREAKING":   ("#b71c1c", "#ffcdd2"),
+    "COMPATIBLE": ("#1b5e20", "#c8e6c9"),
+    "NO_CHANGE":  ("#0d47a1", "#bbdefb"),
+}
+
+_CSS = """
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+.header { padding: 24px 32px; background: #263238; color: #fff; }
+.header h1 { margin: 0 0 4px; font-size: 1.5em; }
+.header .meta { font-size: 0.9em; color: #b0bec5; }
+.verdict-box { margin: 24px 32px; padding: 16px 24px; border-radius: 6px; }
+.verdict-box h2 { margin: 0 0 4px; font-size: 1.3em; }
+.bc-metric { font-size: 1.1em; margin-top: 8px; }
+.section { margin: 0 32px 24px; background: #fff; border-radius: 6px;
+           box-shadow: 0 1px 3px rgba(0,0,0,.1); overflow: hidden; }
+.section h3 { margin: 0; padding: 12px 16px; background: #eceff1;
+              font-size: 1em; border-bottom: 1px solid #cfd8dc; }
+table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+th { background: #f5f5f5; padding: 8px 12px; text-align: left;
+     border-bottom: 2px solid #e0e0e0; }
+td { padding: 8px 12px; border-bottom: 1px solid #eeeeee; vertical-align: top; }
+tr:last-child td { border-bottom: none; }
+.kind { font-family: monospace; font-size: 0.85em; color: #37474f;
+        background: #eceff1; padding: 2px 6px; border-radius: 3px; }
+.breaking { color: #b71c1c; font-weight: bold; }
+.compatible { color: #1b5e20; }
+.sym { font-family: monospace; }
+.empty { padding: 16px; color: #9e9e9e; font-style: italic; }
+footer { padding: 16px 32px; font-size: 0.8em; color: #9e9e9e; }
+"""
+
+
+def generate_html_report(
+    result: CompareResult,
+    lib_name: str = "",
+    old_version: str = "",
+    new_version: str = "",
+) -> str:
+    """Generate a standalone HTML ABI comparison report.
+
+    Args:
+        result: CompareResult from checker.compare().
+        lib_name: Library name for the report header.
+        old_version: Old library version string.
+        new_version: New library version string.
+
+    Returns:
+        Complete HTML document as a string.
+    """
+    verdict = result.verdict.value if hasattr(result.verdict, "value") else str(result.verdict)
+    fg, bg = _VERDICT_STYLE.get(verdict, ("#212121", "#f5f5f5"))
+    changes = getattr(result, "changes", []) or []
+
+    # Derive summary from changes list (DiffResult has no pre-computed summary field)
+    breaking = sum(1 for ch in changes if _is_breaking(ch))
+    compatible_add = sum(1 for ch in changes if not _is_breaking(ch))
+    total = len(changes)
+
+    # BC% = exported symbols with no breaking change / total exported
+    # We approximate: if no breaking changes, 100%; otherwise use breaking count.
+    if breaking == 0:
+        bc_pct = 100.0
+    elif total > 0:
+        bc_pct = max(0.0, (total - breaking) / total * 100)
+    else:
+        bc_pct = 0.0
+
+    h = html.escape
+    lib_display = h(lib_name) if lib_name else "library"
+    old_display = h(old_version) if old_version else "old"
+    new_display = h(new_version) if new_version else "new"
+
+    changes_rows = ""
+    if changes:
+        for ch in changes:
+            kind = getattr(ch, "kind", None)
+            kind_str = kind.value if kind is not None and hasattr(kind, "value") else str(kind)
+            sym = h(getattr(ch, "symbol", "") or "")
+            desc = h(getattr(ch, "description", "") or "")
+            old_val = h(str(getattr(ch, "old_value", "") or ""))
+            new_val = h(str(getattr(ch, "new_value", "") or ""))
+            row_class = "breaking" if kind_str in _BREAKING_KINDS else "compatible"
+            changes_rows += (
+                f"<tr>"
+                f"<td><span class='kind'>{h(kind_str)}</span></td>"
+                f"<td class='sym {row_class}'>{sym}</td>"
+                f"<td>{desc}</td>"
+                f"<td>{old_val}</td>"
+                f"<td>{new_val}</td>"
+                f"</tr>\n"
+            )
+    else:
+        changes_rows = "<tr><td colspan='5' class='empty'>No changes detected.</td></tr>"
+
+    table = f"""
+    <table>
+      <thead>
+        <tr>
+          <th>Kind</th><th>Symbol</th><th>Description</th>
+          <th>Old value</th><th>New value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {changes_rows}
+      </tbody>
+    </table>"""
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ABI Report: {lib_display} {old_display} → {new_display}</title>
+  <style>{_CSS}</style>
+</head>
+<body>
+  <div class="header">
+    <h1>ABI Compatibility Report</h1>
+    <div class="meta">
+      Library: <strong>{lib_display}</strong> &nbsp;|&nbsp;
+      {old_display} → {new_display} &nbsp;|&nbsp;
+      Generated by <strong>abicheck</strong>
+    </div>
+  </div>
+
+  <div class="verdict-box" style="background:{bg}; color:{fg}; border-left: 6px solid {fg};">
+    <h2>Verdict: {h(verdict)}</h2>
+    <div class="bc-metric">
+      Binary Compatibility: <strong>{bc_pct:.1f}%</strong> &nbsp;|&nbsp;
+      Breaking: {breaking} &nbsp;|&nbsp;
+      Compatible additions: {compatible_add} &nbsp;|&nbsp;
+      Total changes: {total}
+    </div>
+  </div>
+
+  <div class="section">
+    <h3>Changes ({total})</h3>
+    {table}
+  </div>
+
+  <footer>Generated by abicheck · ABICC-compatible report format</footer>
+</body>
+</html>
+"""
+
+
+def _is_breaking(change: object) -> bool:
+    kind = getattr(change, "kind", None)
+    kind_str = kind.value if kind is not None and hasattr(kind, "value") else str(kind)
+    return kind_str in _BREAKING_KINDS
+
+
+# Set of kind strings that are considered breaking (for row colouring)
+_BREAKING_KINDS: frozenset[str] = frozenset({
+    "func_removed", "func_params_changed", "func_return_changed",
+    "func_noexcept_removed", "type_size_changed", "struct_size_changed",
+    "struct_field_removed", "struct_field_offset_changed", "struct_field_type_changed",
+    "struct_alignment_changed", "type_vtable_changed", "enum_underlying_size_changed",
+    "enum_member_value_changed", "enum_member_removed", "calling_convention_changed",
+    "struct_packing_changed", "type_visibility_changed", "qualifier_removed",
+    "union_field_removed", "bitfield_size_changed",
+})
+
+
+def write_html_report(
+    result: CompareResult,
+    output_path: Path,
+    lib_name: str = "",
+    old_version: str = "",
+    new_version: str = "",
+) -> None:
+    """Write HTML report to *output_path*, creating parent directories as needed."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    content = generate_html_report(result, lib_name=lib_name,
+                                   old_version=old_version, new_version=new_version)
+    output_path.write_text(content, encoding="utf-8")

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -162,13 +162,8 @@ def generate_html_report(
 """
 
 
-def _is_breaking(change: object) -> bool:
-    kind = getattr(change, "kind", None)
-    kind_str = kind.value if kind is not None and hasattr(kind, "value") else str(kind)
-    return kind_str in _BREAKING_KINDS
-
-
-# Set of kind strings that are considered breaking (for row colouring)
+# Set of kind strings that are considered breaking (for row colouring).
+# Defined before _is_breaking() which references it.
 _BREAKING_KINDS: frozenset[str] = frozenset({
     "func_removed", "func_params_changed", "func_return_changed",
     "func_noexcept_removed", "type_size_changed", "struct_size_changed",
@@ -178,6 +173,12 @@ _BREAKING_KINDS: frozenset[str] = frozenset({
     "struct_packing_changed", "type_visibility_changed", "qualifier_removed",
     "union_field_removed", "bitfield_size_changed",
 })
+
+
+def _is_breaking(change: object) -> bool:
+    kind = getattr(change, "kind", None)
+    kind_str = kind.value if kind is not None and hasattr(kind, "value") else str(kind)
+    return kind_str in _BREAKING_KINDS
 
 
 def write_html_report(

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -144,7 +144,9 @@ def generate_html_report(
   <div class="verdict-box" style="background:{bg}; color:{fg}; border-left: 6px solid {fg};">
     <h2>Verdict: {h(verdict)}</h2>
     <div class="bc-metric">
-      Binary Compatibility: <strong>{bc_pct:.1f}%</strong> &nbsp;|&nbsp;
+      Binary Compatibility: <strong>{bc_pct:.1f}%</strong>
+      <span style="font-size:0.8em; opacity:0.8">(approx. from changed symbols, not total exported surface)</span>
+      &nbsp;|&nbsp;
       Breaking: {breaking} &nbsp;|&nbsp;
       Compatible additions: {compatible_add} &nbsp;|&nbsp;
       Total changes: {total}

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,204 @@
+"""Tests for Sprint 5: ABICC compat layer (descriptor parser + HTML report)."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from abicheck.compat import CompatDescriptor, parse_descriptor
+from abicheck.html_report import generate_html_report
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_xml(tmp_path: Path, content: str, name: str = "desc.xml") -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content).strip(), encoding="utf-8")
+    return p
+
+
+def _make_fake_result(verdict: str = "COMPATIBLE", breaking: int = 0) -> object:
+    """Minimal stand-in for CompareResult (avoids importing checker)."""
+    from types import SimpleNamespace
+    summary = {"breaking": breaking, "compatible_additions": 0,
+               "total_changes": breaking, "source_breaks": 0}
+    changes = []
+    v = SimpleNamespace(value=verdict)
+    return SimpleNamespace(verdict=v, summary=summary, changes=changes,
+                           suppressed_count=0, suppression_file_provided=False)
+
+
+# ---------------------------------------------------------------------------
+# Descriptor parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_descriptor_basic(tmp_path: Path) -> None:
+    xml = """
+    <descriptor>
+      <version>2025.3</version>
+      <headers>/usr/include/mylib</headers>
+      <libs>/usr/lib/libmylib.so</libs>
+    </descriptor>
+    """
+    desc_path = _write_xml(tmp_path, xml)
+    desc = parse_descriptor(desc_path)
+
+    assert isinstance(desc, CompatDescriptor)
+    assert desc.version == "2025.3"
+    assert len(desc.libs) == 1
+    assert desc.libs[0] == Path("/usr/lib/libmylib.so")
+    assert len(desc.headers) == 1
+    assert desc.headers[0] == Path("/usr/include/mylib")
+
+
+def test_parse_descriptor_multiple_headers(tmp_path: Path) -> None:
+    xml = """
+    <descriptor>
+      <version>1.0</version>
+      <headers>/usr/include/foo</headers>
+      <headers>/usr/include/foo/detail</headers>
+      <libs>/usr/lib/libfoo.so</libs>
+    </descriptor>
+    """
+    desc = parse_descriptor(_write_xml(tmp_path, xml))
+    assert len(desc.headers) == 2
+    assert Path("/usr/include/foo/detail") in desc.headers
+
+
+def test_parse_descriptor_multiple_libs(tmp_path: Path) -> None:
+    xml = """
+    <descriptor>
+      <version>3.0</version>
+      <headers>/inc</headers>
+      <libs>/lib/liba.so</libs>
+      <libs>/lib/libb.so</libs>
+    </descriptor>
+    """
+    desc = parse_descriptor(_write_xml(tmp_path, xml))
+    assert len(desc.libs) == 2
+
+
+def test_parse_descriptor_no_headers_ok(tmp_path: Path) -> None:
+    """Headers are optional — not all ABICC descriptors include them."""
+    xml = """
+    <descriptor>
+      <version>1.0</version>
+      <libs>/usr/lib/libx.so</libs>
+    </descriptor>
+    """
+    desc = parse_descriptor(_write_xml(tmp_path, xml))
+    assert desc.version == "1.0"
+    assert desc.headers == []
+
+
+def test_parse_descriptor_missing_libs_raises(tmp_path: Path) -> None:
+    xml = """
+    <descriptor>
+      <version>1.0</version>
+      <headers>/usr/include/mylib</headers>
+    </descriptor>
+    """
+    with pytest.raises(ValueError, match="missing <libs>"):
+        parse_descriptor(_write_xml(tmp_path, xml))
+
+
+def test_parse_descriptor_missing_version_raises(tmp_path: Path) -> None:
+    xml = """
+    <descriptor>
+      <headers>/usr/include/mylib</headers>
+      <libs>/usr/lib/libx.so</libs>
+    </descriptor>
+    """
+    with pytest.raises(ValueError, match="missing <version>"):
+        parse_descriptor(_write_xml(tmp_path, xml))
+
+
+def test_parse_descriptor_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        parse_descriptor(tmp_path / "nonexistent.xml")
+
+
+def test_parse_descriptor_relative_lib_resolved(tmp_path: Path) -> None:
+    """Relative <libs> paths are resolved relative to the descriptor file."""
+    xml = """
+    <descriptor>
+      <version>0.1</version>
+      <libs>mylib.so</libs>
+    </descriptor>
+    """
+    desc = parse_descriptor(_write_xml(tmp_path, xml))
+    # Must be absolute and relative to descriptor's directory
+    assert desc.libs[0].is_absolute()
+    assert desc.libs[0].parent == tmp_path.resolve()
+
+
+def test_parse_descriptor_invalid_xml_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.xml"
+    bad.write_text("<unclosed>", encoding="utf-8")
+    with pytest.raises(ValueError, match="Invalid XML"):
+        parse_descriptor(bad)
+
+
+# ---------------------------------------------------------------------------
+# HTML report generation
+# ---------------------------------------------------------------------------
+
+def test_html_report_contains_verdict() -> None:
+    result = _make_fake_result(verdict="BREAKING", breaking=3)
+    html = generate_html_report(result, lib_name="libtest", old_version="1.0", new_version="2.0")
+    assert "BREAKING" in html
+    assert "libtest" in html
+
+
+def test_html_report_compatible_verdict() -> None:
+    result = _make_fake_result(verdict="COMPATIBLE")
+    html = generate_html_report(result)
+    assert "COMPATIBLE" in html
+
+
+def test_html_report_bc_percent_shown() -> None:
+    result = _make_fake_result(verdict="COMPATIBLE")
+    html = generate_html_report(result)
+    assert "Binary Compatibility" in html
+    assert "100.0%" in html
+
+
+def test_html_report_bc_percent_breaking() -> None:
+    result = _make_fake_result(verdict="BREAKING", breaking=2)
+    html = generate_html_report(result, lib_name="lib", old_version="1", new_version="2")
+    assert "0.0%" in html
+
+
+def test_html_report_is_valid_html() -> None:
+    result = _make_fake_result(verdict="NO_CHANGE")
+    html_out = generate_html_report(result)
+    assert html_out.startswith("<!DOCTYPE html>")
+    assert "</html>" in html_out
+
+
+def test_html_report_versions_in_title(tmp_path: Path) -> None:
+    result = _make_fake_result(verdict="COMPATIBLE")
+    html_out = generate_html_report(result, lib_name="libdnnl",
+                                    old_version="2025.0", new_version="2025.3")
+    assert "2025.0" in html_out
+    assert "2025.3" in html_out
+    assert "libdnnl" in html_out
+
+
+def test_html_report_xss_escape() -> None:
+    """Library name with HTML special chars must be escaped."""
+    result = _make_fake_result()
+    html_out = generate_html_report(result, lib_name="<script>alert(1)</script>")
+    assert "<script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_write_html_report_creates_dirs(tmp_path: Path) -> None:
+    from abicheck.html_report import write_html_report
+    result = _make_fake_result()
+    out = tmp_path / "deep" / "nested" / "report.html"
+    write_html_report(result, out)
+    assert out.exists()
+    assert out.stat().st_size > 100

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -202,3 +202,18 @@ def test_write_html_report_creates_dirs(tmp_path: Path) -> None:
     write_html_report(result, out)
     assert out.exists()
     assert out.stat().st_size > 100
+
+
+def test_parse_descriptor_first_lib_used_warning(tmp_path: Path) -> None:
+    """When descriptor has multiple <libs>, parse still succeeds with both libs captured."""
+    xml = """
+    <descriptor>
+      <version>2.0</version>
+      <libs>/lib/liba.so</libs>
+      <libs>/lib/libb.so</libs>
+    </descriptor>
+    """
+    desc = parse_descriptor(_write_xml(tmp_path, xml))
+    # Both are captured — CLI is responsible for emitting the warning
+    assert len(desc.libs) == 2
+    assert desc.libs[0] == Path("/lib/liba.so")


### PR DESCRIPTION
## Sprint 5 — ABICC Drop-in Replacement (G1)

Allows replacing `abi-compliance-checker` calls with `abicheck compat` without script changes.

### Before / After
```bash
# Before:
abi-compliance-checker -lib libdnnl -old old.xml -new new.xml -report-path report.html

# After (drop-in):
abicheck compat -lib libdnnl -old old.xml -new new.xml -report-path report.html
```

### Files
- `abicheck/compat.py` — defusedxml descriptor parser, CompatDescriptor dataclass
- `abicheck/html_report.py` — standalone HTML report, inline CSS, BC% metric
- `abicheck/cli.py` — new compat subcommand, ABICC-compatible flags + exit codes (0/1/2)
- `tests/test_compat.py` — 17 tests

**ruff/mypy: clean | 150 unit tests passed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `compat` command to analyze binary compatibility between library versions using descriptor files
  * Automatic report generation in HTML, JSON, and Markdown formats with compatibility verdict and change summary
  * Reports include binary compatibility percentage and breaking vs. compatible change counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->