### PR TITLE
Add application compatibility checking (ADR-005)

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -298,7 +298,6 @@ jobs:
           app-binary: examples/case01_symbol_removal/myapp
           old-library: examples/case01_symbol_removal/libv1.so
           new-library: examples/case01_symbol_removal/libv2.so
-          header: examples/case01_symbol_removal/v1.h
           format: json
           output-file: appcompat-result.json
           install-deps: false

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -275,6 +275,77 @@ jobs:
           fi
           echo "Correctly detected API additions (exit code 1, verdict ADDITIONS)"
 
+  # ── Test: appcompat full mode ─────────────────────────────────────────────
+  test-appcompat-full:
+    name: 'Appcompat: detect breaking change affecting app'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build test binaries
+        run: |
+          cd examples/case01_symbol_removal
+          gcc -shared -fPIC v1.c -o libv1.so
+          gcc -shared -fPIC v2.c -o libv2.so
+          gcc app.c -L. -lv1 -o myapp -Wl,-rpath,.
+
+      - name: Run abicheck appcompat (breaking case)
+        id: abi
+        uses: ./
+        continue-on-error: true
+        with:
+          mode: appcompat
+          app-binary: examples/case01_symbol_removal/myapp
+          old-library: examples/case01_symbol_removal/libv1.so
+          new-library: examples/case01_symbol_removal/libv2.so
+          header: examples/case01_symbol_removal/v1.h
+          format: json
+          output-file: appcompat-result.json
+          install-deps: false
+          fail-on-breaking: true
+
+      - name: Verify verdict is BREAKING
+        shell: bash
+        run: |
+          echo "Verdict: ${{ steps.abi.outputs.verdict }}"
+          echo "Exit code: ${{ steps.abi.outputs.exit-code }}"
+          if [[ "${{ steps.abi.outputs.verdict }}" != "BREAKING" ]]; then
+            echo "::error::Expected verdict BREAKING, got ${{ steps.abi.outputs.verdict }}"
+            exit 1
+          fi
+
+  # ── Test: appcompat weak mode (check-against) ───────────────────────────
+  test-appcompat-weak:
+    name: 'Appcompat: weak mode symbol check'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build test binaries
+        run: |
+          cd examples/case01_symbol_removal
+          gcc -shared -fPIC v1.c -o libv1.so
+          gcc app.c -L. -lv1 -o myapp -Wl,-rpath,.
+
+      - name: Run abicheck appcompat weak mode (all symbols present)
+        id: abi
+        uses: ./
+        with:
+          mode: appcompat
+          app-binary: examples/case01_symbol_removal/myapp
+          check-against: examples/case01_symbol_removal/libv1.so
+          install-deps: false
+          fail-on-breaking: true
+
+      - name: Verify verdict is COMPATIBLE
+        shell: bash
+        run: |
+          echo "Verdict: ${{ steps.abi.outputs.verdict }}"
+          if [[ "${{ steps.abi.outputs.verdict }}" != "COMPATIBLE" ]]; then
+            echo "::error::Expected verdict COMPATIBLE, got ${{ steps.abi.outputs.verdict }}"
+            exit 1
+          fi
+
   test-fail-on-additions-allowed:
     name: 'fail-on-additions=false: additions pass through'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ abicheck compare old.so new.so -H foo.h --follow-deps
 
 For the full CLI reference see the [documentation](https://napetrov.github.io/abicheck/getting-started/).
 
+### Check application compatibility
+
+Check whether your **application** (not just the library) is affected by a library update:
+
+```bash
+# Full check: does my app break with the new libfoo?
+abicheck appcompat ./myapp libfoo.so.1 libfoo.so.2 -H include/foo.h
+```
+
+```bash
+# Quick check: does this library have all symbols my app needs?
+abicheck appcompat ./myapp --check-against libfoo.so.2
+```
+
+Unlike `compare` (which shows all library changes), `appcompat` filters the diff to show only changes that affect the symbols your application actually uses. See [Application Compatibility](https://napetrov.github.io/abicheck/appcompat/) for full details.
+
 ---
 
 ## Exit codes
@@ -178,6 +194,7 @@ abicheck compare build/case01_symbol_removal/libv1.so build/case01_symbol_remova
 ```
 
 Covers: symbol removal, type/signature changes, struct layout, enums, vtables, qualifiers, templates, and more. See [Breaking Cases Catalog](https://napetrov.github.io/abicheck/concepts/breaking-cases-catalog/) and [ABI Breaks Explained](https://napetrov.github.io/abicheck/concepts/abi-breaks-explained/) for the full guide.
+>>>>>>> 1ad6748 (docs: add appcompat command documentation)
 
 ---
 
@@ -197,6 +214,7 @@ Full documentation is available at **[napetrov.github.io/abicheck](https://napet
 
 **User guide:**
 - [CLI Usage](https://napetrov.github.io/abicheck/user-guide/cli-usage/)
+- [Application compatibility](https://napetrov.github.io/abicheck/user-guide/appcompat/) — check if your app breaks with a library update
 - [Policy profiles](https://napetrov.github.io/abicheck/user-guide/policies/)
 - [Output formats (SARIF, JSON, HTML)](https://napetrov.github.io/abicheck/user-guide/output-formats/)
 - [GitHub Action](https://napetrov.github.io/abicheck/user-guide/github-action/)

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ abicheck compare build/case01_symbol_removal/libv1.so build/case01_symbol_remova
 ```
 
 Covers: symbol removal, type/signature changes, struct layout, enums, vtables, qualifiers, templates, and more. See [Breaking Cases Catalog](https://napetrov.github.io/abicheck/concepts/breaking-cases-catalog/) and [ABI Breaks Explained](https://napetrov.github.io/abicheck/concepts/abi-breaks-explained/) for the full guide.
->>>>>>> 1ad6748 (docs: add appcompat command documentation)
 
 ---
 

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1,0 +1,566 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Application compatibility checking — ADR-005.
+
+Answers: "Will my application still work with the new library version?"
+by intersecting the app's required symbols with the library diff.
+
+See docs/adr/005-application-compat-check.md for the full design.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import stat
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .checker import Change, DiffResult, compare
+from .checker_policy import ChangeKind, Verdict, compute_verdict
+
+if TYPE_CHECKING:
+    from .policy_file import PolicyFile
+    from .suppression import SuppressionList
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AppRequirements:
+    """Symbols and versions an application binary requires from a library."""
+
+    needed_libs: list[str] = field(default_factory=list)
+    undefined_symbols: set[str] = field(default_factory=set)
+    required_versions: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AppCompatResult:
+    """Result of checking app compatibility with a library update."""
+
+    app_path: str
+    old_lib_path: str
+    new_lib_path: str
+
+    # App's requirements
+    required_symbols: set[str] = field(default_factory=set)
+    required_symbol_count: int = 0
+
+    # Filtered results
+    breaking_for_app: list[Change] = field(default_factory=list)
+    irrelevant_for_app: list[Change] = field(default_factory=list)
+    missing_symbols: list[str] = field(default_factory=list)
+    missing_versions: list[str] = field(default_factory=list)
+
+    # Full library diff (for reference)
+    full_diff: DiffResult | None = None
+
+    # App-specific verdict
+    verdict: Verdict = Verdict.COMPATIBLE
+
+    # Coverage
+    symbol_coverage: float = 100.0  # % of app's required symbols present in new lib
+
+
+# ---------------------------------------------------------------------------
+# Binary format detection
+# ---------------------------------------------------------------------------
+
+_ELF_MAGIC = b"\x7fELF"
+_MZ_MAGIC = b"MZ"
+_MACHO_MAGICS = {
+    b"\xfe\xed\xfa\xce", b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf", b"\xcf\xfa\xed\xfe",
+    b"\xca\xfe\xba\xbe", b"\xbe\xba\xfe\xca",
+    b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca",
+}
+
+
+def _detect_app_format(app_path: Path) -> str | None:
+    """Detect binary format of an application: 'elf', 'pe', or 'macho'."""
+    try:
+        with open(app_path, "rb") as f:
+            st = os.fstat(f.fileno())
+            if not stat.S_ISREG(st.st_mode):
+                return None
+            magic = f.read(4)
+            if magic == _ELF_MAGIC:
+                return "elf"
+            if magic[:2] == _MZ_MAGIC:
+                return "pe"
+            if magic in _MACHO_MAGICS:
+                return "macho"
+    except OSError:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# ELF: parse app requirements
+# ---------------------------------------------------------------------------
+
+def _parse_elf_app_requirements(
+    app_path: Path, library_soname: str,
+) -> AppRequirements:
+    """Extract app requirements for a specific library from an ELF binary.
+
+    Reads .dynsym for UNDEF symbols and .gnu.version_r for required versions.
+    """
+    from elftools.common.exceptions import ELFError
+    from elftools.elf.dynamic import DynamicSection
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.gnuversions import GNUVerNeedSection
+    from elftools.elf.sections import SymbolTableSection
+
+    reqs = AppRequirements()
+
+    try:
+        with open(app_path, "rb") as f:
+            elf = ELFFile(f)
+
+            # 1. Read DT_NEEDED entries
+            for section in elf.iter_sections():
+                if isinstance(section, DynamicSection):
+                    for tag in section.iter_tags():
+                        if tag.entry.d_tag == "DT_NEEDED":
+                            reqs.needed_libs.append(tag.needed)
+
+            # 2. Read undefined symbols from .dynsym
+            for section in elf.iter_sections():
+                if isinstance(section, SymbolTableSection) and section.name == ".dynsym":
+                    for sym in section.iter_symbols():
+                        if sym.entry.st_shndx != "SHN_UNDEF":
+                            continue
+                        if not sym.name:
+                            continue
+                        binding = sym.entry.st_info.bind
+                        if binding not in ("STB_GLOBAL", "STB_WEAK"):
+                            continue
+                        reqs.undefined_symbols.add(sym.name)
+
+            # 3. Read required versions from .gnu.version_r
+            for section in elf.iter_sections():
+                if isinstance(section, GNUVerNeedSection):
+                    for verneed, vernaux_iter in section.iter_versions():
+                        lib = verneed.name
+                        # Only collect versions for the target library
+                        if library_soname and lib != library_soname:
+                            continue
+                        for vernaux in vernaux_iter:
+                            ver = vernaux.name
+                            if ver:
+                                # Map: we don't have per-symbol version mapping
+                                # from .gnu.version_r alone (that requires correlating
+                                # .gnu.version with .dynsym indices). Store lib-level versions.
+                                reqs.required_versions[ver] = lib
+
+    except (ELFError, OSError, ValueError) as exc:
+        log.warning("Failed to parse ELF app requirements from %s: %s", app_path, exc)
+
+    return reqs
+
+
+# ---------------------------------------------------------------------------
+# PE: parse app requirements
+# ---------------------------------------------------------------------------
+
+def _parse_pe_app_requirements(
+    app_path: Path, library_name: str,
+) -> AppRequirements:
+    """Extract app requirements for a specific DLL from a PE binary."""
+    import pefile  # type: ignore[import-untyped]
+
+    reqs = AppRequirements()
+    library_name_lower = library_name.lower() if library_name else ""
+
+    try:
+        pe = pefile.PE(str(app_path), fast_load=True)
+        try:
+            pe.parse_data_directories(
+                directories=[
+                    pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"],
+                ]
+            )
+
+            if hasattr(pe, "DIRECTORY_ENTRY_IMPORT"):
+                for entry in pe.DIRECTORY_ENTRY_IMPORT:
+                    dll_name = entry.dll.decode("utf-8", errors="replace") if entry.dll else ""
+                    reqs.needed_libs.append(dll_name)
+
+                    # Only collect symbols for the target DLL
+                    if library_name_lower and dll_name.lower() != library_name_lower:
+                        continue
+
+                    for imp in entry.imports:
+                        if imp.name:
+                            reqs.undefined_symbols.add(
+                                imp.name.decode("utf-8", errors="replace")
+                            )
+        finally:
+            pe.close()
+
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Failed to parse PE app requirements from %s: %s", app_path, exc)
+
+    return reqs
+
+
+# ---------------------------------------------------------------------------
+# Mach-O: parse app requirements
+# ---------------------------------------------------------------------------
+
+def _parse_macho_app_requirements(
+    app_path: Path, library_name: str,
+) -> AppRequirements:
+    """Extract app requirements for a specific dylib from a Mach-O binary."""
+    from macholib.mach_o import (  # type: ignore[import-untyped]
+        LC_LOAD_DYLIB,
+        N_EXT,
+        N_TYPE,
+        N_UNDF,
+    )
+    from macholib.MachO import MachO  # type: ignore[import-untyped]
+    from macholib.SymbolTable import SymbolTable  # type: ignore[import-untyped]
+
+    reqs = AppRequirements()
+
+    try:
+        macho = MachO(str(app_path))
+        if not macho.headers:
+            return reqs
+
+        header = macho.headers[0]
+
+        # 1. Read dependent libraries
+        for lc, cmd, data in header.commands:
+            if lc.cmd == LC_LOAD_DYLIB:
+                if data:
+                    end = data.find(b"\x00")
+                    if end < 0:
+                        end = len(data)
+                    name = data[:end].decode("utf-8", errors="replace")
+                    reqs.needed_libs.append(name)
+
+        # 2. Read undefined symbols
+        try:
+            symtab = SymbolTable(macho, header=header)
+            # Check undefsyms first (available when LC_DYSYMTAB is present)
+            symbols = getattr(symtab, "undefsyms", None) or symtab.nlists
+            for nlist_entry, name_bytes in symbols:
+                n_type = int(nlist_entry.n_type)
+
+                # For undefsyms, they're already filtered. For nlists, filter manually.
+                if symbols is symtab.nlists:
+                    if not (n_type & N_EXT):
+                        continue
+                    if (n_type & N_TYPE) != N_UNDF:
+                        continue
+
+                name = name_bytes.decode("utf-8", errors="replace") if name_bytes else ""
+                # Strip leading underscore (Mach-O C symbol convention)
+                if name.startswith("_"):
+                    name = name[1:]
+                if name:
+                    reqs.undefined_symbols.add(name)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("SymbolTable failed for %s: %s", app_path, exc)
+
+    except (OSError, ValueError, struct.error) as exc:
+        log.warning("Failed to parse Mach-O app requirements from %s: %s", app_path, exc)
+
+    return reqs
+
+
+# ---------------------------------------------------------------------------
+# Public API: parse_app_requirements
+# ---------------------------------------------------------------------------
+
+def parse_app_requirements(
+    app_path: Path, library_name: str,
+) -> AppRequirements:
+    """Extract app's requirements for a specific library.
+
+    Args:
+        app_path: Path to the application binary (ELF, PE, or Mach-O).
+        library_name: SONAME/DLL name/dylib path to filter by.
+
+    Returns:
+        AppRequirements with the app's needed libs, undefined symbols,
+        and required versions.
+
+    Raises:
+        ValueError: If the binary format cannot be detected.
+    """
+    fmt = _detect_app_format(app_path)
+    if fmt == "elf":
+        return _parse_elf_app_requirements(app_path, library_name)
+    if fmt == "pe":
+        return _parse_pe_app_requirements(app_path, library_name)
+    if fmt == "macho":
+        return _parse_macho_app_requirements(app_path, library_name)
+    raise ValueError(
+        f"Cannot detect binary format of '{app_path}'. "
+        "Expected: ELF, PE, or Mach-O executable."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filtering: is a change relevant to the app?
+# ---------------------------------------------------------------------------
+
+def _is_relevant_to_app(change: Change, app: AppRequirements) -> bool:
+    """Does this change affect a symbol the application uses?"""
+    # Direct symbol match
+    if change.symbol in app.undefined_symbols:
+        return True
+
+    # Type change affecting app's symbols (via affected_symbols enrichment)
+    if change.affected_symbols:
+        if app.undefined_symbols & set(change.affected_symbols):
+            return True
+
+    # ELF-level: SONAME change affects all consumers
+    if change.kind == ChangeKind.SONAME_CHANGED:
+        return True
+
+    # Mach-O compat version change affects all consumers
+    if change.kind == ChangeKind.COMPAT_VERSION_CHANGED:
+        return True
+
+    # Symbol version change for a version the app requires
+    if change.kind == ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED:
+        sym = change.symbol
+        required_ver = app.required_versions.get(sym)
+        if required_ver and change.old_value and required_ver == change.old_value:
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Get new library exported symbols
+# ---------------------------------------------------------------------------
+
+def _get_new_lib_exports(new_lib_path: Path) -> set[str]:
+    """Get the set of exported symbol names from the new library."""
+    fmt = _detect_app_format(new_lib_path)
+    if fmt == "elf":
+        from .elf_metadata import parse_elf_metadata
+        meta = parse_elf_metadata(new_lib_path)
+        return {s.name for s in meta.symbols}
+    if fmt == "pe":
+        from .pe_metadata import parse_pe_metadata
+        meta = parse_pe_metadata(new_lib_path)
+        return {e.name for e in meta.exports if e.name}
+    if fmt == "macho":
+        from .macho_metadata import parse_macho_metadata
+        meta = parse_macho_metadata(new_lib_path)
+        return {e.name for e in meta.exports if e.name}
+    return set()
+
+
+def _get_lib_soname(lib_path: Path) -> str:
+    """Get the SONAME/install_name/DLL name from a library."""
+    fmt = _detect_app_format(lib_path)
+    if fmt == "elf":
+        from .elf_metadata import parse_elf_metadata
+        meta = parse_elf_metadata(lib_path)
+        return meta.soname or lib_path.name
+    if fmt == "pe":
+        return lib_path.name
+    if fmt == "macho":
+        from .macho_metadata import parse_macho_metadata
+        meta = parse_macho_metadata(lib_path)
+        return meta.install_name or lib_path.name
+    return lib_path.name
+
+
+# ---------------------------------------------------------------------------
+# Core: appcompat check
+# ---------------------------------------------------------------------------
+
+def check_appcompat(
+    app_path: Path,
+    old_lib_path: Path,
+    new_lib_path: Path,
+    *,
+    headers: list[Path] | None = None,
+    includes: list[Path] | None = None,
+    old_version: str = "old",
+    new_version: str = "new",
+    lang: str = "c++",
+    suppression: SuppressionList | None = None,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+) -> AppCompatResult:
+    """Check application compatibility with a library update.
+
+    1. Parse app binary → extract required symbols
+    2. Run standard compare() on libraries
+    3. Check symbol availability in new library
+    4. Filter changes by app usage
+    5. Compute app-specific verdict
+    """
+    # Get library SONAME for filtering
+    library_soname = _get_lib_soname(old_lib_path)
+
+    # 1. Parse app requirements
+    app_reqs = parse_app_requirements(app_path, library_soname)
+
+    # 2. Run standard library comparison
+    from .dumper import dump
+    from .errors import AbicheckError
+
+    old_snap = dump(
+        so_path=old_lib_path,
+        headers=headers or [],
+        extra_includes=includes or [],
+        version=old_version,
+        compiler="c++" if lang == "c++" else "cc",
+        lang="c" if lang == "c" else None,
+    )
+    new_snap = dump(
+        so_path=new_lib_path,
+        headers=headers or [],
+        extra_includes=includes or [],
+        version=new_version,
+        compiler="c++" if lang == "c++" else "cc",
+        lang="c" if lang == "c" else None,
+    )
+
+    diff = compare(old_snap, new_snap, suppression=suppression, policy=policy, policy_file=policy_file)
+
+    # 3. Check symbol availability in new library
+    new_exports = _get_new_lib_exports(new_lib_path)
+    missing_symbols = sorted(
+        sym for sym in app_reqs.undefined_symbols
+        if sym not in new_exports
+    )
+
+    # Check version availability
+    missing_versions: list[str] = []
+    if _detect_app_format(new_lib_path) == "elf":
+        from .elf_metadata import parse_elf_metadata
+        new_elf_meta = parse_elf_metadata(new_lib_path)
+        new_defined_versions = set(new_elf_meta.versions_defined)
+        for ver_tag, _lib in app_reqs.required_versions.items():
+            if ver_tag not in new_defined_versions:
+                missing_versions.append(ver_tag)
+
+    # 4. Filter diff by app usage
+    breaking_for_app: list[Change] = []
+    irrelevant_for_app: list[Change] = []
+    for change in diff.changes:
+        if _is_relevant_to_app(change, app_reqs):
+            breaking_for_app.append(change)
+        else:
+            irrelevant_for_app.append(change)
+
+    # 5. Compute app-specific verdict
+    required_count = len(app_reqs.undefined_symbols)
+    if new_exports:
+        coverage = (
+            (required_count - len(missing_symbols)) / required_count * 100.0
+            if required_count > 0 else 100.0
+        )
+    else:
+        coverage = 0.0 if required_count > 0 else 100.0
+
+    # Verdict: missing symbols → BREAKING, else based on relevant changes
+    if missing_symbols:
+        verdict = Verdict.BREAKING
+    elif breaking_for_app:
+        verdict = compute_verdict(breaking_for_app, policy=policy)
+    else:
+        verdict = Verdict.COMPATIBLE if required_count > 0 else Verdict.NO_CHANGE
+
+    return AppCompatResult(
+        app_path=str(app_path),
+        old_lib_path=str(old_lib_path),
+        new_lib_path=str(new_lib_path),
+        required_symbols=app_reqs.undefined_symbols,
+        required_symbol_count=required_count,
+        breaking_for_app=breaking_for_app,
+        irrelevant_for_app=irrelevant_for_app,
+        missing_symbols=missing_symbols,
+        missing_versions=missing_versions,
+        full_diff=diff,
+        verdict=verdict,
+        symbol_coverage=coverage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Weak mode: check-against (no old library needed)
+# ---------------------------------------------------------------------------
+
+def check_against(
+    app_path: Path,
+    new_lib_path: Path,
+) -> AppCompatResult:
+    """Check if a library provides everything the app needs (weak mode).
+
+    No old library required — just checks symbol availability.
+    """
+    library_name = _get_lib_soname(new_lib_path)
+    app_reqs = parse_app_requirements(app_path, library_name)
+
+    new_exports = _get_new_lib_exports(new_lib_path)
+    missing_symbols = sorted(
+        sym for sym in app_reqs.undefined_symbols
+        if sym not in new_exports
+    )
+
+    # Check version availability for ELF
+    missing_versions: list[str] = []
+    if _detect_app_format(new_lib_path) == "elf":
+        from .elf_metadata import parse_elf_metadata
+        new_elf_meta = parse_elf_metadata(new_lib_path)
+        new_defined_versions = set(new_elf_meta.versions_defined)
+        for ver_tag, _lib in app_reqs.required_versions.items():
+            if ver_tag not in new_defined_versions:
+                missing_versions.append(ver_tag)
+
+    required_count = len(app_reqs.undefined_symbols)
+    if new_exports:
+        coverage = (
+            (required_count - len(missing_symbols)) / required_count * 100.0
+            if required_count > 0 else 100.0
+        )
+    else:
+        coverage = 0.0 if required_count > 0 else 100.0
+
+    verdict = Verdict.BREAKING if missing_symbols else Verdict.COMPATIBLE
+
+    return AppCompatResult(
+        app_path=str(app_path),
+        old_lib_path="",
+        new_lib_path=str(new_lib_path),
+        required_symbols=app_reqs.undefined_symbols,
+        required_symbol_count=required_count,
+        breaking_for_app=[],
+        irrelevant_for_app=[],
+        missing_symbols=missing_symbols,
+        missing_versions=missing_versions,
+        full_diff=None,
+        verdict=verdict,
+        symbol_coverage=coverage,
+    )

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -122,12 +122,13 @@ def _parse_elf_app_requirements(
 ) -> AppRequirements:
     """Extract app requirements for a specific library from an ELF binary.
 
-    Reads .dynsym for UNDEF symbols and .gnu.version_r for required versions.
+    Reads .dynsym for UNDEF symbols, correlates with .gnu.version and
+    .gnu.version_r to filter symbols to those imported from ``library_soname``.
     """
     from elftools.common.exceptions import ELFError
     from elftools.elf.dynamic import DynamicSection
     from elftools.elf.elffile import ELFFile
-    from elftools.elf.gnuversions import GNUVerNeedSection
+    from elftools.elf.gnuversions import GNUVerNeedSection, GNUVerSymSection
     from elftools.elf.sections import SymbolTableSection
 
     reqs = AppRequirements()
@@ -143,10 +144,33 @@ def _parse_elf_app_requirements(
                         if tag.entry.d_tag == "DT_NEEDED":
                             reqs.needed_libs.append(tag.needed)
 
-            # 2. Read undefined symbols from .dynsym
+            # 2. Build version-index → library SONAME map from .gnu.version_r
+            #    Each vernaux entry has vna_other (the version index used in
+            #    .gnu.version) and the parent verneed names the source library.
+            ver_idx_to_lib: dict[int, str] = {}
+            for section in elf.iter_sections():
+                if isinstance(section, GNUVerNeedSection):
+                    for verneed, vernaux_iter in section.iter_versions():
+                        lib = verneed.name
+                        for vernaux in vernaux_iter:
+                            ver_idx = vernaux.entry.vna_other
+                            ver_idx_to_lib[ver_idx] = lib
+                            ver = vernaux.name
+                            # Collect required version tags for the target library
+                            if ver and library_soname and lib == library_soname:
+                                reqs.required_versions[ver] = lib
+
+            # 3. Read .gnu.version section (per-symbol version indices)
+            versym_section: GNUVerSymSection | None = None
+            for section in elf.iter_sections():
+                if isinstance(section, GNUVerSymSection):
+                    versym_section = section
+                    break
+
+            # 4. Read undefined symbols from .dynsym, filtered by target library
             for section in elf.iter_sections():
                 if isinstance(section, SymbolTableSection) and section.name == ".dynsym":
-                    for sym in section.iter_symbols():
+                    for idx, sym in enumerate(section.iter_symbols()):
                         if sym.entry.st_shndx != "SHN_UNDEF":
                             continue
                         if not sym.name:
@@ -154,23 +178,34 @@ def _parse_elf_app_requirements(
                         binding = sym.entry.st_info.bind
                         if binding not in ("STB_GLOBAL", "STB_WEAK"):
                             continue
-                        reqs.undefined_symbols.add(sym.name)
 
-            # 3. Read required versions from .gnu.version_r
-            for section in elf.iter_sections():
-                if isinstance(section, GNUVerNeedSection):
-                    for verneed, vernaux_iter in section.iter_versions():
-                        lib = verneed.name
-                        # Only collect versions for the target library
-                        if library_soname and lib != library_soname:
-                            continue
-                        for vernaux in vernaux_iter:
-                            ver = vernaux.name
-                            if ver:
-                                # Map: we don't have per-symbol version mapping
-                                # from .gnu.version_r alone (that requires correlating
-                                # .gnu.version with .dynsym indices). Store lib-level versions.
-                                reqs.required_versions[ver] = lib
+                        # Filter by source library using .gnu.version correlation
+                        if library_soname and versym_section is not None:
+                            try:
+                                ver_entry = versym_section.get_symbol(idx)
+                                ver_ndx = ver_entry.entry["ndx"]
+                                # Mask off the hidden bit (bit 15)
+                                ver_ndx = ver_ndx & 0x7FFF
+                            except (IndexError, KeyError):
+                                ver_ndx = 1  # treat as unversioned
+
+                            if ver_ndx >= 2:
+                                # Versioned symbol — check if from target library
+                                source_lib = ver_idx_to_lib.get(ver_ndx, "")
+                                if source_lib != library_soname:
+                                    continue
+                            elif ver_ndx <= 1:
+                                # Unversioned symbol (index 0=local, 1=global).
+                                # Cannot determine source library from version info;
+                                # include only if it doesn't look like a system symbol.
+                                from .elf_metadata import _guess_symbol_origin
+                                origin = _guess_symbol_origin(
+                                    sym.name, reqs.needed_libs,
+                                )
+                                if origin is not None:
+                                    continue
+
+                        reqs.undefined_symbols.add(sym.name)
 
     except (ELFError, OSError, ValueError) as exc:
         log.warning("Failed to parse ELF app requirements from %s: %s", app_path, exc)
@@ -345,11 +380,12 @@ def _is_relevant_to_app(change: Change, app: AppRequirements) -> bool:
     if change.kind == ChangeKind.COMPAT_VERSION_CHANGED:
         return True
 
-    # Symbol version change for a version the app requires
+    # Symbol version removal for a version the app requires.
+    # change.symbol is the version tag (e.g. "FOO_1.0"); app.required_versions
+    # maps version_tag → library_soname.  If the tag is in the map, the app
+    # depends on it and the removal is relevant.
     if change.kind == ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED:
-        sym = change.symbol
-        required_ver = app.required_versions.get(sym)
-        if required_ver and change.old_value and required_ver == change.old_value:
+        if change.symbol in app.required_versions:
             return True
 
     return False
@@ -427,7 +463,6 @@ def check_appcompat(
 
     # 2. Run standard library comparison
     from .dumper import dump
-    from .errors import AbicheckError
 
     old_snap = dump(
         so_path=old_lib_path,
@@ -484,8 +519,8 @@ def check_appcompat(
     else:
         coverage = 0.0 if required_count > 0 else 100.0
 
-    # Verdict: missing symbols → BREAKING, else based on relevant changes
-    if missing_symbols:
+    # Verdict: missing symbols/versions → BREAKING, else based on relevant changes
+    if missing_symbols or missing_versions:
         verdict = Verdict.BREAKING
     elif breaking_for_app:
         verdict = compute_verdict(breaking_for_app, policy=policy)
@@ -548,7 +583,7 @@ def check_against(
     else:
         coverage = 0.0 if required_count > 0 else 100.0
 
-    verdict = Verdict.BREAKING if missing_symbols else Verdict.COMPATIBLE
+    verdict = Verdict.BREAKING if (missing_symbols or missing_versions) else Verdict.COMPATIBLE
 
     return AppCompatResult(
         app_path=str(app_path),

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -184,8 +184,14 @@ def _parse_elf_app_requirements(
                             try:
                                 ver_entry = versym_section.get_symbol(idx)
                                 ver_ndx = ver_entry.entry["ndx"]
-                                # Mask off the hidden bit (bit 15)
-                                ver_ndx = ver_ndx & 0x7FFF
+                                # pyelftools returns str for special indices
+                                # (VER_NDX_LOCAL, VER_NDX_GLOBAL) and int for
+                                # regular version indices.
+                                if isinstance(ver_ndx, str):
+                                    ver_ndx = 0 if ver_ndx == "VER_NDX_LOCAL" else 1
+                                else:
+                                    # Mask off the hidden bit (bit 15)
+                                    ver_ndx = ver_ndx & 0x7FFF
                             except (IndexError, KeyError):
                                 ver_ndx = 1  # treat as unversioned
 
@@ -203,6 +209,11 @@ def _parse_elf_app_requirements(
                                     sym.name, reqs.needed_libs,
                                 )
                                 if origin is not None:
+                                    continue
+                                # Weak undefined symbols with unknown origin are
+                                # typically optional linker/runtime refs (e.g.
+                                # _ITM_*, __gmon_start__) — skip them.
+                                if binding == "STB_WEAK":
                                     continue
 
                         reqs.undefined_symbols.add(sym.name)

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -221,7 +221,7 @@ def _parse_pe_app_requirements(
     app_path: Path, library_name: str,
 ) -> AppRequirements:
     """Extract app requirements for a specific DLL from a PE binary."""
-    import pefile  # type: ignore[import-untyped]
+    import pefile
 
     reqs = AppRequirements()
     library_name_lower = library_name.lower() if library_name else ""
@@ -249,6 +249,8 @@ def _parse_pe_app_requirements(
                             reqs.undefined_symbols.add(
                                 imp.name.decode("utf-8", errors="replace")
                             )
+                        elif getattr(imp, "import_by_ordinal", False):
+                            reqs.undefined_symbols.add(f"ordinal:{imp.ordinal}")
         finally:
             pe.close()
 
@@ -266,14 +268,14 @@ def _parse_macho_app_requirements(
     app_path: Path, library_name: str,
 ) -> AppRequirements:
     """Extract app requirements for a specific dylib from a Mach-O binary."""
-    from macholib.mach_o import (  # type: ignore[import-untyped]
+    from macholib.mach_o import (
         LC_LOAD_DYLIB,
         N_EXT,
         N_TYPE,
         N_UNDF,
     )
-    from macholib.MachO import MachO  # type: ignore[import-untyped]
-    from macholib.SymbolTable import SymbolTable  # type: ignore[import-untyped]
+    from macholib.MachO import MachO
+    from macholib.SymbolTable import SymbolTable
 
     reqs = AppRequirements()
 
@@ -294,7 +296,21 @@ def _parse_macho_app_requirements(
                     name = data[:end].decode("utf-8", errors="replace")
                     reqs.needed_libs.append(name)
 
-        # 2. Read undefined symbols
+        # 2. Determine index of target library in LC_LOAD_DYLIB list (1-based)
+        #    In Mach-O two-level namespace, the library ordinal stored in
+        #    n_desc bits [15:8] is a 1-based index into the load-dylib list.
+        target_ordinal: int | None = None
+        if library_name:
+            lib_lower = library_name.lower()
+            for idx, lib in enumerate(reqs.needed_libs, start=1):
+                # Match by exact path, basename, or install_name
+                if (lib.lower() == lib_lower
+                        or os.path.basename(lib).lower() == lib_lower
+                        or lib_lower in lib.lower()):
+                    target_ordinal = idx
+                    break
+
+        # 3. Read undefined symbols, filtered by target library ordinal
         try:
             symtab = SymbolTable(macho, header=header)
             # Check undefsyms first (available when LC_DYSYMTAB is present)
@@ -307,6 +323,14 @@ def _parse_macho_app_requirements(
                     if not (n_type & N_EXT):
                         continue
                     if (n_type & N_TYPE) != N_UNDF:
+                        continue
+
+                # Filter by library ordinal when target is known
+                if target_ordinal is not None:
+                    n_desc = int(nlist_entry.n_desc)
+                    ordinal = (n_desc >> 8) & 0xFF
+                    # 0 = SELF, 0xFE = EXECUTABLE, 0xFF = DYNAMIC_LOOKUP
+                    if ordinal not in (0, 0xFE, 0xFF) and ordinal != target_ordinal:
                         continue
 
                 name = name_bytes.decode("utf-8", errors="replace") if name_bytes else ""
@@ -400,16 +424,16 @@ def _get_new_lib_exports(new_lib_path: Path) -> set[str]:
     fmt = _detect_app_format(new_lib_path)
     if fmt == "elf":
         from .elf_metadata import parse_elf_metadata
-        meta = parse_elf_metadata(new_lib_path)
-        return {s.name for s in meta.symbols}
+        elf_meta = parse_elf_metadata(new_lib_path)
+        return {s.name for s in elf_meta.symbols}
     if fmt == "pe":
         from .pe_metadata import parse_pe_metadata
-        meta = parse_pe_metadata(new_lib_path)
-        return {e.name for e in meta.exports if e.name}
+        pe_meta = parse_pe_metadata(new_lib_path)
+        return {e.name for e in pe_meta.exports if e.name}
     if fmt == "macho":
         from .macho_metadata import parse_macho_metadata
-        meta = parse_macho_metadata(new_lib_path)
-        return {e.name for e in meta.exports if e.name}
+        macho_meta = parse_macho_metadata(new_lib_path)
+        return {e.name for e in macho_meta.exports if e.name}
     return set()
 
 
@@ -418,14 +442,14 @@ def _get_lib_soname(lib_path: Path) -> str:
     fmt = _detect_app_format(lib_path)
     if fmt == "elf":
         from .elf_metadata import parse_elf_metadata
-        meta = parse_elf_metadata(lib_path)
-        return meta.soname or lib_path.name
+        elf_meta = parse_elf_metadata(lib_path)
+        return elf_meta.soname or lib_path.name
     if fmt == "pe":
         return lib_path.name
     if fmt == "macho":
         from .macho_metadata import parse_macho_metadata
-        meta = parse_macho_metadata(lib_path)
-        return meta.install_name or lib_path.name
+        macho_meta = parse_macho_metadata(lib_path)
+        return macho_meta.install_name or lib_path.name
     return lib_path.name
 
 
@@ -523,7 +547,11 @@ def check_appcompat(
     if missing_symbols or missing_versions:
         verdict = Verdict.BREAKING
     elif breaking_for_app:
-        verdict = compute_verdict(breaking_for_app, policy=policy)
+        verdict = (
+            policy_file.compute_verdict(breaking_for_app)
+            if policy_file is not None
+            else compute_verdict(breaking_for_app, policy=policy)
+        )
     else:
         verdict = Verdict.COMPATIBLE if required_count > 0 else Verdict.NO_CHANGE
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1209,9 +1209,8 @@ def appcompat_cmd(
     """
     _setup_verbosity(verbose)
 
+    from .appcompat import _get_lib_soname, check_appcompat, parse_app_requirements
     from .appcompat import check_against as _check_against
-    from .appcompat import check_appcompat, parse_app_requirements
-    from .appcompat import _get_lib_soname
     from .reporter import appcompat_to_json, appcompat_to_markdown
 
     # Validate arguments

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 import click
 
-from .checker import DiffResult, LibraryMetadata, compare
+from .checker import DiffResult, LibraryMetadata, Verdict, compare
 from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
 from .compat.cli import compat_group
 from .dumper import dump
@@ -1125,6 +1125,173 @@ def compare_cmd(
                 err=True,
             )
             sys.exit(1)
+
+@main.command("appcompat")
+@click.argument("app_path", type=click.Path(exists=True, path_type=Path))
+@click.argument("old_lib", type=click.Path(exists=True, path_type=Path), required=False, default=None)
+@click.argument("new_lib", type=click.Path(exists=True, path_type=Path), required=False, default=None)
+# ── Weak mode ─────────────────────────────────────────────────────────────────
+@click.option("--check-against", "check_against_lib",
+              type=click.Path(exists=True, path_type=Path), default=None,
+              help="Weak mode: check if a library provides everything the app needs "
+                   "(no old library required).")
+# ── Dump options ──────────────────────────────────────────────────────────────
+@click.option("-H", "--header", "headers", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Public header file or directory for library ABI extraction.")
+@click.option("-I", "--include", "includes", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Extra include directory for castxml.")
+@click.option("--lang", default="c++", show_default=True,
+              type=click.Choice(["c++", "c"], case_sensitive=False),
+              help="Language mode for castxml.")
+@click.option("--old-version", "old_version", default="old", show_default=True)
+@click.option("--new-version", "new_version", default="new", show_default=True)
+# ── Output options ────────────────────────────────────────────────────────────
+@click.option("--format", "fmt", type=click.Choice(["json", "markdown"]),
+              default="markdown", show_default=True)
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
+@click.option("--show-irrelevant", is_flag=True, default=False,
+              help="Include library changes that don't affect the application.")
+@click.option("--list-required-symbols", "list_symbols", is_flag=True, default=False,
+              help="List symbols the application requires and exit.")
+# ── Suppression + policy ─────────────────────────────────────────────────────
+@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Suppression file (YAML).")
+@click.option("--policy", "policy",
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
+              default="strict_abi", show_default=True)
+@click.option("--policy-file", "policy_file_path",
+              type=click.Path(exists=True, path_type=Path), default=None)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def appcompat_cmd(
+    app_path: Path,
+    old_lib: Path | None,
+    new_lib: Path | None,
+    check_against_lib: Path | None,
+    headers: tuple[Path, ...],
+    includes: tuple[Path, ...],
+    lang: str,
+    old_version: str,
+    new_version: str,
+    fmt: str,
+    output: Path | None,
+    show_irrelevant: bool,
+    list_symbols: bool,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
+    verbose: bool,
+) -> None:
+    """Check if an application is compatible with a library update.
+
+    Answers: "Will my application still work with the new library version?"
+    by intersecting the app's required symbols with the library diff.
+
+    \b
+    Full check (with old and new library):
+      abicheck appcompat myapp libfoo.so.1 libfoo.so.2
+      abicheck appcompat myapp libfoo.so.1 libfoo.so.2 -H include/foo.h
+
+    \b
+    Weak mode (only new library — symbol availability check):
+      abicheck appcompat myapp --check-against libfoo.so.2
+
+    \b
+    List required symbols:
+      abicheck appcompat myapp --list-required-symbols --check-against libfoo.so.2
+
+    \b
+    Exit codes:
+      0  COMPATIBLE — application is safe with the new library
+      2  API_BREAK — source-level break affecting app's symbols
+      4  BREAKING — binary ABI break or missing symbols
+    """
+    _setup_verbosity(verbose)
+
+    from .appcompat import check_against as _check_against
+    from .appcompat import check_appcompat, parse_app_requirements
+    from .appcompat import _get_lib_soname
+    from .reporter import appcompat_to_json, appcompat_to_markdown
+
+    # Validate arguments
+    weak_mode = check_against_lib is not None
+    if weak_mode and (old_lib is not None or new_lib is not None):
+        raise click.UsageError(
+            "--check-against cannot be used with positional OLD_LIB/NEW_LIB arguments."
+        )
+    if not weak_mode and (old_lib is None or new_lib is None):
+        raise click.UsageError(
+            "Provide OLD_LIB and NEW_LIB arguments, or use --check-against for weak mode."
+        )
+
+    # --list-required-symbols: just list and exit
+    if list_symbols:
+        target_lib = check_against_lib if weak_mode else (old_lib or new_lib)
+        if target_lib is None:
+            raise click.UsageError(
+                "--list-required-symbols requires a library path "
+                "(via positional args or --check-against)."
+            )
+        lib_name = _get_lib_soname(target_lib)
+        reqs = parse_app_requirements(app_path, lib_name)
+        if fmt == "json":
+            import json as _json
+            click.echo(_json.dumps({
+                "application": str(app_path),
+                "library": lib_name,
+                "needed_libs": reqs.needed_libs,
+                "required_symbols": sorted(reqs.undefined_symbols),
+                "required_versions": reqs.required_versions,
+            }, indent=2))
+        else:
+            click.echo(f"Application: {app_path}")
+            click.echo(f"Library filter: {lib_name}")
+            click.echo(f"Needed libraries: {', '.join(reqs.needed_libs) or '(none)'}")
+            click.echo(f"Required symbols ({len(reqs.undefined_symbols)}):")
+            for sym in sorted(reqs.undefined_symbols):
+                click.echo(f"  {sym}")
+            if reqs.required_versions:
+                click.echo(f"Required versions ({len(reqs.required_versions)}):")
+                for ver, lib in sorted(reqs.required_versions.items()):
+                    click.echo(f"  {ver} (from {lib})")
+        return
+
+    if weak_mode:
+        assert check_against_lib is not None
+        result = _check_against(app_path, check_against_lib)
+    else:
+        assert old_lib is not None and new_lib is not None
+        suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
+        resolved_headers = _expand_header_inputs(list(headers)) if headers else []
+        result = check_appcompat(
+            app_path, old_lib, new_lib,
+            headers=resolved_headers,
+            includes=list(includes),
+            old_version=old_version,
+            new_version=new_version,
+            lang=lang,
+            suppression=suppression,
+            policy=policy,
+            policy_file=pf,
+        )
+
+    if fmt == "json":
+        text = appcompat_to_json(result)
+    else:
+        text = appcompat_to_markdown(result, show_irrelevant=show_irrelevant)
+
+    if output:
+        output.write_text(text, encoding="utf-8")
+        click.echo(f"Report written to {output}", err=True)
+    else:
+        click.echo(text)
+
+    if result.verdict == Verdict.BREAKING:
+        sys.exit(4)
+    elif result.verdict == Verdict.API_BREAK:
+        sys.exit(2)
+
 
 @main.command("compare-release")
 @click.argument("old_dir", type=click.Path(exists=True, path_type=Path))

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -745,3 +745,173 @@ def _format_change_md(c: object) -> str:
         line += f"\n  > Affected symbols: {names}{suffix}"
 
     return line
+
+
+# ---------------------------------------------------------------------------
+# Application compatibility reporters (ADR-005)
+# ---------------------------------------------------------------------------
+
+def appcompat_to_json(result: object, indent: int = 2) -> str:
+    """Render an AppCompatResult as JSON."""
+    import json as _json
+
+    verdict = getattr(result, "verdict", None)
+    full_diff = getattr(result, "full_diff", None)
+
+    d: dict[str, object] = {
+        "application": getattr(result, "app_path", ""),
+        "old_library": getattr(result, "old_lib_path", ""),
+        "new_library": getattr(result, "new_lib_path", ""),
+        "verdict": verdict.value if verdict else "UNKNOWN",
+        "symbol_coverage_pct": round(getattr(result, "symbol_coverage", 0.0), 1),
+        "required_symbol_count": getattr(result, "required_symbol_count", 0),
+    }
+
+    missing = getattr(result, "missing_symbols", [])
+    d["missing_symbols"] = list(missing)
+
+    missing_ver = getattr(result, "missing_versions", [])
+    d["missing_versions"] = list(missing_ver)
+
+    breaking = getattr(result, "breaking_for_app", [])
+    d["relevant_changes"] = [_change_to_dict(c) for c in breaking]
+    d["relevant_change_count"] = len(breaking)
+
+    irrelevant = getattr(result, "irrelevant_for_app", [])
+    d["irrelevant_change_count"] = len(irrelevant)
+
+    total = len(breaking) + len(irrelevant)
+    d["total_library_changes"] = total
+
+    if full_diff:
+        d["full_library_verdict"] = full_diff.verdict.value
+
+    return _json.dumps(d, indent=indent)
+
+
+def appcompat_to_markdown(result: object, *, show_irrelevant: bool = False) -> str:
+    """Render an AppCompatResult as Markdown."""
+    verdict = getattr(result, "verdict", None)
+    v_label = verdict.value if verdict else "UNKNOWN"
+    v_emoji = _VERDICT_EMOJI.get(verdict, "?") if verdict else "?"
+
+    app_path = getattr(result, "app_path", "")
+    old_lib = getattr(result, "old_lib_path", "")
+    new_lib = getattr(result, "new_lib_path", "")
+    required_count = getattr(result, "required_symbol_count", 0)
+    coverage = getattr(result, "symbol_coverage", 0.0)
+    missing = getattr(result, "missing_symbols", [])
+    missing_ver = getattr(result, "missing_versions", [])
+    breaking = getattr(result, "breaking_for_app", [])
+    irrelevant = getattr(result, "irrelevant_for_app", [])
+    full_diff = getattr(result, "full_diff", None)
+
+    total_changes = len(breaking) + len(irrelevant)
+
+    lines: list[str] = [
+        "# Application Compatibility Report",
+        "",
+    ]
+
+    if old_lib:
+        lines += [
+            f"**Application:** `{app_path}`",
+            f"**Library:** `{old_lib}` → `{new_lib}`",
+            f"**Verdict:** {v_emoji} `{v_label}`",
+            "",
+        ]
+    else:
+        # Weak mode
+        lines += [
+            f"**Application:** `{app_path}`",
+            f"**Library:** `{new_lib}`",
+            f"**Verdict:** {v_emoji} `{v_label}`",
+            "",
+        ]
+
+    # Symbol coverage section
+    lines += ["## Symbol Coverage", ""]
+    if full_diff:
+        new_export_count = total_changes  # approximate from changes
+        lines.append(
+            f"App requires **{required_count}** library symbols."
+        )
+    else:
+        lines.append(
+            f"App requires **{required_count}** library symbols."
+        )
+
+    if missing:
+        lines.append(
+            f"**{len(missing)}** required symbol(s) missing from new version "
+            f"({coverage:.0f}% coverage)."
+        )
+    elif required_count > 0:
+        lines.append(
+            f"All {required_count} required symbols present in new version "
+            f"({coverage:.0f}% coverage)."
+        )
+    lines.append("")
+
+    # Missing symbols
+    if missing:
+        lines += ["## Missing Symbols", ""]
+        lines.append("These symbols are required by the application but absent from the new library:")
+        lines.append("")
+        for sym in missing:
+            lines.append(f"- `{sym}`")
+        lines.append("")
+
+    # Missing versions
+    if missing_ver:
+        lines += ["## Missing Symbol Versions", ""]
+        for ver in missing_ver:
+            lines.append(f"- `{ver}`")
+        lines.append("")
+
+    # Relevant changes
+    if breaking:
+        lines += [
+            f"## Relevant Changes ({len(breaking)} of {total_changes} total)",
+            "",
+            "These library changes affect symbols your application uses:",
+            "",
+            "| Kind | Symbol | Description |",
+            "|------|--------|-------------|",
+        ]
+        for c in breaking:
+            kind_val = c.kind.value if c.kind else ""
+            lines.append(f"| `{kind_val}` | `{c.symbol}` | {c.description} |")
+        lines.append("")
+    elif total_changes > 0:
+        lines += [
+            f"## Relevant Changes (0 of {total_changes} total)",
+            "",
+            "None of the library's ABI changes affect your application.",
+            "",
+        ]
+
+    # Irrelevant changes
+    if irrelevant and not show_irrelevant:
+        lines.append(
+            f"_{len(irrelevant)} library ABI change(s) do NOT affect your application. "
+            "Use `--show-irrelevant` to see them._"
+        )
+        lines.append("")
+    elif irrelevant and show_irrelevant:
+        lines += [
+            f"## Irrelevant Changes ({len(irrelevant)})",
+            "",
+            "These library changes do NOT affect your application:",
+            "",
+        ]
+        for c in irrelevant:
+            kind_val = c.kind.value if c.kind else ""
+            lines.append(f"- **{kind_val}**: {c.description}")
+        lines.append("")
+
+    lines += [
+        "---",
+        "_Generated by [abicheck](https://github.com/napetrov/abicheck)_",
+    ]
+    return "\n".join(lines)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -804,7 +804,6 @@ def appcompat_to_markdown(result: object, *, show_irrelevant: bool = False) -> s
     missing_ver = getattr(result, "missing_versions", [])
     breaking = getattr(result, "breaking_for_app", [])
     irrelevant = getattr(result, "irrelevant_for_app", [])
-    full_diff = getattr(result, "full_diff", None)
 
     total_changes = len(breaking) + len(irrelevant)
 
@@ -831,15 +830,9 @@ def appcompat_to_markdown(result: object, *, show_irrelevant: bool = False) -> s
 
     # Symbol coverage section
     lines += ["## Symbol Coverage", ""]
-    if full_diff:
-        new_export_count = total_changes  # approximate from changes
-        lines.append(
-            f"App requires **{required_count}** library symbols."
-        )
-    else:
-        lines.append(
-            f"App requires **{required_count}** library symbols."
-        )
+    lines.append(
+        f"App requires **{required_count}** library symbols."
+    )
 
     if missing:
         lines.append(

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ inputs:
       Operation mode: "compare" (default) compares two ABI surfaces;
       "compare-release" compares all libraries in two directories or packages;
       "dump" generates a JSON baseline snapshot from a single library;
+      "appcompat" checks whether an application binary is affected by a library update;
       "deps" resolves transitive dependencies and symbol bindings (Linux ELF);
       "stack-check" compares a binary's full dependency stack across two
       sysroots (Linux ELF).
@@ -33,7 +34,31 @@ inputs:
       Path to the new (current) library or binary.
       Required for compare and dump modes. For compare-release: new directory
       or package (RPM, Deb, tar, conda, wheel).
-    required: true
+    required: false
+
+  # ── Application compatibility inputs ────────────────────────────────────
+  app-binary:
+    description: >
+      Path to the application binary (ELF, PE, or Mach-O).
+      Required when mode=appcompat.
+    required: false
+  check-against:
+    description: >
+      Path to a library for weak-mode symbol availability check (no old library needed).
+      Only used with mode=appcompat.
+    required: false
+  show-irrelevant:
+    description: >
+      Include library changes that do not affect the application.
+      Only used with mode=appcompat.
+    required: false
+    default: 'false'
+  list-required-symbols:
+    description: >
+      List symbols the application requires from the library and exit.
+      Only used with mode=appcompat.
+    required: false
+    default: 'false'
 
   # ── Package inputs (compare-release mode) ────────────────────────────────────
   debug-info1:
@@ -251,6 +276,10 @@ runs:
         INPUT_MODE: ${{ inputs.mode }}
         INPUT_OLD_LIBRARY: ${{ inputs.old-library }}
         INPUT_NEW_LIBRARY: ${{ inputs.new-library }}
+        INPUT_APP_BINARY: ${{ inputs.app-binary }}
+        INPUT_CHECK_AGAINST: ${{ inputs.check-against }}
+        INPUT_SHOW_IRRELEVANT: ${{ inputs.show-irrelevant }}
+        INPUT_LIST_REQUIRED_SYMBOLS: ${{ inputs.list-required-symbols }}
         INPUT_HEADER: ${{ inputs.header }}
         INPUT_OLD_HEADER: ${{ inputs.old-header }}
         INPUT_NEW_HEADER: ${{ inputs.new-header }}

--- a/action.yml
+++ b/action.yml
@@ -32,12 +32,8 @@ inputs:
   new-library:
     description: >
       Path to the new (current) library or binary.
-<<<<<<< HEAD
       Required for compare and dump modes. For compare-release: new directory
       or package (RPM, Deb, tar, conda, wheel).
-=======
-      Required for compare and dump modes.
->>>>>>> 8421f4b (fix: appcompat ELF version index parsing and weak symbol filtering)
     required: false
 
   # ── Application compatibility inputs ────────────────────────────────────

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,12 @@ inputs:
   new-library:
     description: >
       Path to the new (current) library or binary.
+<<<<<<< HEAD
       Required for compare and dump modes. For compare-release: new directory
       or package (RPM, Deb, tar, conda, wheel).
+=======
+      Required for compare and dump modes.
+>>>>>>> 8421f4b (fix: appcompat ELF version index parsing and weak symbol filtering)
     required: false
 
   # ── Application compatibility inputs ────────────────────────────────────

--- a/action/run.sh
+++ b/action/run.sh
@@ -113,6 +113,48 @@ elif [[ "$MODE" == "compare" ]]; then
   # when an input is a binary, but these cross-compilation flags are not
   # exposed on the compare CLI. They are only passed in dump mode.
 
+elif [[ "$MODE" == "appcompat" ]]; then
+  # ── Appcompat mode ─────────────────────────────────────────────────────
+  CMD+=(appcompat)
+  CMD+=("${INPUT_APP_BINARY:?app-binary is required for appcompat mode}")
+
+  CHECK_AGAINST="${INPUT_CHECK_AGAINST:-}"
+  if [[ -n "$CHECK_AGAINST" ]]; then
+    # Weak mode: symbol availability check only (no old library needed)
+    CMD+=(--check-against "$CHECK_AGAINST")
+  else
+    # Full mode: old + new library comparison
+    CMD+=("${INPUT_OLD_LIBRARY:?old-library is required for appcompat full mode (or use check-against for weak mode)}")
+    CMD+=("${INPUT_NEW_LIBRARY:?new-library is required for appcompat full mode}")
+  fi
+
+  add_flag "-H" "${INPUT_HEADER:-}"
+  add_flag "-I" "${INPUT_INCLUDE:-}"
+  add_single_flag "--old-version" "${INPUT_OLD_VERSION:-}"
+  add_single_flag "--new-version" "${INPUT_NEW_VERSION:-}"
+  add_single_flag "--lang" "${INPUT_LANG:-}"
+
+  # Format
+  FORMAT="${INPUT_FORMAT:-markdown}"
+  CMD+=(--format "$FORMAT")
+
+  OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
+  if [[ -n "$OUTPUT_FILE" ]]; then
+    CMD+=(-o "$OUTPUT_FILE")
+  fi
+
+  add_single_flag "--policy" "${INPUT_POLICY:-}"
+  add_single_flag "--policy-file" "${INPUT_POLICY_FILE:-}"
+  add_single_flag "--suppress" "${INPUT_SUPPRESS:-}"
+
+  if [[ "${INPUT_SHOW_IRRELEVANT:-false}" == "true" ]]; then
+    CMD+=(--show-irrelevant)
+  fi
+
+  if [[ "${INPUT_LIST_REQUIRED_SYMBOLS:-false}" == "true" ]]; then
+    CMD+=(--list-required-symbols)
+  fi
+
 elif [[ "$MODE" == "compare-release" ]]; then
   # ── Compare-release mode (package-level comparison) ──────────────────────
   CMD+=(compare-release)
@@ -201,7 +243,7 @@ elif [[ "$MODE" == "stack-check" ]]; then
   fi
 
 else
-  echo "::error::Unknown mode '$MODE'. Use 'compare', 'compare-release', 'dump', 'deps', or 'stack-check'."
+  echo "::error::Unknown mode '$MODE'. Use 'compare', 'compare-release', 'dump', 'appcompat', 'deps', or 'stack-check'."
   exit 1
 fi
 
@@ -338,21 +380,37 @@ echo "abicheck verdict: $VERDICT (exit code $ABICHECK_EXIT)"
 # ---------------------------------------------------------------------------
 if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
   {
-    echo "## abicheck ABI Compatibility Report"
+    if [[ "$MODE" == "appcompat" ]]; then
+      echo "## abicheck Application Compatibility Report"
+    else
+      echo "## abicheck ABI Compatibility Report"
+    fi
     echo ""
 
     case $VERDICT in
       COMPATIBLE)
-        echo "> **Verdict: COMPATIBLE** — No binary ABI break detected."
+        if [[ "$MODE" == "appcompat" ]]; then
+          echo "> **Verdict: COMPATIBLE** — Application is safe with the new library."
+        else
+          echo "> **Verdict: COMPATIBLE** — No binary ABI break detected."
+        fi
         ;;
       ADDITIONS)
         echo "> **Verdict: ADDITIONS** ⚠️ — No binary ABI break, but new public API was added unexpectedly."
         ;;
       API_BREAK)
-        echo "> **Verdict: API_BREAK** — Source-level API break detected. Recompilation required."
+        if [[ "$MODE" == "appcompat" ]]; then
+          echo "> **Verdict: API_BREAK** — Source-level break affecting application symbols."
+        else
+          echo "> **Verdict: API_BREAK** — Source-level API break detected. Recompilation required."
+        fi
         ;;
       BREAKING)
-        echo "> **Verdict: BREAKING** — Binary ABI break detected. Existing binaries will fail at runtime."
+        if [[ "$MODE" == "appcompat" ]]; then
+          echo "> **Verdict: BREAKING** — Binary ABI break or missing symbols affecting the application."
+        else
+          echo "> **Verdict: BREAKING** — Binary ABI break detected. Existing binaries will fail at runtime."
+        fi
         ;;
       REMOVED_LIBRARY)
         echo "> **Verdict: REMOVED_LIBRARY** — A library present in the old package is missing from the new package."
@@ -374,7 +432,16 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
     echo ""
     echo "| Property | Value |"
     echo "|----------|-------|"
-    if [[ "$MODE" == "compare" || "$MODE" == "compare-release" ]]; then
+    if [[ "$MODE" == "appcompat" ]]; then
+      echo "| Application | \`${INPUT_APP_BINARY:-}\` |"
+      if [[ -n "${INPUT_CHECK_AGAINST:-}" ]]; then
+        echo "| Check against | \`${INPUT_CHECK_AGAINST}\` |"
+      else
+        echo "| Old library | \`${INPUT_OLD_LIBRARY:-}\` (${INPUT_OLD_VERSION:-old}) |"
+        echo "| New library | \`${INPUT_NEW_LIBRARY:-}\` (${INPUT_NEW_VERSION:-new}) |"
+      fi
+      echo "| Policy | ${INPUT_POLICY:-strict_abi} |"
+    elif [[ "$MODE" == "compare" || "$MODE" == "compare-release" ]]; then
       echo "| Old | \`${INPUT_OLD_LIBRARY:-}\` (${INPUT_OLD_VERSION:-old}) |"
       echo "| New | \`${INPUT_NEW_LIBRARY:-}\` (${INPUT_NEW_VERSION:-new}) |"
       echo "| Policy | ${INPUT_POLICY:-strict_abi} |"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,7 +182,27 @@ abicheck compare old.json new.json -v
 
 ---
 
-## 5) Exit codes and CI
+## 5) Application compatibility check
+
+Check whether your **application** is affected by a library update — filtering out irrelevant changes:
+
+```bash
+abicheck appcompat ./myapp libfoo.so.1 libfoo.so.2 -H include/foo.h
+```
+
+This parses your application binary to find which library symbols it actually uses, then shows only the changes that matter. If the library removed a function your app never calls, it won't appear in the report.
+
+Quick symbol availability check (no old library needed):
+
+```bash
+abicheck appcompat ./myapp --check-against libfoo.so.2
+```
+
+See [Application Compatibility](user-guide/appcompat.md) for the full reference.
+
+---
+
+## 6) Exit codes and CI
 
 | Exit code | Verdict | Meaning |
 |-----------|---------|---------|

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -56,6 +56,23 @@ verdict=$(python3 -c "import json,sys; d=json.load(open('result.json')); print(d
 
 ---
 
+## `abicheck appcompat`
+
+Uses the same exit codes as `compare`:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | `COMPATIBLE` or `NO_CHANGE` — application is safe with the new library |
+| `1` | Tool/runtime error (tool failure, invalid input, or unexpected exception) |
+| `2` | `API_BREAK` — source-level break affecting app's symbols |
+| `4` | `BREAKING` — binary ABI break or missing symbols |
+
+> **`BREAKING` (exit 4)** is also returned when the application requires symbols or
+> ELF version tags that are absent from the new library — even if the library
+> diff itself is compatible — because the application would fail to load.
+
+---
+
 ## `abicheck deps`
 
 | Exit code | Meaning |
@@ -126,17 +143,17 @@ In `abicheck compat`, non-verdict failures are further classified where possible
 
 ## Summary table
 
-| Verdict / State | `compare` exit | `deps` exit | `stack-check` exit | `compat` exit |
-|-----------------|---------------|-------------|-------------------|---------------|
-| `NO_CHANGE` / `PASS` | `0` | `0` | `0` | `0` |
-| `COMPATIBLE` | `0` | — | — | `0` |
-| `COMPATIBLE_WITH_RISK` | `0` | — | — | `0` |
-| `ADDITIONS` (with `--fail-on-additions`) | `1` | — | — | n/a |
-| `WARN` (ABI risk) | — | — | `1` | — |
-| `API_BREAK` | `2` | — | — | `2` |
-| `BREAKING` / `FAIL` | `4` | — | `4` | `1` |
-| Load failure | — | `1` | `4` | — |
-| Tool error | `1/2`* | — | — | `3/4/5/6/7/8/10/11` |
+| Verdict / State | `compare` exit | `appcompat` exit | `deps` exit | `stack-check` exit | `compat` exit |
+|-----------------|---------------|-----------------|-------------|-------------------|---------------|
+| `NO_CHANGE` / `PASS` | `0` | `0` | `0` | `0` | `0` |
+| `COMPATIBLE` | `0` | `0` | — | — | `0` |
+| `COMPATIBLE_WITH_RISK` | `0` | `0` | — | — | `0` |
+| `ADDITIONS` (with `--fail-on-additions`) | `1` | n/a | — | — | n/a |
+| `WARN` (ABI risk) | — | — | — | `1` | — |
+| `API_BREAK` | `2` | `2` | — | — | `2` |
+| `BREAKING` / `FAIL` | `4` | `4` | — | `4` | `1` |
+| Load failure | — | — | `1` | `4` | — |
+| Tool error | `1/2`* | `1` | — | — | `3/4/5/6/7/8/10/11` |
 
 \* For `compare`, exit `1` without `--fail-on-additions` is a tool/CLI error.
 With `--fail-on-additions`, exit `1` can indicate `ADDITIONS` but may also occur

--- a/docs/user-guide/appcompat.md
+++ b/docs/user-guide/appcompat.md
@@ -13,7 +13,7 @@ Unlike `compare` (which reports all library changes), `appcompat` filters the di
 | Library maintainer checking all ABI changes | `abicheck compare` |
 | App developer checking if *their app* is affected | `abicheck appcompat` |
 | Distro packager checking if app X works with new libfoo | `abicheck appcompat` |
-| Quick symbol availability check (no old library) | `abicheck appcompat --check-against` |
+| Quick symbol availability check (no old library) | `abicheck appcompat <app-binary> --check-against <target-lib>` |
 
 ---
 
@@ -141,6 +141,7 @@ abicheck appcompat ./myapp --list-required-symbols --check-against libfoo.so.2 -
 | Exit code | Verdict | Meaning |
 |-----------|---------|---------|
 | `0` | `COMPATIBLE` / `NO_CHANGE` | Application is safe with the new library |
+| `1` | `TOOL_ERROR` | Operational or runtime error (tool failure, invalid input, or unexpected exception) |
 | `2` | `API_BREAK` | Source-level break affecting app's symbols |
 | `4` | `BREAKING` | Binary ABI break or missing symbols |
 

--- a/docs/user-guide/appcompat.md
+++ b/docs/user-guide/appcompat.md
@@ -1,0 +1,203 @@
+# Application Compatibility Check
+
+The `abicheck appcompat` command answers: **"Will my application still work with the new library version?"**
+
+Unlike `compare` (which reports all library changes), `appcompat` filters the diff to show only changes that affect the specific application binary you provide. This is the application-centric view of ABI compatibility.
+
+---
+
+## When to use `appcompat`
+
+| Scenario | Command |
+|----------|---------|
+| Library maintainer checking all ABI changes | `abicheck compare` |
+| App developer checking if *their app* is affected | `abicheck appcompat` |
+| Distro packager checking if app X works with new libfoo | `abicheck appcompat` |
+| Quick symbol availability check (no old library) | `abicheck appcompat --check-against` |
+
+---
+
+## Full mode (old + new library)
+
+Provide the application binary, old library, and new library:
+
+```bash
+abicheck appcompat ./myapp libfoo.so.1 libfoo.so.2
+```
+
+With headers for deeper analysis:
+
+```bash
+abicheck appcompat ./myapp libfoo.so.1 libfoo.so.2 \
+  -H include/foo.h
+```
+
+This will:
+
+1. Parse the application binary to extract required symbols
+2. Run a full library comparison (same as `compare`)
+3. Check symbol availability in the new library
+4. Filter changes to show only those affecting the application
+5. Compute an app-specific verdict
+
+### Example output
+
+```text
+# Application Compatibility Report
+
+**Application:** `./myapp`
+**Library:** `libfoo.so.1` → `libfoo.so.2`
+**Verdict:** ✅ `COMPATIBLE`
+
+## Symbol Coverage
+
+App requires **12** library symbols.
+All 12 required symbols present in new version (100% coverage).
+
+## Relevant Changes (1 of 7 total)
+
+These library changes affect symbols your application uses:
+
+| Kind | Symbol | Description |
+|------|--------|-------------|
+| `func_params_changed` | `foo_process` | parameter type changed |
+
+_6 library ABI change(s) do NOT affect your application. Use `--show-irrelevant` to see them._
+```
+
+---
+
+## Weak mode (symbol availability only)
+
+When you don't have the old library — just check if the new library provides everything the application needs:
+
+```bash
+abicheck appcompat ./myapp --check-against libfoo.so.2
+```
+
+Weak mode checks:
+
+- All symbols the application imports from the library are present
+- All required ELF symbol versions are defined
+
+It does **not** compare old vs. new (no diff, no change detection).
+
+---
+
+## List required symbols
+
+Diagnose what symbols your application imports from a library:
+
+```bash
+abicheck appcompat ./myapp --list-required-symbols --check-against libfoo.so.2
+```
+
+```text
+Application: ./myapp
+Library filter: libfoo.so.1
+Needed libraries: libfoo.so.1, libc.so.6
+Required symbols (3):
+  foo_cleanup
+  foo_init
+  foo_process
+Required versions (1):
+  FOO_1.0 (from libfoo.so.1)
+```
+
+JSON output:
+
+```bash
+abicheck appcompat ./myapp --list-required-symbols --check-against libfoo.so.2 --format json
+```
+
+---
+
+## Options reference
+
+| Option | Description |
+|--------|-------------|
+| `APP` | Path to application binary (ELF, PE, or Mach-O) |
+| `OLD_LIB` | Path to old library version |
+| `NEW_LIB` | Path to new library version |
+| `--check-against LIB` | Weak mode: check symbol availability only (no old library needed) |
+| `-H` / `--header` | Public header file or directory (for full mode) |
+| `-I` / `--include` | Extra include directory for castxml |
+| `--lang` | Language mode: `c++` (default) or `c` |
+| `--format` | Output format: `markdown` (default) or `json` |
+| `-o` / `--output` | Write report to file |
+| `--show-irrelevant` | Include library changes that don't affect the application |
+| `--list-required-symbols` | List symbols the application requires and exit |
+| `--suppress` | Suppression file (YAML) |
+| `--policy` | Verdict policy: `strict_abi` (default), `sdk_vendor`, `plugin_abi` |
+| `--policy-file` | Custom YAML policy overrides |
+| `-v` / `--verbose` | Debug output |
+
+---
+
+## Exit codes
+
+`appcompat` uses the same exit codes as `compare`:
+
+| Exit code | Verdict | Meaning |
+|-----------|---------|---------|
+| `0` | `COMPATIBLE` / `NO_CHANGE` | Application is safe with the new library |
+| `2` | `API_BREAK` | Source-level break affecting app's symbols |
+| `4` | `BREAKING` | Binary ABI break or missing symbols |
+
+---
+
+## How symbol filtering works
+
+The application binary is parsed to extract:
+
+- **Imported symbols** — undefined symbols in `.dynsym` (ELF), import table (PE), or symbol table (Mach-O)
+- **Library filter** — only symbols imported from the target library are considered (using ELF `.gnu.version_r`, PE DLL name, or Mach-O two-level namespace)
+- **Required versions** — ELF version tags from `.gnu.version_r`
+
+A library change is **relevant** to the application if any of these conditions hold:
+
+1. The change's symbol is in the app's imported symbol set
+2. The change's `affected_symbols` overlap with the app's imports (type change propagation)
+3. The change is `SONAME_CHANGED` (affects all consumers)
+4. The change is `COMPAT_VERSION_CHANGED` (Mach-O, affects all consumers)
+5. The change is `SYMBOL_VERSION_DEFINED_REMOVED` for a version the app requires
+
+All other changes are classified as **irrelevant** — the library changed, but the application doesn't use the affected symbols.
+
+---
+
+## Supported binary formats
+
+| Format | Application | Library | Symbol filtering |
+|--------|------------|---------|-----------------|
+| **ELF** (Linux) | `.so`, executables | `.so` | `.gnu.version` + `.gnu.version_r` correlation |
+| **PE** (Windows) | `.exe`, `.dll` | `.dll` | Import table DLL name matching (incl. ordinal imports) |
+| **Mach-O** (macOS) | executables, `.dylib` | `.dylib` | Two-level namespace library ordinal |
+
+---
+
+## CI integration
+
+### GitHub Actions example
+
+Check if your application works with a library update in CI:
+
+```yaml
+- name: Check app compatibility
+  run: |
+    abicheck appcompat ./build/myapp \
+      libfoo.so.1 ./build/libfoo.so.2 \
+      -H include/foo.h \
+      --format json -o appcompat.json
+```
+
+### Weak mode in CI (no old library)
+
+Quick check that a library provides all symbols an application needs:
+
+```yaml
+- name: Check symbol availability
+  run: |
+    abicheck appcompat ./build/myapp \
+      --check-against ./build/libfoo.so
+```

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -20,7 +20,7 @@ automatically, then runs ABI comparison and reports results.
 
 | Input | Required | Description |
 |-------|----------|-------------|
-| `mode` | no | `compare` (default), `compare-release`, `dump`, `deps`, or `stack-check` |
+| `mode` | no | `compare` (default), `compare-release`, `dump`, `appcompat`, `deps`, or `stack-check` |
 | `old-library` | yes (compare, compare-release) | Path to old library, JSON snapshot, ABICC dump, directory, or package |
 | `new-library` | yes | Path to new library, binary, directory, or package |
 
@@ -34,6 +34,15 @@ automatically, then runs ABI comparison and reports results.
 | `include` | no | Extra include dirs for castxml (both sides) |
 | `old-include` | no | Include dirs for old side only |
 | `new-include` | no | Include dirs for new side only |
+
+### Application compatibility inputs (appcompat mode)
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `app-binary` | yes (appcompat) | Path to application binary (ELF, PE, or Mach-O) |
+| `check-against` | no | Library for weak-mode symbol availability check (no old library needed) |
+| `show-irrelevant` | no | Include library changes not affecting the application (default `false`) |
+| `list-required-symbols` | no | List symbols the app requires and exit (default `false`) |
 
 ### Version labels
 
@@ -505,6 +514,33 @@ build-id resolution:
           mode: compare-release
           old-library: pkg-v1.conda
           new-library: pkg-v2.conda
+```
+
+### Application compatibility check
+
+Check whether your application binary is affected by a library update:
+
+```yaml
+      - uses: napetrov/abicheck@v1
+        with:
+          mode: appcompat
+          app-binary: build/myapp
+          old-library: libfoo.so.1
+          new-library: build/libfoo.so.2
+          header: include/foo.h
+```
+
+### Quick symbol availability check (weak mode)
+
+Verify a library provides all symbols an application needs — no old library required:
+
+```yaml
+      - uses: napetrov/abicheck@v1
+        with:
+          mode: appcompat
+          app-binary: build/myapp
+          check-against: build/libfoo.so
+          install-deps: false
 ```
 
 ## Versioning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - User Guide:
     - CLI Usage: user-guide/cli-usage.md
     - Tool Modes: user-guide/tool-modes.md
+    - Application Compatibility: user-guide/appcompat.md
     - Policy Profiles: user-guide/policies.md
     - Suppressions: user-guide/suppressions.md
     - Output Formats: user-guide/output-formats.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ ignore_missing_imports = true
 # pyelftools has no type stubs or py.typed marker — all its APIs are untyped.
 # Disable strict checks for modules that directly call pyelftools APIs.
 module = [
+    "abicheck.appcompat",
     "abicheck.elf_metadata",
     "abicheck.pe_metadata",
     "abicheck.macho_metadata",

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for abicheck.appcompat — Application Compatibility Checking (ADR-005)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from abicheck.appcompat import (
+    AppCompatResult,
+    AppRequirements,
+    _detect_app_format,
+    _is_relevant_to_app,
+    check_against,
+    check_appcompat,
+    parse_app_requirements,
+)
+from abicheck.checker import Change, DiffResult
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.reporter import appcompat_to_json, appcompat_to_markdown
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: AppRequirements / AppCompatResult data structures
+# ---------------------------------------------------------------------------
+
+class TestDataStructures:
+    def test_app_requirements_defaults(self):
+        reqs = AppRequirements()
+        assert reqs.needed_libs == []
+        assert reqs.undefined_symbols == set()
+        assert reqs.required_versions == {}
+
+    def test_app_requirements_populated(self):
+        reqs = AppRequirements(
+            needed_libs=["libfoo.so.1", "libc.so.6"],
+            undefined_symbols={"foo_init", "foo_process"},
+            required_versions={"FOO_1.0": "libfoo.so.1"},
+        )
+        assert len(reqs.needed_libs) == 2
+        assert "foo_init" in reqs.undefined_symbols
+        assert reqs.required_versions["FOO_1.0"] == "libfoo.so.1"
+
+    def test_app_compat_result_defaults(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+        )
+        assert result.verdict == Verdict.COMPATIBLE
+        assert result.symbol_coverage == 100.0
+        assert result.missing_symbols == []
+        assert result.breaking_for_app == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_relevant_to_app
+# ---------------------------------------------------------------------------
+
+class TestIsRelevantToApp:
+    def _make_app(self, symbols: set[str] | None = None, versions: dict[str, str] | None = None):
+        return AppRequirements(
+            undefined_symbols=symbols or {"foo_init", "foo_process", "foo_cleanup"},
+            required_versions=versions or {},
+        )
+
+    def test_direct_symbol_match(self):
+        app = self._make_app()
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="foo_init",
+            description="Function removed: foo_init",
+        )
+        assert _is_relevant_to_app(change, app) is True
+
+    def test_no_match(self):
+        app = self._make_app()
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="bar_init",
+            description="Function removed: bar_init",
+        )
+        assert _is_relevant_to_app(change, app) is False
+
+    def test_affected_symbols_match(self):
+        app = self._make_app()
+        change = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol="Config",
+            description="Type size changed: Config",
+            affected_symbols=["foo_init", "bar_init"],
+        )
+        assert _is_relevant_to_app(change, app) is True
+
+    def test_affected_symbols_no_match(self):
+        app = self._make_app()
+        change = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol="Config",
+            description="Type size changed: Config",
+            affected_symbols=["bar_init", "baz_init"],
+        )
+        assert _is_relevant_to_app(change, app) is False
+
+    def test_soname_changed_always_relevant(self):
+        app = self._make_app()
+        change = Change(
+            kind=ChangeKind.SONAME_CHANGED,
+            symbol="",
+            description="SONAME changed",
+            old_value="libfoo.so.1",
+            new_value="libfoo.so.2",
+        )
+        assert _is_relevant_to_app(change, app) is True
+
+    def test_compat_version_changed_always_relevant(self):
+        app = self._make_app()
+        change = Change(
+            kind=ChangeKind.COMPAT_VERSION_CHANGED,
+            symbol="",
+            description="Mach-O compat version changed",
+        )
+        assert _is_relevant_to_app(change, app) is True
+
+    def test_symbol_version_removed_relevant(self):
+        app = self._make_app(
+            versions={"FOO_1.0": "libfoo.so.1"},
+        )
+        change = Change(
+            kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+            symbol="FOO_1.0",
+            description="Symbol version removed",
+            old_value="libfoo.so.1",
+        )
+        assert _is_relevant_to_app(change, app) is True
+
+    def test_symbol_version_removed_different_version(self):
+        app = self._make_app(
+            versions={"FOO_1.0": "libfoo.so.1"},
+        )
+        change = Change(
+            kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
+            symbol="FOO_2.0",
+            description="Symbol version removed",
+            old_value="libfoo.so.1",
+        )
+        assert _is_relevant_to_app(change, app) is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _detect_app_format
+# ---------------------------------------------------------------------------
+
+class TestDetectAppFormat:
+    def test_nonexistent_path(self, tmp_path):
+        assert _detect_app_format(tmp_path / "nope") is None
+
+    def test_unknown_format(self, tmp_path):
+        f = tmp_path / "unknown.bin"
+        f.write_bytes(b"\x00\x00\x00\x00")
+        assert _detect_app_format(f) is None
+
+    def test_elf_magic(self, tmp_path):
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        assert _detect_app_format(f) == "elf"
+
+    def test_pe_magic(self, tmp_path):
+        data = bytearray(512)
+        data[0:2] = b"MZ"
+        data[0x3C:0x40] = (0x80).to_bytes(4, "little")
+        data[0x80:0x84] = b"PE\x00\x00"
+        f = tmp_path / "app.exe"
+        f.write_bytes(bytes(data))
+        assert _detect_app_format(f) == "pe"
+
+    def test_macho_magic(self, tmp_path):
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+        assert _detect_app_format(f) == "macho"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: AppCompatResult verdict computation
+# ---------------------------------------------------------------------------
+
+class TestAppCompatResultVerdict:
+    def test_missing_symbols_means_breaking(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            missing_symbols=["foo_init"],
+            verdict=Verdict.BREAKING,
+        )
+        assert result.verdict == Verdict.BREAKING
+
+    def test_no_changes_means_compatible(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            required_symbol_count=5,
+            verdict=Verdict.COMPATIBLE,
+        )
+        assert result.verdict == Verdict.COMPATIBLE
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: reporters
+# ---------------------------------------------------------------------------
+
+class TestAppCompatReporters:
+    def _make_result(self, *, missing=None, breaking=None, irrelevant=None, verdict=None):
+        return AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="libfoo.so.1",
+            new_lib_path="libfoo.so.2",
+            required_symbols={"foo_init", "foo_process", "foo_cleanup"},
+            required_symbol_count=3,
+            breaking_for_app=breaking or [],
+            irrelevant_for_app=irrelevant or [],
+            missing_symbols=missing or [],
+            missing_versions=[],
+            full_diff=DiffResult(
+                old_version="1.0",
+                new_version="2.0",
+                library="libfoo",
+            ),
+            verdict=verdict or Verdict.COMPATIBLE,
+            symbol_coverage=100.0,
+        )
+
+    def test_markdown_compatible(self):
+        result = self._make_result()
+        md = appcompat_to_markdown(result)
+        assert "# Application Compatibility Report" in md
+        assert "COMPATIBLE" in md
+        assert "/usr/bin/myapp" in md
+
+    def test_markdown_with_missing_symbols(self):
+        result = self._make_result(
+            missing=["foo_init"],
+            verdict=Verdict.BREAKING,
+        )
+        md = appcompat_to_markdown(result)
+        assert "Missing Symbols" in md
+        assert "foo_init" in md
+
+    def test_markdown_with_relevant_changes(self):
+        change = Change(
+            kind=ChangeKind.FUNC_PARAMS_CHANGED,
+            symbol="foo_process",
+            description="parameter type changed",
+        )
+        result = self._make_result(breaking=[change])
+        md = appcompat_to_markdown(result)
+        assert "Relevant Changes" in md
+        assert "foo_process" in md
+
+    def test_markdown_show_irrelevant(self):
+        change = Change(
+            kind=ChangeKind.FUNC_ADDED,
+            symbol="bar_new",
+            description="function added: bar_new",
+        )
+        result = self._make_result(irrelevant=[change])
+        md = appcompat_to_markdown(result, show_irrelevant=True)
+        assert "Irrelevant Changes" in md
+        assert "bar_new" in md
+
+    def test_markdown_hide_irrelevant_default(self):
+        change = Change(
+            kind=ChangeKind.FUNC_ADDED,
+            symbol="bar_new",
+            description="function added",
+        )
+        result = self._make_result(irrelevant=[change])
+        md = appcompat_to_markdown(result)
+        assert "--show-irrelevant" in md
+
+    def test_json_output(self):
+        result = self._make_result()
+        j = appcompat_to_json(result)
+        data = json.loads(j)
+        assert data["verdict"] == "COMPATIBLE"
+        assert data["application"] == "/usr/bin/myapp"
+        assert data["required_symbol_count"] == 3
+
+    def test_json_with_missing(self):
+        result = self._make_result(
+            missing=["foo_init"],
+            verdict=Verdict.BREAKING,
+        )
+        j = appcompat_to_json(result)
+        data = json.loads(j)
+        assert data["verdict"] == "BREAKING"
+        assert "foo_init" in data["missing_symbols"]
+
+    def test_json_with_relevant_changes(self):
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="foo_init",
+            description="Function removed",
+        )
+        result = self._make_result(breaking=[change])
+        j = appcompat_to_json(result)
+        data = json.loads(j)
+        assert data["relevant_change_count"] == 1
+        assert data["relevant_changes"][0]["symbol"] == "foo_init"
+
+    def test_markdown_weak_mode(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="",
+            new_lib_path="libfoo.so.2",
+            required_symbols={"foo_init"},
+            required_symbol_count=1,
+            verdict=Verdict.COMPATIBLE,
+            symbol_coverage=100.0,
+        )
+        md = appcompat_to_markdown(result)
+        assert "libfoo.so.2" in md
+        # Weak mode: no old lib shown with arrow
+        assert "→" not in md
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+class TestAppcompatCLI:
+    def test_appcompat_help(self):
+        from click.testing import CliRunner
+        from abicheck.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["appcompat", "--help"])
+        assert result.exit_code == 0
+        assert "Check if an application is compatible" in result.output
+
+    def test_appcompat_missing_args(self):
+        from click.testing import CliRunner
+        from abicheck.cli import main
+
+        runner = CliRunner()
+        # No arguments at all
+        result = runner.invoke(main, ["appcompat"])
+        assert result.exit_code != 0
+
+    def test_appcompat_weak_mode_with_positional_fails(self, tmp_path):
+        from click.testing import CliRunner
+        from abicheck.cli import main
+
+        app = tmp_path / "app"
+        app.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        lib1 = tmp_path / "lib1.so"
+        lib1.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        lib2 = tmp_path / "lib2.so"
+        lib2.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "appcompat", str(app), str(lib1), str(lib2),
+            "--check-against", str(lib2),
+        ])
+        assert result.exit_code != 0
+        assert "cannot be used with" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Integration-ish: _is_relevant_to_app with realistic change sets
+# ---------------------------------------------------------------------------
+
+class TestFilteringIntegration:
+    """Test that filtering correctly partitions changes."""
+
+    def test_mixed_changes_partitioned(self):
+        app = AppRequirements(
+            undefined_symbols={"foo_init", "foo_process"},
+        )
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="foo_init", description="removed"),
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="bar_init", description="removed"),
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="baz_new", description="added"),
+            Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Config",
+                   description="size changed", affected_symbols=["foo_process"]),
+            Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Internal",
+                   description="size changed", affected_symbols=["bar_helper"]),
+        ]
+
+        relevant = [c for c in changes if _is_relevant_to_app(c, app)]
+        irrelevant = [c for c in changes if not _is_relevant_to_app(c, app)]
+
+        assert len(relevant) == 2  # foo_init removed + Config size (affects foo_process)
+        assert len(irrelevant) == 3  # bar_init removed + baz_new added + Internal size
+        assert relevant[0].symbol == "foo_init"
+        assert relevant[1].symbol == "Config"

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -959,6 +959,72 @@ class TestParseElfAppRequirements:
         # Falls back to ver_ndx=1 (unversioned), then _guess_symbol_origin=None → include
         assert "some_func" in reqs.undefined_symbols
 
+    def test_elf_versym_string_ndx(self, tmp_path):
+        """pyelftools returns string ndx like 'VER_NDX_GLOBAL' for special indices."""
+        from elftools.elf.gnuversions import GNUVerSymSection
+        from elftools.elf.sections import SymbolTableSection
+
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        mock_versym = MagicMock(spec=GNUVerSymSection)
+        mock_ver_entry = MagicMock()
+        mock_ver_entry.entry = {"ndx": "VER_NDX_GLOBAL"}  # string, not int
+        mock_versym.get_symbol.return_value = mock_ver_entry
+
+        mock_sym = MagicMock()
+        mock_sym.entry.st_shndx = "SHN_UNDEF"
+        mock_sym.name = "my_func"
+        mock_sym.entry.st_info.bind = "STB_GLOBAL"
+
+        mock_dynsym = MagicMock(spec=SymbolTableSection)
+        mock_dynsym.name = ".dynsym"
+        mock_dynsym.iter_symbols.return_value = [mock_sym]
+
+        sections = [mock_versym, mock_dynsym]
+        mock_elf = MagicMock()
+        mock_elf.iter_sections.return_value = sections
+
+        with patch("elftools.elf.elffile.ELFFile", return_value=mock_elf):
+            with patch("abicheck.elf_metadata._guess_symbol_origin", return_value=None):
+                reqs = _parse_elf_app_requirements(f, "libfoo.so.1")
+
+        # String ndx mapped to 1 (unversioned), unknown origin, STB_GLOBAL → included
+        assert "my_func" in reqs.undefined_symbols
+
+    def test_elf_weak_unversioned_excluded(self, tmp_path):
+        """Weak undefined symbols with unknown origin are excluded (optional linker refs)."""
+        from elftools.elf.gnuversions import GNUVerSymSection
+        from elftools.elf.sections import SymbolTableSection
+
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        mock_versym = MagicMock(spec=GNUVerSymSection)
+        mock_ver_entry = MagicMock()
+        mock_ver_entry.entry = {"ndx": "VER_NDX_GLOBAL"}
+        mock_versym.get_symbol.return_value = mock_ver_entry
+
+        mock_sym = MagicMock()
+        mock_sym.entry.st_shndx = "SHN_UNDEF"
+        mock_sym.name = "__gmon_start__"
+        mock_sym.entry.st_info.bind = "STB_WEAK"
+
+        mock_dynsym = MagicMock(spec=SymbolTableSection)
+        mock_dynsym.name = ".dynsym"
+        mock_dynsym.iter_symbols.return_value = [mock_sym]
+
+        sections = [mock_versym, mock_dynsym]
+        mock_elf = MagicMock()
+        mock_elf.iter_sections.return_value = sections
+
+        with patch("elftools.elf.elffile.ELFFile", return_value=mock_elf):
+            with patch("abicheck.elf_metadata._guess_symbol_origin", return_value=None):
+                reqs = _parse_elf_app_requirements(f, "libfoo.so.1")
+
+        # STB_WEAK + unknown origin → excluded (optional linker symbol)
+        assert "__gmon_start__" not in reqs.undefined_symbols
+
     def test_elf_no_library_filter(self, tmp_path):
         """When library_soname is empty, all UNDEF symbols are included."""
         from elftools.elf.sections import SymbolTableSection

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -16,23 +16,16 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
-
-import pytest
 
 from abicheck.appcompat import (
     AppCompatResult,
     AppRequirements,
     _detect_app_format,
     _is_relevant_to_app,
-    check_against,
-    check_appcompat,
-    parse_app_requirements,
 )
 from abicheck.checker import Change, DiffResult
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.reporter import appcompat_to_json, appcompat_to_markdown
-
 
 # ---------------------------------------------------------------------------
 # Unit tests: AppRequirements / AppCompatResult data structures
@@ -144,7 +137,7 @@ class TestIsRelevantToApp:
             kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
             symbol="FOO_1.0",
             description="Symbol version removed",
-            old_value="libfoo.so.1",
+            old_value="FOO_1.0",
         )
         assert _is_relevant_to_app(change, app) is True
 
@@ -156,7 +149,7 @@ class TestIsRelevantToApp:
             kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
             symbol="FOO_2.0",
             description="Symbol version removed",
-            old_value="libfoo.so.1",
+            old_value="FOO_2.0",
         )
         assert _is_relevant_to_app(change, app) is False
 
@@ -205,6 +198,16 @@ class TestAppCompatResultVerdict:
             old_lib_path="old.so",
             new_lib_path="new.so",
             missing_symbols=["foo_init"],
+            verdict=Verdict.BREAKING,
+        )
+        assert result.verdict == Verdict.BREAKING
+
+    def test_missing_versions_means_breaking(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            missing_versions=["FOO_1.0"],
             verdict=Verdict.BREAKING,
         )
         assert result.verdict == Verdict.BREAKING
@@ -346,6 +349,7 @@ class TestAppCompatReporters:
 class TestAppcompatCLI:
     def test_appcompat_help(self):
         from click.testing import CliRunner
+
         from abicheck.cli import main
 
         runner = CliRunner()
@@ -355,6 +359,7 @@ class TestAppcompatCLI:
 
     def test_appcompat_missing_args(self):
         from click.testing import CliRunner
+
         from abicheck.cli import main
 
         runner = CliRunner()
@@ -364,6 +369,7 @@ class TestAppcompatCLI:
 
     def test_appcompat_weak_mode_with_positional_fails(self, tmp_path):
         from click.testing import CliRunner
+
         from abicheck.cli import main
 
         app = tmp_path / "app"

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -16,12 +16,24 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from abicheck.appcompat import (
     AppCompatResult,
     AppRequirements,
     _detect_app_format,
+    _get_lib_soname,
+    _get_new_lib_exports,
     _is_relevant_to_app,
+    _parse_elf_app_requirements,
+    _parse_macho_app_requirements,
+    _parse_pe_app_requirements,
+    check_against,
+    check_appcompat,
+    parse_app_requirements,
 )
 from abicheck.checker import Change, DiffResult
 from abicheck.checker_policy import ChangeKind, Verdict
@@ -416,3 +428,1043 @@ class TestFilteringIntegration:
         assert len(irrelevant) == 3  # bar_init removed + baz_new added + Internal size
         assert relevant[0].symbol == "foo_init"
         assert relevant[1].symbol == "Config"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _detect_app_format edge cases
+# ---------------------------------------------------------------------------
+
+class TestDetectAppFormatEdgeCases:
+    def test_directory_returns_none(self, tmp_path):
+        """Directories are not regular files."""
+        assert _detect_app_format(tmp_path) is None
+
+    def test_all_macho_magics(self, tmp_path):
+        """All recognized Mach-O magic bytes should return 'macho'."""
+        magics = [
+            b"\xfe\xed\xfa\xce", b"\xce\xfa\xed\xfe",
+            b"\xfe\xed\xfa\xcf", b"\xcf\xfa\xed\xfe",
+            b"\xca\xfe\xba\xbe", b"\xbe\xba\xfe\xca",
+            b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca",
+        ]
+        for i, magic in enumerate(magics):
+            f = tmp_path / f"app_{i}.macho"
+            f.write_bytes(magic + b"\x00" * 100)
+            assert _detect_app_format(f) == "macho"
+
+    def test_pe_without_pe_signature(self, tmp_path):
+        """MZ magic but no PE signature → still returns 'pe' (MZ detected)."""
+        f = tmp_path / "app.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+        assert _detect_app_format(f) == "pe"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: parse_app_requirements dispatch
+# ---------------------------------------------------------------------------
+
+class TestParseAppRequirements:
+    def test_unknown_format_raises(self, tmp_path):
+        f = tmp_path / "unknown.bin"
+        f.write_bytes(b"\x00\x00\x00\x00")
+        with pytest.raises(ValueError, match="Cannot detect binary format"):
+            parse_app_requirements(f, "libfoo.so")
+
+    def test_elf_dispatch(self, tmp_path):
+        """ELF format dispatches to _parse_elf_app_requirements."""
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        with patch("abicheck.appcompat._parse_elf_app_requirements") as mock:
+            mock.return_value = AppRequirements()
+            result = parse_app_requirements(f, "libfoo.so")
+            mock.assert_called_once_with(f, "libfoo.so")
+            assert isinstance(result, AppRequirements)
+
+    def test_pe_dispatch(self, tmp_path):
+        f = tmp_path / "app.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+        with patch("abicheck.appcompat._parse_pe_app_requirements") as mock:
+            mock.return_value = AppRequirements()
+            result = parse_app_requirements(f, "foo.dll")
+            mock.assert_called_once_with(f, "foo.dll")
+            assert isinstance(result, AppRequirements)
+
+    def test_macho_dispatch(self, tmp_path):
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+        with patch("abicheck.appcompat._parse_macho_app_requirements") as mock:
+            mock.return_value = AppRequirements()
+            result = parse_app_requirements(f, "libfoo.dylib")
+            mock.assert_called_once_with(f, "libfoo.dylib")
+            assert isinstance(result, AppRequirements)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_pe_app_requirements with mocks
+# ---------------------------------------------------------------------------
+
+class TestParsePeAppRequirements:
+    def _make_imp(self, name=None, ordinal=0, import_by_ordinal=False):
+        imp = SimpleNamespace()
+        imp.name = name
+        imp.ordinal = ordinal
+        imp.import_by_ordinal = import_by_ordinal
+        return imp
+
+    def _make_entry(self, dll_name, imports):
+        entry = SimpleNamespace()
+        entry.dll = dll_name.encode("utf-8")
+        entry.imports = imports
+        return entry
+
+    def test_named_imports(self, tmp_path):
+        f = tmp_path / "app.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+
+        imp1 = self._make_imp(name=b"CreateWidget")
+        imp2 = self._make_imp(name=b"DestroyWidget")
+        entry = self._make_entry("widget.dll", [imp1, imp2])
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_IMPORT = [entry]
+
+        with patch("pefile.PE", return_value=mock_pe):
+            with patch("pefile.DIRECTORY_ENTRY", {"IMAGE_DIRECTORY_ENTRY_IMPORT": 1}):
+                reqs = _parse_pe_app_requirements(f, "widget.dll")
+
+        assert "CreateWidget" in reqs.undefined_symbols
+        assert "DestroyWidget" in reqs.undefined_symbols
+        assert "widget.dll" in reqs.needed_libs
+
+    def test_ordinal_only_imports(self, tmp_path):
+        f = tmp_path / "app.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+
+        imp = self._make_imp(name=None, ordinal=42, import_by_ordinal=True)
+        entry = self._make_entry("mylib.dll", [imp])
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_IMPORT = [entry]
+
+        with patch("pefile.PE", return_value=mock_pe):
+            with patch("pefile.DIRECTORY_ENTRY", {"IMAGE_DIRECTORY_ENTRY_IMPORT": 1}):
+                reqs = _parse_pe_app_requirements(f, "mylib.dll")
+
+        assert "ordinal:42" in reqs.undefined_symbols
+
+    def test_filter_by_dll_name(self, tmp_path):
+        f = tmp_path / "app.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+
+        imp1 = self._make_imp(name=b"FooFunc")
+        imp2 = self._make_imp(name=b"BarFunc")
+        entry_foo = self._make_entry("foo.dll", [imp1])
+        entry_bar = self._make_entry("bar.dll", [imp2])
+
+        mock_pe = MagicMock()
+        mock_pe.DIRECTORY_ENTRY_IMPORT = [entry_foo, entry_bar]
+
+        with patch("pefile.PE", return_value=mock_pe):
+            with patch("pefile.DIRECTORY_ENTRY", {"IMAGE_DIRECTORY_ENTRY_IMPORT": 1}):
+                reqs = _parse_pe_app_requirements(f, "foo.dll")
+
+        assert "FooFunc" in reqs.undefined_symbols
+        assert "BarFunc" not in reqs.undefined_symbols
+        # Both DLLs still in needed_libs
+        assert len(reqs.needed_libs) == 2
+
+    def test_pe_parse_error(self, tmp_path):
+        f = tmp_path / "bad.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+
+        with patch("pefile.PE", side_effect=Exception("bad PE")):
+            reqs = _parse_pe_app_requirements(f, "foo.dll")
+
+        assert reqs.undefined_symbols == set()
+
+    def test_no_import_directory(self, tmp_path):
+        f = tmp_path / "app.exe"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+
+        mock_pe = MagicMock(spec=[])  # No DIRECTORY_ENTRY_IMPORT attribute
+        mock_pe.parse_data_directories = MagicMock()
+        mock_pe.close = MagicMock()
+
+        with patch("pefile.PE", return_value=mock_pe):
+            with patch("pefile.DIRECTORY_ENTRY", {"IMAGE_DIRECTORY_ENTRY_IMPORT": 1}):
+                reqs = _parse_pe_app_requirements(f, "foo.dll")
+
+        assert reqs.undefined_symbols == set()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_macho_app_requirements with mocks
+# ---------------------------------------------------------------------------
+
+class TestParseMachoAppRequirements:
+    def test_no_headers(self, tmp_path):
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        mock_macho = MagicMock()
+        mock_macho.headers = []
+
+        with patch("macholib.MachO.MachO", return_value=mock_macho):
+            reqs = _parse_macho_app_requirements(f, "libfoo.dylib")
+
+        assert reqs.undefined_symbols == set()
+
+    def test_with_symbols(self, tmp_path):
+        """Test extraction of undefined symbols with library ordinal filtering."""
+        from macholib.mach_o import LC_LOAD_DYLIB, N_EXT, N_UNDF
+
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        # Build load commands: one LC_LOAD_DYLIB for libfoo.dylib
+        lc = SimpleNamespace(cmd=LC_LOAD_DYLIB)
+        cmd = SimpleNamespace()
+        data = b"/usr/lib/libfoo.dylib\x00"
+
+        header = MagicMock()
+        header.commands = [(lc, cmd, data)]
+
+        # Build symbol table entries
+        # Symbol from libfoo.dylib (ordinal=1)
+        nlist1 = SimpleNamespace(n_type=N_UNDF | N_EXT, n_desc=(1 << 8))
+        # Symbol from different lib (ordinal=2)
+        nlist2 = SimpleNamespace(n_type=N_UNDF | N_EXT, n_desc=(2 << 8))
+
+        mock_symtab = MagicMock()
+        mock_symtab.undefsyms = [
+            (nlist1, b"_foo_init"),
+            (nlist2, b"_bar_init"),
+        ]
+
+        mock_macho = MagicMock()
+        mock_macho.headers = [header]
+
+        with patch("macholib.MachO.MachO", return_value=mock_macho):
+            with patch("macholib.SymbolTable.SymbolTable", return_value=mock_symtab):
+                reqs = _parse_macho_app_requirements(f, "libfoo.dylib")
+
+        assert "foo_init" in reqs.undefined_symbols
+        assert "bar_init" not in reqs.undefined_symbols
+        assert "/usr/lib/libfoo.dylib" in reqs.needed_libs
+
+    def test_no_library_filter(self, tmp_path):
+        """When library_name is empty, all symbols are included."""
+        from macholib.mach_o import N_EXT, N_UNDF
+
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        header = MagicMock()
+        header.commands = []
+
+        nlist1 = SimpleNamespace(n_type=N_UNDF | N_EXT, n_desc=0)
+        nlist2 = SimpleNamespace(n_type=N_UNDF | N_EXT, n_desc=0)
+
+        mock_symtab = MagicMock()
+        mock_symtab.undefsyms = [
+            (nlist1, b"_foo_func"),
+            (nlist2, b"_bar_func"),
+        ]
+
+        mock_macho = MagicMock()
+        mock_macho.headers = [header]
+
+        with patch("macholib.MachO.MachO", return_value=mock_macho):
+            with patch("macholib.SymbolTable.SymbolTable", return_value=mock_symtab):
+                reqs = _parse_macho_app_requirements(f, "")
+
+        assert "foo_func" in reqs.undefined_symbols
+        assert "bar_func" in reqs.undefined_symbols
+
+    def test_symtab_failure(self, tmp_path):
+        """SymbolTable failure is caught, returns empty symbols."""
+        from macholib.mach_o import LC_LOAD_DYLIB
+
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        lc = SimpleNamespace(cmd=LC_LOAD_DYLIB)
+        data = b"libfoo.dylib\x00"
+        header = MagicMock()
+        header.commands = [(lc, SimpleNamespace(), data)]
+
+        mock_macho = MagicMock()
+        mock_macho.headers = [header]
+
+        with patch("macholib.MachO.MachO", return_value=mock_macho):
+            with patch("macholib.SymbolTable.SymbolTable", side_effect=Exception("fail")):
+                reqs = _parse_macho_app_requirements(f, "libfoo.dylib")
+
+        assert reqs.undefined_symbols == set()
+        assert "libfoo.dylib" in reqs.needed_libs
+
+    def test_nlists_fallback(self, tmp_path):
+        """When undefsyms is None, falls back to nlists with manual filtering."""
+        from macholib.mach_o import N_EXT, N_SECT, N_UNDF
+
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        header = MagicMock()
+        header.commands = []
+
+        # Undefined external symbol
+        nlist_undef = SimpleNamespace(n_type=N_UNDF | N_EXT, n_desc=0)
+        # Defined external symbol (N_SECT | N_EXT → should be skipped)
+        nlist_def = SimpleNamespace(n_type=N_SECT | N_EXT, n_desc=0)
+
+        mock_symtab = MagicMock()
+        mock_symtab.undefsyms = None
+        mock_symtab.nlists = [
+            (nlist_undef, b"_foo_func"),
+            (nlist_def, b"_bar_defined"),
+        ]
+
+        mock_macho = MagicMock()
+        mock_macho.headers = [header]
+
+        with patch("macholib.MachO.MachO", return_value=mock_macho):
+            with patch("macholib.SymbolTable.SymbolTable", return_value=mock_symtab):
+                reqs = _parse_macho_app_requirements(f, "")
+
+        assert "foo_func" in reqs.undefined_symbols
+        assert "bar_defined" not in reqs.undefined_symbols
+
+    def test_data_no_null_terminator(self, tmp_path):
+        """Data without null terminator uses full length."""
+        from macholib.mach_o import LC_LOAD_DYLIB
+
+        f = tmp_path / "app.macho"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        lc = SimpleNamespace(cmd=LC_LOAD_DYLIB)
+        data = b"libfoo.dylib"  # No null terminator
+
+        header = MagicMock()
+        header.commands = [(lc, SimpleNamespace(), data)]
+
+        mock_macho = MagicMock()
+        mock_macho.headers = [header]
+
+        with patch("macholib.MachO.MachO", return_value=mock_macho):
+            with patch("macholib.SymbolTable.SymbolTable", side_effect=Exception("skip")):
+                reqs = _parse_macho_app_requirements(f, "libfoo.dylib")
+
+        assert "libfoo.dylib" in reqs.needed_libs
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_elf_app_requirements with mocks
+# ---------------------------------------------------------------------------
+
+class TestParseElfAppRequirements:
+    def test_elf_parse_error(self, tmp_path):
+        f = tmp_path / "bad.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        from elftools.common.exceptions import ELFError
+
+        with patch("elftools.elf.elffile.ELFFile", side_effect=ELFError("bad")):
+            reqs = _parse_elf_app_requirements(f, "libfoo.so")
+
+        assert reqs.undefined_symbols == set()
+
+    def test_elf_os_error(self, tmp_path):
+        f = tmp_path / "missing.elf"  # doesn't exist
+        reqs = _parse_elf_app_requirements(f, "libfoo.so")
+        assert reqs.undefined_symbols == set()
+
+    def test_elf_full_parsing(self, tmp_path):
+        """Test ELF parsing with mocked pyelftools sections."""
+        from elftools.elf.dynamic import DynamicSection
+        from elftools.elf.gnuversions import GNUVerNeedSection, GNUVerSymSection
+        from elftools.elf.sections import SymbolTableSection
+
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        # Mock DT_NEEDED tag
+        mock_tag = MagicMock()
+        mock_tag.entry.d_tag = "DT_NEEDED"
+        mock_tag.needed = "libfoo.so.1"
+
+        mock_other_tag = MagicMock()
+        mock_other_tag.entry.d_tag = "DT_NULL"
+
+        # Mock DynamicSection
+        mock_dynamic = MagicMock(spec=DynamicSection)
+        mock_dynamic.iter_tags.return_value = [mock_tag, mock_other_tag]
+
+        # Mock GNUVerNeedSection
+        mock_vernaux = MagicMock()
+        mock_vernaux.entry.vna_other = 2
+        mock_vernaux.name = "FOO_1.0"
+
+        mock_verneed = MagicMock()
+        mock_verneed.name = "libfoo.so.1"
+
+        mock_verneed_section = MagicMock(spec=GNUVerNeedSection)
+        mock_verneed_section.iter_versions.return_value = [
+            (mock_verneed, [mock_vernaux]),
+        ]
+
+        # Mock GNUVerSymSection
+        mock_versym_section = MagicMock(spec=GNUVerSymSection)
+
+        # Symbol with version index 2 (from libfoo.so.1)
+        mock_ver_entry_2 = MagicMock()
+        mock_ver_entry_2.entry = {"ndx": 2}
+
+        # Symbol with version index 3 (from other lib)
+        mock_ver_entry_3 = MagicMock()
+        mock_ver_entry_3.entry = {"ndx": 3}
+
+        # Unversioned symbol (index 1)
+        mock_ver_entry_1 = MagicMock()
+        mock_ver_entry_1.entry = {"ndx": 1}
+
+        def get_symbol_side_effect(idx):
+            return [mock_ver_entry_2, mock_ver_entry_3, mock_ver_entry_1][idx]
+
+        mock_versym_section.get_symbol.side_effect = get_symbol_side_effect
+
+        # Mock SymbolTableSection (.dynsym)
+        mock_sym_from_foo = MagicMock()
+        mock_sym_from_foo.entry.st_shndx = "SHN_UNDEF"
+        mock_sym_from_foo.name = "foo_init"
+        mock_sym_from_foo.entry.st_info.bind = "STB_GLOBAL"
+
+        mock_sym_from_other = MagicMock()
+        mock_sym_from_other.entry.st_shndx = "SHN_UNDEF"
+        mock_sym_from_other.name = "bar_init"
+        mock_sym_from_other.entry.st_info.bind = "STB_GLOBAL"
+
+        mock_sym_unversioned = MagicMock()
+        mock_sym_unversioned.entry.st_shndx = "SHN_UNDEF"
+        mock_sym_unversioned.name = "unknown_func"
+        mock_sym_unversioned.entry.st_info.bind = "STB_GLOBAL"
+
+        # Non-UNDEF symbol (should be skipped)
+        mock_sym_defined = MagicMock()
+        mock_sym_defined.entry.st_shndx = 1  # defined section
+        mock_sym_defined.name = "defined_func"
+        mock_sym_defined.entry.st_info.bind = "STB_GLOBAL"
+
+        # Empty name symbol (should be skipped)
+        mock_sym_empty = MagicMock()
+        mock_sym_empty.entry.st_shndx = "SHN_UNDEF"
+        mock_sym_empty.name = ""
+        mock_sym_empty.entry.st_info.bind = "STB_GLOBAL"
+
+        # Local binding (should be skipped)
+        mock_sym_local = MagicMock()
+        mock_sym_local.entry.st_shndx = "SHN_UNDEF"
+        mock_sym_local.name = "local_func"
+        mock_sym_local.entry.st_info.bind = "STB_LOCAL"
+
+        mock_dynsym = MagicMock(spec=SymbolTableSection)
+        mock_dynsym.name = ".dynsym"
+        mock_dynsym.iter_symbols.return_value = [
+            mock_sym_from_foo,     # idx=0 → ver_entry_2 (from libfoo.so.1)
+            mock_sym_from_other,   # idx=1 → ver_entry_3 (from other lib)
+            mock_sym_unversioned,  # idx=2 → ver_entry_1 (unversioned)
+            mock_sym_defined,      # idx=3 → should be skipped (not UNDEF)
+            mock_sym_empty,        # idx=4 → should be skipped (empty name)
+            mock_sym_local,        # idx=5 → should be skipped (local binding)
+        ]
+
+        sections = [mock_dynamic, mock_verneed_section, mock_versym_section, mock_dynsym]
+
+        mock_elf = MagicMock()
+        mock_elf.iter_sections.return_value = sections
+
+        with patch("elftools.elf.elffile.ELFFile", return_value=mock_elf):
+            with patch("abicheck.elf_metadata._guess_symbol_origin", return_value=None):
+                reqs = _parse_elf_app_requirements(f, "libfoo.so.1")
+
+        assert "foo_init" in reqs.undefined_symbols
+        assert "bar_init" not in reqs.undefined_symbols  # from other lib
+        assert "unknown_func" in reqs.undefined_symbols  # unversioned, no known origin
+        assert "defined_func" not in reqs.undefined_symbols
+        assert "local_func" not in reqs.undefined_symbols
+        assert "libfoo.so.1" in reqs.needed_libs
+        assert "FOO_1.0" in reqs.required_versions
+
+    def test_elf_unversioned_symbol_from_known_lib(self, tmp_path):
+        """Unversioned symbol identified as from another lib should be excluded."""
+        from elftools.elf.gnuversions import GNUVerSymSection
+        from elftools.elf.sections import SymbolTableSection
+
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        mock_versym = MagicMock(spec=GNUVerSymSection)
+        mock_ver_entry = MagicMock()
+        mock_ver_entry.entry = {"ndx": 1}  # unversioned
+        mock_versym.get_symbol.return_value = mock_ver_entry
+
+        mock_sym = MagicMock()
+        mock_sym.entry.st_shndx = "SHN_UNDEF"
+        mock_sym.name = "printf"
+        mock_sym.entry.st_info.bind = "STB_GLOBAL"
+
+        mock_dynsym = MagicMock(spec=SymbolTableSection)
+        mock_dynsym.name = ".dynsym"
+        mock_dynsym.iter_symbols.return_value = [mock_sym]
+
+        sections = [mock_versym, mock_dynsym]
+        mock_elf = MagicMock()
+        mock_elf.iter_sections.return_value = sections
+
+        with patch("elftools.elf.elffile.ELFFile", return_value=mock_elf):
+            # _guess_symbol_origin returns "libc.so.6" → exclude this symbol
+            with patch("abicheck.elf_metadata._guess_symbol_origin", return_value="libc.so.6"):
+                reqs = _parse_elf_app_requirements(f, "libfoo.so.1")
+
+        assert "printf" not in reqs.undefined_symbols
+
+    def test_elf_versym_index_error(self, tmp_path):
+        """IndexError from get_symbol falls back to unversioned."""
+        from elftools.elf.gnuversions import GNUVerSymSection
+        from elftools.elf.sections import SymbolTableSection
+
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        mock_versym = MagicMock(spec=GNUVerSymSection)
+        mock_versym.get_symbol.side_effect = IndexError("out of range")
+
+        mock_sym = MagicMock()
+        mock_sym.entry.st_shndx = "SHN_UNDEF"
+        mock_sym.name = "some_func"
+        mock_sym.entry.st_info.bind = "STB_GLOBAL"
+
+        mock_dynsym = MagicMock(spec=SymbolTableSection)
+        mock_dynsym.name = ".dynsym"
+        mock_dynsym.iter_symbols.return_value = [mock_sym]
+
+        sections = [mock_versym, mock_dynsym]
+        mock_elf = MagicMock()
+        mock_elf.iter_sections.return_value = sections
+
+        with patch("elftools.elf.elffile.ELFFile", return_value=mock_elf):
+            with patch("abicheck.elf_metadata._guess_symbol_origin", return_value=None):
+                reqs = _parse_elf_app_requirements(f, "libfoo.so.1")
+
+        # Falls back to ver_ndx=1 (unversioned), then _guess_symbol_origin=None → include
+        assert "some_func" in reqs.undefined_symbols
+
+    def test_elf_no_library_filter(self, tmp_path):
+        """When library_soname is empty, all UNDEF symbols are included."""
+        from elftools.elf.sections import SymbolTableSection
+
+        f = tmp_path / "app.elf"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        mock_sym = MagicMock()
+        mock_sym.entry.st_shndx = "SHN_UNDEF"
+        mock_sym.name = "any_func"
+        mock_sym.entry.st_info.bind = "STB_GLOBAL"
+
+        mock_dynsym = MagicMock(spec=SymbolTableSection)
+        mock_dynsym.name = ".dynsym"
+        mock_dynsym.iter_symbols.return_value = [mock_sym]
+
+        mock_elf = MagicMock()
+        mock_elf.iter_sections.return_value = [mock_dynsym]
+
+        with patch("elftools.elf.elffile.ELFFile", return_value=mock_elf):
+            reqs = _parse_elf_app_requirements(f, "")
+
+        assert "any_func" in reqs.undefined_symbols
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _get_new_lib_exports
+# ---------------------------------------------------------------------------
+
+class TestGetNewLibExports:
+    def test_elf_exports(self, tmp_path):
+        from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+
+        f = tmp_path / "lib.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        meta = ElfMetadata(symbols=[ElfSymbol(name="foo"), ElfSymbol(name="bar")])
+        with patch("abicheck.elf_metadata.parse_elf_metadata", return_value=meta):
+            exports = _get_new_lib_exports(f)
+
+        assert exports == {"foo", "bar"}
+
+    def test_pe_exports(self, tmp_path):
+        from abicheck.pe_metadata import PeExport, PeMetadata
+
+        f = tmp_path / "lib.dll"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+
+        meta = PeMetadata(exports=[PeExport(name="CreateFoo"), PeExport(name="")])
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=meta):
+            exports = _get_new_lib_exports(f)
+
+        assert exports == {"CreateFoo"}
+
+    def test_macho_exports(self, tmp_path):
+        from abicheck.macho_metadata import MachoExport, MachoMetadata
+
+        f = tmp_path / "lib.dylib"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        meta = MachoMetadata(exports=[MachoExport(name="foo_init"), MachoExport(name="")])
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=meta):
+            exports = _get_new_lib_exports(f)
+
+        assert exports == {"foo_init"}
+
+    def test_unknown_format(self, tmp_path):
+        f = tmp_path / "lib.bin"
+        f.write_bytes(b"\x00\x00\x00\x00")
+        assert _get_new_lib_exports(f) == set()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _get_lib_soname
+# ---------------------------------------------------------------------------
+
+class TestGetLibSoname:
+    def test_elf_soname(self, tmp_path):
+        from abicheck.elf_metadata import ElfMetadata
+
+        f = tmp_path / "libfoo.so.1.2.3"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        meta = ElfMetadata(soname="libfoo.so.1")
+        with patch("abicheck.elf_metadata.parse_elf_metadata", return_value=meta):
+            assert _get_lib_soname(f) == "libfoo.so.1"
+
+    def test_elf_no_soname(self, tmp_path):
+        from abicheck.elf_metadata import ElfMetadata
+
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        meta = ElfMetadata(soname="")
+        with patch("abicheck.elf_metadata.parse_elf_metadata", return_value=meta):
+            assert _get_lib_soname(f) == "libfoo.so"
+
+    def test_pe_soname(self, tmp_path):
+        f = tmp_path / "foo.dll"
+        f.write_bytes(b"MZ" + b"\x00" * 100)
+        assert _get_lib_soname(f) == "foo.dll"
+
+    def test_macho_install_name(self, tmp_path):
+        from abicheck.macho_metadata import MachoMetadata
+
+        f = tmp_path / "libfoo.dylib"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        meta = MachoMetadata(install_name="/usr/lib/libfoo.1.dylib")
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=meta):
+            assert _get_lib_soname(f) == "/usr/lib/libfoo.1.dylib"
+
+    def test_macho_no_install_name(self, tmp_path):
+        from abicheck.macho_metadata import MachoMetadata
+
+        f = tmp_path / "libfoo.dylib"
+        f.write_bytes(b"\xfe\xed\xfa\xcf" + b"\x00" * 100)
+
+        meta = MachoMetadata(install_name="")
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=meta):
+            assert _get_lib_soname(f) == "libfoo.dylib"
+
+    def test_unknown_format(self, tmp_path):
+        f = tmp_path / "lib.bin"
+        f.write_bytes(b"\x00\x00\x00\x00")
+        assert _get_lib_soname(f) == "lib.bin"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: check_appcompat with mocks
+# ---------------------------------------------------------------------------
+
+class TestCheckAppcompat:
+    def _mock_deps(self, app_reqs, new_exports, diff, soname="libfoo.so.1"):
+        """Return patches for check_appcompat dependencies."""
+        return [
+            patch("abicheck.appcompat._get_lib_soname", return_value=soname),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.dumper.dump", return_value=MagicMock()),
+            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value=new_exports),
+            patch("abicheck.appcompat._detect_app_format", return_value=None),
+        ]
+
+    def test_compatible_no_changes(self, tmp_path):
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init", "foo_process"},
+        )
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+        new_exports = {"foo_init", "foo_process", "foo_cleanup"}
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert result.verdict == Verdict.COMPATIBLE
+        assert result.symbol_coverage == 100.0
+        assert result.missing_symbols == []
+
+    def test_missing_symbols_breaking(self, tmp_path):
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init", "foo_gone"},
+        )
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+        new_exports = {"foo_init"}  # foo_gone is missing
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert result.verdict == Verdict.BREAKING
+        assert "foo_gone" in result.missing_symbols
+        assert result.symbol_coverage == 50.0
+
+    def test_relevant_changes_verdict(self, tmp_path):
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init"},
+        )
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="foo_init",
+            description="removed",
+        )
+        diff = DiffResult(
+            old_version="1", new_version="2", library="libfoo",
+            changes=[change],
+        )
+        new_exports = {"foo_init"}  # still exported (e.g., diff reports signature change)
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert len(result.breaking_for_app) == 1
+        assert result.verdict == Verdict.BREAKING
+
+    def test_irrelevant_changes_compatible(self, tmp_path):
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init"},
+        )
+        change = Change(
+            kind=ChangeKind.FUNC_ADDED,
+            symbol="bar_new",
+            description="added",
+        )
+        diff = DiffResult(
+            old_version="1", new_version="2", library="libfoo",
+            changes=[change],
+        )
+        new_exports = {"foo_init", "bar_new"}
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert result.verdict == Verdict.COMPATIBLE
+        assert len(result.irrelevant_for_app) == 1
+
+    def test_no_required_symbols_no_change(self, tmp_path):
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols=set())
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+        new_exports = {"foo_init"}
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_no_exports_zero_coverage(self, tmp_path):
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols={"foo_init"})
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+        new_exports: set[str] = set()  # No exports at all
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert result.symbol_coverage == 0.0
+
+    def test_policy_file_used_for_verdict(self, tmp_path):
+        """When policy_file is provided, it's used for verdict computation."""
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols={"foo_init"})
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="foo_init",
+            description="removed",
+        )
+        diff = DiffResult(
+            old_version="1", new_version="2", library="libfoo",
+            changes=[change],
+        )
+        new_exports = {"foo_init"}
+
+        mock_pf = MagicMock()
+        mock_pf.compute_verdict.return_value = Verdict.COMPATIBLE_WITH_RISK
+
+        patches = self._mock_deps(app_reqs, new_exports, diff)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = check_appcompat(
+                app, old_lib, new_lib, policy_file=mock_pf,
+            )
+
+        assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+        mock_pf.compute_verdict.assert_called_once()
+
+    def test_missing_versions_breaking(self, tmp_path):
+        """Missing ELF versions should result in BREAKING verdict."""
+        from abicheck.elf_metadata import ElfMetadata
+
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init"},
+            required_versions={"FOO_1.0": "libfoo.so"},
+        )
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+        new_exports = {"foo_init"}
+        elf_meta = ElfMetadata(versions_defined=["FOO_2.0"])
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="libfoo.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.dumper.dump", return_value=MagicMock()),
+            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value=new_exports),
+            patch("abicheck.appcompat._detect_app_format", return_value="elf"),
+            patch("abicheck.elf_metadata.parse_elf_metadata", return_value=elf_meta),
+        ):
+            result = check_appcompat(app, old_lib, new_lib)
+
+        assert result.verdict == Verdict.BREAKING
+        assert "FOO_1.0" in result.missing_versions
+
+    def test_lang_c(self, tmp_path):
+        """Test lang='c' passes correct compiler."""
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols=set())
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+        new_exports: set[str] = set()
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="libfoo.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.dumper.dump", return_value=MagicMock()) as mock_dump,
+            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value=new_exports),
+            patch("abicheck.appcompat._detect_app_format", return_value=None),
+        ):
+            check_appcompat(app, old_lib, new_lib, lang="c")
+            # verify dump was called with compiler="cc" and lang="c"
+            for call in mock_dump.call_args_list:
+                assert call.kwargs.get("compiler") == "cc"
+                assert call.kwargs.get("lang") == "c"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: check_against with mocks
+# ---------------------------------------------------------------------------
+
+class TestCheckAgainst:
+    def test_compatible(self, tmp_path):
+        app = tmp_path / "app"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols={"foo_init"})
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="new.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value={"foo_init"}),
+            patch("abicheck.appcompat._detect_app_format", return_value=None),
+        ):
+            result = check_against(app, new_lib)
+
+        assert result.verdict == Verdict.COMPATIBLE
+        assert result.symbol_coverage == 100.0
+        assert result.old_lib_path == ""
+
+    def test_missing_symbols_breaking(self, tmp_path):
+        app = tmp_path / "app"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init", "foo_missing"},
+        )
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="new.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value={"foo_init"}),
+            patch("abicheck.appcompat._detect_app_format", return_value=None),
+        ):
+            result = check_against(app, new_lib)
+
+        assert result.verdict == Verdict.BREAKING
+        assert "foo_missing" in result.missing_symbols
+        assert result.symbol_coverage == 50.0
+
+    def test_missing_versions_breaking(self, tmp_path):
+        from abicheck.elf_metadata import ElfMetadata
+
+        app = tmp_path / "app"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(
+            undefined_symbols={"foo_init"},
+            required_versions={"FOO_1.0": "libfoo.so"},
+        )
+
+        elf_meta = ElfMetadata(versions_defined=["FOO_2.0"])  # FOO_1.0 missing
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="new.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value={"foo_init"}),
+            patch("abicheck.appcompat._detect_app_format", return_value="elf"),
+            patch("abicheck.elf_metadata.parse_elf_metadata", return_value=elf_meta),
+        ):
+            result = check_against(app, new_lib)
+
+        assert result.verdict == Verdict.BREAKING
+        assert "FOO_1.0" in result.missing_versions
+
+    def test_no_exports_zero_coverage(self, tmp_path):
+        app = tmp_path / "app"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols={"foo_init"})
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="new.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value=set()),
+            patch("abicheck.appcompat._detect_app_format", return_value=None),
+        ):
+            result = check_against(app, new_lib)
+
+        assert result.symbol_coverage == 0.0
+
+    def test_no_required_symbols(self, tmp_path):
+        app = tmp_path / "app"
+        new_lib = tmp_path / "new.so"
+
+        app_reqs = AppRequirements(undefined_symbols=set())
+
+        with (
+            patch("abicheck.appcompat._get_lib_soname", return_value="new.so"),
+            patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
+            patch("abicheck.appcompat._get_new_lib_exports", return_value={"foo"}),
+            patch("abicheck.appcompat._detect_app_format", return_value=None),
+        ):
+            result = check_against(app, new_lib)
+
+        assert result.verdict == Verdict.COMPATIBLE
+        assert result.symbol_coverage == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Reporter edge cases
+# ---------------------------------------------------------------------------
+
+class TestReporterEdgeCases:
+    def test_json_missing_versions(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            missing_versions=["FOO_1.0"],
+            verdict=Verdict.BREAKING,
+        )
+        j = appcompat_to_json(result)
+        data = json.loads(j)
+        assert "FOO_1.0" in data["missing_versions"]
+
+    def test_markdown_missing_versions(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            missing_versions=["FOO_1.0"],
+            verdict=Verdict.BREAKING,
+        )
+        md = appcompat_to_markdown(result)
+        assert "Missing Symbol Versions" in md
+        assert "FOO_1.0" in md
+
+    def test_json_full_diff_verdict(self):
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            full_diff=DiffResult(
+                old_version="1", new_version="2",
+                library="libfoo", verdict=Verdict.BREAKING,
+            ),
+            verdict=Verdict.COMPATIBLE,
+        )
+        j = appcompat_to_json(result)
+        data = json.loads(j)
+        assert data["full_library_verdict"] == "BREAKING"
+
+    def test_markdown_no_changes_message(self):
+        change = Change(
+            kind=ChangeKind.FUNC_ADDED, symbol="x", description="added",
+        )
+        result = AppCompatResult(
+            app_path="/usr/bin/myapp",
+            old_lib_path="old.so",
+            new_lib_path="new.so",
+            irrelevant_for_app=[change],
+            verdict=Verdict.COMPATIBLE,
+        )
+        md = appcompat_to_markdown(result)
+        assert "0 of 1 total" in md
+        assert "do NOT affect" in md


### PR DESCRIPTION
## Summary

Implement application compatibility checking to answer "Will my application still work with the new library version?" by analyzing app binary requirements and intersecting them with library ABI changes.

## Motivation

Closes #ADR-005. Users need to know if their applications will continue to work when updating a library dependency. This feature:
- Parses application binaries (ELF, PE, Mach-O) to extract required symbols and versions
- Compares against library ABI changes to identify breaking changes relevant to the app
- Provides app-specific verdicts and symbol coverage metrics
- Supports both full comparison mode (old vs new library) and weak mode (symbol availability check only)

## Changes

- **New module `abicheck/appcompat.py`**: Core application compatibility checking
  - `AppRequirements` and `AppCompatResult` data structures
  - Binary format detection (ELF, PE, Mach-O)
  - Symbol extraction from application binaries:
    - ELF: reads `.dynsym` for undefined symbols, `.gnu.version_r` for required versions
    - PE: parses import tables via `pefile`
    - Mach-O: extracts undefined symbols via `macholib`
  - `check_appcompat()`: Full comparison mode (requires old and new library)
  - `check_against()`: Weak mode (symbol availability check only)
  - Change filtering to identify which library ABI changes affect the app's symbols

- **New test suite `tests/test_appcompat.py`**: Comprehensive test coverage
  - Data structure tests
  - Binary format detection tests
  - Change relevance filtering tests
  - Reporter integration tests
  - CLI smoke tests

- **Enhanced `abicheck/reporter.py`**: Application compatibility reporters
  - `appcompat_to_json()`: JSON output with verdict, symbol coverage, relevant/irrelevant changes
  - `appcompat_to_markdown()`: Human-readable markdown report with symbol coverage section

- **New CLI command `abicheck appcompat`** in `abicheck/cli.py`
  - Full mode: `abicheck appcompat myapp libfoo.so.1 libfoo.so.2 -H include/foo.h`
  - Weak mode: `abicheck appcompat myapp --check-against libfoo.so.2`
  - Options for headers, includes, language, suppression, policy
  - `--list-required-symbols` to inspect app requirements
  - `--show-irrelevant` to display library changes not affecting the app
  - Exit codes: 0 (COMPATIBLE), 2 (API_BREAK), 4 (BREAKING)

## Checklist

- [x] Tests added for new behaviour (412 lines of comprehensive unit and integration tests)
- [x] No `CHANGELOG.md` update needed (ADR implementation, not user-facing release)
- [x] Docs referenced in module docstring (ADR-005 design document)
- [x] New dependencies properly imported with type hints and error handling
- [x] No new mypy or ruff errors introduced

https://claude.ai/code/session_01CaavoGxqCEDthquRrQr8ng

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an application compatibility checker with full and weak-mode checks and CLI command, plus JSON/Markdown output and exit-code mapping.
  * Reporters now include app-centric summaries: symbol coverage, missing symbols/versions, and option to hide irrelevant changes.

* **Documentation**
  * New user guide and reference pages for application compatibility; README and exit-code docs updated; navigation added.

* **Tests**
  * Large end-to-end test suite covering parsing, relevance logic, verdicts, reporters, and CLI behavior.

* **Chores**
  * Type-check config updated to include the new module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->