### PR TITLE
Add JUnit XML output format for CI integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+#### JUnit XML Output
+- **`--format junit`** for `compare` and `compare-release` commands — produces
+  JUnit XML reports for CI systems (GitLab CI, Jenkins, Azure DevOps) that
+  display ABI check results as standard test results in their dashboards.
+- Each exported symbol/type maps to a `<testcase>`; breaking changes become
+  `<failure>` elements with severity type and source location.
+- Supports `--show-only` filtering, suppression files, and policy overrides.
+- New module: `abicheck/junit_report.py` (stdlib only, no external dependencies).
+
 ### Planned
 - `--policy-file` schema validation improvements
 - Version-stamped typedef suppression (libpng `png_libpng_version_X_Y_Z` pattern)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -900,7 +900,7 @@ def _exit_with_severity_or_verdict(
 @click.option("--new-version", "new_version", default="new", show_default=True,
               help="Version label for new side (used when input is a .so file).")
 # ── Compare options (unchanged) ──────────────────────────────────────────────
-@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif", "html"]),
+@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif", "html", "junit"]),
               default="markdown", show_default=True)
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
@@ -1455,9 +1455,16 @@ def _compare_release_libraries(
     lang: str, suppress: Path | None,
     policy: str, policy_file_path: Path | None,
     output_dir: Path | None,
-) -> tuple[list[dict[str, object]], str]:
-    """Compare each matched library pair and collect results."""
+    collect_diff_results: bool = False,
+) -> tuple[list[dict[str, object]], str, list[tuple[DiffResult, AbiSnapshot]]]:
+    """Compare each matched library pair and collect results.
+
+    When *collect_diff_results* is True, ``(DiffResult, old_snapshot)``
+    pairs are collected and returned as the third element of the tuple
+    (used by the JUnit output format).
+    """
     library_results: list[dict[str, object]] = []
+    diff_pairs: list[tuple[DiffResult, AbiSnapshot]] = []
     worst_verdict = "NO_CHANGE"
 
     for key in matched_keys:
@@ -1466,7 +1473,7 @@ def _compare_release_libraries(
         old_dbg = resolve_debug_info(old_path, old_debug_dir) if old_debug_dir else None
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
         try:
-            result, _, _ = _run_compare_pair(
+            result, old_snap, _ = _run_compare_pair(
                 old_path, new_path,
                 old_h, new_h, old_inc, new_inc,
                 old_version, new_version,
@@ -1494,11 +1501,14 @@ def _compare_release_libraries(
             "compatible_additions": len(result.compatible),
         })
 
+        if collect_diff_results:
+            diff_pairs.append((result, old_snap))
+
         if output_dir:
             lib_report_path = output_dir / f"{old_path.stem}.json"
             _safe_write_output(lib_report_path, to_json(result))
 
-    return library_results, worst_verdict
+    return library_results, worst_verdict, diff_pairs
 
 
 def _format_release_summary(
@@ -1508,8 +1518,14 @@ def _format_release_summary(
     removed_keys: list[str], added_keys: list[str],
     old_map: dict[str, Path], new_map: dict[str, Path],
     warning_msgs: list[str],
+    diff_pairs: list[tuple[DiffResult, AbiSnapshot]] | None = None,
 ) -> str:
-    """Format the release comparison summary as JSON or markdown."""
+    """Format the release comparison summary as JSON, markdown, or JUnit XML."""
+    if fmt == "junit":
+        from .junit_report import to_junit_xml_multi
+        pairs = [(r, s) for r, s in (diff_pairs or [])]
+        return to_junit_xml_multi(pairs)
+
     if fmt == "json":
         summary: dict[str, object] = {
             "verdict": worst_verdict,
@@ -1594,7 +1610,7 @@ def _write_release_summary_file(
 @click.option("--lang", default="c++", show_default=True,
               type=click.Choice(["c++", "c"], case_sensitive=False))
 @click.option("--format", "fmt",
-              type=click.Choice(["json", "markdown"]),
+              type=click.Choice(["json", "markdown", "junit"]),
               default="markdown", show_default=True)
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None,
               help="Output file for summary report (default: stdout).")
@@ -1775,13 +1791,14 @@ def compare_release_cmd(
         if output_dir:
             output_dir.mkdir(parents=True, exist_ok=True)
 
-        library_results, worst_verdict = _compare_release_libraries(
+        library_results, worst_verdict, diff_pairs = _compare_release_libraries(
             matched_keys, old_map, new_map,
             old_debug_dir, new_debug_dir, resolve_debug_info,
             old_h, new_h, old_inc, new_inc,
             old_version, new_version,
             lang, suppress, policy, policy_file_path,
             output_dir,
+            collect_diff_results=(fmt == "junit"),
         )
 
         if removed_keys and _RELEASE_VERDICT_ORDER.get(worst_verdict, 0) < _RELEASE_VERDICT_ORDER.get("COMPATIBLE_WITH_RISK", 0):
@@ -1791,6 +1808,7 @@ def compare_release_cmd(
             fmt, worst_verdict, old_dir, new_dir,
             library_results, removed_keys, added_keys,
             old_map, new_map, warning_msgs,
+            diff_pairs=diff_pairs if fmt == "junit" else None,
         )
         _write_or_echo(output, text)
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1523,8 +1523,14 @@ def _format_release_summary(
     """Format the release comparison summary as JSON, markdown, or JUnit XML."""
     if fmt == "junit":
         from .junit_report import to_junit_xml_multi
-        pairs = [(r, s) for r, s in (diff_pairs or [])]
-        return to_junit_xml_multi(pairs)
+        pairs = list(diff_pairs or [])
+        error_libs = [
+            entry for entry in library_results
+            if entry.get("verdict") == "ERROR"
+        ]
+        return to_junit_xml_multi(
+            pairs, error_libraries=error_libs if error_libs else None,
+        )
 
     if fmt == "json":
         summary: dict[str, object] = {

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1523,7 +1523,7 @@ def _format_release_summary(
     """Format the release comparison summary as JSON, markdown, or JUnit XML."""
     if fmt == "junit":
         from .junit_report import to_junit_xml_multi
-        pairs = list(diff_pairs or [])
+        pairs: list[tuple[DiffResult, AbiSnapshot | None]] = list(diff_pairs or [])
         error_libs = [
             entry for entry in library_results
             if entry.get("verdict") == "ERROR"

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -98,7 +98,10 @@ def _is_failure(
         return True
     if change.kind in risk_set:
         return policy_for(change.kind).severity == "error"
-    return False
+    # Kinds not in any explicit set (e.g. newly added ChangeKinds): consult
+    # policy_for() which defaults to BREAKING/severity="error" for unknown
+    # kinds, ensuring fail-closed behaviour.
+    return policy_for(change.kind).severity == "error"
 
 
 def _failure_type(
@@ -165,11 +168,13 @@ def _build_testsuite(
         if sym not in all_symbols:
             all_symbols[sym] = _classname_for(c)
 
-    # Count failures
-    failure_count = sum(
-        1 for c in change_by_symbol.values()
-        if _is_failure(c, breaking_set, api_break_set, risk_set)
-    )
+    # Count failures — a symbol counts as failing if ANY of its changes fail
+    # (not just the first one stored in change_by_symbol).
+    symbols_with_failure: set[str] = set()
+    for c in changes:
+        if _is_failure(c, breaking_set, api_break_set, risk_set):
+            symbols_with_failure.add(c.symbol)
+    failure_count = len(symbols_with_failure)
 
     total = len(all_symbols) if all_symbols else len(change_by_symbol)
 
@@ -242,7 +247,9 @@ def _add_failure(
     # Body text: detailed explanation + source location
     body_parts = [description]
     if change.old_value is not None or change.new_value is not None:
-        body_parts.append(f"({change.old_value or '?'} \u2192 {change.new_value or '?'})")
+        old = change.old_value if change.old_value is not None else "?"
+        new = change.new_value if change.new_value is not None else "?"
+        body_parts.append(f"({old} \u2192 {new})")
     if change.source_location:
         body_parts.append(f"Source: {change.source_location}")
     fail.text = "\n".join(body_parts)

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -21,10 +21,26 @@ standard dashboards.
 Usage::
 
     abicheck compare old.so new.so --format junit -o results.xml
+
+Mapping rules:
+
+- Each library in a ``compare-release`` is a ``<testsuite>``
+- Each exported symbol/type that was checked is a ``<testcase>``
+- ``classname`` groups: ``functions``, ``variables``, ``types``,
+  ``enums``, ``metadata``
+- Changes with verdict BREAKING or API_BREAK → ``<failure>``
+- Changes with verdict COMPATIBLE_WITH_RISK → ``<failure>`` only when
+  the change kind has severity ``"error"`` (currently none do by default)
+- COMPATIBLE changes → pass (testcase exists with no ``<failure>`` child)
+- ``type`` attribute: the verdict level (``BREAKING``, ``API_BREAK``,
+  ``COMPATIBLE_WITH_RISK``)
+- ``message`` attribute: ``change_kind: one-line summary``
+- Body text: detailed explanation + source location if available
 """
 
 from __future__ import annotations
 
+import io
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
@@ -66,16 +82,32 @@ def _classname_for(change: Change) -> str:
 # Verdict → failure classification
 # ---------------------------------------------------------------------------
 
-def _is_failure(change: Change, breaking_set: frozenset[ChangeKind],
-                api_break_set: frozenset[ChangeKind]) -> bool:
-    """Return True if the change should be a JUnit <failure>."""
-    return change.kind in breaking_set or change.kind in api_break_set
+def _is_failure(
+    change: Change,
+    breaking_set: frozenset[ChangeKind],
+    api_break_set: frozenset[ChangeKind],
+    risk_set: frozenset[ChangeKind],
+) -> bool:
+    """Return True if the change should be a JUnit ``<failure>``.
+
+    BREAKING and API_BREAK changes always fail.  COMPATIBLE_WITH_RISK
+    changes fail only when their per-kind severity is ``"error"``
+    (currently all RISK_KINDS default to ``"warning"``, so they pass).
+    """
+    if change.kind in breaking_set or change.kind in api_break_set:
+        return True
+    if change.kind in risk_set:
+        return policy_for(change.kind).severity == "error"
+    return False
 
 
-def _failure_type(change: Change, breaking_set: frozenset[ChangeKind],
-                  api_break_set: frozenset[ChangeKind],
-                  risk_set: frozenset[ChangeKind]) -> str:
-    """Return the ``type`` attribute for a <failure> element."""
+def _failure_type(
+    change: Change,
+    breaking_set: frozenset[ChangeKind],
+    api_break_set: frozenset[ChangeKind],
+    risk_set: frozenset[ChangeKind],
+) -> str:
+    """Return the ``type`` attribute for a ``<failure>`` element."""
     if change.kind in breaking_set:
         return "BREAKING"
     if change.kind in api_break_set:
@@ -136,7 +168,7 @@ def _build_testsuite(
     # Count failures
     failure_count = sum(
         1 for c in change_by_symbol.values()
-        if _is_failure(c, breaking_set, api_break_set)
+        if _is_failure(c, breaking_set, api_break_set, risk_set)
     )
 
     total = len(all_symbols) if all_symbols else len(change_by_symbol)
@@ -169,7 +201,7 @@ def _build_testsuite(
     # Additional changes for symbols that already have a testcase
     # (e.g. multiple changes to the same symbol) — append as extra failures
     for c in extra_changes:
-        if _is_failure(c, breaking_set, api_break_set):
+        if _is_failure(c, breaking_set, api_break_set, risk_set):
             # Find the existing testcase for this symbol
             for tc in ts:
                 if tc.get("name") == c.symbol:
@@ -187,7 +219,7 @@ def _maybe_add_failure(
     risk_set: frozenset[ChangeKind],
 ) -> None:
     """Add a ``<failure>`` child to *tc* if the change is a failure."""
-    if _is_failure(change, breaking_set, api_break_set):
+    if _is_failure(change, breaking_set, api_break_set, risk_set):
         _add_failure(tc, change, breaking_set, api_break_set, risk_set)
 
 
@@ -200,16 +232,17 @@ def _add_failure(
 ) -> None:
     """Append a ``<failure>`` element to testcase *tc*."""
     ftype = _failure_type(change, breaking_set, api_break_set, risk_set)
-    message = f"{change.kind.value}: {change.description}"
+    description = change.description or change.kind.value.replace("_", " ")
+    message = f"{change.kind.value}: {description}"
 
     fail = ET.SubElement(tc, "failure")
     fail.set("message", message)
     fail.set("type", ftype)
 
     # Body text: detailed explanation + source location
-    body_parts = [change.description]
-    if change.old_value or change.new_value:
-        body_parts.append(f"({change.old_value or '?'} → {change.new_value or '?'})")
+    body_parts = [description]
+    if change.old_value is not None or change.new_value is not None:
+        body_parts.append(f"({change.old_value or '?'} \u2192 {change.new_value or '?'})")
     if change.source_location:
         body_parts.append(f"Source: {change.source_location}")
     fail.text = "\n".join(body_parts)
@@ -289,7 +322,6 @@ def _to_xml_string(root: ET.Element) -> str:
     """Serialize an ElementTree element to an XML string with declaration."""
     ET.indent(root)
     tree = ET.ElementTree(root)
-    import io
     buf = io.BytesIO()
     tree.write(buf, encoding="UTF-8", xml_declaration=True)
     return buf.getvalue().decode("UTF-8")

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -44,12 +44,13 @@ import io
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
+from .checker_policy import ChangeKind, policy_for
 from .checker_types import Change, DiffResult
-from .checker_policy import ChangeKind, Verdict, policy_for
 from .reporter import apply_show_only
 
 if TYPE_CHECKING:
     from .model import AbiSnapshot
+    from .severity import SeverityConfig
 
 
 # ---------------------------------------------------------------------------
@@ -87,15 +88,22 @@ def _is_failure(
     breaking_set: frozenset[ChangeKind],
     api_break_set: frozenset[ChangeKind],
     risk_set: frozenset[ChangeKind],
+    severity_config: SeverityConfig | None = None,
 ) -> bool:
     """Return True if the change should be a JUnit ``<failure>``.
 
     BREAKING and API_BREAK changes always fail.  COMPATIBLE_WITH_RISK
     changes fail only when their per-kind severity is ``"error"``
     (currently all RISK_KINDS default to ``"warning"``, so they pass).
+
+    When *severity_config* is provided (from ``--severity-preset`` or
+    ``--severity-*`` overrides), its level takes precedence so that
+    the JUnit output honours user-configured severity escalations.
     """
     if change.kind in breaking_set or change.kind in api_break_set:
         return True
+    if severity_config is not None:
+        return severity_config.level_for_kind(change.kind).value == "error"
     if change.kind in risk_set:
         return policy_for(change.kind).severity == "error"
     # Kinds not in any explicit set (e.g. newly added ChangeKinds): consult
@@ -129,12 +137,16 @@ def _build_testsuite(
     old_snapshot: AbiSnapshot | None = None,
     *,
     show_only: str | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> ET.Element:
     """Build a ``<testsuite>`` element from a single DiffResult.
 
     Each changed symbol becomes a ``<testcase>``.  If *old_snapshot* is
-    provided, unchanged symbols are also emitted as passing test cases so
-    that the pass-rate is meaningful.
+    provided and *show_only* is **not** active, unchanged symbols are also
+    emitted as passing test cases so that the pass-rate is meaningful.
+
+    When *show_only* is active, only the filtered changes are emitted
+    (no unchanged snapshot symbols) so the test count matches the filter.
     """
     breaking_set, api_break_set, _, risk_set = result._effective_kind_sets()
 
@@ -152,8 +164,11 @@ def _build_testsuite(
             extra_changes.append(c)
 
     # Collect all symbols (changed + unchanged) when snapshot is available
+    # and no show_only filter is active.  When show_only is active, only
+    # filtered changes should appear to match the documented behaviour
+    # ("filtered-out changes are omitted entirely").
     all_symbols: dict[str, str] = {}  # symbol_name → classname
-    if old_snapshot is not None:
+    if old_snapshot is not None and not show_only:
         for f in old_snapshot.functions:
             all_symbols[f.mangled] = "functions"
         for v in old_snapshot.variables:
@@ -172,7 +187,7 @@ def _build_testsuite(
     # (not just the first one stored in change_by_symbol).
     symbols_with_failure: set[str] = set()
     for c in changes:
-        if _is_failure(c, breaking_set, api_break_set, risk_set):
+        if _is_failure(c, breaking_set, api_break_set, risk_set, severity_config):
             symbols_with_failure.add(c.symbol)
     failure_count = len(symbols_with_failure)
 
@@ -194,6 +209,7 @@ def _build_testsuite(
                 _maybe_add_failure(
                     tc, change_by_symbol[sym],
                     breaking_set, api_break_set, risk_set,
+                    severity_config,
                 )
     else:
         # No snapshot — only emit changed symbols
@@ -201,12 +217,14 @@ def _build_testsuite(
             tc = ET.SubElement(ts, "testcase")
             tc.set("name", sym)
             tc.set("classname", _classname_for(c))
-            _maybe_add_failure(tc, c, breaking_set, api_break_set, risk_set)
+            _maybe_add_failure(
+                tc, c, breaking_set, api_break_set, risk_set, severity_config,
+            )
 
     # Additional changes for symbols that already have a testcase
     # (e.g. multiple changes to the same symbol) — append as extra failures
     for c in extra_changes:
-        if _is_failure(c, breaking_set, api_break_set, risk_set):
+        if _is_failure(c, breaking_set, api_break_set, risk_set, severity_config):
             # Find the existing testcase for this symbol
             for tc in ts:
                 if tc.get("name") == c.symbol:
@@ -222,9 +240,10 @@ def _maybe_add_failure(
     breaking_set: frozenset[ChangeKind],
     api_break_set: frozenset[ChangeKind],
     risk_set: frozenset[ChangeKind],
+    severity_config: SeverityConfig | None = None,
 ) -> None:
     """Add a ``<failure>`` child to *tc* if the change is a failure."""
-    if _is_failure(change, breaking_set, api_break_set, risk_set):
+    if _is_failure(change, breaking_set, api_break_set, risk_set, severity_config):
         _add_failure(tc, change, breaking_set, api_break_set, risk_set)
 
 
@@ -256,6 +275,35 @@ def _add_failure(
 
 
 # ---------------------------------------------------------------------------
+# Error testsuite — represent failed compare-release pairs
+# ---------------------------------------------------------------------------
+
+def _build_error_testsuite(library: str, error_msg: str) -> ET.Element:
+    """Build a ``<testsuite>`` with a single errored testcase.
+
+    Used by ``to_junit_xml_multi`` to represent libraries whose comparison
+    failed (e.g. bad input, missing headers) so that CI dashboards show
+    the failure rather than silently omitting the library.
+    """
+    ts = ET.Element("testsuite")
+    ts.set("name", library)
+    ts.set("tests", "1")
+    ts.set("failures", "0")
+    ts.set("errors", "1")
+
+    tc = ET.SubElement(ts, "testcase")
+    tc.set("name", library)
+    tc.set("classname", "metadata")
+
+    err = ET.SubElement(tc, "error")
+    err.set("message", f"Comparison failed: {error_msg}")
+    err.set("type", "ERROR")
+    err.text = error_msg
+
+    return ts
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -264,6 +312,7 @@ def to_junit_xml(
     old_snapshot: AbiSnapshot | None = None,
     *,
     show_only: str | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """Convert a single DiffResult to a JUnit XML string.
 
@@ -277,6 +326,10 @@ def to_junit_xml(
         appear.
     show_only:
         Optional ``--show-only`` filter string.
+    severity_config:
+        Optional severity configuration (from ``--severity-preset`` or
+        ``--severity-*`` overrides).  When provided, the JUnit failure
+        classification honours user-configured severity escalations.
 
     Returns
     -------
@@ -286,7 +339,10 @@ def to_junit_xml(
     root = ET.Element("testsuites")
     root.set("name", "abicheck")
 
-    ts = _build_testsuite(result, old_snapshot, show_only=show_only)
+    ts = _build_testsuite(
+        result, old_snapshot,
+        show_only=show_only, severity_config=severity_config,
+    )
     root.append(ts)
 
     # Roll up counts
@@ -301,26 +357,46 @@ def to_junit_xml_multi(
     results: list[tuple[DiffResult, AbiSnapshot | None]],
     *,
     show_only: str | None = None,
+    severity_config: SeverityConfig | None = None,
+    error_libraries: list[dict[str, object]] | None = None,
 ) -> str:
     """Convert multiple DiffResults to a JUnit XML string (compare-release).
 
     Each ``(DiffResult, old_snapshot)`` pair becomes a ``<testsuite>``.
+
+    *error_libraries* is a list of ``{"library": ..., "error": ...}``
+    dicts for libraries whose comparison failed.  Each becomes a
+    ``<testsuite>`` with a single ``<error>`` testcase so CI dashboards
+    reflect the failure.
     """
     root = ET.Element("testsuites")
     root.set("name", "abicheck")
 
     total_tests = 0
     total_failures = 0
+    total_errors = 0
 
     for result, old_snap in results:
-        ts = _build_testsuite(result, old_snap, show_only=show_only)
+        ts = _build_testsuite(
+            result, old_snap,
+            show_only=show_only, severity_config=severity_config,
+        )
         root.append(ts)
         total_tests += int(ts.get("tests", "0"))
         total_failures += int(ts.get("failures", "0"))
 
+    for entry in error_libraries or []:
+        ts = _build_error_testsuite(
+            str(entry.get("library", "unknown")),
+            str(entry.get("error", "comparison failed")),
+        )
+        root.append(ts)
+        total_tests += 1
+        total_errors += 1
+
     root.set("tests", str(total_tests))
     root.set("failures", str(total_failures))
-    root.set("errors", "0")
+    root.set("errors", str(total_errors))
 
     return _to_xml_string(root)
 

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JUnit XML output for abicheck.
+
+Produces a JUnit XML report suitable for CI systems (GitLab CI, Jenkins,
+Azure DevOps) that display ABI check results as "test results" in their
+standard dashboards.
+
+Usage::
+
+    abicheck compare old.so new.so --format junit -o results.xml
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
+
+from .checker_types import Change, DiffResult
+from .checker_policy import ChangeKind, Verdict, policy_for
+from .reporter import apply_show_only
+
+if TYPE_CHECKING:
+    from .model import AbiSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Classname mapping — groups symbols/types by element kind
+# ---------------------------------------------------------------------------
+
+_FUNC_KINDS = frozenset(k for k in ChangeKind if k.value.startswith("func_"))
+_VAR_KINDS = frozenset(k for k in ChangeKind if k.value.startswith("var_"))
+_TYPE_KINDS = frozenset(
+    k for k in ChangeKind
+    if k.value.startswith("type_") or k.value.startswith("union_")
+)
+_ENUM_KINDS = frozenset(k for k in ChangeKind if k.value.startswith("enum_"))
+
+
+def _classname_for(change: Change) -> str:
+    """Determine the JUnit classname group for a change."""
+    if change.kind in _FUNC_KINDS:
+        return "functions"
+    if change.kind in _VAR_KINDS:
+        return "variables"
+    if change.kind in _TYPE_KINDS:
+        return "types"
+    if change.kind in _ENUM_KINDS:
+        return "enums"
+    return "metadata"
+
+
+# ---------------------------------------------------------------------------
+# Verdict → failure classification
+# ---------------------------------------------------------------------------
+
+def _is_failure(change: Change, breaking_set: frozenset[ChangeKind],
+                api_break_set: frozenset[ChangeKind]) -> bool:
+    """Return True if the change should be a JUnit <failure>."""
+    return change.kind in breaking_set or change.kind in api_break_set
+
+
+def _failure_type(change: Change, breaking_set: frozenset[ChangeKind],
+                  api_break_set: frozenset[ChangeKind],
+                  risk_set: frozenset[ChangeKind]) -> str:
+    """Return the ``type`` attribute for a <failure> element."""
+    if change.kind in breaking_set:
+        return "BREAKING"
+    if change.kind in api_break_set:
+        return "API_BREAK"
+    if change.kind in risk_set:
+        return "COMPATIBLE_WITH_RISK"
+    return "COMPATIBLE"
+
+
+# ---------------------------------------------------------------------------
+# Single DiffResult → <testsuite>
+# ---------------------------------------------------------------------------
+
+def _build_testsuite(
+    result: DiffResult,
+    old_snapshot: AbiSnapshot | None = None,
+    *,
+    show_only: str | None = None,
+) -> ET.Element:
+    """Build a ``<testsuite>`` element from a single DiffResult.
+
+    Each changed symbol becomes a ``<testcase>``.  If *old_snapshot* is
+    provided, unchanged symbols are also emitted as passing test cases so
+    that the pass-rate is meaningful.
+    """
+    breaking_set, api_break_set, _, risk_set = result._effective_kind_sets()
+
+    changes = list(result.changes)
+    if show_only:
+        changes = apply_show_only(changes, show_only, policy=result.policy)
+
+    # Build map: symbol → change (use first change per symbol for the testcase)
+    change_by_symbol: dict[str, Change] = {}
+    extra_changes: list[Change] = []
+    for c in changes:
+        if c.symbol not in change_by_symbol:
+            change_by_symbol[c.symbol] = c
+        else:
+            extra_changes.append(c)
+
+    # Collect all symbols (changed + unchanged) when snapshot is available
+    all_symbols: dict[str, str] = {}  # symbol_name → classname
+    if old_snapshot is not None:
+        for f in old_snapshot.functions:
+            all_symbols[f.mangled] = "functions"
+        for v in old_snapshot.variables:
+            all_symbols[v.mangled] = "variables"
+        for t in old_snapshot.types:
+            all_symbols[t.name] = "types"
+        for e in old_snapshot.enums:
+            all_symbols[e.name] = "enums"
+
+    # Add changed symbols that might not be in old_snapshot (e.g. additions)
+    for sym, c in change_by_symbol.items():
+        if sym not in all_symbols:
+            all_symbols[sym] = _classname_for(c)
+
+    # Count failures
+    failure_count = sum(
+        1 for c in change_by_symbol.values()
+        if _is_failure(c, breaking_set, api_break_set)
+    )
+
+    total = len(all_symbols) if all_symbols else len(change_by_symbol)
+
+    ts = ET.Element("testsuite")
+    ts.set("name", result.library)
+    ts.set("tests", str(total))
+    ts.set("failures", str(failure_count))
+    ts.set("errors", "0")
+
+    # Emit test cases for every symbol
+    if all_symbols:
+        for sym, classname in sorted(all_symbols.items()):
+            tc = ET.SubElement(ts, "testcase")
+            tc.set("name", sym)
+            tc.set("classname", classname)
+            if sym in change_by_symbol:
+                _maybe_add_failure(
+                    tc, change_by_symbol[sym],
+                    breaking_set, api_break_set, risk_set,
+                )
+    else:
+        # No snapshot — only emit changed symbols
+        for sym, c in sorted(change_by_symbol.items()):
+            tc = ET.SubElement(ts, "testcase")
+            tc.set("name", sym)
+            tc.set("classname", _classname_for(c))
+            _maybe_add_failure(tc, c, breaking_set, api_break_set, risk_set)
+
+    # Additional changes for symbols that already have a testcase
+    # (e.g. multiple changes to the same symbol) — append as extra failures
+    for c in extra_changes:
+        if _is_failure(c, breaking_set, api_break_set):
+            # Find the existing testcase for this symbol
+            for tc in ts:
+                if tc.get("name") == c.symbol:
+                    _add_failure(tc, c, breaking_set, api_break_set, risk_set)
+                    break
+
+    return ts
+
+
+def _maybe_add_failure(
+    tc: ET.Element,
+    change: Change,
+    breaking_set: frozenset[ChangeKind],
+    api_break_set: frozenset[ChangeKind],
+    risk_set: frozenset[ChangeKind],
+) -> None:
+    """Add a ``<failure>`` child to *tc* if the change is a failure."""
+    if _is_failure(change, breaking_set, api_break_set):
+        _add_failure(tc, change, breaking_set, api_break_set, risk_set)
+
+
+def _add_failure(
+    tc: ET.Element,
+    change: Change,
+    breaking_set: frozenset[ChangeKind],
+    api_break_set: frozenset[ChangeKind],
+    risk_set: frozenset[ChangeKind],
+) -> None:
+    """Append a ``<failure>`` element to testcase *tc*."""
+    ftype = _failure_type(change, breaking_set, api_break_set, risk_set)
+    message = f"{change.kind.value}: {change.description}"
+
+    fail = ET.SubElement(tc, "failure")
+    fail.set("message", message)
+    fail.set("type", ftype)
+
+    # Body text: detailed explanation + source location
+    body_parts = [change.description]
+    if change.old_value or change.new_value:
+        body_parts.append(f"({change.old_value or '?'} → {change.new_value or '?'})")
+    if change.source_location:
+        body_parts.append(f"Source: {change.source_location}")
+    fail.text = "\n".join(body_parts)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def to_junit_xml(
+    result: DiffResult,
+    old_snapshot: AbiSnapshot | None = None,
+    *,
+    show_only: str | None = None,
+) -> str:
+    """Convert a single DiffResult to a JUnit XML string.
+
+    Parameters
+    ----------
+    result:
+        The comparison result.
+    old_snapshot:
+        When provided, all symbols from the old snapshot appear as test
+        cases (unchanged symbols pass).  Without it, only changed symbols
+        appear.
+    show_only:
+        Optional ``--show-only`` filter string.
+
+    Returns
+    -------
+    str
+        JUnit XML document as a string.
+    """
+    root = ET.Element("testsuites")
+    root.set("name", "abicheck")
+
+    ts = _build_testsuite(result, old_snapshot, show_only=show_only)
+    root.append(ts)
+
+    # Roll up counts
+    root.set("tests", ts.get("tests", "0"))
+    root.set("failures", ts.get("failures", "0"))
+    root.set("errors", "0")
+
+    return _to_xml_string(root)
+
+
+def to_junit_xml_multi(
+    results: list[tuple[DiffResult, AbiSnapshot | None]],
+    *,
+    show_only: str | None = None,
+) -> str:
+    """Convert multiple DiffResults to a JUnit XML string (compare-release).
+
+    Each ``(DiffResult, old_snapshot)`` pair becomes a ``<testsuite>``.
+    """
+    root = ET.Element("testsuites")
+    root.set("name", "abicheck")
+
+    total_tests = 0
+    total_failures = 0
+
+    for result, old_snap in results:
+        ts = _build_testsuite(result, old_snap, show_only=show_only)
+        root.append(ts)
+        total_tests += int(ts.get("tests", "0"))
+        total_failures += int(ts.get("failures", "0"))
+
+    root.set("tests", str(total_tests))
+    root.set("failures", str(total_failures))
+    root.set("errors", "0")
+
+    return _to_xml_string(root)
+
+
+def _to_xml_string(root: ET.Element) -> str:
+    """Serialize an ElementTree element to an XML string with declaration."""
+    ET.indent(root)
+    tree = ET.ElementTree(root)
+    import io
+    buf = io.BytesIO()
+    tree.write(buf, encoding="UTF-8", xml_declaration=True)
+    return buf.getvalue().decode("UTF-8")

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -516,7 +516,7 @@ def render_output(
     Raises:
         ValidationError: For unrecognised output format.
     """
-    if stat:
+    if stat and fmt != "junit":
         if fmt == "json":
             return to_stat_json(result)
         return to_stat(result)

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -543,7 +543,11 @@ def render_output(
             show_impact=show_impact,
         )
 
-    _SUPPORTED_FORMATS = {"json", "sarif", "html", "markdown", "md"}
+    if fmt == "junit":
+        from .junit_report import to_junit_xml
+        return to_junit_xml(result, old, show_only=show_only)
+
+    _SUPPORTED_FORMATS = {"json", "sarif", "html", "junit", "markdown", "md"}
     if fmt not in _SUPPORTED_FORMATS:
         raise ValidationError(f"Unsupported output format: {fmt!r} (expected one of {sorted(_SUPPORTED_FORMATS)})")
 

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -546,7 +546,10 @@ def render_output(
 
     if fmt == "junit":
         from .junit_report import to_junit_xml
-        return to_junit_xml(result, old, show_only=show_only)
+        return to_junit_xml(
+            result, old,
+            show_only=show_only, severity_config=severity_config,
+        )
 
     _SUPPORTED_FORMATS = {"json", "sarif", "html", "junit", "markdown", "md"}
     if fmt not in _SUPPORTED_FORMATS:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -510,7 +510,8 @@ def render_output(
 ) -> str:
     """Render comparison result in the requested output format.
 
-    Supported formats: ``'json'``, ``'markdown'``, ``'sarif'``, ``'html'``.
+    Supported formats: ``'json'``, ``'markdown'``, ``'sarif'``, ``'html'``,
+    ``'junit'``.
 
     Raises:
         ValidationError: For unrecognised output format.

--- a/docs/development/adr/014-output-format-strategy.md
+++ b/docs/development/adr/014-output-format-strategy.md
@@ -23,7 +23,7 @@ format selection works.
 
 ## Decision
 
-### Four output formats
+### Five output formats
 
 | Format | Primary consumer | CLI flag | Default? |
 |--------|-----------------|----------|----------|
@@ -31,6 +31,7 @@ format selection works.
 | **JSON** | Automation, AI agents, scripts | `--format json` | No |
 | **SARIF 2.1.0** | GitHub Code Scanning | `--format sarif` | No |
 | **HTML** | Standalone report viewing | `--format html` | No |
+| **JUnit XML** | GitLab CI, Jenkins, Azure DevOps | `--format junit` | No |
 
 ### Markdown (default)
 
@@ -89,6 +90,25 @@ format-specific data loss.
 Self-contained HTML was chosen over an external-stylesheet approach to ensure
 reports can be emailed, archived, or opened offline without broken rendering.
 
+### JUnit XML
+
+- Targets CI systems with JUnit test result dashboards (GitLab CI, Jenkins,
+  Azure DevOps, CircleCI)
+- Mapping:
+  - Each library → `<testsuite>`
+  - Each exported symbol/type → `<testcase>`
+  - `classname` groups: `functions`, `variables`, `types`, `enums`, `metadata`
+  - `BREAKING` / `API_BREAK` → `<failure>` element
+  - `COMPATIBLE_WITH_RISK` → `<failure>` only when per-kind severity is `error`
+  - `COMPATIBLE` → passing test case (no `<failure>` child)
+- When old snapshot is available, unchanged symbols appear as passing tests
+  for a meaningful pass-rate
+- Uses `xml.etree.ElementTree` (stdlib) — no external dependency
+
+JUnit was chosen over a proprietary CI-specific format because all major CI
+platforms support JUnit natively, making it the best single format for broad
+CI integration.
+
 ### Format selection
 
 ```bash
@@ -97,6 +117,7 @@ abicheck compare old.so new.so --format json                 # JSON
 abicheck compare old.so new.so --format sarif                # SARIF
 abicheck compare old.so new.so --format html                 # HTML
 abicheck compare old.so new.so --format html -o report.html  # HTML written to file
+abicheck compare old.so new.so --format junit -o results.xml # JUnit XML
 ```
 
 The format must be explicitly selected via `--format`. The `-o` / `--output`
@@ -106,7 +127,7 @@ regardless of the output filename.
 
 ### Information preservation
 
-All four formats are generated from the same `DiffResult` object. No
+All five formats are generated from the same `DiffResult` object. No
 format-specific information is added or lost — switching formats changes
 presentation only, not content. Verdict and exit code computation is
 independent of output format.
@@ -125,7 +146,7 @@ independent of output format.
 
 ### Negative
 
-- Four formatters to maintain (reporter.py, sarif.py, html_report.py)
+- Five formatters to maintain (reporter.py, sarif.py, html_report.py, junit_report.py)
 - SARIF severity mapping is a compatibility contract with GitHub
 - Self-contained HTML generates larger files than external-CSS approaches
 - JSON schema evolves with the project (see ADR-015 for schema versioning)
@@ -137,4 +158,5 @@ independent of output format.
 - `abicheck/reporter.py` — Markdown and JSON formatting
 - `abicheck/sarif.py` — SARIF 2.1.0 output
 - `abicheck/html_report.py` — HTML report generation
+- `abicheck/junit_report.py` — JUnit XML output
 - `abicheck/cli.py` — `--format` flag and output file handling

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -41,6 +41,8 @@ abicheck compare libfoo.so.1 libfoo.so.2 -H include/
 # Output formats
 abicheck compare libfoo.so.1 libfoo.so.2 \
   --old-header v1/foo.h --new-header v2/foo.h --format sarif -o abi.sarif
+abicheck compare libfoo.so.1 libfoo.so.2 \
+  --old-header v1/foo.h --new-header v2/foo.h --format junit -o results.xml
 ```
 
 `compare` auto-detects each input: `.so` files are dumped on-the-fly, `.json`

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -8,8 +8,9 @@ abicheck supports multiple output formats for different use cases:
 | JSON | `--format json` | CI pipelines, machine processing |
 | SARIF | `--format sarif` | GitHub Code Scanning, SAST platforms |
 | HTML | `--format html` | Standalone reports, ABICC migration |
+| JUnit XML | `--format junit` | GitLab CI, Jenkins, Azure DevOps test dashboards |
 
-All four formats support the report filtering options described below.
+All five formats support the report filtering options described below.
 The ABICC-compatible XML output (via `abicheck compat check`) includes
 redundancy annotations but does not support `--show-only` filtering.
 
@@ -60,6 +61,9 @@ how many changes matched: `> Filtered by: --show-only ... (5 of 42 changes shown
 
 **SARIF**: The `show_only` parameter filters which results appear in the SARIF
 output.
+
+**JUnit XML**: The `show_only` parameter filters which test cases appear in the
+output. Filtered-out changes are omitted entirely.
 
 ## `--stat` mode
 
@@ -175,4 +179,130 @@ jobs:
     }]
   }]
 }
+```
+
+---
+
+## JUnit XML Output
+
+abicheck can produce JUnit XML reports for CI systems that display test results
+in their standard dashboards — GitLab CI, Jenkins, Azure DevOps, CircleCI, and
+others.
+
+### Usage
+
+```bash
+abicheck compare old.json new.json --format junit -o results.xml
+abicheck compare-release release-1.0/ release-2.0/ --format junit -o abi-tests.xml
+```
+
+### How it works
+
+ABI changes are mapped to JUnit test cases:
+
+- Each **library** in a `compare-release` becomes a `<testsuite>`
+- Each **exported symbol or type** that was checked becomes a `<testcase>`
+- **BREAKING** and **API_BREAK** changes produce `<failure>` elements
+- **COMPATIBLE** changes (additions, no-change) are passing test cases
+- **COMPATIBLE_WITH_RISK** changes pass by default (unless their per-kind
+  severity is overridden to `"error"`)
+- Unchanged symbols from the old library also appear as passing test cases,
+  so the pass-rate is meaningful
+
+### Severity mapping
+
+| ABI Verdict | JUnit Outcome |
+|-------------|---------------|
+| BREAKING | `<failure type="BREAKING">` |
+| API_BREAK | `<failure type="API_BREAK">` |
+| COMPATIBLE_WITH_RISK (severity=warning) | Pass |
+| COMPATIBLE | Pass |
+
+### Classname groups
+
+Test cases are grouped by `classname` for CI dashboards that support
+hierarchical display:
+
+| Element | classname |
+|---------|-----------|
+| Functions | `functions` |
+| Variables | `variables` |
+| Types (struct/class/union) | `types` |
+| Enums | `enums` |
+| ELF metadata (SONAME, etc.) | `metadata` |
+
+### JUnit XML structure
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="abicheck" tests="47" failures="3" errors="0">
+  <testsuite name="libfoo.so.1" tests="47" failures="3" errors="0">
+    <!-- Passing: no ABI change detected -->
+    <testcase name="_ZN3foo3barEv" classname="functions" />
+
+    <!-- Failure: binary-incompatible change -->
+    <testcase name="_ZN3foo3bazEi" classname="functions">
+      <failure message="func_param_type_changed: parameter 1 type changed from int to long"
+               type="BREAKING">
+parameter 1 type changed from int to long
+(int → long)
+Source: include/foo.h:42
+      </failure>
+    </testcase>
+
+    <!-- Failure: removed symbol -->
+    <testcase name="_ZN3foo6legacyEv" classname="functions">
+      <failure message="func_removed: Function foo::legacy() was removed"
+               type="BREAKING">
+Function foo::legacy() was removed
+      </failure>
+    </testcase>
+
+    <!-- Passing: addition is compatible -->
+    <testcase name="_ZN3foo9new_thingEv" classname="functions" />
+  </testsuite>
+</testsuites>
+```
+
+### CI integration examples
+
+#### GitLab CI
+
+```yaml
+abi-check:
+  script:
+    - abicheck compare old.so new.so -H include/ --format junit -o abi-results.xml
+  artifacts:
+    reports:
+      junit: abi-results.xml
+```
+
+#### Jenkins (JUnit plugin)
+
+```groovy
+stage('ABI Check') {
+    steps {
+        sh 'abicheck compare old.so new.so -H include/ --format junit -o abi-results.xml'
+    }
+    post {
+        always {
+            junit 'abi-results.xml'
+        }
+    }
+}
+```
+
+#### Azure DevOps
+
+```yaml
+- task: CmdLine@2
+  inputs:
+    script: |
+      abicheck compare old.so new.so -H include/ --format junit -o abi-results.xml
+  continueOnError: true
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: 'abi-results.xml'
+    testResultsFormat: 'JUnit'
 ```

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -47,6 +47,10 @@ and `caused_count` annotations on root type changes.
 `<caused_by>` and `<caused_count>` elements on individual problems. Both binary
 and source sections include their own redundant counts.
 
+**JUnit XML**: Redundant changes are filtered upstream before the formatter
+receives them, so derived changes do not appear as test cases. No
+JUnit-specific redundancy metadata is emitted.
+
 ## `--show-only` filter
 
 Limit displayed changes by severity, element, or action (AND across dimensions,
@@ -208,6 +212,8 @@ ABI changes are mapped to JUnit test cases:
   severity is overridden to `"error"`)
 - Unchanged symbols from the old library also appear as passing test cases,
   so the pass-rate is meaningful
+- When a symbol has multiple breaking changes, the `<testcase>` contains
+  multiple `<failure>` children (one per change)
 
 ### Severity mapping
 
@@ -271,8 +277,9 @@ Function foo::legacy() was removed
 ```yaml
 abi-check:
   script:
-    - abicheck compare old.so new.so -H include/ --format junit -o abi-results.xml
+    - abicheck compare old.so new.so -H include/ --format junit -o abi-results.xml || true
   artifacts:
+    when: always
     reports:
       junit: abi-results.xml
 ```

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1,0 +1,443 @@
+"""Tests for JUnit XML output."""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from abicheck.checker_types import Change, DiffResult
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.junit_report import to_junit_xml, to_junit_xml_multi
+from abicheck.model import AbiSnapshot, Function, RecordType, Variable, EnumType, EnumMember
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    changes: list[Change],
+    verdict: Verdict = Verdict.BREAKING,
+    library: str = "libfoo.so.1",
+    old: str = "1.0",
+    new: str = "2.0",
+) -> DiffResult:
+    return DiffResult(
+        old_version=old,
+        new_version=new,
+        library=library,
+        changes=changes,
+        verdict=verdict,
+    )
+
+
+def _make_snapshot(
+    library: str = "libfoo.so.1",
+    version: str = "1.0",
+    functions: list[Function] | None = None,
+    types: list[RecordType] | None = None,
+    variables: list[Variable] | None = None,
+    enums: list[EnumType] | None = None,
+) -> AbiSnapshot:
+    s = AbiSnapshot(library=library, version=version)
+    if functions:
+        s.functions = functions
+    if types:
+        s.types = types
+    if variables:
+        s.variables = variables
+    if enums:
+        s.enums = enums
+    return s
+
+
+def _parse(xml_str: str) -> ET.Element:
+    return ET.fromstring(xml_str)
+
+
+# ---------------------------------------------------------------------------
+# Schema structure tests
+# ---------------------------------------------------------------------------
+
+class TestJUnitSchema:
+    def test_top_level_element(self) -> None:
+        xml = to_junit_xml(_make_result([]))
+        root = _parse(xml)
+        assert root.tag == "testsuites"
+        assert root.get("name") == "abicheck"
+
+    def test_single_testsuite(self) -> None:
+        xml = to_junit_xml(_make_result([]))
+        root = _parse(xml)
+        suites = root.findall("testsuite")
+        assert len(suites) == 1
+        assert suites[0].get("name") == "libfoo.so.1"
+
+    def test_errors_always_zero(self) -> None:
+        xml = to_junit_xml(_make_result([]))
+        root = _parse(xml)
+        assert root.get("errors") == "0"
+        assert root.find("testsuite").get("errors") == "0"
+
+    def test_xml_declaration(self) -> None:
+        xml = to_junit_xml(_make_result([]))
+        assert xml.startswith("<?xml version='1.0' encoding='UTF-8'?>")
+
+
+# ---------------------------------------------------------------------------
+# No changes → all pass
+# ---------------------------------------------------------------------------
+
+class TestNoChanges:
+    def test_no_changes_no_snapshot(self) -> None:
+        xml = to_junit_xml(
+            _make_result([], verdict=Verdict.NO_CHANGE),
+        )
+        root = _parse(xml)
+        assert root.get("tests") == "0"
+        assert root.get("failures") == "0"
+
+    def test_no_changes_with_snapshot(self) -> None:
+        snap = _make_snapshot(functions=[
+            Function(name="foo::bar", mangled="_ZN3foo3barEv", return_type="void"),
+            Function(name="foo::baz", mangled="_ZN3foo3bazEi", return_type="int"),
+        ])
+        result = _make_result([], verdict=Verdict.NO_CHANGE)
+        xml = to_junit_xml(result, snap)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("tests") == "2"
+        assert ts.get("failures") == "0"
+        # All testcases pass (no <failure> children)
+        for tc in ts.findall("testcase"):
+            assert tc.find("failure") is None
+
+
+# ---------------------------------------------------------------------------
+# Breaking changes → failures
+# ---------------------------------------------------------------------------
+
+class TestBreakingChanges:
+    def test_func_removed_is_failure(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_REMOVED,
+                symbol="_ZN3foo6legacyEv",
+                description="Function foo::legacy() was removed",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        tc = ts.find("testcase")
+        assert tc.get("name") == "_ZN3foo6legacyEv"
+        assert tc.get("classname") == "functions"
+        fail = tc.find("failure")
+        assert fail is not None
+        assert "BREAKING" in fail.get("type")
+        assert "func_removed" in fail.get("message")
+
+    def test_type_size_changed_is_failure(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.TYPE_SIZE_CHANGED,
+                symbol="struct foo::Config",
+                description="size changed from 16 to 24 bytes",
+                old_value="16",
+                new_value="24",
+                source_location="include/foo.h:42",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        tc = root.find(".//testcase[@name='struct foo::Config']")
+        assert tc is not None
+        assert tc.get("classname") == "types"
+        fail = tc.find("failure")
+        assert fail is not None
+        assert "Source: include/foo.h:42" in fail.text
+
+    def test_func_added_passes(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_ADDED,
+                symbol="_ZN3foo9new_thingEv",
+                description="Function foo::new_thing() was added",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes, verdict=Verdict.COMPATIBLE))
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "0"
+        tc = ts.find("testcase")
+        assert tc.find("failure") is None
+
+    def test_mixed_changes(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_REMOVED,
+                symbol="_ZN3foo6legacyEv",
+                description="Function removed",
+            ),
+            Change(
+                kind=ChangeKind.FUNC_ADDED,
+                symbol="_ZN3foo9new_thingEv",
+                description="Function added",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("tests") == "2"
+        assert ts.get("failures") == "1"
+
+
+# ---------------------------------------------------------------------------
+# Suppressed changes → pass
+# ---------------------------------------------------------------------------
+
+class TestSuppressedChanges:
+    def test_suppressed_symbols_appear_as_passing(self) -> None:
+        """Symbols that were suppressed (not in changes list) should still
+        appear as passing test cases when the old snapshot is provided."""
+        snap = _make_snapshot(functions=[
+            Function(name="foo::bar", mangled="_ZN3foo3barEv", return_type="void"),
+            Function(name="foo::suppressed", mangled="_ZN3foo10suppressedEv", return_type="void"),
+        ])
+        # Only one change — the suppressed one is not in the changes list
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_REMOVED,
+                symbol="_ZN3foo3barEv",
+                description="Function removed",
+            ),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result, snap)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("tests") == "2"
+        assert ts.get("failures") == "1"
+        # The suppressed symbol passes
+        suppressed_tc = ts.find(".//testcase[@name='_ZN3foo10suppressedEv']")
+        assert suppressed_tc is not None
+        assert suppressed_tc.find("failure") is None
+
+
+# ---------------------------------------------------------------------------
+# XML escaping of C++ mangled names with templates
+# ---------------------------------------------------------------------------
+
+class TestXmlEscaping:
+    def test_template_symbol_escaping(self) -> None:
+        """C++ mangled names with angle brackets must be properly escaped."""
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_REMOVED,
+                symbol="_ZN3foo3barINS_3BazIiEEEEvT_",
+                description="Function foo::bar<foo::Baz<int>>() removed",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        # This should parse without error — if escaping is wrong, ET.fromstring fails
+        root = _parse(xml)
+        tc = root.find(".//testcase")
+        assert tc.get("name") == "_ZN3foo3barINS_3BazIiEEEEvT_"
+
+    def test_description_with_angle_brackets(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_RETURN_CHANGED,
+                symbol="_ZN3foo3barEv",
+                description="Return type changed from std::vector<int> to std::vector<long>",
+                old_value="std::vector<int>",
+                new_value="std::vector<long>",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        assert "std::vector<int>" in fail.text or "std::vector&lt;int&gt;" in ET.tostring(fail, encoding="unicode")
+
+
+# ---------------------------------------------------------------------------
+# Failure attributes
+# ---------------------------------------------------------------------------
+
+class TestFailureAttributes:
+    def test_failure_message_format(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_RETURN_CHANGED,
+                symbol="_ZN3foo3bazEv",
+                description="Return type changed from int to long",
+                old_value="int",
+                new_value="long",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        msg = fail.get("message")
+        assert msg == "func_return_changed: Return type changed from int to long"
+
+    def test_failure_body_includes_values(self) -> None:
+        changes = [
+            Change(
+                kind=ChangeKind.TYPE_SIZE_CHANGED,
+                symbol="MyStruct",
+                description="size changed",
+                old_value="16",
+                new_value="24",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        assert "(16 → 24)" in fail.text
+
+
+# ---------------------------------------------------------------------------
+# Classname grouping
+# ---------------------------------------------------------------------------
+
+class TestClassnameGrouping:
+    def test_function_classname(self) -> None:
+        changes = [Change(kind=ChangeKind.FUNC_REMOVED, symbol="f", description="")]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        assert root.find(".//testcase").get("classname") == "functions"
+
+    def test_variable_classname(self) -> None:
+        changes = [Change(kind=ChangeKind.VAR_REMOVED, symbol="v", description="")]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        assert root.find(".//testcase").get("classname") == "variables"
+
+    def test_type_classname(self) -> None:
+        changes = [Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="T", description="")]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        assert root.find(".//testcase").get("classname") == "types"
+
+    def test_enum_classname(self) -> None:
+        changes = [Change(kind=ChangeKind.ENUM_MEMBER_REMOVED, symbol="E", description="")]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        assert root.find(".//testcase").get("classname") == "enums"
+
+    def test_elf_metadata_classname(self) -> None:
+        changes = [Change(kind=ChangeKind.SONAME_CHANGED, symbol="soname", description="")]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        assert root.find(".//testcase").get("classname") == "metadata"
+
+
+# ---------------------------------------------------------------------------
+# Multi-suite (compare-release)
+# ---------------------------------------------------------------------------
+
+class TestMultiSuite:
+    def test_multiple_testsuites(self) -> None:
+        r1 = _make_result(
+            [Change(kind=ChangeKind.FUNC_REMOVED, symbol="f1", description="removed")],
+            library="libfoo.so.1",
+        )
+        r2 = _make_result(
+            [],
+            library="libbar.so.2",
+            verdict=Verdict.NO_CHANGE,
+        )
+        xml = to_junit_xml_multi([(r1, None), (r2, None)])
+        root = _parse(xml)
+        suites = root.findall("testsuite")
+        assert len(suites) == 2
+        assert suites[0].get("name") == "libfoo.so.1"
+        assert suites[1].get("name") == "libbar.so.2"
+
+    def test_rollup_counts(self) -> None:
+        r1 = _make_result(
+            [Change(kind=ChangeKind.FUNC_REMOVED, symbol="f1", description="removed")],
+            library="libfoo.so.1",
+        )
+        r2 = _make_result(
+            [Change(kind=ChangeKind.FUNC_ADDED, symbol="f2", description="added")],
+            library="libbar.so.2",
+            verdict=Verdict.COMPATIBLE,
+        )
+        xml = to_junit_xml_multi([(r1, None), (r2, None)])
+        root = _parse(xml)
+        assert root.get("tests") == "2"
+        assert root.get("failures") == "1"
+
+    def test_empty_multi(self) -> None:
+        xml = to_junit_xml_multi([])
+        root = _parse(xml)
+        assert root.get("tests") == "0"
+        assert root.get("failures") == "0"
+        assert root.findall("testsuite") == []
+
+
+# ---------------------------------------------------------------------------
+# With full snapshot — pass rate
+# ---------------------------------------------------------------------------
+
+class TestWithSnapshot:
+    def test_pass_rate_includes_all_symbols(self) -> None:
+        """Total test count includes unchanged symbols from old snapshot."""
+        snap = _make_snapshot(
+            functions=[
+                Function(name="f1", mangled="f1", return_type="void"),
+                Function(name="f2", mangled="f2", return_type="void"),
+                Function(name="f3", mangled="f3", return_type="void"),
+            ],
+            types=[
+                RecordType(name="MyStruct", kind="struct"),
+            ],
+        )
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="f1", description="removed"),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result, snap)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # 3 functions + 1 type = 4 total
+        assert ts.get("tests") == "4"
+        assert ts.get("failures") == "1"
+
+    def test_additions_included_in_count(self) -> None:
+        """New symbols (not in old snapshot) should also be counted."""
+        snap = _make_snapshot(
+            functions=[
+                Function(name="f1", mangled="f1", return_type="void"),
+            ],
+        )
+        changes = [
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="f2", description="added"),
+        ]
+        result = _make_result(changes, verdict=Verdict.COMPATIBLE)
+        xml = to_junit_xml(result, snap)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # f1 (from snapshot) + f2 (addition) = 2
+        assert ts.get("tests") == "2"
+        assert ts.get("failures") == "0"
+
+
+# ---------------------------------------------------------------------------
+# Valid XML output
+# ---------------------------------------------------------------------------
+
+class TestValidXml:
+    def test_output_is_valid_xml(self) -> None:
+        """Output must be parseable XML."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="sym1", description="desc"),
+            Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="T1", description="size",
+                   old_value="8", new_value="16"),
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="sym2", description="added"),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        # Should not raise
+        root = ET.fromstring(xml)
+        assert root.tag == "testsuites"

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1,12 +1,23 @@
-"""Tests for JUnit XML output."""
+"""Tests for JUnit XML output.
+
+Unit tests for the ``junit_report`` module, plus CLI integration tests that
+exercise the full ``abicheck compare --format junit`` pipeline using JSON
+snapshot files.
+"""
 from __future__ import annotations
 
+import json
 import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
 
 from abicheck.checker_types import Change, DiffResult
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.junit_report import to_junit_xml, to_junit_xml_multi
 from abicheck.model import AbiSnapshot, Function, RecordType, Variable, EnumType, EnumMember
+from abicheck.serialization import snapshot_to_json
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +62,16 @@ def _make_snapshot(
 
 def _parse(xml_str: str) -> ET.Element:
     return ET.fromstring(xml_str)
+
+
+def _write_snapshot(path: Path, snap: AbiSnapshot) -> Path:
+    path.write_text(snapshot_to_json(snap), encoding="utf-8")
+    return path
+
+
+# ===========================================================================
+# UNIT TESTS
+# ===========================================================================
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +211,46 @@ class TestBreakingChanges:
         assert ts.get("tests") == "2"
         assert ts.get("failures") == "1"
 
+    def test_api_break_is_failure(self) -> None:
+        """API_BREAK changes (e.g. enum member renamed) should be failures."""
+        changes = [
+            Change(
+                kind=ChangeKind.ENUM_MEMBER_RENAMED,
+                symbol="Status",
+                description="Enum member renamed from OK to SUCCESS",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes, verdict=Verdict.API_BREAK))
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        fail = root.find(".//failure")
+        assert fail.get("type") == "API_BREAK"
+
+
+# ---------------------------------------------------------------------------
+# COMPATIBLE_WITH_RISK handling
+# ---------------------------------------------------------------------------
+
+class TestCompatibleWithRisk:
+    def test_risk_change_default_severity_passes(self) -> None:
+        """COMPATIBLE_WITH_RISK changes with severity 'warning' should pass."""
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+                symbol="libc.so.6",
+                description="New GLIBC_2.34 version requirement added",
+            ),
+        ]
+        result = _make_result(changes, verdict=Verdict.COMPATIBLE_WITH_RISK)
+        xml = to_junit_xml(result)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # Default severity for RISK_KINDS is "warning", not "error" — passes
+        assert ts.get("failures") == "0"
+        tc = ts.find("testcase")
+        assert tc.find("failure") is None
+
 
 # ---------------------------------------------------------------------------
 # Suppressed changes → pass
@@ -257,6 +318,76 @@ class TestXmlEscaping:
         root = _parse(xml)
         fail = root.find(".//failure")
         assert "std::vector<int>" in fail.text or "std::vector&lt;int&gt;" in ET.tostring(fail, encoding="unicode")
+
+    def test_ampersand_in_symbol(self) -> None:
+        """Symbol names or descriptions containing & must be escaped."""
+        changes = [
+            Change(
+                kind=ChangeKind.FUNC_REMOVED,
+                symbol="foo&bar",
+                description="Function foo&bar() removed",
+            ),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)  # Would raise if escaping failed
+        tc = root.find(".//testcase")
+        assert tc.get("name") == "foo&bar"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_empty_description_uses_kind(self) -> None:
+        """When description is empty, the failure message should still be useful."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="f", description=""),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        assert "func_removed" in fail.get("message")
+        # Body should use kind-derived text when description is empty
+        assert fail.text is not None and len(fail.text) > 0
+
+    def test_none_old_value_none_new_value(self) -> None:
+        """When both old_value and new_value are None, no (? → ?) line appears."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="f", description="removed"),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        assert "→" not in fail.text
+
+    def test_old_value_is_empty_string(self) -> None:
+        """Empty string old_value should still emit the (? → new) line (is not None)."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="f",
+                   description="changed", old_value="", new_value="int"),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        assert "→" in fail.text
+
+    def test_multiple_changes_same_symbol(self) -> None:
+        """Multiple breaking changes on the same symbol produce multiple <failure> children."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="f",
+                   description="return type changed", old_value="int", new_value="long"),
+            Change(kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="f",
+                   description="parameter count changed"),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # Only 1 testcase (same symbol)
+        assert ts.get("tests") == "1"
+        tc = ts.find("testcase")
+        failures = tc.findall("failure")
+        assert len(failures) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -440,4 +571,283 @@ class TestValidXml:
         xml = to_junit_xml(_make_result(changes))
         # Should not raise
         root = ET.fromstring(xml)
+        assert root.tag == "testsuites"
+
+
+# ===========================================================================
+# INTEGRATION TESTS — CLI pipeline
+# ===========================================================================
+
+
+class TestJUnitCLICompare:
+    """Integration tests that run ``abicheck compare --format junit`` via
+    the Click test runner with JSON snapshot files."""
+
+    @staticmethod
+    def _snap(version: str, funcs: list[Function]) -> AbiSnapshot:
+        return AbiSnapshot(library="libtest.so", version=version, functions=funcs)
+
+    def test_compare_no_changes(self, tmp_path: Path) -> None:
+        """No ABI changes → valid JUnit XML with zero failures."""
+        from abicheck.cli import main
+
+        funcs = [Function(name="foo", mangled="_Z3foov", return_type="int")]
+        old = self._snap("1.0", funcs)
+        new = self._snap("2.0", funcs)
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+        ])
+        assert result.exit_code == 0, result.output
+        root = ET.fromstring(result.output)
+        assert root.tag == "testsuites"
+        assert root.get("failures") == "0"
+        ts = root.find("testsuite")
+        assert ts.get("name") == "libtest.so"
+
+    def test_compare_breaking_changes(self, tmp_path: Path) -> None:
+        """Removing a function → JUnit XML with failure, exit code 4."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+            Function(name="bar", mangled="_Z3barv", return_type="void"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+        ])
+        assert result.exit_code == 4  # BREAKING
+        root = ET.fromstring(result.output)
+        assert int(root.get("failures")) >= 1
+        fail = root.find(".//failure")
+        assert fail is not None
+        assert "BREAKING" in fail.get("type")
+
+    def test_compare_compatible_addition(self, tmp_path: Path) -> None:
+        """Adding a function → JUnit XML with zero failures, exit code 0."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+            Function(name="bar", mangled="_Z3barv", return_type="void"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+        ])
+        assert result.exit_code == 0
+        root = ET.fromstring(result.output)
+        assert root.get("failures") == "0"
+        # Addition should appear as a passing testcase
+        tcs = root.findall(".//testcase")
+        assert len(tcs) >= 1
+
+    def test_compare_output_to_file(self, tmp_path: Path) -> None:
+        """--format junit -o file.xml writes valid XML to file."""
+        from abicheck.cli import main
+
+        funcs = [Function(name="foo", mangled="_Z3foov", return_type="int")]
+        old = self._snap("1.0", funcs)
+        new = self._snap("2.0", funcs)
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+        out_path = tmp_path / "results.xml"
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+            "-o", str(out_path),
+        ])
+        assert result.exit_code == 0, result.output
+        assert out_path.exists()
+        content = out_path.read_text(encoding="utf-8")
+        root = ET.fromstring(content)
+        assert root.tag == "testsuites"
+
+    def test_compare_with_suppression(self, tmp_path: Path) -> None:
+        """Suppressed changes should not appear as failures in JUnit output."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+            Function(name="bar", mangled="_Z3barv", return_type="void"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        # Write a suppression file that suppresses the removed function
+        supp_path = tmp_path / "supp.yml"
+        supp_path.write_text(
+            "version: 1\n"
+            "suppressions:\n"
+            "  - symbol: _Z3barv\n"
+            "    change_kind: func_removed\n"
+            "    reason: intentional removal\n",
+            encoding="utf-8",
+        )
+
+        out_path = tmp_path / "results.xml"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+            "--suppress", str(supp_path),
+            "-o", str(out_path),
+        ])
+        # With suppression, verdict may be NO_CHANGE or COMPATIBLE
+        assert result.exit_code == 0, result.output
+        content = out_path.read_text(encoding="utf-8")
+        root = ET.fromstring(content)
+        assert root.get("failures") == "0"
+
+    def test_compare_return_type_changed(self, tmp_path: Path) -> None:
+        """Return type change → JUnit failure with old/new values."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="getval", mangled="_Z6getvalv", return_type="int"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="getval", mangled="_Z6getvalv", return_type="long"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+        ])
+        assert result.exit_code == 4  # BREAKING
+        root = ET.fromstring(result.output)
+        fail = root.find(".//failure")
+        assert fail is not None
+        assert "func_return_changed" in fail.get("message")
+
+    def test_compare_multiple_change_types(self, tmp_path: Path) -> None:
+        """Mix of additions, removals, and unchanged → correct counts."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="keep", mangled="_Z4keepv", return_type="void"),
+            Function(name="remove", mangled="_Z6removev", return_type="void"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="keep", mangled="_Z4keepv", return_type="void"),
+            Function(name="added", mangled="_Z5addedv", return_type="void"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+        ])
+        root = ET.fromstring(result.output)
+        ts = root.find("testsuite")
+        # At minimum we should see a failure for the removed function
+        failures = int(ts.get("failures"))
+        assert failures >= 1
+
+    def test_compare_policy_sdk_vendor(self, tmp_path: Path) -> None:
+        """Different policy can reclassify changes, reflected in JUnit."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+            Function(name="bar", mangled="_Z3barv", return_type="void"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+            "--policy", "sdk_vendor",
+        ])
+        assert result.exit_code == 0
+        root = ET.fromstring(result.output)
+        assert root.get("failures") == "0"
+
+    def test_format_junit_accepted_by_cli(self) -> None:
+        """--format junit is recognized without error (even if inputs are bad)."""
+        from abicheck.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", "/nonexistent/old.json", "/nonexistent/new.json",
+            "--format", "junit",
+        ])
+        # Should fail on missing file, NOT on unrecognized format
+        assert "Unsupported output format" not in (result.output or "")
+
+    def test_xml_output_is_well_formed(self, tmp_path: Path) -> None:
+        """Stress test: verify well-formed XML with special characters."""
+        from abicheck.cli import main
+        from abicheck.model import Param
+
+        old = self._snap("1.0", [
+            Function(name="bar<int>", mangled="_Z3barIiEvT_", return_type="void",
+                     params=[Param(name="x", type="int")]),
+        ])
+        new = self._snap("2.0", [
+            Function(name="bar<int>", mangled="_Z3barIiEvT_", return_type="void",
+                     params=[Param(name="x", type="long")]),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+        ])
+        # Must parse as valid XML regardless of exit code
+        root = ET.fromstring(result.output)
         assert root.tag == "testsuites"

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -6,17 +6,15 @@ snapshot files.
 """
 from __future__ import annotations
 
-import json
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from abicheck.checker_types import Change, DiffResult
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.junit_report import to_junit_xml, to_junit_xml_multi
-from abicheck.model import AbiSnapshot, Function, RecordType, Variable, EnumType, EnumMember
+from abicheck.model import AbiSnapshot, Function, RecordType, Variable, EnumType
 from abicheck.serialization import snapshot_to_json
 
 
@@ -250,6 +248,37 @@ class TestCompatibleWithRisk:
         assert ts.get("failures") == "0"
         tc = ts.find("testcase")
         assert tc.find("failure") is None
+
+    def test_risk_change_with_error_severity_fails(self) -> None:
+        """COMPATIBLE_WITH_RISK changes with overridden severity 'error' should fail.
+
+        We use a policy_file override to promote a RISK kind to severity 'error'.
+        """
+        from unittest.mock import patch
+        from abicheck.checker_policy import PolicyEntry
+
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+                symbol="libc.so.6",
+                description="New GLIBC_2.34 version requirement added",
+            ),
+        ]
+        result = _make_result(changes, verdict=Verdict.COMPATIBLE_WITH_RISK)
+        # Patch policy_for to return severity="error" for this kind
+        original_entry = PolicyEntry(
+            Verdict.COMPATIBLE_WITH_RISK,
+            "error",
+            "symbol_version_required_added",
+        )
+        with patch("abicheck.junit_report.policy_for", return_value=original_entry):
+            xml = to_junit_xml(result)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        fail = root.find(".//failure")
+        assert fail is not None
+        assert fail.get("type") == "COMPATIBLE_WITH_RISK"
 
 
 # ---------------------------------------------------------------------------
@@ -536,6 +565,42 @@ class TestWithSnapshot:
         assert ts.get("tests") == "4"
         assert ts.get("failures") == "1"
 
+    def test_snapshot_with_variables_and_enums(self) -> None:
+        """Snapshot containing variables and enums — all appear as testcases."""
+        from abicheck.model import Visibility
+        snap = _make_snapshot(
+            functions=[
+                Function(name="f1", mangled="f1", return_type="void"),
+            ],
+            variables=[
+                Variable(name="g_count", mangled="g_count", type="int",
+                         visibility=Visibility.PUBLIC),
+            ],
+            enums=[
+                EnumType(name="Color", members=[]),
+            ],
+        )
+        changes = [
+            Change(kind=ChangeKind.VAR_REMOVED, symbol="g_count", description="removed"),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result, snap)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # 1 function + 1 variable + 1 enum = 3 total
+        assert ts.get("tests") == "3"
+        assert ts.get("failures") == "1"
+        # Variable testcase has failure
+        var_tc = ts.find(".//testcase[@name='g_count']")
+        assert var_tc is not None
+        assert var_tc.get("classname") == "variables"
+        assert var_tc.find("failure") is not None
+        # Enum testcase passes
+        enum_tc = ts.find(".//testcase[@name='Color']")
+        assert enum_tc is not None
+        assert enum_tc.get("classname") == "enums"
+        assert enum_tc.find("failure") is None
+
     def test_additions_included_in_count(self) -> None:
         """New symbols (not in old snapshot) should also be counted."""
         snap = _make_snapshot(
@@ -572,6 +637,86 @@ class TestValidXml:
         # Should not raise
         root = ET.fromstring(xml)
         assert root.tag == "testsuites"
+
+
+# ---------------------------------------------------------------------------
+# show_only filter
+# ---------------------------------------------------------------------------
+
+class TestShowOnly:
+    def test_show_only_breaking_filters_compatible(self) -> None:
+        """--show-only breaking hides compatible additions."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="old_func",
+                   description="removed"),
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="new_func",
+                   description="added"),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result, show_only="breaking")
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # Only the breaking change should appear
+        assert ts.get("tests") == "1"
+        assert ts.get("failures") == "1"
+        tc = ts.find("testcase")
+        assert tc.get("name") == "old_func"
+
+    def test_show_only_functions_filters_types(self) -> None:
+        """--show-only functions hides type changes."""
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="f1",
+                   description="removed"),
+            Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="MyStruct",
+                   description="size changed", old_value="8", new_value="16"),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result, show_only="functions")
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("tests") == "1"
+        tc = ts.find("testcase")
+        assert tc.get("name") == "f1"
+
+    def test_show_only_with_multi(self) -> None:
+        """show_only works with to_junit_xml_multi."""
+        r1 = _make_result(
+            [
+                Change(kind=ChangeKind.FUNC_REMOVED, symbol="f1",
+                       description="removed"),
+                Change(kind=ChangeKind.FUNC_ADDED, symbol="f2",
+                       description="added"),
+            ],
+            library="libfoo.so.1",
+        )
+        xml = to_junit_xml_multi([(r1, None)], show_only="breaking")
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("tests") == "1"
+        assert ts.get("failures") == "1"
+
+
+# ---------------------------------------------------------------------------
+# failure_count correctness with extra_changes
+# ---------------------------------------------------------------------------
+
+class TestFailureCountCorrectness:
+    def test_failure_count_when_first_change_is_compatible(self) -> None:
+        """failure_count must count symbols with ANY failing change,
+        even when the first change per symbol is compatible."""
+        changes = [
+            # First change for symbol "f" is compatible (addition)
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="f",
+                   description="added"),
+            # Second change for symbol "f" is breaking
+            Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="f",
+                   description="return type changed"),
+        ]
+        xml = to_junit_xml(_make_result(changes))
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # The symbol should be counted as a failure
+        assert ts.get("failures") == "1"
 
 
 # ===========================================================================
@@ -634,7 +779,7 @@ class TestJUnitCLICompare:
         ])
         assert result.exit_code == 4  # BREAKING
         root = ET.fromstring(result.output)
-        assert int(root.get("failures")) >= 1
+        assert root.get("failures") == "1"
         fail = root.find(".//failure")
         assert fail is not None
         assert "BREAKING" in fail.get("type")
@@ -663,9 +808,9 @@ class TestJUnitCLICompare:
         assert result.exit_code == 0
         root = ET.fromstring(result.output)
         assert root.get("failures") == "0"
-        # Addition should appear as a passing testcase
+        # Both kept and added functions should appear as testcases
         tcs = root.findall(".//testcase")
-        assert len(tcs) >= 1
+        assert len(tcs) == 2
 
     def test_compare_output_to_file(self, tmp_path: Path) -> None:
         """--format junit -o file.xml writes valid XML to file."""
@@ -783,9 +928,8 @@ class TestJUnitCLICompare:
         ])
         root = ET.fromstring(result.output)
         ts = root.find("testsuite")
-        # At minimum we should see a failure for the removed function
-        failures = int(ts.get("failures"))
-        assert failures >= 1
+        # Exactly one function was removed
+        assert ts.get("failures") == "1"
 
     def test_compare_policy_sdk_vendor(self, tmp_path: Path) -> None:
         """Different policy can reclassify changes, reflected in JUnit."""
@@ -812,6 +956,61 @@ class TestJUnitCLICompare:
         assert result.exit_code == 0
         root = ET.fromstring(result.output)
         assert root.get("failures") == "0"
+
+    def test_compare_show_only_breaking(self, tmp_path: Path) -> None:
+        """--show-only breaking with --format junit filters to breaking only."""
+        from abicheck.cli import main
+
+        old = self._snap("1.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+            Function(name="bar", mangled="_Z3barv", return_type="void"),
+        ])
+        new = self._snap("2.0", [
+            Function(name="foo", mangled="_Z3foov", return_type="int"),
+            Function(name="baz", mangled="_Z3bazv", return_type="void"),
+        ])
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+            "--show-only", "breaking",
+        ])
+        assert result.exit_code == 4  # BREAKING
+        root = ET.fromstring(result.output)
+        ts = root.find("testsuite")
+        # Only the breaking removal should be a failure (addition is filtered out)
+        assert ts.get("failures") == "1"
+        # The removed function should have a <failure> element
+        failures = root.findall(".//failure")
+        assert len(failures) == 1
+        assert "BREAKING" in failures[0].get("type")
+
+    def test_compare_stat_with_junit_produces_xml(self, tmp_path: Path) -> None:
+        """--stat --format junit should still produce JUnit XML (stat ignored)."""
+        from abicheck.cli import main
+
+        funcs = [Function(name="foo", mangled="_Z3foov", return_type="int")]
+        old = self._snap("1.0", funcs)
+        new = self._snap("2.0", funcs)
+        _write_snapshot(tmp_path / "old.json", old)
+        _write_snapshot(tmp_path / "new.json", new)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare",
+            str(tmp_path / "old.json"),
+            str(tmp_path / "new.json"),
+            "--format", "junit",
+            "--stat",
+        ])
+        assert result.exit_code == 0, result.output
+        root = ET.fromstring(result.output)
+        assert root.tag == "testsuites"
 
     def test_format_junit_accepted_by_cli(self) -> None:
         """--format junit is recognized without error (even if inputs are bad)."""

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -6,17 +6,16 @@ snapshot files.
 """
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from click.testing import CliRunner
+from defusedxml.ElementTree import fromstring as xml_fromstring
 
-from abicheck.checker_types import Change, DiffResult
 from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.checker_types import Change, DiffResult
 from abicheck.junit_report import to_junit_xml, to_junit_xml_multi
-from abicheck.model import AbiSnapshot, Function, RecordType, Variable, EnumType
+from abicheck.model import AbiSnapshot, EnumType, Function, RecordType, Variable
 from abicheck.serialization import snapshot_to_json
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,8 +57,8 @@ def _make_snapshot(
     return s
 
 
-def _parse(xml_str: str) -> ET.Element:
-    return ET.fromstring(xml_str)
+def _parse(xml_str: str):  # noqa: ANN201
+    return xml_fromstring(xml_str)
 
 
 def _write_snapshot(path: Path, snap: AbiSnapshot) -> Path:
@@ -255,6 +254,7 @@ class TestCompatibleWithRisk:
         We use a policy_file override to promote a RISK kind to severity 'error'.
         """
         from unittest.mock import patch
+
         from abicheck.checker_policy import PolicyEntry
 
         changes = [
@@ -328,7 +328,7 @@ class TestXmlEscaping:
             ),
         ]
         xml = to_junit_xml(_make_result(changes))
-        # This should parse without error — if escaping is wrong, ET.fromstring fails
+        # This should parse without error — if escaping is wrong, xml_fromstring fails
         root = _parse(xml)
         tc = root.find(".//testcase")
         assert tc.get("name") == "_ZN3foo3barINS_3BazIiEEEEvT_"
@@ -346,7 +346,8 @@ class TestXmlEscaping:
         xml = to_junit_xml(_make_result(changes))
         root = _parse(xml)
         fail = root.find(".//failure")
-        assert "std::vector<int>" in fail.text or "std::vector&lt;int&gt;" in ET.tostring(fail, encoding="unicode")
+        import xml.etree.ElementTree
+        assert "std::vector<int>" in fail.text or "std::vector&lt;int&gt;" in xml.etree.ElementTree.tostring(fail, encoding="unicode")
 
     def test_ampersand_in_symbol(self) -> None:
         """Symbol names or descriptions containing & must be escaped."""
@@ -635,7 +636,7 @@ class TestValidXml:
         ]
         xml = to_junit_xml(_make_result(changes))
         # Should not raise
-        root = ET.fromstring(xml)
+        root = xml_fromstring(xml)
         assert root.tag == "testsuites"
 
 
@@ -719,6 +720,115 @@ class TestFailureCountCorrectness:
         assert ts.get("failures") == "1"
 
 
+# ---------------------------------------------------------------------------
+# show_only + snapshot interaction
+# ---------------------------------------------------------------------------
+
+class TestShowOnlyWithSnapshot:
+    def test_show_only_excludes_unchanged_snapshot_symbols(self) -> None:
+        """When show_only is active, unchanged snapshot symbols must NOT
+        appear as passing testcases (documented: 'filtered-out changes
+        are omitted entirely')."""
+        snap = _make_snapshot(
+            functions=[
+                Function(name="unchanged", mangled="unchanged", return_type="void"),
+                Function(name="removed", mangled="removed", return_type="void"),
+            ],
+        )
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="removed",
+                   description="removed"),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result, snap, show_only="breaking")
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        # Only the breaking change should appear — not the unchanged "unchanged"
+        assert ts.get("tests") == "1"
+        assert ts.get("failures") == "1"
+        tcs = ts.findall("testcase")
+        assert len(tcs) == 1
+        assert tcs[0].get("name") == "removed"
+
+
+# ---------------------------------------------------------------------------
+# severity_config propagation
+# ---------------------------------------------------------------------------
+
+class TestSeverityConfig:
+    def test_severity_config_escalates_addition_to_failure(self) -> None:
+        """When severity_config marks additions as 'error', they become
+        failures in JUnit."""
+        from abicheck.severity import SeverityConfig, SeverityLevel
+
+        config = SeverityConfig(
+            abi_breaking=SeverityLevel.ERROR,
+            potential_breaking=SeverityLevel.ERROR,
+            quality_issues=SeverityLevel.WARNING,
+            addition=SeverityLevel.ERROR,
+        )
+        changes = [
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="f",
+                   description="added"),
+        ]
+        result = _make_result(changes, verdict=Verdict.COMPATIBLE)
+        xml = to_junit_xml(result, severity_config=config)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+
+    def test_severity_config_demotes_breaking_to_pass(self) -> None:
+        """When severity_config marks abi_breaking as 'warning', additions
+        that were BREAKING still fail (breaking_set takes priority)."""
+        # Note: _is_failure always returns True for breaking_set regardless of
+        # severity_config. This test verifies that contract.
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="f",
+                   description="removed"),
+        ]
+        result = _make_result(changes)
+        xml = to_junit_xml(result)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+
+
+# ---------------------------------------------------------------------------
+# Error libraries in multi-suite
+# ---------------------------------------------------------------------------
+
+class TestErrorLibraries:
+    def test_error_library_appears_as_error_testsuite(self) -> None:
+        """Failed compare-release pairs should produce <error> testcases."""
+        r1 = _make_result(
+            [Change(kind=ChangeKind.FUNC_REMOVED, symbol="f1",
+                    description="removed")],
+            library="libfoo.so.1",
+        )
+        error_libs = [
+            {"library": "libbar.so.1", "error": "missing headers"},
+        ]
+        xml = to_junit_xml_multi(
+            [(r1, None)],
+            error_libraries=error_libs,
+        )
+        root = _parse(xml)
+        suites = root.findall("testsuite")
+        assert len(suites) == 2
+        # First suite is normal
+        assert suites[0].get("name") == "libfoo.so.1"
+        # Second suite is the error
+        err_suite = suites[1]
+        assert err_suite.get("name") == "libbar.so.1"
+        assert err_suite.get("errors") == "1"
+        err_tc = err_suite.find("testcase")
+        assert err_tc.find("error") is not None
+        assert "missing headers" in err_tc.find("error").get("message")
+        # Roll-up counts
+        assert root.get("errors") == "1"
+        assert root.get("tests") == "2"  # 1 normal + 1 error
+
+
 # ===========================================================================
 # INTEGRATION TESTS — CLI pipeline
 # ===========================================================================
@@ -750,7 +860,7 @@ class TestJUnitCLICompare:
             "--format", "junit",
         ])
         assert result.exit_code == 0, result.output
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         assert root.tag == "testsuites"
         assert root.get("failures") == "0"
         ts = root.find("testsuite")
@@ -778,7 +888,7 @@ class TestJUnitCLICompare:
             "--format", "junit",
         ])
         assert result.exit_code == 4  # BREAKING
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         assert root.get("failures") == "1"
         fail = root.find(".//failure")
         assert fail is not None
