### PR TITLE
Add Debian symbols file adapter for dpkg-gensymbols integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   Integrated as the `fingerprint_renames` detector — fires only in
   `elf_only_mode` (stripped binaries without debug info or headers).
 
+#### Debian Symbols File Adapter
+- **`abicheck debian-symbols generate`** — generate Debian symbols files (`dpkg-gensymbols`
+  format) from shared library binaries. Supports C++ demangled `(c++)` form, ELF symbol
+  versioning (`@Base` / `@VERSION_NODE`), and automatic SONAME-to-package-name derivation.
+  Options: `--package`, `--version`, `--no-cpp`, `-o`.
+- **`abicheck debian-symbols validate`** — validate a Debian symbols file against a binary.
+  Reports missing and new symbols. Respects `(optional)` tag semantics. Exit code `0` = match,
+  `2` = mismatch.
+- **`abicheck debian-symbols diff`** — diff two Debian symbols files showing added, removed,
+  and version-changed symbols.
+- Full Debian tag syntax support: `(c++)`, `(optional)`, `(arch=...)`, pipe-separated groups
+  (`(c++|optional)`), and round-trip formatting preservation.
+- New module: `abicheck.debian_symbols` with Python API for programmatic use
+  (`generate_symbols_file`, `validate_symbols`, `diff_symbols_files`, `parse_symbols_file`).
+
 ### Planned
 - `--policy-file` schema validation improvements
 - Version-stamped typedef suppression (libpng `png_libpng_version_X_Y_Z` pattern)

