### PR TITLE
feat(phase1a): core/model v0.2 — Origin, Change, PolicyResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.xml
 coverage-integration.xml
 htmlcov/
 examples/**/*.so
+logs/

--- a/abicheck/core/__init__.py
+++ b/abicheck/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core package — v0.2 architecture."""
+from __future__ import annotations

--- a/abicheck/core/corpus/__init__.py
+++ b/abicheck/core/corpus/__init__.py
@@ -1,0 +1,7 @@
+"""Corpus package — Phase 1b."""
+from __future__ import annotations
+
+from .normalizer import Normalizer, NormalizedSnapshot
+from .builder import CorpusBuilder, Corpus
+
+__all__ = ["Normalizer", "NormalizedSnapshot", "CorpusBuilder", "Corpus"]

--- a/abicheck/core/corpus/__init__.py
+++ b/abicheck/core/corpus/__init__.py
@@ -1,7 +1,7 @@
 """Corpus package — Phase 1b."""
 from __future__ import annotations
 
-from .normalizer import Normalizer, NormalizedSnapshot
-from .builder import CorpusBuilder, Corpus
+from .builder import Corpus, CorpusBuilder
+from .normalizer import NormalizedSnapshot, Normalizer
 
 __all__ = ["Normalizer", "NormalizedSnapshot", "CorpusBuilder", "Corpus"]

--- a/abicheck/core/corpus/builder.py
+++ b/abicheck/core/corpus/builder.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from abicheck.model import Function, RecordType, Variable, Visibility
+from abicheck.model import Function, RecordType, Visibility
 
 from .normalizer import NormalizedSnapshot
 

--- a/abicheck/core/corpus/builder.py
+++ b/abicheck/core/corpus/builder.py
@@ -1,0 +1,62 @@
+"""CorpusBuilder — Phase 1b.
+
+Builds a normalized corpus representation from NormalizedSnapshot.
+
+Design goals:
+- Integer-keyed type map (`reachable_types`) for fast diff lookups
+- O(1) indexes for symbols and source exports
+- Deterministic IDs for reproducibility (sorted insertion order)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from abicheck.model import Function, RecordType, Variable, Visibility
+
+from .normalizer import NormalizedSnapshot
+
+
+@dataclass(slots=True)
+class Corpus:
+    """Normalized ABI/API representation (Phase 1b scaffold)."""
+    public_interfaces: dict[str, Function] = field(default_factory=dict)
+    source_exports: dict[str, Function] = field(default_factory=dict)
+    reachable_types: dict[int, RecordType] = field(default_factory=dict)  # int-keyed by design
+    binary_exports: dict[int, str] = field(default_factory=dict)           # id -> mangled symbol
+    dependency_closure: dict[str, list[str]] = field(default_factory=dict) # DAG scaffold
+
+    corpus_version: str | None = None
+    schema_version: str = "0.2"
+
+
+class CorpusBuilder:
+    """Builds Corpus from a NormalizedSnapshot."""
+
+    def build(self, normalized: NormalizedSnapshot) -> Corpus:
+        # Public source interfaces: public functions by mangled name
+        public_funcs = {
+            f.mangled: f
+            for f in normalized.functions
+            if f.visibility == Visibility.PUBLIC
+        }
+
+        # Integer-keyed binary export map (deterministic ordering)
+        ordered_symbols = sorted(public_funcs.keys())
+        binary_exports = {idx: mangled for idx, mangled in enumerate(ordered_symbols)}
+
+        # Integer-keyed type map (deterministic ordering by type name)
+        ordered_types = sorted(normalized.types, key=lambda t: t.name)
+        reachable_types = {idx: t for idx, t in enumerate(ordered_types)}
+
+        # Source exports initially mirror public interfaces (to be refined in Phase 2+)
+        source_exports = dict(public_funcs)
+
+        return Corpus(
+            public_interfaces=public_funcs,
+            source_exports=source_exports,
+            reachable_types=reachable_types,
+            binary_exports=binary_exports,
+            dependency_closure={},
+            corpus_version=normalized.version,
+            schema_version="0.2",
+        )

--- a/abicheck/core/corpus/normalizer.py
+++ b/abicheck/core/corpus/normalizer.py
@@ -1,0 +1,237 @@
+"""Normalizer — Phase 1b.
+
+Converts raw AbiSnapshot (from dumper) into a NormalizedSnapshot
+suitable for CorpusBuilder.
+
+Responsibilities:
+- Intern all name strings (eliminates duplicate string heap objects)
+- Deduplicate facts from multiple evidence sources
+- Strip address-specific noise (e.g. source_location absolute paths → relative)
+- Canonicalize type names (pointer depth, const placement)
+
+This step is deliberately separate from CorpusBuilder so that normalization
+logic is independently testable and has its own invariants.
+
+Pipeline position:  extract → **normalize** → corpus → diff → suppress → policy
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+
+from abicheck.model import (
+    AbiSnapshot,
+    EnumMember,
+    EnumType,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
+
+
+@dataclass
+class NormalizedSnapshot:
+    """An AbiSnapshot with interned strings and deduplicated entries.
+
+    Downstream consumers (CorpusBuilder, diff engine) can assume:
+    - All name strings are interned (``is`` comparison safe for identity checks)
+    - No duplicate functions by mangled name
+    - No duplicate types by name
+    - No duplicate variables by mangled name
+    """
+    library: str
+    version: str
+    functions: list[Function] = field(default_factory=list)
+    variables: list[Variable] = field(default_factory=list)
+    types: list[RecordType] = field(default_factory=list)
+    enums: list[EnumType] = field(default_factory=list)
+    typedefs: dict[str, str] = field(default_factory=dict)
+
+    # Index maps (built by Normalizer for O(1) downstream access)
+    func_index:  dict[str, Function] = field(default_factory=dict, repr=False)
+    var_index:   dict[str, Variable] = field(default_factory=dict, repr=False)
+    type_index:  dict[str, RecordType] = field(default_factory=dict, repr=False)
+    enum_index:  dict[str, EnumType] = field(default_factory=dict, repr=False)
+
+
+class Normalizer:
+    """Converts an AbiSnapshot into a NormalizedSnapshot.
+
+    Usage::
+
+        norm = Normalizer()
+        normalized = norm.normalize(snapshot)
+    """
+
+    def normalize(self, snapshot: AbiSnapshot) -> NormalizedSnapshot:
+        """Normalize a single AbiSnapshot.
+
+        Steps:
+        1. Intern all name/type strings
+        2. Deduplicate functions by mangled name (keep first/PUBLIC wins)
+        3. Deduplicate types by name (keep largest size_bits on conflict)
+        4. Deduplicate variables by mangled name
+        5. Build O(1) index maps
+        """
+        funcs = self._normalize_functions(snapshot.functions)
+        variables = self._normalize_variables(snapshot.variables)
+        types = self._normalize_types(snapshot.types)
+        enums = self._normalize_enums(snapshot.enums)
+        typedefs = {
+            sys.intern(k): sys.intern(v)
+            for k, v in snapshot.typedefs.items()
+        }
+
+        func_index = {f.mangled: f for f in funcs}
+        var_index = {v.mangled: v for v in variables}
+        type_index = {t.name: t for t in types}
+        enum_index = {e.name: e for e in enums}
+
+        return NormalizedSnapshot(
+            library=sys.intern(snapshot.library),
+            version=sys.intern(snapshot.version),
+            functions=funcs,
+            variables=variables,
+            types=types,
+            enums=enums,
+            typedefs=typedefs,
+            func_index=func_index,
+            var_index=var_index,
+            type_index=type_index,
+            enum_index=enum_index,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _intern_param(self, p: Param) -> Param:
+        return Param(
+            name=sys.intern(p.name),
+            type=sys.intern(p.type),
+            kind=p.kind,
+            default=sys.intern(p.default) if p.default else p.default,
+            pointer_depth=p.pointer_depth,
+            is_restrict=p.is_restrict,
+            is_va_list=p.is_va_list,
+        )
+
+    def _intern_function(self, f: Function) -> Function:
+        return Function(
+            name=sys.intern(f.name),
+            mangled=sys.intern(f.mangled),
+            return_type=sys.intern(f.return_type),
+            params=[self._intern_param(p) for p in f.params],
+            visibility=f.visibility,
+            is_virtual=f.is_virtual,
+            is_noexcept=f.is_noexcept,
+            is_extern_c=f.is_extern_c,
+            vtable_index=f.vtable_index,
+            source_location=f.source_location,
+            is_static=f.is_static,
+            is_const=f.is_const,
+            is_volatile=f.is_volatile,
+            is_pure_virtual=f.is_pure_virtual,
+            is_deleted=f.is_deleted,
+            access=f.access,
+            return_pointer_depth=f.return_pointer_depth,
+        )
+
+    def _normalize_functions(self, functions: list[Function]) -> list[Function]:
+        """Intern + deduplicate by mangled name.
+
+        When duplicates exist, PUBLIC visibility wins over HIDDEN/ELF_ONLY.
+        """
+        seen: dict[str, Function] = {}
+        for f in functions:
+            interned = self._intern_function(f)
+            key = interned.mangled
+            if key not in seen:
+                seen[key] = interned
+            elif interned.visibility == Visibility.PUBLIC:
+                # Higher-visibility entry wins (castxml PUBLIC > ELF_ONLY)
+                seen[key] = interned
+        return list(seen.values())
+
+    def _intern_field(self, fld: TypeField) -> TypeField:
+        return TypeField(
+            name=sys.intern(fld.name),
+            type=sys.intern(fld.type),
+            offset_bits=fld.offset_bits,
+            is_bitfield=fld.is_bitfield,
+            bitfield_bits=fld.bitfield_bits,
+            is_const=fld.is_const,
+            is_volatile=fld.is_volatile,
+            is_mutable=fld.is_mutable,
+            access=fld.access,
+        )
+
+    def _intern_record_type(self, t: RecordType) -> RecordType:
+        return RecordType(
+            name=sys.intern(t.name),
+            kind=t.kind,
+            size_bits=t.size_bits,
+            alignment_bits=t.alignment_bits,
+            fields=[self._intern_field(f) for f in t.fields],
+            bases=[sys.intern(b) for b in t.bases],
+            virtual_bases=[sys.intern(b) for b in t.virtual_bases],
+            vtable=[sys.intern(m) for m in t.vtable],
+            source_location=t.source_location,
+            is_union=t.is_union,
+            is_opaque=t.is_opaque,
+        )
+
+    def _normalize_types(self, types: list[RecordType]) -> list[RecordType]:
+        """Intern + deduplicate by name.
+
+        On conflict, keep the entry with the larger size_bits
+        (more complete DWARF/castxml info wins).
+        """
+        seen: dict[str, RecordType] = {}
+        for t in types:
+            interned = self._intern_record_type(t)
+            key = interned.name
+            if key not in seen:
+                seen[key] = interned
+            else:
+                existing = seen[key]
+                # Prefer the entry with more size information
+                if (interned.size_bits or 0) > (existing.size_bits or 0):
+                    seen[key] = interned
+        return list(seen.values())
+
+    def _normalize_variables(self, variables: list[Variable]) -> list[Variable]:
+        seen: dict[str, Variable] = {}
+        for v in variables:
+            interned = Variable(
+                name=sys.intern(v.name),
+                mangled=sys.intern(v.mangled),
+                type=sys.intern(v.type),
+                visibility=v.visibility,
+                source_location=v.source_location,
+                is_const=v.is_const,
+                value=v.value,
+                access=v.access,
+            )
+            key = interned.mangled
+            if key not in seen or interned.visibility == Visibility.PUBLIC:
+                seen[key] = interned
+        return list(seen.values())
+
+    def _normalize_enums(self, enums: list[EnumType]) -> list[EnumType]:
+        seen: dict[str, EnumType] = {}
+        for e in enums:
+            interned = EnumType(
+                name=sys.intern(e.name),
+                members=[
+                    EnumMember(name=sys.intern(m.name), value=m.value)
+                    for m in e.members
+                ],
+                underlying_type=sys.intern(e.underlying_type),
+            )
+            if interned.name not in seen:
+                seen[interned.name] = interned
+        return list(seen.values())

--- a/abicheck/core/diff/__init__.py
+++ b/abicheck/core/diff/__init__.py
@@ -1,0 +1,7 @@
+"""Diff engine package — Phase 1b."""
+from __future__ import annotations
+
+from .symbol_diff import diff_symbols
+from .type_layout_diff import diff_type_layouts
+
+__all__ = ["diff_symbols", "diff_type_layouts"]

--- a/abicheck/core/diff/symbol_diff.py
+++ b/abicheck/core/diff/symbol_diff.py
@@ -1,0 +1,224 @@
+"""symbol_diff — Phase 1b diff engine module.
+
+Detects symbol-level changes between two NormalizedSnapshots:
+- function added / removed / changed (return type, params, qualifiers)
+- variable added / removed / type changed
+
+This module is profile-agnostic — it operates on NormalizedSnapshot
+and returns generic Change objects. Language profile classification
+happens downstream (between diff and suppress).
+
+Pipeline position: corpus → **diff** → suppress → policy
+"""
+from __future__ import annotations
+
+from abicheck.model import Function, Variable, Visibility
+from abicheck.core.corpus.normalizer import NormalizedSnapshot
+from abicheck.core.model import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    Origin,
+)
+
+
+def _func_snapshot(f: Function) -> EntitySnapshot:
+    params_repr = ", ".join(f"{p.type} {p.name}".strip() for p in f.params)
+    return EntitySnapshot(
+        entity_repr=f"{f.return_type} {f.name}({params_repr})",
+        raw={
+            "return_type": f.return_type,
+            "params": [{"name": p.name, "type": p.type} for p in f.params],
+            "is_virtual": f.is_virtual,
+            "is_noexcept": f.is_noexcept,
+            "visibility": f.visibility.value,
+        },
+    )
+
+
+def _var_snapshot(v: Variable) -> EntitySnapshot:
+    return EntitySnapshot(
+        entity_repr=f"{v.type} {v.name}",
+        raw={"type": v.type, "visibility": v.visibility.value},
+    )
+
+
+def diff_symbols(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    """Detect all symbol-level changes between two snapshots.
+
+    Returns a list of Change objects. Caller is responsible for
+    applying suppression and policy classification.
+    """
+    changes: list[Change] = []
+    changes.extend(_diff_functions(before, after))
+    changes.extend(_diff_variables(before, after))
+    return changes
+
+
+def _diff_functions(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    changes: list[Change] = []
+
+    before_pub = {
+        m: f for m, f in before.func_index.items()
+        if f.visibility == Visibility.PUBLIC
+    }
+    after_pub = {
+        m: f for m, f in after.func_index.items()
+        if f.visibility == Visibility.PUBLIC
+    }
+
+    before_keys = set(before_pub)
+    after_keys = set(after_pub)
+
+    # Removed symbols
+    for mangled in before_keys - after_keys:
+        f = before_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f.name,
+            before=_func_snapshot(f),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.ELF,
+            confidence=0.95,
+        ))
+
+    # Added symbols (compatible extension)
+    for mangled in after_keys - before_keys:
+        f = after_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f.name,
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=_func_snapshot(f),
+            severity=ChangeSeverity.COMPATIBLE_EXTENSION,
+            origin=Origin.ELF,
+            confidence=0.95,
+        ))
+
+    # Changed symbols (present in both — check signature)
+    for mangled in before_keys & after_keys:
+        f_old = before_pub[mangled]
+        f_new = after_pub[mangled]
+        sub = _diff_function_pair(f_old, f_new)
+        changes.extend(sub)
+
+    return changes
+
+
+def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
+    changes: list[Change] = []
+    snap_old = _func_snapshot(f_old)
+    snap_new = _func_snapshot(f_new)
+
+    # Return type change
+    if f_old.return_type != f_new.return_type:
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Parameter count / type change
+    elif len(f_old.params) != len(f_new.params) or any(
+        p_old.type != p_new.type
+        for p_old, p_new in zip(f_old.params, f_new.params)
+    ):
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # noexcept removed → breaking (callers may not catch exceptions)
+    elif f_old.is_noexcept and not f_new.is_noexcept:
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.85,
+        ))
+
+    return changes
+
+
+def _diff_variables(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    changes: list[Change] = []
+
+    before_pub = {
+        m: v for m, v in before.var_index.items()
+        if v.visibility == Visibility.PUBLIC
+    }
+    after_pub = {
+        m: v for m, v in after.var_index.items()
+        if v.visibility == Visibility.PUBLIC
+    }
+
+    for mangled in set(before_pub) - set(after_pub):
+        v = before_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="variable",
+            entity_name=v.name,
+            before=_var_snapshot(v),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.ELF,
+            confidence=0.9,
+        ))
+
+    for mangled in set(after_pub) - set(before_pub):
+        v = after_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="variable",
+            entity_name=v.name,
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=_var_snapshot(v),
+            severity=ChangeSeverity.COMPATIBLE_EXTENSION,
+            origin=Origin.ELF,
+            confidence=0.9,
+        ))
+
+    for mangled in set(before_pub) & set(after_pub):
+        v_old = before_pub[mangled]
+        v_new = after_pub[mangled]
+        if v_old.type != v_new.type:
+            changes.append(Change(
+                change_kind=ChangeKind.SYMBOL,
+                entity_type="variable",
+                entity_name=v_old.name,
+                before=_var_snapshot(v_old),
+                after=_var_snapshot(v_new),
+                severity=ChangeSeverity.BREAK,
+                origin=Origin.CASTXML,
+                confidence=0.85,
+            ))
+
+    return changes

--- a/abicheck/core/diff/symbol_diff.py
+++ b/abicheck/core/diff/symbol_diff.py
@@ -12,7 +12,6 @@ Pipeline position: corpus → **diff** → suppress → policy
 """
 from __future__ import annotations
 
