### PR TITLE
Refactor remaining CodeFactor complexity hotspots

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .elf_metadata import SymbolBinding
-from .model import AbiSnapshot, EnumType, Function, Visibility
+from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visibility
 
 if TYPE_CHECKING:
     from .suppression import SuppressionList
@@ -341,127 +341,15 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = {t.name: t for t in new.types}
 
     for name, t_old in old_map.items():
-        if name not in new_map:
+        t_new = new_map.get(name)
+        if t_new is None:
             changes.append(Change(
                 kind=ChangeKind.TYPE_REMOVED,
                 symbol=name,
                 description=f"Type removed: {name}",
             ))
             continue
-        t_new = new_map[name]
-
-        if t_old.size_bits is not None and t_new.size_bits is not None:
-            if t_old.size_bits != t_new.size_bits:
-                changes.append(Change(
-                    kind=ChangeKind.TYPE_SIZE_CHANGED,
-                    symbol=name,
-                    description=f"Size changed: {name} ({t_old.size_bits} → {t_new.size_bits} bits)",
-                    old_value=str(t_old.size_bits),
-                    new_value=str(t_new.size_bits),
-                ))
-
-        if t_old.alignment_bits is not None and t_new.alignment_bits is not None:
-            if t_old.alignment_bits != t_new.alignment_bits:
-                changes.append(Change(
-                    kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
-                    symbol=name,
-                    description=f"Alignment changed: {name} ({t_old.alignment_bits} → {t_new.alignment_bits} bits)",
-                    old_value=str(t_old.alignment_bits),
-                    new_value=str(t_new.alignment_bits),
-                ))
-
-        # TYPE_FIELD_* for unions is handled by _diff_unions() to avoid duplicate reports.
-        # Size/alignment/base/vtable checks above apply to unions too.
-        if not t_old.is_union:
-            old_fields = {f.name: f for f in t_old.fields}
-            new_fields = {f.name: f for f in t_new.fields}
-
-            for fname, f_old in old_fields.items():
-                if fname not in new_fields:
-                    changes.append(Change(
-                        kind=ChangeKind.TYPE_FIELD_REMOVED,
-                        symbol=name,
-                        description=f"Field removed: {name}::{fname}",
-                    ))
-                else:
-                    f_new = new_fields[fname]
-                    if f_old.type != f_new.type:
-                        changes.append(Change(
-                            kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
-                            symbol=name,
-                            description=f"Field type changed: {name}::{fname}",
-                            old_value=f_old.type, new_value=f_new.type,
-                        ))
-                    if (f_old.offset_bits is not None and f_new.offset_bits is not None
-                            and f_old.offset_bits != f_new.offset_bits):
-                        changes.append(Change(
-                            kind=ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
-                            symbol=name,
-                            description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
-                            old_value=str(f_old.offset_bits), new_value=str(f_new.offset_bits),
-                        ))
-                    # Bitfield layout check (merged here to avoid redundant type iteration)
-                    if (f_old.is_bitfield != f_new.is_bitfield
-                            or f_old.bitfield_bits != f_new.bitfield_bits):
-                        changes.append(Change(
-                            kind=ChangeKind.FIELD_BITFIELD_CHANGED,
-                            symbol=name,
-                            description=f"Bitfield layout changed: {name}::{fname}",
-                            old_value=f"bits={f_old.bitfield_bits}",
-                            new_value=f"bits={f_new.bitfield_bits}",
-                        ))
-
-            for fname in new_fields:
-                if fname not in old_fields:
-                    # Field addition is BREAKING for polymorphic types or types with vtables;
-                    # COMPATIBLE only for standard-layout types without virtual functions
-                    is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
-                    field_kind = (
-                        ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
-                        if not is_polymorphic and t_new.kind in ("struct",)
-                        else ChangeKind.TYPE_FIELD_ADDED  # BREAKING
-                    )
-                    changes.append(Change(
-                        kind=field_kind,
-                        symbol=name,
-                        description=f"Field added: {name}::{fname}",
-                    ))
-
-        if t_old.bases != t_new.bases or t_old.virtual_bases != t_new.virtual_bases:
-            changes.append(Change(
-                kind=ChangeKind.TYPE_BASE_CHANGED,
-                symbol=name,
-                description=f"Base classes changed: {name}",
-                old_value=str(t_old.bases), new_value=str(t_new.bases),
-            ))
-        else:
-            # Detect non-virtual base promoted to virtual (changes VTT layout).
-            # Only runs when bases/virtual_bases are unchanged as sets but virtualness differs.
-            old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
-            new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
-            if old_all_bases == new_all_bases:
-                old_virt = set(t_old.virtual_bases)
-                new_virt = set(t_new.virtual_bases)
-                if old_virt != new_virt:
-                    changes.append(Change(
-                        kind=ChangeKind.TYPE_BASE_CHANGED,
-                        symbol=name,
-                        description=f"Virtual inheritance changed: {name} (affects VTT layout)",
-                        old_value=f"virtual={sorted(old_virt)}",
-                        new_value=f"virtual={sorted(new_virt)}",
-                    ))
-
-        if t_old.vtable != t_new.vtable:
-            if Counter(t_old.vtable) == Counter(t_new.vtable) and t_old.vtable != t_new.vtable:
-                # Same entries, different order — reorder is still BREAKING
-                description = f"vtable reordered: {name}"
-            else:
-                description = f"vtable changed: {name}"
-            changes.append(Change(
-                kind=ChangeKind.TYPE_VTABLE_CHANGED,
-                symbol=name,
-                description=description,
-            ))
+        changes.extend(_diff_type_pair(name, t_old, t_new))
 
     for name in new_map:
         if name not in old_map:
@@ -472,6 +360,152 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             ))
 
     return changes
+
+
+def _diff_type_pair(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    changes: list[Change] = []
+    _append_type_size_and_alignment_changes(changes, name, t_old, t_new)
+    if not t_old.is_union:
+        changes.extend(_diff_type_fields(name, t_old, t_new))
+    changes.extend(_diff_type_bases(name, t_old, t_new))
+    changes.extend(_diff_type_vtable(name, t_old, t_new))
+    return changes
+
+
+def _append_type_size_and_alignment_changes(
+    changes: list[Change], name: str, t_old: RecordType, t_new: RecordType,
+) -> None:
+    if t_old.size_bits is not None and t_new.size_bits is not None and t_old.size_bits != t_new.size_bits:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol=name,
+            description=f"Size changed: {name} ({t_old.size_bits} → {t_new.size_bits} bits)",
+            old_value=str(t_old.size_bits),
+            new_value=str(t_new.size_bits),
+        ))
+
+    if (
+        t_old.alignment_bits is not None
+        and t_new.alignment_bits is not None
+        and t_old.alignment_bits != t_new.alignment_bits
+    ):
+        changes.append(Change(
+            kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
+            symbol=name,
+            description=f"Alignment changed: {name} ({t_old.alignment_bits} → {t_new.alignment_bits} bits)",
+            old_value=str(t_old.alignment_bits),
+            new_value=str(t_new.alignment_bits),
+        ))
+
+
+def _diff_type_fields(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    changes: list[Change] = []
+    old_fields = {f.name: f for f in t_old.fields}
+    new_fields = {f.name: f for f in t_new.fields}
+
+    for fname, f_old in old_fields.items():
+        f_new = new_fields.get(fname)
+        if f_new is None:
+            changes.append(Change(
+                kind=ChangeKind.TYPE_FIELD_REMOVED,
+                symbol=name,
+                description=f"Field removed: {name}::{fname}",
+            ))
+            continue
+        changes.extend(_diff_type_field_pair(name, fname, f_old, f_new))
+
+    for fname in new_fields:
+        if fname not in old_fields:
+            changes.append(Change(
+                kind=_new_field_change_kind(t_new),
+                symbol=name,
+                description=f"Field added: {name}::{fname}",
+            ))
+    return changes
+
+
+def _diff_type_field_pair(name: str, fname: str, f_old: TypeField, f_new: TypeField) -> list[Change]:
+    changes: list[Change] = []
+    if f_old.type != f_new.type:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
+            symbol=name,
+            description=f"Field type changed: {name}::{fname}",
+            old_value=f_old.type,
+            new_value=f_new.type,
+        ))
+    if f_old.offset_bits is not None and f_new.offset_bits is not None and f_old.offset_bits != f_new.offset_bits:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
+            symbol=name,
+            description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
+            old_value=str(f_old.offset_bits),
+            new_value=str(f_new.offset_bits),
+        ))
+    if f_old.is_bitfield != f_new.is_bitfield or f_old.bitfield_bits != f_new.bitfield_bits:
+        changes.append(Change(
+            kind=ChangeKind.FIELD_BITFIELD_CHANGED,
+            symbol=name,
+            description=f"Bitfield layout changed: {name}::{fname}",
+            old_value=f"bits={f_old.bitfield_bits}",
+            new_value=f"bits={f_new.bitfield_bits}",
+        ))
+    return changes
+
+
+def _new_field_change_kind(t_new: RecordType) -> ChangeKind:
+    # Field addition is BREAKING for polymorphic types or types with vtables;
+    # COMPATIBLE only for standard-layout types without virtual functions.
+    is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
+    return (
+        ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
+        if not is_polymorphic and t_new.kind in ("struct",)
+        else ChangeKind.TYPE_FIELD_ADDED
+    )
+
+
+def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    if t_old.bases != t_new.bases or t_old.virtual_bases != t_new.virtual_bases:
+        return [Change(
+            kind=ChangeKind.TYPE_BASE_CHANGED,
+            symbol=name,
+            description=f"Base classes changed: {name}",
+            old_value=str(t_old.bases),
+            new_value=str(t_new.bases),
+        )]
+
+    old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
+    new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
+    if old_all_bases != new_all_bases:
+        return []
+
+    old_virt = set(t_old.virtual_bases)
+    new_virt = set(t_new.virtual_bases)
+    if old_virt == new_virt:
+        return []
+
+    return [Change(
+        kind=ChangeKind.TYPE_BASE_CHANGED,
+        symbol=name,
+        description=f"Virtual inheritance changed: {name} (affects VTT layout)",
+        old_value=f"virtual={sorted(old_virt)}",
+        new_value=f"virtual={sorted(new_virt)}",
+    )]
+
+
+def _diff_type_vtable(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    if t_old.vtable == t_new.vtable:
+        return []
+    description = (
+        f"vtable reordered: {name}"
+        if Counter(t_old.vtable) == Counter(t_new.vtable)
+        else f"vtable changed: {name}"
+    )
+    return [Change(
+        kind=ChangeKind.TYPE_VTABLE_CHANGED,
+        symbol=name,
+        description=description,
+    )]
 
 
 def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
@@ -690,51 +724,67 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     o: ElfMetadata = getattr(old, "elf", None) or ElfMetadata()
     n: ElfMetadata = getattr(new, "elf", None) or ElfMetadata()
     changes: list[Change] = []
+    changes.extend(_diff_elf_dynamic_section(o, n))
+    changes.extend(_diff_elf_symbol_versioning(o, n))
+    changes.extend(_diff_elf_symbol_metadata(o, n, SymbolType))
+    return changes
 
-    # ── Dynamic section ─────────────────────────────────────────────────
-    if o.soname and n.soname and o.soname != n.soname:
+
+def _diff_elf_dynamic_section(old_elf: Any, new_elf: Any) -> list[Change]:
+    changes: list[Change] = []
+    if old_elf.soname and new_elf.soname and old_elf.soname != new_elf.soname:
         changes.append(Change(
             kind=ChangeKind.SONAME_CHANGED,
             symbol="DT_SONAME",
-            description=f"SONAME changed: {o.soname!r} → {n.soname!r}",
-            old_value=o.soname, new_value=n.soname,
+            description=f"SONAME changed: {old_elf.soname!r} → {new_elf.soname!r}",
+            old_value=old_elf.soname,
+            new_value=new_elf.soname,
         ))
+    changes.extend(_diff_needed_libraries(old_elf.needed, new_elf.needed))
+    if old_elf.rpath != new_elf.rpath:
+        changes.append(Change(
+            kind=ChangeKind.RPATH_CHANGED,
+            symbol="DT_RPATH",
+            description=f"RPATH changed: {old_elf.rpath!r} → {new_elf.rpath!r}",
+            old_value=old_elf.rpath,
+            new_value=new_elf.rpath,
+        ))
+    if old_elf.runpath != new_elf.runpath:
+        changes.append(Change(
+            kind=ChangeKind.RUNPATH_CHANGED,
+            symbol="DT_RUNPATH",
+            description=f"RUNPATH changed: {old_elf.runpath!r} → {new_elf.runpath!r}",
+            old_value=old_elf.runpath,
+            new_value=new_elf.runpath,
+        ))
+    return changes
 
-    old_needed = set(o.needed)
-    new_needed = set(n.needed)
-    for lib in sorted(new_needed - old_needed):
+
+def _diff_needed_libraries(old_needed: list[str], new_needed: list[str]) -> list[Change]:
+    changes: list[Change] = []
+    old_set = set(old_needed)
+    new_set = set(new_needed)
+    for lib in sorted(new_set - old_set):
         changes.append(Change(
             kind=ChangeKind.NEEDED_ADDED,
             symbol="DT_NEEDED",
             description=f"New dependency added: {lib}",
             new_value=lib,
         ))
-    for lib in sorted(old_needed - new_needed):
+    for lib in sorted(old_set - new_set):
         changes.append(Change(
             kind=ChangeKind.NEEDED_REMOVED,
             symbol="DT_NEEDED",
             description=f"Dependency removed: {lib}",
             old_value=lib,
         ))
+    return changes
 
-    if o.rpath != n.rpath:
-        changes.append(Change(
-            kind=ChangeKind.RPATH_CHANGED,
-            symbol="DT_RPATH",
-            description=f"RPATH changed: {o.rpath!r} → {n.rpath!r}",
-            old_value=o.rpath, new_value=n.rpath,
-        ))
-    if o.runpath != n.runpath:
-        changes.append(Change(
-            kind=ChangeKind.RUNPATH_CHANGED,
-            symbol="DT_RUNPATH",
-            description=f"RUNPATH changed: {o.runpath!r} → {n.runpath!r}",
-            old_value=o.runpath, new_value=n.runpath,
-        ))
 
-    # ── Symbol versioning ────────────────────────────────────────────────
-    old_def = set(o.versions_defined)
-    new_def = set(n.versions_defined)
+def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
+    changes: list[Change] = []
+    old_def = set(old_elf.versions_defined)
+    new_def = set(new_elf.versions_defined)
     for ver in sorted(old_def - new_def):
         changes.append(Change(
             kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
@@ -743,12 +793,10 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             old_value=ver,
         ))
 
-    # Required version drift (e.g. new GLIBC_2.34 requirement).
-    # Iterate union of old+new libs to catch libs that disappeared entirely.
-    all_req_libs = set(o.versions_required) | set(n.versions_required)
+    all_req_libs = set(old_elf.versions_required) | set(new_elf.versions_required)
     for lib in sorted(all_req_libs):
-        old_vers = set(o.versions_required.get(lib, []))
-        new_vers = set(n.versions_required.get(lib, []))
+        old_vers = set(old_elf.versions_required.get(lib, []))
+        new_vers = set(new_elf.versions_required.get(lib, []))
         for ver in sorted(new_vers - old_vers):
             changes.append(Change(
                 kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
@@ -763,84 +811,84 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 description=f"Symbol version requirement removed: {ver} (from {lib})",
                 old_value=f"{lib}:{ver}",
             ))
+    return changes
 
-    # ── Per-symbol metadata ──────────────────────────────────────────────
-    old_syms = o.symbol_map
-    new_syms = n.symbol_map
+
+def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any) -> list[Change]:
+    changes: list[Change] = []
+    old_syms = old_elf.symbol_map
+    new_syms = new_elf.symbol_map
 
     for sym_name, s_old in old_syms.items():
