### PR TITLE
fix(benchmark): address PR #22 review feedback — header fixes + script improvements

### DIFF
--- a/docs/benchmark_report.md
+++ b/docs/benchmark_report.md
@@ -47,8 +47,10 @@ abidiff without `--headers-dir` reads DWARF debug info compiled into the `.so` w
 It detects *that* something changed but classifies it as `COMPATIBLE` (exit=4) because
 it cannot determine binary impact without full header type info.
 
-With `--headers-dir` pointing to correct headers, abidiff would likely agree on BREAKING
-for most of these cases. **abicheck uses castxml → always gets full type info → correct verdict.**
+With `--headers-dir`, abidiff returns **NO_CHANGE** (exit=0) for most of these cases —
+it filters indirect/internal changes as non-public API. Still a miss, but for a different reason:
+abidiff treats struct layout as an implementation detail unless directly in the public signature.
+**abicheck uses castxml → always gets full type info → correct BREAKING verdict.**
 
 ## Why ABICC fails (9/14 cases)
 

--- a/examples/case04_no_change/v1.h
+++ b/examples/case04_no_change/v1.h
@@ -1,2 +1,1 @@
-int compute(int x);
-int helper(int x);
+int stable_api(int x);

--- a/examples/case04_no_change/v2.h
+++ b/examples/case04_no_change/v2.h
@@ -1,2 +1,1 @@
-int compute(int x);
-int helper(int x);
+int stable_api(int x);

--- a/examples/case08_enum_value_change/v2.h
+++ b/examples/case08_enum_value_change/v2.h
@@ -1,2 +1,2 @@
-typedef enum { RED=0, GREEN=2, BLUE=3 } Color;
+typedef enum { RED=0, YELLOW=1, GREEN=2, BLUE=3 } Color;
 Color get_color(void);

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -197,7 +197,8 @@ def run_abicc(v1_so: Path, v2_so: Path, v1_h: Path, v2_h: Path,
 # ── Helpers ───────────────────────────────────────────────────────────────────
 def _col(v: str) -> str:
     colors = {"BREAKING": "\033[91m", "COMPATIBLE": "\033[93m",
-              "NO_CHANGE": "\033[92m", "ERROR": "\033[95m", "SKIP": "\033[90m"}
+              "NO_CHANGE": "\033[92m", "ERROR": "\033[95m",
+              "TIMEOUT": "\033[95m", "SKIP": "\033[90m"}
     return f"{colors.get(v, '')}{v:<14}\033[0m"
 
 

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -2,24 +2,24 @@
 """
 Benchmark: abicheck vs ABICC vs abidiff on abicheck examples.
 
+Runs all three tools on each example pair (v1/v2) and prints a comparison table.
+abidiff is run twice: without headers (ELF-only) and with --headers-dir.
+
 Usage: python3 scripts/benchmark_comparison.py
 """
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
-import sys
-import textwrap
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 
-REPO_DIR = Path(__file__).parent.parent
+REPO_DIR     = Path(__file__).parent.parent
 EXAMPLES_DIR = REPO_DIR / "examples"
-REPORT_DIR = REPO_DIR / "benchmark_reports"
-BUILD_DIR = REPORT_DIR / "_build"
+REPORT_DIR   = REPO_DIR / "benchmark_reports"
+BUILD_DIR    = REPORT_DIR / "_build"
 
 
 @dataclass
@@ -43,16 +43,19 @@ def compile_so(src: Path, out_so: Path) -> bool:
 
 
 def make_header(src: Path, out_h: Path) -> None:
-    """Copy explicit .h/.hpp if present. For .cpp sources without .h, skip — do not
-    generate broken fallback headers from naive regex scraping of C++ source."""
-    # Prefer explicit .h next to source
+    """Copy explicit .h/.hpp if present.
+
+    For C sources without a .h, generates a minimal header by stripping function
+    bodies. Not suitable for C++ sources — callers must provide explicit .h/.hpp.
+    Warns when falling back to C-scraper to catch cases where a .h should be added.
+    """
     for ext in (".h", ".hpp"):
         h = src.with_suffix(ext)
         if h.exists():
             shutil.copy(h, out_h)
             return
-    # For C sources without .h, generate minimal header by stripping bodies
     if src.suffix == ".c":
+        print(f"    [warn] no explicit .h for {src.name} — generating from source (add a .h file)")
         lines = []
         for line in src.read_text().splitlines():
             stripped = line.strip()
