### PR TITLE
Add pytest-xdist support for parallel test execution on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,mcp]"
       - name: Run tests with coverage
+        if: runner.os != 'Windows'
         run: |
           pytest tests/ -v --tb=short -m "not integration and not libabigail and not abicc" --cov=abicheck --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+      - name: Run tests (Windows — parallel, no coverage)
+        if: runner.os == 'Windows'
+        run: |
+          pytest tests/ -v --tb=short -m "not integration and not libabigail and not abicc" -n auto --dist worksteal
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
@@ -104,9 +109,14 @@ jobs:
           cache: 'pip'
       - name: Install package
         run: pip install -e ".[dev]"
-      - name: Run integration tests with coverage
+      - name: Run integration tests (Linux/macOS — with coverage)
+        if: runner.os != 'Windows'
         run: |
           pytest tests/ -v -m integration --tb=short --cov=abicheck --cov-report=xml:coverage-integration.xml --ignore=tests/test_abi_examples.py
+      - name: Run integration tests (Windows — parallel, no coverage)
+        if: runner.os == 'Windows'
+        run: |
+          pytest tests/ -v -m integration --tb=short -n auto --dist worksteal --ignore=tests/test_abi_examples.py
       - name: Upload integration coverage to Codecov
         if: always() && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov",
     "pytest-xdist>=3.0",
