### PR TITLE
Fix CodeFactor findings (E221/E241/E741, B110) across Python sources

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -70,40 +70,40 @@ class ChangeKind(str, Enum):
 
     # ── ELF-only (Sprint 2) ──────────────────────────────────────────────
     # Dynamic section contract
-    SONAME_CHANGED           = "soname_changed"
-    NEEDED_ADDED             = "needed_added"            # new DT_NEEDED dep
-    NEEDED_REMOVED           = "needed_removed"          # dep dropped
-    RPATH_CHANGED            = "rpath_changed"
-    RUNPATH_CHANGED          = "runpath_changed"
+    SONAME_CHANGED = "soname_changed"
+    NEEDED_ADDED = "needed_added"            # new DT_NEEDED dep
+    NEEDED_REMOVED = "needed_removed"          # dep dropped
+    RPATH_CHANGED = "rpath_changed"
+    RUNPATH_CHANGED = "runpath_changed"
 
     # Symbol metadata drift (ELF .dynsym)
-    SYMBOL_BINDING_CHANGED      = "symbol_binding_changed"      # GLOBAL→WEAK (breaking)
+    SYMBOL_BINDING_CHANGED = "symbol_binding_changed"      # GLOBAL→WEAK (breaking)
     SYMBOL_BINDING_STRENGTHENED = "symbol_binding_strengthened"  # WEAK→GLOBAL (compatible)
-    SYMBOL_TYPE_CHANGED      = "symbol_type_changed"     # FUNC→OBJECT, etc.
-    SYMBOL_SIZE_CHANGED      = "symbol_size_changed"     # st_size changed
-    IFUNC_INTRODUCED         = "ifunc_introduced"        # → STT_GNU_IFUNC
-    IFUNC_REMOVED            = "ifunc_removed"           # STT_GNU_IFUNC →
-    COMMON_SYMBOL_RISK       = "common_symbol_risk"      # STT_COMMON exported
+    SYMBOL_TYPE_CHANGED = "symbol_type_changed"     # FUNC→OBJECT, etc.
+    SYMBOL_SIZE_CHANGED = "symbol_size_changed"     # st_size changed
+    IFUNC_INTRODUCED = "ifunc_introduced"        # → STT_GNU_IFUNC
+    IFUNC_REMOVED = "ifunc_removed"           # STT_GNU_IFUNC →
+    COMMON_SYMBOL_RISK = "common_symbol_risk"      # STT_COMMON exported
 
     # Symbol versioning contract
-    SYMBOL_VERSION_DEFINED_REMOVED   = "symbol_version_defined_removed"
-    SYMBOL_VERSION_REQUIRED_ADDED    = "symbol_version_required_added"   # new GLIBC_X
-    SYMBOL_VERSION_REQUIRED_REMOVED  = "symbol_version_required_removed"
+    SYMBOL_VERSION_DEFINED_REMOVED = "symbol_version_defined_removed"
+    SYMBOL_VERSION_REQUIRED_ADDED = "symbol_version_required_added"   # new GLIBC_X
+    SYMBOL_VERSION_REQUIRED_REMOVED = "symbol_version_required_removed"
 
     # DWARF layout (Sprint 3)
-    DWARF_INFO_MISSING         = "dwarf_info_missing"         # new binary stripped of -g
-    STRUCT_SIZE_CHANGED        = "struct_size_changed"        # sizeof(T) changed
+    DWARF_INFO_MISSING = "dwarf_info_missing"         # new binary stripped of -g
+    STRUCT_SIZE_CHANGED = "struct_size_changed"        # sizeof(T) changed
     STRUCT_FIELD_OFFSET_CHANGED = "struct_field_offset_changed" # field moved
