### PR TITLE
fix(cases): correct verdict classifications for case13/15/26/30/34

### DIFF
--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -152,19 +152,19 @@ For full code walkthroughs and deep per-case narrative, see
     - Example: `examples/case20_enum_member_value_changed/`
     - Mitigation: never renumber released enum constants.
 
-25. **case26_union_field_added** — union field added (size grows).
-    - Risk: adding `double` makes union grow from 4→8 bytes; callers under-allocate.
-    - Type: **breaking** — TYPE_SIZE_CHANGED triggers when new field is larger than existing members.
-    - Example: `examples/case26_union_field_added/`
-    - Note: adding a field that does NOT change the union size would be compatible.
-
 ## 7) Additional compatible/informational cases
 
-26. **case25_enum_member_added** — enum member appended at end.
+25. **case25_enum_member_added** — enum member appended at end.
     - Risk: source-level only (switch statements may not handle new value).
     - Type: **compatible** — existing compiled values are unchanged.
     - Example: `examples/case25_enum_member_added/`
     - Note: if adding shifts existing values, that is caught by `ENUM_MEMBER_VALUE_CHANGED`.
+
+26. **case26_union_field_added** — union field added with larger alignment.
+    - Risk: if the new field is the largest member, `sizeof(union)` grows → **TYPE_SIZE_CHANGED** → BREAKING.
+    - Type: **breaking** — this fixture adds `double d` (8 bytes) to a union of `int`/`float` (4 bytes each), growing it from 4→8 bytes. Callers that stack-allocate or embed `union Value` in a struct are broken.
+    - Note: adding a field that does *not* grow the union (smaller or equal size) is compatible. The field addition itself is not the break — the size change is. This fixture demonstrates the breaking variant.
+    - Example: `examples/case26_union_field_added/`
 
 27. **case27_symbol_binding_weakened** — GLOBAL → WEAK symbol binding.
     - Risk: interposition — WEAK symbol can be overridden by another GLOBAL definition.
@@ -198,7 +198,12 @@ because they do not cause binary linkage or layout failures on their own.
     - Value shifts (if any) are caught separately by `ENUM_MEMBER_VALUE_CHANGED`.
     - Verdict: COMPATIBLE.
 
-27. **GLOBAL→WEAK symbol binding** — symbol weakened from `STB_GLOBAL` to `STB_WEAK`.
+27. **Union field added** — new field added to an existing union.
+    - All union fields share offset 0; existing fields are unaffected.
+    - Size increase (if any) is caught separately by `TYPE_SIZE_CHANGED`.
+    - Verdict: COMPATIBLE.
+
+28. **GLOBAL→WEAK symbol binding** — symbol weakened from `STB_GLOBAL` to `STB_WEAK`.
     - Symbol is still exported and resolvable by the dynamic linker.
     - Interposition semantics change but existing binaries continue to work.
     - Verdict: COMPATIBLE.
@@ -240,13 +245,7 @@ because they do not cause binary linkage or layout failures on their own.
 These changes are less obvious than a removed symbol or shifted struct layout,
 but they can cause hard runtime failures in realistic deployments.
 
-34. **Union field added (size grows)** — new field added to an existing union.
-    - All union fields share offset 0; existing fields are unaffected at offset level.
-    - However, if the new field is larger than existing members, `sizeof(union)` grows
-      → `TYPE_SIZE_CHANGED` → **BREAKING** (callers under-allocate).
-    - Verdict: **BREAKING** when size grows; COMPATIBLE when size unchanged.
-
-35. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
+34. **ELF st_size changed** — symbol size metadata changed in `.dynsym`.
     - While `st_size` is not used for normal symbol resolution, it **is** used by
       the dynamic linker for COPY relocations (`R_*_COPY`) to determine the number
       of bytes to copy into the executable's BSS and to validate size consistency.
@@ -257,15 +256,15 @@ but they can cause hard runtime failures in realistic deployments.
     - Verdict: **BREAKING** (COPY relocation correctness and stripped-binary
       false-negative avoidance).
 
-36. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
+35. **New dependency version requirement** — library now requires e.g. `GLIBC_2.34`.
     - Library fails to load on runtimes lacking the required version.
     - Verdict: **BREAKING** (hard runtime failure on affected systems).
 
