### PR TITLE
Add comprehensive unit test coverage for core modules

### DIFF
--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,0 +1,309 @@
+"""Coverage tests for cli.py — target 100% on non-compat code paths.
+
+Tests _sniff_text_format edge cases, _resolve_input error paths,
+dump_cmd stdout output, compare_cmd ignored-flags warnings,
+and policy-file warning.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from abicheck.cli import _is_elf, _resolve_input, _sniff_text_format, main
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+# ── _sniff_text_format ─────────────────────────────────────────────────
+
+class TestSniffTextFormat:
+    def test_oserror_returns_unknown(self, tmp_path):
+        """When opening the file raises OSError, return 'unknown'."""
+        missing = tmp_path / "no_such_file.txt"
+        assert _sniff_text_format(missing) == "unknown"
+
+    def test_perl_dump_detected(self, tmp_path):
+        """A file starting with $VAR1 is detected as perl format."""
+        f = tmp_path / "dump.pl"
+        f.write_text("$VAR1 = {\n  'key' => 'value'\n};", encoding="utf-8")
+        assert _sniff_text_format(f) == "perl"
+
+    def test_json_detected(self, tmp_path):
+        """A file starting with '{' is detected as json format."""
+        f = tmp_path / "snap.json"
+        f.write_text('{"library": "test"}', encoding="utf-8")
+        assert _sniff_text_format(f) == "json"
+
+    def test_unknown_content(self, tmp_path):
+        """Unrecognized content returns 'unknown'."""
+        f = tmp_path / "mystery.txt"
+        f.write_text("neither json nor perl", encoding="utf-8")
+        assert _sniff_text_format(f) == "unknown"
+
+
+# ── _resolve_input error paths ─────────────────────────────────────────
+
+class TestResolveInputErrors:
+    def test_elf_bad_include_dir(self, tmp_path, monkeypatch):
+        """Include directory that doesn't exist raises ClickException."""
+        import click
+        import pytest
+
+        so = tmp_path / "lib.so"
+        so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        hdr = tmp_path / "test.h"
+        hdr.write_text("int f();", encoding="utf-8")
+
+        bad_inc = tmp_path / "nonexistent_inc"
+        with pytest.raises(click.ClickException, match="Include directory not found"):
+            _resolve_input(so, [hdr], [bad_inc], "1.0", "c++", is_elf=True)
+
+    def test_elf_dump_error(self, tmp_path, monkeypatch):
+        """When dump() raises, _resolve_input wraps it in ClickException."""
+        import click
+        import pytest
+
+        from abicheck.errors import AbicheckError
+
+        so = tmp_path / "lib.so"
+        so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        hdr = tmp_path / "test.h"
+        hdr.write_text("int f();", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "abicheck.cli.dump",
+            lambda **_kw: (_ for _ in ()).throw(AbicheckError("castxml died")),
+        )
+        with pytest.raises(click.ClickException, match="Failed to dump"):
+            _resolve_input(so, [hdr], [], "1.0", "c++", is_elf=True)
+
+    def test_perl_import_error(self, tmp_path, monkeypatch):
+        """When perl dump import fails, _resolve_input wraps the error."""
+        import click
+        import pytest
+
+        f = tmp_path / "bad.dump"
+        f.write_text("$VAR1 = {\n  broken\n};", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "abicheck.cli.import_abicc_perl_dump",
+            lambda _p: (_ for _ in ()).throw(ValueError("parse error")),
+        )
+        with pytest.raises(click.ClickException, match="Failed to import ABICC Perl dump"):
+            _resolve_input(f, [], [], "1.0", "c++", is_elf=False)
+
+    def test_unknown_format_error(self, tmp_path):
+        """A file with unrecognized format raises UsageError."""
+        import click
+        import pytest
+
+        f = tmp_path / "mystery.bin"
+        f.write_bytes(b"\x00\x01\x02\x03")
+        with pytest.raises(click.UsageError, match="Cannot detect format"):
+            _resolve_input(f, [], [], "1.0", "c++", is_elf=False)
+
+    def test_json_load_error(self, tmp_path, monkeypatch):
+        """When JSON snapshot loading fails, _resolve_input wraps the error."""
+        import click
+        import pytest
+
+        f = tmp_path / "bad.json"
+        f.write_text("{invalid json", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "abicheck.cli.load_snapshot",
+            lambda _p: (_ for _ in ()).throw(ValueError("bad json")),
+        )
+        with pytest.raises(click.ClickException, match="Failed to load JSON snapshot"):
+            _resolve_input(f, [], [], "1.0", "c++", is_elf=False)
+
+
+# ── dump_cmd stdout ────────────────────────────────────────────────────
+
+class TestDumpCmdStdout:
+    def test_dump_to_stdout(self, tmp_path, monkeypatch):
+        """dump command without -o writes JSON to stdout."""
+        so = tmp_path / "libfoo.so"
+        so.write_bytes(b"elf")
+        hdr = tmp_path / "foo.h"
+        hdr.write_text("int foo();", encoding="utf-8")
+
+        snap = AbiSnapshot(library="libfoo.so", version="1.0")
+        monkeypatch.setattr("abicheck.cli.dump", lambda **_kw: snap)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dump", str(so), "-H", str(hdr)])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["library"] == "libfoo.so"
+
+
+# ── compare_cmd ignored-flags warnings ─────────────────────────────────
+
+def _make_snapshots(tmp_path: Path) -> tuple[Path, Path]:
+    old = AbiSnapshot(library="lib.so", version="1.0")
+    new = AbiSnapshot(library="lib.so", version="2.0")
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(snapshot_to_json(old), encoding="utf-8")
+    new_p.write_text(snapshot_to_json(new), encoding="utf-8")
+    return old_p, new_p
+
+
+class TestCompareIgnoredFlagsWarnings:
+    def test_shared_include_ignored_warning(self, tmp_path):
+        """-I/--include is warned when both inputs are snapshots."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        inc = tmp_path / "inc"
+        inc.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "-I", str(inc),
+        ])
+        assert result.exit_code == 0
+        assert "-I/--include" in result.output
+
+    def test_old_header_ignored_warning(self, tmp_path):
+        """--old-header is warned when both inputs are snapshots."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        hdr = tmp_path / "h.h"
+        hdr.write_text("int f();", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--old-header", str(hdr),
+        ])
+        assert result.exit_code == 0
+        assert "--old-header" in result.output
+
+    def test_new_header_ignored_warning(self, tmp_path):
+        """--new-header is warned when both inputs are snapshots."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        hdr = tmp_path / "h.h"
+        hdr.write_text("int f();", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--new-header", str(hdr),
+        ])
+        assert result.exit_code == 0
+        assert "--new-header" in result.output
+
+    def test_old_include_ignored_warning(self, tmp_path):
+        """--old-include is warned when both inputs are snapshots."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        inc = tmp_path / "inc"
+        inc.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--old-include", str(inc),
+        ])
+        assert result.exit_code == 0
+        assert "--old-include" in result.output
+
+    def test_new_include_ignored_warning(self, tmp_path):
+        """--new-include is warned when both inputs are snapshots."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        inc = tmp_path / "inc"
+        inc.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--new-include", str(inc),
+        ])
+        assert result.exit_code == 0
+        assert "--new-include" in result.output
+
+
+# ── compare_cmd policy-file warning ────────────────────────────────────
+
+class TestComparePolicyFileWarning:
+    def test_policy_ignored_when_policy_file_given(self, tmp_path):
+        """When --policy-file is given, --policy is warned as ignored."""
+        old_p, new_p = _make_snapshots(tmp_path)
+
+        policy_file = tmp_path / "policy.yaml"
+        policy_file.write_text(
+            "base_policy: strict_abi\noverrides: {}\n",
+            encoding="utf-8",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p),
+            "--policy", "sdk_vendor",
+            "--policy-file", str(policy_file),
+        ])
+        assert result.exit_code == 0
+        assert "ignored" in result.output.lower()
+
+
+# ── compare_cmd policy-file error paths ────────────────────────────────
+
+class TestComparePolicyFileErrors:
+    def test_policy_file_import_error(self, tmp_path, monkeypatch):
+        """ImportError from PolicyFile.load raises ClickException."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        policy_file = tmp_path / "policy.yaml"
+        policy_file.write_text("bad: policy\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "abicheck.policy_file.PolicyFile.load",
+            classmethod(lambda cls, _p: (_ for _ in ()).throw(ImportError("missing dep"))),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p),
+            "--policy-file", str(policy_file),
+        ])
+        assert result.exit_code != 0
+        assert "missing dep" in result.output
+
+    def test_policy_file_value_error(self, tmp_path, monkeypatch):
+        """ValueError from PolicyFile.load raises BadParameter."""
+        old_p, new_p = _make_snapshots(tmp_path)
+        policy_file = tmp_path / "policy.yaml"
+        policy_file.write_text("bad: policy\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "abicheck.policy_file.PolicyFile.load",
+            classmethod(lambda cls, _p: (_ for _ in ()).throw(ValueError("invalid format"))),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p),
+            "--policy-file", str(policy_file),
+        ])
+        assert result.exit_code != 0
+        assert "invalid format" in result.output
+
+
+# ── compare_cmd API_BREAK exit code ────────────────────────────────────
+
+class TestCompareApiBreakExitCode:
+    def test_api_break_exits_2(self, tmp_path, monkeypatch):
+        """When verdict is API_BREAK, exit code is 2."""
+        from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        old_p.write_text("{}", encoding="utf-8")
+        new_p.write_text("{}", encoding="utf-8")
+
+        snap = AbiSnapshot(library="lib.so", version="1.0")
+        monkeypatch.setattr("abicheck.cli.load_snapshot", lambda _: snap)
+        monkeypatch.setattr(
+            "abicheck.cli.compare",
+            lambda *_a, **_kw: DiffResult(
+                old_version="1", new_version="2", library="lib.so",
+                verdict=Verdict.API_BREAK,
+                changes=[Change(ChangeKind.FUNC_REMOVED, "foo", "removed")],
+            ),
+        )
+        monkeypatch.setattr("abicheck.cli.to_markdown", lambda _r: "API_BREAK REPORT")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["compare", str(old_p), str(new_p)])
+        assert result.exit_code == 2

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from abicheck.cli import _is_elf, _resolve_input, _sniff_text_format, main
-from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.cli import _resolve_input, _sniff_text_format, main
+from abicheck.model import AbiSnapshot
 from abicheck.serialization import snapshot_to_json
