### PR TITLE
Support minimal ABICC Perl `ABI.dump` import for compat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ abicheck compat -lib foo -old old.xml -new new.xml \
 This mode supports ABICC-style descriptor workflows so teams can migrate without
 rewriting their entire pipeline on day one. See [ABICC compatibility reference](docs/abicc_compat.md) for full flag list.
 
+> Note: `compat` now supports minimal ABICC Perl `ABI.dump` (`Data::Dumper`) input for migration workflows.
+> ABICC XML dump variants (`<ABI_dump...>` / `<abi_dump...>`) are still unsupported.
+
 ---
 
 ## abicheck as a drop-in replacement for ABICC

--- a/abicheck/abicc_dump_import.py
+++ b/abicheck/abicc_dump_import.py
@@ -61,11 +61,7 @@ def _parse_perl_dumper_subset(text: str) -> object:
     if rhs.endswith(";"):
         rhs = rhs[:-1].strip()
 
-    # Convert Perl hash rocket syntax to Python dict syntax and undef to None.
-    # This remains safe because we parse via ast.literal_eval (no execution).
-    py_expr = rhs.replace("=>", ":")
-    py_expr = py_expr.replace(" undef", " None").replace("[undef", "[None")
-    py_expr = py_expr.replace("{undef", "{None")
+    py_expr = _perl_expr_to_python_literal(rhs)
 
     try:
         obj = ast.literal_eval(py_expr)
@@ -77,6 +73,57 @@ def _parse_perl_dumper_subset(text: str) -> object:
         return json.loads(json.dumps(obj))
     except (TypeError, json.JSONDecodeError) as exc:
         raise ValueError(f"Failed to normalize ABICC Perl dump structure: {exc}") from exc
+
+
+def _perl_expr_to_python_literal(expr: str) -> str:
+    """Translate a safe Perl-literal subset to Python literal syntax.
+
+    Only performs syntax-token conversion outside single-quoted strings:
+    - ``=>`` -> ``:``
+    - bareword ``undef`` -> ``None``
+    """
+    out: list[str] = []
+    i = 0
+    in_single = False
+    n = len(expr)
+
+    while i < n:
+        ch = expr[i]
+
+        if in_single:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                i += 1
+                out.append(expr[i])
+            elif ch == "'":
+                in_single = False
+            i += 1
+            continue
+
+        if ch == "'":
+            in_single = True
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch == "=" and i + 1 < n and expr[i + 1] == ">":
+            out.append(":")
+            i += 2
+            continue
+
+        if expr.startswith("undef", i):
+            prev_ok = i == 0 or not (expr[i - 1].isalnum() or expr[i - 1] == "_")
+            j = i + 5
+            next_ok = j >= n or not (expr[j].isalnum() or expr[j] == "_")
+            if prev_ok and next_ok:
+                out.append("None")
+                i = j
+                continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
 
 
 def _snapshot_from_abicc_dict(data: dict[str, object], path: Path) -> AbiSnapshot:

