### PR TITLE
Add format validation and new header/include flags for appcompat mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,11 @@ inputs:
 
   # ── Output & policy ─────────────────────────────────────────────────────────
   format:
-    description: 'Output format: markdown (default), json, sarif, html.'
+    description: >
+      Output format: markdown (default), json, sarif, html.
+      sarif and html are only supported in compare mode; other modes
+      support markdown and json only (unsupported formats fall back
+      to markdown with a warning).
     required: false
     default: 'markdown'
   output-file:
@@ -242,22 +246,25 @@ outputs:
   verdict:
     description: >
       ABI verdict. For compare: COMPATIBLE, SEVERITY_ERROR, API_BREAK,
-      BREAKING, or ERROR.
+      BREAKING, or ERROR. SEVERITY_ERROR is produced when
+      --severity-addition=error detects new public API additions
+      (compare mode only).
       For compare-release: COMPATIBLE, API_BREAK, BREAKING,
       REMOVED_LIBRARY (when fail-on-removed-library is set), or ERROR.
-      SEVERITY_ERROR is produced when --severity-addition=error detects
-      new public API additions (compare mode only).
+      For appcompat: COMPATIBLE, API_BREAK, BREAKING, or ERROR.
       For dump: COMPATIBLE or ERROR.
       For stack-check: PASS, WARN, FAIL, or ERROR.
-      For deps: PASS (all resolved) or FAIL (missing deps/symbols).
+      For deps: PASS, FAIL, or ERROR.
     value: ${{ steps.run-abicheck.outputs.verdict }}
   exit-code:
     description: >
-      abicheck exit code. compare: 0 (compatible), 1 (severity-addition error),
-      2 (API break), 4 (ABI break). compare-release: 0 (compatible), 2 (API break),
-      4 (ABI break), 8 (library removed). stack-check: 0 (pass), 1 (warn), 4 (fail).
-      deps: 0 (ok), 1 (missing). Click CLI errors also exit 2 and are mapped
-      to VERDICT=ERROR.
+      abicheck exit code. compare: 0 (compatible), 1 (severity error),
+      2 (API break), 4 (ABI break). compare-release: 0 (compatible),
+      2 (API break), 4 (ABI break), 8 (library removed).
+      appcompat: 0 (compatible), 2 (API break), 4 (ABI break).
+      stack-check: 0 (pass), 1 (warn), 4 (fail).
+      deps: 0 (ok), 1 (missing). Click CLI errors are mapped to
+      VERDICT=ERROR.
     value: ${{ steps.run-abicheck.outputs.exit-code }}
   report-path:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ inputs:
     description: 'Extra compiler flags passed through to castxml (dump mode only).'
     required: false
   sysroot:
-    description: 'Alternative system root directory for cross-compilation (dump mode only).'
+    description: 'Alternative system root directory for cross-compilation (dump and deps modes).'
     required: false
   nostdinc:
     description: 'Do not search standard system include paths (dump mode only).'
@@ -221,36 +221,41 @@ inputs:
   severity-preset:
     description: >
       Severity preset: 'default', 'strict', or 'info-only'.
-      Controls exit codes and report labels.
+      Controls exit codes and report labels. Only applies to compare mode.
     required: false
   severity-addition:
     description: >
       Severity for new public API additions: 'error', 'warning', or 'info'.
       Set to 'error' to fail the step when additions are detected.
+      Only applies to compare mode.
     required: false
   extra-args:
     description: 'Additional CLI arguments passed directly to the abicheck command.'
     required: false
     default: ''
   add-job-summary:
-    description: 'Write a markdown summary to the GitHub Actions Job Summary.'
+    description: 'Write a markdown summary to the GitHub Actions Job Summary. Ignored for dump mode.'
     required: false
     default: 'true'
 
 outputs:
   verdict:
     description: >