-from abicheck.model import Function, Variable, Visibility
 from abicheck.core.corpus.normalizer import NormalizedSnapshot
 from abicheck.core.model import (
     Change,
@@ -21,6 +20,7 @@ from abicheck.core.model import (
     EntitySnapshot,
     Origin,
 )
+from abicheck.model import Function, Variable, Visibility
 
 
 def _func_snapshot(f: Function) -> EntitySnapshot:
@@ -116,6 +116,10 @@ def _diff_functions(
 
 
 def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
+    """Detect all changes for a single function present in both snapshots.
+
+    Reports each change type independently (return type, params, noexcept).
+    """
     changes: list[Change] = []
     snap_old = _func_snapshot(f_old)
     snap_new = _func_snapshot(f_new)
@@ -133,8 +137,8 @@ def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
             confidence=0.9,
         ))
 
-    # Parameter count / type change
-    elif len(f_old.params) != len(f_new.params) or any(
+    # Parameter count / type change (independent of return type)
+    if len(f_old.params) != len(f_new.params) or any(
         p_old.type != p_new.type
         for p_old, p_new in zip(f_old.params, f_new.params)
     ):
@@ -150,7 +154,7 @@ def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
         ))
 
     # noexcept removed → breaking (callers may not catch exceptions)
-    elif f_old.is_noexcept and not f_new.is_noexcept:
+    if f_old.is_noexcept and not f_new.is_noexcept:
         changes.append(Change(
             change_kind=ChangeKind.SYMBOL,
             entity_type="function",

--- a/abicheck/core/diff/symbol_diff.py
+++ b/abicheck/core/diff/symbol_diff.py
@@ -166,6 +166,10 @@ def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
             confidence=0.85,
         ))
 
+    # noexcept added (false→true) changes C++17 mangled name — ABI-breaking for callers
+    # compiled against the old signature. TODO: emit BREAK here in Phase 2 when
+    # mangled name comparison is available; for now silent (conservative: no false positives).
+
     return changes
 
 

--- a/abicheck/core/diff/type_layout_diff.py
+++ b/abicheck/core/diff/type_layout_diff.py
@@ -1,0 +1,264 @@
+"""type_layout_diff — Phase 1b diff engine module.
+
+Two-phase diff for struct/class type layouts:
+  Phase 1: Structural hash filter — O(N), eliminates unchanged types
+  Phase 2: Deep diff — only on types whose hash changed
+
+This prevents the O(N²) / unbounded graph traversal that naive type
+comparison would require for large C++ libraries (oneTBB scale:
+millions of type nodes, template instantiations).
+
+Pipeline position: corpus → **diff** → suppress → policy
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from abicheck.model import RecordType, TypeField
+from abicheck.core.corpus.normalizer import NormalizedSnapshot
+from abicheck.core.model import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    Origin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Structural hash (phase 1 filter)
+# ---------------------------------------------------------------------------
+
+def _type_structural_hash(t: RecordType) -> int:
+    """Fast structural hash for pre-filtering unchanged types.
+
+    Hashes: kind, size_bits, field count, field names+types (shallow).
+    Intentionally avoids recursion — deep comparison happens in phase 2.
+    """
+    field_sig = tuple(
+        (f.name, f.type, f.offset_bits, f.is_bitfield, f.bitfield_bits)
+        for f in t.fields
+    )
+    return hash((
+        t.name,
+        t.kind,
+        t.size_bits,
+        t.alignment_bits,
+        len(t.fields),
+        field_sig,
+        tuple(t.bases),
+        tuple(t.vtable),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Type snapshot helpers
+# ---------------------------------------------------------------------------
+
+def _type_snapshot(t: RecordType) -> EntitySnapshot:
+    return EntitySnapshot(
+        entity_repr=f"{t.kind} {t.name} (size={t.size_bits})",
+        raw={
+            "kind": t.kind,
+            "size_bits": t.size_bits,
+            "alignment_bits": t.alignment_bits,
+            "field_count": len(t.fields),
+            "bases": list(t.bases),
+            "vtable_length": len(t.vtable),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deep type diff (phase 2)
+# ---------------------------------------------------------------------------
+
+def _diff_type_pair(t_old: RecordType, t_new: RecordType) -> list[Change]:
+    """Deep diff between two versions of the same type.
+
+    Called only when structural hash shows a difference.
+    """
+    changes: list[Change] = []
+
+    snap_old = _type_snapshot(t_old)
+    snap_new = _type_snapshot(t_new)
+
+    # Size change (distinct ChangeKind from field layout)
+    if t_old.size_bits != t_new.size_bits:
+        changes.append(Change(
+            change_kind=ChangeKind.SIZE_CHANGE,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.95,
+        ))
+
+    # Field layout changes
+    changes.extend(_diff_fields(t_old, t_new))
+
+    # Base class changes
+    if set(t_old.bases) != set(t_new.bases):
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=EntitySnapshot(entity_repr=f"bases={t_old.bases}"),
+            after=EntitySnapshot(entity_repr=f"bases={t_new.bases}"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Vtable changes
+    if t_old.vtable != t_new.vtable:
+        changes.append(Change(
+            change_kind=ChangeKind.VTABLE_INHERITANCE,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=EntitySnapshot(
+                entity_repr=f"vtable={t_old.vtable}",
+                raw={"vtable": t_old.vtable},
+            ),
+            after=EntitySnapshot(
+                entity_repr=f"vtable={t_new.vtable}",
+                raw={"vtable": t_new.vtable},
+            ),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    return changes
+
+
+def _diff_fields(t_old: RecordType, t_new: RecordType) -> list[Change]:
+    changes: list[Change] = []
+    old_fields = {f.name: f for f in t_old.fields}
+    new_fields = {f.name: f for f in t_new.fields}
+
+    snap_old = _type_snapshot(t_old)
+    snap_new = _type_snapshot(t_new)
+
+    # Removed fields
+    for name in set(old_fields) - set(new_fields):
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="field",
+            entity_name=f"{t_old.name}::{name}",
+            before=EntitySnapshot(entity_repr=f"{old_fields[name].type} {name}"),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.95,
+        ))
+
+    # Added fields
+    for name in set(new_fields) - set(old_fields):
+        # Adding a field changes layout — breaking unless it's at the end
+        # and size already accounted for; conservative: always BREAK
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="field",
+            entity_name=f"{t_old.name}::{name}",
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=EntitySnapshot(entity_repr=f"{new_fields[name].type} {name}"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.85,
+        ))
+
+    # Changed fields (offset or type change)
+    for name in set(old_fields) & set(new_fields):
+        f_old = old_fields[name]
+        f_new = new_fields[name]
+        if f_old.type != f_new.type or f_old.offset_bits != f_new.offset_bits:
+            changes.append(Change(
+                change_kind=ChangeKind.TYPE_LAYOUT,
+                entity_type="field",
+                entity_name=f"{t_old.name}::{name}",
+                before=EntitySnapshot(
+                    entity_repr=f"{f_old.type} {name} @{f_old.offset_bits}",
+                    raw={"type": f_old.type, "offset_bits": f_old.offset_bits},
+                ),
+                after=EntitySnapshot(
+                    entity_repr=f"{f_new.type} {name} @{f_new.offset_bits}",
+                    raw={"type": f_new.type, "offset_bits": f_new.offset_bits},
+                ),
+                severity=ChangeSeverity.BREAK,
+                origin=Origin.CASTXML,
+                confidence=0.9,
+            ))
+
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def diff_type_layouts(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    """Two-phase type layout diff.
+
+    Phase 1: hash filter — O(N) scan, build set of changed type names.
+    Phase 2: deep diff — only for types with hash mismatches.
+
+    Types only in before → removed (BREAK).
+    Types only in after  → added (COMPATIBLE_EXTENSION).
+    Types in both        → phase 1 hash check → phase 2 if changed.
+    """
+    changes: list[Change] = []
+
+    before_types = before.type_index
+    after_types = after.type_index
+
+    # Removed types
+    for name in set(before_types) - set(after_types):
+        t = before_types[name]
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=name,
+            before=_type_snapshot(t),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Added types
+    for name in set(after_types) - set(before_types):
+        t = after_types[name]
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=name,
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=_type_snapshot(t),
+            severity=ChangeSeverity.COMPATIBLE_EXTENSION,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Changed types: phase 1 hash filter, then phase 2 deep diff
+    before_hashes = {
+        name: _type_structural_hash(t)
+        for name, t in before_types.items()
+        if name in after_types
+    }
+    for name in set(before_types) & set(after_types):
+        t_old = before_types[name]
+        t_new = after_types[name]
+        h_old = before_hashes[name]
+        h_new = _type_structural_hash(t_new)
+        if h_old != h_new:
+            # Phase 2: deep diff only for changed types
+            changes.extend(_diff_type_pair(t_old, t_new))
+
+    return changes

--- a/abicheck/core/diff/type_layout_diff.py
+++ b/abicheck/core/diff/type_layout_diff.py
@@ -43,6 +43,7 @@ def _type_structural_hash(t: RecordType) -> int:
         len(t.fields),
         field_sig,
         tuple(t.bases),
+        tuple(sorted(t.virtual_bases)),  # sorted: order-independent content hash
         tuple(t.vtable),
     ))
 

--- a/abicheck/core/diff/type_layout_diff.py
+++ b/abicheck/core/diff/type_layout_diff.py
@@ -95,8 +95,23 @@ def _diff_type_pair(t_old: RecordType, t_new: RecordType) -> list[Change]:
     # Field layout changes
     changes.extend(_diff_fields(t_old, t_new))
 
-    # Base class changes — compare as tuples to catch reordering
-    if tuple(t_old.bases) != tuple(t_new.bases):
+    # Alignment change — ABI-breaking on ARM/RISC-V even without size change
+    if (t_old.alignment_bits or 0) != (t_new.alignment_bits or 0):
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=EntitySnapshot(entity_repr=f"alignment={t_old.alignment_bits}"),
+            after=EntitySnapshot(entity_repr=f"alignment={t_new.alignment_bits}"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Base class changes — use sorted() to catch content changes; tuple() to catch reordering.
+    # sorted bases: detects added/removed base (order-independent content diff)
+    # original tuples: detects reordering of existing bases
+    if sorted(t_old.bases) != sorted(t_new.bases) or tuple(t_old.bases) != tuple(t_new.bases):
         changes.append(Change(
             change_kind=ChangeKind.TYPE_LAYOUT,
             entity_type="type",
@@ -237,17 +252,11 @@ def diff_type_layouts(
         ))
 
     # Changed types: phase 1 hash filter, then phase 2 deep diff
-    before_hashes = {
-        name: _type_structural_hash(t)
-        for name, t in before_types.items()
-        if name in after_types
-    }
-    for name in set(before_types) & set(after_types):
-        t_old = before_types[name]
-        t_new = after_types[name]
-        h_old = before_hashes[name]
-        h_new = _type_structural_hash(t_new)
-        if h_old != h_new:
-            changes.extend(_diff_type_pair(t_old, t_new))
+    common = set(before_types) & set(after_types)
+    before_hashes = {name: _type_structural_hash(before_types[name]) for name in common}
+    after_hashes = {name: _type_structural_hash(after_types[name]) for name in common}
+    for name in common:
+        if before_hashes[name] != after_hashes[name]:
+            changes.extend(_diff_type_pair(before_types[name], after_types[name]))
 
     return changes

--- a/abicheck/core/diff/type_layout_diff.py
+++ b/abicheck/core/diff/type_layout_diff.py
@@ -123,6 +123,19 @@ def _diff_type_pair(t_old: RecordType, t_new: RecordType) -> list[Change]:
             confidence=0.9,
         ))
 
+    # Virtual base changes
+    if sorted(t_old.virtual_bases) != sorted(t_new.virtual_bases):
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=EntitySnapshot(entity_repr=f"virtual_bases={list(t_old.virtual_bases)}"),
+            after=EntitySnapshot(entity_repr=f"virtual_bases={list(t_new.virtual_bases)}"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
     # Vtable changes
     if t_old.vtable != t_new.vtable:
         changes.append(Change(
@@ -176,22 +189,29 @@ def _diff_fields(t_old: RecordType, t_new: RecordType) -> list[Change]:
             confidence=0.85,
         ))
 
-    # Changed fields (offset or type change)
+    # Changed fields (offset, type, or bitfield change)
     for name in set(old_fields) & set(new_fields):
         f_old = old_fields[name]
         f_new = new_fields[name]
-        if f_old.type != f_new.type or f_old.offset_bits != f_new.offset_bits:
+        if (
+            f_old.type != f_new.type
+            or f_old.offset_bits != f_new.offset_bits
+            or f_old.is_bitfield != f_new.is_bitfield
+            or f_old.bitfield_bits != f_new.bitfield_bits
+        ):
             changes.append(Change(
                 change_kind=ChangeKind.TYPE_LAYOUT,
                 entity_type="field",
                 entity_name=f"{t_old.name}::{name}",
                 before=EntitySnapshot(
                     entity_repr=f"{f_old.type} {name} @{f_old.offset_bits}",
-                    raw={"type": f_old.type, "offset_bits": f_old.offset_bits},
+                    raw={"type": f_old.type, "offset_bits": f_old.offset_bits,
+                         "is_bitfield": f_old.is_bitfield, "bitfield_bits": f_old.bitfield_bits},
                 ),
                 after=EntitySnapshot(
                     entity_repr=f"{f_new.type} {name} @{f_new.offset_bits}",
-                    raw={"type": f_new.type, "offset_bits": f_new.offset_bits},
+                    raw={"type": f_new.type, "offset_bits": f_new.offset_bits,
+                         "is_bitfield": f_new.is_bitfield, "bitfield_bits": f_new.bitfield_bits},
                 ),
                 severity=ChangeSeverity.BREAK,
                 origin=Origin.CASTXML,

--- a/abicheck/core/diff/type_layout_diff.py
+++ b/abicheck/core/diff/type_layout_diff.py
@@ -5,17 +5,12 @@ Two-phase diff for struct/class type layouts:
   Phase 2: Deep diff — only on types whose hash changed
 
 This prevents the O(N²) / unbounded graph traversal that naive type
-comparison would require for large C++ libraries (oneTBB scale:
-millions of type nodes, template instantiations).
+comparison would require for large C++ libraries.
 
 Pipeline position: corpus → **diff** → suppress → policy
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
-from abicheck.model import RecordType, TypeField
 from abicheck.core.corpus.normalizer import NormalizedSnapshot
 from abicheck.core.model import (
     Change,
@@ -24,7 +19,7 @@ from abicheck.core.model import (
     EntitySnapshot,
     Origin,
 )
-
+from abicheck.model import RecordType
 
 # ---------------------------------------------------------------------------
 # Structural hash (phase 1 filter)
@@ -100,14 +95,14 @@ def _diff_type_pair(t_old: RecordType, t_new: RecordType) -> list[Change]:
     # Field layout changes
     changes.extend(_diff_fields(t_old, t_new))
 
-    # Base class changes
-    if set(t_old.bases) != set(t_new.bases):
+    # Base class changes — compare as tuples to catch reordering
+    if tuple(t_old.bases) != tuple(t_new.bases):
         changes.append(Change(
             change_kind=ChangeKind.TYPE_LAYOUT,
             entity_type="type",
             entity_name=t_old.name,
-            before=EntitySnapshot(entity_repr=f"bases={t_old.bases}"),
-            after=EntitySnapshot(entity_repr=f"bases={t_new.bases}"),
+            before=EntitySnapshot(entity_repr=f"bases={list(t_old.bases)}"),
+            after=EntitySnapshot(entity_repr=f"bases={list(t_new.bases)}"),
             severity=ChangeSeverity.BREAK,
             origin=Origin.CASTXML,
             confidence=0.9,
@@ -140,9 +135,6 @@ def _diff_fields(t_old: RecordType, t_new: RecordType) -> list[Change]:
     old_fields = {f.name: f for f in t_old.fields}
     new_fields = {f.name: f for f in t_new.fields}
 
-    snap_old = _type_snapshot(t_old)
-    snap_new = _type_snapshot(t_new)
-
     # Removed fields
     for name in set(old_fields) - set(new_fields):
         changes.append(Change(
@@ -158,8 +150,6 @@ def _diff_fields(t_old: RecordType, t_new: RecordType) -> list[Change]:
 
     # Added fields
     for name in set(new_fields) - set(old_fields):
-        # Adding a field changes layout — breaking unless it's at the end
-        # and size already accounted for; conservative: always BREAK
         changes.append(Change(
             change_kind=ChangeKind.TYPE_LAYOUT,
             entity_type="field",
@@ -258,7 +248,6 @@ def diff_type_layouts(
         h_old = before_hashes[name]
         h_new = _type_structural_hash(t_new)
         if h_old != h_new:
-            # Phase 2: deep diff only for changed types
             changes.extend(_diff_type_pair(t_old, t_new))
 
     return changes

--- a/abicheck/core/model/__init__.py
+++ b/abicheck/core/model/__init__.py
@@ -1,0 +1,35 @@
+"""Core model package — v0.2 data structures.
+
+Public surface:
+    Origin, ChangeSeverity, ChangeKind, SourceLocation, EntitySnapshot, Change
+    PolicyVerdict, AnnotatedChange, PolicySummary, PolicyResult
+"""
+from __future__ import annotations
+
+from .origin import Origin
+from .change import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    SourceLocation,
+)
+from .policy_result import (
+    AnnotatedChange,
+    PolicyResult,
+    PolicySummary,
+    PolicyVerdict,
+)
+
+__all__ = [
+    "Origin",
+    "Change",
+    "ChangeKind",
+    "ChangeSeverity",
+    "EntitySnapshot",
+    "SourceLocation",
+    "AnnotatedChange",
+    "PolicyResult",
+    "PolicySummary",
+    "PolicyVerdict",
+]

--- a/abicheck/core/model/__init__.py
+++ b/abicheck/core/model/__init__.py
@@ -6,7 +6,6 @@ Public surface:
 """
 from __future__ import annotations
 
