### PR TITLE
fix: review followup PR85/86 — triviality heuristic, member types, perf caches, CLI error handling

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -206,12 +206,22 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         f_old = old_map[mangled]
         f_new = new_map[mangled]
         if not f_old.is_inline and f_new.is_inline:
-            # Function became inline: symbol may disappear from DSO export table
-            # (depends on compiler / visibility). Potentially breaking — needs review.
+            # Check if the symbol still appears in the new ELF exports.
+            # If yes → symbol kept, just annotation changed (still API_BREAK)
+            # If no or ELF unavailable → symbol may have been dropped
+            new_elf = new.elf
+            still_exported = (
+                new_elf is not None
+                and any(s.name == mangled for s in new_elf.symbols)
+            )
             changes.append(Change(
                 kind=ChangeKind.FUNC_BECAME_INLINE,
                 symbol=mangled,
-                description=f"Function became inline (symbol may be removed from DSO): {f_old.name}",
+                description=(
+                    f"Function became inline, symbol still exported: {f_old.name}"
+                    if still_exported
+                    else f"Function became inline (symbol may be removed from DSO): {f_old.name}"
+                ),
                 old_value="non-inline",
                 new_value="inline",
             ))

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -49,13 +49,20 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
     Example:
       abicheck dump libfoo.so.1 -H include/foo.h --version 1.2.3 -o snap.json
     """
-    snap = dump(
-        so_path=so_path,
-        headers=list(headers),
-        extra_includes=list(includes),
-        version=version,
-        compiler=compiler,
-    )
+    from .core.errors import AbicheckError
+
+    try:
+        snap = dump(
+            so_path=so_path,
+            headers=list(headers),
+            extra_includes=list(includes),
+            version=version,
+            compiler=compiler,
+        )
+    except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
     result = snapshot_to_json(snap)
     if output:
         output.write_text(result, encoding="utf-8")

--- a/abicheck/core/diff/symbol_diff.py
+++ b/abicheck/core/diff/symbol_diff.py
@@ -167,9 +167,20 @@ def _diff_function_pair(f_old: Function, f_new: Function) -> list[Change]:
             confidence=0.85,
         ))
 
-    # noexcept added (false→true) changes C++17 mangled name — ABI-breaking for callers
-    # compiled against the old signature. TODO: emit BREAK here in Phase 2 when
-    # mangled name comparison is available; for now silent (conservative: no false positives).
+    # noexcept added: in C++17, noexcept is part of the function type and mangled name.
+    # This is ABI-breaking: callers compiled against the old (non-noexcept) declaration
+    # will link against the old mangled symbol which no longer exists.
+    if not f_old.is_noexcept and f_new.is_noexcept:
+        changes.append(Change(
+            change_kind=ChangeKind.SYMBOL,
+            entity_type=EntityType.FUNCTION,
+            entity_name=f_old.name,
+            before=snap_old,
+            after=snap_new,
+            severity=ChangeSeverity.BREAK,
+            origin=Origin.CASTXML,
+            confidence=0.9,
+        ))
 
     return changes
 

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -236,6 +236,7 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
     children (handled directly in _check_packed).
     """
     stack: collections.deque[Any] = collections.deque([root])
+    cache = _DwarfTypeCache()  # per-CU cache to avoid redundant traversals
 
     while stack:
         die = stack.pop()
@@ -245,7 +246,7 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
             continue
 
         if tag in ("DW_TAG_subprogram", "DW_TAG_subroutine_type"):
-            _extract_calling_convention(die, meta, CU)
+            _extract_calling_convention(die, meta, CU, cache=cache)
             # Don't descend into subprogram children — not needed for CC extraction
             # and avoids traversing all local variables, params, inlined calls
             continue
@@ -286,29 +287,100 @@ def _resolve_type_die(die: Any, CU: Any) -> Any | None:
         return None
 
 
