### PR TITLE
test(parity): add ABICC upstream issue#128 and PR#109 regression tests

### DIFF
--- a/tests/test_abicc_parity.py
+++ b/tests/test_abicc_parity.py
@@ -171,6 +171,53 @@ PARITY_CASES: list[tuple[str, str, str, str | None, str | None, str, str, str, s
         "int get_version(void);",
         "c", "NO_CHANGE", "BREAKING", "divergence",
     ),
+    # ── issue#128: non-trivial destructor changes calling convention (x64 SysV ABI) ──
+    # Adding a user-defined destructor to a struct makes it non-trivial under the
+    # Itanium C++ ABI.  On x64 System V ABI, non-trivial structs cannot be returned
+    # in SSE registers and must be passed via a hidden pointer instead — an
+    # ABI-breaking change.  Neither abicheck (COMPATIBLE, detects only ELF-level
+    # changes) nor ABICC 2.3 (NO_CHANGE) catches this calling-convention break,
+    # so the two tools also disagree with each other.  Recorded as a known
+    # divergence so regressions are caught if either tool starts detecting it.
+    # The ground-truth verdict is BREAKING; both tools currently miss it.
+    # See: https://github.com/lvc/abi-compliance-checker/issues/128
+    (
+        "nontrivial_dtor_calling_convention",
+        "struct v { float a; float b; };\n"
+        "v get_v(void) { v x; x.a = 1.0f; x.b = 2.0f; return x; }",
+        "struct v { float a; float b; ~v() {} };\n"
+        "v get_v(void) { v x; x.a = 1.0f; x.b = 2.0f; return x; }",
+        "struct v { float a; float b; };\nv get_v(void);",
+        "struct v { float a; float b; ~v(); };\nv get_v(void);",
+        "cpp", "COMPATIBLE", "NO_CHANGE", "divergence",
+    ),
+    # ── PR#109: typedef→derived class false positive in base detection ──
+    # ABICC had a bug where a typedef pointing to a derived class caused a false
+    # positive "added base" report even when nothing changed between versions.
+    # abicheck correctly reports NO_CHANGE; ABICC 2.3 also reports NO_CHANGE,
+    # indicating that the fix from PR#109 is present in this version (or the
+    # specific scenario does not trigger the original bug).
+    # See: https://github.com/lvc/abi-compliance-checker/pull/109
+    (
+        "typedef_derived_false_base_change",
+        "struct Base { int x; };\n"
+        "struct Derived : public Base { int y; };\n"
+        "typedef Derived MyType;\n"
+        "MyType* get_obj(void) { static MyType obj; return &obj; }",
+        "struct Base { int x; };\n"
+        "struct Derived : public Base { int y; };\n"
+        "typedef Derived MyType;\n"
+        "MyType* get_obj(void) { static MyType obj; return &obj; }",
+        "struct Base { int x; };\n"
+        "struct Derived : public Base { int y; };\n"
+        "typedef Derived MyType;\n"
+        "MyType* get_obj(void);",
+        "struct Base { int x; };\n"
+        "struct Derived : public Base { int y; };\n"
+        "typedef Derived MyType;\n"
+        "MyType* get_obj(void);",
+        "cpp", "NO_CHANGE", "NO_CHANGE", "parity",
+    ),
 ]
 
 _CONFIRMED = [c for c in PARITY_CASES if c[8] == "parity"]


### PR DESCRIPTION
## Summary
Adds two new parity test cases based on upstream lvc/abi-compliance-checker issues:

### Issue #128 — Non-trivial destructor changes calling convention
Adding an empty user-defined destructor to a struct makes it non-trivial (Itanium C++ ABI),
changing its x64 SysV ABI calling convention from register-based to pointer-based.
Documents whether abicheck detects this via DWARF analysis or misses it.

**Actual verdicts on ABICC 2.3 + current abicheck:**
- abicheck: `COMPATIBLE` (detects only ELF-level dependency changes, misses calling-convention break)
- ABICC 2.3: `NO_CHANGE` (does not detect this in XML descriptor mode without abi-dumper)
- Ground truth: **BREAKING** — both tools currently miss it
- Category: `divergence` — the two tools disagree AND both are wrong

### PR #109 — typedef→derived class false positive base detection
ABICC PR#109 fixed a false positive where typedef pointing to a derived class
caused 'added base' reports even when nothing changed.
This test verifies abicheck does not have the same false positive.

**Actual verdicts on ABICC 2.3 + current abicheck:**
- abicheck: `NO_CHANGE` ✓ (correct — no false positive)
- ABICC 2.3: `NO_CHANGE` ✓ (fix from PR#109 is present in this version)
- Category: `parity` — both tools agree on the correct answer

## References
- https://github.com/lvc/abi-compliance-checker/issues/128
- https://github.com/lvc/abi-compliance-checker/pull/109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for ABI compatibility verification, including scenarios for destructor calling conventions and class inheritance patterns.
  * Enhanced parity test coverage with documented examples of known divergences and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->