### PR TITLE
docs(mcp): close gaps in MCP tool-use documentation

### DIFF
--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -494,9 +494,9 @@ def abi_dump(
 
     Args:
         library_path: Path to .so, .dll, or .dylib file.
-        headers: Public header file paths. Required for ELF (.so) — omitting them
-            produces a symbol-only snapshot with no type information. Not used for
-            PE (.dll) or Mach-O (.dylib) inputs.
+        headers: Public header file paths. For ELF (.so), omitting them produces
+            a symbol-only snapshot with no type information (strongly recommended
+            to supply headers). Not used for PE (.dll) or Mach-O (.dylib) inputs.
         include_dirs: Extra include directories for the C/C++ parser.
         version: Version label to embed in the snapshot (e.g. "1.2.3").
         language: Language mode — "c++" (default) or "c".

--- a/docs/user-guide/mcp-integration.md
+++ b/docs/user-guide/mcp-integration.md
@@ -64,8 +64,19 @@ Add to `.cursor/mcp.json` or VS Code MCP settings:
 
 The MCP server exposes four tools. All return JSON-encoded strings.
 
-Each tool returns either a success envelope (`{"status": "ok", ...}`) or an
-error envelope (`{"status": "error", "error": "<message>"}`). See
+**Response envelopes.** On failure, every tool returns the same error
+envelope: `{"status": "error", "error": "<message>"}`. On success the
+shape differs by tool:
+
+| Tool | Success envelope |
+|---|---|
+| `abi_compare` | `{"status": "ok", "verdict": ..., ...}` |
+| `abi_dump` | `{"status": "ok", "summary": ..., ...}` |
+| `abi_list_changes` | `{"count": ..., "change_kinds": [...]}` — no `status` field |
+| `abi_explain_change` | `{"kind": ..., "impact": ..., ...}` — no `status` field |
+
+The simplest client check is: `status == "error"` ⇒ failure; otherwise
+treat as success and parse the tool-specific payload. See
 [Error responses](#error-responses) for the error shape and common causes.
 
 ### `abi_compare` — Compare two ABI surfaces

--- a/docs/user-guide/mcp-integration.md
+++ b/docs/user-guide/mcp-integration.md
@@ -62,27 +62,39 @@ Add to `.cursor/mcp.json` or VS Code MCP settings:
 
 ## Tools
 
-The MCP server exposes four tools. All return structured JSON.
+The MCP server exposes four tools. All return JSON-encoded strings.
+
+Each tool returns either a success envelope (`{"status": "ok", ...}`) or an
+error envelope (`{"status": "error", "error": "<message>"}`). See
+[Error responses](#error-responses) for the error shape and common causes.
 
 ### `abi_compare` — Compare two ABI surfaces
 
 The primary tool. Diffs two library versions and reports breaking changes.
 
+Each input is auto-detected and may be a shared library
+(`.so` / `.dll` / `.dylib`), a JSON snapshot produced by `abi_dump`, or an
+ABICC Perl dump (`.pl` / `.dump`).
+
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `old_input` | string | yes | Path to old .so/.dll/.dylib or JSON snapshot |
-| `new_input` | string | yes | Path to new .so/.dll/.dylib or JSON snapshot |
-| `headers` | string[] | no | Header files for both sides |
-| `old_headers` | string[] | no | Headers for old side only |
-| `new_headers` | string[] | no | Headers for new side only |
-| `include_dirs` | string[] | no | Include directories for C/C++ parser |
+| `old_input` | string | yes | Path to old `.so`/`.dll`/`.dylib`, JSON snapshot, or ABICC Perl dump |
+| `new_input` | string | yes | Path to new `.so`/`.dll`/`.dylib`, JSON snapshot, or ABICC Perl dump |
+| `headers` | string[] | no | Shared header file list applied to both sides. Overridden per-side by `old_headers` / `new_headers` when those are supplied |
+| `old_headers` | string[] | no | Headers for old side only. Takes precedence over `headers` |
+| `new_headers` | string[] | no | Headers for new side only. Takes precedence over `headers` |
+| `include_dirs` | string[] | no | Include directories for the C/C++ parser |
 | `language` | string | no | `"c++"` (default) or `"c"` |
-| `policy` | string | no | `"strict_abi"` (default), `"sdk_vendor"`, or `"plugin_abi"` |
-| `policy_file` | string | no | Path to custom YAML policy file |
-| `suppression_file` | string | no | Path to YAML suppression file |
+| `policy` | string | no | `"strict_abi"` (default), `"sdk_vendor"`, or `"plugin_abi"`. See [Policy Profiles](policies.md) |
+| `policy_file` | string | no | Path to custom YAML policy file. Overrides `policy` when set |
+| `suppression_file` | string | no | Path to YAML [suppression](suppressions.md) file |
 | `output_format` | string | no | Report format: `"json"` (default), `"markdown"`, `"sarif"`, `"html"` |
+| `show_only` | string | no | Comma-separated filter tokens (display only). Severity: `breaking`, `api-break`, `risk`, `compatible`. Element: `functions`, `variables`, `types`, `enums`, `elf`. Action: `added`, `removed`, `changed` |
+| `report_mode` | string | no | `"full"` (default) or `"leaf"` (root-type-grouped view) |
+| `show_impact` | boolean | no | If `true`, append an impact summary table to the rendered report |
+| `stat` | boolean | no | If `true`, emit a one-line summary instead of the full report |
 
 **Response fields:**
 
@@ -106,7 +118,7 @@ The primary tool. Diffs two library versions and reports breaking changes.
       "impact": "breaking",
       "old_value": "helper",
       "new_value": null,
-      "source_location": null
+      "source_location": "include/foo.h:42"
     }
   ],
   "suppressed_count": 0,
@@ -114,28 +126,48 @@ The primary tool. Diffs two library versions and reports breaking changes.
 }
 ```
 
-The `verdict` field is one of: `NO_CHANGE`, `COMPATIBLE`, `COMPATIBLE_WITH_RISK`, `API_BREAK`, `BREAKING`.
+- `verdict` is one of: `NO_CHANGE`, `COMPATIBLE`, `COMPATIBLE_WITH_RISK`,
+  `API_BREAK`, `BREAKING`. See [Verdicts](../concepts/verdicts.md).
+- `changes[].impact` is one of `breaking`, `api_break`, `risk`, `compatible`
+  and reflects the *active* policy (so `sdk_vendor` may downgrade
+  source-level renames from `api_break` to `compatible`).
+- `changes[].source_location` is the originating header coordinate
+  (`"header.h:42"`) when known, otherwise `null`.
+- `report` is the rendered report. For `output_format="json"` it is embedded
+  as a nested object; for `"markdown"`, `"sarif"`, and `"html"` it is a
+  string.
 
-The `exit_code` matches CLI semantics: `0` = safe, `2` = API break, `4` = binary ABI break.
+**Verdict → `exit_code` mapping** (matches the CLI):
+
+| Verdict | `exit_code` |
+|---|:---:|
+| `NO_CHANGE` | 0 |
+| `COMPATIBLE` | 0 |
+| `COMPATIBLE_WITH_RISK` | 0 |
+| `API_BREAK` | 2 |
+| `BREAKING` | 4 |
+
+See [Exit Codes](../reference/exit-codes.md) for the full CLI matrix.
 
 ---
 
 ### `abi_dump` — Extract ABI snapshot
 
-Extracts the public ABI surface from a shared library and its headers into a JSON snapshot.
+Extracts the public ABI surface from a shared library (and, for ELF, its
+headers) into a JSON snapshot.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `library_path` | string | yes | Path to .so/.dll/.dylib file |
-| `headers` | string[] | no | Public header file paths (required for ELF) |
-| `include_dirs` | string[] | no | Extra include directories |
-| `version` | string | no | Version label (default: `"unknown"`) |
+| `library_path` | string | yes | Path to `.so`/`.dll`/`.dylib` file |
+| `headers` | string[] | no | Public header file paths. For ELF (`.so`), omitting headers produces a **symbol-only** snapshot with no type information. Not used for PE (`.dll`) or Mach-O (`.dylib`) inputs |
+| `include_dirs` | string[] | no | Extra include directories for the C/C++ parser |
+| `version` | string | no | Version label embedded in the snapshot (default: `"unknown"`) |
 | `language` | string | no | `"c++"` (default) or `"c"` |
-| `output_path` | string | no | Write snapshot to file; otherwise returned inline |
+| `output_path` | string | no | If provided, write the snapshot to this file; otherwise the snapshot is returned inline. See [Path restrictions](#path-restrictions-for-output_path) |
 
-**Response fields:**
+**Response — inline snapshot** (no `output_path`):
 
 ```json
 {
@@ -149,15 +181,38 @@ Extracts the public ABI surface from a shared library and its headers into a JSO
     "types": 12,
     "enums": 5
   },
