### PR TITLE
Reclassify noexcept, enum/union changes, and ELF metadata as compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,38 +80,83 @@ Practical migration path:
 
 ---
 
+## Change classification: BREAKING vs COMPATIBLE
+
+abicheck classifies every detected change into one of three verdicts:
+
+| Verdict | Meaning | CI gate recommendation |
+|---|---|---|
+| **BREAKING** | Binary ABI incompatibility — existing binaries will malfunction | Fail the build |
+| **COMPATIBLE** | Informational/warning change that does not break binary compatibility on its own | Warn, do not fail |
+| **NO_CHANGE** | Identical ABI | Pass |
+
+### What counts as BREAKING
+
+A change is classified as BREAKING only if it causes **binary-level incompatibility**
+when swapping a shared library between two releases without recompiling consumers:
+
+- Symbol removal/disappearance (loader fails with unresolved symbol)
+- Type layout changes (size, alignment, field offsets — causes memory corruption)
+- Vtable changes (virtual dispatch goes to wrong function)
+- Calling convention changes (args in wrong registers)
+- Function signature changes (return type, parameters, static qualifier, cv-qualifiers)
+- SONAME change (dynamic linker can't find the library)
+
+### What counts as COMPATIBLE (informational/warning)
+
+These changes are detected and reported but do **not** trigger a BREAKING verdict
+because they do not cause binary linkage or layout failures on their own:
+
+| Change | Why it's not a binary ABI break |
+|---|---|
+| `noexcept` added/removed | Itanium ABI mangling unchanged; same symbol resolves. Source-level type concern only. |
+| Enum member added | Existing compiled enum values unchanged. Source-level switch coverage concern. Value shifts caught separately. |
+| Union field added | All union fields start at offset 0; existing fields unaffected. Size increase caught by TYPE_SIZE_CHANGED. |
+| GLOBAL→WEAK binding | Symbol still exported and resolvable by the dynamic linker. |
+| ELF `st_size` changed | Metadata not used by dynamic linker for resolution. Layout breaks caught by TYPE_SIZE_CHANGED. |
+| GNU IFUNC introduced/removed | Transparent to callers via PLT/GOT mechanism. |
+| New version requirement (e.g. GLIBC_2.34) | Deployment portability concern, not the library's own ABI surface. |
+| Typeinfo/vtable visibility change | Niche RTTI cross-DSO concern, not general binary ABI break. |
+| Variable const qualifier added/removed | Symbol still resolves; behavioral concern (SIGSEGV on write / ODR), not linkage. |
+| New/removed DT_NEEDED dependency | Deployment concern, not binary interface break. |
+| RPATH/RUNPATH changed | Search path metadata, not symbol contract. |
+| Toolchain flag drift | Informational — not a proven binary break on its own. |
+| DWARF info missing | Coverage gap warning — comparison was incomplete. |
+
+---
+
 ## ABI/API breakages and tool coverage
 
 Below is a high-level matrix aligned with `examples/case01..case24`.
 
 Legend: ✅ supported, ⚠️ partial/context-dependent, ❌ typically unsupported.
 
-| Case | Breakage type | abicheck | abidiff + headers | ABICC #2 (headers) | ABICC #1 (abi-dumper) |
-|---|---|:---:|:---:|:---:|:---:|
-| case01 | Symbol removed | ✅ | ✅ | ✅ | ✅ |
-| case02 | Param type changed | ✅ | ✅ | ✅ | ✅ |
-| case03 | Compatible symbol addition | ✅ | ✅ | ✅ | ✅ |
-| case04 | No change baseline | ✅ | ✅ | ✅ | ✅ |
-| case05 | SONAME policy break | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case06 | Visibility policy break | ✅ | ✅ | ⚠️ | ⚠️ |
-| case07 | Struct layout break | ✅ | ✅ | ✅ | ✅ |
-| case08 | Enum value changed | ✅ | ⚠️ | ✅ | ✅ |
-| case09 | C++ vtable drift | ✅ | ✅ | ✅ | ✅ |
-| case10 | Return type changed | ✅ | ✅ | ✅ | ✅ |
-| case11 | Global variable type changed | ✅ | ✅ | ✅ | ✅ |
-| case12 | Function removed | ✅ | ✅ | ✅ | ✅ |
-| case13 | Symbol version policy break | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case14 | Class size/layout change | ✅ | ✅ | ✅ | ✅ |
-| case15 | `noexcept` changed | ✅ | ⚠️ | ✅ | ❌ |
-| case16 | inline↔non-inline ABI/ODR risk | ✅ | ⚠️ | ✅ | ❌ |
-| case17 | Template ABI drift | ✅ | ⚠️ | ✅ | ✅ |
-| case18 | Dependency leak via headers | ✅ | ⚠️ | ✅ | ✅ |
-| case19 | Enum member removed | ✅ | ✅ | ✅ | ✅ |
-| case20 | Enum member value changed | ✅ | ⚠️ | ✅ | ✅ |
-| case21 | Method became static | ✅ | ✅ | ✅ | ✅ |
-| case22 | Method const qualifier changed | ✅ | ✅ | ✅ | ✅ |
-| case23 | Pure virtual method added | ✅ | ✅ | ✅ | ✅ |
-| case24 | Union field removed | ✅ | ✅ | ✅ | ✅ |
+| Case | Breakage type | Verdict | abicheck | abidiff + headers | ABICC #2 (headers) | ABICC #1 (abi-dumper) |
+|---|---|---|:---:|:---:|:---:|:---:|
+| case01 | Symbol removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case02 | Param type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case03 | Compatible symbol addition | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
+| case04 | No change baseline | NO_CHANGE | ✅ | ✅ | ✅ | ✅ |
+| case05 | SONAME policy break | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| case06 | Visibility policy break | BREAKING | ✅ | ✅ | ⚠️ | ⚠️ |
+| case07 | Struct layout break | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case08 | Enum value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case09 | C++ vtable drift | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case10 | Return type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case11 | Global variable type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case12 | Function removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case13 | Symbol version policy break | COMPATIBLE | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| case14 | Class size/layout change | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case15 | `noexcept` changed | COMPATIBLE | ✅ | ⚠️ | ✅ | ❌ |
+| case16 | inline↔non-inline ABI/ODR risk | BREAKING | ✅ | ⚠️ | ✅ | ❌ |
+| case17 | Template ABI drift | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case18 | Dependency leak via headers | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case19 | Enum member removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case20 | Enum member value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case21 | Method became static | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case22 | Method const qualifier changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case23 | Pure virtual method added | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case24 | Union field removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
 
 ### Tooling summary
 

--- a/README.md
+++ b/README.md
@@ -113,15 +113,21 @@ because they do not cause binary linkage or layout failures on their own:
 | Enum member added | Existing compiled enum values unchanged. Source-level switch coverage concern. Value shifts caught separately. |
 | Union field added | All union fields start at offset 0; existing fields unaffected. Size increase caught by TYPE_SIZE_CHANGED. |
 | GLOBAL→WEAK binding | Symbol still exported and resolvable by the dynamic linker. |
-| ELF `st_size` changed | Metadata not used by dynamic linker for resolution. Layout breaks caught by TYPE_SIZE_CHANGED. |
 | GNU IFUNC introduced/removed | Transparent to callers via PLT/GOT mechanism. |
-| New version requirement (e.g. GLIBC_2.34) | Deployment portability concern, not the library's own ABI surface. |
-| Typeinfo/vtable visibility change | Niche RTTI cross-DSO concern, not general binary ABI break. |
-| Variable const qualifier added/removed | Symbol still resolves; behavioral concern (SIGSEGV on write / ODR), not linkage. |
 | New/removed DT_NEEDED dependency | Deployment concern, not binary interface break. |
 | RPATH/RUNPATH changed | Search path metadata, not symbol contract. |
 | Toolchain flag drift | Informational — not a proven binary break on its own. |
 | DWARF info missing | Coverage gap warning — comparison was incomplete. |
+
+Some changes are classified as **BREAKING** despite being borderline, because they
+can cause runtime failures in realistic deployments:
+
+| Change | Why it's BREAKING |
+|---|---|
+| ELF `st_size` changed | In ELF-only mode (no headers/DWARF), may be the sole signal for vtable/variable layout changes. |
+| New version requirement (e.g. GLIBC_2.34) | Library fails to load on runtimes lacking that version — hard runtime failure. |
+| Typeinfo/vtable visibility change | Cross-DSO `dynamic_cast` and exception matching can fail at runtime. |
+| Variable const qualifier added/removed | Adding const moves variable to `.rodata` — existing writes cause SIGSEGV. |
 
 ---
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -157,7 +157,10 @@ _BREAKING_KINDS = {
     # ELF Sprint 2
     ChangeKind.SONAME_CHANGED,
     ChangeKind.SYMBOL_TYPE_CHANGED,
+    ChangeKind.SYMBOL_SIZE_CHANGED,           # in ELF-only mode (no headers/DWARF) this may be
+                                              # the sole signal for vtable/variable layout changes
     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, # library fails to load on runtimes lacking the version
     # DWARF Sprint 3 + 4
     ChangeKind.STRUCT_SIZE_CHANGED,
     ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
@@ -169,9 +172,13 @@ _BREAKING_KINDS = {
     ChangeKind.STRUCT_PACKING_CHANGED,
     # Sprint 2 — gap detectors
     ChangeKind.FUNC_DELETED,
+    ChangeKind.VAR_BECAME_CONST,              # writes → SIGSEGV when variable moves to .rodata
+    ChangeKind.VAR_LOST_CONST,                # ODR / inlining break; callers may have cached const value
     ChangeKind.TYPE_BECAME_OPAQUE,
     ChangeKind.BASE_CLASS_POSITION_CHANGED,
     ChangeKind.BASE_CLASS_VIRTUAL_CHANGED,
+    # DWARF Sprint 4
+    ChangeKind.TYPE_VISIBILITY_CHANGED,       # cross-DSO dynamic_cast / exception matching can fail
 }
 
 _COMPATIBLE_KINDS: set[ChangeKind] = {
@@ -212,29 +219,10 @@ _COMPATIBLE_KINDS: set[ChangeKind] = {
     # linker; interposition semantics change but existing binaries work.
     ChangeKind.SYMBOL_BINDING_CHANGED,
 
-    # ELF st_size is metadata not used by the dynamic linker for symbol
-    # resolution.  Actual layout breaks are caught by TYPE_SIZE_CHANGED /
-    # STRUCT_SIZE_CHANGED.
-    ChangeKind.SYMBOL_SIZE_CHANGED,
-
     # GNU IFUNC ↔ regular function: transparent to callers; the PLT/GOT
     # mechanism handles resolution.  This is an implementation optimization.
     ChangeKind.IFUNC_INTRODUCED,
     ChangeKind.IFUNC_REMOVED,
-
-    # New version requirement on a *dependency* (e.g. GLIBC_2.34): affects
-    # deployment portability, not the library's own exported ABI surface.
-    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
-
-    # Typeinfo/vtable visibility: niche RTTI cross-DSO concern, not a
-    # general binary ABI break for symbol resolution or calling convention.
-    ChangeKind.TYPE_VISIBILITY_CHANGED,
-
-    # const qualifier on global variables: symbol still resolves at the same
-    # address/size; adding const moves to .rodata (writes SIGSEGV) and
-    # removing const is an ODR concern — both are behavioral, not linkage.
-    ChangeKind.VAR_BECAME_CONST,
-    ChangeKind.VAR_LOST_CONST,
 
     # DWARF diagnostics (comparison coverage gap warning)
     ChangeKind.DWARF_INFO_MISSING,

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -123,12 +123,11 @@ class Verdict(str, Enum):
     BREAKING = "BREAKING"           # binary ABI break
 
 
-# Which ChangeKinds are immediately BREAKING
+# Which ChangeKinds are immediately BREAKING (binary ABI incompatibility)
 _BREAKING_KINDS = {
     ChangeKind.FUNC_REMOVED,
     ChangeKind.FUNC_RETURN_CHANGED,
     ChangeKind.FUNC_PARAMS_CHANGED,
-    ChangeKind.FUNC_NOEXCEPT_REMOVED,
     ChangeKind.FUNC_VIRTUAL_ADDED,
     ChangeKind.FUNC_VIRTUAL_REMOVED,
     ChangeKind.VAR_REMOVED,
@@ -141,10 +140,8 @@ _BREAKING_KINDS = {
     ChangeKind.TYPE_BASE_CHANGED,
     ChangeKind.TYPE_VTABLE_CHANGED,
     ChangeKind.TYPE_REMOVED,
-    ChangeKind.FUNC_NOEXCEPT_ADDED,  # C++17: noexcept is part of the function type (P0012R1)
     ChangeKind.TYPE_FIELD_ADDED,  # for polymorphic / non-standard-layout types
     ChangeKind.ENUM_MEMBER_REMOVED,
-    ChangeKind.ENUM_MEMBER_ADDED,
     ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
     ChangeKind.FUNC_STATIC_CHANGED,
@@ -152,7 +149,6 @@ _BREAKING_KINDS = {
     ChangeKind.FUNC_VISIBILITY_CHANGED,
     ChangeKind.FUNC_PURE_VIRTUAL_ADDED,
     ChangeKind.FUNC_VIRTUAL_BECAME_PURE,
-    ChangeKind.UNION_FIELD_ADDED,
     ChangeKind.UNION_FIELD_REMOVED,
     ChangeKind.UNION_FIELD_TYPE_CHANGED,
     ChangeKind.TYPEDEF_BASE_CHANGED,
@@ -160,13 +156,8 @@ _BREAKING_KINDS = {
     ChangeKind.FIELD_BITFIELD_CHANGED,
     # ELF Sprint 2
     ChangeKind.SONAME_CHANGED,
-    ChangeKind.SYMBOL_BINDING_CHANGED,
     ChangeKind.SYMBOL_TYPE_CHANGED,
-    ChangeKind.SYMBOL_SIZE_CHANGED,
-    ChangeKind.IFUNC_INTRODUCED,
-    ChangeKind.IFUNC_REMOVED,
     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
-    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
     # DWARF Sprint 3 + 4
     ChangeKind.STRUCT_SIZE_CHANGED,
     ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
@@ -174,15 +165,10 @@ _BREAKING_KINDS = {
     ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
     ChangeKind.STRUCT_ALIGNMENT_CHANGED,
     ChangeKind.ENUM_UNDERLYING_SIZE_CHANGED,
-    ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
-    ChangeKind.ENUM_MEMBER_REMOVED,
     ChangeKind.CALLING_CONVENTION_CHANGED,
     ChangeKind.STRUCT_PACKING_CHANGED,
-    ChangeKind.TYPE_VISIBILITY_CHANGED,
-    # Sprint 2
+    # Sprint 2 — gap detectors
     ChangeKind.FUNC_DELETED,
-    ChangeKind.VAR_BECAME_CONST,
-    ChangeKind.VAR_LOST_CONST,
     ChangeKind.TYPE_BECAME_OPAQUE,
     ChangeKind.BASE_CLASS_POSITION_CHANGED,
     ChangeKind.BASE_CLASS_VIRTUAL_CHANGED,
@@ -197,6 +183,22 @@ _COMPATIBLE_KINDS: set[ChangeKind] = {
     # non-polymorphic types; context-aware verdict set in _diff_types()
     ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
 
+    # noexcept changes: Itanium ABI mangling does not change in practice;
+    # existing binaries resolve the same symbol.  Source-level concern only
+    # (C++17 function-pointer type system), not a binary ABI break.
+    ChangeKind.FUNC_NOEXCEPT_ADDED,
+    ChangeKind.FUNC_NOEXCEPT_REMOVED,
+
+    # Enum member addition: existing compiled enum values are unchanged;
+    # new enumerator does not shift others.  Source-level switch coverage
+    # concern, not binary ABI.  Value shifts are caught separately by
+    # ENUM_MEMBER_VALUE_CHANGED.
+    ChangeKind.ENUM_MEMBER_ADDED,
+
+    # Union field addition: all fields start at offset 0; existing fields
+    # are unaffected.  Size increase (if any) is caught by TYPE_SIZE_CHANGED.
+    ChangeKind.UNION_FIELD_ADDED,
+
     # ELF-only warning/compatible drift
     ChangeKind.NEEDED_ADDED,              # new dep: may not exist on older systems — warn, not hard-break
     ChangeKind.NEEDED_REMOVED,            # removing a dep is compatible (but deployment risk)
@@ -205,6 +207,34 @@ _COMPATIBLE_KINDS: set[ChangeKind] = {
     ChangeKind.COMMON_SYMBOL_RISK,        # STT_COMMON — risk, not proven break
     ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
     ChangeKind.SYMBOL_BINDING_STRENGTHENED,  # WEAK→GLOBAL: backward-compatible for most consumers
+
+    # GLOBAL→WEAK: symbol still exported and resolvable by the dynamic
+    # linker; interposition semantics change but existing binaries work.
+    ChangeKind.SYMBOL_BINDING_CHANGED,
+
+    # ELF st_size is metadata not used by the dynamic linker for symbol
+    # resolution.  Actual layout breaks are caught by TYPE_SIZE_CHANGED /
+    # STRUCT_SIZE_CHANGED.
+    ChangeKind.SYMBOL_SIZE_CHANGED,
+
+    # GNU IFUNC ↔ regular function: transparent to callers; the PLT/GOT
+    # mechanism handles resolution.  This is an implementation optimization.
+    ChangeKind.IFUNC_INTRODUCED,
+    ChangeKind.IFUNC_REMOVED,
+
+    # New version requirement on a *dependency* (e.g. GLIBC_2.34): affects
+    # deployment portability, not the library's own exported ABI surface.
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+
+    # Typeinfo/vtable visibility: niche RTTI cross-DSO concern, not a
+    # general binary ABI break for symbol resolution or calling convention.
+    ChangeKind.TYPE_VISIBILITY_CHANGED,
+
+    # const qualifier on global variables: symbol still resolves at the same
+    # address/size; adding const moves to .rodata (writes SIGSEGV) and
+    # removing const is an ODR concern — both are behavioral, not linkage.
+    ChangeKind.VAR_BECAME_CONST,
+    ChangeKind.VAR_LOST_CONST,
 
     # DWARF diagnostics (comparison coverage gap warning)
     ChangeKind.DWARF_INFO_MISSING,

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -55,7 +55,6 @@ _ADDED_KINDS: frozenset[str] = frozenset({
 #: Kinds that are breaking but neither a simple removal nor addition.
 _CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
     "func_params_changed", "func_return_changed",
-    "func_noexcept_added", "func_noexcept_removed",
     "func_virtual_removed", "func_virtual_became_pure",
     "func_pure_virtual_added", "func_static_changed", "func_cv_changed",
     "var_type_changed",
@@ -68,17 +67,12 @@ _CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
     "struct_field_type_changed", "struct_alignment_changed",
     "field_bitfield_changed",
     "calling_convention_changed", "struct_packing_changed",
-    "type_visibility_changed",
     "func_visibility_changed",  # public→hidden: symbol removed from ABI
-    # qualifier_removed: not in canonical _BREAKING_KINDS
     "typedef_base_changed",
     "union_field_type_changed",
     # ELF-layer
-    "soname_changed", "symbol_binding_changed", "symbol_type_changed",
-    "symbol_size_changed", "symbol_version_defined_removed",
-    # needed_removed, rpath_changed, runpath_changed: compatible/warn in checker.py
-    "ifunc_introduced", "ifunc_removed",
-    # dwarf_info_missing: warning only (not breaking) per checker.py
+    "soname_changed", "symbol_type_changed",
+    "symbol_version_defined_removed",
 })
 
 #: Canonical breaking kinds imported from checker — single source of truth.

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -70,9 +70,10 @@ _CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
     "func_visibility_changed",  # public→hidden: symbol removed from ABI
     "typedef_base_changed",
     "union_field_type_changed",
+    "type_visibility_changed",
     # ELF-layer
     "soname_changed", "symbol_type_changed",
-    "symbol_version_defined_removed",
+    "symbol_size_changed", "symbol_version_defined_removed",
 })
 
 #: Canonical breaking kinds imported from checker — single source of truth.

--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -152,10 +152,16 @@ For full code walkthroughs and deep per-case narrative, see
     - Example: `examples/case20_enum_member_value_changed/`
     - Mitigation: never renumber released enum constants.
 
-## 7) Compatible/warning changes (not binary ABI breaks)
+## 7) Additional detected changes and verdicts
 
-These changes are detected and reported by abicheck but classified as **COMPATIBLE**
-because they do not cause binary linkage or layout failures when comparing two releases.
+Beyond the core symbol/type/C++ checks above, abicheck detects a number of
+ELF-metadata, DWARF-diagnostic, and qualifier changes. Each is classified
+according to whether it causes a proven binary-level failure.
+
+### Compatible/warning changes
+
+These are detected and reported but do **not** trigger a BREAKING verdict
+because they do not cause binary linkage or layout failures on their own.
 
 25. **noexcept added/removed** — `noexcept` specifier changed on a function.
     - Itanium ABI mangling does not change in practice — the same symbol resolves.
@@ -178,45 +184,51 @@ because they do not cause binary linkage or layout failures when comparing two r
     - Interposition semantics change but existing binaries continue to work.
     - Verdict: COMPATIBLE.
 
-29. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
-    - `st_size` is informational metadata; the dynamic linker does not use it for resolution.
-    - In ELF-only mode (no headers/DWARF), may be the sole signal for vtable
-      or variable layout changes — classified as **BREAKING** to avoid false negatives.
-
-30. **GNU IFUNC introduced/removed** — symbol changed to/from `STT_GNU_IFUNC`.
+29. **GNU IFUNC introduced/removed** — symbol changed to/from `STT_GNU_IFUNC`.
     - Transparent to callers; PLT/GOT mechanism handles indirect resolution.
     - This is an implementation optimization, not an ABI contract change.
     - Verdict: COMPATIBLE.
 
-31. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
-    - Library fails to load on runtimes lacking the required version.
-    - Verdict: **BREAKING** (hard runtime failure on affected systems).
-
-32. **Typeinfo/vtable visibility changed** — visibility attribute changed on type metadata.
-    - Cross-DSO `dynamic_cast` and C++ exception matching can fail at runtime.
-    - Verdict: **BREAKING**.
-
-33. **Variable const qualifier added/removed** — global variable gained or lost `const`.
-    - Adding `const` moves variable to `.rodata`; existing writes cause SIGSEGV.
-    - Removing `const` is an ODR / inlining break (callers may have cached the value).
-    - Verdict: **BREAKING**.
-
-34. **New/removed DT_NEEDED dependency** — library gained or dropped a shared library dependency.
+30. **New/removed DT_NEEDED dependency** — library gained or dropped a shared library dependency.
     - Deployment/packaging concern; does not affect the library's exported symbol contract.
     - Verdict: COMPATIBLE.
 
-35. **RPATH/RUNPATH changed** — library search path metadata changed.
+31. **RPATH/RUNPATH changed** — library search path metadata changed.
     - Operational concern; no effect on symbol contract or type layout.
     - Verdict: COMPATIBLE.
 
-36. **Toolchain flag drift** — different compiler flags detected via `DW_AT_producer`.
+32. **Toolchain flag drift** — different compiler flags detected via `DW_AT_producer`.
     - Informational diagnostic; not a proven binary break on its own.
     - Verdict: COMPATIBLE.
 
-37. **DWARF info missing** — new binary lacks debug info.
+33. **DWARF info missing** — new binary lacks debug info.
     - Coverage gap warning: struct/enum layout comparison was skipped.
     - Not a break; indicates the comparison is incomplete.
     - Verdict: COMPATIBLE.
+
+### Borderline changes classified as BREAKING
+
+These changes are less obvious than a removed symbol or shifted struct layout,
+but they can cause hard runtime failures in realistic deployments.
+
+34. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
+    - `st_size` is informational metadata; the dynamic linker does not use it for resolution.
+    - However, in ELF-only mode (no headers/DWARF) it may be the **sole** signal for
+      vtable growth or variable type changes.
+    - Verdict: **BREAKING** (to avoid false negatives in stripped-binary workflows).
+
+35. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
+    - Library fails to load on runtimes lacking the required version.
+    - Verdict: **BREAKING** (hard runtime failure on affected systems).
+
+36. **Typeinfo/vtable visibility changed** — visibility attribute changed on type metadata.
+    - Cross-DSO `dynamic_cast` and C++ exception matching can fail at runtime.
+    - Verdict: **BREAKING**.
+
+37. **Variable const qualifier added/removed** — global variable gained or lost `const`.
+    - Adding `const` moves variable to `.rodata`; existing writes cause SIGSEGV.
+    - Removing `const` is an ODR / inlining break (callers may have cached the value).
+    - Verdict: **BREAKING**.
 
 ---
 

--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -185,9 +185,19 @@ because they do not cause binary linkage or layout failures on their own.
     - Verdict: COMPATIBLE.
 
 29. **GNU IFUNC introduced/removed** — symbol changed to/from `STT_GNU_IFUNC`.
-    - Transparent to callers; PLT/GOT mechanism handles indirect resolution.
-    - This is an implementation optimization, not an ABI contract change.
-    - Verdict: COMPATIBLE.
+    - At the call-ABI level, IFUNC resolution is transparent to callers: the
+      PLT/GOT mechanism dispatches through the resolver without changing the
+      calling convention or symbol signature.
+    - However, this is only compatible when:
+      (a) the symbol's signature and versioning are preserved, and
+      (b) the deployment environment supports IFUNC and `R_*_IRELATIVE`
+      relocations (requires a recent dynamic loader, e.g., glibc ≥ 2.11;
+      musl added partial support in 1.1.0; some embedded/non-glibc runtimes
+      do not support IFUNC at all).
+    - On older loaders or non-glibc runtimes, an IFUNC symbol may fail to
+      resolve at load time.
+    - Verdict: COMPATIBLE (assuming modern glibc/musl toolchain; may break on
+      older or non-standard loaders).
 
 30. **New/removed DT_NEEDED dependency** — library gained or dropped a shared library dependency.
     - Deployment/packaging concern; does not affect the library's exported symbol contract.
@@ -212,10 +222,15 @@ These changes are less obvious than a removed symbol or shifted struct layout,
 but they can cause hard runtime failures in realistic deployments.
 
 34. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
-    - `st_size` is informational metadata; the dynamic linker does not use it for resolution.
-    - However, in ELF-only mode (no headers/DWARF) it may be the **sole** signal for
+    - While `st_size` is not used for normal symbol resolution, it **is** used by
+      the dynamic linker for COPY relocations (`R_*_COPY`) to determine the number
+      of bytes to copy into the executable's BSS and to validate size consistency.
+      A size mismatch can cause truncated or over-copied data for COPY-relocated
+      globals.
+    - In ELF-only mode (no headers/DWARF) it may also be the **sole** signal for
       vtable growth or variable type changes.
-    - Verdict: **BREAKING** (to avoid false negatives in stripped-binary workflows).
+    - Verdict: **BREAKING** (COPY relocation correctness and stripped-binary
+      false-negative avoidance).
 
 35. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
     - Library fails to load on runtimes lacking the required version.

--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -83,10 +83,11 @@ For full code walkthroughs and deep per-case narrative, see
     - Mitigation: use Pimpl to stabilize externally visible object layout.
 
 13. **case15_noexcept_change** — `noexcept` removed/changed.
-    - Risk: exception contract change, ABI/behavior mismatch.
-    - Type: semantic break (often poorly detected by ELF-only tools).
+    - Risk: source-level contract change; does NOT change Itanium ABI mangled name.
+    - Type: **compatible/warning** (not a binary ABI break — same symbol resolves).
+    - Verdict: COMPATIBLE.
     - Example: `examples/case15_noexcept_change/`
-    - Mitigation: treat `noexcept` as stable public contract.
+    - Mitigation: treat `noexcept` as stable public contract for source compatibility.
 
 14. **case16_inline_to_non_inline** — inline→non-inline (or reverse) with ODR effects.
     - Risk: multiple definitions, mixed TU behavior.
@@ -150,6 +151,76 @@ For full code walkthroughs and deep per-case narrative, see
     - Type: semantic compatibility break.
     - Example: `examples/case20_enum_member_value_changed/`
     - Mitigation: never renumber released enum constants.
+
+## 7) Compatible/warning changes (not binary ABI breaks)
+
+These changes are detected and reported by abicheck but classified as **COMPATIBLE**
+because they do not cause binary linkage or layout failures when comparing two releases.
+
+25. **noexcept added/removed** — `noexcept` specifier changed on a function.
+    - Itanium ABI mangling does not change in practice — the same symbol resolves.
+    - Source-level concern only (C++17 function-pointer type mismatch).
+    - Verdict: COMPATIBLE.
+
+26. **Enum member added** — new enumerator appended to an existing enum.
+    - Existing compiled enum values are unchanged.
+    - Source-level concern (switch statement coverage).
+    - Value shifts (if any) are caught separately by `ENUM_MEMBER_VALUE_CHANGED`.
+    - Verdict: COMPATIBLE.
+
+27. **Union field added** — new field added to an existing union.
+    - All union fields share offset 0; existing fields are unaffected.
+    - Size increase (if any) is caught separately by `TYPE_SIZE_CHANGED`.
+    - Verdict: COMPATIBLE.
+
+28. **GLOBAL→WEAK symbol binding** — symbol weakened from `STT_GLOBAL` to `STT_WEAK`.
+    - Symbol is still exported and resolvable by the dynamic linker.
+    - Interposition semantics change but existing binaries continue to work.
+    - Verdict: COMPATIBLE.
+
+29. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
+    - `st_size` is informational metadata; the dynamic linker does not use it for resolution.
+    - Actual layout breaks are caught by `TYPE_SIZE_CHANGED` / `STRUCT_SIZE_CHANGED`.
+    - Verdict: COMPATIBLE.
+
+30. **GNU IFUNC introduced/removed** — symbol changed to/from `STT_GNU_IFUNC`.
+    - Transparent to callers; PLT/GOT mechanism handles indirect resolution.
+    - This is an implementation optimization, not an ABI contract change.
+    - Verdict: COMPATIBLE.
+
+31. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
+    - Affects deployment portability on older systems, not the library's own ABI.
+    - Consumers linking against *this* library's symbols are unaffected.
+    - Verdict: COMPATIBLE.
+
+32. **Typeinfo/vtable visibility changed** — visibility attribute changed on type metadata.
+    - Affects RTTI (`dynamic_cast`) across DSO boundaries in specific scenarios.
+    - Not a general binary ABI break for symbol resolution or calling convention.
+    - Verdict: COMPATIBLE.
+
+33. **Variable const qualifier added/removed** — global variable gained or lost `const`.
+    - Symbol still resolves at the same address and size.
+    - Adding `const` moves variable to `.rodata` (writes cause SIGSEGV).
+    - Removing `const` is an ODR concern for inlined values.
+    - Both are behavioral concerns, not linkage breaks.
+    - Verdict: COMPATIBLE.
+
+34. **New/removed DT_NEEDED dependency** — library gained or dropped a shared library dependency.
+    - Deployment/packaging concern; does not affect the library's exported symbol contract.
+    - Verdict: COMPATIBLE.
+
+35. **RPATH/RUNPATH changed** — library search path metadata changed.
+    - Operational concern; no effect on symbol contract or type layout.
+    - Verdict: COMPATIBLE.
+
+36. **Toolchain flag drift** — different compiler flags detected via `DW_AT_producer`.
+    - Informational diagnostic; not a proven binary break on its own.
+    - Verdict: COMPATIBLE.
+
+37. **DWARF info missing** — new binary lacks debug info.
+    - Coverage gap warning: struct/enum layout comparison was skipped.
+    - Not a break; indicates the comparison is incomplete.
+    - Verdict: COMPATIBLE.
 
 ---
 

--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -173,15 +173,15 @@ because they do not cause binary linkage or layout failures when comparing two r
     - Size increase (if any) is caught separately by `TYPE_SIZE_CHANGED`.
     - Verdict: COMPATIBLE.
 
-28. **GLOBAL→WEAK symbol binding** — symbol weakened from `STT_GLOBAL` to `STT_WEAK`.
+28. **GLOBAL→WEAK symbol binding** — symbol weakened from `STB_GLOBAL` to `STB_WEAK`.
     - Symbol is still exported and resolvable by the dynamic linker.
     - Interposition semantics change but existing binaries continue to work.
     - Verdict: COMPATIBLE.
 
 29. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
     - `st_size` is informational metadata; the dynamic linker does not use it for resolution.
-    - Actual layout breaks are caught by `TYPE_SIZE_CHANGED` / `STRUCT_SIZE_CHANGED`.
-    - Verdict: COMPATIBLE.
+    - In ELF-only mode (no headers/DWARF), may be the sole signal for vtable
+      or variable layout changes — classified as **BREAKING** to avoid false negatives.
 
 30. **GNU IFUNC introduced/removed** — symbol changed to/from `STT_GNU_IFUNC`.
     - Transparent to callers; PLT/GOT mechanism handles indirect resolution.
@@ -189,21 +189,17 @@ because they do not cause binary linkage or layout failures when comparing two r
     - Verdict: COMPATIBLE.
 
 31. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
-    - Affects deployment portability on older systems, not the library's own ABI.
-    - Consumers linking against *this* library's symbols are unaffected.
-    - Verdict: COMPATIBLE.
+    - Library fails to load on runtimes lacking the required version.
+    - Verdict: **BREAKING** (hard runtime failure on affected systems).
 
 32. **Typeinfo/vtable visibility changed** — visibility attribute changed on type metadata.
-    - Affects RTTI (`dynamic_cast`) across DSO boundaries in specific scenarios.
-    - Not a general binary ABI break for symbol resolution or calling convention.
-    - Verdict: COMPATIBLE.
+    - Cross-DSO `dynamic_cast` and C++ exception matching can fail at runtime.
+    - Verdict: **BREAKING**.
 
 33. **Variable const qualifier added/removed** — global variable gained or lost `const`.
-    - Symbol still resolves at the same address and size.
-    - Adding `const` moves variable to `.rodata` (writes cause SIGSEGV).
-    - Removing `const` is an ODR concern for inlined values.
-    - Both are behavioral concerns, not linkage breaks.
-    - Verdict: COMPATIBLE.
+    - Adding `const` moves variable to `.rodata`; existing writes cause SIGSEGV.
+    - Removing `const` is an ODR / inlining break (callers may have cached the value).
+    - Verdict: **BREAKING**.
 
 34. **New/removed DT_NEEDED dependency** — library gained or dropped a shared library dependency.
     - Deployment/packaging concern; does not affect the library's exported symbol contract.

--- a/docs/examples_breakage_guide.md
+++ b/docs/examples_breakage_guide.md
@@ -584,13 +584,6 @@ against the GLOBAL version will find and use the (now WEAK) symbol without any c
 The only difference is that the symbol can now be overridden by another definition — an interposition
 concern, not a compatibility break.
 
-### ELF st_size changed
-
-The `st_size` field in the ELF symbol table is metadata. The dynamic linker does not use it for
-symbol resolution or binding. A change in `st_size` is a strong *indicator* that the underlying
-type's layout changed, but the actual binary break (if any) is caught by `TYPE_SIZE_CHANGED` or
-`STRUCT_SIZE_CHANGED`. Reporting `st_size` drift avoids duplicate false-positive BREAKING verdicts.
-
 ### GNU IFUNC introduced or removed
 
 Converting a regular function to GNU IFUNC (indirect function) or back is transparent to callers.
@@ -598,31 +591,18 @@ The PLT/GOT resolution mechanism handles indirect dispatch automatically. This i
 optimization (e.g., CPU-specific dispatch) that does not change the calling convention or symbol
 contract visible to consumers.
 
-### New dependency version requirement
+### Note: borderline checks classified as BREAKING
 
-```text
-v1: NEEDED: libc.so.6 (GLIBC_2.17)
-v2: NEEDED: libc.so.6 (GLIBC_2.17, GLIBC_2.34)
-```
+Some changes are borderline but classified as **BREAKING** because they can cause runtime failures:
 
-A new version requirement (e.g., `GLIBC_2.34`) means the library itself was linked against newer
-system facilities. This affects deployment portability — the library won't load on older systems
-lacking `GLIBC_2.34` — but it does not change the library's own exported symbol contract.
-Consumers linking against this library's symbols are unaffected.
-
-### Variable const qualifier added or removed
-
-```c
-/* v1 */
-extern int g_config;
-
-/* v2 */
-extern const int g_config;
-```
-
-The symbol still resolves at the same address and size. Adding `const` moves the variable to
-`.rodata`, so writes to it will cause SIGSEGV. Removing `const` is an ODR concern for inlined
-values. Both are behavioral/safety concerns rather than linkage breaks.
+- **ELF `st_size` changed** — in ELF-only mode (no headers/DWARF), may be the sole signal for
+  vtable growth or variable type changes. Classified BREAKING to avoid false negatives.
+- **New dependency version requirement** (e.g., `GLIBC_2.34`) — the library fails to load on
+  runtimes lacking the version. Hard runtime failure.
+- **Typeinfo/vtable visibility changed** — cross-DSO `dynamic_cast` and C++ exception matching
+  can fail at runtime.
+- **Variable const qualifier added/removed** — adding `const` moves to `.rodata`; existing writes
+  cause SIGSEGV. Removing `const` breaks ODR/inlining assumptions.
 
 ---
 

--- a/docs/examples_breakage_guide.md
+++ b/docs/examples_breakage_guide.md
@@ -317,7 +317,7 @@ old allocations can be too small, causing writes beyond boundaries. Crashes may 
 
 Use Pimpl to keep public object footprint stable.
 
-## case15_noexcept_change — behavioral ABI contract change
+## case15_noexcept_change — source-level contract change (COMPATIBLE)
 
 ```cpp
 // v1
@@ -332,11 +332,17 @@ int process();
 static_assert(noexcept(process()));
 ```
 
-`noexcept` participates in function type semantics and influences optimization/error handling behavior.
-Mixed object sets built with different assumptions can diverge in exception paths (including terminate).
-This may evade symbol-only checks but still break real-world behavior contracts.
+**abicheck verdict: COMPATIBLE.** The Itanium ABI mangled name does not change when `noexcept` is
+added or removed — the same symbol resolves at load time and existing binaries continue to call the
+function correctly. This is a **source-level concern**, not a binary ABI break.
 
-Treat `noexcept` as stable API commitment; evolve via new API version.
+However, `noexcept` does participate in C++17 function type semantics (P0012R1), so function pointer
+types may mismatch in template code. Additionally, code compiled with v1 headers may omit exception
+landing pads, so if v2's function throws, `std::terminate` is called. These are behavioral/contract
+concerns that should be reviewed, but they do not prevent already-compiled binaries from loading or
+calling the function.
+
+Treat `noexcept` as stable API commitment for source compatibility; evolve via new API version.
 
 ## case16_inline_to_non_inline — ODR/export behavior drift
 
@@ -515,6 +521,108 @@ representation and can invalidate persisted/exchanged data and branch logic rely
 Even if size stays constant, semantic compatibility is broken.
 
 Prefer versioned replacement unions/structs plus explicit conversion rules.
+
+---
+
+## Compatible/warning changes (not binary ABI breaks)
+
+The following changes are detected and reported by abicheck but classified as
+**COMPATIBLE** — they are important for awareness but do not cause binary linkage
+or layout failures when swapping a shared library between two releases.
+
+### Enum member added
+
+```c
+/* v1 */
+enum Color { RED = 0, GREEN = 1, BLUE = 2 };
+
+/* v2 */
+enum Color { RED = 0, GREEN = 1, BLUE = 2, YELLOW = 3 };
+```
+
+```c
+/* consumer compiled against v1 */
+switch (get_color()) {
+    case RED: ...; case GREEN: ...; case BLUE: ...;
+    /* YELLOW not handled — but binary still works correctly */
+}
+```
+
+Adding a new enum member does not change the numeric values of existing members. Already-compiled
+binaries continue to pass and receive the same integer values. The concern is source-level: switch
+statements may not handle the new value, and sentinel patterns like `COLOR_COUNT` may need updating.
+If adding the member shifts existing values, that is a separate change caught by
+`ENUM_MEMBER_VALUE_CHANGED` (which IS breaking).
+
+### Union field added
+
+```c
+/* v1 */
+union Value { int i; float f; };
+
+/* v2 */
+union Value { int i; float f; double d; };
+```
+
+All union fields share offset 0, so adding a new field does not change how existing fields are
+accessed. If the new field is larger than existing ones, the union's size increases — but that
+size change is caught separately by `TYPE_SIZE_CHANGED`. The field addition itself is compatible.
+
+### noexcept added or removed
+
+See [case15_noexcept_change](#case15_noexcept_change--source-level-contract-change-compatible) above.
+
+### GLOBAL→WEAK symbol binding
+
+```text
+v1: foo  GLOBAL  DEFAULT  → strong binding
+v2: foo  WEAK    DEFAULT  → overridable binding
+```
+
+A WEAK symbol is still exported and resolvable by the dynamic linker. Existing binaries that linked
+against the GLOBAL version will find and use the (now WEAK) symbol without any change in behavior.
+The only difference is that the symbol can now be overridden by another definition — an interposition
+concern, not a compatibility break.
+
+### ELF st_size changed
+
+The `st_size` field in the ELF symbol table is metadata. The dynamic linker does not use it for
+symbol resolution or binding. A change in `st_size` is a strong *indicator* that the underlying
+type's layout changed, but the actual binary break (if any) is caught by `TYPE_SIZE_CHANGED` or
+`STRUCT_SIZE_CHANGED`. Reporting `st_size` drift avoids duplicate false-positive BREAKING verdicts.
+
+### GNU IFUNC introduced or removed
+
+Converting a regular function to GNU IFUNC (indirect function) or back is transparent to callers.
+The PLT/GOT resolution mechanism handles indirect dispatch automatically. This is an implementation
+optimization (e.g., CPU-specific dispatch) that does not change the calling convention or symbol
+contract visible to consumers.
+
+### New dependency version requirement
+
+```text
+v1: NEEDED: libc.so.6 (GLIBC_2.17)
+v2: NEEDED: libc.so.6 (GLIBC_2.17, GLIBC_2.34)
+```
+
+A new version requirement (e.g., `GLIBC_2.34`) means the library itself was linked against newer
+system facilities. This affects deployment portability — the library won't load on older systems
+lacking `GLIBC_2.34` — but it does not change the library's own exported symbol contract.
+Consumers linking against this library's symbols are unaffected.
+
+### Variable const qualifier added or removed
+
+```c
+/* v1 */
+extern int g_config;
+
+/* v2 */
+extern const int g_config;
+```
+
+The symbol still resolves at the same address and size. Adding `const` moves the variable to
+`.rodata`, so writes to it will cause SIGSEGV. Removing `const` is an ODR concern for inlined
+values. Both are behavioral/safety concerns rather than linkage breaks.
 
 ---
 

--- a/docs/usage_and_coverage.md
+++ b/docs/usage_and_coverage.md
@@ -79,11 +79,10 @@ A change is BREAKING only when it causes binary-level failures: symbol resolutio
 type layout corruption, vtable mismatch, or calling convention incompatibility.
 
 Changes like `noexcept` addition/removal, enum member addition, union field addition,
-GLOBAL→WEAK binding, ELF `st_size` changes, IFUNC transitions, new dependency version
-requirements, typeinfo visibility changes, and variable const qualifier changes are all
-classified as **COMPATIBLE** — they are detected and reported for awareness but do not
-trigger a BREAKING verdict. See the [README](../README.md#change-classification-breaking-vs-compatible)
-for the full rationale table.
+GLOBAL→WEAK binding, and IFUNC transitions are classified as **COMPATIBLE** — they are
+detected and reported for awareness but do not trigger a BREAKING verdict. See the
+[README](../README.md#change-classification-breaking-vs-compatible) for the full
+rationale table.
 
 ## ABI/API breakages and what each tool mode can detect
 

--- a/docs/usage_and_coverage.md
+++ b/docs/usage_and_coverage.md
@@ -67,6 +67,24 @@ while modernizing internals and outputs.
 3. Optionally move to native `dump/compare` commands for explicit snapshot control.
 4. Switch CI gates to JSON/SARIF-based policy checks.
 
+## Change classification: BREAKING vs COMPATIBLE
+
+abicheck classifies every detected change into a verdict:
+
+- **BREAKING** — binary ABI incompatibility; existing binaries will malfunction.
+- **COMPATIBLE** — informational/warning; does not break binary compatibility on its own.
+- **NO_CHANGE** — identical ABI.
+
+A change is BREAKING only when it causes binary-level failures: symbol resolution errors,
+type layout corruption, vtable mismatch, or calling convention incompatibility.
+
+Changes like `noexcept` addition/removal, enum member addition, union field addition,
+GLOBAL→WEAK binding, ELF `st_size` changes, IFUNC transitions, new dependency version
+requirements, typeinfo visibility changes, and variable const qualifier changes are all
+classified as **COMPATIBLE** — they are detected and reported for awareness but do not
+trigger a BREAKING verdict. See the [README](../README.md#change-classification-breaking-vs-compatible)
+for the full rationale table.
+
 ## ABI/API breakages and what each tool mode can detect
 
 This section maps breakage types to example cases under `examples/` and compares:
@@ -78,32 +96,32 @@ This section maps breakage types to example cases under `examples/` and compares
 
 Legend: ✅ strong support, ⚠️ partial/conditional, ❌ generally not covered.
 
-| Case | Breakage type | abicheck | abidiff + headers | ABICC #2 (headers) | ABICC #1 (dumps) |
-|---|---|:---:|:---:|:---:|:---:|
-| case01_symbol_removal | Public symbol removed | ✅ | ✅ | ✅ | ✅ |
-| case02_param_type_change | Function parameter type changed | ✅ | ✅ | ✅ | ✅ |
-| case03_compat_addition | Compatible API addition | ✅ | ✅ | ✅ | ✅ |
-| case04_no_change | No ABI change baseline | ✅ | ✅ | ✅ | ✅ |
-| case05_soname | SONAME / packaging policy issue | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case06_visibility | Visibility/export policy drift | ✅ | ✅ | ⚠️ | ⚠️ |
-| case07_struct_layout | Struct layout changed | ✅ | ✅ | ✅ | ✅ |
-| case08_enum_value_change | Enum value changed | ✅ | ⚠️ | ✅ | ✅ |
-| case09_cpp_vtable | VTable/method order/signature drift | ✅ | ✅ | ✅ | ✅ |
-| case10_return_type | Function return type changed | ✅ | ✅ | ✅ | ✅ |
-| case11_global_var_type | Global variable type changed | ✅ | ✅ | ✅ | ✅ |
-| case12_function_removed | API function removed | ✅ | ✅ | ✅ | ✅ |
-| case13_symbol_versioning | Symbol version policy regression | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case14_cpp_class_size | C++ class size/layout changed | ✅ | ✅ | ✅ | ✅ |
-| case15_noexcept_change | `noexcept` contract changed | ✅ | ⚠️ | ✅ | ❌ |
-| case16_inline_to_non_inline | Inline/ODR surface change | ✅ | ⚠️ | ✅ | ❌ |
-| case17_template_abi | Template-instantiation ABI drift | ✅ | ⚠️ | ✅ | ✅ |
-| case18_dependency_leak | Transitive dependency leaked into API | ✅ | ⚠️ | ✅ | ✅ |
-| case19_enum_member_removed | Enum member removed | ✅ | ✅ | ✅ | ✅ |
-| case20_enum_member_value_changed | Enum member value changed | ✅ | ⚠️ | ✅ | ✅ |
-| case21_method_became_static | Method became static | ✅ | ✅ | ✅ | ✅ |
-| case22_method_const_changed | Method const-qualifier changed | ✅ | ✅ | ✅ | ✅ |
-| case23_pure_virtual_added | Added pure virtual method | ✅ | ✅ | ✅ | ✅ |
-| case24_union_field_removed | Union field removed | ✅ | ✅ | ✅ | ✅ |
+| Case | Breakage type | Verdict | abicheck | abidiff + headers | ABICC #2 (headers) | ABICC #1 (dumps) |
+|---|---|---|:---:|:---:|:---:|:---:|
+| case01_symbol_removal | Public symbol removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case02_param_type_change | Function parameter type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case03_compat_addition | Compatible API addition | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
+| case04_no_change | No ABI change baseline | NO_CHANGE | ✅ | ✅ | ✅ | ✅ |
+| case05_soname | SONAME / packaging policy issue | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| case06_visibility | Visibility/export policy drift | BREAKING | ✅ | ✅ | ⚠️ | ⚠️ |
+| case07_struct_layout | Struct layout changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case08_enum_value_change | Enum value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case09_cpp_vtable | VTable/method order/signature drift | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case10_return_type | Function return type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case11_global_var_type | Global variable type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case12_function_removed | API function removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case13_symbol_versioning | Symbol version policy regression | COMPATIBLE | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| case14_cpp_class_size | C++ class size/layout changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case15_noexcept_change | `noexcept` contract changed | COMPATIBLE | ✅ | ⚠️ | ✅ | ❌ |
+| case16_inline_to_non_inline | Inline/ODR surface change | BREAKING | ✅ | ⚠️ | ✅ | ❌ |
+| case17_template_abi | Template-instantiation ABI drift | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case18_dependency_leak | Transitive dependency leaked into API | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case19_enum_member_removed | Enum member removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case20_enum_member_value_changed | Enum member value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
+| case21_method_became_static | Method became static | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case22_method_const_changed | Method const-qualifier changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case23_pure_virtual_added | Added pure virtual method | BREAKING | ✅ | ✅ | ✅ | ✅ |
+| case24_union_field_removed | Union field removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
 
 ### Summary by breakage category
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [12](case12_function_removed/README.md) | Function Disappears | Symbol API | 12 🔴 | Function moved to inline, vanishes from .so |
 | [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | — 🟡 | No version script → no `@@VER` on symbols |
 | [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | 4 🟡 | Private member grows, sizeof(class) changes |
-| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | COMPATIBLE 🟢 | Source-level contract; mangling unchanged |
+| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | 0 ❌ | Source-level contract; mangling unchanged |
 | [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | — ⚠️ | ODR violation; symbol appears in v2 .so |
 | [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | 4 🟡 | Explicit-instantiated template grows in size |
 | [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | — ⚠️ | Third-party type in public header changes layout |

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [12](case12_function_removed/README.md) | Function Disappears | Symbol API | 12 🔴 | Function moved to inline, vanishes from .so |
 | [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | — 🟡 | No version script → no `@@VER` on symbols |
 | [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | 4 🟡 | Private member grows, sizeof(class) changes |
-| [15](case15_noexcept_change/README.md) | noexcept Removed | C++ ABI | 0 ❌ | noexcept guarantee dropped; DWARF-invisible |
+| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | COMPATIBLE 🟢 | Source-level contract; mangling unchanged |
 | [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | — ⚠️ | ODR violation; symbol appears in v2 .so |
 | [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | 4 🟡 | Explicit-instantiated template grows in size |
 | [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | — ⚠️ | Third-party type in public header changes layout |

--- a/examples/case15_noexcept_change/README.md
+++ b/examples/case15_noexcept_change/README.md
@@ -1,4 +1,6 @@
-# Case 15 — `noexcept` Removed
+# Case 15 — `noexcept` Changed
+
+**abicheck verdict: COMPATIBLE (informational/warning)**
 
 ## What changes
 
@@ -7,16 +9,26 @@
 | v1 | `void reset() noexcept;` |
 | v2 | `void reset();` |
 
-## What breaks at binary level
+## Why this is NOT a binary ABI break
 
-In the Itanium C++ ABI (GCC/Clang on Linux/macOS) `noexcept` **does** affect the
-mangled name for some function-pointer typedefs (C++17+), and more importantly it
-changes the **exception-handling personality** of call sites:
+In the Itanium C++ ABI (GCC/Clang on Linux/macOS), `noexcept` does **not** change
+the mangled name for function symbols. The **symbol name is identical** in the `.so`,
+so existing binaries resolve the same symbol and calls proceed normally.
 
-- Code compiled against v1 wraps calls to `reset()` with an assumption that no
-  unwinding is needed. The compiler may omit landing pads in callers.
-- With v2, `reset()` *can* throw. A caller compiled with v1 headers will not have
-  the landing pad → exception propagates through a `noexcept` frame → `std::terminate`.
+abicheck classifies this as **COMPATIBLE** because:
+- No symbol resolution failure occurs at load time or call time.
+- No type layout, vtable, or calling convention change is involved.
+- The change is a **source-level contract concern**, not a binary linkage break.
+
+## What it does affect (source-level concerns)
+
+- **C++17 function-pointer types**: `noexcept` is part of the function type in C++17
+  (P0012R1), so `void(*)() noexcept` and `void(*)()` are distinct types. This can
+  cause template instantiation mismatches in source code — but not in already-compiled
+  binaries.
+- **Exception-handling behavior**: code compiled against v1 may omit landing pads,
+  assuming no unwinding is needed. If v2's `reset()` throws, `std::terminate` is
+  called. This is a behavioral contract concern, not a linkage failure.
 
 The **symbol name itself is identical** in the `.so` (no mangling difference for
 member functions in GCC), so `abidiff` sees no change.

--- a/examples/case19_enum_member_removed/README.md
+++ b/examples/case19_enum_member_removed/README.md
@@ -1,0 +1,45 @@
+# Case 19 — Enum Member Removed
+
+**abicheck verdict: BREAKING**
+
+## What changes
+
+| Version | Definition |
+|---------|-----------|
+| v1 | `enum Status { OK = 0, ERROR = 1, FOO = 2 };` |
+| v2 | `enum Status { OK = 0, ERROR = 1 };` |
+
+## What breaks at binary level
+
+Removing an enum member invalidates any code that uses that member's numeric value.
+Existing binaries that were compiled with `FOO = 2` may store, transmit, or switch on
+that value. The new library no longer defines that value as a valid member of the enum.
+
+This is a **semantic ABI break**: while the remaining values (`OK`, `ERROR`) are still
+at the same numeric positions, the removed value `FOO = 2` becomes undefined in the
+new version. Persisted data, protocol messages, or configuration files that contain
+the removed value will be misinterpreted.
+
+## Consumer impact
+
+```c
+/* consumer compiled against v1 */
+enum Status s = FOO;  /* s = 2 */
+write_to_file(s);
+
+/* later, same consumer reads back value 2 with v2 library */
+/* library has no FOO — value 2 is undefined behavior */
+```
+
+## Mitigation
+
+- Never remove released enum members; mark them as deprecated instead.
+- Map legacy values deliberately in deserialization/protocol handling.
+- Use explicit sentinel values (e.g., `STATUS_MAX`) to define valid ranges.
+
+## Code diff
+
+```diff
+-enum Status { OK = 0, ERROR = 1, FOO = 2 };
++enum Status { OK = 0, ERROR = 1 };
+```

--- a/examples/case20_enum_member_value_changed/README.md
+++ b/examples/case20_enum_member_value_changed/README.md
@@ -1,0 +1,45 @@
+# Case 20 — Enum Member Value Changed
+
+**abicheck verdict: BREAKING**
+
+## What changes
+
+| Version | Definition |
+|---------|-----------|
+| v1 | `enum ErrorCode { OK = 0, ERROR = 1 };` |
+| v2 | `enum ErrorCode { OK = 0, ERROR = 99 };` |
+
+## What breaks at binary level
+
+Changing the numeric value of an enum member is a **semantic ABI break**. Existing
+binaries were compiled with `ERROR = 1` and will pass, store, and compare that value.
+The new library interprets `ERROR` as `99` — the same symbolic name now maps to a
+different integer.
+
+This is effectively a protocol rewrite without version negotiation. Components built
+against different versions will exchange the same integer and interpret it with
+opposite semantics.
+
+## Consumer impact
+
+```c
+/* consumer compiled against v1 */
+if (result == ERROR) { /* ERROR = 1 */ }
+
+/* with v2 library, ERROR = 99 */
+/* consumer checks for value 1, library returns 99 */
+/* error condition is silently missed */
+```
+
+## Mitigation
+
+- Never reassign released enum numeric values.
+- Append new constants instead of renumbering.
+- Introduce explicit protocol versioning for cross-version communication.
+
+## Code diff
+
+```diff
+-enum ErrorCode { OK = 0, ERROR = 1 };
++enum ErrorCode { OK = 0, ERROR = 99 };
+```

--- a/examples/case21_method_became_static/README.md
+++ b/examples/case21_method_became_static/README.md
@@ -1,0 +1,51 @@
+# Case 21 — Method Became Static
+
+**abicheck verdict: BREAKING**
+
+## What changes
+
+| Version | Declaration |
+|---------|-----------|
+| v1 | `class Widget { void bar(); };` |
+| v2 | `class Widget { static void bar(); };` |
+
+## What breaks at binary level
+
+In the Itanium C++ ABI, static and instance methods have different calling conventions.
+An instance method receives an implicit `this` pointer as the first argument; a static
+method does not. Changing a method from instance to static (or vice versa) changes:
+
+1. **The mangled symbol name** — callers compiled against v1 look up one symbol; v2
+   exports a different one.
+2. **The calling convention** — even if the symbol somehow resolved, the argument
+   positions in registers/stack would be wrong.
+
+This is a **hard ABI break**: existing binaries fail to bind or invoke the function
+correctly.
+
+## Consumer impact
+
+```cpp
+/* consumer compiled against v1 */
+Widget w;
+w.bar();  /* emits call with implicit 'this' pointer */
+
+/* with v2: Widget::bar() is static — no 'this' expected */
+/* call convention mismatch → undefined behavior or crash */
+```
+
+## Mitigation
+
+- Add the static helper under a new name; preserve the old member method.
+- If migration is needed, deprecate the old method and provide both during a
+  transition period.
+
+## Code diff
+
+```diff
+ class Widget {
+ public:
+-    void bar();
++    static void bar();
+ };
+```

--- a/examples/case22_method_const_changed/README.md
+++ b/examples/case22_method_const_changed/README.md
@@ -1,0 +1,48 @@
+# Case 22 — Method Const Qualifier Changed
+
+**abicheck verdict: BREAKING**
+
+## What changes
+
+| Version | Declaration |
+|---------|-----------|
+| v1 | `class Widget { void get() const; };` |
+| v2 | `class Widget { void get(); };` |
+
+## What breaks at binary level
+
+In the Itanium C++ ABI, `const` qualification on a member function is part of the
+mangled symbol name:
+
+- `Widget::get() const` → `_ZNK6Widget3getEv` (note the `K` for const)
+- `Widget::get()`       → `_ZN6Widget3getEv`
+
+Removing (or adding) `const` produces a **different mangled name**. Existing binaries
+compiled against v1 import `_ZNK6Widget3getEv`, but v2 only exports `_ZN6Widget3getEv`.
+The dynamic linker cannot resolve the symbol → **unresolved symbol error at load time**.
+
+## Consumer impact
+
+```cpp
+/* consumer compiled against v1 */
+const Widget& w = get_widget();
+w.get();  /* calls _ZNK6Widget3getEv */
+
+/* v2 library exports _ZN6Widget3getEv (non-const) */
+/* → undefined symbol: _ZNK6Widget3getEv */
+```
+
+## Mitigation
+
+- Keep the old const-qualified method and add a non-const overload if needed.
+- Provide both signatures during a transition period.
+
+## Code diff
+
+```diff
+ class Widget {
+ public:
+-    void get() const;
++    void get();
+ };
+```

--- a/examples/case23_pure_virtual_added/README.md
+++ b/examples/case23_pure_virtual_added/README.md
@@ -11,16 +11,19 @@
 
 ## What breaks at binary level
 
-Making a virtual method pure (`= 0`) has two ABI consequences:
+Making `Processor::process()` pure virtual (`= 0`) has two ABI consequences:
 
-1. **The class becomes abstract** — existing code that directly instantiates
-   `Processor` objects (e.g., `new Processor()`) will fail. While this is primarily
-   a compile-time issue, it breaks binary compatibility for plugins or modules that
-   were compiled to instantiate the class directly.
+1. **The vtable entry for `process()` is replaced** — the slot that previously
+   pointed to `Processor`'s concrete implementation of `process()` now points to
+   the pure-call handler (`__cxa_pure_virtual`). Already-compiled consumers that
+   invoke `process()` through a `Processor*` vtable dispatch will hit the pure-call
+   handler at runtime, causing `std::terminate` instead of calling the old base
+   implementation.
 
-2. **vtable layout changes** — the vtable entry for `process()` becomes a pure-call
-   stub (typically `__cxa_pure_virtual`). If existing compiled code calls through the
-   vtable, it hits the pure-call handler instead of the concrete implementation.
+2. **`Processor` becomes abstract** — source-level rebuilds will fail to compile
+   `new Processor()` (abstract class cannot be instantiated). For already-compiled
+   binaries this is not the direct failure mode; the runtime break comes from point 1
+   above (dispatch to the pure-call handler via the vtable slot).
 
 ## Consumer impact
 

--- a/examples/case23_pure_virtual_added/README.md
+++ b/examples/case23_pure_virtual_added/README.md
@@ -1,0 +1,62 @@
+# Case 23 — Virtual Method Became Pure Virtual
+
+**abicheck verdict: BREAKING**
+
+## What changes
+
+| Version | Declaration |
+|---------|-----------|
+| v1 | `class Processor { virtual void process(); };` |
+| v2 | `class Processor { virtual void process() = 0; };` |
+
+## What breaks at binary level
+
+Making a virtual method pure (`= 0`) has two ABI consequences:
+
+1. **The class becomes abstract** — existing code that directly instantiates
+   `Processor` objects (e.g., `new Processor()`) will fail. While this is primarily
+   a compile-time issue, it breaks binary compatibility for plugins or modules that
+   were compiled to instantiate the class directly.
+
+2. **vtable layout changes** — the vtable entry for `process()` becomes a pure-call
+   stub (typically `__cxa_pure_virtual`). If existing compiled code calls through the
+   vtable, it hits the pure-call handler instead of the concrete implementation.
+
+## Consumer impact
+
+```cpp
+/* consumer compiled against v1 (concrete class) */
+Processor* p = new Processor();
+p->process();  /* calls concrete implementation */
+
+/* with v2: Processor is abstract */
+/* vtable slot points to __cxa_pure_virtual */
+/* → runtime abort: "pure virtual method called" */
+```
+
+For plugin architectures where downstream code `extends` the interface:
+
+```cpp
+/* old plugin implements only process() */
+struct MyPlugin : Processor {
+    void process() override;
+};
+/* this still works — but any new pure virtual methods
+   added to Processor would break existing plugins */
+```
+
+## Mitigation
+
+- Create `Processor2` (or `IProcessor`) as the new abstract interface.
+- Keep the original `Processor` class frozen for existing consumers.
+- Version plugin interfaces explicitly.
+
+## Code diff
+
+```diff
+ class Processor {
+ public:
+-    virtual void process();
++    virtual void process() = 0;
+ };
+```

--- a/examples/case24_union_field_removed/README.md
+++ b/examples/case24_union_field_removed/README.md
@@ -1,0 +1,53 @@
+# Case 24 — Union Field Removed
+
+**abicheck verdict: BREAKING**
+
+## What changes
+
+| Version | Definition |
+|---------|-----------|
+| v1 | `union Data { int i; float f; };` |
+| v2 | `union Data { int i; };` |
+
+## What breaks at binary level
+
+Removing a union field removes a supported representation of the shared storage.
+While the remaining field (`int i`) is still at offset 0 and accessible, any code
+that was compiled to use the `float f` variant is now accessing an undefined member.
+
+If the removal also reduces the union's size (e.g., removing a `double` field from
+a union of `int` and `double`), existing code that allocates `sizeof(union Data)` with
+the old size will over-allocate (harmless) or under-allocate if the field was the
+largest member (harmful — but this is caught by `TYPE_SIZE_CHANGED`).
+
+The semantic break is the main concern: the removed field was part of the type's
+public contract, and consumers relied on it as a valid interpretation.
+
+**Note:** Adding a union field is classified as **COMPATIBLE** because all fields
+share offset 0 and existing fields are unaffected. Size increases are caught
+separately.
+
+## Consumer impact
+
+```c
+/* consumer compiled against v1 */
+union Data d;
+d.f = 3.14f;   /* valid in v1 */
+lib_consume(d); /* library no longer expects float variant */
+
+/* v2: 'f' field doesn't exist — semantic mismatch */
+```
+
+## Mitigation
+
+- Keep union variants stable across ABI-compatible releases.
+- Introduce versioned replacement types (e.g., `DataV2`) when the union contract
+  must change.
+- Use tagged unions with explicit discriminators to manage variant evolution.
+
+## Code diff
+
+```diff
+-union Data { int i; float f; };
++union Data { int i; };
+```

--- a/examples/case25_enum_member_added/Makefile
+++ b/examples/case25_enum_member_added/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case25: enum member added (COMPATIBLE)"

--- a/examples/case25_enum_member_added/README.md
+++ b/examples/case25_enum_member_added/README.md
@@ -1,0 +1,48 @@
+# Case 25 — Enum Member Added
+
+**abicheck verdict: COMPATIBLE (informational/warning)**
+
+## What changes
+
+| Version | Definition |
+|---------|-----------|
+| v1 | `enum Color { RED = 0, GREEN = 1, BLUE = 2 };` |
+| v2 | `enum Color { RED = 0, GREEN = 1, BLUE = 2, YELLOW = 3 };` |
+
+## Why this is NOT a binary ABI break
+
+Adding a new enum member at the end does **not** change the numeric values of existing
+members. Already-compiled binaries continue to pass and receive `RED = 0`, `GREEN = 1`,
+`BLUE = 2` — all unchanged.
+
+abicheck classifies this as **COMPATIBLE** because:
+- No existing enum values are shifted or reassigned.
+- No symbol resolution, type layout, or calling convention change occurs.
+- The binary representation of existing values is identical.
+
+**Important:** If adding a member *shifts* existing values (e.g., inserting in the
+middle without explicit values), that causes `ENUM_MEMBER_VALUE_CHANGED` which IS
+classified as BREAKING.
+
+## What it does affect (source-level concerns)
+
+- **Switch statements**: code compiled against v1 may not handle `YELLOW`. The
+  default branch (if any) will execute. This is a source-level correctness concern,
+  not a binary compatibility issue.
+- **Sentinel patterns**: if `BLUE` was used as `COLOR_COUNT` or `COLOR_MAX`, adding
+  `YELLOW` changes the count semantics. This is also a source-level design concern.
+
+## Contrast with BREAKING enum changes
+
+| Change | Verdict | Why |
+|---|---|---|
+| Member **added** (values unchanged) | COMPATIBLE | Existing values stable |
+| Member **removed** | BREAKING | Existing code references invalid value |
+| Member **value changed** | BREAKING | Same name maps to different integer |
+
+## Code diff
+
+```diff
+-enum Color { RED = 0, GREEN = 1, BLUE = 2 };
++enum Color { RED = 0, GREEN = 1, BLUE = 2, YELLOW = 3 };
+```

--- a/examples/case25_enum_member_added/new/lib.h
+++ b/examples/case25_enum_member_added/new/lib.h
@@ -1,0 +1,1 @@
+enum Color { RED = 0, GREEN = 1, BLUE = 2, YELLOW = 3 };

--- a/examples/case25_enum_member_added/old/lib.h
+++ b/examples/case25_enum_member_added/old/lib.h
@@ -1,0 +1,1 @@
+enum Color { RED = 0, GREEN = 1, BLUE = 2 };

--- a/examples/case26_union_field_added/Makefile
+++ b/examples/case26_union_field_added/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case26: union field added (COMPATIBLE)"

--- a/examples/case26_union_field_added/README.md
+++ b/examples/case26_union_field_added/README.md
@@ -1,0 +1,50 @@
+# Case 26 — Union Field Added
+
+**abicheck verdict: COMPATIBLE (informational/warning)**
+
+## What changes
+
+| Version | Definition |
+|---------|-----------|
+| v1 | `union Value { int i; float f; };` |
+| v2 | `union Value { int i; float f; double d; };` |
+
+## Why this is NOT a binary ABI break
+
+All union fields share offset 0. Adding a new field (`double d`) does not change
+how existing fields (`int i`, `float f`) are accessed — their offset and
+interpretation remain identical.
+
+abicheck classifies this as **COMPATIBLE** because:
+- Existing fields are unaffected (all at offset 0).
+- No symbol resolution or calling convention change occurs.
+- If the new field increases the union's overall size (e.g., `sizeof(double) > sizeof(float)`),
+  that size change is caught separately by `TYPE_SIZE_CHANGED` (which IS breaking).
+
+## What it does affect
+
+- **Union size**: if the new field is the largest member, `sizeof(union Value)`
+  increases. This is a genuine ABI concern but is detected as a separate
+  `TYPE_SIZE_CHANGED` check.
+- **Semantic contract**: new code paths may use the `double d` variant. Old consumers
+  that interpret the raw storage differently are unaffected as long as they only
+  access their known fields.
+
+## Contrast with BREAKING union changes
+
+| Change | Verdict | Why |
+|---|---|---|
+| Field **added** | COMPATIBLE | Existing fields at offset 0 unchanged |
+| Field **removed** | BREAKING | Removes a valid representation |
+| Field **type changed** | BREAKING | Reinterpretation of shared storage |
+| Size changed (from field addition) | BREAKING | Caught separately by TYPE_SIZE_CHANGED |
+
+## Code diff
+
+```diff
+ union Value {
+     int i;
+     float f;
++    double d;
+ };
+```

--- a/examples/case26_union_field_added/new/lib.h
+++ b/examples/case26_union_field_added/new/lib.h
@@ -1,0 +1,5 @@
+union Value {
+    int i;
+    float f;
+    double d;
+};

--- a/examples/case26_union_field_added/old/lib.h
+++ b/examples/case26_union_field_added/old/lib.h
@@ -1,0 +1,4 @@
+union Value {
+    int i;
+    float f;
+};

--- a/examples/case27_symbol_binding_weakened/Makefile
+++ b/examples/case27_symbol_binding_weakened/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case27: symbol binding weakened GLOBAL→WEAK (COMPATIBLE)"

--- a/examples/case27_symbol_binding_weakened/README.md
+++ b/examples/case27_symbol_binding_weakened/README.md
@@ -1,0 +1,48 @@
+# Case 27 — Symbol Binding Weakened (GLOBAL → WEAK)
+
+**abicheck verdict: COMPATIBLE (informational/warning)**
+
+## What changes
+
+| Version | ELF binding |
+|---------|------------|
+| v1 | `foo: GLOBAL DEFAULT` |
+| v2 | `foo: WEAK DEFAULT` |
+
+This typically happens when a library applies `__attribute__((weak))` to a previously
+strong (GLOBAL) symbol, or when a linker script changes binding.
+
+## Why this is NOT a binary ABI break
+
+A WEAK symbol is still **exported and resolvable** by the dynamic linker. Existing
+binaries that linked against the GLOBAL version of `foo` will find and use the
+(now WEAK) symbol without any change in behavior.
+
+abicheck classifies this as **COMPATIBLE** because:
+- The symbol is still present in `.dynsym` and resolvable.
+- No calling convention, type layout, or signature change occurs.
+- The dynamic linker resolves WEAK symbols the same way as GLOBAL when no
+  override is present.
+
+## What it does affect
+
+- **Symbol interposition**: a WEAK symbol can be overridden by a GLOBAL definition
+  from another shared object or the main executable. If the consumer's environment
+  provides an alternative definition, the WEAK version may not be used.
+- **Linker behavior**: some linkers treat WEAK symbols differently during static
+  linking (e.g., not pulling the object file from an archive).
+
+These are deployment/interposition concerns, not binary compatibility failures.
+
+## Contrast with BREAKING binding changes
+
+The reverse direction — WEAK → GLOBAL (`SYMBOL_BINDING_STRENGTHENED`) — is also
+classified as COMPATIBLE. Neither direction breaks existing symbol resolution.
+
+## Code diff
+
+```diff
+ /* v1: normal definition */
+-int foo(void) { return 42; }
++__attribute__((weak)) int foo(void) { return 42; }
+```

--- a/examples/case27_symbol_binding_weakened/new/lib.h
+++ b/examples/case27_symbol_binding_weakened/new/lib.h
@@ -1,0 +1,2 @@
+/* Symbol 'foo' is WEAK binding in v2 .so (e.g. via __attribute__((weak))) */
+int foo(void);

--- a/examples/case27_symbol_binding_weakened/old/lib.h
+++ b/examples/case27_symbol_binding_weakened/old/lib.h
@@ -1,0 +1,2 @@
+/* Symbol 'foo' is GLOBAL binding in v1 .so */
+int foo(void);

--- a/examples/case29_ifunc_transition/Makefile
+++ b/examples/case29_ifunc_transition/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	@echo "case29: IFUNC transition (COMPATIBLE)"

--- a/examples/case29_ifunc_transition/README.md
+++ b/examples/case29_ifunc_transition/README.md
@@ -1,0 +1,59 @@
+# Case 29 — GNU IFUNC Transition
+
+**abicheck verdict: COMPATIBLE (informational/warning)**
+
+## What changes
+
+| Version | ELF symbol type |
+|---------|----------------|
+| v1 | `dispatch: STT_FUNC` (regular function) |
+| v2 | `dispatch: STT_GNU_IFUNC` (indirect function) |
+
+## What is GNU IFUNC?
+
+GNU IFUNC (indirect function) is a mechanism for runtime CPU dispatch. Instead of
+pointing directly to the function body, the symbol points to a **resolver function**
+that returns the address of the best implementation for the current CPU. The dynamic
+linker calls the resolver at load time and patches the GOT entry.
+
+Common uses:
+- glibc's `memcpy`, `strlen`, etc. use IFUNC to select SSE/AVX/NEON implementations.
+- Math libraries dispatch to architecture-specific code paths.
+
+## Why this is NOT a binary ABI break
+
+The transition from regular function to IFUNC (or back) is **transparent to callers**.
+The PLT/GOT mechanism handles the indirection automatically:
+
+1. Caller calls `dispatch()` through the PLT (same as before).
+2. Dynamic linker resolves the symbol — if IFUNC, calls the resolver first.
+3. GOT entry is patched with the final function address.
+4. All subsequent calls go directly to the resolved address.
+
+abicheck classifies this as **COMPATIBLE** because:
+- The calling convention is unchanged.
+- The function signature is unchanged.
+- Symbol resolution succeeds transparently.
+- This is purely an implementation optimization.
+
+## What it does affect
+
+- **Debugger behavior**: breakpoints on IFUNC symbols may behave differently
+  (breakpoint hits the resolver on first call, then the resolved implementation).
+- **Static analysis tools**: may not recognize the indirection.
+- **Older dynamic linkers**: very old ld.so versions may not support IFUNC
+  (but this is a deployment concern, not an ABI contract issue).
+
+## Code diff
+
+```diff
+-int dispatch(int x) { return x * 2; }
++static int dispatch_generic(int x) { return x * 2; }
++static int dispatch_avx(int x) { /* AVX implementation */ return x * 2; }
++
++/* IFUNC resolver — called by dynamic linker at load time */
++int dispatch(int x) __attribute__((ifunc("resolve_dispatch")));
++static void *resolve_dispatch(void) {
++    return has_avx() ? (void*)dispatch_avx : (void*)dispatch_generic;
++}
+```

--- a/examples/case29_ifunc_transition/new/lib.h
+++ b/examples/case29_ifunc_transition/new/lib.h
@@ -1,0 +1,3 @@
+/* dispatch() is now a GNU IFUNC (STT_GNU_IFUNC) in v2 */
+/* The resolver picks the best implementation at load time */
+int dispatch(int x);

--- a/examples/case29_ifunc_transition/old/lib.h
+++ b/examples/case29_ifunc_transition/old/lib.h
@@ -1,0 +1,2 @@
+/* dispatch() is a regular function (STT_FUNC) in v1 */
+int dispatch(int x);

--- a/tests/test_changekind_coverage.py
+++ b/tests/test_changekind_coverage.py
@@ -444,7 +444,7 @@ class TestTypeVisibilityChanged:
 
         adv = _minimal_adv()
         r = compare(_snap(dwarf_advanced=adv), _snap("2.0", dwarf_advanced=adv))
-        assert r.verdict == Verdict.COMPATIBLE
+        assert r.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.TYPE_VISIBILITY_CHANGED for c in r.changes), (
             "Expected TYPE_VISIBILITY_CHANGED in changes"
         )

--- a/tests/test_changekind_coverage.py
+++ b/tests/test_changekind_coverage.py
@@ -444,7 +444,7 @@ class TestTypeVisibilityChanged:
 
         adv = _minimal_adv()
         r = compare(_snap(dwarf_advanced=adv), _snap("2.0", dwarf_advanced=adv))
-        assert r.verdict == Verdict.BREAKING
+        assert r.verdict == Verdict.COMPATIBLE
         assert any(c.kind == ChangeKind.TYPE_VISIBILITY_CHANGED for c in r.changes), (
             "Expected TYPE_VISIBILITY_CHANGED in changes"
         )

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -124,18 +124,18 @@ class TestParameterChanges:
 # ── noexcept specifier ────────────────────────────────────────────────────────
 
 class TestNoexcept:
-    def test_noexcept_removed_is_breaking(self):
+    def test_noexcept_removed_is_compatible(self):
         old_f = _pub_func("move", "_Z4movev", noexcept=True)
         new_f = _pub_func("move", "_Z4movev", noexcept=False)
         r = compare(_snap("1.0", [old_f]), _snap("2.0", [new_f]))
-        assert r.verdict == Verdict.BREAKING
+        assert r.verdict == Verdict.COMPATIBLE
         assert any(c.kind == ChangeKind.FUNC_NOEXCEPT_REMOVED for c in r.changes)
 
-    def test_noexcept_added_is_breaking(self):  # C++17 P0012R1
+    def test_noexcept_added_is_compatible(self):
         old_f = _pub_func("swap", "_Z4swapv", noexcept=False)
         new_f = _pub_func("swap", "_Z4swapv", noexcept=True)
         r = compare(_snap("1.0", [old_f]), _snap("2.0", [new_f]))
-        assert r.verdict == Verdict.BREAKING
+        assert r.verdict == Verdict.COMPATIBLE
         assert any(c.kind == ChangeKind.FUNC_NOEXCEPT_ADDED for c in r.changes)
 
 
@@ -272,12 +272,12 @@ class TestVerdictPriority:
         r = compare(old, new)
         assert r.verdict == Verdict.BREAKING
 
-    def test_noexcept_added_overrides_compatible(self):
-        """noexcept added (source_break) + new func (compatible) = SOURCE_BREAK."""
+    def test_noexcept_added_stays_compatible(self):
+        """noexcept added (compatible) + new func (compatible) = COMPATIBLE."""
         f_noexcept = _pub_func("swap", "_Z4swapv", noexcept=False)
         f_new = _pub_func("swap", "_Z4swapv", noexcept=True)
         f_added = _pub_func("reset", "_Z5resetv")
         old = _snap("1.0", functions=[f_noexcept])
         new = _snap("1.1", functions=[f_new, f_added])
         r = compare(old, new)
-        assert r.verdict == Verdict.BREAKING
+        assert r.verdict == Verdict.COMPATIBLE

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -50,12 +50,12 @@ class TestMarkdownReporter:
         assert "COMPATIBLE" in md
         assert "Compatible Additions" in md
 
-    def test_noexcept_added_in_breaking_section(self):
+    def test_noexcept_added_in_compatible_section(self):
         c = Change(ChangeKind.FUNC_NOEXCEPT_ADDED, "_Z4swapv",
                    "noexcept specifier added: swap")
-        md = to_markdown(_result(Verdict.BREAKING, [c]))
-        assert "BREAKING" in md
-        assert "Breaking Changes" in md
+        md = to_markdown(_result(Verdict.COMPATIBLE, [c]))
+        assert "COMPATIBLE" in md
+        assert "Compatible Additions" in md
 
     def test_legend_always_present(self):
         md = to_markdown(_result(Verdict.NO_CHANGE))

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -4,7 +4,7 @@ All tests build AbiSnapshot objects directly (no castxml required).
 """
 from __future__ import annotations
 
-from abicheck.checker import ChangeKind, compare
+from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.model import (
     AbiSnapshot,
     EnumMember,
@@ -57,6 +57,7 @@ def test_enum_member_added() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.ENUM_MEMBER_ADDED in kinds
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +140,7 @@ def test_union_field_added() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.UNION_FIELD_ADDED in kinds
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 def test_union_field_type_changed() -> None:

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -191,14 +191,12 @@ def test_sprint1_all_breaking() -> None:
     from abicheck.checker import _BREAKING_KINDS
     sprint1_kinds = {
         ChangeKind.ENUM_MEMBER_REMOVED,
-        ChangeKind.ENUM_MEMBER_ADDED,
         ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
         ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
         ChangeKind.FUNC_STATIC_CHANGED,
         ChangeKind.FUNC_CV_CHANGED,
         ChangeKind.FUNC_PURE_VIRTUAL_ADDED,
         ChangeKind.FUNC_VIRTUAL_BECAME_PURE,
-        ChangeKind.UNION_FIELD_ADDED,
         ChangeKind.UNION_FIELD_REMOVED,
         ChangeKind.UNION_FIELD_TYPE_CHANGED,
         ChangeKind.TYPEDEF_BASE_CHANGED,

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -94,13 +94,13 @@ def test_symbol_version_defined_removed() -> None:
 
 
 def test_symbol_version_required_added() -> None:
-    """New GLIBC_2.34 requirement = breaks on older distros."""
+    """New GLIBC_2.34 requirement = deployment concern, not ABI break."""
     old = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]}))
     new = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]}))
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED in kinds
-    assert result.verdict == Verdict.BREAKING
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 def test_symbol_version_required_removed() -> None:
@@ -121,7 +121,7 @@ def test_symbol_binding_global_to_weak() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.SYMBOL_BINDING_CHANGED in kinds
-    assert result.verdict == Verdict.BREAKING
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 def test_symbol_type_func_to_object() -> None:
@@ -138,7 +138,7 @@ def test_ifunc_introduced() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.IFUNC_INTRODUCED in kinds
-    assert result.verdict == Verdict.BREAKING
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 def test_ifunc_removed() -> None:
@@ -147,7 +147,7 @@ def test_ifunc_removed() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.IFUNC_REMOVED in kinds
-    assert result.verdict == Verdict.BREAKING
+    assert result.verdict == Verdict.COMPATIBLE
 
 
 def test_symbol_size_changed() -> None:
@@ -256,23 +256,16 @@ def test_versions_required_entire_lib_removed() -> None:
 # ---------------------------------------------------------------------------
 
 def test_elf_breaking_kinds_verdict() -> None:
-    """All BREAKING ELF kinds produce BREAKING verdict."""
+    """ELF kinds that are truly BREAKING produce BREAKING verdict."""
     breaking_cases = [
         _snap(_elf(soname="libfoo.so.1")),     # SONAME_CHANGED
-        # NEEDED_ADDED is now COMPATIBLE, removed from breaking_cases
         _snap(_elf(versions_defined=["V1"])),   # SYMBOL_VERSION_DEFINED_REMOVED
-        _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]})),  # VER_REQ_ADDED
-        _snap(_elf(symbols=[_sym("f", binding=SymbolBinding.GLOBAL)])),  # BINDING_CHANGED
         _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.FUNC)])),  # TYPE_CHANGED
-        _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.IFUNC)])),  # IFUNC_INTRODUCED
     ]
     new_cases = [
         _snap(_elf(soname="libfoo.so.2")),
         _snap(_elf(versions_defined=[])),
-        _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]})),
-        _snap(_elf(symbols=[_sym("f", binding=SymbolBinding.WEAK)])),
         _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.OBJECT)])),
-        _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.FUNC)])),
     ]
     for old, new in zip(breaking_cases, new_cases):
         result = compare(old, new)

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -94,13 +94,13 @@ def test_symbol_version_defined_removed() -> None:
 
 
 def test_symbol_version_required_added() -> None:
-    """New GLIBC_2.34 requirement = deployment concern, not ABI break."""
+    """New GLIBC_2.34 requirement = breaks on older runtimes."""
     old = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]}))
     new = _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]}))
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED in kinds
-    assert result.verdict == Verdict.COMPATIBLE
+    assert result.verdict == Verdict.BREAKING
 
 
 def test_symbol_version_required_removed() -> None:
@@ -256,15 +256,17 @@ def test_versions_required_entire_lib_removed() -> None:
 # ---------------------------------------------------------------------------
 
 def test_elf_breaking_kinds_verdict() -> None:
-    """ELF kinds that are truly BREAKING produce BREAKING verdict."""
+    """All BREAKING ELF kinds produce BREAKING verdict."""
     breaking_cases = [
         _snap(_elf(soname="libfoo.so.1")),     # SONAME_CHANGED
         _snap(_elf(versions_defined=["V1"])),   # SYMBOL_VERSION_DEFINED_REMOVED
+        _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5"]})),  # VER_REQ_ADDED
         _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.FUNC)])),  # TYPE_CHANGED
     ]
     new_cases = [
         _snap(_elf(soname="libfoo.so.2")),
         _snap(_elf(versions_defined=[])),
+        _snap(_elf(versions_required={"libc.so.6": ["GLIBC_2.5", "GLIBC_2.34"]})),
         _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.OBJECT)])),
     ]
     for old, new in zip(breaking_cases, new_cases):

--- a/tests/test_sprint2_gap_detectors.py
+++ b/tests/test_sprint2_gap_detectors.py
@@ -100,12 +100,12 @@ class TestFuncDeleted:
 # ── VAR_BECAME_CONST ─────────────────────────────────────────────────────────
 
 class TestVarBecameConst:
-    def test_var_became_const_is_compatible(self):
+    def test_var_became_const_is_breaking(self):
         old = _snap(variables=[_var("g_buf", "_g_buf", is_const=False)])
         new = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
         result = compare(old, new)
         assert ChangeKind.VAR_BECAME_CONST in _kinds(result)
-        assert result.verdict == Verdict.COMPATIBLE
+        assert result.verdict == Verdict.BREAKING
 
     def test_var_already_const_no_change(self):
         old = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
@@ -123,12 +123,12 @@ class TestVarBecameConst:
 # ── VAR_LOST_CONST ───────────────────────────────────────────────────────────
 
 class TestVarLostConst:
-    def test_var_lost_const_is_compatible(self):
+    def test_var_lost_const_is_breaking(self):
         old = _snap(variables=[_var("g_limit", "_g_limit", is_const=True)])
         new = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])
         result = compare(old, new)
         assert ChangeKind.VAR_LOST_CONST in _kinds(result)
-        assert result.verdict == Verdict.COMPATIBLE
+        assert result.verdict == Verdict.BREAKING
 
     def test_var_already_non_const_no_change(self):
         old = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])

--- a/tests/test_sprint2_gap_detectors.py
+++ b/tests/test_sprint2_gap_detectors.py
@@ -100,12 +100,12 @@ class TestFuncDeleted:
 # ── VAR_BECAME_CONST ─────────────────────────────────────────────────────────
 
 class TestVarBecameConst:
-    def test_var_became_const_is_breaking(self):
+    def test_var_became_const_is_compatible(self):
         old = _snap(variables=[_var("g_buf", "_g_buf", is_const=False)])
         new = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
         result = compare(old, new)
         assert ChangeKind.VAR_BECAME_CONST in _kinds(result)
-        assert result.verdict == Verdict.BREAKING
+        assert result.verdict == Verdict.COMPATIBLE
 
     def test_var_already_const_no_change(self):
         old = _snap(variables=[_var("g_buf", "_g_buf", is_const=True)])
@@ -123,12 +123,12 @@ class TestVarBecameConst:
 # ── VAR_LOST_CONST ───────────────────────────────────────────────────────────
 
 class TestVarLostConst:
-    def test_var_lost_const_is_breaking(self):
+    def test_var_lost_const_is_compatible(self):
         old = _snap(variables=[_var("g_limit", "_g_limit", is_const=True)])
         new = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])
         result = compare(old, new)
         assert ChangeKind.VAR_LOST_CONST in _kinds(result)
-        assert result.verdict == Verdict.BREAKING
+        assert result.verdict == Verdict.COMPATIBLE
 
     def test_var_already_non_const_no_change(self):
         old = _snap(variables=[_var("g_limit", "_g_limit", is_const=False)])


### PR DESCRIPTION
## Summary

This PR reclassifies several categories of changes from BREAKING to COMPATIBLE verdicts based on deeper analysis of binary ABI compatibility:

1. **noexcept specifier changes** — Itanium ABI mangling does not change; existing binaries resolve the same symbol
2. **Enum member addition** — Existing compiled enum values are unchanged; new enumerators don't shift others
3. **Union field addition** — All fields start at offset 0; existing fields are unaffected
4. **ELF symbol metadata changes** — Several ELF-level changes that don't affect dynamic linking or symbol resolution

## Key Changes

- **Moved from BREAKING to COMPATIBLE in `_BREAKING_KINDS`:**
  - `FUNC_NOEXCEPT_ADDED` and `FUNC_NOEXCEPT_REMOVED` — C++17 function-pointer type system concern, not binary ABI
  - `ENUM_MEMBER_ADDED` — Value shifts are caught separately by `ENUM_MEMBER_VALUE_CHANGED`
  - `UNION_FIELD_ADDED` — Size increase (if any) is caught by `TYPE_SIZE_CHANGED`
  - `SYMBOL_BINDING_CHANGED` (GLOBAL→WEAK) — Symbol still exported and resolvable; interposition semantics change but existing binaries work
  - `SYMBOL_SIZE_CHANGED` — ELF st_size is metadata not used by dynamic linker for symbol resolution
  - `IFUNC_INTRODUCED` and `IFUNC_REMOVED` — Transparent to callers; PLT/GOT mechanism handles resolution
  - `SYMBOL_VERSION_REQUIRED_ADDED` — Affects deployment portability, not the library's exported ABI surface
  - `TYPE_VISIBILITY_CHANGED` — Niche RTTI cross-DSO concern, not general binary ABI break
  - `VAR_BECAME_CONST` and `VAR_LOST_CONST` — Symbol still resolves at same address/size; behavioral concern, not linkage

- **Updated test expectations** to reflect new COMPATIBLE verdicts for these change kinds
- **Added detailed comments** in `_BREAKING_KINDS` explaining the rationale for each reclassified change
- **Cleaned up HTML report configuration** to remove noexcept and reclassified ELF changes from breaking kinds list

## Implementation Details

- Changes are reorganized in `_BREAKING_KINDS` with grouped comments explaining the binary ABI rationale
- All affected tests updated to expect `COMPATIBLE` verdict instead of `BREAKING`
- Test descriptions updated to clarify the distinction between source-level concerns and binary ABI breaks

https://claude.ai/code/session_01SDCXhnZfmiFGkNZeoRZm5e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revised change classification: many change kinds (noexcept toggles, enum/union member additions, symbol binding/IFUNC/versioning, symbol size/visibility, version-required flags) now treated as COMPATIBLE; TYPE_VISIBILITY_CHANGED marked BREAKING; public change-kind list expanded.
* **Documentation**
  * Added/updated verdict-driven docs, examples, and README sections explaining BREAKING vs COMPATIBLE cases and mitigations.
* **Reporting**
  * Adjusted reporting/grouping and ordering for change categories in generated reports.
* **Tests**
  * Updated tests and expected verdicts/names to reflect the new classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->