### PR TITLE
Add PDB parser and Windows PE debug info extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Typical problems it catches: removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and dozens of other ABI/API incompatibilities that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
-> **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary metadata and header AST analysis on all platforms; debug info cross-check uses DWARF (Linux, macOS) with PDB support planned for Windows.
+> **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary metadata and header AST analysis on all platforms; debug info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 
 ---
 
@@ -443,9 +443,9 @@ abicheck supports three binary formats, each with a dedicated metadata parser:
 |-------|-----------|:-----:|:-------:|:-----:|
 | **Binary metadata** | pyelftools / pefile / macholib | Yes | Yes | Yes |
 | **Header AST** | castxml (Clang) | Yes | Yes | Yes |
-| **Debug info cross-check** | DWARF (pyelftools) / PDB | Yes (DWARF) | Planned (PDB) | Yes (DWARF) |
+| **Debug info cross-check** | DWARF (pyelftools) / PDB | Yes (DWARF) | Yes (PDB) | Yes (DWARF) |
 
-All three layers combine for maximum accuracy. castxml is cross-platform (provided by Kitware for Linux, Windows, and macOS), so header AST analysis works everywhere. Debug info cross-check currently uses DWARF (Linux and macOS); PDB support for Windows is planned.
+All three layers combine for maximum accuracy. castxml is cross-platform (provided by Kitware for Linux, Windows, and macOS), so header AST analysis works everywhere. Debug info cross-check uses DWARF (Linux and macOS) and PDB (Windows).
 
 ### castxml compiler support
 
@@ -497,6 +497,9 @@ abicheck dump foo.dll -H foo.h --gcc-path x86_64-w64-mingw32-g++
 | `detectors.py` | ABI change detection rules |
 | `reporter.py` | Output formatting (markdown, JSON, SARIF, HTML) |
 | `suppression.py` | Suppression rules and symbol filtering |
+| `pdb_parser.py` | Minimal PDB parser (MSF container, TPI, DBI streams) |
+| `pdb_metadata.py` | PDB debug info → DwarfMetadata/AdvancedDwarfMetadata |
+| `pdb_utils.py` | PDB file location from PE debug directory |
 | `policy_file.py` | Custom YAML policy file parsing |
 
 See [Architecture reference](https://napetrov.github.io/abicheck/reference/architecture/) for the full design documentation.

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -106,6 +106,8 @@ def _dump_native_binary(
     path: Path, binary_fmt: str,
     headers: list[Path], includes: list[Path],
     version: str, lang: str,
+    *,
+    pdb_path: Path | None = None,
 ) -> AbiSnapshot:
     """Dump ABI snapshot from a native binary (ELF, PE, or Mach-O).
 
@@ -171,9 +173,27 @@ def _dump_native_binary(
             )
             for exp in pe_meta.exports
         ]
+
+        # PDB debug info extraction (struct layouts, enums, calling conventions)
+        dwarf_meta = None
+        dwarf_adv = None
+        try:
+            from .pdb_metadata import parse_pdb_debug_info
+            from .pdb_utils import locate_pdb
+            pdb_file = locate_pdb(path, pdb_path_override=pdb_path)
+            if pdb_file is not None:
+                dwarf_meta, dwarf_adv = parse_pdb_debug_info(pdb_file)
+                _logger.info("PDB debug info loaded from %s", pdb_file)
+            else:
+                _logger.debug("No PDB file found for %s", path)
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning("PDB parsing failed for %s: %s", path, exc)
+
         return AbiSnapshot(
             library=path.name, version=version,
             functions=funcs, pe=pe_meta,
+            dwarf=dwarf_meta,
+            dwarf_advanced=dwarf_adv,
             platform="pe",
         )
 
@@ -217,6 +237,7 @@ def _resolve_input(
     lang: str,
     *,
     is_elf: bool | None = None,
+    pdb_path: Path | None = None,
 ) -> AbiSnapshot:
     """Auto-detect input type and return an AbiSnapshot.
 
@@ -242,7 +263,8 @@ def _resolve_input(
     # Detect binary format from magic bytes
     binary_fmt = _detect_binary_format(path) if is_elf is None else None
     if binary_fmt is not None:
-        return _dump_native_binary(path, binary_fmt, headers, includes, version, lang)
+        return _dump_native_binary(path, binary_fmt, headers, includes, version, lang,
+                                   pdb_path=pdb_path)
 
     # Text-based formats: detect by sniffing only a small header chunk
     fmt = _sniff_text_format(path)
@@ -311,12 +333,16 @@ def main() -> None:
               help="Alternative system root directory.")
 @click.option("--nostdinc", is_flag=True, default=False,
               help="Do not search standard system include paths.")
+@click.option("--pdb-path", "pdb_path", type=click.Path(path_type=Path), default=None,
+              help="Explicit path to PDB file for Windows PE debug info. "
+                   "Overrides automatic PDB discovery from the PE debug directory.")
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
 def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...],
              version: str, lang: str, output: Path | None,
              gcc_path: str | None, gcc_prefix: str | None, gcc_options: str | None,
-             sysroot: Path | None, nostdinc: bool, verbose: bool) -> None:
+             sysroot: Path | None, nostdinc: bool, pdb_path: Path | None,
+             verbose: bool) -> None:
     """Dump ABI snapshot of a shared library to JSON.
 
     \b
@@ -333,6 +359,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
         try:
             snap = _dump_native_binary(
                 so_path, binary_fmt, list(headers), list(includes), version, lang,
+                pdb_path=pdb_path,
             )
         except click.ClickException:
             raise
@@ -514,6 +541,13 @@ def _render_output(fmt: str, result: DiffResult, old: AbiSnapshot, new: AbiSnaps
 @click.option("--policy-file", "policy_file_path",
               type=click.Path(exists=True, path_type=Path), default=None,
               help="YAML policy file with per-kind verdict overrides. Overrides --policy.")
+@click.option("--pdb-path", "pdb_path", type=click.Path(path_type=Path), default=None,
+              help="Explicit PDB file path for Windows PE debug info (applied to both sides). "
+                   "Overrides automatic PDB discovery.")
+@click.option("--old-pdb-path", "old_pdb_path", type=click.Path(path_type=Path), default=None,
+              help="PDB file path for old side only (overrides --pdb-path for old).")
+@click.option("--new-pdb-path", "new_pdb_path", type=click.Path(path_type=Path), default=None,
+              help="PDB file path for new side only (overrides --pdb-path for new).")
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
 def compare_cmd(
@@ -524,6 +558,7 @@ def compare_cmd(
     old_version: str, new_version: str,
     fmt: str, output: Path | None,
     suppress: Path | None, policy: str, policy_file_path: Path | None,
+    pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
     verbose: bool,
 ) -> None:
     """Compare two ABI surfaces and report changes.
@@ -582,10 +617,16 @@ def compare_cmd(
         old_includes_only, new_includes_only,
     )
 
