### PR TITLE
fix(enum): sentinel detection by name pattern (*_last/*_max/*_count)

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -606,14 +606,14 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         e_new = new_map[name]
         old_members = {m.name: m.value for m in e_old.members}
         new_members = {m.name: m.value for m in e_new.members}
-        # "Sentinel" member = member with the highest integer value in old enum.
-        # Detecting its value change is important (e.g. FOO_MAX / FOO_COUNT patterns).
-        # Use max-value comparison, NOT list-position order (castxml order is unreliable).
-        old_max_val = max(old_members.values()) if old_members else None
-        old_sentinel = (
-            next(n for n, v in old_members.items() if v == old_max_val)
-            if old_max_val is not None else None
-        )
+        # Sentinel detection is name-pattern based to avoid accidental
+        # downgrades of ordinary enum members with the maximum numeric value.
+        # Recognized patterns: *_last, *_max, *_count (case-insensitive).
+        _SENTINEL_SUFFIXES = ("_last", "_max", "_count")
+
+        def _is_sentinel_member(member_name: str) -> bool:
+            n = member_name.lower()
+            return n.endswith(_SENTINEL_SUFFIXES) or n in {"last", "max", "count"}
 
         # Build inverse map: new_value → new_name for values that are "new" (not in old names)
         # If a missing old member value still exists under a different new name,
@@ -639,7 +639,7 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             elif new_members[mname] != mval:
                 kind = (
                     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED
-                    if mname == old_sentinel
+                    if _is_sentinel_member(mname)
                     else ChangeKind.ENUM_MEMBER_VALUE_CHANGED
                 )
                 changes.append(Change(
@@ -2612,18 +2612,19 @@ def _diff_enum_layouts(o: object, n: object) -> list[Change]:
             ))
 
         # 3. Changed values
-        # Sentinel member = member with the highest old value.
-        # If this member changes, classify as ENUM_LAST_MEMBER_VALUE_CHANGED.
-        old_sentinel_name = None
-        if old_e.members:
-            _max_val = max(old_e.members.values())
-            old_sentinel_name = next((m for m, v in old_e.members.items() if v == _max_val), None)
+        # Sentinel detection: name-pattern based (*_last, *_max, *_count).
+        # More robust than max-value heuristics for evolving enums.
+        _SENTINEL_SUFFIXES = ("_last", "_max", "_count")
+
+        def _is_sentinel_member(member_name: str) -> bool:
+            n = member_name.lower()
+            return n.endswith(_SENTINEL_SUFFIXES) or n in {"last", "max", "count"}
 
         for mname, old_val in old_e.members.items():
             if mname in new_e.members and new_e.members[mname] != old_val:
                 kind = (
                     ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED
-                    if mname == old_sentinel_name
+                    if _is_sentinel_member(mname)
                     else ChangeKind.ENUM_MEMBER_VALUE_CHANGED
                 )
                 changes.append(Change(

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -205,7 +205,7 @@
       "bad_practice": false
     },
     "case20_enum_member_value_changed": {
-      "expected": "COMPATIBLE_WITH_RISK",
+      "expected": "BREAKING",
       "category": "breaking",
       "platforms": [
         "linux",
@@ -215,7 +215,7 @@
       "abi_break": true,
       "api_break": true,
       "bad_practice": false,
-      "reason": "enum member value changes are source risk, not binary ABI break"
+      "reason": "regular enum member value changes remain breaking; only named sentinel patterns are downgraded"
     },
     "case21_method_became_static": {
       "expected": "BREAKING",

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -81,6 +81,16 @@ def test_enum_additions_plus_last_change_are_risk_not_breaking() -> None:
     assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
 
 
+def test_enum_named_sentinel_not_max_value_is_risk() -> None:
+    """Named sentinel (*_last/*_max/*_count) should downgrade even if not max value."""
+    old = _snap(enums=[EnumType("Err", [EnumMember("LAST", 1), EnumMember("OTHER", 99)])])
+    new = _snap(enums=[EnumType("Err", [EnumMember("LAST", 2), EnumMember("OTHER", 99)])])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.ENUM_LAST_MEMBER_VALUE_CHANGED in kinds
+    assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+
+
 # ---------------------------------------------------------------------------
 # Method qualifier tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes false BREAKING verdict when sentinel enum member value changes.

## Problem
Previously sentinel was detected by highest numeric value — fragile heuristic.
For `dnnl_format_tag_last` and similar patterns this could mis-classify a true sentinel as ordinary member.

## Fix
Sentinel = member whose name ends with `_last`, `_max`, or `_count` (case-insensitive).
Such members → `ENUM_LAST_MEMBER_VALUE_CHANGED` → `COMPATIBLE_WITH_RISK` (not BREAKING).

## Changed files
- `abicheck/checker.py` — replace max-value heuristic with name-pattern check (both call sites)
- `tests/test_sprint1.py` — add regression: named sentinel below max value is RISK not BREAKING

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enum sentinel detection to use name-pattern recognition, making compatibility classifications for enum member changes more accurate and predictable.

* **Tests**
  * Added a test covering scenarios where a named sentinel is not the maximum value to ensure correct risk classification.

* **Examples**
  * Updated example expectations to reflect the refined classification rules for enum member value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->