### PR TITLE
Clarify XML descriptor root requirement for compat mode

### DIFF
--- a/docs/abicc_format_compliance.md
+++ b/docs/abicc_format_compliance.md
@@ -10,7 +10,7 @@ infrastructure) would continue to work with abicheck's output.
 | Dimension | Status | Risk |
 |-----------|--------|------|
 | Exit codes (0/1/2) | **Full parity** | None |
-| XML descriptor input | **Full parity** | None |
+| XML descriptor input | **Mostly compatible** | Medium |
 | CLI flag acceptance | **Full parity** (40+ flags) | None |
 | XML report output (`-report-format xml`) | **Implemented** (ABICC schema) | Low |
 | `htm` format alias | **Implemented** | None |
@@ -70,19 +70,35 @@ that only check for 0 vs non-zero.
 
 The `-strict` promotion (API_BREAK → exit 1) also matches.
 
-### 2. XML Descriptor Input Format (FULL PARITY)
+### 2. XML Descriptor Input Format (MOSTLY COMPATIBLE)
 
-Both tools accept the same XML descriptor format:
+`abicheck` accepts ABICC-style descriptor fields, but currently requires a
+well-formed XML document with a single root element (for example
+`<descriptor>...</descriptor>`).
+
+ABICC pipelines sometimes use descriptor *fragments* such as sibling
+`<version>`, `<headers>`, `<libs>` tags without a wrapper root. Those fragment
+files are not parseable XML documents and are rejected by `abicheck` with an
+XML parse error.
+
+Supported descriptor shape in `abicheck`:
 ```xml
+<descriptor>
 <version>2025.0</version>
 <headers>/path/to/include/</headers>
 <libs>/path/to/libfoo.so</libs>
+</descriptor>
 ```
 
 abicheck correctly supports:
 - Multiple `<headers>` and `<libs>` elements
 - `{RELPATH}` macro substitution
 - XXE-safe parsing (improvement over ABICC)
+
+Migration note:
+- If existing ABICC jobs generate fragment-style descriptor files, add a
+  one-time normalization step to wrap those tags in a root element before
+  running `abicheck compat`.
 
 ### 3. CLI Flag Acceptance (FULL PARITY)
 

--- a/docs/migration/from_abicc.md
+++ b/docs/migration/from_abicc.md
@@ -19,7 +19,10 @@ After (identical flags):
 abicheck compat -lib libfoo -old OLD.xml -new NEW.xml -report-path report.html
 ```
 
-> `OLD.xml` is your existing ABICC XML descriptor file — no conversion needed.
+> `OLD.xml` is your existing ABICC XML descriptor file in most pipelines.
+> If your ABICC setup emits XML *fragments* (sibling `<version>`, `<headers>`,
+> `<libs>` tags without a single wrapper root), add a one-time normalization
+> step to wrap them in a root element (for example `<descriptor>...</descriptor>`).
 > If you don't have XML descriptors yet, use `abicheck dump` to generate snapshots
 > and then `abicheck compare` instead.
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -134,6 +134,16 @@ def test_parse_descriptor_relative_lib_resolved(tmp_path: Path) -> None:
     assert desc.libs[0].parent == tmp_path.resolve()
 
 
+def test_parse_descriptor_fragment_rejected(tmp_path: Path) -> None:
+    """Fragment descriptors without a root element are not well-formed XML."""
+    xml = """
+    <version>1.0</version>
+    <libs>/usr/lib/libx.so</libs>
+    """
+    with pytest.raises(ValueError, match="Invalid XML"):
+        parse_descriptor(_write_xml(tmp_path, xml))
+
+
 def test_parse_descriptor_invalid_xml_raises(tmp_path: Path) -> None:
     bad = tmp_path / "bad.xml"
     bad.write_text("<unclosed>", encoding="utf-8")


### PR DESCRIPTION
### Motivation

- The ABICC compatibility layer currently uses XML parsing that requires a single root element, which makes fragment-style descriptor files (sibling `<version>`, `<headers>`, `<libs>` tags) fail and is a hidden migration edge for some ABICC pipelines.
- Make the requirement explicit in documentation and add a regression test to prevent regressions and reduce surprises for users migrating from ABICC.

### Description

- Update `docs/abicc_format_compliance.md` to downgrade descriptor-input status to "Mostly compatible" and document that `abicheck` requires a well-formed XML document with a single root element and show an example wrapper such as `<descriptor>...</descriptor>`.
- Update `docs/migration/from_abicc.md` to call out fragment-style descriptors and recommend a one-time normalization step to wrap fragments in a root element before running `abicheck compat`.
- Add a regression test `test_parse_descriptor_fragment_rejected` to `tests/test_compat.py` that asserts fragment descriptors are rejected with a `ValueError` indicating invalid XML.

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_compat.py::test_parse_descriptor_fragment_rejected tests/test_compat.py::test_parse_descriptor_basic tests/test_compat.py::test_parse_descriptor_invalid_xml_raises` and all three tests passed (`3 passed`).
- Performed an ad-hoc parser check by calling `parse_descriptor()` on a fragment descriptor which reproduced the `ValueError: Invalid XML` behavior confirming the documented behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b328f3979c832b820a39aa400f3b94)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified ABICC XML descriptor format support level from full parity to mostly compatible, with concrete examples of compatible descriptor structure.
* Added migration guidance for XML fragment descriptors, including the requirement to wrap them with a root element before use.
* Updated format compliance and migration documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->