### PR TITLE
docs: v1 core pages — verdicts, exit codes, limitations, migration

### DIFF
--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -14,13 +14,15 @@ don't exactly match what was compiled, results will be unreliable.
 **This happens when:**
 - You pass generic system headers but the library was compiled with custom `#define` flags
 - Preprocessor macros change the public API surface (`#ifdef FEATURE_X`)
-- Third-party dependency headers differ between versions (causing dependency ABI leaks to go undetected)
+- Third-party dependency headers differ between versions
 - Platform-specific code paths (`#ifdef __linux__`) differ between compile and analysis environments
 
 **Mitigation:**
 - Always use the exact same headers that were used to build the `.so`
-- Pass all relevant compile-time defines via `castxml` flags
-- Use `--strict` mode to surface more potential issues
+- Pass compile-time defines to castxml: `abicheck dump libfoo.so -H foo.h --castxml-arg=-DFEATURE_X`
+- For `abicheck compat`, use `-s` (strict mode) to promote `COMPATIBLE`/`API_BREAK` to BREAKING:
+  `abicheck compat -lib foo -old OLD.xml -new NEW.xml -s`
+  (use `--strict-mode api` to promote only `API_BREAK`; `-s` is not available on `abicheck compare`)
 - Cross-check with `abicheck compat` (ABICC mode) for independent validation
 
 ---
@@ -34,8 +36,8 @@ Production `.so` files are typically stripped — in this case:
 - Calling convention drift, struct packing changes not detected (Tier 4 unavailable)
 - Tier 1 (castxml/headers) and Tier 2 (ELF symbols) still run — most critical breaks caught
 
-**Mitigation:** Use CI/staging debug builds for deep analysis where possible.
-For production binaries, combine `abicheck` with `abicheck compat` ABICC+headers mode.
+**Mitigation:** Use CI/staging debug builds (`CFLAGS=-g`) for deep analysis where possible.
+For production binaries, Tier 1+2 analysis covers the majority of real-world ABI breaks.
 
 ---
 
@@ -46,31 +48,39 @@ C++ template instantiations with complex type parameters can produce unexpected 
 - Template specializations may not all be captured
 - `case17_template_abi` in the examples demonstrates a detectable case
 
+**Mitigation:** Use explicit template instantiation (`template class Foo<int>;`) for
+ABI-sensitive types you want to guarantee are tracked.
+
 ---
 
 ## `COMPATIBLE` Does Not Mean "Invisible"
 
 `COMPATIBLE` changes are detected and reported — they are not silent. Examples:
-- Adding a new export symbol is `COMPATIBLE` but changes the library's API surface
-- Enum member addition is `COMPATIBLE` but can affect switch statement completeness
+- Adding a new export symbol is `COMPATIBLE` but grows the library's API surface
+  (relevant for semver policy: additive changes may still require a minor version bump)
+- Enum member addition is `COMPATIBLE` but can affect exhaustive `switch` statements
 
-Use `--warn-newsym` to treat new symbols as blocking if your policy requires it.
+For `abicheck compat` pipelines, use `-s` to treat `COMPATIBLE` as blocking.
+For `abicheck compare` pipelines, enforce via CI exit code logic (treat exit `2` as failure).
 
 ---
 
 ## `compat` Mode Verdict Limitations
 
-`abicheck compat` follows ABICC's verdict vocabulary: it cannot emit `API_BREAK`.
-Source-level-only breaks (e.g. `case31_enum_rename`, `case34_access_level`) will be
-reported as `COMPATIBLE` in `compat` mode. Use `abicheck compare` for full verdict fidelity.
+`abicheck compat` *does* emit exit code `2` for `API_BREAK` conditions, but the
+report text uses ABICC-style phrasing rather than a bare `API_BREAK` verdict string.
+Source-level-only breaks (e.g. `case31_enum_rename`, `case34_access_level`) will
+appear as warnings in the compat HTML/text report.
+
+Use `abicheck compare --format json` for precise machine-readable `API_BREAK` verdicts.
 
 ---
 
 ## Inline / Header-Only Code
 
-Functions defined entirely in headers (inline, `constexpr`) may not appear in the `.so`
-symbol table. `abicheck` analyzes the public exported ABI — header-only changes that
-don't affect exported symbols will not be detected.
+Functions defined entirely in headers (inline, `constexpr`, template) may not appear
+in the `.so` symbol table. `abicheck` analyzes the public exported ABI — header-only
+changes that don't affect exported symbols will not be detected.
 
 ---
 

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -1,6 +1,6 @@
 # Limitations & Known Boundaries
 
-`abicheck` is designed to catch real ABI breaks with high accuracy, but has specific
+`abicheck` is designed to catch real ABI and API breaks with high accuracy, but has specific
 limitations you should understand before relying on it in production.
 
 ---

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -1,0 +1,80 @@
+# Limitations & Known Boundaries
+
+`abicheck` is designed to catch real ABI breaks with high accuracy, but has specific
+limitations you should understand before relying on it in production.
+
+---
+
+## Header / Binary Mismatch Risk
+
+**The most important limitation.** `abicheck` uses `castxml` to parse headers and
+compares the result against the compiled `.so`. If the headers passed to analysis
+don't exactly match what was compiled, results will be unreliable.
+
+**This happens when:**
+- You pass generic system headers but the library was compiled with custom `#define` flags
+- Preprocessor macros change the public API surface (`#ifdef FEATURE_X`)
+- Third-party dependency headers differ between versions (causing dependency ABI leaks to go undetected)
+- Platform-specific code paths (`#ifdef __linux__`) differ between compile and analysis environments
+
+**Mitigation:**
+- Always use the exact same headers that were used to build the `.so`
+- Pass all relevant compile-time defines via `castxml` flags
+- Use `--strict` mode to surface more potential issues
+- Cross-check with `abicheck compat` (ABICC mode) for independent validation
+
+---
+
+## Stripped Production Binaries
+
+Tiers 3 and 4 (DWARF layout + Advanced DWARF) require debug symbols (`-g`).
+Production `.so` files are typically stripped — in this case:
+
+- Struct field offset changes may be missed (Tier 3 unavailable)
+- Calling convention drift, struct packing changes not detected (Tier 4 unavailable)
+- Tier 1 (castxml/headers) and Tier 2 (ELF symbols) still run — most critical breaks caught
+
+**Mitigation:** Use CI/staging debug builds for deep analysis where possible.
+For production binaries, combine `abicheck` with `abicheck compat` ABICC+headers mode.
+
+---
+
+## Template Instantiation
+
+C++ template instantiations with complex type parameters can produce unexpected results:
+- Explicit instantiations in `.so` are analyzed; implicit instantiations in headers are not
+- Template specializations may not all be captured
+- `case17_template_abi` in the examples demonstrates a detectable case
+
+---
+
+## `COMPATIBLE` Does Not Mean "Invisible"
+
+`COMPATIBLE` changes are detected and reported — they are not silent. Examples:
+- Adding a new export symbol is `COMPATIBLE` but changes the library's API surface
+- Enum member addition is `COMPATIBLE` but can affect switch statement completeness
+
+Use `--warn-newsym` to treat new symbols as blocking if your policy requires it.
+
+---
+
+## `compat` Mode Verdict Limitations
+
+`abicheck compat` follows ABICC's verdict vocabulary: it cannot emit `API_BREAK`.
+Source-level-only breaks (e.g. `case31_enum_rename`, `case34_access_level`) will be
+reported as `COMPATIBLE` in `compat` mode. Use `abicheck compare` for full verdict fidelity.
+
+---
+
+## Inline / Header-Only Code
+
+Functions defined entirely in headers (inline, `constexpr`) may not appear in the `.so`
+symbol table. `abicheck` analyzes the public exported ABI — header-only changes that
+don't affect exported symbols will not be detected.
+
+---
+
+## Troubleshooting
+
+See [troubleshooting.md](troubleshooting.md) for a diagnostic decision tree
+covering common false positives, false negatives, and unexpected verdicts.

--- a/docs/concepts/troubleshooting.md
+++ b/docs/concepts/troubleshooting.md
@@ -44,10 +44,17 @@ use `abicheck compare --format json`.
 Check if the binary has DWARF debug info:
 
 ```bash
-readelf --sections libfoo.so | grep -E "\.debug_info|\.zdebug_info" || echo "No DWARF sections"
+# Check for embedded DWARF sections
+readelf -S libfoo.so | grep -E "\.debug_info|\.zdebug_info" || echo "No DWARF sections"
+
+# Check for externally linked split-debug files
+readelf --debug-dump=links libfoo.so   # shows .gnu_debuglink / .gnu_debugaltlink references
+readelf --debug-dump=follow-links libfoo.so  # follows the link and inspects linked debug-info
 ```
 
 Without DWARF, Tier 3/4 checks are limited. Use debug builds (`-g`) for deeper analysis.
+If the binary uses split debug (separate `.debug` file), the linked debug info is still
+analysed automatically when `--debug-dump=follow-links` can resolve the path.
 
 ---
 

--- a/docs/concepts/troubleshooting.md
+++ b/docs/concepts/troubleshooting.md
@@ -1,0 +1,65 @@
+# Troubleshooting
+
+Use this page when results look surprising (false positive, false negative, or unexpected verdict).
+
+---
+
+## 1) "Why did I get API_BREAK/BREAKING unexpectedly?"
+
+### Check header/binary mismatch first
+
+- Are these the exact headers used to build the analyzed `.so`?
+- Are required `-D` macros the same as build time?
+- Is include search path the same as build environment?
+
+If not, fix input parity and rerun.
+
+---
+
+## 2) "Why is verdict COMPATIBLE, but I expected NO_CHANGE?"
+
+`COMPATIBLE` means real differences exist (new symbols, policy changes) but no binary break.
+
+Run JSON output for detail:
+
+```bash
+abicheck compare old.json new.json --format json -o result.json
+python3 -c "import json; r=json.load(open('result.json')); print(r['verdict']); print(len(r['changes']))"
+```
+
+---
+
+## 3) "Why is compat mode missing API_BREAK?"
+
+`abicheck compat` follows ABICC verdict vocabulary and does not emit `API_BREAK`.
+Use `abicheck compare` if you need explicit source-level verdicts.
+
+---
+
+## 4) "Why are deep type changes not detected?"
+
+Check if binary is stripped (no DWARF):
+
+```bash
+readelf --debug-dump=info libfoo.so >/dev/null 2>&1 || echo "No DWARF"
+```
+
+Without DWARF, Tier 3/4 checks are limited. Use debug builds for deeper analysis.
+
+---
+
+## 5) CI script says success but report shows changes
+
+Remember: `compare` exit code `0` includes both `NO_CHANGE` and `COMPATIBLE`.
+If you need exact policy, parse JSON verdict instead of checking `$? == 0`.
+
+---
+
+## 6) Still unsure?
+
+Open an issue with:
+- command line used
+- tool version (`abicheck --version`)
+- minimal header + `.so` pair
+- JSON output (`--format json`)
+

--- a/docs/concepts/troubleshooting.md
+++ b/docs/concepts/troubleshooting.md
@@ -29,22 +29,25 @@ python3 -c "import json; r=json.load(open('result.json')); print(r['verdict']); 
 
 ---
 
-## 3) "Why is compat mode missing API_BREAK?"
+## 3) "How does `compat` mode report API_BREAK?"
 
-`abicheck compat` follows ABICC verdict vocabulary and does not emit `API_BREAK`.
-Use `abicheck compare` if you need explicit source-level verdicts.
+`abicheck compat` uses ABICC-style report text, but still returns **exit code `2`**
+for source-level `API_BREAK` conditions.
+
+If you need an explicit `API_BREAK` verdict string in machine-readable output,
+use `abicheck compare --format json`.
 
 ---
 
 ## 4) "Why are deep type changes not detected?"
 
-Check if binary is stripped (no DWARF):
+Check if the binary has DWARF debug info:
 
 ```bash
-readelf --debug-dump=info libfoo.so >/dev/null 2>&1 || echo "No DWARF"
+readelf --sections libfoo.so | grep -E "\.debug_info|\.zdebug_info" || echo "No DWARF sections"
 ```
 
-Without DWARF, Tier 3/4 checks are limited. Use debug builds for deeper analysis.
+Without DWARF, Tier 3/4 checks are limited. Use debug builds (`-g`) for deeper analysis.
 
 ---
 
@@ -62,4 +65,3 @@ Open an issue with:
 - tool version (`abicheck --version`)
 - minimal header + `.so` pair
 - JSON output (`--format json`)
