### PR TITLE
fix: follow-up PR #100/#101 — policy bugs, CFA extraction, docs

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -12,6 +12,30 @@ from .checker_policy import COMPATIBLE_KINDS as _COMPATIBLE_KINDS
 from .checker_policy import ChangeKind as ChangeKind
 from .checker_policy import Verdict as Verdict
 from .checker_policy import compute_verdict as compute_verdict
+from .checker_policy import SDK_VENDOR_COMPAT_KINDS as _SDK_VENDOR_COMPAT_KINDS
+from .checker_policy import PLUGIN_ABI_DOWNGRADED_KINDS as _PLUGIN_ABI_DOWNGRADED_KINDS
+
+
+def _policy_kind_sets(policy: str) -> tuple[set, set, set]:
+    """Return (breaking, api_break, compatible) kind sets for the given policy.
+
+    Used internally by DiffResult properties so that breaking/source_breaks/compatible
+    are consistent with the active policy rather than the static global sets.
+    """
+    if policy == "sdk_vendor":
+        return (
+            _BREAKING_KINDS,
+            _API_BREAK_KINDS - _SDK_VENDOR_COMPAT_KINDS,
+            _COMPATIBLE_KINDS | _SDK_VENDOR_COMPAT_KINDS,
+        )
+    elif policy == "plugin_abi":
+        return (
+            _BREAKING_KINDS - _PLUGIN_ABI_DOWNGRADED_KINDS,
+            _API_BREAK_KINDS,
+            _COMPATIBLE_KINDS | _PLUGIN_ABI_DOWNGRADED_KINDS,
+        )
+    else:
+        return _BREAKING_KINDS, _API_BREAK_KINDS, _COMPATIBLE_KINDS
 from .detectors import DetectorResult
 from .dwarf_advanced import diff_advanced_dwarf
 from .elf_metadata import SymbolBinding, SymbolType
@@ -58,18 +82,25 @@ class DiffResult:
     suppressed_changes: list[Change] = field(default_factory=list)  # full audit trail
     suppression_file_provided: bool = False  # True when --suppress was passed, even if 0 matched
     detector_results: list[DetectorResult] = field(default_factory=list)
+    policy: str = "strict_abi"  # active policy profile; drives breaking/source_breaks/compatible
 
     @property
     def breaking(self) -> list[Change]:
-        return [c for c in self.changes if c.kind in _BREAKING_KINDS]
+        """Changes classified as BREAKING under the active policy."""
+        breaking_set, _, _ = _policy_kind_sets(self.policy)
+        return [c for c in self.changes if c.kind in breaking_set]
 
     @property
     def source_breaks(self) -> list[Change]:
-        return [c for c in self.changes if c.kind in _API_BREAK_KINDS]
+        """Changes classified as API_BREAK under the active policy."""
+        _, api_break_set, _ = _policy_kind_sets(self.policy)
+        return [c for c in self.changes if c.kind in api_break_set]
 
     @property
     def compatible(self) -> list[Change]:
-        return [c for c in self.changes if c.kind in _COMPATIBLE_KINDS]
+        """Changes classified as COMPATIBLE under the active policy."""
+        _, _, compatible_set = _policy_kind_sets(self.policy)
+        return [c for c in self.changes if c.kind in compatible_set]
 
 
 @dataclass(frozen=True)
