### PR TITLE
feat(sprint10): FUNC_VISIBILITY_CHANGED detector + TYPE_FIELD_ADDED breaking coverage

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -53,6 +53,7 @@ class ChangeKind(str, Enum):
     # Method qualifier changes
     FUNC_STATIC_CHANGED = "func_static_changed"
     FUNC_CV_CHANGED = "func_cv_changed"  # const/volatile on this
+    FUNC_VISIBILITY_CHANGED = "func_visibility_changed"  # default→hidden: symbol gone from ABI
 
     # Virtual changes
     FUNC_PURE_VIRTUAL_ADDED = "func_pure_virtual_added"
@@ -140,6 +141,7 @@ _BREAKING_KINDS = {
     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
     ChangeKind.FUNC_STATIC_CHANGED,
     ChangeKind.FUNC_CV_CHANGED,
+    ChangeKind.FUNC_VISIBILITY_CHANGED,
     ChangeKind.FUNC_PURE_VIRTUAL_ADDED,
     ChangeKind.FUNC_VIRTUAL_BECAME_PURE,
     ChangeKind.UNION_FIELD_ADDED,
@@ -235,14 +237,29 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
     new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
 
+    # Build a lookup of ALL functions in new snapshot (including hidden)
+    # to distinguish visibility change from outright removal.
+    new_all = new.function_map
+
     for mangled, f_old in old_map.items():
         if mangled not in new_map:
-            changes.append(Change(
-                kind=ChangeKind.FUNC_REMOVED,
-                symbol=mangled,
-                description=f"Public function removed: {f_old.name}",
-                old_value=f_old.name,
-            ))
+            # Check if it moved to hidden visibility (not truly removed)
+            f_hidden = new_all.get(mangled)
+            if f_hidden is not None and f_hidden.visibility == Visibility.HIDDEN:
+                changes.append(Change(
+                    kind=ChangeKind.FUNC_VISIBILITY_CHANGED,
+                    symbol=mangled,
+                    description=f"Function visibility changed to hidden: {f_old.name}",
+                    old_value="public",
+                    new_value="hidden",
+                ))
+            else:
+                changes.append(Change(
+                    kind=ChangeKind.FUNC_REMOVED,
+                    symbol=mangled,
+                    description=f"Public function removed: {f_old.name}",
+                    old_value=f_old.name,
+                ))
             continue
         f_new = new_map[mangled]
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -237,8 +237,12 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
     new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
 
-    # Build a lookup of ALL functions in new snapshot (including hidden)
-    # to distinguish visibility change from outright removal.
+    # Build a lookup of ALL functions in new snapshot (including hidden).
+    # When dump() uses castxml headers, _CastxmlParser._visibility() assigns
+    # Visibility.HIDDEN to functions present in XML but absent from .dynsym —
+    # so new_all correctly contains hidden functions in the castxml path.
+    # ELF_ONLY→HIDDEN is also treated as FUNC_VISIBILITY_CHANGED: callers
+    # that resolved the symbol dynamically will still break.
     new_all = new.function_map
 
     for mangled, f_old in old_map.items():
@@ -250,8 +254,8 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     kind=ChangeKind.FUNC_VISIBILITY_CHANGED,
                     symbol=mangled,
                     description=f"Function visibility changed to hidden: {f_old.name}",
-                    old_value="public",
-                    new_value="hidden",
+                    old_value=f_old.visibility.value,
+                    new_value=f_hidden.visibility.value,
                 ))
             else:
                 changes.append(Change(

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -261,7 +261,7 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 changes.append(Change(
                     kind=ChangeKind.FUNC_REMOVED,
                     symbol=mangled,
-                    description=f"Public function removed: {f_old.name}",
+                    description=f"{f_old.visibility.value.capitalize()} function removed: {f_old.name}",
                     old_value=f_old.name,
                 ))
             continue

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -69,6 +69,7 @@ _CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
     "field_bitfield_changed",
     "calling_convention_changed", "struct_packing_changed",
     "type_visibility_changed",
+    "func_visibility_changed",  # public→hidden: symbol removed from ABI
     # qualifier_removed: not in canonical _BREAKING_KINDS
     "typedef_base_changed",
     "union_field_type_changed",

--- a/tests/test_integration_phase2_negative.py
+++ b/tests/test_integration_phase2_negative.py
@@ -78,7 +78,6 @@ def test_compare_detects_missing_exported_symbol_end_to_end(tmp_path: Path) -> N
 
     assert cmp_res.returncode == 4
     # api_fn present in header but absent from new .dynsym → FUNC_VISIBILITY_CHANGED
-    assert cmp_res.returncode == 4
     assert "BREAKING" in cmp_res.stdout
     assert "api_fn" in cmp_res.stdout
 

--- a/tests/test_integration_phase2_negative.py
+++ b/tests/test_integration_phase2_negative.py
@@ -77,7 +77,10 @@ def test_compare_detects_missing_exported_symbol_end_to_end(tmp_path: Path) -> N
     cmp_res = _run_abicheck(["compare", str(old_snap), str(new_snap), "--format", "markdown"])
 
     assert cmp_res.returncode == 4
-    assert "func_removed" in cmp_res.stdout
+    # api_fn present in header but absent from new .dynsym → FUNC_VISIBILITY_CHANGED
+    assert cmp_res.returncode == 4
+    assert "BREAKING" in cmp_res.stdout
+    assert "api_fn" in cmp_res.stdout
 
 
 def test_dump_fails_on_broken_header(tmp_path: Path) -> None:

--- a/tests/test_sprint10_abicc_parity.py
+++ b/tests/test_sprint10_abicc_parity.py
@@ -4,6 +4,8 @@ breaking variant coverage.
 Tests for two detector improvements:
 1. FUNC_VISIBILITY_CHANGED: function moved from default to hidden visibility
    (binary ABI break — symbol disappears from dynamic export table).
+   Detection works with castxml headers: _CastxmlParser._visibility() assigns
+   Visibility.HIDDEN to functions present in XML but absent from .dynsym.
 2. TYPE_FIELD_ADDED breaking path: field added to polymorphic class or class
    with virtual bases is BREAKING (not compatible).
 
@@ -81,14 +83,16 @@ class TestFuncVisibilityChanged:
             "FUNC_REMOVED must not be emitted when FUNC_VISIBILITY_CHANGED covers it"
         )
 
-    def test_visibility_change_old_new_values(self) -> None:
+    def test_visibility_change_old_new_values_and_description(self) -> None:
+        """old_value/new_value reflect actual visibility; description names the function."""
         old_f = _func("render", "_Z6renderv", visibility=Visibility.PUBLIC)
         new_f = _func("render", "_Z6renderv", visibility=Visibility.HIDDEN)
         r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[new_f]))
         change = next(c for c in r.changes if c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED)
