### PR TITLE
feat(phase4): scope.profile filtering in SuppressionEngine

### DIFF
--- a/abicheck/core/pipeline.py
+++ b/abicheck/core/pipeline.py
@@ -35,6 +35,9 @@ _normalizer = Normalizer()
 # Valid platform values for scope.platform filtering (Phase 3).
 KNOWN_PLATFORMS: frozenset[str] = frozenset({"elf", "pe", "macho"})
 
+# Valid profile values for scope.profile filtering (Phase 4).
+KNOWN_PROFILES: frozenset[str] = frozenset({"c", "cpp", "sycl"})
+
 
 def detect_platform(snapshot: AbiSnapshot) -> Literal["elf", "pe", "macho"] | None:
     """Detect the binary format platform from an AbiSnapshot.
@@ -53,6 +56,43 @@ def detect_platform(snapshot: AbiSnapshot) -> Literal["elf", "pe", "macho"] | No
         return None
     if snapshot.elf is not None:
         return "elf"
+    return None
+
+
+def detect_profile(snapshot: AbiSnapshot) -> Literal["c", "cpp", "sycl"] | None:
+    """Detect the language profile from an AbiSnapshot.
+
+    Detection priority:
+    1. snapshot.language_profile if already set (explicit override by caller/dumper)
+    2. Heuristic from function symbols:
+       - All public functions are extern "C" (is_extern_c=True) → "c"
+       - Any function has C++ mangling (_Z prefix) → "cpp"
+    3. None (unknown — mixed or no functions)
+
+    Note: "sycl" cannot be auto-detected from the model; set snapshot.language_profile
+    explicitly when processing SYCL libraries.
+    """
+    if snapshot.language_profile is not None:
+        p = snapshot.language_profile
+        if p in KNOWN_PROFILES:
+            return p  # type: ignore[return-value]
+        return None
+
+    public_funcs = [
+        f for f in snapshot.functions
+        if f.visibility.value in ("public", "elf_only")
+    ]
+    if not public_funcs:
+        return None
+
+    # If any function has C++ mangling → cpp
+    if any(f.mangled.startswith("_Z") for f in public_funcs):
+        return "cpp"
+
+    # If all public functions are extern "C" → c
+    if all(f.is_extern_c for f in public_funcs):
+        return "c"
+
     return None
 
 
@@ -86,10 +126,10 @@ def analyse_full(
 ) -> PolicyResult:
     """Run the full v0.2 pipeline: diff → suppress → policy → PolicyResult.
 
