### PR TITLE
fix: downgrade SYMBOL_VERSION_REQUIRED_ADDED from BREAKING to COMPATIBLE

### DIFF
--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -239,7 +239,7 @@ BREAKING_KINDS = {
     ChangeKind.SYMBOL_SIZE_CHANGED,           # in ELF-only mode (no headers/DWARF) this may be
                                               # the sole signal for vtable/variable layout changes
     ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
-    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, # library fails to load on runtimes lacking the version
+    # NOTE: SYMBOL_VERSION_REQUIRED_ADDED moved to COMPATIBLE_KINDS (see below)
     # DWARF Sprint 3 + 4
     ChangeKind.STRUCT_SIZE_CHANGED,
     ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
@@ -312,6 +312,12 @@ COMPATIBLE_KINDS: set[ChangeKind] = {
     ChangeKind.COMMON_SYMBOL_RISK,        # STT_COMMON — risk, not proven break
     ChangeKind.SYMBOL_VERSION_REQUIRED_REMOVED,
     ChangeKind.SYMBOL_BINDING_STRENGTHENED,  # WEAK→GLOBAL: backward-compatible for most consumers
+    # New symbol version requirement: existing binaries are unaffected (already linked);
+    # this is a deployment risk (requires target OS ≥ that glibc version) but NOT a
+    # binary ABI break for already-compiled consumers. Produced false positives on
+    # real-world patch releases (libpng 1.6.43→1.6.44, zlib 1.3.0→1.3.1) where
+    # GLIBC_2.14 (released 2011) was flagged as BREAKING.
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
 
     # GLOBAL→WEAK: symbol still exported and resolvable by the dynamic
     # linker; interposition semantics change but existing binaries work.


### PR DESCRIPTION
## Problem

Patch releases (e.g. `libpng 1.6.43→1.6.44`, `zlib 1.3.0→1.3.1`) were falsely reported as **BREAKING** due to `symbol_version_required_added: GLIBC_2.14`.

## Root cause

`SYMBOL_VERSION_REQUIRED_ADDED` was in `BREAKING_KINDS`. But adding a new GLIBC version requirement (e.g. `GLIBC_2.14`, released **2011**) does NOT break existing compiled consumers — they are already linked and continue to work. It is a deployment risk only on ancient systems (< RHEL 7, < Ubuntu 14.04), not an ABI break.

## Fix

Moved `SYMBOL_VERSION_REQUIRED_ADDED` from `BREAKING_KINDS` → `COMPATIBLE_KINDS`.

The change is still **reported** in output so users are informed, but verdict stays `COMPATIBLE`.

## Verification

Stress-test: **44 pairs**, public non-Intel libs (abseil, openssl, libcurl, libpng, zlib, libxml2, zstd, snappy, libwebp, jpeg-turbo, libopenblas, re2, libevent, gmp, sqlite):

| Metric | Result |
|--------|--------|
| ✅ Correct | 28/44 |
| ❌ False Positives | **0** (was 2 before this fix) |
| ⚠️ False Negatives | 2 (libcurl 7→8, libxml2 2.12→2.13 — curl/xml did not remove ELF symbols) |
| ⚡ dump+compare vs compat discord | 0 |

### Before
```
libpng16  1.6.43→1.6.44  BREAKING  ❌ FP
libz      1.3.0→1.3.1    BREAKING  ❌ FP
```

### After
```
libpng16  1.6.43→1.6.44  COMPATIBLE  ✅
libz      1.3.0→1.3.1    COMPATIBLE  ✅
```