-        assert change.old_value == "public"
-        assert change.new_value == "hidden"
+        assert change.old_value == Visibility.PUBLIC.value
+        assert change.new_value == Visibility.HIDDEN.value
         assert "_Z6renderv" in change.symbol
+        assert "render" in change.description
 
     def test_func_truly_removed_still_reported(self) -> None:
         """Function absent from new snapshot entirely → FUNC_REMOVED (not visibility change)."""
@@ -98,19 +102,24 @@ class TestFuncVisibilityChanged:
         assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
 
     def test_hidden_to_public_is_compatible(self) -> None:
-        """Hidden function becoming public is compatible (new symbol added to ABI)."""
+        """Hidden function becoming public: COMPATIBLE (appears as FUNC_ADDED).
+
+        Hidden functions are not tracked in old_map (built from PUBLIC|ELF_ONLY
+        only), so the function is invisible to the old-side diff. In new_map it
+        appears as a new PUBLIC export → FUNC_ADDED. This is intentional: there
+        was no prior public ABI contract to break.
+        """
         old_f = _func("impl", "_Z4implv", visibility=Visibility.HIDDEN)
         new_f = _func("impl", "_Z4implv", visibility=Visibility.PUBLIC)
         r = compare(_snap(functions=[old_f]), _snap("1.1", functions=[new_f]))
-        # Hidden functions are not tracked in old_map, so this appears as FUNC_ADDED
         assert r.verdict == Verdict.COMPATIBLE
         assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
 
     def test_multiple_functions_only_changed_one_reported(self) -> None:
         """Only the visibility-changed function emits FUNC_VISIBILITY_CHANGED."""
-        stable = _func("stable", "_Z6stablev", visibility=Visibility.PUBLIC)
-        old_api = _func("api", "_Z3apiv", visibility=Visibility.PUBLIC)
-        new_api = _func("api", "_Z3apiv", visibility=Visibility.HIDDEN)
+        stable  = _func("stable", "_Z6stablev", visibility=Visibility.PUBLIC)
+        old_api = _func("api",    "_Z3apiv",    visibility=Visibility.PUBLIC)
+        new_api = _func("api",    "_Z3apiv",    visibility=Visibility.HIDDEN)
         r = compare(
             _snap(functions=[stable, old_api]),
             _snap("2.0", functions=[stable, new_api]),
@@ -120,12 +129,26 @@ class TestFuncVisibilityChanged:
         assert len(vis_changes) == 1
         assert "_Z3apiv" in vis_changes[0].symbol
 
-    def test_elf_only_symbol_removed_not_visibility_change(self) -> None:
-        """ELF_ONLY symbol removed from new snapshot → FUNC_REMOVED, not visibility change."""
+    def test_elf_only_symbol_absent_is_func_removed(self) -> None:
+        """ELF_ONLY symbol absent from new snapshot entirely → FUNC_REMOVED."""
         old_f = _func("sym", "_Z3symv", visibility=Visibility.ELF_ONLY)
         r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[]))
         assert any(c.kind == ChangeKind.FUNC_REMOVED for c in r.changes)
         assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