-    Platform context is auto-detected from the snapshots (new first, old as fallback)
-    and passed to the suppression engine for scope.platform filtering (Phase 3).
-    When platform cannot be detected, platform_context=None is used — suppression
-    rules with scope.platform set will still apply (conservative skip semantics).
+    Platform and language profile are auto-detected from the snapshots (new first,
+    old as fallback) and passed to the suppression engine for scope filtering (Phase 3/4).
+    When context cannot be detected, conservative skip semantics apply — suppression
+    rules with scope filters still match (safest default).
     """
     from abicheck.core.policy import get_profile  # noqa: PLC0415
     from abicheck.core.suppressions import SuppressionEngine as _Engine  # noqa: PLC0415
@@ -97,7 +137,10 @@ def analyse_full(
     changes = analyse(old, new)
 
     # Phase 3: auto-detect platform from snapshot for suppression scope filtering.
-    platform = detect_platform(new) or detect_platform(old)
+    platform_ctx = detect_platform(new) or detect_platform(old)
+
+    # Phase 4: auto-detect language profile from snapshot.
+    profile_ctx = detect_profile(new) or detect_profile(old)
 
     if engine is None:
         engine = _Engine(rules or [])
@@ -108,12 +151,12 @@ def analyse_full(
             stacklevel=2,
         )
 
-    sup_result = engine.apply(changes, platform_context=platform)
+    sup_result = engine.apply(changes, platform_context=platform_ctx, profile_context=profile_ctx)
 
     all_changes = sorted(
         sup_result.active + sup_result.suppressed,
         key=lambda c: (c.entity_type, c.entity_name, c.change_kind.value),
     )
 
-    profile = get_profile(policy)
-    return profile.apply(all_changes)
+    policy_profile = get_profile(policy)
+    return policy_profile.apply(all_changes)

--- a/abicheck/core/suppressions/engine.py
+++ b/abicheck/core/suppressions/engine.py
@@ -30,6 +30,7 @@ import re2  # google-re2: O(N) guaranteed
 from abicheck.core.errors import SuppressionError
 from abicheck.core.model import Change, ChangeSeverity
 from abicheck.core.pipeline import KNOWN_PLATFORMS as _KNOWN_PLATFORMS  # noqa: PLC0415
+from abicheck.core.pipeline import KNOWN_PROFILES as _KNOWN_PROFILES
 from abicheck.core.suppressions.rule import SuppressionRule, VersionRange
 
 # ---------------------------------------------------------------------------
@@ -212,6 +213,7 @@ class _CompiledRule(NamedTuple):
     regex_compiled: re2.Pattern | None  # pre-compiled RE2 from entity_regex
     version_range: VersionRange | None  # Phase 2b: pre-validated version range
     platform: str | None               # Phase 3: "elf" | "pe" | "macho" | None=any
+    profile: str | None                # Phase 4: "c" | "cpp" | "sycl" | None=any
 
 
 # Stable key for match_map audit trail: (entity_type, entity_name, change_kind)
@@ -241,6 +243,9 @@ class SuppressionEngine:
 
     Phase 3: platform_context parameter enables scope.platform filtering.
     When platform_context is None, platform checks are skipped (conservative: suppress).
+
+    Phase 4: profile_context parameter enables scope.profile filtering.
+    When profile_context is None, profile checks are skipped (conservative: suppress).
     """
 
     def __init__(
@@ -248,9 +253,11 @@ class SuppressionEngine:
         rules: list[SuppressionRule],
         version_context: str | None = None,
         platform_context: str | None = None,
+        profile_context: str | None = None,
     ) -> None:
         self._version_context = version_context
         self._platform_context = platform_context
+        self._profile_context = profile_context
         self._compiled: list[_CompiledRule] = []
         for rule in rules:
             # ── Security: enforce input length limits ──────────────────────
@@ -300,14 +307,16 @@ class SuppressionEngine:
                     )
                 compiled_platform = scope.platform
 
-            # scope.profile still unimplemented — fail hard until Phase 4
-            if scope.profile:
-                raise SuppressionError(
-                    f"SuppressionRule scope field 'profile' "
-                    f"is not yet implemented (reason={rule.reason!r}). "
-                    f"Scope filtering is planned for Phase 4. "
-                    f"Remove the scope field until then."
-                )
+            # Phase 4: validate scope.profile value
+            compiled_profile: str | None = None
+            if scope.profile is not None:
+                if scope.profile not in _KNOWN_PROFILES:
+                    raise SuppressionError(
+                        f"Unknown profile {scope.profile!r} in suppression rule "
+                        f"(reason={rule.reason!r}). "
+                        f"Valid values: {sorted(_KNOWN_PROFILES)}"
+                    )
+                compiled_profile = scope.profile
 
             # Phase 2b: pre-validate version_range at load time
             compiled_vr: VersionRange | None = None
@@ -321,6 +330,7 @@ class SuppressionEngine:
                 regex_compiled=compiled_regex,
                 version_range=compiled_vr,
                 platform=compiled_platform,
+                profile=compiled_profile,
             ))
 
     def apply(
@@ -328,23 +338,29 @@ class SuppressionEngine:
         changes: list[Change],
         version_context: str | None = None,
         platform_context: str | None = None,
+        profile_context: str | None = None,
     ) -> SuppressionResult:
         """Apply all rules to a list of Changes. Returns SuppressionResult.
 
-        version_context overrides the version_context set at __init__ time.
-        platform_context overrides the platform_context set at __init__ time.
+        version_context/platform_context/profile_context override init-time values.
         Non-None values override init; None falls back to init value.
         """
         effective_version = version_context if version_context is not None else self._version_context
         effective_platform = platform_context if platform_context is not None else self._platform_context
+        effective_profile = profile_context if profile_context is not None else self._profile_context
         if effective_platform is not None and effective_platform not in _KNOWN_PLATFORMS:
             raise SuppressionError(
                 f"Unknown platform_context {effective_platform!r}. "
                 f"Valid values: {sorted(_KNOWN_PLATFORMS)}"
             )
