### PR TITLE
feat(sprint9): ABICC-compatible HTML report — sectioned layout, BC%, summary table

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -459,7 +459,7 @@ def _new_field_change_kind(t_new: RecordType) -> ChangeKind:
     is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
     return (
         ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
-        if not is_polymorphic and t_new.kind in ("struct",)
+        if not is_polymorphic and t_new.kind == "struct"
         else ChangeKind.TYPE_FIELD_ADDED
     )
 
@@ -473,23 +473,7 @@ def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Ch
             old_value=str(t_old.bases),
             new_value=str(t_new.bases),
         )]
-
-    # Bases and virtual_bases lists are equal at this point; check if any non-virtual
-    # base was promoted to virtual (changes VTT layout) without altering the set membership.
-    # Note: if both lists are equal as lists, the sets are also equal, so this only fires
-    # when the same base appears in different virtual/non-virtual slots.
-    old_virt = set(t_old.virtual_bases)
-    new_virt = set(t_new.virtual_bases)
-    if old_virt == new_virt:
-        return []
-
-    return [Change(
-        kind=ChangeKind.TYPE_BASE_CHANGED,
-        symbol=name,
-        description=f"Virtual inheritance changed: {name} (affects VTT layout)",
-        old_value=f"virtual={sorted(old_virt)}",
-        new_value=f"virtual={sorted(new_virt)}",
-    )]
+    return []
 
 
 def _diff_type_vtable(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .elf_metadata import SymbolBinding
-from .model import AbiSnapshot, EnumType, Function, Visibility
+from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visibility
 
 if TYPE_CHECKING:
     from .suppression import SuppressionList
@@ -341,127 +341,15 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = {t.name: t for t in new.types}
 
     for name, t_old in old_map.items():
-        if name not in new_map:
+        t_new = new_map.get(name)
+        if t_new is None:
             changes.append(Change(
                 kind=ChangeKind.TYPE_REMOVED,
                 symbol=name,
                 description=f"Type removed: {name}",
             ))
             continue
-        t_new = new_map[name]
-
-        if t_old.size_bits is not None and t_new.size_bits is not None:
-            if t_old.size_bits != t_new.size_bits:
-                changes.append(Change(
-                    kind=ChangeKind.TYPE_SIZE_CHANGED,
-                    symbol=name,
-                    description=f"Size changed: {name} ({t_old.size_bits} → {t_new.size_bits} bits)",
-                    old_value=str(t_old.size_bits),
-                    new_value=str(t_new.size_bits),
-                ))
-
-        if t_old.alignment_bits is not None and t_new.alignment_bits is not None:
-            if t_old.alignment_bits != t_new.alignment_bits:
-                changes.append(Change(
-                    kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
-                    symbol=name,
-                    description=f"Alignment changed: {name} ({t_old.alignment_bits} → {t_new.alignment_bits} bits)",
-                    old_value=str(t_old.alignment_bits),
-                    new_value=str(t_new.alignment_bits),
-                ))
-
-        # TYPE_FIELD_* for unions is handled by _diff_unions() to avoid duplicate reports.
-        # Size/alignment/base/vtable checks above apply to unions too.
-        if not t_old.is_union:
-            old_fields = {f.name: f for f in t_old.fields}
-            new_fields = {f.name: f for f in t_new.fields}
-
-            for fname, f_old in old_fields.items():
-                if fname not in new_fields:
-                    changes.append(Change(
-                        kind=ChangeKind.TYPE_FIELD_REMOVED,
-                        symbol=name,
-                        description=f"Field removed: {name}::{fname}",
-                    ))
-                else:
-                    f_new = new_fields[fname]
-                    if f_old.type != f_new.type:
-                        changes.append(Change(
-                            kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
-                            symbol=name,
-                            description=f"Field type changed: {name}::{fname}",
-                            old_value=f_old.type, new_value=f_new.type,
-                        ))
-                    if (f_old.offset_bits is not None and f_new.offset_bits is not None
-                            and f_old.offset_bits != f_new.offset_bits):
-                        changes.append(Change(
-                            kind=ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
-                            symbol=name,
-                            description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
-                            old_value=str(f_old.offset_bits), new_value=str(f_new.offset_bits),
-                        ))
-                    # Bitfield layout check (merged here to avoid redundant type iteration)
-                    if (f_old.is_bitfield != f_new.is_bitfield
-                            or f_old.bitfield_bits != f_new.bitfield_bits):
-                        changes.append(Change(
-                            kind=ChangeKind.FIELD_BITFIELD_CHANGED,
-                            symbol=name,
-                            description=f"Bitfield layout changed: {name}::{fname}",
-                            old_value=f"bits={f_old.bitfield_bits}",
-                            new_value=f"bits={f_new.bitfield_bits}",
-                        ))
-
-            for fname in new_fields:
-                if fname not in old_fields:
-                    # Field addition is BREAKING for polymorphic types or types with vtables;
-                    # COMPATIBLE only for standard-layout types without virtual functions
-                    is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
-                    field_kind = (
-                        ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
-                        if not is_polymorphic and t_new.kind in ("struct",)
-                        else ChangeKind.TYPE_FIELD_ADDED  # BREAKING
-                    )
-                    changes.append(Change(
-                        kind=field_kind,
-                        symbol=name,
-                        description=f"Field added: {name}::{fname}",
-                    ))
-
-        if t_old.bases != t_new.bases or t_old.virtual_bases != t_new.virtual_bases:
-            changes.append(Change(
-                kind=ChangeKind.TYPE_BASE_CHANGED,
-                symbol=name,
-                description=f"Base classes changed: {name}",
-                old_value=str(t_old.bases), new_value=str(t_new.bases),
-            ))
-        else:
-            # Detect non-virtual base promoted to virtual (changes VTT layout).
-            # Only runs when bases/virtual_bases are unchanged as sets but virtualness differs.
-            old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
-            new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
-            if old_all_bases == new_all_bases:
-                old_virt = set(t_old.virtual_bases)
-                new_virt = set(t_new.virtual_bases)
-                if old_virt != new_virt:
-                    changes.append(Change(
-                        kind=ChangeKind.TYPE_BASE_CHANGED,
-                        symbol=name,
-                        description=f"Virtual inheritance changed: {name} (affects VTT layout)",
-                        old_value=f"virtual={sorted(old_virt)}",
-                        new_value=f"virtual={sorted(new_virt)}",
-                    ))
-
-        if t_old.vtable != t_new.vtable:
-            if Counter(t_old.vtable) == Counter(t_new.vtable) and t_old.vtable != t_new.vtable:
-                # Same entries, different order — reorder is still BREAKING
-                description = f"vtable reordered: {name}"
-            else:
-                description = f"vtable changed: {name}"
-            changes.append(Change(
-                kind=ChangeKind.TYPE_VTABLE_CHANGED,
-                symbol=name,
-                description=description,
-            ))
+        changes.extend(_diff_type_pair(name, t_old, t_new))
 
     for name in new_map:
         if name not in old_map:
@@ -472,6 +360,152 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             ))
 
     return changes
