### PR TITLE
Fix type canonicalization and add confidence/audit features

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -35,6 +35,7 @@ from .checker_policy import (
 )
 from .checker_policy import (
     ChangeKind,
+    Confidence,
     Verdict,
     compute_verdict,
 )
@@ -149,7 +150,7 @@ class DiffResult:
     # Evidence tier and confidence — helps users assess how much trust to
     # place in the verdict.  "high" means multiple evidence sources agree;
     # "low" means key detectors were disabled (e.g., DWARF stripped).
-    confidence: str = "high"  # "high" | "medium" | "low"
+    confidence: Confidence = Confidence.HIGH
     evidence_tiers: list[str] = field(default_factory=list)  # e.g. ["elf", "dwarf", "header"]
     coverage_warnings: list[str] = field(default_factory=list)  # human-readable coverage gaps
 
@@ -260,8 +261,8 @@ def _check_function_signature(mangled: str, f_old: Function, f_new: Function) ->
             new_value=f_new.return_type,
         ))
 
-    old_params = [(p.type, p.kind) for p in f_old.params]
-    new_params = [(p.type, p.kind) for p in f_new.params]
+    old_params = [(canonicalize_type_name(p.type), p.kind) for p in f_old.params]
+    new_params = [(canonicalize_type_name(p.type), p.kind) for p in f_new.params]
     if old_params != new_params:
         changes.append(Change(
             kind=ChangeKind.FUNC_PARAMS_CHANGED,
@@ -2333,7 +2334,7 @@ def _compute_confidence(
     detector_results: list[DetectorResult],
     old: AbiSnapshot,
     new: AbiSnapshot,
-) -> tuple[list[str], str, list[str]]:
+) -> tuple[list[str], Confidence, list[str]]:
     """Compute evidence tiers, confidence level, and coverage warnings.
 
     Returns (evidence_tiers, confidence, coverage_warnings).
@@ -2358,8 +2359,10 @@ def _compute_confidence(
     has_dwarf_advanced = old.dwarf_advanced is not None or new.dwarf_advanced is not None
     has_pe = getattr(old, "pe", None) is not None or getattr(new, "pe", None) is not None
     has_macho = getattr(old, "macho", None) is not None or getattr(new, "macho", None) is not None
-    has_headers = bool(old.functions or old.types or old.enums or old.typedefs)
-    is_elf_only = getattr(old, "elf_only_mode", False)
+    has_headers = bool(
+        old.functions or old.types or old.enums or old.typedefs or old.variables
+        or new.functions or new.types or new.enums or new.typedefs or new.variables
+    )
 
     if has_elf:
         tiers.append("elf")
@@ -2381,27 +2384,27 @@ def _compute_confidence(
 
     # Compute confidence level.
     if has_headers and (has_elf or has_dwarf or has_pe or has_macho):
-        confidence = "high"
+        confidence = Confidence.HIGH
     elif has_headers:
-        confidence = "medium"
+        confidence = Confidence.MEDIUM
         if not has_elf and not has_pe and not has_macho:
             warnings.append(
                 "No binary metadata available; verdict is based on header analysis only"
             )
     elif has_elf and has_dwarf:
-        confidence = "medium"
+        confidence = Confidence.MEDIUM
         if not has_headers:
             warnings.append(
                 "No header/AST data; type-level changes may be missed"
             )
     elif has_elf or has_pe or has_macho:
-        confidence = "low"
+        confidence = Confidence.LOW
         warnings.append(
             "Binary-only analysis without debug info; many ABI changes "
             "cannot be detected (struct layout, enum values, type changes)"
         )
     else:
-        confidence = "low"
+        confidence = Confidence.LOW
         warnings.append("Very limited data available; results may be incomplete")
 
     # DWARF-specific warning: if DWARF is expected but stripped.
@@ -2409,8 +2412,8 @@ def _compute_confidence(
         (dr for dr in detector_results if dr.name == "dwarf"), None,
     )
     if dwarf_detector and not dwarf_detector.enabled:
-        if confidence == "high":
-            confidence = "medium"
+        if confidence == Confidence.HIGH:
+            confidence = Confidence.MEDIUM
 
     return tiers, confidence, warnings
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -53,6 +53,7 @@ from .model import (
     TypeField,
     Variable,
     Visibility,
+    canonicalize_type_name,
 )
 from .model import (
     is_compiler_internal_type as _is_compiler_internal_type,
@@ -145,6 +146,12 @@ class DiffResult:
     redundant_changes: list[Change] = field(default_factory=list)  # hidden by redundancy filter
     redundant_count: int = 0
     old_symbol_count: int | None = None  # public exported symbol count in old library
+    # Evidence tier and confidence — helps users assess how much trust to
+    # place in the verdict.  "high" means multiple evidence sources agree;
+    # "low" means key detectors were disabled (e.g., DWARF stripped).
+    confidence: str = "high"  # "high" | "medium" | "low"
+    evidence_tiers: list[str] = field(default_factory=list)  # e.g. ["elf", "dwarf", "header"]
+    coverage_warnings: list[str] = field(default_factory=list)  # human-readable coverage gaps
 
     def _effective_kind_sets(
         self,
@@ -244,7 +251,7 @@ def _check_function_signature(mangled: str, f_old: Function, f_new: Function) ->
     """Compare signatures and qualifiers of two matched functions."""
     changes: list[Change] = []
 
-    if f_old.return_type != f_new.return_type:
+    if canonicalize_type_name(f_old.return_type) != canonicalize_type_name(f_new.return_type):
         changes.append(Change(
             kind=ChangeKind.FUNC_RETURN_CHANGED,
             symbol=mangled,
@@ -405,7 +412,7 @@ def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 symbol=mangled,
                 description=f"Public variable removed: {v_old.name}",
             ))
-        elif old_map[mangled].type != new_map[mangled].type:
+        elif canonicalize_type_name(old_map[mangled].type) != canonicalize_type_name(new_map[mangled].type):
             changes.append(Change(
                 kind=ChangeKind.VAR_TYPE_CHANGED,
                 symbol=mangled,
@@ -546,7 +553,9 @@ def _diff_type_fields(name: str, t_old: RecordType, t_new: RecordType) -> list[C
 
 def _diff_type_field_pair(name: str, fname: str, f_old: TypeField, f_new: TypeField) -> list[Change]:
     changes: list[Change] = []
-    if f_old.type != f_new.type:
+    # Use canonical form for type comparison to avoid false positives from
+    # "struct Foo" vs "Foo" or "const int" vs "int const" differences.
+    if canonicalize_type_name(f_old.type) != canonicalize_type_name(f_new.type):
         changes.append(Change(
             kind=ChangeKind.TYPE_FIELD_TYPE_CHANGED,
             symbol=name,
@@ -2284,6 +2293,128 @@ def _deduplicate_ast_dwarf(changes: list[Change]) -> list[Change]:
     return result
 
 
+def _deduplicate_cross_detector(changes: list[Change]) -> list[Change]:
+    """Remove cross-detector duplicates that the per-detector guards may miss.
+
+    Centralised dedup applied after all detectors have run.  Uses
+    (change_category, symbol) as the dedup key to collapse overlapping
+    reports from different detectors for the same logical event.
+
+    Categories:
+    - "func_removal": FUNC_REMOVED, FUNC_REMOVED_ELF_ONLY
+    - "func_addition": FUNC_ADDED
+    - "var_removal": VAR_REMOVED
+    - "var_addition": VAR_ADDED
+
+    Within each category, the first occurrence wins (preserving detector
+    priority order from the ``compare()`` spec list).
+    """
+    _DEDUP_CATEGORIES: dict[ChangeKind, str] = {
+        ChangeKind.FUNC_REMOVED: "func_removal",
+        ChangeKind.FUNC_REMOVED_ELF_ONLY: "func_removal",
+        ChangeKind.FUNC_ADDED: "func_addition",
+        ChangeKind.VAR_REMOVED: "var_removal",
+        ChangeKind.VAR_ADDED: "var_addition",
+    }
+    seen: set[tuple[str, str]] = set()
+    result: list[Change] = []
+    for c in changes:
+        cat = _DEDUP_CATEGORIES.get(c.kind)
+        if cat is not None:
+            key = (cat, c.symbol)
+            if key in seen:
+                continue
+            seen.add(key)
+        result.append(c)
+    return result
+
+
+def _compute_confidence(
+    detector_results: list[DetectorResult],
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+) -> tuple[list[str], str, list[str]]:
+    """Compute evidence tiers, confidence level, and coverage warnings.
+
+    Returns (evidence_tiers, confidence, coverage_warnings).
+
+    Evidence tiers:
+    - "elf": ELF metadata present and analyzed
+    - "dwarf": DWARF debug info present
+    - "header": Header/AST information (functions/types/enums)
+    - "pe": PE metadata present
+    - "macho": Mach-O metadata present
+
+    Confidence:
+    - "high": headers + at least one binary metadata source (ELF/DWARF/PE/Mach-O)
+    - "medium": headers only, or binary-only with ELF+DWARF
+    - "low": binary-only without DWARF, or very limited data
+    """
+    tiers: list[str] = []
+    warnings: list[str] = []
+
+    has_elf = old.elf is not None or new.elf is not None
+    has_dwarf = old.dwarf is not None or new.dwarf is not None
+    has_dwarf_advanced = old.dwarf_advanced is not None or new.dwarf_advanced is not None
+    has_pe = getattr(old, "pe", None) is not None or getattr(new, "pe", None) is not None
+    has_macho = getattr(old, "macho", None) is not None or getattr(new, "macho", None) is not None
+    has_headers = bool(old.functions or old.types or old.enums or old.typedefs)
+    is_elf_only = getattr(old, "elf_only_mode", False)
+
+    if has_elf:
+        tiers.append("elf")
+    if has_dwarf:
+        tiers.append("dwarf")
+    if has_dwarf_advanced:
+        tiers.append("dwarf_advanced")
+    if has_headers:
+        tiers.append("header")
+    if has_pe:
+        tiers.append("pe")
+    if has_macho:
+        tiers.append("macho")
+
+    # Check for disabled detectors and generate warnings.
+    for dr in detector_results:
+        if not dr.enabled and dr.coverage_gap:
+            warnings.append(f"Detector '{dr.name}' disabled: {dr.coverage_gap}")
+
+    # Compute confidence level.
+    if has_headers and (has_elf or has_dwarf or has_pe or has_macho):
+        confidence = "high"
+    elif has_headers:
+        confidence = "medium"
+        if not has_elf and not has_pe and not has_macho:
+            warnings.append(
+                "No binary metadata available; verdict is based on header analysis only"
+            )
+    elif has_elf and has_dwarf:
+        confidence = "medium"
+        if not has_headers:
+            warnings.append(
+                "No header/AST data; type-level changes may be missed"
+            )
+    elif has_elf or has_pe or has_macho:
+        confidence = "low"
+        warnings.append(
+            "Binary-only analysis without debug info; many ABI changes "
+            "cannot be detected (struct layout, enum values, type changes)"
+        )
+    else:
+        confidence = "low"
+        warnings.append("Very limited data available; results may be incomplete")
+
+    # DWARF-specific warning: if DWARF is expected but stripped.
+    dwarf_detector = next(
+        (dr for dr in detector_results if dr.name == "dwarf"), None,
+    )
+    if dwarf_detector and not dwarf_detector.enabled:
+        if confidence == "high":
+            confidence = "medium"
+
+    return tiers, confidence, warnings
+
+
 def compare(
     old: AbiSnapshot,
     new: AbiSnapshot,
@@ -2377,6 +2508,11 @@ def compare(
     # an unsuppressed DWARF duplicate).
     changes = _deduplicate_ast_dwarf(changes)
 
+    # Cross-detector dedup: collapse overlapping reports from different
+    # detectors (e.g., function detector + PE/Mach-O detector both emitting
+    # FUNC_REMOVED for the same symbol).
+    changes = _deduplicate_cross_detector(changes)
+
     # Enrich source locations before suppression so source_location-based
     # suppression rules can match (most changes have source_location=None
     # until enrichment runs).
@@ -2412,6 +2548,11 @@ def compare(
         1 for v in old.variables if v.visibility in _PUBLIC_VIS
     )
 
+    # Compute evidence tiers and confidence from detector results.
+    evidence_tiers, confidence, coverage_warnings = _compute_confidence(
+        detector_results, old, new,
+    )
+
     return DiffResult(
         old_version=old.version,
         new_version=new.version,
@@ -2427,6 +2568,9 @@ def compare(
         redundant_changes=redundant,
         redundant_count=len(redundant),
         old_symbol_count=old_sym_count if old_sym_count > 0 else None,
+        confidence=confidence,
+        evidence_tiers=evidence_tiers,
+        coverage_warnings=coverage_warnings,
     )
 
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -859,7 +859,7 @@ def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     description=f"Union field removed: {name}::{fname}",
                     old_value=f_old.type,
                 ))
-            elif f_old.type != new_fields[fname].type:
+            elif canonicalize_type_name(f_old.type) != canonicalize_type_name(new_fields[fname].type):
                 changes.append(Change(
                     kind=ChangeKind.UNION_FIELD_TYPE_CHANGED,
                     symbol=name,

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -592,6 +592,44 @@ if not RISK_KINDS.isdisjoint(API_BREAK_KINDS):
         f"offending kinds: {RISK_KINDS & API_BREAK_KINDS}"
     )
 
+# Completeness check: every ChangeKind must be classified in exactly one set.
+# Unclassified kinds silently default to BREAKING at runtime (fail-safe), but
+# this makes the *intent* invisible and risks false negatives if a new kind is
+# added but forgotten here.  Use explicit raise (not assert) so this is never
+# stripped by python -O.
+_ALL_CLASSIFIED: frozenset[ChangeKind] = (
+    frozenset(BREAKING_KINDS) | frozenset(COMPATIBLE_KINDS)
+    | frozenset(API_BREAK_KINDS) | RISK_KINDS
+)
+_UNCLASSIFIED = set(ChangeKind) - _ALL_CLASSIFIED
+if _UNCLASSIFIED:
+    raise AssertionError(
+        "Every ChangeKind must appear in exactly one of BREAKING_KINDS, "
+        "COMPATIBLE_KINDS, API_BREAK_KINDS, or RISK_KINDS. "
+        f"Unclassified kinds (will default to BREAKING at runtime): {_UNCLASSIFIED}"
+    )
+
+# No kind should appear in more than one primary set (BREAKING, COMPATIBLE,
+# API_BREAK).  RISK_KINDS disjointness is already checked above.
+_BREAKING_COMPAT_OVERLAP = frozenset(BREAKING_KINDS) & frozenset(COMPATIBLE_KINDS)
+if _BREAKING_COMPAT_OVERLAP:
+    raise AssertionError(
+        "BREAKING_KINDS and COMPATIBLE_KINDS must be disjoint; "
+        f"offending kinds: {_BREAKING_COMPAT_OVERLAP}"
+    )
+_BREAKING_API_OVERLAP = frozenset(BREAKING_KINDS) & frozenset(API_BREAK_KINDS)
+if _BREAKING_API_OVERLAP:
+    raise AssertionError(
+        "BREAKING_KINDS and API_BREAK_KINDS must be disjoint; "
+        f"offending kinds: {_BREAKING_API_OVERLAP}"
+    )
+_COMPAT_API_OVERLAP = frozenset(COMPATIBLE_KINDS) & frozenset(API_BREAK_KINDS)
+if _COMPAT_API_OVERLAP:
+    raise AssertionError(
+        "COMPATIBLE_KINDS and API_BREAK_KINDS must be disjoint; "
+        f"offending kinds: {_COMPAT_API_OVERLAP}"
+    )
+
 
 @dataclass(frozen=True)
 class PolicyEntry:

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -292,6 +292,13 @@ class Verdict(str, Enum):
     BREAKING = "BREAKING"  # binary ABI break
 
 
+class Confidence(str, Enum):
+    """Evidence confidence level for a comparison result."""
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
 # Which ChangeKinds are immediately BREAKING (binary ABI incompatibility)
 BREAKING_KINDS = {
     ChangeKind.FUNC_REMOVED,

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging as _logging
+import re as _re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -43,6 +44,44 @@ COMPILER_INTERNAL_TYPES: frozenset[str] = frozenset({
 def is_compiler_internal_type(name: str) -> bool:
     """Return True if *name* is a compiler internal type that should be excluded."""
     return bool(name) and name in COMPILER_INTERNAL_TYPES
+
+# ---------------------------------------------------------------------------
+# Type name canonicalization — normalise type names for reliable matching.
+# ---------------------------------------------------------------------------
+
+# Patterns for type-name canonicalization.
+_STRUCT_PREFIX_RE = _re.compile(r"^(struct|class|union|enum)\s+")
+_CONST_REORDER_RE = _re.compile(r"\bconst\s+(\w+)")
+_MULTI_SPACE_RE = _re.compile(r"\s{2,}")
+
+
+def canonicalize_type_name(name: str) -> str:
+    """Normalise a C/C++ type name for comparison.
+
+    Transformations (in order):
+    1. Strip leading ``struct ``/``class ``/``union ``/``enum `` elaborated-type-specifier.
+    2. Normalise ``const int`` → ``int const`` (east-const canonical form).
+    3. Collapse multiple spaces.
+    4. Strip leading/trailing whitespace.
+
+    This prevents false positives from dumpers that emit different
+    elaborated-type-specifier forms for the same type.
+
+    >>> canonicalize_type_name("struct Foo")
+    'Foo'
+    >>> canonicalize_type_name("const int *")
+    'int const *'
+    >>> canonicalize_type_name("  class   Bar  ")
+    'Bar'
+    """
+    result = name
+    # 1. Strip elaborated type specifier prefix.
+    result = _STRUCT_PREFIX_RE.sub("", result)
+    # 2. East-const normalisation: "const T" → "T const" (only for simple types).
+    result = _CONST_REORDER_RE.sub(r"\1 const", result)
+    # 3. Collapse whitespace.
+    result = _MULTI_SPACE_RE.sub(" ", result)
+    return result.strip()
 
 
 class Visibility(str, Enum):

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -50,8 +50,11 @@ def is_compiler_internal_type(name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 # Patterns for type-name canonicalization.
-_STRUCT_PREFIX_RE = _re.compile(r"^(struct|class|union|enum)\s+")
-_LEADING_CONST_RE = _re.compile(r"^const\s+([\w\s]+?)(\s*[*&].*)?$")
+_STRUCT_PREFIX_RE = _re.compile(r"^\s*(struct|class|union|enum)\s+")
+# Match leading "const" followed by a base type (words, ::, spaces) and optional
+# pointer/reference suffix.  The base-type group accepts scope operators (::)
+# so that namespace-qualified types like "const ns::Type &" are handled.
+_LEADING_CONST_RE = _re.compile(r"^const\s+([\w\s:]+?)(\s*[*&].*)?$")
 _MULTI_SPACE_RE = _re.compile(r"\s{2,}")
 
 
@@ -59,11 +62,11 @@ def canonicalize_type_name(name: str) -> str:
     """Normalise a C/C++ type name for comparison.
 
     Transformations (in order):
+    0. Strip leading/trailing whitespace and collapse internal whitespace.
     1. Strip leading ``struct ``/``class ``/``union ``/``enum `` elaborated-type-specifier.
     2. Normalise leading ``const T`` → ``T const`` (east-const canonical form),
-       but only when the base type is simple words (no templates).
-    3. Collapse multiple spaces.
-    4. Strip leading/trailing whitespace.
+       but only when the base type contains no angle brackets (templates).
+    3. Final whitespace cleanup.
 
     This prevents false positives from dumpers that emit different
     elaborated-type-specifier forms for the same type.
@@ -76,20 +79,26 @@ def canonicalize_type_name(name: str) -> str:
     'Bar'
     >>> canonicalize_type_name("const unsigned long long")
     'unsigned long long const'
+    >>> canonicalize_type_name("const ns::Type &")
+    'ns::Type const &'
     """
-    result = name
-    # 1. Strip elaborated type specifier prefix.
+    # 0. Normalise whitespace early so anchored regexes work consistently.
+    result = _MULTI_SPACE_RE.sub(" ", name.strip())
+    # 1. Strip elaborated type specifier prefix (handles leading whitespace).
     result = _STRUCT_PREFIX_RE.sub("", result)
     # 2. East-const normalisation: move leading "const" after the full base
-    #    type (all words before any pointer/reference sigil).  Only applies
+    #    type (all words/:: before any pointer/reference sigil).  Only applies
     #    when the base portion contains no angle brackets (templates).
     m = _LEADING_CONST_RE.match(result)
     if m:
         base = m.group(1).strip()
         suffix = m.group(2) or ""
         if "<" not in base:
+            # Strip elaborated prefix from the base too, handling
+            # "const struct Foo" → base="struct Foo" → "Foo"
+            base = _STRUCT_PREFIX_RE.sub("", base)
             result = base + " const" + suffix
-    # 3. Collapse whitespace.
+    # 3. Final cleanup.
     result = _MULTI_SPACE_RE.sub(" ", result)
     return result.strip()
 

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -51,7 +51,7 @@ def is_compiler_internal_type(name: str) -> bool:
 
 # Patterns for type-name canonicalization.
 _STRUCT_PREFIX_RE = _re.compile(r"^(struct|class|union|enum)\s+")
-_CONST_REORDER_RE = _re.compile(r"\bconst\s+(\w+)")
+_LEADING_CONST_RE = _re.compile(r"^const\s+([\w\s]+?)(\s*[*&].*)?$")
 _MULTI_SPACE_RE = _re.compile(r"\s{2,}")
 
 
@@ -60,7 +60,8 @@ def canonicalize_type_name(name: str) -> str:
 
     Transformations (in order):
     1. Strip leading ``struct ``/``class ``/``union ``/``enum `` elaborated-type-specifier.
-    2. Normalise ``const int`` → ``int const`` (east-const canonical form).
+    2. Normalise leading ``const T`` → ``T const`` (east-const canonical form),
+       but only when the base type is simple words (no templates).
     3. Collapse multiple spaces.
     4. Strip leading/trailing whitespace.
 
@@ -73,12 +74,21 @@ def canonicalize_type_name(name: str) -> str:
     'int const *'
     >>> canonicalize_type_name("  class   Bar  ")
     'Bar'
+    >>> canonicalize_type_name("const unsigned long long")
+    'unsigned long long const'
     """
     result = name
     # 1. Strip elaborated type specifier prefix.
     result = _STRUCT_PREFIX_RE.sub("", result)
-    # 2. East-const normalisation: "const T" → "T const" (only for simple types).
-    result = _CONST_REORDER_RE.sub(r"\1 const", result)
+    # 2. East-const normalisation: move leading "const" after the full base
+    #    type (all words before any pointer/reference sigil).  Only applies
+    #    when the base portion contains no angle brackets (templates).
+    m = _LEADING_CONST_RE.match(result)
+    if m:
+        base = m.group(1).strip()
+        suffix = m.group(2) or ""
+        if "<" not in base:
+            result = base + " const" + suffix
     # 3. Collapse whitespace.
     result = _MULTI_SPACE_RE.sub(" ", result)
     return result.strip()

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -49,6 +49,7 @@ def is_compiler_internal_type(name: str) -> bool:
 # Type name canonicalization — normalise type names for reliable matching.
 # ---------------------------------------------------------------------------
 
+
 # Patterns for type-name canonicalization.
 _STRUCT_PREFIX_RE = _re.compile(r"^\s*(struct|class|union|enum)\s+")
 # Match leading "const" followed by a base type (words, ::, spaces) and optional

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -54,7 +54,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .checker_policy import VALID_BASE_POLICIES, ChangeKind, Verdict, compute_verdict
+from .checker_policy import VALID_BASE_POLICIES, BREAKING_KINDS, ChangeKind, Verdict, compute_verdict
 
 log = logging.getLogger(__name__)
 
@@ -67,6 +67,19 @@ _SEVERITY_MAP: dict[str, Verdict] = {
 }
 
 _VALID_BASE_POLICIES = VALID_BASE_POLICIES  # re-export alias for backward compat
+
+# Kinds that are especially dangerous to downgrade — removing a function
+# or changing its signature always causes hard crashes.
+_CRITICAL_BREAKING_KINDS: frozenset[ChangeKind] = frozenset({
+    ChangeKind.FUNC_REMOVED,
+    ChangeKind.FUNC_RETURN_CHANGED,
+    ChangeKind.FUNC_PARAMS_CHANGED,
+    ChangeKind.TYPE_SIZE_CHANGED,
+    ChangeKind.TYPE_VTABLE_CHANGED,
+    ChangeKind.VAR_REMOVED,
+    ChangeKind.VAR_TYPE_CHANGED,
+    ChangeKind.SONAME_CHANGED,
+})
 
 
 @dataclass
@@ -217,21 +230,6 @@ class PolicyFile:
           (e.g., func_removed → ignore).  These almost certainly mask real breaks.
         - Downgrading BREAKING to COMPATIBLE_WITH_RISK for critical kinds.
         """
-        from .checker_policy import BREAKING_KINDS
-
-        # Kinds that are especially dangerous to downgrade — removing a function
-        # or changing its signature always causes hard crashes.
-        _CRITICAL_BREAKING_KINDS: frozenset[ChangeKind] = frozenset({
-            ChangeKind.FUNC_REMOVED,
-            ChangeKind.FUNC_RETURN_CHANGED,
-            ChangeKind.FUNC_PARAMS_CHANGED,
-            ChangeKind.TYPE_SIZE_CHANGED,
-            ChangeKind.TYPE_VTABLE_CHANGED,
-            ChangeKind.VAR_REMOVED,
-            ChangeKind.VAR_TYPE_CHANGED,
-            ChangeKind.SONAME_CHANGED,
-        })
-
         warnings: list[str] = []
         for kind, verdict in self.overrides.items():
             if kind in _CRITICAL_BREAKING_KINDS:

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -55,11 +55,11 @@ from pathlib import Path
 from typing import Any
 
 from .checker_policy import (
-    BREAKING_KINDS,
     VALID_BASE_POLICIES,
     ChangeKind,
     Verdict,
     compute_verdict,
+    policy_kind_sets,
 )
 
 log = logging.getLogger(__name__)
@@ -236,6 +236,10 @@ class PolicyFile:
           (e.g., func_removed → ignore).  These almost certainly mask real breaks.
         - Downgrading BREAKING to COMPATIBLE_WITH_RISK for critical kinds.
         """
+        # Derive breaking kinds from the configured base policy so that
+        # policy-specific sets (e.g. plugin_abi) are correctly flagged.
+        base_breaking, _, _, _ = policy_kind_sets(self.base_policy)
+
         warnings: list[str] = []
         for kind, verdict in self.overrides.items():
             if kind in _CRITICAL_BREAKING_KINDS:
@@ -251,7 +255,7 @@ class PolicyFile:
                         f"this kind usually causes binary incompatibility. "
                         f"Consider keeping it as 'break'."
                     )
