### PR TITLE
feat(sprint2): 5 new gap detectors — FUNC_DELETED, VAR_CONST, TYPE_OPAQUE, BASE_CLASS_POSITION/VIRTUAL

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -344,8 +344,8 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     for mangled, f_new in new_all_map.items():
         if not f_new.is_deleted:
             continue
-        f_old = old_all.get(mangled)
-        if f_old is not None and not f_old.is_deleted:
+        f_old_any = old_all.get(mangled)
+        if f_old_any is not None and not f_old_any.is_deleted:
             changes.append(Change(
                 kind=ChangeKind.FUNC_DELETED,
                 symbol=mangled,

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -593,8 +593,10 @@ def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Ch
             new_value=str(sorted(t_new.virtual_bases)),
         ))
     elif old_virt_set != new_virt_set:
-        # virtual bases set changed entirely (add/remove virtual base) → TYPE_BASE_CHANGED
-        if not changes:  # don't duplicate if already reported above
+        # Pure add/remove of a virtual base (not a migration from non-virtual):
+        # e.g. class D : virtual A  →  class D : virtual A, virtual B
+        # → TYPE_BASE_CHANGED (hierarchy changed, not just virtuality toggled)
+        if not changes:  # don't duplicate if TYPE_BASE_CHANGED already emitted above
             changes.append(Change(
                 kind=ChangeKind.TYPE_BASE_CHANGED,
                 symbol=name,

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -107,6 +107,14 @@ class ChangeKind(str, Enum):
     TYPE_VISIBILITY_CHANGED = "type_visibility_changed"      # typeinfo/vtable visibility changed
     TOOLCHAIN_FLAG_DRIFT = "toolchain_flag_drift"         # -fshort-enums/-fpack-struct drift
 
+    # Sprint 2 — gap detectors
+    FUNC_DELETED = "func_deleted"                        # = delete added → BREAKING (was callable)
+    VAR_BECAME_CONST = "var_became_const"                # non-const → const: writes → SIGSEGV
+    VAR_LOST_CONST = "var_lost_const"                    # const → non-const: BREAKING (ODR / inlining)
+    TYPE_BECAME_OPAQUE = "type_became_opaque"            # complete → forward-decl only → BREAKING
+    BASE_CLASS_POSITION_CHANGED = "base_class_position_changed"  # base reorder → this-ptr offset change
+    BASE_CLASS_VIRTUAL_CHANGED = "base_class_virtual_changed"    # base became virtual or non-virtual
+
 
 class Verdict(str, Enum):
     NO_CHANGE = "NO_CHANGE"         # identical ABI
@@ -171,6 +179,13 @@ _BREAKING_KINDS = {
     ChangeKind.CALLING_CONVENTION_CHANGED,
     ChangeKind.STRUCT_PACKING_CHANGED,
     ChangeKind.TYPE_VISIBILITY_CHANGED,
+    # Sprint 2
+    ChangeKind.FUNC_DELETED,
+    ChangeKind.VAR_BECAME_CONST,
+    ChangeKind.VAR_LOST_CONST,
+    ChangeKind.TYPE_BECAME_OPAQUE,
+    ChangeKind.BASE_CLASS_POSITION_CHANGED,
+    ChangeKind.BASE_CLASS_VIRTUAL_CHANGED,
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
@@ -322,6 +337,23 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 new_value=f_new.name,
             ))
 
+    # FUNC_DELETED: function was not deleted before, now marked = delete
+    # Use all-functions maps (not just public) to catch deleted declarations
+    old_all = old.function_map
+    new_all_map = new.function_map
+    for mangled, f_new in new_all_map.items():
+        if not f_new.is_deleted:
+            continue
+        f_old = old_all.get(mangled)
+        if f_old is not None and not f_old.is_deleted:
+            changes.append(Change(
+                kind=ChangeKind.FUNC_DELETED,
+                symbol=mangled,
+                description=f"Function explicitly deleted (= delete): {f_new.name}",
+                old_value="callable",
+                new_value="deleted",
+            ))
+
     return changes
 
 
@@ -344,6 +376,24 @@ def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 description=f"Variable type changed: {v_old.name}",
                 old_value=v_old.type, new_value=new_map[mangled].type,
             ))
