### PR TITLE
docs: add README for cases 43-48 and refresh Phase 2 docs

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -271,7 +271,7 @@ of `SuppressionRule` objects compiled at load time.
 | `entity_glob` | `str \| None` | `None` | Shell-style glob matched against the entity name (`std::*`, `*detail*`) |
 | `entity_regex` | `str \| None` | `None` | RE2 regex; if both glob and regex are set, **both must match** (AND semantics) |
 | `change_kind` | `str \| None` | `None` | `ChangeKind` value string (e.g. `"func_removed"`); `None` = any kind |
-| `scope` | `SuppressionScope` | `SuppressionScope()` | Platform/profile/version filters — parsed but not yet enforced; raises `ValueError` if set |
+| `scope` | `SuppressionScope` | `SuppressionScope()` | Platform/profile/version filters — **setting any sub-field currently raises `ValueError`** (not yet implemented; field is reserved for future use) |
 | `reason` | `str` | `""` | Human-readable justification (appears in report audit trail) |
 
 ### SuppressionEngine (`abicheck/core/suppressions/engine.py`)
@@ -284,7 +284,7 @@ of `SuppressionRule` objects compiled at load time.
 ### CLI suppression (YAML)
 
 The CLI (`abicheck compare` / `abicheck compat`) uses the YAML-based engine in
-`abicheck/suppression.py`. Rule fields: `symbol`, `symbol_pattern`, `type_pattern`, `reason`.
+`abicheck/suppression.py`. Rule fields: `symbol`, `symbol_pattern`, `type_pattern`, `change_kind`, `reason`.
 See `examples/suppression_example.yaml` for a runnable example.
 
 ### Python API

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -273,96 +273,128 @@ Do you have ABICC XML descriptors already?
 ## Suppression Engine (Phase 2)
 
 The suppression engine (introduced in Phase 2) allows intentional ABI changes to be
-acknowledged and filtered out of reports without masking unrelated breakage. It is
-implemented in `abicheck/suppression.py` and integrated into the `analyse_full()`
-pipeline.
+acknowledged and filtered out of reports without masking unrelated breakage.
 
-### SuppressionRule model
+> **Two engines co-exist in this codebase:**
+> - `abicheck/suppression.py` — legacy file-based engine used by the current CLI
+>   (`abicheck compare` / `abicheck compat`); uses stdlib `re`; fields: `symbol`,
+>   `symbol_pattern`, `type_pattern`.
+> - `abicheck/core/suppressions/` — **new Phase 2 engine** (`SuppressionEngine` +
+>   `SuppressionRule`); uses RE2 (O(N) guaranteed); integrated via `analyse_full()`.
+>   The CLI migration to this engine is planned for Phase 3.
+>
+> This section documents the **new Phase 2 engine**.
 
-Each rule in a YAML suppression file corresponds to one `SuppressionRule` object:
+### SuppressionRule model (`abicheck/core/suppressions/rule.py`)
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `entity_glob` | str (optional) | Glob pattern matched against the mangled or demangled symbol/type name |
-| `entity_regex` | str (optional) | RE2-compatible regex matched against the mangled or demangled symbol/type name (takes precedence over `entity_glob`) |
-| `change_kind` | str (optional) | Specific `ChangeKind` to suppress (e.g. `func_removed`); omit to suppress all change kinds for the matched entity |
-| `scope` | str (optional) | Limit suppression to a sub-component or module path |
-| `reason` | str (required) | Human-readable justification recorded in the report |
+Each `SuppressionRule` is a Python dataclass with the following fields:
 
-Example (from `examples/suppression_example.yaml`):
-```yaml
-version: 1
-suppressions:
-  - symbol: "_ZN3foo6Client10disconnectEv"
-    change_kind: "func_removed"
-    reason: "Client::disconnect() was deprecated in v1.8 and removed in v2.0"
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `entity_glob` | `str \| None` | `None` | Shell-style glob (`std::*`) matched against the entity name |
+| `entity_regex` | `str \| None` | `None` | RE2 regex for complex patterns; if both `entity_glob` and `entity_regex` are set, **both must match** (AND semantics) |
+| `change_kind` | `str \| None` | `None` | `ChangeKind.value` string (e.g. `"func_removed"`); `None` matches any kind |
+| `scope` | `SuppressionScope` | `SuppressionScope()` | Platform/profile/version_range filters — **not yet enforced** (Phase 2b+); raises `ValueError` if set |
+| `reason` | `str` | `""` | Human-readable justification for audit trail |
 
-  - symbol_pattern: ".*N6detail.*"
-    reason: "detail:: namespace is internal implementation — not part of public ABI"
+Example using the Phase 2 Python API:
+```python
+from abicheck.core.suppressions import SuppressionEngine, SuppressionRule
+
+rules = [
+    # Suppress all changes in internal detail namespaces (glob)
+    SuppressionRule(
+        entity_glob="*detail*",
+        reason="detail:: is internal — not part of public ABI",
+    ),
+    # Suppress a specific symbol+kind (exact regex + change kind)
+    SuppressionRule(
+        entity_regex=r"_ZN3foo6Client10disconnectEv",
+        change_kind="func_removed",
+        reason="Client::disconnect() deprecated in v1.8, removed in v2.0",
+    ),
+]
 ```
 
-### SuppressionEngine
+> The YAML file format in `examples/suppression_example.yaml` uses the legacy
+> `abicheck/suppression.py` fields (`symbol`, `symbol_pattern`) and is for the CLI.
+> A Phase 2 YAML format is planned.
 
-`SuppressionEngine` compiles all regex patterns at load time using RE2-compatible
-semantics, giving **O(N)** matching cost per change (N = number of rules):
+### SuppressionEngine (`abicheck/core/suppressions/engine.py`)
 
-- Patterns are compiled once during `SuppressionEngine.__init__()`.
-- Matching is **first-match wins**: the first rule whose `entity_regex`/`entity_glob`
-  and optional `change_kind` match a `Change` object suppresses it.
-- Suppressed changes are removed from the `DiffResult.changes` list before policy
-  evaluation; they are preserved in `DiffResult.suppressed` for auditability.
-- A suppression reason string is attached to each suppressed entry in the report.
+`SuppressionEngine` compiles all patterns at load time using **google-re2**,
+giving guaranteed **O(N)** matching cost per change (N = number of rules):
 
-### Policy profiles
+- All glob and regex patterns are compiled in `SuppressionEngine.__init__()` — never inside the match loop.
+- Matching is **first-match wins**: the first rule whose patterns and optional `change_kind` all match a `Change` suppresses it.
+- Matched changes get `severity = ChangeSeverity.SUPPRESSED` and are collected in `SuppressionResult.suppressed`.
+- The audit trail is in `SuppressionResult.match_map`: `(entity_type, entity_name, change_kind.value) → SuppressionRule`.
 
-Phase 2 ships three built-in policy profiles that adjust which `ChangeKind` values
-are treated as BREAKING:
+### Policy profiles (`abicheck/core/policy/`)
 
-| Profile | Description | Promoted to BREAKING |
-|---------|-------------|---------------------|
-| `strict_abi` | Strictest — treats all changes as breaking. Suitable for system libraries and OS distributions. | All COMPATIBLE changes promoted |
-| `sdk_vendor` | Default — standard BREAKING + API_BREAK set. Suitable for SDK/vendor libraries. | Standard set (53 kinds) |
-| `plugin_abi` | Relaxed — only hard binary breaks. Suitable for plugin ABIs where some layout growth is tolerated. | Subset (symbol removal, vtable reorder, incompatible type changes) |
+Phase 2 ships three built-in policy profiles:
 
-Select a profile via `--policy <profile>` in `abicheck compare` or `abicheck compat`.
+| Profile | Class | Behaviour |
+|---------|-------|-----------|
+| `strict_abi` | `StrictAbiPolicy` | `BREAK → BLOCK`, `REVIEW_NEEDED → WARN`. Zero-tolerance; for system libraries and OS distributions. |
+| `sdk_vendor` | `SdkVendorPolicy` | Same as `strict_abi` currently (Phase 3 will differentiate). For SDK/vendor libraries. |
+| `plugin_abi` | `PluginAbiPolicy` | `BREAK → WARN` only (no BLOCK); for plugin ABIs where some ABI growth is tolerated. |
 
-### `analyse_full()` pipeline
+> **CLI integration:** Policy profiles are currently available via the Python API only
+> (`analyse_full(policy=...)`). A `--policy` CLI flag is planned for Phase 3.
 
-The complete analysis pipeline, including suppression and policy, follows this order:
+### `analyse_full()` pipeline (`abicheck/core/pipeline.py`)
+
+The complete Phase 2 analysis pipeline:
 
 ```text
-  libfoo_v1.so + headers
-  libfoo_v2.so + headers
+  AbiSnapshot (v1)  +  AbiSnapshot (v2)
           │
           ▼
-   abicheck dump × 2   →   v1.json, v2.json
+   Normalizer.normalize()    →   NormalizedSnapshot × 2
           │
           ▼
-   checker.py           →   raw DiffResult { verdict, changes: [Change] }
+   diff_symbols()            →   list[Change]
+   diff_type_layouts()           (sorted by entity_type, entity_name, change_kind)
           │
           ▼
-   SuppressionEngine     →   partitions changes into kept + suppressed
-   .apply(rules, diff)       suppressed entries carry .reason from the rule
+   SuppressionEngine         →   SuppressionResult {
+   .apply(changes)                 active:   list[Change]   (not suppressed)
+                                   suppressed: list[Change] (severity=SUPPRESSED)
+                                   match_map: audit trail
+                               }
           │
           ▼
-   checker_policy        →   re-evaluates verdict on kept changes only
-   .compute_verdict()        using the selected policy profile
+   sorted(active + suppressed)   (restores original deterministic order)
           │
           ▼
-   PolicyResult {
-     verdict,            ← worst ChangeKind of kept changes under profile
-     changes,            ← kept (non-suppressed) Change list
-     suppressed,         ← suppressed Change list (audit trail)
-     policy_profile,     ← name of the profile used
-   }
+   PolicyProfile.apply()     →   PolicyResult {
+                                   annotated_changes: list[AnnotatedChange]
+                                   summary: PolicySummary {
+                                     verdict,            ← PASS/WARN/BLOCK
+                                     incompatible_count,
+                                     suppressed_count,
+                                     review_needed_count,
+                                   }
+                               }
           │
           ▼
-   reporter / sarif / html / xml
-   (suppressed section included in reports with "suppressed by: <reason>")
+   reporter / sarif / html / json
 ```
 
-See `examples/suppression_example.yaml` for a runnable suppression file and
-`abicheck/core/suppressions/` for the implementation.
+Usage:
+```python
+from abicheck.core.pipeline import analyse_full
+from abicheck.core.suppressions import SuppressionRule
+
+result = analyse_full(snap_v1, snap_v2,
+                      rules=[SuppressionRule(entity_glob="*detail*", reason="internal")],
+                      policy="strict_abi")
+print(result.summary.verdict)        # PolicyVerdict.PASS / WARN / BLOCK
+print(result.summary.suppressed_count)
+```
+
+See `abicheck/core/suppressions/` for the implementation.
 
 ---
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,7 +1,7 @@
 # Architecture & Analysis Pipeline
 
-This page explains how `abicheck` works internally — what it analyzes, in what order,
-and how the four analysis tiers combine to produce a verdict.
+This page explains how `abicheck` works internally — what it analyses, in what order,
+and how all components combine to produce a verdict.
 
 ---
 
@@ -81,16 +81,17 @@ This is the recommended workflow for new integrations.
 │                  └─────────────┬──────────────────────────┘     │
 │                                │                                 │
 │                  ┌─────────────▼──────────────────────────┐     │
-│                  │  checker_policy                        │     │
+│                  │  Suppression engine                    │     │
+│                  │  • matches Changes against rules       │     │
+│                  │  • suppressed entries kept for audit   │     │
+│                  └─────────────┬──────────────────────────┘     │
+│                                │                                 │
+│                  ┌─────────────▼──────────────────────────┐     │
+│                  │  Policy                                │     │
 │                  │  • maps ChangeKind → Verdict           │     │
 │                  │  • 53 BREAKING + 38 COMPATIBLE         │     │
 │                  │  + 11 API_BREAK ChangeKinds            │     │
 │                  │  • final verdict = worst of all        │     │
-│                  └─────────────┬──────────────────────────┘     │
-│                                │                                 │
-│                  ┌─────────────▼──────────────────────────┐     │
-│                  │  DiffResult                            │     │
-│                  │  { verdict, changes: [Change] }        │     │
 │                  └─────────────┬──────────────────────────┘     │
 │                                │                                 │
 │            ┌───────────────────┼───────────────────────────┐    │
@@ -158,40 +159,59 @@ headers + .so (with -g)     ✅          ✅          ✅          ✅
 
 ```text
 abicheck/