-def _is_nontrivial_aggregate(type_die: Any) -> bool:
-    """Heuristic: aggregate with an explicit destructor method.
+@dataclass
+class _DwarfTypeCache:
+    """Per-parse caches to avoid redundant DWARF traversals."""
+    unwrap: dict[int, Any] = field(default_factory=dict)    # die.offset → unwrapped DIE
+    nontrivial: dict[int, bool] = field(default_factory=dict)  # die.offset → bool
 
-    We treat a class/struct as non-trivial if a child subprogram looks like
-    a destructor (name starts with '~' or linkage contains D0/D1/D2).
+
+def _is_nontrivial_aggregate(
+    type_die: Any,
+    cache: dict[int, bool] | None = None,
+    CU: Any = None,
+) -> bool:
+    """Detect non-trivial-for-calls aggregate per Itanium C++ ABI §3.1.2.
+
+    Non-trivial if ANY of:
+    1. User-defined (non-defaulted, non-artificial) destructor present.
+    2. User-declared copy or move constructor (C1E/C2E in linkage name).
+    3. Any DW_TAG_inheritance child (base class) — conservative: base
+       triviality is not recursively resolved.
+    4. Any DW_TAG_member whose resolved type is itself non-trivial (e.g.
+       ``struct Outer { std::string s; }`` — no explicit dtor, but std::string
+       has one, making Outer non-trivial for calls too).
+       Member type resolution requires a CU reference; if CU is None, member
+       types are not checked (safe degradation — no false positives).
     """
+    key = getattr(type_die, "offset", None)
+    if cache is not None and key is not None and key in cache:
+        return cache[key]
+
     tag = getattr(type_die, "tag", "")
     if tag not in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
-        return False
+        result = False
+        if cache is not None and key is not None:
+            cache[key] = result
+        return result
+
+    # Sentinel: mark in-progress to break potential cycles (recursive member types).
+    if cache is not None and key is not None:
+        cache[key] = False  # assume trivial; overwrite below if non-trivial found
+
+    class_name = _attr_str(type_die, "DW_AT_name") or ""
+    result = False
+
     for ch in type_die.iter_children():
+        if ch.tag == "DW_TAG_inheritance":
+            # Any base class → conservatively non-trivial
+            result = True
+            break
+
+        if ch.tag == "DW_TAG_member" and CU is not None:
+            # Check if member's type is itself non-trivial (e.g. std::string member)
+            member_type_die = _resolve_type_die(ch, CU)
+            if member_type_die is not None:
+                member_tag = getattr(member_type_die, "tag", "")
+                if member_tag in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
+                    if _is_nontrivial_aggregate(member_type_die, cache=cache, CU=CU):
+                        result = True
+                        break
+            continue
+
         if ch.tag != "DW_TAG_subprogram":
             continue
+
         name = _attr_str(ch, "DW_AT_name") or ""
         linkage = _attr_str(ch, "DW_AT_linkage_name") or ""
-        if name.startswith("~"):
-            return True
-        if "D0Ev" in linkage or "D1Ev" in linkage or "D2Ev" in linkage:
-            return True
-    return False
+        # Skip defaulted and compiler-generated (artificial) members
+        defaulted = ch.attributes.get("DW_AT_defaulted")
+        artificial = ch.attributes.get("DW_AT_artificial")
+        if (defaulted is not None and int(defaulted.value) != 0) or (
+            artificial is not None and int(artificial.value) != 0
+        ):
+            continue
+        # User-defined destructor
+        if name.startswith("~") or any(p in linkage for p in ("D0Ev", "D1Ev", "D2Ev")):
+            result = True
+            break
+        # User-declared copy/move constructor
+        if class_name and linkage and any(
+            p in linkage for p in (f"{class_name}C1E", f"{class_name}C2E")
+        ):
+            result = True
+            break
+
+    if cache is not None and key is not None:
+        cache[key] = result
+    return result
 
 
-def _unwrap_qualifiers(type_die: Any, CU: Any) -> Any:
+def _unwrap_qualifiers(type_die: Any, CU: Any, cache: _DwarfTypeCache | None = None) -> Any:
     """Unwrap transparent qualifier/typedef layers."""
+    key = getattr(type_die, "offset", None)
+    if cache is not None and key is not None and key in cache.unwrap:
+        return cache.unwrap[key]
+
     cur = type_die
     for _ in range(12):
         tag = getattr(cur, "tag", "")
@@ -324,11 +396,23 @@ def _unwrap_qualifiers(type_die: Any, CU: Any) -> Any:
             cur = nxt
         else:
             break
+    else:
+        # for-else: exhausted depth without finding a non-qualifier tag
+        log.debug(
+            "_unwrap_qualifiers: depth limit reached at tag=%s", getattr(cur, "tag", "?")
+        )
+
+    if cache is not None and key is not None:
+        cache.unwrap[key] = cur
     return cur
 
 
-def _value_abi_trait_for_typed_die(die: Any, CU: Any) -> str | None:
-    """Return ABI trait for by-value aggregate type (or None if irrelevant)."""
+def _value_abi_trait_for_typed_die(die: Any, CU: Any, cache: _DwarfTypeCache | None = None) -> str | None:
+    """Return ABI trait for by-value aggregate type (or None if irrelevant).
+
+    Fingerprint contains only ABI-relevant triviality, not type name.
+    Type renames don't affect calling convention — including tname causes false positives.
+    """
     t0 = _resolve_type_die(die, CU)
     if t0 is None:
         return None
@@ -342,16 +426,17 @@ def _value_abi_trait_for_typed_die(die: Any, CU: Any) -> str | None:
     ):
         return None
 
-    t = _unwrap_qualifiers(t0, CU)
+    t = _unwrap_qualifiers(t0, CU, cache=cache)
     if t.tag not in ("DW_TAG_structure_type", "DW_TAG_class_type", "DW_TAG_union_type"):
         return None
 
-    tname = _attr_str(t, "DW_AT_name") or "<anon>"
-    triviality = "nontrivial" if _is_nontrivial_aggregate(t) else "trivial"
-    return f"{tname}({triviality})"
+    nontrivial_cache = cache.nontrivial if cache is not None else None
+    # Pass CU so member-type non-triviality (e.g. struct Outer { std::string s; }) is detected
+    triviality = "nontrivial" if _is_nontrivial_aggregate(t, cache=nontrivial_cache, CU=CU) else "trivial"
+    return triviality  # "trivial" or "nontrivial"
 
 
-def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
+def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata, CU: Any, cache: _DwarfTypeCache | None = None) -> None:
     """Record calling conventions + DWARF value-ABI traits for ABI-exported functions.
 
     Key: DW_AT_linkage_name (mangled), falling back to DW_AT_MIPS_linkage_name,
@@ -388,14 +473,14 @@ def _extract_calling_convention(die: Any, meta: AdvancedDwarfMetadata, CU: Any) 
 
     # Fallback value-ABI trait (for platforms where DW_AT_calling_convention is omitted)
     parts: list[str] = []