@@ -66,7 +69,16 @@ def make_header(src: Path, out_h: Path) -> None:
             elif "}" not in stripped:
                 lines.append(line)
         out_h.write_text("\n".join(lines))
-    # For .cpp without explicit .h: leave out_h absent — abicheck/ABICC will use ELF-only
+    # For .cpp without explicit .h: leave out_h absent — ELF-only mode
+
+
+def _best_h(ver: str, bdir_h: Path, src_dir: Path) -> Path:
+    """Return the best available header: explicit in src_dir, then generated copy."""
+    for ext in (".h", ".hpp"):
+        p = src_dir / f"{ver}{ext}"
+        if p.exists():
+            return p
+    return bdir_h  # may not exist — callers must check .exists()
 
 
 # ── abicheck ──────────────────────────────────────────────────────────────────
@@ -96,27 +108,40 @@ def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path, v2_h: Path,
         return ToolResult(verdict=result.verdict.value, changes=changes,
                           raw_output=to_markdown(result),
                           report_path=f"{case}_abicheck.md")
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         return ToolResult(verdict="ERROR", raw_output=str(exc))
 
 
-# ── abidiff ───────────────────────────────────────────────────────────────────
-def run_abidiff(v1_so: Path, v2_so: Path, case: str, rdir: Path) -> ToolResult:
+# ── abidiff (two modes) ───────────────────────────────────────────────────────
+def _abidiff_verdict(returncode: int) -> str:
+    if returncode & 1:
+        return "ERROR"
+    if returncode & 8:
+        return "BREAKING"
+    if returncode & 4:
+        return "COMPATIBLE"
+    return "NO_CHANGE"
+
+
+def run_abidiff(v1_so: Path, v2_so: Path, case: str, rdir: Path,
+                headers_dir: Path | None = None) -> ToolResult:
+    """Run abidiff, optionally with --headers-dir for public-API filtering."""
     if not shutil.which("abidiff"):
         return ToolResult(verdict="SKIP")
 
-    r = subprocess.run(["abidiff", "--no-show-locs", str(v1_so), str(v2_so)],
-                       capture_output=True, text=True, timeout=30)
-    code = r.returncode
-    verdict = ("ERROR" if code & 1 else
-               "BREAKING" if code & 8 else
-               "COMPATIBLE" if code & 4 else "NO_CHANGE")
+    cmd = ["abidiff", "--no-show-locs"]
+    if headers_dir and headers_dir.is_dir():
+        cmd += ["--headers-dir1", str(headers_dir), "--headers-dir2", str(headers_dir)]
+    cmd += [str(v1_so), str(v2_so)]
 
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    verdict = _abidiff_verdict(r.returncode)
     out = r.stdout or r.stderr
-    (rdir / f"{case}_abidiff.txt").write_text(out)
-    changes = [line.strip() for line in out.splitlines() if line.strip().startswith("[")]
+    suffix = "_hdr" if headers_dir else ""
+    (rdir / f"{case}_abidiff{suffix}.txt").write_text(out)
+    changes = [ln.strip() for ln in out.splitlines() if ln.strip().startswith("[")]
     return ToolResult(verdict=verdict, changes=changes, raw_output=out,
-                      report_path=f"{case}_abidiff.txt")
+                      report_path=f"{case}_abidiff{suffix}.txt")
 
 
 # ── ABICC ─────────────────────────────────────────────────────────────────────