+
+    def test_elf_only_to_hidden_is_visibility_change(self) -> None:
+        """ELF_ONLY → HIDDEN: callers that resolved the symbol dynamically break.
+
+        old_value reflects actual prior visibility (elf_only), not "public".
+        ELF_ONLY functions are tracked in old_map alongside PUBLIC functions.
+        """
+        old_f = _func("sym", "_Z3symv", visibility=Visibility.ELF_ONLY)
+        new_f = _func("sym", "_Z3symv", visibility=Visibility.HIDDEN)
+        r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[new_f]))
+        assert r.verdict == Verdict.BREAKING
+        change = next(c for c in r.changes if c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED)
+        assert change.old_value == Visibility.ELF_ONLY.value
+        assert change.new_value == Visibility.HIDDEN.value
 
 
 # ── TYPE_FIELD_ADDED breaking variant ────────────────────────────────────────
@@ -182,7 +205,7 @@ class TestTypeFieldAddedBreaking:
         assert not any(c.kind == ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE for c in r.changes)
 
     def test_field_added_to_plain_struct_is_compatible(self) -> None:
-        """Standard-layout struct: field addition is compatible."""
+        """Standard-layout non-polymorphic struct: field addition is compatible."""
         old_t = RecordType(
             name="Point",
             kind="struct",

--- a/tests/test_sprint10_abicc_parity.py
+++ b/tests/test_sprint10_abicc_parity.py
@@ -220,6 +220,7 @@ class TestTypeFieldAddedBreaking:
             ],
         )
         r = compare(_snap(types=[old_t]), _snap("1.1", types=[new_t]))
+        assert r.verdict == Verdict.COMPATIBLE
         assert any(c.kind == ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE for c in r.changes)
         assert not any(c.kind == ChangeKind.TYPE_FIELD_ADDED for c in r.changes)
 

