### PR TITLE
Add severity configuration system for issue categorization

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -238,14 +238,14 @@ jobs:
             exit 1
           fi
 
-  # ── Test: fail-on-additions ────────────────────────────────────────────────
-  test-fail-on-additions:
-    name: 'fail-on-additions: detect unexpected API expansion'
+  # ── Test: severity-addition error ─────────────────────────────────────────
+  test-severity-addition-error:
+    name: 'severity-addition error: detect unexpected API expansion'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run abicheck (compatible additions, should fail)
+      - name: Run abicheck (compatible additions, should fail with severity)
         id: abi
         uses: ./
         continue-on-error: true
@@ -254,9 +254,9 @@ jobs:
           new-library: tests/fixtures/action/action_test_v1_with_addition.json
           install-deps: false
           fail-on-breaking: false
-          fail-on-additions: true
+          extra-args: '--severity-addition error'
 
-      - name: Verify verdict is ADDITIONS
+      - name: Verify severity-driven failure
         shell: bash
         run: |
           if [[ "${{ steps.abi.outcome }}" != "failure" ]]; then
@@ -265,15 +265,15 @@ jobs:
           fi
           echo "Verdict: ${{ steps.abi.outputs.verdict }}"
           echo "Exit code: ${{ steps.abi.outputs.exit-code }}"
-          if [[ "${{ steps.abi.outputs.verdict }}" != "ADDITIONS" ]]; then
-            echo "::error::Expected verdict ADDITIONS, got ${{ steps.abi.outputs.verdict }}"
+          if [[ "${{ steps.abi.outputs.verdict }}" != "SEVERITY_ERROR" ]]; then
+            echo "::error::Expected verdict SEVERITY_ERROR, got ${{ steps.abi.outputs.verdict }}"
             exit 1
           fi
           if [[ "${{ steps.abi.outputs.exit-code }}" != "1" ]]; then
             echo "::error::Expected exit code 1, got ${{ steps.abi.outputs.exit-code }}"
             exit 1
           fi
-          echo "Correctly detected API additions (exit code 1, verdict ADDITIONS)"
+          echo "Correctly detected API additions via severity (exit code 1)"
 
   # ── Test: appcompat full mode ─────────────────────────────────────────────
   test-appcompat-full:
@@ -345,13 +345,13 @@ jobs:
             exit 1
           fi
 
-  test-fail-on-additions-allowed:
-    name: 'fail-on-additions=false: additions pass through'
+  test-additions-pass-by-default:
+    name: 'additions pass through without severity-addition error'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run abicheck (additions allowed explicitly)
+      - name: Run abicheck (additions allowed by default)
         id: abi
         uses: ./
         with:
@@ -359,14 +359,13 @@ jobs:
           new-library: tests/fixtures/action/action_test_v1_with_addition.json
           install-deps: false
           fail-on-breaking: false
-          fail-on-additions: false
 
       - name: Verify step succeeded
         shell: bash
         run: |
           if [[ "${{ steps.abi.outcome }}" != "success" ]]; then
-            echo "::error::Expected success when fail-on-additions=false"
+            echo "::error::Expected success when additions are at default severity"
             exit 1
           fi
-          echo "Correctly passed with additions allowed"
+          echo "Correctly passed with additions at default severity (info)"
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Unlike `compare` (which shows all library changes), `appcompat` filters the diff
 | Exit code | Verdict | Meaning |
 |-----------|---------|---------|
 | `0` | `NO_CHANGE`, `COMPATIBLE`, `COMPATIBLE_WITH_RISK` | Safe — no binary ABI break |
-| `1` | — | Tool/runtime error (or `ADDITIONS` with `--fail-on-additions`) |
+| `1` | — | Severity-driven error in additions/quality (with `--severity-*` flags) |
 | `2` | `API_BREAK` | Source-level break (recompile needed, binary may work) |
 | `4` | `BREAKING` | Binary ABI break (old binaries will crash or misbehave) |
 

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -450,6 +450,11 @@ RISK_KINDS: frozenset[ChangeKind] = frozenset({
 #: Additive kinds — new public API surface (subset of COMPATIBLE_KINDS).
 #: Explicitly enumerated to avoid false positives (e.g. FUNC_NOEXCEPT_ADDED
 #: is a qualifier change, not a new API addition).
+#:
+#: Note: This set includes ELF-level additions (SYMBOL_VERSION_DEFINED_ADDED,
+#: SYMBOL_VERSION_REQUIRED_ADDED_COMPAT) alongside public-API additions.
+#: Users who want to distinguish "new user-facing API" from "new ELF metadata"
+#: should inspect the kind values directly.
 ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.FUNC_ADDED,
     ChangeKind.VAR_ADDED,
@@ -458,6 +463,8 @@ ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.ENUM_MEMBER_ADDED,
     ChangeKind.UNION_FIELD_ADDED,
     ChangeKind.CONSTANT_ADDED,
+    # ELF metadata additions — not user-facing API, but binary-compatible
+    # structural additions that merit reporting.
     ChangeKind.SYMBOL_VERSION_DEFINED_ADDED,
     ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED_COMPAT,
 })