-      ABI verdict. For compare/dump: COMPATIBLE, COMPATIBLE_WITH_RISK,
-      SEVERITY_ERROR, API_BREAK, BREAKING, or ERROR.
+      ABI verdict. For compare: COMPATIBLE, SEVERITY_ERROR, API_BREAK,
+      BREAKING, or ERROR.
+      For compare-release: COMPATIBLE, API_BREAK, BREAKING,
+      REMOVED_LIBRARY (when fail-on-removed-library is set), or ERROR.
       SEVERITY_ERROR is produced when --severity-addition=error detects
-      new public API additions.
+      new public API additions (compare mode only).
+      For dump: COMPATIBLE or ERROR.
       For stack-check: PASS, WARN, FAIL, or ERROR.
       For deps: PASS (all resolved) or FAIL (missing deps/symbols).
     value: ${{ steps.run-abicheck.outputs.verdict }}
   exit-code:
     description: >
       abicheck exit code. compare: 0 (compatible), 1 (severity-addition error),
-      2 (API break), 4 (ABI break). stack-check: 0 (pass), 1 (warn), 4 (fail).
+      2 (API break), 4 (ABI break). compare-release: 0 (compatible), 2 (API break),
+      4 (ABI break), 8 (library removed). stack-check: 0 (pass), 1 (warn), 4 (fail).
       deps: 0 (ok), 1 (missing). Click CLI errors also exit 2 and are mapped
       to VERDICT=ERROR.
     value: ${{ steps.run-abicheck.outputs.exit-code }}

--- a/action/run.sh
+++ b/action/run.sh
@@ -353,8 +353,51 @@ elif [[ "$MODE" == "dump" ]]; then
     fi
   fi
 
+elif [[ "$MODE" == "appcompat" ]]; then
+  # appcompat exit codes: 0=compatible, 2=API_BREAK, 4=BREAKING
+  # No severity support — exit code 1 is always a CLI error.
+  if [[ $ABICHECK_EXIT -eq 2 ]] && echo "$STDERR_CONTENT" | grep -qE '(^Usage:|^Error:|^Try )'; then
+    VERDICT="ERROR"
+    echo "::error::abicheck appcompat failed due to a CLI argument or configuration error (exit code 2)."
+    echo "::error::Check the command and inputs above. This is NOT an API break — the check did not run."
+  else
+    case $ABICHECK_EXIT in
+      0) VERDICT="COMPATIBLE" ;;
+      2) VERDICT="API_BREAK" ;;
+      4) VERDICT="BREAKING" ;;
+      *)
+        VERDICT="ERROR"
+        if _is_cli_error; then
+          echo "::error::abicheck appcompat failed due to a CLI error (exit code $ABICHECK_EXIT)."
+        fi
+        ;;
+    esac
+  fi
+
+elif [[ "$MODE" == "compare-release" ]]; then
+  # compare-release exit codes: 0=compatible, 2=API_BREAK, 4=BREAKING, 8=REMOVED_LIBRARY
+  # No severity support — exit code 1 is always a CLI error.
+  if [[ $ABICHECK_EXIT -eq 2 ]] && echo "$STDERR_CONTENT" | grep -qE '(^Usage:|^Error:|^Try )'; then
+    VERDICT="ERROR"
+    echo "::error::abicheck compare-release failed due to a CLI argument or configuration error (exit code 2)."
+    echo "::error::Check the command and inputs above. This is NOT an API break — the check did not run."
+  else
+    case $ABICHECK_EXIT in
+      0) VERDICT="COMPATIBLE" ;;
+      2) VERDICT="API_BREAK" ;;
+      4) VERDICT="BREAKING" ;;
+      8) VERDICT="REMOVED_LIBRARY" ;;
+      *)
+        VERDICT="ERROR"
+        if _is_cli_error; then
+          echo "::error::abicheck compare-release failed due to a CLI error (exit code $ABICHECK_EXIT)."
+        fi
+        ;;
+    esac
+  fi
+
 else