--- a/README.md
+++ b/README.md
@@ -168,25 +168,6 @@ For the full CLI reference see the [documentation](https://napetrov.github.io/ab
 
 ---
 
-## Debian symbols file integration
-
-Generate, validate, and diff [Debian symbols files](https://manpages.debian.org/unstable/dpkg-dev/dpkg-gensymbols.1.en.html) for `dpkg-gensymbols` / `dpkg-shlibdeps` integration:
-
-```bash
-# Generate symbols file from a shared library
-abicheck debian-symbols generate libfoo.so -o debian/libfoo1.symbols
-
-# Validate symbols file against a binary (exit 0 = match, exit 2 = mismatch)
-abicheck debian-symbols validate libfoo.so debian/libfoo1.symbols
-
-# Diff two symbols files
-abicheck debian-symbols diff old/libfoo1.symbols new/libfoo1.symbols
-```
-
-Supports C++ demangled `(c++)` form, ELF symbol versioning (`@Base` / `@VERSION_NODE`), and Debian tags (`(optional)`, `(arch=...)`, pipe-separated groups). See the [CLI usage guide](https://napetrov.github.io/abicheck/user-guide/cli-usage/) for full options.
-
----
-
 ## Exit codes
 
 Use these exit codes to gate CI pipelines. Non-zero exits can fail your build when breaking changes are detected.
@@ -216,13 +197,6 @@ Use these exit codes to gate CI pipelines. Non-zero exits can fail your build wh
 | `0` | `COMPATIBLE` | App is not affected by the library change |
 | `2` | `API_BREAK` | App uses changed API (recompile needed) |
 | `4` | `BREAKING` | App will crash or misbehave with new library |
-
-### debian-symbols validate
-
-| Exit code | Meaning |
-|-----------|---------|
-| `0` | Symbols file matches the binary |
-| `2` | Mismatch — symbols in the file are missing from the binary |
 
 See the [full exit code reference](https://napetrov.github.io/abicheck/reference/exit-codes/) for CI gate patterns.
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ For the full CLI reference see the [documentation](https://napetrov.github.io/ab
 
 ---
 
+## Debian symbols file integration
+
+Generate, validate, and diff [Debian symbols files](https://manpages.debian.org/unstable/dpkg-dev/dpkg-gensymbols.1.en.html) for `dpkg-gensymbols` / `dpkg-shlibdeps` integration:
+
+```bash
+# Generate symbols file from a shared library
+abicheck debian-symbols generate libfoo.so -o debian/libfoo1.symbols
+
+# Validate symbols file against a binary (exit 0 = match, exit 2 = mismatch)
+abicheck debian-symbols validate libfoo.so debian/libfoo1.symbols
+
+# Diff two symbols files
+abicheck debian-symbols diff old/libfoo1.symbols new/libfoo1.symbols
+```
+
+Supports C++ demangled `(c++)` form, ELF symbol versioning (`@Base` / `@VERSION_NODE`), and Debian tags (`(optional)`, `(arch=...)`, pipe-separated groups). See the [CLI usage guide](https://napetrov.github.io/abicheck/user-guide/cli-usage/) for full options.
+
+---
+
 ## Exit codes
 
 Use these exit codes to gate CI pipelines. Non-zero exits can fail your build when breaking changes are detected.
@@ -197,6 +216,13 @@ Use these exit codes to gate CI pipelines. Non-zero exits can fail your build wh
 | `0` | `COMPATIBLE` | App is not affected by the library change |
 | `2` | `API_BREAK` | App uses changed API (recompile needed) |
 | `4` | `BREAKING` | App will crash or misbehave with new library |
+
+### debian-symbols validate
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Symbols file matches the binary |
+| `2` | Mismatch — symbols in the file are missing from the binary |
 
 See the [full exit code reference](https://napetrov.github.io/abicheck/reference/exit-codes/) for CI gate patterns.
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -2205,9 +2205,7 @@ def debian_symbols_generate(
 
 @debian_symbols_group.command("validate")
 @click.argument("so_path", type=click.Path(exists=True, path_type=Path))
-@click.option("--symbols", "symbols_path", required=True,
-              type=click.Path(exists=True, path_type=Path),
-              help="Path to existing Debian symbols file to validate.")
+@click.argument("symbols_path", type=click.Path(exists=True, path_type=Path))
 def debian_symbols_validate(so_path: Path, symbols_path: Path) -> None:
     """Validate a Debian symbols file against a shared library binary.
 
@@ -2218,7 +2216,7 @@ def debian_symbols_validate(so_path: Path, symbols_path: Path) -> None:
 
     \b
     Example:
-      abicheck debian-symbols validate libfoo.so --symbols debian/libfoo1.symbols
+      abicheck debian-symbols validate libfoo.so debian/libfoo1.symbols
     """
     from .debian_symbols import format_validation_report, validate_from_binary
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -2151,5 +2151,109 @@ from .compat.cli import (  # noqa: E402,F401
 main.add_command(compat_group)
 
 
+# ── debian-symbols command group ──────────────────────────────────────────────
+
+@click.group("debian-symbols")
+def debian_symbols_group() -> None:
+    """Generate, validate, and diff Debian symbols files.
+
+    Integrates abicheck with Debian/Ubuntu packaging workflows where
+    dpkg-gensymbols and dpkg-shlibdeps use symbols files for fine-grained
+    dependency tracking.
+    """
+
+
+@debian_symbols_group.command("generate")
+@click.argument("so_path", type=click.Path(exists=True, path_type=Path))
+@click.option("-o", "--output", "output_path", type=click.Path(path_type=Path), default=None,
+              help="Output file path. Prints to stdout if not specified.")
+@click.option("--package", default="", help="Debian package name (derived from SONAME if empty).")
+@click.option("--version", "version", default="#MINVER#", show_default=True,
+              help="Minimum version string for symbols.")
+@click.option("--no-cpp", "no_cpp", is_flag=True, default=False,
+              help="Do not emit C++ demangled (c++) form; use mangled names only.")
+def debian_symbols_generate(
+    so_path: Path,
+    output_path: Path | None,
+    package: str,
+    version: str,
+    no_cpp: bool,
+) -> None:
+    """Generate a Debian symbols file from a shared library.
+
+    \b
+    Example:
+      abicheck debian-symbols generate libfoo.so -o debian/libfoo1.symbols
+    """
+    from .debian_symbols import generate_from_binary
+
+    symbols_file = generate_from_binary(
+        so_path,
+        package=package,
+        version=version,
+        use_cpp=not no_cpp,
+    )
+
+    text = symbols_file.format()
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(text, encoding="utf-8")
+        click.echo(f"Symbols file written to {output_path}")
+    else:
+        click.echo(text, nl=False)
+
+
+@debian_symbols_group.command("validate")
+@click.argument("so_path", type=click.Path(exists=True, path_type=Path))
+@click.option("--symbols", "symbols_path", required=True,
+              type=click.Path(exists=True, path_type=Path),
+              help="Path to existing Debian symbols file to validate.")
+def debian_symbols_validate(so_path: Path, symbols_path: Path) -> None:
+    """Validate a Debian symbols file against a shared library binary.
+
+    \b
+    Exit codes:
+      0  symbols file matches the binary
+      2  mismatch (missing symbols)
+
+    \b
+    Example:
+      abicheck debian-symbols validate libfoo.so --symbols debian/libfoo1.symbols
+    """
+    from .debian_symbols import format_validation_report, validate_from_binary
+
+    result = validate_from_binary(so_path, symbols_path)
+    click.echo(format_validation_report(result), nl=False)
+
+    if not result.passed:
+        sys.exit(2)
+
+
+@debian_symbols_group.command("diff")
+@click.argument("old_symbols", type=click.Path(exists=True, path_type=Path))
+@click.argument("new_symbols", type=click.Path(exists=True, path_type=Path))
+def debian_symbols_diff(old_symbols: Path, new_symbols: Path) -> None:
+    """Diff two Debian symbols files.
+
+    \b
+    Example:
+      abicheck debian-symbols diff old/libfoo1.symbols new/libfoo1.symbols
+    """
+    from .debian_symbols import (
+        diff_symbols_files,
+        format_diff_report,
+        load_symbols_file,
+    )
+
+    old = load_symbols_file(old_symbols)
+    new = load_symbols_file(new_symbols)
+    diff = diff_symbols_files(old, new)
+
+    click.echo(format_diff_report(diff, str(old_symbols), str(new_symbols)), nl=False)
+
+
+main.add_command(debian_symbols_group)
+
+
 if __name__ == "__main__":
     main()

--- a/abicheck/debian_symbols.py
+++ b/abicheck/debian_symbols.py
@@ -1,0 +1,538 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Debian symbols file generation, parsing, validation, and diffing.
+
+Implements the ``dpkg-gensymbols(1)`` symbols file format used by Debian/Ubuntu
+packaging for fine-grained shared library dependency tracking.
+
+Format reference:
+  https://manpages.debian.org/unstable/dpkg-dev/dpkg-gensymbols.1.en.html
+
+A symbols file has the structure::
+
+    libfoo.so.1 libfoo1 #MINVER#
+     _ZN3foo3barEv@Base 1.0
+     (c++)"foo::bar()@Base" 1.0
+     (arch=amd64)_ZN3foo3bazEv@Base 1.0
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .demangle import demangle
+from .elf_metadata import ElfMetadata, ElfSymbol, SymbolType, parse_elf_metadata
+
+_log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+# Regex for parsing optional tags like (c++), (arch=amd64), (symver), etc.
+_TAG_RE = re.compile(r"^\(([^)]+)\)")
+
+
+@dataclass
+class DebianSymbolEntry:
+    """One symbol line in a Debian symbols file."""
+    name: str               # symbol name (mangled or demangled with quotes)
+    version_node: str       # "Base" or a version node like "LIBFOO_1.0"
+    min_version: str        # minimum package version where this symbol appeared
+    tags: list[str] = field(default_factory=list)  # e.g. ["c++", "arch=amd64"]
+
+    @property
+    def is_cpp(self) -> bool:
+        return "c++" in self.tags
+
+    @property
+    def mangled_name(self) -> str:
+        """Return the mangled symbol name (strip quotes from demangled C++ form)."""
+        if self.is_cpp:
+            # (c++)"foo::bar()@Base" → the name field is foo::bar()
+            # The mangled name is not stored; return name as-is for matching
+            return self.name
+        # For non-C++ entries, name is the mangled form (before @)
+        return self.name
+
+    def format_line(self) -> str:
+        """Format as a Debian symbols file line (without leading space)."""
+        tag_prefix = "".join(f"({t})" for t in self.tags)
+        if self.is_cpp:
+            return f'{tag_prefix}"{self.name}@{self.version_node}" {self.min_version}'
+        return f"{tag_prefix}{self.name}@{self.version_node} {self.min_version}"
+
+
+@dataclass
+class DebianSymbolsFile:
+    """Parsed Debian symbols file."""
+    library: str            # SONAME, e.g. "libfoo.so.1"
+    package: str            # package name, e.g. "libfoo1"
+    min_version: str        # #MINVER# or a version string
+    symbols: list[DebianSymbolEntry] = field(default_factory=list)
+
+    def format(self) -> str:
+        """Format the complete Debian symbols file."""
+        lines = [f"{self.library} {self.package} {self.min_version}"]
+        for sym in sorted(self.symbols, key=lambda s: s.name):
+            lines.append(f" {sym.format_line()}")
+        return "\n".join(lines) + "\n"
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating a symbols file against a binary."""
+    library: str
+    missing: list[DebianSymbolEntry] = field(default_factory=list)
+    new_symbols: list[str] = field(default_factory=list)  # "name@version_node"
+    passed: bool = True
+
+
+@dataclass
+class SymbolsDiff:
+    """Diff between two Debian symbols files."""
+    added: list[DebianSymbolEntry] = field(default_factory=list)
+    removed: list[DebianSymbolEntry] = field(default_factory=list)
+    version_changed: list[tuple[DebianSymbolEntry, DebianSymbolEntry]] = field(
+        default_factory=list,
+    )  # (old, new)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def parse_symbols_file(text: str) -> DebianSymbolsFile:
+    """Parse a Debian symbols file from its text content.
+
+    Raises ``ValueError`` on malformed input.
+    """
+    lines = text.splitlines()
+    if not lines:
+        raise ValueError("Empty symbols file")
+
+    # First line: "libfoo.so.1 libfoo1 #MINVER#"
+    header_parts = lines[0].split(None, 2)
+    if len(header_parts) < 3:
+        raise ValueError(f"Malformed header line: {lines[0]!r}")
+
+    result = DebianSymbolsFile(
+        library=header_parts[0],
+        package=header_parts[1],
+        min_version=header_parts[2],
+    )
+
+    for lineno, line in enumerate(lines[1:], start=2):
+        if not line or not line.startswith(" "):
+            continue  # skip blank or non-symbol lines
+        entry = _parse_symbol_line(line.strip(), lineno)
+        if entry is not None:
+            result.symbols.append(entry)
+
+    return result
+
+
+def _parse_symbol_line(line: str, lineno: int) -> DebianSymbolEntry | None:
+    """Parse a single symbol line (already stripped of leading whitespace).
+
+    Handles forms like::
+
+        _ZN3foo3barEv@Base 1.0
+        (c++)"foo::bar()@Base" 1.0
+        (c++|optional)"foo::bar()@Base" 1.0
+        (arch=amd64)_ZN3foo3barEv@Base 1.0
+    """
+    tags: list[str] = []
+    rest = line
+
+    # Extract leading tags: (tag1)(tag2)...
+    while rest.startswith("("):
+        m = _TAG_RE.match(rest)
+        if not m:
+            break
+        tag_content = m.group(1)
+        # A tag may contain pipe-separated values: (c++|optional)
+        for t in tag_content.split("|"):
+            tags.append(t.strip())
+        rest = rest[m.end():]
+
+    is_cpp = "c++" in tags
+
+    if is_cpp:
+        # C++ form: "demangled_name@VersionNode" min_version
+        if not rest.startswith('"'):
+            _log.warning("Line %d: expected quoted C++ symbol: %s", lineno, line)
+            return None
+        # Find closing quote
+        end_quote = rest.index('"', 1) if '"' in rest[1:] else -1
+        if end_quote == -1:
+            _log.warning("Line %d: unterminated quote: %s", lineno, line)
+            return None
+        quoted = rest[1:end_quote]
+        remainder = rest[end_quote + 1:].strip()
+        # quoted = "foo::bar()@Base"
+        at_idx = quoted.rfind("@")
+        if at_idx == -1:
+            _log.warning("Line %d: missing @version in quoted symbol: %s", lineno, line)
+            return None
+        name = quoted[:at_idx]
+        version_node = quoted[at_idx + 1:]
+        min_version = remainder if remainder else ""
+    else:
+        # Non-C++ form: mangled_name@VersionNode min_version
+        parts = rest.split(None, 1)
+        if not parts:
+            return None
+        sym_ver = parts[0]
+        min_version = parts[1] if len(parts) > 1 else ""
+        at_idx = sym_ver.rfind("@")
+        if at_idx == -1:
+            _log.warning("Line %d: missing @version: %s", lineno, line)
+            return None
+        name = sym_ver[:at_idx]
+        version_node = sym_ver[at_idx + 1:]
+
+    return DebianSymbolEntry(
+        name=name,
+        version_node=version_node,
+        min_version=min_version.strip(),
+        tags=tags,
+    )
+
+
+def load_symbols_file(path: Path) -> DebianSymbolsFile:
+    """Load and parse a Debian symbols file from disk."""
+    return parse_symbols_file(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+def _symbol_version_node(sym: ElfSymbol) -> str:
+    """Determine the version node for a symbol.
+
+    Returns the ELF version tag (e.g. "LIBFOO_1.0") if present,
+    otherwise "Base" (the Debian convention for unversioned symbols).
+    """
+    if sym.version:
+        return sym.version
+    return "Base"
+
+
+def generate_symbols_file(
+    elf_meta: ElfMetadata,
+    *,
+    package: str = "",
+    version: str = "#MINVER#",
+    use_cpp: bool = True,
+) -> DebianSymbolsFile:
+    """Generate a Debian symbols file from ELF metadata.
+
+    Args:
+        elf_meta: Parsed ELF metadata (from ``parse_elf_metadata``).
+        package: Debian package name. If empty, derived from SONAME.
+        version: Version string for the minimum version field.
+        use_cpp: If True, emit C++ symbols in demangled ``(c++)`` form.
+
+    Returns:
+        A ``DebianSymbolsFile`` ready to be formatted.
+    """
+    soname = elf_meta.soname or "UNKNOWN"
+
+    if not package:
+        # Derive package name from SONAME: libfoo.so.1 → libfoo1
+        package = _soname_to_package(soname)
+
+    result = DebianSymbolsFile(
+        library=soname,
+        package=package,
+        min_version=version,
+    )
+
+    for sym in elf_meta.symbols:
+        # Skip symbols that are not exported functions or objects
+        if sym.sym_type not in (SymbolType.FUNC, SymbolType.OBJECT, SymbolType.IFUNC):
+            continue
+
+        ver_node = _symbol_version_node(sym)
+        tags: list[str] = []
+        name = sym.name
+
+        # Try to demangle C++ symbols
+        if use_cpp:
+            demangled = demangle(sym.name)
+            if demangled is not None:
+                tags.append("c++")
+                name = demangled
+
+        result.symbols.append(DebianSymbolEntry(
+            name=name,
+            version_node=ver_node,
+            min_version=version,
+            tags=tags,
+        ))
+
+    return result
+
+
+def generate_from_binary(
+    so_path: Path,
+    *,
+    package: str = "",
+    version: str = "#MINVER#",
+    use_cpp: bool = True,
+) -> DebianSymbolsFile:
+    """Generate a Debian symbols file directly from a shared library binary.
+
+    Convenience wrapper around ``parse_elf_metadata`` + ``generate_symbols_file``.
+    """
+    elf_meta = parse_elf_metadata(so_path)
+    return generate_symbols_file(
+        elf_meta,
+        package=package,
+        version=version,
+        use_cpp=use_cpp,
+    )
+
+
+def _soname_to_package(soname: str) -> str:
+    """Derive a Debian package name from a SONAME.
+
+    Examples::
+
+        libfoo.so.1   → libfoo1
+        libbar.so.2.3 → libbar2
+        libfoo.so     → libfoo
+    """
+    # Strip .so and everything after, then append major version
+    base = soname
+    so_idx = base.find(".so")
+    if so_idx == -1:
+        return base
+
+    lib_base = base[:so_idx]
+    version_part = base[so_idx + 3:]  # ".1" or ".2.3" or ""
+
+    if version_part.startswith("."):
+        # Extract major version number
+        ver_str = version_part[1:]
+        dot_idx = ver_str.find(".")
+        if dot_idx != -1:
+            ver_str = ver_str[:dot_idx]
+        return lib_base + ver_str
+
+    return lib_base
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_symbols(
+    elf_meta: ElfMetadata,
+    symbols_file: DebianSymbolsFile,
+) -> ValidationResult:
+    """Validate a Debian symbols file against an ELF binary's metadata.
+
+    Checks:
+    - Symbols listed in the file but missing from the binary.
+    - Symbols exported by the binary but not listed in the file.
+
+    Returns a ``ValidationResult``.
+    """
+    soname = elf_meta.soname or "UNKNOWN"
+
+    # Build set of exported symbols from binary: "name@version_node"
+    binary_syms: dict[str, ElfSymbol] = {}
+    binary_mangled_set: set[str] = set()
+    for sym in elf_meta.symbols:
+        if sym.sym_type not in (SymbolType.FUNC, SymbolType.OBJECT, SymbolType.IFUNC):
+            continue
+        ver_node = _symbol_version_node(sym)
+        key = f"{sym.name}@{ver_node}"
+        binary_syms[key] = sym
+        binary_mangled_set.add(sym.name)
+
+    # Build demangled → mangled mapping for C++ symbol lookup
+    demangled_to_mangled: dict[str, str] = {}
+    for sym_name in binary_mangled_set:
+        d = demangle(sym_name)
+        if d is not None:
+            demangled_to_mangled[d] = sym_name
+
+    result = ValidationResult(library=soname)
+
+    # Track which binary symbols are accounted for
+    matched_binary_keys: set[str] = set()
+
+    for entry in symbols_file.symbols:
+        if entry.is_cpp:
+            # Look up by demangled name
+            mangled = demangled_to_mangled.get(entry.name)
+            if mangled is not None:
+                key = f"{mangled}@{entry.version_node}"
+                if key in binary_syms:
+                    matched_binary_keys.add(key)
+                    continue
+            # Not found
+            result.missing.append(entry)
+        else:
+            key = f"{entry.name}@{entry.version_node}"
+            if key in binary_syms:
+                matched_binary_keys.add(key)
+            else:
+                result.missing.append(entry)
+
+    # Find new symbols (in binary but not in symbols file)
+    for key in sorted(binary_syms.keys()):
+        if key not in matched_binary_keys:
+            result.new_symbols.append(key)
+
+    result.passed = len(result.missing) == 0
+
+    return result
+
+
+def validate_from_binary(
+    so_path: Path,
+    symbols_path: Path,
+) -> ValidationResult:
+    """Validate a symbols file against a binary (convenience wrapper)."""
+    elf_meta = parse_elf_metadata(so_path)
+    symbols_file = load_symbols_file(symbols_path)
+    return validate_symbols(elf_meta, symbols_file)
+
+
+def format_validation_report(result: ValidationResult) -> str:
+    """Format a human-readable validation report."""
+    lines = [f"Symbols validation for {result.library}:"]
+
+    lines.append("  MISSING from binary (in symbols file but not exported):")
+    if result.missing:
+        for entry in result.missing:
+            lines.append(f"    {entry.format_line()}")
+    else:
+        lines.append("    (none)")
+
+    lines.append("  NEW in binary (exported but not in symbols file):")
+    if result.new_symbols:
+        for sym_key in result.new_symbols:
+            lines.append(f"    {sym_key}")
+    else:
+        lines.append("    (none)")
+
+    n_missing = len(result.missing)
+    n_new = len(result.new_symbols)
+
+    if result.passed and n_new == 0:
+        lines.append("  Result: PASS")
+    elif result.passed:
+        lines.append(f"  Result: PASS ({n_new} new symbol{'s' if n_new != 1 else ''})")
+    else:
+        lines.append(
+            f"  Result: FAIL ({n_missing} missing symbol{'s' if n_missing != 1 else ''})"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+def diff_symbols_files(
+    old: DebianSymbolsFile,
+    new: DebianSymbolsFile,
+) -> SymbolsDiff:
+    """Compute the diff between two Debian symbols files.
+
+    Returns a ``SymbolsDiff`` with added, removed, and version-changed symbols.
+    """
+    result = SymbolsDiff()
+
+    # Index by (name, version_node, is_cpp) for identity
+    def _key(entry: DebianSymbolEntry) -> str:
+        return f"{'(c++)' if entry.is_cpp else ''}{entry.name}@{entry.version_node}"
+
+    old_by_name: dict[str, DebianSymbolEntry] = {}
+    for entry in old.symbols:
+        # Use name + tags as identity key (without version_node for version change detection)
+        ident = f"{'(c++)' if entry.is_cpp else ''}{entry.name}"
+        old_by_name[ident] = entry
+
+    new_by_name: dict[str, DebianSymbolEntry] = {}
+    for entry in new.symbols:
+        ident = f"{'(c++)' if entry.is_cpp else ''}{entry.name}"
+        new_by_name[ident] = entry
+
+    old_keys = set(old_by_name.keys())
+    new_keys = set(new_by_name.keys())
+
+    # Removed: in old but not in new
+    for ident in sorted(old_keys - new_keys):
+        result.removed.append(old_by_name[ident])
+
+    # Added: in new but not in old
+    for ident in sorted(new_keys - old_keys):
+        result.added.append(new_by_name[ident])
+
+    # Version changed: same symbol, different min_version
+    for ident in sorted(old_keys & new_keys):
+        old_entry = old_by_name[ident]
+        new_entry = new_by_name[ident]
+        if old_entry.min_version != new_entry.min_version:
+            result.version_changed.append((old_entry, new_entry))
+
+    return result
+
+
+def format_diff_report(
+    diff: SymbolsDiff,
+    old_path: str = "old",
+    new_path: str = "new",
+) -> str:
+    """Format a human-readable diff report."""
+    lines = [f"Symbols diff: {old_path} -> {new_path}"]
+
+    lines.append("  ADDED:")
+    if diff.added:
+        for entry in diff.added:
+            lines.append(f"    + {entry.format_line()}")
+    else:
+        lines.append("    (none)")
+
+    lines.append("  REMOVED:")
+    if diff.removed:
+        for entry in diff.removed:
+            lines.append(f"    - {entry.format_line()}")
+    else:
+        lines.append("    (none)")
+
+    lines.append("  VERSION CHANGED:")
+    if diff.version_changed:
+        for old_entry, new_entry in diff.version_changed:
+            lines.append(
+                f"    {old_entry.name}: {old_entry.min_version} -> {new_entry.min_version}"
+            )
+    else:
+        lines.append("    (none)")
+
+    total = len(diff.added) + len(diff.removed) + len(diff.version_changed)
+    lines.append(f"  Total changes: {total}")
+
+    return "\n".join(lines) + "\n"

--- a/abicheck/debian_symbols.py
+++ b/abicheck/debian_symbols.py
@@ -26,11 +26,17 @@ A symbols file has the structure::
      _ZN3foo3barEv@Base 1.0
      (c++)"foo::bar()@Base" 1.0
      (arch=amd64)_ZN3foo3bazEv@Base 1.0
+
+Limitations:
+  - ``#include`` directives and ``#PACKAGE#`` substitution are not supported.
+  - ``(regex)`` and ``(symver)`` pattern-matching tags are not evaluated.
+  - ``(arch=...)`` tags are parsed but not filtered (no ``--arch`` option yet).
 """
 from __future__ import annotations
 
 import logging
 import re
+import stat
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -38,6 +44,9 @@ from .demangle import demangle
 from .elf_metadata import ElfMetadata, ElfSymbol, SymbolType, parse_elf_metadata
 
 _log = logging.getLogger(__name__)
+
+# Maximum symbols file size we are willing to read (50 MiB).
+_MAX_SYMBOLS_FILE_BYTES = 50 * 1024 * 1024
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -53,25 +62,32 @@ class DebianSymbolEntry:
     name: str               # symbol name (mangled or demangled with quotes)
     version_node: str       # "Base" or a version node like "LIBFOO_1.0"
     min_version: str        # minimum package version where this symbol appeared
-    tags: list[str] = field(default_factory=list)  # e.g. ["c++", "arch=amd64"]
+    # Raw tag groups exactly as parsed, e.g. [["c++", "optional"], ["arch=amd64"]].
+    # Each inner list is one parenthesised group; pipe-separated values stay together.
+    tag_groups: list[list[str]] = field(default_factory=list)
+
+    @property
+    def tags(self) -> list[str]:
+        """Flat list of all individual tag values (convenience accessor)."""
+        return [t for group in self.tag_groups for t in group]
 
     @property
     def is_cpp(self) -> bool:
         return "c++" in self.tags
 
     @property
-    def mangled_name(self) -> str:
-        """Return the mangled symbol name (strip quotes from demangled C++ form)."""
-        if self.is_cpp:
-            # (c++)"foo::bar()@Base" → the name field is foo::bar()
-            # The mangled name is not stored; return name as-is for matching
-            return self.name
-        # For non-C++ entries, name is the mangled form (before @)
-        return self.name
+    def is_optional(self) -> bool:
+        return "optional" in self.tags
 
     def format_line(self) -> str:
-        """Format as a Debian symbols file line (without leading space)."""
-        tag_prefix = "".join(f"({t})" for t in self.tags)
+        """Format as a Debian symbols file line (without leading space).
+
+        Preserves the original tag grouping so that ``(c++|optional)``
+        round-trips correctly instead of being split into ``(c++)(optional)``.
+        """
+        tag_prefix = "".join(
+            "(" + "|".join(group) + ")" for group in self.tag_groups
+        )
         if self.is_cpp:
             return f'{tag_prefix}"{self.name}@{self.version_node}" {self.min_version}'
         return f"{tag_prefix}{self.name}@{self.version_node} {self.min_version}"
@@ -88,7 +104,7 @@ class DebianSymbolsFile:
     def format(self) -> str:
         """Format the complete Debian symbols file."""
         lines = [f"{self.library} {self.package} {self.min_version}"]
-        for sym in sorted(self.symbols, key=lambda s: s.name):
+        for sym in sorted(self.symbols, key=lambda s: s.format_line()):
             lines.append(f" {sym.format_line()}")
         return "\n".join(lines) + "\n"
 
@@ -99,7 +115,11 @@ class ValidationResult:
     library: str
     missing: list[DebianSymbolEntry] = field(default_factory=list)
     new_symbols: list[str] = field(default_factory=list)  # "name@version_node"
-    passed: bool = True
+
+    @property
+    def passed(self) -> bool:
+        """Validation passes when no required symbols are missing."""
+        return len(self.missing) == 0
 
 
 @dataclass
@@ -156,21 +176,23 @@ def _parse_symbol_line(line: str, lineno: int) -> DebianSymbolEntry | None:
         (c++|optional)"foo::bar()@Base" 1.0
         (arch=amd64)_ZN3foo3barEv@Base 1.0
     """
-    tags: list[str] = []
+    tag_groups: list[list[str]] = []
     rest = line
 
     # Extract leading tags: (tag1)(tag2)...
+    # Each parenthesised group is stored as a list so pipe-separated tags
+    # (e.g. "c++|optional") round-trip correctly.
     while rest.startswith("("):
         m = _TAG_RE.match(rest)
         if not m:
             break
         tag_content = m.group(1)
-        # A tag may contain pipe-separated values: (c++|optional)
-        for t in tag_content.split("|"):
-            tags.append(t.strip())
+        group = [t.strip() for t in tag_content.split("|")]
+        tag_groups.append(group)
         rest = rest[m.end():]
 
-    is_cpp = "c++" in tags
+    flat_tags = [t for g in tag_groups for t in g]
+    is_cpp = "c++" in flat_tags
 
     if is_cpp:
         # C++ form: "demangled_name@VersionNode" min_version
@@ -210,12 +232,29 @@ def _parse_symbol_line(line: str, lineno: int) -> DebianSymbolEntry | None:
         name=name,
         version_node=version_node,
         min_version=min_version.strip(),
-        tags=tags,
+        tag_groups=tag_groups,
     )
 
 
 def load_symbols_file(path: Path) -> DebianSymbolsFile:
-    """Load and parse a Debian symbols file from disk."""
+    """Load and parse a Debian symbols file from disk.
+
+    Verifies the target is a regular file and enforces a size limit to
+    prevent memory exhaustion from malicious input.
+
+    The regular-file check uses ``os.stat()`` before ``open()`` to avoid
+    blocking on FIFOs or device nodes.  (``parse_elf_metadata`` uses
+    ``fstat()`` *after* open, which works for ELF binaries but would block
+    on a FIFO.)
+    """
+    st = path.stat()
+    if not stat.S_ISREG(st.st_mode):
+        raise ValueError(f"Not a regular file: {path}")
+    if st.st_size > _MAX_SYMBOLS_FILE_BYTES:
+        raise ValueError(
+            f"Symbols file too large ({st.st_size} bytes, "
+            f"limit {_MAX_SYMBOLS_FILE_BYTES}): {path}"
+        )
     return parse_symbols_file(path.read_text(encoding="utf-8"))
 
 
@@ -270,21 +309,21 @@ def generate_symbols_file(
             continue
 
         ver_node = _symbol_version_node(sym)
-        tags: list[str] = []
+        tag_groups: list[list[str]] = []
         name = sym.name
 
         # Try to demangle C++ symbols
         if use_cpp:
             demangled = demangle(sym.name)
             if demangled is not None:
-                tags.append("c++")
+                tag_groups.append(["c++"])
                 name = demangled
 
         result.symbols.append(DebianSymbolEntry(
             name=name,
             version_node=ver_node,
             min_version=version,
-            tags=tags,
+            tag_groups=tag_groups,
         ))
 
     return result
@@ -353,6 +392,9 @@ def validate_symbols(
     - Symbols listed in the file but missing from the binary.
     - Symbols exported by the binary but not listed in the file.
 
+    Symbols tagged ``(optional)`` are skipped — they do not cause a failure
+    when absent from the binary (per ``dpkg-gensymbols(1)`` semantics).
+
     Returns a ``ValidationResult``.
     """
     soname = elf_meta.soname or "UNKNOWN"
@@ -368,12 +410,13 @@ def validate_symbols(
         binary_syms[key] = sym
         binary_mangled_set.add(sym.name)
 
-    # Build demangled → mangled mapping for C++ symbol lookup
-    demangled_to_mangled: dict[str, str] = {}
+    # Build demangled → list of mangled names for C++ symbol lookup.
+    # Multiple mangled names can demangle to the same string (e.g. ABI tags).
+    demangled_to_mangled: dict[str, list[str]] = {}
     for sym_name in binary_mangled_set:
         d = demangle(sym_name)
         if d is not None:
-            demangled_to_mangled[d] = sym_name
+            demangled_to_mangled.setdefault(d, []).append(sym_name)
 
     result = ValidationResult(library=soname)
 
@@ -381,31 +424,44 @@ def validate_symbols(
     matched_binary_keys: set[str] = set()
 
     for entry in symbols_file.symbols:
-        if entry.is_cpp:
-            # Look up by demangled name
-            mangled = demangled_to_mangled.get(entry.name)
-            if mangled is not None:
-                key = f"{mangled}@{entry.version_node}"
-                if key in binary_syms:
-                    matched_binary_keys.add(key)
-                    continue
-            # Not found
+        # (optional) symbols are not required — skip validation
+        if entry.is_optional:
+            # Still try to match so they don't appear as "new"
+            _try_match(entry, binary_syms, demangled_to_mangled, matched_binary_keys)
+            continue
+
+        if not _try_match(entry, binary_syms, demangled_to_mangled, matched_binary_keys):
             result.missing.append(entry)
-        else:
-            key = f"{entry.name}@{entry.version_node}"
-            if key in binary_syms:
-                matched_binary_keys.add(key)
-            else:
-                result.missing.append(entry)
 
     # Find new symbols (in binary but not in symbols file)
     for key in sorted(binary_syms.keys()):
         if key not in matched_binary_keys:
             result.new_symbols.append(key)
 
-    result.passed = len(result.missing) == 0
-
     return result
+
+
+def _try_match(
+    entry: DebianSymbolEntry,
+    binary_syms: dict[str, ElfSymbol],
+    demangled_to_mangled: dict[str, list[str]],
+    matched_binary_keys: set[str],
+) -> bool:
+    """Try to match a symbols-file entry against the binary.  Returns True on match."""
+    if entry.is_cpp:
+        candidates = demangled_to_mangled.get(entry.name, [])
+        for mangled in candidates:
+            key = f"{mangled}@{entry.version_node}"
+            if key in binary_syms:
+                matched_binary_keys.add(key)
+                return True
+        return False
+
+    key = f"{entry.name}@{entry.version_node}"
+    if key in binary_syms:
+        matched_binary_keys.add(key)
+        return True
+    return False
 
 
 def validate_from_binary(
@@ -461,40 +517,44 @@ def diff_symbols_files(
 ) -> SymbolsDiff:
     """Compute the diff between two Debian symbols files.
 
+    Identity key includes the version node so that the same symbol name
+    under different version nodes (common with ELF symbol versioning)
+    is tracked correctly.
+
     Returns a ``SymbolsDiff`` with added, removed, and version-changed symbols.
     """
     result = SymbolsDiff()
 
-    # Index by (name, version_node, is_cpp) for identity
     def _key(entry: DebianSymbolEntry) -> str:
         return f"{'(c++)' if entry.is_cpp else ''}{entry.name}@{entry.version_node}"
 
-    old_by_name: dict[str, DebianSymbolEntry] = {}
+    def _ident(entry: DebianSymbolEntry) -> str:
+        """Name-only key for version-change detection."""
+        return f"{'(c++)' if entry.is_cpp else ''}{entry.name}"
+
+    old_by_key: dict[str, DebianSymbolEntry] = {}
     for entry in old.symbols:
-        # Use name + tags as identity key (without version_node for version change detection)
-        ident = f"{'(c++)' if entry.is_cpp else ''}{entry.name}"
-        old_by_name[ident] = entry
+        old_by_key[_key(entry)] = entry
 
-    new_by_name: dict[str, DebianSymbolEntry] = {}
+    new_by_key: dict[str, DebianSymbolEntry] = {}
     for entry in new.symbols:
-        ident = f"{'(c++)' if entry.is_cpp else ''}{entry.name}"
-        new_by_name[ident] = entry
+        new_by_key[_key(entry)] = entry
 
-    old_keys = set(old_by_name.keys())
-    new_keys = set(new_by_name.keys())
+    old_keys = set(old_by_key.keys())
+    new_keys = set(new_by_key.keys())
 
     # Removed: in old but not in new
-    for ident in sorted(old_keys - new_keys):
-        result.removed.append(old_by_name[ident])
+    for k in sorted(old_keys - new_keys):
+        result.removed.append(old_by_key[k])
 
     # Added: in new but not in old
-    for ident in sorted(new_keys - old_keys):
-        result.added.append(new_by_name[ident])
+    for k in sorted(new_keys - old_keys):
+        result.added.append(new_by_key[k])
 
-    # Version changed: same symbol, different min_version
-    for ident in sorted(old_keys & new_keys):
-        old_entry = old_by_name[ident]
-        new_entry = new_by_name[ident]
+    # Version changed: same full key, different min_version
+    for k in sorted(old_keys & new_keys):
+        old_entry = old_by_key[k]
+        new_entry = new_by_key[k]
         if old_entry.min_version != new_entry.min_version:
             result.version_changed.append((old_entry, new_entry))
 

--- a/abicheck/debian_symbols.py
+++ b/abicheck/debian_symbols.py
@@ -199,9 +199,11 @@ def _parse_symbol_line(line: str, lineno: int) -> DebianSymbolEntry | None:
         if not rest.startswith('"'):
             _log.warning("Line %d: expected quoted C++ symbol: %s", lineno, line)
             return None
-        # Find closing quote
-        end_quote = rest.index('"', 1) if '"' in rest[1:] else -1
-        if end_quote == -1:
+        # Find closing quote — use rfind to handle names containing quotes
+        # (e.g. operator"" _foo).  The closing quote is the last '"' in the
+        # line, followed by the min_version string.
+        end_quote = rest.rfind('"')
+        if end_quote <= 0:
             _log.warning("Line %d: unterminated quote: %s", lineno, line)
             return None
         quoted = rest[1:end_quote]
@@ -242,10 +244,12 @@ def load_symbols_file(path: Path) -> DebianSymbolsFile:
     Verifies the target is a regular file and enforces a size limit to
     prevent memory exhaustion from malicious input.
 
-    The regular-file check uses ``os.stat()`` before ``open()`` to avoid
-    blocking on FIFOs or device nodes.  (``parse_elf_metadata`` uses
-    ``fstat()`` *after* open, which works for ELF binaries but would block
-    on a FIFO.)
+    The regular-file check uses ``path.stat()`` *before* ``open()`` —
+    intentional tradeoff: this creates a small TOCTOU window, but avoids
+    blocking indefinitely on FIFOs or device nodes.  By contrast,
+    ``parse_elf_metadata`` uses ``fstat()`` *after* ``open()`` which is
+    TOCTOU-safe but would hang on a FIFO.  For a text symbols file the
+    pre-open stat is the safer choice.
     """
     st = path.stat()
     if not stat.S_ISREG(st.st_mode):
@@ -526,11 +530,12 @@ def diff_symbols_files(
     result = SymbolsDiff()
 
     def _key(entry: DebianSymbolEntry) -> str:
-        return f"{'(c++)' if entry.is_cpp else ''}{entry.name}@{entry.version_node}"
-
-    def _ident(entry: DebianSymbolEntry) -> str:
-        """Name-only key for version-change detection."""
-        return f"{'(c++)' if entry.is_cpp else ''}{entry.name}"
+        # Include tags so (arch=amd64)foo@Base and (arch=arm64)foo@Base
+        # are tracked as distinct entries.
+        tag_str = "".join(
+            "(" + "|".join(g) + ")" for g in entry.tag_groups
+        )
+        return f"{tag_str}{entry.name}@{entry.version_node}"
 
     old_by_key: dict[str, DebianSymbolEntry] = {}
     for entry in old.symbols:

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Save a baseline at release time, compare every new build:
 - [Change Kind Reference](reference/change-kinds.md) — full list of 114 detected change types
 - [Policy Profiles](user-guide/policies.md) — built-in and custom policies
 - [Suppressions](user-guide/suppressions.md) — YAML schema, matching semantics, and expiry rules
+- [Debian Symbols](user-guide/cli-usage.md#6-debian-symbols-file-integration) — generate, validate, and diff Debian symbols files for dpkg integration
 - [Migrating from ABICC](user-guide/from-abicc.md) — drop-in replacement and migration from abi-compliance-checker
 - [MCP Integration](user-guide/mcp-integration.md) — use abicheck from AI agents via MCP
 - [Tool Comparison](reference/tool-comparison.md) — abicheck vs abidiff vs ABICC

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -139,6 +139,55 @@ exit 0
 
 ---
 
+## `abicheck debian-symbols`
+
+### `debian-symbols generate`
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Symbols file generated successfully |
+| `1` | Error (binary not found, ELF parse error, I/O failure) |
+
+### `debian-symbols validate`
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Symbols file matches the binary (all required symbols present) |
+| `2` | Mismatch — one or more required symbols are missing from the binary |
+
+> Symbols tagged `(optional)` are not required — their absence does not cause
+> exit code `2`. This matches `dpkg-gensymbols` behaviour.
+
+New symbols found in the binary but not listed in the symbols file are reported
+in the output but do **not** change the exit code.
+
+### `debian-symbols diff`
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Diff computed successfully (regardless of whether changes were found) |
+| `1` | Error (file not found, parse error) |
+
+### CI gate patterns
+
+```bash
+# Update symbols file when library changes
+abicheck debian-symbols generate ./build/libfoo.so \
+    --package libfoo1 --version "$(dpkg-parsechangelog -SVersion)" \
+    -o debian/libfoo1.symbols
+
+# Validate symbols file in CI (fail on missing symbols)
+abicheck debian-symbols validate ./build/libfoo.so debian/libfoo1.symbols
+ret=$?
+[ $ret -eq 2 ] && echo "FAIL — symbols file needs updating" && exit 1
+echo "OK — symbols file matches binary"
+
+# Diff before/after to see what changed
+abicheck debian-symbols diff old.symbols new.symbols
+```
+
+---
+
 ## `abicheck compat`
 
 Matches `abi-compliance-checker` exit codes (ABICC drop-in):
@@ -173,18 +222,19 @@ In `abicheck compat`, non-verdict failures are further classified where possible
 
 ## Summary table
 
-| Verdict / State | `compare` exit (legacy) | `compare` exit (severity) | `appcompat` exit | `deps` exit | `stack-check` exit | `compat` exit |
-|-----------------|------------------------|--------------------------|-----------------|-------------|-------------------|---------------|
-| `NO_CHANGE` / `PASS` | `0` | `0` | `0` | `0` | `0` | `0` |
-| `COMPATIBLE` | `0` | `0` | `0` | — | — | `0` |
-| `COMPATIBLE_WITH_RISK` | `0` | `0`–`2`* | `0` | — | — | `0` |
-| Additions only | `0` | `0`–`1`* | n/a | — | — | n/a |
-| Quality issues only | `0` | `0`–`1`* | n/a | — | — | n/a |
-| `WARN` (ABI risk) | — | — | — | — | `1` | — |
-| `API_BREAK` | `2` | `0`–`2`* | `2` | — | — | `2` |
-| `BREAKING` / `FAIL` | `4` | `4` | `4` | — | `4` | `1` |
-| Load failure | — | — | — | `1` | `4` | — |
-| Tool error | `2`† | `2`† | `1` | — | — | `3/4/5/6/7/8/10/11` |
+| Verdict / State | `compare` exit (legacy) | `compare` exit (severity) | `appcompat` exit | `deps` exit | `stack-check` exit | `debian-symbols validate` exit | `compat` exit |
+|-----------------|------------------------|--------------------------|-----------------|-------------|-------------------|-------------------------------|---------------|
+| `NO_CHANGE` / `PASS` | `0` | `0` | `0` | `0` | `0` | `0` | `0` |
+| `COMPATIBLE` | `0` | `0` | `0` | — | — | — | `0` |
+| `COMPATIBLE_WITH_RISK` | `0` | `0`–`2`* | `0` | — | — | — | `0` |
+| Additions only | `0` | `0`–`1`* | n/a | — | — | — | n/a |
+| Quality issues only | `0` | `0`–`1`* | n/a | — | — | — | n/a |
+| `WARN` (ABI risk) | — | — | — | — | `1` | — | — |
+| `API_BREAK` | `2` | `0`–`2`* | `2` | — | — | — | `2` |
+| `BREAKING` / `FAIL` | `4` | `4` | `4` | — | `4` | — | `1` |
+| Missing symbols | — | — | — | — | — | `2` | — |
+| Load failure | — | — | — | `1` | `4` | — | — |
+| Tool error | `2`† | `2`† | `1` | — | — | `1` | `3/4/5/6/7/8/10/11` |
 
 \* Severity exit codes depend on the configuration. For example, with
 `--severity-addition error`, additions exit `1`; with `--severity-preset

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -355,6 +355,113 @@ The `stack-check` command compares two environments and reports:
 The `--follow-deps` flag on `dump` and `compare` includes dependency graph
 and binding information in the output alongside the regular ABI diff.
 
+### 6) Debian symbols file integration
+
+Generate, validate, and diff [Debian symbols files](https://manpages.debian.org/unstable/dpkg-dev/dpkg-gensymbols.1.en.html) for integration with Debian/Ubuntu packaging workflows where `dpkg-gensymbols` and `dpkg-shlibdeps` use symbols files for fine-grained dependency tracking.
+
+#### Generate a symbols file from a shared library
+
+```bash
+# Generate and print to stdout
+abicheck debian-symbols generate libfoo.so
+
+# Write to file with explicit package name and version
+abicheck debian-symbols generate libfoo.so -o debian/libfoo1.symbols \
+    --package libfoo1 --version 1.0
+```
+
+Output format (Debian symbols file):
+
+```
+libfoo.so.1 libfoo1 1.0
+ _ZN3foo3barEv@Base 1.0
+ _ZN3foo3bazEi@Base 1.0
+ _ZN3foo9new_thingEv@LIBFOO_2.0 1.1
+ (c++)"foo::Config::Config()@Base" 1.0
+ (c++)"foo::Config::~Config()@Base" 1.0
+```
+
+Mapping:
+
+- **Library SONAME** → first line (library, package name, minimum version)
+- **Each exported symbol** → one line with `@Base` or `@VERSION_NODE` and version
+- **C++ symbols** → demangled form with `(c++)` prefix (Debian convention)
+- **Version** comes from ELF symbol version nodes if present, else `@Base`
+- **Package name** is derived from SONAME (e.g. `libfoo.so.1` → `libfoo1`) or set with `--package`
+
+Use `--no-cpp` to emit mangled names only (no demangling):
+
+```bash
+abicheck debian-symbols generate libfoo.so --no-cpp -o symbols
+```
+
+#### Validate a symbols file against a binary
+
+```bash
+abicheck debian-symbols validate libfoo.so debian/libfoo1.symbols
+```
+
+Example output:
+
+```
+Symbols validation for libfoo.so.1:
+  MISSING from binary (in symbols file but not exported):
+    _ZN3foo6legacyEv@Base 1.0
+  NEW in binary (exported but not in symbols file):
+    _ZN3foo9new_thingEv@Base
+  Result: FAIL (1 missing symbol)
+```
+
+Exit codes: `0` = match (symbols file is valid), `2` = mismatch (missing symbols).
+
+Symbols tagged `(optional)` are not required — their absence does not cause failure, matching `dpkg-gensymbols` semantics.
+
+#### Diff two symbols files
+
+```bash
+abicheck debian-symbols diff old/libfoo1.symbols new/libfoo1.symbols
+```
+
+Example output:
+
+```
+Symbols diff: old/libfoo1.symbols -> new/libfoo1.symbols
+  ADDED:
+    + _ZN3foo9new_thingEv@Base 1.1
+  REMOVED:
+    - _ZN3foo6legacyEv@Base 1.0
+  VERSION CHANGED:
+    (none)
+  Total changes: 2
+```
+
+#### Options reference
+
+| Subcommand | Option | Description |
+|------------|--------|-------------|
+| `generate` | `-o` / `--output` | Output file path (stdout if omitted) |
+| `generate` | `--package` | Debian package name (derived from SONAME if empty) |
+| `generate` | `--version` | Minimum version string (default: `#MINVER#`) |
+| `generate` | `--no-cpp` | Emit mangled names only, no `(c++)` demangled form |
+| `validate` | _(positional)_ | `SO_PATH SYMBOLS_PATH` — binary and symbols file |
+| `diff` | _(positional)_ | `OLD_SYMBOLS NEW_SYMBOLS` — two symbols files |
+
+#### Supported tag syntax
+
+The parser handles the full Debian symbols tag syntax:
+
+- `(c++)` — C++ demangled symbol with quoted name
+- `(optional)` — symbol is not required during validation
+- `(arch=amd64)` — architecture-specific symbol (parsed, not filtered yet)
+- `(c++|optional)` — pipe-separated tag groups (round-trip preserved)
+- `(symver)`, `(regex)` — parsed but not evaluated
+
+#### Limitations
+
+- `#include` directives and `#PACKAGE#` substitution are not supported.
+- `(regex)` and `(symver)` pattern-matching tags are parsed but not evaluated.
+- `(arch=...)` tags are parsed but not filtered (no `--arch` option yet).
+
 ## High-level architecture
 
 ```text
@@ -363,6 +470,9 @@ CLI
   compare                      — compare two ABI surfaces
   deps                         — show dependency tree + binding status (Linux ELF)
   stack-check                  — full-stack comparison across environments (Linux ELF)
+  debian-symbols generate      — generate Debian symbols file from shared library
+  debian-symbols validate      — validate symbols file against binary
+  debian-symbols diff          — diff two Debian symbols files
   compat check                 — ABICC drop-in comparison
   compat dump                  — dump from ABICC XML descriptor
     -> dumper (castxml AST + ELF metadata)
@@ -370,6 +480,7 @@ CLI
     -> resolver (transitive dependency resolution)
     -> binder (symbol binding simulation)
     -> stack_checker (stack-level ABI comparison)
+    -> debian_symbols (Debian symbols file adapter)
     -> reporters (markdown/json/sarif/html)
 ```
 
@@ -383,6 +494,7 @@ CLI
 - `abicheck.stack_checker` — stack-level ABI comparison and verdict computation.
 - `abicheck.stack_report` — JSON and Markdown output for stack-level results.
 - `abicheck.compat` — ABICC compatibility layer (`abicheck.compat.descriptor`, `abicheck.compat.xml_report`, `abicheck.compat.cli`, `abicheck.compat.abicc_dump_import`).
+- `abicheck.debian_symbols` — Debian symbols file generation, parsing, validation, and diffing.
 - `abicheck.reporter` / `abicheck.sarif` / `abicheck.html_report` — output generators.
 - `abicheck.elf_metadata`, `abicheck.dwarf_metadata`, `abicheck.dwarf_advanced` — low-level binary metadata extraction.
 

--- a/tests/test_debian_symbols.py
+++ b/tests/test_debian_symbols.py
@@ -15,6 +15,7 @@
 """Tests for the Debian symbols file adapter (abicheck.debian_symbols)."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1015,10 +1016,9 @@ class TestLoadSymbolsFile:
         with pytest.raises(FileNotFoundError):
             load_symbols_file(tmp_path / "nope.symbols")
 
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="os.mkfifo not available on Windows")
     def test_load_rejects_non_regular_file(self, tmp_path: Path):
         """load_symbols_file should reject FIFOs / devices."""
-        import os
-
         fifo = tmp_path / "fifo.symbols"
         os.mkfifo(str(fifo))
         with pytest.raises(ValueError, match="Not a regular file"):

--- a/tests/test_debian_symbols.py
+++ b/tests/test_debian_symbols.py
@@ -271,6 +271,32 @@ class TestParseSymbolsFile:
         sf = parse_symbols_file(text)
         assert len(sf.symbols) == 0
 
+    def test_cpp_symbol_with_quotes_in_name(self):
+        """C++ user-defined literal operator with quotes in the demangled name."""
+        text = (
+            'libfoo.so.1 libfoo1 #MINVER#\n'
+            ' (c++)"operator"" _foo(char const*, unsigned long)@Base" 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 1
+        entry = sf.symbols[0]
+        assert entry.name == 'operator"" _foo(char const*, unsigned long)'
+        assert entry.version_node == "Base"
+
+    def test_cpp_quotes_roundtrip(self):
+        """Symbols with quotes in the name survive format -> parse round-trip."""
+        entry = DebianSymbolEntry(
+            name='operator"" _foo(char const*, unsigned long)',
+            version_node="Base",
+            min_version="1.0",
+            tag_groups=[["c++"]],
+        )
+        line = entry.format_line()
+        text = f"libfoo.so.1 libfoo1 #MINVER#\n {line}\n"
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 1
+        assert sf.symbols[0].name == entry.name
+
     def test_header_with_extra_whitespace(self):
         text = "  libfoo.so.1   libfoo1   #MINVER#\n foo@Base 1.0\n"
         sf = parse_symbols_file(text)
@@ -799,6 +825,35 @@ class TestDiff:
         diff = diff_symbols_files(old, new)
         assert len(diff.removed) == 1
         assert diff.removed[0].version_node == "LIBFOO_2.0"
+        assert len(diff.added) == 0
+
+    def test_same_name_different_arch_tags(self):
+        """(arch=amd64)foo@Base and (arch=arm64)foo@Base are distinct entries."""
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(
+                    name="foo_init", version_node="Base", min_version="1.0",
+                    tag_groups=[["arch=amd64"]],
+                ),
+                DebianSymbolEntry(
+                    name="foo_init", version_node="Base", min_version="1.0",
+                    tag_groups=[["arch=arm64"]],
+                ),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(
+                    name="foo_init", version_node="Base", min_version="1.0",
+                    tag_groups=[["arch=amd64"]],
+                ),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.removed) == 1
+        assert "arch=arm64" in diff.removed[0].tags
         assert len(diff.added) == 0
 
     def test_diff_report_format(self):

--- a/tests/test_debian_symbols.py
+++ b/tests/test_debian_symbols.py
@@ -36,7 +36,7 @@ from abicheck.debian_symbols import (
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# Helpers
 # ---------------------------------------------------------------------------
 
 def _make_elf_meta(
@@ -61,6 +61,33 @@ def _make_symbol(
         sym_type=sym_type,
         version=version,
         binding=binding,
+    )
+
+
+def _entry(
+    name: str,
+    version_node: str = "Base",
+    min_version: str = "1.0",
+    tag_groups: list[list[str]] | None = None,
+) -> DebianSymbolEntry:
+    return DebianSymbolEntry(
+        name=name,
+        version_node=version_node,
+        min_version=min_version,
+        tag_groups=tag_groups or [],
+    )
+
+
+def _cpp_entry(
+    name: str,
+    version_node: str = "Base",
+    min_version: str = "1.0",
+) -> DebianSymbolEntry:
+    return DebianSymbolEntry(
+        name=name,
+        version_node=version_node,
+        min_version=min_version,
+        tag_groups=[["c++"]],
     )
 
 
@@ -97,7 +124,7 @@ class TestParseSymbolsFile:
         assert entry.version_node == "Base"
         assert entry.min_version == "1.0"
 
-    def test_multiple_tags(self):
+    def test_multiple_tags_pipe_separated(self):
         text = (
             "libfoo.so.1 libfoo1 #MINVER#\n"
             ' (c++|optional)"foo::bar()@Base" 1.0\n'
@@ -106,6 +133,19 @@ class TestParseSymbolsFile:
         entry = sf.symbols[0]
         assert "c++" in entry.tags
         assert "optional" in entry.tags
+        assert entry.is_cpp
+        assert entry.is_optional
+        # Pipe-separated tags are stored in one group
+        assert entry.tag_groups == [["c++", "optional"]]
+
+    def test_multiple_separate_tag_groups(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " (c++)(arch=amd64)\"foo::bar()@Base\" 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        assert entry.tag_groups == [["c++"], ["arch=amd64"]]
         assert entry.is_cpp
 
     def test_arch_tag(self):
@@ -146,6 +186,16 @@ class TestParseSymbolsFile:
         sf = parse_symbols_file(text)
         assert len(sf.symbols) == 1
 
+    def test_non_symbol_lines_skipped(self):
+        """Lines that don't start with a space (e.g. comments) are skipped."""
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            "# this is a comment\n"
+            " foo_init@Base 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 1
+
     def test_cpp_template_symbol(self):
         text = (
             'libfoo.so.1 libfoo1 #MINVER#\n'
@@ -155,6 +205,77 @@ class TestParseSymbolsFile:
         entry = sf.symbols[0]
         assert entry.name == "std::vector<int>::push_back(int const&)"
         assert entry.version_node == "Base"
+
+    def test_deeply_nested_template(self):
+        name = "std::map<std::string, std::vector<std::pair<int, double>>>"
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            f' (c++)"{name}::insert()@Base" 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        assert entry.name == f"{name}::insert()"
+
+    def test_symbol_with_at_in_name(self):
+        """rfind('@') should handle symbols whose demangled name contains @."""
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " __cxa_atexit@@GLIBC_2.17 2.17\n"
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        # rfind picks the last @, so name="__cxa_atexit@", version_node="GLIBC_2.17"
+        assert entry.version_node == "GLIBC_2.17"
+
+    def test_special_chars_in_symbol_name(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " __libc_csu_init$impl@Base 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        assert sf.symbols[0].name == "__libc_csu_init$impl"
+
+    # --- Error paths in _parse_symbol_line ---
+
+    def test_missing_at_in_mangled_symbol(self):
+        """A mangled symbol line without @ is skipped with a warning."""
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " foo_init 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 0
+
+    def test_cpp_not_starting_with_quote(self):
+        """A (c++) tag followed by non-quoted text is skipped."""
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " (c++)foo::bar()@Base 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 0
+
+    def test_cpp_unterminated_quote(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            ' (c++)"foo::bar()@Base 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 0
+
+    def test_cpp_missing_at_in_quoted(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            ' (c++)"foo::bar()" 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 0
+
+    def test_header_with_extra_whitespace(self):
+        text = "  libfoo.so.1   libfoo1   #MINVER#\n foo@Base 1.0\n"
+        sf = parse_symbols_file(text)
+        assert sf.library == "libfoo.so.1"
+        assert sf.package == "libfoo1"
 
 
 # ---------------------------------------------------------------------------
@@ -176,30 +297,40 @@ class TestFormatSymbolsFile:
         assert len(sf2.symbols) == len(sf.symbols)
 
     def test_cpp_format_line(self):
+        entry = _cpp_entry("foo::bar()")
+        assert entry.format_line() == '(c++)"foo::bar()@Base" 1.0'
+
+    def test_mangled_format_line(self):
+        entry = _entry("_ZN3foo3barEv")
+        assert entry.format_line() == "_ZN3foo3barEv@Base 1.0"
+
+    def test_tagged_format_line(self):
+        entry = _entry("_ZN3foo3barEv", tag_groups=[["arch=amd64"]])
+        assert entry.format_line() == "(arch=amd64)_ZN3foo3barEv@Base 1.0"
+
+    def test_pipe_separated_tags_roundtrip(self):
+        """(c++|optional) must round-trip as (c++|optional), not (c++)(optional)."""
         entry = DebianSymbolEntry(
             name="foo::bar()",
             version_node="Base",
             min_version="1.0",
-            tags=["c++"],
+            tag_groups=[["c++", "optional"]],
         )
-        assert entry.format_line() == '(c++)"foo::bar()@Base" 1.0'
+        line = entry.format_line()
+        assert line == '(c++|optional)"foo::bar()@Base" 1.0'
+        # Parse it back
+        text = f"libfoo.so.1 libfoo1 #MINVER#\n {line}\n"
+        sf = parse_symbols_file(text)
+        assert sf.symbols[0].tag_groups == [["c++", "optional"]]
 
-    def test_mangled_format_line(self):
+    def test_multiple_tag_groups_format(self):
         entry = DebianSymbolEntry(
-            name="_ZN3foo3barEv",
+            name="foo::bar()",
             version_node="Base",
             min_version="1.0",
+            tag_groups=[["c++"], ["arch=amd64"]],
         )
-        assert entry.format_line() == "_ZN3foo3barEv@Base 1.0"
-
-    def test_tagged_format_line(self):
-        entry = DebianSymbolEntry(
-            name="_ZN3foo3barEv",
-            version_node="Base",
-            min_version="1.0",
-            tags=["arch=amd64"],
-        )
-        assert entry.format_line() == "(arch=amd64)_ZN3foo3barEv@Base 1.0"
+        assert entry.format_line() == '(c++)(arch=amd64)"foo::bar()@Base" 1.0'
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +427,13 @@ class TestGenerateSymbolsFile:
         sf = generate_symbols_file(meta, version="1.0")
         assert sf.package == "libfoo2"
 
+    def test_soname_to_package_no_so(self):
+        meta = _make_elf_meta(soname="libfoo", symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.package == "libfoo"
+
     def test_custom_package_name(self):
         meta = _make_elf_meta(symbols=[
             _make_symbol("foo_init"),
@@ -309,6 +447,18 @@ class TestGenerateSymbolsFile:
         ])
         sf = generate_symbols_file(meta, version="1.0")
         assert len(sf.symbols) == 1
+
+    def test_empty_symbols_list(self):
+        meta = _make_elf_meta(symbols=[])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert len(sf.symbols) == 0
+        text = sf.format()
+        assert text.startswith("libfoo.so.1 libfoo1")
+
+    def test_unknown_soname_fallback(self):
+        meta = _make_elf_meta(soname="", symbols=[_make_symbol("foo")])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.library == "UNKNOWN"
 
 
 # ---------------------------------------------------------------------------
@@ -331,13 +481,32 @@ class TestRoundtrip:
         assert len(sf2.symbols) == len(sf.symbols)
 
     def test_generate_validate_same_binary_pass(self):
-        """Generate symbols from a binary, then validate against the same binary → PASS."""
+        """Generate symbols from a binary, then validate against the same binary -> PASS."""
         meta = _make_elf_meta(symbols=[
             _make_symbol("foo_init"),
             _make_symbol("foo_process"),
         ])
         sf = generate_symbols_file(meta, version="1.0", use_cpp=False)
         result = validate_symbols(meta, sf)
+        assert result.passed
+        assert len(result.missing) == 0
+        assert len(result.new_symbols) == 0
+
+    def test_generate_parse_validate_roundtrip_cpp(self):
+        """Round-trip with C++ symbols: generate -> format -> parse -> validate -> PASS."""
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("_ZN3foo3barEv"),
+            _make_symbol("_ZN3foo3bazEi"),
+        ])
+        with patch("abicheck.debian_symbols.demangle") as mock_demangle:
+            mock_demangle.side_effect = lambda s: {
+                "_ZN3foo3barEv": "foo::bar()",
+                "_ZN3foo3bazEi": "foo::baz(int)",
+            }.get(s)
+            sf = generate_symbols_file(meta, version="1.0", use_cpp=True)
+            text = sf.format()
+            sf2 = parse_symbols_file(text)
+            result = validate_symbols(meta, sf2)
         assert result.passed
         assert len(result.missing) == 0
         assert len(result.new_symbols) == 0
@@ -353,12 +522,10 @@ class TestValidation:
             _make_symbol("foo_init"),
         ])
         sf = DebianSymbolsFile(
-            library="libfoo.so.1",
-            package="libfoo1",
-            min_version="#MINVER#",
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
             symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-                DebianSymbolEntry(name="foo_legacy", version_node="Base", min_version="1.0"),
+                _entry("foo_init"),
+                _entry("foo_legacy"),
             ],
         )
         result = validate_symbols(meta, sf)
@@ -372,12 +539,8 @@ class TestValidation:
             _make_symbol("foo_new_thing"),
         ])
         sf = DebianSymbolsFile(
-            library="libfoo.so.1",
-            package="libfoo1",
-            min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-            ],
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[_entry("foo_init")],
         )
         result = validate_symbols(meta, sf)
         assert result.passed  # new symbols don't cause failure
@@ -389,17 +552,8 @@ class TestValidation:
             _make_symbol("_ZN3foo3barEv"),
         ])
         sf = DebianSymbolsFile(
-            library="libfoo.so.1",
-            package="libfoo1",
-            min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(
-                    name="foo::bar()",
-                    version_node="Base",
-                    min_version="1.0",
-                    tags=["c++"],
-                ),
-            ],
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[_cpp_entry("foo::bar()")],
         )
         with patch("abicheck.debian_symbols.demangle", return_value="foo::bar()"):
             result = validate_symbols(meta, sf)
@@ -411,12 +565,8 @@ class TestValidation:
             _make_symbol("foo_init", version="LIBFOO_1.0"),
         ])
         sf = DebianSymbolsFile(
-            library="libfoo.so.1",
-            package="libfoo1",
-            min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="LIBFOO_1.0", min_version="1.0"),
-            ],
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[_entry("foo_init", version_node="LIBFOO_1.0")],
         )
         result = validate_symbols(meta, sf)
         assert result.passed
@@ -426,19 +576,95 @@ class TestValidation:
             _make_symbol("foo_init", version="LIBFOO_2.0"),
         ])
         sf = DebianSymbolsFile(
-            library="libfoo.so.1",
-            package="libfoo1",
-            min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="LIBFOO_1.0", min_version="1.0"),
-            ],
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[_entry("foo_init", version_node="LIBFOO_1.0")],
         )
         result = validate_symbols(meta, sf)
         assert not result.passed
         assert len(result.missing) == 1
 
+    def test_optional_symbol_missing_does_not_fail(self):
+        """Symbols tagged (optional) should not cause validation failure."""
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                _entry("foo_init"),
+                DebianSymbolEntry(
+                    name="foo_optional",
+                    version_node="Base",
+                    min_version="1.0",
+                    tag_groups=[["optional"]],
+                ),
+            ],
+        )
+        result = validate_symbols(meta, sf)
+        assert result.passed
+        assert len(result.missing) == 0
+
+    def test_optional_symbol_present_not_reported_as_new(self):
+        """An (optional) symbol that IS present should not appear in new_symbols."""
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+            _make_symbol("foo_optional"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                _entry("foo_init"),
+                DebianSymbolEntry(
+                    name="foo_optional",
+                    version_node="Base",
+                    min_version="1.0",
+                    tag_groups=[["optional"]],
+                ),
+            ],
+        )
+        result = validate_symbols(meta, sf)
+        assert result.passed
+        assert len(result.new_symbols) == 0
+
+    def test_cpp_optional_missing_does_not_fail(self):
+        """(c++|optional) symbol missing from binary should not cause failure."""
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                _entry("foo_init"),
+                DebianSymbolEntry(
+                    name="foo::legacy()",
+                    version_node="Base",
+                    min_version="1.0",
+                    tag_groups=[["c++", "optional"]],
+                ),
+            ],
+        )
+        with patch("abicheck.debian_symbols.demangle", return_value=None):
+            result = validate_symbols(meta, sf)
+        assert result.passed
+
+    def test_multiple_mangled_same_demangled(self):
+        """Multiple mangled names demangling to the same string should all match."""
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("_ZN3foo3barEv"),        # foo::bar()
+            _make_symbol("_ZN3foo3barB5cxx11Ev"),  # foo::bar() [abi:cxx11]
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[_cpp_entry("foo::bar()")],
+        )
+        with patch("abicheck.debian_symbols.demangle", return_value="foo::bar()"):
+            result = validate_symbols(meta, sf)
+        assert result.passed
+        # One of the two mangled names is unmatched -> appears as new
+        assert len(result.new_symbols) == 1
+
     def test_validation_report_pass(self):