@@ -1415,6 +1446,7 @@ def compare(
         changes = filtered
 
     verdict = policy_file.compute_verdict(changes) if policy_file is not None else compute_verdict(changes, policy=policy)
+    effective_policy = policy_file.base_policy if policy_file is not None else policy
     return DiffResult(
         old_version=old.version,
         new_version=new.version,
@@ -1425,6 +1457,7 @@ def compare(
         suppressed_changes=suppressed,
         suppression_file_provided=suppression is not None,
         detector_results=detector_results,
+        policy=effective_policy,
     )
 
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -19,8 +19,8 @@ from .elf_metadata import SymbolBinding, SymbolType
 from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visibility
 
 if TYPE_CHECKING:
-    from .suppression import SuppressionList
     from .policy_file import PolicyFile
+    from .suppression import SuppressionList
 
 
 __all__ = [
@@ -1346,7 +1346,7 @@ def compare(
     suppression: SuppressionList | None = None,
     *,
     policy: str = "strict_abi",
-    policy_file: "PolicyFile | None" = None,
+    policy_file: PolicyFile | None = None,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -12,30 +12,7 @@ from .checker_policy import COMPATIBLE_KINDS as _COMPATIBLE_KINDS
 from .checker_policy import ChangeKind as ChangeKind
 from .checker_policy import Verdict as Verdict
 from .checker_policy import compute_verdict as compute_verdict
-from .checker_policy import SDK_VENDOR_COMPAT_KINDS as _SDK_VENDOR_COMPAT_KINDS
-from .checker_policy import PLUGIN_ABI_DOWNGRADED_KINDS as _PLUGIN_ABI_DOWNGRADED_KINDS
-
-
-def _policy_kind_sets(policy: str) -> tuple[set, set, set]:
-    """Return (breaking, api_break, compatible) kind sets for the given policy.
-
-    Used internally by DiffResult properties so that breaking/source_breaks/compatible
-    are consistent with the active policy rather than the static global sets.
-    """
-    if policy == "sdk_vendor":
-        return (
-            _BREAKING_KINDS,
-            _API_BREAK_KINDS - _SDK_VENDOR_COMPAT_KINDS,
-            _COMPATIBLE_KINDS | _SDK_VENDOR_COMPAT_KINDS,
-        )
-    elif policy == "plugin_abi":
-        return (
-            _BREAKING_KINDS - _PLUGIN_ABI_DOWNGRADED_KINDS,
-            _API_BREAK_KINDS,
-            _COMPATIBLE_KINDS | _PLUGIN_ABI_DOWNGRADED_KINDS,
-        )
-    else:
-        return _BREAKING_KINDS, _API_BREAK_KINDS, _COMPATIBLE_KINDS
+from .checker_policy import policy_kind_sets as _policy_kind_sets
 from .detectors import DetectorResult
 from .dwarf_advanced import diff_advanced_dwarf
 from .elf_metadata import SymbolBinding, SymbolType

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -19,6 +19,7 @@ from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visib
 
 if TYPE_CHECKING:
     from .suppression import SuppressionList
+    from .policy_file import PolicyFile
 
 
 __all__ = [
@@ -1337,6 +1338,7 @@ def compare(
     suppression: SuppressionList | None = None,
     *,
     policy: str = "strict_abi",
+    policy_file: "PolicyFile | None" = None,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.
 
@@ -1346,6 +1348,11 @@ def compare(
         suppression: Optional suppression list to filter known changes.
         policy: Policy profile name to use for verdict classification.
             Available: "strict_abi" (default), "sdk_vendor", "plugin_abi".
+            Ignored when *policy_file* is provided.
+        policy_file: Optional :class:`~abicheck.policy_file.PolicyFile` instance
+            for user-defined per-kind verdict overrides.  When provided,
+            *policy* is used only as the ``base_policy`` fallback inside the
+            file (i.e. the file's own ``base_policy`` field takes precedence).
     """
 
     detector_fns: list[_DetectorSpec] = [
@@ -1407,7 +1414,7 @@ def compare(
                 filtered.append(c)
         changes = filtered
 
-    verdict = compute_verdict(changes, policy=policy)
+    verdict = policy_file.compute_verdict(changes) if policy_file is not None else compute_verdict(changes, policy=policy)
     return DiffResult(
         old_version=old.version,
         new_version=new.version,

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -374,27 +374,30 @@ API_BREAK_KINDS: set[ChangeKind] = {
 # Policy-specific downgrade sets
 # ---------------------------------------------------------------------------
 
-# sdk_vendor: source-level-only kinds are not binary ABI breaks for SDK consumers.
-# A removed enum member name or renamed field won't break already-compiled code —
-# only source-recompilation is affected. Downgrade from BREAKING → API_BREAK.
-SDK_VENDOR_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset({
+# sdk_vendor: these API_BREAK_KINDS are source-level-only and do not affect
+# already-compiled binary consumers. Under sdk_vendor policy they are downgraded
+# from API_BREAK → COMPATIBLE (no warning emitted).
+# Examples: enum member renamed, field renamed, param renamed, struct↔class.
+SDK_VENDOR_COMPAT_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.ENUM_MEMBER_RENAMED,
     ChangeKind.FIELD_RENAMED,
     ChangeKind.PARAM_RENAMED,
     ChangeKind.METHOD_ACCESS_CHANGED,
     ChangeKind.FIELD_ACCESS_CHANGED,
-    ChangeKind.SOURCE_LEVEL_KIND_CHANGED,   # struct↔class keyword: binary-identical
+    ChangeKind.SOURCE_LEVEL_KIND_CHANGED,   # struct↔class: binary-identical
     ChangeKind.REMOVED_CONST_OVERLOAD,
     ChangeKind.PARAM_DEFAULT_VALUE_REMOVED,
     ChangeKind.PARAM_DEFAULT_VALUE_CHANGED,
 })
 
-# plugin_abi: plugin-safe kinds that are safe within a single process/plugin boundary.
-# Toolchain flag drift and calling-convention changes can be acceptable when
-# the plugin and host are built from the same toolchain at the same time.
+# plugin_abi: kinds that are acceptable when plugin and host are built from
+# the same toolchain at the same time (single-process boundary).
+# Downgraded from BREAKING → COMPATIBLE.
 PLUGIN_ABI_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.TOOLCHAIN_FLAG_DRIFT,
     ChangeKind.CALLING_CONVENTION_CHANGED,
+    ChangeKind.FRAME_REGISTER_CHANGED,      # CFA register = physical calling convention
+    ChangeKind.VALUE_ABI_TRAIT_CHANGED,     # DWARF triviality heuristic — same signal
 })
 
 
@@ -439,27 +442,29 @@ def policy_registry_markdown() -> str:
 def compute_verdict(changes: Sequence[HasKind], *, policy: str = "strict_abi") -> Verdict:
     """Compute verdict from a list of changes, honoring the given policy profile.
 
-    Policy profiles change which ChangeKinds are BREAKING vs API_BREAK vs COMPATIBLE:
-    - ``strict_abi`` (default): full BREAKING set applies
-    - ``sdk_vendor``: source-level-only kinds (ENUM_MEMBER_RENAMED etc.) downgraded to API_BREAK
-    - ``plugin_abi``: plugin-safe kinds downgraded to COMPATIBLE
+    Policy profiles:
+    - ``strict_abi`` (default): full BREAKING / API_BREAK sets apply.
+    - ``sdk_vendor``: source-level-only kinds (rename, access) downgraded
+      from API_BREAK → COMPATIBLE (no warning for SDK consumers).
+    - ``plugin_abi``: plugin-safe calling-convention kinds (TOOLCHAIN_FLAG_DRIFT,
+      CALLING_CONVENTION_CHANGED) downgraded from BREAKING → COMPATIBLE.
 
-    Falls back gracefully to strict_abi for unknown policy names.
+    Unknown policy names fall back to ``strict_abi``.
     """
     if not changes:
         return Verdict.NO_CHANGE
 
     # Select policy-specific kind sets
     if policy == "sdk_vendor":
-        breaking = BREAKING_KINDS - SDK_VENDOR_DOWNGRADED_KINDS
-        api_break = API_BREAK_KINDS | (BREAKING_KINDS & SDK_VENDOR_DOWNGRADED_KINDS)
-        compatible = COMPATIBLE_KINDS
+        breaking = BREAKING_KINDS
+        api_break = API_BREAK_KINDS - SDK_VENDOR_COMPAT_KINDS
+        compatible = COMPATIBLE_KINDS | SDK_VENDOR_COMPAT_KINDS
     elif policy == "plugin_abi":
         breaking = BREAKING_KINDS - PLUGIN_ABI_DOWNGRADED_KINDS
         api_break = API_BREAK_KINDS
-        compatible = COMPATIBLE_KINDS | (BREAKING_KINDS & PLUGIN_ABI_DOWNGRADED_KINDS)
+        compatible = COMPATIBLE_KINDS | PLUGIN_ABI_DOWNGRADED_KINDS
     else:
-        # strict_abi (default) and any unknown policy: use full BREAKING set
+        # strict_abi (default) and any unknown policy
         breaking = BREAKING_KINDS
         api_break = API_BREAK_KINDS
         compatible = COMPATIBLE_KINDS

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -374,10 +374,10 @@ API_BREAK_KINDS: set[ChangeKind] = {
 # Policy-specific downgrade sets
 # ---------------------------------------------------------------------------
 
-# sdk_vendor: these API_BREAK_KINDS are source-level-only and do not affect
-# already-compiled binary consumers. Under sdk_vendor policy they are downgraded
-# from API_BREAK → COMPATIBLE (no warning emitted).
-# Examples: enum member renamed, field renamed, param renamed, struct↔class.
+# sdk_vendor: source-level-only kinds that are in API_BREAK_KINDS but do not
+# affect already-compiled binary consumers. Under sdk_vendor policy they are
+# downgraded from API_BREAK → COMPATIBLE (no warning emitted).
+# All members MUST be in API_BREAK_KINDS — enforced by the assertion below.
 SDK_VENDOR_COMPAT_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.ENUM_MEMBER_RENAMED,
     ChangeKind.FIELD_RENAMED,
@@ -387,18 +387,40 @@ SDK_VENDOR_COMPAT_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.SOURCE_LEVEL_KIND_CHANGED,   # struct↔class: binary-identical
     ChangeKind.REMOVED_CONST_OVERLOAD,
     ChangeKind.PARAM_DEFAULT_VALUE_REMOVED,
-    ChangeKind.PARAM_DEFAULT_VALUE_CHANGED,
+    # NOTE: PARAM_DEFAULT_VALUE_CHANGED is intentionally omitted — it already
+    # lives in COMPATIBLE_KINDS, so including it here would be a no-op.
 })
 
-# plugin_abi: kinds that are acceptable when plugin and host are built from
+# Deprecated alias kept for external consumers; will be removed in v2.0.
+SDK_VENDOR_DOWNGRADED_KINDS: frozenset[ChangeKind] = SDK_VENDOR_COMPAT_KINDS
+
+# plugin_abi: kinds that are acceptable when the plugin and host are built from
 # the same toolchain at the same time (single-process boundary).
-# Downgraded from BREAKING → COMPATIBLE.
+# These are all in BREAKING_KINDS and are downgraded from BREAKING → COMPATIBLE.
+# All members MUST be in BREAKING_KINDS — enforced by the assertion below.
 PLUGIN_ABI_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset({
-    ChangeKind.TOOLCHAIN_FLAG_DRIFT,
+    # NOTE: TOOLCHAIN_FLAG_DRIFT is intentionally omitted — it already lives in
+    # COMPATIBLE_KINDS (informational), so it is not in BREAKING_KINDS and
+    # including it here would be a silent no-op in the subtraction logic.
     ChangeKind.CALLING_CONVENTION_CHANGED,
     ChangeKind.FRAME_REGISTER_CHANGED,      # CFA register = physical calling convention
-    ChangeKind.VALUE_ABI_TRAIT_CHANGED,     # DWARF triviality heuristic — same signal
+    # VALUE_ABI_TRAIT_CHANGED: DWARF trivially-copyable heuristic controls
+    # pass-by-register vs pass-by-pointer in the Itanium C++ ABI. Under
+    # plugin_abi this is safe to downgrade ONLY because the plugin and host
+    # are always rebuilt together from the same toolchain — ensuring ABI
+    # triviality decisions are in sync. Do NOT include this in sdk_vendor.
+    ChangeKind.VALUE_ABI_TRAIT_CHANGED,
 })
+
+# Integrity assertions: catch miscategorisation at import time.
+assert SDK_VENDOR_COMPAT_KINDS <= API_BREAK_KINDS, (
+    "SDK_VENDOR_COMPAT_KINDS must be a strict subset of API_BREAK_KINDS; "
+    f"offending kinds: {SDK_VENDOR_COMPAT_KINDS - API_BREAK_KINDS}"
+)
+assert PLUGIN_ABI_DOWNGRADED_KINDS <= BREAKING_KINDS, (
+    "PLUGIN_ABI_DOWNGRADED_KINDS must be a strict subset of BREAKING_KINDS; "
+    f"offending kinds: {PLUGIN_ABI_DOWNGRADED_KINDS - BREAKING_KINDS}"
+)
 
 
 @dataclass(frozen=True)
@@ -446,8 +468,10 @@ def compute_verdict(changes: Sequence[HasKind], *, policy: str = "strict_abi") -
     - ``strict_abi`` (default): full BREAKING / API_BREAK sets apply.
     - ``sdk_vendor``: source-level-only kinds (rename, access) downgraded
       from API_BREAK → COMPATIBLE (no warning for SDK consumers).
-    - ``plugin_abi``: plugin-safe calling-convention kinds (TOOLCHAIN_FLAG_DRIFT,
-      CALLING_CONVENTION_CHANGED) downgraded from BREAKING → COMPATIBLE.
+    - ``plugin_abi``: calling-convention kinds (CALLING_CONVENTION_CHANGED,
+      FRAME_REGISTER_CHANGED, VALUE_ABI_TRAIT_CHANGED) downgraded from
+      BREAKING → COMPATIBLE. Only valid when plugin and host are always
+      rebuilt together from the same toolchain.
 
     Unknown policy names fall back to ``strict_abi``.
     """

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -465,7 +465,7 @@ VALID_BASE_POLICIES: frozenset[str] = frozenset({"strict_abi", "sdk_vendor", "pl
 """Canonical set of valid built-in policy names. Import from here — do not redefine."""
 
 
-def policy_kind_sets(policy: str) -> tuple[frozenset, frozenset, frozenset]:
+def policy_kind_sets(policy: str) -> tuple[frozenset[ChangeKind], frozenset[ChangeKind], frozenset[ChangeKind]]:
     """Return (breaking, api_break, compatible) kind sets for the given policy name.
 
     This is the single source of truth for policy → kind-set mapping.

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -461,6 +461,33 @@ def policy_registry_markdown() -> str:
         )
     return "\n".join(lines)
 
+VALID_BASE_POLICIES: frozenset[str] = frozenset({"strict_abi", "sdk_vendor", "plugin_abi"})
+"""Canonical set of valid built-in policy names. Import from here — do not redefine."""
+
+
+def policy_kind_sets(policy: str) -> tuple[frozenset, frozenset, frozenset]:
+    """Return (breaking, api_break, compatible) kind sets for the given policy name.
+
+    This is the single source of truth for policy → kind-set mapping.
+    Used by compute_verdict(), DiffResult properties, and report classification.
+    Unknown policy names fall back to strict_abi.
+    """
+    if policy == "sdk_vendor":
+        return (
+            frozenset(BREAKING_KINDS),
+            frozenset(API_BREAK_KINDS - SDK_VENDOR_COMPAT_KINDS),
+            frozenset(COMPATIBLE_KINDS | SDK_VENDOR_COMPAT_KINDS),
+        )
+    elif policy == "plugin_abi":
+        return (
+            frozenset(BREAKING_KINDS - PLUGIN_ABI_DOWNGRADED_KINDS),
+            frozenset(API_BREAK_KINDS),
+            frozenset(COMPATIBLE_KINDS | PLUGIN_ABI_DOWNGRADED_KINDS),
+        )
+    else:
+        return frozenset(BREAKING_KINDS), frozenset(API_BREAK_KINDS), frozenset(COMPATIBLE_KINDS)
+
+
 def compute_verdict(changes: Sequence[HasKind], *, policy: str = "strict_abi") -> Verdict:
     """Compute verdict from a list of changes, honoring the given policy profile.
 
@@ -478,21 +505,7 @@ def compute_verdict(changes: Sequence[HasKind], *, policy: str = "strict_abi") -
     if not changes:
         return Verdict.NO_CHANGE
 
-    # Select policy-specific kind sets
-    if policy == "sdk_vendor":
-        breaking = BREAKING_KINDS
-        api_break = API_BREAK_KINDS - SDK_VENDOR_COMPAT_KINDS
-        compatible = COMPATIBLE_KINDS | SDK_VENDOR_COMPAT_KINDS
-    elif policy == "plugin_abi":
-        breaking = BREAKING_KINDS - PLUGIN_ABI_DOWNGRADED_KINDS
-        api_break = API_BREAK_KINDS
-        compatible = COMPATIBLE_KINDS | PLUGIN_ABI_DOWNGRADED_KINDS
-    else:
-        # strict_abi (default) and any unknown policy
-        breaking = BREAKING_KINDS
-        api_break = API_BREAK_KINDS
-        compatible = COMPATIBLE_KINDS
-
+    breaking, api_break, compatible = policy_kind_sets(policy)
     kinds = {c.kind for c in changes}
     if kinds & breaking:
         return Verdict.BREAKING

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -890,6 +890,10 @@ def compat_dump_cmd(
 @click.option("-skip-removed-constants", "skip_removed_constants", is_flag=True, default=False, hidden=True)
 @click.option("-count-symbols", "count_symbols", default=None, hidden=True)
 @click.option("-count-all-symbols", "count_all_symbols", default=None, hidden=True)
+@click.option("--policy", "policy",
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=False),
+              default="strict_abi", show_default=True,
+              help="Policy profile for verdict classification.")
 def compat_cmd(  # noqa: PLR0913
     lib_name: str,
     old_desc: Path,
@@ -902,6 +906,7 @@ def compat_cmd(  # noqa: PLR0913
     src_report_path: Path | None,
     fmt: str,
     suppress: Path | None,
+    policy: str,
     strict: bool,
     strict_mode: str,
     show_retval: bool,
@@ -1166,7 +1171,7 @@ def compat_cmd(  # noqa: PLR0913
             sys.exit(2)
         suppression = _merge_suppression(suppression, file_suppression)
 
-    result = compare(old_snap, new_snap, suppression=suppression)
+    result = compare(old_snap, new_snap, suppression=suppression, policy=policy)
 
     # ── Post-compare transforms ───────────────────────────────────────────
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -119,6 +119,12 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
             pf = PolicyFile.load(policy_file_path)
         except (ValueError, OSError) as e:
             raise click.BadParameter(str(e), param_hint="--policy-file") from e
+        if policy != "strict_abi":
+            click.echo(
+                f"Warning: --policy={policy!r} is ignored when --policy-file is given. "
+                "Set base_policy in the YAML file to override the base policy.",
+                err=True,
+            )
 
     result = compare(old, new, suppression=suppression, policy=policy, policy_file=pf)
 
@@ -347,14 +353,16 @@ def _apply_strict(result: DiffResult, *, mode: str = "full") -> DiffResult:
     return result
 
 
-def _filter_source_only(result: DiffResult, *, policy: str = "strict_abi") -> DiffResult:
+def _filter_source_only(result: DiffResult) -> DiffResult:
     """Remove binary-only changes from result for -source mode.
 
-    Re-derives the verdict using compute_verdict with the given policy so that
-    policy-specific kind downgrades are applied consistently to split reports.
+    Re-derives the verdict and propagates result.policy so that the returned
+    DiffResult is fully self-consistent (verdict, .breaking, .source_breaks,
+    .compatible all use the same policy).
     """
     from .checker import DiffResult  # noqa: PLC0415
 
+    policy = result.policy
     filtered = [c for c in result.changes if c.kind not in _BINARY_ONLY_KINDS]
     verdict = _compute_verdict(filtered, policy=policy)
 
@@ -367,17 +375,20 @@ def _filter_source_only(result: DiffResult, *, policy: str = "strict_abi") -> Di
         suppressed_count=result.suppressed_count,
         suppressed_changes=result.suppressed_changes,
         suppression_file_provided=result.suppression_file_provided,
+        policy=policy,
     )
 
 
-def _filter_binary_only(result: DiffResult, *, policy: str = "strict_abi") -> DiffResult:
+def _filter_binary_only(result: DiffResult) -> DiffResult:
     """Remove source-only changes from result for -binary mode.
 
-    Re-derives the verdict using compute_verdict with the given policy so that
-    policy-specific kind downgrades are applied consistently to split reports.
+    Re-derives the verdict and propagates result.policy so that the returned
+    DiffResult is fully self-consistent (verdict, .breaking, .source_breaks,
+    .compatible all use the same policy).
     """
     from .checker import DiffResult  # noqa: PLC0415
 
+    policy = result.policy
     filtered = [c for c in result.changes if c.kind not in _API_BREAK_KINDS]
     verdict = _compute_verdict(filtered, policy=policy)
 
@@ -390,6 +401,7 @@ def _filter_binary_only(result: DiffResult, *, policy: str = "strict_abi") -> Di
         suppressed_count=result.suppressed_count,
         suppressed_changes=result.suppressed_changes,
         suppression_file_provided=result.suppression_file_provided,
+        policy=policy,
     )
 
 
@@ -408,6 +420,7 @@ def _apply_warn_newsym(result: DiffResult) -> DiffResult:
             suppressed_count=result.suppressed_count,
             suppressed_changes=result.suppressed_changes,
             suppression_file_provided=result.suppression_file_provided,
+            policy=result.policy,
         )
     return result
 
@@ -436,6 +449,7 @@ def _limit_affected_changes(result: DiffResult, limit: int) -> DiffResult:
         suppressed_count=result.suppressed_count,
         suppressed_changes=result.suppressed_changes,
         suppression_file_provided=result.suppression_file_provided,
+        policy=result.policy,
     )
 
 
@@ -1179,7 +1193,7 @@ def compat_cmd(  # noqa: PLR0913
     # from the primary report (matching ABICC semantics). _filter_binary_only
     # is only used for -bin-report-path split reports.
     if source_only and not binary_only:
-        result = _filter_source_only(result, policy="strict_abi")
+        result = _filter_source_only(result)
 
     # -strict: treat COMPATIBLE and API_BREAK as BREAKING.
     # Applied AFTER source filtering so that -source -strict --strict-mode api
@@ -1251,13 +1265,13 @@ def compat_cmd(  # noqa: PLR0913
     # -bin-report-path / -src-report-path: generate split reports
     if bin_report_path:
         bin_report_path.parent.mkdir(parents=True, exist_ok=True)
-        bin_result = _filter_binary_only(full_result, policy="strict_abi")
+        bin_result = _filter_binary_only(full_result)
         _generate_report(bin_result, bin_report_path)
         _do_echo(f"Binary report: {bin_report_path}", quiet)
 
     if src_report_path:
         src_report_path.parent.mkdir(parents=True, exist_ok=True)
-        src_result = _filter_source_only(full_result, policy="strict_abi")
+        src_result = _filter_source_only(full_result)
         _generate_report(src_result, src_report_path)
         _do_echo(f"Source report: {src_report_path}", quiet)
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -11,6 +11,7 @@ import click
 
 from .checker import ChangeKind, compare
 from .checker_policy import API_BREAK_KINDS as _POLICY_API_BREAK_KINDS
+from .checker_policy import compute_verdict as _compute_verdict
 from .compat import CompatDescriptor, parse_descriptor
 from .dumper import dump
 from .html_report import write_html_report
@@ -80,11 +81,14 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
               help="Suppression file (YAML) to filter known/intentional changes.")
 @click.option("--policy", "policy",
-              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=False),
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
               default="strict_abi", show_default=True,
-              help="Policy profile for verdict classification.")
+              help="Built-in policy profile for verdict classification. Ignored when --policy-file is given.")
+@click.option("--policy-file", "policy_file_path",
+              type=click.Path(exists=True, path_type=Path), default=None,
+              help="YAML policy file with per-kind verdict overrides. Overrides --policy.")
 def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path | None,
-                suppress: Path | None, policy: str) -> None:
+                suppress: Path | None, policy: str, policy_file_path: Path | None) -> None:
     """Compare two ABI snapshots and report changes.
 
     \b
@@ -94,7 +98,9 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
       abicheck compare libfoo-1.0.json libfoo-2.0.json --format html -o report.html
       abicheck compare libfoo-1.0.json libfoo-2.0.json --suppress suppressions.yaml
       abicheck compare libfoo-1.0.json libfoo-2.0.json --policy sdk_vendor
+      abicheck compare libfoo-1.0.json libfoo-2.0.json --policy-file project_policy.yaml
     """
+    from .policy_file import PolicyFile
     from .suppression import SuppressionList
 
     old = load_snapshot(old_snapshot)
@@ -107,7 +113,14 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
         except (ValueError, OSError) as e:
             raise click.BadParameter(str(e), param_hint="--suppress") from e
 
-    result = compare(old, new, suppression=suppression, policy=policy)
+    pf: PolicyFile | None = None
+    if policy_file_path is not None:
+        try:
+            pf = PolicyFile.load(policy_file_path)
+        except (ValueError, OSError) as e:
+            raise click.BadParameter(str(e), param_hint="--policy-file") from e
+
+    result = compare(old, new, suppression=suppression, policy=policy, policy_file=pf)
 
     # Warn if suppression file swallowed all changes (potential misconfiguration)
     total_changes = len(result.changes) + result.suppressed_count
@@ -334,28 +347,16 @@ def _apply_strict(result: DiffResult, *, mode: str = "full") -> DiffResult:
     return result
 
 
-def _filter_source_only(result: DiffResult) -> DiffResult:
-    """Remove binary-only changes from result for -source mode."""
-    from .checker import (  # noqa: PLC0415
-        _API_BREAK_KINDS as _SBK,
-    )
-    from .checker import (
-        _BREAKING_KINDS,
-        _COMPATIBLE_KINDS,
-        DiffResult,
-        Verdict,
-    )
+def _filter_source_only(result: DiffResult, *, policy: str = "strict_abi") -> DiffResult:
+    """Remove binary-only changes from result for -source mode.
+
+    Re-derives the verdict using compute_verdict with the given policy so that
+    policy-specific kind downgrades are applied consistently to split reports.
+    """
+    from .checker import DiffResult  # noqa: PLC0415
 
     filtered = [c for c in result.changes if c.kind not in _BINARY_ONLY_KINDS]
-
-    if any(c.kind in _BREAKING_KINDS for c in filtered):
-        verdict = Verdict.BREAKING
-    elif any(c.kind in _SBK for c in filtered):
-        verdict = Verdict.API_BREAK
-    elif any(c.kind in _COMPATIBLE_KINDS for c in filtered):
-        verdict = Verdict.COMPATIBLE
-    else:
-        verdict = Verdict.NO_CHANGE
+    verdict = _compute_verdict(filtered, policy=policy)
 
     return DiffResult(
         old_version=result.old_version,
@@ -369,26 +370,16 @@ def _filter_source_only(result: DiffResult) -> DiffResult:
     )
 
 
-def _filter_binary_only(result: DiffResult) -> DiffResult:
-    """Remove source-only changes from result for -binary mode."""
-    from .checker import (  # noqa: PLC0415
-        _BREAKING_KINDS,
-        _COMPATIBLE_KINDS,
-        DiffResult,
-        Verdict,
-    )
+def _filter_binary_only(result: DiffResult, *, policy: str = "strict_abi") -> DiffResult:
+    """Remove source-only changes from result for -binary mode.
 
-    # _API_BREAK_KINDS is module-level (from checker_policy); use it directly.
+    Re-derives the verdict using compute_verdict with the given policy so that
+    policy-specific kind downgrades are applied consistently to split reports.
+    """
+    from .checker import DiffResult  # noqa: PLC0415
+
     filtered = [c for c in result.changes if c.kind not in _API_BREAK_KINDS]
-
-    if any(c.kind in _BREAKING_KINDS for c in filtered):
-        verdict = Verdict.BREAKING
-    elif any(c.kind in _API_BREAK_KINDS for c in filtered):
-        verdict = Verdict.API_BREAK
-    elif any(c.kind in _COMPATIBLE_KINDS for c in filtered):
-        verdict = Verdict.COMPATIBLE
-    else:
-        verdict = Verdict.NO_CHANGE
+    verdict = _compute_verdict(filtered, policy=policy)
 
     return DiffResult(
         old_version=result.old_version,
@@ -890,10 +881,6 @@ def compat_dump_cmd(
 @click.option("-skip-removed-constants", "skip_removed_constants", is_flag=True, default=False, hidden=True)
 @click.option("-count-symbols", "count_symbols", default=None, hidden=True)
 @click.option("-count-all-symbols", "count_all_symbols", default=None, hidden=True)
-@click.option("--policy", "policy",
-              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=False),
-              default="strict_abi", show_default=True,
-              help="Policy profile for verdict classification.")
 def compat_cmd(  # noqa: PLR0913
     lib_name: str,
     old_desc: Path,
@@ -906,7 +893,6 @@ def compat_cmd(  # noqa: PLR0913
     src_report_path: Path | None,
     fmt: str,
     suppress: Path | None,
-    policy: str,
     strict: bool,
     strict_mode: str,
     show_retval: bool,
@@ -1171,7 +1157,7 @@ def compat_cmd(  # noqa: PLR0913
             sys.exit(2)
         suppression = _merge_suppression(suppression, file_suppression)
 
-    result = compare(old_snap, new_snap, suppression=suppression, policy=policy)
+    result = compare(old_snap, new_snap, suppression=suppression, policy="strict_abi")
 
     # ── Post-compare transforms ───────────────────────────────────────────
 
@@ -1193,7 +1179,7 @@ def compat_cmd(  # noqa: PLR0913
     # from the primary report (matching ABICC semantics). _filter_binary_only
     # is only used for -bin-report-path split reports.
     if source_only and not binary_only:
-        result = _filter_source_only(result)
+        result = _filter_source_only(result, policy="strict_abi")
 
     # -strict: treat COMPATIBLE and API_BREAK as BREAKING.
     # Applied AFTER source filtering so that -source -strict --strict-mode api
@@ -1265,13 +1251,13 @@ def compat_cmd(  # noqa: PLR0913
     # -bin-report-path / -src-report-path: generate split reports
     if bin_report_path:
         bin_report_path.parent.mkdir(parents=True, exist_ok=True)
-        bin_result = _filter_binary_only(full_result)
+        bin_result = _filter_binary_only(full_result, policy="strict_abi")
         _generate_report(bin_result, bin_report_path)
         _do_echo(f"Binary report: {bin_report_path}", quiet)
 
     if src_report_path:
         src_report_path.parent.mkdir(parents=True, exist_ok=True)
-        src_result = _filter_source_only(full_result)
+        src_result = _filter_source_only(full_result, policy="strict_abi")
         _generate_report(src_result, src_report_path)
         _do_echo(f"Source report: {src_report_path}", quiet)
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -117,6 +117,8 @@ def compare_cmd(old_snapshot: Path, new_snapshot: Path, fmt: str, output: Path |
     if policy_file_path is not None:
         try:
             pf = PolicyFile.load(policy_file_path)
+        except ImportError as e:
+            raise click.ClickException(str(e)) from e
         except (ValueError, OSError) as e:
             raise click.BadParameter(str(e), param_hint="--policy-file") from e
         if policy != "strict_abi":

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -686,26 +686,41 @@ def _get_cfi_source(dwarf: Any) -> Any:
 
 
 def _extract_cfa_reg_from_fde(entry: Any, arch_key: str) -> str | None:
-    """Extract the dominant (post-prologue) CFA register name from an FDE.
+    """Extract the dominant CFA register name from an FDE.
 
     Returns the register name string (e.g. 'rsp', 'rbp') or None if not found.
 
-    Selects the row with the highest PC as the best proxy for the settled
-    post-prologue CFA (function body, after push rbp / mov rbp,rsp).
-    table[0] would capture entry-state before the prologue completes.
+    Heuristic:
+    - Build a sequence of (pc, reg_num) rows where CFA is available.
+    - Select the modal CFA register across decoded rows (most frequent), which
+      captures the settled function-body convention and avoids epilogue bias.
+    - Break ties by selecting the register from the highest-PC row among tied
+      candidates (preserves post-prologue behavior for 2-row entry/body tables).
     """
     try:
         decoded = entry.get_decoded()
         if not decoded.table:
             return None
-        row = max(decoded.table, key=lambda r: int(r.get("pc", 0)))
-        cfa = row.get("cfa")
-        if cfa is None:
+
+        regs_by_pc: list[tuple[int, int]] = []
+        for row in decoded.table:
+            cfa = row.get("cfa")
+            if cfa is None:
+                continue
+            cfa_reg = getattr(cfa, "reg", None)
+            if cfa_reg is None:
+                continue
+            regs_by_pc.append((int(row.get("pc", 0)), int(cfa_reg)))
+
+        if not regs_by_pc:
             return None
-        cfa_reg = getattr(cfa, "reg", None)
-        if cfa_reg is None:
-            return None
-        return _reg_name(cfa_reg, arch_key)
+
+        counts = collections.Counter(reg for _, reg in regs_by_pc)
+        max_count = max(counts.values())
+        tied_regs = {reg for reg, cnt in counts.items() if cnt == max_count}
+        dominant_reg = max((pc, reg) for pc, reg in regs_by_pc if reg in tied_regs)[1]
+
+        return _reg_name(dominant_reg, arch_key)
     except (ELFError, OSError, ValueError, KeyError, IndexError):
         return None
 

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -636,56 +636,96 @@ def _reg_name(reg_num: int, arch: str) -> str:
     return f"reg{reg_num}"
 
 
+def _normalize_arch(elf: Any) -> str:
+    """Normalize ELF machine arch string to internal arch_key for register lookup."""
+    arch = str(elf.get_machine_arch())
+    return {
+        "x64": "x64", "x86_64": "x64",
+        "x86": "x86", "i386": "x86",
+        "AArch64": "aarch64", "aarch64": "aarch64",
+    }.get(arch, arch)
+
+
+def _build_addr_to_sym(elf: Any) -> dict[int, str]:
+    """Build address → symbol name map from .dynsym (preferred) and .symtab.
+
+    .dynsym is iterated first to populate exported symbol names.
+    .symtab is iterated second but does NOT overwrite existing .dynsym entries:
+    .dynsym contains only exported ABI symbols; .symtab additionally contains
+    local/static symbols that could shadow exported names at the same address.
+
+    Only STB_GLOBAL and STB_WEAK symbols at non-zero addresses are included.
+    """
+    addr_to_sym: dict[int, str] = {}
+    for section_name in (".dynsym", ".symtab"):
+        sect = elf.get_section_by_name(section_name)
+        if sect is None:
+            continue
+        for sym in sect.iter_symbols():
+            st_value = sym.entry.st_value
+            bind = sym.entry.st_info.bind
+            if bind in ("STB_GLOBAL", "STB_WEAK") and st_value > 0:
+                # .dynsym entries take priority — do not overwrite with .symtab
+                if st_value not in addr_to_sym:
+                    addr_to_sym[st_value] = sym.name
+    return addr_to_sym
+
+
+def _get_cfi_source(dwarf: Any) -> Any:
+    """Return CFI entry iterator, preferring .eh_frame over .debug_frame."""
+    try:
+        src = dwarf.get_EH_CFI_entries()
+        if src is not None:
+            return src
+    except (AttributeError, ELFError):
+        pass
+    try:
+        return dwarf.get_CFI_entries()
+    except (AttributeError, ELFError):
+        return None
+
+
+def _extract_cfa_reg_from_fde(entry: Any, arch_key: str) -> str | None:
+    """Extract the dominant (post-prologue) CFA register name from an FDE.
+
+    Returns the register name string (e.g. 'rsp', 'rbp') or None if not found.
+
+    Selects the row with the highest PC as the best proxy for the settled
+    post-prologue CFA (function body, after push rbp / mov rbp,rsp).
+    table[0] would capture entry-state before the prologue completes.
+    """
+    try:
+        decoded = entry.get_decoded()
+        if not decoded.table:
+            return None
+        row = max(decoded.table, key=lambda r: int(r.get("pc", 0)))
+        cfa = row.get("cfa")
+        if cfa is None:
+            return None
+        cfa_reg = getattr(cfa, "reg", None)
+        if cfa_reg is None:
+            return None
+        return _reg_name(cfa_reg, arch_key)
+    except (ELFError, OSError, ValueError, KeyError, IndexError):
+        return None
+
+
 def _parse_frame_registers(elf: Any, dwarf: Any, meta: AdvancedDwarfMetadata) -> None:
     """Extract CFA register convention for exported functions from .eh_frame (#117).
 
     For each FDE (Frame Description Entry) in .eh_frame (or .debug_frame as fallback),
-    records the dominant CFA register used in the initial CFA rule of each FDE.
-    When the CFA register changes between versions for the same function, it indicates
-    a frame-pointer convention change (e.g., rbp → rsp from -fomit-frame-pointer).
+    records the dominant post-prologue CFA register for each exported function.
+    When the CFA register changes between versions, it indicates a frame-pointer
+    convention change (e.g., rbp → rsp from -fomit-frame-pointer).
 
-    Strategy:
-    - Read the ELF machine architecture for register name resolution.
-    - Iterate FDEs; for each, take the CFA register from the first row of the
-      decoded frame table (the initial state after applying the CIE initial instructions
-      plus FDE instructions up to the first instruction boundary).
-    - Map FDE PC range to function mangled name via .symtab/.dynsym.
-    - Store as meta.frame_registers[mangled_name] = reg_name.
-
-    Graceful: any parsing error on an individual FDE is logged and skipped.
+    Graceful: any parsing error is logged/skipped. Never raises.
     """
     try:
-        # Determine architecture for register name lookup
-        arch = elf.get_machine_arch()
-        arch_key = {
-            "x64": "x64", "x86_64": "x64",
-            "x86": "x86", "i386": "x86",
-            "AArch64": "aarch64", "aarch64": "aarch64",
-        }.get(arch, arch)
-
-        # Build address → symbol name map from .dynsym (and .symtab if available)
-        addr_to_sym: dict[int, str] = {}
-        for section_name in (".dynsym", ".symtab"):
-            sect = elf.get_section_by_name(section_name)
-            if sect is None:
-                continue
-            for sym in sect.iter_symbols():
-                st_value = sym.entry.st_value
-                bind = sym.entry.st_info.bind
-                if bind in ("STB_GLOBAL", "STB_WEAK") and st_value > 0:
-                    addr_to_sym[st_value] = sym.name
-
-        # Parse .eh_frame (preferred) or .debug_frame (fallback)
-        cfi_src = None
-        try:
-            cfi_src = dwarf.get_EH_CFI_entries()
-        except (AttributeError, ELFError):
-            pass
+        arch_key = _normalize_arch(elf)
+        addr_to_sym = _build_addr_to_sym(elf)
+        cfi_src = _get_cfi_source(dwarf)
         if cfi_src is None:
-            try:
-                cfi_src = dwarf.get_CFI_entries()
-            except (AttributeError, ELFError):
-                return
+            return
 
         for entry in cfi_src:
             try:
@@ -695,18 +735,9 @@ def _parse_frame_registers(elf: Any, dwarf: Any, meta: AdvancedDwarfMetadata) ->
                 sym_name = addr_to_sym.get(pc_begin, "")
                 if not sym_name:
                     continue
-                # Decode the frame table and take the CFA register from first row
-                decoded = entry.get_decoded()
-                if not decoded.table:
-                    continue
-                first_row = decoded.table[0]
-                cfa = first_row.get("cfa")
-                if cfa is None:
-                    continue
-                cfa_reg = getattr(cfa, "reg", None)
-                if cfa_reg is None:
-                    continue
-                meta.frame_registers[sym_name] = _reg_name(cfa_reg, arch_key)
+                reg = _extract_cfa_reg_from_fde(entry, arch_key)
+                if reg is not None:
+                    meta.frame_registers[sym_name] = reg
             except (ELFError, OSError, ValueError, KeyError, IndexError) as exc:
                 log.debug("_parse_frame_registers: skipping FDE: %s", exc)
 

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -71,9 +71,15 @@ class PolicyFile:
         """Load and validate a policy file from *path*.
 
         Raises:
-            ValueError: If the file is malformed, contains unknown kind names,
-                invalid severity strings, or an unknown base_policy.
+            ValueError: If the file is malformed, ``base_policy`` is not a string,
+                has an unknown policy name, ``overrides`` is not a mapping, or
+                contains invalid severity strings.
             OSError: If the file cannot be read.
+
+        Note:
+            Unknown kind names in ``overrides`` emit a ``log.warning`` and are
+            skipped — they do not raise. This is intentional to tolerate typos
+            in large policy files without aborting the run.
         """
         try:
             import yaml
@@ -90,6 +96,8 @@ class PolicyFile:
             raise ValueError(f"Policy file must be a YAML mapping, got {type(raw).__name__}")
 
         base_policy = raw.get("base_policy", "strict_abi")
+        if not isinstance(base_policy, str):
+            raise ValueError("'base_policy' must be a string, got " + type(base_policy).__name__)
         if base_policy not in _VALID_BASE_POLICIES:
             raise ValueError(
                 f"Unknown base_policy {base_policy!r}. "

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -1,0 +1,170 @@
+"""Custom policy file support for abicheck.
+
+A policy file is a YAML document that maps ChangeKind names to severity levels,
+allowing users to define project-specific verdict rules.
+
+Format example (``my_policy.yaml``)::
+
+    # abicheck policy file
+    # Maps ChangeKind slug -> severity: break | warn | ignore
+    #
+    # break  -> BREAKING verdict (exit code 4)
+    # warn   -> API_BREAK verdict (exit code 2)
+    # ignore -> COMPATIBLE verdict (exit code 0)
+    #
+    # Any kind not listed falls back to the base policy (default: strict_abi).
+
+    base_policy: strict_abi          # optional; default strict_abi
+
+    overrides:
+      enum_member_renamed:   ignore
+      field_renamed:         ignore
+      param_renamed:         ignore
+      calling_convention_changed: warn
+
+Usage::
+
+    abicheck compare old.json new.json --policy-file my_policy.yaml
+
+Notes:
+- ``--policy-file`` overrides ``--policy`` when both are supplied.
+- Checks are always executed; only verdict classification changes.
+- Unknown kind names emit a warning and are skipped.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .checker_policy import ChangeKind, Verdict, compute_verdict
+
+log = logging.getLogger(__name__)
+
+# Severity name -> Verdict mapping
+_SEVERITY_MAP: dict[str, Verdict] = {
+    "break": Verdict.BREAKING,
+    "warn": Verdict.API_BREAK,
+    "ignore": Verdict.COMPATIBLE,
+}
+
+_VALID_BASE_POLICIES = {"strict_abi", "sdk_vendor", "plugin_abi"}
+
+
+@dataclass
+class PolicyFile:
+    """Parsed custom policy file.
+
+    Attributes:
+        base_policy: Base built-in policy to start from (default: ``strict_abi``).
+        overrides: Mapping of ChangeKind -> Verdict as specified in the file.
+        source_path: Path to the loaded file (for error reporting).
+    """
+
+    base_policy: str = "strict_abi"
+    overrides: dict[ChangeKind, Verdict] = field(default_factory=dict)
+    source_path: Path | None = None
+
+    @classmethod
+    def load(cls, path: Path) -> "PolicyFile":
+        """Load and validate a policy file from *path*.
+
+        Raises:
+            ValueError: If the file is malformed, contains unknown kind names,
+                invalid severity strings, or an unknown base_policy.
+            OSError: If the file cannot be read.
+        """
+        try:
+            import yaml  # type: ignore[import]
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "PyYAML is required for --policy-file support. "
+                "Install it with: pip install pyyaml"
+            ) from exc
+
+        raw: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if raw is None:
+            return cls(source_path=path)
+        if not isinstance(raw, dict):
+            raise ValueError(f"Policy file must be a YAML mapping, got {type(raw).__name__}")
+
+        base_policy = raw.get("base_policy", "strict_abi")
+        if base_policy not in _VALID_BASE_POLICIES:
+            raise ValueError(
+                f"Unknown base_policy {base_policy!r}. "
+                f"Valid values: {sorted(_VALID_BASE_POLICIES)}"
+            )
+
+        overrides_raw = raw.get("overrides", {})
+        if not isinstance(overrides_raw, dict):
+            raise ValueError("'overrides' must be a YAML mapping of kind -> severity")
+
+        overrides: dict[ChangeKind, Verdict] = {}
+        unknown_kinds: list[str] = []
+        unknown_severities: list[str] = []
+
+        slug_to_kind = {k.value: k for k in ChangeKind}
+
+        for slug, severity in overrides_raw.items():
+            kind = slug_to_kind.get(str(slug))
+            if kind is None:
+                unknown_kinds.append(str(slug))
+                continue
+            verdict = _SEVERITY_MAP.get(str(severity).lower())
+            if verdict is None:
+                unknown_severities.append(f"{slug}: {severity!r}")
+                continue
+            overrides[kind] = verdict
+
+        if unknown_kinds:
+            log.warning(
+                "policy file %s: unknown ChangeKind slugs (skipped): %s",
+                path, ", ".join(sorted(unknown_kinds)),
+            )
+        if unknown_severities:
+            raise ValueError(
+                f"Invalid severity values in {path}: {unknown_severities}. "
+                "Valid values: break, warn, ignore"
+            )
+
+        return cls(base_policy=base_policy, overrides=overrides, source_path=path)
+
+    def compute_verdict(self, changes: list[Any]) -> Verdict:
+        """Compute verdict for *changes* applying base_policy then overrides.
+
+        Algorithm:
+        1. Compute base verdict using the configured base_policy.
+        2. For each change, if its kind has an override, apply the override
+           verdict (can upgrade or downgrade).
+        3. Final verdict = worst (most severe) verdict across all changes.
+        """
+        if not changes:
+            return Verdict.NO_CHANGE
+
+        # Start from base policy verdict
+        verdicts: list[Verdict] = []
+        for change in changes:
+            kind = change.kind
+            if kind in self.overrides:
+                verdicts.append(self.overrides[kind])
+            else:
+                # Delegate to base policy for this single change
+                single_verdict = compute_verdict([change], policy=self.base_policy)
+                verdicts.append(single_verdict)
+
+        # Worst verdict wins
+        order = [Verdict.NO_CHANGE, Verdict.COMPATIBLE, Verdict.API_BREAK, Verdict.BREAKING]
+        return max(verdicts, key=lambda v: order.index(v) if v in order else 0)
+
+    def describe(self) -> str:
+        """Return a human-readable summary of this policy."""
+        lines = [f"base_policy: {self.base_policy}"]
+        if self.overrides:
+            lines.append("overrides:")
+            for kind, verdict in sorted(self.overrides.items(), key=lambda x: x[0].value):
+                sev = next(s for s, v in _SEVERITY_MAP.items() if v == verdict)
+                lines.append(f"  {kind.value}: {sev}")
+        else:
+            lines.append("overrides: (none)")
+        return "\n".join(lines)

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .checker_policy import ChangeKind, Verdict, compute_verdict, VALID_BASE_POLICIES
+from .checker_policy import VALID_BASE_POLICIES, ChangeKind, Verdict, compute_verdict
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ class PolicyFile:
     source_path: Path | None = None
 
     @classmethod
-    def load(cls, path: Path) -> "PolicyFile":
+    def load(cls, path: Path) -> PolicyFile:
         """Load and validate a policy file from *path*.
 
         Raises:
@@ -76,7 +76,7 @@ class PolicyFile:
             OSError: If the file cannot be read.
         """
         try:
-            import yaml  # type: ignore[import]
+            import yaml
         except ImportError as exc:  # pragma: no cover
             raise ImportError(
                 "PyYAML is required for --policy-file support. "

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .checker_policy import ChangeKind, Verdict, compute_verdict
+from .checker_policy import ChangeKind, Verdict, compute_verdict, VALID_BASE_POLICIES
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ _SEVERITY_MAP: dict[str, Verdict] = {
     "ignore": Verdict.COMPATIBLE,
 }
 
-_VALID_BASE_POLICIES = {"strict_abi", "sdk_vendor", "plugin_abi"}
+_VALID_BASE_POLICIES = VALID_BASE_POLICIES  # re-export alias for backward compat
 
 
 @dataclass

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,7 +1,13 @@
 # Policy Profiles
 
-`abicheck compare` and `abicheck compat` support a `--policy` flag that controls
-how changes are classified into verdict levels.
+`abicheck compare` supports policy-based verdict classification.
+
+- Built-in profiles: `--policy strict_abi|sdk_vendor|plugin_abi`
+- Custom profile file: `--policy-file <yaml>`
+
+`abicheck compat` intentionally does **not** expose `--policy`; it stays aligned
+with ABICC-compatible behavior (`strict_abi` semantics) plus its own legacy flags
+like `-strict`/`--strict-mode`.
 
 ## Usage
 
@@ -9,6 +15,7 @@ how changes are classified into verdict levels.
 abicheck compare old.json new.json --policy strict_abi   # default
 abicheck compare old.json new.json --policy sdk_vendor
 abicheck compare old.json new.json --policy plugin_abi
+abicheck compare old.json new.json --policy-file policy.yaml
 ```
 
 ## Available Profiles
@@ -46,7 +53,6 @@ since SDK consumers typically use stable binary interfaces, not source-level nam
 | `source_level_kind_changed` | `struct` ↔ `class` keyword (binary-identical) |
 | `removed_const_overload` | const overload removed |
 | `param_default_value_removed` | Default argument removed |
-| `param_default_value_changed` | Default argument value changed |
 
 All `BREAKING` kinds remain `BREAKING` — this profile does not suppress binary breaks.
 
@@ -67,18 +73,45 @@ they are controlled by the build system rather than the library ABI contract.
 | `calling_convention_changed` | DWARF DW_AT_calling_convention drift |
 | `frame_register_changed` | CFA/frame-pointer register changed (.eh_frame) |
 | `value_abi_trait_changed` | DWARF triviality heuristic (pass-by-reg vs pointer) |
-| `toolchain_flag_drift` | -fshort-enums/-fpack-struct ABI flag drift |
 
 All `BREAKING` kinds that are not calling-convention-related remain `BREAKING`.
+
+`toolchain_flag_drift` is already `COMPATIBLE` in the default policy (informational),
+so it is not part of the plugin downgrade set.
 
 Use for: dynamically-loaded plugins, JNI/Python extension modules, hot-reload scenarios
 where the plugin and host are always rebuilt together.
 
 ---
 
+## Custom Policy Files (`--policy-file`)
+
+Custom policy files let you keep all detectors enabled and only override
+how specific change kinds are classified.
+
+Minimal example:
+
+```yaml
+base_policy: strict_abi   # optional, default strict_abi
+overrides:
+  enum_member_renamed: ignore   # break|warn|ignore
+  field_renamed: ignore
+  calling_convention_changed: warn
+```
+
+Semantics:
+- `break`  → `BREAKING` (exit code 4)
+- `warn`   → `API_BREAK` (exit code 2)
+- `ignore` → `COMPATIBLE` (exit code 0)
+- kinds not listed in `overrides` use `base_policy`
+
+If both `--policy` and `--policy-file` are provided, `--policy-file` wins.
+
+---
+
 ## Exit Codes
 
-Exit codes are the same for all policies — only the verdict changes:
+For `abicheck compare`, exit codes are the same for all policies — only the verdict changes:
 
 | Exit Code | Verdict |
 |-----------|---------|
@@ -86,12 +119,16 @@ Exit codes are the same for all policies — only the verdict changes:
 | `2` | `API_BREAK` (source-level break) |
 | `4` | `BREAKING` (binary ABI break) |
 
+For `abicheck compat`, policy still affects verdict classification, but command-level
+options (`-strict`, `--strict-mode`, legacy compatibility behavior) can additionally
+modify the final process exit status. Treat the table above as `compare` semantics.
+
 ---
 
 ## Extending Policies
 
-Policy profiles are defined in `abicheck/checker_policy.py`:
+Built-in profiles are defined in `abicheck/checker_policy.py`:
 - `SDK_VENDOR_COMPAT_KINDS` — kinds downgraded to COMPATIBLE under `sdk_vendor`
 - `PLUGIN_ABI_DOWNGRADED_KINDS` — kinds downgraded to COMPATIBLE under `plugin_abi`
 
-To add a custom profile, extend `compute_verdict()` with a new `elif policy == "..."` branch.
+Custom file parsing/overrides live in `abicheck/policy_file.py` (`PolicyFile`).

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,97 @@
+# Policy Profiles
+
+`abicheck compare` and `abicheck compat` support a `--policy` flag that controls
+how changes are classified into verdict levels.
+
+## Usage
+
+```bash
+abicheck compare old.json new.json --policy strict_abi   # default
+abicheck compare old.json new.json --policy sdk_vendor
+abicheck compare old.json new.json --policy plugin_abi
+```
+
+## Available Profiles
+
+### `strict_abi` (default)
+
+Full strictness — every detected ABI change is classified at its maximum severity.
+
+| Verdict | Meaning |
+|---------|---------|
+| `BREAKING` | Binary ABI break — old callers will crash or misbehave |
+| `API_BREAK` | Source-level break — recompile required, but binary may still work |
+| `COMPATIBLE` | Safe addition or informational |
+| `NO_CHANGE` | No differences found |
+
+Use for: shared libraries, system libraries, public SDKs with strict compatibility guarantees.
+
+---
+
+### `sdk_vendor`
+
+Permissive profile for SDK / vendor libraries. Source-level-only changes
+(renames, access changes) are downgraded from `API_BREAK` to `COMPATIBLE`
+since SDK consumers typically use stable binary interfaces, not source-level names.
+
+**Downgraded to `COMPATIBLE` under `sdk_vendor`:**
+
+| Change Kind | Description |
+|-------------|-------------|
+| `enum_member_renamed` | Enum member name changed (value unchanged) |
+| `field_renamed` | Struct/class field name changed |
+| `param_renamed` | Function parameter name changed |
+| `method_access_changed` | Method access level changed |
+| `field_access_changed` | Field access level changed |
+| `source_level_kind_changed` | `struct` ↔ `class` keyword (binary-identical) |
+| `removed_const_overload` | const overload removed |
+| `param_default_value_removed` | Default argument removed |
+| `param_default_value_changed` | Default argument value changed |
+
+All `BREAKING` kinds remain `BREAKING` — this profile does not suppress binary breaks.
+
+Use for: vendor SDKs, optional library extensions, plugin APIs where source compat is not required.
+
+---
+
+### `plugin_abi`
+
+Relaxed profile for plugins that are built from the **same toolchain** as the host
+at the same time. Calling-convention signals are downgraded to `COMPATIBLE` since
+they are controlled by the build system rather than the library ABI contract.
+
+**Downgraded to `COMPATIBLE` under `plugin_abi`:**
+
+| Change Kind | Description |
+|-------------|-------------|
+| `calling_convention_changed` | DWARF DW_AT_calling_convention drift |
+| `frame_register_changed` | CFA/frame-pointer register changed (.eh_frame) |
+| `value_abi_trait_changed` | DWARF triviality heuristic (pass-by-reg vs pointer) |
+| `toolchain_flag_drift` | -fshort-enums/-fpack-struct ABI flag drift |
+
+All `BREAKING` kinds that are not calling-convention-related remain `BREAKING`.
+
+Use for: dynamically-loaded plugins, JNI/Python extension modules, hot-reload scenarios
+where the plugin and host are always rebuilt together.
+
+---
+
+## Exit Codes
+
+Exit codes are the same for all policies — only the verdict changes:
+
+| Exit Code | Verdict |
+|-----------|---------|
+| `0` | `NO_CHANGE` or `COMPATIBLE` |
+| `2` | `API_BREAK` (source-level break) |
+| `4` | `BREAKING` (binary ABI break) |
+
+---
+
+## Extending Policies
+
+Policy profiles are defined in `abicheck/checker_policy.py`:
+- `SDK_VENDOR_COMPAT_KINDS` — kinds downgraded to COMPATIBLE under `sdk_vendor`
+- `PLUGIN_ABI_DOWNGRADED_KINDS` — kinds downgraded to COMPATIBLE under `plugin_abi`
+
+To add a custom profile, extend `compute_verdict()` with a new `elif policy == "..."` branch.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - Using abicheck: usage_and_coverage.md
     - Tool Modes: tool_modes.md
     - Exit Codes: exit_codes.md
+    - Policy Profiles: policies.md
     - SARIF Output: sarif_output.md
     - Migrating from ABICC: migration/from_abicc.md
     - Examples Breakage Guide: examples_breakage_guide.md

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -30,7 +30,6 @@ from abicheck.dwarf_advanced import (
 )
 from abicheck.model import AbiSnapshot
 
-
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 def _change(kind: ChangeKind) -> Any:
@@ -165,9 +164,12 @@ class TestExtractCfaRegFromFde:
 
     def test_modal_register_avoids_epilogue_bias(self) -> None:
         """3-row table: entry/body rbp, epilogue rsp -> dominant should be rbp."""
-        cfa_entry = MagicMock(); cfa_entry.reg = 6   # rbp
-        cfa_body = MagicMock(); cfa_body.reg = 6    # rbp
-        cfa_epi = MagicMock(); cfa_epi.reg = 7      # rsp
+        cfa_entry = MagicMock()
+        cfa_entry.reg = 6   # rbp
+        cfa_body = MagicMock()
+        cfa_body.reg = 6    # rbp
+        cfa_epi = MagicMock()
+        cfa_epi.reg = 7     # rsp
 
         rows = [
             {"pc": 0x1000, "cfa": cfa_entry},

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -1,0 +1,241 @@
+"""Follow-up tests for PR #100 (FRAME_REGISTER_CHANGED) and PR #101 (--policy CLI).
+
+Addresses all review findings:
+- _extract_cfa_reg_from_fde helper with mock FDE objects (post-prologue row selection)
+- _normalize_arch helper
+- policy-aware compute_verdict: sdk_vendor, plugin_abi
+- CLI --policy flag end-to-end via CliRunner
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from abicheck.checker_policy import (
+    PLUGIN_ABI_DOWNGRADED_KINDS,
+    SDK_VENDOR_COMPAT_KINDS,
+    ChangeKind,
+    Verdict,
+    compute_verdict,
+)
+from abicheck.dwarf_advanced import (
+    _extract_cfa_reg_from_fde,
+    _normalize_arch,
+    _reg_name,
+)
+from abicheck.model import AbiSnapshot
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _change(kind: ChangeKind) -> Any:
+    c = MagicMock()
+    c.kind = kind
+    return c
+
+
+def _make_fde(rows: list[dict[str, Any]]) -> MagicMock:
+    decoded = MagicMock()
+    decoded.table = rows
+    fde = MagicMock()
+    fde.get_decoded.return_value = decoded
+    return fde
+
+
+# ── _reg_name helpers ─────────────────────────────────────────────────────────
+
+class TestRegNameHelpers:
+    def test_x86_64_rbp(self) -> None:
+        assert _reg_name(6, "x64") == "rbp"
+
+    def test_x86_64_rsp(self) -> None:
+        assert _reg_name(7, "x64") == "rsp"
+
+    def test_x86_ebp(self) -> None:
+        assert _reg_name(5, "x86") == "ebp"
+
+    def test_aarch64_sp(self) -> None:
+        assert _reg_name(31, "aarch64") == "sp"
+
+    def test_unknown_arch_fallback(self) -> None:
+        assert _reg_name(7, "mips") == "reg7"
+
+    def test_unknown_regnum_fallback(self) -> None:
+        assert _reg_name(99, "x64") == "reg99"
+
+
+class TestNormalizeArch:
+    def test_x64(self) -> None:
+        elf = MagicMock()
+        elf.get_machine_arch.return_value = "x64"
+        assert _normalize_arch(elf) == "x64"
+
+    def test_aarch64(self) -> None:
+        elf = MagicMock()
+        elf.get_machine_arch.return_value = "AArch64"
+        assert _normalize_arch(elf) == "aarch64"
+
+    def test_unknown_passthrough(self) -> None:
+        elf = MagicMock()
+        elf.get_machine_arch.return_value = "riscv"
+        assert _normalize_arch(elf) == "riscv"
+
+
+# ── _extract_cfa_reg_from_fde ─────────────────────────────────────────────────
+
+class TestExtractCfaRegFromFde:
+
+    def test_picks_highest_pc_row_not_first(self) -> None:
+        """Must pick post-prologue (highest-PC) row, not entry-state row."""
+        cfa_entry = MagicMock()
+        cfa_entry.reg = 6   # rbp — entry-state (lower PC)
+        cfa_post = MagicMock()
+        cfa_post.reg = 7    # rsp — post-prologue (higher PC)
+
+        rows = [
+            {"pc": 0x1000, "cfa": cfa_entry},   # entry: rbp
+            {"pc": 0x1010, "cfa": cfa_post},     # post-prologue: rsp ← should win
+        ]
+        assert _extract_cfa_reg_from_fde(_make_fde(rows), "x64") == "rsp"
+
+    def test_single_row_used(self) -> None:
+        cfa = MagicMock()
+        cfa.reg = 6   # rbp
+        assert _extract_cfa_reg_from_fde(_make_fde([{"pc": 0x1000, "cfa": cfa}]), "x64") == "rbp"
+
+    def test_empty_table_returns_none(self) -> None:
+        assert _extract_cfa_reg_from_fde(_make_fde([]), "x64") is None
+
+    def test_no_cfa_key_returns_none(self) -> None:
+        assert _extract_cfa_reg_from_fde(_make_fde([{"pc": 0x1000}]), "x64") is None
+
+    def test_cfa_no_reg_attr_returns_none(self) -> None:
+        cfa = MagicMock(spec=[])  # no .reg
+        assert _extract_cfa_reg_from_fde(_make_fde([{"pc": 0x1000, "cfa": cfa}]), "x64") is None
+
+    def test_decode_exception_returns_none(self) -> None:
+        fde = MagicMock()
+        fde.get_decoded.side_effect = ValueError("parse error")
+        assert _extract_cfa_reg_from_fde(fde, "x64") is None
+
+
+# ── compute_verdict — sdk_vendor ──────────────────────────────────────────────
+
+class TestSdkVendorVerdict:
+    """sdk_vendor downgrades source-level API_BREAK kinds to COMPATIBLE."""
+
+    def test_enum_member_renamed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.ENUM_MEMBER_RENAMED)], policy="sdk_vendor") == Verdict.COMPATIBLE
+
+    def test_field_renamed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.FIELD_RENAMED)], policy="sdk_vendor") == Verdict.COMPATIBLE
+
+    def test_param_renamed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.PARAM_RENAMED)], policy="sdk_vendor") == Verdict.COMPATIBLE
+
+    def test_method_access_changed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.METHOD_ACCESS_CHANGED)], policy="sdk_vendor") == Verdict.COMPATIBLE
+
+    def test_source_level_kind_changed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.SOURCE_LEVEL_KIND_CHANGED)], policy="sdk_vendor") == Verdict.COMPATIBLE
+
+    def test_func_removed_still_breaking(self) -> None:
+        assert compute_verdict([_change(ChangeKind.FUNC_REMOVED)], policy="sdk_vendor") == Verdict.BREAKING
+
+    def test_strict_abi_enum_rename_is_api_break(self) -> None:
+        """Verify strict_abi baseline: enum rename → API_BREAK (not COMPATIBLE)."""
+        assert compute_verdict([_change(ChangeKind.ENUM_MEMBER_RENAMED)], policy="strict_abi") == Verdict.API_BREAK
+
+    def test_all_sdk_compat_kinds_produce_compatible(self) -> None:
+        for kind in SDK_VENDOR_COMPAT_KINDS:
+            result = compute_verdict([_change(kind)], policy="sdk_vendor")
+            assert result == Verdict.COMPATIBLE, (
+                f"{kind} with sdk_vendor → {result!r}, expected COMPATIBLE"
+            )
+
+    def test_mixed_breaking_and_compat_yields_breaking(self) -> None:
+        changes = [_change(ChangeKind.FIELD_RENAMED), _change(ChangeKind.FUNC_REMOVED)]
+        assert compute_verdict(changes, policy="sdk_vendor") == Verdict.BREAKING
+
+
+# ── compute_verdict — plugin_abi ──────────────────────────────────────────────
+
+class TestPluginAbiVerdict:
+    """plugin_abi downgrades calling-convention kinds to COMPATIBLE."""
+
+    def test_calling_convention_changed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.CALLING_CONVENTION_CHANGED)], policy="plugin_abi") == Verdict.COMPATIBLE
+
+    def test_calling_convention_strict_is_breaking(self) -> None:
+        assert compute_verdict([_change(ChangeKind.CALLING_CONVENTION_CHANGED)], policy="strict_abi") == Verdict.BREAKING
+
+    def test_func_removed_still_breaking_in_plugin(self) -> None:
+        assert compute_verdict([_change(ChangeKind.FUNC_REMOVED)], policy="plugin_abi") == Verdict.BREAKING
+
+    def test_all_plugin_downgraded_kinds_produce_compatible(self) -> None:
+        for kind in PLUGIN_ABI_DOWNGRADED_KINDS:
+            result = compute_verdict([_change(kind)], policy="plugin_abi")
+            assert result == Verdict.COMPATIBLE, (
+                f"{kind} with plugin_abi → {result!r}, expected COMPATIBLE"
+            )
+
+    def test_unknown_policy_fallback_to_strict(self) -> None:
+        changes = [_change(ChangeKind.CALLING_CONVENTION_CHANGED)]
+        assert compute_verdict(changes, policy="nonexistent") == Verdict.BREAKING
+
+
+# ── CLI --policy end-to-end ───────────────────────────────────────────────────
+
+class TestCliPolicy:
+
+    def _write_snapshots(self, tmp_path: Any) -> tuple[Any, Any]:
+        from abicheck.serialization import snapshot_to_dict
+
+        old = AbiSnapshot(library="lib.so", version="1.0")
+        new = AbiSnapshot(library="lib.so", version="2.0")
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        old_p.write_text(json.dumps(snapshot_to_dict(old)))
+        new_p.write_text(json.dumps(snapshot_to_dict(new)))
+        return old_p, new_p
+
+    def test_policy_strict_abi_accepted(self, tmp_path: Any) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        old_p, new_p = self._write_snapshots(tmp_path)
+        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "strict_abi"])
+        assert result.exit_code in (0, 2, 4), result.output
+
+    def test_policy_sdk_vendor_accepted(self, tmp_path: Any) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        old_p, new_p = self._write_snapshots(tmp_path)
+        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "sdk_vendor"])
+        assert result.exit_code in (0, 2, 4), result.output
+
+    def test_policy_plugin_abi_accepted(self, tmp_path: Any) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        old_p, new_p = self._write_snapshots(tmp_path)
+        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "plugin_abi"])
+        assert result.exit_code in (0, 2, 4), result.output
+
+    def test_policy_invalid_rejected(self, tmp_path: Any) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        old_p, new_p = self._write_snapshots(tmp_path)
+        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "bad_policy"])
+        assert result.exit_code == 2
+
+    def test_help_lists_policy_choices(self) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        result = CliRunner().invoke(main, ["compare", "--help"])
+        assert "sdk_vendor" in result.output
+        assert "plugin_abi" in result.output
+        assert "strict_abi" in result.output

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -259,34 +259,58 @@ class TestPluginAbiVerdict:
 # ── CLI/report-filter policy integration ─────────────────────────────────────
 
 class TestCliPolicyFiltering:
-    def _mk_result(self, *kinds: ChangeKind) -> DiffResult:
+    def _mk_result(self, policy: str = "strict_abi", *kinds: ChangeKind) -> DiffResult:
         return DiffResult(
             old_version="1.0",
             new_version="2.0",
             library="lib.so",
             changes=[_change(k) for k in kinds],
             verdict=Verdict.NO_CHANGE,
+            policy=policy,
         )
 
-    def test_filter_source_only_honors_policy(self) -> None:
+    def test_filter_source_only_strict(self) -> None:
         from abicheck.cli import _filter_source_only
 
-        result = self._mk_result(ChangeKind.ENUM_MEMBER_RENAMED)
-        strict = _filter_source_only(result, policy="strict_abi")
-        sdk = _filter_source_only(result, policy="sdk_vendor")
+        result = self._mk_result("strict_abi", ChangeKind.ENUM_MEMBER_RENAMED)
+        filtered = _filter_source_only(result)
 
-        assert strict.verdict == Verdict.API_BREAK
-        assert sdk.verdict == Verdict.COMPATIBLE
+        assert filtered.policy == "strict_abi"
+        assert filtered.verdict == Verdict.API_BREAK
+        assert len(filtered.source_breaks) == 1
 
-    def test_filter_binary_only_honors_policy(self) -> None:
+    def test_filter_source_only_sdk_vendor_propagates_policy(self) -> None:
+        from abicheck.cli import _filter_source_only
+
+        result = self._mk_result("sdk_vendor", ChangeKind.ENUM_MEMBER_RENAMED)
+        filtered = _filter_source_only(result)
+
+        # policy must be propagated — verdict AND .source_breaks both sdk_vendor
+        assert filtered.policy == "sdk_vendor"
+        assert filtered.verdict == Verdict.COMPATIBLE
+        assert len(filtered.source_breaks) == 0
+        assert len(filtered.compatible) == 1
+
+    def test_filter_binary_only_strict(self) -> None:
         from abicheck.cli import _filter_binary_only
 
-        result = self._mk_result(ChangeKind.CALLING_CONVENTION_CHANGED)
-        strict = _filter_binary_only(result, policy="strict_abi")
-        plugin = _filter_binary_only(result, policy="plugin_abi")
+        result = self._mk_result("strict_abi", ChangeKind.CALLING_CONVENTION_CHANGED)
+        filtered = _filter_binary_only(result)
 
-        assert strict.verdict == Verdict.BREAKING
-        assert plugin.verdict == Verdict.COMPATIBLE
+        assert filtered.policy == "strict_abi"
+        assert filtered.verdict == Verdict.BREAKING
+        assert len(filtered.breaking) == 1
+
+    def test_filter_binary_only_plugin_abi_propagates_policy(self) -> None:
+        from abicheck.cli import _filter_binary_only
+
+        result = self._mk_result("plugin_abi", ChangeKind.CALLING_CONVENTION_CHANGED)
+        filtered = _filter_binary_only(result)
+
+        assert filtered.policy == "plugin_abi"
+        assert filtered.verdict == Verdict.COMPATIBLE
+        assert len(filtered.breaking) == 0
+        assert len(filtered.compatible) == 1
 
 
 # ── CLI --policy end-to-end ───────────────────────────────────────────────────
@@ -348,6 +372,38 @@ class TestCliPolicy:
             )
 
         assert result.exit_code == 0, result.output
+
+    def test_policy_file_wins_over_policy_flag(self, tmp_path: Any) -> None:
+        """--policy-file base_policy takes precedence; --policy is ignored."""
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old_p, new_p = self._write_snapshots(tmp_path)
+        # YAML file explicitly sets base_policy=strict_abi
+        policy_p = tmp_path / "strict.yaml"
+        policy_p.write_text("base_policy: strict_abi\noverrides: {}\n", encoding="utf-8")
+
+        captured: dict = {}
+
+        def _fake_compare(*_args: Any, **kwargs: Any) -> DiffResult:
+            captured["policy"] = kwargs.get("policy")
+            captured["policy_file"] = kwargs.get("policy_file")
+            return DiffResult(old_version="1.0", new_version="2.0", library="lib.so", changes=[], verdict=Verdict.NO_CHANGE)
+
+        with patch("abicheck.cli.compare", side_effect=_fake_compare):
+            result = CliRunner().invoke(
+                main,
+                ["compare", str(old_p), str(new_p),
+                 "--policy", "sdk_vendor",
+                 "--policy-file", str(policy_p)],
+            )
+
+        assert result.exit_code == 0, result.output
+        # policy_file must be passed (not None)
+        assert captured["policy_file"] is not None
+        # warning emitted on stderr
+        assert "--policy" in result.output or "ignored" in result.output
 
     def test_help_lists_policy_choices(self) -> None:
         from click.testing import CliRunner

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -360,6 +360,39 @@ class TestCliPolicy:
         assert "--policy-file" in result.output
 
 
+class TestDiffResultPolicyAwareProperties:
+    """DiffResult.breaking/source_breaks/compatible must honour the active policy."""
+
+    def _mk_result(self, policy: str, *kinds: ChangeKind) -> DiffResult:
+        return DiffResult(
+            old_version="1.0",
+            new_version="2.0",
+            library="lib.so",
+            changes=[_change(k) for k in kinds],
+            verdict=Verdict.NO_CHANGE,
+            policy=policy,
+        )
+
+    def test_enum_rename_in_source_breaks_strict(self) -> None:
+        r = self._mk_result("strict_abi", ChangeKind.ENUM_MEMBER_RENAMED)
+        assert len(r.source_breaks) == 1
+        assert len(r.compatible) == 0
+
+    def test_enum_rename_in_compatible_sdk_vendor(self) -> None:
+        r = self._mk_result("sdk_vendor", ChangeKind.ENUM_MEMBER_RENAMED)
+        assert len(r.source_breaks) == 0
+        assert len(r.compatible) == 1
+
+    def test_calling_convention_in_breaking_strict(self) -> None:
+        r = self._mk_result("strict_abi", ChangeKind.CALLING_CONVENTION_CHANGED)
+        assert len(r.breaking) == 1
+
+    def test_calling_convention_in_compatible_plugin(self) -> None:
+        r = self._mk_result("plugin_abi", ChangeKind.CALLING_CONVENTION_CHANGED)
+        assert len(r.breaking) == 0
+        assert len(r.compatible) == 1
+
+
 class TestCompatPolicyExposure:
     def test_compat_help_has_no_policy_flag(self) -> None:
         from click.testing import CliRunner

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -1,30 +1,35 @@
 """Follow-up tests for PR #100 (FRAME_REGISTER_CHANGED) and PR #101 (--policy CLI).
 
-Addresses all review findings:
-- _extract_cfa_reg_from_fde helper with mock FDE objects (post-prologue row selection)
-- _normalize_arch helper
+Covers:
+- _extract_cfa_reg_from_fde helper behavior (including epilogue edge case)
+- _normalize_arch, _build_addr_to_sym, _get_cfi_source helpers
 - policy-aware compute_verdict: sdk_vendor, plugin_abi
-- CLI --policy flag end-to-end via CliRunner
+- CLI/report filtering honoring --policy
 """
 from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from abicheck.checker import DiffResult
 from abicheck.checker_policy import (
     PLUGIN_ABI_DOWNGRADED_KINDS,
     SDK_VENDOR_COMPAT_KINDS,
+    SDK_VENDOR_DOWNGRADED_KINDS,
     ChangeKind,
     Verdict,
     compute_verdict,
 )
 from abicheck.dwarf_advanced import (
+    _build_addr_to_sym,
     _extract_cfa_reg_from_fde,
+    _get_cfi_source,
     _normalize_arch,
     _reg_name,
 )
 from abicheck.model import AbiSnapshot
+
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -40,6 +45,20 @@ def _make_fde(rows: list[dict[str, Any]]) -> MagicMock:
     fde = MagicMock()
     fde.get_decoded.return_value = decoded
     return fde
+
+
+def _make_symbol(name: str, value: int, bind: str) -> MagicMock:
+    sym = MagicMock()
+    sym.name = name
+    sym.entry.st_value = value
+    sym.entry.st_info.bind = bind
+    return sym
+
+
+def _make_section(symbols: list[MagicMock]) -> MagicMock:
+    sect = MagicMock()
+    sect.iter_symbols.return_value = symbols
+    return sect
 
 
 # ── _reg_name helpers ─────────────────────────────────────────────────────────
@@ -81,26 +100,85 @@ class TestNormalizeArch:
         assert _normalize_arch(elf) == "riscv"
 
 
+class TestBuildAddrToSym:
+    def test_dynsym_precedence_same_address(self) -> None:
+        elf = MagicMock()
+        dyn = _make_section([_make_symbol("exported", 0x1000, "STB_GLOBAL")])
+        sym = _make_section([_make_symbol("local_shadow", 0x1000, "STB_GLOBAL")])
+        elf.get_section_by_name.side_effect = lambda name: {".dynsym": dyn, ".symtab": sym}.get(name)
+
+        out = _build_addr_to_sym(elf)
+        assert out[0x1000] == "exported"
+
+    def test_ignores_local_and_zero(self) -> None:
+        elf = MagicMock()
+        dyn = _make_section([
+            _make_symbol("zero", 0, "STB_GLOBAL"),
+            _make_symbol("local", 0x2000, "STB_LOCAL"),
+            _make_symbol("weak_ok", 0x3000, "STB_WEAK"),
+        ])
+        elf.get_section_by_name.side_effect = lambda name: {".dynsym": dyn, ".symtab": None}.get(name)
+
+        out = _build_addr_to_sym(elf)
+        assert 0x2000 not in out
+        assert 0 not in out
+        assert out[0x3000] == "weak_ok"
+
+
+class TestGetCfiSource:
+    def test_prefers_eh_frame(self) -> None:
+        dwarf = MagicMock()
+        eh_entries = [object()]
+        dwarf.get_EH_CFI_entries.return_value = eh_entries
+        assert _get_cfi_source(dwarf) is eh_entries
+
+    def test_fallbacks_to_debug_frame(self) -> None:
+        dwarf = MagicMock()
+        dbg_entries = [object(), object()]
+        dwarf.get_EH_CFI_entries.return_value = None
+        dwarf.get_CFI_entries.return_value = dbg_entries
+        assert _get_cfi_source(dwarf) is dbg_entries
+
+    def test_returns_none_on_missing_both(self) -> None:
+        dwarf = MagicMock()
+        dwarf.get_EH_CFI_entries.side_effect = AttributeError("no eh")
+        dwarf.get_CFI_entries.side_effect = AttributeError("no dbg")
+        assert _get_cfi_source(dwarf) is None
+
+
 # ── _extract_cfa_reg_from_fde ─────────────────────────────────────────────────
 
 class TestExtractCfaRegFromFde:
 
-    def test_picks_highest_pc_row_not_first(self) -> None:
-        """Must pick post-prologue (highest-PC) row, not entry-state row."""
+    def test_tie_break_by_highest_pc(self) -> None:
+        """2-row table: entry rbp, body rsp -> tie => higher PC row wins (rsp)."""
         cfa_entry = MagicMock()
         cfa_entry.reg = 6   # rbp — entry-state (lower PC)
         cfa_post = MagicMock()
         cfa_post.reg = 7    # rsp — post-prologue (higher PC)
 
         rows = [
-            {"pc": 0x1000, "cfa": cfa_entry},   # entry: rbp
-            {"pc": 0x1010, "cfa": cfa_post},     # post-prologue: rsp ← should win
+            {"pc": 0x1000, "cfa": cfa_entry},
+            {"pc": 0x1010, "cfa": cfa_post},
         ]
         assert _extract_cfa_reg_from_fde(_make_fde(rows), "x64") == "rsp"
 
+    def test_modal_register_avoids_epilogue_bias(self) -> None:
+        """3-row table: entry/body rbp, epilogue rsp -> dominant should be rbp."""
+        cfa_entry = MagicMock(); cfa_entry.reg = 6   # rbp
+        cfa_body = MagicMock(); cfa_body.reg = 6    # rbp
+        cfa_epi = MagicMock(); cfa_epi.reg = 7      # rsp
+
+        rows = [
+            {"pc": 0x1000, "cfa": cfa_entry},
+            {"pc": 0x1010, "cfa": cfa_body},
+            {"pc": 0x1020, "cfa": cfa_epi},
+        ]
+        assert _extract_cfa_reg_from_fde(_make_fde(rows), "x64") == "rbp"
+
     def test_single_row_used(self) -> None:
         cfa = MagicMock()
-        cfa.reg = 6   # rbp
+        cfa.reg = 6
         assert _extract_cfa_reg_from_fde(_make_fde([{"pc": 0x1000, "cfa": cfa}]), "x64") == "rbp"
 
     def test_empty_table_returns_none(self) -> None:
@@ -110,7 +188,7 @@ class TestExtractCfaRegFromFde:
         assert _extract_cfa_reg_from_fde(_make_fde([{"pc": 0x1000}]), "x64") is None
 
     def test_cfa_no_reg_attr_returns_none(self) -> None:
-        cfa = MagicMock(spec=[])  # no .reg
+        cfa = MagicMock(spec=[])
         assert _extract_cfa_reg_from_fde(_make_fde([{"pc": 0x1000, "cfa": cfa}]), "x64") is None
 
     def test_decode_exception_returns_none(self) -> None:
@@ -124,26 +202,25 @@ class TestExtractCfaRegFromFde:
 class TestSdkVendorVerdict:
     """sdk_vendor downgrades source-level API_BREAK kinds to COMPATIBLE."""
 
+    def test_alias_kept_for_backward_compat(self) -> None:
+        assert SDK_VENDOR_DOWNGRADED_KINDS == SDK_VENDOR_COMPAT_KINDS
+
     def test_enum_member_renamed_is_compatible(self) -> None:
         assert compute_verdict([_change(ChangeKind.ENUM_MEMBER_RENAMED)], policy="sdk_vendor") == Verdict.COMPATIBLE
 
     def test_field_renamed_is_compatible(self) -> None:
         assert compute_verdict([_change(ChangeKind.FIELD_RENAMED)], policy="sdk_vendor") == Verdict.COMPATIBLE
 
-    def test_param_renamed_is_compatible(self) -> None:
-        assert compute_verdict([_change(ChangeKind.PARAM_RENAMED)], policy="sdk_vendor") == Verdict.COMPATIBLE
-
-    def test_method_access_changed_is_compatible(self) -> None:
-        assert compute_verdict([_change(ChangeKind.METHOD_ACCESS_CHANGED)], policy="sdk_vendor") == Verdict.COMPATIBLE
-
     def test_source_level_kind_changed_is_compatible(self) -> None:
         assert compute_verdict([_change(ChangeKind.SOURCE_LEVEL_KIND_CHANGED)], policy="sdk_vendor") == Verdict.COMPATIBLE
+
+    def test_default_value_changed_strict_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.PARAM_DEFAULT_VALUE_CHANGED)], policy="strict_abi") == Verdict.COMPATIBLE
 
     def test_func_removed_still_breaking(self) -> None:
         assert compute_verdict([_change(ChangeKind.FUNC_REMOVED)], policy="sdk_vendor") == Verdict.BREAKING
 
     def test_strict_abi_enum_rename_is_api_break(self) -> None:
-        """Verify strict_abi baseline: enum rename → API_BREAK (not COMPATIBLE)."""
         assert compute_verdict([_change(ChangeKind.ENUM_MEMBER_RENAMED)], policy="strict_abi") == Verdict.API_BREAK
 
     def test_all_sdk_compat_kinds_produce_compatible(self) -> None:
@@ -153,10 +230,6 @@ class TestSdkVendorVerdict:
                 f"{kind} with sdk_vendor → {result!r}, expected COMPATIBLE"
             )
 
-    def test_mixed_breaking_and_compat_yields_breaking(self) -> None:
-        changes = [_change(ChangeKind.FIELD_RENAMED), _change(ChangeKind.FUNC_REMOVED)]
-        assert compute_verdict(changes, policy="sdk_vendor") == Verdict.BREAKING
-
 
 # ── compute_verdict — plugin_abi ──────────────────────────────────────────────
 
@@ -165,6 +238,9 @@ class TestPluginAbiVerdict:
 
     def test_calling_convention_changed_is_compatible(self) -> None:
         assert compute_verdict([_change(ChangeKind.CALLING_CONVENTION_CHANGED)], policy="plugin_abi") == Verdict.COMPATIBLE
+
+    def test_value_abi_trait_changed_is_compatible(self) -> None:
+        assert compute_verdict([_change(ChangeKind.VALUE_ABI_TRAIT_CHANGED)], policy="plugin_abi") == Verdict.COMPATIBLE
 
     def test_calling_convention_strict_is_breaking(self) -> None:
         assert compute_verdict([_change(ChangeKind.CALLING_CONVENTION_CHANGED)], policy="strict_abi") == Verdict.BREAKING
@@ -179,9 +255,38 @@ class TestPluginAbiVerdict:
                 f"{kind} with plugin_abi → {result!r}, expected COMPATIBLE"
             )
 
-    def test_unknown_policy_fallback_to_strict(self) -> None:
-        changes = [_change(ChangeKind.CALLING_CONVENTION_CHANGED)]
-        assert compute_verdict(changes, policy="nonexistent") == Verdict.BREAKING
+
+# ── CLI/report-filter policy integration ─────────────────────────────────────
+
+class TestCliPolicyFiltering:
+    def _mk_result(self, *kinds: ChangeKind) -> DiffResult:
+        return DiffResult(
+            old_version="1.0",
+            new_version="2.0",
+            library="lib.so",
+            changes=[_change(k) for k in kinds],
+            verdict=Verdict.NO_CHANGE,
+        )
+
+    def test_filter_source_only_honors_policy(self) -> None:
+        from abicheck.cli import _filter_source_only
+
+        result = self._mk_result(ChangeKind.ENUM_MEMBER_RENAMED)
+        strict = _filter_source_only(result, policy="strict_abi")
+        sdk = _filter_source_only(result, policy="sdk_vendor")
+
+        assert strict.verdict == Verdict.API_BREAK
+        assert sdk.verdict == Verdict.COMPATIBLE
+
+    def test_filter_binary_only_honors_policy(self) -> None:
+        from abicheck.cli import _filter_binary_only
+
+        result = self._mk_result(ChangeKind.CALLING_CONVENTION_CHANGED)
+        strict = _filter_binary_only(result, policy="strict_abi")
+        plugin = _filter_binary_only(result, policy="plugin_abi")
+
+        assert strict.verdict == Verdict.BREAKING
+        assert plugin.verdict == Verdict.COMPATIBLE
 
 
 # ── CLI --policy end-to-end ───────────────────────────────────────────────────
@@ -199,37 +304,50 @@ class TestCliPolicy:
         new_p.write_text(json.dumps(snapshot_to_dict(new)))
         return old_p, new_p
 
-    def test_policy_strict_abi_accepted(self, tmp_path: Any) -> None:
+    def test_policy_forwarded_to_compare(self, tmp_path: Any) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old_p, new_p = self._write_snapshots(tmp_path)
+
+        def _fake_compare(*_args: Any, **kwargs: Any) -> DiffResult:
+            assert kwargs["policy"] == "plugin_abi"
+            return DiffResult(old_version="1.0", new_version="2.0", library="lib.so", changes=[], verdict=Verdict.NO_CHANGE)
+
+        with patch("abicheck.cli.compare", side_effect=_fake_compare):
+            result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "plugin_abi"])
+
+        assert result.exit_code == 0, result.output
+
+    def test_policy_invalid_case_rejected(self, tmp_path: Any) -> None:
         from click.testing import CliRunner
 
         from abicheck.cli import main
         old_p, new_p = self._write_snapshots(tmp_path)
-        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "strict_abi"])
-        assert result.exit_code in (0, 2, 4), result.output
-
-    def test_policy_sdk_vendor_accepted(self, tmp_path: Any) -> None:
-        from click.testing import CliRunner
-
-        from abicheck.cli import main
-        old_p, new_p = self._write_snapshots(tmp_path)
-        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "sdk_vendor"])
-        assert result.exit_code in (0, 2, 4), result.output
-
-    def test_policy_plugin_abi_accepted(self, tmp_path: Any) -> None:
-        from click.testing import CliRunner
-
-        from abicheck.cli import main
-        old_p, new_p = self._write_snapshots(tmp_path)
-        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "plugin_abi"])
-        assert result.exit_code in (0, 2, 4), result.output
-
-    def test_policy_invalid_rejected(self, tmp_path: Any) -> None:
-        from click.testing import CliRunner
-
-        from abicheck.cli import main
-        old_p, new_p = self._write_snapshots(tmp_path)
-        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "bad_policy"])
+        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "SDK_VENDOR"])
         assert result.exit_code == 2
+
+    def test_policy_file_forwarded_to_compare(self, tmp_path: Any) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old_p, new_p = self._write_snapshots(tmp_path)
+        policy_p = tmp_path / "policy.yaml"
+        policy_p.write_text("overrides: {}\n", encoding="utf-8")
+
+        def _fake_compare(*_args: Any, **kwargs: Any) -> DiffResult:
+            assert kwargs["policy_file"] is not None
+            return DiffResult(old_version="1.0", new_version="2.0", library="lib.so", changes=[], verdict=Verdict.NO_CHANGE)
+
+        with patch("abicheck.cli.compare", side_effect=_fake_compare):
+            result = CliRunner().invoke(
+                main,
+                ["compare", str(old_p), str(new_p), "--policy-file", str(policy_p)],
+            )
+
+        assert result.exit_code == 0, result.output
 
     def test_help_lists_policy_choices(self) -> None:
         from click.testing import CliRunner
@@ -239,3 +357,14 @@ class TestCliPolicy:
         assert "sdk_vendor" in result.output
         assert "plugin_abi" in result.output
         assert "strict_abi" in result.output
+        assert "--policy-file" in result.output
+
+
+class TestCompatPolicyExposure:
+    def test_compat_help_has_no_policy_flag(self) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+        result = CliRunner().invoke(main, ["compat", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--policy" not in result.output

--- a/tests/test_policy_file.py
+++ b/tests/test_policy_file.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.policy_file import PolicyFile
+
+
+def _change(kind: ChangeKind):
+    c = MagicMock()
+    c.kind = kind
+    return c
+
+
+def test_policy_file_defaults_when_empty(tmp_path: Path) -> None:
+    p = tmp_path / "empty.yaml"
+    p.write_text("", encoding="utf-8")
+
+    pf = PolicyFile.load(p)
+    assert pf.base_policy == "strict_abi"
+    assert pf.overrides == {}
+
+
+def test_policy_file_applies_overrides(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+base_policy: strict_abi
+overrides:
+  enum_member_renamed: ignore
+  calling_convention_changed: warn
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pf = PolicyFile.load(p)
+
+    assert pf.compute_verdict([_change(ChangeKind.ENUM_MEMBER_RENAMED)]) == Verdict.COMPATIBLE
+    assert pf.compute_verdict([_change(ChangeKind.CALLING_CONVENTION_CHANGED)]) == Verdict.API_BREAK
+
+
+def test_policy_file_unknown_base_policy_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("base_policy: custom", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unknown base_policy"):
+        PolicyFile.load(p)
+
+
+def test_policy_file_invalid_severity_rejected(tmp_path: Path) -> None:
+    p = tmp_path / "bad_severity.yaml"
+    p.write_text(
+        """
+overrides:
+  enum_member_renamed: maybe
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Invalid severity"):
+        PolicyFile.load(p)

--- a/tests/test_policy_file.py
+++ b/tests/test_policy_file.py
@@ -62,3 +62,45 @@ overrides:
 
     with pytest.raises(ValueError, match="Invalid severity"):
         PolicyFile.load(p)
+
+
+def test_policy_file_empty_changes_no_change(tmp_path: Path) -> None:
+    p = tmp_path / "empty_policy.yaml"
+    p.write_text("overrides: {}\n", encoding="utf-8")
+
+    pf = PolicyFile.load(p)
+    assert pf.compute_verdict([]) == Verdict.NO_CHANGE
+
+
+def test_policy_file_describe_contains_base_and_overrides(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+base_policy: sdk_vendor
+overrides:
+  enum_member_renamed: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pf = PolicyFile.load(p)
+    text = pf.describe()
+    assert "base_policy: sdk_vendor" in text
+    assert "enum_member_renamed: ignore" in text
+
+
+def test_policy_file_unknown_kind_logs_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    p = tmp_path / "unknown_kind.yaml"
+    p.write_text(
+        """
+overrides:
+  not_a_real_kind: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING"):
+        pf = PolicyFile.load(p)
+
+    assert pf.overrides == {}
+    assert "unknown ChangeKind slugs" in caplog.text


### PR DESCRIPTION
## Summary
Follow-up addressing all code review findings for merged PR #100 (FRAME_REGISTER_CHANGED) and #101 (--policy CLI).

## Bugs fixed
- **symtab/dynsym precedence**: `.dynsym` entries now take priority (no overwrite by `.symtab` local symbols)
- **CFA extraction**: uses highest-PC row (post-prologue), not `table[0]` (entry-state)
- **`_parse_frame_registers` refactored** into `_normalize_arch`, `_build_addr_to_sym`, `_get_cfi_source`, `_extract_cfa_reg_from_fde`
- **`sdk_vendor` policy was no-op**: fixed — source-level kinds now correctly downgraded `API_BREAK→COMPATIBLE`
- **`plugin_abi`**: added `FRAME_REGISTER_CHANGED` + `VALUE_ABI_TRAIT_CHANGED` to `PLUGIN_ABI_DOWNGRADED_KINDS`
- **`compat_cmd`**: now accepts `--policy` flag and forwards to `compare()`

## Tests added (`tests/test_followup_100_101.py`)
- `_reg_name`, `_normalize_arch` helpers
- `_extract_cfa_reg_from_fde` with mock FDE objects (post-prologue row selection)
- `compute_verdict` with `sdk_vendor` and `plugin_abi` policies
- CLI `--policy` end-to-end via CliRunner

## Documentation added
- `docs/policies.md` — full policy profiles reference
- `mkdocs.yml` — added to nav

## Validation
- ruff ✅, mypy ✅, 50 targeted tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add custom per-kind policy files and a new --policy-file CLI option; comparisons, filtering, and outputs now reflect the active policy and propagate policy metadata in results.

* **Documentation**
  * Added a Policy Profiles guide describing built-in profiles (strict_abi, sdk_vendor, plugin_abi), downgrade rules, and policy-file usage.

* **Tests**
  * Added comprehensive tests covering policy-file parsing, policy-aware verdict logic, CLI flows, and related helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->