### PR TITLE
Docs: modernize README and docs (installation, outputs, verdicts, ABICC compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,53 @@ abicheck is inspired by two foundational projects:
 - [libabigail / abidiff](https://sourceware.org/libabigail/)
 - [ABI Compliance Checker (ABICC)](https://lvc.github.io/abi-compliance-checker/)
 
-Many thanks and kudos to both communities for defining the practical ABI-checking ecosystem.
-Sadly, both projects are effectively no longer maintained for many modern contributor workflows,
-and it is often not practical to land new fixes there. abicheck is designed to be a
-**drop-in replacement for ABICC** while providing a modern, maintainable Python codebase.
+Kudos and many thanks to both communities for building the ABI compatibility ecosystem.
 
----
+It is designed to be a practical drop-in replacement for
+[ABI Compliance Checker (ABICC)](https://lvc.github.io/abi-compliance-checker/),
+with modern CLI ergonomics and machine-readable outputs (`json`/`sarif`).
+
+Note: ABICC is currently not actively maintained for many modern workflows,
+which is a key reason abicheck exists.
 
 ## Requirements
 
-### Mandatory
+You need all of the following:
 
 - Python 3.10+
-- `castxml` (for header-based C/C++ API parsing)
-- A C/C++ compiler available to castxml (`g++` or `clang++`)
+- `castxml` (system package; not installed from Python package metadata)
+- C/C++ compiler for castxml (`g++` or `clang++`)
+- Python runtime deps (installed automatically from package metadata):
+  - `click`
+  - `pyelftools`
+  - `defusedxml`
+  - `pyyaml`
+  - `google-re2`
+  - `packaging`
 
-### Runtime Python dependencies
+If `castxml` is missing, install it via your OS package manager (see [docs/getting_started.md](docs/getting_started.md)).
 
-- `click` (CLI)
-- `pyelftools` (ELF/DWARF metadata extraction)
-- `defusedxml` (safe ABICC XML parsing)
+## Installation
 
----
+PyPI package publishing is planned, but not yet available.
 
-## How to use abicheck
+```bash
+# coming later
+pip install abicheck
+```
+
+For local development from this repository:
+
+```bash
+pip install -e .
+```
+
+## Quick start
+
+### Can I compare in one command?
+
+- **Native mode (`dump` + `compare`)**: currently requires two snapshot files, then one compare command.
+- **Single-command flow exists via `compat`** when you already have ABICC XML descriptors (`-old` / `-new`).
 
 ### 1) Create ABI snapshots
 
@@ -48,255 +71,64 @@ abicheck dump libfoo.so.2 -H include/foo.h --version 2.0 -o libfoo-2.0.json
 # Markdown report (default)
 abicheck compare libfoo-1.0.json libfoo-2.0.json
 
-# JSON
+# JSON report
 abicheck compare libfoo-1.0.json libfoo-2.0.json --format json -o report.json
 
-# SARIF
+# SARIF report
 abicheck compare libfoo-1.0.json libfoo-2.0.json --format sarif -o report.sarif
 ```
 
-### 3) ABICC-compatible mode
+### 3) ABICC-compatible mode (`compat`)
 
 ```bash
-# Minimal (same flags as abi-compliance-checker):
+# ABICC-style invocation
 abicheck compat -lib foo -old old.xml -new new.xml
 
-# Full flag parity:
-abicheck compat -lib foo -old old.xml -new new.xml \
-  -report-path report.html \
-  -s \
-  -show-retval \
-  -v1 1.0 -v2 2.0
+# Strict mode and explicit versions
+abicheck compat -lib foo -old old.xml -new new.xml -s -v1 1.0 -v2 2.0
 ```
 
-This mode supports ABICC-style descriptor workflows so teams can migrate without
-rewriting their entire pipeline on day one. See [ABICC compatibility reference](docs/abicc_compat.md) for full flag list.
+See [ABICC compatibility reference](docs/abicc_compat.md) for the full flag list and behavior notes.
 
----
+## Verdicts and CI behavior
 
-## abicheck as a drop-in replacement for ABICC
+`abicheck compare` returns one of four **final verdicts**:
 
-abicheck keeps the ABICC descriptor-driven model available (`compat` mode), while adding:
+- `NO_CHANGE`
+- `COMPATIBLE`
+- `API_BREAK`
+- `BREAKING`
 
-- Native JSON/SARIF/Markdown outputs for automation
-- Easier CI embedding in Python-based tooling
-- More explicit architecture with reusable Python modules
-- Cleaner evolution path for new ABI rules and checks
-- **Superset detectors** — finds everything ABICC finds, plus more (see [gap report](docs/gap_report.md))
+Additionally, some internal checks can be marked as **review-needed** severity
+(at change level / policy level) when evidence is uncertain. This is separate from the
+final top-level compare verdict and is primarily used in policy workflows.
 
-### Migration: one-line swap
+For exact exit code semantics and CI gate patterns, use:
 
-```bash
-# Before:
-abi-compliance-checker -lib libdnnl -old old.xml -new new.xml -report-path r.html
+- [docs/exit_codes.md](docs/exit_codes.md)
+- [docs/concepts/verdicts.md](docs/concepts/verdicts.md)
 
-# After (identical):
-abicheck compat -lib libdnnl -old old.xml -new new.xml -report-path r.html
-```
-
-### Supported ABICC flags
-
-| Flag | Alias(es) | Description |
-|------|-----------|-------------|
-| `-lib NAME` | `-l`, `-library` | Library name |
-| `-old PATH` | `-d1` | Old version descriptor |
-| `-new PATH` | `-d2` | New version descriptor |
-| `-report-path PATH` | | Output report path |
-| `-report-format FMT` | | `html` / `json` / `md` (default: `html`) |
-| `-s` | `-strict` | Any change → exit 1 (BREAKING) |
-| `-source` | `-src`, `-api` | Source/API compat only (filter ELF-only changes) |
-| `-binary` | `-bin`, `-abi` | Binary ABI mode (default) |
-| `-show-retval` | | Include return-value changes in report |
-| `-v1 NUM` | `-vnum1` | Override old version label |
-| `-v2 NUM` | `-vnum2` | Override new version label |
-| `-title NAME` | | Custom report title |
-| `-skip-symbols PATH` | | File with symbols to suppress |
-| `-skip-types PATH` | | File with types to suppress |
-| `-stdout` | | Print report to stdout |
-| `-headers-only` | | _(reserved — not yet implemented)_ |
-| `-skip-headers PATH` | | _(reserved — not yet implemented)_ |
-
-Practical migration path:
-
-1. Keep your existing XML descriptor generation.
-2. Replace ABICC CLI call with `abicheck compat`.
-3. Move to `dump` + `compare` when you want explicit snapshot control and richer outputs.
-
----
-
-## Change classification: BREAKING vs COMPATIBLE
-
-abicheck classifies every detected change into one of three verdicts:
-
-| Verdict | Meaning | CI gate recommendation |
-|---|---|---|
-| **BREAKING** | Binary ABI incompatibility — existing binaries will malfunction | Fail the build |
-| **COMPATIBLE** | Informational/warning change that does not break binary compatibility on its own | Warn, do not fail |
-| **NO_CHANGE** | Identical ABI | Pass |
-
-### What counts as BREAKING
-
-A change is classified as BREAKING only if it causes **binary-level incompatibility**
-when swapping a shared library between two releases without recompiling consumers:
-
-- Symbol removal/disappearance (loader fails with unresolved symbol)
-- Type layout changes (size, alignment, field offsets — causes memory corruption)
-- Vtable changes (virtual dispatch goes to wrong function)
-- Calling convention changes (args in wrong registers)
-- Function signature changes (return type, parameters, static qualifier, cv-qualifiers)
-- SONAME change (dynamic linker can't find the library)
-
-### What counts as COMPATIBLE (informational/warning)
-
-These changes are detected and reported but do **not** trigger a BREAKING verdict
-because they do not cause binary linkage or layout failures on their own:
-
-| Change | Why it's not a binary ABI break |
-|---|---|
-| `noexcept` added/removed | Itanium ABI mangling unchanged; same symbol resolves. Source-level type concern only. |
-| Enum member added | Existing compiled enum values unchanged. Source-level switch coverage concern. Value shifts caught separately. |
-| Union field added | All union fields start at offset 0; existing fields unaffected. Size increase caught by TYPE_SIZE_CHANGED. |
-| GLOBAL→WEAK binding | Symbol still exported and resolvable by the dynamic linker. |
-| GNU IFUNC introduced/removed | Transparent to callers via PLT/GOT mechanism. |
-| New/removed DT_NEEDED dependency | Deployment concern, not binary interface break. |
-| RPATH/RUNPATH changed | Search path metadata, not symbol contract. |
-| Toolchain flag drift | Informational — not a proven binary break on its own. |
-| DWARF info missing | Coverage gap warning — comparison was incomplete. |
-
-Some changes are classified as **BREAKING** despite being borderline, because they
-can cause runtime failures in realistic deployments:
-
-| Change | Why it's BREAKING |
-|---|---|
-| ELF `st_size` changed | In ELF-only mode (no headers/DWARF), may be the sole signal for vtable/variable layout changes. |
-| New version requirement (e.g. GLIBC_2.34) | Library fails to load on runtimes lacking that version — hard runtime failure. |
-| Typeinfo/vtable visibility change | Cross-DSO `dynamic_cast` and exception matching can fail at runtime. |
-| Variable const qualifier added/removed | Adding const moves variable to `.rodata` — existing writes cause SIGSEGV. |
-
----
-
-## ABI/API breakages and tool coverage
-
-Below is a high-level matrix for all 42 example cases based on benchmark results (2026-03-11).
-
-Legend: ✅ correct · ⚠️ wrong/undercounted · ❌ wrong · ⏱️ timeout
-
-| Case | Breakage type | Expected | abicheck | abidiff | ABICC(dump) | ABICC(xml) |
-|---|---|---|:---:|:---:|:---:|:---:|
-| case01 | Symbol removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case02 | Param type changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case03 | Compatible addition | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case04 | No change baseline | NO_CHANGE | ✅ | ✅ | ⚠️ | ⚠️ |
-| case05 | SONAME missing | COMPATIBLE | ✅ | ⚠️ | ✅ | ✅ |
-| case06 | Visibility leak | COMPATIBLE | ✅ | ⚠️ | ❌ | ❌ |
-| case07 | Struct layout break | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case08 | Enum value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case09 | C++ vtable drift | BREAKING | ✅ | ⚠️ | ⏱️ | ✅ |
-| case10 | Return type changed | BREAKING | ✅ | ⚠️ | ✅ | ⚠️ |
-| case11 | Global var type changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case12 | Function removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case13 | Symbol version policy | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case14 | Class size/layout | BREAKING | ✅ | ⚠️ | ✅ | ⚠️ |
-| case15 | noexcept changed | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case16 | inline↔non-inline | COMPATIBLE | ✅ | ✅ | ❌ | ⏱️ |
-| case17 | Template ABI drift | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case18 | Dependency leak | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case19 | Enum member removed | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case20 | Enum value changed | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case21 | Method became static | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case22 | Method const changed | BREAKING | ✅ | ✅ | ✅ | ⚠️ |
-| case23 | Pure virtual added | BREAKING | ✅ | ✅ | ✅ | ⚠️ |
-| case24 | Union field removed | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case25 | Enum member added | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case26 | Union field added (break) | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case26b | Union field added (compat) | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case27 | Symbol binding weakened | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case28 | Typedef opaque | BREAKING | ✅ | ⚠️ | ❌ | ⚠️ |
-| case29 | ifunc transition | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case30 | Field qualifiers | BREAKING | ✅ | ⚠️ | ❌ | ⚠️ |
-| case31 | Enum rename | API_BREAK | ✅ | ⚠️ | ❌ | ⚠️ |
-| case32 | Param defaults | NO_CHANGE | ✅ | ✅ | ❌ | ⚠️ |
-| case33 | Pointer level | BREAKING | ✅ | ⚠️ | ❌ | ⚠️ |
-| case34 | Access level | API_BREAK | ✅ | ⚠️ | ❌ | ⚠️ |
-| case35 | Field rename | BREAKING | ✅ | ⚠️ | ❌ | ⚠️ |
-| case36 | Anon struct | BREAKING | ✅ | ⚠️ | ❌ | ⚠️ |
-| case37 | Base class change | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case38 | Virtual methods | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case39 | Var const | BREAKING | ✅ | ✅ | ❌ | ✅ |
-| case40 | Field layout | BREAKING | ✅ | ⚠️ | ❌ | ⚠️ |
-| case41 | Type changes | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| **Total** | | | **42/42 (100%)** | **11/42 (26%)** | **20/30 (66%)** | **25/41 (61%)** |
-
-> See [docs/benchmark_report.md](docs/benchmark_report.md) for full analysis, timing data, and explanations.
-
-### Tooling summary
-
-- **abicheck**: 100% accuracy across all 42 cases. Uses castxml (Clang AST) + ELF — no GCC required.
-- `abidiff`: 26% — ELF/DWARF only, misses semantic changes (struct layout, enum values, vtable, return type).
-  `--headers-dir` does not improve results when `-fvisibility=default` is used.
-- `ABICC (abi-dumper)`: 66% scored on 30/42 — 12 cases ERROR/TIMEOUT on complex C++ patterns.
-- `ABICC (xml)`: 61% — slow (GCC per case), unstable (timeouts), misses most type-level changes.
-
----
-
-## Architecture and dependencies
-
-```text
-CLI (abicheck dump | compare | compat)
-  -> Dumper (castxml + ELF/DWARF metadata)
-  -> Checker engine (detector orchestration)
-       -> Checker policy (ChangeKind + verdict registry)
-  -> Report summary (canonical counters)
-  -> Reporters (markdown/json/sarif/html/xml)
-```
-
-Key modules:
-
-- `abicheck.cli` — command entry points
-- `abicheck.dumper` — builds ABI snapshots
-- `abicheck.checker` — runs detectors and builds `DiffResult`
-- `abicheck.checker_policy` — central `ChangeKind`/`Verdict` policy and `compute_verdict`
-- `abicheck.detectors` — detector protocol and detector result types
-- `abicheck.report_summary` — canonical summary metrics shared by reporters
-- `abicheck.compat` — ABICC XML compatibility layer
-- `abicheck.reporter`, `abicheck.sarif`, `abicheck.html_report`, `abicheck.xml_report` — output generators
-- `abicheck.elf_metadata`, `abicheck.dwarf_metadata`, `abicheck.dwarf_advanced` — metadata extraction
-
----
-
-## Installation
-
-```bash
-pip install -e .
-```
-
----
-
-## Documentation
+## Documentation map
 
 - [Docs home](docs/index.md)
 - [Getting started](docs/getting_started.md)
-- [Using abicheck, compatibility modes, and coverage](docs/usage_and_coverage.md)
-- [Examples breakage guide](docs/examples_breakage_guide.md)
+- [Usage and coverage model](docs/usage_and_coverage.md)
+- [Migration from ABICC](docs/migration/from_abicc.md)
+- [ABICC compatibility flags](docs/abicc_compat.md)
+- [Tool comparison (interpretation)](docs/tool_comparison.md)
+- [Benchmark report (numbers + methodology)](docs/benchmark_report.md)
+- [Architecture reference](docs/reference/architecture.md)
 
-
----
-
-## Testing and coverage
+## Testing
 
 ```bash
-# fast tests (default CI gate — matches workflow)
+# Fast tests (CI-style)
 pytest tests/ -v --tb=short -m "not integration and not libabigail" \
   --cov=abicheck --cov-report=term-missing --cov-report=xml --cov-fail-under=52
 
-# full local suite (includes integration/parity when deps are present)
+# Full local suite (when optional external tools are available)
 pytest --cov=abicheck --cov-report=term-missing
 ```
-
-Coverage settings are centralized in `pyproject.toml` and CI publishes `coverage.xml` as an artifact.
-See `docs/testing_coverage.md` for the current baseline and a gap analysis.
-
----
 
 ## License
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,7 +102,7 @@ abicheck compare v1.json v2.json --format sarif -o abi.sarif
 
 ## 5) Exit codes (`abicheck compare`)
 
-`abicheck compare` uses four statuses:
+`abicheck compare` uses four exit-code outcomes:
 - `0` → `NO_CHANGE` or `COMPATIBLE`
 - `1` → tool/runtime error
 - `2` → `API_BREAK`

--- a/docs/usage_and_coverage.md
+++ b/docs/usage_and_coverage.md
@@ -97,50 +97,21 @@ detected and reported for awareness but do not trigger a BREAKING verdict. See t
 [ABI Break Catalog](abi_breaking_cases_catalog.md) for the full
 rationale table.
 
-## ABI/API breakages and what each tool mode can detect
+## ABI/API breakages and tool coverage
 
-This section maps breakage types to example cases under `examples/` and compares:
+High-level guidance:
 
-- `abicheck` (header + ELF metadata pipeline)
-- `abidiff + headers`
-- `ABICC Usage #2` (header-based ABICC mode)
-- `ABICC Usage #1` (abi-dumper / DWARF dump mode)
+- `abicheck compare` is the canonical mode for highest-fidelity verdicts (`NO_CHANGE`, `COMPATIBLE`, `API_BREAK`, `BREAKING`).
+- `abicheck compat` is the ABICC drop-in mode and intentionally constrained to ABICC-style semantics.
+- `abicheck compat -s` (`strict`) intentionally promotes compatible changes to breaking for conservative policy gates.
 
-Legend: ✅ strong support, ⚠️ partial/conditional, ❌ generally not covered.
+To avoid data drift, detailed per-case matrices are maintained in dedicated docs:
 
-| Case | Breakage type | Verdict | abicheck | abidiff + headers | ABICC #2 (headers) | ABICC #1 (dumps) |
-|---|---|---|:---:|:---:|:---:|:---:|
-| case01_symbol_removal | Public symbol removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case02_param_type_change | Function parameter type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case03_compat_addition | Compatible API addition | COMPATIBLE | ✅ | ✅ | ✅ | ✅ |
-| case04_no_change | No ABI change baseline | NO_CHANGE | ✅ | ✅ | ✅ | ✅ |
-| case05_soname | SONAME / packaging policy issue | BREAKING | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case06_visibility | Visibility/export policy drift | BREAKING | ✅ | ✅ | ⚠️ | ⚠️ |
-| case07_struct_layout | Struct layout changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case08_enum_value_change | Enum value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case09_cpp_vtable | VTable/method order/signature drift | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case10_return_type | Function return type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case11_global_var_type | Global variable type changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case12_function_removed | API function removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case13_symbol_versioning | Symbol version policy regression | COMPATIBLE | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| case14_cpp_class_size | C++ class size/layout changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case15_noexcept_change | `noexcept` contract changed | COMPATIBLE | ✅ | ⚠️ | ✅ | ❌ |
-| case16_inline_to_non_inline | Inline/ODR surface change | BREAKING | ✅ | ⚠️ | ✅ | ❌ |
-| case17_template_abi | Template-instantiation ABI drift | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case18_dependency_leak | Transitive dependency leaked into API | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case19_enum_member_removed | Enum member removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case20_enum_member_value_changed | Enum member value changed | BREAKING | ✅ | ⚠️ | ✅ | ✅ |
-| case21_method_became_static | Method became static | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case22_method_const_changed | Method const-qualifier changed | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case23_pure_virtual_added | Added pure virtual method | BREAKING | ✅ | ✅ | ✅ | ✅ |
-| case24_union_field_removed | Union field removed | BREAKING | ✅ | ✅ | ✅ | ✅ |
+- [Benchmark report](benchmark_report.md) — exact scored results, denominators, and timing notes
+- [Tool comparison](tool_comparison.md) — interpretation and trade-offs by workflow
+- [ABI break catalog](abi_breaking_cases_catalog.md) — rationale for classification of each change kind
 
-### Summary by breakage category
-
-- **API surface breaks** (removed/changed signatures): all modes generally catch these.
-- **C++ semantic contract breaks** (`noexcept`, inline/ODR): header-aware analysis is strongest.
-- **DWARF-only detail** (some anonymous/internal layout details): ABICC dump mode can be strongest when debug info exists.
-- **Policy/linking hygiene** (SONAME/versioning/visibility): best handled by a tool that includes explicit ELF policy checks.
+This page intentionally keeps only workflow-level guidance and links to those canonical sources.
 
 ## Architecture and dependencies
 


### PR DESCRIPTION
### Motivation

- Make the project documentation clearer and more actionable for modern CI/workflows by consolidating installation, quick-start, and output format guidance.
- Clarify runtime requirements and the role of external tools (notably that `castxml` is a system dependency rather than a Python package). 
- Simplify and modernize the ABICC-compatibility guidance and make verdict/exit-code semantics and CI usage explicit.

### Description

- Rewrote and reorganized `README.md` to add an explicit `Installation` section, a `Quick start`, and a concise documentation map, and to call out `castxml` and required Python runtime deps. 
- Clarified requirements by listing the Python runtime dependencies and explaining how to install `castxml` via the OS package manager; moved CI/coverage commands into a clearer `Testing` subsection. 
- Consolidated and simplified ABICC compatibility content into a short `compat` example, linked to `docs/abicc_compat.md`, and made final compare verdicts and exit-code semantics explicit. 
- Updated `docs/getting_started.md` and `docs/usage_and_coverage.md` to reflect the new output-format examples, exit-code wording, and guidance around `compat` vs `compare` usage and documentation links.

### Testing

- Ran the fast unit test suite with `pytest tests/ -v --tb=short -m "not integration and not libabigail" --cov=abicheck --cov-report=term-missing --cov-report=xml --cov-fail-under=52` and it completed successfully. 
- Ran the full local suite with `pytest --cov=abicheck --cov-report=term-missing` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b345a77c30832b95a1a604709e591e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved README introduction with clearer project positioning and updated framing
  * Enhanced setup and requirements sections with better installation guidance
  * Added BREAKING exit code (4) to getting started documentation
  * Streamlined usage documentation with simplified workflow guidance and better reference links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->