-        result = ValidationResult(library="libfoo.so.1", passed=True)
+        result = ValidationResult(library="libfoo.so.1")
         report = format_validation_report(result)
         assert "PASS" in report
         assert "MISSING" in report
@@ -446,24 +672,36 @@ class TestValidation:
     def test_validation_report_fail(self):
         result = ValidationResult(
             library="libfoo.so.1",
-            missing=[
-                DebianSymbolEntry(name="foo_legacy", version_node="Base", min_version="1.0"),
-            ],
-            passed=False,
+            missing=[_entry("foo_legacy")],
         )
         report = format_validation_report(result)
         assert "FAIL" in report
         assert "1 missing symbol" in report
 
+    def test_validation_report_fail_plural(self):
+        result = ValidationResult(
+            library="libfoo.so.1",
+            missing=[_entry("foo_a"), _entry("foo_b"), _entry("foo_c")],
+        )
+        report = format_validation_report(result)
+        assert "FAIL" in report
+        assert "3 missing symbols" in report
+
     def test_validation_report_with_new(self):
         result = ValidationResult(
             library="libfoo.so.1",
             new_symbols=["foo_new@Base"],
-            passed=True,
         )
         report = format_validation_report(result)
         assert "PASS" in report
         assert "1 new symbol" in report
+
+    def test_validation_result_passed_is_computed(self):
+        """passed is a @property, not a stored field."""
+        r = ValidationResult(library="test")
+        assert r.passed
+        r.missing.append(_entry("gone"))
+        assert not r.passed
 
 
 # ---------------------------------------------------------------------------
