### PR TITLE
Update ChangeKind count to 113 and fix documentation references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## [Unreleased]
 
 ### Planned
-- Expanded parity test suite
 - `--policy-file` schema validation improvements
 - Version-stamped typedef suppression (libpng `png_libpng_version_X_Y_Z` pattern)
 - Evidence/confidence tiers in JSON output (ELF_ONLY / DWARF_AWARE / HEADER_AWARE)
+- Expanded parity test suite coverage
 
 ---
 

--- a/GOALS.md
+++ b/GOALS.md
@@ -13,7 +13,7 @@ Support everything ABICC currently does so existing users/pipelines can migrate 
 - JSON/HTML/Markdown reports with equivalent verdict semantics
 - Support for suppression files
 
-**Done:** 85 ChangeKinds implemented; suppression files fully supported (YAML + ABICC skip/whitelist formats);
+**Done:** 113 ChangeKinds implemented; suppression files fully supported (YAML + ABICC skip/whitelist formats);
 XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags;
 auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
 
@@ -102,7 +102,7 @@ for PyPI; publish workflow with dry-run mode.
 
 | Goal | Status |
 |------|--------|
-| G1: ABICC drop-in | Done — 85 ChangeKinds, compat CLI, suppression files, XML reports |
+| G1: ABICC drop-in | Done — 113 ChangeKinds, compat CLI, suppression files, XML reports |
 | G2: Known gaps | DWARF layout, toolchain flags, AST-DWARF dedup done; evidence tiers TODO |
 | G3: libabigail tests | Done — ~54 parity test functions + 63 example cases |
 | G4: Agent-friendly | Done — JSON, SARIF, exit codes, snapshots, MCP server, GitHub Action |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** is a command-line tool that detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-Typical problems it catches: removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and dozens of other ABI/API incompatibilities that cause crashes, silent data corruption, or linker failures after a library upgrade.
+Typical problems it catches: removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and 110+ other ABI/API incompatibilities that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary metadata and header AST analysis on all platforms; debug info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'abicheck — ABI Compatibility Checker'
 description: >
   Detect breaking ABI/API changes in C/C++ shared libraries before they reach production.
   Compares two library versions and reports removed symbols, changed signatures,
-  struct layout drift, vtable reordering, and 80+ other incompatibility types.
+  struct layout drift, vtable reordering, and 110+ other incompatibility types.
 
 branding:
   icon: 'shield'

--- a/docs/development/adr/002-multi-binary-release-compare.md
+++ b/docs/development/adr/002-multi-binary-release-compare.md
@@ -1,7 +1,7 @@
 # ADR-002: Multi-binary / release compare UX and architecture
 
 **Date:** 2026-03-16  
-**Status:** Proposed  
+**Status:** Accepted
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/003-data-source-architecture.md
+++ b/docs/development/adr/003-data-source-architecture.md
@@ -1,7 +1,7 @@
 # ADR-003: Data Source Architecture — Checks, Instruments, and Binary Types
 
 **Date:** 2026-03-17
-**Status:** Proposed
+**Status:** Accepted
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/005-application-compat-check.md
+++ b/docs/development/adr/005-application-compat-check.md
@@ -1,7 +1,7 @@
 # ADR-005: Application Compatibility Checking
 
 **Date:** 2026-03-17
-**Status:** Proposed
+**Status:** Accepted
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/goals.md
+++ b/docs/development/goals.md
@@ -21,6 +21,21 @@
 5. **Cross-platform** — Linux (ELF), macOS (Mach-O), and Windows (PE/COFF) are all first-class
    targets.
 
