### PR TITLE
Add BTF and CTF debug format parsers for kernel ABI analysis

### DIFF
--- a/abicheck/btf_metadata.py
+++ b/abicheck/btf_metadata.py
@@ -177,7 +177,7 @@ def _read_btf_section(elf_path: Path) -> bytes | None:
         section = elf.get_section_by_name(".BTF")  # type: ignore[no-untyped-call]
         if section is None:
             return None
-        return section.data()  # type: ignore[no-untyped-call]
+        return bytes(section.data())
 
 
 # ---------------------------------------------------------------------------
@@ -424,7 +424,7 @@ class _TypeResolver:
         if kind == BTF_KIND_INT:
             # INT encoding: bits 0-7 = nr_bits, bits 8-15 = unused, bits 16-23 = offset
             if len(t.extra) >= 4:
-                enc = struct.unpack_from("<I", t.extra, 0)[0]
+                enc: int = struct.unpack_from("<I", t.extra, 0)[0]
                 nr_bits = enc & 0xFF
                 return (nr_bits + 7) // 8
             return t.size_or_type
@@ -437,6 +437,8 @@ class _TypeResolver:
 
         if kind == BTF_KIND_ARRAY:
             if len(t.extra) >= 12:
+                elem_type: int
+                nelems: int
                 elem_type, _, nelems = struct.unpack_from("<III", t.extra, 0)
                 return self.size(elem_type) * nelems
             return 0

--- a/abicheck/btf_metadata.py
+++ b/abicheck/btf_metadata.py
@@ -1,0 +1,708 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BTF (BPF Type Format) parser for Linux kernel ABI analysis.
+
+Pure-Python implementation using only the ``struct`` module — no external
+dependencies beyond pyelftools (for ELF section access).
+
+BTF is a compact, pre-deduplicated type format used by Linux kernel 5.x+
+and eBPF programs.  It is often the **only** debug format available in
+production kernel builds (DWARF stripped, BTF kept).
+
+Reference: ``include/uapi/linux/btf.h`` in the Linux kernel source.
+
+Public API
+----------
+parse_btf_metadata(elf_path)
+    → BtfMetadata (implements TypeMetadataSource protocol)
+
+has_btf_section(elf_path)
+    → bool  (quick check without full parse)
+"""
+from __future__ import annotations
+
+import logging
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# BTF constants (from include/uapi/linux/btf.h)
+# ---------------------------------------------------------------------------
+
+BTF_MAGIC = 0xEB9F
+BTF_VERSION = 1
+
+# BTF type kinds (bits 24-28 of btf_type.info)
+BTF_KIND_VOID = 0
+BTF_KIND_INT = 1
+BTF_KIND_PTR = 2
+BTF_KIND_ARRAY = 3
+BTF_KIND_STRUCT = 4
+BTF_KIND_UNION = 5
+BTF_KIND_ENUM = 6
+BTF_KIND_FWD = 7
+BTF_KIND_TYPEDEF = 8
+BTF_KIND_VOLATILE = 9
+BTF_KIND_CONST = 10
+BTF_KIND_RESTRICT = 11
+BTF_KIND_FUNC = 12
+BTF_KIND_FUNC_PROTO = 13
+BTF_KIND_VAR = 14
+BTF_KIND_DATASEC = 15
+BTF_KIND_FLOAT = 16
+BTF_KIND_DECL_TAG = 17
+BTF_KIND_TYPE_TAG = 18
+BTF_KIND_ENUM64 = 19
+
+# BTF_INT encoding bits
+BTF_INT_SIGNED = 1 << 0
+BTF_INT_CHAR = 1 << 1
+BTF_INT_BOOL = 1 << 2
+
+# Header size
+_BTF_HEADER_SIZE = 24  # magic(2) + version(1) + flags(1) + hdr_len(4) + type_off/len(4+4) + str_off/len(4+4)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BtfType:
+    """Raw parsed BTF type entry."""
+    type_id: int
+    name_off: int
+    info: int       # kind(5) | vlen(16) | kflag(1)
+    size_or_type: int
+    extra: bytes    # kind-specific trailing data
+
+    @property
+    def kind(self) -> int:
+        return (self.info >> 24) & 0x1F
+
+    @property
+    def vlen(self) -> int:
+        return self.info & 0xFFFF
+
+    @property
+    def kflag(self) -> int:
+        return (self.info >> 31) & 1
+
+
+@dataclass
+class FuncProto:
+    """Function prototype extracted from BTF."""
+    name: str
+    return_type: str
+    params: list[tuple[str, str]]  # [(param_name, param_type), ...]
+
+
+@dataclass
+class BtfMetadata:
+    """BTF-derived ABI-relevant type information.
+
+    Implements the same interface as DwarfMetadata so the checker's
+    detectors work without modification (TypeMetadataSource protocol).
+    """
+    structs: dict[str, StructLayout] = field(default_factory=dict)
+    enums: dict[str, EnumInfo] = field(default_factory=dict)
+    func_protos: dict[str, FuncProto] = field(default_factory=dict)
+    typedefs: dict[str, str] = field(default_factory=dict)
+    has_btf: bool = False
+    type_count: int = 0
+
+    # TypeMetadataSource protocol
+    @property
+    def has_data(self) -> bool:
+        return self.has_btf
+
+    def get_struct_layout(self, name: str) -> StructLayout | None:
+        return self.structs.get(name)
+
+    def get_enum_info(self, name: str) -> EnumInfo | None:
+        return self.enums.get(name)
+
+    def get_function_proto(self, name: str) -> FuncProto | None:
+        return self.func_protos.get(name)
+
+    def get_typedef(self, name: str) -> str | None:
+        return self.typedefs.get(name)
+
+    def to_dwarf_metadata(self) -> DwarfMetadata:
+        """Convert to DwarfMetadata for checker compatibility."""
+        return DwarfMetadata(
+            structs=dict(self.structs),
+            enums=dict(self.enums),
+            has_dwarf=self.has_btf,
+        )
+
+
+# ---------------------------------------------------------------------------
+# BTF section reader
+# ---------------------------------------------------------------------------
+
+def has_btf_section(elf_path: Path) -> bool:
+    """Quick check: does the ELF file have a .BTF section?"""
+    try:
+        from elftools.elf.elffile import ELFFile
+        with open(elf_path, "rb") as f:
+            elf = ELFFile(f)  # type: ignore[no-untyped-call]
+            return elf.get_section_by_name(".BTF") is not None  # type: ignore[no-untyped-call]
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _read_btf_section(elf_path: Path) -> bytes | None:
+    """Read raw .BTF section data from an ELF file."""
+    from elftools.elf.elffile import ELFFile
+    with open(elf_path, "rb") as f:
+        elf = ELFFile(f)  # type: ignore[no-untyped-call]
+        section = elf.get_section_by_name(".BTF")  # type: ignore[no-untyped-call]
+        if section is None:
+            return None
+        return section.data()  # type: ignore[no-untyped-call]
+
+
+# ---------------------------------------------------------------------------
+# BTF header + type/string parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BtfHeader:
+    """Parsed BTF header."""
+    magic: int
+    version: int
+    flags: int
+    hdr_len: int
+    type_off: int
+    type_len: int
+    str_off: int
+    str_len: int
+
+
+def _parse_header(data: bytes) -> BtfHeader:
+    """Parse BTF header from raw bytes."""
+    if len(data) < _BTF_HEADER_SIZE:
+        raise ValueError(f"BTF data too small ({len(data)} bytes, need {_BTF_HEADER_SIZE})")
+
+    magic, version, flags, hdr_len = struct.unpack_from("<HBBI", data, 0)
+
+    if magic != BTF_MAGIC:
+        raise ValueError(f"Bad BTF magic: 0x{magic:04X} (expected 0x{BTF_MAGIC:04X})")
+    if version != BTF_VERSION:
+        log.warning("BTF version %d (expected %d), parsing may fail", version, BTF_VERSION)
+
+    type_off, type_len, str_off, str_len = struct.unpack_from("<IIII", data, 8)
+
+    return BtfHeader(
+        magic=magic, version=version, flags=flags, hdr_len=hdr_len,
+        type_off=type_off, type_len=type_len,
+        str_off=str_off, str_len=str_len,
+    )
+
+
+def _read_string(str_data: bytes, offset: int) -> str:
+    """Read a null-terminated string from the BTF string section."""
+    if offset < 0 or offset >= len(str_data):
+        return ""
+    end = str_data.find(b"\x00", offset)
+    if end < 0:
+        return str_data[offset:].decode("utf-8", errors="replace")
+    return str_data[offset:end].decode("utf-8", errors="replace")
+
+
+def _parse_types(type_data: bytes) -> list[BtfType]:
+    """Parse all BTF type entries from the type section.
+
+    Returns a list indexed by type_id (0-based; type_id 0 is void/sentinel).
+    """
+    # Type ID 0 is always void (implicit, not in the data)
+    types: list[BtfType] = [BtfType(type_id=0, name_off=0, info=0, size_or_type=0, extra=b"")]
+
+    pos = 0
+    type_id = 1
+    while pos + 12 <= len(type_data):
+        name_off, info, size_or_type = struct.unpack_from("<III", type_data, pos)
+        pos += 12
+        kind = (info >> 24) & 0x1F
+        vlen = info & 0xFFFF
+
+        # Determine extra data size based on kind
+        extra_size = _extra_data_size(kind, vlen)
+        if pos + extra_size > len(type_data):
+            log.warning("BTF type %d (kind=%d) truncated at offset %d", type_id, kind, pos)
+            break
+
+        extra = type_data[pos:pos + extra_size]
+        pos += extra_size
+
+        types.append(BtfType(
+            type_id=type_id,
+            name_off=name_off,
+            info=info,
+            size_or_type=size_or_type,
+            extra=extra,
+        ))
+        type_id += 1
+
+    return types
+
+
+def _extra_data_size(kind: int, vlen: int) -> int:
+    """Calculate the size of kind-specific extra data following a btf_type."""
+    if kind in (BTF_KIND_INT, BTF_KIND_FLOAT):
+        return 4  # encoding info
+    if kind == BTF_KIND_ARRAY:
+        return 12  # btf_array: type(4) + index_type(4) + nelems(4)
+    if kind in (BTF_KIND_STRUCT, BTF_KIND_UNION):
+        return vlen * 12  # btf_member: name_off(4) + type(4) + offset(4)
+    if kind == BTF_KIND_ENUM:
+        return vlen * 8  # btf_enum: name_off(4) + val(4)
+    if kind == BTF_KIND_ENUM64:
+        return vlen * 12  # btf_enum64: name_off(4) + val_lo32(4) + val_hi32(4)
+    if kind == BTF_KIND_FUNC_PROTO:
+        return vlen * 8  # btf_param: name_off(4) + type(4)
+    if kind == BTF_KIND_VAR:
+        return 4  # linkage
+    if kind == BTF_KIND_DATASEC:
+        return vlen * 12  # btf_var_secinfo: type(4) + offset(4) + size(4)
+    if kind == BTF_KIND_DECL_TAG:
+        return 4  # component_idx
+    # PTR, FWD, TYPEDEF, VOLATILE, CONST, RESTRICT, FUNC, TYPE_TAG: no extra
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Type resolution
+# ---------------------------------------------------------------------------
+
+class _TypeResolver:
+    """Resolves BTF type references to names and sizes."""
+
+    def __init__(self, types: list[BtfType], str_data: bytes) -> None:
+        self._types = types
+        self._str = str_data
+        self._name_cache: dict[int, str] = {}
+        self._size_cache: dict[int, int] = {}
+        # Track resolution in progress for cycle detection
+        self._resolving_name: set[int] = set()
+        self._resolving_size: set[int] = set()
+
+    def name(self, type_id: int) -> str:
+        """Resolve a type ID to a human-readable type name."""
+        if type_id in self._name_cache:
+            return self._name_cache[type_id]
+        if type_id in self._resolving_name:
+            return "..."  # cycle
+        self._resolving_name.add(type_id)
+        try:
+            result = self._resolve_name(type_id)
+            self._name_cache[type_id] = result
+            return result
+        finally:
+            self._resolving_name.discard(type_id)
+
+    def size(self, type_id: int) -> int:
+        """Resolve a type ID to its byte size."""
+        if type_id in self._size_cache:
+            return self._size_cache[type_id]
+        if type_id in self._resolving_size:
+            return 0  # cycle
+        self._resolving_size.add(type_id)
+        try:
+            result = self._resolve_size(type_id)
+            self._size_cache[type_id] = result
+            return result
+        finally:
+            self._resolving_size.discard(type_id)
+
+    def _get(self, type_id: int) -> BtfType | None:
+        if 0 <= type_id < len(self._types):
+            return self._types[type_id]
+        return None
+
+    def _str_at(self, offset: int) -> str:
+        return _read_string(self._str, offset)
+
+    def _resolve_name(self, type_id: int) -> str:
+        if type_id == 0:
+            return "void"
+        t = self._get(type_id)
+        if t is None:
+            return f"<btf:{type_id}>"
+
+        kind = t.kind
+        tname = self._str_at(t.name_off)
+
+        if kind in (BTF_KIND_STRUCT, BTF_KIND_UNION):
+            tag = "union" if kind == BTF_KIND_UNION else "struct"
+            return tname if tname else f"<anon {tag}>"
+
+        if kind in (BTF_KIND_ENUM, BTF_KIND_ENUM64):
+            return tname if tname else "<anon enum>"
+
+        if kind == BTF_KIND_INT:
+            return tname if tname else "int"
+
+        if kind == BTF_KIND_FLOAT:
+            return tname if tname else "float"
+
+        if kind == BTF_KIND_PTR:
+            ref = self.name(t.size_or_type)
+            return f"{ref} *"
+
+        if kind == BTF_KIND_ARRAY:
+            if len(t.extra) >= 12:
+                elem_type, _, nelems = struct.unpack_from("<III", t.extra, 0)
+                ref = self.name(elem_type)
+                return f"{ref}[{nelems}]"
+            return "[]"
+
+        if kind == BTF_KIND_TYPEDEF:
+            return tname if tname else self.name(t.size_or_type)
+
+        if kind == BTF_KIND_VOLATILE:
+            return f"volatile {self.name(t.size_or_type)}"
+
+        if kind == BTF_KIND_CONST:
+            return f"const {self.name(t.size_or_type)}"
+
+        if kind == BTF_KIND_RESTRICT:
+            return f"restrict {self.name(t.size_or_type)}"
+
+        if kind == BTF_KIND_FWD:
+            tag = "union" if t.kflag else "struct"
+            return tname if tname else f"<fwd {tag}>"
+
+        if kind == BTF_KIND_FUNC_PROTO:
+            ret = self.name(t.size_or_type)
+            return f"{ret}(...)"
+
+        if kind == BTF_KIND_FUNC:
+            return tname if tname else "<func>"
+
+        if kind == BTF_KIND_VAR:
+            return tname if tname else "<var>"
+
+        if kind == BTF_KIND_TYPE_TAG:
+            return self.name(t.size_or_type)
+
+        return f"<btf_kind_{kind}:{type_id}>"
+
+    def _resolve_size(self, type_id: int) -> int:
+        if type_id == 0:
+            return 0
+        t = self._get(type_id)
+        if t is None:
+            return 0
+
+        kind = t.kind
+
+        if kind in (BTF_KIND_STRUCT, BTF_KIND_UNION):
+            return t.size_or_type  # size field
+
+        if kind in (BTF_KIND_ENUM, BTF_KIND_ENUM64):
+            return t.size_or_type  # size field
+
+        if kind == BTF_KIND_INT:
+            # INT encoding: bits 0-7 = nr_bits, bits 8-15 = unused, bits 16-23 = offset
+            if len(t.extra) >= 4:
+                enc = struct.unpack_from("<I", t.extra, 0)[0]
+                nr_bits = enc & 0xFF
+                return (nr_bits + 7) // 8
+            return t.size_or_type
+
+        if kind == BTF_KIND_FLOAT:
+            return t.size_or_type
+
+        if kind == BTF_KIND_PTR:
+            return 8  # 64-bit pointers (kernel is typically 64-bit)
+
+        if kind == BTF_KIND_ARRAY:
+            if len(t.extra) >= 12:
+                elem_type, _, nelems = struct.unpack_from("<III", t.extra, 0)
+                return self.size(elem_type) * nelems
+            return 0
+
+        if kind in (BTF_KIND_TYPEDEF, BTF_KIND_VOLATILE, BTF_KIND_CONST,
+                     BTF_KIND_RESTRICT, BTF_KIND_TYPE_TAG):
+            return self.size(t.size_or_type)
+
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# High-level extraction
+# ---------------------------------------------------------------------------
+
+def _extract_structs(
+    types: list[BtfType], resolver: _TypeResolver, str_data: bytes,
+) -> dict[str, StructLayout]:
+    """Extract struct/union layouts from BTF types."""
+    structs: dict[str, StructLayout] = {}
+
+    for t in types:
+        if t.kind not in (BTF_KIND_STRUCT, BTF_KIND_UNION):
+            continue
+
+        name = _read_string(str_data, t.name_off)
+        if not name:
+            continue  # skip anonymous
+
+        fields: list[FieldInfo] = []
+        vlen = t.vlen
+        for i in range(vlen):
+            off = i * 12
+            if off + 12 > len(t.extra):
+                break
+            m_name_off, m_type, m_offset = struct.unpack_from("<III", t.extra, off)
+            m_name = _read_string(str_data, m_name_off)
+
+            # kflag determines offset encoding:
+            # kflag=0: m_offset is byte_offset * 8 (bit offset from struct start)
+            # kflag=1: bits 0-23 = bit offset, bits 24-31 = bitfield size
+            if t.kflag:
+                bit_size = (m_offset >> 24) & 0xFF
+                bit_offset_total = m_offset & 0xFFFFFF
+            else:
+                bit_size = 0
+                bit_offset_total = m_offset
+
+            byte_offset = bit_offset_total // 8
+            bit_offset = bit_offset_total % 8 if bit_size else 0
+
+            fields.append(FieldInfo(
+                name=m_name,
+                type_name=resolver.name(m_type),
+                byte_offset=byte_offset,
+                byte_size=resolver.size(m_type),
+                bit_offset=bit_offset,
+                bit_size=bit_size,
+            ))
+
+        layout = StructLayout(
+            name=name,
+            byte_size=t.size_or_type,
+            alignment=0,  # BTF doesn't store alignment
+            fields=fields,
+            is_union=(t.kind == BTF_KIND_UNION),
+        )
+
+        if name not in structs:
+            structs[name] = layout
+
+    return structs
+
+
+def _extract_enums(
+    types: list[BtfType], str_data: bytes,
+) -> dict[str, EnumInfo]:
+    """Extract enum types from BTF."""
+    enums: dict[str, EnumInfo] = {}
+
+    for t in types:
+        if t.kind == BTF_KIND_ENUM:
+            name = _read_string(str_data, t.name_off)
+            if not name:
+                continue
+            members: dict[str, int] = {}
+            for i in range(t.vlen):
+                off = i * 8
+                if off + 8 > len(t.extra):
+                    break
+                e_name_off, e_val = struct.unpack_from("<Ii", t.extra, off)
+                e_name = _read_string(str_data, e_name_off)
+                if e_name:
+                    members[e_name] = e_val
+
+            if name not in enums:
+                enums[name] = EnumInfo(
+                    name=name,
+                    underlying_byte_size=t.size_or_type,
+                    members=members,
+                )
+
+        elif t.kind == BTF_KIND_ENUM64:
+            name = _read_string(str_data, t.name_off)
+            if not name:
+                continue
+            members = {}
+            for i in range(t.vlen):
+                off = i * 12
+                if off + 12 > len(t.extra):
+                    break
+                e_name_off, e_val_lo, e_val_hi = struct.unpack_from(
+                    "<III", t.extra, off)
+                e_name = _read_string(str_data, e_name_off)
+                e_val = e_val_lo | (e_val_hi << 32)
+                if e_name:
+                    members[e_name] = e_val
+
+            if name not in enums:
+                enums[name] = EnumInfo(
+                    name=name,
+                    underlying_byte_size=t.size_or_type,
+                    members=members,
+                )
+
+    return enums
+
+
+def _extract_func_protos(
+    types: list[BtfType], resolver: _TypeResolver, str_data: bytes,
+) -> dict[str, FuncProto]:
+    """Extract function prototypes from BTF FUNC + FUNC_PROTO pairs."""
+    # Build proto_id → FuncProto mapping first
+    proto_map: dict[int, BtfType] = {}
+    for t in types:
+        if t.kind == BTF_KIND_FUNC_PROTO:
+            proto_map[t.type_id] = t
+
+    funcs: dict[str, FuncProto] = {}
+    for t in types:
+        if t.kind != BTF_KIND_FUNC:
+            continue
+        name = _read_string(str_data, t.name_off)
+        if not name:
+            continue
+
+        proto = proto_map.get(t.size_or_type)
+        if proto is None:
+            continue
+
+        ret_type = resolver.name(proto.size_or_type)
+        params: list[tuple[str, str]] = []
+        for i in range(proto.vlen):
+            off = i * 8
+            if off + 8 > len(proto.extra):
+                break
+            p_name_off, p_type = struct.unpack_from("<II", proto.extra, off)
+            p_name = _read_string(str_data, p_name_off)
+            p_type_name = resolver.name(p_type)
+            params.append((p_name, p_type_name))
+
+        if name not in funcs:
+            funcs[name] = FuncProto(
+                name=name,
+                return_type=ret_type,
+                params=params,
+            )
+
+    return funcs
+
+
+def _extract_typedefs(
+    types: list[BtfType], resolver: _TypeResolver, str_data: bytes,
+) -> dict[str, str]:
+    """Extract typedef mappings."""
+    typedefs: dict[str, str] = {}
+    for t in types:
+        if t.kind != BTF_KIND_TYPEDEF:
+            continue
+        name = _read_string(str_data, t.name_off)
+        if not name:
+            continue
+        target = resolver.name(t.size_or_type)
+        if name not in typedefs:
+            typedefs[name] = target
+    return typedefs
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_btf_metadata(elf_path: Path) -> BtfMetadata:
+    """Parse BTF section from an ELF file and return BtfMetadata.
+
+    Returns ``BtfMetadata()`` on any error.  Never raises.
+    """
+    empty = BtfMetadata()
+
+    try:
+        raw = _read_btf_section(elf_path)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_btf_metadata: failed to read .BTF from %s: %s", elf_path, exc)
+        return empty
+
+    if raw is None:
+        log.debug("parse_btf_metadata: no .BTF section in %s", elf_path)
+        return empty
+
+    return parse_btf_from_bytes(raw)
+
+
+def parse_btf_from_bytes(data: bytes) -> BtfMetadata:
+    """Parse BTF from raw bytes (useful for testing without ELF wrapper).
+
+    Returns ``BtfMetadata()`` on any error.  Never raises.
+    """
+    empty = BtfMetadata()
+
+    try:
+        header = _parse_header(data)
+    except (ValueError, struct.error) as exc:
+        log.warning("parse_btf_from_bytes: bad header: %s", exc)
+        return empty
+
+    hdr_len = header.hdr_len
+    type_start = hdr_len + header.type_off
+    type_end = type_start + header.type_len
+    str_start = hdr_len + header.str_off
+    str_end = str_start + header.str_len
+
+    if type_end > len(data) or str_end > len(data):
+        log.warning("parse_btf_from_bytes: section bounds exceed data size")
+        return empty
+
+    type_data = data[type_start:type_end]
+    str_data = data[str_start:str_end]
+
+    try:
+        types = _parse_types(type_data)
+    except (struct.error, ValueError) as exc:
+        log.warning("parse_btf_from_bytes: type parsing failed: %s", exc)
+        return empty
+
+    resolver = _TypeResolver(types, str_data)
+
+    meta = BtfMetadata(has_btf=True, type_count=len(types) - 1)
+
+    try:
+        meta.structs = _extract_structs(types, resolver, str_data)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_btf_from_bytes: struct extraction failed: %s", exc)
+
+    try:
+        meta.enums = _extract_enums(types, str_data)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_btf_from_bytes: enum extraction failed: %s", exc)
+
+    try:
+        meta.func_protos = _extract_func_protos(types, resolver, str_data)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_btf_from_bytes: func_proto extraction failed: %s", exc)
+
+    try:
+        meta.typedefs = _extract_typedefs(types, resolver, str_data)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_btf_from_bytes: typedef extraction failed: %s", exc)
+
+    return meta

--- a/abicheck/btf_metadata.py
+++ b/abicheck/btf_metadata.py
@@ -525,11 +525,13 @@ def _extract_enums(
             if not name:
                 continue
             members: dict[str, int] = {}
+            # kflag=1 → signed enumerators, kflag=0 → unsigned
+            fmt = "<Ii" if t.kflag else "<II"
             for i in range(t.vlen):
                 off = i * 8
                 if off + 8 > len(t.extra):
                     break
-                e_name_off, e_val = struct.unpack_from("<Ii", t.extra, off)
+                e_name_off, e_val = struct.unpack_from(fmt, t.extra, off)
                 e_name = _read_string(str_data, e_name_off)
                 if e_name:
                     members[e_name] = e_val
@@ -554,6 +556,9 @@ def _extract_enums(
                     "<III", t.extra, off)
                 e_name = _read_string(str_data, e_name_off)
                 e_val = e_val_lo | (e_val_hi << 32)
+                # kflag=1 → signed: sign-extend 64-bit value
+                if t.kflag and e_val >= (1 << 63):
+                    e_val -= 1 << 64
                 if e_name:
                     members[e_name] = e_val
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -138,6 +138,7 @@ def _sniff_text_format(path: Path) -> str:
 def _dump_elf(
     path: Path, headers: list[Path], includes: list[Path],
     version: str, lang: str, *, dwarf_only: bool = False,
+    debug_format: str | None = None,
 ) -> AbiSnapshot:
     """Dump ABI snapshot from an ELF binary."""
     resolved_headers = _expand_header_inputs(headers) if headers else []
@@ -166,6 +167,7 @@ def _dump_elf(
             compiler=compiler,
             lang=lang if lang == "c" else None,
             dwarf_only=dwarf_only,
+            debug_format=debug_format,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(f"Failed to dump '{path}': {exc}") from exc
@@ -208,6 +210,7 @@ def _dump_native_binary(
     *,
     pdb_path: Path | None = None,
     dwarf_only: bool = False,
+    debug_format: str | None = None,
 ) -> AbiSnapshot:
     """Dump ABI snapshot from a native binary (ELF, PE, or Mach-O).
 