@@ -474,15 +712,11 @@ class TestDiff:
     def test_no_changes(self):
         old = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-            ],
+            symbols=[_entry("foo_init")],
         )
         new = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-            ],
+            symbols=[_entry("foo_init")],
         )
         diff = diff_symbols_files(old, new)
         assert len(diff.added) == 0
@@ -492,16 +726,11 @@ class TestDiff:
     def test_added_symbol(self):
         old = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-            ],
+            symbols=[_entry("foo_init")],
         )
         new = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-                DebianSymbolEntry(name="foo_new", version_node="Base", min_version="1.1"),
-            ],
+            symbols=[_entry("foo_init"), _entry("foo_new", min_version="1.1")],
         )
         diff = diff_symbols_files(old, new)
         assert len(diff.added) == 1
@@ -510,16 +739,11 @@ class TestDiff:
     def test_removed_symbol(self):
         old = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-                DebianSymbolEntry(name="foo_legacy", version_node="Base", min_version="1.0"),
-            ],
+            symbols=[_entry("foo_init"), _entry("foo_legacy")],
         )
         new = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-            ],
+            symbols=[_entry("foo_init")],
         )
         diff = diff_symbols_files(old, new)
         assert len(diff.removed) == 1
@@ -528,15 +752,11 @@ class TestDiff:
     def test_version_changed(self):
         old = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
