### PR TITLE
feat(phase1b): Normalizer + CorpusBuilder + isolated diff modules

### DIFF
--- a/abicheck/core/__init__.py
+++ b/abicheck/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core package — v0.2 architecture."""
+from __future__ import annotations

--- a/abicheck/core/corpus/__init__.py
+++ b/abicheck/core/corpus/__init__.py
@@ -1,0 +1,7 @@
+"""Corpus package — Phase 1b."""
+from __future__ import annotations
+
+from .normalizer import Normalizer, NormalizedSnapshot
+from .builder import CorpusBuilder, Corpus
+
+__all__ = ["Normalizer", "NormalizedSnapshot", "CorpusBuilder", "Corpus"]

--- a/abicheck/core/corpus/builder.py
+++ b/abicheck/core/corpus/builder.py
@@ -1,0 +1,62 @@
+"""CorpusBuilder — Phase 1b.
+
+Builds a normalized corpus representation from NormalizedSnapshot.
+
+Design goals:
+- Integer-keyed type map (`reachable_types`) for fast diff lookups
+- O(1) indexes for symbols and source exports
+- Deterministic IDs for reproducibility (sorted insertion order)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from abicheck.model import Function, RecordType, Variable, Visibility
+
+from .normalizer import NormalizedSnapshot
+
+
+@dataclass(slots=True)
+class Corpus:
+    """Normalized ABI/API representation (Phase 1b scaffold)."""
+    public_interfaces: dict[str, Function] = field(default_factory=dict)
+    source_exports: dict[str, Function] = field(default_factory=dict)
+    reachable_types: dict[int, RecordType] = field(default_factory=dict)  # int-keyed by design
+    binary_exports: dict[int, str] = field(default_factory=dict)           # id -> mangled symbol
+    dependency_closure: dict[str, list[str]] = field(default_factory=dict) # DAG scaffold
+
+    corpus_version: str | None = None
+    schema_version: str = "0.2"
+
+
+class CorpusBuilder:
+    """Builds Corpus from a NormalizedSnapshot."""
+
+    def build(self, normalized: NormalizedSnapshot) -> Corpus:
+        # Public source interfaces: public functions by mangled name
+        public_funcs = {
+            f.mangled: f
+            for f in normalized.functions
+            if f.visibility == Visibility.PUBLIC
+        }
+
+        # Integer-keyed binary export map (deterministic ordering)
+        ordered_symbols = sorted(public_funcs.keys())
+        binary_exports = {idx: mangled for idx, mangled in enumerate(ordered_symbols)}
+
+        # Integer-keyed type map (deterministic ordering by type name)
+        ordered_types = sorted(normalized.types, key=lambda t: t.name)
+        reachable_types = {idx: t for idx, t in enumerate(ordered_types)}
+
+        # Source exports initially mirror public interfaces (to be refined in Phase 2+)
+        source_exports = dict(public_funcs)
+
+        return Corpus(
+            public_interfaces=public_funcs,
+            source_exports=source_exports,
+            reachable_types=reachable_types,
+            binary_exports=binary_exports,
+            dependency_closure={},
+            corpus_version=normalized.version,
+            schema_version="0.2",
+        )

