### PR TITLE
feat(build_mode): capture compiler/stdlib/std normalization in snapshot (PR 3/3, schema v5)

### DIFF
--- a/abicheck/build_mode.py
+++ b/abicheck/build_mode.py
@@ -1,0 +1,298 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build-mode capture for ABI snapshots.
+
+Captures normalized toolchain / build-configuration metadata into the
+snapshot so the comparator can attribute layout/mangling differences to
+build mode rather than to a real ABI change.
+
+The dropdead requirement from the PR-ε.1 design review (CI / infra
+engineer):
+
+    Only normalized fields go into the comparable :class:`BuildMode`
+    record. Raw producer strings live under ``provenance.raw_producer``
+    which is *not* part of equality. This guarantees stable snapshots
+    across CI runners with different point-version toolchains.
+
+Detection heuristics (from PR-ε.1's DWARF expert review):
+
+* **Compiler family** — ``DW_AT_producer`` (per-CU) and ELF
+  ``.comment``.  Producer strings differ in format but are reliably
+  prefixed: ``GCC: (...) 11.4.0``, ``clang version 17.0.6``,
+  ``Microsoft (R) Optimizing Compiler``, ``Intel(R) oneAPI DPC++/C++``.
+* **C++ standard** — ``DW_AT_language`` is *unreliable* (clang stamps
+  ``DW_LANG_C_plus_plus_14`` for everything ≤ c++17 in older versions).
+  We fall back to ``unknown`` rather than guessing.
+* **libstdc++ dual-ABI** — presence of the ``B5cxx11`` ABI tag in any
+  mangled symbol indicates ``_GLIBCXX_USE_CXX11_ABI=1``. The
+  ``__cxx11::`` namespace component is a less-reliable secondary signal.
+* **libc++ ABI version** — ``_ZNSt3__1`` prefix = ABI v1 (stable);
+  ``_ZNSt3__2`` = ABI v2 (``_LIBCPP_ABI_VERSION=2``).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class CompilerFamily(str, Enum):
+    """Normalized compiler identity.  Patch / minor version intentionally
+    NOT captured here — those live in :attr:`BuildMode.provenance` so
+    snapshots stay equal across CI runners with different point releases."""
+
+    GCC = "gcc"
+    CLANG = "clang"
+    MSVC = "msvc"
+    ICX = "icx"          # Intel oneAPI DPC++/C++ (clang-based)
+    ICC = "icc"          # Classic Intel C++ compiler (pre-oneAPI)
+    UNKNOWN = "unknown"
+
+
+class StdlibFamily(str, Enum):
+    LIBSTDCXX = "libstdc++"
+    LIBCXX = "libc++"
+    MSVC_STL = "msvc_stl"
+    UNKNOWN = "unknown"
+
+
+class CxxStandard(str, Enum):
+    """Coarse-grained C++ standard bucket.
+
+    Maps DWARF ``DW_AT_language`` values to a stable enum.  Note that
+    clang ≤ 16 emits ``DW_LANG_C_plus_plus_14`` for any ``-std=c++14/17``
+    target, so the bucket for those cases is :attr:`CXX14_OR_LATER` —
+    callers must not assume the literal ``c++14`` constraint.
+    """
+
+    C = "c"
+    CXX98 = "c++98"
+    CXX11 = "c++11"
+    CXX14 = "c++14"
+    CXX14_OR_LATER = "c++14_or_later"   # clang ≤ 16 ambiguity bucket
+    CXX17 = "c++17"
+    CXX20 = "c++20"
+    CXX23 = "c++23"
+    UNKNOWN = "unknown"
+
+
+class GlibcxxDualAbi(str, Enum):
+    """libstdc++ dual-ABI flavor (only meaningful when stdlib == LIBSTDCXX)."""
+
+    CXX11 = "cxx11"      # _GLIBCXX_USE_CXX11_ABI=1 (default since gcc 5)
+    OLD = "old"          # _GLIBCXX_USE_CXX11_ABI=0 (legacy)
+    NOT_APPLICABLE = "n/a"
+
+
+@dataclass(frozen=True)
+class BuildModeProvenance:
+    """Raw, non-normalized capture for debugging / human inspection.
+
+    These fields are **excluded from equality comparison** so two
+    snapshots produced on different CI runners with the same effective
+    build configuration compare equal.  Mark this clearly: anything that
+    encodes a point-release version, a build timestamp, or a runner
+    identifier belongs here, not in :class:`BuildMode`.
+    """
+
+    raw_producer: str | None = None       # DW_AT_producer of the first CU
+    raw_comment: str | None = None        # ELF .comment section contents
+    compiler_version: str | None = None   # extracted version, e.g. "11.4.0"
+
+
+@dataclass
+class BuildMode:
+    """Normalized build-mode descriptor.  Stable across CI runners; the
+    fields are exactly the dimensions that materially change ABI."""
+
+    compiler_family: CompilerFamily = CompilerFamily.UNKNOWN
+    language_std: CxxStandard = CxxStandard.UNKNOWN
+    stdlib: StdlibFamily = StdlibFamily.UNKNOWN
+    glibcxx_dual_abi: GlibcxxDualAbi = GlibcxxDualAbi.NOT_APPLICABLE
+    libcpp_abi_version: int | None = None   # 1, 2 (libc++ inline-NS); None = N/A
+    # Non-compared provenance.  Use a default factory so equality on
+    # BuildMode is "frozen on the normalized fields only" even though
+    # provenance is mutable / per-runner.
+    provenance: BuildModeProvenance = field(
+        default_factory=BuildModeProvenance, compare=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detection helpers (pure functions, easy to unit-test against raw strings)
+# ---------------------------------------------------------------------------
+
+
+# The patterns below capture both shapes GCC emits:
+#   1. ELF .comment: ``GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0``
+#   2. DW_AT_producer: ``GNU C++17 11.4.0 -mtune=generic -march=x86-64``
+_GCC_PRODUCER = re.compile(
+    r"(?:GCC:?|GNU\s+(?:C|C\+\+|C99|Fortran)[\d+]*)\s*\(?[^)]*\)?\s*"
+    r"(?P<ver>\d+(?:\.\d+){0,2})",
+    re.IGNORECASE,
+)
+_CLANG_PRODUCER = re.compile(
+    r"clang\s+version\s+(?P<ver>\d+(?:\.\d+){0,2})", re.IGNORECASE,
+)
+_ICX_PRODUCER = re.compile(
+    r"(?:Intel\(R\)\s+oneAPI\s+DPC\+\+/C\+\+|icx)\s*[A-Za-z]*\s*(?P<ver>\d+(?:\.\d+){0,2})?",
+    re.IGNORECASE,
+)
+_ICC_PRODUCER = re.compile(
+    r"(?:Intel\(R\)\s+C\+\+\s+Compiler|icc)\s*[A-Za-z]*\s*(?P<ver>\d+(?:\.\d+){0,2})?",
+    re.IGNORECASE,
+)
+# MSVC ships several producer-string variants:
+#   ``Microsoft (R) Optimizing Compiler``
+#   ``Microsoft (R) C/C++ Optimizing Compiler Version 19.35.32217``
+# Match any "Microsoft (R) ... Compiler" prefix.
+_MSVC_PRODUCER = re.compile(
+    r"(?:Microsoft\s*\(R\)\s+[\w/+ ]*?Compiler|^MSVC)"
+    r"(?:\s+Version)?\s*(?P<ver>\d+(?:\.\d+){0,2})?",
+    re.IGNORECASE,
+)
+
+
+def detect_compiler_family(
+    producer: str | None,
+    comment: str | None,
+) -> tuple[CompilerFamily, str | None]:
+    """Return (family, version_string) from raw producer / comment strings.
+
+    Priority order matches real-world ambiguity: ICX strings can contain
+    the substring "clang", so we check Intel markers first; MSVC strings
+    are unique; classic ICC is checked before generic clang.
+    """
+    for text in (producer or "", comment or ""):
+        if not text:
+            continue
+        m = _ICX_PRODUCER.search(text)
+        if m and "DPC++" in text or "oneAPI" in (text or ""):
+            return CompilerFamily.ICX, (m.group("ver") if m else None)
+        m = _ICC_PRODUCER.search(text)
+        if m and "Intel" in text and "DPC++" not in text:
+            return CompilerFamily.ICC, m.group("ver")
+        m = _MSVC_PRODUCER.search(text)
+        if m and ("Microsoft" in text or "MSVC" in text):
+            return CompilerFamily.MSVC, m.group("ver")
+        m = _CLANG_PRODUCER.search(text)
+        if m:
+            return CompilerFamily.CLANG, m.group("ver")
+        m = _GCC_PRODUCER.search(text)
+        if m:
+            return CompilerFamily.GCC, m.group("ver")
+    return CompilerFamily.UNKNOWN, None
+
+
+# DWARF language tags (from <dwarf.h>) → CxxStandard.  Many real
+# compilers stamp coarse tags even for stricter -std= flags; the bucket
+# below reflects what is actually observable.  Caller MUST treat
+# CXX14_OR_LATER as a lower-bound, not a literal claim of C++14.
+_DWARF_LANG_TO_STD: dict[int, CxxStandard] = {
+    0x01: CxxStandard.C,                # DW_LANG_C89
+    0x02: CxxStandard.CXX98,            # DW_LANG_C_plus_plus (pre-C++03)
+    0x0c: CxxStandard.C,                # DW_LANG_C99
+    0x19: CxxStandard.CXX11,            # DW_LANG_C_plus_plus_03
+    0x1a: CxxStandard.CXX11,            # DW_LANG_C_plus_plus_11
+    0x21: CxxStandard.CXX14_OR_LATER,   # DW_LANG_C_plus_plus_14
+    0x2a: CxxStandard.CXX17,            # DW_LANG_C_plus_plus_17
+    0x2b: CxxStandard.CXX20,            # DW_LANG_C_plus_plus_20
+    0x2e: CxxStandard.CXX23,            # DW_LANG_C_plus_plus_23
+}
+
+
+def detect_cxx_standard(dwarf_language: int | None) -> CxxStandard:
+    """Map a DWARF ``DW_AT_language`` constant to a :class:`CxxStandard`."""
+    if dwarf_language is None:
+        return CxxStandard.UNKNOWN
+    return _DWARF_LANG_TO_STD.get(int(dwarf_language), CxxStandard.UNKNOWN)
+
+
+# Substrings on mangled names that uniquely identify a stdlib.  The
+# B5cxx11 ABI tag is the *primary* libstdc++ dual-ABI signal; namespace
+# components like __cxx11 are secondary.
+_LIBCXX_NAMESPACE_RE = re.compile(r"_ZN(?:K?)St(\d+)__([12])")
+_GLIBCXX_CXX11_TAG = "B5cxx11"
+# The libstdc++ ``__cxx11::`` inline-namespace mangles as ``7__cxx11`` in
+# Itanium symbols.  Presence is a secondary signal of the C++11 dual-ABI
+# when the more specific ``B5cxx11`` ABI tag isn't present on the sample.
+_GLIBCXX_CXX11_NAMESPACE = "7__cxx11"
+
+
+def detect_stdlib_and_abi(
+    mangled_symbols: list[str],
+) -> tuple[StdlibFamily, GlibcxxDualAbi, int | None]:
+    """Infer stdlib family + dual-ABI flag + libc++ ABI version from a
+    sample of mangled names. Returns ``(stdlib, glibcxx_dual_abi,
+    libcpp_abi_version)``."""
+    saw_libstdcxx = False
+    saw_libcxx = False
+    saw_glibcxx_tag = False
+    libcpp_abi: int | None = None
+
+    for sym in mangled_symbols:
+        if not sym or not sym.startswith("_Z"):
+            continue
+        if _GLIBCXX_CXX11_TAG in sym or _GLIBCXX_CXX11_NAMESPACE in sym:
+            saw_glibcxx_tag = True
+            saw_libstdcxx = True
+        m = _LIBCXX_NAMESPACE_RE.match(sym)
+        if m:
+            saw_libcxx = True
+            if libcpp_abi is None:
+                # The second capture group is the inline-NS digit.
+                libcpp_abi = int(m.group(2))
+        # libstdc++ symbols are prefixed _ZNSt without the __[12] suffix.
+        elif sym.startswith(("_ZNSt", "_ZNKSt")):
+            saw_libstdcxx = True
+
+    if saw_libcxx and not saw_libstdcxx:
+        return StdlibFamily.LIBCXX, GlibcxxDualAbi.NOT_APPLICABLE, libcpp_abi
+    if saw_libstdcxx:
+        abi = (
+            GlibcxxDualAbi.CXX11 if saw_glibcxx_tag
+            else GlibcxxDualAbi.OLD
+        )
+        return StdlibFamily.LIBSTDCXX, abi, None
+    return StdlibFamily.UNKNOWN, GlibcxxDualAbi.NOT_APPLICABLE, libcpp_abi
+
+
+def build_mode_from_signals(
+    *,
+    raw_producer: str | None = None,
+    raw_comment: str | None = None,
+    dwarf_language: int | None = None,
+    mangled_symbols: list[str] | None = None,
+) -> BuildMode:
+    """Convenience constructor that runs every detector in turn.
+
+    Test inputs go in as raw strings; production callers thread the
+    same values from :class:`AbiSnapshot.dwarf` and :class:`ElfMetadata`.
+    """
+    family, version = detect_compiler_family(raw_producer, raw_comment)
+    std = detect_cxx_standard(dwarf_language)
+    stdlib, dual_abi, libcpp_abi = detect_stdlib_and_abi(mangled_symbols or [])
+    return BuildMode(
+        compiler_family=family,
+        language_std=std,
+        stdlib=stdlib,
+        glibcxx_dual_abi=dual_abi,
+        libcpp_abi_version=libcpp_abi,
+        provenance=BuildModeProvenance(
+            raw_producer=raw_producer,
+            raw_comment=raw_comment,
+            compiler_version=version,
+        ),
+    )

--- a/abicheck/build_mode.py
+++ b/abicheck/build_mode.py
@@ -146,12 +146,16 @@ _GCC_PRODUCER = re.compile(
 _CLANG_PRODUCER = re.compile(
     r"clang\s+version\s+(?P<ver>\d+(?:\.\d+){0,2})", re.IGNORECASE,
 )
+# Word boundaries on ``icx``/``icc`` so we don't false-match arbitrary
+# substrings (e.g. an unrelated ``pacicx-tool`` or ``pickle``).
 _ICX_PRODUCER = re.compile(
-    r"(?:Intel\(R\)\s+oneAPI\s+DPC\+\+/C\+\+|icx)\s*[A-Za-z]*\s*(?P<ver>\d+(?:\.\d+){0,2})?",
+    r"(?:Intel\(R\)\s+oneAPI\s+DPC\+\+/C\+\+|\bicx\b)"
+    r"\s*[A-Za-z]*\s*(?P<ver>\d+(?:\.\d+){0,2})?",
     re.IGNORECASE,
 )
 _ICC_PRODUCER = re.compile(
-    r"(?:Intel\(R\)\s+C\+\+\s+Compiler|icc)\s*[A-Za-z]*\s*(?P<ver>\d+(?:\.\d+){0,2})?",
+    r"(?:Intel\(R\)\s+C\+\+\s+Compiler|\bicc\b)"
+    r"\s*[A-Za-z]*\s*(?P<ver>\d+(?:\.\d+){0,2})?",
     re.IGNORECASE,
 )
 # MSVC ships several producer-string variants:
@@ -179,10 +183,21 @@ def detect_compiler_family(
         if not text:
             continue
         m = _ICX_PRODUCER.search(text)
-        if m and "DPC++" in text or "oneAPI" in (text or ""):
-            return CompilerFamily.ICX, (m.group("ver") if m else None)
+        # Parentheses required: ``m and (... or ...)``; the un-parenthesized
+        # form ``m and X or Y`` parses as ``(m and X) or Y`` and incorrectly
+        # classifies any string containing "oneAPI" as ICX even when the
+        # ICX regex did not match (e.g. mixed .comment blobs from linked
+        # objects, or unrelated tooling that mentions oneAPI in passing).
+        if m and ("DPC++" in text or "oneAPI" in text):
+            return CompilerFamily.ICX, m.group("ver")
         m = _ICC_PRODUCER.search(text)
-        if m and "Intel" in text and "DPC++" not in text:
+        # Classic icc producer strings sometimes omit the literal
+        # "Intel" prefix (e.g. ``icc 19.1.3.304``); the regex already
+        # requires either the full "Intel(R) C++ Compiler" form or a
+        # word-boundary-bounded ``icc`` token, so we only need to guard
+        # against an oneAPI / DPC++ string accidentally hitting the
+        # generic icc match.
+        if m and "DPC++" not in text and "oneAPI" not in text:
             return CompilerFamily.ICC, m.group("ver")
         m = _MSVC_PRODUCER.search(text)
         if m and ("Microsoft" in text or "MSVC" in text):
@@ -204,7 +219,11 @@ _DWARF_LANG_TO_STD: dict[int, CxxStandard] = {
     0x01: CxxStandard.C,                # DW_LANG_C89
     0x02: CxxStandard.CXX98,            # DW_LANG_C_plus_plus (pre-C++03)
     0x0c: CxxStandard.C,                # DW_LANG_C99
-    0x19: CxxStandard.CXX11,            # DW_LANG_C_plus_plus_03
+    # 0x19 (DW_LANG_C_plus_plus_03) is mapped to CXX98 rather than CXX11
+    # because the enum has no CXX03 bucket and CXX98 is the closest
+    # pre-C++11 standard; upgrading C++03 binaries to CXX11 would
+    # misattribute ABI differences to the wrong build mode.
+    0x19: CxxStandard.CXX98,            # DW_LANG_C_plus_plus_03
     0x1a: CxxStandard.CXX11,            # DW_LANG_C_plus_plus_11
     0x21: CxxStandard.CXX14_OR_LATER,   # DW_LANG_C_plus_plus_14
     0x2a: CxxStandard.CXX17,            # DW_LANG_C_plus_plus_17

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -50,10 +50,22 @@ class Change:
 
 @dataclass
 class LibraryMetadata:
-    """File-level metadata for a library artifact (path, hash, size)."""
+    """File-level metadata for a library artifact (path, hash, size).
+
+    The optional ``tbb_interface_version`` field captures
+    ``TBB_INTERFACE_VERSION`` from oneTBB's ``oneapi/tbb/version.h`` when
+    a TBB-shaped header set is supplied to the dumper. It is reported as
+    a first-class signal in ``appcompat`` so users can spot
+    forward-compatibility violations (binary's
+    ``TBB_runtime_interface_version()`` < headers' compile-time
+    ``TBB_INTERFACE_VERSION``) without having to read the symbol table.
+    None when the dumper did not see a TBB version header.
+    """
+
     path: str                     # file path as given on the CLI
     sha256: str                   # hex digest
     size_bytes: int               # file size in bytes
+    tbb_interface_version: int | None = None
 
 
 @dataclass

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -22,6 +22,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .build_mode import BuildMode
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .elf_metadata import ElfMetadata
@@ -282,6 +283,13 @@ class AbiSnapshot:
     git_tag: str | None = None      # e.g. "v2.0.0", set via --git-tag or auto-detected
     created_at: str | None = None   # ISO 8601 timestamp, auto-set at dump time
     build_id: str | None = None     # opaque CI identifier (run ID, build number, etc.)
+    # Build-mode capture (schema v5) — normalized compiler / stdlib / std
+    # mode derived from DWARF DW_AT_producer, ELF .comment, and mangled
+    # symbol heuristics. Used to attribute layout/mangling differences
+    # to build configuration rather than real ABI breaks. See
+    # ``abicheck/build_mode.py`` for the dataclass and detector logic.
+    # None when capture is unavailable or the dumper predates v5.
+    build_mode: BuildMode | None = None
     # Optional on-disk artifact path that produced this snapshot.
     # Keyword-only (placed after all other fields) to prevent accidental positional binding.
     # Used by binary-only fallback detectors that need lightweight disassembly.

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .build_mode import BuildMode
 
 from .model import (
     AbiSnapshot,
@@ -42,7 +45,8 @@ from .model import (
 # v2: schema_version field added (PR #89)
 # v3: pe/macho metadata fields added (multi-format support)
 # v4: provenance metadata (git_commit, git_tag, created_at, build_id)
-SCHEMA_VERSION: int = 4
+# v5: build_mode capture (compiler/stdlib/std normalization)
+SCHEMA_VERSION: int = 5
 
 
 def _sets_to_lists(obj: Any) -> Any:
@@ -95,6 +99,16 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     # Convert all sets → sorted lists (needed for AdvancedDwarfMetadata.packed_structs
     # and ToolchainInfo.abi_flags; json.dumps raises TypeError on set objects)
     converted: dict[str, Any] = _sets_to_lists(d)
+
+    # BuildMode enums are (str, Enum), so dataclasses.asdict() carries
+    # them through as Enum instances rather than plain strings; normalize
+    # the build_mode subtree to bare strings for JSON serialization.
+    bm = converted.get("build_mode")
+    if isinstance(bm, dict):
+        for k in ("compiler_family", "language_std", "stdlib", "glibcxx_dual_abi"):
+            v = bm.get(k)
+            if v is not None and not isinstance(v, str):
+                bm[k] = v.value if hasattr(v, "value") else str(v)
 
     # Embed schema version for forward-compatibility.
     # Placed at top level so loaders can inspect it without parsing the full snapshot.
@@ -417,6 +431,10 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         else None
     )
 
+    # Rehydrate BuildMode (schema v5). Missing key = older snapshot →
+    # leave as None so build-mode-aware detectors fall back to "unknown".
+    build_mode = _build_mode_from_dict(d.get("build_mode"))
+
     return AbiSnapshot(
         library=d["library"], version=d["version"],
         source_path=d.get("source_path"),
@@ -434,6 +452,55 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         git_tag=d.get("git_tag"),
         created_at=d.get("created_at"),
         build_id=d.get("build_id"),
+        # Build-mode capture (v5)
+        build_mode=build_mode,
+    )
+
+
+def _build_mode_from_dict(raw: Any) -> BuildMode | None:
+    """Convert a serialized BuildMode dict (or None) back into the
+    typed dataclass. Returns None when the field is missing (older
+    snapshots) or malformed."""
+    if not isinstance(raw, dict):
+        return None
+    from .build_mode import (
+        BuildMode,
+        BuildModeProvenance,
+        CompilerFamily,
+        CxxStandard,
+        GlibcxxDualAbi,
+        StdlibFamily,
+    )
+
+    def _enum_or(cls: type, value: Any, default: Any) -> Any:
+        if value is None:
+            return default
+        try:
+            return cls(value)
+        except (ValueError, KeyError):
+            return default
+
+    prov_raw = raw.get("provenance") or {}
+    provenance = BuildModeProvenance(
+        raw_producer=prov_raw.get("raw_producer"),
+        raw_comment=prov_raw.get("raw_comment"),
+        compiler_version=prov_raw.get("compiler_version"),
+    )
+    return BuildMode(
+        compiler_family=_enum_or(
+            CompilerFamily, raw.get("compiler_family"), CompilerFamily.UNKNOWN,
+        ),
+        language_std=_enum_or(
+            CxxStandard, raw.get("language_std"), CxxStandard.UNKNOWN,
+        ),
+        stdlib=_enum_or(StdlibFamily, raw.get("stdlib"), StdlibFamily.UNKNOWN),
+        glibcxx_dual_abi=_enum_or(
+            GlibcxxDualAbi,
+            raw.get("glibcxx_dual_abi"),
+            GlibcxxDualAbi.NOT_APPLICABLE,
+        ),
+        libcpp_abi_version=raw.get("libcpp_abi_version"),
+        provenance=provenance,
     )
 
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -480,12 +480,35 @@ def _build_mode_from_dict(raw: Any) -> BuildMode | None:
         except (ValueError, KeyError):
             return default
 
-    prov_raw = raw.get("provenance") or {}
+    # Validate provenance shape: a malformed snapshot may carry a
+    # non-dict value (string/list from hand-edited JSON, or a partial
+    # corruption). Per the function contract, return None for
+    # malformed inputs rather than raising at .get().
+    prov_raw = raw.get("provenance")
+    if prov_raw is None:
+        prov_raw = {}
+    if not isinstance(prov_raw, dict):
+        return None
     provenance = BuildModeProvenance(
         raw_producer=prov_raw.get("raw_producer"),
         raw_comment=prov_raw.get("raw_comment"),
         compiler_version=prov_raw.get("compiler_version"),
     )
+
+    # Coerce libcpp_abi_version: int passes through; numeric string
+    # (some YAML/JSON producers emit "1" instead of 1) coerces; anything
+    # else (bool wraps as 0/1 which would be misleading; lists/dicts)
+    # falls back to None.
+    libcpp_raw = raw.get("libcpp_abi_version")
+    if isinstance(libcpp_raw, bool):
+        libcpp_abi_version: int | None = None
+    elif isinstance(libcpp_raw, int):
+        libcpp_abi_version = libcpp_raw
+    elif isinstance(libcpp_raw, str) and libcpp_raw.isdigit():
+        libcpp_abi_version = int(libcpp_raw)
+    else:
+        libcpp_abi_version = None
+
     return BuildMode(
         compiler_family=_enum_or(
             CompilerFamily, raw.get("compiler_family"), CompilerFamily.UNKNOWN,
@@ -499,7 +522,7 @@ def _build_mode_from_dict(raw: Any) -> BuildMode | None:
             raw.get("glibcxx_dual_abi"),
             GlibcxxDualAbi.NOT_APPLICABLE,
         ),
-        libcpp_abi_version=raw.get("libcpp_abi_version"),
+        libcpp_abi_version=libcpp_abi_version,
         provenance=provenance,
     )
 

--- a/tests/fixtures/schema/v5.json
+++ b/tests/fixtures/schema/v5.json
@@ -1,0 +1,129 @@
+{
+  "library": "libcompat.so.1",
+  "version": "1.0.0",
+  "functions": [
+    {
+      "name": "compat_init",
+      "mangled": "_Z11compat_initv",
+      "return_type": "int",
+      "params": [],
+      "visibility": "public",
+      "is_virtual": false,
+      "is_noexcept": false,
+      "vtable_index": null,
+      "source_location": null,
+      "is_static": false,
+      "is_const": false,
+      "is_volatile": false,
+      "is_pure_virtual": false,
+      "is_deleted": false,
+      "is_inline": false,
+      "is_extern_c": false,
+      "access": "public",
+      "return_pointer_depth": 0,
+      "elf_visibility": null,
+      "ref_qualifier": ""
+    },
+    {
+      "name": "compat_free",
+      "mangled": "_Z11compat_freev",
+      "return_type": "void",
+      "params": [],
+      "visibility": "public",
+      "is_virtual": false,
+      "is_noexcept": false,
+      "vtable_index": null,
+      "source_location": null,
+      "is_static": false,
+      "is_const": false,
+      "is_volatile": false,
+      "is_pure_virtual": false,
+      "is_deleted": false,
+      "is_inline": false,
+      "is_extern_c": false,
+      "access": "public",
+      "return_pointer_depth": 0,
+      "elf_visibility": null,
+      "ref_qualifier": ""
+    }
+  ],
+  "variables": [],
+  "types": [
+    {
+      "name": "compat_config",
+      "kind": "struct",
+      "size_bits": 64,
+      "alignment_bits": 32,
+      "fields": [
+        {
+          "name": "flags",
+          "type": "int",
+          "offset_bits": 0,
+          "is_bitfield": false,
+          "bitfield_bits": null,
+          "is_const": false,
+          "is_volatile": false,
+          "is_mutable": false,
+          "access": "public"
+        },
+        {
+          "name": "version",
+          "type": "int",
+          "offset_bits": 32,
+          "is_bitfield": false,
+          "bitfield_bits": null,
+          "is_const": false,
+          "is_volatile": false,
+          "is_mutable": false,
+          "access": "public"
+        }
+      ],
+      "bases": [],
+      "virtual_bases": [],
+      "vtable": [],
+      "source_location": null,
+      "is_union": false,
+      "is_opaque": false
+    }
+  ],
+  "enums": [
+    {
+      "name": "compat_status",
+      "underlying_type": "int",
+      "members": [
+        {
+          "name": "OK",
+          "value": 0
+        },
+        {
+          "name": "ERROR",
+          "value": 1
+        }
+      ]
+    }
+  ],
+  "typedefs": {},
+  "elf": null,
+  "pe": null,
+  "macho": null,
+  "dwarf": null,
+  "dwarf_advanced": null,
+  "sycl": null,
+  "schema_version": 5,
+  "git_commit": "abc1234",
+  "git_tag": "v1.0.0",
+  "created_at": "2026-03-24T00:00:00+00:00",
+  "build_id": "fixture",
+  "build_mode": {
+    "compiler_family": "gcc",
+    "language_std": "c++17",
+    "stdlib": "libstdc++",
+    "glibcxx_dual_abi": "cxx11",
+    "libcpp_abi_version": null,
+    "provenance": {
+      "raw_producer": "GNU C++17 11.4.0 -mtune=generic",
+      "raw_comment": "GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0",
+      "compiler_version": "11.4.0"
+    }
+  }
+}

--- a/tests/test_baseline_pinning.py
+++ b/tests/test_baseline_pinning.py
@@ -26,8 +26,8 @@ def _sample_snap(**kwargs) -> AbiSnapshot:
 # ---------------------------------------------------------------------------
 
 class TestSchemaV4:
-    def test_schema_version_is_4(self):
-        assert SCHEMA_VERSION == 4
+    def test_schema_version_is_5(self):
+        assert SCHEMA_VERSION == 5
 
     def test_provenance_fields_roundtrip(self):
         snap = _sample_snap(
@@ -37,7 +37,7 @@ class TestSchemaV4:
             build_id="ci-run-42",
         )
         d = snapshot_to_dict(snap)
-        assert d["schema_version"] == 4
+        assert d["schema_version"] == SCHEMA_VERSION
         assert d["git_commit"] == "abc1234def5678"
         assert d["git_tag"] == "v2.0.0"
         assert d["created_at"] == "2026-03-24T12:00:00+00:00"
@@ -84,7 +84,7 @@ class TestSchemaV4:
             # Verify JSON on disk has provenance
             raw = json.loads(tmp.read_text())
             assert raw["git_commit"] == "deadbeef"
-            assert raw["schema_version"] == 4
+            assert raw["schema_version"] == SCHEMA_VERSION
 
             snap2 = load_snapshot(tmp)
             assert snap2.git_commit == "deadbeef"

--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -1,0 +1,210 @@
+"""Tests for abicheck.build_mode — normalized build-mode capture.
+
+Pure unit tests against synthetic input strings.  The CI-engineer
+swarm-review dropdead requirement: normalization must be stable across
+real-world ``DW_AT_producer`` / ELF ``.comment`` strings from every
+shipped compiler version, so this file pins ALL of them with fixtures.
+"""
+from __future__ import annotations
+
+from abicheck.build_mode import (
+    BuildMode,
+    BuildModeProvenance,
+    CompilerFamily,
+    CxxStandard,
+    GlibcxxDualAbi,
+    StdlibFamily,
+    build_mode_from_signals,
+    detect_compiler_family,
+    detect_cxx_standard,
+    detect_stdlib_and_abi,
+)
+
+# ── Compiler-family normalization ──────────────────────────────────────
+
+
+class TestCompilerFamily:
+    def test_gcc_producer_strings(self) -> None:
+        fixtures = [
+            "GNU C++17 11.4.0 -mtune=generic -march=x86-64",
+            "GNU C 9.3.0",
+            "GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0",
+            "GCC: (GNU) 13.2.1 20231205 (Red Hat 13.2.1-6)",
+            "GNU C++23 14.2.0",
+        ]
+        for f in fixtures:
+            fam, ver = detect_compiler_family(producer=f, comment=None)
+            assert fam == CompilerFamily.GCC, f"failed on {f!r}"
+            assert ver is not None and ver.split(".")[0].isdigit()
+
+    def test_clang_producer_strings(self) -> None:
+        fixtures = [
+            "clang version 14.0.6 (Fedora 14.0.6-1.fc36)",
+            "clang version 17.0.6 (https://github.com/llvm/llvm-project ...)",
+            "clang version 18.1.8",
+            "Ubuntu clang version 16.0.0",
+        ]
+        for f in fixtures:
+            fam, ver = detect_compiler_family(producer=f, comment=None)
+            assert fam == CompilerFamily.CLANG, f"failed on {f!r}"
+            assert ver is not None
+
+    def test_msvc_producer_strings(self) -> None:
+        fixtures = [
+            "Microsoft (R) Optimizing Compiler",
+            "Microsoft (R) C/C++ Optimizing Compiler Version 19.35.32217",
+            "MSVC 19.36.32532",
+        ]
+        for f in fixtures:
+            fam, ver = detect_compiler_family(producer=f, comment=None)
+            assert fam == CompilerFamily.MSVC, f"failed on {f!r}"
+
+    def test_icx_producer_strings(self) -> None:
+        fixtures = [
+            "Intel(R) oneAPI DPC++/C++ Compiler 2024.1.0 (2024.x.y.20240202)",
+            "Intel(R) oneAPI DPC++/C++ Compiler 2025.0.0",
+        ]
+        for f in fixtures:
+            fam, _ver = detect_compiler_family(producer=f, comment=None)
+            assert fam == CompilerFamily.ICX, f"failed on {f!r}"
+
+    def test_unknown_producer_strings(self) -> None:
+        fam, _ver = detect_compiler_family(producer=None, comment=None)
+        assert fam == CompilerFamily.UNKNOWN
+        fam, _ver = detect_compiler_family(producer="random garbage", comment="")
+        assert fam == CompilerFamily.UNKNOWN
+
+    def test_falls_back_to_comment_when_producer_empty(self) -> None:
+        fam, _ver = detect_compiler_family(
+            producer=None,
+            comment="GCC: (Ubuntu 13.2.0-23ubuntu4) 13.2.0",
+        )
+        assert fam == CompilerFamily.GCC
+
+
+# ── C++ standard mapping ───────────────────────────────────────────────
+
+
+class TestCxxStandard:
+    def test_dwarf_tags(self) -> None:
+        # Spot-check the main mappings.
+        assert detect_cxx_standard(0x02) == CxxStandard.CXX98
+        assert detect_cxx_standard(0x1a) == CxxStandard.CXX11
+        assert detect_cxx_standard(0x21) == CxxStandard.CXX14_OR_LATER
+        assert detect_cxx_standard(0x2a) == CxxStandard.CXX17
+        assert detect_cxx_standard(0x2b) == CxxStandard.CXX20
+        assert detect_cxx_standard(0x2e) == CxxStandard.CXX23
+
+    def test_unknown_tag(self) -> None:
+        assert detect_cxx_standard(None) == CxxStandard.UNKNOWN
+        assert detect_cxx_standard(0xffff) == CxxStandard.UNKNOWN
+
+
+# ── stdlib + dual-ABI inference ────────────────────────────────────────
+
+
+class TestStdlibDetection:
+    def test_libstdcxx_dual_abi_cxx11(self) -> None:
+        # B5cxx11 ABI tag in any symbol signals new dual-ABI.
+        syms = [
+            "_ZNSt7__cxx115ctypeIcE13_M_widen_initEv",
+            "_ZNKSs5emptyEv",
+            "_ZN3foo3barB5cxx11Ev",   # the marker
+        ]
+        stdlib, abi, libcpp_v = detect_stdlib_and_abi(syms)
+        assert stdlib == StdlibFamily.LIBSTDCXX
+        assert abi == GlibcxxDualAbi.CXX11
+        assert libcpp_v is None
+
+    def test_libstdcxx_old_abi(self) -> None:
+        # libstdc++ symbols without the B5cxx11 tag → old ABI.
+        syms = ["_ZNSt5listIiSaIiEEC1Ev", "_ZNSsC1Ev"]
+        stdlib, abi, libcpp_v = detect_stdlib_and_abi(syms)
+        assert stdlib == StdlibFamily.LIBSTDCXX
+        assert abi == GlibcxxDualAbi.OLD
+        assert libcpp_v is None
+
+    def test_libcxx_v1(self) -> None:
+        syms = ["_ZNSt3__16vectorIiNS_9allocatorIiEEEC1Ev"]
+        stdlib, abi, libcpp_v = detect_stdlib_and_abi(syms)
+        assert stdlib == StdlibFamily.LIBCXX
+        assert abi == GlibcxxDualAbi.NOT_APPLICABLE
+        assert libcpp_v == 1
+
+    def test_libcxx_v2(self) -> None:
+        syms = ["_ZNSt3__26stringE"]
+        stdlib, abi, libcpp_v = detect_stdlib_and_abi(syms)
+        assert stdlib == StdlibFamily.LIBCXX
+        assert libcpp_v == 2
+
+    def test_empty_or_no_stdlib(self) -> None:
+        stdlib, abi, libcpp_v = detect_stdlib_and_abi([])
+        assert stdlib == StdlibFamily.UNKNOWN
+        assert abi == GlibcxxDualAbi.NOT_APPLICABLE
+        stdlib, _abi, _v = detect_stdlib_and_abi(["dispatch", "init_helper"])
+        assert stdlib == StdlibFamily.UNKNOWN
+
+
+# ── End-to-end BuildMode synthesis ─────────────────────────────────────
+
+
+class TestBuildModeFromSignals:
+    def test_typical_linux_gcc_cxx17(self) -> None:
+        bm = build_mode_from_signals(
+            raw_producer="GNU C++17 11.4.0 -mtune=generic",
+            raw_comment="GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0",
+            dwarf_language=0x2a,   # DW_LANG_C_plus_plus_17
+            mangled_symbols=[
+                "_ZNSt7__cxx115ctypeIcE13_M_widen_initEv",
+                "_Z3fooi",
+            ],
+        )
+        assert bm.compiler_family == CompilerFamily.GCC
+        assert bm.language_std == CxxStandard.CXX17
+        assert bm.stdlib == StdlibFamily.LIBSTDCXX
+        assert bm.glibcxx_dual_abi == GlibcxxDualAbi.CXX11
+        # Provenance retained but does not affect equality.
+        assert bm.provenance.compiler_version is not None
+        assert bm.provenance.raw_producer is not None
+
+    def test_typical_macos_clang_libcxx(self) -> None:
+        bm = build_mode_from_signals(
+            raw_producer="clang version 17.0.6 (https://github.com/llvm/llvm-project ...)",
+            dwarf_language=0x21,
+            mangled_symbols=["_ZNSt3__16vectorIiNS_9allocatorIiEEEC1Ev"],
+        )
+        assert bm.compiler_family == CompilerFamily.CLANG
+        assert bm.stdlib == StdlibFamily.LIBCXX
+        assert bm.libcpp_abi_version == 1
+        assert bm.glibcxx_dual_abi == GlibcxxDualAbi.NOT_APPLICABLE
+
+    def test_provenance_excluded_from_equality(self) -> None:
+        """Two BuildModes from different point versions of the same
+        compiler must compare equal (CI engineer's dropdead requirement).
+        """
+        a = build_mode_from_signals(
+            raw_producer="GCC: (Ubuntu 11.4.0) 11.4.0",
+            dwarf_language=0x2a,
+            mangled_symbols=["_ZNSt7__cxx115ctypeIcE_xyz"],
+        )
+        b = build_mode_from_signals(
+            raw_producer="GCC: (Ubuntu 13.2.0-23ubuntu4) 13.2.0",
+            dwarf_language=0x2a,
+            mangled_symbols=["_ZNSt7__cxx115ctypeIcE_xyz"],
+        )
+        # Same normalized fields → equal even with different provenance.
+        assert a == b
+        # …yet the raw producer string differs.
+        assert a.provenance.raw_producer != b.provenance.raw_producer
+
+    def test_default_constructed_buildmode(self) -> None:
+        """A bare ``BuildMode()`` has all-unknown fields and an empty
+        provenance.  Used when capture is unavailable (no DWARF, no
+        ELF .comment)."""
+        bm = BuildMode()
+        assert bm.compiler_family == CompilerFamily.UNKNOWN
+        assert bm.language_std == CxxStandard.UNKNOWN
+        assert bm.stdlib == StdlibFamily.UNKNOWN
+        assert bm.glibcxx_dual_abi == GlibcxxDualAbi.NOT_APPLICABLE
+        assert bm.libcpp_abi_version is None
+        assert isinstance(bm.provenance, BuildModeProvenance)

--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -68,6 +68,18 @@ class TestCompilerFamily:
             fam, _ver = detect_compiler_family(producer=f, comment=None)
             assert fam == CompilerFamily.ICX, f"failed on {f!r}"
 
+    def test_icc_producer_strings(self) -> None:
+        """Classic Intel C++ Compiler (pre-oneAPI). Producer strings vary,
+        and may not always include the literal 'Intel' prefix."""
+        fixtures = [
+            "Intel(R) C++ Compiler 19.1.3.304",
+            "icc 19.1.3.304",
+            "icc (ICC) 2021.7.1 20221019",
+        ]
+        for f in fixtures:
+            fam, _ver = detect_compiler_family(producer=f, comment=None)
+            assert fam == CompilerFamily.ICC, f"failed on {f!r}"
+
     def test_unknown_producer_strings(self) -> None:
         fam, _ver = detect_compiler_family(producer=None, comment=None)
         assert fam == CompilerFamily.UNKNOWN
@@ -78,6 +90,29 @@ class TestCompilerFamily:
         fam, _ver = detect_compiler_family(
             producer=None,
             comment="GCC: (Ubuntu 13.2.0-23ubuntu4) 13.2.0",
+        )
+        assert fam == CompilerFamily.GCC
+
+    def test_oneapi_substring_does_not_trigger_icx_alone(self) -> None:
+        """Regression for the Codex P2 finding: the un-parenthesized
+        condition ``m and "DPC++" in text or "oneAPI" in text`` would
+        classify any string mentioning oneAPI as ICX even when the ICX
+        producer regex did not match. With the fix, an unrelated string
+        like a third-party tool that happens to print 'oneAPI' in its
+        version banner must NOT be misclassified.
+        """
+        # No 'Intel(R) oneAPI DPC++/C++' producer prefix, just a stray
+        # mention of "oneAPI" — must NOT classify as ICX.
+        fam, _ver = detect_compiler_family(
+            producer="some_tool 1.2.3 (built against oneAPI)",
+            comment=None,
+        )
+        assert fam == CompilerFamily.UNKNOWN
+        # Same for a GCC producer string with 'oneAPI' in it: should
+        # still resolve to GCC (later branch), not ICX.
+        fam, _ver = detect_compiler_family(
+            producer="GCC: (Ubuntu 11.4.0) 11.4.0 (oneAPI compat layer)",
+            comment=None,
         )
         assert fam == CompilerFamily.GCC
 
@@ -94,6 +129,14 @@ class TestCxxStandard:
         assert detect_cxx_standard(0x2a) == CxxStandard.CXX17
         assert detect_cxx_standard(0x2b) == CxxStandard.CXX20
         assert detect_cxx_standard(0x2e) == CxxStandard.CXX23
+
+    def test_cpp03_maps_to_pre_cxx11_bucket(self) -> None:
+        """Regression for the Codex P2 finding: DW_LANG_C_plus_plus_03
+        (0x19) must NOT be upgraded to CXX11. The enum has no CXX03
+        bucket, so the closest pre-C++11 value (CXX98) is used. This
+        avoids misattributing ABI differences between C++03 and C++11
+        binaries to the wrong build mode."""
+        assert detect_cxx_standard(0x19) == CxxStandard.CXX98
 
     def test_unknown_tag(self) -> None:
         assert detect_cxx_standard(None) == CxxStandard.UNKNOWN

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -28,6 +28,7 @@ SCHEMA_VERSIONS = [
     pytest.param("v2.json", id="v2"),
     pytest.param("v3.json", id="v3"),
     pytest.param("v4.json", id="v4-provenance"),
+    pytest.param("v5.json", id="v5-build-mode"),
 ]
 
 
@@ -110,6 +111,20 @@ class TestCrossVersionCompare:
         result = compare(snap_v3, snap_v4)
         assert result.verdict == Verdict.NO_CHANGE
 
+    def test_v4_vs_v5_no_change(self):
+        """v5 adds build_mode metadata but the ABI surface is identical."""
+        snap_v4 = snapshot_from_dict(_load_fixture("v4.json"))
+        snap_v5 = snapshot_from_dict(_load_fixture("v5.json"))
+        result = compare(snap_v4, snap_v5)
+        assert result.verdict == Verdict.NO_CHANGE
+
+    def test_v1_vs_v5_no_change(self):
+        """Cross-jump: v1 ↔ v5 must still compare equal on identical ABI."""
+        snap_v1 = snapshot_from_dict(_load_fixture("v1.json"))
+        snap_v5 = snapshot_from_dict(_load_fixture("v5.json"))
+        result = compare(snap_v1, snap_v5)
+        assert result.verdict == Verdict.NO_CHANGE
+
 
 # ---------------------------------------------------------------------------
 # 3d. Reserialization stability tests
@@ -145,6 +160,41 @@ class TestReserialization:
         reserialized = snapshot_to_dict(snap)
         assert reserialized["git_commit"] == "abc1234"
         assert reserialized["git_tag"] == "v1.0.0"
+
+    def test_v5_build_mode_preserved(self):
+        """v5 build_mode field survives roundtrip with enums rehydrated."""
+        from abicheck.build_mode import (
+            BuildMode,
+            CompilerFamily,
+            CxxStandard,
+            GlibcxxDualAbi,
+            StdlibFamily,
+        )
+
+        d = _load_fixture("v5.json")
+        snap = snapshot_from_dict(d)
+        assert isinstance(snap.build_mode, BuildMode)
+        assert snap.build_mode.compiler_family == CompilerFamily.GCC
+        assert snap.build_mode.language_std == CxxStandard.CXX17
+        assert snap.build_mode.stdlib == StdlibFamily.LIBSTDCXX
+        assert snap.build_mode.glibcxx_dual_abi == GlibcxxDualAbi.CXX11
+        assert snap.build_mode.provenance.compiler_version == "11.4.0"
+
+        # Round-trip: serialize → reload → equal.
+        reserialized = snapshot_to_dict(snap)
+        bm = reserialized["build_mode"]
+        assert bm["compiler_family"] == "gcc"
+        assert bm["language_std"] == "c++17"
+        snap2 = snapshot_from_dict(reserialized)
+        assert snap2.build_mode == snap.build_mode
+
+    def test_v4_loads_with_build_mode_none(self):
+        """Older v4 snapshots that lack build_mode load as None — the
+        loader must not assume the field is present. This is the
+        backward-compat guarantee for the schema-v5 bump."""
+        d = _load_fixture("v4.json")
+        snap = snapshot_from_dict(d)
+        assert snap.build_mode is None
 
     def test_future_version_warning(self):
         """Loading a snapshot with schema_version > current emits a warning."""

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -196,6 +196,41 @@ class TestReserialization:
         snap = snapshot_from_dict(d)
         assert snap.build_mode is None
 
+    def test_malformed_build_mode_falls_back_to_none(self):
+        """A malformed ``build_mode`` payload (e.g. a string instead of
+        a dict, or a dict whose ``provenance`` is the wrong shape) must
+        load as None rather than raising. Regression for CodeRabbit's
+        review: previously ``prov_raw.get(...)`` would raise on a
+        non-dict provenance."""
+        d = _load_fixture("v5.json")
+
+        # Case 1: build_mode itself is a non-dict.
+        d_bad = dict(d)
+        d_bad["build_mode"] = "garbage"
+        snap = snapshot_from_dict(d_bad)
+        assert snap.build_mode is None
+
+        # Case 2: provenance is a non-dict.
+        d_bad = dict(d)
+        d_bad["build_mode"] = {
+            "compiler_family": "gcc",
+            "provenance": "not-a-dict",
+        }
+        snap = snapshot_from_dict(d_bad)
+        assert snap.build_mode is None
+
+        # Case 3: libcpp_abi_version is a non-int (must coerce to None,
+        # not raise downstream when other code does arithmetic on it).
+        d_bad = dict(d)
+        d_bad["build_mode"] = {
+            "compiler_family": "clang",
+            "libcpp_abi_version": "not-a-number",
+            "provenance": {},
+        }
+        snap = snapshot_from_dict(d_bad)
+        assert snap.build_mode is not None
+        assert snap.build_mode.libcpp_abi_version is None
+
     def test_future_version_warning(self):
         """Loading a snapshot with schema_version > current emits a warning."""
         d = _load_fixture("v4.json")


### PR DESCRIPTION
## Summary

PR 3 of 3 from the oneTBB ABI compatibility follow-up. Captures normalized build-mode metadata into snapshots so the comparator can attribute layout / mangling differences to toolchain configuration rather than real ABI breaks. Schema bump v4 → v5.

## What's new

- **`abicheck/build_mode.py`** — new module with `BuildMode`, `CompilerFamily`, `StdlibFamily`, `CxxStandard`, `GlibcxxDualAbi` enums and detector functions for raw `DW_AT_producer` / ELF `.comment` strings and mangled-name heuristics.
- **`AbiSnapshot.build_mode`** — new optional field; loader handles missing key as `None` for backward compat with v4 snapshots.
- **`LibraryMetadata.tbb_interface_version`** — new optional int field to carry oneTBB's `TBB_INTERFACE_VERSION` (data structure; live capture deferred to a follow-up).
- **Schema v4 → v5** bump in `serialization.py`, with `tests/fixtures/schema/v5.json` round-trip fixture.

## Provenance is non-comparable (CI-engineer dropdead requirement)

From the PR-ε.1 swarm review:

> A new `abicheck/build_mode.py` defining `BuildMode` as a structured enum/dataclass with **only normalized fields**. No raw producer strings in equality.

Raw `DW_AT_producer` strings and compiler patch versions live under `BuildMode.provenance` which is marked `compare=False`. Two snapshots built with gcc 11.4 vs gcc 13.2 of the same source compare equal as long as the normalized fields match. Pinned by `test_provenance_excluded_from_equality`.

## Captured normalized fields

| Field | Values | Source |
|---|---|---|
| `compiler_family` | gcc / clang / msvc / icx / icc / unknown | `DW_AT_producer` + ELF `.comment` |
| `language_std` | c / c++98 / c++11 / c++14 / c++14_or_later / c++17 / c++20 / c++23 / unknown | DWARF `DW_AT_language` |
| `stdlib` | libstdc++ / libc++ / msvc_stl / unknown | mangled-name prefix (`_ZNSt3__1`, `_ZNSt`, ...) |
| `glibcxx_dual_abi` | cxx11 / old / n/a | `B5cxx11` ABI tag + `7__cxx11` namespace |
| `libcpp_abi_version` | 1 / 2 / None | libc++ `__[12]` inline-NS digit |

The `c++14_or_later` bucket reflects clang ≤16's known habit of stamping `DW_LANG_C_plus_plus_14` for any `-std=c++14/17` target. Callers must treat it as a lower bound, not a literal claim.

## Tests

- `tests/test_build_mode.py` — **17 tests** with fixture strings from real gcc 9/11/13, clang 14/17/18, Intel oneAPI, MSVC.
- `tests/test_schema_compat.py` — v5 fixture added to the parametrized suite; new `test_v4_vs_v5_no_change`, `test_v1_vs_v5_no_change`, `test_v5_build_mode_preserved`, `test_v4_loads_with_build_mode_none` pin the v4→v5 migration contract.
- `tests/test_baseline_pinning.py` — `SCHEMA_VERSION` assertions bumped to 5 (switched to the constant so future bumps don't repeat the churn).

## Deferred to follow-up PRs

- **Dumper-side capture**: wiring `build_mode_from_signals(...)` into `dumper._dump_elf` / `_dump_pe` / `_dump_macho` so live snapshots populate `build_mode` automatically. Currently `build_mode` is `None` on freshly-dumped snapshots; it round-trips correctly when authored by user / test code.
- **`MIXED_TBB_RUNTIMES` detector**: appcompat-side detection of a binary that statically embeds `tbb::detail::r1::*` symbols *and* carries `DT_NEEDED libtbb.so.X`, or pulls multiple `libtbb` SONAMEs through its dep closure. The oneTBB-maintainer review called this the #1 user-facing crash source; it requires appcompat-layer changes that are a separate scope.
- **case110**: the example case demonstrating `MIXED_TBB_RUNTIMES`; cannot be authored until the detector lands.

This PR is the load-bearing groundwork; the follow-ups are pure feature additions on top.

## Test plan

- [x] `pytest tests/ -m "not integration and not libabigail and not abicc and not slow"` — **5998 passed, 16 skipped, 4 xfailed**
- [x] `pytest tests/test_build_mode.py tests/test_schema_compat.py` — **58 passed**
- [x] `ruff check abicheck/ tests/` — clean
- [x] `mypy abicheck/` — 26 errors, pre-change baseline

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q69m85H4BBJQ2yEtGeajZH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced build mode detection and normalization to capture compiler family, C++ standard, and standard library configuration.
  * Added TBB interface version tracking to library metadata for enhanced compatibility checks.
  * Updated snapshot schema to v5 with support for compiler/build provenance metadata.

* **Tests**
  * Added comprehensive build mode detection test coverage.
  * Extended schema compatibility tests for v5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napetrov/abicheck/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->