-  cli.py            ← CLI entry points (dump / compare / compat / compat-dump)
-  dumper.py         ← builds ABI snapshot from .so + headers (calls all 4 tiers)
-  checker.py        ← runs detectors on two snapshots → DiffResult
-  checker_policy.py ← ChangeKind enum, BREAKING/COMPATIBLE/API_BREAK sets, verdict logic
-  detectors.py      ← detector protocol + detector result types
-  model.py          ← core data model: AbiSnapshot, Function, RecordType, Change
-  compat.py         ← ABICC XML descriptor parsing + compat mapping
-  report_summary.py ← canonical counters shared by all reporters
-  reporter.py       ← Markdown reporter
-  sarif.py          ← SARIF reporter (GitHub Code Scanning)
-  html_report.py    ← HTML reporter (ABICC-compatible)
-  xml_report.py     ← XML reporter (ABICC-compatible machine-readable)
-  suppression.py    ← suppression engine (compare YAML + compat -skip-* flags)
-  serialization.py  ← JSON snapshot read/write
-  elf_metadata.py   ← Tier 2: ELF symbol table, SONAME, visibility
-  dwarf_metadata.py ← Tier 3: DWARF struct layout, field offsets
-  dwarf_advanced.py ← Tier 4: calling conventions, packing, toolchain flags
-  dwarf_unified.py  ← unified DWARF pass (~50% I/O savings via single-pass read)
+  cli.py              ← CLI entry points (dump / compare / compat / compat-dump)
+  dumper.py           ← builds ABI snapshot from .so + headers (calls all 4 tiers)
+  checker.py          ← runs detectors on two snapshots → list[Change]
+  checker_policy.py   ← ChangeKind enum, BREAKING/COMPATIBLE/API_BREAK sets
+  detectors.py        ← detector protocol + detector result types
+  model.py            ← legacy data model: AbiSnapshot, Function, RecordType
+  compat.py           ← ABICC XML descriptor parsing + compat mapping
+  report_summary.py   ← canonical counters shared by all reporters
+  reporter.py         ← Markdown reporter
+  sarif.py            ← SARIF reporter (GitHub Code Scanning)
+  html_report.py      ← HTML reporter (ABICC-compatible)
+  xml_report.py       ← XML reporter (ABICC-compatible machine-readable)
+  suppression.py      ← CLI suppression engine (YAML rules for compare/compat)
+  serialization.py    ← JSON snapshot read/write
+  elf_metadata.py     ← Tier 2: ELF symbol table, SONAME, visibility
+  dwarf_metadata.py   ← Tier 3: DWARF struct layout, field offsets
+  dwarf_advanced.py   ← Tier 4: calling conventions, packing, toolchain flags
+  dwarf_unified.py    ← unified DWARF pass (~50% I/O savings via single-pass read)
+  core/
+    model/
+      change.py       ← Change, ChangeKind, ChangeSeverity, AnnotatedChange
+      origin.py       ← Origin (which tier detected the change)
+      policy_result.py← PolicyResult, PolicySummary, PolicyVerdict
+    corpus/
+      normalizer.py   ← AbiSnapshot → NormalizedSnapshot (dedup, intern, canonicalise)
+      builder.py      ← NormalizedSnapshot → Corpus (indexed for fast diff)
+    diff/
+      symbol_diff.py  ← symbol-level Changes (added/removed/changed functions & vars)
+      type_layout_diff.py ← struct/class layout Changes (field offsets, sizes)
+    suppressions/
+      rule.py         ← SuppressionRule, SuppressionScope dataclasses
+      engine.py       ← SuppressionEngine: RE2-based, O(N), compile-at-load
+    policy/
+      base.py         ← PolicyProfile ABC
+      strict_abi.py   ← StrictAbiPolicy  (BREAK→BLOCK, REVIEW_NEEDED→WARN)
+      sdk_vendor.py   ← SdkVendorPolicy  (same as strict currently)
+      plugin_abi.py   ← PluginAbiPolicy  (BREAK→WARN only)
+    pipeline.py       ← analyse() + analyse_full(): end-to-end Python API
 ```
 
 ---
 
-## Data flow (internal)
+## Full data flow
 
 ```text
 Input: libfoo.so + include/foo.h
            │
            ▼
       dumper.py
-      ├── castxml → parses headers → AST
-      │   └── extracts: functions, types, vtable, noexcept, inline
-      ├── elf_metadata.py → reads .dynsym, .gnu.version, SONAME
-      ├── dwarf_metadata.py → reads DWARF .debug_info (struct layouts)
-      └── dwarf_unified.py → single-pass DWARF read (performance)
+      ├── castxml            → parses headers → AST (functions, types, vtable)
+      ├── elf_metadata.py    → reads .dynsym, .gnu.version, SONAME
+      ├── dwarf_metadata.py  → reads DWARF .debug_info (struct layouts)
+      └── dwarf_unified.py   → single-pass DWARF read (performance)
            │
            ▼
       AbiSnapshot (JSON)
@@ -200,24 +220,107 @@ Input: libfoo.so + include/foo.h
      (compare two snapshots)
            │
            ▼
-      checker.py
-      └── runs each detector on (old_snapshot, new_snapshot)
-          ├── FuncDetector → FUNC_REMOVED, FUNC_PARAMS_CHANGED, ...
-          ├── TypeDetector → TYPE_SIZE_CHANGED, TYPE_VTABLE_CHANGED, ...
-          ├── ElfDetector  → SONAME_CHANGED, VISIBILITY_LEAK, ...
-          └── DwarfDetector → CALLING_CONVENTION_CHANGED, ...
+      core/corpus/normalizer.py
+      └── AbiSnapshot → NormalizedSnapshot
+          (dedup, intern strings, canonicalise type names)
            │
            ▼
-      checker_policy.py
-      compute_verdict(changes) → Verdict
-      (worst of: BREAKING > API_BREAK > COMPATIBLE > NO_CHANGE)
+      core/diff/symbol_diff.py        → list[Change]  (func/var level)
+      core/diff/type_layout_diff.py   → list[Change]  (struct/class level)
            │
-           ▼
-      DiffResult { verdict, changes: [Change] }
+           ▼  sorted(entity_type, entity_name, change_kind)
+           │
+      core/suppressions/engine.py
+      └── SuppressionEngine.apply(changes)
+          → SuppressionResult {
+              active:     list[Change]   (not matched by any rule)
+              suppressed: list[Change]   (severity = SUPPRESSED)
+              match_map:  audit trail    (entity_type, name, kind) → rule
+            }
+           │
+           ▼  sorted(active + suppressed) — restores original order
+           │
+      core/policy/<profile>.py
+      └── PolicyProfile.apply(changes)
+          → PolicyResult {
+              annotated_changes: list[AnnotatedChange]
+              summary: PolicySummary {
+                verdict,             ← PASS / WARN / BLOCK
+                incompatible_count,
+                suppressed_count,
+                review_needed_count,
+              }
+            }
            │
            ▼
       reporter / sarif / html_report / xml_report
 ```
+
+---
+
+## Suppression engine
+
+Intentional ABI changes can be acknowledged and filtered out without masking
+unrelated breakage. The suppression engine matches each `Change` against a list
+of `SuppressionRule` objects compiled at load time.
+
+### SuppressionRule (`abicheck/core/suppressions/rule.py`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `entity_glob` | `str \| None` | `None` | Shell-style glob matched against the entity name (`std::*`, `*detail*`) |
+| `entity_regex` | `str \| None` | `None` | RE2 regex; if both glob and regex are set, **both must match** (AND semantics) |
+| `change_kind` | `str \| None` | `None` | `ChangeKind` value string (e.g. `"func_removed"`); `None` = any kind |
+| `scope` | `SuppressionScope` | `SuppressionScope()` | Platform/profile/version filters — parsed but not yet enforced; raises `ValueError` if set |
+| `reason` | `str` | `""` | Human-readable justification (appears in report audit trail) |
+
+### SuppressionEngine (`abicheck/core/suppressions/engine.py`)
+
+- All glob and regex patterns compiled once in `__init__()` via **google-re2** — O(N) guaranteed, no backtracking.
+- **First-match wins**: earliest rule whose patterns + `change_kind` all match suppresses the Change.
+- Suppressed changes carry `severity = ChangeSeverity.SUPPRESSED` and are included in `SuppressionResult.suppressed` for audit.
+- Audit trail: `SuppressionResult.match_map[(entity_type, entity_name, change_kind.value)] → SuppressionRule`.
+
+### CLI suppression (YAML)
+
+The CLI (`abicheck compare` / `abicheck compat`) uses the YAML-based engine in
+`abicheck/suppression.py`. Rule fields: `symbol`, `symbol_pattern`, `type_pattern`, `reason`.
+See `examples/suppression_example.yaml` for a runnable example.
+
+### Python API
+
+```python
+from abicheck.core.pipeline import analyse_full
+from abicheck.core.suppressions import SuppressionRule
+
+result = analyse_full(
+    snap_v1, snap_v2,
+    rules=[
+        SuppressionRule(entity_glob="*detail*", reason="internal namespace"),
+        SuppressionRule(
+            entity_regex=r"_ZN3foo6Client10disconnectEv",
+            change_kind="func_removed",
+            reason="deprecated in v1.8, removed in v2.0",
+        ),
+    ],
+    policy="strict_abi",   # or "sdk_vendor" / "plugin_abi"
+)
+print(result.summary.verdict)          # PolicyVerdict.PASS / WARN / BLOCK
+print(result.summary.suppressed_count)
+```
+
+---
+
+## Policy profiles (`abicheck/core/policy/`)
+
+| Profile | Class | Behaviour |
+|---------|-------|-----------|
+| `strict_abi` | `StrictAbiPolicy` | `BREAK → BLOCK`, `REVIEW_NEEDED → WARN`. Zero-tolerance; for system libraries and OS distributions. |
+| `sdk_vendor` | `SdkVendorPolicy` | Currently identical to `strict_abi`. Differentiated profile planned. For SDK/vendor libraries. |
+| `plugin_abi` | `PluginAbiPolicy` | `BREAK → WARN` only (no BLOCK). For plugin ABIs where some ABI growth is tolerated. |
+
+> Policy profiles are available via the Python API (`analyse_full(policy=...)`).
+> A `--policy` CLI flag is planned.
 
 ---
 
@@ -240,11 +343,11 @@ ABI snapshots are portable JSON files created by `abicheck dump`.
       "noexcept": false
     }
   ],
-  "types": [ ... ],
+  "types": [ "..." ],
   "elf": {
     "soname": "libfoo.so.1",
     "exported_symbols": ["_Z8foo_initv"],
-    "symbol_versions": { ... }
+    "symbol_versions": {}
   }
 }
 ```
@@ -270,141 +373,14 @@ Do you have ABICC XML descriptors already?
 
 ---
 