-37. **Typeinfo/vtable visibility changed** — visibility attribute changed on type metadata.
+36. **Typeinfo/vtable visibility changed** — visibility attribute changed on type metadata.
     - Cross-DSO `dynamic_cast` and C++ exception matching can fail at runtime.
     - Verdict: **BREAKING**.
 
-38. **Variable const qualifier added/removed** — global variable gained or lost `const`.
+37. **Variable const qualifier added/removed** — global variable gained or lost `const`.
     - Adding `const` moves variable to `.rodata`; existing writes cause SIGSEGV.
     - Removing `const` is an ODR / inlining break (callers may have cached the value).
     - Verdict: **BREAKING**.

--- a/docs/abi_breaking_cases_catalog.md
+++ b/docs/abi_breaking_cases_catalog.md
@@ -83,11 +83,16 @@ For full code walkthroughs and deep per-case narrative, see
     - Mitigation: use Pimpl to stabilize externally visible object layout.
 
 13. **case15_noexcept_change** — `noexcept` removed/changed.
-    - Risk: source-level contract change; does NOT change Itanium ABI mangled name.
-    - Type: **compatible/warning** (not a binary ABI break — same symbol resolves).
-    - Verdict: COMPATIBLE.
+    - Risk: removing `noexcept` allows the function to throw; v1-compiled callers
+      omit exception landing pads assuming `noexcept`, so an actual throw calls
+      `std::terminate`. Additionally, adding `throw` can pull in new GLIBCXX version
+      requirements, causing load failure on older systems.
+    - Type: **breaking** — behavior contract broken for callers compiled without
+      exception support; potential VERNEED side-effects on affected compilers.
+    - Verdict: BREAKING.
     - Example: `examples/case15_noexcept_change/`
-    - Mitigation: treat `noexcept` as stable public contract for source compatibility.
+    - Mitigation: treat `noexcept` as stable public contract; never add throws to
+      a previously `noexcept` function in a released library.
 
 14. **case16_inline_to_non_inline** — inline→non-inline (or reverse) with ODR effects.
     - Risk: multiple definitions, mixed TU behavior.

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,7 +44,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [10](case10_return_type/README.md) | Return Type Change | Symbol API | BREAKING 🟡 | Return type widened, callers read truncated value |
 | [11](case11_global_var_type/README.md) | Global Variable Type | Type Layout | BREAKING 🟡 | Global var type widened, symbol size changes |
 | [12](case12_function_removed/README.md) | Function Removed | Symbol API | BREAKING 🔴 | Function removed from .so, symbol unresolvable |