+    # Resolve per-side PDB paths: --old-pdb-path overrides --pdb-path for old, etc.
+    resolved_old_pdb = old_pdb_path if old_pdb_path else pdb_path
+    resolved_new_pdb = new_pdb_path if new_pdb_path else pdb_path
+
     old = _resolve_input(old_input, old_h, old_inc, old_version, lang,
-                         is_elf=True if old_fmt == "elf" else None)
+                         is_elf=True if old_fmt == "elf" else None,
+                         pdb_path=resolved_old_pdb)
     new = _resolve_input(new_input, new_h, new_inc, new_version, lang,
-                         is_elf=True if new_fmt == "elf" else None)
+                         is_elf=True if new_fmt == "elf" else None,
+                         pdb_path=resolved_new_pdb)
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -180,7 +180,10 @@ def _dump_native_binary(
         try:
             from .pdb_metadata import parse_pdb_debug_info
             from .pdb_utils import locate_pdb
-            pdb_file = locate_pdb(path, pdb_path_override=pdb_path)
+            pdb_file = locate_pdb(
+                path, pdb_path_override=pdb_path,
+                allow_network=pdb_path is not None,
+            )
             if pdb_file is not None:
                 dwarf_meta, dwarf_adv = parse_pdb_debug_info(pdb_file)
                 _logger.info("PDB debug info loaded from %s", pdb_file)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -182,7 +182,7 @@ def _dump_native_binary(
             from .pdb_utils import locate_pdb
             pdb_file = locate_pdb(
                 path, pdb_path_override=pdb_path,
-                allow_network=pdb_path is not None,
+                allow_network=False,  # never auto-download from symbol servers
             )
             if pdb_file is not None:
                 dwarf_meta, dwarf_adv = parse_pdb_debug_info(pdb_file)

--- a/abicheck/pdb_metadata.py
+++ b/abicheck/pdb_metadata.py
@@ -36,18 +36,17 @@ from __future__ import annotations
 
 import logging
 import re
+import struct
 from pathlib import Path
 
 from .dwarf_advanced import AdvancedDwarfMetadata, ToolchainInfo
 from .dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
 from .pdb_parser import (
-    CvBitfield,
     CvEnumerator,
     CvMember,
     CvStruct,
     PdbFile,
     TypeDatabase,
-    _CC_NAMES,
     parse_pdb,
 )
 
@@ -80,7 +79,7 @@ def parse_pdb_debug_info(
 
     try:
         pdb = parse_pdb(pdb_path)
-    except (ValueError, OSError) as exc:
+    except (ValueError, OSError, struct.error) as exc:
         log.warning("parse_pdb_debug_info: failed to parse %s: %s", pdb_path, exc)
         return empty
 
@@ -230,20 +229,16 @@ def _extract_calling_conventions(
 ) -> None:
     """Extract calling conventions from LF_PROCEDURE and LF_MFUNCTION.
 
-    Populates ``adv.calling_conventions`` and ``adv.packed_structs``.
+    Populates ``adv.packed_structs``.
+
+    Note: ``adv.calling_conventions`` is NOT populated because TPI type
+    indices are not stable across builds — unrelated type insertions shift
+    all indices.  ``diff_advanced_dwarf()`` compares calling conventions by
+    key intersection, so using TPI indices as keys would cause false
+    ``calling_convention_changed`` reports.  Populating this dict requires
+    stable function identities (linkage names) from the PDB symbol stream,
+    which is not yet implemented.
     """
-    # Collect calling conventions from procedures
-    for ti, proc in types.all_procedures().items():
-        cc_name = types.calling_convention_name(proc.calling_convention)
-        # We store by type index as we don't have linkage names from TPI alone.
-        # The symbol stream would be needed for linkage names, but for ABI
-        # comparison purposes the CC set per binary is what matters.
-        adv.calling_conventions[f"<proc:0x{ti:x}>"] = cc_name
-
-    for ti, mfunc in types.all_mfunctions().items():
-        cc_name = types.calling_convention_name(mfunc.calling_convention)
-        adv.calling_conventions[f"<mfunc:0x{ti:x}>"] = cc_name
-
     # Collect packed structs
     for ti, cv_struct in types.all_structs().items():
         if cv_struct.is_forward_ref:
@@ -269,8 +264,6 @@ def _extract_toolchain_info(pdb: PdbFile, adv: AdvancedDwarfMetadata) -> None:
     # BuildNumber: bits 0-7 = minor, bits 8-14 = major, bit 15 = new format
     major = (h.build_number >> 8) & 0x7F
     minor = h.build_number & 0xFF
-    is_new = bool(h.build_number & 0x8000)
-
     # Construct a producer-like string from DBI metadata
     producer = f"MSVC {major}.{minor}"
     if machine:

--- a/abicheck/pdb_metadata.py
+++ b/abicheck/pdb_metadata.py
@@ -1,0 +1,310 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PDB-based debug info extraction for Windows PE binaries.
+
+Produces the **same** ``DwarfMetadata`` and ``AdvancedDwarfMetadata`` dataclasses
+used by the DWARF pipeline so that the checker's ``_diff_dwarf()`` and
+``_diff_advanced_dwarf()`` detectors work without modification.
+
+Phases implemented:
+  1. Struct/class/union sizes and field layouts (offsets, types) from TPI stream
+  2. Enum underlying types and member values from TPI stream
+  3. Calling convention extraction from LF_PROCEDURE / LF_MFUNCTION
+  4. Toolchain info from DBI stream header (machine type, build number)
+
+Public API
+----------
+parse_pdb_debug_info(pdb_path)
+    → tuple[DwarfMetadata, AdvancedDwarfMetadata]
+
+Requires a PDB file path.  Use ``pdb_utils.locate_pdb()`` to find the PDB
+for a given PE binary.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from .dwarf_advanced import AdvancedDwarfMetadata, ToolchainInfo
+from .dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
+from .pdb_parser import (
+    CvBitfield,
+    CvEnumerator,
+    CvMember,
+    CvStruct,
+    PdbFile,
+    TypeDatabase,
+    _CC_NAMES,
+    parse_pdb,
+)
+
+log = logging.getLogger(__name__)
+
+# Machine type values from PE/COFF spec (DBI header.machine field)
+_MACHINE_NAMES: dict[int, str] = {
+    0x014C: "x86",
+    0x0200: "IA64",
+    0x8664: "AMD64",
+    0xAA64: "ARM64",
+    0x01C0: "ARM",
+    0x01C4: "ARMNT",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_pdb_debug_info(
+    pdb_path: Path,
+) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
+    """Parse a PDB file and return (DwarfMetadata, AdvancedDwarfMetadata).
+
+    Returns ``(DwarfMetadata(), AdvancedDwarfMetadata())`` on any error.
+    Never raises.
+    """
+    empty = DwarfMetadata(), AdvancedDwarfMetadata()
+
+    try:
+        pdb = parse_pdb(pdb_path)
+    except (ValueError, OSError) as exc:
+        log.warning("parse_pdb_debug_info: failed to parse %s: %s", pdb_path, exc)
+        return empty
+
+    if pdb.types is None:
+        log.debug("parse_pdb_debug_info: no TPI stream in %s", pdb_path)
+        return empty
+
+    meta = DwarfMetadata(has_dwarf=True)
+    adv = AdvancedDwarfMetadata(has_dwarf=True)
+
+    try:
+        _extract_struct_layouts(pdb.types, meta)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_pdb_debug_info: struct extraction failed: %s", exc)
+
+    try:
+        _extract_enums(pdb.types, meta)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_pdb_debug_info: enum extraction failed: %s", exc)
+
+    try:
+        _extract_calling_conventions(pdb.types, adv)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_pdb_debug_info: calling convention extraction failed: %s", exc)
+
+    try:
+        _extract_toolchain_info(pdb, adv)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_pdb_debug_info: toolchain info extraction failed: %s", exc)
+
+    return meta, adv
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Struct/class/union layouts
+# ---------------------------------------------------------------------------
+
+def _extract_struct_layouts(types: TypeDatabase, meta: DwarfMetadata) -> None:
+    """Extract struct/class/union layouts from TPI into DwarfMetadata.structs."""
+    for ti, cv_struct in types.all_structs().items():
+        if cv_struct.is_forward_ref:
+            continue
+        if not cv_struct.name:
+            continue
+        # Skip anonymous/unnamed types and compiler-internal names
+        if cv_struct.name.startswith("<") or cv_struct.name.startswith("__"):
+            continue
+
+        fields = _extract_fields(types, cv_struct)
+
+        layout = StructLayout(
+            name=cv_struct.name,
+            byte_size=cv_struct.byte_size,
+            alignment=0,  # PDB doesn't store explicit alignment
+            fields=fields,
+            is_union=cv_struct.is_union,
+        )
+
+        # Track packed structs for advanced metadata
+        if cv_struct.is_packed:
+            # Will be picked up later in _extract_calling_conventions
+            pass
+
+        # ODR: keep first complete definition
+        if cv_struct.name not in meta.structs:
+            meta.structs[cv_struct.name] = layout
+
+
+def _extract_fields(types: TypeDatabase, cv_struct: CvStruct) -> list[FieldInfo]:
+    """Extract field information from a struct's fieldlist."""
+    if cv_struct.field_list_ti == 0:
+        return []
+
+    members = types.get_fieldlist(cv_struct.field_list_ti)
+    fields: list[FieldInfo] = []
+
+    for member in members:
+        if not isinstance(member, CvMember):
+            continue
+        if not member.name:
+            continue
+
+        type_name = types.type_name(member.type_ti)
+        byte_size = types.type_size(member.type_ti)
+        bit_offset = 0
+        bit_size = 0
+
+        # Check if the member type is a bitfield
+        bf = types._bitfields.get(member.type_ti)
+        if bf is not None:
+            bit_size = bf.length
+            bit_offset = bf.position
+            # For bitfields, resolve the underlying type name and size
+            type_name = types.type_name(bf.underlying_ti)
+            byte_size = types.type_size(bf.underlying_ti)
+
+        fields.append(FieldInfo(
+            name=member.name,
+            type_name=type_name,
+            byte_offset=member.offset,
+            byte_size=byte_size,
+            bit_offset=bit_offset,
+            bit_size=bit_size,
+        ))
+
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Enum types
+# ---------------------------------------------------------------------------
+
+def _extract_enums(types: TypeDatabase, meta: DwarfMetadata) -> None:
+    """Extract enum types from TPI into DwarfMetadata.enums."""
+    for ti, cv_enum in types.all_enums().items():
+        if cv_enum.is_forward_ref:
+            continue
+        if not cv_enum.name:
+            continue
+        if cv_enum.name.startswith("<") or cv_enum.name.startswith("__"):
+            continue
+
+        underlying_size = types.type_size(cv_enum.underlying_type_ti)
+
+        members: dict[str, int] = {}
+        field_members = types.get_fieldlist(cv_enum.field_list_ti)
+        for m in field_members:
+            if isinstance(m, CvEnumerator) and m.name:
+                members[m.name] = m.value
+
+        enum_info = EnumInfo(
+            name=cv_enum.name,
+            underlying_byte_size=underlying_size,
+            members=members,
+        )
+
+        if cv_enum.name not in meta.enums:
+            meta.enums[cv_enum.name] = enum_info
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Calling conventions
+# ---------------------------------------------------------------------------
+
+def _extract_calling_conventions(
+    types: TypeDatabase, adv: AdvancedDwarfMetadata,
+) -> None:
+    """Extract calling conventions from LF_PROCEDURE and LF_MFUNCTION.
+
+    Populates ``adv.calling_conventions`` and ``adv.packed_structs``.
+    """
+    # Collect calling conventions from procedures
+    for ti, proc in types.all_procedures().items():
+        cc_name = types.calling_convention_name(proc.calling_convention)
+        # We store by type index as we don't have linkage names from TPI alone.
+        # The symbol stream would be needed for linkage names, but for ABI
+        # comparison purposes the CC set per binary is what matters.
+        adv.calling_conventions[f"<proc:0x{ti:x}>"] = cc_name
+
+    for ti, mfunc in types.all_mfunctions().items():
+        cc_name = types.calling_convention_name(mfunc.calling_convention)
+        adv.calling_conventions[f"<mfunc:0x{ti:x}>"] = cc_name
+
+    # Collect packed structs
+    for ti, cv_struct in types.all_structs().items():
+        if cv_struct.is_forward_ref:
+            continue
+        if cv_struct.name:
+            adv.all_struct_names.add(cv_struct.name)
+            if cv_struct.is_packed:
+                adv.packed_structs.add(cv_struct.name)
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Toolchain / compiler info from DBI
+# ---------------------------------------------------------------------------
+
+def _extract_toolchain_info(pdb: PdbFile, adv: AdvancedDwarfMetadata) -> None:
+    """Extract compiler/toolchain info from DBI stream header."""
+    if pdb.dbi is None:
+        return
+
+    h = pdb.dbi.header
+    machine = _MACHINE_NAMES.get(h.machine, f"0x{h.machine:04x}")
+
+    # BuildNumber: bits 0-7 = minor, bits 8-14 = major, bit 15 = new format
+    major = (h.build_number >> 8) & 0x7F
+    minor = h.build_number & 0xFF
+    is_new = bool(h.build_number & 0x8000)
+
+    # Construct a producer-like string from DBI metadata
+    producer = f"MSVC {major}.{minor}"
+    if machine:
+        producer += f" ({machine})"
+
+    abi_flags: set[str] = set()
+    # Machine type implies ABI
+    if h.machine == 0x014C:
+        abi_flags.add("-m32")
+    elif h.machine == 0x8664:
+        abi_flags.add("-m64")
+    elif h.machine == 0xAA64:
+        abi_flags.add("-marm64")
+
+    # Check for incremental linking
+    if h.flags & 0x01:
+        abi_flags.add("/INCREMENTAL")
+
+    adv.toolchain = ToolchainInfo(
+        producer_string=producer,
+        compiler="MSVC",
+        version=f"{major}.{minor}",
+        abi_flags=abi_flags,
+    )
+
+    # Try to extract more detailed info from module names
+    for mod in pdb.dbi.modules:
+        obj = mod.obj_file_name
+        if not obj:
+            continue
+        # Look for MSVC version patterns in obj paths
+        # e.g. "C:\Program Files\...\VC\Tools\MSVC\14.36.32532\..."
+        m = re.search(r"MSVC[\\/](\d+\.\d+\.\d+)", obj)
+        if m:
+            adv.toolchain.version = m.group(1)
+            adv.toolchain.producer_string = f"MSVC {m.group(1)} ({machine})"
+            break

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -35,7 +35,7 @@ import math
 import struct
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any
 
 log = logging.getLogger(__name__)
 

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -1,0 +1,1159 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal PDB (Program Database) parser for Windows debug info.
+
+Pure-Python implementation using only the ``struct`` module — no GPL/AGPL
+dependencies.  Parses the MSF container format and exposes the TPI (type
+information) and DBI (debug information) streams needed for ABI checking.
+
+Reference specifications:
+- LLVM PDB documentation: https://llvm.org/docs/PDB/
+- Microsoft PDB: https://github.com/microsoft/microsoft-pdb
+- CodeView type records: microsoft-pdb/include/cvinfo.h (MIT licensed)
+
+Only the subset of CodeView records relevant to ABI checking is implemented:
+LF_STRUCTURE, LF_CLASS, LF_UNION, LF_ENUM, LF_FIELDLIST, LF_MEMBER,
+LF_ENUMERATE, LF_PROCEDURE, LF_MFUNCTION, LF_MODIFIER, LF_POINTER,
+LF_ARRAY, LF_BITFIELD, LF_INDEX.
+"""
+from __future__ import annotations
+
+import logging
+import math
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MSF_MAGIC = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00"
+_MSF_MAGIC_LEN = 32
+
+# Well-known stream indices
+_PDB_STREAM = 1
+_TPI_STREAM = 2
+_DBI_STREAM = 3
+_IPI_STREAM = 4
+
+# TPI header version
+_TPI_VERSION_V80 = 20040203
+
+# Type index base (indices below this are "simple" / built-in types)
+_TI_BASE = 0x1000
+
+# CodeView leaf type constants (from cvinfo.h — MIT licensed)
+LF_MODIFIER = 0x1001
+LF_POINTER = 0x1002
+LF_PROCEDURE = 0x1008
+LF_MFUNCTION = 0x1009
+LF_ARGLIST = 0x1201
+LF_FIELDLIST = 0x1203
+LF_BITFIELD = 0x1205
+LF_INDEX = 0x1602
+LF_ENUMERATE = 0x1502
+LF_ARRAY = 0x1503
+LF_CLASS = 0x1504
+LF_STRUCTURE = 0x1505
+LF_UNION = 0x1506
+LF_ENUM = 0x1507
+LF_MEMBER = 0x150D
+LF_STMEMBER = 0x150E
+LF_NESTTYPE = 0x1510
+LF_ONEMETHOD = 0x1511
+LF_VFUNCTAB = 0x1409
+LF_BCLASS = 0x1400
+LF_VBCLASS = 0x1401
+LF_IVBCLASS = 0x1402
+LF_METHOD = 0x150F
+
+# Numeric leaf constants
+LF_NUMERIC = 0x8000
+LF_CHAR = 0x8000
+LF_SHORT = 0x8001
+LF_USHORT = 0x8002
+LF_LONG = 0x8003
+LF_ULONG = 0x8004
+LF_QUADWORD = 0x8009
+LF_UQUADWORD = 0x800A
+
+# CV_call_e — calling convention values (from cvconst.h)
+CV_CALL_NEAR_C = 0x00
+CV_CALL_NEAR_PASCAL = 0x02
+CV_CALL_NEAR_FAST = 0x04
+CV_CALL_NEAR_STD = 0x07
+CV_CALL_THISCALL = 0x0B
+CV_CALL_CLRCALL = 0x16
+CV_CALL_INLINE = 0x17
+CV_CALL_NEAR_VECTOR = 0x18
+
+_CC_NAMES: dict[int, str] = {
+    0x00: "cdecl",
+    0x01: "far_cdecl",
+    0x02: "pascal",
+    0x03: "far_pascal",
+    0x04: "fastcall",
+    0x05: "far_fastcall",
+    0x07: "stdcall",
+    0x08: "far_stdcall",
+    0x09: "syscall",
+    0x0A: "far_syscall",
+    0x0B: "thiscall",
+    0x0D: "generic",
+    0x11: "armcall",
+    0x16: "clrcall",
+    0x17: "inline",
+    0x18: "vectorcall",
+}
+
+# CV_prop_t flags
+_PROP_FORWARD_REF = 0x0080
+_PROP_PACKED = 0x0800
+
+# Simple type kind (lower 8 bits of type index < 0x1000)
+_SIMPLE_TYPE_NAMES: dict[int, str] = {
+    0x00: "void",
+    0x03: "void",
+    0x10: "signed char",
+    0x11: "short",
+    0x12: "long",
+    0x13: "long long",
+    0x20: "unsigned char",
+    0x21: "unsigned short",
+    0x22: "unsigned long",
+    0x23: "unsigned long long",
+    0x30: "bool",
+    0x40: "float",
+    0x41: "double",
+    0x42: "long double",
+    0x68: "char",
+    0x69: "wchar_t",
+    0x70: "int",
+    0x71: "unsigned int",
+    0x72: "char16_t",
+    0x73: "char32_t",
+    0x74: "int",        # 32-bit signed int
+    0x75: "unsigned int",  # 32-bit unsigned int
+    0x76: "long long",  # 64-bit signed
+    0x77: "unsigned long long",  # 64-bit unsigned
+}
+
+# Simple type sizes in bytes (by kind, lower 8 bits)
+_SIMPLE_TYPE_SIZES: dict[int, int] = {
+    0x00: 0, 0x03: 0,
+    0x10: 1, 0x20: 1, 0x68: 1,
+    0x11: 2, 0x21: 2, 0x72: 2,
+    0x12: 4, 0x22: 4, 0x70: 4, 0x71: 4, 0x74: 4, 0x75: 4,
+    0x13: 8, 0x23: 8, 0x76: 8, 0x77: 8,
+    0x30: 1, 0x69: 2, 0x73: 4,
+    0x40: 4, 0x41: 8, 0x42: 16,
+}
+
+
+# ---------------------------------------------------------------------------
+# MSF (Multi-Stream File) container parser
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MsfFile:
+    """Parsed MSF container — provides access to individual streams."""
+    block_size: int
+    num_blocks: int
+    stream_sizes: list[int]
+    stream_blocks: list[list[int]]
+    _data: bytes = field(repr=False)
+
+    def stream_count(self) -> int:
+        return len(self.stream_sizes)
+
+    def stream_data(self, index: int) -> bytes:
+        """Read and concatenate all blocks for stream *index*."""
+        if index < 0 or index >= len(self.stream_sizes):
+            return b""
+        size = self.stream_sizes[index]
+        if size <= 0:
+            return b""
+        blocks = self.stream_blocks[index]
+        parts: list[bytes] = []
+        remaining = size
+        for blk in blocks:
+            offset = blk * self.block_size
+            chunk = min(remaining, self.block_size)
+            parts.append(self._data[offset:offset + chunk])
+            remaining -= chunk
+            if remaining <= 0:
+                break
+        return b"".join(parts)[:size]
+
+
+def parse_msf(data: bytes) -> MsfFile:
+    """Parse the MSF 7.0 container from raw file bytes.
+
+    Raises ``ValueError`` on invalid format.
+    """
+    if len(data) < _MSF_MAGIC_LEN + 24:
+        raise ValueError("File too small to be a PDB")
+    if data[:_MSF_MAGIC_LEN] != _MSF_MAGIC:
+        raise ValueError("Not a PDB 7.0 file (bad magic)")
+
+    (block_size, _fpm_block, num_blocks, dir_bytes, _unknown,
+     block_map_addr) = struct.unpack_from("<IIIIII", data, _MSF_MAGIC_LEN)
+
+    if block_size not in (512, 1024, 2048, 4096):
+        raise ValueError(f"Unsupported PDB block size: {block_size}")
+
+    # Number of blocks the stream directory occupies
+    dir_block_count = math.ceil(dir_bytes / block_size)
+
+    # The block at block_map_addr contains the block indices of the directory
+    bm_offset = block_map_addr * block_size
+    dir_block_indices: list[int] = []
+    for i in range(dir_block_count):
+        idx = struct.unpack_from("<I", data, bm_offset + i * 4)[0]
+        dir_block_indices.append(idx)
+
+    # Assemble the stream directory
+    dir_data = b""
+    remaining = dir_bytes
+    for blk in dir_block_indices:
+        off = blk * block_size
+        chunk = min(remaining, block_size)
+        dir_data += data[off:off + chunk]
+        remaining -= chunk
+
+    # Parse the stream directory
+    pos = 0
+    (num_streams,) = struct.unpack_from("<I", dir_data, pos)
+    pos += 4
+
+    stream_sizes: list[int] = []
+    for _ in range(num_streams):
+        (sz,) = struct.unpack_from("<i", dir_data, pos)
+        pos += 4
+        # -1 or 0xFFFFFFFF means "nil stream"
+        stream_sizes.append(max(sz, 0))
+
+    stream_blocks: list[list[int]] = []
+    for sz in stream_sizes:
+        if sz <= 0:
+            stream_blocks.append([])
+            continue
+        n_blocks = math.ceil(sz / block_size)
+        blocks = []
+        for _ in range(n_blocks):
+            (blk,) = struct.unpack_from("<I", dir_data, pos)
+            pos += 4
+            blocks.append(blk)
+        stream_blocks.append(blocks)
+
+    return MsfFile(
+        block_size=block_size,
+        num_blocks=num_blocks,
+        stream_sizes=stream_sizes,
+        stream_blocks=stream_blocks,
+        _data=data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Numeric leaf decoding
+# ---------------------------------------------------------------------------
+
+def _read_numeric_leaf(data: bytes, offset: int) -> tuple[int, int]:
+    """Read a CodeView numeric leaf at *offset*.
+
+    Returns ``(value, new_offset)`` where *new_offset* points past the leaf.
+    If the 16-bit value at *offset* is < 0x8000 it is the value itself.
+    Otherwise it is a leaf type tag followed by the actual value.
+    """
+    if offset + 2 > len(data):
+        return (0, offset + 2)
+    (val,) = struct.unpack_from("<H", data, offset)
+    if val < LF_NUMERIC:
+        return (val, offset + 2)
+    if val == LF_CHAR:
+        (v,) = struct.unpack_from("<b", data, offset + 2)
+        return (v, offset + 3)
+    if val == LF_SHORT:
+        (v,) = struct.unpack_from("<h", data, offset + 2)
+        return (v, offset + 4)
+    if val == LF_USHORT:
+        (v,) = struct.unpack_from("<H", data, offset + 2)
+        return (v, offset + 4)
+    if val == LF_LONG:
+        (v,) = struct.unpack_from("<i", data, offset + 2)
+        return (v, offset + 6)
+    if val == LF_ULONG:
+        (v,) = struct.unpack_from("<I", data, offset + 2)
+        return (v, offset + 6)
+    if val == LF_QUADWORD:
+        (v,) = struct.unpack_from("<q", data, offset + 2)
+        return (v, offset + 10)
+    if val == LF_UQUADWORD:
+        (v,) = struct.unpack_from("<Q", data, offset + 2)
+        return (v, offset + 10)
+    # Unknown numeric leaf — skip 4 bytes as a guess
+    log.debug("Unknown numeric leaf 0x%04x at offset %d", val, offset)
+    return (0, offset + 6)
+
+
+def _read_cstring(data: bytes, offset: int) -> tuple[str, int]:
+    """Read a null-terminated string at *offset*.
+
+    Returns ``(string, new_offset)`` past the null terminator.
+    """
+    end = data.find(b"\x00", offset)
+    if end < 0:
+        return ("", len(data))
+    return (data[offset:end].decode("utf-8", errors="replace"), end + 1)
+
+
+# ---------------------------------------------------------------------------
+# TPI stream parser
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TpiRecord:
+    """A single CodeView type record from the TPI stream."""
+    type_index: int
+    leaf: int       # record kind (LF_xxx)
+    data: bytes     # record payload (after leaf type field)
+
+
+@dataclass
+class TpiStream:
+    """Parsed TPI (or IPI) stream."""
+    type_index_begin: int
+    type_index_end: int
+    records: list[TpiRecord]
+    _record_map: dict[int, TpiRecord] = field(default_factory=dict, repr=False)
+
+    def get(self, ti: int) -> TpiRecord | None:
+        """Look up a type record by type index."""
+        if not self._record_map:
+            self._record_map = {r.type_index: r for r in self.records}
+        return self._record_map.get(ti)
+
+
+def parse_tpi_stream(data: bytes) -> TpiStream:
+    """Parse TPI stream header + all type records."""
+    if len(data) < 56:
+        raise ValueError("TPI stream too small")
+
+    (version, header_size, ti_begin, ti_end, type_bytes,
+     ) = struct.unpack_from("<IIIII", data, 0)
+
+    if version != _TPI_VERSION_V80:
+        log.warning("Unexpected TPI version %d (expected %d)", version, _TPI_VERSION_V80)
+
+    records: list[TpiRecord] = []
+    pos = header_size
+    end = header_size + type_bytes
+    current_ti = ti_begin
+
+    while pos + 4 <= end and current_ti < ti_end:
+        (rec_len,) = struct.unpack_from("<H", data, pos)
+        if rec_len < 2:
+            break
+        (leaf,) = struct.unpack_from("<H", data, pos + 2)
+        rec_data = data[pos + 4:pos + 2 + rec_len]
+        records.append(TpiRecord(
+            type_index=current_ti,
+            leaf=leaf,
+            data=rec_data,
+        ))
+        # Records are 4-byte aligned
+        pos += 2 + rec_len
+        pos = (pos + 3) & ~3
+        current_ti += 1
+
+    return TpiStream(
+        type_index_begin=ti_begin,
+        type_index_end=ti_end,
+        records=records,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DBI stream parser
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DbiHeader:
+    """Parsed DBI stream header (64 bytes)."""
+    version_signature: int
+    version_header: int
+    age: int
+    global_stream_index: int
+    build_number: int
+    public_stream_index: int
+    pdb_dll_version: int
+    sym_record_stream: int
+    mod_info_size: int
+    section_contribution_size: int
+    section_map_size: int
+    source_info_size: int
+    type_server_map_size: int
+    mfc_type_server_index: int
+    optional_dbg_header_size: int
+    ec_substream_size: int
+    flags: int
+    machine: int
+    padding: int
+
+
+@dataclass
+class DbiModuleInfo:
+    """One module entry from the DBI module info substream."""
+    module_name: str
+    obj_file_name: str
+    module_sym_stream: int
+    sym_byte_size: int
+    c13_byte_size: int
+    source_file_count: int
+
+
+@dataclass
+class DbiStream:
+    """Parsed DBI stream."""
+    header: DbiHeader
+    modules: list[DbiModuleInfo]
+
+
+def parse_dbi_stream(data: bytes) -> DbiStream:
+    """Parse DBI stream header and module info substream."""
+    if len(data) < 64:
+        raise ValueError("DBI stream too small")
+
+    fields = struct.unpack_from("<iIIHHHHHHiiiiiIiiHHI", data, 0)
+    header = DbiHeader(
+        version_signature=fields[0],
+        version_header=fields[1],
+        age=fields[2],
+        global_stream_index=fields[3],
+        build_number=fields[4],
+        public_stream_index=fields[5],
+        pdb_dll_version=fields[6],
+        sym_record_stream=fields[7],
+        mod_info_size=fields[9],
+        section_contribution_size=fields[10],
+        section_map_size=fields[11],
+        source_info_size=fields[12],
+        type_server_map_size=fields[13],
+        mfc_type_server_index=fields[14],
+        optional_dbg_header_size=fields[15],
+        ec_substream_size=fields[16],
+        flags=fields[17],
+        machine=fields[18],
+        padding=fields[19],
+    )
+
+    modules: list[DbiModuleInfo] = []
+    pos = 64
+    end = 64 + header.mod_info_size
+
+    while pos + 64 <= end:
+        # Fixed-size part of ModInfo (64 bytes)
+        # Layout: Unused1(4) + SectionContribEntry(28) + rest(32)
+        (_unused1, _sec, _pad1, _offset, _size, _chars,
+         _mod_idx, _pad2, _data_crc, _reloc_crc,
+         mod_flags, mod_sym_stream,
+         sym_byte_size, c11_byte_size, c13_byte_size,
+         source_file_count, _pad3, _unused2,
+         _src_name_idx, _pdb_path_idx,
+         ) = struct.unpack_from("<IHHiiIHHIIHHIIIHHIII", data, pos)
+        pos += 64
+
+        # Two null-terminated strings: ModuleName, ObjFileName
+        mod_name, pos = _read_cstring(data, pos)
+        obj_name, pos = _read_cstring(data, pos)
+
+        # 4-byte align
+        pos = (pos + 3) & ~3
+
+        modules.append(DbiModuleInfo(
+            module_name=mod_name,
+            obj_file_name=obj_name,
+            module_sym_stream=mod_sym_stream,
+            sym_byte_size=sym_byte_size,
+            c13_byte_size=c13_byte_size,
+            source_file_count=source_file_count,
+        ))
+
+    return DbiStream(header=header, modules=modules)
+
+
+# ---------------------------------------------------------------------------
+# High-level type record interpretation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CvStruct:
+    """Parsed LF_STRUCTURE / LF_CLASS / LF_UNION."""
+    type_index: int
+    name: str
+    field_list_ti: int
+    byte_size: int
+    is_forward_ref: bool
+    is_packed: bool
+    is_union: bool
+    count: int  # number of members
+
+
+@dataclass
+class CvEnum:
+    """Parsed LF_ENUM."""
+    type_index: int
+    name: str
+    field_list_ti: int
+    underlying_type_ti: int
+    is_forward_ref: bool
+    count: int
+
+
+@dataclass
+class CvMember:
+    """Parsed LF_MEMBER (non-static data member)."""
+    name: str
+    type_ti: int
+    offset: int
+    access: int  # CV_fldattr_t access bits
+
+
+@dataclass
+class CvEnumerator:
+    """Parsed LF_ENUMERATE."""
+    name: str
+    value: int
+
+
+@dataclass
+class CvProcedure:
+    """Parsed LF_PROCEDURE."""
+    type_index: int
+    return_type_ti: int
+    calling_convention: int
+    param_count: int
+    arglist_ti: int
+
+
+@dataclass
+class CvMemberFunction:
+    """Parsed LF_MFUNCTION."""
+    type_index: int
+    return_type_ti: int
+    class_type_ti: int
+    this_type_ti: int
+    calling_convention: int
+    param_count: int
+    arglist_ti: int
+    this_adjust: int
+
+
+@dataclass
+class CvPointer:
+    """Parsed LF_POINTER."""
+    type_index: int
+    referent_ti: int
+    attrs: int
+    byte_size: int
+
+
+@dataclass
+class CvArray:
+    """Parsed LF_ARRAY."""
+    type_index: int
+    element_type_ti: int
+    index_type_ti: int
+    byte_size: int
+    name: str
+
+
+@dataclass
+class CvModifier:
+    """Parsed LF_MODIFIER."""
+    type_index: int
+    modified_ti: int
+    is_const: bool
+    is_volatile: bool
+    is_unaligned: bool
+
+
+@dataclass
+class CvBitfield:
+    """Parsed LF_BITFIELD."""
+    type_index: int
+    underlying_ti: int
+    length: int   # bit width
+    position: int  # bit position
+
+
+class TypeDatabase:
+    """Indexed collection of parsed CodeView type records.
+
+    Provides name and size resolution for type indices, including simple
+    (built-in) types and user-defined types from the TPI stream.
+    """
+
+    def __init__(self, tpi: TpiStream) -> None:
+        self._tpi = tpi
+        self._structs: dict[int, CvStruct] = {}
+        self._enums: dict[int, CvEnum] = {}
+        self._procedures: dict[int, CvProcedure] = {}
+        self._mfunctions: dict[int, CvMemberFunction] = {}
+        self._pointers: dict[int, CvPointer] = {}
+        self._arrays: dict[int, CvArray] = {}
+        self._modifiers: dict[int, CvModifier] = {}
+        self._bitfields: dict[int, CvBitfield] = {}
+        self._fieldlists: dict[int, list[Any]] = {}  # ti → list of CvMember/CvEnumerator/etc.
+        self._arglists: dict[int, list[int]] = {}  # ti → list of type indices
+        # Forward-ref → definition mapping
+        self._fwd_to_def: dict[int, int] = {}
+        self._name_cache: dict[int, str] = {}
+        self._size_cache: dict[int, int] = {}
+        self._parsed = False
+
+    def parse_all(self) -> None:
+        """Parse all TPI records into structured objects."""
+        if self._parsed:
+            return
+        self._parsed = True
+
+        for rec in self._tpi.records:
+            try:
+                self._parse_record(rec)
+            except (struct.error, IndexError, ValueError) as exc:
+                log.debug("Failed to parse TPI record ti=0x%x leaf=0x%x: %s",
+                          rec.type_index, rec.leaf, exc)
+
+        # Build forward-ref → definition mapping
+        name_to_def: dict[str, int] = {}
+        for ti, s in self._structs.items():
+            if not s.is_forward_ref:
+                name_to_def[s.name] = ti
+        for ti, e in self._enums.items():
+            if not e.is_forward_ref:
+                name_to_def[e.name] = ti
+        for ti, s in self._structs.items():
+            if s.is_forward_ref and s.name in name_to_def:
+                self._fwd_to_def[ti] = name_to_def[s.name]
+        for ti, e in self._enums.items():
+            if e.is_forward_ref and e.name in name_to_def:
+                self._fwd_to_def[ti] = name_to_def[e.name]
+
+    def _parse_record(self, rec: TpiRecord) -> None:
+        d = rec.data
+        ti = rec.type_index
+        leaf = rec.leaf
+
+        if leaf in (LF_STRUCTURE, LF_CLASS):
+            self._parse_struct(ti, d, is_union=False)
+        elif leaf == LF_UNION:
+            self._parse_union(ti, d)
+        elif leaf == LF_ENUM:
+            self._parse_enum(ti, d)
+        elif leaf == LF_FIELDLIST:
+            self._parse_fieldlist(ti, d)
+        elif leaf == LF_PROCEDURE:
+            self._parse_procedure(ti, d)
+        elif leaf == LF_MFUNCTION:
+            self._parse_mfunction(ti, d)
+        elif leaf == LF_POINTER:
+            self._parse_pointer(ti, d)
+        elif leaf == LF_ARRAY:
+            self._parse_array(ti, d)
+        elif leaf == LF_MODIFIER:
+            self._parse_modifier(ti, d)
+        elif leaf == LF_BITFIELD:
+            self._parse_bitfield(ti, d)
+        elif leaf == LF_ARGLIST:
+            self._parse_arglist(ti, d)
+
+    def _parse_struct(self, ti: int, d: bytes, *, is_union: bool) -> None:
+        if len(d) < 16:
+            return
+        (count, prop, field_ti, derived_ti, vshape_ti) = struct.unpack_from(
+            "<HHIII", d, 0)
+        pos = 16
+        byte_size, pos = _read_numeric_leaf(d, pos)
+        name, _pos = _read_cstring(d, pos)
+        self._structs[ti] = CvStruct(
+            type_index=ti,
+            name=name,
+            field_list_ti=field_ti,
+            byte_size=byte_size,
+            is_forward_ref=bool(prop & _PROP_FORWARD_REF),
+            is_packed=bool(prop & _PROP_PACKED),
+            is_union=is_union,
+            count=count,
+        )
+
+    def _parse_union(self, ti: int, d: bytes) -> None:
+        if len(d) < 8:
+            return
+        (count, prop, field_ti) = struct.unpack_from("<HHI", d, 0)
+        pos = 8
+        byte_size, pos = _read_numeric_leaf(d, pos)
+        name, _pos = _read_cstring(d, pos)
+        self._structs[ti] = CvStruct(
+            type_index=ti,
+            name=name,
+            field_list_ti=field_ti,
+            byte_size=byte_size,
+            is_forward_ref=bool(prop & _PROP_FORWARD_REF),
+            is_packed=bool(prop & _PROP_PACKED),
+            is_union=True,
+            count=count,
+        )
+
+    def _parse_enum(self, ti: int, d: bytes) -> None:
+        if len(d) < 12:
+            return
+        (count, prop, utype_ti, field_ti) = struct.unpack_from("<HHII", d, 0)
+        name, _ = _read_cstring(d, 12)
+        self._enums[ti] = CvEnum(
+            type_index=ti,
+            name=name,
+            field_list_ti=field_ti,
+            underlying_type_ti=utype_ti,
+            is_forward_ref=bool(prop & _PROP_FORWARD_REF),
+            count=count,
+        )
+
+    def _parse_fieldlist(self, ti: int, d: bytes) -> None:
+        members: list[Any] = []
+        pos = 0
+        while pos + 2 <= len(d):
+            (sub_leaf,) = struct.unpack_from("<H", d, pos)
+            pos += 2
+
+            if sub_leaf == LF_MEMBER:
+                if pos + 6 > len(d):
+                    break
+                (attr, type_ti) = struct.unpack_from("<HI", d, pos)
+                pos += 6
+                offset_val, pos = _read_numeric_leaf(d, pos)
+                name, pos = _read_cstring(d, pos)
+                members.append(CvMember(
+                    name=name, type_ti=type_ti,
+                    offset=offset_val, access=attr & 0x03,
+                ))
+
+            elif sub_leaf == LF_ENUMERATE:
+                if pos + 2 > len(d):
+                    break
+                (attr,) = struct.unpack_from("<H", d, pos)
+                pos += 2
+                val, pos = _read_numeric_leaf(d, pos)
+                name, pos = _read_cstring(d, pos)
+                members.append(CvEnumerator(name=name, value=val))
+
+            elif sub_leaf == LF_INDEX:
+                # LF_INDEX — continuation to another LF_FIELDLIST
+                if pos + 4 > len(d):
+                    break
+                (cont_ti,) = struct.unpack_from("<I", d, pos + 2)
+                pos += 6
+                # Resolve continuation
+                cont_rec = self._tpi.get(cont_ti)
+                if cont_rec and cont_rec.leaf == LF_FIELDLIST:
+                    self._parse_fieldlist(cont_ti, cont_rec.data)
+                    cont_members = self._fieldlists.get(cont_ti, [])
+                    members.extend(cont_members)
+
+            elif sub_leaf in (LF_STMEMBER, LF_NESTTYPE, LF_ONEMETHOD,
+                              LF_VFUNCTAB, LF_BCLASS, LF_VBCLASS,
+                              LF_IVBCLASS, LF_METHOD):
+                # Skip known sub-records we don't need
+                pos = self._skip_subrecord(sub_leaf, d, pos)
+
+            elif sub_leaf >= 0xF0:
+                # Padding bytes — skip
+                pos = pos  # already past the leaf byte
+                continue
+
+            else:
+                # Unknown sub-record — can't safely continue
+                log.debug("Unknown fieldlist sub-leaf 0x%04x at pos %d", sub_leaf, pos)
+                break
+
+            # 4-byte alignment within fieldlist
+            pos = (pos + 3) & ~3
+
+        self._fieldlists[ti] = members
+
+    def _skip_subrecord(self, sub_leaf: int, d: bytes, pos: int) -> int:
+        """Skip known sub-record types we don't parse.
+
+        Returns the new position past the sub-record data.
+        """
+        if sub_leaf == LF_STMEMBER:
+            # attr(2) + type_ti(4) + name(variable)
+            if pos + 6 > len(d):
+                return len(d)
+            pos += 6
+            _, pos = _read_cstring(d, pos)
+            return pos
+
+        if sub_leaf == LF_NESTTYPE:
+            # padding(2) + type_ti(4) + name(variable)
+            if pos + 6 > len(d):
+                return len(d)
+            pos += 6
+            _, pos = _read_cstring(d, pos)
+            return pos
+
+        if sub_leaf == LF_ONEMETHOD:
+            # attr(2) + type_ti(4) [+ vbaseoff(4) if virtual] + name(variable)
+            if pos + 6 > len(d):
+                return len(d)
+            (attr,) = struct.unpack_from("<H", d, pos)
+            pos += 6
+            mprop = (attr >> 2) & 0x07
+            if mprop in (4, 6):  # intro/pure intro virtual — has vbaseoff
+                pos += 4
+            _, pos = _read_cstring(d, pos)
+            return pos
+
+        if sub_leaf == LF_METHOD:
+            # count(2) + mlist_ti(4) + name(variable)
+            if pos + 6 > len(d):
+                return len(d)
+            pos += 6
+            _, pos = _read_cstring(d, pos)
+            return pos
+
+        if sub_leaf == LF_VFUNCTAB:
+            # padding(2) + type_ti(4)
+            return pos + 6
+
+        if sub_leaf == LF_BCLASS:
+            # attr(2) + type_ti(4) + offset(numeric leaf)
+            if pos + 6 > len(d):
+                return len(d)
+            pos += 6
+            _, pos = _read_numeric_leaf(d, pos)
+            return pos
+
+        if sub_leaf in (LF_VBCLASS, LF_IVBCLASS):
+            # attr(2) + direct_ti(4) + vbptr_ti(4) + vbpoff(numeric) + vbtableoff(numeric)
+            if pos + 10 > len(d):
+                return len(d)
+            pos += 10
+            _, pos = _read_numeric_leaf(d, pos)
+            _, pos = _read_numeric_leaf(d, pos)
+            return pos
+
+        return len(d)  # bail out — can't continue
+
+    def _parse_procedure(self, ti: int, d: bytes) -> None:
+        if len(d) < 12:
+            return
+        (rvtype, calltype, funcattr, parmcount, arglist) = struct.unpack_from(
+            "<IBBHI", d, 0)
+        self._procedures[ti] = CvProcedure(
+            type_index=ti,
+            return_type_ti=rvtype,
+            calling_convention=calltype,
+            param_count=parmcount,
+            arglist_ti=arglist,
+        )
+
+    def _parse_mfunction(self, ti: int, d: bytes) -> None:
+        if len(d) < 24:
+            return
+        (rvtype, classtype, thistype, calltype, funcattr,
+         parmcount, arglist, thisadjust) = struct.unpack_from(
+            "<IIIBBHIi", d, 0)
+        self._mfunctions[ti] = CvMemberFunction(
+            type_index=ti,
+            return_type_ti=rvtype,
+            class_type_ti=classtype,
+            this_type_ti=thistype,
+            calling_convention=calltype,
+            param_count=parmcount,
+            arglist_ti=arglist,
+            this_adjust=thisadjust,
+        )
+
+    def _parse_pointer(self, ti: int, d: bytes) -> None:
+        if len(d) < 8:
+            return
+        (referent, attrs) = struct.unpack_from("<II", d, 0)
+        size = (attrs >> 13) & 0x3F
+        self._pointers[ti] = CvPointer(
+            type_index=ti,
+            referent_ti=referent,
+            attrs=attrs,
+            byte_size=size if size else 8,  # default to 8 for 64-bit
+        )
+
+    def _parse_array(self, ti: int, d: bytes) -> None:
+        if len(d) < 8:
+            return
+        (elem_ti, idx_ti) = struct.unpack_from("<II", d, 0)
+        pos = 8
+        byte_size, pos = _read_numeric_leaf(d, pos)
+        name, _ = _read_cstring(d, pos)
+        self._arrays[ti] = CvArray(
+            type_index=ti,
+            element_type_ti=elem_ti,
+            index_type_ti=idx_ti,
+            byte_size=byte_size,
+            name=name,
+        )
+
+    def _parse_modifier(self, ti: int, d: bytes) -> None:
+        if len(d) < 6:
+            return
+        (mod_ti, attr) = struct.unpack_from("<IH", d, 0)
+        self._modifiers[ti] = CvModifier(
+            type_index=ti,
+            modified_ti=mod_ti,
+            is_const=bool(attr & 0x01),
+            is_volatile=bool(attr & 0x02),
+            is_unaligned=bool(attr & 0x04),
+        )
+
+    def _parse_bitfield(self, ti: int, d: bytes) -> None:
+        if len(d) < 6:
+            return
+        (underlying, length, position) = struct.unpack_from("<IBB", d, 0)
+        self._bitfields[ti] = CvBitfield(
+            type_index=ti,
+            underlying_ti=underlying,
+            length=length,
+            position=position,
+        )
+
+    def _parse_arglist(self, ti: int, d: bytes) -> None:
+        if len(d) < 4:
+            return
+        (count,) = struct.unpack_from("<I", d, 0)
+        args = []
+        pos = 4
+        for _ in range(count):
+            if pos + 4 > len(d):
+                break
+            (arg_ti,) = struct.unpack_from("<I", d, pos)
+            pos += 4
+            args.append(arg_ti)
+        self._arglists[ti] = args
+
+    # --- Public query API ---
+
+    def resolve_struct(self, ti: int) -> CvStruct | None:
+        """Resolve a type index to a CvStruct (following forward refs)."""
+        real_ti = self._fwd_to_def.get(ti, ti)
+        return self._structs.get(real_ti)
+
+    def resolve_enum(self, ti: int) -> CvEnum | None:
+        """Resolve a type index to a CvEnum (following forward refs)."""
+        real_ti = self._fwd_to_def.get(ti, ti)
+        return self._enums.get(real_ti)
+
+    def get_fieldlist(self, ti: int) -> list[Any]:
+        """Get the parsed fieldlist members for type index *ti*."""
+        return self._fieldlists.get(ti, [])
+
+    def get_procedure(self, ti: int) -> CvProcedure | None:
+        return self._procedures.get(ti)
+
+    def get_mfunction(self, ti: int) -> CvMemberFunction | None:
+        return self._mfunctions.get(ti)
+
+    def all_structs(self) -> dict[int, CvStruct]:
+        return self._structs
+
+    def all_enums(self) -> dict[int, CvEnum]:
+        return self._enums
+
+    def all_procedures(self) -> dict[int, CvProcedure]:
+        return self._procedures
+
+    def all_mfunctions(self) -> dict[int, CvMemberFunction]:
+        return self._mfunctions
+
+    def type_name(self, ti: int, depth: int = 0) -> str:
+        """Resolve a type index to a human-readable name."""
+        if depth > 10:
+            return "..."
+        if ti in self._name_cache:
+            return self._name_cache[ti]
+
+        name = self._resolve_type_name(ti, depth)
+        self._name_cache[ti] = name
+        return name
+
+    def type_size(self, ti: int, depth: int = 0) -> int:
+        """Resolve a type index to its byte size."""
+        if depth > 10:
+            return 0
+        if ti in self._size_cache:
+            return self._size_cache[ti]
+
+        size = self._resolve_type_size(ti, depth)
+        self._size_cache[ti] = size
+        return size
+
+    def _resolve_type_name(self, ti: int, depth: int) -> str:
+        # Simple (built-in) types
+        if ti < _TI_BASE:
+            kind = ti & 0xFF
+            mode = (ti >> 8) & 0x0F
+            base = _SIMPLE_TYPE_NAMES.get(kind, f"<simple:0x{kind:02x}>")
+            if mode == 0:
+                return base
+            if mode in (0x02, 0x06):  # near32 / near64
+                return f"{base} *"
+            return f"{base} *"
+
+        s = self._structs.get(ti)
+        if s:
+            real_ti = self._fwd_to_def.get(ti, ti)
+            real = self._structs.get(real_ti, s)
+            return real.name
+
+        e = self._enums.get(ti)
+        if e:
+            return f"enum {e.name}"
+
+        p = self._pointers.get(ti)
+        if p:
+            ref_name = self.type_name(p.referent_ti, depth + 1)
+            mode = (p.attrs >> 5) & 0x07
+            if mode == 1:  # LValueReference
+                return f"{ref_name} &"
+            if mode == 4:  # RValueReference
+                return f"{ref_name} &&"
+            return f"{ref_name} *"
+
+        m = self._modifiers.get(ti)
+        if m:
+            base = self.type_name(m.modified_ti, depth + 1)
+            quals = []
+            if m.is_const:
+                quals.append("const")
+            if m.is_volatile:
+                quals.append("volatile")
+            return f"{' '.join(quals)} {base}" if quals else base
+
+        a = self._arrays.get(ti)
+        if a:
+            elem = self.type_name(a.element_type_ti, depth + 1)
+            return f"{elem}[]"
+
+        bf = self._bitfields.get(ti)
+        if bf:
+            return self.type_name(bf.underlying_ti, depth + 1)
+
+        proc = self._procedures.get(ti)
+        if proc:
+            return "fn(...)"
+
+        mf = self._mfunctions.get(ti)
+        if mf:
+            return "fn(...)"
+
+        return f"<ti:0x{ti:04x}>"
+
+    def _resolve_type_size(self, ti: int, depth: int) -> int:
+        if ti < _TI_BASE:
+            kind = ti & 0xFF
+            mode = (ti >> 8) & 0x0F
+            if mode == 0:
+                return _SIMPLE_TYPE_SIZES.get(kind, 0)
+            # Pointer modes: size depends on 32-bit vs 64-bit
+            if mode == 0x02:  # near32
+                return 4
+            if mode == 0x06:  # near64
+                return 8
+            return 8  # default pointer size
+
+        s = self._structs.get(ti)
+        if s:
+            real_ti = self._fwd_to_def.get(ti, ti)
+            real = self._structs.get(real_ti, s)
+            return real.byte_size
+
+        p = self._pointers.get(ti)
+        if p:
+            return p.byte_size
+
+        m = self._modifiers.get(ti)
+        if m:
+            return self.type_size(m.modified_ti, depth + 1)
+
+        a = self._arrays.get(ti)
+        if a:
+            return a.byte_size
+
+        bf = self._bitfields.get(ti)
+        if bf:
+            return self.type_size(bf.underlying_ti, depth + 1)
+
+        e = self._enums.get(ti)
+        if e:
+            return self.type_size(e.underlying_type_ti, depth + 1)
+
+        return 0
+
+    def calling_convention_name(self, cc: int) -> str:
+        """Map a CV_call_e value to a human-readable name."""
+        return _CC_NAMES.get(cc, f"cc_{cc:#x}")
+
+
+# ---------------------------------------------------------------------------
+# Top-level PDB file parser
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PdbFile:
+    """Fully parsed PDB file."""
+    msf: MsfFile
+    tpi: TpiStream | None = None
+    dbi: DbiStream | None = None
+    types: TypeDatabase | None = None
+
+
+def parse_pdb(path: Path) -> PdbFile:
+    """Parse a PDB file and return structured data.
+
+    Raises ``ValueError`` on invalid format, ``OSError`` on I/O errors.
+    """
+    data = path.read_bytes()
+    msf = parse_msf(data)
+
+    pdb = PdbFile(msf=msf)
+
+    # Parse TPI stream (stream 2)
+    if msf.stream_count() > _TPI_STREAM:
+        tpi_data = msf.stream_data(_TPI_STREAM)
+        if tpi_data:
+            pdb.tpi = parse_tpi_stream(tpi_data)
+            pdb.types = TypeDatabase(pdb.tpi)
+            pdb.types.parse_all()
+
+    # Parse DBI stream (stream 3)
+    if msf.stream_count() > _DBI_STREAM:
+        dbi_data = msf.stream_data(_DBI_STREAM)
+        if dbi_data:
+            pdb.dbi = parse_dbi_stream(dbi_data)
+
+    return pdb

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -308,7 +308,11 @@ def _read_numeric_leaf(data: bytes, offset: int) -> tuple[int, int]:
     if val == LF_UQUADWORD:
         (v,) = struct.unpack_from("<Q", data, offset + 2)
         return (v, offset + 10)
-    # Unknown numeric leaf — skip 4 bytes as a guess
+    # Unknown numeric leaf — best-effort skip of 6 bytes (2-byte tag + 4-byte
+    # value), which is correct for most CodeView numeric encodings.  May be
+    # wrong for exotic leaf types; if this fires frequently, consider adding
+    # explicit support for the leaf type.
+    # TODO: validate skip length or abort parsing when unknown leaves appear.
     log.debug("Unknown numeric leaf 0x%04x at offset %d", val, offset)
     return (0, offset + 6)
 
@@ -736,7 +740,17 @@ class TypeDatabase:
             count=count,
         )
 
-    def _parse_fieldlist(self, ti: int, d: bytes) -> None:
+    def _parse_fieldlist(
+        self, ti: int, d: bytes,
+        _visited: set[int] | None = None,
+    ) -> None:
+        if _visited is None:
+            _visited = set()
+        if ti in _visited:
+            log.warning("Circular LF_INDEX reference at ti=0x%x, skipping", ti)
+            return
+        _visited.add(ti)
+
         members: list[Any] = []
         pos = 0
         while pos + 2 <= len(d):
@@ -773,7 +787,7 @@ class TypeDatabase:
                 # Resolve continuation
                 cont_rec = self._tpi.get(cont_ti)
                 if cont_rec and cont_rec.leaf == LF_FIELDLIST:
-                    self._parse_fieldlist(cont_ti, cont_rec.data)
+                    self._parse_fieldlist(cont_ti, cont_rec.data, _visited)
                     cont_members = self._fieldlists.get(cont_ti, [])
                     members.extend(cont_members)
 

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -1162,14 +1162,21 @@ def parse_pdb(path: Path) -> PdbFile:
     if msf.stream_count() > _TPI_STREAM:
         tpi_data = msf.stream_data(_TPI_STREAM)
         if tpi_data:
-            pdb.tpi = parse_tpi_stream(tpi_data)
-            pdb.types = TypeDatabase(pdb.tpi)
-            pdb.types.parse_all()
+            try:
+                pdb.tpi = parse_tpi_stream(tpi_data)
+            except (ValueError, struct.error) as exc:
+                log.debug("Failed to parse TPI stream from %s: %s", path, exc)
+            else:
+                pdb.types = TypeDatabase(pdb.tpi)
+                pdb.types.parse_all()
 
-    # Parse DBI stream (stream 3)
+    # Parse DBI stream (stream 3) — failures are non-fatal: TPI data is preserved.
     if msf.stream_count() > _DBI_STREAM:
         dbi_data = msf.stream_data(_DBI_STREAM)
         if dbi_data:
-            pdb.dbi = parse_dbi_stream(dbi_data)
+            try:
+                pdb.dbi = parse_dbi_stream(dbi_data)
+            except (ValueError, struct.error) as exc:
+                log.debug("Failed to parse DBI stream from %s: %s", path, exc)
 
     return pdb

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -225,25 +225,34 @@ def parse_msf(data: bytes) -> MsfFile:
     bm_offset = block_map_addr * block_size
     dir_block_indices: list[int] = []
     for i in range(dir_block_count):
+        if bm_offset + i * 4 + 4 > len(data):
+            raise ValueError("PDB block map address out of bounds")
         idx = struct.unpack_from("<I", data, bm_offset + i * 4)[0]
         dir_block_indices.append(idx)
 
-    # Assemble the stream directory
-    dir_data = b""
+    # Assemble the stream directory (use list+join for O(n) rather than O(n²))
+    dir_parts: list[bytes] = []
     remaining = dir_bytes
     for blk in dir_block_indices:
         off = blk * block_size
         chunk = min(remaining, block_size)
-        dir_data += data[off:off + chunk]
+        if off + chunk > len(data):
+            raise ValueError(f"PDB block {blk} out of bounds (file too small)")
+        dir_parts.append(data[off:off + chunk])
         remaining -= chunk
+    dir_data = b"".join(dir_parts)
 
     # Parse the stream directory
     pos = 0
+    if pos + 4 > len(dir_data):
+        raise ValueError("PDB stream directory truncated (no num_streams)")
     (num_streams,) = struct.unpack_from("<I", dir_data, pos)
     pos += 4
 
     stream_sizes: list[int] = []
     for _ in range(num_streams):
+        if pos + 4 > len(dir_data):
+            raise ValueError("PDB stream directory truncated (stream sizes)")
         (sz,) = struct.unpack_from("<i", dir_data, pos)
         pos += 4
         # -1 or 0xFFFFFFFF means "nil stream"
@@ -257,6 +266,8 @@ def parse_msf(data: bytes) -> MsfFile:
         n_blocks = math.ceil(sz / block_size)
         blocks = []
         for _ in range(n_blocks):
+            if pos + 4 > len(dir_data):
+                raise ValueError("PDB stream directory truncated (block indices)")
             (blk,) = struct.unpack_from("<I", dir_data, pos)
             pos += 4
             blocks.append(blk)
@@ -754,6 +765,13 @@ class TypeDatabase:
         members: list[Any] = []
         pos = 0
         while pos + 2 <= len(d):
+            # Detect single-byte padding (LF_PAD1..LF_PADn = 0xF1..0xFF) before
+            # consuming the 2-byte sub_leaf: a byte >= 0xF0 at pos is a pad byte,
+            # not the start of a sub-leaf record.
+            if d[pos] >= 0xF0:
+                skip = d[pos] & 0x0F  # lower nibble = total pad length
+                pos += skip if skip > 0 else 1
+                continue
             (sub_leaf,) = struct.unpack_from("<H", d, pos)
             pos += 2
 
@@ -779,8 +797,9 @@ class TypeDatabase:
                 members.append(CvEnumerator(name=name, value=val))
 
             elif sub_leaf == LF_INDEX:
-                # LF_INDEX — continuation to another LF_FIELDLIST
-                if pos + 4 > len(d):
+                # LF_INDEX — continuation to another LF_FIELDLIST.
+                # Structure: 2-byte sub_leaf (already consumed) + 2-byte padding + 4-byte TI = 6 bytes total.
+                if pos + 6 > len(d):
                     break
                 (cont_ti,) = struct.unpack_from("<I", d, pos + 2)
                 pos += 6
@@ -796,13 +815,6 @@ class TypeDatabase:
                               LF_IVBCLASS, LF_METHOD):
                 # Skip known sub-records we don't need
                 pos = self._skip_subrecord(sub_leaf, d, pos)
-
-            elif sub_leaf >= 0xF0:
-                # Padding bytes — lower nibble is total pad length;
-                # subtract 2 for the two bytes already consumed.
-                skip = sub_leaf & 0x0F
-                pos += max(0, skip - 2)
-                continue
 
             else:
                 # Unknown sub-record — can't safely continue

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -312,7 +312,7 @@ def _read_numeric_leaf(data: bytes, offset: int) -> tuple[int, int]:
     # value), which is correct for most CodeView numeric encodings.  May be
     # wrong for exotic leaf types; if this fires frequently, consider adding
     # explicit support for the leaf type.
-    # TODO: validate skip length or abort parsing when unknown leaves appear.
+    # Note: skip length is not validated; unknown leaves may cause mis-alignment.
     log.debug("Unknown numeric leaf 0x%04x at offset %d", val, offset)
     return (0, offset + 6)
 

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -798,8 +798,10 @@ class TypeDatabase:
                 pos = self._skip_subrecord(sub_leaf, d, pos)
 
             elif sub_leaf >= 0xF0:
-                # Padding bytes — skip
-                pos = pos  # already past the leaf byte
+                # Padding bytes — lower nibble is total pad length;
+                # subtract 2 for the two bytes already consumed.
+                skip = sub_leaf & 0x0F
+                pos += max(0, skip - 2)
                 continue
 
             else:

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -38,11 +38,16 @@ _DEBUG_TYPE_CODEVIEW = 2
 def _is_network_path(p: str | Path) -> bool:
     """Return True if *p* looks like a UNC or network path."""
     s = str(p)
-    if s.startswith("\\\\") or s.startswith("//"):
+    # Normalise to backslashes for uniform checking
+    s_norm = s.replace("/", "\\")
+    if s_norm.startswith("\\\\"):
         return True
-    # Also check via PureWindowsPath — catches normalised UNC anchors.
+    # Also check Win32 extended UNC prefix \\?\UNC\
+    if s_norm.startswith("\\\\?\\UNC\\"):
+        return True
+    # Fallback via PureWindowsPath — catches edge cases after normalisation
     try:
-        anchor = PureWindowsPath(s).anchor
+        anchor = PureWindowsPath(s_norm).anchor
         if anchor.startswith("\\\\"):
             return True
     except Exception:  # noqa: BLE001
@@ -50,22 +55,61 @@ def _is_network_path(p: str | Path) -> bool:
     return False
 
 
+# Maximum CodeView debug directory entry size we're willing to allocate.
+# PDB filenames are at most MAX_PATH (260) chars; RSDS header is 24 bytes.
+_MAX_CODEVIEW_SIZE = 4096
+
+
 def _resolve_embedded_pdb(
     dll_path: Path,
     allow_network: bool,
 ) -> Path | None:
-    """Try to locate a PDB via the path embedded in the PE debug directory."""
+    """Try to locate a PDB via the path embedded in the PE debug directory.
+
+    Only considers the PDB path embedded in the PE's CodeView debug entry.
+    The resolved path must be either:
+    - An absolute path sharing the same drive/root as the DLL (prevents
+      path traversal to unrelated filesystem locations), or
+    - A relative path resolved against the DLL's directory.
+
+    Network/UNC paths are always blocked unless *allow_network* is True.
+    """
     embedded = _extract_pdb_path_from_pe(dll_path)
     if embedded is None:
         return None
     embedded_path = Path(embedded)
+
+    # Block network/UNC paths during auto-discovery
     if not allow_network and _is_network_path(embedded_path):
         log.debug(
             "locate_pdb: skipping network path %s (use --pdb-path to override)", embedded
         )
+        # Still try the filename-only fallback (always local)
+        local = dll_path.parent / embedded_path.name
+        if local.is_file():
+            return local
+        return None
+
+    # Security: only trust absolute embedded paths if they share the same
+    # drive/root as the DLL itself, to prevent traversal to arbitrary locations.
+    if embedded_path.is_absolute():
+        try:
+            dll_root = Path(dll_path).resolve().anchor
+            emb_root = embedded_path.resolve().anchor
+            if dll_root and emb_root and dll_root.lower() != emb_root.lower():
+                log.debug(
+                    "locate_pdb: skipping embedded path on different drive %s", embedded
+                )
+                embedded_path = embedded_path.with_drive("") if hasattr(embedded_path, "with_drive") else embedded_path
+                # Fall through to filename-only lookup below
+            elif embedded_path.is_file():
+                return embedded_path
+        except (ValueError, OSError):
+            pass  # drive comparison failed; fall through to filename-only
     elif embedded_path.is_file():
         return embedded_path
-    # Fall back to same filename in the DLL's directory (always local)
+
+    # Fall back to same filename in the DLL's directory (always local, no traversal)
     local = dll_path.parent / embedded_path.name
     if local.is_file():
         return local
@@ -138,7 +182,9 @@ def _extract_pdb_path_from_pe(dll_path: Path) -> str | None:
                 # Fall back to raw data via AddressOfRawData (RVA),
                 # which is what pe.get_data() expects.
                 size = dbg.struct.SizeOfData
-                if size and dbg.struct.AddressOfRawData:
+                # Sanity cap: CodeView header + MAX_PATH is well under 1 KB.
+                # Reject oversized entries to prevent OOM from crafted PEs.
+                if size and size <= _MAX_CODEVIEW_SIZE and dbg.struct.AddressOfRawData:
                     raw: bytes = pe.get_data(dbg.struct.AddressOfRawData, size)
                     if raw and len(raw) >= 24 and raw[:4] == _RSDS_SIG:
                         # RSDS: 4 (sig) + 16 (GUID) + 4 (age) + filename

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -50,6 +50,28 @@ def _is_network_path(p: str | Path) -> bool:
     return False
 
 
+def _resolve_embedded_pdb(
+    dll_path: Path,
+    allow_network: bool,
+) -> Path | None:
+    """Try to locate a PDB via the path embedded in the PE debug directory."""
+    embedded = _extract_pdb_path_from_pe(dll_path)
+    if embedded is None:
+        return None
+    embedded_path = Path(embedded)
+    if not allow_network and _is_network_path(embedded_path):
+        log.debug(
+            "locate_pdb: skipping network path %s (use --pdb-path to override)", embedded
+        )
+    elif embedded_path.is_file():
+        return embedded_path
+    # Fall back to same filename in the DLL's directory (always local)
+    local = dll_path.parent / embedded_path.name
+    if local.is_file():
+        return local
+    return None
+
+
 def locate_pdb(
     dll_path: Path,
     *,
@@ -76,21 +98,9 @@ def locate_pdb(
         log.warning("locate_pdb: explicit pdb_path does not exist: %s", pdb_path_override)
         return None
 
-    # Try extracting from PE debug directory
-    embedded = _extract_pdb_path_from_pe(dll_path)
-    if embedded is not None:
-        embedded_path = Path(embedded)
-        # Skip network paths during auto-discovery unless allowed
-        if not allow_network and _is_network_path(embedded_path):
-            log.debug("locate_pdb: skipping network path %s (use --pdb-path to override)", embedded)
-        else:
-            # Try the embedded path directly
-            if embedded_path.is_file():
-                return embedded_path
-        # Try just the filename in the DLL's directory (always local)
-        local = dll_path.parent / embedded_path.name
-        if local.is_file():
-            return local
+    found = _resolve_embedded_pdb(dll_path, allow_network)
+    if found is not None:
+        return found
 
     # Fallback: same name with .pdb extension
     stem_pdb = dll_path.with_suffix(".pdb")

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -79,13 +79,17 @@ def _resolve_embedded_pdb(
         return None
     embedded_path = Path(embedded)
 
+    # Use Windows path semantics to extract the basename — on non-Windows hosts
+    # Path(r"C:\build\foo.pdb").name returns the whole string, not "foo.pdb".
+    embedded_name: str = PureWindowsPath(embedded).name or embedded_path.name
+
     # Block network/UNC paths during auto-discovery
     if not allow_network and _is_network_path(embedded_path):
         log.debug(
             "locate_pdb: skipping network path %s (use --pdb-path to override)", embedded
         )
         # Still try the filename-only fallback (always local)
-        local = dll_path.parent / embedded_path.name
+        local = dll_path.parent / embedded_name
         if local.is_file():
             return local
         return None
@@ -110,7 +114,7 @@ def _resolve_embedded_pdb(
         return embedded_path
 
     # Fall back to same filename in the DLL's directory (always local, no traversal)
-    local = dll_path.parent / embedded_path.name
+    local = dll_path.parent / embedded_name
     if local.is_file():
         return local
     return None
@@ -186,9 +190,13 @@ def _extract_pdb_path_from_pe(dll_path: Path) -> str | None:
                 # Reject oversized entries to prevent OOM from crafted PEs.
                 if size and size <= _MAX_CODEVIEW_SIZE and dbg.struct.AddressOfRawData:
                     raw: bytes = pe.get_data(dbg.struct.AddressOfRawData, size)
-                    if raw and len(raw) >= 24 and raw[:4] == _RSDS_SIG:
+                    if raw[:4] == _RSDS_SIG and len(raw) >= 24:
                         # RSDS: 4 (sig) + 16 (GUID) + 4 (age) + filename
                         pdb_name = raw[24:].split(b"\x00", 1)[0]
+                        return pdb_name.decode("utf-8", errors="replace")
+                    if raw[:4] == _NB10_SIG and len(raw) >= 16:
+                        # NB10: 4 (sig) + 4 (offset) + 4 (timestamp) + 4 (age) + filename
+                        pdb_name = raw[16:].split(b"\x00", 1)[0]
                         return pdb_name.decode("utf-8", errors="replace")
                 continue
 

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -127,9 +127,8 @@ def _extract_pdb_path_from_pe(dll_path: Path) -> str | None:
             if data is None:
                 # Fall back to raw data via AddressOfRawData (RVA),
                 # which is what pe.get_data() expects.
-                offset = dbg.struct.PointerToRawData
                 size = dbg.struct.SizeOfData
-                if offset and size:
+                if size and dbg.struct.AddressOfRawData:
                     raw: bytes = pe.get_data(dbg.struct.AddressOfRawData, size)
                     if raw and len(raw) >= 24 and raw[:4] == _RSDS_SIG:
                         # RSDS: 4 (sig) + 16 (GUID) + 4 (age) + filename

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -46,7 +46,7 @@ def _is_network_path(p: str | Path) -> bool:
         if anchor.startswith("\\\\"):
             return True
     except Exception:  # noqa: BLE001
-        pass
+        log.debug("PureWindowsPath parsing failed for %r", s, exc_info=True)
     return False
 
 
@@ -125,11 +125,12 @@ def _extract_pdb_path_from_pe(dll_path: Path) -> str | None:
 
             data = dbg.entry
             if data is None:
-                # Fall back to raw data at PointerToRawData
+                # Fall back to raw data via AddressOfRawData (RVA),
+                # which is what pe.get_data() expects.
                 offset = dbg.struct.PointerToRawData
                 size = dbg.struct.SizeOfData
                 if offset and size:
-                    raw = pe.get_data(dbg.struct.AddressOfRawData, size)
+                    raw: bytes = pe.get_data(dbg.struct.AddressOfRawData, size)
                     if raw and len(raw) >= 24 and raw[:4] == _RSDS_SIG:
                         # RSDS: 4 (sig) + 16 (GUID) + 4 (age) + filename
                         pdb_name = raw[24:].split(b"\x00", 1)[0]

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 import struct
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pefile  # type: ignore[import-untyped]
 
@@ -35,13 +35,38 @@ _NB10_SIG = b"NB10"
 _DEBUG_TYPE_CODEVIEW = 2
 
 
-def locate_pdb(dll_path: Path, *, pdb_path_override: Path | None = None) -> Path | None:
+def _is_network_path(p: str | Path) -> bool:
+    """Return True if *p* looks like a UNC or network path."""
+    s = str(p)
+    if s.startswith("\\\\") or s.startswith("//"):
+        return True
+    # Also check via PureWindowsPath — catches normalised UNC anchors.
+    try:
+        anchor = PureWindowsPath(s).anchor
+        if anchor.startswith("\\\\"):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
+def locate_pdb(
+    dll_path: Path,
+    *,
+    pdb_path_override: Path | None = None,
+    allow_network: bool = False,
+) -> Path | None:
     """Find the PDB file for a PE binary.
 
     Search order:
     1. Explicit ``pdb_path_override`` (from --pdb-path CLI flag)
     2. PDB path embedded in PE debug directory (RSDS/NB10 CodeView entry)
     3. Same directory as the DLL, with ``.pdb`` extension
+
+    When *allow_network* is False (default), any candidate whose path looks
+    like a UNC/network share (``\\\\server\\...``) is silently skipped during
+    auto-discovery.  An explicit *pdb_path_override* is always honoured
+    regardless of *allow_network*.
 
     Returns the path if found (and the file exists), otherwise ``None``.
     """
@@ -55,10 +80,14 @@ def locate_pdb(dll_path: Path, *, pdb_path_override: Path | None = None) -> Path
     embedded = _extract_pdb_path_from_pe(dll_path)
     if embedded is not None:
         embedded_path = Path(embedded)
-        # Try the embedded path directly
-        if embedded_path.is_file():
-            return embedded_path
-        # Try just the filename in the DLL's directory
+        # Skip network paths during auto-discovery unless allowed
+        if not allow_network and _is_network_path(embedded_path):
+            log.debug("locate_pdb: skipping network path %s (use --pdb-path to override)", embedded)
+        else:
+            # Try the embedded path directly
+            if embedded_path.is_file():
+                return embedded_path
+        # Try just the filename in the DLL's directory (always local)
         local = dll_path.parent / embedded_path.name
         if local.is_file():
             return local

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -77,14 +77,14 @@ def _resolve_embedded_pdb(
     embedded = _extract_pdb_path_from_pe(dll_path)
     if embedded is None:
         return None
-    embedded_path = Path(embedded)
 
-    # Use Windows path semantics to extract the basename — on non-Windows hosts
-    # Path(r"C:\build\foo.pdb").name returns the whole string, not "foo.pdb".
-    embedded_name: str = PureWindowsPath(embedded).name or embedded_path.name
+    # Use PureWindowsPath for Windows-aware path parsing: drive/absolute checks
+    # and basename extraction work correctly on all host platforms.
+    pwin = PureWindowsPath(embedded)
+    embedded_name: str = pwin.name or Path(embedded).name
 
     # Block network/UNC paths during auto-discovery
-    if not allow_network and _is_network_path(embedded_path):
+    if not allow_network and _is_network_path(embedded):
         log.debug(
             "locate_pdb: skipping network path %s (use --pdb-path to override)", embedded
         )
@@ -94,24 +94,39 @@ def _resolve_embedded_pdb(
             return local
         return None
 
-    # Security: only trust absolute embedded paths if they share the same
-    # drive/root as the DLL itself, to prevent traversal to arbitrary locations.
-    if embedded_path.is_absolute():
+    # Security: only trust absolute Windows paths (drive-letter or rooted) if
+    # they share the same drive/root as the DLL itself.  Use PureWindowsPath so
+    # that "C:\build\foo.pdb" is recognised as absolute on POSIX hosts too.
+    if pwin.drive or pwin.is_absolute():
         try:
-            dll_root = Path(dll_path).resolve().anchor
-            emb_root = embedded_path.resolve().anchor
-            if dll_root and emb_root and dll_root.lower() != emb_root.lower():
+            dll_drive = PureWindowsPath(str(Path(dll_path).resolve())).drive
+            emb_drive = pwin.drive
+            if dll_drive and emb_drive and dll_drive.lower() != emb_drive.lower():
                 log.debug(
                     "locate_pdb: skipping embedded path on different drive %s", embedded
                 )
-                embedded_path = embedded_path.with_drive("") if hasattr(embedded_path, "with_drive") else embedded_path
                 # Fall through to filename-only lookup below
-            elif embedded_path.is_file():
-                return embedded_path
+            else:
+                # Construct a host-native Path for the filesystem check.
+                # For relative Windows paths (backslash but no drive), join parts.
+                if pwin.drive:
+                    candidate = Path(*pwin.parts[1:]) if len(pwin.parts) > 1 else Path(embedded_name)
+                    candidate = dll_path.parent / candidate
+                else:
+                    candidate = Path(embedded)
+                if candidate.is_file():
+                    return candidate
         except (ValueError, OSError):
             pass  # drive comparison failed; fall through to filename-only
-    elif embedded_path.is_file():
-        return embedded_path
+    else:
+        # Relative path: resolve against DLL directory and guard against traversal.
+        candidate = dll_path.parent / Path(*pwin.parts) if pwin.parts else dll_path.parent / embedded_name
+        try:
+            candidate.resolve().relative_to(dll_path.parent.resolve())
+            if candidate.is_file():
+                return candidate
+        except (ValueError, OSError):
+            pass  # traversal attempt or resolution error; fall through
 
     # Fall back to same filename in the DLL's directory (always local, no traversal)
     local = dll_path.parent / embedded_name

--- a/abicheck/pdb_utils.py
+++ b/abicheck/pdb_utils.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PDB file location utilities for Windows PE binaries.
+
+Extracts the PDB path and GUID from the PE debug directory
+(IMAGE_DEBUG_TYPE_CODEVIEW / RSDS signature) using ``pefile``.
+"""
+from __future__ import annotations
+
+import logging
+import struct
+from pathlib import Path
+
+import pefile  # type: ignore[import-untyped]
+
+log = logging.getLogger(__name__)
+
+# CodeView signature bytes
+_RSDS_SIG = b"RSDS"
+_NB10_SIG = b"NB10"
+
+# IMAGE_DEBUG_TYPE_CODEVIEW = 2
+_DEBUG_TYPE_CODEVIEW = 2
+
+
+def locate_pdb(dll_path: Path, *, pdb_path_override: Path | None = None) -> Path | None:
+    """Find the PDB file for a PE binary.
+
+    Search order:
+    1. Explicit ``pdb_path_override`` (from --pdb-path CLI flag)
+    2. PDB path embedded in PE debug directory (RSDS/NB10 CodeView entry)
+    3. Same directory as the DLL, with ``.pdb`` extension
+
+    Returns the path if found (and the file exists), otherwise ``None``.
+    """
+    if pdb_path_override is not None:
+        if pdb_path_override.is_file():
+            return pdb_path_override
+        log.warning("locate_pdb: explicit pdb_path does not exist: %s", pdb_path_override)
+        return None
+
+    # Try extracting from PE debug directory
+    embedded = _extract_pdb_path_from_pe(dll_path)
+    if embedded is not None:
+        embedded_path = Path(embedded)
+        # Try the embedded path directly
+        if embedded_path.is_file():
+            return embedded_path
+        # Try just the filename in the DLL's directory
+        local = dll_path.parent / embedded_path.name
+        if local.is_file():
+            return local
+
+    # Fallback: same name with .pdb extension
+    stem_pdb = dll_path.with_suffix(".pdb")
+    if stem_pdb.is_file():
+        return stem_pdb
+
+    return None
+
+
+def _extract_pdb_path_from_pe(dll_path: Path) -> str | None:
+    """Extract the PDB path string from a PE binary's debug directory.
+
+    Parses IMAGE_DEBUG_DIRECTORY entries for IMAGE_DEBUG_TYPE_CODEVIEW,
+    then reads the RSDS or NB10 CodeView header to get the PDB filename.
+    """
+    try:
+        pe = pefile.PE(str(dll_path), fast_load=True)
+    except Exception:  # noqa: BLE001
+        return None
+
+    try:
+        pe.parse_data_directories(directories=[
+            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_DEBUG"],
+        ])
+
+        if not hasattr(pe, "DIRECTORY_ENTRY_DEBUG"):
+            return None
+
+        for dbg in pe.DIRECTORY_ENTRY_DEBUG:
+            if dbg.struct.Type != _DEBUG_TYPE_CODEVIEW:
+                continue
+
+            data = dbg.entry
+            if data is None:
+                # Fall back to raw data at PointerToRawData
+                offset = dbg.struct.PointerToRawData
+                size = dbg.struct.SizeOfData
+                if offset and size:
+                    raw = pe.get_data(dbg.struct.AddressOfRawData, size)
+                    if raw and len(raw) >= 24 and raw[:4] == _RSDS_SIG:
+                        # RSDS: 4 (sig) + 16 (GUID) + 4 (age) + filename
+                        pdb_name = raw[24:].split(b"\x00", 1)[0]
+                        return pdb_name.decode("utf-8", errors="replace")
+                continue
+
+            # pefile parses the CodeView data into a named structure
+            if hasattr(data, "CvSignature"):
+                sig_bytes = struct.pack("<I", data.CvSignature)
+                if sig_bytes == _RSDS_SIG:
+                    if hasattr(data, "PdbFileName"):
+                        fname = data.PdbFileName
+                        if isinstance(fname, bytes):
+                            return fname.rstrip(b"\x00").decode("utf-8", errors="replace")
+                        return str(fname)
+                elif sig_bytes == _NB10_SIG:
+                    if hasattr(data, "PdbFileName"):
+                        fname = data.PdbFileName
+                        if isinstance(fname, bytes):
+                            return fname.rstrip(b"\x00").decode("utf-8", errors="replace")
+                        return str(fname)
+
+        return None
+
+    except Exception as exc:  # noqa: BLE001
+        log.debug("_extract_pdb_path_from_pe: %s: %s", dll_path, exc)
+        return None
+    finally:
+        pe.close()

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -10,15 +10,16 @@ limitations you should understand before relying on it in production.
 | Platform | Binary format | Binary metadata | Header AST (castxml) | Debug info cross-check |
 |----------|--------------|:---------------:|:--------------------:|:----------------------:|
 | Linux | ELF (`.so`) | Yes (pyelftools) | Yes (GCC, Clang) | Yes (DWARF) |
-| Windows | PE/COFF (`.dll`) | Yes (pefile) | Yes (MSVC, MinGW) | Planned (PDB) |
+| Windows | PE/COFF (`.dll`) | Yes (pefile) | Yes (MSVC, MinGW) | Yes (PDB) |
 | macOS | Mach-O (`.dylib`) | Yes (macholib) | Yes (Clang, GCC) | Yes (DWARF) |
 
 **Header AST analysis** (via castxml) is available on all platforms. castxml is
 maintained by Kitware and available via conda-forge, Homebrew, apt, or direct download.
 
-**Debug info cross-check** currently uses DWARF (Linux and macOS). Windows uses PDB
-(Program Database) files for debug information — PDB cross-check is planned for a
-future release.
+**Debug info cross-check** uses DWARF (Linux and macOS) and PDB (Windows). PDB
+support extracts struct/class/union layouts, enum types, calling conventions, and
+toolchain info from PDB files produced by MSVC (`/Zi` flag). Use `--pdb-path` to
+specify the PDB file location if automatic discovery fails.
 
 ---
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -116,9 +116,13 @@ When debug info is available in the binary:
 - Checks vtable slot offsets
 - Detects calling convention and frame register changes
 
-**PDB** (Windows `.dll` — planned):
-- Windows uses PDB (Program Database) files for debug information
-- PDB cross-check support is planned for a future release
+**PDB** (Windows `.dll` — via built-in PDB parser):
+- Extracts struct/class/union sizes and field layouts from TPI stream
+- Extracts enum underlying types and member values
+- Detects calling convention changes (`__cdecl`, `__stdcall`, `__fastcall`,
+  `__thiscall`, `__vectorcall`) from `LF_PROCEDURE` / `LF_MFUNCTION` records
+- Extracts MSVC toolchain info (version, machine type, ABI flags) from DBI stream
+- Auto-discovers PDB files from PE debug directory; use `--pdb-path` to override
 
 ---
 
@@ -140,9 +144,12 @@ When debug info is available in the binary:
 | `sarif.py` | SARIF output for GitHub Code Scanning |
 | `suppression.py` | Suppression rules, symbol/type filtering |
 | `serialization.py` | JSON snapshot serialization/deserialization |
-| `dwarf_unified.py` | Unified DWARF handling (layer 3, Linux only) |
-| `dwarf_advanced.py` | Advanced DWARF analysis (Linux only) |
-| `dwarf_metadata.py` | DWARF metadata extraction (Linux only) |
+| `dwarf_unified.py` | Unified DWARF handling (layer 3, Linux/macOS) |
+| `dwarf_advanced.py` | Advanced DWARF analysis (Linux/macOS) |
+| `dwarf_metadata.py` | DWARF metadata extraction (Linux/macOS) |
+| `pdb_parser.py` | Minimal PDB parser (MSF container, TPI, DBI streams) |
+| `pdb_metadata.py` | PDB debug info → DwarfMetadata/AdvancedDwarfMetadata |
+| `pdb_utils.py` | PDB file location from PE debug directory |
 | `model.py` | Data models for snapshots and changes |
 | `errors.py` | Custom exception definitions |
 | `compat/` | ABICC compatibility layer (compat check, compat dump, XML parsing) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ module = [
     "abicheck.dwarf_advanced",
     "abicheck.dwarf_unified",
     "abicheck.dumper",
+    "abicheck.pdb_parser",
+    "abicheck.pdb_metadata",
+    "abicheck.pdb_utils",
 ]
 disallow_untyped_calls = false
 disable_error_code = ["attr-defined", "unused-ignore"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ disable_error_code = ["import-untyped"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = [
     "integration: requires castxml, gcc/g++ installed",
     "libabigail: requires abidiff + gcc/g++ — libabigail parity tests",

--- a/tests/test_pdb_metadata.py
+++ b/tests/test_pdb_metadata.py
@@ -279,6 +279,81 @@ class TestPdbToAdvancedDwarfMetadata:
         assert adv.toolchain.compiler == "MSVC"
         assert "-m32" in adv.toolchain.abi_flags
 
+    def test_toolchain_arm64(self, tmp_path: Path) -> None:
+        dbi = _build_dbi_stream(machine=0xAA64, build_major=14, build_minor=36)
+        pdb_bytes = _build_minimal_pdb(dbi_data=dbi)
+        pdb_file = tmp_path / "arm64.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        _, adv = parse_pdb_debug_info(pdb_file)
+        assert "-marm64" in adv.toolchain.abi_flags
+
+    def test_toolchain_unknown_machine(self, tmp_path: Path) -> None:
+        dbi = _build_dbi_stream(machine=0xFFFF, build_major=14, build_minor=36)
+        pdb_bytes = _build_minimal_pdb(dbi_data=dbi)
+        pdb_file = tmp_path / "unknown.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        _, adv = parse_pdb_debug_info(pdb_file)
+        assert "0xffff" in adv.toolchain.producer_string
+
+    def test_toolchain_incremental_link(self, tmp_path: Path) -> None:
+        dbi = _build_dbi_stream(machine=0x8664, flags=0x01)
+        pdb_bytes = _build_minimal_pdb(dbi_data=dbi)
+        pdb_file = tmp_path / "incr.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        _, adv = parse_pdb_debug_info(pdb_file)
+        assert "/INCREMENTAL" in adv.toolchain.abi_flags
+
+    def test_toolchain_no_incremental(self, tmp_path: Path) -> None:
+        dbi = _build_dbi_stream(machine=0x8664, flags=0x00)
+        pdb_bytes = _build_minimal_pdb(dbi_data=dbi)
+        pdb_file = tmp_path / "no_incr.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        _, adv = parse_pdb_debug_info(pdb_file)
+        assert "/INCREMENTAL" not in adv.toolchain.abi_flags
+
+    def test_toolchain_msvc_version_from_module(self, tmp_path: Path) -> None:
+        """Module obj paths with MSVC version patterns should override version."""
+        dbi = _build_dbi_stream(
+            machine=0x8664,
+            modules=[
+                ("foo.obj", r"C:\Program Files\MSVC\14.36.32532\lib\foo.obj"),
+            ],
+        )
+        pdb_bytes = _build_minimal_pdb(dbi_data=dbi)
+        pdb_file = tmp_path / "msvc_ver.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        _, adv = parse_pdb_debug_info(pdb_file)
+        assert adv.toolchain.version == "14.36.32532"
+        assert "14.36.32532" in adv.toolchain.producer_string
+
+    def test_no_dbi_stream(self, tmp_path: Path) -> None:
+        """PDB without DBI stream should still parse (no toolchain info)."""
+        # Build PDB with empty DBI that's too small — will fail DBI parse
+        # but parse_pdb_debug_info should handle it gracefully.
+        # Actually, _extract_toolchain_info handles pdb.dbi is None.
+        from unittest.mock import patch
+
+        pdb_bytes = _build_minimal_pdb(tpi_records=[])
+        pdb_file = tmp_path / "no_dbi.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+
+        # Patch parse_pdb to return a PdbFile with no DBI
+        from abicheck.pdb_parser import parse_pdb
+
+        original = parse_pdb
+
+        def mock_parse(path):
+            result = original(path)
+            result.dbi = None
+            return result
+
+        with patch("abicheck.pdb_metadata.parse_pdb", side_effect=mock_parse):
+            meta, adv = parse_pdb_debug_info(pdb_file)
+
+        assert meta.has_dwarf is True
+        # No toolchain since DBI is None
+        assert adv.toolchain.compiler == ""
+
     def test_struct_names_tracked(self, pdb_with_struct_and_enum: Path) -> None:
         _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
         assert "Vec3" in adv.all_struct_names
@@ -421,6 +496,93 @@ class TestPdbInAbiSnapshot:
         assert snap.dwarf_advanced is not None
         assert snap.dwarf_advanced.has_dwarf
         assert snap.platform == "pe"
+
+    def test_no_tpi_stream(self, tmp_path: Path) -> None:
+        """PDB without TPI should return empty metadata."""
+        # Create a PDB with no records — tpi.records will be empty,
+        # but pdb.types will still be created. Instead, test via a
+        # struct.error by corrupting TPI.
+        pdb_bytes = _build_minimal_pdb(tpi_records=[])
+        pdb_file = tmp_path / "empty_tpi.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, adv = parse_pdb_debug_info(pdb_file)
+        # Has dwarf because TPI stream exists, just no types
+        assert isinstance(meta, DwarfMetadata)
+
+    def test_forward_ref_struct_skipped(self, tmp_path: Path) -> None:
+        """Forward-ref structs should not appear in metadata."""
+        records = [
+            (LF_STRUCTURE, _make_lf_structure(0, 0x0080, 0, 0, "FwdOnly")),
+        ]
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "fwd.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, _ = parse_pdb_debug_info(pdb_file)
+        assert "FwdOnly" not in meta.structs
+
+    def test_anonymous_struct_skipped(self, tmp_path: Path) -> None:
+        """Structs with names starting with '<' or '__' should be skipped."""
+        fl = _make_lf_fieldlist([_make_lf_member(0, 0x74, 0, "x")])
+        records = [
+            (LF_FIELDLIST, fl),
+            (LF_STRUCTURE, _make_lf_structure(1, 0, 0x1000, 4, "<unnamed>")),
+            (LF_STRUCTURE, _make_lf_structure(1, 0, 0x1000, 4, "__internal")),
+        ]
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "anon.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, _ = parse_pdb_debug_info(pdb_file)
+        assert "<unnamed>" not in meta.structs
+        assert "__internal" not in meta.structs
+
+    def test_empty_struct_name_skipped(self, tmp_path: Path) -> None:
+        """Structs with empty names should be skipped."""
+        fl = _make_lf_fieldlist([_make_lf_member(0, 0x74, 0, "x")])
+        records = [
+            (LF_FIELDLIST, fl),
+            (LF_STRUCTURE, _make_lf_structure(1, 0, 0x1000, 4, "")),
+        ]
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "noname.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, _ = parse_pdb_debug_info(pdb_file)
+        assert "" not in meta.structs
+
+    def test_forward_ref_enum_skipped(self, tmp_path: Path) -> None:
+        """Forward-ref enums should not appear in metadata."""
+        records = [
+            (LF_ENUM, _make_lf_enum(0, 0x0080, 0x74, 0, "FwdEnum")),
+        ]
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "fwd_enum.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, _ = parse_pdb_debug_info(pdb_file)
+        assert "FwdEnum" not in meta.enums
+
+    def test_anonymous_enum_skipped(self, tmp_path: Path) -> None:
+        """Enums with names starting with '<' or '__' should be skipped."""
+        fl = _make_lf_fieldlist([_make_lf_enumerate(0, 0, "A")])
+        records = [
+            (LF_FIELDLIST, fl),
+            (LF_ENUM, _make_lf_enum(1, 0, 0x74, 0x1000, "<unnamed-enum>")),
+        ]
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "anon_enum.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, _ = parse_pdb_debug_info(pdb_file)
+        assert "<unnamed-enum>" not in meta.enums
+
+    def test_empty_fieldlist_struct(self, tmp_path: Path) -> None:
+        """Struct with field_list_ti=0 should have no fields."""
+        records = [
+            (LF_STRUCTURE, _make_lf_structure(0, 0, 0, 0, "Empty")),
+        ]
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "empty_struct.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        meta, _ = parse_pdb_debug_info(pdb_file)
+        assert "Empty" in meta.structs
+        assert len(meta.structs["Empty"].fields) == 0
 
     def test_serialization_round_trip(self, pdb_with_struct_and_enum: Path, tmp_path: Path) -> None:
         """DwarfMetadata from PDB should survive JSON serialization."""

--- a/tests/test_pdb_metadata.py
+++ b/tests/test_pdb_metadata.py
@@ -1,0 +1,456 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PDB metadata extraction (pdb_metadata.py).
+
+Validates that PDB-derived metadata produces the same DwarfMetadata and
+AdvancedDwarfMetadata dataclasses as the DWARF pipeline, ensuring unified
+data model consistency for the checker layer.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.dwarf_advanced import AdvancedDwarfMetadata, ToolchainInfo
+from abicheck.dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
+from abicheck.pdb_metadata import parse_pdb_debug_info
+
+# Import test helpers from test_pdb_parser
+from tests.test_pdb_parser import (
+    LF_BITFIELD,
+    LF_ENUM,
+    LF_FIELDLIST,
+    LF_MFUNCTION,
+    LF_PROCEDURE,
+    LF_STRUCTURE,
+    LF_UNION,
+    _build_dbi_stream,
+    _build_minimal_pdb,
+    _make_lf_bitfield,
+    _make_lf_enum,
+    _make_lf_enumerate,
+    _make_lf_fieldlist,
+    _make_lf_member,
+    _make_lf_mfunction,
+    _make_lf_procedure,
+    _make_lf_structure,
+    _make_lf_union,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def pdb_with_struct_and_enum(tmp_path: Path) -> Path:
+    """Create a PDB file with a struct, union, enum, and procedure."""
+    fl_struct = _make_lf_fieldlist([
+        _make_lf_member(0, 0x74, 0, "x"),      # int x at offset 0
+        _make_lf_member(0, 0x74, 4, "y"),      # int y at offset 4
+        _make_lf_member(0, 0x41, 8, "z"),      # double z at offset 8
+    ])
+    fl_union = _make_lf_fieldlist([
+        _make_lf_member(0, 0x74, 0, "i"),      # int i
+        _make_lf_member(0, 0x40, 0, "f"),      # float f
+    ])
+    fl_enum = _make_lf_fieldlist([
+        _make_lf_enumerate(0, 0, "NONE"),
+        _make_lf_enumerate(0, 1, "READ"),
+        _make_lf_enumerate(0, 2, "WRITE"),
+        _make_lf_enumerate(0, 3, "READWRITE"),
+    ])
+
+    records = [
+        (LF_FIELDLIST, fl_struct),                                      # 0x1000
+        (LF_STRUCTURE, _make_lf_structure(3, 0, 0x1000, 16, "Vec3")),  # 0x1001
+        (LF_FIELDLIST, fl_union),                                       # 0x1002
+        (LF_UNION, _make_lf_union(2, 0, 0x1002, 4, "Data")),          # 0x1003
+        (LF_FIELDLIST, fl_enum),                                        # 0x1004
+        (LF_ENUM, _make_lf_enum(4, 0, 0x74, 0x1004, "Access")),       # 0x1005
+        # Procedures with different calling conventions
+        (LF_PROCEDURE, _make_lf_procedure(0x74, 0x00, 2, 0)),         # 0x1006 cdecl
+        (LF_PROCEDURE, _make_lf_procedure(0x74, 0x07, 1, 0)),         # 0x1007 stdcall
+        (LF_PROCEDURE, _make_lf_procedure(0x74, 0x04, 2, 0)),         # 0x1008 fastcall
+        (LF_MFUNCTION, _make_lf_mfunction(0x74, 0x1001, 0, 0x0B, 0, 0)),  # 0x1009 thiscall
+        (LF_PROCEDURE, _make_lf_procedure(0x74, 0x18, 3, 0)),         # 0x100A vectorcall
+    ]
+
+    dbi = _build_dbi_stream(
+        machine=0x8664, build_major=14, build_minor=36,
+        modules=[("foo.obj", "C:\\src\\foo.cpp")],
+    )
+
+    pdb_bytes = _build_minimal_pdb(tpi_records=records, dbi_data=dbi)
+    pdb_file = tmp_path / "test.pdb"
+    pdb_file.write_bytes(pdb_bytes)
+    return pdb_file
+
+
+@pytest.fixture()
+def pdb_packed_struct(tmp_path: Path) -> Path:
+    """Create a PDB with a packed struct."""
+    fl = _make_lf_fieldlist([
+        _make_lf_member(0, 0x10, 0, "a"),  # signed char at 0
+        _make_lf_member(0, 0x74, 1, "b"),  # int at 1 (packed — no padding)
+    ])
+    records = [
+        (LF_FIELDLIST, fl),
+        (LF_STRUCTURE, _make_lf_structure(2, 0x0800, 0x1000, 5, "Packed")),  # packed flag
+    ]
+    pdb_bytes = _build_minimal_pdb(tpi_records=records)
+    pdb_file = tmp_path / "packed.pdb"
+    pdb_file.write_bytes(pdb_bytes)
+    return pdb_file
+
+
+@pytest.fixture()
+def pdb_with_bitfield(tmp_path: Path) -> Path:
+    """Create a PDB with a struct containing bitfields."""
+    records = [
+        (LF_BITFIELD, _make_lf_bitfield(0x74, 3, 0)),  # 0x1000: int:3 at bit 0
+        (LF_BITFIELD, _make_lf_bitfield(0x74, 5, 3)),  # 0x1001: int:5 at bit 3
+        (LF_FIELDLIST, _make_lf_fieldlist([
+            _make_lf_member(0, 0x1000, 0, "flags"),
+            _make_lf_member(0, 0x1001, 0, "mode"),
+        ])),                                              # 0x1002
+        (LF_STRUCTURE, _make_lf_structure(2, 0, 0x1002, 4, "BitStruct")),  # 0x1003
+    ]
+    pdb_bytes = _build_minimal_pdb(tpi_records=records)
+    pdb_file = tmp_path / "bitfield.pdb"
+    pdb_file.write_bytes(pdb_bytes)
+    return pdb_file
+
+
+# ---------------------------------------------------------------------------
+# Data model consistency: DwarfMetadata from PDB
+# ---------------------------------------------------------------------------
+
+class TestPdbToDwarfMetadata:
+    """Verify that PDB-derived DwarfMetadata matches DWARF pipeline's model."""
+
+    def test_struct_layout(self, pdb_with_struct_and_enum: Path) -> None:
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        assert isinstance(meta, DwarfMetadata)
+        assert meta.has_dwarf is True
+        assert "Vec3" in meta.structs
+
+        vec3 = meta.structs["Vec3"]
+        assert isinstance(vec3, StructLayout)
+        assert vec3.name == "Vec3"
+        assert vec3.byte_size == 16
+        assert vec3.is_union is False
+        assert len(vec3.fields) == 3
+
+        # Field 0: int x at offset 0
+        f0 = vec3.fields[0]
+        assert isinstance(f0, FieldInfo)
+        assert f0.name == "x"
+        assert f0.byte_offset == 0
+        assert f0.byte_size == 4
+        assert "int" in f0.type_name
+
+        # Field 1: int y at offset 4
+        f1 = vec3.fields[1]
+        assert f1.name == "y"
+        assert f1.byte_offset == 4
+
+        # Field 2: double z at offset 8
+        f2 = vec3.fields[2]
+        assert f2.name == "z"
+        assert f2.byte_offset == 8
+        assert f2.byte_size == 8
+
+    def test_union_layout(self, pdb_with_struct_and_enum: Path) -> None:
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        assert "Data" in meta.structs
+        data = meta.structs["Data"]
+        assert data.is_union is True
+        assert data.byte_size == 4
+        assert len(data.fields) == 2
+        assert data.fields[0].name == "i"
+        assert data.fields[1].name == "f"
+
+    def test_enum_extraction(self, pdb_with_struct_and_enum: Path) -> None:
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        assert "Access" in meta.enums
+        access_enum = meta.enums["Access"]
+        assert isinstance(access_enum, EnumInfo)
+        assert access_enum.name == "Access"
+        assert access_enum.underlying_byte_size == 4  # int
+        assert len(access_enum.members) == 4
+        assert access_enum.members["NONE"] == 0
+        assert access_enum.members["READ"] == 1
+        assert access_enum.members["WRITE"] == 2
+        assert access_enum.members["READWRITE"] == 3
+
+    def test_packed_struct(self, pdb_packed_struct: Path) -> None:
+        meta, adv = parse_pdb_debug_info(pdb_packed_struct)
+
+        assert "Packed" in meta.structs
+        assert meta.structs["Packed"].byte_size == 5
+        assert "Packed" in adv.packed_structs
+
+    def test_bitfield_extraction(self, pdb_with_bitfield: Path) -> None:
+        meta, _ = parse_pdb_debug_info(pdb_with_bitfield)
+
+        assert "BitStruct" in meta.structs
+        bs = meta.structs["BitStruct"]
+        assert bs.byte_size == 4
+        assert len(bs.fields) == 2
+
+        f0 = bs.fields[0]
+        assert f0.name == "flags"
+        assert f0.bit_size == 3
+        assert f0.bit_offset == 0
+
+        f1 = bs.fields[1]
+        assert f1.name == "mode"
+        assert f1.bit_size == 5
+        assert f1.bit_offset == 3
+
+    def test_missing_pdb(self, tmp_path: Path) -> None:
+        meta, adv = parse_pdb_debug_info(tmp_path / "nonexistent.pdb")
+        assert meta.has_dwarf is False
+        assert adv.has_dwarf is False
+
+    def test_invalid_pdb(self, tmp_path: Path) -> None:
+        bad_file = tmp_path / "bad.pdb"
+        bad_file.write_bytes(b"not a pdb file" + b"\x00" * 100)
+        meta, adv = parse_pdb_debug_info(bad_file)
+        assert meta.has_dwarf is False
+        assert adv.has_dwarf is False
+
+
+# ---------------------------------------------------------------------------
+# Data model consistency: AdvancedDwarfMetadata from PDB
+# ---------------------------------------------------------------------------
+
+class TestPdbToAdvancedDwarfMetadata:
+    """Verify that PDB-derived AdvancedDwarfMetadata matches DWARF pipeline's model."""
+
+    def test_calling_conventions(self, pdb_with_struct_and_enum: Path) -> None:
+        _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        assert isinstance(adv, AdvancedDwarfMetadata)
+        assert adv.has_dwarf is True
+
+        # Should have procedures with various calling conventions
+        cc_values = set(adv.calling_conventions.values())
+        assert "cdecl" in cc_values
+        assert "stdcall" in cc_values
+        assert "fastcall" in cc_values
+        assert "thiscall" in cc_values
+        assert "vectorcall" in cc_values
+
+    def test_packed_structs_in_advanced(self, pdb_packed_struct: Path) -> None:
+        _, adv = parse_pdb_debug_info(pdb_packed_struct)
+        assert "Packed" in adv.packed_structs
+        assert "Packed" in adv.all_struct_names
+
+    def test_toolchain_info(self, pdb_with_struct_and_enum: Path) -> None:
+        _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        assert isinstance(adv.toolchain, ToolchainInfo)
+        assert adv.toolchain.compiler == "MSVC"
+        assert "MSVC" in adv.toolchain.producer_string
+        assert adv.toolchain.version  # should have a version string
+        assert "-m64" in adv.toolchain.abi_flags  # AMD64
+
+    def test_toolchain_x86(self, tmp_path: Path) -> None:
+        dbi = _build_dbi_stream(machine=0x014C, build_major=19, build_minor=42)
+        pdb_bytes = _build_minimal_pdb(dbi_data=dbi)
+        pdb_file = tmp_path / "x86.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+        _, adv = parse_pdb_debug_info(pdb_file)
+        assert adv.toolchain.compiler == "MSVC"
+        assert "-m32" in adv.toolchain.abi_flags
+
+    def test_struct_names_tracked(self, pdb_with_struct_and_enum: Path) -> None:
+        _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+        assert "Vec3" in adv.all_struct_names
+        assert "Data" in adv.all_struct_names
+
+
+# ---------------------------------------------------------------------------
+# Data model structural consistency
+# ---------------------------------------------------------------------------
+
+class TestDataModelConsistency:
+    """Verify PDB output is structurally compatible with DWARF output.
+
+    The checker's _diff_dwarf() and _diff_advanced_dwarf() functions operate
+    on DwarfMetadata and AdvancedDwarfMetadata. These tests ensure PDB
+    produces output that these functions can consume without error.
+    """
+
+    def test_dwarf_metadata_fields_present(self, pdb_with_struct_and_enum: Path) -> None:
+        """DwarfMetadata from PDB has all required attributes."""
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        # Core attributes
+        assert hasattr(meta, "structs")
+        assert hasattr(meta, "enums")
+        assert hasattr(meta, "has_dwarf")
+
+        # Types match
+        assert isinstance(meta.structs, dict)
+        assert isinstance(meta.enums, dict)
+        assert isinstance(meta.has_dwarf, bool)
+
+    def test_struct_layout_fields_present(self, pdb_with_struct_and_enum: Path) -> None:
+        """StructLayout from PDB has all required attributes for checker."""
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+        for name, layout in meta.structs.items():
+            assert isinstance(layout.name, str)
+            assert isinstance(layout.byte_size, int)
+            assert isinstance(layout.alignment, int)
+            assert isinstance(layout.is_union, bool)
+            assert isinstance(layout.fields, list)
+            for f in layout.fields:
+                assert isinstance(f.name, str)
+                assert isinstance(f.type_name, str)
+                assert isinstance(f.byte_offset, int)
+                assert isinstance(f.byte_size, int)
+                assert isinstance(f.bit_offset, int)
+                assert isinstance(f.bit_size, int)
+
+    def test_enum_info_fields_present(self, pdb_with_struct_and_enum: Path) -> None:
+        """EnumInfo from PDB has all required attributes for checker."""
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+        for name, info in meta.enums.items():
+            assert isinstance(info.name, str)
+            assert isinstance(info.underlying_byte_size, int)
+            assert isinstance(info.members, dict)
+            for member_name, member_val in info.members.items():
+                assert isinstance(member_name, str)
+                assert isinstance(member_val, int)
+
+    def test_advanced_metadata_fields_present(self, pdb_with_struct_and_enum: Path) -> None:
+        """AdvancedDwarfMetadata from PDB has all required attributes."""
+        _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        assert isinstance(adv.has_dwarf, bool)
+        assert isinstance(adv.toolchain, ToolchainInfo)
+        assert isinstance(adv.calling_conventions, dict)
+        assert isinstance(adv.packed_structs, set)
+        assert isinstance(adv.all_struct_names, set)
+        assert isinstance(adv.value_abi_traits, dict)
+        assert isinstance(adv.frame_registers, dict)
+
+    def test_toolchain_info_fields_present(self, pdb_with_struct_and_enum: Path) -> None:
+        """ToolchainInfo from PDB has all required attributes."""
+        _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+        tc = adv.toolchain
+        assert isinstance(tc.producer_string, str)
+        assert isinstance(tc.compiler, str)
+        assert isinstance(tc.version, str)
+        assert isinstance(tc.abi_flags, set)
+
+    def test_checker_diff_dwarf_compatible(self, pdb_with_struct_and_enum: Path) -> None:
+        """Simulate what _diff_dwarf does: iterate structs and enums."""
+        meta, _ = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        # _diff_dwarf iterates over structs and compares fields
+        for name, layout in meta.structs.items():
+            assert layout.byte_size >= 0
+            for field in layout.fields:
+                # Field offsets should be non-negative
+                assert field.byte_offset >= 0
+                assert field.byte_size >= 0
+
+        # _diff_dwarf iterates over enums and compares members
+        for name, info in meta.enums.items():
+            assert info.underlying_byte_size >= 0
+            for member_name, val in info.members.items():
+                assert isinstance(val, int)
+
+    def test_checker_diff_advanced_compatible(self, pdb_with_struct_and_enum: Path) -> None:
+        """Simulate what _diff_advanced_dwarf does: compare CC, packing, toolchain."""
+        _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+
+        # _diff_advanced_dwarf compares calling_conventions
+        for key, cc in adv.calling_conventions.items():
+            assert isinstance(key, str)
+            assert isinstance(cc, str)
+
+        # _diff_advanced_dwarf compares packed_structs
+        for name in adv.packed_structs:
+            assert name in adv.all_struct_names
+
+        # _diff_advanced_dwarf compares toolchain flags
+        assert isinstance(adv.toolchain.abi_flags, set)
+        for flag in adv.toolchain.abi_flags:
+            assert isinstance(flag, str)
+
+
+# ---------------------------------------------------------------------------
+# Integration: PDB metadata used in AbiSnapshot comparison
+# ---------------------------------------------------------------------------
+
+class TestPdbInAbiSnapshot:
+    """Test that PDB metadata integrates into the AbiSnapshot model."""
+
+    def test_snapshot_with_pdb_dwarf(self, pdb_with_struct_and_enum: Path) -> None:
+        from abicheck.model import AbiSnapshot
+
+        meta, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+        snap = AbiSnapshot(
+            library="test.dll",
+            version="1.0",
+            dwarf=meta,
+            dwarf_advanced=adv,
+            platform="pe",
+        )
+
+        assert snap.dwarf is not None
+        assert snap.dwarf.has_dwarf
+        assert snap.dwarf_advanced is not None
+        assert snap.dwarf_advanced.has_dwarf
+        assert snap.platform == "pe"
+
+    def test_serialization_round_trip(self, pdb_with_struct_and_enum: Path, tmp_path: Path) -> None:
+        """DwarfMetadata from PDB should survive JSON serialization."""
+        import json
+
+        from abicheck.model import AbiSnapshot
+        from abicheck.serialization import snapshot_from_dict, snapshot_to_json
+
+        meta, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
+        snap = AbiSnapshot(
+            library="test.dll",
+            version="1.0",
+            dwarf=meta,
+            dwarf_advanced=adv,
+            platform="pe",
+        )
+
+        json_str = snapshot_to_json(snap)
+        loaded = snapshot_from_dict(json.loads(json_str))
+
+        assert loaded.dwarf is not None
+        assert loaded.dwarf.has_dwarf
+        assert "Vec3" in loaded.dwarf.structs
+        assert loaded.dwarf.structs["Vec3"].byte_size == 16
+        assert "Access" in loaded.dwarf.enums
+        assert loaded.dwarf.enums["Access"].members["READ"] == 1
+
+        assert loaded.dwarf_advanced is not None
+        assert loaded.dwarf_advanced.has_dwarf
+        assert loaded.dwarf_advanced.toolchain.compiler == "MSVC"

--- a/tests/test_pdb_metadata.py
+++ b/tests/test_pdb_metadata.py
@@ -50,7 +50,6 @@ from tests.test_pdb_parser import (
     _make_lf_union,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -245,19 +244,17 @@ class TestPdbToDwarfMetadata:
 class TestPdbToAdvancedDwarfMetadata:
     """Verify that PDB-derived AdvancedDwarfMetadata matches DWARF pipeline's model."""
 
-    def test_calling_conventions(self, pdb_with_struct_and_enum: Path) -> None:
+    def test_calling_conventions_not_populated(self, pdb_with_struct_and_enum: Path) -> None:
+        """calling_conventions is intentionally empty — TPI type indices are
+        not stable across builds, so per-function matching would cause false
+        positives in diff_advanced_dwarf().  Populating this dict requires
+        stable function identities (linkage names) from the PDB symbol stream.
+        """
         _, adv = parse_pdb_debug_info(pdb_with_struct_and_enum)
 
         assert isinstance(adv, AdvancedDwarfMetadata)
         assert adv.has_dwarf is True
-
-        # Should have procedures with various calling conventions
-        cc_values = set(adv.calling_conventions.values())
-        assert "cdecl" in cc_values
-        assert "stdcall" in cc_values
-        assert "fastcall" in cc_values
-        assert "thiscall" in cc_values
-        assert "vectorcall" in cc_values
+        assert adv.calling_conventions == {}
 
     def test_packed_structs_in_advanced(self, pdb_packed_struct: Path) -> None:
         _, adv = parse_pdb_debug_info(pdb_packed_struct)

--- a/tests/test_pdb_parser.py
+++ b/tests/test_pdb_parser.py
@@ -317,13 +317,17 @@ def _make_lf_enumerate(attr: int, value: int, name: str) -> bytes:
 
 
 def _make_lf_fieldlist(sub_records: list[bytes]) -> bytes:
-    """Build LF_FIELDLIST payload from sub-record bytes."""
+    """Build LF_FIELDLIST payload from sub-record bytes.
+
+    Padding bytes follow the CodeView spec: 0xF0 + pad_length (so pad==1 -> 0xF1,
+    pad==2 -> 0xF2, pad==3 -> 0xF3) repeated *pad* times for 4-byte alignment.
+    """
     data = b""
     for rec in sub_records:
         data += rec
-        # 4-byte align
+        # 4-byte align with spec-compliant LF_PADn bytes (0xF0 + n, repeated n times)
         pad = (4 - (len(data) % 4)) % 4
-        data += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
+        data += bytes([0xF0 + pad] * pad) if pad else b""
     return data
 
 
@@ -1151,6 +1155,43 @@ class TestFieldlistExtended:
         db = self._make_db([(LF_FIELDLIST, data)])
         members = db.get_fieldlist(0x1000)
         assert len(members) == 0
+
+    def test_truncated_lf_index_4_bytes(self) -> None:
+        """LF_INDEX with only 4 extra bytes (need 6) should break out."""
+        # LF_INDEX sub-record needs 2-byte sub_leaf + 2-byte pad + 4-byte TI = 6 bytes.
+        # Here we have 2 (sub_leaf) + 4 extra = 6 total, but sub_leaf already consumed 2,
+        # so pos + 6 > len(d) check: pos=2, remaining=4 bytes → 2+6=8 > 6 → break.
+        data = struct.pack("<H", LF_INDEX) + b"\x00" * 4  # exactly 4 extra bytes (need 6)
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 0
+
+    def test_truncated_lf_index_5_bytes(self) -> None:
+        """LF_INDEX with 5 extra bytes (need 6) should break out."""
+        data = struct.pack("<H", LF_INDEX) + b"\x00" * 5  # 5 extra bytes (need 6)
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 0
+
+    def test_padding_lf_pad1_between_members(self) -> None:
+        """Single-byte LF_PAD1 (0xF1) between members should be skipped correctly.
+
+        _make_lf_member(0, 0x74, 0, "") produces 11 bytes:
+          2 (LF_MEMBER) + 2 (attr) + 4 (type_ti) + 2 (_cv_numeric(0)) + 1 (empty cstring)
+        11 % 4 == 3 → needs exactly 1 pad byte (LF_PAD1 = 0xF1) to align to 12.
+        """
+        # Empty name gives 11-byte record → 1-byte pad needed
+        first = _make_lf_member(0, 0x74, 0, "")
+        assert len(first) % 4 == 3, f"Expected 3 mod 4, got {len(first) % 4}"
+        # Insert explicit LF_PAD1 byte (0xF1 = 0xF0 + 1)
+        padded = first + bytes([0xF1])
+        assert len(padded) % 4 == 0
+        second = _make_lf_member(0, 0x74, 4, "b")
+        fl_data = padded + second
+        db = self._make_db([(LF_FIELDLIST, fl_data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 2
+        assert members[1].name == "b"
 
 
 class TestSkipSubrecord:

--- a/tests/test_pdb_parser.py
+++ b/tests/test_pdb_parser.py
@@ -30,10 +30,10 @@ from pathlib import Path
 import pytest
 
 from abicheck.pdb_parser import (
+    _CC_NAMES,
     LF_ARRAY,
     LF_BITFIELD,
     LF_CHAR,
-    LF_CLASS,
     LF_ENUM,
     LF_ENUMERATE,
     LF_FIELDLIST,
@@ -48,18 +48,13 @@ from abicheck.pdb_parser import (
     LF_ULONG,
     LF_UNION,
     LF_USHORT,
-    MsfFile,
-    TpiRecord,
-    TpiStream,
     TypeDatabase,
-    _CC_NAMES,
     _read_cstring,
     _read_numeric_leaf,
     parse_dbi_stream,
     parse_msf,
     parse_tpi_stream,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helper: build a minimal MSF PDB file in memory

--- a/tests/test_pdb_parser.py
+++ b/tests/test_pdb_parser.py
@@ -31,23 +31,34 @@ import pytest
 
 from abicheck.pdb_parser import (
     _CC_NAMES,
+    LF_ARGLIST,
     LF_ARRAY,
+    LF_BCLASS,
     LF_BITFIELD,
     LF_CHAR,
     LF_ENUM,
     LF_ENUMERATE,
     LF_FIELDLIST,
+    LF_INDEX,
     LF_LONG,
     LF_MEMBER,
+    LF_METHOD,
     LF_MFUNCTION,
     LF_MODIFIER,
+    LF_NESTTYPE,
+    LF_ONEMETHOD,
     LF_POINTER,
     LF_PROCEDURE,
+    LF_QUADWORD,
     LF_SHORT,
+    LF_STMEMBER,
     LF_STRUCTURE,
     LF_ULONG,
     LF_UNION,
+    LF_UQUADWORD,
     LF_USHORT,
+    LF_VBCLASS,
+    LF_VFUNCTAB,
     TypeDatabase,
     _read_cstring,
     _read_numeric_leaf,
@@ -810,3 +821,454 @@ class TestPdbRoundTrip:
         p = pdb.types.get_procedure(0x1004)
         assert p is not None
         assert p.calling_convention == 0x07  # stdcall
+
+
+# ---------------------------------------------------------------------------
+# Tests: additional coverage for edge cases
+# ---------------------------------------------------------------------------
+
+class TestNumericLeafExtended:
+    def test_truncated_data(self) -> None:
+        """Offset past end of data returns (0, offset+2)."""
+        val, pos = _read_numeric_leaf(b"", 0)
+        assert val == 0
+        assert pos == 2
+
+    def test_lf_quadword(self) -> None:
+        data = struct.pack("<Hq", LF_QUADWORD, -(2**60))
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == -(2**60)
+        assert pos == 10
+
+    def test_lf_uquadword(self) -> None:
+        data = struct.pack("<HQ", LF_UQUADWORD, 2**63)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == 2**63
+        assert pos == 10
+
+    def test_unknown_leaf(self) -> None:
+        """Unknown leaf tag should return (0, offset+6)."""
+        data = struct.pack("<HI", 0x800F, 0xDEADBEEF)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == 0
+        assert pos == 6
+
+
+class TestCStringExtended:
+    def test_no_null_terminator(self) -> None:
+        """String without null terminator returns empty string."""
+        data = b"abc"
+        s, pos = _read_cstring(data, 0)
+        assert s == ""
+        assert pos == len(data)
+
+
+class TestMsfParserExtended:
+    def test_stream_data_negative_index(self) -> None:
+        pdb_data = _build_minimal_pdb()
+        msf = parse_msf(pdb_data)
+        assert msf.stream_data(-1) == b""
+
+    def test_stream_data_out_of_range(self) -> None:
+        pdb_data = _build_minimal_pdb()
+        msf = parse_msf(pdb_data)
+        assert msf.stream_data(999) == b""
+
+    def test_invalid_block_size(self) -> None:
+        """Invalid block size in header should raise ValueError."""
+        pdb_data = bytearray(_build_minimal_pdb())
+        # Patch block_size field (at offset 32) to an unsupported value
+        struct.pack_into("<I", pdb_data, 32, 8192)
+        with pytest.raises(ValueError, match="Unsupported PDB block size"):
+            parse_msf(bytes(pdb_data))
+
+
+class TestTpiParserExtended:
+    def test_record_with_small_rec_len(self) -> None:
+        """Record with rec_len < 2 should stop parsing."""
+        # Build TPI header for 1 record
+        ti_begin = 0x1000
+        ti_end = 0x1001
+        # Create a record with rec_len=1 (< 2 threshold)
+        rec_data = struct.pack("<H", 1)  # rec_len = 1
+        rec_data += b"\x00" * 2  # padding
+        header = struct.pack("<IIIII", 20040203, 56, ti_begin, ti_end, len(rec_data))
+        header += b"\x00" * (56 - len(header))
+        tpi = parse_tpi_stream(header + rec_data)
+        assert len(tpi.records) == 0
+
+    def test_tpi_get_method(self) -> None:
+        """TpiStream.get() returns records by type index."""
+        fieldlist_payload = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "x"),
+        ])
+        tpi_data = _build_tpi_stream([(LF_FIELDLIST, fieldlist_payload)])
+        tpi = parse_tpi_stream(tpi_data)
+        rec = tpi.get(0x1000)
+        assert rec is not None
+        assert rec.leaf == LF_FIELDLIST
+        assert tpi.get(0xFFFF) is None
+
+
+class TestTypeDatabaseExtended:
+    def _make_db(self, records: list[tuple[int, bytes]]) -> TypeDatabase:
+        tpi_data = _build_tpi_stream(records)
+        tpi = parse_tpi_stream(tpi_data)
+        db = TypeDatabase(tpi)
+        db.parse_all()
+        return db
+
+    def test_all_structs(self) -> None:
+        struct_payload = _make_lf_structure(0, 0, 0, 4, "Foo")
+        db = self._make_db([(LF_STRUCTURE, struct_payload)])
+        assert len(db.all_structs()) == 1
+
+    def test_all_enums(self) -> None:
+        fl = _make_lf_fieldlist([_make_lf_enumerate(0, 0, "A")])
+        enum_payload = _make_lf_enum(1, 0, 0x74, 0x1000, "E")
+        db = self._make_db([(LF_FIELDLIST, fl), (LF_ENUM, enum_payload)])
+        assert len(db.all_enums()) == 1
+
+    def test_all_procedures(self) -> None:
+        db = self._make_db([(LF_PROCEDURE, _make_lf_procedure(0x74, 0, 0, 0))])
+        assert len(db.all_procedures()) == 1
+
+    def test_all_mfunctions(self) -> None:
+        db = self._make_db([(LF_MFUNCTION, _make_lf_mfunction(0x74, 0, 0, 0, 0, 0))])
+        assert len(db.all_mfunctions()) == 1
+
+    def test_modifier_volatile(self) -> None:
+        mod_payload = _make_lf_modifier(0x74, is_volatile=True)
+        db = self._make_db([(LF_MODIFIER, mod_payload)])
+        name = db.type_name(0x1000)
+        assert "volatile" in name
+        assert "int" in name
+
+    def test_type_name_depth_limit(self) -> None:
+        db = self._make_db([])
+        assert db.type_name(0x74, depth=11) == "..."
+
+    def test_type_size_depth_limit(self) -> None:
+        db = self._make_db([])
+        assert db.type_size(0x74, depth=11) == 0
+
+    def test_type_name_unknown_ti(self) -> None:
+        db = self._make_db([])
+        name = db.type_name(0x9999)
+        assert "<ti:0x9999>" == name
+
+    def test_type_size_enum(self) -> None:
+        fl = _make_lf_fieldlist([_make_lf_enumerate(0, 0, "X")])
+        enum_payload = _make_lf_enum(1, 0, 0x74, 0x1000, "MyEnum")
+        db = self._make_db([(LF_FIELDLIST, fl), (LF_ENUM, enum_payload)])
+        # Enum size should resolve to underlying type (int = 4)
+        assert db.type_size(0x1001) == 4
+
+    def test_type_name_enum(self) -> None:
+        fl = _make_lf_fieldlist([_make_lf_enumerate(0, 0, "X")])
+        enum_payload = _make_lf_enum(1, 0, 0x74, 0x1000, "MyEnum")
+        db = self._make_db([(LF_FIELDLIST, fl), (LF_ENUM, enum_payload)])
+        assert db.type_name(0x1001) == "enum MyEnum"
+
+    def test_type_name_procedure(self) -> None:
+        db = self._make_db([(LF_PROCEDURE, _make_lf_procedure(0x74, 0, 0, 0))])
+        assert db.type_name(0x1000) == "fn(...)"
+
+    def test_type_name_mfunction(self) -> None:
+        db = self._make_db([(LF_MFUNCTION, _make_lf_mfunction(0x74, 0, 0, 0, 0, 0))])
+        assert db.type_name(0x1000) == "fn(...)"
+
+    def test_simple_type_near32_pointer(self) -> None:
+        """Near32 pointer mode (0x02) should resolve to pointer."""
+        db = self._make_db([])
+        ti = 0x0274  # mode=0x02 (near32), kind=0x74 (int)
+        name = db.type_name(ti)
+        assert "*" in name
+        assert db.type_size(ti) == 4
+
+    def test_simple_type_other_pointer_mode(self) -> None:
+        """Unknown pointer mode should still produce pointer name."""
+        db = self._make_db([])
+        ti = 0x0374  # mode=0x03, kind=0x74
+        name = db.type_name(ti)
+        assert "*" in name
+        assert db.type_size(ti) == 8  # default ptr size
+
+    def test_pointer_lvalue_reference(self) -> None:
+        """LValueReference pointer mode (1)."""
+        # attrs: mode=1 at bits 5-7 → (1 << 5) = 0x20, plus near64 marker
+        attrs = (8 << 13) | (1 << 5) | 0x0C
+        payload = struct.pack("<II", 0x74, attrs)
+        db = self._make_db([(LF_POINTER, payload)])
+        name = db.type_name(0x1000)
+        assert "&" in name
+        assert "&&" not in name
+
+    def test_pointer_rvalue_reference(self) -> None:
+        """RValueReference pointer mode (4)."""
+        attrs = (8 << 13) | (4 << 5) | 0x0C
+        payload = struct.pack("<II", 0x74, attrs)
+        db = self._make_db([(LF_POINTER, payload)])
+        name = db.type_name(0x1000)
+        assert "&&" in name
+
+    def test_calling_convention_unknown(self) -> None:
+        db = self._make_db([])
+        assert db.calling_convention_name(0xFF) == "cc_0xff"
+
+    def test_parse_all_idempotent(self) -> None:
+        """Calling parse_all() twice should not break anything."""
+        db = self._make_db([(LF_STRUCTURE, _make_lf_structure(0, 0, 0, 4, "S"))])
+        db.parse_all()  # second call, should be no-op
+        assert len(db.all_structs()) == 1
+
+    def test_truncated_struct_data(self) -> None:
+        """Struct with truncated data should be skipped."""
+        db = self._make_db([(LF_STRUCTURE, b"\x00" * 4)])  # < 16 bytes
+        assert len(db.all_structs()) == 0
+
+    def test_truncated_union_data(self) -> None:
+        db = self._make_db([(LF_UNION, b"\x00" * 4)])  # < 8 bytes
+        assert len(db.all_structs()) == 0
+
+    def test_truncated_enum_data(self) -> None:
+        db = self._make_db([(LF_ENUM, b"\x00" * 4)])  # < 12 bytes
+        assert len(db.all_enums()) == 0
+
+    def test_truncated_procedure_data(self) -> None:
+        db = self._make_db([(LF_PROCEDURE, b"\x00" * 4)])  # < 12 bytes
+        assert len(db.all_procedures()) == 0
+
+    def test_truncated_mfunction_data(self) -> None:
+        db = self._make_db([(LF_MFUNCTION, b"\x00" * 4)])  # < 24 bytes
+        assert len(db.all_mfunctions()) == 0
+
+    def test_truncated_pointer_data(self) -> None:
+        db = self._make_db([(LF_POINTER, b"\x00" * 4)])  # < 8 bytes
+        # Should be silently skipped
+        assert db.type_name(0x1000) == "<ti:0x1000>"
+
+    def test_truncated_modifier_data(self) -> None:
+        db = self._make_db([(LF_MODIFIER, b"\x00" * 2)])  # < 6 bytes
+        assert db.type_name(0x1000) == "<ti:0x1000>"
+
+    def test_truncated_bitfield_data(self) -> None:
+        db = self._make_db([(LF_BITFIELD, b"\x00" * 2)])  # < 6 bytes
+        assert db.type_name(0x1000) == "<ti:0x1000>"
+
+    def test_truncated_array_data(self) -> None:
+        db = self._make_db([(LF_ARRAY, b"\x00" * 4)])  # < 8 bytes
+        assert db.type_name(0x1000) == "<ti:0x1000>"
+
+    def test_truncated_arglist_data(self) -> None:
+        db = self._make_db([(LF_ARGLIST, b"\x00" * 2)])  # < 4 bytes
+        assert db.type_name(0x1000) == "<ti:0x1000>"
+
+    def test_arglist_truncated_entries(self) -> None:
+        """Arglist with count > available data should parse partial."""
+        # count=5 but only room for 2
+        payload = struct.pack("<III", 5, 0x74, 0x74)
+        db = self._make_db([(LF_ARGLIST, payload)])
+        args = db._arglists.get(0x1000, [])
+        assert len(args) == 2
+
+
+class TestFieldlistExtended:
+    def _make_db(self, records: list[tuple[int, bytes]]) -> TypeDatabase:
+        tpi_data = _build_tpi_stream(records)
+        tpi = parse_tpi_stream(tpi_data)
+        db = TypeDatabase(tpi)
+        db.parse_all()
+        return db
+
+    def test_lf_index_continuation(self) -> None:
+        """LF_INDEX should follow continuation to another fieldlist."""
+        # First fieldlist: member "a", then LF_INDEX pointing to 0x1001
+        fl1_data = _make_lf_member(0, 0x74, 0, "a")
+        # Pad to 4-byte boundary
+        pad = (4 - (len(fl1_data) % 4)) % 4
+        fl1_data += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        # Add LF_INDEX sub-record: leaf(2) + pad(2) + cont_ti(4)
+        fl1_data += struct.pack("<HHI", LF_INDEX, 0, 0x1001)
+
+        # Second fieldlist: member "b"
+        fl2_data = _make_lf_fieldlist([_make_lf_member(0, 0x74, 4, "b")])
+
+        db = self._make_db([
+            (LF_FIELDLIST, fl1_data),      # 0x1000
+            (LF_FIELDLIST, fl2_data),       # 0x1001
+        ])
+        members = db.get_fieldlist(0x1000)
+        names = [m.name for m in members]
+        assert "a" in names
+        assert "b" in names
+
+    def test_circular_lf_index(self) -> None:
+        """Circular LF_INDEX reference should be detected and skipped."""
+        # Fieldlist with LF_INDEX pointing to itself (0x1000)
+        fl_data = struct.pack("<HHI", LF_INDEX, 0, 0x1000)
+        db = self._make_db([(LF_FIELDLIST, fl_data)])
+        # Should not raise (infinite recursion guarded)
+        members = db.get_fieldlist(0x1000)
+        assert isinstance(members, list)
+
+    def test_padding_bytes(self) -> None:
+        """Padding bytes (>= 0xF0) should be skipped correctly."""
+        fl = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "a"),
+            _make_lf_member(0, 0x74, 4, "b"),
+        ])
+        db = self._make_db([(LF_FIELDLIST, fl)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 2
+
+    def test_unknown_sub_leaf(self) -> None:
+        """Unknown sub-leaf should stop parsing (break)."""
+        # Unknown leaf 0x0001 followed by valid member
+        data = struct.pack("<H", 0x0001)  # unknown sub-leaf
+        data += _make_lf_member(0, 0x74, 0, "x")
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 0  # stopped at unknown
+
+    def test_truncated_lf_member(self) -> None:
+        """LF_MEMBER with truncated data should break out."""
+        data = struct.pack("<H", LF_MEMBER) + b"\x00" * 2  # only 2 extra bytes, need 6
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 0
+
+    def test_truncated_lf_enumerate(self) -> None:
+        """LF_ENUMERATE with truncated data should break out."""
+        data = struct.pack("<H", LF_ENUMERATE)  # no attr bytes
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 0
+
+    def test_truncated_lf_index(self) -> None:
+        """LF_INDEX with truncated data should break out."""
+        data = struct.pack("<H", LF_INDEX) + b"\x00" * 2  # need 4+ extra bytes
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 0
+
+
+class TestSkipSubrecord:
+    def _make_db(self, records: list[tuple[int, bytes]]) -> TypeDatabase:
+        tpi_data = _build_tpi_stream(records)
+        tpi = parse_tpi_stream(tpi_data)
+        db = TypeDatabase(tpi)
+        db.parse_all()
+        return db
+
+    def test_lf_stmember(self) -> None:
+        """LF_STMEMBER sub-record should be skipped, allowing next member."""
+        # Build fieldlist with LF_STMEMBER then LF_MEMBER
+        stmember = struct.pack("<HHI", LF_STMEMBER, 0, 0x74) + _cv_cstring("sval")
+        pad = (4 - (len(stmember) % 4)) % 4
+        stmember += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "x")
+        data = stmember + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "x" for m in members)
+
+    def test_lf_nesttype(self) -> None:
+        """LF_NESTTYPE should be skipped."""
+        nesttype = struct.pack("<HHI", LF_NESTTYPE, 0, 0x1001) + _cv_cstring("Inner")
+        pad = (4 - (len(nesttype) % 4)) % 4
+        nesttype += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "val")
+        data = nesttype + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "val" for m in members)
+
+    def test_lf_onemethod_nonvirtual(self) -> None:
+        """LF_ONEMETHOD (non-virtual) should be skipped."""
+        # attr with mprop=0 (not virtual), so no vbaseoff
+        onemethod = struct.pack("<HHI", LF_ONEMETHOD, 0, 0x1001) + _cv_cstring("foo")
+        pad = (4 - (len(onemethod) % 4)) % 4
+        onemethod += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "val")
+        data = onemethod + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "val" for m in members)
+
+    def test_lf_onemethod_virtual(self) -> None:
+        """LF_ONEMETHOD (intro virtual, mprop=4) has extra vbaseoff field."""
+        # mprop=4 → attr = 4 << 2 = 16
+        attr = 4 << 2
+        onemethod = struct.pack("<HHI", LF_ONEMETHOD, attr, 0x1001)
+        onemethod += struct.pack("<I", 0)  # vbaseoff
+        onemethod += _cv_cstring("vfunc")
+        pad = (4 - (len(onemethod) % 4)) % 4
+        onemethod += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "data")
+        data = onemethod + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "data" for m in members)
+
+    def test_lf_method(self) -> None:
+        """LF_METHOD should be skipped."""
+        method = struct.pack("<HHI", LF_METHOD, 1, 0x1001) + _cv_cstring("bar")
+        pad = (4 - (len(method) % 4)) % 4
+        method += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "v")
+        data = method + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "v" for m in members)
+
+    def test_lf_vfunctab(self) -> None:
+        """LF_VFUNCTAB should skip 6 bytes."""
+        vfunctab = struct.pack("<HHI", LF_VFUNCTAB, 0, 0x1001)
+        pad = (4 - (len(vfunctab) % 4)) % 4
+        vfunctab += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "w")
+        data = vfunctab + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "w" for m in members)
+
+    def test_lf_bclass(self) -> None:
+        """LF_BCLASS should skip attr(2) + type_ti(4) + numeric leaf."""
+        bclass = struct.pack("<HHI", LF_BCLASS, 0, 0x1001) + _cv_numeric(0)
+        pad = (4 - (len(bclass) % 4)) % 4
+        bclass += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "bval")
+        data = bclass + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "bval" for m in members)
+
+    def test_lf_vbclass(self) -> None:
+        """LF_VBCLASS should skip attr(2)+direct(4)+vbptr(4)+2 numeric leaves."""
+        vbclass = struct.pack("<HHII", LF_VBCLASS, 0, 0x1001, 0x1002)
+        vbclass += _cv_numeric(0)  # vbpoff
+        vbclass += _cv_numeric(0)  # vbtableoff
+        pad = (4 - (len(vbclass) % 4)) % 4
+        vbclass += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        member = _make_lf_member(0, 0x74, 0, "vb")
+        data = vbclass + member
+        db = self._make_db([(LF_FIELDLIST, data)])
+        members = db.get_fieldlist(0x1000)
+        assert any(m.name == "vb" for m in members)
+
+    def test_subrecord_truncated_data(self) -> None:
+        """Truncated sub-record data should return len(d)."""
+        # LF_STMEMBER with only 2 bytes after leaf — needs 6
+        data = struct.pack("<H", LF_STMEMBER) + b"\x00" * 2
+        db = self._make_db([(LF_FIELDLIST, data)])
+        # Should not crash, just stop parsing
+        members = db.get_fieldlist(0x1000)
+        assert members == []
+
+
+class TestDbiParserExtended:
+    def test_dbi_flags(self) -> None:
+        dbi_data = _build_dbi_stream(flags=0x01)
+        dbi = parse_dbi_stream(dbi_data)
+        assert dbi.header.flags == 0x01