-  # compare exit codes: 0=compatible, 1=additions, 2=API_BREAK, 4=BREAKING
+  # compare exit codes: 0=compatible, 1=severity error, 2=API_BREAK, 4=BREAKING
   # Click also uses exit code 2 for usage/argument errors — detect via stderr.
   if [[ $ABICHECK_EXIT -eq 2 ]] && echo "$STDERR_CONTENT" | grep -qE '(^Usage:|^Error:|^Try )'; then
     VERDICT="ERROR"
@@ -374,7 +417,6 @@ else
         ;;
       2) VERDICT="API_BREAK" ;;
       4) VERDICT="BREAKING" ;;
-      8) VERDICT="REMOVED_LIBRARY" ;;
       *) VERDICT="ERROR" ;;
     esac
   fi
@@ -474,7 +516,7 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
       echo "| Binary | \`${INPUT_NEW_LIBRARY:-}\` |"
     fi
     echo "| Mode | $MODE |"
-    echo "| Format | ${INPUT_FORMAT:-markdown} |"
+    echo "| Format | ${FORMAT:-markdown} |"
     if [[ -n "${OUTPUT_FILE:-}" ]]; then
       echo "| Report | \`${OUTPUT_FILE}\` |"
     fi
@@ -517,9 +559,39 @@ elif [[ "$MODE" == "dump" ]]; then
   # dump: non-zero is always an error (already mapped to ERROR above)
   :
 
+elif [[ "$MODE" == "appcompat" ]]; then
+  # appcompat: same failure flags as compare (fail-on-breaking, fail-on-api-break)
+  if [[ "$VERDICT" == "BREAKING" && "${INPUT_FAIL_ON_BREAKING:-true}" == "true" ]]; then
+    echo "::error::ABI break or missing symbols affecting application. Set fail-on-breaking: false to continue."
+    FINAL_EXIT=1
+  fi
+
+  if [[ "$VERDICT" == "API_BREAK" && "${INPUT_FAIL_ON_API_BREAK:-false}" == "true" ]]; then
+    echo "::error::API break affecting application. Set fail-on-api-break: false to ignore."
+    FINAL_EXIT=1
+  fi
+
+elif [[ "$MODE" == "compare-release" ]]; then
+  # compare-release: BREAKING/API_BREAK follow fail-on flags; REMOVED_LIBRARY
+  # only appears when --fail-on-removed-library was passed to the CLI.
+  if [[ "$VERDICT" == "BREAKING" && "${INPUT_FAIL_ON_BREAKING:-true}" == "true" ]]; then
+    echo "::error::ABI break detected. Set fail-on-breaking: false to continue despite breaks."
+    FINAL_EXIT=1
+  fi
+
+  if [[ "$VERDICT" == "API_BREAK" && "${INPUT_FAIL_ON_API_BREAK:-false}" == "true" ]]; then
+    echo "::error::API break detected. Set fail-on-api-break: false to ignore API-level breaks."
+    FINAL_EXIT=1
+  fi
+
+  if [[ "$VERDICT" == "REMOVED_LIBRARY" ]]; then
+    echo "::error::Library removed between old and new package. Set fail-on-removed-library: false to allow."
+    FINAL_EXIT=1
+  fi
+
 else
   # compare mode
-  if [[ $ABICHECK_EXIT -eq 4 && "${INPUT_FAIL_ON_BREAKING:-true}" == "true" ]]; then
+  if [[ "$VERDICT" == "BREAKING" && "${INPUT_FAIL_ON_BREAKING:-true}" == "true" ]]; then
     echo "::error::ABI break detected. Set fail-on-breaking: false to continue despite breaks."
     FINAL_EXIT=1
   fi
@@ -532,11 +604,6 @@ else
   # Severity-driven exit code 1 (from --severity-* flags)
   if [[ "$VERDICT" == "SEVERITY_ERROR" ]]; then
     echo "::error::Severity-level error detected by abicheck."
