### PR TITLE
test(func_deleted): edge-case regressions for abicc #100 (= delete hardening)

### DIFF
--- a/docs/development/abicc-parity-status.md
+++ b/docs/development/abicc-parity-status.md
@@ -182,3 +182,11 @@ abicheck workflow:         abidiff workflow:
 > - ABICC lacks: anonymous struct field tracking, combined access+qualifier detection
 > - abidiff lacks: enum renames, param defaults, access level changes, field/param renames
 > - Remaining out-of-scope items: cross-architecture ABI diff (32-bit vs 64-bit), BTF/CTF kernel support
+
+---
+
+## Upstream Issue Tracking
+
+| Issue | Topic | Status | Evidence | Notes |
+|------|-------|--------|----------|-------|
+| [#100](https://github.com/lvc/abi-compliance-checker/issues/100) | `= delete` functions | **DONE / COVERED** | `tests/test_func_deleted.py` (`TestFuncDeletedDetection`, `TestFuncDeletedEdgeCases`) | CastXML path (`deleted="1"` → `FUNC_DELETED`) plus guarded ELF heuristic (`FUNC_DELETED_ELF_FALLBACK`) to avoid duplicate reporting. |

--- a/docs/development/abicc-parity-status.md
+++ b/docs/development/abicc-parity-status.md
@@ -189,4 +189,4 @@ abicheck workflow:         abidiff workflow:
 
 | Issue | Topic | Status | Evidence | Notes |
 |------|-------|--------|----------|-------|
-| [#100](https://github.com/lvc/abi-compliance-checker/issues/100) | `= delete` functions | **DONE / COVERED** | `tests/test_func_deleted.py` (`TestFuncDeletedDetection`, `TestFuncDeletedEdgeCases`) | CastXML path (`deleted="1"` → `FUNC_DELETED`) plus guarded ELF heuristic (`FUNC_DELETED_ELF_FALLBACK`) to avoid duplicate reporting. |
+| [#100](https://github.com/lvc/abi-compliance-checker/issues/100) | `= delete` functions | **PARTIAL (checker-covered; e2e parity follow-up)** | `tests/test_func_deleted.py` (`TestFuncDeletedDetection`, `TestFuncDeletedEdgeCases`) | Checker-level behavior is covered (including guarded ELF fallback); keep as partial until full headers+CastXML parity cases are aligned with expected `FUNC_DELETED` outcomes. |

--- a/tests/test_func_deleted.py
+++ b/tests/test_func_deleted.py
@@ -178,3 +178,71 @@ class TestFuncDeletedCastxmlMock:
         funcs = parser.parse_functions()
         assert len(funcs) == 1
         assert funcs[0].is_deleted is False
+
+
+class TestFuncDeletedEdgeCases:
+    """Edge-case regression coverage for abicc #100."""
+
+    def test_free_function_deleted(self) -> None:
+        """Free function becoming deleted must be BREAKING."""
+        old = _snap(functions=[_func("process", "_Z7processv")])
+        new = _snap(functions=[_func("process", "_Z7processv", is_deleted=True)])
+
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+
+        assert ChangeKind.FUNC_DELETED in kinds
+        assert result.verdict == Verdict.BREAKING
+
+    def test_one_overload_deleted(self) -> None:
+        """Only the deleted overload should trigger FUNC_DELETED."""
+        old = _snap(functions=[
+            _func("process", "_Z7processi"),
+            _func("process", "_Z7processf"),
+        ])
+        new = _snap(functions=[
+            _func("process", "_Z7processi"),
+            _func("process", "_Z7processf", is_deleted=True),
+        ])
+
+        result = compare(old, new)
+        deleted_symbols = {
+            c.symbol for c in result.changes if c.kind == ChangeKind.FUNC_DELETED
+        }
+
+        assert deleted_symbols == {"_Z7processf"}
+        assert result.verdict == Verdict.BREAKING
+
+    def test_destructor_deleted(self) -> None:
+        """Deleted destructor must be treated as BREAKING."""
+        old = _snap(functions=[_func("~Foo", "_ZN3FooD1Ev")])
+        new = _snap(functions=[_func("~Foo", "_ZN3FooD1Ev", is_deleted=True)])
+
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+
+        assert ChangeKind.FUNC_DELETED in kinds
+        assert result.verdict == Verdict.BREAKING
+
+    def test_template_instantiation_deleted(self) -> None:
+        """Deleted template instantiation must be treated as BREAKING."""
+        old = _snap(functions=[_func("foo<int>", "_Z3fooIiEvT_")])
+        new = _snap(functions=[_func("foo<int>", "_Z3fooIiEvT_", is_deleted=True)])
+
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+
+        assert ChangeKind.FUNC_DELETED in kinds
+        assert result.verdict == Verdict.BREAKING
+
+
+    def test_elf_fallback_not_double_reported(self) -> None:
+        """Explicit castxml deletion marker must prevent ELF fallback duplicate."""
+        old = _snap(functions=[_func("process", "_Z7processv")])
+        new = _snap(functions=[_func("process", "_Z7processv", is_deleted=True)])
+
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+
+        assert ChangeKind.FUNC_DELETED in kinds
+        assert ChangeKind.FUNC_DELETED_ELF_FALLBACK not in kinds

--- a/tests/test_func_deleted.py
+++ b/tests/test_func_deleted.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.checker_policy import BREAKING_KINDS
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
 from abicheck.model import AbiSnapshot, Function, Visibility
 
 
@@ -29,6 +30,14 @@ def _func(name: str, mangled: str, **kwargs: object) -> Function:
     defaults: dict[str, object] = dict(return_type="void", visibility=Visibility.PUBLIC)
     defaults.update(kwargs)
     return Function(name=name, mangled=mangled, **defaults)  # type: ignore[arg-type]
+
+
+def _elf_with_syms(*names: str) -> ElfMetadata:
+    syms = [
+        ElfSymbol(name=n, binding=SymbolBinding.GLOBAL, sym_type=SymbolType.FUNC, size=0)
+        for n in names
+    ]
+    return ElfMetadata(symbols=syms)
 
 
 class TestFuncDeletedModel:
@@ -206,11 +215,11 @@ class TestFuncDeletedEdgeCases:
         ])
 
         result = compare(old, new)
-        deleted_symbols = {
-            c.symbol for c in result.changes if c.kind == ChangeKind.FUNC_DELETED
-        }
+        deleted_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_DELETED]
+        deleted_symbols = {c.symbol for c in deleted_changes}
 
         assert deleted_symbols == {"_Z7processf"}
