### PR TITLE
fix(benchmark): parse ABICC verdict from output; raise timeout to 120s

### DIFF
--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -24,6 +24,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import json
 import os
 import shlex
@@ -74,7 +75,7 @@ def _abicheck_available() -> bool:
 _HAS_ABICHECK: bool = _abicheck_available()
 
 
-DEFAULT_ABICC_TIMEOUT = 30  # seconds
+DEFAULT_ABICC_TIMEOUT = 120  # seconds
 
 # Expected verdicts from case READMEs
 EXPECTED: dict[str, str] = {
@@ -447,10 +448,14 @@ def run_abicc_xml(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None
     out = r.stdout + r.stderr
     (rdir / f"{case}_abicc_xml.txt").write_text(out)
 
-    if r.returncode == 1:
+    # Parse from output first: ABICC may exit non-zero due to GCC header warnings
+    # while still producing a correct compatibility report.
+    m_pct = re.search(r"Binary compatibility: (\d+(?:\.\d+)?)%", out)
+    if m_pct:
+        pct = float(m_pct.group(1))
+        verdict = "NO_CHANGE" if pct == 100.0 else "BREAKING"
+    elif r.returncode == 1:
         verdict = "BREAKING"
-    elif "Binary compatibility: 100%" in out:
-        verdict = "NO_CHANGE"
     elif r.returncode == 0:
         verdict = "COMPATIBLE"
     else:
@@ -502,10 +507,12 @@ def run_abicc_dumper(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | N
     out = r.stdout + r.stderr
     (rdir / f"{case}_abicc_dumper.txt").write_text(out)
 
-    if r.returncode == 1:
+    m_pct = re.search(r"Binary compatibility: (\d+(?:\.\d+)?)%", out)
+    if m_pct:
+        pct = float(m_pct.group(1))
+        verdict = "NO_CHANGE" if pct == 100.0 else "BREAKING"
+    elif r.returncode == 1:
         verdict = "BREAKING"
-    elif "Binary compatibility: 100%" in out:
-        verdict = "NO_CHANGE"
     elif r.returncode == 0:
         verdict = "COMPATIBLE"
     else:


### PR DESCRIPTION
## Summary

Two fixes to ABICC result handling in `scripts/benchmark_comparison.py`:

### A. Parse verdict from `Binary compatibility: N%` output

`abi-compliance-checker` exits with non-zero when GCC emits header-compilation warnings (GCC version mismatch bug #78040), **even when the report is correct**. Previously the benchmark was classifying these as `ERROR`.

Fix: read `Binary compatibility: N%` from stdout first; fall back to exit code only if the pattern is absent.

**Impact:** 6 cases previously counted as `abicc_xml ERROR` are now correctly classified as `BREAKING` (case11, case22, case23, case38, case39, case41).

### B. Raise `DEFAULT_ABICC_TIMEOUT` 30s → 120s

`abi-compliance-checker` in dumper workflow takes >60s on C++ vtable/virtual-method cases (case09, case21, case22, case23). 30s was causing spurious `TIMEOUT` results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced binary compatibility assessment by leveraging percentage-based verdict determination for greater accuracy.
  * Extended timeout threshold for compatibility checks to improve stability on slower systems and reduce false failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->