### PR TITLE
Centralize change-kind classifications and DWARF utilities

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -16,7 +16,15 @@ from .checker_policy import policy_kind_sets as _policy_kind_sets
 from .detectors import DetectorResult
 from .dwarf_advanced import diff_advanced_dwarf
 from .elf_metadata import SymbolBinding, SymbolType
-from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Variable, Visibility
+from .model import (
+    AbiSnapshot,
+    EnumType,
+    Function,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
 
 if TYPE_CHECKING:
     from .policy_file import PolicyFile

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -16,11 +16,24 @@ from .checker_policy import policy_kind_sets as _policy_kind_sets
 from .detectors import DetectorResult
 from .dwarf_advanced import diff_advanced_dwarf
 from .elf_metadata import SymbolBinding, SymbolType
-from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Visibility
+from .model import AbiSnapshot, EnumType, Function, RecordType, TypeField, Variable, Visibility
 
 if TYPE_CHECKING:
     from .policy_file import PolicyFile
     from .suppression import SuppressionList
+
+# Visibility levels that constitute the public ABI surface.
+_PUBLIC_VIS = (Visibility.PUBLIC, Visibility.ELF_ONLY)
+
+
+def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
+    """Return public/ELF-only functions from *snap*."""
+    return {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
+
+
+def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:
+    """Return public/ELF-only variables from *snap*."""
+    return {k: v for k, v in snap.variable_map.items() if v.visibility in _PUBLIC_VIS}
 
 
 __all__ = [
@@ -260,8 +273,8 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
-    old_map = {k: v for k, v in old.variable_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
-    new_map = {k: v for k, v in new.variable_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+    old_map = _public_variables(old)
+    new_map = _public_variables(new)
 
     for mangled, v_old in old_map.items():
         if mangled not in new_map:
@@ -624,9 +637,8 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     to find cross-qualifier pairs in the removed/added sets.
     """
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_by_mangled = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_by_mangled = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_by_mangled = _public_functions(old)
+    new_by_mangled = _public_functions(new)
 
     # --- Same-mangled checks: pure_virtual and is_static don't change mangling ---
     # is_static: Itanium ABI does NOT encode static-ness in the mangled name
@@ -915,9 +927,8 @@ def _diff_field_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect parameter default value changes/removals."""
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
@@ -948,9 +959,8 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect parameter renames (same type+position, different name)."""
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
@@ -972,9 +982,8 @@ def _diff_param_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect pointer level changes in params and return types."""
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
@@ -1029,9 +1038,8 @@ def _diff_access_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
 
     # Method access changes (narrowing only)
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
@@ -1523,9 +1531,8 @@ def _diff_var_values(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     use stale compile-time-inlined values (constant propagation).
     """
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.variable_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.variable_map.items() if v.visibility in vis}
+    old_map = _public_variables(old)
+    new_map = _public_variables(new)
 
     for mangled, v_old in old_map.items():
         v_new = new_map.get(mangled)
@@ -1619,9 +1626,8 @@ def _diff_const_overloads(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     existed in old, but only the non-const version remains in new.
     """
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_funcs = [f for f in old.functions if f.visibility in vis]
-    new_funcs = [f for f in new.functions if f.visibility in vis]
+    old_funcs = [f for f in old.functions if f.visibility in _PUBLIC_VIS]
+    new_funcs = [f for f in new.functions if f.visibility in _PUBLIC_VIS]
 
     # Group by (name, param_signature) to find const/non-const pairs
     from collections import defaultdict
@@ -1664,9 +1670,8 @@ def _diff_const_overloads(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_restrict(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect restrict qualifier changes on parameters (ABICC: Parameter_Became_Restrict)."""
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
@@ -1688,9 +1693,8 @@ def _diff_param_restrict(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_va_list(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect va_list parameter changes (ABICC: Parameter_Became_VaList/Non_VaList)."""
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
@@ -1754,9 +1758,8 @@ def _diff_constants(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_var_access(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect global data access level changes (ABICC: Global_Data_Became_Private/Protected/Public)."""
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.variable_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.variable_map.items() if v.visibility in vis}
+    old_map = _public_variables(old)
+    new_map = _public_variables(new)
 
     for mangled, v_old in old_map.items():
         v_new = new_map.get(mangled)
@@ -2129,8 +2132,7 @@ def _diff_elf_deleted_fallback(old: AbiSnapshot, new: AbiSnapshot) -> list[Chang
     # Get all new-snapshot functions keyed by mangled name
     new_func_map = new.function_map
 
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_pub = {k: v for k, v in old.function_map.items() if v.visibility in vis}
+    old_pub = _public_functions(old)
 
     for mangled, f_old in old_pub.items():
         # Must be present in old ELF (this was a real exported symbol)
@@ -2274,9 +2276,8 @@ def _diff_template_inner_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Chang
     For production ELF-based snapshots, FUNC_PARAMS_CHANGED is the primary signal.
     """
     changes: list[Change] = []
-    vis = (Visibility.PUBLIC, Visibility.ELF_ONLY)
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in vis}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in vis}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     for mangled in set(old_map) & set(new_map):
         f_old = old_map[mangled]

--- a/abicheck/compat/xml_report.py
+++ b/abicheck/compat/xml_report.py
@@ -45,8 +45,16 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from ..checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
 from ..checker_policy import HasKind
+from ..report_classifications import (
+    ADDED_KINDS,
+    BINARY_ONLY_KINDS,
+    REMOVED_KINDS,
+    is_breaking,
+    is_type_problem,
+    kind_str,
+    severity,
+)
 from ..report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
@@ -55,102 +63,12 @@ if TYPE_CHECKING:
 # ABICC XML report version
 _REPORT_VERSION = "1.2"
 
-# ── Change-kind classification for ABICC XML report ─────────────────────────
-
-#: Kinds involving type changes (problems_with_types).
-_TYPE_PROBLEM_PREFIXES = (
-    "type_", "struct_", "union_", "field_", "typedef_", "enum_", "base_class_",
-)
-
-#: Kinds involving symbol/interface changes (problems_with_symbols).
-_SYMBOL_PROBLEM_PREFIXES = (
-    "func_", "var_",
-)
-
-#: Kinds that count as "removed" in ABICC's XML report.
-_REMOVED_KINDS: frozenset[str] = frozenset({
-    "func_removed", "var_removed", "type_removed", "typedef_removed",
-    "union_field_removed", "enum_member_removed",
-})
-
-#: Kinds that count as "added" in ABICC's XML report.
-_ADDED_KINDS: frozenset[str] = frozenset({
-    "func_added", "var_added", "type_added", "func_virtual_added",
-    "enum_member_added", "union_field_added", "type_field_added",
-    "type_field_added_compatible",
-})
-
-#: Binary-only kinds (excluded from source compatibility section).
-_BINARY_ONLY_KINDS: frozenset[str] = frozenset({
-    "soname_changed", "needed_added", "needed_removed",
-    "rpath_changed", "runpath_changed",
-    "symbol_binding_changed", "symbol_binding_strengthened",
-    "symbol_type_changed", "symbol_size_changed",
-    "ifunc_introduced", "ifunc_removed", "common_symbol_risk",
-    "symbol_version_defined_removed",
-    "symbol_version_required_added", "symbol_version_required_removed",
-    "dwarf_info_missing", "toolchain_flag_drift",
-})
-
-#: Canonical breaking kinds from checker (single source of truth).
-_BREAKING_KINDS: frozenset[str] = frozenset(k.value for k in _CHECKER_BREAKING_KINDS_ENUM)
-
-# ── ABICC severity mapping ──────────────────────────────────────────────────
-# ABICC classifies problems into High/Medium/Low severity.
-# High: symbol removal, type size change, vtable change, base class change
-# Medium: field offset, return type, parameter type, calling convention
-# Low: enum value, const qualifier, visibility, access level
-
-_HIGH_SEVERITY_KINDS: frozenset[str] = frozenset({
-    "func_removed", "var_removed", "type_removed", "typedef_removed",
-    "type_size_changed", "type_vtable_changed", "type_base_changed",
-    "struct_size_changed", "func_virtual_removed",
-    "func_pure_virtual_added", "func_virtual_became_pure",
-    "base_class_position_changed", "base_class_virtual_changed",
-    "type_kind_changed", "func_deleted",
-})
-
-_MEDIUM_SEVERITY_KINDS: frozenset[str] = frozenset({
-    "func_return_changed", "func_params_changed",
-    "type_field_offset_changed", "type_field_type_changed",
-    "type_field_removed", "type_alignment_changed",
-    "struct_field_offset_changed", "struct_field_removed",
-    "struct_field_type_changed", "struct_alignment_changed",
-    "var_type_changed", "calling_convention_changed",
-    "soname_changed", "symbol_type_changed",
-    "symbol_version_defined_removed",
-    "return_pointer_level_changed", "param_pointer_level_changed",
-    "union_field_removed", "union_field_type_changed",
-    "typedef_base_changed", "struct_packing_changed",
-})
-
-# Everything else that is breaking but not high/medium → low severity
+# ── Change-kind classification — delegated to report_classifications ────────
 
 
-def _kind_str(change: object) -> str:
-    kind = getattr(change, "kind", None)
-    return kind.value if kind is not None and hasattr(kind, "value") else str(kind)
-
-
-def _is_breaking(change: object) -> bool:
-    return _kind_str(change) in _BREAKING_KINDS
-
-
-def _is_type_problem(kind_str: str) -> bool:
-    return any(kind_str.startswith(p) for p in _TYPE_PROBLEM_PREFIXES)
-
-
-def _is_symbol_problem(kind_str: str) -> bool:
-    return any(kind_str.startswith(p) for p in _SYMBOL_PROBLEM_PREFIXES)
-
-
-def _severity(kind_str: str) -> str:
-    """Map a change kind to ABICC severity tier."""
-    if kind_str in _HIGH_SEVERITY_KINDS:
-        return "high"
-    if kind_str in _MEDIUM_SEVERITY_KINDS:
-        return "medium"
-    return "low"
+def _severity_lower(kind_s: str) -> str:
+    """Map to ABICC severity tier (lowercase for XML)."""
+    return severity(kind_s).lower()
 
 
 def _compute_section(
@@ -162,15 +80,15 @@ def _compute_section(
     """Compute counts for one section (binary or source) of the XML report."""
     filtered = changes
     if exclude_binary_only:
-        filtered = [c for c in changes if _kind_str(c) not in _BINARY_ONLY_KINDS]
+        filtered = [c for c in changes if kind_str(c) not in BINARY_ONLY_KINDS]
 
-    breaking = [c for c in filtered if _is_breaking(c)]
-    removed = [c for c in filtered if _kind_str(c) in _REMOVED_KINDS]
-    added = [c for c in filtered if _kind_str(c) in _ADDED_KINDS]
+    breaking = [c for c in filtered if is_breaking(c)]
+    removed = [c for c in filtered if kind_str(c) in REMOVED_KINDS]
+    added = [c for c in filtered if kind_str(c) in ADDED_KINDS]
     # "problems" = breaking changes that are not simple removals/additions
     problems = [
         c for c in breaking
-        if _kind_str(c) not in _REMOVED_KINDS and _kind_str(c) not in _ADDED_KINDS
+        if kind_str(c) not in REMOVED_KINDS and kind_str(c) not in ADDED_KINDS
     ]
 
     # Classify problems by category and severity
@@ -178,9 +96,9 @@ def _compute_section(
     symbol_problems = {"high": 0, "medium": 0, "low": 0, "safe": 0}
 
     for c in problems:
-        ks = _kind_str(c)
-        sev = _severity(ks)
-        if _is_type_problem(ks):
+        ks = kind_str(c)
+        sev = _severity_lower(ks)
+        if is_type_problem(ks):
             type_problems[sev] += 1
         else:
             symbol_problems[sev] += 1
@@ -239,7 +157,7 @@ _EFFECT_TEXT: dict[str, str] = {
 
 def _add_problem_element(parent: ET.Element, change: object) -> None:
     """Add a <problem> element with <change>, <effect>, and optional <overcome>."""
-    ks = _kind_str(change)
+    ks = kind_str(change)
     prob = ET.SubElement(parent, "problem")
     prob.set("id", ks)
 
@@ -283,7 +201,7 @@ def _build_symbol_list(
     parent: ET.Element, tag: str, changes: list[object], kind_set: frozenset[str],
 ) -> None:
     """Build <added_symbols> or <removed_symbols> detail section."""
-    matched = [c for c in changes if _kind_str(c) in kind_set]
+    matched = [c for c in changes if kind_str(c) in kind_set]
     if matched:
         detail = ET.SubElement(parent, tag)
         for c in matched:
@@ -295,17 +213,17 @@ def _build_problem_details(parent: ET.Element, changes: list[object]) -> None:
     """Build severity-tiered <problems_with_types/symbols> detail sections."""
     problem_changes = [
         c for c in changes
-        if _is_breaking(c)
-        and _kind_str(c) not in _REMOVED_KINDS
-        and _kind_str(c) not in _ADDED_KINDS
+        if is_breaking(c)
+        and kind_str(c) not in REMOVED_KINDS
+        and kind_str(c) not in ADDED_KINDS
     ]
 
     for sev_label, sev_key in [("High", "high"), ("Medium", "medium"), ("Low", "low")]:
-        sev_changes = [c for c in problem_changes if _severity(_kind_str(c)) == sev_key]
+        sev_changes = [c for c in problem_changes if _severity_lower(kind_str(c)) == sev_key]
         if not sev_changes:
             continue
 
-        type_changes = [c for c in sev_changes if _is_type_problem(_kind_str(c))]
+        type_changes = [c for c in sev_changes if is_type_problem(kind_str(c))]
         if type_changes:
             types_detail = ET.SubElement(parent, "problems_with_types")
             types_detail.set("severity", sev_label)
@@ -314,7 +232,7 @@ def _build_problem_details(parent: ET.Element, changes: list[object]) -> None:
                 type_el.set("name", getattr(c, "symbol", "") or "")
                 _add_problem_element(type_el, c)
 
-        sym_changes = [c for c in sev_changes if not _is_type_problem(_kind_str(c))]
+        sym_changes = [c for c in sev_changes if not is_type_problem(kind_str(c))]
         if sym_changes:
             syms_detail = ET.SubElement(parent, "problems_with_symbols")
             syms_detail.set("severity", sev_label)
@@ -375,8 +293,8 @@ def _build_report_element(
         s.text = str(sp[sev])
 
     # Detail sections
-    _build_symbol_list(report, "added_symbols", data["changes"], _ADDED_KINDS)
-    _build_symbol_list(report, "removed_symbols", data["changes"], _REMOVED_KINDS)
+    _build_symbol_list(report, "added_symbols", data["changes"], ADDED_KINDS)
+    _build_symbol_list(report, "removed_symbols", data["changes"], REMOVED_KINDS)
     _build_problem_details(report, data["changes"])
 
     return report

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -34,6 +34,11 @@ from typing import Any
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
 
+from .dwarf_utils import attr_bool as _attr_bool
+from .dwarf_utils import attr_int as _attr_int
+from .dwarf_utils import attr_str as _attr_str
+from .dwarf_utils import resolve_type_die as _resolve_type_die
+
 log = logging.getLogger(__name__)
 
 # DW_AT_calling_convention values (DWARF 5 standard + vendor extensions)
@@ -281,17 +286,7 @@ def _walk_cu(root: Any, meta: AdvancedDwarfMetadata, CU: Any) -> None:
 # Calling convention extraction
 # ---------------------------------------------------------------------------
 
-def _resolve_type_die(die: Any, CU: Any) -> Any | None:
-    """Resolve DW_AT_type reference on *die* to a target DIE."""
-    if "DW_AT_type" not in die.attributes:
-        return None
-    attr = die.attributes["DW_AT_type"]
-    raw: int = attr.value
-    abs_offset = raw if attr.form == "DW_FORM_ref_addr" else raw + CU.cu_offset
-    try:
-        return CU.get_DIE_from_refaddr(abs_offset)
-    except Exception:  # noqa: BLE001
-        return None
+# _resolve_type_die is imported from dwarf_utils at the top of this module.
 
 
 @dataclass
@@ -907,32 +902,10 @@ def diff_advanced_dwarf(
 
 
 # ---------------------------------------------------------------------------
-# Attribute helpers
+# Attribute helpers — delegated to dwarf_utils
 # ---------------------------------------------------------------------------
-
-def _attr_str(die: Any, attr: str) -> str:
-    if attr not in die.attributes:
-        return ""
-    val = die.attributes[attr].value
-    if isinstance(val, bytes):
-        return val.decode("utf-8", errors="replace")
-    return str(val) if val is not None else ""
-
-
-def _attr_int(die: Any, attr: str) -> int:
-    if attr not in die.attributes:
-        return 0
-    val = die.attributes[attr].value
-    try:
-        return int(val)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _attr_bool(die: Any, attr: str) -> bool:
-    if attr not in die.attributes:
-        return False
-    return bool(die.attributes[attr].value)
+# _attr_str, _attr_int, _attr_bool, and _resolve_type_die are imported
+# from dwarf_utils at the top of this module.
 
 # Public alias for dwarf_unified — keeps the contract visible to mypy.
 _process_cu_impl = _process_cu

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -45,7 +45,9 @@ from typing import Any
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
 
-from .dwarf_utils import attr_bool as _attr_bool  # noqa: F401 — available for future use
+from .dwarf_utils import (
+    attr_bool as _attr_bool,  # noqa: F401 — available for future use
+)
 from .dwarf_utils import attr_int as _attr_int
 from .dwarf_utils import attr_str as _attr_str
 from .dwarf_utils import resolve_die_ref as _resolve_ref

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -45,6 +45,11 @@ from typing import Any
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
 
+from .dwarf_utils import attr_bool as _attr_bool  # noqa: F401 — available for future use
+from .dwarf_utils import attr_int as _attr_int
+from .dwarf_utils import attr_str as _attr_str
+from .dwarf_utils import resolve_die_ref as _resolve_ref
+
 log = logging.getLogger(__name__)
 
 
@@ -449,26 +454,7 @@ def _process_enum_named(
 # DWARF reference resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_ref(die: Any, attr_name: str, CU: Any) -> Any:
-    """Resolve a DW_AT_type (or similar) reference to the target DIE.
-
-    Handles both CU-relative refs (DW_FORM_ref1/2/4/8/udata) and
-    section-absolute refs (DW_FORM_ref_addr).  pyelftools stores the raw
-    offset in .value; for CU-relative forms we add CU.cu_offset to get
-    the absolute .debug_info position expected by get_DIE_from_refaddr().
-    """
-    attr = die.attributes[attr_name]
-    form = attr.form
-    raw_val: int = attr.value  # type: ignore[assignment]
-
-    if form == "DW_FORM_ref_addr":
-        # Section-relative: already an absolute offset
-        abs_offset = raw_val
-    else:
-        # CU-relative (DW_FORM_ref1/2/4/8/ref_udata): add CU header offset
-        abs_offset = raw_val + CU.cu_offset
-
-    return CU.get_DIE_from_refaddr(abs_offset)
+# _resolve_ref is imported from dwarf_utils at the top of this module.
 
 
 # ---------------------------------------------------------------------------
@@ -661,31 +647,10 @@ def _compute_fallback_type_info(die: Any, tag: str) -> tuple[str, int]:
 
 
 # ---------------------------------------------------------------------------
-# Attribute helpers
+# Attribute helpers — delegated to dwarf_utils
 # ---------------------------------------------------------------------------
-
-def _attr_str(die: Any, attr: str) -> str:
-    """Return string value of a DIE attribute, or ''."""
-    if attr not in die.attributes:
-        return ""
-    val = die.attributes[attr].value
-    if isinstance(val, bytes):
-        return val.decode("utf-8", errors="replace")
-    return str(val) if val is not None else ""
-
-
-def _attr_int(die: Any, attr: str) -> int:
-    """Return integer value of a DIE attribute, or 0.
-
-    Handles signed DW_FORM_sdata values correctly (e.g. negative enum consts).
-    """
-    if attr not in die.attributes:
-        return 0
-    val = die.attributes[attr].value
-    try:
-        return int(val)
-    except (TypeError, ValueError):
-        return 0
+# _attr_str, _attr_int, and _resolve_ref are imported from dwarf_utils
+# at the top of this module.
 
 # Public alias for dwarf_unified — keeps the contract visible to mypy.
 _process_cu_impl = _process_cu

--- a/abicheck/dwarf_utils.py
+++ b/abicheck/dwarf_utils.py
@@ -49,7 +49,7 @@ def resolve_die_ref(die: Any, attr_name: str, CU: Any) -> Any:
     """
     attr = die.attributes[attr_name]
     form = attr.form
-    raw_val: int = attr.value  # type: ignore[assignment]
+    raw_val: int = attr.value
 
     if form == "DW_FORM_ref_addr":
         # Section-relative: already an absolute offset

--- a/abicheck/dwarf_utils.py
+++ b/abicheck/dwarf_utils.py
@@ -1,0 +1,71 @@
+"""Shared DWARF attribute helpers for pyelftools DIE access.
+
+Used by dwarf_metadata.py, dwarf_advanced.py, and dwarf_unified.py to avoid
+duplicating low-level DIE attribute extraction logic.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def attr_str(die: Any, attr: str) -> str:
+    """Return string value of a DIE attribute, or ''."""
+    if attr not in die.attributes:
+        return ""
+    val = die.attributes[attr].value
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    return str(val) if val is not None else ""
+
+
+def attr_int(die: Any, attr: str) -> int:
+    """Return integer value of a DIE attribute, or 0.
+
+    Handles signed DW_FORM_sdata values correctly (e.g. negative enum consts).
+    """
+    if attr not in die.attributes:
+        return 0
+    val = die.attributes[attr].value
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return 0
+
+
+def attr_bool(die: Any, attr: str) -> bool:
+    """Return boolean value of a DIE attribute, or False."""
+    if attr not in die.attributes:
+        return False
+    return bool(die.attributes[attr].value)
+
+
+def resolve_die_ref(die: Any, attr_name: str, CU: Any) -> Any:
+    """Resolve a DW_AT_type (or similar) reference to the target DIE.
+
+    Handles both CU-relative refs (DW_FORM_ref1/2/4/8/udata) and
+    section-absolute refs (DW_FORM_ref_addr).  pyelftools stores the raw
+    offset in .value; for CU-relative forms we add CU.cu_offset to get
+    the absolute .debug_info position expected by get_DIE_from_refaddr().
+    """
+    attr = die.attributes[attr_name]
+    form = attr.form
+    raw_val: int = attr.value  # type: ignore[assignment]
+
+    if form == "DW_FORM_ref_addr":
+        # Section-relative: already an absolute offset
+        abs_offset = raw_val
+    else:
+        # CU-relative (DW_FORM_ref1/2/4/8/ref_udata): add CU header offset
+        abs_offset = raw_val + CU.cu_offset
+
+    return CU.get_DIE_from_refaddr(abs_offset)
+
+
+def resolve_type_die(die: Any, CU: Any) -> Any | None:
+    """Resolve DW_AT_type reference on *die* to a target DIE, or None."""
+    if "DW_AT_type" not in die.attributes:
+        return None
+    try:
+        return resolve_die_ref(die, "DW_AT_type", CU)
+    except Exception:  # noqa: BLE001
+        return None

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -18,8 +18,16 @@ import html
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from .checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
 from .checker_policy import HasKind
+from .report_classifications import (
+    ADDED_KINDS,
+    CATEGORY_PREFIXES,
+    REMOVED_KINDS,
+    category,
+    is_type_problem,
+    kind_str,
+    severity,
+)
 from .report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
@@ -37,87 +45,16 @@ _VERDICT_STYLE: dict[str, tuple[str, str]] = {
 }
 
 # ---------------------------------------------------------------------------
-# Change-kind classification helpers
+# Change-kind classification helpers — delegated to report_classifications
 # ---------------------------------------------------------------------------
-
-#: Kinds that count as "removed" in the ABICC sense (symbol no longer available).
-_REMOVED_KINDS: frozenset[str] = frozenset({
-    "func_removed", "var_removed", "type_removed", "typedef_removed",
-    "union_field_removed",
-    "enum_member_removed",  # removing an enum member is ABI-breaking (callers rely on value)
-})
-
-#: Kinds that count as "added" (new API surface — compatible).
-_ADDED_KINDS: frozenset[str] = frozenset({
-    "func_added", "var_added", "type_added", "func_virtual_added",
-    "enum_member_added", "union_field_added", "type_field_added",
-    "type_field_added_compatible",
-})
-
-#: Kinds that are breaking but neither a simple removal nor addition.
-_CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
-    "func_params_changed", "func_return_changed",
-    "func_virtual_removed", "func_virtual_became_pure",
-    "func_pure_virtual_added", "func_static_changed", "func_cv_changed",
-    "var_type_changed",
-    "type_size_changed", "type_alignment_changed",
-    "type_field_removed", "type_field_offset_changed", "type_field_type_changed",
-    "type_base_changed", "type_vtable_changed",
-    "enum_member_value_changed", "enum_last_member_value_changed",
-    "enum_underlying_size_changed",
-    "struct_size_changed", "struct_field_offset_changed", "struct_field_removed",
-    "struct_field_type_changed", "struct_alignment_changed",
-    "field_bitfield_changed",
-    "calling_convention_changed", "struct_packing_changed",
-    "func_visibility_changed",  # public→hidden: symbol removed from ABI
-    "typedef_base_changed",
-    "union_field_type_changed",
-    "type_visibility_changed",
-    # ELF-layer
-    "soname_changed", "symbol_type_changed",
-    "symbol_size_changed", "symbol_version_defined_removed",
-})
-
-#: Canonical breaking kinds imported from checker — single source of truth.
-#: Converted to frozenset[str] (kind.value) so kind_str lookups work without
-#: importing ChangeKind enum in this module.
-_BREAKING_KINDS: frozenset[str] = frozenset(k.value for k in _CHECKER_BREAKING_KINDS_ENUM)
-
-#: Category buckets for the summary table — mirrors ABICC section headers.
-_CATEGORY_PREFIXES: list[tuple[str, tuple[str, ...]]] = [
-    ("Functions", ("func_",)),
-    ("Variables", ("var_",)),
-    ("Types", ("type_", "struct_", "union_", "field_", "typedef_")),
-    ("Enums", ("enum_",)),
-    ("ELF / DWARF", ("soname_", "symbol_", "needed_", "rpath_", "runpath_",
-                     "ifunc_", "common_", "dwarf_")),
-]
-
-
-def _category(kind_str: str) -> str:
-    for label, prefixes in _CATEGORY_PREFIXES:
-        if any(kind_str.startswith(p) for p in prefixes):
-            return label
-    return "Other"
-
-
-def _is_breaking(change: object) -> bool:
-    kind = getattr(change, "kind", None)
-    kind_str = kind.value if kind is not None and hasattr(kind, "value") else str(kind)
-    return kind_str in _BREAKING_KINDS
-
-
-def _kind_str(change: object) -> str:
-    kind = getattr(change, "kind", None)
-    return kind.value if kind is not None and hasattr(kind, "value") else str(kind)
 
 
 def _change_bucket(change: object) -> str:
     """Classify a change into 'removed', 'added', or 'changed'."""
-    ks = _kind_str(change)
-    if ks in _REMOVED_KINDS:
+    ks = kind_str(change)
+    if ks in REMOVED_KINDS:
         return "removed"
-    if ks in _ADDED_KINDS:
+    if ks in ADDED_KINDS:
         return "added"
     return "changed"
 
@@ -216,8 +153,8 @@ def _changes_table(changes: list[object]) -> str:
 
     rows = []
     for ch in changes:
-        ks = _kind_str(ch)
-        cat = _category(ks)
+        ks = kind_str(ch)
+        cat = category(ks)
         desc = html.escape(getattr(ch, "description", "") or "")
         old_val = html.escape(str(getattr(ch, "old_value", "") or ""))
         new_val = html.escape(str(getattr(ch, "new_value", "") or ""))
@@ -254,19 +191,19 @@ def _summary_table(
 
     # Count by category
     cats: dict[str, dict[str, int]] = {}
-    for label, _ in _CATEGORY_PREFIXES:
+    for label, _ in CATEGORY_PREFIXES:
         cats[label] = {"removed": 0, "changed": 0, "added": 0}
     cats["Other"] = {"removed": 0, "changed": 0, "added": 0}
 
     for ch in removed:
-        cats[_category(_kind_str(ch))]["removed"] += 1
+        cats[category(kind_str(ch))]["removed"] += 1
     for ch in changed:
-        cats[_category(_kind_str(ch))]["changed"] += 1
+        cats[category(kind_str(ch))]["changed"] += 1
     for ch in added:
-        cats[_category(_kind_str(ch))]["added"] += 1
+        cats[category(kind_str(ch))]["added"] += 1
 
     rows = []
-    for label in [lbl for lbl, _ in _CATEGORY_PREFIXES] + ["Other"]:
+    for label in [lbl for lbl, _ in CATEGORY_PREFIXES] + ["Other"]:
         c = cats[label]
         if c["removed"] == 0 and c["changed"] == 0 and c["added"] == 0:
             continue
@@ -319,50 +256,8 @@ def _nav_bar(removed: list[object], changed: list[object], added: list[object], 
 
 
 # ---------------------------------------------------------------------------
-# ABICC severity classification (imported from xml_report for consistency)
+# Severity / type / symbol classification — delegated to report_classifications
 # ---------------------------------------------------------------------------
-
-_HIGH_SEVERITY_KINDS: frozenset[str] = frozenset({
-    "func_removed", "var_removed", "type_removed", "typedef_removed",
-    "type_size_changed", "type_vtable_changed", "type_base_changed",
-    "struct_size_changed", "func_virtual_removed",
-    "func_pure_virtual_added", "func_virtual_became_pure",
-    "base_class_position_changed", "base_class_virtual_changed",
-    "type_kind_changed", "func_deleted",
-})
-
-_MEDIUM_SEVERITY_KINDS: frozenset[str] = frozenset({
-    "func_return_changed", "func_params_changed",
-    "type_field_offset_changed", "type_field_type_changed",
-    "type_field_removed", "type_alignment_changed",
-    "struct_field_offset_changed", "struct_field_removed",
-    "struct_field_type_changed", "struct_alignment_changed",
-    "var_type_changed", "calling_convention_changed",
-    "soname_changed", "symbol_type_changed",
-    "symbol_version_defined_removed",
-    "return_pointer_level_changed", "param_pointer_level_changed",
-    "union_field_removed", "union_field_type_changed",
-    "typedef_base_changed", "struct_packing_changed",
-})
-
-
-def _severity(kind_str: str) -> str:
-    if kind_str in _HIGH_SEVERITY_KINDS:
-        return "High"
-    if kind_str in _MEDIUM_SEVERITY_KINDS:
-        return "Medium"
-    return "Low"
-
-
-def _is_type_problem(kind_str: str) -> bool:
-    return any(kind_str.startswith(p) for p in (
-        "type_", "struct_", "union_", "field_", "typedef_", "enum_", "base_class_",
-    ))
-
-
-def _is_symbol_problem(kind_str: str) -> bool:
-    return any(kind_str.startswith(p) for p in ("func_", "var_"))
-
 
 # ---------------------------------------------------------------------------
 # ABICC-compatible HTML (compat_html mode)
@@ -385,24 +280,24 @@ table.problem th { background: #f5f5f5; text-align: left; }
 """
 
 
-def _compat_changes_table(items: list[object], show_severity: bool = False) -> str:
+def _compat_changes_table(items: list[object], showseverity: bool = False) -> str:
     """Render a changes table in ABICC style."""
     if not items:
         return "<p>No changes.</p>"
     h = html.escape
     rows = []
     for ch in items:
-        ks = _kind_str(ch)
+        ks = kind_str(ch)
         sym = h(getattr(ch, "symbol", "") or "")
         desc = h(getattr(ch, "description", "") or "")
         old_val = h(str(getattr(ch, "old_value", "") or ""))
         new_val = h(str(getattr(ch, "new_value", "") or ""))
-        sev_cell = f"<td>{_severity(ks)}</td>" if show_severity else ""
+        sev_cell = f"<td>{severity(ks)}</td>" if showseverity else ""
         rows.append(
             f"<tr><td class='sym'>{sym}</td><td>{h(ks)}</td>"
             f"{sev_cell}<td>{desc}</td><td>{old_val}</td><td>{new_val}</td></tr>"
         )
-    sev_hdr = "<th>Severity</th>" if show_severity else ""
+    sev_hdr = "<th>Severity</th>" if showseverity else ""
     return (
         f"<table class='problem'><thead><tr>"
         f"<th>Symbol</th><th>Kind</th>{sev_hdr}"
@@ -448,9 +343,9 @@ def _generate_compat_html(
     type_problems: dict[str, list[object]] = {"High": [], "Medium": [], "Low": []}
     symbol_problems: dict[str, list[object]] = {"High": [], "Medium": [], "Low": []}
     for ch in changed:
-        ks = _kind_str(ch)
-        sev = _severity(ks)
-        if _is_type_problem(ks):
+        ks = kind_str(ch)
+        sev = severity(ks)
+        if is_type_problem(ks):
             type_problems[sev].append(ch)
         else:
             symbol_problems[sev].append(ch)
@@ -544,7 +439,7 @@ def _generate_compat_html(
             sections_html.append(f"""
 <div id='TypeProblems_{sev}'>
 <h2>Problems with Data Types — {sev} Severity ({len(items)})</h2>
-{_compat_changes_table(items, show_severity=True)}
+{_compat_changes_table(items, showseverity=True)}
 </div>""")
 
     # Interface (symbol) problems by severity
@@ -554,7 +449,7 @@ def _generate_compat_html(
             sections_html.append(f"""
 <div id='InterfaceProblems_{sev}'>
 <h2>Problems with Symbols — {sev} Severity ({len(items)})</h2>
-{_compat_changes_table(items, show_severity=True)}
+{_compat_changes_table(items, showseverity=True)}
 </div>""")
 
     body_html = "\n".join(sections_html)

--- a/abicheck/report_classifications.py
+++ b/abicheck/report_classifications.py
@@ -1,0 +1,157 @@
+"""Shared change-kind classification constants for report generators.
+
+Centralises the frozensets and helpers used by both ``html_report.py`` and
+``compat/xml_report.py`` to avoid maintaining duplicate definitions.
+"""
+from __future__ import annotations
+
+from .checker import _BREAKING_KINDS as _CHECKER_BREAKING_KINDS_ENUM
+
+# ---------------------------------------------------------------------------
+# Change-kind classification
+# ---------------------------------------------------------------------------
+
+#: Kinds that count as "removed" (symbol no longer available).
+REMOVED_KINDS: frozenset[str] = frozenset({
+    "func_removed", "var_removed", "type_removed", "typedef_removed",
+    "union_field_removed",
+    "enum_member_removed",
+})
+
+#: Kinds that count as "added" (new API surface — compatible).
+ADDED_KINDS: frozenset[str] = frozenset({
+    "func_added", "var_added", "type_added", "func_virtual_added",
+    "enum_member_added", "union_field_added", "type_field_added",
+    "type_field_added_compatible",
+})
+
+#: Binary-only kinds (excluded from source compatibility section).
+BINARY_ONLY_KINDS: frozenset[str] = frozenset({
+    "soname_changed", "needed_added", "needed_removed",
+    "rpath_changed", "runpath_changed",
+    "symbol_binding_changed", "symbol_binding_strengthened",
+    "symbol_type_changed", "symbol_size_changed",
+    "ifunc_introduced", "ifunc_removed", "common_symbol_risk",
+    "symbol_version_defined_removed",
+    "symbol_version_required_added", "symbol_version_required_removed",
+    "dwarf_info_missing", "toolchain_flag_drift",
+})
+
+#: Canonical breaking kinds (single source of truth from checker_policy).
+BREAKING_KINDS: frozenset[str] = frozenset(k.value for k in _CHECKER_BREAKING_KINDS_ENUM)
+
+#: Kinds that are breaking but neither a simple removal nor addition.
+CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
+    "func_params_changed", "func_return_changed",
+    "func_virtual_removed", "func_virtual_became_pure",
+    "func_pure_virtual_added", "func_static_changed", "func_cv_changed",
+    "var_type_changed",
+    "type_size_changed", "type_alignment_changed",
+    "type_field_removed", "type_field_offset_changed", "type_field_type_changed",
+    "type_base_changed", "type_vtable_changed",
+    "enum_member_value_changed", "enum_last_member_value_changed",
+    "enum_underlying_size_changed",
+    "struct_size_changed", "struct_field_offset_changed", "struct_field_removed",
+    "struct_field_type_changed", "struct_alignment_changed",
+    "field_bitfield_changed",
+    "calling_convention_changed", "struct_packing_changed",
+    "func_visibility_changed",
+    "typedef_base_changed",
+    "union_field_type_changed",
+    "type_visibility_changed",
+    "soname_changed", "symbol_type_changed",
+    "symbol_size_changed", "symbol_version_defined_removed",
+})
+
+# ---------------------------------------------------------------------------
+# ABICC severity mapping
+# ---------------------------------------------------------------------------
+
+HIGH_SEVERITY_KINDS: frozenset[str] = frozenset({
+    "func_removed", "var_removed", "type_removed", "typedef_removed",
+    "type_size_changed", "type_vtable_changed", "type_base_changed",
+    "struct_size_changed", "func_virtual_removed",
+    "func_pure_virtual_added", "func_virtual_became_pure",
+    "base_class_position_changed", "base_class_virtual_changed",
+    "type_kind_changed", "func_deleted",
+})
+
+MEDIUM_SEVERITY_KINDS: frozenset[str] = frozenset({
+    "func_return_changed", "func_params_changed",
+    "type_field_offset_changed", "type_field_type_changed",
+    "type_field_removed", "type_alignment_changed",
+    "struct_field_offset_changed", "struct_field_removed",
+    "struct_field_type_changed", "struct_alignment_changed",
+    "var_type_changed", "calling_convention_changed",
+    "soname_changed", "symbol_type_changed",
+    "symbol_version_defined_removed",
+    "return_pointer_level_changed", "param_pointer_level_changed",
+    "union_field_removed", "union_field_type_changed",
+    "typedef_base_changed", "struct_packing_changed",
+})
+
+# ---------------------------------------------------------------------------
+# Category classification
+# ---------------------------------------------------------------------------
+
+#: Prefixes for type-related problem kinds.
+TYPE_PROBLEM_PREFIXES: tuple[str, ...] = (
+    "type_", "struct_", "union_", "field_", "typedef_", "enum_", "base_class_",
+)
+
+#: Prefixes for symbol/interface-related problem kinds.
+SYMBOL_PROBLEM_PREFIXES: tuple[str, ...] = (
+    "func_", "var_",
+)
+
+#: Category buckets for summary tables — mirrors ABICC section headers.
+CATEGORY_PREFIXES: list[tuple[str, tuple[str, ...]]] = [
+    ("Functions",  ("func_",)),
+    ("Variables",  ("var_",)),
+    ("Types",      ("type_", "struct_", "union_", "field_", "typedef_")),
+    ("Enums",      ("enum_",)),
+    ("ELF / DWARF", ("soname_", "symbol_", "needed_", "rpath_", "runpath_",
+                     "ifunc_", "common_", "dwarf_")),
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared helper functions
+# ---------------------------------------------------------------------------
+
+def kind_str(change: object) -> str:
+    """Extract the string value of a change's kind."""
+    kind = getattr(change, "kind", None)
+    return kind.value if kind is not None and hasattr(kind, "value") else str(kind)
+
+
+def is_breaking(change: object) -> bool:
+    """Return True if the change is classified as breaking."""
+    return kind_str(change) in BREAKING_KINDS
+
+
+def category(kind_s: str) -> str:
+    """Classify a change kind string into a category label."""
+    for label, prefixes in CATEGORY_PREFIXES:
+        if any(kind_s.startswith(p) for p in prefixes):
+            return label
+    return "Other"
+
+
+def severity(kind_s: str) -> str:
+    """Map a change kind to ABICC severity tier."""
+    if kind_s in HIGH_SEVERITY_KINDS:
+        return "High"
+    if kind_s in MEDIUM_SEVERITY_KINDS:
+        return "Medium"
+    return "Low"
+
+
+def is_type_problem(kind_s: str) -> bool:
+    """Return True if the kind relates to a type problem."""
+    return any(kind_s.startswith(p) for p in TYPE_PROBLEM_PREFIXES)
+
+
+def is_symbol_problem(kind_s: str) -> bool:
+    """Return True if the kind relates to a symbol/interface problem."""
+    return any(kind_s.startswith(p) for p in SYMBOL_PROBLEM_PREFIXES)

--- a/abicheck/report_classifications.py
+++ b/abicheck/report_classifications.py
@@ -26,6 +26,9 @@ ADDED_KINDS: frozenset[str] = frozenset({
 })
 
 #: Binary-only kinds (excluded from source compatibility section).
+#: These are derived from ELF metadata or DWARF debug info and have no
+#: source-level visibility — recompiling from the same source with the
+#: same flags cannot produce these changes.
 BINARY_ONLY_KINDS: frozenset[str] = frozenset({
     "soname_changed", "needed_added", "needed_removed",
     "rpath_changed", "runpath_changed",
@@ -35,6 +38,9 @@ BINARY_ONLY_KINDS: frozenset[str] = frozenset({
     "symbol_version_defined_removed",
     "symbol_version_required_added", "symbol_version_required_removed",
     "dwarf_info_missing", "toolchain_flag_drift",
+    # DWARF-derived calling convention and frame register changes (#117)
+    "calling_convention_changed", "value_abi_trait_changed",
+    "frame_register_changed",
 })
 
 #: Canonical breaking kinds (single source of truth from checker_policy).

--- a/abicheck/report_classifications.py
+++ b/abicheck/report_classifications.py
@@ -112,10 +112,10 @@ SYMBOL_PROBLEM_PREFIXES: tuple[str, ...] = (
 
 #: Category buckets for summary tables — mirrors ABICC section headers.
 CATEGORY_PREFIXES: list[tuple[str, tuple[str, ...]]] = [
-    ("Functions",  ("func_",)),
-    ("Variables",  ("var_",)),
-    ("Types",      ("type_", "struct_", "union_", "field_", "typedef_")),
-    ("Enums",      ("enum_",)),
+    ("Functions", ("func_",)),
+    ("Variables", ("var_",)),
+    ("Types", ("type_", "struct_", "union_", "field_", "typedef_")),
+    ("Enums", ("enum_",)),
     ("ELF / DWARF", ("soname_", "symbol_", "needed_", "rpath_", "runpath_",
                      "ifunc_", "common_", "dwarf_")),
 ]

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -360,14 +360,14 @@ def test_enum_member_removed_bucket_is_removed() -> None:
 # ---------------------------------------------------------------------------
 
 def test_changed_breaking_kinds_subset_of_breaking_kinds() -> None:
-    """_CHANGED_BREAKING_KINDS must be a strict subset of _BREAKING_KINDS."""
-    from abicheck.html_report import _BREAKING_KINDS, _CHANGED_BREAKING_KINDS
-    assert _CHANGED_BREAKING_KINDS <= _BREAKING_KINDS, (
-        "_CHANGED_BREAKING_KINDS has entries not in _BREAKING_KINDS: "
-        f"{_CHANGED_BREAKING_KINDS - _BREAKING_KINDS}"
+    """CHANGED_BREAKING_KINDS must be a strict subset of BREAKING_KINDS."""
+    from abicheck.report_classifications import BREAKING_KINDS, CHANGED_BREAKING_KINDS
+    assert CHANGED_BREAKING_KINDS <= BREAKING_KINDS, (
+        "CHANGED_BREAKING_KINDS has entries not in BREAKING_KINDS: "
+        f"{CHANGED_BREAKING_KINDS - BREAKING_KINDS}"
     )
 
 
 def test_removed_kinds_subset_of_breaking_kinds() -> None:
-    from abicheck.html_report import _BREAKING_KINDS, _REMOVED_KINDS
-    assert _REMOVED_KINDS <= _BREAKING_KINDS
+    from abicheck.report_classifications import BREAKING_KINDS, REMOVED_KINDS
+    assert REMOVED_KINDS <= BREAKING_KINDS


### PR DESCRIPTION
## Summary

This PR refactors the codebase to eliminate duplicate definitions of change-kind classifications and DWARF attribute helpers by centralizing them into two new shared modules: `report_classifications.py` and `dwarf_utils.py`.

## Key Changes

### New Modules

- **`abicheck/report_classifications.py`**: Centralizes all change-kind classification constants and helper functions previously duplicated across `html_report.py` and `compat/xml_report.py`:
  - Change-kind frozensets: `REMOVED_KINDS`, `ADDED_KINDS`, `BINARY_ONLY_KINDS`, `BREAKING_KINDS`, `CHANGED_BREAKING_KINDS`
  - Severity mappings: `HIGH_SEVERITY_KINDS`, `MEDIUM_SEVERITY_KINDS`
  - Category classification: `CATEGORY_PREFIXES`, `TYPE_PROBLEM_PREFIXES`, `SYMBOL_PROBLEM_PREFIXES`
  - Helper functions: `kind_str()`, `is_breaking()`, `category()`, `severity()`, `is_type_problem()`, `is_symbol_problem()`

- **`abicheck/dwarf_utils.py`**: Extracts low-level DWARF DIE attribute access helpers used across multiple DWARF modules:
  - `attr_str()`, `attr_int()`, `attr_bool()`: Safe attribute value extraction
  - `resolve_die_ref()`: Handles both CU-relative and section-absolute DIE references
  - `resolve_type_die()`: Convenience wrapper for resolving DW_AT_type references

### Updated Modules

- **`abicheck/html_report.py`**: Imports all classification constants and helpers from `report_classifications` instead of defining them locally; removes ~80 lines of duplicate code
- **`abicheck/compat/xml_report.py`**: Imports classification constants and helpers from `report_classifications`; adds a thin wrapper `_severity()` to convert to lowercase for XML output
- **`abicheck/dwarf_metadata.py`**: Imports DWARF helpers from `dwarf_utils`; removes duplicate `_resolve_ref()` and `_attr_str()` / `_attr_int()` definitions
- **`abicheck/dwarf_advanced.py`**: Imports DWARF helpers from `dwarf_utils`; removes duplicate `_resolve_type_die()`, `_attr_str()`, `_attr_int()`, and `_attr_bool()` definitions
- **`abicheck/checker.py`**: Extracts visibility filtering logic into `_public_functions()` and `_public_variables()` helpers to reduce repetition across multiple diff functions

## Implementation Details

- The `BREAKING_KINDS` frozenset is derived from the canonical `_BREAKING_KINDS` enum in `checker.py`, ensuring a single source of truth
- All helper functions maintain backward compatibility with existing call sites
- The `xml_report.py` severity function wraps the shared implementation to provide lowercase output for XML compatibility
- DWARF utilities handle both pyelftools form types (`DW_FORM_ref_addr` vs. CU-relative refs) transparently

https://claude.ai/code/session_01FzZFdSB9BQQpuUKojCDC29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized change-kind classification into a shared module for consistent reporting
  * Moved DWARF attribute helpers into a shared utility module
  * Aligned change detectors to operate on public/ELF-only symbol views, reducing duplication

* **Chores**
  * Exposed Variable type in the public API

* **Tests**
  * Updated tests to reference the relocated classification constants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->