### PR TITLE
Add cases 63-68: bitfield, calling convention, symbol version, linkage, TLS, virtual method

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -114,7 +114,7 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [61](case61_var_added/README.md) | Global Variable Added | Addition | COMPATIBLE 🟢 |
 | [62](case62_type_field_added_compatible/README.md) | Type Field Added (Opaque Struct) | Addition | COMPATIBLE 🟢 |
 | [63](case63_bitfield_changed/README.md) | Bitfield Width Changed | Breaking | BREAKING 🔴 |
-| [64](case64_calling_convention_changed/README.md) | Calling Convention Changed (regcall) | Breaking | BREAKING 🔴 |
+| [64](case64_calling_convention_changed/README.md) | Calling Convention Changed (ms_abi) | Breaking | BREAKING 🔴 |
 | [65](case65_symbol_version_removed/README.md) | Symbol Version Removed (ELF) | Breaking | BREAKING 🔴 |
 | [66](case66_language_linkage_changed/README.md) | Language Linkage Changed (extern "C") | Breaking | BREAKING 🔴 |
 | [67](case67_tls_var_size_changed/README.md) | TLS Variable Size Changed | Breaking | BREAKING 🔴 |

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,11 +33,11 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 > Authoritative expected verdicts for benchmarking are in [`ground_truth.json`](ground_truth.json).
 > If a per-case README and benchmark expectation differ, treat [`ground_truth.json`](ground_truth.json) as source of truth.
 
-**63 published cases** (01–62 + 26b):
+**69 published cases** (01–68 + 26b):
 
 | Verdict | Count | checker_policy.py set | Icon |
 |---------|-------|-----------------------|------|
-| BREAKING | 42 | `BREAKING_KINDS` | 🔴 |
+| BREAKING | 48 | `BREAKING_KINDS` | 🔴 |
 | API_BREAK | 2 | `API_BREAK_KINDS` | 🟠 |
 | COMPATIBLE_WITH_RISK | 1 | `RISK_KINDS` | 🟡 |
 | COMPATIBLE (addition) | 7 | `ADDITION_KINDS` | 🟢 |
@@ -113,6 +113,12 @@ embedded firmware all depend on ABI stability for safe rolling upgrades.
 | [60](case60_base_class_position_changed/README.md) | Base Class Position Changed (MI reorder) | Breaking | BREAKING 🔴 |
 | [61](case61_var_added/README.md) | Global Variable Added | Addition | COMPATIBLE 🟢 |
 | [62](case62_type_field_added_compatible/README.md) | Type Field Added (Opaque Struct) | Addition | COMPATIBLE 🟢 |
+| [63](case63_bitfield_changed/README.md) | Bitfield Width Changed | Breaking | BREAKING 🔴 |
+| [64](case64_calling_convention_changed/README.md) | Calling Convention Changed (regcall) | Breaking | BREAKING 🔴 |
+| [65](case65_symbol_version_removed/README.md) | Symbol Version Removed (ELF) | Breaking | BREAKING 🔴 |
+| [66](case66_language_linkage_changed/README.md) | Language Linkage Changed (extern "C") | Breaking | BREAKING 🔴 |
+| [67](case67_tls_var_size_changed/README.md) | TLS Variable Size Changed | Breaking | BREAKING 🔴 |
+| [68](case68_virtual_method_added/README.md) | Virtual Method Added (non-virtual → virtual) | Breaking | BREAKING 🔴 |
 
 ---
 

--- a/examples/case63_bitfield_changed/CMakeLists.txt
+++ b/examples/case63_bitfield_changed/CMakeLists.txt
@@ -3,5 +3,6 @@ abicheck_add_case(case63_bitfield_changed
     V2_SOURCES v2.c
     V1_HEADERS v1.h
     V2_HEADERS v2.h
+    APP_SOURCES app.c
     PLATFORMS linux macos windows
 )

--- a/examples/case63_bitfield_changed/CMakeLists.txt
+++ b/examples/case63_bitfield_changed/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case63_bitfield_changed
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.c
-    PLATFORMS linux macos windows
+    PLATFORMS linux
 )

--- a/examples/case63_bitfield_changed/CMakeLists.txt
+++ b/examples/case63_bitfield_changed/CMakeLists.txt
@@ -1,0 +1,7 @@
+abicheck_add_case(case63_bitfield_changed
+    V1_SOURCES v1.c
+    V2_SOURCES v2.c
+    V1_HEADERS v1.h
+    V2_HEADERS v2.h
+    PLATFORMS linux macos windows
+)

--- a/examples/case63_bitfield_changed/README.md
+++ b/examples/case63_bitfield_changed/README.md
@@ -1,0 +1,86 @@
+# Case 63: Bitfield Width Changed
+
+**Category:** Type Layout | **Verdict:** BREAKING
+
+## What breaks
+
+The `mode` bitfield in `RegMap` is widened from 3 bits to 5 bits. This shifts
+every subsequent bitfield (`channel`, `priority`, `reserved`) to different bit
+positions within the same 32-bit word. Any consumer compiled against the v1
+layout reads `priority` from the wrong bits, getting a corrupt value.
+
+## Why this matters
+
+Bitfields are widely used in hardware register maps, network protocol headers,
+and compact flag structs. Unlike regular struct fields where padding can absorb
+small changes, **every bit position after the widened field shifts**. There is
+no alignment padding between bitfields within the same storage unit.
+
+This is especially dangerous because:
+- `sizeof(RegMap)` does **not** change (still 4 bytes) — naive size checks pass
+- The struct looks "compatible" at the symbol level — same functions, same names
+- The corruption is **silent**: wrong values, no crash, no diagnostic
+
+## Code diff
+
+| Field | v1 (bits) | v2 (bits) | Change |
+|-------|-----------|-----------|--------|
+| `enable` | 0 | 0 | unchanged |
+| `mode` | 1-3 (3 bits) | 1-5 (5 bits) | **widened +2 bits** |
+| `channel` | 4-7 | 6-9 | **shifted +2** |
+| `priority` | 8-15 | 10-17 | **shifted +2** |
+| `reserved` | 16-31 (16 bits) | 18-31 (14 bits) | **shrunk -2 bits** |
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile app against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build old library + app
+gcc -shared -fPIC -g v1.c -o libfoo.so
+gcc -g app.c -L. -lfoo -Wl,-rpath,. -o app
+./app
+# → priority = 128 (expected 128)
+
+# Swap in new library (no recompile)
+gcc -shared -fPIC -g v2.c -o libfoo.so
+./app
+# → priority = 32 (expected 128)
+# → CORRUPTION: priority bits shifted due to bitfield width change!
+```
+
+**Why CRITICAL:** The v2 library writes `priority=128` into bits 10-17, but the
+app (compiled against v1) reads bits 8-15 — extracting a completely different
+value. No crash occurs; the data is silently wrong. In a hardware register
+context, this could program the wrong DMA priority, causing system instability.
+
+## How to fix
+
+Never change bitfield widths in a public struct. If more bits are needed:
+
+1. **Use the reserved field**: consume bits from `reserved` without shifting others
+2. **Add a new struct version**: `RegMapV2` with the wider field
+3. **Use an opaque handle**: hide the register layout behind accessor functions
+
+## Real-world example
+
+Linux kernel `iphdr` (IP header) structure uses bitfields for version and IHL.
+Any change to these widths would corrupt every network packet parsed by
+userspace tools like `tcpdump` that embed the struct layout at compile time.
+
+The Windows `BITMAP` info header uses bitfields for color masks — driver
+compatibility across Windows versions depends on these widths being frozen.
+
+## abicheck detection
+
+abicheck detects this as `field_bitfield_changed` (BREAKING) by comparing
+DWARF `DW_AT_bit_size` / `DW_AT_bit_offset` attributes between the two
+versions. Even though `sizeof` doesn't change, the per-field bit layout
+difference is caught.
+
+## References
+
+- [C11 §6.7.2.1 — Structure and union specifiers (bit-fields)](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf)
+- [System V ABI — Bit-field allocation](https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf)

--- a/examples/case63_bitfield_changed/README.md
+++ b/examples/case63_bitfield_changed/README.md
@@ -42,13 +42,17 @@ This is especially dangerous because:
 gcc -shared -fPIC -g v1.c -o libfoo.so
 gcc -g app.c -L. -lfoo -Wl,-rpath,. -o app
 ./app
+# → mode     = 2 (expected 2)
+# → channel  = 5 (expected 5)
 # → priority = 128 (expected 128)
 
 # Swap in new library (no recompile)
 gcc -shared -fPIC -g v2.c -o libfoo.so
 ./app
-# → priority = 32 (expected 128)
-# → CORRUPTION: priority bits shifted due to bitfield width change!
+# → mode     = 2 (expected 2)
+# → channel  = 4 (expected 5)
+# → priority = 1 (expected 128)
+# → CORRUPTION: bitfield layout mismatch
 ```
 
 **Why CRITICAL:** The v2 library writes `priority=128` into bits 10-17, but the

--- a/examples/case63_bitfield_changed/app.c
+++ b/examples/case63_bitfield_changed/app.c
@@ -4,11 +4,12 @@
    The app reads bits 8-15 and gets a different value. */
 #include "v1.h"
 #include <stdio.h>
