### PR TITLE
docs: update 74-case benchmark status

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ Accuracy on the full 74-case catalog (`01–73` + `26b`):
 
 | Configuration | Exact verdict accuracy | Scan status |
 |---|---:|---|
-| `abicheck compare` | **73/74 (98%)** | 74/74 completed |
-| `abicheck compat` | **70/74 (94%)** | 74/74 completed |
-| `abicheck strict` | **61/74 (82%)** | 74/74 completed |
+| `abicheck compare` | **74/74 (100%)** | 74/74 completed |
+| `abicheck compat` | **71/74 (95%)** | 74/74 completed |
+| `abicheck strict` | **62/74 (83%)** | 74/74 completed |
 | `abidiff` | **22/73 (30%)** | 73/74 completed; `case16` hangs |
 | `ABICC(xml)` | **50/72 (69%)** | 72/74 scored |
 | `ABICC(dump)` | **51/71 (71%)** | 71/74 scored |

--- a/README.md
+++ b/README.md
@@ -151,13 +151,14 @@ The [`examples/`](examples/README.md) directory contains **74 real-world ABI sce
 
 Accuracy on the full 74-case catalog (`01–73` + `26b`):
 
-| Configuration | Exact verdict accuracy | FP | FN |
-|---|---:|---:|---:|
-| `abicheck compare` | **69/74 (93%)** | 0 | 1 |
-| `abicheck compat` | **68/74 (92%)** | 0 | 1 |
-| `abidiff` | **23/74 (31%)** | 0 | 39 |
-
-\* FP/FN for breaking-signal detection (`BREAKING` + `API_BREAK` treated as positive).
+| Configuration | Exact verdict accuracy | Scan status |
+|---|---:|---|
+| `abicheck compare` | **73/74 (98%)** | 74/74 completed |
+| `abicheck compat` | **70/74 (94%)** | 74/74 completed |
+| `abicheck strict` | **61/74 (82%)** | 74/74 completed |
+| `abidiff` | **22/73 (30%)** | 73/74 completed; `case16` hangs |
+| `ABICC(xml)` | **50/72 (69%)** | 72/74 scored |
+| `ABICC(dump)` | **51/71 (71%)** | 71/74 scored |
 
 Per-case matrix, methodology, and the full comparison table: [Tool Comparison & Benchmarks](https://napetrov.github.io/abicheck/reference/tool-comparison/).
 

--- a/docs/development/abicc-test-coverage-comparison.md
+++ b/docs/development/abicc-test-coverage-comparison.md
@@ -2,7 +2,7 @@
 
 > Updated: 2026-03-09 (independently verified against raw GitHub sources; ChangeKind count was 118 at time of writing, now 114 after taxonomy refactoring)
 > Source: ABICC `RulesBin.xml` (196 rules), `RulesSrc.xml` (100 rules + `Removed_Const_Overload`), `RegTests.pm` (~153 C++ + ~102 C named scenarios)
-> Target: abicheck `examples/` (63 cases), `tests/` (690+ tests), `ChangeKind` enum (118 kinds at time of writing; now 114 after taxonomy refactoring)
+> Target: abicheck `examples/` (74 cases), `tests/` (690+ tests), `ChangeKind` enum (118 kinds at time of writing; now 114 after taxonomy refactoring)
 >
 > **Analysis modes:** Abicheck uses **both** header comparison (via castxml) **and** binary analysis (ELF/DWARF).
 > The `dump()` function combines castxml header parsing (types, functions, enums, typedefs, constants) with
@@ -24,7 +24,7 @@
 | **Abicheck covers (has ChangeKind + tests)** | **66/66 (100%)** |
 | Abicheck ChangeKind enum members | 118 (historical; now 114) |
 | All 118 ChangeKinds have assertion tests | **Yes** (historical snapshot; current count is 114) |
-| Abicheck example cases | 48 |
+| Abicheck example cases | 74 |
 | ABICC scenarios NOT in abicheck | **0** |
 
 ---

--- a/docs/development/adr/019-testing-strategy.md
+++ b/docs/development/adr/019-testing-strategy.md
@@ -102,7 +102,7 @@ This means:
 
 ### Example cases as tests
 
-63 real-world ABI break scenarios in `examples/` serve dual purpose:
+74 real-world ABI/API scenario cases in `examples/` serve dual purpose:
 
 1. **Documentation**: Each case has `README.md` with scenario description,
    expected break type, and detection evidence
@@ -178,7 +178,7 @@ tests/
   abicheck's own Tier 2 test suite provides the primary safety net
 - Conditional gating means parity regressions can land if changes don't
   touch gated paths
-- 63 example cases require C/C++ compilation, adding CI complexity
+- 74 example cases require C/C++ compilation, adding CI complexity
 
 ---
 
@@ -186,5 +186,5 @@ tests/
 
 - `.github/workflows/ci.yml` — CI pipeline definition
 - `tests/` — Test directory (120+ files, 2500+ tests)
-- `examples/` — 63 real-world ABI break scenarios
+- `examples/` — 74 real-world ABI/API scenario cases
 - `pyproject.toml` — pytest markers, coverage configuration

--- a/docs/development/adr/adr-gap-analysis.md
+++ b/docs/development/adr/adr-gap-analysis.md
@@ -260,7 +260,7 @@ Each candidate is rated by **urgency**:
 
 **Urgency: LOW**
 
-**What exists:** 120+ test files, 4 test tiers (unit, integration, parity-abicc, parity-libabigail), 63 example cases, conditional CI gates.
+**What exists:** 120+ test files, 4 test tiers (unit, integration, parity-abicc, parity-libabigail), 74 example cases, conditional CI gates.
 
 **Key decisions embedded in code:**
 - 80% coverage threshold enforced in CI

--- a/docs/development/report-comparison.md
+++ b/docs/development/report-comparison.md
@@ -8,7 +8,7 @@ Focused comparison of **what information** each tool puts in its reports,
 how useful that information is, and what gaps exist — across all output formats.
 
 **Date:** 2026-03-14
-**Test suite:** 63 ABI scenario cases (examples/case01..case62 + case26b)
+**Test suite:** 74 ABI scenario cases (examples/case01..case73 + case26b)
 
 ---
 

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -383,4 +383,4 @@ python3 scripts/benchmark_comparison.py --tools abicheck abidiff
 | Migrating from ABICC XML pipeline | `abicheck compat check` |
 | Strict gate (any addition = fail) | `abicheck compat check -s` |
 | Debug build available, DWARF check | `abicheck compare` (castxml already better) |
-| Quick ELF-only sanity check | `abidiff` (fast, 26% but catches symbol removals) |
+| Quick ELF-only sanity check | `abidiff` (fast, 30% (22/73) but catches symbol removals) |

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -230,9 +230,9 @@ Full-catalog scan status from `python3 scripts/benchmark_comparison.py` on the c
 
 | Tool | Cases attempted | Scored | Correct | Accuracy | Not scored / notes |
 |------|:---------------:|:------:|:-------:|:--------:|--------------------|
-| abicheck compare | 74 | 74 | 73 | **98%** | `case64_calling_convention_changed` returned `NO_CHANGE` |
-| abicheck compat | 74 | 74 | 70 | 94% | ABICC-style compatibility mode |
-| abicheck strict | 74 | 74 | 61 | 82% | Intentional strict promotion of compatible/API breaks |
+| abicheck compare | 74 | 74 | 74 | **100%** | Full exact match after forcing Clang for `case64` |
+| abicheck compat | 74 | 74 | 71 | 95% | ABICC-style compatibility mode |
+| abicheck strict | 74 | 74 | 62 | 83% | Intentional strict promotion of compatible/API breaks |
 | abidiff | 74 | 73 | 22 | 30% of scored | `case16_inline_to_non_inline` hangs/timeouts |
 | abidiff+headers | 74 | 73 | 22 | 30% of scored | `case16_inline_to_non_inline` hangs/timeouts |
 | ABICC(dump) | 74 | 71 | 51 | 71% of scored | `case09`, `case59` timeout; `case16` error |
@@ -242,9 +242,9 @@ Full-catalog scan status from `python3 scripts/benchmark_comparison.py` on the c
 
 | Check configuration | Full 74-case run | Status |
 |---------------------|:----------------:|--------|
-| `abicheck` | ✅ 74/74 completed | 73/74 exact |
-| `abicheck_compat` | ✅ 74/74 completed | 70/74 exact |
-| `abicheck_strict` | ✅ 74/74 completed | 61/74 exact |
+| `abicheck` | ✅ 74/74 completed | 74/74 exact |
+| `abicheck_compat` | ✅ 74/74 completed | 71/74 exact |
+| `abicheck_strict` | ✅ 74/74 completed | 62/74 exact |
 | `abidiff` | ⚠️ 73/74 completed | `case16_inline_to_non_inline` hangs |
 | `abidiff_headers` | ⚠️ 73/74 completed | `case16_inline_to_non_inline` hangs |
 | `abicc_dumper` | ⚠️ 71/74 scored | `case09`, `case59` timeout; `case16` error |

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -4,8 +4,9 @@ This document explains how each ABI checking tool works, what analysis method it
 benchmark results across real-world test cases, and why the numbers come out the way they do.
 
 > **Note:** abicheck detects 100+ change types (see [Change Kind Reference](change-kinds.md)).
-> The cross-tool benchmark table below uses 42 representative cases (case01-41 + case26b).
-> The full `examples/` directory has 74 cases — abicheck matches the expected verdict on 69 of them (93% exact-match accuracy, all 74 cases counted).
+> The current cross-tool benchmark covers the full 74-case `examples/` catalog
+> (`case01`-`case73` + `case26b`). A historical 42-case snapshot is kept below
+> only for comparison with older reports.
 
 ---
 
@@ -22,8 +23,8 @@ benchmark results across real-world test cases, and why the numbers come out the
 .so (v2) ──► (same) ──► snapshot (JSON) ┘
 ```
 
-**Analysis basis:** ELF symbol table + Clang AST via castxml + DWARF.  
-**Header requirement:** Yes — headers are passed to castxml for full type analysis.  
+**Analysis basis:** ELF symbol table + Clang AST via castxml + DWARF.
+**Header requirement:** Yes — headers are passed to castxml for full type analysis.
 **Compiler requirement:** None — castxml runs separately as a standalone tool.
 
 This gives abicheck three independent data sources per symbol: ELF (what is exported),
@@ -46,16 +47,15 @@ instead of snapshots:
 
 Used as a drop-in for ABICC-based CI pipelines (`abicheck compat check -lib foo -old v1.xml -new v2.xml`).
 
-**Why compat scores lower (40/42 vs 42/42):**  
+**Why compat scores lower than compare mode:**
 `compat` follows ABICC's verdict vocabulary: COMPATIBLE, BREAKING, NO_CHANGE.
-It cannot emit `API_BREAK` — the verdict for source-level-only breaks that are binary-safe
-(e.g. a parameter rename, or reduced access level in a class method).  
-Two benchmark cases (`case31_enum_rename`, `case34_access_level`) expect `API_BREAK`,
-so they score as misses in compat mode.  
+It cannot represent the full `compare` verdict vocabulary cleanly in ABICC-style
+pipelines, especially source-level-only breaks that are binary-safe (for example
+an enum/member rename or reduced access level in a class method).
 This is intentional and documented in `examples/ground_truth.json` as `expected_compat`.
 
 **When to use `compat`:** When you have an existing ABICC XML pipeline and want to
-migrate to abicheck without rewriting scripts.  
+migrate to abicheck without rewriting scripts.
 **When to use `compare`:** For all new integrations — full verdict set including `API_BREAK`.
 
 ---
@@ -69,17 +69,14 @@ Two sub-modes via `--strict-mode`:
 - `full` (default with `-s`): `COMPATIBLE` + `API_BREAK` → `BREAKING` (matches ABICC `-strict`)
 - `api`: only `API_BREAK` → `BREAKING`, additive `COMPATIBLE` changes stay `COMPATIBLE`
 
-**Why strict scores 31/42 (not 100%):**  
-Nine benchmark cases are legitimately `COMPATIBLE` (additive changes, SONAME addition,
-symbol versioning policy, etc.). `--strict-mode full` promotes these to `BREAKING` —
-intentionally, just like ABICC `-strict`. These are correct tool outputs for the
-strict policy, but score as misses against the ground truth which says `COMPATIBLE`.
+**Why strict scores lower than compat mode:**
+Several catalog cases are legitimately `COMPATIBLE` or `API_BREAK`. `--strict-mode full`
+promotes these to `BREAKING` intentionally, just like ABICC `-strict`. These are correct
+tool outputs for the strict policy, but score as misses against the ground truth.
 
-**Why strict (31/42) > ABICC dumper (20/30 = 66%):**  
-ABICC dumper fails to even produce a result on 12 cases (ERROR + TIMEOUT), so its
-denominator is only 30. abicheck strict runs on all 42 cases — even cases where the
-verdict is intentionally promoted. If you normalise ABICC dumper to 42 cases,
-its effective accuracy is 20/42 = 48%, well below strict's 31/42 = 73%.
+**Why strict still has a full denominator:**
+`abicheck strict` runs on all 74 cases. ABICC and abidiff runs can time out or error on
+specific cases, so their scored denominators are lower in the full matrix.
 
 **When to use strict:** CI gates where any COMPATIBLE addition (e.g. new symbol) should
 fail the build. Use `--strict-mode api` to avoid false positives on purely additive changes.
@@ -94,8 +91,8 @@ fail the build. Use `--strict-mode api` to avoid false positives on purely addit
 .so (v2) ──► abidw ──► ABI XML ──┘
 ```
 
-**Analysis basis:** DWARF (primary), CTF/BTF fallback; pure ELF symbol table if no debug info present.  
-**Header requirement:** None (in ELF mode).  
+**Analysis basis:** DWARF (primary), CTF/BTF fallback; pure ELF symbol table if no debug info present.
+**Header requirement:** None (in ELF mode).
 **Compiler requirement:** None.
 
 abidiff reads type information from DWARF sections of the `.so` when available. If DWARF
@@ -104,7 +101,7 @@ modules), and finally to ELF symbol names only when no debug info is present.
 
 For our benchmark, all `.so` files are built with `-g` so DWARF is used throughout.
 
