### PR TITLE
feat(sprint7-a): SARIF 2.1.0 output for GitHub Code Scanning

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -58,7 +58,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
 @main.command("compare")
 @click.argument("old_snapshot", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_snapshot", type=click.Path(exists=True, path_type=Path))
-@click.option("--format", "fmt", type=click.Choice(["json", "markdown"]),
+@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif"]),
               default="markdown", show_default=True)
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
@@ -70,6 +70,7 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
     \b
     Example:
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format markdown
+      abicheck compare libfoo-1.0.json libfoo-2.0.json --format sarif -o results.sarif
       abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
     """
     from .suppression import SuppressionList
@@ -97,6 +98,9 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
 
     if fmt == "json":
         text = to_json(result)
+    elif fmt == "sarif":
+        from .sarif import to_sarif_str
+        text = to_sarif_str(result)
     else:
         text = to_markdown(result)
 

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -1,0 +1,183 @@
+"""SARIF 2.1.0 output for abicheck.
+
+Produces a Static Analysis Results Interchange Format (SARIF) document
+suitable for upload to GitHub Code Scanning via:
+
+    abicheck compare old.so new.so --format sarif > results.sarif
+
+GitHub Code Scanning docs:
+  https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning
+
+SARIF spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+"""
+from __future__ import annotations
+
+import json
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+from typing import Any
+
+from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+
+# ---------------------------------------------------------------------------
+# Severity mapping
+# ---------------------------------------------------------------------------
+_BREAKING_SEVERITY = "error"
+_COMPATIBLE_SEVERITY = "warning"
+_NOTE_SEVERITY = "note"
+
+# ChangeKinds that are purely informational (compatible additions)
+_COMPATIBLE_KINDS: frozenset[ChangeKind] = frozenset(
+    {
+        ChangeKind.FUNC_ADDED,
+        ChangeKind.VAR_ADDED,
+        ChangeKind.SYMBOL_BINDING_STRENGTHENED,
+        ChangeKind.ENUM_MEMBER_ADDED,
+    }
+)
+
+# Rule ID = change_kind value (snake_case, already stable)
+
+
+def _tool_version() -> str:
+    try:
+        return _pkg_version("abicheck")
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _severity(change: Change) -> str:
+    if change.kind in _COMPATIBLE_KINDS:
+        return _COMPATIBLE_SEVERITY
+    return _BREAKING_SEVERITY
+
+
+def _rule_for(kind: ChangeKind) -> dict[str, Any]:
+    """Produce a SARIF reportingDescriptor for a ChangeKind."""
+    rule_id = kind.value
+    severity = _BREAKING_SEVERITY if kind not in _COMPATIBLE_KINDS else _COMPATIBLE_SEVERITY
+    help_uri = (
+        "https://github.com/napetrov/abicheck/blob/main/docs/libabigail_parity.md"
+    )
+    return {
+        "id": rule_id,
+        "name": "".join(w.capitalize() for w in rule_id.split("_")),
+        "shortDescription": {"text": rule_id.replace("_", " ").capitalize()},
+        "fullDescription": {"text": f"ABI change detected: {rule_id.replace('_', ' ')}"},
+        "helpUri": help_uri,
+        "defaultConfiguration": {"level": severity},
+        "properties": {"tags": ["abi", "binary-compatibility"]},
+    }
+
+
+def _result_for(change: Change, library: str, old_version: str, new_version: str) -> dict[str, Any]:
+    """Produce a SARIF result object for a Change."""
+    msg_parts = [change.description]
+    if change.old_value or change.new_value:
+        msg_parts.append(
+            f"({change.old_value or '?'} → {change.new_value or '?'})"
+        )
+
+    return {
+        "ruleId": change.kind.value,
+        "level": _severity(change),
+        "message": {
+            "text": " ".join(msg_parts),
+        },
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": library,
+                        "uriBaseId": "%SRCROOT%",
+                    },
+                },
+                "logicalLocations": [
+                    {
+                        "name": change.symbol,
+                        "kind": "member",
+                    }
+                ],
+            }
+        ],
+        "properties": {
+            "symbol": change.symbol,
+            "oldVersion": old_version,
+            "newVersion": new_version,
+        },
+    }
+
+
+def to_sarif(result: DiffResult) -> dict[str, Any]:
+    """Convert a DiffResult to a SARIF 2.1.0 document (dict)."""
+    tool_version = _tool_version()
+
+    # Collect unique rules used
+    rules_seen: dict[str, dict[str, Any]] = {}
+    sarif_results: list[dict[str, Any]] = []
+
+    for change in result.changes:
+        rule_id = change.kind.value
+        if rule_id not in rules_seen:
+            rules_seen[rule_id] = _rule_for(change.kind)
+        sarif_results.append(
+            _result_for(change, result.library, result.old_version, result.new_version)
+        )
+
+    # Overall ABI verdict as a notification
+    invocation_success = result.verdict != Verdict.BREAKING
+
+    return {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "abicheck",
+                        "version": tool_version,
+                        "informationUri": "https://github.com/napetrov/abicheck",
+                        "rules": list(rules_seen.values()),
+                    }
+                },
+                "invocations": [
+                    {
+                        "executionSuccessful": invocation_success,
+                        "exitCode": 0 if result.verdict == Verdict.NO_CHANGE else (
+                            1 if result.verdict == Verdict.BREAKING else 0
+                        ),
+                        "exitCodeDescription": result.verdict.value,
+                    }
+                ],
+                "results": sarif_results,
+                "automationDetails": {
+                    "id": f"abicheck/{result.library}/{result.old_version}_to_{result.new_version}",
+                    "description": {
+                        "text": (
+                            f"ABI comparison: {result.library} "
+                            f"{result.old_version} → {result.new_version} "
+                            f"verdict={result.verdict.value}"
+                        )
+                    },
+                },
+                "properties": {
+                    "abiVerdict": result.verdict.value,
+                    "oldVersion": result.old_version,
+                    "newVersion": result.new_version,
+                    "library": result.library,
+                    "changeCount": len(result.changes),
+                    "suppressedCount": result.suppressed_count,
+                },
+            }
+        ],
+    }
+
+
+def to_sarif_str(result: DiffResult, indent: int = 2) -> str:
+    """Serialize DiffResult to a SARIF JSON string."""
+    return json.dumps(to_sarif(result), indent=indent)
+
+
+def write_sarif(result: DiffResult, path: Path) -> None:
+    """Write SARIF output to *path*."""
+    path.write_text(to_sarif_str(result), encoding="utf-8")

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,0 +1,200 @@
+"""Tests for SARIF 2.1.0 output (Sprint 7)."""
+from __future__ import annotations
+
+import json
+
+from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+from abicheck.sarif import to_sarif, to_sarif_str
+
+
+def _make_result(
+    changes: list[Change],
+    verdict: Verdict = Verdict.BREAKING,
+    library: str = "libfoo.so.1",
+    old: str = "1.0",
+    new: str = "2.0",
+) -> DiffResult:
+    return DiffResult(
+        old_version=old,
+        new_version=new,
+        library=library,
+        changes=changes,
+        verdict=verdict,
+    )
+
+
+def _breaking_change() -> Change:
+    return Change(
+        kind=ChangeKind.FUNC_REMOVED,
+        symbol="_Z3foov",
+        description="Function foo() removed",
+    )
+
+
+def _compatible_change() -> Change:
+    return Change(
+        kind=ChangeKind.FUNC_ADDED,
+        symbol="_Z3barv",
+        description="Function bar() added",
+    )
+
+
+def _valued_change() -> Change:
+    return Change(
+        kind=ChangeKind.FUNC_RETURN_CHANGED,
+        symbol="_Z7get_valv",
+        description="Return type changed",
+        old_value="int",
+        new_value="long",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema structure tests
+# ---------------------------------------------------------------------------
+
+class TestSarifSchema:
+    def test_top_level_keys(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        assert doc["version"] == "2.1.0"
+        assert "$schema" in doc
+        assert "runs" in doc
+        assert len(doc["runs"]) == 1
+
+    def test_tool_driver(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        driver = doc["runs"][0]["tool"]["driver"]
+        assert driver["name"] == "abicheck"
+        assert "version" in driver
+        assert "informationUri" in driver
+
+    def test_rules_populated(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change(), _compatible_change()]))
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        rule_ids = {r["id"] for r in rules}
+        assert "func_removed" in rule_ids
+        assert "func_added" in rule_ids
+
+    def test_rules_deduplicated(self) -> None:
+        """Two changes of same kind → one rule."""
+        c1 = Change(kind=ChangeKind.FUNC_REMOVED, symbol="foo", description="foo removed")
+        c2 = Change(kind=ChangeKind.FUNC_REMOVED, symbol="bar", description="bar removed")
+        doc = to_sarif(_make_result([c1, c2]))
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        func_removed_rules = [r for r in rules if r["id"] == "func_removed"]
+        assert len(func_removed_rules) == 1
+
+    def test_results_count(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change(), _compatible_change()]))
+        assert len(doc["runs"][0]["results"]) == 2
+
+    def test_empty_changes(self) -> None:
+        doc = to_sarif(_make_result([], verdict=Verdict.NO_CHANGE))
+        assert doc["runs"][0]["results"] == []
+        assert doc["runs"][0]["tool"]["driver"]["rules"] == []
+
+
+# ---------------------------------------------------------------------------
+# Severity mapping
+# ---------------------------------------------------------------------------
+
+class TestSeverityMapping:
+    def test_func_removed_is_error(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        result = doc["runs"][0]["results"][0]
+        assert result["level"] == "error"
+
+    def test_func_added_is_warning(self) -> None:
+        doc = to_sarif(_make_result([_compatible_change()], verdict=Verdict.COMPATIBLE))
+        result = doc["runs"][0]["results"][0]
+        assert result["level"] == "warning"
+
+    def test_rule_default_level_breaking(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["defaultConfiguration"]["level"] == "error"
+
+    def test_rule_default_level_compatible(self) -> None:
+        doc = to_sarif(_make_result([_compatible_change()], verdict=Verdict.COMPATIBLE))
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["defaultConfiguration"]["level"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Result content
+# ---------------------------------------------------------------------------
+
+class TestResultContent:
+    def test_result_message_plain(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        msg = doc["runs"][0]["results"][0]["message"]["text"]
+        assert "Function foo() removed" in msg
+
+    def test_result_message_with_values(self) -> None:
+        doc = to_sarif(_make_result([_valued_change()]))
+        msg = doc["runs"][0]["results"][0]["message"]["text"]
+        assert "int" in msg
+        assert "long" in msg
+        assert "→" in msg
+
+    def test_result_rule_id(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        result = doc["runs"][0]["results"][0]
+        assert result["ruleId"] == "func_removed"
+
+    def test_result_location_symbol(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        locs = doc["runs"][0]["results"][0]["locations"]
+        assert locs[0]["logicalLocations"][0]["name"] == "_Z3foov"
+
+    def test_result_location_library(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()], library="libbar.so.2"))
+        locs = doc["runs"][0]["results"][0]["locations"]
+        assert locs[0]["physicalLocation"]["artifactLocation"]["uri"] == "libbar.so.2"
+
+    def test_result_properties(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        props = doc["runs"][0]["results"][0]["properties"]
+        assert props["symbol"] == "_Z3foov"
+        assert props["oldVersion"] == "1.0"
+        assert props["newVersion"] == "2.0"
+
+
+# ---------------------------------------------------------------------------
+# Invocation / automation details
+# ---------------------------------------------------------------------------
+
+class TestInvocation:
+    def test_invocation_breaking_not_successful(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()], verdict=Verdict.BREAKING))
+        assert doc["runs"][0]["invocations"][0]["executionSuccessful"] is False
+
+    def test_invocation_no_change_successful(self) -> None:
+        doc = to_sarif(_make_result([], verdict=Verdict.NO_CHANGE))
+        assert doc["runs"][0]["invocations"][0]["executionSuccessful"] is True
+
+    def test_automation_details_id(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()], library="libfoo.so.1", old="1.0", new="2.0"))
+        aid = doc["runs"][0]["automationDetails"]["id"]
+        assert "abicheck/libfoo.so.1/1.0_to_2.0" == aid
+
+    def test_run_properties(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()]))
+        props = doc["runs"][0]["properties"]
+        assert props["abiVerdict"] == "BREAKING"
+        assert props["changeCount"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+class TestSerialization:
+    def test_to_sarif_str_is_valid_json(self) -> None:
+        s = to_sarif_str(_make_result([_breaking_change()]))
+        parsed = json.loads(s)
+        assert parsed["version"] == "2.1.0"
+
+    def test_to_sarif_str_indented(self) -> None:
+        s = to_sarif_str(_make_result([]), indent=4)
+        assert "    " in s  # 4-space indent present


### PR DESCRIPTION
## Sprint 7a — SARIF Output

Adds `--format sarif` to `abicheck compare`. Upload results to GitHub Code Scanning:

```yaml
- name: ABI check
  run: |
    abicheck compare old.json new.json --format sarif -o results.sarif

- uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: results.sarif
```

### What
- `abicheck/sarif.py` — SARIF 2.1.0 serializer
- `abicheck/cli.py` — `--format sarif` option
- BREAKING changes → `level=error`, COMPATIBLE → `level=warning`
- Rules deduplicated per `ChangeKind`
- `automationDetails.id` = `abicheck/<lib>/<v1>_to_<v2>`

### Tests
22 tests in `tests/test_sarif.py` — schema, severity, content, invocation, serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SARIF format output option to the compare command, enabling integration with SARIF 2.1.0 compatible security and analysis tools.

* **Tests**
  * Added comprehensive test coverage for SARIF output generation, including schema validation and severity mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->