### PR TITLE
fix(examples): add case26b union field added without size change (COMPATIBLE)

### DIFF
--- a/examples/case26b_union_field_added_compatible/Makefile
+++ b/examples/case26b_union_field_added_compatible/Makefile
@@ -1,15 +1,24 @@
-.PHONY: all clean
+.PHONY: all clean test-compat
 
 CC ?= gcc
-CFLAGS = -shared -fPIC -g
+CFLAGS_LIB = -shared -fPIC -g
 
-all: libv1.so libv2.so
+all: libv1.so libv2.so app_v1
 
 libv1.so: old/lib.c old/lib.h
-	$(CC) $(CFLAGS) -Iold -o libv1.so old/lib.c
+	$(CC) $(CFLAGS_LIB) -Iold -o libv1.so old/lib.c
 
 libv2.so: new/lib.c new/lib.h
-	$(CC) $(CFLAGS) -Inew -o libv2.so new/lib.c
+	$(CC) $(CFLAGS_LIB) -Inew -o libv2.so new/lib.c
+
+app_v1: app.c old/lib.h libv1.so
+	$(CC) -g app.c -Iold -L. -lv1 -Wl,-rpath,. -o app_v1
+
+# Demonstrate ABI compatibility: compile against v1, run with v2
+test-compat: all
+	cp libv1.so libv1.so.bak
+	cp libv2.so libv1.so
+	./app_v1; ret=$$?; mv libv1.so.bak libv1.so; echo "EXIT:$$ret"; [ $$ret -eq 0 ]
 
 clean:
-	rm -f libv1.so libv2.so
+	rm -f libv1.so libv2.so app_v1 libv1.so.bak

--- a/examples/case26b_union_field_added_compatible/Makefile
+++ b/examples/case26b_union_field_added_compatible/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all clean
+
+CC ?= gcc
+CFLAGS = -shared -fPIC -g
+
+all: libv1.so libv2.so
+
+libv1.so: old/lib.c old/lib.h
+	$(CC) $(CFLAGS) -Iold -o libv1.so old/lib.c
+
+libv2.so: new/lib.c new/lib.h
+	$(CC) $(CFLAGS) -Inew -o libv2.so new/lib.c
+
+clean:
+	rm -f libv1.so libv2.so

--- a/examples/case26b_union_field_added_compatible/README.md
+++ b/examples/case26b_union_field_added_compatible/README.md
@@ -1,0 +1,60 @@
+# Case 26b — Union Field Added (No Size Change)
+
+**Verdict:** 🟢 COMPATIBLE
+
+## What changes
+
+| Version | Definition |
+|---------|-----------|
+| v1 | `union Value { long l; double d; };` |
+| v2 | `union Value { long l; double d; int i; };` |
+
+## Why this is NOT a binary ABI break
+
+Adding `int i` does **not** change `sizeof(union Value)`:
+- v1: `sizeof = max(sizeof(long)=8, sizeof(double)=8) = 8 bytes`
+- v2: `sizeof = max(sizeof(long)=8, sizeof(double)=8, sizeof(int)=4) = 8 bytes`
+
+All existing fields remain at offset 0 with identical sizes and types.
+Old callers allocate exactly the right amount of memory for v2 as well.
+No struct embeddings or array strides are affected.
+
+## Contrast with case26
+
+| Case | Field added | sizeof change | Verdict |
+|------|-------------|---------------|---------|
+| case26 | `double d` to `{int i; float f}` | 4 → 8 bytes | BREAKING (TYPE_SIZE_CHANGED) |
+| case26b | `int i` to `{long l; double d}` | 8 → 8 bytes | COMPATIBLE |
+
+## Code diff
+
+```diff
+ union Value {
+     long   l;
+     double d;
++    int    i;   /* sizeof stays 8: smaller than double — COMPATIBLE */
+ };
+```
+
+## Runtime Demo
+
+```bash
+# Build v1 lib + app
+gcc -shared -fPIC -g -Iold -o libv1.so old/lib.c
+gcc -g app.c -Iold -L. -lv1 -Wl,-rpath,. -o app_v1
+./app_v1
+# → after fill: v.l = 42
+# → OK: union field added (no size change) is ABI-compatible
+
+# Swap to v2 (int i added, sizeof unchanged)
+gcc -shared -fPIC -g -Inew -o libv2.so new/lib.c
+cp libv2.so libv1.so
+./app_v1
+# → after fill: v.l = 42   ← identical result: COMPATIBLE
+```
+
+## abicheck output
+
+abicheck detects **no TYPE_SIZE_CHANGED** (sizeof stays 8 bytes).
+The added `int i` field appears as a new union member — informational only.
+Verdict: **COMPATIBLE**.