+        if effective_profile is not None and effective_profile not in _KNOWN_PROFILES:
+            raise SuppressionError(
+                f"Unknown profile_context {effective_profile!r}. "
+                f"Valid values: {sorted(_KNOWN_PROFILES)}"
+            )
         result = SuppressionResult()
         for change in changes:
-            matched_rule = self._match(change, effective_version, effective_platform)
+            matched_rule = self._match(change, effective_version, effective_platform, effective_profile)
             if matched_rule is not None:
                 # Return a new Change with severity SUPPRESSED (Change is a frozen-ish dataclass)
                 suppressed = _with_severity(change, ChangeSeverity.SUPPRESSED)
@@ -364,10 +380,11 @@ class SuppressionEngine:
         change: Change,
         version_context: str | None,
         platform_context: str | None,
+        profile_context: str | None,
     ) -> SuppressionRule | None:
         """Return the first matching rule, or None."""
         for cr in self._compiled:
-            if self._rule_matches(cr, change, version_context, platform_context):
+            if self._rule_matches(cr, change, version_context, platform_context, profile_context):
                 return cr.rule
         return None
 
@@ -377,6 +394,7 @@ class SuppressionEngine:
         change: Change,
         version_context: str | None,
         platform_context: str | None,
+        profile_context: str | None,
     ) -> bool:
         rule = cr.rule
 
@@ -390,6 +408,13 @@ class SuppressionEngine:
         # When platform_context is None, skip (conservative: suppress if other fields match).
         if cr.platform is not None and platform_context is not None:
             if cr.platform != platform_context:
+                return False
+
+        # Phase 4: profile filter
+        # When profile_context is provided AND a profile is set on the rule, apply filter.
+        # When profile_context is None, skip (conservative: suppress if other fields match).
+        if cr.profile is not None and profile_context is not None:
+            if cr.profile != profile_context:
                 return False
 
         # Phase 2b: version_range filter

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -655,6 +655,14 @@ def dump(
         exported_dynamic = exported_dynamic_funcs | exported_dynamic_objects
     dwarf_meta, dwarf_adv = parse_dwarf(so_path)
 
+    profile_hint: str | None = None
+    if lang is not None:
+        lu = lang.upper()
+        if lu == "C":
+            profile_hint = "c"
+        elif lu in ("C++", "CPP"):
+            profile_hint = "cpp"
+
     if not headers:
         warnings.warn(
             "No headers provided — only ELF-exported symbols will be captured; "
@@ -675,6 +683,7 @@ def dump(
             dwarf_advanced=dwarf_adv,
             elf_only_mode=True,
             platform="elf",
+            language_profile=profile_hint,
         )
         return snapshot
 
@@ -697,5 +706,6 @@ def dump(
         dwarf=dwarf_meta,
         dwarf_advanced=dwarf_adv,
         platform="elf",
+        language_profile=profile_hint,
     )
     return snapshot

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -137,6 +137,11 @@ class AbiSnapshot:
     # Populated by detect_platform() in pipeline or by the dumper.
     platform: str | None = None   # "elf" | "pe" | "macho" | None
 
+    # Phase 4: language profile — detected from symbol mangling / extern "C" annotations.
+    # None = unknown / mixed / not yet detected.
+    # Populated by detect_profile() in pipeline or by the dumper.
+    language_profile: str | None = None  # "c" | "cpp" | "sycl" | None
+
     # Indexes (built lazily)
     _func_by_mangled: dict[str, Function] | None = field(default=None, repr=False, compare=False)
     _var_by_mangled: dict[str, Variable] | None = field(default=None, repr=False, compare=False)

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -239,6 +239,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         elf_only_mode=bool(d.get("elf_only_mode", False)),
         constants=d.get("constants", {}),
         platform=d.get("platform"),
+        language_profile=d.get("language_profile"),
     )
 
 

--- a/tests/test_phase2_suppression_policy.py
+++ b/tests/test_phase2_suppression_policy.py
@@ -63,13 +63,12 @@ class TestSuppressionEngine:
         engine = SuppressionEngine([SuppressionRule(entity_glob="std::*")])
         assert engine is not None
 
-    def test_scope_fields_fail_at_load(self) -> None:
-        # Phase 3: platform is now implemented, profile still fails
-        with pytest.raises(ValueError, match="not yet implemented"):
+    def test_scope_unknown_profile_fails_at_load(self) -> None:
+        with pytest.raises(ValueError, match="Unknown profile"):
             SuppressionEngine([
                 SuppressionRule(
                     entity_glob="foo*",
-                    scope=SuppressionScope(profile="c"),
+                    scope=SuppressionScope(profile="fortran"),
                 ),
             ])
 
@@ -322,12 +321,22 @@ class TestSuppressionEngineCoverage:
         assert [c.entity_name for c in result.active] == ["foocZ"]
 
     def test_scope_with_profile_field_raises(self) -> None:
-        """scope.profile set → ValueError at load time."""
-        with pytest.raises(ValueError, match="not yet implemented"):
+        """scope.profile set with unknown value → ValueError at load time."""
+        # Valid profile "cpp" should load
+        engine = SuppressionEngine([
+            SuppressionRule(
+                entity_glob="*",
+                scope=SuppressionScope(profile="cpp"),
+            ),
+        ])
+        assert engine is not None
+
+        # Unknown profile "fortran" should raise
+        with pytest.raises(ValueError, match="Unknown profile"):
             SuppressionEngine([
                 SuppressionRule(
                     entity_glob="*",
-                    scope=SuppressionScope(profile="cpp"),
+                    scope=SuppressionScope(profile="fortran"),
                 ),
             ])
 

--- a/tests/test_phase4_profile_filter.py
+++ b/tests/test_phase4_profile_filter.py
@@ -1,0 +1,261 @@
+"""Tests for Phase 4: scope.profile filtering in SuppressionEngine + detect_profile()."""
+from __future__ import annotations
+
+import pytest
+
+from abicheck.core.errors import SuppressionError
+from abicheck.core.model import (
+    Change,
+    ChangeKind,
+    ChangeSeverity,
+    EntitySnapshot,
+    EntityType,
+    Origin,
+)
+from abicheck.core.pipeline import KNOWN_PROFILES, detect_profile
+from abicheck.core.suppressions import SuppressionEngine, SuppressionRule
+from abicheck.core.suppressions.rule import SuppressionScope
+from abicheck.model import AbiSnapshot
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_change(name: str = "foo") -> Change:
+    return Change(
+        change_kind=ChangeKind.SYMBOL,
+        entity_type=EntityType.FUNCTION,
+        entity_name=name,
+        before=EntitySnapshot("int foo()"),
+        after=EntitySnapshot("void foo()"),
+        severity=ChangeSeverity.BREAK,
+        origin=Origin.CASTXML,
+        confidence=0.9,
+    )
+
+
+def _engine_with_profile(profile: str) -> SuppressionEngine:
+    return SuppressionEngine([
+        SuppressionRule(
+            entity_glob="*",
+            scope=SuppressionScope(profile=profile),
+            reason=f"profile={profile}",
+        )
+    ])
+
+
+def _snap(profile: str | None = None) -> AbiSnapshot:
+    return AbiSnapshot(library="libfoo.so", version="1.0", language_profile=profile)
+
+
+# ---------------------------------------------------------------------------
+# detect_profile()
+# ---------------------------------------------------------------------------
+
+class TestDetectProfile:
+    def test_explicit_c_profile(self) -> None:
+        snap = _snap(profile="c")
+        assert detect_profile(snap) == "c"
+
+    def test_explicit_cpp_profile(self) -> None:
+        snap = _snap(profile="cpp")
+        assert detect_profile(snap) == "cpp"
+
+    def test_explicit_sycl_profile(self) -> None:
+        snap = _snap(profile="sycl")
+        assert detect_profile(snap) == "sycl"
+
+    def test_unknown_explicit_profile_returns_none(self) -> None:
+        snap = _snap(profile="fortran")
+        assert detect_profile(snap) is None
+
+    def test_none_when_no_profile_and_no_functions(self) -> None:
+        snap = _snap(profile=None)
+        assert detect_profile(snap) is None
+
+    def test_infer_cpp_from_mangled_symbol(self) -> None:
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        snap = _snap(profile=None)
+        snap.functions = [
+            Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC),
+        ]
+        assert detect_profile(snap) == "cpp"
+
+    def test_infer_c_from_extern_c_only(self) -> None:
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        snap = _snap(profile=None)
+        snap.functions = [
+            Function(
+                name="foo",
+                mangled="foo",
+                return_type="int",
+                visibility=Visibility.PUBLIC,
+                is_extern_c=True,
+            ),
+            Function(
+                name="bar",
+                mangled="bar",
+                return_type="int",
+                visibility=Visibility.PUBLIC,
+                is_extern_c=True,
+            ),
+        ]
+        assert detect_profile(snap) == "c"
+
+    def test_mixed_symbols_unknown(self) -> None:
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        snap = _snap(profile=None)
+        snap.functions = [
+            Function(name="foo", mangled="foo", return_type="int", visibility=Visibility.PUBLIC, is_extern_c=False),
+            Function(name="bar", mangled="bar", return_type="int", visibility=Visibility.PUBLIC, is_extern_c=True),
+        ]
+        assert detect_profile(snap) is None
+
+    def test_known_profiles_constant(self) -> None:
+        assert "c" in KNOWN_PROFILES
+        assert "cpp" in KNOWN_PROFILES
+        assert "sycl" in KNOWN_PROFILES
+
+
+# ---------------------------------------------------------------------------
+# scope.profile validation at load time
+# ---------------------------------------------------------------------------
+
+class TestProfileValidationAtLoad:
+    def test_valid_c_profile_ok(self) -> None:
+        engine = _engine_with_profile("c")
+        assert engine is not None
+
+    def test_valid_cpp_profile_ok(self) -> None:
+        engine = _engine_with_profile("cpp")
+        assert engine is not None
+
+    def test_valid_sycl_profile_ok(self) -> None:
+        engine = _engine_with_profile("sycl")
+        assert engine is not None
+
+    def test_unknown_profile_raises(self) -> None:
+        with pytest.raises(SuppressionError, match="Unknown profile"):
+            _engine_with_profile("fortran")
+
+    def test_invalid_profile_context_in_apply_raises(self) -> None:
+        engine = _engine_with_profile("cpp")
+        with pytest.raises(SuppressionError, match="Unknown profile_context"):
+            engine.apply([_make_change()], profile_context="fortran")
+
+
+# ---------------------------------------------------------------------------
+# profile_context filtering semantics
+# ---------------------------------------------------------------------------
+
+class TestProfileContextFiltering:
+    def test_matching_profile_suppresses(self) -> None:
+        engine = _engine_with_profile("cpp")
+        result = engine.apply([_make_change()], profile_context="cpp")
+        assert len(result.suppressed) == 1
+
+    def test_non_matching_profile_not_suppressed(self) -> None:
+        engine = _engine_with_profile("cpp")
+        result = engine.apply([_make_change()], profile_context="c")
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 0
+
+    def test_profile_context_none_skips_filter_conservative(self) -> None:
+        engine = _engine_with_profile("cpp")
+        result = engine.apply([_make_change()])
+        assert len(result.suppressed) == 1
+
+    def test_profile_context_in_init_applies(self) -> None:
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(profile="cpp"))],
+            profile_context="cpp",
+        )
+        result = engine.apply([_make_change()])
+        assert len(result.suppressed) == 1
+
+    def test_apply_profile_context_overrides_init(self) -> None:
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(profile="cpp"))],
+            profile_context="c",
+        )
+        result = engine.apply([_make_change()], profile_context="cpp")
+        assert len(result.suppressed) == 1
+
+    def test_apply_profile_context_none_falls_back_to_init(self) -> None:
+        engine = SuppressionEngine(
+            [SuppressionRule(entity_glob="*", scope=SuppressionScope(profile="cpp"))],
+            profile_context="c",
+        )
+        result = engine.apply([_make_change()], profile_context=None)
+        assert len(result.active) == 1
+
+    def test_profile_combined_with_platform_both_must_match(self) -> None:
+        engine = SuppressionEngine([
+            SuppressionRule(
+                entity_glob="*",
+                scope=SuppressionScope(platform="elf", profile="cpp"),
+                reason="elf+cpp",
+            )
+        ])
+        # both match
+        r1 = engine.apply([_make_change()], platform_context="elf", profile_context="cpp")
+        assert len(r1.suppressed) == 1
+        # profile mismatch
+        r2 = engine.apply([_make_change()], platform_context="elf", profile_context="c")
+        assert len(r2.active) == 1
+        # platform mismatch
+        r3 = engine.apply([_make_change()], platform_context="pe", profile_context="cpp")
+        assert len(r3.active) == 1
+
+
+class TestDetectProfileIntegration:
+    def test_analyse_full_auto_detects_cpp_profile(self) -> None:
+        from abicheck.core.pipeline import analyse_full  # noqa: PLC0415
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        old = AbiSnapshot(
+            library="libfoo.so",
+            version="1",
+            platform="elf",
+            functions=[Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC)],
+        )
+        new = AbiSnapshot(
+            library="libfoo.so",
+            version="2",
+            platform="elf",
+            functions=[],
+        )
+
+        engine = SuppressionEngine([
+            SuppressionRule(entity_glob="foo", scope=SuppressionScope(platform="elf", profile="cpp"))
+        ])
+        out = analyse_full(old, new, engine=engine)
+        assert out.summary.verdict.value == "pass"
+
+    def test_analyse_full_profile_mismatch_not_suppressed(self) -> None:
+        from abicheck.core.pipeline import analyse_full  # noqa: PLC0415
+        from abicheck.model import Function, Visibility  # noqa: PLC0415
+
+        old = AbiSnapshot(
+            library="libfoo.so",
+            version="1",
+            platform="elf",
+            language_profile="c",
+            functions=[Function(name="foo", mangled="foo", return_type="int", visibility=Visibility.PUBLIC, is_extern_c=True)],
+        )
+        new = AbiSnapshot(
+            library="libfoo.so",
+            version="2",
+            platform="elf",
+            language_profile="c",
+            functions=[],
+        )
+
+        engine = SuppressionEngine([
+            SuppressionRule(entity_glob="foo", scope=SuppressionScope(platform="elf", profile="cpp"))
+        ])
+        out = analyse_full(old, new, engine=engine)
+        assert out.summary.verdict.value == "block"