--- a/tests/test_sprint10_abicc_parity.py
+++ b/tests/test_sprint10_abicc_parity.py
@@ -1,0 +1,239 @@
+"""Sprint 10: ABICC parity — func_visibility_changed + type_field_added
+breaking variant coverage.
+
+Tests for two detector improvements:
+1. FUNC_VISIBILITY_CHANGED: function moved from default to hidden visibility
+   (binary ABI break — symbol disappears from dynamic export table).
+2. TYPE_FIELD_ADDED breaking path: field added to polymorphic class or class
+   with virtual bases is BREAKING (not compatible).
+
+All fixtures are original C++ ABI scenarios authored for this project.
+"""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _snap(
+    version: str = "1.0",
+    *,
+    functions: list[Function] | None = None,
+    variables: list[Variable] | None = None,
+    types: list[RecordType] | None = None,
+) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version=version,
+        functions=functions or [],
+        variables=variables or [],
+        types=types or [],
+    )
+
+
+def _func(
+    name: str,
+    mangled: str,
+    ret: str = "void",
+    visibility: Visibility = Visibility.PUBLIC,
+) -> Function:
+    return Function(
+        name=name,
+        mangled=mangled,
+        return_type=ret,
+        visibility=visibility,
+    )
+
+
+# ── FUNC_VISIBILITY_CHANGED ───────────────────────────────────────────────────
+
+class TestFuncVisibilityChanged:
+    """Public function becomes hidden: binary ABI break.
+
+    Callers that linked against the public symbol will get an undefined
+    reference at load time — strictly more severe than FUNC_REMOVED from
+    the dynamic linker's perspective.
+    """
+
+    def test_public_to_hidden_is_breaking(self) -> None:
+        old_f = _func("api", "_Z3apiv", visibility=Visibility.PUBLIC)
+        new_f = _func("api", "_Z3apiv", visibility=Visibility.HIDDEN)
+        r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[new_f]))
+        assert r.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes), (
+            "Expected FUNC_VISIBILITY_CHANGED"
+        )
+
+    def test_visibility_change_not_reported_as_func_removed(self) -> None:
+        """FUNC_VISIBILITY_CHANGED must NOT also emit FUNC_REMOVED."""
+        old_f = _func("process", "_Z7processv", visibility=Visibility.PUBLIC)
+        new_f = _func("process", "_Z7processv", visibility=Visibility.HIDDEN)
+        r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[new_f]))
+        assert not any(c.kind == ChangeKind.FUNC_REMOVED for c in r.changes), (
+            "FUNC_REMOVED must not be emitted when FUNC_VISIBILITY_CHANGED covers it"
+        )
+
+    def test_visibility_change_old_new_values(self) -> None:
+        old_f = _func("render", "_Z6renderv", visibility=Visibility.PUBLIC)
+        new_f = _func("render", "_Z6renderv", visibility=Visibility.HIDDEN)
+        r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[new_f]))
+        change = next(c for c in r.changes if c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED)
+        assert change.old_value == "public"
+        assert change.new_value == "hidden"
+        assert "_Z6renderv" in change.symbol
+
+    def test_func_truly_removed_still_reported(self) -> None:
+        """Function absent from new snapshot entirely → FUNC_REMOVED (not visibility change)."""
+        old_f = _func("gone", "_Z4gonev", visibility=Visibility.PUBLIC)
+        r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[]))
+        assert any(c.kind == ChangeKind.FUNC_REMOVED for c in r.changes)
+        assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
+
+    def test_hidden_to_public_is_compatible(self) -> None:
+        """Hidden function becoming public is compatible (new symbol added to ABI)."""
+        old_f = _func("impl", "_Z4implv", visibility=Visibility.HIDDEN)
+        new_f = _func("impl", "_Z4implv", visibility=Visibility.PUBLIC)
+        r = compare(_snap(functions=[old_f]), _snap("1.1", functions=[new_f]))
+        # Hidden functions are not tracked in old_map, so this appears as FUNC_ADDED
+        assert r.verdict == Verdict.COMPATIBLE
+        assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
+
+    def test_multiple_functions_only_changed_one_reported(self) -> None:
+        """Only the visibility-changed function emits FUNC_VISIBILITY_CHANGED."""
+        stable = _func("stable", "_Z6stablev", visibility=Visibility.PUBLIC)
+        old_api = _func("api", "_Z3apiv", visibility=Visibility.PUBLIC)
+        new_api = _func("api", "_Z3apiv", visibility=Visibility.HIDDEN)
+        r = compare(
+            _snap(functions=[stable, old_api]),
+            _snap("2.0", functions=[stable, new_api]),
+        )
+        assert r.verdict == Verdict.BREAKING
+        vis_changes = [c for c in r.changes if c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED]
+        assert len(vis_changes) == 1
+        assert "_Z3apiv" in vis_changes[0].symbol
+
+    def test_elf_only_symbol_removed_not_visibility_change(self) -> None:
+        """ELF_ONLY symbol removed from new snapshot → FUNC_REMOVED, not visibility change."""
+        old_f = _func("sym", "_Z3symv", visibility=Visibility.ELF_ONLY)
+        r = compare(_snap(functions=[old_f]), _snap("2.0", functions=[]))
+        assert any(c.kind == ChangeKind.FUNC_REMOVED for c in r.changes)
+        assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
+
+
+# ── TYPE_FIELD_ADDED breaking variant ────────────────────────────────────────
+
+class TestTypeFieldAddedBreaking:
+    """Field addition is BREAKING for polymorphic types.
+
+    Standard-layout non-polymorphic structs get TYPE_FIELD_ADDED_COMPATIBLE.
+    Classes with vtable or virtual_bases get TYPE_FIELD_ADDED (BREAKING).
+    """
+
+    def test_field_added_to_vtable_class_is_breaking(self) -> None:
+        old_t = RecordType(
+            name="Widget",
+            kind="class",
+            size_bits=64,
+            vtable=["_ZN6Widget6renderEv"],
+            fields=[TypeField("id", "int", offset_bits=0)],
+        )
+        new_t = RecordType(
+            name="Widget",
+            kind="class",
+            size_bits=96,
+            vtable=["_ZN6Widget6renderEv"],
+            fields=[
+                TypeField("id",    "int", offset_bits=0),
+                TypeField("flags", "int", offset_bits=32),
+            ],
+        )
+        r = compare(_snap(types=[old_t]), _snap("2.0", types=[new_t]))
+        assert r.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPE_FIELD_ADDED for c in r.changes)
+        assert not any(c.kind == ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE for c in r.changes)
+
+    def test_field_added_to_virtual_base_class_is_breaking(self) -> None:
+        old_t = RecordType(
+            name="Derived",
+            kind="class",
+            virtual_bases=["Base"],
+            fields=[TypeField("x", "int", offset_bits=0)],
+        )
+        new_t = RecordType(
+            name="Derived",
+            kind="class",
+            virtual_bases=["Base"],
+            fields=[
+                TypeField("x", "int", offset_bits=0),
+                TypeField("y", "int", offset_bits=32),
+            ],
+        )
+        r = compare(_snap(types=[old_t]), _snap("2.0", types=[new_t]))
+        assert r.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPE_FIELD_ADDED for c in r.changes)
+        assert not any(c.kind == ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE for c in r.changes)
+
+    def test_field_added_to_plain_struct_is_compatible(self) -> None:
+        """Standard-layout struct: field addition is compatible."""
+        old_t = RecordType(
+            name="Point",
+            kind="struct",
+            fields=[TypeField("x", "float", offset_bits=0)],
+        )
+        new_t = RecordType(
+            name="Point",
+            kind="struct",
+            fields=[
+                TypeField("x", "float", offset_bits=0),
+                TypeField("y", "float", offset_bits=32),
+            ],
+        )
+        r = compare(_snap(types=[old_t]), _snap("1.1", types=[new_t]))
+        assert any(c.kind == ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE for c in r.changes)
+        assert not any(c.kind == ChangeKind.TYPE_FIELD_ADDED for c in r.changes)
+
+    def test_field_added_to_pure_virtual_class_is_breaking(self) -> None:
+        """Abstract class (pure virtual in vtable) — field addition is BREAKING."""
+        old_t = RecordType(
+            name="IRenderer",
+            kind="class",
+            vtable=["_ZN9IRenderer6renderEv", "__cxa_pure_virtual"],
+            fields=[],
+        )
+        new_t = RecordType(
+            name="IRenderer",
+            kind="class",
+            vtable=["_ZN9IRenderer6renderEv", "__cxa_pure_virtual"],
+            fields=[TypeField("_reserved", "int", offset_bits=0)],
+        )
+        r = compare(_snap(types=[old_t]), _snap("2.0", types=[new_t]))
+        assert r.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPE_FIELD_ADDED for c in r.changes)
+
+    def test_field_added_breaking_symbol_matches(self) -> None:
+        old_t = RecordType(
+            name="EventHandler",
+            kind="class",
+            vtable=["_ZN12EventHandler6handleEv"],
+            fields=[TypeField("id", "int", offset_bits=0)],
+        )
+        new_t = RecordType(
+            name="EventHandler",
+            kind="class",
+            vtable=["_ZN12EventHandler6handleEv"],
+            fields=[
+                TypeField("id",   "int", offset_bits=0),
+                TypeField("data", "int", offset_bits=32),
+            ],
+        )
+        r = compare(_snap(types=[old_t]), _snap("2.0", types=[new_t]))
+        change = next(c for c in r.changes if c.kind == ChangeKind.TYPE_FIELD_ADDED)
+        assert change.symbol == "EventHandler"