+        assert len(deleted_changes) == 1  # must not double-report the same symbol
         assert result.verdict == Verdict.BREAKING
 
     def test_destructor_deleted(self) -> None:
@@ -237,9 +246,22 @@ class TestFuncDeletedEdgeCases:
 
 
     def test_elf_fallback_not_double_reported(self) -> None:
-        """Explicit castxml deletion marker must prevent ELF fallback duplicate."""
-        old = _snap(functions=[_func("process", "_Z7processv")])
-        new = _snap(functions=[_func("process", "_Z7processv", is_deleted=True)])
+        """Explicit castxml deletion marker must prevent ELF fallback duplicate.
+
+        ELF metadata is intentionally provided so the fallback detector sees a
+        symbol disappear from dynsym — without is_deleted=True it would fire
+        FUNC_DELETED_ELF_FALLBACK.  With is_deleted=True the checker must take
+        the castxml path (FUNC_DELETED) and skip the ELF path.
+        """
+        mangled = "_Z7processv"
+        old = _snap(
+            functions=[_func("process", mangled)],
+            elf=_elf_with_syms(mangled),
+        )
+        new = _snap(
+            functions=[_func("process", mangled, is_deleted=True)],
+            elf=_elf_with_syms(),  # symbol also gone from dynsym
+        )
 
         result = compare(old, new)
         kinds = {c.kind for c in result.changes}

--- a/tests/test_func_deleted.py
+++ b/tests/test_func_deleted.py
@@ -244,6 +244,17 @@ class TestFuncDeletedEdgeCases:
         assert ChangeKind.FUNC_DELETED in kinds
         assert result.verdict == Verdict.BREAKING
 
+    def test_deleted_to_callable_is_not_breaking(self) -> None:
+        """Reverting `= delete` should not emit FUNC_DELETED or BREAKING verdict."""
+        old = _snap(functions=[_func("process", "_Z7processv", is_deleted=True)])
+        new = _snap(functions=[_func("process", "_Z7processv", is_deleted=False)])
+
+        result = compare(old, new)
+        kinds = {c.kind for c in result.changes}
+
+        assert ChangeKind.FUNC_DELETED not in kinds
+        assert ChangeKind.FUNC_DELETED_ELF_FALLBACK not in kinds
+        assert result.verdict != Verdict.BREAKING
 
     def test_elf_fallback_not_double_reported(self) -> None:
         """Explicit castxml deletion marker must prevent ELF fallback duplicate.

--- a/tests/test_func_deleted.py
+++ b/tests/test_func_deleted.py
@@ -136,8 +136,15 @@ class TestFuncDeletedCastxmlMock:
     Tests the dumper's _CastxmlParser without running castxml binary.
     """
 