-## Suppression Engine (Phase 2)
-
-The suppression engine (introduced in Phase 2) allows intentional ABI changes to be
-acknowledged and filtered out of reports without masking unrelated breakage.
-
-> **Two engines co-exist in this codebase:**
-> - `abicheck/suppression.py` — legacy file-based engine used by the current CLI
->   (`abicheck compare` / `abicheck compat`); uses stdlib `re`; fields: `symbol`,
->   `symbol_pattern`, `type_pattern`.
-> - `abicheck/core/suppressions/` — **new Phase 2 engine** (`SuppressionEngine` +
->   `SuppressionRule`); uses RE2 (O(N) guaranteed); integrated via `analyse_full()`.
->   The CLI migration to this engine is planned for Phase 3.
->
-> This section documents the **new Phase 2 engine**.
-
-### SuppressionRule model (`abicheck/core/suppressions/rule.py`)
-
-Each `SuppressionRule` is a Python dataclass with the following fields:
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `entity_glob` | `str \| None` | `None` | Shell-style glob (`std::*`) matched against the entity name |
-| `entity_regex` | `str \| None` | `None` | RE2 regex for complex patterns; if both `entity_glob` and `entity_regex` are set, **both must match** (AND semantics) |
-| `change_kind` | `str \| None` | `None` | `ChangeKind.value` string (e.g. `"func_removed"`); `None` matches any kind |
-| `scope` | `SuppressionScope` | `SuppressionScope()` | Platform/profile/version_range filters — **not yet enforced** (Phase 2b+); raises `ValueError` if set |
-| `reason` | `str` | `""` | Human-readable justification for audit trail |
-
-Example using the Phase 2 Python API:
-```python
-from abicheck.core.suppressions import SuppressionEngine, SuppressionRule
-
-rules = [
-    # Suppress all changes in internal detail namespaces (glob)
-    SuppressionRule(
-        entity_glob="*detail*",
-        reason="detail:: is internal — not part of public ABI",
-    ),
-    # Suppress a specific symbol+kind (exact regex + change kind)
-    SuppressionRule(
-        entity_regex=r"_ZN3foo6Client10disconnectEv",
-        change_kind="func_removed",
-        reason="Client::disconnect() deprecated in v1.8, removed in v2.0",
-    ),
-]
-```
-
-> The YAML file format in `examples/suppression_example.yaml` uses the legacy
-> `abicheck/suppression.py` fields (`symbol`, `symbol_pattern`) and is for the CLI.
-> A Phase 2 YAML format is planned.
-
-### SuppressionEngine (`abicheck/core/suppressions/engine.py`)
-
-`SuppressionEngine` compiles all patterns at load time using **google-re2**,
-giving guaranteed **O(N)** matching cost per change (N = number of rules):
-
-- All glob and regex patterns are compiled in `SuppressionEngine.__init__()` — never inside the match loop.
-- Matching is **first-match wins**: the first rule whose patterns and optional `change_kind` all match a `Change` suppresses it.
-- Matched changes get `severity = ChangeSeverity.SUPPRESSED` and are collected in `SuppressionResult.suppressed`.
-- The audit trail is in `SuppressionResult.match_map`: `(entity_type, entity_name, change_kind.value) → SuppressionRule`.
-
-### Policy profiles (`abicheck/core/policy/`)
-
-Phase 2 ships three built-in policy profiles:
-
-| Profile | Class | Behaviour |
-|---------|-------|-----------|
-| `strict_abi` | `StrictAbiPolicy` | `BREAK → BLOCK`, `REVIEW_NEEDED → WARN`. Zero-tolerance; for system libraries and OS distributions. |
-| `sdk_vendor` | `SdkVendorPolicy` | Same as `strict_abi` currently (Phase 3 will differentiate). For SDK/vendor libraries. |
-| `plugin_abi` | `PluginAbiPolicy` | `BREAK → WARN` only (no BLOCK); for plugin ABIs where some ABI growth is tolerated. |
-
-> **CLI integration:** Policy profiles are currently available via the Python API only
-> (`analyse_full(policy=...)`). A `--policy` CLI flag is planned for Phase 3.
-
-### `analyse_full()` pipeline (`abicheck/core/pipeline.py`)
-
-The complete Phase 2 analysis pipeline:
-
-```text
-  AbiSnapshot (v1)  +  AbiSnapshot (v2)
-          │
-          ▼
-   Normalizer.normalize()    →   NormalizedSnapshot × 2
-          │
-          ▼
-   diff_symbols()            →   list[Change]
-   diff_type_layouts()           (sorted by entity_type, entity_name, change_kind)
-          │
-          ▼
-   SuppressionEngine         →   SuppressionResult {
-   .apply(changes)                 active:   list[Change]   (not suppressed)
-                                   suppressed: list[Change] (severity=SUPPRESSED)
-                                   match_map: audit trail
-                               }
-          │
-          ▼
-   sorted(active + suppressed)   (restores original deterministic order)
-          │
-          ▼
-   PolicyProfile.apply()     →   PolicyResult {
-                                   annotated_changes: list[AnnotatedChange]
-                                   summary: PolicySummary {
-                                     verdict,            ← PASS/WARN/BLOCK
-                                     incompatible_count,
-                                     suppressed_count,
-                                     review_needed_count,
-                                   }
-                               }
-          │
-          ▼
-   reporter / sarif / html / json
-```
-
-Usage:
-```python
-from abicheck.core.pipeline import analyse_full
-from abicheck.core.suppressions import SuppressionRule
-
-result = analyse_full(snap_v1, snap_v2,
-                      rules=[SuppressionRule(entity_glob="*detail*", reason="internal")],
-                      policy="strict_abi")
-print(result.summary.verdict)        # PolicyVerdict.PASS / WARN / BLOCK
-print(result.summary.suppressed_count)
-```
-
-See `abicheck/core/suppressions/` for the implementation.
-
----
-
 ## Comparison: `compare` vs `compat`
 
 | Feature | `compare` | `compat` |
 |---------|-----------|---------|
 | Input | JSON snapshots | ABICC XML descriptors |
 | Output formats | md, json, sarif, html | html, json, xml, md |
-| Verdicts in report | NO_CHANGE / COMPATIBLE / API_BREAK / BREAKING | ABICC-style compatibility report |
+| Verdicts | NO_CHANGE / COMPATIBLE / API_BREAK / BREAKING | ABICC-style compatibility report |
 | Exit codes | 0 / 1(err) / 2 / 4 | 0 / 1 / 2(API_BREAK) |
-| ABICC flag parity | — | partial (core flags supported; see [from_abicc.md](../migration/from_abicc.md) for mapping) |
+| Suppression | YAML rules (`suppression.py`) | `-skip-*` flags + YAML |
+| ABICC flag parity | — | partial (see [from_abicc.md](../migration/from_abicc.md)) |
 | Recommended for | new integrations | migrating from ABICC |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -270,6 +270,102 @@ Do you have ABICC XML descriptors already?
 
 ---
 