--- a/tests/test_pdb_parser.py
+++ b/tests/test_pdb_parser.py
@@ -323,7 +323,7 @@ def _make_lf_fieldlist(sub_records: list[bytes]) -> bytes:
         data += rec
         # 4-byte align
         pad = (4 - (len(data) % 4)) % 4
-        data += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        data += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
     return data
 
 
@@ -1087,7 +1087,7 @@ class TestFieldlistExtended:
         fl1_data = _make_lf_member(0, 0x74, 0, "a")
         # Pad to 4-byte boundary
         pad = (4 - (len(fl1_data) % 4)) % 4
-        fl1_data += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        fl1_data += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         # Add LF_INDEX sub-record: leaf(2) + pad(2) + cont_ti(4)
         fl1_data += struct.pack("<HHI", LF_INDEX, 0, 0x1001)
 
@@ -1166,7 +1166,7 @@ class TestSkipSubrecord:
         # Build fieldlist with LF_STMEMBER then LF_MEMBER
         stmember = struct.pack("<HHI", LF_STMEMBER, 0, 0x74) + _cv_cstring("sval")
         pad = (4 - (len(stmember) % 4)) % 4
-        stmember += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        stmember += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "x")
         data = stmember + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1177,7 +1177,7 @@ class TestSkipSubrecord:
         """LF_NESTTYPE should be skipped."""
         nesttype = struct.pack("<HHI", LF_NESTTYPE, 0, 0x1001) + _cv_cstring("Inner")
         pad = (4 - (len(nesttype) % 4)) % 4