-    FINAL_EXIT=1
-  fi
-
-  if [[ "$VERDICT" == "REMOVED_LIBRARY" ]]; then
-    echo "::error::Library removed between old and new package. Set fail-on-removed-library: false to allow."
     FINAL_EXIT=1
   fi
 fi

--- a/action/run.sh
+++ b/action/run.sh
@@ -128,13 +128,21 @@ elif [[ "$MODE" == "appcompat" ]]; then
   fi
 
   add_flag "-H" "${INPUT_HEADER:-}"
+  add_flag "--old-header" "${INPUT_OLD_HEADER:-}"
+  add_flag "--new-header" "${INPUT_NEW_HEADER:-}"
   add_flag "-I" "${INPUT_INCLUDE:-}"
+  add_flag "--old-include" "${INPUT_OLD_INCLUDE:-}"
+  add_flag "--new-include" "${INPUT_NEW_INCLUDE:-}"
   add_single_flag "--old-version" "${INPUT_OLD_VERSION:-}"
   add_single_flag "--new-version" "${INPUT_NEW_VERSION:-}"
   add_single_flag "--lang" "${INPUT_LANG:-}"
 
-  # Format
+  # Format — appcompat only supports markdown and json
   FORMAT="${INPUT_FORMAT:-markdown}"
+  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
+    echo "::warning::appcompat mode only supports 'markdown' and 'json' formats. Falling back to 'markdown'."
+    FORMAT="markdown"
+  fi
   CMD+=(--format "$FORMAT")
 
   OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
@@ -168,14 +176,15 @@ elif [[ "$MODE" == "compare-release" ]]; then
   add_single_flag "--new-version" "${INPUT_NEW_VERSION:-}"
   add_single_flag "--lang" "${INPUT_LANG:-}"
 
-  # Format
+  # Format — compare-release only supports markdown and json
   FORMAT="${INPUT_FORMAT:-markdown}"
+  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
+    echo "::warning::compare-release mode only supports 'markdown' and 'json' formats. Falling back to 'markdown'."
+    FORMAT="markdown"
+  fi
   CMD+=(--format "$FORMAT")
 
   OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
-  if [[ "$FORMAT" == "sarif" && -z "$OUTPUT_FILE" ]]; then
-    OUTPUT_FILE="abicheck-results.sarif"
-  fi
   if [[ -n "$OUTPUT_FILE" ]]; then
     CMD+=(-o "$OUTPUT_FILE")
   fi
@@ -212,7 +221,12 @@ elif [[ "$MODE" == "deps" ]]; then
   add_flag "--search-path" "${INPUT_SEARCH_PATH:-}"
   add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
 
+  # Format — deps only supports markdown and json
   FORMAT="${INPUT_FORMAT:-markdown}"
+  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
+    echo "::warning::deps mode only supports 'markdown' and 'json' formats. Falling back to 'markdown'."
+    FORMAT="markdown"
+  fi
   CMD+=(--format "$FORMAT")
 
   OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
@@ -230,7 +244,12 @@ elif [[ "$MODE" == "stack-check" ]]; then
   add_flag "--search-path" "${INPUT_SEARCH_PATH:-}"
   add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
 
+  # Format — stack-check only supports markdown and json
   FORMAT="${INPUT_FORMAT:-markdown}"
+  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
+    echo "::warning::stack-check mode only supports 'markdown' and 'json' formats. Falling back to 'markdown'."
+    FORMAT="markdown"
+  fi
   CMD+=(--format "$FORMAT")
 
   OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -59,7 +59,7 @@ automatically, then runs ABI comparison and reports results.
 | `gcc-path` | — | Path to cross-compiler binary (dump mode only) |
 | `gcc-prefix` | — | Cross-toolchain prefix, e.g. `aarch64-linux-gnu-` (dump mode only) |
 | `gcc-options` | — | Extra flags for castxml (dump mode only) |
-| `sysroot` | — | Alternative system root (dump mode only) |
+| `sysroot` | — | Alternative system root (dump and deps modes) |
 | `nostdinc` | `false` | Skip standard include paths (dump mode only) |
 
 ### Full-stack dependency validation (Linux ELF)