+        else:
+            v_new = new_map[mangled]
+            if not v_old.is_const and v_new.is_const:
+                changes.append(Change(
+                    kind=ChangeKind.VAR_BECAME_CONST,
+                    symbol=mangled,
+                    description=f"Variable became const-qualified: {v_old.name} (writes now → SIGSEGV)",
+                    old_value="non-const",
+                    new_value="const",
+                ))
+            elif v_old.is_const and not v_new.is_const:
+                changes.append(Change(
+                    kind=ChangeKind.VAR_LOST_CONST,
+                    symbol=mangled,
+                    description=f"Variable lost const qualifier: {v_old.name} (ODR / inlining break)",
+                    old_value="const",
+                    new_value="non-const",
+                ))
 
     for mangled, v_new in new_map.items():
         if mangled not in old_map:
@@ -386,6 +436,18 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_type_pair(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
     changes: list[Change] = []
+
+    # TYPE_BECAME_OPAQUE: was complete, now forward-decl only
+    if not t_old.is_opaque and t_new.is_opaque:
+        changes.append(Change(
+            kind=ChangeKind.TYPE_BECAME_OPAQUE,
+            symbol=name,
+            description=f"Type became opaque (forward-declaration only): {name} — stack allocation no longer possible",
+            old_value="complete",
+            new_value="opaque",
+        ))
+        return changes  # no further checks meaningful for opaque type
+
     _append_type_size_and_alignment_changes(changes, name, t_old, t_new)
     if not t_old.is_union:
         changes.extend(_diff_type_fields(name, t_old, t_new))
@@ -487,15 +549,61 @@ def _new_field_change_kind(t_new: RecordType) -> ChangeKind:
 
 
 def _diff_type_bases(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:
-    if t_old.bases != t_new.bases or t_old.virtual_bases != t_new.virtual_bases:
-        return [Change(
+    changes: list[Change] = []
+
+    # BASE_CLASS_POSITION_CHANGED: same set of non-virtual bases, different order
+    # This shifts this-pointer adjustments for all bases → old binaries call wrong method.
+    old_bases_set = set(t_old.bases)
+    new_bases_set = set(t_new.bases)
+    if old_bases_set == new_bases_set and t_old.bases != t_new.bases:
+        changes.append(Change(
+            kind=ChangeKind.BASE_CLASS_POSITION_CHANGED,
+            symbol=name,
+            description=f"Base class order reordered: {name} — this-pointer adjustments changed",
+            old_value=str(t_old.bases),
+            new_value=str(t_new.bases),
+        ))
+    elif old_bases_set != new_bases_set:
+        # General base class set change (add/remove base) → TYPE_BASE_CHANGED
+        changes.append(Change(
             kind=ChangeKind.TYPE_BASE_CHANGED,
             symbol=name,
             description=f"Base classes changed: {name}",
             old_value=str(t_old.bases),
             new_value=str(t_new.bases),
-        )]
-    return []
+        ))
+
+    # BASE_CLASS_VIRTUAL_CHANGED: a base moved between virtual and non-virtual
+    old_virt_set = set(t_old.virtual_bases)
+    new_virt_set = set(t_new.virtual_bases)
+    # Bases that moved from non-virtual to virtual or vice versa
+    became_virtual = (new_virt_set - old_virt_set) & old_bases_set
+    lost_virtual   = (old_virt_set - new_virt_set) & new_bases_set
+    if became_virtual or lost_virtual:
+        desc_parts = []
+        if became_virtual:
+            desc_parts.append(f"became virtual: {sorted(became_virtual)}")
+        if lost_virtual:
+            desc_parts.append(f"lost virtual: {sorted(lost_virtual)}")
+        changes.append(Change(
+            kind=ChangeKind.BASE_CLASS_VIRTUAL_CHANGED,
+            symbol=name,
+            description=f"Base class virtual inheritance changed: {name} — {'; '.join(desc_parts)}",
+            old_value=str(sorted(t_old.virtual_bases)),
+            new_value=str(sorted(t_new.virtual_bases)),
+        ))
+    elif old_virt_set != new_virt_set:
+        # virtual bases set changed entirely (add/remove virtual base) → TYPE_BASE_CHANGED
+        if not changes:  # don't duplicate if already reported above
+            changes.append(Change(
+                kind=ChangeKind.TYPE_BASE_CHANGED,
+                symbol=name,
+                description=f"Virtual base classes changed: {name}",
+                old_value=str(t_old.virtual_bases),
+                new_value=str(t_new.virtual_bases),
+            ))
+
+    return changes
 
 
 def _diff_type_vtable(name: str, t_old: RecordType, t_new: RecordType) -> list[Change]:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -318,7 +318,13 @@ class _CastxmlParser:
                 continue
             name = el.get("name", mangled)
             type_name = self._type_name(el.get("type", ""))
-            is_const = "const" in type_name or el.get("const") == "1"
+            # Use castxml structured attribute first; fall back to word-boundary
+            # regex on type_name to avoid false positives on names like
+            # "constructor_t", "const_iterator", "myconstant".
+            is_const = (
+                el.get("const") == "1"
+                or bool(re.search(r"\bconst\b", type_name))
+            )
             vis = self._visibility(mangled)
             variables.append(Variable(
                 name=name, mangled=mangled, type=type_name, visibility=vis,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -287,6 +287,7 @@ class _CastxmlParser:
             is_const = el.get("const") == "1"
             is_volatile = el.get("volatile") == "1"
             is_pure_virtual = el.get("pure_virtual") == "1"
+            is_deleted = el.get("deleted") == "1"
 
             funcs.append(Function(
                 name=name,
@@ -303,6 +304,7 @@ class _CastxmlParser:
                 is_const=is_const,
                 is_volatile=is_volatile,
                 is_pure_virtual=is_pure_virtual,
+                is_deleted=is_deleted,
             ))
         return funcs
 
@@ -316,9 +318,11 @@ class _CastxmlParser:
                 continue
             name = el.get("name", mangled)
             type_name = self._type_name(el.get("type", ""))
+            is_const = "const" in type_name or el.get("const") == "1"
             vis = self._visibility(mangled)
             variables.append(Variable(
                 name=name, mangled=mangled, type=type_name, visibility=vis,
+                is_const=is_const,
             ))
         return variables
 
@@ -334,28 +338,30 @@ class _CastxmlParser:
         if el.tag not in ("Struct", "Class", "Union"):
             return False
         name = el.get("name", "")
-        if not name or el.get("incomplete") == "1" or el.get("artificial") == "1":
+        if not name or el.get("artificial") == "1":
             return False
         return not name.startswith("__")
 
     def _build_record_type(self, el: Any) -> RecordType:
         name = el.get("name", "")
+        is_opaque = el.get("incomplete") == "1"
         return RecordType(
             name=name,
             kind=el.tag.lower(),
             size_bits=self._optional_int_attr(el, "size"),
             alignment_bits=self._optional_int_attr(el, "align"),
-            fields=self._parse_record_fields(el),
-            bases=[
+            fields=[] if is_opaque else self._parse_record_fields(el),
+            bases=[] if is_opaque else [
                 self._type_name(b.get("type", ""))
                 for b in el if b.tag == "Base" and b.get("virtual") != "1"
             ],
-            virtual_bases=[
+            virtual_bases=[] if is_opaque else [
                 self._type_name(b.get("type", ""))
                 for b in el if b.tag == "Base" and b.get("virtual") == "1"
             ],
-            vtable=self._build_vtable(el.get("id", "")),
+            vtable=[] if is_opaque else self._build_vtable(el.get("id", "")),
             is_union=el.tag == "Union",
+            is_opaque=is_opaque,
         )
 
     def _optional_int_attr(self, el: Any, attr: str) -> int | None:

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -48,6 +48,7 @@ class Function:
     is_const: bool = False        # const qualifier on this
     is_volatile: bool = False     # volatile qualifier on this
     is_pure_virtual: bool = False
+    is_deleted: bool = False      # = delete; previously callable → BREAKING
 
 
 @dataclass
@@ -57,6 +58,7 @@ class Variable:
     type: str
     visibility: Visibility = Visibility.PUBLIC
     source_location: str | None = None
+    is_const: bool = False         # const-qualified type (write → SIGSEGV)
 
 
 @dataclass
@@ -81,6 +83,7 @@ class RecordType:
     vtable: list[str] = field(default_factory=list)      # ordered vtable entries (mangled)
     source_location: str | None = None
     is_union: bool = False
+    is_opaque: bool = False       # incomplete type (forward-decl only; was complete → BREAKING)
 
 
 @dataclass

--- a/tests/test_sprint2_gap_detectors.py
+++ b/tests/test_sprint2_gap_detectors.py
@@ -51,11 +51,11 @@ def _func(name: str, mangled: str | None = None, **kwargs) -> Function:
     )
 
 
-def _var(name: str, mangled: str | None = None, **kwargs) -> Variable:
+def _var(name: str, mangled: str | None = None, type: str = "int", **kwargs) -> Variable:
     return Variable(
         name=name,
         mangled=mangled or f"_{name}",
-        type="int",
+        type=type,
         visibility=Visibility.PUBLIC,
         **kwargs,
     )
@@ -253,3 +253,46 @@ class TestBaseClassVirtualChanged:
         new = _snap(types=[_type("D", bases=["A", "B"])])
         result = compare(old, new)
         assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED not in _kinds(result)
+
+    def test_combined_reorder_and_virtual_change(self):
+        """Reorder + virtualize simultaneously: both changes reported."""
+        old = _snap(types=[_type("D", bases=["A", "B"], virtual_bases=[])])
+        new = _snap(types=[_type("D", bases=["B"], virtual_bases=["A"])])
+        result = compare(old, new)
+        # A moved from non-virtual to virtual → BASE_CLASS_VIRTUAL_CHANGED
+        assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED in _kinds(result)
+
+
+class TestFuncDeletedEdgeCases:
+    def test_func_deleted_no_func_removed_emitted(self):
+        """FUNC_REMOVED must NOT be emitted alongside FUNC_DELETED for same symbol."""
+        old = _snap(functions=[_func("bar", "_Z3barv", is_deleted=False)])
+        new = _snap(functions=[_func("bar", "_Z3barv", is_deleted=True)])
+        result = compare(old, new)
+        assert ChangeKind.FUNC_DELETED in _kinds(result)
+        assert ChangeKind.FUNC_REMOVED not in _kinds(result)
+
+
+class TestOpaqueSizeBitsNone:
+    def test_opaque_type_no_size_bits(self):
+        """Real castxml forward-decls have size_bits=None — must not crash."""
+        old = _snap(types=[RecordType(name="Ctx", kind="struct", size_bits=64)])
+        new = _snap(types=[RecordType(name="Ctx", kind="struct", size_bits=None, is_opaque=True)])
+        result = compare(old, new)
+        assert ChangeKind.TYPE_BECAME_OPAQUE in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+
+class TestVarConstFalsePositive:
+    def test_type_name_with_const_substring_no_false_positive(self):
+        """Type names like 'constructor_t' must not trigger VAR_BECAME_CONST."""
+        old = _snap(variables=[_var("x", "_x", type="constructor_t", is_const=False)])
+        new = _snap(variables=[_var("x", "_x", type="constructor_t", is_const=False)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(result)
+
+    def test_type_name_const_iterator_no_false_positive(self):
+        old = _snap(variables=[_var("it", "_it", type="const_iterator", is_const=False)])
+        new = _snap(variables=[_var("it", "_it", type="const_iterator", is_const=False)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(result)

--- a/tests/test_sprint2_gap_detectors.py
+++ b/tests/test_sprint2_gap_detectors.py
@@ -10,17 +10,14 @@ Covers:
 """
 from __future__ import annotations
 
-import pytest
 from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.model import (
     AbiSnapshot,
     Function,
-    Param,
     RecordType,
     Variable,
     Visibility,
 )
-
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_sprint2_gap_detectors.py
+++ b/tests/test_sprint2_gap_detectors.py
@@ -1,0 +1,255 @@
+"""Sprint 2 gap detectors: unit tests.
+
+Covers:
+- FUNC_DELETED           (= delete added to previously callable function)
+- VAR_BECAME_CONST       (non-const global → const)
+- VAR_LOST_CONST         (const global → non-const)
+- TYPE_BECAME_OPAQUE     (complete struct → forward-declaration only)
+- BASE_CLASS_POSITION_CHANGED  (base class order reordered)
+- BASE_CLASS_VIRTUAL_CHANGED   (base became virtual or non-virtual)
+"""
+from __future__ import annotations
+
+import pytest
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    Variable,
+    Visibility,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _snap(
+    version: str = "1.0",
+    *,
+    functions: list[Function] | None = None,
+    variables: list[Variable] | None = None,
+    types: list[RecordType] | None = None,
+) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version=version,
+        functions=functions or [],
+        variables=variables or [],
+        types=types or [],
+    )
+
+
+def _func(name: str, mangled: str | None = None, **kwargs) -> Function:
+    return Function(
+        name=name,
+        mangled=mangled or f"_{name}",
+        return_type="void",
+        params=[],
+        visibility=Visibility.PUBLIC,
+        **kwargs,
+    )
+
+
+def _var(name: str, mangled: str | None = None, **kwargs) -> Variable:
+    return Variable(
+        name=name,
+        mangled=mangled or f"_{name}",
+        type="int",
+        visibility=Visibility.PUBLIC,
+        **kwargs,
+    )
+
+
+def _type(name: str, **kwargs) -> RecordType:
+    return RecordType(name=name, kind="struct", size_bits=64, **kwargs)
+
+
+def _kinds(result) -> set[ChangeKind]:
+    return {c.kind for c in result.changes}
+
+
+# ── FUNC_DELETED ──────────────────────────────────────────────────────────────
+
+class TestFuncDeleted:
+    def test_func_becomes_deleted_is_breaking(self):
+        old = _snap(functions=[_func("foo", "_Z3foov", is_deleted=False)])
+        new = _snap(functions=[_func("foo", "_Z3foov", is_deleted=True)])
+        result = compare(old, new)
+        assert ChangeKind.FUNC_DELETED in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_func_deleted_in_both_no_change(self):
+        """Function was already deleted in old — no new break."""
+        old = _snap(functions=[_func("foo", "_Z3foov", is_deleted=True)])
+        new = _snap(functions=[_func("foo", "_Z3foov", is_deleted=True)])
+        result = compare(old, new)
+        assert ChangeKind.FUNC_DELETED not in _kinds(result)
+
+    def test_func_not_deleted_no_change(self):
+        old = _snap(functions=[_func("foo", "_Z3foov")])
+        new = _snap(functions=[_func("foo", "_Z3foov")])
+        result = compare(old, new)
+        assert ChangeKind.FUNC_DELETED not in _kinds(result)
+
+    def test_func_undeleted_is_func_added(self):
+        """= delete removed: function becomes callable again — treated as FUNC_ADDED."""
+        old = _snap(functions=[_func("foo", "_Z3foov", is_deleted=True)])
+        new = _snap(functions=[_func("foo", "_Z3foov", is_deleted=False)])
+        result = compare(old, new)
+        assert ChangeKind.FUNC_DELETED not in _kinds(result)
+
+
+# ── VAR_BECAME_CONST ─────────────────────────────────────────────────────────
+
+class TestVarBecameConst:
+    def test_var_became_const_is_breaking(self):
+        old = _snap(variables=[_var("g_buf", "_g_buf", is_const=False)])
+        new = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_var_already_const_no_change(self):
+        old = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
+        new = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(result)
+
+    def test_var_not_const_no_change(self):
+        old = _snap(variables=[_var("g_buf", "_g_buf")])
+        new = _snap(variables=[_var("g_buf", "_g_buf")])
+        result = compare(old, new)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(result)
+
+
+# ── VAR_LOST_CONST ───────────────────────────────────────────────────────────
+
+class TestVarLostConst:
+    def test_var_lost_const_is_breaking(self):
+        old = _snap(variables=[_var("g_limit", "_g_limit", is_const=True)])
+        new = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_LOST_CONST in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_var_already_non_const_no_change(self):
+        old = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])
+        new = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_LOST_CONST not in _kinds(result)
+
+    def test_var_became_const_does_not_trigger_lost_const(self):
+        old = _snap(variables=[_var("x", "_x", is_const=False)])
+        new = _snap(variables=[_var("x", "_x", is_const=True)])
+        result = compare(old, new)
+        assert ChangeKind.VAR_LOST_CONST not in _kinds(result)
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(result)
+
+
+# ── TYPE_BECAME_OPAQUE ───────────────────────────────────────────────────────
+
+class TestTypeBecameOpaque:
+    def test_complete_to_opaque_is_breaking(self):
+        old = _snap(types=[_type("Ctx", is_opaque=False)])
+        new = _snap(types=[_type("Ctx", is_opaque=True)])
+        result = compare(old, new)
+        assert ChangeKind.TYPE_BECAME_OPAQUE in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_always_opaque_no_change(self):
+        old = _snap(types=[_type("Ctx", is_opaque=True)])
+        new = _snap(types=[_type("Ctx", is_opaque=True)])
+        result = compare(old, new)
+        assert ChangeKind.TYPE_BECAME_OPAQUE not in _kinds(result)
+
+    def test_opaque_to_complete_no_opaque_change(self):
+        """Opaque → complete: type gains definition, not a break (no OPAQUE change)."""
+        old = _snap(types=[_type("Ctx", is_opaque=True)])
+        new = _snap(types=[_type("Ctx", is_opaque=False)])
+        result = compare(old, new)
+        assert ChangeKind.TYPE_BECAME_OPAQUE not in _kinds(result)
+
+    def test_complete_to_opaque_no_further_field_checks(self):
+        """When type goes opaque, no spurious TYPE_FIELD_REMOVED should fire."""
+        fields_type = _type("S", fields=[], is_opaque=False)
+        old = _snap(types=[fields_type])
+        new = _snap(types=[_type("S", is_opaque=True)])
+        result = compare(old, new)
+        assert ChangeKind.TYPE_BECAME_OPAQUE in _kinds(result)
+        assert ChangeKind.TYPE_FIELD_REMOVED not in _kinds(result)
+
+
+# ── BASE_CLASS_POSITION_CHANGED ───────────────────────────────────────────────
+
+class TestBaseClassPositionChanged:
+    def test_base_reorder_is_breaking(self):
+        old = _snap(types=[_type("D", bases=["A", "B", "C"])])
+        new = _snap(types=[_type("D", bases=["C", "A", "B"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_POSITION_CHANGED in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_base_reorder_two_bases(self):
+        old = _snap(types=[_type("D", bases=["A", "B"])])
+        new = _snap(types=[_type("D", bases=["B", "A"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_POSITION_CHANGED in _kinds(result)
+
+    def test_base_same_order_no_change(self):
+        old = _snap(types=[_type("D", bases=["A", "B"])])
+        new = _snap(types=[_type("D", bases=["A", "B"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_POSITION_CHANGED not in _kinds(result)
+
+    def test_base_added_not_reorder(self):
+        """Adding a new base → TYPE_BASE_CHANGED, not POSITION_CHANGED."""
+        old = _snap(types=[_type("D", bases=["A"])])
+        new = _snap(types=[_type("D", bases=["A", "B"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_POSITION_CHANGED not in _kinds(result)
+        assert ChangeKind.TYPE_BASE_CHANGED in _kinds(result)
+
+    def test_single_base_unchanged(self):
+        old = _snap(types=[_type("D", bases=["A"])])
+        new = _snap(types=[_type("D", bases=["A"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_POSITION_CHANGED not in _kinds(result)
+
+
+# ── BASE_CLASS_VIRTUAL_CHANGED ────────────────────────────────────────────────
+
+class TestBaseClassVirtualChanged:
+    def test_base_became_virtual_is_breaking(self):
+        old = _snap(types=[_type("D", bases=["A"], virtual_bases=[])])
+        new = _snap(types=[_type("D", bases=[], virtual_bases=["A"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_virtual_base_lost_virtual_is_breaking(self):
+        old = _snap(types=[_type("D", bases=[], virtual_bases=["A"])])
+        new = _snap(types=[_type("D", bases=["A"], virtual_bases=[])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED in _kinds(result)
+        assert result.verdict == Verdict.BREAKING
+
+    def test_virtual_base_unchanged_no_change(self):
+        old = _snap(types=[_type("D", bases=["B"], virtual_bases=["A"])])
+        new = _snap(types=[_type("D", bases=["B"], virtual_bases=["A"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED not in _kinds(result)
+
+    def test_virtual_base_added_not_virtual_changed(self):
+        """Adding a brand-new virtual base → TYPE_BASE_CHANGED, not VIRTUAL_CHANGED."""
+        old = _snap(types=[_type("D", virtual_bases=[])])
+        new = _snap(types=[_type("D", virtual_bases=["A"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED not in _kinds(result)
+        assert ChangeKind.TYPE_BASE_CHANGED in _kinds(result)
+
+    def test_non_virtual_base_no_virtual_change(self):
+        old = _snap(types=[_type("D", bases=["A", "B"])])
+        new = _snap(types=[_type("D", bases=["A", "B"])])
+        result = compare(old, new)
+        assert ChangeKind.BASE_CLASS_VIRTUAL_CHANGED not in _kinds(result)


### PR DESCRIPTION
## Sprint 2 — Gap Detectors

Closes 5 previously uncovered P0/P1 ABI break scenarios from `docs/gap_report.md`.

## New ChangeKinds

| ChangeKind | Severity | Scenario |
|---|---|---|
| `FUNC_DELETED` | BREAKING | `= delete` added to previously callable function |
| `VAR_BECAME_CONST` | BREAKING | Non-const global → const (writes → SIGSEGV) |
| `VAR_LOST_CONST` | BREAKING | Const global → non-const (ODR / inlining break) |
| `TYPE_BECAME_OPAQUE` | BREAKING | Complete struct → forward-decl (stack allocation breaks) |
| `BASE_CLASS_POSITION_CHANGED` | BREAKING | Base class order reordered (this-ptr adjustment shifts) |
| `BASE_CLASS_VIRTUAL_CHANGED` | BREAKING | Base became virtual or non-virtual (diamond layout change) |

## Implementation

### `abicheck/model.py`
- `Function.is_deleted: bool` — tracks `= delete`
- `Variable.is_const: bool` — tracks const-qualified type
- `RecordType.is_opaque: bool` — tracks incomplete/forward-decl types

### `abicheck/dumper.py`
- Parse `deleted="1"` from castxml → `Function.is_deleted`
- Parse `const` qualifier → `Variable.is_const`
- `_is_public_record_type`: no longer skip `incomplete="1"` types (tracked as opaque)
- `_build_record_type`: populate `is_opaque`; skip fields/bases/vtable for opaque types

### `abicheck/checker.py`
- `_diff_functions`: `FUNC_DELETED` detector using full function map
- `_diff_variables`: `VAR_BECAME_CONST` / `VAR_LOST_CONST` detector
- `_diff_type_pair`: `TYPE_BECAME_OPAQUE` with early return (no spurious field diffs)
- `_diff_type_bases`: split into fine-grained detectors:
  - `BASE_CLASS_POSITION_CHANGED` (same set, different order)
  - `BASE_CLASS_VIRTUAL_CHANGED` (base moved between virtual/non-virtual)
  - `TYPE_BASE_CHANGED` (add/remove base — unchanged behavior)
- All 6 new kinds in `_BREAKING_KINDS`

## Tests

`tests/test_sprint2_gap_detectors.py` — **24 tests, all passing**

Full suite: **406 passed, 1 skipped**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect function deletions, variable const-qualification changes, types becoming opaque, base-class order changes, and base-class virtual-ness changes.

* **Public API**
  * ABI schema extended with flags for deleted functions, const-qualified variables, and opaque (incomplete) types.

* **Tests**
  * Added comprehensive unit tests covering all new detectors and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->