### PR TITLE
docs: add Part 4 (ELF and linker-level concerns) to ABI stability guide

### DIFF
--- a/docs/concepts/abi-stability-guide.md
+++ b/docs/concepts/abi-stability-guide.md
@@ -81,10 +81,10 @@ lives in the `DT_SONAME` entry of `.dynamic` and is set via
 `DT_NEEDED`, and at runtime `ld.so` searches for a file (usually an
 `ldconfig`-managed symlink) matching that string.
 
-[Case 05](https://github.com/napetrov/abicheck/tree/main/examples/case05_soname) covers a library built
+[Case 05](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/README.md) covers a library built
 without `-Wl,-soname` at all: `DT_NEEDED` points at the bare `libfoo.so`,
 which `ldconfig` cannot manage, so shipping `libfoo.so.1` later breaks
-every consumer. [Case 50](https://github.com/napetrov/abicheck/tree/main/examples/case50_soname_inconsistent)
+every consumer. [Case 50](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/README.md)
 is the subtler bug where a 1.x release is tagged `libfoo.so.0`: packaging
 generates dependencies on the wrong major, and the cutover forces a
 distribution-wide rebuild. Rule: SONAME major equals ABI epoch, and it
@@ -97,13 +97,13 @@ Every `.dynsym` entry has an `st_other` visibility byte: `STV_DEFAULT`
 interposable), or `STV_INTERNAL`. Without `-fvisibility=hidden`, every
 non-`static` function defaults to `STV_DEFAULT`, dragging the entire
 translation unit into the public ABI.
-[Case 06](https://github.com/napetrov/abicheck/tree/main/examples/case06_visibility) is the accidental
+[Case 06](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/README.md) is the accidental
 leak: `internal_helper` was never intended as public API, but lacking
 `static` consumers can resolve it — the later "cleanup" that hides it
-breaks them. [Case 53](https://github.com/napetrov/abicheck/tree/main/examples/case53_namespace_pollution)
+breaks them. [Case 53](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/README.md)
 is the related design error: exporting unprefixed names like `init` that
 collide in the process's flat symbol namespace.
-[Case 51](https://github.com/napetrov/abicheck/tree/main/examples/case51_protected_visibility) rounds it
+[Case 51](https://github.com/napetrov/abicheck/blob/main/examples/case51_protected_visibility/README.md) rounds it
 out: `DEFAULT` → `PROTECTED` is ABI-compatible for normal callers but
 silently defeats `LD_PRELOAD` interposition.
 
@@ -113,10 +113,10 @@ A version script (`-Wl,--version-script=libfoo.map`) groups symbols into
 named nodes like `LIBFOO_1.0`, recorded in `.gnu.version_d` and tagged in
 `.gnu.versym`; consumers carry matching `.gnu.version_r` entries. This lets
 one `.so` ship multiple ABI generations side by side.
-[Case 13](https://github.com/napetrov/abicheck/tree/main/examples/case13_symbol_versioning) shows that
+[Case 13](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/README.md) shows that
 *adding* a version script is backward compatible — old binaries have no
 `DT_VERNEED`, so `ld.so` resolves by name.
-[Case 65](https://github.com/napetrov/abicheck/tree/main/examples/case65_symbol_version_removed) is the
+[Case 65](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/README.md) is the
 opposite: once a node has shipped, removing it deletes every symbol it
 tagged. glibc's `GLIBC_2.0` has been append-only since 1997 — which is
 why a binary built against an old glibc still loads against a current one,
@@ -131,7 +131,7 @@ x86-64 the two you meet are System V AMD64 (Linux/macOS/BSD, args in
 `rdi, rsi, rdx, rcx, r8, r9`) and Microsoft x64 (Windows or via
 `__attribute__((ms_abi))`, args in `rcx, rdx, r8, r9`). On 32-bit x86 the
 zoo is larger: `cdecl`, `stdcall`, `fastcall`, `thiscall`, `vectorcall`.
-[Case 64](https://github.com/napetrov/abicheck/tree/main/examples/case64_calling_convention_changed) shows
+[Case 64](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/README.md) shows
 the attribute flipping silently: the v1 caller loads pointers into
 `rdi`/`rsi`, the v2 `ms_abi` callee reads `rcx`/`rdx`, and the function
 operates on stale register contents — zero results or a segfault.
@@ -145,18 +145,18 @@ The `PT_GNU_STACK` program header advertises whether the process stack
 must be executable, and the linker unions it across input objects — so a
 single assembly file missing its `.note.GNU-stack` annotation promotes the
 entire `.so` (and every process that loads it) to an executable stack.
-[Case 49](https://github.com/napetrov/abicheck/tree/main/examples/case49_executable_stack) shows
+[Case 49](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/README.md) shows
 `readelf -l` reporting `RWE` instead of `RW`; rpmlint and Debian lintian
 both reject the package.
 `DT_RPATH`/`DT_RUNPATH` hold extra linker search paths.
-[Case 52](https://github.com/napetrov/abicheck/tree/main/examples/case52_rpath_leak) shows a build system
+[Case 52](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/README.md) shows a build system
 baking `/home/build/myproject/lib` into the artifact: it only works on the
 build host, and anyone who can write that path gets a library-injection
 primitive. Use `$ORIGIN`-relative paths or strip `RPATH` entirely.
 
 ### Language Linkage and TLS
 
-[Case 66](https://github.com/napetrov/abicheck/tree/main/examples/case66_language_linkage_changed) covers
+[Case 66](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/README.md) covers
 `extern "C"` removal during a C++ modernization: source still compiles,
 but the `.dynsym` symbol flips from unmangled `parse_config` to mangled
 `_Z12parse_configPKc`, and every pre-linked consumer fails at load time.
@@ -165,7 +165,7 @@ TLS has four access models: `global-dynamic` (default for `.so`,
 `dlopen`-safe), `local-dynamic`, `initial-exec` (faster but requires
 presence at startup — `dlopen` fails), and `local-exec` (main executable
 only). Libraries intended for `dlopen` must avoid `initial-exec`.
-[Case 67](https://github.com/napetrov/abicheck/tree/main/examples/case67_tls_var_size_changed) adds a
+[Case 67](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/README.md) adds a
 second hazard: any exported `__thread` struct whose layout shifts corrupts
 consumers per-thread. Freeze size, layout, and access model of TLS exports
 as first-class ABI.

--- a/docs/concepts/abi-stability-guide.md
+++ b/docs/concepts/abi-stability-guide.md
@@ -81,10 +81,10 @@ lives in the `DT_SONAME` entry of `.dynamic` and is set via
 `DT_NEEDED`, and at runtime `ld.so` searches for a file (usually an
 `ldconfig`-managed symlink) matching that string.
 
-[Case 05](../../examples/case05_soname/README.md) covers a library built
+[Case 05](https://github.com/napetrov/abicheck/tree/main/examples/case05_soname) covers a library built
 without `-Wl,-soname` at all: `DT_NEEDED` points at the bare `libfoo.so`,
 which `ldconfig` cannot manage, so shipping `libfoo.so.1` later breaks
-every consumer. [Case 50](../../examples/case50_soname_inconsistent/README.md)
+every consumer. [Case 50](https://github.com/napetrov/abicheck/tree/main/examples/case50_soname_inconsistent)
 is the subtler bug where a 1.x release is tagged `libfoo.so.0`: packaging
 generates dependencies on the wrong major, and the cutover forces a
 distribution-wide rebuild. Rule: SONAME major equals ABI epoch, and it
@@ -97,13 +97,13 @@ Every `.dynsym` entry has an `st_other` visibility byte: `STV_DEFAULT`
 interposable), or `STV_INTERNAL`. Without `-fvisibility=hidden`, every
 non-`static` function defaults to `STV_DEFAULT`, dragging the entire
 translation unit into the public ABI.
-[Case 06](../../examples/case06_visibility/README.md) is the accidental
+[Case 06](https://github.com/napetrov/abicheck/tree/main/examples/case06_visibility) is the accidental
 leak: `internal_helper` was never intended as public API, but lacking
 `static` consumers can resolve it — the later "cleanup" that hides it
-breaks them. [Case 53](../../examples/case53_namespace_pollution/README.md)
+breaks them. [Case 53](https://github.com/napetrov/abicheck/tree/main/examples/case53_namespace_pollution)
 is the related design error: exporting unprefixed names like `init` that
 collide in the process's flat symbol namespace.
-[Case 51](../../examples/case51_protected_visibility/README.md) rounds it
+[Case 51](https://github.com/napetrov/abicheck/tree/main/examples/case51_protected_visibility) rounds it
 out: `DEFAULT` → `PROTECTED` is ABI-compatible for normal callers but
 silently defeats `LD_PRELOAD` interposition.
 
@@ -113,15 +113,15 @@ A version script (`-Wl,--version-script=libfoo.map`) groups symbols into
 named nodes like `LIBFOO_1.0`, recorded in `.gnu.version_d` and tagged in
 `.gnu.versym`; consumers carry matching `.gnu.version_r` entries. This lets
 one `.so` ship multiple ABI generations side by side.
-[Case 13](../../examples/case13_symbol_versioning/README.md) shows that
+[Case 13](https://github.com/napetrov/abicheck/tree/main/examples/case13_symbol_versioning) shows that
 *adding* a version script is backward compatible — old binaries have no
 `DT_VERNEED`, so `ld.so` resolves by name.
-[Case 65](../../examples/case65_symbol_version_removed/README.md) is the
+[Case 65](https://github.com/napetrov/abicheck/tree/main/examples/case65_symbol_version_removed) is the
 opposite: once a node has shipped, removing it deletes every symbol it
 tagged. glibc's `GLIBC_2.0` has been append-only since 1997 — which is
-why modern binaries still load on decade-old systems, and why OpenSSL
-3.0's version-node removals forced the SONAME bump from `libssl.so.1.1`
-to `.so.3`.
+why a binary built against an old glibc still loads against a current one,
+and why OpenSSL 3.0's version-node removals forced the SONAME bump from
+`libssl.so.1.1` to `.so.3`.
 
 ### Calling Conventions
 
@@ -131,7 +131,7 @@ x86-64 the two you meet are System V AMD64 (Linux/macOS/BSD, args in
 `rdi, rsi, rdx, rcx, r8, r9`) and Microsoft x64 (Windows or via
 `__attribute__((ms_abi))`, args in `rcx, rdx, r8, r9`). On 32-bit x86 the
 zoo is larger: `cdecl`, `stdcall`, `fastcall`, `thiscall`, `vectorcall`.
-[Case 64](../../examples/case64_calling_convention_changed/README.md) shows
+[Case 64](https://github.com/napetrov/abicheck/tree/main/examples/case64_calling_convention_changed) shows
 the attribute flipping silently: the v1 caller loads pointers into
 `rdi`/`rsi`, the v2 `ms_abi` callee reads `rcx`/`rdx`, and the function
 operates on stale register contents — zero results or a segfault.
@@ -145,18 +145,18 @@ The `PT_GNU_STACK` program header advertises whether the process stack
 must be executable, and the linker unions it across input objects — so a
 single assembly file missing its `.note.GNU-stack` annotation promotes the
 entire `.so` (and every process that loads it) to an executable stack.
-[Case 49](../../examples/case49_executable_stack/README.md) shows
+[Case 49](https://github.com/napetrov/abicheck/tree/main/examples/case49_executable_stack) shows
 `readelf -l` reporting `RWE` instead of `RW`; rpmlint and Debian lintian
 both reject the package.
 `DT_RPATH`/`DT_RUNPATH` hold extra linker search paths.
-[Case 52](../../examples/case52_rpath_leak/README.md) shows a build system
+[Case 52](https://github.com/napetrov/abicheck/tree/main/examples/case52_rpath_leak) shows a build system
 baking `/home/build/myproject/lib` into the artifact: it only works on the
 build host, and anyone who can write that path gets a library-injection
 primitive. Use `$ORIGIN`-relative paths or strip `RPATH` entirely.
 
 ### Language Linkage and TLS
 
-[Case 66](../../examples/case66_language_linkage_changed/README.md) covers
+[Case 66](https://github.com/napetrov/abicheck/tree/main/examples/case66_language_linkage_changed) covers
 `extern "C"` removal during a C++ modernization: source still compiles,
 but the `.dynsym` symbol flips from unmangled `parse_config` to mangled
 `_Z12parse_configPKc`, and every pre-linked consumer fails at load time.
@@ -165,7 +165,7 @@ TLS has four access models: `global-dynamic` (default for `.so`,
 `dlopen`-safe), `local-dynamic`, `initial-exec` (faster but requires
 presence at startup — `dlopen` fails), and `local-exec` (main executable
 only). Libraries intended for `dlopen` must avoid `initial-exec`.
-[Case 67](../../examples/case67_tls_var_size_changed/README.md) adds a
+[Case 67](https://github.com/napetrov/abicheck/tree/main/examples/case67_tls_var_size_changed) adds a
 second hazard: any exported `__thread` struct whose layout shifts corrupts
 consumers per-thread. Freeze size, layout, and access model of TLS exports
 as first-class ABI.

--- a/docs/concepts/abi-stability-guide.md
+++ b/docs/concepts/abi-stability-guide.md
@@ -67,7 +67,121 @@ Exported globals are the hardest class to refactor compatibly because the execut
 
 ## Part 4: ELF and Linker-Level Concerns
 
-<!-- filled by agent 5 -->
+A second contract sits between the source-level ABI and the running
+process: the one enforced by the dynamic linker. SONAME, visibility bits,
+version nodes, calling-convention attributes, and the TLS access model are
+all recorded in the `.so` and consulted at load time.
+
+### SONAME and Library Identity
+
+The SONAME is how `ld.so` answers "is this the library you asked for?". It
+lives in the `DT_SONAME` entry of `.dynamic` and is set via
+`-Wl,-soname,libfoo.so.MAJOR` at link time. When an app links against
+`libfoo.so`, the linker copies the SONAME — not the filename — into
+`DT_NEEDED`, and at runtime `ld.so` searches for a file (usually an
+`ldconfig`-managed symlink) matching that string.
+
+[Case 05](../../examples/case05_soname/README.md) covers a library built
+without `-Wl,-soname` at all: `DT_NEEDED` points at the bare `libfoo.so`,
+which `ldconfig` cannot manage, so shipping `libfoo.so.1` later breaks
+every consumer. [Case 50](../../examples/case50_soname_inconsistent/README.md)
+is the subtler bug where a 1.x release is tagged `libfoo.so.0`: packaging
+generates dependencies on the wrong major, and the cutover forces a
+distribution-wide rebuild. Rule: SONAME major equals ABI epoch, and it
+never silently changes.
+
+### Symbol Visibility
+
+Every `.dynsym` entry has an `st_other` visibility byte: `STV_DEFAULT`
+(public, interposable), `STV_HIDDEN`, `STV_PROTECTED` (exported but not
+interposable), or `STV_INTERNAL`. Without `-fvisibility=hidden`, every
+non-`static` function defaults to `STV_DEFAULT`, dragging the entire
+translation unit into the public ABI.
+[Case 06](../../examples/case06_visibility/README.md) is the accidental
+leak: `internal_helper` was never intended as public API, but lacking
+`static` consumers can resolve it — the later "cleanup" that hides it
+breaks them. [Case 53](../../examples/case53_namespace_pollution/README.md)
+is the related design error: exporting unprefixed names like `init` that
+collide in the process's flat symbol namespace.
+[Case 51](../../examples/case51_protected_visibility/README.md) rounds it
+out: `DEFAULT` → `PROTECTED` is ABI-compatible for normal callers but
+silently defeats `LD_PRELOAD` interposition.
+
+### Symbol Versioning
+
+A version script (`-Wl,--version-script=libfoo.map`) groups symbols into
+named nodes like `LIBFOO_1.0`, recorded in `.gnu.version_d` and tagged in
+`.gnu.versym`; consumers carry matching `.gnu.version_r` entries. This lets
+one `.so` ship multiple ABI generations side by side.
+[Case 13](../../examples/case13_symbol_versioning/README.md) shows that
+*adding* a version script is backward compatible — old binaries have no
+`DT_VERNEED`, so `ld.so` resolves by name.
+[Case 65](../../examples/case65_symbol_version_removed/README.md) is the
+opposite: once a node has shipped, removing it deletes every symbol it
+tagged. glibc's `GLIBC_2.0` has been append-only since 1997 — which is
+why modern binaries still load on decade-old systems, and why OpenSSL
+3.0's version-node removals forced the SONAME bump from `libssl.so.1.1`
+to `.so.3`.
+
+### Calling Conventions
+
+A calling convention is the register-and-stack contract: which registers
+hold args, which are callee-saved, and how the return comes back. On
+x86-64 the two you meet are System V AMD64 (Linux/macOS/BSD, args in
+`rdi, rsi, rdx, rcx, r8, r9`) and Microsoft x64 (Windows or via
+`__attribute__((ms_abi))`, args in `rcx, rdx, r8, r9`). On 32-bit x86 the
+zoo is larger: `cdecl`, `stdcall`, `fastcall`, `thiscall`, `vectorcall`.
+[Case 64](../../examples/case64_calling_convention_changed/README.md) shows
+the attribute flipping silently: the v1 caller loads pointers into
+`rdi`/`rsi`, the v2 `ms_abi` callee reads `rcx`/`rdx`, and the function
+operates on stale register contents — zero results or a segfault.
+`abicheck` catches it by diffing the `DW_AT_calling_convention` DWARF
+attribute; the signature is unchanged, so name-and-type-only checks miss
+it.
+
+### Security Metadata
+
+The `PT_GNU_STACK` program header advertises whether the process stack
+must be executable, and the linker unions it across input objects — so a
+single assembly file missing its `.note.GNU-stack` annotation promotes the
+entire `.so` (and every process that loads it) to an executable stack.
+[Case 49](../../examples/case49_executable_stack/README.md) shows
+`readelf -l` reporting `RWE` instead of `RW`; rpmlint and Debian lintian
+both reject the package.
+`DT_RPATH`/`DT_RUNPATH` hold extra linker search paths.
+[Case 52](../../examples/case52_rpath_leak/README.md) shows a build system
+baking `/home/build/myproject/lib` into the artifact: it only works on the
+build host, and anyone who can write that path gets a library-injection
+primitive. Use `$ORIGIN`-relative paths or strip `RPATH` entirely.
+
+### Language Linkage and TLS
+
+[Case 66](../../examples/case66_language_linkage_changed/README.md) covers
+`extern "C"` removal during a C++ modernization: source still compiles,
+but the `.dynsym` symbol flips from unmangled `parse_config` to mangled
+`_Z12parse_configPKc`, and every pre-linked consumer fails at load time.
+Treat `extern "C"` blocks as part of the public ABI.
+TLS has four access models: `global-dynamic` (default for `.so`,
+`dlopen`-safe), `local-dynamic`, `initial-exec` (faster but requires
+presence at startup — `dlopen` fails), and `local-exec` (main executable
+only). Libraries intended for `dlopen` must avoid `initial-exec`.
+[Case 67](../../examples/case67_tls_var_size_changed/README.md) adds a
+second hazard: any exported `__thread` struct whose layout shifts corrupts
+consumers per-thread. Freeze size, layout, and access model of TLS exports
+as first-class ABI.
+
+> **Best practice**
+>
+> - **Version scripts as the source of truth.** A `.map` file enumerating
+>   every intentional export is the canonical place to negotiate API surface.
+> - **`ABI_EXPORT` macro discipline.** Build with `-fvisibility=hidden` and
+>   annotate public functions with a project-specific macro.
+> - **CI gate: `abicheck` on every PR.** Dump the previous release, compare
+>   the candidate, fail on any `BREAKING` not paired with a SONAME bump.
+> - **Never link with absolute `--rpath`.** Use `$ORIGIN` or install-time
+>   rewriting; absolute build paths are non-portable and a security hazard.
+> - **Declare TLS access models explicitly.** If a TLS variable is ever
+>   reached via `dlopen`, pin `-ftls-model=global-dynamic`.
 
 ## Part 5: Subtle and Transitive Breaks
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - Architecture: concepts/architecture.md
     - ABI Breaks Explained: concepts/abi-breaks-explained.md
     - Breaking Cases Catalog: concepts/breaking-cases-catalog.md
+    - ABI Stability Guide: concepts/abi-stability-guide.md
     - Limitations: concepts/limitations.md
   - Reference:
     - Change Kinds: reference/change-kinds.md


### PR DESCRIPTION
## Summary

- Seeds `docs/concepts/abi-stability-guide.md` with a scaffold and fills in
  Part 4: ELF and Linker-Level Concerns.
- Six sub-sections cover SONAME, symbol visibility, symbol versioning,
  calling conventions, security metadata (GNU_STACK / RPATH), and language
  linkage with TLS models.
- Cross-references cases 05, 06, 13, 49, 50, 51, 52, 53, 64, 65, 66, 67,
  and closes with a best-practice checklist (version scripts as source of
  truth, `ABI_EXPORT` macro discipline, CI gating on `abicheck`, no
  absolute `--rpath`, explicit TLS models).

Parts 1–3 and Part 5 remain as `<!-- filled by agent N -->` placeholders
for the other agents in this coordinated docs effort.

## Test plan

- [ ] Preview `docs/concepts/abi-stability-guide.md` in a Markdown renderer
      and confirm all case links resolve to `examples/caseNN_*/README.md`.
- [ ] Verify Part 4 reads cleanly alongside the eventual Part 1–3 and
      Part 5 contributions.

https://claude.ai/code/session_01V5siyXj6oap255hdkfvYmU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive ABI Stability Guide covering dynamic-linker/ELF contracts: library identity (SONAME), symbol visibility and versioning, calling-convention mismatches, security-relevant metadata (e.g., stack executability), runtime search-path behavior, language linkage effects, and TLS access-model hazards. Includes practical examples, case references, and a consolidated best-practice checklist to help maintain stable, secure native interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->