-            elif kind in BREAKING_KINDS and verdict == Verdict.COMPATIBLE:
+            elif kind in base_breaking and verdict == Verdict.COMPATIBLE:
                 warnings.append(
                     f"'{kind.value}' (BREAKING) downgraded to 'ignore' — "
                     f"verify this is intentional."

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -54,7 +54,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .checker_policy import VALID_BASE_POLICIES, BREAKING_KINDS, ChangeKind, Verdict, compute_verdict
+from .checker_policy import (
+    BREAKING_KINDS,
+    VALID_BASE_POLICIES,
+    ChangeKind,
+    Verdict,
+    compute_verdict,
+)
 
 log = logging.getLogger(__name__)
 

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -206,3 +206,50 @@ class PolicyFile:
         else:
             lines.append("overrides: (none)")
         return "\n".join(lines)
+
+    def validate_overrides(self) -> list[str]:
+        """Check for high-risk or suspicious overrides and return warnings.
+
+        Returns a list of human-readable warning strings.  Empty list = no issues.
+
+        Checks:
+        - Downgrading known-dangerous BREAKING kinds to COMPATIBLE
+          (e.g., func_removed → ignore).  These almost certainly mask real breaks.
+        - Downgrading BREAKING to COMPATIBLE_WITH_RISK for critical kinds.
+        """
+        from .checker_policy import BREAKING_KINDS
+
+        # Kinds that are especially dangerous to downgrade — removing a function
+        # or changing its signature always causes hard crashes.
+        _CRITICAL_BREAKING_KINDS: frozenset[ChangeKind] = frozenset({
+            ChangeKind.FUNC_REMOVED,
+            ChangeKind.FUNC_RETURN_CHANGED,
+            ChangeKind.FUNC_PARAMS_CHANGED,
+            ChangeKind.TYPE_SIZE_CHANGED,
+            ChangeKind.TYPE_VTABLE_CHANGED,
+            ChangeKind.VAR_REMOVED,
+            ChangeKind.VAR_TYPE_CHANGED,
+            ChangeKind.SONAME_CHANGED,
+        })
+
+        warnings: list[str] = []
+        for kind, verdict in self.overrides.items():
+            if kind in _CRITICAL_BREAKING_KINDS:
+                if verdict == Verdict.COMPATIBLE:
+                    warnings.append(
+                        f"HIGH RISK: '{kind.value}' downgraded to 'ignore' — "
+                        f"this is almost certainly a mistake. "
+                        f"This kind causes hard crashes when the ABI changes."
+                    )
+                elif verdict == Verdict.COMPATIBLE_WITH_RISK:
+                    warnings.append(
+                        f"RISK: '{kind.value}' downgraded to 'risk' — "
+                        f"this kind usually causes binary incompatibility. "
+                        f"Consider keeping it as 'break'."
+                    )
+            elif kind in BREAKING_KINDS and verdict == Verdict.COMPATIBLE:
+                warnings.append(
+                    f"'{kind.value}' (BREAKING) downgraded to 'ignore' — "
+                    f"verify this is intentional."
+                )
+        return warnings

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -308,7 +308,7 @@ class SuppressionList:
         """
         from .checker_policy import BREAKING_KINDS
         check_date = today or date.today()
-        near_expiry_cutoff = check_date + __import__("datetime").timedelta(days=near_expiry_days)
+        near_expiry_cutoff = check_date + timedelta(days=near_expiry_days)
 
         match_counts: dict[int, int] = {i: 0 for i in range(len(self._suppressions))}
         high_risk: list[tuple[Suppression, Change]] = []

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -290,8 +290,109 @@ class SuppressionList:
         """Return all rules with the given label."""
         return [s for s in self._suppressions if s.label == label]
 
+    def audit(
+        self,
+        changes: list[Change],
+        today: date | None = None,
+        *,
+        near_expiry_days: int = 30,
+    ) -> SuppressionAudit:
+        """Audit suppression rules against a set of changes.
+
+        Returns a :class:`SuppressionAudit` with:
+        - ``stale_rules``: suppressions that matched zero changes (misconfigured?)
+        - ``high_risk_matches``: suppressions that matched BREAKING changes
+        - ``expired_rules``: rules past their expiry date
+        - ``near_expiry_rules``: rules expiring within *near_expiry_days*
+        - ``match_counts``: per-rule match count
+        """
+        from .checker_policy import BREAKING_KINDS
+        check_date = today or date.today()
+        near_expiry_cutoff = check_date + __import__("datetime").timedelta(days=near_expiry_days)
+
+        match_counts: dict[int, int] = {i: 0 for i in range(len(self._suppressions))}
+        high_risk: list[tuple[Suppression, Change]] = []
+
+        for c in changes:
+            for i, s in enumerate(self._suppressions):
+                if s.matches(c, today=today):
+                    match_counts[i] += 1
+                    if c.kind in BREAKING_KINDS:
+                        high_risk.append((s, c))
+
+        stale = [
+            self._suppressions[i]
+            for i, count in match_counts.items()
+            if count == 0 and not self._suppressions[i].is_expired(today)
+        ]
+
+        expired = self.expired_rules(today)
+
+        near_expiry = [
+            s for s in self._suppressions
+            if s.expires is not None
+            and not s.is_expired(today)
+            and s.expires <= near_expiry_cutoff
+        ]
+
+        return SuppressionAudit(
+            stale_rules=stale,
+            high_risk_matches=high_risk,
+            expired_rules=expired,
+            near_expiry_rules=near_expiry,
+            match_counts={i: match_counts[i] for i in match_counts},
+            total_rules=len(self._suppressions),
+        )
+
     def __len__(self) -> int:
         return len(self._suppressions)
 
     def __repr__(self) -> str:
         return f"SuppressionList({len(self._suppressions)} rules)"
+
+
+@dataclass
+class SuppressionAudit:
+    """Result of auditing suppression rules against detected changes."""
+    stale_rules: list[Suppression]
+    """Rules that matched zero changes (likely stale or misconfigured)."""
+    high_risk_matches: list[tuple[Suppression, "Change"]]
+    """Suppressions that matched BREAKING changes (high risk — should require reason)."""
+    expired_rules: list[Suppression]
+    """Rules past their expiry date."""
+    near_expiry_rules: list[Suppression]
+    """Rules expiring within the near-expiry window."""
+    match_counts: dict[int, int]
+    """Per-rule match count (rule index → number of matched changes)."""
+    total_rules: int
+    """Total number of suppression rules."""
+
+    @property
+    def has_issues(self) -> bool:
+        """True if the audit found any issues worth reporting."""
+        return bool(
+            self.stale_rules
+            or self.high_risk_matches
+            or self.expired_rules
+            or self.near_expiry_rules
+        )
+
+    def summary(self) -> str:
+        """Human-readable audit summary."""
+        lines = [f"Suppression audit: {self.total_rules} rules"]
+        if self.stale_rules:
+            lines.append(f"  ⚠ {len(self.stale_rules)} stale rule(s) matched nothing")
+            for s in self.stale_rules[:5]:
+                target = s.symbol or s.symbol_pattern or s.type_pattern or s.source_location or "?"
+                lines.append(f"    - {target} ({s.reason or 'no reason'})")
+        if self.high_risk_matches:
+            lines.append(f"  ⚠ {len(self.high_risk_matches)} suppression(s) matched BREAKING changes")
+            for sup, change in self.high_risk_matches[:5]:
+                lines.append(f"    - {change.kind.value}: {change.symbol}")
+        if self.expired_rules:
+            lines.append(f"  ⚠ {len(self.expired_rules)} expired rule(s)")
+        if self.near_expiry_rules:
+            lines.append(f"  ℹ {len(self.near_expiry_rules)} rule(s) expiring soon")
+        if not self.has_issues:
+            lines.append("  ✓ No issues found")
+        return "\n".join(lines)

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -356,7 +356,7 @@ class SuppressionAudit:
     """Result of auditing suppression rules against detected changes."""
     stale_rules: list[Suppression]
     """Rules that matched zero changes (likely stale or misconfigured)."""
-    high_risk_matches: list[tuple[Suppression, "Change"]]
+    high_risk_matches: list[tuple[Suppression, Change]]
     """Suppressions that matched BREAKING changes (high risk — should require reason)."""
     expired_rules: list[Suppression]
     """Rules past their expiry date."""

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -306,6 +306,8 @@ class SuppressionList:
         - ``near_expiry_rules``: rules expiring within *near_expiry_days*
         - ``match_counts``: per-rule match count
         """
+        if near_expiry_days < 0:
+            raise ValueError("near_expiry_days must be non-negative")
         from .checker_policy import BREAKING_KINDS
         check_date = today or date.today()
         near_expiry_cutoff = check_date + timedelta(days=near_expiry_days)

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -1,6 +1,6 @@
 {
-  "version": "2",
-  "description": "Ground-truth expected verdicts for all abicheck example cases. Single source of truth \u2014 kept in sync with tests/test_example_autodiscovery.py::EXPECTED.",
+  "version": "3",
+  "description": "Ground-truth expected verdicts and change kinds for all abicheck example cases. Single source of truth \u2014 kept in sync with tests/test_example_autodiscovery.py::EXPECTED. expected_kinds lists the ChangeKind values that MUST appear in the diff result (subset check). expected_absent_kinds lists kinds that MUST NOT appear (false positive guard).",
   "cross_references": {
     "verdict_classification": "abicheck/checker_policy.py — BREAKING_KINDS, API_BREAK_KINDS, RISK_KINDS, COMPATIBLE_KINDS (= ADDITION_KINDS ∪ QUALITY_KINDS)",
     "category_mapping": "breaking → BREAKING_KINDS | api_break → API_BREAK_KINDS | risk → RISK_KINDS | addition → ADDITION_KINDS | quality → QUALITY_KINDS | no_change → (empty)",
@@ -19,7 +19,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_removed"]
     },
     "case02_param_type_change": {
       "expected": "BREAKING",
@@ -29,7 +30,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_params_changed"]
     },
     "case03_compat_addition": {
       "expected": "COMPATIBLE",
@@ -41,7 +43,8 @@
       ],
       "abi_break": false,
       "api_break": false,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_added"]
     },
     "case04_no_change": {
       "expected": "NO_CHANGE",
@@ -53,7 +56,9 @@
       ],
       "abi_break": false,
       "api_break": false,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": [],
+      "expected_absent_kinds": ["func_removed", "func_params_changed", "type_size_changed"]
     },
     "case05_soname": {
       "expected": "COMPATIBLE",
@@ -63,7 +68,8 @@
       ],
       "abi_break": false,
       "api_break": false,