### PR DESCRIPTION
## Summary

Implements Phase 4: `scope.profile` filter in suppression rules.

## Changes

- **`AbiSnapshot.language_profile`** — new field `str | None` (`"c" | "cpp" | "sycl" | None`)
- **`KNOWN_PROFILES`** — constant in `pipeline.py` (single source of truth, imported by engine)
- **`detect_profile()`** — infers profile from `snapshot.language_profile` (explicit) or heuristic:
  - any function with `_Z` mangling → `"cpp"`
  - all public functions `is_extern_c=True` → `"c"`
  - `"sycl"` requires explicit `language_profile` field (not auto-detectable)
- **`SuppressionEngine`** — `profile_context` param in `__init__()` and `apply()`
- **`_rule_matches()`** — profile filter applied alongside platform; conservative skip when `profile_context=None`
- **`analyse_full()`** — auto-detects profile from snapshot, passes as `profile_context`
- **`dumper.py`** — sets `language_profile` from `lang` param (`"C"` → `"c"`, `"C++"` → `"cpp"`)
- **`serialization.py`** — round-trips `language_profile` field through JSON

## Backward Compatibility

- `profile_context=None` (default) skips profile filter — conservative, existing behavior unchanged
- All 3 scope fields (platform + profile + version_range) now fully implemented

## Tests

23 new tests in `test_phase4_profile_filter.py` covering:
- `detect_profile()` — explicit, C++ mangling, extern-C heuristic, unknown, None
- Validation at load time (unknown profile → `SuppressionError`)
- Filtering semantics (match / no-match / None-skip / init-override / combined with platform)
- `analyse_full()` integration (auto-detect cpp → suppression applies/not applies)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic language profile detection to identify C, C++, and SYCL projects from code characteristics
  * Implemented profile-aware suppression filtering for more precise issue suppression based on detected language context

* **Tests**
  * Added comprehensive test coverage for profile detection and filtering functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->