-            ],
+            symbols=[_entry("foo_init")],
         )
         new = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.1"),
-            ],
+            symbols=[_entry("foo_init", min_version="1.1")],
         )
         diff = diff_symbols_files(old, new)
         assert len(diff.version_changed) == 1
@@ -547,18 +767,13 @@ class TestDiff:
     def test_cpp_diff(self):
         old = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
-            symbols=[
-                DebianSymbolEntry(name="foo::bar()", version_node="Base",
-                                  min_version="1.0", tags=["c++"]),
-            ],
+            symbols=[_cpp_entry("foo::bar()")],
         )
         new = DebianSymbolsFile(
             library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
             symbols=[
-                DebianSymbolEntry(name="foo::bar()", version_node="Base",
-                                  min_version="1.0", tags=["c++"]),
-                DebianSymbolEntry(name="foo::baz(int)", version_node="Base",
-                                  min_version="1.1", tags=["c++"]),
+                _cpp_entry("foo::bar()"),
+                _cpp_entry("foo::baz(int)", min_version="1.1"),
             ],
         )
         diff = diff_symbols_files(old, new)
@@ -566,10 +781,30 @@ class TestDiff:
         assert diff.added[0].name == "foo::baz(int)"
         assert diff.added[0].is_cpp
 
+    def test_same_name_different_version_nodes(self):
+        """Same symbol name under different version nodes should be tracked separately."""
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                _entry("foo_init", version_node="LIBFOO_1.0"),
+                _entry("foo_init", version_node="LIBFOO_2.0"),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                _entry("foo_init", version_node="LIBFOO_1.0"),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.removed) == 1
+        assert diff.removed[0].version_node == "LIBFOO_2.0"
+        assert len(diff.added) == 0
+
     def test_diff_report_format(self):
         diff = SymbolsDiff(
-            added=[DebianSymbolEntry(name="foo_new", version_node="Base", min_version="1.1")],
-            removed=[DebianSymbolEntry(name="foo_old", version_node="Base", min_version="1.0")],
+            added=[_entry("foo_new", min_version="1.1")],
+            removed=[_entry("foo_old")],
         )
         report = format_diff_report(diff, "old.symbols", "new.symbols")
         assert "old.symbols" in report
