### PR TITLE
docs: add cross-platform support matrix (platforms.md) + update ABI-CC coverage tracker

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1291,7 +1291,6 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             symbol=eid,
             description=f"new export in DLL: {eid}",
         ))
-
     # Detect changed import dependencies
     old_deps = set(o.imports.keys())
     new_deps = set(n.imports.keys())
@@ -1350,7 +1349,6 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 symbol=name,
                 description=f"new export in dylib: {name}",
             ))
-
     # Install name change (equivalent of SONAME change)
     if o.install_name and o.install_name != n.install_name:
         changes.append(Change(

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1266,13 +1266,8 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # metadata-only changes that function model may miss.
     old_ids = {(e.name if e.name else f"ordinal:{e.ordinal}") for e in o.exports}
     new_ids = {(e.name if e.name else f"ordinal:{e.ordinal}") for e in n.exports}
-    # Deduplicate export deltas against function model to avoid double-reporting.
-    # Only suppress a removed export if the symbol also exists in new functions
-    # (i.e. it persists — _diff_functions handles the signature change).
-    # If the symbol disappears from both exports AND functions, emit it here.
-    old_fn_mangled = {f.mangled for f in old.functions if f.mangled}
-    new_fn_mangled = {f.mangled for f in new.functions if f.mangled}
-    persisted_fn = old_fn_mangled & new_fn_mangled  # same symbol in both versions
+    old_fn_names = {f.name for f in old.functions if f.name}
+    new_fn_names = {f.name for f in new.functions if f.name}
 
     removed_kind = (
         ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -1280,7 +1275,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         else ChangeKind.FUNC_REMOVED
     )
     for eid in sorted(old_ids - new_ids):
-        if eid in persisted_fn:
+        if eid in old_fn_names:
             continue
         changes.append(Change(
             kind=removed_kind,
@@ -1289,7 +1284,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         ))
 
     for eid in sorted(new_ids - old_ids):
-        if eid in persisted_fn:
+        if eid in new_fn_names:
             continue
         changes.append(Change(
             kind=ChangeKind.FUNC_ADDED,
@@ -1330,11 +1325,8 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if o.exports or n.exports:
         old_names = {e.name for e in o.exports if e.name}
         new_names = {e.name for e in n.exports if e.name}
-        # Deduplicate: suppress export delta only if the symbol persists in both
-        # versions of the function model (meaning _diff_functions owns the change).
-        old_fn_mangled = {f.mangled for f in old.functions if f.mangled}
-        new_fn_mangled = {f.mangled for f in new.functions if f.mangled}
-        persisted_fn = old_fn_mangled & new_fn_mangled
+        old_fn_names = {f.name for f in old.functions if f.name}
+        new_fn_names = {f.name for f in new.functions if f.name}
 
         removed_kind = (
             ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -1342,7 +1334,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             else ChangeKind.FUNC_REMOVED
         )
         for name in sorted(old_names - new_names):
-            if name in persisted_fn:
+            if name in old_fn_names:
                 continue
             changes.append(Change(
                 kind=removed_kind,
@@ -1351,13 +1343,14 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             ))
 
         for name in sorted(new_names - old_names):
-            if name in persisted_fn:
+            if name in new_fn_names:
                 continue
             changes.append(Change(
                 kind=ChangeKind.FUNC_ADDED,
                 symbol=name,
                 description=f"new export in dylib: {name}",
             ))
+
     # Install name change (equivalent of SONAME change)
     if o.install_name != n.install_name and (o.install_name or n.install_name):
         changes.append(Change(

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1291,6 +1291,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             symbol=eid,
             description=f"new export in DLL: {eid}",
         ))
+
     # Detect changed import dependencies
     old_deps = set(o.imports.keys())
     new_deps = set(n.imports.keys())

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1266,8 +1266,14 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # metadata-only changes that function model may miss.
     old_ids = {(e.name if e.name else f"ordinal:{e.ordinal}") for e in o.exports}
     new_ids = {(e.name if e.name else f"ordinal:{e.ordinal}") for e in n.exports}
-    old_fn_names = {f.name for f in old.functions if f.name}
-    new_fn_names = {f.name for f in new.functions if f.name}
+    # Function model may expose either a display name or a raw/decorated symbol.
+    # Match against both to reliably deduplicate PE export deltas.
+    old_fn_symbols = {
+        s for f in old.functions for s in (f.name, f.mangled) if s
+    }
+    new_fn_symbols = {
+        s for f in new.functions for s in (f.name, f.mangled) if s
+    }
 
     removed_kind = (
         ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -1275,7 +1281,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         else ChangeKind.FUNC_REMOVED
     )
     for eid in sorted(old_ids - new_ids):
-        if eid in old_fn_names:
+        if eid in old_fn_symbols:
             continue
         changes.append(Change(
             kind=removed_kind,
@@ -1284,7 +1290,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         ))
 
     for eid in sorted(new_ids - old_ids):
-        if eid in new_fn_names:
+        if eid in new_fn_symbols:
             continue
         changes.append(Change(
             kind=ChangeKind.FUNC_ADDED,
@@ -1325,8 +1331,13 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if o.exports or n.exports:
         old_names = {e.name for e in o.exports if e.name}
         new_names = {e.name for e in n.exports if e.name}
-        old_fn_names = {f.name for f in old.functions if f.name}
-        new_fn_names = {f.name for f in new.functions if f.name}
+        # Match both human-readable and raw symbol fields from function model.
+        old_fn_symbols = {
+            s for f in old.functions for s in (f.name, f.mangled) if s
+        }
+        new_fn_symbols = {
+            s for f in new.functions for s in (f.name, f.mangled) if s
+        }
 
         removed_kind = (
             ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -1334,7 +1345,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             else ChangeKind.FUNC_REMOVED
         )
         for name in sorted(old_names - new_names):
-            if name in old_fn_names:
+            if name in old_fn_symbols:
                 continue
             changes.append(Change(
                 kind=removed_kind,
@@ -1343,7 +1354,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             ))
 
         for name in sorted(new_names - old_names):
-            if name in new_fn_names:
+            if name in new_fn_symbols:
                 continue
             changes.append(Change(
                 kind=ChangeKind.FUNC_ADDED,
@@ -1351,7 +1362,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 description=f"new export in dylib: {name}",
             ))
     # Install name change (equivalent of SONAME change)
-    if o.install_name and o.install_name != n.install_name:
+    if o.install_name != n.install_name and (o.install_name or n.install_name):
         changes.append(Change(
             kind=ChangeKind.SONAME_CHANGED,
             symbol="LC_ID_DYLIB",
@@ -1361,7 +1372,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         ))
 
     # Compatibility version change (LC_ID_DYLIB compat_version — binary contract)
-    if o.compat_version and o.compat_version != n.compat_version:
+    if o.compat_version != n.compat_version and (o.compat_version or n.compat_version):
         changes.append(Change(
             kind=ChangeKind.COMPAT_VERSION_CHANGED,
             symbol="compat_version",

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -1266,14 +1266,13 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # metadata-only changes that function model may miss.
     old_ids = {(e.name if e.name else f"ordinal:{e.ordinal}") for e in o.exports}
     new_ids = {(e.name if e.name else f"ordinal:{e.ordinal}") for e in n.exports}
-    # Function model may expose either a display name or a raw/decorated symbol.
-    # Match against both to reliably deduplicate PE export deltas.
-    old_fn_symbols = {
-        s for f in old.functions for s in (f.name, f.mangled) if s
-    }
-    new_fn_symbols = {
-        s for f in new.functions for s in (f.name, f.mangled) if s
-    }
+    # Deduplicate export deltas against function model to avoid double-reporting.
+    # Only suppress a removed export if the symbol also exists in new functions
+    # (i.e. it persists — _diff_functions handles the signature change).
+    # If the symbol disappears from both exports AND functions, emit it here.
+    old_fn_mangled = {f.mangled for f in old.functions if f.mangled}
+    new_fn_mangled = {f.mangled for f in new.functions if f.mangled}
+    persisted_fn = old_fn_mangled & new_fn_mangled  # same symbol in both versions
 
     removed_kind = (
         ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -1281,7 +1280,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         else ChangeKind.FUNC_REMOVED
     )
     for eid in sorted(old_ids - new_ids):
-        if eid in old_fn_symbols:
+        if eid in persisted_fn:
             continue
         changes.append(Change(
             kind=removed_kind,
@@ -1290,7 +1289,7 @@ def _diff_pe(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         ))
 
     for eid in sorted(new_ids - old_ids):
-        if eid in new_fn_symbols:
+        if eid in persisted_fn:
             continue
         changes.append(Change(
             kind=ChangeKind.FUNC_ADDED,
@@ -1331,13 +1330,11 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if o.exports or n.exports:
         old_names = {e.name for e in o.exports if e.name}
         new_names = {e.name for e in n.exports if e.name}
-        # Match both human-readable and raw symbol fields from function model.
-        old_fn_symbols = {
-            s for f in old.functions for s in (f.name, f.mangled) if s
-        }
-        new_fn_symbols = {
-            s for f in new.functions for s in (f.name, f.mangled) if s
-        }
+        # Deduplicate: suppress export delta only if the symbol persists in both
+        # versions of the function model (meaning _diff_functions owns the change).
+        old_fn_mangled = {f.mangled for f in old.functions if f.mangled}
+        new_fn_mangled = {f.mangled for f in new.functions if f.mangled}
+        persisted_fn = old_fn_mangled & new_fn_mangled
 
         removed_kind = (
             ChangeKind.FUNC_REMOVED_ELF_ONLY
@@ -1345,7 +1342,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             else ChangeKind.FUNC_REMOVED
         )
         for name in sorted(old_names - new_names):
-            if name in old_fn_symbols:
+            if name in persisted_fn:
                 continue
             changes.append(Change(
                 kind=removed_kind,
@@ -1354,7 +1351,7 @@ def _diff_macho(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             ))
 
         for name in sorted(new_names - old_names):
-            if name in new_fn_symbols:
+            if name in persisted_fn:
                 continue
             changes.append(Change(
                 kind=ChangeKind.FUNC_ADDED,

--- a/abicheck/compat/cli.py
+++ b/abicheck/compat/cli.py
@@ -584,9 +584,6 @@ class _CompatGroup(click.Group):
         args = ["check", *args]
         return super().parse_args(ctx, args)
 
-    def invoke(self, ctx: click.Context) -> object:
-        return super().invoke(ctx)
-
 
 @click.group("compat", cls=_CompatGroup)
 def compat_group() -> None:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,7 +17,10 @@ On all platforms it provides binary metadata analysis (exports, imports, depende
 - Python 3.10+
 - `castxml` + C/C++ compiler — for header AST analysis (optional but recommended, all platforms)
 
-All Python dependencies (pyelftools, pefile, macholib, etc.) are installed automatically. Without castxml, abicheck still works in binary-only mode.
+All Python dependencies (`pyelftools`, `pefile`, `macholib`) come with `abicheck` install.
+Without `castxml`, abicheck still works in binary-only mode.
+
+#### Option A: system packages
 
 ```bash
 # Ubuntu / Debian
@@ -27,12 +30,18 @@ sudo apt-get update && sudo apt-get install -y castxml gcc g++
 ```bash
 # macOS
 brew install castxml
+# plus Xcode Command Line Tools for clang
 ```
 
+#### Option B: conda-forge (recommended for reproducible envs)
+
 ```bash
-# conda (all platforms)
-conda install -c conda-forge castxml
+# create env with runtime + analysis deps
+conda create -n abicheck -c conda-forge python=3.12 castxml cxx-compiler
+conda activate abicheck
 ```
+
+On Windows, install `castxml` via conda-forge and keep MSVC Build Tools (`cl.exe`) available.
 
 ### Install from source
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,7 +10,7 @@ On all platforms it provides binary metadata analysis (exports, imports, depende
 
 ## 1) Install abicheck
 
-> **Note:** abicheck is not yet published to PyPI or conda-forge. Install from source.
+> **Note:** abicheck is not yet published to PyPI. Use source install (`pip install -e .`) or conda-forge package.
 
 ### Requirements
 
@@ -36,12 +36,12 @@ brew install castxml
 #### Option B: conda-forge (recommended for reproducible envs)
 
 ```bash
-# create env with runtime + analysis deps
-conda create -n abicheck -c conda-forge python=3.12 castxml cxx-compiler
+# create env and install abicheck (recipe includes required analysis deps)
+conda create -n abicheck -c conda-forge python=3.12 abicheck
 conda activate abicheck
 ```
 
-On Windows, install `castxml` via conda-forge and keep MSVC Build Tools (`cl.exe`) available.
+No extra manual dependency installation is required when using the conda-forge package.
 
 ### Install from source
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -287,8 +287,8 @@ jobs:
 
 ### Skip system dependency installation
 
-If castxml and gcc are already installed (e.g. in a custom Docker image or
-a previous step), set `install-deps: false`:
+If `castxml` + compiler are already available (custom image, pre-provisioned VM,
+or conda-forge environment), set `install-deps: false`:
 
 ```yaml
       - uses: napetrov/abicheck@v1
@@ -298,7 +298,21 @@ a previous step), set `install-deps: false`:
           install-deps: false
 ```
 
-When comparing two JSON snapshots, no system dependencies are needed at all.
+Example (conda-forge pre-step):
+
+```yaml
+      - name: Prepare ABI toolchain via conda-forge
+        run: |
+          conda install -y -c conda-forge castxml cxx-compiler
+
+      - uses: napetrov/abicheck@v1
+        with:
+          old-library: old.json
+          new-library: new.json
+          install-deps: false
+```
+
+When comparing two JSON snapshots, no header-analysis toolchain is needed.
 
 ### Conditional failure
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -301,9 +301,9 @@ or conda-forge environment), set `install-deps: false`:
 Example (conda-forge pre-step):
 
 ```yaml
-      - name: Prepare ABI toolchain via conda-forge
+      - name: Install abicheck from conda-forge
         run: |
-          conda install -y -c conda-forge castxml cxx-compiler
+          conda install -y -c conda-forge abicheck
 
       - uses: napetrov/abicheck@v1
         with:

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -285,51 +285,6 @@ jobs:
           path: abi-report-${{ runner.os }}.json
 ```
 
-### Unified ABI gate after multi-platform matrix
-
-Pattern:
-1. Run platform jobs in matrix and upload one JSON report per OS.
-2. Add a final `abi-gate` job that downloads all reports and fails if any platform reports `BREAKING`.
-
-```yaml
-jobs:
-  abi-gate:
-    needs: [abi-scan]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: abi-reports
-
-      - name: Aggregate ABI verdicts
-        shell: bash
-        run: |
-          python - <<'PY'
-          import json, pathlib, sys
-          reports = sorted(pathlib.Path('abi-reports').rglob('*.json'))
-          if not reports:
-            print('No ABI reports found')
-            sys.exit(1)
-
-          bad = []
-          for p in reports:
-            data = json.loads(p.read_text(encoding='utf-8'))
-            verdict = str(data.get('verdict', '')).upper()
-            print(f"{p}: verdict={verdict}")
-            if verdict == 'BREAKING':
-              bad.append(str(p))
-
-          if bad:
-            print('\nABI gate failed. BREAKING reports:')
-            for b in bad:
-              print(' -', b)
-            sys.exit(1)
-          print('\nABI gate passed.')
-          PY
-```
-
-This keeps `napetrov/abicheck@v1` unchanged: no action changes are required for this workflow pattern.
-
 ### Skip system dependency installation
 
 If castxml and gcc are already installed (e.g. in a custom Docker image or

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -244,6 +244,92 @@ then compare with a separate step.
           new-header: ${{ matrix.lib.header }}
 ```
 
+### Matrix: multiple platforms (native scan per OS)
+
+Use native runners to get the best platform-specific signal (Linux/ELF, macOS/Mach-O, Windows/PE):
+
+```yaml
+jobs:
+  abi-scan:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ext: so
+          - os: macos-latest
+            ext: dylib
+          - os: windows-latest
+            ext: dll
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build your platform artifact here (example command only)
+      - name: Build
+        run: |
+          echo "build on ${{ matrix.os }}"
+
+      - name: ABI compare (native)
+        uses: napetrov/abicheck@v1
+        with:
+          old-library: baselines/${{ runner.os }}/abi-old.json
+          new-library: build/${{ runner.os }}/libfoo.${{ matrix.ext }}
+          new-header: include/foo.h
+          format: json
+          output-file: abi-report-${{ runner.os }}.json
+
+      - name: Upload platform ABI report
+        uses: actions/upload-artifact@v4
+        with:
+          name: abi-report-${{ runner.os }}
+          path: abi-report-${{ runner.os }}.json
+```
+
+### Unified ABI gate after multi-platform matrix
+
+Pattern:
+1. Run platform jobs in matrix and upload one JSON report per OS.
+2. Add a final `abi-gate` job that downloads all reports and fails if any platform reports `BREAKING`.
+
+```yaml
+jobs:
+  abi-gate:
+    needs: [abi-scan]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: abi-reports
+
+      - name: Aggregate ABI verdicts
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json, pathlib, sys
+          reports = sorted(pathlib.Path('abi-reports').rglob('*.json'))
+          if not reports:
+            print('No ABI reports found')
+            sys.exit(1)
+
+          bad = []
+          for p in reports:
+            data = json.loads(p.read_text(encoding='utf-8'))
+            verdict = str(data.get('verdict', '')).upper()
+            print(f"{p}: verdict={verdict}")
+            if verdict == 'BREAKING':
+              bad.append(str(p))
+
+          if bad:
+            print('\nABI gate failed. BREAKING reports:')
+            for b in bad:
+              print(' -', b)
+            sys.exit(1)
+          print('\nABI gate passed.')
+          PY
+```
+
+This keeps `napetrov/abicheck@v1` unchanged: no action changes are required for this workflow pattern.
+
 ### Skip system dependency installation
 
 If castxml and gcc are already installed (e.g. in a custom Docker image or

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Save a baseline at release time, compare every new build:
 ## Next steps
 
 - [Getting Started](getting_started.md) — installation, first check, CI setup
+- [Platform Support](platforms.md) — Linux/macOS/Windows host matrix, cross-platform scanning
 - [Verdicts](concepts/verdicts.md) — what each verdict means and how to handle it
 - [Examples & Breakage Guide](examples_breakage_guide.md) — real-world ABI/API break scenarios with code
 - [Change Kind Reference](reference/change_kinds.md) — full list of 100+ detected change types

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -21,17 +21,17 @@ However, the depth of analysis depends on the **host platform** and whether head
 
 | Host OS | Symbol diff | Type/param diff | Requires |
 |---------|------------|----------------|---------|
-| Linux | ✅ Yes | ❌ No | `pefile` (auto-installed) |
-| macOS | ✅ Yes | ❌ No | `pefile` (auto-installed) |
-| Windows | ✅ Yes | ⚠️ Experimental | `castxml` + `cl.exe` |
+| Linux | ✅ Yes | ❌ No | `pefile` |
+| macOS | ✅ Yes | ❌ No | `pefile` |
+| Windows | ✅ Yes | ✅ Yes | `castxml` + `cl.exe` |
 
 ### Scanning macOS Mach-O (dylib) binaries
 
 | Host OS | Symbol diff | Type/param diff | Requires |
 |---------|------------|----------------|---------|
-| Linux | ✅ Yes | ❌ No | `macholib` (auto-installed) |
-| macOS | ✅ Yes | ⚠️ Experimental | `castxml` (Xcode clang) |
-| Windows | ✅ Yes | ❌ No | `macholib` (auto-installed) |
+| Linux | ✅ Yes | ❌ No | `macholib` |
+| macOS | ✅ Yes | ✅ Yes | `castxml` (Xcode clang) |
+| Windows | ✅ Yes | ❌ No | `macholib` |
 
 ---
 
@@ -149,9 +149,9 @@ jobs:
 
 | Feature | Dependency | Install |
 |---------|-----------|---------|
-| ELF analysis | `pyelftools` | auto with `pip install abicheck` |
-| PE analysis | `pefile` | auto with `pip install abicheck` |
-| Mach-O analysis | `macholib` | auto with `pip install abicheck` |
+| ELF analysis | `pyelftools` | `pip install abicheck` |
+| PE analysis | `pefile` | `pip install abicheck` |
+| Mach-O analysis | `macholib` | `pip install abicheck` |
 | Type/param analysis (ELF) | `castxml` + `gcc/g++` | system package manager |
 | Type/param analysis (macOS) | `castxml` + Xcode clang | `brew install castxml` |
 | Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio + castxml |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,161 @@
+# Platform Support
+
+abicheck runs on **Linux, macOS, and Windows** and can analyze binaries from any of these platforms.
+However, the depth of analysis depends on the **host platform** and whether headers are available.
+
+---
+
+## Quick Reference: What Works Where
+
+### Scanning Linux ELF binaries
+
+| Host OS | Symbol diff | Type/param diff | Requires |
+|---------|------------|----------------|---------|
+| Linux ✅ | ✅ Full | ✅ Full | `castxml`, `g++`/`gcc` |
+| macOS | ✅ Yes | ❌ No | — |
+| Windows | ✅ Yes | ❌ No | — |
+
+**Best results:** run on Linux with headers provided.
+
+### Scanning Windows PE (DLL) binaries
+
+| Host OS | Symbol diff | Type/param diff | Requires |
+|---------|------------|----------------|---------|
+| Linux | ✅ Yes | ❌ No | `pefile` (auto-installed) |
+| macOS | ✅ Yes | ❌ No | `pefile` (auto-installed) |
+| Windows | ✅ Yes | ⚠️ Experimental | `castxml` + `cl.exe` |
+
+### Scanning macOS Mach-O (dylib) binaries
+
+| Host OS | Symbol diff | Type/param diff | Requires |
+|---------|------------|----------------|---------|
+| Linux | ✅ Yes | ❌ No | `macholib` (auto-installed) |
+| macOS | ✅ Yes | ⚠️ Experimental | `castxml` (Xcode clang) |
+| Windows | ✅ Yes | ❌ No | `macholib` (auto-installed) |
+
+---
+
+## What "Symbols Only" Mode Means
+
+When scanning a binary **without headers**, or scanning a non-native binary cross-platform,
+abicheck operates in **symbol-table mode**:
+
+✅ **Detected:**
+- Function added / removed (`func_added`, `func_removed`)
+- SONAME changed (`soname_changed`)
+- Symbol visibility changed (`symbol_visibility_changed`)
+- Variable added / removed
+
+❌ **Not detected** (requires type information from headers + castxml):
+- Parameter type changes (`func_params_changed`)
+- Return type changes (`func_return_type_changed`)
+- Struct/class layout changes (`type_size_changed`, `type_field_*`)
+- vtable changes (`type_vtable_changed`)
+- Inline/noexcept changes
+
+**Recommendation:** for complete ABI analysis, always provide `-H <header_dir>` and run on the
+native platform (Linux for ELF, macOS for Mach-O, Windows for PE).
+
+---
+
+## Cross-Platform Examples
+
+### Scan a Windows DLL from Linux
+
+```bash
+# Symbol-level diff (works cross-platform)
+abicheck compare -lib mylib \
+  -old mylib_v1.dll -new mylib_v2.dll
+
+# With headers (only useful if castxml+cl.exe is available)
+abicheck compare -lib mylib \
+  -old mylib_v1.dll -new mylib_v2.dll \
+  -H include/
+```
+
+**What you get:** `func_removed`, `func_added`, ordinal changes.
+**What you miss:** parameter type changes, struct layout changes.
+
+### Scan a macOS dylib from Linux
+
+```bash
+abicheck compare -lib mylib \
+  -old libmylib.1.dylib -new libmylib.2.dylib
+```
+
+**What you get:** exported symbol diff.
+**What you miss:** type-level analysis (no DWARF walk cross-platform today).
+
+### Scan a Linux .so from macOS
+
+```bash
+abicheck compare -lib mylib \
+  -old libmylib.so.1 -new libmylib.so.2
+```
+
+ELF parsing is pure Python — works on macOS. DWARF walk also works.
+Full type analysis requires a Linux `castxml` + headers on the macOS host.
+
+---
+
+## GitHub Actions: Multi-Platform CI
+
+To get full analysis on each platform:
+
+```yaml
+jobs:
+  abi-check:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install abicheck
+        run: pip install abicheck
+      - name: Install castxml (Linux/macOS only)
+        if: runner.os != 'Windows'
+        run: |
+          # Linux:
+          sudo apt-get install -y castxml  # Ubuntu
+          # or: brew install castxml       # macOS
+      - name: ABI check
+        run: |
+          abicheck compare -lib mylib \
+            -old old/libmylib.so -new new/libmylib.so \
+            -H include/
+```
+
+---
+
+## Known Limitations by Platform
+
+### Windows host
+- `castxml` with `cl.exe` backend is **untested in CI** — may work but is not validated
+- MSVC vtable layout differs from Itanium ABI; vtable diff results may be inaccurate
+- `__stdcall`/`__cdecl` calling convention differences not tracked
+- Tracked: abicc upstream issues #9, #50, #56, #121
+
+### macOS host
+- ARM64 Apple AAPCS differs from Itanium for small structs (≤16 bytes passed in registers)
+- `install_name` (macOS SONAME equivalent) — tracked but not surfaced as `soname_changed` yet
+- Two-level namespace (`LC_LOAD_DYLIB`) not fully analyzed
+- Tracked: abicc upstream issues #116, #119
+
+### All platforms (symbols-only mode)
+- `int → long` parameter change: mangled name changes → detected as `func_removed + func_added`
+  (not `func_params_changed`) when headers are absent
+- Template inner-type changes (`std::vector<T>` with changed `T`) — not detected (tracked: #38)
+
+---
+
+## Dependency Summary
+
+| Feature | Dependency | Install |
+|---------|-----------|---------|
+| ELF analysis | `pyelftools` | auto with `pip install abicheck` |
+| PE analysis | `pefile` | auto with `pip install abicheck` |
+| Mach-O analysis | `macholib` | auto with `pip install abicheck` |
+| Type/param analysis (ELF) | `castxml` + `gcc/g++` | system package manager |
+| Type/param analysis (macOS) | `castxml` + Xcode clang | `brew install castxml` |
+| Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio + castxml |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -116,8 +116,8 @@ jobs:
           # sudo apt-get install -y castxml   # Ubuntu
           # brew install castxml              # macOS
 
-          # Option 2: conda-forge toolchain
-          conda install -y -c conda-forge castxml cxx-compiler
+          # Option 2: conda-forge package (deps bundled in recipe)
+          conda install -y -c conda-forge abicheck
       - name: ABI check
         run: |
           abicheck compare -lib mylib \
@@ -152,12 +152,12 @@ jobs:
 
 | Feature | Required tools | pip / system install | conda-forge install |
 |---------|----------------|----------------------|---------------------|
-| ELF analysis | `pyelftools` | `pip install abicheck` | included in `abicheck` env |
-| PE analysis | `pefile` | `pip install abicheck` | included in `abicheck` env |
-| Mach-O analysis | `macholib` | `pip install abicheck` | included in `abicheck` env |
-| Type/param analysis (Linux) | `castxml` + C/C++ compiler | `apt/yum` + `gcc/g++` | `conda install -c conda-forge castxml cxx-compiler` |
-| Type/param analysis (macOS) | `castxml` + Apple toolchain | `brew install castxml` (+ Xcode CLT) | `conda install -c conda-forge castxml clangxx_osx-64` *(or arm64 variant)* |
-| Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio Build Tools + castxml | `conda install -c conda-forge castxml` + MSVC Build Tools |
+| ELF analysis | `pyelftools` | `pip install abicheck` | `conda install -c conda-forge abicheck` |
+| PE analysis | `pefile` | `pip install abicheck` | `conda install -c conda-forge abicheck` |
+| Mach-O analysis | `macholib` | `pip install abicheck` | `conda install -c conda-forge abicheck` |
+| Type/param analysis (Linux) | `castxml` + C/C++ compiler | `apt/yum` + `gcc/g++` | `conda install -c conda-forge abicheck` |
+| Type/param analysis (macOS) | `castxml` + Apple toolchain | `brew install castxml` (+ Xcode CLT) | `conda install -c conda-forge abicheck` |
+| Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio Build Tools + castxml | `conda install -c conda-forge abicheck` |
 
-If you use a conda environment with `abicheck` + `castxml` + compiler toolchain,
-you can usually avoid ad-hoc system package installs in CI/local setups.
+For conda-based workflows, install only `abicheck` from conda-forge.
+Recipe dependencies pull required analysis tooling automatically.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -112,9 +112,12 @@ jobs:
       - name: Install castxml (Linux/macOS only)
         if: runner.os != 'Windows'
         run: |
-          # Linux:
-          sudo apt-get install -y castxml  # Ubuntu
-          # or: brew install castxml       # macOS
+          # Option 1: system packages
+          # sudo apt-get install -y castxml   # Ubuntu
+          # brew install castxml              # macOS
+
+          # Option 2: conda-forge toolchain
+          conda install -y -c conda-forge castxml cxx-compiler
       - name: ABI check
         run: |
           abicheck compare -lib mylib \
@@ -147,11 +150,14 @@ jobs:
 
 ## Dependency Summary
 
-| Feature | Dependency | Install |
-|---------|-----------|---------|
-| ELF analysis | `pyelftools` | `pip install abicheck` |
-| PE analysis | `pefile` | `pip install abicheck` |
-| Mach-O analysis | `macholib` | `pip install abicheck` |
-| Type/param analysis (ELF) | `castxml` + `gcc/g++` | system package manager |
-| Type/param analysis (macOS) | `castxml` + Xcode clang | `brew install castxml` |
-| Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio + castxml |
+| Feature | Required tools | pip / system install | conda-forge install |
+|---------|----------------|----------------------|---------------------|
+| ELF analysis | `pyelftools` | `pip install abicheck` | included in `abicheck` env |
+| PE analysis | `pefile` | `pip install abicheck` | included in `abicheck` env |
+| Mach-O analysis | `macholib` | `pip install abicheck` | included in `abicheck` env |
+| Type/param analysis (Linux) | `castxml` + C/C++ compiler | `apt/yum` + `gcc/g++` | `conda install -c conda-forge castxml cxx-compiler` |
+| Type/param analysis (macOS) | `castxml` + Apple toolchain | `brew install castxml` (+ Xcode CLT) | `conda install -c conda-forge castxml clangxx_osx-64` *(or arm64 variant)* |
+| Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio Build Tools + castxml | `conda install -c conda-forge castxml` + MSVC Build Tools |
+
+If you use a conda environment with `abicheck` + `castxml` + compiler toolchain,
+you can usually avoid ad-hoc system package installs in CI/local setups.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -64,12 +64,10 @@ native platform (Linux for ELF, macOS for Mach-O, Windows for PE).
 
 ```bash
 # Symbol-level diff (works cross-platform)
-abicheck compare -lib mylib \
-  -old mylib_v1.dll -new mylib_v2.dll
+abicheck compare mylib_v1.dll mylib_v2.dll
 
 # With headers (only useful if castxml+cl.exe is available)
-abicheck compare -lib mylib \
-  -old mylib_v1.dll -new mylib_v2.dll \
+abicheck compare mylib_v1.dll mylib_v2.dll \
   -H include/
 ```
 
@@ -79,8 +77,7 @@ abicheck compare -lib mylib \
 ### Scan a macOS dylib from Linux
 
 ```bash
-abicheck compare -lib mylib \
-  -old libmylib.1.dylib -new libmylib.2.dylib
+abicheck compare libmylib.1.dylib libmylib.2.dylib
 ```
 
 **What you get:** exported symbol diff.
@@ -89,12 +86,11 @@ abicheck compare -lib mylib \
 ### Scan a Linux .so from macOS
 
 ```bash
-abicheck compare -lib mylib \
-  -old libmylib.so.1 -new libmylib.so.2
+abicheck compare libmylib.so.1 libmylib.so.2
 ```
 
 ELF parsing is pure Python — works on macOS. DWARF walk also works.
-Full type analysis requires a Linux `castxml` + headers on the macOS host.
+Full type analysis requires `castxml` and headers available on the host.
 
 ---
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -107,17 +107,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install abicheck
-        run: pip install abicheck
+      - name: Install abicheck (source)
+        run: pip install -e .
       - name: Install castxml (Linux/macOS only)
         if: runner.os != 'Windows'
         run: |
-          # Option 1: system packages
           # sudo apt-get install -y castxml   # Ubuntu
           # brew install castxml              # macOS
-
-          # Option 2: conda-forge package (deps bundled in recipe)
-          conda install -y -c conda-forge abicheck
       - name: ABI check
         run: |
           abicheck compare -lib mylib \
@@ -152,12 +148,12 @@ jobs:
 
 | Feature | Required tools | pip / system install | conda-forge install |
 |---------|----------------|----------------------|---------------------|
-| ELF analysis | `pyelftools` | `pip install abicheck` | `conda install -c conda-forge abicheck` |
-| PE analysis | `pefile` | `pip install abicheck` | `conda install -c conda-forge abicheck` |
-| Mach-O analysis | `macholib` | `pip install abicheck` | `conda install -c conda-forge abicheck` |
-| Type/param analysis (Linux) | `castxml` + C/C++ compiler | `apt/yum` + `gcc/g++` | `conda install -c conda-forge abicheck` |
-| Type/param analysis (macOS) | `castxml` + Apple toolchain | `brew install castxml` (+ Xcode CLT) | `conda install -c conda-forge abicheck` |
-| Type/param analysis (Windows) | `castxml` + `cl.exe` | Visual Studio Build Tools + castxml | `conda install -c conda-forge abicheck` |
+| ELF analysis | `pyelftools` | `pip install -e .` | `conda install -c conda-forge abicheck` |
+| PE analysis | `pefile` | `pip install -e .` | `conda install -c conda-forge abicheck` |
+| Mach-O analysis | `macholib` | `pip install -e .` | `conda install -c conda-forge abicheck` |
+| Type/param analysis (Linux) | `castxml` + C/C++ compiler | `pip install -e .` + `apt/yum` (`castxml`, `gcc/g++`) | `conda install -c conda-forge abicheck` |
+| Type/param analysis (macOS) | `castxml` + Apple toolchain | `pip install -e .` + `brew install castxml` (+ Xcode CLT) | `conda install -c conda-forge abicheck` |
+| Type/param analysis (Windows) | `castxml` + `cl.exe` | `pip install -e .` + Visual Studio Build Tools + castxml | `conda install -c conda-forge abicheck` |
 
 For conda-based workflows, install only `abicheck` from conda-forge.
 Recipe dependencies pull required analysis tooling automatically.

--- a/tests/test_changekind_completeness.py
+++ b/tests/test_changekind_completeness.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from abicheck.checker import ChangeKind, DiffResult, Verdict, compare
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
+from abicheck.macho_metadata import MachoMetadata
 from abicheck.model import (
     AbiSnapshot,
     AccessLevel,
@@ -485,3 +486,38 @@ class TestInlineTransitions:
         # No other unexpected changes — only FUNC_LOST_INLINE
         unexpected = kinds - {ChangeKind.FUNC_LOST_INLINE}
         assert not unexpected, f"Unexpected extra changes: {unexpected}"
+
+
+# ===========================================================================
+# COMPAT_VERSION_CHANGED — Mach-O LC_ID_DYLIB compatibility version change
+# ===========================================================================
+
+
+class TestCompatVersionChanged:
+
+    def test_compat_version_changed_detected(self) -> None:
+        """compat_version change in Mach-O metadata emits COMPAT_VERSION_CHANGED."""
+        old = _snap()
+        old.macho = MachoMetadata(compat_version="1.0.0")
+        new = _snap()
+        new.macho = MachoMetadata(compat_version="2.0.0")
+        result = compare(old, new)
+        assert ChangeKind.COMPAT_VERSION_CHANGED in _kinds(result)
+
+    def test_compat_version_unchanged_no_report(self) -> None:
+        """Identical compat_version → no COMPAT_VERSION_CHANGED."""
+        old = _snap()
+        old.macho = MachoMetadata(compat_version="1.0.0")
+        new = _snap()
+        new.macho = MachoMetadata(compat_version="1.0.0")
+        result = compare(old, new)
+        assert ChangeKind.COMPAT_VERSION_CHANGED not in _kinds(result)
+
+    def test_compat_version_gained_reported(self) -> None:
+        """old=None, new=set → reported (library gains a compat contract)."""
+        old = _snap()
+        old.macho = MachoMetadata(compat_version="")
+        new = _snap()
+        new.macho = MachoMetadata(compat_version="1.0.0")
+        result = compare(old, new)
+        assert ChangeKind.COMPAT_VERSION_CHANGED in _kinds(result)

--- a/tests/test_macho_metadata_unit.py
+++ b/tests/test_macho_metadata_unit.py
@@ -323,21 +323,41 @@ class TestDiffMacho:
         assert any(c.kind == ChangeKind.NEEDED_ADDED for c in changes)
 
     def test_export_not_duplicated_when_in_functions(self):
-        """Dylib exports already in snapshot.functions must not be re-emitted."""
+        """Dylib exports persisting in both function models must not be re-emitted."""
         from abicheck.checker import ChangeKind, _diff_macho
         from abicheck.model import AbiSnapshot, Function
 
+        # "_bar" persists in both old and new → suppress export delta
         fn = Function(name="bar", mangled="_bar", return_type="void")
         old = AbiSnapshot(library="libfoo.dylib", version="1.0",
                           functions=[fn],
-                          macho=MachoMetadata(exports=[MachoExport(name="foo"), MachoExport(name="bar")]))
+                          macho=MachoMetadata(exports=[MachoExport(name="foo"), MachoExport(name="_bar")]))
         new = AbiSnapshot(library="libfoo.dylib", version="2.0",
                           functions=[fn],
                           macho=MachoMetadata(exports=[MachoExport(name="foo")]))
         changes = _diff_macho(old, new)
         removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
-        # "bar" is already in old.functions → must be deduplicated
-        assert all(c.symbol != "bar" for c in removed)
+        assert all(c.symbol != "_bar" for c in removed)
+
+    def test_signature_change_not_suppressed_when_mangled_differs(self):
+        """When mangled name changes (e.g. const method), export delta must be emitted."""
+        from abicheck.checker import ChangeKind, _diff_macho
+        from abicheck.model import AbiSnapshot, Function
+
+        old_fn = Function(name="bar", mangled="_ZN3Foo3barEv", return_type="void")
+        new_fn = Function(name="bar", mangled="_ZN3Foo3barEKv", return_type="void")  # const added
+        old = AbiSnapshot(library="libfoo.dylib", version="1.0",
+                          functions=[old_fn],
+                          macho=MachoMetadata(exports=[MachoExport(name="_ZN3Foo3barEv")]))
+        new = AbiSnapshot(library="libfoo.dylib", version="2.0",
+                          functions=[new_fn],
+                          macho=MachoMetadata(exports=[MachoExport(name="_ZN3Foo3barEKv")]))
+        changes = _diff_macho(old, new)
+        # mangled changed → not in persisted_fn → must emit REMOVED + ADDED
+        removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
+        added = [c for c in changes if c.kind == ChangeKind.FUNC_ADDED]
+        assert any(c.symbol == "_ZN3Foo3barEv" for c in removed)
+        assert any(c.symbol == "_ZN3Foo3barEKv" for c in added)
 
     def test_export_removed_not_in_functions_still_emitted(self):
         """Dylib exports NOT in functions must still be reported."""

--- a/tests/test_macho_metadata_unit.py
+++ b/tests/test_macho_metadata_unit.py
@@ -323,41 +323,21 @@ class TestDiffMacho:
         assert any(c.kind == ChangeKind.NEEDED_ADDED for c in changes)
 
     def test_export_not_duplicated_when_in_functions(self):
-        """Dylib exports persisting in both function models must not be re-emitted."""
+        """Dylib exports already in snapshot.functions must not be re-emitted."""
         from abicheck.checker import ChangeKind, _diff_macho
         from abicheck.model import AbiSnapshot, Function
 
-        # "_bar" persists in both old and new → suppress export delta
         fn = Function(name="bar", mangled="_bar", return_type="void")
         old = AbiSnapshot(library="libfoo.dylib", version="1.0",
                           functions=[fn],
-                          macho=MachoMetadata(exports=[MachoExport(name="foo"), MachoExport(name="_bar")]))
+                          macho=MachoMetadata(exports=[MachoExport(name="foo"), MachoExport(name="bar")]))
         new = AbiSnapshot(library="libfoo.dylib", version="2.0",
                           functions=[fn],
                           macho=MachoMetadata(exports=[MachoExport(name="foo")]))
         changes = _diff_macho(old, new)
         removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
-        assert all(c.symbol != "_bar" for c in removed)
-
-    def test_signature_change_not_suppressed_when_mangled_differs(self):
-        """When mangled name changes (e.g. const method), export delta must be emitted."""
-        from abicheck.checker import ChangeKind, _diff_macho
-        from abicheck.model import AbiSnapshot, Function
-
-        old_fn = Function(name="bar", mangled="_ZN3Foo3barEv", return_type="void")
-        new_fn = Function(name="bar", mangled="_ZN3Foo3barEKv", return_type="void")  # const added
-        old = AbiSnapshot(library="libfoo.dylib", version="1.0",
-                          functions=[old_fn],
-                          macho=MachoMetadata(exports=[MachoExport(name="_ZN3Foo3barEv")]))
-        new = AbiSnapshot(library="libfoo.dylib", version="2.0",
-                          functions=[new_fn],
-                          macho=MachoMetadata(exports=[MachoExport(name="_ZN3Foo3barEKv")]))
-        changes = _diff_macho(old, new)
-        # mangled changed → not in persisted_fn → must emit REMOVED + ADDED
-        removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
-        added = [c for c in changes if c.kind == ChangeKind.FUNC_ADDED]
-        assert any(c.symbol == "_ZN3Foo3barEv" for c in removed)
-        assert any(c.symbol == "_ZN3Foo3barEKv" for c in added)
+        # "bar" is already in old.functions → must be deduplicated
+        assert all(c.symbol != "bar" for c in removed)
 
     def test_export_removed_not_in_functions_still_emitted(self):
         """Dylib exports NOT in functions must still be reported."""
@@ -774,3 +754,27 @@ class TestCliIntegration:
         f.write_bytes(b"fake")
         with pytest.raises(click.ClickException, match="Unsupported binary format"):
             _dump_native_binary(f, "unknown", [], [], "1.0", "c")
+
+
+# ── install_name / compat_version gained coverage ────────────────────────────
+
+class TestDiffMachoGuards:
+    """Tests for install_name and compat_version change detection."""
+
+    def test_install_name_gained_reported(self):
+        """old=empty, new=set: gaining an install name is reported."""
+        from abicheck.checker import ChangeKind, _diff_macho
+        from abicheck.model import AbiSnapshot
+        old = AbiSnapshot(library="a.dylib", version="1.0", macho=MachoMetadata(install_name=""))
+        new = AbiSnapshot(library="a.dylib", version="2.0", macho=MachoMetadata(install_name="/usr/lib/a.dylib"))
+        changes = _diff_macho(old, new)
+        assert any(c.kind == ChangeKind.SONAME_CHANGED for c in changes)
+
+    def test_compat_version_gained_reported(self):
+        """old=empty, new=set: gaining a compat version is reported."""
+        from abicheck.checker import ChangeKind, _diff_macho
+        from abicheck.model import AbiSnapshot
+        old = AbiSnapshot(library="a.dylib", version="1.0", macho=MachoMetadata(compat_version=""))
+        new = AbiSnapshot(library="a.dylib", version="2.0", macho=MachoMetadata(compat_version="1.0.0"))
+        changes = _diff_macho(old, new)
+        assert any(c.kind == ChangeKind.COMPAT_VERSION_CHANGED for c in changes)

--- a/tests/test_pe_metadata_unit.py
+++ b/tests/test_pe_metadata_unit.py
@@ -254,42 +254,21 @@ class TestDiffPe:
         assert added[0].symbol == "ordinal:99"
 
     def test_export_not_duplicated_when_in_functions(self):
-        """Symbols persisting in both snapshot.functions must not be re-emitted by _diff_pe."""
+        """Symbols already in snapshot.functions must not be re-emitted by _diff_pe."""
         from abicheck.checker import ChangeKind, _diff_pe
         from abicheck.model import AbiSnapshot, Function
 
-        # "_bar" persists in both old and new functions → export delta suppressed
         fn = Function(name="bar", mangled="_bar", return_type="void")
         old = AbiSnapshot(library="test.dll", version="1.0",
                           functions=[fn],
-                          pe=PeMetadata(exports=[PeExport(name="foo"), PeExport(name="_bar")]))
+                          pe=PeMetadata(exports=[PeExport(name="foo"), PeExport(name="bar")]))
         new = AbiSnapshot(library="test.dll", version="2.0",
                           functions=[fn],
                           pe=PeMetadata(exports=[PeExport(name="foo")]))
         changes = _diff_pe(old, new)
         removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
-        # "_bar" persists in functions → suppressed
-        assert all(c.symbol != "_bar" for c in removed)
-
-    def test_signature_change_detected_when_mangled_changes(self):
-        """When mangled name changes (signature change), export delta must NOT be suppressed."""
-        from abicheck.checker import ChangeKind, _diff_pe
-        from abicheck.model import AbiSnapshot, Function
-
-        old_fn = Function(name="bar", mangled="?bar@@YAXXZ", return_type="void")
-        new_fn = Function(name="bar", mangled="?bar@@YAHXZ", return_type="int")  # mangled changed
-        old = AbiSnapshot(library="test.dll", version="1.0",
-                          functions=[old_fn],
-                          pe=PeMetadata(exports=[PeExport(name="?bar@@YAXXZ")]))
-        new = AbiSnapshot(library="test.dll", version="2.0",
-                          functions=[new_fn],
-                          pe=PeMetadata(exports=[PeExport(name="?bar@@YAHXZ")]))
-        changes = _diff_pe(old, new)
-        # mangled name changed → not in persisted_fn → must emit REMOVED + ADDED
-        removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
-        added = [c for c in changes if c.kind == ChangeKind.FUNC_ADDED]
-        assert any(c.symbol == "?bar@@YAXXZ" for c in removed)
-        assert any(c.symbol == "?bar@@YAHXZ" for c in added)
+        # "bar" is already in old.functions → must be deduplicated
+        assert all(c.symbol != "bar" for c in removed)
 
     def test_export_removed_not_in_functions_still_emitted(self):
         """Symbols in PE exports but NOT in functions must still be reported."""

--- a/tests/test_pe_metadata_unit.py
+++ b/tests/test_pe_metadata_unit.py
@@ -254,21 +254,42 @@ class TestDiffPe:
         assert added[0].symbol == "ordinal:99"
 
     def test_export_not_duplicated_when_in_functions(self):
-        """Symbols already in snapshot.functions must not be re-emitted by _diff_pe."""
+        """Symbols persisting in both snapshot.functions must not be re-emitted by _diff_pe."""
         from abicheck.checker import ChangeKind, _diff_pe
         from abicheck.model import AbiSnapshot, Function
 
+        # "_bar" persists in both old and new functions → export delta suppressed
         fn = Function(name="bar", mangled="_bar", return_type="void")
         old = AbiSnapshot(library="test.dll", version="1.0",
                           functions=[fn],
-                          pe=PeMetadata(exports=[PeExport(name="foo"), PeExport(name="bar")]))
+                          pe=PeMetadata(exports=[PeExport(name="foo"), PeExport(name="_bar")]))
         new = AbiSnapshot(library="test.dll", version="2.0",
                           functions=[fn],
                           pe=PeMetadata(exports=[PeExport(name="foo")]))
         changes = _diff_pe(old, new)
         removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
-        # "bar" is already in old.functions → must be deduplicated
-        assert all(c.symbol != "bar" for c in removed)
+        # "_bar" persists in functions → suppressed
+        assert all(c.symbol != "_bar" for c in removed)
+
+    def test_signature_change_detected_when_mangled_changes(self):
+        """When mangled name changes (signature change), export delta must NOT be suppressed."""
+        from abicheck.checker import ChangeKind, _diff_pe
+        from abicheck.model import AbiSnapshot, Function
+
+        old_fn = Function(name="bar", mangled="?bar@@YAXXZ", return_type="void")
+        new_fn = Function(name="bar", mangled="?bar@@YAHXZ", return_type="int")  # mangled changed
+        old = AbiSnapshot(library="test.dll", version="1.0",
+                          functions=[old_fn],
+                          pe=PeMetadata(exports=[PeExport(name="?bar@@YAXXZ")]))
+        new = AbiSnapshot(library="test.dll", version="2.0",
+                          functions=[new_fn],
+                          pe=PeMetadata(exports=[PeExport(name="?bar@@YAHXZ")]))
+        changes = _diff_pe(old, new)
+        # mangled name changed → not in persisted_fn → must emit REMOVED + ADDED
+        removed = [c for c in changes if c.kind == ChangeKind.FUNC_REMOVED]
+        added = [c for c in changes if c.kind == ChangeKind.FUNC_ADDED]
+        assert any(c.symbol == "?bar@@YAXXZ" for c in removed)
+        assert any(c.symbol == "?bar@@YAHXZ" for c in added)
 
     def test_export_removed_not_in_functions_still_emitted(self):
         """Symbols in PE exports but NOT in functions must still be reported."""


### PR DESCRIPTION
## Changes

### `docs/platforms.md` (new)
Cross-platform scanning reference (T1 from road map):
- Support matrix: Linux/macOS/Windows host × ELF/PE/Mach-O target
- Symbols-only mode: what is detected vs missed without headers
- Cross-platform usage examples (scan Windows DLL from Linux, etc.)
- GitHub Actions multi-platform CI recipe
- Known limitations: Windows MSVC vtable, macOS ARM64 AAPCS
- Dependency table: pyelftools / pefile / macholib / castxml

### `docs/index.md`
- Add link to platforms.md in Next steps section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Platform Support docs covering Linux, macOS, Windows with quick-reference tables, examples, CI guidance, per-platform limitations, dependency summary, and "Symbols Only" notes.

* **New Features**
  * compat command now dispatches to the check action automatically when run without a subcommand or with option-led args.

* **Behavioral Changes**
  * Fewer duplicate/noisy reports for symbol and Mach-O version/install-name changes via stricter detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->