-        nesttype += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        nesttype += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "val")
         data = nesttype + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1189,7 +1189,7 @@ class TestSkipSubrecord:
         # attr with mprop=0 (not virtual), so no vbaseoff
         onemethod = struct.pack("<HHI", LF_ONEMETHOD, 0, 0x1001) + _cv_cstring("foo")
         pad = (4 - (len(onemethod) % 4)) % 4
-        onemethod += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        onemethod += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "val")
         data = onemethod + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1204,7 +1204,7 @@ class TestSkipSubrecord:
         onemethod += struct.pack("<I", 0)  # vbaseoff
         onemethod += _cv_cstring("vfunc")
         pad = (4 - (len(onemethod) % 4)) % 4
-        onemethod += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        onemethod += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "data")
         data = onemethod + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1215,7 +1215,7 @@ class TestSkipSubrecord:
         """LF_METHOD should be skipped."""
         method = struct.pack("<HHI", LF_METHOD, 1, 0x1001) + _cv_cstring("bar")
         pad = (4 - (len(method) % 4)) % 4
-        method += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        method += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "v")
         data = method + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1226,7 +1226,7 @@ class TestSkipSubrecord:
         """LF_VFUNCTAB should skip 6 bytes."""
         vfunctab = struct.pack("<HHI", LF_VFUNCTAB, 0, 0x1001)
         pad = (4 - (len(vfunctab) % 4)) % 4
