### PR TITLE
Optimize CMake configuration in integration tests with session-scoped build dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
   integration-tests:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -105,7 +106,7 @@ jobs:
         run: pip install -e ".[dev]"
       - name: Run integration tests with coverage
         run: |
-          pytest tests/ -v -m integration --tb=short --cov=abicheck --cov-report=xml:coverage-integration.xml
+          pytest tests/ -v -m integration --tb=short --cov=abicheck --cov-report=xml:coverage-integration.xml --ignore=tests/test_abi_examples.py
       - name: Upload integration coverage to Codecov
         if: always() && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """conftest.py — pytest configuration for abicheck tests."""
-import subprocess
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """conftest.py — pytest configuration for abicheck tests."""
+import subprocess
 import shutil
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -74,3 +76,31 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
 def update_goldens(request: pytest.FixtureRequest) -> bool:
     """True when --update-goldens flag is passed."""
     return bool(request.config.getoption("--update-goldens"))
+
+
+@pytest.fixture(scope="session")
+def shared_cmake_build_dir(tmp_path_factory: pytest.TempPathFactory) -> Path | None:
+    """Session-scoped CMake build directory for integration tests.
+
+    Configures the examples/ CMakeLists.txt **once** per session so that
+    individual tests only need to run ``cmake --build`` for their specific
+    targets.  On Windows this avoids ~30 redundant cmake-configure passes
+    (each one re-parses all 63 example CMakeLists).
+    """
+    examples_dir = Path(__file__).parent.parent / "examples"
+    cmake_lists = examples_dir / "CMakeLists.txt"
+    cmake = shutil.which("cmake")
+
+    if not cmake or not cmake_lists.exists():
+        return None
+
+    build_dir = tmp_path_factory.mktemp("cmake_build")
+    r = subprocess.run(
+        [cmake, "-S", str(examples_dir), "-B", str(build_dir),
+         "-DCMAKE_BUILD_TYPE=Debug"],
+        capture_output=True, text=True, timeout=120,
+    )
+    if r.returncode != 0:
+        return None
+
+    return build_dir

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -1,8 +1,9 @@
 """Integration tests for ABI check examples (legacy — cases 01-18).
 
 Superseded by test_example_autodiscovery.py which auto-discovers all cases.
-Kept for backward compatibility. Uses CMake when available, falls back to
-direct compilation.
+Kept for backward compatibility on Linux.  Skipped in CI integration runs
+to avoid duplicate cmake-configure overhead (especially costly on Windows
+where each configure adds ~30 s).
 """
 from __future__ import annotations
 

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -222,8 +222,19 @@ def _compile_shared(src: Path, out: Path) -> None:
         )
 
 
-def _build_with_cmake(case_dir: Path, build_dir: Path) -> tuple[Path, Path]:
-    """Build a case using CMake. Returns (v1_lib, v2_lib) paths."""
+def _build_with_cmake(
+    case_dir: Path,
+    build_dir: Path,
+    *,
+    already_configured: bool = False,
+) -> tuple[Path, Path]:
+    """Build a case using CMake. Returns (v1_lib, v2_lib) paths.
+
+    When *already_configured* is True the expensive ``cmake -S … -B …``
+    configure step is skipped — the caller guarantees that the build tree
+    has already been configured (e.g. via the session-scoped
+    ``shared_cmake_build_dir`` fixture).
+    """
     cmake = shutil.which("cmake")
     if not cmake:
         pytest.skip("cmake not found in PATH")
@@ -231,14 +242,15 @@ def _build_with_cmake(case_dir: Path, build_dir: Path) -> tuple[Path, Path]:
     case_name = case_dir.name
     case_out = build_dir / case_name
 