@@ -92,10 +92,10 @@ automatically, then runs ABI comparison and reports results.
 | `upload-sarif` | `false` | Upload SARIF to GitHub Code Scanning |
 | `fail-on-breaking` | `true` | Fail step on binary ABI break |
 | `fail-on-api-break` | `false` | Fail step on source-level API break |
-| `severity-preset` | — | Severity preset: `default`, `strict`, or `info-only` |
-| `severity-addition` | — | Severity for additions: `error`, `warning`, or `info` |
+| `severity-preset` | — | Severity preset: `default`, `strict`, or `info-only` (compare mode only) |
+| `severity-addition` | — | Severity for additions: `error`, `warning`, or `info` (compare mode only) |
 | `extra-args` | `''` | Additional CLI arguments passed to abicheck |
-| `add-job-summary` | `true` | Write summary to Job Summary panel |
+| `add-job-summary` | `true` | Write summary to Job Summary panel (ignored for dump mode) |
 
 ### Package comparison inputs (compare-release mode)
 
@@ -114,8 +114,8 @@ automatically, then runs ABI comparison and reports results.
 
 | Output | Description |
 |--------|-------------|
-| `verdict` | **compare/dump:** `COMPATIBLE`, `COMPATIBLE_WITH_RISK`, `SEVERITY_ERROR`, `API_BREAK`, `BREAKING`, or `ERROR`. `SEVERITY_ERROR` is produced when `severity-addition: error` detects new public API. **stack-check:** `PASS`, `WARN`, `FAIL`, or `ERROR`. **deps:** `PASS`, `FAIL`, or `ERROR`. |
-| `exit-code` | **compare:** `0` (compatible), `1` (severity error), `2` (API break), `4` (ABI break). **stack-check:** `0` (pass), `1` (warn), `4` (fail). **deps:** `0` (ok), `1` (missing). |
+| `verdict` | **compare:** `COMPATIBLE`, `SEVERITY_ERROR`, `API_BREAK`, `BREAKING`, or `ERROR`. `SEVERITY_ERROR` is produced when `severity-addition: error` detects new public API. **compare-release:** `COMPATIBLE`, `API_BREAK`, `BREAKING`, `REMOVED_LIBRARY`, or `ERROR`. **dump:** `COMPATIBLE` or `ERROR`. **stack-check:** `PASS`, `WARN`, `FAIL`, or `ERROR`. **deps:** `PASS`, `FAIL`, or `ERROR`. |
+| `exit-code` | **compare:** `0` (compatible), `1` (severity error), `2` (API break), `4` (ABI break). **compare-release:** `0` (compatible), `2` (API break), `4` (ABI break), `8` (library removed). **stack-check:** `0` (pass), `1` (warn), `4` (fail). **deps:** `0` (ok), `1` (missing). |
 | `report-path` | Path to the generated report file (empty when no output file was produced) |
 
 ## Usage examples

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -76,7 +76,7 @@ automatically, then runs ABI comparison and reports results.
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `format` | `markdown` | Output format: `markdown`, `json`, `sarif`, `html` |
+| `format` | `markdown` | Output format: `markdown`, `json`, `sarif`, `html`. `sarif`/`html` only supported in compare mode; other modes fall back to `markdown` |
 | `output-file` | — | Path to write report (auto-set for SARIF) |
 | `policy` | `strict_abi` | Built-in policy: `strict_abi`, `sdk_vendor`, `plugin_abi` |
 | `policy-file` | — | Custom YAML policy file |
@@ -114,8 +114,8 @@ automatically, then runs ABI comparison and reports results.
 
 | Output | Description |
 |--------|-------------|