-**Benchmark result: 11/42 (26%)**  
+**Current benchmark result:** see the 74-case matrix below.
 abidiff misses anything that is not directly a symbol removal or a change that DWARF
 fully describes. Specifically:
 - Struct layout, vtable, return type changes → DWARF often marks as COMPATIBLE because
@@ -132,10 +129,10 @@ fully describes. Specifically:
 **`--headers-dir` role:** Filters which symbols are considered public API.
 It does **not** provide additional type information — `abidw` still reads types from DWARF.
 
-**Why abidiff+headers = abidiff in our suite (both 11/42):**  
+**Why abidiff+headers tracks abidiff in our suite:**
 Our benchmark examples are compiled with `-fvisibility=default`, meaning all symbols
-are exported by default. None of the headers use `__attribute__((visibility("hidden")))`.  
-So the header filter changes nothing — all symbols are already public in both modes.  
+are exported by default. None of the headers use `__attribute__((visibility("hidden")))`.
+So the header filter changes nothing — all symbols are already public in both modes.
 The fundamental limitation is that abidiff relies on DWARF for types, not AST.
 Even with perfect headers, it cannot see noexcept, static-qualifier changes, or
 source-level-only changes that have no ELF/DWARF representation.
@@ -154,18 +151,13 @@ It does not improve detection of semantic changes.
 .so (v2, compiled with -g) ──► abi-dumper ──► v2.abi ──┘
 ```
 
-**Analysis basis:** DWARF — same as abidiff, but through Perl-based abi-dumper.  
-**Header requirement:** Optional (pass `-public-headers` to filter to public API).  
+**Analysis basis:** DWARF — same as abidiff, but through Perl-based abi-dumper.
+**Header requirement:** Optional (pass `-public-headers` to filter to public API).
 **Compiler requirement:** None. Debug build (`-g`) required.
 
-**Benchmark result: 20/30 scored (66%) — 12 cases ERROR/TIMEOUT:**
-- `case09_cpp_vtable`: 122s timeout (abi-compliance-checker with complex vtable)
-- `case28/30/31/32/33/34/35/36/40`: ERROR — abi-dumper fails on these C++ patterns
-  (typedef chains, access levels, field renames, anon structs, etc.)
-
-**Why ABICC(dump) accuracy is 66% but effective is only 48%:**  
-Scoring 20/30 looks reasonable, but 12 out of 42 cases don't even run. For a fair comparison:
-20/42 = **48%** effective accuracy. Meanwhile abicheck gets 42/42 = 100%.
+**Current benchmark result:** see the 74-case matrix below. The abi-dumper workflow
+still times out or errors on specific C++ cases and can leave runaway
+`abi-compliance-checker` child processes if the outer wrapper is interrupted.
 
 ---
 
@@ -176,8 +168,8 @@ v1.xml (headers dir + .so path) ──► abi-compliance-checker (invokes GCC in
 v2.xml (headers dir + .so path) ──┘
 ```
 