@@ -216,7 +219,8 @@ def _dump_native_binary(
     For PE/Mach-O, headers are optional — export tables provide the symbol surface.
     """
     if binary_fmt == "elf":
-        return _dump_elf(path, headers, includes, version, lang, dwarf_only=dwarf_only)
+        return _dump_elf(path, headers, includes, version, lang,
+                         dwarf_only=dwarf_only, debug_format=debug_format)
 
     if binary_fmt == "pe":
         from .service import _dump_pe
@@ -242,6 +246,7 @@ def _resolve_input(
     is_elf: bool | None = None,
     pdb_path: Path | None = None,
     dwarf_only: bool = False,
+    debug_format: str | None = None,
 ) -> AbiSnapshot:
     """Auto-detect input type and return an AbiSnapshot.
 
@@ -260,12 +265,14 @@ def _resolve_input(
             performed here (avoids a second ``open()`` when the caller already
             knows the result).
         dwarf_only: If True, force DWARF-only mode (ADR-003).
+        debug_format: Force debug format ("dwarf", "btf", "ctf") or None for auto.
     """
     # Fast path: caller already knows it's ELF
     if is_elf is True:
         return _dump_native_binary(
             path, "elf", headers, includes, version, lang,
             dwarf_only=dwarf_only,
+            debug_format=debug_format,
         )
 
     # Detect binary format from magic bytes
@@ -275,6 +282,7 @@ def _resolve_input(
             path, binary_fmt, headers, includes, version, lang,
             pdb_path=pdb_path,
             dwarf_only=dwarf_only,
+            debug_format=debug_format,
         )
 
     # Text-based formats: detect by sniffing only a small header chunk
@@ -421,6 +429,12 @@ def _populate_dependency_info(
 @click.option("--show-data-sources", is_flag=True, default=False,
               help="Print which data layers (L0/L1/L2) are available for the "
                    "binary and exit.")
+@click.option("--btf", "debug_format", flag_value="btf", default=None,
+              help="Force BTF debug format (ELF only).")
+@click.option("--ctf", "debug_format", flag_value="ctf",
+              help="Force CTF debug format (ELF only).")
+@click.option("--dwarf", "debug_format", flag_value="dwarf",
+              help="Force DWARF debug format (ELF only).")
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
 def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...],
@@ -429,6 +443,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
              sysroot: Path | None, nostdinc: bool, pdb_path: Path | None,
              follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
              dwarf_only: bool, show_data_sources: bool,
+             debug_format: str | None,
              verbose: bool) -> None:
     """Dump ABI snapshot of a shared library to JSON.
 
@@ -486,6 +501,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             nostdinc=nostdinc,
             lang=lang if lang == "c" else None,
             dwarf_only=dwarf_only,
+            debug_format=debug_format,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -959,6 +975,12 @@ def _exit_with_severity_or_verdict(
 @click.option("--strict-elf-only", is_flag=True, default=False,
               help="Treat ELF-only symbol removals as BREAKING instead of COMPATIBLE. "
                    "Use when headers are unavailable but all exported symbols are public API.")
+@click.option("--btf", "debug_format", flag_value="btf", default=None,
+              help="Force BTF debug format for both sides (ELF only).")
+@click.option("--ctf", "debug_format", flag_value="ctf",
+              help="Force CTF debug format for both sides (ELF only).")
+@click.option("--dwarf", "debug_format", flag_value="dwarf",
+              help="Force DWARF debug format for both sides (ELF only).")
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
 def compare_cmd(
@@ -980,6 +1002,7 @@ def compare_cmd(
     show_redundant: bool, show_only: str | None, stat: bool,
     report_mode: str, show_impact: bool,
     strict_elf_only: bool,
+    debug_format: str | None,
     verbose: bool,
 ) -> None:
     """Compare two ABI surfaces and report changes.
@@ -1058,12 +1081,14 @@ def compare_cmd(
         is_elf=True if old_fmt == "elf" else None,
         pdb_path=resolved_old_pdb,
         dwarf_only=dwarf_only,
+        debug_format=debug_format,
     )
     new = _resolve_input(
         new_input, new_h, new_inc, new_version, lang,
         is_elf=True if new_fmt == "elf" else None,
         pdb_path=resolved_new_pdb,
         dwarf_only=dwarf_only,
+        debug_format=debug_format,
     )
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)

--- a/abicheck/ctf_metadata.py
+++ b/abicheck/ctf_metadata.py
@@ -323,10 +323,13 @@ def _parse_types(
                 pos += 2
             else:
                 break
-            # Re-encode info for uniform handling
+            # Re-encode info for uniform handling (v3 layout)
             info = (kind << 24) | (int(isroot) << 31) | vlen
+            # kind, vlen already decoded above — no re-parse needed
 
-        kind, vlen, _isroot = parse_info(info)
+        if version >= CTF_VERSION_3:
+            # For v3, kind/vlen not yet decoded — decode now
+            kind, vlen, _isroot = _parse_info_v3(info)
 
         # Read kind-specific extra data
         extra_size = _extra_data_size(kind, vlen, version, size_or_type)

--- a/abicheck/ctf_metadata.py
+++ b/abicheck/ctf_metadata.py
@@ -183,7 +183,7 @@ def _read_ctf_section(elf_path: Path) -> bytes | None:
             section = elf.get_section_by_name(".SUNW_ctf")  # type: ignore[no-untyped-call]
         if section is None:
             return None
-        return section.data()  # type: ignore[no-untyped-call]
+        return bytes(section.data())
 
 
 # ---------------------------------------------------------------------------
@@ -493,15 +493,15 @@ class _TypeResolver:
 
         if kind == CTF_K_INTEGER:
             if len(t.extra) >= 4:
-                enc = struct.unpack_from("<I", t.extra, 0)[0]
+                enc: int = struct.unpack_from("<I", t.extra, 0)[0]
                 nr_bits = enc & 0xFFFF
                 return (nr_bits + 7) // 8
             return 0
 
         if kind == CTF_K_FLOAT:
             if len(t.extra) >= 4:
-                enc = struct.unpack_from("<I", t.extra, 0)[0]
-                nr_bits = enc & 0xFFFF
+                enc_f: int = struct.unpack_from("<I", t.extra, 0)[0]
+                nr_bits = enc_f & 0xFFFF
                 return (nr_bits + 7) // 8
             return 0
 
@@ -510,11 +510,15 @@ class _TypeResolver:
 
         if kind == CTF_K_ARRAY:
             if self._version >= CTF_VERSION_3 and len(t.extra) >= 12:
+                elem_type: int
+                nelems: int
                 elem_type, _, nelems = struct.unpack_from("<III", t.extra, 0)
                 return self.size(elem_type) * nelems
             if self._version < CTF_VERSION_3 and len(t.extra) >= 6:
-                elem_type, _, nelems = struct.unpack_from("<HHH", t.extra, 0)
-                return self.size(elem_type) * nelems
+                elem_type_v2: int
+                nelems_v2: int
+                elem_type_v2, _, nelems_v2 = struct.unpack_from("<HHH", t.extra, 0)
+                return self.size(elem_type_v2) * nelems_v2
             return 0
 
         if kind in (CTF_K_TYPEDEF, CTF_K_VOLATILE, CTF_K_CONST, CTF_K_RESTRICT):

--- a/abicheck/ctf_metadata.py
+++ b/abicheck/ctf_metadata.py
@@ -1,0 +1,749 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CTF (Compact C Type Format) parser for illumos/Solaris ABI analysis.
+
+Pure-Python implementation using only the ``struct`` module — no external
+dependencies beyond pyelftools (for ELF section access).
+
+CTF is a compact debug format used by illumos, SmartOS, OmniOS, and DTrace.
+It stores struct/union layouts, enum types, typedefs, and function signatures
+in a space-efficient binary format.
+
+Supports CTF v2 (legacy) and v3 (current).
+
+Reference: illumos ``sys/ctf.h`` and ``libctf`` source.
+
+Public API
+----------
+parse_ctf_metadata(elf_path)
+    → CtfMetadata (implements TypeMetadataSource protocol)
+
+has_ctf_section(elf_path)
+    → bool  (quick check without full parse)
+"""
+from __future__ import annotations
+
+import logging
+import struct
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .btf_metadata import FuncProto
+from .dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# CTF constants (from sys/ctf.h)
+# ---------------------------------------------------------------------------
+
+CTF_MAGIC = 0xCFF1
+CTF_VERSION_2 = 2
+CTF_VERSION_3 = 3
+
+# CTF type kinds (encoded in ctt_info)
+CTF_K_UNKNOWN = 0
+CTF_K_INTEGER = 1
+CTF_K_FLOAT = 2
+CTF_K_POINTER = 3
+CTF_K_ARRAY = 4
+CTF_K_FUNCTION = 5
+CTF_K_STRUCT = 6
+CTF_K_UNION = 7
+CTF_K_ENUM = 8
+CTF_K_FORWARD = 9
+CTF_K_TYPEDEF = 10
+CTF_K_VOLATILE = 11
+CTF_K_CONST = 12
+CTF_K_RESTRICT = 13
+
+# CTF integer encoding bits
+CTF_INT_SIGNED = 0x01
+CTF_INT_CHAR = 0x02
+CTF_INT_BOOL = 0x04
+
+# CTF header flags
+CTF_F_COMPRESS = 0x01
+
+# Size thresholds for large vs small type encoding
+_CTF_V2_LSTRUCT_THRESH = 0x1FFF   # vlen threshold for v2 "large" members
+_CTF_V3_LSTRUCT_THRESH = 0x1FFF
+
+# Header sizes
+_CTF_PREAMBLE_SIZE = 4  # magic(2) + version(1) + flags(1)
+_CTF_V2_HEADER_SIZE = 36
+_CTF_V3_HEADER_SIZE = 36
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CtfType:
+    """Raw parsed CTF type entry."""
+    type_id: int
+    name_off: int
+    info: int
+    size_or_type: int  # depends on kind
+    extra: bytes = b""
+
+    @property
+    def kind(self) -> int:
+        return (self.info >> 24) & 0x1F  # v3; v2 uses >> 11 & 0x1F
+
+    @property
+    def vlen(self) -> int:
+        return self.info & 0xFFFF  # v3; v2 uses & 0x3FF
+
+    @property
+    def isroot(self) -> bool:
+        return bool((self.info >> 31) & 1)  # v3; v2 uses >> 10 & 1
+
+
+@dataclass
+class CtfMetadata:
+    """CTF-derived ABI-relevant type information.
+
+    Implements the same interface as DwarfMetadata so the checker's
+    detectors work without modification (TypeMetadataSource protocol).
+    """
+    structs: dict[str, StructLayout] = field(default_factory=dict)
+    enums: dict[str, EnumInfo] = field(default_factory=dict)
+    func_protos: dict[str, FuncProto] = field(default_factory=dict)
+    typedefs: dict[str, str] = field(default_factory=dict)
+    has_ctf: bool = False
+    type_count: int = 0
+
+    # TypeMetadataSource protocol
+    @property
+    def has_data(self) -> bool:
+        return self.has_ctf
+
+    def get_struct_layout(self, name: str) -> StructLayout | None:
+        return self.structs.get(name)
+
+    def get_enum_info(self, name: str) -> EnumInfo | None:
+        return self.enums.get(name)
+
+    def get_function_proto(self, name: str) -> FuncProto | None:
+        return self.func_protos.get(name)
+
+    def get_typedef(self, name: str) -> str | None:
+        return self.typedefs.get(name)
+
+    def to_dwarf_metadata(self) -> DwarfMetadata:
+        """Convert to DwarfMetadata for checker compatibility."""
+        return DwarfMetadata(
+            structs=dict(self.structs),
+            enums=dict(self.enums),
+            has_dwarf=self.has_ctf,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CTF section reader
+# ---------------------------------------------------------------------------
+
+def has_ctf_section(elf_path: Path) -> bool:
+    """Quick check: does the ELF file have a .ctf section?"""
+    try:
+        from elftools.elf.elffile import ELFFile
+        with open(elf_path, "rb") as f:
+            elf = ELFFile(f)  # type: ignore[no-untyped-call]
+            # CTF can be in .ctf or .SUNW_ctf sections
+            return (
+                elf.get_section_by_name(".ctf") is not None  # type: ignore[no-untyped-call]
+                or elf.get_section_by_name(".SUNW_ctf") is not None  # type: ignore[no-untyped-call]
+            )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _read_ctf_section(elf_path: Path) -> bytes | None:
+    """Read raw .ctf section data from an ELF file."""
+    from elftools.elf.elffile import ELFFile
+    with open(elf_path, "rb") as f:
+        elf = ELFFile(f)  # type: ignore[no-untyped-call]
+        section = elf.get_section_by_name(".ctf")  # type: ignore[no-untyped-call]
+        if section is None:
+            section = elf.get_section_by_name(".SUNW_ctf")  # type: ignore[no-untyped-call]
+        if section is None:
+            return None
+        return section.data()  # type: ignore[no-untyped-call]
+
+
+# ---------------------------------------------------------------------------
+# CTF header parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CtfHeader:
+    """Parsed CTF header."""
+    magic: int
+    version: int
+    flags: int
+    parent_label: int
+    parent_name: int
+    label_off: int
+    object_off: int
+    func_off: int
+    type_off: int
+    str_off: int
+    str_len: int
+
+
+def _parse_header(data: bytes) -> CtfHeader:
+    """Parse CTF preamble + header."""
+    if len(data) < _CTF_PREAMBLE_SIZE:
+        raise ValueError(f"CTF data too small ({len(data)} bytes)")
+
+    magic, version, flags = struct.unpack_from("<HBB", data, 0)
+    if magic != CTF_MAGIC:
+        raise ValueError(f"Bad CTF magic: 0x{magic:04X} (expected 0x{CTF_MAGIC:04X})")
+    if version not in (CTF_VERSION_2, CTF_VERSION_3):
+        raise ValueError(f"Unsupported CTF version {version}")
+
+    if len(data) < _CTF_V3_HEADER_SIZE:
+        raise ValueError(f"CTF header truncated ({len(data)} bytes)")
+
+    (parent_label, parent_name,
+     label_off, object_off, func_off, type_off,
+     str_off, str_len) = struct.unpack_from("<IIIIIIII", data, 4)
+
+    return CtfHeader(
+        magic=magic, version=version, flags=flags,
+        parent_label=parent_label, parent_name=parent_name,
+        label_off=label_off, object_off=object_off,
+        func_off=func_off, type_off=type_off,
+        str_off=str_off, str_len=str_len,
+    )
+
+
+def _decompress_if_needed(data: bytes, header: CtfHeader) -> bytes:
+    """Decompress CTF data if CTF_F_COMPRESS flag is set."""
+    if not (header.flags & CTF_F_COMPRESS):
+        return data
+    # Data after the preamble (4 bytes) is zlib-compressed
+    try:
+        decompressed = zlib.decompress(data[_CTF_PREAMBLE_SIZE:])
+    except zlib.error as exc:
+        raise ValueError(f"CTF decompression failed: {exc}") from exc
+    # Reassemble: preamble + decompressed body
+    return data[:_CTF_PREAMBLE_SIZE] + decompressed
+
+
+# ---------------------------------------------------------------------------
+# CTF string table
+# ---------------------------------------------------------------------------
+
+def _read_string(str_data: bytes, offset: int) -> str:
+    """Read a null-terminated string from the CTF string table."""
+    if offset < 0 or offset >= len(str_data):
+        return ""
+    end = str_data.find(b"\x00", offset)
+    if end < 0:
+        return str_data[offset:].decode("utf-8", errors="replace")
+    return str_data[offset:end].decode("utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# CTF type parsing
+# ---------------------------------------------------------------------------
+
+def _parse_info_v2(info: int) -> tuple[int, int, bool]:
+    """Parse v2 ctt_info: kind(5 bits), isroot(1 bit), vlen(10 bits)."""
+    kind = (info >> 11) & 0x1F
+    isroot = bool((info >> 10) & 1)
+    vlen = info & 0x3FF
+    return kind, vlen, isroot
+
+
+def _parse_info_v3(info: int) -> tuple[int, int, bool]:
+    """Parse v3 ctt_info: kind(5 bits) + isroot(1 bit) in upper, vlen(16 bits) in lower."""
+    kind = (info >> 24) & 0x1F
+    isroot = bool((info >> 31) & 1)
+    vlen = info & 0xFFFF
+    return kind, vlen, isroot
+
+
+def _parse_types(
+    type_data: bytes, version: int,
+) -> list[CtfType]:
+    """Parse all CTF type entries from the type section."""
+    types: list[CtfType] = [
+        CtfType(type_id=0, name_off=0, info=0, size_or_type=0)
+    ]
+
+    parse_info = _parse_info_v3 if version >= CTF_VERSION_3 else _parse_info_v2
+
+    pos = 0
+    type_id = 1
+
+    while pos < len(type_data):
+        # Each type starts with: name(4) + info(4)
+        # Then either size(4) for large or type(2) for small (v2)
+        # v3 always uses 4-byte size_or_type
+        if version >= CTF_VERSION_3:
+            if pos + 12 > len(type_data):
+                break
+            name_off, info, size_or_type = struct.unpack_from("<III", type_data, pos)
+            pos += 12
+        else:
+            # CTF v2: name(4) + info(2) + size_or_type(2 or 4)
+            if pos + 6 > len(type_data):
+                break
+            name_off = struct.unpack_from("<I", type_data, pos)[0]
+            info = struct.unpack_from("<H", type_data, pos + 4)[0]
+            pos += 6
+            kind, vlen, isroot = parse_info(info)
+            # In v2, if size >= CTF_LSTRUCT_THRESH, next 4 bytes are actual size
+            if kind in (CTF_K_STRUCT, CTF_K_UNION) and pos + 2 <= len(type_data):
+                size_or_type = struct.unpack_from("<H", type_data, pos)[0]
+                pos += 2
+                if size_or_type >= _CTF_V2_LSTRUCT_THRESH:
+                    if pos + 4 <= len(type_data):
+                        size_or_type = struct.unpack_from("<I", type_data, pos)[0]
+                        pos += 4
+            elif pos + 2 <= len(type_data):
+                size_or_type = struct.unpack_from("<H", type_data, pos)[0]
+                pos += 2
+            else:
+                break
+            # Re-encode info for uniform handling
+            info = (kind << 24) | (int(isroot) << 31) | vlen
+
+        kind, vlen, _isroot = parse_info(info)
+
+        # Read kind-specific extra data
+        extra_size = _extra_data_size(kind, vlen, version, size_or_type)
+        if pos + extra_size > len(type_data):
+            log.warning("CTF type %d (kind=%d) truncated", type_id, kind)
+            break
+
+        extra = type_data[pos:pos + extra_size]
+        pos += extra_size
+
+        types.append(CtfType(
+            type_id=type_id,
+            name_off=name_off,
+            info=info,
+            size_or_type=size_or_type,
+            extra=extra,
+        ))
+        type_id += 1
+
+    return types
+
+
+def _extra_data_size(kind: int, vlen: int, version: int, size_or_type: int) -> int:
+    """Calculate the size of kind-specific extra data."""
+    if kind == CTF_K_INTEGER:
+        return 4  # encoding word
+    if kind == CTF_K_FLOAT:
+        return 4  # encoding word
+    if kind == CTF_K_ARRAY:
+        if version >= CTF_VERSION_3:
+            return 12  # contents(4) + index(4) + nelems(4)
+        return 6  # contents(2) + index(2) + nelems(2)  (v2 uses short)
+    if kind in (CTF_K_STRUCT, CTF_K_UNION):
+        if version >= CTF_VERSION_3:
+            # v3: always 4+4 per member (name_off + ctm_offset) for small,
+            # 4+4+4 (name_off + offset_hi + offset_lo) for large
+            if size_or_type >= 0x2000:  # large struct
+                return vlen * 12
+            return vlen * 8
+        else:
+            # v2: small = name(2) + offset(2), large = name(2) + pad(2) + offset_hi(2) + offset_lo(2)
+            if size_or_type >= _CTF_V2_LSTRUCT_THRESH:
+                return vlen * 8
+            return vlen * 4
+    if kind == CTF_K_ENUM:
+        return vlen * 8  # name(4) + value(4) per enumerator
+    if kind == CTF_K_FUNCTION:
+        # vlen argument type IDs
+        size = vlen * 4 if version >= CTF_VERSION_3 else vlen * 2
+        # Pad to 4-byte alignment
+        return (size + 3) & ~3
+    # POINTER, FORWARD, TYPEDEF, VOLATILE, CONST, RESTRICT: no extra
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Type resolution
+# ---------------------------------------------------------------------------
+
+class _TypeResolver:
+    """Resolves CTF type references to names and sizes."""
+
+    def __init__(self, types: list[CtfType], str_data: bytes, version: int) -> None:
+        self._types = types
+        self._str = str_data
+        self._version = version
+        self._name_cache: dict[int, str] = {}
+        self._size_cache: dict[int, int] = {}
+        self._resolving_name: set[int] = set()
+        self._resolving_size: set[int] = set()
+
+    def name(self, type_id: int) -> str:
+        if type_id in self._name_cache:
+            return self._name_cache[type_id]
+        if type_id in self._resolving_name:
+            return "..."
+        self._resolving_name.add(type_id)
+        try:
+            result = self._resolve_name(type_id)
+            self._name_cache[type_id] = result
+            return result
+        finally:
+            self._resolving_name.discard(type_id)
+
+    def size(self, type_id: int) -> int:
+        if type_id in self._size_cache:
+            return self._size_cache[type_id]
+        if type_id in self._resolving_size:
+            return 0
+        self._resolving_size.add(type_id)
+        try:
+            result = self._resolve_size(type_id)
+            self._size_cache[type_id] = result
+            return result
+        finally:
+            self._resolving_size.discard(type_id)
+
+    def _get(self, type_id: int) -> CtfType | None:
+        if 0 <= type_id < len(self._types):
+            return self._types[type_id]
+        return None
+
+    def _str_at(self, offset: int) -> str:
+        return _read_string(self._str, offset)
+
+    def _resolve_name(self, type_id: int) -> str:
+        if type_id == 0:
+            return "void"
+        t = self._get(type_id)
+        if t is None:
+            return f"<ctf:{type_id}>"
+
+        kind = t.kind
+        tname = self._str_at(t.name_off)
+
+        if kind == CTF_K_INTEGER:
+            return tname if tname else "int"
+        if kind == CTF_K_FLOAT:
+            return tname if tname else "float"
+        if kind == CTF_K_POINTER:
+            return f"{self.name(t.size_or_type)} *"
+        if kind in (CTF_K_STRUCT, CTF_K_UNION):
+            tag = "union" if kind == CTF_K_UNION else "struct"
+            return tname if tname else f"<anon {tag}>"
+        if kind == CTF_K_ENUM:
+            return tname if tname else "<anon enum>"
+        if kind == CTF_K_TYPEDEF:
+            return tname if tname else self.name(t.size_or_type)
+        if kind == CTF_K_VOLATILE:
+            return f"volatile {self.name(t.size_or_type)}"
+        if kind == CTF_K_CONST:
+            return f"const {self.name(t.size_or_type)}"
+        if kind == CTF_K_RESTRICT:
+            return f"restrict {self.name(t.size_or_type)}"
+        if kind == CTF_K_FORWARD:
+            return tname if tname else "<fwd>"
+        if kind == CTF_K_ARRAY:
+            if self._version >= CTF_VERSION_3 and len(t.extra) >= 12:
+                elem_type = struct.unpack_from("<I", t.extra, 0)[0]
+                nelems = struct.unpack_from("<I", t.extra, 8)[0]
+                return f"{self.name(elem_type)}[{nelems}]"
+            if self._version < CTF_VERSION_3 and len(t.extra) >= 6:
+                elem_type = struct.unpack_from("<H", t.extra, 0)[0]
+                nelems = struct.unpack_from("<H", t.extra, 4)[0]
+                return f"{self.name(elem_type)}[{nelems}]"
+            return "[]"
+        if kind == CTF_K_FUNCTION:
+            ret = self.name(t.size_or_type)
+            return f"{ret}(...)"
+
+        return f"<ctf_kind_{kind}:{type_id}>"
+
+    def _resolve_size(self, type_id: int) -> int:
+        if type_id == 0:
+            return 0
+        t = self._get(type_id)
+        if t is None:
+            return 0
+
+        kind = t.kind
+
+        if kind in (CTF_K_STRUCT, CTF_K_UNION, CTF_K_ENUM):
+            return t.size_or_type
+
+        if kind == CTF_K_INTEGER:
+            if len(t.extra) >= 4:
+                enc = struct.unpack_from("<I", t.extra, 0)[0]
+                nr_bits = enc & 0xFFFF
+                return (nr_bits + 7) // 8
+            return 0
+
+        if kind == CTF_K_FLOAT:
+            if len(t.extra) >= 4:
+                enc = struct.unpack_from("<I", t.extra, 0)[0]
+                nr_bits = enc & 0xFFFF
+                return (nr_bits + 7) // 8
+            return 0
+
+        if kind == CTF_K_POINTER:
+            return 8  # assume 64-bit
+
+        if kind == CTF_K_ARRAY:
+            if self._version >= CTF_VERSION_3 and len(t.extra) >= 12:
+                elem_type, _, nelems = struct.unpack_from("<III", t.extra, 0)
+                return self.size(elem_type) * nelems
+            if self._version < CTF_VERSION_3 and len(t.extra) >= 6:
+                elem_type, _, nelems = struct.unpack_from("<HHH", t.extra, 0)
+                return self.size(elem_type) * nelems
+            return 0
+
+        if kind in (CTF_K_TYPEDEF, CTF_K_VOLATILE, CTF_K_CONST, CTF_K_RESTRICT):
+            return self.size(t.size_or_type)
+
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# High-level extraction
+# ---------------------------------------------------------------------------
+
+def _extract_structs(
+    types: list[CtfType], resolver: _TypeResolver,
+    str_data: bytes, version: int,
+) -> dict[str, StructLayout]:
+    """Extract struct/union layouts from CTF types."""
+    structs: dict[str, StructLayout] = {}
+
+    for t in types:
+        if t.kind not in (CTF_K_STRUCT, CTF_K_UNION):
+            continue
+
+        name = _read_string(str_data, t.name_off)
+        if not name:
+            continue
+
+        fields: list[FieldInfo] = []
+        byte_size = t.size_or_type
+        is_large = byte_size >= 0x2000
+
+        for i in range(t.vlen):
+            if version >= CTF_VERSION_3:
+                if is_large:
+                    off = i * 12
+                    if off + 12 > len(t.extra):
+                        break
+                    m_name_off = struct.unpack_from("<I", t.extra, off)[0]
+                    m_off_hi = struct.unpack_from("<I", t.extra, off + 4)[0]
+                    m_off_lo = struct.unpack_from("<I", t.extra, off + 8)[0]
+                    m_type = m_off_hi >> 16  # upper 16 bits = type
+                    m_offset = ((m_off_hi & 0xFFFF) << 32) | m_off_lo
+                else:
+                    off = i * 8
+                    if off + 8 > len(t.extra):
+                        break
+                    m_name_off, m_off_val = struct.unpack_from("<II", t.extra, off)
+                    m_type = m_off_val >> 16  # upper 16 bits = type
+                    m_offset = m_off_val & 0xFFFF  # lower 16 bits = bit offset
+            else:
+                # CTF v2
+                if is_large:
+                    off = i * 8
+                    if off + 8 > len(t.extra):
+                        break
+                    m_name_off = struct.unpack_from("<H", t.extra, off)[0]
+                    m_type = struct.unpack_from("<H", t.extra, off + 2)[0]
+                    m_off_hi = struct.unpack_from("<H", t.extra, off + 4)[0]
+                    m_off_lo = struct.unpack_from("<H", t.extra, off + 6)[0]
+                    m_offset = (m_off_hi << 16) | m_off_lo
+                else:
+                    off = i * 4
+                    if off + 4 > len(t.extra):
+                        break
+                    m_name_off, m_off_val = struct.unpack_from("<HH", t.extra, off)
+                    m_type = (m_off_val >> 10) & 0x3F  # v2 packs type in offset
+                    m_offset = m_off_val & 0x3FF
+
+            m_name = _read_string(str_data, m_name_off)
+            byte_offset = m_offset // 8
+            bit_offset = m_offset % 8
+
+            fields.append(FieldInfo(
+                name=m_name,
+                type_name=resolver.name(m_type),
+                byte_offset=byte_offset,
+                byte_size=resolver.size(m_type),
+                bit_offset=bit_offset if bit_offset else 0,
+                bit_size=0,  # CTF doesn't encode bitfield size directly
+            ))
+
+        layout = StructLayout(
+            name=name,
+            byte_size=byte_size,
+            alignment=0,
+            fields=fields,
+            is_union=(t.kind == CTF_K_UNION),
+        )
+
+        if name not in structs:
+            structs[name] = layout
+
+    return structs
+
+
+def _extract_enums(
+    types: list[CtfType], str_data: bytes,
+) -> dict[str, EnumInfo]:
+    """Extract enum types from CTF."""
+    enums: dict[str, EnumInfo] = {}
+
+    for t in types:
+        if t.kind != CTF_K_ENUM:
+            continue
+
+        name = _read_string(str_data, t.name_off)
+        if not name:
+            continue
+
+        members: dict[str, int] = {}
+        for i in range(t.vlen):
+            off = i * 8
+            if off + 8 > len(t.extra):
+                break
+            e_name_off, e_val = struct.unpack_from("<Ii", t.extra, off)
+            e_name = _read_string(str_data, e_name_off)
+            if e_name:
+                members[e_name] = e_val
+
+        if name not in enums:
+            enums[name] = EnumInfo(
+                name=name,
+                underlying_byte_size=t.size_or_type,
+                members=members,
+            )
+
+    return enums
+
+
+def _extract_typedefs(
+    types: list[CtfType], resolver: _TypeResolver, str_data: bytes,
+) -> dict[str, str]:
+    """Extract typedef mappings."""
+    typedefs: dict[str, str] = {}
+    for t in types:
+        if t.kind != CTF_K_TYPEDEF:
+            continue
+        name = _read_string(str_data, t.name_off)
+        if not name:
+            continue
+        target = resolver.name(t.size_or_type)
+        if name not in typedefs:
+            typedefs[name] = target
+    return typedefs
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_ctf_metadata(elf_path: Path) -> CtfMetadata:
+    """Parse CTF section from an ELF file and return CtfMetadata.
+
+    Returns ``CtfMetadata()`` on any error.  Never raises.
+    """
+    empty = CtfMetadata()
+
+    try:
+        raw = _read_ctf_section(elf_path)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_ctf_metadata: failed to read .ctf from %s: %s", elf_path, exc)
+        return empty
+
+    if raw is None:
+        log.debug("parse_ctf_metadata: no .ctf section in %s", elf_path)
+        return empty
+
+    return parse_ctf_from_bytes(raw)
+
+
+def parse_ctf_from_bytes(data: bytes) -> CtfMetadata:
+    """Parse CTF from raw bytes (useful for testing without ELF wrapper).
+
+    Returns ``CtfMetadata()`` on any error.  Never raises.
+    """
+    empty = CtfMetadata()
+
+    try:
+        header = _parse_header(data)
+    except (ValueError, struct.error) as exc:
+        log.warning("parse_ctf_from_bytes: bad header: %s", exc)
+        return empty
+
+    # Decompress if needed
+    try:
+        data = _decompress_if_needed(data, header)
+        # Re-parse header after decompression (offsets may have changed)
+        if header.flags & CTF_F_COMPRESS:
+            header = _parse_header(data)
+    except (ValueError, zlib.error) as exc:
+        log.warning("parse_ctf_from_bytes: decompression failed: %s", exc)
+        return empty
+
+    hdr_size = _CTF_V3_HEADER_SIZE
+    type_start = hdr_size + header.type_off
+    type_end = hdr_size + header.str_off  # type section ends where string section begins
+    str_start = hdr_size + header.str_off
+    str_end = str_start + header.str_len
+
+    if type_end > len(data) or str_end > len(data):
+        log.warning("parse_ctf_from_bytes: section bounds exceed data size")
+        return empty
+
+    type_data = data[type_start:type_end]
+    str_data = data[str_start:str_end]
+
+    try:
+        types = _parse_types(type_data, header.version)
+    except (struct.error, ValueError) as exc:
+        log.warning("parse_ctf_from_bytes: type parsing failed: %s", exc)
+        return empty
+
+    resolver = _TypeResolver(types, str_data, header.version)
+
+    meta = CtfMetadata(has_ctf=True, type_count=len(types) - 1)
+
+    try:
+        meta.structs = _extract_structs(types, resolver, str_data, header.version)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_ctf_from_bytes: struct extraction failed: %s", exc)
+
+    try:
+        meta.enums = _extract_enums(types, str_data)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_ctf_from_bytes: enum extraction failed: %s", exc)
+
+    try:
+        meta.typedefs = _extract_typedefs(types, resolver, str_data)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("parse_ctf_from_bytes: typedef extraction failed: %s", exc)
+
+    return meta

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import re
 import shlex
@@ -46,6 +47,8 @@ from .model import (
     Variable,
     Visibility,
 )
+
+log = logging.getLogger(__name__)
 
 
 def _castxml_available() -> bool:
@@ -1103,20 +1106,19 @@ def _resolve_debug_metadata(
     BTF/CTF data is converted to DwarfMetadata for checker compatibility.
     """
     from .dwarf_advanced import AdvancedDwarfMetadata
-    from .dwarf_metadata import DwarfMetadata
 
     if debug_format == "btf":
         from .btf_metadata import parse_btf_metadata
         btf = parse_btf_metadata(so_path)
         if not btf.has_btf:
-            _logger.warning("BTF requested but no .BTF section in %s", so_path)
+            log.warning("BTF requested but no .BTF section in %s", so_path)
         return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
 
     if debug_format == "ctf":
         from .ctf_metadata import parse_ctf_metadata
         ctf = parse_ctf_metadata(so_path)
         if not ctf.has_ctf:
-            _logger.warning("CTF requested but no .ctf section in %s", so_path)
+            log.warning("CTF requested but no .ctf section in %s", so_path)
         return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
 
     if debug_format == "dwarf":
@@ -1132,7 +1134,7 @@ def _resolve_debug_metadata(
         if has_btf_section(so_path):
             btf = parse_btf_metadata(so_path)
             if btf.has_btf:
-                _logger.info("Using BTF debug info from %s (kernel binary)", so_path)
+                log.info("Using BTF debug info from %s (kernel binary)", so_path)
                 return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
 
     # DWARF > BTF > CTF for userspace (or kernel fallback)
@@ -1146,7 +1148,7 @@ def _resolve_debug_metadata(
     if has_btf_section(so_path):
         btf = parse_btf_metadata(so_path)
         if btf.has_btf:
-            _logger.info("No DWARF, falling back to BTF in %s", so_path)
+            log.info("No DWARF, falling back to BTF in %s", so_path)
             return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
 
     # Fallback to CTF
@@ -1154,7 +1156,7 @@ def _resolve_debug_metadata(
     if has_ctf_section(so_path):
         ctf = parse_ctf_metadata(so_path)
         if ctf.has_ctf:
-            _logger.info("No DWARF/BTF, falling back to CTF in %s", so_path)
+            log.info("No DWARF/BTF, falling back to CTF in %s", so_path)
             return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
 
     # No debug info at all — return empty DWARF metadata

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1014,6 +1014,7 @@ def dump(
     nostdinc: bool = False,
     lang: str | None = None,
     dwarf_only: bool = False,
+    debug_format: str | None = None,
 ) -> AbiSnapshot:
     """Create an AbiSnapshot from a shared library + headers.
 
@@ -1035,6 +1036,8 @@ def dump(
         lang: Force language ("C" or "C++").
         dwarf_only: If True, force DWARF-only mode even when headers
             are available (ADR-003).
+        debug_format: Force debug format: "dwarf", "btf", or "ctf".
+            None = auto-detect (DWARF preferred for userspace, BTF for kernel).
 
     Returns:
         AbiSnapshot with functions, variables, and types populated.
@@ -1067,7 +1070,95 @@ def dump(
         gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
         sysroot=sysroot, nostdinc=nostdinc, lang=lang,
         dwarf_only=dwarf_only,
+        debug_format=debug_format,
     )
+
+
+def _is_kernel_binary(path: Path) -> bool:
+    """Heuristic: is this a kernel binary (vmlinux, *.ko, *.ko.xz, *.ko.zst)?"""
+    name = path.name
+    if name == "vmlinux":
+        return True
+    suffixes = path.suffixes  # e.g. ['.ko', '.xz']
+    suffix_str = "".join(suffixes)
+    if suffix_str in (".ko", ".ko.xz", ".ko.zst", ".ko.gz"):
+        return True
+    # Check for .modinfo section (kernel module indicator)
+    try:
+        from elftools.elf.elffile import ELFFile
+        with open(path, "rb") as f:
+            elf = ELFFile(f)  # type: ignore[no-untyped-call]
+            return elf.get_section_by_name(".modinfo") is not None  # type: ignore[no-untyped-call]
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _resolve_debug_metadata(
+    so_path: Path,
+    debug_format: str | None,
+) -> tuple[Any, Any]:
+    """Resolve debug metadata using the specified or auto-detected format.
+
+    Returns (dwarf_meta, dwarf_adv) — the same types as parse_dwarf().
+    BTF/CTF data is converted to DwarfMetadata for checker compatibility.
+    """
+    from .dwarf_advanced import AdvancedDwarfMetadata
+    from .dwarf_metadata import DwarfMetadata
+
+    if debug_format == "btf":
+        from .btf_metadata import parse_btf_metadata
+        btf = parse_btf_metadata(so_path)
+        if not btf.has_btf:
+            _logger.warning("BTF requested but no .BTF section in %s", so_path)
+        return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    if debug_format == "ctf":
+        from .ctf_metadata import parse_ctf_metadata
+        ctf = parse_ctf_metadata(so_path)
+        if not ctf.has_ctf:
+            _logger.warning("CTF requested but no .ctf section in %s", so_path)
+        return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    if debug_format == "dwarf":
+        from .dwarf_unified import parse_dwarf
+        return parse_dwarf(so_path)
+
+    # Auto-detect: kernel binaries prefer BTF, userspace prefers DWARF
+    is_kernel = _is_kernel_binary(so_path)
+
+    if is_kernel:
+        # BTF > DWARF > CTF for kernel binaries
+        from .btf_metadata import has_btf_section, parse_btf_metadata
+        if has_btf_section(so_path):
+            btf = parse_btf_metadata(so_path)
+            if btf.has_btf:
+                _logger.info("Using BTF debug info from %s (kernel binary)", so_path)
+                return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    # DWARF > BTF > CTF for userspace (or kernel fallback)
+    from .dwarf_unified import parse_dwarf
+    dwarf_meta, dwarf_adv = parse_dwarf(so_path)
+    if dwarf_meta.has_dwarf:
+        return dwarf_meta, dwarf_adv
+
+    # Fallback to BTF if DWARF not available
+    from .btf_metadata import has_btf_section, parse_btf_metadata
+    if has_btf_section(so_path):
+        btf = parse_btf_metadata(so_path)
+        if btf.has_btf:
+            _logger.info("No DWARF, falling back to BTF in %s", so_path)
+            return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    # Fallback to CTF
+    from .ctf_metadata import has_ctf_section, parse_ctf_metadata
+    if has_ctf_section(so_path):
+        ctf = parse_ctf_metadata(so_path)
+        if ctf.has_ctf:
+            _logger.info("No DWARF/BTF, falling back to CTF in %s", so_path)
+            return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    # No debug info at all — return empty DWARF metadata
+    return dwarf_meta, dwarf_adv
 
 
 _ELF_VIS_MAP: dict[str, ElfVisibility] = {
@@ -1107,11 +1198,11 @@ def _dump_elf(
     nostdinc: bool = False,
     lang: str | None = None,
     dwarf_only: bool = False,
+    debug_format: str | None = None,
 ) -> AbiSnapshot:
-    """ELF-specific dump: pyelftools + DWARF + castxml."""
+    """ELF-specific dump: pyelftools + debug info (DWARF/BTF/CTF) + castxml."""
     exported_dynamic, exported_static = _pyelftools_exported_symbols(so_path)
 
-    from .dwarf_unified import parse_dwarf
     from .elf_metadata import SymbolType, parse_elf_metadata
 
     elf_meta = parse_elf_metadata(so_path)
@@ -1139,7 +1230,7 @@ def _dump_elf(
         }
         # Full set for CastxmlParser: determines PUBLIC vs ELF_ONLY visibility
         exported_dynamic = exported_dynamic_funcs | exported_dynamic_objects | exported_dynamic_tls
-    dwarf_meta, dwarf_adv = parse_dwarf(so_path)
+    dwarf_meta, dwarf_adv = _resolve_debug_metadata(so_path, debug_format)
 
     profile_hint: str | None = None
     if lang is not None:

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -105,12 +105,26 @@ class EnumInfo:
 
 @dataclass
 class DwarfMetadata:
-    """All DWARF-derived ABI-relevant type information from one .so."""
+    """All DWARF-derived ABI-relevant type information from one .so.
+
+    Implements the TypeMetadataSource protocol (see type_metadata.py).
+    """
     # name → StructLayout  (structs, classes, unions)
     structs: dict[str, StructLayout] = field(default_factory=dict)
     # name → EnumInfo
     enums: dict[str, EnumInfo] = field(default_factory=dict)
     has_dwarf: bool = False   # False = binary had no DWARF info
+
+    # TypeMetadataSource protocol methods
+    @property
+    def has_data(self) -> bool:
+        return self.has_dwarf
+
+    def get_struct_layout(self, name: str) -> StructLayout | None:
+        return self.structs.get(name)
+
+    def get_enum_info(self, name: str) -> EnumInfo | None:
+        return self.enums.get(name)
 
 
 # Tags whose subtrees we never descend into (function-local types, inline

--- a/abicheck/type_metadata.py
+++ b/abicheck/type_metadata.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified TypeMetadataSource protocol for all debug format readers.
+
+All debug format metadata classes (DwarfMetadata, BtfMetadata, CtfMetadata)
+implement this protocol so the checker's detectors can consume type
+information without knowing the source format.
+
+See ADR-007 for design rationale.
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .dwarf_metadata import EnumInfo, StructLayout
+
+
+@runtime_checkable
+class TypeMetadataSource(Protocol):
+    """Common interface for all debug format readers.
+
+    Implemented by: DwarfMetadata, BtfMetadata, CtfMetadata.
+    The checker's detectors accept this protocol instead of a concrete class.
+    """
+
+    def get_struct_layout(self, name: str) -> StructLayout | None:
+        """Look up a struct/union layout by name."""
+        ...
+
+    def get_enum_info(self, name: str) -> EnumInfo | None:
+        """Look up an enum type by name."""
+        ...
+
+    @property
+    def has_data(self) -> bool:
+        """Whether this source has any type data available."""
+        ...
+
+
+def resolve_debug_metadata(
+    *,
+    dwarf: object | None = None,
+    btf: object | None = None,
+    ctf: object | None = None,
+    prefer_btf: bool = False,
+) -> TypeMetadataSource | None:
+    """Select the best available debug metadata source.
+
+    Priority (userspace, default):  DWARF > BTF > CTF
+    Priority (kernel, prefer_btf):  BTF > DWARF > CTF
+
+    Returns None if no source has data.
+    """
+    sources: list[object]
+    if prefer_btf:
+        sources = [btf, dwarf, ctf]
+    else:
+        sources = [dwarf, btf, ctf]
+
+    for src in sources:
+        if src is not None and isinstance(src, TypeMetadataSource) and src.has_data:
+            return src
+
+    return None

--- a/tests/test_btf_metadata.py
+++ b/tests/test_btf_metadata.py
@@ -42,6 +42,7 @@ from abicheck.btf_metadata import (
     BTF_MAGIC,
     BTF_VERSION,
     BtfMetadata,
+    BtfType,
     _extra_data_size,
     _parse_header,
     _parse_types,
@@ -555,23 +556,15 @@ class TestTypeResolverExtended:
         assert r.size(2) == 40
 
     def test_array_short_extra(self) -> None:
-        """Array with short extra data (< 12 bytes) returns fallback names."""
-        b = BtfBuilder()
-        # Manually add array type with short extra (8 bytes instead of 12)
-        # This will still parse since BtfBuilder puts extra directly in the entry
-        # but the resolver will see len(extra) < 12
-        array_extra = struct.pack("<III", 0, 0, 0)[:8]  # only 8 bytes
-        b.add_type("", BTF_KIND_ARRAY, 0, 0, extra=array_extra)
-        r = self._build_and_resolve(b)
-        # _parse_types expects 12 bytes for array, but we only provided 8
-        # The type will still be parsed since we're cheating through BtfBuilder
-        # However, the resolver's name/size methods check extra length
-        # Actually with BTF_KIND_ARRAY, _extra_data_size returns 12,
-        # but builder gave 8, so parse_types reads 12 (including 4 bytes of next data)
-        # This is fragile; let's just test the resolver handles it
-        # Since the type might not parse correctly, just verify no crash
-        assert isinstance(r.name(1), str)
-        assert isinstance(r.size(1), int)
+        """Array with short extra data (< 12 bytes) returns fallback values."""
+        # Construct BtfType directly with truncated extra to bypass _parse_types
+        void = BtfType(type_id=0, name_off=0, info=0, size_or_type=0, extra=b"")
+        array_info = (BTF_KIND_ARRAY << 24)
+        arr = BtfType(type_id=1, name_off=0, info=array_info, size_or_type=0,
+                      extra=b"\x00" * 8)  # only 8 bytes, need 12
+        resolver = _TypeResolver([void, arr], b"\x00")
+        assert resolver.name(1) == "[]"
+        assert resolver.size(1) == 0
 
     def test_volatile_name(self) -> None:
         b = BtfBuilder()
@@ -780,8 +773,8 @@ class TestTypeResolverExtended:
 # ---------------------------------------------------------------------------
 
 class TestParseHeaderExtended:
-    def test_version_warning(self) -> None:
-        """Non-standard BTF version should still parse (with warning)."""
+    def test_nonstandard_version_parses(self) -> None:
+        """Non-standard BTF version should still parse."""
         hdr = struct.pack("<HBBIIIII", BTF_MAGIC, 99, 0, 24, 0, 0, 0, 1)
         str_data = b"\x00"
         data = hdr + str_data

--- a/tests/test_btf_metadata.py
+++ b/tests/test_btf_metadata.py
@@ -20,27 +20,35 @@ import struct
 import pytest
 
 from abicheck.btf_metadata import (
+    BTF_KIND_ARRAY,
     BTF_KIND_CONST,
+    BTF_KIND_DATASEC,
+    BTF_KIND_DECL_TAG,
     BTF_KIND_ENUM,
     BTF_KIND_ENUM64,
+    BTF_KIND_FLOAT,
     BTF_KIND_FUNC,
     BTF_KIND_FUNC_PROTO,
+    BTF_KIND_FWD,
     BTF_KIND_INT,
     BTF_KIND_PTR,
+    BTF_KIND_RESTRICT,
     BTF_KIND_STRUCT,
+    BTF_KIND_TYPE_TAG,
     BTF_KIND_TYPEDEF,
     BTF_KIND_UNION,
+    BTF_KIND_VAR,
+    BTF_KIND_VOLATILE,
     BTF_MAGIC,
     BTF_VERSION,
     BtfMetadata,
-    FuncProto,
-    _TypeResolver,
+    _extra_data_size,
     _parse_header,
     _parse_types,
     _read_string,
+    _TypeResolver,
     parse_btf_from_bytes,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers to build synthetic BTF blobs
@@ -441,3 +449,455 @@ class TestTypeMetadataSourceProtocol:
         from abicheck.type_metadata import TypeMetadataSource
         meta = BtfMetadata(has_btf=True)
         assert isinstance(meta, TypeMetadataSource)
+
+
+# ---------------------------------------------------------------------------
+# BtfMetadata accessor methods
+# ---------------------------------------------------------------------------
+
+class TestBtfMetadataAccessors:
+    def test_get_function_proto(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        params = struct.pack("<II", 0, 1)  # unnamed param of type int
+        b.add_type("", BTF_KIND_FUNC_PROTO, 1, 1, extra=params)
+        b.add_type("myfunc", BTF_KIND_FUNC, 0, 2)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.get_function_proto("myfunc") is not None
+        assert meta.get_function_proto("nonexistent") is None
+
+    def test_get_typedef(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("myint", BTF_KIND_TYPEDEF, 0, 1)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.get_typedef("myint") == "int"
+        assert meta.get_typedef("nonexistent") is None
+
+    def test_empty_metadata(self) -> None:
+        meta = BtfMetadata()
+        assert meta.has_data is False
+        assert meta.get_struct_layout("x") is None
+        assert meta.get_enum_info("x") is None
+        assert meta.get_function_proto("x") is None
+        assert meta.get_typedef("x") is None
+
+
+# ---------------------------------------------------------------------------
+# _extra_data_size coverage
+# ---------------------------------------------------------------------------
+
+class TestExtraDataSize:
+    def test_float(self) -> None:
+        assert _extra_data_size(BTF_KIND_FLOAT, 0) == 4
+
+    def test_array(self) -> None:
+        assert _extra_data_size(BTF_KIND_ARRAY, 0) == 12
+
+    def test_var(self) -> None:
+        assert _extra_data_size(BTF_KIND_VAR, 0) == 4
+
+    def test_datasec(self) -> None:
+        assert _extra_data_size(BTF_KIND_DATASEC, 3) == 36
+
+    def test_decl_tag(self) -> None:
+        assert _extra_data_size(BTF_KIND_DECL_TAG, 0) == 4
+
+    def test_fwd_no_extra(self) -> None:
+        assert _extra_data_size(BTF_KIND_FWD, 0) == 0
+
+    def test_typedef_no_extra(self) -> None:
+        assert _extra_data_size(BTF_KIND_TYPEDEF, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Extended type resolver coverage
+# ---------------------------------------------------------------------------
+
+class TestTypeResolverExtended:
+    def _build_and_resolve(self, builder: BtfBuilder) -> _TypeResolver:
+        data = builder.build()
+        hdr = _parse_header(data)
+        type_start = hdr.hdr_len + hdr.type_off
+        str_start = hdr.hdr_len + hdr.str_off
+        str_end = str_start + hdr.str_len
+        types = _parse_types(data[type_start:type_start + hdr.type_len])
+        return _TypeResolver(types, data[str_start:str_end])
+
+    def test_float_name_and_size(self) -> None:
+        b = BtfBuilder()
+        enc = struct.pack("<I", 32)
+        b.add_type("float", BTF_KIND_FLOAT, 0, 4, extra=enc)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "float"
+        assert r.size(1) == 4
+
+    def test_float_anonymous(self) -> None:
+        b = BtfBuilder()
+        enc = struct.pack("<I", 64)
+        b.add_type("", BTF_KIND_FLOAT, 0, 8, extra=enc)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "float"
+
+    def test_array_name_and_size(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        # array: elem_type=1(int), index_type=1, nelems=10
+        array_extra = struct.pack("<III", 1, 1, 10)
+        b.add_type("", BTF_KIND_ARRAY, 0, 0, extra=array_extra)
+        r = self._build_and_resolve(b)
+        assert r.name(2) == "int[10]"
+        assert r.size(2) == 40
+
+    def test_array_short_extra(self) -> None:
+        """Array with short extra data (< 12 bytes) returns fallback names."""
+        b = BtfBuilder()
+        # Manually add array type with short extra (8 bytes instead of 12)
+        # This will still parse since BtfBuilder puts extra directly in the entry
+        # but the resolver will see len(extra) < 12
+        array_extra = struct.pack("<III", 0, 0, 0)[:8]  # only 8 bytes
+        b.add_type("", BTF_KIND_ARRAY, 0, 0, extra=array_extra)
+        r = self._build_and_resolve(b)
+        # _parse_types expects 12 bytes for array, but we only provided 8
+        # The type will still be parsed since we're cheating through BtfBuilder
+        # However, the resolver's name/size methods check extra length
+        # Actually with BTF_KIND_ARRAY, _extra_data_size returns 12,
+        # but builder gave 8, so parse_types reads 12 (including 4 bytes of next data)
+        # This is fragile; let's just test the resolver handles it
+        # Since the type might not parse correctly, just verify no crash
+        assert isinstance(r.name(1), str)
+        assert isinstance(r.size(1), int)
+
+    def test_volatile_name(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_VOLATILE, 0, 1)
+        r = self._build_and_resolve(b)
+        assert r.name(2) == "volatile int"
+
+    def test_restrict_name(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_RESTRICT, 0, 1)
+        r = self._build_and_resolve(b)
+        assert r.name(2) == "restrict int"
+
+    def test_fwd_struct(self) -> None:
+        b = BtfBuilder()
+        b.add_type("mystruct", BTF_KIND_FWD, 0, 0, kflag=0)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "mystruct"
+
+    def test_fwd_union(self) -> None:
+        b = BtfBuilder()
+        b.add_type("", BTF_KIND_FWD, 0, 0, kflag=1)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<fwd union>"
+
+    def test_func_proto_name(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_FUNC_PROTO, 0, 1, extra=b"")
+        r = self._build_and_resolve(b)
+        assert r.name(2) == "int(...)"
+
+    def test_func_name(self) -> None:
+        b = BtfBuilder()
+        b.add_type("myfn", BTF_KIND_FUNC, 0, 0)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "myfn"
+
+    def test_func_anonymous(self) -> None:
+        b = BtfBuilder()
+        b.add_type("", BTF_KIND_FUNC, 0, 0)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<func>"
+
+    def test_var_name(self) -> None:
+        b = BtfBuilder()
+        var_extra = struct.pack("<I", 0)  # linkage
+        b.add_type("myvar", BTF_KIND_VAR, 0, 0, extra=var_extra)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "myvar"
+
+    def test_var_anonymous(self) -> None:
+        b = BtfBuilder()
+        var_extra = struct.pack("<I", 0)
+        b.add_type("", BTF_KIND_VAR, 0, 0, extra=var_extra)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<var>"
+
+    def test_type_tag_name(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_TYPE_TAG, 0, 1)
+        r = self._build_and_resolve(b)
+        assert r.name(2) == "int"
+
+    def test_unknown_kind(self) -> None:
+        b = BtfBuilder()
+        # Use an unrecognized kind (30)
+        name_off = 0
+        info = (30 << 24) | 0
+        entry = struct.pack("<III", name_off, info, 0)
+        b._type_entries.append(entry)
+        r = self._build_and_resolve(b)
+        assert "<btf_kind_30:" in r.name(1)
+
+    def test_invalid_type_id(self) -> None:
+        b = BtfBuilder()
+        r = self._build_and_resolve(b)
+        assert "<btf:" in r.name(999)
+        assert r.size(999) == 0
+
+    def test_cycle_detection_name(self) -> None:
+        b = BtfBuilder()
+        # TYPEDEF pointing to itself: id=1 references id=1
+        b.add_type("self_ref", BTF_KIND_TYPEDEF, 0, 1)
+        r = self._build_and_resolve(b)
+        # Should not infinite loop; returns "..." for cycle
+        result = r.name(1)
+        assert result == "self_ref"  # typedef with name returns name
+
+    def test_cycle_detection_size(self) -> None:
+        b = BtfBuilder()
+        # TYPEDEF id=1 -> TYPEDEF id=2 -> TYPEDEF id=1
+        b.add_type("a", BTF_KIND_TYPEDEF, 0, 2)
+        b.add_type("b", BTF_KIND_TYPEDEF, 0, 1)
+        r = self._build_and_resolve(b)
+        # Should not infinite loop; cycle returns 0
+        assert r.size(1) == 0
+
+    def test_size_struct(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        m_name = b.add_string("x")
+        members = struct.pack("<III", m_name, 1, 0)
+        b.add_type("s", BTF_KIND_STRUCT, 1, 16, extra=members)
+        r = self._build_and_resolve(b)
+        assert r.size(2) == 16
+
+    def test_size_enum(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("e", BTF_KIND_ENUM, 1, 4, extra=entries)
+        r = self._build_and_resolve(b)
+        assert r.size(1) == 4
+
+    def test_size_enum64(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<III", e_name, 0, 0)
+        b.add_type("e64", BTF_KIND_ENUM64, 1, 8, extra=entries)
+        r = self._build_and_resolve(b)
+        assert r.size(1) == 8
+
+    def test_size_int_from_extra(self) -> None:
+        b = BtfBuilder()
+        # INT with 16 bits
+        int_enc = struct.pack("<I", 16)
+        b.add_type("short", BTF_KIND_INT, 0, 2, extra=int_enc)
+        r = self._build_and_resolve(b)
+        assert r.size(1) == 2
+
+    def test_size_int_from_size_or_type(self) -> None:
+        """INT size falls back to size_or_type when extra is small."""
+        b = BtfBuilder()
+        # Build normally first, then we test INT with proper encoding
+        int_enc = struct.pack("<I", 64)  # 64 bits = 8 bytes
+        b.add_type("long", BTF_KIND_INT, 0, 8, extra=int_enc)
+        r = self._build_and_resolve(b)
+        assert r.size(1) == 8
+
+    def test_size_float(self) -> None:
+        b = BtfBuilder()
+        float_enc = struct.pack("<I", 64)
+        b.add_type("double", BTF_KIND_FLOAT, 0, 8, extra=float_enc)
+        r = self._build_and_resolve(b)
+        assert r.size(1) == 8
+
+    def test_size_typedef(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("myint", BTF_KIND_TYPEDEF, 0, 1)
+        r = self._build_and_resolve(b)
+        assert r.size(2) == 4
+
+    def test_size_volatile(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_VOLATILE, 0, 1)
+        r = self._build_and_resolve(b)
+        assert r.size(2) == 4
+
+    def test_anon_struct_name(self) -> None:
+        b = BtfBuilder()
+        b.add_type("", BTF_KIND_STRUCT, 0, 0, extra=b"")
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<anon struct>"
+
+    def test_anon_union_name(self) -> None:
+        b = BtfBuilder()
+        b.add_type("", BTF_KIND_UNION, 0, 0, extra=b"")
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<anon union>"
+
+    def test_anon_enum_name(self) -> None:
+        b = BtfBuilder()
+        b.add_type("", BTF_KIND_ENUM, 0, 4, extra=b"")
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<anon enum>"
+
+    def test_int_anonymous(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("", BTF_KIND_INT, 0, 4, extra=int_enc)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "int"
+
+    def test_fwd_anon_struct(self) -> None:
+        b = BtfBuilder()
+        b.add_type("", BTF_KIND_FWD, 0, 0, kflag=0)
+        r = self._build_and_resolve(b)
+        assert r.name(1) == "<fwd struct>"
+
+
+# ---------------------------------------------------------------------------
+# Header edge cases
+# ---------------------------------------------------------------------------
+
+class TestParseHeaderExtended:
+    def test_version_warning(self) -> None:
+        """Non-standard BTF version should still parse (with warning)."""
+        hdr = struct.pack("<HBBIIIII", BTF_MAGIC, 99, 0, 24, 0, 0, 0, 1)
+        str_data = b"\x00"
+        data = hdr + str_data
+        result = _parse_header(data)
+        assert result.version == 99
+
+    def test_string_no_null_terminator(self) -> None:
+        """String without null terminator returns remainder."""
+        data = b"no_null"
+        assert _read_string(data, 0) == "no_null"
+
+
+# ---------------------------------------------------------------------------
+# Anonymous/unnamed enum and func proto edge cases
+# ---------------------------------------------------------------------------
+
+class TestBtfEdgeCases:
+    def test_anonymous_enum_skipped(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("", BTF_KIND_ENUM, 1, 4, extra=entries)
+        meta = parse_btf_from_bytes(b.build())
+        assert len(meta.enums) == 0
+
+    def test_anonymous_enum64_skipped(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<III", e_name, 0, 0)
+        b.add_type("", BTF_KIND_ENUM64, 1, 8, extra=entries)
+        meta = parse_btf_from_bytes(b.build())
+        assert len(meta.enums) == 0
+
+    def test_anonymous_func_skipped(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_FUNC_PROTO, 0, 1, extra=b"")
+        b.add_type("", BTF_KIND_FUNC, 0, 2)
+        meta = parse_btf_from_bytes(b.build())
+        assert len(meta.func_protos) == 0
+
+    def test_anonymous_typedef_skipped(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_TYPEDEF, 0, 1)
+        meta = parse_btf_from_bytes(b.build())
+        assert len(meta.typedefs) == 0
+
+    def test_func_without_proto(self) -> None:
+        """FUNC that references non-FUNC_PROTO type is skipped."""
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("bad_func", BTF_KIND_FUNC, 0, 1)  # points to INT, not PROTO
+        meta = parse_btf_from_bytes(b.build())
+        assert len(meta.func_protos) == 0
+
+    def test_truncated_type_section(self) -> None:
+        """Type section that ends mid-entry."""
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        data = b.build()
+        # Chop off last 2 bytes of type data to cause truncation
+        # The header says type_len includes the full type, so we corrupt it
+        hdr = _parse_header(data)
+        type_start = hdr.hdr_len + hdr.type_off
+        # Truncate to only have partial type data (just the 12-byte header, no extra)
+        truncated_type_data = data[type_start:type_start + 12]
+        # The int type needs 4 bytes of extra, so 12 bytes is truncated
+        types = _parse_types(truncated_type_data)
+        # Should get just the void sentinel since the int is truncated
+        assert len(types) == 1
+
+    def test_section_bounds_exceed_data(self) -> None:
+        """Header claiming type/string sections beyond data size."""
+        # Build valid header but with inflated lengths
+        hdr = struct.pack("<HBBIIIII",
+                          BTF_MAGIC, BTF_VERSION, 0, 24,
+                          0, 99999, 0, 1)  # type_len way too large
+        data = hdr + b"\x00"
+        meta = parse_btf_from_bytes(data)
+        assert not meta.has_btf
+
+    def test_type_count(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("float", BTF_KIND_FLOAT, 0, 4, extra=int_enc)
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.type_count == 2
+
+    def test_duplicate_struct_name_first_wins(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+
+        m_name = b.add_string("x")
+        members = struct.pack("<III", m_name, 1, 0)
+        b.add_type("dup", BTF_KIND_STRUCT, 1, 4, extra=members)
+        b.add_type("dup", BTF_KIND_STRUCT, 1, 8, extra=members)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.structs["dup"].byte_size == 4  # first wins
+
+    def test_duplicate_enum_first_wins(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("dup", BTF_KIND_ENUM, 1, 4, extra=entries)
+
+        e2_name = b.add_string("B")
+        entries2 = struct.pack("<Ii", e2_name, 1)
+        b.add_type("dup", BTF_KIND_ENUM, 1, 4, extra=entries2)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert "A" in meta.enums["dup"].members

--- a/tests/test_btf_metadata.py
+++ b/tests/test_btf_metadata.py
@@ -274,14 +274,35 @@ class TestBtfEnums:
         e = meta.enums["big_enum"]
         assert e.members["BIG_VAL"] == 0x1DEADBEEF
 
+    def test_enum64_signed(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("NEG64")
+        # -1 as unsigned 64-bit: lo=0xFFFFFFFF, hi=0xFFFFFFFF
+        entries = struct.pack("<III", e_name, 0xFFFFFFFF, 0xFFFFFFFF)
+        b.add_type("signed64", BTF_KIND_ENUM64, 1, 8, extra=entries, kflag=1)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.enums["signed64"].members["NEG64"] == -1
+
     def test_negative_enum_values(self) -> None:
         b = BtfBuilder()
         e_name = b.add_string("NEG")
         entries = struct.pack("<Ii", e_name, -1)
-        b.add_type("signed_enum", BTF_KIND_ENUM, 1, 4, extra=entries)
+        # kflag=1 marks enumerators as signed
+        b.add_type("signed_enum", BTF_KIND_ENUM, 1, 4, extra=entries, kflag=1)
 
         meta = parse_btf_from_bytes(b.build())
         assert meta.enums["signed_enum"].members["NEG"] == -1
+
+    def test_unsigned_enum_values(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("BIG")
+        entries = struct.pack("<II", e_name, 0xFFFFFFFF)
+        # kflag=0 (default) → unsigned
+        b.add_type("unsigned_enum", BTF_KIND_ENUM, 1, 4, extra=entries)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.enums["unsigned_enum"].members["BIG"] == 0xFFFFFFFF
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_btf_metadata.py
+++ b/tests/test_btf_metadata.py
@@ -1,0 +1,443 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for BTF (BPF Type Format) parser."""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from abicheck.btf_metadata import (
+    BTF_KIND_CONST,
+    BTF_KIND_ENUM,
+    BTF_KIND_ENUM64,
+    BTF_KIND_FUNC,
+    BTF_KIND_FUNC_PROTO,
+    BTF_KIND_INT,
+    BTF_KIND_PTR,
+    BTF_KIND_STRUCT,
+    BTF_KIND_TYPEDEF,
+    BTF_KIND_UNION,
+    BTF_MAGIC,
+    BTF_VERSION,
+    BtfMetadata,
+    FuncProto,
+    _TypeResolver,
+    _parse_header,
+    _parse_types,
+    _read_string,
+    parse_btf_from_bytes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build synthetic BTF blobs
+# ---------------------------------------------------------------------------
+
+class BtfBuilder:
+    """Helper to construct synthetic BTF binary blobs for testing."""
+
+    def __init__(self) -> None:
+        self._strings = bytearray(b"\x00")  # string section starts with NUL
+        self._type_entries: list[bytes] = []
+        self._str_offsets: dict[str, int] = {"": 0}
+
+    def add_string(self, s: str) -> int:
+        """Add a string to the string table, return its offset."""
+        if s in self._str_offsets:
+            return self._str_offsets[s]
+        off = len(self._strings)
+        self._strings.extend(s.encode("utf-8") + b"\x00")
+        self._str_offsets[s] = off
+        return off
+
+    def add_type(self, name: str, kind: int, vlen: int, size_or_type: int,
+                 extra: bytes = b"", kflag: int = 0) -> int:
+        """Add a type entry, return its 1-based type ID."""
+        name_off = self.add_string(name) if name else 0
+        info = (kflag << 31) | (kind << 24) | (vlen & 0xFFFF)
+        entry = struct.pack("<III", name_off, info, size_or_type) + extra
+        self._type_entries.append(entry)
+        return len(self._type_entries)  # 1-based
+
+    def build(self) -> bytes:
+        """Build a complete BTF blob with header + types + strings."""
+        type_data = b"".join(self._type_entries)
+        str_data = bytes(self._strings)
+        hdr_len = 24
+        type_off = 0
+        type_len = len(type_data)
+        str_off = type_len
+        str_len = len(str_data)
+        header = struct.pack("<HBBIIIII",
+                             BTF_MAGIC, BTF_VERSION, 0, hdr_len,
+                             type_off, type_len, str_off, str_len)
+        return header + type_data + str_data
+
+
+# ---------------------------------------------------------------------------
+# String table
+# ---------------------------------------------------------------------------
+
+class TestReadString:
+    def test_basic(self) -> None:
+        data = b"hello\x00world\x00"
+        assert _read_string(data, 0) == "hello"
+        assert _read_string(data, 6) == "world"
+
+    def test_empty(self) -> None:
+        assert _read_string(b"\x00", 0) == ""
+
+    def test_out_of_bounds(self) -> None:
+        assert _read_string(b"abc\x00", 100) == ""
+        assert _read_string(b"abc\x00", -1) == ""
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+class TestParseHeader:
+    def test_valid_header(self) -> None:
+        b = BtfBuilder()
+        data = b.build()
+        hdr = _parse_header(data)
+        assert hdr.magic == BTF_MAGIC
+        assert hdr.version == BTF_VERSION
+        assert hdr.hdr_len == 24
+
+    def test_bad_magic(self) -> None:
+        data = struct.pack("<HBBI", 0xDEAD, 1, 0, 24) + b"\x00" * 16
+        with pytest.raises(ValueError, match="Bad BTF magic"):
+            _parse_header(data)
+
+    def test_too_small(self) -> None:
+        with pytest.raises(ValueError, match="too small"):
+            _parse_header(b"\x00" * 10)
+
+
+# ---------------------------------------------------------------------------
+# Type parsing
+# ---------------------------------------------------------------------------
+
+class TestParseTypes:
+    def test_empty_section(self) -> None:
+        types = _parse_types(b"")
+        assert len(types) == 1  # only void sentinel
+        assert types[0].type_id == 0
+
+    def test_int_type(self) -> None:
+        b = BtfBuilder()
+        # INT encoding: bits=32, offset=0, signed
+        int_enc = struct.pack("<I", (0 << 16) | (0 << 8) | 32)  # 32 bits
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        data = b.build()
+        # Parse just the type section
+        hdr = _parse_header(data)
+        type_start = hdr.hdr_len + hdr.type_off
+        type_end = type_start + hdr.type_len
+        types = _parse_types(data[type_start:type_end])
+        assert len(types) == 2  # void + int
+        assert types[1].kind == BTF_KIND_INT
+
+
+# ---------------------------------------------------------------------------
+# Full parse: structs
+# ---------------------------------------------------------------------------
+
+class TestBtfStructs:
+    def test_simple_struct(self) -> None:
+        b = BtfBuilder()
+        # Add INT type (id=1)
+        int_enc = struct.pack("<I", 32)  # 32 bits
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+
+        # Add struct with 2 members (id=2)
+        # Member: name_off(4) + type(4) + offset(4)
+        m1_name = b.add_string("x")
+        m2_name = b.add_string("y")
+        members = struct.pack("<III", m1_name, 1, 0)     # x: int at offset 0
+        members += struct.pack("<III", m2_name, 1, 32)   # y: int at offset 32 bits
+        b.add_type("point", BTF_KIND_STRUCT, 2, 8, extra=members)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.has_btf
+        assert "point" in meta.structs
+
+        s = meta.structs["point"]
+        assert s.name == "point"
+        assert s.byte_size == 8
+        assert len(s.fields) == 2
+        assert s.fields[0].name == "x"
+        assert s.fields[0].byte_offset == 0
+        assert s.fields[0].type_name == "int"
+        assert s.fields[1].name == "y"
+        assert s.fields[1].byte_offset == 4
+
+    def test_union(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+
+        m1_name = b.add_string("i")
+        m2_name = b.add_string("f")
+        members = struct.pack("<III", m1_name, 1, 0)
+        members += struct.pack("<III", m2_name, 1, 0)
+        b.add_type("my_union", BTF_KIND_UNION, 2, 4, extra=members)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert "my_union" in meta.structs
+        assert meta.structs["my_union"].is_union
+
+    def test_bitfield_struct(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("unsigned int", BTF_KIND_INT, 0, 4, extra=int_enc)
+
+        # kflag=1: offset encodes bitfield_size in bits 24-31
+        m1_name = b.add_string("a")
+        m2_name = b.add_string("b")
+        # a: 3 bits at bit 0, b: 5 bits at bit 3
+        m1_offset = (3 << 24) | 0   # bitfield_size=3, bit_offset=0
+        m2_offset = (5 << 24) | 3   # bitfield_size=5, bit_offset=3
+        members = struct.pack("<III", m1_name, 1, m1_offset)
+        members += struct.pack("<III", m2_name, 1, m2_offset)
+        b.add_type("flags", BTF_KIND_STRUCT, 2, 4, extra=members, kflag=1)
+
+        meta = parse_btf_from_bytes(b.build())
+        s = meta.structs["flags"]
+        assert s.fields[0].bit_size == 3
+        assert s.fields[1].bit_size == 5
+
+    def test_anonymous_struct_skipped(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        # Struct with empty name (anonymous)
+        b.add_type("", BTF_KIND_STRUCT, 0, 0, extra=b"")
+
+        meta = parse_btf_from_bytes(b.build())
+        assert len(meta.structs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Full parse: enums
+# ---------------------------------------------------------------------------
+
+class TestBtfEnums:
+    def test_simple_enum(self) -> None:
+        b = BtfBuilder()
+        e1_name = b.add_string("RED")
+        e2_name = b.add_string("GREEN")
+        e3_name = b.add_string("BLUE")
+        entries = struct.pack("<Ii", e1_name, 0)
+        entries += struct.pack("<Ii", e2_name, 1)
+        entries += struct.pack("<Ii", e3_name, 2)
+        b.add_type("color", BTF_KIND_ENUM, 3, 4, extra=entries)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert "color" in meta.enums
+        e = meta.enums["color"]
+        assert e.underlying_byte_size == 4
+        assert e.members == {"RED": 0, "GREEN": 1, "BLUE": 2}
+
+    def test_enum64(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("BIG_VAL")
+        # ENUM64: name_off(4) + val_lo(4) + val_hi(4)
+        entries = struct.pack("<III", e_name, 0xDEADBEEF, 0x1)
+        b.add_type("big_enum", BTF_KIND_ENUM64, 1, 8, extra=entries)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert "big_enum" in meta.enums
+        e = meta.enums["big_enum"]
+        assert e.members["BIG_VAL"] == 0x1DEADBEEF
+
+    def test_negative_enum_values(self) -> None:
+        b = BtfBuilder()
+        e_name = b.add_string("NEG")
+        entries = struct.pack("<Ii", e_name, -1)
+        b.add_type("signed_enum", BTF_KIND_ENUM, 1, 4, extra=entries)
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.enums["signed_enum"].members["NEG"] == -1
+
+
+# ---------------------------------------------------------------------------
+# Full parse: function prototypes
+# ---------------------------------------------------------------------------
+
+class TestBtfFuncProtos:
+    def test_function_proto(self) -> None:
+        b = BtfBuilder()
+        # Add int (id=1)
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+
+        # Add FUNC_PROTO: int(int, int) (id=2)
+        p1_name = b.add_string("a")
+        p2_name = b.add_string("b")
+        params = struct.pack("<II", p1_name, 1)  # param a: int
+        params += struct.pack("<II", p2_name, 1)  # param b: int
+        b.add_type("", BTF_KIND_FUNC_PROTO, 2, 1, extra=params)  # returns int (type_id=1)
+
+        # Add FUNC pointing to FUNC_PROTO (id=3)
+        b.add_type("add", BTF_KIND_FUNC, 0, 2)  # size_or_type = proto type_id
+
+        meta = parse_btf_from_bytes(b.build())
+        assert "add" in meta.func_protos
+        fp = meta.func_protos["add"]
+        assert fp.return_type == "int"
+        assert len(fp.params) == 2
+        assert fp.params[0] == ("a", "int")
+        assert fp.params[1] == ("b", "int")
+
+
+# ---------------------------------------------------------------------------
+# Full parse: typedefs
+# ---------------------------------------------------------------------------
+
+class TestBtfTypedefs:
+    def test_typedef(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("myint", BTF_KIND_TYPEDEF, 0, 1)  # typedef int myint
+
+        meta = parse_btf_from_bytes(b.build())
+        assert meta.typedefs.get("myint") == "int"
+
+
+# ---------------------------------------------------------------------------
+# Type resolution
+# ---------------------------------------------------------------------------
+
+class TestTypeResolver:
+    def test_pointer_name(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_PTR, 0, 1)  # ptr to int
+
+        data = b.build()
+        hdr = _parse_header(data)
+        type_start = hdr.hdr_len + hdr.type_off
+        str_start = hdr.hdr_len + hdr.str_off
+        str_end = str_start + hdr.str_len
+        types = _parse_types(data[type_start:type_start + hdr.type_len])
+        resolver = _TypeResolver(types, data[str_start:str_end])
+        assert resolver.name(2) == "int *"
+        assert resolver.size(2) == 8
+
+    def test_const_name(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_CONST, 0, 1)  # const int
+
+        data = b.build()
+        hdr = _parse_header(data)
+        type_start = hdr.hdr_len + hdr.type_off
+        str_start = hdr.hdr_len + hdr.str_off
+        str_end = str_start + hdr.str_len
+        types = _parse_types(data[type_start:type_start + hdr.type_len])
+        resolver = _TypeResolver(types, data[str_start:str_end])
+        assert resolver.name(2) == "const int"
+
+    def test_void(self) -> None:
+        b = BtfBuilder()
+        data = b.build()
+        hdr = _parse_header(data)
+        types = _parse_types(b"")
+        resolver = _TypeResolver(types, data[hdr.hdr_len + hdr.str_off:])
+        assert resolver.name(0) == "void"
+        assert resolver.size(0) == 0
+
+
+# ---------------------------------------------------------------------------
+# to_dwarf_metadata conversion
+# ---------------------------------------------------------------------------
+
+class TestToDwarfMetadata:
+    def test_conversion(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        m_name = b.add_string("val")
+        members = struct.pack("<III", m_name, 1, 0)
+        b.add_type("simple", BTF_KIND_STRUCT, 1, 4, extra=members)
+
+        meta = parse_btf_from_bytes(b.build())
+        dwarf = meta.to_dwarf_metadata()
+
+        assert dwarf.has_dwarf  # maps to has_btf
+        assert "simple" in dwarf.structs
+        assert dwarf.structs["simple"].name == "simple"
+
+
+# ---------------------------------------------------------------------------
+# Error handling / graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestBtfErrorHandling:
+    def test_empty_data(self) -> None:
+        meta = parse_btf_from_bytes(b"")
+        assert not meta.has_btf
+
+    def test_bad_magic(self) -> None:
+        meta = parse_btf_from_bytes(b"\x00" * 100)
+        assert not meta.has_btf
+
+    def test_truncated_types(self) -> None:
+        # Valid header but type section is truncated
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        data = b.build()
+        # Truncate the data
+        meta = parse_btf_from_bytes(data[:30])
+        # Should degrade gracefully (empty or partial)
+        assert isinstance(meta, BtfMetadata)
+
+
+# ---------------------------------------------------------------------------
+# TypeMetadataSource protocol
+# ---------------------------------------------------------------------------
+
+class TestTypeMetadataSourceProtocol:
+    def test_protocol_methods(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        m_name = b.add_string("x")
+        members = struct.pack("<III", m_name, 1, 0)
+        b.add_type("point", BTF_KIND_STRUCT, 1, 4, extra=members)
+
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("my_enum", BTF_KIND_ENUM, 1, 4, extra=entries)
+
+        meta = parse_btf_from_bytes(b.build())
+
+        assert meta.has_data is True
+        assert meta.get_struct_layout("point") is not None
+        assert meta.get_struct_layout("nonexistent") is None
+        assert meta.get_enum_info("my_enum") is not None
+        assert meta.get_enum_info("nonexistent") is None
+
+    def test_isinstance_check(self) -> None:
+        from abicheck.type_metadata import TypeMetadataSource
+        meta = BtfMetadata(has_btf=True)
+        assert isinstance(meta, TypeMetadataSource)

--- a/tests/test_ctf_metadata.py
+++ b/tests/test_ctf_metadata.py
@@ -1,0 +1,330 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CTF (Compact C Type Format) parser."""
+from __future__ import annotations
+
+import struct
+import zlib
+
+import pytest
+
+from abicheck.ctf_metadata import (
+    CTF_F_COMPRESS,
+    CTF_K_CONST,
+    CTF_K_ENUM,
+    CTF_K_INTEGER,
+    CTF_K_POINTER,
+    CTF_K_STRUCT,
+    CTF_K_TYPEDEF,
+    CTF_K_UNION,
+    CTF_MAGIC,
+    CTF_VERSION_3,
+    CtfMetadata,
+    _parse_header,
+    _read_string,
+    parse_ctf_from_bytes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build synthetic CTF v3 blobs
+# ---------------------------------------------------------------------------
+
+class CtfBuilder:
+    """Helper to construct synthetic CTF v3 binary blobs for testing."""
+
+    def __init__(self) -> None:
+        self._strings = bytearray(b"\x00")  # string section starts with NUL
+        self._type_entries: list[bytes] = []
+        self._str_offsets: dict[str, int] = {"": 0}
+
+    def add_string(self, s: str) -> int:
+        if s in self._str_offsets:
+            return self._str_offsets[s]
+        off = len(self._strings)
+        self._strings.extend(s.encode("utf-8") + b"\x00")
+        self._str_offsets[s] = off
+        return off
+
+    def add_type(self, name: str, kind: int, vlen: int, size_or_type: int,
+                 extra: bytes = b"", isroot: bool = False) -> int:
+        """Add a CTF v3 type entry, return its 1-based type ID."""
+        name_off = self.add_string(name) if name else 0
+        # v3 info: isroot(1) + kind(5) in upper byte, vlen(16) in lower
+        info = (int(isroot) << 31) | (kind << 24) | (vlen & 0xFFFF)
+        entry = struct.pack("<III", name_off, info, size_or_type) + extra
+        self._type_entries.append(entry)
+        return len(self._type_entries)  # 1-based
+
+    def build(self, *, compress: bool = False) -> bytes:
+        """Build a complete CTF v3 blob."""
+        type_data = b"".join(self._type_entries)
+        str_data = bytes(self._strings)
+        hdr_size = 36
+        # Offsets are relative to the end of the header
+        label_off = 0
+        object_off = 0
+        func_off = 0
+        type_off = 0
+        str_off = len(type_data)
+        str_len = len(str_data)
+
+        flags = CTF_F_COMPRESS if compress else 0
+
+        header = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, flags)
+        header += struct.pack("<IIIIIIII",
+                              0,  # parent_label
+                              0,  # parent_name
+                              label_off,
+                              object_off,
+                              func_off,
+                              type_off,
+                              str_off,
+                              str_len)
+
+        body = type_data + str_data
+
+        if compress:
+            # Compress everything after the preamble (4 bytes)
+            preamble = header[:4]
+            rest = header[4:] + body
+            compressed = zlib.compress(rest)
+            return preamble + compressed
+        else:
+            return header + body
+
+
+# ---------------------------------------------------------------------------
+# String table
+# ---------------------------------------------------------------------------
+
+class TestReadString:
+    def test_basic(self) -> None:
+        data = b"hello\x00world\x00"
+        assert _read_string(data, 0) == "hello"
+        assert _read_string(data, 6) == "world"
+
+    def test_empty(self) -> None:
+        assert _read_string(b"\x00", 0) == ""
+
+    def test_out_of_bounds(self) -> None:
+        assert _read_string(b"abc\x00", 100) == ""
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+class TestParseHeader:
+    def test_valid_header(self) -> None:
+        b = CtfBuilder()
+        data = b.build()
+        hdr = _parse_header(data)
+        assert hdr.magic == CTF_MAGIC
+        assert hdr.version == CTF_VERSION_3
+
+    def test_bad_magic(self) -> None:
+        data = struct.pack("<HBB", 0xDEAD, 3, 0) + b"\x00" * 40
+        with pytest.raises(ValueError, match="Bad CTF magic"):
+            _parse_header(data)
+
+    def test_too_small(self) -> None:
+        with pytest.raises(ValueError, match="too small"):
+            _parse_header(b"\x00")
+
+
+# ---------------------------------------------------------------------------
+# Full parse: structs
+# ---------------------------------------------------------------------------
+
+class TestCtfStructs:
+    def test_simple_struct(self) -> None:
+        b = CtfBuilder()
+        # Add INT type (id=1): encoding word = nr_bits in lower 16 bits
+        int_enc = struct.pack("<I", 32)  # 32 bits
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+
+        # Add struct with 2 members (id=2)
+        # v3 small struct member: name_off(4) + packed(type<<16 | bit_offset)(4)
+        m1_name = b.add_string("x")
+        m2_name = b.add_string("y")
+        members = struct.pack("<II", m1_name, (1 << 16) | 0)     # type=1, offset=0
+        members += struct.pack("<II", m2_name, (1 << 16) | 32)   # type=1, offset=32
+        b.add_type("point", CTF_K_STRUCT, 2, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+        assert "point" in meta.structs
+
+        s = meta.structs["point"]
+        assert s.name == "point"
+        assert s.byte_size == 8
+        assert len(s.fields) == 2
+        assert s.fields[0].name == "x"
+        assert s.fields[0].byte_offset == 0
+        assert s.fields[1].name == "y"
+        assert s.fields[1].byte_offset == 4
+
+    def test_union(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+
+        m1_name = b.add_string("i")
+        m2_name = b.add_string("f")
+        members = struct.pack("<II", m1_name, (1 << 16) | 0)
+        members += struct.pack("<II", m2_name, (1 << 16) | 0)
+        b.add_type("my_union", CTF_K_UNION, 2, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert "my_union" in meta.structs
+        assert meta.structs["my_union"].is_union
+
+    def test_anonymous_struct_skipped(self) -> None:
+        b = CtfBuilder()
+        b.add_type("", CTF_K_STRUCT, 0, 0, extra=b"")
+        meta = parse_ctf_from_bytes(b.build())
+        assert len(meta.structs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Full parse: enums
+# ---------------------------------------------------------------------------
+
+class TestCtfEnums:
+    def test_simple_enum(self) -> None:
+        b = CtfBuilder()
+        e1_name = b.add_string("RED")
+        e2_name = b.add_string("GREEN")
+        e3_name = b.add_string("BLUE")
+        entries = struct.pack("<Ii", e1_name, 0)
+        entries += struct.pack("<Ii", e2_name, 1)
+        entries += struct.pack("<Ii", e3_name, 2)
+        b.add_type("color", CTF_K_ENUM, 3, 4, extra=entries)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert "color" in meta.enums
+        e = meta.enums["color"]
+        assert e.underlying_byte_size == 4
+        assert e.members == {"RED": 0, "GREEN": 1, "BLUE": 2}
+
+    def test_negative_enum_values(self) -> None:
+        b = CtfBuilder()
+        e_name = b.add_string("NEG")
+        entries = struct.pack("<Ii", e_name, -42)
+        b.add_type("signed_enum", CTF_K_ENUM, 1, 4, extra=entries)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.enums["signed_enum"].members["NEG"] == -42
+
+
+# ---------------------------------------------------------------------------
+# Full parse: typedefs
+# ---------------------------------------------------------------------------
+
+class TestCtfTypedefs:
+    def test_typedef(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("myint", CTF_K_TYPEDEF, 0, 1)  # typedef int myint
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.typedefs.get("myint") == "int"
+
+
+# ---------------------------------------------------------------------------
+# Compression
+# ---------------------------------------------------------------------------
+
+class TestCtfCompression:
+    def test_compressed_ctf(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+
+        m_name = b.add_string("val")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("simple", CTF_K_STRUCT, 1, 4, extra=members)
+
+        data = b.build(compress=True)
+        meta = parse_ctf_from_bytes(data)
+        assert meta.has_ctf
+        assert "simple" in meta.structs
+
+
+# ---------------------------------------------------------------------------
+# to_dwarf_metadata conversion
+# ---------------------------------------------------------------------------
+
+class TestToDwarfMetadata:
+    def test_conversion(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        m_name = b.add_string("val")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("simple", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        dwarf = meta.to_dwarf_metadata()
+
+        assert dwarf.has_dwarf
+        assert "simple" in dwarf.structs
+
+
+# ---------------------------------------------------------------------------
+# Error handling / graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestCtfErrorHandling:
+    def test_empty_data(self) -> None:
+        meta = parse_ctf_from_bytes(b"")
+        assert not meta.has_ctf
+
+    def test_bad_magic(self) -> None:
+        meta = parse_ctf_from_bytes(b"\x00" * 100)
+        assert not meta.has_ctf
+
+
+# ---------------------------------------------------------------------------
+# TypeMetadataSource protocol
+# ---------------------------------------------------------------------------
+
+class TestTypeMetadataSourceProtocol:
+    def test_protocol_methods(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("point", CTF_K_STRUCT, 1, 4, extra=members)
+
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("my_enum", CTF_K_ENUM, 1, 4, extra=entries)
+
+        meta = parse_ctf_from_bytes(b.build())
+
+        assert meta.has_data is True
+        assert meta.get_struct_layout("point") is not None
+        assert meta.get_struct_layout("nonexistent") is None
+        assert meta.get_enum_info("my_enum") is not None
+        assert meta.get_enum_info("nonexistent") is None
+
+    def test_isinstance_check(self) -> None:
+        from abicheck.type_metadata import TypeMetadataSource
+        meta = CtfMetadata(has_ctf=True)
+        assert isinstance(meta, TypeMetadataSource)

--- a/tests/test_ctf_metadata.py
+++ b/tests/test_ctf_metadata.py
@@ -22,21 +22,31 @@ import pytest
 
 from abicheck.ctf_metadata import (
     CTF_F_COMPRESS,
+    CTF_K_ARRAY,
     CTF_K_CONST,
     CTF_K_ENUM,
+    CTF_K_FLOAT,
+    CTF_K_FORWARD,
+    CTF_K_FUNCTION,
     CTF_K_INTEGER,
     CTF_K_POINTER,
+    CTF_K_RESTRICT,
     CTF_K_STRUCT,
     CTF_K_TYPEDEF,
     CTF_K_UNION,
+    CTF_K_VOLATILE,
     CTF_MAGIC,
+    CTF_VERSION_2,
     CTF_VERSION_3,
     CtfMetadata,
+    _decompress_if_needed,
+    _extra_data_size,
     _parse_header,
+    _parse_info_v2,
+    _parse_info_v3,
     _read_string,
     parse_ctf_from_bytes,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers to build synthetic CTF v3 blobs
@@ -72,7 +82,6 @@ class CtfBuilder:
         """Build a complete CTF v3 blob."""
         type_data = b"".join(self._type_entries)
         str_data = bytes(self._strings)
-        hdr_size = 36
         # Offsets are relative to the end of the header
         label_off = 0
         object_off = 0
@@ -328,3 +337,600 @@ class TestTypeMetadataSourceProtocol:
         from abicheck.type_metadata import TypeMetadataSource
         meta = CtfMetadata(has_ctf=True)
         assert isinstance(meta, TypeMetadataSource)
+
+
+# ---------------------------------------------------------------------------
+# CtfMetadata accessor methods
+# ---------------------------------------------------------------------------
+
+class TestCtfMetadataAccessors:
+    def test_get_function_proto(self) -> None:
+        meta = CtfMetadata(has_ctf=True)
+        assert meta.get_function_proto("x") is None
+
+    def test_get_typedef(self) -> None:
+        meta = CtfMetadata(has_ctf=True)
+        assert meta.get_typedef("x") is None
+
+    def test_empty_metadata(self) -> None:
+        meta = CtfMetadata()
+        assert meta.has_data is False
+        assert meta.get_struct_layout("x") is None
+        assert meta.get_enum_info("x") is None
+        assert meta.get_function_proto("x") is None
+        assert meta.get_typedef("x") is None
+
+    def test_isroot_property(self) -> None:
+        from abicheck.ctf_metadata import CtfType
+        t = CtfType(type_id=1, name_off=0, info=(1 << 31) | (CTF_K_INTEGER << 24), size_or_type=4)
+        assert t.isroot is True
+        t2 = CtfType(type_id=2, name_off=0, info=(CTF_K_INTEGER << 24), size_or_type=4)
+        assert t2.isroot is False
+
+
+# ---------------------------------------------------------------------------
+# Parse info functions
+# ---------------------------------------------------------------------------
+
+class TestParseInfo:
+    def test_parse_info_v2(self) -> None:
+        # v2: kind(5) at bits 15-11, isroot(1) at bit 10, vlen(10) at bits 9-0
+        info = (CTF_K_STRUCT << 11) | (1 << 10) | 5
+        kind, vlen, isroot = _parse_info_v2(info)
+        assert kind == CTF_K_STRUCT
+        assert vlen == 5
+        assert isroot is True
+
+    def test_parse_info_v3(self) -> None:
+        # v3: kind(5) at bits 28-24, isroot(1) at bit 31, vlen(16) at bits 15-0
+        info = (1 << 31) | (CTF_K_ENUM << 24) | 42
+        kind, vlen, isroot = _parse_info_v3(info)
+        assert kind == CTF_K_ENUM
+        assert vlen == 42
+        assert isroot is True
+
+
+# ---------------------------------------------------------------------------
+# _extra_data_size coverage
+# ---------------------------------------------------------------------------
+
+class TestCtfExtraDataSize:
+    def test_integer(self) -> None:
+        assert _extra_data_size(CTF_K_INTEGER, 0, CTF_VERSION_3, 0) == 4
+
+    def test_float(self) -> None:
+        assert _extra_data_size(CTF_K_FLOAT, 0, CTF_VERSION_3, 0) == 4
+
+    def test_array_v3(self) -> None:
+        assert _extra_data_size(CTF_K_ARRAY, 0, CTF_VERSION_3, 0) == 12
+
+    def test_array_v2(self) -> None:
+        assert _extra_data_size(CTF_K_ARRAY, 0, CTF_VERSION_2, 0) == 6
+
+    def test_struct_v3_small(self) -> None:
+        assert _extra_data_size(CTF_K_STRUCT, 3, CTF_VERSION_3, 100) == 24  # 3*8
+
+    def test_struct_v3_large(self) -> None:
+        assert _extra_data_size(CTF_K_STRUCT, 3, CTF_VERSION_3, 0x2000) == 36  # 3*12
+
+    def test_struct_v2_small(self) -> None:
+        assert _extra_data_size(CTF_K_STRUCT, 3, CTF_VERSION_2, 100) == 12  # 3*4
+
+    def test_struct_v2_large(self) -> None:
+        assert _extra_data_size(CTF_K_STRUCT, 3, CTF_VERSION_2, 0x2000) == 24  # 3*8
+
+    def test_enum(self) -> None:
+        assert _extra_data_size(CTF_K_ENUM, 5, CTF_VERSION_3, 0) == 40  # 5*8
+
+    def test_function_v3(self) -> None:
+        # 2 args * 4 bytes = 8, already aligned
+        assert _extra_data_size(CTF_K_FUNCTION, 2, CTF_VERSION_3, 0) == 8
+
+    def test_function_v3_padding(self) -> None:
+        # 3 args * 4 = 12, already aligned
+        assert _extra_data_size(CTF_K_FUNCTION, 3, CTF_VERSION_3, 0) == 12
+
+    def test_function_v2(self) -> None:
+        # 2 args * 2 = 4, already aligned
+        assert _extra_data_size(CTF_K_FUNCTION, 2, CTF_VERSION_2, 0) == 4
+
+    def test_function_v2_padding(self) -> None:
+        # 3 args * 2 = 6, padded to 8
+        assert _extra_data_size(CTF_K_FUNCTION, 3, CTF_VERSION_2, 0) == 8
+
+    def test_pointer_no_extra(self) -> None:
+        assert _extra_data_size(CTF_K_POINTER, 0, CTF_VERSION_3, 0) == 0
+
+    def test_typedef_no_extra(self) -> None:
+        assert _extra_data_size(CTF_K_TYPEDEF, 0, CTF_VERSION_3, 0) == 0
+
+    def test_forward_no_extra(self) -> None:
+        assert _extra_data_size(CTF_K_FORWARD, 0, CTF_VERSION_3, 0) == 0
+
+    def test_const_no_extra(self) -> None:
+        assert _extra_data_size(CTF_K_CONST, 0, CTF_VERSION_3, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Decompression
+# ---------------------------------------------------------------------------
+
+class TestDecompression:
+    def test_decompress_not_needed(self) -> None:
+        from abicheck.ctf_metadata import CtfHeader
+        hdr = CtfHeader(
+            magic=CTF_MAGIC, version=CTF_VERSION_3, flags=0,
+            parent_label=0, parent_name=0, label_off=0, object_off=0,
+            func_off=0, type_off=0, str_off=0, str_len=0,
+        )
+        data = b"some data"
+        result = _decompress_if_needed(data, hdr)
+        assert result == data
+
+    def test_decompress_bad_data(self) -> None:
+        from abicheck.ctf_metadata import CtfHeader
+        hdr = CtfHeader(
+            magic=CTF_MAGIC, version=CTF_VERSION_3, flags=CTF_F_COMPRESS,
+            parent_label=0, parent_name=0, label_off=0, object_off=0,
+            func_off=0, type_off=0, str_off=0, str_len=0,
+        )
+        # Preamble + garbage (not valid zlib)
+        data = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, CTF_F_COMPRESS) + b"garbage"
+        with pytest.raises(ValueError, match="decompression failed"):
+            _decompress_if_needed(data, hdr)
+
+
+# ---------------------------------------------------------------------------
+# Type resolver extended coverage
+# ---------------------------------------------------------------------------
+
+class TestCtfTypeResolverExtended:
+    def test_pointer_name(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        # Pointer: size_or_type = type id of pointee
+        # In v3, info = kind << 24
+        name_off = 0
+        info = (CTF_K_POINTER << 24)
+        entry = struct.pack("<III", name_off, info, 1)  # points to int (id=1)
+        b._type_entries.append(entry)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_volatile_name(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_VOLATILE, 0, 1)  # volatile int
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_const_type(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_CONST, 0, 1)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_restrict_type(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_RESTRICT, 0, 1)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_forward_type(self) -> None:
+        b = CtfBuilder()
+        b.add_type("fwd_struct", CTF_K_FORWARD, 0, 0)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_array_type(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        # v3 array: contents(4) + index(4) + nelems(4)
+        array_extra = struct.pack("<III", 1, 1, 5)
+        b.add_type("", CTF_K_ARRAY, 0, 0, extra=array_extra)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_float_type(self) -> None:
+        b = CtfBuilder()
+        float_enc = struct.pack("<I", 64)
+        b.add_type("double", CTF_K_FLOAT, 0, 8, extra=float_enc)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+    def test_function_type(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        # function with 2 params: return type in size_or_type, params as extra
+        params = struct.pack("<II", 1, 1)  # two int params
+        b.add_type("", CTF_K_FUNCTION, 2, 1, extra=params)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+
+
+# ---------------------------------------------------------------------------
+# Header edge cases
+# ---------------------------------------------------------------------------
+
+class TestCtfHeaderExtended:
+    def test_unsupported_version(self) -> None:
+        data = struct.pack("<HBB", CTF_MAGIC, 99, 0) + b"\x00" * 40
+        with pytest.raises(ValueError, match="Unsupported CTF version"):
+            _parse_header(data)
+
+    def test_truncated_header(self) -> None:
+        data = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, 0)  # only 4 bytes
+        with pytest.raises(ValueError, match="truncated"):
+            _parse_header(data)
+
+    def test_v2_header(self) -> None:
+        """V2 header should also parse since header structure is the same."""
+        b = CtfBuilder()
+        data = b.build()
+        # Replace version byte with V2
+        data = data[:2] + bytes([CTF_VERSION_2]) + data[3:]
+        hdr = _parse_header(data)
+        assert hdr.version == CTF_VERSION_2
+
+
+# ---------------------------------------------------------------------------
+# CTF error/edge cases
+# ---------------------------------------------------------------------------
+
+class TestCtfEdgeCases:
+    def test_anonymous_enum_skipped(self) -> None:
+        b = CtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("", CTF_K_ENUM, 1, 4, extra=entries)
+        meta = parse_ctf_from_bytes(b.build())
+        assert len(meta.enums) == 0
+
+    def test_anonymous_typedef_skipped(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_TYPEDEF, 0, 1)
+        meta = parse_ctf_from_bytes(b.build())
+        assert len(meta.typedefs) == 0
+
+    def test_section_bounds_exceed_data(self) -> None:
+        """Header claiming sections beyond data size."""
+        header = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, 0)
+        header += struct.pack("<IIIIIIII", 0, 0, 0, 0, 0, 0, 99999, 1)
+        data = header + b"\x00"
+        meta = parse_ctf_from_bytes(data)
+        assert not meta.has_ctf
+
+    def test_type_count(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("float", CTF_K_FLOAT, 0, 4, extra=int_enc)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.type_count == 2
+
+    def test_duplicate_struct_first_wins(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("dup", CTF_K_STRUCT, 1, 4, extra=members)
+        b.add_type("dup", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["dup"].byte_size == 4
+
+    def test_duplicate_enum_first_wins(self) -> None:
+        b = CtfBuilder()
+        e_name = b.add_string("A")
+        entries = struct.pack("<Ii", e_name, 0)
+        b.add_type("dup", CTF_K_ENUM, 1, 4, extra=entries)
+
+        e2_name = b.add_string("B")
+        entries2 = struct.pack("<Ii", e2_name, 1)
+        b.add_type("dup", CTF_K_ENUM, 1, 4, extra=entries2)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert "A" in meta.enums["dup"].members
+
+    def test_string_out_of_bounds(self) -> None:
+        assert _read_string(b"abc\x00", 100) == ""
+        assert _read_string(b"abc\x00", -1) == ""
+
+    def test_string_no_null(self) -> None:
+        assert _read_string(b"no_null", 0) == "no_null"
+
+
+# ---------------------------------------------------------------------------
+# Resolver coverage through struct member type resolution
+# ---------------------------------------------------------------------------
+
+class TestCtfResolverThroughExtraction:
+    """Test resolver name/size paths by creating structs with typed members."""
+
+    def test_pointer_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)  # id=1
+        # Pointer to int (id=2)
+        b.add_type("", CTF_K_POINTER, 0, 1)
+        # Struct with pointer member
+        m_name = b.add_string("ptr")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        s = meta.structs["s"]
+        assert s.fields[0].type_name == "int *"
+        assert s.fields[0].byte_size == 8
+
+    def test_const_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)  # id=1
+        b.add_type("", CTF_K_CONST, 0, 1)  # id=2, const int
+        m_name = b.add_string("c")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "const int"
+
+    def test_volatile_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_VOLATILE, 0, 1)
+        m_name = b.add_string("v")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "volatile int"
+
+    def test_restrict_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_POINTER, 0, 1)  # ptr to int
+        b.add_type("", CTF_K_RESTRICT, 0, 2)  # restrict ptr
+        m_name = b.add_string("r")
+        members = struct.pack("<II", m_name, (3 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "restrict int *"
+
+    def test_typedef_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("size_t", CTF_K_TYPEDEF, 0, 1)  # typedef int size_t
+        m_name = b.add_string("sz")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "size_t"
+        # typedef size should resolve through to int
+        assert meta.structs["s"].fields[0].byte_size == 4
+
+    def test_float_member(self) -> None:
+        b = CtfBuilder()
+        float_enc = struct.pack("<I", 64)  # 64 bits
+        b.add_type("double", CTF_K_FLOAT, 0, 8, extra=float_enc)
+        m_name = b.add_string("d")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "double"
+        assert meta.structs["s"].fields[0].byte_size == 8
+
+    def test_array_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        # v3 array: contents(4) + index(4) + nelems(4)
+        array_extra = struct.pack("<III", 1, 1, 5)
+        b.add_type("", CTF_K_ARRAY, 0, 0, extra=array_extra)
+        m_name = b.add_string("arr")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 20, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "int[5]"
+        assert meta.structs["s"].fields[0].byte_size == 20
+
+    def test_forward_member(self) -> None:
+        b = CtfBuilder()
+        b.add_type("fwd_struct", CTF_K_FORWARD, 0, 0)
+        m_name = b.add_string("fwd")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 0, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "fwd_struct"
+
+    def test_function_member(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        # function type: returns int, 0 params
+        b.add_type("", CTF_K_FUNCTION, 0, 1, extra=b"")
+        m_name = b.add_string("fn")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "int(...)"
+
+    def test_void_member(self) -> None:
+        b = CtfBuilder()
+        # Pointer to void (type 0)
+        b.add_type("", CTF_K_POINTER, 0, 0)
+        m_name = b.add_string("p")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "void *"
+
+    def test_anon_enum_name(self) -> None:
+        b = CtfBuilder()
+        b.add_type("", CTF_K_ENUM, 0, 4, extra=b"")
+        m_name = b.add_string("e")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "<anon enum>"
+
+    def test_anon_struct_name(self) -> None:
+        b = CtfBuilder()
+        b.add_type("", CTF_K_STRUCT, 0, 4, extra=b"")
+        m_name = b.add_string("inner")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("outer", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["outer"].fields[0].type_name == "<anon struct>"
+
+    def test_anon_union_name(self) -> None:
+        b = CtfBuilder()
+        b.add_type("", CTF_K_UNION, 0, 4, extra=b"")
+        m_name = b.add_string("u")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "<anon union>"
+
+    def test_anon_fwd_name(self) -> None:
+        b = CtfBuilder()
+        b.add_type("", CTF_K_FORWARD, 0, 0)
+        m_name = b.add_string("f")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 0, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "<fwd>"
+
+    def test_anon_int_name(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "int"
+
+    def test_anon_float_name(self) -> None:
+        b = CtfBuilder()
+        float_enc = struct.pack("<I", 32)
+        b.add_type("", CTF_K_FLOAT, 0, 4, extra=float_enc)
+        m_name = b.add_string("f")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "float"
+
+    def test_anon_typedef_resolves(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_TYPEDEF, 0, 1)  # anon typedef -> resolves to target
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].type_name == "int"
+
+    def test_unknown_type_id(self) -> None:
+        b = CtfBuilder()
+        # Struct member references non-existent type id 99
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (99 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 0, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert "<ctf:" in meta.structs["s"].fields[0].type_name
+
+    def test_unknown_kind(self) -> None:
+        b = CtfBuilder()
+        # Add a type with unrecognized kind (30)
+        name_off = 0
+        info = (30 << 24) | 0
+        entry = struct.pack("<III", name_off, info, 0)
+        b._type_entries.append(entry)
+        # Struct referencing it
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (1 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 0, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert "<ctf_kind_30:" in meta.structs["s"].fields[0].type_name
+
+    def test_resolver_size_void(self) -> None:
+        """Void type returns size 0."""
+        b = CtfBuilder()
+        m_name = b.add_string("x")
+        members = struct.pack("<II", m_name, (0 << 16) | 0)  # type=0 (void)
+        b.add_type("s", CTF_K_STRUCT, 1, 0, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].byte_size == 0
+
+    def test_resolver_size_pointer(self) -> None:
+        """Pointer size is 8 (64-bit assumed)."""
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_POINTER, 0, 1)  # ptr to int
+        m_name = b.add_string("p")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 8, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].byte_size == 8
+
+    def test_resolver_size_const(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        b.add_type("", CTF_K_CONST, 0, 1)
+        m_name = b.add_string("c")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 4, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].byte_size == 4
+
+    def test_resolver_size_array(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        array_extra = struct.pack("<III", 1, 1, 3)  # 3 ints
+        b.add_type("", CTF_K_ARRAY, 0, 0, extra=array_extra)
+        m_name = b.add_string("a")
+        members = struct.pack("<II", m_name, (2 << 16) | 0)
+        b.add_type("s", CTF_K_STRUCT, 1, 12, extra=members)
+
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.structs["s"].fields[0].byte_size == 12

--- a/tests/test_type_metadata.py
+++ b/tests/test_type_metadata.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for TypeMetadataSource protocol and resolution logic."""
+from __future__ import annotations
+
+from abicheck.btf_metadata import BtfMetadata
+from abicheck.ctf_metadata import CtfMetadata
+from abicheck.dwarf_metadata import DwarfMetadata, EnumInfo, StructLayout
+from abicheck.type_metadata import TypeMetadataSource, resolve_debug_metadata
+
+
+class TestTypeMetadataSourceProtocol:
+    """All three metadata classes implement TypeMetadataSource."""
+
+    def test_dwarf_is_source(self) -> None:
+        meta = DwarfMetadata(has_dwarf=True)
+        assert isinstance(meta, TypeMetadataSource)
+        assert meta.has_data is True
+
+    def test_btf_is_source(self) -> None:
+        meta = BtfMetadata(has_btf=True)
+        assert isinstance(meta, TypeMetadataSource)
+        assert meta.has_data is True
+
+    def test_ctf_is_source(self) -> None:
+        meta = CtfMetadata(has_ctf=True)
+        assert isinstance(meta, TypeMetadataSource)
+        assert meta.has_data is True
+
+    def test_empty_sources(self) -> None:
+        assert DwarfMetadata().has_data is False
+        assert BtfMetadata().has_data is False
+        assert CtfMetadata().has_data is False
+
+    def test_dwarf_get_methods(self) -> None:
+        meta = DwarfMetadata(
+            has_dwarf=True,
+            structs={"foo": StructLayout(name="foo", byte_size=8)},
+            enums={"bar": EnumInfo(name="bar", underlying_byte_size=4, members={"X": 1})},
+        )
+        assert meta.get_struct_layout("foo") is not None
+        assert meta.get_struct_layout("missing") is None
+        assert meta.get_enum_info("bar") is not None
+        assert meta.get_enum_info("missing") is None
+
+
+class TestResolveDebugMetadata:
+    def _make_dwarf(self) -> DwarfMetadata:
+        return DwarfMetadata(has_dwarf=True)
+
+    def _make_btf(self) -> BtfMetadata:
+        return BtfMetadata(has_btf=True)
+
+    def _make_ctf(self) -> CtfMetadata:
+        return CtfMetadata(has_ctf=True)
+
+    def test_userspace_prefers_dwarf(self) -> None:
+        result = resolve_debug_metadata(
+            dwarf=self._make_dwarf(), btf=self._make_btf(), ctf=self._make_ctf(),
+        )
+        assert isinstance(result, DwarfMetadata)
+
+    def test_kernel_prefers_btf(self) -> None:
+        result = resolve_debug_metadata(
+            dwarf=self._make_dwarf(), btf=self._make_btf(), ctf=self._make_ctf(),
+            prefer_btf=True,
+        )
+        assert isinstance(result, BtfMetadata)
+
+    def test_fallback_to_btf_when_no_dwarf(self) -> None:
+        result = resolve_debug_metadata(
+            dwarf=DwarfMetadata(), btf=self._make_btf(), ctf=self._make_ctf(),
+        )
+        assert isinstance(result, BtfMetadata)
+
+    def test_fallback_to_ctf_when_nothing_else(self) -> None:
+        result = resolve_debug_metadata(
+            dwarf=DwarfMetadata(), btf=BtfMetadata(), ctf=self._make_ctf(),
+        )
+        assert isinstance(result, CtfMetadata)
+
+    def test_none_when_all_empty(self) -> None:
+        result = resolve_debug_metadata(
+            dwarf=DwarfMetadata(), btf=BtfMetadata(), ctf=CtfMetadata(),
+        )
+        assert result is None
+
+    def test_none_when_no_sources(self) -> None:
+        result = resolve_debug_metadata()
+        assert result is None


### PR DESCRIPTION
## Summary

Add pure-Python parsers for BTF (BPF Type Format) and CTF (Compact C Type Format) debug metadata, enabling ABI checking on Linux kernel binaries and illumos/Solaris systems where DWARF may be unavailable or stripped.

## Motivation

Production kernel builds often strip DWARF debug info but retain BTF (Linux 5.x+) or CTF (illumos/SmartOS). The existing DWARF-only metadata reader cannot analyze these binaries. This PR adds:

1. **BTF parser** (`abicheck/btf_metadata.py`): Reads `.BTF` sections from Linux kernel binaries and eBPF programs
2. **CTF parser** (`abicheck/ctf_metadata.py`): Reads `.ctf`/`.SUNW_ctf` sections from illumos/Solaris binaries
3. **Unified protocol** (`abicheck/type_metadata.py`): `TypeMetadataSource` protocol allows detectors to work with any debug format without modification
4. **Format auto-detection** in `dumper.py`: Automatically selects BTF for kernel binaries, DWARF for userspace

Both parsers implement the same interface as `DwarfMetadata`, so existing ABI checkers work unchanged.

## Changes

- **New modules:**
  - `abicheck/btf_metadata.py` (708 lines): BTF v1 parser with struct/union/enum/function extraction
  - `abicheck/ctf_metadata.py` (749 lines): CTF v2/v3 parser with zlib decompression support
  - `abicheck/type_metadata.py` (76 lines): `TypeMetadataSource` protocol for format-agnostic type access

- **Modified modules:**
  - `abicheck/dumper.py`: Added `debug_format` parameter and `_resolve_debug_metadata()` helper; auto-detects kernel binaries
  - `abicheck/dwarf_metadata.py`: Added protocol implementation to `DwarfMetadata`
  - `abicheck/cli.py`: Threaded `debug_format` parameter through CLI

- **Test coverage:**
  - `tests/test_btf_metadata.py` (443 lines): 30+ tests for BTF parsing, struct/union/enum/bitfield handling
  - `tests/test_ctf_metadata.py` (330 lines): 20+ tests for CTF v2/v3, compression, struct/enum parsing
  - `tests/test_type_metadata.py` (102 lines): Protocol conformance tests for all three metadata classes

## Key Features

- **No external dependencies** beyond existing `pyelftools` (uses only `struct` and `zlib`)
- **Cycle detection** in type resolution to handle forward references
- **Bitfield support** in BTF (kflag-encoded bit offsets and sizes)
- **Compression support** in CTF (zlib-compressed sections)
- **Format auto-detection**: Kernel binaries default to BTF, userspace to DWARF
- **Backward compatible**: Existing DWARF-based checks work unchanged

## Checklist

- [x] Tests added for new behaviour (70+ unit tests across 3 test files)
- [ ] `CHANGELOG.md` updated (not shown in diff; should be done separately)
- [ ] Docs updated if user-visible behaviour changed (CLI `--debug-format` flag)
- [ ] `pre-commit run --all-files` passes locally
- [ ] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_0121dSAHknrBPsLDMNdex2rx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pure‑Python BTF and CTF debug‑metadata parsers that extract structs, enums, typedefs and function prototypes and return safe empty results on parse failures.
  * Added a unified type‑metadata protocol to select/bridge DWARF/BTF/CTF providers and small DWARF accessors for type lookups.

* **CLI / Dumping**
  * New --btf/--ctf/--dwarf debug-format control, kernel-aware auto‑selection, and conversion of found debug info into DWARF‑compatible metadata.

* **Tests**
  * Extensive tests covering BTF/CTF parsing, resolver selection, protocol conformance and many edge/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->