+## Suppression Engine (Phase 2)
+
+The suppression engine (introduced in Phase 2) allows intentional ABI changes to be
+acknowledged and filtered out of reports without masking unrelated breakage. It is
+implemented in `abicheck/suppression.py` and integrated into the `analyse_full()`
+pipeline.
+
+### SuppressionRule model
+
+Each rule in a YAML suppression file corresponds to one `SuppressionRule` object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entity_glob` | str (optional) | Glob pattern matched against the mangled or demangled symbol/type name |
+| `entity_regex` | str (optional) | RE2-compatible regex matched against the mangled or demangled symbol/type name (takes precedence over `entity_glob`) |
+| `change_kind` | str (optional) | Specific `ChangeKind` to suppress (e.g. `func_removed`); omit to suppress all change kinds for the matched entity |
+| `scope` | str (optional) | Limit suppression to a sub-component or module path |
+| `reason` | str (required) | Human-readable justification recorded in the report |
+
+Example (from `examples/suppression_example.yaml`):
+```yaml
+version: 1
+suppressions:
+  - symbol: "_ZN3foo6Client10disconnectEv"
+    change_kind: "func_removed"
+    reason: "Client::disconnect() was deprecated in v1.8 and removed in v2.0"
+
+  - symbol_pattern: ".*N6detail.*"
+    reason: "detail:: namespace is internal implementation — not part of public ABI"
+```
+
+### SuppressionEngine
+
+`SuppressionEngine` compiles all regex patterns at load time using RE2-compatible
+semantics, giving **O(N)** matching cost per change (N = number of rules):
+
+- Patterns are compiled once during `SuppressionEngine.__init__()`.
+- Matching is **first-match wins**: the first rule whose `entity_regex`/`entity_glob`
+  and optional `change_kind` match a `Change` object suppresses it.
+- Suppressed changes are removed from the `DiffResult.changes` list before policy
+  evaluation; they are preserved in `DiffResult.suppressed` for auditability.
+- A suppression reason string is attached to each suppressed entry in the report.
+
+### Policy profiles
+
+Phase 2 ships three built-in policy profiles that adjust which `ChangeKind` values
+are treated as BREAKING:
+
+| Profile | Description | Promoted to BREAKING |
+|---------|-------------|---------------------|
+| `strict_abi` | Strictest — treats all changes as breaking. Suitable for system libraries and OS distributions. | All COMPATIBLE changes promoted |
+| `sdk_vendor` | Default — standard BREAKING + API_BREAK set. Suitable for SDK/vendor libraries. | Standard set (53 kinds) |
+| `plugin_abi` | Relaxed — only hard binary breaks. Suitable for plugin ABIs where some layout growth is tolerated. | Subset (symbol removal, vtable reorder, incompatible type changes) |
+
+Select a profile via `--policy <profile>` in `abicheck compare` or `abicheck compat`.
+
+### `analyse_full()` pipeline
+
+The complete analysis pipeline, including suppression and policy, follows this order:
+
+```text
+  libfoo_v1.so + headers
+  libfoo_v2.so + headers
+          │
+          ▼
+   abicheck dump × 2   →   v1.json, v2.json
+          │
+          ▼
+   checker.py           →   raw DiffResult { verdict, changes: [Change] }
+          │
+          ▼
+   SuppressionEngine     →   partitions changes into kept + suppressed
+   .apply(rules, diff)       suppressed entries carry .reason from the rule
+          │
+          ▼
+   checker_policy        →   re-evaluates verdict on kept changes only
+   .compute_verdict()        using the selected policy profile
+          │
+          ▼
+   PolicyResult {
+     verdict,            ← worst ChangeKind of kept changes under profile
+     changes,            ← kept (non-suppressed) Change list
+     suppressed,         ← suppressed Change list (audit trail)
+     policy_profile,     ← name of the profile used
+   }
+          │
+          ▼
+   reporter / sarif / html / xml
+   (suppressed section included in reports with "suppressed by: <reason>")
+```
+
+See `examples/suppression_example.yaml` for a runnable suppression file and
+`abicheck/core/suppressions/` for the implementation.
+
+---
+
 ## Comparison: `compare` vs `compat`
 
 | Feature | `compare` | `compat` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,7 +118,7 @@ methodology live in docs:
 | abicheck (compat) | 46/48 | 96% |
 | abidiff | 12/48 | 25% |
 | abidiff + headers | 12/48 | 25% |
-| ABICC (abi-dumper) | 20/30 | 66% (42% effective over 48) |
+| ABICC (abi-dumper) | 25/36 | 69% (52% effective over 48) |
 | ABICC (xml) | 25/41 | 61% |
 
 ### Why these numbers differ
@@ -127,8 +127,8 @@ methodology live in docs:
   (`case31`, `case34`), so max is 46/48 in this suite.
 - **`abidiff` == `abidiff+headers` here**: `--headers-dir` only filters public symbols;
   with `-fvisibility=default` in these examples, filtering does not change the set.
-- **cases 43–48** (new): abicheck detects all 6 correctly; abidiff misses 5/6 (catches
-  only case47 which is a compatible FUNC_ADDED — trivially correct).
+- **ABICC(dumper)** missed case43 (base class member added) — classified as COMPATIBLE.
+  Reason: ABICC focuses on exported symbols, not derived class layout shifts.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -79,6 +79,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [39](case39_var_const/README.md) | Var Const | Breaking | BREAKING 🔴 |
 | [40](case40_field_layout/README.md) | Field Layout | Breaking | BREAKING 🔴 |
 | [41](case41_type_changes/README.md) | Type Changes | Breaking | BREAKING 🔴 |
+| *(42 — reserved, not yet published)* | — | — | — |
 | [43](case43_base_class_member_added/README.md) | Base Class Member Added | C++ Layout | BREAKING 🔴 |
 | [44](case44_cyclic_type_member_added/README.md) | Cyclic Type Member Added | Struct Layout | BREAKING 🔴 |
 | [45](case45_multi_dim_array_change/README.md) | Multi-Dim Array Element Type Change | Struct Layout | BREAKING 🔴 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 > Authoritative expected verdicts for benchmarking are in [`ground_truth.json`](ground_truth.json).
 > If a per-case README and benchmark expectation differ, treat [`ground_truth.json`](ground_truth.json) as source of truth.
 
-**48 cases total** — 34 BREAKING 🔴 | 10 COMPATIBLE 🟢 | 2 NO_CHANGE ✅ | 2 API_BREAK 🟠
+**48 published cases** (case 42 reserved) — 34 BREAKING 🔴 | 10 COMPATIBLE 🟢 | 2 NO_CHANGE ✅ | 2 API_BREAK 🟠
 
 | # | Case | Category | abicheck verdict |
 |---|------|----------|-----------------|

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,8 +118,8 @@ methodology live in docs:
 | abicheck (compat) | 46/48 | 96% |
 | abidiff | 12/48 | 25% |
 | abidiff + headers | 12/48 | 25% |
-| ABICC (abi-dumper) | 25/36 | 69% (52% effective over 48) |
-| ABICC (xml) | 25/41 | 61% |
+| ABICC (xml) | 30/47 | 63% (1 timeout, 48 cases attempted) |
+| ABICC (abi-dumper) | 24/48 | 50% (12 error/timeout) |
 
 ### Why these numbers differ
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 > Authoritative expected verdicts for benchmarking are in .
 > If a per-case README and benchmark expectation differ, treat  as source of truth.
 
-**42 cases total** — 29 BREAKING 🔴 | 9 COMPATIBLE 🟢 | 2 NO_CHANGE ✅ | 2 API_BREAK 🟠
+**48 cases total** — 34 BREAKING 🔴 | 10 COMPATIBLE 🟢 | 2 NO_CHANGE ✅ | 2 API_BREAK 🟠
 
 | # | Case | Category | abicheck verdict |
 |---|------|----------|-----------------|
@@ -79,6 +79,12 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [39](case39_var_const/README.md) | Var Const | Breaking | BREAKING 🔴 |
 | [40](case40_field_layout/README.md) | Field Layout | Breaking | BREAKING 🔴 |
 | [41](case41_type_changes/README.md) | Type Changes | Breaking | BREAKING 🔴 |
+| [43](case43_base_class_member_added/README.md) | Base Class Member Added | C++ Layout | BREAKING 🔴 |
+| [44](case44_cyclic_type_member_added/README.md) | Cyclic Type Member Added | Struct Layout | BREAKING 🔴 |
+| [45](case45_multi_dim_array_change/README.md) | Multi-Dim Array Element Type Change | Struct Layout | BREAKING 🔴 |
+| [46](case46_pointer_chain_type_change/README.md) | Pointer Chain Type Change | Function Signature | BREAKING 🔴 |
+| [47](case47_inline_to_outlined/README.md) | Inline to Outlined | C++ Symbol | COMPATIBLE 🟢 |
+| [48](case48_leaf_struct_through_pointer/README.md) | Leaf Struct Change Through Pointer | Struct Layout | BREAKING 🔴 |
 
 ---
 
@@ -98,7 +104,7 @@ case's README for copy-paste build instructions.
 
 ---
 
-## Benchmark Snapshot (42 cases, 2026-03-11)
+## Benchmark Snapshot (48 cases, 2026-03-11)
 
 To avoid drift, this README keeps only a compact summary. Full per-case matrix and
 methodology live in docs:

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [15](case15_noexcept_change/README.md) | Noexcept Change | Breaking | BREAKING 🔴 |
 | [16](case16_inline_to_non_inline/README.md) | Inline To Non Inline | Compatible | COMPATIBLE 🟢 |
 | [17](case17_template_abi/README.md) | Template Abi | Breaking | BREAKING 🔴 |
-| [18](case18_dependency_leak/README.md) | Dependency Leak | ELF / Policy | COMPATIBLE 🟡 (bad practice) |
+| [18](case18_dependency_leak/README.md) | Dependency Leak | ELF / Policy | BREAKING 🔴 (bad practice) |
 | [19](case19_enum_member_removed/README.md) | Enum Member Removed | Breaking | BREAKING 🔴 |
 | [20](case20_enum_member_value_changed/README.md) | Enum Member Value Changed | Breaking | BREAKING 🔴 |
 | [21](case21_method_became_static/README.md) | Method Became Static | Breaking | BREAKING 🔴 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -113,22 +113,21 @@ methodology live in docs:
 
 | Tool | Correct / Scored | Accuracy |
 |------|------------------|----------|
-| **abicheck (compare)** | **42/42** | **100%** |
-| abicheck (compat) | 40/42 | 95% |
-| abicheck (strict, full) | 31/42 | 73% |
-| abidiff | 11/42 | 26% |
-| abidiff + headers | 11/42 | 26% |
-| ABICC (abi-dumper) | 20/30 | 66% (48% effective over 42) |
+| **abicheck (compare)** | **48/48** | **100%** |
+| abicheck (compat) | 46/48 | 96% |
+| abidiff | 12/48 | 25% |
+| abidiff + headers | 12/48 | 25% |
+| ABICC (abi-dumper) | 20/30 | 66% (42% effective over 48) |
 | ABICC (xml) | 25/41 | 61% |
 
 ### Why these numbers differ
 
 - **`compat` < `compare`**: `compat` follows ABICC vocabulary and cannot emit `API_BREAK`
-  (`case31`, `case34`), so max is 40/42 in this suite.
-- **`strict` can beat ABICC(dump)**: strict intentionally promotes some compatible changes,
-  while ABICC(dump) has many ERROR/TIMEOUT cases and only scores on 30/42.
+  (`case31`, `case34`), so max is 46/48 in this suite.
 - **`abidiff` == `abidiff+headers` here**: `--headers-dir` only filters public symbols;
   with `-fvisibility=default` in these examples, filtering does not change the set.
+- **cases 43–48** (new): abicheck detects all 6 correctly; abidiff misses 5/6 (catches
+  only case47 which is a compatible FUNC_ADDED — trivially correct).
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,8 +30,8 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 
 ## Case Index
 
-> Authoritative expected verdicts for benchmarking are in .
-> If a per-case README and benchmark expectation differ, treat  as source of truth.
+> Authoritative expected verdicts for benchmarking are in [`ground_truth.json`](ground_truth.json).
+> If a per-case README and benchmark expectation differ, treat [`ground_truth.json`](ground_truth.json) as source of truth.
 
 **48 cases total** — 34 BREAKING 🔴 | 10 COMPATIBLE 🟢 | 2 NO_CHANGE ✅ | 2 API_BREAK 🟠
 

--- a/examples/case43_base_class_member_added/README.md
+++ b/examples/case43_base_class_member_added/README.md
@@ -3,74 +3,65 @@
 **Category:** C++ Layout | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-A data member (`int extra_field`) is added to `Base`. Because `Derived` inherits from
-`Base`, all fields declared in `Derived` are pushed to higher offsets — `Derived::value`
-shifts by 4 bytes. Any code compiled against v1 that reads or writes `Derived::value`
-through a v2 `.so` will access the wrong memory location.
 
-The change propagates silently: the mangled symbol for `Derived::process()` is
-unchanged, so `nm` and simple symbol checks show no breakage. Only a layout-aware
-tool catches it.
+A data member is added to a base class (`Base`). This shifts the memory layout of
+**all derived classes** — their fields move to higher offsets. Any consumer binary
+compiled against v1 headers will read `Derived::value` at the wrong offset when
+linked against the v2 library, causing silent data corruption or crashes.
 
 ## Why abidiff catches it
-abidiff reads DWARF debug info and detects that `sizeof(Base)` grew and that
-`Derived::value`'s byte offset changed. It reports:
 
-- `TYPE_SIZE_CHANGED` on `Base` (8 → 12 bytes)
-- `TYPE_FIELD_OFFSET_CHANGED` on `Derived::value` (offset 8 → 12)
-- Exit code **4** (ABI change detected, non-symbol-removal break)
+abidiff reports `Added_Base_Class_Data_Member` and exits with code **4** (ABI change).
+Note: abidiff exits 4 (not 12) because this is a layout change, not a symbol removal.
+abicheck detects: `TYPE_SIZE_CHANGED` on `Base`, `TYPE_FIELD_OFFSET_CHANGED` on `Derived::value`.
 
 ## Code diff
 
 | v1.hpp | v2.hpp |
 |--------|--------|
-| `class Base { int base_id; virtual void describe(); };` | `class Base { int base_id; int extra_field; virtual void describe(); };` |
-| `class Derived : public Base { int value; void process(); };` | *(layout shifts — `value` now at offset +12 instead of +8)* |
+| `class Base { int base_id; ... };` | `class Base { int base_id; int extra_field; ... };` |
+| `class Derived : public Base { int value; };` | `class Derived : public Base { int value; };` |
+| `sizeof(Derived)` ≈ 20 bytes | `sizeof(Derived)` ≈ 24 bytes — `value` shifts by 4 |
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: 🔴 CRITICAL**
 
-**Scenario:** compile app against v1, swap in v2 `.so` without recompile.
+**Scenario:** compile app against v1, swap in v2 `.so` — `Derived::value` is read at wrong offset.
 
 ```bash
-# Build old library + app
+# Build libraries
 g++ -shared -fPIC -g v1.cpp -o libv1.so
-# (app.cpp reads Derived::value using v1 offsets)
-g++ -g -I. app.cpp -L. -lv1 -Wl,-rpath,. -o app
-./app
-# → value = 42  (correct)
+g++ -shared -fPIC -g v2.cpp -o libv2.so
 
-# Swap in new library (no recompile)
-g++ -shared -fPIC -g v2.cpp -o libv1.so
-./app
-# → value = <garbage>  (reads extra_field or padding instead of value)
-# → or: SIGSEGV if object is stack-allocated by caller
+# The size shift is immediately visible:
+python3 -c "
+import ctypes, subprocess, tempfile, os, sys
+
+# Quick check via abidw
+"
+
+abidw --out-file v1.abi libv1.so
+abidw --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+echo "exit: $?"   # → 4 (ABI change: base class data member added)
 ```
 
-**Why CRITICAL:** The `this`-pointer arithmetic baked into the caller's object code
-uses the old field offset. With v2, the same byte offset belongs to `extra_field`;
-`value` is four bytes further. No runtime error is raised — the program continues
-with a silently wrong value, leading to data corruption or hard-to-reproduce crashes.
-
 ## Reproduce manually
+
 ```bash
 g++ -shared -fPIC -g v1.cpp -o libv1.so
 g++ -shared -fPIC -g v2.cpp -o libv2.so
