### PR TITLE
fix(btf): post-merge review fixes — pointer_size from ELF class, debug_format validation

### DIFF
--- a/abicheck/btf_metadata.py
+++ b/abicheck/btf_metadata.py
@@ -142,7 +142,12 @@ class BtfMetadata:
         return self.typedefs.get(name)
 
     def to_dwarf_metadata(self) -> DwarfMetadata:
-        """Convert to DwarfMetadata for checker compatibility."""
+        """Convert to DwarfMetadata for checker compatibility.
+
+        Note: Only structs and enums are transferred; func_protos and
+        typedefs are not included in DwarfMetadata. Callers needing full
+        BTF data should use BtfMetadata directly.
+        """
         return DwarfMetadata(
             structs=dict(self.structs),
             enums=dict(self.enums),
@@ -165,15 +170,17 @@ def has_btf_section(elf_path: Path) -> bool:
         return False
 
 
-def _read_btf_section(elf_path: Path) -> bytes | None:
-    """Read raw .BTF section data from an ELF file."""
+def _read_btf_section(elf_path: Path) -> tuple[bytes, int] | None:
+    """Read raw .BTF section data from an ELF file; return (data, pointer_size)."""
     from elftools.elf.elffile import ELFFile
     with open(elf_path, "rb") as f:
         elf = ELFFile(f)  # type: ignore[no-untyped-call]
         section = elf.get_section_by_name(".BTF")  # type: ignore[no-untyped-call]
         if section is None:
             return None
-        return bytes(section.data())
+        elf_class = elf.get_class()  # type: ignore[no-untyped-call]
+        pointer_size = 4 if elf_class == "ELFCLASS32" else 8
+        return bytes(section.data()), pointer_size
 
 
 # ---------------------------------------------------------------------------
@@ -287,9 +294,10 @@ def _extra_data_size(kind: int, vlen: int) -> int:
 class _TypeResolver:
     """Resolves BTF type references to names and sizes."""
 
-    def __init__(self, types: list[BtfType], str_data: bytes) -> None:
+    def __init__(self, types: list[BtfType], str_data: bytes, *, pointer_size: int = 8) -> None:
         self._types = types
         self._str = str_data
+        self._pointer_size = pointer_size
         self._name_cache: dict[int, str] = {}
         self._size_cache: dict[int, int] = {}
         # Track resolution in progress for cycle detection
@@ -439,7 +447,7 @@ class _TypeResolver:
             return t.size_or_type
 
         if kind == BTF_KIND_PTR:
-            return 8  # 64-bit pointers (kernel is typically 64-bit)
+            return self._pointer_size  # derived from ELF class (4 for 32-bit, 8 for 64-bit)
 
         if kind == BTF_KIND_ARRAY:
             if len(t.extra) >= 12:
@@ -659,11 +667,17 @@ def parse_btf_metadata(elf_path: Path) -> BtfMetadata:
         log.debug("parse_btf_metadata: no .BTF section in %s", elf_path)
         return empty
 
-    return parse_btf_from_bytes(raw)
+    btf_data, pointer_size = raw
+    return parse_btf_from_bytes(btf_data, pointer_size=pointer_size)
 
 
-def parse_btf_from_bytes(data: bytes) -> BtfMetadata:
+def parse_btf_from_bytes(data: bytes, pointer_size: int = 8) -> BtfMetadata:
     """Parse BTF from raw bytes (useful for testing without ELF wrapper).
+
+    Args:
+        data: Raw BTF section bytes.
+        pointer_size: Pointer size in bytes (4 for 32-bit, 8 for 64-bit).
+            Defaults to 8 (typical for kernel BTF).
 
     Returns ``BtfMetadata()`` on any error.  Never raises.
     """
@@ -694,7 +708,7 @@ def parse_btf_from_bytes(data: bytes) -> BtfMetadata:
         log.warning("parse_btf_from_bytes: type parsing failed: %s", exc)
         return empty
 
-    resolver = _TypeResolver(types, str_data)
+    resolver = _TypeResolver(types, str_data, pointer_size=pointer_size)
 
     meta = BtfMetadata(has_btf=True, type_count=len(types) - 1)
 

--- a/abicheck/btf_metadata.py
+++ b/abicheck/btf_metadata.py
@@ -178,8 +178,7 @@ def _read_btf_section(elf_path: Path) -> tuple[bytes, int] | None:
         section = elf.get_section_by_name(".BTF")  # type: ignore[no-untyped-call]
         if section is None:
             return None
-        elf_class = elf.get_class()  # type: ignore[no-untyped-call]
-        pointer_size = 4 if elf_class == "ELFCLASS32" else 8
+        pointer_size = 4 if elf.elfclass == 32 else 8
         return bytes(section.data()), pointer_size
 
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -550,6 +550,10 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
 
     # Auto-detect binary format — PE/Mach-O skip the ELF/castxml path
     binary_fmt = _detect_binary_format(so_path)
+    if debug_format is not None and binary_fmt in ("pe", "macho"):
+        raise click.BadParameter(
+            f"--{debug_format} is only supported for ELF binaries, not {binary_fmt.upper()}."
+        )
     if binary_fmt in ("pe", "macho"):
         if follow_deps:
             click.echo("Warning: --follow-deps is only supported for ELF binaries.", err=True)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1044,8 +1044,9 @@ def dump(
         lang: Force language ("C" or "C++").
         dwarf_only: If True, force DWARF-only mode even when headers
             are available (ADR-003).
-        debug_format: Force debug format: "dwarf", "btf", or "ctf".
+        debug_format: Force debug format for ELF inputs: "dwarf", "btf", or "ctf".
             None = auto-detect (DWARF preferred for userspace, BTF for kernel).
+            Ignored for Mach-O and PE binaries.
 
     Returns:
         AbiSnapshot with functions, variables, and types populated.
@@ -1129,6 +1130,11 @@ def _resolve_debug_metadata(
     if debug_format == "dwarf":
         from .dwarf_unified import parse_dwarf
         return parse_dwarf(so_path)
+
+    if debug_format is not None:
+        raise ValueError(
+            f"Invalid debug_format {debug_format!r}; expected 'dwarf', 'btf', or 'ctf'."
+        )
 
     # Auto-detect: kernel binaries prefer BTF, userspace prefers DWARF
     from .btf_metadata import has_btf_section, parse_btf_metadata

--- a/tests/test_btf_metadata.py
+++ b/tests/test_btf_metadata.py
@@ -46,9 +46,11 @@ from abicheck.btf_metadata import (
     _extra_data_size,
     _parse_header,
     _parse_types,
+    _read_btf_section,
     _read_string,
     _TypeResolver,
     parse_btf_from_bytes,
+    parse_btf_metadata,
 )
 
 # ---------------------------------------------------------------------------
@@ -371,6 +373,22 @@ class TestTypeResolver:
         assert resolver.name(2) == "int *"
         assert resolver.size(2) == 8
 
+    def test_pointer_size_can_be_32_bit(self) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_PTR, 0, 1)
+
+        data = b.build()
+        hdr = _parse_header(data)
+        type_start = hdr.hdr_len + hdr.type_off
+        str_start = hdr.hdr_len + hdr.str_off
+        str_end = str_start + hdr.str_len
+        types = _parse_types(data[type_start:type_start + hdr.type_len])
+        resolver = _TypeResolver(types, data[str_start:str_end], pointer_size=4)
+        assert resolver.name(2) == "int *"
+        assert resolver.size(2) == 4
+
     def test_const_name(self) -> None:
         b = BtfBuilder()
         int_enc = struct.pack("<I", 32)
@@ -420,6 +438,76 @@ class TestToDwarfMetadata:
 # ---------------------------------------------------------------------------
 # Error handling / graceful degradation
 # ---------------------------------------------------------------------------
+
+class TestBtfElfSection:
+    def test_read_btf_section_returns_data_and_pointer_size(self, tmp_path, monkeypatch) -> None:
+        btf_data = b"btf"
+
+        class FakeSection:
+            def data(self) -> bytes:
+                return btf_data
+
+        class FakeElf:
+            elfclass = 32
+
+            def __init__(self, _file) -> None:
+                pass
+
+            def get_section_by_name(self, name: str):
+                assert name == ".BTF"
+                return FakeSection()
+
+        import elftools.elf.elffile
+        monkeypatch.setattr(elftools.elf.elffile, "ELFFile", FakeElf)
+        elf_path = tmp_path / "lib.so"
+        elf_path.write_bytes(b"not really elf")
+
+        assert _read_btf_section(elf_path) == (btf_data, 4)
+
+    def test_read_btf_section_returns_none_when_section_missing(self, tmp_path, monkeypatch) -> None:
+        class FakeElf:
+            elfclass = 64
+
+            def __init__(self, _file) -> None:
+                pass
+
+            def get_section_by_name(self, name: str):
+                assert name == ".BTF"
+                return None
+
+        import elftools.elf.elffile
+        monkeypatch.setattr(elftools.elf.elffile, "ELFFile", FakeElf)
+        elf_path = tmp_path / "lib.so"
+        elf_path.write_bytes(b"not really elf")
+
+        assert _read_btf_section(elf_path) is None
+
+    def test_parse_btf_metadata_returns_empty_when_section_missing(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("abicheck.btf_metadata._read_btf_section", lambda _path: None)
+
+        meta = parse_btf_metadata(tmp_path / "lib.so")
+
+        assert not meta.has_btf
+
+    def test_parse_btf_metadata_passes_pointer_size_from_elf(self, tmp_path, monkeypatch) -> None:
+        b = BtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", BTF_KIND_INT, 0, 4, extra=int_enc)
+        b.add_type("", BTF_KIND_PTR, 0, 1)
+        ptr_name = b.add_string("ptr")
+        members = struct.pack("<III", ptr_name, 2, 0)
+        b.add_type("box", BTF_KIND_STRUCT, 1, 4, extra=members)
+
+        monkeypatch.setattr(
+            "abicheck.btf_metadata._read_btf_section",
+            lambda _path: (b.build(), 4),
+        )
+
+        meta = parse_btf_metadata(tmp_path / "lib32.so")
+
+        assert meta.has_btf
+        assert meta.structs["box"].fields[0].byte_size == 4
+
 
 class TestBtfErrorHandling:
     def test_empty_data(self) -> None:

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -69,6 +69,30 @@ class TestDumpVerbose:
         assert out.exists()
 
 
+# ── debug format on non-ELF binaries ─────────────────────────────────────
+
+class TestDumpDebugFormatValidation:
+    def test_btf_flag_rejected_for_pe_binary(self, tmp_path):
+        dll = tmp_path / "foo.dll"
+        dll.write_bytes(b"MZ" + b"\0" * 62)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dump", str(dll), "--btf"])
+
+        assert result.exit_code != 0
+        assert "--btf is only supported for ELF binaries, not PE" in result.output
+
+    def test_ctf_flag_rejected_for_macho_binary(self, tmp_path):
+        dylib = tmp_path / "libfoo.dylib"
+        dylib.write_bytes(b"\xfe\xed\xfa\xcf" + b"\0" * 60)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dump", str(dylib), "--ctf"])
+
+        assert result.exit_code != 0
+        assert "--ctf is only supported for ELF binaries, not MACHO" in result.output
+
+
 # ── --lang on compare ────────────────────────────────────────────────────
 
 class TestCompareLang:

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -20,6 +20,7 @@ from abicheck.dumper import (
     _CastxmlParser,
     _parse_vtable_index,
     _pyelftools_exported_symbols,
+    _resolve_debug_metadata,
     _vt_sort_key,
 )
 from abicheck.model import Visibility
@@ -105,6 +106,49 @@ class TestCachePath:
         p = _cache_path("abc123")
         assert p.name == "abc123.xml"
         assert "abi_check" in str(p)
+
+
+# ── _resolve_debug_metadata ─────────────────────────────────────────────
+
+class TestResolveDebugMetadata:
+    def test_forced_btf_uses_btf_parser(self, tmp_path, monkeypatch):
+        from abicheck.btf_metadata import BtfMetadata
+
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.parse_btf_metadata",
+            lambda _path: BtfMetadata(has_btf=True),
+        )
+
+        dwarf_meta, dwarf_adv = _resolve_debug_metadata(tmp_path / "lib.so", "btf")
+
+        assert dwarf_meta.has_dwarf
+        assert dwarf_adv is not None
+
+    def test_forced_ctf_uses_ctf_parser(self, tmp_path, monkeypatch):
+        from abicheck.ctf_metadata import CtfMetadata
+
+        monkeypatch.setattr(
+            "abicheck.ctf_metadata.parse_ctf_metadata",
+            lambda _path: CtfMetadata(has_ctf=True),
+        )
+
+        dwarf_meta, dwarf_adv = _resolve_debug_metadata(tmp_path / "lib.so", "ctf")
+
+        assert dwarf_meta.has_dwarf
+        assert dwarf_adv is not None
+
+    def test_forced_dwarf_uses_dwarf_parser(self, tmp_path, monkeypatch):
+        from abicheck.dwarf_advanced import AdvancedDwarfMetadata
+        from abicheck.dwarf_metadata import DwarfMetadata
+
+        expected = (DwarfMetadata(has_dwarf=True), AdvancedDwarfMetadata())
+        monkeypatch.setattr("abicheck.dwarf_unified.parse_dwarf", lambda _path: expected)
+
+        assert _resolve_debug_metadata(tmp_path / "lib.so", "dwarf") is expected
+
+    def test_invalid_debug_format_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid debug_format"):
+            _resolve_debug_metadata(tmp_path / "lib.so", "invalid")
 
 
 # ── _pyelftools_exported_symbols ────────────────────────────────────────


### PR DESCRIPTION
Addresses 5 CodeRabbit actionable comments from the original BTF/CTF PR (#158) that were not included in the merge.

## Changes

### \`abicheck/btf_metadata.py\`
- **Pointer size from ELF class** — \`_read_btf_section\` now reads ELF class (ELFCLASS32/ELFCLASS64) and returns \`(data, pointer_size)\`. \`parse_btf_metadata\` unpacks and propagates to \`parse_btf_from_bytes(pointer_size=)\`, which passes it to \`_TypeResolver\`. \`BTF_KIND_PTR\` now returns \`self._pointer_size\` instead of hardcoded 8.
- \`parse_btf_from_bytes\` accepts \`pointer_size: int = 8\` kwarg (backward-compatible).
- \`to_dwarf_metadata()\` docstring clarifies that \`func_protos\` and \`typedefs\` are not transferred.

### \`abicheck/cli.py\`
- \`dump\` command now raises \`BadParameter\` when \`--btf\`/\`--ctf\`/\`--dwarf\` is used with a PE or Mach-O binary (ELF-only flag).

### \`abicheck/dumper.py\`
- \`debug_format\` docstring clarified as ELF-only, ignored for Mach-O/PE.
- \`_resolve_debug_metadata\` raises \`ValueError\` for unrecognized \`debug_format\` values instead of silently falling through to auto-detection.

## Tests
All 167 BTF/CTF tests pass. Lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pointer-size detection for 32-bit binaries to improve metadata size resolution.

* **Bug Fixes**
  * Rejects ELF-only debug-format options when used with PE or Mach-O inputs.
  * Raises on invalid debug-format values instead of falling through.

* **Documentation**
  * Clarified debug-format options apply only to ELF.
  * Clarified metadata conversion now includes only structs and enums.

* **Tests**
  * Added coverage for pointer-size handling, CLI validation, and debug-format resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->