@@ -577,6 +812,20 @@ class TestDiff:
         assert "+ foo_new@Base 1.1" in report
         assert "- foo_old@Base 1.0" in report
         assert "Total changes: 2" in report
+
+    def test_diff_report_version_changed(self):
+        diff = SymbolsDiff(
+            version_changed=[(_entry("foo_init"), _entry("foo_init", min_version="2.0"))],
+        )
+        report = format_diff_report(diff)
+        assert "VERSION CHANGED" in report
+        assert "foo_init: 1.0 -> 2.0" in report
+        assert "Total changes: 1" in report
+
+    def test_diff_report_empty(self):
+        diff = SymbolsDiff()
+        report = format_diff_report(diff)
+        assert "Total changes: 0" in report
 
 
 # ---------------------------------------------------------------------------
@@ -608,6 +857,16 @@ class TestCLI:
         assert "--package" in result.output
         assert "--version" in result.output
 
+    def test_validate_takes_positional_symbols_path(self):
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["debian-symbols", "validate", "--help"])
+        assert result.exit_code == 0
+        assert "SYMBOLS_PATH" in result.output
+
     def test_diff_with_files(self, tmp_path: Path):
         from click.testing import CliRunner
 
@@ -635,6 +894,49 @@ class TestCLI:
         assert "ADDED" in result.output
         assert "foo_new" in result.output
 