-      "bad_practice": true
+      "bad_practice": true,
+      "expected_kinds": ["soname_missing"]
     },
     "case06_visibility": {
       "expected": "BREAKING",
@@ -73,7 +79,8 @@
       ],
       "abi_break": true,
       "api_break": false,
-      "bad_practice": true
+      "bad_practice": true,
+      "expected_kinds": ["func_visibility_changed"]
     },
     "case07_struct_layout": {
       "expected": "BREAKING",
@@ -83,7 +90,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["type_size_changed"]
     },
     "case08_enum_value_change": {
       "expected": "BREAKING",
@@ -93,7 +101,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["enum_member_value_changed"]
     },
     "case09_cpp_vtable": {
       "expected": "BREAKING",
@@ -103,7 +112,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["type_vtable_changed"]
     },
     "case10_return_type": {
       "expected": "BREAKING",
@@ -113,7 +123,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_return_changed"]
     },
     "case11_global_var_type": {
       "expected": "BREAKING",
@@ -123,7 +134,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["var_type_changed"]
     },
     "case12_function_removed": {
       "expected": "BREAKING",
@@ -135,7 +147,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_removed"]
     },
     "case13_symbol_versioning": {
       "expected": "COMPATIBLE",
@@ -208,7 +221,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["enum_member_removed"]
     },
     "case20_enum_member_value_changed": {
       "expected": "BREAKING",
@@ -221,7 +235,8 @@
       "abi_break": true,
       "api_break": true,
       "bad_practice": false,
-      "reason": "regular enum member value changes remain breaking; only named sentinel patterns are downgraded"
+      "reason": "regular enum member value changes remain breaking; only named sentinel patterns are downgraded",
+      "expected_kinds": ["enum_member_value_changed"]
     },
     "case21_method_became_static": {
       "expected": "BREAKING",
@@ -231,7 +246,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_static_changed"]
     },
     "case22_method_const_changed": {
       "expected": "BREAKING",
@@ -243,7 +259,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_cv_changed"]
     },
     "case23_pure_virtual_added": {
       "expected": "BREAKING",
@@ -255,7 +272,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["func_pure_virtual_added"]
     },
     "case24_union_field_removed": {
       "expected": "BREAKING",
@@ -267,7 +285,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["union_field_removed"]
     },
     "case25_enum_member_added": {
       "expected": "COMPATIBLE",
@@ -279,7 +298,8 @@
       ],
       "abi_break": false,
       "api_break": false,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["enum_member_added"]
     },
     "case26_union_field_added": {
       "expected": "BREAKING",
@@ -313,7 +333,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["type_became_opaque"]
     },
     "case29_ifunc_transition": {
       "expected": "COMPATIBLE",
@@ -348,7 +369,8 @@
       ],
       "abi_break": false,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["enum_member_renamed"]
     },
     "case32_param_defaults": {
       "expected": "NO_CHANGE",
@@ -372,7 +394,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["param_pointer_level_changed"]
     },
     "case34_access_level": {
       "expected": "API_BREAK",
@@ -396,7 +419,8 @@
       ],
       "abi_break": false,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["field_renamed"]
     },
     "case36_anon_struct": {
       "expected": "BREAKING",
@@ -420,7 +444,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["type_base_changed"]
     },
     "case38_virtual_methods": {
       "expected": "BREAKING",
@@ -444,7 +469,8 @@
       ],
       "abi_break": true,
       "api_break": true,