-    def _make_xml_root(self, deleted: str = "0") -> object:
-        """Build a minimal castxml XML tree with one function."""
+    def _make_xml_root(
+        self,
+        *,
+        deleted: str = "0",
+        tag: str = "Function",
+        name: str = "doWork",
+        mangled: str = "_Z6doWorkv",
+    ) -> object:
+        """Build a minimal castxml XML tree with one callable element."""
         from xml.etree.ElementTree import Element, SubElement
 
         root = Element("CastXML")
@@ -150,11 +157,11 @@ class TestFuncDeletedCastxmlMock:
         loc_el.set("id", "l1")
         loc_el.set("file", "f1")
         loc_el.set("line", "1")
-        # Function entry
-        func_el = SubElement(root, "Function")
+        # Callable entry
+        func_el = SubElement(root, tag)
         func_el.set("id", "_1")
-        func_el.set("name", "doWork")
-        func_el.set("mangled", "_Z6doWorkv")
+        func_el.set("name", name)
+        func_el.set("mangled", mangled)
         func_el.set("returns", "")
         func_el.set("location", "l1")
         func_el.set("deleted", deleted)
@@ -187,6 +194,46 @@ class TestFuncDeletedCastxmlMock:
         funcs = parser.parse_functions()
         assert len(funcs) == 1
         assert funcs[0].is_deleted is False
+
+    def test_dumper_parses_deleted_constructor_true(self) -> None:
+        """Constructor tag must preserve deleted='1' marker."""
+        from abicheck.dumper import _CastxmlParser
+
+        root = self._make_xml_root(
+            deleted="1",
+            tag="Constructor",
+            name="Foo",
+            mangled="_ZN3FooC1Ev",
+        )
+        parser = _CastxmlParser(
+            root,
+            exported_dynamic={"_ZN3FooC1Ev"},
+            exported_static={"_ZN3FooC1Ev"},
+        )
+        funcs = parser.parse_functions()
+        assert len(funcs) == 1
+        assert funcs[0].name == "Foo"
+        assert funcs[0].is_deleted is True
+
+    def test_dumper_parses_deleted_destructor_true(self) -> None:
+        """Destructor tag must preserve deleted='1' marker."""
+        from abicheck.dumper import _CastxmlParser
+
+        root = self._make_xml_root(
+            deleted="1",
+            tag="Destructor",
+            name="~Foo",
+            mangled="_ZN3FooD1Ev",
+        )
+        parser = _CastxmlParser(
+            root,
+            exported_dynamic={"_ZN3FooD1Ev"},
+            exported_static={"_ZN3FooD1Ev"},
+        )
+        funcs = parser.parse_functions()
+        assert len(funcs) == 1
+        assert funcs[0].name == "~Foo"
+        assert funcs[0].is_deleted is True
 
 
 class TestFuncDeletedEdgeCases:


### PR DESCRIPTION
## Summary

Adds `TestFuncDeletedEdgeCases` to `tests/test_func_deleted.py` covering four previously untested scenarios for `= delete` detection (abicc upstream issue #100):

- **Free function deleted** — plain non-method function
- **One overload deleted** — only the matching mangled symbol fires FUNC_DELETED
- **Template instantiation deleted**
- **Destructor deleted** — `~Foo` / `_ZN3FooD1Ev`
- **No double-report guard** — when castxml already marks `is_deleted=True`, `FUNC_DELETED_ELF_FALLBACK` must NOT also fire

Also appends an `## Upstream Issue Tracking` table to `docs/development/abicc-parity-status.md` mapping issue #100 to its implementation and test evidence.

**Tests: 17/17 passed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added upstream issue-tracking entries documenting coverage for deleted-function handling; duplicate section was unintentionally introduced.

* **Tests**
  * Added comprehensive edge-case tests for deleted-function scenarios (overloads, destructors, template instantiations) and tests verifying ELF-based fallback behavior to ensure deleted-function reports are emitted once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->