### PR TITLE
feat(phase3): scope.platform filtering in SuppressionEngine

### DIFF
--- a/abicheck/core/pipeline.py
+++ b/abicheck/core/pipeline.py
@@ -18,7 +18,7 @@ Note: importing abicheck.core.pipeline does NOT import re2 / suppressions.
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from abicheck.core.corpus.normalizer import Normalizer
 from abicheck.core.diff.symbol_diff import diff_symbols
@@ -31,6 +31,29 @@ if TYPE_CHECKING:
     from abicheck.core.suppressions import SuppressionEngine, SuppressionRule
 
 _normalizer = Normalizer()
+
+# Valid platform values for scope.platform filtering (Phase 3).
+KNOWN_PLATFORMS: frozenset[str] = frozenset({"elf", "pe", "macho"})
+
+
+def detect_platform(snapshot: AbiSnapshot) -> Literal["elf", "pe", "macho"] | None:
+    """Detect the binary format platform from an AbiSnapshot.
+
+    Detection priority:
+    1. snapshot.platform if already set (explicit override by caller/dumper)
+    2. snapshot.elf is not None → "elf"
+    3. None (unknown — PE/MachO not yet implemented)
+
+    Returns the detected platform string or None if unknown.
+    """
+    if snapshot.platform is not None:
+        p = snapshot.platform
+        if p in KNOWN_PLATFORMS:
+            return p  # type: ignore[return-value]
+        return None
+    if snapshot.elf is not None:
+        return "elf"
+    return None
 
 
 def analyse(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
@@ -61,11 +84,18 @@ def analyse_full(
     policy: str = "strict_abi",
     engine: SuppressionEngine | None = None,
 ) -> PolicyResult:
-    """Run the full v0.2 pipeline: diff → suppress → policy → PolicyResult."""
+    """Run the full v0.2 pipeline: diff → suppress → policy → PolicyResult.
+
+    Platform context is auto-detected from the 'new' snapshot and passed to
+    the suppression engine for scope.platform filtering (Phase 3).
+    """
     from abicheck.core.policy import get_profile  # noqa: PLC0415
     from abicheck.core.suppressions import SuppressionEngine as _Engine  # noqa: PLC0415
 
     changes = analyse(old, new)
+
+    # Phase 3: auto-detect platform from snapshot for suppression scope filtering.
+    platform = detect_platform(new) or detect_platform(old)
 
     if engine is None:
         engine = _Engine(rules or [])
@@ -76,7 +106,7 @@ def analyse_full(
             stacklevel=2,
         )
 
-    sup_result = engine.apply(changes)
+    sup_result = engine.apply(changes, platform_context=platform)
 
     all_changes = sorted(
         sup_result.active + sup_result.suppressed,

--- a/abicheck/core/pipeline.py
+++ b/abicheck/core/pipeline.py
@@ -86,8 +86,10 @@ def analyse_full(
 ) -> PolicyResult:
     """Run the full v0.2 pipeline: diff → suppress → policy → PolicyResult.
 
-    Platform context is auto-detected from the 'new' snapshot and passed to
-    the suppression engine for scope.platform filtering (Phase 3).
+    Platform context is auto-detected from the snapshots (new first, old as fallback)
+    and passed to the suppression engine for scope.platform filtering (Phase 3).
+    When platform cannot be detected, platform_context=None is used — suppression
+    rules with scope.platform set will still apply (conservative skip semantics).
     """
     from abicheck.core.policy import get_profile  # noqa: PLC0415
     from abicheck.core.suppressions import SuppressionEngine as _Engine  # noqa: PLC0415

--- a/abicheck/core/suppressions/engine.py
+++ b/abicheck/core/suppressions/engine.py
@@ -31,6 +31,9 @@ from abicheck.core.errors import SuppressionError
 from abicheck.core.model import Change, ChangeSeverity
 from abicheck.core.suppressions.rule import SuppressionRule, VersionRange
 
+# Valid platform values for scope.platform filtering (Phase 3).
+_KNOWN_PLATFORMS: frozenset[str] = frozenset({"elf", "pe", "macho"})
+
 # ---------------------------------------------------------------------------
 # Input length limits (security hardening)
 # ---------------------------------------------------------------------------
@@ -210,6 +213,7 @@ class _CompiledRule(NamedTuple):
     glob_re: re2.Pattern | None       # pre-compiled RE2 from glob (via fnmatch.translate)
     regex_compiled: re2.Pattern | None  # pre-compiled RE2 from entity_regex
     version_range: VersionRange | None  # Phase 2b: pre-validated version range
+    platform: str | None               # Phase 3: "elf" | "pe" | "macho" | None=any
 
 
 # Stable key for match_map audit trail: (entity_type, entity_name, change_kind)
@@ -236,14 +240,19 @@ class SuppressionEngine:
 
     Phase 2b: version_context parameter enables version range filtering.
     When version_context is None, version_range checks are skipped (conservative).
+
+    Phase 3: platform_context parameter enables scope.platform filtering.
+    When platform_context is None, platform checks are skipped (conservative: suppress).
     """
 
     def __init__(
         self,
         rules: list[SuppressionRule],
         version_context: str | None = None,
+        platform_context: str | None = None,
     ) -> None:
         self._version_context = version_context
+        self._platform_context = platform_context
         self._compiled: list[_CompiledRule] = []
         for rule in rules:
             # ── Security: enforce input length limits ──────────────────────
@@ -281,15 +290,19 @@ class SuppressionEngine:
                         f"(reason={rule.reason!r}): {rule.entity_regex!r} — {exc}"
                     ) from exc
 
-            # Reject scope fields that are modelled but not yet enforced
+            # Phase 3: validate scope.platform value
             scope = rule.scope
-            if scope.platform:
-                raise SuppressionError(
-                    f"SuppressionRule scope field 'platform' "
-                    f"is not yet implemented (reason={rule.reason!r}). "
-                    f"Scope filtering is planned for Phase 3. "
-                    f"Remove the scope field until then."
-                )
+            compiled_platform: str | None = None
+            if scope.platform is not None:
+                if scope.platform not in _KNOWN_PLATFORMS:
+                    raise SuppressionError(
+                        f"Unknown platform {scope.platform!r} in suppression rule "
+                        f"(reason={rule.reason!r}). "
+                        f"Valid values: {sorted(_KNOWN_PLATFORMS)}"
+                    )
+                compiled_platform = scope.platform
+
+            # scope.profile still unimplemented — fail hard until Phase 4
             if scope.profile:
                 raise SuppressionError(
                     f"SuppressionRule scope field 'profile' "
@@ -309,22 +322,31 @@ class SuppressionEngine:
                 glob_re=glob_re,
                 regex_compiled=compiled_regex,
                 version_range=compiled_vr,
+                platform=compiled_platform,
             ))
 
     def apply(
         self,
         changes: list[Change],
         version_context: str | None = None,
+        platform_context: str | None = None,
     ) -> SuppressionResult:
         """Apply all rules to a list of Changes. Returns SuppressionResult.
 
-        version_context overrides the version_context set at __init__ time
-        for this specific apply() call.
+        version_context overrides the version_context set at __init__ time.
+        platform_context overrides the platform_context set at __init__ time.
+        Non-None values override init; None falls back to init value.
         """
         effective_version = version_context if version_context is not None else self._version_context
+        effective_platform = platform_context if platform_context is not None else self._platform_context
+        if effective_platform is not None and effective_platform not in _KNOWN_PLATFORMS:
+            raise SuppressionError(
+                f"Unknown platform_context {effective_platform!r}. "
+                f"Valid values: {sorted(_KNOWN_PLATFORMS)}"
+            )
         result = SuppressionResult()
         for change in changes:
-            matched_rule = self._match(change, effective_version)
+            matched_rule = self._match(change, effective_version, effective_platform)
             if matched_rule is not None:
                 # Return a new Change with severity SUPPRESSED (Change is a frozen-ish dataclass)
                 suppressed = _with_severity(change, ChangeSeverity.SUPPRESSED)
@@ -339,10 +361,15 @@ class SuppressionEngine:
                 result.active.append(change)
         return result
 
-    def _match(self, change: Change, version_context: str | None) -> SuppressionRule | None:
+    def _match(
+        self,
+        change: Change,
+        version_context: str | None,
+        platform_context: str | None,
+    ) -> SuppressionRule | None:
         """Return the first matching rule, or None."""
         for cr in self._compiled:
-            if self._rule_matches(cr, change, version_context):
+            if self._rule_matches(cr, change, version_context, platform_context):
                 return cr.rule
         return None
 
@@ -351,12 +378,20 @@ class SuppressionEngine:
         cr: _CompiledRule,
         change: Change,
         version_context: str | None,
+        platform_context: str | None,
     ) -> bool:
         rule = cr.rule
 
         # change_kind filter
         if rule.change_kind is not None:
             if change.change_kind.value != rule.change_kind:
+                return False
+
+        # Phase 3: platform filter
+        # When platform_context is provided AND a platform is set on the rule, apply filter.
+        # When platform_context is None, skip (conservative: suppress if other fields match).
+        if cr.platform is not None and platform_context is not None:
+            if cr.platform != platform_context:
                 return False
 
         # Phase 2b: version_range filter

--- a/abicheck/core/suppressions/engine.py
+++ b/abicheck/core/suppressions/engine.py
@@ -29,10 +29,8 @@ import re2  # google-re2: O(N) guaranteed
 
 from abicheck.core.errors import SuppressionError
 from abicheck.core.model import Change, ChangeSeverity
+from abicheck.core.pipeline import KNOWN_PLATFORMS as _KNOWN_PLATFORMS  # noqa: PLC0415
 from abicheck.core.suppressions.rule import SuppressionRule, VersionRange
-
-# Valid platform values for scope.platform filtering (Phase 3).
-_KNOWN_PLATFORMS: frozenset[str] = frozenset({"elf", "pe", "macho"})
 
 # ---------------------------------------------------------------------------
 # Input length limits (security hardening)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -674,6 +674,7 @@ def dump(
             dwarf=dwarf_meta,
             dwarf_advanced=dwarf_adv,
             elf_only_mode=True,
+            platform="elf",
         )
         return snapshot
 
@@ -695,5 +696,6 @@ def dump(
         elf=elf_meta,
         dwarf=dwarf_meta,
         dwarf_advanced=dwarf_adv,
+        platform="elf",
     )
     return snapshot

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -132,6 +132,11 @@ class AbiSnapshot:
     constants: dict[str, str] = field(default_factory=dict)  # #define / constexpr name -> value string
     elf_only_mode: bool = False  # True when dumped without headers (all functions are ELF_ONLY provenance)
 
+    # Phase 3: binary format platform — detected from ELF/PE/MachO metadata.
+    # None = unknown / not yet detected.
+    # Populated by detect_platform() in pipeline or by the dumper.
+    platform: str | None = None   # "elf" | "pe" | "macho" | None
+
     # Indexes (built lazily)
     _func_by_mangled: dict[str, Function] | None = field(default=None, repr=False, compare=False)
     _var_by_mangled: dict[str, Variable] | None = field(default=None, repr=False, compare=False)

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -238,6 +238,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         elf=elf, dwarf=dwarf, dwarf_advanced=dwarf_advanced,
         elf_only_mode=bool(d.get("elf_only_mode", False)),
         constants=d.get("constants", {}),
+        platform=d.get("platform"),
     )
 
 

--- a/tests/test_phase2_suppression_policy.py
+++ b/tests/test_phase2_suppression_policy.py
@@ -64,11 +64,12 @@ class TestSuppressionEngine:
         assert engine is not None
 
     def test_scope_fields_fail_at_load(self) -> None:
+        # Phase 3: platform is now implemented, profile still fails
         with pytest.raises(ValueError, match="not yet implemented"):
             SuppressionEngine([
                 SuppressionRule(
                     entity_glob="foo*",
-                    scope=SuppressionScope(platform="elf"),
+                    scope=SuppressionScope(profile="c"),
                 ),
             ])
 

--- a/tests/test_phase3_platform_filter.py
+++ b/tests/test_phase3_platform_filter.py
@@ -17,7 +17,6 @@ from abicheck.core.suppressions import SuppressionEngine, SuppressionRule
 from abicheck.core.suppressions.rule import SuppressionScope
 from abicheck.model import AbiSnapshot
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_phase3_platform_filter.py
+++ b/tests/test_phase3_platform_filter.py
@@ -1,0 +1,279 @@
+"""Tests for Phase 3: scope.platform filtering in SuppressionEngine + detect_platform()."""
+from __future__ import annotations
+
+import pytest
+
+from abicheck.core.errors import SuppressionError
+from abicheck.core.model import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    EntityType,
+    Origin,
+)
+from abicheck.core.pipeline import KNOWN_PLATFORMS, detect_platform
+from abicheck.core.suppressions import SuppressionEngine, SuppressionRule
+from abicheck.core.suppressions.rule import SuppressionScope
+from abicheck.model import AbiSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_change(name: str = "foo") -> Change:
+    return Change(
+        change_kind=ChangeKind.SYMBOL,
+        entity_type=EntityType.FUNCTION,
+        entity_name=name,
+        before=EntitySnapshot("int foo()"),
+        after=EntitySnapshot("void foo()"),
+        severity=ChangeSeverity.BREAK,
+        origin=Origin.CASTXML,
+        confidence=0.9,
+    )
+
+
+def _engine_with_platform(platform: str) -> SuppressionEngine:
+    return SuppressionEngine([
+        SuppressionRule(
+            entity_glob="*",
+            scope=SuppressionScope(platform=platform),
+            reason=f"platform={platform}",
+        )
+    ])
+
+
+def _snap(platform: str | None = None, has_elf: bool = False) -> AbiSnapshot:
+    from abicheck.elf_metadata import ElfMetadata  # noqa: PLC0415
+    elf = ElfMetadata(soname="", needed=[], rpath="", runpath="",
+                      versions_defined=[], versions_required={}, symbols=[]) if has_elf else None
+    return AbiSnapshot(library="libfoo.so", version="1.0", platform=platform, elf=elf)
+
+
+# ---------------------------------------------------------------------------
+# detect_platform()
+# ---------------------------------------------------------------------------
+
+class TestDetectPlatform:
+    def test_explicit_elf_platform(self) -> None:
+        snap = _snap(platform="elf")
+        assert detect_platform(snap) == "elf"
+
+    def test_explicit_pe_platform(self) -> None:
+        snap = _snap(platform="pe")
+        assert detect_platform(snap) == "pe"
+
+    def test_explicit_macho_platform(self) -> None:
+        snap = _snap(platform="macho")
+        assert detect_platform(snap) == "macho"
+
+    def test_inferred_from_elf_metadata(self) -> None:
+        """When platform is None but elf metadata present → infer 'elf'."""
+        snap = _snap(platform=None, has_elf=True)
+        assert detect_platform(snap) == "elf"
+
+    def test_none_when_no_platform_and_no_elf(self) -> None:
+        snap = _snap(platform=None, has_elf=False)
+        assert detect_platform(snap) is None
+
+    def test_unknown_explicit_platform_returns_none(self) -> None:
+        """Unknown platform string → returns None (not a known platform)."""
+        snap = _snap(platform="wasm")
+        assert detect_platform(snap) is None
+
+    def test_explicit_platform_takes_priority_over_elf_infer(self) -> None:
+        """Explicit platform wins even when elf metadata present."""
+        snap = _snap(platform="macho", has_elf=True)
+        assert detect_platform(snap) == "macho"
+
+    def test_known_platforms_constant(self) -> None:
+        assert "elf" in KNOWN_PLATFORMS
+        assert "pe" in KNOWN_PLATFORMS
+        assert "macho" in KNOWN_PLATFORMS
+
+
+# ---------------------------------------------------------------------------
+# scope.platform validation at load time
+# ---------------------------------------------------------------------------
+
+class TestPlatformValidationAtLoad:
+    def test_valid_elf_platform_ok(self) -> None:
+        engine = _engine_with_platform("elf")
+        assert engine is not None
+
+    def test_valid_pe_platform_ok(self) -> None:
+        engine = _engine_with_platform("pe")
+        assert engine is not None
+
+    def test_valid_macho_platform_ok(self) -> None:
+        engine = _engine_with_platform("macho")
+        assert engine is not None
+
+    def test_unknown_platform_raises(self) -> None:
+        with pytest.raises(SuppressionError, match="Unknown platform"):
+            _engine_with_platform("wasm")
+
+    def test_unknown_platform_error_lists_valid_values(self) -> None:
+        with pytest.raises(SuppressionError, match="elf"):
+            _engine_with_platform("foobar")
+
+    def test_invalid_platform_context_in_apply_raises(self) -> None:
+        engine = _engine_with_platform("elf")
+        with pytest.raises(SuppressionError, match="Unknown platform_context"):
+            engine.apply([_make_change()], platform_context="wasm")
+
+
+# ---------------------------------------------------------------------------
+# platform_context filtering semantics
+# ---------------------------------------------------------------------------
+
+class TestPlatformContextFiltering:
+    def test_matching_platform_suppresses(self) -> None:
+        engine = _engine_with_platform("elf")
+        result = engine.apply([_make_change()], platform_context="elf")
+        assert len(result.suppressed) == 1
+
+    def test_non_matching_platform_not_suppressed(self) -> None:
+        engine = _engine_with_platform("elf")
+        result = engine.apply([_make_change()], platform_context="pe")
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 0
+
+    def test_platform_context_none_skips_filter_conservative(self) -> None:
+        """When platform_context=None, filter is skipped → rule still applies."""
+        engine = _engine_with_platform("elf")
+        result = engine.apply([_make_change()])  # no platform_context
+        assert len(result.suppressed) == 1
+
+    def test_platform_context_in_init_applies(self) -> None:
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(platform="elf"))],
+            platform_context="elf",
+        )
+        result = engine.apply([_make_change()])
+        assert len(result.suppressed) == 1
+
+    def test_platform_context_in_init_non_match(self) -> None:
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(platform="elf"))],
+            platform_context="macho",
+        )
+        result = engine.apply([_make_change()])
+        assert len(result.active) == 1
+
+    def test_apply_platform_context_overrides_init(self) -> None:
+        """platform_context in apply() overrides init."""
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(platform="elf"))],
+            platform_context="pe",  # no match at init
+        )
+        # Override with matching platform
+        result = engine.apply([_make_change()], platform_context="elf")
+        assert len(result.suppressed) == 1
+
+    def test_apply_platform_context_none_falls_back_to_init(self) -> None:
+        """apply(platform_context=None) falls back to init value."""
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(platform="elf"))],
+            platform_context="pe",  # no match
+        )
+        result = engine.apply([_make_change()], platform_context=None)
+        assert len(result.active) == 1  # uses init "pe" → no match
+
+    def test_rule_without_platform_matches_any_context(self) -> None:
+        """Rule with no platform scope → matches regardless of platform_context."""
+        engine = SuppressionEngine([SuppressionRule(entity_glob="*", reason="any")])
+        for p in ["elf", "pe", "macho"]:
+            result = engine.apply([_make_change()], platform_context=p)
+            assert len(result.suppressed) == 1, f"Expected suppressed for platform={p}"
+
+    def test_multiple_rules_platform_filters_independently(self) -> None:
+        """Different rules for different platforms — each applies only to its platform."""
+        engine = SuppressionEngine([
+            SuppressionRule(entity_glob="elf_*",
+                            scope=SuppressionScope(platform="elf"), reason="elf-only"),
+            SuppressionRule(entity_glob="pe_*",
+                            scope=SuppressionScope(platform="pe"), reason="pe-only"),
+        ])
+        elf_result = engine.apply([_make_change("elf_func"), _make_change("pe_func")],
+                                   platform_context="elf")
+        assert len(elf_result.suppressed) == 1
+        assert elf_result.suppressed[0].entity_name == "elf_func"
+        assert len(elf_result.active) == 1
+        assert elf_result.active[0].entity_name == "pe_func"
+
+    def test_macho_platform_not_suppressed_on_elf(self) -> None:
+        engine = _engine_with_platform("macho")
+        result = engine.apply([_make_change()], platform_context="elf")
+        assert len(result.active) == 1
+
+    def test_platform_combined_with_version_range(self) -> None:
+        """platform + version_range: BOTH must match."""
+        from abicheck.core.suppressions.rule import VersionRange  # noqa: PLC0415
+        engine = SuppressionEngine([
+            SuppressionRule(
+                entity_glob="*",
+                scope=SuppressionScope(
+                    platform="elf",
+                    version_range=VersionRange(from_version="1.0.0", to_version="2.0.0"),
+                ),
+                reason="elf + semver range",
+            )
+        ])
+        # Both match
+        r1 = engine.apply([_make_change()], platform_context="elf", version_context="1.5.0")
+        assert len(r1.suppressed) == 1
+
+        # Platform matches, version doesn't
+        r2 = engine.apply([_make_change()], platform_context="elf", version_context="3.0.0")
+        assert len(r2.active) == 1
+
+        # Version matches, platform doesn't
+        r3 = engine.apply([_make_change()], platform_context="pe", version_context="1.5.0")
+        assert len(r3.active) == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_platform integration with analyse_full()
+# ---------------------------------------------------------------------------
+
+class TestDetectPlatformIntegration:
+    def test_analyse_full_auto_detects_elf_platform(self) -> None:
+        """analyse_full auto-detects 'elf' from snapshot and passes to engine."""
+        from abicheck.core.pipeline import analyse_full  # noqa: PLC0415
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        snap_v1 = _snap(platform="elf")
+        snap_v1.functions = [Function(name="foo", mangled="_Z3foov",
+                                       return_type="int", visibility=Visibility.PUBLIC)]
+
+        snap_v2 = _snap(platform="elf")
+        snap_v2.functions = []  # foo removed → BREAKING
+
+        # Rule only suppresses on elf — should apply
+        engine = SuppressionEngine([
+            SuppressionRule(entity_glob="foo", scope=SuppressionScope(platform="elf"))
+        ])
+        result = analyse_full(snap_v1, snap_v2, engine=engine)
+        # foo removed and suppressed → verdict PASS
+        assert result.summary.verdict.value in ("pass",), f"Expected PASS, got {result.summary.verdict}"
+
+    def test_analyse_full_no_suppression_on_wrong_platform(self) -> None:
+        """analyse_full with pe snapshot: elf-only rule should not suppress."""
+        from abicheck.core.pipeline import analyse_full  # noqa: PLC0415
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        snap_v1 = _snap(platform="pe")
+        snap_v1.functions = [Function(name="foo", mangled="_Z3foov",
+                                       return_type="int", visibility=Visibility.PUBLIC)]
+        snap_v2 = _snap(platform="pe")
+        snap_v2.functions = []  # foo removed → BREAKING, not suppressed
+
+        engine = SuppressionEngine([
+            SuppressionRule(entity_glob="foo", scope=SuppressionScope(platform="elf"))
+        ])
+        result = analyse_full(snap_v1, snap_v2, engine=engine)
+        # foo removed, elf rule doesn't apply to pe → BLOCK
+        assert result.summary.verdict.value in ("block",), f"Expected BLOCK, got {result.summary.verdict}"


### PR DESCRIPTION
## Summary

Implements Phase 3: `scope.platform` filter in suppression rules.

## Changes

- **`AbiSnapshot.platform`** — new field `str | None` (`"elf" | "pe" | "macho" | None`)
- **`detect_platform()`** — infers platform from `snapshot.platform` (explicit) or `snapshot.elf` presence (auto)
- **`SuppressionEngine`** — `platform_context` parameter in `__init__()` and `apply()`; validates unknown values at both load-time and apply-time
- **`_rule_matches()`** — platform filter applied before entity glob/regex; conservative skip when `platform_context=None`
- **`analyse_full()`** — auto-detects platform from snapshot, passes to engine
- **`dumper.py`** — sets `platform="elf"` on all ELF snapshots
- **`serialization.py`** — round-trips `platform` field through JSON

## Backward Compatibility

- `platform_context=None` (default) skips platform filter — conservative, existing behavior unchanged
- `scope.profile` still raises `SuppressionError` (Phase 4)

## Tests

27 new tests in `test_phase3_platform_filter.py` covering:
- `detect_platform()` — explicit, inferred, unknown, priority
- Validation at load time (unknown platform → `SuppressionError`)
- Filtering semantics (match / no-match / None-skip / init-override / combined with version_range)
- `analyse_full()` integration (auto-detect elf → suppression applies/not applies)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic binary-format detection (ELF, PE, Mach-O) during analysis.
  * Platform-scoped suppression: suppressions can be constrained to a specific platform and honor detected or provided platform context.

* **Documentation**
  * Pipeline docs clarified to describe automatic platform detection and conservative handling when platform is unknown.

* **Tests**
  * Comprehensive tests for detection, platform-filtered suppression, and integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->