-      "bad_practice": false
+      "bad_practice": false,
+      "expected_kinds": ["var_became_const"]
     },
     "case40_field_layout": {
       "expected": "BREAKING",

--- a/tests/test_policy_changekind_matrix.py
+++ b/tests/test_policy_changekind_matrix.py
@@ -15,11 +15,11 @@ from abicheck.checker_policy import (
     COMPATIBLE_KINDS,
     RISK_KINDS,
     ChangeKind,
+    Confidence,
     Verdict,
     compute_verdict,
     policy_kind_sets,
 )
-
 
 # All known policies.
 ALL_POLICIES = ("strict_abi", "sdk_vendor", "plugin_abi")
@@ -161,7 +161,7 @@ class TestConfidenceComputation:
         )
         result = compare(snap, snap)
         assert hasattr(result, "confidence")
-        assert result.confidence in ("high", "medium", "low")
+        assert result.confidence in (Confidence.HIGH, Confidence.MEDIUM, Confidence.LOW)
         assert isinstance(result.evidence_tiers, list)
         assert isinstance(result.coverage_warnings, list)
 
@@ -176,4 +176,4 @@ class TestConfidenceComputation:
         )
         result = compare(snap, snap)
         # No data at all → low confidence
-        assert result.confidence == "low"
+        assert result.confidence == Confidence.LOW

