### PR TITLE
Configure mypy overrides and update project documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ htmlcov/
 examples/**/*.so
 logs/
 compat_reports/
+dist/
+build/
+site/

--- a/docs/examples_breakage_guide.md
+++ b/docs/examples_breakage_guide.md
@@ -575,7 +575,7 @@ under-allocate memory when running against the v2 library.
 
 ### noexcept added or removed
 
-See [case15_noexcept_change](#case15_noexcept_change--source-level-contract-change-compatible) above.
+See [case15_noexcept_change](#case15_noexcept_change-source-level-contract-change-compatible) above.
 
 ### GLOBAL→WEAK symbol binding
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,10 @@ nav:
     - Coverage Report: coverage_report.md
     - Benchmark Report: benchmark_report.md
     - V2 Coverage Plan: v2_coverage_plan.md
+  - Development:
+    - Testing Strategy: testing_coverage.md
+    - Codebase Analysis: codebase_analysis.md
+    - ABICC Test Coverage Comparison: abicc_test_coverage_comparison.md
   - Architecture Decisions:
     - ADR Index: adr/index.md
     - ADR-001 Technology Stack: adr/001-technology-stack.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools>=68,<75"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -60,9 +60,26 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 # pyelftools has no type stubs or py.typed marker — all its APIs are untyped.
 # Disable strict checks for modules that directly call pyelftools APIs.
-module = ["abicheck.elf_metadata", "abicheck.dwarf_metadata"]
+module = [
+    "abicheck.elf_metadata",
+    "abicheck.dwarf_metadata",
+    "abicheck.dwarf_advanced",
+    "abicheck.dwarf_unified",
+    "abicheck.dumper",
+]
 disallow_untyped_calls = false
 disable_error_code = ["attr-defined", "unused-ignore"]
+
+[[tool.mypy.overrides]]
+# Click decorators (@click.command, @click.option, etc.) are untyped.
+module = ["abicheck.cli", "abicheck.compat.cli"]
+disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+# types-PyYAML stubs may not be found in all environments;
+# the package is listed in [project.optional-dependencies.dev].
+module = ["abicheck.policy_file", "abicheck.suppression"]
+disable_error_code = ["import-untyped"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
This PR updates the project configuration and documentation to improve type checking coverage and add development documentation sections.

## Key Changes

- **setuptools version constraint**: Updated `pyproject.toml` to constrain setuptools to `<75` to ensure compatibility with the build system
- **mypy configuration enhancements**:
  - Expanded the existing pyelftools override to include additional modules (`abicheck.dwarf_advanced`, `abicheck.dwarf_unified`, `abicheck.dumper`)
  - Added new override for Click CLI modules (`abicheck.cli`, `abicheck.compat.cli`) to disable strict decorator type checking
  - Added new override for YAML-related modules (`abicheck.policy_file`, `abicheck.suppression`) to handle optional type stub dependencies
- **Documentation structure**: Added new "Development" section to mkdocs navigation with three new documentation pages for testing strategy, codebase analysis, and test coverage comparison
- **gitignore updates**: Added common build artifacts (`dist/`, `build/`, `site/`) to version control exclusions
- **Documentation fix**: Corrected a markdown anchor link in the examples breakage guide

## Implementation Details

The mypy overrides follow a pattern of disabling strict type checking for modules that have legitimate reasons (untyped third-party libraries, decorator-heavy frameworks, optional dependencies) while maintaining type safety in the rest of the codebase.

https://claude.ai/code/session_019yM1v1PfW5MiW2z75EvEsb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Development section with new guides: Testing Strategy, Codebase Analysis, and ABICC Test Coverage Comparison.
  * Fixed documentation link formatting.

* **Chores**
  * Updated build system configuration and dependency constraints.
  * Added ignore patterns for build artifacts and generated directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->