### PR TITLE
ci(security): run pip-audit in project mode

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,9 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pip-audit bandit
-          pip install -e ".[dev]"
       - name: pip-audit
-        run: pip-audit --skip-editable
+        run: pip-audit .
       - name: bandit (high severity gate)
         run: bandit -r abicheck/ -x tests -lll
 


### PR DESCRIPTION
## Summary
- remove editable install from security job
- switch from `pip-audit --skip-editable` to `pip-audit .`

## Why
Current job audits the full runtime environment, which includes dev transitive dependencies (e.g. `pygments` via `pytest`/`rich`) and can fail on vulnerabilities unrelated to abicheck runtime dependencies.

`pip-audit .` audits project-declared dependencies from `pyproject.toml`, which is the intended gate for this job.

## Validation
- local `pip-audit .` => no known vulnerabilities
- bandit step remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security workflow dependencies and vulnerability scanning configuration to streamline the continuous integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->