@@ -806,7 +916,7 @@ class TestJUnitCLICompare:
             "--format", "junit",
         ])
         assert result.exit_code == 0
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         assert root.get("failures") == "0"
         # Both kept and added functions should appear as testcases
         tcs = root.findall(".//testcase")
@@ -834,7 +944,7 @@ class TestJUnitCLICompare:
         assert result.exit_code == 0, result.output
         assert out_path.exists()
         content = out_path.read_text(encoding="utf-8")
-        root = ET.fromstring(content)
+        root = xml_fromstring(content)
         assert root.tag == "testsuites"
 
     def test_compare_with_suppression(self, tmp_path: Path) -> None:
@@ -875,7 +985,7 @@ class TestJUnitCLICompare:
         # With suppression, verdict may be NO_CHANGE or COMPATIBLE
         assert result.exit_code == 0, result.output
         content = out_path.read_text(encoding="utf-8")
-        root = ET.fromstring(content)
+        root = xml_fromstring(content)
         assert root.get("failures") == "0"
 
     def test_compare_return_type_changed(self, tmp_path: Path) -> None:
@@ -899,7 +1009,7 @@ class TestJUnitCLICompare:
             "--format", "junit",
         ])
         assert result.exit_code == 4  # BREAKING
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         fail = root.find(".//failure")
         assert fail is not None
         assert "func_return_changed" in fail.get("message")
