### PR TITLE
fix(policy): downgrade enum_last_member_value_changed to risk 

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -2612,10 +2612,22 @@ def _diff_enum_layouts(o: object, n: object) -> list[Change]:
             ))
 
         # 3. Changed values
+        # Sentinel member = member with the highest old value.
+        # If this member changes, classify as ENUM_LAST_MEMBER_VALUE_CHANGED.
+        old_sentinel_name = None
+        if old_e.members:
+            _max_val = max(old_e.members.values())
+            old_sentinel_name = next((m for m, v in old_e.members.items() if v == _max_val), None)
+
         for mname, old_val in old_e.members.items():
             if mname in new_e.members and new_e.members[mname] != old_val:
+                kind = (
+                    ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED
+                    if mname == old_sentinel_name
+                    else ChangeKind.ENUM_MEMBER_VALUE_CHANGED
+                )
                 changes.append(Change(
-                    kind=ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
+                    kind=kind,
                     symbol=f"{name}::{mname}",
                     description=(
                         f"Enum member value changed: {name}::{mname} "

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -299,7 +299,6 @@ BREAKING_KINDS = {
     ChangeKind.TYPE_FIELD_ADDED,  # for polymorphic / non-standard-layout types
     ChangeKind.ENUM_MEMBER_REMOVED,
     ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
-    ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
     ChangeKind.FUNC_STATIC_CHANGED,
     ChangeKind.FUNC_CV_CHANGED,
     ChangeKind.FUNC_VISIBILITY_CHANGED,
@@ -433,6 +432,9 @@ RISK_KINDS: frozenset[ChangeKind] = frozenset({
     # Deployment risk: the new library will NOT load on systems with a glibc
     # older than the required version. The user must verify target environments.
     ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+    # Sentinel/MAX enum value moved. Existing binaries are unaffected,
+    # but source code using it as loop bound/array size may need review.
+    ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
     # A symbol exported by this library that originates from a dependency changed.
     # This is a real ABI change but caused by dependency versioning, not the
     # library's own API.  Direct consumers do not link against these symbols

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -435,6 +435,8 @@ RISK_KINDS: frozenset[ChangeKind] = frozenset({
     # Sentinel/MAX enum value moved. Existing binaries are unaffected,
     # but source code using it as loop bound/array size may need review.
     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
+    # Regular enum member value change — source risk, not a guaranteed binary break.
+    ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
     # A symbol exported by this library that originates from a dependency changed.
     # This is a real ABI change but caused by dependency versioning, not the
     # library's own API.  Direct consumers do not link against these symbols

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -435,8 +435,6 @@ RISK_KINDS: frozenset[ChangeKind] = frozenset({
     # Sentinel/MAX enum value moved. Existing binaries are unaffected,
     # but source code using it as loop bound/array size may need review.
     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
-    # Regular enum member value change — source risk, not a guaranteed binary break.
-    ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
     # A symbol exported by this library that originates from a dependency changed.
     # This is a real ABI change but caused by dependency versioning, not the
     # library's own API.  Direct consumers do not link against these symbols

--- a/abicheck/report_classifications.py
+++ b/abicheck/report_classifications.py
@@ -69,7 +69,7 @@ CHANGED_BREAKING_KINDS: frozenset[str] = frozenset({
     "type_size_changed", "type_alignment_changed",
     "type_field_removed", "type_field_offset_changed", "type_field_type_changed",
     "type_base_changed", "type_vtable_changed",
-    "enum_member_value_changed", "enum_last_member_value_changed",
+    "enum_member_value_changed",
     "enum_underlying_size_changed",
     "struct_size_changed", "struct_field_offset_changed", "struct_field_removed",
     "struct_field_type_changed", "struct_alignment_changed",

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -205,7 +205,7 @@
       "bad_practice": false
     },
     "case20_enum_member_value_changed": {
-      "expected": "BREAKING",
+      "expected": "COMPATIBLE_WITH_RISK",
       "category": "breaking",
       "platforms": [
         "linux",
@@ -214,7 +214,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "reason": "enum sentinel/last value change is a source risk, not a binary ABI break"
     },
     "case21_method_became_static": {
       "expected": "BREAKING",

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -205,7 +205,7 @@
       "bad_practice": false
     },
     "case20_enum_member_value_changed": {
-      "expected": "BREAKING",
+      "expected": "COMPATIBLE_WITH_RISK",
       "category": "breaking",
       "platforms": [
         "linux",
@@ -215,7 +215,7 @@
       "abi_break": true,
       "api_break": true,
       "bad_practice": false,
-      "reason": "regular enum member value changes remain breaking; sentinel-only change is risk"
+      "reason": "enum member value changes are source risk, not binary ABI break"
     },
     "case21_method_became_static": {
       "expected": "BREAKING",

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -205,7 +205,7 @@
       "bad_practice": false
     },
     "case20_enum_member_value_changed": {
-      "expected": "COMPATIBLE_WITH_RISK",
+      "expected": "BREAKING",
       "category": "breaking",
       "platforms": [
         "linux",
@@ -215,7 +215,7 @@
       "abi_break": true,
       "api_break": true,
       "bad_practice": false,
-      "reason": "enum sentinel/last value change is a source risk, not a binary ABI break"
+      "reason": "regular enum member value changes remain breaking; sentinel-only change is risk"
     },
     "case21_method_became_static": {
       "expected": "BREAKING",

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -229,11 +229,11 @@ def test_sprint1_breaking_subset() -> None:
     )
 
 
-def test_regular_enum_member_value_change_is_risk() -> None:
-    """Non-sentinel enum member value change is COMPATIBLE_WITH_RISK (source risk, not binary break)."""
+def test_regular_enum_member_value_change_remains_breaking() -> None:
+    """Non-sentinel enum member value change stays BREAKING."""
     old = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("E", 1), EnumMember("LAST", 2)])])
     new = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("E", 99), EnumMember("LAST", 2)])])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds
-    assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+    assert result.verdict == Verdict.BREAKING

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -227,3 +227,12 @@ def test_sprint1_breaking_subset() -> None:
     assert sprint1_kinds.issubset(_BREAKING_KINDS), (
         f"Not in _BREAKING_KINDS: {sprint1_kinds - _BREAKING_KINDS}"
     )
+
+
+def test_regular_enum_member_value_change_remains_breaking() -> None:
+    old = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("E", 1), EnumMember("LAST", 2)])])
+    new = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("E", 99), EnumMember("LAST", 2)])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds
+    assert result.verdict == Verdict.BREAKING

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -229,10 +229,11 @@ def test_sprint1_breaking_subset() -> None:
     )
 
 