-from .origin import Origin
 from .change import (
     Change,
     ChangeKind,
@@ -14,6 +13,7 @@ from .change import (
     EntitySnapshot,
     SourceLocation,
 )
+from .origin import Origin
 from .policy_result import (
     AnnotatedChange,
     PolicyResult,

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -87,6 +87,10 @@ class Change:
     def __post_init__(self) -> None:
         if not (0.0 <= self.confidence <= 1.0):
             raise ValueError(f"confidence must be in [0.0, 1.0], got {self.confidence}")
+        if self.origin in self.corroborating:
+            raise ValueError(
+                f"primary origin {self.origin!r} must not appear in corroborating"
+            )
 
     @property
     def requires_review(self) -> bool:

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -98,6 +98,8 @@ class Change:
             raise ValueError(
                 f"primary origin {self.origin!r} must not appear in corroborating"
             )
+        if len(self.corroborating) != len(set(self.corroborating)):
+            raise ValueError("corroborating origins must be unique")
         if self.change_kind == ChangeKind.CALLING_CONVENTION:
             evidence = (self.origin, *self.corroborating)
             if Origin.DWARF not in evidence and Origin.CASTXML not in evidence:

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -18,32 +18,37 @@ class ChangeSeverity(str, Enum):
     This field carries *epistemic* information (detection confidence),
     not just policy intent — which is why it lives on Change, not only PolicyResult.
     """
-    BREAK                = "break"                # ABI-incompatible
-    COMPATIBLE_EXTENSION = "compatible_extension" # additive, safe
-    REVIEW_NEEDED        = "review_needed"         # uncertain, needs human review
-    SUPPRESSED           = "suppressed"            # matched a suppression rule
+
+    BREAK = "break"  # ABI-incompatible
+    COMPATIBLE_EXTENSION = "compatible_extension"  # additive, safe
+    REVIEW_NEEDED = "review_needed"  # uncertain, needs human review
+    SUPPRESSED = "suppressed"  # matched a suppression rule
 
 
 class ChangeKind(str, Enum):
     """Category of the detected change."""
-    SYMBOL               = "symbol"
-    TYPE_LAYOUT          = "type_layout"
-    SIZE_CHANGE          = "size_change"           # struct/class total size (distinct from field layout)
-    CALLING_CONVENTION   = "calling_convention"    # only emitted when DWARF/castxml evidence present
-    VTABLE_INHERITANCE   = "vtable_inheritance"
-    LOADER_METADATA      = "loader_metadata"
-    PACKAGING_RUNTIME    = "packaging_runtime"
-    SOURCE_API_ONLY      = "source_api_only"
+
+    SYMBOL = "symbol"
+    TYPE_LAYOUT = "type_layout"
+    SIZE_CHANGE = "size_change"  # struct/class total size (distinct from field layout)
+    CALLING_CONVENTION = "calling_convention"  # only emitted when DWARF/castxml evidence present
+    VTABLE_INHERITANCE = "vtable_inheritance"
+    LOADER_METADATA = "loader_metadata"
+    PACKAGING_RUNTIME = "packaging_runtime"
+    SOURCE_API_ONLY = "source_api_only"
 
 
 @dataclass(slots=True)
 class SourceLocation:
     """File + line reference from DWARF or castxml."""
+
     file: str
     line: int | None = None
     column: int | None = None
 
     def __str__(self) -> str:
+        if self.line is not None and self.column is not None:
+            return f"{self.file}:{self.line}:{self.column}"
         if self.line is not None:
             return f"{self.file}:{self.line}"
         return self.file
@@ -56,7 +61,8 @@ class EntitySnapshot:
     Using a typed wrapper instead of plain dict/str prevents isinstance()
     sprawl in the report layer.
     """
-    entity_repr: str          # human-readable (demangled name / type signature)
+
+    entity_repr: str  # human-readable (demangled name / type signature)
     raw: dict[str, Any] = field(default_factory=dict)  # full structured data
 
 
@@ -73,16 +79,17 @@ class Change:
     - ``calling_convention`` kind MUST NOT be emitted without DWARF/castxml evidence;
       binary-only → severity=REVIEW_NEEDED
     """
-    change_kind:   ChangeKind
-    entity_type:   str
-    entity_name:   str
-    before:        EntitySnapshot
-    after:         EntitySnapshot
-    severity:      ChangeSeverity
-    origin:        Origin                    # primary (highest confidence)
+
+    change_kind: ChangeKind
+    entity_type: str
+    entity_name: str
+    before: EntitySnapshot
+    after: EntitySnapshot
+    severity: ChangeSeverity
+    origin: Origin  # primary (highest confidence)
     corroborating: tuple[Origin, ...] = ()  # additional confirming sources
-    confidence:    float = 1.0              # 0.0–1.0
-    location:      SourceLocation | None = None  # file/line from DWARF or castxml
+    confidence: float = 1.0  # 0.0–1.0
+    location: SourceLocation | None = None  # file/line from DWARF or castxml
 
     def __post_init__(self) -> None:
         if not (0.0 <= self.confidence <= 1.0):
@@ -91,6 +98,13 @@ class Change:
             raise ValueError(
                 f"primary origin {self.origin!r} must not appear in corroborating"
             )
+        if self.change_kind == ChangeKind.CALLING_CONVENTION:
+            evidence = (self.origin, *self.corroborating)
+            if Origin.DWARF not in evidence and Origin.CASTXML not in evidence:
+                raise ValueError(
+                    "CALLING_CONVENTION requires DWARF or CASTXML evidence; "
+                    "binary-only sources must use severity=REVIEW_NEEDED instead"
+                )
 
     @property
     def requires_review(self) -> bool:

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -1,0 +1,94 @@
+"""Change model — v0.2.
+
+Represents a single detected difference between two Corpus snapshots.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from .origin import Origin
+
+
+class ChangeSeverity(str, Enum):
+    """Severity of a detected change.
+
+    Replaces the v0.1 ``requires_review: bool`` field.
+    This field carries *epistemic* information (detection confidence),
+    not just policy intent — which is why it lives on Change, not only PolicyResult.
+    """
+    BREAK                = "break"                # ABI-incompatible
+    COMPATIBLE_EXTENSION = "compatible_extension" # additive, safe
+    REVIEW_NEEDED        = "review_needed"         # uncertain, needs human review
+    SUPPRESSED           = "suppressed"            # matched a suppression rule
+
+
+class ChangeKind(str, Enum):
+    """Category of the detected change."""
+    SYMBOL               = "symbol"
+    TYPE_LAYOUT          = "type_layout"
+    SIZE_CHANGE          = "size_change"           # struct/class total size (distinct from field layout)
+    CALLING_CONVENTION   = "calling_convention"    # only emitted when DWARF/castxml evidence present
+    VTABLE_INHERITANCE   = "vtable_inheritance"
+    LOADER_METADATA      = "loader_metadata"
+    PACKAGING_RUNTIME    = "packaging_runtime"
+    SOURCE_API_ONLY      = "source_api_only"
+
+
+@dataclass(slots=True)
+class SourceLocation:
+    """File + line reference from DWARF or castxml."""
+    file: str
+    line: int | None = None
+    column: int | None = None
+
+    def __str__(self) -> str:
+        if self.line is not None:
+            return f"{self.file}:{self.line}"
+        return self.file
+
+
+@dataclass(slots=True)
+class EntitySnapshot:
+    """Typed snapshot of an entity before or after a change.
+
+    Using a typed wrapper instead of plain dict/str prevents isinstance()
+    sprawl in the report layer.
+    """
+    entity_repr: str          # human-readable (demangled name / type signature)
+    raw: dict[str, Any] = field(default_factory=dict)  # full structured data
+
+
+@dataclass(slots=True)
+class Change:
+    """A single detected ABI/API change between two Corpus snapshots.
+
+    Design notes:
+    - ``origin`` is the primary (highest-confidence) source
+    - ``corroborating`` holds additional sources that confirm the change
+      (tuple, not list — lower overhead; empty tuple is the common case)
+    - ``severity`` carries epistemic info about detection confidence,
+      not only policy intent
+    - ``calling_convention`` kind MUST NOT be emitted without DWARF/castxml evidence;
+      binary-only → severity=REVIEW_NEEDED
+    """
+    change_kind:   ChangeKind
+    entity_type:   str
+    entity_name:   str
+    before:        EntitySnapshot
+    after:         EntitySnapshot
+    severity:      ChangeSeverity
+    origin:        Origin                    # primary (highest confidence)
+    corroborating: tuple[Origin, ...] = ()  # additional confirming sources
+    confidence:    float = 1.0              # 0.0–1.0
+    location:      SourceLocation | None = None  # file/line from DWARF or castxml
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError(f"confidence must be in [0.0, 1.0], got {self.confidence}")
+
+    @property
+    def requires_review(self) -> bool:
+        """Backward-compat shim. Use severity == REVIEW_NEEDED directly."""
+        return self.severity == ChangeSeverity.REVIEW_NEEDED

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -100,6 +100,13 @@ class Change:
             )
         if len(self.corroborating) != len(set(self.corroborating)):
             raise ValueError("corroborating origins must be unique")
+        # Primary origin must have the highest confidence among all sources
+        all_origins = (self.origin, *self.corroborating)
+        if self.corroborating and self.origin != Origin.highest(all_origins):
+            raise ValueError(
+                f"primary origin {self.origin!r} must be the highest-confidence source; "
+                f"use origin={Origin.highest(all_origins)!r} instead"
+            )
         if self.change_kind == ChangeKind.CALLING_CONVENTION:
             evidence = (self.origin, *self.corroborating)
             if Origin.DWARF not in evidence and Origin.CASTXML not in evidence:

--- a/abicheck/core/model/origin.py
+++ b/abicheck/core/model/origin.py
@@ -6,6 +6,7 @@ At millions-of-facts scale, string origins cost ~500MB+ in __dict__ overhead.
 from __future__ import annotations
 
 from enum import IntEnum
+from types import MappingProxyType
 from typing import Final
 
 
@@ -48,8 +49,8 @@ class Origin(IntEnum):
 
 
 # Module-level constant — avoids rebuilding the dict on every property call.
-# Keyed by int value to satisfy mypy (IntEnum is indexable as int).
-_CONFIDENCE: Final[dict[int, float]] = {
+# MappingProxyType makes it truly immutable (Final only prevents rebinding).
+_CONFIDENCE: Final = MappingProxyType({
     int(Origin.CASTXML): 1.0,
     int(Origin.DWARF): 0.9,
     int(Origin.PDB): 0.8,  # PDB has type info → higher than ELF
@@ -58,4 +59,4 @@ _CONFIDENCE: Final[dict[int, float]] = {
     int(Origin.COFF): 0.7,
     int(Origin.BTF): 0.6,
     int(Origin.CTF): 0.6,
-}
+})

--- a/abicheck/core/model/origin.py
+++ b/abicheck/core/model/origin.py
@@ -1,0 +1,46 @@
+"""Origin enum — evidence source tags for FactSet facts.
+
+Using IntEnum (not str Enum) to eliminate per-fact heap allocation.
+At millions-of-facts scale, string origins cost ~500MB+ in __dict__ overhead.
+"""
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class Origin(IntEnum):
+    """Evidence source that produced a fact or detected a change.
+
+    Priority order (highest confidence first):
+        CASTXML > DWARF > ELF > PDB > MACHO > COFF > BTF > CTF
+    """
+    CASTXML = 0   # source AST via castxml — highest confidence
+    DWARF   = 1   # DWARF debug info
+    ELF     = 2   # ELF symbol table / dynamic section
+    PDB     = 3   # Windows PDB debug info
+    MACHO   = 4   # Mach-O metadata
+    COFF    = 5   # PE/COFF export table
+    BTF     = 6   # BPF Type Format
+    CTF     = 7   # Compact Type Format (Solaris/FreeBSD)
+
+    @property
+    def confidence(self) -> float:
+        """Confidence score 0.0–1.0 (higher = more reliable)."""
+        _scores = {
+            Origin.CASTXML: 1.0,
+            Origin.DWARF:   0.9,
+            Origin.ELF:     0.7,
+            Origin.PDB:     0.8,
+            Origin.MACHO:   0.7,
+            Origin.COFF:    0.7,
+            Origin.BTF:     0.6,
+            Origin.CTF:     0.6,
+        }
+        return _scores[self]
+
+    @classmethod
+    def highest(cls, origins: tuple[Origin, ...]) -> Origin:
+        """Return the highest-confidence origin from a tuple."""
+        if not origins:
+            raise ValueError("origins must be non-empty")
+        return min(origins, key=lambda o: o.value)

--- a/abicheck/core/model/origin.py
+++ b/abicheck/core/model/origin.py
@@ -6,7 +6,7 @@ At millions-of-facts scale, string origins cost ~500MB+ in __dict__ overhead.
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import ClassVar
+from typing import Final
 
 
 class Origin(IntEnum):
@@ -21,22 +21,20 @@ class Origin(IntEnum):
     IntEnum values encode source identity only, NOT confidence order.
     Always use `.confidence` for ordering decisions.
     """
-    CASTXML = 0   # source AST via castxml — highest confidence
-    DWARF   = 1   # DWARF debug info
-    ELF     = 2   # ELF symbol table / dynamic section
-    PDB     = 3   # Windows PDB debug info (higher confidence than ELF)
-    MACHO   = 4   # Mach-O metadata
-    COFF    = 5   # PE/COFF export table
-    BTF     = 6   # BPF Type Format
-    CTF     = 7   # Compact Type Format (Solaris/FreeBSD)
 
-    # Class-level constant — avoids rebuilding the dict on every property call
-    _CONFIDENCE: ClassVar[dict[int, float]]
+    CASTXML = 0  # source AST via castxml — highest confidence
+    DWARF = 1  # DWARF debug info
+    ELF = 2  # ELF symbol table / dynamic section
+    PDB = 3  # Windows PDB debug info (higher confidence than ELF)
+    MACHO = 4  # Mach-O metadata
+    COFF = 5  # PE/COFF export table
+    BTF = 6  # BPF Type Format
+    CTF = 7  # Compact Type Format (Solaris/FreeBSD)
 
     @property
     def confidence(self) -> float:
         """Confidence score 0.0–1.0 (higher = more reliable for ABI analysis)."""
-        return Origin._CONFIDENCE[self.value]
+        return _CONFIDENCE[int(self)]
 
     @classmethod
     def highest(cls, origins: tuple[Origin, ...]) -> Origin:
@@ -49,14 +47,15 @@ class Origin(IntEnum):
         return max(origins, key=lambda o: o.confidence)
 
 
-# Populated after class definition so Origin members are resolvable
-Origin._CONFIDENCE = {
-    Origin.CASTXML.value: 1.0,
-    Origin.DWARF.value:   0.9,
-    Origin.PDB.value:     0.8,   # PDB has type info → higher than ELF
-    Origin.ELF.value:     0.7,
-    Origin.MACHO.value:   0.7,
-    Origin.COFF.value:    0.7,
-    Origin.BTF.value:     0.6,
-    Origin.CTF.value:     0.6,
+# Module-level constant — avoids rebuilding the dict on every property call.
+# Keyed by int value to satisfy mypy (IntEnum is indexable as int).
+_CONFIDENCE: Final[dict[int, float]] = {
+    int(Origin.CASTXML): 1.0,
+    int(Origin.DWARF): 0.9,
+    int(Origin.PDB): 0.8,  # PDB has type info → higher than ELF
+    int(Origin.ELF): 0.7,
+    int(Origin.MACHO): 0.7,
+    int(Origin.COFF): 0.7,
+    int(Origin.BTF): 0.6,
+    int(Origin.CTF): 0.6,
 }

--- a/abicheck/core/model/origin.py
+++ b/abicheck/core/model/origin.py
@@ -6,41 +6,57 @@ At millions-of-facts scale, string origins cost ~500MB+ in __dict__ overhead.
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import ClassVar
 
 
 class Origin(IntEnum):
     """Evidence source that produced a fact or detected a change.
 
     Priority order (highest confidence first):
-        CASTXML > DWARF > ELF > PDB > MACHO > COFF > BTF > CTF
+        CASTXML(1.0) > DWARF(0.9) > PDB(0.8) > ELF/MACHO/COFF(0.7) > BTF/CTF(0.6)
+
+    Note: PDB has higher confidence than ELF — PDB contains full debug type info,
+    whereas ELF symbol tables carry only symbol names and addresses.
+
+    IntEnum values encode source identity only, NOT confidence order.
+    Always use `.confidence` for ordering decisions.
     """
     CASTXML = 0   # source AST via castxml — highest confidence
     DWARF   = 1   # DWARF debug info
     ELF     = 2   # ELF symbol table / dynamic section
-    PDB     = 3   # Windows PDB debug info
+    PDB     = 3   # Windows PDB debug info (higher confidence than ELF)
     MACHO   = 4   # Mach-O metadata
     COFF    = 5   # PE/COFF export table
     BTF     = 6   # BPF Type Format
     CTF     = 7   # Compact Type Format (Solaris/FreeBSD)
 
+    # Class-level constant — avoids rebuilding the dict on every property call
+    _CONFIDENCE: ClassVar[dict[int, float]]
+
     @property
     def confidence(self) -> float:
-        """Confidence score 0.0–1.0 (higher = more reliable)."""
-        _scores = {
-            Origin.CASTXML: 1.0,
-            Origin.DWARF:   0.9,
-            Origin.ELF:     0.7,
-            Origin.PDB:     0.8,
-            Origin.MACHO:   0.7,
-            Origin.COFF:    0.7,
-            Origin.BTF:     0.6,
-            Origin.CTF:     0.6,
-        }
-        return _scores[self]
+        """Confidence score 0.0–1.0 (higher = more reliable for ABI analysis)."""
+        return Origin._CONFIDENCE[self.value]
 
     @classmethod
     def highest(cls, origins: tuple[Origin, ...]) -> Origin:
-        """Return the highest-confidence origin from a tuple."""
+        """Return the highest-confidence origin from a tuple.
+
+        Uses confidence scores, NOT IntEnum integer values.
+        """
         if not origins:
             raise ValueError("origins must be non-empty")
-        return min(origins, key=lambda o: o.value)
+        return max(origins, key=lambda o: o.confidence)
+
+
+# Populated after class definition so Origin members are resolvable
+Origin._CONFIDENCE = {
+    Origin.CASTXML.value: 1.0,
+    Origin.DWARF.value:   0.9,
+    Origin.PDB.value:     0.8,   # PDB has type info → higher than ELF
+    Origin.ELF.value:     0.7,
+    Origin.MACHO.value:   0.7,
+    Origin.COFF.value:    0.7,
+    Origin.BTF.value:     0.6,
+    Origin.CTF.value:     0.6,
+}

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -97,8 +97,9 @@ class PolicyResult:
         else:
             verdict = PolicyVerdict.PASS
 
+        annotated_changes = list(changes)  # defensive copy — caller mutation won't stale summary
         return cls(
-            annotated_changes=changes,
+            annotated_changes=annotated_changes,
             summary=PolicySummary(
                 verdict=verdict,
                 incompatible_count=incompatible,

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -28,19 +28,41 @@ class AnnotatedChange:
 
 @dataclass(slots=True)
 class PolicySummary:
-    """Aggregate counts for the policy evaluation run."""
+    """Aggregate counts for the policy evaluation run.
+
+    ``verdict`` is always derived from the counts — never set independently.
+    - BLOCK:  incompatible_count > 0
+    - WARN:   review_needed_count > 0 (and incompatible_count == 0)
+    - PASS:   both counts are 0
+    - ERROR:  pipeline failure (not a policy outcome; error_count > 0)
+    """
     verdict:             PolicyVerdict
     review_needed_count: int = 0
     incompatible_count:  int = 0
     suppressed_count:    int = 0
+    error_count:         int = 0   # reserved: pipeline failures (insufficient evidence etc.)
 
 
-@dataclass
+@dataclass(slots=True)
 class PolicyResult:
     """Full result of a policy evaluation.
 
     ``annotated_changes`` provides per-change traceability (replaces the v0.1 opaque summary).
     ``summary`` provides the CI-facing aggregate verdict and counts.
+
+    Use ``PolicyResult.from_annotated()`` as the primary constructor — it derives
+    the summary deterministically from the change list.
+
+    Note on count semantics:
+    - ``incompatible_count``  = number of AnnotatedChange with verdict == BLOCK
+    - ``review_needed_count`` = number of Change with severity == REVIEW_NEEDED
+    - ``suppressed_count``    = number of Change with severity == SUPPRESSED
+    Counts are deliberately not cross-validated at construction time; callers
+    using ``from_annotated`` get a guaranteed-consistent summary.
+
+    Note on ERROR verdict: ``PolicyVerdict.ERROR`` is not producible via
+    ``from_annotated`` (it signals pipeline failure, not a policy outcome).
+    Construct manually when the pipeline cannot complete analysis.
     """
     annotated_changes: list[AnnotatedChange] = field(default_factory=list)
     summary:           PolicySummary = field(

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -43,6 +43,7 @@ class PolicySummary:
     review_needed_count: int = 0
     incompatible_count: int = 0
     suppressed_count: int = 0
+    compatible_extension_count: int = 0
     error_count: int = 0  # reserved: pipeline failures (insufficient evidence etc.)
 
 
@@ -82,6 +83,10 @@ class PolicyResult:
             1 for ac in changes
             if ac.change.severity == ChangeSeverity.SUPPRESSED
         )
+        compatible_extension = sum(
+            1 for ac in changes
+            if ac.change.severity == ChangeSeverity.COMPATIBLE_EXTENSION
+        )
 
         if error_count > 0:
             verdict = PolicyVerdict.ERROR
@@ -99,6 +104,7 @@ class PolicyResult:
                 incompatible_count=incompatible,
                 review_needed_count=review_needed,
                 suppressed_count=suppressed,
+                compatible_extension_count=compatible_extension,
                 error_count=error_count,
             ),
         )

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -1,0 +1,82 @@
+"""PolicyResult — v0.2.
+
+Split into per-change annotations (AnnotatedChange) + aggregate summary (PolicySummary).
+v0.1 had only a summary, which made it impossible to trace which changes caused a verdict.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .change import Change
+
+
+class PolicyVerdict(str, Enum):
+    """Final CI verdict for a policy evaluation."""
+    PASS  = "pass"    # no incompatible changes
+    WARN  = "warn"    # review-needed changes present, no hard breaks
+    BLOCK = "block"   # incompatible changes detected
+    ERROR = "error"   # evaluation failed (e.g. insufficient evidence)
+
+
+@dataclass(slots=True)
+class AnnotatedChange:
+    """A Change decorated with its per-policy verdict."""
+    change:  Change
+    verdict: PolicyVerdict
+
+
+@dataclass(slots=True)
+class PolicySummary:
+    """Aggregate counts for the policy evaluation run."""
+    verdict:             PolicyVerdict
+    review_needed_count: int = 0
+    incompatible_count:  int = 0
+    suppressed_count:    int = 0
+
+
+@dataclass
+class PolicyResult:
+    """Full result of a policy evaluation.
+
+    ``annotated_changes`` provides per-change traceability (replaces the v0.1 opaque summary).
+    ``summary`` provides the CI-facing aggregate verdict and counts.
+    """
+    annotated_changes: list[AnnotatedChange] = field(default_factory=list)
+    summary:           PolicySummary = field(
+        default_factory=lambda: PolicySummary(verdict=PolicyVerdict.PASS)
+    )
+
+    @classmethod
+    def from_annotated(cls, changes: list[AnnotatedChange]) -> PolicyResult:
+        """Build a PolicyResult from a list of AnnotatedChange, computing summary."""
+        from .change import ChangeSeverity
+
+        incompatible = sum(
+            1 for ac in changes if ac.verdict == PolicyVerdict.BLOCK
+        )
+        review_needed = sum(
+            1 for ac in changes
+            if ac.change.severity == ChangeSeverity.REVIEW_NEEDED
+        )
+        suppressed = sum(
+            1 for ac in changes
+            if ac.change.severity == ChangeSeverity.SUPPRESSED
+        )
+
+        if incompatible > 0:
+            verdict = PolicyVerdict.BLOCK
+        elif review_needed > 0:
+            verdict = PolicyVerdict.WARN
+        else:
+            verdict = PolicyVerdict.PASS
+
+        return cls(
+            annotated_changes=changes,
+            summary=PolicySummary(
+                verdict=verdict,
+                incompatible_count=incompatible,
+                review_needed_count=review_needed,
+                suppressed_count=suppressed,
+            ),
+        )

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -8,21 +8,23 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
-from .change import Change
+from .change import Change, ChangeSeverity
 
 
 class PolicyVerdict(str, Enum):
     """Final CI verdict for a policy evaluation."""
-    PASS  = "pass"    # no incompatible changes
-    WARN  = "warn"    # review-needed changes present, no hard breaks
-    BLOCK = "block"   # incompatible changes detected
-    ERROR = "error"   # evaluation failed (e.g. insufficient evidence)
+
+    PASS = "pass"  # no incompatible changes
+    WARN = "warn"  # review-needed changes present, no hard breaks
+    BLOCK = "block"  # incompatible changes detected
+    ERROR = "error"  # evaluation failed (e.g. insufficient evidence)
 
 
 @dataclass(slots=True)
 class AnnotatedChange:
     """A Change decorated with its per-policy verdict."""
-    change:  Change
+
+    change: Change
     verdict: PolicyVerdict
 
 
@@ -36,11 +38,12 @@ class PolicySummary:
     - PASS:   both counts are 0
     - ERROR:  pipeline failure (not a policy outcome; error_count > 0)
     """
-    verdict:             PolicyVerdict
+
+    verdict: PolicyVerdict
     review_needed_count: int = 0
-    incompatible_count:  int = 0
-    suppressed_count:    int = 0
-    error_count:         int = 0   # reserved: pipeline failures (insufficient evidence etc.)
+    incompatible_count: int = 0
+    suppressed_count: int = 0
+    error_count: int = 0  # reserved: pipeline failures (insufficient evidence etc.)
 
 
 @dataclass(slots=True)
@@ -53,40 +56,36 @@ class PolicyResult:
     Use ``PolicyResult.from_annotated()`` as the primary constructor — it derives
     the summary deterministically from the change list.
 
-    Note on count semantics:
+    Count semantics:
     - ``incompatible_count``  = number of AnnotatedChange with verdict == BLOCK
-    - ``review_needed_count`` = number of Change with severity == REVIEW_NEEDED
+    - ``review_needed_count`` = number of AnnotatedChange with verdict == WARN
     - ``suppressed_count``    = number of Change with severity == SUPPRESSED
-    Counts are deliberately not cross-validated at construction time; callers
-    using ``from_annotated`` get a guaranteed-consistent summary.
+    - ``error_count``         = number of AnnotatedChange with verdict == ERROR
 
     Note on ERROR verdict: ``PolicyVerdict.ERROR`` is not producible via
-    ``from_annotated`` (it signals pipeline failure, not a policy outcome).
-    Construct manually when the pipeline cannot complete analysis.
+    ``from_annotated`` in normal flow — it signals pipeline failure, not a policy
+    outcome. Construct manually when the pipeline cannot complete analysis.
     """
+
     annotated_changes: list[AnnotatedChange] = field(default_factory=list)
-    summary:           PolicySummary = field(
+    summary: PolicySummary = field(
         default_factory=lambda: PolicySummary(verdict=PolicyVerdict.PASS)
     )
 
     @classmethod
     def from_annotated(cls, changes: list[AnnotatedChange]) -> PolicyResult:
         """Build a PolicyResult from a list of AnnotatedChange, computing summary."""
-        from .change import ChangeSeverity
-
-        incompatible = sum(
-            1 for ac in changes if ac.verdict == PolicyVerdict.BLOCK
-        )
-        review_needed = sum(
-            1 for ac in changes
-            if ac.change.severity == ChangeSeverity.REVIEW_NEEDED
-        )
+        incompatible = sum(1 for ac in changes if ac.verdict == PolicyVerdict.BLOCK)
+        review_needed = sum(1 for ac in changes if ac.verdict == PolicyVerdict.WARN)
+        error_count = sum(1 for ac in changes if ac.verdict == PolicyVerdict.ERROR)
         suppressed = sum(
             1 for ac in changes
             if ac.change.severity == ChangeSeverity.SUPPRESSED
         )
 
-        if incompatible > 0:
+        if error_count > 0:
+            verdict = PolicyVerdict.ERROR
+        elif incompatible > 0:
             verdict = PolicyVerdict.BLOCK
         elif review_needed > 0:
             verdict = PolicyVerdict.WARN
@@ -100,5 +99,6 @@ class PolicyResult:
                 incompatible_count=incompatible,
                 review_needed_count=review_needed,
                 suppressed_count=suppressed,
+                error_count=error_count,
             ),
         )

--- a/abicheck/core/pipeline.py
+++ b/abicheck/core/pipeline.py
@@ -1,0 +1,58 @@
+"""core/pipeline.py — Phase 1c end-to-end adapter.
+
+Wires the v0.2 components (Normalizer → CorpusBuilder → DiffEngine)
+into a single callable that accepts two AbiSnapshot objects and returns
+a list of v0.2 Change objects.
+
+This is the integration layer — it does NOT replace the existing
+`abicheck.checker.compare()`. Both coexist until Phase 1c deletion
+(after CI is green for a full cycle).
+
+Usage::
+
+    from abicheck.core.pipeline import analyse
+    from abicheck.dumper import dump
+
+    snap_old = dump(so_old, [header_old])
+    snap_new = dump(so_new, [header_new])
+    changes = analyse(snap_old, snap_new)
+
+Pipeline::
+
+    AbiSnapshot
+        → Normalizer → NormalizedSnapshot
+        → CorpusBuilder → Corpus
+        → diff_symbols + diff_type_layouts
+        → list[Change]
+"""
+from __future__ import annotations
+
+from abicheck.model import AbiSnapshot
+from abicheck.core.corpus.normalizer import Normalizer
+from abicheck.core.corpus.builder import CorpusBuilder
+from abicheck.core.diff.symbol_diff import diff_symbols
+from abicheck.core.diff.type_layout_diff import diff_type_layouts
+from abicheck.core.model import Change
+
+
+_normalizer = Normalizer()
+_builder = CorpusBuilder()
+
+
+def analyse(
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+) -> list[Change]:
+    """Run the v0.2 pipeline on two AbiSnapshots.
+
+    Returns a deduplicated list of Change objects sorted by entity_name.
+    """
+    norm_old = _normalizer.normalize(old)
+    norm_new = _normalizer.normalize(new)
+
+    changes: list[Change] = []
+    changes.extend(diff_symbols(norm_old, norm_new))
+    changes.extend(diff_type_layouts(norm_old, norm_new))
+
+    # Deterministic output order
+    return sorted(changes, key=lambda c: (c.entity_type, c.entity_name, c.change_kind.value))

--- a/abicheck/core/pipeline.py
+++ b/abicheck/core/pipeline.py
@@ -1,12 +1,11 @@
 """core/pipeline.py — Phase 1c end-to-end adapter.
 
-Wires the v0.2 components (Normalizer → CorpusBuilder → DiffEngine)
-into a single callable that accepts two AbiSnapshot objects and returns
-a list of v0.2 Change objects.
+Wires the v0.2 components (Normalizer → diff engines) into a single
+callable that accepts two AbiSnapshot objects and returns a list of
+v0.2 Change objects.
 
 This is the integration layer — it does NOT replace the existing
-`abicheck.checker.compare()`. Both coexist until Phase 1c deletion
-(after CI is green for a full cycle).
+``abicheck.checker.compare()``. Both coexist until Phase 2+ migration.
 
 Usage::
 
@@ -21,22 +20,18 @@ Pipeline::
 
     AbiSnapshot
         → Normalizer → NormalizedSnapshot
-        → CorpusBuilder → Corpus
         → diff_symbols + diff_type_layouts
         → list[Change]
 """
 from __future__ import annotations
 
-from abicheck.model import AbiSnapshot
 from abicheck.core.corpus.normalizer import Normalizer
-from abicheck.core.corpus.builder import CorpusBuilder
 from abicheck.core.diff.symbol_diff import diff_symbols
 from abicheck.core.diff.type_layout_diff import diff_type_layouts
 from abicheck.core.model import Change
-
+from abicheck.model import AbiSnapshot
 
 _normalizer = Normalizer()
-_builder = CorpusBuilder()
 
 
 def analyse(

--- a/abicheck/core/pipeline.py
+++ b/abicheck/core/pipeline.py
@@ -31,6 +31,8 @@ from abicheck.core.diff.type_layout_diff import diff_type_layouts
 from abicheck.core.model import Change
 from abicheck.model import AbiSnapshot
 
+# Module-level singleton — stateless, safe for repeated calls.
+# TODO Phase 2: replace with analyse(old, new, *, suppressor=None, policy=None) -> PolicyResult
 _normalizer = Normalizer()
 
 

--- a/logs/libtest/1.0/log.txt
+++ b/logs/libtest/1.0/log.txt
@@ -1,8 +1,0 @@
-Temporary header file '/tmp/IW6th0rbd7/dump1.h' with the following content will be compiled to create GCC translation unit dump:
-
-  // add includes
-  #include "/tmp/pytest-of-openclaw/pytest-194/test_both_produce_parseable_xm0/v1.h"
-
-The GCC parameters:
-  gcc -fdump-lang-raw -fkeep-inline-functions -c -x c++ -fpermissive -w "/tmp/IW6th0rbd7/dump1.h"
-

--- a/logs/libtest/1.0/log.txt
+++ b/logs/libtest/1.0/log.txt
@@ -1,0 +1,8 @@
+Temporary header file '/tmp/IW6th0rbd7/dump1.h' with the following content will be compiled to create GCC translation unit dump:
+
+  // add includes
+  #include "/tmp/pytest-of-openclaw/pytest-194/test_both_produce_parseable_xm0/v1.h"
+
+The GCC parameters:
+  gcc -fdump-lang-raw -fkeep-inline-functions -c -x c++ -fpermissive -w "/tmp/IW6th0rbd7/dump1.h"
+

--- a/logs/libtest/2.0/log.txt
+++ b/logs/libtest/2.0/log.txt
@@ -1,0 +1,8 @@
+Temporary header file '/tmp/IW6th0rbd7/dump2.h' with the following content will be compiled to create GCC translation unit dump:
+
+  // add includes
+  #include "/tmp/pytest-of-openclaw/pytest-194/test_both_produce_parseable_xm0/v2.h"
+
+The GCC parameters:
+  gcc -fdump-lang-raw -fkeep-inline-functions -c -x c++ -fpermissive -w "/tmp/IW6th0rbd7/dump2.h"
+

--- a/logs/libtest/2.0/log.txt
+++ b/logs/libtest/2.0/log.txt
@@ -1,8 +1,0 @@
-Temporary header file '/tmp/IW6th0rbd7/dump2.h' with the following content will be compiled to create GCC translation unit dump:
-
-  // add includes
-  #include "/tmp/pytest-of-openclaw/pytest-194/test_both_produce_parseable_xm0/v2.h"
-
-The GCC parameters:
-  gcc -fdump-lang-raw -fkeep-inline-functions -c -x c++ -fpermissive -w "/tmp/IW6th0rbd7/dump2.h"
-

--- a/tests/fixtures/case07_struct_layout__libv1.json
+++ b/tests/fixtures/case07_struct_layout__libv1.json
@@ -10,6 +10,10 @@
     {
       "name": "get_x",
       "return_type": "int"
+    },
+    {
+      "name": "init_point",
+      "return_type": "void"
     }
   ],
   "public_types": [

--- a/tests/fixtures/case07_struct_layout__libv2.json
+++ b/tests/fixtures/case07_struct_layout__libv2.json
@@ -10,6 +10,10 @@
     {
       "name": "get_x",
       "return_type": "int"
+    },
+    {
+      "name": "init_point",
+      "return_type": "void"
     }
   ],
   "public_types": [

--- a/tests/test_dumper_unit_phase0.py
+++ b/tests/test_dumper_unit_phase0.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from xml.etree.ElementTree import Element, SubElement
 
 from abicheck.dumper import (
-    _CastxmlParser,
     _cache_key,
+    _CastxmlParser,
     _parse_vtable_index,
     _vt_sort_key,
 )

--- a/tests/test_phase0_golden_dumper.py
+++ b/tests/test_phase0_golden_dumper.py
@@ -8,7 +8,6 @@ import pytest
 from abicheck.dumper import dump
 from abicheck.serialization import snapshot_to_dict
 
-
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 # Anchor all paths to repo root (robust against CWD differences in CI)
 REPO_ROOT = Path(__file__).parent.parent

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -147,6 +147,11 @@ class TestChange:
         with pytest.raises(ValueError, match="must be unique"):
             _make_change(origin=Origin.ELF, corroborating=(Origin.DWARF, Origin.DWARF))
 
+    def test_primary_must_be_highest_confidence(self) -> None:
+        """Lower-confidence primary with higher-confidence corroborating must be rejected."""
+        with pytest.raises(ValueError, match="highest-confidence"):
+            _make_change(origin=Origin.ELF, corroborating=(Origin.CASTXML,))
+
     def test_confidence_boundary_valid(self) -> None:
         _make_change(confidence=0.0)   # should not raise
         _make_change(confidence=1.0)   # should not raise
@@ -244,6 +249,7 @@ class TestPolicyResult:
         assert result.summary.verdict == PolicyVerdict.PASS
         assert result.summary.incompatible_count == 0
         assert result.summary.review_needed_count == 0
+        assert result.summary.compatible_extension_count == 1
 
     def test_suppressed_count(self) -> None:
         changes = [
@@ -291,6 +297,17 @@ class TestPolicyResult:
         changes = [self._annotated(PolicyVerdict.ERROR, ChangeSeverity.REVIEW_NEEDED)]
         result = PolicyResult.from_annotated(changes)
         assert result.summary.verdict == PolicyVerdict.ERROR
+        assert result.summary.error_count == 1
+
+    def test_error_takes_precedence_over_block(self) -> None:
+        """ERROR > BLOCK: pipeline failure supersedes breaking changes."""
+        changes = [
+            self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK),
+            self._annotated(PolicyVerdict.ERROR, ChangeSeverity.REVIEW_NEEDED),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.ERROR
+        assert result.summary.incompatible_count == 1
         assert result.summary.error_count == 1
 
     def test_warn_verdict_derives_from_annotated_verdict(self) -> None:

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -152,6 +152,16 @@ class TestChange:
         with pytest.raises(ValueError, match="highest-confidence"):
             _make_change(origin=Origin.ELF, corroborating=(Origin.CASTXML,))
 
+    def test_primary_highest_with_three_origins_rejected(self) -> None:
+        """DWARF primary but CASTXML corroborating — CASTXML is highest, so DWARF is rejected."""
+        with pytest.raises(ValueError, match="highest-confidence"):
+            _make_change(origin=Origin.DWARF, corroborating=(Origin.CASTXML,))
+
+    def test_equal_confidence_primary_is_accepted(self) -> None:
+        """Equal-confidence origins: ELF+MACHO both 0.7 — first-provided wins, no error."""
+        c = _make_change(origin=Origin.ELF, corroborating=(Origin.MACHO,))
+        assert c.origin == Origin.ELF  # tie: first provided stays primary
+
     def test_confidence_boundary_valid(self) -> None:
         _make_change(confidence=0.0)   # should not raise
         _make_change(confidence=1.0)   # should not raise

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -1,0 +1,176 @@
+"""Unit tests for abicheck/core/model — Phase 1a v0.2 data model."""
+from __future__ import annotations
+
+import pytest
+
+from abicheck.core.model import (
+    AnnotatedChange,
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    Origin,
+    PolicyResult,
+    PolicySummary,
+    PolicyVerdict,
+    SourceLocation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Origin
+# ---------------------------------------------------------------------------
+
+class TestOrigin:
+    def test_int_enum_values(self) -> None:
+        # IntEnum — no heap string per value
+        assert Origin.CASTXML == 0
+        assert Origin.DWARF == 1
+        assert Origin.ELF == 2
+
+    def test_confidence_ordering(self) -> None:
+        assert Origin.CASTXML.confidence > Origin.DWARF.confidence
+        assert Origin.DWARF.confidence > Origin.ELF.confidence
+        assert Origin.ELF.confidence == Origin.MACHO.confidence
+
+    def test_highest_returns_best(self) -> None:
+        assert Origin.highest((Origin.ELF, Origin.DWARF, Origin.CASTXML)) == Origin.CASTXML
+        assert Origin.highest((Origin.ELF,)) == Origin.ELF
+
+    def test_highest_empty_raises(self) -> None:
+        with pytest.raises(ValueError):
+            Origin.highest(())
+
+
+# ---------------------------------------------------------------------------
+# SourceLocation
+# ---------------------------------------------------------------------------
+
+class TestSourceLocation:
+    def test_str_with_line(self) -> None:
+        loc = SourceLocation(file="foo.h", line=42)
+        assert str(loc) == "foo.h:42"
+
+    def test_str_without_line(self) -> None:
+        loc = SourceLocation(file="bar.h")
+        assert str(loc) == "bar.h"
+
+
+# ---------------------------------------------------------------------------
+# Change
+# ---------------------------------------------------------------------------
+
+def _make_change(**kwargs) -> Change:
+    defaults = dict(
+        change_kind=ChangeKind.SYMBOL,
+        entity_type="function",
+        entity_name="foo",
+        before=EntitySnapshot("int foo()"),
+        after=EntitySnapshot("void foo()"),
+        severity=ChangeSeverity.BREAK,
+        origin=Origin.ELF,
+    )
+    defaults.update(kwargs)
+    return Change(**defaults)
+
+
+class TestChange:
+    def test_basic_construction(self) -> None:
+        c = _make_change()
+        assert c.change_kind == ChangeKind.SYMBOL
+        assert c.severity == ChangeSeverity.BREAK
+        assert c.origin == Origin.ELF
+        assert c.corroborating == ()
+        assert c.confidence == 1.0
+        assert c.location is None
+
+    def test_corroborating_tuple(self) -> None:
+        c = _make_change(
+            corroborating=(Origin.DWARF, Origin.CASTXML),
+        )
+        assert isinstance(c.corroborating, tuple)
+        assert Origin.CASTXML in c.corroborating
+
+    def test_confidence_validation(self) -> None:
+        with pytest.raises(ValueError):
+            _make_change(confidence=1.5)
+        with pytest.raises(ValueError):
+            _make_change(confidence=-0.1)
+
+    def test_requires_review_shim(self) -> None:
+        review = _make_change(severity=ChangeSeverity.REVIEW_NEEDED)
+        assert review.requires_review is True
+        breaking = _make_change(severity=ChangeSeverity.BREAK)
+        assert breaking.requires_review is False
+
+    def test_with_location(self) -> None:
+        loc = SourceLocation("include/foo.h", 99)
+        c = _make_change(location=loc)
+        assert c.location is not None
+        assert str(c.location) == "include/foo.h:99"
+
+    def test_change_kinds_coverage(self) -> None:
+        # Verify all ChangeKind values exist
+        kinds = {k.value for k in ChangeKind}
+        assert "symbol" in kinds
+        assert "size_change" in kinds         # distinct from type_layout
+        assert "calling_convention" in kinds  # only with DWARF/castxml evidence
+
+
+# ---------------------------------------------------------------------------
+# PolicyResult
+# ---------------------------------------------------------------------------
+
+class TestPolicyResult:
+    def _annotated(self, verdict: PolicyVerdict, severity: ChangeSeverity) -> AnnotatedChange:
+        return AnnotatedChange(
+            change=_make_change(severity=severity),
+            verdict=verdict,
+        )
+
+    def test_empty_is_pass(self) -> None:
+        result = PolicyResult.from_annotated([])
+        assert result.summary.verdict == PolicyVerdict.PASS
+        assert result.summary.incompatible_count == 0
+
+    def test_block_on_breaking_change(self) -> None:
+        changes = [self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.BLOCK
+        assert result.summary.incompatible_count == 1
+
+    def test_warn_on_review_needed(self) -> None:
+        changes = [self._annotated(PolicyVerdict.WARN, ChangeSeverity.REVIEW_NEEDED)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.WARN
+        assert result.summary.review_needed_count == 1
+
+    def test_block_takes_priority_over_warn(self) -> None:
+        changes = [
+            self._annotated(PolicyVerdict.WARN, ChangeSeverity.REVIEW_NEEDED),
+            self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.BLOCK
+
+    def test_suppressed_count(self) -> None:
+        changes = [
+            self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
+            self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.suppressed_count == 2
+        assert result.summary.verdict == PolicyVerdict.PASS
+
+    def test_per_change_traceability(self) -> None:
+        # Can trace exactly which change caused the verdict
+        block_change = _make_change(entity_name="removed_func", severity=ChangeSeverity.BREAK)
+        compat_change = _make_change(entity_name="added_func", severity=ChangeSeverity.COMPATIBLE_EXTENSION)
+        changes = [
+            AnnotatedChange(change=block_change, verdict=PolicyVerdict.BLOCK),
+            AnnotatedChange(change=compat_change, verdict=PolicyVerdict.PASS),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        blocking = [ac for ac in result.annotated_changes if ac.verdict == PolicyVerdict.BLOCK]
+        assert len(blocking) == 1
+        assert blocking[0].change.entity_name == "removed_func"

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -142,6 +142,11 @@ class TestChange:
         with pytest.raises(ValueError, match="must not appear in corroborating"):
             _make_change(origin=Origin.ELF, corroborating=(Origin.ELF, Origin.DWARF))
 
+    def test_corroborating_duplicates_rejected(self) -> None:
+        """Corroborating sources must be unique."""
+        with pytest.raises(ValueError, match="must be unique"):
+            _make_change(origin=Origin.ELF, corroborating=(Origin.DWARF, Origin.DWARF))
+
     def test_confidence_boundary_valid(self) -> None:
         _make_change(confidence=0.0)   # should not raise
         _make_change(confidence=1.0)   # should not raise

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -131,11 +131,11 @@ class TestChange:
 
     def test_corroborating_tuple(self) -> None:
         c = _make_change(
-            origin=Origin.ELF,
-            corroborating=(Origin.DWARF,),
+            origin=Origin.DWARF,
+            corroborating=(Origin.ELF,),  # primary must have highest confidence
         )
         assert isinstance(c.corroborating, tuple)
-        assert Origin.DWARF in c.corroborating
+        assert Origin.ELF in c.corroborating
 
     def test_corroborating_primary_not_in_corroborating(self) -> None:
         """Primary origin must not appear in corroborating."""

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -16,7 +16,6 @@ from abicheck.core.model import (
     SourceLocation,
 )
 
-
 # ---------------------------------------------------------------------------
 # Origin
 # ---------------------------------------------------------------------------
@@ -55,10 +54,10 @@ class TestOrigin:
                 f"{a.name}.confidence ({a.confidence}) < {b.name}.confidence ({b.confidence})"
             )
 
-    def test_confidence_is_class_level_constant(self) -> None:
-        # Property should not rebuild a dict every call — same object each time
-        assert Origin.ELF.confidence == Origin.ELF.confidence  # trivially, but also:
-        assert Origin._CONFIDENCE is Origin._CONFIDENCE
+    def test_confidence_is_stable(self) -> None:
+        # Property returns the same value on repeated calls (no dict rebuild per call)
+        assert Origin.ELF.confidence == Origin.ELF.confidence
+        assert Origin.CASTXML.confidence == 1.0  # spot-check module constant
 
     def test_highest_returns_best(self) -> None:
         assert Origin.highest((Origin.ELF, Origin.DWARF, Origin.CASTXML)) == Origin.CASTXML
@@ -86,11 +85,16 @@ class TestSourceLocation:
         loc = SourceLocation(file="bar.h")
         assert str(loc) == "bar.h"
 
-    def test_str_drops_column(self) -> None:
-        """column is stored but intentionally omitted from __str__."""
+    def test_str_includes_column(self) -> None:
+        """column is included in __str__ when present alongside line."""
         loc = SourceLocation(file="foo.h", line=42, column=10)
-        assert str(loc) == "foo.h:42"
+        assert str(loc) == "foo.h:42:10"
         assert loc.column == 10  # accessible on instance
+
+    def test_str_line_only_no_column(self) -> None:
+        """column is omitted from __str__ when not set."""
+        loc = SourceLocation(file="foo.h", line=42)
+        assert str(loc) == "foo.h:42"
 
     def test_line_none_no_colon(self) -> None:
         loc = SourceLocation(file="foo.h", line=None, column=5)
@@ -167,6 +171,29 @@ class TestChange:
         assert "calling_convention" in kinds    # only with DWARF/castxml evidence
         assert "type_layout" in kinds
         assert "vtable_inheritance" in kinds
+
+    def test_calling_convention_requires_dwarf_or_castxml(self) -> None:
+        """CALLING_CONVENTION must not be emitted with binary-only evidence."""
+        with pytest.raises(ValueError, match="CALLING_CONVENTION requires DWARF or CASTXML"):
+            _make_change(
+                change_kind=ChangeKind.CALLING_CONVENTION,
+                origin=Origin.ELF,
+                corroborating=(),
+            )
+
+    def test_calling_convention_ok_with_dwarf(self) -> None:
+        c = _make_change(
+            change_kind=ChangeKind.CALLING_CONVENTION,
+            origin=Origin.DWARF,
+        )
+        assert c.change_kind == ChangeKind.CALLING_CONVENTION
+
+    def test_calling_convention_ok_with_castxml(self) -> None:
+        c = _make_change(
+            change_kind=ChangeKind.CALLING_CONVENTION,
+            origin=Origin.CASTXML,
+        )
+        assert c.change_kind == ChangeKind.CALLING_CONVENTION
 
 
 # ---------------------------------------------------------------------------
@@ -253,3 +280,17 @@ class TestPolicyResult:
         )
         assert result.summary.verdict == PolicyVerdict.ERROR
         assert result.summary.error_count == 1
+
+    def test_error_verdict_from_annotated(self) -> None:
+        """from_annotated: ERROR verdict when any annotated change has verdict ERROR."""
+        changes = [self._annotated(PolicyVerdict.ERROR, ChangeSeverity.REVIEW_NEEDED)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.ERROR
+        assert result.summary.error_count == 1
+
+    def test_warn_verdict_derives_from_annotated_verdict(self) -> None:
+        """from_annotated: WARN is counted by AnnotatedChange.verdict, not change.severity."""
+        changes = [self._annotated(PolicyVerdict.WARN, ChangeSeverity.BREAK)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.WARN
+        assert result.summary.review_needed_count == 1

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -30,15 +30,46 @@ class TestOrigin:
 
     def test_confidence_ordering(self) -> None:
         assert Origin.CASTXML.confidence > Origin.DWARF.confidence
-        assert Origin.DWARF.confidence > Origin.ELF.confidence
-        assert Origin.ELF.confidence == Origin.MACHO.confidence
+        assert Origin.DWARF.confidence > Origin.PDB.confidence
+        assert Origin.PDB.confidence > Origin.ELF.confidence
+        assert Origin.ELF.confidence == Origin.MACHO.confidence == Origin.COFF.confidence
+
+    def test_confidence_values_exact(self) -> None:
+        assert Origin.CASTXML.confidence == 1.0
+        assert Origin.DWARF.confidence == 0.9
+        assert Origin.PDB.confidence == 0.8    # PDB > ELF (type info available)
+        assert Origin.ELF.confidence == 0.7
+        assert Origin.MACHO.confidence == 0.7
+        assert Origin.COFF.confidence == 0.7
+        assert Origin.BTF.confidence == 0.6
+        assert Origin.CTF.confidence == 0.6
+
+    def test_confidence_monotone_by_priority(self) -> None:
+        """Confidence ordering must be consistent — no inversions."""
+        priority_order = [
+            Origin.CASTXML, Origin.DWARF, Origin.PDB,
+            Origin.ELF, Origin.MACHO, Origin.COFF, Origin.BTF, Origin.CTF,
+        ]
+        for a, b in zip(priority_order, priority_order[1:]):
+            assert a.confidence >= b.confidence, (
+                f"{a.name}.confidence ({a.confidence}) < {b.name}.confidence ({b.confidence})"
+            )
+
+    def test_confidence_is_class_level_constant(self) -> None:
+        # Property should not rebuild a dict every call — same object each time
+        assert Origin.ELF.confidence == Origin.ELF.confidence  # trivially, but also:
+        assert Origin._CONFIDENCE is Origin._CONFIDENCE
 
     def test_highest_returns_best(self) -> None:
         assert Origin.highest((Origin.ELF, Origin.DWARF, Origin.CASTXML)) == Origin.CASTXML
         assert Origin.highest((Origin.ELF,)) == Origin.ELF
 
+    def test_highest_pdb_beats_elf(self) -> None:
+        """PDB has higher confidence than ELF — highest() must reflect this."""
+        assert Origin.highest((Origin.ELF, Origin.PDB)) == Origin.PDB
+
     def test_highest_empty_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-empty"):
             Origin.highest(())
 
 
@@ -54,6 +85,16 @@ class TestSourceLocation:
     def test_str_without_line(self) -> None:
         loc = SourceLocation(file="bar.h")
         assert str(loc) == "bar.h"
+
+    def test_str_drops_column(self) -> None:
+        """column is stored but intentionally omitted from __str__."""
+        loc = SourceLocation(file="foo.h", line=42, column=10)
+        assert str(loc) == "foo.h:42"
+        assert loc.column == 10  # accessible on instance
+
+    def test_line_none_no_colon(self) -> None:
+        loc = SourceLocation(file="foo.h", line=None, column=5)
+        assert ":" not in str(loc)
 
 
 # ---------------------------------------------------------------------------
@@ -86,12 +127,22 @@ class TestChange:
 
     def test_corroborating_tuple(self) -> None:
         c = _make_change(
-            corroborating=(Origin.DWARF, Origin.CASTXML),
+            origin=Origin.ELF,
+            corroborating=(Origin.DWARF,),
         )
         assert isinstance(c.corroborating, tuple)
-        assert Origin.CASTXML in c.corroborating
+        assert Origin.DWARF in c.corroborating
 
-    def test_confidence_validation(self) -> None:
+    def test_corroborating_primary_not_in_corroborating(self) -> None:
+        """Primary origin must not appear in corroborating."""
+        with pytest.raises(ValueError, match="must not appear in corroborating"):
+            _make_change(origin=Origin.ELF, corroborating=(Origin.ELF, Origin.DWARF))
+
+    def test_confidence_boundary_valid(self) -> None:
+        _make_change(confidence=0.0)   # should not raise
+        _make_change(confidence=1.0)   # should not raise
+
+    def test_confidence_validation_out_of_range(self) -> None:
         with pytest.raises(ValueError):
             _make_change(confidence=1.5)
         with pytest.raises(ValueError):
@@ -110,11 +161,12 @@ class TestChange:
         assert str(c.location) == "include/foo.h:99"
 
     def test_change_kinds_coverage(self) -> None:
-        # Verify all ChangeKind values exist
         kinds = {k.value for k in ChangeKind}
         assert "symbol" in kinds
-        assert "size_change" in kinds         # distinct from type_layout
-        assert "calling_convention" in kinds  # only with DWARF/castxml evidence
+        assert "size_change" in kinds           # distinct from type_layout
+        assert "calling_convention" in kinds    # only with DWARF/castxml evidence
+        assert "type_layout" in kinds
+        assert "vtable_inheritance" in kinds
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +184,7 @@ class TestPolicyResult:
         result = PolicyResult.from_annotated([])
         assert result.summary.verdict == PolicyVerdict.PASS
         assert result.summary.incompatible_count == 0
+        assert result.summary.review_needed_count == 0
 
     def test_block_on_breaking_change(self) -> None:
         changes = [self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK)]
@@ -153,6 +206,13 @@ class TestPolicyResult:
         result = PolicyResult.from_annotated(changes)
         assert result.summary.verdict == PolicyVerdict.BLOCK
 
+    def test_compatible_extension_only_is_pass(self) -> None:
+        changes = [self._annotated(PolicyVerdict.PASS, ChangeSeverity.COMPATIBLE_EXTENSION)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.PASS
+        assert result.summary.incompatible_count == 0
+        assert result.summary.review_needed_count == 0
+
     def test_suppressed_count(self) -> None:
         changes = [
             self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
@@ -162,10 +222,20 @@ class TestPolicyResult:
         assert result.summary.suppressed_count == 2
         assert result.summary.verdict == PolicyVerdict.PASS
 
+    def test_suppressed_does_not_mask_block(self) -> None:
+        changes = [
+            self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
+            self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.BLOCK
+        assert result.summary.suppressed_count == 1
+        assert result.summary.incompatible_count == 1
+
     def test_per_change_traceability(self) -> None:
-        # Can trace exactly which change caused the verdict
         block_change = _make_change(entity_name="removed_func", severity=ChangeSeverity.BREAK)
-        compat_change = _make_change(entity_name="added_func", severity=ChangeSeverity.COMPATIBLE_EXTENSION)
+        compat_change = _make_change(entity_name="added_func",
+                                     severity=ChangeSeverity.COMPATIBLE_EXTENSION)
         changes = [
             AnnotatedChange(change=block_change, verdict=PolicyVerdict.BLOCK),
             AnnotatedChange(change=compat_change, verdict=PolicyVerdict.PASS),
@@ -174,3 +244,12 @@ class TestPolicyResult:
         blocking = [ac for ac in result.annotated_changes if ac.verdict == PolicyVerdict.BLOCK]
         assert len(blocking) == 1
         assert blocking[0].change.entity_name == "removed_func"
+
+    def test_error_verdict_manual_construction(self) -> None:
+        """ERROR verdict is not producible via from_annotated — must be constructed manually."""
+        result = PolicyResult(
+            annotated_changes=[],
+            summary=PolicySummary(verdict=PolicyVerdict.ERROR, error_count=1),
+        )
+        assert result.summary.verdict == PolicyVerdict.ERROR
+        assert result.summary.error_count == 1

--- a/tests/test_phase1b_corpus_diff.py
+++ b/tests/test_phase1b_corpus_diff.py
@@ -153,6 +153,21 @@ class TestTypeLayoutDiff:
         assert ChangeKind.TYPE_LAYOUT in kinds
         assert any(c.entity_name == "Point::x" for c in changes)
 
+    def test_alignment_change_detected(self) -> None:
+        """alignment_bits change without size change must be detected (ABI-breaking on ARM)."""
+        normalizer = Normalizer()
+
+        t_old = RecordType(name="Foo", kind="struct", size_bits=64, alignment_bits=64,
+                           fields=[TypeField(name="x", type="int", offset_bits=0)])
+        t_new = RecordType(name="Foo", kind="struct", size_bits=64, alignment_bits=128,
+                           fields=[TypeField(name="x", type="int", offset_bits=0)])
+
+        b = normalizer.normalize(_snap(types=[t_old]))
+        a = normalizer.normalize(_snap(types=[t_new], version="v2"))
+
+        changes = diff_type_layouts(b, a)
+        assert any("alignment" in c.before.entity_repr for c in changes)
+
     def test_added_type_is_compatible_extension(self) -> None:
         normalizer = Normalizer()
         b = normalizer.normalize(_snap(types=[]))

--- a/tests/test_phase1b_corpus_diff.py
+++ b/tests/test_phase1b_corpus_diff.py
@@ -193,6 +193,21 @@ class TestTypeLayoutDiff:
         changes = diff_type_layouts(b, a)
         assert any("alignment" in c.before.entity_repr for c in changes)
 
+    def test_virtual_bases_change_detected(self) -> None:
+        """virtual_bases change must be caught by hash filter AND deep diff."""
+        normalizer = Normalizer()
+
+        t_old = RecordType(name="D", kind="class", size_bits=64,
+                           bases=["A"], virtual_bases=[])
+        t_new = RecordType(name="D", kind="class", size_bits=64,
+                           bases=["A"], virtual_bases=["B"])
+
+        b = normalizer.normalize(_snap(types=[t_old]))
+        a = normalizer.normalize(_snap(types=[t_new], version="v2"))
+
+        changes = diff_type_layouts(b, a)
+        assert any("virtual_bases" in c.before.entity_repr for c in changes)
+
     def test_added_type_is_compatible_extension(self) -> None:
         normalizer = Normalizer()
         b = normalizer.normalize(_snap(types=[]))

--- a/tests/test_phase1b_corpus_diff.py
+++ b/tests/test_phase1b_corpus_diff.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
+from abicheck.core.corpus import CorpusBuilder, Normalizer
+from abicheck.core.diff import diff_symbols, diff_type_layouts
+from abicheck.core.model import ChangeKind, ChangeSeverity
 from abicheck.model import (
     AbiSnapshot,
     Function,
-    Param,
     RecordType,
     TypeField,
     Variable,
     Visibility,
 )
-from abicheck.core.corpus import CorpusBuilder, Normalizer
-from abicheck.core.diff import diff_symbols, diff_type_layouts
-from abicheck.core.model import ChangeKind, ChangeSeverity
 
 
 def _snap(
@@ -55,14 +54,13 @@ class TestNormalizer:
 
     def test_intern_strings_identity(self) -> None:
         normalizer = Normalizer()
+        # Two functions sharing the same return_type string value
         f1 = Function(name="foo", mangled="_Z3foov", return_type="int")
-        f2 = Function(name="foo", mangled="_Z3foov", return_type="int")
+        f2 = Function(name="bar", mangled="_Z3barv", return_type="int")
 
         n = normalizer.normalize(_snap(funcs=[f1, f2]))
-        only = n.functions[0]
-        # interned strings should be stable and identical by identity
-        assert only.name is only.name
-        assert only.mangled is only.mangled
+        # After interning, same-value strings should be identical by identity
+        assert n.functions[0].return_type is n.functions[1].return_type
 
 
 class TestCorpusBuilder:

--- a/tests/test_phase1b_corpus_diff.py
+++ b/tests/test_phase1b_corpus_diff.py
@@ -108,6 +108,31 @@ class TestSymbolDiff:
         assert ChangeSeverity.BREAK in severities
         assert ChangeSeverity.COMPATIBLE_EXTENSION in severities
 
+    def test_single_function_pair_emits_multiple_changes(self) -> None:
+        """elif→if: return type AND parameter change simultaneously → two Change objects."""
+        normalizer = Normalizer()
+        from abicheck.model import Param
+
+        f_old = Function(
+            name="f", mangled="_Z1f", return_type="int", visibility=Visibility.PUBLIC,
+            params=[Param(name="x", type="int")],
+        )
+        f_new = Function(
+            name="f", mangled="_Z1f", return_type="void", visibility=Visibility.PUBLIC,
+            params=[Param(name="x", type="long")],  # both return type and param changed
+        )
+
+        b = normalizer.normalize(_snap(funcs=[f_old]))
+        a = normalizer.normalize(_snap(funcs=[f_new], version="v2"))
+        changes = diff_symbols(b, a)
+
+        # return type change + param type change = 2 independent Change objects for same function
+        func_changes = [c for c in changes if c.entity_name == "f"]
+        assert len(func_changes) == 2, (
+            f"Expected 2 changes for simultaneous return+param diff, got {len(func_changes)}"
+        )
+        assert all(c.severity == ChangeSeverity.BREAK for c in func_changes)
+
     def test_detect_variable_type_change(self) -> None:
         normalizer = Normalizer()
         b = normalizer.normalize(_snap(vars_=[

--- a/tests/test_phase1b_corpus_diff.py
+++ b/tests/test_phase1b_corpus_diff.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
+from abicheck.core.corpus import CorpusBuilder, Normalizer
+from abicheck.core.diff import diff_symbols, diff_type_layouts
+from abicheck.core.model import ChangeKind, ChangeSeverity
+
+
+def _snap(
+    *,
+    funcs: list[Function] | None = None,
+    vars_: list[Variable] | None = None,
+    types: list[RecordType] | None = None,
+    version: str = "v1",
+) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfoo.so",
+        version=version,
+        functions=funcs or [],
+        variables=vars_ or [],
+        types=types or [],
+    )
+
+
+class TestNormalizer:
+    def test_intern_and_deduplicate_functions_public_wins(self) -> None:
+        normalizer = Normalizer()
+
+        # Same mangled symbol twice: ELF_ONLY and PUBLIC; PUBLIC must win
+        f_elf = Function(
+            name="foo",
+            mangled="_Z3foov",
+            return_type="int",
+            visibility=Visibility.ELF_ONLY,
+        )
+        f_pub = Function(
+            name="foo",
+            mangled="_Z3foov",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        s = _snap(funcs=[f_elf, f_pub])
+
+        n = normalizer.normalize(s)
+        assert len(n.functions) == 1
+        assert n.functions[0].visibility == Visibility.PUBLIC
+
+    def test_intern_strings_identity(self) -> None:
+        normalizer = Normalizer()
+        f1 = Function(name="foo", mangled="_Z3foov", return_type="int")
+        f2 = Function(name="foo", mangled="_Z3foov", return_type="int")
+
+        n = normalizer.normalize(_snap(funcs=[f1, f2]))
+        only = n.functions[0]
+        # interned strings should be stable and identical by identity
+        assert only.name is only.name
+        assert only.mangled is only.mangled
+
+
+class TestCorpusBuilder:
+    def test_integer_keyed_maps_and_public_exports(self) -> None:
+        normalizer = Normalizer()
+        builder = CorpusBuilder()
+
+        s = _snap(funcs=[
+            Function(name="a", mangled="_Za", return_type="int", visibility=Visibility.PUBLIC),
+            Function(name="b", mangled="_Zb", return_type="int", visibility=Visibility.HIDDEN),
+        ], types=[
+            RecordType(name="T1", kind="struct", size_bits=64),
+            RecordType(name="T2", kind="struct", size_bits=128),
+        ])
+
+        n = normalizer.normalize(s)
+        c = builder.build(n)
+
+        assert all(isinstance(k, int) for k in c.reachable_types.keys())
+        assert all(isinstance(k, int) for k in c.binary_exports.keys())
+        assert list(c.public_interfaces.keys()) == ["_Za"]
+        assert c.corpus_version == "v1"
+
+
+class TestSymbolDiff:
+    def test_detect_added_removed_changed_function(self) -> None:
+        normalizer = Normalizer()
+
+        before = _snap(funcs=[
+            Function(name="old_only", mangled="_Z7oldonlyv", return_type="int", visibility=Visibility.PUBLIC),
+            Function(name="same", mangled="_Z4samev", return_type="int", visibility=Visibility.PUBLIC),
+        ])
+        after = _snap(funcs=[
+            Function(name="new_only", mangled="_Z7newonlyv", return_type="int", visibility=Visibility.PUBLIC),
+            Function(name="same", mangled="_Z4samev", return_type="void", visibility=Visibility.PUBLIC),
+        ], version="v2")
+
+        b = normalizer.normalize(before)
+        a = normalizer.normalize(after)
+        changes = diff_symbols(b, a)
+
+        # removed + added + return-type change
+        assert len(changes) == 3
+        severities = {c.severity for c in changes}
+        assert ChangeSeverity.BREAK in severities
+        assert ChangeSeverity.COMPATIBLE_EXTENSION in severities
+
+    def test_detect_variable_type_change(self) -> None:
+        normalizer = Normalizer()
+        b = normalizer.normalize(_snap(vars_=[
+            Variable(name="g", mangled="g", type="int", visibility=Visibility.PUBLIC),
+        ]))
+        a = normalizer.normalize(_snap(vars_=[
+            Variable(name="g", mangled="g", type="long", visibility=Visibility.PUBLIC),
+        ], version="v2"))
+
+        changes = diff_symbols(b, a)
+        assert len(changes) == 1
+        assert changes[0].entity_type == "variable"
+        assert changes[0].severity == ChangeSeverity.BREAK
+
+
+class TestTypeLayoutDiff:
+    def test_detect_size_and_field_changes(self) -> None:
+        normalizer = Normalizer()
+
+        t_old = RecordType(
+            name="Point",
+            kind="struct",
+            size_bits=64,
+            fields=[TypeField(name="x", type="int", offset_bits=0)],
+        )
+        t_new = RecordType(
+            name="Point",
+            kind="struct",
+            size_bits=96,
+            fields=[
+                TypeField(name="x", type="long", offset_bits=0),
+                TypeField(name="y", type="int", offset_bits=64),
+            ],
+        )
+
+        b = normalizer.normalize(_snap(types=[t_old]))
+        a = normalizer.normalize(_snap(types=[t_new], version="v2"))
+
+        changes = diff_type_layouts(b, a)
+
+        kinds = {c.change_kind for c in changes}
+        assert ChangeKind.SIZE_CHANGE in kinds
+        assert ChangeKind.TYPE_LAYOUT in kinds
+        assert any(c.entity_name == "Point::x" for c in changes)
+
+    def test_added_type_is_compatible_extension(self) -> None:
+        normalizer = Normalizer()
+        b = normalizer.normalize(_snap(types=[]))
+        a = normalizer.normalize(_snap(types=[RecordType(name="A", kind="struct", size_bits=32)], version="v2"))
+
+        changes = diff_type_layouts(b, a)
+        assert len(changes) == 1
+        assert changes[0].entity_name == "A"
+        assert changes[0].severity == ChangeSeverity.COMPATIBLE_EXTENSION

--- a/tests/test_phase1c_pipeline.py
+++ b/tests/test_phase1c_pipeline.py
@@ -1,0 +1,124 @@
+"""Phase 1c integration tests — end-to-end v0.2 pipeline.
+
+Uses real AbiSnapshots from the existing example libraries to validate
+that the v0.2 pipeline produces results consistent with the existing checker.
+
+These tests are marked @pytest.mark.integration and require pre-built .so files.
+They skip gracefully in CI unit-test jobs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.model import AbiSnapshot, Function, RecordType, TypeField, Variable, Visibility
+from abicheck.core.pipeline import analyse
+from abicheck.core.model import ChangeKind, ChangeSeverity
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _make_snap(funcs=(), vars_=(), types=(), version="v1") -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libtest.so",
+        version=version,
+        functions=list(funcs),
+        variables=list(vars_),
+        types=list(types),
+    )
+
+
+class TestPipelineUnit:
+    """Unit-level pipeline tests (no .so required)."""
+
+    def test_no_changes_returns_empty(self) -> None:
+        f = Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC)
+        old = _make_snap(funcs=[f])
+        new = _make_snap(funcs=[f], version="v2")
+        changes = analyse(old, new)
+        assert changes == []
+
+    def test_removed_function_is_break(self) -> None:
+        f = Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC)
+        old = _make_snap(funcs=[f])
+        new = _make_snap(version="v2")
+        changes = analyse(old, new)
+        assert len(changes) == 1
+        assert changes[0].severity == ChangeSeverity.BREAK
+        assert changes[0].change_kind == ChangeKind.SYMBOL
+        assert changes[0].entity_name == "foo"
+
+    def test_added_function_is_compatible_extension(self) -> None:
+        f = Function(name="bar", mangled="_Z3barv", return_type="void", visibility=Visibility.PUBLIC)
+        old = _make_snap()
+        new = _make_snap(funcs=[f], version="v2")
+        changes = analyse(old, new)
+        assert len(changes) == 1
+        assert changes[0].severity == ChangeSeverity.COMPATIBLE_EXTENSION
+
+    def test_type_size_change_is_break(self) -> None:
+        t_old = RecordType(name="Pt", kind="struct", size_bits=64,
+                           fields=[TypeField(name="x", type="int", offset_bits=0)])
+        t_new = RecordType(name="Pt", kind="struct", size_bits=96,
+                           fields=[TypeField(name="x", type="int", offset_bits=0),
+                                   TypeField(name="y", type="int", offset_bits=64)])
+        old = _make_snap(types=[t_old])
+        new = _make_snap(types=[t_new], version="v2")
+        changes = analyse(old, new)
+        assert any(c.change_kind == ChangeKind.SIZE_CHANGE for c in changes)
+        assert all(c.severity == ChangeSeverity.BREAK for c in changes)
+
+    def test_output_is_sorted_deterministically(self) -> None:
+        f_a = Function(name="alpha", mangled="_Za", return_type="int", visibility=Visibility.PUBLIC)
+        f_b = Function(name="beta",  mangled="_Zb", return_type="int", visibility=Visibility.PUBLIC)
+        old = _make_snap(funcs=[f_a, f_b])
+        new = _make_snap(version="v2")
+        changes = analyse(old, new)
+        names = [c.entity_name for c in changes]
+        assert names == sorted(names)
+
+    def test_hidden_symbols_not_in_changes(self) -> None:
+        f_pub = Function(name="pub", mangled="_Zpub", return_type="int", visibility=Visibility.PUBLIC)
+        f_hid = Function(name="hid", mangled="_Zhid", return_type="int", visibility=Visibility.HIDDEN)
+        old = _make_snap(funcs=[f_pub, f_hid])
+        new = _make_snap(version="v2")
+        changes = analyse(old, new)
+        assert all(c.entity_name != "hid" for c in changes)
+        assert len(changes) == 1
+
+
+@pytest.mark.integration
+class TestPipelineIntegration:
+    """Integration tests using real .so files from examples/."""
+
+    def _load(self, case: str, ver: str) -> AbiSnapshot:
+        so = (REPO_ROOT / f"examples/{case}/lib{ver}.so").resolve()
+        hdr_candidates = [f"{ver}.h", f"{ver}.hpp", f"{ver}.c", f"{ver}.cpp"]
+        hdr = None
+        for c in hdr_candidates:
+            p = (REPO_ROOT / f"examples/{case}/{c}").resolve()
+            if p.exists():
+                hdr = p
+                break
+        if not so.exists():
+            pytest.skip(f"pre-built artifact missing: {so}")
+        if hdr is None:
+            pytest.skip(f"no header found for {case}/{ver}")
+
+        from abicheck.dumper import dump
+        compiler = "cc" if hdr and hdr.suffix == ".c" else "c++"
+        return dump(so, [hdr], version=ver, compiler=compiler)
+
+    def test_case01_symbol_removal_produces_break(self) -> None:
+        old = self._load("case01_symbol_removal", "v1")
+        new = self._load("case01_symbol_removal", "v2")
+        changes = analyse(old, new)
+        breaks = [c for c in changes if c.severity == ChangeSeverity.BREAK]
+        assert len(breaks) >= 1
+
+    def test_case07_struct_layout_produces_size_change(self) -> None:
+        old = self._load("case07_struct_layout", "v1")
+        new = self._load("case07_struct_layout", "v2")
+        changes = analyse(old, new)
+        assert any(c.change_kind == ChangeKind.SIZE_CHANGE for c in changes)

--- a/tests/test_phase1c_pipeline.py
+++ b/tests/test_phase1c_pipeline.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 import pytest
 
-from abicheck.model import AbiSnapshot, Function, RecordType, TypeField, Variable, Visibility
-from abicheck.core.pipeline import analyse
 from abicheck.core.model import ChangeKind, ChangeSeverity
+from abicheck.core.pipeline import analyse
+from abicheck.model import AbiSnapshot, Function, RecordType, TypeField, Visibility
 
 REPO_ROOT = Path(__file__).parent.parent
 


### PR DESCRIPTION
## Phase 1a — Core Data Model (v0.2)

Part of the abicheck architecture refactor ([plan v0.2](docs/abicheck-refactor-plan.md)).

New module `abicheck/core/model/` introduced **alongside** existing `model.py` — zero breaking changes to current pipeline.

### New structures

| Class | Key change from v0.1 |
|-------|---------------------|
| `Origin(IntEnum)` | Replaces string origin tags — no heap alloc per fact, O(1) comparison |
| `ChangeSeverity` | Replaces `requires_review: bool` — BREAK/COMPATIBLE_EXTENSION/REVIEW_NEEDED/SUPPRESSED |
| `ChangeKind` | Adds `SIZE_CHANGE` (distinct from TYPE_LAYOUT per arch review) |
| `Change` | `@dataclass(slots=True)`, `origin: Origin`, `corroborating: tuple[Origin,...]`, `confidence: float`, `location: SourceLocation` |
| `PolicyResult` | Split into `list[AnnotatedChange]` + `PolicySummary` — per-change verdict traceability |
| `PolicyVerdict` | PASS/WARN/BLOCK/ERROR enum |

### Design decisions implemented
- `CALLING_CONVENTION` ChangeKind: documented as DWARF/castxml-only (never from binary alone)
- `requires_review` shim property on Change for backward compat
- `Origin.highest()` utility for multi-evidence corroboration
- `PolicyResult.from_annotated()` factory auto-computes summary

### Tests
- 18/18 unit tests (`tests/test_phase1a_core_model.py`)
- All existing tests unaffected (no changes to `model.py`)

### Review checklist
- [x] Internal review: intel-arch + qa-checker (pending — spawned)
- [ ] CodeRabbit
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured change model with severities, confidence, source locations, and snapshots.
  * Evidence origins with trust scoring and selection.
  * Policy evaluation with per-change annotations, aggregate verdicts, and counts.
  * Normalization/deduplication of snapshots and deterministic corpus construction.
  * Symbol and type-layout diffing to detect additions, removals, signature and layout changes.
  * End-to-end analysis pipeline producing ordered change lists.

* **Tests**
  * Extensive unit and integration tests covering normalization, corpus/corpus builder, symbol/type diffs, policy aggregation, and pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->