+
+
+def _diff_type_pair(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    changes: list[Change] = []
+    _append_type_size_and_alignment_changes(changes, name, t_old, t_new)
+    if not t_old.is_union:
+        changes.extend(_diff_type_fields(name, t_old, t_new))
+    changes.extend(_diff_type_bases(name, t_old, t_new))
+    changes.extend(_diff_type_vtable(name, t_old, t_new))
+    return changes
+
+
+def _append_type_size_and_alignment_changes(
+    changes: list[Change], name: str, t_old: RecordType, t_new: RecordType,
+) -> None:
+    if t_old.size_bits is not None and t_new.size_bits is not None and t_old.size_bits != t_new.size_bits:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol=name,
+            description=f"Size changed: {name} ({t_old.size_bits} → {t_new.size_bits} bits)",
+            old_value=str(t_old.size_bits),
+            new_value=str(t_new.size_bits),
+        ))
+
+    if (
+        t_old.alignment_bits is not None
+        and t_new.alignment_bits is not None
+        and t_old.alignment_bits != t_new.alignment_bits
+    ):
+        changes.append(Change(
+            kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
+            symbol=name,
+            description=f"Alignment changed: {name} ({t_old.alignment_bits} → {t_new.alignment_bits} bits)",
+            old_value=str(t_old.alignment_bits),
+            new_value=str(t_new.alignment_bits),
+        ))
+
+
+def _diff_type_fields(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    changes: list[Change] = []
+    old_fields = {f.name: f for f in t_old.fields}
+    new_fields = {f.name: f for f in t_new.fields}
+
+    for fname, f_old in old_fields.items():
+        f_new = new_fields.get(fname)
+        if f_new is None:
+            changes.append(Change(
+                kind=ChangeKind.TYPE_FIELD_REMOVED,
+                symbol=name,
+                description=f"Field removed: {name}::{fname}",
+            ))
+            continue
+        changes.extend(_diff_type_field_pair(name, fname, f_old, f_new))
+
+    for fname in new_fields:
+        if fname not in old_fields:
+            changes.append(Change(
+                kind=_new_field_change_kind(t_new),
+                symbol=name,
+                description=f"Field added: {name}::{fname}",
+            ))
+    return changes
+
+
+def _diff_type_field_pair(name: str, fname: str, f_old: TypeField, f_new: TypeField) -> list[Change]:
+    changes: list[Change] = []
+    if f_old.type != f_new.type:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
+            symbol=name,
+            description=f"Field type changed: {name}::{fname}",
+            old_value=f_old.type,
+            new_value=f_new.type,
+        ))
+    if f_old.offset_bits is not None and f_new.offset_bits is not None and f_old.offset_bits != f_new.offset_bits:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
+            symbol=name,
+            description=f"Field offset changed: {name}::{fname} ({f_old.offset_bits} → {f_new.offset_bits} bits)",
+            old_value=str(f_old.offset_bits),
+            new_value=str(f_new.offset_bits),
+        ))
+    if f_old.is_bitfield != f_new.is_bitfield or f_old.bitfield_bits != f_new.bitfield_bits:
+        changes.append(Change(
+            kind=ChangeKind.FIELD_BITFIELD_CHANGED,
+            symbol=name,
+            description=f"Bitfield layout changed: {name}::{fname}",
+            old_value=f"bits={f_old.bitfield_bits}",
+            new_value=f"bits={f_new.bitfield_bits}",
+        ))
+    return changes
+
+
+def _new_field_change_kind(t_new: RecordType) -> ChangeKind:
+    # Field addition is BREAKING for polymorphic types or types with vtables;
+    # COMPATIBLE only for standard-layout types without virtual functions.
+    is_polymorphic = bool(t_new.vtable or t_new.virtual_bases)
+    return (
+        ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE
+        if not is_polymorphic and t_new.kind in ("struct",)
+        else ChangeKind.TYPE_FIELD_ADDED
+    )
+
+
+def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    if t_old.bases != t_new.bases or t_old.virtual_bases != t_new.virtual_bases:
+        return [Change(
+            kind=ChangeKind.TYPE_BASE_CHANGED,
+            symbol=name,
+            description=f"Base classes changed: {name}",
+            old_value=str(t_old.bases),
+            new_value=str(t_new.bases),
+        )]
+
+    old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
+    new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
+    if old_all_bases != new_all_bases:
+        return []
+
+    old_virt = set(t_old.virtual_bases)
+    new_virt = set(t_new.virtual_bases)
+    if old_virt == new_virt:
+        return []
+
+    return [Change(
+        kind=ChangeKind.TYPE_BASE_CHANGED,
+        symbol=name,
+        description=f"Virtual inheritance changed: {name} (affects VTT layout)",
+        old_value=f"virtual={sorted(old_virt)}",
+        new_value=f"virtual={sorted(new_virt)}",
+    )]
+
+
+def _diff_type_vtable(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
+    if t_old.vtable == t_new.vtable:
+        return []
+    description = (
+        f"vtable reordered: {name}"
+        if Counter(t_old.vtable) == Counter(t_new.vtable)
+        else f"vtable changed: {name}"
+    )
+    return [Change(
+        kind=ChangeKind.TYPE_VTABLE_CHANGED,
+        symbol=name,
+        description=description,
+    )]
 
 
 def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
@@ -690,51 +724,67 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     o: ElfMetadata = getattr(old, "elf", None) or ElfMetadata()
     n: ElfMetadata = getattr(new, "elf", None) or ElfMetadata()
     changes: list[Change] = []
+    changes.extend(_diff_elf_dynamic_section(o, n))
+    changes.extend(_diff_elf_symbol_versioning(o, n))
+    changes.extend(_diff_elf_symbol_metadata(o, n, SymbolType))
+    return changes
 
-    # ── Dynamic section ─────────────────────────────────────────────────
-    if o.soname and n.soname and o.soname != n.soname:
+
+def _diff_elf_dynamic_section(old_elf: Any, new_elf: Any) -> list[Change]:
+    changes: list[Change] = []
+    if old_elf.soname and new_elf.soname and old_elf.soname != new_elf.soname:
         changes.append(Change(
             kind=ChangeKind.SONAME_CHANGED,
             symbol="DT_SONAME",
-            description=f"SONAME changed: {o.soname!r} → {n.soname!r}",
-            old_value=o.soname, new_value=n.soname,
+            description=f"SONAME changed: {old_elf.soname!r} → {new_elf.soname!r}",
+            old_value=old_elf.soname,
+            new_value=new_elf.soname,
         ))
+    changes.extend(_diff_needed_libraries(old_elf.needed, new_elf.needed))
+    if old_elf.rpath != new_elf.rpath:
+        changes.append(Change(
+            kind=ChangeKind.RPATH_CHANGED,
+            symbol="DT_RPATH",
+            description=f"RPATH changed: {old_elf.rpath!r} → {new_elf.rpath!r}",
+            old_value=old_elf.rpath,
+            new_value=new_elf.rpath,
+        ))
+    if old_elf.runpath != new_elf.runpath:
+        changes.append(Change(
+            kind=ChangeKind.RUNPATH_CHANGED,
+            symbol="DT_RUNPATH",
+            description=f"RUNPATH changed: {old_elf.runpath!r} → {new_elf.runpath!r}",
+            old_value=old_elf.runpath,
+            new_value=new_elf.runpath,
+        ))
+    return changes
 
-    old_needed = set(o.needed)
-    new_needed = set(n.needed)
-    for lib in sorted(new_needed - old_needed):
+
+def _diff_needed_libraries(old_needed: list[str], new_needed: list[str]) -> list[Change]:
+    changes: list[Change] = []
+    old_set = set(old_needed)
+    new_set = set(new_needed)
+    for lib in sorted(new_set - old_set):
         changes.append(Change(
             kind=ChangeKind.NEEDED_ADDED,
             symbol="DT_NEEDED",
             description=f"New dependency added: {lib}",
             new_value=lib,
         ))
-    for lib in sorted(old_needed - new_needed):
+    for lib in sorted(old_set - new_set):
         changes.append(Change(
             kind=ChangeKind.NEEDED_REMOVED,
             symbol="DT_NEEDED",
             description=f"Dependency removed: {lib}",
             old_value=lib,
         ))
+    return changes
 
-    if o.rpath != n.rpath:
-        changes.append(Change(
-            kind=ChangeKind.RPATH_CHANGED,
-            symbol="DT_RPATH",
-            description=f"RPATH changed: {o.rpath!r} → {n.rpath!r}",
-            old_value=o.rpath, new_value=n.rpath,
-        ))
-    if o.runpath != n.runpath:
-        changes.append(Change(
-            kind=ChangeKind.RUNPATH_CHANGED,
-            symbol="DT_RUNPATH",
-            description=f"RUNPATH changed: {o.runpath!r} → {n.runpath!r}",
-            old_value=o.runpath, new_value=n.runpath,
-        ))
 
-    # ── Symbol versioning ────────────────────────────────────────────────
-    old_def = set(o.versions_defined)
-    new_def = set(n.versions_defined)
+def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
+    changes: list[Change] = []
+    old_def = set(old_elf.versions_defined)
+    new_def = set(new_elf.versions_defined)
     for ver in sorted(old_def - new_def):
         changes.append(Change(
             kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
@@ -743,12 +793,10 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             old_value=ver,
         ))
 
-    # Required version drift (e.g. new GLIBC_2.34 requirement).
-    # Iterate union of old+new libs to catch libs that disappeared entirely.
-    all_req_libs = set(o.versions_required) | set(n.versions_required)
+    all_req_libs = set(old_elf.versions_required) | set(new_elf.versions_required)
     for lib in sorted(all_req_libs):
-        old_vers = set(o.versions_required.get(lib, []))
-        new_vers = set(n.versions_required.get(lib, []))
+        old_vers = set(old_elf.versions_required.get(lib, []))
+        new_vers = set(new_elf.versions_required.get(lib, []))
         for ver in sorted(new_vers - old_vers):
             changes.append(Change(
                 kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
@@ -763,84 +811,84 @@ def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 description=f"Symbol version requirement removed: {ver} (from {lib})",
                 old_value=f"{lib}:{ver}",
             ))
+    return changes
 
-    # ── Per-symbol metadata ──────────────────────────────────────────────
-    old_syms = o.symbol_map
-    new_syms = n.symbol_map
+
+def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any) -> list[Change]:
+    changes: list[Change] = []
+    old_syms = old_elf.symbol_map
+    new_syms = new_elf.symbol_map
 
     for sym_name, s_old in old_syms.items():
-        if sym_name not in new_syms:
+        s_new = new_syms.get(sym_name)
+        if s_new is None:
             continue
-        s_new = new_syms[sym_name]
+        changes.extend(_diff_elf_symbol_pair(sym_name, s_old, s_new, symbol_type_enum))
 
-        # IFUNC introduced/removed
-        if s_old.sym_type != SymbolType.IFUNC and s_new.sym_type == SymbolType.IFUNC:
-            changes.append(Change(
-                kind=ChangeKind.IFUNC_INTRODUCED,
-                symbol=sym_name,
-                description=f"Symbol became GNU_IFUNC: {sym_name}",
-                old_value=s_old.sym_type.value, new_value="ifunc",
-            ))
-        elif s_old.sym_type == SymbolType.IFUNC and s_new.sym_type != SymbolType.IFUNC:
-            changes.append(Change(
-                kind=ChangeKind.IFUNC_REMOVED,
-                symbol=sym_name,
-                description=f"Symbol no longer GNU_IFUNC: {sym_name}",
-                old_value="ifunc", new_value=s_new.sym_type.value,
-            ))
-        elif s_old.sym_type != s_new.sym_type:
-            changes.append(Change(
-                kind=ChangeKind.SYMBOL_TYPE_CHANGED,
-                symbol=sym_name,
-                description=f"Symbol type changed: {sym_name} ({s_old.sym_type.value} → {s_new.sym_type.value})",
-                old_value=s_old.sym_type.value, new_value=s_new.sym_type.value,
-            ))
-
-        # Binding drift.
-        # GLOBAL→WEAK: breaking — consumers expecting reliable strong resolution may get
-        # the weak version overridden or missing at link time.
-        # WEAK→GLOBAL: compatible for most consumers (symbol is strengthened). Edge case:
-        # interposing libraries that relied on weak-override semantics will stop working,
-        # but that's an unusual deployment pattern; classified COMPATIBLE per ADR-001.
-        if s_old.binding != s_new.binding:
-            is_weakening = (
-                s_old.binding == SymbolBinding.GLOBAL
-                and s_new.binding == SymbolBinding.WEAK
-            )
-            kind = ChangeKind.SYMBOL_BINDING_CHANGED if is_weakening else ChangeKind.SYMBOL_BINDING_STRENGTHENED
-            changes.append(Change(
-                kind=kind,
-                symbol=sym_name,
-                description=f"Symbol binding changed: {sym_name} ({s_old.binding.value} → {s_new.binding.value})",
-                old_value=s_old.binding.value, new_value=s_new.binding.value,
-            ))
-
-        # Size drift — only meaningful for data objects (STT_OBJECT, STT_TLS).
-        # STT_FUNC size = machine-code bytes: changes with every compile/optimization,
-        # is not an ABI contract, and produces massive false positives. Ignored.
-        if (
-            s_old.size > 0 and s_new.size > 0
-            and s_old.size != s_new.size
-            and s_new.sym_type in (SymbolType.OBJECT, SymbolType.COMMON, SymbolType.TLS)
-        ):
-            changes.append(Change(
-                kind=ChangeKind.SYMBOL_SIZE_CHANGED,
-                symbol=sym_name,
-                description=f"Symbol size changed: {sym_name} ({s_old.size} → {s_new.size} bytes)",
-                old_value=str(s_old.size), new_value=str(s_new.size),
-            ))
-
-    # STT_COMMON risk: any new COMMON symbols in exported API
     for sym_name, s_new in new_syms.items():
-        if s_new.sym_type == SymbolType.COMMON:
-            old_common = old_syms.get(sym_name)
-            if old_common is None or old_common.sym_type != SymbolType.COMMON:
-                changes.append(Change(
-                    kind=ChangeKind.COMMON_SYMBOL_RISK,
-                    symbol=sym_name,
-                    description=f"Exported STT_COMMON symbol: {sym_name} (resolution depends on linker/loader)",
-                ))
+        if s_new.sym_type != symbol_type_enum.COMMON:
+            continue
+        old_common = old_syms.get(sym_name)
+        if old_common is None or old_common.sym_type != symbol_type_enum.COMMON:
+            changes.append(Change(
+                kind=ChangeKind.COMMON_SYMBOL_RISK,
+                symbol=sym_name,
+                description=f"Exported STT_COMMON symbol: {sym_name} (resolution depends on linker/loader)",
+            ))
+    return changes
 
+
+def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enum: Any) -> list[Change]:
+    changes: list[Change] = []
+    if s_old.sym_type != symbol_type_enum.IFUNC and s_new.sym_type == symbol_type_enum.IFUNC:
+        changes.append(Change(
+            kind=ChangeKind.IFUNC_INTRODUCED,
+            symbol=sym_name,
+            description=f"Symbol became GNU_IFUNC: {sym_name}",
+            old_value=s_old.sym_type.value,
+            new_value="ifunc",
+        ))
+    elif s_old.sym_type == symbol_type_enum.IFUNC and s_new.sym_type != symbol_type_enum.IFUNC:
+        changes.append(Change(
+            kind=ChangeKind.IFUNC_REMOVED,
+            symbol=sym_name,
+            description=f"Symbol no longer GNU_IFUNC: {sym_name}",
+            old_value="ifunc",
+            new_value=s_new.sym_type.value,
+        ))
+    elif s_old.sym_type != s_new.sym_type:
+        changes.append(Change(
+            kind=ChangeKind.SYMBOL_TYPE_CHANGED,
+            symbol=sym_name,
+            description=f"Symbol type changed: {sym_name} ({s_old.sym_type.value} → {s_new.sym_type.value})",
+            old_value=s_old.sym_type.value,
+            new_value=s_new.sym_type.value,
+        ))
+
+    if s_old.binding != s_new.binding:
+        is_weakening = s_old.binding == SymbolBinding.GLOBAL and s_new.binding == SymbolBinding.WEAK
+        kind = ChangeKind.SYMBOL_BINDING_CHANGED if is_weakening else ChangeKind.SYMBOL_BINDING_STRENGTHENED
+        changes.append(Change(
+            kind=kind,
+            symbol=sym_name,
+            description=f"Symbol binding changed: {sym_name} ({s_old.binding.value} → {s_new.binding.value})",
+            old_value=s_old.binding.value,
+            new_value=s_new.binding.value,
+        ))
+
+    if (
+        s_old.size > 0
+        and s_new.size > 0
+        and s_old.size != s_new.size
+        and s_new.sym_type in (symbol_type_enum.OBJECT, symbol_type_enum.COMMON, symbol_type_enum.TLS)
+    ):
+        changes.append(Change(
+            kind=ChangeKind.SYMBOL_SIZE_CHANGED,
+            symbol=sym_name,
+            description=f"Symbol size changed: {sym_name} ({s_old.size} → {s_new.size} bytes)",
+            old_value=str(s_old.size),
+            new_value=str(s_new.size),
+        ))
     return changes
 
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from .elf_metadata import SymbolBinding
+from .elf_metadata import SymbolBinding, SymbolType
 from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visibility
 
 if TYPE_CHECKING:
@@ -474,11 +474,10 @@ def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Ch
             new_value=str(t_new.bases),
         )]
 
-    old_all_bases = set(t_old.bases) | set(t_old.virtual_bases)
-    new_all_bases = set(t_new.bases) | set(t_new.virtual_bases)
-    if old_all_bases != new_all_bases:
-        return []
-
+    # Bases and virtual_bases lists are equal at this point; check if any non-virtual
+    # base was promoted to virtual (changes VTT layout) without altering the set membership.
+    # Note: if both lists are equal as lists, the sets are also equal, so this only fires
+    # when the same base appears in different virtual/non-virtual slots.
     old_virt = set(t_old.virtual_bases)
     new_virt = set(t_new.virtual_bases)
     if old_virt == new_virt:
@@ -719,14 +718,14 @@ def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_elf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """ELF-only detectors (Sprint 2): no debug info required."""
-    from .elf_metadata import ElfMetadata, SymbolType
+    from .elf_metadata import ElfMetadata
 
     o: ElfMetadata = getattr(old, "elf", None) or ElfMetadata()
     n: ElfMetadata = getattr(new, "elf", None) or ElfMetadata()
     changes: list[Change] = []
     changes.extend(_diff_elf_dynamic_section(o, n))
     changes.extend(_diff_elf_symbol_versioning(o, n))
-    changes.extend(_diff_elf_symbol_metadata(o, n, SymbolType))
+    changes.extend(_diff_elf_symbol_metadata(o, n))
     return changes
 
 
@@ -814,7 +813,7 @@ def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
     return changes
 
 
-def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any) -> list[Change]:
+def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any) -> list[Change]:
     changes: list[Change] = []
     old_syms = old_elf.symbol_map
     new_syms = new_elf.symbol_map
@@ -823,13 +822,13 @@ def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any)
         s_new = new_syms.get(sym_name)
         if s_new is None:
             continue
-        changes.extend(_diff_elf_symbol_pair(sym_name, s_old, s_new, symbol_type_enum))
+        changes.extend(_diff_elf_symbol_pair(sym_name, s_old, s_new))
 
     for sym_name, s_new in new_syms.items():
-        if s_new.sym_type != symbol_type_enum.COMMON:
+        if s_new.sym_type != SymbolType.COMMON:
             continue
         old_common = old_syms.get(sym_name)
-        if old_common is None or old_common.sym_type != symbol_type_enum.COMMON:
+        if old_common is None or old_common.sym_type != SymbolType.COMMON:
             changes.append(Change(
                 kind=ChangeKind.COMMON_SYMBOL_RISK,
                 symbol=sym_name,
@@ -838,9 +837,9 @@ def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any, symbol_type_enum: Any)
     return changes
 
 
-def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enum: Any) -> list[Change]:
+def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any) -> list[Change]:
     changes: list[Change] = []
-    if s_old.sym_type != symbol_type_enum.IFUNC and s_new.sym_type == symbol_type_enum.IFUNC:
+    if s_old.sym_type != SymbolType.IFUNC and s_new.sym_type == SymbolType.IFUNC:
         changes.append(Change(
             kind=ChangeKind.IFUNC_INTRODUCED,
             symbol=sym_name,
@@ -848,7 +847,7 @@ def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enu
             old_value=s_old.sym_type.value,
             new_value="ifunc",
         ))