@@ -926,7 +1036,7 @@ class TestJUnitCLICompare:
             str(tmp_path / "new.json"),
             "--format", "junit",
         ])
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         ts = root.find("testsuite")
         # Exactly one function was removed
         assert ts.get("failures") == "1"
@@ -954,7 +1064,7 @@ class TestJUnitCLICompare:
             "--policy", "sdk_vendor",
         ])
         assert result.exit_code == 0
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         assert root.get("failures") == "0"
 
     def test_compare_show_only_breaking(self, tmp_path: Path) -> None:
@@ -981,7 +1091,7 @@ class TestJUnitCLICompare:
             "--show-only", "breaking",
         ])
         assert result.exit_code == 4  # BREAKING
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         ts = root.find("testsuite")
         # Only the breaking removal should be a failure (addition is filtered out)
         assert ts.get("failures") == "1"
@@ -1009,7 +1119,7 @@ class TestJUnitCLICompare:
             "--stat",
         ])
         assert result.exit_code == 0, result.output
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         assert root.tag == "testsuites"
 
     def test_format_junit_accepted_by_cli(self) -> None:
@@ -1048,5 +1158,5 @@ class TestJUnitCLICompare:
             "--format", "junit",
         ])
         # Must parse as valid XML regardless of exit code
-        root = ET.fromstring(result.output)
+        root = xml_fromstring(result.output)
         assert root.tag == "testsuites"