--- a/tests/test_policy_changekind_matrix.py
+++ b/tests/test_policy_changekind_matrix.py
@@ -1,0 +1,179 @@
+"""Policy × ChangeKind matrix test — verify every kind is classified correctly under each policy.
+
+This test ensures that:
+1. Every ChangeKind appears in exactly one primary classification set per policy.
+2. Policy downgrade/upgrade logic is consistent.
+3. No kind is accidentally unclassified (would silently default to BREAKING).
+"""
+from __future__ import annotations
+
+import pytest
+
+from abicheck.checker_policy import (
+    API_BREAK_KINDS,
+    BREAKING_KINDS,
+    COMPATIBLE_KINDS,
+    RISK_KINDS,
+    ChangeKind,
+    Verdict,
+    compute_verdict,
+    policy_kind_sets,
+)
+
+
+# All known policies.
+ALL_POLICIES = ("strict_abi", "sdk_vendor", "plugin_abi")
+
+
+class TestChangeKindCompleteness:
+    """Every ChangeKind must be in exactly one primary set."""
+
+    def test_all_kinds_classified(self):
+        """Every ChangeKind must appear in at least one of the four sets."""
+        all_classified = (
+            frozenset(BREAKING_KINDS)
+            | frozenset(COMPATIBLE_KINDS)
+            | frozenset(API_BREAK_KINDS)
+            | RISK_KINDS
+        )
+        unclassified = set(ChangeKind) - all_classified
+        assert not unclassified, (
+            f"Unclassified ChangeKinds (default to BREAKING silently): {unclassified}"
+        )
+
+    def test_no_kind_in_multiple_primary_sets(self):
+        """No kind should appear in more than one primary classification set."""
+        b = frozenset(BREAKING_KINDS)
+        c = frozenset(COMPATIBLE_KINDS)
+        a = frozenset(API_BREAK_KINDS)
+        r = RISK_KINDS
+
+        assert not (b & c), f"BREAKING ∩ COMPATIBLE: {b & c}"
+        assert not (b & a), f"BREAKING ∩ API_BREAK: {b & a}"
+        assert not (b & r), f"BREAKING ∩ RISK: {b & r}"
+        assert not (c & a), f"COMPATIBLE ∩ API_BREAK: {c & a}"
+        assert not (c & r), f"COMPATIBLE ∩ RISK: {c & r}"
+        assert not (a & r), f"API_BREAK ∩ RISK: {a & r}"
+
+
+class TestPolicyKindSetsConsistency:
+    """For each policy, the four returned sets must be complete and disjoint."""
+
+    @pytest.mark.parametrize("policy", ALL_POLICIES)
+    def test_policy_sets_cover_all_kinds(self, policy: str):
+        breaking, api_break, compatible, risk = policy_kind_sets(policy)
+        all_covered = breaking | api_break | compatible | risk
+        uncovered = set(ChangeKind) - all_covered
+        assert not uncovered, (
+            f"Policy '{policy}' leaves kinds uncovered: {uncovered}"
+        )
+
+    @pytest.mark.parametrize("policy", ALL_POLICIES)
+    def test_policy_sets_disjoint(self, policy: str):
+        breaking, api_break, compatible, risk = policy_kind_sets(policy)
+        assert not (breaking & compatible), f"{policy}: BREAKING ∩ COMPATIBLE"
+        assert not (breaking & api_break), f"{policy}: BREAKING ∩ API_BREAK"
+        assert not (breaking & risk), f"{policy}: BREAKING ∩ RISK"
+        assert not (compatible & api_break), f"{policy}: COMPATIBLE ∩ API_BREAK"
+        assert not (compatible & risk), f"{policy}: COMPATIBLE ∩ RISK"
+        assert not (api_break & risk), f"{policy}: API_BREAK ∩ RISK"
+
+
+class TestVerdictComputationMatrix:
+    """Verify that each kind produces the expected verdict under each policy."""
+
+    @pytest.mark.parametrize("policy", ALL_POLICIES)
+    def test_each_kind_produces_expected_verdict(self, policy: str):
+        """For every ChangeKind, compute_verdict with a single change must
+        produce a verdict consistent with policy_kind_sets classification."""
+        breaking, api_break, compatible, risk = policy_kind_sets(policy)
+
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class _FakeChange:
+            kind: ChangeKind
+
+        for kind in ChangeKind:
+            changes = [_FakeChange(kind=kind)]
+            verdict = compute_verdict(changes, policy=policy)
+
+            if kind in breaking:
+                assert verdict == Verdict.BREAKING, (
+                    f"{policy}/{kind}: expected BREAKING, got {verdict}"
+                )
+            elif kind in api_break:
+                assert verdict == Verdict.API_BREAK, (
+                    f"{policy}/{kind}: expected API_BREAK, got {verdict}"
+                )
+            elif kind in risk:
+                assert verdict == Verdict.COMPATIBLE_WITH_RISK, (
+                    f"{policy}/{kind}: expected COMPATIBLE_WITH_RISK, got {verdict}"
+                )
+            elif kind in compatible:
+                assert verdict == Verdict.COMPATIBLE, (
+                    f"{policy}/{kind}: expected COMPATIBLE, got {verdict}"
+                )
+            else:
+                # Unclassified — should default to BREAKING (fail-safe)
+                assert verdict == Verdict.BREAKING, (
+                    f"{policy}/{kind}: unclassified kind should default to BREAKING, got {verdict}"
+                )
+
+    def test_empty_changes_no_change(self):
+        """Empty change list must always produce NO_CHANGE."""
+        for policy in ALL_POLICIES:
+            assert compute_verdict([], policy=policy) == Verdict.NO_CHANGE
+
+    def test_mixed_breaking_and_compatible(self):
+        """If any BREAKING kind is present, verdict must be BREAKING."""
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class _FakeChange:
+            kind: ChangeKind
+
+        changes = [
+            _FakeChange(kind=ChangeKind.FUNC_ADDED),      # COMPATIBLE
+            _FakeChange(kind=ChangeKind.FUNC_REMOVED),     # BREAKING
+        ]
+        for policy in ALL_POLICIES:
+            assert compute_verdict(changes, policy=policy) == Verdict.BREAKING
+
+    def test_unknown_policy_falls_back_to_strict(self):
+        """Unknown policy names should fall back to strict_abi."""
+        strict_sets = policy_kind_sets("strict_abi")
+        unknown_sets = policy_kind_sets("nonexistent_policy")
+        assert strict_sets == unknown_sets
+
+
+class TestConfidenceComputation:
+    """Test the new confidence/evidence tier computation."""
+
+    def test_compare_returns_confidence_field(self):
+        from abicheck.checker import compare
+        from abicheck.model import AbiSnapshot
+
+        snap = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[], variables=[], types=[], enums=[],
+            typedefs={},
+        )
+        result = compare(snap, snap)
+        assert hasattr(result, "confidence")
+        assert result.confidence in ("high", "medium", "low")
+        assert isinstance(result.evidence_tiers, list)
+        assert isinstance(result.coverage_warnings, list)
+
+    def test_empty_snapshots_low_confidence(self):
+        from abicheck.checker import compare
+        from abicheck.model import AbiSnapshot
+
+        snap = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[], variables=[], types=[], enums=[],
+            typedefs={},
+        )
+        result = compare(snap, snap)
+        # No data at all → low confidence
+        assert result.confidence == "low"

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -1,0 +1,323 @@
+"""Tests for fixes identified during the scan-accuracy review.
+
+Covers:
+- canonicalize_type_name edge cases (C3: const-reorder, multi-word, templates)
+- Parameter type canonicalization in function signature checks (C1)
+- Confidence computation with both snapshots and variables (C2)
+- SuppressionList.audit() (H1)
+- PolicyFile.validate_overrides() (H1)
+- Confidence enum (H2)
+"""
+from __future__ import annotations
+
+import copy
+import textwrap
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from abicheck.checker import Change, ChangeKind, Verdict, compare
+from abicheck.checker_policy import Confidence
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    ParamKind,
+    Variable,
+    Visibility,
+    canonicalize_type_name,
+)
+from abicheck.policy_file import PolicyFile
+
+
+# ─── canonicalize_type_name ──────────────────────────────────────────────────
+
+
+class TestCanonicalizeTypeName:
+    """Direct unit tests for canonicalize_type_name."""
+
+    def test_strip_struct_prefix(self):
+        assert canonicalize_type_name("struct Foo") == "Foo"
+
+    def test_strip_class_prefix(self):
+        assert canonicalize_type_name("class Bar") == "Bar"
+
+    def test_strip_union_prefix(self):
+        assert canonicalize_type_name("union Baz") == "Baz"
+
+    def test_strip_enum_prefix(self):
+        assert canonicalize_type_name("enum Color") == "Color"
+
+    def test_east_const_simple(self):
+        assert canonicalize_type_name("const int") == "int const"
+
+    def test_east_const_pointer(self):
+        assert canonicalize_type_name("const int *") == "int const *"
+
+    def test_east_const_multi_word(self):
+        """const unsigned long long should move const after full base type."""
+        assert canonicalize_type_name("const unsigned long long") == "unsigned long long const"
+
+    def test_east_const_volatile(self):
+        """const volatile int should move const after the full base."""
+        assert canonicalize_type_name("const volatile int") == "volatile int const"
+
+    def test_east_const_multi_word_pointer(self):
+        assert canonicalize_type_name("const unsigned int *") == "unsigned int const *"
+
+    def test_template_type_preserved(self):
+        """Template types with angle brackets should not be reordered."""
+        assert canonicalize_type_name("const std::vector<int>") == "const std::vector<int>"
+
+    def test_already_east_const(self):
+        assert canonicalize_type_name("int const") == "int const"
+
+    def test_pointer_to_const(self):
+        """int const * should be left alone (const is already east)."""
+        assert canonicalize_type_name("int const *") == "int const *"
+
+    def test_whitespace_collapse(self):
+        # Leading whitespace prevents struct-prefix regex from matching (anchored at ^)
+        assert canonicalize_type_name("class   Bar") == "Bar"
+        assert canonicalize_type_name("int    *") == "int *"
+
+    def test_identity(self):
+        assert canonicalize_type_name("int") == "int"
+
+    def test_empty_string(self):
+        assert canonicalize_type_name("") == ""
+
+
+# ─── Parameter type canonicalization (C1) ────────────────────────────────────
+
+
+class TestParamTypeCanonicalization:
+    """Verify that struct/class prefix differences in param types don't cause false positives."""
+
+    def test_struct_prefix_in_param_no_false_positive(self):
+        """'struct stat *' vs 'stat *' should NOT trigger FUNC_PARAMS_CHANGED."""
+        old = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[Function(
+                name="do_stat", mangled="_Z7do_statP4stat",
+                return_type="int",
+                params=[Param(name="s", type="struct stat *", kind=ParamKind.POINTER)],
+                visibility=Visibility.PUBLIC,
+            )],
+        )
+        new = AbiSnapshot(
+            library="libtest.so", version="2.0",
+            functions=[Function(
+                name="do_stat", mangled="_Z7do_statP4stat",
+                return_type="int",
+                params=[Param(name="s", type="stat *", kind=ParamKind.POINTER)],
+                visibility=Visibility.PUBLIC,
+            )],
+        )
+        result = compare(old, new)
+        param_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_PARAMS_CHANGED]
+        assert len(param_changes) == 0, "struct prefix difference should not be a param change"
+
+    def test_const_reorder_in_param_no_false_positive(self):
+        """'const int' vs 'int const' in params should NOT trigger FUNC_PARAMS_CHANGED."""
+        old = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[Function(
+                name="get", mangled="_Z3geti",
+                return_type="void",
+                params=[Param(name="x", type="const int", kind=ParamKind.VALUE)],
+                visibility=Visibility.PUBLIC,
+            )],
+        )
+        new = AbiSnapshot(
+            library="libtest.so", version="2.0",
+            functions=[Function(
+                name="get", mangled="_Z3geti",
+                return_type="void",
+                params=[Param(name="x", type="int const", kind=ParamKind.VALUE)],
+                visibility=Visibility.PUBLIC,
+            )],
+        )
+        result = compare(old, new)
+        param_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_PARAMS_CHANGED]
+        assert len(param_changes) == 0
+
+
+# ─── Confidence computation (C2) ────────────────────────────────────────────
+
+
+class TestConfidenceComputation:
+    """Verify confidence checks both snapshots and includes variables."""
+
+    def test_confidence_is_enum(self):
+        old = AbiSnapshot(library="lib.so", version="1.0")
+        new = AbiSnapshot(library="lib.so", version="2.0")
+        result = compare(old, new)
+        assert isinstance(result.confidence, Confidence)
+
+    def test_confidence_str_comparison_still_works(self):
+        """Confidence enum is str-based so string comparisons keep working."""
+        assert Confidence.HIGH == "high"
+        assert Confidence.MEDIUM == "medium"
+        assert Confidence.LOW == "low"
+
+    def test_empty_old_populated_new_has_headers(self):
+        """When old is empty but new has functions, has_headers should be True."""
+        old = AbiSnapshot(library="lib.so", version="1.0")
+        new = AbiSnapshot(
+            library="lib.so", version="2.0",
+            functions=[Function(
+                name="foo", mangled="_Z3foov",
+                return_type="void", visibility=Visibility.PUBLIC,
+            )],
+        )
+        result = compare(old, new)
+        assert "header" in result.evidence_tiers
+
+    def test_variables_only_detected_as_headers(self):
+        """Snapshots with only variables should still be detected as having header data."""
+        old = AbiSnapshot(
+            library="lib.so", version="1.0",
+            variables=[Variable(
+                name="ver", mangled="_Z3verv", type="int",
+                visibility=Visibility.PUBLIC,
+            )],
+        )
+        new = copy.deepcopy(old)
+        new.version = "2.0"
+        result = compare(old, new)
+        assert "header" in result.evidence_tiers
+
+
+# ─── SuppressionList.audit() ────────────────────────────────────────────────
+
+
+class TestSuppressionAudit:
+    """Tests for SuppressionList.audit()."""
+
+    def test_audit_stale_rules(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+        ])
+        # No changes match the suppression
+        audit = slist.audit([])
+        assert len(audit.stale_rules) == 1
+        assert audit.has_issues
+
+    def test_audit_matching_rule_not_stale(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+        ])
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="_Z3foov",
+            description="removed",
+        )
+        audit = slist.audit([change])
+        assert len(audit.stale_rules) == 0
+        # FUNC_REMOVED is BREAKING so should appear in high_risk
+        assert len(audit.high_risk_matches) == 1
+
+    def test_audit_expired_rules(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        past = date.today() - timedelta(days=10)
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="expired", expires=past),
+        ])
+        audit = slist.audit([])
+        assert len(audit.expired_rules) == 1
+        assert audit.has_issues
+
+    def test_audit_near_expiry(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        soon = date.today() + timedelta(days=5)
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="expiring", expires=soon),
+        ])
+        audit = slist.audit([], near_expiry_days=30)
+        assert len(audit.near_expiry_rules) == 1
+
+    def test_audit_no_issues(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+        ])
+        change = Change(
+            kind=ChangeKind.FUNC_ADDED,
+            symbol="_Z3foov",
+            description="added",
+        )
+        audit = slist.audit([change])
+        # FUNC_ADDED is not BREAKING, rule matched, no expiry
+        assert len(audit.stale_rules) == 0
+        assert len(audit.high_risk_matches) == 0
+        assert not audit.has_issues
+
+    def test_audit_summary_output(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+        ])
+        audit = slist.audit([])
+        summary = audit.summary()
+        assert "stale" in summary.lower() or "matched nothing" in summary.lower()
+
+
+# ─── PolicyFile.validate_overrides() ─────────────────────────────────────────
+
+
+class TestPolicyFileValidateOverrides:
+    """Tests for PolicyFile.validate_overrides()."""
+
+    def test_no_overrides_no_warnings(self):
+        pf = PolicyFile()
+        assert pf.validate_overrides() == []
+
+    def test_critical_kind_to_ignore_warns(self):
+        from abicheck.checker_policy import Verdict
+
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 1
+        assert "HIGH RISK" in warnings[0]
+
+    def test_critical_kind_to_risk_warns(self):
+        from abicheck.checker_policy import Verdict
+
+        pf = PolicyFile(overrides={ChangeKind.TYPE_SIZE_CHANGED: Verdict.COMPATIBLE_WITH_RISK})
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 1
+        assert "RISK" in warnings[0]
+
+    def test_breaking_kind_to_ignore_warns(self):
+        from abicheck.checker_policy import Verdict
+
+        pf = PolicyFile(overrides={ChangeKind.FUNC_VIRTUAL_ADDED: Verdict.COMPATIBLE})
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 1
+        assert "BREAKING" in warnings[0]
+
+    def test_safe_override_no_warning(self):
+        from abicheck.checker_policy import Verdict
+
+        pf = PolicyFile(overrides={ChangeKind.ENUM_MEMBER_RENAMED: Verdict.COMPATIBLE})
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 0
+
+    def test_critical_kind_to_warn_no_warning(self):
+        """Downgrading critical BREAKING to API_BREAK (warn) should not warn."""
+        from abicheck.checker_policy import Verdict
+
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.API_BREAK})
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 0

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -20,6 +20,8 @@ from abicheck.model import (
     Function,
     Param,
     ParamKind,
+    RecordType,
+    TypeField,
     Variable,
     Visibility,
     canonicalize_type_name,
@@ -380,3 +382,68 @@ class TestPolicyFileValidateOverrides:
         })
         warnings = pf.validate_overrides()
         assert len(warnings) == 3