-    elif s_old.sym_type == symbol_type_enum.IFUNC and s_new.sym_type != symbol_type_enum.IFUNC:
+    elif s_old.sym_type == SymbolType.IFUNC and s_new.sym_type != SymbolType.IFUNC:
         changes.append(Change(
             kind=ChangeKind.IFUNC_REMOVED,
             symbol=sym_name,
@@ -880,7 +879,7 @@ def _diff_elf_symbol_pair(sym_name: str, s_old: Any, s_new: Any, symbol_type_enu
         s_old.size > 0
         and s_new.size > 0
         and s_old.size != s_new.size
-        and s_new.sym_type in (symbol_type_enum.OBJECT, symbol_type_enum.COMMON, symbol_type_enum.TLS)
+        and s_new.sym_type in (SymbolType.OBJECT, SymbolType.COMMON, SymbolType.TLS)
     ):
         changes.append(Change(
             kind=ChangeKind.SYMBOL_SIZE_CHANGED,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -58,7 +58,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
 @main.command("compare")
 @click.argument("old_snapshot", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_snapshot", type=click.Path(exists=True, path_type=Path))
-@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif"]),
+@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif", "html"]),
               default="markdown", show_default=True)
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
@@ -71,6 +71,7 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
     Example:
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format markdown
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format sarif -o results.sarif
+      abicheck compare libfoo-1.0.json libfoo-2.0.json --format html -o report.html
       abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
     """
     from .suppression import SuppressionList
@@ -101,6 +102,16 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
     elif fmt == "sarif":
         from .sarif import to_sarif_str
         text = to_sarif_str(result)
+    elif fmt == "html":
+        from .html_report import generate_html_report
+        old_symbol_count = len(old.functions) + len(old.variables)
+        text = generate_html_report(
+            result,
+            lib_name=old.library,
+            old_version=old.version,
+            new_version=new.version,
+            old_symbol_count=old_symbol_count or None,
+        )
     else:
         text = to_markdown(result)
 
@@ -233,9 +244,11 @@ def compat_cmd(
     report_path.parent.mkdir(parents=True, exist_ok=True)
 
     if fmt == "html":
+        old_symbol_count = len(old_snap.functions) + len(old_snap.variables)
         write_html_report(result, output_path=report_path,
                           lib_name=lib_name,
-                          old_version=old.version, new_version=new.version)
+                          old_version=old.version, new_version=new.version,
+                          old_symbol_count=old_symbol_count or None)
     elif fmt == "json":
         report_path.write_text(to_json(result), encoding="utf-8")
     else:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -325,99 +325,97 @@ class _CastxmlParser:
     def parse_types(self) -> list[RecordType]:
         types = []
         for el in self._root:
-            if el.tag not in ("Struct", "Class", "Union"):
+            if not self._is_public_record_type(el):
                 continue
-            name = el.get("name", "")
-            # Skip compiler-internal / incomplete / anonymous types
-            if not name or el.get("incomplete") == "1" or el.get("artificial") == "1":
-                continue
-            if name.startswith("__"):  # double-underscore = internal
-                continue
+            types.append(self._build_record_type(el))
+        return types
 
-            size_str = el.get("size")
-            size_bits = int(size_str) if size_str and size_str.isdigit() else None
+    def _is_public_record_type(self, el: Any) -> bool:
+        if el.tag not in ("Struct", "Class", "Union"):
+            return False
+        name = el.get("name", "")
+        if not name or el.get("incomplete") == "1" or el.get("artificial") == "1":
+            return False
+        return not name.startswith("__")
 
-            align_str = el.get("align")
-            alignment_bits = int(align_str) if align_str and align_str.isdigit() else None
-
-            fields = []
-            for child in el:
-                if child.tag == "Field":
-                    f_name = child.get("name", "")
-                    f_type = self._type_name(child.get("type", ""))
-                    off_str = child.get("offset")
-                    offset = int(off_str) if off_str and off_str.isdigit() else None
-                    bits_str = child.get("bits")
-                    try:
-                        bitfield_bits = int(bits_str) if bits_str is not None else None
-                        is_bitfield = bitfield_bits is not None
-                    except ValueError:
-                        is_bitfield = False
-                        bitfield_bits = None
-                    fields.append(TypeField(
-                        name=f_name, type=f_type, offset_bits=offset,
-                        is_bitfield=is_bitfield, bitfield_bits=bitfield_bits,
-                    ))
-
-            bases = [
+    def _build_record_type(self, el: Any) -> RecordType:
+        name = el.get("name", "")
+        return RecordType(
+            name=name,
+            kind=el.tag.lower(),
+            size_bits=self._optional_int_attr(el, "size"),
+            alignment_bits=self._optional_int_attr(el, "align"),
+            fields=self._parse_record_fields(el),
+            bases=[
                 self._type_name(b.get("type", ""))
                 for b in el if b.tag == "Base" and b.get("virtual") != "1"
-            ]
-            virtual_bases = [
+            ],
+            virtual_bases=[
                 self._type_name(b.get("type", ""))
                 for b in el if b.tag == "Base" and b.get("virtual") == "1"
-            ]
+            ],
+            vtable=self._build_vtable(el.get("id", "")),
+            is_union=el.tag == "Union",
+        )
 
-            # Collect vtable: virtual methods from this class and its base classes
-            # In castxml, Method elements are top-level with "context" pointing to class id
-            class_id = el.get("id", "")
-            virtual_methods = []
+    def _optional_int_attr(self, el: Any, attr: str) -> int | None:
+        raw = el.get(attr)
+        return int(raw) if raw and raw.isdigit() else None
 
-            # Collect virtual methods: look up in the top-level map by class id
-            # Also include inherited virtual methods from base classes (prepend them)
-            def _collect_virtual_methods(cid: str, seen: set[str] | None = None) -> list[tuple[int | None, str]]:
-                if seen is None:
-                    seen = set()
-                if cid in seen:
-                    return []
-                seen.add(cid)
-                class_el = self._id_map.get(cid)
-                if class_el is None:
-                    return []
-                result = []
-                # First collect from base classes (inherited methods come first in vtable)
-                for base in class_el:
-                    if base.tag == "Base":
-                        base_type_el = self._resolve(base.get("type", ""))
-                        if base_type_el is not None:
-                            result.extend(_collect_virtual_methods(base_type_el.get("id", ""), seen))
-                # Then add this class's own virtual methods
-                for m in self._virtual_methods_by_class.get(cid, []):
-                    mangled_m = m.get("mangled", "")
-                    if mangled_m:
-                        vi = _parse_vtable_index(m.get("vtable_index"))
-                        result.append((vi, mangled_m))
-                return result
-
-            virtual_methods = _collect_virtual_methods(class_id)
-
-            # Sort: methods with vtable_index first (by index), then remainder in XML order
-            virtual_methods.sort(key=_vt_sort_key)
-            vtable = [m for _, m in virtual_methods]
-
-            is_union = el.tag == "Union"
-            types.append(RecordType(
-                name=name,
-                kind=el.tag.lower(),
-                size_bits=size_bits,
-                alignment_bits=alignment_bits,
-                fields=fields,
-                bases=bases,
-                virtual_bases=virtual_bases,
-                vtable=vtable,
-                is_union=is_union,
+    def _parse_record_fields(self, el: Any) -> list[TypeField]:
+        fields: list[TypeField] = []
+        for child in el:
+            if child.tag != "Field":
+                continue
+            bitfield_bits, is_bitfield = self._parse_bitfield_bits(child.get("bits"))
+            fields.append(TypeField(
+                name=child.get("name", ""),
+                type=self._type_name(child.get("type", "")),
+                offset_bits=self._optional_int_attr(child, "offset"),
+                is_bitfield=is_bitfield,
+                bitfield_bits=bitfield_bits,
             ))
-        return types
+        return fields
+
+    @staticmethod
+    def _parse_bitfield_bits(bits_raw: str | None) -> tuple[int | None, bool]:
+        try:
+            bitfield_bits = int(bits_raw) if bits_raw is not None else None
+        except ValueError:
+            return (None, False)
+        return (bitfield_bits, bitfield_bits is not None)
+
+    def _build_vtable(self, class_id: str) -> list[str]:
+        virtual_methods = self._collect_virtual_methods(class_id)
+        virtual_methods.sort(key=_vt_sort_key)
+        return [m for _, m in virtual_methods]
+
+    def _collect_virtual_methods(
+        self, cid: str, seen: set[str] | None = None,
+    ) -> list[tuple[int | None, str]]:
+        if seen is None:
+            seen = set()
+        if cid in seen:
+            return []
+        seen.add(cid)
+        class_el = self._id_map.get(cid)
+        if class_el is None:
+            return []
+
+        result: list[tuple[int | None, str]] = []
+        for base in class_el:
+            if base.tag != "Base":
+                continue
+            base_type_el = self._resolve(base.get("type", ""))
+            if base_type_el is not None:
+                result.extend(self._collect_virtual_methods(base_type_el.get("id", ""), seen))
+
+        for method_el in self._virtual_methods_by_class.get(cid, []):
+            mangled_name = method_el.get("mangled", "")
+            if not mangled_name:
+                continue
+            result.append((_parse_vtable_index(method_el.get("vtable_index")), mangled_name))
+        return result
 
 
     def parse_enums(self) -> list[EnumType]:

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -510,7 +510,7 @@ def _die_to_type_info(  # noqa: PLR0911
     return result
 
 
-def _compute_type_info(  # noqa: PLR0911
+def _compute_type_info(
     die: Any,
     CU: Any,
     depth: int,
@@ -519,80 +519,124 @@ def _compute_type_info(  # noqa: PLR0911
     tag = die.tag
 
     if tag == "DW_TAG_base_type":
-        name = _attr_str(die, "DW_AT_name") or "base"
-        size = _attr_int(die, "DW_AT_byte_size")
-        return (name, size)
+        return (_attr_str(die, "DW_AT_name") or "base", _attr_int(die, "DW_AT_byte_size"))
 
     if tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
-        name = _attr_str(die, "DW_AT_name") or "<anon>"
-        size = _attr_int(die, "DW_AT_byte_size")
-        prefix = "struct " if tag == "DW_TAG_structure_type" else ""
-        return (f"{prefix}{name}", size)
+        return _compute_record_type_info(die, tag)
 
     if tag == "DW_TAG_enumeration_type":
         name = _attr_str(die, "DW_AT_name") or "<enum>"
-        size = _attr_int(die, "DW_AT_byte_size")
-        return (f"enum {name}", size)
+        return (f"enum {name}", _attr_int(die, "DW_AT_byte_size"))
 
     if tag == "DW_TAG_pointer_type":
-        ptr_size = _attr_int(die, "DW_AT_byte_size") or 8
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (f"{inner_name} *", ptr_size)
-            except Exception:  # noqa: BLE001
-                return ("void *", ptr_size)
-        return ("void *", ptr_size)
+        return _compute_pointer_like_info(die, CU, depth, cache, suffix=" *", fallback="void *")
 
     if tag in ("DW_TAG_reference_type", "DW_TAG_rvalue_reference_type"):
-        ref_size = _attr_int(die, "DW_AT_byte_size") or 8
-        suffix = "&&" if tag == "DW_TAG_rvalue_reference_type" else "&"
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (f"{inner_name} {suffix}", ref_size)
-            except Exception:  # noqa: BLE001
-                return (f"? {suffix}", ref_size)
-        return (f"? {suffix}", ref_size)
+        suffix = " &&" if tag == "DW_TAG_rvalue_reference_type" else " &"
+        return _compute_pointer_like_info(die, CU, depth, cache, suffix=suffix, fallback=f"?{suffix}")
 
     if tag in ("DW_TAG_const_type", "DW_TAG_volatile_type", "DW_TAG_restrict_type"):
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                qualifier = tag.split("_")[2].lower()  # const / volatile / restrict
-                return (f"{qualifier} {inner_name}", size)
-            except Exception:  # noqa: BLE001
-                return (tag.split("_")[2].lower(), 0)
+        qualifier = tag.split("_")[2].lower()
+        return _compute_qualified_type_info(die, CU, depth, cache, qualifier)
 
     if tag == "DW_TAG_typedef":
-        name = _attr_str(die, "DW_AT_name")
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, size = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (name or inner_name, size)
-            except Exception:  # noqa: BLE001
-                return (name or "typedef", 0)
-        return (name or "typedef", 0)
+        return _compute_typedef_info(die, CU, depth, cache)
 
     if tag == "DW_TAG_array_type":
-        size = _attr_int(die, "DW_AT_byte_size")
-        if "DW_AT_type" in die.attributes:
-            try:
-                inner_die = _resolve_ref(die, "DW_AT_type", CU)
-                inner_name, _ = _die_to_type_info(inner_die, CU, depth + 1, cache)
-                return (f"{inner_name}[]", size)
-            except Exception:  # noqa: BLE001
-                return ("array", size)
-        return ("array", size)
+        return _compute_array_type_info(die, CU, depth, cache)
 
     if tag == "DW_TAG_subroutine_type":
         return ("fn(...)", _attr_int(die, "DW_AT_byte_size"))
 
-    # Fallback: use whatever name/size we can get from this DIE
+    return _compute_fallback_type_info(die, tag)
+
+
+def _compute_record_type_info(die: Any, tag: str) -> tuple[str, int]:
+    name = _attr_str(die, "DW_AT_name") or "<anon>"
+    prefix = "struct " if tag == "DW_TAG_structure_type" else ""
+    return (f"{prefix}{name}", _attr_int(die, "DW_AT_byte_size"))
+
+
+def _compute_pointer_like_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+    suffix: str,
+    fallback: str,
+) -> tuple[str, int]:
+    pointee = _resolve_inner_type_name(die, CU, depth, cache)
+    size = _attr_int(die, "DW_AT_byte_size") or 8
+    if pointee is None:
+        return (fallback, size)
+    return (f"{pointee}{suffix}", size)
+
+
+def _compute_qualified_type_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+    qualifier: str,
+) -> tuple[str, int]:
+    inner = _resolve_inner_type_info(die, CU, depth, cache)
+    if inner is None:
+        return (qualifier, 0)
+    inner_name, size = inner
+    return (f"{qualifier} {inner_name}", size)
+
+
+def _compute_typedef_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int]:
+    name = _attr_str(die, "DW_AT_name")
+    inner = _resolve_inner_type_info(die, CU, depth, cache)
+    if inner is None:
+        return (name or "typedef", 0)
+    inner_name, size = inner
+    return (name or inner_name, size)
+
+
+def _compute_array_type_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int]:
+    size = _attr_int(die, "DW_AT_byte_size")
+    inner_name = _resolve_inner_type_name(die, CU, depth, cache)
+    return (f"{inner_name}[]", size) if inner_name is not None else ("array", size)
+
+
+def _resolve_inner_type_info(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> tuple[str, int] | None:
+    if "DW_AT_type" not in die.attributes:
+        return None
+    try:
+        inner_die = _resolve_ref(die, "DW_AT_type", CU)
+        return _die_to_type_info(inner_die, CU, depth + 1, cache)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _resolve_inner_type_name(
+    die: Any,
+    CU: Any,
+    depth: int,
+    cache: dict[tuple[int, int], tuple[str, int]],
+) -> str | None:
+    inner = _resolve_inner_type_info(die, CU, depth, cache)
+    return inner[0] if inner is not None else None
+
+
+def _compute_fallback_type_info(die: Any, tag: str) -> tuple[str, int]:
     name = _attr_str(die, "DW_AT_name")
     size = _attr_int(die, "DW_AT_byte_size")
     return (name or tag or "unknown", size)

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -1,10 +1,16 @@
-"""Sprint 5: HTML report generator for ABI comparison results.
+"""Sprint 9: ABICC-compatible HTML report generator.
 
-Generates a self-contained HTML report (no external CSS/JS dependencies)
-matching the structure of ABICC reports:
-- Verdict banner (BREAKING / COMPATIBLE / NO_CHANGE)
-- Binary Compatibility % metric
-- Changes table (kind, symbol, description, old/new value)
+Generates a self-contained HTML report that mirrors the structure of
+abi-compliance-checker (ABICC) reports:
+
+  - Verdict banner (BREAKING / COMPATIBLE / NO_CHANGE)
+  - Binary Compatibility % metric (based on old exported symbol count)
+  - Summary table: changes by category (functions, variables, types, enums, ELF)
+  - Sectioned changes: Removed | Changed | Added (with anchored navigation)
+  - Suppressed changes section (if any)
+  - Demangled symbol names as display text, mangled as tooltip
+
+No external CSS/JS dependencies — fully self-contained single HTML file.
 """
 from __future__ import annotations
 
@@ -13,168 +19,86 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .checker import DiffResult as CompareResult
+    from .checker import Change, DiffResult
 
-# Verdict colours matching ABICC's visual style
+# ---------------------------------------------------------------------------
+# Verdict styling — matches ABICC's visual palette
+# ---------------------------------------------------------------------------
+
 _VERDICT_STYLE: dict[str, tuple[str, str]] = {
     "BREAKING": ("#b71c1c", "#ffcdd2"),
     "COMPATIBLE": ("#1b5e20", "#c8e6c9"),
     "NO_CHANGE": ("#0d47a1", "#bbdefb"),
+    "SOURCE_BREAK": ("#e65100", "#ffe0b2"),
 }
 
-_CSS = """
-body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-.header { padding: 24px 32px; background: #263238; color: #fff; }
-.header h1 { margin: 0 0 4px; font-size: 1.5em; }
-.header .meta { font-size: 0.9em; color: #b0bec5; }
-.verdict-box { margin: 24px 32px; padding: 16px 24px; border-radius: 6px; }
-.verdict-box h2 { margin: 0 0 4px; font-size: 1.3em; }
-.bc-metric { font-size: 1.1em; margin-top: 8px; }
-.section { margin: 0 32px 24px; background: #fff; border-radius: 6px;
-           box-shadow: 0 1px 3px rgba(0,0,0,.1); overflow: hidden; }
-.section h3 { margin: 0; padding: 12px 16px; background: #eceff1;
-              font-size: 1em; border-bottom: 1px solid #cfd8dc; }
-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
-th { background: #f5f5f5; padding: 8px 12px; text-align: left;
-     border-bottom: 2px solid #e0e0e0; }
-td { padding: 8px 12px; border-bottom: 1px solid #eeeeee; vertical-align: top; }
-tr:last-child td { border-bottom: none; }
-.kind { font-family: monospace; font-size: 0.85em; color: #37474f;
-        background: #eceff1; padding: 2px 6px; border-radius: 3px; }
-.breaking { color: #b71c1c; font-weight: bold; }
-.compatible { color: #1b5e20; }
-.sym { font-family: monospace; }
-.empty { padding: 16px; color: #9e9e9e; font-style: italic; }
-footer { padding: 16px 32px; font-size: 0.8em; color: #9e9e9e; }
-"""
+# ---------------------------------------------------------------------------
+# Change-kind classification helpers
+# ---------------------------------------------------------------------------
 
-
-def generate_html_report(
-    result: CompareResult,
-    lib_name: str = "",
-    old_version: str = "",
-    new_version: str = "",
-) -> str:
-    """Generate a standalone HTML ABI comparison report.
-
-    Args:
-        result: CompareResult from checker.compare().
-        lib_name: Library name for the report header.
-        old_version: Old library version string.
-        new_version: New library version string.
-
-    Returns:
-        Complete HTML document as a string.
-    """
-    verdict = result.verdict.value if hasattr(result.verdict, "value") else str(result.verdict)
-    fg, bg = _VERDICT_STYLE.get(verdict, ("#212121", "#f5f5f5"))
-    changes = getattr(result, "changes", []) or []
-
-    # Derive summary from changes list (DiffResult has no pre-computed summary field)
-    breaking = sum(1 for ch in changes if _is_breaking(ch))
-    compatible_add = sum(1 for ch in changes if not _is_breaking(ch))
-    total = len(changes)
-
-    # BC% = exported symbols with no breaking change / total exported
-    # We approximate: if no breaking changes, 100%; otherwise use breaking count.
-    if breaking == 0:
-        bc_pct = 100.0
-    elif total > 0:
-        bc_pct = max(0.0, (total - breaking) / total * 100)
-    else:
-        bc_pct = 0.0
-
-    h = html.escape
-    lib_display = h(lib_name) if lib_name else "library"
-    old_display = h(old_version) if old_version else "old"
-    new_display = h(new_version) if new_version else "new"
-
-    changes_rows = ""
-    if changes:
-        for ch in changes:
-            kind = getattr(ch, "kind", None)
-            kind_str = kind.value if kind is not None and hasattr(kind, "value") else str(kind)
-            sym = h(getattr(ch, "symbol", "") or "")
-            desc = h(getattr(ch, "description", "") or "")
-            old_val = h(str(getattr(ch, "old_value", "") or ""))
-            new_val = h(str(getattr(ch, "new_value", "") or ""))
-            row_class = "breaking" if kind_str in _BREAKING_KINDS else "compatible"
-            changes_rows += (
-                f"<tr>"
-                f"<td><span class='kind'>{h(kind_str)}</span></td>"
-                f"<td class='sym {row_class}'>{sym}</td>"
-                f"<td>{desc}</td>"
-                f"<td>{old_val}</td>"
-                f"<td>{new_val}</td>"
-                f"</tr>\n"
-            )
-    else:
-        changes_rows = "<tr><td colspan='5' class='empty'>No changes detected.</td></tr>"
-
-    table = f"""
-    <table>
-      <thead>
-        <tr>
-          <th>Kind</th><th>Symbol</th><th>Description</th>
-          <th>Old value</th><th>New value</th>
-        </tr>
-      </thead>
-      <tbody>
-        {changes_rows}
-      </tbody>
-    </table>"""
-
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>ABI Report: {lib_display} {old_display} → {new_display}</title>
-  <style>{_CSS}</style>
-</head>
-<body>
-  <div class="header">
-    <h1>ABI Compatibility Report</h1>
-    <div class="meta">
-      Library: <strong>{lib_display}</strong> &nbsp;|&nbsp;
-      {old_display} → {new_display} &nbsp;|&nbsp;
-      Generated by <strong>abicheck</strong>
-    </div>
-  </div>
-
-  <div class="verdict-box" style="background:{bg}; color:{fg}; border-left: 6px solid {fg};">
-    <h2>Verdict: {h(verdict)}</h2>
-    <div class="bc-metric">
-      Binary Compatibility: <strong>{bc_pct:.1f}%</strong>
-      <span style="font-size:0.8em; opacity:0.8">(approx. from changed symbols, not total exported surface)</span>
-      &nbsp;|&nbsp;
-      Breaking: {breaking} &nbsp;|&nbsp;
-      Compatible additions: {compatible_add} &nbsp;|&nbsp;
-      Total changes: {total}
-    </div>
-  </div>
-
-  <div class="section">
-    <h3>Changes ({total})</h3>
-    {table}
-  </div>
-
-  <footer>Generated by abicheck · ABICC-compatible report format</footer>
-</body>
-</html>
-"""
-
-
-# Set of kind strings that are considered breaking (for row colouring).
-# Defined before _is_breaking() which references it.
-_BREAKING_KINDS: frozenset[str] = frozenset({
-    "func_removed", "func_params_changed", "func_return_changed",
-    "func_noexcept_removed", "type_size_changed", "struct_size_changed",
-    "struct_field_removed", "struct_field_offset_changed", "struct_field_type_changed",
-    "struct_alignment_changed", "type_vtable_changed", "enum_underlying_size_changed",
-    "enum_member_value_changed", "enum_member_removed", "calling_convention_changed",
-    "struct_packing_changed", "type_visibility_changed", "qualifier_removed",
-    "union_field_removed", "bitfield_size_changed",
+#: Kinds that count as "removed" in the ABICC sense (symbol no longer available).
+_REMOVED_KINDS: frozenset[str] = frozenset({
+    "func_removed", "var_removed", "type_removed", "typedef_removed",
+    "union_field_removed",
 })
+
+#: Kinds that count as "added" (new API surface — compatible).
+_ADDED_KINDS: frozenset[str] = frozenset({
+    "func_added", "var_added", "type_added", "func_virtual_added",
+    "enum_member_added", "union_field_added", "type_field_added",
+    "type_field_added_compatible",
+})
+
+#: Kinds that are breaking but neither a simple removal nor addition.
+_CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
+    "func_params_changed", "func_return_changed",
+    "func_noexcept_added", "func_noexcept_removed",
+    "func_virtual_removed", "func_virtual_became_pure",
+    "func_pure_virtual_added", "func_static_changed", "func_cv_changed",
+    "var_type_changed",
+    "type_size_changed", "type_alignment_changed",
+    "type_field_removed", "type_field_offset_changed", "type_field_type_changed",
+    "type_base_changed", "type_vtable_changed",
+    "enum_member_value_changed", "enum_last_member_value_changed",
+    "enum_underlying_size_changed",
+    "struct_size_changed", "struct_field_offset_changed", "struct_field_removed",
+    "struct_field_type_changed", "struct_alignment_changed",
+    "field_bitfield_changed",
+    "calling_convention_changed", "struct_packing_changed",
+    "type_visibility_changed", "qualifier_removed",
+    "typedef_base_changed",
+    "union_field_type_changed",
+    # ELF-layer
+    "soname_changed", "symbol_binding_changed", "symbol_type_changed",
+    "symbol_size_changed", "symbol_version_defined_removed",
+    "needed_removed", "rpath_changed", "runpath_changed",
+    "ifunc_introduced", "ifunc_removed",
+    # DWARF
+    "dwarf_info_missing",
+})
+
+#: All breaking kinds (union of removals + changes, not additions)
+_BREAKING_KINDS: frozenset[str] = _REMOVED_KINDS | _CHANGED_BREAKING_KINDS | frozenset({
+    "func_noexcept_added",  # noexcept added is breaking per C++17 P0012R1
+    "func_virtual_removed", "func_virtual_became_pure", "func_pure_virtual_added",
+})
+
+#: Category buckets for the summary table — mirrors ABICC section headers.
+_CATEGORY_PREFIXES: list[tuple[str, str]] = [
+    ("Functions",  ("func_",)),
+    ("Variables",  ("var_",)),
+    ("Types",      ("type_", "struct_", "union_", "field_", "typedef_")),
+    ("Enums",      ("enum_",)),
+    ("ELF / DWARF", ("soname_", "symbol_", "needed_", "rpath_", "runpath_",
+                     "ifunc_", "common_", "dwarf_")),
+]
+
+
+def _category(kind_str: str) -> str:
+    for label, prefixes in _CATEGORY_PREFIXES:
+        if any(kind_str.startswith(p) for p in prefixes):
+            return label
+    return "Other"
 
 
 def _is_breaking(change: object) -> bool:
@@ -183,15 +107,386 @@ def _is_breaking(change: object) -> bool:
     return kind_str in _BREAKING_KINDS
 
 
+def _kind_str(change: object) -> str:
+    kind = getattr(change, "kind", None)
+    return kind.value if kind is not None and hasattr(kind, "value") else str(kind)
+
+
+def _change_bucket(change: object) -> str:
+    """Classify a change into 'removed', 'added', or 'changed'."""
+    ks = _kind_str(change)
+    if ks in _REMOVED_KINDS:
+        return "removed"
+    if ks in _ADDED_KINDS:
+        return "added"
+    return "changed"
+
+
+# ---------------------------------------------------------------------------
+# CSS — ABICC visual style, no external deps
+# ---------------------------------------------------------------------------
+
+_CSS = """\
+*, *::before, *::after { box-sizing: border-box; }
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f5f5f5; color: #212121; }
+
+/* ---- header ---- */
+.header { padding: 20px 32px; background: #263238; color: #fff; }
+.header h1 { margin: 0 0 4px; font-size: 1.4em; letter-spacing: .02em; }
+.header .meta { font-size: 0.88em; color: #b0bec5; }
+
+/* ---- verdict banner ---- */
+.verdict-box { margin: 20px 32px 0; padding: 14px 22px; border-radius: 6px; }
+.verdict-box h2 { margin: 0 0 6px; font-size: 1.2em; }
+.bc-metric { font-size: 1em; margin-top: 4px; }
+.bc-metric strong { font-size: 1.1em; }
+
+/* ---- nav bar ---- */
+.nav { margin: 14px 32px 0; display: flex; gap: 8px; flex-wrap: wrap; }
+.nav a { display: inline-block; padding: 5px 12px; border-radius: 4px;
+          background: #eceff1; color: #37474f; font-size: 0.85em;
+          text-decoration: none; border: 1px solid #cfd8dc; }
+.nav a:hover { background: #cfd8dc; }
+.nav a.breaking { background: #ffcdd2; border-color: #e57373; color: #b71c1c; }
+.nav a.added    { background: #c8e6c9; border-color: #81c784; color: #1b5e20; }
+
+/* ---- summary table ---- */
+.summary-section { margin: 20px 32px 0; background: #fff; border-radius: 6px;
+                   box-shadow: 0 1px 3px rgba(0,0,0,.1); overflow: hidden; }
+.summary-section h3 { margin: 0; padding: 10px 16px; background: #eceff1;
+                      font-size: .95em; border-bottom: 1px solid #cfd8dc; }
+.summary-table { width: 100%; border-collapse: collapse; font-size: 0.88em; }
+.summary-table th { background: #f5f5f5; padding: 7px 12px; text-align: left;
+                    border-bottom: 2px solid #e0e0e0; }
+.summary-table td { padding: 6px 12px; border-bottom: 1px solid #eeeeee; }
+.summary-table tr:last-child td { border-bottom: none; }
+.num { font-weight: bold; font-family: monospace; }
+.num-red  { color: #b71c1c; }
+.num-green { color: #1b5e20; }
+.num-blue  { color: #1565c0; }
+
+/* ---- change sections ---- */
+.section { margin: 16px 32px 0; background: #fff; border-radius: 6px;
+           box-shadow: 0 1px 3px rgba(0,0,0,.1); overflow: hidden; }
+.section h3 { margin: 0; padding: 10px 16px; font-size: .95em;
+              border-bottom: 1px solid #cfd8dc; }
+.section-removed h3 { background: #ffebee; color: #b71c1c; }
+.section-changed h3 { background: #fff8e1; color: #e65100; }
+.section-added   h3 { background: #e8f5e9; color: #1b5e20; }
+.section-suppressed h3 { background: #f3e5f5; color: #6a1b9a; }
+
+/* ---- changes table ---- */
+table.changes { width: 100%; border-collapse: collapse; font-size: 0.87em; }
+table.changes th { background: #fafafa; padding: 7px 12px; text-align: left;
+                   border-bottom: 2px solid #e0e0e0; white-space: nowrap; }
+table.changes td { padding: 7px 12px; border-bottom: 1px solid #eeeeee; vertical-align: top; }
+table.changes tr:last-child td { border-bottom: none; }
+.kind-badge { font-family: monospace; font-size: 0.82em; color: #37474f;
+              background: #eceff1; padding: 2px 6px; border-radius: 3px;
+              white-space: nowrap; }
+.sym { font-family: monospace; font-size: 0.85em; }
+.sym abbr { text-decoration: underline dotted #9e9e9e; cursor: help; }
+.empty { padding: 14px 16px; color: #9e9e9e; font-style: italic; font-size: 0.88em; }
+.cat-badge { font-size: 0.78em; background: #e3f2fd; color: #1565c0;
+             padding: 1px 5px; border-radius: 3px; white-space: nowrap; }
+
+/* ---- footer ---- */
+footer { margin: 20px 32px 32px; padding: 12px 16px; font-size: 0.8em;
+         color: #9e9e9e; border-top: 1px solid #e0e0e0; }
+"""
+
+# ---------------------------------------------------------------------------
+# HTML generation helpers
+# ---------------------------------------------------------------------------
+
+
+def _symbol_cell(change: object) -> str:
+    """Render symbol name: demangled text with mangled name as tooltip."""
+    h = html.escape
+    mangled = h(getattr(change, "symbol", "") or "")
+    demangled = h(getattr(change, "demangled_symbol", "") or mangled)
+    if demangled and demangled != mangled and mangled:
+        return f"<abbr title='{mangled}'>{demangled}</abbr>"
+    return demangled or mangled
+
+
+def _changes_table(changes: list) -> str:
+    if not changes:
+        return "<p class='empty'>No changes in this category.</p>"
+
+    rows = []
+    for ch in changes:
+        ks = _kind_str(ch)
+        cat = _category(ks)
+        desc = html.escape(getattr(ch, "description", "") or "")
+        old_val = html.escape(str(getattr(ch, "old_value", "") or ""))
+        new_val = html.escape(str(getattr(ch, "new_value", "") or ""))
+        sym_cell = _symbol_cell(ch)
+        rows.append(
+            f"<tr>"
+            f"<td><span class='kind-badge'>{html.escape(ks)}</span></td>"
+            f"<td class='sym'>{sym_cell}</td>"
+            f"<td><span class='cat-badge'>{html.escape(cat)}</span></td>"
+            f"<td>{desc}</td>"
+            f"<td>{old_val}</td>"
+            f"<td>{new_val}</td>"
+            f"</tr>"
+        )
+
+    body = "\n".join(rows)
+    return f"""<table class='changes'>
+  <thead>
+    <tr>
+      <th>Kind</th><th>Symbol</th><th>Category</th>
+      <th>Description</th><th>Old&nbsp;value</th><th>New&nbsp;value</th>
+    </tr>
+  </thead>
+  <tbody>
+    {body}
+  </tbody>
+</table>"""
+
+
+def _summary_table(
+    removed: list, changed: list, added: list, suppressed_count: int
+) -> str:
+    """Build category-level summary table (mirrors ABICC's overview section)."""
+    all_changes = removed + changed + added
+
+    # Count by category
+    cats: dict[str, dict[str, int]] = {}
+    for label, _ in _CATEGORY_PREFIXES:
+        cats[label] = {"removed": 0, "changed": 0, "added": 0}
+    cats["Other"] = {"removed": 0, "changed": 0, "added": 0}
+
+    for ch in removed:
+        cats[_category(_kind_str(ch))]["removed"] += 1
+    for ch in changed:
+        cats[_category(_kind_str(ch))]["changed"] += 1
+    for ch in added:
+        cats[_category(_kind_str(ch))]["added"] += 1
+
+    rows = []
+    for label in [lbl for lbl, _ in _CATEGORY_PREFIXES] + ["Other"]:
+        c = cats[label]
+        if c["removed"] == 0 and c["changed"] == 0 and c["added"] == 0:
+            continue
+        r = f"<span class='num num-red'>{c['removed']}</span>" if c["removed"] else "—"
+        ch_n = f"<span class='num num-blue'>{c['changed']}</span>" if c["changed"] else "—"
+        a = f"<span class='num num-green'>{c['added']}</span>" if c["added"] else "—"
+        rows.append(f"<tr><td>{html.escape(label)}</td><td>{r}</td><td>{ch_n}</td><td>{a}</td></tr>")
+
+    total_r = f"<span class='num num-red'>{len(removed)}</span>"
+    total_ch = f"<span class='num num-blue'>{len(changed)}</span>"
+    total_a = f"<span class='num num-green'>{len(added)}</span>"
+    rows.append(
+        f"<tr style='border-top:2px solid #e0e0e0; font-weight:bold;'>"
+        f"<td>Total</td><td>{total_r}</td><td>{total_ch}</td><td>{total_a}</td></tr>"
+    )
+
+    if suppressed_count:
+        rows.append(
+            f"<tr><td colspan='4' style='color:#6a1b9a; font-size:0.85em; padding:6px 12px;'>"
+            f"ℹ️ {suppressed_count} change(s) suppressed by suppression file</td></tr>"
+        )
+
+    body = "\n".join(rows)
+    return f"""<div class='summary-section'>
+  <h3>📊 Change Summary</h3>
+  <table class='summary-table'>
+    <thead>
+      <tr><th>Category</th><th>Removed</th><th>Changed</th><th>Added</th></tr>
+    </thead>
+    <tbody>
+      {body}
+    </tbody>
+  </table>
+</div>"""
+
+
+def _nav_bar(removed: list, changed: list, added: list, suppressed_count: int) -> str:
+    links = []
+    if removed:
+        links.append(f"<a href='#removed' class='breaking'>⛔ Removed ({len(removed)})</a>")
+    if changed:
+        links.append(f"<a href='#changed' class='breaking'>⚠️ Changed ({len(changed)})</a>")
+    if added:
+        links.append(f"<a href='#added' class='added'>✅ Added ({len(added)})</a>")
+    if suppressed_count:
+        links.append(f"<a href='#suppressed'>🔕 Suppressed ({suppressed_count})</a>")
+    if not links:
+        return ""
+    return "<div class='nav'>" + "".join(links) + "</div>"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_html_report(
+    result: "DiffResult",
+    lib_name: str = "",
+    old_version: str = "",
+    new_version: str = "",
+    old_symbol_count: int | None = None,
+) -> str:
+    """Generate a standalone ABICC-compatible HTML ABI report.
+
+    Args:
+        result: DiffResult from checker.compare().
+        lib_name: Library name for the report header.
+        old_version: Old library version string.
+        new_version: New library version string.
+        old_symbol_count: Total exported public symbol count in the old library.
+            Used to compute Binary Compatibility %. If None, approximated from
+            changes (legacy behaviour).
+
+    Returns:
+        Complete self-contained HTML document as a string.
+    """
+    verdict = result.verdict.value if hasattr(result.verdict, "value") else str(result.verdict)
+    fg, bg = _VERDICT_STYLE.get(verdict, ("#212121", "#f5f5f5"))
+
+    changes: list = list(getattr(result, "changes", None) or [])
+    suppressed: list = list(getattr(result, "suppressed_changes", None) or [])
+    suppressed_count: int = getattr(result, "suppressed_count", len(suppressed))
+
+    # Split changes into buckets
+    removed = [ch for ch in changes if _change_bucket(ch) == "removed"]
+    added   = [ch for ch in changes if _change_bucket(ch) == "added"]
+    changed = [ch for ch in changes if _change_bucket(ch) == "changed"]
+
+    # Binary Compatibility %
+    breaking_count = sum(1 for ch in changes if _is_breaking(ch))
+    if breaking_count == 0:
+        bc_pct = 100.0
+    elif old_symbol_count and old_symbol_count > 0:
+        # ABICC-style: (total_old - breaking) / total_old * 100
+        bc_pct = max(0.0, (old_symbol_count - breaking_count) / old_symbol_count * 100)
+    else:
+        total = len(changes)
+        bc_pct = max(0.0, (total - breaking_count) / total * 100) if total > 0 else 0.0
+
+    h = html.escape
+    lib_display  = h(lib_name)  if lib_name  else "library"
+    old_display  = h(old_version) if old_version else "old"
+    new_display  = h(new_version) if new_version else "new"
+
+    # Verdict icon
+    verdict_icon = {"BREAKING": "🔴", "COMPATIBLE": "🟢",
+                    "NO_CHANGE": "🔵", "SOURCE_BREAK": "🟠"}.get(verdict, "⚪")
+
+    summary_html = _summary_table(removed, changed, added, suppressed_count)
+    nav_html     = _nav_bar(removed, changed, added, suppressed_count)
+
+    def _section(title: str, anchor: str, css_class: str, items: list) -> str:
+        count = len(items)
+        tbl = _changes_table(items)
+        return (
+            f"<div class='section {css_class}' id='{anchor}'>"
+            f"<h3>{title} ({count})</h3>"
+            f"{tbl}"
+            f"</div>"
+        )
+
+    sections = []
+    if removed:
+        sections.append(_section("⛔ Removed Symbols", "removed", "section-removed", removed))
+    if changed:
+        sections.append(_section("⚠️ Changed Symbols", "changed", "section-changed", changed))
+    if added:
+        sections.append(_section("✅ Added Symbols", "added", "section-added", added))
+    if suppressed:
+        sections.append(_section("🔕 Suppressed Changes", "suppressed",
+                                  "section-suppressed", suppressed))
+    elif suppressed_count and not suppressed:
+        # Count known but details not stored
+        sections.append(
+            f"<div class='section section-suppressed' id='suppressed'>"
+            f"<h3>🔕 Suppressed Changes ({suppressed_count})</h3>"
+            f"<p class='empty'>Details not available (suppressed_changes list is empty).</p>"
+            f"</div>"
+        )
+
+    if not sections:
+        sections.append(
+            "<div class='section'><p class='empty'>"
+            "No ABI changes detected between the two versions."
+            "</p></div>"
+        )
+
+    sections_html = "\n".join(sections)
+
+    symbol_count_note = ""
+    if old_symbol_count:
+        symbol_count_note = (
+            f" / {old_symbol_count} exported symbols"
+        )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ABI Report: {lib_display} {old_display} → {new_display}</title>
+  <style>{_CSS}</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>ABI Compatibility Report — {lib_display}</h1>
+  <div class="meta">
+    {old_display} → {new_display} &nbsp;|&nbsp;
+    Generated by <strong>abicheck</strong> (ABICC-compatible)
+  </div>
+</div>
+
+<div class="verdict-box" style="background:{bg}; color:{fg}; border-left:6px solid {fg};">
+  <h2>{verdict_icon} Verdict: {h(verdict)}</h2>
+  <div class="bc-metric">
+    Binary Compatibility: <strong>{bc_pct:.1f}%</strong>
+    <span style="font-size:0.82em; opacity:0.75">
+      ({breaking_count} breaking change(s){symbol_count_note})
+    </span>
+    &nbsp;&nbsp;
+    <span style="font-size:0.85em;">
+      Removed: <strong>{len(removed)}</strong>
+      &nbsp;|&nbsp; Changed: <strong>{len(changed)}</strong>
+      &nbsp;|&nbsp; Added: <strong>{len(added)}</strong>
+    </span>
+  </div>
+</div>
+
+{nav_html}
+{summary_html}
+{sections_html}
+
+<footer>
+  Generated by <strong>abicheck</strong> · ABICC-compatible report format ·
+  <a href="https://github.com/napetrov/abicheck" style="color:#9e9e9e;">napetrov/abicheck</a>
+</footer>
+
+</body>
+</html>
+"""
+
+
 def write_html_report(
-    result: CompareResult,
+    result: "DiffResult",
     output_path: Path,
     lib_name: str = "",
     old_version: str = "",
     new_version: str = "",
+    old_symbol_count: int | None = None,
 ) -> None:
     """Write HTML report to *output_path*, creating parent directories as needed."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    content = generate_html_report(result, lib_name=lib_name,
-                                   old_version=old_version, new_version=new_version)
+    content = generate_html_report(
+        result,
+        lib_name=lib_name,
+        old_version=old_version,
+        new_version=new_version,
+        old_symbol_count=old_symbol_count,
+    )
     output_path.write_text(content, encoding="utf-8")

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .checker import Change, DiffResult
+    from .checker import DiffResult
 
 # ---------------------------------------------------------------------------
 # Verdict styling — matches ABICC's visual palette
@@ -40,6 +40,7 @@ _VERDICT_STYLE: dict[str, tuple[str, str]] = {
 _REMOVED_KINDS: frozenset[str] = frozenset({
     "func_removed", "var_removed", "type_removed", "typedef_removed",
     "union_field_removed",
+    "enum_member_removed",  # removing an enum member is ABI-breaking (callers rely on value)
 })
 
 #: Kinds that count as "added" (new API surface — compatible).
@@ -77,14 +78,18 @@ _CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
     "dwarf_info_missing",
 })
 
-#: All breaking kinds (union of removals + changes, not additions)
-_BREAKING_KINDS: frozenset[str] = _REMOVED_KINDS | _CHANGED_BREAKING_KINDS | frozenset({
-    "func_noexcept_added",  # noexcept added is breaking per C++17 P0012R1
-    "func_virtual_removed", "func_virtual_became_pure", "func_pure_virtual_added",
-})
+#: All breaking kinds (union of removals + changed-breaking).
+#: _CHANGED_BREAKING_KINDS already contains all breaking "changed" entries
+#: (func_noexcept_added, func_virtual_removed, etc.) — no need to repeat them.
+_BREAKING_KINDS: frozenset[str] = _REMOVED_KINDS | _CHANGED_BREAKING_KINDS
+
+# Drift guard: assert at import time that _CHANGED_BREAKING_KINDS ⊆ _BREAKING_KINDS
+assert _CHANGED_BREAKING_KINDS <= _BREAKING_KINDS, (
+    "_CHANGED_BREAKING_KINDS has entries outside _BREAKING_KINDS — update _BREAKING_KINDS"
+)
 
 #: Category buckets for the summary table — mirrors ABICC section headers.
-_CATEGORY_PREFIXES: list[tuple[str, str]] = [
+_CATEGORY_PREFIXES: list[tuple[str, tuple[str, ...]]] = [
     ("Functions",  ("func_",)),
     ("Variables",  ("var_",)),
     ("Types",      ("type_", "struct_", "union_", "field_", "typedef_")),
@@ -210,7 +215,7 @@ def _symbol_cell(change: object) -> str:
     return demangled or mangled
 
 
-def _changes_table(changes: list) -> str:
+def _changes_table(changes: list[object]) -> str:
     if not changes:
         return "<p class='empty'>No changes in this category.</p>"
 
@@ -248,10 +253,9 @@ def _changes_table(changes: list) -> str:
 
 
 def _summary_table(
-    removed: list, changed: list, added: list, suppressed_count: int
+    removed: list[object], changed: list[object], added: list[object], suppressed_count: int
 ) -> str:
     """Build category-level summary table (mirrors ABICC's overview section)."""
-    all_changes = removed + changed + added
 
     # Count by category
     cats: dict[str, dict[str, int]] = {}
@@ -304,7 +308,7 @@ def _summary_table(
 </div>"""
 
 
-def _nav_bar(removed: list, changed: list, added: list, suppressed_count: int) -> str:
+def _nav_bar(removed: list[object], changed: list[object], added: list[object], suppressed_count: int) -> str:
     links = []
     if removed:
         links.append(f"<a href='#removed' class='breaking'>⛔ Removed ({len(removed)})</a>")
@@ -325,7 +329,7 @@ def _nav_bar(removed: list, changed: list, added: list, suppressed_count: int) -
 
 
 def generate_html_report(
-    result: "DiffResult",
+    result: DiffResult,
     lib_name: str = "",
     old_version: str = "",
     new_version: str = "",
@@ -348,8 +352,8 @@ def generate_html_report(
     verdict = result.verdict.value if hasattr(result.verdict, "value") else str(result.verdict)
     fg, bg = _VERDICT_STYLE.get(verdict, ("#212121", "#f5f5f5"))
 
-    changes: list = list(getattr(result, "changes", None) or [])
-    suppressed: list = list(getattr(result, "suppressed_changes", None) or [])
+    changes: list[object] = list(getattr(result, "changes", None) or [])
+    suppressed: list[object] = list(getattr(result, "suppressed_changes", None) or [])
     suppressed_count: int = getattr(result, "suppressed_count", len(suppressed))
 
     # Split changes into buckets
@@ -361,10 +365,12 @@ def generate_html_report(
     breaking_count = sum(1 for ch in changes if _is_breaking(ch))
     if breaking_count == 0:
         bc_pct = 100.0
-    elif old_symbol_count and old_symbol_count > 0:
+    elif old_symbol_count is not None and old_symbol_count > 0:
         # ABICC-style: (total_old - breaking) / total_old * 100
+        # Clamp to 0% if breaking exceeds symbol count (stale snapshot edge case)
         bc_pct = max(0.0, (old_symbol_count - breaking_count) / old_symbol_count * 100)
     else:
+        # old_symbol_count is None or 0 — fall back to change-ratio approximation
         total = len(changes)
         bc_pct = max(0.0, (total - breaking_count) / total * 100) if total > 0 else 0.0
 
@@ -380,7 +386,7 @@ def generate_html_report(
     summary_html = _summary_table(removed, changed, added, suppressed_count)
     nav_html     = _nav_bar(removed, changed, added, suppressed_count)
 
-    def _section(title: str, anchor: str, css_class: str, items: list) -> str:
+    def _section(title: str, anchor: str, css_class: str, items: list[object]) -> str:
         count = len(items)
         tbl = _changes_table(items)
         return (
@@ -473,7 +479,7 @@ def generate_html_report(
 
 
 def write_html_report(
-    result: "DiffResult",
+    result: DiffResult,
     output_path: Path,
     lib_name: str = "",
     old_version: str = "",

--- a/docs/sprint9.md
+++ b/docs/sprint9.md
@@ -1,0 +1,1 @@
+# Sprint 9 — ABICC-compatible HTML output

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -1,13 +1,10 @@
 """Sprint 9: Tests for ABICC-compatible HTML report generator."""
 from __future__ import annotations
 
-from types import SimpleNamespace
 from pathlib import Path
-
-import pytest
+from types import SimpleNamespace
 
 from abicheck.html_report import generate_html_report, write_html_report
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -262,6 +259,21 @@ def test_xss_escape_description() -> None:
     assert "<img" not in out
 
 
+def test_xss_escape_old_value() -> None:
+    ch = _ch("func_params_changed", old='<script>x()</script>', new="int")
+    r = _result(verdict="BREAKING", changes=[ch])
+    out = generate_html_report(r)
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_xss_escape_new_value() -> None:
+    ch = _ch("func_params_changed", old="int", new='<img src=x onerror="alert(1)">')
+    r = _result(verdict="BREAKING", changes=[ch])
+    out = generate_html_report(r)
+    assert "<img" not in out
+
+
 # ---------------------------------------------------------------------------
 # write_html_report
 # ---------------------------------------------------------------------------
@@ -303,3 +315,59 @@ def test_no_change_verdict_blue_color() -> None:
     r = _result(verdict="NO_CHANGE")
     out = generate_html_report(r)
     assert "#0d47a1" in out  # NO_CHANGE foreground
+
+
+# ---------------------------------------------------------------------------
+# BC% edge cases (review feedback)
+# ---------------------------------------------------------------------------
+
+def test_bc_old_symbol_count_zero_uses_legacy_fallback() -> None:
+    """old_symbol_count=0 → falls back to change-ratio: 1 breaking / 1 total = 0%."""
+    r = _result(verdict="BREAKING", changes=[_ch("func_removed")])
+    out = generate_html_report(r, old_symbol_count=0)
+    assert "0.0%" in out
+
+
+def test_bc_clamped_to_zero_when_breaking_exceeds_symbol_count() -> None:
+    """breaking > old_symbol_count → clamped to 0% (stale snapshot edge case)."""
+    r = _result(verdict="BREAKING", changes=[_ch("func_removed")] * 5)
+    out = generate_html_report(r, old_symbol_count=3)
+    assert "0.0%" in out
+
+
+# ---------------------------------------------------------------------------
+# enum_member_removed is breaking (review feedback)
+# ---------------------------------------------------------------------------
+
+def test_enum_member_removed_is_breaking() -> None:
+    """enum_member_removed must count as breaking and appear in Removed section."""
+    r = _result(verdict="BREAKING", changes=[_ch("enum_member_removed", "MY_VAL")])
+    out = generate_html_report(r, old_symbol_count=10)
+    # Must NOT be 100% — it's a breaking removal
+    assert "100.0%" not in out
+    # Must appear in removed section
+    assert "id='removed'" in out
+
+
+def test_enum_member_removed_bucket_is_removed() -> None:
+    from abicheck.html_report import _change_bucket
+    ch = _ch("enum_member_removed", "SOME_VAL")
+    assert _change_bucket(ch) == "removed"
+
+
+# ---------------------------------------------------------------------------
+# _BREAKING_KINDS drift guard (review feedback)
+# ---------------------------------------------------------------------------
+
+def test_changed_breaking_kinds_subset_of_breaking_kinds() -> None:
+    """_CHANGED_BREAKING_KINDS must be a strict subset of _BREAKING_KINDS."""
+    from abicheck.html_report import _BREAKING_KINDS, _CHANGED_BREAKING_KINDS
+    assert _CHANGED_BREAKING_KINDS <= _BREAKING_KINDS, (
+        "_CHANGED_BREAKING_KINDS has entries not in _BREAKING_KINDS: "
+        f"{_CHANGED_BREAKING_KINDS - _BREAKING_KINDS}"
+    )
+
+
+def test_removed_kinds_subset_of_breaking_kinds() -> None:
+    from abicheck.html_report import _BREAKING_KINDS, _REMOVED_KINDS
+    assert _REMOVED_KINDS <= _BREAKING_KINDS

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -1,0 +1,305 @@
+"""Sprint 9: Tests for ABICC-compatible HTML report generator."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from abicheck.html_report import generate_html_report, write_html_report
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ch(kind: str, symbol: str = "foo", desc: str = "", old: str = "", new: str = "",
+        demangled: str = "") -> object:
+    """Minimal Change-like object."""
+    from enum import Enum
+
+    class K(str, Enum):
+        V = kind
+
+    return SimpleNamespace(
+        kind=K.V,
+        symbol=symbol,
+        demangled_symbol=demangled or symbol,
+        description=desc,
+        old_value=old,
+        new_value=new,
+    )
+
+
+def _result(
+    verdict: str = "COMPATIBLE",
+    changes: list | None = None,
+    suppressed: list | None = None,
+    suppressed_count: int = 0,
+    old_version: str = "1.0",
+    new_version: str = "2.0",
+    library: str = "libtest.so",
+) -> object:
+    v = SimpleNamespace(value=verdict)
+    return SimpleNamespace(
+        verdict=v,
+        changes=changes or [],
+        suppressed_changes=suppressed or [],
+        suppressed_count=suppressed_count,
+        old_version=old_version,
+        new_version=new_version,
+        library=library,
+        suppression_file_provided=bool(suppressed_count),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic structure tests
+# ---------------------------------------------------------------------------
+
+def test_html_is_valid_document() -> None:
+    r = _result()
+    out = generate_html_report(r)
+    assert out.startswith("<!DOCTYPE html>")
+    assert "</html>" in out
+    assert "<head>" in out
+    assert "<body>" in out
+
+
+def test_html_contains_verdict() -> None:
+    r = _result(verdict="BREAKING")
+    out = generate_html_report(r)
+    assert "BREAKING" in out
+
+
+def test_html_contains_library_and_versions() -> None:
+    r = _result()
+    out = generate_html_report(r, lib_name="libdnnl", old_version="2025.0", new_version="2025.3")
+    assert "libdnnl" in out
+    assert "2025.0" in out
+    assert "2025.3" in out
+
+
+def test_html_title_contains_versions() -> None:
+    r = _result()
+    out = generate_html_report(r, lib_name="libfoo", old_version="1.0", new_version="2.0")
+    assert "<title>" in out
+    assert "1.0" in out
+    assert "2.0" in out
+
+
+# ---------------------------------------------------------------------------
+# BC% calculation
+# ---------------------------------------------------------------------------
+
+def test_bc_100_when_no_breaking() -> None:
+    r = _result(verdict="COMPATIBLE", changes=[_ch("func_added")])
+    out = generate_html_report(r)
+    assert "100.0%" in out
+
+
+def test_bc_0_when_all_breaking_no_symbol_count() -> None:
+    r = _result(verdict="BREAKING", changes=[_ch("func_removed"), _ch("func_removed", "bar")])
+    out = generate_html_report(r)
+    assert "0.0%" in out
+
+
+def test_bc_uses_old_symbol_count_when_provided() -> None:
+    """BC% = (100 - 1) / 100 * 100 = 99.0%."""
+    r = _result(verdict="BREAKING", changes=[_ch("func_removed")])
+    out = generate_html_report(r, old_symbol_count=100)
+    assert "99.0%" in out
+
+
+def test_bc_no_change_is_100() -> None:
+    r = _result(verdict="NO_CHANGE")
+    out = generate_html_report(r)
+    assert "100.0%" in out
+
+
+# ---------------------------------------------------------------------------
+# Sectioned layout
+# ---------------------------------------------------------------------------
+
+def test_removed_section_present_when_removals_exist() -> None:
+    r = _result(verdict="BREAKING", changes=[_ch("func_removed", "myfunc")])
+    out = generate_html_report(r)
+    assert "id='removed'" in out
+    assert "Removed Symbols" in out
+
+
+def test_added_section_present_when_additions_exist() -> None:
+    r = _result(verdict="COMPATIBLE", changes=[_ch("func_added", "newfunc")])
+    out = generate_html_report(r)
+    assert "id='added'" in out
+    assert "Added Symbols" in out
+
+
+def test_changed_section_present_for_changed_kinds() -> None:
+    r = _result(verdict="BREAKING", changes=[_ch("func_return_changed", "myfunc")])
+    out = generate_html_report(r)
+    assert "id='changed'" in out
+    assert "Changed Symbols" in out
+
+
+def test_no_empty_sections_when_no_changes() -> None:
+    r = _result(verdict="NO_CHANGE")
+    out = generate_html_report(r)
+    # None of the section anchors should appear when there are no changes
+    assert "id='removed'" not in out
+    assert "id='added'" not in out
+    assert "id='changed'" not in out
+
+
+def test_no_change_fallback_message() -> None:
+    r = _result(verdict="NO_CHANGE")
+    out = generate_html_report(r)
+    assert "No ABI changes detected" in out
+
+
+# ---------------------------------------------------------------------------
+# Summary table
+# ---------------------------------------------------------------------------
+
+def test_summary_table_present() -> None:
+    r = _result(changes=[_ch("func_removed"), _ch("func_added")])
+    out = generate_html_report(r)
+    assert "Change Summary" in out
+
+
+def test_summary_table_categories() -> None:
+    r = _result(changes=[
+        _ch("func_removed"),
+        _ch("type_size_changed"),
+        _ch("enum_member_removed"),
+        _ch("soname_changed"),
+    ])
+    out = generate_html_report(r)
+    assert "Functions" in out
+    assert "Types" in out
+    assert "Enums" in out
+    assert "ELF" in out
+
+
+# ---------------------------------------------------------------------------
+# Navigation bar
+# ---------------------------------------------------------------------------
+
+def test_nav_links_to_sections() -> None:
+    r = _result(changes=[_ch("func_removed"), _ch("func_added")])
+    out = generate_html_report(r)
+    assert "href='#removed'" in out
+    assert "href='#added'" in out
+
+
+def test_nav_absent_when_no_changes() -> None:
+    r = _result(verdict="NO_CHANGE")
+    out = generate_html_report(r)
+    assert "href='#removed'" not in out
+    assert "href='#added'" not in out
+
+
+# ---------------------------------------------------------------------------
+# Suppressed changes
+# ---------------------------------------------------------------------------
+
+def test_suppressed_section_shown() -> None:
+    sup = [_ch("func_removed", "hidden_func")]
+    r = _result(suppressed=sup, suppressed_count=1)
+    out = generate_html_report(r)
+    assert "id='suppressed'" in out
+    assert "Suppressed" in out
+
+
+def test_suppressed_count_only_shown_when_no_details() -> None:
+    r = _result(suppressed_count=3)
+    out = generate_html_report(r)
+    assert "Suppressed" in out
+
+
+# ---------------------------------------------------------------------------
+# Demangled symbol display
+# ---------------------------------------------------------------------------
+
+def test_demangled_symbol_shown_as_text() -> None:
+    ch = _ch("func_removed", symbol="_ZN3FooC1Ev",
+             demangled="Foo::Foo()")
+    r = _result(verdict="BREAKING", changes=[ch])
+    out = generate_html_report(r)
+    assert "Foo::Foo()" in out
+
+
+def test_mangled_symbol_in_tooltip() -> None:
+    ch = _ch("func_removed", symbol="_ZN3FooC1Ev",
+             demangled="Foo::Foo()")
+    r = _result(verdict="BREAKING", changes=[ch])
+    out = generate_html_report(r)
+    assert "_ZN3FooC1Ev" in out  # mangled in abbr title
+
+
+# ---------------------------------------------------------------------------
+# XSS safety
+# ---------------------------------------------------------------------------
+
+def test_xss_escape_lib_name() -> None:
+    r = _result()
+    out = generate_html_report(r, lib_name="<script>alert(1)</script>")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_xss_escape_symbol_name() -> None:
+    ch = _ch("func_removed", symbol="<evil>")
+    r = _result(verdict="BREAKING", changes=[ch])
+    out = generate_html_report(r)
+    assert "<evil>" not in out
+
+
+def test_xss_escape_description() -> None:
+    ch = _ch("func_removed", desc='<img src=x onerror="alert(1)">')
+    r = _result(verdict="BREAKING", changes=[ch])
+    out = generate_html_report(r)
+    assert "<img" not in out
+
+
+# ---------------------------------------------------------------------------
+# write_html_report
+# ---------------------------------------------------------------------------
+
+def test_write_creates_dirs_and_file(tmp_path: Path) -> None:
+    r = _result()
+    out = tmp_path / "deep" / "nested" / "report.html"
+    write_html_report(r, out)
+    assert out.exists()
+    assert out.stat().st_size > 500
+
+
+def test_write_passes_old_symbol_count(tmp_path: Path) -> None:
+    r = _result(verdict="BREAKING", changes=[_ch("func_removed")])
+    out = tmp_path / "report.html"
+    write_html_report(r, out, lib_name="libfoo", old_version="1.0", new_version="2.0",
+                      old_symbol_count=50)
+    content = out.read_text()
+    assert "98.0%" in content  # (50-1)/50 * 100
+
+
+# ---------------------------------------------------------------------------
+# Verdict colours
+# ---------------------------------------------------------------------------
+
+def test_breaking_verdict_red_color() -> None:
+    r = _result(verdict="BREAKING")
+    out = generate_html_report(r)
+    assert "#b71c1c" in out  # BREAKING foreground
+
+
+def test_compatible_verdict_green_color() -> None:
+    r = _result(verdict="COMPATIBLE")
+    out = generate_html_report(r)
+    assert "#1b5e20" in out  # COMPATIBLE foreground
+
+
+def test_no_change_verdict_blue_color() -> None:
+    r = _result(verdict="NO_CHANGE")
+    out = generate_html_report(r)
+    assert "#0d47a1" in out  # NO_CHANGE foreground


### PR DESCRIPTION
## Sprint 9: ABICC-compatible HTML output

### What changed

**`abicheck/html_report.py`** — full rewrite to mirror abi-compliance-checker (ABICC) report structure:
- **Sectioned layout**: Removed / Changed / Added symbols as separate sections with anchor IDs
- **Navigation bar**: anchor links to each section, styled by severity (red/orange/green)
- **Summary table**: breakdown by category (Functions, Variables, Types, Enums, ELF/DWARF) with Removed/Changed/Added columns
- **Accurate BC%**: computed from `old_symbol_count` (total exported symbols in old library) when provided; falls back to change-ratio approximation. Correctly handles `old_symbol_count=0` and `breaking > old_symbol_count` (clamped to 0%)
- **Demangled symbols**: display text = demangled name, mangled name in `<abbr>` tooltip
- **Suppressed changes**: rendered as section when `suppressed_changes` is populated
- **Drift guard**: runtime `assert _CHANGED_BREAKING_KINDS <= _BREAKING_KINDS` at module import

**`abicheck/cli.py`**:
- `compare` command: added `html` to `--format` choices; auto-computes `old_symbol_count` from snapshot
- `compat` command: passes `old_symbol_count` to `write_html_report` for accurate BC%

**Bug fixes from internal review**:
- `enum_member_removed` added to `_REMOVED_KINDS` (was falling to changed bucket, not counted as breaking)
- `_BREAKING_KINDS` collapsed to `_REMOVED_KINDS | _CHANGED_BREAKING_KINDS` (removed redundant trailing frozenset)
- BC% guard: `is not None` instead of truthiness so `old_symbol_count=0` correctly falls back to legacy
- Type annotation fix: `_CATEGORY_PREFIXES` corrected to `list[tuple[str, tuple[str, ...]]]`

### Tests
37 new tests in `tests/test_sprint9_html.py`:
- HTML structure, verdict/color, versions in title
- BC% with/without symbol count, edge cases (0, clamp, 100%)
- Sectioned layout anchors (removed/changed/added/suppressed)
- Summary table categories, nav bar
- Demangled tooltip, XSS (lib_name, symbol, description, old_value, new_value)
- `enum_member_removed` bucket + breaking classification
- `_BREAKING_KINDS` subset drift guards

**295 total tests pass, 1 skipped.**

### Usage
```bash
# compare now supports HTML
abicheck compare old.json new.json --format html -o report.html

# compat (ABICC drop-in) — HTML default, now with accurate BC%
abicheck compat -lib libdnnl -old old.xml -new new.xml -report-path report.html
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ABICC-style HTML reports for compare/compat flows with verdict banner, BC% and optional symbol-count support.

* **Bug Fixes**
  * Improved detection and reporting for ELF dynamic changes, needed libraries, symbol versioning/binding/size changes (including COMMON symbol risk), and more granular type-change reporting.

* **Refactor**
  * Internal parsing and diff logic modularized for clearer, more deterministic change detection.

* **Tests**
  * Added comprehensive tests for HTML report rendering, BC% calculations, and related behaviors.

* **Documentation**
  * Added Sprint 9 (ABICC-compatible HTML) note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->