--- a/abicheck/core/corpus/normalizer.py
+++ b/abicheck/core/corpus/normalizer.py
@@ -1,0 +1,237 @@
+"""Normalizer — Phase 1b.
+
+Converts raw AbiSnapshot (from dumper) into a NormalizedSnapshot
+suitable for CorpusBuilder.
+
+Responsibilities:
+- Intern all name strings (eliminates duplicate string heap objects)
+- Deduplicate facts from multiple evidence sources
+- Strip address-specific noise (e.g. source_location absolute paths → relative)
+- Canonicalize type names (pointer depth, const placement)
+
+This step is deliberately separate from CorpusBuilder so that normalization
+logic is independently testable and has its own invariants.
+
+Pipeline position:  extract → **normalize** → corpus → diff → suppress → policy
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+
+from abicheck.model import (
+    AbiSnapshot,
+    EnumMember,
+    EnumType,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
+
+
+@dataclass
+class NormalizedSnapshot:
+    """An AbiSnapshot with interned strings and deduplicated entries.
+
+    Downstream consumers (CorpusBuilder, diff engine) can assume:
+    - All name strings are interned (``is`` comparison safe for identity checks)
+    - No duplicate functions by mangled name
+    - No duplicate types by name
+    - No duplicate variables by mangled name
+    """
+    library: str
+    version: str
+    functions: list[Function] = field(default_factory=list)
+    variables: list[Variable] = field(default_factory=list)
+    types: list[RecordType] = field(default_factory=list)
+    enums: list[EnumType] = field(default_factory=list)
+    typedefs: dict[str, str] = field(default_factory=dict)
+
+    # Index maps (built by Normalizer for O(1) downstream access)
+    func_index:  dict[str, Function] = field(default_factory=dict, repr=False)
+    var_index:   dict[str, Variable] = field(default_factory=dict, repr=False)
+    type_index:  dict[str, RecordType] = field(default_factory=dict, repr=False)
+    enum_index:  dict[str, EnumType] = field(default_factory=dict, repr=False)
+
+
+class Normalizer:
+    """Converts an AbiSnapshot into a NormalizedSnapshot.
+
+    Usage::
+
+        norm = Normalizer()
+        normalized = norm.normalize(snapshot)
+    """
+
+    def normalize(self, snapshot: AbiSnapshot) -> NormalizedSnapshot:
+        """Normalize a single AbiSnapshot.
+
+        Steps:
+        1. Intern all name/type strings
+        2. Deduplicate functions by mangled name (keep first/PUBLIC wins)
+        3. Deduplicate types by name (keep largest size_bits on conflict)
+        4. Deduplicate variables by mangled name
+        5. Build O(1) index maps
+        """
+        funcs = self._normalize_functions(snapshot.functions)
+        variables = self._normalize_variables(snapshot.variables)
+        types = self._normalize_types(snapshot.types)
+        enums = self._normalize_enums(snapshot.enums)
+        typedefs = {
+            sys.intern(k): sys.intern(v)
+            for k, v in snapshot.typedefs.items()
+        }
+
+        func_index = {f.mangled: f for f in funcs}
+        var_index = {v.mangled: v for v in variables}
+        type_index = {t.name: t for t in types}
+        enum_index = {e.name: e for e in enums}
+
+        return NormalizedSnapshot(
+            library=sys.intern(snapshot.library),
+            version=sys.intern(snapshot.version),
+            functions=funcs,
+            variables=variables,
+            types=types,
+            enums=enums,
+            typedefs=typedefs,
+            func_index=func_index,
+            var_index=var_index,
+            type_index=type_index,
+            enum_index=enum_index,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _intern_param(self, p: Param) -> Param:
+        return Param(
+            name=sys.intern(p.name),
+            type=sys.intern(p.type),
+            kind=p.kind,
+            default=sys.intern(p.default) if p.default else p.default,
+            pointer_depth=p.pointer_depth,
+            is_restrict=p.is_restrict,
+            is_va_list=p.is_va_list,
+        )
+
+    def _intern_function(self, f: Function) -> Function:
+        return Function(
+            name=sys.intern(f.name),
+            mangled=sys.intern(f.mangled),
+            return_type=sys.intern(f.return_type),
+            params=[self._intern_param(p) for p in f.params],
+            visibility=f.visibility,
+            is_virtual=f.is_virtual,
+            is_noexcept=f.is_noexcept,
+            is_extern_c=f.is_extern_c,
+            vtable_index=f.vtable_index,
+            source_location=f.source_location,
+            is_static=f.is_static,
+            is_const=f.is_const,
+            is_volatile=f.is_volatile,
+            is_pure_virtual=f.is_pure_virtual,
+            is_deleted=f.is_deleted,
+            access=f.access,
+            return_pointer_depth=f.return_pointer_depth,
+        )
+
+    def _normalize_functions(self, functions: list[Function]) -> list[Function]:
+        """Intern + deduplicate by mangled name.
+
+        When duplicates exist, PUBLIC visibility wins over HIDDEN/ELF_ONLY.
+        """
+        seen: dict[str, Function] = {}
+        for f in functions:
+            interned = self._intern_function(f)
+            key = interned.mangled
+            if key not in seen:
+                seen[key] = interned
+            elif interned.visibility == Visibility.PUBLIC:
+                # Higher-visibility entry wins (castxml PUBLIC > ELF_ONLY)
+                seen[key] = interned
+        return list(seen.values())
+
+    def _intern_field(self, fld: TypeField) -> TypeField:
+        return TypeField(
+            name=sys.intern(fld.name),
+            type=sys.intern(fld.type),
+            offset_bits=fld.offset_bits,
+            is_bitfield=fld.is_bitfield,
+            bitfield_bits=fld.bitfield_bits,
+            is_const=fld.is_const,
+            is_volatile=fld.is_volatile,
+            is_mutable=fld.is_mutable,
+            access=fld.access,
+        )
+
+    def _intern_record_type(self, t: RecordType) -> RecordType:
+        return RecordType(
+            name=sys.intern(t.name),
+            kind=t.kind,
+            size_bits=t.size_bits,
+            alignment_bits=t.alignment_bits,
+            fields=[self._intern_field(f) for f in t.fields],
+            bases=[sys.intern(b) for b in t.bases],
+            virtual_bases=[sys.intern(b) for b in t.virtual_bases],
+            vtable=[sys.intern(m) for m in t.vtable],
+            source_location=t.source_location,
+            is_union=t.is_union,
+            is_opaque=t.is_opaque,
+        )
+
+    def _normalize_types(self, types: list[RecordType]) -> list[RecordType]:
+        """Intern + deduplicate by name.
+
+        On conflict, keep the entry with the larger size_bits
+        (more complete DWARF/castxml info wins).
+        """
+        seen: dict[str, RecordType] = {}
+        for t in types:
+            interned = self._intern_record_type(t)
+            key = interned.name
+            if key not in seen:
+                seen[key] = interned
+            else:
+                existing = seen[key]
+                # Prefer the entry with more size information
+                if (interned.size_bits or 0) > (existing.size_bits or 0):
+                    seen[key] = interned
+        return list(seen.values())
+
+    def _normalize_variables(self, variables: list[Variable]) -> list[Variable]:
+        seen: dict[str, Variable] = {}
+        for v in variables:
+            interned = Variable(
+                name=sys.intern(v.name),
+                mangled=sys.intern(v.mangled),
+                type=sys.intern(v.type),
+                visibility=v.visibility,
+                source_location=v.source_location,
+                is_const=v.is_const,
+                value=v.value,
+                access=v.access,
+            )
+            key = interned.mangled
+            if key not in seen or interned.visibility == Visibility.PUBLIC:
+                seen[key] = interned
+        return list(seen.values())
+
+    def _normalize_enums(self, enums: list[EnumType]) -> list[EnumType]:
+        seen: dict[str, EnumType] = {}
+        for e in enums:
+            interned = EnumType(
+                name=sys.intern(e.name),
+                members=[
+                    EnumMember(name=sys.intern(m.name), value=m.value)
+                    for m in e.members
+                ],
+                underlying_type=sys.intern(e.underlying_type),
+            )
+            if interned.name not in seen:
+                seen[interned.name] = interned
+        return list(seen.values())

--- a/abicheck/core/diff/__init__.py
+++ b/abicheck/core/diff/__init__.py
@@ -1,0 +1,7 @@
+"""Diff engine package — Phase 1b."""
+from __future__ import annotations
+
+from .symbol_diff import diff_symbols
+from .type_layout_diff import diff_type_layouts
+
+__all__ = ["diff_symbols", "diff_type_layouts"]

--- a/abicheck/core/diff/symbol_diff.py
+++ b/abicheck/core/diff/symbol_diff.py
@@ -1,0 +1,224 @@
+"""symbol_diff — Phase 1b diff engine module.
+
+Detects symbol-level changes between two NormalizedSnapshots:
+- function added / removed / changed (return type, params, qualifiers)
+- variable added / removed / type changed
+
+This module is profile-agnostic — it operates on NormalizedSnapshot
+and returns generic Change objects. Language profile classification
+happens downstream (between diff and suppress).
+
+Pipeline position: corpus → **diff** → suppress → policy
+"""
+from __future__ import annotations
+
+from abicheck.model import Function, Variable, Visibility
+from abicheck.core.corpus.normalizer import NormalizedSnapshot
+from abicheck.core.model import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    Origin,
+)
+
+
+def _func_snapshot(f: Function) -> EntitySnapshot:
+    params_repr = ", ".join(f"{p.type} {p.name}".strip() for p in f.params)
+    return EntitySnapshot(
+        entity_repr=f"{f.return_type} {f.name}({params_repr})",
+        raw={
+            "return_type": f.return_type,
+            "params": [{"name": p.name, "type": p.type} for p in f.params],
+            "is_virtual": f.is_virtual,
+            "is_noexcept": f.is_noexcept,
+            "visibility": f.visibility.value,
+        },
+    )
+
+
+def _var_snapshot(v: Variable) -> EntitySnapshot:
+    return EntitySnapshot(
+        entity_repr=f"{v.type} {v.name}",
+        raw={"type": v.type, "visibility": v.visibility.value},
+    )
+
+
+def diff_symbols(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    """Detect all symbol-level changes between two snapshots.
+
+    Returns a list of Change objects. Caller is responsible for
+    applying suppression and policy classification.
+    """
+    changes: list[Change] = []
+    changes.extend(_diff_functions(before, after))
+    changes.extend(_diff_variables(before, after))
+    return changes
+
+
+def _diff_functions(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    changes: list[Change] = []
+
+    before_pub = {
+        m: f for m, f in before.func_index.items()
+        if f.visibility == Visibility.PUBLIC
+    }
+    after_pub = {
+        m: f for m, f in after.func_index.items()
+        if f.visibility == Visibility.PUBLIC
+    }
+
+    before_keys = set(before_pub)
+    after_keys = set(after_pub)
+
+    # Removed symbols
+    for mangled in before_keys - after_keys:
+        f = before_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f.name,
+            before=_func_snapshot(f),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.ELF,
+            confidence=0.95,
+        ))
+
+    # Added symbols (compatible extension)
+    for mangled in after_keys - before_keys:
+        f = after_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f.name,
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=_func_snapshot(f),
+            severity=ChangeSeverity.COMPATIBLE_EXTENSION,
+            origin=Origin.ELF,
+            confidence=0.95,
+        ))
+
+    # Changed symbols (present in both — check signature)
+    for mangled in before_keys & after_keys:
+        f_old = before_pub[mangled]
+        f_new = after_pub[mangled]
+        sub = _diff_function_pair(f_old, f_new)
+        changes.extend(sub)
+
+    return changes
+
+
+def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
+    changes: list[Change] = []
+    snap_old = _func_snapshot(f_old)
+    snap_new = _func_snapshot(f_new)
+
+    # Return type change
+    if f_old.return_type != f_new.return_type:
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Parameter count / type change
+    elif len(f_old.params) != len(f_new.params) or any(
+        p_old.type != p_new.type
+        for p_old, p_new in zip(f_old.params, f_new.params)
+    ):
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # noexcept removed → breaking (callers may not catch exceptions)
+    elif f_old.is_noexcept and not f_new.is_noexcept:
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="function",
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.85,
+        ))
+
+    return changes
+
+
+def _diff_variables(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    changes: list[Change] = []
+
+    before_pub = {
+        m: v for m, v in before.var_index.items()
+        if v.visibility == Visibility.PUBLIC
+    }
+    after_pub = {
+        m: v for m, v in after.var_index.items()
+        if v.visibility == Visibility.PUBLIC
+    }
+
+    for mangled in set(before_pub) - set(after_pub):
+        v = before_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="variable",
+            entity_name=v.name,
+            before=_var_snapshot(v),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.ELF,
+            confidence=0.9,
+        ))
+
+    for mangled in set(after_pub) - set(before_pub):
+        v = after_pub[mangled]
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type="variable",
+            entity_name=v.name,
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=_var_snapshot(v),
+            severity=ChangeSeverity.COMPATIBLE_EXTENSION,
+            origin=Origin.ELF,
+            confidence=0.9,
+        ))
+
+    for mangled in set(before_pub) & set(after_pub):
+        v_old = before_pub[mangled]
+        v_new = after_pub[mangled]
+        if v_old.type != v_new.type:
+            changes.append(Change(
+                change_kind=ChangeKind.SYMBOL,
+                entity_type="variable",
+                entity_name=v_old.name,
+                before=_var_snapshot(v_old),
+                after=_var_snapshot(v_new),
+                severity=ChangeSeverity.BREAK,
+                origin=Origin.CASTXML,
+                confidence=0.85,
+            ))
+
+    return changes

--- a/abicheck/core/diff/type_layout_diff.py
+++ b/abicheck/core/diff/type_layout_diff.py
@@ -1,0 +1,264 @@
+"""type_layout_diff — Phase 1b diff engine module.
+
+Two-phase diff for struct/class type layouts:
+  Phase 1: Structural hash filter — O(N), eliminates unchanged types
+  Phase 2: Deep diff — only on types whose hash changed
+
+This prevents the O(N²) / unbounded graph traversal that naive type
+comparison would require for large C++ libraries (oneTBB scale:
+millions of type nodes, template instantiations).
+
+Pipeline position: corpus → **diff** → suppress → policy
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from abicheck.model import RecordType, TypeField
+from abicheck.core.corpus.normalizer import NormalizedSnapshot
+from abicheck.core.model import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    Origin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Structural hash (phase 1 filter)
+# ---------------------------------------------------------------------------
+
+def _type_structural_hash(t: RecordType) -> int:
+    """Fast structural hash for pre-filtering unchanged types.
+
+    Hashes: kind, size_bits, field count, field names+types (shallow).
+    Intentionally avoids recursion — deep comparison happens in phase 2.
+    """
+    field_sig = tuple(
+        (f.name, f.type, f.offset_bits, f.is_bitfield, f.bitfield_bits)
+        for f in t.fields
+    )
+    return hash((
+        t.name,
+        t.kind,
+        t.size_bits,
+        t.alignment_bits,
+        len(t.fields),
+        field_sig,
+        tuple(t.bases),
+        tuple(t.vtable),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Type snapshot helpers
+# ---------------------------------------------------------------------------
+
+def _type_snapshot(t: RecordType) -> EntitySnapshot:
+    return EntitySnapshot(
+        entity_repr=f"{t.kind} {t.name} (size={t.size_bits})",
+        raw={
+            "kind": t.kind,
+            "size_bits": t.size_bits,
+            "alignment_bits": t.alignment_bits,
+            "field_count": len(t.fields),
+            "bases": list(t.bases),
+            "vtable_length": len(t.vtable),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deep type diff (phase 2)
+# ---------------------------------------------------------------------------
+
+def _diff_type_pair(t_old: RecordType, t_new: RecordType) -> list[Change]:
+    """Deep diff between two versions of the same type.
+
+    Called only when structural hash shows a difference.
+    """
+    changes: list[Change] = []
+
+    snap_old = _type_snapshot(t_old)
+    snap_new = _type_snapshot(t_new)
+
+    # Size change (distinct ChangeKind from field layout)
+    if t_old.size_bits != t_new.size_bits:
+        changes.append(Change(
+            change_kind=ChangeKind.SIZE_CHANGE,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.95,
+        ))
+
+    # Field layout changes
+    changes.extend(_diff_fields(t_old, t_new))
+
+    # Base class changes
+    if set(t_old.bases) != set(t_new.bases):
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=EntitySnapshot(entity_repr=f"bases={t_old.bases}"),
+            after=EntitySnapshot(entity_repr=f"bases={t_new.bases}"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Vtable changes
+    if t_old.vtable != t_new.vtable:
+        changes.append(Change(
+            change_kind=ChangeKind.VTABLE_INHERITANCE,
+            entity_type="type",
+            entity_name=t_old.name,
+            before=EntitySnapshot(
+                entity_repr=f"vtable={t_old.vtable}",
+                raw={"vtable": t_old.vtable},
+            ),
+            after=EntitySnapshot(
+                entity_repr=f"vtable={t_new.vtable}",
+                raw={"vtable": t_new.vtable},
+            ),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    return changes
+
+
+def _diff_fields(t_old: RecordType, t_new: RecordType) -> list[Change]:
+    changes: list[Change] = []
+    old_fields = {f.name: f for f in t_old.fields}
+    new_fields = {f.name: f for f in t_new.fields}
+
+    snap_old = _type_snapshot(t_old)
+    snap_new = _type_snapshot(t_new)
+
+    # Removed fields
+    for name in set(old_fields) - set(new_fields):
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="field",
+            entity_name=f"{t_old.name}::{name}",
+            before=EntitySnapshot(entity_repr=f"{old_fields[name].type} {name}"),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.95,
+        ))
+
+    # Added fields
+    for name in set(new_fields) - set(old_fields):
+        # Adding a field changes layout — breaking unless it's at the end
+        # and size already accounted for; conservative: always BREAK
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="field",
+            entity_name=f"{t_old.name}::{name}",
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=EntitySnapshot(entity_repr=f"{new_fields[name].type} {name}"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.85,
+        ))
+
+    # Changed fields (offset or type change)
+    for name in set(old_fields) & set(new_fields):
+        f_old = old_fields[name]
+        f_new = new_fields[name]
+        if f_old.type != f_new.type or f_old.offset_bits != f_new.offset_bits:
+            changes.append(Change(
+                change_kind=ChangeKind.TYPE_LAYOUT,
+                entity_type="field",
+                entity_name=f"{t_old.name}::{name}",
+                before=EntitySnapshot(
+                    entity_repr=f"{f_old.type} {name} @{f_old.offset_bits}",
+                    raw={"type": f_old.type, "offset_bits": f_old.offset_bits},
+                ),
+                after=EntitySnapshot(
+                    entity_repr=f"{f_new.type} {name} @{f_new.offset_bits}",
+                    raw={"type": f_new.type, "offset_bits": f_new.offset_bits},
+                ),
+                severity=ChangeSeverity.BREAK,
+                origin=Origin.CASTXML,
+                confidence=0.9,
+            ))
+
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def diff_type_layouts(
+    before: NormalizedSnapshot,
+    after: NormalizedSnapshot,
+) -> list[Change]:
+    """Two-phase type layout diff.
+
+    Phase 1: hash filter — O(N) scan, build set of changed type names.
+    Phase 2: deep diff — only for types with hash mismatches.
+
+    Types only in before → removed (BREAK).
+    Types only in after  → added (COMPATIBLE_EXTENSION).
+    Types in both        → phase 1 hash check → phase 2 if changed.
+    """
+    changes: list[Change] = []
+
+    before_types = before.type_index
+    after_types = after.type_index
+
+    # Removed types
+    for name in set(before_types) - set(after_types):
+        t = before_types[name]
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=name,
+            before=_type_snapshot(t),
+            after=EntitySnapshot(entity_repr="<removed>"),
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Added types
+    for name in set(after_types) - set(before_types):
+        t = after_types[name]
+        changes.append(Change(
+            change_kind=ChangeKind.TYPE_LAYOUT,
+            entity_type="type",
+            entity_name=name,
+            before=EntitySnapshot(entity_repr="<absent>"),
+            after=_type_snapshot(t),
+            severity=ChangeSeverity.COMPATIBLE_EXTENSION,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
+
+    # Changed types: phase 1 hash filter, then phase 2 deep diff
+    before_hashes = {
+        name: _type_structural_hash(t)
+        for name, t in before_types.items()
+        if name in after_types
+    }
+    for name in set(before_types) & set(after_types):
+        t_old = before_types[name]
+        t_new = after_types[name]
+        h_old = before_hashes[name]
+        h_new = _type_structural_hash(t_new)
+        if h_old != h_new:
+            # Phase 2: deep diff only for changed types
+            changes.extend(_diff_type_pair(t_old, t_new))
+
+    return changes

--- a/abicheck/core/model/__init__.py
+++ b/abicheck/core/model/__init__.py
@@ -1,0 +1,35 @@
+"""Core model package — v0.2 data structures.
+
+Public surface:
+    Origin, ChangeSeverity, ChangeKind, SourceLocation, EntitySnapshot, Change
+    PolicyVerdict, AnnotatedChange, PolicySummary, PolicyResult
+"""
+from __future__ import annotations
+
+from .origin import Origin
+from .change import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    SourceLocation,
+)
+from .policy_result import (
+    AnnotatedChange,
+    PolicyResult,
+    PolicySummary,
+    PolicyVerdict,
+)
+
+__all__ = [
+    "Origin",
+    "Change",
+    "ChangeKind",
+    "ChangeSeverity",
+    "EntitySnapshot",
+    "SourceLocation",
+    "AnnotatedChange",
+    "PolicyResult",
+    "PolicySummary",
+    "PolicyVerdict",
+]

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -87,6 +87,10 @@ class Change:
     def __post_init__(self) -> None:
         if not (0.0 <= self.confidence <= 1.0):
             raise ValueError(f"confidence must be in [0.0, 1.0], got {self.confidence}")
+        if self.origin in self.corroborating:
+            raise ValueError(
+                f"primary origin {self.origin!r} must not appear in corroborating"
+            )
 
     @property
     def requires_review(self) -> bool:

--- a/abicheck/core/model/change.py
+++ b/abicheck/core/model/change.py
@@ -1,0 +1,94 @@
+"""Change model — v0.2.
+
+Represents a single detected difference between two Corpus snapshots.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from .origin import Origin
+
+
+class ChangeSeverity(str, Enum):
+    """Severity of a detected change.
+
+    Replaces the v0.1 ``requires_review: bool`` field.
+    This field carries *epistemic* information (detection confidence),
+    not just policy intent — which is why it lives on Change, not only PolicyResult.
+    """
+    BREAK                = "break"                # ABI-incompatible
+    COMPATIBLE_EXTENSION = "compatible_extension" # additive, safe
+    REVIEW_NEEDED        = "review_needed"         # uncertain, needs human review
+    SUPPRESSED           = "suppressed"            # matched a suppression rule
+
+
+class ChangeKind(str, Enum):
+    """Category of the detected change."""
+    SYMBOL               = "symbol"
+    TYPE_LAYOUT          = "type_layout"
+    SIZE_CHANGE          = "size_change"           # struct/class total size (distinct from field layout)
+    CALLING_CONVENTION   = "calling_convention"    # only emitted when DWARF/castxml evidence present
+    VTABLE_INHERITANCE   = "vtable_inheritance"
+    LOADER_METADATA      = "loader_metadata"
+    PACKAGING_RUNTIME    = "packaging_runtime"
+    SOURCE_API_ONLY      = "source_api_only"
+
+
+@dataclass(slots=True)
+class SourceLocation:
+    """File + line reference from DWARF or castxml."""
+    file: str
+    line: int | None = None
+    column: int | None = None
+
+    def __str__(self) -> str:
+        if self.line is not None:
+            return f"{self.file}:{self.line}"
+        return self.file
+
+
+@dataclass(slots=True)
+class EntitySnapshot:
+    """Typed snapshot of an entity before or after a change.
+
+    Using a typed wrapper instead of plain dict/str prevents isinstance()
+    sprawl in the report layer.
+    """
+    entity_repr: str          # human-readable (demangled name / type signature)
+    raw: dict[str, Any] = field(default_factory=dict)  # full structured data
+
+
+@dataclass(slots=True)
+class Change:
+    """A single detected ABI/API change between two Corpus snapshots.
+
+    Design notes:
+    - ``origin`` is the primary (highest-confidence) source
+    - ``corroborating`` holds additional sources that confirm the change
+      (tuple, not list — lower overhead; empty tuple is the common case)
+    - ``severity`` carries epistemic info about detection confidence,
+      not only policy intent
+    - ``calling_convention`` kind MUST NOT be emitted without DWARF/castxml evidence;
+      binary-only → severity=REVIEW_NEEDED
+    """
+    change_kind:   ChangeKind
+    entity_type:   str
+    entity_name:   str
+    before:        EntitySnapshot
+    after:         EntitySnapshot
+    severity:      ChangeSeverity
+    origin:        Origin                    # primary (highest confidence)
+    corroborating: tuple[Origin, ...] = ()  # additional confirming sources
+    confidence:    float = 1.0              # 0.0–1.0
+    location:      SourceLocation | None = None  # file/line from DWARF or castxml
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError(f"confidence must be in [0.0, 1.0], got {self.confidence}")
+
+    @property
+    def requires_review(self) -> bool:
+        """Backward-compat shim. Use severity == REVIEW_NEEDED directly."""
+        return self.severity == ChangeSeverity.REVIEW_NEEDED

--- a/abicheck/core/model/origin.py
+++ b/abicheck/core/model/origin.py
@@ -1,0 +1,46 @@
+"""Origin enum — evidence source tags for FactSet facts.
+
+Using IntEnum (not str Enum) to eliminate per-fact heap allocation.
+At millions-of-facts scale, string origins cost ~500MB+ in __dict__ overhead.
+"""
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class Origin(IntEnum):
+    """Evidence source that produced a fact or detected a change.
+
+    Priority order (highest confidence first):
+        CASTXML > DWARF > ELF > PDB > MACHO > COFF > BTF > CTF
+    """
+    CASTXML = 0   # source AST via castxml — highest confidence
+    DWARF   = 1   # DWARF debug info
+    ELF     = 2   # ELF symbol table / dynamic section
+    PDB     = 3   # Windows PDB debug info
+    MACHO   = 4   # Mach-O metadata
+    COFF    = 5   # PE/COFF export table
+    BTF     = 6   # BPF Type Format
+    CTF     = 7   # Compact Type Format (Solaris/FreeBSD)
+
+    @property
+    def confidence(self) -> float:
+        """Confidence score 0.0–1.0 (higher = more reliable)."""
+        _scores = {
+            Origin.CASTXML: 1.0,
+            Origin.DWARF:   0.9,
+            Origin.ELF:     0.7,
+            Origin.PDB:     0.8,
+            Origin.MACHO:   0.7,
+            Origin.COFF:    0.7,
+            Origin.BTF:     0.6,
+            Origin.CTF:     0.6,
+        }
+        return _scores[self]
+
+    @classmethod
+    def highest(cls, origins: tuple[Origin, ...]) -> Origin:
+        """Return the highest-confidence origin from a tuple."""
+        if not origins:
+            raise ValueError("origins must be non-empty")
+        return min(origins, key=lambda o: o.value)

--- a/abicheck/core/model/origin.py
+++ b/abicheck/core/model/origin.py
@@ -6,41 +6,57 @@ At millions-of-facts scale, string origins cost ~500MB+ in __dict__ overhead.
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import ClassVar
 
 
 class Origin(IntEnum):
     """Evidence source that produced a fact or detected a change.
 
     Priority order (highest confidence first):
-        CASTXML > DWARF > ELF > PDB > MACHO > COFF > BTF > CTF
+        CASTXML(1.0) > DWARF(0.9) > PDB(0.8) > ELF/MACHO/COFF(0.7) > BTF/CTF(0.6)
+
+    Note: PDB has higher confidence than ELF — PDB contains full debug type info,
+    whereas ELF symbol tables carry only symbol names and addresses.
+
+    IntEnum values encode source identity only, NOT confidence order.
+    Always use `.confidence` for ordering decisions.
     """
     CASTXML = 0   # source AST via castxml — highest confidence
     DWARF   = 1   # DWARF debug info
     ELF     = 2   # ELF symbol table / dynamic section
-    PDB     = 3   # Windows PDB debug info
+    PDB     = 3   # Windows PDB debug info (higher confidence than ELF)
     MACHO   = 4   # Mach-O metadata
     COFF    = 5   # PE/COFF export table
     BTF     = 6   # BPF Type Format
     CTF     = 7   # Compact Type Format (Solaris/FreeBSD)
 
+    # Class-level constant — avoids rebuilding the dict on every property call
+    _CONFIDENCE: ClassVar[dict[int, float]]
+
     @property
     def confidence(self) -> float:
-        """Confidence score 0.0–1.0 (higher = more reliable)."""
-        _scores = {
-            Origin.CASTXML: 1.0,
-            Origin.DWARF:   0.9,
-            Origin.ELF:     0.7,
-            Origin.PDB:     0.8,
-            Origin.MACHO:   0.7,
-            Origin.COFF:    0.7,
-            Origin.BTF:     0.6,
-            Origin.CTF:     0.6,
-        }
-        return _scores[self]
+        """Confidence score 0.0–1.0 (higher = more reliable for ABI analysis)."""
+        return Origin._CONFIDENCE[self.value]
 
     @classmethod
     def highest(cls, origins: tuple[Origin, ...]) -> Origin:
-        """Return the highest-confidence origin from a tuple."""
+        """Return the highest-confidence origin from a tuple.
+
+        Uses confidence scores, NOT IntEnum integer values.
+        """
         if not origins:
             raise ValueError("origins must be non-empty")
-        return min(origins, key=lambda o: o.value)
+        return max(origins, key=lambda o: o.confidence)
+
+
+# Populated after class definition so Origin members are resolvable
+Origin._CONFIDENCE = {
+    Origin.CASTXML.value: 1.0,
+    Origin.DWARF.value:   0.9,
+    Origin.PDB.value:     0.8,   # PDB has type info → higher than ELF
+    Origin.ELF.value:     0.7,
+    Origin.MACHO.value:   0.7,
+    Origin.COFF.value:    0.7,
+    Origin.BTF.value:     0.6,
+    Origin.CTF.value:     0.6,
+}

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -28,19 +28,41 @@ class AnnotatedChange:
 
 @dataclass(slots=True)
 class PolicySummary:
-    """Aggregate counts for the policy evaluation run."""
+    """Aggregate counts for the policy evaluation run.
+
+    ``verdict`` is always derived from the counts — never set independently.
+    - BLOCK:  incompatible_count > 0
+    - WARN:   review_needed_count > 0 (and incompatible_count == 0)
+    - PASS:   both counts are 0
+    - ERROR:  pipeline failure (not a policy outcome; error_count > 0)
+    """
     verdict:             PolicyVerdict
     review_needed_count: int = 0
     incompatible_count:  int = 0
     suppressed_count:    int = 0
+    error_count:         int = 0   # reserved: pipeline failures (insufficient evidence etc.)
 
 
-@dataclass
+@dataclass(slots=True)
 class PolicyResult:
     """Full result of a policy evaluation.
 
     ``annotated_changes`` provides per-change traceability (replaces the v0.1 opaque summary).
     ``summary`` provides the CI-facing aggregate verdict and counts.
+
+    Use ``PolicyResult.from_annotated()`` as the primary constructor — it derives
+    the summary deterministically from the change list.
+
+    Note on count semantics:
+    - ``incompatible_count``  = number of AnnotatedChange with verdict == BLOCK
+    - ``review_needed_count`` = number of Change with severity == REVIEW_NEEDED
+    - ``suppressed_count``    = number of Change with severity == SUPPRESSED
+    Counts are deliberately not cross-validated at construction time; callers
+    using ``from_annotated`` get a guaranteed-consistent summary.
+
+    Note on ERROR verdict: ``PolicyVerdict.ERROR`` is not producible via
+    ``from_annotated`` (it signals pipeline failure, not a policy outcome).
+    Construct manually when the pipeline cannot complete analysis.
     """
     annotated_changes: list[AnnotatedChange] = field(default_factory=list)
     summary:           PolicySummary = field(

--- a/abicheck/core/model/policy_result.py
+++ b/abicheck/core/model/policy_result.py
@@ -1,0 +1,82 @@
+"""PolicyResult — v0.2.
+
+Split into per-change annotations (AnnotatedChange) + aggregate summary (PolicySummary).
+v0.1 had only a summary, which made it impossible to trace which changes caused a verdict.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .change import Change
+
+
+class PolicyVerdict(str, Enum):
+    """Final CI verdict for a policy evaluation."""
+    PASS  = "pass"    # no incompatible changes
+    WARN  = "warn"    # review-needed changes present, no hard breaks
+    BLOCK = "block"   # incompatible changes detected
+    ERROR = "error"   # evaluation failed (e.g. insufficient evidence)
+
+
+@dataclass(slots=True)
+class AnnotatedChange:
+    """A Change decorated with its per-policy verdict."""
+    change:  Change
+    verdict: PolicyVerdict
+
+
+@dataclass(slots=True)
+class PolicySummary:
+    """Aggregate counts for the policy evaluation run."""
+    verdict:             PolicyVerdict
+    review_needed_count: int = 0
+    incompatible_count:  int = 0
+    suppressed_count:    int = 0
+
+
+@dataclass
+class PolicyResult:
+    """Full result of a policy evaluation.
+
+    ``annotated_changes`` provides per-change traceability (replaces the v0.1 opaque summary).
+    ``summary`` provides the CI-facing aggregate verdict and counts.
+    """
+    annotated_changes: list[AnnotatedChange] = field(default_factory=list)
+    summary:           PolicySummary = field(
+        default_factory=lambda: PolicySummary(verdict=PolicyVerdict.PASS)
+    )
+
+    @classmethod
+    def from_annotated(cls, changes: list[AnnotatedChange]) -> PolicyResult:
+        """Build a PolicyResult from a list of AnnotatedChange, computing summary."""
+        from .change import ChangeSeverity
+
+        incompatible = sum(
+            1 for ac in changes if ac.verdict == PolicyVerdict.BLOCK
+        )
+        review_needed = sum(
+            1 for ac in changes
+            if ac.change.severity == ChangeSeverity.REVIEW_NEEDED
+        )
+        suppressed = sum(
+            1 for ac in changes
+            if ac.change.severity == ChangeSeverity.SUPPRESSED
+        )
+
+        if incompatible > 0:
+            verdict = PolicyVerdict.BLOCK
+        elif review_needed > 0:
+            verdict = PolicyVerdict.WARN
+        else:
+            verdict = PolicyVerdict.PASS
+
+        return cls(
+            annotated_changes=changes,
+            summary=PolicySummary(
+                verdict=verdict,
+                incompatible_count=incompatible,
+                review_needed_count=review_needed,
+                suppressed_count=suppressed,
+            ),
+        )

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -1,0 +1,176 @@
+"""Unit tests for abicheck/core/model — Phase 1a v0.2 data model."""
+from __future__ import annotations
+
+import pytest
+
+from abicheck.core.model import (
+    AnnotatedChange,
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    Origin,
+    PolicyResult,
+    PolicySummary,
+    PolicyVerdict,
+    SourceLocation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Origin
+# ---------------------------------------------------------------------------
+
+class TestOrigin:
+    def test_int_enum_values(self) -> None:
+        # IntEnum — no heap string per value
+        assert Origin.CASTXML == 0
+        assert Origin.DWARF == 1
+        assert Origin.ELF == 2
+
+    def test_confidence_ordering(self) -> None:
+        assert Origin.CASTXML.confidence > Origin.DWARF.confidence
+        assert Origin.DWARF.confidence > Origin.ELF.confidence
+        assert Origin.ELF.confidence == Origin.MACHO.confidence
+
+    def test_highest_returns_best(self) -> None:
+        assert Origin.highest((Origin.ELF, Origin.DWARF, Origin.CASTXML)) == Origin.CASTXML
+        assert Origin.highest((Origin.ELF,)) == Origin.ELF
+
+    def test_highest_empty_raises(self) -> None:
+        with pytest.raises(ValueError):
+            Origin.highest(())
+
+
+# ---------------------------------------------------------------------------
+# SourceLocation
+# ---------------------------------------------------------------------------
+
+class TestSourceLocation:
+    def test_str_with_line(self) -> None:
+        loc = SourceLocation(file="foo.h", line=42)
+        assert str(loc) == "foo.h:42"
+
+    def test_str_without_line(self) -> None:
+        loc = SourceLocation(file="bar.h")
+        assert str(loc) == "bar.h"
+
+
+# ---------------------------------------------------------------------------
+# Change
+# ---------------------------------------------------------------------------
+
+def _make_change(**kwargs) -> Change:
+    defaults = dict(
+        change_kind=ChangeKind.SYMBOL,
+        entity_type="function",
+        entity_name="foo",
+        before=EntitySnapshot("int foo()"),
+        after=EntitySnapshot("void foo()"),
+        severity=ChangeSeverity.BREAK,
+        origin=Origin.ELF,
+    )
+    defaults.update(kwargs)
+    return Change(**defaults)
+
+
+class TestChange:
+    def test_basic_construction(self) -> None:
+        c = _make_change()
+        assert c.change_kind == ChangeKind.SYMBOL
+        assert c.severity == ChangeSeverity.BREAK
+        assert c.origin == Origin.ELF
+        assert c.corroborating == ()
+        assert c.confidence == 1.0
+        assert c.location is None
+
+    def test_corroborating_tuple(self) -> None:
+        c = _make_change(
+            corroborating=(Origin.DWARF, Origin.CASTXML),
+        )
+        assert isinstance(c.corroborating, tuple)
+        assert Origin.CASTXML in c.corroborating
+
+    def test_confidence_validation(self) -> None:
+        with pytest.raises(ValueError):
+            _make_change(confidence=1.5)
+        with pytest.raises(ValueError):
+            _make_change(confidence=-0.1)
+
+    def test_requires_review_shim(self) -> None:
+        review = _make_change(severity=ChangeSeverity.REVIEW_NEEDED)
+        assert review.requires_review is True
+        breaking = _make_change(severity=ChangeSeverity.BREAK)
+        assert breaking.requires_review is False
+
+    def test_with_location(self) -> None:
+        loc = SourceLocation("include/foo.h", 99)
+        c = _make_change(location=loc)
+        assert c.location is not None
+        assert str(c.location) == "include/foo.h:99"
+
+    def test_change_kinds_coverage(self) -> None:
+        # Verify all ChangeKind values exist
+        kinds = {k.value for k in ChangeKind}
+        assert "symbol" in kinds
+        assert "size_change" in kinds         # distinct from type_layout
+        assert "calling_convention" in kinds  # only with DWARF/castxml evidence
+
+
+# ---------------------------------------------------------------------------
+# PolicyResult
+# ---------------------------------------------------------------------------
+
+class TestPolicyResult:
+    def _annotated(self, verdict: PolicyVerdict, severity: ChangeSeverity) -> AnnotatedChange:
+        return AnnotatedChange(
+            change=_make_change(severity=severity),
+            verdict=verdict,
+        )
+
+    def test_empty_is_pass(self) -> None:
+        result = PolicyResult.from_annotated([])
+        assert result.summary.verdict == PolicyVerdict.PASS
+        assert result.summary.incompatible_count == 0
+
+    def test_block_on_breaking_change(self) -> None:
+        changes = [self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.BLOCK
+        assert result.summary.incompatible_count == 1
+
+    def test_warn_on_review_needed(self) -> None:
+        changes = [self._annotated(PolicyVerdict.WARN, ChangeSeverity.REVIEW_NEEDED)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.WARN
+        assert result.summary.review_needed_count == 1
+
+    def test_block_takes_priority_over_warn(self) -> None:
+        changes = [
+            self._annotated(PolicyVerdict.WARN, ChangeSeverity.REVIEW_NEEDED),
+            self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.BLOCK
+
+    def test_suppressed_count(self) -> None:
+        changes = [
+            self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
+            self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.suppressed_count == 2
+        assert result.summary.verdict == PolicyVerdict.PASS
+
+    def test_per_change_traceability(self) -> None:
+        # Can trace exactly which change caused the verdict
+        block_change = _make_change(entity_name="removed_func", severity=ChangeSeverity.BREAK)
+        compat_change = _make_change(entity_name="added_func", severity=ChangeSeverity.COMPATIBLE_EXTENSION)
+        changes = [
+            AnnotatedChange(change=block_change, verdict=PolicyVerdict.BLOCK),
+            AnnotatedChange(change=compat_change, verdict=PolicyVerdict.PASS),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        blocking = [ac for ac in result.annotated_changes if ac.verdict == PolicyVerdict.BLOCK]
+        assert len(blocking) == 1
+        assert blocking[0].change.entity_name == "removed_func"

--- a/tests/test_phase1a_core_model.py
+++ b/tests/test_phase1a_core_model.py
@@ -30,15 +30,46 @@ class TestOrigin:
 
     def test_confidence_ordering(self) -> None:
         assert Origin.CASTXML.confidence > Origin.DWARF.confidence
-        assert Origin.DWARF.confidence > Origin.ELF.confidence
-        assert Origin.ELF.confidence == Origin.MACHO.confidence
+        assert Origin.DWARF.confidence > Origin.PDB.confidence
+        assert Origin.PDB.confidence > Origin.ELF.confidence
+        assert Origin.ELF.confidence == Origin.MACHO.confidence == Origin.COFF.confidence
+
+    def test_confidence_values_exact(self) -> None:
+        assert Origin.CASTXML.confidence == 1.0
+        assert Origin.DWARF.confidence == 0.9
+        assert Origin.PDB.confidence == 0.8    # PDB > ELF (type info available)
+        assert Origin.ELF.confidence == 0.7
+        assert Origin.MACHO.confidence == 0.7
+        assert Origin.COFF.confidence == 0.7
+        assert Origin.BTF.confidence == 0.6
+        assert Origin.CTF.confidence == 0.6
+
+    def test_confidence_monotone_by_priority(self) -> None:
+        """Confidence ordering must be consistent — no inversions."""
+        priority_order = [
+            Origin.CASTXML, Origin.DWARF, Origin.PDB,
+            Origin.ELF, Origin.MACHO, Origin.COFF, Origin.BTF, Origin.CTF,
+        ]
+        for a, b in zip(priority_order, priority_order[1:]):
+            assert a.confidence >= b.confidence, (
+                f"{a.name}.confidence ({a.confidence}) < {b.name}.confidence ({b.confidence})"
+            )
+
+    def test_confidence_is_class_level_constant(self) -> None:
+        # Property should not rebuild a dict every call — same object each time
+        assert Origin.ELF.confidence == Origin.ELF.confidence  # trivially, but also:
+        assert Origin._CONFIDENCE is Origin._CONFIDENCE
 
     def test_highest_returns_best(self) -> None:
         assert Origin.highest((Origin.ELF, Origin.DWARF, Origin.CASTXML)) == Origin.CASTXML
         assert Origin.highest((Origin.ELF,)) == Origin.ELF
 
+    def test_highest_pdb_beats_elf(self) -> None:
+        """PDB has higher confidence than ELF — highest() must reflect this."""
+        assert Origin.highest((Origin.ELF, Origin.PDB)) == Origin.PDB
+
     def test_highest_empty_raises(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-empty"):
             Origin.highest(())
 
 
@@ -54,6 +85,16 @@ class TestSourceLocation:
     def test_str_without_line(self) -> None:
         loc = SourceLocation(file="bar.h")
         assert str(loc) == "bar.h"
+
+    def test_str_drops_column(self) -> None:
+        """column is stored but intentionally omitted from __str__."""
+        loc = SourceLocation(file="foo.h", line=42, column=10)
+        assert str(loc) == "foo.h:42"
+        assert loc.column == 10  # accessible on instance
+
+    def test_line_none_no_colon(self) -> None:
+        loc = SourceLocation(file="foo.h", line=None, column=5)
+        assert ":" not in str(loc)
 
 
 # ---------------------------------------------------------------------------
@@ -86,12 +127,22 @@ class TestChange:
 
     def test_corroborating_tuple(self) -> None:
         c = _make_change(
-            corroborating=(Origin.DWARF, Origin.CASTXML),
+            origin=Origin.ELF,
+            corroborating=(Origin.DWARF,),
         )
         assert isinstance(c.corroborating, tuple)
-        assert Origin.CASTXML in c.corroborating
+        assert Origin.DWARF in c.corroborating
 
-    def test_confidence_validation(self) -> None:
+    def test_corroborating_primary_not_in_corroborating(self) -> None:
+        """Primary origin must not appear in corroborating."""
+        with pytest.raises(ValueError, match="must not appear in corroborating"):
+            _make_change(origin=Origin.ELF, corroborating=(Origin.ELF, Origin.DWARF))
+
+    def test_confidence_boundary_valid(self) -> None:
+        _make_change(confidence=0.0)   # should not raise
+        _make_change(confidence=1.0)   # should not raise
+
+    def test_confidence_validation_out_of_range(self) -> None:
         with pytest.raises(ValueError):
             _make_change(confidence=1.5)
         with pytest.raises(ValueError):
@@ -110,11 +161,12 @@ class TestChange:
         assert str(c.location) == "include/foo.h:99"
 
     def test_change_kinds_coverage(self) -> None:
-        # Verify all ChangeKind values exist
         kinds = {k.value for k in ChangeKind}
         assert "symbol" in kinds
-        assert "size_change" in kinds         # distinct from type_layout
-        assert "calling_convention" in kinds  # only with DWARF/castxml evidence
+        assert "size_change" in kinds           # distinct from type_layout
+        assert "calling_convention" in kinds    # only with DWARF/castxml evidence
+        assert "type_layout" in kinds
+        assert "vtable_inheritance" in kinds
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +184,7 @@ class TestPolicyResult:
         result = PolicyResult.from_annotated([])
         assert result.summary.verdict == PolicyVerdict.PASS
         assert result.summary.incompatible_count == 0
+        assert result.summary.review_needed_count == 0
 
     def test_block_on_breaking_change(self) -> None:
         changes = [self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK)]
@@ -153,6 +206,13 @@ class TestPolicyResult:
         result = PolicyResult.from_annotated(changes)
         assert result.summary.verdict == PolicyVerdict.BLOCK
 
+    def test_compatible_extension_only_is_pass(self) -> None:
+        changes = [self._annotated(PolicyVerdict.PASS, ChangeSeverity.COMPATIBLE_EXTENSION)]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.PASS
+        assert result.summary.incompatible_count == 0
+        assert result.summary.review_needed_count == 0
+
     def test_suppressed_count(self) -> None:
         changes = [
             self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
@@ -162,10 +222,20 @@ class TestPolicyResult:
         assert result.summary.suppressed_count == 2
         assert result.summary.verdict == PolicyVerdict.PASS
 
+    def test_suppressed_does_not_mask_block(self) -> None:
+        changes = [
+            self._annotated(PolicyVerdict.PASS, ChangeSeverity.SUPPRESSED),
+            self._annotated(PolicyVerdict.BLOCK, ChangeSeverity.BREAK),
+        ]
+        result = PolicyResult.from_annotated(changes)
+        assert result.summary.verdict == PolicyVerdict.BLOCK
+        assert result.summary.suppressed_count == 1
+        assert result.summary.incompatible_count == 1
+
     def test_per_change_traceability(self) -> None:
-        # Can trace exactly which change caused the verdict
         block_change = _make_change(entity_name="removed_func", severity=ChangeSeverity.BREAK)
-        compat_change = _make_change(entity_name="added_func", severity=ChangeSeverity.COMPATIBLE_EXTENSION)
+        compat_change = _make_change(entity_name="added_func",
+                                     severity=ChangeSeverity.COMPATIBLE_EXTENSION)
         changes = [
             AnnotatedChange(change=block_change, verdict=PolicyVerdict.BLOCK),
             AnnotatedChange(change=compat_change, verdict=PolicyVerdict.PASS),
@@ -174,3 +244,12 @@ class TestPolicyResult:
         blocking = [ac for ac in result.annotated_changes if ac.verdict == PolicyVerdict.BLOCK]
         assert len(blocking) == 1
         assert blocking[0].change.entity_name == "removed_func"
+
+    def test_error_verdict_manual_construction(self) -> None:
+        """ERROR verdict is not producible via from_annotated — must be constructed manually."""
+        result = PolicyResult(
+            annotated_changes=[],
+            summary=PolicySummary(verdict=PolicyVerdict.ERROR, error_count=1),
+        )
+        assert result.summary.verdict == PolicyVerdict.ERROR
+        assert result.summary.error_count == 1

--- a/tests/test_phase1b_corpus_diff.py
+++ b/tests/test_phase1b_corpus_diff.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
+from abicheck.core.corpus import CorpusBuilder, Normalizer
+from abicheck.core.diff import diff_symbols, diff_type_layouts
+from abicheck.core.model import ChangeKind, ChangeSeverity
+
+
+def _snap(
+    *,
+    funcs: list[Function] | None = None,
+    vars_: list[Variable] | None = None,
+    types: list[RecordType] | None = None,
+    version: str = "v1",
+) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfoo.so",
+        version=version,
+        functions=funcs or [],
+        variables=vars_ or [],
+        types=types or [],
+    )
+
+
+class TestNormalizer:
+    def test_intern_and_deduplicate_functions_public_wins(self) -> None:
+        normalizer = Normalizer()
+
+        # Same mangled symbol twice: ELF_ONLY and PUBLIC; PUBLIC must win
+        f_elf = Function(
+            name="foo",
+            mangled="_Z3foov",
+            return_type="int",
+            visibility=Visibility.ELF_ONLY,
+        )
+        f_pub = Function(
+            name="foo",
+            mangled="_Z3foov",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        s = _snap(funcs=[f_elf, f_pub])
+
+        n = normalizer.normalize(s)
+        assert len(n.functions) == 1
+        assert n.functions[0].visibility == Visibility.PUBLIC
+
+    def test_intern_strings_identity(self) -> None:
+        normalizer = Normalizer()
+        f1 = Function(name="foo", mangled="_Z3foov", return_type="int")
+        f2 = Function(name="foo", mangled="_Z3foov", return_type="int")
+
+        n = normalizer.normalize(_snap(funcs=[f1, f2]))
+        only = n.functions[0]
+        # interned strings should be stable and identical by identity
+        assert only.name is only.name
+        assert only.mangled is only.mangled
+
+
+class TestCorpusBuilder:
+    def test_integer_keyed_maps_and_public_exports(self) -> None:
+        normalizer = Normalizer()
+        builder = CorpusBuilder()
+
+        s = _snap(funcs=[
+            Function(name="a", mangled="_Za", return_type="int", visibility=Visibility.PUBLIC),
+            Function(name="b", mangled="_Zb", return_type="int", visibility=Visibility.HIDDEN),
+        ], types=[
+            RecordType(name="T1", kind="struct", size_bits=64),
+            RecordType(name="T2", kind="struct", size_bits=128),
+        ])
+
+        n = normalizer.normalize(s)
+        c = builder.build(n)
+
+        assert all(isinstance(k, int) for k in c.reachable_types.keys())
+        assert all(isinstance(k, int) for k in c.binary_exports.keys())
+        assert list(c.public_interfaces.keys()) == ["_Za"]
+        assert c.corpus_version == "v1"
+
+
+class TestSymbolDiff:
+    def test_detect_added_removed_changed_function(self) -> None:
+        normalizer = Normalizer()
+
+        before = _snap(funcs=[
+            Function(name="old_only", mangled="_Z7oldonlyv", return_type="int", visibility=Visibility.PUBLIC),
+            Function(name="same", mangled="_Z4samev", return_type="int", visibility=Visibility.PUBLIC),
+        ])
+        after = _snap(funcs=[
+            Function(name="new_only", mangled="_Z7newonlyv", return_type="int", visibility=Visibility.PUBLIC),
+            Function(name="same", mangled="_Z4samev", return_type="void", visibility=Visibility.PUBLIC),
+        ], version="v2")
+
+        b = normalizer.normalize(before)
+        a = normalizer.normalize(after)
+        changes = diff_symbols(b, a)
+
+        # removed + added + return-type change
+        assert len(changes) == 3
+        severities = {c.severity for c in changes}
+        assert ChangeSeverity.BREAK in severities
+        assert ChangeSeverity.COMPATIBLE_EXTENSION in severities
+
+    def test_detect_variable_type_change(self) -> None:
+        normalizer = Normalizer()
+        b = normalizer.normalize(_snap(vars_=[
+            Variable(name="g", mangled="g", type="int", visibility=Visibility.PUBLIC),
+        ]))
+        a = normalizer.normalize(_snap(vars_=[
+            Variable(name="g", mangled="g", type="long", visibility=Visibility.PUBLIC),
+        ], version="v2"))
+
+        changes = diff_symbols(b, a)
+        assert len(changes) == 1
+        assert changes[0].entity_type == "variable"
+        assert changes[0].severity == ChangeSeverity.BREAK
+
+
+class TestTypeLayoutDiff:
+    def test_detect_size_and_field_changes(self) -> None:
+        normalizer = Normalizer()
+
+        t_old = RecordType(
+            name="Point",
+            kind="struct",
+            size_bits=64,
+            fields=[TypeField(name="x", type="int", offset_bits=0)],
+        )
+        t_new = RecordType(
+            name="Point",
+            kind="struct",
+            size_bits=96,
+            fields=[
+                TypeField(name="x", type="long", offset_bits=0),
+                TypeField(name="y", type="int", offset_bits=64),
+            ],
+        )
+
+        b = normalizer.normalize(_snap(types=[t_old]))
+        a = normalizer.normalize(_snap(types=[t_new], version="v2"))
+
+        changes = diff_type_layouts(b, a)
+
+        kinds = {c.change_kind for c in changes}
+        assert ChangeKind.SIZE_CHANGE in kinds
+        assert ChangeKind.TYPE_LAYOUT in kinds
+        assert any(c.entity_name == "Point::x" for c in changes)
+
+    def test_added_type_is_compatible_extension(self) -> None:
+        normalizer = Normalizer()
+        b = normalizer.normalize(_snap(types=[]))
+        a = normalizer.normalize(_snap(types=[RecordType(name="A", kind="struct", size_bits=32)], version="v2"))
+
+        changes = diff_type_layouts(b, a)
+        assert len(changes) == 1
+        assert changes[0].entity_name == "A"
+        assert changes[0].severity == ChangeSeverity.COMPATIBLE_EXTENSION


### PR DESCRIPTION
## Phase 1b (stacked on #78)

This PR implements Phase 1b scaffold from the refactor plan v0.2:

- 
  - 
  - intern all names via 
  - dedupe rules (PUBLIC wins for duplicate symbols)

- 
  -  scaffold
  - integer-keyed  and 
  - deterministic ordering for reproducibility

- 
  - isolated symbol diff (functions + variables)

- 
  - two-phase type layout diff (structural hash prefilter + deep diff)
  - detects , , 

- tests: 

Validation:
-  +  => **36 passing**

### Stacking
This PR depends on #78 () and should be reviewed/merged after #78.
