### PR TITLE
docs(adr): ADR-002 multi-binary release compare

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1028,8 +1027,8 @@ def compare_release_cmd(
         lines: list[str] = [
             "# ABI Release Comparison",
             "",
-            f"| | |",
-            f"|---|---|",
+            "| | |",
+            "|---|---|",
             f"| **Old** | `{old_dir}` |",
             f"| **New** | `{new_dir}` |",
             f"| **Verdict** | {_VERDICT_EMOJI.get(worst_verdict, '?')} `{worst_verdict}` |",

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -15,7 +15,9 @@
 """CLI — abicheck dump | compare | compat (dump | check)."""
 from __future__ import annotations
 
+import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -546,6 +548,111 @@ def _render_output(fmt: str, result: DiffResult, old: AbiSnapshot, new: AbiSnaps
     return to_markdown(result)
 
 
+def _collect_additions(result: DiffResult) -> list[object]:
+    """Collect additive changes in a policy-independent way."""
+    from .checker_policy import COMPATIBLE_KINDS
+    addition_kinds = {k for k in COMPATIBLE_KINDS if k.value.endswith("_added")}
+    return [c for c in result.changes if c.kind in addition_kinds]
+
+
+def _run_compare_pair(
+    old_input: Path,
+    new_input: Path,
+    old_headers: list[Path],
+    new_headers: list[Path],
+    old_includes: list[Path],
+    new_includes: list[Path],
+    old_version: str,
+    new_version: str,
+    lang: str,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
+    old_pdb_path: Path | None,
+    new_pdb_path: Path | None,
+) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+    """Run compare for one old/new pair and return result + resolved snapshots."""
+    old_fmt = _detect_binary_format(old_input)
+    new_fmt = _detect_binary_format(new_input)
+
+    old = _resolve_input(
+        old_input,
+        old_headers,
+        old_includes,
+        old_version,
+        lang,
+        is_elf=True if old_fmt == "elf" else None,
+        pdb_path=old_pdb_path,
+    )
+    new = _resolve_input(
+        new_input,
+        new_headers,
+        new_includes,
+        new_version,
+        lang,
+        is_elf=True if new_fmt == "elf" else None,
+        pdb_path=new_pdb_path,
+    )
+
+    suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
+    result = compare(old, new, suppression=suppression, policy=policy, policy_file=pf)
+    result.old_metadata = _collect_metadata(old_input)
+    result.new_metadata = _collect_metadata(new_input)
+    return result, old, new
+
+
+def _canonical_library_key(path: Path) -> str:
+    """Canonical key used to match libraries across releases."""
+    name = path.name
+    lower = name.lower()
+    so_idx = lower.find(".so")
+    if so_idx != -1:
+        return lower[: so_idx + 3]
+    return lower
+
+
+def _is_supported_compare_input(path: Path) -> bool:
+    """Return True for files accepted by compare/resolve_input."""
+    if not path.is_file():
+        return False
+    lower = path.name.lower()
+    if ".so" in lower or lower.endswith((".dll", ".dylib", ".json", ".pl", ".pm")):
+        return True
+    if _detect_binary_format(path) is not None:
+        return True
+    return _sniff_text_format(path) in {"json", "perl"}
+
+
+def _collect_release_inputs(path: Path) -> list[Path]:
+    """Collect compare-able inputs from a file or directory."""
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        raise click.ClickException(f"Input path is neither file nor directory: {path}")
+    files = [p for p in sorted(path.rglob("*")) if _is_supported_compare_input(p)]
+    if not files:
+        raise click.ClickException(f"No supported ABI inputs found in directory: {path}")
+    return files
+
+
+def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
+    """Build key->path map with deterministic duplicate resolution."""
+    buckets: dict[str, list[Path]] = {}
+    for p in paths:
+        buckets.setdefault(_canonical_library_key(p), []).append(p)
+
+    mapping: dict[str, Path] = {}
+    warnings: list[str] = []
+    for key, vals in buckets.items():
+        ordered = sorted(vals, key=lambda x: x.name)
+        mapping[key] = ordered[-1]
+        if len(ordered) > 1:
+            warnings.append(
+                f"Ambiguous match for '{key}': {[v.name for v in ordered]}; using '{ordered[-1].name}'"
+            )
+    return mapping, warnings
+
+
 @main.command("compare")
 @click.argument("old_input", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_input", type=click.Path(exists=True, path_type=Path))
@@ -732,6 +839,252 @@ def compare_cmd(
                 err=True,
             )
             sys.exit(1)
+
+@main.command("compare-release")
+@click.argument("old_dir", type=click.Path(exists=True, path_type=Path))
+@click.argument("new_dir", type=click.Path(exists=True, path_type=Path))
+@click.option("-H", "--header", "headers", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Public header file or directory applied to both sides.")
+@click.option("-I", "--include", "includes", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Extra include directory for castxml.")
+@click.option("--old-header", "old_headers_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Header for old side only (overrides -H for old).")
+@click.option("--new-header", "new_headers_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Header for new side only (overrides -H for new).")
+@click.option("--old-version", "old_version", default="old", show_default=True,
+              help="Version label for old side.")
+@click.option("--new-version", "new_version", default="new", show_default=True,
+              help="Version label for new side.")
+@click.option("--lang", default="c++", show_default=True,
+              type=click.Choice(["c++", "c"], case_sensitive=False))
+@click.option("--format", "fmt",
+              type=click.Choice(["json", "markdown"]),
+              default="markdown", show_default=True)
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None,
+              help="Output file for summary report (default: stdout).")
+@click.option("--output-dir", "output_dir", type=click.Path(path_type=Path), default=None,
+              help="Directory to write per-library reports.")
+@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Suppression file (YAML).")
+@click.option("--policy", "policy",
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
+              default="strict_abi", show_default=True)
+@click.option("--policy-file", "policy_file_path",
+              type=click.Path(exists=True, path_type=Path), default=None)
+@click.option("--fail-on-removed-library/--no-fail-on-removed-library",
+              "fail_on_removed", default=False,
+              help="Exit 8 when a library present in old_dir is absent in new_dir.")
+@click.option("--fail-on-additions/--no-fail-on-additions",
+              "fail_on_additions", default=False)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def compare_release_cmd(
+    old_dir: Path,
+    new_dir: Path,
+    headers: tuple[Path, ...],
+    includes: tuple[Path, ...],
+    old_headers_only: tuple[Path, ...],
+    new_headers_only: tuple[Path, ...],
+    old_version: str,
+    new_version: str,
+    lang: str,
+    fmt: str,
+    output: Path | None,
+    output_dir: Path | None,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
+    fail_on_removed: bool,
+    fail_on_additions: bool,
+    verbose: bool,
+) -> None:
+    """Compare all libraries in two release directories.
+
+    OLD_DIR and NEW_DIR may each be a file or a directory.
+    When directories are given, libraries are matched by filename stem.
+
+    \b
+    Exit codes:
+      0  All libraries: NO_CHANGE, COMPATIBLE, or COMPATIBLE_WITH_RISK
+      2  At least one library: API_BREAK
+      4  At least one library: BREAKING
+      8  Library removed (only when --fail-on-removed-library)
+
+    \b
+    Examples:
+      abicheck compare-release release-1.0/ release-2.0/ -H include/
+      abicheck compare-release release-1.0/ release-2.0/ \\
+          --old-header include/v1/ --new-header include/v2/ --format json
+    """
+    _setup_verbosity(verbose)
+
+    old_files = _collect_release_inputs(old_dir)
+    new_files = _collect_release_inputs(new_dir)
+
+    old_map, old_warns = _build_match_map(old_files)
+    new_map, new_warns = _build_match_map(new_files)
+    warning_msgs: list[str] = [f"Warning: {w}" for w in (old_warns + new_warns)]
+
+    old_h: list[Path] = list(old_headers_only) if old_headers_only else list(headers)
+    new_h: list[Path] = list(new_headers_only) if new_headers_only else list(headers)
+    old_inc: list[Path] = list(includes)
+    new_inc: list[Path] = list(includes)
+
+    # Special case: file-vs-file should compare directly even when names differ.
+    direct_file_pair = old_dir.is_file() and new_dir.is_file()
+    if direct_file_pair:
+        matched_keys = ["__direct_pair__"]
+        old_map = {"__direct_pair__": old_files[0]}
+        new_map = {"__direct_pair__": new_files[0]}
+        removed_keys = []
+        added_keys = []
+    else:
+        matched_keys = sorted(set(old_map) & set(new_map))
+        removed_keys = sorted(set(old_map) - set(new_map))
+        added_keys = sorted(set(new_map) - set(old_map))
+
+    if removed_keys:
+        for k in removed_keys:
+            warning_msgs.append(f"Warning: library removed: {old_map[k].name}")
+
+    if added_keys:
+        for k in added_keys:
+            warning_msgs.append(f"Info: library added: {new_map[k].name}")
+
+    if fmt != "json":
+        for msg in warning_msgs:
+            click.echo(msg, err=True)
+
+    if not matched_keys and not old_files and not new_files:
+        raise click.ClickException("No libraries to compare.")
+
+    if output_dir:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    library_results: list[dict[str, object]] = []
+    worst_verdict = "NO_CHANGE"
+    _VERDICT_ORDER = {
+        "NO_CHANGE": 0, "COMPATIBLE": 1, "COMPATIBLE_WITH_RISK": 2,
+        "API_BREAK": 3, "BREAKING": 4,
+    }
+
+    for key in matched_keys:
+        old_path = old_map[key]
+        new_path = new_map[key]
+        try:
+            result, old_snap, new_snap = _run_compare_pair(
+                old_path, new_path,
+                old_h, new_h, old_inc, new_inc,
+                old_version, new_version,
+                lang, suppress, policy, policy_file_path,
+                old_pdb_path=None, new_pdb_path=None,
+            )
+        except (click.ClickException, click.UsageError) as exc:
+            click.echo(f"Error comparing {old_path.name}: {exc.format_message()}", err=True)
+            library_results.append({
+                "library": old_path.name,
+                "verdict": "ERROR",
+                "error": exc.format_message(),
+            })
+            continue
+
+        v = result.verdict.value
+        if _VERDICT_ORDER.get(v, 0) > _VERDICT_ORDER.get(worst_verdict, 0):
+            worst_verdict = v
+
+        lib_entry: dict[str, object] = {
+            "library": old_path.name,
+            "verdict": v,
+            "breaking": len(result.breaking),
+            "source_breaks": len(result.source_breaks),
+            "risk_changes": len(result.risk),
+            "compatible_additions": len(result.compatible),
+        }
+        library_results.append(lib_entry)
+
+        if output_dir:
+            lib_report_path = output_dir / f"{old_path.stem}.json"
+            lib_report_path.write_text(to_json(result), encoding="utf-8")
+
+    # Summary output
+    if fmt == "json":
+        summary: dict[str, object] = {
+            "verdict": worst_verdict,
+            "old_dir": str(old_dir),
+            "new_dir": str(new_dir),
+            "libraries": library_results,
+            "unmatched_old": [old_map[k].name for k in removed_keys],
+            "unmatched_new": [new_map[k].name for k in added_keys],
+        }
+        text = json.dumps(summary, indent=2)
+    else:
+        _VERDICT_EMOJI = {
+            "NO_CHANGE": "✅", "COMPATIBLE": "✅", "COMPATIBLE_WITH_RISK": "⚠️",
+            "API_BREAK": "⚠️", "BREAKING": "❌", "ERROR": "💥",
+        }
+        lines: list[str] = [
+            "# ABI Release Comparison",
+            "",
+            f"| | |",
+            f"|---|---|",
+            f"| **Old** | `{old_dir}` |",
+            f"| **New** | `{new_dir}` |",
+            f"| **Verdict** | {_VERDICT_EMOJI.get(worst_verdict, '?')} `{worst_verdict}` |",
+            "",
+            "## Libraries",
+            "",
+            "| Library | Verdict | Breaking | Source | Risk | Additions |",
+            "|---|---|---|---|---|---|",
+        ]
+        for lib in library_results:
+            em = _VERDICT_EMOJI.get(str(lib["verdict"]), "?")
+            lines.append(
+                f"| `{lib['library']}` | {em} `{lib['verdict']}` "
+                f"| {lib.get('breaking', '—')} | {lib.get('source_breaks', '—')} "
+                f"| {lib.get('risk_changes', '—')} | {lib.get('compatible_additions', '—')} |"
+            )
+        if removed_keys:
+            lines += ["", "## ⚠️ Removed Libraries", ""]
+            for k in removed_keys:
+                lines.append(f"- `{old_map[k].name}`")
+        if added_keys:
+            lines += ["", "## ℹ️ Added Libraries", ""]
+            for k in added_keys:
+                lines.append(f"- `{new_map[k].name}`")
+        text = "\n".join(lines)
+
+    if output:
+        output.write_text(text, encoding="utf-8")
+        click.echo(f"Report written to {output}", err=True)
+    else:
+        click.echo(text)
+
+    if output_dir:
+        summary_path = output_dir / "summary.json"
+        summary_data: dict[str, object] = {
+            "verdict": worst_verdict,
+            "libraries": library_results,
+            "unmatched_old": [old_map[k].name for k in removed_keys],
+            "unmatched_new": [new_map[k].name for k in added_keys],
+        }
+        summary_path.write_text(json.dumps(summary_data, indent=2), encoding="utf-8")
+        click.echo(f"Per-library reports written to {output_dir}/", err=True)
+
+    # Exit codes
+    if fail_on_removed and removed_keys:
+        sys.exit(8)
+    if worst_verdict == "BREAKING":
+        sys.exit(4)
+    elif worst_verdict == "API_BREAK":
+        sys.exit(2)
+    if fail_on_additions:
+        # check if any library has additions
+        if any(lib.get("compatible_additions", 0) for lib in library_results):
+            sys.exit(1)
+
 
 # ── ABICC compat subcommands (implementation in abicheck.compat) ─────────────
 # NOTE: eagerly loads abicheck.compat.cli at import time — intentional so all

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -601,13 +602,37 @@ def _run_compare_pair(
 
 
 def _canonical_library_key(path: Path) -> str:
-    """Canonical key used to match libraries across releases."""
-    name = path.name
-    lower = name.lower()
-    so_idx = lower.find(".so")
-    if so_idx != -1:
-        return lower[: so_idx + 3]
+    """Canonical key used to match libraries across releases.
+
+    For ELF versioned names, canonicalize to ``*.so`` (e.g. ``libfoo.so.1.2`` → ``libfoo.so``).
+    """
+    lower = path.name.lower()
+    m = re.search(r"\.so(?:\.|$)", lower)
+    if m:
+        return lower[: m.start() + 3]
     return lower
+
+
+def _version_sort_key(path: Path, canonical_key: str) -> tuple[list[tuple[int, int | str]], str]:
+    """Build a version-aware sort key for ambiguous library candidates."""
+    lower = path.name.lower()
+    remainder = lower
+    if canonical_key.endswith(".so") and canonical_key in lower:
+        remainder = lower[lower.find(canonical_key) + len(canonical_key):]
+    # strip known wrapper extensions for snapshots/dumps
+    for suffix in (".json", ".pl", ".pm"):
+        if remainder.endswith(suffix):
+            remainder = remainder[: -len(suffix)]
+            break
+    remainder = remainder.lstrip("._-")
+    tokens = re.findall(r"\d+|[a-z]+", remainder)
+    parsed: list[tuple[int, int | str]] = []
+    for tok in tokens:
+        if tok.isdigit():
+            parsed.append((1, int(tok)))
+        else:
+            parsed.append((0, tok))
+    return parsed, lower
 
 
 def _is_supported_compare_input(path: Path) -> bool:
@@ -635,7 +660,7 @@ def _collect_release_inputs(path: Path) -> list[Path]:
 
 
 def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
-    """Build key->path map with deterministic duplicate resolution."""
+    """Build key->path map with version-aware duplicate resolution."""
     buckets: dict[str, list[Path]] = {}
     for p in paths:
         buckets.setdefault(_canonical_library_key(p), []).append(p)
@@ -643,11 +668,12 @@ def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
     mapping: dict[str, Path] = {}
     warnings: list[str] = []
     for key, vals in buckets.items():
-        ordered = sorted(vals, key=lambda x: x.name)
-        mapping[key] = ordered[-1]
+        ordered = sorted(vals, key=lambda x: _version_sort_key(x, key))
+        selected = ordered[-1]
+        mapping[key] = selected
         if len(ordered) > 1:
             warnings.append(
-                f"Ambiguous match for '{key}': {[v.name for v in ordered]}; using '{ordered[-1].name}'"
+                f"Ambiguous match for '{key}': {[v.name for v in ordered]}; using '{selected.name}'"
             )
     return mapping, warnings
 
@@ -953,12 +979,14 @@ def compare_release_cmd(
         for k in added_keys:
             warning_msgs.append(f"Info: library added: {new_map[k].name}")
 
+    if not matched_keys:
+        warning_msgs.append(
+            "Warning: no matching library pairs found between OLD and NEW inputs."
+        )
+
     if fmt != "json":
         for msg in warning_msgs:
             click.echo(msg, err=True)
-
-    if not matched_keys and not old_files and not new_files:
-        raise click.ClickException("No libraries to compare.")
 
     if output_dir:
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -966,15 +994,19 @@ def compare_release_cmd(
     library_results: list[dict[str, object]] = []
     worst_verdict = "NO_CHANGE"
     _VERDICT_ORDER = {
-        "NO_CHANGE": 0, "COMPATIBLE": 1, "COMPATIBLE_WITH_RISK": 2,
-        "API_BREAK": 3, "BREAKING": 4,
+        "NO_CHANGE": 0,
+        "COMPATIBLE": 1,
+        "COMPATIBLE_WITH_RISK": 2,
+        "API_BREAK": 3,
+        "BREAKING": 4,
+        "ERROR": 5,
     }
 
     for key in matched_keys:
         old_path = old_map[key]
         new_path = new_map[key]
         try:
-            result, old_snap, new_snap = _run_compare_pair(
+            result, _, _ = _run_compare_pair(
                 old_path, new_path,
                 old_h, new_h, old_inc, new_inc,
                 old_version, new_version,
@@ -982,12 +1014,14 @@ def compare_release_cmd(
                 old_pdb_path=None, new_pdb_path=None,
             )
         except (click.ClickException, click.UsageError) as exc:
-            click.echo(f"Error comparing {old_path.name}: {exc.format_message()}", err=True)
+            msg = exc.format_message()
+            click.echo(f"Error comparing {old_path.name}: {msg}", err=True)
             library_results.append({
                 "library": old_path.name,
                 "verdict": "ERROR",
-                "error": exc.format_message(),
+                "error": msg,
             })
+            worst_verdict = "ERROR"
             continue
 
         v = result.verdict.value
@@ -1017,6 +1051,7 @@ def compare_release_cmd(
             "libraries": library_results,
             "unmatched_old": [old_map[k].name for k in removed_keys],
             "unmatched_new": [new_map[k].name for k in added_keys],
+            "warnings": warning_msgs,
         }
         text = json.dumps(summary, indent=2)
     else:
@@ -1072,17 +1107,16 @@ def compare_release_cmd(
         summary_path.write_text(json.dumps(summary_data, indent=2), encoding="utf-8")
         click.echo(f"Per-library reports written to {output_dir}/", err=True)
 
-    # Exit codes
-    if fail_on_removed and removed_keys:
-        sys.exit(8)
-    if worst_verdict == "BREAKING":
+    # Exit codes — ABI severity takes priority over policy flags.
+    # A removed library is a deployment decision; a binary ABI break is more urgent.
+    if worst_verdict in ("BREAKING", "ERROR"):
         sys.exit(4)
     elif worst_verdict == "API_BREAK":
         sys.exit(2)
-    if fail_on_additions:
-        # check if any library has additions
-        if any(lib.get("compatible_additions", 0) for lib in library_results):
-            sys.exit(1)
+    if fail_on_removed and removed_keys:
+        sys.exit(8)
+    if fail_on_additions and any(lib.get("compatible_additions", 0) for lib in library_results):
+        sys.exit(1)
 
 
 # ── ABICC compat subcommands (implementation in abicheck.compat) ─────────────

--- a/docs/adr/002-multi-binary-release-compare.md
+++ b/docs/adr/002-multi-binary-release-compare.md
@@ -78,7 +78,7 @@ libbaz.so
 ## Matching Rules (auto-mode)
 
 1. Match by **filename stem** ignoring version suffix (e.g. `libfoo.so.1.2` → `libfoo.so`).
-2. If ambiguous (multiple versions of same stem): pick latest by sort order, warn.
+2. If ambiguous (multiple versions of same stem): pick latest by **version-aware** sort, warn.
 3. **Unmatched in old (removed):** report as `LIBRARY_REMOVED` (configurable fail/warn/ignore).
 4. **Unmatched in new (added):** report as `LIBRARY_ADDED` (configurable fail/warn/ignore).
 5. **Override:** `--map mappings.yaml` wins over auto-match.
@@ -148,6 +148,7 @@ New inputs needed:
 | `new-library-dir` | Directory of new binaries |
 | `library-map` | YAML mapping file for non-trivial name changes |
 | `fail-on-removed-library` | Fail if a library disappeared |
+| `fail-on-additions` | Fail if compatible additions are detected |
 | `output-dir` | Per-library report output directory |
 
 Example:

--- a/docs/adr/002-multi-binary-release-compare.md
+++ b/docs/adr/002-multi-binary-release-compare.md
@@ -1,0 +1,186 @@
+# ADR-002: Multi-binary / release compare UX and architecture
+
+**Date:** 2026-03-16  
+**Status:** Proposed  
+**Decision maker:** Nikolay Petrov
+
+---
+
+## Context
+
+Real-world releases contain multiple binaries per package (e.g. `libfoo.so`, `libfoo_gpu.so`,
+`libbar.so`, `libbar_cxx.so`). Today `abicheck compare` accepts exactly one OLD and one NEW binary.
+Users must script their own loops and manually aggregate verdicts.
+
+---
+
+## Proposed UX
+
+### Pattern A — Multiple explicit pairs (extend current `compare`)
+
+```bash
+# Multiple binaries, same header dir for all
+abicheck compare old/libfoo.so old/libbar.so \
+           new/libfoo.so new/libbar.so \
+           -H include/
+
+# Per-pair per-side headers (run separately)
+abicheck compare old/libfoo.so new/libfoo.so --old-header v1/foo.h --new-header v2/foo.h
+abicheck compare old/libbar.so new/libbar.so --old-header v1/bar.h --new-header v2/bar.h
+```
+
+**Problem:** CLI gets ambiguous for 3+ binaries.
+
+### Pattern B — Directory-vs-directory (preferred for releases)
+
+```bash
+# Auto-match by filename, single header dir
+abicheck compare-release release-1.0/ release-2.0/ -H include/
+
+# Per-side header directories
+abicheck compare-release release-1.0/ release-2.0/ \
+    --old-header include/v1/ --new-header include/v2/
+
+# With mapping file (when binary names differ between versions)
+abicheck compare-release release-1.0/ release-2.0/ \
+    -H include/ --map mappings.yaml
+
+# Policy: fail if a binary was removed
+abicheck compare-release release-1.0/ release-2.0/ -H include/ \
+    --fail-on-removed-library
+```
+
+**mappings.yaml:**
+```yaml
+map:
+  - old: libfoo.so.1.2
+    new: libfoo.so.1.3
+  - old: liblegacy.so
+    new: null       # intentionally removed (suppress verdict)
+```
+
+### Pattern C — Glob / list via file
+
+```bash
+# Compare specific set of binaries
+abicheck compare-release --libs-list libs.txt old/ new/ -H include/
+```
+
+**libs.txt:**
+```text
+libfoo.so
+libbar.so
+libbaz.so
+```
+
+---
+
+## Matching Rules (auto-mode)
+
+1. Match by **filename stem** ignoring version suffix (e.g. `libfoo.so.1.2` → `libfoo.so`).
+2. If ambiguous (multiple versions of same stem): pick latest by sort order, warn.
+3. **Unmatched in old (removed):** report as `LIBRARY_REMOVED` (configurable fail/warn/ignore).
+4. **Unmatched in new (added):** report as `LIBRARY_ADDED` (configurable fail/warn/ignore).
+5. **Override:** `--map mappings.yaml` wins over auto-match.
+
+---
+
+## Output
+
+### Summary table (markdown/stdout):
+
+```text
+╔══════════════════════╦══════════════╦══════════════╗
+║ Library              ║ Verdict      ║ Changes      ║
+╠══════════════════════╬══════════════╬══════════════╣
+║ libfoo.so            ║ ❌ BREAKING  ║ 3 breaking   ║
+║ libbar.so            ║ ✅ COMPATIBLE║ 2 additions  ║
+║ libbaz.so            ║ ✅ NO_CHANGE ║ 0 changes    ║
+╚══════════════════════╩══════════════╩══════════════╝
+Overall: BREAKING (worst of 3 libs)
+```
+
+### Machine JSON (`--format json`):
+
+```json
+{
+  "verdict": "BREAKING",
+  "libraries": [
+    { "library": "libfoo.so", "verdict": "BREAKING", "changes": [...] },
+    { "library": "libbar.so", "verdict": "COMPATIBLE", "changes": [...] },
+    { "library": "libbaz.so", "verdict": "NO_CHANGE", "changes": [] }
+  ],
+  "unmatched_old": [],
+  "unmatched_new": []
+}
+```
+
+### Per-library detail report (`--output-dir`)
+
+```bash
+abicheck compare-release release-1.0/ release-2.0/ -H include/ \
+    --output-dir reports/
+# Generates: reports/libfoo.so.json, reports/libbar.so.json, ...
+# And: reports/summary.json, reports/summary.md
+```
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All libraries: NO_CHANGE or COMPATIBLE |
+| 1 | ADDITIONS (only when --fail-on-additions) |
+| 2 | At least one: API_BREAK |
+| 4 | At least one: BREAKING |
+| 8 | Missing/unmatched libraries (only when --fail-on-removed-library) |
+
+---
+
+## GitHub Action Impact
+
+New inputs needed:
+
+| Input | Description |
+|-------|-------------|
+| `old-library-dir` | Directory of old binaries |
+| `new-library-dir` | Directory of new binaries |
+| `library-map` | YAML mapping file for non-trivial name changes |
+| `fail-on-removed-library` | Fail if a library disappeared |
+| `output-dir` | Per-library report output directory |
+
+Example:
+```yaml
+- uses: napetrov/abicheck@v1
+  with:
+    old-library-dir: release-1.0/lib/
+    new-library-dir: release-2.0/lib/
+    old-header: include/v1/
+    new-header: include/v2/
+    format: json
+    output-dir: abi-reports/
+```
+
+---
+
+## Implementation Plan
+
+1. **CLI:** new `compare-release` subcommand in `abicheck/cli.py`
+2. **Matcher:** `abicheck/multi_compare.py` — filename-stem matching + mapping file
+3. **Aggregator:** collect DiffResult per pair → aggregate verdict (worst-of)
+4. **Output:** extend reporter to handle multi-library summary
+5. **Tests:** all combinations — files, dirs, globs, missing pairs, explicit maps
+6. **Action:** new inputs + updated `action.yml`
+7. **Docs:** `docs/adr/002-multi-binary-release-compare.md` + update `docs/github-action.md`
+
+---
+
+## Open Questions
+
+- Should `compare-release` also accept explicit list `OLD1 OLD2 ... NEW1 NEW2 ...` positionally?  
+  → Leaning no — ambiguous for 3+ libs. Use directory or `--libs-list`.
+- Should we support SONAME-based matching (not just filename stem)?  
+  → Yes, as secondary strategy when filename stem fails.
+- Parallel execution?  
+  → Yes (ThreadPoolExecutor) — each pair is independent.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -3,3 +3,4 @@
 | # | Title | Status |
 |---|-------|--------|
 | [001](001-technology-stack.md) | Technology Stack — Python + pyelftools + castxml | Accepted |
+| [002](002-multi-binary-release-compare.md) | Multi-binary / release compare UX and architecture | Proposed |

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -1,0 +1,245 @@
+"""Tests for the compare-release command (multi-binary directory comparison)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _snap(version: str = "1.0", funcs: list[Function] | None = None, library: str = "libfoo.so") -> AbiSnapshot:
+    if funcs is None:
+        funcs = [Function(name="foo", mangled="_Z3foov", return_type="int",
+                          visibility=Visibility.PUBLIC)]
+    return AbiSnapshot(library=library, version=version, functions=funcs)
+
+
+def _write_snap(path: Path, snap: AbiSnapshot) -> Path:
+    path.write_text(snapshot_to_json(snap), encoding="utf-8")
+    return path
+
+
+def _breaking_pair(lib: str = "libfoo.so") -> tuple[AbiSnapshot, AbiSnapshot]:
+    old = _snap("1.0", [
+        Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC),
+        Function(name="bar", mangled="_Z3barv", return_type="void", visibility=Visibility.PUBLIC),
+    ], library=lib)
+    new = _snap("2.0", [
+        Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC),
+    ], library=lib)
+    return old, new
+
+
+def _invoke(*args: str) -> tuple[int, str]:
+    result = CliRunner().invoke(main, list(args))
+    return result.exit_code, result.output
+
+
+# ── file vs file ─────────────────────────────────────────────────────────────
+
+class TestFileVsFile:
+    def test_no_change(self, tmp_path):
+        snap = _snap()
+        old_f = _write_snap(tmp_path / "libfoo.json", snap)
+        new_f = _write_snap(tmp_path / "libfoo_new.json", snap)
+        code, out = _invoke("compare-release", str(old_f), str(new_f))
+        assert code == 0
+        assert "NO_CHANGE" in out
+
+    def test_breaking(self, tmp_path):
+        old, new = _breaking_pair()
+        old_f = _write_snap(tmp_path / "libfoo.json", old)
+        new_f = _write_snap(tmp_path / "libfoo_new.json", new)
+        code, out = _invoke("compare-release", str(old_f), str(new_f))
+        assert code == 4
+
+    def test_json_output(self, tmp_path):
+        snap = _snap()
+        old_f = _write_snap(tmp_path / "libfoo.json", snap)
+        new_f = _write_snap(tmp_path / "libfoo2.json", snap)
+        code, out = _invoke("compare-release", str(old_f), str(new_f), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        assert data["verdict"] == "NO_CHANGE"
+        assert len(data["libraries"]) == 1
+
+
+# ── dir vs dir ───────────────────────────────────────────────────────────────
+
+class TestDirVsDir:
+    def test_matching_by_name_no_change(self, tmp_path):
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir(); new_dir.mkdir()
+
+        snap = _snap()
+        _write_snap(old_dir / "libfoo.json", snap)
+        _write_snap(new_dir / "libfoo.json", snap)
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 0
+        assert "NO_CHANGE" in out
+
+    def test_matching_multi_library_all_ok(self, tmp_path):
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        for name in ("libfoo.json", "libbar.json", "libbaz.json"):
+            snap = _snap()
+            _write_snap(old_dir / name, snap)
+            _write_snap(new_dir / name, snap)
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 0
+
+    def test_breaking_in_one_library(self, tmp_path):
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        # libfoo: breaking
+        old_foo, new_foo = _breaking_pair("libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old_foo)
+        _write_snap(new_dir / "libfoo.json", new_foo)
+
+        # libbar: no change
+        _write_snap(old_dir / "libbar.json", _snap())
+        _write_snap(new_dir / "libbar.json", _snap())
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 4
+        assert "BREAKING" in out
+
+    def test_json_output_multi(self, tmp_path):
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        for name in ("libfoo.json", "libbar.json"):
+            snap = _snap()
+            _write_snap(old_dir / name, snap)
+            _write_snap(new_dir / name, snap)
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        assert data["verdict"] == "NO_CHANGE"
+        assert len(data["libraries"]) == 2
+
+
+# ── unmatched / missing ───────────────────────────────────────────────────────
+
+class TestUnmatched:
+    def test_removed_library_no_flag(self, tmp_path):
+        """Removed library should warn but not fail by default."""
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(old_dir / "libbar.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        # libbar missing in new
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 0  # no --fail-on-removed-library
+        # warning should be on stderr but click test merges stdout/stderr
+        # at least the summary is ok
+
+    def test_removed_library_with_flag(self, tmp_path):
+        """--fail-on-removed-library should exit 8 when library disappears."""
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(old_dir / "libbar.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        code, _ = _invoke(
+            "compare-release", str(old_dir), str(new_dir),
+            "--fail-on-removed-library",
+        )
+        assert code == 8
+
+    def test_added_library_ok(self, tmp_path):
+        """New library in new_dir not in old_dir is fine (no flag needed)."""
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libbar.json", _snap())  # new lib
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 0
+
+    def test_unmatched_reported_in_json(self, tmp_path):
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(old_dir / "libremoved.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libadded.json", _snap())
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        assert "libremoved.json" in data["unmatched_old"]
+        assert "libadded.json" in data["unmatched_new"]
+
+
+# ── output-dir ────────────────────────────────────────────────────────────────
+
+class TestOutputDir:
+    def test_per_library_reports_written(self, tmp_path):
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+        out_dir = tmp_path / "reports"
+
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        code, _ = _invoke(
+            "compare-release", str(old_dir), str(new_dir),
+            "--output-dir", str(out_dir),
+        )
+        assert code == 0
+        assert (out_dir / "libfoo.json").exists()
+        assert (out_dir / "summary.json").exists()
+
+    def test_summary_json_structure(self, tmp_path):
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+        out_dir = tmp_path / "reports"
+
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        _invoke("compare-release", str(old_dir), str(new_dir), "--output-dir", str(out_dir))
+        summary = json.loads((out_dir / "summary.json").read_text())
+        assert summary["verdict"] == "NO_CHANGE"
+        assert len(summary["libraries"]) == 1
+
+
+# ── mixed input (file vs file, different names, same stem) ───────────────────
+
+class TestMixedInputs:
+    def test_so_versioned_name_matching(self, tmp_path):
+        """libfoo.so.1.2 in old should match libfoo.so.1.3 in new via stem."""
+        old_dir = tmp_path / "old"; old_dir.mkdir()
+        new_dir = tmp_path / "new"; new_dir.mkdir()
+
+        snap = _snap()
+        _write_snap(old_dir / "libfoo.so.1.2.json", snap)
+        _write_snap(new_dir / "libfoo.so.1.3.json", snap)
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        assert len(data["libraries"]) == 1
+        assert data["verdict"] == "NO_CHANGE"

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -6,13 +6,17 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from abicheck.cli import main
-from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.cli import _canonical_library_key, _version_sort_key, main
+from abicheck.model import AbiSnapshot, Function, Param, Visibility
 from abicheck.serialization import snapshot_to_json
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
-def _snap(version: str = "1.0", funcs: list[Function] | None = None, library: str = "libfoo.so") -> AbiSnapshot:
+def _snap(
+    version: str = "1.0",
+    funcs: list[Function] | None = None,
+    library: str = "libfoo.so",
+) -> AbiSnapshot:
     if funcs is None:
         funcs = [Function(name="foo", mangled="_Z3foov", return_type="int",
                           visibility=Visibility.PUBLIC)]
@@ -25,6 +29,7 @@ def _write_snap(path: Path, snap: AbiSnapshot) -> Path:
 
 
 def _breaking_pair(lib: str = "libfoo.so") -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Remove a function — always produces BREAKING verdict."""
     old = _snap("1.0", [
         Function(name="foo", mangled="_Z3foov", return_type="int", visibility=Visibility.PUBLIC),
         Function(name="bar", mangled="_Z3barv", return_type="void", visibility=Visibility.PUBLIC),
@@ -35,15 +40,75 @@ def _breaking_pair(lib: str = "libfoo.so") -> tuple[AbiSnapshot, AbiSnapshot]:
     return old, new
 
 
+def _api_break_pair(lib: str = "libfoo.so") -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Signature change that requires recompilation but is not a binary break."""
+    old = _snap("1.0", [
+        Function(
+            name="foo",
+            mangled="_Z3foov",
+            return_type="int",
+            params=[Param(name="x", type="int", default="0")],
+            visibility=Visibility.PUBLIC,
+        ),
+    ], library=lib)
+    new = _snap("2.0", [
+        Function(
+            name="foo",
+            mangled="_Z3foov",
+            return_type="int",
+            params=[Param(name="x", type="int")],
+            visibility=Visibility.PUBLIC,
+        ),
+    ], library=lib)
+    return old, new
+
+
 def _invoke(*args: str) -> tuple[int, str]:
     result = CliRunner().invoke(main, list(args))
     return result.exit_code, result.output
 
 
+# ── canonical key helpers ─────────────────────────────────────────────────────
+
+class TestCanonicalLibraryKey:
+    def test_so_versioned(self, tmp_path: Path) -> None:
+        assert _canonical_library_key(Path("libfoo.so.1.2")) == "libfoo.so"
+
+    def test_so_no_version(self, tmp_path: Path) -> None:
+        assert _canonical_library_key(Path("libfoo.so")) == "libfoo.so"
+
+    def test_json_snapshot(self, tmp_path: Path) -> None:
+        # No .so in name — returns as-is
+        assert _canonical_library_key(Path("libfoo.json")) == "libfoo.json"
+
+    def test_so_json_snapshot(self, tmp_path: Path) -> None:
+        # .so in name + .json suffix
+        assert _canonical_library_key(Path("libfoo.so.1.2.json")) == "libfoo.so"
+
+    def test_so_in_stem_not_confused(self, tmp_path: Path) -> None:
+        # "libsome.so" — ".so" is real extension, not inside stem
+        assert _canonical_library_key(Path("libsome.so")) == "libsome.so"
+
+    def test_dll(self, tmp_path: Path) -> None:
+        assert _canonical_library_key(Path("libfoo.dll")) == "libfoo.dll"
+
+
+class TestVersionSortKey:
+    def test_1_9_vs_1_10(self) -> None:
+        k9 = _version_sort_key(Path("libfoo.so.1.9"), "libfoo.so")
+        k10 = _version_sort_key(Path("libfoo.so.1.10"), "libfoo.so")
+        assert k9 < k10, "1.10 should sort after 1.9"
+
+    def test_1_2_vs_1_3(self) -> None:
+        k2 = _version_sort_key(Path("libfoo.so.1.2"), "libfoo.so")
+        k3 = _version_sort_key(Path("libfoo.so.1.3"), "libfoo.so")
+        assert k2 < k3
+
+
 # ── file vs file ─────────────────────────────────────────────────────────────
 
 class TestFileVsFile:
-    def test_no_change(self, tmp_path):
+    def test_no_change(self, tmp_path: Path) -> None:
         snap = _snap()
         old_f = _write_snap(tmp_path / "libfoo.json", snap)
         new_f = _write_snap(tmp_path / "libfoo_new.json", snap)
@@ -51,14 +116,22 @@ class TestFileVsFile:
         assert code == 0
         assert "NO_CHANGE" in out
 
-    def test_breaking(self, tmp_path):
+    def test_breaking(self, tmp_path: Path) -> None:
         old, new = _breaking_pair()
         old_f = _write_snap(tmp_path / "libfoo.json", old)
         new_f = _write_snap(tmp_path / "libfoo_new.json", new)
         code, out = _invoke("compare-release", str(old_f), str(new_f))
         assert code == 4
+        assert "BREAKING" in out
 
-    def test_json_output(self, tmp_path):
+    def test_api_break(self, tmp_path: Path) -> None:
+        old, new = _api_break_pair()
+        old_f = _write_snap(tmp_path / "libfoo.json", old)
+        new_f = _write_snap(tmp_path / "libfoo_new.json", new)
+        code, out = _invoke("compare-release", str(old_f), str(new_f))
+        assert code == 2
+
+    def test_json_output(self, tmp_path: Path) -> None:
         snap = _snap()
         old_f = _write_snap(tmp_path / "libfoo.json", snap)
         new_f = _write_snap(tmp_path / "libfoo2.json", snap)
@@ -72,153 +145,189 @@ class TestFileVsFile:
 # ── dir vs dir ───────────────────────────────────────────────────────────────
 
 class TestDirVsDir:
-    def test_matching_by_name_no_change(self, tmp_path):
+    def test_matching_by_name_no_change(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         new_dir = tmp_path / "new"
         old_dir.mkdir()
         new_dir.mkdir()
-
         snap = _snap()
         _write_snap(old_dir / "libfoo.json", snap)
         _write_snap(new_dir / "libfoo.json", snap)
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir))
         assert code == 0
         assert "NO_CHANGE" in out
 
-    def test_matching_multi_library_all_ok(self, tmp_path):
+    def test_matching_multi_library_all_ok(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
-
         for name in ("libfoo.json", "libbar.json", "libbaz.json"):
             snap = _snap()
             _write_snap(old_dir / name, snap)
             _write_snap(new_dir / name, snap)
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir))
         assert code == 0
+        assert "NO_CHANGE" in out
 
-    def test_breaking_in_one_library(self, tmp_path):
+    def test_breaking_in_one_library(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
-
-        # libfoo: breaking
         old_foo, new_foo = _breaking_pair("libfoo.so")
         _write_snap(old_dir / "libfoo.json", old_foo)
         _write_snap(new_dir / "libfoo.json", new_foo)
-
-        # libbar: no change
         _write_snap(old_dir / "libbar.json", _snap())
         _write_snap(new_dir / "libbar.json", _snap())
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir))
         assert code == 4
         assert "BREAKING" in out
 
-    def test_json_output_multi(self, tmp_path):
+    def test_api_break_in_one_library(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
+        old_foo, new_foo = _api_break_pair("libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old_foo)
+        _write_snap(new_dir / "libfoo.json", new_foo)
+        _write_snap(old_dir / "libbar.json", _snap())
+        _write_snap(new_dir / "libbar.json", _snap())
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 2
 
+    def test_json_output_multi(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
         for name in ("libfoo.json", "libbar.json"):
             snap = _snap()
             _write_snap(old_dir / name, snap)
             _write_snap(new_dir / name, snap)
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
         assert code == 0
         data = json.loads(out)
         assert data["verdict"] == "NO_CHANGE"
         assert len(data["libraries"]) == 2
 
+    def test_breaking_overrides_api_break(self, tmp_path: Path) -> None:
+        """Aggregate verdict is BREAKING even when another lib has API_BREAK."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        old_foo, new_foo = _breaking_pair("libfoo.so")
+        old_bar, new_bar = _api_break_pair("libbar.so")
+        _write_snap(old_dir / "libfoo.json", old_foo)
+        _write_snap(new_dir / "libfoo.json", new_foo)
+        _write_snap(old_dir / "libbar.json", old_bar)
+        _write_snap(new_dir / "libbar.json", new_bar)
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 4
+        assert "BREAKING" in out
+
+    def test_fully_disjoint_dirs_warns_and_exits_0(self, tmp_path: Path) -> None:
+        """Dirs with no matching lib names: warn, empty libraries list, exit 0."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libbar.json", _snap())
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir))
+        assert code == 0
+        assert "no matching" in out.lower() or "warning" in out.lower()
+
 
 # ── unmatched / missing ───────────────────────────────────────────────────────
 
 class TestUnmatched:
-    def test_removed_library_no_flag(self, tmp_path):
-        """Removed library should warn but not fail by default."""
+    def test_removed_library_no_flag(self, tmp_path: Path) -> None:
+        """Removed library warns but does not fail by default."""
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
-
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(old_dir / "libbar.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
-        # libbar missing in new
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir))
-        assert code == 0  # no --fail-on-removed-library
-        # warning should be on stderr but click test merges stdout/stderr
-        # at least the summary is ok
+        assert code == 0
 
-    def test_removed_library_with_flag(self, tmp_path):
-        """--fail-on-removed-library should exit 8 when library disappears."""
+    def test_removed_library_with_flag(self, tmp_path: Path) -> None:
+        """--fail-on-removed-library exits 8 when library disappears."""
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
-
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(old_dir / "libbar.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
-
         code, _ = _invoke(
             "compare-release", str(old_dir), str(new_dir),
             "--fail-on-removed-library",
         )
         assert code == 8
 
-    def test_added_library_ok(self, tmp_path):
-        """New library in new_dir not in old_dir is fine (no flag needed)."""
+    def test_removed_and_breaking_exits_4_not_8(self, tmp_path: Path) -> None:
+        """BREAKING (4) takes priority over removed-library (8)."""
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
+        old_foo, new_foo = _breaking_pair("libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old_foo)
+        _write_snap(new_dir / "libfoo.json", new_foo)
+        _write_snap(old_dir / "libremoved.json", _snap())  # removed
+        code, _ = _invoke(
+            "compare-release", str(old_dir), str(new_dir),
+            "--fail-on-removed-library",
+        )
+        assert code == 4
 
+    def test_added_library_ok(self, tmp_path: Path) -> None:
+        """New library in new_dir not in old_dir is fine."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
-        _write_snap(new_dir / "libbar.json", _snap())  # new lib
-
+        _write_snap(new_dir / "libbar.json", _snap())
         code, out = _invoke("compare-release", str(old_dir), str(new_dir))
         assert code == 0
 
-    def test_unmatched_reported_in_json(self, tmp_path):
+    def test_unmatched_reported_in_json(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
-
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(old_dir / "libremoved.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
         _write_snap(new_dir / "libadded.json", _snap())
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
         assert code == 0
         data = json.loads(out)
+        assert isinstance(data["unmatched_old"], list)
         assert "libremoved.json" in data["unmatched_old"]
+        assert isinstance(data["unmatched_new"], list)
         assert "libadded.json" in data["unmatched_new"]
 
 
 # ── output-dir ────────────────────────────────────────────────────────────────
 
 class TestOutputDir:
-    def test_per_library_reports_written(self, tmp_path):
+    def test_per_library_reports_written(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
         out_dir = tmp_path / "reports"
-
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
-
         code, _ = _invoke(
             "compare-release", str(old_dir), str(new_dir),
             "--output-dir", str(out_dir),
@@ -227,38 +336,53 @@ class TestOutputDir:
         assert (out_dir / "libfoo.json").exists()
         assert (out_dir / "summary.json").exists()
 
-    def test_summary_json_structure(self, tmp_path):
+    def test_summary_json_structure(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
         out_dir = tmp_path / "reports"
-
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
-
-        _invoke("compare-release", str(old_dir), str(new_dir), "--output-dir", str(out_dir))
+        code, _ = _invoke("compare-release", str(old_dir), str(new_dir), "--output-dir", str(out_dir))
+        assert code == 0
         summary = json.loads((out_dir / "summary.json").read_text())
         assert summary["verdict"] == "NO_CHANGE"
         assert len(summary["libraries"]) == 1
 
 
-# ── mixed input (file vs file, different names, same stem) ───────────────────
+# ── version-aware name matching ───────────────────────────────────────────────
 
 class TestMixedInputs:
-    def test_so_versioned_name_matching(self, tmp_path):
+    def test_so_versioned_name_matching(self, tmp_path: Path) -> None:
         """libfoo.so.1.2 in old should match libfoo.so.1.3 in new via stem."""
         old_dir = tmp_path / "old"
         old_dir.mkdir()
         new_dir = tmp_path / "new"
         new_dir.mkdir()
-
         snap = _snap()
         _write_snap(old_dir / "libfoo.so.1.2.json", snap)
         _write_snap(new_dir / "libfoo.so.1.3.json", snap)
-
         code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
         assert code == 0
         data = json.loads(out)
         assert len(data["libraries"]) == 1
         assert data["verdict"] == "NO_CHANGE"
+
+    def test_version_aware_picks_1_10_over_1_9(self, tmp_path: Path) -> None:
+        """Version-aware sort must pick 1.10 as latest, not 1.9."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        # Two old candidates for same stem — 1.10 is newer
+        snap = _snap()
+        _write_snap(old_dir / "libfoo.so.1.9.json", snap)
+        _write_snap(old_dir / "libfoo.so.1.10.json", snap)
+        _write_snap(new_dir / "libfoo.so.2.0.json", snap)
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        # Only 1 comparison, and warnings should mention 1.10 as selected
+        assert len(data["libraries"]) == 1
+        assert any("1.10" in w for w in data.get("warnings", []))

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from abicheck.cli import main
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.serialization import snapshot_to_json
-
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -77,7 +75,8 @@ class TestDirVsDir:
     def test_matching_by_name_no_change(self, tmp_path):
         old_dir = tmp_path / "old"
         new_dir = tmp_path / "new"
-        old_dir.mkdir(); new_dir.mkdir()
+        old_dir.mkdir()
+        new_dir.mkdir()
 
         snap = _snap()
         _write_snap(old_dir / "libfoo.json", snap)
@@ -88,8 +87,10 @@ class TestDirVsDir:
         assert "NO_CHANGE" in out
 
     def test_matching_multi_library_all_ok(self, tmp_path):
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         for name in ("libfoo.json", "libbar.json", "libbaz.json"):
             snap = _snap()
@@ -100,8 +101,10 @@ class TestDirVsDir:
         assert code == 0
 
     def test_breaking_in_one_library(self, tmp_path):
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         # libfoo: breaking
         old_foo, new_foo = _breaking_pair("libfoo.so")
@@ -117,8 +120,10 @@ class TestDirVsDir:
         assert "BREAKING" in out
 
     def test_json_output_multi(self, tmp_path):
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         for name in ("libfoo.json", "libbar.json"):
             snap = _snap()
@@ -137,8 +142,10 @@ class TestDirVsDir:
 class TestUnmatched:
     def test_removed_library_no_flag(self, tmp_path):
         """Removed library should warn but not fail by default."""
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(old_dir / "libbar.json", _snap())
@@ -152,8 +159,10 @@ class TestUnmatched:
 
     def test_removed_library_with_flag(self, tmp_path):
         """--fail-on-removed-library should exit 8 when library disappears."""
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(old_dir / "libbar.json", _snap())
@@ -167,8 +176,10 @@ class TestUnmatched:
 
     def test_added_library_ok(self, tmp_path):
         """New library in new_dir not in old_dir is fine (no flag needed)."""
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(new_dir / "libfoo.json", _snap())
@@ -178,8 +189,10 @@ class TestUnmatched:
         assert code == 0
 
     def test_unmatched_reported_in_json(self, tmp_path):
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         _write_snap(old_dir / "libfoo.json", _snap())
         _write_snap(old_dir / "libremoved.json", _snap())
@@ -197,8 +210,10 @@ class TestUnmatched:
 
 class TestOutputDir:
     def test_per_library_reports_written(self, tmp_path):
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
         out_dir = tmp_path / "reports"
 
         _write_snap(old_dir / "libfoo.json", _snap())
@@ -213,8 +228,10 @@ class TestOutputDir:
         assert (out_dir / "summary.json").exists()
 
     def test_summary_json_structure(self, tmp_path):
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
         out_dir = tmp_path / "reports"
 
         _write_snap(old_dir / "libfoo.json", _snap())
@@ -231,8 +248,10 @@ class TestOutputDir:
 class TestMixedInputs:
     def test_so_versioned_name_matching(self, tmp_path):
         """libfoo.so.1.2 in old should match libfoo.so.1.3 in new via stem."""
-        old_dir = tmp_path / "old"; old_dir.mkdir()
-        new_dir = tmp_path / "new"; new_dir.mkdir()
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
 
         snap = _snap()
         _write_snap(old_dir / "libfoo.so.1.2.json", snap)


### PR DESCRIPTION
Adds ADR-002 with concrete UX/API proposal for multi-binary release compare (directory-vs-directory), matching rules, output contract, CI/GitHub Action impact, and implementation plan.\n\nThis restores the multi-binary direction as a clean standalone PR after branch cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR 002 describing UX, matching rules, output formats, exit-code semantics, and architecture for multi-binary release comparison; updated ADR index.
* **New Features**
  * Added a compare-release command to compare single or multi-binary releases, auto-match libraries, report additions/removals, and produce per-library and summary JSON or human-readable outputs.
* **Tests**
  * Added comprehensive tests for file-vs-file and directory-vs-directory comparisons, matching behavior, reporting, and exit-code outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->