-        vfunctab += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        vfunctab += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "w")
         data = vfunctab + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1237,7 +1237,7 @@ class TestSkipSubrecord:
         """LF_BCLASS should skip attr(2) + type_ti(4) + numeric leaf."""
         bclass = struct.pack("<HHI", LF_BCLASS, 0, 0x1001) + _cv_numeric(0)
         pad = (4 - (len(bclass) % 4)) % 4
-        bclass += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        bclass += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "bval")
         data = bclass + member
         db = self._make_db([(LF_FIELDLIST, data)])
@@ -1250,7 +1250,7 @@ class TestSkipSubrecord:
         vbclass += _cv_numeric(0)  # vbpoff
         vbclass += _cv_numeric(0)  # vbtableoff
         pad = (4 - (len(vbclass) % 4)) % 4
-        vbclass += bytes([0xF0 + pad - 1] * pad) if pad else b""
+        vbclass += bytes([0xF0 + n for n in range(pad, 0, -1)]) if pad else b""
         member = _make_lf_member(0, 0x74, 0, "vb")
         data = vbclass + member
         db = self._make_db([(LF_FIELDLIST, data)])

--- a/tests/test_pdb_parser.py
+++ b/tests/test_pdb_parser.py
@@ -1,0 +1,817 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the minimal PDB parser (pdb_parser.py).
+
+These tests validate the MSF container parser, TPI stream parser,
+numeric leaf decoding, type database resolution, and DBI stream parsing
+using synthetically constructed PDB-like byte streams.
+
+Data model consistency tests ensure that PDB-derived data produces the
+same DwarfMetadata / AdvancedDwarfMetadata structures as the DWARF pipeline.
+"""
+from __future__ import annotations
+
+import math
+import struct
+from pathlib import Path
+
+import pytest
+
+from abicheck.pdb_parser import (
+    LF_ARRAY,
+    LF_BITFIELD,
+    LF_CHAR,
+    LF_CLASS,
+    LF_ENUM,
+    LF_ENUMERATE,
+    LF_FIELDLIST,
+    LF_LONG,
+    LF_MEMBER,
+    LF_MFUNCTION,
+    LF_MODIFIER,
+    LF_POINTER,
+    LF_PROCEDURE,
+    LF_SHORT,
+    LF_STRUCTURE,
+    LF_ULONG,
+    LF_UNION,
+    LF_USHORT,
+    MsfFile,
+    TpiRecord,
+    TpiStream,
+    TypeDatabase,
+    _CC_NAMES,
+    _read_cstring,
+    _read_numeric_leaf,
+    parse_dbi_stream,
+    parse_msf,
+    parse_tpi_stream,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal MSF PDB file in memory
+# ---------------------------------------------------------------------------
+
+_BLOCK_SIZE = 4096
+_MSF_MAGIC = b"Microsoft C/C++ MSF 7.00\r\n\x1a\x44\x53\x00\x00\x00"
+
+
+def _pad_block(data: bytes, block_size: int = _BLOCK_SIZE) -> bytes:
+    """Pad data to a multiple of block_size."""
+    remainder = len(data) % block_size
+    if remainder:
+        data += b"\x00" * (block_size - remainder)
+    return data
+
+
+def _build_tpi_stream(records: list[tuple[int, bytes]]) -> bytes:
+    """Build a TPI stream from a list of (leaf_type, payload) tuples.
+
+    Returns the raw TPI stream bytes (header + records).
+    """
+    ti_begin = 0x1000
+    ti_end = ti_begin + len(records)
+
+    # Build record data
+    rec_data = b""
+    for leaf, payload in records:
+        rec_len = 2 + len(payload)  # leaf (2) + payload
+        rec_bytes = struct.pack("<HH", rec_len, leaf) + payload
+        # 4-byte alignment
+        pad = (4 - (len(rec_bytes) % 4)) % 4
+        rec_bytes += b"\x00" * pad
+        rec_data += rec_bytes
+
+    # TPI header (56 bytes)
+    version = 20040203
+    header_size = 56
+    # The rest of the header fields (hash info) — zeros
+    header = struct.pack("<IIIII", version, header_size, ti_begin, ti_end, len(rec_data))
+    header += b"\x00" * (header_size - len(header))
+
+    return header + rec_data
+
+
+def _build_dbi_stream(
+    machine: int = 0x8664,
+    build_major: int = 14,
+    build_minor: int = 36,
+    flags: int = 0,
+    modules: list[tuple[str, str]] | None = None,
+) -> bytes:
+    """Build a minimal DBI stream.
+
+    Args:
+        machine: CPU type (0x8664 = AMD64, 0x014C = x86)
+        build_major: major version (bits 8-14 of build_number)
+        build_minor: minor version (bits 0-7 of build_number)
+        flags: DBI flags
+        modules: list of (module_name, obj_file_name) pairs
+    """
+    modules = modules or []
+    build_number = (build_major << 8) | build_minor | 0x8000  # new format flag
+
+    # Build module info substream
+    mod_data = b""
+    for mod_name, obj_name in modules:
+        # Fixed part (64 bytes)
+        fixed = struct.pack(
+            "<IHHiiIHHIIHHIIIHHIII",
+            0,              # Unused1
+            0, 0,           # Section, Padding1
+            0, 0,           # Offset, Size
+            0,              # Characteristics
+            0, 0,           # ModuleIndex, Padding2
+            0, 0,           # DataCrc, RelocCrc
+            0,              # Flags
+            0xFFFF,         # ModuleSymStream (nil)
+            0, 0, 0,        # SymByteSize, C11ByteSize, C13ByteSize
+            0, 0,           # SourceFileCount, Padding
+            0,              # Unused2
+            0, 0,           # SourceFileNameIndex, PdbFilePathNameIndex
+        )
+        entry = fixed + mod_name.encode() + b"\x00" + obj_name.encode() + b"\x00"
+        # 4-byte align
+        pad = (4 - (len(entry) % 4)) % 4
+        entry += b"\x00" * pad
+        mod_data += entry
+
+    # DBI header (64 bytes)
+    header = struct.pack(
+        "<iIIHHHHHHiiiiiIiiHHI",
+        -1,                     # VersionSignature
+        20040203,               # VersionHeader
+        1,                      # Age
+        0xFFFF,                 # GlobalStreamIndex
+        build_number,           # BuildNumber
+        0xFFFF,                 # PublicStreamIndex
+        0,                      # PdbDllVersion
+        0xFFFF,                 # SymRecordStream
+        0,                      # PdbDllRbld (skipped in unpack — mapped as fields[8])
+        len(mod_data),          # ModInfoSize
+        0,                      # SectionContributionSize
+        0,                      # SectionMapSize
+        0,                      # SourceInfoSize
+        0,                      # TypeServerMapSize
+        0,                      # MFCTypeServerIndex
+        0,                      # OptionalDbgHeaderSize
+        0,                      # ECSubstreamSize
+        flags,                  # Flags
+        machine,                # Machine
+        0,                      # Padding
+    )
+
+    return header + mod_data
+
+
+def _build_minimal_pdb(
+    tpi_records: list[tuple[int, bytes]] | None = None,
+    dbi_data: bytes | None = None,
+) -> bytes:
+    """Construct a minimal valid PDB 7.0 file in memory.
+
+    The file contains:
+    - Block 0: superblock
+    - Block 1: FPM1
+    - Block 2: FPM2
+    - Blocks 3+: stream directory and stream data
+    """
+    tpi_data = _build_tpi_stream(tpi_records or [])
+    dbi_data = dbi_data or _build_dbi_stream()
+
+    # Stream 0: Old MSF directory (empty)
+    # Stream 1: PDB info stream (minimal)
+    pdb_info = struct.pack("<III", 20000404, 0, 1)  # version, signature, age
+    pdb_info += b"\x00" * 16  # GUID
+    # Stream 2: TPI
+    # Stream 3: DBI
+
+    streams = [
+        b"",        # Stream 0 (old directory)
+        pdb_info,   # Stream 1 (PDB info)
+        tpi_data,   # Stream 2 (TPI)
+        dbi_data,   # Stream 3 (DBI)
+    ]
+
+    # Allocate blocks for each stream
+    # First 3 blocks: superblock, FPM1, FPM2
+    next_block = 5  # blocks 3-4 reserved for stream directory
+
+    stream_sizes = [len(s) for s in streams]
+    stream_blocks: list[list[int]] = []
+
+    for s in streams:
+        n_blocks = math.ceil(len(s) / _BLOCK_SIZE) if s else 0
+        blocks = list(range(next_block, next_block + n_blocks))
+        stream_blocks.append(blocks)
+        next_block += n_blocks
+
+    # Build stream directory
+    dir_data = struct.pack("<I", len(streams))
+    for sz in stream_sizes:
+        dir_data += struct.pack("<i", sz)
+    for blocks in stream_blocks:
+        for b in blocks:
+            dir_data += struct.pack("<I", b)
+
+    dir_blocks_needed = math.ceil(len(dir_data) / _BLOCK_SIZE) or 1
+    # Place directory at blocks 3,4,...
+    dir_block_list = list(range(3, 3 + dir_blocks_needed))
+    # Block map block: points to the directory block indices
+    block_map_block = 3 + dir_blocks_needed
+    if block_map_block >= next_block:
+        next_block = block_map_block + 1
+
+    num_blocks = next_block
+
+    # Build the full file
+    file_data = bytearray(num_blocks * _BLOCK_SIZE)
+
+    # Superblock (block 0)
+    superblock = _MSF_MAGIC
+    superblock += struct.pack("<IIIIII",
+                              _BLOCK_SIZE,     # BlockSize
+                              1,               # FreeBlockMapBlock
+                              num_blocks,      # NumBlocks
+                              len(dir_data),   # NumDirectoryBytes
+                              0,               # Unknown
+                              block_map_block) # BlockMapAddr
+    file_data[:len(superblock)] = superblock
+
+    # Write directory blocks
+    dir_padded = _pad_block(dir_data, _BLOCK_SIZE)
+    for i, blk in enumerate(dir_block_list):
+        start = blk * _BLOCK_SIZE
+        chunk = dir_padded[i * _BLOCK_SIZE:(i + 1) * _BLOCK_SIZE]
+        file_data[start:start + len(chunk)] = chunk
+
+    # Write block map (at block_map_block)
+    bm_data = b""
+    for blk in dir_block_list:
+        bm_data += struct.pack("<I", blk)
+    bm_offset = block_map_block * _BLOCK_SIZE
+    file_data[bm_offset:bm_offset + len(bm_data)] = bm_data
+
+    # Write stream data
+    for i, s in enumerate(streams):
+        for j, blk in enumerate(stream_blocks[i]):
+            start = blk * _BLOCK_SIZE
+            chunk_start = j * _BLOCK_SIZE
+            chunk = s[chunk_start:chunk_start + _BLOCK_SIZE]
+            file_data[start:start + len(chunk)] = chunk
+
+    return bytes(file_data)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build CodeView type records
+# ---------------------------------------------------------------------------
+
+def _cv_cstring(name: str) -> bytes:
+    """Null-terminated string."""
+    return name.encode("utf-8") + b"\x00"
+
+
+def _cv_numeric(value: int) -> bytes:
+    """Encode a CodeView numeric leaf."""
+    if 0 <= value < 0x8000:
+        return struct.pack("<H", value)
+    if -128 <= value <= 127:
+        return struct.pack("<Hb", LF_CHAR, value)
+    if 0 <= value <= 0xFFFF:
+        return struct.pack("<HH", LF_USHORT, value)
+    if -32768 <= value <= 32767:
+        return struct.pack("<Hh", LF_SHORT, value)
+    if 0 <= value <= 0xFFFFFFFF:
+        return struct.pack("<HI", LF_ULONG, value)
+    return struct.pack("<Hi", LF_LONG, value)
+
+
+def _make_lf_member(attr: int, type_ti: int, offset: int, name: str) -> bytes:
+    """Build an LF_MEMBER sub-record (for inside LF_FIELDLIST)."""
+    return struct.pack("<HHI", LF_MEMBER, attr, type_ti) + _cv_numeric(offset) + _cv_cstring(name)
+
+
+def _make_lf_enumerate(attr: int, value: int, name: str) -> bytes:
+    """Build an LF_ENUMERATE sub-record."""
+    return struct.pack("<HH", LF_ENUMERATE, attr) + _cv_numeric(value) + _cv_cstring(name)
+
+
+def _make_lf_fieldlist(sub_records: list[bytes]) -> bytes:
+    """Build LF_FIELDLIST payload from sub-record bytes."""
+    data = b""
+    for rec in sub_records:
+        data += rec
+        # 4-byte align
+        pad = (4 - (len(data) % 4)) % 4
+        data += bytes([0xF0 + pad - 1] * pad) if pad else b""
+    return data
+
+
+def _make_lf_structure(
+    count: int, prop: int, field_ti: int,
+    byte_size: int, name: str,
+) -> bytes:
+    """Build LF_STRUCTURE / LF_CLASS payload."""
+    return struct.pack("<HHIII", count, prop, field_ti, 0, 0) + _cv_numeric(byte_size) + _cv_cstring(name)
+
+
+def _make_lf_union(count: int, prop: int, field_ti: int, byte_size: int, name: str) -> bytes:
+    """Build LF_UNION payload."""
+    return struct.pack("<HHI", count, prop, field_ti) + _cv_numeric(byte_size) + _cv_cstring(name)
+
+
+def _make_lf_enum(count: int, prop: int, utype_ti: int, field_ti: int, name: str) -> bytes:
+    """Build LF_ENUM payload."""
+    return struct.pack("<HHII", count, prop, utype_ti, field_ti) + _cv_cstring(name)
+
+
+def _make_lf_procedure(rvtype: int, calltype: int, parmcount: int, arglist: int) -> bytes:
+    """Build LF_PROCEDURE payload."""
+    return struct.pack("<IBBHI", rvtype, calltype, 0, parmcount, arglist)
+
+
+def _make_lf_mfunction(
+    rvtype: int, classtype: int, thistype: int,
+    calltype: int, parmcount: int, arglist: int, thisadjust: int = 0,
+) -> bytes:
+    """Build LF_MFUNCTION payload."""
+    return struct.pack("<IIIBBHIi", rvtype, classtype, thistype,
+                       calltype, 0, parmcount, arglist, thisadjust)
+
+
+def _make_lf_pointer(referent_ti: int, size: int = 8, mode: int = 0) -> bytes:
+    """Build LF_POINTER payload."""
+    # attrs: bits 13-18 = size, bits 5-7 = mode
+    attrs = (size << 13) | (mode << 5) | 0x0C  # near64
+    return struct.pack("<II", referent_ti, attrs)
+
+
+def _make_lf_modifier(modified_ti: int, is_const: bool = False, is_volatile: bool = False) -> bytes:
+    """Build LF_MODIFIER payload."""
+    attr = 0
+    if is_const:
+        attr |= 0x01
+    if is_volatile:
+        attr |= 0x02
+    return struct.pack("<IH", modified_ti, attr)
+
+
+def _make_lf_bitfield(underlying_ti: int, length: int, position: int) -> bytes:
+    """Build LF_BITFIELD payload."""
+    return struct.pack("<IBB", underlying_ti, length, position)
+
+
+def _make_lf_array(elem_ti: int, idx_ti: int, byte_size: int, name: str = "") -> bytes:
+    """Build LF_ARRAY payload."""
+    return struct.pack("<II", elem_ti, idx_ti) + _cv_numeric(byte_size) + _cv_cstring(name)
+
+
+# ---------------------------------------------------------------------------
+# Tests: numeric leaf decoding
+# ---------------------------------------------------------------------------
+
+class TestNumericLeaf:
+    def test_inline_value(self) -> None:
+        data = struct.pack("<H", 42)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == 42
+        assert pos == 2
+
+    def test_lf_char(self) -> None:
+        data = struct.pack("<Hb", LF_CHAR, -5)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == -5
+        assert pos == 3
+
+    def test_lf_short(self) -> None:
+        data = struct.pack("<Hh", LF_SHORT, -1000)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == -1000
+        assert pos == 4
+
+    def test_lf_ushort(self) -> None:
+        data = struct.pack("<HH", LF_USHORT, 50000)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == 50000
+        assert pos == 4
+
+    def test_lf_long(self) -> None:
+        data = struct.pack("<Hi", LF_LONG, -100000)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == -100000
+        assert pos == 6
+
+    def test_lf_ulong(self) -> None:
+        data = struct.pack("<HI", LF_ULONG, 0xDEADBEEF)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == 0xDEADBEEF
+        assert pos == 6
+
+    def test_zero(self) -> None:
+        data = struct.pack("<H", 0)
+        val, pos = _read_numeric_leaf(data, 0)
+        assert val == 0
+        assert pos == 2
+
+
+class TestCString:
+    def test_simple(self) -> None:
+        data = b"hello\x00world"
+        s, pos = _read_cstring(data, 0)
+        assert s == "hello"
+        assert pos == 6
+
+    def test_at_offset(self) -> None:
+        data = b"\x00\x00foo\x00"
+        s, pos = _read_cstring(data, 2)
+        assert s == "foo"
+        assert pos == 6
+
+    def test_empty(self) -> None:
+        data = b"\x00rest"
+        s, pos = _read_cstring(data, 0)
+        assert s == ""
+        assert pos == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: MSF parser
+# ---------------------------------------------------------------------------
+
+class TestMsfParser:
+    def test_valid_pdb(self, tmp_path: Path) -> None:
+        pdb_data = _build_minimal_pdb()
+        pdb_file = tmp_path / "test.pdb"
+        pdb_file.write_bytes(pdb_data)
+        msf = parse_msf(pdb_data)
+        assert msf.block_size == _BLOCK_SIZE
+        assert msf.stream_count() == 4
+
+    def test_bad_magic(self) -> None:
+        with pytest.raises(ValueError, match="Not a PDB"):
+            parse_msf(b"not a pdb file" + b"\x00" * 100)
+
+    def test_too_small(self) -> None:
+        with pytest.raises(ValueError, match="too small"):
+            parse_msf(b"tiny")
+
+    def test_stream_data_round_trip(self) -> None:
+        """Verify stream data can be read back correctly."""
+        dbi_data = _build_dbi_stream(machine=0x014C)
+        pdb_data = _build_minimal_pdb(dbi_data=dbi_data)
+        msf = parse_msf(pdb_data)
+        # Stream 3 = DBI
+        stream3 = msf.stream_data(3)
+        assert len(stream3) == len(dbi_data)
+        assert stream3 == dbi_data
+
+
+# ---------------------------------------------------------------------------
+# Tests: TPI stream parser
+# ---------------------------------------------------------------------------
+
+class TestTpiParser:
+    def test_empty_tpi(self) -> None:
+        tpi_data = _build_tpi_stream([])
+        tpi = parse_tpi_stream(tpi_data)
+        assert tpi.type_index_begin == 0x1000
+        assert tpi.type_index_end == 0x1000
+        assert len(tpi.records) == 0
+
+    def test_single_structure(self) -> None:
+        fieldlist_payload = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "x"),   # int x at offset 0
+            _make_lf_member(0, 0x74, 4, "y"),   # int y at offset 4
+        ])
+        struct_payload = _make_lf_structure(
+            count=2, prop=0, field_ti=0x1000,
+            byte_size=8, name="Point",
+        )
+        tpi_data = _build_tpi_stream([
+            (LF_FIELDLIST, fieldlist_payload),   # ti=0x1000
+            (LF_STRUCTURE, struct_payload),      # ti=0x1001
+        ])
+        tpi = parse_tpi_stream(tpi_data)
+        assert len(tpi.records) == 2
+        assert tpi.records[0].type_index == 0x1000
+        assert tpi.records[0].leaf == LF_FIELDLIST
+        assert tpi.records[1].type_index == 0x1001
+        assert tpi.records[1].leaf == LF_STRUCTURE
+
+    def test_too_small_tpi(self) -> None:
+        with pytest.raises(ValueError, match="too small"):
+            parse_tpi_stream(b"\x00" * 10)
+
+
+# ---------------------------------------------------------------------------
+# Tests: TypeDatabase
+# ---------------------------------------------------------------------------
+
+class TestTypeDatabase:
+    def _make_db(self, records: list[tuple[int, bytes]]) -> TypeDatabase:
+        tpi_data = _build_tpi_stream(records)
+        tpi = parse_tpi_stream(tpi_data)
+        db = TypeDatabase(tpi)
+        db.parse_all()
+        return db
+
+    def test_simple_type_names(self) -> None:
+        db = self._make_db([])
+        assert db.type_name(0x74) == "int"       # int (kind=0x74)
+        assert db.type_name(0x75) == "unsigned int"
+        assert db.type_name(0x03) == "void"
+        assert db.type_name(0x40) == "float"
+        assert db.type_name(0x41) == "double"
+
+    def test_simple_type_sizes(self) -> None:
+        db = self._make_db([])
+        assert db.type_size(0x74) == 4   # int
+        assert db.type_size(0x41) == 8   # double
+        assert db.type_size(0x10) == 1   # signed char
+        assert db.type_size(0x03) == 0   # void
+
+    def test_simple_pointer_type(self) -> None:
+        db = self._make_db([])
+        # Near64 pointer to int (kind=0x74, mode=0x06)
+        ti = 0x0674
+        assert "int" in db.type_name(ti)
+        assert "*" in db.type_name(ti)
+        assert db.type_size(ti) == 8
+
+    def test_struct_resolution(self) -> None:
+        fieldlist_payload = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "x"),
+            _make_lf_member(0, 0x74, 4, "y"),
+        ])
+        struct_payload = _make_lf_structure(
+            count=2, prop=0, field_ti=0x1000,
+            byte_size=8, name="Point",
+        )
+        db = self._make_db([
+            (LF_FIELDLIST, fieldlist_payload),
+            (LF_STRUCTURE, struct_payload),
+        ])
+
+        s = db.resolve_struct(0x1001)
+        assert s is not None
+        assert s.name == "Point"
+        assert s.byte_size == 8
+        assert s.count == 2
+        assert not s.is_forward_ref
+        assert not s.is_union
+
+        fields = db.get_fieldlist(0x1000)
+        assert len(fields) == 2
+        assert fields[0].name == "x"
+        assert fields[0].offset == 0
+        assert fields[1].name == "y"
+        assert fields[1].offset == 4
+
+    def test_forward_ref_resolution(self) -> None:
+        """Forward-ref struct should resolve to the definition."""
+        fwd_payload = _make_lf_structure(
+            count=0, prop=0x0080, field_ti=0,
+            byte_size=0, name="Foo",
+        )
+        fieldlist_payload = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "val"),
+        ])
+        def_payload = _make_lf_structure(
+            count=1, prop=0, field_ti=0x1001,
+            byte_size=4, name="Foo",
+        )
+        db = self._make_db([
+            (LF_STRUCTURE, fwd_payload),       # ti=0x1000 (fwd ref)
+            (LF_FIELDLIST, fieldlist_payload),  # ti=0x1001
+            (LF_STRUCTURE, def_payload),        # ti=0x1002 (definition)
+        ])
+
+        s = db.resolve_struct(0x1000)
+        assert s is not None
+        assert s.name == "Foo"
+        assert s.byte_size == 4
+
+    def test_union(self) -> None:
+        fieldlist = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "i"),
+            _make_lf_member(0, 0x40, 0, "f"),
+        ])
+        union_payload = _make_lf_union(
+            count=2, prop=0, field_ti=0x1000,
+            byte_size=4, name="Data",
+        )
+        db = self._make_db([
+            (LF_FIELDLIST, fieldlist),
+            (LF_UNION, union_payload),
+        ])
+        s = db.resolve_struct(0x1001)
+        assert s is not None
+        assert s.is_union
+        assert s.name == "Data"
+        assert s.byte_size == 4
+
+    def test_enum(self) -> None:
+        fieldlist = _make_lf_fieldlist([
+            _make_lf_enumerate(0, 0, "RED"),
+            _make_lf_enumerate(0, 1, "GREEN"),
+            _make_lf_enumerate(0, 2, "BLUE"),
+        ])
+        enum_payload = _make_lf_enum(
+            count=3, prop=0, utype_ti=0x74,
+            field_ti=0x1000, name="Color",
+        )
+        db = self._make_db([
+            (LF_FIELDLIST, fieldlist),
+            (LF_ENUM, enum_payload),
+        ])
+        e = db.resolve_enum(0x1001)
+        assert e is not None
+        assert e.name == "Color"
+        assert e.count == 3
+        members = db.get_fieldlist(0x1000)
+        assert len(members) == 3
+        assert members[0].name == "RED" and members[0].value == 0
+        assert members[2].name == "BLUE" and members[2].value == 2
+
+    def test_procedure(self) -> None:
+        proc_payload = _make_lf_procedure(0x74, 0x00, 2, 0x1001)
+        db = self._make_db([
+            (LF_PROCEDURE, proc_payload),
+        ])
+        p = db.get_procedure(0x1000)
+        assert p is not None
+        assert p.calling_convention == 0x00  # cdecl
+        assert p.param_count == 2
+        assert db.calling_convention_name(0x00) == "cdecl"
+
+    def test_mfunction(self) -> None:
+        mf_payload = _make_lf_mfunction(0x74, 0x1002, 0x1003, 0x0B, 1, 0x1004)
+        db = self._make_db([
+            (LF_MFUNCTION, mf_payload),
+        ])
+        mf = db.get_mfunction(0x1000)
+        assert mf is not None
+        assert mf.calling_convention == 0x0B  # thiscall
+        assert db.calling_convention_name(0x0B) == "thiscall"
+
+    def test_pointer_type_name(self) -> None:
+        ptr_payload = _make_lf_pointer(0x74, size=8)
+        db = self._make_db([
+            (LF_POINTER, ptr_payload),
+        ])
+        assert "int" in db.type_name(0x1000)
+        assert "*" in db.type_name(0x1000)
+
+    def test_modifier_const(self) -> None:
+        mod_payload = _make_lf_modifier(0x74, is_const=True)
+        db = self._make_db([
+            (LF_MODIFIER, mod_payload),
+        ])
+        name = db.type_name(0x1000)
+        assert "const" in name
+        assert "int" in name
+
+    def test_bitfield(self) -> None:
+        bf_payload = _make_lf_bitfield(0x74, length=3, position=5)
+        db = self._make_db([
+            (LF_BITFIELD, bf_payload),
+        ])
+        # Bitfield type name resolves to underlying type
+        assert db.type_name(0x1000) == "int"
+        assert db.type_size(0x1000) == 4
+
+    def test_array(self) -> None:
+        arr_payload = _make_lf_array(0x74, 0x74, 40, "")
+        db = self._make_db([
+            (LF_ARRAY, arr_payload),
+        ])
+        assert "int" in db.type_name(0x1000)
+        assert "[]" in db.type_name(0x1000)
+        assert db.type_size(0x1000) == 40
+
+    def test_packed_struct(self) -> None:
+        fieldlist = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "a"),
+        ])
+        struct_payload = _make_lf_structure(
+            count=1, prop=0x0800, field_ti=0x1000,  # packed flag
+            byte_size=4, name="Packed",
+        )
+        db = self._make_db([
+            (LF_FIELDLIST, fieldlist),
+            (LF_STRUCTURE, struct_payload),
+        ])
+        s = db.resolve_struct(0x1001)
+        assert s is not None
+        assert s.is_packed
+
+    def test_calling_convention_names(self) -> None:
+        assert _CC_NAMES[0x00] == "cdecl"
+        assert _CC_NAMES[0x04] == "fastcall"
+        assert _CC_NAMES[0x07] == "stdcall"
+        assert _CC_NAMES[0x0B] == "thiscall"
+        assert _CC_NAMES[0x18] == "vectorcall"
+
+
+# ---------------------------------------------------------------------------
+# Tests: DBI stream parser
+# ---------------------------------------------------------------------------
+
+class TestDbiParser:
+    def test_minimal_dbi(self) -> None:
+        dbi_data = _build_dbi_stream(machine=0x8664, build_major=14, build_minor=36)
+        dbi = parse_dbi_stream(dbi_data)
+        assert dbi.header.machine == 0x8664
+        # Build number: (14 << 8) | 36 | 0x8000
+        assert (dbi.header.build_number >> 8) & 0x7F == 14
+        assert dbi.header.build_number & 0xFF == 36
+
+    def test_dbi_with_modules(self) -> None:
+        modules = [
+            ("foo.obj", "C:\\src\\foo.cpp"),
+            ("bar.obj", "C:\\src\\bar.cpp"),
+        ]
+        dbi_data = _build_dbi_stream(modules=modules)
+        dbi = parse_dbi_stream(dbi_data)
+        assert len(dbi.modules) == 2
+        assert dbi.modules[0].module_name == "foo.obj"
+        assert dbi.modules[0].obj_file_name == "C:\\src\\foo.cpp"
+        assert dbi.modules[1].module_name == "bar.obj"
+
+    def test_dbi_x86(self) -> None:
+        dbi_data = _build_dbi_stream(machine=0x014C)
+        dbi = parse_dbi_stream(dbi_data)
+        assert dbi.header.machine == 0x014C
+
+    def test_too_small(self) -> None:
+        with pytest.raises(ValueError, match="too small"):
+            parse_dbi_stream(b"\x00" * 10)
+
+
+# ---------------------------------------------------------------------------
+# Tests: full PDB parse round-trip
+# ---------------------------------------------------------------------------
+
+class TestPdbRoundTrip:
+    def test_full_parse(self, tmp_path: Path) -> None:
+        """Build a PDB with struct + enum, parse it, verify types."""
+        # Fieldlist for struct Point { int x; int y; }
+        fl_struct = _make_lf_fieldlist([
+            _make_lf_member(0, 0x74, 0, "x"),
+            _make_lf_member(0, 0x74, 4, "y"),
+        ])
+        # Fieldlist for enum Color { RED=0, GREEN=1, BLUE=2 }
+        fl_enum = _make_lf_fieldlist([
+            _make_lf_enumerate(0, 0, "RED"),
+            _make_lf_enumerate(0, 1, "GREEN"),
+            _make_lf_enumerate(0, 2, "BLUE"),
+        ])
+
+        records = [
+            (LF_FIELDLIST, fl_struct),                                    # 0x1000
+            (LF_STRUCTURE, _make_lf_structure(2, 0, 0x1000, 8, "Point")), # 0x1001
+            (LF_FIELDLIST, fl_enum),                                      # 0x1002
+            (LF_ENUM, _make_lf_enum(3, 0, 0x74, 0x1002, "Color")),       # 0x1003
+            (LF_PROCEDURE, _make_lf_procedure(0x74, 0x07, 1, 0)),        # 0x1004 stdcall
+        ]
+
+        pdb_bytes = _build_minimal_pdb(tpi_records=records)
+        pdb_file = tmp_path / "test.pdb"
+        pdb_file.write_bytes(pdb_bytes)
+
+        from abicheck.pdb_parser import parse_pdb
+        pdb = parse_pdb(pdb_file)
+
+        assert pdb.tpi is not None
+        assert pdb.types is not None
+        assert pdb.dbi is not None
+
+        # Struct
+        s = pdb.types.resolve_struct(0x1001)
+        assert s is not None
+        assert s.name == "Point"
+        assert s.byte_size == 8
+
+        # Enum
+        e = pdb.types.resolve_enum(0x1003)
+        assert e is not None
+        assert e.name == "Color"
+
+        # Procedure
+        p = pdb.types.get_procedure(0x1004)
+        assert p is not None
+        assert p.calling_convention == 0x07  # stdcall

--- a/tests/test_pdb_utils.py
+++ b/tests/test_pdb_utils.py
@@ -1,0 +1,323 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PDB utility functions (pdb_utils.py)."""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from abicheck.pdb_utils import (
+    _extract_pdb_path_from_pe,
+    _is_network_path,
+    locate_pdb,
+)
+
+# ---------------------------------------------------------------------------
+# Tests: _is_network_path
+# ---------------------------------------------------------------------------
+
+class TestIsNetworkPath:
+    def test_unc_backslash(self) -> None:
+        assert _is_network_path("\\\\server\\share") is True
+
+    def test_unc_forward_slash(self) -> None:
+        assert _is_network_path("//server/share") is True
+
+    def test_regular_windows_path(self) -> None:
+        assert _is_network_path("C:\\foo\\bar.pdb") is False
+
+    def test_regular_unix_path(self) -> None:
+        assert _is_network_path("/home/user/foo.pdb") is False
+
+    def test_relative_path(self) -> None:
+        assert _is_network_path("foo.pdb") is False
+
+    def test_empty_string(self) -> None:
+        assert _is_network_path("") is False
+
+    def test_path_object(self) -> None:
+        assert _is_network_path(Path("/tmp/foo.pdb")) is False
+
+    def test_exception_handling(self) -> None:
+        """PureWindowsPath parsing exception should be logged and return False."""
+        with patch("abicheck.pdb_utils.PureWindowsPath") as mock_pwp:
+            mock_pwp.side_effect = TypeError("test error")
+            # Should not raise, returns False
+            assert _is_network_path("normal") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: locate_pdb
+# ---------------------------------------------------------------------------
+
+class TestLocatePdb:
+    def test_override_exists(self, tmp_path: Path) -> None:
+        pdb = tmp_path / "override.pdb"
+        pdb.write_bytes(b"fake pdb")
+        dll = tmp_path / "test.dll"
+        result = locate_pdb(dll, pdb_path_override=pdb)
+        assert result == pdb
+
+    def test_override_missing(self, tmp_path: Path) -> None:
+        pdb = tmp_path / "nonexistent.pdb"
+        dll = tmp_path / "test.dll"
+        result = locate_pdb(dll, pdb_path_override=pdb)
+        assert result is None
+
+    def test_stem_fallback(self, tmp_path: Path) -> None:
+        """Should find DLL_name.pdb in same directory."""
+        dll = tmp_path / "test.dll"
+        dll.write_bytes(b"MZ")
+        pdb = tmp_path / "test.pdb"
+        pdb.write_bytes(b"fake pdb")
+        with patch("abicheck.pdb_utils._extract_pdb_path_from_pe", return_value=None):
+            result = locate_pdb(dll)
+        assert result == pdb
+
+    def test_no_pdb_found(self, tmp_path: Path) -> None:
+        dll = tmp_path / "test.dll"
+        dll.write_bytes(b"MZ")
+        with patch("abicheck.pdb_utils._extract_pdb_path_from_pe", return_value=None):
+            result = locate_pdb(dll)
+        assert result is None
+
+    def test_embedded_path_local_fallback(self, tmp_path: Path) -> None:
+        """Embedded path doesn't exist, but filename in DLL dir does."""
+        dll = tmp_path / "test.dll"
+        dll.write_bytes(b"MZ")
+        pdb = tmp_path / "foo.pdb"
+        pdb.write_bytes(b"fake")
+        # Use forward slashes so Path.name works correctly on Linux
+        with patch("abicheck.pdb_utils._extract_pdb_path_from_pe",
+                    return_value="/nonexistent/build/foo.pdb"):
+            result = locate_pdb(dll)
+        assert result == pdb
+
+    def test_embedded_network_path_skipped(self, tmp_path: Path) -> None:
+        """Network path in PE should be skipped when allow_network=False."""
+        dll = tmp_path / "test.dll"
+        dll.write_bytes(b"MZ")
+        with patch("abicheck.pdb_utils._extract_pdb_path_from_pe",
+                    return_value="\\\\server\\share\\foo.pdb"):
+            result = locate_pdb(dll, allow_network=False)
+        assert result is None
+
+    def test_embedded_network_path_allowed(self, tmp_path: Path) -> None:
+        """Network path in PE should be tried when allow_network=True."""
+        dll = tmp_path / "test.dll"
+        dll.write_bytes(b"MZ")
+        with patch("abicheck.pdb_utils._extract_pdb_path_from_pe",
+                    return_value="\\\\server\\share\\foo.pdb"):
+            # The network path won't exist, so returns None
+            result = locate_pdb(dll, allow_network=True)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_pdb_path_from_pe
+# ---------------------------------------------------------------------------
+
+class TestExtractPdbPath:
+    def test_invalid_pe(self, tmp_path: Path) -> None:
+        """Non-PE file should return None."""
+        f = tmp_path / "bad.exe"
+        f.write_bytes(b"not a PE")
+        assert _extract_pdb_path_from_pe(f) is None
+
+    def test_rsds_bytes_entry(self) -> None:
+        """RSDS entry with PdbFileName as bytes."""
+        pdb_name = b"C:\\build\\test.pdb\x00"
+        cv_sig = struct.unpack("<I", b"RSDS")[0]
+
+        entry = SimpleNamespace(
+            CvSignature=cv_sig,
+            PdbFileName=pdb_name,
+        )
+        dbg_struct = SimpleNamespace(Type=2)
+        dbg = SimpleNamespace(struct=dbg_struct, entry=entry)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result == "C:\\build\\test.pdb"
+
+    def test_rsds_string_entry(self) -> None:
+        """RSDS entry with PdbFileName as string (not bytes)."""
+        cv_sig = struct.unpack("<I", b"RSDS")[0]
+
+        entry = SimpleNamespace(
+            CvSignature=cv_sig,
+            PdbFileName="C:\\build\\test.pdb",
+        )
+        dbg_struct = SimpleNamespace(Type=2)
+        dbg = SimpleNamespace(struct=dbg_struct, entry=entry)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result == "C:\\build\\test.pdb"
+
+    def test_nb10_entry(self) -> None:
+        """NB10 entry should also extract PdbFileName."""
+        cv_sig = struct.unpack("<I", b"NB10")[0]
+
+        entry = SimpleNamespace(
+            CvSignature=cv_sig,
+            PdbFileName=b"old.pdb\x00",
+        )
+        dbg_struct = SimpleNamespace(Type=2)
+        dbg = SimpleNamespace(struct=dbg_struct, entry=entry)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result == "old.pdb"
+
+    def test_no_debug_directory(self) -> None:
+        """PE with no DIRECTORY_ENTRY_DEBUG should return None."""
+        mock_pe = MagicMock(spec=[])  # no attributes
+        mock_pe.parse_data_directories = MagicMock()
+        mock_pe.close = MagicMock()
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result is None
+
+    def test_non_codeview_entry_skipped(self) -> None:
+        """Non-CodeView debug entries (Type != 2) should be skipped."""
+        dbg_struct = SimpleNamespace(Type=9)  # IMAGE_DEBUG_TYPE_BORLAND
+        dbg = SimpleNamespace(struct=dbg_struct, entry=None)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result is None
+
+    def test_raw_data_fallback(self) -> None:
+        """When entry is None, should fall back to raw data parsing."""
+        # Build RSDS raw data: sig(4) + GUID(16) + age(4) + filename
+        raw = b"RSDS" + b"\x00" * 16 + struct.pack("<I", 1) + b"raw.pdb\x00"
+
+        dbg_struct = SimpleNamespace(
+            Type=2,
+            AddressOfRawData=0x1000,
+            SizeOfData=len(raw),
+        )
+        dbg = SimpleNamespace(struct=dbg_struct, entry=None)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+        mock_pe.get_data.return_value = raw
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result == "raw.pdb"
+
+    def test_raw_data_no_rsds(self) -> None:
+        """Raw data that doesn't start with RSDS should be skipped."""
+        raw = b"XXXX" + b"\x00" * 20 + b"nope.pdb\x00"
+
+        dbg_struct = SimpleNamespace(
+            Type=2,
+            AddressOfRawData=0x1000,
+            SizeOfData=len(raw),
+        )
+        dbg = SimpleNamespace(struct=dbg_struct, entry=None)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+        mock_pe.get_data.return_value = raw
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result is None
+
+    def test_parse_exception(self) -> None:
+        """Exception during parsing should return None."""
+        mock_pe = MagicMock()
+        mock_pe.parse_data_directories.side_effect = RuntimeError("parse fail")
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result is None
+
+    def test_entry_no_cvsignature(self) -> None:
+        """Entry without CvSignature attr should be skipped."""
+        entry = SimpleNamespace()  # no CvSignature
+        dbg_struct = SimpleNamespace(Type=2)
+        dbg = SimpleNamespace(struct=dbg_struct, entry=entry)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result is None
+
+    def test_raw_data_no_address(self) -> None:
+        """When entry is None and AddressOfRawData is 0, should skip."""
+        dbg_struct = SimpleNamespace(
+            Type=2,
+            AddressOfRawData=0,
+            SizeOfData=100,
+        )
+        dbg = SimpleNamespace(struct=dbg_struct, entry=None)
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_DEBUG = [dbg]
+
+        with patch("abicheck.pdb_utils.pefile") as mock_pefile:
+            mock_pefile.PE.return_value = mock_pe
+            mock_pefile.DIRECTORY_ENTRY = {"IMAGE_DIRECTORY_ENTRY_DEBUG": 6}
+            result = _extract_pdb_path_from_pe(Path("test.dll"))
+
+        assert result is None

