### PR TITLE
Add comprehensive unit tests for service and demangle modules

### DIFF
--- a/tests/test_demangle_unit.py
+++ b/tests/test_demangle_unit.py
@@ -1,0 +1,269 @@
+"""Unit tests for abicheck.demangle — targeting ≥80% coverage."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Clear the LRU cache before each test to avoid cross-test contamination
+import abicheck.demangle as _mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    _mod.demangle.cache_clear()
+    _mod._warned_no_demangler = False
+    yield
+    _mod.demangle.cache_clear()
+    _mod._warned_no_demangler = False
+
+
+# ── demangle() ──────────────────────────────────────────────────────────────
+
+
+class TestDemangle:
+    """Tests for the single-symbol demangle() function."""
+
+    def test_empty_string_returns_none(self):
+        assert _mod.demangle("") is None
+
+    def test_non_cpp_symbol_returns_none(self):
+        assert _mod.demangle("printf") is None
+
+    def test_non_z_prefix_returns_none(self):
+        assert _mod.demangle("myFunction") is None
+
+    def test_cxxfilt_available(self):
+        """When cxxfilt is importable and works, we get a demangled string."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.return_value = "foo::bar()"
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            result = _mod.demangle("_ZN3foo3barEv")
+        assert result == "foo::bar()"
+
+    def test_cxxfilt_raises_falls_through_to_cppfilt(self):
+        """When cxxfilt raises, fall back to c++filt subprocess."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("boom")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt", "_ZN3foo3barEv"],
+                    returncode=0,
+                    stdout="foo::bar()\n",
+                    stderr="",
+                )
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result == "foo::bar()"
+
+    def test_cppfilt_non_zero_return_code(self):
+        """When c++filt returns non-zero, we get None (after cxxfilt also fails)."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=1, stdout="", stderr="error",
+                )
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+
+    def test_cppfilt_output_same_as_input(self):
+        """If c++filt outputs the same symbol, treat as failed demangling."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"],
+                    returncode=0,
+                    stdout="_ZN3foo3barEv\n",
+                    stderr="",
+                )
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+
+    def test_cppfilt_empty_output(self):
+        """If c++filt returns empty stdout, treat as failed."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=0, stdout="", stderr="",
+                )
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+
+    def test_cppfilt_file_not_found(self):
+        """When c++filt binary is missing, return None."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+
+    def test_cppfilt_timeout(self):
+        """When c++filt times out, return None."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("c++filt", 5)):
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result is None
+
+    def test_warning_emitted_once(self):
+        """The 'demangling unavailable' warning fires only once."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                _mod.demangle("_ZN3foo3barEv")
+                _mod.demangle.cache_clear()
+                _mod.demangle("_ZN3foo3bazEv")
+        assert _mod._warned_no_demangler is True
+
+
+# ── demangle_batch() ────────────────────────────────────────────────────────
+
+
+class TestDemangleBatch:
+    """Tests for the batch demangling function."""
+
+    def test_empty_list(self):
+        assert _mod.demangle_batch([]) == {}
+
+    def test_no_cpp_symbols(self):
+        assert _mod.demangle_batch(["printf", "strlen", ""]) == {}
+
+    def test_cxxfilt_available_batch(self):
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = lambda s: f"demangled_{s}"
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            result = _mod.demangle_batch(["_ZN3foo3barEv", "_ZN3baz4quxEv"])
+        assert result == {
+            "_ZN3foo3barEv": "demangled__ZN3foo3barEv",
+            "_ZN3baz4quxEv": "demangled__ZN3baz4quxEv",
+        }
+
+    def test_cxxfilt_partial_failure_falls_to_cppfilt(self):
+        """When cxxfilt fails on some symbols, c++filt handles the rest."""
+        mock_cxxfilt = MagicMock()
+        call_count = 0
+
+        def _side_effect(s):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return f"demangled_{s}"
+            raise RuntimeError("fail")
+
+        mock_cxxfilt.demangle.side_effect = _side_effect
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=0,
+                    stdout="baz::qux()\n", stderr="",
+                )
+                result = _mod.demangle_batch(["_ZN3foo3barEv", "_ZN3baz4quxEv"])
+        assert "_ZN3foo3barEv" in result
+        assert result["_ZN3baz4quxEv"] == "baz::qux()"
+
+    def test_cxxfilt_import_error_falls_to_cppfilt(self):
+        """When cxxfilt can't be imported, use c++filt for all."""
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=0,
+                    stdout="foo::bar()\n", stderr="",
+                )
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {"_ZN3foo3barEv": "foo::bar()"}
+
+    def test_cppfilt_file_not_found_batch(self):
+        """When c++filt is missing, batch returns empty for those symbols."""
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {}
+
+    def test_cppfilt_timeout_batch(self):
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("c++filt", 30)):
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {}
+
+    def test_cppfilt_non_zero_return_batch(self):
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=1, stdout="", stderr="err",
+                )
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {}
+
+    def test_cppfilt_same_as_input_skipped(self):
+        """Symbols that c++filt returns unchanged are excluded."""
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=0,
+                    stdout="_ZN3foo3barEv\n", stderr="",
+                )
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {}
+
+    def test_cxxfilt_returns_same_as_input(self):
+        """When cxxfilt.demangle returns the same string, push to remaining."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = lambda s: s  # return unchanged
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=["c++filt"], returncode=0,
+                    stdout="foo::bar()\n", stderr="",
+                )
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {"_ZN3foo3barEv": "foo::bar()"}
+
+    def test_mixed_cpp_and_non_cpp(self):
+        """Non-C++ symbols are filtered out from the batch."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.return_value = "foo::bar()"
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            result = _mod.demangle_batch(["printf", "_ZN3foo3barEv", "", "strlen"])
+        assert list(result.keys()) == ["_ZN3foo3barEv"]
+
+
+# ── base_name() ─────────────────────────────────────────────────────────────
+
+
+class TestBaseName:
+    """Tests for the base_name() helper."""
+
+    def test_plain_c_name(self):
+        assert _mod.base_name("add") == "add"
+
+    def test_demangled_qualified(self):
+        """When demangle returns a qualified name, extract the last part."""
+        with patch.object(_mod, "demangle", return_value="Widget::getValue() const"):
+            result = _mod.base_name("_ZNK6Widget8getValueEv")
+        assert result == "getValue"
+
+    def test_demangled_no_parens(self):
+        with patch.object(_mod, "demangle", return_value="ns::Foo"):
+            result = _mod.base_name("_ZN2ns3FooE")
+        assert result == "Foo"
+
+    def test_demangle_returns_none(self):
+        """When demangle returns None, base_name uses the raw symbol."""
+        with patch.object(_mod, "demangle", return_value=None):
+            result = _mod.base_name("simple_func")
+        assert result == "simple_func"
+
+    def test_no_namespace(self):
+        with patch.object(_mod, "demangle", return_value="getValue()"):
+            result = _mod.base_name("_Z8getValuev")
+        assert result == "getValue"

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -2,14 +2,12 @@
 from __future__ import annotations
 
 import json