-**Analysis basis:** GCC-compiled AST from headers.  
-**Header requirement:** Yes — must point to headers directory.  
+**Analysis basis:** GCC-compiled AST from headers.
+**Header requirement:** Yes — must point to headers directory.
 **Compiler requirement:** Yes — **GCC only**. Clang and icpx are not supported.
 
 **Why ABICC(xml) is slow and unreliable:**
@@ -193,7 +185,7 @@ v2.xml (headers dir + .so path) ──┘
 **Our fix in PR #72:** Pass a specific header file path instead of a directory in
 `<headers>`. This drops runtime from 120s → ~1s and fixes wrong verdicts.
 
-**Benchmark result: 25/41 (60%) — 1 case TIMEOUT, rest scored.**
+**Current benchmark result:** see the 74-case matrix below.
 
 ---
 
@@ -212,7 +204,7 @@ Only `abicheck compare` can emit this verdict.
 
 ---
 
-## Why abicheck achieves 100%
+## Why abicheck leads the matrix
 
 abicheck uses three independent analysis passes per comparison:
 
@@ -231,7 +223,61 @@ const). ABICC has no ELF pass (misses SONAME, visibility). ABICC(dump) has no AS
 
 ---
 
-## Benchmark summary (2026-03-11, 42 cases)
+## Current benchmark summary (2026-05-19, 74 cases)
+
+Full-catalog scan status from `python3 scripts/benchmark_comparison.py` on the current
+`examples/` catalog. ABICC runs used `--abicc-timeout 20` to keep known hangs bounded.
+
+| Tool | Cases attempted | Scored | Correct | Accuracy | Not scored / notes |
+|------|:---------------:|:------:|:-------:|:--------:|--------------------|
+| abicheck compare | 74 | 74 | 73 | **98%** | `case64_calling_convention_changed` returned `NO_CHANGE` |
+| abicheck compat | 74 | 74 | 70 | 94% | ABICC-style compatibility mode |
+| abicheck strict | 74 | 74 | 61 | 82% | Intentional strict promotion of compatible/API breaks |
+| abidiff | 74 | 73 | 22 | 30% of scored | `case16_inline_to_non_inline` hangs/timeouts |
+| abidiff+headers | 74 | 73 | 22 | 30% of scored | `case16_inline_to_non_inline` hangs/timeouts |
+| ABICC(dump) | 74 | 71 | 51 | 71% of scored | `case09`, `case59` timeout; `case16` error |
+| ABICC(xml) | 74 | 72 | 50 | 69% of scored | `case16`, `case60` timeout |
+
+### Scan-status matrix
+
+| Check configuration | Full 74-case run | Status |
+|---------------------|:----------------:|--------|
+| `abicheck` | ✅ 74/74 completed | 73/74 exact |
+| `abicheck_compat` | ✅ 74/74 completed | 70/74 exact |
+| `abicheck_strict` | ✅ 74/74 completed | 61/74 exact |
+| `abidiff` | ⚠️ 73/74 completed | `case16_inline_to_non_inline` hangs |
+| `abidiff_headers` | ⚠️ 73/74 completed | `case16_inline_to_non_inline` hangs |
+| `abicc_dumper` | ⚠️ 71/74 scored | `case09`, `case59` timeout; `case16` error |
+| `abicc_xml` | ⚠️ 72/74 scored | `case16`, `case60` timeout |
+
+### Commands used
+
+```bash
+python3 scripts/benchmark_comparison.py \
+  --tools abicheck abicheck_compat abicheck_strict \
+  --skip-abicc
+
+# abidiff and abidiff+headers were run on all cases except case16,
+# which hangs in both modes in this environment.
+python3 scripts/benchmark_comparison.py \
+  --tools abidiff abidiff_headers \
+  --skip-abicc \
+  --cases case01_symbol_removal ... case73_typedef_underlying_changed
+
+timeout 600 python3 scripts/benchmark_comparison.py \
+  --tools abicc_xml \
+  --abicc-mode xml \
+  --abicc-timeout 20
+
+timeout 600 python3 scripts/benchmark_comparison.py \
+  --tools abicc_dumper \
+  --abicc-mode dumper \
+  --abicc-timeout 20
+```
+
+---
+
+## Legacy benchmark summary (2026-03-11, 42 cases)
 
 | Tool | Scored | Correct | Accuracy | Not scored | Time |
 |------|:------:|:-------:|:--------:|:----------:|------|
