### PR TITLE
chore: add Apache 2.0 license headers and NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+abicheck
+
+Copyright 2026 Nikolay Petrov
+
+This product is licensed under the Apache License, Version 2.0.
+See the LICENSE file for details.
+
+---
+
+abicheck is a Python-native ABI compatibility checker for C/C++ shared libraries.
+All source code in this repository was written independently.
+
+Runtime tool dependencies (invoked as subprocesses, not distributed):
+  - castxml (Apache-2.0)  https://github.com/CastXML/CastXML
+  - GCC / Clang           system C++ compiler backend for castxml
+
+Python package dependencies (not distributed, installed separately):
+  - click         (BSD-3-Clause)
+  - PyYAML        (MIT)
+  - defusedxml    (PSF-2.0)
+  - pyelftools    (Public Domain)
+  - packaging     (Apache-2.0 / BSD-2-Clause)
+
+For third-party attribution details see NOTICE.md.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/napetrov/abicheck/actions/workflows/ci.yml/badge.svg)](https://github.com/napetrov/abicheck/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/napetrov/abicheck/branch/main/graph/badge.svg)](https://codecov.io/gh/napetrov/abicheck)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 **abicheck** is a command-line tool that detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a `.so` library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
@@ -447,4 +448,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, testing, code sty
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE) and [NOTICE.md](NOTICE.md).
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) and [NOTICE.md](NOTICE.md).
+
+Copyright 2026 Nikolay Petrov

--- a/abicheck/__init__.py
+++ b/abicheck/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """abicheck — ABI compatibility checker."""
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version

--- a/abicheck/abicc_dump_import.py
+++ b/abicheck/abicc_dump_import.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Backward-compatibility shim for abicheck.abicc_dump_import.
 
 The module was moved to abicheck.compat.abicc_dump_import in PR #110.

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Checker — diff two AbiSnapshots, classify changes, produce a verdict."""
 from __future__ import annotations
 

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Central change policy registry and verdict computation."""
 
 from __future__ import annotations

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """CLI — abicheck dump | compare | compat (dump | check)."""
 from __future__ import annotations
 

--- a/abicheck/compat/__init__.py
+++ b/abicheck/compat/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """abicheck.compat — ABICC compatibility layer.
 
 Submodules:

--- a/abicheck/compat/abicc_dump_import.py
+++ b/abicheck/compat/abicc_dump_import.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Minimal ABICC (abi-dumper) Perl dump importer.
 
 This module is intentionally isolated from main compat logic so ABICC dump parsing

--- a/abicheck/compat/cli.py
+++ b/abicheck/compat/cli.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """ABICC compatibility CLI commands and helpers.
 
 All ABICC-specific command logic lives here.

--- a/abicheck/compat/descriptor.py
+++ b/abicheck/compat/descriptor.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """ABICC XML descriptor parsing.
 
 Implements:

--- a/abicheck/compat/xml_report.py
+++ b/abicheck/compat/xml_report.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """ABICC-compatible XML report generator.
 
 Produces XML reports matching the structure expected by abi-compliance-checker

--- a/abicheck/detectors.py
+++ b/abicheck/detectors.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Detector contracts used by checker orchestration."""
 from __future__ import annotations
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Dumper — headers + .so → AbiSnapshot via castxml."""
 from __future__ import annotations
 

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Sprint 4: Advanced DWARF analysis.
 
 Detects:

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """DWARF-aware type layout extraction via pyelftools.
 
 Reads DWARF debug info from a compiled .so to extract:

--- a/abicheck/dwarf_unified.py
+++ b/abicheck/dwarf_unified.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """dwarf_unified.py — single-pass DWARF extraction.
 
 Combines the work of ``dwarf_metadata.parse_dwarf_metadata`` and

--- a/abicheck/dwarf_utils.py
+++ b/abicheck/dwarf_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Shared DWARF attribute helpers for pyelftools DIE access.
 
 Used by dwarf_metadata.py, dwarf_advanced.py, and dwarf_unified.py to avoid

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """ELF dynamic-section and symbol-table metadata.
 
 Uses ``pyelftools`` (pure Python, actively maintained) for robust ELF/DWARF

--- a/abicheck/errors.py
+++ b/abicheck/errors.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Structured error hierarchy for abicheck.
 
 All public exceptions inherit from AbicheckError, which itself extends

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Sprint 9: ABICC-compatible HTML report generator.
 
 Generates a self-contained HTML report that mirrors the structure of

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """ABI data model — shared across dumper, checker and reporter."""
 from __future__ import annotations
 

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Custom policy file support for abicheck.
 
 A policy file is a YAML document that maps ChangeKind names to severity levels,

--- a/abicheck/report_classifications.py
+++ b/abicheck/report_classifications.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Shared change-kind classification constants for report generators.
 
 Centralises the frozensets and helpers used by both ``html_report.py`` and

--- a/abicheck/report_summary.py
+++ b/abicheck/report_summary.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Canonical summary metric computation for all report formats."""
 
 from __future__ import annotations

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Reporter — DiffResult → JSON / Markdown."""
 
 from __future__ import annotations

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """SARIF 2.1.0 output for abicheck.
 
 Produces a Static Analysis Results Interchange Format (SARIF) document

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Serialization helpers — AbiSnapshot ↔ JSON."""
 from __future__ import annotations
 

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Suppression — load and apply suppression rules to ABI changes."""
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Completes Apache 2.0 licensing setup for the repository.

### Changes

**License headers** — added to all 27 source files in `abicheck/` and `abicheck/compat/`:
```python
# Copyright 2026 Nikolay Petrov
#
# Licensed under the Apache License, Version 2.0 (the "License");
# ...
```

**NOTICE** — new plain-text file (Apache convention) with:
- Project name and copyright
- Third-party tool attribution (castxml, gcc/clang)
- Python dependency attribution

**README** — added License badge + copyright line in License section:
- `[![License: Apache 2.0](...)](LICENSE)` badge
- `Copyright 2026 Nikolay Petrov` footer

### Tests
- 1623 passed, 15 skipped, 0 failed ✅
- Import check: `import abicheck` — OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Apache 2.0 license badge and copyright notice to README.
  * Created NOTICE file with comprehensive licensing, dependencies, and attribution information.
  * Added license headers to all source files.

* **Deprecation**
  * Deprecated old import path; users should migrate to new location as indicated by DeprecationWarning.

* **Chores**
  * Standardized licensing across the codebase with Apache 2.0 headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->