+    def test_diff_identical_files(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        content = "libfoo.so.1 libfoo1 #MINVER#\n foo@Base 1.0\n"
+        (tmp_path / "a.sym").write_text(content)
+        (tmp_path / "b.sym").write_text(content)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "debian-symbols", "diff",
+            str(tmp_path / "a.sym"), str(tmp_path / "b.sym"),
+        ])
+        assert result.exit_code == 0
+        assert "Total changes: 0" in result.output
+
+    def test_validate_exit_code_2_on_mismatch(self, tmp_path: Path):
+        """validate should exit 2 when symbols are missing from binary."""
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        # Create a symbols file that references a symbol not in the binary
+        sym_content = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " missing_sym@Base 1.0\n"
+        )
+        sym_path = tmp_path / "test.symbols"
+        sym_path.write_text(sym_content)
+
+        # We need an actual ELF binary; mock parse_elf_metadata instead
+        mock_meta = _make_elf_meta(symbols=[_make_symbol("other_sym")])
+        with patch("abicheck.debian_symbols.parse_elf_metadata", return_value=mock_meta):
+            runner = CliRunner()
+            so_path = tmp_path / "libfoo.so"
+            so_path.write_bytes(b"\x7fELF")  # dummy file
+            result = runner.invoke(main, [
+                "debian-symbols", "validate", str(so_path), str(sym_path),
+            ])
+        assert result.exit_code == 2
+        assert "FAIL" in result.output
+
 
 # ---------------------------------------------------------------------------
 # Load from file
@@ -653,3 +955,16 @@ class TestLoadSymbolsFile:
         sf = load_symbols_file(path)
         assert sf.library == "libfoo.so.1"
         assert len(sf.symbols) == 2