### PR DESCRIPTION
## Summary

Add `--format junit` support to `abicheck compare` and `compare-release` commands, enabling integration with CI systems (GitLab CI, Jenkins, Azure DevOps) that display test results in their standard dashboards.

## Motivation

ABI compatibility checks are often run in CI pipelines, but results are currently only available in Markdown, JSON, SARIF, or HTML formats. CI systems like GitLab CI, Jenkins, and Azure DevOps have native support for JUnit XML test reports, which integrate seamlessly into their dashboards and provide better visibility into ABI compatibility status alongside other test results.

## Changes

- **New module `abicheck/junit_report.py`**: Implements JUnit XML generation with:
  - `to_junit_xml()`: Converts a single `DiffResult` to JUnit XML
  - `to_junit_xml_multi()`: Converts multiple results (for `compare-release`) to a single XML document
  - Proper mapping of ABI changes to JUnit test cases and failures
  - Support for `--show-only` filtering
  - Correct failure counting when symbols have multiple changes
  - XML escaping for C++ mangled names and special characters

- **CLI integration** (`abicheck/cli.py`):
  - Added `"junit"` to `--format` option choices
  - Integrated JUnit output into `compare` and `compare-release` commands
  - Proper exit code handling based on verdict

- **Service layer** (`abicheck/service.py`):
  - Updated `render_output()` to support `"junit"` format