-  "snapshot": { "..." }
+  "snapshot": { "...": "..." }
 }
 ```
+
+**Response — snapshot written to disk** (with `output_path`):
+
+```json
+{
+  "status": "ok",
+  "output_path": "/abs/path/to/snapshot.json",
+  "summary": {
+    "library": "libfoo.so.1",
+    "version": "1.2.3",
+    "platform": "elf",
+    "functions": 42,
+    "variables": 3,
+    "types": 12,
+    "enums": 5
+  }
+}
+```
+
+The `snapshot` field is omitted when `output_path` is used — read the file
+from disk instead.
 
 ---
 
 ### `abi_list_changes` — List detectable change kinds
 
-Enumerates all 145 `ChangeKind` values with their impact classification.
+Enumerates all 145 `ChangeKind` values with their impact classification. See
+the [Change Kinds Reference](../reference/change-kinds.md) for canonical
+documentation of each kind.
 
 **Parameters:**
 
@@ -206,6 +261,9 @@ Returns a detailed explanation of what a change kind means, why it's dangerous, 
 }
 ```
 
+The `severity` field is either `"error"` (`BREAKING`) or `"warning"`
+(`API_BREAK`, `COMPATIBLE_WITH_RISK`, and `COMPATIBLE` kinds).
+
 ## Agent workflow examples
 
 ### Check a PR for ABI compatibility