-abidw --out-file v1.xml libv1.so
-abidw --out-file v2.xml libv2.so
-abidiff v1.xml v2.xml
+abidw --headers-dir . --out-file v1.abi libv1.so
+abidw --headers-dir . --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
 echo "exit: $?"   # → 4
 ```
 
 ## How to fix
-Never add data members to a base class once the library is released. Alternatives:
 
-1. **Pimpl in Base** — put all implementation state in a `BaseImpl* pImpl_` pointer.
-   Adding members to `BaseImpl` is transparent to derived classes.
-2. **Reserve padding** — add `char _reserved[N]` at the end of `Base` to absorb
-   future members without shifting derived-class layouts (common in stable C++ ABIs).
-3. **New derived class** — introduce `EnhancedBase : Base` with the extra field;
-   existing `Derived` keeps its layout.
-4. **SONAME bump** — if the addition is unavoidable, bump the major version
-   (`libfoo.so.2`) and force recompilation of all consumers.
+Never add data members to a base class that has derived classes in the public API.
+Options:
+1. **Pimpl on Base** — put the new field in a private `Impl*` struct.
+2. **SONAME bump** — major version bump + abi_tag if breaking change is unavoidable.
+3. **Add to Derived, not Base** — if only one derived class needs the field.

--- a/examples/case43_base_class_member_added/README.md
+++ b/examples/case43_base_class_member_added/README.md
@@ -1,0 +1,76 @@
+# Case 43: Base Class Member Added
+
+**Category:** C++ Layout | **Verdict:** 🔴 BREAKING
+
+## What breaks
+A data member (`int extra_field`) is added to `Base`. Because `Derived` inherits from
+`Base`, all fields declared in `Derived` are pushed to higher offsets — `Derived::value`
+shifts by 4 bytes. Any code compiled against v1 that reads or writes `Derived::value`
+through a v2 `.so` will access the wrong memory location.
+
+The change propagates silently: the mangled symbol for `Derived::process()` is
+unchanged, so `nm` and simple symbol checks show no breakage. Only a layout-aware
+tool catches it.
+
+## Why abidiff catches it
+abidiff reads DWARF debug info and detects that `sizeof(Base)` grew and that
+`Derived::value`'s byte offset changed. It reports:
+
+- `TYPE_SIZE_CHANGED` on `Base` (8 → 12 bytes)
+- `TYPE_FIELD_OFFSET_CHANGED` on `Derived::value` (offset 8 → 12)
+- Exit code **4** (ABI change detected, non-symbol-removal break)
+
+## Code diff
+
+| v1.hpp | v2.hpp |
+|--------|--------|
+| `class Base { int base_id; virtual void describe(); };` | `class Base { int base_id; int extra_field; virtual void describe(); };` |
+| `class Derived : public Base { int value; void process(); };` | *(layout shifts — `value` now at offset +12 instead of +8)* |
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile app against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build old library + app
+g++ -shared -fPIC -g v1.cpp -o libv1.so
+# (app.cpp reads Derived::value using v1 offsets)
+g++ -g -I. app.cpp -L. -lv1 -Wl,-rpath,. -o app
+./app
+# → value = 42  (correct)
+
+# Swap in new library (no recompile)
+g++ -shared -fPIC -g v2.cpp -o libv1.so
+./app
+# → value = <garbage>  (reads extra_field or padding instead of value)
+# → or: SIGSEGV if object is stack-allocated by caller
+```
+
+**Why CRITICAL:** The `this`-pointer arithmetic baked into the caller's object code
+uses the old field offset. With v2, the same byte offset belongs to `extra_field`;
+`value` is four bytes further. No runtime error is raised — the program continues
+with a silently wrong value, leading to data corruption or hard-to-reproduce crashes.
+
+## Reproduce manually
+```bash
+g++ -shared -fPIC -g v1.cpp -o libv1.so
+g++ -shared -fPIC -g v2.cpp -o libv2.so
+abidw --out-file v1.xml libv1.so
+abidw --out-file v2.xml libv2.so
+abidiff v1.xml v2.xml
+echo "exit: $?"   # → 4
+```
+
+## How to fix
+Never add data members to a base class once the library is released. Alternatives:
+
+1. **Pimpl in Base** — put all implementation state in a `BaseImpl* pImpl_` pointer.
+   Adding members to `BaseImpl` is transparent to derived classes.
+2. **Reserve padding** — add `char _reserved[N]` at the end of `Base` to absorb
+   future members without shifting derived-class layouts (common in stable C++ ABIs).
+3. **New derived class** — introduce `EnhancedBase : Base` with the extra field;
+   existing `Derived` keeps its layout.
+4. **SONAME bump** — if the addition is unavoidable, bump the major version
+   (`libfoo.so.2`) and force recompilation of all consumers.

--- a/examples/case43_base_class_member_added/README.md
+++ b/examples/case43_base_class_member_added/README.md
@@ -21,7 +21,7 @@ abicheck detects: `TYPE_SIZE_CHANGED` on `Base`, `TYPE_FIELD_OFFSET_CHANGED` on 
 |--------|--------|
 | `class Base { int base_id; ... };` | `class Base { int base_id; int extra_field; ... };` |
 | `class Derived : public Base { int value; };` | `class Derived : public Base { int value; };` |
-| `sizeof(Derived)` ≈ 20 bytes | `sizeof(Derived)` ≈ 24 bytes — `value` shifts by 4 |
+| `sizeof(Derived)=16`, `Derived::value` @ offset 12 | `sizeof(Derived)=24`, `Derived::value` shifts to offset 16 (+4 bytes) |
 
 ## Real Failure Demo
 

--- a/examples/case44_cyclic_type_member_added/README.md
+++ b/examples/case44_cyclic_type_member_added/README.md
@@ -3,71 +3,54 @@
 **Category:** Struct Layout | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-`Node` is a self-referential linked-list struct: it contains a pointer to itself
-(`struct Node *next`). A new `long priority` field is added in v2. On a 64-bit
-system the existing padding between `flags` and `next` is consumed, growing
-`sizeof(Node)` from 16 to 24 bytes.
 
-`node_sum()` accepts `Node` **by value** — so the struct size is directly part of
-the calling convention. Callers compiled with v1 push 16 bytes onto the stack;
-the v2 library reads 24 bytes, interpreting stack garbage as `priority`.
+A `long priority` field is added to a self-referential linked-list `Node` struct.
+On 64-bit systems, the existing padding is consumed and `sizeof(Node)` grows from
+**16 → 24 bytes**. Because `node_sum()` accepts `Node` **by value**, the size is
+directly part of the ABI calling convention — callers compiled against v1 pass
+a 16-byte struct on the stack while the v2 function expects 24 bytes.
 
 ## Why abidiff catches it
-abidiff reads DWARF and detects the size increase on the cyclic type:
 
-- `TYPE_SIZE_CHANGED` on `Node` (16 → 24 bytes on 64-bit)
-- `TYPE_FIELD_ADDED`: `long priority` at offset 8
-- Exit code **4** (ABI change, non-removal break)
-
-The cyclic pointer (`Node *next`) does not confuse abidiff — it resolves the
-recursion and still correctly reports the outer-struct size change.
+abidiff reports `Added_Non_Virtual_Member_Variable` and exits **4**.
+abicheck detects: `TYPE_SIZE_CHANGED` (Node: 16→24 bytes).
 
 ## Code diff
 
 | v1.h | v2.h |
 |------|------|
-| `typedef struct Node { int data; int flags; struct Node *next; } Node;` | `typedef struct Node { int data; int flags; long priority; struct Node *next; } Node;` |
-| `sizeof(Node) == 16` (on 64-bit) | `sizeof(Node) == 24` (+8 bytes) |
+| `struct Node { int data; int flags; struct Node *next; }` | `struct Node { int data; int flags; long priority; struct Node *next; }` |
+| `int node_sum(Node n);` — by value, 16 bytes | `int node_sum(Node n);` — by value, 24 bytes |
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: 🔴 CRITICAL**
 
-**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
+**Scenario:** compile app against v1, run with v2 `.so` — stack corruption due to by-value size mismatch.
 
-```bash
-# Build v1 library + caller
-gcc -shared -fPIC -g v1.c -o libv1.so
-gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
-./app
-# → sum = 3  (correct)
-
-# Swap in v2 library (no recompile)
-gcc -shared -fPIC -g v2.c -o libv1.so
-./app
-# → sum = <wrong> or crash: by-value arg passes 16-byte frame, lib reads 24 bytes
-```
-
-**Why CRITICAL:** The by-value call passes `sizeof(Node)` bytes as determined at
-compile time. The v2 function reads past the caller's stack frame to access
-`priority`, producing an arbitrary value or a stack-smashing crash.
-
-## Reproduce manually
 ```bash
 gcc -shared -fPIC -g v1.c -o libv1.so
 gcc -shared -fPIC -g v2.c -o libv2.so
-abidw --out-file v1.xml libv1.so
-abidw --out-file v2.xml libv2.so
-abidiff v1.xml v2.xml
-echo "exit: $?"   # → 4
+
+abidw --out-file v1.abi libv1.so
+abidw --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+echo "exit: $?"   # → 4 (TYPE_SIZE_CHANGED)
+```
+
+## Reproduce manually
+
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --headers-dir . --out-file v1.abi libv1.so
+abidw --headers-dir . --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
 ```
 
 ## How to fix
-1. **Never pass structs by value in public APIs.** Use pointers (`Node *`) so the
-   caller never needs to know `sizeof(Node)`.
-2. **Opaque handle pattern** — expose only `Node *` and keep the struct definition
-   in the `.c` file (not the header).
-3. **Reserve padding** — add `char _reserved[8]` to absorb one extra field without
-   changing the size.
-4. **SONAME bump** — if the change is unavoidable and by-value is required, bump
-   the major version and force recompilation.
+
+Avoid by-value passing of structs in public API:
+1. **Pass by pointer** — `int node_sum(const Node *n)` — pointer size is stable.
+2. **Opaque handle** — hide `Node` behind a typedef to an incomplete struct.
+3. **Version bump** — if by-value semantics are required, bump SONAME.

--- a/examples/case44_cyclic_type_member_added/README.md
+++ b/examples/case44_cyclic_type_member_added/README.md
@@ -1,0 +1,73 @@
+# Case 44: Cyclic Type Member Added
+
+**Category:** Struct Layout | **Verdict:** 🔴 BREAKING
+
+## What breaks
+`Node` is a self-referential linked-list struct: it contains a pointer to itself
+(`struct Node *next`). A new `long priority` field is added in v2. On a 64-bit
+system the existing padding between `flags` and `next` is consumed, growing
+`sizeof(Node)` from 16 to 24 bytes.
+
+`node_sum()` accepts `Node` **by value** — so the struct size is directly part of
+the calling convention. Callers compiled with v1 push 16 bytes onto the stack;
+the v2 library reads 24 bytes, interpreting stack garbage as `priority`.
+
+## Why abidiff catches it
+abidiff reads DWARF and detects the size increase on the cyclic type:
+
+- `TYPE_SIZE_CHANGED` on `Node` (16 → 24 bytes on 64-bit)
+- `TYPE_FIELD_ADDED`: `long priority` at offset 8
+- Exit code **4** (ABI change, non-removal break)
+
+The cyclic pointer (`Node *next`) does not confuse abidiff — it resolves the
+recursion and still correctly reports the outer-struct size change.
+
+## Code diff
+
+| v1.h | v2.h |
+|------|------|
+| `typedef struct Node { int data; int flags; struct Node *next; } Node;` | `typedef struct Node { int data; int flags; long priority; struct Node *next; } Node;` |
+| `sizeof(Node) == 16` (on 64-bit) | `sizeof(Node) == 24` (+8 bytes) |
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build v1 library + caller
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
+./app
+# → sum = 3  (correct)
+
+# Swap in v2 library (no recompile)
+gcc -shared -fPIC -g v2.c -o libv1.so
+./app
+# → sum = <wrong> or crash: by-value arg passes 16-byte frame, lib reads 24 bytes
+```
+
+**Why CRITICAL:** The by-value call passes `sizeof(Node)` bytes as determined at
+compile time. The v2 function reads past the caller's stack frame to access
+`priority`, producing an arbitrary value or a stack-smashing crash.
+
+## Reproduce manually
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --out-file v1.xml libv1.so
+abidw --out-file v2.xml libv2.so
+abidiff v1.xml v2.xml
+echo "exit: $?"   # → 4
+```
+
+## How to fix
+1. **Never pass structs by value in public APIs.** Use pointers (`Node *`) so the
+   caller never needs to know `sizeof(Node)`.
+2. **Opaque handle pattern** — expose only `Node *` and keep the struct definition
+   in the `.c` file (not the header).
+3. **Reserve padding** — add `char _reserved[8]` to absorb one extra field without
+   changing the size.
+4. **SONAME bump** — if the change is unavoidable and by-value is required, bump
+   the major version and force recompilation.

--- a/examples/case45_multi_dim_array_change/README.md
+++ b/examples/case45_multi_dim_array_change/README.md
@@ -3,74 +3,51 @@
 **Category:** Struct Layout | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-`Matrix.data` changes from `float[4][4]` to `double[4][4]`. The element type doubles
-in size (4 → 8 bytes), so the array grows from 64 bytes to 128 bytes. Because `data`
-is the first member of `Matrix`, every subsequent field (`rows`, `cols`) shifts by
-64 bytes. Any caller that accesses `rows`, `cols`, or individual array elements
-through a stale v1-compiled binary reads completely wrong memory.
 
-Additionally, the return type of `matrix_get()` changes from `float` to `double`,
-which alters the calling convention on some architectures (different floating-point
-registers).
+The `Matrix` struct contains a 2D array member `data[ROWS][COLS]`. Its element type
+changes from `float` (4 bytes) to `double` (8 bytes), so `sizeof(Matrix)` doubles
+from **72 → 136 bytes** (`4×4×4 + 8 = 72` → `4×4×8 + 8 = 136`). Any consumer
+compiled against v1 headers will read/write the struct at the wrong offsets.
+Return types of `matrix_get()`/`matrix_set()` also change.
 
 ## Why abidiff catches it
-abidiff detects the element-type change within the multi-dimensional array sub-ranges:
 
-- `TYPE_SIZE_CHANGED` on `Matrix` (72 → 136 bytes)
-- `TYPE_FIELD_TYPE_CHANGED` on `data` (element type `float` → `double`)
-- `TYPE_FIELD_OFFSET_CHANGED` on `rows` and `cols` (offset shifts by 64 bytes)
-- `FUNC_RETURN_CHANGED` on `matrix_get` (`float` → `double`)
-- Exit code **4** (ABI change detected)
+abidiff reports `Subrange_Change` in multi-dim array and exits **4**.
+abicheck detects: `TYPE_SIZE_CHANGED`, `TYPE_FIELD_TYPE_CHANGED`, `FUNC_RETURN_CHANGED`.
 
 ## Code diff
 
 | v1.h | v2.h |
 |------|------|
-| `float data[ROWS][COLS];` (64 bytes) | `double data[ROWS][COLS];` (128 bytes) |
-| `float matrix_get(const Matrix *m, int r, int c);` | `double matrix_get(const Matrix *m, int r, int c);` |
-| `sizeof(Matrix) == 72` | `sizeof(Matrix) == 136` |
+| `float data[4][4];` — 64 bytes | `double data[4][4];` — 128 bytes |
+| `float matrix_get(...)` | `double matrix_get(...)` |
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: 🔴 CRITICAL**
 
-**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
-
-```bash
-# Build v1 library + caller
-gcc -shared -fPIC -g v1.c -o libv1.so
-gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
-./app
-# → m.rows = 4, m.cols = 4, get(0,0) = 1.5  (correct)
-
-# Swap in v2 library (no recompile)
-gcc -shared -fPIC -g v2.c -o libv1.so
-./app
-# → m.rows = <garbage>, get(0,0) = NaN or wrong value
-# → caller passes float-sized buffer; lib reads as double, crosses field boundaries
-```
-
-**Why CRITICAL:** The caller allocates `Matrix` with `sizeof(Matrix)` baked in at
-compile time (72 bytes). The library treats the pointer as pointing to a 136-byte
-struct. Reading `rows` reads 64 bytes past the expected array end, hitting either
-uninitialised memory or another variable entirely.
-
-## Reproduce manually
 ```bash
 gcc -shared -fPIC -g v1.c -o libv1.so
 gcc -shared -fPIC -g v2.c -o libv2.so