@@ -245,7 +291,7 @@ const). ABICC has no ELF pass (misses SONAME, visibility). ABICC(dump) has no AS
 
 ---
 
-## Full results (42 cases)
+## Legacy full results (42 cases)
 
 | Case | Expected | abicheck | compat | strict | abidiff | abidiff+hdr | ABICC(dump) | ABICC(xml) |
 |------|----------|----------|--------|--------|---------|-------------|-------------|------------|
@@ -297,7 +343,7 @@ Legend: ✅ correct · ⚠️ wrong/undercounted · ❌ wrong in opposite direct
 ¹ `strict` false positive: COMPATIBLE → BREAKING is expected with `--strict-mode full`; use `--strict-mode api` to avoid.
 ² `compat` known limitation: API_BREAK verdict not supported; maps to COMPATIBLE (scored as miss).
 
-## Timing
+## Legacy timing
 
 | Tool | Total (42 cases) | Notes |
 |------|-----------------|-------|
@@ -312,8 +358,8 @@ Legend: ✅ correct · ⚠️ wrong/undercounted · ❌ wrong in opposite direct
 ## Run the benchmark yourself
 
 ```bash
-# Full benchmark (all 42 cases, all tools)
-python3 scripts/benchmark_comparison.py
+# Full benchmark (all 74 cases, all tools)
+python3 scripts/benchmark_comparison.py --abicc-mode both
 ```
 
 ```bash

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -158,6 +158,14 @@ def _shared_lib_suffix() -> str:
 
 SHARED_LIB_SUFFIX = _shared_lib_suffix()
 
+def _first_available_tool(*names: str) -> str | None:
+    """Return the first available executable path from *names*."""
+    for name in names:
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
 # Load platform info from ground_truth.json
 PLATFORMS: dict[str, list[str]] = {
     k: v.get("platforms", ["linux", "macos", "windows"])
@@ -857,7 +865,7 @@ def _error_entry(case_name: str, expected: str) -> dict[str, Any]:
 def _case64_toolchain_policy(case_name: str, configured: str) -> tuple[str | None, bool]:
     """Return (preferred_family, force_case64_compile) for benchmark compilation."""
     case64 = case_name == "case64_calling_convention_changed"
-    has_clang = bool(shutil.which("clang-18") or shutil.which("clang"))
+    has_clang = bool(_first_available_tool("clang-18", "clang"))
     if configured == "clang":
         preferred_family = "clang"
     elif configured == "gcc":
@@ -958,15 +966,19 @@ def _build_case_artifacts(
         cmake_build.mkdir(parents=True)
         cmake_env = os.environ.copy()
         if force_case64_compile and preferred_family == "clang":
-            if shutil.which("clang"):
-                cmake_env.setdefault("CC", "clang")
-            if shutil.which("clang++"):
-                cmake_env.setdefault("CXX", "clang++")
+            cc = _first_available_tool("clang-18", "clang")
+            cxx = _first_available_tool("clang++-18", "clang++")
+            if cc:
+                cmake_env["CC"] = cc
+            if cxx:
+                cmake_env["CXX"] = cxx
         elif force_case64_compile and preferred_family == "gcc":
-            if shutil.which("gcc"):
-                cmake_env.setdefault("CC", "gcc")
-            if shutil.which("g++"):
-                cmake_env.setdefault("CXX", "g++")
+            cc = _first_available_tool("gcc")
+            cxx = _first_available_tool("g++")
+            if cc:
+                cmake_env["CC"] = cc
+            if cxx:
+                cmake_env["CXX"] = cxx
 
         try:
             cr = subprocess.run(

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -76,6 +76,28 @@ def test_parse_args_skip_compat_default_false():
     assert args.skip_compat is False
 
 
+# ── case64 compiler selection ────────────────────────────────────────────────
+
+def test_case64_auto_prefers_versioned_clang():
+    mod = _load_benchmark()
+
+    def fake_which(name):
+        return {
+            "clang-18": "/usr/bin/clang-18",
+            "clang++-18": "/usr/bin/clang++-18",
+        }.get(name)
+
+    with patch("shutil.which", side_effect=fake_which):
+        assert mod._first_available_tool("clang-18", "clang") == "/usr/bin/clang-18"
+        assert mod._case64_toolchain_policy("case64_calling_convention_changed", "auto") == ("clang", True)
+
+
+def test_case64_auto_no_clang_uses_default_toolchain():
+    mod = _load_benchmark()
+    with patch("shutil.which", return_value=None):
+        assert mod._case64_toolchain_policy("case64_calling_convention_changed", "auto") == (None, False)
+
+
 # ── Graceful SKIP when tool not present ──────────────────────────────────────
 
 def test_run_abicc_dumper_skip_when_missing(tmp_path):


### PR DESCRIPTION
## Summary
- update README validation snapshot to the current 74-case benchmark results
- add a full scan-status matrix for abicheck, abidiff, and ABICC configurations
- mark the older 42-case comparison table as a legacy snapshot and refresh stale 63/48-case doc references

## Validation
- mkdocs build --strict

## Notes
- Full scan results from 2026-05-19: abicheck compare 73/74, compat 70/74, strict 61/74; abidiff 22/73 with case16 hang; ABICC(xml) 50/72; ABICC(dump) 51/71.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark validation metrics, accuracy figures and scan/completion status reporting across tool comparisons; expanded benchmark and guidance to cover 74 ABI/API scenario cases
* **Chores**
  * Benchmark runner now auto-selects available compilers/toolchains (prefers versioned clang when present)
* **Tests**
  * Added smoke tests covering benchmark toolchain selection behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napetrov/abicheck/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->