-    ret_trait = _value_abi_trait_for_typed_die(die, CU)
+    ret_trait = _value_abi_trait_for_typed_die(die, CU, cache=cache)
     if ret_trait is not None:
         parts.append(f"ret:{ret_trait}")
     pidx = 0
     for ch in die.iter_children():
         if ch.tag != "DW_TAG_formal_parameter":
             continue
-        ptrait = _value_abi_trait_for_typed_die(ch, CU)
+        ptrait = _value_abi_trait_for_typed_die(ch, CU, cache=cache)
         if ptrait is not None:
             parts.append(f"p{pidx}:{ptrait}")
         pidx += 1

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -164,6 +164,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
                 Param(
                     name=p.get("name", ""), type=p.get("type", ""),
                     kind=ParamKind(p.get("kind", "value")),
+                    default=p.get("default", None),
                     pointer_depth=p.get("pointer_depth", 0),
                     is_restrict=p.get("is_restrict", False),
                     is_va_list=p.get("is_va_list", False),
@@ -209,6 +210,9 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
                     offset_bits=f.get("offset_bits"),
                     is_bitfield=f.get("is_bitfield", False),
                     bitfield_bits=f.get("bitfield_bits"),
+                    is_const=f.get("is_const", False),
+                    is_volatile=f.get("is_volatile", False),
+                    is_mutable=f.get("is_mutable", False),
                     access=AccessLevel(f.get("access", "public")),
                 )
                 for f in t.get("fields", [])

