### PR TITLE
fix(action): shorten marketplace description under 125 chars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,5 @@
 name: 'abicheck — ABI Compatibility Checker'
-description: >
-  Detect breaking ABI/API changes in C/C++ shared libraries before they reach production.
-  Compares two library versions and reports removed symbols, changed signatures,
-  struct layout drift, vtable reordering, among 114 total incompatibility types.
+description: 'Detect ABI/API breaking changes in C/C++ shared libraries during CI.'
 
 branding:
   icon: 'shield'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'abicheck — ABI Compatibility Checker'
-description: 'Detect ABI/API breaking changes in C/C++ shared libraries during CI.'
+description: 'Detect ABI/API and dependency breakages across C/C++ binaries, packages, and releases in CI.'
 
 branding:
   icon: 'shield'


### PR DESCRIPTION
Fix GitHub Action Marketplace release validation error by shortening the top-level `action.yml` description to a single line under 125 characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated action description to more clearly communicate that the action detects ABI/API and dependency breakages across C/C++ binaries, packages, and releases in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->