@@ -151,7 +176,6 @@ def run_abicc(v1_so: Path, v2_so: Path, v1_h: Path, v2_h: Path,
     out = r.stdout + r.stderr
     (rdir / f"{case}_abicc.txt").write_text(out)
 
-    # exit 0 = compatible, 1 = incompatible
     if r.returncode == 1:
         verdict = "BREAKING"
     elif "Binary compatibility: 100%" in out:
@@ -161,19 +185,20 @@ def run_abicc(v1_so: Path, v2_so: Path, v1_h: Path, v2_h: Path,
     else:
         verdict = "ERROR"
 
-    changes = [line.strip() for line in out.splitlines()
-               if any(keyword in line for keyword in ("removed", "added", "changed")) and line.strip()]
+    changes = [ln.strip() for ln in out.splitlines()
+               if any(k in ln for k in ("removed", "added", "changed")) and ln.strip()]
     return ToolResult(verdict=verdict, changes=changes[:8], raw_output=out,
                       report_path=f"{case}_abicc_report.html")
 
 
-# ── Main ──────────────────────────────────────────────────────────────────────
+# ── Helpers ───────────────────────────────────────────────────────────────────
 def _col(v: str) -> str:
     colors = {"BREAKING": "\033[91m", "COMPATIBLE": "\033[93m",
               "NO_CHANGE": "\033[92m", "ERROR": "\033[95m", "SKIP": "\033[90m"}
-    return f"{colors.get(v,'')}{v:<12}\033[0m"
+    return f"{colors.get(v, '')}{v:<14}\033[0m"
 
 
+# ── Main ──────────────────────────────────────────────────────────────────────
 def main() -> None:
     REPORT_DIR.mkdir(exist_ok=True)
     BUILD_DIR.mkdir(exist_ok=True)
@@ -183,30 +208,28 @@ def main() -> None:
         if d.is_dir() and ((d / "v1.c").exists() or (d / "v1.cpp").exists())
     )
 
-    results: list[dict] = []
+    results: list[dict[str, object]] = []
 
-    print(f"\n{'Case':<35} {'abicheck':<14} {'abidiff':<14} {'ABICC':<14} agree?")
-    print("─" * 84)
+    print(f"\n{'Case':<35} {'abicheck':<16} {'abidiff':<16} {'abidiff+hdr':<16} {'ABICC':<14}")
+    print("─" * 100)
 
     for case_dir in cases:
-        name = case_dir.name
-        ext = ".cpp" if (case_dir / "v1.cpp").exists() else ".c"
-        v1_src = case_dir / f"v1{ext}"
-        v2_src = case_dir / f"v2{ext}"
+        name    = case_dir.name
+        ext     = ".cpp" if (case_dir / "v1.cpp").exists() else ".c"
+        v1_src  = case_dir / f"v1{ext}"
+        v2_src  = case_dir / f"v2{ext}"
+        if not v2_src.exists():
+            v2_src = v1_src   # case04: no change
 
         rdir = REPORT_DIR / name
         rdir.mkdir(exist_ok=True)
         bdir = BUILD_DIR / name
         bdir.mkdir(exist_ok=True)
 
-        # case04: no v2 → copy v1 (no change)
-        if not v2_src.exists():
-            v2_src = v1_src
-
         v1_so = bdir / "lib_v1.so"
         v2_so = bdir / "lib_v2.so"
-        v1_h = bdir / "v1.h"
-        v2_h = bdir / "v2.h"
+        v1_h  = bdir / "v1.h"
+        v2_h  = bdir / "v2.h"
 
         if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
             print(f"  {name:<33} COMPILE_ERR")
@@ -215,57 +238,48 @@ def main() -> None:
         make_header(v1_src, v1_h)
         make_header(v2_src, v2_h)
 
-        # For ABICC/abicheck: prefer explicit headers in case dir over generated ones
-        # (make_header copies them to bdir; if not present, pass case_dir .h/.hpp directly)
-        def _best_h(ver: str, bdir_h: Path, case_dir: Path) -> Path:
-            if bdir_h.exists():
-                return bdir_h
-            for ext in (".h", ".hpp"):
-                p = case_dir / f"{ver}{ext}"
-                if p.exists():
-                    return p
-            return bdir_h  # may not exist — callers handle missing gracefully
-
         eff_v1_h = _best_h("v1", v1_h, case_dir)
         eff_v2_h = _best_h("v2", v2_h, case_dir)
 
-        ac = run_abicheck(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
-        ab = run_abidiff(v1_so, v2_so, name, rdir)
-        acc = run_abicc(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
+        ac      = run_abicheck(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
+        ab      = run_abidiff(v1_so, v2_so, name, rdir)
+        ab_hdr  = run_abidiff(v1_so, v2_so, name, rdir, headers_dir=case_dir)
+        acc     = run_abicc(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
 
-        verdicts = {ac.verdict, ab.verdict, acc.verdict} - {"SKIP", "ERROR"}
-        agree = "✅" if len(verdicts) <= 1 else (
-            "~" if ac.verdict in (ab.verdict, acc.verdict) else "❌")
+        print(f"  {name:<33} {_col(ac.verdict)} {_col(ab.verdict)} {_col(ab_hdr.verdict)} {_col(acc.verdict)}")
 
-        print(f"  {name:<33} {_col(ac.verdict)} {_col(ab.verdict)} {_col(acc.verdict)} {agree}")
+        results.append({
+            "case":             name,
+            "abicheck":         ac.verdict,
+            "abidiff":          ab.verdict,
+            "abidiff_headers":  ab_hdr.verdict,
+            "abicc":            acc.verdict,
+            "abicheck_changes": ac.changes,
+            "abidiff_changes":  ab.changes,
+            "abicc_changes":    acc.changes,
+        })
 
-        results.append({"case": name,
-                        "abicheck": ac.verdict, "abidiff": ab.verdict, "abicc": acc.verdict,
-                        "abicheck_changes": ac.changes,
-                        "abidiff_changes": ab.changes,
-                        "abicc_changes": acc.changes})
-
-    # ── Summary ──
-    total = len(results)
-    skip = lambda r: "SKIP" in (r["abicheck"], r["abidiff"], r["abicc"])
-    valid = [r for r in results if not skip(r)]
-    all3 = sum(1 for r in valid if r["abicheck"] == r["abidiff"] == r["abicc"])
+    # ── Summary ──────────────────────────────────────────────────────────────
+    valid = [r for r in results
+             if "SKIP" not in (r["abicheck"], r["abidiff"], r["abicc"])]
+    n     = len(valid)
+    all3  = sum(1 for r in valid if r["abicheck"] == r["abidiff"] == r["abicc"])
     ac_ab = sum(1 for r in valid if r["abicheck"] == r["abidiff"])
     ac_acc = sum(1 for r in valid if r["abicheck"] == r["abicc"])
-    n = len(valid)
 
-    print("\n" + "─" * 84)
-    print(f"  Total cases: {total}   (valid for comparison: {n})")
-    print(f"  All three agree:     {all3}/{n} ({100*all3//n if n else 0}%)")
-    print(f"  abicheck == abidiff: {ac_ab}/{n}")
-    print(f"  abicheck == ABICC:   {ac_acc}/{n}")
+    print("\n" + "─" * 100)
+    print(f"  Total cases: {len(results)}   (valid for comparison: {n})")
+    print(f"  All three agree:          {all3}/{n} ({100 * all3 // n if n else 0}%)")
+    print(f"  abicheck == abidiff:      {ac_ab}/{n}")
+    print(f"  abicheck == ABICC:        {ac_acc}/{n}")
 
-    # Divergences
-    divs = [r for r in valid if not (r["abicheck"] == r["abidiff"] == r["abicc"])]
+    divs = [r for r in valid if r["abicheck"] != r["abidiff"] or r["abicheck"] != r["abicc"]]
     if divs:
         print("\n  Divergences:")
         for r in divs:
-            print(f"    {r['case']:<33} ac={r['abicheck']} ab={r['abidiff']} abicc={r['abicc']}")
+            print(f"    {r['case']:<35} ac={r['abicheck']:<12} "
+                  f"ab={r['abidiff']:<12} ab+hdr={r['abidiff_headers']:<12} "
+                  f"abicc={r['abicc']}")
 
     summary = REPORT_DIR / "comparison_summary.json"
     summary.write_text(json.dumps(results, indent=2))

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -134,7 +134,10 @@ def run_abidiff(v1_so: Path, v2_so: Path, case: str, rdir: Path,
         cmd += ["--headers-dir1", str(headers_dir), "--headers-dir2", str(headers_dir)]
     cmd += [str(v1_so), str(v2_so)]
 
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        return ToolResult(verdict="TIMEOUT", raw_output="abidiff timed out")
     verdict = _abidiff_verdict(r.returncode)
     out = r.stdout or r.stderr
     suffix = "_hdr" if headers_dir else ""
@@ -243,37 +246,47 @@ def main() -> None:
 
         ac      = run_abicheck(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
         ab      = run_abidiff(v1_so, v2_so, name, rdir)
-        ab_hdr  = run_abidiff(v1_so, v2_so, name, rdir, headers_dir=case_dir)
+        # Pass resolved headers (eff_v1_h parent) so cases without explicit .h
+        # use the generated header dir rather than the raw case_dir
+        hdr_dir = eff_v1_h.parent if eff_v1_h.exists() else case_dir
+        ab_hdr  = run_abidiff(v1_so, v2_so, name, rdir, headers_dir=hdr_dir)
         acc     = run_abicc(v1_so, v2_so, eff_v1_h, eff_v2_h, name, rdir)
 
         print(f"  {name:<33} {_col(ac.verdict)} {_col(ab.verdict)} {_col(ab_hdr.verdict)} {_col(acc.verdict)}")
 
         results.append({
-            "case":             name,
-            "abicheck":         ac.verdict,
-            "abidiff":          ab.verdict,
-            "abidiff_headers":  ab_hdr.verdict,
-            "abicc":            acc.verdict,
-            "abicheck_changes": ac.changes,
-            "abidiff_changes":  ab.changes,
-            "abicc_changes":    acc.changes,
+            "case":                    name,
+            "abicheck":                ac.verdict,
+            "abidiff":                 ab.verdict,
+            "abidiff_headers":         ab_hdr.verdict,
+            "abicc":                   acc.verdict,
+            "abicheck_changes":        ac.changes,
+            "abidiff_changes":         ab.changes,
+            "abidiff_headers_changes": ab_hdr.changes,
+            "abicc_changes":           acc.changes,
         })
 
     # ── Summary ──────────────────────────────────────────────────────────────
     valid = [r for r in results
-             if "SKIP" not in (r["abicheck"], r["abidiff"], r["abicc"])]
-    n     = len(valid)
-    all3  = sum(1 for r in valid if r["abicheck"] == r["abidiff"] == r["abicc"])
-    ac_ab = sum(1 for r in valid if r["abicheck"] == r["abidiff"])
+             if "SKIP" not in (r["abicheck"], r["abidiff"], r["abidiff_headers"], r["abicc"])]
+    n      = len(valid)
+    all4   = sum(1 for r in valid
+                 if r["abicheck"] == r["abidiff"] == r["abidiff_headers"] == r["abicc"])
+    all3   = sum(1 for r in valid if r["abicheck"] == r["abidiff"] == r["abicc"])
+    ac_ab  = sum(1 for r in valid if r["abicheck"] == r["abidiff"])
+    ac_abh = sum(1 for r in valid if r["abicheck"] == r["abidiff_headers"])
     ac_acc = sum(1 for r in valid if r["abicheck"] == r["abicc"])
 
     print("\n" + "─" * 100)
     print(f"  Total cases: {len(results)}   (valid for comparison: {n})")
-    print(f"  All three agree:          {all3}/{n} ({100 * all3 // n if n else 0}%)")
-    print(f"  abicheck == abidiff:      {ac_ab}/{n}")
-    print(f"  abicheck == ABICC:        {ac_acc}/{n}")
+    print(f"  All four agree:               {all4}/{n} ({100 * all4 // n if n else 0}%)")
+    print(f"  All three (excl abidiff+hdr): {all3}/{n}")
+    print(f"  abicheck == abidiff:          {ac_ab}/{n}")
+    print(f"  abicheck == abidiff+headers:  {ac_abh}/{n}")
+    print(f"  abicheck == ABICC:            {ac_acc}/{n}")
 
-    divs = [r for r in valid if r["abicheck"] != r["abidiff"] or r["abicheck"] != r["abicc"]]
+    divs = [r for r in valid
+            if len({r["abicheck"], r["abidiff"], r["abidiff_headers"], r["abicc"]}) > 1]
     if divs:
         print("\n  Divergences:")
         for r in divs:


### PR DESCRIPTION
## Fixes for PR #22 review feedback

### Header fixes (qa-checker)
- **case04** `v1.h`/`v2.h`: declared `compute/helper` but source exports `stable_api` — fixed
- **case08** `v2.h`: missing `YELLOW=1` member — added (source: `{RED=0, YELLOW=1, GREEN=2, BLUE=3}`)

### Script fixes (intel-arch + qa-checker)
- `_best_h()`: hoisted out of loop to module level, param renamed `src_dir` (was shadowing `case_dir`)
- `skip = lambda`: replaced with inline filter expression (PEP8 E731)
- Removed unused `import os` and `import sys`
- `abidiff`: added second run with `--headers-dir` → new column `abidiff+hdr` in output table

### Docs fix (intel-arch)
- `benchmark_report.md`: corrected claim about `--headers-dir` behavior — gives NO_CHANGE (exit=0), **not** BREAKING; abidiff filters indirect changes as non-public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified rationale for header-aware compatibility checks, noting filtered internal/indirect changes and revised observed outcomes.

* **New Features**
  * Added optional header-based comparison mode and a dedicated report column for header-filtered results; improved multi-tool verdict reporting and layout.

* **Examples**
  * Updated sample cases to show collapsing of function declarations into a stable API and an enum-value addition scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->