-    # Configure
-    r = subprocess.run(
-        [cmake, "-S", str(case_dir.parent), "-B", str(build_dir),
-         "-DCMAKE_BUILD_TYPE=Debug"],
-        capture_output=True, text=True, timeout=60,
-    )
-    if r.returncode != 0:
-        pytest.fail(f"cmake configure failed for {case_name}:\n{r.stderr[:600]}")
+    # Configure — only when no pre-configured build tree is provided
+    if not already_configured:
+        r = subprocess.run(
+            [cmake, "-S", str(case_dir.parent), "-B", str(build_dir),
+             "-DCMAKE_BUILD_TYPE=Debug"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if r.returncode != 0:
+            pytest.fail(f"cmake configure failed for {case_name}:\n{r.stderr[:600]}")
 
     # Build only this case's targets (--config for multi-config generators)
     v1_target = f"{case_name}_v1"
@@ -311,7 +323,12 @@ _ALL_CASES = _collect_cases()
     [(c, e) for c, e in _ALL_CASES if e is not None],
     ids=[c for c, e in _ALL_CASES if e is not None],
 )
-def test_example_pipeline(case_name: str, expected_verdict: str, tmp_path: Path) -> None:
+def test_example_pipeline(
+    case_name: str,
+    expected_verdict: str,
+    tmp_path: Path,
+    shared_cmake_build_dir: Path | None,
+) -> None:
     """Compile → dump → compare for every example case."""
     # --- Platform filter ---
     case_platforms = PLATFORMS.get(case_name, ["linux", "macos", "windows"])
@@ -330,15 +347,23 @@ def test_example_pipeline(case_name: str, expected_verdict: str, tmp_path: Path)
     v1_src, v2_src, v1_hdr, v2_hdr = _find_sources(case_dir)
 
     # Build strategy:
-    # 1. CMake (if CMakeLists.txt exists) — cross-platform, handles special flags
-    # 2. Direct compilation fallback — simple cases without special flags
+    # 1. Shared (session-scoped) CMake build dir — configure once, build per-test
+    # 2. Per-test CMake configure fallback
+    # 3. Direct compilation fallback — simple cases without special flags
     has_cmake_file = (case_dir / "CMakeLists.txt").exists()
     has_cmake = bool(shutil.which("cmake"))
 
-    if has_cmake_file and has_cmake:
+    if has_cmake_file and has_cmake and shared_cmake_build_dir is not None:
+        # Fast path: reuse session-wide cmake configure
+        v1_lib, v2_lib = _build_with_cmake(
+            case_dir, shared_cmake_build_dir, already_configured=True,
+        )
+        headers_v1 = [v1_hdr] if v1_hdr and v1_hdr.exists() else []
+        headers_v2 = [v2_hdr] if v2_hdr and v2_hdr.exists() else []
+    elif has_cmake_file and has_cmake:
+        # Fallback: per-test cmake configure (shared fixture failed)
         build_dir = tmp_path / "cmake_build"
         v1_lib, v2_lib = _build_with_cmake(case_dir, build_dir)
-        # Resolve header paths — headers stay in the source tree
         headers_v1 = [v1_hdr] if v1_hdr and v1_hdr.exists() else []
         headers_v2 = [v2_hdr] if v2_hdr and v2_hdr.exists() else []
     elif has_cmake_file and not has_cmake:


### PR DESCRIPTION
## Summary

Optimize integration tests by configuring CMake once per session instead of per-test, significantly reducing test runtime especially on Windows where cmake configure is expensive.

## Motivation

The integration tests were running `cmake -S … -B …` (configure step) for every test case, which is redundant since all cases share the same CMakeLists.txt. On Windows, each configure pass takes ~30 seconds, making the full test suite very slow. This change introduces a session-scoped fixture that configures CMake once and reuses it across all tests.

## Changes

- **conftest.py**: Added `shared_cmake_build_dir` session-scoped fixture that configures the examples CMakeLists.txt once per session. Returns `None` gracefully if cmake is unavailable or configuration fails.

- **test_example_autodiscovery.py**: 
  - Modified `_build_with_cmake()` to accept optional `already_configured` parameter, skipping the expensive configure step when a pre-configured build tree is provided
  - Updated `test_example_pipeline()` to accept the new fixture and implement a three-tier build strategy:
    1. Fast path: reuse session-wide cmake configure (when fixture available)
    2. Fallback: per-test cmake configure (if shared fixture failed)
    3. Direct compilation fallback (for simple cases)

- **test_abi_examples.py**: Updated docstring to clarify this legacy test file is skipped in CI to avoid duplicate cmake-configure overhead

- **.github/workflows/ci.yml**: 
  - Added 30-minute timeout to integration-tests job
  - Updated pytest invocation to skip `test_abi_examples.py` in CI runs, preventing redundant cmake configurations

## Checklist

- [x] Tests added / updated for new behaviour (existing tests now use optimized fixture)
- [ ] `CHANGELOG.md` updated (not applicable for internal test optimization)
- [ ] Docs updated if user-visible behaviour changed (internal change only)
- [ ] `pre-commit run --all-files` passes locally
- [ ] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_01KDiHabGpM6tsBGGc2i6qLT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized test infrastructure to reuse CMake builds across test runs, improving test execution time and reducing CI overhead, particularly on Windows.
* Updated integration test configuration and test organization for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->