--- a/examples/case26b_union_field_added_compatible/README.md
+++ b/examples/case26b_union_field_added_compatible/README.md
@@ -23,8 +23,8 @@ No struct embeddings or array strides are affected.
 
 | Case | Field added | sizeof change | Verdict |
 |------|-------------|---------------|---------|
-| case26 | `double d` to `{int i; float f}` | 4 → 8 bytes | BREAKING (TYPE_SIZE_CHANGED) |
-| case26b | `int i` to `{long l; double d}` | 8 → 8 bytes | COMPATIBLE |
+| case26 | `double d` added to `{int i; float f}` | 4 → 8 bytes | BREAKING (TYPE_SIZE_CHANGED) |
+| case26b | `int i` added to `{long l; double d}` | 8 → 8 bytes | COMPATIBLE |
 
 ## Code diff
 
@@ -39,18 +39,18 @@ No struct embeddings or array strides are affected.
 ## Runtime Demo
 
 ```bash
-# Build v1 lib + app
-gcc -shared -fPIC -g -Iold -o libv1.so old/lib.c
-gcc -g app.c -Iold -L. -lv1 -Wl,-rpath,. -o app_v1
+# Build libs + app compiled against v1
+make all
+
+# Run with v1 lib — baseline
 ./app_v1
 # → after fill: v.l = 42
 # → OK: union field added (no size change) is ABI-compatible
 
-# Swap to v2 (int i added, sizeof unchanged)
-gcc -shared -fPIC -g -Inew -o libv2.so new/lib.c
-cp libv2.so libv1.so
-./app_v1
-# → after fill: v.l = 42   ← identical result: COMPATIBLE
+# Swap to v2 (old binary, new lib — sizeof unchanged)
+make test-compat
+# → after fill: v.l = 42   ← identical result
+# → EXIT:0                  ← app exits cleanly: COMPATIBLE
 ```
 
 ## abicheck output

--- a/examples/case26b_union_field_added_compatible/app.c
+++ b/examples/case26b_union_field_added_compatible/app.c
@@ -1,0 +1,15 @@
+#include "old/lib.h"
+#include <stdio.h>
+
+int main(void) {
+    union Value v;
+    v.l = 0;
+    fill(&v);
+    printf("after fill: v.l = %ld\n", v.l);
+    if (v.l != 42) {
+        printf("UNEXPECTED: v.l should be 42\n");
+        return 1;
+    }
+    printf("OK: union field added (no size change) is ABI-compatible\n");
+    return 0;
+}

--- a/examples/case26b_union_field_added_compatible/new/lib.c
+++ b/examples/case26b_union_field_added_compatible/new/lib.c
@@ -1,0 +1,4 @@
+#include "lib.h"
+
+/* v2 still writes via the same long member; adding int i is inert at runtime */
+void fill(union Value* v) { v->l = 42; }

--- a/examples/case26b_union_field_added_compatible/new/lib.h
+++ b/examples/case26b_union_field_added_compatible/new/lib.h
@@ -1,0 +1,13 @@
+#ifndef LIB_H
+#define LIB_H
+
+/* v2: int i added — sizeof stays 8 (int 4 < double 8); no ABI break */
+union Value {
+    long   l;
+    double d;
+    int    i;   /* new: smaller than max member, sizeof unchanged */
+};
+
+void fill(union Value* v);
+
+#endif /* LIB_H */

--- a/examples/case26b_union_field_added_compatible/old/lib.c
+++ b/examples/case26b_union_field_added_compatible/old/lib.c
@@ -1,0 +1,3 @@
+#include "lib.h"
+
+void fill(union Value* v) { v->l = 42; }