+#include <string.h>
 
 int main(void) {
     RegMap r;
     /* Zero-initialize to make corruption visible */
-    *(uint32_t *)&r = 0;
+    memset(&r, 0, sizeof(r));
 
     /* v2 library writes fields using v2 bit positions */
     regmap_init(&r);
@@ -22,7 +23,11 @@ int main(void) {
     printf("mode     = %u (expected 2)\n", mode);
     printf("channel  = %u (expected 5)\n", channel);
     printf("priority = %u (expected 128)\n", pri);
-    printf("raw word = 0x%08X\n", *(uint32_t *)&r);
+
+    /* Show the raw word for debugging */
+    uint32_t raw;
+    memcpy(&raw, &r, sizeof(raw));
+    printf("raw word = 0x%08X\n", raw);
 
     if (pri != 128) {
         printf("CORRUPTION: bitfield layout mismatch — app reads v1 bit "

--- a/examples/case63_bitfield_changed/app.c
+++ b/examples/case63_bitfield_changed/app.c
@@ -1,0 +1,23 @@
+/* DEMO: app compiled against v1 layout, but linked to v2 library at runtime.
+   v1 priority is at bits 8-15; v2 priority is at bits 10-17.
+   The app reads the wrong bits, getting a corrupt priority value. */
+#include "v1.h"
+#include <stdio.h>
+
+int main(void) {
+    RegMap r;
+    regmap_init(&r);  /* v2 writes mode=2 into 5-bit field, shifts everything */
+
+    uint32_t pri = regmap_read_priority(&r);
+    printf("priority = %u (expected 128)\n", pri);
+
+    /* Also demonstrate the mode field mismatch */
+    regmap_set_mode(&r, 3);
+    printf("raw word after set_mode(3): 0x%08X\n", *(uint32_t *)&r);
+
+    if (pri != 128) {
+        printf("CORRUPTION: priority bits shifted due to bitfield width change!\n");
+        return 1;
+    }
+    return 0;
+}

--- a/examples/case63_bitfield_changed/app.c
+++ b/examples/case63_bitfield_changed/app.c
@@ -1,22 +1,32 @@
 /* DEMO: app compiled against v1 layout, but linked to v2 library at runtime.
-   v1 priority is at bits 8-15; v2 priority is at bits 10-17.
-   The app reads the wrong bits, getting a corrupt priority value. */
+   The app reads the priority field using v1 bit positions (bits 8-15).
+   v2's regmap_init() writes priority=128 into bits 10-17 (v2 layout).
+   The app reads bits 8-15 and gets a different value. */
 #include "v1.h"
 #include <stdio.h>
 
 int main(void) {
     RegMap r;
-    regmap_init(&r);  /* v2 writes mode=2 into 5-bit field, shifts everything */
+    /* Zero-initialize to make corruption visible */
+    *(uint32_t *)&r = 0;
 
-    uint32_t pri = regmap_read_priority(&r);
+    /* v2 library writes fields using v2 bit positions */
+    regmap_init(&r);
+
+    /* App reads using v1 compiled layout — v1 priority is at bits 8-15,
+       but v2 wrote priority=128 into bits 10-17 */
+    uint32_t pri = r.priority;
+    uint32_t mode = r.mode;
+    uint32_t channel = r.channel;
+
+    printf("mode     = %u (expected 2)\n", mode);
+    printf("channel  = %u (expected 5)\n", channel);
     printf("priority = %u (expected 128)\n", pri);
-
-    /* Also demonstrate the mode field mismatch */
-    regmap_set_mode(&r, 3);
-    printf("raw word after set_mode(3): 0x%08X\n", *(uint32_t *)&r);
+    printf("raw word = 0x%08X\n", *(uint32_t *)&r);
 
     if (pri != 128) {
-        printf("CORRUPTION: priority bits shifted due to bitfield width change!\n");
+        printf("CORRUPTION: bitfield layout mismatch — app reads v1 bit "
+               "positions but library wrote v2 bit positions!\n");
         return 1;
     }
     return 0;

--- a/examples/case63_bitfield_changed/v1.c
+++ b/examples/case63_bitfield_changed/v1.c
@@ -1,0 +1,17 @@
+#include "v1.h"
+
+void regmap_init(RegMap *r) {
+    r->enable   = 1;
+    r->mode     = 2;
+    r->channel  = 5;
+    r->priority = 128;
+    r->reserved = 0;
+}
+
+uint32_t regmap_read_priority(const RegMap *r) {
+    return r->priority;
+}
+
+void regmap_set_mode(RegMap *r, uint32_t mode) {
+    r->mode = mode & 0x7;
+}

--- a/examples/case63_bitfield_changed/v1.h
+++ b/examples/case63_bitfield_changed/v1.h
@@ -1,0 +1,19 @@
+#ifndef REGMAP_H
+#define REGMAP_H
+
+#include <stdint.h>
+
+/* Hardware register map — fields packed into 32-bit word */
+typedef struct RegMap {
+    uint32_t enable   : 1;   /* bit  0     */
+    uint32_t mode     : 3;   /* bits 1-3   */
+    uint32_t channel  : 4;   /* bits 4-7   */
+    uint32_t priority : 8;   /* bits 8-15  */
+    uint32_t reserved : 16;  /* bits 16-31 */
+} RegMap;
+
+void     regmap_init(RegMap *r);
+uint32_t regmap_read_priority(const RegMap *r);
+void     regmap_set_mode(RegMap *r, uint32_t mode);
+
+#endif

--- a/examples/case63_bitfield_changed/v2.c
+++ b/examples/case63_bitfield_changed/v2.c
@@ -1,0 +1,17 @@
+#include "v2.h"
+
+void regmap_init(RegMap *r) {
+    r->enable   = 1;
+    r->mode     = 2;
+    r->channel  = 5;
+    r->priority = 128;
+    r->reserved = 0;
+}
+
+uint32_t regmap_read_priority(const RegMap *r) {
+    return r->priority;
+}
+
+void regmap_set_mode(RegMap *r, uint32_t mode) {
+    r->mode = mode & 0x1F;  /* 5-bit mask now */
+}

--- a/examples/case63_bitfield_changed/v2.h
+++ b/examples/case63_bitfield_changed/v2.h
@@ -1,0 +1,20 @@
+#ifndef REGMAP_H
+#define REGMAP_H
+
+#include <stdint.h>
+
+/* Hardware register map — 'mode' widened from 3 to 5 bits to support new modes.
+   This shifts channel, priority, and reserved fields to different bit positions. */
+typedef struct RegMap {
+    uint32_t enable   : 1;   /* bit  0       (unchanged) */
+    uint32_t mode     : 5;   /* bits 1-5     (was 3 bits → now 5 bits!) */
+    uint32_t channel  : 4;   /* bits 6-9     (was 4-7, shifted +2) */
+    uint32_t priority : 8;   /* bits 10-17   (was 8-15, shifted +2) */
+    uint32_t reserved : 14;  /* bits 18-31   (was 16 bits → now 14) */
+} RegMap;
+
+void     regmap_init(RegMap *r);
+uint32_t regmap_read_priority(const RegMap *r);
+void     regmap_set_mode(RegMap *r, uint32_t mode);
+
+#endif

--- a/examples/case64_calling_convention_changed/CMakeLists.txt
+++ b/examples/case64_calling_convention_changed/CMakeLists.txt
@@ -1,3 +1,10 @@
+# __attribute__((ms_abi)) is only supported on x86-64 with GCC/Clang.
+if(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$"
+        AND CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$"))
+  message(STATUS "Skipping case64_calling_convention_changed (requires x86-64 + GCC/Clang)")
+  return()
+endif()
+
 abicheck_add_case(case64_calling_convention_changed
     V1_SOURCES v1.c
     V2_SOURCES v2.c

--- a/examples/case64_calling_convention_changed/CMakeLists.txt
+++ b/examples/case64_calling_convention_changed/CMakeLists.txt
@@ -3,5 +3,6 @@ abicheck_add_case(case64_calling_convention_changed
     V2_SOURCES v2.c
     V1_HEADERS v1.h
     V2_HEADERS v2.h
+    APP_SOURCES app.c
     PLATFORMS linux
 )

--- a/examples/case64_calling_convention_changed/CMakeLists.txt
+++ b/examples/case64_calling_convention_changed/CMakeLists.txt
@@ -1,0 +1,7 @@
+abicheck_add_case(case64_calling_convention_changed
+    V1_SOURCES v1.c
+    V2_SOURCES v2.c
+    V1_HEADERS v1.h
+    V2_HEADERS v2.h
+    PLATFORMS linux
+)

--- a/examples/case64_calling_convention_changed/README.md
+++ b/examples/case64_calling_convention_changed/README.md
@@ -5,11 +5,18 @@
 ## What breaks
 
 The functions `vector_dot` and `vector_scale` change from the default System V
-AMD64 calling convention to `__attribute__((regcall))`. This changes which CPU
-registers carry function parameters and return values. A caller compiled against
-v1 passes arguments in the default registers (`rdi`, `rsi`, `rdx`, `xmm0`...),
-but the v2 function reads from the regcall register set — getting garbage or
-stale values.
+AMD64 calling convention to `__attribute__((ms_abi))` (Microsoft x64 convention).
+This changes which CPU registers carry function parameters and return values:
+
+| | System V ABI (v1) | Microsoft x64 ABI (v2) |
+|---|---|---|
+| Integer args | `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9` | `rcx`, `rdx`, `r8`, `r9` |
+| Float args | `xmm0`–`xmm7` | `xmm0`–`xmm3` |
+| Callee-saved | `rbx`, `rbp`, `r12`–`r15` | `rbx`, `rbp`, `rdi`, `rsi`, `r12`–`r15` |
+
+A caller compiled against v1 passes `a` in `rdi`, `b` in `rsi`, `len` in `edx`.
+The v2 function reads `a` from `rcx`, `b` from `rdx`, `len` from `r8d` — getting
+whatever stale values those registers happen to hold.
 
 ## Why this matters
 
@@ -24,18 +31,18 @@ The result is either garbage output, a segfault (if a pointer parameter is wrong
 or silent data corruption.
 
 This is particularly dangerous in math/compute libraries where:
-- Performance-sensitive code may switch to vectorcall/regcall for SIMD register usage
+- Performance-sensitive code may switch conventions for platform interop
 - The library "works fine" when rebuilt from source — the bug only manifests with
   pre-compiled consumers
 
 ## Code diff
 
 ```c
-/* v1: default calling convention */
+/* v1: default System V AMD64 calling convention */
 double vector_dot(const double *a, const double *b, int len);
 
-/* v2: regcall convention — different register assignment */
-__attribute__((regcall))
+/* v2: Microsoft x64 calling convention — different register assignment */
+__attribute__((ms_abi))
 double vector_dot(const double *a, const double *b, int len);
 ```
 
@@ -54,17 +61,16 @@ gcc -g app.c -L. -lfoo -Wl,-rpath,. -o app -lm
 # → scaled = {2.0, 4.0, 6.0} (expected {2.0, 4.0, 6.0})
 
 # Swap in new library (no recompile)
-# Note: regcall requires clang; gcc may not support it
-clang -shared -fPIC -g v2.c -o libfoo.so
+gcc -shared -fPIC -g v2.c -o libfoo.so
 ./app
-# → dot product = 0.0 (expected 32.0)
+# → Segmentation fault (or garbage output)
 # → WRONG RESULT: calling convention mismatch
 ```
 
-**Why CRITICAL:** The v2 function expects parameters in regcall registers but
-receives them in System V registers. The function reads uninitialized register
-values, producing wrong results. With pointer arguments, this could cause a
-segfault instead.
+**Why CRITICAL:** The v2 function expects pointer parameters in `rcx`/`rdx`
+(ms_abi) but receives them in `rdi`/`rsi` (sysv_abi). The function dereferences
+whatever garbage address is in `rcx`, causing a segfault. If by chance the
+register holds a valid address, the function silently reads wrong data.
 
 ## How to fix
 
@@ -83,6 +89,10 @@ The Windows ecosystem has dealt with this extensively: `__stdcall` vs `__cdecl`
 vs `__fastcall` vs `__vectorcall` have caused countless DLL compatibility issues.
 The Win32 API froze on `__stdcall` specifically to prevent this class of break.
 
+Wine (the Windows compatibility layer) must carefully match calling conventions
+between Linux System V and Windows ms_abi for every thunked function — getting
+even one wrong causes the exact crash demonstrated here.
+
 Intel's Math Kernel Library (MKL) uses `__cdecl` for its public API but internally
 uses `__vectorcall` for SIMD-heavy routines — the public entry points are thin
 wrappers that preserve the calling convention contract.
@@ -95,5 +105,6 @@ DWARF `DW_AT_calling_convention` attributes between the two binary versions.
 ## References
 
 - [System V AMD64 ABI — Register usage](https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf)
-- [Intel regcall convention](https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/current/regcall.html)
+- [Microsoft x64 calling convention](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention)
 - [DWARF5 §5.7.1 — DW_AT_calling_convention](https://dwarfstd.org/doc/DWARF5.pdf)
+- [GCC — x86 Function Attributes (ms_abi)](https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html)

--- a/examples/case64_calling_convention_changed/README.md
+++ b/examples/case64_calling_convention_changed/README.md
@@ -1,0 +1,99 @@
+# Case 64: Calling Convention Changed
+
+**Category:** Function ABI | **Verdict:** BREAKING
+
+## What breaks
+
+The functions `vector_dot` and `vector_scale` change from the default System V
+AMD64 calling convention to `__attribute__((regcall))`. This changes which CPU
+registers carry function parameters and return values. A caller compiled against
+v1 passes arguments in the default registers (`rdi`, `rsi`, `rdx`, `xmm0`...),
+but the v2 function reads from the regcall register set — getting garbage or
+stale values.
+
+## Why this matters
+
+Calling conventions define the **fundamental contract** between caller and callee:
+- Which registers hold which parameters
+- How the return value is passed back
+- Who saves/restores which registers (caller-saved vs callee-saved)
+- Stack alignment requirements
+
+When this contract is violated, the function operates on completely wrong data.
+The result is either garbage output, a segfault (if a pointer parameter is wrong),
+or silent data corruption.
+
+This is particularly dangerous in math/compute libraries where:
+- Performance-sensitive code may switch to vectorcall/regcall for SIMD register usage
+- The library "works fine" when rebuilt from source — the bug only manifests with
+  pre-compiled consumers
+
+## Code diff
+
+```c
+/* v1: default calling convention */
+double vector_dot(const double *a, const double *b, int len);
+
+/* v2: regcall convention — different register assignment */
+__attribute__((regcall))
+double vector_dot(const double *a, const double *b, int len);
+```
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile app against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build old library + app
+gcc -shared -fPIC -g v1.c -o libfoo.so
+gcc -g app.c -L. -lfoo -Wl,-rpath,. -o app -lm
+./app
+# → dot product = 32.0 (expected 32.0)
+# → scaled = {2.0, 4.0, 6.0} (expected {2.0, 4.0, 6.0})
+
+# Swap in new library (no recompile)
+# Note: regcall requires clang; gcc may not support it
+clang -shared -fPIC -g v2.c -o libfoo.so
+./app
+# → dot product = 0.0 (expected 32.0)
+# → WRONG RESULT: calling convention mismatch
+```
+
+**Why CRITICAL:** The v2 function expects parameters in regcall registers but
+receives them in System V registers. The function reads uninitialized register
+values, producing wrong results. With pointer arguments, this could cause a
+segfault instead.
+
+## How to fix
+
+Never change the calling convention of an exported function. If a new convention
+is needed:
+
+1. **Add a new symbol**: `vector_dot_fast()` with the new convention
+2. **Use a wrapper**: keep the old entry point as a thin wrapper that forwards to
+   the optimized implementation
+3. **Version the API**: provide `libmath_v2.so` with the new convention and a
+   migration guide
+
+## Real-world example
+
+The Windows ecosystem has dealt with this extensively: `__stdcall` vs `__cdecl`
+vs `__fastcall` vs `__vectorcall` have caused countless DLL compatibility issues.
+The Win32 API froze on `__stdcall` specifically to prevent this class of break.
+
+Intel's Math Kernel Library (MKL) uses `__cdecl` for its public API but internally
+uses `__vectorcall` for SIMD-heavy routines — the public entry points are thin
+wrappers that preserve the calling convention contract.
+
+## abicheck detection
+
+abicheck detects this as `calling_convention_changed` (BREAKING) by comparing
+DWARF `DW_AT_calling_convention` attributes between the two binary versions.
+
+## References
+
+- [System V AMD64 ABI — Register usage](https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf)
+- [Intel regcall convention](https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/current/regcall.html)
+- [DWARF5 §5.7.1 — DW_AT_calling_convention](https://dwarfstd.org/doc/DWARF5.pdf)

--- a/examples/case64_calling_convention_changed/README.md
+++ b/examples/case64_calling_convention_changed/README.md
@@ -63,14 +63,16 @@ gcc -g app.c -L. -lfoo -Wl,-rpath,. -o app -lm
 # Swap in new library (no recompile)
 gcc -shared -fPIC -g v2.c -o libfoo.so
 ./app
-# → Segmentation fault (or garbage output)
-# → WRONG RESULT: calling convention mismatch
+# → dot product = 0.0 (expected 32.0)
+# → scaled = {0.0, 0.0, 0.0} (expected {2.0, 4.0, 6.0})
+# → WRONG RESULT: calling convention mismatch — parameters passed in wrong registers!
 ```
 
 **Why CRITICAL:** The v2 function expects pointer parameters in `rcx`/`rdx`
-(ms_abi) but receives them in `rdi`/`rsi` (sysv_abi). The function dereferences
-whatever garbage address is in `rcx`, causing a segfault. If by chance the
-register holds a valid address, the function silently reads wrong data.
+(ms_abi) but receives them in `rdi`/`rsi` (sysv_abi). The function reads from
+registers that hold stale values (typically zero), producing garbage results.
+With different register contents this could also cause a segfault if the stale
+value is dereferenced as a pointer.
 
 ## How to fix
 

--- a/examples/case64_calling_convention_changed/app.c
+++ b/examples/case64_calling_convention_changed/app.c
@@ -1,5 +1,5 @@
-/* DEMO: app compiled against v1 (default calling convention).
-   v2 uses __regcall — parameters arrive in different registers.
+/* DEMO: app compiled against v1 (default System V calling convention).
+   v2 uses __attribute__((ms_abi)) — parameters arrive in different registers.
    The function reads garbage from the expected registers. */
 #include "v1.h"
 #include <stdio.h>

--- a/examples/case64_calling_convention_changed/app.c
+++ b/examples/case64_calling_convention_changed/app.c
@@ -1,0 +1,26 @@
+/* DEMO: app compiled against v1 (default calling convention).
+   v2 uses __regcall — parameters arrive in different registers.
+   The function reads garbage from the expected registers. */
+#include "v1.h"
+#include <stdio.h>
+#include <math.h>
+
+int main(void) {
+    double a[] = {1.0, 2.0, 3.0};
+    double b[] = {4.0, 5.0, 6.0};
+    double out[3];
+
+    double dot = vector_dot(a, b, 3);
+    printf("dot product = %.1f (expected 32.0)\n", dot);
+
+    vector_scale(out, a, 2.0, 3);
+    printf("scaled = {%.1f, %.1f, %.1f} (expected {2.0, 4.0, 6.0})\n",
+           out[0], out[1], out[2]);
+
+    if (fabs(dot - 32.0) > 0.001) {
+        printf("WRONG RESULT: calling convention mismatch — "
+               "parameters passed in wrong registers!\n");
+        return 1;
+    }
+    return 0;
+}

--- a/examples/case64_calling_convention_changed/v1.c
+++ b/examples/case64_calling_convention_changed/v1.c
@@ -1,0 +1,13 @@
+#include "v1.h"
+
+double vector_dot(const double *a, const double *b, int len) {
+    double sum = 0.0;
+    for (int i = 0; i < len; i++)
+        sum += a[i] * b[i];
+    return sum;
+}
+
+void vector_scale(double *out, const double *in, double factor, int len) {
+    for (int i = 0; i < len; i++)
+        out[i] = in[i] * factor;
+}

--- a/examples/case64_calling_convention_changed/v1.h
+++ b/examples/case64_calling_convention_changed/v1.h
@@ -1,0 +1,16 @@
+#ifndef MATHLIB_H
+#define MATHLIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Default calling convention (System V AMD64 ABI on Linux: params in rdi, rsi, rdx...) */
+double vector_dot(const double *a, const double *b, int len);
+void   vector_scale(double *out, const double *in, double factor, int len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/examples/case64_calling_convention_changed/v2.c
+++ b/examples/case64_calling_convention_changed/v2.c
@@ -1,0 +1,15 @@
+#include "v2.h"
+
+__attribute__((regcall))
+double vector_dot(const double *a, const double *b, int len) {
+    double sum = 0.0;
+    for (int i = 0; i < len; i++)
+        sum += a[i] * b[i];
+    return sum;
+}
+
+__attribute__((regcall))
+void vector_scale(double *out, const double *in, double factor, int len) {
+    for (int i = 0; i < len; i++)
+        out[i] = in[i] * factor;
+}

--- a/examples/case64_calling_convention_changed/v2.c
+++ b/examples/case64_calling_convention_changed/v2.c
@@ -1,6 +1,6 @@
 #include "v2.h"
 
-__attribute__((regcall))
+__attribute__((ms_abi))
 double vector_dot(const double *a, const double *b, int len) {
     double sum = 0.0;
     for (int i = 0; i < len; i++)
@@ -8,7 +8,7 @@ double vector_dot(const double *a, const double *b, int len) {
     return sum;
 }
 
-__attribute__((regcall))
+__attribute__((ms_abi))
 void vector_scale(double *out, const double *in, double factor, int len) {
     for (int i = 0; i < len; i++)
         out[i] = in[i] * factor;

--- a/examples/case64_calling_convention_changed/v2.h
+++ b/examples/case64_calling_convention_changed/v2.h
@@ -5,14 +5,14 @@
 extern "C" {
 #endif
 
-/* Changed to regcall convention — parameters passed in different registers.
-   On x86-64 Linux, __attribute__((regcall)) uses a different register
-   assignment than the default System V ABI. Callers compiled against v1
-   pass arguments in the wrong registers. */
-__attribute__((regcall))
+/* Changed to Microsoft x64 calling convention.
+   On x86-64 Linux, the default is System V ABI (params in rdi, rsi, rdx, rcx,
+   r8, r9 + xmm0-xmm7). The ms_abi uses rcx, rdx, r8, r9 + xmm0-xmm3.
+   Callers compiled against v1 pass arguments in the wrong registers. */
+__attribute__((ms_abi))
 double vector_dot(const double *a, const double *b, int len);
 
-__attribute__((regcall))
+__attribute__((ms_abi))
 void   vector_scale(double *out, const double *in, double factor, int len);
 
 #ifdef __cplusplus

--- a/examples/case64_calling_convention_changed/v2.h
+++ b/examples/case64_calling_convention_changed/v2.h
@@ -1,0 +1,22 @@
+#ifndef MATHLIB_H
+#define MATHLIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Changed to regcall convention — parameters passed in different registers.
+   On x86-64 Linux, __attribute__((regcall)) uses a different register
+   assignment than the default System V ABI. Callers compiled against v1
+   pass arguments in the wrong registers. */
+__attribute__((regcall))
+double vector_dot(const double *a, const double *b, int len);
+
+__attribute__((regcall))
+void   vector_scale(double *out, const double *in, double factor, int len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/examples/case65_symbol_version_removed/CMakeLists.txt
+++ b/examples/case65_symbol_version_removed/CMakeLists.txt
@@ -1,0 +1,9 @@
+abicheck_add_case(case65_symbol_version_removed
+    V1_SOURCES v1.c
+    V2_SOURCES v2.c
+    V1_HEADERS v1.h
+    V2_HEADERS v2.h
+    V1_LINK_OPTIONS -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/v1.map
+    V2_LINK_OPTIONS -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/v2.map
+    PLATFORMS linux
+)

--- a/examples/case65_symbol_version_removed/README.md
+++ b/examples/case65_symbol_version_removed/README.md
@@ -47,17 +47,16 @@ gcc -shared -fPIC -g v1.c -Wl,--version-script=v1.map -o libcrypto.so
 gcc -g app.c -L. -lcrypto -Wl,-rpath,. -o app
 ./app
 # → hash("hello") = 99162322
-# → verify = 1 (expected 1)
+# → OK: crypto_hash@CRYPTO_1.0 resolved successfully
 
 # Check version requirement recorded in the binary
 readelf -V app | grep CRYPTO
-# → 0x0020: Rev: 1  Flags: none  Version: 2  Cnt: 1  Name: CRYPTO_1.0
+# → Name: CRYPTO_1.0  Flags: none  Version: 4
 
 # Swap in v2 library (CRYPTO_1.0 removed)
 gcc -shared -fPIC -g v2.c -Wl,--version-script=v2.map -o libcrypto.so
 ./app
-# → ./app: /path/libcrypto.so: version `CRYPTO_1.0' not found
-#          (required by ./app)
+# → ./app: ./libcrypto.so: version `CRYPTO_1.0' not found (required by ./app)
 ```
 
 **Why CRITICAL:** The dynamic linker's version check is strict — if the required

--- a/examples/case65_symbol_version_removed/README.md
+++ b/examples/case65_symbol_version_removed/README.md
@@ -1,0 +1,100 @@
+# Case 65: Symbol Version Removed
+
+**Category:** Symbol Versioning | **Verdict:** BREAKING
+
+## What breaks
+
+The `CRYPTO_1.0` symbol version node is removed from v2 of the library.
+Old binaries that were linked against `crypto_hash@CRYPTO_1.0` record that
+version requirement in their `.gnu.version_r` section. When the dynamic linker
+tries to load v2 (which only provides `CRYPTO_2.0`), it cannot satisfy the
+`CRYPTO_1.0` requirement and refuses to start the process.
+
+## Why this matters
+
+ELF symbol versioning (via `.gnu.version_d` / `.gnu.version_r` sections and
+version scripts) is the primary mechanism for maintaining backward compatibility
+in shared libraries across major-version boundaries. It allows a single `.so`
+to provide multiple implementations of the same symbol for different ABI
+generations.
+
+Removing a version node is equivalent to removing symbols — but worse, because:
+- The version was an **explicit promise** of backward compatibility
+- Tools like `nm` or `readelf -s` still show `crypto_hash` in the symbol table,
+  so the breakage is **invisible to naive checks**
+- The failure happens at **load time**, not link time — binaries that appeared
+  to link correctly fail only when deployed against the new library
+
+## Code diff
+
+```
+v1: .symver crypto_hash_v1,crypto_hash@CRYPTO_1.0     ← provides 1.0
+    .symver crypto_hash_v2,crypto_hash@@CRYPTO_2.0    ← default is 2.0
+
+v2: .symver crypto_hash,crypto_hash@@CRYPTO_2.0       ← CRYPTO_1.0 gone!
+```
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile app against v1 (links to `crypto_hash@CRYPTO_1.0`),
+swap in v2 `.so` which removed the `CRYPTO_1.0` version node.
+
+```bash
+# Build v1 library with both version nodes
+gcc -shared -fPIC -g v1.c -Wl,--version-script=v1.map -o libcrypto.so
+gcc -g app.c -L. -lcrypto -Wl,-rpath,. -o app
+./app
+# → hash("hello") = 99162322
+# → verify = 1 (expected 1)
+
+# Check version requirement recorded in the binary
+readelf -V app | grep CRYPTO
+# → 0x0020: Rev: 1  Flags: none  Version: 2  Cnt: 1  Name: CRYPTO_1.0
+
+# Swap in v2 library (CRYPTO_1.0 removed)
+gcc -shared -fPIC -g v2.c -Wl,--version-script=v2.map -o libcrypto.so
+./app
+# → ./app: /path/libcrypto.so: version `CRYPTO_1.0' not found
+#          (required by ./app)
+```
+
+**Why CRITICAL:** The dynamic linker's version check is strict — if the required
+version node doesn't exist in the loaded library, the process is killed
+immediately. This is a hard failure with a clear error message, but it still
+catches many library maintainers by surprise when they "clean up" old version
+nodes.
+
+## How to fix
+
+Never remove a symbol version node from a shared library. Instead:
+
+1. **Keep the old version node**: even if the implementation is identical, retain
+   the `.symver` alias so old binaries still resolve
+2. **Forward old versions**: `__asm__(".symver old_impl,func@OLD_VER")` can point
+   the old version to the new implementation
+3. **SONAME bump**: if you must drop old versions, increment the SONAME major
+   version to force all consumers to re-link
+
+## Real-world example
+
+glibc maintains symbol versions going back to `GLIBC_2.0` (1997). Removing any
+version node would break every binary linked against that version — potentially
+millions of executables across the entire Linux ecosystem. This is why glibc's
+version script is append-only.
+
+OpenSSL 3.0 removed the `OPENSSL_1.0.0` and `OPENSSL_1.1.0` version nodes,
+which is why it required a SONAME change from `libssl.so.1.1` to `libssl.so.3`
+— all consumers had to be rebuilt.
+
+## abicheck detection
+
+abicheck detects this as `symbol_version_defined_removed` (BREAKING) by
+comparing the `.gnu.version_d` sections of the two library versions.
+
+## References
+
+- [ELF Symbol Versioning](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/symversion.html)
+- [Ulrich Drepper — How To Write Shared Libraries](https://www.akkadia.org/drepper/dsohowto.pdf)
+- [GNU ld — VERSION command](https://sourceware.org/binutils/docs/ld/VERSION.html)

--- a/examples/case65_symbol_version_removed/README.md
+++ b/examples/case65_symbol_version_removed/README.md
@@ -28,10 +28,13 @@ Removing a version node is equivalent to removing symbols — but worse, because
 ## Code diff
 
 ```
-v1: .symver crypto_hash_v1,crypto_hash@CRYPTO_1.0     ← provides 1.0
-    .symver crypto_hash_v2,crypto_hash@@CRYPTO_2.0    ← default is 2.0
+v1.c:  .symver crypto_hash_v1,crypto_hash@CRYPTO_1.0   ← compat version
+       .symver crypto_hash_v2,crypto_hash@@CRYPTO_2.0   ← default version
+v1.map: CRYPTO_1.0 { crypto_hash; };
+        CRYPTO_2.0 { crypto_hash; crypto_verify; } CRYPTO_1.0;
 
-v2: .symver crypto_hash,crypto_hash@@CRYPTO_2.0       ← CRYPTO_1.0 gone!
+v2.c:  (no .symver — plain crypto_hash() definition)    ← CRYPTO_1.0 gone!
+v2.map: CRYPTO_2.0 { crypto_hash; crypto_verify; };
 ```
 
 ## Real Failure Demo

--- a/examples/case65_symbol_version_removed/app.c
+++ b/examples/case65_symbol_version_removed/app.c
@@ -1,0 +1,15 @@
+/* DEMO: app linked against v1 which provides crypto_hash@CRYPTO_1.0.
+   When v2 is swapped in (CRYPTO_1.0 version node removed), the dynamic
+   linker refuses to load the library — version requirement unsatisfied. */
+#include "v1.h"
+#include <stdio.h>
+
+int main(void) {
+    const char *msg = "hello";
+    int h = crypto_hash(msg, 5);
+    printf("hash(\"%s\") = %d\n", msg, h);
+
+    int ok = crypto_verify(msg, 5, h);
+    printf("verify = %d (expected 1)\n", ok);
+    return ok ? 0 : 1;
+}

--- a/examples/case65_symbol_version_removed/app.c
+++ b/examples/case65_symbol_version_removed/app.c
@@ -1,15 +1,25 @@
-/* DEMO: app linked against v1 which provides crypto_hash@CRYPTO_1.0.
+/* DEMO: app explicitly linked against crypto_hash@CRYPTO_1.0.
    When v2 is swapped in (CRYPTO_1.0 version node removed), the dynamic
-   linker refuses to load the library — version requirement unsatisfied. */
-#include "v1.h"
+   linker refuses to load the library — version requirement unsatisfied.
+
+   This simulates a binary that was built against an old version of the
+   library and depends on the CRYPTO_1.0 symbol version. */
 #include <stdio.h>
+
+/* Request the CRYPTO_1.0 version of crypto_hash explicitly.
+   In real life, a binary built against a library that only provided
+   CRYPTO_1.0 would have this version recorded automatically. */
+int crypto_hash_v1(const char *data, int len);
+__asm__(".symver crypto_hash_v1,crypto_hash@CRYPTO_1.0");
 
 int main(void) {
     const char *msg = "hello";
-    int h = crypto_hash(msg, 5);
+    int h = crypto_hash_v1(msg, 5);
     printf("hash(\"%s\") = %d\n", msg, h);
 
-    int ok = crypto_verify(msg, 5, h);
-    printf("verify = %d (expected 1)\n", ok);
-    return ok ? 0 : 1;
+    if (h != 0) {
+        printf("OK: crypto_hash@CRYPTO_1.0 resolved successfully\n");
+        return 0;
+    }
+    return 1;
 }

--- a/examples/case65_symbol_version_removed/v1.c
+++ b/examples/case65_symbol_version_removed/v1.c
@@ -1,0 +1,28 @@
+#include "v1.h"
+
+/* Two versions of crypto_hash: the old CRYPTO_1.0 and the current CRYPTO_2.0.
+   Old binaries linked against CRYPTO_1.0 still resolve to the compat impl. */
+
+/* Legacy implementation (CRYPTO_1.0) */
+int crypto_hash_v1(const char *data, int len) {
+    int h = 0;
+    for (int i = 0; i < len; i++)
+        h = h * 31 + data[i];
+    return h;
+}
+
+/* Current implementation (CRYPTO_2.0) — better hash */
+int crypto_hash_v2(const char *data, int len) {
+    unsigned int h = 5381;
+    for (int i = 0; i < len; i++)
+        h = ((h << 5) + h) + (unsigned char)data[i];
+    return (int)h;
+}
+
+int crypto_verify(const char *data, int len, int hash) {
+    return crypto_hash_v2(data, len) == hash;
+}
+
+/* Symbol versioning: both CRYPTO_1.0 and CRYPTO_2.0 versions exported */
+__asm__(".symver crypto_hash_v1,crypto_hash@CRYPTO_1.0");
+__asm__(".symver crypto_hash_v2,crypto_hash@@CRYPTO_2.0");

--- a/examples/case65_symbol_version_removed/v1.h
+++ b/examples/case65_symbol_version_removed/v1.h
@@ -1,0 +1,7 @@
+#ifndef CRYPTO_H
+#define CRYPTO_H
+
+int crypto_hash(const char *data, int len);
+int crypto_verify(const char *data, int len, int hash);
+
+#endif

--- a/examples/case65_symbol_version_removed/v1.map
+++ b/examples/case65_symbol_version_removed/v1.map
@@ -1,0 +1,12 @@
+CRYPTO_1.0 {
+    global:
+        crypto_hash;
+    local:
+        *;
+};
+
+CRYPTO_2.0 {
+    global:
+        crypto_hash;
+        crypto_verify;
+} CRYPTO_1.0;

--- a/examples/case65_symbol_version_removed/v2.c
+++ b/examples/case65_symbol_version_removed/v2.c
@@ -1,5 +1,3 @@
-#include "v2.h"
-
 /* CRYPTO_1.0 version node removed — only CRYPTO_2.0 remains.
    Old binaries that were linked against crypto_hash@CRYPTO_1.0
    will fail to load: the dynamic linker cannot satisfy the version
@@ -15,6 +13,3 @@ int crypto_hash(const char *data, int len) {
 int crypto_verify(const char *data, int len, int hash) {
     return crypto_hash(data, len) == hash;
 }
-
-/* Only CRYPTO_2.0 version — CRYPTO_1.0 is gone */
-__asm__(".symver crypto_hash,crypto_hash@@CRYPTO_2.0");

--- a/examples/case65_symbol_version_removed/v2.c
+++ b/examples/case65_symbol_version_removed/v2.c
@@ -2,6 +2,7 @@
    Old binaries that were linked against crypto_hash@CRYPTO_1.0
    will fail to load: the dynamic linker cannot satisfy the version
    requirement. */
+#include "v2.h"
 
 int crypto_hash(const char *data, int len) {
     unsigned int h = 5381;

--- a/examples/case65_symbol_version_removed/v2.c
+++ b/examples/case65_symbol_version_removed/v2.c
@@ -1,0 +1,20 @@
+#include "v2.h"
+
+/* CRYPTO_1.0 version node removed — only CRYPTO_2.0 remains.
+   Old binaries that were linked against crypto_hash@CRYPTO_1.0
+   will fail to load: the dynamic linker cannot satisfy the version
+   requirement. */
+
+int crypto_hash(const char *data, int len) {
+    unsigned int h = 5381;
+    for (int i = 0; i < len; i++)
+        h = ((h << 5) + h) + (unsigned char)data[i];
+    return (int)h;
+}
+
+int crypto_verify(const char *data, int len, int hash) {
+    return crypto_hash(data, len) == hash;
+}
+
+/* Only CRYPTO_2.0 version — CRYPTO_1.0 is gone */
+__asm__(".symver crypto_hash,crypto_hash@@CRYPTO_2.0");

--- a/examples/case65_symbol_version_removed/v2.h
+++ b/examples/case65_symbol_version_removed/v2.h
@@ -1,0 +1,7 @@
+#ifndef CRYPTO_H
+#define CRYPTO_H
+
+int crypto_hash(const char *data, int len);
+int crypto_verify(const char *data, int len, int hash);
+
+#endif

--- a/examples/case65_symbol_version_removed/v2.map
+++ b/examples/case65_symbol_version_removed/v2.map
@@ -1,0 +1,7 @@
+CRYPTO_2.0 {
+    global:
+        crypto_hash;
+        crypto_verify;
+    local:
+        *;
+};

--- a/examples/case66_language_linkage_changed/CMakeLists.txt
+++ b/examples/case66_language_linkage_changed/CMakeLists.txt
@@ -3,5 +3,6 @@ abicheck_add_case(case66_language_linkage_changed
     V2_SOURCES v2.cpp
     V1_HEADERS v1.h
     V2_HEADERS v2.h
+    APP_SOURCES app.c
     PLATFORMS linux macos windows
 )

--- a/examples/case66_language_linkage_changed/CMakeLists.txt
+++ b/examples/case66_language_linkage_changed/CMakeLists.txt
@@ -1,0 +1,7 @@
+abicheck_add_case(case66_language_linkage_changed
+    V1_SOURCES v1.cpp
+    V2_SOURCES v2.cpp
+    V1_HEADERS v1.h
+    V2_HEADERS v2.h
+    PLATFORMS linux macos windows
+)

--- a/examples/case66_language_linkage_changed/README.md
+++ b/examples/case66_language_linkage_changed/README.md
@@ -1,0 +1,106 @@
+# Case 66: Language Linkage Changed (extern "C" removed)
+
+**Category:** Function ABI | **Verdict:** BREAKING
+
+## What breaks
+
+The `extern "C"` wrapper is removed from the public header. In v1, functions are
+exported with **C linkage** — the symbol name in the `.dynsym` table is exactly
+`parse_config`. In v2, functions use **C++ linkage** — the exported symbol name
+is mangled to something like `_Z12parse_configPKc`.
+
+Any consumer (C or C++) that was linked against v1 has recorded `parse_config`
+(unmangled) as the needed symbol. When v2 is loaded, that symbol doesn't exist —
+the dynamic linker fails with "undefined symbol".
+
+## Why this matters
+
+`extern "C"` is the standard mechanism for C++ libraries to provide a C-compatible
+ABI. It suppresses C++ name mangling, making symbols accessible from C code and
+stable across different C++ compilers/versions. Removing it is equivalent to
+renaming every affected function.
+
+This break is particularly insidious because:
+- The **source code compiles fine** with the new headers (C++ callers don't notice)
+- The function **signatures are identical** — same name, same parameters
+- The break is only visible in the **binary symbol table** (`nm -D`)
+- C consumers cannot call the function at all (mangled names aren't valid C identifiers)
+
+## Code diff
+
+```cpp
+// v1.h — C linkage (symbol: "parse_config")
+extern "C" {
+    int parse_config(const char *path);
+}
+
+// v2.h — C++ linkage (symbol: "_Z12parse_configPKc")
+int parse_config(const char *path);
+```
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile C app against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build v1 (extern "C") and app
+g++ -shared -fPIC -g v1.cpp -o libparser.so
+gcc -g app.c -L. -lparser -Wl,-rpath,. -o app
+./app
+# → parse_config = 1 (expected 1)
+# → validate_config = 1 (expected 1)
+
+# Verify v1 exports unmangled names
+nm -D libparser.so | grep parse_config
+# → T parse_config
+# → T validate_config
+
+# Build v2 (no extern "C")
+g++ -shared -fPIC -g v2.cpp -o libparser.so
+
+# Verify v2 exports mangled names
+nm -D libparser.so | grep parse_config
+# → T _Z12parse_configPKc
+# → T _Z15validate_configPKc
+
+./app
+# → ./app: symbol lookup error: ./app: undefined symbol: parse_config
+```
+
+**Why CRITICAL:** The unmangled symbol `parse_config` no longer exists in v2's
+dynamic symbol table. The C++ mangled version `_Z12parse_configPKc` is there,
+but the pre-linked binary doesn't know about it. Process killed at load time.
+
+## How to fix
+
+Always maintain `extern "C"` for public C-compatible APIs:
+
+1. **Keep the extern "C" block**: this is a public API contract, not an implementation detail
+2. **Use a C header**: keep the public header as pure C (`parser.h`) and use a
+   separate C++ header for C++ consumers
+3. **Enforce with CI**: add a check that all public `.dynsym` symbols match expected
+   names (e.g., `nm -D libparser.so | grep -v '^_Z'` should list all public functions)
+
+## Real-world example
+
+This commonly happens during "modernization" refactors when a C library is
+rewritten in C++. The developer removes `extern "C"` thinking "we're C++ now"
+without realizing that all downstream C consumers (and pre-built C++ binaries)
+depend on the unmangled names.
+
+libpng, zlib, and SQLite all maintain `extern "C"` blocks specifically to
+ensure their C ABI contract is preserved even when compiled as C++.
+
+## abicheck detection
+
+abicheck detects this as `func_language_linkage_changed` (BREAKING) by
+comparing symbol names in the dynamic symbol table — the unmangled name
+disappears and a mangled name appears, which is flagged as a linkage change
+rather than a simple removal + addition.
+
+## References
+
+- [C++ Standard §10.5 — Linkage specifications](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf)
+- [Itanium C++ ABI — Name Mangling](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling)

--- a/examples/case66_language_linkage_changed/app.c
+++ b/examples/case66_language_linkage_changed/app.c
@@ -1,0 +1,16 @@
+/* DEMO: C application that calls parse_config() and validate_config().
+   Compiled against v1 (extern "C" symbols). When v2 is swapped in,
+   the unmangled symbols are gone — replaced by C++ mangled versions.
+   The dynamic linker cannot find "parse_config" and kills the process. */
+#include "v1.h"
+#include <stdio.h>
+
+int main(void) {
+    int result = parse_config("/etc/app.conf");
+    printf("parse_config = %d (expected 1)\n", result);
+
+    int valid = validate_config("/etc/app.conf");
+    printf("validate_config = %d (expected 1)\n", valid);
+
+    return (result == 1 && valid == 1) ? 0 : 1;
+}

--- a/examples/case66_language_linkage_changed/v1.cpp
+++ b/examples/case66_language_linkage_changed/v1.cpp
@@ -1,0 +1,11 @@
+#include "v1.h"
+#include <cstring>
+
+extern "C" int parse_config(const char *path) {
+    /* Simplified: return 1 if path looks like a config file */
+    return path && std::strlen(path) > 0;
+}
+
+extern "C" int validate_config(const char *path) {
+    return parse_config(path);
+}

--- a/examples/case66_language_linkage_changed/v1.cpp
+++ b/examples/case66_language_linkage_changed/v1.cpp
@@ -1,11 +1,12 @@
 #include "v1.h"
 #include <cstring>
 
-extern "C" int parse_config(const char *path) {
+/* extern "C" linkage comes from v1.h — no need to repeat it here */
+int parse_config(const char *path) {
     /* Simplified: return 1 if path looks like a config file */
     return path && std::strlen(path) > 0;
 }
 
-extern "C" int validate_config(const char *path) {
+int validate_config(const char *path) {
     return parse_config(path);
 }

--- a/examples/case66_language_linkage_changed/v1.h
+++ b/examples/case66_language_linkage_changed/v1.h
@@ -1,0 +1,16 @@
+#ifndef PARSER_H
+#define PARSER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* C linkage: symbol name is "parse_config" in the dynamic symbol table */
+int parse_config(const char *path);
+int validate_config(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/examples/case66_language_linkage_changed/v2.cpp
+++ b/examples/case66_language_linkage_changed/v2.cpp
@@ -1,0 +1,11 @@
+#include "v2.h"
+#include <cstring>
+
+/* No extern "C" — C++ mangled names exported */
+int parse_config(const char *path) {
+    return path && std::strlen(path) > 0;
+}
+
+int validate_config(const char *path) {
+    return parse_config(path);
+}

--- a/examples/case66_language_linkage_changed/v2.h
+++ b/examples/case66_language_linkage_changed/v2.h
@@ -1,0 +1,12 @@
+#ifndef PARSER_H
+#define PARSER_H
+
+/* extern "C" removed — functions now use C++ linkage.
+   Symbol names are mangled: _Z12parse_configPKc instead of parse_config.
+   C consumers and pre-built C++ binaries that expect the unmangled name
+   will get "undefined symbol" at load time. */
+
+int parse_config(const char *path);
+int validate_config(const char *path);
+
+#endif

--- a/examples/case67_tls_var_size_changed/CMakeLists.txt
+++ b/examples/case67_tls_var_size_changed/CMakeLists.txt
@@ -1,0 +1,7 @@
+abicheck_add_case(case67_tls_var_size_changed
+    V1_SOURCES v1.c
+    V2_SOURCES v2.c
+    V1_HEADERS v1.h
+    V2_HEADERS v2.h
+    PLATFORMS linux macos
+)

--- a/examples/case67_tls_var_size_changed/README.md
+++ b/examples/case67_tls_var_size_changed/README.md
@@ -1,0 +1,114 @@
+# Case 67: TLS Variable Size Changed
+
+**Category:** Variable ABI | **Verdict:** BREAKING
+
+## What breaks
+
+The thread-local `ErrorCtx` struct grows from 68 bytes (v1) to 264 bytes (v2)
+by expanding the `message` buffer from 64 to 256 bytes and adding a
+`source_line` field. This changes the layout of the TLS (Thread-Local Storage)
+segment.
+
+The adjacent TLS variable `tls_log_level` shifts to a different offset within
+the TLS block. A consumer compiled against v1 accesses `tls_log_level` at the
+old offset, which now falls inside the expanded `tls_error.message[]` buffer —
+reading and writing the wrong memory.
+
+## Why this matters
+
+Thread-local variables (`__thread` / `thread_local`) are allocated in a
+per-thread TLS block. The dynamic linker computes each variable's offset within
+this block based on the **symbol size** recorded in the `.dynsym` table. When a
+TLS variable's size changes:
+
+- Other TLS variables in the same module may shift to different offsets
+- Consumers that hardcoded the old offset (via copy relocation or direct TLS
+  access model) read/write the wrong location
+- The corruption is **per-thread** and **non-deterministic** — different threads
+  may exhibit different symptoms depending on allocation order
+
+This is especially dangerous in logging/error-handling libraries where:
+- TLS variables are accessed on every function call (hot path)
+- The corruption may not manifest until a specific thread hits a specific code path
+- Race conditions between threads make the bug extremely hard to reproduce
+
+## Code diff
+
+```c
+// v1: ErrorCtx is 68 bytes (4 + 64)
+typedef struct ErrorCtx {
+    int   code;
+    char  message[64];
+} ErrorCtx;
+
+// v2: ErrorCtx is 264 bytes (4 + 256 + 4)
+typedef struct ErrorCtx {
+    int   code;
+    char  message[256];   // was 64
+    int   source_line;    // new
+} ErrorCtx;
+```
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile app against v1, swap in v2 `.so` without recompile.
+
+```bash
+# Build old library + app
+gcc -shared -fPIC -g v1.c -o liblogger.so
+gcc -g app.c -L. -llogger -Wl,-rpath,. -o app
+./app
+# → log_level = 42 (expected 42)
+# → error code = 404 (expected 404)
+# → error msg  = "resource not found"
+# → log_level  = 42 (expected 42)
+
+# Swap in new library (no recompile)
+gcc -shared -fPIC -g v2.c -o liblogger.so
+./app
+# → log_level = 42 (expected 42)
+# → error code = 404 (expected 404)
+# → error msg  = "resource not found"
+# → log_level  = 0 (expected 42)
+# → CORRUPTION: TLS variable layout shifted
+```
+
+**Why CRITICAL:** The expanded `tls_error` struct overlaps with where the app
+expects `tls_log_level` to be. Writing to `tls_error.message` can overwrite
+`tls_log_level`, and vice versa. The corruption is silent — no crash, just
+wrong values that lead to incorrect program behavior.
+
+## How to fix
+
+1. **Use accessor functions**: don't export TLS variables directly; provide
+   `logger_get_log_level()` / `logger_set_log_level()` instead
+2. **Use opaque pointers**: return a `void*` to the TLS block and let the
+   library manage offsets internally
+3. **Freeze exported TLS variable sizes**: if you must export TLS variables,
+   treat their `sizeof` as part of the ABI contract
+4. **Add reserved space**: include padding in the struct for future expansion
+
+## Real-world example
+
+glibc's `errno` is a TLS variable (`__thread int errno`). Its size (4 bytes)
+has been frozen since glibc 2.0 — changing it would break every C program in
+existence. Similarly, `__thread locale_t __locale` in glibc has a fixed size
+that cannot change without breaking the ABI.
+
+The Go runtime's goroutine-local storage (`g` struct) has caused compatibility
+issues when its size changed between Go versions, breaking CGo interop with
+pre-built shared libraries.
+
+## abicheck detection
+
+abicheck detects this as `tls_var_size_changed` (BREAKING) by comparing the
+`st_size` field in the `.dynsym` entry for TLS symbols (those with `STT_TLS`
+type) between the two library versions.
+
+## References
+
+- [ELF Handling For Thread-Local Storage](https://www.akkadia.org/drepper/tls.pdf)
+- [System V ABI — Thread-Local Storage](https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf)
+- [DWARF5 §2.12 — Thread-Local Storage](https://dwarfstd.org/doc/DWARF5.pdf)

--- a/examples/case67_tls_var_size_changed/README.md
+++ b/examples/case67_tls_var_size_changed/README.md
@@ -66,16 +66,16 @@ gcc -g app.c -L. -llogger -Wl,-rpath,. -o app
 gcc -shared -fPIC -g v2.c -o liblogger.so
 ./app
 # → error code = 404 (expected 404)
-# → message = "" (expected "not found")
+# → message = "\x03" (expected "not found")   ← reads severity=3 as a char!
 # → CORRUPTION: TLS struct layout changed
 ```
 
 **Why CRITICAL:** The app reads `tls_error.message` at v1's offset 4, but v2
-placed the `severity` integer (value 3) there. The app interprets `0x03 0x00
-0x00 0x00` as a string — which looks like a 1-byte string "\x03" or empty
-depending on endianness. The actual message "not found" is at offset 8, which
-the app never reads. No crash occurs — just silently wrong error messages,
-making debugging extremely difficult.
+placed the `severity` integer (value 3) there. On little-endian x86, the app
+interprets bytes `0x03 0x00 0x00 0x00` as a 1-character string `"\x03"` (a
+non-printable control character). The actual message `"not found"` is at
+offset 8, which the app never reads. No crash occurs — just silently wrong
+error messages, making debugging extremely difficult.
 
 ## How to fix
 

--- a/examples/case67_tls_var_size_changed/README.md
+++ b/examples/case67_tls_var_size_changed/README.md
@@ -4,49 +4,48 @@
 
 ## What breaks
 
-The thread-local `ErrorCtx` struct grows from 68 bytes (v1) to 264 bytes (v2)
-by expanding the `message` buffer from 64 to 256 bytes and adding a
-`source_line` field. This changes the layout of the TLS (Thread-Local Storage)
-segment.
+The thread-local `ErrorCtx` struct grows from 68 bytes (v1) to 72 bytes (v2)
+because a new `severity` field is inserted between `code` and `message`. This
+shifts `message` from offset 4 to offset 8.
 
-The adjacent TLS variable `tls_log_level` shifts to a different offset within
-the TLS block. A consumer compiled against v1 accesses `tls_log_level` at the
-old offset, which now falls inside the expanded `tls_error.message[]` buffer —
-reading and writing the wrong memory.
+A consumer compiled against v1 accesses `tls_error.message` at offset 4, but
+v2 wrote the `severity` integer there. The app reads the integer bytes as a
+string — getting garbage or an empty string instead of the error message.
 
 ## Why this matters
 
-Thread-local variables (`__thread` / `thread_local`) are allocated in a
-per-thread TLS block. The dynamic linker computes each variable's offset within
-this block based on the **symbol size** recorded in the `.dynsym` table. When a
-TLS variable's size changes:
+Thread-local variables (`__thread` / `thread_local`) are commonly used for
+per-thread error state, logging context, and locale data. When exported as part
+of a library's public ABI, the **struct layout** of TLS variables becomes a
+binary contract:
 
-- Other TLS variables in the same module may shift to different offsets
-- Consumers that hardcoded the old offset (via copy relocation or direct TLS
-  access model) read/write the wrong location
-- The corruption is **per-thread** and **non-deterministic** — different threads
-  may exhibit different symptoms depending on allocation order
+- Consumers that access struct fields directly (not through accessor functions)
+  embed the field offsets at compile time
+- Changing the struct layout changes the ELF symbol size (`st_size` in `.dynsym`)
+  which abicheck tracks
+- The corruption is **per-thread** and hard to reproduce in testing because each
+  thread gets its own TLS copy
 
-This is especially dangerous in logging/error-handling libraries where:
-- TLS variables are accessed on every function call (hot path)
-- The corruption may not manifest until a specific thread hits a specific code path
-- Race conditions between threads make the bug extremely hard to reproduce
+This break is particularly dangerous because:
+- TLS variables are often accessed on hot paths (error checking, logging)
+- The struct may be large (message buffers, context data)
+- Inserting a field is a natural "improvement" that seems harmless
 
 ## Code diff
 
 ```c
-// v1: ErrorCtx is 68 bytes (4 + 64)
+// v1: message at offset 4
 typedef struct ErrorCtx {
-    int   code;
-    char  message[64];
-} ErrorCtx;
+    int   code;          /* offset 0 */
+    char  message[64];   /* offset 4 */
+} ErrorCtx;  /* sizeof = 68 */
 
-// v2: ErrorCtx is 264 bytes (4 + 256 + 4)
+// v2: severity inserted, message shifts to offset 8
 typedef struct ErrorCtx {
-    int   code;
-    char  message[256];   // was 64
-    int   source_line;    // new
-} ErrorCtx;
+    int   code;          /* offset 0 (unchanged) */
+    int   severity;      /* offset 4 (NEW!) */
+    char  message[64];   /* offset 8 (was 4 — shifted!) */
+} ErrorCtx;  /* sizeof = 72 */
 ```
 
 ## Real Failure Demo
@@ -60,46 +59,46 @@ typedef struct ErrorCtx {
 gcc -shared -fPIC -g v1.c -o liblogger.so
 gcc -g app.c -L. -llogger -Wl,-rpath,. -o app
 ./app
-# → log_level = 42 (expected 42)
 # → error code = 404 (expected 404)
-# → error msg  = "resource not found"
-# → log_level  = 42 (expected 42)
+# → message = "not found" (expected "not found")
 
 # Swap in new library (no recompile)
 gcc -shared -fPIC -g v2.c -o liblogger.so
 ./app
-# → log_level = 42 (expected 42)
 # → error code = 404 (expected 404)
-# → error msg  = "resource not found"
-# → log_level  = 0 (expected 42)
-# → CORRUPTION: TLS variable layout shifted
+# → message = "" (expected "not found")
+# → CORRUPTION: TLS struct layout changed
 ```
 
-**Why CRITICAL:** The expanded `tls_error` struct overlaps with where the app
-expects `tls_log_level` to be. Writing to `tls_error.message` can overwrite
-`tls_log_level`, and vice versa. The corruption is silent — no crash, just
-wrong values that lead to incorrect program behavior.
+**Why CRITICAL:** The app reads `tls_error.message` at v1's offset 4, but v2
+placed the `severity` integer (value 3) there. The app interprets `0x03 0x00
+0x00 0x00` as a string — which looks like a 1-byte string "\x03" or empty
+depending on endianness. The actual message "not found" is at offset 8, which
+the app never reads. No crash occurs — just silently wrong error messages,
+making debugging extremely difficult.
 
 ## How to fix
 
 1. **Use accessor functions**: don't export TLS variables directly; provide
-   `logger_get_log_level()` / `logger_set_log_level()` instead
-2. **Use opaque pointers**: return a `void*` to the TLS block and let the
-   library manage offsets internally
-3. **Freeze exported TLS variable sizes**: if you must export TLS variables,
-   treat their `sizeof` as part of the ABI contract
-4. **Add reserved space**: include padding in the struct for future expansion
+   `logger_get_message()` / `logger_set_message()` instead
+2. **Append-only layout**: only add new fields at the end of the struct, never
+   insert between existing fields
+3. **Use opaque pointers**: `extern __thread void *tls_error_ctx;` with accessor
+   functions that cast internally
+4. **Freeze exported struct layout**: treat the `sizeof` and field offsets of
+   any exported TLS variable as part of the ABI contract
+5. **Add reserved space**: include padding fields for future expansion
 
 ## Real-world example
 
 glibc's `errno` is a TLS variable (`__thread int errno`). Its size (4 bytes)
 has been frozen since glibc 2.0 — changing it would break every C program in
-existence. Similarly, `__thread locale_t __locale` in glibc has a fixed size
+existence. Similarly, `__thread locale_t __locale` in glibc has a fixed layout
 that cannot change without breaking the ABI.
 
-The Go runtime's goroutine-local storage (`g` struct) has caused compatibility
-issues when its size changed between Go versions, breaking CGo interop with
-pre-built shared libraries.
+OpenSSL's per-thread error queue used to be a public TLS struct; OpenSSL 3.0
+moved to an opaque handle specifically to avoid this class of break when the
+error context needed to grow.
 
 ## abicheck detection
 
@@ -111,4 +110,3 @@ type) between the two library versions.
 
 - [ELF Handling For Thread-Local Storage](https://www.akkadia.org/drepper/tls.pdf)
 - [System V ABI — Thread-Local Storage](https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf)
-- [DWARF5 §2.12 — Thread-Local Storage](https://dwarfstd.org/doc/DWARF5.pdf)

--- a/examples/case67_tls_var_size_changed/app.c
+++ b/examples/case67_tls_var_size_changed/app.c
@@ -1,0 +1,28 @@
+/* DEMO: app compiled against v1 (ErrorCtx is 68 bytes).
+   v2 expands ErrorCtx to 264 bytes. The TLS block layout changes —
+   tls_log_level is at a different offset in v2's TLS segment.
+   When the app accesses tls_log_level directly, it reads from the
+   old offset, which now overlaps with tls_error.message[]. */
+#include "v1.h"
+#include <stdio.h>
+
+int main(void) {
+    /* Set a known log level */
+    tls_log_level = 42;
+    printf("log_level = %d (expected 42)\n", tls_log_level);
+
+    /* Now set an error — in v2, the expanded message buffer may
+       overwrite the old tls_log_level offset */
+    logger_set_error(404, "resource not found");
+
+    printf("error code = %d (expected 404)\n", logger_get_error_code());
+    printf("error msg  = \"%s\"\n", logger_get_error_message());
+    printf("log_level  = %d (expected 42)\n", tls_log_level);
+
+    if (tls_log_level != 42) {
+        printf("CORRUPTION: TLS variable layout shifted — "
+               "tls_log_level overwritten by expanded tls_error!\n");
+        return 1;
+    }
+    return 0;
+}

--- a/examples/case67_tls_var_size_changed/app.c
+++ b/examples/case67_tls_var_size_changed/app.c
@@ -1,27 +1,28 @@
-/* DEMO: app compiled against v1 (ErrorCtx is 68 bytes).
-   v2 expands ErrorCtx to 264 bytes. The TLS block layout changes —
-   tls_log_level is at a different offset in v2's TLS segment.
-   When the app accesses tls_log_level directly, it reads from the
-   old offset, which now overlaps with tls_error.message[]. */
+/* DEMO: app compiled against v1 where tls_error.message is at offset 4.
+   v2 inserts a 'severity' field at offset 4, pushing message to offset 8.
+   The app reads tls_error.message at offset 4 (v1 layout) but v2 wrote
+   the severity integer there — the app gets garbage instead of the string. */
 #include "v1.h"
 #include <stdio.h>
+#include <string.h>
 
 int main(void) {
-    /* Set a known log level */
-    tls_log_level = 42;
-    printf("log_level = %d (expected 42)\n", tls_log_level);
+    /* Library sets error using v2 layout */
+    logger_set_error(404, "not found");
 
-    /* Now set an error — in v2, the expanded message buffer may
-       overwrite the old tls_log_level offset */
-    logger_set_error(404, "resource not found");
+    /* Read error code via library function — works fine */
+    int code = logger_get_error_code();
+    printf("error code = %d (expected 404)\n", code);
 
-    printf("error code = %d (expected 404)\n", logger_get_error_code());
-    printf("error msg  = \"%s\"\n", logger_get_error_message());
-    printf("log_level  = %d (expected 42)\n", tls_log_level);
+    /* Read message directly using v1 compiled layout.
+       v1: message is at offset 4 (immediately after code)
+       v2: severity=3 is at offset 4, message is at offset 8
+       The app reads offset 4 as a char[] and gets the severity int bytes. */
+    printf("message = \"%s\" (expected \"not found\")\n", tls_error.message);
 
-    if (tls_log_level != 42) {
-        printf("CORRUPTION: TLS variable layout shifted — "
-               "tls_log_level overwritten by expanded tls_error!\n");
+    if (strcmp(tls_error.message, "not found") != 0) {
+        printf("CORRUPTION: TLS struct layout changed — app reads v1 offset "
+               "but library wrote v2 layout!\n");
         return 1;
     }
     return 0;

--- a/examples/case67_tls_var_size_changed/v1.c
+++ b/examples/case67_tls_var_size_changed/v1.c
@@ -1,0 +1,19 @@
+#include "v1.h"
+#include <string.h>
+
+__thread ErrorCtx tls_error = {0, ""};
+__thread int      tls_log_level = 0;
+
+void logger_set_error(int code, const char *msg) {
+    tls_error.code = code;
+    strncpy(tls_error.message, msg, sizeof(tls_error.message) - 1);
+    tls_error.message[sizeof(tls_error.message) - 1] = '\0';
+}
+
+int logger_get_error_code(void) {
+    return tls_error.code;
+}
+
+const char *logger_get_error_message(void) {
+    return tls_error.message;
+}

--- a/examples/case67_tls_var_size_changed/v1.c
+++ b/examples/case67_tls_var_size_changed/v1.c
@@ -2,7 +2,6 @@
 #include <string.h>
 
 __thread ErrorCtx tls_error = {0, ""};
-__thread int      tls_log_level = 0;
 
 void logger_set_error(int code, const char *msg) {
     tls_error.code = code;
@@ -12,8 +11,4 @@ void logger_set_error(int code, const char *msg) {
 
 int logger_get_error_code(void) {
     return tls_error.code;
-}
-
-const char *logger_get_error_message(void) {
-    return tls_error.message;
 }

--- a/examples/case67_tls_var_size_changed/v1.h
+++ b/examples/case67_tls_var_size_changed/v1.h
@@ -3,15 +3,14 @@
 
 /* Thread-local error context — each thread gets its own copy */
 typedef struct ErrorCtx {
-    int   code;
-    char  message[64];
+    int   code;          /* offset 0, 4 bytes */
+    char  message[64];   /* offset 4, 64 bytes */
 } ErrorCtx;
+/* sizeof(ErrorCtx) = 68 */
 
 extern __thread ErrorCtx tls_error;
-extern __thread int      tls_log_level;
 
 void logger_set_error(int code, const char *msg);
 int  logger_get_error_code(void);
-const char *logger_get_error_message(void);
 
 #endif

--- a/examples/case67_tls_var_size_changed/v1.h
+++ b/examples/case67_tls_var_size_changed/v1.h
@@ -1,0 +1,17 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+/* Thread-local error context — each thread gets its own copy */
+typedef struct ErrorCtx {
+    int   code;
+    char  message[64];
+} ErrorCtx;
+
+extern __thread ErrorCtx tls_error;
+extern __thread int      tls_log_level;
+
+void logger_set_error(int code, const char *msg);
+int  logger_get_error_code(void);
+const char *logger_get_error_message(void);
+
+#endif

--- a/examples/case67_tls_var_size_changed/v2.c
+++ b/examples/case67_tls_var_size_changed/v2.c
@@ -1,0 +1,20 @@
+#include "v2.h"
+#include <string.h>
+
+__thread ErrorCtx tls_error = {0, "", 0};
+__thread int      tls_log_level = 0;
+
+void logger_set_error(int code, const char *msg) {
+    tls_error.code = code;
+    strncpy(tls_error.message, msg, sizeof(tls_error.message) - 1);
+    tls_error.message[sizeof(tls_error.message) - 1] = '\0';
+    tls_error.source_line = 0;
+}
+
+int logger_get_error_code(void) {
+    return tls_error.code;
+}
+
+const char *logger_get_error_message(void) {
+    return tls_error.message;
+}

--- a/examples/case67_tls_var_size_changed/v2.c
+++ b/examples/case67_tls_var_size_changed/v2.c
@@ -1,20 +1,15 @@
 #include "v2.h"
 #include <string.h>
 
-__thread ErrorCtx tls_error = {0, "", 0};
-__thread int      tls_log_level = 0;
+__thread ErrorCtx tls_error = {0, 0, ""};
 
 void logger_set_error(int code, const char *msg) {
     tls_error.code = code;
+    tls_error.severity = 3;  /* new field — written at offset 4 */
     strncpy(tls_error.message, msg, sizeof(tls_error.message) - 1);
     tls_error.message[sizeof(tls_error.message) - 1] = '\0';
-    tls_error.source_line = 0;
 }
 
 int logger_get_error_code(void) {
     return tls_error.code;
-}
-
-const char *logger_get_error_message(void) {
-    return tls_error.message;
 }

--- a/examples/case67_tls_var_size_changed/v2.h
+++ b/examples/case67_tls_var_size_changed/v2.h
@@ -2,20 +2,19 @@
 #define LOGGER_H
 
 /* Thread-local error context — EXPANDED in v2.
-   message buffer grew from 64 to 256 bytes, and a new 'source_line' field
-   was added. sizeof(ErrorCtx) changes from 68 to 264 bytes.
-   This shifts tls_log_level to a different TLS offset. */
+   New 'severity' field inserted BEFORE message, shifting message offset.
+   v1 message at offset 4, v2 message at offset 8.
+   sizeof(ErrorCtx) changes from 68 to 72 bytes. */
 typedef struct ErrorCtx {
-    int   code;
-    char  message[256];   /* was 64 — now 256 */
-    int   source_line;    /* new field */
+    int   code;          /* offset 0, 4 bytes (unchanged) */
+    int   severity;      /* offset 4, 4 bytes (NEW — shifts message!) */
+    char  message[64];   /* offset 8, 64 bytes (was at offset 4) */
 } ErrorCtx;
+/* sizeof(ErrorCtx) = 72 */
 
 extern __thread ErrorCtx tls_error;
-extern __thread int      tls_log_level;
 
 void logger_set_error(int code, const char *msg);
 int  logger_get_error_code(void);
-const char *logger_get_error_message(void);
 
 #endif

--- a/examples/case67_tls_var_size_changed/v2.h
+++ b/examples/case67_tls_var_size_changed/v2.h
@@ -1,0 +1,21 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+/* Thread-local error context — EXPANDED in v2.
+   message buffer grew from 64 to 256 bytes, and a new 'source_line' field
+   was added. sizeof(ErrorCtx) changes from 68 to 264 bytes.
+   This shifts tls_log_level to a different TLS offset. */
+typedef struct ErrorCtx {
+    int   code;
+    char  message[256];   /* was 64 — now 256 */
+    int   source_line;    /* new field */
+} ErrorCtx;
+
+extern __thread ErrorCtx tls_error;
+extern __thread int      tls_log_level;
+
+void logger_set_error(int code, const char *msg);
+int  logger_get_error_code(void);
+const char *logger_get_error_message(void);
+
+#endif

--- a/examples/case68_virtual_method_added/CMakeLists.txt
+++ b/examples/case68_virtual_method_added/CMakeLists.txt
@@ -1,0 +1,7 @@
+abicheck_add_case(case68_virtual_method_added
+    V1_SOURCES v1.cpp
+    V2_SOURCES v2.cpp
+    V1_HEADERS v1.h
+    V2_HEADERS v2.h
+    PLATFORMS linux macos windows
+)

--- a/examples/case68_virtual_method_added/CMakeLists.txt
+++ b/examples/case68_virtual_method_added/CMakeLists.txt
@@ -3,5 +3,6 @@ abicheck_add_case(case68_virtual_method_added
     V2_SOURCES v2.cpp
     V1_HEADERS v1.h
     V2_HEADERS v2.h
+    APP_SOURCES app.cpp
     PLATFORMS linux macos windows
 )

--- a/examples/case68_virtual_method_added/README.md
+++ b/examples/case68_virtual_method_added/README.md
@@ -1,0 +1,143 @@
+# Case 68: Virtual Method Added to Non-Virtual Class
+
+**Category:** Class Layout / Vtable | **Verdict:** BREAKING
+
+## What breaks
+
+The `Sensor` class gains a virtual destructor and `read()` becomes virtual. This
+introduces a **vtable pointer** (`vptr`) as a hidden member at the beginning of
+the object. On x86-64, this adds 8 bytes to the object size and shifts **every
+data member** to a higher offset:
+
+| Member | v1 offset | v2 offset | Shift |
+|--------|-----------|-----------|-------|
+| *(vptr)* | — | 0 | *new* |
+| `value_` | 0 | 8 | +8 |
+| `id_` | 8 | 16 | +8 |
+| **sizeof** | **16** | **24** | **+8** |
+
+Any consumer compiled against v1 that accesses `value_` at offset 0 will instead
+read the vtable pointer — interpreting a memory address as a `double`, producing
+astronomically wrong values.
+
+## Why this matters
+
+Adding the first virtual method to a class is one of the most destructive ABI
+changes possible, because it fundamentally alters the object layout:
+
+1. **Object size increases**: `sizeof(Sensor)` grows by `sizeof(void*)`, breaking
+   stack allocation, arrays, and embedding in other structs
+2. **All fields shift**: every data member moves to accommodate the vtable pointer,
+   causing every field access to read/write the wrong memory
+3. **Construction changes**: the constructor now initializes the vtable pointer,
+   adding a hidden write that wasn't there before
+4. **Copy semantics change**: memcpy of the object must include the vtable pointer
+5. **It's a one-way door**: once virtual, removing virtuality is equally breaking
+
+This is especially common when adding:
+- A virtual destructor (for proper cleanup through base pointers)
+- A virtual method for plugin/extension APIs
+- A virtual method for testing/mocking
+
+## Code diff
+
+```cpp
+// v1: non-virtual class (no vtable pointer)
+class Sensor {
+public:
+    Sensor(int id, double initial);
+    double read() const;        // non-virtual
+    void   calibrate(double offset);
+    int    get_id() const;
+private:
+    double value_;  // offset 0
+    int    id_;     // offset 8
+};
+// sizeof(Sensor) = 16
+
+// v2: virtual methods added (vtable pointer inserted!)
+class Sensor {
+public:
+    Sensor(int id, double initial);
+    virtual ~Sensor();            // NEW virtual destructor
+    virtual double read() const;  // NOW virtual
+    void   calibrate(double offset);
+    int    get_id() const;
+private:
+    double value_;  // offset 8 (shifted!)
+    int    id_;     // offset 16 (shifted!)
+};
+// sizeof(Sensor) = 24
+```
+
+## Real Failure Demo
+
+**Severity: CRITICAL**
+
+**Scenario:** compile app against v1 (non-virtual, 16 bytes), link to v2 `.so`.
+
+```bash
+# Build old library + app
+g++ -shared -fPIC -g v1.cpp -o libsensor.so
+g++ -g app.cpp -L. -lsensor -Wl,-rpath,. -o app
+./app
+# → sensor id    = 7 (expected 7)
+# → sensor value = 98.6 (expected 98.6)
+# → sizeof(Sensor) compiled = 16
+# → local sensor = 42.0 (expected 42.0)
+
+# Swap in new library (no recompile)
+g++ -shared -fPIC -g v2.cpp -o libsensor.so
+./app
+# → sensor id    = 0 (expected 7)         ← wrong offset!
+# → sensor value = 98.6 (expected 98.6)   ← may work via function call
+# → sizeof(Sensor) compiled = 16          ← but real size is now 24!
+# → local sensor = 5.3e-308 (expected 42.0) ← reads vtable ptr as double
+# → CORRUPTION: vtable pointer insertion shifted all fields!
+```
+
+**Why CRITICAL:** Stack-allocated objects are only 16 bytes (v1 size), but v2
+needs 24 bytes. The vtable pointer write at offset 0 overwrites `value_`, and
+`value_` is written to offset 8 where `id_` was, creating a cascade of
+corruption. For heap-allocated objects returned by the library, the function
+call may work (v2 created a 24-byte object), but direct field access by the
+app uses v1 offsets and reads the wrong data.
+
+## How to fix
+
+1. **Design for virtuality from the start**: if a class might ever need virtual
+   methods, add a virtual destructor in v1 to reserve the vtable pointer slot
+2. **Use the Pimpl idiom**: hide the implementation behind a pointer to avoid
+   exposing the class layout
+3. **Use C-style opaque handles**: `typedef struct Sensor Sensor;` with factory
+   functions — sizeof is never exposed
+4. **SONAME bump**: if virtual methods must be added, bump the major version
+
+## Real-world example
+
+Qt's `QObject` has been virtual since Qt 1.0 specifically to avoid this problem.
+The Qt ABI guidelines explicitly state: "never add a virtual function to a class
+that previously had none."
+
+The KDE Frameworks ABI policy documents this as one of the "cardinal sins" of
+ABI breakage, requiring a SONAME bump if violated.
+
+The Chromium project's Blink engine has encountered this when refactoring DOM
+classes — adding virtuality to `Node` subclasses required rebuilding all
+downstream components.
+
+## abicheck detection
+
+abicheck detects this via multiple change kinds:
+- `func_virtual_added` (BREAKING) — new virtual method introduced
+- `type_size_changed` (BREAKING) — sizeof increased due to vtable pointer
+- `type_vtable_changed` (BREAKING) — vtable created where none existed
+
+The combination provides high confidence that this is a vtable-insertion break,
+not just a coincidental size change.
+
+## References
+
+- [Itanium C++ ABI §2.4 — Virtual Table Layout](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#vtable)
+- [KDE ABI Policy — Binary Compatibility Issues](https://community.kde.org/Policies/Binary_Compatibility_Issues_With_C%2B%2B)
+- [Qt ABI Stability Guidelines](https://wiki.qt.io/ABI_Stability)

--- a/examples/case68_virtual_method_added/README.md
+++ b/examples/case68_virtual_method_added/README.md
@@ -45,27 +45,21 @@ This is especially common when adding:
 // v1: non-virtual class (no vtable pointer)
 class Sensor {
 public:
-    Sensor(int id, double initial);
-    double read() const;        // non-virtual
-    void   calibrate(double offset);
-    int    get_id() const;
-private:
     double value_;  // offset 0
     int    id_;     // offset 8
+    Sensor(int id, double initial);
+    double read() const;        // non-virtual
 };
 // sizeof(Sensor) = 16
 
 // v2: virtual methods added (vtable pointer inserted!)
 class Sensor {
 public:
+    double value_;  // offset 8 (shifted!)
+    int    id_;     // offset 16 (shifted!)
     Sensor(int id, double initial);
     virtual ~Sensor();            // NEW virtual destructor
     virtual double read() const;  // NOW virtual
-    void   calibrate(double offset);
-    int    get_id() const;
-private:
-    double value_;  // offset 8 (shifted!)
-    int    id_;     // offset 16 (shifted!)
 };
 // sizeof(Sensor) = 24
 ```

--- a/examples/case68_virtual_method_added/README.md
+++ b/examples/case68_virtual_method_added/README.md
@@ -75,27 +75,26 @@ public:
 g++ -shared -fPIC -g v1.cpp -o libsensor.so
 g++ -g app.cpp -L. -lsensor -Wl,-rpath,. -o app
 ./app
-# → sensor id    = 7 (expected 7)
-# → sensor value = 98.6 (expected 98.6)
-# → sizeof(Sensor) compiled = 16
-# → local sensor = 42.0 (expected 42.0)
+# → sizeof(Sensor) = 16 (v1=16, v2=24)
+# → id    = 7 (expected 7)
+# → value = 98.6 (expected 98.6)
 
 # Swap in new library (no recompile)
 g++ -shared -fPIC -g v2.cpp -o libsensor.so
 ./app
-# → sensor id    = 0 (expected 7)         ← wrong offset!
-# → sensor value = 98.6 (expected 98.6)   ← may work via function call
-# → sizeof(Sensor) compiled = 16          ← but real size is now 24!
-# → local sensor = 5.3e-308 (expected 42.0) ← reads vtable ptr as double
-# → CORRUPTION: vtable pointer insertion shifted all fields!
+# → sizeof(Sensor) = 16 (v1=16, v2=24)       ← app thinks 16, reality is 24
+# → id    = 1717986918 (expected 7)           ← reads value_ bytes as int!
+# → value = 0.0 (expected 98.6)              ← reads vtable pointer as double!
+# → CORRUPTION: id_ at v1 offset 8 reads v2's value_ field!
+# → CORRUPTION: value_ at v1 offset 0 reads v2's vtable pointer!
 ```
 
-**Why CRITICAL:** Stack-allocated objects are only 16 bytes (v1 size), but v2
-needs 24 bytes. The vtable pointer write at offset 0 overwrites `value_`, and
-`value_` is written to offset 8 where `id_` was, creating a cascade of
-corruption. For heap-allocated objects returned by the library, the function
-call may work (v2 created a 24-byte object), but direct field access by the
-app uses v1 offsets and reads the wrong data.
+**Why CRITICAL:** The app accesses `s->value_` at v1 offset 0, but v2 placed
+the vtable pointer there — the app reads an address as a `double`, getting 0.0
+or garbage. The app accesses `s->id_` at v1 offset 8, but v2 placed `value_`
+(98.6) there — interpreting the double's bytes as an `int` yields 1717986918.
+For heap-allocated objects the library created a 24-byte object correctly, but
+the app's direct field access uses v1 offsets and reads the wrong data.
 
 ## How to fix
 
@@ -122,13 +121,11 @@ downstream components.
 
 ## abicheck detection
 
-abicheck detects this via multiple change kinds:
-- `func_virtual_added` (BREAKING) — new virtual method introduced
-- `type_size_changed` (BREAKING) — sizeof increased due to vtable pointer
-- `type_vtable_changed` (BREAKING) — vtable created where none existed
-
-The combination provides high confidence that this is a vtable-insertion break,
-not just a coincidental size change.
+abicheck detects this primarily as `func_virtual_added` (BREAKING) — a virtual
+method was introduced to a class that previously had none. Depending on the
+analysis depth (DWARF-aware, header-aware), additional change kinds such as
+`type_size_changed` and `type_vtable_changed` may also be reported, providing
+further evidence of the vtable-insertion break.
 
 ## References
 

--- a/examples/case68_virtual_method_added/app.cpp
+++ b/examples/case68_virtual_method_added/app.cpp
@@ -1,42 +1,40 @@
 /* DEMO: app compiled against v1 (non-virtual Sensor, sizeof=16).
-   v2 adds a virtual destructor — inserting a vtable pointer at offset 0.
-   All field offsets shift by 8 bytes. The app reads value_ from offset 0
-   but gets the vtable pointer instead, interpreting it as a double. */
+   v2 adds virtual methods — inserting a vtable pointer at offset 0.
+   The app accesses value_ at offset 0 but gets the vtable pointer,
+   and accesses id_ at offset 8 but gets value_ instead. */
 #include "v1.h"
 #include <cstdio>
-#include <cstring>
+#include <cmath>
 
 extern "C" Sensor* sensor_create(int id, double initial);
-extern "C" double  sensor_read(const Sensor* s);
-extern "C" void    sensor_calibrate(Sensor* s, double offset);
+extern "C" void    sensor_destroy(Sensor* s);
 
 int main() {
-    /* v1 Sensor: [value_(8 bytes)][id_(4 bytes)][pad(4 bytes)] = 16 bytes
-       v2 Sensor: [vptr(8 bytes)][value_(8 bytes)][id_(4 bytes)][pad(4)] = 24 bytes */
+    /* Create sensor via library (v2 allocates 24 bytes with vptr) */
     Sensor* s = sensor_create(7, 98.6);
 
-    /* With v1: read() accesses value_ at offset 0 → 98.6
-       With v2 lib but v1 layout assumption: app may try to read
-       field at wrong offset */
-    double val = sensor_read(s);
-    int id = s->get_id();
+    /* Direct field access using v1 compiled offsets:
+       v1: value_ at offset 0, id_ at offset 8
+       v2: vptr at offset 0, value_ at offset 8, id_ at offset 16
+       So s->value_ (v1 offset 0) reads the vtable pointer as a double!
+       And s->id_ (v1 offset 8) reads value_ (98.6) as an int! */
+    double val = s->value_;
+    int id = s->id_;
 
-    std::printf("sensor id    = %d (expected 7)\n", id);
-    std::printf("sensor value = %.1f (expected 98.6)\n", val);
+    std::printf("sizeof(Sensor) = %zu (v1=16, v2=24)\n", sizeof(Sensor));
+    std::printf("id    = %d (expected 7)\n", id);
+    std::printf("value = %.1f (expected 98.6)\n", val);
 
-    /* Stack-allocated sensor shows the size mismatch directly */
-    std::printf("sizeof(Sensor) compiled = %zu\n", sizeof(Sensor));
-
-    /* If sizeof doesn't match, the stack layout is wrong */
-    Sensor local(3, 42.0);
-    double local_val = local.read();
-    std::printf("local sensor = %.1f (expected 42.0)\n", local_val);
-
-    if (local_val != 42.0) {
-        std::printf("CORRUPTION: vtable pointer insertion shifted all fields!\n");
-        return 1;
+    int broken = 0;
+    if (id != 7) {
+        std::printf("CORRUPTION: id_ at v1 offset 8 reads v2's value_ field!\n");
+        broken = 1;
+    }
+    if (std::fabs(val - 98.6) > 0.001) {
+        std::printf("CORRUPTION: value_ at v1 offset 0 reads v2's vtable pointer!\n");
+        broken = 1;
     }
 
-    delete s;
-    return 0;
+    sensor_destroy(s);
+    return broken;
 }

--- a/examples/case68_virtual_method_added/app.cpp
+++ b/examples/case68_virtual_method_added/app.cpp
@@ -1,0 +1,42 @@
+/* DEMO: app compiled against v1 (non-virtual Sensor, sizeof=16).
+   v2 adds a virtual destructor — inserting a vtable pointer at offset 0.
+   All field offsets shift by 8 bytes. The app reads value_ from offset 0
+   but gets the vtable pointer instead, interpreting it as a double. */
+#include "v1.h"
+#include <cstdio>
+#include <cstring>
+
+extern "C" Sensor* sensor_create(int id, double initial);
+extern "C" double  sensor_read(const Sensor* s);
+extern "C" void    sensor_calibrate(Sensor* s, double offset);
+
+int main() {
+    /* v1 Sensor: [value_(8 bytes)][id_(4 bytes)][pad(4 bytes)] = 16 bytes
+       v2 Sensor: [vptr(8 bytes)][value_(8 bytes)][id_(4 bytes)][pad(4)] = 24 bytes */
+    Sensor* s = sensor_create(7, 98.6);
+
+    /* With v1: read() accesses value_ at offset 0 → 98.6
+       With v2 lib but v1 layout assumption: app may try to read
+       field at wrong offset */
+    double val = sensor_read(s);
+    int id = s->get_id();
+
+    std::printf("sensor id    = %d (expected 7)\n", id);
+    std::printf("sensor value = %.1f (expected 98.6)\n", val);
+
+    /* Stack-allocated sensor shows the size mismatch directly */
+    std::printf("sizeof(Sensor) compiled = %zu\n", sizeof(Sensor));
+
+    /* If sizeof doesn't match, the stack layout is wrong */
+    Sensor local(3, 42.0);
+    double local_val = local.read();
+    std::printf("local sensor = %.1f (expected 42.0)\n", local_val);
+
+    if (local_val != 42.0) {
+        std::printf("CORRUPTION: vtable pointer insertion shifted all fields!\n");
+        return 1;
+    }
+
+    delete s;
+    return 0;
+}

--- a/examples/case68_virtual_method_added/app.cpp
+++ b/examples/case68_virtual_method_added/app.cpp
@@ -6,8 +6,7 @@
 #include <cstdio>
 #include <cmath>
 
-extern "C" Sensor* sensor_create(int id, double initial);
-extern "C" void    sensor_destroy(Sensor* s);
+/* sensor_create and sensor_destroy are declared in v1.h */
 
 int main() {
     /* Create sensor via library (v2 allocates 24 bytes with vptr) */

--- a/examples/case68_virtual_method_added/v1.cpp
+++ b/examples/case68_virtual_method_added/v1.cpp
@@ -1,0 +1,21 @@
+#include "v1.h"
+
+Sensor::Sensor(int id, double initial) : value_(initial), id_(id) {}
+
+double Sensor::read() const { return value_; }
+
+void Sensor::calibrate(double offset) { value_ += offset; }
+
+int Sensor::get_id() const { return id_; }
+
+extern "C" Sensor* sensor_create(int id, double initial) {
+    return new Sensor(id, initial);
+}
+
+extern "C" double sensor_read(const Sensor* s) {
+    return s->read();
+}
+
+extern "C" void sensor_calibrate(Sensor* s, double offset) {
+    s->calibrate(offset);
+}

--- a/examples/case68_virtual_method_added/v1.cpp
+++ b/examples/case68_virtual_method_added/v1.cpp
@@ -12,10 +12,6 @@ extern "C" Sensor* sensor_create(int id, double initial) {
     return new Sensor(id, initial);
 }
 
-extern "C" double sensor_read(const Sensor* s) {
-    return s->read();
-}
-
-extern "C" void sensor_calibrate(Sensor* s, double offset) {
-    s->calibrate(offset);
+extern "C" void sensor_destroy(Sensor* s) {
+    delete s;
 }

--- a/examples/case68_virtual_method_added/v1.h
+++ b/examples/case68_virtual_method_added/v1.h
@@ -2,22 +2,20 @@
 #define SENSOR_H
 
 /* Non-virtual class — no vtable pointer, sizeof = 16 bytes
-   (double value + int id, possibly with padding) */
+   Layout: [value_(8 bytes @ offset 0)] [id_(4 bytes @ offset 8)] [pad(4)] */
 class Sensor {
 public:
+    double value_;   /* offset 0,  8 bytes */
+    int    id_;      /* offset 8,  4 bytes */
+    /* + 4 bytes padding → sizeof = 16 */
+
     Sensor(int id, double initial);
     double read() const;
     void   calibrate(double offset);
     int    get_id() const;
-
-private:
-    double value_;   /* offset 0,  8 bytes */
-    int    id_;      /* offset 8,  4 bytes */
-    /* + 4 bytes padding to align to 8 → sizeof = 16 */
 };
 
 extern "C" Sensor* sensor_create(int id, double initial);
-extern "C" double  sensor_read(const Sensor* s);
-extern "C" void    sensor_calibrate(Sensor* s, double offset);
+extern "C" void    sensor_destroy(Sensor* s);
 
 #endif

--- a/examples/case68_virtual_method_added/v1.h
+++ b/examples/case68_virtual_method_added/v1.h
@@ -1,0 +1,23 @@
+#ifndef SENSOR_H
+#define SENSOR_H
+
+/* Non-virtual class — no vtable pointer, sizeof = 16 bytes
+   (double value + int id, possibly with padding) */
+class Sensor {
+public:
+    Sensor(int id, double initial);
+    double read() const;
+    void   calibrate(double offset);
+    int    get_id() const;
+
+private:
+    double value_;   /* offset 0,  8 bytes */
+    int    id_;      /* offset 8,  4 bytes */
+    /* + 4 bytes padding to align to 8 → sizeof = 16 */
+};
+
+extern "C" Sensor* sensor_create(int id, double initial);
+extern "C" double  sensor_read(const Sensor* s);
+extern "C" void    sensor_calibrate(Sensor* s, double offset);
+
+#endif

--- a/examples/case68_virtual_method_added/v2.cpp
+++ b/examples/case68_virtual_method_added/v2.cpp
@@ -1,0 +1,23 @@
+#include "v2.h"
+
+Sensor::Sensor(int id, double initial) : value_(initial), id_(id) {}
+
+Sensor::~Sensor() {}
+
+double Sensor::read() const { return value_; }
+
+void Sensor::calibrate(double offset) { value_ += offset; }
+
+int Sensor::get_id() const { return id_; }
+
+extern "C" Sensor* sensor_create(int id, double initial) {
+    return new Sensor(id, initial);
+}
+
+extern "C" double sensor_read(const Sensor* s) {
+    return s->read();
+}
+
+extern "C" void sensor_calibrate(Sensor* s, double offset) {
+    s->calibrate(offset);
+}

--- a/examples/case68_virtual_method_added/v2.cpp
+++ b/examples/case68_virtual_method_added/v2.cpp
@@ -14,10 +14,6 @@ extern "C" Sensor* sensor_create(int id, double initial) {
     return new Sensor(id, initial);
 }
 
-extern "C" double sensor_read(const Sensor* s) {
-    return s->read();
-}
-
-extern "C" void sensor_calibrate(Sensor* s, double offset) {
-    s->calibrate(offset);
+extern "C" void sensor_destroy(Sensor* s) {
+    delete s;
 }

--- a/examples/case68_virtual_method_added/v2.h
+++ b/examples/case68_virtual_method_added/v2.h
@@ -1,0 +1,24 @@
+#ifndef SENSOR_H
+#define SENSOR_H
+
+/* Virtual method added — class now has a vtable pointer!
+   sizeof grows from 16 to 24 bytes (vtable ptr inserted at offset 0).
+   All data member offsets shift by 8 bytes (pointer size on x86-64). */
+class Sensor {
+public:
+    Sensor(int id, double initial);
+    virtual ~Sensor();             /* NEW: virtual destructor */
+    virtual double read() const;   /* was non-virtual, now virtual */
+    void   calibrate(double offset);
+    int    get_id() const;
+
+private:
+    double value_;   /* was offset 0, now offset 8  (shifted by vptr) */
+    int    id_;      /* was offset 8, now offset 16 (shifted by vptr) */
+};
+
+extern "C" Sensor* sensor_create(int id, double initial);
+extern "C" double  sensor_read(const Sensor* s);
+extern "C" void    sensor_calibrate(Sensor* s, double offset);
+
+#endif

--- a/examples/case68_virtual_method_added/v2.h
+++ b/examples/case68_virtual_method_added/v2.h
@@ -2,23 +2,22 @@
 #define SENSOR_H
 
 /* Virtual method added — class now has a vtable pointer!
-   sizeof grows from 16 to 24 bytes (vtable ptr inserted at offset 0).
+   Layout: [vptr(8 bytes @ offset 0)] [value_(8 bytes @ offset 8)]
+           [id_(4 bytes @ offset 16)] [pad(4)] → sizeof = 24
    All data member offsets shift by 8 bytes (pointer size on x86-64). */
 class Sensor {
 public:
+    double value_;   /* was offset 0, now offset 8  (shifted by vptr) */
+    int    id_;      /* was offset 8, now offset 16 (shifted by vptr) */
+
     Sensor(int id, double initial);
     virtual ~Sensor();             /* NEW: virtual destructor */
     virtual double read() const;   /* was non-virtual, now virtual */
     void   calibrate(double offset);
     int    get_id() const;
-
-private:
-    double value_;   /* was offset 0, now offset 8  (shifted by vptr) */
-    int    id_;      /* was offset 8, now offset 16 (shifted by vptr) */
 };
 
 extern "C" Sensor* sensor_create(int id, double initial);
-extern "C" double  sensor_read(const Sensor* s);
-extern "C" void    sensor_calibrate(Sensor* s, double offset);
+extern "C" void    sensor_destroy(Sensor* s);
 
 #endif

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -790,7 +790,7 @@
       "abi_break": true,
       "api_break": false,
       "bad_practice": false,
-      "description": "Function calling convention changed from default to regcall \u2014 parameters passed in wrong registers (CALLING_CONVENTION_CHANGED)",
+      "description": "Function calling convention changed from default System V to ms_abi \u2014 parameters passed in wrong registers (CALLING_CONVENTION_CHANGED)",
       "expected_kinds": ["calling_convention_changed"]
     },
     "case65_symbol_version_removed": {
@@ -829,7 +829,7 @@
       "abi_break": true,
       "api_break": true,
       "bad_practice": false,
-      "description": "Thread-local variable ErrorCtx grows from 68 to 264 bytes \u2014 adjacent TLS variables shift to wrong offsets (TLS_VAR_SIZE_CHANGED)",
+      "description": "Thread-local variable ErrorCtx grows from 68 to 72 bytes due to inserted field \u2014 struct field offsets shift, causing consumers to read wrong data (TLS_VAR_SIZE_CHANGED)",
       "expected_kinds": ["tls_var_size_changed"]
     },
     "case68_virtual_method_added": {

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -766,6 +766,85 @@
       "api_break": false,
       "bad_practice": false,
       "description": "Field added to opaque struct (callers use pointer only) \u2014 layout change invisible to consumers (TYPE_FIELD_ADDED compatible)"
+    },
+    "case63_bitfield_changed": {
+      "expected": "BREAKING",
+      "category": "breaking",
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "abi_break": true,
+      "api_break": true,
+      "bad_practice": false,
+      "description": "Bitfield width changed in struct \u2014 all subsequent bitfields shift to different bit positions (FIELD_BITFIELD_CHANGED)",
+      "expected_kinds": ["field_bitfield_changed"]
+    },
+    "case64_calling_convention_changed": {
+      "expected": "BREAKING",
+      "category": "breaking",
+      "platforms": [
+        "linux"
+      ],
+      "abi_break": true,
+      "api_break": false,
+      "bad_practice": false,
+      "description": "Function calling convention changed from default to regcall \u2014 parameters passed in wrong registers (CALLING_CONVENTION_CHANGED)",
+      "expected_kinds": ["calling_convention_changed"]
+    },
+    "case65_symbol_version_removed": {
+      "expected": "BREAKING",
+      "category": "breaking",
+      "platforms": [
+        "linux"
+      ],
+      "abi_break": true,
+      "api_break": false,
+      "bad_practice": false,
+      "description": "ELF symbol version node CRYPTO_1.0 removed \u2014 old binaries linked against that version fail at load time (SYMBOL_VERSION_DEFINED_REMOVED)",
+      "expected_kinds": ["symbol_version_defined_removed"]
+    },
+    "case66_language_linkage_changed": {
+      "expected": "BREAKING",
+      "category": "breaking",
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "abi_break": true,
+      "api_break": true,
+      "bad_practice": false,
+      "description": "extern \"C\" removed from C++ functions \u2014 symbol names change from unmangled to C++ mangled (FUNC_LANGUAGE_LINKAGE_CHANGED)",
+      "expected_kinds": ["func_language_linkage_changed"]
+    },
+    "case67_tls_var_size_changed": {
+      "expected": "BREAKING",
+      "category": "breaking",
+      "platforms": [
+        "linux",
+        "macos"
+      ],
+      "abi_break": true,
+      "api_break": true,
+      "bad_practice": false,
+      "description": "Thread-local variable ErrorCtx grows from 68 to 264 bytes \u2014 adjacent TLS variables shift to wrong offsets (TLS_VAR_SIZE_CHANGED)",
+      "expected_kinds": ["tls_var_size_changed"]
+    },
+    "case68_virtual_method_added": {
+      "expected": "BREAKING",
+      "category": "breaking",
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "abi_break": true,
+      "api_break": true,
+      "bad_practice": false,
+      "description": "Virtual method added to previously non-virtual class \u2014 vtable pointer inserted, sizeof grows, all field offsets shift (FUNC_VIRTUAL_ADDED)",
+      "expected_kinds": ["func_virtual_added"]
     }
   }
 }

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -771,9 +771,7 @@
       "expected": "BREAKING",
       "category": "breaking",
       "platforms": [
-        "linux",
-        "macos",
-        "windows"
+        "linux"
       ],
       "abi_break": true,
       "api_break": true,

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -791,7 +791,8 @@
       "api_break": false,
       "bad_practice": false,
       "description": "Function calling convention changed from default System V to ms_abi \u2014 parameters passed in wrong registers (CALLING_CONVENTION_CHANGED)",
-      "expected_kinds": ["calling_convention_changed"]
+      "expected_kinds": ["calling_convention_changed"],
+      "known_gap": "GCC does not emit DW_AT_calling_convention for __attribute__((ms_abi)); detection requires Clang"
     },
     "case65_symbol_version_removed": {
       "expected": "BREAKING",

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -30,7 +30,7 @@ _VALID_CATEGORIES = frozenset(
 _VALID_VERDICTS = frozenset(
     {"BREAKING", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "NO_CHANGE", "API_BREAK"}
 )
-_EXPECTED_CASE_COUNT = 63
+_EXPECTED_CASE_COUNT = 69
 
 
 # ── _normalize_verdict ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add six new ABI breakage test cases (cases 63–68) demonstrating critical binary compatibility failures: bitfield layout changes, calling convention mismatches, symbol version removal, language linkage changes, thread-local variable size changes, and virtual method addition to non-virtual classes.

## Motivation

These cases fill gaps in the ABI test suite by covering important real-world scenarios that cause silent data corruption or load-time failures:

- **Case 63** (bitfield width change): Demonstrates how widening a bitfield shifts all subsequent fields to different bit positions, causing silent data corruption even when `sizeof` doesn't change.
- **Case 64** (calling convention change): Shows how changing from System V to Microsoft x64 ABI causes parameters to arrive in wrong registers, producing garbage results.
- **Case 65** (symbol version removal): Illustrates how removing an ELF symbol version node breaks old binaries at load time despite the symbol still existing in the table.
- **Case 66** (language linkage change): Demonstrates how removing `extern "C"` causes C++ name mangling, making symbols inaccessible to pre-built consumers.
- **Case 67** (TLS variable size change): Shows how inserting a field in a thread-local struct shifts subsequent field offsets, causing per-thread data corruption.
- **Case 68** (virtual method added): Demonstrates the most destructive ABI change—adding virtuality to a non-virtual class inserts a vtable pointer, shifting all data members and breaking direct field access.

Each case includes:
- Detailed README explaining the break mechanism and real-world impact
- Minimal v1/v2 library implementations
- Demonstration app showing the corruption/failure
- CMake build configuration
- Ground truth entries for benchmarking

## Changes

- Added `examples/case63_bitfield_changed/` with v1/v2 implementations, app, and README
- Added `examples/case64_calling_convention_changed/` with System V vs ms_abi comparison
- Added `examples/case65_symbol_version_removed/` with ELF versioning demo
- Added `examples/case66_language_linkage_changed/` with extern "C" removal scenario
- Added `examples/case67_tls_var_size_changed/` with thread-local struct layout shift
- Added `examples/case68_virtual_method_added/` with vtable pointer insertion demo
- Updated `examples/ground_truth.json` with expected verdicts for all six cases
- Updated `examples/README.md` to reference new cases

## Checklist

- [x] Tests added: Each case includes a working demo app that exhibits the breakage
- [x] `ground_truth.json` updated with expected verdicts and detection kinds
- [x] Docs provided: Comprehensive READMEs for each case explaining the mechanism and real-world impact
- [x] CMake build files added for all cases
- [x] No new Python/linting issues (all changes are C/C++ examples and JSON)

https://claude.ai/code/session_0118wadvfbp8Bdzajng74LL6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six new ABI test scenarios (cases 63–68) demonstrating breaking changes: bitfield width, calling convention, symbol versioning, language linkage, TLS size, and added virtual method.

* **Documentation**
  * Expanded catalog to 69 cases with detailed READMEs, failure demos, detection notes, and mitigation guidance for each new scenario.

* **Tests**
  * Added example apps, reference verdicts, and updated unit expectation to require 69 cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->