-        if sym_name not in new_syms:
+        s_new = new_syms.get(sym_name)
+        if s_new is None:
             continue
-        s_new = new_syms[sym_name]
+        changes.extend(_diff_elf_symbol_pair(sym_name, s_old, s_new, symbol_type_enum))
 
-        # IFUNC introduced/removed
-        if s_old.sym_type != SymbolType.IFUNC and s_new.sym_type == SymbolType.IFUNC:
-            changes.append(Change(
-                kind=ChangeKind.IFUNC_INTRODUCED,
-                symbol=sym_name,
-                description=f"Symbol became GNU_IFUNC: {sym_name}",
-                old_value=s_old.sym_type.value, new_value="ifunc",
-            ))
-        elif s_old.sym_type == SymbolType.IFUNC and s_new.sym_type != SymbolType.IFUNC:
-            changes.append(Change(
-                kind=ChangeKind.IFUNC_REMOVED,
-                symbol=sym_name,
-                description=f"Symbol no longer GNU_IFUNC: {sym_name}",
-                old_value="ifunc", new_value=s_new.sym_type.value,
-            ))
-        elif s_old.sym_type != s_new.sym_type:
-            changes.append(Change(
-                kind=ChangeKind.SYMBOL_TYPE_CHANGED,
-                symbol=sym_name,
-                description=f"Symbol type changed: {sym_name} ({s_old.sym_type.value} → {s_new.sym_type.value})",
-                old_value=s_old.sym_type.value, new_value=s_new.sym_type.value,
-            ))
-
-        # Binding drift.
-        # GLOBAL→WEAK: breaking — consumers expecting reliable strong resolution may get
-        # the weak version overridden or missing at link time.
-        # WEAK→GLOBAL: compatible for most consumers (symbol is strengthened). Edge case:
-        # interposing libraries that relied on weak-override semantics will stop working,
-        # but that's an unusual deployment pattern; classified COMPATIBLE per ADR-001.
-        if s_old.binding != s_new.binding:
-            is_weakening = (
-                s_old.binding == SymbolBinding.GLOBAL
-                and s_new.binding == SymbolBinding.WEAK
-            )
-            kind = ChangeKind.SYMBOL_BINDING_CHANGED if is_weakening else ChangeKind.SYMBOL_BINDING_STRENGTHENED
-            changes.append(Change(
-                kind=kind,
-                symbol=sym_name,
-                description=f"Symbol binding changed: {sym_name} ({s_old.binding.value} → {s_new.binding.value})",
-                old_value=s_old.binding.value, new_value=s_new.binding.value,
-            ))
-
-        # Size drift — only meaningful for data objects (STT_OBJECT, STT_TLS).
-        # STT_FUNC size = machine-code bytes: changes with every compile/optimization,
-        # is not an ABI contract, and produces massive false positives. Ignored.
-        if (
-            s_old.size > 0 and s_new.size > 0
-            and s_old.size != s_new.size
-            and s_new.sym_type in (SymbolType.OBJECT, SymbolType.COMMON, SymbolType.TLS)
-        ):
-            changes.append(Change(
-                kind=ChangeKind.SYMBOL_SIZE_CHANGED,
-                symbol=sym_name,
-                description=f"Symbol size changed: {sym_name} ({s_old.size} → {s_new.size} bytes)",
-                old_value=str(s_old.size), new_value=str(s_new.size),
-            ))
-
-    # STT_COMMON risk: any new COMMON symbols in exported API
     for sym_name, s_new in new_syms.items():