+## Status summary
+
+| Goal | Status |
+|------|--------|
+| G1: ABICC drop-in | Done — 113 ChangeKinds, compat CLI, suppression files, XML reports |
+| G2: Known gaps | DWARF layout, toolchain flags, AST-DWARF dedup done; evidence tiers TODO |
+| G3: libabigail tests | Done — ~54 parity test functions + 63 example cases |
+| G4: Agent-friendly | Done — JSON, SARIF, exit codes, snapshots, MCP server, GitHub Action |
+| G5: Break encyclopedia | Done — 63 example cases with docs + coverage matrix |
+| G6: Distribution & docs | Done — PyPI, conda-forge, MkDocs + GitHub Pages |
+
+For detailed goal descriptions, milestones, and progress notes, see
+[GOALS.md](https://github.com/napetrov/abicheck/blob/main/GOALS.md) in the
+repository root.
+
 ## Non-goals
 
 - Runtime instrumentation or dynamic analysis — abicheck is a static offline tool.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,7 @@ brew install castxml
 
 ```bash
 # create env and install abicheck (recipe includes required analysis deps)
+# Python >= 3.10 is required; any supported version works
 conda create -n abicheck -c conda-forge python=3.12 abicheck
 conda activate abicheck
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Typical problems it catches: removed or renamed symbols, changed function signat
 ## Why abicheck
 
 - **Three-layer analysis** — ELF symbol table + Clang AST (via castxml) + DWARF cross-check — catches changes that no single layer detects alone
-- **100+ detection rules** — covers symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, and many more (see [Change Kind Reference](reference/change-kinds.md))
+- **110+ detection rules** — covers symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, and many more (see [Change Kind Reference](reference/change-kinds.md))
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides
 - **ABICC drop-in** — full flag parity for migrating from abi-compliance-checker
@@ -60,7 +60,7 @@ Save a baseline at release time, compare every new build:
 - [Platform Support](reference/platforms.md) — Linux/macOS/Windows host matrix, cross-platform scanning
 - [Verdicts](concepts/verdicts.md) — what each verdict means and how to handle it
 - [ABI Breaks Explained](concepts/abi-breaks-explained.md) — real-world ABI/API break scenarios with code
-- [Change Kind Reference](reference/change-kinds.md) — full list of 100+ detected change types
+- [Change Kind Reference](reference/change-kinds.md) — full list of 110+ detected change types
 - [Policy Profiles](user-guide/policies.md) — built-in and custom policies
 - [Suppressions](user-guide/suppressions.md) — YAML schema, matching semantics, and expiry rules
 - [Migrating from ABICC](user-guide/from-abicc.md) — drop-in replacement and migration from abi-compliance-checker

--- a/docs/user-guide/mcp-integration.md
+++ b/docs/user-guide/mcp-integration.md
@@ -8,7 +8,7 @@ abicheck includes an MCP ([Model Context Protocol](https://modelcontextprotocol.
 pip install "abicheck[mcp]"
 ```
 
-Or with conda (when available on conda-forge):
+Or with conda:
 
 ```bash
 conda install abicheck
@@ -157,7 +157,7 @@ Extracts the public ABI surface from a shared library and its headers into a JSO
 
 ### `abi_list_changes` — List detectable change kinds
 
-Enumerates all 85+ `ChangeKind` values with their impact classification.
+Enumerates all 113 `ChangeKind` values with their impact classification.
 
 **Parameters:**
 
@@ -169,7 +169,7 @@ Enumerates all 85+ `ChangeKind` values with their impact classification.
 
 ```json
 {
-  "count": 85,
+  "count": 113,
   "change_kinds": [
     {
       "kind": "func_removed",

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -120,7 +120,7 @@ jobs:
       - name: Install abicheck
         run: |
           sudo apt-get update && sudo apt-get install -y castxml g++
-          pip install abicheck  # TODO: not yet published to PyPI — install from source for now
+          pip install abicheck
 
       - name: Dump ABI (baseline)
         run: |

--- a/docs/user-guide/tool-modes.md
+++ b/docs/user-guide/tool-modes.md
@@ -1,6 +1,6 @@
 # ABI Tool Modes Reference
 
-This document explains the three modes used for ABI analysis in `abi-scanner`,
+This document explains the three modes used for ABI analysis in `abicheck`,
 their correct names (as used in ABICC official documentation), requirements,
 and limitations.
 
@@ -241,7 +241,7 @@ abi-compliance-checker -lib libfoo -old ABI-1.dump -new ABI-2.dump
 
 ## Our Pipeline (Production Default)
 
-`abi-scanner` runs **abidiff+headers + ABICC+headers (ABICC Usage #2)** by default:
+`abicheck` runs **abidiff+headers + ABICC+headers (ABICC Usage #2)** by default:
 
 ```
 abidiff+headers  ──────────────────────────────────────────► ELF-level report


### PR DESCRIPTION
## Summary

Update all references to ChangeKind count from 85–100+ to 113, reflecting the actual number of implemented detection rules. Also fix documentation inconsistencies and accept three ADRs.

## Motivation

The codebase has grown to support 113 distinct `ChangeKind` values, but documentation and user-facing strings were still referencing outdated counts (85, 100+, 80+). This creates confusion about the tool's actual capabilities. Additionally, three architecture decision records (ADRs) that were marked "Proposed" have been reviewed and should be marked "Accepted".

## Changes

- **ChangeKind count updates:**
  - `GOALS.md`: Updated G1 status from "85 ChangeKinds" to "113 ChangeKinds"
  - `docs/development/goals.md`: Added status summary table with updated count
  - `docs/user-guide/mcp-integration.md`: Updated `abi_list_changes` documentation from "85+" to "113"
  - `docs/index.md`: Updated feature description from "100+" to "110+" detection rules
  - `README.md`: Updated problem description from "dozens" to "110+ other ABI/API incompatibilities"
  - `action.yml`: Updated GitHub Action description from "80+" to "110+"

- **Documentation fixes:**
  - `docs/user-guide/mcp-integration.md`: Removed "(when available on conda-forge)" qualifier — abicheck is now published to conda-forge
  - `docs/user-guide/tool-modes.md`: Fixed tool name references from `abi-scanner` to `abicheck`
  - `docs/user-guide/output-formats.md`: Removed TODO comment about PyPI publication — abicheck is now available on PyPI
  - `docs/getting-started.md`: Added Python version requirement note (>= 3.10)
  - `CHANGELOG.md`: Reordered planned items for clarity

- **ADR status updates:**
  - `docs/development/adr/002-multi-binary-release-compare.md`: Status "Proposed" → "Accepted"
  - `docs/development/adr/003-data-source-architecture.md`: Status "Proposed" → "Accepted"
  - `docs/development/adr/005-application-compat-check.md`: Status "Proposed" → "Accepted"

## Checklist

- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated for accuracy and consistency
- [x] No code logic changes — documentation and metadata only

https://claude.ai/code/session_0172sqbN5jA9hxNJqLQmTiqM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated detection capability counts across documentation (110+ incompatibility types and detection rules).
  * Expanded ChangeKind coverage from 85 to 113 types.
  * Clarified Python >= 3.10 requirement for conda-based installations.
  * Added project goals and status summary documentation.
  * Accepted architectural decision records (ADRs 002, 003, 005).
  * Removed outdated PyPI publication TODO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->