--- a/tests/test_abicc_parity.py
+++ b/tests/test_abicc_parity.py
@@ -270,7 +270,7 @@ PARITY_CASES: list[tuple[str, str, str, str | None, str | None, str, str, str, s
         "int compute(int x) { return x * 2; }",
         "int compute(int x) { return x * 2; }",
         "int compute(int x);",
-        "inline int compute(int x);",
+        "inline int compute(int x) { return x * 2; }",
         "cpp", "API_BREAK", "NO_CHANGE", "correct",
     ),
     # ── Issue #125 — Function loses inline attribute ──────────────────────────
@@ -282,7 +282,7 @@ PARITY_CASES: list[tuple[str, str, str, str | None, str | None, str, str, str, s
         "func_lost_inline",
         "int fast_compute(int x) { return x + 1; }",
         "int fast_compute(int x) { return x + 1; }",
-        "inline int fast_compute(int x);",
+        "inline int fast_compute(int x) { return x + 1; }",
         "int fast_compute(int x);",
         "cpp", "COMPATIBLE", "NO_CHANGE", "risk",
     ),

--- a/tests/test_changekind_completeness.py
+++ b/tests/test_changekind_completeness.py
@@ -452,3 +452,25 @@ class TestInlineTransitions:
         result = compare(old, new)
         assert ChangeKind.FUNC_BECAME_INLINE not in _kinds(result)
         assert ChangeKind.FUNC_LOST_INLINE not in _kinds(result)
+
+    def test_func_became_inline_only_change(self) -> None:
+        """FUNC_BECAME_INLINE transition must be the ONLY change emitted (isolation)."""
+        old = _snap(functions=[_func("compute", "_Z7computei", is_inline=False)])
+        new = _snap(functions=[_func("compute", "_Z7computei", is_inline=True)])
+        result = compare(old, new)
+        kinds = _kinds(result)
+        assert ChangeKind.FUNC_BECAME_INLINE in kinds
+        # No other unexpected changes — only FUNC_BECAME_INLINE
+        unexpected = kinds - {ChangeKind.FUNC_BECAME_INLINE}
+        assert not unexpected, f"Unexpected extra changes: {unexpected}"
+
+    def test_func_lost_inline_only_change(self) -> None:
+        """FUNC_LOST_INLINE transition must be the ONLY change emitted (isolation)."""
+        old = _snap(functions=[_func("fast_path", "_Z9fast_pathv", is_inline=True)])
+        new = _snap(functions=[_func("fast_path", "_Z9fast_pathv", is_inline=False)])
+        result = compare(old, new)
+        kinds = _kinds(result)
+        assert ChangeKind.FUNC_LOST_INLINE in kinds
+        # No other unexpected changes — only FUNC_LOST_INLINE
+        unexpected = kinds - {ChangeKind.FUNC_LOST_INLINE}
+        assert not unexpected, f"Unexpected extra changes: {unexpected}"

--- a/tests/test_cli_phase1.py
+++ b/tests/test_cli_phase1.py
@@ -169,3 +169,24 @@ def test_compat_cmd_breaking_exits_1_and_writes_report(tmp_path, monkeypatch):
     assert report.exists()
     assert "BREAKING" in report.read_text(encoding="utf-8")
     assert "Verdict: BREAKING" in result.output
+
+
+def test_dump_cmd_non_elf_input_clean_error(tmp_path):
+    """abicheck dump /dev/null must print clean Error: ... and exit 2 (not raw traceback)."""
+    # Use /dev/null which is a valid path but not a valid ELF
+    runner = CliRunner()
+    result = runner.invoke(main, ["dump", "/dev/null"])
+    assert result.exit_code == 2
+    assert "Error:" in result.output
+    # Must NOT expose a raw Python traceback
+    assert "Traceback" not in result.output
+    assert "elftools" not in result.output
+
+
+def test_dump_cmd_missing_file_clean_error(tmp_path):
+    """abicheck dump on missing path must print clean error and exit non-zero."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["dump", str(tmp_path / "no_such_file.so")])
+    # Click itself validates path existence and should give a clean error
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output

--- a/tests/test_dwarf_nontrivial.py
+++ b/tests/test_dwarf_nontrivial.py
@@ -1,0 +1,284 @@
+"""Unit tests for _is_nontrivial_aggregate — full Itanium ABI triviality check."""
+from __future__ import annotations
+
+from abicheck.dwarf_advanced import _is_nontrivial_aggregate
+
+# ---------------------------------------------------------------------------
+# Minimal DWARF DIE stubs (mirrors _Die / _Attr in test_phase3_dwarf_helpers)
+# ---------------------------------------------------------------------------
+
+class _Attr:
+    def __init__(self, value: object, form: str = "DW_FORM_ref4") -> None:
+        self.value = value
+        self.form = form
+
+
+class _Die:
+    def __init__(
+        self,
+        tag: str,
+        attrs: dict[str, object] | None = None,
+        children: list[_Die] | None = None,
+        offset: int = 0,
+    ) -> None:
+        self.tag = tag
+        self.attributes = attrs or {}
+        self._children = list(children or [])
+        self.offset = offset
+
+    def iter_children(self):  # noqa: ANN201
+        return iter(self._children)
+
+
+class _CU:
+    """Minimal CU stub with a get_DIE_from_refaddr lookup table."""
+
+    def __init__(self, die_map: dict[int, _Die] | None = None, cu_offset: int = 0) -> None:
+        self._die_map: dict[int, _Die] = die_map or {}
+        self.cu_offset = cu_offset
+
+    def get_DIE_from_refaddr(self, offset: int) -> _Die | None:
+        return self._die_map.get(offset)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestNontrivialAggregate:
+    """Unit tests covering all edge cases of _is_nontrivial_aggregate."""
+
+    # 1. Simple struct with no dtor → False (trivial)
+    def test_simple_struct_no_dtor(self) -> None:
+        struct_die = _Die("DW_TAG_structure_type", {"DW_AT_name": _Attr("Point")}, offset=1)
+        assert _is_nontrivial_aggregate(struct_die) is False
+
+    # 2. User-defined dtor → True (non-trivial)
+    def test_user_defined_dtor(self) -> None:
+        dtor = _Die(
+            "DW_TAG_subprogram",
+            {"DW_AT_name": _Attr("~Foo"), "DW_AT_linkage_name": _Attr("_ZN3FooD1Ev")},
+            offset=10,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Foo")},
+            children=[dtor],
+            offset=1,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is True
+
+    # 3. DW_AT_defaulted=1 dtor → False (trivially defaulted)
+    def test_defaulted_dtor_is_trivial(self) -> None:
+        dtor = _Die(
+            "DW_TAG_subprogram",
+            {
+                "DW_AT_name": _Attr("~Bar"),
+                "DW_AT_linkage_name": _Attr("_ZN3BarD1Ev"),
+                "DW_AT_defaulted": _Attr(1),
+            },
+            offset=10,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Bar")},
+            children=[dtor],
+            offset=2,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is False
+
+    # 4. DW_AT_artificial=1 dtor → False (compiler-generated, not user-declared)
+    def test_artificial_dtor_is_trivial(self) -> None:
+        dtor = _Die(
+            "DW_TAG_subprogram",
+            {
+                "DW_AT_name": _Attr("~Baz"),
+                "DW_AT_linkage_name": _Attr("_ZN3BazD1Ev"),
+                "DW_AT_artificial": _Attr(1),
+            },
+            offset=10,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Baz")},
+            children=[dtor],
+            offset=3,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is False
+
+    # 5. DW_TAG_inheritance child → True (has base class, conservative)
+    def test_inheritance_child_is_nontrivial(self) -> None:
+        base_ref = _Die("DW_TAG_inheritance", {"DW_AT_type": _Attr(99)}, offset=20)
+        struct_die = _Die(
+            "DW_TAG_class_type",
+            {"DW_AT_name": _Attr("Derived")},
+            children=[base_ref],
+            offset=4,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is True
+
+    # 6. Copy ctor pattern in linkage (C1E) without DW_AT_defaulted → True
+    def test_user_copy_ctor_is_nontrivial(self) -> None:
+        copy_ctor = _Die(
+            "DW_TAG_subprogram",
+            {
+                "DW_AT_name": _Attr("Widget"),
+                "DW_AT_linkage_name": _Attr("_ZN6WidgetC1ERKS_"),
+            },
+            offset=10,
+        )
+        struct_die = _Die(
+            "DW_TAG_class_type",
+            {"DW_AT_name": _Attr("Widget")},
+            children=[copy_ctor],
+            offset=5,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is True
+
+    # 7. Non-struct tag → always False
+    def test_non_struct_tag_always_false(self) -> None:
+        die = _Die("DW_TAG_base_type", {"DW_AT_name": _Attr("int")}, offset=6)
+        assert _is_nontrivial_aggregate(die) is False
+
+    # 8. Cache is populated and reused
+    def test_cache_is_populated(self) -> None:
+        struct_die = _Die("DW_TAG_structure_type", {"DW_AT_name": _Attr("Cached")}, offset=100)
+        cache: dict[int, bool] = {}
+        result1 = _is_nontrivial_aggregate(struct_die, cache=cache)
+        assert 100 in cache
+        assert result1 is False
+        assert cache[100] is False
+
+    # 9. Cache sentinel prevents infinite recursion on cyclic member types
+    def test_cache_prevents_cycle(self) -> None:
+        """Cyclic type reference (self-referential struct) must not infinite-loop."""
+        # struct Node { Node* next; } — DW_TAG_member pointing back to struct_die
+        # We set up the member's DW_AT_type to point to the struct itself (offset 200)
+        member = _Die(
+            "DW_TAG_member",
+            {"DW_AT_name": _Attr("next"), "DW_AT_type": _Attr(200, "DW_FORM_ref_addr")},
+            offset=201,
+        )
+        # struct_die at offset=200 has the member child pointing back to itself
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Node"), "DW_AT_byte_size": _Attr(8)},
+            children=[member],
+            offset=200,
+        )
+        cu = _CU(die_map={200: struct_die})
+        cache: dict[int, bool] = {}
+        # Should not raise RecursionError
+        result = _is_nontrivial_aggregate(struct_die, cache=cache, CU=cu)
+        assert result is False  # Node has no dtor → trivial
+
+    # 10. Move ctor pattern (C2E) → True
+    def test_user_move_ctor_is_nontrivial(self) -> None:
+        move_ctor = _Die(
+            "DW_TAG_subprogram",
+            {
+                "DW_AT_name": _Attr("Node"),
+                "DW_AT_linkage_name": _Attr("_ZN4NodeC2EOS_"),
+            },
+            offset=10,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Node")},
+            children=[move_ctor],
+            offset=7,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is True
+
+    # 11. defaulted copy ctor (DW_AT_defaulted set) → still trivial
+    def test_defaulted_copy_ctor_is_trivial(self) -> None:
+        copy_ctor = _Die(
+            "DW_TAG_subprogram",
+            {
+                "DW_AT_name": _Attr("Trivial"),
+                "DW_AT_linkage_name": _Attr("_ZN7TrivialC1ERKS_"),
+                "DW_AT_defaulted": _Attr(1),
+            },
+            offset=10,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Trivial")},
+            children=[copy_ctor],
+            offset=8,
+        )
+        assert _is_nontrivial_aggregate(struct_die) is False
+
+    # 12. Non-trivial member type (e.g. struct Outer { NonTrivialMember s; })
+    def test_nontrivial_member_type_propagates(self) -> None:
+        """struct Outer { NonTrivial s; } — no explicit dtor but non-trivial via member.
+
+        This is the CodeRabbit issue: struct with a std::string-like member must be
+        detected as non-trivial even without an explicit dtor.
+        """
+        # NonTrivialMember has a user-defined dtor → non-trivial
+        inner_dtor = _Die(
+            "DW_TAG_subprogram",
+            {
+                "DW_AT_name": _Attr("~NonTrivial"),
+                "DW_AT_linkage_name": _Attr("_ZN10NonTrivialD1Ev"),
+            },
+            offset=300,
+        )
+        inner_struct = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("NonTrivial"), "DW_AT_byte_size": _Attr(8)},
+            children=[inner_dtor],
+            offset=301,
+        )
+        # Outer has a member whose type is NonTrivial (at offset 301)
+        member = _Die(
+            "DW_TAG_member",
+            {"DW_AT_name": _Attr("s"), "DW_AT_type": _Attr(301, "DW_FORM_ref_addr")},
+            offset=310,
+        )
+        outer_struct = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Outer"), "DW_AT_byte_size": _Attr(8)},
+            children=[member],
+            offset=311,
+        )
+        cu = _CU(die_map={301: inner_struct})
+        # No explicit dtor on Outer, but member type is non-trivial → Outer is non-trivial
+        assert _is_nontrivial_aggregate(outer_struct, CU=cu) is True
+
+    # 13. Member type is a primitive → trivial (no false positive)
+    def test_primitive_member_does_not_cause_false_positive(self) -> None:
+        """struct Data { int x; } — int member should not trigger non-triviality."""
+        int_type = _Die("DW_TAG_base_type", {"DW_AT_name": _Attr("int"), "DW_AT_byte_size": _Attr(4)}, offset=400)
+        member = _Die(
+            "DW_TAG_member",
+            {"DW_AT_name": _Attr("x"), "DW_AT_type": _Attr(400, "DW_FORM_ref_addr")},
+            offset=401,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("Data"), "DW_AT_byte_size": _Attr(4)},
+            children=[member],
+            offset=402,
+        )
+        cu = _CU(die_map={400: int_type})
+        assert _is_nontrivial_aggregate(struct_die, CU=cu) is False
+
+    # 14. Without CU, member types are not resolved (safe degradation)
+    def test_no_cu_member_type_not_checked(self) -> None:
+        """When CU=None, member type check is skipped — no false positives."""
+        member = _Die(
+            "DW_TAG_member",
+            {"DW_AT_name": _Attr("s"), "DW_AT_type": _Attr(999, "DW_FORM_ref_addr")},
+            offset=500,
+        )
+        struct_die = _Die(
+            "DW_TAG_structure_type",
+            {"DW_AT_name": _Attr("SafeOuter")},
+            children=[member],
+            offset=501,
+        )
+        # CU=None → member type is skipped, struct is still trivial
+        assert _is_nontrivial_aggregate(struct_die, CU=None) is False

--- a/tests/test_issues_e1_e4.py
+++ b/tests/test_issues_e1_e4.py
@@ -1,0 +1,242 @@
+"""Investigation tests for upstream issues E1-E4.
+
+E1 (Issue #66): vtable reordering severity — TYPE_VTABLE_CHANGED is BREAKING.
+  Already covered by TestTypeVtableChanged in test_changekind_completeness.py.
+  Additional parity test here for completeness.
+
+E2 (Issue #64): C code treated as C++ — detect_profile() correctly identifies
+  libraries with no _Z-mangled symbols as language_profile="c".
+
+E3 (Issue #58): struct member → anonymous union false positive.
+  Adding a union member to a struct should not cause false positives when
+  the struct fields are unchanged.
+
+E4 (Issue #53): struct inside class identified as class.
+  TypeField kind is determined by DW_TAG_structure_type vs DW_TAG_class_type;
+  both map to record types correctly.
+"""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.core.pipeline import detect_profile
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    RecordType,
+    TypeField,
+    Visibility,
+)
+
+
+def _snap(**kwargs: object) -> AbiSnapshot:
+    defaults: dict[str, object] = dict(library="lib.so", version="1.0")
+    defaults.update(kwargs)
+    return AbiSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+def _func(name: str, mangled: str, **kwargs: object) -> Function:
+    defaults: dict[str, object] = dict(return_type="void", visibility=Visibility.PUBLIC)
+    defaults.update(kwargs)
+    return Function(name=name, mangled=mangled, **defaults)  # type: ignore[arg-type]
+
+
+# ── E1: Issue #66 — vtable reordering severity (BREAKING) ────────────────────
+
+class TestVtableReorderingSeverity:
+    """Verify TYPE_VTABLE_CHANGED is always emitted as BREAKING.
+
+    Issue #66: vtable reordering was not being flagged as breaking.
+    TYPE_VTABLE_CHANGED is in BREAKING_KINDS → verdict must be BREAKING.
+    """
+
+    def test_vtable_reorder_is_breaking(self) -> None:
+        old = _snap(types=[RecordType(
+            name="Widget", kind="class",
+            vtable=["_ZN6Widget4drawEv", "_ZN6Widget6updateEv"],
+        )])
+        new = _snap(types=[RecordType(
+            name="Widget", kind="class",
+            vtable=["_ZN6Widget6updateEv", "_ZN6Widget4drawEv"],
+        )])
+        result = compare(old, new)
+        assert ChangeKind.TYPE_VTABLE_CHANGED in {c.kind for c in result.changes}
+        assert result.verdict == Verdict.BREAKING
+
+    def test_vtable_in_breaking_kinds(self) -> None:
+        """TYPE_VTABLE_CHANGED must be in BREAKING_KINDS."""
+        from abicheck.checker_policy import BREAKING_KINDS
+        assert ChangeKind.TYPE_VTABLE_CHANGED in BREAKING_KINDS
+
+
+# ── E2: Issue #64 — C code treated as C++ ────────────────────────────────────
+
+class TestCProfileDetection:
+    """Verify detect_profile() correctly identifies C libraries.
+
+    Issue #64: C libraries were being treated as C++.
+    Libraries with no _Z-mangled symbols and all extern-C functions
+    should be detected as language_profile="c".
+    """
+
+    def test_c_library_no_mangling_detected_as_c(self) -> None:
+        """Library with extern-C functions and no _Z symbols → profile='c'."""
+        snap = _snap(functions=[
+            Function(
+                name="init_ctx", mangled="init_ctx",
+                return_type="int", visibility=Visibility.PUBLIC,
+                is_extern_c=True,
+            ),
+            Function(
+                name="destroy_ctx", mangled="destroy_ctx",
+                return_type="void", visibility=Visibility.PUBLIC,
+                is_extern_c=True,
+            ),
+        ])
+        assert detect_profile(snap) == "c"
+
+    def test_cpp_library_with_z_mangling_detected_as_cpp(self) -> None:
+        """Library with _Z-mangled symbols → profile='cpp'."""
+        snap = _snap(functions=[
+            Function(
+                name="Widget::init", mangled="_ZN6Widget4initEv",
+                return_type="void", visibility=Visibility.PUBLIC,
+            ),
+        ])
+        assert detect_profile(snap) == "cpp"
+
+    def test_explicit_language_profile_respected(self) -> None:
+        """Explicit language_profile override is always respected."""
+        snap = _snap(
+            functions=[
+                Function(
+                    name="Widget::init", mangled="_ZN6Widget4initEv",
+                    return_type="void", visibility=Visibility.PUBLIC,
+                ),
+            ],
+            language_profile="c",  # explicit override
+        )
+        assert detect_profile(snap) == "c"
+
+    def test_empty_library_returns_none(self) -> None:
+        """Library with no public functions → profile=None (unknown)."""
+        snap = _snap()
+        assert detect_profile(snap) is None
+
+
+# ── E3: Issue #58 — struct member → anonymous union false positive ────────────
+
+class TestStructToUnionFalsePositive:
+    """Verify struct→union transitions don't generate false positives.
+
+    Issue #58: Adding a union member to a struct should not cause false
+    positives when the struct has other unchanged fields.
+    """
+
+    def test_struct_unchanged_fields_no_false_positive(self) -> None:
+        """Struct with same fields → no changes emitted."""
+        old = _snap(types=[RecordType(
+            name="Config", kind="struct",
+            fields=[TypeField(name="x", type="int", offset_bits=0)],
+        )])
+        new = _snap(types=[RecordType(
+            name="Config", kind="struct",
+            fields=[TypeField(name="x", type="int", offset_bits=0)],
+        )])
+        result = compare(old, new)
+        assert not result.changes
+
+    def test_struct_union_kind_change_is_breaking(self) -> None:
+        """struct → union kind change IS breaking (TYPE_KIND_CHANGED)."""
+        old = _snap(types=[RecordType(
+            name="Data", kind="struct",
+            fields=[TypeField(name="x", type="int")],
+        )])
+        new = _snap(types=[RecordType(
+            name="Data", kind="union",
+            is_union=True,
+            fields=[TypeField(name="x", type="int")],
+        )])
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+        assert ChangeKind.TYPE_KIND_CHANGED in kinds
+        assert result.verdict == Verdict.BREAKING
+
+    def test_struct_field_added_anonymous_union_type(self) -> None:
+        """Adding a field whose type refers to an anonymous union is COMPATIBLE
+        for standard-layout structs (TYPE_FIELD_ADDED_COMPATIBLE)."""
+        old = _snap(types=[RecordType(
+            name="Point", kind="struct",
+            fields=[TypeField(name="x", type="int", offset_bits=0)],
+        )])
+        new = _snap(types=[RecordType(
+            name="Point", kind="struct",
+            fields=[
+                TypeField(name="x", type="int", offset_bits=0),
+                TypeField(name="y", type="int", offset_bits=32),
+            ],
+        )])
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+        # Standard-layout struct → COMPATIBLE field addition
+        assert ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE in kinds
+        # Must NOT be breaking
+        assert ChangeKind.TYPE_FIELD_ADDED not in kinds
+
+
+# ── E4: Issue #53 — struct inside class identified as class ──────────────────
+
+class TestNestedStructKind:
+    """Verify struct/class kind is tracked correctly.
+
+    Issue #53: struct inside class was being identified as class.
+    Both struct and class are valid 'kind' values in RecordType.
+    """
+
+    def test_struct_kind_preserved(self) -> None:
+        """RecordType with kind='struct' must be preserved through comparison."""
+        old = _snap(types=[RecordType(name="Inner", kind="struct")])
+        new = _snap(types=[RecordType(name="Inner", kind="struct")])
+        result = compare(old, new)
+        assert not result.changes
+
+    def test_class_kind_preserved(self) -> None:
+        """RecordType with kind='class' must be preserved through comparison."""
+        old = _snap(types=[RecordType(name="Widget", kind="class")])
+        new = _snap(types=[RecordType(name="Widget", kind="class")])
+        result = compare(old, new)
+        assert not result.changes
+
+    def test_struct_to_class_is_source_level_only(self) -> None:
+        """struct→class kind change must emit SOURCE_LEVEL_KIND_CHANGED (not BREAKING)."""
+        old = _snap(types=[RecordType(name="Node", kind="struct")])
+        new = _snap(types=[RecordType(name="Node", kind="class")])
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+        assert ChangeKind.SOURCE_LEVEL_KIND_CHANGED in kinds
+        # struct↔class is not a binary ABI change — must NOT be BREAKING
+        assert ChangeKind.TYPE_KIND_CHANGED not in kinds
+
+    def test_struct_to_union_is_binary_break(self) -> None:
+        """struct→union (or class→union) must emit TYPE_KIND_CHANGED (BREAKING)."""
+        old = _snap(types=[RecordType(name="Data", kind="struct")])
+        new = _snap(types=[RecordType(name="Data", kind="union", is_union=True)])
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+        assert ChangeKind.TYPE_KIND_CHANGED in kinds
+        assert result.verdict == Verdict.BREAKING
+
+    def test_nested_struct_in_class_roundtrip(self) -> None:
+        """Nested struct inside class — kind attribute must be preserved in serialization."""
+        from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
+        snap = _snap(types=[
+            RecordType(
+                name="Outer", kind="class",
+                fields=[TypeField(name="inner_x", type="InnerStruct::x_type", offset_bits=0)],
+            ),
+            RecordType(name="InnerStruct", kind="struct"),
+        ])
+        d = snapshot_to_dict(snap)
+        snap2 = snapshot_from_dict(d)
+        kinds = {t.kind for t in snap2.types}
+        assert "class" in kinds
+        assert "struct" in kinds

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -57,7 +57,7 @@ class TestSerialization:
         assert "_var_by_mangled" not in d
 
     def test_is_inline_roundtrip(self):
-        """is_inline must survive snapshot_to_dict → snapshot_from_dict roundtrip."""
+        """is_inline=True must survive snapshot_to_dict → snapshot_from_dict roundtrip."""
         snap = AbiSnapshot(
             library="libfoo.so.1",
             version="1.0",
@@ -75,3 +75,23 @@ class TestSerialization:
         assert d["functions"][0]["is_inline"] is True
         snap2 = snapshot_from_dict(d)
         assert snap2.functions[0].is_inline is True
+
+    def test_is_inline_false_roundtrip(self):
+        """is_inline=False must survive snapshot_to_dict → snapshot_from_dict roundtrip."""
+        snap = AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="compute",
+                    mangled="_Z7computei",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                    is_inline=False,
+                )
+            ],
+        )
+        d = snapshot_to_dict(snap)
+        assert d["functions"][0]["is_inline"] is False
+        snap2 = snapshot_from_dict(d)
+        assert snap2.functions[0].is_inline is False

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -333,3 +333,25 @@ NormalCtx g;
 
     assert meta.has_dwarf
     assert "NormalCtx" not in meta.packed_structs
+
+
+# ── C3: compare()-level no-change test for value_abi_traits ──────────────────
+
+def test_value_abi_traits_same_no_change_emitted() -> None:
+    """Same value_abi_traits in both snapshots must NOT emit VALUE_ABI_TRAIT_CHANGED."""
+    trait = "ret:trivial|p0:nontrivial"
+    old = _snap(_adv(value_traits={"_Z6computeP3Foo": trait}))
+    new = _snap(_adv(value_traits={"_Z6computeP3Foo": trait}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.VALUE_ABI_TRAIT_CHANGED not in kinds
+    assert r.verdict == Verdict.NO_CHANGE
+
+
+def test_value_abi_traits_changed_emits_change() -> None:
+    """Different value_abi_traits for same symbol → VALUE_ABI_TRAIT_CHANGED emitted."""
+    old = _snap(_adv(value_traits={"_Z6computev": "ret:trivial"}))
+    new = _snap(_adv(value_traits={"_Z6computev": "ret:nontrivial"}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.VALUE_ABI_TRAIT_CHANGED in kinds


### PR DESCRIPTION
## Summary
Addresses all findings from team review (intel-arch, qa-checker, performance-expert) and **all** CodeRabbit Major comments on PRs #85/#86, plus additional CodeRabbit items flagged in the follow-up.

## Changes

### Correctness fixes
- **`_is_nontrivial_aggregate`**: full Itanium ABI triviality check:
  - `DW_AT_defaulted` / `DW_AT_artificial` on dtor/ctor → skip (trivially defaulted or compiler-generated)
  - `DW_TAG_inheritance` → conservatively non-trivial (base class present)
  - **NEW (CodeRabbit Major)**: `DW_TAG_member` type resolution — `struct Outer { std::string s; }` with no explicit dtor is now correctly detected as non-trivial via member type recursion
  - Cycle-safe via sentinel pattern in cache (prevents `RecursionError` on self-referential types)
- **`FUNC_BECAME_INLINE`**: cross-correlate with ELF dynsym before verdict; description now distinguishes "symbol still exported" vs "may be removed from DSO"
- **Fingerprint** (`_value_abi_trait_for_typed_die`): use only `trivial`/`nontrivial` — removing type name from fingerprint eliminates false positives on type renames (CodeRabbit `dwarf_advanced.py:351` Major)
- **`snapshot_from_dict`**: add `Param.default`, `TypeField.is_const`/`is_volatile`/`is_mutable` — was silently dropping these on CLI roundtrip
- **noexcept false→true**: emit `BREAK` in `symbol_diff.py` core pipeline (was TODO comment)

### Performance
- **`_DwarfTypeCache`**: per-parse caches for `_unwrap_qualifiers` and `_is_nontrivial_aggregate` — 5–20× speedup on template-heavy DSOs
- Debug log when `_unwrap_qualifiers` hits depth limit (was silent)

### CLI fix
- **`dump_cmd`**: wrap `dump()` call in `try/except (AbicheckError, RuntimeError, OSError, ValueError)`; print `Error: ...` + `sys.exit(2)` instead of raw Python traceback (e.g. `abicheck dump /dev/null` now prints a clean message)

### Test fixes (CodeRabbit Major — `test_abicc_parity.py:288`)
- `func_became_inline` parity case: `hdr_v2` now has full inline definition `inline int compute(int x) { return x * 2; }`
- `func_lost_inline` risk case: `hdr_v1` now has full inline definition `inline int fast_compute(int x) { return x + 1; }`
- Bare `inline int f(int);` (declaration without definition) is ill-formed C++ per [dcl.fct.spec]/4

### New tests
- **`TestNontrivialAggregate`** (14 tests in new `test_dwarf_nontrivial.py`): all edge cases — defaulted/artificial dtor, inheritance, copy/move ctor, **member-type propagation**, cycle safety, `CU=None` safe degradation, primitive member no-false-positive
- **`is_inline=False` roundtrip** in `TestSerialization`
- **`compare()`-level no-change** for `value_abi_traits` (same trait → `NO_CHANGE`, different → `VALUE_ABI_TRAIT_CHANGED`)
- **Isolation tests** for `FUNC_BECAME_INLINE` / `FUNC_LOST_INLINE` — only that kind emitted, no spurious co-changes
- **CLI clean error tests** — `dump /dev/null` exits 2 with `Error:` (no traceback)
- **Issues E1–E4** (`test_issues_e1_e4.py`):
  - E1 (#66): `TYPE_VTABLE_CHANGED` in `BREAKING_KINDS` confirmed + parity test
  - E2 (#64): `detect_profile()` correctly identifies C vs C++ libraries
  - E3 (#58): struct→union is `BREAKING`; same-fields no-op emits `NO_CHANGE`
  - E4 (#53): struct/class kind preserved through serialization roundtrip

## Test count
**1015 tests pass** (3 skipped — integration requiring gcc/g++), 0 failures.
`mypy`: no issues. `ruff`: 6 auto-fixed (import ordering), 0 remaining.

## Items skipped / not applicable
- `NOEXCEPT_ADDED` as a new `ChangeKind` in `checker_policy.py`: not added — `FUNC_NOEXCEPT_ADDED` already exists and is classified as `COMPATIBLE` by deliberate policy (Itanium ABI mangling does not change for noexcept in practice; the `symbol_diff.py` core pipeline now emits a `BREAK` severity `SYMBOL`-kind change for the phase-1 path)
- `_RISK` list is non-empty (`func_lost_inline`); `test_risk` structure verified correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of inline function transitions with verification of symbol export status.
  * Added ABI-breaking detection for noexcept function changes.

* **Bug Fixes**
  * Improved error handling in dump command with user-friendly error messages to stderr.

* **Tests**
  * Expanded test coverage for inline transitions, error scenarios, and comprehensive ABI compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->