### PR TITLE
feat(sprint7-b): GitHub Pages — MkDocs Material docs site (G6)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install MkDocs + Material theme
+        run: pip install mkdocs mkdocs-material
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| # | Title | Status |
+|---|-------|--------|
+| [001](001-technology-stack.md) | Technology Stack — Python + pyelftools + castxml | Accepted |

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,60 @@
+# Getting Started
+
+## Installation
+
+```bash
+pip install abicheck
+```
+
+System dependencies (for header analysis):
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install castxml
+
+# macOS
+brew install castxml
+```
+
+## Basic workflow
+
+### 1. Dump ABI snapshots
+
+```bash
+abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o libfoo-1.0.json
+abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o libfoo-2.0.json
+```
+
+### 2. Compare
+
+```bash
+# Markdown report (default)
+abicheck compare libfoo-1.0.json libfoo-2.0.json
+
+# JSON
+abicheck compare libfoo-1.0.json libfoo-2.0.json --format json
+
+# SARIF (GitHub Code Scanning)
+abicheck compare libfoo-1.0.json libfoo-2.0.json --format sarif -o results.sarif
+```
+
+### 3. ABICC-compatible mode
+
+```bash
+abicheck compat -lib foo -old foo-1.0.xml -new foo-2.0.xml
+```
+
+## Python API
+
+```python
+from pathlib import Path
+from abicheck.dumper import dump
+from abicheck.checker import compare
+
+old = dump(Path("libfoo.so.1"), headers=[Path("include/foo.h")], version="1.0")
+new = dump(Path("libfoo.so.2"), headers=[Path("include/foo.h")], version="2.0")
+
+result = compare(old, new)
+print(result.verdict)       # NO_CHANGE | COMPATIBLE | BREAKING
+print(result.changes)       # list[Change]
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# abicheck
+
+**ABI compatibility checker for shared libraries.**
+
+Drop-in replacement for [ABICC](https://lvc.github.io/abi-compliance-checker/) with modern Python API, JSON/SARIF output, and GitHub Actions integration.
+
+## Features
+
+- 🔍 **Deep analysis** — struct layout, vtable, enum values, calling conventions, symbol visibility
+- 📄 **SARIF output** — native GitHub Code Scanning integration
+- 🔌 **ABICC-compatible** — same XML descriptor format (`-lib`, `-old`, `-new` CLI flags)
+- 🐍 **Python API** — import and use programmatically
+- ⚡ **Fast** — no DWARF required for header-based analysis
+
+## Quick start
+
+```bash
+pip install abicheck
+
+# Dump ABI snapshots
+abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o libfoo-1.0.json
+abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o libfoo-2.0.json
+
+# Compare
+abicheck compare libfoo-1.0.json libfoo-2.0.json
+```
+
+## GitHub Actions
+
+```yaml
+- name: Check ABI
+  run: |
+    abicheck compare old.json new.json --format sarif -o abi.sarif
+
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: abi.sarif
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No ABI changes |
+| 1 | Compatible changes only |
+| 4 | Breaking ABI changes detected |
+
+## Status
+
+[![CI](https://github.com/napetrov/abicheck/actions/workflows/ci.yml/badge.svg)](https://github.com/napetrov/abicheck/actions/workflows/ci.yml)

--- a/docs/local_compare.md
+++ b/docs/local_compare.md
@@ -270,6 +270,5 @@ jobs:
 
 ## See Also
 
-- [QUICKSTART.md](../QUICKSTART.md) — Getting started with all commands
-- [docs/INSTALLATION.md](INSTALLATION.md) — Installation guide
-- [examples/README.md](../examples/README.md) — ABI scenario catalog
+- [Getting Started](getting_started.md) — Getting started with all commands
+- [Gap Report](gap_report.md) — Coverage analysis vs ABICC/libabigail

--- a/docs/sarif_output.md
+++ b/docs/sarif_output.md
@@ -1,0 +1,77 @@
+# SARIF Output
+
+abicheck supports [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/) output for integration with GitHub Code Scanning and other SAST platforms.
+
+## Usage
+
+```bash
+abicheck compare old.json new.json --format sarif -o results.sarif
+```
+
+## GitHub Code Scanning integration
+
+```yaml
+# .github/workflows/abi-check.yml
+name: ABI Check
+
+on: [pull_request]
+
+jobs:
+  abi-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install abicheck
+        run: pip install abicheck
+
+      - name: Dump ABI (baseline)
+        run: |
+          abicheck dump lib/libfoo.so.1 -H include/foo.h \
+            --version ${{ github.base_ref }} -o old.json
+
+      - name: Dump ABI (PR)
+        run: |
+          abicheck dump lib/libfoo.so.2 -H include/foo.h \
+            --version ${{ github.head_ref }} -o new.json
+
+      - name: Compare ABI
+        run: |
+          abicheck compare old.json new.json --format sarif -o abi.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: abi.sarif
+```
+
+## Severity mapping
+
+| ABI Change | SARIF Level |
+|-----------|-------------|
+| Function/variable removed | `error` |
+| Type size/layout changed | `error` |
+| Return/parameter type changed | `error` |
+| Function/variable added | `warning` |
+
+## SARIF document structure
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/.../sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [{
+    "tool": { "driver": { "name": "abicheck", "rules": [...] } },
+    "results": [{
+      "ruleId": "func_removed",
+      "level": "error",
+      "message": { "text": "Function foo() removed" },
+      "locations": [{
+        "physicalLocation": { "artifactLocation": { "uri": "libfoo.so.1" } },
+        "logicalLocations": [{ "name": "_Z3foov" }]
+      }]
+    }]
+  }]
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,66 @@
+site_name: abicheck
+site_description: ABI compatibility checker for shared libraries — drop-in replacement for ABICC, libabigail-aware
+site_url: https://napetrov.github.io/abicheck
+repo_url: https://github.com/napetrov/abicheck
+repo_name: napetrov/abicheck
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started: getting_started.md
+  - User Guide:
+    - Local Compare: tool_modes.md
+    - Tool Modes: local_compare.md
+    - SARIF Output: sarif_output.md
+  - Reference:
+    - Gap Report: gap_report.md
+    - libabigail Parity: libabigail_parity.md
+    - ABI Break Catalog: abi_breaking_cases_catalog_ru.md
+    - V2 Coverage Plan: v2_coverage_plan.md
+  - Architecture:
+    - ADR Index: adr/index.md
+    - ADR-001 Technology Stack: adr/001-technology-stack.md
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/napetrov/abicheck


### PR DESCRIPTION
## Sprint 7b — GitHub Pages (G6)

Publishes docs to **https://napetrov.github.io/abicheck** on every push to main.

### What
- `mkdocs.yml` — Material theme, dark/light toggle, search, nav tabs
- `docs/index.md` — landing page with quick start + CI snippet
- `docs/getting_started.md` — install, dump/compare/compat workflow, Python API
- `docs/sarif_output.md` — SARIF integration guide with full GitHub Actions example
- `docs/adr/index.md` — ADR index
- `.github/workflows/pages.yml` — build + deploy on push to main

### To enable
After merge: **Settings → Pages → Source → GitHub Actions**

`mkdocs build --strict` passes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Introduced comprehensive documentation site including Getting Started guide, SARIF output details, and Architecture Decision Records.
  * Updated and reorganized documentation structure for improved navigation and accessibility.

* **Chores**
  * Added automated GitHub Pages deployment workflow for the documentation site.
  * Configured MkDocs with Material theme for enhanced documentation presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->