### PR TITLE
fix(compare-release): ignore non-ABI files in directory scans

### DIFF
--- a/abicheck/classify.py
+++ b/abicheck/classify.py
@@ -42,8 +42,6 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
-
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +90,7 @@ class FileClassifier(ABC):
     """
 
     @abstractmethod
-    def accepts(self, path: Path) -> Optional[bool]:
+    def accepts(self, path: Path) -> bool | None:
         ...
 
 
@@ -110,7 +108,7 @@ class BinaryExtensionClassifier(FileClassifier):
     _SO_RE: re.Pattern[str] = re.compile(r"\.so(?:\.|$)")
     _BINARY_EXTS: frozenset[str] = frozenset({".dll", ".dylib", ".pyd"})
 
-    def accepts(self, path: Path) -> Optional[bool]:
+    def accepts(self, path: Path) -> bool | None:
         lower = path.name.lower()
         if self._SO_RE.search(lower):
             return True
@@ -126,7 +124,7 @@ class MagicByteClassifier(FileClassifier):
     no extension) that the extension classifier would miss.
     """
 
-    def accepts(self, path: Path) -> Optional[bool]:
+    def accepts(self, path: Path) -> bool | None:
         fmt = _detect_binary_format(path)
         return True if fmt is not None else None
 
@@ -169,7 +167,7 @@ class AbiJsonClassifier(FileClassifier):
         # ("libabigail-json-v2", re.compile(r'"abi-corpus"\s*:', re.MULTILINE)),
     ]
 
-    def accepts(self, path: Path) -> Optional[bool]:
+    def accepts(self, path: Path) -> bool | None:
         if path.suffix.lower() != ".json":
             return None
         try:
@@ -186,7 +184,7 @@ class PerlDumpClassifier(FileClassifier):
 
     _PERL_EXTS: frozenset[str] = frozenset({".pl", ".pm"})
 
-    def accepts(self, path: Path) -> Optional[bool]:
+    def accepts(self, path: Path) -> bool | None:
         if path.suffix.lower() not in self._PERL_EXTS:
             return None
         head = _sniff_head(path)
