### PR TITLE
Fix ruff lint issues in benchmark and demo scripts

### DIFF
--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -24,16 +24,18 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import re
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
+import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 REPO_DIR     = Path(__file__).parent.parent
 EXAMPLES_DIR = REPO_DIR / "examples"
@@ -43,8 +45,6 @@ BUILD_DIR    = REPORT_DIR / "_build"
 # Ensure we use abicheck from THIS repo, not any globally-installed version
 # (abicheck CLI shebang may point to a different Python/site-packages)
 os.environ.setdefault("PYTHONPATH", str(REPO_DIR))
-
-import sys as _sys
 
 _abicheck_bin = shutil.which("abicheck")
 if _abicheck_bin:
@@ -59,13 +59,13 @@ if _abicheck_bin:
             elif _tokens:
                 _PYTHON = _tokens[0]
             else:
-                _PYTHON = _sys.executable
+                _PYTHON = sys.executable
         else:
-            _PYTHON = _sys.executable
+            _PYTHON = sys.executable
     except (OSError, IsADirectoryError, IndexError, UnicodeDecodeError):
-        _PYTHON = _sys.executable
+        _PYTHON = sys.executable
 else:
-    _PYTHON = _sys.executable
+    _PYTHON = sys.executable
 _ABICHECK_ENV = {**os.environ, "PYTHONPATH": str(REPO_DIR)}
 # True when abicheck CLI is importable via _PYTHON (even without installed bin)
 def _abicheck_available() -> bool:
@@ -684,7 +684,7 @@ def parse_args() -> argparse.Namespace:
 
 
 # ── Helpers (module-level) ──────────────────────────────────────────────────
-def _remap_to_build(h: "Path | None", src: "Path", dst: "Path") -> "Path | None":
+def _remap_to_build(h: Path | None, src: Path, dst: Path) -> Path | None:
     """Remap a header path from the original case dir to the make_build copy."""
     if not h:
         return None

--- a/scripts/demo_libz.py
+++ b/scripts/demo_libz.py
@@ -9,7 +9,6 @@ Requires: castxml, zlib1g-dev
 """
 from __future__ import annotations
 
-import json
 import sys
 import tempfile
 from pathlib import Path
@@ -83,8 +82,8 @@ def main() -> None:
         snap2_path = tmp / "libz-1.4.json"
         save_snapshot(snap_v2, snap2_path)
         print(f"  Removed : {removed}")
-        print(f"  Changed return type: zlibCompileFlags uLong → unsigned long")
-        print(f"  Added   : deflate2")
+        print("  Changed return type: zlibCompileFlags uLong → unsigned long")
+        print("  Added   : deflate2")
         print(f"  Saved → {snap2_path}\n")
 
         # ── Step 3: Compare ───────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Quiet static-analysis/lint warnings found in utility scripts to keep the repository clean and adhere to the project's style rules.

### Description
- Reordered and consolidated imports in `scripts/benchmark_comparison.py` and moved `sys` into the main import block to fix an E402 module-level import complaint. 
- Replaced uses of `_sys.executable` with `sys.executable` to reflect the consolidated import. 
- Modernized typing by importing `Callable` from `collections.abc` and replaced quoted `"Path | None"` annotations with unquoted `Path | None` in `_remap_to_build`. 
- Removed an unused `json` import from `scripts/demo_libz.py` and converted two f-strings that contained no placeholders into plain strings. 

### Testing
- Ran `ruff check scripts/benchmark_comparison.py scripts/demo_libz.py` and it passed. 
- Ran `ruff check .` across the repository and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33fdc3a54832ba7ba9a427952d261)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements and type annotation enhancements for better code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->