### PR TITLE
fix(benchmark): Makefile build + fix case05/case13 expected to COMPATIBLE

### DIFF
--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -82,7 +82,7 @@ EXPECTED: dict[str, str] = {
     "case02_param_type_change":       "BREAKING",
     "case03_compat_addition":         "COMPATIBLE",
     "case04_no_change":               "NO_CHANGE",
-    "case05_soname":                  "BREAKING",    # KNOWN GAP: abicheck doesn't detect missing SONAME (ELF DT_SONAME absent)
+    "case05_soname":                  "COMPATIBLE",  # SONAME added — non-breaking metadata fix (bad practice flag)
     "case06_visibility":              "BREAKING",    # KNOWN GAP: needs -fvisibility=hidden at compile time; benchmark builds with -fvisibility=default
     "case07_struct_layout":           "BREAKING",
     "case08_enum_value_change":       "BREAKING",
@@ -90,7 +90,7 @@ EXPECTED: dict[str, str] = {
     "case10_return_type":             "BREAKING",
     "case11_global_var_type":         "BREAKING",
     "case12_function_removed":        "BREAKING",
-    "case13_symbol_versioning":       "BREAKING",    # KNOWN GAP: abicheck doesn't detect missing version script (ELF symbol versioning)
+    "case13_symbol_versioning":       "COMPATIBLE",  # unversioned→versioned export — binary compatible
     "case14_cpp_class_size":          "BREAKING",
     "case15_noexcept_change":         "BREAKING",   # v2.cpp adds throw → pulls GLIBCXX_3.4.21 → SYMBOL_VERSION_REQUIRED_ADDED
     "case16_inline_to_non_inline":    "COMPATIBLE",
@@ -607,7 +607,42 @@ def main() -> None:
         v1_h_gen = bdir / "v1.h"
         v2_h_gen = bdir / "v2.h"
 
-        if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
+        # If the case ships a Makefile, use it so SONAME / version scripts /
+        # extra linker flags are applied exactly as intended.
+        makefile = case_dir / "Makefile"
+        if makefile.exists():
+            import shutil as _shutil
+            build_copy = bdir / "make_build"
+            if build_copy.exists():
+                _shutil.rmtree(str(build_copy))
+            _shutil.copytree(str(case_dir), str(build_copy))
+            mr = subprocess.run(
+                ["make", "-C", str(build_copy)],
+                capture_output=True, text=True, timeout=60,
+            )
+            if mr.returncode != 0:
+                print(f"  {name:<35} MAKE_ERR")
+                results.append({"case": name, "expected": expected,
+                                 "expected_compat": EXPECTED_COMPAT.get(name, expected),
+                                 "abicheck": "ERROR", "abicheck_compat": "ERROR",
+                                 "abidiff": "ERROR", "abidiff_headers": "ERROR",
+                                 "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+                continue
+            built_v1 = build_copy / "libv1.so"
+            built_v2 = build_copy / "libv2.so"
+            if built_v1.exists() and built_v2.exists():
+                v1_so = built_v1
+                v2_so = built_v2
+                def _remap(h, src, dst):
+                    if not h:
+                        return None
+                    try:
+                        return dst / h.relative_to(src)
+                    except ValueError:
+                        return dst / h.name
+                v1_h_hint = _remap(v1_h_hint, case_dir, build_copy)
+                v2_h_hint = _remap(v2_h_hint, case_dir, build_copy)
+        elif not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
             print(f"  {name:<35} COMPILE_ERR")
             results.append({"case": name, "expected": expected,
                              "expected_compat": EXPECTED_COMPAT.get(name, expected),


### PR DESCRIPTION
## Summary

Two fixes to `scripts/benchmark_comparison.py`:

### 1. Use Makefile when present

Previously the benchmark compiled sources directly (`gcc -shared -fPIC src.c`) for all cases, losing SONAME / version-script flags. Now it mirrors the pytest integration suite: copy case dir to a temp build tree and run `make` first.

**Impact:** case05 and case13 now produce the correct `.so` files with SONAME and symbol versioning metadata, so abicheck can detect the actual ELF changes.

### 2. Fix EXPECTED for case05 / case13

| Case | Old expected | New expected | Reason |
|------|-------------|-------------|--------|
| case05_soname | `BREAKING` | `COMPATIBLE` | Adding SONAME is a bad-practice fix, not an ABI break |
| case13_symbol_versioning | `BREAKING` | `COMPATIBLE` | unversioned→versioned export is binary compatible |

These match `ground_truth.json` and the test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated compatibility expectations for specific ABI test cases to accurately reflect non-breaking metadata-related changes
  * Enhanced test infrastructure with improved build support, flexible path handling, and conditional workflow execution
  * Added robust error handling and fallback mechanisms to ensure reliable testing across various build configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->