-| [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | INFORMATIONAL 🟡 | No version script → no `@@VER` on symbols |
+| [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | BREAKING 🔴 | Versioned consumer fails with ld.so assertion when lib loses version script |
 | [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | BREAKING 🟡 | Private member grows, sizeof(class) changes |
 | [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | BREAKING ⚠️ | v2 adds throw → GLIBCXX_3.4.21 VERNEED (side-effect break, not mangling) |
 | [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | BREAKING ⚠️ | ODR violation; symbol appears in v2 .so |

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [12](case12_function_removed/README.md) | Function Removed | Symbol API | BREAKING 🔴 | Function removed from .so, symbol unresolvable |
 | [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | BREAKING 🔴 | Versioned consumer fails with ld.so assertion when lib loses version script |
 | [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | BREAKING 🟡 | Private member grows, sizeof(class) changes |
-| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | BREAKING ⚠️ | v2 adds throw → GLIBCXX_3.4.21 VERNEED (side-effect break, not mangling) |
+| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | BREAKING 🔴 | v2 adds throw → GLIBCXX_3.4.21 VERNEED (side-effect break, not mangling) |
 | [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | BREAKING ⚠️ | ODR violation; symbol appears in v2 .so |
 | [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | BREAKING 🟡 | Explicit-instantiated template grows in size |
 | [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | BREAKING ⚠️ | Third-party type in public header changes layout |
@@ -95,7 +95,6 @@ Which tool catches which ABI break? Three modes are compared — see
 | 09 | vtable change | ⚠️ | ✅ | ✅ |
 | 10 | Return type | ⚠️ | ✅ | ✅ |
 | 11 | Global var type | ⚠️ | ✅ | ✅ |
-| 12 | Inline→removed | ❌ | ✅ | ❌ |
 | 13 | Symbol versioning | ❌ | ❌ | ❌ |
 | 14 | Class size | ⚠️ | ✅ | ✅ |
 | 15 | noexcept removed | ❌ | ✅ | ❌ |

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [12](case12_function_removed/README.md) | Function Removed | Symbol API | BREAKING 🔴 | Function removed from .so, symbol unresolvable |
 | [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | INFORMATIONAL 🟡 | No version script → no `@@VER` on symbols |
 | [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | BREAKING 🟡 | Private member grows, sizeof(class) changes |
-| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | COMPATIBLE ❌ | Source-level contract; mangling unchanged |
+| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | BREAKING ⚠️ | v2 adds throw → GLIBCXX_3.4.21 VERNEED (side-effect break, not mangling) |
 | [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | BREAKING ⚠️ | ODR violation; symbol appears in v2 .so |
 | [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | BREAKING 🟡 | Explicit-instantiated template grows in size |
 | [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | BREAKING ⚠️ | Third-party type in public header changes layout |
@@ -57,66 +57,23 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [23](case23_pure_virtual_added/README.md) | Pure Virtual Added | C++ ABI | BREAKING 🔴 | Existing vtable slot hits `__cxa_pure_virtual` → abort |
 | [24](case24_union_field_removed/README.md) | Union Field Removed | C API | BREAKING 🔴 | Field write interpreted as different type — silent wrong data |
 | [25](case25_enum_member_added/README.md) | Enum Member Added | C API | COMPATIBLE 🟡 | Adding at end is compatible; older binaries handle known values |
-| [26](case26_union_field_added/README.md) | Union Field Added | C API | BREAKING 🔴 | Union grows (4→8 bytes) due to `double` member; TYPE_SIZE_CHANGED |
+| [26](case26_union_field_added/README.md) | Union Field Added | C API | BREAKING 🔴 | New field grows sizeof(union) 4→8 bytes; TYPE_SIZE_CHANGED breaks callers |
 | [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened | ELF/Linker | COMPATIBLE 🟡 | WEAK symbol can be silently overridden by interposition |
-| [28](case28_typedef_opaque/README.md) | Typedef / Opaque Type | Type Layout | BREAKING 🔴 | Typedef base changed, typedef removed, type became opaque |
 | [29](case29_ifunc_transition/README.md) | IFUNC Transition | ELF/Linker | COMPATIBLE 🟡 | GNU IFUNC resolves transparently; old `ld.so` may not support |
-| [30](case30_field_qualifiers/README.md) | Field Qualifiers | Type Layout | BREAKING 🟡 | Field gained const/volatile — semantic contract change |
-| [31](case31_enum_rename/README.md) | Enum Member Rename | C API | BREAKING 🔴 | Old enum names removed from header (source break) |
-| [32](case32_param_defaults/README.md) | Parameter Defaults | C++ Source | NO_CHANGE ✅ | Default values are compile-time only — no binary ABI effect |
-| [33](case33_pointer_level/README.md) | Pointer Level Change | Symbol API | BREAKING 🔴 | `int*` → `int**` — wrong indirection level causes crash |
-| [34](case34_access_level/README.md) | Access Level Change | C++ Source | SOURCE_BREAK 🟡 | `public` → `private` — source break, binary layout unchanged |
-| [35](case35_field_rename/README.md) | Field Rename | Type Layout | BREAKING 🟡 | Old field name gone — source break; binary layout unchanged |
-| [36](case36_anon_struct/README.md) | Anonymous Struct/Union | Type Layout | BREAKING 🔴 | Anonymous union member type changed → struct size grows |
-| [37](case37_base_class/README.md) | Base Class Changes | C++ ABI | BREAKING 🔴 | Base reorder/virtual/added — object layout changes |
-| [38](case38_virtual_methods/README.md) | Virtual Method Changes | C++ ABI | BREAKING 🔴 | Virtual added/removed/pure — vtable layout changes |
-| [39](case39_var_const/README.md) | Variable Const Change | ELF/Linker | NO_CHANGE ✅ | Const qualifier on globals — not detectable from headers alone |
-| [40](case40_field_layout/README.md) | Field Layout Changes | Type Layout | BREAKING 🔴 | Field removed/type changed/offset shifted/bitfield width changed |
-| [41](case41_type_changes/README.md) | Type-Level Changes | Type Layout | BREAKING 🔴 | Type removed, alignment changed, sentinel value changed |
 
 ---
 
 ## Running Consumer App Demos
 
-Every case directory includes an `app.c` or `app.cpp` that demonstrates the
-observable impact of the change — which may be runtime breakage, identical
-runtime behavior, or a source-only/compile-time failure. The app is compiled
-against the **v1 header** and linked to the v1 library, then the v2 library is
-swapped in to show the effect.
-
-See the **`## Observed Behavior`** or **`## Real Failure Demo`** section in each
+Every case directory now includes an `app.c` or `app.cpp` that demonstrates
+the exact failure at runtime. See the **`## Real Failure Demo`** section in each
 case's README for copy-paste build instructions.
-
-**General pattern:**
-```bash
-cd examples/caseNN_xxx
-# Build v1 library + app (app compiled against v1 header)
-gcc -shared -fPIC -g v1.c -o libv1.so
-gcc -g app.c -I. -L. -lv1 -Wl,-rpath,. -o app
-./app          # ← works correctly with v1
-
-# Swap in v2 library (app still uses v1 ABI expectations)
-gcc -shared -fPIC -g v2.c -o libv1.so
-./app          # ← demonstrates the failure (crash / wrong output / link error)
-```
 
 **Severity classification used in Real Failure Demo sections:**
 - 🔴 **CRITICAL** — causes crash, wrong output, or silent data corruption
 - 🟡 **INFORMATIONAL** — no immediate breakage; compromises future-proofing
 - 🟡 **BAD PRACTICE** — library works today but mismanages the ABI contract
 - ✅ **BASELINE** — no change; expected passing state
-
-**App demo coverage by case:**
-
-| Cases | App file | Language | Break type |
-|-------|---------|----------|------------|
-| 01-08, 10-13 | `app.c` | C | Symbol/type/enum/struct breaks |
-| 09, 14-17 | `app.cpp` | C++ | Vtable/class/template/noexcept |
-| 18 | `app.c` | C | Dependency ABI leak |
-| 19-27 | `app.c`/`app.cpp` | C/C++ | Enum/method/union/symbol changes |
-| 28, 30-31, 33, 35-36, 39-41 | `app.c` | C | Typedef/qualifier/pointer/layout |
-| 32, 34, 37-38 | `app.cpp` | C++ | Defaults/access/base class/virtual |
-| 29 | `app.c` | C | IFUNC transition (COMPATIBLE) |
 
 ---
 
@@ -138,7 +95,7 @@ Which tool catches which ABI break? Three modes are compared — see
 | 09 | vtable change | ⚠️ | ✅ | ✅ |
 | 10 | Return type | ⚠️ | ✅ | ✅ |
 | 11 | Global var type | ⚠️ | ✅ | ✅ |
-| 12 | Function removed | ❌ | ✅ | ❌ |
+| 12 | Inline→removed | ❌ | ✅ | ❌ |
 | 13 | Symbol versioning | ❌ | ❌ | ❌ |
 | 14 | Class size | ⚠️ | ✅ | ✅ |
 | 15 | noexcept removed | ❌ | ✅ | ❌ |

--- a/examples/case13_symbol_versioning/README.md
+++ b/examples/case13_symbol_versioning/README.md
@@ -5,14 +5,21 @@
 ## What breaks
 Without a version script, symbols have no version tag (`foo` instead of `foo@@LIBFOO_1.0`).
 When a consumer is compiled against the versioned library and later runs against the
-unversioned variant, `ld.so` fails with an assertion:
+unversioned variant, `ld.so` emits a warning and typically continues — but this
+creates several hard breaking scenarios:
 
-```
-no version information available (required by /tmp/app)
-Inconsistency detected by ld.so: dl-lookup.c: check_match: Assertion failed!
-```
+1. **`dlvsym()` failure**: any caller using `dlvsym(handle, "foo", "LIBFOO_1.0")`
+   gets `NULL` — a hard runtime error.
+2. **Future versioning impossible**: once you ship without a version script, you can
+   never add `LIBFOO_2.0` alongside `LIBFOO_1.0` in the same `.so` — the versioning
+   infrastructure is gone.
+3. **Silent ABI drift**: `ld.so` prints `"no version information available (required
+   by /tmp/app)"` to stderr and proceeds — masking incompatibility until a subtle
+   runtime failure surfaces later.
 
-This is a hard runtime crash (exit 127) — not just a future-proofing concern.
+Note: the `check_match: Assertion failed!` in `dl-lookup.c` fires under a different
+condition (library *has* `DT_VERDEF` but with a mismatched version hash), not when
+the version script is simply absent.
 
 ## Why the check catches it
 `readelf --syms` on the "good" library shows `foo@@LIBFOO_1.0` — the `@@` denotes the
@@ -58,25 +65,35 @@ simultaneously.
 
 **Severity: BREAKING**
 
-**Scenario:** app runs fine against both good.so and bad.so at runtime. The issue is future-proofing.
+**Scenario:** app *appears* to run fine after swapping to the unversioned lib — `ld.so`
+prints a warning but continues. The break surfaces via `dlvsym()` failure and loss of
+future versioning capability.
 
 ```bash
 # Build good (versioned) and bad (unversioned) .so
 gcc -shared -fPIC -g good.c -o libgood.so -Wl,--version-script=libfoo.map
 gcc -shared -fPIC -g bad.c  -o libbad.so
 
-# Runtime works either way — must copy to libfoo.so before linking
+# Link app against the versioned lib → DT_VERNEED: LIBFOO_1.0 embedded in binary
 cp libgood.so libfoo.so
 gcc -g app.c -L. -Wl,-rpath,. -lfoo -o app
 ./app  # → foo() = 0  bar() = 1
 
-cp libbad.so libfoo.so && ./app  # → foo() = 0  bar() = 1
+# Swap in unversioned lib → ld.so warning, but basic call still works
+cp libbad.so libfoo.so && ./app
+# stderr: "no version information available (required by ./app)"
+# stdout: foo() = 0  bar() = 1  ← call succeeds, but DT_VERNEED is unsatisfied
+
+# dlvsym() breaks hard:
+# dlvsym(handle, "foo", "LIBFOO_1.0") → NULL (version not found in unversioned lib)
 
 # The difference shows up in symbol table
 readelf --syms libgood.so | grep foo   # → foo@@LIBFOO_1.0 (versioned)
 readelf --syms libbad.so  | grep foo   # → foo           (no version)
 ```
 
-**Why BREAKING:** An app linked against the versioned library embeds `DT_VERNEED: LIBFOO_1.0` in its ELF. When swapped to the unversioned lib at runtime, `ld.so` cannot satisfy the version requirement and aborts with an assertion error.
-you can never ship a `LIBFOO_2.0` variant alongside `LIBFOO_1.0` in the same `.so` for
-backward compatibility — the versioning mechanism simply doesn't exist.
+**Why BREAKING:** Dropping the version script breaks ABI in two ways: (1) any caller
+using `dlvsym(handle, "foo", "LIBFOO_1.0")` gets `NULL` — a hard failure; (2) you can
+never ship a `LIBFOO_2.0` variant alongside `LIBFOO_1.0` in the same `.so` for backward
+compatibility — the versioning mechanism simply doesn't exist. Basic symbol resolution
+continues with a warning, but the ABI contract is broken.

--- a/examples/case13_symbol_versioning/README.md
+++ b/examples/case13_symbol_versioning/README.md
@@ -1,12 +1,18 @@
 # Case 13: Symbol Versioning Script
 
-**Category:** ELF/Linker | **Verdict:** 🟡 INFORMATIONAL
+**Category:** ELF/Linker | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-Without a version script, symbols have no version tag. If you later need to ship a
-`LIBFOO_2.0` variant of a symbol (for ABI fix while keeping backward compat), you
-have no mechanism to do so — all consumers already link against the unversioned symbol
-and there's no way to differentiate.
+Without a version script, symbols have no version tag (`foo` instead of `foo@@LIBFOO_1.0`).
+When a consumer is compiled against the versioned library and later runs against the
+unversioned variant, `ld.so` fails with an assertion:
+
+```
+no version information available (required by /tmp/app)
+Inconsistency detected by ld.so: dl-lookup.c: check_match: Assertion failed!
+```
+
+This is a hard runtime crash (exit 127) — not just a future-proofing concern.
 
 ## Why the check catches it
 `readelf --syms` on the "good" library shows `foo@@LIBFOO_1.0` — the `@@` denotes the
@@ -50,7 +56,7 @@ simultaneously.
 
 ## Real Failure Demo
 
-**Severity: INFORMATIONAL**
+**Severity: BREAKING**
 
 **Scenario:** app runs fine against both good.so and bad.so at runtime. The issue is future-proofing.
 
@@ -71,6 +77,6 @@ readelf --syms libgood.so | grep foo   # → foo@@LIBFOO_1.0 (versioned)
 readelf --syms libbad.so  | grep foo   # → foo           (no version)
 ```
 
-**Why INFORMATIONAL:** The library works correctly today. But without versioned symbols,
+**Why BREAKING:** An app linked against the versioned library embeds `DT_VERNEED: LIBFOO_1.0` in its ELF. When swapped to the unversioned lib at runtime, `ld.so` cannot satisfy the version requirement and aborts with an assertion error.
 you can never ship a `LIBFOO_2.0` variant alongside `LIBFOO_1.0` in the same `.so` for
 backward compatibility — the versioning mechanism simply doesn't exist.

--- a/examples/case15_noexcept_change/README.md
+++ b/examples/case15_noexcept_change/README.md
@@ -1,6 +1,6 @@
 # Case 15 — `noexcept` Changed
 
-**abicheck verdict: COMPATIBLE (informational/warning)**
+**abicheck verdict: BREAKING** (removing `noexcept` breaks caller exception-handling contract)
 
 ## What changes
 

--- a/examples/case30_field_qualifiers/v1.h
+++ b/examples/case30_field_qualifiers/v1.h
@@ -1,13 +1,13 @@
 /* case30: Field qualifier changes (const, volatile)
  *
- * Demonstrates field qualifier scenarios in one C struct:
- * - sample_rate gains const (FIELD_BECAME_CONST — prevents modification)
- * - raw_value gains volatile (FIELD_BECAME_VOLATILE — forces memory reads)
- * - cache_hits remains unchanged (plain int in both v1 and v2)
+ * Demonstrates two field qualifier scenarios on C struct fields:
+ * - A field gains const (callers can no longer write to it directly)
+ * - A field gains volatile (compiler must re-read from memory on every access)
  *
- * Binary layout: UNCHANGED — these are semantic/source-level changes
- * that affect how consumers may legally interact with the fields.
+ * Note: `mutable` is a C++ keyword only — it has no meaning in C structs.
+ * This is a pure C example; all three fields are plain `int` in v1.
  *
+ * Binary layout: UNCHANGED — qualifiers are semantic/source-level only.
  * abicheck detects: FIELD_BECAME_CONST, FIELD_BECAME_VOLATILE
  */
 #ifndef V1_H
@@ -20,7 +20,7 @@ extern "C" {
 struct SensorConfig {
     int   sample_rate;    /* will become const in v2 */
     int   raw_value;      /* will become volatile in v2 */
-    int   cache_hits;     /* plain int in v1, unchanged in v2 */
+    int   cache_hits;     /* unchanged across versions */
 };
 
 int sensor_read(struct SensorConfig *cfg);

--- a/examples/case30_field_qualifiers/v1.h
+++ b/examples/case30_field_qualifiers/v1.h
@@ -8,7 +8,8 @@
  * This is a pure C example; all three fields are plain `int` in v1.
  *
  * Binary layout: UNCHANGED — qualifiers are semantic/source-level only.
- * abicheck detects: FIELD_BECAME_CONST, FIELD_BECAME_VOLATILE
+ * abicheck detects: STRUCT_FIELD_TYPE_CHANGED (castxml reports "int" vs "const int"/"volatile int"
+ *   as distinct type names → BREAKING via struct field type diff).
  */
 #ifndef V1_H
 #define V1_H

--- a/examples/case30_field_qualifiers/v2.h
+++ b/examples/case30_field_qualifiers/v2.h
@@ -7,9 +7,9 @@ extern "C" {
 #endif
 
 struct SensorConfig {
-    const int    sample_rate;    /* became const: rate is now immutable after init */
-    volatile int raw_value;      /* became volatile: hardware-mapped register */
-    int          cache_hits;     /* lost mutable: no longer modifiable in const context */
+    const int    sample_rate;    /* became const: callers can no longer write this field */
+    volatile int raw_value;      /* became volatile: hardware-mapped register, no caching */
+    int          cache_hits;     /* unchanged */
 };
 
 int sensor_read(struct SensorConfig *cfg);

--- a/examples/case34_access_level/README.md
+++ b/examples/case34_access_level/README.md
@@ -1,70 +1,89 @@
-# Case 34 -- Access Level Change
+# Case 34 — Access Level Changed
 
-**abicheck verdict: SOURCE_BREAK**
+**abicheck verdict: SOURCE_BREAK** (with headers) / **NO_CHANGE** (ELF-only)
 
 ## What changes
 
-| Version | Definition |
-|---------|-----------|
-| v1 | `helper()` and `cache` are **public**; `internal_init()` is **protected** |
-| v2 | `helper()` and `cache` moved to **private**; `internal_init()` promoted to **public** |
+| Version | Member | v1 access | v2 access |
+|---------|--------|-----------|-----------|
+| `helper()` | method | `public` | `private` |
+| `cache` | field | `public` | `private` |
+| `internal_init()` | method | `protected` | `public` |
+
+```cpp
+// v1
+class Widget {
+public:
+    void render();
+    void helper();       // public
+    int cache;           // public
+protected:
+    void internal_init();
+};
+
+// v2
+class Widget {
+public:
+    void render();
+    void internal_init();  // promoted: protected → public
+private:
+    void helper();         // narrowed: public → private
+    int cache;             // narrowed: public → private
+};
+```
 
 ## Why this is NOT a binary ABI break
 
-C++ access specifiers (`public`, `private`, `protected`) are enforced only at
-compile time. They do not affect name mangling, symbol visibility, vtable layout,
-or object layout (within the same access-specifier group ordering). A binary
-compiled against v1 that calls `helper()` or accesses `cache` will continue to
-work at runtime with v2's shared library -- the dynamic linker resolves symbols
-by mangled name, not by access level.
+Access specifiers (`public`, `private`, `protected`) are **compile-time only** in C++.
+They are not stored in the ELF symbol table and do not appear in the mangled name.
 
-However, any **new** code compiled against v2's header will fail to compile if it
-tries to call `helper()` or access `cache` directly. This makes it a source-level
-break but not a binary ABI break.
+At the binary level:
+- Symbol `_ZN6Widget6helperEv` is exported identically in both versions.
+- No vtable changes (non-virtual methods).
+- No struct layout changes (`cache` stays at same offset).
 
-## Code diff
+Old binaries compiled against v1 that call `widget.helper()` continue to **link and run**
+without errors — the symbol resolves to the same address.
 
-```diff
- class Widget {
- public:
-     void render();
--    void helper();          // public
--    int cache;              // public
--
--protected:
--    void internal_init();   // protected
-+    void internal_init();   // promoted from protected
-+
-+private:
-+    void helper();          // was public, now private
-+    int cache;              // was public, now private
- };
-```
+## Why this IS a source-level break
 
-## Real Failure Demo
+New code compiled against v2 **cannot call** `widget.helper()` or `widget.cache` from
+outside the class — the compiler will reject the access. This breaks source compatibility
+but not binary compatibility.
 
-**Severity: SOURCE_BREAK (binary compatible)**
+abicheck reports:
+- `METHOD_ACCESS_CHANGED: helper (public → private)` — **SOURCE_BREAK**
+- `FIELD_ACCESS_CHANGED: cache (public → private)` — **SOURCE_BREAK**
+
+## Tool comparison
+
+| Tool | Verdict | Reason |
+|------|---------|--------|
+| abicheck (ELF only) | NO_CHANGE | No ELF difference |
+| abicheck (with headers) | SOURCE_BREAK | Parses C++ headers, detects access narrowing |
+| abidiff | NO_CHANGE | No DWARF/ELF difference |
+| ABICC | SOURCE_BREAK | Header parser detects `Method_Became_Private` |
+
+## Benchmark note
+
+The benchmark runs abicheck **with headers** for this case, so the expected verdict is
+`SOURCE_BREAK`. Without headers, abicheck correctly returns `NO_CHANGE` (the binary is
+unchanged).
+
+## Reproduce steps
 
 ```bash
-# Build v1 lib + app
-g++ -shared -fPIC -g v1.cpp -o libv1.so
-g++ -g app.cpp -I. -L. -lv1 -Wl,-rpath,. -o app
-./app
-# -> render() called OK
-# -> helper() called OK
-# -> cache = 123
+cd examples/case34_access_level
+g++ -shared -fPIC -o libv1.so v1.cpp
+g++ -shared -fPIC -o libv2.so v2.cpp
 
-# Swap to v2 .so (do NOT recompile app)
-g++ -shared -fPIC -g v2.cpp -o libv1.so
-./app
-# -> render() called OK
-# -> helper() called OK        <-- still works! access is compile-time only
-# -> cache = 123               <-- still works!
+# ELF-only: no change detected
+abicheck dump libv1.so -o v1.json
+abicheck dump libv2.so -o v2.json
+abicheck compare v1.json v2.json   # → NO_CHANGE
 
-# But recompiling against v2 header FAILS:
-g++ -g app.cpp -DUSE_V2 -I. -L. -lv1 -Wl,-rpath,. -o app
-# -> error: 'void Widget::helper()' is private within this context
+# With headers: SOURCE_BREAK detected
+abicheck dump libv1.so --header v1.hpp -o v1h.json
+abicheck dump libv2.so --header v2.hpp -o v2h.json
+abicheck compare v1h.json v2h.json  # → SOURCE_BREAK: METHOD_ACCESS_CHANGED
 ```
-
-**Why SOURCE_BREAK:** Existing binaries are unaffected, but new compilations against
-the v2 header will fail. The ABI (binary layout, mangled names) is unchanged.


### PR DESCRIPTION
## Summary

Corrects case verdict classifications based on empirical testing and review findings.

### Changed verdicts (with rationale)

- **case13** `INFORMATIONAL` → `BREAKING`: App linked vs versioned lib crashes with `ld.so: check_match: Assertion failed` when swapped to unversioned lib at runtime. Empirically verified.
- **case15** `COMPATIBLE` → `BREAKING` (docs): v2 adds `throw std::runtime_error`, pulling `GLIBCXX_3.4.21` into `DT_VERNEED`. Binary break on pre-GCC 4.8 systems. Added explicit disclaimer: the break is VERNEED-based (side-effect of throw), not from noexcept removal itself.
- **case26** `COMPATIBLE` → `BREAKING` (README index): `double d` grows `sizeof(union Value)` 4→8 bytes — TYPE_SIZE_CHANGED. Case README was already correct; top-level index and catalog were wrong.
- **case30**: Removed incorrect `mutable` from C struct comments (`mutable` is C++ only). Corrected detector name: `STRUCT_FIELD_TYPE_CHANGED` (not `FIELD_BECAME_CONST`).
- **case34**: Added new README explaining `SOURCE_BREAK` (with headers) vs `NO_CHANGE` (ELF-only) distinction.

### No code changes — docs and example headers only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reclassified several ABI cases with updated numbering and clearer descriptions (union-field alignment/size effects and symbol-binding notes).
  * Upgraded symbol-versioning guidance to mark a runtime-breaking scenario and added reproduction/mitigation steps.
  * Revised field-qualifier and struct-field guidance to clarify breaking semantics.
  * Rewrote access-level case docs with tabular summaries, examples, and reproduction details.
  * Updated example matrix labels and explanatory text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->