### PR TITLE
Update ABI catalog and case documentation for v2 with 29 cases

### DIFF
--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -1,6 +1,6 @@
-# ABI Breaking Cases Catalog (v1)
+# ABI Breaking Cases Catalog (v2)
 
-This catalog summarizes breakage patterns covered by `examples/case01..case24`.
+This catalog summarizes breakage patterns covered by `examples/case01..case29`.
 For full code walkthroughs and deep per-case narrative, see
 [`docs/examples_breakage_guide.md`](examples_breakage_guide.md).
 
@@ -152,7 +152,30 @@ For full code walkthroughs and deep per-case narrative, see
     - Example: `examples/case20_enum_member_value_changed/`
     - Mitigation: never renumber released enum constants.
 
-## 7) Additional detected changes and verdicts
+## 7) Additional compatible/informational cases
+
+25. **case25_enum_member_added** — enum member appended at end.
+    - Risk: source-level only (switch statements may not handle new value).
+    - Type: **compatible** — existing compiled values are unchanged.
+    - Example: `examples/case25_enum_member_added/`
+    - Note: if adding shifts existing values, that is caught by `ENUM_MEMBER_VALUE_CHANGED`.
+
+26. **case26_union_field_added** — union field added.
+    - Risk: size increase if new field is largest (caught separately by `TYPE_SIZE_CHANGED`).
+    - Type: **compatible** — all union fields share offset 0; existing fields unaffected.
+    - Example: `examples/case26_union_field_added/`
+
+27. **case27_symbol_binding_weakened** — GLOBAL → WEAK symbol binding.
+    - Risk: interposition — WEAK symbol can be overridden by another GLOBAL definition.
+    - Type: **compatible** — symbol is still exported and resolvable.
+    - Example: `examples/case27_symbol_binding_weakened/`
+
+28. **case29_ifunc_transition** — regular function → GNU IFUNC.
+    - Risk: older dynamic linkers may not support IFUNC resolution.
+    - Type: **compatible** — PLT/GOT mechanism handles indirection transparently.
+    - Example: `examples/case29_ifunc_transition/`
+
+## 8) Additional detected changes and verdicts
 
 Beyond the core symbol/type/C++ checks above, abicheck detects a number of
 ELF-metadata, DWARF-diagnostic, and qualifier changes. Each is classified

--- a/docs/examples_breakage_guide.md
+++ b/docs/examples_breakage_guide.md
@@ -1,4 +1,4 @@
-# Full ABI/API breakage guide for `examples/case01..case24`
+# Full ABI/API breakage guide for `examples/case01..case29`
 
 This guide is intentionally verbose. Every case includes:
 
@@ -38,25 +38,25 @@ co-install or consciously migrate.
 
 ```c
 /* lib v1 */
-int parse_value(int x);
+double process(int a, int b);
 
 /* lib v2 */
-int parse_value(long x);
+double process(double a, int b);
 ```
 
 ```c
-/* consumer */
-extern int parse_value(int);
-int run(void) { return parse_value(42); }
+/* consumer (compiled against v1) */
+extern double process(int, int);
+double run(void) { return process(3, 4); }
 ```
 
-Parameter type changes alter the call contract. Even when both types are integral, ABI rules may differ
-in width/sign extension/register class on different targets. An old caller compiled for `int` can pass
-bits that the new callee interprets as `long`, leading to value corruption or undefined behavior. The
-symbol name might stay “the same” in C, but call semantics are not.
+Parameter type changes alter the call contract. On x86-64 SysV ABI, `int` is passed in an integer
+register (`%edi`) while `double` is passed in an SSE register (`%xmm0`). An old caller compiled for
+`int` puts the value in the wrong register class — the new callee reads uninitialized `%xmm0`,
+producing garbage. The symbol name stays the same in C, but call semantics are completely different.
 