### PR DESCRIPTION
## Sprint 10: ABICC parity

### New: `FUNC_VISIBILITY_CHANGED` ChangeKind

When a public function moves to `__attribute__((visibility("hidden")))`, callers that linked against it get an undefined reference at load time — binary ABI break stricter than removal.

**Detection logic in `_diff_functions`:**
- Build `new_all` (full function map incl. hidden) alongside `new_map` (public only)
- When symbol absent from `new_map`: check `new_all` — if found as HIDDEN → `FUNC_VISIBILITY_CHANGED`; otherwise → `FUNC_REMOVED`
- Added to `_BREAKING_KINDS`

### `TYPE_FIELD_ADDED` breaking variant — additional test coverage

5 tests documenting the polymorphic/non-polymorphic split:
- vtable class → BREAKING
- virtual_bases class → BREAKING
- plain struct → COMPATIBLE (`TYPE_FIELD_ADDED_COMPATIBLE`)
- abstract class (pure virtual in vtable) → BREAKING
- symbol name match

### Tests: `tests/test_sprint10_abicc_parity.py` (12 tests, all pass)

```
12 passed in 0.16s
296 total unit tests pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects when a function’s visibility changes (e.g., public→hidden) and reports it as a distinct breaking change; summaries and reports include old/new visibility and symbol details.

* **Tests**
  * Added comprehensive tests covering visibility-change detection (multiple scenarios) and type-field addition distinctions (breaking vs compatible).
  * Updated integration expectation to reflect visibility-change reporting in end-to-end output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->