-

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -1,0 +1,107 @@
+# Verdicts
+
+Every `abicheck compare` run produces one of four verdicts.
+
+---
+
+## The four verdicts
+
+### `NO_CHANGE`
+The two snapshots are **identical** — no differences found.
+
+**CI action:** pass.
+
+---
+
+### `COMPATIBLE`
+Changes found, but **backwards-compatible** — existing compiled consumers can upgrade without recompiling.
+
+Examples:
+- New exported symbol added
+- `noexcept` specifier added/removed (Itanium ABI mangling unchanged)
+- `GLOBAL` → `WEAK` symbol binding
+- Enum member added at end of enum
+
+**CI action:** warn; do not fail. Use `--strict` to block if your policy requires.
+
+---
+
+### `API_BREAK`
+A **source-level (compile-time) break** that does not break existing compiled binaries.
+Pre-compiled consumers still work at runtime. Consumers that **recompile** against new headers get compile errors.
+
+Examples:
+- Field rename (same binary layout, different source name)
+- Enum member rename
+- Parameter default value removed
+- Reduced access level (`public` → `protected`)
+
+**CI action:** fail in API-strict pipelines; warn in ABI-only gates.
+
+> **Note:** `abicheck compat` mode does not emit `API_BREAK` — it follows ABICC's
+> binary vocabulary (`COMPATIBLE` / `BREAKING` / `NO_CHANGE`).
+
+---
+
+### `BREAKING`
+A **binary ABI break** — existing compiled consumers malfunction when the library is updated.
+
+Examples:
+- Symbol removed from `.so`
+- Function parameter type changed
+- Struct field removed or offset shifted
+- C++ vtable reordered (virtual method inserted)
+- `const` qualifier added to global variable (moves to `.rodata`, breaks writes)
+
+**CI action:** always fail; do not ship.
+
+---
+
+## Edge case: `noexcept` (case15)
+
+`FUNC_NOEXCEPT_REMOVED` ChangeKind maps to `COMPATIBLE` (Itanium ABI mangling unchanged).
+But **case15** verdict is `BREAKING` — because removing `noexcept` with `throw()` on `libstdc++`
+triggers `SYMBOL_VERSION_REQUIRED_ADDED: GLIBCXX_3.4.21` (ELF hard break).
+The ChangeKind and the case verdict differ because verdict = worst of all detected ChangeKinds.
+
+---
+
+## CI policy templates
+
+### Strict production gate
+```bash
+abicheck compare old.json new.json
+ret=$?
+[ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
+[ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
+```
+
+### Warning-only gate
+```bash
+abicheck compare old.json new.json
+ret=$?
+[ $ret -eq 4 ] && echo "::error::BREAKING ABI change" && exit 1
+[ $ret -eq 2 ] && echo "::warning::API_BREAK (source-level)"
+```
+
+### Permissive gate (migration from ABICC)
+```bash
+# Only fail on binary breaks; allow API_BREAK during migration period
+abicheck compare old.json new.json
+[ $? -eq 4 ] && exit 1 || exit 0
+```
+
+---
+
+## Exit code summary
+
+| Verdict | `compare` exit | `compat` exit |
+|---------|---------------|---------------|
+| `NO_CHANGE` | `0` | `0` |
+| `COMPATIBLE` | `0` | `0` |
+| `API_BREAK` | `2` | `2` |
+| `BREAKING` | `4` | `1` |
+
+> ⚠️ `compare` exits `0` for both `NO_CHANGE` and `COMPATIBLE`. See [exit_codes.md](../exit_codes.md).
+
+Full ChangeKind reference: [reference/change_kinds.md](../reference/change_kinds.md)

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -18,7 +18,7 @@ Changes found, but **backwards-compatible** — existing compiled consumers can 
 
 Examples:
 - New exported symbol added