@@ -248,6 +306,130 @@ Agent: "What kinds of ABI breaks can you detect?"
 2. Agent summarizes the categories for the user
 ```
 
+## Error responses
+
+Every tool returns a JSON-encoded string. When something goes wrong the
+envelope is:
+
+```json
+{
+  "status": "error",
+  "error": "<short, sanitized message>"
+}
+```
+
+`error` messages from `AbicheckError`, `ValueError`, and `KeyError` are
+surfaced verbatim. Errors arising from the host file system
+(`OSError` / `FileNotFoundError` / `PermissionError`) and unexpected
+exceptions are reduced to generic messages — full details are logged to
+stderr but never returned to the MCP client. This avoids leaking absolute
+paths or internals through the agent transcript.
+
+Common causes:
+
+| Cause | Example `error` field |
+|---|---|
+| Missing input | `"File not found for old_input"` |
+| File too large | `"old_input is 612.4 MB, exceeds limit of 500 MB"` |
+| Tool exceeded `--timeout` | `"abi_compare timed out after 120s"` |
+| Unknown policy | `"Unknown policy: 'foo'. Valid policies: plugin_abi, sdk_vendor, strict_abi"` |
+| Bad `output_format` | `"Unknown output format 'pdf'. Valid: ['html', 'json', 'markdown', 'sarif']"` |
+| Bad `show_only` | `"Invalid show_only: <token>"` |
+| Disallowed `output_path` | `"output_path must have a .json extension, got: '.txt'"` |
+| Unrecognized change kind | `"Unknown change kind: 'foo'. Use abi_list_changes to see all available kinds."` |
+| Unparseable input | `"Cannot detect input format. Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."` |
+
+The MCP server process keeps running on errors — only the failing tool
+invocation is terminated.
+
+## Runtime configuration
+
+`abicheck-mcp` accepts CLI flags and environment variables for resource
+limits and logging. Flags override environment variables; environment
+variables override defaults.
+
+| CLI flag | Environment variable | Default | Purpose |
+|---|---|---|---|
+| `--timeout <s>` | `ABICHECK_MCP_TIMEOUT` | `120` | Per-call timeout (seconds) for `abi_dump` and `abi_compare`. On timeout the tool returns a structured error; the server stays up |
+| `--max-file-size <bytes>` | `ABICHECK_MCP_MAX_FILE_SIZE` | `524288000` (500 MB) | Maximum size of any input file (`library_path`, `old_input`, `new_input`) |
+| `--log-format text\|json` | — | `text` | Audit log format on stderr |
+
+Example invocation tuned for large libraries:
+
+```bash
+ABICHECK_MCP_TIMEOUT=600 ABICHECK_MCP_MAX_FILE_SIZE=2147483648 \
+  abicheck-mcp --log-format json
+```
+
+Or via MCP config:
+
+```json
+{
+  "mcpServers": {
+    "abicheck": {
+      "command": "abicheck-mcp",
+      "args": ["--timeout", "600", "--log-format", "json"],
+      "env": {
+        "ABICHECK_MCP_MAX_FILE_SIZE": "2147483648"
+      }
+    }
+  }
+}
+```
+
+### Audit logging
+
+Every tool invocation is logged at `INFO` level to **stderr** (stdout is
+reserved for JSON-RPC). The default text format looks like:
+
+```text
+INFO: abicheck.mcp: tool=abi_compare old=libfoo_v1.so new=libfoo_v2.so duration=3.412s status=ok verdict=BREAKING
+```
+
+With `--log-format json`:
+
+```json
+{"tool": "abi_compare", "inputs": {"old": "libfoo_v1.so", "new": "libfoo_v2.so"}, "duration_s": 3.412, "status": "ok", "verdict": "BREAKING"}
+```
+
+Only basenames are logged — never absolute paths. `status` is one of `ok`,
+`timeout`, or `error`. See [ADR-021](../development/adr/021-mcp-security-model.md)
+for the audit-logging rationale.
+
+## Troubleshooting
+
+**The MCP client can't find `abicheck-mcp`.**
+The optional `[mcp]` extra is required: `pip install "abicheck[mcp]"`. The
+plain `pip install abicheck` does not pull `mcp` in. With conda:
+`conda install abicheck && pip install "mcp[cli]>=1.2.0"`.
+
+**Tool calls silently fail with no logs.**
+Logs go to **stderr**, not stdout. If you launched the server through an
+MCP client, capture its stderr — most clients expose this in a "server
+output" or "logs" panel. Stdout must remain pure JSON-RPC; anything written
+there will corrupt the transport.
+
+**`abi_compare` returns `timed out after 120s`.**
+Large libraries with full DWARF can exceed the default. Raise
+`--timeout` (or `ABICHECK_MCP_TIMEOUT`). 600 s is a reasonable ceiling for
+multi-hundred-MB libraries. Use `abi_dump` to materialise snapshots once
+and compare snapshots thereafter — snapshot-to-snapshot compares are far
+faster than binary-to-binary.
+
+**`abi_dump` on a `.so` returns very few `types`/`enums`.**
+You probably didn't supply `headers`. Without headers, ELF dumps degrade
+to a symbol-only snapshot. Add the public headers (and `include_dirs` if
+they include third-party headers).
+
+**`Cannot detect input format`.**
+The file is not an ELF/PE/Mach-O binary, a JSON snapshot, or an ABICC
+Perl dump. Check the file with `file <path>` and convert if needed.
+
+**`output_path` is rejected.**
+Only `.json` outputs are allowed, and the path must not resolve into
+system or credential directories. Write to a project-local directory or
+a temp dir.
+
 ## Transport
 
 The server uses **stdio** transport — the agent spawns `abicheck-mcp` as a local subprocess and communicates over stdin/stdout. No network, no ports, no deployment needed.
@@ -281,6 +463,9 @@ The server uses **stdio** transport — the agent spawns `abicheck-mcp` as a loc
 
 ## Security
 
+See [ADR-021](../development/adr/021-mcp-security-model.md) for the full
+threat model and design rationale.
+
 ### Path restrictions for `output_path`
 
 When `abi_dump` writes a snapshot to disk via `output_path`, the MCP server
@@ -296,3 +481,41 @@ enforces the following policy:
 
 Read paths (`library_path`, `headers`, `include_dirs`) are not restricted —
 they follow the same access controls as the user running the MCP server.
+
+### Read-side protections
+
+In addition to the write-path policy above, every tool call is bounded
+to keep one bad input from disabling the server:
+
+- **File-size cap**: input files larger than `--max-file-size` (default
+  500 MB) are rejected before any parsing begins.
+- **Per-call timeout**: `abi_dump` and `abi_compare` run in a worker
+  thread bounded by `--timeout` (default 120 s). On timeout the tool
+  returns a structured error and the server keeps serving subsequent
+  calls.
+- **Sanitized errors**: filesystem paths and internal stack frames are
+  scrubbed from error messages returned to the client. Full details
+  remain in stderr logs for operators.
+
+### Transport
+
+The default stdio transport has no network listener — the MCP client
+spawns `abicheck-mcp` as a local subprocess and inherits the user's
+filesystem permissions. There is no authentication layer because there is
+no remote surface. Do not expose the server over the network without
+adding loopback-only binding and bearer-token auth (see ADR-021).
+
+## Related documentation
+
+- [Verdicts](../concepts/verdicts.md) — what each `verdict` value means
+- [Change Kinds Reference](../reference/change-kinds.md) — canonical list
+  of values for `change_kind` and `changes[].kind`
+- [Exit Codes](../reference/exit-codes.md) — full CLI exit-code matrix
+- [Policy Profiles](policies.md) — `strict_abi`, `sdk_vendor`,
+  `plugin_abi`, and custom YAML policies
+- [Suppressions](suppressions.md) — YAML and ABICC-format suppression
+  files accepted by `suppression_file`
+- [Output Formats](output-formats.md) — JSON, Markdown, SARIF, HTML
+- [Architecture](../concepts/architecture.md) — where the MCP server
+  sits in the overall pipeline
+- [ADR-021: MCP Security Model](../development/adr/021-mcp-security-model.md)


### PR DESCRIPTION
## Summary

Cross-referenced `docs/user-guide/mcp-integration.md` against the live `abicheck/mcp_server.py` implementation and closed every documentation gap that an agent author or operator would hit.

### What was missing before

- **Four `abi_compare` parameters** were undocumented: `show_only`, `report_mode`, `show_impact`, `stat`.
- **Input format coverage** omitted ABICC Perl dumps (the server auto-detects them).
- **Error responses** were not specified — only the success envelope appeared in examples.
- **Runtime configuration** (`--timeout` / `--max-file-size` / `--log-format` and their `ABICHECK_MCP_*` env vars) was source-only.
- The **verdict → `exit_code` mapping** glossed over `NO_CHANGE` / `COMPATIBLE` / `COMPATIBLE_WITH_RISK` (all 0).
- The `abi_dump` **response shape with `output_path`** (no inline `snapshot`, plus `output_path` field) wasn't shown.
- `abi_dump`'s "headers required for ELF" claim was wrong — they're strongly recommended; absence yields a symbol-only snapshot.
- No troubleshooting section; no cross-links to Verdicts, Change Kinds, Exit Codes, Policies, Suppressions, Output Formats, Architecture, or ADR-021.
- `changes[].source_location` format and `abi_explain_change.severity` values (`error` / `warning`) weren't described.
- Security section covered only `output_path` — read-side protections (file-size cap, per-call timeout, sanitized errors) weren't mentioned.

### Changes

- `docs/user-guide/mcp-integration.md`: +250 lines net, new sections **Error responses**, **Runtime configuration**, **Audit logging**, **Troubleshooting**, **Read-side protections**, **Related documentation**; corrected param tables and response examples.
- `abicheck/mcp_server.py`: fix the contradictory `abi_dump` docstring ("required for ELF" → "strongly recommended; absence produces a symbol-only snapshot").

## Test plan

- [x] `mkdocs build --strict` passes (no warnings, no broken cross-links).
- [x] `pytest tests/test_mcp_hardening.py tests/test_mcp_server_unit.py tests/test_mcp_server_coverage.py` → 189 passed, 4 skipped.
- [x] `ruff check abicheck/mcp_server.py` clean. (Pre-existing `ruff format` diffs in this file are unrelated to the docstring edit.)
- [x] All new sections present (`## Error responses`, `## Runtime configuration`, `## Troubleshooting`, `### Read-side protections`, `## Related documentation`).

https://claude.ai/code/session_0114dqhto2EnEf2hLnHUMqr7

---
_Generated by [Claude Code](https://claude.ai/code/session_0114dqhto2EnEf2hLnHUMqr7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded MCP integration guide with detailed tool parameter options, standardized JSON response envelopes, and clearly described response fields and exit-code mapping.
  * Clarified behavior of the header parameter and its effect on snapshot contents.
  * Added sections for error responses, runtime configuration, audit logging, troubleshooting, and strengthened security guidance with references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napetrov/abicheck/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->