+
+    def test_validate_uses_base_policy_breaking_kinds(self):
+        """validate_overrides should use the base policy's breaking set."""
+        # Under plugin_abi, CALLING_CONVENTION_CHANGED is downgraded to COMPATIBLE.
+        # Under strict_abi, it's BREAKING. So overriding it to 'ignore' under
+        # strict_abi should warn, but the kind itself is still in BREAKING_KINDS
+        # for strict_abi.
+        pf = PolicyFile(
+            base_policy="strict_abi",
+            overrides={ChangeKind.CALLING_CONVENTION_CHANGED: Verdict.COMPATIBLE},
+        )
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 1
+        assert "BREAKING" in warnings[0]
+
+
+# ─── Namespace-qualified canonicalization ─────────────────────────────────────
+
+
+class TestCanonicalizeNamespaceTypes:
+    """Verify canonicalize_type_name handles scoped/qualified identifiers."""
+
+    def test_const_namespace_type_pointer(self):
+        assert canonicalize_type_name("const ns::Type *") == "ns::Type const *"
+
+    def test_const_namespace_type_reference(self):
+        assert canonicalize_type_name("const ns::Type &") == "ns::Type const &"
+
+    def test_const_nested_namespace(self):
+        assert canonicalize_type_name("const a::b::C") == "a::b::C const"
+
+    def test_leading_whitespace_struct(self):
+        """Leading whitespace should not prevent struct-prefix stripping."""
+        assert canonicalize_type_name("  struct Foo") == "Foo"
+
+    def test_const_struct_combined(self):
+        """const struct Foo * should canonicalize to Foo const *."""
+        assert canonicalize_type_name("const struct Foo *") == "Foo const *"
+
+
+# ─── Union field type canonicalization ────────────────────────────────────────
+
+
+class TestUnionFieldCanonicalization:
+    """Verify union field type comparison uses canonicalize_type_name."""
+
+    def test_union_field_struct_prefix_no_false_positive(self):
+        """'struct X' vs 'X' in union field types should NOT trigger UNION_FIELD_TYPE_CHANGED."""
+        old = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            types=[RecordType(
+                name="MyUnion", kind="union", is_union=True,
+                fields=[TypeField(name="data", type="struct Inner")],
+            )],
+        )
+        new = AbiSnapshot(
+            library="libtest.so", version="2.0",
+            types=[RecordType(
+                name="MyUnion", kind="union", is_union=True,
+                fields=[TypeField(name="data", type="Inner")],
+            )],
+        )
+        result = compare(old, new)
+        union_changes = [c for c in result.changes if c.kind == ChangeKind.UNION_FIELD_TYPE_CHANGED]
+        assert len(union_changes) == 0, "struct prefix difference should not be a union field type change"

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -11,15 +11,10 @@ Covers:
 from __future__ import annotations
 
 import copy
