### PR TITLE
feat: add --policy option to compare CLI + policy-aware verdicts

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1335,8 +1335,18 @@ def compare(
     old: AbiSnapshot,
     new: AbiSnapshot,
     suppression: SuppressionList | None = None,
+    *,
+    policy: str = "strict_abi",
 ) -> DiffResult:
-    """Diff two AbiSnapshots and return a DiffResult with verdict."""
+    """Diff two AbiSnapshots and return a DiffResult with verdict.
+
+    Args:
+        old: Old ABI snapshot.
+        new: New ABI snapshot.
+        suppression: Optional suppression list to filter known changes.
+        policy: Policy profile name to use for verdict classification.
+            Available: "strict_abi" (default), "sdk_vendor", "plugin_abi".
+    """
 
     detector_fns: list[_DetectorSpec] = [
         _DetectorSpec("functions", _diff_functions),
@@ -1397,7 +1407,7 @@ def compare(
                 filtered.append(c)
         changes = filtered
 
-    verdict = compute_verdict(changes)
+    verdict = compute_verdict(changes, policy=policy)
     return DiffResult(
         old_version=old.version,
         new_version=new.version,

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -368,6 +368,33 @@ API_BREAK_KINDS: set[ChangeKind] = {
                                              # is now emitted only inline; needs manual review
 }
 
+# ---------------------------------------------------------------------------
+# Policy-specific downgrade sets
+# ---------------------------------------------------------------------------
+
+# sdk_vendor: source-level-only kinds are not binary ABI breaks for SDK consumers.
+# A removed enum member name or renamed field won't break already-compiled code —
+# only source-recompilation is affected. Downgrade from BREAKING → API_BREAK.
+SDK_VENDOR_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset({
+    ChangeKind.ENUM_MEMBER_RENAMED,
+    ChangeKind.FIELD_RENAMED,
+    ChangeKind.PARAM_RENAMED,
+    ChangeKind.METHOD_ACCESS_CHANGED,
+    ChangeKind.FIELD_ACCESS_CHANGED,
+    ChangeKind.SOURCE_LEVEL_KIND_CHANGED,   # struct↔class keyword: binary-identical
+    ChangeKind.REMOVED_CONST_OVERLOAD,
+    ChangeKind.PARAM_DEFAULT_VALUE_REMOVED,
+    ChangeKind.PARAM_DEFAULT_VALUE_CHANGED,
+})
+
+# plugin_abi: plugin-safe kinds that are safe within a single process/plugin boundary.
+# Toolchain flag drift and calling-convention changes can be acceptable when
+# the plugin and host are built from the same toolchain at the same time.
+PLUGIN_ABI_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset({
+    ChangeKind.TOOLCHAIN_FLAG_DRIFT,
+    ChangeKind.CALLING_CONVENTION_CHANGED,
+})
+
 
 @dataclass(frozen=True)
 class PolicyEntry:
@@ -407,16 +434,40 @@ def policy_registry_markdown() -> str:
         )
     return "\n".join(lines)
 
-def compute_verdict(changes: Sequence[HasKind]) -> Verdict:
+def compute_verdict(changes: Sequence[HasKind], *, policy: str = "strict_abi") -> Verdict:
+    """Compute verdict from a list of changes, honoring the given policy profile.
+
+    Policy profiles change which ChangeKinds are BREAKING vs API_BREAK vs COMPATIBLE:
+    - ``strict_abi`` (default): full BREAKING set applies
+    - ``sdk_vendor``: source-level-only kinds (ENUM_MEMBER_RENAMED etc.) downgraded to API_BREAK
+    - ``plugin_abi``: plugin-safe kinds downgraded to COMPATIBLE
+
+    Falls back gracefully to strict_abi for unknown policy names.
+    """
     if not changes:
         return Verdict.NO_CHANGE
+
+    # Select policy-specific kind sets
+    if policy == "sdk_vendor":
+        breaking = BREAKING_KINDS - SDK_VENDOR_DOWNGRADED_KINDS
+        api_break = API_BREAK_KINDS | (BREAKING_KINDS & SDK_VENDOR_DOWNGRADED_KINDS)
+        compatible = COMPATIBLE_KINDS
+    elif policy == "plugin_abi":
+        breaking = BREAKING_KINDS - PLUGIN_ABI_DOWNGRADED_KINDS
+        api_break = API_BREAK_KINDS
+        compatible = COMPATIBLE_KINDS | (BREAKING_KINDS & PLUGIN_ABI_DOWNGRADED_KINDS)
+    else:
+        # strict_abi (default) and any unknown policy: use full BREAKING set
+        breaking = BREAKING_KINDS
+        api_break = API_BREAK_KINDS
+        compatible = COMPATIBLE_KINDS
+
     kinds = {c.kind for c in changes}
-    if kinds & BREAKING_KINDS:
+    if kinds & breaking:
         return Verdict.BREAKING
-    if kinds & API_BREAK_KINDS:
+    if kinds & api_break:
         return Verdict.API_BREAK
-    # Only COMPATIBLE_KINDS changes (ELF warnings, deployment risks)
-    if kinds - COMPATIBLE_KINDS == set():
+    if kinds - compatible == set():
         return Verdict.COMPATIBLE
     # Unclassified change kinds default to BREAKING (fail-safe)
     return Verdict.BREAKING

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -79,8 +79,12 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
               help="Suppression file (YAML) to filter known/intentional changes.")
+@click.option("--policy", "policy",
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=False),
+              default="strict_abi", show_default=True,
+              help="Policy profile for verdict classification.")
 def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path | None,
-                suppress: Path | None) -> None:
+                suppress: Path | None, policy: str) -> None:
     """Compare two ABI snapshots and report changes.
 
     \b
@@ -89,6 +93,7 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format sarif -o results.sarif
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format html -o report.html
       abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
+      abicheck compare libfoo-1.0.json libfoo-2.0.json --policy sdk_vendor
     """
     from .suppression import SuppressionList
 
@@ -102,7 +107,7 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
         except (ValueError, OSError) as e:
             raise click.BadParameter(str(e), param_hint="--suppress") from e
 
-    result = compare(old, new, suppression=suppression)
+    result = compare(old, new, suppression=suppression, policy=policy)
 
     # Warn if suppression file swallowed all changes (potential misconfiguration)
     total_changes = len(result.changes) + result.suppressed_count


### PR DESCRIPTION
## Summary
Adds policy selection to CLI compare command and makes verdict computation policy-aware.

## Changes
- `abicheck compare` now supports:
  - `--policy strict_abi|sdk_vendor|plugin_abi` (default: `strict_abi`)
- `checker.compare()` now accepts `policy` kwarg and forwards it to `compute_verdict()`
- `compute_verdict()` in `checker_policy.py` now applies policy-specific kind sets:
  - `strict_abi`: unchanged default behavior
  - `sdk_vendor`: selected source-level kinds downgraded BREAKING → API_BREAK
  - `plugin_abi`: selected plugin-safe kinds downgraded BREAKING → COMPATIBLE

## Validation
- `ruff check abicheck/checker.py abicheck/checker_policy.py abicheck/cli.py`
- `mypy abicheck/ --ignore-missing-imports`
- `pytest tests/test_cli_unit.py tests/test_policy_registry_and_summary.py tests/test_phase2_suppression_policy.py -q`
- result: 57 passed