--- a/tests/test_pdb_utils.py
+++ b/tests/test_pdb_utils.py
@@ -49,8 +49,8 @@ class TestIsNetworkPath:
     def test_empty_string(self) -> None:
         assert _is_network_path("") is False
 
-    def test_path_object(self) -> None:
-        assert _is_network_path(Path("/tmp/foo.pdb")) is False
+    def test_path_object(self, tmp_path: Path) -> None:
+        assert _is_network_path(tmp_path / "foo.pdb") is False
 
     def test_exception_handling(self) -> None:
         """PureWindowsPath parsing exception should be logged and return False."""


### PR DESCRIPTION
## Summary

Implements a pure-Python PDB (Program Database) parser for Windows PE binaries, enabling ABI checking on Windows platforms with debug information. The implementation includes MSF container parsing, TPI/DBI stream extraction, CodeView type record interpretation, and integration with the existing DWARF metadata model.

## Key Changes

- **`abicheck/pdb_parser.py`** (1159 lines): Core PDB parsing implementation
  - MSF 7.0 container parser with block-based stream extraction
  - TPI stream parser for CodeView type records (LF_STRUCTURE, LF_CLASS, LF_UNION, LF_ENUM, LF_MEMBER, LF_PROCEDURE, LF_MFUNCTION, LF_MODIFIER, LF_POINTER, LF_ARRAY, LF_BITFIELD, etc.)
  - DBI stream parser for module info and toolchain metadata
  - `TypeDatabase` class for indexed type record lookup and name/size resolution
  - Numeric leaf decoding for variable-length integer encoding in CodeView
  - Support for simple (built-in) types and user-defined types with forward reference resolution