-Safe evolution pattern: keep `parse_value(int)` and introduce `parse_value_v2(long)`. Route old API to
-new internals where possible, but preserve old symbol and signature for binary stability.
+Safe evolution pattern: keep `process(int, int)` and introduce `process_v2(double, int)`. Route old API
+to new internals where possible, but preserve old symbol and signature for binary stability.
 
 ## case03_compat_addition — additive symbol
 

--- a/docs/examples_breakage_guide.md
+++ b/docs/examples_breakage_guide.md
@@ -480,25 +480,28 @@ It may also alter overload behavior for rebuilt source consumers.
 
 Keep old method and add overload/new API variant.
 
-## case23_pure_virtual_added — interface contract expansion break
+## case23_pure_virtual_added — existing method made pure virtual
 
 ```cpp
 // v1
-struct IFace { virtual void run() = 0; };
+class Processor { virtual void process(); };
 
 // v2
-struct IFace { virtual void run() = 0; virtual void stop() = 0; };
+class Processor { virtual void process() = 0; };
 ```
 
 ```cpp
-// old plugin class implements only run()
-struct Plugin : IFace { void run() override; };
+// consumer compiled against v1 (concrete class)
+Processor* p = new Processor();
+p->process();  // calls concrete implementation
 ```
 
-Adding pure virtual methods changes required interface and vtable shape. Existing implementations are
-no longer complete for new base contract and can fail to instantiate or dispatch safely.
+Making an existing concrete virtual method pure virtual replaces the vtable entry for that method
+with the pure-call handler (`__cxa_pure_virtual`). Old binaries that call `process()` via vtable
+dispatch now hit the handler and abort. Additionally, `Processor` becomes abstract — source-level
+rebuilds fail to compile `new Processor()`.
 
-Create `IFace2` and keep original interface stable for existing plugins.
+Create `Processor2` as the new abstract interface and keep the original class frozen.
 
 ## case24_union_field_removed — representation set reduced
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,36 +30,36 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 
 ## Case Index
 
