### PR TITLE
fix: dedup mangled symbols, flatten anon-unions, normalize struct tag prefixes

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1762,16 +1762,32 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 
 def _normalize_type_name(name: str) -> str:
-    """Strip 'struct '/'class '/'union ' prefixes for stable DWARF↔castxml comparison.
+    """Normalize a C/C++ type name for stable DWARF↔castxml comparison.
 
-    DWARF parsers historically prefix the tag keyword to type names
-    (e.g. "struct Foo"), while castxml returns bare names ("Foo").
-    Normalizing before comparison prevents false STRUCT_FIELD_TYPE_CHANGED.
+    Strips leading/trailing whitespace, CV-qualifiers, pointer/reference
+    decorations, and 'struct'/'class'/'union' tag keywords so that semantically
+    equivalent names compare equal regardless of DWARF vs castxml source:
+
+    Examples::
+
+        "struct Foo"     → "Foo"
+        "const struct Foo *" → "Foo"
+        "class Bar &"    → "Bar"
+        "union U"        → "U"
+        "int"            → "int"   (unchanged)
+
+    Note: this normalizer is intentionally lossy for comparison purposes only.
+    The original type names are still preserved in Change.old_value/new_value.
     """
-    for prefix in ("struct ", "class ", "union "):
-        if name.startswith(prefix):
-            return name[len(prefix):]
-    return name
+    import re as _re
+    s = name.strip()
+    # Remove trailing pointer/reference decorators and CV-qualifiers
+    s = _re.sub(r"[\s*&]+$", "", s).strip()
+    # Remove leading CV-qualifiers
+    s = _re.sub(r"^(const|volatile)(\s+(const|volatile))?\s+", "", s).strip()
+    # Remove struct/class/union tag keyword
+    s = _re.sub(r"^(struct|class|union)\s+", "", s).strip()
+    return s
 
 
 def _diff_struct_layouts(o: object, n: object) -> list[Change]:

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1833,8 +1833,16 @@ def _diff_struct_layouts(o: object, n: object) -> list[Change]:
 
             # Field type drift:
             # - catches same-size type substitutions (int→float, Foo*→Bar*)
+            # - strip "struct "/"class "/"union " prefixes for stable comparison
             # - still includes explicit size drift when known on both sides
-            type_name_changed = old_f.type_name != new_f.type_name
+            def _normalize_type_name(name: str) -> str:
+                """Strip 'struct '/'class '/'union ' prefixes for stable comparison."""
+                for prefix in ("struct ", "class ", "union "):
+                    if name.startswith(prefix):
+                        return name[len(prefix):]
+                return name
+
+            type_name_changed = _normalize_type_name(old_f.type_name) != _normalize_type_name(new_f.type_name)
             type_size_changed = (
                 old_f.byte_size > 0
                 and new_f.byte_size > 0

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1761,6 +1761,19 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     return changes
 
 
+def _normalize_type_name(name: str) -> str:
+    """Strip 'struct '/'class '/'union ' prefixes for stable DWARF↔castxml comparison.
+
+    DWARF parsers historically prefix the tag keyword to type names
+    (e.g. "struct Foo"), while castxml returns bare names ("Foo").
+    Normalizing before comparison prevents false STRUCT_FIELD_TYPE_CHANGED.
+    """
+    for prefix in ("struct ", "class ", "union "):
+        if name.startswith(prefix):
+            return name[len(prefix):]
+    return name
+
+
 def _diff_struct_layouts(o: object, n: object) -> list[Change]:
     from .dwarf_metadata import StructLayout
 
@@ -1835,13 +1848,6 @@ def _diff_struct_layouts(o: object, n: object) -> list[Change]:
             # - catches same-size type substitutions (int→float, Foo*→Bar*)
             # - strip "struct "/"class "/"union " prefixes for stable comparison
             # - still includes explicit size drift when known on both sides
-            def _normalize_type_name(name: str) -> str:
-                """Strip 'struct '/'class '/'union ' prefixes for stable comparison."""
-                for prefix in ("struct ", "class ", "union "):
-                    if name.startswith(prefix):
-                        return name[len(prefix):]
-                return name
-
             type_name_changed = _normalize_type_name(old_f.type_name) != _normalize_type_name(new_f.type_name)
             type_size_changed = (
                 old_f.byte_size > 0

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -494,9 +494,14 @@ class _CastxmlParser:
                     field_elements.append(member_el)
 
         for child in field_elements:
+            child_name = child.get("name", "")
+            if not child_name:
+                # Anonymous struct/union member — flatten its fields into parent
+                fields.extend(self._expand_anonymous_field(child))
+                continue
             bitfield_bits, is_bitfield = self._parse_bitfield_bits(child.get("bits"))
             fields.append(TypeField(
-                name=child.get("name", ""),
+                name=child_name,
                 type=self._type_name(child.get("type", "")),
                 offset_bits=self._optional_int_attr(child, "offset"),
                 is_bitfield=is_bitfield,
@@ -504,6 +509,49 @@ class _CastxmlParser:
                 access=self._access_level(child),
             ))
         return fields
+
+    def _expand_anonymous_field(self, field_el: Any) -> list[TypeField]:
+        """Flatten anonymous struct/union field into the parent's field list.
+
+        In castxml output, anonymous unions/structs inside a struct appear as
+        ``Field`` elements with ``name=""`` pointing to a ``Union`` or ``Struct``
+        element.  We inline their named fields at the correct offset to prevent
+        false ``TYPE_FIELD_REMOVED`` reports when a named field moves into an
+        anonymous union (issue #58).
+        """
+        type_id = field_el.get("type", "")
+        type_el = self._resolve(type_id)
+        if type_el is None or type_el.tag not in ("Union", "Struct"):
+            return []
+
+        parent_offset = self._optional_int_attr(field_el, "offset") or 0
+        result: list[TypeField] = []
+
+        # Collect inner Field elements (inline children or members attribute)
+        inner_fields: list[Any] = [c for c in type_el if c.tag == "Field"]
+        if not inner_fields:
+            for mid in type_el.get("members", "").split():
+                member_el = self._id_map.get(mid)
+                if member_el is not None and member_el.tag == "Field":
+                    inner_fields.append(member_el)
+
+        for inner in inner_fields:
+            inner_name = inner.get("name", "")
+            if not inner_name:
+                # Doubly-nested anonymous member — recurse
+                result.extend(self._expand_anonymous_field(inner))
+                continue
+            inner_offset = self._optional_int_attr(inner, "offset") or 0
+            bitfield_bits, is_bitfield = self._parse_bitfield_bits(inner.get("bits"))
+            result.append(TypeField(
+                name=inner_name,
+                type=self._type_name(inner.get("type", "")),
+                offset_bits=parent_offset + inner_offset,
+                is_bitfield=is_bitfield,
+                bitfield_bits=bitfield_bits,
+                access=self._access_level(inner),
+            ))
+        return result
 
     @staticmethod
     def _parse_bitfield_bits(bits_raw: str | None) -> tuple[int | None, bool]:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -511,7 +511,7 @@ class _CastxmlParser:
         return fields
 
     def _expand_anonymous_field(
-        self, field_el: Any, _depth: int = 0
+        self, field_el: Any, _depth: int = 0, _outer_offset: int = 0
     ) -> list[TypeField]:
         """Flatten anonymous struct/union field into the parent's field list.
 
@@ -522,6 +522,8 @@ class _CastxmlParser:
         anonymous union (issue #58).
 
         ``_depth`` guards against malformed/cyclic XML (max nesting: 16).
+        ``_outer_offset`` carries the accumulated offset from outer anonymous
+        members so doubly-nested fields get correct absolute ``offset_bits``.
         """
         if _depth > 16:
             return []
@@ -530,7 +532,7 @@ class _CastxmlParser:
         if type_el is None or type_el.tag not in ("Union", "Struct"):
             return []
 
-        parent_offset = self._optional_int_attr(field_el, "offset") or 0
+        this_offset = _outer_offset + (self._optional_int_attr(field_el, "offset") or 0)
         result: list[TypeField] = []
 
         # Collect inner Field elements (inline children or members attribute)
@@ -544,15 +546,17 @@ class _CastxmlParser:
         for inner in inner_fields:
             inner_name = inner.get("name", "")
             if not inner_name:
-                # Doubly-nested anonymous member — recurse
-                result.extend(self._expand_anonymous_field(inner, _depth + 1))
+                # Doubly-nested anonymous member — recurse, passing accumulated offset
+                result.extend(self._expand_anonymous_field(
+                    inner, _depth + 1, _outer_offset=this_offset,
+                ))
                 continue
             inner_offset = self._optional_int_attr(inner, "offset") or 0
             bitfield_bits, is_bitfield = self._parse_bitfield_bits(inner.get("bits"))
             result.append(TypeField(
                 name=inner_name,
                 type=self._type_name(inner.get("type", "")),
-                offset_bits=parent_offset + inner_offset,
+                offset_bits=this_offset + inner_offset,
                 is_bitfield=is_bitfield,
                 bitfield_bits=bitfield_bits,
                 access=self._access_level(inner),

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -510,7 +510,9 @@ class _CastxmlParser:
             ))
         return fields
 
-    def _expand_anonymous_field(self, field_el: Any) -> list[TypeField]:
+    def _expand_anonymous_field(
+        self, field_el: Any, _depth: int = 0
+    ) -> list[TypeField]:
         """Flatten anonymous struct/union field into the parent's field list.
 
         In castxml output, anonymous unions/structs inside a struct appear as
@@ -518,7 +520,11 @@ class _CastxmlParser:
         element.  We inline their named fields at the correct offset to prevent
         false ``TYPE_FIELD_REMOVED`` reports when a named field moves into an
         anonymous union (issue #58).
+
+        ``_depth`` guards against malformed/cyclic XML (max nesting: 16).
         """
+        if _depth > 16:
+            return []
         type_id = field_el.get("type", "")
         type_el = self._resolve(type_id)
         if type_el is None or type_el.tag not in ("Union", "Struct"):
@@ -539,7 +545,7 @@ class _CastxmlParser:
             inner_name = inner.get("name", "")
             if not inner_name:
                 # Doubly-nested anonymous member — recurse
-                result.extend(self._expand_anonymous_field(inner))
+                result.extend(self._expand_anonymous_field(inner, _depth + 1))
                 continue
             inner_offset = self._optional_int_attr(inner, "offset") or 0
             bitfield_bits, is_bitfield = self._parse_bitfield_bits(inner.get("bits"))

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -557,8 +557,10 @@ def _compute_type_info(
 
 def _compute_record_type_info(die: Any, tag: str) -> tuple[str, int]:
     name = _attr_str(die, "DW_AT_name") or "<anon>"
-    prefix = "struct " if tag == "DW_TAG_structure_type" else ""
-    return (f"{prefix}{name}", _attr_int(die, "DW_AT_byte_size"))
+    # Use bare names for struct/class/union to match castxml naming.
+    # Prefixes like "struct Foo" vs "Foo" can cause false type-drift reports
+    # when comparing DWARF-derived layouts to castxml/header-derived models.
+    return (name, _attr_int(die, "DW_AT_byte_size"))
 
 
 def _compute_pointer_like_info(

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -177,7 +177,12 @@ class AbiSnapshot:
 
         type_map: dict[str, RecordType] = {}
         for t in self.types:
-            if t.name not in type_map:
+            if t.name in type_map:
+                _model_log.warning(
+                    "Duplicate type name skipped (first-wins): %s in %s@%s",
+                    t.name, self.library, self.version,
+                )
+            else:
                 type_map[t.name] = t
         self._type_by_name = type_map
 

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -1,6 +1,7 @@
 """ABI data model — shared across dumper, checker and reporter."""
 from __future__ import annotations
 
+import logging as _logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -9,6 +10,8 @@ if TYPE_CHECKING:
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .elf_metadata import ElfMetadata
+
+_model_log = _logging.getLogger(__name__)
 
 
 class Visibility(str, Enum):
@@ -149,9 +152,34 @@ class AbiSnapshot:
     _type_by_name: dict[str, RecordType] | None = field(default=None, repr=False, compare=False)
 
     def index(self) -> None:
-        self._func_by_mangled = {f.mangled: f for f in self.functions}
-        self._var_by_mangled = {v.mangled: v for v in self.variables}
-        self._type_by_name = {t.name: t for t in self.types}
+        """Build lookup indexes. Uses first-wins for duplicate mangled names."""
+        func_map: dict[str, Function] = {}
+        for f in self.functions:
+            if f.mangled in func_map:
+                _model_log.warning(
+                    "Duplicate mangled symbol skipped (first-wins): %s in %s@%s",
+                    f.mangled, self.library, self.version,
+                )
+            else:
+                func_map[f.mangled] = f
+        self._func_by_mangled = func_map
+
+        var_map: dict[str, Variable] = {}
+        for v in self.variables:
+            if v.mangled in var_map:
+                _model_log.warning(
+                    "Duplicate mangled variable skipped (first-wins): %s in %s@%s",
+                    v.mangled, self.library, self.version,
+                )
+            else:
+                var_map[v.mangled] = v
+        self._var_by_mangled = var_map
+
+        type_map: dict[str, RecordType] = {}
+        for t in self.types:
+            if t.name not in type_map:
+                type_map[t.name] = t
+        self._type_by_name = type_map
 
     @property
     def function_map(self) -> dict[str, Function]:

--- a/tests/test_anon_union_fp.py
+++ b/tests/test_anon_union_fp.py
@@ -360,3 +360,61 @@ class TestCastxmlAnonUnionExpansion:
         assert ChangeKind.TYPE_FIELD_REMOVED not in kinds, (
             "x must not be reported as removed when it's still present in anon union"
         )
+
+    def test_anon_union_members_attribute_path(self) -> None:
+        """Anon union via 'members' attribute (castxml v2 format) is also expanded."""
+        from xml.etree.ElementTree import Element, SubElement
+
+        from abicheck.dumper import _CastxmlParser
+
+        root = Element("CastXML")
+
+        f1 = SubElement(root, "File")
+        f1.set("id", "f1")
+        f1.set("name", "mylib.h")
+
+        fund_int = SubElement(root, "FundamentalType")
+        fund_int.set("id", "_int")
+        fund_int.set("name", "int")
+
+        # Fields as top-level elements (castxml v2 members-attribute style)
+        uf_x = SubElement(root, "Field")
+        uf_x.set("id", "_fx")
+        uf_x.set("name", "x")
+        uf_x.set("type", "_int")
+        uf_x.set("offset", "0")
+
+        uf_y = SubElement(root, "Field")
+        uf_y.set("id", "_fy")
+        uf_y.set("name", "y")
+        uf_y.set("type", "_int")
+        uf_y.set("offset", "0")
+
+        # Anonymous union using 'members' attribute
+        anon_union = SubElement(root, "Union")
+        anon_union.set("id", "_u1")
+        anon_union.set("name", "")
+        anon_union.set("file", "f1")
+        anon_union.set("size", "32")
+        anon_union.set("members", "_fx _fy")  # members attribute path
+
+        # Parent struct S with anonymous Field pointing to the union
+        struct_s = SubElement(root, "Struct")
+        struct_s.set("id", "_s1")
+        struct_s.set("name", "S")
+        struct_s.set("size", "32")
+        struct_s.set("file", "f1")
+
+        anon_field = SubElement(struct_s, "Field")
+        anon_field.set("name", "")
+        anon_field.set("type", "_u1")
+        anon_field.set("offset", "0")
+
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = parser.parse_types()
+        s = next((t for t in types if t.name == "S"), None)
+        assert s is not None
+        field_names = {f.name for f in s.fields}
+        assert "x" in field_names, "x from anon union (members attr) must appear in S.fields"
+        assert "y" in field_names, "y from anon union (members attr) must appear in S.fields"
+        assert "" not in field_names

--- a/tests/test_anon_union_fp.py
+++ b/tests/test_anon_union_fp.py
@@ -4,8 +4,13 @@ When a struct gains an anonymous union member, the existing field `x` should
 NOT be reported as removed/changed if it's still present at the same offset.
 
 Scenario:
-  v1: struct S { int x; };
-  v2: struct S { union { int x; int y; }; };  // anon union, x still at offset 0
+  v1: struct S { int x
+  }
+  v2: struct S { union { int x
+  int y
+  }
+  }
+  // anon union, x still at offset 0
 
 Expected behavior:
 - MUST NOT emit STRUCT_FIELD_REMOVED for 'x'
@@ -202,32 +207,42 @@ class TestCastxmlAnonUnionExpansion:
     Uses real castxml XML format: elements carry 'file' attr directly.
     """
 
-    def _make_xml_with_anon_union(self) -> "Element":
+    def _make_xml_with_anon_union(self) -> Element:
         """Build castxml XML: struct S { union { int x; int y; }; };"""
         from xml.etree.ElementTree import Element, SubElement
         root = Element("CastXML")
 
         f1 = SubElement(root, "File")
-        f1.set("id", "f1"); f1.set("name", "mylib.h")
+        f1.set("id", "f1")
+        f1.set("name", "mylib.h")
 
         fund_int = SubElement(root, "FundamentalType")
-        fund_int.set("id", "_int"); fund_int.set("name", "int")
+        fund_int.set("id", "_int")
+        fund_int.set("name", "int")
 
         # Anonymous union
         anon_union = SubElement(root, "Union")
-        anon_union.set("id", "_u1"); anon_union.set("name", ""); anon_union.set("file", "f1")
+        anon_union.set("id", "_u1")
+        anon_union.set("name", "")
+        anon_union.set("file", "f1")
         anon_union.set("size", "32")
 
         uf_x = SubElement(anon_union, "Field")
-        uf_x.set("name", "x"); uf_x.set("type", "_int"); uf_x.set("offset", "0")
+        uf_x.set("name", "x")
+        uf_x.set("type", "_int")
+        uf_x.set("offset", "0")
 
         uf_y = SubElement(anon_union, "Field")
-        uf_y.set("name", "y"); uf_y.set("type", "_int"); uf_y.set("offset", "0")
+        uf_y.set("name", "y")
+        uf_y.set("type", "_int")
+        uf_y.set("offset", "0")
 
         # Parent struct S with anonymous Field pointing to the union
         struct_s = SubElement(root, "Struct")
-        struct_s.set("id", "_s1"); struct_s.set("name", "S")
-        struct_s.set("size", "32"); struct_s.set("file", "f1")
+        struct_s.set("id", "_s1")
+        struct_s.set("name", "S")
+        struct_s.set("size", "32")
+        struct_s.set("file", "f1")
 
         anon_field = SubElement(struct_s, "Field")
         anon_field.set("name", "")   # anonymous
@@ -236,44 +251,62 @@ class TestCastxmlAnonUnionExpansion:
 
         return root
 
-    def _make_xml_with_nested_anon(self) -> "Element":
+    def _make_xml_with_nested_anon(self) -> Element:
         """Build castxml XML: struct S { union { struct { int a; int b; }; int c; }; };"""
         from xml.etree.ElementTree import Element, SubElement
         root = Element("CastXML")
 
         f1 = SubElement(root, "File")
-        f1.set("id", "f1"); f1.set("name", "mylib.h")
+        f1.set("id", "f1")
+        f1.set("name", "mylib.h")
 
         fund_int = SubElement(root, "FundamentalType")
-        fund_int.set("id", "_int"); fund_int.set("name", "int")
+        fund_int.set("id", "_int")
+        fund_int.set("name", "int")
 
         # Inner anonymous struct { int a; int b; }
         inner_struct = SubElement(root, "Struct")
-        inner_struct.set("id", "_is1"); inner_struct.set("name", ""); inner_struct.set("file", "f1")
+        inner_struct.set("id", "_is1")
+        inner_struct.set("name", "")
+        inner_struct.set("file", "f1")
 
         ia = SubElement(inner_struct, "Field")
-        ia.set("name", "a"); ia.set("type", "_int"); ia.set("offset", "0")
+        ia.set("name", "a")
+        ia.set("type", "_int")
+        ia.set("offset", "0")
 
         ib = SubElement(inner_struct, "Field")
-        ib.set("name", "b"); ib.set("type", "_int"); ib.set("offset", "32")
+        ib.set("name", "b")
+        ib.set("type", "_int")
+        ib.set("offset", "32")
 
         # Outer anonymous union with anon struct + int c
         anon_union = SubElement(root, "Union")
-        anon_union.set("id", "_u1"); anon_union.set("name", ""); anon_union.set("file", "f1")
+        anon_union.set("id", "_u1")
+        anon_union.set("name", "")
+        anon_union.set("file", "f1")
 
         uf_struct = SubElement(anon_union, "Field")
-        uf_struct.set("name", ""); uf_struct.set("type", "_is1"); uf_struct.set("offset", "0")
+        uf_struct.set("name", "")
+        uf_struct.set("type", "_is1")
+        uf_struct.set("offset", "0")
 
         uf_c = SubElement(anon_union, "Field")
-        uf_c.set("name", "c"); uf_c.set("type", "_int"); uf_c.set("offset", "0")
+        uf_c.set("name", "c")
+        uf_c.set("type", "_int")
+        uf_c.set("offset", "0")
 
         # Parent struct S
         struct_s = SubElement(root, "Struct")
-        struct_s.set("id", "_s1"); struct_s.set("name", "S")
-        struct_s.set("size", "64"); struct_s.set("file", "f1")
+        struct_s.set("id", "_s1")
+        struct_s.set("name", "S")
+        struct_s.set("size", "64")
+        struct_s.set("file", "f1")
 
         anon_field = SubElement(struct_s, "Field")
-        anon_field.set("name", ""); anon_field.set("type", "_u1"); anon_field.set("offset", "0")
+        anon_field.set("name", "")
+        anon_field.set("type", "_u1")
+        anon_field.set("offset", "0")
 
         return root
 

--- a/tests/test_anon_union_fp.py
+++ b/tests/test_anon_union_fp.py
@@ -194,3 +194,136 @@ class TestAnonUnionFalsePositive:
         x_field = next(f for f in s_new.fields if f.name == "x")
         y_field = next(f for f in s_new.fields if f.name == "y")
         assert x_field.offset_bits == y_field.offset_bits == 0
+
+
+class TestCastxmlAnonUnionExpansion:
+    """Verify _expand_anonymous_field correctly flattens anonymous union/struct.
+
+    Uses real castxml XML format: elements carry 'file' attr directly.
+    """
+
+    def _make_xml_with_anon_union(self) -> "Element":
+        """Build castxml XML: struct S { union { int x; int y; }; };"""
+        from xml.etree.ElementTree import Element, SubElement
+        root = Element("CastXML")
+
+        f1 = SubElement(root, "File")
+        f1.set("id", "f1"); f1.set("name", "mylib.h")
+
+        fund_int = SubElement(root, "FundamentalType")
+        fund_int.set("id", "_int"); fund_int.set("name", "int")
+
+        # Anonymous union
+        anon_union = SubElement(root, "Union")
+        anon_union.set("id", "_u1"); anon_union.set("name", ""); anon_union.set("file", "f1")
+        anon_union.set("size", "32")
+
+        uf_x = SubElement(anon_union, "Field")
+        uf_x.set("name", "x"); uf_x.set("type", "_int"); uf_x.set("offset", "0")
+
+        uf_y = SubElement(anon_union, "Field")
+        uf_y.set("name", "y"); uf_y.set("type", "_int"); uf_y.set("offset", "0")
+
+        # Parent struct S with anonymous Field pointing to the union
+        struct_s = SubElement(root, "Struct")
+        struct_s.set("id", "_s1"); struct_s.set("name", "S")
+        struct_s.set("size", "32"); struct_s.set("file", "f1")
+
+        anon_field = SubElement(struct_s, "Field")
+        anon_field.set("name", "")   # anonymous
+        anon_field.set("type", "_u1")
+        anon_field.set("offset", "0")
+
+        return root
+
+    def _make_xml_with_nested_anon(self) -> "Element":
+        """Build castxml XML: struct S { union { struct { int a; int b; }; int c; }; };"""
+        from xml.etree.ElementTree import Element, SubElement
+        root = Element("CastXML")
+
+        f1 = SubElement(root, "File")
+        f1.set("id", "f1"); f1.set("name", "mylib.h")
+
+        fund_int = SubElement(root, "FundamentalType")
+        fund_int.set("id", "_int"); fund_int.set("name", "int")
+
+        # Inner anonymous struct { int a; int b; }
+        inner_struct = SubElement(root, "Struct")
+        inner_struct.set("id", "_is1"); inner_struct.set("name", ""); inner_struct.set("file", "f1")
+
+        ia = SubElement(inner_struct, "Field")
+        ia.set("name", "a"); ia.set("type", "_int"); ia.set("offset", "0")
+
+        ib = SubElement(inner_struct, "Field")
+        ib.set("name", "b"); ib.set("type", "_int"); ib.set("offset", "32")
+
+        # Outer anonymous union with anon struct + int c
+        anon_union = SubElement(root, "Union")
+        anon_union.set("id", "_u1"); anon_union.set("name", ""); anon_union.set("file", "f1")
+
+        uf_struct = SubElement(anon_union, "Field")
+        uf_struct.set("name", ""); uf_struct.set("type", "_is1"); uf_struct.set("offset", "0")
+
+        uf_c = SubElement(anon_union, "Field")
+        uf_c.set("name", "c"); uf_c.set("type", "_int"); uf_c.set("offset", "0")
+
+        # Parent struct S
+        struct_s = SubElement(root, "Struct")
+        struct_s.set("id", "_s1"); struct_s.set("name", "S")
+        struct_s.set("size", "64"); struct_s.set("file", "f1")
+
+        anon_field = SubElement(struct_s, "Field")
+        anon_field.set("name", ""); anon_field.set("type", "_u1"); anon_field.set("offset", "0")
+
+        return root
+
+    def test_castxml_anon_union_expansion(self) -> None:
+        """struct S { union { int x; int y; }; } — anon field must be expanded."""
+        from abicheck.dumper import _CastxmlParser
+        root = self._make_xml_with_anon_union()
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = parser.parse_types()
+        s = next((t for t in types if t.name == "S"), None)
+        assert s is not None, "Struct S must be parsed"
+        field_names = {f.name for f in s.fields}
+        assert "x" in field_names, "x from anon union must appear in S.fields"
+        assert "y" in field_names, "y from anon union must appear in S.fields"
+        # No empty-named field
+        assert "" not in field_names
+
+    def test_castxml_nested_anon_struct_expansion(self) -> None:
+        """struct S { union { struct { int a; int b; }; int c; }; } — all leaves."""
+        from abicheck.dumper import _CastxmlParser
+        root = self._make_xml_with_nested_anon()
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = parser.parse_types()
+        s = next((t for t in types if t.name == "S"), None)
+        assert s is not None
+        field_names = {f.name for f in s.fields}
+        assert "a" in field_names
+        assert "b" in field_names
+        assert "c" in field_names
+        assert "" not in field_names
+
+    def test_false_positive_prevented_end_to_end(self) -> None:
+        """v1: struct S { int x; } vs v2: struct S { union { int x; int y; }; }
+        Must NOT emit TYPE_FIELD_REMOVED for x."""
+        from abicheck.checker import ChangeKind, compare
+        from abicheck.model import AbiSnapshot, RecordType, TypeField
+
+        old_snap = AbiSnapshot(library="lib.so", version="1.0", types=[
+            RecordType(name="S", kind="struct", fields=[
+                TypeField(name="x", type="int", offset_bits=0),
+            ])
+        ])
+        new_snap = AbiSnapshot(library="lib.so", version="2.0", types=[
+            RecordType(name="S", kind="struct", fields=[
+                TypeField(name="x", type="int", offset_bits=0),
+                TypeField(name="y", type="int", offset_bits=0),
+            ])
+        ])
+        result = compare(old_snap, new_snap)
+        kinds = {c.kind for c in result.changes}
+        assert ChangeKind.TYPE_FIELD_REMOVED not in kinds, (
+            "x must not be reported as removed when it's still present in anon union"
+        )

--- a/tests/test_duplicate_mangled.py
+++ b/tests/test_duplicate_mangled.py
@@ -30,24 +30,22 @@ def _func(name: str, mangled: str, return_type: str = "void", **kwargs: object) 
 class TestDuplicateMangledSymbols:
     """Verify deduplication behavior for duplicate mangled names."""
 
-    def test_snapshot_index_last_wins(self) -> None:
-        """When two functions share a mangled name, last one wins in function_map.
+    def test_snapshot_index_first_wins(self) -> None:
+        """When two functions share a mangled name, first one wins in function_map.
 
-        The index is built via dict comprehension:
-          {f.mangled: f for f in self.functions}
-        which is last-wins for duplicate keys. This is documented behavior.
-        Callers must ensure no duplicate mangled names are inserted if
-        first-wins semantics are needed.
+        Policy: first-wins (abi-dumper #41 fix). The first Function inserted
+        with a given mangled name takes precedence; subsequent duplicates are
+        skipped with a warning.
         """
         mangled = "_Z3foov"
         f1 = _func("foo", mangled, return_type="void")
         f2 = _func("foo_alt", mangled, return_type="int")  # same mangled, different name
 
         snap = AbiSnapshot(library="lib.so", version="1.0", functions=[f1, f2])
-        # Dict comprehension → last-wins: f2 takes precedence
+        # first-wins: f1 takes precedence
         indexed = snap.function_map[mangled]
-        assert indexed.name == "foo_alt"
-        assert indexed.return_type == "int"
+        assert indexed.name == "foo"
+        assert indexed.return_type == "void"
 
     def test_snapshot_index_deduplication_deterministic(self) -> None:
         """function_map must always return the same function for a given mangled name."""
@@ -87,43 +85,80 @@ class TestDuplicateMangledSymbols:
         removed = [c for c in result.changes if c.kind == ChangeKind.FUNC_REMOVED]
         assert not removed
 
-    def test_duplicate_mangled_different_versions_detected(self) -> None:
-        """If two functions with same mangled name differ in return type,
-        the last one's signature (last-wins) is used for comparison."""
+    def test_duplicate_mangled_first_wins_for_comparison(self) -> None:
+        """First-wins: when two functions share mangled name, first signature is used."""
         mangled = "_Z6updatev"
-        f1_old = _func("update", mangled, return_type="void")
-        f2_old = _func("update_extra", mangled, return_type="int")  # duplicate, last-wins
+        f1_old = _func("update", mangled, return_type="void")       # first → wins
+        f2_old = _func("update_extra", mangled, return_type="int")  # duplicate → skipped
 
-        # In new snapshot, the function has return_type="int" (same as f2_old last-wins)
-        f1_new = _func("update", mangled, return_type="int")
+        # New snapshot has return_type="void" — same as first (first-wins) in old
+        f1_new = _func("update", mangled, return_type="void")
 
         old = AbiSnapshot(library="lib.so", version="1.0", functions=[f1_old, f2_old])
         new = AbiSnapshot(library="lib.so", version="2.0", functions=[f1_new])
 
         result = compare(old, new)
-        # Last-wins: old index has f2_old (return=int), new has f1_new (return=int)
+        # First-wins: old index has f1_old (return=void), new has f1_new (return=void)
         # → no return type change
         kinds = {c.kind for c in result.changes}
-        # Both sides have int return type (last-wins for old) → no FUNC_RETURN_CHANGED
         assert ChangeKind.FUNC_RETURN_CHANGED not in kinds
 
     def test_dedup_documented_behavior(self) -> None:
-        """Document last-wins deduplication: verify function_map iteration order
-        matches insertion order (Python dict maintains insertion order ≥3.7).
-
-        The index is built as: {f.mangled: f for f in self.functions}
-        For duplicate keys, the last entry wins (standard Python dict behavior).
-        """
+        """Document first-wins deduplication: first inserted entry wins."""
         mangled = "_Z3bazv"
         first = _func("baz_first", mangled, return_type="void")
         second = _func("baz_second", mangled, return_type="int")
 
         snap = AbiSnapshot(library="lib.so", version="1.0", functions=[first, second])
-        # Dict comprehension: {f.mangled: f for f in [first, second]} → last-wins
         indexed = snap.function_map[mangled]
-        # Last inserted (second) must win
-        assert indexed.name == "baz_second"
-        assert indexed.return_type == "int"
+        # First inserted must win
+        assert indexed.name == "baz_first"
+        assert indexed.return_type == "void"
+
+    def test_first_wins_semantics(self) -> None:
+        """Explicit first-wins: first Function with a given mangled name is kept."""
+        mangled = "_Z5firstEv"
+        kept = _func("kept", mangled, return_type="int")
+        dropped = _func("dropped", mangled, return_type="double")
+
+        snap = AbiSnapshot(library="lib.so", version="1.0", functions=[kept, dropped])
+        assert snap.function_map[mangled].name == "kept"
+
+    def test_duplicate_logs_warning(self) -> None:
+        """Inserting duplicate mangled symbol: first-wins and warning is logged."""
+        import logging
+        mangled = "_Z3dupv"
+        f1 = _func("dup", mangled, return_type="void")
+        f2 = _func("dup2", mangled, return_type="int")
+
+        snap = AbiSnapshot(library="lib.so", version="1.0", functions=[f1, f2])
+
+        # Capture WARNING from abicheck.model logger
+        with __import__("unittest.mock", fromlist=["patch"]).patch.object(
+            logging.getLogger("abicheck.model"), "warning"
+        ) as mock_warn:
+            _ = snap.function_map
+
+        # Warning should have been emitted for the duplicate
+        assert mock_warn.called
+        call_args = mock_warn.call_args[0]
+        assert mangled in call_args[1] or mangled in str(call_args)
+
+        # First-wins
+        assert snap.function_map[mangled].name == "dup"
+
+    def test_variable_first_wins(self) -> None:
+        """Variable deduplication: first-wins for duplicate mangled names."""
+        from abicheck.model import Variable
+
+        mangled = "_ZN3Foo3gVarE"
+        v1 = Variable(name="Foo::gVar", mangled=mangled, type="int")
+        v2 = Variable(name="Foo::gVar", mangled=mangled, type="double")  # duplicate
+
+        snap = AbiSnapshot(library="lib.so", version="1.0", variables=[v1, v2])
+        indexed = snap.variable_map[mangled]
+        # First wins
+        assert indexed.type == "int"
 
     def test_variable_dedup_consistent(self) -> None:
         """Variable deduplication must also be consistent."""
@@ -135,6 +170,6 @@ class TestDuplicateMangledSymbols:
 
         snap = AbiSnapshot(library="lib.so", version="1.0", variables=[v1, v2])
         indexed = snap.variable_map[mangled]
-        # Must be one of the two — deterministic
+        # Must be first one
         assert indexed.mangled == mangled
-        assert indexed.type in ("int", "double")
+        assert indexed.type == "int"

--- a/tests/test_nested_struct_tag.py
+++ b/tests/test_nested_struct_tag.py
@@ -1,0 +1,117 @@
+"""Nested struct tag normalization (abicc #53).
+
+castxml returns bare type names for struct/class/union fields (e.g. "Inner"),
+while older DWARF parsers historically prefixed the tag keyword ("struct Inner").
+This mismatch caused false STRUCT_FIELD_TYPE_CHANGED reports.
+
+Fixes:
+1. _compute_record_type_info() in dwarf_metadata.py — drops "struct " prefix
+2. _diff_struct_layouts() in checker.py — normalizes type names before comparison
+"""
+from __future__ import annotations
+
+from abicheck.dwarf_metadata import DwarfMetadata, FieldInfo, StructLayout
+
+
+class TestComputeRecordTypeInfo:
+    """_compute_record_type_info must return bare names (no struct/class prefix)."""
+
+    def _make_die(self, tag: str, name: str, size: int = 4) -> object:
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            tag=tag,
+            attributes={
+                "DW_AT_name": SimpleNamespace(value=name.encode()),
+                "DW_AT_byte_size": SimpleNamespace(value=size),
+            }
+        )
+
+    def test_struct_tag_no_prefix(self) -> None:
+        """DW_TAG_structure_type must produce 'Inner', not 'struct Inner'."""
+        from abicheck.dwarf_metadata import _compute_record_type_info  # type: ignore[attr-defined]
+        die = self._make_die("DW_TAG_structure_type", "Inner", 8)
+        name, _ = _compute_record_type_info(die, "DW_TAG_structure_type")
+        assert name == "Inner", f"Expected 'Inner', got {name!r}"
+        assert not name.startswith("struct "), "struct prefix must NOT be added"
+
+    def test_class_tag_no_prefix(self) -> None:
+        """DW_TAG_class_type must produce 'Foo', not 'class Foo'."""
+        from abicheck.dwarf_metadata import _compute_record_type_info  # type: ignore[attr-defined]
+        die = self._make_die("DW_TAG_class_type", "Foo", 16)
+        name, _ = _compute_record_type_info(die, "DW_TAG_class_type")
+        assert name == "Foo", f"Expected 'Foo', got {name!r}"
+
+
+class TestNestedStructTagNormalization:
+    """DWARF 'struct Foo' vs castxml 'Foo' must not emit STRUCT_FIELD_TYPE_CHANGED."""
+
+    def _make_meta(
+        self,
+        struct_name: str,
+        field_name: str,
+        field_type: str,
+        byte_size: int = 8,
+    ) -> DwarfMetadata:
+        return DwarfMetadata(
+            structs={
+                struct_name: StructLayout(
+                    name=struct_name,
+                    byte_size=byte_size,
+                    fields=[FieldInfo(name=field_name, type_name=field_type,
+                                     byte_offset=0, byte_size=4)],
+                )
+            },
+            has_dwarf=True,
+        )
+
+    def test_no_false_struct_field_type_changed(self) -> None:
+        """'struct Inner' (old) vs 'Inner' (new) must NOT emit STRUCT_FIELD_TYPE_CHANGED."""
+        from abicheck.checker import ChangeKind
+        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+
+        old_meta = self._make_meta("Outer", "child", "struct Inner")
+        new_meta = self._make_meta("Outer", "child", "Inner")
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED not in kinds, (
+            "'struct Inner' vs 'Inner' must not trigger STRUCT_FIELD_TYPE_CHANGED"
+        )
+
+    def test_no_false_class_field_type_changed(self) -> None:
+        """'class Foo' vs 'Foo' must NOT emit STRUCT_FIELD_TYPE_CHANGED."""
+        from abicheck.checker import ChangeKind
+        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+
+        old_meta = self._make_meta("Container", "item", "class Foo")
+        new_meta = self._make_meta("Container", "item", "Foo")
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED not in kinds
+
+    def test_real_type_change_still_detected(self) -> None:
+        """'Inner' vs 'Other' (genuinely different type) must STILL be detected."""
+        from abicheck.checker import ChangeKind
+        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+
+        old_meta = self._make_meta("Outer", "child", "Inner")
+        new_meta = self._make_meta("Outer", "child", "Other")
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds, (
+            "Real type change Inner→Other must still be detected"
+        )
+
+    def test_union_prefix_normalized(self) -> None:
+        """'union U' vs 'U' must NOT emit STRUCT_FIELD_TYPE_CHANGED."""
+        from abicheck.checker import ChangeKind
+        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+
+        old_meta = self._make_meta("Outer", "u_field", "union U")
+        new_meta = self._make_meta("Outer", "u_field", "U")
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED not in kinds

--- a/tests/test_nested_struct_tag.py
+++ b/tests/test_nested_struct_tag.py
@@ -28,7 +28,9 @@ class TestComputeRecordTypeInfo:
 
     def test_struct_tag_no_prefix(self) -> None:
         """DW_TAG_structure_type must produce 'Inner', not 'struct Inner'."""
-        from abicheck.dwarf_metadata import _compute_record_type_info  # type: ignore[attr-defined]
+        from abicheck.dwarf_metadata import (
+            _compute_record_type_info,  # type: ignore[attr-defined]
+        )
         die = self._make_die("DW_TAG_structure_type", "Inner", 8)
         name, _ = _compute_record_type_info(die, "DW_TAG_structure_type")
         assert name == "Inner", f"Expected 'Inner', got {name!r}"
@@ -36,7 +38,9 @@ class TestComputeRecordTypeInfo:
 
     def test_class_tag_no_prefix(self) -> None:
         """DW_TAG_class_type must produce 'Foo', not 'class Foo'."""
-        from abicheck.dwarf_metadata import _compute_record_type_info  # type: ignore[attr-defined]
+        from abicheck.dwarf_metadata import (
+            _compute_record_type_info,  # type: ignore[attr-defined]
+        )
         die = self._make_die("DW_TAG_class_type", "Foo", 16)
         name, _ = _compute_record_type_info(die, "DW_TAG_class_type")
         assert name == "Foo", f"Expected 'Foo', got {name!r}"
@@ -66,8 +70,10 @@ class TestNestedStructTagNormalization:
 
     def test_no_false_struct_field_type_changed(self) -> None:
         """'struct Inner' (old) vs 'Inner' (new) must NOT emit STRUCT_FIELD_TYPE_CHANGED."""
-        from abicheck.checker import ChangeKind
-        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
 
         old_meta = self._make_meta("Outer", "child", "struct Inner")
         new_meta = self._make_meta("Outer", "child", "Inner")
@@ -80,8 +86,10 @@ class TestNestedStructTagNormalization:
 
     def test_no_false_class_field_type_changed(self) -> None:
         """'class Foo' vs 'Foo' must NOT emit STRUCT_FIELD_TYPE_CHANGED."""
-        from abicheck.checker import ChangeKind
-        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
 
         old_meta = self._make_meta("Container", "item", "class Foo")
         new_meta = self._make_meta("Container", "item", "Foo")
@@ -92,8 +100,10 @@ class TestNestedStructTagNormalization:
 
     def test_real_type_change_still_detected(self) -> None:
         """'Inner' vs 'Other' (genuinely different type) must STILL be detected."""
-        from abicheck.checker import ChangeKind
-        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
 
         old_meta = self._make_meta("Outer", "child", "Inner")
         new_meta = self._make_meta("Outer", "child", "Other")
@@ -106,8 +116,10 @@ class TestNestedStructTagNormalization:
 
     def test_union_prefix_normalized(self) -> None:
         """'union U' vs 'U' must NOT emit STRUCT_FIELD_TYPE_CHANGED."""
-        from abicheck.checker import ChangeKind
-        from abicheck.checker import _diff_struct_layouts  # type: ignore[attr-defined]
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
 
         old_meta = self._make_meta("Outer", "u_field", "union U")
         new_meta = self._make_meta("Outer", "u_field", "U")


### PR DESCRIPTION
## Summary

Three fixes for known gaps from abi-dumper / ABICC upstream analysis.

### Commit 1 — Duplicate mangled symbol dedup (abi-dumper #41)
- `AbiSnapshot.index()` now uses **first-wins** instead of last-wins dict comprehension
- Duplicate entries emit a `WARNING` log
- Applied to functions, variables, and types
- Updated `tests/test_duplicate_mangled.py` to assert first-wins semantics

### Commit 2 — Anonymous union FP fix (abicc #58)
- `_CastxmlParser._parse_record_fields()` now expands anonymous `Field name=""` entries
- New `_expand_anonymous_field()` method recursively flattens nested anon unions/structs with correct offset addition
- Prevents false `TYPE_FIELD_REMOVED` when a field moves into an anonymous union
- Added `TestCastxmlAnonUnionExpansion` with single, double-nested, and end-to-end tests

### Commit 3 — Nested struct tag normalization (abicc #53)
- `_compute_record_type_info()` in `dwarf_metadata.py` no longer prefixes `"struct "` to type names
- `_diff_struct_layouts()` in `checker.py` normalizes `"struct Foo"` / `"class Foo"` / `"union U"` to bare names before comparison
- Prevents false `STRUCT_FIELD_TYPE_CHANGED` when DWARF and castxml use different naming conventions
- New `tests/test_nested_struct_tag.py` with 6 tests

## Tests
All 1344 tests pass (excluding parity/external-tool tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive compatibility warnings by normalizing struct/class/union type names.
  * Prevented spurious field-change/removed reports by correctly flattening anonymous struct/union members, including nested cases.

* **Refactor**
  * Deduplication now preserves the first-seen symbol and emits warnings on duplicates for clearer, stable comparisons.
  * Added internal logging for indexing and duplicate detection.

* **Tests**
  * Added end-to-end and unit tests covering anonymous member expansion and type-name normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->