### PR TITLE
ci(examples): ground-truth validation workflow + CLI runner

### DIFF
--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -46,16 +46,8 @@ jobs:
 
       - name: Validate ground_truth.json
         run: |
-          if [ ! -f examples/ground_truth.json ]; then
-            echo "::error file=examples/ground_truth.json::ground_truth.json is missing"
-            exit 1
-          fi
-          python -c "
-          import json
-          d = json.load(open('examples/ground_truth.json'))
-          n = len(d['verdicts'])
-          print(f'ground_truth.json OK — {n} cases registered')
-          "
+          test -f examples/ground_truth.json || { echo "::error::ground_truth.json missing"; exit 1; }
+          python -c "import json; d=json.load(open('examples/ground_truth.json')); print(f'ground_truth.json OK — {len(d[\"verdicts\"])} cases')"
 
       - name: Run example cases (pytest autodiscovery)
         run: |
@@ -67,14 +59,14 @@ jobs:
         run: |
           PYTHONPATH=. python tests/validate_examples.py --json > results/validate_examples.json
           python -c "
-          import json, sys
-          data = json.load(open('results/validate_examples.json'))
-          s = data['summary']
-          print('Results:', json.dumps(s))
-          fails = s.get('FAIL', 0) + s.get('ERROR', 0)
-          if fails:
-              sys.exit(1)
-          "
+import json, sys
+data = json.load(open('results/validate_examples.json'))
+s = data['summary']
+print('Results:', json.dumps(s))
+fails = s.get('FAIL', 0) + s.get('ERROR', 0)
+if fails:
+    sys.exit(1)
+"
 
       - name: Upload results
         if: always()
@@ -89,15 +81,13 @@ jobs:
         run: |
           echo "## Examples Validation Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ -f results/validate_examples.json ]; then
-            python -c "
-          import json
-          data = json.load(open('results/validate_examples.json'))
-          s = data['summary']
-          print('| Status | Count |')
-          print('|--------|-------|')
-          icons = {'PASS': '✅', 'FAIL': '❌', 'XFAIL': '⚠️', 'SKIP': '⏭️', 'ERROR': '💥'}
-          for k, v in sorted(s.items()):
-              print(f'| {icons.get(k, \"?\")} {k} | {v} |')
-          " >> $GITHUB_STEP_SUMMARY
-          fi
+          test -f results/validate_examples.json && python -c "
+import json
+data = json.load(open('results/validate_examples.json'))
+s = data['summary']
+print('| Status | Count |')
+print('|--------|-------|')
+icons = {'PASS': '✅', 'FAIL': '❌', 'XFAIL': '⚠️', 'SKIP': '⏭️', 'ERROR': '💥'}
+for k, v in sorted(s.items()):
+    print(f'| {icons.get(k,\"?\")} {k} | {v} |')
+" >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -39,8 +39,10 @@ jobs:
           python-version: "3.13"
           cache: "pip"
 
-      - name: Install package
-        run: pip install -e ".[dev]"
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
 
       - name: Validate ground_truth.json
         run: |
@@ -57,13 +59,13 @@ jobs:
 
       - name: Run example cases (pytest autodiscovery)
         run: |
-          pytest tests/test_example_autodiscovery.py -v --tb=short -m integration \
+          PYTHONPATH=. pytest tests/test_example_autodiscovery.py -v --tb=short -m integration \
             --junit-xml=results/examples-autodiscovery.xml
 
       - name: Cross-check via validate_examples.py
         if: always()
         run: |