-    STRUCT_FIELD_REMOVED       = "struct_field_removed"       # field deleted
-    STRUCT_FIELD_TYPE_CHANGED  = "struct_field_type_changed"  # field type/size changed
-    STRUCT_ALIGNMENT_CHANGED   = "struct_alignment_changed"   # alignof(T) changed
+    STRUCT_FIELD_REMOVED = "struct_field_removed"       # field deleted
+    STRUCT_FIELD_TYPE_CHANGED = "struct_field_type_changed"  # field type/size changed
+    STRUCT_ALIGNMENT_CHANGED = "struct_alignment_changed"   # alignof(T) changed
     ENUM_UNDERLYING_SIZE_CHANGED = "enum_underlying_size_changed"  # int→long
 
     # DWARF advanced (Sprint 4)
     CALLING_CONVENTION_CHANGED = "calling_convention_changed"   # DW_AT_calling_convention drift
-    STRUCT_PACKING_CHANGED     = "struct_packing_changed"       # __attribute__((packed)) added/removed
-    TYPE_VISIBILITY_CHANGED    = "type_visibility_changed"      # typeinfo/vtable visibility changed
-    TOOLCHAIN_FLAG_DRIFT       = "toolchain_flag_drift"         # -fshort-enums/-fpack-struct drift
+    STRUCT_PACKING_CHANGED = "struct_packing_changed"       # __attribute__((packed)) added/removed
+    TYPE_VISIBILITY_CHANGED = "type_visibility_changed"      # typeinfo/vtable visibility changed
+    TOOLCHAIN_FLAG_DRIFT = "toolchain_flag_drift"         # -fshort-enums/-fpack-struct drift
 
 
 class Verdict(str, Enum):
@@ -585,7 +585,7 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_mangles = set(old_by_mangled)
     new_mangles = set(new_by_mangled)
     removed_funcs = [old_by_mangled[m] for m in (old_mangles - new_mangles)]
-    added_funcs   = [new_by_mangled[m] for m in (new_mangles - old_mangles)]
+    added_funcs = [new_by_mangled[m] for m in (new_mangles - old_mangles)]
 
     # Build sig-keyed lookup over newly-added functions
     added_by_sig: dict[tuple[str, tuple[str, ...]], Function] = {}