@@ -534,6 +541,8 @@ PLUGIN_ABI_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset(
 
 # Integrity assertions: catch miscategorisation at import time.
 # Use explicit raises (not assert) so these are never stripped by python -O.
+# All checks below use ``if not …: raise`` instead of ``assert`` so that
+# running under ``python -O`` does not silently disable them.
 if not SDK_VENDOR_COMPAT_KINDS <= API_BREAK_KINDS:
     raise AssertionError(
         "SDK_VENDOR_COMPAT_KINDS must be a strict subset of API_BREAK_KINDS; "

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -451,10 +451,9 @@ RISK_KINDS: frozenset[ChangeKind] = frozenset({
 #: Explicitly enumerated to avoid false positives (e.g. FUNC_NOEXCEPT_ADDED
 #: is a qualifier change, not a new API addition).
 #:
-#: Note: This set includes ELF-level additions (SYMBOL_VERSION_DEFINED_ADDED,
-#: SYMBOL_VERSION_REQUIRED_ADDED_COMPAT) alongside public-API additions.
-#: Users who want to distinguish "new user-facing API" from "new ELF metadata"
-#: should inspect the kind values directly.
+#: ELF versioning metadata (SYMBOL_VERSION_DEFINED_ADDED,
+#: SYMBOL_VERSION_REQUIRED_ADDED_COMPAT) is intentionally excluded — those
+#: are internal VERNEED/VERDEF churn, not user-facing API additions.
 ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.FUNC_ADDED,
     ChangeKind.VAR_ADDED,
@@ -463,10 +462,6 @@ ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.ENUM_MEMBER_ADDED,
     ChangeKind.UNION_FIELD_ADDED,
     ChangeKind.CONSTANT_ADDED,
-    # ELF metadata additions — not user-facing API, but binary-compatible
-    # structural additions that merit reporting.
-    ChangeKind.SYMBOL_VERSION_DEFINED_ADDED,
-    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED_COMPAT,
 })
 
 #: Quality / behavioral issues — COMPATIBLE_KINDS that are NOT additions.

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -443,6 +443,30 @@ RISK_KINDS: frozenset[ChangeKind] = frozenset({
     ChangeKind.SYMBOL_LEAKED_FROM_DEPENDENCY_CHANGED,
 })
 
+# ---------------------------------------------------------------------------
+# Compatible sub-categories: additions vs quality/behavioral issues
+# ---------------------------------------------------------------------------
+
+#: Additive kinds — new public API surface (subset of COMPATIBLE_KINDS).
+#: Explicitly enumerated to avoid false positives (e.g. FUNC_NOEXCEPT_ADDED
+#: is a qualifier change, not a new API addition).
+ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
+    ChangeKind.FUNC_ADDED,
+    ChangeKind.VAR_ADDED,
+    ChangeKind.TYPE_ADDED,
+    ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
+    ChangeKind.ENUM_MEMBER_ADDED,
+    ChangeKind.UNION_FIELD_ADDED,
+    ChangeKind.CONSTANT_ADDED,
+    ChangeKind.SYMBOL_VERSION_DEFINED_ADDED,
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED_COMPAT,
+})
+
+#: Quality / behavioral issues — COMPATIBLE_KINDS that are NOT additions.
+#: Examples: VISIBILITY_LEAK, SONAME_MISSING, DWARF_INFO_MISSING, noexcept changes.
+QUALITY_KINDS: frozenset[ChangeKind] = frozenset(COMPATIBLE_KINDS - ADDITION_KINDS)
+
+
 API_BREAK_KINDS: set[ChangeKind] = {
     ChangeKind.ENUM_MEMBER_RENAMED,
     ChangeKind.PARAM_DEFAULT_VALUE_REMOVED,
@@ -519,6 +543,18 @@ assert PLUGIN_ABI_DOWNGRADED_KINDS <= BREAKING_KINDS, (
 )
 # Safety-critical invariants: RISK_KINDS must be disjoint from all other kind sets.
 # Use explicit raises (not assert) so these are never stripped by python -O.
+# ADDITION_KINDS must be a subset of COMPATIBLE_KINDS; their union with
+# QUALITY_KINDS must cover all COMPATIBLE_KINDS exactly.
+assert ADDITION_KINDS <= COMPATIBLE_KINDS, (
+    "ADDITION_KINDS must be a subset of COMPATIBLE_KINDS; "
+    f"offending kinds: {ADDITION_KINDS - COMPATIBLE_KINDS}"
+)
+assert ADDITION_KINDS | QUALITY_KINDS == COMPATIBLE_KINDS, (
+    "ADDITION_KINDS | QUALITY_KINDS must equal COMPATIBLE_KINDS; "
+    f"missing: {COMPATIBLE_KINDS - (ADDITION_KINDS | QUALITY_KINDS)}, "
+    f"extra: {(ADDITION_KINDS | QUALITY_KINDS) - COMPATIBLE_KINDS}"
+)
+
 if not RISK_KINDS.isdisjoint(BREAKING_KINDS):
     raise AssertionError(
         "RISK_KINDS must not overlap with BREAKING_KINDS; "

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -533,27 +533,28 @@ PLUGIN_ABI_DOWNGRADED_KINDS: frozenset[ChangeKind] = frozenset(
 )
 
 # Integrity assertions: catch miscategorisation at import time.
-assert SDK_VENDOR_COMPAT_KINDS <= API_BREAK_KINDS, (
-    "SDK_VENDOR_COMPAT_KINDS must be a strict subset of API_BREAK_KINDS; "
-    f"offending kinds: {SDK_VENDOR_COMPAT_KINDS - API_BREAK_KINDS}"
-)
-assert PLUGIN_ABI_DOWNGRADED_KINDS <= BREAKING_KINDS, (
-    "PLUGIN_ABI_DOWNGRADED_KINDS must be a strict subset of BREAKING_KINDS; "
-    f"offending kinds: {PLUGIN_ABI_DOWNGRADED_KINDS - BREAKING_KINDS}"
-)
-# Safety-critical invariants: RISK_KINDS must be disjoint from all other kind sets.
 # Use explicit raises (not assert) so these are never stripped by python -O.
-# ADDITION_KINDS must be a subset of COMPATIBLE_KINDS; their union with
-# QUALITY_KINDS must cover all COMPATIBLE_KINDS exactly.
-assert ADDITION_KINDS <= COMPATIBLE_KINDS, (
-    "ADDITION_KINDS must be a subset of COMPATIBLE_KINDS; "
-    f"offending kinds: {ADDITION_KINDS - COMPATIBLE_KINDS}"
-)
-assert ADDITION_KINDS | QUALITY_KINDS == COMPATIBLE_KINDS, (
-    "ADDITION_KINDS | QUALITY_KINDS must equal COMPATIBLE_KINDS; "
-    f"missing: {COMPATIBLE_KINDS - (ADDITION_KINDS | QUALITY_KINDS)}, "
-    f"extra: {(ADDITION_KINDS | QUALITY_KINDS) - COMPATIBLE_KINDS}"
-)
+if not SDK_VENDOR_COMPAT_KINDS <= API_BREAK_KINDS:
+    raise AssertionError(
+        "SDK_VENDOR_COMPAT_KINDS must be a strict subset of API_BREAK_KINDS; "
+        f"offending kinds: {SDK_VENDOR_COMPAT_KINDS - API_BREAK_KINDS}"
+    )
+if not PLUGIN_ABI_DOWNGRADED_KINDS <= BREAKING_KINDS:
+    raise AssertionError(
+        "PLUGIN_ABI_DOWNGRADED_KINDS must be a strict subset of BREAKING_KINDS; "
+        f"offending kinds: {PLUGIN_ABI_DOWNGRADED_KINDS - BREAKING_KINDS}"
+    )
+if not ADDITION_KINDS <= COMPATIBLE_KINDS:
+    raise AssertionError(
+        "ADDITION_KINDS must be a subset of COMPATIBLE_KINDS; "
+        f"offending kinds: {ADDITION_KINDS - COMPATIBLE_KINDS}"
+    )
+if ADDITION_KINDS | QUALITY_KINDS != COMPATIBLE_KINDS:
+    raise AssertionError(
+        "ADDITION_KINDS | QUALITY_KINDS must equal COMPATIBLE_KINDS; "
+        f"missing: {COMPATIBLE_KINDS - (ADDITION_KINDS | QUALITY_KINDS)}, "
+        f"extra: {(ADDITION_KINDS | QUALITY_KINDS) - COMPATIBLE_KINDS}"
+    )
 
 if not RISK_KINDS.isdisjoint(BREAKING_KINDS):
     raise AssertionError(

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1076,6 +1076,10 @@ def compare_cmd(
 
     # Resolve severity configuration (preset + per-category overrides)
     from .severity import resolve_severity_config
+    severity_explicitly_set = any(v is not None for v in (
+        severity_preset, severity_abi_breaking, severity_potential_breaking,
+        severity_quality_issues, severity_additions,
+    ))
     sev_config = resolve_severity_config(
         preset=severity_preset,
         abi_breaking=severity_abi_breaking,
@@ -1182,7 +1186,7 @@ def compare_cmd(
         follow_deps=follow_deps,
         show_only=show_only, report_mode=report_mode,
         show_impact=show_impact, stat=stat,
-        severity_config=sev_config,
+        severity_config=sev_config if severity_explicitly_set else None,
     )
     if output:
         _safe_write_output(output, text)
@@ -1190,10 +1194,11 @@ def compare_cmd(
     else:
         click.echo(text)
 
-    # Severity-aware exit code: use severity config when a non-default preset
-    # or any per-category override was specified.
-    from .severity import PRESET_DEFAULT, compute_exit_code
-    if sev_config != PRESET_DEFAULT:
+    # Severity-aware exit code: use severity config when any --severity-*
+    # flag was explicitly provided.  Otherwise fall back to legacy verdict-
+    # based exit codes for full backward compatibility.
+    from .severity import compute_exit_code
+    if severity_explicitly_set:
         exit_code = compute_exit_code(result.changes, sev_config)
         if exit_code != 0:
             sys.exit(exit_code)
@@ -1205,12 +1210,11 @@ def compare_cmd(
             sys.exit(2)
 
     # --fail-on-additions: exit 1 if any new public symbols/types were added.
-    # Filter result.changes directly (not result.compatible) so the check is
-    # policy-independent: _ADDITION_KINDS covers all known additive change kinds.
+    # Uses the canonical ADDITION_KINDS set from checker_policy (single source
+    # of truth) rather than a heuristic string match.
     if fail_on_additions:
-        from .checker_policy import COMPATIBLE_KINDS
-        _ADDITION_KINDS = {k for k in COMPATIBLE_KINDS if k.value.endswith("_added")}
-        additions = [c for c in result.changes if c.kind in _ADDITION_KINDS]
+        from .checker_policy import ADDITION_KINDS
+        additions = [c for c in result.changes if c.kind in ADDITION_KINDS]
         if additions:
             click.echo(
                 f"API expansion detected: {len(additions)} addition(s) "

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1199,7 +1199,10 @@ def compare_cmd(
     # based exit codes for full backward compatibility.
     from .severity import compute_exit_code
     if severity_explicitly_set:
-        exit_code = compute_exit_code(result.changes, sev_config, policy=policy)
+        # Use effective kind sets which include PolicyFile and --strict-elf-only
+        # overrides, not just the built-in policy name.
+        eff_sets = result._effective_kind_sets()
+        exit_code = compute_exit_code(result.changes, sev_config, kind_sets=eff_sets)
         if exit_code != 0:
             sys.exit(exit_code)
     else:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -671,6 +671,7 @@ def _render_output(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
+    severity_config: object | None = None,
 ) -> str:
     """Render comparison result in the requested output format."""
     if stat:
@@ -678,7 +679,10 @@ def _render_output(
             return to_stat_json(result)
         return to_stat(result)
     if fmt == "json":
-        base = to_json(result, show_only=show_only, report_mode=report_mode, show_impact=show_impact)
+        base = to_json(
+            result, show_only=show_only, report_mode=report_mode,
+            show_impact=show_impact, severity_config=severity_config,
+        )
         if follow_deps and (old.dependency_info or (new and new.dependency_info)):
             import json
             d = json.loads(base)
@@ -704,7 +708,10 @@ def _render_output(
             show_only=show_only,
             show_impact=show_impact,
         )
-    md = to_markdown(result, show_only=show_only, report_mode=report_mode, show_impact=show_impact)
+    md = to_markdown(
+        result, show_only=show_only, report_mode=report_mode,
+        show_impact=show_impact, severity_config=severity_config,
+    )
     if follow_deps and (old.dependency_info or (new and new.dependency_info)):
         md += _render_deps_section_md(old, new)
     return md
@@ -945,6 +952,30 @@ def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
               help="Exit with code 1 if any new public symbols, types, or fields were added "
                    "(COMPATIBLE changes). Useful for detecting unintentional API expansion in PRs. "
                    "Use --no-fail-on-additions (or omit the flag) to allow API growth.")
+@click.option("--severity-preset", "severity_preset",
+              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
+              default=None,
+              help="Severity preset controlling exit codes and report labels for four issue "
+                   "categories: abi-breaking, potential-breaking, quality-issues, additions. "
+                   "Presets: 'default' (breaks=error, potential/quality=warning, additions=info), "
+                   "'strict' (all=error), 'info-only' (all=info, exit 0 always). "
+                   "Per-category --severity-* options override the preset.")
+@click.option("--severity-abi-breaking", "severity_abi_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for clear ABI/API incompatibilities (overrides preset).")
+@click.option("--severity-potential-breaking", "severity_potential_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for potential incompatibilities needing review (overrides preset).")
+@click.option("--severity-quality-issues", "severity_quality_issues",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for problematic behaviors like std symbol leaks (overrides preset).")
+@click.option("--severity-additions", "severity_additions",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for new public API additions (overrides preset).")
 @click.option("--follow-deps", is_flag=True, default=False,
               help="Resolve transitive dependencies for both old and new, compute symbol "
                    "bindings, and include a dependency-change section in the report. ELF only.")
@@ -989,6 +1020,11 @@ def compare_cmd(
     pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
     dwarf_only: bool,
     fail_on_additions: bool,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_additions: str | None,
     follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
     show_redundant: bool, show_only: str | None, stat: bool,
     report_mode: str, show_impact: bool,
@@ -1037,6 +1073,16 @@ def compare_cmd(
       abicheck compare old.json new.json --suppress suppressions.yaml
     """
     _setup_verbosity(verbose)
+
+    # Resolve severity configuration (preset + per-category overrides)
+    from .severity import resolve_severity_config
+    sev_config = resolve_severity_config(
+        preset=severity_preset,
+        abi_breaking=severity_abi_breaking,
+        potential_breaking=severity_potential_breaking,
+        quality_issues=severity_quality_issues,
+        additions=severity_additions,
+    )
 
     old_h, new_h, old_inc, new_inc = _resolve_per_side_options(
         headers, includes, old_headers_only, new_headers_only,
@@ -1136,6 +1182,7 @@ def compare_cmd(
         follow_deps=follow_deps,
         show_only=show_only, report_mode=report_mode,
         show_impact=show_impact, stat=stat,
+        severity_config=sev_config,
     )
     if output:
         _safe_write_output(output, text)
@@ -1143,10 +1190,19 @@ def compare_cmd(
     else:
         click.echo(text)
 
-    if result.verdict.value == "BREAKING":
-        sys.exit(4)
-    elif result.verdict.value == "API_BREAK":
-        sys.exit(2)
+    # Severity-aware exit code: use severity config when a non-default preset
+    # or any per-category override was specified.
+    from .severity import PRESET_DEFAULT, compute_exit_code
+    if sev_config != PRESET_DEFAULT:
+        exit_code = compute_exit_code(result.changes, sev_config)
+        if exit_code != 0:
+            sys.exit(exit_code)
+    else:
+        # Legacy exit-code behaviour (preserves backward compatibility)
+        if result.verdict.value == "BREAKING":
+            sys.exit(4)
+        elif result.verdict.value == "API_BREAK":
+            sys.exit(2)
 
     # --fail-on-additions: exit 1 if any new public symbols/types were added.
     # Filter result.changes directly (not result.compatible) so the check is

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1035,11 +1035,17 @@ def compare_cmd(
     DWARF-only mode (if DWARF available) or symbols-only analysis.
 
     \b
-    Exit codes:
+    Exit codes (legacy, without --severity-* flags):
       0  NO_CHANGE, COMPATIBLE, or COMPATIBLE_WITH_RISK — no binary ABI break
          (COMPATIBLE_WITH_RISK: deployment risk present; check the report)
       2  API_BREAK — source-level API break — recompilation required
       4  BREAKING — binary ABI break detected
+    \b
+    Exit codes (severity-aware, with any --severity-* flag):
+      0  No error-level findings
+      1  Error-level findings in addition or quality_issues only
+      2  Error-level findings in potential_breaking (but not abi_breaking)
+      4  Error-level findings in abi_breaking
 
     \b
     Examples:
@@ -1193,7 +1199,7 @@ def compare_cmd(
     # based exit codes for full backward compatibility.
     from .severity import compute_exit_code
     if severity_explicitly_set:
-        exit_code = compute_exit_code(result.changes, sev_config)
+        exit_code = compute_exit_code(result.changes, sev_config, policy=policy)
         if exit_code != 0:
             sys.exit(exit_code)
     else:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -949,10 +949,6 @@ def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
 @click.option("--dwarf-only", is_flag=True, default=False,
               help="Force DWARF-only mode for both sides: use DWARF debug info "
                    "as primary data source even when headers are available.")
-@click.option("--fail-on-additions/--no-fail-on-additions", "fail_on_additions", default=False,
-              help="Exit with code 1 if any new public symbols, types, or fields were added "
-                   "(COMPATIBLE changes). Useful for detecting unintentional API expansion in PRs. "
-                   "Use --no-fail-on-additions (or omit the flag) to allow API growth.")
 @click.option("--severity-preset", "severity_preset",
               type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
               default=None,
@@ -971,7 +967,7 @@ def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
               type=click.Choice(["error", "warning", "info"], case_sensitive=True),
               default=None,
               help="Severity for problematic behaviors like std symbol leaks (overrides preset).")
-@click.option("--severity-additions", "severity_additions",
+@click.option("--severity-addition", "severity_addition",
               type=click.Choice(["error", "warning", "info"], case_sensitive=True),
               default=None,
               help="Severity for new public API additions (overrides preset).")
@@ -1018,12 +1014,11 @@ def compare_cmd(
     suppress: Path | None, policy: str, policy_file_path: Path | None,
     pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
     dwarf_only: bool,
-    fail_on_additions: bool,
     severity_preset: str | None,
     severity_abi_breaking: str | None,
     severity_potential_breaking: str | None,
     severity_quality_issues: str | None,
-    severity_additions: str | None,
+    severity_addition: str | None,
     follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
     show_redundant: bool, show_only: str | None, stat: bool,
     report_mode: str, show_impact: bool,
@@ -1077,14 +1072,14 @@ def compare_cmd(
     from .severity import resolve_severity_config
     severity_explicitly_set = any(v is not None for v in (
         severity_preset, severity_abi_breaking, severity_potential_breaking,
-        severity_quality_issues, severity_additions,
+        severity_quality_issues, severity_addition,
     ))
     sev_config = resolve_severity_config(
         preset=severity_preset,
         abi_breaking=severity_abi_breaking,
         potential_breaking=severity_potential_breaking,
         quality_issues=severity_quality_issues,
-        additions=severity_additions,
+        addition=severity_addition,
     )
 
     old_h, new_h, old_inc, new_inc = _resolve_per_side_options(
@@ -1208,20 +1203,6 @@ def compare_cmd(
         elif result.verdict.value == "API_BREAK":
             sys.exit(2)
 
-    # --fail-on-additions: exit 1 if any new public symbols/types were added.
-    # Uses the canonical ADDITION_KINDS set from checker_policy (single source
-    # of truth) rather than a heuristic string match.
-    if fail_on_additions:
-        from .checker_policy import ADDITION_KINDS
-        additions = [c for c in result.changes if c.kind in ADDITION_KINDS]
-        if additions:
-            click.echo(
-                f"API expansion detected: {len(additions)} addition(s) "
-                f"({', '.join(sorted({c.kind.value for c in additions}))}). "
-                "Use --no-fail-on-additions (or omit the flag) to allow API growth.",
-                err=True,
-            )
-            sys.exit(1)
 
 @main.command("appcompat")
 @click.argument("app_path", type=click.Path(exists=True, path_type=Path))
@@ -1471,8 +1452,6 @@ def appcompat_cmd(
 @click.option("--fail-on-removed-library/--no-fail-on-removed-library",
               "fail_on_removed", default=False,
               help="Exit 8 when a library present in old_dir is absent in new_dir.")
-@click.option("--fail-on-additions/--no-fail-on-additions",
-              "fail_on_additions", default=False)
 @click.option("--debug-info1", type=click.Path(exists=True, path_type=Path), default=None,
               help="Debug info package for old side (RPM/Deb/tar).")
 @click.option("--debug-info2", type=click.Path(exists=True, path_type=Path), default=None,
@@ -1505,7 +1484,6 @@ def compare_release_cmd(
     policy: str,
     policy_file_path: Path | None,
     fail_on_removed: bool,
-    fail_on_additions: bool,
     debug_info1: Path | None,
     debug_info2: Path | None,
     devel_pkg1: Path | None,
@@ -1814,8 +1792,6 @@ def compare_release_cmd(
             sys.exit(2)
         if fail_on_removed and removed_keys:
             sys.exit(8)
-        if fail_on_additions and any(lib.get("compatible_additions", 0) for lib in library_results):
-            sys.exit(1)
     finally:
         import shutil as _shutil
         if not keep_extracted:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -34,6 +34,7 @@ from .serialization import load_snapshot, snapshot_to_json
 
 if TYPE_CHECKING:
     from .policy_file import PolicyFile
+    from .severity import SeverityConfig
     from .suppression import SuppressionList
 
 from . import __version__ as _abicheck_version
@@ -671,7 +672,7 @@ def _render_output(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
-    severity_config: object | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """Render comparison result in the requested output format."""
     if stat:
@@ -955,11 +956,9 @@ def _build_match_map(paths: list[Path]) -> tuple[dict[str, Path], list[str]]:
 @click.option("--severity-preset", "severity_preset",
               type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
               default=None,
-              help="Severity preset controlling exit codes and report labels for four issue "
-                   "categories: abi-breaking, potential-breaking, quality-issues, additions. "
-                   "Presets: 'default' (breaks=error, potential/quality=warning, additions=info), "
-                   "'strict' (all=error), 'info-only' (all=info, exit 0 always). "
-                   "Per-category --severity-* options override the preset.")
+              help="Severity preset: 'default', 'strict', or 'info-only'. "
+                   "Controls exit codes and report labels. Per-category "
+                   "--severity-* options override the chosen preset.")
 @click.option("--severity-abi-breaking", "severity_abi_breaking",
               type=click.Choice(["error", "warning", "info"], case_sensitive=True),
               default=None,

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -511,7 +511,11 @@ def to_json(
 
     # Severity-categorized summary when severity config is provided
     if severity_config is not None:
-        d["severity"] = _build_severity_json(changes, severity_config)
+        d["severity"] = _build_severity_json(
+            changes, severity_config,
+            all_changes=list(result.changes),
+            policy=effective_policy,
+        )
 
     d["changes"] = [_change_to_dict(c, policy=effective_policy) for c in changes]
     if result.redundant_count > 0:
@@ -647,11 +651,13 @@ def _section_severity_label(severity_config: SeverityConfig | None, category_att
 def _build_severity_summary_md(
     changes: list[Change],
     severity_config: SeverityConfig,
+    *,
+    policy: str | None = None,
 ) -> list[str]:
     """Build a severity configuration summary table for markdown output."""
     from .severity import SeverityLevel, categorize_changes
 
-    categorized = categorize_changes(changes)
+    categorized = categorize_changes(changes, policy=policy)
     lines = [
         "## Severity Configuration",
         "",
@@ -683,11 +689,19 @@ def _build_severity_summary_md(
 def _build_severity_json(
     changes: list[Change],
     severity_config: SeverityConfig,
+    *,
+    all_changes: list[Change] | None = None,
+    policy: str | None = None,
 ) -> dict[str, object]:
-    """Build severity information for JSON output."""
+    """Build severity information for JSON output.
+
+    *changes* are the (possibly filtered) changes for display counts.
+    *all_changes*, when provided, is the unfiltered set used to compute
+    the exit code so that ``--show-only`` does not affect the exit code.
+    """
     from .severity import SeverityLevel, categorize_changes, compute_exit_code
 
-    categorized = categorize_changes(changes)
+    categorized = categorize_changes(changes, policy=policy)
 
     config_dict: dict[str, str] = {}
     for attr in ("abi_breaking", "potential_breaking", "quality_issues", "addition"):
@@ -713,7 +727,10 @@ def _build_severity_json(
         },
     }
 
-    exit_code = compute_exit_code(changes, severity_config)
+    # Exit code uses the full unfiltered change set so --show-only
+    # does not affect it.
+    exit_changes = all_changes if all_changes is not None else changes
+    exit_code = compute_exit_code(exit_changes, severity_config, policy=policy)
 
     return {
         "config": config_dict,
@@ -790,7 +807,9 @@ def to_markdown(
 
     # Severity configuration summary when provided
     if severity_config is not None:
-        lines += _build_severity_summary_md(changes, severity_config)
+        lines += _build_severity_summary_md(
+            changes, severity_config, policy=result.policy,
+        )
 
     if show_only:
         lines.append(f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)")

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -784,7 +784,7 @@ def to_markdown(
         f"| Breaking changes | {len(result.breaking)} |",
         f"| Source-level breaks | {len(result.source_breaks)} |",
         f"| Deployment risk changes | {len(result.risk)} |",
-        f"| Compatible additions | {len(result.compatible)} |",
+        f"| Compatible changes | {len(result.compatible)} |",
         "",
     ]
 
@@ -826,6 +826,9 @@ def to_markdown(
         lines.append("")
 
     if risk:
+        # Risk changes share the "potential_breaking" severity category with
+        # source-level breaks (both are potential incompatibilities), so they
+        # show the same severity badge in the report.
         sev_label = _section_severity_label(severity_config, "potential_breaking")
         lines += [f"## {_RISK_ICON} Deployment Risk Changes{sev_label}", ""]
         lines += [

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -466,6 +466,7 @@ def to_json(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
+    severity_config: object | None = None,
 ) -> str:
     if stat:
         return to_stat_json(result, indent=indent)
@@ -502,6 +503,11 @@ def to_json(
     }
     effective_policy = result.policy or "strict_abi"
     d["policy"] = effective_policy
+
+    # Severity-categorized summary when severity config is provided
+    if severity_config is not None:
+        d["severity"] = _build_severity_json(changes, severity_config)
+
     d["changes"] = [_change_to_dict(c, policy=effective_policy) for c in changes]
     if result.redundant_count > 0:
         d["redundant_count"] = result.redundant_count
@@ -604,6 +610,113 @@ def _append_suppression_note(lines: list[str], result: DiffResult) -> None:
                 lines.append(f">   - `{sc.symbol}` — {sc.description}")
 
 
+# ---------------------------------------------------------------------------
+# Severity section helpers
+# ---------------------------------------------------------------------------
+
+_BREAKING_ICON = "\u274c"  # ❌
+_SOURCE_BREAK_ICON = "\u26a0\ufe0f"  # ⚠️
+_RISK_ICON = "\u26a0\ufe0f"  # ⚠️
+_QUALITY_ICON = "\U0001f50d"  # 🔍
+_ADDITION_ICON = "\u2705"  # ✅
+
+_SEVERITY_EMOJI = {
+    "error": "\u274c",  # ❌
+    "warning": "\u26a0\ufe0f",  # ⚠️
+    "info": "\u2139\ufe0f",  # ℹ️
+}
+
+
+def _section_severity_label(severity_config: object | None, category_attr: str) -> str:
+    """Return a severity label suffix like ' [ERROR]' for a report section header."""
+    if severity_config is None:
+        return ""
+    level = getattr(severity_config, category_attr, None)
+    if level is None:
+        return ""
+    level_val = level.value if hasattr(level, "value") else str(level)
+    emoji = _SEVERITY_EMOJI.get(level_val, "")
+    return f" {emoji} `{level_val.upper()}`"
+
+
+def _build_severity_summary_md(
+    changes: list[Change],
+    severity_config: object,
+) -> list[str]:
+    """Build a severity configuration summary table for markdown output."""
+    from .severity import SeverityLevel, categorize_changes
+
+    categorized = categorize_changes(changes)
+    lines = [
+        "## Severity Configuration",
+        "",
+        "| Category | Severity | Count | Exit Impact |",
+        "|----------|----------|-------|-------------|",
+    ]
+
+    _CATEGORY_INFO: list[tuple[str, str, list[object]]] = [
+        ("ABI/API Incompatibilities", "abi_breaking", categorized.abi_breaking),
+        ("Potential Incompatibilities", "potential_breaking", categorized.potential_breaking),
+        ("Quality Issues", "quality_issues", categorized.quality_issues),
+        ("Additions", "additions", categorized.additions),
+    ]
+
+    for label, attr, cat_changes in _CATEGORY_INFO:
+        level = getattr(severity_config, attr, SeverityLevel.INFO)
+        level_val = level.value if hasattr(level, "value") else str(level)
+        emoji = _SEVERITY_EMOJI.get(level_val, "")
+        count = len(cat_changes)
+        impact = "causes non-zero exit" if level_val == "error" and count > 0 else "no exit impact"
+        lines.append(
+            f"| {label} | {emoji} `{level_val.upper()}` | {count} | {impact} |"
+        )
+
+    lines.append("")
+    return lines
+
+
+def _build_severity_json(
+    changes: list[Change],
+    severity_config: object,
+) -> dict[str, object]:
+    """Build severity information for JSON output."""
+    from .severity import SeverityLevel, categorize_changes, compute_exit_code
+
+    categorized = categorize_changes(changes)
+
+    config_dict: dict[str, str] = {}
+    for attr in ("abi_breaking", "potential_breaking", "quality_issues", "additions"):
+        level = getattr(severity_config, attr, SeverityLevel.INFO)
+        config_dict[attr] = level.value if hasattr(level, "value") else str(level)
+
+    categories: dict[str, object] = {
+        "abi_breaking": {
+            "severity": config_dict["abi_breaking"],
+            "count": len(categorized.abi_breaking),
+        },
+        "potential_breaking": {
+            "severity": config_dict["potential_breaking"],
+            "count": len(categorized.potential_breaking),
+        },
+        "quality_issues": {
+            "severity": config_dict["quality_issues"],
+            "count": len(categorized.quality_issues),
+        },
+        "additions": {
+            "severity": config_dict["additions"],
+            "count": len(categorized.additions),
+        },
+    }
+
+    exit_code = compute_exit_code(changes, severity_config)  # type: ignore[arg-type]
+
+    return {
+        "config": config_dict,
+        "categories": categories,
+        "exit_code": exit_code,
+    }
+
+
 def _footer_lines() -> list[str]:
     return [
         "---",
@@ -628,6 +741,7 @@ def to_markdown(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
+    severity_config: object | None = None,
 ) -> str:
     if stat:
         return to_stat(result)
@@ -669,6 +783,10 @@ def to_markdown(
         "",
     ]
 
+    # Severity configuration summary when provided
+    if severity_config is not None:
+        lines += _build_severity_summary_md(changes, severity_config)
+
     if show_only:
         lines.append(f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)")
         lines.append("")
@@ -689,19 +807,22 @@ def to_markdown(
         ]
 
     if breaking:
-        lines += ["## ❌ Breaking Changes", ""]
+        sev_label = _section_severity_label(severity_config, "abi_breaking")
+        lines += [f"## {_BREAKING_ICON} Breaking Changes{sev_label}", ""]
         for c in breaking:
             lines.append(_format_change_md(c))
         lines.append("")
 
     if source_breaks:
-        lines += ["## ⚠️ Source-Level Breaks", ""]
+        sev_label = _section_severity_label(severity_config, "potential_breaking")
+        lines += [f"## {_SOURCE_BREAK_ICON} Source-Level Breaks{sev_label}", ""]
         for c in source_breaks:
             lines.append(_format_change_md(c))
         lines.append("")
 
     if risk:
-        lines += ["## ⚠️ Deployment Risk Changes", ""]
+        sev_label = _section_severity_label(severity_config, "potential_breaking")
+        lines += [f"## {_RISK_ICON} Deployment Risk Changes{sev_label}", ""]
         lines += [
             "> These changes are **binary-compatible** but may cause the library to fail",
             "> loading on older systems (e.g. a new GLIBC version requirement). Verify",
@@ -712,11 +833,24 @@ def to_markdown(
             lines.append(f"- **{c.kind.value}**: {c.description}")
         lines.append("")
 
+    # Split compatible changes into quality/behavioral issues vs additions
+    # using the canonical kind sets from checker_policy (single source of truth).
     if compatible:
-        lines += ["## ✅ Compatible Changes", ""]
-        for c in compatible:
-            lines.append(f"- {c.description}")
-        lines.append("")
+        from .checker_policy import ADDITION_KINDS as _ADDITION_KINDS
+        quality = [c for c in compatible if c.kind not in _ADDITION_KINDS]
+        additions_list = [c for c in compatible if c.kind in _ADDITION_KINDS]
+        if quality:
+            sev_label = _section_severity_label(severity_config, "quality_issues")
+            lines += [f"## {_QUALITY_ICON} Quality Issues{sev_label}", ""]
+            for c in quality:
+                lines.append(f"- **{c.kind.value}**: {c.description}")
+            lines.append("")
+        if additions_list:
+            sev_label = _section_severity_label(severity_config, "additions")
+            lines += [f"## {_ADDITION_ICON} Additions{sev_label}", ""]
+            for c in additions_list:
+                lines.append(f"- {c.description}")
+            lines.append("")
 
     if not changes:
         if show_only and result.changes:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .checker_policy import HasKind
-    from .severity import SeverityConfig
+    from .severity import KindSets, SeverityConfig
 
 from .checker import (
     Change,
@@ -511,10 +511,11 @@ def to_json(
 
     # Severity-categorized summary when severity config is provided
     if severity_config is not None:
+        eff_sets = result._effective_kind_sets()
         d["severity"] = _build_severity_json(
             changes, severity_config,
             all_changes=list(result.changes),
-            policy=effective_policy,
+            kind_sets=eff_sets,
         )
 
     d["changes"] = [_change_to_dict(c, policy=effective_policy) for c in changes]
@@ -652,12 +653,12 @@ def _build_severity_summary_md(
     changes: list[Change],
     severity_config: SeverityConfig,
     *,
-    policy: str | None = None,
+    kind_sets: KindSets | None = None,
 ) -> list[str]:
     """Build a severity configuration summary table for markdown output."""
     from .severity import SeverityLevel, categorize_changes
 
-    categorized = categorize_changes(changes, policy=policy)
+    categorized = categorize_changes(changes, kind_sets=kind_sets)
     lines = [
         "## Severity Configuration",
         "",
@@ -691,17 +692,19 @@ def _build_severity_json(
     severity_config: SeverityConfig,
     *,
     all_changes: list[Change] | None = None,
-    policy: str | None = None,
+    kind_sets: KindSets | None = None,
 ) -> dict[str, object]:
     """Build severity information for JSON output.
 
     *changes* are the (possibly filtered) changes for display counts.
     *all_changes*, when provided, is the unfiltered set used to compute
     the exit code so that ``--show-only`` does not affect the exit code.
+    *kind_sets* from ``DiffResult._effective_kind_sets()`` includes
+    PolicyFile overrides.
     """
     from .severity import SeverityLevel, categorize_changes, compute_exit_code
 
-    categorized = categorize_changes(changes, policy=policy)
+    categorized = categorize_changes(changes, kind_sets=kind_sets)
 
     config_dict: dict[str, str] = {}
     for attr in ("abi_breaking", "potential_breaking", "quality_issues", "addition"):
@@ -730,7 +733,7 @@ def _build_severity_json(
     # Exit code uses the full unfiltered change set so --show-only
     # does not affect it.
     exit_changes = all_changes if all_changes is not None else changes
-    exit_code = compute_exit_code(exit_changes, severity_config, policy=policy)
+    exit_code = compute_exit_code(exit_changes, severity_config, kind_sets=kind_sets)
 
     return {
         "config": config_dict,
@@ -808,7 +811,7 @@ def to_markdown(
     # Severity configuration summary when provided
     if severity_config is not None:
         lines += _build_severity_summary_md(
-            changes, severity_config, policy=result.policy,
+            changes, severity_config, kind_sets=result._effective_kind_sets(),
         )
 
     if show_only:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -663,7 +663,7 @@ def _build_severity_summary_md(
         ("ABI/API Incompatibilities", "abi_breaking", categorized.abi_breaking),
         ("Potential Incompatibilities", "potential_breaking", categorized.potential_breaking),
         ("Quality Issues", "quality_issues", categorized.quality_issues),
-        ("Additions", "additions", categorized.additions),
+        ("Additions", "addition", categorized.addition),
     ]
 
     for label, attr, cat_changes in _CATEGORY_INFO:
@@ -690,7 +690,7 @@ def _build_severity_json(
     categorized = categorize_changes(changes)
 
     config_dict: dict[str, str] = {}
-    for attr in ("abi_breaking", "potential_breaking", "quality_issues", "additions"):
+    for attr in ("abi_breaking", "potential_breaking", "quality_issues", "addition"):
         level = getattr(severity_config, attr, SeverityLevel.INFO)
         config_dict[attr] = level.value if hasattr(level, "value") else str(level)
 
@@ -707,9 +707,9 @@ def _build_severity_json(
             "severity": config_dict["quality_issues"],
             "count": len(categorized.quality_issues),
         },
-        "additions": {
-            "severity": config_dict["additions"],
-            "count": len(categorized.additions),
+        "addition": {
+            "severity": config_dict["addition"],
+            "count": len(categorized.addition),
         },
     }
 
@@ -854,7 +854,7 @@ def to_markdown(
                 lines.append(f"- **{c.kind.value}**: {c.description}")
             lines.append("")
         if additions_list:
-            sev_label = _section_severity_label(severity_config, "additions")
+            sev_label = _section_severity_label(severity_config, "addition")
             lines += [f"## {_ADDITION_ICON} Additions{sev_label}", ""]
             for c in additions_list:
                 lines.append(f"- {c.description}")

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -19,6 +19,11 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .checker_policy import HasKind
+    from .severity import SeverityConfig
 
 from .checker import (
     Change,
@@ -466,7 +471,7 @@ def to_json(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
-    severity_config: object | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     if stat:
         return to_stat_json(result, indent=indent)
@@ -627,7 +632,7 @@ _SEVERITY_EMOJI = {
 }
 
 
-def _section_severity_label(severity_config: object | None, category_attr: str) -> str:
+def _section_severity_label(severity_config: SeverityConfig | None, category_attr: str) -> str:
     """Return a severity label suffix like ' [ERROR]' for a report section header."""
     if severity_config is None:
         return ""
@@ -641,7 +646,7 @@ def _section_severity_label(severity_config: object | None, category_attr: str) 
 
 def _build_severity_summary_md(
     changes: list[Change],
-    severity_config: object,
+    severity_config: SeverityConfig,
 ) -> list[str]:
     """Build a severity configuration summary table for markdown output."""
     from .severity import SeverityLevel, categorize_changes
@@ -654,7 +659,7 @@ def _build_severity_summary_md(
         "|----------|----------|-------|-------------|",
     ]
 
-    _CATEGORY_INFO: list[tuple[str, str, list[object]]] = [
+    _CATEGORY_INFO: list[tuple[str, str, list[HasKind]]] = [
         ("ABI/API Incompatibilities", "abi_breaking", categorized.abi_breaking),
         ("Potential Incompatibilities", "potential_breaking", categorized.potential_breaking),
         ("Quality Issues", "quality_issues", categorized.quality_issues),
@@ -677,7 +682,7 @@ def _build_severity_summary_md(
 
 def _build_severity_json(
     changes: list[Change],
-    severity_config: object,
+    severity_config: SeverityConfig,
 ) -> dict[str, object]:
     """Build severity information for JSON output."""
     from .severity import SeverityLevel, categorize_changes, compute_exit_code
@@ -708,7 +713,7 @@ def _build_severity_json(
         },
     }
 
-    exit_code = compute_exit_code(changes, severity_config)  # type: ignore[arg-type]
+    exit_code = compute_exit_code(changes, severity_config)
 
     return {
         "config": config_dict,
@@ -741,7 +746,7 @@ def to_markdown(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
-    severity_config: object | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     if stat:
         return to_stat(result)

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -14,15 +14,32 @@
 
 """Severity configuration for issue categories.
 
-Provides configurable criticality levels for four categories of ABI/API findings:
+Builds on top of the existing policy/verdict system in ``checker_policy``
+to provide user-facing severity presets that control exit codes and report
+presentation.
 
-1. **abi_breaking** — clear ABI/API incompatibilities (symbol removed, type layout
-   changed, etc.).  Default: ``error``.
-2. **potential_breaking** — potential incompatibilities that need manual review
-   (source-level API breaks, deployment risk).  Default: ``warning``.
-3. **quality_issues** — problematic behaviors such as exposing std symbols,
-   missing SONAME, toolchain flag drift.  Default: ``warning``.
-4. **additions** — new public symbols, types, enum members.  Default: ``info``.
+The canonical kind-set classification lives in ``checker_policy`` (single
+source of truth).  This module provides:
+
+- **SeverityLevel** — ``error`` / ``warning`` / ``info``.
+- **IssueCategory** — the four high-level categories users interact with.
+- **SeverityConfig** — maps each category to a severity level.
+- **Presets** — ``default``, ``strict``, ``info-only``.
+- **classify_change** / **categorize_changes** — thin wrappers over the
+  canonical kind sets.
+- **compute_exit_code** — severity-aware exit-code computation.
+
+The four categories map to the canonical kind sets as follows:
+
+1. **abi_breaking** → ``BREAKING_KINDS`` — clear ABI/API incompatibilities.
+   Default: ``error``.
+2. **potential_breaking** → ``API_BREAK_KINDS ∪ RISK_KINDS`` — potential
+   incompatibilities that need manual review.  Default: ``warning``.
+3. **quality_issues** → ``QUALITY_KINDS`` (= ``COMPATIBLE_KINDS − ADDITION_KINDS``)
+   — problematic behaviors such as exposing std symbols, missing SONAME,
+   toolchain flag drift.  Default: ``warning``.
+4. **additions** → ``ADDITION_KINDS`` — new public symbols, types, enum
+   members.  Default: ``info``.
 
 Each category can be set to ``error``, ``warning``, or ``info``:
 
@@ -45,9 +62,10 @@ from dataclasses import dataclass
 from enum import Enum
 
 from .checker_policy import (
+    ADDITION_KINDS,
     API_BREAK_KINDS,
     BREAKING_KINDS,
-    COMPATIBLE_KINDS,
+    QUALITY_KINDS,
     RISK_KINDS,
     ChangeKind,
     HasKind,
@@ -74,50 +92,23 @@ class IssueCategory(str, Enum):
 # ---------------------------------------------------------------------------
 # Change-kind -> IssueCategory classification
 # ---------------------------------------------------------------------------
-
-#: Kinds that are clear binary ABI / API incompatibilities.
-_ABI_BREAKING_KINDS: frozenset[ChangeKind] = frozenset(BREAKING_KINDS)
-
-#: Kinds that are potential incompatibilities requiring review
-#: (source-level breaks + deployment risk).
-_POTENTIAL_BREAKING_KINDS: frozenset[ChangeKind] = frozenset(
-    API_BREAK_KINDS | RISK_KINDS
-)
-
-#: Additive kinds — new API surface (subset of COMPATIBLE_KINDS).
-#: Explicitly enumerated to avoid false positives (e.g. FUNC_NOEXCEPT_ADDED
-#: is a qualifier change, not a new API addition).
-_ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
-    ChangeKind.FUNC_ADDED,
-    ChangeKind.VAR_ADDED,
-    ChangeKind.TYPE_ADDED,
-    ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
-    ChangeKind.ENUM_MEMBER_ADDED,
-    ChangeKind.UNION_FIELD_ADDED,
-    ChangeKind.CONSTANT_ADDED,
-    ChangeKind.SYMBOL_VERSION_DEFINED_ADDED,
-    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED_COMPAT,
-})
-
-#: Quality / behavioral issues — COMPATIBLE_KINDS that are NOT additions.
-_QUALITY_ISSUE_KINDS: frozenset[ChangeKind] = frozenset(
-    COMPATIBLE_KINDS - _ADDITION_KINDS
-)
+# Delegates entirely to the canonical kind sets in checker_policy.py.
+# No duplicate frozensets here — single source of truth.
 
 
 def classify_change(kind: ChangeKind) -> IssueCategory:
     """Classify a ChangeKind into one of the four issue categories.
 
-    Classification is deterministic and uses the canonical kind sets from
-    ``checker_policy``.  Unknown kinds default to ``ABI_BREAKING`` (fail-safe).
+    Uses the canonical kind sets from ``checker_policy`` directly.
+    Unknown kinds default to ``ABI_BREAKING`` (fail-safe).
     """
-    if kind in _ABI_BREAKING_KINDS:
+    if kind in BREAKING_KINDS:
         return IssueCategory.ABI_BREAKING
-    if kind in _POTENTIAL_BREAKING_KINDS:
+    if kind in API_BREAK_KINDS or kind in RISK_KINDS:
         return IssueCategory.POTENTIAL_BREAKING
-    if kind in _ADDITION_KINDS:
+    if kind in ADDITION_KINDS:
         return IssueCategory.ADDITIONS
-    if kind in _QUALITY_ISSUE_KINDS:
+    if kind in QUALITY_KINDS:
         return IssueCategory.QUALITY_ISSUES
     # Fail-safe: unclassified kinds are treated as breaking.
     return IssueCategory.ABI_BREAKING

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -136,13 +136,12 @@ class SeverityConfig:
     additions: SeverityLevel = SeverityLevel.INFO
 
     def level_for(self, category: IssueCategory) -> SeverityLevel:
-        """Return the configured severity level for *category*."""
-        return {
-            IssueCategory.ABI_BREAKING: self.abi_breaking,
-            IssueCategory.POTENTIAL_BREAKING: self.potential_breaking,
-            IssueCategory.QUALITY_ISSUES: self.quality_issues,
-            IssueCategory.ADDITIONS: self.additions,
-        }[category]
+        """Return the configured severity level for *category*.
+
+        Works because SeverityConfig field names match IssueCategory values.
+        """
+        result: SeverityLevel = getattr(self, category.value)
+        return result
 
     def level_for_kind(self, kind: ChangeKind) -> SeverityLevel:
         """Return the configured severity level for a specific ChangeKind."""

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -72,6 +72,14 @@ from .checker_policy import (
     policy_kind_sets,
 )
 
+#: Pre-computed (breaking, api_break, compatible, risk) kind sets.
+KindSets = tuple[
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+]
+
 
 class SeverityLevel(str, Enum):
     """Criticality level for an issue category."""
@@ -99,18 +107,18 @@ class IssueCategory(str, Enum):
 # are classified correctly.
 
 
-def _effective_sets(
-    policy: str | None,
-) -> tuple[
-    frozenset[ChangeKind],
-    frozenset[ChangeKind],
-    frozenset[ChangeKind],
-    frozenset[ChangeKind],
-]:
-    """Return (breaking, api_break, compatible, risk) for the given policy.
+def _resolve_kind_sets(
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+) -> KindSets:
+    """Return (breaking, api_break, compatible, risk) kind sets.
 
-    Returns the canonical sets when *policy* is None or ``"strict_abi"``.
+    *kind_sets* takes precedence when provided (e.g. from
+    ``DiffResult._effective_kind_sets()`` which includes PolicyFile overrides).
+    Falls back to ``policy_kind_sets(policy)`` or canonical sets.
     """
+    if kind_sets is not None:
+        return kind_sets
     if policy is None or policy == "strict_abi":
         return (
             frozenset(BREAKING_KINDS),
@@ -125,13 +133,17 @@ def classify_change(
     kind: ChangeKind,
     *,
     policy: str | None = None,
+    kind_sets: KindSets | None = None,
 ) -> IssueCategory:
     """Classify a ChangeKind into one of the four issue categories.
 
     Uses the canonical kind sets from ``checker_policy`` by default.
-    When *policy* is provided, uses the policy-adjusted sets so that
-    kinds moved between categories by a non-default policy are handled
-    correctly.
+
+    When *kind_sets* is provided (e.g. from ``DiffResult._effective_kind_sets()``),
+    those sets are used directly, which includes PolicyFile overrides and
+    ``--strict-elf-only`` reclassifications.
+
+    When only *policy* is provided, uses the built-in policy-adjusted sets.
 
     Unknown kinds default to ``ABI_BREAKING`` (fail-safe).
 
@@ -139,7 +151,7 @@ def classify_change(
     construction (``QUALITY_KINDS = COMPATIBLE_KINDS - ADDITION_KINDS``),
     so the check order between them does not matter.
     """
-    breaking, api_break, compatible, risk = _effective_sets(policy)
+    breaking, api_break, compatible, risk = _resolve_kind_sets(policy, kind_sets)
     if kind in breaking:
         return IssueCategory.ABI_BREAKING
     if kind in api_break or kind in risk:
@@ -183,17 +195,26 @@ class SeverityConfig:
         return result
 
     def level_for_kind(
-        self, kind: ChangeKind, *, policy: str | None = None,
+        self,
+        kind: ChangeKind,
+        *,
+        policy: str | None = None,
+        kind_sets: KindSets | None = None,
     ) -> SeverityLevel:
         """Return the configured severity level for a specific ChangeKind."""
-        return self.level_for(classify_change(kind, policy=policy))
+        return self.level_for(classify_change(kind, policy=policy, kind_sets=kind_sets))
 
     def has_errors(
-        self, changes: Sequence[HasKind], *, policy: str | None = None,
+        self,
+        changes: Sequence[HasKind],
+        *,
+        policy: str | None = None,
+        kind_sets: KindSets | None = None,
     ) -> bool:
         """Return True if any change falls into a category configured as error."""
         return any(
-            self.level_for_kind(c.kind, policy=policy) == SeverityLevel.ERROR
+            self.level_for_kind(c.kind, policy=policy, kind_sets=kind_sets)
+            == SeverityLevel.ERROR
             for c in changes
         )
 
@@ -338,6 +359,7 @@ def compute_exit_code(
     config: SeverityConfig,
     *,
     policy: str | None = None,
+    kind_sets: KindSets | None = None,
 ) -> int:
     """Compute the process exit code based on severity configuration.
 
@@ -345,14 +367,14 @@ def compute_exit_code(
     - at least one finding, AND
     - severity configured as ``error``.
 
-    When *policy* is provided, uses the policy-adjusted kind sets
-    so that kinds moved between categories are classified correctly.
+    *kind_sets* (from ``DiffResult._effective_kind_sets()``) includes
+    PolicyFile overrides and takes precedence over *policy*.
 
     Returns 0 if no category at error level has findings.
     """
     worst = 0
     for change in changes:
-        cat = classify_change(change.kind, policy=policy)
+        cat = classify_change(change.kind, policy=policy, kind_sets=kind_sets)
         if config.level_for(cat) == SeverityLevel.ERROR:
             code = _CATEGORY_EXIT_CODES[cat]
             if code > worst:
@@ -380,6 +402,7 @@ def categorize_changes(
     changes: Sequence[HasKind],
     *,
     policy: str | None = None,
+    kind_sets: KindSets | None = None,
 ) -> CategorizedChanges:
     """Partition changes into the four issue categories."""
     abi: list[HasKind] = []
@@ -388,7 +411,7 @@ def categorize_changes(
     adds: list[HasKind] = []
 
     for c in changes:
-        cat = classify_change(c.kind, policy=policy)
+        cat = classify_change(c.kind, policy=policy, kind_sets=kind_sets)
         if cat == IssueCategory.ABI_BREAKING:
             abi.append(c)
         elif cat == IssueCategory.POTENTIAL_BREAKING:

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -65,10 +65,11 @@ from .checker_policy import (
     ADDITION_KINDS,
     API_BREAK_KINDS,
     BREAKING_KINDS,
-    QUALITY_KINDS,
+    COMPATIBLE_KINDS,
     RISK_KINDS,
     ChangeKind,
     HasKind,
+    policy_kind_sets,
 )
 
 
@@ -93,26 +94,60 @@ class IssueCategory(str, Enum):
 # Change-kind -> IssueCategory classification
 # ---------------------------------------------------------------------------
 # Delegates entirely to the canonical kind sets in checker_policy.py.
-# No duplicate frozensets here — single source of truth.
+# When a *policy* is provided, uses the policy-adjusted sets so that
+# kinds downgraded/upgraded by the policy (e.g. sdk_vendor, plugin_abi)
+# are classified correctly.
 
 
-def classify_change(kind: ChangeKind) -> IssueCategory:
+def _effective_sets(
+    policy: str | None,
+) -> tuple[
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+    frozenset[ChangeKind],
+]:
+    """Return (breaking, api_break, compatible, risk) for the given policy.
+
+    Returns the canonical sets when *policy* is None or ``"strict_abi"``.
+    """
+    if policy is None or policy == "strict_abi":
+        return (
+            frozenset(BREAKING_KINDS),
+            frozenset(API_BREAK_KINDS),
+            frozenset(COMPATIBLE_KINDS),
+            RISK_KINDS,
+        )
+    return policy_kind_sets(policy)
+
+
+def classify_change(
+    kind: ChangeKind,
+    *,
+    policy: str | None = None,
+) -> IssueCategory:
     """Classify a ChangeKind into one of the four issue categories.
 
-    Uses the canonical kind sets from ``checker_policy`` directly.
+    Uses the canonical kind sets from ``checker_policy`` by default.
+    When *policy* is provided, uses the policy-adjusted sets so that
+    kinds moved between categories by a non-default policy are handled
+    correctly.
+
     Unknown kinds default to ``ABI_BREAKING`` (fail-safe).
 
     Note: ``ADDITION_KINDS`` and ``QUALITY_KINDS`` are disjoint by
     construction (``QUALITY_KINDS = COMPATIBLE_KINDS - ADDITION_KINDS``),
     so the check order between them does not matter.
     """
-    if kind in BREAKING_KINDS:
+    breaking, api_break, compatible, risk = _effective_sets(policy)
+    if kind in breaking:
         return IssueCategory.ABI_BREAKING
-    if kind in API_BREAK_KINDS or kind in RISK_KINDS:
+    if kind in api_break or kind in risk:
         return IssueCategory.POTENTIAL_BREAKING
+    # Within compatible, split into additions vs quality issues.
     if kind in ADDITION_KINDS:
         return IssueCategory.ADDITION
-    if kind in QUALITY_KINDS:
+    if kind in compatible:
         return IssueCategory.QUALITY_ISSUES
     # Fail-safe: unclassified kinds are treated as breaking.
     return IssueCategory.ABI_BREAKING
@@ -147,14 +182,19 @@ class SeverityConfig:
         result: SeverityLevel = getattr(self, category.value)
         return result
 
-    def level_for_kind(self, kind: ChangeKind) -> SeverityLevel:
+    def level_for_kind(
+        self, kind: ChangeKind, *, policy: str | None = None,
+    ) -> SeverityLevel:
         """Return the configured severity level for a specific ChangeKind."""
-        return self.level_for(classify_change(kind))
+        return self.level_for(classify_change(kind, policy=policy))
 
-    def has_errors(self, changes: Sequence[HasKind]) -> bool:
+    def has_errors(
+        self, changes: Sequence[HasKind], *, policy: str | None = None,
+    ) -> bool:
         """Return True if any change falls into a category configured as error."""
         return any(
-            self.level_for_kind(c.kind) == SeverityLevel.ERROR for c in changes
+            self.level_for_kind(c.kind, policy=policy) == SeverityLevel.ERROR
+            for c in changes
         )
 
     def describe(self, *, prefix: str = "", title: str | None = None) -> str:
@@ -296,6 +336,8 @@ _CATEGORY_EXIT_CODES: dict[IssueCategory, int] = {
 def compute_exit_code(
     changes: Sequence[HasKind],
     config: SeverityConfig,
+    *,
+    policy: str | None = None,
 ) -> int:
     """Compute the process exit code based on severity configuration.
 
@@ -303,11 +345,14 @@ def compute_exit_code(
     - at least one finding, AND
     - severity configured as ``error``.
 
+    When *policy* is provided, uses the policy-adjusted kind sets
+    so that kinds moved between categories are classified correctly.
+
     Returns 0 if no category at error level has findings.
     """
     worst = 0
     for change in changes:
-        cat = classify_change(change.kind)
+        cat = classify_change(change.kind, policy=policy)
         if config.level_for(cat) == SeverityLevel.ERROR:
             code = _CATEGORY_EXIT_CODES[cat]
             if code > worst:
@@ -331,7 +376,11 @@ class CategorizedChanges:
     addition: list[HasKind]
 
 
-def categorize_changes(changes: Sequence[HasKind]) -> CategorizedChanges:
+def categorize_changes(
+    changes: Sequence[HasKind],
+    *,
+    policy: str | None = None,
+) -> CategorizedChanges:
     """Partition changes into the four issue categories."""
     abi: list[HasKind] = []
     potential: list[HasKind] = []
@@ -339,7 +388,7 @@ def categorize_changes(changes: Sequence[HasKind]) -> CategorizedChanges:
     adds: list[HasKind] = []
 
     for c in changes:
-        cat = classify_change(c.kind)
+        cat = classify_change(c.kind, policy=policy)
         if cat == IssueCategory.ABI_BREAKING:
             abi.append(c)
         elif cat == IssueCategory.POTENTIAL_BREAKING:

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -38,7 +38,7 @@ The four categories map to the canonical kind sets as follows:
 3. **quality_issues** → ``QUALITY_KINDS`` (= ``COMPATIBLE_KINDS − ADDITION_KINDS``)
    — problematic behaviors such as exposing std symbols, missing SONAME,
    toolchain flag drift.  Default: ``warning``.
-4. **additions** → ``ADDITION_KINDS`` — new public symbols, types, enum
+4. **addition** → ``ADDITION_KINDS`` — new public symbols, types, enum
    members.  Default: ``info``.
 
 Each category can be set to ``error``, ``warning``, or ``info``:
@@ -50,7 +50,7 @@ Each category can be set to ``error``, ``warning``, or ``info``:
 Built-in presets:
 
 - ``default`` — abi_breaking=error, potential_breaking=warning,
-  quality_issues=warning, additions=info.
+  quality_issues=warning, addition=info.
 - ``strict`` — all categories set to error.
 - ``info-only`` — all categories set to info (purely informational report).
 """
@@ -86,7 +86,7 @@ class IssueCategory(str, Enum):
     ABI_BREAKING = "abi_breaking"
     POTENTIAL_BREAKING = "potential_breaking"
     QUALITY_ISSUES = "quality_issues"
-    ADDITIONS = "additions"
+    ADDITION = "addition"
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +111,7 @@ def classify_change(kind: ChangeKind) -> IssueCategory:
     if kind in API_BREAK_KINDS or kind in RISK_KINDS:
         return IssueCategory.POTENTIAL_BREAKING
     if kind in ADDITION_KINDS:
-        return IssueCategory.ADDITIONS
+        return IssueCategory.ADDITION
     if kind in QUALITY_KINDS:
         return IssueCategory.QUALITY_ISSUES
     # Fail-safe: unclassified kinds are treated as breaking.
@@ -131,13 +131,13 @@ class SeverityConfig:
         abi_breaking: Severity for clear ABI/API incompatibilities.
         potential_breaking: Severity for potential incompatibilities needing review.
         quality_issues: Severity for problematic behaviors (e.g., std symbol leaks).
-        additions: Severity for additive changes (new public API surface).
+        addition: Severity for additive changes (new public API surface).
     """
 
     abi_breaking: SeverityLevel = SeverityLevel.ERROR
     potential_breaking: SeverityLevel = SeverityLevel.WARNING
     quality_issues: SeverityLevel = SeverityLevel.WARNING
-    additions: SeverityLevel = SeverityLevel.INFO
+    addition: SeverityLevel = SeverityLevel.INFO
 
     def level_for(self, category: IssueCategory) -> SeverityLevel:
         """Return the configured severity level for *category*.
@@ -185,7 +185,7 @@ PRESET_STRICT = SeverityConfig(
     abi_breaking=SeverityLevel.ERROR,
     potential_breaking=SeverityLevel.ERROR,
     quality_issues=SeverityLevel.ERROR,
-    additions=SeverityLevel.ERROR,
+    addition=SeverityLevel.ERROR,
 )
 
 #: Info-only preset: everything is informational (no exit-code impact).
@@ -193,7 +193,7 @@ PRESET_INFO_ONLY = SeverityConfig(
     abi_breaking=SeverityLevel.INFO,
     potential_breaking=SeverityLevel.INFO,
     quality_issues=SeverityLevel.INFO,
-    additions=SeverityLevel.INFO,
+    addition=SeverityLevel.INFO,
 )
 
 SEVERITY_PRESETS: dict[str, SeverityConfig] = {
@@ -210,7 +210,7 @@ def resolve_severity_config(
     abi_breaking: str | None = None,
     potential_breaking: str | None = None,
     quality_issues: str | None = None,
-    additions: str | None = None,
+    addition: str | None = None,
 ) -> SeverityConfig:
     """Build a SeverityConfig from a preset name and optional per-category overrides.
 
@@ -221,7 +221,7 @@ def resolve_severity_config(
         abi_breaking: Override for the abi_breaking category (``error``, ``warning``, ``info``).
         potential_breaking: Override for potential_breaking.
         quality_issues: Override for quality_issues.
-        additions: Override for additions.
+        addition: Override for addition.
 
     Returns:
         A fully resolved SeverityConfig.
@@ -257,7 +257,7 @@ def resolve_severity_config(
             "potential_breaking", potential_breaking, base.potential_breaking
         ),
         quality_issues=_parse("quality_issues", quality_issues, base.quality_issues),
-        additions=_parse("additions", additions, base.additions),
+        addition=_parse("addition", addition, base.addition),
     )
 
 
@@ -289,7 +289,7 @@ _CATEGORY_EXIT_CODES: dict[IssueCategory, int] = {
     IssueCategory.ABI_BREAKING: 4,
     IssueCategory.POTENTIAL_BREAKING: 2,
     IssueCategory.QUALITY_ISSUES: 1,
-    IssueCategory.ADDITIONS: 1,
+    IssueCategory.ADDITION: 1,
 }
 
 
@@ -328,7 +328,7 @@ class CategorizedChanges:
     abi_breaking: list[HasKind]
     potential_breaking: list[HasKind]
     quality_issues: list[HasKind]
-    additions: list[HasKind]
+    addition: list[HasKind]
 
 
 def categorize_changes(changes: Sequence[HasKind]) -> CategorizedChanges:
@@ -353,5 +353,5 @@ def categorize_changes(changes: Sequence[HasKind]) -> CategorizedChanges:
         abi_breaking=abi,
         potential_breaking=potential,
         quality_issues=quality,
-        additions=adds,
+        addition=adds,
     )

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -101,6 +101,10 @@ def classify_change(kind: ChangeKind) -> IssueCategory:
 
     Uses the canonical kind sets from ``checker_policy`` directly.
     Unknown kinds default to ``ABI_BREAKING`` (fail-safe).
+
+    Note: ``ADDITION_KINDS`` and ``QUALITY_KINDS`` are disjoint by
+    construction (``QUALITY_KINDS = COMPATIBLE_KINDS - ADDITION_KINDS``),
+    so the check order between them does not matter.
     """
     if kind in BREAKING_KINDS:
         return IssueCategory.ABI_BREAKING
@@ -153,11 +157,18 @@ class SeverityConfig:
             self.level_for_kind(c.kind) == SeverityLevel.ERROR for c in changes
         )
 
-    def describe(self) -> str:
-        """Human-readable summary of this configuration."""
-        lines = []
+    def describe(self, *, prefix: str = "", title: str | None = None) -> str:
+        """Human-readable summary of this configuration.
+
+        Args:
+            prefix: String prepended to each line (e.g. indentation).
+            title: Optional title line printed before the category listing.
+        """
+        lines: list[str] = []
+        if title is not None:
+            lines.append(f"{prefix}{title}")
         for cat in IssueCategory:
-            lines.append(f"  {cat.value}: {self.level_for(cat).value}")
+            lines.append(f"{prefix}  {cat.value}: {self.level_for(cat).value}")
         return "\n".join(lines)
 
 
@@ -189,6 +200,7 @@ SEVERITY_PRESETS: dict[str, SeverityConfig] = {
     "default": PRESET_DEFAULT,
     "strict": PRESET_STRICT,
     "info-only": PRESET_INFO_ONLY,
+    "info_only": PRESET_INFO_ONLY,  # underscore alias for programmatic use
 }
 
 
@@ -253,11 +265,25 @@ def resolve_severity_config(
 # Exit code computation
 # ---------------------------------------------------------------------------
 
-# Severity-aware exit codes:
+# Severity-aware exit codes (used when any --severity-* flag is set):
+#
 #   0 — no error-level findings
 #   1 — error-level findings in additions or quality_issues only
 #   2 — error-level findings in potential_breaking (but not abi_breaking)
 #   4 — error-level findings in abi_breaking
+#
+# The highest applicable code wins (e.g. both abi_breaking=error and
+# quality_issues=error → exit 4).
+#
+# Note: exit codes 1 and 2 intentionally share a code between two
+# categories each (additions/quality_issues → 1, potential_breaking → 2).
+# Callers that need per-category granularity should inspect the JSON
+# ``severity.categories`` output instead of the exit code.
+#
+# These codes align with the legacy verdict-based exits (BREAKING → 4,
+# API_BREAK → 2) but are independent: the legacy path runs when no
+# --severity-* flag is provided.  The two paths are mutually exclusive
+# in cli.py.
 
 _CATEGORY_EXIT_CODES: dict[IssueCategory, int] = {
     IssueCategory.ABI_BREAKING: 4,
@@ -291,7 +317,13 @@ def compute_exit_code(
 
 @dataclass(frozen=True)
 class CategorizedChanges:
-    """Changes partitioned into the four issue categories."""
+    """Changes partitioned into the four issue categories.
+
+    Fields use ``list[HasKind]`` intentionally so that any object with a
+    ``.kind`` attribute can be categorized (e.g. ``Change``, ``AbiChange``,
+    or lightweight stubs in tests).  Callers that need full change objects
+    should cast the elements to the concrete type.
+    """
 
     abi_breaking: list[HasKind]
     potential_breaking: list[HasKind]

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Severity configuration for issue categories.
+
+Provides configurable criticality levels for four categories of ABI/API findings:
+
+1. **abi_breaking** — clear ABI/API incompatibilities (symbol removed, type layout
+   changed, etc.).  Default: ``error``.
+2. **potential_breaking** — potential incompatibilities that need manual review
+   (source-level API breaks, deployment risk).  Default: ``warning``.
+3. **quality_issues** — problematic behaviors such as exposing std symbols,
+   missing SONAME, toolchain flag drift.  Default: ``warning``.
+4. **additions** — new public symbols, types, enum members.  Default: ``info``.
+
+Each category can be set to ``error``, ``warning``, or ``info``:
+
+- ``error`` — flagged prominently in the report, contributes to non-zero exit code.
+- ``warning`` — shown as a warning in the report, does NOT affect exit code.
+- ``info`` — informational only, shown in the report but neutral.
+
+Built-in presets:
+
+- ``default`` — abi_breaking=error, potential_breaking=warning,
+  quality_issues=warning, additions=info.
+- ``strict`` — all categories set to error.
+- ``info-only`` — all categories set to info (purely informational report).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+from .checker_policy import (
+    API_BREAK_KINDS,
+    BREAKING_KINDS,
+    COMPATIBLE_KINDS,
+    RISK_KINDS,
+    ChangeKind,
+    HasKind,
+)
+
+
+class SeverityLevel(str, Enum):
+    """Criticality level for an issue category."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class IssueCategory(str, Enum):
+    """The four high-level issue categories."""
+
+    ABI_BREAKING = "abi_breaking"
+    POTENTIAL_BREAKING = "potential_breaking"
+    QUALITY_ISSUES = "quality_issues"
+    ADDITIONS = "additions"
+
+
+# ---------------------------------------------------------------------------
+# Change-kind -> IssueCategory classification
+# ---------------------------------------------------------------------------
+
+#: Kinds that are clear binary ABI / API incompatibilities.
+_ABI_BREAKING_KINDS: frozenset[ChangeKind] = frozenset(BREAKING_KINDS)
+
+#: Kinds that are potential incompatibilities requiring review
+#: (source-level breaks + deployment risk).
+_POTENTIAL_BREAKING_KINDS: frozenset[ChangeKind] = frozenset(
+    API_BREAK_KINDS | RISK_KINDS
+)
+
+#: Additive kinds — new API surface (subset of COMPATIBLE_KINDS).
+#: Explicitly enumerated to avoid false positives (e.g. FUNC_NOEXCEPT_ADDED
+#: is a qualifier change, not a new API addition).
+_ADDITION_KINDS: frozenset[ChangeKind] = frozenset({
+    ChangeKind.FUNC_ADDED,
+    ChangeKind.VAR_ADDED,
+    ChangeKind.TYPE_ADDED,
+    ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
+    ChangeKind.ENUM_MEMBER_ADDED,
+    ChangeKind.UNION_FIELD_ADDED,
+    ChangeKind.CONSTANT_ADDED,
+    ChangeKind.SYMBOL_VERSION_DEFINED_ADDED,
+    ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED_COMPAT,
+})
+
+#: Quality / behavioral issues — COMPATIBLE_KINDS that are NOT additions.
+_QUALITY_ISSUE_KINDS: frozenset[ChangeKind] = frozenset(
+    COMPATIBLE_KINDS - _ADDITION_KINDS
+)
+
+
+def classify_change(kind: ChangeKind) -> IssueCategory:
+    """Classify a ChangeKind into one of the four issue categories.
+
+    Classification is deterministic and uses the canonical kind sets from
+    ``checker_policy``.  Unknown kinds default to ``ABI_BREAKING`` (fail-safe).
+    """
+    if kind in _ABI_BREAKING_KINDS:
+        return IssueCategory.ABI_BREAKING
+    if kind in _POTENTIAL_BREAKING_KINDS:
+        return IssueCategory.POTENTIAL_BREAKING
+    if kind in _ADDITION_KINDS:
+        return IssueCategory.ADDITIONS
+    if kind in _QUALITY_ISSUE_KINDS:
+        return IssueCategory.QUALITY_ISSUES
+    # Fail-safe: unclassified kinds are treated as breaking.
+    return IssueCategory.ABI_BREAKING
+
+
+# ---------------------------------------------------------------------------
+# Severity configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SeverityConfig:
+    """Maps each issue category to a criticality level.
+
+    Attributes:
+        abi_breaking: Severity for clear ABI/API incompatibilities.
+        potential_breaking: Severity for potential incompatibilities needing review.
+        quality_issues: Severity for problematic behaviors (e.g., std symbol leaks).
+        additions: Severity for additive changes (new public API surface).
+    """
+
+    abi_breaking: SeverityLevel = SeverityLevel.ERROR
+    potential_breaking: SeverityLevel = SeverityLevel.WARNING
+    quality_issues: SeverityLevel = SeverityLevel.WARNING
+    additions: SeverityLevel = SeverityLevel.INFO
+
+    def level_for(self, category: IssueCategory) -> SeverityLevel:
+        """Return the configured severity level for *category*."""
+        return {
+            IssueCategory.ABI_BREAKING: self.abi_breaking,
+            IssueCategory.POTENTIAL_BREAKING: self.potential_breaking,
+            IssueCategory.QUALITY_ISSUES: self.quality_issues,
+            IssueCategory.ADDITIONS: self.additions,
+        }[category]
+
+    def level_for_kind(self, kind: ChangeKind) -> SeverityLevel:
+        """Return the configured severity level for a specific ChangeKind."""
+        return self.level_for(classify_change(kind))
+
+    def has_errors(self, changes: Sequence[HasKind]) -> bool:
+        """Return True if any change falls into a category configured as error."""
+        return any(
+            self.level_for_kind(c.kind) == SeverityLevel.ERROR for c in changes
+        )
+
+    def describe(self) -> str:
+        """Human-readable summary of this configuration."""
+        lines = []
+        for cat in IssueCategory:
+            lines.append(f"  {cat.value}: {self.level_for(cat).value}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Built-in presets
+# ---------------------------------------------------------------------------
+
+#: Default preset: breaks are errors, potential issues and quality are warnings,
+#: additions are informational.
+PRESET_DEFAULT = SeverityConfig()
+
+#: Strict preset: everything is an error.
+PRESET_STRICT = SeverityConfig(
+    abi_breaking=SeverityLevel.ERROR,
+    potential_breaking=SeverityLevel.ERROR,
+    quality_issues=SeverityLevel.ERROR,
+    additions=SeverityLevel.ERROR,
+)
+
+#: Info-only preset: everything is informational (no exit-code impact).
+PRESET_INFO_ONLY = SeverityConfig(
+    abi_breaking=SeverityLevel.INFO,
+    potential_breaking=SeverityLevel.INFO,
+    quality_issues=SeverityLevel.INFO,
+    additions=SeverityLevel.INFO,
+)
+
+SEVERITY_PRESETS: dict[str, SeverityConfig] = {
+    "default": PRESET_DEFAULT,
+    "strict": PRESET_STRICT,
+    "info-only": PRESET_INFO_ONLY,
+}
+
+
+def resolve_severity_config(
+    preset: str | None = None,
+    *,
+    abi_breaking: str | None = None,
+    potential_breaking: str | None = None,
+    quality_issues: str | None = None,
+    additions: str | None = None,
+) -> SeverityConfig:
+    """Build a SeverityConfig from a preset name and optional per-category overrides.
+
+    Per-category overrides take precedence over the preset.
+
+    Args:
+        preset: One of ``default``, ``strict``, ``info-only``, or *None* for default.
+        abi_breaking: Override for the abi_breaking category (``error``, ``warning``, ``info``).
+        potential_breaking: Override for potential_breaking.
+        quality_issues: Override for quality_issues.
+        additions: Override for additions.
+
+    Returns:
+        A fully resolved SeverityConfig.
+
+    Raises:
+        ValueError: If the preset name or any override value is invalid.
+    """
+    if preset is None:
+        base = PRESET_DEFAULT
+    else:
+        looked_up = SEVERITY_PRESETS.get(preset)
+        if looked_up is None:
+            raise ValueError(
+                f"Unknown severity preset {preset!r}. "
+                f"Valid presets: {sorted(SEVERITY_PRESETS)}"
+            )
+        base = looked_up
+
+    def _parse(name: str, raw: str | None, fallback: SeverityLevel) -> SeverityLevel:
+        if raw is None:
+            return fallback
+        try:
+            return SeverityLevel(raw.lower())
+        except ValueError:
+            raise ValueError(
+                f"Invalid severity level {raw!r} for {name}. "
+                f"Valid values: error, warning, info"
+            ) from None
+
+    return SeverityConfig(
+        abi_breaking=_parse("abi_breaking", abi_breaking, base.abi_breaking),
+        potential_breaking=_parse(
+            "potential_breaking", potential_breaking, base.potential_breaking
+        ),
+        quality_issues=_parse("quality_issues", quality_issues, base.quality_issues),
+        additions=_parse("additions", additions, base.additions),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exit code computation
+# ---------------------------------------------------------------------------
+
+# Severity-aware exit codes:
+#   0 — no error-level findings
+#   1 — error-level findings in additions or quality_issues only
+#   2 — error-level findings in potential_breaking (but not abi_breaking)
+#   4 — error-level findings in abi_breaking
+
+_CATEGORY_EXIT_CODES: dict[IssueCategory, int] = {
+    IssueCategory.ABI_BREAKING: 4,
+    IssueCategory.POTENTIAL_BREAKING: 2,
+    IssueCategory.QUALITY_ISSUES: 1,
+    IssueCategory.ADDITIONS: 1,
+}
+
+
+def compute_exit_code(
+    changes: Sequence[HasKind],
+    config: SeverityConfig,
+) -> int:
+    """Compute the process exit code based on severity configuration.
+
+    Returns the highest exit code among categories that have both:
+    - at least one finding, AND
+    - severity configured as ``error``.
+
+    Returns 0 if no category at error level has findings.
+    """
+    worst = 0
+    for change in changes:
+        cat = classify_change(change.kind)
+        if config.level_for(cat) == SeverityLevel.ERROR:
+            code = _CATEGORY_EXIT_CODES[cat]
+            if code > worst:
+                worst = code
+    return worst
+
+
+@dataclass(frozen=True)
+class CategorizedChanges:
+    """Changes partitioned into the four issue categories."""
+
+    abi_breaking: list[HasKind]
+    potential_breaking: list[HasKind]
+    quality_issues: list[HasKind]
+    additions: list[HasKind]
+
+
+def categorize_changes(changes: Sequence[HasKind]) -> CategorizedChanges:
+    """Partition changes into the four issue categories."""
+    abi: list[HasKind] = []
+    potential: list[HasKind] = []
+    quality: list[HasKind] = []
+    adds: list[HasKind] = []
+
+    for c in changes:
+        cat = classify_change(c.kind)
+        if cat == IssueCategory.ABI_BREAKING:
+            abi.append(c)
+        elif cat == IssueCategory.POTENTIAL_BREAKING:
+            potential.append(c)
+        elif cat == IssueCategory.QUALITY_ISSUES:
+            quality.append(c)
+        else:
+            adds.append(c)
+
+    return CategorizedChanges(
+        abi_breaking=abi,
+        potential_breaking=potential,
+        quality_issues=quality,
+        additions=adds,
+    )

--- a/action.yml
+++ b/action.yml
@@ -220,8 +220,8 @@ inputs:
     default: 'false'
   fail-on-additions:
     description: >
-      Fail the step (exit code 1) when any new public symbols, types, or fields were added.
-      Useful for detecting unintentional API expansion in PRs.
+      DEPRECATED: use severity-addition: error instead.
+      Translated to --severity-addition error internally.
     required: false
     default: 'false'
   add-job-summary:

--- a/action.yml
+++ b/action.yml
@@ -218,12 +218,20 @@ inputs:
     description: 'Fail the step when a source-level API break is detected (exit code 2).'
     required: false
     default: 'false'
-  fail-on-additions:
+  severity-preset:
     description: >
-      DEPRECATED: use severity-addition: error instead.
-      Translated to --severity-addition error internally.
+      Severity preset: 'default', 'strict', or 'info-only'.
+      Controls exit codes and report labels.
     required: false
-    default: 'false'
+  severity-addition:
+    description: >
+      Severity for new public API additions: 'error', 'warning', or 'info'.
+      Set to 'error' to fail the step when additions are detected.
+    required: false
+  extra-args:
+    description: 'Additional CLI arguments passed directly to the abicheck command.'
+    required: false
+    default: ''
   add-job-summary:
     description: 'Write a markdown summary to the GitHub Actions Job Summary.'
     required: false
@@ -307,7 +315,9 @@ runs:
         INPUT_LD_LIBRARY_PATH: ${{ inputs.ld-library-path }}
         INPUT_FAIL_ON_BREAKING: ${{ inputs.fail-on-breaking }}
         INPUT_FAIL_ON_API_BREAK: ${{ inputs.fail-on-api-break }}
-        INPUT_FAIL_ON_ADDITIONS: ${{ inputs.fail-on-additions }}
+        INPUT_SEVERITY_PRESET: ${{ inputs.severity-preset }}
+        INPUT_SEVERITY_ADDITION: ${{ inputs.severity-addition }}
+        INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
         INPUT_ADD_JOB_SUMMARY: ${{ inputs.add-job-summary }}
         INPUT_DEBUG_INFO1: ${{ inputs.debug-info1 }}
         INPUT_DEBUG_INFO2: ${{ inputs.debug-info2 }}

--- a/action/run.sh
+++ b/action/run.sh
@@ -97,9 +97,9 @@ elif [[ "$MODE" == "compare" ]]; then
   add_single_flag "--policy-file" "${INPUT_POLICY_FILE:-}"
   add_single_flag "--suppress" "${INPUT_SUPPRESS:-}"
 
-  # API addition detection
+  # API addition detection (legacy fail-on-additions → severity-addition error)
   if [[ "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
-    CMD+=(--fail-on-additions)
+    CMD+=(--severity-addition error)
   fi
 
   if [[ "${INPUT_FOLLOW_DEPS:-false}" == "true" ]]; then
@@ -204,7 +204,7 @@ elif [[ "$MODE" == "compare-release" ]]; then
     CMD+=(--fail-on-removed-library)
   fi
   if [[ "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
-    CMD+=(--fail-on-additions)
+    CMD+=(--severity-addition error)
   fi
 
 elif [[ "$MODE" == "deps" ]]; then
@@ -508,10 +508,8 @@ else
     FINAL_EXIT=1
   fi
 
-  if [[ "$VERDICT" == "ADDITIONS" && "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
-    echo "::error::API additions detected (unintentional API expansion). Set fail-on-additions: false to allow."
-    FINAL_EXIT=1
-  fi
+  # fail-on-additions is now handled by --severity-addition error at the CLI
+  # level, so no separate check is needed here.
 
   if [[ "$VERDICT" == "REMOVED_LIBRARY" ]]; then
     echo "::error::Library removed between old and new package. Set fail-on-removed-library: false to allow."

--- a/action/run.sh
+++ b/action/run.sh
@@ -97,10 +97,9 @@ elif [[ "$MODE" == "compare" ]]; then
   add_single_flag "--policy-file" "${INPUT_POLICY_FILE:-}"
   add_single_flag "--suppress" "${INPUT_SUPPRESS:-}"
 
-  # API addition detection (legacy fail-on-additions → severity-addition error)
-  if [[ "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
-    CMD+=(--severity-addition error)
-  fi
+  # Severity configuration
+  add_single_flag "--severity-preset" "${INPUT_SEVERITY_PRESET:-}"
+  add_single_flag "--severity-addition" "${INPUT_SEVERITY_ADDITION:-}"
 
   if [[ "${INPUT_FOLLOW_DEPS:-false}" == "true" ]]; then
     CMD+=(--follow-deps)
@@ -203,9 +202,6 @@ elif [[ "$MODE" == "compare-release" ]]; then
   if [[ "${INPUT_FAIL_ON_REMOVED_LIBRARY:-false}" == "true" ]]; then
     CMD+=(--fail-on-removed-library)
   fi
-  if [[ "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
-    CMD+=(--severity-addition error)
-  fi
 
 elif [[ "$MODE" == "deps" ]]; then
   # ── Deps mode (Linux ELF) ───────────────────────────────────────────────
@@ -254,6 +250,12 @@ fi
 # ---------------------------------------------------------------------------
 # Run abicheck
 # ---------------------------------------------------------------------------
+# Append extra-args (pass-through CLI arguments)
+if [[ -n "${INPUT_EXTRA_ARGS:-}" ]]; then
+  # shellcheck disable=SC2206
+  CMD+=($INPUT_EXTRA_ARGS)
+fi
+
 echo "::group::abicheck $MODE"
 echo "Command: ${CMD[*]}"
 echo ""
@@ -320,7 +322,7 @@ elif [[ "$MODE" == "deps" ]]; then
 
 elif [[ "$MODE" == "dump" ]]; then
   # dump exit codes: 0=success, anything else=error.
-  # dump never produces ADDITIONS/API_BREAK/BREAKING verdicts.
+  # dump never produces API_BREAK/BREAKING/SEVERITY_ERROR verdicts.
   if [[ $ABICHECK_EXIT -eq 0 ]]; then
     VERDICT="COMPATIBLE"
   else
@@ -348,7 +350,7 @@ else
           echo "::error::abicheck failed due to a CLI argument or configuration error (exit code 1)."
           echo "::error::Check the command and inputs above."
         else
-          VERDICT="ADDITIONS"
+          VERDICT="SEVERITY_ERROR"
         fi
         ;;
       2) VERDICT="API_BREAK" ;;
@@ -395,8 +397,8 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
           echo "> **Verdict: COMPATIBLE** — No binary ABI break detected."
         fi
         ;;
-      ADDITIONS)
-        echo "> **Verdict: ADDITIONS** ⚠️ — No binary ABI break, but new public API was added unexpectedly."
+      SEVERITY_ERROR)
+        echo "> **Verdict: SEVERITY_ERROR** ⚠️ — Severity-level issue detected (see severity configuration)."
         ;;
       API_BREAK)
         if [[ "$MODE" == "appcompat" ]]; then
@@ -508,10 +510,9 @@ else
     FINAL_EXIT=1
   fi
 
-  # fail-on-additions is handled by --severity-addition error at the CLI level.
-  # When the CLI exits 1 (severity-driven), propagate it as a step failure.
-  if [[ "$VERDICT" == "ADDITIONS" && "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
-    echo "::error::API additions detected (unintentional API expansion). Set fail-on-additions: false to allow."
+  # Severity-driven exit code 1 (from --severity-* flags)
+  if [[ "$VERDICT" == "SEVERITY_ERROR" ]]; then
+    echo "::error::Severity-level error detected by abicheck."
     FINAL_EXIT=1
   fi
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -508,8 +508,12 @@ else
     FINAL_EXIT=1
   fi
 
-  # fail-on-additions is now handled by --severity-addition error at the CLI
-  # level, so no separate check is needed here.
+  # fail-on-additions is handled by --severity-addition error at the CLI level.
+  # When the CLI exits 1 (severity-driven), propagate it as a step failure.
+  if [[ "$VERDICT" == "ADDITIONS" && "${INPUT_FAIL_ON_ADDITIONS:-false}" == "true" ]]; then
+    echo "::error::API additions detected (unintentional API expansion). Set fail-on-additions: false to allow."
+    FINAL_EXIT=1
+  fi
 
   if [[ "$VERDICT" == "REMOVED_LIBRARY" ]]; then
     echo "::error::Library removed between old and new package. Set fail-on-removed-library: false to allow."

--- a/docs/development/adr/002-multi-binary-release-compare.md
+++ b/docs/development/adr/002-multi-binary-release-compare.md
@@ -148,7 +148,7 @@ New inputs needed:
 | `new-library-dir` | Directory of new binaries |
 | `library-map` | YAML mapping file for non-trivial name changes |
 | `fail-on-removed-library` | Fail if a library disappeared |
-| `fail-on-additions` | **Deprecated** — translated to `--severity-addition error` |
+| `severity-preset` / `severity-addition` | Severity configuration for exit codes |
 | `output-dir` | Per-library report output directory |
 
 Example:

--- a/docs/development/adr/002-multi-binary-release-compare.md
+++ b/docs/development/adr/002-multi-binary-release-compare.md
@@ -131,7 +131,7 @@ abicheck compare-release release-1.0/ release-2.0/ -H include/ \
 | Code | Meaning |
 |------|---------|
 | 0 | All libraries: NO_CHANGE or COMPATIBLE |
-| 1 | ADDITIONS (only when --fail-on-additions) |
+| 1 | Severity-driven error (with `--severity-*` flags) |
 | 2 | At least one: API_BREAK |
 | 4 | At least one: BREAKING |
 | 8 | Missing/unmatched libraries (only when --fail-on-removed-library) |
@@ -148,7 +148,7 @@ New inputs needed:
 | `new-library-dir` | Directory of new binaries |
 | `library-map` | YAML mapping file for non-trivial name changes |
 | `fail-on-removed-library` | Fail if a library disappeared |
-| `fail-on-additions` | Fail if compatible additions are detected |
+| `fail-on-additions` | **Deprecated** — translated to `--severity-addition error` |
 | `output-dir` | Per-library report output directory |
 
 Example:

--- a/docs/development/adr/009-verdict-system-and-exit-codes.md
+++ b/docs/development/adr/009-verdict-system-and-exit-codes.md
@@ -153,10 +153,14 @@ Display filtering is cosmetic; exit codes are authoritative.
   COMPATIBLE_WITH_RISK, or parse JSON output for `risk_count > 0`. The
   `plugin_abi` policy profile (ADR-010) promotes all RISK_KINDS to BREAKING
   automatically
-- Exit code 1 is overloaded: `--fail-on-additions` in `compare`, BREAKING in
-  `compat`. Disambiguation: scripts must know which command they invoked.
-  The `compare` command never returns exit code 1 without `--fail-on-additions`.
-  The `compat` command never returns exit code 4 (uses 1 for BREAKING instead)
+- Exit code 1 is overloaded: severity-driven errors in `compare` (with
+  `--severity-*` flags), BREAKING in `compat`. Disambiguation: scripts must
+  know which command they invoked. The `compare` command returns exit code 1
+  only when the severity system is active and `addition` or `quality_issues`
+  are at error level. The `compat` command never returns exit code 4 (uses 1
+  for BREAKING instead).
+  See [severity guide](../../user-guide/severity.md) for the four-category
+  severity model that supersedes `--fail-on-additions`
 
 ---
 

--- a/docs/development/adr/009-verdict-system-and-exit-codes.md
+++ b/docs/development/adr/009-verdict-system-and-exit-codes.md
@@ -70,7 +70,7 @@ equivalent. It captures cases like:
 | **0** | NO_CHANGE, COMPATIBLE, COMPATIBLE_WITH_RISK | Binary-compatible — safe to deploy |
 | **2** | API_BREAK | Source-level break only |
 | **4** | BREAKING | Binary ABI break |
-| **1** | (conditional) | Only when `--fail-on-additions` is set and additions are detected |
+| **1** | (severity-driven) | When `--severity-*` flags cause error-level findings in `addition` or `quality_issues` |
 
 Exit codes use powers of 2 for clear separation of severity tiers.
 

--- a/docs/development/adr/017-github-action.md
+++ b/docs/development/adr/017-github-action.md
@@ -74,7 +74,7 @@ is a supported alternative.
 
 | Output | Description |
 |--------|-------------|
-| `verdict` | NO_CHANGE, COMPATIBLE, COMPATIBLE_WITH_RISK, API_BREAK, BREAKING, SEVERITY_ERROR, ERROR (see ADR-009 for the 5-tier system). For `stack-check`: PASS, WARN, FAIL. SEVERITY_ERROR is emitted when the severity system (via `--severity-*` flags) causes a non-zero exit code 1. |
+| `verdict` | COMPATIBLE, API_BREAK, BREAKING, SEVERITY_ERROR, REMOVED_LIBRARY, ERROR (see ADR-009 for the 5-tier system). For `stack-check`: PASS, WARN, FAIL. SEVERITY_ERROR is emitted when the severity system (via `--severity-*` flags) causes a non-zero exit code 1. |
 | `exit-code` | abicheck numeric exit code |
 | `report-path` | Path to generated report file |
 

--- a/docs/development/adr/017-github-action.md
+++ b/docs/development/adr/017-github-action.md
@@ -65,14 +65,16 @@ is a supported alternative.
 | `format` | Output: markdown, json, sarif, html | `markdown` |
 | `policy` / `policy-file` | Built-in or custom policy | `strict_abi` |
 | `suppress` | YAML suppression file | — |
-| `fail-on-breaking` / `fail-on-api-break` / `fail-on-additions` | Exit code flags | — |
+| `fail-on-breaking` / `fail-on-api-break` | Exit code flags | — |
+| `severity-preset` / `severity-addition` | Severity configuration | — |
+| `extra-args` | Additional CLI arguments | `''` |
 | `install-deps` | Install castxml + gcc automatically | `true` |
 
 ### Output variables
 
 | Output | Description |
 |--------|-------------|
-| `verdict` | NO_CHANGE, COMPATIBLE, COMPATIBLE_WITH_RISK, API_BREAK, BREAKING, ERROR (see ADR-009 for the 5-tier system). For `stack-check`: PASS, WARN, FAIL. Note: the action maps exit code 1 with `--fail-on-additions` to verdict string `ADDITIONS` for scripting convenience, but this is not a formal verdict tier. |
+| `verdict` | NO_CHANGE, COMPATIBLE, COMPATIBLE_WITH_RISK, API_BREAK, BREAKING, SEVERITY_ERROR, ERROR (see ADR-009 for the 5-tier system). For `stack-check`: PASS, WARN, FAIL. SEVERITY_ERROR is emitted when the severity system (via `--severity-*` flags) causes a non-zero exit code 1. |
 | `exit-code` | abicheck numeric exit code |
 | `report-path` | Path to generated report file |
 

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -8,47 +8,77 @@
 
 ## `abicheck compare`
 
+### Legacy exit codes (default, no `--severity-*` flags)
+
 | Exit code | Meaning |
 |-----------|---------|
 | `0` | `NO_CHANGE`, `COMPATIBLE`, or `COMPATIBLE_WITH_RISK` — no binary ABI break |
-| `1` | `ADDITIONS` — new public symbols/types detected (**only with `--fail-on-additions`**; without the flag, additions exit `0`) |
 | `2` | `API_BREAK` — source-level API break — recompilation required |
 | `4` | `BREAKING` — binary ABI break |
 
 > **⚠️ Exit `0` covers `NO_CHANGE`, `COMPATIBLE`, and `COMPATIBLE_WITH_RISK`.** If your pipeline needs
 > to distinguish them (e.g. warn on deployment risk), use `--format json` and
 > read the `verdict` field — exit code alone is not sufficient.
->
-> **ℹ️ Exit `1` (ADDITIONS)** is only produced when `--fail-on-additions` is passed.
-> Without that flag, API additions are reported as `COMPATIBLE` with exit code `0`.
+
+### Severity-aware exit codes (with any `--severity-*` flag)
+
+When any `--severity-preset` or `--severity-*` option is provided, the exit code
+is computed from the severity configuration rather than the verdict:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No error-level findings |
+| `1` | Error-level findings in `addition` or `quality_issues` only |
+| `2` | Error-level findings in `potential_breaking` (but not `abi_breaking`) |
+| `4` | Error-level findings in `abi_breaking` |
+
+The highest applicable code wins. For example, if both `abi_breaking=error` and
+`quality_issues=error` have findings, the exit code is `4`.
+
+> **ℹ️ The two exit code paths are mutually exclusive.** Without `--severity-*`
+> flags, the legacy verdict-based path runs. With any `--severity-*` flag, the
+> severity-aware path runs. They never both execute.
+
+### Severity presets
+
+| Preset | `abi_breaking` | `potential_breaking` | `quality_issues` | `addition` |
+|--------|---------------|---------------------|------------------|-----------|
+| `default` | error | warning | warning | info |
+| `strict` | error | error | error | error |
+| `info-only` | info | info | info | info |
+
+Per-category overrides (`--severity-abi-breaking`, `--severity-potential-breaking`,
+`--severity-quality-issues`, `--severity-addition`) take precedence over the preset.
 
 ### CI gate patterns
 
 ```bash
-# Production gate: fail on any break
+# Production gate: fail on any break (legacy exit codes)
 abicheck compare old.json new.json
 ret=$?
 [ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
 [ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
 echo "OK (NO_CHANGE or COMPATIBLE)"
 
-# With --fail-on-additions: also block unexpected API expansion
-abicheck compare old.json new.json --fail-on-additions
+# Block unexpected API expansion (severity-aware)
+abicheck compare old.json new.json --severity-addition error
 ret=$?
-[ $ret -eq 1 ] && echo "ADDITIONS — unexpected API expansion" && exit 1   # only with --fail-on-additions
+[ $ret -eq 1 ] && echo "ADDITIONS — unexpected API expansion" && exit 1
 [ $ret -eq 4 ] && echo "BREAKING — release blocked" && exit 1
 [ $ret -eq 2 ] && echo "API_BREAK — source-level break" && exit 1
 echo "OK"
 
-# Permissive gate: fail only on binary breaks (allow API_BREAK + COMPATIBLE)
+# Strict mode: all categories at error level
+abicheck compare old.json new.json --severity-preset strict
+
+# Permissive gate: fail only on binary breaks
 abicheck compare old.json new.json
 ret=$?
 [ $ret -eq 4 ] && exit 1   # BREAKING only; API_BREAK (exit 2) allowed
 exit 0
-# note: exit 0 includes both NO_CHANGE and COMPATIBLE
 
-# Parse exact verdict from JSON
-abicheck compare old.json new.json --format json -o result.json
+# Parse exact verdict from JSON (with severity info)
+abicheck compare old.json new.json --format json --severity-preset default -o result.json
 verdict=$(python3 -c "import json,sys; d=json.load(open('result.json')); print(d['verdict'])" \
   || { echo "ERROR parsing result.json"; exit 1; })
 [ "$verdict" = "BREAKING" ] && exit 1
@@ -143,24 +173,25 @@ In `abicheck compat`, non-verdict failures are further classified where possible
 
 ## Summary table
 
-| Verdict / State | `compare` exit | `appcompat` exit | `deps` exit | `stack-check` exit | `compat` exit |
-|-----------------|---------------|-----------------|-------------|-------------------|---------------|
-| `NO_CHANGE` / `PASS` | `0` | `0` | `0` | `0` | `0` |
-| `COMPATIBLE` | `0` | `0` | — | — | `0` |
-| `COMPATIBLE_WITH_RISK` | `0` | `0` | — | — | `0` |
-| `ADDITIONS` (with `--fail-on-additions`) | `1` | n/a | — | — | n/a |
-| `WARN` (ABI risk) | — | — | — | `1` | — |
-| `API_BREAK` | `2` | `2` | — | — | `2` |
-| `BREAKING` / `FAIL` | `4` | `4` | — | `4` | `1` |
-| Load failure | — | — | `1` | `4` | — |
-| Tool error | `1/2`* | `1` | — | — | `3/4/5/6/7/8/10/11` |
+| Verdict / State | `compare` exit (legacy) | `compare` exit (severity) | `appcompat` exit | `deps` exit | `stack-check` exit | `compat` exit |
+|-----------------|------------------------|--------------------------|-----------------|-------------|-------------------|---------------|
+| `NO_CHANGE` / `PASS` | `0` | `0` | `0` | `0` | `0` | `0` |
+| `COMPATIBLE` | `0` | `0` | `0` | — | — | `0` |
+| `COMPATIBLE_WITH_RISK` | `0` | `0`–`2`* | `0` | — | — | `0` |
+| Additions only | `0` | `0`–`1`* | n/a | — | — | n/a |
+| Quality issues only | `0` | `0`–`1`* | n/a | — | — | n/a |
+| `WARN` (ABI risk) | — | — | — | — | `1` | — |
+| `API_BREAK` | `2` | `0`–`2`* | `2` | — | — | `2` |
+| `BREAKING` / `FAIL` | `4` | `4` | `4` | — | `4` | `1` |
+| Load failure | — | — | — | `1` | `4` | — |
+| Tool error | `2`† | `2`† | `1` | — | — | `3/4/5/6/7/8/10/11` |
 
-\* For `compare`, exit `1` without `--fail-on-additions` is a tool/CLI error.
-With `--fail-on-additions`, exit `1` can indicate `ADDITIONS` but may also occur
-for non-verdict failures. Exit `2` can also represent a CLI/configuration error
-(Click uses exit code 2 for argument/usage errors), not just `API_BREAK`. To
-reliably distinguish verdicts from tool errors, use `--format json` and read the
-`verdict` field as the authoritative discriminator.
+\* Severity exit codes depend on the configuration. For example, with
+`--severity-addition error`, additions exit `1`; with `--severity-preset
+info-only`, everything exits `0`.
+
+† Click uses exit code `2` for argument/usage errors. To reliably distinguish
+verdicts from tool errors, use `--format json` and read the `verdict` field.
 
 ---
 

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -146,6 +146,28 @@ abicheck compare old.json new.json --show-only breaking,risk
 
 Invalid tokens are caught immediately with a clear error message.
 
+#### Severity configuration (`--severity-*`)
+
+Control exit codes and report labels by assigning severity levels to four issue
+categories:
+
+```bash
+# Block on API additions
+abicheck compare old.json new.json --severity-addition error
+
+# Everything is an error (strict)
+abicheck compare old.json new.json --severity-preset strict
+
+# Custom: breaks are errors, additions are warnings, rest is info
+abicheck compare old.json new.json \
+  --severity-abi-breaking error \
+  --severity-potential-breaking info \
+  --severity-quality-issues info \
+  --severity-addition warning
+```
+
+See the [severity guide](severity.md) for the full reference.
+
 #### `--stat`: one-line CI summary
 
 ```bash

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -92,7 +92,7 @@ automatically, then runs ABI comparison and reports results.
 | `upload-sarif` | `false` | Upload SARIF to GitHub Code Scanning |
 | `fail-on-breaking` | `true` | Fail step on binary ABI break |
 | `fail-on-api-break` | `false` | Fail step on source-level API break |
-| `fail-on-additions` | `false` | Fail step when new public symbols/types are added (detects unintentional API expansion) |
+| `fail-on-additions` | `false` | **Deprecated**: translated to `--severity-addition error` internally. Use the severity system instead. |
 | `add-job-summary` | `true` | Write summary to Job Summary panel |
 
 ### Package comparison inputs (compare-release mode)

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -92,7 +92,9 @@ automatically, then runs ABI comparison and reports results.
 | `upload-sarif` | `false` | Upload SARIF to GitHub Code Scanning |
 | `fail-on-breaking` | `true` | Fail step on binary ABI break |
 | `fail-on-api-break` | `false` | Fail step on source-level API break |
-| `fail-on-additions` | `false` | **Deprecated**: translated to `--severity-addition error` internally. Use the severity system instead. |
+| `severity-preset` | — | Severity preset: `default`, `strict`, or `info-only` |
+| `severity-addition` | — | Severity for additions: `error`, `warning`, or `info` |
+| `extra-args` | `''` | Additional CLI arguments passed to abicheck |
 | `add-job-summary` | `true` | Write summary to Job Summary panel |
 
 ### Package comparison inputs (compare-release mode)
@@ -112,8 +114,8 @@ automatically, then runs ABI comparison and reports results.
 
 | Output | Description |
 |--------|-------------|
-| `verdict` | **compare/dump:** `COMPATIBLE`, `ADDITIONS`, `API_BREAK`, `BREAKING`, or `ERROR`. **stack-check:** `PASS`, `WARN`, `FAIL`, or `ERROR`. **deps:** `PASS`, `FAIL`, or `ERROR`. |
-| `exit-code` | **compare:** `0` (compatible), `1` (additions), `2` (API break), `4` (ABI break). **stack-check:** `0` (pass), `1` (warn), `4` (fail). **deps:** `0` (ok), `1` (missing). |
+| `verdict` | **compare/dump:** `COMPATIBLE`, `SEVERITY_ERROR`, `API_BREAK`, `BREAKING`, or `ERROR`. **stack-check:** `PASS`, `WARN`, `FAIL`, or `ERROR`. **deps:** `PASS`, `FAIL`, or `ERROR`. |
+| `exit-code` | **compare:** `0` (compatible), `1` (severity error), `2` (API break), `4` (ABI break). **stack-check:** `0` (pass), `1` (warn), `4` (fail). **deps:** `0` (ok), `1` (missing). |
 | `report-path` | Path to the generated report file (empty when no output file was produced) |
 
 ## Usage examples
@@ -437,11 +439,11 @@ Block PRs that accidentally add new public symbols or types:
           new-library: build/libfoo.so
           new-header: include/foo.h
           fail-on-breaking: true
-          fail-on-additions: true   # exit code 1 if any new public API appears
+          severity-addition: error   # exit code 1 if any new public API appears
 ```
 
-When `fail-on-additions: true`:
-- Exit code `1` → new public symbol/type added (`verdict: ADDITIONS`)
+When `severity-addition: error`:
+- Exit code `1` → new public symbol/type added (`verdict: SEVERITY_ERROR`)
 - Exit code `0` → no additions, no breaks (`verdict: COMPATIBLE`)
 - Exit code `4` → binary ABI break (`verdict: BREAKING`)
 

--- a/docs/user-guide/severity.md
+++ b/docs/user-guide/severity.md
@@ -135,17 +135,25 @@ accordingly.
 This means `--policy sdk_vendor --severity-preset strict` will **not** exit
 non-zero for changes that the `sdk_vendor` policy explicitly accepts.
 
-## Migrating from `--fail-on-additions`
+## GitHub Action
 
-The `--fail-on-additions` flag has been removed. Use the severity system instead:
+The GitHub Action supports severity configuration via inputs:
 
-```bash
-# Old (removed)
-abicheck compare old.json new.json --fail-on-additions
-
-# New (equivalent)
-abicheck compare old.json new.json --severity-addition error
+```yaml
+- uses: napetrov/abicheck@v1
+  with:
+    old-library: libfoo-v1.json
+    new-library: libfoo-v2.json
+    severity-addition: error        # fail on new API additions
+    # severity-preset: strict       # or use a preset
 ```
 
-The GitHub Action's `fail-on-additions: true` input is automatically translated
-to `--severity-addition error` for backward compatibility.
+For arbitrary `--severity-*` overrides not exposed as inputs, use `extra-args`:
+
+```yaml
+- uses: napetrov/abicheck@v1
+  with:
+    old-library: libfoo-v1.json
+    new-library: libfoo-v2.json
+    extra-args: '--severity-quality-issues error --severity-potential-breaking info'
+```

--- a/docs/user-guide/severity.md
+++ b/docs/user-guide/severity.md
@@ -132,8 +132,13 @@ under `sdk_vendor`, kinds that are downgraded from `API_BREAK` to `COMPATIBLE`
 are reclassified from `potential_breaking` to `quality_issues` or `addition`
 accordingly.
 
-This means `--policy sdk_vendor --severity-preset strict` will **not** exit
-non-zero for changes that the `sdk_vendor` policy explicitly accepts.
+This means `--policy sdk_vendor --severity-preset default` will **not** exit
+non-zero for changes that the `sdk_vendor` policy downgrades — for example,
+kinds moved from `potential_breaking` to `quality_issues` or `addition` are
+demoted to `warning` or `info` under the `default` preset. However, the
+`strict` preset maps **all** categories (including `quality_issues` and
+`addition`) to `error`, so `--policy sdk_vendor --severity-preset strict` will
+still exit non-zero for any detected changes, even those the policy downgrades.
 
 ## GitHub Action
 

--- a/docs/user-guide/severity.md
+++ b/docs/user-guide/severity.md
@@ -1,0 +1,151 @@
+# Severity Configuration
+
+abicheck classifies every detected change into one of four **issue categories**,
+each with a configurable severity level that controls exit codes and report
+presentation.
+
+---
+
+## Issue categories
+
+Every `ChangeKind` is assigned to exactly one of these categories:
+
+| Category | What it covers | Default severity |
+|----------|---------------|------------------|
+| **abi_breaking** | Clear ABI/API incompatibilities (e.g. `func_removed`, `type_size_changed`) | `error` |
+| **potential_breaking** | Source-level breaks and deployment risk (e.g. `enum_member_renamed`, `symbol_version_required_added`) | `warning` |
+| **quality_issues** | Problematic behaviors that don't break compatibility (e.g. `visibility_leak`, `soname_missing`, `func_noexcept_added`) | `warning` |
+| **addition** | New public API surface (e.g. `func_added`, `type_added`, `enum_member_added`) | `info` |
+
+The category assignment is based on canonical kind sets defined in
+`checker_policy.py` and respects the active `--policy` (e.g. `sdk_vendor`
+downgrades `enum_member_renamed` from `potential_breaking` to `quality_issues`).
+
+## Severity levels
+
+Each category can be set to one of three levels:
+
+| Level | Report presentation | Exit code impact |
+|-------|-------------------|------------------|
+| `error` | Flagged prominently with badge | Contributes to non-zero exit code |
+| `warning` | Shown as a warning with badge | Does **not** affect exit code |
+| `info` | Informational, neutral | Does **not** affect exit code |
+
+## CLI options
+
+### Presets
+
+```bash
+# Use the default preset (explicit)
+abicheck compare old.json new.json --severity-preset default
+
+# Strict: everything is an error (exits non-zero on any finding)
+abicheck compare old.json new.json --severity-preset strict
+
+# Info-only: purely informational (always exits 0)
+abicheck compare old.json new.json --severity-preset info-only
+```
+
+### Per-category overrides
+
+Override individual categories on top of a preset:
+
+```bash
+# Default preset but fail on API additions too
+abicheck compare old.json new.json --severity-addition error
+
+# Strict preset but ignore quality issues
+abicheck compare old.json new.json --severity-preset strict --severity-quality-issues info
+
+# Only fail on binary ABI breaks, everything else informational
+abicheck compare old.json new.json --severity-preset info-only --severity-abi-breaking error
+```
+
+Available flags:
+- `--severity-abi-breaking {error,warning,info}`
+- `--severity-potential-breaking {error,warning,info}`
+- `--severity-quality-issues {error,warning,info}`
+- `--severity-addition {error,warning,info}`
+
+### Presets reference
+
+| Preset | `abi_breaking` | `potential_breaking` | `quality_issues` | `addition` |
+|--------|---------------|---------------------|------------------|-----------|
+| `default` | error | warning | warning | info |
+| `strict` | error | error | error | error |
+| `info-only` | info | info | info | info |
+
+## Exit codes
+
+When any `--severity-*` flag is provided, the exit code is computed from the
+severity configuration instead of the legacy verdict system:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No error-level findings |
+| `1` | Error-level findings in `addition` or `quality_issues` only |
+| `2` | Error-level findings in `potential_breaking` (but not `abi_breaking`) |
+| `4` | Error-level findings in `abi_breaking` |
+
+The highest applicable code wins. Without any `--severity-*` flag, the legacy
+verdict-based exit codes apply (see [exit codes reference](../reference/exit-codes.md)).
+
+## Report output
+
+### Markdown
+
+When severity is configured, the markdown report includes:
+
+1. **Severity Configuration table** — shows the configured level, finding count,
+   and exit impact for each category.
+2. **Section badges** — each change section header includes the severity level
+   badge (e.g. `## ❌ Breaking Changes ❌ \`ERROR\``).
+
+### JSON
+
+The JSON output includes a `severity` object when severity is configured:
+
+```json
+{
+  "severity": {
+    "config": {
+      "abi_breaking": "error",
+      "potential_breaking": "warning",
+      "quality_issues": "warning",
+      "addition": "info"
+    },
+    "categories": {
+      "abi_breaking": {"severity": "error", "count": 2},
+      "potential_breaking": {"severity": "warning", "count": 1},
+      "quality_issues": {"severity": "warning", "count": 0},
+      "addition": {"severity": "info", "count": 3}
+    },
+    "exit_code": 4
+  }
+}
+```
+
+## Policy interaction
+
+The severity system respects the active policy (`--policy`). For example,
+under `sdk_vendor`, kinds that are downgraded from `API_BREAK` to `COMPATIBLE`
+are reclassified from `potential_breaking` to `quality_issues` or `addition`
+accordingly.
+
+This means `--policy sdk_vendor --severity-preset strict` will **not** exit
+non-zero for changes that the `sdk_vendor` policy explicitly accepts.
+
+## Migrating from `--fail-on-additions`
+
+The `--fail-on-additions` flag has been removed. Use the severity system instead:
+
+```bash
+# Old (removed)
+abicheck compare old.json new.json --fail-on-additions
+
+# New (equivalent)
+abicheck compare old.json new.json --severity-addition error
+```
+
+The GitHub Action's `fail-on-additions: true` input is automatically translated
+to `--severity-addition error` for backward compatibility.

--- a/scripts/demo_libz.py
+++ b/scripts/demo_libz.py
@@ -91,7 +91,7 @@ def main() -> None:
         result = compare(snap_v1, snap_v2)
         print(f"  Verdict : {result.verdict.value}")
         print(f"  Breaking: {len(result.breaking)}")
-        print(f"  Compatible additions: {len(result.compatible)}")
+        print(f"  Compatible changes: {len(result.compatible)}")
         for c in result.changes:
             print(f"  [{c.kind.value}] {c.description}")
 

--- a/tests/golden/compatible_addition.md
+++ b/tests/golden/compatible_addition.md
@@ -10,7 +10,7 @@
 | Deployment risk changes | 0 |
 | Compatible additions | 1 |
 
-## ✅ Compatible Changes
+## ✅ Additions
 
 - New public function: helper
 

--- a/tests/golden/compatible_addition.md
+++ b/tests/golden/compatible_addition.md
@@ -8,7 +8,7 @@
 | Breaking changes | 0 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 0 |
-| Compatible additions | 1 |
+| Compatible changes | 1 |
 
 ## ✅ Additions
 

--- a/tests/golden/compatible_with_risk.md
+++ b/tests/golden/compatible_with_risk.md
@@ -8,7 +8,7 @@
 | Breaking changes | 0 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 1 |
-| Compatible additions | 0 |
+| Compatible changes | 0 |
 
 ## ⚠️ Deployment Risk Changes
 

--- a/tests/golden/enum_change.md
+++ b/tests/golden/enum_change.md
@@ -8,7 +8,7 @@
 | Breaking changes | 1 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 0 |
-| Compatible additions | 0 |
+| Compatible changes | 0 |
 
 ## ❌ Breaking Changes
 

--- a/tests/golden/func_removed.md
+++ b/tests/golden/func_removed.md
@@ -8,7 +8,7 @@
 | Breaking changes | 1 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 0 |
-| Compatible additions | 0 |
+| Compatible changes | 0 |
 
 ## ❌ Breaking Changes
 

--- a/tests/golden/leaked_dependency_symbol.md
+++ b/tests/golden/leaked_dependency_symbol.md
@@ -8,7 +8,7 @@
 | Breaking changes | 0 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 1 |
-| Compatible additions | 0 |
+| Compatible changes | 0 |
 
 ## ⚠️ Deployment Risk Changes
 

--- a/tests/golden/no_change.md
+++ b/tests/golden/no_change.md
@@ -8,7 +8,7 @@
 | Breaking changes | 0 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 0 |
-| Compatible additions | 0 |
+| Compatible changes | 0 |
 
 _No ABI changes detected._
 ---

--- a/tests/golden/struct_size_change.md
+++ b/tests/golden/struct_size_change.md
@@ -15,7 +15,7 @@
 - **type_size_changed**: Size changed: Point (64 → 96 bits) (`64` → `96`)
   > Old code allocates or copies the type with the old size; heap/stack corruption, out-of-bounds access.
 
-## ✅ Compatible Changes
+## ✅ Additions
 
 - Field added: Point::z
 

--- a/tests/golden/struct_size_change.md
+++ b/tests/golden/struct_size_change.md
@@ -8,7 +8,7 @@
 | Breaking changes | 1 |
 | Source-level breaks | 0 |
 | Deployment risk changes | 0 |
-| Compatible additions | 1 |
+| Compatible changes | 1 |
 
 ## ❌ Breaking Changes
 

--- a/tests/test_checker_reporter_branches.py
+++ b/tests/test_checker_reporter_branches.py
@@ -785,7 +785,7 @@ class TestToMarkdownBranches:
         c = Change(kind=ChangeKind.FUNC_ADDED, symbol="new_fn", description="new_fn added")
         result = _make_diff(changes=[c], verdict=Verdict.COMPATIBLE)
         out = to_markdown(result)
-        assert "Compatible Changes" in out
+        assert "Additions" in out
 
     def test_to_markdown_source_breaks_section(self):
         """Exercise source-level breaks section."""

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -440,7 +440,7 @@ class TestCompareExitCodeDocs:
         runner = CliRunner()
         result = runner.invoke(main, ["compare", "--help"])
         assert result.exit_code == 0
-        assert "Exit codes:" in result.output
+        assert "Exit codes" in result.output
         assert "0" in result.output
         assert "BREAKING" in result.output
 

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -351,62 +351,18 @@ class TestCompatClassifiedErrorPaths:
         assert "write" in result.output.lower() or "report" in result.output.lower()
 
 
-class TestFailOnAdditions:
-    """Tests for --fail-on-additions flag in compare command."""
+class TestNoFailOnAdditionsFlag:
+    """Verify --fail-on-additions was removed (use --severity-addition error instead)."""
 
-    def _make_snapshot(self, tmp_path: Path, name: str, funcs: list[str]) -> Path:
-        """Create a minimal JSON snapshot with the given function names."""
+    def test_fail_on_additions_flag_rejected(self, tmp_path: Path) -> None:
+        """--fail-on-additions should no longer be recognized by the CLI."""
         snap = {
-            "library": "libtest.so",
-            "version": "1.0",
-            "platform": "elf",
-            "functions": [
-                {
-                    "name": fn,
-                    "mangled": f"_Z{len(fn)}{fn}v",
-                    "return_type": "void",
-                    "visibility": "public",
-                    "is_extern_c": False,
-                    "params": [],
-                }
-                for fn in funcs
-            ],
-            "variables": [],
-            "types": [],
-            "enums": [],
-            "typedefs": {},
+            "library": "libtest.so", "version": "1.0", "platform": "elf",
+            "functions": [], "variables": [], "types": [], "enums": [], "typedefs": {},
         }
-        p = tmp_path / f"{name}.json"
+        p = tmp_path / "snap.json"
         p.write_text(json.dumps(snap), encoding="utf-8")
-        return p
-
-    def test_fail_on_additions_exits_1_when_function_added(self, tmp_path: Path) -> None:
-        """--fail-on-additions: new public function → exit code 1."""
-
-        old = self._make_snapshot(tmp_path, "old", ["foo"])
-        new = self._make_snapshot(tmp_path, "new", ["foo", "bar"])
 
         runner = CliRunner()
-        result = runner.invoke(main, ["compare", str(old), str(new), "--fail-on-additions"])
-        assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}"
-        assert "addition" in result.output.lower() or "addition" in (result.stderr or "").lower()
-
-    def test_fail_on_additions_exits_0_when_no_additions(self, tmp_path: Path) -> None:
-        """--fail-on-additions: no additions → exit code 0."""
-
-        snap = self._make_snapshot(tmp_path, "snap", ["foo", "bar"])
-
-        runner = CliRunner()
-        result = runner.invoke(main, ["compare", str(snap), str(snap), "--fail-on-additions"])
-        assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}"
-
-    def test_no_fail_on_additions_by_default(self, tmp_path: Path) -> None:
-        """Without --fail-on-additions: new function → exit code 0 (COMPATIBLE)."""
-
-        old = self._make_snapshot(tmp_path, "old", ["foo"])
-        new = self._make_snapshot(tmp_path, "new", ["foo", "bar"])
-
-        runner = CliRunner()
-        result = runner.invoke(main, ["compare", str(old), str(new)])
-        assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}"
-        assert "COMPATIBLE" in result.output
+        result = runner.invoke(main, ["compare", str(p), str(p), "--fail-on-additions"])
+        assert result.exit_code == 2  # Click returns 2 for unrecognised options

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -160,7 +160,7 @@ class TestSeverityJson:
         sev = d["severity"]
         assert "config" in sev
         assert sev["config"]["abi_breaking"] == "error"
-        assert sev["config"]["additions"] == "info"
+        assert sev["config"]["addition"] == "info"
         assert "categories" in sev
         assert sev["categories"]["abi_breaking"]["count"] == 1
 
@@ -191,6 +191,6 @@ class TestSeverityJson:
         d = json.loads(to_json(r, severity_config=PRESET_DEFAULT))
         cats = d["severity"]["categories"]
         assert cats["abi_breaking"]["count"] == 1
-        assert cats["additions"]["count"] == 1
+        assert cats["addition"]["count"] == 1
         assert cats["quality_issues"]["count"] == 1
         assert cats["potential_breaking"]["count"] == 0

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -48,14 +48,14 @@ class TestMarkdownReporter:
                    new_value="new_api")
         md = to_markdown(_result(Verdict.COMPATIBLE, [c]))
         assert "COMPATIBLE" in md
-        assert "Compatible Changes" in md
+        assert "Additions" in md
 
-    def test_noexcept_added_in_compatible_section(self):
+    def test_noexcept_added_in_quality_section(self):
         c = Change(ChangeKind.FUNC_NOEXCEPT_ADDED, "_Z4swapv",
                    "noexcept specifier added: swap")
         md = to_markdown(_result(Verdict.COMPATIBLE, [c]))
         assert "COMPATIBLE" in md
-        assert "Compatible Changes" in md
+        assert "Quality Issues" in md
 
     def test_legend_always_present(self):
         md = to_markdown(_result(Verdict.NO_CHANGE))

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -98,18 +98,21 @@ class TestSeverityMarkdown:
     """Tests for to_markdown with severity_config parameter."""
 
     def test_severity_badges_shown_when_config_provided(self):
-        """Section headers include severity badges when severity_config is set."""
+        """Section header for breaking changes includes ERROR badge."""
         from abicheck.severity import PRESET_DEFAULT
         c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo",
                    old_value="foo")
         md = to_markdown(_result(Verdict.BREAKING, [c]), severity_config=PRESET_DEFAULT)
-        assert "`ERROR`" in md
+        # Exact section header produced by the reporter
+        assert "## \u274c Breaking Changes \u274c `ERROR`" in md
 
     def test_severity_badges_absent_without_config(self):
         """Section headers do NOT include severity badges without severity_config."""
         c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo",
                    old_value="foo")
         md = to_markdown(_result(Verdict.BREAKING, [c]))
+        # Without severity_config, the header has no badge suffix
+        assert "## \u274c Breaking Changes\n" in md
         assert "`ERROR`" not in md
         assert "`WARNING`" not in md
         assert "`INFO`" not in md
@@ -119,9 +122,10 @@ class TestSeverityMarkdown:
         from abicheck.severity import PRESET_STRICT
         c = Change(ChangeKind.FUNC_ADDED, "_Z6newapiv", "New public function: new_api")
         md = to_markdown(_result(Verdict.COMPATIBLE, [c]), severity_config=PRESET_STRICT)
-        assert "Severity Configuration" in md
-        assert "ABI/API Incompatibilities" in md
-        assert "Additions" in md
+        assert "## Severity Configuration" in md
+        # Exact table rows
+        assert "| ABI/API Incompatibilities |" in md
+        assert "| Additions |" in md
 
     def test_severity_summary_absent_without_config(self):
         """Markdown does NOT include severity table without config."""
@@ -130,21 +134,21 @@ class TestSeverityMarkdown:
         assert "Severity Configuration" not in md
 
     def test_quality_section_with_severity_label(self):
-        """Quality section shows severity badge when config is provided."""
+        """Quality section header includes WARNING badge."""
         from abicheck.severity import PRESET_DEFAULT
         c = Change(ChangeKind.FUNC_NOEXCEPT_ADDED, "_Z4swapv",
                    "noexcept specifier added: swap")
         md = to_markdown(_result(Verdict.COMPATIBLE, [c]), severity_config=PRESET_DEFAULT)
-        assert "Quality Issues" in md
-        assert "`WARNING`" in md
+        # Exact section header
+        assert "## \U0001f50d Quality Issues \u26a0\ufe0f `WARNING`" in md
 
     def test_additions_section_with_severity_label(self):
-        """Additions section shows severity badge when config is provided."""
+        """Additions section header includes INFO badge."""
         from abicheck.severity import PRESET_DEFAULT
         c = Change(ChangeKind.FUNC_ADDED, "_Z6newapiv", "New public function: new_api")
         md = to_markdown(_result(Verdict.COMPATIBLE, [c]), severity_config=PRESET_DEFAULT)
-        assert "Additions" in md
-        assert "`INFO`" in md
+        # Exact section header
+        assert "## \u2705 Additions \u2139\ufe0f `INFO`" in md
 
 
 class TestSeverityJson:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -88,3 +88,109 @@ class TestMarkdownReporter:
                    "New GLIBC_2.34 version requirement added")
         md = to_markdown(_result(Verdict.COMPATIBLE_WITH_RISK, [c]))
         assert "⚠️ `COMPATIBLE_WITH_RISK`" in md
+
+
+# ---------------------------------------------------------------------------
+# Severity-aware reporter output
+# ---------------------------------------------------------------------------
+
+class TestSeverityMarkdown:
+    """Tests for to_markdown with severity_config parameter."""
+
+    def test_severity_badges_shown_when_config_provided(self):
+        """Section headers include severity badges when severity_config is set."""
+        from abicheck.severity import PRESET_DEFAULT
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo",
+                   old_value="foo")
+        md = to_markdown(_result(Verdict.BREAKING, [c]), severity_config=PRESET_DEFAULT)
+        assert "`ERROR`" in md
+
+    def test_severity_badges_absent_without_config(self):
+        """Section headers do NOT include severity badges without severity_config."""
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo",
+                   old_value="foo")
+        md = to_markdown(_result(Verdict.BREAKING, [c]))
+        assert "`ERROR`" not in md
+        assert "`WARNING`" not in md
+        assert "`INFO`" not in md
+
+    def test_severity_summary_table_in_markdown(self):
+        """Markdown includes a severity configuration table when config is provided."""
+        from abicheck.severity import PRESET_STRICT
+        c = Change(ChangeKind.FUNC_ADDED, "_Z6newapiv", "New public function: new_api")
+        md = to_markdown(_result(Verdict.COMPATIBLE, [c]), severity_config=PRESET_STRICT)
+        assert "Severity Configuration" in md
+        assert "ABI/API Incompatibilities" in md
+        assert "Additions" in md
+
+    def test_severity_summary_absent_without_config(self):
+        """Markdown does NOT include severity table without config."""
+        c = Change(ChangeKind.FUNC_ADDED, "_Z6newapiv", "New public function: new_api")
+        md = to_markdown(_result(Verdict.COMPATIBLE, [c]))
+        assert "Severity Configuration" not in md
+
+    def test_quality_section_with_severity_label(self):
+        """Quality section shows severity badge when config is provided."""
+        from abicheck.severity import PRESET_DEFAULT
+        c = Change(ChangeKind.FUNC_NOEXCEPT_ADDED, "_Z4swapv",
+                   "noexcept specifier added: swap")
+        md = to_markdown(_result(Verdict.COMPATIBLE, [c]), severity_config=PRESET_DEFAULT)
+        assert "Quality Issues" in md
+        assert "`WARNING`" in md
+
+    def test_additions_section_with_severity_label(self):
+        """Additions section shows severity badge when config is provided."""
+        from abicheck.severity import PRESET_DEFAULT
+        c = Change(ChangeKind.FUNC_ADDED, "_Z6newapiv", "New public function: new_api")
+        md = to_markdown(_result(Verdict.COMPATIBLE, [c]), severity_config=PRESET_DEFAULT)
+        assert "Additions" in md
+        assert "`INFO`" in md
+
+
+class TestSeverityJson:
+    """Tests for to_json with severity_config parameter."""
+
+    def test_severity_section_in_json(self):
+        """JSON output includes severity section when config is provided."""
+        from abicheck.severity import PRESET_DEFAULT
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo")
+        r = _result(Verdict.BREAKING, changes=[c])
+        d = json.loads(to_json(r, severity_config=PRESET_DEFAULT))
+        assert "severity" in d
+        sev = d["severity"]
+        assert "config" in sev
+        assert sev["config"]["abi_breaking"] == "error"
+        assert sev["config"]["additions"] == "info"
+        assert "categories" in sev
+        assert sev["categories"]["abi_breaking"]["count"] == 1
+
+    def test_severity_absent_in_json_without_config(self):
+        """JSON output does NOT include severity section without config."""
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo")
+        r = _result(Verdict.BREAKING, changes=[c])
+        d = json.loads(to_json(r))
+        assert "severity" not in d
+
+    def test_severity_exit_code_in_json(self):
+        """JSON severity section includes computed exit_code."""
+        from abicheck.severity import PRESET_STRICT
+        c = Change(ChangeKind.FUNC_ADDED, "_Z6newapiv", "New public function: new_api")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        d = json.loads(to_json(r, severity_config=PRESET_STRICT))
+        assert d["severity"]["exit_code"] == 1
+
+    def test_severity_category_counts(self):
+        """JSON severity categories have correct counts for mixed changes."""
+        from abicheck.severity import PRESET_DEFAULT
+        changes = [
+            Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo"),
+            Change(ChangeKind.FUNC_ADDED, "_Z3barv", "added: bar"),
+            Change(ChangeKind.VISIBILITY_LEAK, "std::string", "std symbol exposed"),
+        ]
+        r = _result(Verdict.BREAKING, changes=changes)
+        d = json.loads(to_json(r, severity_config=PRESET_DEFAULT))
+        cats = d["severity"]["categories"]
+        assert cats["abi_breaking"]["count"] == 1
+        assert cats["additions"]["count"] == 1
+        assert cats["quality_issues"]["count"] == 1
+        assert cats["potential_breaking"]["count"] == 0

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -57,7 +57,7 @@ class TestClassifyChange:
         assert classify_change(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED) == IssueCategory.POTENTIAL_BREAKING
 
     def test_addition_kind(self) -> None:
-        assert classify_change(ChangeKind.FUNC_ADDED) == IssueCategory.ADDITIONS
+        assert classify_change(ChangeKind.FUNC_ADDED) == IssueCategory.ADDITION
 
     def test_quality_issue_kind(self) -> None:
         assert classify_change(ChangeKind.VISIBILITY_LEAK) == IssueCategory.QUALITY_ISSUES
@@ -67,13 +67,13 @@ class TestClassifyChange:
         assert classify_change(ChangeKind.FUNC_NOEXCEPT_ADDED) == IssueCategory.QUALITY_ISSUES
 
     def test_type_added_is_addition(self) -> None:
-        assert classify_change(ChangeKind.TYPE_ADDED) == IssueCategory.ADDITIONS
+        assert classify_change(ChangeKind.TYPE_ADDED) == IssueCategory.ADDITION
 
     def test_var_added_is_addition(self) -> None:
-        assert classify_change(ChangeKind.VAR_ADDED) == IssueCategory.ADDITIONS
+        assert classify_change(ChangeKind.VAR_ADDED) == IssueCategory.ADDITION
 
     def test_enum_member_added_is_addition(self) -> None:
-        assert classify_change(ChangeKind.ENUM_MEMBER_ADDED) == IssueCategory.ADDITIONS
+        assert classify_change(ChangeKind.ENUM_MEMBER_ADDED) == IssueCategory.ADDITION
 
     def test_soname_missing_is_quality(self) -> None:
         assert classify_change(ChangeKind.SONAME_MISSING) == IssueCategory.QUALITY_ISSUES
@@ -99,7 +99,7 @@ class TestClassifyChange:
         elif kind in API_BREAK_KINDS or kind in RISK_KINDS:
             assert cat == IssueCategory.POTENTIAL_BREAKING
         elif kind in ADDITION_KINDS:
-            assert cat == IssueCategory.ADDITIONS
+            assert cat == IssueCategory.ADDITION
         elif kind in QUALITY_KINDS:
             assert cat == IssueCategory.QUALITY_ISSUES
         else:
@@ -117,7 +117,7 @@ class TestSeverityConfig:
         assert cfg.abi_breaking == SeverityLevel.ERROR
         assert cfg.potential_breaking == SeverityLevel.WARNING
         assert cfg.quality_issues == SeverityLevel.WARNING
-        assert cfg.additions == SeverityLevel.INFO
+        assert cfg.addition == SeverityLevel.INFO
 
     def test_strict_preset_all_error(self) -> None:
         cfg = PRESET_STRICT
@@ -154,7 +154,7 @@ class TestSeverityConfig:
     def test_describe(self) -> None:
         desc = PRESET_DEFAULT.describe()
         assert "abi_breaking: error" in desc
-        assert "additions: info" in desc
+        assert "addition: info" in desc
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +180,9 @@ class TestResolveSeverityConfig:
             resolve_severity_config(preset="nonexistent")
 
     def test_per_category_override(self) -> None:
-        cfg = resolve_severity_config(additions="error")
+        cfg = resolve_severity_config(addition="error")
         assert cfg.abi_breaking == SeverityLevel.ERROR  # from default
-        assert cfg.additions == SeverityLevel.ERROR  # overridden
+        assert cfg.addition == SeverityLevel.ERROR  # overridden
 
     def test_override_on_preset(self) -> None:
         cfg = resolve_severity_config(
@@ -201,12 +201,12 @@ class TestResolveSeverityConfig:
             abi_breaking="warning",
             potential_breaking="error",
             quality_issues="info",
-            additions="error",
+            addition="error",
         )
         assert cfg.abi_breaking == SeverityLevel.WARNING
         assert cfg.potential_breaking == SeverityLevel.ERROR
         assert cfg.quality_issues == SeverityLevel.INFO
-        assert cfg.additions == SeverityLevel.ERROR
+        assert cfg.addition == SeverityLevel.ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -265,7 +265,7 @@ class TestComputeExitCode:
             abi_breaking=SeverityLevel.INFO,
             potential_breaking=SeverityLevel.ERROR,
             quality_issues=SeverityLevel.INFO,
-            additions=SeverityLevel.INFO,
+            addition=SeverityLevel.INFO,
         )
         changes = [
             _FakeChange(ChangeKind.FUNC_REMOVED),  # abi_breaking → info → exit 0
@@ -298,8 +298,8 @@ class TestCategorizeChanges:
         assert result.potential_breaking[0].kind == ChangeKind.ENUM_MEMBER_RENAMED
         assert len(result.quality_issues) == 1
         assert result.quality_issues[0].kind == ChangeKind.VISIBILITY_LEAK
-        assert len(result.additions) == 1
-        assert result.additions[0].kind == ChangeKind.FUNC_ADDED
+        assert len(result.addition) == 1
+        assert result.addition[0].kind == ChangeKind.FUNC_ADDED
 
     def test_risk_kinds_go_to_potential(self) -> None:
         changes = [_FakeChange(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED)]
@@ -336,7 +336,7 @@ class TestSeverityConfigDescribe:
     def test_describe_default(self) -> None:
         out = PRESET_DEFAULT.describe()
         assert "abi_breaking: error" in out
-        assert "additions: info" in out
+        assert "addition: info" in out
 
     def test_describe_with_title(self) -> None:
         out = PRESET_STRICT.describe(title="Strict preset:")

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -81,6 +81,30 @@ class TestClassifyChange:
     def test_dwarf_info_missing_is_quality(self) -> None:
         assert classify_change(ChangeKind.DWARF_INFO_MISSING) == IssueCategory.QUALITY_ISSUES
 
+    @pytest.mark.parametrize("kind", list(ChangeKind), ids=lambda k: k.value)
+    def test_exhaustive_all_kinds_classified(self, kind: ChangeKind) -> None:
+        """Every ChangeKind must map to a real category, never the fail-safe default."""
+        from abicheck.checker_policy import (
+            ADDITION_KINDS,
+            API_BREAK_KINDS,
+            BREAKING_KINDS,
+            QUALITY_KINDS,
+            RISK_KINDS,
+        )
+        cat = classify_change(kind)
+        assert cat in set(IssueCategory), f"{kind} classified as unknown category {cat}"
+        # Verify classify_change agrees with the canonical kind sets
+        if kind in BREAKING_KINDS:
+            assert cat == IssueCategory.ABI_BREAKING
+        elif kind in API_BREAK_KINDS or kind in RISK_KINDS:
+            assert cat == IssueCategory.POTENTIAL_BREAKING
+        elif kind in ADDITION_KINDS:
+            assert cat == IssueCategory.ADDITIONS
+        elif kind in QUALITY_KINDS:
+            assert cat == IssueCategory.QUALITY_ISSUES
+        else:
+            pytest.fail(f"{kind} not in any canonical kind set — update checker_policy.py")
+
 
 # ---------------------------------------------------------------------------
 # SeverityConfig

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -1,0 +1,284 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the severity configuration module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from abicheck.checker_policy import ChangeKind
+from abicheck.severity import (
+    PRESET_DEFAULT,
+    PRESET_INFO_ONLY,
+    PRESET_STRICT,
+    CategorizedChanges,
+    IssueCategory,
+    SeverityConfig,
+    SeverityLevel,
+    categorize_changes,
+    classify_change,
+    compute_exit_code,
+    resolve_severity_config,
+)
+
+
+@dataclass
+class _FakeChange:
+    kind: ChangeKind
+
+
+# ---------------------------------------------------------------------------
+# classify_change
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyChange:
+    def test_breaking_kind(self) -> None:
+        assert classify_change(ChangeKind.FUNC_REMOVED) == IssueCategory.ABI_BREAKING
+
+    def test_api_break_kind(self) -> None:
+        assert classify_change(ChangeKind.ENUM_MEMBER_RENAMED) == IssueCategory.POTENTIAL_BREAKING
+
+    def test_risk_kind(self) -> None:
+        assert classify_change(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED) == IssueCategory.POTENTIAL_BREAKING
+
+    def test_addition_kind(self) -> None:
+        assert classify_change(ChangeKind.FUNC_ADDED) == IssueCategory.ADDITIONS
+
+    def test_quality_issue_kind(self) -> None:
+        assert classify_change(ChangeKind.VISIBILITY_LEAK) == IssueCategory.QUALITY_ISSUES
+
+    def test_compatible_noexcept_is_quality(self) -> None:
+        # noexcept changes are COMPATIBLE but not additions → quality issues
+        assert classify_change(ChangeKind.FUNC_NOEXCEPT_ADDED) == IssueCategory.QUALITY_ISSUES
+
+    def test_type_added_is_addition(self) -> None:
+        assert classify_change(ChangeKind.TYPE_ADDED) == IssueCategory.ADDITIONS
+
+    def test_var_added_is_addition(self) -> None:
+        assert classify_change(ChangeKind.VAR_ADDED) == IssueCategory.ADDITIONS
+
+    def test_enum_member_added_is_addition(self) -> None:
+        assert classify_change(ChangeKind.ENUM_MEMBER_ADDED) == IssueCategory.ADDITIONS
+
+    def test_soname_missing_is_quality(self) -> None:
+        assert classify_change(ChangeKind.SONAME_MISSING) == IssueCategory.QUALITY_ISSUES
+
+    def test_dwarf_info_missing_is_quality(self) -> None:
+        assert classify_change(ChangeKind.DWARF_INFO_MISSING) == IssueCategory.QUALITY_ISSUES
+
+
+# ---------------------------------------------------------------------------
+# SeverityConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityConfig:
+    def test_default_preset_values(self) -> None:
+        cfg = PRESET_DEFAULT
+        assert cfg.abi_breaking == SeverityLevel.ERROR
+        assert cfg.potential_breaking == SeverityLevel.WARNING
+        assert cfg.quality_issues == SeverityLevel.WARNING
+        assert cfg.additions == SeverityLevel.INFO
+
+    def test_strict_preset_all_error(self) -> None:
+        cfg = PRESET_STRICT
+        for cat in IssueCategory:
+            assert cfg.level_for(cat) == SeverityLevel.ERROR
+
+    def test_info_only_preset_all_info(self) -> None:
+        cfg = PRESET_INFO_ONLY
+        for cat in IssueCategory:
+            assert cfg.level_for(cat) == SeverityLevel.INFO
+
+    def test_level_for_kind(self) -> None:
+        cfg = PRESET_DEFAULT
+        assert cfg.level_for_kind(ChangeKind.FUNC_REMOVED) == SeverityLevel.ERROR
+        assert cfg.level_for_kind(ChangeKind.ENUM_MEMBER_RENAMED) == SeverityLevel.WARNING
+        assert cfg.level_for_kind(ChangeKind.VISIBILITY_LEAK) == SeverityLevel.WARNING
+        assert cfg.level_for_kind(ChangeKind.FUNC_ADDED) == SeverityLevel.INFO
+
+    def test_has_errors_true(self) -> None:
+        cfg = PRESET_DEFAULT
+        changes = [_FakeChange(ChangeKind.FUNC_REMOVED)]
+        assert cfg.has_errors(changes) is True
+
+    def test_has_errors_false_no_breaking(self) -> None:
+        cfg = PRESET_DEFAULT
+        changes = [_FakeChange(ChangeKind.FUNC_ADDED)]
+        assert cfg.has_errors(changes) is False
+
+    def test_has_errors_strict_additions(self) -> None:
+        cfg = PRESET_STRICT
+        changes = [_FakeChange(ChangeKind.FUNC_ADDED)]
+        assert cfg.has_errors(changes) is True
+
+    def test_describe(self) -> None:
+        desc = PRESET_DEFAULT.describe()
+        assert "abi_breaking: error" in desc
+        assert "additions: info" in desc
+
+
+# ---------------------------------------------------------------------------
+# resolve_severity_config
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSeverityConfig:
+    def test_no_args_returns_default(self) -> None:
+        cfg = resolve_severity_config()
+        assert cfg == PRESET_DEFAULT
+
+    def test_preset_strict(self) -> None:
+        cfg = resolve_severity_config(preset="strict")
+        assert cfg == PRESET_STRICT
+
+    def test_preset_info_only(self) -> None:
+        cfg = resolve_severity_config(preset="info-only")
+        assert cfg == PRESET_INFO_ONLY
+
+    def test_invalid_preset_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown severity preset"):
+            resolve_severity_config(preset="nonexistent")
+
+    def test_per_category_override(self) -> None:
+        cfg = resolve_severity_config(additions="error")
+        assert cfg.abi_breaking == SeverityLevel.ERROR  # from default
+        assert cfg.additions == SeverityLevel.ERROR  # overridden
+
+    def test_override_on_preset(self) -> None:
+        cfg = resolve_severity_config(
+            preset="info-only",
+            abi_breaking="error",
+        )
+        assert cfg.abi_breaking == SeverityLevel.ERROR
+        assert cfg.potential_breaking == SeverityLevel.INFO  # from info-only
+
+    def test_invalid_override_value_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid severity level"):
+            resolve_severity_config(abi_breaking="critical")
+
+    def test_all_overrides(self) -> None:
+        cfg = resolve_severity_config(
+            abi_breaking="warning",
+            potential_breaking="error",
+            quality_issues="info",
+            additions="error",
+        )
+        assert cfg.abi_breaking == SeverityLevel.WARNING
+        assert cfg.potential_breaking == SeverityLevel.ERROR
+        assert cfg.quality_issues == SeverityLevel.INFO
+        assert cfg.additions == SeverityLevel.ERROR
+
+
+# ---------------------------------------------------------------------------
+# compute_exit_code
+# ---------------------------------------------------------------------------
+
+
+class TestComputeExitCode:
+    def test_no_changes(self) -> None:
+        assert compute_exit_code([], PRESET_DEFAULT) == 0
+
+    def test_breaking_default_exits_4(self) -> None:
+        changes = [_FakeChange(ChangeKind.FUNC_REMOVED)]
+        assert compute_exit_code(changes, PRESET_DEFAULT) == 4
+
+    def test_api_break_default_exits_0(self) -> None:
+        # API breaks are WARNING by default, so exit 0
+        changes = [_FakeChange(ChangeKind.ENUM_MEMBER_RENAMED)]
+        assert compute_exit_code(changes, PRESET_DEFAULT) == 0
+
+    def test_api_break_strict_exits_2(self) -> None:
+        changes = [_FakeChange(ChangeKind.ENUM_MEMBER_RENAMED)]
+        assert compute_exit_code(changes, PRESET_STRICT) == 2
+
+    def test_additions_default_exits_0(self) -> None:
+        changes = [_FakeChange(ChangeKind.FUNC_ADDED)]
+        assert compute_exit_code(changes, PRESET_DEFAULT) == 0
+
+    def test_additions_strict_exits_1(self) -> None:
+        changes = [_FakeChange(ChangeKind.FUNC_ADDED)]
+        assert compute_exit_code(changes, PRESET_STRICT) == 1
+
+    def test_quality_strict_exits_1(self) -> None:
+        changes = [_FakeChange(ChangeKind.VISIBILITY_LEAK)]
+        assert compute_exit_code(changes, PRESET_STRICT) == 1
+
+    def test_info_only_always_0(self) -> None:
+        changes = [
+            _FakeChange(ChangeKind.FUNC_REMOVED),
+            _FakeChange(ChangeKind.ENUM_MEMBER_RENAMED),
+            _FakeChange(ChangeKind.FUNC_ADDED),
+        ]
+        assert compute_exit_code(changes, PRESET_INFO_ONLY) == 0
+
+    def test_worst_exit_code_wins(self) -> None:
+        changes = [
+            _FakeChange(ChangeKind.FUNC_REMOVED),  # abi_breaking → exit 4
+            _FakeChange(ChangeKind.ENUM_MEMBER_RENAMED),  # potential → exit 2
+            _FakeChange(ChangeKind.FUNC_ADDED),  # additions → exit 1
+        ]
+        assert compute_exit_code(changes, PRESET_STRICT) == 4
+
+    def test_mixed_severity_custom(self) -> None:
+        # Only potential_breaking is error, rest is info
+        cfg = SeverityConfig(
+            abi_breaking=SeverityLevel.INFO,
+            potential_breaking=SeverityLevel.ERROR,
+            quality_issues=SeverityLevel.INFO,
+            additions=SeverityLevel.INFO,
+        )
+        changes = [
+            _FakeChange(ChangeKind.FUNC_REMOVED),  # abi_breaking → info → exit 0
+            _FakeChange(ChangeKind.ENUM_MEMBER_RENAMED),  # potential → error → exit 2
+        ]
+        assert compute_exit_code(changes, cfg) == 2
+
+
+# ---------------------------------------------------------------------------
+# categorize_changes
+# ---------------------------------------------------------------------------
+
+
+class TestCategorizeChanges:
+    def test_empty(self) -> None:
+        result = categorize_changes([])
+        assert result == CategorizedChanges([], [], [], [])
+
+    def test_all_categories(self) -> None:
+        changes = [
+            _FakeChange(ChangeKind.FUNC_REMOVED),
+            _FakeChange(ChangeKind.ENUM_MEMBER_RENAMED),
+            _FakeChange(ChangeKind.VISIBILITY_LEAK),
+            _FakeChange(ChangeKind.FUNC_ADDED),
+        ]
+        result = categorize_changes(changes)
+        assert len(result.abi_breaking) == 1
+        assert result.abi_breaking[0].kind == ChangeKind.FUNC_REMOVED
+        assert len(result.potential_breaking) == 1
+        assert result.potential_breaking[0].kind == ChangeKind.ENUM_MEMBER_RENAMED
+        assert len(result.quality_issues) == 1
+        assert result.quality_issues[0].kind == ChangeKind.VISIBILITY_LEAK
+        assert len(result.additions) == 1
+        assert result.additions[0].kind == ChangeKind.FUNC_ADDED
+
+    def test_risk_kinds_go_to_potential(self) -> None:
+        changes = [_FakeChange(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED)]
+        result = categorize_changes(changes)
+        assert len(result.potential_breaking) == 1
+        assert len(result.abi_breaking) == 0

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -306,3 +306,58 @@ class TestCategorizeChanges:
         result = categorize_changes(changes)
         assert len(result.potential_breaking) == 1
         assert len(result.abi_breaking) == 0
+
+
+# ---------------------------------------------------------------------------
+# Additional exit-code and config edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestComputeExitCodeEdgeCases:
+    """Additional coverage for exit-code edge cases flagged during review."""
+
+    def test_quality_default_exits_0(self) -> None:
+        """Quality issues are WARNING under default preset → exit 0."""
+        changes = [_FakeChange(ChangeKind.VISIBILITY_LEAK)]
+        assert compute_exit_code(changes, PRESET_DEFAULT) == 0
+
+    def test_quality_and_additions_only_exits_0_default(self) -> None:
+        """Quality + additions under default preset → exit 0 (both below error)."""
+        changes = [
+            _FakeChange(ChangeKind.VISIBILITY_LEAK),
+            _FakeChange(ChangeKind.FUNC_ADDED),
+        ]
+        assert compute_exit_code(changes, PRESET_DEFAULT) == 0
+
+
+class TestSeverityConfigDescribe:
+    """Tests for SeverityConfig.describe() method."""
+
+    def test_describe_default(self) -> None:
+        out = PRESET_DEFAULT.describe()
+        assert "abi_breaking: error" in out
+        assert "additions: info" in out
+
+    def test_describe_with_title(self) -> None:
+        out = PRESET_STRICT.describe(title="Strict preset:")
+        assert out.startswith("Strict preset:")
+        assert "abi_breaking: error" in out
+
+    def test_describe_with_prefix(self) -> None:
+        out = PRESET_DEFAULT.describe(prefix=">> ")
+        for line in out.splitlines():
+            assert line.startswith(">> ")
+
+    def test_describe_with_title_and_prefix(self) -> None:
+        out = PRESET_INFO_ONLY.describe(prefix="  ", title="Info-only:")
+        lines = out.splitlines()
+        assert lines[0] == "  Info-only:"
+        assert "info" in lines[1]
+
+
+class TestInfoOnlyAlias:
+    """The info_only alias resolves to the same preset as info-only."""
+
+    def test_alias_resolves(self) -> None:
+        from abicheck.severity import SEVERITY_PRESETS
+        assert SEVERITY_PRESETS["info_only"] is SEVERITY_PRESETS["info-only"]


### PR DESCRIPTION
## Summary

Introduces a new severity configuration system that categorizes ABI/API changes into four high-level issue categories (abi_breaking, potential_breaking, quality_issues, additions) with configurable severity levels (error, warning, info) that control exit codes and report presentation.

## Motivation

The existing policy/verdict system in `checker_policy` provides detailed change classification, but users need a simpler, user-facing way to control which categories of issues should cause non-zero exit codes and how they're presented in reports. This PR adds a severity layer on top of the canonical kind sets, enabling flexible severity presets and per-category overrides while maintaining a single source of truth in `checker_policy`.

## Changes

- **New module `abicheck/severity.py`**: Implements the severity configuration system
  - `SeverityLevel` enum: error, warning, info
  - `IssueCategory` enum: abi_breaking, potential_breaking, quality_issues, additions
  - `SeverityConfig` dataclass: Maps categories to severity levels with preset support
  - `classify_change()`: Thin wrapper mapping ChangeKind to IssueCategory using canonical kind sets
  - `categorize_changes()`: Partitions changes into the four categories
  - `compute_exit_code()`: Severity-aware exit code computation (0, 1, 2, or 4)
  - Built-in presets: `default`, `strict`, `info-only`
  - `resolve_severity_config()`: Resolves presets with per-category overrides

- **Updated `abicheck/checker_policy.py`**: Defines canonical kind sets for severity mapping
  - `ADDITION_KINDS`: New public API surface (subset of COMPATIBLE_KINDS)
  - `QUALITY_KINDS`: Behavioral/quality issues (COMPATIBLE_KINDS minus ADDITION_KINDS)
  - Added integrity assertions to validate the new kind sets

- **Updated `abicheck/reporter.py`**: Integrates severity configuration into report output
  - `to_json()` and `to_markdown()` now accept optional `severity_config` parameter
  - Adds severity configuration summary table to markdown reports
  - Adds severity section to JSON output with category counts and computed exit code
  - Section headers include severity badges (emoji + level) when config is provided
  - Splits compatible changes into "Quality Issues" and "Additions" sections

- **Updated `abicheck/cli.py`**: Adds CLI options for severity configuration
  - `--severity-preset`: Choose from default/strict/info-only
  - `--severity-abi-breaking`, `--severity-potential-breaking`, `--severity-quality-issues`, `--severity-additions`: Per-category overrides
  - Passes resolved config to report rendering functions

- **Comprehensive test coverage** in `tests/test_severity.py`:
  - Tests for `classify_change()` covering all ChangeKind values
  - Tests for SeverityConfig presets and methods
  - Tests for `resolve_severity_config()` with presets and overrides
  - Tests for `compute_exit_code()` with various configurations
  - Tests for `categorize_changes()` partitioning

- **Updated reporter tests** in `tests/test_reporter.py`:
  - Tests for severity badges in markdown output
  - Tests for severity configuration table in markdown
  - Tests for severity section in JSON output
  - Tests verifying severity output is absent when config not provided

- **Updated golden test files**: Reflect renamed "Compatible Additions" → "Additions" section

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed
- [x] `pre-commit run --all-files` passes locally
- [x] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_014jCip7QE86dCBYZusQzok3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add severity configuration with presets and per-category CLI options; reports (JSON/Markdown) show severity info and split compatible changes into “Additions” and “Quality Issues”; severity can drive exit codes.

* **Deprecation**
  * Removed legacy --fail-on-additions; use severity-based flags (e.g., --severity-addition error).

* **Chores**
  * CI action and demo adjusted to accept new severity inputs and extra-args passthrough.

* **Tests**
  * New and updated tests covering severity classification, reporters, and CLI behavior.

* **Documentation**
  * New severity guide and updated CLI/exit-code docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->