### PR TITLE
fix: benchmark FP/FN — verdict inflation, inline-namespace detection, verdict parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,20 @@ print(len(result.changes))  # number of detected changes
 
 ---
 
+## Validation snapshot (abicheck)
+
+Latest benchmark snapshot (see full methodology in docs):
+
+- **abicheck `compare`**: **42/42** on representative benchmark cases
+- **abicheck `compat`**: **40/42** (ABICC-compatible verdict vocabulary)
+- **abicheck `strict`**: **31/42** (intentional strict-policy promotion)
+- Full `examples/` suite: **63/63** cases pass for abicheck
+
+Details, caveats, and cross-tool analysis:
+- [Benchmark & Tool Comparison](https://napetrov.github.io/abicheck/reference/tool-comparison/)
+
+---
+
 ## Documentation
 
 Full documentation is available at **[napetrov.github.io/abicheck](https://napetrov.github.io/abicheck/)**.

--- a/README.md
+++ b/README.md
@@ -423,22 +423,24 @@ print(len(result.changes))  # number of detected changes
 
 ## Validation snapshot (abicheck)
 
-### Full examples coverage
-- **74/74** published examples are covered by abicheck and validated in CI.
-- Details: [`examples/README.md`](examples/README.md)
+All numbers below are computed on the **full 74-case catalog** (`01–73` + `26b`).
 
-### Benchmark characteristics (representative 42-case subset)
-
-| Mode | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
+| Configuration | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
 |---|---:|---:|---:|---:|
-| `compare` | 42 | **42/42 (100%)** | 0 | 0 |
-| `compat` | 42 | **40/42 (95%)** | 0 | 2 |
-| `strict` (`--strict-mode full`) | 42 | **31/42 (73%)** | 9 | 0 |
+| `abicheck compare` | 74 | **69/74 (93%)** | 0 | 1 |
+| `abicheck compat` | 74 | **68/74 (92%)** | 0 | 1 |
+| `abicheck strict` (`--strict-mode full`) | 74 | **61/74 (82%)** | 6 | 1 |
+| `abidiff` | 74 | **23/74 (31%)** | 0 | 39 |
+| `abidiff + headers` | 74 | **23/74 (31%)** | 0 | 39 |
 
-\* FP/FN here are for **breaking-signal detection** (`BREAKING` + `API_BREAK` treated as positive).
+\* FP/FN are for breaking-signal detection (`BREAKING` + `API_BREAK` treated as positive).
 
-Full methodology and cross-tool details:
+Source run:
+- `python3 scripts/benchmark_comparison.py --tools abicheck abicheck_compat abicheck_strict abidiff abidiff_headers`
+
+Per-case matrix and methodology:
 - [Benchmark & Tool Comparison](https://napetrov.github.io/abicheck/reference/tool-comparison/)
+- [examples/README.md](examples/README.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -423,14 +423,21 @@ print(len(result.changes))  # number of detected changes
 
 ## Validation snapshot (abicheck)
 
-Latest benchmark snapshot (see full methodology in docs):
+### Full examples coverage
+- **74/74** published examples are covered by abicheck and validated in CI.
+- Details: [`examples/README.md`](examples/README.md)
 
-- **abicheck `compare`**: **42/42** on representative benchmark cases
-- **abicheck `compat`**: **40/42** (ABICC-compatible verdict vocabulary)
-- **abicheck `strict`**: **31/42** (intentional strict-policy promotion)
-- Full `examples/` suite: **63/63** cases pass for abicheck
+### Benchmark characteristics (representative 42-case subset)
 
-Details, caveats, and cross-tool analysis:
+| Mode | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
+|---|---:|---:|---:|---:|
+| `compare` | 42 | **42/42 (100%)** | 0 | 0 |
+| `compat` | 42 | **40/42 (95%)** | 0 | 2 |
+| `strict` (`--strict-mode full`) | 42 | **31/42 (73%)** | 9 | 0 |
+
+\* FP/FN here are for **breaking-signal detection** (`BREAKING` + `API_BREAK` treated as positive).
+
+Full methodology and cross-tool details:
 - [Benchmark & Tool Comparison](https://napetrov.github.io/abicheck/reference/tool-comparison/)
 
 ---

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -212,9 +212,11 @@ def compare(
     verdict = policy_file.compute_verdict(all_unsuppressed) if policy_file is not None else compute_verdict(all_unsuppressed, policy=policy)
     effective_policy = policy_file.base_policy if policy_file is not None else policy
 
-    # Keep opaque-filtered changes available for audit/UI (show-redundant),
-    # but never let them influence verdict computation.
+    # opaque_filtered changes are visible under --show-redundant for audit, but their
+    # label in the reporter is distinct from true display-dedup redundant changes.
+    # redundant_count reflects only the display-dedup set; opaque_filtered is additive.
     redundant_for_report = redundant + opaque_filtered
+    true_redundant_count = len(redundant)  # dedup-only (not opaque); used for report label
 
     # Compute old_symbol_count once for downstream metrics (Bug 8)
     old_sym_count = sum(
@@ -241,7 +243,7 @@ def compare(
         policy=effective_policy,
         policy_file=policy_file,
         redundant_changes=redundant_for_report,
-        redundant_count=len(redundant_for_report),
+        redundant_count=true_redundant_count,
         old_symbol_count=old_sym_count if old_sym_count > 0 else None,
         confidence=confidence,
         evidence_tiers=evidence_tiers,

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -202,12 +202,19 @@ def compare(
     pp_ctx = DEFAULT_PIPELINE.run(changes, old, new, suppression=suppression)
     kept = pp_ctx.kept
     redundant = pp_ctx.redundant
+    opaque_filtered = pp_ctx.opaque_filtered
     suppressed = pp_ctx.suppressed
 
-    # Verdict computed on all unsuppressed changes (kept + redundant)
+    # Verdict computed on unsuppressed semantic changes.
+    # NOTE: opaque_filtered changes are intentionally excluded from verdict
+    # (they are compatibility-preserving noise, e.g. opaque handle size drift).
     all_unsuppressed = kept + redundant
     verdict = policy_file.compute_verdict(all_unsuppressed) if policy_file is not None else compute_verdict(all_unsuppressed, policy=policy)
     effective_policy = policy_file.base_policy if policy_file is not None else policy
+
+    # Keep opaque-filtered changes available for audit/UI (show-redundant),
+    # but never let them influence verdict computation.
+    redundant_for_report = redundant + opaque_filtered
 
     # Compute old_symbol_count once for downstream metrics (Bug 8)
     old_sym_count = sum(
@@ -233,8 +240,8 @@ def compare(
         detector_results=detector_results,
         policy=effective_policy,
         policy_file=policy_file,
-        redundant_changes=redundant,
-        redundant_count=len(redundant),
+        redundant_changes=redundant_for_report,
+        redundant_count=len(redundant_for_report),
         old_symbol_count=old_sym_count if old_sym_count > 0 else None,
         confidence=confidence,
         evidence_tiers=evidence_tiers,

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -854,6 +854,18 @@ def _diff_inline_namespace(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # Anchored to :: on both sides to avoid matching inside identifiers.
     _INLINE_NS_RE = re.compile(r'::(?:__)?(?:v)?\d+::')
 
+    from .demangle import demangle_batch
+
+    # In elf_only mode Function.name may still be mangled; demangle in batch to
+    # make namespace-move detection robust across dump modes.
+    _all_mangled = [m for m in (removed | added) if m.startswith("_Z")]
+    _demangled = demangle_batch(_all_mangled)
+
+    def _func_name_for_matching(mangled: str, func_name: str) -> str:
+        if "::" in func_name:
+            return func_name
+        return _demangled.get(mangled, func_name)
+
     def _strip_inline_ns(name: str) -> str:
         return _INLINE_NS_RE.sub("::", name)
 
@@ -862,17 +874,20 @@ def _diff_inline_namespace(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     removed_by_stripped: dict[str, list[str]] = {}
     for m in removed:
         f = old_map[m]
-        stripped = _strip_inline_ns(f.name)
+        match_name = _func_name_for_matching(m, f.name)
+        stripped = _strip_inline_ns(match_name)
         removed_by_stripped.setdefault(stripped, []).append(m)
 
     matched_count = 0
     for m in added:
         f = new_map[m]
-        stripped = _strip_inline_ns(f.name)
+        new_name = _func_name_for_matching(m, f.name)
+        stripped = _strip_inline_ns(new_name)
         if stripped in removed_by_stripped:
             # Only count as a move if at least one side had an inline namespace
-            old_name = old_map[removed_by_stripped[stripped][0]].name
-            if stripped != f.name or stripped != old_name:
+            old_m = removed_by_stripped[stripped][0]
+            old_name = _func_name_for_matching(old_m, old_map[old_m].name)
+            if stripped != new_name or stripped != old_name:
                 matched_count += 1
 
     # Only emit if we find a pattern of namespace-version moves (2+ symbols)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1296,6 +1296,7 @@ def _dump_elf(
         snapshot = AbiSnapshot(
             library=so_path.name,
             version=version,
+            source_path=str(so_path),
             functions=[
                 Function(
                     name=sym,
@@ -1336,6 +1337,7 @@ def _dump_elf(
     snapshot = AbiSnapshot(
         library=so_path.name,
         version=version,
+        source_path=str(so_path),
         functions=parser.parse_functions(),
         variables=parser.parse_variables(),
         types=parser.parse_types(),
@@ -1416,6 +1418,7 @@ def _dump_macho(
         return AbiSnapshot(
             library=dylib_path.name,
             version=version,
+            source_path=str(dylib_path),
             functions=[
                 Function(
                     name=_normalize_macho_sym(exp.name),
@@ -1465,6 +1468,7 @@ def _dump_macho(
     return AbiSnapshot(
         library=dylib_path.name,
         version=version,
+        source_path=str(dylib_path),
         functions=parser.parse_functions(),
         variables=parser.parse_variables(),
         types=parser.parse_types(),
@@ -1518,6 +1522,7 @@ def _dump_pe(
         return AbiSnapshot(
             library=dll_path.name,
             version=version,
+            source_path=str(dll_path),
             functions=[
                 Function(
                     name=sym, mangled=sym, return_type="?",
@@ -1542,6 +1547,7 @@ def _dump_pe(
     return AbiSnapshot(
         library=dll_path.name,
         version=version,
+        source_path=str(dll_path),
         functions=parser.parse_functions(),
         variables=parser.parse_variables(),
         types=parser.parse_types(),

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -142,6 +142,13 @@ class AdvancedDwarfMetadata:
     # A change from "rbp" (frame-pointer) to "rsp" (stack-pointer) or vice-versa
     # indicates a calling-convention / frame-layout drift (#117).
     frame_registers: dict[str, str] = field(default_factory=dict)
+    # linkage_name → frozenset of callee-saved register names for exported functions.
+    # Derived from CFI DW_CFA_offset / DW_CFA_rel_offset rules in the function prologue.
+    # On x86-64 SysV ABI the callee-saved set is {rbx,rbp,r12-r15}.
+    # On x86-64 ms_abi (Windows x64) it additionally includes {rdi,rsi,r10,r11}.
+    # Presence of rdi/rsi in the saved-registers set is a strong ELF-level signal
+    # that the function uses ms_abi, even when DW_AT_calling_convention is absent (GCC gap).
+    callee_saved_regs: dict[str, frozenset[str]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -697,12 +704,19 @@ def _extract_cfa_reg_from_fde(entry: Any, arch_key: str) -> str | None:
 
 
 def _parse_frame_registers(elf: Any, dwarf: Any, meta: AdvancedDwarfMetadata) -> None:
-    """Extract CFA register convention for exported functions from .eh_frame (#117).
+    """Extract CFA register convention + callee-saved regs for exported functions.
 
-    For each FDE (Frame Description Entry) in .eh_frame (or .debug_frame as fallback),
-    records the dominant post-prologue CFA register for each exported function.
-    When the CFA register changes between versions, it indicates a frame-pointer
-    convention change (e.g., rbp → rsp from -fomit-frame-pointer).
+    For each FDE in .eh_frame / .debug_frame:
+    - Records the dominant CFA register (frame_registers): rbp/rsp drift.
+    - Records callee-saved register fingerprint (callee_saved_regs): the set of
+      registers spilled in the prologue via DW_CFA_offset/DW_CFA_rel_offset.
+
+    Callee-saved fingerprint heuristic for calling-convention detection:
+      x86-64 SysV ABI  callee-saved: rbx, rbp, r12–r15
+      x86-64 ms_abi    callee-saved: rbx, rbp, rdi, rsi, r12–r15, xmm6–xmm15
+    Presence of rdi or rsi in the saved-register set is a reliable ELF-level
+    signal that the function uses ms_abi even when DW_AT_calling_convention is
+    absent (GCC does not emit this attribute for __attribute__((ms_abi))).
 
     Graceful: any parsing error is logged/skipped. Never raises.
     """
@@ -724,11 +738,41 @@ def _parse_frame_registers(elf: Any, dwarf: Any, meta: AdvancedDwarfMetadata) ->
                 reg = _extract_cfa_reg_from_fde(entry, arch_key)
                 if reg is not None:
                     meta.frame_registers[sym_name] = reg
+                # Extract callee-saved register fingerprint from prologue
+                saved = _extract_callee_saved_regs(entry, arch_key)
+                if saved:
+                    meta.callee_saved_regs[sym_name] = frozenset(saved)
             except (ELFError, OSError, ValueError, KeyError, IndexError) as exc:
                 log.debug("_parse_frame_registers: skipping FDE: %s", exc)
 
     except (ELFError, OSError, ValueError) as exc:
         log.warning("_parse_frame_registers: failed: %s", exc)
+
+
+def _extract_callee_saved_regs(entry: Any, arch_key: str) -> frozenset[str]:
+    """Extract the set of register names saved in the function prologue.
+
+    Uses DW_CFA_offset and DW_CFA_rel_offset rules (register is spilled to stack)
+    to identify callee-saved registers.  Returns frozenset of register name strings.
+    """
+    try:
+        decoded = entry.get_decoded()
+        if not decoded.table:
+            return frozenset()
+
+        saved: set[str] = set()
+        for row in decoded.table:
+            for reg_key, rule in row.items():
+                if reg_key in ("pc", "cfa"):
+                    continue
+                # rule is an object with .type; "offset" means register is saved
+                rule_type = getattr(rule, "type", None)
+                if rule_type and str(rule_type).lower() in ("offset", "reg_rule_offset"):
+                    if isinstance(reg_key, int):
+                        saved.add(_reg_name(reg_key, arch_key))
+        return frozenset(saved)
+    except Exception:  # noqa: BLE001
+        return frozenset()
 
 
 def _parse_producer(producer: str) -> ToolchainInfo:
@@ -792,7 +836,32 @@ def diff_advanced_dwarf(
                 old_cc, new_cc,
             ))
 
-    # 1b. Value-ABI trait drift (DWARF-based heuristic for platforms where
+    # 1b. ELF CFI callee-saved fingerprint drift.
+    # Fallback for GCC/Linux where DW_AT_calling_convention is often omitted:
+    # compare saved-register sets extracted from .eh_frame/.debug_frame.
+    old_saved_keys = set(old_meta.callee_saved_regs)
+    new_saved_keys = set(new_meta.callee_saved_regs)
+    already_reported_cc = {fname for fname in (old_cc_keys & new_cc_keys)
+                           if old_meta.calling_conventions[fname] != new_meta.calling_conventions[fname]}
+    for fname in sorted((old_saved_keys & new_saved_keys) - already_reported_cc):
+        old_saved = old_meta.callee_saved_regs[fname]
+        new_saved = new_meta.callee_saved_regs[fname]
+        if old_saved != new_saved:
+            # Strong x86-64 indicator: rdi/rsi becoming callee-saved implies ms_abi.
+            old_has_ms_hint = any(r in old_saved for r in ("rdi", "rsi", "edi", "esi"))
+            new_has_ms_hint = any(r in new_saved for r in ("rdi", "rsi", "edi", "esi"))
+            hint = ""
+            if old_has_ms_hint != new_has_ms_hint:
+                hint = " (ms_abi/sysv_abi drift inferred from CFI saved regs)"
+            results.append((
+                "calling_convention_changed", fname,
+                f"Calling convention changed (ELF CFI fallback): {fname} "
+                f"(saved regs: {sorted(old_saved)} → {sorted(new_saved)}){hint}",
+                ",".join(sorted(old_saved)), ",".join(sorted(new_saved)),
+            ))
+            already_reported_cc.add(fname)
+
+    # 1c. Value-ABI trait drift (DWARF-based heuristic for platforms where
     # DW_AT_calling_convention is not emitted, e.g. Linux x86-64 System V AMD64).
     #
     # On x86-64 SysV ABI, whether an aggregate is passed by value in registers
@@ -805,8 +874,6 @@ def diff_advanced_dwarf(
     #
     # Deduplication: skip if calling_convention_changed already fired for this function
     # (explicit DW_AT_calling_convention change is more authoritative).
-    already_reported_cc = {fname for fname in (old_cc_keys & new_cc_keys)
-                           if old_meta.calling_conventions[fname] != new_meta.calling_conventions[fname]}
     old_trait_keys = set(old_meta.value_abi_traits)
     new_trait_keys = set(new_meta.value_abi_traits)
     for fname in sorted((old_trait_keys & new_trait_keys) - already_reported_cc):

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -847,16 +847,23 @@ def diff_advanced_dwarf(
         old_saved = old_meta.callee_saved_regs[fname]
         new_saved = new_meta.callee_saved_regs[fname]
         if old_saved != new_saved:
-            # Strong x86-64 indicator: rdi/rsi becoming callee-saved implies ms_abi.
-            old_has_ms_hint = any(r in old_saved for r in ("rdi", "rsi", "edi", "esi"))
-            new_has_ms_hint = any(r in new_saved for r in ("rdi", "rsi", "edi", "esi"))
-            hint = ""
-            if old_has_ms_hint != new_has_ms_hint:
-                hint = " (ms_abi/sysv_abi drift inferred from CFI saved regs)"
+            # Only emit calling_convention_changed when ABI-distinguishing marker
+            # registers change.  On x86-64: rdi/rsi are callee-saved in ms_abi
+            # but caller-saved in SysV ABI — their appearance/disappearance is a
+            # reliable signal of calling-convention drift.  Ordinary
+            # register-allocation churn (rbx, r12–r15, etc.) that is present in
+            # *both* sides should not produce a false positive.
+            _MS_ABI_MARKERS = frozenset(("rdi", "rsi", "edi", "esi"))
+            old_has_ms_hint = bool(old_saved & _MS_ABI_MARKERS)
+            new_has_ms_hint = bool(new_saved & _MS_ABI_MARKERS)
+            if old_has_ms_hint == new_has_ms_hint:
+                # No ABI-marker change — register-allocation noise, skip.
+                continue
             results.append((
                 "calling_convention_changed", fname,
                 f"Calling convention changed (ELF CFI fallback): {fname} "
-                f"(saved regs: {sorted(old_saved)} → {sorted(new_saved)}){hint}",
+                f"(saved regs: {sorted(old_saved)} → {sorted(new_saved)}) "
+                f"(ms_abi/sysv_abi drift inferred from CFI saved regs)",
                 ",".join(sorted(old_saved)), ",".join(sorted(new_saved)),
             ))
             already_reported_cc.add(fname)

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -740,8 +740,8 @@ def _parse_frame_registers(elf: Any, dwarf: Any, meta: AdvancedDwarfMetadata) ->
                     meta.frame_registers[sym_name] = reg
                 # Extract callee-saved register fingerprint from prologue
                 saved = _extract_callee_saved_regs(entry, arch_key)
-                if saved:
-                    meta.callee_saved_regs[sym_name] = frozenset(saved)
+                if saved is not None:
+                    meta.callee_saved_regs[sym_name] = saved
             except (ELFError, OSError, ValueError, KeyError, IndexError) as exc:
                 log.debug("_parse_frame_registers: skipping FDE: %s", exc)
 
@@ -749,11 +749,15 @@ def _parse_frame_registers(elf: Any, dwarf: Any, meta: AdvancedDwarfMetadata) ->
         log.warning("_parse_frame_registers: failed: %s", exc)
 
 
-def _extract_callee_saved_regs(entry: Any, arch_key: str) -> frozenset[str]:
+def _extract_callee_saved_regs(entry: Any, arch_key: str) -> frozenset[str] | None:
     """Extract the set of register names saved in the function prologue.
 
     Uses DW_CFA_offset and DW_CFA_rel_offset rules (register is spilled to stack)
-    to identify callee-saved registers.  Returns frozenset of register name strings.
+    to identify callee-saved registers.
+
+    Returns:
+    - frozenset[str] on successful decode (including empty set), or
+    - None when decoding failed and no trustworthy data is available.
     """
     try:
         decoded = entry.get_decoded()
@@ -772,7 +776,7 @@ def _extract_callee_saved_regs(entry: Any, arch_key: str) -> frozenset[str]:
                         saved.add(_reg_name(reg_key, arch_key))
         return frozenset(saved)
     except Exception:  # noqa: BLE001
-        return frozenset()
+        return None
 
 
 def _parse_producer(producer: str) -> ToolchainInfo:
@@ -853,7 +857,7 @@ def diff_advanced_dwarf(
             # reliable signal of calling-convention drift.  Ordinary
             # register-allocation churn (rbx, r12–r15, etc.) that is present in
             # *both* sides should not produce a false positive.
-            _MS_ABI_MARKERS = frozenset(("rdi", "rsi", "edi", "esi"))
+            _MS_ABI_MARKERS = frozenset(("rdi", "rsi"))
             old_has_ms_hint = bool(old_saved & _MS_ABI_MARKERS)
             new_has_ms_hint = bool(new_saved & _MS_ABI_MARKERS)
             if old_has_ms_hint == new_has_ms_hint:

--- a/abicheck/dwarf_advanced.py
+++ b/abicheck/dwarf_advanced.py
@@ -809,25 +809,12 @@ def _parse_producer(producer: str) -> ToolchainInfo:
 # Diff (called from checker.py _diff_advanced_dwarf)
 # ---------------------------------------------------------------------------
 
-def diff_advanced_dwarf(
+def _diff_calling_conventions(
     old_meta: AdvancedDwarfMetadata,
     new_meta: AdvancedDwarfMetadata,
-) -> list[tuple[str, str, str, str | None, str | None]]:
-    """Return (kind, symbol, description, old_value, new_value) tuples.
-
-    Returns [] gracefully if either side has no DWARF.
-    """
-    if not old_meta.has_dwarf or not new_meta.has_dwarf:
-        return []
-
+) -> tuple[list[tuple[str, str, str, str | None, str | None]], set[str]]:
+    """Diff explicit DW_AT_calling_convention. Returns (results, already_reported_cc)."""
     results: list[tuple[str, str, str, str | None, str | None]] = []
-
-    # 1. Calling convention drift (explicit DW_AT_calling_convention).
-    # calling_conventions now stores ALL external functions (including "normal"),
-    # so we can distinguish "CC changed" from "function added/removed".
-    # Functions present only in old → removed (handled by ELF checker, skip here).
-    # Functions present only in new → added (skip; new additions are COMPATIBLE by default).
-    # Functions present in both → compare CC values.
     old_cc_keys = set(old_meta.calling_conventions)
     new_cc_keys = set(new_meta.calling_conventions)
     for fname in sorted(old_cc_keys & new_cc_keys):
@@ -839,29 +826,29 @@ def diff_advanced_dwarf(
                 f"Calling convention changed: {fname} ({old_cc} → {new_cc})",
                 old_cc, new_cc,
             ))
-
-    # 1b. ELF CFI callee-saved fingerprint drift.
-    # Fallback for GCC/Linux where DW_AT_calling_convention is often omitted:
-    # compare saved-register sets extracted from .eh_frame/.debug_frame.
-    old_saved_keys = set(old_meta.callee_saved_regs)
-    new_saved_keys = set(new_meta.callee_saved_regs)
     already_reported_cc = {fname for fname in (old_cc_keys & new_cc_keys)
                            if old_meta.calling_conventions[fname] != new_meta.calling_conventions[fname]}
+    return results, already_reported_cc
+
+
+def _diff_callee_saved_regs(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+    already_reported_cc: set[str],
+) -> tuple[list[tuple[str, str, str, str | None, str | None]], set[str]]:
+    """Diff ELF CFI callee-saved fingerprint. Returns (results, updated already_reported_cc)."""
+    results: list[tuple[str, str, str, str | None, str | None]] = []
+    old_saved_keys = set(old_meta.callee_saved_regs)
+    new_saved_keys = set(new_meta.callee_saved_regs)
+    already_reported_cc = set(already_reported_cc)
+    _MS_ABI_MARKERS = frozenset(("rdi", "rsi"))
     for fname in sorted((old_saved_keys & new_saved_keys) - already_reported_cc):
         old_saved = old_meta.callee_saved_regs[fname]
         new_saved = new_meta.callee_saved_regs[fname]
         if old_saved != new_saved:
-            # Only emit calling_convention_changed when ABI-distinguishing marker
-            # registers change.  On x86-64: rdi/rsi are callee-saved in ms_abi
-            # but caller-saved in SysV ABI — their appearance/disappearance is a
-            # reliable signal of calling-convention drift.  Ordinary
-            # register-allocation churn (rbx, r12–r15, etc.) that is present in
-            # *both* sides should not produce a false positive.
-            _MS_ABI_MARKERS = frozenset(("rdi", "rsi"))
             old_has_ms_hint = bool(old_saved & _MS_ABI_MARKERS)
             new_has_ms_hint = bool(new_saved & _MS_ABI_MARKERS)
             if old_has_ms_hint == new_has_ms_hint:
-                # No ABI-marker change — register-allocation noise, skip.
                 continue
             results.append((
                 "calling_convention_changed", fname,
@@ -871,20 +858,16 @@ def diff_advanced_dwarf(
                 ",".join(sorted(old_saved)), ",".join(sorted(new_saved)),
             ))
             already_reported_cc.add(fname)
+    return results, already_reported_cc
 
-    # 1c. Value-ABI trait drift (DWARF-based heuristic for platforms where
-    # DW_AT_calling_convention is not emitted, e.g. Linux x86-64 System V AMD64).
-    #
-    # On x86-64 SysV ABI, whether an aggregate is passed by value in registers
-    # or by hidden pointer depends on its triviality (Itanium C++ ABI §3.1.2):
-    # - trivially-destructible (no user-defined dtor): may use registers
-    # - non-trivially-destructible (has user-defined dtor): passed by pointer
-    #
-    # We detect this by comparing the per-function value-ABI trait fingerprint
-    # (return-type + parameter triviality) between versions.
-    #
-    # Deduplication: skip if calling_convention_changed already fired for this function
-    # (explicit DW_AT_calling_convention change is more authoritative).
+
+def _diff_value_abi_traits(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+    already_reported_cc: set[str],
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Diff DWARF value-ABI trait fingerprints. Returns results list."""
+    results: list[tuple[str, str, str, str | None, str | None]] = []
     old_trait_keys = set(old_meta.value_abi_traits)
     new_trait_keys = set(new_meta.value_abi_traits)
     for fname in sorted((old_trait_keys & new_trait_keys) - already_reported_cc):
@@ -896,11 +879,15 @@ def diff_advanced_dwarf(
                 f"DWARF value-ABI trait changed: {fname} ({old_trait} → {new_trait})",
                 old_trait, new_trait,
             ))
+    return results
 
-    # 2. Struct packing drift.
-    # Use all_struct_names to guard against false "packing removed" reports when
-    # the struct itself was deleted (deletion is detected by the AST/ELF checker).
-    # Guard: only report "packing removed" when struct exists in BOTH binaries.
+
+def _diff_struct_packing(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Diff struct packing attributes. Returns results list."""
+    results: list[tuple[str, str, str, str | None, str | None]] = []
     both_struct_names = old_meta.all_struct_names & new_meta.all_struct_names
     for name in sorted((old_meta.packed_structs - new_meta.packed_structs) & both_struct_names):
         results.append((
@@ -908,18 +895,21 @@ def diff_advanced_dwarf(
             f"Struct packing removed: {name} was packed, now standard layout",
             "packed", "standard",
         ))
-    # "Packing added": only report when struct existed in old binary too.
-    # A brand-new packed struct has no prior ABI contract to break — consistent
-    # with how calling-convention additions are handled (new-only functions skipped).
-    # Symmetric with packing-removed guard above.
     for name in sorted((new_meta.packed_structs - old_meta.packed_structs) & old_meta.all_struct_names):
         results.append((
             "struct_packing_changed", name,
             f"Struct packing added: {name} is now __attribute__((packed))",
             "standard", "packed",
         ))
+    return results
 
-    # 3. Toolchain ABI flag drift
+
+def _diff_toolchain_flags(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Diff ABI-affecting compiler flags. Returns results list."""
+    results: list[tuple[str, str, str, str | None, str | None]] = []
     old_flags = old_meta.toolchain.abi_flags
     new_flags = new_meta.toolchain.abi_flags
     removed_flags = old_flags - new_flags
@@ -936,10 +926,15 @@ def diff_advanced_dwarf(
             ",".join(sorted(old_flags)) or None,
             ",".join(sorted(new_flags)) or None,
         ))
+    return results
 
-    # 4. Frame register / CFA convention drift (#117)
-    # Compare the dominant CFA register for functions present in both binaries.
-    # rsp ↔ rbp transition is the canonical indicator of -fomit-frame-pointer drift.
+
+def _diff_frame_registers(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Diff frame/CFA register usage. Returns results list."""
+    results: list[tuple[str, str, str, str | None, str | None]] = []
     old_fr_keys = set(old_meta.frame_registers)
     new_fr_keys = set(new_meta.frame_registers)
     for fname in sorted(old_fr_keys & new_fr_keys):
@@ -951,8 +946,28 @@ def diff_advanced_dwarf(
                 f"Frame/CFA register changed: {fname} ({old_reg} → {new_reg})",
                 old_reg, new_reg,
             ))
-
     return results
+
+
+def diff_advanced_dwarf(
+    old_meta: AdvancedDwarfMetadata,
+    new_meta: AdvancedDwarfMetadata,
+) -> list[tuple[str, str, str, str | None, str | None]]:
+    """Return (kind, symbol, description, old_value, new_value) tuples.
+
+    Returns [] gracefully if either side has no DWARF.
+    """
+    if not old_meta.has_dwarf or not new_meta.has_dwarf:
+        return []
+
+    cc_results, already_reported_cc = _diff_calling_conventions(old_meta, new_meta)
+    csr_results, already_reported_cc = _diff_callee_saved_regs(old_meta, new_meta, already_reported_cc)
+    trait_results = _diff_value_abi_traits(old_meta, new_meta, already_reported_cc)
+    pack_results = _diff_struct_packing(old_meta, new_meta)
+    flag_results = _diff_toolchain_flags(old_meta, new_meta)
+    frame_results = _diff_frame_registers(old_meta, new_meta)
+
+    return cc_results + csr_results + trait_results + pack_results + flag_results + frame_results
 
 
 # ---------------------------------------------------------------------------

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -241,6 +241,9 @@ class AbiSnapshot:
     """Complete ABI snapshot of one version of a library."""
     library: str                   # e.g. "libfoo.so.1"
     version: str                   # e.g. "1.2.3"
+    # Optional on-disk artifact path that produced this snapshot.
+    # Used by binary-only fallback detectors that need lightweight disassembly.
+    source_path: str | None = None
     functions: list[Function] = field(default_factory=list)
     variables: list[Variable] = field(default_factory=list)
     types: list[RecordType] = field(default_factory=list)

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -276,7 +276,7 @@ class AbiSnapshot:
     # Optional on-disk artifact path that produced this snapshot.
     # Keyword-only (placed after all other fields) to prevent accidental positional binding.
     # Used by binary-only fallback detectors that need lightweight disassembly.
-    source_path: str | None = None
+    source_path: str | None = field(default=None, kw_only=True)
 
     # Indexes (built lazily)
     _func_by_mangled: dict[str, Function] | None = field(default=None, repr=False, compare=False)

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -241,9 +241,6 @@ class AbiSnapshot:
     """Complete ABI snapshot of one version of a library."""
     library: str                   # e.g. "libfoo.so.1"
     version: str                   # e.g. "1.2.3"
-    # Optional on-disk artifact path that produced this snapshot.
-    # Used by binary-only fallback detectors that need lightweight disassembly.
-    source_path: str | None = None
     functions: list[Function] = field(default_factory=list)
     variables: list[Variable] = field(default_factory=list)
     types: list[RecordType] = field(default_factory=list)
@@ -276,6 +273,10 @@ class AbiSnapshot:
     git_tag: str | None = None      # e.g. "v2.0.0", set via --git-tag or auto-detected
     created_at: str | None = None   # ISO 8601 timestamp, auto-set at dump time
     build_id: str | None = None     # opaque CI identifier (run ID, build number, etc.)
+    # Optional on-disk artifact path that produced this snapshot.
+    # Keyword-only (placed after all other fields) to prevent accidental positional binding.
+    # Used by binary-only fallback detectors that need lightweight disassembly.
+    source_path: str | None = None
 
     # Indexes (built lazily)
     _func_by_mangled: dict[str, Function] | None = field(default=None, repr=False, compare=False)

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -220,7 +220,7 @@ class FilterRedundant:
 
         kept, redundant = _filter_redundant(changes)
         ctx.redundant.extend(redundant)
-        ctx.redundant.extend(ctx.opaque_filtered)
+        # opaque_filtered are kept separate - they are compatible changes that should not affect verdict
         ctx.kept = kept
         return kept
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -51,7 +51,7 @@ def _sets_to_lists(obj: Any) -> Any:
     dataclasses.asdict() does NOT convert set → list, so json.dumps() would
     raise TypeError. This post-processes the entire dict tree.
     """
-    if isinstance(obj, set):
+    if isinstance(obj, (set, frozenset)):
         return sorted(obj)
     if isinstance(obj, dict):
         return {k: _sets_to_lists(v) for k, v in obj.items()}
@@ -262,6 +262,8 @@ def _dwarf_advanced_from_dict(d: dict[str, Any]) -> Any:
         value_abi_traits=d.get("value_abi_traits", {}),
         packed_structs=set(d.get("packed_structs", [])),
         all_struct_names=set(d.get("all_struct_names", [])),
+        frame_registers=d.get("frame_registers", {}),
+        callee_saved_regs={k: frozenset(v) for k, v in d.get("callee_saved_regs", {}).items()},
     )
 
 
@@ -413,6 +415,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
 
     return AbiSnapshot(
         library=d["library"], version=d["version"],
+        source_path=d.get("source_path"),
         functions=funcs, variables=variables, types=types,
         enums=enums, typedefs=typedefs,
         elf=elf, pe=pe, macho=macho,

--- a/examples/README.md
+++ b/examples/README.md
@@ -147,30 +147,29 @@ may keep identical runtime output for prebuilt binaries. For those, the demo sho
 
 ---
 
-## Benchmark Snapshot (63 cases, 2026-03-17)
+## Coverage & benchmark snapshot
 
-To avoid drift, this README keeps only a compact summary. Full per-case matrix and
-methodology live in docs:
-- [`../docs/benchmark_report.md`](../docs/benchmark_report.md)
-- [`../docs/tool_comparison.md`](../docs/tool_comparison.md)
+### Full examples coverage (abicheck)
 
-| Tool | Correct / Scored | Accuracy |
-|------|------------------|----------|
-| **abicheck (compare)** | **48/48** | **100%** |
-| abicheck (compat) | 46/48 | 96% |
-| abidiff | 12/48 | 25% |
-| abidiff + headers | 12/48 | 25% |
-| ABICC (xml) | 30/47 | 63% (1 timeout, 48 cases attempted) |
-| ABICC (abi-dumper) | 24/48 | 50% (12 error/timeout) |
+- The catalog currently contains **74 published cases** (`01–73` + `26b`).
+- `abicheck` has an expected verdict for **all 74/74** cases in [`ground_truth.json`](ground_truth.json).
+- CI validates this catalog via the **"Validate all examples"** job.
 
-### Why these numbers differ
+### Cross-tool benchmark subset
 
-- **`compat` < `compare`**: `compat` follows ABICC vocabulary and cannot emit `API_BREAK`
-  (`case31`, `case34`), so max is 46/48 in this suite.
-- **`abidiff` == `abidiff+headers` here**: `--headers-dir` only filters public symbols;
-  with `-fvisibility=default` in these examples, filtering does not change the set.
-- **ABICC(dumper)** missed case43 (base class member added) — classified as COMPATIBLE.
-  Reason: ABICC focuses on exported symbols, not derived class layout shifts.
+For cross-tool comparison (abicheck vs abidiff vs ABICC), we use a representative
+subset with stable scoring semantics. Full methodology and current numbers:
+
+- [`../docs/reference/tool-comparison.md`](../docs/reference/tool-comparison.md)
+
+Current documented snapshot:
+- **abicheck `compare`**: **42/42**
+- **abicheck `compat`**: **40/42**
+- **abicheck `strict`**: **31/42**
+
+> Why subset for cross-tool numbers: ABICC/libabigail comparability is tracked on
+> representative cases, while the full `examples/` catalog is used as abicheck
+> regression coverage.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -147,41 +147,33 @@ may keep identical runtime output for prebuilt binaries. For those, the demo sho
 
 ---
 
-## Coverage & benchmark snapshot
+## Coverage snapshot
 
-### Full examples coverage (abicheck)
+### Full catalog coverage (abicheck)
 
-- The catalog currently contains **74 published cases** (`01–73` + `26b`).
-- `abicheck` has an expected verdict for **all 74/74** cases in [`ground_truth.json`](ground_truth.json).
-- CI validates this catalog via the **"Validate all examples"** job.
+- Catalog size: **74 cases** (`01–73` + `26b`).
+- `ground_truth.json` contains expected verdicts for **74/74**.
+- CI job **Validate all examples** validates the whole catalog.
 
-### Cross-tool benchmark subset
+### abicheck mode characteristics (42-case benchmark subset)
 
-For cross-tool comparison (abicheck vs abidiff vs ABICC), we use a representative
-subset with stable scoring semantics. Full methodology and current numbers:
+| Mode | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
+|---|---:|---:|---:|---:|
+| `compare` | 42 | **42/42 (100%)** | 0 | 0 |
+| `compat` | 42 | **40/42 (95%)** | 0 | 2 |
+| `strict` (`--strict-mode full`) | 42 | **31/42 (73%)** | 9 | 0 |
 
+\* FP/FN are for **breaking-signal detection** (`BREAKING` + `API_BREAK` treated as positive).
+
+### abidiff quick signal (full catalog)
+
+| Tool | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
+|---|---:|---:|---:|---:|
+| `abidiff` | 74 | **23/74 (31%)** | 0 | 39 |
+| `abidiff + headers` | 74 | **23/74 (31%)** | 0 | 39 |
+
+Methodology and full per-case matrix:
 - [`../docs/reference/tool-comparison.md`](../docs/reference/tool-comparison.md)
-
-Current documented snapshot:
-- **abicheck `compare`**: **42/42**
-- **abicheck `compat`**: **40/42**
-- **abicheck `strict`**: **31/42**
-
-### Accuracy + FP/FN profile
-
-In addition to percentage accuracy, we track false positives and false negatives.
-For this section, **positive** means "breaking/API break expected" (`BREAKING` or
-`API_BREAK`).
-
-| Tool / run | Scored cases | Accuracy | False Positives | False Negatives | Notes |
-|---|---:|---:|---:|---:|---|
-| **abicheck (full catalog, CI Validate all examples)** | 74/74 | 100% | 0 | 0 | exact verdict match on all published cases |
-| abidiff (full catalog run) | 74/74 | 23/74 = 31% | 0 | 39 | full run including case65 symbol-version removal |
-| abidiff + headers (full catalog run) | 74/74 | 23/74 = 31% | 0 | 39 | same profile as abidiff in this suite |
-
-> Why subset for cross-tool numbers: ABICC/libabigail comparability is tracked on
-> representative cases, while the full `examples/` catalog is used as abicheck
-> regression coverage.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -176,8 +176,8 @@ For this section, **positive** means "breaking/API break expected" (`BREAKING` o
 | Tool / run | Scored cases | Accuracy | False Positives | False Negatives | Notes |
 |---|---:|---:|---:|---:|---|
 | **abicheck (full catalog, CI Validate all examples)** | 74/74 | 100% | 0 | 0 | exact verdict match on all published cases |
-| abidiff (full catalog run) | 73/74 | 22/73 = 30% | 0 | 39 | `case65_symbol_version_removed` compile error in benchmark script run |
-| abidiff + headers (full catalog run) | 73/74 | 22/73 = 30% | 0 | 39 | same profile as abidiff in this suite |
+| abidiff (full catalog run) | 74/74 | 23/74 = 31% | 0 | 39 | full run including case65 symbol-version removal |
+| abidiff + headers (full catalog run) | 74/74 | 23/74 = 31% | 0 | 39 | same profile as abidiff in this suite |
 
 > Why subset for cross-tool numbers: ABICC/libabigail comparability is tracked on
 > representative cases, while the full `examples/` catalog is used as abicheck

--- a/examples/README.md
+++ b/examples/README.md
@@ -167,6 +167,18 @@ Current documented snapshot:
 - **abicheck `compat`**: **40/42**
 - **abicheck `strict`**: **31/42**
 
+### Accuracy + FP/FN profile
+
+In addition to percentage accuracy, we track false positives and false negatives.
+For this section, **positive** means "breaking/API break expected" (`BREAKING` or
+`API_BREAK`).
+
+| Tool / run | Scored cases | Accuracy | False Positives | False Negatives | Notes |
+|---|---:|---:|---:|---:|---|
+| **abicheck (full catalog, CI Validate all examples)** | 74/74 | 100% | 0 | 0 | exact verdict match on all published cases |
+| abidiff (full catalog run) | 73/74 | 22/73 = 30% | 0 | 39 | `case65_symbol_version_removed` compile error in benchmark script run |
+| abidiff + headers (full catalog run) | 73/74 | 22/73 = 30% | 0 | 39 | same profile as abidiff in this suite |
+
 > Why subset for cross-tool numbers: ABICC/libabigail comparability is tracked on
 > representative cases, while the full `examples/` catalog is used as abicheck
 > regression coverage.

--- a/examples/README.md
+++ b/examples/README.md
@@ -149,30 +149,14 @@ may keep identical runtime output for prebuilt binaries. For those, the demo sho
 
 ## Coverage snapshot
 
-### Full catalog coverage (abicheck)
-
 - Catalog size: **74 cases** (`01–73` + `26b`).
 - `ground_truth.json` contains expected verdicts for **74/74**.
 - CI job **Validate all examples** validates the whole catalog.
 
-### abicheck mode characteristics (42-case benchmark subset)
+Unified 74-case comparison table (all configurations, accuracy + FP/FN):
+- [`../README.md#validation-snapshot-abicheck`](../README.md#validation-snapshot-abicheck)
 
-| Mode | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
-|---|---:|---:|---:|---:|
-| `compare` | 42 | **42/42 (100%)** | 0 | 0 |
-| `compat` | 42 | **40/42 (95%)** | 0 | 2 |
-| `strict` (`--strict-mode full`) | 42 | **31/42 (73%)** | 9 | 0 |
-
-\* FP/FN are for **breaking-signal detection** (`BREAKING` + `API_BREAK` treated as positive).
-
-### abidiff quick signal (full catalog)
-
-| Tool | Cases | Exact verdict accuracy | False Positives* | False Negatives* |
-|---|---:|---:|---:|---:|
-| `abidiff` | 74 | **23/74 (31%)** | 0 | 39 |
-| `abidiff + headers` | 74 | **23/74 (31%)** | 0 | 39 |
-
-Methodology and full per-case matrix:
+Per-case matrix and methodology:
 - [`../docs/reference/tool-comparison.md`](../docs/reference/tool-comparison.md)
 
 ---

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -936,9 +936,7 @@ def main() -> None:
                                  "abidiff": "ERROR", "abidiff_headers": "ERROR",
                                  "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
                 continue
-        elif used_prebuilt_artifacts:
-            pass
-        elif cmake_file.exists() and shutil.which("cmake"):
+        elif not used_prebuilt_artifacts and cmake_file.exists() and shutil.which("cmake"):
             cmake_build = bdir / "cmake_build"
             if cmake_build.exists():
                 shutil.rmtree(str(cmake_build))

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -865,6 +865,178 @@ def _try_reuse_prebuilt(
     return None, None, False, False
 
 
+# ── Module-level helpers extracted from main() ────────────────────────────────
+
+def _accuracy(results: list[dict], key: str, expected_key: str = "expected") -> tuple[int, int]:
+    scored = [r for r in results if r.get(expected_key, "?") != "?" and r[key] not in ("SKIP", "ERROR", "TIMEOUT", "NO_SOURCE")]
+    correct = sum(1 for r in scored if r[key] == r[expected_key])
+    return correct, len(scored)
+
+
+def _total_ms(results: list[dict], ms_key: str) -> float:
+    return sum(r.get(ms_key, 0) for r in results)
+
+
+@dataclass
+class _BuildResult:
+    v1_so: Path
+    v2_so: Path
+    used_make_artifacts: bool
+    used_cmake_artifacts: bool
+    v1_h_hint: Path | None
+    v2_h_hint: Path | None
+    ok: bool
+
+
+def _build_case_artifacts(
+    name: str,
+    expected: str,
+    case_dir: Path,
+    bdir: Path,
+    v1_src: Path,
+    v2_src: Path,
+    v1_h_hint: Path | None,
+    v2_h_hint: Path | None,
+    args: Any,
+    results: list[dict],
+) -> _BuildResult:
+    """Build shared libraries for a test case. Returns _BuildResult with ok=False on error."""
+    v1_so = bdir / f"lib_v1{SHARED_LIB_SUFFIX}"
+    v2_so = bdir / f"lib_v2{SHARED_LIB_SUFFIX}"
+    used_make_artifacts = False
+    used_cmake_artifacts = False
+
+    cmake_file = case_dir / "CMakeLists.txt"
+    makefile = case_dir / "Makefile"
+
+    preferred_family, force_case64_compile = _case64_toolchain_policy(name, args.case64_toolchain)
+    pb_v1, pb_v2, used_prebuilt_artifacts, pb_cmake = _try_reuse_prebuilt(
+        force_case64_compile=force_case64_compile, case_name=name,
+    )
+    if pb_v1 and pb_v2:
+        v1_so, v2_so = pb_v1, pb_v2
+        used_cmake_artifacts = pb_cmake
+
+    if force_case64_compile:
+        if not compile_so(v1_src, v1_so, preferred_family=preferred_family) or not compile_so(v2_src, v2_so, preferred_family=preferred_family):
+            print(f"  {name:<35} COMPILE_ERR({preferred_family})")
+            results.append(_error_entry(name, expected))
+            return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
+    elif not used_prebuilt_artifacts and cmake_file.exists() and shutil.which("cmake"):
+        cmake_build = bdir / "cmake_build"
+        if cmake_build.exists():
+            shutil.rmtree(str(cmake_build))
+        cmake_build.mkdir(parents=True)
+        try:
+            cr = subprocess.run(
+                ["cmake", "-S", str(case_dir.parent), "-B", str(cmake_build),
+                 "-DCMAKE_BUILD_TYPE=Debug"],
+                capture_output=True, text=True, timeout=60,
+            )
+            if cr.returncode == 0:
+                cr = subprocess.run(
+                    ["cmake", "--build", str(cmake_build),
+                     "--target", f"{name}_v1", f"{name}_v2",
+                     "--config", "Debug"],
+                    capture_output=True, text=True, timeout=120,
+                )
+        except subprocess.TimeoutExpired:
+            cr = type("R", (), {"returncode": -1})()
+        cmake_out = cmake_build / name
+        if cr.returncode == 0 and cmake_out.exists():
+            built_v1 = _find_cmake_lib(cmake_out, "v1")
+            built_v2 = _find_cmake_lib(cmake_out, "v2")
+            if built_v1 and built_v2:
+                v1_so = built_v1
+                v2_so = built_v2
+                used_cmake_artifacts = True
+            else:
+                print(f"  {name:<35} CMAKE_NO_LIB")
+                results.append(_error_entry(name, expected))
+                return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
+        else:
+            print(f"  {name:<35} CMAKE_BUILD_ERR")
+            results.append(_error_entry(name, expected))
+            return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
+    elif makefile.exists() and shutil.which("make"):
+        build_copy = bdir / "make_build"
+        if build_copy.exists():
+            shutil.rmtree(str(build_copy))
+        shutil.copytree(str(case_dir), str(build_copy))
+        try:
+            mr = subprocess.run(
+                ["make", "-C", str(build_copy)],
+                capture_output=True, text=True, timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            mr = type("R", (), {"returncode": -1})()
+        built_v1 = build_copy / "libv1.so"
+        built_v2 = build_copy / "libv2.so"
+        if mr.returncode == 0 and built_v1.exists() and built_v2.exists():
+            v1_so = built_v1
+            v2_so = built_v2
+            used_make_artifacts = True
+        else:
+            if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
+                print(f"  {name:<35} COMPILE_ERR")
+                results.append(_error_entry(name, expected))
+                return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
+        if v1_so == built_v1:
+            v1_h_hint = _remap_to_build(v1_h_hint, case_dir, build_copy)
+            v2_h_hint = _remap_to_build(v2_h_hint, case_dir, build_copy)
+    elif not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
+        print(f"  {name:<35} COMPILE_ERR")
+        results.append(_error_entry(name, expected))
+        return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
+
+    return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=True)
+
+
+def _print_accuracy_summary(results: list[dict], active_tools: list[Any], selected_tools: set[str]) -> None:
+    print("\n" + "─" * 80)
+    print("  Accuracy vs expected verdicts:")
+    for t in active_tools:
+        c, total = _accuracy(results, t.name, t.expected_key)
+        if total > 0:
+            pct = 100 * c // total
+            bar = "█" * (pct // 5) + "░" * (20 - pct // 5)
+            tot_s = _total_ms(results, t.ms_key) / 1000
+            print(f"    {t.label}: {c:>2}/{total} ({pct:3}%) {bar}  [{tot_s:6.1f}s total]")
+
+    # Divergences from expected
+    if "abicheck" in selected_tools:
+        print("\n  Cases where abicheck differs from expected:")
+        for r in results:
+            if r.get("expected", "?") == "?":
+                continue
+            if r["abicheck"] not in ("SKIP", "ERROR", "TIMEOUT") and r["abicheck"] != r["expected"]:
+                print(f"    {r['case']:<40} got={r['abicheck']} expected={r['expected']}")
+
+    # Strict vs compat divergences
+    if "abicheck_strict" in selected_tools and "abicheck_compat" in selected_tools:
+        print("\n  Cases where abicheck_strict differs from abicheck_compat:")
+        for r in results:
+            ac_s = r.get("abicheck_strict", "SKIP")
+            ac_c = r.get("abicheck_compat", "SKIP")
+            if ac_s in ("SKIP", "ERROR", "TIMEOUT") or ac_c in ("SKIP", "ERROR", "TIMEOUT"):
+                continue
+            if ac_s != ac_c:
+                exp = r.get("expected", "?")
+                print(f"    {r['case']:<40} compat={ac_c} strict={ac_s} expected={exp}")
+
+    # Per-case timing for slow tools (registry-driven via show_slowest flag)
+    for tool_obj in active_tools:
+        if not tool_obj.show_slowest:
+            continue
+        print(f"\n  Top {tool_obj.col_name} slowest cases:")
+        slow = sorted(results, key=lambda r, k=tool_obj.ms_key: r.get(k, 0), reverse=True)
+        for r in slow[:10]:
+            ms = r.get(tool_obj.ms_key, 0)
+            if ms > 0:
+                verdict = r.get(tool_obj.name, "SKIP")
+                print(f"    {r['case']:<40} {ms:>7}ms  [{verdict}]")
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 def main() -> None:
     args = parse_args()
@@ -939,96 +1111,20 @@ def main() -> None:
         bdir = BUILD_DIR / name
         bdir.mkdir(exist_ok=True)
 
-        v1_so = bdir / f"lib_v1{SHARED_LIB_SUFFIX}"
-        v2_so = bdir / f"lib_v2{SHARED_LIB_SUFFIX}"
         v1_h_gen = bdir / "v1.h"
         v2_h_gen = bdir / "v2.h"
 
         # Build strategy: CMake > Makefile > direct compilation
-        cmake_file = case_dir / "CMakeLists.txt"
-        makefile = case_dir / "Makefile"
-        used_make_artifacts = False
-        used_cmake_artifacts = False
-
-        preferred_family, force_case64_compile = _case64_toolchain_policy(name, args.case64_toolchain)
-        pb_v1, pb_v2, used_prebuilt_artifacts, pb_cmake = _try_reuse_prebuilt(
-            force_case64_compile=force_case64_compile, case_name=name,
-        )
-        if pb_v1 and pb_v2:
-            v1_so, v2_so = pb_v1, pb_v2
-            used_cmake_artifacts = pb_cmake
-
-        if force_case64_compile:
-            if not compile_so(v1_src, v1_so, preferred_family=preferred_family) or not compile_so(v2_src, v2_so, preferred_family=preferred_family):
-                print(f"  {name:<35} COMPILE_ERR({preferred_family})")
-                results.append(_error_entry(name, expected))
-                continue
-        elif not used_prebuilt_artifacts and cmake_file.exists() and shutil.which("cmake"):
-            cmake_build = bdir / "cmake_build"
-            if cmake_build.exists():
-                shutil.rmtree(str(cmake_build))
-            cmake_build.mkdir(parents=True)
-            try:
-                cr = subprocess.run(
-                    ["cmake", "-S", str(case_dir.parent), "-B", str(cmake_build),
-                     "-DCMAKE_BUILD_TYPE=Debug"],
-                    capture_output=True, text=True, timeout=60,
-                )
-                if cr.returncode == 0:
-                    cr = subprocess.run(
-                        ["cmake", "--build", str(cmake_build),
-                         "--target", f"{name}_v1", f"{name}_v2",
-                         "--config", "Debug"],
-                        capture_output=True, text=True, timeout=120,
-                    )
-            except subprocess.TimeoutExpired:
-                cr = type("R", (), {"returncode": -1})()
-            cmake_out = cmake_build / name
-            if cr.returncode == 0 and cmake_out.exists():
-                built_v1 = _find_cmake_lib(cmake_out, "v1")
-                built_v2 = _find_cmake_lib(cmake_out, "v2")
-                if built_v1 and built_v2:
-                    v1_so = built_v1
-                    v2_so = built_v2
-                    used_cmake_artifacts = True
-                else:
-                    print(f"  {name:<35} CMAKE_NO_LIB")
-                    results.append(_error_entry(name, expected))
-                    continue
-            else:
-                print(f"  {name:<35} CMAKE_BUILD_ERR")
-                results.append(_error_entry(name, expected))
-                continue
-        elif makefile.exists() and shutil.which("make"):
-            build_copy = bdir / "make_build"
-            if build_copy.exists():
-                shutil.rmtree(str(build_copy))
-            shutil.copytree(str(case_dir), str(build_copy))
-            try:
-                mr = subprocess.run(
-                    ["make", "-C", str(build_copy)],
-                    capture_output=True, text=True, timeout=60,
-                )
-            except subprocess.TimeoutExpired:
-                mr = type("R", (), {"returncode": -1})()
-            built_v1 = build_copy / "libv1.so"
-            built_v2 = build_copy / "libv2.so"
-            if mr.returncode == 0 and built_v1.exists() and built_v2.exists():
-                v1_so = built_v1
-                v2_so = built_v2
-                used_make_artifacts = True
-            else:
-                if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
-                    print(f"  {name:<35} COMPILE_ERR")
-                    results.append(_error_entry(name, expected))
-                    continue
-            if v1_so == built_v1:
-                v1_h_hint = _remap_to_build(v1_h_hint, case_dir, build_copy)
-                v2_h_hint = _remap_to_build(v2_h_hint, case_dir, build_copy)
-        elif not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
-            print(f"  {name:<35} COMPILE_ERR")
-            results.append(_error_entry(name, expected))
+        br = _build_case_artifacts(name, expected, case_dir, bdir, v1_src, v2_src,
+                                   v1_h_hint, v2_h_hint, args, results)
+        if not br.ok:
             continue
+        v1_so = br.v1_so
+        v2_so = br.v2_so
+        used_make_artifacts = br.used_make_artifacts
+        used_cmake_artifacts = br.used_cmake_artifacts
+        v1_h_hint = br.v1_h_hint
+        v2_h_hint = br.v2_h_hint
 
         # Header selection policy:
         # abicheck family (abicheck / abicheck_compat / abicheck_strict):
@@ -1080,56 +1176,7 @@ def main() -> None:
         results.append(entry)
 
     # ── Accuracy summary ──────────────────────────────────────────────────────
-    def accuracy(key: str, expected_key: str = "expected") -> tuple[int, int]:
-        scored = [r for r in results if r.get(expected_key, "?") != "?" and r[key] not in ("SKIP", "ERROR", "TIMEOUT", "NO_SOURCE")]
-        correct = sum(1 for r in scored if r[key] == r[expected_key])
-        return correct, len(scored)
-
-    def total_ms(ms_key: str) -> float:
-        return sum(r.get(ms_key, 0) for r in results)
-
-    print("\n" + "─" * 80)
-    print("  Accuracy vs expected verdicts:")
-    for t in active_tools:
-        c, total = accuracy(t.name, t.expected_key)
-        if total > 0:
-            pct = 100 * c // total
-            bar = "█" * (pct // 5) + "░" * (20 - pct // 5)
-            tot_s = total_ms(t.ms_key) / 1000
-            print(f"    {t.label}: {c:>2}/{total} ({pct:3}%) {bar}  [{tot_s:6.1f}s total]")
-
-    # Divergences from expected
-    if "abicheck" in selected_tools:
-        print("\n  Cases where abicheck differs from expected:")
-        for r in results:
-            if r.get("expected", "?") == "?":
-                continue
-            if r["abicheck"] not in ("SKIP", "ERROR", "TIMEOUT") and r["abicheck"] != r["expected"]:
-                print(f"    {r['case']:<40} got={r['abicheck']} expected={r['expected']}")
-
-    # Strict vs compat divergences
-    if "abicheck_strict" in selected_tools and "abicheck_compat" in selected_tools:
-        print("\n  Cases where abicheck_strict differs from abicheck_compat:")
-        for r in results:
-            ac_s = r.get("abicheck_strict", "SKIP")
-            ac_c = r.get("abicheck_compat", "SKIP")
-            if ac_s in ("SKIP", "ERROR", "TIMEOUT") or ac_c in ("SKIP", "ERROR", "TIMEOUT"):
-                continue
-            if ac_s != ac_c:
-                exp = r.get("expected", "?")
-                print(f"    {r['case']:<40} compat={ac_c} strict={ac_s} expected={exp}")
-
-    # Per-case timing for slow tools (registry-driven via show_slowest flag)
-    for tool_obj in active_tools:
-        if not tool_obj.show_slowest:
-            continue
-        print(f"\n  Top {tool_obj.col_name} slowest cases:")
-        slow = sorted(results, key=lambda r, k=tool_obj.ms_key: r.get(k, 0), reverse=True)
-        for r in slow[:10]:
-            ms = r.get(tool_obj.ms_key, 0)
-            if ms > 0:
-                verdict = r.get(tool_obj.name, "SKIP")
-                print(f"    {r['case']:<40} {ms:>7}ms  [{verdict}]")
+    _print_accuracy_summary(results, active_tools, selected_tools)
 
     summary = REPORT_DIR / "comparison_summary.json"
     summary.write_text(json.dumps(results, indent=2))

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -214,7 +214,13 @@ def _find_compiler(is_cpp: bool = False, preferred_family: str | None = None) ->
 
 
 # ── Compile ───────────────────────────────────────────────────────────────────
-def compile_so(src: Path, out_so: Path, *, preferred_family: str | None = None) -> bool:
+def compile_so(
+    src: Path,
+    out_so: Path,
+    *,
+    preferred_family: str | None = None,
+    extra_link_opts: list[str] | None = None,
+) -> bool:
     is_cpp = src.suffix == ".cpp"
     compiler = _find_compiler(is_cpp, preferred_family=preferred_family)
     if not compiler:
@@ -230,11 +236,30 @@ def compile_so(src: Path, out_so: Path, *, preferred_family: str | None = None) 
     else:
         args = [compiler, "-shared", "-fPIC", "-g", "-Og", "-fvisibility=default",
                 "-o", str(out_so), str(src)]
+        if extra_link_opts:
+            args.extend(extra_link_opts)
 
     r = subprocess.run(args, capture_output=True, text=True)
     if r.returncode != 0:
         print(f"    [compile error] {src.name}: {r.stderr[:120]}")
     return r.returncode == 0
+
+
+def _fallback_link_opts(case_dir: Path, src: Path) -> list[str]:
+    """Best-effort linker options for direct compilation fallback.
+
+    Preserves case-specific version-script semantics when CMake isn't used.
+    """
+    if sys.platform.startswith("linux"):
+        # case65: explicit per-version scripts (v1.map / v2.map)
+        if src.stem == "v1" and (case_dir / "v1.map").exists():
+            return [f"-Wl,--version-script={case_dir / 'v1.map'}"]
+        if src.stem == "v2" and (case_dir / "v2.map").exists():
+            return [f"-Wl,--version-script={case_dir / 'v2.map'}"]
+        # case13: v2/good side has symbol version script
+        if src.stem == "good" and (case_dir / "libfoo.map").exists():
+            return [f"-Wl,--version-script={case_dir / 'libfoo.map'}"]
+    return []
 
 
 def make_header(src: Path, out_h: Path) -> None:
@@ -918,7 +943,17 @@ def _build_case_artifacts(
         used_cmake_artifacts = pb_cmake
 
     if force_case64_compile:
-        if not compile_so(v1_src, v1_so, preferred_family=preferred_family) or not compile_so(v2_src, v2_so, preferred_family=preferred_family):
+        if not compile_so(
+            v1_src,
+            v1_so,
+            preferred_family=preferred_family,
+            extra_link_opts=_fallback_link_opts(case_dir, v1_src),
+        ) or not compile_so(
+            v2_src,
+            v2_so,
+            preferred_family=preferred_family,
+            extra_link_opts=_fallback_link_opts(case_dir, v2_src),
+        ):
             print(f"  {name:<35} COMPILE_ERR({preferred_family})")
             results.append(_error_entry(name, expected))
             return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
@@ -977,14 +1012,14 @@ def _build_case_artifacts(
             v2_so = built_v2
             used_make_artifacts = True
         else:
-            if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
+            if not compile_so(v1_src, v1_so, extra_link_opts=_fallback_link_opts(case_dir, v1_src)) or not compile_so(v2_src, v2_so, extra_link_opts=_fallback_link_opts(case_dir, v2_src)):
                 print(f"  {name:<35} COMPILE_ERR")
                 results.append(_error_entry(name, expected))
                 return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
         if v1_so == built_v1:
             v1_h_hint = _remap_to_build(v1_h_hint, case_dir, build_copy)
             v2_h_hint = _remap_to_build(v2_h_hint, case_dir, build_copy)
-    elif not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
+    elif not compile_so(v1_src, v1_so, extra_link_opts=_fallback_link_opts(case_dir, v1_src)) or not compile_so(v2_src, v2_so, extra_link_opts=_fallback_link_opts(case_dir, v2_src)):
         print(f"  {name:<35} COMPILE_ERR")
         results.append(_error_entry(name, expected))
         return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -807,6 +807,60 @@ def _remap_to_build(h: Path | None, src: Path, dst: Path) -> Path | None:
         return dst / h.name
 
 
+def _error_entry(case_name: str, expected: str) -> dict[str, Any]:
+    """Standardized error row for tool outputs."""
+    return {
+        "case": case_name,
+        "expected": expected,
+        "expected_compat": EXPECTED_COMPAT.get(case_name, expected),
+        "abicheck": "ERROR",
+        "abicheck_compat": "ERROR",
+        "abicheck_strict": "ERROR",
+        "abidiff": "ERROR",
+        "abidiff_headers": "ERROR",
+        "abicc_dumper": "ERROR",
+        "abicc_xml": "ERROR",
+    }
+
+
+def _case64_toolchain_policy(case_name: str, configured: str) -> tuple[str | None, bool]:
+    """Return (preferred_family, force_clang_case64) for benchmark compilation."""
+    case64 = case_name == "case64_calling_convention_changed"
+    has_clang = bool(shutil.which("clang-18") or shutil.which("clang"))
+    if configured == "clang":
+        preferred_family = "clang"
+    elif configured == "gcc":
+        preferred_family = "gcc"
+    else:  # auto
+        preferred_family = "clang" if (case64 and has_clang) else None
+    return preferred_family, (case64 and preferred_family == "clang")
+
+
+def _try_reuse_prebuilt(
+    *,
+    force_clang_case64: bool,
+    case_name: str,
+) -> tuple[Path | None, Path | None, bool, bool]:
+    """Try to reuse prebuilt example artifacts.
+
+    Returns (v1_so, v2_so, used_prebuilt_artifacts, used_cmake_artifacts).
+    """
+    if force_clang_case64:
+        return None, None, False, False
+
+    prebuilt_dirs = [EXAMPLES_DIR / "build-all-local", EXAMPLES_DIR / "build-real"]
+    for prebuilt_root in prebuilt_dirs:
+        prebuilt_case_dir = prebuilt_root / case_name
+        if not prebuilt_case_dir.is_dir():
+            continue
+        built_v1 = _find_cmake_lib(prebuilt_case_dir, "v1")
+        built_v2 = _find_cmake_lib(prebuilt_case_dir, "v2")
+        if built_v1 and built_v2:
+            return built_v1, built_v2, True, True
+
+    return None, None, False, False
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 def main() -> None:
     args = parse_args()
@@ -892,49 +946,18 @@ def main() -> None:
         used_make_artifacts = False
         used_cmake_artifacts = False
 
-        # case64_calling_convention_changed needs clang to expose CC drift reliably.
-        case64 = name == "case64_calling_convention_changed"
-        has_clang = bool(shutil.which("clang-18") or shutil.which("clang"))
-        if args.case64_toolchain == "clang":
-            preferred_family = "clang"
-        elif args.case64_toolchain == "gcc":
-            preferred_family = "gcc"
-        else:  # auto
-            preferred_family = "clang" if (case64 and has_clang) else None
-        force_clang_case64 = case64 and preferred_family == "clang"
-
-        # Reuse prebuilt example binaries when available (e.g. examples/build-all-local).
-        # This keeps benchmark runs working in environments without a compiler toolchain.
-        # For case64+clang we intentionally bypass prebuilt artifacts to ensure
-        # calling_convention_changed is exercised with clang-emitted DWARF.
-        prebuilt_dirs = [EXAMPLES_DIR / "build-all-local", EXAMPLES_DIR / "build-real"]
-        used_prebuilt_artifacts = False
-        for prebuilt_root in prebuilt_dirs:
-            if force_clang_case64:
-                break
-            prebuilt_case_dir = prebuilt_root / name
-            if not prebuilt_case_dir.is_dir():
-                continue
-            built_v1 = _find_cmake_lib(prebuilt_case_dir, "v1")
-            built_v2 = _find_cmake_lib(prebuilt_case_dir, "v2")
-            if built_v1 and built_v2:
-                v1_so = built_v1
-                v2_so = built_v2
-                used_prebuilt_artifacts = True
-                # Treat prebuilt CMake outputs the same as fresh CMake artifacts
-                # for header policy below.
-                used_cmake_artifacts = True
-                break
+        preferred_family, force_clang_case64 = _case64_toolchain_policy(name, args.case64_toolchain)
+        pb_v1, pb_v2, used_prebuilt_artifacts, pb_cmake = _try_reuse_prebuilt(
+            force_clang_case64=force_clang_case64, case_name=name,
+        )
+        if pb_v1 and pb_v2:
+            v1_so, v2_so = pb_v1, pb_v2
+            used_cmake_artifacts = pb_cmake
 
         if force_clang_case64:
             if not compile_so(v1_src, v1_so, preferred_family="clang") or not compile_so(v2_src, v2_so, preferred_family="clang"):
                 print(f"  {name:<35} COMPILE_ERR(clang)")
-                results.append({"case": name, "expected": expected,
-                                 "expected_compat": EXPECTED_COMPAT.get(name, expected),
-                                 "abicheck": "ERROR", "abicheck_compat": "ERROR",
-                                 "abicheck_strict": "ERROR",
-                                 "abidiff": "ERROR", "abidiff_headers": "ERROR",
-                                 "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+                results.append(_error_entry(name, expected))
                 continue
         elif not used_prebuilt_artifacts and cmake_file.exists() and shutil.which("cmake"):
             cmake_build = bdir / "cmake_build"
@@ -965,24 +988,12 @@ def main() -> None:
                     v2_so = built_v2
                     used_cmake_artifacts = True
                 else:
-                    # CMake built but libs not found — don't fallback to compile_so
                     print(f"  {name:<35} CMAKE_NO_LIB")
-                    results.append({"case": name, "expected": expected,
-                                     "expected_compat": EXPECTED_COMPAT.get(name, expected),
-                                     "abicheck": "ERROR", "abicheck_compat": "ERROR",
-                                     "abicheck_strict": "ERROR",
-                                     "abidiff": "ERROR", "abidiff_headers": "ERROR",
-                                     "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+                    results.append(_error_entry(name, expected))
                     continue
             else:
-                # CMake build failed — don't fallback to compile_so
                 print(f"  {name:<35} CMAKE_BUILD_ERR")
-                results.append({"case": name, "expected": expected,
-                                 "expected_compat": EXPECTED_COMPAT.get(name, expected),
-                                 "abicheck": "ERROR", "abicheck_compat": "ERROR",
-                                 "abicheck_strict": "ERROR",
-                                 "abidiff": "ERROR", "abidiff_headers": "ERROR",
-                                 "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+                results.append(_error_entry(name, expected))
                 continue
         elif makefile.exists() and shutil.which("make"):
             build_copy = bdir / "make_build"
@@ -1005,24 +1016,14 @@ def main() -> None:
             else:
                 if not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
                     print(f"  {name:<35} COMPILE_ERR")
-                    results.append({"case": name, "expected": expected,
-                                     "expected_compat": EXPECTED_COMPAT.get(name, expected),
-                                     "abicheck": "ERROR", "abicheck_compat": "ERROR",
-                                     "abicheck_strict": "ERROR",
-                                     "abidiff": "ERROR", "abidiff_headers": "ERROR",
-                                     "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+                    results.append(_error_entry(name, expected))
                     continue
             if v1_so == built_v1:
                 v1_h_hint = _remap_to_build(v1_h_hint, case_dir, build_copy)
                 v2_h_hint = _remap_to_build(v2_h_hint, case_dir, build_copy)
         elif not compile_so(v1_src, v1_so) or not compile_so(v2_src, v2_so):
             print(f"  {name:<35} COMPILE_ERR")
-            results.append({"case": name, "expected": expected,
-                             "expected_compat": EXPECTED_COMPAT.get(name, expected),
-                             "abicheck": "ERROR", "abicheck_compat": "ERROR",
-                             "abicheck_strict": "ERROR",
-                             "abidiff": "ERROR", "abidiff_headers": "ERROR",
-                             "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+            results.append(_error_entry(name, expected))
             continue
 
         # Header selection policy:

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -185,13 +185,28 @@ def _find_cmake_lib(directory: Path, name: str) -> Path | None:
     return None
 
 
-def _find_compiler(is_cpp: bool = False) -> str | None:
+def _find_compiler(is_cpp: bool = False, preferred_family: str | None = None) -> str | None:
     if is_cpp:
         candidates = {"win32": ["cl", "g++", "clang++"],
                        "darwin": ["clang++", "g++"]}.get(sys.platform, ["g++", "clang++"])
     else:
         candidates = {"win32": ["cl", "gcc", "clang"],
                        "darwin": ["clang", "gcc"]}.get(sys.platform, ["gcc", "clang"])
+
+    if preferred_family == "clang":
+        if is_cpp:
+            pref = ["clang++-18", "clang++", "g++", "cl"]
+        else:
+            pref = ["clang-18", "clang", "gcc", "cl"]
+        # Keep only known candidates while preserving preference.
+        candidates = [c for c in pref if c in set(candidates) or c.startswith("clang")]
+    elif preferred_family == "gcc":
+        if is_cpp:
+            pref = ["g++", "clang++", "cl"]
+        else:
+            pref = ["gcc", "clang", "cl"]
+        candidates = [c for c in pref if c in set(candidates)]
+
     for cc in candidates:
         if shutil.which(cc):
             return cc
@@ -199,9 +214,9 @@ def _find_compiler(is_cpp: bool = False) -> str | None:
 
 
 # ── Compile ───────────────────────────────────────────────────────────────────
-def compile_so(src: Path, out_so: Path) -> bool:
+def compile_so(src: Path, out_so: Path, *, preferred_family: str | None = None) -> bool:
     is_cpp = src.suffix == ".cpp"
-    compiler = _find_compiler(is_cpp)
+    compiler = _find_compiler(is_cpp, preferred_family=preferred_family)
     if not compiler:
         print(f"    [compile error] no {'C++' if is_cpp else 'C'} compiler found")
         return False
@@ -776,6 +791,8 @@ def parse_args() -> argparse.Namespace:
                    choices=["abicheck", "abicheck_compat", "abicheck_strict",
                             "abidiff", "abidiff_headers", "abicc_dumper", "abicc_xml"],
                    help="Run only selected tools")
+    p.add_argument("--case64-toolchain", choices=["auto", "gcc", "clang"], default="auto",
+                   help="Toolchain for case64_calling_convention_changed (default: auto; prefers clang when available)")
     return p.parse_args()
 
 
@@ -875,11 +892,26 @@ def main() -> None:
         used_make_artifacts = False
         used_cmake_artifacts = False
 
+        # case64_calling_convention_changed needs clang to expose CC drift reliably.
+        case64 = name == "case64_calling_convention_changed"
+        has_clang = bool(shutil.which("clang-18") or shutil.which("clang"))
+        if args.case64_toolchain == "clang":
+            preferred_family = "clang"
+        elif args.case64_toolchain == "gcc":
+            preferred_family = "gcc"
+        else:  # auto
+            preferred_family = "clang" if (case64 and has_clang) else None
+        force_clang_case64 = case64 and preferred_family == "clang"
+
         # Reuse prebuilt example binaries when available (e.g. examples/build-all-local).
         # This keeps benchmark runs working in environments without a compiler toolchain.
+        # For case64+clang we intentionally bypass prebuilt artifacts to ensure
+        # calling_convention_changed is exercised with clang-emitted DWARF.
         prebuilt_dirs = [EXAMPLES_DIR / "build-all-local", EXAMPLES_DIR / "build-real"]
         used_prebuilt_artifacts = False
         for prebuilt_root in prebuilt_dirs:
+            if force_clang_case64:
+                break
             prebuilt_case_dir = prebuilt_root / name
             if not prebuilt_case_dir.is_dir():
                 continue
@@ -894,7 +926,17 @@ def main() -> None:
                 used_cmake_artifacts = True
                 break
 
-        if used_prebuilt_artifacts:
+        if force_clang_case64:
+            if not compile_so(v1_src, v1_so, preferred_family="clang") or not compile_so(v2_src, v2_so, preferred_family="clang"):
+                print(f"  {name:<35} COMPILE_ERR(clang)")
+                results.append({"case": name, "expected": expected,
+                                 "expected_compat": EXPECTED_COMPAT.get(name, expected),
+                                 "abicheck": "ERROR", "abicheck_compat": "ERROR",
+                                 "abicheck_strict": "ERROR",
+                                 "abidiff": "ERROR", "abidiff_headers": "ERROR",
+                                 "abicc_dumper": "ERROR", "abicc_xml": "ERROR"})
+                continue
+        elif used_prebuilt_artifacts:
             pass
         elif cmake_file.exists() and shutil.which("cmake"):
             cmake_build = bdir / "cmake_build"

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -765,7 +765,9 @@ _RESET = "\033[0m"
 
 
 def _col(v: str, width: int = 12) -> str:
-    return f"{_COLORS.get(v, '')}{v:<{width}}{_RESET}"
+    # Keep table alignment stable even for long labels like COMPATIBLE_WITH_RISK.
+    clipped = v[:width]
+    return f"{_COLORS.get(v, '')}{clipped:<{width}}{_RESET}"
 
 
 def _correct(verdict: str, expected: str) -> str:
@@ -824,7 +826,7 @@ def _error_entry(case_name: str, expected: str) -> dict[str, Any]:
 
 
 def _case64_toolchain_policy(case_name: str, configured: str) -> tuple[str | None, bool]:
-    """Return (preferred_family, force_clang_case64) for benchmark compilation."""
+    """Return (preferred_family, force_case64_compile) for benchmark compilation."""
     case64 = case_name == "case64_calling_convention_changed"
     has_clang = bool(shutil.which("clang-18") or shutil.which("clang"))
     if configured == "clang":
@@ -833,19 +835,21 @@ def _case64_toolchain_policy(case_name: str, configured: str) -> tuple[str | Non
         preferred_family = "gcc"
     else:  # auto
         preferred_family = "clang" if (case64 and has_clang) else None
-    return preferred_family, (case64 and preferred_family == "clang")
+    # For case64, if toolchain is explicitly/implicitly selected, compile directly
+    # and bypass prebuilt artifacts to honor selected calling-convention compiler.
+    return preferred_family, (case64 and preferred_family is not None)
 
 
 def _try_reuse_prebuilt(
     *,
-    force_clang_case64: bool,
+    force_case64_compile: bool,
     case_name: str,
 ) -> tuple[Path | None, Path | None, bool, bool]:
     """Try to reuse prebuilt example artifacts.
 
     Returns (v1_so, v2_so, used_prebuilt_artifacts, used_cmake_artifacts).
     """
-    if force_clang_case64:
+    if force_case64_compile:
         return None, None, False, False
 
     prebuilt_dirs = [EXAMPLES_DIR / "build-all-local", EXAMPLES_DIR / "build-real"]
@@ -946,17 +950,17 @@ def main() -> None:
         used_make_artifacts = False
         used_cmake_artifacts = False
 
-        preferred_family, force_clang_case64 = _case64_toolchain_policy(name, args.case64_toolchain)
+        preferred_family, force_case64_compile = _case64_toolchain_policy(name, args.case64_toolchain)
         pb_v1, pb_v2, used_prebuilt_artifacts, pb_cmake = _try_reuse_prebuilt(
-            force_clang_case64=force_clang_case64, case_name=name,
+            force_case64_compile=force_case64_compile, case_name=name,
         )
         if pb_v1 and pb_v2:
             v1_so, v2_so = pb_v1, pb_v2
             used_cmake_artifacts = pb_cmake
 
-        if force_clang_case64:
-            if not compile_so(v1_src, v1_so, preferred_family="clang") or not compile_so(v2_src, v2_so, preferred_family="clang"):
-                print(f"  {name:<35} COMPILE_ERR(clang)")
+        if force_case64_compile:
+            if not compile_so(v1_src, v1_so, preferred_family=preferred_family) or not compile_so(v2_src, v2_so, preferred_family=preferred_family):
+                print(f"  {name:<35} COMPILE_ERR({preferred_family})")
                 results.append(_error_entry(name, expected))
                 continue
         elif not used_prebuilt_artifacts and cmake_file.exists() and shutil.which("cmake"):

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -942,38 +942,40 @@ def _build_case_artifacts(
         v1_so, v2_so = pb_v1, pb_v2
         used_cmake_artifacts = pb_cmake
 
-    if force_case64_compile:
-        if not compile_so(
-            v1_src,
-            v1_so,
-            preferred_family=preferred_family,
-            extra_link_opts=_fallback_link_opts(case_dir, v1_src),
-        ) or not compile_so(
-            v2_src,
-            v2_so,
-            preferred_family=preferred_family,
-            extra_link_opts=_fallback_link_opts(case_dir, v2_src),
-        ):
-            print(f"  {name:<35} COMPILE_ERR({preferred_family})")
+    if not used_prebuilt_artifacts:
+        if not (cmake_file.exists() and shutil.which("cmake")):
+            print(f"  {name:<35} BUILD_PATH_UNAVAILABLE(prebuilt|cmake)")
             results.append(_error_entry(name, expected))
             return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
-    elif not used_prebuilt_artifacts and cmake_file.exists() and shutil.which("cmake"):
+
         cmake_build = bdir / "cmake_build"
         if cmake_build.exists():
             shutil.rmtree(str(cmake_build))
         cmake_build.mkdir(parents=True)
+        cmake_env = os.environ.copy()
+        if force_case64_compile and preferred_family == "clang":
+            if shutil.which("clang"):
+                cmake_env.setdefault("CC", "clang")
+            if shutil.which("clang++"):
+                cmake_env.setdefault("CXX", "clang++")
+        elif force_case64_compile and preferred_family == "gcc":
+            if shutil.which("gcc"):
+                cmake_env.setdefault("CC", "gcc")
+            if shutil.which("g++"):
+                cmake_env.setdefault("CXX", "g++")
+
         try:
             cr = subprocess.run(
                 ["cmake", "-S", str(case_dir.parent), "-B", str(cmake_build),
                  "-DCMAKE_BUILD_TYPE=Debug"],
-                capture_output=True, text=True, timeout=60,
+                capture_output=True, text=True, timeout=60, env=cmake_env,
             )
             if cr.returncode == 0:
                 cr = subprocess.run(
                     ["cmake", "--build", str(cmake_build),
                      "--target", f"{name}_v1", f"{name}_v2",
                      "--config", "Debug"],
-                    capture_output=True, text=True, timeout=120,
+                    capture_output=True, text=True, timeout=120, env=cmake_env,
                 )
         except subprocess.TimeoutExpired:
             cr = type("R", (), {"returncode": -1})()
@@ -993,36 +995,6 @@ def _build_case_artifacts(
             print(f"  {name:<35} CMAKE_BUILD_ERR")
             results.append(_error_entry(name, expected))
             return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
-    elif makefile.exists() and shutil.which("make"):
-        build_copy = bdir / "make_build"
-        if build_copy.exists():
-            shutil.rmtree(str(build_copy))
-        shutil.copytree(str(case_dir), str(build_copy))
-        try:
-            mr = subprocess.run(
-                ["make", "-C", str(build_copy)],
-                capture_output=True, text=True, timeout=60,
-            )
-        except subprocess.TimeoutExpired:
-            mr = type("R", (), {"returncode": -1})()
-        built_v1 = build_copy / "libv1.so"
-        built_v2 = build_copy / "libv2.so"
-        if mr.returncode == 0 and built_v1.exists() and built_v2.exists():
-            v1_so = built_v1
-            v2_so = built_v2
-            used_make_artifacts = True
-        else:
-            if not compile_so(v1_src, v1_so, extra_link_opts=_fallback_link_opts(case_dir, v1_src)) or not compile_so(v2_src, v2_so, extra_link_opts=_fallback_link_opts(case_dir, v2_src)):
-                print(f"  {name:<35} COMPILE_ERR")
-                results.append(_error_entry(name, expected))
-                return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
-        if v1_so == built_v1:
-            v1_h_hint = _remap_to_build(v1_h_hint, case_dir, build_copy)
-            v2_h_hint = _remap_to_build(v2_h_hint, case_dir, build_copy)
-    elif not compile_so(v1_src, v1_so, extra_link_opts=_fallback_link_opts(case_dir, v1_src)) or not compile_so(v2_src, v2_so, extra_link_opts=_fallback_link_opts(case_dir, v2_src)):
-        print(f"  {name:<35} COMPILE_ERR")
-        results.append(_error_entry(name, expected))
-        return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=False)
 
     return _BuildResult(v1_so, v2_so, used_make_artifacts, used_cmake_artifacts, v1_h_hint, v2_h_hint, ok=True)
 

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -401,6 +401,8 @@ def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
             verdict = "COMPATIBLE"
         elif raw_v == "NO_CHANGE":
             verdict = "NO_CHANGE"
+        elif raw_v == "COMPATIBLE_WITH_RISK":
+            verdict = "COMPATIBLE_WITH_RISK"
         else:
             verdict = "ERROR"
     except (json.JSONDecodeError, AttributeError):
@@ -873,7 +875,28 @@ def main() -> None:
         used_make_artifacts = False
         used_cmake_artifacts = False
 
-        if cmake_file.exists() and shutil.which("cmake"):
+        # Reuse prebuilt example binaries when available (e.g. examples/build-all-local).
+        # This keeps benchmark runs working in environments without a compiler toolchain.
+        prebuilt_dirs = [EXAMPLES_DIR / "build-all-local", EXAMPLES_DIR / "build-real"]
+        used_prebuilt_artifacts = False
+        for prebuilt_root in prebuilt_dirs:
+            prebuilt_case_dir = prebuilt_root / name
+            if not prebuilt_case_dir.is_dir():
+                continue
+            built_v1 = _find_cmake_lib(prebuilt_case_dir, "v1")
+            built_v2 = _find_cmake_lib(prebuilt_case_dir, "v2")
+            if built_v1 and built_v2:
+                v1_so = built_v1
+                v2_so = built_v2
+                used_prebuilt_artifacts = True
+                # Treat prebuilt CMake outputs the same as fresh CMake artifacts
+                # for header policy below.
+                used_cmake_artifacts = True
+                break
+
+        if used_prebuilt_artifacts:
+            pass
+        elif cmake_file.exists() and shutil.which("cmake"):
             cmake_build = bdir / "cmake_build"
             if cmake_build.exists():
                 shutil.rmtree(str(cmake_build))

--- a/tests/test_regression_verdict_stability.py
+++ b/tests/test_regression_verdict_stability.py
@@ -81,21 +81,21 @@ def test_verdict_stable_for_non_target_cases(case_name: str) -> None:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("case_name", sorted(ALLOWED_TO_CHANGE))
-def test_target_cases_have_expected_pre_fix_baseline(case_name: str) -> None:
-    """Document current (pre-fix) behavior for targeted cases.
+def test_target_cases_match_committed_post_fix_baseline(case_name: str) -> None:
+    """Document current post-fix baseline for the originally targeted cases.
 
-    This is intentionally strict: if baseline artifacts are changed, reviewers see
-    explicit diffs for these target cases.
+    This remains intentionally strict: when baseline artifacts change, reviewers
+    get explicit diffs for the historically sensitive target set.
     """
     case_dir = BENCH_DIR / case_name
     baseline = _baseline_verdict(case_dir)
 
-    expected_pre_fix = {
-        "case49_executable_stack": "NO_CHANGE",
-        "case50_soname_inconsistent": "BREAKING",
-        "case51_protected_visibility": "NO_CHANGE",
-        "case54_used_reserved_field": "BREAKING",
-        "case62_type_field_added_compatible": "BREAKING",
+    expected_post_fix = {
+        "case49_executable_stack": "COMPATIBLE",
+        "case50_soname_inconsistent": "COMPATIBLE",
+        "case51_protected_visibility": "COMPATIBLE",
+        "case54_used_reserved_field": "COMPATIBLE",
+        "case62_type_field_added_compatible": "COMPATIBLE",
     }[case_name]
 
-    assert baseline == expected_pre_fix
+    assert baseline == expected_post_fix

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -41,6 +41,8 @@ def _adv(
     packed: set[str] | None = None,
     flags: set[str] | None = None,
     all_structs: set[str] | None = None,
+    frame_regs: dict[str, str] | None = None,
+    callee_saved: dict[str, frozenset[str]] | None = None,
 ) -> AdvancedDwarfMetadata:
     packed_set = packed or set()
     # all_struct_names must include packed structs so diff guards work correctly
@@ -57,6 +59,8 @@ def _adv(
         value_abi_traits=value_traits or {},
         packed_structs=packed_set,
         all_struct_names=struct_names,
+        frame_registers=frame_regs or {},
+        callee_saved_regs=callee_saved or {},
     )
 
 
@@ -136,6 +140,16 @@ def test_value_abi_trait_changed_breaking() -> None:
     r = compare(old, new)
     kinds = {c.kind for c in r.changes}
     assert ChangeKind.VALUE_ABI_TRAIT_CHANGED in kinds
+    assert r.verdict == Verdict.BREAKING
+
+
+def test_callee_saved_fallback_detects_calling_convention_drift() -> None:
+    """ELF CFI fallback: saved rdi/rsi indicates ms_abi shift."""
+    old = _snap(_adv(callee_saved={"foo": frozenset({"rbx", "rbp", "r12"})}))
+    new = _snap(_adv(callee_saved={"foo": frozenset({"rbx", "rbp", "r12", "rdi", "rsi"})}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.CALLING_CONVENTION_CHANGED in kinds
     assert r.verdict == Verdict.BREAKING
 
 

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -165,32 +165,32 @@ def test_callee_saved_fallback_ignores_non_marker_register_churn() -> None:
 def test_extract_callee_saved_regs_mocked() -> None:
     """Test _extract_callee_saved_regs with a mocked FDE."""
     from abicheck.dwarf_advanced import _extract_callee_saved_regs
-    
+
     class MockRow:
         def __init__(self, pc, regs):
             self.pc = pc
             self.regs = regs
-        
+
         def items(self):
             return self.regs.items()
-    
+
     class MockRule:
         def __init__(self, typ):
             self.type = typ
-    
+
     class MockTable:
         table = [
             MockRow(pc=0x1000, regs={16: MockRule("offset")}),
             MockRow(pc=0x1004, regs={3: MockRule("offset"), 4: MockRule("undefined")}),
         ]
-    
+
     class MockDecoded:
         table = MockTable.table
-    
+
     class MockEntry:
         def get_decoded(self):
             return MockDecoded()
-    
+
     entry = MockEntry()
     result = _extract_callee_saved_regs(entry, "x86_64")
     # x86_64: reg 16 = rip, reg 3 = rbx, reg 4 = rsi (but undefined → not saved)

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -153,6 +153,15 @@ def test_callee_saved_fallback_detects_calling_convention_drift() -> None:
     assert r.verdict == Verdict.BREAKING
 
 
+def test_callee_saved_fallback_ignores_non_marker_register_churn() -> None:
+    """rbx/r12 churn alone is not enough to claim calling-convention drift."""
+    old = _snap(_adv(callee_saved={"foo": frozenset({"rbx", "rbp", "r12"})}))
+    new = _snap(_adv(callee_saved={"foo": frozenset({"rbx", "rbp", "r12", "r13"})}))
+    r = compare(old, new)
+    kinds = {c.kind for c in r.changes}
+    assert ChangeKind.CALLING_CONVENTION_CHANGED not in kinds
+
+
 def test_value_abi_trait_unchanged_no_change() -> None:
     results = diff_advanced_dwarf(
         _adv(value_traits={"foo": "ret:v(trivial)|p0:v(trivial)"}),

--- a/tests/test_sprint4_dwarf_advanced.py
+++ b/tests/test_sprint4_dwarf_advanced.py
@@ -162,6 +162,41 @@ def test_callee_saved_fallback_ignores_non_marker_register_churn() -> None:
     assert ChangeKind.CALLING_CONVENTION_CHANGED not in kinds
 
 
+def test_extract_callee_saved_regs_mocked() -> None:
+    """Test _extract_callee_saved_regs with a mocked FDE."""
+    from abicheck.dwarf_advanced import _extract_callee_saved_regs
+    
+    class MockRow:
+        def __init__(self, pc, regs):
+            self.pc = pc
+            self.regs = regs
+        
+        def items(self):
+            return self.regs.items()
+    
+    class MockRule:
+        def __init__(self, typ):
+            self.type = typ
+    
+    class MockTable:
+        table = [
+            MockRow(pc=0x1000, regs={16: MockRule("offset")}),
+            MockRow(pc=0x1004, regs={3: MockRule("offset"), 4: MockRule("undefined")}),
+        ]
+    
+    class MockDecoded:
+        table = MockTable.table
+    
+    class MockEntry:
+        def get_decoded(self):
+            return MockDecoded()
+    
+    entry = MockEntry()
+    result = _extract_callee_saved_regs(entry, "x86_64")
+    # x86_64: reg 16 = rip, reg 3 = rbx, reg 4 = rsi (but undefined → not saved)
+    assert result == frozenset({"rip", "rbx"})
+
+
 def test_value_abi_trait_unchanged_no_change() -> None:
     results = diff_advanced_dwarf(
         _adv(value_traits={"foo": "ret:v(trivial)|p0:v(trivial)"}),


### PR DESCRIPTION
## What

This PR addresses the benchmark FP/FN investigation follow-ups:

1. **Fix benchmark verdict parsing**
   - `scripts/benchmark_comparison.py`: handle `COMPATIBLE_WITH_RISK` from JSON verdict output instead of mapping it to `ERROR`.

2. **Fix opaque-type verdict inflation (case62)**
   - `abicheck/post_processing.py`, `abicheck/checker.py`
   - Keep opaque filtered changes visible for audit/reporting, but exclude them from semantic verdict computation.

3. **Fix inline namespace move detection in ELF-only mode (case71)**
   - `abicheck/diff_platform.py`
   - Use batched demangling fallback when `Function.name` is still mangled, then apply inline namespace matching.

4. **Add ELF CFI fallback signal for calling convention drift (case64 path)**
   - `abicheck/dwarf_advanced.py`, `abicheck/model.py`, `abicheck/serialization.py`, `abicheck/dumper.py`
   - Track per-function callee-saved register fingerprints from CFI and compare across versions as fallback `calling_convention_changed` evidence.

5. **Tests**
   - `tests/test_sprint4_dwarf_advanced.py`: extended fixtures + added fallback CC drift test.

## Validation

- `pytest tests/test_sprint4_dwarf_advanced.py tests/test_new_detectors.py::TestInlineNamespace -q`
- Local spot-checks:
  - case62 now yields `COMPATIBLE`
  - case71 now yields `BREAKING` with `inline_namespace_moved`

## Notes

- The ELF CFI fallback is additive and conservative; GCC-specific `ms_abi` coverage remains toolchain-sensitive and this PR improves fallback evidence without regressing existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calling-convention drift detection via callee-saved register fingerprints.
  * New verdict: COMPATIBLE_WITH_RISK.
  * Benchmark option to prefer a specific toolchain for cases.

* **Improvements**
  * Better namespace-move detection using demangled symbol matching.
  * Snapshot metadata now records source path.
  * Opaque/filtered changes are reported but excluded from compatibility verdicts.
  * Serialization now supports frozenset values.

* **Tests**
  * Added tests for calling-convention drift and updated baseline expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->