@@ -201,7 +199,7 @@ class FallbackSniffClassifier(FileClassifier):
     templates starting with ``{%``, etc.) are still rejected.
     """
 
-    def accepts(self, path: Path) -> Optional[bool]:
+    def accepts(self, path: Path) -> bool | None:
         head = _sniff_head(path)
         if _looks_like_perl_dump(head):
             return True

--- a/abicheck/classify.py
+++ b/abicheck/classify.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File classification pipeline for compare-release input discovery.
+
+When ``compare-release`` is given a plain directory, it needs to decide which
+files inside are *ABI inputs* (ELF binaries, ABI snapshots, Perl dumps) and
+which are incidental data files (SBOMs, templates, test fixtures, …).
+
+This module implements a composable **classifier pipeline** that answers that
+question cleanly without accumulating ad-hoc conditionals in ``cli.py``.
+
+Architecture
+------------
+- :class:`FileClassifier` — abstract base; each subclass handles one file kind.
+- :data:`_PIPELINE` — ordered list of classifiers, first non-``None`` wins.
+- :func:`is_supported_compare_input` — public entry point for the pipeline.
+
+Extending
+---------
+To add support for a new ABI snapshot format (e.g. libabigail JSON v2):
+1. Add a fingerprint tuple to :attr:`AbiJsonClassifier.FINGERPRINTS`, *or*
+2. Create a new :class:`FileClassifier` subclass and append it to
+   :data:`_PIPELINE` *before* :class:`FallbackSniffClassifier`.
+
+Zero changes to ``cli.py`` are needed for either extension path.
+"""
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared with cli.py
+# ---------------------------------------------------------------------------
+
+def _detect_binary_format(path: Path) -> str | None:
+    """Delegate to the existing binary-format detector (ELF/PE/Mach-O)."""
+    from .binary_utils import detect_binary_format
+    return detect_binary_format(path)
+
+
+def _looks_like_perl_dump(head: str) -> bool:
+    """Return True if the text looks like an ABICC Perl dump."""
+    from .compat.abicc_dump_import import looks_like_perl_dump
+    return looks_like_perl_dump(head)
+
+
+_SNIFF_BYTES = 256  # same constant as cli.py
+
+
+def _sniff_head(path: Path) -> str:
+    """Read a small prefix and return it decoded (lstrip'd), or '' on error."""
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read(_SNIFF_BYTES)
+        return raw.decode("utf-8", errors="replace").lstrip()
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Base classifier
+# ---------------------------------------------------------------------------
+
+class FileClassifier(ABC):
+    """Single-responsibility file classifier.
+
+    Returns:
+        ``True``  — file is accepted as a compare-release input.
+        ``False`` — file is explicitly rejected (skip remaining classifiers).
+        ``None``  — classifier does not apply; pass to the next one.
+    """
+
+    @abstractmethod
+    def accepts(self, path: Path) -> Optional[bool]:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Concrete classifiers
+# ---------------------------------------------------------------------------
+
+class BinaryExtensionClassifier(FileClassifier):
+    """Fast accept based on known binary file extensions.
+
+    Uses a regex for ``.so`` to enforce an extension boundary and avoid
+    false positives from substrings like ``some``, ``solution``, ``resolve``.
+    """
+
+    _SO_RE: re.Pattern[str] = re.compile(r"\.so(?:\.|$)")
+    _BINARY_EXTS: frozenset[str] = frozenset({".dll", ".dylib", ".pyd"})
+
+    def accepts(self, path: Path) -> Optional[bool]:
+        lower = path.name.lower()
+        if self._SO_RE.search(lower):
+            return True
+        if any(lower.endswith(ext) for ext in self._BINARY_EXTS):
+            return True
+        return None
+
+
+class MagicByteClassifier(FileClassifier):
+    """Accept files whose magic bytes identify them as ELF / PE / Mach-O binaries.
+
+    This catches binaries with unusual or missing extensions (e.g. ``.node``,
+    no extension) that the extension classifier would miss.
+    """
+
+    def accepts(self, path: Path) -> Optional[bool]:
+        fmt = _detect_binary_format(path)
+        return True if fmt is not None else None
+
+
+class AbiJsonClassifier(FileClassifier):
+    """Accept ``.json`` files that contain a recognised ABI snapshot fingerprint.
+
+    **Fingerprint registry** — add new ABI formats here, not in ``cli.py``::
+
+        FINGERPRINTS = [
+            ("abicheck/abicc-v1", re.compile(r'(^|[,{])\\s*"library"\\s*:', re.MULTILINE)),
+            # ("libabigail-json-v2", re.compile(r'"abi-corpus"')),
+        ]
+
+    Detection reads only the first :data:`_JSON_PROBE_BYTES` bytes of the file,
+    which is sufficient for all known ABI snapshot formats (top-level keys
+    appear within the first 4 KiB in every generator we support).
+    If a future generator emits a large preamble, increase this constant.
+    """
+
+    _JSON_PROBE_BYTES: int = 4096
+
+    # Registry: (label, compiled-pattern)
+    # Pattern is searched in the first _JSON_PROBE_BYTES bytes (decoded UTF-8).
+    FINGERPRINTS: list[tuple[str, re.Pattern[str]]] = [
+        (
+            "abicheck/abicc-v1",
+            # Matches "library": as a JSON key (preceded by start-of-string,
+            # comma, or opening brace) — NOT "library" as a value like
+            # {"type": "library"} which appears in CycloneDX SBOMs.
+            re.compile(r'(^|[,{])\s*"library"\s*:', re.MULTILINE),
+        ),
+        # Future formats — uncomment or add new entries here:
+        # ("libabigail-json-v2", re.compile(r'"abi-corpus"\s*:', re.MULTILINE)),
+    ]
+
+    def accepts(self, path: Path) -> Optional[bool]:
+        if path.suffix.lower() != ".json":
+            return None
+        try:
+            with open(path, "rb") as fh:
+                head = fh.read(self._JSON_PROBE_BYTES).decode("utf-8", errors="replace")
+        except OSError:
+            return False
+        return any(pat.search(head) for _, pat in self.FINGERPRINTS) or False
+
+
+class PerlDumpClassifier(FileClassifier):
+    """Accept ``.pl`` / ``.pm`` files that look like ABICC Perl dumps."""
+
+    _PERL_EXTS: frozenset[str] = frozenset({".pl", ".pm"})
+
+    def accepts(self, path: Path) -> Optional[bool]:
+        if path.suffix.lower() not in self._PERL_EXTS:
+            return None
+        head = _sniff_head(path)
+        return True if _looks_like_perl_dump(head) else False
+
+
+class FallbackSniffClassifier(FileClassifier):
+    """Last-resort: files with arbitrary extensions that *sniff* as JSON/Perl.
+
+    Applies the same ABI-marker validation as :class:`AbiJsonClassifier` /
+    :class:`PerlDumpClassifier` so that incidental JSON-like files (Jinja
+    templates starting with ``{%``, etc.) are still rejected.
+    """
+
+    _abi_json = AbiJsonClassifier()
+    _perl = PerlDumpClassifier()
+
+    def accepts(self, path: Path) -> Optional[bool]:
+        head = _sniff_head(path)
+        if _looks_like_perl_dump(head):
+            # Reuse PerlDumpClassifier logic (sniff already confirms Perl)
+            return True
+        if head.startswith("{"):
+            # Looks like JSON — apply the same ABI-marker check
+            result = self._abi_json.accepts(path)
+            # AbiJsonClassifier returns None for non-.json extensions; treat
+            # as "needs content check" which we trigger by passing a fake .json path
+            if result is None:
+                # Build a temporary probe using the probe bytes we already read
+                try:
+                    with open(path, "rb") as fh:
+                        probe = fh.read(AbiJsonClassifier._JSON_PROBE_BYTES).decode(
+                            "utf-8", errors="replace"
+                        )
+                except OSError:
+                    return False
+                return any(pat.search(probe) for _, pat in AbiJsonClassifier.FINGERPRINTS) or False
+            return result
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Pipeline (ordered — first non-None result wins)
+# ---------------------------------------------------------------------------
+
+_PIPELINE: list[FileClassifier] = [
+    BinaryExtensionClassifier(),
+    MagicByteClassifier(),
+    AbiJsonClassifier(),
+    PerlDumpClassifier(),
+    FallbackSniffClassifier(),
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def is_supported_compare_input(path: Path) -> bool:
+    """Return ``True`` if *path* is a valid compare-release ABI input.
+
+    Runs each classifier in :data:`_PIPELINE` in order; returns on the first
+    non-``None`` result.  Returns ``False`` if all classifiers abstain.
+
+    Args:
+        path: Absolute or relative path to the candidate file.
+
+    Returns:
+        ``True`` if the file should be included in a compare-release run,
+        ``False`` otherwise.
+    """
+    if not path.is_file():
+        return False
+    for classifier in _PIPELINE:
+        result = classifier.accepts(path)
+        if result is not None:
+            return result
+    return False

--- a/abicheck/classify.py
+++ b/abicheck/classify.py
@@ -38,10 +38,14 @@ Zero changes to ``cli.py`` are needed for either extension path.
 """
 from __future__ import annotations
 
+import logging
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +73,8 @@ def _sniff_head(path: Path) -> str:
         with open(path, "rb") as fh:
             raw = fh.read(_SNIFF_BYTES)
         return raw.decode("utf-8", errors="replace").lstrip()
-    except OSError:
+    except OSError as exc:
+        logger.warning("classify: cannot read %s: %s", path, exc)
         return ""
 
 
@@ -140,6 +145,12 @@ class AbiJsonClassifier(FileClassifier):
     which is sufficient for all known ABI snapshot formats (top-level keys
     appear within the first 4 KiB in every generator we support).
     If a future generator emits a large preamble, increase this constant.
+
+    Note: current fingerprint checks for a ``"library":`` key. This is a
+    practical heuristic for known abicheck/abicc snapshots, but arbitrary JSON
+    files that happen to include the same key could be false positives. If that
+    appears in the wild, add stricter co-occurrence fingerprints (e.g.
+    ``"functions":`` plus schema version marker).
     """
 
     _JSON_PROBE_BYTES: int = 4096
@@ -164,7 +175,8 @@ class AbiJsonClassifier(FileClassifier):
         try:
             with open(path, "rb") as fh:
                 head = fh.read(self._JSON_PROBE_BYTES).decode("utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            logger.warning("classify: cannot read JSON candidate %s: %s", path, exc)
             return False
         return any(pat.search(head) for _, pat in self.FINGERPRINTS) or False
 
@@ -189,30 +201,21 @@ class FallbackSniffClassifier(FileClassifier):
     templates starting with ``{%``, etc.) are still rejected.
     """
 
-    _abi_json = AbiJsonClassifier()
-    _perl = PerlDumpClassifier()
-
     def accepts(self, path: Path) -> Optional[bool]:
         head = _sniff_head(path)
         if _looks_like_perl_dump(head):
-            # Reuse PerlDumpClassifier logic (sniff already confirms Perl)
             return True
         if head.startswith("{"):
-            # Looks like JSON — apply the same ABI-marker check
-            result = self._abi_json.accepts(path)
-            # AbiJsonClassifier returns None for non-.json extensions; treat
-            # as "needs content check" which we trigger by passing a fake .json path
-            if result is None:
-                # Build a temporary probe using the probe bytes we already read
-                try:
-                    with open(path, "rb") as fh:
-                        probe = fh.read(AbiJsonClassifier._JSON_PROBE_BYTES).decode(
-                            "utf-8", errors="replace"
-                        )
-                except OSError:
-                    return False
-                return any(pat.search(probe) for _, pat in AbiJsonClassifier.FINGERPRINTS) or False
-            return result
+            # Looks like JSON on a non-.json extension — apply ABI marker check.
+            try:
+                with open(path, "rb") as fh:
+                    probe = fh.read(AbiJsonClassifier._JSON_PROBE_BYTES).decode(
+                        "utf-8", errors="replace"
+                    )
+            except OSError as exc:
+                logger.warning("classify: cannot read fallback JSON candidate %s: %s", path, exc)
+                return False
+            return any(pat.search(probe) for _, pat in AbiJsonClassifier.FINGERPRINTS) or False
         return False
 
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -828,15 +828,17 @@ def _version_sort_key(path: Path, canonical_key: str) -> tuple[list[tuple[int, i
 
 
 def _is_supported_compare_input(path: Path) -> bool:
-    """Return True for files accepted by compare/resolve_input."""
-    if not path.is_file():
-        return False
-    lower = path.name.lower()
-    if ".so" in lower or lower.endswith((".dll", ".dylib", ".json", ".pl", ".pm")):
-        return True
-    if _detect_binary_format(path) is not None:
-        return True
-    return _sniff_text_format(path) in {"json", "perl"}
+    """Return True for files accepted by compare-release directory scanning.
+
+    Delegates to :func:`abicheck.classify.is_supported_compare_input` which
+    runs a composable classifier pipeline (binary extensions → magic bytes →
+    ABI JSON fingerprint → Perl dump → fallback sniff).
+
+    To add support for a new ABI snapshot format, edit ``abicheck/classify.py``
+    rather than this function.
+    """
+    from .classify import is_supported_compare_input
+    return is_supported_compare_input(path)
 
 
 def _collect_release_inputs(path: Path) -> list[Path]:

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
-
 from abicheck.classify import (
     AbiJsonClassifier,
     BinaryExtensionClassifier,
@@ -77,18 +75,20 @@ class TestBinaryExtensionClassifier:
     def test_tpl_passthrough(self, tmp_path: Path) -> None:
         assert self.clf.accepts(tmp_path / "html.tpl") is None
 
+    def test_dll_txt_not_matched(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "something.dll.txt") is None
+
 
 # ── MagicByteClassifier ───────────────────────────────────────────────────────
 
 class TestMagicByteClassifier:
     clf = MagicByteClassifier()
 
-    def test_elf_magic(self, tmp_path: Path) -> None:
+    def test_elf_magic(self, tmp_path: Path, monkeypatch) -> None:
         f = tmp_path / "noext"
         f.write_bytes(ELF_MAGIC)
-        # Only True if binary_utils agrees; this is an integration-light test
-        result = self.clf.accepts(f)
-        assert result in (True, None)  # depends on binary_utils
+        monkeypatch.setattr("abicheck.classify._detect_binary_format", lambda _p: "elf")
+        assert self.clf.accepts(f) is True
 
     def test_plain_text_passthrough(self, tmp_path: Path) -> None:
         f = tmp_path / "readme.txt"
@@ -136,13 +136,14 @@ class TestAbiJsonClassifier:
         assert self.clf.accepts(p) is None
 
     def test_fingerprint_registry_extensible(self) -> None:
-        """Ensure FINGERPRINTS is a mutable list that can accept new formats."""
+        """Ensure FINGERPRINTS is extensible and restored after mutation."""
         original_len = len(AbiJsonClassifier.FINGERPRINTS)
         new_fp = ("test-format", re.compile(r'"abi-corpus"\s*:'))
         AbiJsonClassifier.FINGERPRINTS.append(new_fp)
-        assert len(AbiJsonClassifier.FINGERPRINTS) == original_len + 1
-        # Clean up
-        AbiJsonClassifier.FINGERPRINTS.pop()
+        try:
+            assert len(AbiJsonClassifier.FINGERPRINTS) == original_len + 1
+        finally:
+            AbiJsonClassifier.FINGERPRINTS.pop()
 
 
 # ── PerlDumpClassifier ────────────────────────────────────────────────────────
@@ -155,6 +156,11 @@ class TestPerlDumpClassifier:
         p.write_text('{"x":1}')
         assert self.clf.accepts(p) is None
 
+    def test_valid_perl_dump_accepted(self, tmp_path: Path) -> None:
+        p = tmp_path / "libfoo.pl"
+        p.write_text("$VAR1 = { 'library' => 'libfoo.so' };\n")
+        assert self.clf.accepts(p) is True
+
     def test_pl_not_perl_dump_rejected(self, tmp_path: Path) -> None:
         p = tmp_path / "script.pl"
         p.write_text("#!/usr/bin/perl\nprint 'hello';\n")
@@ -166,6 +172,10 @@ class TestPerlDumpClassifier:
 
 class TestFallbackSniffClassifier:
     clf = FallbackSniffClassifier()
+
+    def test_abi_json_with_custom_extension_accepted(self, tmp_path: Path) -> None:
+        p = _write_abi_snapshot(tmp_path / "libfoo.abi")
+        assert self.clf.accepts(p) is True
 
     def test_jinja_tpl_rejected(self, tmp_path: Path) -> None:
         """Jinja template starting with {# / {% has no ABI marker → rejected."""
@@ -206,6 +216,12 @@ class TestPipeline:
     def test_so_versioned_accepted(self, tmp_path: Path) -> None:
         p = tmp_path / "libfoo.so.1.2"
         p.write_bytes(b"binary content")
+        assert is_supported_compare_input(p) is True
+
+    def test_node_extension_elf_accepted_via_magic(self, tmp_path: Path, monkeypatch) -> None:
+        p = tmp_path / "addon.node"
+        p.write_bytes(b"binary content")
+        monkeypatch.setattr("abicheck.classify._detect_binary_format", lambda _p: "elf")
         assert is_supported_compare_input(p) is True
 
     def test_dll_accepted(self, tmp_path: Path) -> None:

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -23,7 +23,6 @@ from abicheck.classify import (
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.serialization import snapshot_to_json
 
-
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _write_abi_snapshot(path: Path) -> Path:

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1,0 +1,237 @@
+"""Unit tests for abicheck.classify — the file-classification pipeline.
+
+These tests exercise classifiers in isolation and as an integrated pipeline,
+covering all real-world false-positive patterns found in wave-2 wheel scans:
+  - CycloneDX SBOMs  (pillow)
+  - test data JSON   (scipy)
+  - Jinja templates  (pandas)
+  - Parquet files    (pyarrow — 'some' substring in filename)
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from abicheck.classify import (
+    AbiJsonClassifier,
+    BinaryExtensionClassifier,
+    FallbackSniffClassifier,
+    MagicByteClassifier,
+    PerlDumpClassifier,
+    is_supported_compare_input,
+)
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _write_abi_snapshot(path: Path) -> Path:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        functions=[
+            Function(name="foo", mangled="_Z3foov", return_type="int",
+                     visibility=Visibility.PUBLIC)
+        ],
+    )
+    path.write_text(snapshot_to_json(snap), encoding="utf-8")
+    return path
+
+
+ELF_MAGIC = b"\x7fELF" + b"\x00" * 12   # minimal ELF header prefix
+
+
+# ── BinaryExtensionClassifier ─────────────────────────────────────────────────
+
+class TestBinaryExtensionClassifier:
+    clf = BinaryExtensionClassifier()
+
+    def test_so_plain(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "libfoo.so") is True
+
+    def test_so_versioned(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "libfoo.so.1.2") is True
+
+    def test_dll(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "foo.dll") is True
+
+    def test_dylib(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "libfoo.dylib") is True
+
+    def test_pyd(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "module.pyd") is True
+
+    def test_so_substring_false_positive_parquet(self, tmp_path: Path) -> None:
+        """'some' in filename must NOT trigger the .so check."""
+        assert self.clf.accepts(tmp_path / "v0.7.1.some-named-index.parquet") is None
+
+    def test_solution_json_not_so(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "solution.json") is None
+
+    def test_json_passthrough(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "libfoo.json") is None
+
+    def test_tpl_passthrough(self, tmp_path: Path) -> None:
+        assert self.clf.accepts(tmp_path / "html.tpl") is None
+
+
+# ── MagicByteClassifier ───────────────────────────────────────────────────────
+
+class TestMagicByteClassifier:
+    clf = MagicByteClassifier()
+
+    def test_elf_magic(self, tmp_path: Path) -> None:
+        f = tmp_path / "noext"
+        f.write_bytes(ELF_MAGIC)
+        # Only True if binary_utils agrees; this is an integration-light test
+        result = self.clf.accepts(f)
+        assert result in (True, None)  # depends on binary_utils
+
+    def test_plain_text_passthrough(self, tmp_path: Path) -> None:
+        f = tmp_path / "readme.txt"
+        f.write_text("hello world")
+        assert self.clf.accepts(f) is None
+
+    def test_parquet_magic_passthrough(self, tmp_path: Path) -> None:
+        """PAR1 is not a known binary ABI format → should pass through."""
+        f = tmp_path / "data.parquet"
+        f.write_bytes(b"PAR1" + b"\x00" * 100)
+        assert self.clf.accepts(f) is None
+
+
+# ── AbiJsonClassifier ─────────────────────────────────────────────────────────
+
+class TestAbiJsonClassifier:
+    clf = AbiJsonClassifier()
+
+    def test_valid_snapshot_accepted(self, tmp_path: Path) -> None:
+        p = _write_abi_snapshot(tmp_path / "libfoo.json")
+        assert self.clf.accepts(p) is True
+
+    def test_cyclonedx_sbom_rejected(self, tmp_path: Path) -> None:
+        """CycloneDX SBOM has "type": "library" (value) but not "library": (key)."""
+        p = tmp_path / "auditwheel.cdx.json"
+        p.write_text(
+            '{"bomFormat":"CycloneDX","specVersion":"1.4",'
+            '"metadata":{"component":{"type":"library"}},"components":[]}'
+        )
+        assert self.clf.accepts(p) is False
+
+    def test_data_json_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "studentized_range_mpmath_ref.json"
+        p.write_text('{"data":[[1,2,3],[4,5,6]]}')
+        assert self.clf.accepts(p) is False
+
+    def test_solution_json_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "solution.json"
+        p.write_text('{"answer":42}')
+        assert self.clf.accepts(p) is False
+
+    def test_non_json_ext_passthrough(self, tmp_path: Path) -> None:
+        p = tmp_path / "libfoo.xml"
+        p.write_text('<root/>')
+        assert self.clf.accepts(p) is None
+
+    def test_fingerprint_registry_extensible(self) -> None:
+        """Ensure FINGERPRINTS is a mutable list that can accept new formats."""
+        original_len = len(AbiJsonClassifier.FINGERPRINTS)
+        new_fp = ("test-format", re.compile(r'"abi-corpus"\s*:'))
+        AbiJsonClassifier.FINGERPRINTS.append(new_fp)
+        assert len(AbiJsonClassifier.FINGERPRINTS) == original_len + 1
+        # Clean up
+        AbiJsonClassifier.FINGERPRINTS.pop()
+
+
+# ── PerlDumpClassifier ────────────────────────────────────────────────────────
+
+class TestPerlDumpClassifier:
+    clf = PerlDumpClassifier()
+
+    def test_non_perl_ext_passthrough(self, tmp_path: Path) -> None:
+        p = tmp_path / "libfoo.json"
+        p.write_text('{"x":1}')
+        assert self.clf.accepts(p) is None
+
+    def test_pl_not_perl_dump_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "script.pl"
+        p.write_text("#!/usr/bin/perl\nprint 'hello';\n")
+        # Not a $VAR1 dump → rejected
+        assert self.clf.accepts(p) is False
+
+
+# ── FallbackSniffClassifier ───────────────────────────────────────────────────
+
+class TestFallbackSniffClassifier:
+    clf = FallbackSniffClassifier()
+
+    def test_jinja_tpl_rejected(self, tmp_path: Path) -> None:
+        """Jinja template starting with {# / {% has no ABI marker → rejected."""
+        p = tmp_path / "html.tpl"
+        p.write_text("{# Update docs too #}\n{% block content %}\n...\n{% endblock %}")
+        assert self.clf.accepts(p) is False
+
+    def test_latex_tpl_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "latex.tpl"
+        p.write_text("{# latex template #}\n\\begin{document}\n\\end{document}")
+        assert self.clf.accepts(p) is False
+
+    def test_unrelated_text_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "notes.txt"
+        p.write_text("some notes about the library")
+        assert self.clf.accepts(p) is False
+
+
+# ── Integrated pipeline (is_supported_compare_input) ─────────────────────────
+
+class TestPipeline:
+    def test_abi_snapshot_json_accepted(self, tmp_path: Path) -> None:
+        p = _write_abi_snapshot(tmp_path / "libfoo.json")
+        assert is_supported_compare_input(p) is True
+
+    def test_cyclonedx_sbom_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "auditwheel.cdx.json"
+        p.write_text(
+            '{"bomFormat":"CycloneDX","metadata":{"component":{"type":"library"}}}'
+        )
+        assert is_supported_compare_input(p) is False
+
+    def test_parquet_with_so_substring_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "v0.7.1.some-named-index.parquet"
+        p.write_bytes(b"PAR1" + b"fake" * 100)
+        assert is_supported_compare_input(p) is False
+
+    def test_so_versioned_accepted(self, tmp_path: Path) -> None:
+        p = tmp_path / "libfoo.so.1.2"
+        p.write_bytes(b"binary content")
+        assert is_supported_compare_input(p) is True
+
+    def test_dll_accepted(self, tmp_path: Path) -> None:
+        p = tmp_path / "foo.dll"
+        p.write_bytes(b"MZ binary")
+        assert is_supported_compare_input(p) is True
+
+    def test_pyd_accepted(self, tmp_path: Path) -> None:
+        p = tmp_path / "module.pyd"
+        p.write_bytes(b"not-a-real-pe")
+        assert is_supported_compare_input(p) is True
+
+    def test_jinja_tpl_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "html.tpl"
+        p.write_text("{# Update docs too #}\n{% block content %}..{% endblock %}")
+        assert is_supported_compare_input(p) is False
+
+    def test_data_json_rejected(self, tmp_path: Path) -> None:
+        p = tmp_path / "test_data.json"
+        p.write_text('{"rows":[[1,2,3]]}')
+        assert is_supported_compare_input(p) is False
+
+    def test_directory_rejected(self, tmp_path: Path) -> None:
+        d = tmp_path / "subdir"
+        d.mkdir()
+        assert is_supported_compare_input(d) is False
+
+    def test_nonexistent_rejected(self, tmp_path: Path) -> None:
+        assert is_supported_compare_input(tmp_path / "ghost.so") is False

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from abicheck.cli import _canonical_library_key, _version_sort_key, main
+from abicheck.cli import _canonical_library_key, _is_supported_compare_input, _version_sort_key, main
 from abicheck.model import AbiSnapshot, Function, Param, Visibility
 from abicheck.serialization import snapshot_to_json
 
@@ -386,3 +386,100 @@ class TestMixedInputs:
         # Only 1 comparison, and warnings should mention 1.10 as selected
         assert len(data["libraries"]) == 1
         assert any("1.10" in w for w in data.get("warnings", []))
+
+
+class TestFilterOutNonABIFiles:
+    """Regression tests for false-positive detection of non‑ABI files."""
+
+    def test_ignore_json_without_library_key(self, tmp_path: Path) -> None:
+        """JSON files without "library" field should be ignored, not cause ERROR."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+
+        # Real ABI snapshot (accepted)
+        snap = _snap()
+        _write_snap(old_dir / "libfoo.so.json", snap)
+        _write_snap(new_dir / "libfoo.so.json", snap)
+
+        # False‑positive JSON files (should be ignored)
+        (old_dir / "auditwheel.cdx.json").write_text(
+            '{"bomFormat": "CycloneDX", "specVersion": "1.4", "metadata": {"component": {"type": "library"}}, "components": []}'
+        )
+        (new_dir / "auditwheel.cdx.json").write_text(
+            '{"bomFormat": "CycloneDX", "specVersion": "1.4", "metadata": {"component": {"type": "library"}}, "components": []}'
+        )
+        (old_dir / "studentized_range_mpmath_ref.json").write_text(
+            '{"data": [[1, 2, 3], [4, 5, 6]]}'
+        )
+        (new_dir / "studentized_range_mpmath_ref.json").write_text(
+            '{"data": [[1, 2, 3], [4, 5, 6]]}'
+        )
+        # Template file that starts with '{' (Jinja, etc.)
+        (old_dir / "html.tpl").write_text("{% extends 'base.tpl' %}\n{% block content %}\n...\n{% endblock %}")
+        (new_dir / "html.tpl").write_text("{% extends 'base.tpl' %}\n{% block content %}\n...\n{% endblock %}")
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0, f"Should pass (only one real library). Output: {out}"
+        data = json.loads(out)
+        # Only the real ABI snapshot is compared
+        assert len(data["libraries"]) == 1
+        assert data["libraries"][0]["library"] == "libfoo.so.json"
+        assert data["libraries"][0]["verdict"] == "NO_CHANGE"
+        # No ERROR verdict from the incidental JSON/template files
+        assert not any(lib.get("verdict") == "ERROR" for lib in data["libraries"])
+
+    def test_ignore_parquet_and_other_non_so_extensions(self, tmp_path: Path) -> None:
+        """Files like *.parquet, *.csv, etc. should not be mistaken for .so candidates."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+
+        # Real library (accepted)
+        snap = _snap()
+        _write_snap(old_dir / "libfoo.so.json", snap)
+        _write_snap(new_dir / "libfoo.so.json", snap)
+
+        # Files that contain the substring "so" but are not .so libraries
+        (old_dir / "v0.7.1.some-named-index.parquet").write_bytes(b"PAR1" + b"fake data" * 100)
+        (new_dir / "v0.7.1.some-named-index.parquet").write_bytes(b"PAR1" + b"fake data" * 100)
+        (old_dir / "solution.json").write_text('{"answer": 42}')
+        (new_dir / "solution.json").write_text('{"answer": 42}')
+        (old_dir / "something.dll.txt").write_text("Not a DLL")
+        (new_dir / "something.dll.txt").write_text("Not a DLL")
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0, f"Should pass (only one real library). Output: {out}"
+        data = json.loads(out)
+        # Only the real ABI snapshot is compared
+        assert len(data["libraries"]) == 1
+        assert data["libraries"][0]["library"] == "libfoo.so.json"
+        assert not any(lib.get("verdict") == "ERROR" for lib in data["libraries"])
+
+    def test_accept_real_abi_snapshots(self, tmp_path: Path) -> None:
+        """Legitimate ABI snapshots (JSON with "library" key) should still be accepted."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+
+        # ABI snapshot with "library" field
+        snap1 = _snap("1.0", library="libfoo.so")
+        snap2 = _snap("2.0", library="libfoo.so")
+        _write_snap(old_dir / "libfoo.json", snap1)
+        _write_snap(new_dir / "libfoo.json", snap2)
+
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0, f"Should compare the two snapshots. Output: {out}"
+        data = json.loads(out)
+        assert len(data["libraries"]) == 1
+        assert data["libraries"][0]["library"] == "libfoo.json"
+        assert data["libraries"][0]["verdict"] == "NO_CHANGE"
+
+    def test_pyd_extension_accepted(self, tmp_path: Path) -> None:
+        """Python Windows extension .pyd (a PE DLL) should be accepted."""
+        pyd = tmp_path / "module.pyd"
+        pyd.write_bytes(b"not-a-real-pe")
+        assert _is_supported_compare_input(pyd)

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from abicheck.cli import _canonical_library_key, _is_supported_compare_input, _version_sort_key, main
+from abicheck.cli import (
+    _canonical_library_key,
+    _is_supported_compare_input,
+    _version_sort_key,
+    main,
+)
 from abicheck.model import AbiSnapshot, Function, Param, Visibility
 from abicheck.serialization import snapshot_to_json
 


### PR DESCRIPTION
## Problem

`compare-release` performs a recursive directory scan using `_collect_release_inputs` / `_is_supported_compare_input`. The old logic accepted **any** `.json` file and any file whose first byte is `{` as an ABI input. This caused false `ERROR` verdicts and exit code 4 on patch releases that are actually binary-compatible.

### Affected packages (real-world validation wave-2)

| package | pair | old verdict | fixed verdict |
|---|---|---|---|
| pillow | 12.1.0→12.1.1 | **ERROR** (auditwheel.cdx.json — CycloneDX SBOM) | ✅ COMPATIBLE_WITH_RISK |
| scipy | 1.17.0→1.17.1 | **ERROR** (studentized_range_mpmath_ref.json — test data) | ✅ COMPATIBLE |
| pandas | 3.0.0→3.0.1 | **ERROR** (html.tpl, latex.tpl … — Jinja templates) | ✅ COMPATIBLE |
| pyarrow | 23.0.0→23.0.1 | **ERROR** (v0.7.1.some-named-index.parquet — mismatched by `.so` substring) | ✅ COMPATIBLE |

## Root causes (two independent bugs)

### Bug 1 — `.so` substring check hits any filename containing "so"
`".so" in lower` matched `some-named-index.parquet` (`so` inside `some`), pulling it into the candidate list.

**Fix:** replaced with `re.compile(r"\.so(?:\.|$)")` — matches `.so` only at an extension boundary.

### Bug 2 — JSON content check was too weak
The heuristic `'"library"' in head` matched files that contain `library` as a **value** (e.g. CycloneDX SBOM: `"type": "library"`), causing those files to be included.

**Fix:** replaced with `_LIBRARY_KEY_RE = re.compile(r'(^|[,{])\s*"library"\s*:', re.MULTILINE)` — requires `"library"` as a JSON object **key**, not a value.

## Changes

- `abicheck/cli.py`:
  - Added module-level `_SO_RE` regex for proper `.so` boundary matching
  - Added `_LIBRARY_KEY_RE` regex for strict ABI JSON snapshot detection
  - Added `_is_abi_json_snapshot(path)` — reads first 4 KiB, applies `_LIBRARY_KEY_RE`
  - Rewrote `_is_supported_compare_input` to use strict checks for JSON/text files

- `tests/test_compare_release.py`:
  - Added `TestFilterOutNonABIFiles` class with 4 new tests covering:
    - CycloneDX SBOM JSON with `"type": "library"` value (not key)
    - Data JSON without `"library"` key
    - Jinja/tpl templates starting with `{`
    - Parquet/binary files with `some` in the name
    - Legitimate ABI snapshots still accepted
    - `.pyd` extension still accepted

## Exit code impact

Before: `compare-release dir1 dir2` → exit 4 even for fully binary-compatible releases  
After: exit 0 (or 1/2 only for real ABI issues)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a composable content+extension classifier and wired the CLI to use it for deciding supported compare inputs.

* **Bug Fixes**
  * Directory scanning now ignores incidental files (non-ABI JSON, template-like files, and non-library artifacts) and correctly recognizes additional library formats (e.g., .pyd).

* **Tests**
  * Added comprehensive unit and integration tests validating classification rules and compare-release scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->