-import textwrap
 from datetime import date, timedelta
-from pathlib import Path
-from unittest.mock import MagicMock
 
-import pytest
-
-from abicheck.checker import Change, ChangeKind, Verdict, compare
-from abicheck.checker_policy import Confidence
+from abicheck.checker import Change, ChangeKind, compare
+from abicheck.checker_policy import Confidence, Verdict
 from abicheck.model import (
     AbiSnapshot,
     Function,
@@ -30,7 +25,6 @@ from abicheck.model import (
     canonicalize_type_name,
 )
 from abicheck.policy_file import PolicyFile
-
 
 # ─── canonicalize_type_name ──────────────────────────────────────────────────
 
@@ -272,6 +266,72 @@ class TestSuppressionAudit:
         summary = audit.summary()
         assert "stale" in summary.lower() or "matched nothing" in summary.lower()
 
+    def test_audit_summary_no_issues(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+        ])
+        change = Change(
+            kind=ChangeKind.FUNC_ADDED,
+            symbol="_Z3foov",
+            description="added",
+        )
+        audit = slist.audit([change])
+        summary = audit.summary()
+        assert "No issues found" in summary
+
+    def test_audit_summary_high_risk(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+        ])
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="_Z3foov",
+            description="removed",
+        )
+        audit = slist.audit([change])
+        summary = audit.summary()
+        assert "BREAKING" in summary
+
+    def test_audit_summary_expired(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        past = date.today() - timedelta(days=10)
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="old", expires=past),
+        ])
+        audit = slist.audit([])
+        summary = audit.summary()
+        assert "expired" in summary.lower()
+
+    def test_audit_summary_near_expiry(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        soon = date.today() + timedelta(days=5)
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="soon", expires=soon),
+        ])
+        audit = slist.audit([], near_expiry_days=30)
+        summary = audit.summary()
+        assert "expiring soon" in summary.lower()
+
+    def test_audit_match_counts(self):
+        from abicheck.suppression import Suppression, SuppressionList
+
+        slist = SuppressionList([
+            Suppression(symbol="_Z3foov", reason="test"),
+            Suppression(symbol="_Z3barv", reason="test2"),
+        ])
+        c1 = Change(kind=ChangeKind.FUNC_ADDED, symbol="_Z3foov", description="added")
+        c2 = Change(kind=ChangeKind.FUNC_ADDED, symbol="_Z3foov", description="added2")
+        audit = slist.audit([c1, c2])
+        assert audit.match_counts[0] == 2  # first rule matched twice
+        assert audit.match_counts[1] == 0  # second rule matched nothing
+        assert audit.total_rules == 2
+
 
 # ─── PolicyFile.validate_overrides() ─────────────────────────────────────────
 
@@ -284,40 +344,39 @@ class TestPolicyFileValidateOverrides:
         assert pf.validate_overrides() == []
 
     def test_critical_kind_to_ignore_warns(self):
-        from abicheck.checker_policy import Verdict
-
         pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
         warnings = pf.validate_overrides()
         assert len(warnings) == 1
         assert "HIGH RISK" in warnings[0]
 
     def test_critical_kind_to_risk_warns(self):
-        from abicheck.checker_policy import Verdict
-
         pf = PolicyFile(overrides={ChangeKind.TYPE_SIZE_CHANGED: Verdict.COMPATIBLE_WITH_RISK})
         warnings = pf.validate_overrides()
         assert len(warnings) == 1
         assert "RISK" in warnings[0]
 
     def test_breaking_kind_to_ignore_warns(self):
-        from abicheck.checker_policy import Verdict
-
         pf = PolicyFile(overrides={ChangeKind.FUNC_VIRTUAL_ADDED: Verdict.COMPATIBLE})
         warnings = pf.validate_overrides()
         assert len(warnings) == 1
         assert "BREAKING" in warnings[0]
 
     def test_safe_override_no_warning(self):
-        from abicheck.checker_policy import Verdict
-
         pf = PolicyFile(overrides={ChangeKind.ENUM_MEMBER_RENAMED: Verdict.COMPATIBLE})
         warnings = pf.validate_overrides()
         assert len(warnings) == 0
 
     def test_critical_kind_to_warn_no_warning(self):
         """Downgrading critical BREAKING to API_BREAK (warn) should not warn."""
-        from abicheck.checker_policy import Verdict
-
         pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.API_BREAK})
         warnings = pf.validate_overrides()
         assert len(warnings) == 0
+
+    def test_multiple_overrides_multiple_warnings(self):
+        pf = PolicyFile(overrides={
+            ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE,
+            ChangeKind.VAR_REMOVED: Verdict.COMPATIBLE,
+            ChangeKind.SONAME_CHANGED: Verdict.COMPATIBLE_WITH_RISK,
+        })
+        warnings = pf.validate_overrides()
+        assert len(warnings) == 3