-- `noexcept` specifier added/removed (Itanium ABI mangling unchanged)
+- `noexcept` specifier added/removed _(Itanium ABI mangling unchanged for non-template, non-function-pointer contexts; in C++17+, `noexcept` is part of function type and may affect mangling in template/function-pointer contexts — see [case15 edge case](#edge-case-noexcept-case15))_
 - `GLOBAL` → `WEAK` symbol binding
 - Enum member added at end of enum
 
@@ -36,7 +36,7 @@ Examples:
 - Parameter default value removed
 - Reduced access level (`public` → `protected`)
 
-**CI action:** fail in API-strict pipelines; warn in ABI-only gates.
+**CI action:** fail in API-strict pipelines or pipelines that test building from source; warn in ABI-only gates.
 
 > **Note:** `abicheck compat` mode does not emit `API_BREAK` — it follows ABICC's
 > binary vocabulary (`COMPATIBLE` / `BREAKING` / `NO_CHANGE`).
@@ -59,10 +59,16 @@ Examples:
 
 ## Edge case: `noexcept` (case15)
 
-`FUNC_NOEXCEPT_REMOVED` ChangeKind maps to `COMPATIBLE` (Itanium ABI mangling unchanged).
-But **case15** verdict is `BREAKING` — because removing `noexcept` with `throw()` on `libstdc++`
-triggers `SYMBOL_VERSION_REQUIRED_ADDED: GLIBCXX_3.4.21` (ELF hard break).
-The ChangeKind and the case verdict differ because verdict = worst of all detected ChangeKinds.
+`FUNC_NOEXCEPT_REMOVED` (removing a `noexcept` specifier) normally maps to `COMPATIBLE`
+for non-template, non-function-pointer contexts.
+
+However, **case15** is classified `BREAKING` because the function previously had `throw()` —
+the legacy C++03/C++11 exception specification — which caused the symbol to carry a versioned
+requirement (`SYMBOL_VERSION_REQUIRED_ADDED: GLIBCXX_3.4.21`). Removing `throw()` drops
+that versioned symbol from the binary, breaking consumers that were linked against it.
+
+The verdict is the **worst** of all detected ChangeKinds — `FUNC_NOEXCEPT_REMOVED` alone is
+`COMPATIBLE`, but combined with the ELF `SYMBOL_VERSION_REQUIRED_ADDED` event it becomes `BREAKING`.
 
 ---
 
@@ -72,23 +78,30 @@ The ChangeKind and the case verdict differ because verdict = worst of all detect
 ```bash
 abicheck compare old.json new.json
 ret=$?
+[ $ret -eq 1 ] && echo "ERROR — tool failed (check inputs)" && exit 1
 [ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
 [ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
+echo "OK (NO_CHANGE or COMPATIBLE)"
 ```
 
 ### Warning-only gate
 ```bash
 abicheck compare old.json new.json
 ret=$?
+[ $ret -eq 1 ] && echo "::error::tool error" && exit 1
 [ $ret -eq 4 ] && echo "::error::BREAKING ABI change" && exit 1
 [ $ret -eq 2 ] && echo "::warning::API_BREAK (source-level)"
+echo "ABI check passed"
 ```
 
 ### Permissive gate (migration from ABICC)
 ```bash
 # Only fail on binary breaks; allow API_BREAK during migration period
 abicheck compare old.json new.json
-[ $? -eq 4 ] && exit 1 || exit 0
+ret=$?
+[ $ret -eq 1 ] && exit 1   # tool error
+[ $ret -eq 4 ] && exit 1   # BREAKING only
+exit 0
 ```
 
 ---
@@ -101,7 +114,10 @@ abicheck compare old.json new.json
 | `COMPATIBLE` | `0` | `0` |
 | `API_BREAK` | `2` | `2` |
 | `BREAKING` | `4` | `1` |
+| Error | `1` | `2` |
 
-> ⚠️ `compare` exits `0` for both `NO_CHANGE` and `COMPATIBLE`. See [exit_codes.md](../exit_codes.md).
+> ⚠️ `compare` exits `0` for both `NO_CHANGE` and `COMPATIBLE`. If your pipeline
+> should warn on `COMPATIBLE` changes (e.g. new symbol exports), you cannot
+> distinguish them via exit code alone — use `--format json` and check the `verdict` field.
 
 Full ChangeKind reference: [reference/change_kinds.md](../reference/change_kinds.md)

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -91,11 +91,13 @@ echo "OK (NO_CHANGE or COMPATIBLE)"
 
 ### Warning-only gate
 ```bash
-abicheck compare old.json new.json
+abicheck compare old.json new.json --format json -o result.json
 ret=$?
 [ $ret -eq 1 ] && echo "::error::tool error" && exit 1
 [ $ret -eq 4 ] && echo "::error::BREAKING ABI change" && exit 1
 [ $ret -eq 2 ] && echo "::warning::API_BREAK (source-level)"
+verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict'])" 2>/dev/null || echo "")
+[ "$verdict" = "COMPATIBLE" ] && echo "::warning::COMPATIBLE ABI change (new symbols or compatible modifications)"
 echo "ABI check passed"
 ```
 

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -18,7 +18,7 @@ Changes found, but **backwards-compatible** — existing compiled consumers can 
 
 Examples:
 - New exported symbol added
-- `noexcept` specifier added/removed _(Itanium ABI mangling unchanged for non-template, non-function-pointer contexts; in C++17+, `noexcept` is part of function type and may affect mangling in template/function-pointer contexts — see [case15 edge case](#edge-case-noexcept-case15))_
+- `noexcept` specifier added/removed *(Itanium ABI mangling unchanged for plain functions; in C++17+, `noexcept` is part of function type and can affect mangling in function-pointer and template contexts — see [edge case below](#edge-case-noexcept-case15))*
 - `GLOBAL` → `WEAK` symbol binding
 - Enum member added at end of enum
 
@@ -38,8 +38,10 @@ Examples:
 
 **CI action:** fail in API-strict pipelines or pipelines that test building from source; warn in ABI-only gates.
 
-> **Note:** `abicheck compat` mode does not emit `API_BREAK` — it follows ABICC's
-> binary vocabulary (`COMPATIBLE` / `BREAKING` / `NO_CHANGE`).
+> **Note:** `abicheck compat` mode **can** emit `API_BREAK` — exit code `2`.
+> This mirrors ABICC's exit code `2` for source-level breaks.
+> The only difference: `compat` does not produce the `API_BREAK` verdict string
+> in the report text (it uses ABICC-style "binary compatible" phrasing).
 
 ---
 
@@ -60,7 +62,7 @@ Examples:
 ## Edge case: `noexcept` (case15)
 
 `FUNC_NOEXCEPT_REMOVED` (removing a `noexcept` specifier) normally maps to `COMPATIBLE`
-for non-template, non-function-pointer contexts.
+for plain non-template, non-function-pointer contexts.
 
 However, **case15** is classified `BREAKING` because the function previously had `throw()` —
 the legacy C++03/C++11 exception specification — which caused the symbol to carry a versioned
@@ -94,9 +96,8 @@ ret=$?
 echo "ABI check passed"
 ```
 
-### Permissive gate (migration from ABICC)
+### Permissive gate (allow API_BREAK, block only binary breaks)
 ```bash
-# Only fail on binary breaks; allow API_BREAK during migration period
 abicheck compare old.json new.json
 ret=$?
 [ $ret -eq 1 ] && exit 1   # tool error
@@ -114,10 +115,10 @@ exit 0
 | `COMPATIBLE` | `0` | `0` |
 | `API_BREAK` | `2` | `2` |
 | `BREAKING` | `4` | `1` |
-| Error | `1` | `2` |
+| Tool error | `1` | `1` |
 
 > ⚠️ `compare` exits `0` for both `NO_CHANGE` and `COMPATIBLE`. If your pipeline
-> should warn on `COMPATIBLE` changes (e.g. new symbol exports), you cannot
-> distinguish them via exit code alone — use `--format json` and check the `verdict` field.
+> should warn on `COMPATIBLE` changes (e.g. new symbol exports), use `--format json`
+> and check the `verdict` field — exit code alone is not sufficient.
 
 Full ChangeKind reference: [reference/change_kinds.md](../reference/change_kinds.md)

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -18,11 +18,11 @@ Changes found, but **backwards-compatible** — existing compiled consumers can 
 
 Examples:
 - New exported symbol added
-- `noexcept` specifier added/removed *(Itanium ABI mangling unchanged for plain functions; in C++17+, `noexcept` is part of function type and can affect mangling in function-pointer and template contexts — see [edge case below](#edge-case-noexcept-case15))*
-- `GLOBAL` → `WEAK` symbol binding
+- `noexcept` specifier added/removed *(for plain non-template functions; in C++17+, `noexcept` is part of function type and can affect mangling in function-pointer/template contexts — see [edge case](#edge-case-noexcept-case15). Note: abicheck does not currently flag function-pointer or template context noexcept changes separately.)*
+- `GLOBAL` → `WEAK` symbol binding (ELF/Linux only — weak symbols have different semantics on Mach-O/macOS; abicheck targets Linux ELF)
 - Enum member added at end of enum
 
-**CI action:** warn; do not fail. Use `--strict` to block if your policy requires.
+**CI action:** warn; do not fail. Use `-s` to promote to BREAKING if your policy requires.
 
 ---
 
@@ -38,10 +38,11 @@ Examples:
 
 **CI action:** fail in API-strict pipelines or pipelines that test building from source; warn in ABI-only gates.
 
-> **Note:** `abicheck compat` mode **can** emit `API_BREAK` — exit code `2`.
-> This mirrors ABICC's exit code `2` for source-level breaks.
-> The only difference: `compat` does not produce the `API_BREAK` verdict string
-> in the report text (it uses ABICC-style "binary compatible" phrasing).
+> **Note:** `abicheck compat` *does* emit exit code `2` for `API_BREAK` conditions.
+> However, the `compat` HTML/text report uses ABICC-style phrasing
+> ("⚠️ API_BREAK — Source-level API change, binary compatible") rather than a bare
+> `API_BREAK` verdict string. Use `abicheck compare --format json` for machine-readable
+> verdict values.
 
 ---
 
@@ -62,25 +63,27 @@ Examples:
 ## Edge case: `noexcept` (case15)
 
 `FUNC_NOEXCEPT_REMOVED` (removing a `noexcept` specifier) normally maps to `COMPATIBLE`
-for plain non-template, non-function-pointer contexts.
+for plain non-template functions.
 
-However, **case15** is classified `BREAKING` because the function previously had `throw()` —
-the legacy C++03/C++11 exception specification — which caused the symbol to carry a versioned
-requirement (`SYMBOL_VERSION_REQUIRED_ADDED: GLIBCXX_3.4.21`). Removing `throw()` drops
-that versioned symbol from the binary, breaking consumers that were linked against it.
+However, **case15** is classified `BREAKING`. The function was compiled with `throw()` —
+the legacy C++03 exception specification. Compiled with `-std=c++03`, `throw()` generates
+a call to `__cxa_call_unexpected`, which pulls in the `GLIBCXX_3.4.21` version symbol.
+Removing `throw()` drops that versioned symbol from the binary, triggering
+`SYMBOL_VERSION_REQUIRED_ADDED: GLIBCXX_3.4.21` — a hard binary break for consumers
+linked against the old symbol version.
 
-The verdict is the **worst** of all detected ChangeKinds — `FUNC_NOEXCEPT_REMOVED` alone is
-`COMPATIBLE`, but combined with the ELF `SYMBOL_VERSION_REQUIRED_ADDED` event it becomes `BREAKING`.
+The verdict is the **worst** of all detected ChangeKinds: `FUNC_NOEXCEPT_REMOVED` alone
+is `COMPATIBLE`, but combined with `SYMBOL_VERSION_REQUIRED_ADDED` it becomes `BREAKING`.
 
 ---
 
-## CI policy templates
+## CI policy templates (compare mode)
 
 ### Strict production gate
 ```bash
 abicheck compare old.json new.json
 ret=$?
-[ $ret -eq 1 ] && echo "ERROR — tool failed (check inputs)" && exit 1
+[ $ret -eq 1 ] && echo "ERROR — check tool inputs" && exit 1
 [ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
 [ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
 echo "OK (NO_CHANGE or COMPATIBLE)"
@@ -96,14 +99,18 @@ ret=$?
 echo "ABI check passed"
 ```
 
-### Permissive gate (allow API_BREAK, block only binary breaks)
+### Permissive gate (binary breaks only)
 ```bash
 abicheck compare old.json new.json
 ret=$?
 [ $ret -eq 1 ] && exit 1   # tool error
-[ $ret -eq 4 ] && exit 1   # BREAKING only
+[ $ret -eq 4 ] && exit 1   # BREAKING only; API_BREAK (exit 2) allowed
 exit 0
 ```
+
+> For `compat` mode CI patterns, see [Migrating from ABICC](../migration/from_abicc.md).
+> Note: in compat mode, exit `1` = BREAKING, exit `2` = API_BREAK **or** tool error.
+> Use `--format json` to distinguish tool errors from real `API_BREAK` verdicts.
 
 ---
 
@@ -115,10 +122,9 @@ exit 0
 | `COMPATIBLE` | `0` | `0` |
 | `API_BREAK` | `2` | `2` |
 | `BREAKING` | `4` | `1` |
-| Tool error | `1` | `1` |
+| Tool error | `1` | `2` |
 
-> ⚠️ `compare` exits `0` for both `NO_CHANGE` and `COMPATIBLE`. If your pipeline
-> should warn on `COMPATIBLE` changes (e.g. new symbol exports), use `--format json`
-> and check the `verdict` field — exit code alone is not sufficient.
+> ⚠️ `compare` exits `0` for both `NO_CHANGE` and `COMPATIBLE`.
+> Use `--format json` + `verdict` field to distinguish them in automation.
 
-Full ChangeKind reference: [reference/change_kinds.md](../reference/change_kinds.md)
+Full reference: [exit_codes.md](../exit_codes.md)

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -1,0 +1,73 @@
+# Exit Codes
+
+`abicheck` uses different exit codes depending on the command (`compare` vs `compat`).
+
+---
+
+## `abicheck compare`
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | `NO_CHANGE` **or** `COMPATIBLE` — no binary ABI break detected |
+| `2` | `API_BREAK` — source-level break (compile-time only; existing binaries are safe) |
+| `4` | `BREAKING` — binary ABI break; existing consumers will malfunction |
+
+> **⚠️ Important:** Exit code `0` means **either** `NO_CHANGE` or `COMPATIBLE`.
+> If you use `$? -eq 0` to detect "nothing changed", you will silently miss `COMPATIBLE`
+> changes (e.g. new exported symbols). Use `--format json` and parse the `verdict` field
+> for precise detection, or use `--fail-on breaking` / `--fail-on api_break`.
+
+### CI gate recommendations
+
+```bash
+# Strict: fail on any ABI/API change (CI production gate)
+abicheck compare old.json new.json
+[ $? -eq 0 ] || exit 1
+
+# Permissive: fail only on binary ABI breaks (allow additive changes)
+abicheck compare old.json new.json
+ret=$?
+[ $ret -eq 4 ] && exit 1  # only fail on BREAKING
+
+# Parse precise verdict
+abicheck compare old.json new.json --format json -o result.json
+verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict'])")
+[ "$verdict" = "BREAKING" ] && exit 1
+```
+
+---
+
+## `abicheck compat`
+
+ABICC-compatible mode uses a **different exit code scheme** (matches `abi-compliance-checker`):
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No breaking changes (COMPATIBLE or NO_CHANGE) |
+| `1` | `BREAKING` — binary ABI break detected |
+| `2` | `API_BREAK` (source-level break) **or** error (descriptor parse failure, missing files) |
+
+> **⚠️ Migration note:** If you are migrating from `abi-compliance-checker`, the
+> `compat` exit codes are intentionally compatible. However, if you switch to
+> `abicheck compare` (recommended for new integrations), the exit codes are different.
+> See [Migrating from ABICC](../migration/from_abicc.md) for a full mapping table.
+
+---
+
+## Quick comparison
+
+| Verdict | `compare` exit | `compat` exit |
+|---------|---------------|---------------|
+| `NO_CHANGE` | `0` | `0` |
+| `COMPATIBLE` | `0` | `0` |
+| `API_BREAK` | `2` | `2` |
+| `BREAKING` | `4` | `1` |
+| Error | `1` | `2` |
+
+---
+
+## `--strict` / `-s` flag (compat mode)
+
+In `compat -s` mode, `COMPATIBLE` and `API_BREAK` are promoted to `BREAKING`,
+so exit code `1` is also returned for those cases.
+

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -9,27 +9,34 @@
 | Exit code | Meaning |
 |-----------|---------|
 | `0` | `NO_CHANGE` **or** `COMPATIBLE` — no binary ABI break detected |
+| `1` | Error — missing input, invalid snapshot, or tool failure |
 | `2` | `API_BREAK` — source-level break (compile-time only; existing binaries are safe) |
 | `4` | `BREAKING` — binary ABI break; existing consumers will malfunction |
 
 > **⚠️ Important:** Exit code `0` means **either** `NO_CHANGE` or `COMPATIBLE`.
-> If you use `$? -eq 0` to detect "nothing changed", you will silently miss `COMPATIBLE`
-> changes (e.g. new exported symbols). Use `--format json` and parse the `verdict` field
-> for precise detection, or use `--fail-on breaking` / `--fail-on api_break`.
+> If your pipeline should **warn** on `COMPATIBLE` changes (e.g. new symbol exports),
+> you cannot distinguish them via exit code alone — use `--format json` and check the
+> `verdict` field.
 
 ### CI gate recommendations
 
 ```bash
-# Strict: fail on any ABI/API change (CI production gate)
-abicheck compare old.json new.json
-[ $? -eq 0 ] || exit 1
-
-# Permissive: fail only on binary ABI breaks (allow additive changes)
+# Strict: fail on any break (production gate)
 abicheck compare old.json new.json
 ret=$?
-[ $ret -eq 4 ] && exit 1  # only fail on BREAKING
+[ $ret -eq 1 ] && echo "ERROR — check tool inputs" && exit 1
+[ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
+[ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
+echo "OK"
 
-# Parse precise verdict
+# Permissive: fail only on binary ABI breaks
+abicheck compare old.json new.json
+ret=$?
+[ $ret -eq 1 ] && exit 1   # tool error
+[ $ret -eq 4 ] && exit 1   # binary break only
+exit 0
+
+# Parse exact verdict
 abicheck compare old.json new.json --format json -o result.json
 verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict'])")
 [ "$verdict" = "BREAKING" ] && exit 1
@@ -47,10 +54,9 @@ ABICC-compatible mode uses a **different exit code scheme** (matches `abi-compli
 | `1` | `BREAKING` — binary ABI break detected |
 | `2` | `API_BREAK` (source-level break) **or** error (descriptor parse failure, missing files) |
 
-> **⚠️ Migration note:** If you are migrating from `abi-compliance-checker`, the
-> `compat` exit codes are intentionally compatible. However, if you switch to
-> `abicheck compare` (recommended for new integrations), the exit codes are different.
-> See [Migrating from ABICC](../migration/from_abicc.md) for a full mapping table.
+> **⚠️ Migration note:** Exit code `2` conflates `API_BREAK` with tool errors in `compat` mode.
+> Validate that your input XML files exist before relying on exit `2` as an API_BREAK signal.
+> See [Migrating from ABICC](../migration/from_abicc.md) for the full mapping.
 
 ---
 
@@ -70,4 +76,3 @@ ABICC-compatible mode uses a **different exit code scheme** (matches `abi-compli
 
 In `compat -s` mode, `COMPATIBLE` and `API_BREAK` are promoted to `BREAKING`,
 so exit code `1` is also returned for those cases.
-

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -15,28 +15,28 @@
 
 > **⚠️ Important:** Exit code `0` means **either** `NO_CHANGE` or `COMPATIBLE`.
 > If your pipeline should **warn** on `COMPATIBLE` changes (e.g. new symbol exports),
-> you cannot distinguish them via exit code alone — use `--format json` and check the
-> `verdict` field.
+> you cannot distinguish them via exit code alone — use `--format json` and parse
+> the `verdict` field.
 
-### CI gate recommendations
+### CI gate examples
 
 ```bash
-# Strict: fail on any break (production gate)
+# Fail on any break (production gate)
 abicheck compare old.json new.json
 ret=$?
-[ $ret -eq 1 ] && echo "ERROR — check tool inputs" && exit 1
+[ $ret -eq 1 ] && echo "ERROR — check inputs" && exit 1
 [ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
 [ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
-echo "OK"
+echo "OK (NO_CHANGE or COMPATIBLE)"
 
-# Permissive: fail only on binary ABI breaks
+# Fail only on binary ABI breaks (allow API_BREAK and COMPATIBLE)
 abicheck compare old.json new.json
 ret=$?
 [ $ret -eq 1 ] && exit 1   # tool error
 [ $ret -eq 4 ] && exit 1   # binary break only
 exit 0
 
-# Parse exact verdict
+# Parse exact verdict via JSON
 abicheck compare old.json new.json --format json -o result.json
 verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict'])")
 [ "$verdict" = "BREAKING" ] && exit 1
@@ -46,33 +46,35 @@ verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict
 
 ## `abicheck compat`
 
-ABICC-compatible mode uses a **different exit code scheme** (matches `abi-compliance-checker`):
+ABICC-compatible mode (matches `abi-compliance-checker` exit codes):
 
 | Exit code | Meaning |
 |-----------|---------|
-| `0` | No breaking changes (COMPATIBLE or NO_CHANGE) |
+| `0` | No breaking changes (`COMPATIBLE` or `NO_CHANGE`) |
 | `1` | `BREAKING` — binary ABI break detected |
-| `2` | `API_BREAK` (source-level break) **or** error (descriptor parse failure, missing files) |
+| `2` | `API_BREAK` — source-level break (binary compatible) |
+| `1` | Error — also exits `1` for tool failures (same as BREAKING) |
 
-> **⚠️ Migration note:** Exit code `2` conflates `API_BREAK` with tool errors in `compat` mode.
-> Validate that your input XML files exist before relying on exit `2` as an API_BREAK signal.
-> See [Migrating from ABICC](../migration/from_abicc.md) for the full mapping.
+> **⚠️ Note:** In `compat` mode, exit `2` means `API_BREAK` (not an error — unlike
+> `compare` mode where `1` is the error code). Validate your XML descriptor files
+> exist before treating exit `2` as a definitive signal.
 
 ---
 
 ## Quick comparison
 
-| Verdict | `compare` exit | `compat` exit |
-|---------|---------------|---------------|
+| Verdict / State | `compare` exit | `compat` exit |
+|-----------------|---------------|---------------|
 | `NO_CHANGE` | `0` | `0` |
 | `COMPATIBLE` | `0` | `0` |
 | `API_BREAK` | `2` | `2` |
 | `BREAKING` | `4` | `1` |
-| Error | `1` | `2` |
+| Tool error | `1` | `1` |
 
 ---
 
 ## `--strict` / `-s` flag (compat mode)
 
-In `compat -s` mode, `COMPATIBLE` and `API_BREAK` are promoted to `BREAKING`,
-so exit code `1` is also returned for those cases.
+In `compat -s` mode:
+- `--strict-mode full` (default): `COMPATIBLE` and `API_BREAK` → exit `1` (BREAKING)
+- `--strict-mode api`: only `API_BREAK` → exit `1`; `COMPATIBLE` unchanged

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -1,6 +1,6 @@
 # Exit Codes
 
-`abicheck` uses different exit codes depending on the command (`compare` vs `compat`).
+`abicheck` uses different exit codes depending on the command.
 
 ---
 
@@ -8,37 +8,38 @@
 
 | Exit code | Meaning |
 |-----------|---------|
-| `0` | `NO_CHANGE` **or** `COMPATIBLE` — no binary ABI break detected |
-| `1` | Error — missing input, invalid snapshot, or tool failure |
-| `2` | `API_BREAK` — source-level break (compile-time only; existing binaries are safe) |
-| `4` | `BREAKING` — binary ABI break; existing consumers will malfunction |
+| `0` | `NO_CHANGE` or `COMPATIBLE` — no binary ABI break |
+| `1` | Tool error (missing input, invalid snapshot) — Click/Python uncaught exception |
+| `2` | `API_BREAK` — source-level break; existing binaries are safe |
+| `4` | `BREAKING` — binary ABI break |
 
-> **⚠️ Important:** Exit code `0` means **either** `NO_CHANGE` or `COMPATIBLE`.
-> If your pipeline should **warn** on `COMPATIBLE` changes (e.g. new symbol exports),
-> you cannot distinguish them via exit code alone — use `--format json` and parse
-> the `verdict` field.
+> **⚠️ Exit `0` covers both `NO_CHANGE` and `COMPATIBLE`.** If your pipeline needs
+> to distinguish them (e.g. warn on new symbol exports), use `--format json` and
+> read the `verdict` field — exit code alone is not sufficient.
 
-### CI gate examples
+### CI gate patterns
 
 ```bash
-# Fail on any break (production gate)
+# Production gate: fail on any break
 abicheck compare old.json new.json
 ret=$?
-[ $ret -eq 1 ] && echo "ERROR — check inputs" && exit 1
+[ $ret -eq 1 ] && echo "ERROR — check tool inputs" && exit 1    # tool error
 [ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
 [ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
 echo "OK (NO_CHANGE or COMPATIBLE)"
 
-# Fail only on binary ABI breaks (allow API_BREAK and COMPATIBLE)
+# Permissive gate: fail only on binary breaks (allow API_BREAK + COMPATIBLE)
 abicheck compare old.json new.json
 ret=$?
 [ $ret -eq 1 ] && exit 1   # tool error
-[ $ret -eq 4 ] && exit 1   # binary break only
+[ $ret -eq 4 ] && exit 1   # BREAKING only; API_BREAK (exit 2) allowed
 exit 0
+# note: exit 0 includes both NO_CHANGE and COMPATIBLE
 
-# Parse exact verdict via JSON
+# Parse exact verdict from JSON
 abicheck compare old.json new.json --format json -o result.json
-verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict'])")
+verdict=$(python3 -c "import json,sys; d=json.load(open('result.json')); print(d['verdict'])" \
+  || { echo "ERROR parsing result.json"; exit 1; })
 [ "$verdict" = "BREAKING" ] && exit 1
 ```
 
@@ -46,22 +47,22 @@ verdict=$(python3 -c "import json; print(json.load(open('result.json'))['verdict
 
 ## `abicheck compat`
 
-ABICC-compatible mode (matches `abi-compliance-checker` exit codes):
+Matches `abi-compliance-checker` exit codes (ABICC drop-in):
 
 | Exit code | Meaning |
 |-----------|---------|
-| `0` | No breaking changes (`COMPATIBLE` or `NO_CHANGE`) |
-| `1` | `BREAKING` — binary ABI break detected |
-| `2` | `API_BREAK` — source-level break (binary compatible) |
-| `1` | Error — also exits `1` for tool failures (same as BREAKING) |
+| `0` | No breaking changes (`NO_CHANGE` or `COMPATIBLE`) |
+| `1` | `BREAKING` (mirrors ABICC) |
+| `2` | `API_BREAK` **or** tool error (descriptor parse failure, missing `.so`, etc.) |
 
-> **⚠️ Note:** In `compat` mode, exit `2` means `API_BREAK` (not an error — unlike
-> `compare` mode where `1` is the error code). Validate your XML descriptor files
-> exist before treating exit `2` as a definitive signal.
+> **⚠️ In `compat` mode, exit `2` covers both `API_BREAK` and tool errors.**
+> Always pre-validate that your XML descriptor files exist before running.
+> To disambiguate: use `--format json` — a tool error produces no `changes`
+> in the JSON output, while a real `API_BREAK` will have change entries.
 
 ---
 
-## Quick comparison
+## Summary table
 
 | Verdict / State | `compare` exit | `compat` exit |
 |-----------------|---------------|---------------|
@@ -69,12 +70,27 @@ ABICC-compatible mode (matches `abi-compliance-checker` exit codes):
 | `COMPATIBLE` | `0` | `0` |
 | `API_BREAK` | `2` | `2` |
 | `BREAKING` | `4` | `1` |
-| Tool error | `1` | `1` |
+| Tool error | `1` | `2` |
 
 ---
 
-## `--strict` / `-s` flag (compat mode)
+## Strict mode (`-s` / `-strict`)
 
-In `compat -s` mode:
-- `--strict-mode full` (default): `COMPATIBLE` and `API_BREAK` → exit `1` (BREAKING)
-- `--strict-mode api`: only `API_BREAK` → exit `1`; `COMPATIBLE` unchanged
+`compat` (and only `compat`) supports strict mode to promote lesser verdicts:
+
+```bash
+# Strict mode: COMPATIBLE + API_BREAK → exit 1 (BREAKING)
+abicheck compat -lib foo -old OLD.xml -new NEW.xml -s
+
+# Strict API-only: only API_BREAK → exit 1; COMPATIBLE stays exit 0
+abicheck compat -lib foo -old OLD.xml -new NEW.xml -s --strict-mode api
+```
+
+`--strict-mode` values:
+- `full` (default when `-s` is set): `COMPATIBLE` + `API_BREAK` → BREAKING
+- `api`: only `API_BREAK` → BREAKING; `COMPATIBLE` unchanged
+
+`--strict-mode` has no effect unless `-s` is also passed.
+
+> Note: `abicheck compare` does not have `-s` / `--strict` flags.
+> For compare-mode strict pipelines, use CI exit code logic (check exit `2` as a failure).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,69 +1,108 @@
 # Getting Started
 
-## Requirements
+This guide gets you from **zero** to a first ABI verdict in ~10–15 minutes.
+
+---
+
+## 1) Requirements
 
 - Python 3.10+
-- `castxml` (required for header-based API/ABI parsing)
-- C/C++ toolchain (`g++` or `clang++`) for realistic header parsing context
+- `castxml`
+- C/C++ compiler available to castxml (`g++` or `clang++`)
 
-## Installation
+### Install system dependencies
+
+```bash
+# Ubuntu / Debian
+sudo apt-get update
+sudo apt-get install -y castxml g++
+
+# macOS
+brew install castxml llvm
+```
+
+---
+
+## 2) Install abicheck
 
 ```bash
 pip install abicheck
 ```
 
-System dependencies:
+For development from source:
 
 ```bash
-# Ubuntu/Debian
-sudo apt-get install castxml
-
-# macOS
-brew install castxml
+git clone https://github.com/napetrov/abicheck.git
+cd abicheck
+pip install -e .
 ```
 
-## Quick workflow
+---
 
-### 1. Dump ABI snapshots
+## 3) First check (dump + compare)
+
+Assume:
+- old library: `libfoo.so.1`
+- new library: `libfoo.so.2`
+- public header: `include/foo.h`
 
 ```bash
-abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o libfoo-1.0.json
-abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o libfoo-2.0.json
+abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o foo-1.0.json
+abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o foo-2.0.json
+abicheck compare foo-1.0.json foo-2.0.json
 ```
 
-### 2. Compare snapshots
+You get one verdict:
+- `NO_CHANGE`
+- `COMPATIBLE`
+- `API_BREAK`
+- `BREAKING`
+
+---
+
+## 4) Exit codes (important)
+
+`abicheck compare`:
+- `0` = `NO_CHANGE` **or** `COMPATIBLE`
+- `2` = `API_BREAK`
+- `4` = `BREAKING`
+
+> ⚠️ If your CI treats `0` as “nothing changed”, you will miss `COMPATIBLE` changes.
+> Parse JSON output if you need exact verdict in automation.
+
+Full details: [Exit Codes](exit_codes.md)
+
+---
+
+## 5) Add to GitHub Actions
+
+```yaml
+- name: Compare ABI snapshots
+  run: |
+    abicheck compare old.json new.json --format sarif -o abi.sarif
+
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: abi.sarif
+```
+
+---
+
+## 6) Migrating from ABICC?
+
+Use `compat` mode as a drop-in:
 
 ```bash
-# Markdown report (default)
-abicheck compare libfoo-1.0.json libfoo-2.0.json
-
-# JSON report
-abicheck compare libfoo-1.0.json libfoo-2.0.json --format json -o results.json
-
-# SARIF report (GitHub Code Scanning)
-abicheck compare libfoo-1.0.json libfoo-2.0.json --format sarif -o results.sarif
+abicheck compat -lib foo -old OLD.xml -new NEW.xml
 ```
 
-### 3. ABICC-compatible mode (drop-in migration)
+Read: [Migrating from ABICC](migration/from_abicc.md)
 
-```bash
-abicheck compat -lib foo -old foo-1.0.xml -new foo-2.0.xml
-```
+---
 
-For a deeper walkthrough (drop-in ABICC usage, breakage matrix, and architecture),
-see [Using abicheck, Compatibility Modes, and Coverage](usage_and_coverage.md).
+## 7) Next steps
 
-## Python API
-
-```python
-from pathlib import Path
-from abicheck.dumper import dump
-from abicheck.checker import compare
-
-old = dump(Path("libfoo.so.1"), headers=[Path("include/foo.h")], version="1.0")
-new = dump(Path("libfoo.so.2"), headers=[Path("include/foo.h")], version="2.0")
-
-result = compare(old, new)
-print(result.verdict)       # NO_CHANGE | COMPATIBLE | BREAKING
-print(result.changes)       # list[Change]
-```
+- [Verdicts](concepts/verdicts.md)
+- [Limitations](concepts/limitations.md)
+- [Tool comparison](tool_comparison.md)
+- [Examples breakage guide](examples_breakage_guide.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,5 +1,10 @@
 # Getting Started
 
+> ⚠️ **Exit code note before you start:** `abicheck compare` exits `0` for both
+> `NO_CHANGE` and `COMPATIBLE`. If you check `$? -eq 0` to detect "no changes",
+> you will silently miss compatible changes (new exports, etc.).
+> See [Exit Codes](exit_codes.md) for how to handle this in CI.
+
 This guide gets you from **zero** to a first ABI verdict in ~10–15 minutes.
 
 ---
@@ -7,10 +12,10 @@ This guide gets you from **zero** to a first ABI verdict in ~10–15 minutes.
 ## 1) Requirements
 
 - Python 3.10+
-- `castxml`
+- `castxml` (for header-based analysis) — [castxml project](https://github.com/CastXML/CastXML)
 - C/C++ compiler available to castxml (`g++` or `clang++`)
 
-### Install system dependencies
+### Install system dependencies first
 
 ```bash
 # Ubuntu / Debian
@@ -27,6 +32,9 @@ brew install castxml llvm
 
 ```bash
 pip install abicheck
+
+# Verify install
+abicheck --version
 ```
 
 For development from source:
@@ -39,12 +47,28 @@ pip install -e .
 
 ---
 
-## 3) First check (dump + compare)
+## 3) First check (using repo examples)
 
-Assume:
-- old library: `libfoo.so.1`
-- new library: `libfoo.so.2`
-- public header: `include/foo.h`
+The repo includes 42 pre-built example cases. Run a quick check on one:
+
+```bash
+git clone https://github.com/napetrov/abicheck.git
+cd abicheck/examples/case01_symbol_removal
+
+# Build v1 and v2
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+
+# Dump ABI snapshots
+abicheck dump libv1.so -H v1.h --version 1.0 -o v1.json
+abicheck dump libv2.so -H v2.h --version 2.0 -o v2.json
+
+# Compare
+abicheck compare v1.json v2.json
+# Expected: BREAKING (symbol removed)
+```
+
+For your own library with `libfoo.so.1`, `libfoo.so.2`, `include/foo.h`:
 
 ```bash
 abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o foo-1.0.json
@@ -52,45 +76,57 @@ abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o foo-2.0.json
 abicheck compare foo-1.0.json foo-2.0.json
 ```
 
-You get one verdict:
-- `NO_CHANGE`
-- `COMPATIBLE`
-- `API_BREAK`
-- `BREAKING`
+---
+
+## 4) Understanding output formats
+
+```bash
+# Default: markdown report to stdout
+abicheck compare foo-1.0.json foo-2.0.json
+
+# JSON (machine-readable, includes precise verdict)
+abicheck compare foo-1.0.json foo-2.0.json --format json -o result.json
+
+# SARIF (GitHub Code Scanning)
+abicheck compare foo-1.0.json foo-2.0.json --format sarif -o abi.sarif
+```
 
 ---
 
-## 4) Exit codes (important)
+## 5) Exit codes
 
 `abicheck compare`:
 - `0` = `NO_CHANGE` **or** `COMPATIBLE`
+- `1` = tool error (check inputs)
 - `2` = `API_BREAK`
 - `4` = `BREAKING`
 
-> ⚠️ If your CI treats `0` as “nothing changed”, you will miss `COMPATIBLE` changes.
-> Parse JSON output if you need exact verdict in automation.
-
-Full details: [Exit Codes](exit_codes.md)
+Full details and CI gate templates: [Exit Codes](exit_codes.md)
 
 ---
 
-## 5) Add to GitHub Actions
+## 6) Add to GitHub Actions
 
 ```yaml
 - name: Compare ABI snapshots
   run: |
     abicheck compare old.json new.json --format sarif -o abi.sarif
+    ret=$?
+    # Handle exit codes explicitly
+    if [ $ret -eq 4 ]; then echo "BREAKING ABI change"; exit 1; fi
+    if [ $ret -eq 2 ]; then echo "API_BREAK"; exit 1; fi
 
 - uses: github/codeql-action/upload-sarif@v3
+  if: always()
   with:
     sarif_file: abi.sarif
 ```
 
 ---
 
-## 6) Migrating from ABICC?
+## 7) Migrating from ABICC?
 
-Use `compat` mode as a drop-in:
+Use `compat` mode as a drop-in (same single-hyphen flags):
 
 ```bash
 abicheck compat -lib foo -old OLD.xml -new NEW.xml
@@ -100,9 +136,9 @@ Read: [Migrating from ABICC](migration/from_abicc.md)
 
 ---
 
-## 7) Next steps
+## 8) Next steps
 
-- [Verdicts](concepts/verdicts.md)
-- [Limitations](concepts/limitations.md)
-- [Tool comparison](tool_comparison.md)
+- [Verdicts explained](concepts/verdicts.md)
+- [Limitations & known boundaries](concepts/limitations.md)
+- [Tool comparison: abicheck vs abidiff vs ABICC](tool_comparison.md)
 - [Examples breakage guide](examples_breakage_guide.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,11 +1,8 @@
 # Getting Started
 
-> ⚠️ **Exit code note before you start:** `abicheck compare` exits `0` for both
-> `NO_CHANGE` and `COMPATIBLE`. If you check `$? -eq 0` to detect "no changes",
-> you will silently miss compatible changes (new exports, etc.).
-> See [Exit Codes](exit_codes.md) for how to handle this in CI.
-
-This guide gets you from **zero** to a first ABI verdict in ~10–15 minutes.
+> ⚠️ **Before you start:** `abicheck compare` exits `0` for both `NO_CHANGE` *and*
+> `COMPATIBLE`. Checking `$? -eq 0` does **not** mean "nothing changed" — it means
+> "no binary ABI break". See [Exit Codes](exit_codes.md) for CI gate patterns.
 
 ---
 
@@ -13,16 +10,19 @@ This guide gets you from **zero** to a first ABI verdict in ~10–15 minutes.
 
 - Python 3.10+
 - `castxml` (for header-based analysis) — [castxml project](https://github.com/CastXML/CastXML)
-- C/C++ compiler available to castxml (`g++` or `clang++`)
+- C/C++ compiler (`gcc`/`g++` or `clang`/`clang++`)
 
 ### Install system dependencies first
 
 ```bash
 # Ubuntu / Debian
 sudo apt-get update
-sudo apt-get install -y castxml g++
+sudo apt-get install -y castxml gcc g++
 
-# macOS
+# macOS (development only — ELF analysis requires Linux)
+# abicheck analyzes Linux ELF binaries only; macOS Mach-O is not supported.
+# castxml can be installed for Tier 1 header-parsing development,
+# but Tier 2/3/4 ELF analysis requires a Linux environment.
 brew install castxml llvm
 ```
 
@@ -31,9 +31,12 @@ brew install castxml llvm
 ## 2) Install abicheck
 
 ```bash
+# Recommended: use a virtual environment
+python3 -m venv .venv && source .venv/bin/activate
+
 pip install abicheck
 
-# Verify install
+# Verify
 abicheck --version
 ```
 
@@ -49,28 +52,31 @@ pip install -e .
 
 ## 3) First check (using repo examples)
 
-The repo includes 42 pre-built example cases. Run a quick check on one:
+The repo includes 42 example ABI break cases, each with pre-built `v1.c`/`v2.c` and headers.
+This makes it easy to verify your install is working correctly.
 
 ```bash
+# Clone the repo (skip if already done in step 2)
 git clone https://github.com/napetrov/abicheck.git
 cd abicheck/examples/case01_symbol_removal
 
-# Build v1 and v2
+# Build v1 and v2 shared libraries
 gcc -shared -fPIC -g v1.c -o libv1.so
 gcc -shared -fPIC -g v2.c -o libv2.so
 
-# Dump ABI snapshots
+# Dump ABI snapshots (v1.h and v2.h are in the same directory)
 abicheck dump libv1.so -H v1.h --version 1.0 -o v1.json
 abicheck dump libv2.so -H v2.h --version 2.0 -o v2.json
 
 # Compare
 abicheck compare v1.json v2.json
-# Expected: BREAKING (symbol removed)
+# Expected output: verdict BREAKING (symbol 'helper' was removed)
 ```
 
-For your own library with `libfoo.so.1`, `libfoo.so.2`, `include/foo.h`:
+For your own C++ library:
 
 ```bash
+# Replace with your actual paths
 abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o foo-1.0.json
 abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o foo-2.0.json
 abicheck compare foo-1.0.json foo-2.0.json
@@ -78,58 +84,79 @@ abicheck compare foo-1.0.json foo-2.0.json
 
 ---
 
-## 4) Understanding output formats
+## 4) Output formats
 
 ```bash
 # Default: markdown report to stdout
-abicheck compare foo-1.0.json foo-2.0.json
+abicheck compare v1.json v2.json
 
-# JSON (machine-readable, includes precise verdict)
-abicheck compare foo-1.0.json foo-2.0.json --format json -o result.json
+# JSON — includes precise verdict field for CI parsing
+abicheck compare v1.json v2.json --format json -o result.json
 
-# SARIF (GitHub Code Scanning)
-abicheck compare foo-1.0.json foo-2.0.json --format sarif -o abi.sarif
+# SARIF — for GitHub Code Scanning
+abicheck compare v1.json v2.json --format sarif -o abi.sarif
 ```
 
 ---
 
-## 5) Exit codes
+## 5) Exit codes (`abicheck compare`)
 
-`abicheck compare`:
-- `0` = `NO_CHANGE` **or** `COMPATIBLE`
-- `1` = tool error (check inputs)
-- `2` = `API_BREAK`
-- `4` = `BREAKING`
+| Code | Meaning |
+|------|---------|
+| `0` | `NO_CHANGE` or `COMPATIBLE` — no binary ABI break |
+| `1` | Tool error (bad inputs, missing file) |
+| `2` | `API_BREAK` — source-level break, existing binaries unaffected |
+| `4` | `BREAKING` — binary ABI break |
 
-Full details and CI gate templates: [Exit Codes](exit_codes.md)
+> ⚠️ Exit `0` covers both `NO_CHANGE` and `COMPATIBLE`. To distinguish them, use
+> `--format json` and read the `verdict` field.
+
+Full reference: [Exit Codes](exit_codes.md)
 
 ---
 
 ## 6) Add to GitHub Actions
 
 ```yaml
-- name: Compare ABI snapshots
-  run: |
-    abicheck compare old.json new.json --format sarif -o abi.sarif
-    ret=$?
-    # Handle exit codes explicitly
-    if [ $ret -eq 4 ]; then echo "BREAKING ABI change"; exit 1; fi
-    if [ $ret -eq 2 ]; then echo "API_BREAK"; exit 1; fi
+steps:
+  # Step 1: Generate baseline snapshot (typically from previous release tag)
+  - name: Dump old ABI snapshot
+    run: abicheck dump libfoo.so.1 -H include/foo.h --version 1.0 -o old.json
 
-- uses: github/codeql-action/upload-sarif@v3
-  if: always()
-  with:
-    sarif_file: abi.sarif
+  # Step 2: Dump new snapshot (from current build)
+  - name: Dump new ABI snapshot
+    run: abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o new.json
+
+  # Step 3: Compare and generate SARIF
+  - name: Compare ABI
+    run: |
+      abicheck compare old.json new.json --format sarif -o abi.sarif
+      ret=$?
+      [ $ret -eq 1 ] && echo "Tool error" && exit 1
+      [ $ret -eq 4 ] && echo "BREAKING ABI change — blocked" && exit 1
+      [ $ret -eq 2 ] && echo "::warning::API_BREAK detected"
+      exit 0
+
+  - uses: github/codeql-action/upload-sarif@v3
+    if: always()
+    with:
+      sarif_file: abi.sarif
 ```
 
 ---
 
 ## 7) Migrating from ABICC?
 
-Use `compat` mode as a drop-in (same single-hyphen flags):
+If you have existing ABICC XML descriptors, use `compat` mode — same single-hyphen flags,
+no XML changes needed:
 
 ```bash
+# Direct drop-in
 abicheck compat -lib foo -old OLD.xml -new NEW.xml
+
+# OLD.xml is the same ABICC descriptor format you already have.
+# If you don't have XML descriptors yet, use abicheck dump to generate snapshots
+# and then abicheck compare instead.
 ```
 
 Read: [Migrating from ABICC](migration/from_abicc.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,9 @@ abicheck compare libfoo-1.0.json libfoo-2.0.json
 ## Next steps
 
 - [Getting Started](getting_started.md)
+- [Verdicts](concepts/verdicts.md)
+- [Exit Codes](exit_codes.md)
+- [Migrating from ABICC](migration/from_abicc.md)
 - [Using abicheck, Compatibility Modes, and Coverage](usage_and_coverage.md)
 - [Examples Breakage Guide](examples_breakage_guide.md)
 - [Tool Modes](tool_modes.md)
@@ -57,13 +60,15 @@ abicheck compare libfoo-1.0.json libfoo-2.0.json
     sarif_file: abi.sarif
 ```
 
-## Exit codes
+## Exit codes (abicheck compare)
 
 | Code | Meaning |
 |------|---------|
-| 0 | No ABI changes |
-| 1 | Compatible changes only |
-| 4 | Breaking ABI changes detected |
+| 0 | NO_CHANGE or COMPATIBLE |
+| 2 | API_BREAK |
+| 4 | BREAKING |
+
+For `compat` mode (ABICC drop-in), see [Exit Codes](exit_codes.md).
 
 ## Status
 

--- a/docs/migration/from_abicc.md
+++ b/docs/migration/from_abicc.md
@@ -1,6 +1,7 @@
 # Migrating from ABI Compliance Checker (ABICC)
 
 `abicheck compat` is designed as a practical drop-in path for ABICC pipelines.
+Flags use single-hyphen style (`-lib`, `-old`, `-new`) to match ABICC exactly.
 
 ---
 
@@ -12,7 +13,7 @@ Before:
 abi-compliance-checker -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
 ```
 
-After:
+After (identical flags):
 
 ```bash
 abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
@@ -22,65 +23,83 @@ abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
 
 ## 2) Exit codes (critical difference)
 
+> ⚠️ If you switch to `abicheck compare` (not `compat`), exit codes differ — update CI logic.
+
 | Tool / mode | 0 | 1 | 2 | 4 |
 |-------------|---|---|---|---|
-| ABICC | ok | breaking | error | - |
-| `abicheck compat` | ok | breaking | API_BREAK or error | - |
+| ABICC | ok | breaking | error | — |
+| `abicheck compat` | ok | breaking | API_BREAK **or** error | — |
 | `abicheck compare` | NO_CHANGE or COMPATIBLE | error | API_BREAK | BREAKING |
 
-> ⚠️ If you migrate from ABICC to `abicheck compare` (not `compat`), update CI logic.
+Note: In `compat` mode, exit `2` conflates `API_BREAK` with tool errors. Pre-validate
+that your XML descriptor files exist before relying on exit `2` as an API_BREAK signal.
 
 ---
 
-## 3) Flag compatibility
+## 3) Supported ABICC flags
 
-Core flags preserved:
+Core flags — fully supported:
 
-- `-lib`
-- `-old` / `-new`
-- `-report-path`
-- `-report-format`
-- `-s` / `-strict`
-- `-source` / `-binary`
-- `-show-retval`
-- `-v1` / `-v2`
-- `-skip-symbols` / `-skip-types`
+| Flag | Aliases | Description |
+|------|---------|-------------|
+| `-lib NAME` | `-l`, `-library` | Library name |
+| `-old PATH` | `-d1` | Old version descriptor or dump |
+| `-new PATH` | `-d2` | New version descriptor or dump |
+| `-report-path PATH` | | Output report path |
+| `-report-format FMT` | | `html` (default), `json`, `md` |
+| `-s` | `-strict` | Strict mode: COMPATIBLE → BREAKING |
+| `-source` | `-src`, `-api` | Source/API compat only |
+| `-binary` | `-bin`, `-abi` | Binary ABI mode (default) |
+| `-show-retval` | | Include return-value changes |
+| `-v1 NUM` | `-vnum1` | Override old version label |
+| `-v2 NUM` | `-vnum2` | Override new version label |
+| `-skip-symbols PATH` | | Suppress listed symbols |
+| `-skip-types PATH` | | Suppress listed types |
+| `-stdout` | | Print report to stdout |
 
-Full list: [ABICC compatibility reference](../abicc_compat.md)
+Not supported (ABICC-only features):
+- `-xml` / `-dump` / `-dump-path` — ABICC's ABI dump generation; use `abicheck dump` instead
+- `-headers-only` — reserved, not yet implemented
+- `-cross-gcc` — cross-compilation checks not yet implemented
+- `-relpath` — relative paths in reports
 
 ---
 
 ## 4) Migration checklist
 
-1. Replace ABICC binary call with `abicheck compat`
-2. Keep existing XML descriptors unchanged
-3. Validate exit code behavior in CI
-4. Compare 3–5 historical releases to establish confidence
-5. Optionally migrate to `abicheck compare` for full `API_BREAK` fidelity and JSON/SARIF workflows
+1. Replace ABICC binary call with `abicheck compat` (keep XML descriptors unchanged)
+2. Validate exit code behavior in CI (especially exit `2` semantics)
+3. Run on 3–5 historical releases to establish confidence
+4. Optionally migrate to `abicheck compare` for `API_BREAK` verdict and JSON/SARIF workflows
 
 ---
 
 ## 5) Jenkins stage example
 
 ```bash
-abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-format html -report-path abi-report.html
+# Pre-validate inputs to avoid exit-2 ambiguity
+[ ! -f OLD.xml ] || [ ! -f NEW.xml ] && echo "ERROR: descriptor files missing" && exit 1
+
+abicheck compat -lib libfoo -old OLD.xml -new NEW.xml \
+  -report-format html -report-path abi-report.html
 ret=$?
+
 if [ $ret -eq 1 ]; then
-  echo "BREAKING ABI change"
+  echo "BREAKING ABI change — build blocked"
   exit 1
 fi
 if [ $ret -eq 2 ]; then
-  echo "API_BREAK or execution error"
+  echo "API_BREAK or tool error — investigate abi-report.html"
   exit 1
 fi
+echo "ABI check passed"
 ```
 
 ---
 
-## 6) When to leave `compat`
+## 6) When to move beyond `compat`
 
 Use `abicheck compare` if you need:
-- `API_BREAK` as explicit verdict in CI
-- JSON / SARIF-first automation
-- direct snapshot workflow (`dump` → `compare`)
-
+- `API_BREAK` as an explicit, unambiguous verdict (not conflated with errors)
+- JSON / SARIF-first automation (GitHub Code Scanning, dashboards)
+- Direct snapshot workflow (`abicheck dump` → `abicheck compare`)

--- a/docs/migration/from_abicc.md
+++ b/docs/migration/from_abicc.md
@@ -1,0 +1,86 @@
+# Migrating from ABI Compliance Checker (ABICC)
+
+`abicheck compat` is designed as a practical drop-in path for ABICC pipelines.
+
+---
+
+## 1) One-line swap
+
+Before:
+
+```bash
+abi-compliance-checker -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
+```
+
+After:
+
+```bash
+abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
+```
+
+---
+
+## 2) Exit codes (critical difference)
+
+| Tool / mode | 0 | 1 | 2 | 4 |
+|-------------|---|---|---|---|
+| ABICC | ok | breaking | error | - |
+| `abicheck compat` | ok | breaking | API_BREAK or error | - |
+| `abicheck compare` | NO_CHANGE or COMPATIBLE | error | API_BREAK | BREAKING |
+
+> ⚠️ If you migrate from ABICC to `abicheck compare` (not `compat`), update CI logic.
+
+---
+
+## 3) Flag compatibility
+
+Core flags preserved:
+
+- `-lib`
+- `-old` / `-new`
+- `-report-path`
+- `-report-format`
+- `-s` / `-strict`
+- `-source` / `-binary`
+- `-show-retval`
+- `-v1` / `-v2`
+- `-skip-symbols` / `-skip-types`
+
+Full list: [ABICC compatibility reference](../abicc_compat.md)
+
+---
+
+## 4) Migration checklist
+
+1. Replace ABICC binary call with `abicheck compat`
+2. Keep existing XML descriptors unchanged
+3. Validate exit code behavior in CI
+4. Compare 3–5 historical releases to establish confidence
+5. Optionally migrate to `abicheck compare` for full `API_BREAK` fidelity and JSON/SARIF workflows
+
+---
+
+## 5) Jenkins stage example
+
+```bash
+abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-format html -report-path abi-report.html
+ret=$?
+if [ $ret -eq 1 ]; then
+  echo "BREAKING ABI change"
+  exit 1
+fi
+if [ $ret -eq 2 ]; then
+  echo "API_BREAK or execution error"
+  exit 1
+fi
+```
+
+---
+
+## 6) When to leave `compat`
+
+Use `abicheck compare` if you need:
+- `API_BREAK` as explicit verdict in CI
+- JSON / SARIF-first automation
+- direct snapshot workflow (`dump` → `compare`)
+

--- a/docs/migration/from_abicc.md
+++ b/docs/migration/from_abicc.md
@@ -19,6 +19,10 @@ After (identical flags):
 abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
 ```
 
+> `OLD.xml` is your existing ABICC XML descriptor file — no conversion needed.
+> If you don't have XML descriptors yet, use `abicheck dump` to generate snapshots
+> and then `abicheck compare` instead.
+
 ---
 
 ## 2) Exit codes (critical difference)
@@ -28,11 +32,14 @@ abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
 | Tool / mode | 0 | 1 | 2 | 4 |
 |-------------|---|---|---|---|
 | ABICC | ok | breaking | error | — |
-| `abicheck compat` | ok | breaking | API_BREAK **or** error | — |
-| `abicheck compare` | NO_CHANGE or COMPATIBLE | error | API_BREAK | BREAKING |
+| `abicheck compat` | ok | BREAKING | API_BREAK or tool error | — |
+| `abicheck compare` | NO_CHANGE or COMPATIBLE | tool error | API_BREAK | BREAKING |
 
-Note: In `compat` mode, exit `2` conflates `API_BREAK` with tool errors. Pre-validate
-that your XML descriptor files exist before relying on exit `2` as an API_BREAK signal.
+> ⚠️ In `compat` mode, exit `1` = BREAKING (mirrors ABICC). Exit `2` = API_BREAK
+> **or** tool error (descriptor parse failure, missing `.so`). Pre-validate that your
+> XML descriptor files exist before running — a missing file exits `2`, same as
+> API_BREAK. To disambiguate, use `--format json` and check the `verdict` field
+> (a tool error will produce no `changes` in the JSON output).
 
 ---
 
@@ -47,7 +54,7 @@ Core flags — fully supported:
 | `-new PATH` | `-d2` | New version descriptor or dump |
 | `-report-path PATH` | | Output report path |
 | `-report-format FMT` | | `html` (default), `json`, `md` |
-| `-s` | `-strict` | Strict mode: COMPATIBLE → BREAKING |
+| `-s` | `-strict` | Strict mode: COMPATIBLE + API_BREAK → exit 1 |
 | `-source` | `-src`, `-api` | Source/API compat only |
 | `-binary` | `-bin`, `-abi` | Binary ABI mode (default) |
 | `-show-retval` | | Include return-value changes |
@@ -56,29 +63,40 @@ Core flags — fully supported:
 | `-skip-symbols PATH` | | Suppress listed symbols |
 | `-skip-types PATH` | | Suppress listed types |
 | `-stdout` | | Print report to stdout |
+| `-warn-newsym` | | Treat new exported symbols as a break (exit 2) |
+| `-relpath PATH` | | Base path for relative paths in reports |
 
 Not supported (ABICC-only features):
 - `-xml` / `-dump` / `-dump-path` — ABICC's ABI dump generation; use `abicheck dump` instead
 - `-headers-only` — reserved, not yet implemented
 - `-cross-gcc` — cross-compilation checks not yet implemented
-- `-relpath` — relative paths in reports
 
 ---
 
 ## 4) Migration checklist
 
 1. Replace ABICC binary call with `abicheck compat` (keep XML descriptors unchanged)
-2. Validate exit code behavior in CI (especially exit `2` semantics)
-3. Run on 3–5 historical releases to establish confidence
-4. Optionally migrate to `abicheck compare` for `API_BREAK` verdict and JSON/SARIF workflows
+2. Validate exit code behavior in CI — especially: compat exit `1` = BREAKING, exit `2` = API_BREAK or error
+3. Run on 3–5 historical releases to establish confidence, e.g.:
+   ```bash
+   for ver in v1.0 v1.1 v1.2; do
+     abicheck compat -lib libfoo -old ${ver}.xml -new current.xml \
+       -report-path report-${ver}.html
+     echo "vs ${ver}: exit $?"
+   done
+   ```
+4. Optionally migrate to `abicheck compare` for unambiguous `API_BREAK` verdict and JSON/SARIF workflows
 
 ---
 
 ## 5) Jenkins stage example
 
 ```bash
-# Pre-validate inputs to avoid exit-2 ambiguity
-[ ! -f OLD.xml ] || [ ! -f NEW.xml ] && echo "ERROR: descriptor files missing" && exit 1
+# Pre-validate inputs to avoid exit-2 ambiguity (missing file → exit 2 = same as API_BREAK)
+if [ ! -f OLD.xml ] || [ ! -f NEW.xml ]; then
+  echo "ERROR: descriptor files missing"
+  exit 1
+fi
 
 abicheck compat -lib libfoo -old OLD.xml -new NEW.xml \
   -report-format html -report-path abi-report.html

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,0 +1,283 @@
+# Architecture & Analysis Pipeline
+
+This page explains how `abicheck` works internally — what it analyzes, in what order,
+and how the four analysis tiers combine to produce a verdict.
+
+---
+
+## Overview
+
+`abicheck` uses **four independent analysis tiers** to build a complete picture of
+a library's ABI and API surface. Each tier captures things the others cannot:
+
+| Tier | Source | What it catches |
+|------|--------|-----------------|
+| 1 — castxml/header | C/C++ headers via castxml | function signatures, types, vtables, templates, `noexcept`, `inline` |
+| 2 — ELF | `.so` symbol table | symbol presence/removal, SONAME, visibility, binding, versioning |
+| 3 — DWARF layout | debug info (`-g`) | struct/class field offsets, sizes, alignment |
+| 4 — Advanced DWARF | debug info (`-g`) | calling conventions, struct packing, toolchain flag drift |
+
+The final verdict is the **worst** of all ChangeKinds found across all tiers.
+
+---
+
+## Workflow: `dump` + `compare`
+
+This is the recommended workflow for new integrations.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  abicheck dump                                                   │
+│                                                                  │
+│  libfoo_v1.so ──► ┌────────────────────────────────────────┐    │
+│  include/foo.h ──►│  Tier 1: castxml                       │    │
+│                   │  (parses headers → C++ AST)            │    │
+│                   │  • function signatures                 │    │
+│                   │  • struct/class types & vtables        │    │
+│                   │  • template instantiations             │    │
+│                   │  • noexcept, inline, access levels     │    │
+│                   └─────────────┬──────────────────────────┘    │
+│                                 │                                │
+│                   ┌─────────────▼──────────────────────────┐    │
+│                   │  Tier 2: ELF reader                    │    │
+│                   │  (reads .so symbol table)              │    │
+│                   │  • exported symbol names               │    │
+│                   │  • SONAME, RPATH, DT_NEEDED            │    │
+│                   │  • symbol visibility & binding         │    │
+│                   │  • GNU symbol versioning               │    │
+│                   └─────────────┬──────────────────────────┘    │
+│                                 │                                │
+│                   ┌─────────────▼──────────────────────────┐    │
+│                   │  Tier 3: DWARF layout (optional)       │    │
+│                   │  (requires -g debug info in .so)       │    │
+│                   │  • struct field offsets                │    │
+│                   │  • class/union sizes & alignment       │    │
+│                   │  • base class offsets                  │    │
+│                   └─────────────┬──────────────────────────┘    │
+│                                 │                                │
+│                   ┌─────────────▼──────────────────────────┐    │
+│                   │  Tier 4: Advanced DWARF (optional)     │    │
+│                   │  (requires -g debug info in .so)       │    │
+│                   │  • calling conventions                 │    │
+│                   │  • struct packing (#pragma pack)       │    │
+│                   │  • toolchain flag drift (DW_AT_prod.)  │    │
+│                   └─────────────┬──────────────────────────┘    │
+│                                 │                                │
+│                   ┌─────────────▼──────────────────────────┐    │
+│                   │  ABI Snapshot (JSON)                   │    │
+│                   │  foo-v1.json                           │    │
+│                   └────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────┘
+
+         (repeat for libfoo_v2.so → foo-v2.json)
+
+┌──────────────────────────────────────────────────────────────────┐
+│  abicheck compare                                                │
+│                                                                  │
+│  foo-v1.json ──► ┌────────────────────────────────────────┐     │
+│  foo-v2.json ──► │  Checker engine                        │     │
+│                  │  • runs detectors on paired snapshots  │     │
+│                  │  • each detector emits ChangeKinds     │     │
+│                  └─────────────┬──────────────────────────┘     │
+│                                │                                 │
+│                  ┌─────────────▼──────────────────────────┐     │
+│                  │  checker_policy                        │     │
+│                  │  • maps ChangeKind → Verdict           │     │
+│                  │  • 53 BREAKING + 38 COMPATIBLE         │     │
+│                  │  + 11 API_BREAK ChangeKinds            │     │
+│                  │  • final verdict = worst of all        │     │
+│                  └─────────────┬──────────────────────────┘     │
+│                                │                                 │
+│                  ┌─────────────▼──────────────────────────┐     │
+│                  │  DiffResult                            │     │
+│                  │  { verdict, changes: [Change] }        │     │
+│                  └─────────────┬──────────────────────────┘     │
+│                                │                                 │
+│            ┌───────────────────┼───────────────────────────┐    │
+│            ▼                   ▼                           ▼    │
+│  Markdown report         JSON report               SARIF report  │
+│  (stdout / -o)           (-o result.json)          (-o abi.sarif)│
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Workflow: `compat` mode (ABICC drop-in)
+
+Use this when you have an existing ABICC XML descriptor pipeline.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  abicheck compat                                                 │
+│                                                                  │
+│  OLD.xml ──► ┌─────────────────────────────────────────────┐    │
+│  NEW.xml ──► │  compat layer                               │    │
+│              │  • parses ABICC XML descriptor format       │    │
+│              │  • extracts headers path + .so path         │    │
+│              │  • calls same dump engine as compare mode   │    │
+│              └──────────────┬──────────────────────────────┘    │
+│                             │                                    │
+│                   ┌─────────▼──────────────────────────────┐    │
+│                   │  same 4-tier analysis pipeline         │    │
+│                   │  (Tier 1–4, see above)                 │    │
+│                   └──────────────┬─────────────────────────┘    │
+│                                  │                               │
+│                   ┌──────────────▼─────────────────────────┐    │
+│                   │  ABICC verdict mapping                 │    │
+│                   │  API_BREAK → COMPATIBLE (compat vocab) │    │
+│                   │  exit: 0=ok 1=BREAKING 2=API_BREAK/err │    │
+│                   └──────────────┬─────────────────────────┘    │
+│                                  │                               │
+│               ┌──────────────────┼──────────────────────┐       │
+│               ▼                  ▼                       ▼       │
+│        HTML report         JSON report             XML report    │
+│        (ABICC-style)                               (ABICC-style) │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## When tiers activate
+
+```
+Configuration              Tier 1     Tier 2     Tier 3     Tier 4
+───────────────────────    ──────     ──────     ──────     ──────
+headers + .so (no -g)       ✅          ✅          ❌          ❌
+headers + .so (with -g)     ✅          ✅          ✅          ✅
+.so only (no headers)       ❌          ✅          partial     partial
+```
+
+> **Recommended:** always pass headers (`-H include/`) for full Tier 1 analysis.
+> Without headers, abicheck falls back to ELF-only mode — misses type layout,
+> vtable, template, and noexcept changes.
+
+---
+
+## Module map
+
+```
+abicheck/
+  cli.py            ← CLI entry points (dump / compare / compat / compat-dump)
+  dumper.py         ← builds ABI snapshot from .so + headers (calls all 4 tiers)
+  checker.py        ← runs detectors on two snapshots → DiffResult
+  checker_policy.py ← ChangeKind enum, BREAKING/COMPATIBLE/API_BREAK sets, verdict logic
+  detectors.py      ← detector protocol + detector result types
+  model.py          ← core data model: AbiSnapshot, Function, RecordType, Change
+  compat.py         ← ABICC XML descriptor parsing + compat verdict mapping
+  report_summary.py ← canonical counters shared by all reporters
+  reporter.py       ← Markdown reporter
+  sarif.py          ← SARIF reporter (GitHub Code Scanning)
+  html_report.py    ← HTML reporter (ABICC-compatible)
+  xml_report.py     ← XML reporter (ABICC-compatible machine-readable)
+  suppression.py    ← suppression engine (compare YAML + compat -skip-* flags)
+  serialization.py  ← JSON snapshot read/write
+  elf_metadata.py   ← Tier 2: ELF symbol table, SONAME, visibility
+  dwarf_metadata.py ← Tier 3: DWARF struct layout, field offsets
+  dwarf_advanced.py ← Tier 4: calling conventions, packing, toolchain flags
+  dwarf_unified.py  ← unified DWARF pass (~50% I/O savings via single-pass read)
+```
+
+---
+
+## Data flow (internal)
+
+```
+Input: libfoo.so + include/foo.h
+           │
+           ▼
+      dumper.py
+      ├── castxml → parses headers → AST
+      │   └── extracts: functions, types, vtable, noexcept, inline
+      ├── elf_metadata.py → reads .dynsym, .gnu.version, SONAME
+      ├── dwarf_metadata.py → reads DWARF .debug_info (struct layouts)
+      └── dwarf_unified.py → single-pass DWARF read (performance)
+           │
+           ▼
+      AbiSnapshot (JSON)
+      { functions: [...], types: [...], elf: {...} }
+           │
+     (compare two snapshots)
+           │
+           ▼
+      checker.py
+      └── runs each detector on (old_snapshot, new_snapshot)
+          ├── FuncDetector → FUNC_REMOVED, FUNC_PARAMS_CHANGED, ...
+          ├── TypeDetector → TYPE_SIZE_CHANGED, TYPE_VTABLE_CHANGED, ...
+          ├── ElfDetector  → SONAME_CHANGED, VISIBILITY_LEAK, ...
+          └── DwarfDetector → CALLING_CONVENTION_CHANGED, ...
+           │
+           ▼
+      checker_policy.py
+      compute_verdict(changes) → Verdict
+      (worst of: BREAKING > API_BREAK > COMPATIBLE > NO_CHANGE)
+           │
+           ▼
+      DiffResult { verdict, changes: [Change] }
+           │
+           ▼
+      reporter / sarif / html_report / xml_report
+```
+
+---
+
+## Snapshot format
+
+ABI snapshots are portable JSON files created by `abicheck dump`. They contain
+everything needed for offline comparison — no `.so` or headers required at compare time.
+
+```json
+{
+  "version": "1",
+  "library": "libfoo",
+  "library_version": "1.0",
+  "functions": [
+    {
+      "name": "foo_init",
+      "mangled": "_Z8foo_initv",
+      "return_type": "int",
+      "params": [],
+      "is_virtual": false,
+      "noexcept": false
+    }
+  ],
+  "types": [ ... ],
+  "elf": {
+    "soname": "libfoo.so.1",
+    "exported_symbols": ["_Z8foo_initv"],
+    "symbol_versions": { ... }
+  }
+}
+```
+
+Snapshots can be stored in CI artifacts for offline comparison, baselining, or
+auditing historical ABI evolution.
+
+---
+
+## Choosing a workflow
+
+```
+Do you have ABICC XML descriptors already?
+├── YES → use `abicheck compat` (drop-in, same flags)
+│          then migrate to `abicheck compare` when ready
+│
+└── NO → use `abicheck dump` + `abicheck compare`
+          │
+          Is your .so compiled with -g (debug info)?
+          ├── YES → full 4-tier analysis (most accurate)
+          └── NO  → Tier 1+2 only (headers + ELF)
+                    covers the vast majority of ABI breaks
+```
+
+---
+
+## Comparison: `compare` vs `compat` mode
+
+| Feature | `compare` | `compat` |
+|---------|-----------|---------|
+| Input | JSON snapshots | ABICC XML descriptors |
+| Output formats | md, json, sarif, html | html, json, xml, md |
+| Verdicts | NO_CHANGE / COMPATIBLE / API_BREAK / BREAKING | NO_CHANGE / COMPATIBLE / BREAKING |
+| Exit codes | 0 / 1(err) / 2 / 4 | 0 / 1 / 2(api+err) |
+| ABICC flag parity | — | full (`-lib`, `-old`, `-new`, `-s`, ...) |
+| Recommended for | new integrations | migrating from ABICC |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -8,7 +8,7 @@ and how the four analysis tiers combine to produce a verdict.
 ## Overview
 
 `abicheck` uses **four independent analysis tiers** to build a complete picture of
-a library's ABI and API surface. Each tier captures things the others cannot:
+a library's ABI and API surface. Each tier captures things the others cannot.
 
 | Tier | Source | What it catches |
 |------|--------|-----------------|
@@ -25,7 +25,7 @@ The final verdict is the **worst** of all ChangeKinds found across all tiers.
 
 This is the recommended workflow for new integrations.
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────┐
 │  abicheck dump                                                   │
 │                                                                  │
@@ -104,15 +104,15 @@ This is the recommended workflow for new integrations.
 
 ## Workflow: `compat` mode (ABICC drop-in)
 
-Use this when you have an existing ABICC XML descriptor pipeline.
+Use this when you already have ABICC XML descriptor pipelines.
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────┐
 │  abicheck compat                                                 │
 │                                                                  │
 │  OLD.xml ──► ┌─────────────────────────────────────────────┐    │
 │  NEW.xml ──► │  compat layer                               │    │
-│              │  • parses ABICC XML descriptor format       │    │
+│              │  • parses ABICC XML descriptors             │    │
 │              │  • extracts headers path + .so path         │    │
 │              │  • calls same dump engine as compare mode   │    │
 │              └──────────────┬──────────────────────────────┘    │
@@ -123,9 +123,10 @@ Use this when you have an existing ABICC XML descriptor pipeline.
 │                   └──────────────┬─────────────────────────┘    │
 │                                  │                               │
 │                   ┌──────────────▼─────────────────────────┐    │
-│                   │  ABICC verdict mapping                 │    │
-│                   │  API_BREAK → COMPATIBLE (compat vocab) │    │
-│                   │  exit: 0=ok 1=BREAKING 2=API_BREAK/err │    │
+│                   │  compat exit-code mapping              │    │
+│                   │  exit 0 = NO_CHANGE / COMPATIBLE       │    │
+│                   │  exit 1 = BREAKING or tool error       │    │
+│                   │  exit 2 = API_BREAK                    │    │
 │                   └──────────────┬─────────────────────────┘    │
 │                                  │                               │
 │               ┌──────────────────┼──────────────────────┐       │
@@ -139,7 +140,7 @@ Use this when you have an existing ABICC XML descriptor pipeline.
 
 ## When tiers activate
 
-```
+```text
 Configuration              Tier 1     Tier 2     Tier 3     Tier 4
 ───────────────────────    ──────     ──────     ──────     ──────
 headers + .so (no -g)       ✅          ✅          ❌          ❌
@@ -155,7 +156,7 @@ headers + .so (with -g)     ✅          ✅          ✅          ✅
 
 ## Module map
 
-```
+```text
 abicheck/
   cli.py            ← CLI entry points (dump / compare / compat / compat-dump)
   dumper.py         ← builds ABI snapshot from .so + headers (calls all 4 tiers)
@@ -163,7 +164,7 @@ abicheck/
   checker_policy.py ← ChangeKind enum, BREAKING/COMPATIBLE/API_BREAK sets, verdict logic
   detectors.py      ← detector protocol + detector result types
   model.py          ← core data model: AbiSnapshot, Function, RecordType, Change
-  compat.py         ← ABICC XML descriptor parsing + compat verdict mapping
+  compat.py         ← ABICC XML descriptor parsing + compat mapping
   report_summary.py ← canonical counters shared by all reporters
   reporter.py       ← Markdown reporter
   sarif.py          ← SARIF reporter (GitHub Code Scanning)
@@ -181,7 +182,7 @@ abicheck/
 
 ## Data flow (internal)
 
-```
+```text
 Input: libfoo.so + include/foo.h
            │
            ▼
@@ -222,8 +223,7 @@ Input: libfoo.so + include/foo.h
 
 ## Snapshot format
 
-ABI snapshots are portable JSON files created by `abicheck dump`. They contain
-everything needed for offline comparison — no `.so` or headers required at compare time.
+ABI snapshots are portable JSON files created by `abicheck dump`.
 
 ```json
 {
@@ -249,14 +249,13 @@ everything needed for offline comparison — no `.so` or headers required at com
 }
 ```
 
-Snapshots can be stored in CI artifacts for offline comparison, baselining, or
-auditing historical ABI evolution.
+Snapshots can be stored in CI artifacts for offline comparison and ABI history tracking.
 
 ---
 
 ## Choosing a workflow
 
-```
+```text
 Do you have ABICC XML descriptors already?
 ├── YES → use `abicheck compat` (drop-in, same flags)
 │          then migrate to `abicheck compare` when ready
@@ -266,18 +265,18 @@ Do you have ABICC XML descriptors already?
           Is your .so compiled with -g (debug info)?
           ├── YES → full 4-tier analysis (most accurate)
           └── NO  → Tier 1+2 only (headers + ELF)
-                    covers the vast majority of ABI breaks
+                    covers the majority of ABI breaks
 ```
 
 ---
 
-## Comparison: `compare` vs `compat` mode
+## Comparison: `compare` vs `compat`
 
 | Feature | `compare` | `compat` |
 |---------|-----------|---------|
 | Input | JSON snapshots | ABICC XML descriptors |
 | Output formats | md, json, sarif, html | html, json, xml, md |
-| Verdicts | NO_CHANGE / COMPATIBLE / API_BREAK / BREAKING | NO_CHANGE / COMPATIBLE / BREAKING |
-| Exit codes | 0 / 1(err) / 2 / 4 | 0 / 1 / 2(api+err) |
+| Verdicts in report | NO_CHANGE / COMPATIBLE / API_BREAK / BREAKING | ABICC-style compatibility report |
+| Exit codes | 0 / 1(err) / 2 / 4 | 0 / 1 / 2(API_BREAK) |
 | ABICC flag parity | — | full (`-lib`, `-old`, `-new`, `-s`, ...) |
 | Recommended for | new integrations | migrating from ABICC |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -278,5 +278,5 @@ Do you have ABICC XML descriptors already?
 | Output formats | md, json, sarif, html | html, json, xml, md |
 | Verdicts in report | NO_CHANGE / COMPATIBLE / API_BREAK / BREAKING | ABICC-style compatibility report |
 | Exit codes | 0 / 1(err) / 2 / 4 | 0 / 1 / 2(API_BREAK) |
-| ABICC flag parity | — | full (`-lib`, `-old`, `-new`, `-s`, ...) |
+| ABICC flag parity | — | partial (core flags supported; see [from_abicc.md](../migration/from_abicc.md) for mapping) |
 | Recommended for | new integrations | migrating from ABICC |

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,40 +30,55 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 
 ## Case Index
 
-> Authoritative expected verdicts for benchmarking are in `examples/ground_truth.json`
-> (`expected`, `expected_compat`, `expected_abicc`). If a per-case README text and
-> benchmark expectation differ, treat `ground_truth.json` as source of truth.
+> Authoritative expected verdicts for benchmarking are in .
+> If a per-case README and benchmark expectation differ, treat  as source of truth.
 
-| # | Case | Category | abicheck verdict | Root cause |
-|---|------|----------|-----------------|-----------|
-| [01](case01_symbol_removal/README.md) | Symbol Removal | Symbol API | BREAKING 🔴 | Public function deleted from .so |
-| [02](case02_param_type_change/README.md) | Parameter Type Change | Symbol API | BREAKING 🟡 | Param type widened, callers pass wrong register |
-| [03](case03_compat_addition/README.md) | Compatible Addition | Symbol API | COMPATIBLE 🟢 | New export added, existing callers unaffected |
-| [04](case04_no_change/README.md) | No Change | Symbol API | NO_CHANGE ✅ | Identical binary — baseline |
-| [05](case05_soname/README.md) | Missing SONAME | ELF/Linker | BAD PRACTICE 🟡 | Library built without -Wl,-soname |
-| [06](case06_visibility/README.md) | Visibility Leak | Visibility | BAD PRACTICE 🟡 | Internal symbols unintentionally exported |
-| [07](case07_struct_layout/README.md) | Struct Layout Change | Type Layout | BREAKING 🟡 | Field added, sizeof grows, callers undersize |
-| [08](case08_enum_value_change/README.md) | Enum Value Change | Type Layout | BREAKING 🟡 | Value inserted mid-enum, existing constants shift |
-| [09](case09_cpp_vtable/README.md) | C++ Vtable Change | C++ ABI | BREAKING 🟡 | Virtual method inserted, vtable offsets shift |
-| [10](case10_return_type/README.md) | Return Type Change | Symbol API | BREAKING 🟡 | Return type widened, callers read truncated value |
-| [11](case11_global_var_type/README.md) | Global Variable Type | Type Layout | BREAKING 🟡 | Global var type widened, symbol size changes |
-| [12](case12_function_removed/README.md) | Function Removed | Symbol API | BREAKING 🔴 | Function removed from .so, symbol unresolvable |
-| [13](case13_symbol_versioning/README.md) | Symbol Versioning | ELF/Linker | BREAKING 🔴 | Versioned consumer fails with ld.so assertion when lib loses version script |
-| [14](case14_cpp_class_size/README.md) | C++ Class Size Change | C++ ABI | BREAKING 🟡 | Private member grows, sizeof(class) changes |
-| [15](case15_noexcept_change/README.md) | noexcept Changed | C++ Source | BREAKING 🔴 | v2 adds throw → GLIBCXX_3.4.21 VERNEED (side-effect break, not mangling) |
-| [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline | C++ ABI | BREAKING ⚠️ | ODR violation; symbol appears in v2 .so |
-| [17](case17_template_abi/README.md) | Template Layout Change | C++ ABI | BREAKING 🟡 | Explicit-instantiated template grows in size |
-| [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Type Layout | BREAKING ⚠️ | Third-party type in public header changes layout |
-| [19](case19_enum_member_removed/README.md) | Enum Member Removed | C API | BREAKING 🔴 | Removing an enum value breaks stored/transmitted integers |
-| [20](case20_enum_member_value_changed/README.md) | Enum Value Changed | C API | BREAKING 🔴 | Renumbering enum breaks all consumers using stored values |
-| [21](case21_method_became_static/README.md) | Method Became Static | C++ ABI | BREAKING 🔴 | Calling convention mismatch — implicit `this` ignored |
-| [22](case22_method_const_changed/README.md) | const Qualifier Changed | C++ ABI | BREAKING 🔴 | `_ZNK...` vs `_ZN...` — different mangled symbol name |
-| [23](case23_pure_virtual_added/README.md) | Pure Virtual Added | C++ ABI | BREAKING 🔴 | Existing vtable slot hits `__cxa_pure_virtual` → abort |
-| [24](case24_union_field_removed/README.md) | Union Field Removed | C API | BREAKING 🔴 | Field write interpreted as different type — silent wrong data |
-| [25](case25_enum_member_added/README.md) | Enum Member Added | C API | COMPATIBLE 🟡 | Adding at end is compatible; older binaries handle known values |
-| [26](case26_union_field_added/README.md) | Union Field Added | C API | BREAKING 🔴 | New field grows sizeof(union) 4→8 bytes; TYPE_SIZE_CHANGED breaks callers |
-| [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened | ELF/Linker | COMPATIBLE 🟡 | WEAK symbol can be silently overridden by interposition |
-| [29](case29_ifunc_transition/README.md) | IFUNC Transition | ELF/Linker | COMPATIBLE 🟡 | GNU IFUNC resolves transparently; old `ld.so` may not support |
+**42 cases total** — 29 BREAKING 🔴 | 9 COMPATIBLE 🟢 | 2 NO_CHANGE ✅ | 2 API_BREAK 🟠
+
+| # | Case | Category | abicheck verdict |
+|---|------|----------|-----------------|
+| [01](case01_symbol_removal/README.md) | Symbol Removal | Breaking | BREAKING 🔴 |
+| [02](case02_param_type_change/README.md) | Param Type Change | Breaking | BREAKING 🔴 |
+| [03](case03_compat_addition/README.md) | Compat Addition | Compatible | COMPATIBLE 🟢 |
+| [04](case04_no_change/README.md) | No Change | Compatible | NO_CHANGE ✅ |
+| [05](case05_soname/README.md) | Soname | ELF / Policy | COMPATIBLE 🟡 (bad practice) |
+| [06](case06_visibility/README.md) | Visibility | ELF / Policy | COMPATIBLE 🟡 (bad practice) |
+| [07](case07_struct_layout/README.md) | Struct Layout | Breaking | BREAKING 🔴 |
+| [08](case08_enum_value_change/README.md) | Enum Value Change | Breaking | BREAKING 🔴 |
+| [09](case09_cpp_vtable/README.md) | Cpp Vtable | Breaking | BREAKING 🔴 |
+| [10](case10_return_type/README.md) | Return Type | Breaking | BREAKING 🔴 |
+| [11](case11_global_var_type/README.md) | Global Var Type | Breaking | BREAKING 🔴 |
+| [12](case12_function_removed/README.md) | Function Removed | Breaking | BREAKING 🔴 |
+| [13](case13_symbol_versioning/README.md) | Symbol Versioning | Compatible | COMPATIBLE 🟢 |
+| [14](case14_cpp_class_size/README.md) | Cpp Class Size | Breaking | BREAKING 🔴 |
+| [15](case15_noexcept_change/README.md) | Noexcept Change | Breaking | BREAKING 🔴 |
+| [16](case16_inline_to_non_inline/README.md) | Inline To Non Inline | Compatible | COMPATIBLE 🟢 |
+| [17](case17_template_abi/README.md) | Template Abi | Breaking | BREAKING 🔴 |
+| [18](case18_dependency_leak/README.md) | Dependency Leak | ELF / Policy | COMPATIBLE 🟡 (bad practice) |
+| [19](case19_enum_member_removed/README.md) | Enum Member Removed | Breaking | BREAKING 🔴 |
+| [20](case20_enum_member_value_changed/README.md) | Enum Member Value Changed | Breaking | BREAKING 🔴 |
+| [21](case21_method_became_static/README.md) | Method Became Static | Breaking | BREAKING 🔴 |
+| [22](case22_method_const_changed/README.md) | Method Const Changed | Breaking | BREAKING 🔴 |
+| [23](case23_pure_virtual_added/README.md) | Pure Virtual Added | Breaking | BREAKING 🔴 |
+| [24](case24_union_field_removed/README.md) | Union Field Removed | Breaking | BREAKING 🔴 |
+| [25](case25_enum_member_added/README.md) | Enum Member Added | Compatible | COMPATIBLE 🟢 |
+| [26](case26_union_field_added/README.md) | Union Field Added | Breaking | BREAKING 🔴 |
+| [26b](case26b_union_field_added_compatible/README.md) | Union Field Added Compatible | Compatible | COMPATIBLE 🟢 |
+| [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened | Compatible | COMPATIBLE 🟢 |
+| [28](case28_typedef_opaque/README.md) | Typedef Opaque | Breaking | BREAKING 🔴 |
+| [29](case29_ifunc_transition/README.md) | Ifunc Transition | Compatible | COMPATIBLE 🟢 |
+| [30](case30_field_qualifiers/README.md) | Field Qualifiers | API / Source | BREAKING 🔴 |
+| [31](case31_enum_rename/README.md) | Enum Rename | API / Source | API_BREAK 🟠 |
+| [32](case32_param_defaults/README.md) | Param Defaults | Compatible | NO_CHANGE ✅ |
+| [33](case33_pointer_level/README.md) | Pointer Level | Breaking | BREAKING 🔴 |
+| [34](case34_access_level/README.md) | Access Level | API / Source | API_BREAK 🟠 |
+| [35](case35_field_rename/README.md) | Field Rename | API / Source | BREAKING 🔴 |
+| [36](case36_anon_struct/README.md) | Anon Struct | Breaking | BREAKING 🔴 |
+| [37](case37_base_class/README.md) | Base Class | Breaking | BREAKING 🔴 |
+| [38](case38_virtual_methods/README.md) | Virtual Methods | Breaking | BREAKING 🔴 |
+| [39](case39_var_const/README.md) | Var Const | Breaking | BREAKING 🔴 |
+| [40](case40_field_layout/README.md) | Field Layout | Breaking | BREAKING 🔴 |
+| [41](case41_type_changes/README.md) | Type Changes | Breaking | BREAKING 🔴 |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds v1 core documentation pages addressing critical blockers from 5-reviewer doc plan swarm review.

### New pages
- `docs/concepts/verdicts.md` — 4-verdict reference with CI policy templates and noexcept edge case
- `docs/concepts/limitations.md` — header/binary mismatch risk, stripped binary, template limitations
- `docs/concepts/troubleshooting.md` — diagnostic decision tree for false positives/negatives
- `docs/exit_codes.md` — compare vs compat exit code matrix; warning: COMPATIBLE exits 0
- `docs/migration/from_abicc.md` — one-line ABICC swap, full flag table, Jenkins example

### Updated
- `docs/getting_started.md` — full rewrite: install → first check → CI in <15 min
- `docs/index.md` — corrected exit codes table, links to new core pages

### Addresses
- Exit code silent trap: COMPATIBLE = 0 in compare mode
- ABICC migration guide with exit code differences prominently warned
- Limitations section (header/binary mismatch, stripped .so)
- Troubleshooting for J5 user journey

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed docs on limitations and recommended mitigations
  * New troubleshooting guide with diagnostic steps and escalation checklist
  * Added verdicts reference for NO_CHANGE, COMPATIBLE, API_BREAK, BREAKING and CI actions
  * New exit codes guide with mode-specific tables and CI examples
  * Expanded Getting Started with step-by-step setup, examples, and CI integration
  * Added migration guide from ABICC to abicheck and updated navigation links
  * New architecture & analysis pipeline docs describing tiers, workflows, and reporting
  * Simplified examples index and condensed case matrix in examples README
<!-- end of auto-generated comment: release notes by coderabbit.ai -->