-        if s_new.sym_type == SymbolType.COMMON:
-            old_common = old_syms.get(sym_name)
-            if old_common is None or old_common.sym_type != SymbolType.COMMON:
-                changes.append(Change(
-                    kind=ChangeKind.COMMON_SYMBOL_RISK,
-                    symbol=sym_name,
-                    description=f"Exported STT_COMMON symbol: {sym_name} (resolution depends on linker/loader)",
-                ))
+        if s_new.sym_type != symbol_type_enum.COMMON:
+            continue
+        old_common = old_syms.get(sym_name)
+        if old_common is None or old_common.sym_type != symbol_type_enum.COMMON:
+            changes.append(Change(
+                kind=ChangeKind.COMMON_SYMBOL_RISK,
+                symbol=sym_name,
+                description=f"Exported STT_COMMON symbol: {sym_name} (resolution depends on linker/loader)",
+            ))
+    return changes
 
+
+def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enum: Any) -> list[Change]:
+    changes: list[Change] = []
+    if s_old.sym_type != symbol_type_enum.IFUNC and s_new.sym_type == symbol_type_enum.IFUNC:
+        changes.append(Change(
+            kind=ChangeKind.IFUNC_INTRODUCED,
+            symbol=sym_name,
+            description=f"Symbol became GNU_IFUNC: {sym_name}",
+            old_value=s_old.sym_type.value,
+            new_value="ifunc",
+        ))
+    elif s_old.sym_type == symbol_type_enum.IFUNC and s_new.sym_type != symbol_type_enum.IFUNC:
+        changes.append(Change(
+            kind=ChangeKind.IFUNC_REMOVED,
+            symbol=sym_name,
+            description=f"Symbol no longer GNU_IFUNC: {sym_name}",
+            old_value="ifunc",
+            new_value=s_new.sym_type.value,
+        ))
+    elif s_old.sym_type != s_new.sym_type:
+        changes.append(Change(
+            kind=ChangeKind.SYMBOL_TYPE_CHANGED,
+            symbol=sym_name,
+            description=f"Symbol type changed: {sym_name} ({s_old.sym_type.value} → {s_new.sym_type.value})",
+            old_value=s_old.sym_type.value,
+            new_value=s_new.sym_type.value,
+        ))
+
+    if s_old.binding != s_new.binding:
+        is_weakening = s_old.binding == SymbolBinding.GLOBAL and s_new.binding == SymbolBinding.WEAK
+        kind = ChangeKind.SYMBOL_BINDING_CHANGED if is_weakening else ChangeKind.SYMBOL_BINDING_STRENGTHENED
+        changes.append(Change(
+            kind=kind,
+            symbol=sym_name,
+            description=f"Symbol binding changed: {sym_name} ({s_old.binding.value} → {s_new.binding.value})",
+            old_value=s_old.binding.value,
+            new_value=s_new.binding.value,
+        ))
+
+    if (
+        s_old.size > 0
+        and s_new.size > 0
+        and s_old.size != s_new.size
+        and s_new.sym_type in (symbol_type_enum.OBJECT, symbol_type_enum.COMMON, symbol_type_enum.TLS)
+    ):
+        changes.append(Change(
+            kind=ChangeKind.SYMBOL_SIZE_CHANGED,
+            symbol=sym_name,
+            description=f"Symbol size changed: {sym_name} ({s_old.size} → {s_new.size} bytes)",
+            old_value=str(s_old.size),
+            new_value=str(s_new.size),
+        ))
     return changes
 
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from .elf_metadata import SymbolBinding
+from .elf_metadata import SymbolBinding, SymbolType
 from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visibility
 
 if TYPE_CHECKING:
@@ -474,11 +474,10 @@ def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Ch
             new_value=str(t_new.bases),
         )]
 
-    old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
-    new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
-    if old_all_bases != new_all_bases:
-        return []
-
+    # Bases and virtual_bases lists are equal at this point; check if any non-virtual
+    # base was promoted to virtual (changes VTT layout) without altering the set membership.
+    # Note: if both lists are equal as lists, the sets are also equal, so this only fires
+    # when the same base appears in different virtual/non-virtual slots.
     old_virt = set(t_old.virtual_bases)
     new_virt = set(t_new.virtual_bases)
     if old_virt == new_virt:
@@ -719,14 +718,14 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """ELF-only detectors (Sprint 2): no debug info required."""
-    from .elf_metadata import ElfMetadata, SymbolType
+    from .elf_metadata import ElfMetadata
 
     o: ElfMetadata = getattr(old, "elf", None) or ElfMetadata()
     n: ElfMetadata = getattr(new, "elf", None) or ElfMetadata()
     changes: list[Change] = []
     changes.extend(_diff_elf_dynamic_section(o, n))
     changes.extend(_diff_elf_symbol_versioning(o, n))
-    changes.extend(_diff_elf_symbol_metadata(o, n, SymbolType))
+    changes.extend(_diff_elf_symbol_metadata(o, n))
     return changes
 
 
@@ -814,7 +813,7 @@ def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
     return changes
 
 
-def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any) -> list[Change]:
+def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any) -> list[Change]:
     changes: list[Change] = []
     old_syms = old_elf.symbol_map
     new_syms = new_elf.symbol_map
@@ -823,13 +822,13 @@ def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any)
         s_new = new_syms.get(sym_name)
         if s_new is None:
             continue
-        changes.extend(_diff_elf_symbol_pair(sym_name, s_old, s_new, symbol_type_enum))
+        changes.extend(_diff_elf_symbol_pair(sym_name, s_old, s_new))
 
     for sym_name, s_new in new_syms.items():
-        if s_new.sym_type != symbol_type_enum.COMMON:
+        if s_new.sym_type != SymbolType.COMMON:
             continue
         old_common = old_syms.get(sym_name)
-        if old_common is None or old_common.sym_type != symbol_type_enum.COMMON:
+        if old_common is None or old_common.sym_type != SymbolType.COMMON:
             changes.append(Change(
                 kind=ChangeKind.COMMON_SYMBOL_RISK,
                 symbol=sym_name,
@@ -838,9 +837,9 @@ def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any)
     return changes
 
 
-def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enum: Any) -> list[Change]:
+def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any) -> list[Change]:
     changes: list[Change] = []
-    if s_old.sym_type != symbol_type_enum.IFUNC and s_new.sym_type == symbol_type_enum.IFUNC:
+    if s_old.sym_type != SymbolType.IFUNC and s_new.sym_type == SymbolType.IFUNC:
         changes.append(Change(
             kind=ChangeKind.IFUNC_INTRODUCED,
             symbol=sym_name,
@@ -848,7 +847,7 @@ def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enu
             old_value=s_old.sym_type.value,
             new_value="ifunc",
         ))