-| # | Case | Category | abidiff exit | Root cause |
-|---|------|----------|-------------|-----------|
-| [01](case01_symbol_removal/README.md) | Symbol Removal | Symbol API | 12 🔴 | Public function deleted from .so |
-| [02](case02_param_type_change/README.md) | Parameter Type Change | Symbol API | 4 🟡 | Param type widened, callers pass wrong register |
-| [03](case03_compat_addition/README.md) | Compatible Addition | Symbol API | 4 🟢 | New export added, existing callers unaffected |
-| [04](case04_no_change/README.md) | No Change | Symbol API | 0 ✅ | Identical binary — baseline |
-| [05](case05_soname/README.md) | Missing SONAME | ELF/Linker | — 🟡 | Library built without -Wl,-soname |
-| [06](case06_visibility/README.md) | Visibility Leak | Visibility | — 🟡 | Internal symbols unintentionally exported |
-| [07](case07_struct_layout/README.md) | Struct Layout Change | Type Layout | 4 🟡 | Field added, sizeof grows, callers undersize |
-| [08](case08_enum_value_change/README.md) | Enum Value Change | Type Layout | 4 🟡 | Value inserted mid-enum, existing constants shift |
-| [09](case09_cpp_vtable/README.md) | C++ Vtable Change | C++ ABI | 4 🟡 | Virtual method inserted, vtable offsets shift |
-| [10](case10_return_type/README.md) | Return Type Change | Symbol API | 4 🟡 | Return type widened, callers read truncated value |
-| [11](case11_global_var_type/README.md) | Global Variable Type | Type Layout | 4 🟡 | Global var type widened, symbol size changes |
-| [12](case12_function_removed/README.md) | Function Disappears | Symbol API | 12 🔴 | Function moved to inline, vanishes from .so |
-| [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | — 🟡 | No version script → no `@@VER` on symbols |
-| [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | 4 🟡 | Private member grows, sizeof(class) changes |
-| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | 0 ❌ | Source-level contract; mangling unchanged |
-| [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | — ⚠️ | ODR violation; symbol appears in v2 .so |
-| [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | 4 🟡 | Explicit-instantiated template grows in size |
-| [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | — ⚠️ | Third-party type in public header changes layout |
-| [19](case19_enum_member_removed/README.md) | Enum Member Removed | C API | 8 🔴 | Removing an enum value breaks stored/transmitted integers |
-| [20](case20_enum_member_value_changed/README.md) | Enum Value Changed | C API | 8 🔴 | Renumbering enum breaks all consumers using stored values |
-| [21](case21_method_became_static/README.md) | Method Became Static | C++ ABI | 8 🔴 | Calling convention mismatch — implicit `this` ignored |
-| [22](case22_method_const_changed/README.md) | const Qualifier Changed | C++ ABI | 8 🔴 | `_ZNK...` vs `_ZN...` — different mangled symbol name |
-| [23](case23_pure_virtual_added/README.md) | Pure Virtual Added | C++ ABI | 8 🔴 | Existing vtable slot hits `__cxa_pure_virtual` → abort |
-| [24](case24_union_field_removed/README.md) | Union Field Removed | C API | 8 🔴 | Field write interpreted as different type — silent wrong data |
-| [25](case25_enum_member_added/README.md) | Enum Member Added | C API | 4 🟡 | Adding at end is compatible; older binaries handle known values |
-| [26](case26_union_field_added/README.md) | Union Field Added | C API | 4 🟡 | Existing fields unaffected; size increase is separate concern |
-| [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened | ELF/Linker | 4 🟡 | WEAK symbol can be silently overridden by interposition |
-| [29](case29_ifunc_transition/README.md) | IFUNC Transition | ELF/Linker | 4 🟡 | GNU IFUNC resolves transparently; old `ld.so` may not support |
+| # | Case | Category | abicheck verdict | Root cause |
+|---|------|----------|-----------------|-----------|
+| [01](case01_symbol_removal/README.md) | Symbol Removal | Symbol API | BREAKING 🔴 | Public function deleted from .so |
+| [02](case02_param_type_change/README.md) | Parameter Type Change | Symbol API | BREAKING 🟡 | Param type widened, callers pass wrong register |
+| [03](case03_compat_addition/README.md) | Compatible Addition | Symbol API | COMPATIBLE 🟢 | New export added, existing callers unaffected |
+| [04](case04_no_change/README.md) | No Change | Symbol API | NO_CHANGE ✅ | Identical binary — baseline |
+| [05](case05_soname/README.md) | Missing SONAME | ELF/Linker | BAD PRACTICE 🟡 | Library built without -Wl,-soname |
+| [06](case06_visibility/README.md) | Visibility Leak | Visibility | BAD PRACTICE 🟡 | Internal symbols unintentionally exported |
+| [07](case07_struct_layout/README.md) | Struct Layout Change | Type Layout | BREAKING 🟡 | Field added, sizeof grows, callers undersize |
+| [08](case08_enum_value_change/README.md) | Enum Value Change | Type Layout | BREAKING 🟡 | Value inserted mid-enum, existing constants shift |
+| [09](case09_cpp_vtable/README.md) | C++ Vtable Change | C++ ABI | BREAKING 🟡 | Virtual method inserted, vtable offsets shift |
+| [10](case10_return_type/README.md) | Return Type Change | Symbol API | BREAKING 🟡 | Return type widened, callers read truncated value |
+| [11](case11_global_var_type/README.md) | Global Variable Type | Type Layout | BREAKING 🟡 | Global var type widened, symbol size changes |
+| [12](case12_function_removed/README.md) | Function Removed | Symbol API | BREAKING 🔴 | Function removed from .so, symbol unresolvable |
+| [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | INFORMATIONAL 🟡 | No version script → no `@@VER` on symbols |
+| [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | BREAKING 🟡 | Private member grows, sizeof(class) changes |
+| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | COMPATIBLE ❌ | Source-level contract; mangling unchanged |
+| [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | BREAKING ⚠️ | ODR violation; symbol appears in v2 .so |
+| [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | BREAKING 🟡 | Explicit-instantiated template grows in size |
+| [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | BREAKING ⚠️ | Third-party type in public header changes layout |
+| [19](case19_enum_member_removed/README.md) | Enum Member Removed | C API | BREAKING 🔴 | Removing an enum value breaks stored/transmitted integers |
+| [20](case20_enum_member_value_changed/README.md) | Enum Value Changed | C API | BREAKING 🔴 | Renumbering enum breaks all consumers using stored values |
+| [21](case21_method_became_static/README.md) | Method Became Static | C++ ABI | BREAKING 🔴 | Calling convention mismatch — implicit `this` ignored |
+| [22](case22_method_const_changed/README.md) | const Qualifier Changed | C++ ABI | BREAKING 🔴 | `_ZNK...` vs `_ZN...` — different mangled symbol name |
+| [23](case23_pure_virtual_added/README.md) | Pure Virtual Added | C++ ABI | BREAKING 🔴 | Existing vtable slot hits `__cxa_pure_virtual` → abort |
+| [24](case24_union_field_removed/README.md) | Union Field Removed | C API | BREAKING 🔴 | Field write interpreted as different type — silent wrong data |
+| [25](case25_enum_member_added/README.md) | Enum Member Added | C API | COMPATIBLE 🟡 | Adding at end is compatible; older binaries handle known values |
+| [26](case26_union_field_added/README.md) | Union Field Added | C API | COMPATIBLE 🟡 | Existing fields unaffected; size increase is separate concern |
+| [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened | ELF/Linker | COMPATIBLE 🟡 | WEAK symbol can be silently overridden by interposition |
+| [29](case29_ifunc_transition/README.md) | IFUNC Transition | ELF/Linker | COMPATIBLE 🟡 | GNU IFUNC resolves transparently; old `ld.so` may not support |
 
 ---
 

--- a/examples/case01_symbol_removal/README.md
+++ b/examples/case01_symbol_removal/README.md
@@ -3,9 +3,8 @@
 **Category:** Symbol API | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-Any downstream binary that calls `helper()` will fail to link (or crash at runtime
-with `undefined symbol`) after upgrading to v2. Statically-linked consumers that
-captured the old address will call garbage. Even if *you* no longer use `helper()`,
+Any downstream binary that dynamically links against `helper()` will fail at runtime
+with `undefined symbol` after upgrading to v2. Even if *you* no longer use `helper()`,
 removing it from the public `.so` is an ABI contract violation.
 
 ## Why abidiff catches it

--- a/examples/case01_symbol_removal/README.md
+++ b/examples/case01_symbol_removal/README.md
@@ -35,7 +35,7 @@ gcc -g app.c -L. -lfoo -Wl,-rpath,. -o app
 # Swap in new library (no recompile)
 gcc -shared -fPIC -g v2.c -o libfoo.so
 ./app
-# → ./app: symbol lookup error: ./libfoo.so: undefined symbol: helper
+# → ./app: symbol lookup error: ./app: undefined symbol: helper
 ```
 
 **Why CRITICAL:** `helper` is removed from the dynamic symbol table in v2; the runtime

--- a/examples/case07_struct_layout/README.md
+++ b/examples/case07_struct_layout/README.md
@@ -36,8 +36,9 @@ Never add fields to public structs. Use the opaque-pointer (PIMPL) idiom: expose
 is hidden from callers.
 
 ## Real-world example
-The Linux kernel uses opaque `struct task_struct*` for exactly this reason. Public
-kernel API headers expose only opaque handles; layout is internal.
+The C standard library's `FILE*` is a classic opaque handle — callers never see
+the struct layout; all access is through `fopen`/`fread`/`fclose`. This pattern
+keeps the ABI stable across libc versions even as the internal `FILE` struct changes.
 
 ## Real Failure Demo
 

--- a/examples/case09_cpp_vtable/README.md
+++ b/examples/case09_cpp_vtable/README.md
@@ -7,7 +7,7 @@
 > `"note that this is an ABI incompatible change to the vtable of class Widget"`.
 
 ## What breaks
-The vtable is a hidden array of function pointers embedded in every `Widget` object.
+Every `Widget` object contains a hidden vptr (pointer to the vtable — a static array of function pointers).
 Old code calls `widget->resize()` via vtable slot 1. After v2 inserts `recolor()` at
 slot 1, that same call dispatches to `recolor()` instead — silent wrong behavior or
 a crash.

--- a/examples/case10_return_type/README.md
+++ b/examples/case10_return_type/README.md
@@ -4,7 +4,7 @@
 
 > **Note on abidiff 2.4.0:** Returns exit **4**. Semantically breaking — on
 > x86-64, `int` is returned in the lower 32 bits of `rax`; `long` uses all 64 bits.
-> Old callers zero-extend only 32 bits, potentially reading garbage for large values.
+> Old callers sign-extend only the lower 32 bits, potentially reading garbage for large values.
 
 ## What breaks
 Callers compiled against v1 truncate the return value to 32 bits. For counts above
@@ -59,5 +59,5 @@ gcc -shared -fPIC -g v2.c -o libfoo.so
 ```
 
 **Why CRITICAL:** On x86-64, `int` is returned in the lower 32 bits of `rax`; `long`
-uses all 64. The app zero-extends only 32 bits, reading a completely wrong value. Silent
-data corruption for any count above `INT_MAX`.
+uses all 64. The app sign-extends only the lower 32 bits, reading a completely wrong
+value. Silent data corruption for any count above `INT_MAX`.

--- a/examples/case10_return_type/README.md
+++ b/examples/case10_return_type/README.md
@@ -4,7 +4,7 @@
 
 > **Note on abidiff 2.4.0:** Returns exit **4**. Semantically breaking — on
 > x86-64, `int` is returned in the lower 32 bits of `rax`; `long` uses all 64 bits.
-> Old callers sign-extend only the lower 32 bits, potentially reading garbage for large values.
+> Old callers read only the lower 32 bits of `rax` as a signed int, producing garbage for large values.
 
 ## What breaks
 Callers compiled against v1 truncate the return value to 32 bits. For counts above
@@ -59,5 +59,5 @@ gcc -shared -fPIC -g v2.c -o libfoo.so
 ```
 
 **Why CRITICAL:** On x86-64, `int` is returned in the lower 32 bits of `rax`; `long`
-uses all 64. The app sign-extends only the lower 32 bits, reading a completely wrong
-value. Silent data corruption for any count above `INT_MAX`.
+uses all 64. The app reads only `eax` (lower 32 bits) as a signed int, interpreting a
+completely wrong value. Silent data corruption for any count above `INT_MAX`.

--- a/examples/case12_function_removed/README.md
+++ b/examples/case12_function_removed/README.md
@@ -56,7 +56,7 @@ gcc -g app.c -I. -L. -lfoo -Wl,-rpath,. -o app
 # Swap in v2 (fast_add gone from .so)
 gcc -shared -fPIC -g v2.c -o libfoo.so
 ./app
-# → ./app: symbol lookup error: ./libfoo.so: undefined symbol: fast_add
+# → ./app: symbol lookup error: ./app: undefined symbol: fast_add
 ```
 
 **Why CRITICAL:** With default lazy binding (RTLD_LAZY), the error surfaces on the

--- a/examples/case12_function_removed/README.md
+++ b/examples/case12_function_removed/README.md
@@ -1,6 +1,6 @@
 # Case 12: Function Removed from Shared Library
 
-**Category:** Symbol API | **Verdict:** 🔴 BREAKING (exit 12)
+**Category:** Symbol API | **Abicheck verdict:** BREAKING
 
 ## What breaks
 Any binary dynamically linked against v1 will fail to load with

--- a/examples/case12_function_removed/README.md
+++ b/examples/case12_function_removed/README.md
@@ -1,12 +1,13 @@
-# Case 12: Function Disappears (Moved to Inline)
+# Case 12: Function Removed from Shared Library
 
 **Category:** Symbol API | **Verdict:** 🔴 BREAKING (exit 12)
 
 ## What breaks
 Any binary dynamically linked against v1 will fail to load with
-`undefined symbol: fast_add` when upgraded to v2. Even if the function is still
-available as an inline in a header, the `.so` no longer exports the symbol,
-so pre-built binaries have nowhere to resolve it.
+`undefined symbol: fast_add` when upgraded to v2. The `.so` no longer exports
+the symbol, so pre-built binaries have nowhere to resolve it. Even if the function
+were moved to a header as an inline, already-compiled binaries cannot benefit from
+that — they need the dynamic symbol.
 
 ## Why abidiff catches it
 Reports `1 Removed function: fast_add` with exit **12** (breaking removal).

--- a/examples/case14_cpp_class_size/README.md
+++ b/examples/case14_cpp_class_size/README.md
@@ -6,9 +6,10 @@
 > code that heap-allocates `Buffer` via operator new or embeds it by value.
 
 ## What breaks
-Old code allocates `new Buffer()` expecting 64 bytes. v2's `Buffer` needs 128 bytes.
-The allocator returns only 64 bytes; writing to `data[64..127]` corrupts heap memory.
-Any consumer that inherits from or embeds `Buffer` by value is also broken.
+Old code allocates `Buffer` on the stack or via `new` expecting 64 bytes. v2's `Buffer`
+needs 128 bytes. The constructor (which zero-initializes the `data` array) writes 128
+bytes into a 64-byte allocation, corrupting adjacent memory. Any consumer that inherits
+from or embeds `Buffer` by value is also broken.
 
 ## Why abidiff catches it
 Reports `type size changed from 512 to 1024 (in bits)` (64 bytes → 128 bytes).

--- a/examples/case14_cpp_class_size/README.md
+++ b/examples/case14_cpp_class_size/README.md
@@ -8,8 +8,9 @@
 ## What breaks
 Old code allocates `Buffer` on the stack or via `new` expecting 64 bytes. v2's `Buffer`
 needs 128 bytes. The constructor (which zero-initializes the `data` array) writes 128
-bytes into a 64-byte allocation, corrupting adjacent memory. Any consumer that inherits
-from or embeds `Buffer` by value is also broken.
+bytes into a 64-byte allocation, corrupting adjacent memory. Any pre-built consumer
+compiled against the older 64-byte v1 layout that inherits from or embeds `Buffer` by
+value is also broken; consumers recompiled against the new 128-byte layout are unaffected.
 
 ## Why abidiff catches it
 Reports `type size changed from 512 to 1024 (in bits)` (64 bytes → 128 bytes).

--- a/examples/case14_cpp_class_size/v1.cpp
+++ b/examples/case14_cpp_class_size/v1.cpp
@@ -1,5 +1,6 @@
 class Buffer {
 public:
+    Buffer() { __builtin_memset(data, 0, sizeof(data)); }
     int size() { return 64; }
 private:
     char data[64];

--- a/examples/case14_cpp_class_size/v1.h
+++ b/examples/case14_cpp_class_size/v1.h
@@ -1,5 +1,6 @@
 class Buffer {
 public:
+    Buffer();
     int size();
 private:
     char data[64];

--- a/examples/case14_cpp_class_size/v2.cpp
+++ b/examples/case14_cpp_class_size/v2.cpp
@@ -1,6 +1,7 @@
 /* data[128] — sizeof(Buffer) doubles, heap allocs undersize the object */
 class Buffer {
 public:
+    Buffer() { __builtin_memset(data, 0, sizeof(data)); }
     int size() { return 128; }
 private:
     char data[128];

--- a/examples/case14_cpp_class_size/v2.h
+++ b/examples/case14_cpp_class_size/v2.h
@@ -1,5 +1,6 @@
 class Buffer {
 public:
+    Buffer();
     int size();
 private:
     char data[128];

--- a/examples/case15_noexcept_change/README.md
+++ b/examples/case15_noexcept_change/README.md
@@ -41,9 +41,10 @@ detect the change.
 
 ## Why ABICC catches it
 
-ABICC (ABI Compliance Checker) parses the **C++ header AST** via libclang. It sees
-the `noexcept` specifier on the function declaration and records it as part of the
-function's ABI profile. When v1 and v2 headers differ in `noexcept`, ABICC flags it.
+ABICC (ABI Compliance Checker) parses **C++ headers** using GCC's compiler internals
+and its own header analysis infrastructure. It sees the `noexcept` specifier on the
+function declaration and records it as part of the function's ABI profile. When v1 and
+v2 headers differ in `noexcept`, ABICC flags it.
 
 ## Real-world example
 

--- a/examples/case15_noexcept_change/README.md
+++ b/examples/case15_noexcept_change/README.md
@@ -81,9 +81,16 @@ abi-compliance-checker -lib Buffer -v1 1.0 -v2 2.0 \
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: CRITICAL (behavioral, not linkage)**
 
 **Scenario:** app compiled against v1 (`reset()` noexcept) calls v2 which throws — exception propagates through a noexcept frame → `std::terminate`.
+
+> **Important:** This demo conflates two changes: (1) removing `noexcept` from the
+> declaration, and (2) adding `throw` to the implementation. Removing `noexcept` alone
+> does **not** cause a crash — the binary links and runs identically. The crash only
+> occurs because v2 also introduces throwing code. The ABI verdict remains **COMPATIBLE**
+> (same symbol resolves), but removing `noexcept` increases the *risk* of this behavioral
+> failure if the implementation later throws.
 
 ```bash
 # Build v1 + app (app includes v1.h which declares reset() noexcept)
@@ -101,6 +108,8 @@ g++ -shared -fPIC -std=c++17 -g v2.cpp -o libbuf.so
 # → Aborted (core dumped)
 ```
 
-**Why CRITICAL:** The caller was compiled with the assumption that `reset()` is `noexcept`,
-so no try/catch or landing pad was generated. When v2 throws, the exception propagates
-through the noexcept frame and `std::terminate` is called unconditionally — no recovery possible.
+**Why CRITICAL (behavioral):** The caller was compiled with the assumption that `reset()`
+is `noexcept`, so no try/catch or landing pad was generated. When v2 throws, the exception
+propagates through the noexcept frame and `std::terminate` is called unconditionally — no
+recovery possible. Note: the binary linkage is fine (COMPATIBLE); the crash is a behavioral
+contract violation, not a symbol resolution failure.

--- a/examples/case21_method_became_static/README.md
+++ b/examples/case21_method_became_static/README.md
@@ -24,8 +24,12 @@ However, they pass a garbage `this` value in `%rdi` to a function that doesn't e
 For a void no-arg method like `bar()`, the function simply ignores `%rdi` — resulting in
 **silent success** rather than a crash. The UB is real but may be invisible without UBSAN.
 
-This is a **source-level ABI break**: the calling convention is wrong, and any method that
-reads `this` through the implicit parameter would behave incorrectly.
+This is a **calling convention ABI break**: the calling convention is wrong, and any method
+that reads `this` through the implicit parameter would behave incorrectly.
+
+> **Note:** Because the mangled name is identical, `abidiff` **cannot detect this change**
+> — it sees the same symbol in both `.so` files. This is a known blind spot. ABICC
+> catches it via header AST comparison.
 
 ## Consumer impact
 

--- a/examples/case29_ifunc_transition/README.md
+++ b/examples/case29_ifunc_transition/README.md
@@ -49,14 +49,15 @@ abicheck classifies this as **COMPATIBLE** because:
 ```diff
 -int dispatch(int x) { return x * 2; }
 +static int dispatch_generic(int x) { return x * 2; }
-+static int dispatch_avx(int x) { /* AVX implementation */ return x * 2; }
 +
 +/* IFUNC resolver — called by dynamic linker at load time */
++static void *resolve_dispatch(void) { return (void*)dispatch_generic; }
 +int dispatch(int x) __attribute__((ifunc("resolve_dispatch")));
-+static void *resolve_dispatch(void) {
-+    return has_avx() ? (void*)dispatch_avx : (void*)dispatch_generic;
-+}
 ```
+
+> In production, the resolver would typically select between multiple implementations
+> (e.g., generic vs AVX) based on CPU feature detection. This example uses a single
+> implementation for simplicity.
 
 ## Real Failure Demo
 


### PR DESCRIPTION
## Summary
This PR updates the ABI breaking cases catalog and documentation to reflect version 2 with expanded coverage (cases 01–29). The changes include renaming the verdict column from "abidiff exit" to "abicheck verdict" with standardized verdict labels, adding documentation for cases 25–29, and clarifying several technical details across existing case READMEs.

## Key Changes

- **Catalog version bump:** Updated title from "v1" to "v2" and extended case coverage from case01..case24 to case01..case29
- **Verdict column standardization:** Replaced numeric exit codes and emoji with semantic verdict labels:
  - `BREAKING` for ABI-incompatible changes
  - `COMPATIBLE` for backward-compatible changes
  - `NO_CHANGE` for identical binaries
  - `BAD PRACTICE` for problematic patterns
  - `INFORMATIONAL` for metadata-only changes
- **New case documentation:** Added section 7 "Additional compatible/informational cases" documenting:
  - case25_enum_member_added (COMPATIBLE)
  - case26_union_field_added (COMPATIBLE)
  - case27_symbol_binding_weakened (COMPATIBLE)
  - case29_ifunc_transition (COMPATIBLE)
- **Clarified technical details:**
  - case02: Expanded explanation of parameter type changes with x86-64 SysV ABI register class details
  - case10: Corrected sign-extension behavior for return value truncation
  - case12: Renamed from "Function Disappears" to "Function Removed" and clarified that inline alternatives don't help pre-built binaries
  - case15: Added important note distinguishing between ABI compatibility (COMPATIBLE) and behavioral risk (CRITICAL)
  - case21: Clarified as "calling convention ABI break" and noted that abidiff cannot detect this due to identical mangled names
  - case01: Simplified description to focus on dynamic linking failure
  - case07: Updated real-world example from Linux kernel to C standard library's FILE* pattern
- **Documentation scope:** Updated guide title to reflect case01..case29 coverage

## Notable Implementation Details

The verdict labels provide clearer semantic meaning than numeric exit codes, making the catalog more accessible to users unfamiliar with abidiff's exit code conventions. The addition of cases 25–29 completes the coverage of both breaking and compatible ABI changes, with explicit documentation of why compatible changes are safe despite potential source-level concerns.

https://claude.ai/code/session_01HiuL9s2pHtybQNhZof29Sx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded ABI compatibility catalog from 24 to 29 cases and reorganized sections to separate compatible/informational cases from breaking ones.
  * Added several new compatible/warning case entries with verdicts and illustrative examples.
  * Converted example verdicts from numeric exit codes to semantic labels with emojis (BREAKING/COMPATIBLE/NO_CHANGE).
  * Updated many per-case READMEs to clarify real-world impacts, failure demos, and nuanced diagnostic guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->