--- a/tests/test_scan_accuracy.py
+++ b/tests/test_scan_accuracy.py
@@ -1,0 +1,311 @@
+"""Scan accuracy tests — property-based and mutation-based tests for FP/FN prevention.
+
+These tests systematically verify that:
+1. Identical snapshots always produce NO_CHANGE (false positive resistance).
+2. Known single mutations always produce the expected ChangeKind (false negative resistance).
+3. Cross-detector deduplication doesn't lose real changes.
+4. Confidence/evidence tiers are computed correctly.
+"""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
+from abicheck.model import (
+    AbiSnapshot,
+    EnumMember,
+    EnumType,
+    Function,
+    Param,
+    ParamKind,
+    RecordType,
+    TypeField,
+    Variable,
+    Visibility,
+)
+
+
+def _base_snap(version: str = "1.0") -> AbiSnapshot:
+    """Create a realistic baseline snapshot with functions, types, enums, vars."""
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version=version,
+        functions=[
+            Function(
+                name="process", mangled="_Z7processv",
+                return_type="int", params=[Param(name="data", type="void *", kind=ParamKind.POINTER)],
+                visibility=Visibility.PUBLIC,
+            ),
+            Function(
+                name="init", mangled="_Z4initv",
+                return_type="void", params=[],
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        variables=[
+            Variable(name="version", mangled="_Z7versionv", type="const char *",
+                     visibility=Visibility.PUBLIC),
+        ],
+        types=[
+            RecordType(
+                name="Config", kind="struct",
+                fields=[
+                    TypeField(name="width", type="int", offset_bits=0),
+                    TypeField(name="height", type="int", offset_bits=32),
+                ],
+                size_bits=64,
+            ),
+        ],
+        enums=[
+            EnumType(
+                name="Color",
+                members=[
+                    EnumMember(name="RED", value=0),
+                    EnumMember(name="GREEN", value=1),
+                    EnumMember(name="BLUE", value=2),
+                ],
+            ),
+        ],
+        typedefs={"ColorType": "enum Color"},
+    )
+
+
+class TestIdenticalSnapshotsNoChange:
+    """Identical snapshots must always produce NO_CHANGE — false positive resistance."""
+
+    def test_identical_snapshots_no_change(self):
+        snap = _base_snap()
+        result = compare(snap, copy.deepcopy(snap))
+        assert result.verdict == Verdict.NO_CHANGE
+        assert len(result.changes) == 0
+
+    def test_identical_empty_snapshots_no_change(self):
+        snap = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[], variables=[], types=[], enums=[],
+            typedefs={},
+        )
+        result = compare(snap, copy.deepcopy(snap))
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_version_change_only_no_abi_change(self):
+        """Different version strings but identical API — should be NO_CHANGE."""
+        old = _base_snap("1.0")
+        new = _base_snap("2.0")
+        result = compare(old, new)
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_source_location_change_not_reported(self):
+        """Moving a function to a different line is not an ABI break."""
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        old.functions[0].source_location = "foo.h:10"
+        new.functions[0].source_location = "foo.h:42"
+        result = compare(old, new)
+        assert result.verdict == Verdict.NO_CHANGE
+
+
+class TestSingleMutationDetection:
+    """Single known mutations must be detected — false negative resistance."""
+
+    def test_func_removed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.functions = [f for f in new.functions if f.name != "process"]
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.FUNC_REMOVED for c in result.changes)
+
+    def test_func_added_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.functions.append(Function(
+            name="cleanup", mangled="_Z7cleanupv",
+            return_type="void", params=[], visibility=Visibility.PUBLIC,
+        ))
+        result = compare(old, new)
+        assert result.verdict == Verdict.COMPATIBLE
+        assert any(c.kind == ChangeKind.FUNC_ADDED for c in result.changes)
+
+    def test_return_type_changed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.functions[0].return_type = "long"
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.FUNC_RETURN_CHANGED for c in result.changes)
+
+    def test_param_type_changed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.functions[0].params[0].type = "int *"
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes)
+
+    def test_var_removed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.variables = []
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.VAR_REMOVED for c in result.changes)
+
+    def test_var_type_changed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.variables[0].type = "int"
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.VAR_TYPE_CHANGED for c in result.changes)
+
+    def test_type_size_changed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.types[0].size_bits = 128
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in result.changes)
+
+    def test_type_field_removed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.types[0].fields = [new.types[0].fields[0]]  # keep only 'width'
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPE_FIELD_REMOVED for c in result.changes)
+
+    def test_enum_member_removed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.enums[0].members = [m for m in new.enums[0].members if m.name != "BLUE"]
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.ENUM_MEMBER_REMOVED for c in result.changes)
+
+    def test_enum_member_value_changed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.enums[0].members[1] = EnumMember(name="GREEN", value=42)
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.ENUM_MEMBER_VALUE_CHANGED for c in result.changes)
+
+    def test_enum_member_added_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.enums[0].members.append(EnumMember(name="YELLOW", value=3))
+        result = compare(old, new)
+        assert result.verdict == Verdict.COMPATIBLE
+        assert any(c.kind == ChangeKind.ENUM_MEMBER_ADDED for c in result.changes)
+
+    def test_typedef_removed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.typedefs = {}
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPEDEF_REMOVED for c in result.changes)
+
+    def test_typedef_base_changed_detected(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        new.typedefs["ColorType"] = "int"
+        result = compare(old, new)
+        assert result.verdict == Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPEDEF_BASE_CHANGED for c in result.changes)
+
+
+class TestHiddenSymbolsFalsePositiveResistance:
+    """Hidden/internal symbols must not produce false positives."""
+
+    def test_hidden_func_change_not_reported(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        # Add a hidden function to old, remove it from new
+        old.functions.append(Function(
+            name="internal", mangled="_Z8internalv",
+            return_type="void", params=[], visibility=Visibility.HIDDEN,
+        ))
+        result = compare(old, new)
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_hidden_var_change_not_reported(self):
+        old = _base_snap()
+        new = copy.deepcopy(old)
+        old.variables.append(Variable(
+            name="secret", mangled="_Z6secretv", type="int",
+            visibility=Visibility.HIDDEN,
+        ))
+        result = compare(old, new)
+        assert result.verdict == Verdict.NO_CHANGE
+
+
+class TestCrossDetectorDeduplication:
+    """Cross-detector dedup must not drop unique changes."""
+
+    def test_dedup_preserves_different_symbols(self):
+        """Two FUNC_REMOVED for different symbols must both be kept."""
+        old = _base_snap()
+        new = AbiSnapshot(
+            library="libtest.so.1", version="1.0",
+            functions=[], variables=old.variables,
+            types=old.types, enums=old.enums,
+            typedefs=old.typedefs,
+        )
+        result = compare(old, new)
+        removed = [c for c in result.changes if c.kind == ChangeKind.FUNC_REMOVED]
+        assert len(removed) == 2  # both 'process' and 'init' should be reported
+
+
+class TestConfidenceAndEvidenceTiers:
+    """Confidence levels and evidence tier tracking."""
+
+    def test_header_only_medium_confidence(self):
+        """Snapshot with header data but no ELF/DWARF → medium."""
+        snap = _base_snap()
+        result = compare(snap, copy.deepcopy(snap))
+        # Has header data (functions, types, enums) but no binary metadata
+        assert result.confidence in ("medium", "low")
+        assert "header" in result.evidence_tiers
+
+    def test_empty_snapshot_low_confidence(self):
+        snap = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[], variables=[], types=[], enums=[],
+            typedefs={},
+        )
+        result = compare(snap, snap)
+        assert result.confidence == "low"
+
+
+class TestGroundTruthExpectedKinds:
+    """Validate that ground_truth.json expected_kinds field is parseable."""
+
+    def test_ground_truth_expected_kinds_are_valid(self):
+        import json
+        from pathlib import Path
+
+        gt_path = Path(__file__).parent.parent / "examples" / "ground_truth.json"
+        if not gt_path.exists():
+            pytest.skip("ground_truth.json not found")
+
+        gt = json.loads(gt_path.read_text())
+        valid_kinds = {ck.value for ck in ChangeKind}
+
+        for case_name, case_data in gt["verdicts"].items():
+            expected_kinds = case_data.get("expected_kinds")
+            if expected_kinds is not None:
+                for kind_val in expected_kinds:
+                    assert kind_val in valid_kinds, (
+                        f"{case_name}: expected_kind '{kind_val}' is not a valid ChangeKind"
+                    )
+
+            absent_kinds = case_data.get("expected_absent_kinds")
+            if absent_kinds is not None:
+                for kind_val in absent_kinds:
+                    assert kind_val in valid_kinds, (
+                        f"{case_name}: expected_absent_kind '{kind_val}' is not a valid ChangeKind"
+                    )

--- a/tests/test_scan_accuracy.py
+++ b/tests/test_scan_accuracy.py
@@ -12,7 +12,8 @@ import copy
 
 import pytest
 
-from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.checker_policy import Confidence
 from abicheck.model import (
     AbiSnapshot,
     EnumMember,
@@ -268,7 +269,7 @@ class TestConfidenceAndEvidenceTiers:
         snap = _base_snap()
         result = compare(snap, copy.deepcopy(snap))
         # Has header data (functions, types, enums) but no binary metadata
-        assert result.confidence in ("medium", "low")
+        assert result.confidence in (Confidence.MEDIUM, Confidence.LOW)
         assert "header" in result.evidence_tiers
 
     def test_empty_snapshot_low_confidence(self):
@@ -278,7 +279,7 @@ class TestConfidenceAndEvidenceTiers:
             typedefs={},
         )
         result = compare(snap, snap)
-        assert result.confidence == "low"
+        assert result.confidence == Confidence.LOW
 
 
 class TestGroundTruthExpectedKinds:


### PR DESCRIPTION
## Summary

Fixes false positives in ABI comparison by canonicalizing type names, adds confidence/evidence tier tracking to comparison results, implements suppression rule auditing, and validates policy overrides for dangerous downgrades.

## Motivation

The ABI checker was producing false positives when comparing types that differ only in:
- Elaborated type specifiers (`struct Foo` vs `Foo`)
- Const placement (`const int` vs `int const`)
- Multi-word base types (`const unsigned long long`)

Additionally, users had no way to audit suppression rules for staleness or dangerous overrides, and comparison results lacked confidence/evidence metadata to help users assess result reliability.

## Changes

### Core Fixes
- **Type canonicalization** (`abicheck/model.py`): Added `canonicalize_type_name()` function that normalizes type names by:
  - Stripping elaborated type specifiers (`struct`, `class`, `union`, `enum`)
  - Converting leading `const` to east-const form (`const int` → `int const`)
  - Collapsing whitespace
  - Preserving template types (no reordering inside angle brackets)

- **Function signature checking** (`abicheck/checker.py`): Apply canonicalization to return types and parameter types before comparison to eliminate false positives from formatting differences.

- **Variable type checking** (`abicheck/checker.py`): Apply canonicalization to variable types.

- **Type field checking** (`abicheck/checker.py`): Apply canonicalization to struct/union field types.

### Confidence & Evidence Tracking
- **Confidence enum** (`abicheck/checker_policy.py`): Added `Confidence` enum with `HIGH`, `MEDIUM`, `LOW` levels.

- **Evidence computation** (`abicheck/checker.py`): 
  - Added `_compute_confidence()` to assess result reliability based on available metadata (ELF, DWARF, headers, PE, Mach-O).
  - `DiffResult` now includes `confidence`, `evidence_tiers`, and `coverage_warnings` fields.
  - Confidence is `HIGH` when headers + binary metadata present, `MEDIUM` for headers-only or binary-only with DWARF, `LOW` otherwise.

### Suppression Auditing
- **SuppressionList.audit()** (`abicheck/suppression.py`): New method that audits suppression rules against detected changes, identifying:
  - Stale rules (matched zero changes)
  - High-risk matches (suppressions covering BREAKING changes)
  - Expired rules (past expiry date)
  - Near-expiry rules (expiring within configurable window)

- **SuppressionAudit dataclass** (`abicheck/suppression.py`): Result object with `has_issues` property and `summary()` method for human-readable reporting.

### Policy Validation
- **PolicyFile.validate_overrides()** (`abicheck/policy_file.py`): New method that warns about dangerous policy overrides:
  - Downgrading critical BREAKING kinds (func_removed, type_size_changed, etc.) to COMPATIBLE
  - Downgrading BREAKING to COMPATIBLE_WITH_RISK for critical kinds
  - Returns list of warning strings; empty list means no issues.

### Deduplication
- **Cross-detector deduplication** (`abicheck/checker.py`): Added `_deduplicate_cross_detector()` to remove overlapping reports from different detectors while preserving unique changes for different symbols.

### Classification Validation
- **Completeness checks** (`abicheck/checker_policy.py`): Added runtime validation ensuring every `ChangeKind` is classified in exactly one of `BREAKING_KINDS`, `COMPATIBLE_KINDS`, `API_BREAK_KINDS`, or `RISK_KINDS`. Unclassified kinds raise `AssertionError` at module load time (fail-safe).

### Test Coverage
- **test_review_fixes.py**: 323 lines of tests covering:
  - `canonicalize_type_name()` edge cases (struct/class/union/enum prefixes, const reordering, multi-word types, templates)

https://claude.ai/code/session_01KSmycHLx6WQh6BbPEHX79o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ABI diffs now include confidence levels, evidence tiers and coverage warnings.
  * Type canonicalization added to normalize type spellings.
  * Suppression auditing reports stale, expired and near-expiry rules.
  * Policy override validation emits warnings for dangerous downgrades.

* **Bug Fixes**
  * Cross-detector deduplication reduces overlapping/duplicate change reports.
  * Reduced false positives by normalizing type comparisons.

* **Tests**
  * Many new tests and updated ground-truth examples to validate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->