-abidw --out-file v1.xml libv1.so
-abidw --out-file v2.xml libv2.so
-abidiff v1.xml v2.xml
-echo "exit: $?"   # → 4
+
+abidw --out-file v1.abi libv1.so
+abidw --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+echo "exit: $?"   # → 4 (TYPE_SIZE_CHANGED + FUNC_RETURN_CHANGED)
+```
+
+## Reproduce manually
+
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --headers-dir . --out-file v1.abi libv1.so
+abidw --headers-dir . --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
 ```
 
 ## How to fix
-1. **Do not expose array element types in public structs.** Use an opaque handle or
-   pointer to an incomplete type; resize internally.
-2. **Template / generic matrix** — if the precision must be configurable, use a
-   separate type (`FloatMatrix` / `DoubleMatrix`) and never change an existing one.
-3. **Versioned struct** — introduce `Matrix_v2` with the new layout; keep `Matrix`
-   (v1) for backward compatibility, provide conversion helpers.
-4. **SONAME bump** — if the change is unavoidable, bump the major version and require
-   consumer recompilation.
+
+1. **Abstract the element type** via a typedef: `typedef float mat_elem_t;` — change the typedef, not the struct directly.
+2. **Version via SONAME** — element type changes in matrix structs require a major version bump.
+3. **Provide both** `matrix_float_get()` and `matrix_double_get()` during a deprecation window.

--- a/examples/case45_multi_dim_array_change/README.md
+++ b/examples/case45_multi_dim_array_change/README.md
@@ -1,0 +1,76 @@
+# Case 45: Multi-Dimensional Array Element Type Change
+
+**Category:** Struct Layout | **Verdict:** 🔴 BREAKING
+
+## What breaks
+`Matrix.data` changes from `float[4][4]` to `double[4][4]`. The element type doubles
+in size (4 → 8 bytes), so the array grows from 64 bytes to 128 bytes. Because `data`
+is the first member of `Matrix`, every subsequent field (`rows`, `cols`) shifts by
+64 bytes. Any caller that accesses `rows`, `cols`, or individual array elements
+through a stale v1-compiled binary reads completely wrong memory.
+
+Additionally, the return type of `matrix_get()` changes from `float` to `double`,
+which alters the calling convention on some architectures (different floating-point
+registers).
+
+## Why abidiff catches it
+abidiff detects the element-type change within the multi-dimensional array sub-ranges:
+
+- `TYPE_SIZE_CHANGED` on `Matrix` (72 → 136 bytes)
+- `TYPE_FIELD_TYPE_CHANGED` on `data` (element type `float` → `double`)
+- `TYPE_FIELD_OFFSET_CHANGED` on `rows` and `cols` (offset shifts by 64 bytes)
+- `FUNC_RETURN_CHANGED` on `matrix_get` (`float` → `double`)
+- Exit code **4** (ABI change detected)
+
+## Code diff
+
+| v1.h | v2.h |
+|------|------|
+| `float data[ROWS][COLS];` (64 bytes) | `double data[ROWS][COLS];` (128 bytes) |
+| `float matrix_get(const Matrix *m, int r, int c);` | `double matrix_get(const Matrix *m, int r, int c);` |
+| `sizeof(Matrix) == 72` | `sizeof(Matrix) == 136` |
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build v1 library + caller
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
+./app
+# → m.rows = 4, m.cols = 4, get(0,0) = 1.5  (correct)
+
+# Swap in v2 library (no recompile)
+gcc -shared -fPIC -g v2.c -o libv1.so
+./app
+# → m.rows = <garbage>, get(0,0) = NaN or wrong value
+# → caller passes float-sized buffer; lib reads as double, crosses field boundaries
+```
+
+**Why CRITICAL:** The caller allocates `Matrix` with `sizeof(Matrix)` baked in at
+compile time (72 bytes). The library treats the pointer as pointing to a 136-byte
+struct. Reading `rows` reads 64 bytes past the expected array end, hitting either
+uninitialised memory or another variable entirely.
+
+## Reproduce manually
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --out-file v1.xml libv1.so
+abidw --out-file v2.xml libv2.so
+abidiff v1.xml v2.xml
+echo "exit: $?"   # → 4
+```
+
+## How to fix
+1. **Do not expose array element types in public structs.** Use an opaque handle or
+   pointer to an incomplete type; resize internally.
+2. **Template / generic matrix** — if the precision must be configurable, use a
+   separate type (`FloatMatrix` / `DoubleMatrix`) and never change an existing one.
+3. **Versioned struct** — introduce `Matrix_v2` with the new layout; keep `Matrix`
+   (v1) for backward compatibility, provide conversion helpers.
+4. **SONAME bump** — if the change is unavoidable, bump the major version and require
+   consumer recompilation.

--- a/examples/case46_pointer_chain_type_change/README.md
+++ b/examples/case46_pointer_chain_type_change/README.md
@@ -1,0 +1,75 @@
+# Case 46: Pointer Chain Type Change
+
+**Category:** Function Signature | **Verdict:** 🔴 BREAKING
+
+## What breaks
+`get_matrix()` returns `int **` in v1 and `long **` in v2. The ultimate pointee type
+changes from `int` (4 bytes) to `long` (8 bytes on 64-bit). Callers that dereference
+the double-indirect pointer chain and read individual elements interpret each 8-byte
+`long` as a 4-byte `int`, reading only half the value and mistaking the next element's
+bytes for a separate cell.
+
+`set_cell()` and `sum_row()` also change their pointer-chain parameter types and return
+types along the same `int` → `long` axis.
+
+## Why abidiff catches it
+abidiff walks the full pointer chain in the DWARF/castxml type graph and detects the
+ultimate pointee-type change:
+
+- `FUNC_RETURN_CHANGED` on `get_matrix` (`int **` → `long **`)
+- `PARAM_TYPE_CHANGED` on `set_cell` and `sum_row` (pointer params `int *const *` → `long *const *`)
+- `FUNC_RETURN_CHANGED` on `sum_row` (`int` → `long`)
+- Exit code **4** (ABI change detected)
+
+## Code diff
+
+| v1.h | v2.h |
+|------|------|
+| `int **get_matrix(void);` | `long **get_matrix(void);` |
+| `void set_cell(int *const *matrix, int row, int col, int val);` | `void set_cell(long *const *matrix, int row, int col, long val);` |
+| `int sum_row(int *const *matrix, int row, int cols);` | `long sum_row(long *const *matrix, int row, int cols);` |
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build v1 library + caller
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
+./app
+# → sum_row(0) = 6  (correct for int row [1,2,3])
+
+# Swap in v2 library (no recompile)
+gcc -shared -fPIC -g v2.c -o libv1.so
+./app
+# → sum_row(0) = 0 or garbage: int-sized reads over long-sized array elements
+# → or: SIGSEGV if pointer alignment breaks
+```
+
+**Why CRITICAL:** The caller's dereferencing code treats each element as `sizeof(int)`
+(4 bytes) while the library writes them as `sizeof(long)` (8 bytes). Every second read
+lands in padding or the next element, producing wrong sums and potentially corrupting
+memory if `set_cell()` writes with the wrong stride.
+
+## Reproduce manually
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --out-file v1.xml libv1.so
+abidw --out-file v2.xml libv2.so
+abidiff v1.xml v2.xml
+echo "exit: $?"   # → 4
+```
+
+## How to fix
+1. **Use fixed-width types** in public APIs (`int32_t`, `int64_t` from `<stdint.h>`)
+   and never change them — platform-size types like `long` vary across ABIs.
+2. **Opaque handle / stride parameter** — pass an opaque handle plus an explicit
+   element-size argument so the pointee type is decoupled from the ABI.
+3. **New symbol name** — introduce `get_matrix_l()` returning `long **`; keep
+   `get_matrix()` returning `int **` for backward compatibility.
+4. **SONAME bump** — if the signature must change, bump the major version and force
+   recompilation of all consumers.

--- a/examples/case46_pointer_chain_type_change/README.md
+++ b/examples/case46_pointer_chain_type_change/README.md
@@ -1,25 +1,18 @@
 # Case 46: Pointer Chain Type Change
 
-**Category:** Function Signature | **Verdict:** 🔴 BREAKING
+**Category:** Breaking | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-`get_matrix()` returns `int **` in v1 and `long **` in v2. The ultimate pointee type
-changes from `int` (4 bytes) to `long` (8 bytes on 64-bit). Callers that dereference
-the double-indirect pointer chain and read individual elements interpret each 8-byte
-`long` as a 4-byte `int`, reading only half the value and mistaking the next element's
-bytes for a separate cell.
 
-`set_cell()` and `sum_row()` also change their pointer-chain parameter types and return
-types along the same `int` → `long` axis.
+Functions return `int**` and accept `int*const*` in v1. In v2, the ultimate pointee
+type changes from `int` to `long`. Callers that dereference the returned pointer chain
+and write `int`-sized values will corrupt memory — `long` is 8 bytes on 64-bit,
+`int` is 4 bytes, so every write is half the expected size.
 
 ## Why abidiff catches it
-abidiff walks the full pointer chain in the DWARF/castxml type graph and detects the
-ultimate pointee-type change:
 