--- a/abicheck/abicc_dump_import.py
+++ b/abicheck/abicc_dump_import.py
@@ -1,0 +1,209 @@
+"""Minimal ABICC (abi-dumper) Perl dump importer.
+
+This module is intentionally isolated from main compat logic so ABICC dump parsing
+can evolve independently while keeping the CLI flow simple.
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from .model import AbiSnapshot, Function, Param, RecordType, Variable, Visibility
+
+
+def looks_like_perl_dump(text: str) -> bool:
+    """Heuristic detection for Data::Dumper ABI dumps."""
+    head = text.lstrip()
+    return head.startswith("$VAR1")
+
+
+def import_abicc_perl_dump(path: Path) -> AbiSnapshot:
+    """Convert abi-dumper Perl Data::Dumper output into a minimal AbiSnapshot.
+
+    This importer is deliberately lenient and migration-focused:
+    - parses symbols and a minimal subset of type names,
+    - tolerates unknown sections,
+    - preserves compatibility verdict signal over full-fidelity metadata.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ValueError(f"Failed to read ABICC Perl dump: {exc}") from exc
+
+    if not looks_like_perl_dump(text):
+        raise ValueError("Invalid ABICC Perl dump: expected Data::Dumper content starting with $VAR1")
+
+    data = _parse_perl_dumper_subset(text)
+
+    if not isinstance(data, dict):
+        raise ValueError("Invalid ABICC Perl dump: top-level structure is not a hash/dict")
+
+    return _snapshot_from_abicc_dict(data, path)
+
+
+def _parse_perl_dumper_subset(text: str) -> object:
+    """Parse a strict, safe subset of Perl Data::Dumper syntax.
+
+    Accepted shape: ``$VAR1 = <perl-literal>;`` where perl-literal is composed of
+    dict/list/scalar literals (single-quoted strings, numbers, undef, hashes,
+    arrays). No code execution is performed.
+    """
+    stripped = text.lstrip()
+    if not stripped.startswith("$VAR1"):
+        raise ValueError("Invalid ABICC Perl dump: missing $VAR1 assignment")
+
+    if "=" not in stripped:
+        raise ValueError("Invalid ABICC Perl dump: malformed assignment")
+
+    _, rhs = stripped.split("=", 1)
+    rhs = rhs.strip()
+    if rhs.endswith(";"):
+        rhs = rhs[:-1].strip()
+
+    # Convert Perl hash rocket syntax to Python dict syntax and undef to None.
+    # This remains safe because we parse via ast.literal_eval (no execution).
+    py_expr = rhs.replace("=>", ":")
+    py_expr = py_expr.replace(" undef", " None").replace("[undef", "[None")
+    py_expr = py_expr.replace("{undef", "{None")
+
+    try:
+        obj = ast.literal_eval(py_expr)
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError(f"Failed to parse ABICC Perl dump safely: {exc}") from exc
+
+    # Round-trip through JSON-compatible form for predictable primitive types.
+    try:
+        return json.loads(json.dumps(obj))
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Failed to normalize ABICC Perl dump structure: {exc}") from exc
+
+
+def _snapshot_from_abicc_dict(data: dict[str, object], path: Path) -> AbiSnapshot:
+    type_info = data.get("TypeInfo")
+    symbol_info = data.get("SymbolInfo")
+
+    type_map: dict[str, dict[str, object]] = type_info if isinstance(type_info, dict) else {}
+    sym_map: dict[str, dict[str, object]] = symbol_info if isinstance(symbol_info, dict) else {}
+
+    library = str(data.get("LibraryName") or path.stem)
+    version = str(data.get("LibraryVersion") or "unknown")
+
+    functions: list[Function] = []
+    variables: list[Variable] = []
+
+    for _, sym in sym_map.items():
+        if not isinstance(sym, dict):
+            continue
+
+        mangled = str(sym.get("MnglName") or "")
+        if not mangled:
+            continue
+
+        short_name = str(sym.get("ShortName") or mangled)
+
+        is_function = any(k in sym for k in ("Param", "Return", "Constructor", "Destructor"))
+        if is_function:
+            params = _parse_params(sym, type_map)
+            return_type = _resolve_type_name(sym.get("Return"), type_map)
+            functions.append(
+                Function(
+                    name=short_name,
+                    mangled=mangled,
+                    return_type=return_type,
+                    params=params,
+                    visibility=Visibility.PUBLIC,
+                )
+            )
+        else:
+            var_type = _resolve_type_name(sym.get("Type"), type_map)
+            variables.append(
+                Variable(
+                    name=short_name,
+                    mangled=mangled,
+                    type=var_type,
+                    visibility=Visibility.PUBLIC,
+                )
+            )
+
+    types = _extract_record_types(type_map)
+
+    return AbiSnapshot(
+        library=library,
+        version=version,
+        functions=functions,
+        variables=variables,
+        types=types,
+    )
+
+
+def _parse_params(sym: dict[str, object], type_map: dict[str, dict[str, object]]) -> list[Param]:
+    raw = sym.get("Param")
+    if not isinstance(raw, dict):
+        return []
+
+    params: list[tuple[int, Param]] = []
+    for pos, pinfo in raw.items():
+        if not isinstance(pinfo, dict):
+            continue
+        try:
+            idx = int(str(pos))
+        except ValueError:
+            idx = 9999
+
+        ptype = _resolve_type_name(pinfo.get("type"), type_map)
+        pname = str(pinfo.get("name") or f"arg{idx}")
+        params.append((idx, Param(name=pname, type=ptype)))
+
+    params.sort(key=lambda x: x[0])
+    return [p for _, p in params]
+
+
+def _resolve_type_name(type_id: object, type_map: dict[str, dict[str, object]]) -> str:
+    if type_id is None:
+        return "unknown"
+
+    tid = str(type_id)
+    tinfo = type_map.get(tid)
+    if not isinstance(tinfo, dict):
+        return "unknown"
+
+    name = tinfo.get("Name")
+    if isinstance(name, str) and name.strip():
+        return name
+
+    return "unknown"
+
+
+def _extract_record_types(type_map: dict[str, dict[str, object]]) -> list[RecordType]:
+    out: list[RecordType] = []
+    for _, tinfo in type_map.items():
+        if not isinstance(tinfo, dict):
+            continue
+        kind_raw = str(tinfo.get("Type") or "").lower()
+        if kind_raw not in ("struct", "class", "union"):
+            continue
+
+        name = tinfo.get("Name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+
+        out.append(
+            RecordType(
+                name=name,
+                kind=kind_raw,
+                is_union=(kind_raw == "union"),
+            )
+        )
+    return out
+
+
+def is_abicc_perl_dump_file(path: Path) -> bool:
+    """Return True if path looks like an ABICC Perl Data::Dumper dump."""
+    if path.suffix == ".dump":
+        return True
+    try:
+        head = path.read_text(encoding="utf-8", errors="replace")[:512]
+    except OSError:
+        return False
+    return looks_like_perl_dump(head)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -9,6 +9,11 @@ from typing import TYPE_CHECKING
 
 import click
 
+from .abicc_dump_import import (
+    import_abicc_perl_dump,
+    is_abicc_perl_dump_file,
+    looks_like_perl_dump,
+)
 from .checker import ChangeKind, compare
 from .checker_policy import API_BREAK_KINDS as _POLICY_API_BREAK_KINDS
 from .compat import CompatDescriptor, parse_descriptor
@@ -1033,6 +1038,16 @@ def compat_cmd(  # noqa: PLR0913
     old_relpath = relpath1 or relpath
     new_relpath = relpath2 or relpath
 
+    old_is_abicc_perl = is_abicc_perl_dump_file(old_desc)
+    new_is_abicc_perl = is_abicc_perl_dump_file(new_desc)
+    if old_is_abicc_perl or new_is_abicc_perl:
+        _do_echo(
+            "Info: ABICC Perl ABI.dump input detected. "
+            "Using migration-focused importer (full ABICC dump parity is not guaranteed). "
+            "Prefer abicheck JSON dumps for best fidelity.",
+            quiet,
+        )
+
     # ── Parse descriptors (support both XML descriptors and JSON dumps) ──
     try:
         old_d = _load_descriptor_or_dump(old_desc, relpath=old_relpath)
@@ -1304,15 +1319,9 @@ def _load_descriptor_or_dump(path: Path, *, relpath: str | None = None) -> Compa
     Raises:
         ValueError: If the file is an ABICC Perl dump (unsupported format).
     """
-    # Detect ABICC Perl dump format (.dump extension or Data::Dumper content)
+    # ABICC Perl dump support (minimal migration-focused importer)
     if path.suffix == ".dump":
-        raise ValueError(
-            f"ABICC Perl dump format is not supported: {path}\n"
-            "  abicheck uses its own JSON dump format.\n"
-            "  To migrate, re-create the dump from the original XML descriptor:\n"
-            "    abicheck compat-dump -lib LIBNAME -dump descriptor.xml -dump-path output.json\n"
-            "  Then use the JSON dump for comparison."
-        )
+        return import_abicc_perl_dump(path)
 
     # Heuristic: if the file is JSON, load as a dump
     if path.suffix == ".json":
@@ -1326,23 +1335,16 @@ def _load_descriptor_or_dump(path: Path, *, relpath: str | None = None) -> Compa
         head = ""
 
     # Detect ABICC Perl Data::Dumper format (starts with $VAR1 = { or similar)
-    if head.lstrip().startswith("$VAR1"):
-        raise ValueError(
-            f"ABICC Perl dump format detected: {path}\n"
-            "  abicheck uses its own JSON dump format.\n"
-            "  To migrate, re-create the dump from the original XML descriptor:\n"
-            "    abicheck compat-dump -lib LIBNAME -dump descriptor.xml -dump-path output.json\n"
-            "  Then use the JSON dump for comparison."
-        )
+    if looks_like_perl_dump(head):
+        return import_abicc_perl_dump(path)
 
     # Detect ABICC XML dump format (contains <ABI_dump_* or <abi_dump tags)
     if "<ABI_dump" in head or "<abi_dump" in head or "ABI_COMPLIANCE_CHECKER" in head:
         raise ValueError(
             f"ABICC XML dump format detected: {path}\n"
-            "  abicheck uses its own JSON dump format and cannot read ABICC XML dumps.\n"
-            "  To migrate, re-create the dump from the original XML descriptor:\n"
-            "    abicheck compat-dump -lib LIBNAME -dump descriptor.xml -dump-path output.json\n"
-            "  Then use the JSON dump for comparison."
+            "  abicheck currently supports ABICC Perl Data::Dumper dumps, not ABICC XML dumps.\n"
+            "  If possible, generate the default ABI.dump (Perl) format with abi-dumper,\n"
+            "  or convert via descriptor using compat-dump to abicheck JSON."
         )
 
     # Otherwise parse as XML descriptor

--- a/docs/abicc_compat.md
+++ b/docs/abicc_compat.md
@@ -250,19 +250,26 @@ abicheck compare libfoo-v1.json libfoo-v2.json --format html -o report.html
 
 ### Dump format
 
-abicheck uses its own **JSON dump format** — it does not use ABICC's Perl
-`Data::Dumper` or XML dump formats. If you have existing ABICC dumps, you need
-to re-create them from the original XML descriptors:
+abicheck supports:
+
+- native **JSON** dumps, and
+- minimal ABICC Perl `Data::Dumper` (`ABI.dump`) input for migration workflows.
+
+ABICC XML dump variants (`<ABI_dump...>` / `<abi_dump...>`) are still unsupported.
 
 ```bash
-# ABICC dump → not supported:
-abicheck compat -old old.dump -new new.dump  # ❌ Error with migration guidance
+# ABICC Perl dump (default abi-dumper output):
+abicheck compat -lib libfoo -old old.ABI.dump -new new.ABI.dump  # ✅
 
-# Re-create from descriptor:
+# ABICC XML dump variant:
+abicheck compat -lib libfoo -old old.xml_dump -new new.xml_dump  # ❌ not supported
+
+# Descriptor-based fallback:
 abicheck compat-dump -lib libfoo -dump old_descriptor.xml -dump-path old.json
 abicheck compat-dump -lib libfoo -dump new_descriptor.xml -dump-path new.json
 abicheck compat -lib libfoo -old old.json -new new.json  # ✅
 ```
+
 
 ## `-source` mode: what gets filtered
 
@@ -377,7 +384,7 @@ Full coverage comparison: see [gap_report.md](gap_report.md).
 | `-limit-affected` | ✅ Full parity |
 | `-list-affected` | ✅ Generates `.affected.txt` |
 | `-q` / `-quiet` | ✅ Suppress console output |
-| `-dump` (via `compat-dump`) | ✅ JSON format (not ABICC Perl/XML) |
+| `-dump` (via `compat-dump`) | ✅ JSON format |
 | `-dump-path` (via `compat-dump`) | ✅ Full parity |
 | `-dump-format` (via `compat-dump`) | ✅ JSON only (with warning) |
 | `-vnum` (via `compat-dump`) | ✅ Version override for dumps |

--- a/tests/test_abicc_dump_import.py
+++ b/tests/test_abicc_dump_import.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.abicc_dump_import import (
+    _snapshot_from_abicc_dict,
+    import_abicc_perl_dump,
+    looks_like_perl_dump,
+)
+
+
+def test_looks_like_perl_dump_detects_var1_with_whitespace() -> None:
+    assert looks_like_perl_dump("\n  \t$VAR1 = {};")
+    assert not looks_like_perl_dump("<?xml version='1.0'?><ABI_dump_1.0/>")
+
+
+def test_snapshot_from_abicc_dict_maps_functions_variables_and_types(tmp_path: Path) -> None:
+    data = {
+        "LibraryName": "libdemo",
+        "LibraryVersion": "2.0",
+        "TypeInfo": {
+            "0": {"Name": "void", "Type": "Intrinsic"},
+            "1": {"Name": "int", "Type": "Intrinsic"},
+            "2": {"Name": "Demo", "Type": "Struct"},
+            "3": {"Name": "DemoU", "Type": "Union"},
+        },
+        "SymbolInfo": {
+            "10": {
+                "MnglName": "foo",
+                "ShortName": "foo",
+                "Return": "0",
+                "Param": {"1": {"type": "1", "name": "x"}},
+            },
+            "11": {
+                "MnglName": "glob",
+                "ShortName": "glob",
+                "Type": "1",
+            },
+        },
+    }
+
+    snap = _snapshot_from_abicc_dict(data, tmp_path / "sample.dump")
+
+    assert snap.library == "libdemo"
+    assert snap.version == "2.0"
+    assert len(snap.functions) == 1
+    assert snap.functions[0].mangled == "foo"
+    assert snap.functions[0].params[0].name == "x"
+    assert snap.functions[0].params[0].type == "int"
+    assert len(snap.variables) == 1
+    assert snap.variables[0].mangled == "glob"
+    assert snap.variables[0].type == "int"
+    type_names = {t.name for t in snap.types}
+    assert "Demo" in type_names
+    assert "DemoU" in type_names
+
+
+def test_snapshot_defaults_when_library_fields_missing(tmp_path: Path) -> None:
+    snap = _snapshot_from_abicc_dict({}, tmp_path / "x.ABI.dump")
+    assert snap.library == "x.ABI"
+    assert snap.version == "unknown"
+
+
+def test_import_abicc_perl_dump_rejects_non_dumper_content(tmp_path: Path) -> None:
+    dump = tmp_path / "bad.dump"
+    dump.write_text("print 'hello';", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected Data::Dumper content"):
+        import_abicc_perl_dump(dump)
+
+
+def test_import_abicc_perl_dump_rejects_malformed_content(tmp_path: Path) -> None:
+    dump = tmp_path / "bad.dump"
+    dump.write_text("$VAR1 = do { system('touch /tmp/pwned') };", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to parse ABICC Perl dump safely"):
+        import_abicc_perl_dump(dump)
+
+
+def test_import_abicc_perl_dump_safe_roundtrip_without_perl(tmp_path: Path) -> None:
+    dump = tmp_path / "ok.dump"
+    dump.write_text(
+        """
+        $VAR1 = {
+          'LibraryName' => 'libok',
+          'LibraryVersion' => '1',
+          'TypeInfo' => {
+            '0' => { 'Name' => 'void', 'Type' => 'Intrinsic' }
+          },
+          'SymbolInfo' => {
+            '1' => { 'MnglName' => 'foo', 'ShortName' => 'foo', 'Return' => '0' }
+          }
+        };
+        """,
+        encoding="utf-8",
+    )
+
+    snap = import_abicc_perl_dump(dump)
+
+    assert snap.library == "libok"
+    assert snap.version == "1"
+    assert any(f.mangled == "foo" for f in snap.functions)

--- a/tests/test_abicc_dump_import.py
+++ b/tests/test_abicc_dump_import.py
@@ -5,8 +5,11 @@ from pathlib import Path
 import pytest
 
 from abicheck.abicc_dump_import import (
+    _parse_perl_dumper_subset,
+    _perl_expr_to_python_literal,
     _snapshot_from_abicc_dict,
     import_abicc_perl_dump,
+    is_abicc_perl_dump_file,
     looks_like_perl_dump,
 )
 
@@ -102,3 +105,28 @@ def test_import_abicc_perl_dump_safe_roundtrip_without_perl(tmp_path: Path) -> N
     assert snap.library == "libok"
     assert snap.version == "1"
     assert any(f.mangled == "foo" for f in snap.functions)
+
+
+def test_perl_expr_conversion_preserves_spaceship_inside_strings() -> None:
+    expr = "{'SymbolName' => 'operator<=>', 'Kind' => 'demo'}"
+    converted = _perl_expr_to_python_literal(expr)
+    assert "'operator<=>'" in converted
+    assert converted == "{'SymbolName' : 'operator<=>', 'Kind' : 'demo'}"
+
+
+def test_parse_subset_converts_undef_only_as_bareword() -> None:
+    dump = "$VAR1 = {'a' => undef, 'b' => 'undef', 'c' => ['x', undef]};"
+    parsed = _parse_perl_dumper_subset(dump)
+    assert parsed == {"a": None, "b": "undef", "c": ["x", None]}
+
+
+def test_is_abicc_perl_dump_file_by_content(tmp_path: Path) -> None:
+    p = tmp_path / "dump.txt"
+    p.write_text("$VAR1 = {};", encoding="utf-8")
+    assert is_abicc_perl_dump_file(p)
+
+
+def test_is_abicc_perl_dump_file_false_for_regular_xml(tmp_path: Path) -> None:
+    p = tmp_path / "desc.xml"
+    p.write_text("<descriptor/>", encoding="utf-8")
+    assert not is_abicc_perl_dump_file(p)

--- a/tests/test_abicc_dump_integration.py
+++ b/tests/test_abicc_dump_integration.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    shutil.which("cc") is None or shutil.which("abi-dumper") is None,
+    reason="requires cc and abi-dumper",
+)
+def test_compat_accepts_real_abicc_abi_dump(tmp_path: Path) -> None:
+    src = tmp_path / "libx.c"
+    hdr = tmp_path / "libx.h"
+    so = tmp_path / "libx.so"
+    dump = tmp_path / "ABI.dump"
+
+    hdr.write_text("int foo(int x);\n", encoding="utf-8")
+    src.write_text("#include \"libx.h\"\nint foo(int x) { return x + 1; }\n", encoding="utf-8")
+
+    subprocess.run(
+        [
+            "cc",
+            "-fPIC",
+            "-shared",
+            "-g",
+            "-Og",
+            "-gdwarf-4",
+            "-o",
+            str(so),
+            str(src),
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    subprocess.run(
+        [
+            "abi-dumper",
+            str(so),
+            "-o",
+            str(dump),
+            "-lver",
+            "1.0",
+            "-public-headers",
+            str(tmp_path),
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    proc = subprocess.run(
+        [
+            "python",
+            "-m",
+            "abicheck.cli",
+            "compat",
+            "-lib",
+            "libx",
+            "-old",
+            str(dump),
+            "-new",
+            str(dump),
+        ],
+        cwd="/workspace/abicheck",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout + proc.stderr
+    assert "Binary compatibility:" in out
+    assert "Verdict:" in out

--- a/tests/test_abicc_dump_integration.py
+++ b/tests/test_abicc_dump_integration.py
@@ -64,7 +64,7 @@ def test_compat_accepts_real_abicc_abi_dump(tmp_path: Path) -> None:
             "-new",
             str(dump),
         ],
-        cwd="/workspace/abicheck",
+        cwd=str(Path(__file__).resolve().parents[1]),
         text=True,
         capture_output=True,
         check=False,

--- a/tests/test_compat_extended.py
+++ b/tests/test_compat_extended.py
@@ -19,8 +19,8 @@ Covers:
 from __future__ import annotations
 
 import json
-import shutil
 import logging
+import shutil
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/test_compat_extended.py
+++ b/tests/test_compat_extended.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import logging
-import shutil
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -281,7 +280,6 @@ class TestLoadDescriptorOrDump:
         assert isinstance(result, CompatDescriptor)
         assert result.version == "2.0"
 
-    @pytest.mark.skipif(shutil.which("perl") is None, reason="perl is required for ABICC Perl dump import")
     def test_loads_abicc_perl_dump_by_extension(self, tmp_path: Path) -> None:
         dump_file = tmp_path / "old.dump"
         dump_file.write_text("""
@@ -304,7 +302,6 @@ class TestLoadDescriptorOrDump:
         assert result.version == "1.2.3"
         assert any(f.mangled == "foo" for f in result.functions)
 
-    @pytest.mark.skipif(shutil.which("perl") is None, reason="perl is required for ABICC Perl dump import")
     def test_loads_abicc_perl_dump_by_content(self, tmp_path: Path) -> None:
         dump_file = tmp_path / "old.txt"
         dump_file.write_text("""

--- a/tests/test_compat_extended.py
+++ b/tests/test_compat_extended.py
@@ -8,7 +8,7 @@ Covers:
 - -skip-internal-symbols / -skip-internal-types regex flags
 - -title wired to HTML output
 - -quiet flag
-- ABICC dump format detection and clear error messaging
+- ABICC dump loading (Perl Data::Dumper) and XML dump error messaging
 - JSON dump input support for compat mode
 - relpath support in descriptor parsing
 - P2 stub flag acceptance
@@ -19,6 +19,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import shutil
 import logging
 import textwrap
 from pathlib import Path
@@ -280,17 +281,49 @@ class TestLoadDescriptorOrDump:
         assert isinstance(result, CompatDescriptor)
         assert result.version == "2.0"
 
-    def test_rejects_abicc_perl_dump_by_extension(self, tmp_path: Path) -> None:
+    @pytest.mark.skipif(shutil.which("perl") is None, reason="perl is required for ABICC Perl dump import")
+    def test_loads_abicc_perl_dump_by_extension(self, tmp_path: Path) -> None:
         dump_file = tmp_path / "old.dump"
-        dump_file.write_text("$VAR1 = { ... }", encoding="utf-8")
-        with pytest.raises(ValueError, match="ABICC Perl dump format is not supported"):
-            _load_descriptor_or_dump(dump_file)
+        dump_file.write_text("""
+            $VAR1 = {
+              'LibraryName' => 'libfoo',
+              'LibraryVersion' => '1.2.3',
+              'TypeInfo' => {
+                '0' => { 'Name' => 'void', 'Type' => 'Intrinsic' }
+              },
+              'SymbolInfo' => {
+                '1' => { 'MnglName' => 'foo', 'ShortName' => 'foo', 'Return' => '0' }
+              }
+            };
+        """, encoding="utf-8")
 
-    def test_rejects_abicc_perl_dump_by_content(self, tmp_path: Path) -> None:
+        result = _load_descriptor_or_dump(dump_file)
+        from abicheck.model import AbiSnapshot
+        assert isinstance(result, AbiSnapshot)
+        assert result.library == "libfoo"
+        assert result.version == "1.2.3"
+        assert any(f.mangled == "foo" for f in result.functions)
+
+    @pytest.mark.skipif(shutil.which("perl") is None, reason="perl is required for ABICC Perl dump import")
+    def test_loads_abicc_perl_dump_by_content(self, tmp_path: Path) -> None:
         dump_file = tmp_path / "old.txt"
-        dump_file.write_text("$VAR1 = {\n  'LibraryName' => 'libfoo',\n};", encoding="utf-8")
-        with pytest.raises(ValueError, match="ABICC Perl dump format detected"):
-            _load_descriptor_or_dump(dump_file)
+        dump_file.write_text("""
+            $VAR1 = {
+              'LibraryName' => 'libbar',
+              'LibraryVersion' => '9',
+              'TypeInfo' => {
+                '0' => { 'Name' => 'void', 'Type' => 'Intrinsic' }
+              },
+              'SymbolInfo' => {
+                '1' => { 'MnglName' => 'bar', 'ShortName' => 'bar', 'Return' => '0' }
+              }
+            };
+        """, encoding="utf-8")
+
+        result = _load_descriptor_or_dump(dump_file)
+        from abicheck.model import AbiSnapshot
+        assert isinstance(result, AbiSnapshot)
+        assert result.library == "libbar"
 
     def test_rejects_abicc_xml_dump(self, tmp_path: Path) -> None:
         dump_file = tmp_path / "dump.xml"
@@ -301,11 +334,85 @@ class TestLoadDescriptorOrDump:
         with pytest.raises(ValueError, match="ABICC XML dump format detected"):
             _load_descriptor_or_dump(dump_file)
 
-    def test_error_message_guides_migration(self, tmp_path: Path) -> None:
-        dump_file = tmp_path / "old.dump"
-        dump_file.write_text("$VAR1 = {}", encoding="utf-8")
-        with pytest.raises(ValueError, match="compat-dump"):
+    def test_error_message_for_abicc_xml_dump_mentions_current_support(self, tmp_path: Path) -> None:
+        dump_file = tmp_path / "dump.xml"
+        dump_file.write_text("<?xml version='1.0'?><ABI_dump_1.0/>", encoding="utf-8")
+        with pytest.raises(ValueError, match="supports ABICC Perl Data::Dumper dumps"):
             _load_descriptor_or_dump(dump_file)
+
+
+class TestAbiccPerlDumpInfoMessage:
+    def _write_dump(self, path: Path, lib: str) -> None:
+        path.write_text(
+            f"""
+            $VAR1 = {{
+              'LibraryName' => '{lib}',
+              'LibraryVersion' => '1.0',
+              'TypeInfo' => {{
+                '0' => {{ 'Name' => 'void', 'Type' => 'Intrinsic' }}
+              }},
+              'SymbolInfo' => {{
+                '1' => {{ 'MnglName' => 'foo', 'ShortName' => 'foo', 'Return' => '0' }}
+              }}
+            }};
+            """,
+            encoding="utf-8",
+        )
+
+    def test_info_message_shown_for_abicc_dump_input(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old_dump = tmp_path / "old.dump"
+        new_dump = tmp_path / "new.dump"
+        self._write_dump(old_dump, "libfoo")
+        self._write_dump(new_dump, "libfoo")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "compat",
+                "-lib",
+                "libfoo",
+                "-old",
+                str(old_dump),
+                "-new",
+                str(new_dump),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Info: ABICC Perl ABI.dump input detected" in result.output
+
+    def test_info_message_suppressed_in_quiet_mode(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old_dump = tmp_path / "old.dump"
+        new_dump = tmp_path / "new.dump"
+        self._write_dump(old_dump, "libfoo")
+        self._write_dump(new_dump, "libfoo")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "compat",
+                "-lib",
+                "libfoo",
+                "-old",
+                str(old_dump),
+                "-new",
+                str(new_dump),
+                "-q",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Info: ABICC Perl ABI.dump input detected" not in result.output
 
 
 # ── HTML title wiring ─────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Allow teams to migrate from ABICC by accepting the common Perl `Data::Dumper`-style `ABI.dump` output as a minimal, migration-focused input to `abicheck compat` instead of forcing an immediate JSON-only workflow.
- Provide a safe, non-executing parser for legacy dumps that preserves compatibility signals without promising full ABICC dump parity.

### Description

- Add a new isolated importer module `abicheck/abicc_dump_import.py` that heuristically detects Perl `Data::Dumper` dumps, safely parses a strict subset via `ast.literal_eval` (converting `=>` and `undef`), and converts to `AbiSnapshot` (functions, variables, and record types).
- Update the CLI (`abicheck/cli.py`) to detect `.dump` files and `Data::Dumper` content, use the new importer for those inputs, and emit an informational message when ABICC Perl dumps are used while keeping XML dump variants rejected with a clearer message.
- Update documentation and `README.md` to advertise minimal ABICC Perl `ABI.dump` support and to clarify that ABICC XML dumps remain unsupported.
- Add unit and integration tests: `tests/test_abicc_dump_import.py` for parser behavior, `tests/test_abicc_dump_integration.py` for an end-to-end smoke test (skipped if toolchain missing), and update `tests/test_compat_extended.py` to exercise the new import path and CLI info messaging.

### Testing

- Ran unit tests for the new importer with `pytest tests/test_abicc_dump_import.py`, which passed.
- Ran the extended compat-mode test suite with `pytest tests/test_compat_extended.py`, which includes new cases for loading `.dump` content and CLI info-message checks, and these tests passed (environment permitting `perl` where marked).
- The integration smoke test `tests/test_abicc_dump_integration.py` was added and is skipped automatically when system prerequisites (`cc` and `abi-dumper`) are not present, otherwise it runs and exercises `abicheck compat` end-to-end; in CI it is expected to be skipped unless toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b327034b08832bae04632b24fde44c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing minimal ABICC Perl Data::Dumper dumps and CLI handling that detects such inputs and emits an informational migration message.

* **Documentation**
  * Updated README and compatibility docs to state supported dump formats (JSON and ABICC Perl) and that ABICC XML dumps remain unsupported.

* **Tests**
  * Added unit and integration tests covering ABICC Perl dump detection, import behavior, CLI messaging, and end-to-end compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->