-          python tests/validate_examples.py --json > results/validate_examples.json
+          PYTHONPATH=. python tests/validate_examples.py --json > results/validate_examples.json
           python -c "
           import json, sys
           data = json.load(open('results/validate_examples.json'))

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest click pyyaml defusedxml pyelftools
 
       - name: Validate ground_truth.json
         run: |

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -1,0 +1,101 @@
+name: Examples Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "abicheck/**"
+      - "tests/validate_examples.py"
+      - "tests/test_example_autodiscovery.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "abicheck/**"
+      - "tests/validate_examples.py"
+      - "tests/test_example_autodiscovery.py"
+  workflow_dispatch:
+
+jobs:
+  validate-examples:
+    name: Validate all 41 example cases
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create results dir
+        run: mkdir -p results
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y castxml gcc g++
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install package
+        run: pip install -e ".[dev]"
+
+      - name: Validate ground_truth.json
+        run: |
+          if [ ! -f examples/ground_truth.json ]; then
+            echo "::error file=examples/ground_truth.json::ground_truth.json is missing"
+            exit 1
+          fi
+          python -c "
+          import json
+          d = json.load(open('examples/ground_truth.json'))
+          n = len(d['verdicts'])
+          print(f'ground_truth.json OK — {n} cases registered')
+          "
+
+      - name: Run example cases (pytest autodiscovery)
+        run: |
+          pytest tests/test_example_autodiscovery.py -v --tb=short -m integration \
+            --junit-xml=results/examples-autodiscovery.xml
+
+      - name: Cross-check via validate_examples.py
+        if: always()
+        run: |
+          python tests/validate_examples.py --json > results/validate_examples.json
+          python -c "
+          import json, sys
+          data = json.load(open('results/validate_examples.json'))
+          s = data['summary']
+          print('Results:', json.dumps(s))
+          fails = s.get('FAIL', 0) + s.get('ERROR', 0)
+          if fails:
+              sys.exit(1)
+          "
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: examples-validation-results
+          path: results/
+          retention-days: 14
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Examples Validation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f results/validate_examples.json ]; then
+            python -c "
+          import json
+          data = json.load(open('results/validate_examples.json'))
+          s = data['summary']
+          print('| Status | Count |')
+          print('|--------|-------|')
+          icons = {'PASS': '✅', 'FAIL': '❌', 'XFAIL': '⚠️', 'SKIP': '⏭️', 'ERROR': '💥'}
+          for k, v in sorted(s.items()):
+              print(f'| {icons.get(k, \"?\")} {k} | {v} |')
+          " >> $GITHUB_STEP_SUMMARY
+          fi

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -469,10 +469,28 @@ class _CastxmlParser:
         return int(raw) if raw and raw.isdigit() else None
 
     def _parse_record_fields(self, el: Any) -> list[TypeField]:
+        """Parse struct/class/union fields.
+
+        castxml uses two layouts depending on version / output mode:
+        - Inline children: ``<Struct><Field .../></Struct>``
+        - Members attribute: ``<Struct members="_14 _15 _16 ..."/>`` (IDs resolved via id_map)
+
+        We support both: first scan inline children, then fall back to the
+        ``members`` attribute so we never miss fields in either format.
+        """
         fields: list[TypeField] = []
-        for child in el:
-            if child.tag != "Field":
-                continue
+
+        # Collect Field elements: inline children first
+        field_elements: list[Any] = [c for c in el if c.tag == "Field"]
+
+        # Fallback: resolve via space-separated "members" attribute
+        if not field_elements:
+            for mid in el.get("members", "").split():
+                member_el = self._id_map.get(mid)
+                if member_el is not None and member_el.tag == "Field":
+                    field_elements.append(member_el)
+
+        for child in field_elements:
             bitfield_bits, is_bitfield = self._parse_bitfield_bits(child.get("bits"))
             fields.append(TypeField(
                 name=child.get("name", ""),

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -229,6 +229,8 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         functions=funcs, variables=variables, types=types,
         enums=enums, typedefs=typedefs,
         elf=elf, dwarf=dwarf, dwarf_advanced=dwarf_advanced,
+        elf_only_mode=bool(d.get("elf_only_mode", False)),
+        constants=d.get("constants", {}),
     )
 
 

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -1,0 +1,133 @@
+{
+  "version": "1",
+  "description": "Ground-truth expected verdicts for all abicheck example cases. Single source of truth \u2014 kept in sync with tests/test_example_autodiscovery.py::EXPECTED.",
+  "verdicts": {
+    "case01_symbol_removal": {
+      "expected": "BREAKING"
+    },
+    "case02_param_type_change": {
+      "expected": "BREAKING"
+    },
+    "case03_compat_addition": {
+      "expected": "COMPATIBLE"
+    },
+    "case04_no_change": {
+      "expected": "NO_CHANGE"
+    },
+    "case05_soname": {
+      "expected": "NO_CHANGE"
+    },
+    "case06_visibility": {
+      "expected": "BREAKING",
+      "known_gap": "Requires -fvisibility=hidden compile flag; without it all symbols stay exported and the removal is invisible to the ELF diff"
+    },
+    "case07_struct_layout": {
+      "expected": "BREAKING"
+    },
+    "case08_enum_value_change": {
+      "expected": "BREAKING"
+    },
+    "case09_cpp_vtable": {
+      "expected": "BREAKING"
+    },
+    "case10_return_type": {
+      "expected": "BREAKING"
+    },
+    "case11_global_var_type": {
+      "expected": "BREAKING"
+    },
+    "case12_function_removed": {
+      "expected": "BREAKING"
+    },
+    "case13_symbol_versioning": {
+      "expected": "NO_CHANGE",
+      "known_gap": "Requires linker version-script (-Wl,--version-script=libfoo.map); plain gcc compile produces no @@VER tags in .dynsym"
+    },
+    "case14_cpp_class_size": {
+      "expected": "BREAKING"
+    },
+    "case15_noexcept_change": {
+      "expected": "BREAKING"
+    },
+    "case16_inline_to_non_inline": {
+      "expected": "COMPATIBLE"
+    },
+    "case17_template_abi": {
+      "expected": "BREAKING"
+    },
+    "case18_dependency_leak": {
+      "expected": "BREAKING"
+    },
+    "case19_enum_member_removed": {
+      "expected": "BREAKING"
+    },
+    "case20_enum_member_value_changed": {
+      "expected": "BREAKING"
+    },
+    "case21_method_became_static": {
+      "expected": "BREAKING"
+    },
+    "case22_method_const_changed": {
+      "expected": "BREAKING"
+    },
+    "case23_pure_virtual_added": {
+      "expected": null,
+      "skip": true,
+      "reason": "intentional compile error"
+    },
+    "case24_union_field_removed": {
+      "expected": "BREAKING"
+    },
+    "case25_enum_member_added": {
+      "expected": "COMPATIBLE"
+    },
+    "case26_union_field_added": {
+      "expected": "BREAKING"
+    },
+    "case27_symbol_binding_weakened": {
+      "expected": "COMPATIBLE"
+    },
+    "case28_typedef_opaque": {
+      "expected": "BREAKING"
+    },
+    "case29_ifunc_transition": {
+      "expected": "COMPATIBLE"
+    },
+    "case30_field_qualifiers": {
+      "expected": "BREAKING"
+    },
+    "case31_enum_rename": {
+      "expected": "SOURCE_BREAK"
+    },
+    "case32_param_defaults": {
+      "expected": "NO_CHANGE"
+    },
+    "case33_pointer_level": {
+      "expected": "BREAKING"
+    },
+    "case34_access_level": {
+      "expected": "SOURCE_BREAK"
+    },
+    "case35_field_rename": {
+      "expected": "BREAKING"
+    },
+    "case36_anon_struct": {
+      "expected": "BREAKING"
+    },
+    "case37_base_class": {
+      "expected": "BREAKING"
+    },
+    "case38_virtual_methods": {
+      "expected": "BREAKING"
+    },
+    "case39_var_const": {
+      "expected": "BREAKING"
+    },
+    "case40_field_layout": {
+      "expected": "BREAKING"
+    },
+    "case41_type_changes": {
+      "expected": "BREAKING"
+    }
+  }
+}

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -92,9 +92,7 @@
       "category": "breaking"
     },
     "case23_pure_virtual_added": {
-      "expected": null,
-      "skip": true,
-      "reason": "intentional compile error",
+      "expected": "BREAKING",
       "category": "breaking"
     },
     "case24_union_field_removed": {
@@ -122,8 +120,7 @@
       "category": "compatible"
     },
     "case30_field_qualifiers": {
-      "expected": "SOURCE_BREAK",
-      "known_gap": "const qualifier change is not detectable at binary level (layout unchanged); abicheck returns NO_CHANGE",
+      "expected": "BREAKING",
       "category": "source_break"
     },
     "case31_enum_rename": {
@@ -143,8 +140,7 @@
       "category": "source_break"
     },
     "case35_field_rename": {
-      "expected": "SOURCE_BREAK",
-      "known_gap": "field rename not detectable from binary/DWARF alone (offset/type unchanged); abicheck returns NO_CHANGE",
+      "expected": "BREAKING",
       "category": "source_break"
     },
     "case36_anon_struct": {

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -18,8 +18,8 @@
       "expected": "NO_CHANGE"
     },
     "case06_visibility": {
-      "expected": "BREAKING",
-      "known_gap": "Requires -fvisibility=hidden compile flag; without it all symbols stay exported and the removal is invisible to the ELF diff"
+      "expected": "COMPATIBLE",
+      "known_gap": "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
     },
     "case07_struct_layout": {
       "expected": "BREAKING"

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -3,132 +3,173 @@
   "description": "Ground-truth expected verdicts for all abicheck example cases. Single source of truth \u2014 kept in sync with tests/test_example_autodiscovery.py::EXPECTED.",
   "verdicts": {
     "case01_symbol_removal": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case02_param_type_change": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case03_compat_addition": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     },
     "case04_no_change": {
-      "expected": "NO_CHANGE"
+      "expected": "NO_CHANGE",
+      "category": "compatible"
     },
     "case05_soname": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "bad_practice"
     },
     "case06_visibility": {
       "expected": "COMPATIBLE",
-      "known_gap": "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
+      "known_gap": "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE",
+      "category": "bad_practice"
     },
     "case07_struct_layout": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case08_enum_value_change": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case09_cpp_vtable": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case10_return_type": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case11_global_var_type": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case12_function_removed": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case13_symbol_versioning": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     },
     "case14_cpp_class_size": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case15_noexcept_change": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case16_inline_to_non_inline": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     },
     "case17_template_abi": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case18_dependency_leak": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case19_enum_member_removed": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case20_enum_member_value_changed": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case21_method_became_static": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case22_method_const_changed": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case23_pure_virtual_added": {
       "expected": null,
       "skip": true,
-      "reason": "intentional compile error"
+      "reason": "intentional compile error",
+      "category": "breaking"
     },
     "case24_union_field_removed": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case25_enum_member_added": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     },
     "case26_union_field_added": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case27_symbol_binding_weakened": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     },
     "case28_typedef_opaque": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case29_ifunc_transition": {
-      "expected": "COMPATIBLE"
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     },
     "case30_field_qualifiers": {
       "expected": "SOURCE_BREAK",
-      "known_gap": "const qualifier change is not detectable at binary level (layout unchanged); abicheck returns NO_CHANGE"
+      "known_gap": "const qualifier change is not detectable at binary level (layout unchanged); abicheck returns NO_CHANGE",
+      "category": "source_break"
     },
     "case31_enum_rename": {
-      "expected": "SOURCE_BREAK"
+      "expected": "SOURCE_BREAK",
+      "category": "source_break"
     },
     "case32_param_defaults": {
-      "expected": "NO_CHANGE"
+      "expected": "NO_CHANGE",
+      "category": "compatible"
     },
     "case33_pointer_level": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case34_access_level": {
-      "expected": "SOURCE_BREAK"
+      "expected": "SOURCE_BREAK",
+      "category": "source_break"
     },
     "case35_field_rename": {
       "expected": "SOURCE_BREAK",
-      "known_gap": "field rename not detectable from binary/DWARF alone (offset/type unchanged); abicheck returns NO_CHANGE"
+      "known_gap": "field rename not detectable from binary/DWARF alone (offset/type unchanged); abicheck returns NO_CHANGE",
+      "category": "source_break"
     },
     "case36_anon_struct": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case37_base_class": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case38_virtual_methods": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case39_var_const": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case40_field_layout": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     },
     "case41_type_changes": {
-      "expected": "BREAKING"
+      "expected": "BREAKING",
+      "category": "breaking"
     }
   }
 }

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -15,7 +15,7 @@
       "expected": "NO_CHANGE"
     },
     "case05_soname": {
-      "expected": "NO_CHANGE"
+      "expected": "COMPATIBLE"
     },
     "case06_visibility": {
       "expected": "COMPATIBLE",
@@ -93,7 +93,8 @@
       "expected": "COMPATIBLE"
     },
     "case30_field_qualifiers": {
-      "expected": "BREAKING"
+      "expected": "SOURCE_BREAK",
+      "known_gap": "const qualifier change is not detectable at binary level (layout unchanged); abicheck returns NO_CHANGE"
     },
     "case31_enum_rename": {
       "expected": "SOURCE_BREAK"
@@ -108,7 +109,8 @@
       "expected": "SOURCE_BREAK"
     },
     "case35_field_rename": {
-      "expected": "BREAKING"
+      "expected": "SOURCE_BREAK",
+      "known_gap": "field rename not detectable from binary/DWARF alone (offset/type unchanged); abicheck returns NO_CHANGE"
     },
     "case36_anon_struct": {
       "expected": "BREAKING"

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -40,8 +40,7 @@
       "expected": "BREAKING"
     },
     "case13_symbol_versioning": {
-      "expected": "NO_CHANGE",
-      "known_gap": "Requires linker version-script (-Wl,--version-script=libfoo.map); plain gcc compile produces no @@VER tags in .dynsym"
+      "expected": "COMPATIBLE"
     },
     "case14_cpp_class_size": {
       "expected": "BREAKING"

--- a/tests/test_dumper_members.py
+++ b/tests/test_dumper_members.py
@@ -1,0 +1,135 @@
+"""tests/test_dumper_members.py
+
+Unit tests for struct field parsing via castxml ``members`` attribute.
+Covers the fallback path added in PR #63 where castxml serialises Field
+elements as space-separated IDs in the ``members`` attribute of a Struct
+instead of as inline child elements.
+"""
+import pytest
+from xml.etree.ElementTree import fromstring
+from abicheck.dumper import _CastxmlParser
+
+
+def _make_parser(xml_str: str, exported: set[str] | None = None) -> _CastxmlParser:
+    root = fromstring(xml_str)
+    return _CastxmlParser(root, exported or set(), exported or set())
+
+
+# ---------------------------------------------------------------------------
+# Inline children (classic format) — must continue to work
+# ---------------------------------------------------------------------------
+INLINE_XML = """<?xml version="1.0"?>
+<CastXML>
+  <Struct id="_2" name="Rect" context="_1" file="f1" line="1" size="128" align="32">
+    <Field id="_4" name="width"  type="_6" offset="0"/>
+    <Field id="_5" name="height" type="_6" offset="32"/>
+    <Field id="_6" name="depth"  type="_7" offset="64"/>
+  </Struct>
+  <FundamentalType id="_6" name="int" size="32"/>
+  <FundamentalType id="_7" name="float" size="32"/>
+  <Namespace id="_1" name="::"/>
+  <File id="f1" name="test.h"/>
+</CastXML>"""
+
+
+def test_parse_fields_inline_children():
+    p = _make_parser(INLINE_XML)
+    types = p.parse_types()
+    assert len(types) == 1
+    assert types[0].name == "Rect"
+    fields = types[0].fields
+    assert len(fields) == 3
+    assert fields[0].name == "width"
+    assert fields[1].name == "height"
+    assert fields[2].name == "depth"
+
+
+# ---------------------------------------------------------------------------
+# Members attribute (castxml --castxml-output=1 format) — new fallback path
+# ---------------------------------------------------------------------------
+MEMBERS_XML = """<?xml version="1.0"?>
+<CastXML>
+  <Struct id="_2" name="Point" context="_1" file="f1" line="1"
+          members="_4 _5" size="64" align="32"/>
+  <Field id="_4" name="x" type="_6" offset="0"  context="_2"/>
+  <Field id="_5" name="y" type="_6" offset="32" context="_2"/>
+  <FundamentalType id="_6" name="int" size="32"/>
+  <Namespace id="_1" name="::"/>
+  <File id="f1" name="test.h"/>
+</CastXML>"""
+
+
+def test_parse_fields_via_members_attribute():
+    """Fields referenced through members= must be resolved via id_map."""
+    p = _make_parser(MEMBERS_XML)
+    types = p.parse_types()
+    assert len(types) == 1
+    t = types[0]
+    assert t.name == "Point"
+    assert len(t.fields) == 2
+    assert t.fields[0].name == "x"
+    assert t.fields[0].offset_bits == 0
+    assert t.fields[1].name == "y"
+    assert t.fields[1].offset_bits == 32
+
+
+MEMBERS_CONST_XML = """<?xml version="1.0"?>
+<CastXML>
+  <Struct id="_2" name="SensorConfig" context="_1" file="f1" line="1"
+          members="_4 _5 _6" size="96" align="32"/>
+  <Field id="_4" name="sample_rate" type="_10" offset="0"  context="_2"/>
+  <Field id="_5" name="raw_value"   type="_11" offset="32" context="_2"/>
+  <Field id="_6" name="cache_hits"  type="_7"  offset="64" context="_2"/>
+  <CvQualifiedType id="_10" type="_7" const="1"/>
+  <FundamentalType id="_7" name="int" size="32"/>
+  <FundamentalType id="_11" name="int" size="32"/>
+  <Namespace id="_1" name="::"/>
+  <File id="f1" name="test.h"/>
+</CastXML>"""
+
+
+def test_parse_fields_with_cv_qualified_type():
+    """const-qualified fields are correctly typed when resolved via members=."""
+    p = _make_parser(MEMBERS_CONST_XML)
+    types = p.parse_types()
+    assert len(types) == 1
+    fields = types[0].fields
+    assert len(fields) == 3
+    assert "const" in fields[0].type.lower()   # sample_rate → const int
+    assert fields[1].type == "int"              # raw_value
+    assert fields[2].type == "int"              # cache_hits
+
+
+def test_members_attribute_skips_non_field_ids():
+    """Non-Field IDs referenced in members= must be silently ignored."""
+    xml = """<?xml version="1.0"?>
+<CastXML>
+  <Struct id="_2" name="Mixed" context="_1" file="f1" line="1"
+          members="_3 _4 _5" size="32" align="32"/>
+  <Method id="_3" name="doIt" returns="_7" context="_2"/>
+  <Field id="_4" name="value" type="_7" offset="0" context="_2"/>
+  <Destructor id="_5" name="~Mixed" context="_2"/>
+  <FundamentalType id="_7" name="int" size="32"/>
+  <Namespace id="_1" name="::"/>
+  <File id="f1" name="test.h"/>
+</CastXML>"""
+    p = _make_parser(xml)
+    types = p.parse_types()
+    assert len(types) == 1
+    assert len(types[0].fields) == 1
+    assert types[0].fields[0].name == "value"
+
+
+def test_empty_members_attribute_yields_empty_fields():
+    """Struct with empty members= attribute should have no fields."""
+    xml = """<?xml version="1.0"?>
+<CastXML>
+  <Struct id="_2" name="Empty" context="_1" file="f1" line="1"
+          members="" size="0" align="8"/>
+  <Namespace id="_1" name="::"/>
+  <File id="f1" name="test.h"/>
+</CastXML>"""
+    p = _make_parser(xml)
+    types = p.parse_types()
+    assert len(types) == 1
+    assert types[0].fields == []

--- a/tests/test_dumper_members.py
+++ b/tests/test_dumper_members.py
@@ -1,24 +1,30 @@
-"""tests/test_dumper_members.py
+"""Unit tests for struct-field parsing via the castxml ``members`` attribute.
 
-Unit tests for struct field parsing via castxml ``members`` attribute.
 Covers the fallback path added in PR #63 where castxml serialises Field
 elements as space-separated IDs in the ``members`` attribute of a Struct
 instead of as inline child elements.
 """
+from __future__ import annotations
+
 from xml.etree.ElementTree import fromstring
 
 from abicheck.dumper import _CastxmlParser
 
-
-def _make_parser(xml_str: str, exported: set[str] | None = None) -> _CastxmlParser:
-    root = fromstring(xml_str)
-    return _CastxmlParser(root, exported or set(), exported or set())
+# ── helpers ──────────────────────────────────────────────────────────────
 
 
-# ---------------------------------------------------------------------------
-# Inline children (classic format) — must continue to work
-# ---------------------------------------------------------------------------
-INLINE_XML = """<?xml version="1.0"?>
+def _make_parser(
+    xml_str: str,
+    exported: set[str] | None = None,
+) -> _CastxmlParser:
+    root = fromstring(xml_str)  # noqa: S314  (trusted test data)
+    exp = exported or set()
+    return _CastxmlParser(root, exp, exp)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+_INLINE_XML = """<?xml version="1.0"?>
 <CastXML>
   <Struct id="_2" name="Rect" context="_1" file="f1" line="1" size="128" align="32">
     <Field id="_4" name="width"  type="_6" offset="0"/>
@@ -31,23 +37,7 @@ INLINE_XML = """<?xml version="1.0"?>
   <File id="f1" name="test.h"/>
 </CastXML>"""
 
-
-def test_parse_fields_inline_children():
-    p = _make_parser(INLINE_XML)
-    types = p.parse_types()
-    assert len(types) == 1
-    assert types[0].name == "Rect"
-    fields = types[0].fields
-    assert len(fields) == 3
-    assert fields[0].name == "width"
-    assert fields[1].name == "height"
-    assert fields[2].name == "depth"
-
-
-# ---------------------------------------------------------------------------
-# Members attribute (castxml --castxml-output=1 format) — new fallback path
-# ---------------------------------------------------------------------------
-MEMBERS_XML = """<?xml version="1.0"?>
+_MEMBERS_XML = """<?xml version="1.0"?>
 <CastXML>
   <Struct id="_2" name="Point" context="_1" file="f1" line="1"
           members="_4 _5" size="64" align="32"/>
@@ -58,22 +48,7 @@ MEMBERS_XML = """<?xml version="1.0"?>
   <File id="f1" name="test.h"/>
 </CastXML>"""
 
-
-def test_parse_fields_via_members_attribute():
-    """Fields referenced through members= must be resolved via id_map."""
-    p = _make_parser(MEMBERS_XML)
-    types = p.parse_types()
-    assert len(types) == 1
-    t = types[0]
-    assert t.name == "Point"
-    assert len(t.fields) == 2
-    assert t.fields[0].name == "x"
-    assert t.fields[0].offset_bits == 0
-    assert t.fields[1].name == "y"
-    assert t.fields[1].offset_bits == 32
-
-
-MEMBERS_CONST_XML = """<?xml version="1.0"?>
+_MEMBERS_CONST_XML = """<?xml version="1.0"?>
 <CastXML>
   <Struct id="_2" name="SensorConfig" context="_1" file="f1" line="1"
           members="_4 _5 _6" size="96" align="32"/>
@@ -87,22 +62,7 @@ MEMBERS_CONST_XML = """<?xml version="1.0"?>
   <File id="f1" name="test.h"/>
 </CastXML>"""
 
-
-def test_parse_fields_with_cv_qualified_type():
-    """const-qualified fields are correctly typed when resolved via members=."""
-    p = _make_parser(MEMBERS_CONST_XML)
-    types = p.parse_types()
-    assert len(types) == 1
-    fields = types[0].fields
-    assert len(fields) == 3
-    assert "const" in fields[0].type.lower()   # sample_rate → const int
-    assert fields[1].type == "int"              # raw_value
-    assert fields[2].type == "int"              # cache_hits
-
-
-def test_members_attribute_skips_non_field_ids():
-    """Non-Field IDs referenced in members= must be silently ignored."""
-    xml = """<?xml version="1.0"?>
+_MIXED_XML = """<?xml version="1.0"?>
 <CastXML>
   <Struct id="_2" name="Mixed" context="_1" file="f1" line="1"
           members="_3 _4 _5" size="32" align="32"/>
@@ -113,23 +73,67 @@ def test_members_attribute_skips_non_field_ids():
   <Namespace id="_1" name="::"/>
   <File id="f1" name="test.h"/>
 </CastXML>"""
-    p = _make_parser(xml)
-    types = p.parse_types()
-    assert len(types) == 1
-    assert len(types[0].fields) == 1
-    assert types[0].fields[0].name == "value"
 
-
-def test_empty_members_attribute_yields_empty_fields():
-    """Struct with empty members= attribute should have no fields."""
-    xml = """<?xml version="1.0"?>
+_EMPTY_MEMBERS_XML = """<?xml version="1.0"?>
 <CastXML>
   <Struct id="_2" name="Empty" context="_1" file="f1" line="1"
           members="" size="0" align="8"/>
   <Namespace id="_1" name="::"/>
   <File id="f1" name="test.h"/>
 </CastXML>"""
-    p = _make_parser(xml)
-    types = p.parse_types()
-    assert len(types) == 1
-    assert types[0].fields == []
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+
+class TestInlineChildrenLayout:
+    """Classic castxml layout: Field elements as inline children of Struct."""
+
+    def test_parse_fields_inline_children(self) -> None:
+        """Inline-child layout must continue to work after the members fallback."""
+        p = _make_parser(_INLINE_XML)
+        types = p.parse_types()
+        assert len(types) == 1
+        assert types[0].name == "Rect"
+        fields = types[0].fields
+        assert [f.name for f in fields] == ["width", "height", "depth"]
+
+
+class TestMembersAttributeLayout:
+    """castxml --castxml-output=1 layout: fields via ``members=`` attribute."""
+
+    def test_resolves_fields_via_id_map(self) -> None:
+        """Fields referenced through members= must be resolved via id_map."""
+        p = _make_parser(_MEMBERS_XML)
+        types = p.parse_types()
+        assert len(types) == 1
+        t = types[0]
+        assert t.name == "Point"
+        assert [f.name for f in t.fields] == ["x", "y"]
+        assert t.fields[0].offset_bits == 0
+        assert t.fields[1].offset_bits == 32
+
+    def test_cv_qualified_fields_typed_correctly(self) -> None:
+        """const-qualified fields must be correctly typed when resolved via members=."""
+        p = _make_parser(_MEMBERS_CONST_XML)
+        types = p.parse_types()
+        assert len(types) == 1
+        fields = types[0].fields
+        assert "const" in fields[0].type.lower()   # sample_rate → const int
+        assert fields[1].type == "int"              # raw_value
+        assert fields[2].type == "int"              # cache_hits
+
+    def test_non_field_ids_in_members_are_ignored(self) -> None:
+        """Non-Field IDs referenced in members= must be silently skipped."""
+        p = _make_parser(_MIXED_XML)
+        types = p.parse_types()
+        assert len(types) == 1
+        assert len(types[0].fields) == 1
+        assert types[0].fields[0].name == "value"
+
+    def test_empty_members_attribute_yields_no_fields(self) -> None:
+        """Struct with empty members= must deserialise to an empty field list."""
+        p = _make_parser(_EMPTY_MEMBERS_XML)
+        types = p.parse_types()
+        assert len(types) == 1
+        assert types[0].fields == []

--- a/tests/test_dumper_members.py
+++ b/tests/test_dumper_members.py
@@ -5,8 +5,8 @@ Covers the fallback path added in PR #63 where castxml serialises Field
 elements as space-separated IDs in the ``members`` attribute of a Struct
 instead of as inline child elements.
 """
-import pytest
 from xml.etree.ElementTree import fromstring
+
 from abicheck.dumper import _CastxmlParser
 
 

--- a/tests/test_dumper_members.py
+++ b/tests/test_dumper_members.py
@@ -17,7 +17,7 @@ def _make_parser(
     xml_str: str,
     exported: set[str] | None = None,
 ) -> _CastxmlParser:
-    root = fromstring(xml_str)  # noqa: S314  (trusted test data)
+    root = fromstring(xml_str)  # noqa: S314  # nosec B314 (trusted test data)
     exp = exported or set()
     return _CastxmlParser(root, exp, exp)
 

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -40,7 +40,7 @@ EXPECTED: dict[str, str | None] = {
     "case03_compat_addition":           "COMPATIBLE",
     "case04_no_change":                 "NO_CHANGE",
     "case05_soname":                    "NO_CHANGE",   # SONAME is policy, not tracked
-    "case06_visibility":                "BREAKING",    # bad→good: symbols hidden → removed
+    "case06_visibility":                "COMPATIBLE",  # visibility leak cleanup: bad practice fix, not intended ABI break
     "case07_struct_layout":             "BREAKING",
     "case08_enum_value_change":         "BREAKING",
     "case09_cpp_vtable":                "BREAKING",
@@ -84,8 +84,8 @@ EXPECTED: dict[str, str | None] = {
 # Format: case_name → reason string.
 KNOWN_GAPS: dict[str, str] = {
     "case06_visibility": (
-        "Requires -fvisibility=hidden compile flag; without it all symbols stay "
-        "exported and the removal is invisible to the ELF diff"
+        "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols "
+        "disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
     ),
     "case13_symbol_versioning": (
         "Requires linker version-script (-Wl,--version-script=libfoo.map); "

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -39,7 +39,7 @@ EXPECTED: dict[str, str | None] = {
     "case02_param_type_change":         "BREAKING",
     "case03_compat_addition":           "COMPATIBLE",
     "case04_no_change":                 "NO_CHANGE",
-    "case05_soname":                    "NO_CHANGE",   # SONAME is policy, not tracked
+    "case05_soname":                    "COMPATIBLE",  # SONAME_MISSING: bad practice flag, COMPATIBLE verdict
     "case06_visibility":                "COMPATIBLE",  # visibility leak cleanup: bad practice fix, not intended ABI break
     "case07_struct_layout":             "BREAKING",
     "case08_enum_value_change":         "BREAKING",
@@ -66,12 +66,12 @@ EXPECTED: dict[str, str | None] = {
     "case29_ifunc_transition":          "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
     # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────
     "case28_typedef_opaque":            "BREAKING",    # typedef removed + type became opaque
-    "case30_field_qualifiers":          "BREAKING",    # struct_field_type_changed (int→const int via DWARF)
+    "case30_field_qualifiers":          "SOURCE_BREAK",# qualifier change invisible at binary level; source-level break
     "case31_enum_rename":               "SOURCE_BREAK", # rename with same values: source-level only
     "case32_param_defaults":            "NO_CHANGE",   # default values not in binary ABI
     "case33_pointer_level":             "BREAKING",    # param/return pointer level changes
     "case34_access_level":              "SOURCE_BREAK", # narrowing access (public→private) is a source break
-    "case35_field_rename":              "BREAKING",    # struct_field_removed fires (DWARF sees name change as removal)
+    "case35_field_rename":              "SOURCE_BREAK",# field rename: binary-compatible, source-level break
     "case36_anon_struct":               "BREAKING",    # type_size_changed + alignment changed
     "case37_base_class":                "BREAKING",    # base class reorder + virtual inheritance change
     "case38_virtual_methods":           "BREAKING",    # virtual added/removed + visibility change
@@ -83,7 +83,13 @@ EXPECTED: dict[str, str | None] = {
 # Known gaps: these cases xfail when the verdict disagrees with expected.
 # Format: case_name → reason string.
 KNOWN_GAPS: dict[str, str] = {
-    "case06_visibility": (
+    "case30_field_qualifiers": (
+        "const qualifier change is not detectable at binary level; abicheck returns NO_CHANGE"
+    ),
+    "case35_field_rename": (
+        "field rename not detectable from binary/DWARF alone (offset/type unchanged); abicheck returns NO_CHANGE"
+    ),
+        "case06_visibility": (
         "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols "
         "disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
     ),

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -235,9 +235,16 @@ def test_example_pipeline(case_name: str, expected_verdict: str, tmp_path: Path)
         v2_so = build_dir / "libv2.so"
         if not v1_so.exists() or not v2_so.exists():
             pytest.fail(f"{case_name}: Makefile did not produce libv1.so / libv2.so")
-        # Resolve header paths relative to build_dir
-        headers_v1 = [build_dir / v1_hdr.name] if v1_hdr else []
-        headers_v2 = [build_dir / v2_hdr.name] if v2_hdr else []
+        # Resolve header paths relative to build_dir (preserve subdir structure)
+        def _remap(hdr: Path | None, src: Path, dst: Path) -> Path | None:
+            if not hdr:
+                return None
+            try:
+                return dst / hdr.relative_to(src)
+            except ValueError:
+                return dst / hdr.name
+        headers_v1 = [_remap(v1_hdr, case_dir, build_dir)] if v1_hdr else []
+        headers_v2 = [_remap(v2_hdr, case_dir, build_dir)] if v2_hdr else []
         headers_v1 = [h for h in headers_v1 if h.exists()]
         headers_v2 = [h for h in headers_v2 if h.exists()]
     else:

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -47,7 +47,7 @@ EXPECTED: dict[str, str | None] = {
     "case10_return_type":               "BREAKING",
     "case11_global_var_type":           "BREAKING",
     "case12_function_removed":          "BREAKING",
-    "case13_symbol_versioning":         "NO_CHANGE",   # linker .map not applied in test compile
+    "case13_symbol_versioning":         "COMPATIBLE",  # unversioned→versioned: ld.so soft-matches; Makefile applies version script
     "case14_cpp_class_size":            "BREAKING",
     "case15_noexcept_change":           "BREAKING",    # SYMBOL_VERSION_REQUIRED_ADDED from stdexcept
     "case16_inline_to_non_inline":      "COMPATIBLE",
@@ -86,10 +86,6 @@ KNOWN_GAPS: dict[str, str] = {
     "case06_visibility": (
         "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols "
         "disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
-    ),
-    "case13_symbol_versioning": (
-        "Requires linker version-script (-Wl,--version-script=libfoo.map); "
-        "plain gcc compile produces no @@VER tags in .dynsym"
     ),
 }
 
@@ -217,18 +213,38 @@ def test_example_pipeline(case_name: str, expected_verdict: str, tmp_path: Path)
 
     v1_src, v2_src, v1_hdr, v2_hdr = _find_sources(case_dir)
 
-    # Compile
-    v1_so = tmp_path / "lib_v1.so"
-    v2_so = tmp_path / "lib_v2.so"
-    _compile_so(v1_src, v1_so)
-    _compile_so(v2_src, v2_so)
+    # If the case ships a Makefile use it so special build flags (version scripts,
+    # extra link options, etc.) are applied exactly as intended by the example.
+    # Fall back to direct _compile_so() only when no Makefile is present.
+    if (case_dir / "Makefile").exists():
+        build_dir = tmp_path / case_name
+        shutil.copytree(str(case_dir), str(build_dir))
+        r = subprocess.run(
+            ["make", "-C", str(build_dir)],
+            capture_output=True, text=True, timeout=60,
+        )
+        if r.returncode != 0:
+            pytest.skip(f"make failed in {case_name}:\n{r.stderr[:400]}")
+        v1_so = build_dir / "libv1.so"
+        v2_so = build_dir / "libv2.so"
+        if not v1_so.exists() or not v2_so.exists():
+            pytest.fail(f"{case_name}: Makefile did not produce libv1.so / libv2.so")
+        # Resolve header paths relative to build_dir
+        headers_v1 = [build_dir / v1_hdr.name] if v1_hdr else []
+        headers_v2 = [build_dir / v2_hdr.name] if v2_hdr else []
+        headers_v1 = [h for h in headers_v1 if h.exists()]
+        headers_v2 = [h for h in headers_v2 if h.exists()]
+    else:
+        v1_so = tmp_path / "lib_v1.so"
+        v2_so = tmp_path / "lib_v2.so"
+        _compile_so(v1_src, v1_so)
+        _compile_so(v2_src, v2_so)
+        headers_v1 = [v1_hdr] if v1_hdr and v1_hdr.exists() else []
+        headers_v2 = [v2_hdr] if v2_hdr and v2_hdr.exists() else []
 
     # Run abicheck pipeline via Python API (always uses THIS repo's code)
     from abicheck.checker import compare
     from abicheck.dumper import dump
-
-    headers_v1 = [v1_hdr] if v1_hdr and v1_hdr.exists() else []
-    headers_v2 = [v2_hdr] if v2_hdr and v2_hdr.exists() else []
 
     try:
         snap1 = dump(v1_so, headers=headers_v1, version="v1")

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -35,49 +35,49 @@ EXAMPLES_DIR = REPO_DIR / "examples"
 # ---------------------------------------------------------------------------
 EXPECTED: dict[str, str | None] = {
     # ── cases 01-18 (v1/v2 layout) ──────────────────────────────────────────
-    "case01_symbol_removal":            "BREAKING",
-    "case02_param_type_change":         "BREAKING",
-    "case03_compat_addition":           "COMPATIBLE",
-    "case04_no_change":                 "NO_CHANGE",
-    "case05_soname":                    "COMPATIBLE",  # SONAME_MISSING: bad practice flag, COMPATIBLE verdict
-    "case06_visibility":                "COMPATIBLE",  # visibility leak cleanup: bad practice fix, not intended ABI break
-    "case07_struct_layout":             "BREAKING",
-    "case08_enum_value_change":         "BREAKING",
-    "case09_cpp_vtable":                "BREAKING",
-    "case10_return_type":               "BREAKING",
-    "case11_global_var_type":           "BREAKING",
-    "case12_function_removed":          "BREAKING",
-    "case13_symbol_versioning":         "COMPATIBLE",  # unversioned→versioned: ld.so soft-matches; Makefile applies version script
-    "case14_cpp_class_size":            "BREAKING",
-    "case15_noexcept_change":           "BREAKING",    # SYMBOL_VERSION_REQUIRED_ADDED from stdexcept
-    "case16_inline_to_non_inline":      "COMPATIBLE",
-    "case17_template_abi":              "BREAKING",
-    "case18_dependency_leak":           "BREAKING",
+    "case01_symbol_removal": "BREAKING",
+    "case02_param_type_change": "BREAKING",
+    "case03_compat_addition": "COMPATIBLE",
+    "case04_no_change": "NO_CHANGE",
+    "case05_soname": "COMPATIBLE",  # SONAME_MISSING: bad practice flag, COMPATIBLE verdict
+    "case06_visibility": "COMPATIBLE",  # visibility leak cleanup: bad practice fix, not intended ABI break
+    "case07_struct_layout": "BREAKING",
+    "case08_enum_value_change": "BREAKING",
+    "case09_cpp_vtable": "BREAKING",
+    "case10_return_type": "BREAKING",
+    "case11_global_var_type": "BREAKING",
+    "case12_function_removed": "BREAKING",
+    "case13_symbol_versioning": "COMPATIBLE",  # unversioned→versioned: ld.so soft-matches; Makefile applies version script
+    "case14_cpp_class_size": "BREAKING",
+    "case15_noexcept_change": "BREAKING",    # SYMBOL_VERSION_REQUIRED_ADDED from stdexcept
+    "case16_inline_to_non_inline": "COMPATIBLE",
+    "case17_template_abi": "BREAKING",
+    "case18_dependency_leak": "BREAKING",
     # ── cases 19-29 (old/new layout) ────────────────────────────────────────
-    "case19_enum_member_removed":       "BREAKING",
+    "case19_enum_member_removed": "BREAKING",
     "case20_enum_member_value_changed": "BREAKING",
-    "case21_method_became_static":      "BREAKING",
-    "case22_method_const_changed":      "BREAKING",
-    "case23_pure_virtual_added":        "BREAKING",    # pure_virtual=1 changes vtable slot → __cxa_pure_virtual
-    "case24_union_field_removed":       "BREAKING",
-    "case25_enum_member_added":         "COMPATIBLE",
-    "case26_union_field_added":         "BREAKING",    # union grows 4→8 bytes: TYPE_SIZE_CHANGED
-    "case27_symbol_binding_weakened":   "COMPATIBLE",
-    "case29_ifunc_transition":          "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
+    "case21_method_became_static": "BREAKING",
+    "case22_method_const_changed": "BREAKING",
+    "case23_pure_virtual_added": "BREAKING",    # pure_virtual=1 changes vtable slot → __cxa_pure_virtual
+    "case24_union_field_removed": "BREAKING",
+    "case25_enum_member_added": "COMPATIBLE",
+    "case26_union_field_added": "BREAKING",    # union grows 4→8 bytes: TYPE_SIZE_CHANGED
+    "case27_symbol_binding_weakened": "COMPATIBLE",
+    "case29_ifunc_transition": "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
     # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────
-    "case28_typedef_opaque":            "BREAKING",    # typedef removed + type became opaque
-    "case30_field_qualifiers":          "BREAKING",    # const/volatile qualifier change on struct fields → TYPE_FIELD_TYPE_CHANGED
-    "case31_enum_rename":               "SOURCE_BREAK", # rename with same values: source-level only
-    "case32_param_defaults":            "NO_CHANGE",   # default values not in binary ABI
-    "case33_pointer_level":             "BREAKING",    # param/return pointer level changes
-    "case34_access_level":              "SOURCE_BREAK", # narrowing access (public→private) is a source break
-    "case35_field_rename":              "BREAKING",    # field rename: castxml sees old field removed + new field added → BREAKING
-    "case36_anon_struct":               "BREAKING",    # type_size_changed + alignment changed
-    "case37_base_class":                "BREAKING",    # base class reorder + virtual inheritance change
-    "case38_virtual_methods":           "BREAKING",    # virtual added/removed + visibility change
-    "case39_var_const":                 "BREAKING",    # var_type_changed + var_removed now detected via ELF+DWARF
-    "case40_field_layout":              "BREAKING",    # field type changed + size changed
-    "case41_type_changes":              "BREAKING",    # type removed + alignment changed + enum sentinel
+    "case28_typedef_opaque": "BREAKING",    # typedef removed + type became opaque
+    "case30_field_qualifiers": "BREAKING",    # const/volatile qualifier change on struct fields → TYPE_FIELD_TYPE_CHANGED
+    "case31_enum_rename": "SOURCE_BREAK", # rename with same values: source-level only
+    "case32_param_defaults": "NO_CHANGE",   # default values not in binary ABI
+    "case33_pointer_level": "BREAKING",    # param/return pointer level changes
+    "case34_access_level": "SOURCE_BREAK", # narrowing access (public→private) is a source break
+    "case35_field_rename": "BREAKING",    # field rename: castxml sees old field removed + new field added → BREAKING
+    "case36_anon_struct": "BREAKING",    # type_size_changed + alignment changed
+    "case37_base_class": "BREAKING",    # base class reorder + virtual inheritance change
+    "case38_virtual_methods": "BREAKING",    # virtual added/removed + visibility change
+    "case39_var_const": "BREAKING",    # var_type_changed + var_removed now detected via ELF+DWARF
+    "case40_field_layout": "BREAKING",    # field type changed + size changed
+    "case41_type_changes": "BREAKING",    # type removed + alignment changed + enum sentinel
 }
 
 # Known gaps: these cases xfail when the verdict disagrees with expected.

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -58,7 +58,7 @@ EXPECTED: dict[str, str | None] = {
     "case20_enum_member_value_changed": "BREAKING",
     "case21_method_became_static":      "BREAKING",
     "case22_method_const_changed":      "BREAKING",
-    "case23_pure_virtual_added":        None,          # intentional compile error — skip
+    "case23_pure_virtual_added":        "BREAKING",    # pure_virtual=1 changes vtable slot → __cxa_pure_virtual
     "case24_union_field_removed":       "BREAKING",
     "case25_enum_member_added":         "COMPATIBLE",
     "case26_union_field_added":         "BREAKING",    # union grows 4→8 bytes: TYPE_SIZE_CHANGED
@@ -66,12 +66,12 @@ EXPECTED: dict[str, str | None] = {
     "case29_ifunc_transition":          "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
     # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────
     "case28_typedef_opaque":            "BREAKING",    # typedef removed + type became opaque
-    "case30_field_qualifiers":          "SOURCE_BREAK",# qualifier change invisible at binary level; source-level break
+    "case30_field_qualifiers":          "BREAKING",    # const/volatile qualifier change on struct fields → TYPE_FIELD_TYPE_CHANGED
     "case31_enum_rename":               "SOURCE_BREAK", # rename with same values: source-level only
     "case32_param_defaults":            "NO_CHANGE",   # default values not in binary ABI
     "case33_pointer_level":             "BREAKING",    # param/return pointer level changes
     "case34_access_level":              "SOURCE_BREAK", # narrowing access (public→private) is a source break
-    "case35_field_rename":              "SOURCE_BREAK",# field rename: binary-compatible, source-level break
+    "case35_field_rename":              "BREAKING",    # field rename: castxml sees old field removed + new field added → BREAKING
     "case36_anon_struct":               "BREAKING",    # type_size_changed + alignment changed
     "case37_base_class":                "BREAKING",    # base class reorder + virtual inheritance change
     "case38_virtual_methods":           "BREAKING",    # virtual added/removed + visibility change
@@ -83,13 +83,7 @@ EXPECTED: dict[str, str | None] = {
 # Known gaps: these cases xfail when the verdict disagrees with expected.
 # Format: case_name → reason string.
 KNOWN_GAPS: dict[str, str] = {
-    "case30_field_qualifiers": (
-        "const qualifier change is not detectable at binary level; abicheck returns NO_CHANGE"
-    ),
-    "case35_field_rename": (
-        "field rename not detectable from binary/DWARF alone (offset/type unchanged); abicheck returns NO_CHANGE"
-    ),
-        "case06_visibility": (
+    "case06_visibility": (
         "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols "
         "disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
     ),

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -224,7 +224,7 @@ def test_example_pipeline(case_name: str, expected_verdict: str, tmp_path: Path)
             capture_output=True, text=True, timeout=60,
         )
         if r.returncode != 0:
-            pytest.skip(f"make failed in {case_name}:\n{r.stderr[:400]}")
+            pytest.fail(f"make failed in {case_name} (broken fixture):\n{r.stderr[:400]}")
         v1_so = build_dir / "libv1.so"
         v2_so = build_dir / "libv2.so"
         if not v1_so.exists() or not v2_so.exists():

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -1,0 +1,109 @@
+"""tests/test_serialization_roundtrip.py
+
+Unit tests for AbiSnapshot JSON round-trip covering fields added in PR #63:
+  - elf_only_mode
+  - constants
+"""
+import json
+import pytest
+from abicheck.serialization import snapshot_to_json, snapshot_from_dict, load_snapshot, save_snapshot
+from abicheck.model import AbiSnapshot
+
+
+def _minimal_dict(**overrides) -> dict:
+    base = {
+        "library": "libtest.so",
+        "version": "v1",
+        "functions": [],
+        "variables": [],
+        "types": [],
+        "enums": [],
+        "typedefs": [],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# elf_only_mode
+# ---------------------------------------------------------------------------
+
+def test_elf_only_mode_true_survives_roundtrip():
+    """elf_only_mode=True must be preserved through to_json → from_dict."""
+    snap = AbiSnapshot(
+        library="libfoo.so", version="v1",
+        functions=[], variables=[], types=[], enums=[], typedefs=[],
+        elf_only_mode=True,
+    )
+    j = json.loads(snapshot_to_json(snap))
+    assert j.get("elf_only_mode") is True, "elf_only_mode must be serialised as True"
+    restored = snapshot_from_dict(j)
+    assert restored.elf_only_mode is True
+
+
+def test_elf_only_mode_false_survives_roundtrip():
+    """elf_only_mode=False (default) must round-trip correctly."""
+    snap = AbiSnapshot(
+        library="libfoo.so", version="v1",
+        functions=[], variables=[], types=[], enums=[], typedefs=[],
+        elf_only_mode=False,
+    )
+    j = json.loads(snapshot_to_json(snap))
+    restored = snapshot_from_dict(j)
+    assert restored.elf_only_mode is False
+
+
+def test_elf_only_mode_defaults_to_false_when_absent():
+    """Snapshots produced before PR #63 (no elf_only_mode key) must deserialise to False."""
+    d = _minimal_dict()
+    assert "elf_only_mode" not in d
+    snap = snapshot_from_dict(d)
+    assert snap.elf_only_mode is False
+
+
+def test_elf_only_mode_truthy_string_not_accepted():
+    """Truthy non-bool values must still result in bool True (bool() coercion)."""
+    d = _minimal_dict(elf_only_mode=1)
+    snap = snapshot_from_dict(d)
+    assert snap.elf_only_mode is True
+
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
+
+def test_constants_roundtrip():
+    """constants dict must survive serialisation → deserialisation."""
+    snap = AbiSnapshot(
+        library="libfoo.so", version="v1",
+        functions=[], variables=[], types=[], enums=[], typedefs=[],
+        constants={"MAX_SIZE": "256", "VERSION": "3"},
+    )
+    j = json.loads(snapshot_to_json(snap))
+    restored = snapshot_from_dict(j)
+    assert restored.constants == {"MAX_SIZE": "256", "VERSION": "3"}
+
+
+def test_constants_defaults_to_empty_dict_when_absent():
+    """Old snapshots without constants key must deserialise to empty dict."""
+    d = _minimal_dict()
+    snap = snapshot_from_dict(d)
+    assert snap.constants == {}
+
+
+# ---------------------------------------------------------------------------
+# file-based round-trip (load_snapshot / save_snapshot)
+# ---------------------------------------------------------------------------
+
+def test_elf_only_mode_survives_file_roundtrip(tmp_path):
+    snap = AbiSnapshot(
+        library="libfoo.so", version="v1",
+        functions=[], variables=[], types=[], enums=[], typedefs=[],
+        elf_only_mode=True,
+        constants={"FOO": "bar"},
+    )
+    p = tmp_path / "snap.json"
+    save_snapshot(snap, p)
+    restored = load_snapshot(p)
+    assert restored.elf_only_mode is True
+    assert restored.constants == {"FOO": "bar"}

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -1,9 +1,11 @@
-"""tests/test_serialization_roundtrip.py
+"""Unit tests for AbiSnapshot JSON round-trip — elf_only_mode and constants.
 
-Unit tests for AbiSnapshot JSON round-trip covering fields added in PR #63:
+Covers serialisation fields added in PR #63:
   - elf_only_mode
   - constants
 """
+from __future__ import annotations
+
 import json
 
 from abicheck.model import AbiSnapshot
@@ -15,8 +17,8 @@ from abicheck.serialization import (
 )
 
 
-def _minimal_dict(**overrides) -> dict:
-    base = {
+def _minimal_dict(**overrides: object) -> dict:
+    base: dict = {
         "library": "libtest.so",
         "version": "v1",
         "functions": [],
@@ -29,86 +31,76 @@ def _minimal_dict(**overrides) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
-# elf_only_mode
-# ---------------------------------------------------------------------------
-
-def test_elf_only_mode_true_survives_roundtrip():
-    """elf_only_mode=True must be preserved through to_json → from_dict."""
-    snap = AbiSnapshot(
-        library="libfoo.so", version="v1",
-        functions=[], variables=[], types=[], enums=[], typedefs=[],
-        elf_only_mode=True,
-    )
-    j = json.loads(snapshot_to_json(snap))
-    assert j.get("elf_only_mode") is True, "elf_only_mode must be serialised as True"
-    restored = snapshot_from_dict(j)
-    assert restored.elf_only_mode is True
+def _make_snap(**kwargs: object) -> AbiSnapshot:
+    defaults = {
+        "library": "libfoo.so",
+        "version": "v1",
+        "functions": [],
+        "variables": [],
+        "types": [],
+        "enums": [],
+        "typedefs": [],
+    }
+    defaults.update(kwargs)
+    return AbiSnapshot(**defaults)  # type: ignore[arg-type]
 
 
-def test_elf_only_mode_false_survives_roundtrip():
-    """elf_only_mode=False (default) must round-trip correctly."""
-    snap = AbiSnapshot(
-        library="libfoo.so", version="v1",
-        functions=[], variables=[], types=[], enums=[], typedefs=[],
-        elf_only_mode=False,
-    )
-    j = json.loads(snapshot_to_json(snap))
-    restored = snapshot_from_dict(j)
-    assert restored.elf_only_mode is False
+# ── elf_only_mode ─────────────────────────────────────────────────────────
 
 
-def test_elf_only_mode_defaults_to_false_when_absent():
-    """Snapshots produced before PR #63 (no elf_only_mode key) must deserialise to False."""
-    d = _minimal_dict()
-    assert "elf_only_mode" not in d
-    snap = snapshot_from_dict(d)
-    assert snap.elf_only_mode is False
+class TestElfOnlyModeRoundTrip:
+    """elf_only_mode must survive JSON serialisation and deserialisation."""
+
+    def test_true_survives_roundtrip(self) -> None:
+        snap = _make_snap(elf_only_mode=True)
+        j = json.loads(snapshot_to_json(snap))
+        assert j.get("elf_only_mode") is True
+        assert snapshot_from_dict(j).elf_only_mode is True
+
+    def test_false_survives_roundtrip(self) -> None:
+        snap = _make_snap(elf_only_mode=False)
+        j = json.loads(snapshot_to_json(snap))
+        restored = snapshot_from_dict(j)
+        assert restored.elf_only_mode is False
+
+    def test_defaults_to_false_when_absent(self) -> None:
+        """Old snapshots without elf_only_mode key must deserialise to False."""
+        d = _minimal_dict()
+        assert "elf_only_mode" not in d
+        assert snapshot_from_dict(d).elf_only_mode is False
+
+    def test_truthy_int_coerces_to_bool_true(self) -> None:
+        """Truthy non-bool values must coerce to bool True."""
+        assert snapshot_from_dict(_minimal_dict(elf_only_mode=1)).elf_only_mode is True
 
 
-def test_elf_only_mode_truthy_string_not_accepted():
-    """Truthy non-bool values must still result in bool True (bool() coercion)."""
-    d = _minimal_dict(elf_only_mode=1)
-    snap = snapshot_from_dict(d)
-    assert snap.elf_only_mode is True
+# ── constants ─────────────────────────────────────────────────────────────
 
 
-# ---------------------------------------------------------------------------
-# constants
-# ---------------------------------------------------------------------------
+class TestConstantsRoundTrip:
+    """constants dict must survive JSON serialisation and deserialisation."""
 
-def test_constants_roundtrip():
-    """constants dict must survive serialisation → deserialisation."""
-    snap = AbiSnapshot(
-        library="libfoo.so", version="v1",
-        functions=[], variables=[], types=[], enums=[], typedefs=[],
-        constants={"MAX_SIZE": "256", "VERSION": "3"},
-    )
-    j = json.loads(snapshot_to_json(snap))
-    restored = snapshot_from_dict(j)
-    assert restored.constants == {"MAX_SIZE": "256", "VERSION": "3"}
+    def test_dict_survives_roundtrip(self) -> None:
+        snap = _make_snap(constants={"MAX_SIZE": "256", "VERSION": "3"})
+        j = json.loads(snapshot_to_json(snap))
+        restored = snapshot_from_dict(j)
+        assert restored.constants == {"MAX_SIZE": "256", "VERSION": "3"}
+
+    def test_defaults_to_empty_dict_when_absent(self) -> None:
+        """Old snapshots without constants must deserialise to an empty dict."""
+        assert snapshot_from_dict(_minimal_dict()).constants == {}
 
 
-def test_constants_defaults_to_empty_dict_when_absent():
-    """Old snapshots without constants key must deserialise to empty dict."""
-    d = _minimal_dict()
-    snap = snapshot_from_dict(d)
-    assert snap.constants == {}
+# ── file-based round-trip ─────────────────────────────────────────────────
 
 
-# ---------------------------------------------------------------------------
-# file-based round-trip (load_snapshot / save_snapshot)
-# ---------------------------------------------------------------------------
+class TestFileRoundTrip:
+    """save_snapshot / load_snapshot must preserve new fields."""
 
-def test_elf_only_mode_survives_file_roundtrip(tmp_path):
-    snap = AbiSnapshot(
-        library="libfoo.so", version="v1",
-        functions=[], variables=[], types=[], enums=[], typedefs=[],
-        elf_only_mode=True,
-        constants={"FOO": "bar"},
-    )
-    p = tmp_path / "snap.json"
-    save_snapshot(snap, p)
-    restored = load_snapshot(p)
-    assert restored.elf_only_mode is True
-    assert restored.constants == {"FOO": "bar"}
+    def test_elf_only_mode_and_constants_survive_file_io(self, tmp_path: object) -> None:
+        snap = _make_snap(elf_only_mode=True, constants={"FOO": "bar"})
+        p = tmp_path / "snap.json"  # type: ignore[operator]
+        save_snapshot(snap, p)
+        restored = load_snapshot(p)
+        assert restored.elf_only_mode is True
+        assert restored.constants == {"FOO": "bar"}

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -5,9 +5,14 @@ Unit tests for AbiSnapshot JSON round-trip covering fields added in PR #63:
   - constants
 """
 import json
-import pytest
-from abicheck.serialization import snapshot_to_json, snapshot_from_dict, load_snapshot, save_snapshot
+
 from abicheck.model import AbiSnapshot
+from abicheck.serialization import (
+    load_snapshot,
+    save_snapshot,
+    snapshot_from_dict,
+    snapshot_to_json,
+)
 
 
 def _minimal_dict(**overrides) -> dict:

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -4,21 +4,17 @@ Unit tests for the validate_examples.py CLI harness (PR #63).
 Does NOT require a full compile/run of examples — tests harness logic only.
 """
 import json
-import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
 import sys
-import importlib
+from pathlib import Path
+from unittest.mock import patch
 
 # Load module under test
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from tests.validate_examples import (
-    main,
-    _find_sources,
-    _normalize_verdict,
     CaseResult,
+    _normalize_verdict,
+    main,
 )
-
 
 # ---------------------------------------------------------------------------
 # _normalize_verdict — SOURCE_BREAK must NOT collapse to COMPATIBLE
@@ -91,8 +87,9 @@ def test_main_category_filter_json(tmp_path, monkeypatch):
     gt_file = tmp_path / "ground_truth.json"
     gt_file.write_text(json.dumps(gt))
 
-    import tests.validate_examples as ve
     import shutil as real_shutil
+
+    import tests.validate_examples as ve
     monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
     monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
     monkeypatch.setattr(real_shutil, "which", lambda t: "/usr/bin/" + t)

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -1,0 +1,154 @@
+"""tests/test_validate_examples_unit.py
+
+Unit tests for the validate_examples.py CLI harness (PR #63).
+Does NOT require a full compile/run of examples — tests harness logic only.
+"""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import sys
+import importlib
+
+# Load module under test
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from tests.validate_examples import (
+    main,
+    _find_sources,
+    _normalize_verdict,
+    CaseResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_verdict — SOURCE_BREAK must NOT collapse to COMPATIBLE
+# ---------------------------------------------------------------------------
+
+def test_normalize_verdict_preserves_source_break():
+    assert _normalize_verdict("SOURCE_BREAK") == "SOURCE_BREAK"
+
+
+def test_normalize_verdict_preserves_compatible():
+    assert _normalize_verdict("COMPATIBLE") == "COMPATIBLE"
+
+
+def test_normalize_verdict_preserves_breaking():
+    assert _normalize_verdict("BREAKING") == "BREAKING"
+
+
+def test_normalize_verdict_preserves_no_change():
+    assert _normalize_verdict("NO_CHANGE") == "NO_CHANGE"
+
+
+# ---------------------------------------------------------------------------
+# ground_truth.json structural integrity
+# ---------------------------------------------------------------------------
+
+GROUND_TRUTH = Path(__file__).parent.parent / "examples" / "ground_truth.json"
+VALID_CATEGORIES = {"breaking", "compatible", "bad_practice", "source_break"}
+VALID_VERDICTS   = {"BREAKING", "COMPATIBLE", "NO_CHANGE", "SOURCE_BREAK"}
+
+
+def test_ground_truth_has_41_cases():
+    j = json.loads(GROUND_TRUTH.read_text())
+    assert len(j["verdicts"]) == 41, f"Expected 41 cases, got {len(j['verdicts'])}"
+
+
+def test_ground_truth_all_entries_have_category():
+    j = json.loads(GROUND_TRUTH.read_text())
+    missing = [k for k, v in j["verdicts"].items() if "category" not in v]
+    assert not missing, f"Missing 'category' in: {missing}"
+
+
+def test_ground_truth_categories_are_valid():
+    j = json.loads(GROUND_TRUTH.read_text())
+    invalid = {k: v["category"] for k, v in j["verdicts"].items()
+               if v.get("category") not in VALID_CATEGORIES}
+    assert not invalid, f"Invalid categories: {invalid}"
+
+
+def test_ground_truth_verdicts_are_valid():
+    j = json.loads(GROUND_TRUTH.read_text())
+    invalid = {k: v["expected"] for k, v in j["verdicts"].items()
+               if v.get("expected") not in VALID_VERDICTS and v.get("expected") is not None}
+    assert not invalid, f"Invalid expected verdicts: {invalid}"
+
+
+# ---------------------------------------------------------------------------
+# CLI: --category filter
+# ---------------------------------------------------------------------------
+
+def test_main_category_filter_json(tmp_path, monkeypatch):
+    """--category filter must restrict processed cases to matching category."""
+    gt = {
+        "version": "1",
+        "description": "",
+        "verdicts": {
+            "case_breaking": {"expected": "BREAKING", "category": "breaking"},
+            "case_compatible": {"expected": "COMPATIBLE", "category": "compatible"},
+        }
+    }
+    gt_file = tmp_path / "ground_truth.json"
+    gt_file.write_text(json.dumps(gt))
+
+    import tests.validate_examples as ve
+    import shutil as real_shutil
+    monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+    monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+    monkeypatch.setattr(real_shutil, "which", lambda t: "/usr/bin/" + t)
+
+    captured_names: list[str] = []
+
+    def capturing_run(name, entry, tmp_base, fail_fast=False):
+        captured_names.append(name)
+        return CaseResult(name, "PASS", entry.get("expected"), entry.get("expected"), "")
+
+    with patch.object(ve, "run_case", side_effect=capturing_run):
+        main(["--category", "breaking", "--json"])
+
+    assert "case_breaking" in captured_names
+    assert "case_compatible" not in captured_names, "compatible case must be filtered out"
+
+
+# ---------------------------------------------------------------------------
+# CLI: --json exit code
+# ---------------------------------------------------------------------------
+
+def test_main_exits_0_when_all_pass(tmp_path, monkeypatch, capsys):
+    gt = {"version": "1", "description": "", "verdicts": {
+        "case01": {"expected": "BREAKING", "category": "breaking"},
+    }}
+    gt_file = tmp_path / "ground_truth.json"
+    gt_file.write_text(json.dumps(gt))
+
+    import tests.validate_examples as ve
+    monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+    monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+    monkeypatch.setattr("shutil.which", lambda t: "/usr/bin/" + t)
+
+    with patch.object(ve, "run_case", return_value=CaseResult("case01", "PASS", "BREAKING", "BREAKING", "")):
+        rc = main(["--json"])
+    assert rc == 0
+
+
+def test_main_exits_1_on_fail(tmp_path, monkeypatch, capsys):
+    gt = {"version": "1", "description": "", "verdicts": {
+        "case01": {"expected": "BREAKING", "category": "breaking"},
+    }}
+    gt_file = tmp_path / "ground_truth.json"
+    gt_file.write_text(json.dumps(gt))
+
+    import tests.validate_examples as ve
+    monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+    monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+    monkeypatch.setattr("shutil.which", lambda t: "/usr/bin/" + t)
+
+    with patch.object(ve, "run_case", return_value=CaseResult("case01", "FAIL", "BREAKING", "COMPATIBLE", "mismatch")):
+        rc = main(["--json"])
+    assert rc == 1
+
+
+def test_main_exits_2_when_tool_missing(monkeypatch, capsys):
+    monkeypatch.setattr("shutil.which", lambda t: None)
+    rc = main(["--json"])
+    assert rc == 2

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -1,151 +1,144 @@
-"""tests/test_validate_examples_unit.py
+"""Unit tests for the validate_examples CLI harness (PR #63).
 
-Unit tests for the validate_examples.py CLI harness (PR #63).
 Does NOT require a full compile/run of examples — tests harness logic only.
 """
+from __future__ import annotations
+
 import json
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-# Load module under test
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from tests.validate_examples import (
+
+from tests.validate_examples import (  # noqa: E402
     CaseResult,
     _normalize_verdict,
     main,
 )
 
-# ---------------------------------------------------------------------------
-# _normalize_verdict — SOURCE_BREAK must NOT collapse to COMPATIBLE
-# ---------------------------------------------------------------------------
+# ── ground_truth.json paths ───────────────────────────────────────────────
 
-def test_normalize_verdict_preserves_source_break():
-    assert _normalize_verdict("SOURCE_BREAK") == "SOURCE_BREAK"
-
-
-def test_normalize_verdict_preserves_compatible():
-    assert _normalize_verdict("COMPATIBLE") == "COMPATIBLE"
+_GROUND_TRUTH = Path(__file__).parent.parent / "examples" / "ground_truth.json"
+_VALID_CATEGORIES = frozenset({"breaking", "compatible", "bad_practice", "source_break"})
+_VALID_VERDICTS = frozenset({"BREAKING", "COMPATIBLE", "NO_CHANGE", "SOURCE_BREAK"})
+_EXPECTED_CASE_COUNT = 41
 
 
-def test_normalize_verdict_preserves_breaking():
-    assert _normalize_verdict("BREAKING") == "BREAKING"
+# ── _normalize_verdict ────────────────────────────────────────────────────
 
 
-def test_normalize_verdict_preserves_no_change():
-    assert _normalize_verdict("NO_CHANGE") == "NO_CHANGE"
+class TestNormalizeVerdict:
+    """_normalize_verdict must preserve each canonical verdict string."""
+
+    @pytest.mark.parametrize("verdict", list(_VALID_VERDICTS))
+    def test_preserves_canonical_verdict(self, verdict: str) -> None:
+        assert _normalize_verdict(verdict) == verdict
 
 
-# ---------------------------------------------------------------------------
-# ground_truth.json structural integrity
-# ---------------------------------------------------------------------------
-
-GROUND_TRUTH = Path(__file__).parent.parent / "examples" / "ground_truth.json"
-VALID_CATEGORIES = {"breaking", "compatible", "bad_practice", "source_break"}
-VALID_VERDICTS   = {"BREAKING", "COMPATIBLE", "NO_CHANGE", "SOURCE_BREAK"}
+# ── ground_truth.json structural integrity ────────────────────────────────
 
 
-def test_ground_truth_has_41_cases():
-    j = json.loads(GROUND_TRUTH.read_text())
-    assert len(j["verdicts"]) == 41, f"Expected 41 cases, got {len(j['verdicts'])}"
+class TestGroundTruthIntegrity:
+    """ground_truth.json must be well-formed and complete."""
+
+    @pytest.fixture(scope="class")
+    def verdicts(self) -> dict:
+        return json.loads(_GROUND_TRUTH.read_text())["verdicts"]
+
+    def test_has_expected_case_count(self, verdicts: dict) -> None:
+        assert len(verdicts) == _EXPECTED_CASE_COUNT
+
+    def test_all_entries_have_category(self, verdicts: dict) -> None:
+        missing = [k for k, v in verdicts.items() if "category" not in v]
+        assert not missing
+
+    def test_all_categories_are_valid(self, verdicts: dict) -> None:
+        invalid = {k: v["category"] for k, v in verdicts.items()
+                   if v.get("category") not in _VALID_CATEGORIES}
+        assert not invalid
+
+    def test_all_verdicts_are_valid(self, verdicts: dict) -> None:
+        invalid = {k: v["expected"] for k, v in verdicts.items()
+                   if v.get("expected") not in _VALID_VERDICTS
+                   and v.get("expected") is not None}
+        assert not invalid
 
 
-def test_ground_truth_all_entries_have_category():
-    j = json.loads(GROUND_TRUTH.read_text())
-    missing = [k for k, v in j["verdicts"].items() if "category" not in v]
-    assert not missing, f"Missing 'category' in: {missing}"
+# ── CLI entry-point ───────────────────────────────────────────────────────
 
 
-def test_ground_truth_categories_are_valid():
-    j = json.loads(GROUND_TRUTH.read_text())
-    invalid = {k: v["category"] for k, v in j["verdicts"].items()
-               if v.get("category") not in VALID_CATEGORIES}
-    assert not invalid, f"Invalid categories: {invalid}"
-
-
-def test_ground_truth_verdicts_are_valid():
-    j = json.loads(GROUND_TRUTH.read_text())
-    invalid = {k: v["expected"] for k, v in j["verdicts"].items()
-               if v.get("expected") not in VALID_VERDICTS and v.get("expected") is not None}
-    assert not invalid, f"Invalid expected verdicts: {invalid}"
-
-
-# ---------------------------------------------------------------------------
-# CLI: --category filter
-# ---------------------------------------------------------------------------
-
-def test_main_category_filter_json(tmp_path, monkeypatch):
-    """--category filter must restrict processed cases to matching category."""
-    gt = {
-        "version": "1",
-        "description": "",
-        "verdicts": {
-            "case_breaking": {"expected": "BREAKING", "category": "breaking"},
-            "case_compatible": {"expected": "COMPATIBLE", "category": "compatible"},
-        }
-    }
+def _make_gt(tmp_path: Path, cases: dict) -> Path:
+    """Write a minimal ground_truth.json and return its path."""
     gt_file = tmp_path / "ground_truth.json"
-    gt_file.write_text(json.dumps(gt))
-
-    import shutil as real_shutil
-
-    import tests.validate_examples as ve
-    monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
-    monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
-    monkeypatch.setattr(real_shutil, "which", lambda t: "/usr/bin/" + t)
-
-    captured_names: list[str] = []
-
-    def capturing_run(name, entry, tmp_base, fail_fast=False):
-        captured_names.append(name)
-        return CaseResult(name, "PASS", entry.get("expected"), entry.get("expected"), "")
-
-    with patch.object(ve, "run_case", side_effect=capturing_run):
-        main(["--category", "breaking", "--json"])
-
-    assert "case_breaking" in captured_names
-    assert "case_compatible" not in captured_names, "compatible case must be filtered out"
+    gt_file.write_text(json.dumps({"version": "1", "description": "", "verdicts": cases}))
+    return gt_file
 
 
-# ---------------------------------------------------------------------------
-# CLI: --json exit code
-# ---------------------------------------------------------------------------
+class TestMainCategoryFilter:
+    """--category must restrict processed cases to the matching category."""
 
-def test_main_exits_0_when_all_pass(tmp_path, monkeypatch, capsys):
-    gt = {"version": "1", "description": "", "verdicts": {
-        "case01": {"expected": "BREAKING", "category": "breaking"},
-    }}
-    gt_file = tmp_path / "ground_truth.json"
-    gt_file.write_text(json.dumps(gt))
+    def test_filters_out_other_categories(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tests.validate_examples as ve
 
-    import tests.validate_examples as ve
-    monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
-    monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
-    monkeypatch.setattr("shutil.which", lambda t: "/usr/bin/" + t)
+        gt_file = _make_gt(tmp_path, {
+            "case_breaking":   {"expected": "BREAKING",   "category": "breaking"},
+            "case_compatible": {"expected": "COMPATIBLE",  "category": "compatible"},
+        })
+        monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+        monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda t: f"/usr/bin/{t}")
 
-    with patch.object(ve, "run_case", return_value=CaseResult("case01", "PASS", "BREAKING", "BREAKING", "")):
+        captured: list[str] = []
+
+        def fake_run(name: str, entry: dict, tmp_base: Path, fail_fast: bool = False) -> CaseResult:
+            captured.append(name)
+            return CaseResult(name, "PASS", entry.get("expected"), entry.get("expected"), "")
+
+        with patch.object(ve, "run_case", side_effect=fake_run):
+            main(["--category", "breaking", "--json"])
+
+        assert "case_breaking" in captured
+        assert "case_compatible" not in captured
+
+
+class TestMainExitCodes:
+    """CLI exit codes: 0=all pass, 1=failures, 2=preflight error."""
+
+    def test_exits_0_when_all_pass(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tests.validate_examples as ve
+
+        gt_file = _make_gt(tmp_path, {
+            "case01": {"expected": "BREAKING", "category": "breaking"},
+        })
+        monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+        monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda t: f"/usr/bin/{t}")
+
+        with patch.object(ve, "run_case",
+                          return_value=CaseResult("case01", "PASS", "BREAKING", "BREAKING", "")):
+            rc = main(["--json"])
+        assert rc == 0
+
+    def test_exits_1_on_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tests.validate_examples as ve
+
+        gt_file = _make_gt(tmp_path, {
+            "case01": {"expected": "BREAKING", "category": "breaking"},
+        })
+        monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+        monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda t: f"/usr/bin/{t}")
+
+        with patch.object(ve, "run_case",
+                          return_value=CaseResult("case01", "FAIL", "BREAKING", "COMPATIBLE", "mismatch")):
+            rc = main(["--json"])
+        assert rc == 1
+
+    def test_exits_2_when_tool_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "which", lambda _t: None)
         rc = main(["--json"])
-    assert rc == 0
-
-
-def test_main_exits_1_on_fail(tmp_path, monkeypatch, capsys):
-    gt = {"version": "1", "description": "", "verdicts": {
-        "case01": {"expected": "BREAKING", "category": "breaking"},
-    }}
-    gt_file = tmp_path / "ground_truth.json"
-    gt_file.write_text(json.dumps(gt))
-
-    import tests.validate_examples as ve
-    monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
-    monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
-    monkeypatch.setattr("shutil.which", lambda t: "/usr/bin/" + t)
-
-    with patch.object(ve, "run_case", return_value=CaseResult("case01", "FAIL", "BREAKING", "COMPATIBLE", "mismatch")):
-        rc = main(["--json"])
-    assert rc == 1
-
-
-def test_main_exits_2_when_tool_missing(monkeypatch, capsys):
-    monkeypatch.setattr("shutil.which", lambda t: None)
-    rc = main(["--json"])
-    assert rc == 2
+        assert rc == 2

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -85,8 +85,8 @@ class TestMainCategoryFilter:
         import tests.validate_examples as ve
 
         gt_file = _make_gt(tmp_path, {
-            "case_breaking":   {"expected": "BREAKING",   "category": "breaking"},
-            "case_compatible": {"expected": "COMPATIBLE",  "category": "compatible"},
+            "case_breaking": {"expected": "BREAKING", "category": "breaking"},
+            "case_compatible": {"expected": "COMPATIBLE", "category": "compatible"},
         })
         monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
         monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -1,0 +1,269 @@
+"""validate_examples.py — standalone CLI validation of all abicheck example cases.
+
+Reads expected verdicts from examples/ground_truth.json, compiles each
+example with gcc/g++, runs abicheck dump+compare, and reports results.
+
+Usage:
+    python tests/validate_examples.py                   # all cases
+    python tests/validate_examples.py case01 case07     # filter by name substring
+    python tests/validate_examples.py --fail-fast       # stop on first failure
+    python tests/validate_examples.py --json            # machine-readable output
+
+Exit codes:
+    0  all pass (known gaps are xfail, not failures)
+    1  one or more unexpected failures
+    2  environment error (tools missing, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_DIR = Path(__file__).parent.parent
+EXAMPLES_DIR = REPO_DIR / "examples"
+GROUND_TRUTH = EXAMPLES_DIR / "ground_truth.json"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+class CaseResult(NamedTuple):
+    name: str
+    status: str          # PASS | FAIL | XFAIL | SKIP | ERROR
+    expected: str | None
+    got: str | None
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _find_sources(
+    case_dir: Path,
+) -> tuple[Path, Path, Path | None, Path | None] | None:
+    """Return (v1_src, v2_src, v1_hdr, v2_hdr) or None if no layout matched."""
+
+    def _hdr(base: Path, stem: str) -> Path | None:
+        for ext in (".h", ".hpp"):
+            h = base / f"{stem}{ext}"
+            if h.exists():
+                return h
+        return None
+
+    # v1/v2 layout
+    for ext in (".c", ".cpp"):
+        v1 = case_dir / f"v1{ext}"
+        if v1.exists():
+            v2 = case_dir / f"v2{ext}"
+            if not v2.exists() and case_dir.name == "case04_no_change":
+                v2 = v1
+            if v2.exists():
+                return v1, v2, _hdr(case_dir, "v1"), _hdr(case_dir, "v2")
+
+    # old/new layout
+    old_dir, new_dir = case_dir / "old", case_dir / "new"
+    if old_dir.is_dir() and new_dir.is_dir():
+        for ext in (".c", ".cpp"):
+            v1 = old_dir / f"lib{ext}"
+            if v1.exists():
+                v2 = new_dir / f"lib{ext}"
+                if v2.exists():
+                    return v1, v2, _hdr(old_dir, "lib"), _hdr(new_dir, "lib")
+
+    # good/bad layout
+    for ext in (".c", ".cpp"):
+        bad = case_dir / f"bad{ext}"
+        if bad.exists():
+            good = case_dir / f"good{ext}"
+            if good.exists():
+                return bad, good, None, None
+
+    # libfoo_v1/v2 layout
+    for ext in (".c", ".cpp"):
+        v1 = case_dir / f"libfoo_v1{ext}"
+        if v1.exists():
+            v2 = case_dir / f"libfoo_v2{ext}"
+            if v2.exists():
+                return v1, v2, _hdr(case_dir, "foo_v1"), _hdr(case_dir, "foo_v2")
+
+    return None
+
+
+def _compile(src: Path, out: Path) -> str | None:
+    """Compile src → shared lib. Returns error string on failure, None on success."""
+    compiler = "g++" if src.suffix == ".cpp" else "gcc"
+    r = subprocess.run(
+        [compiler, "-shared", "-fPIC", "-g", "-Og", "-fvisibility=default",
+         "-o", str(out), str(src)],
+        capture_output=True, text=True, timeout=30,
+    )
+    return None if r.returncode == 0 else r.stderr[:600]
+
+
+def _normalize_verdict(v: str) -> str:
+    return "COMPATIBLE" if v in ("SOURCE_BREAK", "COMPATIBLE") else v
+
+
+# ---------------------------------------------------------------------------
+# Core: run one case
+# ---------------------------------------------------------------------------
+def run_case(
+    name: str,
+    entry: dict,
+    tmp_base: Path,
+    fail_fast: bool = False,
+) -> CaseResult:
+    expected_raw = entry.get("expected")
+    skip = entry.get("skip", False)
+    known_gap = entry.get("known_gap")
+
+    if skip:
+        return CaseResult(name, "SKIP", expected_raw, None, entry.get("reason", "skip=true"))
+
+    case_dir = EXAMPLES_DIR / name
+    if not case_dir.is_dir():
+        return CaseResult(name, "ERROR", expected_raw, None, "directory not found")
+
+    sources = _find_sources(case_dir)
+    if sources is None:
+        return CaseResult(name, "SKIP", expected_raw, None, "no recognised source layout")
+
+    v1_src, v2_src, v1_hdr, v2_hdr = sources
+    tmp = tmp_base / name
+    tmp.mkdir(parents=True)
+
+    v1_so = tmp / "libv1.so"
+    v2_so = tmp / "libv2.so"
+
+    err = _compile(v1_src, v1_so)
+    if err:
+        return CaseResult(name, "ERROR", expected_raw, None, f"compile v1 failed: {err[:200]}")
+    err = _compile(v2_src, v2_so)
+    if err:
+        return CaseResult(name, "ERROR", expected_raw, None, f"compile v2 failed: {err[:200]}")
+
+    # dump v1
+    snap1 = tmp / "snap1.json"
+    cmd_dump1 = [sys.executable, "-m", "abicheck.cli", "dump", str(v1_so), "-o", str(snap1)]
+    if v1_hdr:
+        cmd_dump1 += ["-H", str(v1_hdr)]
+    r1 = subprocess.run(cmd_dump1, capture_output=True, text=True, timeout=60)
+    if r1.returncode != 0:
+        return CaseResult(name, "ERROR", expected_raw, None, f"dump v1 failed: {r1.stderr[:200]}")
+
+    # dump v2
+    snap2 = tmp / "snap2.json"
+    cmd_dump2 = [sys.executable, "-m", "abicheck.cli", "dump", str(v2_so), "-o", str(snap2)]
+    if v2_hdr:
+        cmd_dump2 += ["-H", str(v2_hdr)]
+    r2 = subprocess.run(cmd_dump2, capture_output=True, text=True, timeout=60)
+    if r2.returncode != 0:
+        return CaseResult(name, "ERROR", expected_raw, None, f"dump v2 failed: {r2.stderr[:200]}")
+
+    # compare
+    rc = subprocess.run(
+        [sys.executable, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json"],
+        capture_output=True, text=True, timeout=60,
+    )
+    try:
+        data = json.loads(rc.stdout)
+        got = data.get("verdict", "UNKNOWN")
+    except json.JSONDecodeError:
+        return CaseResult(name, "ERROR", expected_raw, None,
+                          f"invalid JSON from compare: {rc.stdout[:200]}")
+
+    expected = expected_raw or "UNKNOWN"
+    if _normalize_verdict(got) == _normalize_verdict(expected):
+        return CaseResult(name, "PASS", expected_raw, got, "")
+
+    if known_gap:
+        return CaseResult(name, "XFAIL", expected_raw, got, known_gap)
+
+    return CaseResult(
+        name, "FAIL", expected_raw, got,
+        f"expected={expected!r} got={got!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("filters", nargs="*",
+                    help="Name substrings to filter cases (default: all)")
+    ap.add_argument("--fail-fast", action="store_true",
+                    help="Stop after first FAIL")
+    ap.add_argument("--json", action="store_true", dest="json_out",
+                    help="Machine-readable JSON output")
+    args = ap.parse_args(argv)
+
+    # Check required tools
+    if not shutil.which("gcc"):
+        print("ERROR: required tool 'gcc' not found in PATH", file=sys.stderr)
+        return 2
+
+    try:
+        __import__("abicheck")
+    except Exception as exc:
+        print(f"ERROR: abicheck module import failed: {exc}", file=sys.stderr)
+        return 2
+
+    # Load ground truth
+    if not GROUND_TRUTH.exists():
+        print(f"ERROR: {GROUND_TRUTH} not found", file=sys.stderr)
+        return 2
+
+    with open(GROUND_TRUTH) as f:
+        gt = json.load(f)
+
+    verdicts: dict[str, dict] = gt["verdicts"]
+
+    # Filter cases
+    names = sorted(verdicts.keys())
+    if args.filters:
+        names = [n for n in names if any(f in n for f in args.filters)]
+
+    results: list[CaseResult] = []
+    with tempfile.TemporaryDirectory(prefix="validate_examples_") as tmp_root:
+        tmp_base = Path(tmp_root)
+        for name in names:
+            res = run_case(name, verdicts[name], tmp_base)
+            results.append(res)
+            if not args.json_out:
+                icon = {"PASS": "✅", "FAIL": "❌", "XFAIL": "⚠️ ",
+                        "SKIP": "⏭️ ", "ERROR": "💥"}.get(res.status, "?")
+                msg = f"  {res.message}" if res.message else ""
+                print(f"{icon} {res.name:<42}  {res.status}{msg}")
+            if args.fail_fast and res.status == "FAIL":
+                break
+
+    # Summary
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+
+    if args.json_out:
+        print(json.dumps({
+            "summary": counts,
+            "results": [r._asdict() for r in results],
+        }, indent=2))
+    else:
+        total = len(results)
+        print(f"\n{'─'*60}")
+        print(f"Total: {total}  " +
+              "  ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+
+    failures = counts.get("FAIL", 0) + counts.get("ERROR", 0)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -107,7 +107,12 @@ def _compile(src: Path, out: Path) -> str | None:
 
 
 def _normalize_verdict(v: str) -> str:
-    return "COMPATIBLE" if v in ("SOURCE_BREAK", "COMPATIBLE") else v
+    """Normalize verdict for comparison.
+
+    SOURCE_BREAK and COMPATIBLE are intentionally kept distinct so that a
+    regression from SOURCE_BREAK to COMPATIBLE is caught as a test failure.
+    """
+    return v
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +137,8 @@ def run_case(
 
     sources = _find_sources(case_dir)
     if sources is None:
-        return CaseResult(name, "SKIP", expected_raw, None, "no recognised source layout")
+        return CaseResult(name, "ERROR", expected_raw, None,
+                          "no recognised source layout (harness error — fix example or mark skip in ground_truth.json)")
 
     v1_src, v2_src, v1_hdr, v2_hdr = sources
     tmp = tmp_base / name
@@ -243,9 +249,10 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     # Check required tools
-    if not shutil.which("gcc"):
-        print("ERROR: required tool 'gcc' not found in PATH", file=sys.stderr)
-        return 2
+    for tool in ("gcc", "g++", "castxml"):
+        if not shutil.which(tool):
+            print(f"ERROR: required tool '{tool}' not found in PATH", file=sys.stderr)
+            return 2
 
     try:
         __import__("abicheck")

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -154,8 +154,23 @@ def run_case(
         if not v1_so.exists() or not v2_so.exists():
             return CaseResult(name, "ERROR", expected_raw, None,
                               "Makefile did not produce libv1.so / libv2.so")
-        v1_hdr_path = (build_dir / v1_hdr.name) if v1_hdr else None
-        v2_hdr_path = (build_dir / v2_hdr.name) if v2_hdr else None
+        # Remap header path: relative to original case_dir → same relative path under build_dir
+        if v1_hdr:
+            try:
+                rel = v1_hdr.relative_to(case_dir)
+                v1_hdr_path = build_dir / rel
+            except ValueError:
+                v1_hdr_path = build_dir / v1_hdr.name
+        else:
+            v1_hdr_path = None
+        if v2_hdr:
+            try:
+                rel = v2_hdr.relative_to(case_dir)
+                v2_hdr_path = build_dir / rel
+            except ValueError:
+                v2_hdr_path = build_dir / v2_hdr.name
+        else:
+            v2_hdr_path = None
     else:
         v1_so = tmp / "libv1.so"
         v2_so = tmp / "libv2.so"
@@ -223,6 +238,8 @@ def main(argv: list[str] | None = None) -> int:
                     help="Stop after first FAIL")
     ap.add_argument("--json", action="store_true", dest="json_out",
                     help="Machine-readable JSON output")
+    ap.add_argument("--category", metavar="CAT",
+                    help="Filter by category: breaking, compatible, bad_practice, source_break")
     args = ap.parse_args(argv)
 
     # Check required tools
@@ -250,6 +267,8 @@ def main(argv: list[str] | None = None) -> int:
     names = sorted(verdicts.keys())
     if args.filters:
         names = [n for n in names if any(f in n for f in args.filters)]
+    if args.category:
+        names = [n for n in names if verdicts[n].get("category") == args.category]
 
     results: list[CaseResult] = []
     with tempfile.TemporaryDirectory(prefix="validate_examples_") as tmp_root:

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -138,21 +138,41 @@ def run_case(
     tmp = tmp_base / name
     tmp.mkdir(parents=True)
 
-    v1_so = tmp / "libv1.so"
-    v2_so = tmp / "libv2.so"
-
-    err = _compile(v1_src, v1_so)
-    if err:
-        return CaseResult(name, "ERROR", expected_raw, None, f"compile v1 failed: {err[:200]}")
-    err = _compile(v2_src, v2_so)
-    if err:
-        return CaseResult(name, "ERROR", expected_raw, None, f"compile v2 failed: {err[:200]}")
+    # Use the Makefile if the case ships one — ensures special build flags
+    # (version scripts, extra link options) are applied as the example intends.
+    if (case_dir / "Makefile").exists():
+        import shutil as _shutil
+        build_dir = tmp / "build"
+        _shutil.copytree(str(case_dir), str(build_dir))
+        r = subprocess.run(["make", "-C", str(build_dir)],
+                           capture_output=True, text=True, timeout=60)
+        if r.returncode != 0:
+            return CaseResult(name, "ERROR", expected_raw, None,
+                              f"make failed: {r.stderr[:300]}")
+        v1_so = build_dir / "libv1.so"
+        v2_so = build_dir / "libv2.so"
+        if not v1_so.exists() or not v2_so.exists():
+            return CaseResult(name, "ERROR", expected_raw, None,
+                              "Makefile did not produce libv1.so / libv2.so")
+        v1_hdr_path = (build_dir / v1_hdr.name) if v1_hdr else None
+        v2_hdr_path = (build_dir / v2_hdr.name) if v2_hdr else None
+    else:
+        v1_so = tmp / "libv1.so"
+        v2_so = tmp / "libv2.so"
+        err = _compile(v1_src, v1_so)
+        if err:
+            return CaseResult(name, "ERROR", expected_raw, None, f"compile v1 failed: {err[:200]}")
+        err = _compile(v2_src, v2_so)
+        if err:
+            return CaseResult(name, "ERROR", expected_raw, None, f"compile v2 failed: {err[:200]}")
+        v1_hdr_path = v1_hdr
+        v2_hdr_path = v2_hdr
 
     # dump v1
     snap1 = tmp / "snap1.json"
     cmd_dump1 = [sys.executable, "-m", "abicheck.cli", "dump", str(v1_so), "-o", str(snap1)]
-    if v1_hdr:
-        cmd_dump1 += ["-H", str(v1_hdr)]
+    if v1_hdr_path and Path(v1_hdr_path).exists():
+        cmd_dump1 += ["-H", str(v1_hdr_path)]
     r1 = subprocess.run(cmd_dump1, capture_output=True, text=True, timeout=60)
     if r1.returncode != 0:
         return CaseResult(name, "ERROR", expected_raw, None, f"dump v1 failed: {r1.stderr[:200]}")
@@ -160,8 +180,8 @@ def run_case(
     # dump v2
     snap2 = tmp / "snap2.json"
     cmd_dump2 = [sys.executable, "-m", "abicheck.cli", "dump", str(v2_so), "-o", str(snap2)]
-    if v2_hdr:
-        cmd_dump2 += ["-H", str(v2_hdr)]
+    if v2_hdr_path and Path(v2_hdr_path).exists():
+        cmd_dump2 += ["-H", str(v2_hdr_path)]
     r2 = subprocess.run(cmd_dump2, capture_output=True, text=True, timeout=60)
     if r2.returncode != 0:
         return CaseResult(name, "ERROR", expected_raw, None, f"dump v2 failed: {r2.stderr[:200]}")


### PR DESCRIPTION
## Summary

Adds a dedicated CI workflow that runs on every `examples/**` change, plus supporting files.

### Files

| File | Purpose |
|------|---------|
| `examples/ground_truth.json` | Single source of truth — expected verdict for all 41 cases, with `known_gap` annotations for systematic limitations |
| `tests/validate_examples.py` | Standalone CLI runner: compile → dump → compare, no pytest required. Useful for local audits and machine-readable JSON output |
| `.github/workflows/examples-validation.yml` | CI job triggered on `examples/**`, `abicheck/**`, or `tests/validate_examples.py` changes; produces a step summary table |

### How it works

1. `examples-validation.yml` runs on push/PR when `examples/**` changes
2. Uses `pytest tests/test_example_autodiscovery.py -m integration` (existing suite) as the primary check
3. Cross-checks via `python tests/validate_examples.py --json` for a second pass
4. Uploads JUnit XML + JSON results as artifacts (14 day retention)
5. Writes a markdown summary table to the GitHub Actions step summary

### Local usage

```bash
# All cases
PYTHONPATH=. python tests/validate_examples.py

# Filter by name
PYTHONPATH=. python tests/validate_examples.py case01 case13

# Machine-readable
PYTHONPATH=. python tests/validate_examples.py --json
```

### Tested locally
- `case01_symbol_removal` → PASS (BREAKING)
- `case03_compat_addition` → PASS (COMPATIBLE)
- `case13_symbol_versioning` → PASS (NO_CHANGE, known gap)
- `case31_enum_rename` → PASS (SOURCE_BREAK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CLI tool to validate all example cases against the ground-truth dataset, producing per-case JSON and human-friendly summaries with PASS/FAIL/SKIP statuses.
  * Added the ground-truth examples dataset covering 41 cases.
  * Updated example expectations and metadata (notably case06_visibility and case13_symbol_versioning) and adjusted known-gap handling.
  * Improved example test harness to better detect and build example variants.

* **Chores**
  * Added CI workflow to run example validation on pushes/PRs (and manually), upload artifacts, and append a summarized status table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->