+
+    def test_load_nonexistent_file(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_symbols_file(tmp_path / "nope.symbols")
+
+    def test_load_rejects_non_regular_file(self, tmp_path: Path):
+        """load_symbols_file should reject FIFOs / devices."""
+        import os
+
+        fifo = tmp_path / "fifo.symbols"
+        os.mkfifo(str(fifo))
+        with pytest.raises(ValueError, match="Not a regular file"):
+            load_symbols_file(fifo)

--- a/tests/test_debian_symbols.py
+++ b/tests/test_debian_symbols.py
@@ -1,0 +1,655 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Debian symbols file adapter (abicheck.debian_symbols)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from abicheck.debian_symbols import (
+    DebianSymbolEntry,
+    DebianSymbolsFile,
+    SymbolsDiff,
+    ValidationResult,
+    diff_symbols_files,
+    format_diff_report,
+    format_validation_report,
+    generate_symbols_file,
+    load_symbols_file,
+    parse_symbols_file,
+    validate_symbols,
+)
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_elf_meta(
+    soname: str = "libfoo.so.1",
+    symbols: list[ElfSymbol] | None = None,
+) -> ElfMetadata:
+    """Create an ElfMetadata with the given symbols."""
+    return ElfMetadata(
+        soname=soname,
+        symbols=symbols or [],
+    )
+
+
+def _make_symbol(
+    name: str,
+    sym_type: SymbolType = SymbolType.FUNC,
+    version: str = "",
+    binding: SymbolBinding = SymbolBinding.GLOBAL,
+) -> ElfSymbol:
+    return ElfSymbol(
+        name=name,
+        sym_type=sym_type,
+        version=version,
+        binding=binding,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parsing tests
+# ---------------------------------------------------------------------------
+
+class TestParseSymbolsFile:
+    def test_basic(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " _ZN3foo3barEv@Base 1.0\n"
+            " _ZN3foo3bazEi@Base 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        assert sf.library == "libfoo.so.1"
+        assert sf.package == "libfoo1"
+        assert sf.min_version == "#MINVER#"
+        assert len(sf.symbols) == 2
+        assert sf.symbols[0].name == "_ZN3foo3barEv"
+        assert sf.symbols[0].version_node == "Base"
+        assert sf.symbols[0].min_version == "1.0"
+
+    def test_cpp_symbol(self):
+        text = (
+            'libfoo.so.1 libfoo1 #MINVER#\n'
+            ' (c++)"foo::bar()@Base" 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 1
+        entry = sf.symbols[0]
+        assert entry.is_cpp
+        assert entry.name == "foo::bar()"
+        assert entry.version_node == "Base"
+        assert entry.min_version == "1.0"
+
+    def test_multiple_tags(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            ' (c++|optional)"foo::bar()@Base" 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        assert "c++" in entry.tags
+        assert "optional" in entry.tags
+        assert entry.is_cpp
+
+    def test_arch_tag(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " (arch=amd64)_ZN3foo3barEv@Base 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        assert "arch=amd64" in entry.tags
+        assert not entry.is_cpp
+
+    def test_versioned_symbol(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " _ZN3foo3barEv@LIBFOO_1.0 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        assert entry.name == "_ZN3foo3barEv"
+        assert entry.version_node == "LIBFOO_1.0"
+
+    def test_empty_file_raises(self):
+        with pytest.raises(ValueError, match="Empty"):
+            parse_symbols_file("")
+
+    def test_malformed_header_raises(self):
+        with pytest.raises(ValueError, match="Malformed header"):
+            parse_symbols_file("libfoo.so.1 libfoo1\n")
+
+    def test_blank_lines_skipped(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            "\n"
+            " _ZN3foo3barEv@Base 1.0\n"
+            "\n"
+        )
+        sf = parse_symbols_file(text)
+        assert len(sf.symbols) == 1
+
+    def test_cpp_template_symbol(self):
+        text = (
+            'libfoo.so.1 libfoo1 #MINVER#\n'
+            ' (c++)"std::vector<int>::push_back(int const&)@Base" 1.0\n'
+        )
+        sf = parse_symbols_file(text)
+        entry = sf.symbols[0]
+        assert entry.name == "std::vector<int>::push_back(int const&)"
+        assert entry.version_node == "Base"
+
+
+# ---------------------------------------------------------------------------
+# Formatting tests
+# ---------------------------------------------------------------------------
+
+class TestFormatSymbolsFile:
+    def test_roundtrip_basic(self):
+        text = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " _ZN3foo3barEv@Base 1.0\n"
+            " _ZN3foo3bazEi@Base 1.0\n"
+        )
+        sf = parse_symbols_file(text)
+        output = sf.format()
+        sf2 = parse_symbols_file(output)
+        assert sf2.library == sf.library
+        assert sf2.package == sf.package
+        assert len(sf2.symbols) == len(sf.symbols)
+
+    def test_cpp_format_line(self):
+        entry = DebianSymbolEntry(
+            name="foo::bar()",
+            version_node="Base",
+            min_version="1.0",
+            tags=["c++"],
+        )
+        assert entry.format_line() == '(c++)"foo::bar()@Base" 1.0'
+
+    def test_mangled_format_line(self):
+        entry = DebianSymbolEntry(
+            name="_ZN3foo3barEv",
+            version_node="Base",
+            min_version="1.0",
+        )
+        assert entry.format_line() == "_ZN3foo3barEv@Base 1.0"
+
+    def test_tagged_format_line(self):
+        entry = DebianSymbolEntry(
+            name="_ZN3foo3barEv",
+            version_node="Base",
+            min_version="1.0",
+            tags=["arch=amd64"],
+        )
+        assert entry.format_line() == "(arch=amd64)_ZN3foo3barEv@Base 1.0"
+
+
+# ---------------------------------------------------------------------------
+# Generation tests
+# ---------------------------------------------------------------------------
+
+class TestGenerateSymbolsFile:
+    def test_basic_c_symbols(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+            _make_symbol("foo_process"),
+            _make_symbol("foo_cleanup"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.library == "libfoo.so.1"
+        assert sf.package == "libfoo1"
+        assert len(sf.symbols) == 3
+        names = {s.name for s in sf.symbols}
+        assert names == {"foo_init", "foo_process", "foo_cleanup"}
+
+    def test_cpp_symbols_demangled(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("_ZN3foo3barEv"),
+        ])
+        with patch("abicheck.debian_symbols.demangle", return_value="foo::bar()"):
+            sf = generate_symbols_file(meta, version="1.0")
+        assert len(sf.symbols) == 1
+        entry = sf.symbols[0]
+        assert entry.is_cpp
+        assert entry.name == "foo::bar()"
+
+    def test_no_cpp_mode(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("_ZN3foo3barEv"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0", use_cpp=False)
+        assert len(sf.symbols) == 1
+        entry = sf.symbols[0]
+        assert not entry.is_cpp
+        assert entry.name == "_ZN3foo3barEv"
+
+    def test_versioned_symbols(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init", version="LIBFOO_1.0"),
+            _make_symbol("foo_new", version="LIBFOO_2.0"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        ver_nodes = {s.name: s.version_node for s in sf.symbols}
+        assert ver_nodes["foo_init"] == "LIBFOO_1.0"
+        assert ver_nodes["foo_new"] == "LIBFOO_2.0"
+
+    def test_unversioned_symbols_use_base(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.symbols[0].version_node == "Base"
+
+    def test_skips_non_abi_types(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init", sym_type=SymbolType.FUNC),
+            _make_symbol("_notype_thing", sym_type=SymbolType.NOTYPE),
+            _make_symbol("_tls_thing", sym_type=SymbolType.TLS),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert len(sf.symbols) == 1
+        assert sf.symbols[0].name == "foo_init"
+
+    def test_includes_object_symbols(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_global_var", sym_type=SymbolType.OBJECT),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert len(sf.symbols) == 1
+
+    def test_soname_to_package_derivation(self):
+        meta = _make_elf_meta(soname="libbar.so.2", symbols=[
+            _make_symbol("bar_init"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.package == "libbar2"
+
+    def test_soname_to_package_no_version(self):
+        meta = _make_elf_meta(soname="libfoo.so", symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.package == "libfoo"
+
+    def test_soname_to_package_multi_version(self):
+        meta = _make_elf_meta(soname="libfoo.so.2.3", symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert sf.package == "libfoo2"
+
+    def test_custom_package_name(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = generate_symbols_file(meta, package="my-libfoo", version="1.0")
+        assert sf.package == "my-libfoo"
+
+    def test_ifunc_included(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("memcpy", sym_type=SymbolType.IFUNC),
+        ])
+        sf = generate_symbols_file(meta, version="1.0")
+        assert len(sf.symbols) == 1
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip: generate → parse → validate
+# ---------------------------------------------------------------------------
+
+class TestRoundtrip:
+    def test_generate_parse_roundtrip(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+            _make_symbol("foo_process"),
+            _make_symbol("foo_data", sym_type=SymbolType.OBJECT),
+        ])
+        sf = generate_symbols_file(meta, version="1.0", use_cpp=False)
+        text = sf.format()
+        sf2 = parse_symbols_file(text)
+
+        assert sf2.library == sf.library
+        assert sf2.package == sf.package
+        assert len(sf2.symbols) == len(sf.symbols)
+
+    def test_generate_validate_same_binary_pass(self):
+        """Generate symbols from a binary, then validate against the same binary → PASS."""
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+            _make_symbol("foo_process"),
+        ])
+        sf = generate_symbols_file(meta, version="1.0", use_cpp=False)
+        result = validate_symbols(meta, sf)
+        assert result.passed
+        assert len(result.missing) == 0
+        assert len(result.new_symbols) == 0
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_missing_symbol(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1",
+            package="libfoo1",
+            min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+                DebianSymbolEntry(name="foo_legacy", version_node="Base", min_version="1.0"),
+            ],
+        )
+        result = validate_symbols(meta, sf)
+        assert not result.passed
+        assert len(result.missing) == 1
+        assert result.missing[0].name == "foo_legacy"
+
+    def test_new_symbol_detected(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init"),
+            _make_symbol("foo_new_thing"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1",
+            package="libfoo1",
+            min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+            ],
+        )
+        result = validate_symbols(meta, sf)
+        assert result.passed  # new symbols don't cause failure
+        assert len(result.new_symbols) == 1
+        assert "foo_new_thing@Base" in result.new_symbols
+
+    def test_cpp_symbol_validation(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("_ZN3foo3barEv"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1",
+            package="libfoo1",
+            min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(
+                    name="foo::bar()",
+                    version_node="Base",
+                    min_version="1.0",
+                    tags=["c++"],
+                ),
+            ],
+        )
+        with patch("abicheck.debian_symbols.demangle", return_value="foo::bar()"):
+            result = validate_symbols(meta, sf)
+        assert result.passed
+        assert len(result.missing) == 0
+
+    def test_versioned_symbol_validation(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init", version="LIBFOO_1.0"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1",
+            package="libfoo1",
+            min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="LIBFOO_1.0", min_version="1.0"),
+            ],
+        )
+        result = validate_symbols(meta, sf)
+        assert result.passed
+
+    def test_versioned_symbol_mismatch(self):
+        meta = _make_elf_meta(symbols=[
+            _make_symbol("foo_init", version="LIBFOO_2.0"),
+        ])
+        sf = DebianSymbolsFile(
+            library="libfoo.so.1",
+            package="libfoo1",
+            min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="LIBFOO_1.0", min_version="1.0"),
+            ],
+        )
+        result = validate_symbols(meta, sf)
+        assert not result.passed
+        assert len(result.missing) == 1
+
+    def test_validation_report_pass(self):
+        result = ValidationResult(library="libfoo.so.1", passed=True)
+        report = format_validation_report(result)
+        assert "PASS" in report
+        assert "MISSING" in report
+
+    def test_validation_report_fail(self):
+        result = ValidationResult(
+            library="libfoo.so.1",
+            missing=[
+                DebianSymbolEntry(name="foo_legacy", version_node="Base", min_version="1.0"),
+            ],
+            passed=False,
+        )
+        report = format_validation_report(result)
+        assert "FAIL" in report
+        assert "1 missing symbol" in report
+
+    def test_validation_report_with_new(self):
+        result = ValidationResult(
+            library="libfoo.so.1",
+            new_symbols=["foo_new@Base"],
+            passed=True,
+        )
+        report = format_validation_report(result)
+        assert "PASS" in report
+        assert "1 new symbol" in report
+
+
+# ---------------------------------------------------------------------------
+# Diff tests
+# ---------------------------------------------------------------------------
+
+class TestDiff:
+    def test_no_changes(self):
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.added) == 0
+        assert len(diff.removed) == 0
+        assert len(diff.version_changed) == 0
+
+    def test_added_symbol(self):
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+                DebianSymbolEntry(name="foo_new", version_node="Base", min_version="1.1"),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.added) == 1
+        assert diff.added[0].name == "foo_new"
+
+    def test_removed_symbol(self):
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+                DebianSymbolEntry(name="foo_legacy", version_node="Base", min_version="1.0"),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.removed) == 1
+        assert diff.removed[0].name == "foo_legacy"
+
+    def test_version_changed(self):
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.0"),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo_init", version_node="Base", min_version="1.1"),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.version_changed) == 1
+        old_entry, new_entry = diff.version_changed[0]
+        assert old_entry.min_version == "1.0"
+        assert new_entry.min_version == "1.1"
+
+    def test_cpp_diff(self):
+        old = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo::bar()", version_node="Base",
+                                  min_version="1.0", tags=["c++"]),
+            ],
+        )
+        new = DebianSymbolsFile(
+            library="libfoo.so.1", package="libfoo1", min_version="#MINVER#",
+            symbols=[
+                DebianSymbolEntry(name="foo::bar()", version_node="Base",
+                                  min_version="1.0", tags=["c++"]),
+                DebianSymbolEntry(name="foo::baz(int)", version_node="Base",
+                                  min_version="1.1", tags=["c++"]),
+            ],
+        )
+        diff = diff_symbols_files(old, new)
+        assert len(diff.added) == 1
+        assert diff.added[0].name == "foo::baz(int)"
+        assert diff.added[0].is_cpp
+
+    def test_diff_report_format(self):
+        diff = SymbolsDiff(
+            added=[DebianSymbolEntry(name="foo_new", version_node="Base", min_version="1.1")],
+            removed=[DebianSymbolEntry(name="foo_old", version_node="Base", min_version="1.0")],
+        )
+        report = format_diff_report(diff, "old.symbols", "new.symbols")
+        assert "old.symbols" in report
+        assert "new.symbols" in report
+        assert "+ foo_new@Base 1.1" in report
+        assert "- foo_old@Base 1.0" in report
+        assert "Total changes: 2" in report
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_debian_symbols_group_registered(self):
+        """The debian-symbols command group should be registered on the main CLI."""
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["debian-symbols", "--help"])
+        assert result.exit_code == 0
+        assert "generate" in result.output
+        assert "validate" in result.output
+        assert "diff" in result.output
+
+    def test_generate_help(self):
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["debian-symbols", "generate", "--help"])
+        assert result.exit_code == 0
+        assert "--package" in result.output
+        assert "--version" in result.output
+
+    def test_diff_with_files(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old_content = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " foo_init@Base 1.0\n"
+        )
+        new_content = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " foo_init@Base 1.0\n"
+            " foo_new@Base 1.1\n"
+        )
+        old_path = tmp_path / "old.symbols"
+        new_path = tmp_path / "new.symbols"
+        old_path.write_text(old_content)
+        new_path.write_text(new_content)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "debian-symbols", "diff", str(old_path), str(new_path),
+        ])
+        assert result.exit_code == 0
+        assert "ADDED" in result.output
+        assert "foo_new" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Load from file
+# ---------------------------------------------------------------------------
+
+class TestLoadSymbolsFile:
+    def test_load_from_file(self, tmp_path: Path):
+        content = (
+            "libfoo.so.1 libfoo1 #MINVER#\n"
+            " foo_init@Base 1.0\n"
+            " foo_process@Base 1.0\n"
+        )
+        path = tmp_path / "libfoo1.symbols"
+        path.write_text(content)
+
+        sf = load_symbols_file(path)
+        assert sf.library == "libfoo.so.1"
+        assert len(sf.symbols) == 2


### PR DESCRIPTION
## Summary

Adds comprehensive support for generating, parsing, validating, and diffing Debian symbols files (`dpkg-gensymbols` format) to integrate abicheck with Debian/Ubuntu packaging workflows.

## Motivation

Debian/Ubuntu packages use symbols files for fine-grained shared library dependency tracking via `dpkg-gensymbols` and `dpkg-shlibdeps`. This adapter enables abicheck to:
- Generate symbols files from ELF binaries with C++ demangling support
- Validate symbols files against binaries to detect ABI breaks
- Diff symbols files to track ABI changes across versions
- Integrate seamlessly into Debian packaging CI/CD pipelines

## Changes

### Core Implementation (`abicheck/debian_symbols.py`)
- **Data model**: `DebianSymbolEntry`, `DebianSymbolsFile`, `ValidationResult`, `SymbolsDiff` classes
- **Parsing**: `parse_symbols_file()` and `load_symbols_file()` with full support for:
  - Tag syntax: `(c++)`, `(optional)`, `(arch=...)`, pipe-separated `(c++|optional)`
  - C++ quoted symbols with demangling
  - ELF symbol versioning (`@Base`, `@VERSION_NODE`)
  - Robust error handling with logging
- **Generation**: `generate_symbols_file()` and `generate_from_binary()` with:
  - Automatic C++ demangling (optional via `use_cpp` flag)
  - SONAME-to-package name derivation
  - ELF symbol type filtering (FUNC, OBJECT, IFUNC)
- **Validation**: `validate_symbols()` with:
  - Detection of missing and new symbols
  - `(optional)` tag semantics (missing optional symbols don't fail validation)
  - C++ symbol matching via demangling
  - Detailed `ValidationResult` reporting
- **Diffing**: `diff_symbols_files()` to compare two symbols files
- **Formatting**: `format_validation_report()` and `format_diff_report()` for human-readable output

### CLI Integration (`abicheck/cli.py`)
- **`abicheck debian-symbols generate`** — generate symbols file from binary with options for package name, version, and C++ demangling
- **`abicheck debian-symbols validate`** — validate symbols file against binary (exit 0 = match, exit 2 = mismatch)
- **`abicheck debian-symbols diff`** — compare two symbols files

### Documentation
- User guide with examples for all three subcommands
- Exit code reference for CI integration patterns
- README section highlighting Debian symbols integration
- CHANGELOG entry documenting the new feature

### Tests (`tests/test_debian_symbols.py`)
- 970 lines of comprehensive test coverage including:
  - Parsing: basic symbols, C++ quoted form, tags, versioning, edge cases
  - Formatting: roundtrip preservation, tag grouping
  - Generation: symbol filtering, demangling, package name derivation
  - Validation: missing/new symbols, optional tags, C++ matching, version mismatches
  - Diffing: added/removed/version-changed symbols
  - Reporting: formatted output for validation and diff results
  - Error handling: malformed input, unterminated quotes, missing version markers

## Checklist

- [x] Tests added — 970 lines of comprehensive unit tests covering all major code paths
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated — user guide, exit codes, README, and index
- [x] Pre-commit checks pass (no new mypy/ruff errors)
- [x] Follows Debian symbols file format specification (dpkg-gensymbols(1))

https://claude.ai/code/session_01AfUA8uiXkKPWHcaN5V5zj4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `abicheck debian-symbols` CLI: generate, validate, and diff Debian dpkg-style symbols files; C++ demangling, version-node handling, optional/arch tags, and SONAME→package derivation.
  * Exposed a Python API to parse, generate, validate, and diff symbols files.

* **Documentation**
  * Added user-guide and exit-code docs for the new commands and tag syntax; updated navigation.

* **Tests**
  * End-to-end test suite covering parsing, generation, validation, diffing, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->