-    elif s_old.sym_type == symbol_type_enum.IFUNC and s_new.sym_type != symbol_type_enum.IFUNC:
+    elif s_old.sym_type == SymbolType.IFUNC and s_new.sym_type != SymbolType.IFUNC:
         changes.append(Change(
             kind=ChangeKind.IFUNC_REMOVED,
             symbol=sym_name,
@@ -880,7 +879,7 @@ def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enu
         s_old.size > 0
         and s_new.size > 0
         and s_old.size != s_new.size
-        and s_new.sym_type in (symbol_type_enum.OBJECT, symbol_type_enum.COMMON, symbol_type_enum.TLS)
+        and s_new.sym_type in (SymbolType.OBJECT, SymbolType.COMMON, SymbolType.TLS)
     ):
         changes.append(Change(
             kind=ChangeKind.SYMBOL_SIZE_CHANGED,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -325,99 +325,97 @@ class _CastxmlParser:
     def parse_types(self) -> list[RecordType]:
         types = []
         for el in self._root:
-            if el.tag not in ("Struct", "Class", "Union"):
+            if not self._is_public_record_type(el):
                 continue
-            name = el.get("name", "")
-            # Skip compiler-internal / incomplete / anonymous types
-            if not name or el.get("incomplete") == "1" or el.get("artificial") == "1":
-                continue
-            if name.startswith("__"):  # double-underscore = internal
-                continue
+            types.append(self._build_record_type(el))
+        return types
 
-            size_str = el.get("size")
-            size_bits = int(size_str) if size_str and size_str.isdigit() else None
+    def _is_public_record_type(self, el: Any) -> bool:
+        if el.tag not in ("Struct", "Class", "Union"):
+            return False
+        name = el.get("name", "")
+        if not name or el.get("incomplete") == "1" or el.get("artificial") == "1":
+            return False
+        return not name.startswith("__")
 
-            align_str = el.get("align")
-            alignment_bits = int(align_str) if align_str and align_str.isdigit() else None
-
-            fields = []
-            for child in el:
-                if child.tag == "Field":
-                    f_name = child.get("name", "")
-                    f_type = self._type_name(child.get("type", ""))
-                    off_str = child.get("offset")
-                    offset = int(off_str) if off_str and off_str.isdigit() else None
-                    bits_str = child.get("bits")
-                    try:
-                        bitfield_bits = int(bits_str) if bits_str is not None else None
-                        is_bitfield = bitfield_bits is not None
-                    except ValueError:
-                        is_bitfield = False
-                        bitfield_bits = None
-                    fields.append(TypeField(
-                        name=f_name, type=f_type, offset_bits=offset,
-                        is_bitfield=is_bitfield, bitfield_bits=bitfield_bits,
-                    ))
-
-            bases = [
+    def _build_record_type(self, el: Any) -> RecordType:
+        name = el.get("name", "")
+        return RecordType(
+            name=name,
+            kind=el.tag.lower(),
+            size_bits=self._optional_int_attr(el, "size"),
+            alignment_bits=self._optional_int_attr(el, "align"),
+            fields=self._parse_record_fields(el),
+            bases=[
                 self._type_name(b.get("type", ""))
                 for b in el if b.tag == "Base" and b.get("virtual") != "1"
-            ]
-            virtual_bases = [
+            ],
+            virtual_bases=[
                 self._type_name(b.get("type", ""))
                 for b in el if b.tag == "Base" and b.get("virtual") == "1"
-            ]
+            ],
+            vtable=self._build_vtable(el.get("id", "")),
+            is_union=el.tag == "Union",
+        )
 
-            # Collect vtable: virtual methods from this class and its base classes
-            # In castxml, Method elements are top-level with "context" pointing to class id
-            class_id = el.get("id", "")
-            virtual_methods = []
+    def _optional_int_attr(self, el: Any, attr: str) -> int | None:
+        raw = el.get(attr)
+        return int(raw) if raw and raw.isdigit() else None
 
-            # Collect virtual methods: look up in the top-level map by class id
-            # Also include inherited virtual methods from base classes (prepend them)
-            def _collect_virtual_methods(cid: str, seen: set[str] | None = None) -> list[tuple[int | None, str]]:
-                if seen is None:
-                    seen = set()
-                if cid in seen:
-                    return []
-                seen.add(cid)
-                class_el = self._id_map.get(cid)
-                if class_el is None:
-                    return []
-                result = []
-                # First collect from base classes (inherited methods come first in vtable)
-                for base in class_el:
-                    if base.tag == "Base":
-                        base_type_el = self._resolve(base.get("type", ""))
-                        if base_type_el is not None:
-                            result.extend(_collect_virtual_methods(base_type_el.get("id", ""), seen))
-                # Then add this class's own virtual methods
-                for m in self._virtual_methods_by_class.get(cid, []):
-                    mangled_m = m.get("mangled", "")
-                    if mangled_m:
-                        vi = _parse_vtable_index(m.get("vtable_index"))
-                        result.append((vi, mangled_m))
-                return result
-
-            virtual_methods = _collect_virtual_methods(class_id)
-
-            # Sort: methods with vtable_index first (by index), then remainder in XML order
-            virtual_methods.sort(key=_vt_sort_key)
-            vtable = [m for _, m in virtual_methods]
-
-            is_union = el.tag == "Union"
-            types.append(RecordType(
-                name=name,
-                kind=el.tag.lower(),
-                size_bits=size_bits,
-                alignment_bits=alignment_bits,
-                fields=fields,
-                bases=bases,
-                virtual_bases=virtual_bases,
-                vtable=vtable,
-                is_union=is_union,
+    def _parse_record_fields(self, el: Any) -> list[TypeField]:
+        fields: list[TypeField] = []
+        for child in el:
+            if child.tag != "Field":
+                continue
+            bitfield_bits, is_bitfield = self._parse_bitfield_bits(child.get("bits"))
+            fields.append(TypeField(
+                name=child.get("name", ""),
+                type=self._type_name(child.get("type", "")),
+                offset_bits=self._optional_int_attr(child, "offset"),
+                is_bitfield=is_bitfield,
+                bitfield_bits=bitfield_bits,
             ))
-        return types
+        return fields
+
+    @staticmethod
+    def _parse_bitfield_bits(bits_raw: str | None) -> tuple[int | None, bool]:
+        try:
+            bitfield_bits = int(bits_raw) if bits_raw is not None else None
+        except ValueError:
+            return (None, False)
+        return (bitfield_bits, bitfield_bits is not None)
+
+    def _build_vtable(self, class_id: str) -> list[str]:
+        virtual_methods = self._collect_virtual_methods(class_id)
+        virtual_methods.sort(key=_vt_sort_key)
+        return [m for _, m in virtual_methods]
+
+    def _collect_virtual_methods(
+        self, cid: str, seen: set[str] | None = None,
+    ) -> list[tuple[int | None, str]]:
+        if seen is None:
+            seen = set()
+        if cid in seen:
+            return []
+        seen.add(cid)
+        class_el = self._id_map.get(cid)
+        if class_el is None:
+            return []
+
+        result: list[tuple[int | None, str]] = []
+        for base in class_el:
+            if base.tag != "Base":
+                continue
+            base_type_el = self._resolve(base.get("type", ""))
+            if base_type_el is not None:
+                result.extend(self._collect_virtual_methods(base_type_el.get("id", ""), seen))
+
+        for method_el in self._virtual_methods_by_class.get(cid, []):
+            mangled_name = method_el.get("mangled", "")
+            if not mangled_name:
+                continue
+            result.append((_parse_vtable_index(method_el.get("vtable_index")), mangled_name))
+        return result
 
 
     def parse_enums(self) -> list[EnumType]:

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -510,7 +510,7 @@ def _die_to_type_info(  # noqa: PLR0911
     return result
 
 
-def _compute_type_info(  # noqa: PLR0911
+def _compute_type_info(
     die: Any,
     CU: Any,
     depth: int,
@@ -519,80 +519,124 @@ def _compute_type_info(  # noqa: PLR0911
     tag = die.tag
 
     if tag == "DW_TAG_base_type":
-        name = _attr_str(die, "DW_AT_name") or "base"
-        size = _attr_int(die, "DW_AT_byte_size")
-        return (name, size)
+        return (_attr_str(die, "DW_AT_name") or "base", _attr_int(die, "DW_AT_byte_size"))
 
     if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
-        name = _attr_str(die, "DW_AT_name") or "<anon>"
-        size = _attr_int(die, "DW_AT_byte_size")
-        prefix = "struct " if tag == "DW_TAG_structure_type" else ""
-        return (f"{prefix}{name}", size)
+        return _compute_record_type_info(die, tag)
 
     if tag == "DW_TAG_enumeration_type":
         name = _attr_str(die, "DW_AT_name") or "<enum>"
-        size = _attr_int(die, "DW_AT_byte_size")
-        return (f"enum {name}", size)
+        return (f"enum {name}", _attr_int(die, "DW_AT_byte_size"))
 
     if tag == "DW_TAG_pointer_type":
-        ptr_size = _attr_int(die, "DW_AT_byte_size") or 8
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (f"{inner_name} *", ptr_size)
-            except Exception:  # noqa: BLE001
-                return ("void *", ptr_size)
-        return ("void *", ptr_size)
+        return _compute_pointer_like_info(die, CU, depth, cache, suffix=" *", fallback="void *")
 
     if tag in ("DW_TAG_reference_type", "DW_TAG_rvalue_reference_type"):
-        ref_size = _attr_int(die, "DW_AT_byte_size") or 8
-        suffix = "&&" if tag == "DW_TAG_rvalue_reference_type" else "&"
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (f"{inner_name} {suffix}", ref_size)
-            except Exception:  # noqa: BLE001
-                return (f"? {suffix}", ref_size)
-        return (f"? {suffix}", ref_size)
+        suffix = " &&" if tag == "DW_TAG_rvalue_reference_type" else " &"
+        return _compute_pointer_like_info(die, CU, depth, cache, suffix=suffix, fallback=f"?{suffix}")
 
     if tag in ("DW_TAG_const_type", "DW_TAG_volatile_type", "DW_TAG_restrict_type"):
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                qualifier = tag.split("_")[2].lower()  # const / volatile / restrict
-                return (f"{qualifier} {inner_name}", size)
-            except Exception:  # noqa: BLE001
-                return (tag.split("_")[2].lower(), 0)
+        qualifier = tag.split("_")[2].lower()
+        return _compute_qualified_type_info(die, CU, depth, cache, qualifier)
 
     if tag == "DW_TAG_typedef":
-        name = _attr_str(die, "DW_AT_name")
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (name or inner_name, size)
-            except Exception:  # noqa: BLE001
-                return (name or "typedef", 0)
-        return (name or "typedef", 0)
+        return _compute_typedef_info(die, CU, depth, cache)
 
     if tag == "DW_TAG_array_type":
-        size = _attr_int(die, "DW_AT_byte_size")
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (f"{inner_name}[]", size)
-            except Exception:  # noqa: BLE001
-                return ("array", size)
-        return ("array", size)
+        return _compute_array_type_info(die, CU, depth, cache)
 
     if tag == "DW_TAG_subroutine_type":
         return ("fn(...)", _attr_int(die, "DW_AT_byte_size"))
 
-    # Fallback: use whatever name/size we can get from this DIE
+    return _compute_fallback_type_info(die, tag)
+
+
+def _compute_record_type_info(die: Any, tag: str) -> tuple[str, int]:
+    name = _attr_str(die, "DW_AT_name") or "<anon>"
+    prefix = "struct " if tag == "DW_TAG_structure_type" else ""
+    return (f"{prefix}{name}", _attr_int(die, "DW_AT_byte_size"))
+
+
+def _compute_pointer_like_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+    suffix: str,
+    fallback: str,
+) -> tuple[str, int]:
+    pointee = _resolve_inner_type_name(die, CU, depth, cache)
+    size = _attr_int(die, "DW_AT_byte_size") or 8
+    if pointee is None:
+        return (fallback, size)
+    return (f"{pointee}{suffix}", size)
+
+
+def _compute_qualified_type_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+    qualifier: str,
+) -> tuple[str, int]:
+    inner = _resolve_inner_type_info(die, CU, depth, cache)
+    if inner is None:
+        return (qualifier, 0)
+    inner_name, size = inner
+    return (f"{qualifier} {inner_name}", size)
+
+
+def _compute_typedef_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int]:
+    name = _attr_str(die, "DW_AT_name")
+    inner = _resolve_inner_type_info(die, CU, depth, cache)
+    if inner is None:
+        return (name or "typedef", 0)
+    inner_name, size = inner
+    return (name or inner_name, size)
+
+
+def _compute_array_type_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int]:
+    size = _attr_int(die, "DW_AT_byte_size")
+    inner_name = _resolve_inner_type_name(die, CU, depth, cache)
+    return (f"{inner_name}[]", size) if inner_name is not None else ("array", size)
+
+
+def _resolve_inner_type_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int] | None:
+    if "DW_AT_type" not in die.attributes:
+        return None
+    try:
+        inner_die = _resolve_ref(die, "DW_AT_type", CU)
+        return _die_to_type_info(inner_die, CU, depth + 1, cache)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _resolve_inner_type_name(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> str | None:
+    inner = _resolve_inner_type_info(die, CU, depth, cache)
+    return inner[0] if inner is not None else None
+
+
+def _compute_fallback_type_info(die: Any, tag: str) -> tuple[str, int]:
     name = _attr_str(die, "DW_AT_name")
     size = _attr_int(die, "DW_AT_byte_size")
     return (name or tag or "unknown", size)


### PR DESCRIPTION
### Motivation
- Reduce cyclomatic complexity and improve maintainability for CodeFactor-flagged hotspots in the ABI diffing and DWARF parsing code while preserving existing behavior.
- Target the largest/most complex functions found by the analyser: `_diff_types()` and `_diff_elf()` in `abicheck/checker.py`, `parse_types()` in `abicheck/dumper.py`, and `_compute_type_info()` in `abicheck/dwarf_metadata.py`.
- No external skills or behavioural changes were introduced; the refactor is purely internal decomposition to make logic easier to follow and test.

### Description
- Decomposed `_diff_types()` into smaller helpers (`_diff_type_pair`, `_diff_type_fields`, `_diff_type_field_pair`, `_append_type_size_and_alignment_changes`, `_diff_type_bases`, `_diff_type_vtable`, `_new_field_change_kind`) and kept the original semantics for size/alignment/field/base/vtable checks.
- Split `_diff_elf()` into focused helpers (`_diff_elf_dynamic_section`, `_diff_needed_libraries`, `_diff_elf_symbol_versioning`, `_diff_elf_symbol_metadata`, `_diff_elf_symbol_pair`) to isolate dynamic-section, versioning, and per-symbol logic.
- Reworked `parse_types()` in `abicheck/dumper.py` into clearer helpers (`_is_public_record_type`, `_build_record_type`, `_optional_int_attr`, `_parse_record_fields`, `_parse_bitfield_bits`, `_build_vtable`, `_collect_virtual_methods`) to simplify parsing and vtable assembly.
- Rewrote `_compute_type_info()` in `abicheck/dwarf_metadata.py` as a dispatcher with per-kind helpers (`_compute_record_type_info`, `_compute_pointer_like_info`, `_compute_qualified_type_info`, `_compute_typedef_info`, `_compute_array_type_info`, `_resolve_inner_type_info`, `_resolve_inner_type_name`, `_compute_fallback_type_info`) to reduce branching and improve readability while preserving resolution logic.

### Testing
- Ran the full test suite with `python -m pytest -q` and observed all tests passing: `221 passed, 38 skipped`.
- Ran linting on the modified files with `python -m ruff check abicheck/checker.py abicheck/dumper.py abicheck/dwarf_metadata.py` and the checks passed for the changed modules.
- Ran `python -m ruff check .` which reports unrelated pre-existing issues in `scripts/` (these were not introduced by this refactor) and are noted but unrelated to the PR changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd7e67604832bb3ebacaa3a9f68e3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored and modularized internal code architecture across core modules including type diffing, ELF binary diffing, CastXML parsing, and DWARF metadata computation. Reorganized complex logic into focused helper functions to improve code maintainability, readability, and sustainability without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->