--- a/examples/case26b_union_field_added_compatible/old/lib.h
+++ b/examples/case26b_union_field_added_compatible/old/lib.h
@@ -1,0 +1,12 @@
+#ifndef LIB_H
+#define LIB_H
+
+/* v1: union dominated by double (8 bytes); sizeof(Value) == 8 */
+union Value {
+    long   l;
+    double d;
+};
+
+void fill(union Value* v);
+
+#endif /* LIB_H */

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -166,6 +166,10 @@
     "case41_type_changes": {
       "expected": "BREAKING",
       "category": "breaking"
+    },
+    "case26b_union_field_added_compatible": {
+      "expected": "COMPATIBLE",
+      "category": "compatible"
     }
   }
 }

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -62,7 +62,7 @@ EXPECTED: dict[str, str | None] = {
     "case24_union_field_removed": "BREAKING",
     "case25_enum_member_added": "COMPATIBLE",
     "case26_union_field_added": "BREAKING",    # union grows 4→8 bytes: TYPE_SIZE_CHANGED
-    case26b_union_field_added_compatible: COMPATIBLE,  # added member without sizeof change
+    "case26b_union_field_added_compatible": "COMPATIBLE",  # added member without sizeof change
     "case27_symbol_binding_weakened": "COMPATIBLE",
     "case29_ifunc_transition": "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
     # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -62,6 +62,7 @@ EXPECTED: dict[str, str | None] = {
     "case24_union_field_removed": "BREAKING",
     "case25_enum_member_added": "COMPATIBLE",
     "case26_union_field_added": "BREAKING",    # union grows 4→8 bytes: TYPE_SIZE_CHANGED
+    case26b_union_field_added_compatible: COMPATIBLE,  # added member without sizeof change
     "case27_symbol_binding_weakened": "COMPATIBLE",
     "case29_ifunc_transition": "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
     # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -10,14 +10,14 @@ Layout support:
   • good/bad  — examples/caseXX/bad.c (v1) + good.c (v2)  [bad=before, good=fixed]
   • libfoo    — examples/caseXX/libfoo_v1.c + libfoo_v2.c
 
-Expected verdicts are declared here (not in the example source tree) so the
-tests remain authoritative even if README files get out of sync.
-Set to `None` to skip a case entirely (e.g. intentional compile errors).
+Expected verdicts are loaded from examples/ground_truth.json (single source
+of truth). Set a case to null in ground_truth.json to skip it entirely.
 
 Marked `@pytest.mark.integration` — requires gcc/g++ + castxml in PATH.
 """
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -31,54 +31,13 @@ REPO_DIR     = Path(__file__).parent.parent
 EXAMPLES_DIR = REPO_DIR / "examples"
 
 # ---------------------------------------------------------------------------
-# Expected verdicts (single source of truth for the test suite)
+# Expected verdicts — loaded from ground_truth.json (single source of truth).
+# To skip a case, set its value to null in ground_truth.json.
 # ---------------------------------------------------------------------------
+_GT_PATH = REPO_DIR / "examples" / "ground_truth.json"
+_gt_data = json.loads(_GT_PATH.read_text())
 EXPECTED: dict[str, str | None] = {
-    # ── cases 01-18 (v1/v2 layout) ──────────────────────────────────────────
-    "case01_symbol_removal": "BREAKING",
-    "case02_param_type_change": "BREAKING",
-    "case03_compat_addition": "COMPATIBLE",
-    "case04_no_change": "NO_CHANGE",
-    "case05_soname": "COMPATIBLE",  # SONAME_MISSING: bad practice flag, COMPATIBLE verdict
-    "case06_visibility": "COMPATIBLE",  # visibility leak cleanup: bad practice fix, not intended ABI break
-    "case07_struct_layout": "BREAKING",
-    "case08_enum_value_change": "BREAKING",
-    "case09_cpp_vtable": "BREAKING",
-    "case10_return_type": "BREAKING",
-    "case11_global_var_type": "BREAKING",
-    "case12_function_removed": "BREAKING",
-    "case13_symbol_versioning": "COMPATIBLE",  # unversioned→versioned: ld.so soft-matches; Makefile applies version script
-    "case14_cpp_class_size": "BREAKING",
-    "case15_noexcept_change": "BREAKING",    # SYMBOL_VERSION_REQUIRED_ADDED from stdexcept
-    "case16_inline_to_non_inline": "COMPATIBLE",
-    "case17_template_abi": "BREAKING",
-    "case18_dependency_leak": "BREAKING",
-    # ── cases 19-29 (old/new layout) ────────────────────────────────────────
-    "case19_enum_member_removed": "BREAKING",
-    "case20_enum_member_value_changed": "BREAKING",
-    "case21_method_became_static": "BREAKING",
-    "case22_method_const_changed": "BREAKING",
-    "case23_pure_virtual_added": "BREAKING",    # pure_virtual=1 changes vtable slot → __cxa_pure_virtual
-    "case24_union_field_removed": "BREAKING",
-    "case25_enum_member_added": "COMPATIBLE",
-    "case26_union_field_added": "BREAKING",    # union grows 4→8 bytes: TYPE_SIZE_CHANGED
-    "case26b_union_field_added_compatible": "COMPATIBLE",  # added member without sizeof change
-    "case27_symbol_binding_weakened": "COMPATIBLE",
-    "case29_ifunc_transition": "COMPATIBLE",  # FUNC→IFUNC → IFUNC_INTRODUCED (COMPATIBLE)
-    # ── cases 28, 30-41 (Sprint 7 — full parity examples) ─────────────────
-    "case28_typedef_opaque": "BREAKING",    # typedef removed + type became opaque
-    "case30_field_qualifiers": "BREAKING",    # const/volatile qualifier change on struct fields → TYPE_FIELD_TYPE_CHANGED
-    "case31_enum_rename": "SOURCE_BREAK", # rename with same values: source-level only
-    "case32_param_defaults": "NO_CHANGE",   # default values not in binary ABI
-    "case33_pointer_level": "BREAKING",    # param/return pointer level changes
-    "case34_access_level": "SOURCE_BREAK", # narrowing access (public→private) is a source break
-    "case35_field_rename": "BREAKING",    # field rename: castxml sees old field removed + new field added → BREAKING
-    "case36_anon_struct": "BREAKING",    # type_size_changed + alignment changed
-    "case37_base_class": "BREAKING",    # base class reorder + virtual inheritance change
-    "case38_virtual_methods": "BREAKING",    # virtual added/removed + visibility change
-    "case39_var_const": "BREAKING",    # var_type_changed + var_removed now detected via ELF+DWARF
-    "case40_field_layout": "BREAKING",    # field type changed + size changed
-    "case41_type_changes": "BREAKING",    # type removed + alignment changed + enum sentinel
+    k: v.get("expected") for k, v in _gt_data["verdicts"].items()
 }
 
 # Known gaps: these cases xfail when the verdict disagrees with expected.

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -31,23 +31,22 @@ REPO_DIR     = Path(__file__).parent.parent
 EXAMPLES_DIR = REPO_DIR / "examples"
 
 # ---------------------------------------------------------------------------
-# Expected verdicts — loaded from ground_truth.json (single source of truth).
-# To skip a case, set its value to null in ground_truth.json.
+# Expected verdicts and known gaps — loaded from ground_truth.json.
+# Single source of truth: add cases / known_gap fields there, not here.
+# To skip a case, set its "expected" value to null in ground_truth.json.
 # ---------------------------------------------------------------------------
 _GT_PATH = REPO_DIR / "examples" / "ground_truth.json"
 _gt_data = json.loads(_GT_PATH.read_text())
 EXPECTED: dict[str, str | None] = {
     k: v.get("expected") for k, v in _gt_data["verdicts"].items()
 }
-
-# Known gaps: these cases xfail when the verdict disagrees with expected.
-# Format: case_name → reason string.
+# known_gap: case_name → xfail reason (sourced from ground_truth.json)
 KNOWN_GAPS: dict[str, str] = {
-    "case06_visibility": (
-        "Current checker may report BREAKING via FUNC_VISIBILITY_CHANGED when leaked internal symbols "
-        "disappear from dynsym; semantically this case is a bad-practice cleanup and is treated as COMPATIBLE"
-    ),
+    k: v["known_gap"]
+    for k, v in _gt_data["verdicts"].items()
+    if "known_gap" in v
 }
+
 
 # ---------------------------------------------------------------------------
 # Layout detection helpers

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -25,7 +25,7 @@ from tests.validate_examples import (  # noqa: E402
 _GROUND_TRUTH = Path(__file__).parent.parent / "examples" / "ground_truth.json"
 _VALID_CATEGORIES = frozenset({"breaking", "compatible", "bad_practice", "source_break"})
 _VALID_VERDICTS = frozenset({"BREAKING", "COMPATIBLE", "NO_CHANGE", "SOURCE_BREAK"})
-_EXPECTED_CASE_COUNT = 41
+_EXPECTED_CASE_COUNT = 42
 
 
 # ── _normalize_verdict ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds **case26b** — union field added where the new member does not grow `sizeof(union)`, verdict is **COMPATIBLE**.

### What is case26b?

| Version | Definition | sizeof |
|---------|-----------|--------|
| v1 | `union Value { long l; double d; }` | 8 bytes |
| v2 | `union Value { long l; double d; int i; }` | 8 bytes (`int` < `double`) |

Adding `int i` does not change `sizeof` — max member stays at 8 bytes → **COMPATIBLE**.

### Contrast with case26

| Case | Field added | sizeof change | Verdict |
|------|-------------|---------------|---------|
| case26 | `double d` added to union of `{int, float}` | 4→8 bytes | BREAKING |
| case26b | `int i` added to union of `{long, double}` | 8→8 bytes | **COMPATIBLE** |

### Changes

- `examples/case26b_union_field_added_compatible/` — new fixture (old/, new/, app.c, Makefile, README)
- `examples/ground_truth.json` — 42 cases, case26b: COMPATIBLE
- `tests/test_example_autodiscovery.py` — case26b entry added

### Verified locally

abicheck verdict: `COMPATIBLE`, change: `union_field_added` (no `TYPE_SIZE_CHANGED`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable compatibility demo with dual library builds and a test target to exercise legacy vs new variants at runtime.

* **Documentation**
  * Added a detailed example README explaining the union-field-added compatibility case with verdict and justification.

* **Tests**
  * Added automated runtime compatibility check, integrated the new example into test discovery, and updated expected verdicts source.

* **Chores**
  * Build and cleanup targets added to streamline running and cleaning the example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->