- **Comprehensive test suite** (`tests/test_junit_report.py`):
  - 1052 lines of unit and integration tests covering:
    - Schema structure and XML validity
    - Verdict-to-failure mapping (BREAKING, API_BREAK, COMPATIBLE_WITH_RISK)
    - Classname grouping (functions, variables, types, enums, metadata)
    - Multiple changes per symbol
    - XML escaping of C++ templates and special characters
    - `--show-only` filtering
    - Multi-suite output for `compare-release`
    - Full CLI integration tests with snapshot files

- **Documentation**:
  - Added JUnit XML section to `docs/user-guide/output-formats.md` with usage examples, severity mapping, and XML structure
  - Updated ADR 014 to document the fifth output format
  - Updated `docs/user-guide/cli-usage.md` with JUnit examples
  - Updated `CHANGELOG.md` with feature announcement

## Mapping Rules

- Each library becomes a `<testsuite>`
- Each exported symbol/type becomes a `<testcase>`
- BREAKING and API_BREAK changes → `<failure>` elements
- COMPATIBLE changes → passing test cases
- COMPATIBLE_WITH_RISK changes → pass by default (severity="warning")
- Unchanged symbols from old snapshot also appear as passing test cases (meaningful pass-rate)
- Multiple changes to the same symbol produce multiple `<failure>` children

## Checklist

- [x] Tests added / updated for new behaviour (1052 lines of comprehensive tests)
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated (user guide, ADR, CLI examples)
- [x] No new `mypy` or `ruff` errors introduced

https://claude.ai/code/session_01CZagq6fmfN6maz1dsMyaxG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JUnit XML output (`--format junit`) for compare and compare-release, producing per-library test suites and testcases that represent ABI checks, with multi-library rollups and library-error reporting.

* **Behavior**
  * JUnit output maps verdicts to failures/passes, respects severity/policy overrides, supports show-only filtering and suppression, and omits derived/redundant changes from testcases.

* **Documentation**
  * Added usage examples, mapping details, and CI integration guidance for JUnit XML.

* **Tests**
  * Added unit and end-to-end tests validating JUnit XML generation and CLI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->