@@ -1144,9 +1144,9 @@ def _diff_advanced_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
     _kind_map = {
         "calling_convention_changed": ChangeKind.CALLING_CONVENTION_CHANGED,
-        "struct_packing_changed":     ChangeKind.STRUCT_PACKING_CHANGED,
-        "toolchain_flag_drift":       ChangeKind.TOOLCHAIN_FLAG_DRIFT,
-        "type_visibility_changed":    ChangeKind.TYPE_VISIBILITY_CHANGED,
+        "struct_packing_changed": ChangeKind.STRUCT_PACKING_CHANGED,
+        "toolchain_flag_drift": ChangeKind.TOOLCHAIN_FLAG_DRIFT,
+        "type_visibility_changed": ChangeKind.TYPE_VISIBILITY_CHANGED,
     }
 
     return [

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -60,7 +60,7 @@ class FieldInfo:
     byte_offset: int    # DW_AT_data_member_location
     byte_size: int      # size of the field's type (0 if unknown)
     bit_offset: int = 0 # for bitfields: normalised bit offset from LSB
-    bit_size: int   = 0 # for bitfields: width in bits (0 = not a bitfield)
+    bit_size: int = 0 # for bitfields: width in bits (0 = not a bitfield)
 
 
 @dataclass
@@ -433,7 +433,7 @@ def _process_enum_named(
         if child.tag == "DW_TAG_enumerator":
             member_name = _attr_str(child, "DW_AT_name")
             # DW_AT_const_value may be signed (DW_FORM_sdata → negative values)
-            member_val  = _attr_int(child, "DW_AT_const_value")
+            member_val = _attr_int(child, "DW_AT_const_value")
             if member_name:
                 enum.members[member_name] = member_val
 
@@ -542,7 +542,7 @@ def _compute_type_info(  # noqa: PLR0911
                 inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (f"{inner_name} *", ptr_size)
             except Exception:  # noqa: BLE001
-                pass
+                return ("void *", ptr_size)
         return ("void *", ptr_size)
 
     if tag in ("DW_TAG_reference_type", "DW_TAG_rvalue_reference_type"):
@@ -554,7 +554,7 @@ def _compute_type_info(  # noqa: PLR0911
                 inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (f"{inner_name} {suffix}", ref_size)
             except Exception:  # noqa: BLE001
-                pass
+                return (f"? {suffix}", ref_size)
         return (f"? {suffix}", ref_size)
 
     if tag in ("DW_TAG_const_type", "DW_TAG_volatile_type", "DW_TAG_restrict_type"):
@@ -565,7 +565,7 @@ def _compute_type_info(  # noqa: PLR0911
                 qualifier = tag.split("_")[2].lower()  # const / volatile / restrict
                 return (f"{qualifier} {inner_name}", size)
             except Exception:  # noqa: BLE001
-                pass
+                return (tag.split("_")[2].lower(), None)
 
     if tag == "DW_TAG_typedef":
         name = _attr_str(die, "DW_AT_name")
@@ -575,7 +575,7 @@ def _compute_type_info(  # noqa: PLR0911
                 inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (name or inner_name, size)
             except Exception:  # noqa: BLE001
-                pass
+                return (name or "typedef", 0)
         return (name or "typedef", 0)
 
     if tag == "DW_TAG_array_type":
@@ -586,7 +586,7 @@ def _compute_type_info(  # noqa: PLR0911
                 inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
                 return (f"{inner_name}[]", size)
             except Exception:  # noqa: BLE001
-                pass
+                return ("array", size)
         return ("array", size)
 
     if tag == "DW_TAG_subroutine_type":

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -565,7 +565,7 @@ def _compute_type_info(  # noqa: PLR0911
                 qualifier = tag.split("_")[2].lower()  # const / volatile / restrict
                 return (f"{qualifier} {inner_name}", size)
             except Exception:  # noqa: BLE001
-                return (tag.split("_")[2].lower(), None)
+                return (tag.split("_")[2].lower(), 0)
 
     if tag == "DW_TAG_typedef":
         name = _attr_str(die, "DW_AT_name")

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -30,30 +30,30 @@ log = logging.getLogger(__name__)
 
 class SymbolBinding(str, Enum):
     GLOBAL = "global"
-    WEAK   = "weak"
-    LOCAL  = "local"
-    OTHER  = "other"
+    WEAK = "weak"
+    LOCAL = "local"
+    OTHER = "other"
 
 
 class SymbolType(str, Enum):
-    FUNC   = "func"
+    FUNC = "func"
     OBJECT = "object"
-    TLS    = "tls"
-    IFUNC  = "ifunc"   # STT_GNU_IFUNC
+    TLS = "tls"
+    IFUNC = "ifunc"   # STT_GNU_IFUNC
     COMMON = "common"  # STT_COMMON
     NOTYPE = "notype"
-    OTHER  = "other"
+    OTHER = "other"
 
 
 @dataclass
 class ElfSymbol:
     name: str
-    binding:  SymbolBinding = SymbolBinding.GLOBAL
-    sym_type: SymbolType    = SymbolType.FUNC
-    size:     int           = 0
-    version:  str           = ""       # version tag from .gnu.version_d/.gnu.version_r
-    is_default: bool        = True
-    visibility: str         = "default"  # default / hidden / protected / internal
+    binding: SymbolBinding = SymbolBinding.GLOBAL
+    sym_type: SymbolType = SymbolType.FUNC
+    size: int = 0
+    version: str = ""       # version tag from .gnu.version_d/.gnu.version_r
+    is_default: bool = True
+    visibility: str = "default"  # default / hidden / protected / internal
 
 
 @dataclass
@@ -63,9 +63,9 @@ class ElfMetadata:
     NOTE: Do NOT add ``frozen=True`` to this dataclass — ``@cached_property``
     (used by ``symbol_map``) requires a writable instance ``__dict__``.
     """
-    soname:  str = ""
-    needed:  list[str] = field(default_factory=list)
-    rpath:   str = ""
+    soname: str = ""
+    needed: list[str] = field(default_factory=list)
+    rpath: str = ""
     runpath: str = ""
 
     # Symbol versions defined by this library (.gnu.version_d)
@@ -93,17 +93,17 @@ class ElfMetadata:
 
 _BINDING_MAP: dict[str, SymbolBinding] = {
     "STB_GLOBAL": SymbolBinding.GLOBAL,
-    "STB_WEAK":   SymbolBinding.WEAK,
-    "STB_LOCAL":  SymbolBinding.LOCAL,
+    "STB_WEAK": SymbolBinding.WEAK,
+    "STB_LOCAL": SymbolBinding.LOCAL,
 }
 
 _TYPE_MAP: dict[str, SymbolType] = {
-    "STT_FUNC":      SymbolType.FUNC,
-    "STT_OBJECT":    SymbolType.OBJECT,
-    "STT_TLS":       SymbolType.TLS,
+    "STT_FUNC": SymbolType.FUNC,
+    "STT_OBJECT": SymbolType.OBJECT,
+    "STT_TLS": SymbolType.TLS,
     "STT_GNU_IFUNC": SymbolType.IFUNC,
-    "STT_COMMON":    SymbolType.COMMON,
-    "STT_NOTYPE":    SymbolType.NOTYPE,
+    "STT_COMMON": SymbolType.COMMON,
+    "STT_NOTYPE": SymbolType.NOTYPE,
 }
 
 _HIDDEN_VISIBILITIES = frozenset({"STV_HIDDEN", "STV_INTERNAL"})
@@ -196,8 +196,8 @@ def _parse_dynsym(section: SymbolTableSection, meta: ElfMetadata) -> None:
             continue
 
         binding_str = sym.entry.st_info.bind
-        type_str    = sym.entry.st_info.type
-        vis_str     = sym.entry.st_other.visibility
+        type_str = sym.entry.st_info.type
+        vis_str = sym.entry.st_other.visibility
 
         binding = _BINDING_MAP.get(binding_str, SymbolBinding.OTHER)
 
@@ -210,7 +210,7 @@ def _parse_dynsym(section: SymbolTableSection, meta: ElfMetadata) -> None:
             continue
 
         sym_type = _TYPE_MAP.get(type_str, SymbolType.OTHER)
-        name     = sym.name
+        name = sym.name
 
         # NOTE: pyelftools does NOT embed version suffixes (@@/@ notation) in
         # sym.name — that's a readelf text-output artifact. Symbol version info

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
 
 # Verdict colours matching ABICC's visual style
 _VERDICT_STYLE: dict[str, tuple[str, str]] = {
-    "BREAKING":   ("#b71c1c", "#ffcdd2"),
+    "BREAKING": ("#b71c1c", "#ffcdd2"),
     "COMPATIBLE": ("#1b5e20", "#c8e6c9"),
-    "NO_CHANGE":  ("#0d47a1", "#bbdefb"),
+    "NO_CHANGE": ("#0d47a1", "#bbdefb"),
 }
 
 _CSS = """

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -48,7 +48,7 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     if d.get("elf"):
         elf = d["elf"]
         for sym in elf.get("symbols", []):
-            sym["binding"]  = sym["binding"] if isinstance(sym["binding"], str) else sym["binding"].value
+            sym["binding"] = sym["binding"] if isinstance(sym["binding"], str) else sym["binding"].value
             sym["sym_type"] = sym["sym_type"] if isinstance(sym["sym_type"], str) else sym["sym_type"].value
 
     # Convert all sets → sorted lists (needed for AdvancedDwarfMetadata.packed_structs

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -16,10 +16,10 @@ import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 
-REPO_DIR     = Path(__file__).parent.parent
+REPO_DIR = Path(__file__).parent.parent
 EXAMPLES_DIR = REPO_DIR / "examples"
-REPORT_DIR   = REPO_DIR / "benchmark_reports"
-BUILD_DIR    = REPORT_DIR / "_build"
+REPORT_DIR = REPO_DIR / "benchmark_reports"
+BUILD_DIR = REPORT_DIR / "_build"
 
 
 @dataclass
@@ -114,7 +114,7 @@ def run_abidiff(v1_so: Path, v2_so: Path, case: str, rdir: Path) -> ToolResult:
 
     out = r.stdout or r.stderr
     (rdir / f"{case}_abidiff.txt").write_text(out)
-    changes = [l.strip() for l in out.splitlines() if l.strip().startswith("[")]
+    changes = [line.strip() for line in out.splitlines() if line.strip().startswith("[")]
     return ToolResult(verdict=verdict, changes=changes, raw_output=out,
                       report_path=f"{case}_abidiff.txt")
 
@@ -161,8 +161,8 @@ def run_abicc(v1_so: Path, v2_so: Path, v1_h: Path, v2_h: Path,
     else:
         verdict = "ERROR"
 
-    changes = [l.strip() for l in out.splitlines()
-               if any(k in l for k in ("removed", "added", "changed")) and l.strip()]
+    changes = [line.strip() for line in out.splitlines()
+               if any(keyword in line for keyword in ("removed", "added", "changed")) and line.strip()]
     return ToolResult(verdict=verdict, changes=changes[:8], raw_output=out,
                       report_path=f"{case}_abicc_report.html")
 
@@ -190,7 +190,7 @@ def main() -> None:
 
     for case_dir in cases:
         name = case_dir.name
-        ext  = ".cpp" if (case_dir / "v1.cpp").exists() else ".c"
+        ext = ".cpp" if (case_dir / "v1.cpp").exists() else ".c"
         v1_src = case_dir / f"v1{ext}"
         v2_src = case_dir / f"v2{ext}"
 
@@ -205,8 +205,8 @@ def main() -> None:
 
         v1_so = bdir / "lib_v1.so"
         v2_so = bdir / "lib_v2.so"
-        v1_h  = bdir / "v1.h"
-        v2_h  = bdir / "v2.h"
+        v1_h = bdir / "v1.h"
+        v2_h = bdir / "v2.h"
 
         if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
             print(f"  {name:<33} COMPILE_ERR")
@@ -229,8 +229,8 @@ def main() -> None:
         eff_v1_h = _best_h("v1", v1_h, case_dir)
         eff_v2_h = _best_h("v2", v2_h, case_dir)
 
-        ac  = run_abicheck(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
-        ab  = run_abidiff(v1_so, v2_so, name, rdir)
+        ac = run_abicheck(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
+        ab = run_abidiff(v1_so, v2_so, name, rdir)
         acc = run_abicc(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
 
         verdicts = {ac.verdict, ab.verdict, acc.verdict} - {"SKIP", "ERROR"}
@@ -242,17 +242,17 @@ def main() -> None:
         results.append({"case": name,
                         "abicheck": ac.verdict, "abidiff": ab.verdict, "abicc": acc.verdict,
                         "abicheck_changes": ac.changes,
-                        "abidiff_changes":  ab.changes,
-                        "abicc_changes":    acc.changes})
+                        "abidiff_changes": ab.changes,
+                        "abicc_changes": acc.changes})
 
     # ── Summary ──
-    total    = len(results)
-    skip     = lambda r: "SKIP" in (r["abicheck"], r["abidiff"], r["abicc"])
-    valid    = [r for r in results if not skip(r)]
-    all3     = sum(1 for r in valid if r["abicheck"] == r["abidiff"] == r["abicc"])
-    ac_ab    = sum(1 for r in valid if r["abicheck"] == r["abidiff"])
-    ac_acc   = sum(1 for r in valid if r["abicheck"] == r["abicc"])
-    n        = len(valid)
+    total = len(results)
+    skip = lambda r: "SKIP" in (r["abicheck"], r["abidiff"], r["abicc"])
+    valid = [r for r in results if not skip(r)]
+    all3 = sum(1 for r in valid if r["abicheck"] == r["abidiff"] == r["abicc"])
+    ac_ab = sum(1 for r in valid if r["abicheck"] == r["abidiff"])
+    ac_acc = sum(1 for r in valid if r["abicheck"] == r["abicc"])
+    n = len(valid)
 
     print("\n" + "─" * 84)
     print(f"  Total cases: {total}   (valid for comparison: {n})")

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -19,43 +19,43 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 #
 CASES = [
     # ✅ Symbol removed from ELF dynsym → FUNC_REMOVED → BREAKING
-    ("case01_symbol_removal",       "BREAKING",   "v1.c",     "v2.c"),
+    ("case01_symbol_removal", "BREAKING", "v1.c", "v2.c"),
     # ✅ Parameter type change visible via castxml → FUNC_PARAMS_CHANGED → BREAKING
-    ("case02_param_type_change",    "BREAKING",   "v1.c",     "v2.c"),
+    ("case02_param_type_change", "BREAKING", "v1.c", "v2.c"),
     # ✅ New symbol added → FUNC_ADDED → COMPATIBLE
-    ("case03_compat_addition",      "COMPATIBLE", "v1.c",     "v2.c"),
+    ("case03_compat_addition", "COMPATIBLE", "v1.c", "v2.c"),
     # ✅ Identical libs → NO_CHANGE
-    ("case04_no_change",            "NO_CHANGE",  "v1.c",     "v1.c"),
+    ("case04_no_change", "NO_CHANGE", "v1.c", "v1.c"),
     # 📋 SONAME is a policy attribute, not tracked by checker → NO_CHANGE
-    ("case05_soname",               "NO_CHANGE",  "bad.c",    "good.c"),
+    ("case05_soname", "NO_CHANGE", "bad.c", "good.c"),
     # ✅ internal_helper/another_impl hidden in good.c → removed from dynsym → BREAKING
-    ("case06_visibility",           "BREAKING",   "bad.c",    "good.c"),
+    ("case06_visibility", "BREAKING", "bad.c", "good.c"),
     # ✅ Struct size change detected via castxml → TYPE_SIZE_CHANGED → BREAKING
-    ("case07_struct_layout",        "BREAKING",   "v1.c",     "v2.c"),
+    ("case07_struct_layout", "BREAKING", "v1.c", "v2.c"),
     # ✅ Enum member value changes detected via _diff_enums() → BREAKING
-    ("case08_enum_value_change",    "BREAKING",   "v1.c",     "v2.c"),
+    ("case08_enum_value_change", "BREAKING", "v1.c", "v2.c"),
     # ✅ vtable reorder/change detected → TYPE_VTABLE_CHANGED → BREAKING
-    ("case09_cpp_vtable",           "BREAKING",   "v1.cpp",   "v2.cpp"),
+    ("case09_cpp_vtable", "BREAKING", "v1.cpp", "v2.cpp"),
     # ✅ Return type change detected via castxml → FUNC_RETURN_CHANGED → BREAKING
-    ("case10_return_type",          "BREAKING",   "v1.c",     "v2.c"),
+    ("case10_return_type", "BREAKING", "v1.c", "v2.c"),
     # ⚠️ int→long variable type change: castxml parses type from header but
     #    global var definitions in .c may not appear in ELF dynsym reliably → NO_CHANGE
-    ("case11_global_var_type",      "BREAKING",   "v1.c",     "v2.c"),
+    ("case11_global_var_type", "BREAKING", "v1.c", "v2.c"),
     # ✅ Function inlined away → disappears from .so → FUNC_REMOVED → BREAKING
-    ("case12_function_removed",     "BREAKING",   "v1.c",     "v2.c"),
+    ("case12_function_removed", "BREAKING", "v1.c", "v2.c"),
     # 📋 Symbol versioning adds @@VER tags; checker strips @-suffix → NO_CHANGE
-    ("case13_symbol_versioning",    "NO_CHANGE",  "bad.c",    "good.c"),
+    ("case13_symbol_versioning", "NO_CHANGE", "bad.c", "good.c"),
     # ✅ Class size change (private member added) → TYPE_SIZE_CHANGED → BREAKING
-    ("case14_cpp_class_size",       "BREAKING",   "v1.cpp",   "v2.cpp"),
+    ("case14_cpp_class_size", "BREAKING", "v1.cpp", "v2.cpp"),
     # ✅ noexcept removed → FUNC_NOEXCEPT_REMOVED → BREAKING (castxml sees noexcept attr)
-    ("case15_noexcept_change",      "BREAKING",   "v1.cpp",   "v2.cpp"),
+    ("case15_noexcept_change", "BREAKING", "v1.cpp", "v2.cpp"),
     # ✅ Symbol appears in v2 that was inline in v1 → FUNC_ADDED → COMPATIBLE
-    ("case16_inline_to_non_inline", "COMPATIBLE", "v1.hpp",   "v2.hpp"),
+    ("case16_inline_to_non_inline", "COMPATIBLE", "v1.hpp", "v2.hpp"),
     # ✅ Explicit-instantiated template size grows → TYPE_SIZE_CHANGED → BREAKING
-    ("case17_template_abi",         "BREAKING",   "v1.hpp",   "v2.hpp"),
+    ("case17_template_abi", "BREAKING", "v1.hpp", "v2.hpp"),
     # ✅ castxml processes headers transitively: ThirdPartyHandle (4→8 bytes) detected
     #    via TYPE_SIZE_CHANGED → BREAKING. This is correct behaviour — the struct grew.
-    ("case18_dependency_leak",      "BREAKING",   "foo_v1.h", "foo_v2.h"),
+    ("case18_dependency_leak", "BREAKING", "foo_v1.h", "foo_v2.h"),
 ]
 
 

--- a/tests/test_abidiff_parity.py
+++ b/tests/test_abidiff_parity.py
@@ -175,7 +175,7 @@ def _run_abidiff(old: Path, new: Path) -> str:
 # Split into confirmed-parity and known-divergence sets
 # ---------------------------------------------------------------------------
 _CONFIRMED = [c for c in PARITY_CASES if not c[6]]
-_DIVERGE   = [c for c in PARITY_CASES if c[6]]
+_DIVERGE = [c for c in PARITY_CASES if c[6]]
 
 
 @pytest.mark.libabigail
@@ -200,7 +200,7 @@ def test_confirmed_parity(
     ab = _run_abidiff(v1, v2)
 
     assert ac == abicheck_exp, f"abicheck: expected {abicheck_exp}, got {ac}"
-    assert ab == abidiff_exp,  f"abidiff: expected {abidiff_exp}, got {ab}"
+    assert ab == abidiff_exp, f"abidiff: expected {abidiff_exp}, got {ab}"
     assert ac == ab, f"PARITY BROKEN: abicheck={ac}, abidiff={ab}"
 
 


### PR DESCRIPTION
### Motivation
- Address CodeFactor / pycodestyle style violations (multiple spaces before/after operators and ambiguous loop variables) and Bandit findings for `try/except: pass` patterns to improve code quality and robustness.
- Make minimal, behavior-preserving fixes where possible and replace silent exception swallowing with explicit fallbacks in DWARF type resolution.

### Description
- Normalised spacing (E221/E241) across core modules and tests including `abicheck/checker.py`, `abicheck/elf_metadata.py`, `abicheck/html_report.py`, `abicheck/serialization.py`, and several test files to satisfy style checks.
- Replaced ambiguous loop variable `l` with descriptive names (`line`, `keyword`) in `scripts/benchmark_comparison.py` to fix E741 and improve readability.
- Removed `try/except: pass` patterns in DWARF type resolution (`abicheck/dwarf_metadata.py`) and returned explicit fallback values to address Bandit B110 while keeping behavior explicit.
- Minor whitespace/formatting adjustments in `scripts/benchmark_comparison.py`, `tests/test_abi_examples.py`, and `tests/test_abidiff_parity.py` to avoid cascading style issues.

### Testing
- Ran `pycodestyle --select=E221,E241,E741 abicheck tests scripts` and confirmed the selected style issues are resolved.
- Ran `bandit -q -r abicheck -s B101,B404,B405,B603 -t B110` with the targeted checks and observed no outstanding B110-related findings for modified locations.
- Ran the full test suite with `PYTHONPATH=. pytest -q` which passed with `221 passed, 38 skipped` (note: running `pytest -q` without `PYTHONPATH` initially raised `ModuleNotFoundError` due to test import path expectations).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd175c85c832baad039e4ea5c9328)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Code formatting and whitespace normalization across the codebase for improved consistency.

* **Bug Fixes**
  * DWARF type-resolution now returns safe, interpretable defaults on inner-type resolution failures instead of silently falling through.

* **Tests**
  * Test cases reformatted for compact spacing; assertions and test scaffolding spacing normalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->