- **`abicheck/pdb_metadata.py`** (310 lines): High-level metadata extraction
  - Converts PDB type records into `DwarfMetadata` and `AdvancedDwarfMetadata` dataclasses (same model as DWARF pipeline)
  - Struct/class/union layout extraction with field offsets and types
  - Enum member extraction with underlying type resolution
  - Calling convention detection from procedure/member function records
  - Toolchain info extraction (machine type, build number) from DBI header

- **`abicheck/pdb_utils.py`** (132 lines): PDB file location utilities
  - PE debug directory parsing to extract embedded PDB path and GUID
  - Search strategy: explicit override → embedded path → local .pdb file
  - Uses `pefile` library for PE binary inspection

- **`tests/test_pdb_parser.py`** (817 lines): Comprehensive parser tests
  - MSF container construction and parsing validation
  - TPI stream record parsing (all supported CodeView leaf types)
  - Numeric leaf decoding edge cases
  - DBI stream parsing with module info
  - Type database lookup and forward reference resolution
  - Synthetic PDB file generation for testing

- **`tests/test_pdb_metadata.py`** (456 lines): Metadata extraction tests
  - Data model consistency: PDB-derived metadata matches DWARF pipeline output
  - Struct layout validation (field offsets, sizes, types)
  - Union and bitfield handling
  - Enum member extraction
  - Calling convention detection
  - Packed struct and forward reference handling

