### PR TITLE
fix(docs): replace broken README link in usage_and_coverage.md

### DIFF
--- a/docs/usage_and_coverage.md
+++ b/docs/usage_and_coverage.md
@@ -94,7 +94,7 @@ type layout corruption, vtable mismatch, or calling convention incompatibility.
 Changes like `noexcept` addition/removal, enum member addition, union field addition,
 GLOBAL→WEAK binding, and IFUNC transitions are classified as **COMPATIBLE** — they are
 detected and reported for awareness but do not trigger a BREAKING verdict. See the
-[README](../README.md#change-classification-breaking-vs-compatible) for the full
+[ABI Break Catalog](abi_breaking_cases_catalog.md) for the full
 rationale table.
 
 ## ABI/API breakages and what each tool mode can detect


### PR DESCRIPTION
Fixes `Deploy GitHub Pages / build` failure on main.

`mkdocs build --strict` was aborting due to a broken link `../README.md#change-classification-breaking-vs-compatible` in `docs/usage_and_coverage.md` — README is not in the docs directory.

Replaced with a valid internal link to `abi_breaking_cases_catalog.md`.

Verified locally: `mkdocs build --strict` completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation link references in the usage and coverage guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->