-- `FUNC_RETURN_CHANGED` on `get_matrix` (`int **` → `long **`)
-- `PARAM_TYPE_CHANGED` on `set_cell` and `sum_row` (pointer params `int *const *` → `long *const *`)
-- `FUNC_RETURN_CHANGED` on `sum_row` (`int` → `long`)
-- Exit code **4** (ABI change detected)
+abidiff reports `Function_Return_Type_Change` (indirect pointee type) and exits **4**.
+abicheck detects: `FUNC_RETURN_CHANGED`, `PARAM_TYPE_CHANGED`.
 
 ## Code diff
 
@@ -31,45 +24,32 @@ ultimate pointee-type change:
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: 🔴 CRITICAL — silent memory corruption**
 
-**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
+**Scenario:** v1 caller writes `int` values into memory allocated for `long` — adjacent cells are overwritten.
 
-```bash
-# Build v1 library + caller
-gcc -shared -fPIC -g v1.c -o libv1.so
-gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
-./app
-# → sum_row(0) = 6  (correct for int row [1,2,3])
-
-# Swap in v2 library (no recompile)
-gcc -shared -fPIC -g v2.c -o libv1.so
-./app
-# → sum_row(0) = 0 or garbage: int-sized reads over long-sized array elements
-# → or: SIGSEGV if pointer alignment breaks
-```
-
-**Why CRITICAL:** The caller's dereferencing code treats each element as `sizeof(int)`
-(4 bytes) while the library writes them as `sizeof(long)` (8 bytes). Every second read
-lands in padding or the next element, producing wrong sums and potentially corrupting
-memory if `set_cell()` writes with the wrong stride.
-
-## Reproduce manually
 ```bash
 gcc -shared -fPIC -g v1.c -o libv1.so
 gcc -shared -fPIC -g v2.c -o libv2.so
-abidw --out-file v1.xml libv1.so
-abidw --out-file v2.xml libv2.so
-abidiff v1.xml v2.xml
-echo "exit: $?"   # → 4
+
+abidw --out-file v1.abi libv1.so
+abidw --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+echo "exit: $?"   # → 4 (FUNC_RETURN_CHANGED)
+```
+
+## Reproduce manually
+
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --headers-dir . --out-file v1.abi libv1.so
+abidw --headers-dir . --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
 ```
 
 ## How to fix
-1. **Use fixed-width types** in public APIs (`int32_t`, `int64_t` from `<stdint.h>`)
-   and never change them — platform-size types like `long` vary across ABIs.
-2. **Opaque handle / stride parameter** — pass an opaque handle plus an explicit
-   element-size argument so the pointee type is decoupled from the ABI.
-3. **New symbol name** — introduce `get_matrix_l()` returning `long **`; keep
-   `get_matrix()` returning `int **` for backward compatibility.
-4. **SONAME bump** — if the signature must change, bump the major version and force
-   recompilation of all consumers.
+
+1. **Opaque element type**: `typedef int mat_cell_t;` at the API boundary — change only the typedef.
+2. **Never change primitive types deep in pointer chains** — consumers are forced to cast through every level.
+3. **SONAME bump** if the type change is unavoidable.

--- a/examples/case47_inline_to_outlined/README.md
+++ b/examples/case47_inline_to_outlined/README.md
@@ -1,0 +1,78 @@
+# Case 47: Inline to Outlined Function
+
+**Category:** C++ Symbol | **Verdict:** 🟢 COMPATIBLE
+
+## What breaks
+Nothing breaks at the binary level — this is a **compatible extension**.
+
+In v1, `Calculator::add()` is defined `inline` in the header: the compiler emits the
+body directly at every call site, and no exported symbol exists in `libv1.so`. In v2,
+`add()` is moved out-of-line to `v2.cpp` and its symbol (`_ZN10Calculator3addEii`) is
+now exported from `libv2.so`.
+
+Existing binaries compiled against v1 already have the `add()` body inlined — they
+never call the symbol, so the new export is invisible to them. New code compiled
+against v2 calls the outlined version. Both coexist safely.
+
+The subtle risk is in the **reverse** direction: if v1 headers are accidentally used
+with a v2 library that inlines a different body, there is a One-Definition Rule (ODR)
+violation. That scenario requires a header downgrade and is not present here.
+
+## Why abidiff catches it
+abidiff detects the new exported symbol:
+
+- `FUNC_ADDED`: `Calculator::add(int, int)` appears in v2's `.dynsym`
+- Exit code **4** (ABI change detected — addition, not removal)
+
+Because the verdict is `FUNC_ADDED` (not `FUNC_REMOVED`), abicheck classifies this
+as **COMPATIBLE**: the addition is a backward-compatible extension.
+
+## Code diff
+
+| v1.hpp | v2.hpp |
+|--------|--------|
+| `inline int add(int a, int b) { return a + b; }` | `int add(int a, int b);` *(outlined in v2.cpp)* |
+| *(no exported symbol)* | `_ZN10Calculator3addEii` exported |
+
+## Real Failure Demo
+
+**Severity: BASELINE** (no breakage expected)
+
+```bash
+# Build v1 library + app
+g++ -shared -fPIC -g v1.cpp -o libv1.so
+g++ -g -I. app.cpp -L. -lv1 -Wl,-rpath,. -o app
+./app
+# → add(3,4) = 7  (inline body in app)
+
+# Swap in v2 library (no recompile)
+g++ -shared -fPIC -g v2.cpp -o libv1.so
+./app
+# → add(3,4) = 7  (still uses inlined v1 body — no symbol lookup needed)
+# → no crash, no wrong output
+```
+
+**Why BASELINE:** The inlined call site in the app binary does not resolve `add`
+via the dynamic linker. Swapping the library has no effect on the already-inlined
+computation.
+
+## Reproduce manually
+```bash
+g++ -shared -fPIC -g v1.cpp -o libv1.so
+g++ -shared -fPIC -g v2.cpp -o libv2.so
+abidw --out-file v1.xml libv1.so
+abidw --out-file v2.xml libv2.so
+abidiff v1.xml v2.xml
+echo "exit: $?"   # → 4 (FUNC_ADDED — compatible)
+```
+
+## How to fix
+No fix required — this change is compatible. However, be aware of:
+
+1. **ODR risk** — if you later move the inline *back* to the header with a different
+   body, consumers that still have the old outlined symbol in their link path may
+   call the wrong version. Document the change in release notes.
+2. **Debug-info drift** — consumers that relied on the inlined form for debugging
+   will now step into the library instead. This is usually desirable.
+3. **Consider `[[deprecated]]` + new name** if the move is part of a broader refactor
+   to make the function testable or mockable.

--- a/examples/case47_inline_to_outlined/README.md
+++ b/examples/case47_inline_to_outlined/README.md
@@ -1,78 +1,55 @@
-# Case 47: Inline to Outlined Function
+# Case 47: Inline Function Moved to Outlined
 
-**Category:** C++ Symbol | **Verdict:** 🟢 COMPATIBLE
+**Category:** Compatible | **Verdict:** 🟢 COMPATIBLE
 
-## What breaks
-Nothing breaks at the binary level — this is a **compatible extension**.
+## What does NOT break
 
-In v1, `Calculator::add()` is defined `inline` in the header: the compiler emits the
-body directly at every call site, and no exported symbol exists in `libv1.so`. In v2,
-`add()` is moved out-of-line to `v2.cpp` and its symbol (`_ZN10Calculator3addEii`) is
-now exported from `libv2.so`.
+In v1, `Calculator::add()` is defined `inline` in the header — no exported symbol.
+In v2, it is moved out-of-line — the symbol is now exported from the `.so`.
 
-Existing binaries compiled against v1 already have the `add()` body inlined — they
-never call the symbol, so the new export is invisible to them. New code compiled
-against v2 calls the outlined version. Both coexist safely.
+Consumers compiled against v1 already have the inlined body baked into their binary.
+Consumers compiled against v2 will call the exported symbol. Both work correctly.
+No existing binary breaks — this is a **FUNC_ADDED** (compatible extension).
 
-The subtle risk is in the **reverse** direction: if v1 headers are accidentally used
-with a v2 library that inlines a different body, there is a One-Definition Rule (ODR)
-violation. That scenario requires a header downgrade and is not present here.
+## Why abidiff sees it as compatible
 
-## Why abidiff catches it
-abidiff detects the new exported symbol:
-
-- `FUNC_ADDED`: `Calculator::add(int, int)` appears in v2's `.dynsym`
-- Exit code **4** (ABI change detected — addition, not removal)
-
-Because the verdict is `FUNC_ADDED` (not `FUNC_REMOVED`), abicheck classifies this
-as **COMPATIBLE**: the addition is a backward-compatible extension.
+abidiff reports `Function_Symbol_Added` and exits **4** (change detected), but the
+change kind is additive. abicheck classifies as `COMPATIBLE` (FUNC_ADDED).
 
 ## Code diff
 
 | v1.hpp | v2.hpp |
 |--------|--------|
-| `inline int add(int a, int b) { return a + b; }` | `int add(int a, int b);` *(outlined in v2.cpp)* |
-| *(no exported symbol)* | `_ZN10Calculator3addEii` exported |
+| `inline int add(int a, int b) { return a + b; }` | `int add(int a, int b);` — definition in v2.cpp |
+| No exported symbol for `add` | Symbol `_ZN10Calculator3addEii` now exported |
 
 ## Real Failure Demo
 
-**Severity: BASELINE** (no breakage expected)
+**Severity: ✅ BASELINE — no failure**
 
-```bash
-# Build v1 library + app
-g++ -shared -fPIC -g v1.cpp -o libv1.so
-g++ -g -I. app.cpp -L. -lv1 -Wl,-rpath,. -o app
-./app
-# → add(3,4) = 7  (inline body in app)
-
-# Swap in v2 library (no recompile)
-g++ -shared -fPIC -g v2.cpp -o libv1.so
-./app
-# → add(3,4) = 7  (still uses inlined v1 body — no symbol lookup needed)
-# → no crash, no wrong output
-```
-
-**Why BASELINE:** The inlined call site in the app binary does not resolve `add`
-via the dynamic linker. Swapping the library has no effect on the already-inlined
-computation.
-
-## Reproduce manually
 ```bash
 g++ -shared -fPIC -g v1.cpp -o libv1.so
 g++ -shared -fPIC -g v2.cpp -o libv2.so
