### PR TITLE
fix(examples): cases 15/17/28/31 runtime demos, README accuracy, enum rename classifier

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -485,8 +485,21 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             if old_max_val is not None else None
         )
 
+        # Build inverse map: new_value → new_name for values that are "new" (not in old names)
+        # If a missing old member value still exists under a different new name,
+        # it is a rename, not a true removal. The separate rename detector emits
+        # ENUM_MEMBER_RENAMED; we should not emit ENUM_MEMBER_REMOVED here.
+        new_val_to_newname = {
+            nval: nname for nname, nval in new_members.items()
+            if nname not in old_members
+        }
+
         for mname, mval in old_members.items():
             if mname not in new_members:
+                # rename-only -> skip removed emission
+                if mval in new_val_to_newname:
+                    continue
+                # Value truly removed
                 changes.append(Change(
                     kind=ChangeKind.ENUM_MEMBER_REMOVED,
                     symbol=name,
@@ -507,8 +520,15 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     new_value=str(new_members[mname]),
                 ))
 
+        # Skip additions whose values exist in the old enum:
+        # those will be handled as ENUM_MEMBER_RENAMED by _diff_enum_renames,
+        # which runs after _diff_enums. Checking local `changes` would always
+        # yield an empty set here (ENUM_MEMBER_RENAMED not yet emitted).
+        old_values = {str(v) for v in old_members.values()}
         for mname, mval in new_members.items():
             if mname not in old_members:
+                if str(mval) in old_values:
+                    continue  # value exists in old enum — rename, not addition
                 changes.append(Change(
                     kind=ChangeKind.ENUM_MEMBER_ADDED,
                     symbol=name,
@@ -1815,13 +1835,23 @@ def _diff_enum_layouts(o: object, n: object) -> list[Change]:
                 new_value=str(new_e.underlying_byte_size),
             ))
 
-        # 2. Removed members
+        # 2. Removed members — skip rename-only removals here.
+        # A dedicated rename detector emits ENUM_MEMBER_RENAMED. Here we only
+        # report truly removed values.
         for mname in sorted(old_e.members.keys() - new_e.members.keys()):
+            old_val = old_e.members[mname]
+            is_rename = any(
+                nval == old_val
+                for nname, nval in new_e.members.items()
+                if nname not in old_e.members
+            )
+            if is_rename:
+                continue
             changes.append(Change(
                 kind=ChangeKind.ENUM_MEMBER_REMOVED,
                 symbol=f"{name}::{mname}",
                 description=f"Enum member removed: {name}::{mname}",
-                old_value=str(old_e.members[mname]),
+                old_value=str(old_val),
             ))
 
         # 3. Changed values

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -522,13 +522,18 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
         # Skip additions whose values exist in the old enum:
         # those will be handled as ENUM_MEMBER_RENAMED by _diff_enum_renames,
-        # which runs after _diff_enums. Checking local `changes` would always
-        # yield an empty set here (ENUM_MEMBER_RENAMED not yet emitted).
-        old_values = {str(v) for v in old_members.values()}
+        # Skip additions whose value matches a removed old member (likely a rename).
+        # Use only *removed* old member values — if the old member still exists under
+        # the same name, the new member is a genuine addition (alias/duplicate), not
+        # a rename, and must be reported. (CodeRabbit P1: one-to-one guard)
+        removed_old_values = {
+            str(v) for mname, v in old_members.items()
+            if mname not in new_members
+        }
         for mname, mval in new_members.items():
             if mname not in old_members:
-                if str(mval) in old_values:
-                    continue  # value exists in old enum — rename, not addition
+                if str(mval) in removed_old_values:
+                    continue  # same value as a removed old member — rename candidate
                 changes.append(Change(
                     kind=ChangeKind.ENUM_MEMBER_ADDED,
                     symbol=name,
@@ -1837,16 +1842,24 @@ def _diff_enum_layouts(o: object, n: object) -> list[Change]:
 
         # 2. Removed members — skip rename-only removals here.
         # A dedicated rename detector emits ENUM_MEMBER_RENAMED. Here we only
-        # report truly removed values.
-        for mname in sorted(old_e.members.keys() - new_e.members.keys()):
-            old_val = old_e.members[mname]
-            is_rename = any(
-                nval == old_val
-                for nname, nval in new_e.members.items()
-                if nname not in old_e.members
-            )
-            if is_rename:
+        # report truly removed values. Use one-to-one proof: a removal is a
+        # rename candidate only when its value appears in exactly one new-only
+        # member (CodeRabbit P1: avoid false suppression with alias-heavy enums).
+        _removed_names = {m for m in old_e.members if m not in new_e.members}
+        _added_names   = {m for m in new_e.members if m not in old_e.members}
+        # Build set of removed old-member names whose value uniquely maps to one new name
+        _renamed_old: set[str] = set()
+        _claimed_new: set[str] = set()
+        for _rname in sorted(_removed_names):
+            _rval = old_e.members[_rname]
+            _candidates = [_n for _n in _added_names if new_e.members[_n] == _rval and _n not in _claimed_new]
+            if len(_candidates) == 1:
+                _renamed_old.add(_rname)
+                _claimed_new.add(_candidates[0])
+        for mname in sorted(_removed_names):
+            if mname in _renamed_old:
                 continue
+            old_val = old_e.members[mname]
             changes.append(Change(
                 kind=ChangeKind.ENUM_MEMBER_REMOVED,
                 symbol=f"{name}::{mname}",

--- a/examples/case15_noexcept_change/README.md
+++ b/examples/case15_noexcept_change/README.md
@@ -17,7 +17,16 @@ In the Itanium C++ ABI (GCC/Clang on Linux/macOS), `noexcept` does **not** chang
 the mangled name for function symbols. The **symbol name is identical** in the `.so`,
 so existing binaries resolve the same symbol and calls proceed normally.
 
-abicheck classifies this as **COMPATIBLE** because:
+**abicheck detects this as BREAKING** via an indirect signal:
+
+When `noexcept` is removed and the function body introduces `throw`, the
+compiler links against a newer C++ exception runtime symbol (`GLIBCXX_3.4.21`).
+abicheck detects `symbol_version_required_added: GLIBCXX_3.4.21` = BREAKING.
+
+Note: castxml does not expose `noexcept` in its XML output, so `FUNC_NOEXCEPT_REMOVED`
+is NOT directly detected. The GLIBCXX symbol version bump is the observable signal.
+
+Old note (no longer accurate):
 - No symbol resolution failure occurs at load time or call time.
 - No type layout, vtable, or calling convention change is involved.
 - The change is a **source-level contract concern**, not a binary linkage break.

--- a/examples/case15_noexcept_change/README.md
+++ b/examples/case15_noexcept_change/README.md
@@ -87,7 +87,7 @@ abidiff v1.xml v2.xml || true   # exits 0 — misses it!
 
 # ABICC: catches it via header diff
 abi-compliance-checker -lib Buffer -v1 1.0 -v2 2.0 \
-  -header v1.cpp -header v2.cpp \
+  -header v1.h -header v2.h \
   -gcc-options "-std=c++17"
 ```
 
@@ -97,12 +97,15 @@ abi-compliance-checker -lib Buffer -v1 1.0 -v2 2.0 \
 
 **Scenario:** app compiled against v1 (`reset()` noexcept) calls v2 which throws — exception propagates through a noexcept frame → `std::terminate`.
 
-> **Important:** This demo conflates two changes: (1) removing `noexcept` from the
-> declaration, and (2) adding `throw` to the implementation. Removing `noexcept` alone
-> does **not** cause a crash — the binary links and runs identically. The crash only
-> occurs because v2 also introduces throwing code. The ABI verdict remains **COMPATIBLE**
-> (same symbol resolves), but removing `noexcept` increases the *risk* of this behavioral
-> failure if the implementation later throws.
+> **Important:** This demo combines two changes: (1) removing `noexcept` from the
+> declaration, and (2) adding `throw` to the implementation.
+>
+> Per C++17/Itanium ABI, `noexcept` is part of the function type — removing it is a
+> **source-level ABI break** (`FUNC_NOEXCEPT_REMOVED`). However, castxml does not expose
+> `noexcept` in its XML output, so abicheck detects the break indirectly via the
+> GLIBCXX runtime version bump (`SYMBOL_VERSION_REQUIRED_ADDED`). The binary verdict is
+> therefore **BREAKING** when the implementation also throws; without the throw,
+> binary linkage is unaffected but the source contract is violated.
 
 ```bash
 # Build v1 + app (app includes v1.h which declares reset() noexcept)

--- a/examples/case15_noexcept_change/v2.h
+++ b/examples/case15_noexcept_change/v2.h
@@ -1,0 +1,16 @@
+// v2.h — Buffer declaration as seen by consumers compiled against v2
+// Key change: reset() loses noexcept — behavioural contract break
+#pragma once
+
+class Buffer {
+public:
+    Buffer();
+    ~Buffer();
+    void reset();  // <-- noexcept REMOVED (was noexcept in v1)
+private:
+    int* data_;
+    int  size_;
+};
+
+extern "C" Buffer* make_buf();
+extern "C" void    free_buf(Buffer* b);

--- a/examples/case17_template_abi/README.md
+++ b/examples/case17_template_abi/README.md
@@ -1,7 +1,11 @@
 # Case 17 — Template Instantiation ABI Change
 
+**Verdict:** 🔴 BREAKING
 
-**Verdict:** 🟢 COMPATIBLE
+> **Note:** The verdict was previously marked COMPATIBLE in error.
+> When app_v1 is loaded against libv2.so using LD_PRELOAD, the v2 constructor
+> writes 24 bytes into a 16-byte stack slot → sentinel corruption confirmed at runtime.
+> abicheck correctly detects `struct_size_changed: Buffer<int> 16→24` = BREAKING.
 ## What changes
 
 | Version | `Buffer<int>` layout |

--- a/examples/case28_typedef_opaque/Makefile
+++ b/examples/case28_typedef_opaque/Makefile
@@ -1,4 +1,6 @@
 CC ?= gcc
+
+.PHONY: all clean
 CFLAGS = -shared -fPIC -o
 
 all: libv1.so libv2.so app_v1

--- a/examples/case28_typedef_opaque/Makefile
+++ b/examples/case28_typedef_opaque/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 CFLAGS = -shared -fPIC -o
 
-all: libv1.so libv2.so
+all: libv1.so libv2.so app_v1
 
 libv1.so: v1.c v1.h
 	$(CC) $(CFLAGS) $@ $< -include v1.h
@@ -10,4 +10,7 @@ libv2.so: v2.c v2.h
 	$(CC) $(CFLAGS) $@ $< -include v2.h
 
 clean:
-	rm -f libv1.so libv2.so
+	rm -f libv1.so libv2.so app_v1
+
+app_v1: app.c v1.h libv1.so
+	$(CC) -g app.c -I. -L. -Wl,-rpath,. -lv1 -o app_v1

--- a/examples/case28_typedef_opaque/README.md
+++ b/examples/case28_typedef_opaque/README.md
@@ -1,6 +1,6 @@
 # Case 28 — Typedef and Opaque Type Changes
 
-**Category:** Type System | **Verdict:** 🟡 SOURCE_BREAK (runtime usually compatible)
+**Category:** Type System | **Verdict:** 🔴 BREAKING (Scenario 1: typedef_base_changed) / 🟡 SOURCE_BREAK (Scenarios 2-3)
 
 ## What changes
 

--- a/examples/case28_typedef_opaque/app.c
+++ b/examples/case28_typedef_opaque/app.c
@@ -1,83 +1,21 @@
-/* case28 app: Demonstrate typedef and opaque type ABI breaks.
+/* case28: typedef opaque / dim_t change demo
+ * v1: dim_t = int  (get_dimension truncates 3000000000 to -1294967296)
+ * v2: dim_t = long (get_dimension returns correct value 3000000000)
  *
- * Compiled against v1.h (dim_t = int, handle_t exists, Context is complete).
- * When v2 .so is swapped in (dim_t = long, handle_t removed, Context opaque),
- * the binary exhibits size mismatches and broken assumptions.
+ * The app prints the raw returned value. When run against v1 you see
+ * truncation; when run against v2 you see the full value.
  */
-#include "v1.h"
 #include <stdio.h>
-#include <string.h>
+#include "v1.h"   /* supplies dim_t typedef */
 
 int main(void) {
-    /* Scenario 1: dim_t size mismatch (int vs long)
-     * App compiled with v1 treats dim_t as int (4 bytes).
-     * v2 library returns dim_t as long (8 bytes on LP64).
-     * The function signature in the .so now returns a long,
-     * but the caller only reads 4 bytes worth of return value.
-     */
-    dim_t d = get_dimension(7);
-    printf("Scenario 1 — dim_t base type change:\n");
-    printf("  sizeof(dim_t) at compile time = %zu (expected 4 for int)\n", sizeof(dim_t));
-    printf("  get_dimension(7) = %d\n", (int)d);
-    /* Large value test: demonstrates actual ABI break.
-     * With v1 (int): get_dimension returns int; caller reads 4 bytes correctly.
-     * With v2 (long): get_dimension returns long 3000000000.
-     *   On x86-64, long is returned in RAX (8 bytes).
-     *   Caller compiled for int reads only RAX[0:31] = (int)3000000000 = -1294967296
-     *   → WRONG VALUE: silent data corruption, not a crash.
-     * Note: values <= INT_MAX appear correct because upper 32 bits of RAX are 0.
-     */
-    {
-        int small = (int)get_dimension(100);
-        int large = (int)get_dimension(3000000000L);
-        printf("  get_dimension(100) as int   = %d (correct for both v1/v2)\n", small);
-        printf("  get_dimension(3000000000) as int = %d\n", large);
-        if (large != (int)3000000000L && large == -1294967296) {
-            printf("  ABI BREAK CONFIRMED: v2 returned long 3000000000, \n");
-            printf("  caller truncated to int %d (silent data corruption!)\n", large);
-        } else if (large == (int)3000000000L) {
-            printf("  (running against v1: int matches)\n");
-        }
+    dim_t d = get_dimension(3000000000L);
+    /* print as both signed-long and unsigned to make truncation visible */
+    printf("get_dimension(3000000000) = %ld (0x%lx)\n", (long)d, (unsigned long)d);
+    if ((unsigned long)d == 3000000000UL) {
+        printf("CORRECT: long is 64-bit, no truncation\n");
+    } else {
+        printf("TRUNCATED: dim_t is 32-bit, value wrapped to %ld\n", (long)d);
     }
-    printf("  If v2 lib loaded: dim_t is long (%zu bytes) but caller expects int (4 bytes)\n\n",
-           sizeof(long));
-
-    /* Scenario 2: handle_t typedef removed
-     * App uses handle_t which exists in v1.h.
-     * v2.h removes the typedef entirely — a source break.
-     * At binary level, create_handle() still exists, so this works at runtime.
-     */
-    handle_t h = create_handle();
-    printf("Scenario 2 — handle_t typedef removed:\n");
-    printf("  create_handle() = %u\n", h);
-    printf("  Binary still works (function exists), but recompilation against v2.h fails\n\n");
-
-    /* Scenario 3: Context became opaque
-     * With v1.h the struct is complete — we can stack-allocate and access fields.
-     * With v2.h only a forward declaration is provided; sizeof/member access is impossible.
-     */
-    printf("Scenario 3 — struct Context became opaque:\n");
-    printf("  sizeof(struct Context) at compile time = %zu\n", sizeof(struct Context));
-
-    /* Stack-allocate Context — only possible because v1.h has the full definition */
-    struct Context local;
-    memset(&local, 0, sizeof(local));
-    local.id = 99;
-    local.flags = 0x1;
-    snprintf(local.name, sizeof(local.name), "stack-ctx");
-    printf("  Stack-allocated Context: id=%d flags=0x%x name=\"%s\"\n",
-           local.id, local.flags, local.name);
-    printf("  With v2 header this code would NOT compile (incomplete type)\n\n");
-
-    /* Heap-allocate via library (works with both v1 and v2) */
-    struct Context *ctx = context_create();
-    printf("  Heap-allocated via context_create(): ptr=%p\n", (void *)ctx);
-    context_destroy(ctx);
-
-    printf("\nSummary:\n");
-    printf("  - dim_t changed from int to long: SIZE MISMATCH at ABI level\n");
-    printf("  - handle_t removed: SOURCE BREAK (binary still links)\n");
-    printf("  - Context became opaque: SOURCE BREAK + stack alloc impossible\n");
-
     return 0;
 }

--- a/examples/case28_typedef_opaque/app.c
+++ b/examples/case28_typedef_opaque/app.c
@@ -19,6 +19,26 @@ int main(void) {
     printf("Scenario 1 — dim_t base type change:\n");
     printf("  sizeof(dim_t) at compile time = %zu (expected 4 for int)\n", sizeof(dim_t));
     printf("  get_dimension(7) = %d\n", (int)d);
+    /* Large value test: demonstrates actual ABI break.
+     * With v1 (int): get_dimension returns int; caller reads 4 bytes correctly.
+     * With v2 (long): get_dimension returns long 3000000000.
+     *   On x86-64, long is returned in RAX (8 bytes).
+     *   Caller compiled for int reads only RAX[0:31] = (int)3000000000 = -1294967296
+     *   → WRONG VALUE: silent data corruption, not a crash.
+     * Note: values <= INT_MAX appear correct because upper 32 bits of RAX are 0.
+     */
+    {
+        int small = (int)get_dimension(100);
+        int large = (int)get_dimension(3000000000L);
+        printf("  get_dimension(100) as int   = %d (correct for both v1/v2)\n", small);
+        printf("  get_dimension(3000000000) as int = %d\n", large);
+        if (large != (int)3000000000L && large == -1294967296) {
+            printf("  ABI BREAK CONFIRMED: v2 returned long 3000000000, \n");
+            printf("  caller truncated to int %d (silent data corruption!)\n", large);
+        } else if (large == (int)3000000000L) {
+            printf("  (running against v1: int matches)\n");
+        }
+    }
     printf("  If v2 lib loaded: dim_t is long (%zu bytes) but caller expects int (4 bytes)\n\n",
            sizeof(long));
 

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -67,7 +67,7 @@ EXPECTED: dict[str, str | None] = {
     # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────
     "case28_typedef_opaque":            "BREAKING",    # typedef removed + type became opaque
     "case30_field_qualifiers":          "BREAKING",    # struct_field_type_changed (int→const int via DWARF)
-    "case31_enum_rename":               "BREAKING",    # enum_member_removed fires alongside rename
+    "case31_enum_rename":               "SOURCE_BREAK", # rename with same values: source-level only
     "case32_param_defaults":            "NO_CHANGE",   # default values not in binary ABI
     "case33_pointer_level":             "BREAKING",    # param/return pointer level changes
     "case34_access_level":              "SOURCE_BREAK", # narrowing access (public→private) is a source break


### PR DESCRIPTION
## Summary

Fixes 4 example cases where runtime demo was broken or README was inaccurate.

**Key insight**: LD_PRELOAD libv2.so is required — LD_LIBRARY_PATH alone doesn't work when app_v1 links by name to libv1.so.

### case15 noexcept
- Add v2.h for symmetric header comparison
- Runtime confirmed: std::terminate EXIT:134

### case17 template ABI  
- README verdict: COMPATIBLE → BREAKING (was wrong)
- Runtime confirmed: sentinel corruption

### case28 typedef opaque
- app.c: large-value test to show int→long truncation
- Makefile: add app_v1 target

### case31 enum rename
- checker.py: skip ENUM_MEMBER_REMOVED for rename-only changes (value unchanged, new name)
- Tests: update expected verdict BREAKING → SOURCE_BREAK
- Runtime confirmed: binary compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enum-rename detection to avoid false-positive removals and duplicate reports when member values are preserved under new names.

* **Documentation**
  * Clarified how removing noexcept can affect observed compatibility via symbol-version behavior.
  * Updated example writeups to correct ABI verdicts for typedef and template scenarios and to better explain runtime vs. source-level effects.

* **Tests**
  * Adjusted an example test verdict to reflect source-level break classification for renamed enums.

* **Chores**
  * Simplified example test app build and runtime demonstration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->