-| `verdict` | **compare:** `COMPATIBLE`, `SEVERITY_ERROR`, `API_BREAK`, `BREAKING`, or `ERROR`. `SEVERITY_ERROR` is produced when `severity-addition: error` detects new public API. **compare-release:** `COMPATIBLE`, `API_BREAK`, `BREAKING`, `REMOVED_LIBRARY`, or `ERROR`. **dump:** `COMPATIBLE` or `ERROR`. **stack-check:** `PASS`, `WARN`, `FAIL`, or `ERROR`. **deps:** `PASS`, `FAIL`, or `ERROR`. |
-| `exit-code` | **compare:** `0` (compatible), `1` (severity error), `2` (API break), `4` (ABI break). **compare-release:** `0` (compatible), `2` (API break), `4` (ABI break), `8` (library removed). **stack-check:** `0` (pass), `1` (warn), `4` (fail). **deps:** `0` (ok), `1` (missing). |
+| `verdict` | **compare:** `COMPATIBLE`, `SEVERITY_ERROR`, `API_BREAK`, `BREAKING`, or `ERROR`. **compare-release:** `COMPATIBLE`, `API_BREAK`, `BREAKING`, `REMOVED_LIBRARY`, or `ERROR`. **appcompat:** `COMPATIBLE`, `API_BREAK`, `BREAKING`, or `ERROR`. **dump:** `COMPATIBLE` or `ERROR`. **stack-check:** `PASS`, `WARN`, `FAIL`, or `ERROR`. **deps:** `PASS`, `FAIL`, or `ERROR`. |
+| `exit-code` | **compare:** `0` (compatible), `1` (severity error), `2` (API break), `4` (ABI break). **compare-release:** `0` (compatible), `2` (API break), `4` (ABI break), `8` (library removed). **appcompat:** `0` (compatible), `2` (API break), `4` (ABI break). **stack-check:** `0` (pass), `1` (warn), `4` (fail). **deps:** `0` (ok), `1` (missing). |
 | `report-path` | Path to the generated report file (empty when no output file was produced) |
 
 ## Usage examples


### PR DESCRIPTION
## Summary

Add format validation across all modes to restrict to markdown/json, introduce new header and include flags for appcompat mode, and improve documentation clarity for mode-specific inputs/outputs.

## Motivation

The abicheck tool only supports markdown and json output formats in appcompat, compare-release, deps, and stack-check modes. This change adds validation to prevent invalid format selections and provides helpful fallback behavior. Additionally, appcompat mode needs separate flags for old and new headers/includes to support comparing different API definitions.

## Changes

- **Format validation:** Added checks in `appcompat`, `compare-release`, `deps`, and `stack-check` modes to validate format is either "markdown" or "json", with a warning and fallback to markdown for invalid values
- **New appcompat flags:** Added `--old-header`, `--new-header`, `--old-include`, and `--new-include` flags to support separate header/include specifications for old and new API versions
- **Removed SARIF auto-naming:** Removed automatic output file naming for SARIF format in compare-release mode (SARIF is no longer supported in this mode)
- **Documentation updates:**
  - Clarified `sysroot` applies to dump and deps modes (not just dump)
  - Noted `severity-preset` and `severity-addition` only apply to compare mode
  - Clarified `add-job-summary` is ignored for dump mode
  - Updated verdict and exit-code output descriptions to be mode-specific and accurate for compare-release mode
  - Removed references to `COMPATIBLE_WITH_RISK` verdict which doesn't apply to current modes

## Checklist

- [ ] Tests added / updated for new behaviour
- [ ] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed
- [ ] `pre-commit run --all-files` passes locally
- [ ] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_01PkgQt2Ehp4FuCKZAoidS6p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit REMOVED_LIBRARY verdict and exit code 8 for compare-release.
  * Added support for additional header/include options in appcompat mode.

* **Bug Fixes**
  * Report format now restricted to markdown/json in non-compare modes with automatic fallback and warning.
  * Job summary now shows the resolved report format; mode-specific fail-on flags now enforce final exit behavior.

* **Documentation**
  * Clarified which inputs/outputs apply per mode (sysroot, severity settings, add-job-summary, verdicts, exit codes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->