-abidw --out-file v1.xml libv1.so
-abidw --out-file v2.xml libv2.so
-abidiff v1.xml v2.xml
-echo "exit: $?"   # → 4 (FUNC_ADDED — compatible)
+
+abidw --out-file v1.abi libv1.so
+abidw --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+echo "exit: $?"   # → 4 (FUNC_ADDED — change detected, but compatible)
+nm -D libv2.so | grep add   # → T _ZN10Calculator3addEii (now exported)
 ```
 
-## How to fix
-No fix required — this change is compatible. However, be aware of:
+## Reproduce manually
 
-1. **ODR risk** — if you later move the inline *back* to the header with a different
-   body, consumers that still have the old outlined symbol in their link path may
-   call the wrong version. Document the change in release notes.
-2. **Debug-info drift** — consumers that relied on the inlined form for debugging
-   will now step into the library instead. This is usually desirable.
-3. **Consider `[[deprecated]]` + new name** if the move is part of a broader refactor
-   to make the function testable or mockable.
+```bash
+g++ -shared -fPIC -g v1.cpp -o libv1.so
+g++ -shared -fPIC -g v2.cpp -o libv2.so
+abidw --headers-dir . --out-file v1.abi libv1.so
+abidw --headers-dir . --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+```
+
+## Why this is still a risk
+
+While ABI-compatible, moving inline→outlined is a **source-level change**: any
+consumer that relied on the inlined body being optimized away (e.g. in `constexpr`
+contexts or LTO-heavy builds) may see different behavior. Document the change.

--- a/examples/case48_leaf_struct_through_pointer/README.md
+++ b/examples/case48_leaf_struct_through_pointer/README.md
@@ -1,80 +1,61 @@
 # Case 48: Leaf Struct Change Propagated Through Pointer
 
-**Category:** Struct Layout | **Verdict:** 🔴 BREAKING
+**Category:** Breaking | **Verdict:** 🔴 BREAKING
 
 ## What breaks
-`Leaf` gains a new `int z` field, growing from 4 bytes to 8 bytes. `Leaf` is embedded
-(not pointed to) inside `Container` at offset 4. Because `Leaf` grew by 4 bytes,
-`Container::flags` shifts from offset 8 to offset 12, and `sizeof(Container)` grows
-from 12 to 16 bytes.
 
-The public API only takes `Container *` — no by-value `Container` or `Leaf` in any
-signature. But any caller that has `Container` on the stack (e.g. `Container c;
-container_init(&c, ...);`) allocates it with the v1 size (12 bytes). The v2 library
-writes `flags` 4 bytes further than the caller's allocation, overflowing the stack
-object and corrupting adjacent memory.
+A nested "leaf" struct `Leaf` gains a new `int z` field, growing from **4 → 8 bytes**.
+`Leaf` is embedded (not pointed to) inside `Container`, so `Container::flags` shifts
+from offset 8 to offset 16. The public API only takes `Container*` — no by-value
+`Leaf` in function signatures — but the size change propagates through the embedding.
+
+Callers compiled against v1 allocate `Container` with the old layout: passing such
+a struct to a v2 function causes `flags` to be read at the wrong offset.
 
 ## Why abidiff catches it
-abidiff follows the embedded `Leaf` type through `Container` and detects the cascading
-layout change:
 
-- `TYPE_SIZE_CHANGED` on `Leaf` (4 → 8 bytes)
-- `TYPE_FIELD_ADDED` on `Leaf`: `int z` at offset 4
-- `TYPE_SIZE_CHANGED` on `Container` (12 → 16 bytes)
-- `TYPE_FIELD_OFFSET_CHANGED` on `Container::flags` (offset 8 → 12)
-- Exit code **4** (ABI change detected)
+abidiff reports `Leaf_Type_Change` / `TYPE_SIZE_CHANGED` and exits **4**.
+abicheck detects: `TYPE_SIZE_CHANGED` on `Leaf` (4→8 bytes) propagates to `Container`.
 
 ## Code diff
 
 | v1.h | v2.h |
 |------|------|
-| `typedef struct Leaf { short x; short y; } Leaf;` (4 bytes) | `typedef struct Leaf { short x; short y; int z; } Leaf;` (8 bytes) |
-| `Container::flags` at byte offset 8 | `Container::flags` at byte offset 12 |
-| `sizeof(Container) == 12` | `sizeof(Container) == 16` |
+| `typedef struct Leaf { short x; short y; } Leaf;` — 4 bytes | `typedef struct Leaf { short x; short y; int z; } Leaf;` — 8 bytes |
+| `Container { int id; Leaf position; int flags; }` — `flags` at offset 8 | `Container { int id; Leaf position; int flags; }` — `flags` at offset 16 |
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: 🔴 CRITICAL — silent wrong-field reads**
 
-**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
-
-```bash
-# Build v1 library + caller
-gcc -shared -fPIC -g v1.c -o libv1.so
-gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
-./app
-# → flags = 7, position = (10, 20)  (correct)
-
-# Swap in v2 library (no recompile)
-gcc -shared -fPIC -g v2.c -o libv1.so
-./app
-# → flags = <garbage>: container_init() writes flags 4 bytes past the caller's 12-byte allocation
-# → or: SIGSEGV / stack corruption depending on surrounding variables
-```
-
-**Why CRITICAL:** The caller allocates a 12-byte `Container` (v1 layout). The v2
-`container_init()` writes `flags` at byte 12, which is outside the allocated 12-byte
-region — corrupting adjacent stack memory. This is a stack-buffer overflow caused
-purely by a leaf struct growing silently.
-
-## Reproduce manually
 ```bash
 gcc -shared -fPIC -g v1.c -o libv1.so
 gcc -shared -fPIC -g v2.c -o libv2.so
-abidw --out-file v1.xml libv1.so
-abidw --out-file v2.xml libv2.so
-abidiff v1.xml v2.xml
-echo "exit: $?"   # → 4
+
+abidw --out-file v1.abi libv1.so
+abidw --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
+echo "exit: $?"   # → 4 (TYPE_SIZE_CHANGED on Leaf → Container)
+```
+
+## Reproduce manually
+
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --headers-dir . --out-file v1.abi libv1.so
+abidw --headers-dir . --out-file v2.abi libv2.so
+abidiff v1.abi v2.abi
 ```
 
 ## How to fix
-1. **Pimpl for `Leaf`** — forward-declare `Leaf` in the public header and expose it
-   only as an opaque pointer; define it fully in the `.c` file. Adding fields to the
-   private definition does not affect `Container`'s public layout.
-2. **Reserve padding in `Leaf`** — add `char _reserved[4]` to absorb one future
-   `int`-sized field without changing the struct size.
-3. **Opaque accessor pattern** — instead of embedding `Leaf` by value in `Container`,
-   use `Leaf *position` (pointer). The pointer size (8 bytes on 64-bit) stays fixed
-   regardless of `Leaf`'s internals.
-4. **SONAME bump** — if the layout change is necessary and cannot be hidden, bump the
-   major version (`libfoo.so.2`) and require recompilation of all consumers.
+
+1. **Pimpl on Leaf** — replace embedded `Leaf` with `Leaf*` (pointer to incomplete type); size is pointer-stable.
+2. **Add field without breaking**: only possible if there is tail padding in the struct — verify with `pahole`.
+3. **SONAME bump** if embedding is required and the field is necessary.
+
+## Real-world pattern
+
+Intel TBB `tbb::task_arena` was embedded in oneDal public headers. When TBB changed
+`task_arena`'s internal layout, all oneDAL consumers were broken — same propagation
+mechanism as this case. See `case18_dependency_leak` for the external-library variant.

--- a/examples/case48_leaf_struct_through_pointer/README.md
+++ b/examples/case48_leaf_struct_through_pointer/README.md
@@ -1,0 +1,80 @@
+# Case 48: Leaf Struct Change Propagated Through Pointer
+
+**Category:** Struct Layout | **Verdict:** 🔴 BREAKING
+
+## What breaks
+`Leaf` gains a new `int z` field, growing from 4 bytes to 8 bytes. `Leaf` is embedded
+(not pointed to) inside `Container` at offset 4. Because `Leaf` grew by 4 bytes,
+`Container::flags` shifts from offset 8 to offset 12, and `sizeof(Container)` grows
+from 12 to 16 bytes.
+
+The public API only takes `Container *` — no by-value `Container` or `Leaf` in any
+signature. But any caller that has `Container` on the stack (e.g. `Container c;
+container_init(&c, ...);`) allocates it with the v1 size (12 bytes). The v2 library
+writes `flags` 4 bytes further than the caller's allocation, overflowing the stack
+object and corrupting adjacent memory.
+
+## Why abidiff catches it
+abidiff follows the embedded `Leaf` type through `Container` and detects the cascading
+layout change:
+
+- `TYPE_SIZE_CHANGED` on `Leaf` (4 → 8 bytes)
+- `TYPE_FIELD_ADDED` on `Leaf`: `int z` at offset 4
+- `TYPE_SIZE_CHANGED` on `Container` (12 → 16 bytes)
+- `TYPE_FIELD_OFFSET_CHANGED` on `Container::flags` (offset 8 → 12)
+- Exit code **4** (ABI change detected)
+
+## Code diff
+
+| v1.h | v2.h |
+|------|------|
+| `typedef struct Leaf { short x; short y; } Leaf;` (4 bytes) | `typedef struct Leaf { short x; short y; int z; } Leaf;` (8 bytes) |
+| `Container::flags` at byte offset 8 | `Container::flags` at byte offset 12 |
+| `sizeof(Container) == 12` | `sizeof(Container) == 16` |
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile caller against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build v1 library + caller
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -g -I. app.c -L. -lv1 -Wl,-rpath,. -o app
+./app
+# → flags = 7, position = (10, 20)  (correct)
+
+# Swap in v2 library (no recompile)
+gcc -shared -fPIC -g v2.c -o libv1.so
+./app
+# → flags = <garbage>: container_init() writes flags 4 bytes past the caller's 12-byte allocation
+# → or: SIGSEGV / stack corruption depending on surrounding variables
+```
+
+**Why CRITICAL:** The caller allocates a 12-byte `Container` (v1 layout). The v2
+`container_init()` writes `flags` at byte 12, which is outside the allocated 12-byte
+region — corrupting adjacent stack memory. This is a stack-buffer overflow caused
+purely by a leaf struct growing silently.
+
+## Reproduce manually
+```bash
+gcc -shared -fPIC -g v1.c -o libv1.so
+gcc -shared -fPIC -g v2.c -o libv2.so
+abidw --out-file v1.xml libv1.so
+abidw --out-file v2.xml libv2.so
+abidiff v1.xml v2.xml
+echo "exit: $?"   # → 4
+```
+
+## How to fix
+1. **Pimpl for `Leaf`** — forward-declare `Leaf` in the public header and expose it
+   only as an opaque pointer; define it fully in the `.c` file. Adding fields to the
+   private definition does not affect `Container`'s public layout.
+2. **Reserve padding in `Leaf`** — add `char _reserved[4]` to absorb one future
+   `int`-sized field without changing the struct size.
+3. **Opaque accessor pattern** — instead of embedding `Leaf` by value in `Container`,
+   use `Leaf *position` (pointer). The pointer size (8 bytes on 64-bit) stays fixed
+   regardless of `Leaf`'s internals.
+4. **SONAME bump** — if the layout change is necessary and cannot be hidden, bump the
+   major version (`libfoo.so.2`) and require recompilation of all consumers.


### PR DESCRIPTION
## Summary

- Added README.md for examples case43–case48 (6 new ABI scenario guides)
- Updated examples catalog from 42 → 48 cases with correct case index and verdicts
- Added Phase 2 Suppression Engine section to `docs/reference/architecture.md`
- Refreshed benchmark snapshot with results from fresh run on onedal-build
- Fixed case18 verdict in index table (was `COMPATIBLE`, correctly `BREAKING`)
- Restored `ground_truth.json` link in Case Index note

## New cases

| Case | Verdict | Change detected |
|------|---------|----------------|
| case43 — Base Class Member Added | 🔴 BREAKING | `TYPE_SIZE_CHANGED`, `TYPE_FIELD_OFFSET_CHANGED` |
| case44 — Cyclic Type Member Added | 🔴 BREAKING | `TYPE_SIZE_CHANGED` (Node 16→24 bytes, by-value) |
| case45 — Multi-Dim Array Change | 🔴 BREAKING | `TYPE_FIELD_TYPE_CHANGED` float→double, `FUNC_RETURN_CHANGED` |
| case46 — Pointer Chain Type Change | 🔴 BREAKING | `FUNC_RETURN_CHANGED`, `PARAM_TYPE_CHANGED` int**→long** |
| case47 — Inline to Outlined | 🟢 COMPATIBLE | `FUNC_ADDED` (new exported symbol, existing callers unaffected) |
| case48 — Leaf Struct Through Pointer | 🔴 BREAKING | `TYPE_SIZE_CHANGED` on Leaf propagates into Container |

## Benchmark (2026-03-11, 48-case suite, onedal-build)

| Tool | Correct / Scored | Accuracy |
|------|-----------------|---------|
| **abicheck (compare)** | **48/48** | **100%** |
| abicheck (compat) | 46/48 | 96% |
| abidiff | 12/48 | 25% |
| abidiff + headers | 12/48 | 25% |

## Validation

- `benchmark_comparison.py --skip-abicc --skip-compat` on onedal-build: all 48 cases pass
- Internal review: intel-arch + qa-checker — all actionable items addressed
- CodeRabbit actionable items addressed in c6faff5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Suppression Engine docs: rules, behavior (compiled patterns, first‑match semantics, audit trail), CLI/Python usage, and integration guidance.
  * Introduced Policy profiles (StrictABI, SdkVendor, PluginAbi) and updated compare workflow/output language to a suppression+policy-driven flow producing annotated changes and a PolicyResult.
  * Expanded case library from 42 to 48 (Cases 43–48 added; 42 reserved) and updated benchmark snapshots, ground‑truth references, per‑case verdicts, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->