-import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from abicheck.checker_policy import ChangeKind, Verdict
-from abicheck.checker_types import Change, DiffResult
+from abicheck.checker_types import DiffResult
 from abicheck.errors import SnapshotError, ValidationError
 from abicheck.model import AbiSnapshot, DependencyInfo, Function, Visibility
 from abicheck.service import (
@@ -24,7 +22,6 @@ from abicheck.service import (
     run_dump,
     sniff_text_format,
 )
-
 
 # ── detect_binary_format() ──────────────────────────────────────────────────
 
@@ -213,7 +210,7 @@ class TestRunDump:
         p = tmp_path / "lib.so"
         p.write_bytes(b"\x7fELF" + b"\x00" * 100)
         snap = AbiSnapshot(library="test", version="1.0")
-        with patch("abicheck.service._dump_elf", return_value=snap) as mock:
+        with patch("abicheck.service._dump_elf", return_value=snap):
             result = run_dump(p, "elf")
         assert result is snap
 
@@ -221,7 +218,7 @@ class TestRunDump:
         p = tmp_path / "lib.dll"
         p.write_bytes(b"MZ" + b"\x00" * 100)
         snap = AbiSnapshot(library="test", version="1.0")
-        with patch("abicheck.service._dump_pe", return_value=snap) as mock:
+        with patch("abicheck.service._dump_pe", return_value=snap):
             result = run_dump(p, "pe")
         assert result is snap
 
@@ -229,7 +226,7 @@ class TestRunDump:
         p = tmp_path / "lib.dylib"
         p.write_bytes(b"\xfe\xed\xfa\xce" + b"\x00" * 100)
         snap = AbiSnapshot(library="test", version="1.0")
-        with patch("abicheck.service._dump_macho", return_value=snap) as mock:
+        with patch("abicheck.service._dump_macho", return_value=snap):
             result = run_dump(p, "macho")
         assert result is snap
 
@@ -555,11 +552,14 @@ class TestLoadSuppressionAndPolicy:
         assert p is None
 
     def test_policy_file_with_non_default_policy_warns(self, tmp_path, caplog):
+        import logging
+
         pf = tmp_path / "policy.yaml"
         pf.write_text("overrides: {}\n")
-        _, p = load_suppression_and_policy(None, policy="permissive", policy_file_path=pf)
+        with caplog.at_level(logging.WARNING, logger="abicheck.service"):
+            _, p = load_suppression_and_policy(None, policy="permissive", policy_file_path=pf)
         assert p is not None
-        assert "ignored" in caplog.text.lower() or True  # warning may or may not show
+        assert "ignored" in caplog.text.lower()
 
     def test_invalid_policy_file(self, tmp_path):
         pf = tmp_path / "bad_policy.yaml"

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -1,0 +1,730 @@
+"""Unit tests for abicheck.service — targeting ≥80% coverage."""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.checker_types import Change, DiffResult
+from abicheck.errors import SnapshotError, ValidationError
+from abicheck.model import AbiSnapshot, DependencyInfo, Function, Visibility
+from abicheck.service import (
+    _render_deps_section_md,
+    collect_metadata,
+    detect_binary_format,
+    expand_header_inputs,
+    load_suppression_and_policy,
+    render_output,
+    resolve_input,
+    run_compare,
+    run_dump,
+    sniff_text_format,
+)
+
+
+# ── detect_binary_format() ──────────────────────────────────────────────────
+
+
+class TestDetectBinaryFormat:
+    def test_delegates_to_binary_utils(self, tmp_path):
+        p = tmp_path / "test.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        result = detect_binary_format(p)
+        assert result == "elf"
+
+    def test_non_binary_returns_none(self, tmp_path):
+        p = tmp_path / "test.txt"
+        p.write_text("hello world")
+        result = detect_binary_format(p)
+        assert result is None
+
+
+# ── sniff_text_format() ─────────────────────────────────────────────────────
+
+
+class TestSniffTextFormat:
+    def test_json_format(self, tmp_path):
+        p = tmp_path / "snap.json"
+        p.write_text('{"library": "test"}')
+        assert sniff_text_format(p) == "json"
+
+    def test_perl_format(self, tmp_path):
+        p = tmp_path / "dump.pl"
+        p.write_text("$VAR1 = { 'Headers' => {} };")
+        assert sniff_text_format(p) == "perl"
+
+    def test_unknown_format(self, tmp_path):
+        p = tmp_path / "test.txt"
+        p.write_text("Some random text content")
+        assert sniff_text_format(p) == "unknown"
+
+    def test_oserror_returns_unknown(self, tmp_path):
+        p = tmp_path / "nonexistent"
+        assert sniff_text_format(p) == "unknown"
+
+    def test_json_with_whitespace(self, tmp_path):
+        p = tmp_path / "snap.json"
+        p.write_text("   \n  {}")
+        assert sniff_text_format(p) == "json"
+
+
+# ── expand_header_inputs() ──────────────────────────────────────────────────
+
+
+class TestExpandHeaderInputs:
+    def test_single_file(self, tmp_path):
+        h = tmp_path / "foo.h"
+        h.write_text("#pragma once")
+        result = expand_header_inputs([h])
+        assert result == [h]
+
+    def test_directory_expansion(self, tmp_path):
+        d = tmp_path / "include"
+        d.mkdir()
+        (d / "a.h").write_text("")
+        (d / "b.hpp").write_text("")
+        (d / "c.txt").write_text("")  # not a header
+        result = expand_header_inputs([d])
+        names = {p.name for p in result}
+        assert "a.h" in names
+        assert "b.hpp" in names
+        assert "c.txt" not in names
+
+    def test_nonexistent_path_raises(self, tmp_path):
+        with pytest.raises(ValidationError, match="not found"):
+            expand_header_inputs([tmp_path / "missing.h"])
+
+    def test_empty_directory_raises(self, tmp_path):
+        d = tmp_path / "empty"
+        d.mkdir()
+        with pytest.raises(ValidationError, match="no supported header"):
+            expand_header_inputs([d])
+
+    def test_deduplication(self, tmp_path):
+        h = tmp_path / "foo.h"
+        h.write_text("")
+        result = expand_header_inputs([h, h])
+        assert len(result) == 1
+
+    def test_directory_with_subdirs(self, tmp_path):
+        d = tmp_path / "include"
+        d.mkdir()
+        sub = d / "sub"
+        sub.mkdir()
+        (sub / "deep.h").write_text("")
+        result = expand_header_inputs([d])
+        assert len(result) == 1
+        assert result[0].name == "deep.h"
+
+    def test_various_extensions(self, tmp_path):
+        d = tmp_path / "hdrs"
+        d.mkdir()
+        for ext in (".h", ".hh", ".hpp", ".hxx", ".h++", ".ipp", ".tpp", ".inc"):
+            (d / f"test{ext}").write_text("")
+        result = expand_header_inputs([d])
+        assert len(result) == 8
+
+
+# ── resolve_input() ─────────────────────────────────────────────────────────
+
+
+class TestResolveInput:
+    def test_is_elf_true_calls_run_dump(self, tmp_path):
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service.run_dump", return_value=snap) as mock:
+            result = resolve_input(p, is_elf=True)
+        assert result is snap
+        mock.assert_called_once()
+
+    def test_binary_detection_elf(self, tmp_path):
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service.run_dump", return_value=snap):
+            result = resolve_input(p)
+        assert result is snap
+
+    def test_json_text_format(self, tmp_path):
+        p = tmp_path / "snap.json"
+        snap = AbiSnapshot(library="test", version="1.0")
+        p.write_text('{"library": "test"}')
+        with patch("abicheck.service.load_snapshot", return_value=snap):
+            result = resolve_input(p, is_elf=False)
+        assert result is snap
+
+    def test_json_load_error_wraps_in_snapshot_error(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{invalid json")
+        with patch("abicheck.service.load_snapshot", side_effect=ValueError("bad")):
+            with pytest.raises(SnapshotError, match="Failed to load JSON"):
+                resolve_input(p, is_elf=False)
+
+    def test_perl_format(self, tmp_path):
+        p = tmp_path / "dump.pl"
+        p.write_text("$VAR1 = {};")
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service.detect_binary_format", return_value=None):
+            with patch("abicheck.service.sniff_text_format", return_value="perl"):
+                with patch(
+                    "abicheck.compat.abicc_dump_import.import_abicc_perl_dump",
+                    return_value=snap,
+                ):
+                    result = resolve_input(p, is_elf=False)
+        assert result is snap
+
+    def test_perl_import_error(self, tmp_path):
+        p = tmp_path / "dump.pl"
+        p.write_text("$VAR1 = {};")
+        with patch("abicheck.service.detect_binary_format", return_value=None):
+            with patch("abicheck.service.sniff_text_format", return_value="perl"):
+                with patch(
+                    "abicheck.compat.abicc_dump_import.import_abicc_perl_dump",
+                    side_effect=ValueError("parse fail"),
+                ):
+                    with pytest.raises(SnapshotError, match="ABICC Perl"):
+                        resolve_input(p, is_elf=False)
+
+    def test_unknown_format_raises(self, tmp_path):
+        p = tmp_path / "mystery"
+        p.write_text("???")
+        with patch("abicheck.service.detect_binary_format", return_value=None):
+            with patch("abicheck.service.sniff_text_format", return_value="unknown"):
+                with pytest.raises(ValidationError, match="Cannot detect format"):
+                    resolve_input(p, is_elf=False)
+
+
+# ── run_dump() ──────────────────────────────────────────────────────────────
+
+
+class TestRunDump:
+    def test_unsupported_format(self, tmp_path):
+        p = tmp_path / "lib.xyz"
+        p.write_bytes(b"\x00" * 100)
+        with pytest.raises(ValidationError, match="Unsupported binary format"):
+            run_dump(p, "webasm")
+
+    def test_elf_format_delegates(self, tmp_path):
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service._dump_elf", return_value=snap) as mock:
+            result = run_dump(p, "elf")
+        assert result is snap
+
+    def test_pe_format_delegates(self, tmp_path):
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service._dump_pe", return_value=snap) as mock:
+            result = run_dump(p, "pe")
+        assert result is snap
+
+    def test_macho_format_delegates(self, tmp_path):
+        p = tmp_path / "lib.dylib"
+        p.write_bytes(b"\xfe\xed\xfa\xce" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service._dump_macho", return_value=snap) as mock:
+            result = run_dump(p, "macho")
+        assert result is snap
+
+
+# ── _dump_elf() ─────────────────────────────────────────────────────────────
+
+
+class TestDumpElf:
+    def test_no_headers_warning(self, tmp_path):
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service.expand_header_inputs", return_value=[]):
+            with patch("abicheck.dumper.dump", return_value=snap):
+                result = _dump_elf(p, [], [], "1.0", "c++")
+        assert result is snap
+
+    def test_invalid_include_dir_raises(self, tmp_path):
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        h = tmp_path / "foo.h"
+        h.write_text("")
+        bad_inc = tmp_path / "nonexistent"
+        with patch("abicheck.service.expand_header_inputs", return_value=[h]):
+            with pytest.raises(ValidationError, match="Include directory"):
+                _dump_elf(p, [h], [bad_inc], "1.0", "c++")
+
+    def test_dump_error_wraps(self, tmp_path):
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x00" * 10)
+        with patch("abicheck.service.expand_header_inputs", return_value=[]):
+            with patch("abicheck.dumper.dump", side_effect=RuntimeError("bad elf")):
+                with pytest.raises(SnapshotError, match="Failed to dump"):
+                    _dump_elf(p, [], [], "1.0", "c++")
+
+    def test_includes_without_headers_warns(self, tmp_path):
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        inc = tmp_path / "inc"
+        inc.mkdir()
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service.expand_header_inputs", return_value=[]):
+            with patch("abicheck.dumper.dump", return_value=snap):
+                result = _dump_elf(p, [], [inc], "1.0", "c++")
+        assert result is snap
+
+    def test_lang_c_sets_compiler(self, tmp_path):
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with patch("abicheck.service.expand_header_inputs", return_value=[]):
+            with patch("abicheck.dumper.dump", return_value=snap) as mock_dump:
+                _dump_elf(p, [], [], "1.0", "c")
+        call_kwargs = mock_dump.call_args
+        assert call_kwargs.kwargs.get("compiler") == "cc" or call_kwargs[1].get("compiler") == "cc"
+
+
+# ── _dump_pe() ──────────────────────────────────────────────────────────────
+
+
+class TestDumpPe:
+    def test_no_machine_raises(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        pe_meta = MagicMock()
+        pe_meta.machine = None
+        pe_meta.exports = []
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with pytest.raises(SnapshotError, match="Failed to extract PE metadata"):
+                _dump_pe(p, "1.0")
+
+    def test_no_exports_raises(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        pe_meta = MagicMock()
+        pe_meta.machine = "AMD64"
+        pe_meta.exports = []
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with pytest.raises(ValidationError, match="no exports"):
+                _dump_pe(p, "1.0")
+
+    def test_successful_pe_dump(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        export = MagicMock()
+        export.name = "MyFunc"
+        export.ordinal = 1
+        pe_meta = MagicMock()
+        pe_meta.machine = "AMD64"
+        pe_meta.exports = [export]
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with patch("abicheck.pdb_utils.locate_pdb", return_value=None):
+                result = _dump_pe(p, "1.0")
+        assert result.platform == "pe"
+        assert len(result.functions) == 1
+        assert result.functions[0].name == "MyFunc"
+
+    def test_pe_import_error(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        with patch("abicheck.pe_metadata.parse_pe_metadata", side_effect=ImportError("no pefile")):
+            with pytest.raises(SnapshotError, match="no pefile"):
+                _dump_pe(p, "1.0")
+
+    def test_pe_runtime_error(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        with patch("abicheck.pe_metadata.parse_pe_metadata", side_effect=RuntimeError("corrupt")):
+            with pytest.raises(SnapshotError, match="Failed to parse PE"):
+                _dump_pe(p, "1.0")
+
+    def test_ordinal_export(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        export = MagicMock()
+        export.name = None
+        export.ordinal = 42
+        pe_meta = MagicMock()
+        pe_meta.machine = "AMD64"
+        pe_meta.exports = [export]
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with patch("abicheck.pdb_utils.locate_pdb", return_value=None):
+                result = _dump_pe(p, "1.0")
+        assert result.functions[0].name == "ordinal:42"
+
+    def test_pdb_found_and_parsed(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        export = MagicMock()
+        export.name = "Func"
+        export.ordinal = 1
+        pe_meta = MagicMock()
+        pe_meta.machine = "AMD64"
+        pe_meta.exports = [export]
+        mock_dwarf = MagicMock()
+        mock_adv = MagicMock()
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with patch("abicheck.pdb_utils.locate_pdb", return_value=Path("/fake.pdb")):
+                with patch("abicheck.pdb_metadata.parse_pdb_debug_info", return_value=(mock_dwarf, mock_adv)):
+                    result = _dump_pe(p, "1.0")
+        assert result.dwarf is mock_dwarf
+        assert result.dwarf_advanced is mock_adv
+
+    def test_pdb_parsing_exception_handled(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        export = MagicMock()
+        export.name = "Func"
+        export.ordinal = 1
+        pe_meta = MagicMock()
+        pe_meta.machine = "AMD64"
+        pe_meta.exports = [export]
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with patch("abicheck.pdb_utils.locate_pdb", side_effect=RuntimeError("pdb error")):
+                result = _dump_pe(p, "1.0")
+        assert result.dwarf is None
+
+    def test_cpp_name_not_extern_c(self, tmp_path):
+        from abicheck.service import _dump_pe
+
+        p = tmp_path / "lib.dll"
+        p.write_bytes(b"MZ" + b"\x00" * 100)
+        export = MagicMock()
+        export.name = "?MyFunc@@YAXXZ"  # MSVC mangled
+        export.ordinal = 1
+        pe_meta = MagicMock()
+        pe_meta.machine = "AMD64"
+        pe_meta.exports = [export]
+        with patch("abicheck.pe_metadata.parse_pe_metadata", return_value=pe_meta):
+            with patch("abicheck.pdb_utils.locate_pdb", return_value=None):
+                result = _dump_pe(p, "1.0")
+        assert result.functions[0].is_extern_c is False
+
+
+# ── _dump_macho() ───────────────────────────────────────────────────────────
+
+
+class TestDumpMacho:
+    def test_successful_macho_dump(self, tmp_path):
+        from abicheck.service import _dump_macho
+
+        p = tmp_path / "lib.dylib"
+        p.write_bytes(b"\xfe\xed\xfa\xce" + b"\x00" * 100)
+        export = MagicMock()
+        export.name = "_myFunc"
+        macho_meta = MagicMock()
+        macho_meta.exports = [export]
+        macho_meta.install_name = "libtest.dylib"
+        macho_meta.dependent_libs = []
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=macho_meta):
+            result = _dump_macho(p, "1.0")
+        assert result.platform == "macho"
+        assert len(result.functions) == 1
+
+    def test_no_exports_no_metadata_raises(self, tmp_path):
+        from abicheck.service import _dump_macho
+
+        p = tmp_path / "lib.dylib"
+        p.write_bytes(b"\x00" * 100)
+        macho_meta = MagicMock()
+        macho_meta.exports = []
+        macho_meta.install_name = None
+        macho_meta.dependent_libs = []
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=macho_meta):
+            with pytest.raises(SnapshotError, match="no exports"):
+                _dump_macho(p, "1.0")
+
+    def test_parse_error(self, tmp_path):
+        from abicheck.service import _dump_macho
+
+        p = tmp_path / "lib.dylib"
+        p.write_bytes(b"\x00" * 100)
+        with patch("abicheck.macho_metadata.parse_macho_metadata", side_effect=RuntimeError("bad macho")):
+            with pytest.raises(SnapshotError, match="Failed to parse Mach-O"):
+                _dump_macho(p, "1.0")
+
+    def test_export_without_name_skipped(self, tmp_path):
+        from abicheck.service import _dump_macho
+
+        p = tmp_path / "lib.dylib"
+        p.write_bytes(b"\x00" * 100)
+        exp_named = MagicMock()
+        exp_named.name = "_func"
+        exp_empty = MagicMock()
+        exp_empty.name = ""
+        macho_meta = MagicMock()
+        macho_meta.exports = [exp_named, exp_empty]
+        macho_meta.install_name = "libtest.dylib"
+        macho_meta.dependent_libs = []
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=macho_meta):
+            result = _dump_macho(p, "1.0")
+        assert len(result.functions) == 1
+
+    def test_cpp_symbol_not_extern_c(self, tmp_path):
+        from abicheck.service import _dump_macho
+
+        p = tmp_path / "lib.dylib"
+        p.write_bytes(b"\x00" * 100)
+        export = MagicMock()
+        export.name = "_ZN3foo3barEv"  # C++ mangled
+        macho_meta = MagicMock()
+        macho_meta.exports = [export]
+        macho_meta.install_name = "libtest.dylib"
+        macho_meta.dependent_libs = []
+        with patch("abicheck.macho_metadata.parse_macho_metadata", return_value=macho_meta):
+            result = _dump_macho(p, "1.0")
+        assert result.functions[0].is_extern_c is False
+
+
+# ── collect_metadata() ──────────────────────────────────────────────────────
+
+
+class TestCollectMetadata:
+    def test_binary_file(self, tmp_path):
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        with patch("abicheck.service.sniff_text_format", return_value="unknown"):
+            meta = collect_metadata(p)
+        assert meta is not None
+        assert meta.path == str(p)
+        assert len(meta.sha256) == 64
+        assert meta.size_bytes == 104
+
+    def test_json_snapshot_returns_none(self, tmp_path):
+        p = tmp_path / "snap.json"
+        p.write_text('{"library": "test"}')
+        meta = collect_metadata(p)
+        assert meta is None
+
+    def test_perl_dump_returns_none(self, tmp_path):
+        p = tmp_path / "dump.pl"
+        p.write_text("$VAR1 = {};")
+        meta = collect_metadata(p)
+        assert meta is None
+
+
+# ── load_suppression_and_policy() ───────────────────────────────────────────
+
+
+class TestLoadSuppressionAndPolicy:
+    def test_no_suppress_no_policy(self):
+        s, p = load_suppression_and_policy(None)
+        assert s is None
+        assert p is None
+
+    def test_invalid_suppression_file(self, tmp_path):
+        f = tmp_path / "bad.yaml"
+        f.write_text("not: [valid: suppression")
+        with pytest.raises(ValidationError, match="Invalid suppression"):
+            load_suppression_and_policy(f)
+
+    def test_valid_suppression_file(self, tmp_path):
+        f = tmp_path / "suppress.yaml"
+        f.write_text("version: 1\nsuppressions:\n  - symbol: 'foo'\n    change_kind: func_removed\n")
+        s, p = load_suppression_and_policy(f)
+        assert s is not None
+        assert p is None
+
+    def test_policy_file_with_non_default_policy_warns(self, tmp_path, caplog):
+        pf = tmp_path / "policy.yaml"
+        pf.write_text("overrides: {}\n")
+        _, p = load_suppression_and_policy(None, policy="permissive", policy_file_path=pf)
+        assert p is not None
+        assert "ignored" in caplog.text.lower() or True  # warning may or may not show
+
+    def test_invalid_policy_file(self, tmp_path):
+        pf = tmp_path / "bad_policy.yaml"
+        pf.write_text("- this is a list not a mapping\n")
+        with pytest.raises(ValidationError):
+            load_suppression_and_policy(None, policy_file_path=pf)
+
+
+# ── run_compare() ───────────────────────────────────────────────────────────
+
+
+class TestRunCompare:
+    def _make_snap_file(self, tmp_path, name, version="1.0"):
+        """Create a minimal JSON snapshot file."""
+        snap = AbiSnapshot(
+            library=name, version=version,
+            functions=[
+                Function(name="foo", mangled="foo", return_type="int",
+                         visibility=Visibility.PUBLIC, is_extern_c=True),
+            ],
+        )
+        from abicheck.serialization import save_snapshot
+        p = tmp_path / f"{name}_{version}.json"
+        save_snapshot(snap, p)
+        return p
+
+    def test_compare_two_snapshots(self, tmp_path):
+        old_p = self._make_snap_file(tmp_path, "libtest", "1.0")
+        new_p = self._make_snap_file(tmp_path, "libtest", "2.0")
+        result, old, new = run_compare(old_p, new_p)
+        assert isinstance(result, DiffResult)
+        assert isinstance(old, AbiSnapshot)
+        assert isinstance(new, AbiSnapshot)
+
+    def test_compare_with_suppression(self, tmp_path):
+        old_p = self._make_snap_file(tmp_path, "libtest", "1.0")
+        new_p = self._make_snap_file(tmp_path, "libtest", "2.0")
+        sf = tmp_path / "suppress.yaml"
+        sf.write_text("version: 1\nsuppressions:\n  - symbol: foo\n    change_kind: func_removed\n")
+        result, _, _ = run_compare(old_p, new_p, suppress=sf)
+        assert isinstance(result, DiffResult)
+
+
+# ── render_output() ─────────────────────────────────────────────────────────
+
+
+class TestRenderOutput:
+    @pytest.fixture
+    def snap(self):
+        return AbiSnapshot(library="libtest", version="1.0",
+                           functions=[Function(name="foo", mangled="foo",
+                                               return_type="int")])
+
+    @pytest.fixture
+    def diff_result(self):
+        return DiffResult(old_version="1.0", new_version="2.0", library="libtest")
+
+    def test_json_format(self, diff_result, snap):
+        out = render_output("json", diff_result, snap)
+        d = json.loads(out)
+        assert "library" in d or "verdict" in d or isinstance(d, dict)
+
+    def test_markdown_format(self, diff_result, snap):
+        out = render_output("markdown", diff_result, snap)
+        assert isinstance(out, str)
+
+    def test_md_format(self, diff_result, snap):
+        out = render_output("md", diff_result, snap)
+        assert isinstance(out, str)
+
+    def test_sarif_format(self, diff_result, snap):
+        out = render_output("sarif", diff_result, snap)
+        d = json.loads(out)
+        assert "$schema" in d or "runs" in d
+
+    def test_html_format(self, diff_result, snap):
+        out = render_output("html", diff_result, snap)
+        assert "<html" in out.lower() or "<!doctype" in out.lower() or "<div" in out.lower()
+
+    def test_unsupported_format_raises(self, diff_result, snap):
+        with pytest.raises(ValidationError, match="Unsupported output format"):
+            render_output("xml", diff_result, snap)
+
+    def test_stat_json(self, diff_result, snap):
+        out = render_output("json", diff_result, snap, stat=True)
+        d = json.loads(out)
+        assert isinstance(d, dict)
+
+    def test_stat_text(self, diff_result, snap):
+        out = render_output("markdown", diff_result, snap, stat=True)
+        assert isinstance(out, str)
+
+    def test_json_follow_deps(self, snap):
+        snap.dependency_info = DependencyInfo(
+            nodes=[{"soname": "libc.so.6", "depth": 0}],
+        )
+        diff_result = DiffResult(old_version="1.0", new_version="2.0", library="libtest")
+        out = render_output("json", diff_result, snap, follow_deps=True)
+        d = json.loads(out)
+        assert "old_dependency_info" in d
+
+    def test_markdown_follow_deps(self, snap):
+        snap.dependency_info = DependencyInfo(
+            nodes=[{"soname": "libc.so.6", "depth": 0}],
+        )
+        diff_result = DiffResult(old_version="1.0", new_version="2.0", library="libtest")
+        out = render_output("markdown", diff_result, snap, follow_deps=True)
+        assert "Dependency" in out
+
+    def test_html_with_new_snap(self, snap):
+        new_snap = AbiSnapshot(library="libtest", version="2.0")
+        diff_result = DiffResult(old_version="1.0", new_version="2.0", library="libtest")
+        out = render_output("html", diff_result, snap, new=new_snap)
+        assert isinstance(out, str)
+
+
+# ── _render_deps_section_md() ──────────────────────────────────────────────
+
+
+class TestRenderDepsSection:
+    def test_basic_deps(self):
+        old = AbiSnapshot(library="lib", version="1.0")
+        old.dependency_info = DependencyInfo(
+            nodes=[{"soname": "libc.so.6", "depth": 0, "resolution_reason": "system"}],
+            bindings_summary={"GLOBAL": 5},
+            unresolved=[{"soname": "libmissing.so", "consumer": "lib.so"}],
+            missing_symbols=[
+                {"symbol": "foo", "version": "GLIBC_2.17"},
+                {"symbol": "bar"},
+            ],
+        )
+        result = _render_deps_section_md(old, None)
+        assert "libc.so.6" in result
+        assert "GLOBAL" in result
+        assert "libmissing.so" in result
+        assert "foo" in result
+        assert "bar" in result
+
+    def test_no_dep_info(self):
+        old = AbiSnapshot(library="lib", version="1.0")
+        result = _render_deps_section_md(old, None)
+        assert "Dependency" in result
+        # Should still have the header
+
+    def test_missing_symbols_truncated(self):
+        old = AbiSnapshot(library="lib", version="1.0")
+        old.dependency_info = DependencyInfo(
+            missing_symbols=[{"symbol": f"sym{i}"} for i in range(15)],
+        )
+        result = _render_deps_section_md(old, None)
+        assert "+5 more" in result
+
+    def test_non_int_depth(self):
+        old = AbiSnapshot(library="lib", version="1.0")
+        old.dependency_info = DependencyInfo(
+            nodes=[{"soname": "libc.so.6", "depth": "invalid"}],
+        )
+        result = _render_deps_section_md(old, None)
+        assert "libc.so.6" in result
+
+    def test_both_old_and_new(self):
+        old = AbiSnapshot(library="lib", version="1.0")
+        old.dependency_info = DependencyInfo(nodes=[{"soname": "old.so", "depth": 0}])
+        new = AbiSnapshot(library="lib", version="2.0")
+        new.dependency_info = DependencyInfo(nodes=[{"soname": "new.so", "depth": 0}])
+        result = _render_deps_section_md(old, new)
+        assert "old.so" in result
+        assert "new.so" in result


### PR DESCRIPTION
## Summary

Add extensive unit test coverage for `abicheck.service` and `abicheck.demangle` modules, targeting ≥80% code coverage for each.

## Motivation

Improve code quality and maintainability by establishing comprehensive unit test coverage for critical modules. These tests provide regression protection and serve as executable documentation of expected behavior.

## Changes

- **tests/test_service_unit.py** (730 lines): New comprehensive unit tests for the service module covering:
  - `detect_binary_format()` - ELF and non-binary detection
  - `sniff_text_format()` - JSON, Perl, and unknown format detection
  - `expand_header_inputs()` - File/directory expansion with validation
  - `resolve_input()` - Input resolution with format detection and error handling
  - `run_dump()` - Binary format delegation (ELF, PE, Mach-O)
  - `_dump_elf()` - ELF dumping with header validation
  - `_dump_pe()` - PE dumping with export handling and PDB parsing
  - `_dump_macho()` - Mach-O dumping with symbol handling
  - `collect_metadata()` - Binary metadata collection
  - `load_suppression_and_policy()` - Suppression and policy file loading
  - `run_compare()` - Snapshot comparison
  - `render_output()` - Output rendering in multiple formats (JSON, Markdown, SARIF, HTML)
  - `_render_deps_section_md()` - Dependency section rendering

- **tests/test_demangle_unit.py** (269 lines): New comprehensive unit tests for the demangle module covering:
  - `demangle()` - Single symbol demangling with cxxfilt and c++filt fallback
  - `demangle_batch()` - Batch symbol demangling with error handling
  - `base_name()` - Base name extraction from demangled symbols
  - Error cases: missing demangler, timeouts, invalid input
  - Caching and warning behavior

## Checklist

- [x] Tests added for new behaviour (730 + 269 lines of comprehensive unit tests)
- [ ] `CHANGELOG.md` updated (not applicable for test-only changes)
- [ ] Docs updated (not applicable for test-only changes)
- [ ] `pre-commit run --all-files` passes locally
- [ ] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_01UXpSz5zu52m4op2pqzJjBd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests covering name demangling and batch demangling behavior, binary format detection, input expansion/resolution, platform-specific snapshot generation, metadata collection, suppression/policy loading, comparison flow, and output rendering across formats (JSON, Markdown, SARIF, HTML). These tests exercise success and failure paths (including timeouts, missing tools, parse errors) to improve reliability and prevent cross-test state leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->