### PR TITLE
Centralize policy registry + summary metrics; add detector capability contracts

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -69,8 +70,8 @@ class DiffResult:
 @dataclass(frozen=True)
 class _DetectorSpec:
     name: str
-    run: Any
-    is_supported: Any = None
+    run: Callable[[AbiSnapshot, AbiSnapshot], list[Change]]
+    is_supported: Callable[[AbiSnapshot, AbiSnapshot], tuple[bool, str | None]] | None = None
 
     def support(self, old: AbiSnapshot, new: AbiSnapshot) -> tuple[bool, str | None]:
         if self.is_supported is None:
@@ -1205,7 +1206,7 @@ def compare(
         _DetectorSpec(
             "advanced_dwarf",
             _diff_advanced_dwarf,
-            lambda o, n: ((o.dwarf_advanced is not None or n.dwarf_advanced is not None), "missing DWARF advanced metadata"),
+            lambda o, n: ((o.dwarf_advanced is not None and n.dwarf_advanced is not None), "missing DWARF advanced metadata"),
         ),
         _DetectorSpec("enum_renames", _diff_enum_renames),
         _DetectorSpec("field_qualifiers", _diff_field_qualifiers),

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -66,6 +65,17 @@ class DiffResult:
     def compatible(self) -> list[Change]:
         return [c for c in self.changes if c.kind in _COMPATIBLE_KINDS]
 
+
+@dataclass(frozen=True)
+class _DetectorSpec:
+    name: str
+    run: Any
+    is_supported: Any = None
+
+    def support(self, old: AbiSnapshot, new: AbiSnapshot) -> tuple[bool, str | None]:
+        if self.is_supported is None:
+            return True, None
+        return self.is_supported(old, new)
 
 def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
@@ -1182,41 +1192,52 @@ def compare(
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict."""
 
-    detector_fns: list[tuple[str, Callable[[AbiSnapshot, AbiSnapshot], list[Change]]]] = [
-        ("functions", _diff_functions),
-        ("variables", _diff_variables),
-        ("types", _diff_types),
-        ("enums", _diff_enums),
-        ("method_qualifiers", _diff_method_qualifiers),
-        ("unions", _diff_unions),
-        ("typedefs", _diff_typedefs),
-        ("elf", _diff_elf),
-        ("dwarf", _diff_dwarf),
-        ("advanced_dwarf", _diff_advanced_dwarf),
-        ("enum_renames", _diff_enum_renames),
-        ("field_qualifiers", _diff_field_qualifiers),
-        ("field_renames", _diff_field_renames),
-        ("param_defaults", _diff_param_defaults),
-        ("param_renames", _diff_param_renames),
-        ("pointer_levels", _diff_pointer_levels),
-        ("access_levels", _diff_access_levels),
-        ("anon_fields", _diff_anon_fields),
-        ("var_values", _diff_var_values),
-        ("type_kind_changes", _diff_type_kind_changes),
-        ("reserved_fields", _diff_reserved_fields),
-        ("const_overloads", _diff_const_overloads),
-        ("param_restrict", _diff_param_restrict),
-        ("param_va_list", _diff_param_va_list),
-        ("constants", _diff_constants),
-        ("var_access", _diff_var_access),
+    detector_fns: list[_DetectorSpec] = [
+        _DetectorSpec("functions", _diff_functions),
+        _DetectorSpec("variables", _diff_variables),
+        _DetectorSpec("types", _diff_types),
+        _DetectorSpec("enums", _diff_enums),
+        _DetectorSpec("method_qualifiers", _diff_method_qualifiers),
+        _DetectorSpec("unions", _diff_unions),
+        _DetectorSpec("typedefs", _diff_typedefs),
+        _DetectorSpec("elf", _diff_elf),
+        _DetectorSpec("dwarf", _diff_dwarf),
+        _DetectorSpec(
+            "advanced_dwarf",
+            _diff_advanced_dwarf,
+            lambda o, n: ((o.dwarf_advanced is not None or n.dwarf_advanced is not None), "missing DWARF advanced metadata"),
+        ),
+        _DetectorSpec("enum_renames", _diff_enum_renames),
+        _DetectorSpec("field_qualifiers", _diff_field_qualifiers),
+        _DetectorSpec("field_renames", _diff_field_renames),
+        _DetectorSpec("param_defaults", _diff_param_defaults),
+        _DetectorSpec("param_renames", _diff_param_renames),
+        _DetectorSpec("pointer_levels", _diff_pointer_levels),
+        _DetectorSpec("access_levels", _diff_access_levels),
+        _DetectorSpec("anon_fields", _diff_anon_fields),
+        _DetectorSpec("var_values", _diff_var_values),
+        _DetectorSpec("type_kind_changes", _diff_type_kind_changes),
+        _DetectorSpec("reserved_fields", _diff_reserved_fields),
+        _DetectorSpec("const_overloads", _diff_const_overloads),
+        _DetectorSpec("param_restrict", _diff_param_restrict),
+        _DetectorSpec("param_va_list", _diff_param_va_list),
+        _DetectorSpec("constants", _diff_constants),
+        _DetectorSpec("var_access", _diff_var_access),
     ]
 
     changes: list[Change] = []
     detector_results: list[DetectorResult] = []
-    for name, detector in detector_fns:
-        detected = detector(old, new)
+    for spec in detector_fns:
+        enabled, reason = spec.support(old, new)
+        if not enabled:
+            detector_results.append(
+                DetectorResult(name=spec.name, changes_count=0, enabled=False, coverage_gap=reason)
+            )
+            continue
+
+        detected = spec.run(old, new)
         changes.extend(detected)
-        detector_results.append(DetectorResult(name=name, changes_count=len(detected)))
+        detector_results.append(DetectorResult(name=spec.name, changes_count=len(detected), enabled=True))
 
     suppressed: list[Change] = []
     if suppression is not None:

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -330,15 +330,39 @@ SOURCE_BREAK_KINDS: set[ChangeKind] = {
 class PolicyEntry:
     default_verdict: Verdict
     severity: str
+    doc_slug: str
 
 
 POLICY_REGISTRY: dict[ChangeKind, PolicyEntry] = {
-    k: PolicyEntry(Verdict.BREAKING, "error") for k in BREAKING_KINDS
+    k: PolicyEntry(Verdict.BREAKING, "error", k.value) for k in BREAKING_KINDS
 } | {
-    k: PolicyEntry(Verdict.SOURCE_BREAK, "warning") for k in SOURCE_BREAK_KINDS
+    k: PolicyEntry(Verdict.SOURCE_BREAK, "warning", k.value) for k in SOURCE_BREAK_KINDS
 } | {
-    k: PolicyEntry(Verdict.COMPATIBLE, "note") for k in COMPATIBLE_KINDS
+    k: PolicyEntry(Verdict.COMPATIBLE, "warning", k.value) for k in COMPATIBLE_KINDS
 }
+
+
+def policy_for(kind: ChangeKind) -> PolicyEntry:
+    """Get policy metadata for a ChangeKind.
+
+    Unknown kinds are treated as BREAKING by default (fail-safe).
+    """
+    return POLICY_REGISTRY.get(kind, PolicyEntry(Verdict.BREAKING, "error", kind.value))
+
+
+def policy_registry_markdown() -> str:
+    """Build a markdown snippet for docs from the policy registry."""
+    lines = [
+        "| ChangeKind | Default verdict | Severity | Doc slug |",
+        "|---|---|---|---|",
+    ]
+    for kind in sorted(ChangeKind, key=lambda k: k.value):
+        entry = policy_for(kind)
+        lines.append(
+            f"| `{kind.value}` | `{entry.default_verdict.value}` | "
+            f"`{entry.severity}` | `{entry.doc_slug}` |"
+        )
+    return "\n".join(lines)
 
 def compute_verdict(changes: Sequence[HasKind]) -> Verdict:
     if not changes:
@@ -353,4 +377,3 @@ def compute_verdict(changes: Sequence[HasKind]) -> Verdict:
         return Verdict.COMPATIBLE
     # Unclassified change kinds default to BREAKING (fail-safe)
     return Verdict.BREAKING
-

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1262,15 +1262,10 @@ def compat_cmd(  # noqa: PLR0913
         click.echo(report_path.read_text(encoding="utf-8"))
 
     # Compute BC% for console output (matches ABICC console format)
-    from .checker import _BREAKING_KINDS as _BK  # noqa: PLC0415
-    breaking_count = sum(1 for c in result.changes if c.kind in _BK)
-    if breaking_count == 0:
-        _bc_pct = 100.0
-    elif old_symbol_count and old_symbol_count > 0:
-        _bc_pct = max(0.0, (old_symbol_count - breaking_count) / old_symbol_count * 100)
-    else:
-        _total = len(result.changes)
-        _bc_pct = max(0.0, (_total - breaking_count) / _total * 100) if _total > 0 else 0.0
+    from .report_summary import compatibility_metrics  # noqa: PLC0415
+    metrics = compatibility_metrics(result.changes, old_symbol_count)
+    breaking_count = metrics.breaking_count
+    _bc_pct = metrics.binary_compatibility_pct
 
     _do_echo(f"Binary compatibility: {_bc_pct:.1f}%", quiet)
     _do_echo(f"Total binary compatibility problems: {breaking_count}, warnings: 0", quiet)

--- a/abicheck/detectors.py
+++ b/abicheck/detectors.py
@@ -15,8 +15,12 @@ class ChangeLike(Protocol):
 
 class Detector(Protocol):
     name: str
+    description: str
 
     def run(self, old: AbiSnapshot, new: AbiSnapshot) -> list[ChangeLike]:
+        ...
+
+    def is_supported(self, old: AbiSnapshot, new: AbiSnapshot) -> tuple[bool, str | None]:
         ...
 
 
@@ -24,3 +28,5 @@ class Detector(Protocol):
 class DetectorResult:
     name: str
     changes_count: int
+    enabled: bool = True
+    coverage_gap: str | None = None

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
+from .report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
     from .checker import DiffResult
@@ -418,6 +419,7 @@ def _generate_compat_html(
     suppressed: list[object],
     suppressed_count: int,
     bc_pct: float,
+    affected_pct: float,
     breaking_count: int,
     verdict: str,
     lib_display: str,
@@ -462,14 +464,14 @@ def _generate_compat_html(
 
     compat_verdict = "incompatible" if verdict in ("BREAKING", "SOURCE_BREAK") else "compatible"
     bc_css = "incompatible" if bc_pct < 90 else ("warning" if bc_pct < 100 else "compatible")
-    affected_pct = f"{100 - bc_pct:.1f}" if old_symbol_count else "0"
+    affected_pct_label = f"{affected_pct:.1f}" if old_symbol_count else "0"
 
     kind_label = report_kind.capitalize()  # "Binary" or "Source"
 
     # META_DATA comment (semicolon-delimited, matches ABICC format)
     meta_data = (
         f"verdict:{compat_verdict};kind:{report_kind};"
-        f"affected:{affected_pct};"
+        f"affected:{affected_pct_label};"
         f"added:{len(added)};removed:{len(removed)};"
         f"type_problems_high:{tp_high};"
         f"type_problems_medium:{tp_med};"
@@ -620,18 +622,10 @@ def generate_html_report(
     added   = [ch for ch in changes if _change_bucket(ch) == "added"]
     changed = [ch for ch in changes if _change_bucket(ch) == "changed"]
 
-    # Binary Compatibility %
-    breaking_count = sum(1 for ch in changes if _is_breaking(ch))
-    if breaking_count == 0:
-        bc_pct = 100.0
-    elif old_symbol_count is not None and old_symbol_count > 0:
-        # ABICC-style: (total_old - breaking) / total_old * 100
-        # Clamp to 0% if breaking exceeds symbol count (stale snapshot edge case)
-        bc_pct = max(0.0, (old_symbol_count - breaking_count) / old_symbol_count * 100)
-    else:
-        # old_symbol_count is None or 0 — fall back to change-ratio approximation
-        total = len(changes)
-        bc_pct = max(0.0, (total - breaking_count) / total * 100) if total > 0 else 0.0
+    metrics = compatibility_metrics(changes, old_symbol_count)
+    breaking_count = metrics.breaking_count
+    bc_pct = metrics.binary_compatibility_pct
+    affected_pct = metrics.affected_pct
 
     h = html.escape
     lib_display  = h(lib_name)  if lib_name  else "library"
@@ -642,7 +636,7 @@ def generate_html_report(
         return _generate_compat_html(
             result, changes, removed, changed, added,
             suppressed, suppressed_count,
-            bc_pct, breaking_count, verdict,
+            bc_pct, affected_pct, breaking_count, verdict,
             lib_display, old_display, new_display,
             old_symbol_count, title,
             report_kind=report_kind,

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 import html
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
+from .checker_policy import HasKind
 from .report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
@@ -622,7 +623,7 @@ def generate_html_report(
     added   = [ch for ch in changes if _change_bucket(ch) == "added"]
     changed = [ch for ch in changes if _change_bucket(ch) == "changed"]
 
-    metrics = compatibility_metrics(changes, old_symbol_count)
+    metrics = compatibility_metrics(cast(list[HasKind], changes), old_symbol_count)
     breaking_count = metrics.breaking_count
     bc_pct = metrics.binary_compatibility_pct
     affected_pct = metrics.affected_pct

--- a/abicheck/report_summary.py
+++ b/abicheck/report_summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .checker import _BREAKING_KINDS
 from .checker import DiffResult
 
 
@@ -12,12 +13,48 @@ class ReportSummary:
     source_breaks: int
     compatible_additions: int
     total_changes: int
+    binary_compatibility_pct: float
+    affected_pct: float
+
+
+@dataclass(frozen=True)
+class CompatibilityMetrics:
+    breaking_count: int
+    binary_compatibility_pct: float
+    affected_pct: float
+
+
+def compatibility_metrics(changes: list[object], old_symbol_count: int | None = None) -> CompatibilityMetrics:
+    """Compute canonical ABICC-style binary compatibility counters/percentages."""
+    breaking_count = sum(1 for c in changes if getattr(c, "kind", None) in _BREAKING_KINDS)
+
+    if breaking_count == 0:
+        bc_pct = 100.0
+    elif old_symbol_count and old_symbol_count > 0:
+        bc_pct = max(0.0, (old_symbol_count - breaking_count) / old_symbol_count * 100)
+    else:
+        total = len(changes)
+        bc_pct = max(0.0, (total - breaking_count) / total * 100) if total > 0 else 0.0
+
+    if old_symbol_count and old_symbol_count > 0:
+        affected_pct = breaking_count / old_symbol_count * 100
+    else:
+        affected_pct = 0.0
+
+    return CompatibilityMetrics(
+        breaking_count=breaking_count,
+        binary_compatibility_pct=bc_pct,
+        affected_pct=affected_pct,
+    )
 
 
 def build_summary(result: DiffResult) -> ReportSummary:
+    metrics = compatibility_metrics(result.changes)
     return ReportSummary(
         breaking=len(result.breaking),
         source_breaks=len(result.source_breaks),
         compatible_additions=len(result.compatible),
         total_changes=len(result.changes),
+        binary_compatibility_pct=metrics.binary_compatibility_pct,
+        affected_pct=metrics.affected_pct,
     )

--- a/abicheck/report_summary.py
+++ b/abicheck/report_summary.py
@@ -1,10 +1,11 @@
 """Canonical summary metric computation for all report formats."""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
-from .checker import _BREAKING_KINDS
-from .checker import DiffResult
+from .checker import _BREAKING_KINDS, DiffResult
+from .checker_policy import HasKind
 
 
 @dataclass(frozen=True)
@@ -24,9 +25,9 @@ class CompatibilityMetrics:
     affected_pct: float
 
 
-def compatibility_metrics(changes: list[object], old_symbol_count: int | None = None) -> CompatibilityMetrics:
+def compatibility_metrics(changes: Sequence[HasKind], old_symbol_count: int | None = None) -> CompatibilityMetrics:
     """Compute canonical ABICC-style binary compatibility counters/percentages."""
-    breaking_count = sum(1 for c in changes if getattr(c, "kind", None) in _BREAKING_KINDS)
+    breaking_count = sum(1 for c in changes if c.kind in _BREAKING_KINDS)
 
     if breaking_count == 0:
         bc_pct = 100.0

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -36,6 +36,8 @@ def to_json(result: DiffResult, indent: int = 2) -> str:
             "source_breaks": summary.source_breaks,
             "compatible_additions": summary.compatible_additions,
             "total_changes": summary.total_changes,
+            "binary_compatibility_pct": round(summary.binary_compatibility_pct, 1),
+            "affected_pct": round(summary.affected_pct, 1),
         },
         "changes": [
             {
@@ -59,6 +61,15 @@ def to_json(result: DiffResult, indent: int = 2) -> str:
                 for c in result.suppressed_changes
             ],
         },
+        "detectors": [
+            {
+                "name": d.name,
+                "changes_count": d.changes_count,
+                "enabled": d.enabled,
+                "coverage_gap": d.coverage_gap,
+            }
+            for d in result.detector_results
+        ],
     }
     return json.dumps(d, indent=indent)
 

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -18,23 +18,12 @@ from pathlib import Path
 from typing import Any
 
 from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+from abicheck.checker_policy import policy_for
 
 # ---------------------------------------------------------------------------
 # Severity mapping
 # ---------------------------------------------------------------------------
 _BREAKING_SEVERITY = "error"
-_COMPATIBLE_SEVERITY = "warning"
-_NOTE_SEVERITY = "note"
-
-# ChangeKinds that are purely informational (compatible additions)
-_COMPATIBLE_KINDS: frozenset[ChangeKind] = frozenset(
-    {
-        ChangeKind.FUNC_ADDED,
-        ChangeKind.VAR_ADDED,
-        ChangeKind.SYMBOL_BINDING_STRENGTHENED,
-        ChangeKind.ENUM_MEMBER_ADDED,
-    }
-)
 
 # Rule ID = change_kind value (snake_case, already stable)
 
@@ -47,17 +36,16 @@ def _tool_version() -> str:
 
 
 def _severity(change: Change) -> str:
-    if change.kind in _COMPATIBLE_KINDS:
-        return _COMPATIBLE_SEVERITY
-    return _BREAKING_SEVERITY
+    return policy_for(change.kind).severity
 
 
 def _rule_for(kind: ChangeKind) -> dict[str, Any]:
     """Produce a SARIF reportingDescriptor for a ChangeKind."""
     rule_id = kind.value
-    severity = _BREAKING_SEVERITY if kind not in _COMPATIBLE_KINDS else _COMPATIBLE_SEVERITY
+    severity = policy_for(kind).severity
+    doc_slug = policy_for(kind).doc_slug
     help_uri = (
-        "https://github.com/napetrov/abicheck/blob/main/docs/libabigail_parity.md"
+        f"https://github.com/napetrov/abicheck/blob/main/docs/abi_breaking_cases_catalog.md#{doc_slug}"
     )
     return {
         "id": rule_id,

--- a/abicheck/xml_report.py
+++ b/abicheck/xml_report.py
@@ -43,9 +43,10 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from .checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
+from .checker_policy import HasKind
 from .report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
@@ -187,7 +188,7 @@ def _compute_section(
     total_type = sum(type_problems.values())
     total_symbol = sum(symbol_problems.values())
 
-    metrics = compatibility_metrics(filtered, old_symbol_count)
+    metrics = compatibility_metrics(cast(list[HasKind], filtered), old_symbol_count)
     breaking_count = metrics.breaking_count
     bc_pct = metrics.binary_compatibility_pct
     affected_pct = metrics.affected_pct

--- a/abicheck/xml_report.py
+++ b/abicheck/xml_report.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
+from .report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
     from .checker import DiffResult
@@ -186,20 +187,10 @@ def _compute_section(
     total_type = sum(type_problems.values())
     total_symbol = sum(symbol_problems.values())
 
-    breaking_count = len(breaking)
-    if breaking_count == 0:
-        bc_pct = 100.0
-    elif old_symbol_count is not None and old_symbol_count > 0:
-        bc_pct = max(0.0, (old_symbol_count - breaking_count) / old_symbol_count * 100)
-    else:
-        total = len(filtered)
-        bc_pct = max(0.0, (total - breaking_count) / total * 100) if total > 0 else 0.0
-
-    # Affected percentage (of old symbols)
-    if old_symbol_count and old_symbol_count > 0:
-        affected_pct = breaking_count / old_symbol_count * 100
-    else:
-        affected_pct = 0.0
+    metrics = compatibility_metrics(filtered, old_symbol_count)
+    breaking_count = metrics.breaking_count
+    bc_pct = metrics.binary_compatibility_pct
+    affected_pct = metrics.affected_pct
 
     verdict = "incompatible" if breaking_count > 0 else "compatible"
 

--- a/tests/test_detector_contracts.py
+++ b/tests/test_detector_contracts.py
@@ -1,0 +1,12 @@
+from abicheck.checker import compare
+from abicheck.model import AbiSnapshot
+
+
+def test_advanced_dwarf_detector_reports_coverage_gap_when_unsupported() -> None:
+    old = AbiSnapshot(library="libx.so", version="1.0")
+    new = AbiSnapshot(library="libx.so", version="2.0")
+
+    result = compare(old, new)
+    adv = next(d for d in result.detector_results if d.name == "advanced_dwarf")
+    assert adv.enabled is False
+    assert adv.coverage_gap == "missing DWARF advanced metadata"

--- a/tests/test_detector_contracts.py
+++ b/tests/test_detector_contracts.py
@@ -1,9 +1,24 @@
 from abicheck.checker import compare
+from abicheck.dwarf_advanced import AdvancedDwarfMetadata
 from abicheck.model import AbiSnapshot
 
 
 def test_advanced_dwarf_detector_reports_coverage_gap_when_unsupported() -> None:
     old = AbiSnapshot(library="libx.so", version="1.0")
+    new = AbiSnapshot(library="libx.so", version="2.0")
+
+    result = compare(old, new)
+    adv = next(d for d in result.detector_results if d.name == "advanced_dwarf")
+    assert adv.enabled is False
+    assert adv.coverage_gap == "missing DWARF advanced metadata"
+
+
+def test_advanced_dwarf_detector_requires_both_sides() -> None:
+    old = AbiSnapshot(
+        library="libx.so",
+        version="1.0",
+        dwarf_advanced=AdvancedDwarfMetadata(has_dwarf=True),
+    )
     new = AbiSnapshot(library="libx.so", version="2.0")
 
     result = compare(old, new)

--- a/tests/test_policy_registry_and_summary.py
+++ b/tests/test_policy_registry_and_summary.py
@@ -1,0 +1,38 @@
+from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+from abicheck.checker_policy import policy_for, policy_registry_markdown
+from abicheck.report_summary import build_summary, compatibility_metrics
+
+
+def test_policy_registry_has_doc_slug_and_severity() -> None:
+    entry = policy_for(ChangeKind.FUNC_REMOVED)
+    assert entry.doc_slug == "func_removed"
+    assert entry.severity == "error"
+
+
+def test_policy_registry_markdown_contains_header() -> None:
+    md = policy_registry_markdown()
+    assert "| ChangeKind | Default verdict | Severity | Doc slug |" in md
+    assert "`func_removed`" in md
+
+
+def test_summary_metrics_include_percentages() -> None:
+    result = DiffResult(
+        old_version="1.0",
+        new_version="2.0",
+        library="libx.so",
+        changes=[Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed")],
+        verdict=Verdict.BREAKING,
+    )
+    summary = build_summary(result)
+    assert summary.binary_compatibility_pct == 0.0
+    assert summary.affected_pct == 0.0
+
+
+def test_compatibility_metrics_use_old_symbol_count() -> None:
+    metrics = compatibility_metrics(
+        [Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed")],
+        old_symbol_count=10,
+    )
+    assert metrics.breaking_count == 1
+    assert round(metrics.binary_compatibility_pct, 1) == 90.0
+    assert round(metrics.affected_pct, 1) == 10.0

--- a/tests/test_policy_registry_and_summary.py
+++ b/tests/test_policy_registry_and_summary.py
@@ -36,3 +36,35 @@ def test_compatibility_metrics_use_old_symbol_count() -> None:
     assert metrics.breaking_count == 1
     assert round(metrics.binary_compatibility_pct, 1) == 90.0
     assert round(metrics.affected_pct, 1) == 10.0
+
+
+def test_compatibility_metrics_no_breaking_is_full_compatibility() -> None:
+    metrics = compatibility_metrics(
+        [Change(ChangeKind.FUNC_ADDED, "_Z3barv", "added")],
+        old_symbol_count=10,
+    )
+    assert metrics.breaking_count == 0
+    assert metrics.binary_compatibility_pct == 100.0
+    assert metrics.affected_pct == 0.0
+
+
+def test_compatibility_metrics_without_old_symbol_count_uses_change_ratio() -> None:
+    metrics = compatibility_metrics(
+        [
+            Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed"),
+            Change(ChangeKind.FUNC_ADDED, "_Z3barv", "added"),
+        ],
+    )
+    assert metrics.breaking_count == 1
+    assert round(metrics.binary_compatibility_pct, 1) == 50.0
+    assert metrics.affected_pct == 0.0
+
+
+def test_policy_for_unknown_kind_falls_back_to_breaking() -> None:
+    class _UnknownKind:
+        value = "unknown_kind"
+
+    entry = policy_for(_UnknownKind())  # type: ignore[arg-type]
+    assert entry.default_verdict == Verdict.BREAKING
+    assert entry.severity == "error"
+    assert entry.doc_slug == "unknown_kind"

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -119,6 +119,11 @@ class TestSeverityMapping:
         rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
         assert rule["defaultConfiguration"]["level"] == "warning"
 
+    def test_rule_help_uri_uses_policy_doc_slug(self) -> None:
+        doc = to_sarif(_make_result([_compatible_change()], verdict=Verdict.COMPATIBLE))
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["helpUri"].endswith("#func_added")
+
 
 # ---------------------------------------------------------------------------
 # Result content


### PR DESCRIPTION
### Motivation

- Provide a single source-of-truth for change kind policy metadata so reporters and tools use consistent verdict/severity/doc links.
- Centralize binary-compatibility counters/percentages into a canonical helper so all output adapters compute identical BC%/affected% metrics.
- Make detectors self-describing so the checker can gracefully skip unsupported detectors and report coverage gaps.

### Description

- Extended the policy registry shape in `abicheck/checker_policy.py` by adding a `PolicyEntry` field `doc_slug` and helper accessors `policy_for(ChangeKind)` and `policy_registry_markdown()` that emit a docs-friendly table.
- Added canonical summary computation in `abicheck/report_summary.py` with `compatibility_metrics(...)` and expanded `ReportSummary` to include `binary_compatibility_pct` and `affected_pct`; `build_summary()` now uses the shared metrics.
- Updated output adapters to consume the centralized metadata/metrics: JSON reporter now includes BC/affected percentages and detector metadata, SARIF reads severity/help links from the policy registry, and XML/HTML/CLI now use `compatibility_metrics(...)` for consistent BC computations.
- Introduced detector capability contracts in `abicheck/detectors.py` (added `is_supported` to the `Detector` protocol and extended `DetectorResult` with `enabled` and `coverage_gap`) and updated checker orchestration in `abicheck/checker.py` to use `_DetectorSpec` wrappers that can be skipped when unsupported and to emit `DetectorResult` entries accordingly (example: `advanced_dwarf` reports a coverage gap when DWARF advanced metadata is absent).
- Added unit tests covering the new behavior: `tests/test_policy_registry_and_summary.py` (policy registry + summary) and `tests/test_detector_contracts.py` (detector capability reporting).

### Testing

- Ran reporter/SARIF/XML/CLI focused tests with:
  - `PYTHONPATH=. pytest -q tests/test_reporter.py tests/test_sarif.py tests/test_xml_report.py tests/test_cli_unit.py` which passed (combined runs observed passing during the rollout).
- Exercised the new registry/metrics and detector tests together with core reporters via:
  - `PYTHONPATH=. pytest -q tests/test_policy_registry_and_summary.py tests/test_detector_contracts.py tests/test_reporter.py tests/test_sarif.py tests/test_xml_report.py tests/test_cli_unit.py` which completed successfully (`77 passed`).
- Verified checker unit suite with:
  - `PYTHONPATH=. pytest -q tests/test_checker.py` which also passed (`24 passed`).

All automated tests executed during the change verification passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4eaf5180832bbc0836cc6a71796a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detector results now include enabled/disabled status and coverage-gap reasons.
  * Reports include computed compatibility metrics: binary compatibility % and affected symbols %.
  * Policy registry exposes doc slugs and can render as markdown.

* **Improvements**
  * Advanced DWARF detector is selectively enabled when required metadata is present.
  * JSON, HTML and XML outputs now use the new compatibility metrics.

* **Tests**
  * Added tests for detector coverage reporting, policy registry, metrics, and SARIF help URIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->