- **`abicheck/cli.py`**: Integration with existing CLI
  - Added `--pdb-path` option for explicit PDB file specification
  - PDB debug info extraction in `_dump_native_binary()` for PE binaries
  - Fallback to `locate_pdb()` if not explicitly provided

- **Documentation updates**:
  - `docs/reference/architecture.md`: PDB support now implemented (not planned)
  - `docs/concepts/limitations.md`: Updated platform/format support matrix
  - `README.md`: Updated feature list
  - `pyproject.toml`: Added new modules to mypy configuration

## Implementation Details

- **No external GPL/AGPL dependencies**: Uses only Python standard library (`struct`, `dataclasses`, `pathlib`) plus existing `pefile` dependency
- **Unified data model**: PDB metadata produces identical `DwarfMetadata`/`AdvancedDwarfMetadata` structures as DWARF pipeline, allowing checker's `_diff_dwarf()` and `_diff_advanced_dwarf()` detectors to work without modification
- **Robust error handling**: Graceful degradation on malformed PDB files; never raises exceptions in public API
- **Type index resolution**: Handles both simple types (built-in) and user-defined types with proper forward reference → definition mapping
- **CodeView record subset**: Implements only the ABI-relevant record types (structures, en

https://claude.ai/code/session_01HMCBHTpz76oUwN6jFPiRZA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows PDB support for debug-info cross-check: extracts struct/union/enum layouts, calling conventions, and toolchain info. Snapshots and comparisons can include PDB-derived metadata. CLI adds per-side PDB options with auto-discovery and explicit override behavior; PDB loading is non-fatal on parse failures.

* **Documentation**
  * Platform matrix and architecture docs updated to reflect PDB support and PDB-path usage.

* **Tests**
  * Extensive tests covering PDB parsing, metadata extraction, interoperability, CLI flows, and snapshot serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->