-
 
 # ── _sniff_text_format ─────────────────────────────────────────────────
 

--- a/tests/test_dumper_coverage.py
+++ b/tests/test_dumper_coverage.py
@@ -1,0 +1,435 @@
+"""Coverage tests for dumper.py — target 80%+ coverage.
+
+Covers _castxml_dump internal branches (gcc_prefix, gcc_path, sysroot,
+nostdinc, gcc_options, lang, MSVC detection, castxml failure),
+dump() elf_meta symbol filtering and lang parameter,
+_CastxmlParser edge cases (builtin elements, anonymous fields,
+members-attribute parsing, _pointer_depth, _underlying_type_name).
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import warnings
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from xml.etree.ElementTree import Element, SubElement
+
+import pytest
+
+from abicheck.dumper import (
+    _cache_key,
+    _CastxmlParser,
+    _castxml_dump,
+    _pyelftools_exported_symbols,
+    dump,
+)
+from abicheck.model import AbiSnapshot, Function, Visibility
+
+
+# ── _castxml_dump internal branches ────────────────────────────────────
+
+class TestCastxmlDumpBranches:
+    def _setup(self, monkeypatch, tmp_path):
+        """Common setup: castxml available, cache miss."""
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/castxml")
+        monkeypatch.setattr("abicheck.dumper._cache_key", lambda *a, **kw: "test_key")
+
+        # Cache path that doesn't exist yet
+        cache_file = tmp_path / "cache.xml"
+        monkeypatch.setattr("abicheck.dumper._cache_path", lambda k: cache_file)
+
+        header = tmp_path / "test.h"
+        header.write_text("int foo();", encoding="utf-8")
+        return header
+
+    def _make_spy(self, monkeypatch):
+        """Create a subprocess.run spy that writes valid XML and captures cmd."""
+        captured_cmd = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            for i, arg in enumerate(cmd):
+                if arg == "-o" and i + 1 < len(cmd):
+                    Path(cmd[i + 1]).write_text("<GCC_XML/>", encoding="utf-8")
+                    break
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        return captured_cmd
+
+    def test_gcc_path_used(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        result = _castxml_dump([header], [], gcc_path="/opt/cross/bin/g++")
+        assert result.tag == "GCC_XML"
+        assert "/opt/cross/bin/g++" in captured
+
+    def test_gcc_prefix_cpp(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], compiler="c++", gcc_prefix="aarch64-linux-gnu-")
+        assert "aarch64-linux-gnu-g++" in captured
+
+    def test_gcc_prefix_c(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], compiler="cc", gcc_prefix="arm-none-eabi-")
+        assert "arm-none-eabi-gcc" in captured
+
+    def test_msvc_detection(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], gcc_path="cl.exe")
+        assert "--castxml-cc-msvc" in captured
+
+    def test_sysroot_flag(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], sysroot=Path("/opt/sysroot"))
+        assert "--sysroot=/opt/sysroot" in captured
+
+    def test_nostdinc_flag(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], nostdinc=True)
+        assert "-nostdinc" in captured
+
+    def test_gcc_options_split(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], gcc_options="-march=armv8-a -mfloat-abi=hard")
+        assert "-march=armv8-a" in captured
+        assert "-mfloat-abi=hard" in captured
+
+    def test_lang_c_forces_c_mode(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [], lang="C")
+        assert "-x" in captured
+        assert "c" in captured
+        assert "-std=gnu11" in captured
+
+    def test_castxml_failure_raises(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+
+        def fake_run(cmd, **kwargs):
+            for i, arg in enumerate(cmd):
+                if arg == "-o" and i + 1 < len(cmd):
+                    Path(cmd[i + 1]).write_text("", encoding="utf-8")
+                    break
+            return SimpleNamespace(returncode=1, stdout="", stderr="compilation error")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        with pytest.raises(RuntimeError, match="castxml failed"):
+            _castxml_dump([header], [])
+
+    def test_extra_includes_passed(self, tmp_path, monkeypatch):
+        header = self._setup(monkeypatch, tmp_path)
+        inc = tmp_path / "inc"
+        inc.mkdir()
+        captured = self._make_spy(monkeypatch)
+        _castxml_dump([header], [inc])
+        assert "-I" in captured
+        assert str(inc) in captured
+
+
+# ── dump() elf_meta symbol filtering and lang ──────────────────────────
+
+class TestDumpSymbolFiltering:
+    def test_elf_meta_symbol_type_filtering(self, tmp_path, monkeypatch):
+        """When elf_meta has symbols, they are split by type."""
+        from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
+
+        so_path = tmp_path / "libfoo.so"
+        so_path.write_bytes(b"elf")
+
+        monkeypatch.setattr(
+            "abicheck.dumper._pyelftools_exported_symbols",
+            lambda _p: ({"func_sym", "obj_sym"}, {"func_sym", "obj_sym"}),
+        )
+
+        elf_meta = ElfMetadata(
+            soname="libfoo.so",
+            symbols=[
+                ElfSymbol(name="func_sym", sym_type=SymbolType.FUNC, version=""),
+                ElfSymbol(name="obj_sym", sym_type=SymbolType.OBJECT, version=""),
+            ],
+        )
+        monkeypatch.setattr("abicheck.elf_metadata.parse_elf_metadata", lambda _p: elf_meta)
+        monkeypatch.setattr("abicheck.dwarf_metadata.parse_dwarf_metadata", lambda _p: None)
+        monkeypatch.setattr("abicheck.dwarf_advanced.parse_advanced_dwarf", lambda _p: None)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            snap = dump(so_path=so_path, headers=[], version="1.0")
+
+        # Only FUNC symbols appear as functions in no-header mode
+        func_names = {f.name for f in snap.functions}
+        assert "func_sym" in func_names
+        # Object symbols should NOT be in functions
+        assert "obj_sym" not in func_names
+
+    def test_lang_c_sets_profile(self, tmp_path, monkeypatch):
+        """lang='C' sets language_profile to 'c'."""
+        so_path = tmp_path / "lib.so"
+        so_path.write_bytes(b"elf")
+
+        monkeypatch.setattr(
+            "abicheck.dumper._pyelftools_exported_symbols",
+            lambda _p: (set(), set()),
+        )
+        monkeypatch.setattr("abicheck.elf_metadata.parse_elf_metadata", lambda _p: None)
+        monkeypatch.setattr("abicheck.dwarf_metadata.parse_dwarf_metadata", lambda _p: None)
+        monkeypatch.setattr("abicheck.dwarf_advanced.parse_advanced_dwarf", lambda _p: None)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            snap = dump(so_path=so_path, headers=[], version="1.0", lang="C")
+
+        assert snap.language_profile == "c"
+
+    def test_lang_cpp_sets_profile(self, tmp_path, monkeypatch):
+        """lang='C++' sets language_profile to 'cpp'."""
+        so_path = tmp_path / "lib.so"
+        so_path.write_bytes(b"elf")
+
+        monkeypatch.setattr(
+            "abicheck.dumper._pyelftools_exported_symbols",
+            lambda _p: (set(), set()),
+        )
+        monkeypatch.setattr("abicheck.elf_metadata.parse_elf_metadata", lambda _p: None)
+        monkeypatch.setattr("abicheck.dwarf_metadata.parse_dwarf_metadata", lambda _p: None)
+        monkeypatch.setattr("abicheck.dwarf_advanced.parse_advanced_dwarf", lambda _p: None)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            snap = dump(so_path=so_path, headers=[], version="1.0", lang="C++")
+
+        assert snap.language_profile == "cpp"
+
+
+# ── _CastxmlParser edge cases ─────────────────────────────────────────
+
+def _xml_root(*children: Element) -> Element:
+    root = Element("GCC_XML")
+    for c in children:
+        root.append(c)
+    return root
+
+
+def _fund_type(id_: str, name: str) -> Element:
+    return Element("FundamentalType", id=id_, name=name)
+
+
+class TestCastxmlParserBuiltinSkip:
+    def test_builtin_function_skipped(self):
+        """Functions from <builtin> file are skipped."""
+        builtin_file = Element("File", id="f_builtin", name="<builtin>")
+        ft = _fund_type("t1", "void")
+        fn = Element("Function", id="fn1", name="__builtin_trap", mangled="__builtin_trap",
+                      returns="t1", file="f_builtin")
+        root = _xml_root(builtin_file, ft, fn)
+        p = _CastxmlParser(root, {"__builtin_trap"}, set())
+        assert p.parse_functions() == []
+
+    def test_builtin_variable_skipped(self):
+        builtin_file = Element("File", id="f_builtin", name="<built-in>")
+        ft = _fund_type("t1", "int")
+        v = Element("Variable", id="v1", name="__builtin_var", mangled="__builtin_var",
+                     type="t1", file="f_builtin")
+        root = _xml_root(builtin_file, ft, v)
+        p = _CastxmlParser(root, set(), set())
+        assert p.parse_variables() == []
+
+    def test_builtin_type_skipped(self):
+        builtin_file = Element("File", id="f_builtin", name="<command-line>")
+        s = Element("Struct", id="s1", name="CmdLineDef", file="f_builtin")
+        root = _xml_root(builtin_file, s)
+        p = _CastxmlParser(root, set(), set())
+        assert p.parse_types() == []
+
+    def test_builtin_enum_skipped(self):
+        builtin_file = Element("File", id="f_builtin", name="<builtin>")
+        e = Element("Enumeration", id="e1", name="BuiltinEnum", file="f_builtin")
+        root = _xml_root(builtin_file, e)
+        p = _CastxmlParser(root, set(), set())
+        assert p.parse_enums() == []
+
+    def test_builtin_typedef_skipped(self):
+        builtin_file = Element("File", id="f_builtin", name="<builtin>")
+        ft = _fund_type("t1", "int")
+        td = Element("Typedef", id="td1", name="__builtin_td", type="t1", file="f_builtin")
+        root = _xml_root(builtin_file, ft, td)
+        p = _CastxmlParser(root, set(), set())
+        assert p.parse_typedefs() == {}
+
+
+class TestCastxmlParserAnonymousField:
+    def test_anonymous_field_expanded(self):
+        """Anonymous union field gets its members inlined."""
+        ft = _fund_type("t1", "int")
+        inner_union = Element("Union", id="u1", name="")
+        SubElement(inner_union, "Field", name="i", type="t1", offset="0")
+        SubElement(inner_union, "Field", name="f", type="t1", offset="0")
+
+        s = Element("Struct", id="s1", name="Outer", size="32", align="32")
+        # Anonymous field (no name) pointing to the union
+        SubElement(s, "Field", name="", type="u1", offset="0")
+
+        root = _xml_root(ft, inner_union, s)
+        p = _CastxmlParser(root, set(), set())
+        types = p.parse_types()
+        assert len(types) == 1
+        field_names = [f.name for f in types[0].fields]
+        assert "i" in field_names
+        assert "f" in field_names
+
+    def test_members_attribute_fallback(self):
+        """Fields resolved via members= attribute when no inline children."""
+        ft = _fund_type("t1", "int")
+        f1 = Element("Field", id="_f1", name="x", type="t1", offset="0")
+        f2 = Element("Field", id="_f2", name="y", type="t1", offset="32")
+
+        s = Element("Struct", id="s1", name="Via", size="64", members="_f1 _f2")
+        # No inline Field children in Struct
+
+        root = _xml_root(ft, f1, f2, s)
+        p = _CastxmlParser(root, set(), set())
+        types = p.parse_types()
+        assert len(types) == 1
+        assert len(types[0].fields) == 2
+        assert types[0].fields[0].name == "x"
+        assert types[0].fields[1].name == "y"
+
+
+class TestCastxmlParserPointerDepth:
+    def test_double_pointer(self):
+        ft = _fund_type("t1", "int")
+        p1 = Element("PointerType", id="t2", type="t1")
+        p2 = Element("PointerType", id="t3", type="t2")
+        root = _xml_root(ft, p1, p2)
+        p = _CastxmlParser(root, set(), set())
+        assert p._pointer_depth("t3") == 2
+
+    def test_pointer_through_typedef(self):
+        ft = _fund_type("t1", "int")
+        td = Element("Typedef", id="t2", name="myint", type="t1")
+        ptr = Element("PointerType", id="t3", type="t2")
+        root = _xml_root(ft, td, ptr)
+        p = _CastxmlParser(root, set(), set())
+        assert p._pointer_depth("t3") == 1
+
+    def test_pointer_through_cv_qualified(self):
+        ft = _fund_type("t1", "int")
+        cv = Element("CvQualifiedType", id="t2", type="t1", const="1")
+        ptr = Element("PointerType", id="t3", type="t2")
+        root = _xml_root(ft, cv, ptr)
+        p = _CastxmlParser(root, set(), set())
+        assert p._pointer_depth("t3") == 1
+
+    def test_non_pointer_returns_zero(self):
+        ft = _fund_type("t1", "int")
+        root = _xml_root(ft)
+        p = _CastxmlParser(root, set(), set())
+        assert p._pointer_depth("t1") == 0
+
+    def test_missing_returns_zero(self):
+        root = _xml_root()
+        p = _CastxmlParser(root, set(), set())
+        assert p._pointer_depth("missing") == 0
+
+
+class TestCastxmlParserUnderlyingType:
+    def test_typedef_chain_resolved(self):
+        ft = _fund_type("t1", "int")
+        td1 = Element("Typedef", id="t2", name="int32_t", type="t1")
+        td2 = Element("Typedef", id="t3", name="my_int", type="t2")
+        root = _xml_root(ft, td1, td2)
+        p = _CastxmlParser(root, set(), set())
+        assert p._underlying_type_name("t3") == "int"
+
+    def test_non_typedef_returns_type_name(self):
+        ft = _fund_type("t1", "int")
+        root = _xml_root(ft)
+        p = _CastxmlParser(root, set(), set())
+        assert p._underlying_type_name("t1") == "int"
+
+    def test_missing_returns_question(self):
+        root = _xml_root()
+        p = _CastxmlParser(root, set(), set())
+        assert p._underlying_type_name("missing") == "?"
+
+    def test_depth_limit(self):
+        """Deep typedef chain returns '?'."""
+        # Create chain: t0 → t1 → t2 → ... → t25
+        ft = _fund_type("t0", "int")
+        elements = [ft]
+        for i in range(1, 25):
+            td = Element("Typedef", id=f"t{i}", name=f"td{i}", type=f"t{i-1}")
+            elements.append(td)
+        root = _xml_root(*elements)
+        p = _CastxmlParser(root, set(), set())
+        assert p._underlying_type_name("t24") == "?"
+
+
+class TestCastxmlParserFunctionSourceLoc:
+    def test_function_with_source_location(self):
+        """Function with location element gets source_location set."""
+        file_el = Element("File", id="f1", name="test.hpp")
+        loc = Element("Location", id="loc1", file="f1", line="42")
+        ft = _fund_type("t1", "void")
+        fn = Element("Function", id="fn1", name="test_func", mangled="_Z9test_funcv",
+                      returns="t1", location="loc1")
+        root = _xml_root(file_el, loc, ft, fn)
+        p = _CastxmlParser(root, set(), set())
+        funcs = p.parse_functions()
+        assert funcs[0].source_location == "test.hpp:42"
+
+    def test_function_inline(self):
+        ft = _fund_type("t1", "void")
+        fn = Element("Function", id="fn1", name="inlined", mangled="_Z7inlinedv",
+                      returns="t1", inline="1")
+        root = _xml_root(ft, fn)
+        p = _CastxmlParser(root, set(), set())
+        funcs = p.parse_functions()
+        assert funcs[0].is_inline is True
+
+
+class TestCacheKeyToolchain:
+    def test_different_toolchain_params_different_keys(self, tmp_path):
+        h = tmp_path / "h.h"
+        h.write_text("int f();", encoding="utf-8")
+        k1 = _cache_key([h], [], "c++", gcc_path="/usr/bin/g++")
+        k2 = _cache_key([h], [], "c++", gcc_prefix="arm-")
+        k3 = _cache_key([h], [], "c++", sysroot=Path("/opt"))
+        k4 = _cache_key([h], [], "c++", nostdinc=True)
+        k5 = _cache_key([h], [], "c++", lang="C")
+        k6 = _cache_key([h], [], "c++", gcc_options="-march=armv8")
+        # All should be different from base
+        k_base = _cache_key([h], [], "c++")
+        assert len({k_base, k1, k2, k3, k4, k5, k6}) == 7
+
+
+class TestCastxmlParserAccessLevel:
+    def test_protected_access(self):
+        ft = _fund_type("t1", "int")
+        s = Element("Struct", id="s1", name="S")
+        f = SubElement(s, "Field", name="x", type="t1", access="protected")
+        root = _xml_root(ft, s)
+        p = _CastxmlParser(root, set(), set())
+        types = p.parse_types()
+        from abicheck.model import AccessLevel
+        assert types[0].fields[0].access == AccessLevel.PROTECTED
+
+    def test_private_access(self):
+        ft = _fund_type("t1", "int")
+        s = Element("Struct", id="s1", name="S")
+        SubElement(s, "Field", name="x", type="t1", access="private")
+        root = _xml_root(ft, s)
+        p = _CastxmlParser(root, set(), set())
+        types = p.parse_types()
+        from abicheck.model import AccessLevel
+        assert types[0].fields[0].access == AccessLevel.PRIVATE

--- a/tests/test_dumper_coverage.py
+++ b/tests/test_dumper_coverage.py
@@ -13,20 +13,16 @@ import subprocess
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
 from xml.etree.ElementTree import Element, SubElement
 
 import pytest
 
 from abicheck.dumper import (
     _cache_key,
-    _CastxmlParser,
     _castxml_dump,
-    _pyelftools_exported_symbols,
+    _CastxmlParser,
     dump,
 )
-from abicheck.model import AbiSnapshot, Function, Visibility
-
 
 # ── _castxml_dump internal branches ────────────────────────────────────
 
@@ -417,7 +413,7 @@ class TestCastxmlParserAccessLevel:
     def test_protected_access(self):
         ft = _fund_type("t1", "int")
         s = Element("Struct", id="s1", name="S")
-        f = SubElement(s, "Field", name="x", type="t1", access="protected")
+        SubElement(s, "Field", name="x", type="t1", access="protected")
         root = _xml_root(ft, s)
         p = _CastxmlParser(root, set(), set())
         types = p.parse_types()

--- a/tests/test_dwarf_metadata_coverage.py
+++ b/tests/test_dwarf_metadata_coverage.py
@@ -1,0 +1,681 @@
+"""Coverage tests for dwarf_metadata.py — mock-based unit tests.
+
+Covers parse_dwarf_metadata entry points, _parse, _process_cu error handling,
+_walk_die_iter traversal, _process_struct with ODR, _process_member bitfields,
+_process_enum, _process_typedef, _expand_anonymous_member, _compute_type_info
+branches, _attr_str/_attr_int edge cases, and _compute_fallback_type_info.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from abicheck.dwarf_metadata import (
+    DwarfMetadata,
+    EnumInfo,
+    FieldInfo,
+    StructLayout,
+    _attr_int,
+    _attr_str,
+    _compute_array_type_info,
+    _compute_fallback_type_info,
+    _compute_qualified_type_info,
+    _compute_record_type_info,
+    _compute_type_info,
+    _compute_typedef_info,
+    _die_to_type_info,
+    _expand_anonymous_member,
+    _parse,
+    _process_cu,
+    _process_enum,
+    _process_enum_named,
+    _process_member,
+    _process_struct,
+    _process_struct_named,
+    _process_typedef,
+    _resolve_inner_type_info,
+    _resolve_ref,
+    _resolve_type,
+    _walk_die_iter,
+    parse_dwarf_metadata,
+)
+
+
+# ── Mock helpers ───────────────────────────────────────────────────────
+
+class _Attr:
+    def __init__(self, value, form="DW_FORM_ref4"):
+        self.value = value
+        self.form = form
+
+
+class _Die:
+    def __init__(self, tag, attrs=None, children=None, offset=0):
+        self.tag = tag
+        self.attributes = {k: _Attr(v) if not isinstance(v, _Attr) else v
+                          for k, v in (attrs or {}).items()}
+        self._children = list(children or [])
+        self.offset = offset
+
+    def iter_children(self):
+        return iter(self._children)
+
+
+class _CU:
+    cu_offset = 0
+
+    def __init__(self, top_die=None, offset=0):
+        self._top = top_die
+        self.cu_offset = offset
+
+    def get_top_DIE(self):
+        return self._top
+
+    def get_DIE_from_refaddr(self, off):
+        return getattr(self, '_die_map', {}).get(off)
+
+
+# ── parse_dwarf_metadata entry point ──────────────────────────────────
+
+class TestParseDwarfMetadata:
+    def test_nonexistent_file_returns_empty(self, tmp_path):
+        result = parse_dwarf_metadata(tmp_path / "nope.so")
+        assert isinstance(result, DwarfMetadata)
+        assert result.has_dwarf is False
+
+    def test_non_regular_file_returns_empty(self, tmp_path):
+        """Passing a directory-like path returns empty metadata."""
+        # Create a named pipe or use a special file; for simplicity, mock os.fstat
+        import os
+        import stat
+
+        f = tmp_path / "weird.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        with patch("abicheck.dwarf_metadata.os.fstat") as mock_fstat:
+            mock_st = MagicMock()
+            mock_st.st_mode = stat.S_IFIFO | 0o644  # pipe, not regular
+            mock_fstat.return_value = mock_st
+            result = parse_dwarf_metadata(f)
+        assert result.has_dwarf is False
+
+    def test_elf_error_returns_empty(self, tmp_path):
+        f = tmp_path / "bad.so"
+        f.write_bytes(b"not elf at all")
+        result = parse_dwarf_metadata(f)
+        assert result.has_dwarf is False
+
+
+# ── _parse with no DWARF ─────────────────────────────────────────────
+
+class TestParse:
+    def test_no_dwarf_info(self):
+        mock_elf = MagicMock()
+        mock_elf.has_dwarf_info.return_value = False
+
+        with patch("abicheck.dwarf_metadata.ELFFile", return_value=mock_elf):
+            result = _parse(MagicMock(), Path("/fake.so"))
+        assert result.has_dwarf is False
+
+    def test_cu_exception_skipped(self):
+        """When a CU raises, it is skipped and processing continues."""
+        mock_elf = MagicMock()
+        mock_elf.has_dwarf_info.return_value = True
+        mock_dwarf = MagicMock()
+
+        # CU that will cause an error
+        bad_cu = MagicMock()
+        bad_cu.get_top_DIE.side_effect = RuntimeError("corrupt CU")
+
+        # Good CU with empty top DIE
+        good_die = _Die("DW_TAG_compile_unit")
+        good_cu = MagicMock()
+        good_cu.cu_offset = 0
+        good_cu.get_top_DIE.return_value = good_die
+
+        mock_dwarf.iter_CUs.return_value = [bad_cu, good_cu]
+        mock_elf.get_dwarf_info.return_value = mock_dwarf
+
+        with patch("abicheck.dwarf_metadata.ELFFile", return_value=mock_elf):
+            result = _parse(MagicMock(), Path("/fake.so"))
+        assert result.has_dwarf is True
+
+
+# ── _walk_die_iter ────────────────────────────────────────────────────
+
+class TestWalkDieIter:
+    def test_skip_tags_not_descended(self):
+        """DW_TAG_subprogram subtrees are skipped."""
+        inner = _Die("DW_TAG_structure_type", {"DW_AT_name": "InnerStruct", "DW_AT_byte_size": 4})
+        func = _Die("DW_TAG_subprogram", children=[inner])
+        root = _Die("DW_TAG_compile_unit", children=[func])
+
+        meta = DwarfMetadata(has_dwarf=True)
+        cu = _CU(offset=0)
+        _walk_die_iter(root, meta, cu, {})
+        # Inner struct inside subprogram should NOT be registered
+        assert "InnerStruct" not in meta.structs
+
+    def test_namespace_scoping(self):
+        """Types inside namespaces get qualified names."""
+        struct = _Die("DW_TAG_structure_type", {
+            "DW_AT_name": "Foo",
+            "DW_AT_byte_size": 8,
+        })
+        ns = _Die("DW_TAG_namespace", {"DW_AT_name": "MyNS"}, children=[struct])
+        root = _Die("DW_TAG_compile_unit", children=[ns])
+
+        meta = DwarfMetadata(has_dwarf=True)
+        cu = _CU(offset=0)
+        _walk_die_iter(root, meta, cu, {})
+        assert "MyNS::Foo" in meta.structs
+
+    def test_enum_processed(self):
+        """DW_TAG_enumeration_type is processed."""
+        enumerator = _Die("DW_TAG_enumerator", {"DW_AT_name": "A", "DW_AT_const_value": 0})
+        enum = _Die("DW_TAG_enumeration_type", {
+            "DW_AT_name": "Color",
+            "DW_AT_byte_size": 4,
+        }, children=[enumerator])
+        root = _Die("DW_TAG_compile_unit", children=[enum])
+
+        meta = DwarfMetadata(has_dwarf=True)
+        cu = _CU(offset=0)
+        _walk_die_iter(root, meta, cu, {})
+        assert "Color" in meta.enums
+        assert meta.enums["Color"].members["A"] == 0
+
+    def test_typedef_to_anonymous_struct(self):
+        """DW_TAG_typedef pointing to anonymous struct registers under typedef name."""
+        # Create anonymous struct (no DW_AT_name)
+        member = _Die("DW_TAG_member", {
+            "DW_AT_name": "x",
+            "DW_AT_data_member_location": 0,
+        }, offset=10)
+        anon_struct = _Die("DW_TAG_structure_type", {
+            "DW_AT_byte_size": 4,
+        }, children=[member], offset=20)
+
+        # Create typedef pointing to it
+        typedef = _Die("DW_TAG_typedef", {
+            "DW_AT_name": "MyType",
+            "DW_AT_type": _Attr(20, "DW_FORM_ref_addr"),
+        }, offset=30)
+
+        root = _Die("DW_TAG_compile_unit", children=[anon_struct, typedef])
+
+        cu = _CU(offset=0)
+        cu._die_map = {20: anon_struct}
+
+        meta = DwarfMetadata(has_dwarf=True)
+        _walk_die_iter(root, meta, cu, {})
+        assert "MyType" in meta.structs
+
+    def test_typedef_to_anonymous_enum(self):
+        """DW_TAG_typedef pointing to anonymous enum registers under typedef name."""
+        enumerator = _Die("DW_TAG_enumerator", {"DW_AT_name": "VAL", "DW_AT_const_value": 1})
+        anon_enum = _Die("DW_TAG_enumeration_type", {
+            "DW_AT_byte_size": 4,
+        }, children=[enumerator], offset=50)
+
+        typedef = _Die("DW_TAG_typedef", {
+            "DW_AT_name": "MyEnum",
+            "DW_AT_type": _Attr(50, "DW_FORM_ref_addr"),
+        }, offset=60)
+
+        root = _Die("DW_TAG_compile_unit", children=[anon_enum, typedef])
+
+        cu = _CU(offset=0)
+        cu._die_map = {50: anon_enum}
+
+        meta = DwarfMetadata(has_dwarf=True)
+        _walk_die_iter(root, meta, cu, {})
+        assert "MyEnum" in meta.enums
+
+
+# ── _process_struct / _process_struct_named ────────────────────────────
+
+class TestProcessStruct:
+    def test_anonymous_struct_skipped(self):
+        die = _Die("DW_TAG_structure_type", {"DW_AT_byte_size": 4})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_struct(die, meta, _CU(), {})
+        assert len(meta.structs) == 0
+
+    def test_declaration_only_skipped(self):
+        """Struct with byte_size 0 (declaration-only) is skipped."""
+        die = _Die("DW_TAG_structure_type", {"DW_AT_name": "Fwd", "DW_AT_byte_size": 0})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_struct(die, meta, _CU(), {})
+        assert "Fwd" not in meta.structs
+
+    def test_odr_keeps_first(self):
+        """ODR: second definition with different size is not registered."""
+        die1 = _Die("DW_TAG_structure_type", {"DW_AT_name": "S", "DW_AT_byte_size": 8})
+        die2 = _Die("DW_TAG_structure_type", {"DW_AT_name": "S", "DW_AT_byte_size": 16})
+
+        meta = DwarfMetadata(has_dwarf=True)
+        cu = _CU()
+        _process_struct(die1, meta, cu, {})
+        _process_struct(die2, meta, cu, {})
+        assert meta.structs["S"].byte_size == 8
+
+    def test_union_flag(self):
+        die = _Die("DW_TAG_union_type", {"DW_AT_name": "U", "DW_AT_byte_size": 4})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_struct(die, meta, _CU(), {})
+        assert meta.structs["U"].is_union is True
+
+    def test_with_scope_prefix(self):
+        die = _Die("DW_TAG_structure_type", {"DW_AT_name": "Inner", "DW_AT_byte_size": 4})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_struct(die, meta, _CU(), {}, scope_prefix="Outer")
+        assert "Outer::Inner" in meta.structs
+
+    def test_anonymous_member_inlined(self):
+        """Anonymous struct member fields are inlined into parent."""
+        # Inner anon struct
+        inner_member = _Die("DW_TAG_member", {
+            "DW_AT_name": "y",
+            "DW_AT_data_member_location": 0,
+        })
+        anon_struct = _Die("DW_TAG_structure_type", {
+            "DW_AT_byte_size": 4,
+        }, children=[inner_member], offset=100)
+
+        # Anon member pointing to the struct
+        anon_member = _Die("DW_TAG_member", {
+            "DW_AT_data_member_location": 4,
+            "DW_AT_type": _Attr(100, "DW_FORM_ref_addr"),
+        })
+
+        outer = _Die("DW_TAG_structure_type", {
+            "DW_AT_name": "S",
+            "DW_AT_byte_size": 8,
+        }, children=[anon_member])
+
+        cu = _CU()
+        cu._die_map = {100: anon_struct}
+
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_struct(outer, meta, cu, {})
+        assert "S" in meta.structs
+        assert any(f.name == "y" for f in meta.structs["S"].fields)
+
+
+# ── _process_member ───────────────────────────────────────────────────
+
+class TestProcessMember:
+    def test_unnamed_member_returns_none(self):
+        die = _Die("DW_TAG_member", {"DW_AT_data_member_location": 0})
+        assert _process_member(die, _CU(), {}) is None
+
+    def test_list_expression_offset(self):
+        """DW_OP expression list: last element used as offset."""
+        die = _Die("DW_TAG_member", {
+            "DW_AT_name": "x",
+            "DW_AT_data_member_location": _Attr([0x23, 8]),
+        })
+        fi = _process_member(die, _CU(), {})
+        assert fi is not None
+        assert fi.byte_offset == 8
+
+    def test_empty_list_expression(self):
+        """Empty DW_OP expression list → offset 0."""
+        die = _Die("DW_TAG_member", {
+            "DW_AT_name": "x",
+            "DW_AT_data_member_location": _Attr([]),
+        })
+        fi = _process_member(die, _CU(), {})
+        assert fi is not None
+        assert fi.byte_offset == 0
+
+    def test_bitfield_data_bit_offset(self):
+        """DW_AT_data_bit_offset takes priority over DW_AT_bit_offset."""
+        die = _Die("DW_TAG_member", {
+            "DW_AT_name": "bf",
+            "DW_AT_data_member_location": 0,
+            "DW_AT_bit_size": 3,
+            "DW_AT_data_bit_offset": 5,
+            "DW_AT_bit_offset": 99,
+        })
+        fi = _process_member(die, _CU(), {})
+        assert fi is not None
+        assert fi.bit_size == 3
+        assert fi.bit_offset == 5
+
+    def test_bitfield_legacy_bit_offset(self):
+        """When DW_AT_data_bit_offset absent, DW_AT_bit_offset is used."""
+        die = _Die("DW_TAG_member", {
+            "DW_AT_name": "bf",
+            "DW_AT_data_member_location": 0,
+            "DW_AT_bit_size": 4,
+            "DW_AT_bit_offset": 12,
+        })
+        fi = _process_member(die, _CU(), {})
+        assert fi is not None
+        assert fi.bit_offset == 12
+
+
+# ── _process_enum ─────────────────────────────────────────────────────
+
+class TestProcessEnum:
+    def test_anonymous_enum_skipped(self):
+        die = _Die("DW_TAG_enumeration_type", {"DW_AT_byte_size": 4})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_enum(die, meta, _CU())
+        assert len(meta.enums) == 0
+
+    def test_declaration_only_skipped(self):
+        die = _Die("DW_TAG_enumeration_type", {"DW_AT_name": "E", "DW_AT_byte_size": 0})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_enum(die, meta, _CU())
+        assert "E" not in meta.enums
+
+    def test_scoped_enum(self):
+        enumerator = _Die("DW_TAG_enumerator", {"DW_AT_name": "A", "DW_AT_const_value": 1})
+        die = _Die("DW_TAG_enumeration_type", {
+            "DW_AT_name": "E",
+            "DW_AT_byte_size": 4,
+        }, children=[enumerator])
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_enum(die, meta, _CU(), scope_prefix="NS")
+        assert "NS::E" in meta.enums
+
+    def test_odr_keeps_first_enum(self):
+        die1 = _Die("DW_TAG_enumeration_type", {"DW_AT_name": "E", "DW_AT_byte_size": 4})
+        die2 = _Die("DW_TAG_enumeration_type", {"DW_AT_name": "E", "DW_AT_byte_size": 8})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_enum(die1, meta, _CU())
+        _process_enum(die2, meta, _CU())
+        assert meta.enums["E"].underlying_byte_size == 4
+
+
+# ── _expand_anonymous_member ──────────────────────────────────────────
+
+class TestExpandAnonymousMember:
+    def test_no_type_returns_empty(self):
+        die = _Die("DW_TAG_member", {})
+        result = _expand_anonymous_member(die, _CU(), {}, 0)
+        assert result == []
+
+    def test_bad_ref_returns_empty(self):
+        die = _Die("DW_TAG_member", {"DW_AT_type": _Attr(999, "DW_FORM_ref_addr")})
+        cu = _CU()
+        cu._die_map = {}
+        with patch("abicheck.dwarf_metadata._resolve_ref", side_effect=RuntimeError("bad")):
+            result = _expand_anonymous_member(die, cu, {}, 0)
+        assert result == []
+
+    def test_non_struct_target_returns_empty(self):
+        target = _Die("DW_TAG_base_type", {"DW_AT_name": "int"}, offset=10)
+        die = _Die("DW_TAG_member", {"DW_AT_type": _Attr(10, "DW_FORM_ref_addr")})
+        cu = _CU()
+        cu._die_map = {10: target}
+        result = _expand_anonymous_member(die, cu, {}, 0)
+        assert result == []
+
+
+# ── _compute_type_info branches ───────────────────────────────────────
+
+class TestComputeTypeInfo:
+    def test_base_type(self):
+        die = _Die("DW_TAG_base_type", {"DW_AT_name": "long", "DW_AT_byte_size": 8})
+        assert _compute_type_info(die, _CU(), 0, {}) == ("long", 8)
+
+    def test_enum_type(self):
+        die = _Die("DW_TAG_enumeration_type", {"DW_AT_name": "Color", "DW_AT_byte_size": 4})
+        assert _compute_type_info(die, _CU(), 0, {}) == ("enum Color", 4)
+
+    def test_enum_anonymous(self):
+        die = _Die("DW_TAG_enumeration_type", {"DW_AT_byte_size": 4})
+        assert _compute_type_info(die, _CU(), 0, {}) == ("enum <enum>", 4)
+
+    def test_subroutine_type(self):
+        die = _Die("DW_TAG_subroutine_type", {"DW_AT_byte_size": 8})
+        assert _compute_type_info(die, _CU(), 0, {}) == ("fn(...)", 8)
+
+    def test_record_struct(self):
+        die = _Die("DW_TAG_structure_type", {"DW_AT_name": "Foo", "DW_AT_byte_size": 16})
+        result = _compute_type_info(die, _CU(), 0, {})
+        assert result == ("Foo", 16)
+
+    def test_record_anon(self):
+        die = _Die("DW_TAG_class_type", {"DW_AT_byte_size": 8})
+        result = _compute_type_info(die, _CU(), 0, {})
+        assert result == ("<anon>", 8)
+
+    def test_rvalue_reference(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        rref = _Die("DW_TAG_rvalue_reference_type", {
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+            "DW_AT_byte_size": 8,
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(rref, cu, 0, {})
+        assert result == ("int &&", 8)
+
+    def test_const_qualified(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        const = _Die("DW_TAG_const_type", {
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(const, cu, 0, {})
+        assert result == ("const int", 4)
+
+    def test_volatile_qualified(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        vol = _Die("DW_TAG_volatile_type", {
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(vol, cu, 0, {})
+        assert result == ("volatile int", 4)
+
+    def test_restrict_qualified(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        restrict = _Die("DW_TAG_restrict_type", {
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(restrict, cu, 0, {})
+        assert result == ("restrict int", 4)
+
+    def test_typedef_chain(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        td = _Die("DW_TAG_typedef", {
+            "DW_AT_name": "myint",
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(td, cu, 0, {})
+        assert result == ("myint", 4)
+
+    def test_array_type(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        arr = _Die("DW_TAG_array_type", {
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+            "DW_AT_byte_size": 40,
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(arr, cu, 0, {})
+        assert result == ("int[]", 40)
+
+    def test_array_no_inner_type(self):
+        arr = _Die("DW_TAG_array_type", {"DW_AT_byte_size": 8})
+        result = _compute_type_info(arr, _CU(), 0, {})
+        assert result == ("array", 8)
+
+    def test_qualified_no_inner(self):
+        const = _Die("DW_TAG_const_type", {})
+        result = _compute_type_info(const, _CU(), 0, {})
+        assert result == ("const", 0)
+
+    def test_typedef_no_inner(self):
+        td = _Die("DW_TAG_typedef", {"DW_AT_name": "foo"})
+        result = _compute_type_info(td, _CU(), 0, {})
+        assert result == ("foo", 0)
+
+    def test_typedef_unnamed_no_inner(self):
+        td = _Die("DW_TAG_typedef", {})
+        result = _compute_type_info(td, _CU(), 0, {})
+        assert result == ("typedef", 0)
+
+    def test_reference_type(self):
+        base = _Die("DW_TAG_base_type", {"DW_AT_name": "int", "DW_AT_byte_size": 4}, offset=10)
+        ref = _Die("DW_TAG_reference_type", {
+            "DW_AT_type": _Attr(10, "DW_FORM_ref_addr"),
+            "DW_AT_byte_size": 8,
+        })
+        cu = _CU()
+        cu._die_map = {10: base}
+        result = _compute_type_info(ref, cu, 0, {})
+        assert result == ("int &", 8)
+
+    def test_reference_no_inner(self):
+        ref = _Die("DW_TAG_reference_type", {"DW_AT_byte_size": 8})
+        result = _compute_type_info(ref, _CU(), 0, {})
+        assert result == ("? &", 8)
+
+    def test_rvalue_reference_no_inner(self):
+        rref = _Die("DW_TAG_rvalue_reference_type", {"DW_AT_byte_size": 8})
+        result = _compute_type_info(rref, _CU(), 0, {})
+        assert result == ("? &&", 8)
+
+
+# ── _compute_fallback_type_info ───────────────────────────────────────
+
+class TestComputeFallbackTypeInfo:
+    def test_with_name(self):
+        die = _Die("DW_TAG_whatever", {"DW_AT_name": "CustomType", "DW_AT_byte_size": 4})
+        result = _compute_fallback_type_info(die, "DW_TAG_whatever")
+        assert result == ("CustomType", 4)
+
+    def test_without_name_logs_warning(self, monkeypatch):
+        """Unknown tag without name triggers warning and uses tag as name."""
+        from abicheck import dwarf_metadata as dm
+        monkeypatch.setattr(dm, "_SEEN_UNKNOWN_DWARF_TAGS", set())
+
+        die = _Die("DW_TAG_exotic_vendor", {"DW_AT_byte_size": 2}, offset=42)
+        result = _compute_fallback_type_info(die, "DW_TAG_exotic_vendor")
+        assert result == ("DW_TAG_exotic_vendor", 2)
+        assert "DW_TAG_exotic_vendor" in dm._SEEN_UNKNOWN_DWARF_TAGS
+
+    def test_empty_tag(self, monkeypatch):
+        from abicheck import dwarf_metadata as dm
+        monkeypatch.setattr(dm, "_SEEN_UNKNOWN_DWARF_TAGS", set())
+
+        die = _Die("", {"DW_AT_byte_size": 0}, offset=0)
+        result = _compute_fallback_type_info(die, "")
+        assert result == ("unknown", 0)
+
+
+# ── _resolve_type ─────────────────────────────────────────────────────
+
+class TestResolveType:
+    def test_no_type_attr(self):
+        die = _Die("DW_TAG_member", {"DW_AT_name": "x"})
+        assert _resolve_type(die, _CU(), {}) == ("unknown", 0)
+
+    def test_error_in_resolution(self):
+        die = _Die("DW_TAG_member", {
+            "DW_AT_name": "x",
+            "DW_AT_type": _Attr(999, "DW_FORM_ref_addr"),
+        })
+        with patch("abicheck.dwarf_metadata._resolve_ref", side_effect=RuntimeError("bad")):
+            assert _resolve_type(die, _CU(), {}) == ("unknown", 0)
+
+
+# ── _resolve_inner_type_info ──────────────────────────────────────────
+
+class TestResolveInnerTypeInfo:
+    def test_no_type_attr(self):
+        die = _Die("DW_TAG_const_type", {})
+        assert _resolve_inner_type_info(die, _CU(), 0, {}) is None
+
+    def test_error_returns_none(self):
+        die = _Die("DW_TAG_const_type", {"DW_AT_type": _Attr(999, "DW_FORM_ref_addr")})
+        with patch("abicheck.dwarf_metadata._resolve_ref", side_effect=RuntimeError("bad")):
+            assert _resolve_inner_type_info(die, _CU(), 0, {}) is None
+
+
+# ── _attr_str / _attr_int edge cases ─────────────────────────────────
+
+class TestAttrHelpers:
+    def test_attr_str_bytes_value(self):
+        die = _Die("X", {"DW_AT_name": _Attr(b"hello\xff")})
+        assert _attr_str(die, "DW_AT_name") == "hello\ufffd"
+
+    def test_attr_str_none_value(self):
+        die = _Die("X", {"DW_AT_name": _Attr(None)})
+        assert _attr_str(die, "DW_AT_name") == ""
+
+    def test_attr_str_missing(self):
+        die = _Die("X", {})
+        assert _attr_str(die, "DW_AT_name") == ""
+
+    def test_attr_int_missing(self):
+        die = _Die("X", {})
+        assert _attr_int(die, "DW_AT_byte_size") == 0
+
+    def test_attr_int_bad_value(self):
+        die = _Die("X", {"DW_AT_byte_size": _Attr("not a number")})
+        assert _attr_int(die, "DW_AT_byte_size") == 0
+
+    def test_attr_int_none_value(self):
+        die = _Die("X", {"DW_AT_byte_size": _Attr(None)})
+        assert _attr_int(die, "DW_AT_byte_size") == 0
+
+
+# ── _process_typedef ──────────────────────────────────────────────────
+
+class TestProcessTypedef:
+    def test_unnamed_typedef_skipped(self):
+        die = _Die("DW_TAG_typedef", {"DW_AT_type": _Attr(10)})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_typedef(die, meta, _CU(), {})
+        assert len(meta.structs) == 0
+        assert len(meta.enums) == 0
+
+    def test_no_type_attr_skipped(self):
+        die = _Die("DW_TAG_typedef", {"DW_AT_name": "foo"})
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_typedef(die, meta, _CU(), {})
+        assert len(meta.structs) == 0
+
+    def test_bad_ref_skipped(self):
+        die = _Die("DW_TAG_typedef", {
+            "DW_AT_name": "foo",
+            "DW_AT_type": _Attr(999),
+        })
+        meta = DwarfMetadata(has_dwarf=True)
+        with patch("abicheck.dwarf_metadata._resolve_ref", side_effect=RuntimeError("bad")):
+            _process_typedef(die, meta, _CU(), {})
+        assert len(meta.structs) == 0
+
+    def test_named_target_not_registered(self):
+        """Typedef to a named struct does not re-register."""
+        target = _Die("DW_TAG_structure_type", {
+            "DW_AT_name": "RealName",
+            "DW_AT_byte_size": 8,
+        }, offset=20)
+        die = _Die("DW_TAG_typedef", {
+            "DW_AT_name": "Alias",
+            "DW_AT_type": _Attr(20, "DW_FORM_ref_addr"),
+        })
+        cu = _CU()
+        cu._die_map = {20: target}
+        meta = DwarfMetadata(has_dwarf=True)
+        _process_typedef(die, meta, cu, {})
+        assert "Alias" not in meta.structs

--- a/tests/test_dwarf_metadata_coverage.py
+++ b/tests/test_dwarf_metadata_coverage.py
@@ -7,43 +7,26 @@ branches, _attr_str/_attr_int edge cases, and _compute_fallback_type_info.
 """
 from __future__ import annotations
 
-import logging
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from abicheck.dwarf_metadata import (
     DwarfMetadata,
-    EnumInfo,
-    FieldInfo,
-    StructLayout,
     _attr_int,
     _attr_str,
-    _compute_array_type_info,
     _compute_fallback_type_info,
-    _compute_qualified_type_info,
-    _compute_record_type_info,
     _compute_type_info,
-    _compute_typedef_info,
-    _die_to_type_info,
     _expand_anonymous_member,
     _parse,
-    _process_cu,
     _process_enum,
-    _process_enum_named,
     _process_member,
     _process_struct,
-    _process_struct_named,
     _process_typedef,
     _resolve_inner_type_info,
-    _resolve_ref,
     _resolve_type,
     _walk_die_iter,
     parse_dwarf_metadata,
 )
-
 
 # ── Mock helpers ───────────────────────────────────────────────────────
 
@@ -90,7 +73,6 @@ class TestParseDwarfMetadata:
     def test_non_regular_file_returns_empty(self, tmp_path):
         """Passing a directory-like path returns empty metadata."""
         # Create a named pipe or use a special file; for simplicity, mock os.fstat
-        import os
         import stat
 
         f = tmp_path / "weird.so"

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -8,15 +8,15 @@ def test_version_fallback_when_not_installed(monkeypatch):
     """When the package is not installed, __version__ falls back to dev string."""
     from importlib.metadata import PackageNotFoundError
 
-    monkeypatch.setattr(
-        "importlib.metadata.version",
-        lambda _name: (_ for _ in ()).throw(PackageNotFoundError("abicheck")),
-    )
-
-    # Force reimport to exercise the except branch
     import abicheck
-    importlib.reload(abicheck)
-    assert abicheck.__version__ == "0.0.0.dev0"
 
-    # Restore normal state
+    with monkeypatch.context() as m:
+        m.setattr(
+            "importlib.metadata.version",
+            lambda _name: (_ for _ in ()).throw(PackageNotFoundError("abicheck")),
+        )
+        importlib.reload(abicheck)
+        assert abicheck.__version__ == "0.0.0.dev0"
+
+    # Patch is reverted — restore real version
     importlib.reload(abicheck)

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -1,0 +1,22 @@
+"""Coverage tests for abicheck/__init__.py — PackageNotFoundError fallback."""
+from __future__ import annotations
+
+import importlib
+
+
+def test_version_fallback_when_not_installed(monkeypatch):
+    """When the package is not installed, __version__ falls back to dev string."""
+    from importlib.metadata import PackageNotFoundError
+
+    monkeypatch.setattr(
+        "importlib.metadata.version",
+        lambda _name: (_ for _ in ()).throw(PackageNotFoundError("abicheck")),
+    )
+
+    # Force reimport to exercise the except branch
+    import abicheck
+    importlib.reload(abicheck)
+    assert abicheck.__version__ == "0.0.0.dev0"
+
+    # Restore normal state
+    importlib.reload(abicheck)


### PR DESCRIPTION
This PR adds extensive mock-based unit test suites for the core abicheck modules to improve code coverage and test robustness.

## Summary
Four new test modules have been added that provide comprehensive coverage of critical functionality:

- **test_dwarf_metadata_coverage.py** (681 lines): Tests for DWARF metadata parsing
  - Entry point testing (`parse_dwarf_metadata`)
  - DIE traversal and namespace scoping (`_walk_die_iter`)
  - Struct/union processing with ODR (One Definition Rule) handling
  - Member field processing including bitfield edge cases
  - Enum processing and typedef handling
  - Type info computation for all DWARF type tags
  - Fallback type info and error handling paths
  - Attribute extraction edge cases (`_attr_str`, `_attr_int`)

- **test_dumper_coverage.py** (435 lines): Tests for CastXML dump functionality
  - `_castxml_dump` internal branches (compiler detection, flags, error handling)
  - Symbol filtering by type in `dump()`
  - Language profile setting
  - `_CastxmlParser` edge cases (builtin file skipping, anonymous field expansion)
  - Pointer depth calculation and typedef chain resolution

- **test_cli_coverage.py** (309 lines): Tests for CLI command handling
  - Text format detection (`_sniff_text_format`)
  - Input resolution error paths
  - Dump command stdout output
  - Compare command ignored-flags warnings
  - Policy file loading and error handling

- **test_init_coverage.py** (22 lines): Tests for package initialization
  - Version fallback when package is not installed

## Key Implementation Details
- Uses mock objects and fixtures to isolate units under test
- Covers both happy paths and error conditions
- Tests edge cases like empty lists, missing attributes, and malformed data
- Validates ODR behavior for struct/enum definitions
- Tests namespace scoping and type qualification
- Covers MSVC detection and cross-compiler prefix handling
- Tests bitfield handling with both modern (`DW_AT_data_bit_offset`) and legacy (`DW_AT_bit_offset`) attributes

https://claude.ai/code/session_01A66QRktyZgPHBRHr6SsNWB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for CLI functionality, including command-line argument handling, error conditions, and output validation.
  * Added extensive tests for dumper functionality, covering various toolchain configurations and edge cases.
  * Added mock-based test suite for DWARF metadata parsing and type resolution.
  * Added version fallback test to ensure graceful handling when package metadata is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->