+    "filelock>=3.0",
     "ruff>=0.3",
     "mypy>=1.0",
     "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ mcp = [
 dev = [
     "pytest>=7.0",
     "pytest-cov",
+    "pytest-xdist>=3.0",
     "ruff>=0.3",
     "mypy>=1.0",
     "types-PyYAML",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,16 @@
 """conftest.py — pytest configuration for abicheck tests."""
+import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+try:
+    import filelock  # shipped with pytest-xdist
+except ImportError:
+    filelock = None  # type: ignore[assignment]
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -78,6 +84,20 @@ def update_goldens(request: pytest.FixtureRequest) -> bool:
     return bool(request.config.getoption("--update-goldens"))
 
 
+def _cmake_configure_once(build_dir: Path) -> bool:
+    """Run cmake configure into *build_dir*.  Returns True on success."""
+    examples_dir = Path(__file__).parent.parent / "examples"
+    cmake = shutil.which("cmake")
+    if not cmake:
+        return False
+    r = subprocess.run(
+        [cmake, "-S", str(examples_dir), "-B", str(build_dir),
+         "-DCMAKE_BUILD_TYPE=Debug"],
+        capture_output=True, text=True, timeout=120,
+    )
+    return r.returncode == 0
+
+
 @pytest.fixture(scope="session")
 def shared_cmake_build_dir(tmp_path_factory: pytest.TempPathFactory) -> Path | None:
     """Session-scoped CMake build directory for integration tests.
@@ -86,6 +106,10 @@ def shared_cmake_build_dir(tmp_path_factory: pytest.TempPathFactory) -> Path | N
     individual tests only need to run ``cmake --build`` for their specific
     targets.  On Windows this avoids ~30 redundant cmake-configure passes
     (each one re-parses all 63 example CMakeLists).
+
+    When running under pytest-xdist, a file lock ensures only the first
+    worker runs the expensive cmake configure; other workers wait and
+    reuse the same build directory.
     """
     examples_dir = Path(__file__).parent.parent / "examples"
     cmake_lists = examples_dir / "CMakeLists.txt"
@@ -94,6 +118,31 @@ def shared_cmake_build_dir(tmp_path_factory: pytest.TempPathFactory) -> Path | N
     if not cmake or not cmake_lists.exists():
         return None
 
+    # Under pytest-xdist, share a single build dir across all workers
+    is_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+
+    if is_xdist and filelock is not None:
+        # All workers share the same root tmp dir; use a fixed name
+        root_tmp = tmp_path_factory.getbasetemp().parent
+        build_dir = root_tmp / "cmake_shared_build"
+        lock_path = root_tmp / "cmake_shared_build.lock"
+        done_flag = root_tmp / "cmake_shared_build.done"
+        fail_flag = root_tmp / "cmake_shared_build.fail"
+
+        with filelock.FileLock(str(lock_path), timeout=180):
+            if fail_flag.exists():
+                return None
+            if not done_flag.exists():
+                build_dir.mkdir(exist_ok=True)
+                if _cmake_configure_once(build_dir):
+                    done_flag.write_text("ok")
+                else:
+                    fail_flag.write_text("fail")
+                    return None
+
+        return build_dir
+
+    # Sequential execution: one configure per session
     build_dir = tmp_path_factory.mktemp("cmake_build")
     r = subprocess.run(
         [cmake, "-S", str(examples_dir), "-B", str(build_dir),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 try:
-    import filelock  # shipped with pytest-xdist
+    import filelock  # explicit dev dependency; used for xdist cmake locking
 except ImportError:
     filelock = None  # type: ignore[assignment]
 
@@ -90,11 +90,14 @@ def _cmake_configure_once(build_dir: Path) -> bool:
     cmake = shutil.which("cmake")
     if not cmake:
         return False
-    r = subprocess.run(
-        [cmake, "-S", str(examples_dir), "-B", str(build_dir),
-         "-DCMAKE_BUILD_TYPE=Debug"],
-        capture_output=True, text=True, timeout=120,
-    )
+    try:
+        r = subprocess.run(
+            [cmake, "-S", str(examples_dir), "-B", str(build_dir),
+             "-DCMAKE_BUILD_TYPE=Debug"],
+            capture_output=True, text=True, timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return False
     return r.returncode == 0
 
 
@@ -129,27 +132,25 @@ def shared_cmake_build_dir(tmp_path_factory: pytest.TempPathFactory) -> Path | N
         done_flag = root_tmp / "cmake_shared_build.done"
         fail_flag = root_tmp / "cmake_shared_build.fail"
 
-        with filelock.FileLock(str(lock_path), timeout=180):
-            if fail_flag.exists():
-                return None
-            if not done_flag.exists():
-                build_dir.mkdir(exist_ok=True)
-                if _cmake_configure_once(build_dir):
-                    done_flag.write_text("ok")
-                else:
-                    fail_flag.write_text("fail")
+        try:
+            with filelock.FileLock(str(lock_path), timeout=180):
+                if fail_flag.exists():
                     return None
+                if not done_flag.exists():
+                    build_dir.mkdir(exist_ok=True)
+                    if _cmake_configure_once(build_dir):
+                        done_flag.write_text("ok")
+                    else:
+                        fail_flag.write_text("fail")
+                        return None
+        except filelock.Timeout:
+            return None
 
         return build_dir
 
     # Sequential execution: one configure per session
     build_dir = tmp_path_factory.mktemp("cmake_build")
-    r = subprocess.run(
-        [cmake, "-S", str(examples_dir), "-B", str(build_dir),
-         "-DCMAKE_BUILD_TYPE=Debug"],
-        capture_output=True, text=True, timeout=120,
-    )
-    if r.returncode != 0:
+    if not _cmake_configure_once(build_dir):
         return None
 
     return build_dir

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -23,12 +23,18 @@ Marked `@pytest.mark.integration` — requires a C/C++ compiler + castxml in PAT
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+try:
+    import filelock as _filelock  # explicit dev dependency; used for xdist build locking
+except ImportError:
+    _filelock = None  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -252,14 +258,26 @@ def _build_with_cmake(
         if r.returncode != 0:
             pytest.fail(f"cmake configure failed for {case_name}:\n{r.stderr[:600]}")
 
-    # Build only this case's targets (--config for multi-config generators)
+    # Build only this case's targets (--config for multi-config generators).
+    # Under pytest-xdist, serialize cmake --build calls on the shared build
+    # tree to avoid concurrent writes to shared CMake internal state (e.g.
+    # .ninja_log, CMakeCache reads) which can be flaky on Windows/NTFS.
     v1_target = f"{case_name}_v1"
     v2_target = f"{case_name}_v2"
-    r = subprocess.run(
-        [cmake, "--build", str(build_dir), "--target", v1_target, v2_target,
-         "--config", "Debug"],
-        capture_output=True, text=True, timeout=120,
-    )
+    build_cmd = [cmake, "--build", str(build_dir), "--target", v1_target,
+                 v2_target, "--config", "Debug"]
+
+    is_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    if is_xdist and already_configured and _filelock is not None:
+        lock_path = build_dir.parent / "cmake_build.lock"
+        with _filelock.FileLock(str(lock_path), timeout=300):
+            r = subprocess.run(
+                build_cmd, capture_output=True, text=True, timeout=120,
+            )
+    else:
+        r = subprocess.run(
+            build_cmd, capture_output=True, text=True, timeout=120,
+        )
     if r.returncode != 0:
         pytest.fail(f"cmake build failed for {case_name}:\n{r.stderr[:600]}")
 

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -39,7 +39,7 @@ _EXPECTED_CASE_COUNT = 63
 class TestNormalizeVerdict:
     """_normalize_verdict must preserve each canonical verdict string."""
 
-    @pytest.mark.parametrize("verdict", list(_VALID_VERDICTS))
+    @pytest.mark.parametrize("verdict", sorted(_VALID_VERDICTS))
     def test_preserves_canonical_verdict(self, verdict: str) -> None:
         assert _normalize_verdict(verdict) == verdict
 


### PR DESCRIPTION
## Summary

Enable parallel test execution on Windows using pytest-xdist with proper CMake build directory sharing across workers via file locking.

## Motivation

Windows CI runs are slow due to repeated CMake configure passes (one per worker). By implementing file-locked coordination of the shared CMake build directory, we can run tests in parallel on Windows while ensuring only one worker performs the expensive configure step. This significantly reduces CI time on Windows while maintaining sequential execution on other platforms where it's already efficient.

## Changes

- **conftest.py**: 
  - Added optional `filelock` import (shipped with pytest-xdist)
  - Extracted `_cmake_configure_once()` helper function for reusable CMake configuration
  - Enhanced `shared_cmake_build_dir` fixture to detect pytest-xdist workers and coordinate via file locks (`cmake_shared_build.lock`, `cmake_shared_build.done`, `cmake_shared_build.fail`) to ensure only the first worker runs configure while others wait and reuse the build directory
  - Falls back to sequential execution when pytest-xdist is not available

- **pyproject.toml**:
  - Added `pytest-xdist>=3.0` to dev dependencies

- **.github/workflows/ci.yml**:
  - Split test runs by OS: Linux/macOS run sequentially with coverage; Windows runs in parallel with `-n auto --dist worksteal` without coverage
  - Applied same pattern to integration tests job

## Checklist

- [x] Tests added / updated for new behaviour (existing integration tests exercise the fixture)
- [ ] `CHANGELOG.md` updated (not applicable for internal test infrastructure)
- [ ] Docs updated if user-visible behaviour changed (internal change only)
- [ ] `pre-commit run --all-files` passes locally
- [ ] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_01AgK359wt74Euewi1LziEKu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to run Windows test jobs alongside Linux/macOS, enabling parallel platform coverage.
  * Added test parallelism tooling to dev dependencies.

* **Tests**
  * Shared test build coordination added so parallel test workers reuse configuration safely.
  * Improved test determinism by parameterizing a flaky unit test consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->