-def test_regular_enum_member_value_change_remains_breaking() -> None:
+def test_regular_enum_member_value_change_is_risk() -> None:
+    """Non-sentinel enum member value change is COMPATIBLE_WITH_RISK (source risk, not binary break)."""
     old = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("E", 1), EnumMember("LAST", 2)])])
     new = _snap(enums=[EnumType("Err", [EnumMember("OK", 0), EnumMember("E", 99), EnumMember("LAST", 2)])])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds
-    assert result.verdict == Verdict.BREAKING
+    assert result.verdict == Verdict.COMPATIBLE_WITH_RISK

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -49,6 +49,7 @@ def test_enum_last_member_changed() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED in kinds
+    assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
 
 
 def test_enum_member_added() -> None:
@@ -58,6 +59,26 @@ def test_enum_member_added() -> None:
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.ENUM_MEMBER_ADDED in kinds
     assert result.verdict == Verdict.COMPATIBLE
+
+
+def test_enum_additions_plus_last_change_are_risk_not_breaking() -> None:
+    """Multiple enum member additions + sentinel move should be COMPATIBLE_WITH_RISK."""
+    from abicheck.elf_metadata import ElfMetadata
+
+    old = _snap(
+        enums=[EnumType("Tag", [EnumMember("A", 0), EnumMember("LAST", 10)])],
+        elf=ElfMetadata(needed=["libc.so.6"]),
+    )
+    new = _snap(
+        enums=[EnumType("Tag", [EnumMember("A", 0), EnumMember("B", 1), EnumMember("LAST", 11)])],
+        elf=ElfMetadata(needed=["libc.so.6", "libsvml.so"]),
+    )
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_MEMBER_ADDED in kinds
+    assert ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED in kinds
+    assert ChangeKind.NEEDED_ADDED in kinds
+    assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
 
 
 # ---------------------------------------------------------------------------
@@ -188,13 +209,12 @@ def test_bitfield_changed() -> None:
 # Verdict checks (all sprint1 changes are BREAKING)
 # ---------------------------------------------------------------------------
 
-def test_sprint1_all_breaking() -> None:
-    """All new change kinds must produce BREAKING verdict."""
+def test_sprint1_breaking_subset() -> None:
+    """Sprint1 binary-breaking subset remains in BREAKING bucket."""
     from abicheck.checker import _BREAKING_KINDS
     sprint1_kinds = {
         ChangeKind.ENUM_MEMBER_REMOVED,
         ChangeKind.ENUM_MEMBER_VALUE_CHANGED,
-        ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED,
         ChangeKind.FUNC_STATIC_CHANGED,
         ChangeKind.FUNC_CV_CHANGED,
         ChangeKind.FUNC_PURE_VIRTUAL_ADDED,

--- a/tests/test_sprint3_dwarf.py
+++ b/tests/test_sprint3_dwarf.py
@@ -229,8 +229,8 @@ def test_enum_member_removed() -> None:
 # ── enum member value changed ─────────────────────────────────────────────────
 
 def test_enum_member_value_changed() -> None:
-    old = _snap(_meta(enums={"Code": _enum("Code", 4, members={"OK": 0, "FAIL": 1})}))
-    new = _snap(_meta(enums={"Code": _enum("Code", 4, members={"OK": 0, "FAIL": 2})}))
+    old = _snap(_meta(enums={"Code": _enum("Code", 4, members={"OK": 0, "FAIL": 1, "LAST": 2})}))
+    new = _snap(_meta(enums={"Code": _enum("Code", 4, members={"OK": 0, "FAIL": 3, "LAST": 2})}))
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.ENUM_MEMBER_VALUE_CHANGED in kinds


### PR DESCRIPTION
## Context

From oneDNN 2025.0.2 -> 2025.1.0 scan, report was overly harsh () with mostly enum additions + DT_NEEDED add.

## Changes

- Move  from  to 
- Keep  and  as non-breaking (existing policy)
- Add regression test for oneDNN-like combination:
  - enum member additions
  - enum sentinel () value change
  - 
  - expected verdict: 
- Update sprint1 policy expectation test accordingly

## Why

Sentinel moves are source/deployment risk (loop bounds, array sizes), but not guaranteed binary ABI break for already-compiled consumers.

## Notes

This PR does **not** change  classification yet; that remains the likely remaining hard-break driver in some oneDNN outputs and should be evaluated separately with targeted policy options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reclassified last-member enum value changes from breaking to deployment-risk, improving compatibility verdicts; regular enum member value changes remain breaking.

* **Tests**
  * Added tests covering enum additions combined with a last-member value change as a risk.
  * Updated and renamed existing tests to assert COMPATIBLE_WITH_RISK where applicable.

* **Documentation**
  * Updated example case and explanatory text to reflect the new risk classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->