### PR TITLE
docs: add real failure demos to examples

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -600,14 +600,21 @@ class _CastxmlParser:
                 self._source_lines_cache[fname] = lines
         except (OSError, UnicodeDecodeError, ValueError, IndexError):
             return None
-        start = max(0, line_no - 1)
+        # CastXML can point a split conversion operator at the ``operator``
+        # line, while the ``explicit`` keyword is on the preceding line.
+        start = max(0, line_no - 4)
         window_parts: list[str] = []
-        for line in lines[start : min(len(lines), start + 6)]:
+        for line in lines[start : min(len(lines), line_no + 5)]:
             window_parts.append(line.strip())
-            if ";" in line or "{" in line:
+            if line_no - 1 <= start + len(window_parts) - 1 and (";" in line or "{" in line):
                 break
         window = " ".join(window_parts)
-        return bool(re.search(r"\bexplicit\b.*\boperator\b", window))
+        operator_match = re.search(r"\boperator\b", window)
+        if operator_match is None:
+            return False
+        prefix = window[:operator_match.start()]
+        declaration_start = max(prefix.rfind(";"), prefix.rfind("{"), prefix.rfind("}"))
+        return bool(re.search(r"\bexplicit\b", prefix[declaration_start + 1 :]))
 
     def _type_name(self, id_: str, depth: int = 0) -> str:
         if depth > 10:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -553,6 +553,7 @@ class _CastxmlParser:
         self._exported_static = exported_static
         self._id_map: dict[str, Element] = {}
         self._virtual_methods_by_class: dict[str, list[Element]] = {}
+        self._source_lines_cache: dict[str, list[str]] = {}
         self._build_id_map()
 
     def _build_id_map(self) -> None:
@@ -593,7 +594,10 @@ class _CastxmlParser:
             return None
         try:
             line_no = int(line_raw)
-            lines = Path(fname).read_text(encoding="utf-8").splitlines()
+            lines = self._source_lines_cache.get(fname)
+            if lines is None:
+                lines = Path(fname).read_text(encoding="utf-8").splitlines()
+                self._source_lines_cache[fname] = lines
         except (OSError, UnicodeDecodeError, ValueError, IndexError):
             return None
         start = max(0, line_no - 1)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -571,6 +571,40 @@ class _CastxmlParser:
     def _resolve(self, id_: str) -> Element | None:
         return self._id_map.get(id_)
 
+    def _source_line_has_explicit(
+        self,
+        loc_el: Element | None,
+        declaration_el: Element | None = None,
+    ) -> bool | None:
+        """Fallback for castxml Converter nodes that omit explicit="1"."""
+        if loc_el is not None:
+            file_id = loc_el.get("file", "")
+            line_raw = loc_el.get("line", "")
+        elif declaration_el is not None:
+            file_id = declaration_el.get("file", "")
+            line_raw = declaration_el.get("line", "")
+        else:
+            return None
+        file_el = self._id_map.get(file_id)
+        if file_el is None:
+            return None
+        fname = file_el.get("name", "")
+        if not fname or not line_raw:
+            return None
+        try:
+            line_no = int(line_raw)
+            lines = Path(fname).read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError, ValueError, IndexError):
+            return None
+        start = max(0, line_no - 1)
+        window_parts: list[str] = []
+        for line in lines[start : min(len(lines), start + 6)]:
+            window_parts.append(line.strip())
+            if ";" in line or "{" in line:
+                break
+        window = " ".join(window_parts)
+        return bool(re.search(r"\bexplicit\b.*\boperator\b", window))
+
     def _type_name(self, id_: str, depth: int = 0) -> str:
         if depth > 10:
             return "?"
@@ -764,8 +798,14 @@ class _CastxmlParser:
             # attribute is conceptually N/A and we leave is_explicit=None so
             # the diff does not produce spurious findings.
             is_explicit: bool | None
-            if el.tag in ("Constructor", "Method", "Converter"):
+            if el.tag in ("Constructor", "Method"):
                 is_explicit = el.get("explicit") == "1"
+            elif el.tag == "Converter":
+                is_explicit = (
+                    el.get("explicit") == "1"
+                    if el.get("explicit") is not None
+                    else self._source_line_has_explicit(loc_el, el)
+                )
             else:
                 is_explicit = None
 

--- a/docs/concepts/abi-breaks-explained.md
+++ b/docs/concepts/abi-breaks-explained.md
@@ -13,7 +13,7 @@ abicheck compare libv1.so libv2.so --old-header v1.h --new-header v2.h
 ```
 
 Expected verdicts for all cases are in
-[`examples/ground_truth.json`](../../examples/ground_truth.json).
+`examples/ground_truth.json`.
 For the complete list of detected change types, see the
 [Change Kind Reference](../reference/change-kinds.md).
 

--- a/docs/concepts/abi-breaks-explained.md
+++ b/docs/concepts/abi-breaks-explained.md
@@ -13,7 +13,7 @@ abicheck compare libv1.so libv2.so --old-header v1.h --new-header v2.h
 ```
 
 Expected verdicts for all cases are in
-[`examples/ground_truth.json`](https://github.com/napetrov/abicheck/blob/main/examples/ground_truth.json).
+[`examples/ground_truth.json`](../../examples/ground_truth.json).
 For the complete list of detected change types, see the
 [Change Kind Reference](../reference/change-kinds.md).
 

--- a/docs/concepts/abi-cheat-sheet.md
+++ b/docs/concepts/abi-cheat-sheet.md
@@ -12,14 +12,14 @@ These changes preserve binary compatibility. Existing consumers continue to work
 
 | Change | Why Safe | Example |
 |--------|----------|---------|
-| Add new exported function | Existing binaries never reference it; linker ignores unknown symbols | [case03](https://github.com/napetrov/abicheck/tree/main/examples/case03_compat_addition) |
-| Append enum member (end, no value shift) | Compiled binaries use integer values; existing values unchanged | [case25](https://github.com/napetrov/abicheck/tree/main/examples/case25_enum_member_added) |
-| Add union field without growing size | Union size = max(fields); fits within existing allocation | [case26b](https://github.com/napetrov/abicheck/tree/main/examples/case26b_union_field_added_compatible) |
-| Weaken symbol binding (GLOBAL to WEAK) | Symbol still resolves; interposition semantics relax | [case27](https://github.com/napetrov/abicheck/tree/main/examples/case27_symbol_binding_weakened) |
-| Add IFUNC dispatch | Transparent to callers; resolver picks implementation at load time | [case29](https://github.com/napetrov/abicheck/tree/main/examples/case29_ifunc_transition) |
-| Outline an inline function (add export) | New symbol appears; callers with inlined copy still work | [case47](https://github.com/napetrov/abicheck/tree/main/examples/case47_inline_to_outlined) |
-| Add new global variable | No existing code references it | [case61](https://github.com/napetrov/abicheck/tree/main/examples/case61_var_added) |
-| Add field to opaque struct | Callers access through pointers only; layout is hidden | [case62](https://github.com/napetrov/abicheck/tree/main/examples/case62_type_field_added_compatible) |
+| Add new exported function | Existing binaries never reference it; linker ignores unknown symbols | [case03](../examples/case03_compat_addition.md) |
+| Append enum member (end, no value shift) | Compiled binaries use integer values; existing values unchanged | [case25](../examples/case25_enum_member_added.md) |
+| Add union field without growing size | Union size = max(fields); fits within existing allocation | [case26b](../examples/case26b_union_field_added_compatible.md) |
+| Weaken symbol binding (GLOBAL to WEAK) | Symbol still resolves; interposition semantics relax | [case27](../examples/case27_symbol_binding_weakened.md) |
+| Add IFUNC dispatch | Transparent to callers; resolver picks implementation at load time | [case29](../examples/case29_ifunc_transition.md) |
+| Outline an inline function (add export) | New symbol appears; callers with inlined copy still work | [case47](../examples/case47_inline_to_outlined.md) |
+| Add new global variable | No existing code references it | [case61](../examples/case61_var_added.md) |
+| Add field to opaque struct | Callers access through pointers only; layout is hidden | [case62](../examples/case62_type_field_added_compatible.md) |
 
 ---
 
@@ -29,18 +29,18 @@ These cause crashes, wrong results, or link failures in pre-compiled consumers.
 
 | Change | What Happens at Runtime | Example |
 |--------|------------------------|---------|
-| Remove exported symbol | `undefined symbol` on dlopen/startup | [case01](https://github.com/napetrov/abicheck/tree/main/examples/case01_symbol_removal) |
-| Change parameter types | Caller passes args in wrong registers/format; garbage or crash | [case02](https://github.com/napetrov/abicheck/tree/main/examples/case02_param_type_change) |
-| Change struct layout/size | Stack corruption; reads/writes past allocation boundary | [case07](https://github.com/napetrov/abicheck/tree/main/examples/case07_struct_layout) |
-| Change enum member values | Switch/lookup tables use stale integer values; wrong branch taken | [case08](https://github.com/napetrov/abicheck/tree/main/examples/case08_enum_value_change) |
-| Reorder virtual methods | Vtable slot mismatch; call dispatches to wrong method silently | [case09](https://github.com/napetrov/abicheck/tree/main/examples/case09_cpp_vtable) |
-| Change return type | Caller interprets return register/memory as wrong type | [case10](https://github.com/napetrov/abicheck/tree/main/examples/case10_return_type) |
-| Change class size (add members) | `new`/stack allocation undersized; heap corruption, SIGSEGV | [case14](https://github.com/napetrov/abicheck/tree/main/examples/case14_cpp_class_size) |
-| Remove enum member | Code referencing removed constant fails at compile time or uses stale value | [case19](https://github.com/napetrov/abicheck/tree/main/examples/case19_enum_member_removed) |
-| Change type alignment (`alignas`) | Misaligned access; SIGBUS on strict-alignment architectures | [case42](https://github.com/napetrov/abicheck/tree/main/examples/case42_type_alignment_changed) |
-| Change struct packing (`pragma pack`) | Field offsets shift; every member read is wrong | [case56](https://github.com/napetrov/abicheck/tree/main/examples/case56_struct_packing_changed) |
-| Change calling convention | Parameters read from wrong registers; total data corruption | [case64](https://github.com/napetrov/abicheck/tree/main/examples/case64_calling_convention_changed) |
-| Remove symbol version node | Dynamic linker refuses to load; `version 'FOO_1.0' not found` | [case65](https://github.com/napetrov/abicheck/tree/main/examples/case65_symbol_version_removed) |
+| Remove exported symbol | `undefined symbol` on dlopen/startup | [case01](../examples/case01_symbol_removal.md) |
+| Change parameter types | Caller passes args in wrong registers/format; garbage or crash | [case02](../examples/case02_param_type_change.md) |
+| Change struct layout/size | Stack corruption; reads/writes past allocation boundary | [case07](../examples/case07_struct_layout.md) |
+| Change enum member values | Switch/lookup tables use stale integer values; wrong branch taken | [case08](../examples/case08_enum_value_change.md) |
+| Reorder virtual methods | Vtable slot mismatch; call dispatches to wrong method silently | [case09](../examples/case09_cpp_vtable.md) |
+| Change return type | Caller interprets return register/memory as wrong type | [case10](../examples/case10_return_type.md) |
+| Change class size (add members) | `new`/stack allocation undersized; heap corruption, SIGSEGV | [case14](../examples/case14_cpp_class_size.md) |
+| Remove enum member | Code referencing removed constant fails at compile time or uses stale value | [case19](../examples/case19_enum_member_removed.md) |
+| Change type alignment (`alignas`) | Misaligned access; SIGBUS on strict-alignment architectures | [case42](../examples/case42_type_alignment_changed.md) |
+| Change struct packing (`pragma pack`) | Field offsets shift; every member read is wrong | [case56](../examples/case56_struct_packing_changed.md) |
+| Change calling convention | Parameters read from wrong registers; total data corruption | [case64](../examples/case64_calling_convention_changed.md) |
+| Remove symbol version node | Dynamic linker refuses to load; `version 'FOO_1.0' not found` | [case65](../examples/case65_symbol_version_removed.md) |
 
 See the full breaking catalog in [Breaking Cases Catalog](breaking-cases-catalog.md).
 
@@ -52,8 +52,8 @@ Binary-compatible, but recompilation against new headers fails. Verdict: 🟠 AP
 
 | Change | Impact | Example |
 |--------|--------|---------|
-| Rename enum member (same value) | `LOG_ERR` no longer compiles; binary still uses integer `1` | [case31](https://github.com/napetrov/abicheck/tree/main/examples/case31_enum_rename) |
-| Narrow access level (public to private) | Downstream code calling `helper()` gets compile error | [case34](https://github.com/napetrov/abicheck/tree/main/examples/case34_access_level) |
+| Rename enum member (same value) | `LOG_ERR` no longer compiles; binary still uses integer `1` | [case31](../examples/case31_enum_rename.md) |
+| Narrow access level (public to private) | Downstream code calling `helper()` gets compile error | [case34](../examples/case34_access_level.md) |
 | Remove default parameter | Call sites relying on default fail to compile; ABI unchanged | -- |
 
 ---
@@ -66,7 +66,7 @@ Binary-compatible, but may break at deployment time. Verdict: 🟡 COMPATIBLE_WI
 |--------|------|---------|
 | New GLIBC/GLIBCXX version requirement | Binaries won't load on older distros missing the required symbol version | -- (detected via `SYMBOL_VERSION_REQUIRED_ADDED`) |
 | Leaked dependency symbol changed | Transitive dependency update shifts symbols your consumers never directly linked | -- |
-| `noexcept` removed | C++17 callers compiled with `noexcept` in function type get UB on throw | [case15](https://github.com/napetrov/abicheck/tree/main/examples/case15_noexcept_change) |
+| `noexcept` removed | C++17 callers compiled with `noexcept` in function type get UB on throw | [case15](../examples/case15_noexcept_change.md) |
 
 ---
 
@@ -76,11 +76,11 @@ No immediate breakage, but these compromise the ABI contract or security posture
 
 | Warning | Why It Matters | Example |
 |---------|---------------|---------|
-| Missing SONAME | Consumers record bare filename; library versioning breaks | [case05](https://github.com/napetrov/abicheck/tree/main/examples/case05_soname) |
-| Visibility leak (no `-fvisibility=hidden`) | Internal symbols become public ABI surface you must maintain forever | [case06](https://github.com/napetrov/abicheck/tree/main/examples/case06_visibility) (fixing later = BREAKING) |
-| Executable stack (`GNU_STACK RWX`) | Disables NX protection process-wide; trivial exploit target | [case49](https://github.com/napetrov/abicheck/tree/main/examples/case49_executable_stack) |
-| RPATH leak (hardcoded build path) | Library only works on the build machine; deployment fails everywhere else | [case52](https://github.com/napetrov/abicheck/tree/main/examples/case52_rpath_leak) |
-| Namespace pollution (generic names) | Unprefixed symbols like `init()` collide across libraries | [case53](https://github.com/napetrov/abicheck/tree/main/examples/case53_namespace_pollution) (fixing later = BREAKING) |
+| Missing SONAME | Consumers record bare filename; library versioning breaks | [case05](../examples/case05_soname.md) |
+| Visibility leak (no `-fvisibility=hidden`) | Internal symbols become public ABI surface you must maintain forever | [case06](../examples/case06_visibility.md) (fixing later = BREAKING) |
+| Executable stack (`GNU_STACK RWX`) | Disables NX protection process-wide; trivial exploit target | [case49](../examples/case49_executable_stack.md) |
+| RPATH leak (hardcoded build path) | Library only works on the build machine; deployment fails everywhere else | [case52](../examples/case52_rpath_leak.md) |
+| Namespace pollution (generic names) | Unprefixed symbols like `init()` collide across libraries | [case53](../examples/case53_namespace_pollution.md) (fixing later = BREAKING) |
 
 ---
 

--- a/docs/concepts/abi-stability-guide.md
+++ b/docs/concepts/abi-stability-guide.md
@@ -14,7 +14,7 @@ The dynamic linker (`ld.so` on Linux, `dyld` on macOS, the PE loader on Windows)
 
 ### Removing or renaming symbols
 
-When an executable is linked against `libfoo.so.1`, every reference to a library function is recorded as a named relocation in the binary's `.rela.plt` (for functions) or `.rela.dyn` (for data). At load time `ld.so` walks those relocations and performs `dlsym`-equivalent lookups against the library's `.dynsym` table. If the name is absent — whether v2 dropped it entirely (see [case01](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/README.md), where `helper` disappears) or only kept a differently-named function alongside the deletion (see [case12](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/README.md), where `fast_add` is removed and `other_func` is added) — the lookup returns `NULL` and the process aborts before `main()` under `RTLD_NOW`, or at the first PLT trampoline under the default lazy binding. A rename is the same mechanism: from the loader's viewpoint, renaming `fast_add` to `fast_add_v2` is a removal of the old name plus an addition of the new one, and every pre-existing binary still resolves against the old name. v1 of case01 exports both entry points:
+When an executable is linked against `libfoo.so.1`, every reference to a library function is recorded as a named relocation in the binary's `.rela.plt` (for functions) or `.rela.dyn` (for data). At load time `ld.so` walks those relocations and performs `dlsym`-equivalent lookups against the library's `.dynsym` table. If the name is absent — whether v2 dropped it entirely (see [case01](../examples/case01_symbol_removal.md), where `helper` disappears) or only kept a differently-named function alongside the deletion (see [case12](../examples/case12_function_removed.md), where `fast_add` is removed and `other_func` is added) — the lookup returns `NULL` and the process aborts before `main()` under `RTLD_NOW`, or at the first PLT trampoline under the default lazy binding. A rename is the same mechanism: from the loader's viewpoint, renaming `fast_add` to `fast_add_v2` is a removal of the old name plus an addition of the new one, and every pre-existing binary still resolves against the old name. v1 of case01 exports both entry points:
 
 ```c
 int compute(int x) { return x * 2; }
@@ -25,18 +25,18 @@ v2 drops `helper`, and every downstream binary that ever called it fails with `.
 
 ### Changing function signatures
 
-Signatures are not part of the symbol name in C — `process` mangles to `process` regardless of whether it takes `(int, int)` or `(double, int)` — so the dynamic linker cheerfully binds v1 callers to v2 implementations whose parameter types disagree. The x86-64 System V ABI passes the first six integer-class arguments in `RDI, RSI, RDX, RCX, R8, R9` and the first eight floating-point arguments in `XMM0..XMM7`, with integer and FP registers assigned from independent queues; anything past those queues spills onto the stack in right-to-left order. When [case02](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/README.md) widens the first parameter from `int` to `double`, the v1 caller loads an integer into `EDI` while the v2 callee reads an FP value from `XMM0` — two disjoint registers — and `XMM0` holds whatever garbage the caller last left there:
+Signatures are not part of the symbol name in C — `process` mangles to `process` regardless of whether it takes `(int, int)` or `(double, int)` — so the dynamic linker cheerfully binds v1 callers to v2 implementations whose parameter types disagree. The x86-64 System V ABI passes the first six integer-class arguments in `RDI, RSI, RDX, RCX, R8, R9` and the first eight floating-point arguments in `XMM0..XMM7`, with integer and FP registers assigned from independent queues; anything past those queues spills onto the stack in right-to-left order. When [case02](../examples/case02_param_type_change.md) widens the first parameter from `int` to `double`, the v1 caller loads an integer into `EDI` while the v2 callee reads an FP value from `XMM0` — two disjoint registers — and `XMM0` holds whatever garbage the caller last left there:
 
 ```c
 /* v1 */ double process(int a, int b)    { return (double)(a + b); }
 /* v2 */ double process(double a, int b) { return a + b; }
 ```
 
-[case10](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/README.md) is the mirror failure on the return path: widening `int` → `long` makes the callee write all 64 bits of `RAX`, but v1 callers read only `EAX`, truncating `3_000_000_000` to `-1_294_967_296`. Struct-passing changes are worse still, because aggregates straddle the register/stack boundary by classification rules that depend on size, alignment, and member types — a single added `int64_t` field can push an entire argument onto the stack.
+[case10](../examples/case10_return_type.md) is the mirror failure on the return path: widening `int` → `long` makes the callee write all 64 bits of `RAX`, but v1 callers read only `EAX`, truncating `3_000_000_000` to `-1_294_967_296`. Struct-passing changes are worse still, because aggregates straddle the register/stack boundary by classification rules that depend on size, alignment, and member types — a single added `int64_t` field can push an entire argument onto the stack.
 
 ### Pointer-level changes
 
-Every pointer on a 64-bit target occupies 8 bytes, so `int *` and `int **` look identical in a symbol's size on the wire. They are not identical in semantics. The v1 and v2 implementations of [case33](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/README.md) make the contrast concrete:
+Every pointer on a 64-bit target occupies 8 bytes, so `int *` and `int **` look identical in a symbol's size on the wire. They are not identical in semantics. The v1 and v2 implementations of [case33](../examples/case33_pointer_level.md) make the contrast concrete:
 
 ```c
 /* v1 */ void process(int *data)  { buf[0] = *data; }
@@ -47,7 +47,7 @@ A v1 caller passes the address of a stack `int`; v2 treats that address as an `i
 
 ### Global variable changes
 
-Exported globals are the hardest class to refactor compatibly because the executable bakes in layout facts about the variable at link time. On ELF, a reference to an imported data symbol typically generates a **COPY relocation**: the linker allocates space in the executable's own `.bss` sized to `sizeof(v1_type)`, and at load time `ld.so` memcpy's the library's initial value into that executable-owned slot. Subsequent reads and writes on *both* sides redirect to the executable's copy. If v2 widens the type — as in [case11](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/README.md), `int lib_version` → `long lib_version` — the executable's 4-byte slot cannot hold the 8-byte value; `ld.so` either warns about a size mismatch or silently truncates, so the app reads `705_032_704` where the library wrote `5_000_000_000`. [case58](https://github.com/napetrov/abicheck/blob/main/examples/case58_var_removed/README.md) removes the global outright: the COPY relocation has no target, and the process fails to start with `undefined symbol: lib_debug_level`. [case39](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/README.md) shows the qualifier failure mode in two flavours: when COPY relocation is in play (typical for non-PIE executables on ELF), a mutable-in-v1 global that v2 declares `const` still lives in the app's writable `.bss` copy, so app-side writes succeed but the library's own updates never propagate to that copy — the two sides silently diverge. For PIE binaries that reach the library symbol directly through the GOT, the same change moves the variable into the library's `.rodata` and a write from app code faults with SIGSEGV. Either way the combined demo in case39 also removes `g_legacy_flag`, so the process itself fails to start with an undefined-symbol error before the divergence ever becomes observable.
+Exported globals are the hardest class to refactor compatibly because the executable bakes in layout facts about the variable at link time. On ELF, a reference to an imported data symbol typically generates a **COPY relocation**: the linker allocates space in the executable's own `.bss` sized to `sizeof(v1_type)`, and at load time `ld.so` memcpy's the library's initial value into that executable-owned slot. Subsequent reads and writes on *both* sides redirect to the executable's copy. If v2 widens the type — as in [case11](../examples/case11_global_var_type.md), `int lib_version` → `long lib_version` — the executable's 4-byte slot cannot hold the 8-byte value; `ld.so` either warns about a size mismatch or silently truncates, so the app reads `705_032_704` where the library wrote `5_000_000_000`. [case58](../examples/case58_var_removed.md) removes the global outright: the COPY relocation has no target, and the process fails to start with `undefined symbol: lib_debug_level`. [case39](../examples/case39_var_const.md) shows the qualifier failure mode in two flavours: when COPY relocation is in play (typical for non-PIE executables on ELF), a mutable-in-v1 global that v2 declares `const` still lives in the app's writable `.bss` copy, so app-side writes succeed but the library's own updates never propagate to that copy — the two sides silently diverge. For PIE binaries that reach the library symbol directly through the GOT, the same change moves the variable into the library's `.rodata` and a write from app code faults with SIGSEGV. Either way the combined demo in case39 also removes `g_legacy_flag`, so the process itself fails to start with an undefined-symbol error before the divergence ever becomes observable.
 
 > **Best practice — keeping the symbol contract intact**
 >
@@ -63,27 +63,27 @@ Every aggregate type published in a header is a byte-level contract: its size, i
 
 ### Struct/Class Size and Offsets
 
-The most common layout break is appending, inserting, or reordering a struct field. In [case07](https://github.com/napetrov/abicheck/tree/main/examples/case07_struct_layout), `struct Point { int x; int y; }` grows to `{ int x; int y; int z; }`. `sizeof(Point)` goes from 8 to 12, so every caller that allocates `Point` on the stack or inside another struct under-allocates; every caller passing `Point` by value sends 8 bytes while the library reads 12. In [case14](https://github.com/napetrov/abicheck/tree/main/examples/case14_cpp_class_size) the same failure mode strikes C++: a `char data[64]` buffer grows to `char data[128]`, `sizeof(Buffer)` doubles, and v1 callers `new Buffer()` hand the constructor a 64-byte allocation that it promptly zero-fills with 128 bytes, corrupting whatever lives next on the heap. [case43](https://github.com/napetrov/abicheck/tree/main/examples/case43_base_class_member_added) shows the transitive case: adding `int extra_field` to `class Base` shifts `Derived::value` from offset 12 to offset 16, so every subclass member in the ecosystem silently moves. [case40](https://github.com/napetrov/abicheck/tree/main/examples/case40_field_layout) bundles five field-level mutations — type widening, removal, reorder, bitfield resize, append — into a single struct to show that "just one field" changes cascade across the whole layout.
+The most common layout break is appending, inserting, or reordering a struct field. In [case07](../examples/case07_struct_layout.md), `struct Point { int x; int y; }` grows to `{ int x; int y; int z; }`. `sizeof(Point)` goes from 8 to 12, so every caller that allocates `Point` on the stack or inside another struct under-allocates; every caller passing `Point` by value sends 8 bytes while the library reads 12. In [case14](../examples/case14_cpp_class_size.md) the same failure mode strikes C++: a `char data[64]` buffer grows to `char data[128]`, `sizeof(Buffer)` doubles, and v1 callers `new Buffer()` hand the constructor a 64-byte allocation that it promptly zero-fills with 128 bytes, corrupting whatever lives next on the heap. [case43](../examples/case43_base_class_member_added.md) shows the transitive case: adding `int extra_field` to `class Base` shifts `Derived::value` from offset 12 to offset 16, so every subclass member in the ecosystem silently moves. [case40](../examples/case40_field_layout.md) bundles five field-level mutations — type widening, removal, reorder, bitfield resize, append — into a single struct to show that "just one field" changes cascade across the whole layout.
 
 ### Alignment and Packing
 
-Alignment is the second axis of layout. [case42](https://github.com/napetrov/abicheck/tree/main/examples/case42_type_alignment_changed) changes only the alignment attribute — fields and sizes stay identical — going from `__attribute__((aligned(8)))` to `__attribute__((aligned(64)))`. v1 callers allocate `CacheBlock` on 8-byte boundaries; v2 code may emit aligned-load instructions (e.g., `vmovdqa`) and fault on misaligned access — the signal delivered varies by architecture and OS (commonly `SIGSEGV` on x86-64 Linux, `SIGBUS` on strict-alignment platforms) — and `malloc` (typically 16-byte aligned) can no longer hand out correctly-aligned storage without `aligned_alloc`. [case56](https://github.com/napetrov/abicheck/tree/main/examples/case56_struct_packing_changed) is the inverse: v1 has natural padding (`char tag` at 0, `int value` at 4, total 12), v2 adds `#pragma pack(1)` and eliminates all padding (`value` at offset 1, total 6). `sizeof` shrinks, every field except `tag` moves, and on strict-alignment architectures (ARM, SPARC) the unaligned `int` access traps. Because `alignas` and `#pragma pack` propagate across translation unit boundaries through the header, a single-line change in one header silently rewrites offsets for every TU that includes it.
+Alignment is the second axis of layout. [case42](../examples/case42_type_alignment_changed.md) changes only the alignment attribute — fields and sizes stay identical — going from `__attribute__((aligned(8)))` to `__attribute__((aligned(64)))`. v1 callers allocate `CacheBlock` on 8-byte boundaries; v2 code may emit aligned-load instructions (e.g., `vmovdqa`) and fault on misaligned access — the signal delivered varies by architecture and OS (commonly `SIGSEGV` on x86-64 Linux, `SIGBUS` on strict-alignment platforms) — and `malloc` (typically 16-byte aligned) can no longer hand out correctly-aligned storage without `aligned_alloc`. [case56](../examples/case56_struct_packing_changed.md) is the inverse: v1 has natural padding (`char tag` at 0, `int value` at 4, total 12), v2 adds `#pragma pack(1)` and eliminates all padding (`value` at offset 1, total 6). `sizeof` shrinks, every field except `tag` moves, and on strict-alignment architectures (ARM, SPARC) the unaligned `int` access traps. Because `alignas` and `#pragma pack` propagate across translation unit boundaries through the header, a single-line change in one header silently rewrites offsets for every TU that includes it.
 
 ### Enum Value Stability
 
-Enumerations look like constants, but they are part of the wire format. In [case08](https://github.com/napetrov/abicheck/tree/main/examples/case08_enum_value_change) `{ RED=0, GREEN=1, BLUE=2 }` becomes `{ RED=0, YELLOW=1, GREEN=2, BLUE=3 }`: inserting `YELLOW` in the middle shifts `GREEN` and `BLUE` by one, so every existing binary that tested `== 1` for green now hits the yellow branch. [case20](https://github.com/napetrov/abicheck/tree/main/examples/case20_enum_member_value_changed) changes `ERROR = 1` to `ERROR = 99` — the same symbolic name, a different integer — which is effectively a protocol rewrite without version negotiation. [case19](https://github.com/napetrov/abicheck/tree/main/examples/case19_enum_member_removed) removes an enumerator: any persisted value, any database row, any network message carrying that integer becomes undefined on read. The safe counterpoint is [case25](https://github.com/napetrov/abicheck/tree/main/examples/case25_enum_member_added): appending `YELLOW = 3` to the end does not perturb existing values and is `COMPATIBLE`. A more insidious failure is [case57](https://github.com/napetrov/abicheck/tree/main/examples/case57_enum_underlying_size_changed), which adds a sentinel `= 0x100000000LL` that forces the compiler to widen the underlying type from `int` to `long`; `sizeof(Color)` jumps from 4 to 8, and every struct embedding `Color` silently grows and relocates its subsequent fields.
+Enumerations look like constants, but they are part of the wire format. In [case08](../examples/case08_enum_value_change.md) `{ RED=0, GREEN=1, BLUE=2 }` becomes `{ RED=0, YELLOW=1, GREEN=2, BLUE=3 }`: inserting `YELLOW` in the middle shifts `GREEN` and `BLUE` by one, so every existing binary that tested `== 1` for green now hits the yellow branch. [case20](../examples/case20_enum_member_value_changed.md) changes `ERROR = 1` to `ERROR = 99` — the same symbolic name, a different integer — which is effectively a protocol rewrite without version negotiation. [case19](../examples/case19_enum_member_removed.md) removes an enumerator: any persisted value, any database row, any network message carrying that integer becomes undefined on read. The safe counterpoint is [case25](../examples/case25_enum_member_added.md): appending `YELLOW = 3` to the end does not perturb existing values and is `COMPATIBLE`. A more insidious failure is [case57](../examples/case57_enum_underlying_size_changed.md), which adds a sentinel `= 0x100000000LL` that forces the compiler to widen the underlying type from `int` to `long`; `sizeof(Color)` jumps from 4 to 8, and every struct embedding `Color` silently grows and relocates its subsequent fields.
 
 ### Union Layout
 
-Unions share offset 0 across all members, so adding a new variant does not move existing fields — but the union's size equals the largest member, and that size *does* propagate. [case26](https://github.com/napetrov/abicheck/tree/main/examples/case26_union_field_added) adds `double d` to `union Value { int i; float f; }`: `sizeof` grows from 4 to 8, so every stack allocation, every array stride, every embedding struct shifts. This is `TYPE_SIZE_CHANGED` and classified `BREAKING`. By contrast, [case26b](https://github.com/napetrov/abicheck/tree/main/examples/case26b_union_field_added_compatible) adds `int i` to `union { long l; double d; }` where `max(8, 8, 4) == 8` — the union does not grow, nothing downstream moves, and the verdict is `COMPATIBLE`. The rule is: a new union field is safe if and only if `sizeof(new_member) <= sizeof(old_union)` and `alignof(new_member) <= alignof(old_union)`. [case24](https://github.com/napetrov/abicheck/tree/main/examples/case24_union_field_removed) shows the other direction — removing a variant removes a supported reinterpretation, which is a semantic contract break even when the size is unchanged, because consumers compiled to write `d.f = 3.14f` have no replacement for that access path.
+Unions share offset 0 across all members, so adding a new variant does not move existing fields — but the union's size equals the largest member, and that size *does* propagate. [case26](../examples/case26_union_field_added.md) adds `double d` to `union Value { int i; float f; }`: `sizeof` grows from 4 to 8, so every stack allocation, every array stride, every embedding struct shifts. This is `TYPE_SIZE_CHANGED` and classified `BREAKING`. By contrast, [case26b](../examples/case26b_union_field_added_compatible.md) adds `int i` to `union { long l; double d; }` where `max(8, 8, 4) == 8` — the union does not grow, nothing downstream moves, and the verdict is `COMPATIBLE`. The rule is: a new union field is safe if and only if `sizeof(new_member) <= sizeof(old_union)` and `alignof(new_member) <= alignof(old_union)`. [case24](../examples/case24_union_field_removed.md) shows the other direction — removing a variant removes a supported reinterpretation, which is a semantic contract break even when the size is unchanged, because consumers compiled to write `d.f = 3.14f` have no replacement for that access path.
 
 ### Bitfields and Flexible Arrays
 
-Bitfields are the most fragile layout primitive because storage-unit allocation is implementation-defined. [case63](https://github.com/napetrov/abicheck/tree/main/examples/case63_bitfield_changed) widens `mode` from 3 bits to 5 bits inside a 32-bit `RegMap`. `sizeof` is unchanged — naive size checks pass — but `channel`, `priority`, and `reserved` all shift two bit positions, so every v1 consumer reads corrupt values with no crash and no diagnostic. This pattern bites hardest in hardware-register maps and protocol headers, exactly the contexts where bitfields are most useful. Flexible array members have the opposite static-size profile but the same failure: [case70](https://github.com/napetrov/abicheck/tree/main/examples/case70_flexible_array_member_changed) changes `float data[]` to `double data[]`. The fixed header of `struct Packet` is unchanged — `sizeof(Packet)` compares equal — but every caller that allocated `sizeof(Packet) + count * sizeof(float)` now holds half the needed memory, and `p->data[i]` indexes with stride 8 instead of 4.
+Bitfields are the most fragile layout primitive because storage-unit allocation is implementation-defined. [case63](../examples/case63_bitfield_changed.md) widens `mode` from 3 bits to 5 bits inside a 32-bit `RegMap`. `sizeof` is unchanged — naive size checks pass — but `channel`, `priority`, and `reserved` all shift two bit positions, so every v1 consumer reads corrupt values with no crash and no diagnostic. This pattern bites hardest in hardware-register maps and protocol headers, exactly the contexts where bitfields are most useful. Flexible array members have the opposite static-size profile but the same failure: [case70](../examples/case70_flexible_array_member_changed.md) changes `float data[]` to `double data[]`. The fixed header of `struct Packet` is unchanged — `sizeof(Packet)` compares equal — but every caller that allocated `sizeof(Packet) + count * sizeof(float)` now holds half the needed memory, and `p->data[i]` indexes with stride 8 instead of 4.
 
 ### Pointer Chains and Arrays
 
-Multi-level type changes propagate through indirection. [case45](https://github.com/napetrov/abicheck/tree/main/examples/case45_multi_dim_array_change) changes `float data[4][4]` to `double data[4][4]` inside `struct Matrix`: the inner element type changes, the struct doubles from 72 to 136 bytes, the array stride doubles, and both `matrix_get` and `matrix_set` change return/parameter widths so the caller reads the wrong register. [case46](https://github.com/napetrov/abicheck/tree/main/examples/case46_pointer_chain_type_change) reaches further — a function returning `int **` becomes `long **`, a two-level pointer chain where only the ultimate pointee type changes. Every v1 caller that dereferences the returned chain and writes an `int` writes 4 bytes into what v2 treats as an 8-byte cell, corrupting the adjacent slot. abicheck walks pointer and array types structurally during `FUNC_RETURN_CHANGED` and `PARAM_TYPE_CHANGED` detection precisely because a surface-level "both sides return a pointer" comparison would miss these.
+Multi-level type changes propagate through indirection. [case45](../examples/case45_multi_dim_array_change.md) changes `float data[4][4]` to `double data[4][4]` inside `struct Matrix`: the inner element type changes, the struct doubles from 72 to 136 bytes, the array stride doubles, and both `matrix_get` and `matrix_set` change return/parameter widths so the caller reads the wrong register. [case46](../examples/case46_pointer_chain_type_change.md) reaches further — a function returning `int **` becomes `long **`, a two-level pointer chain where only the ultimate pointee type changes. Every v1 caller that dereferences the returned chain and writes an `int` writes 4 bytes into what v2 treats as an 8-byte cell, corrupting the adjacent slot. abicheck walks pointer and array types structurally during `FUNC_RETURN_CHANGED` and `PARAM_TYPE_CHANGED` detection precisely because a surface-level "both sides return a pointer" comparison would miss these.
 
 > **Best Practice — Defending Type Layout**
 >
@@ -101,37 +101,37 @@ C++ is the language where ABI stability is hardest. Every class with a virtual m
 
 Every polymorphic class carries a hidden `vptr` as its first word, pointing to a per-class vtable — a static array of function pointers indexed by the order virtual methods are declared. The Itanium C++ ABI fixes this slot ordering as a public part of the class contract: callers compile `widget->resize()` into `(*widget->vptr[1])(widget)` where `1` is baked into the call site. The ordering is determined at the point of declaration, propagates unchanged into every derived class, and cannot be renegotiated after the first binary ships.
 
-Inserting a new virtual method *before* an existing one silently shifts every later slot. [case09](https://github.com/napetrov/abicheck/tree/main/examples/case09_cpp_vtable) demonstrates the canonical form: a new `recolor()` at slot 1 reroutes every call to `resize()` into `recolor()`, producing wrong results without a crash. Making an existing method pure-virtual ([case23](https://github.com/napetrov/abicheck/tree/main/examples/case23_pure_virtual_added)) replaces the slot with `__cxa_pure_virtual`, turning every old call site into an unconditional `abort()`.
+Inserting a new virtual method *before* an existing one silently shifts every later slot. [case09](../examples/case09_cpp_vtable.md) demonstrates the canonical form: a new `recolor()` at slot 1 reroutes every call to `resize()` into `recolor()`, producing wrong results without a crash. Making an existing method pure-virtual ([case23](../examples/case23_pure_virtual_added.md)) replaces the slot with `__cxa_pure_virtual`, turning every old call site into an unconditional `abort()`.
 
-Adding the *first* virtual method to a previously non-polymorphic class is the most destructive variant ([case68](https://github.com/napetrov/abicheck/tree/main/examples/case68_virtual_method_added)): a vptr is prepended, every data member shifts by `sizeof(void*)`, and `sizeof` grows — readers of the old layout interpret the new vptr as their first field. [case38](https://github.com/napetrov/abicheck/tree/main/examples/case38_virtual_methods) combines virtual-insertion, pure-virtual promotion, and copy-constructor deletion in a single release to show how the hazards compound. The only safe addition is to *append* new virtual methods after every existing slot, and only when no derived classes exist in consumer binaries that would themselves need to extend the vtable.
+Adding the *first* virtual method to a previously non-polymorphic class is the most destructive variant ([case68](../examples/case68_virtual_method_added.md)): a vptr is prepended, every data member shifts by `sizeof(void*)`, and `sizeof` grows — readers of the old layout interpret the new vptr as their first field. [case38](../examples/case38_virtual_methods.md) combines virtual-insertion, pure-virtual promotion, and copy-constructor deletion in a single release to show how the hazards compound. The only safe addition is to *append* new virtual methods after every existing slot, and only when no derived classes exist in consumer binaries that would themselves need to extend the vtable.
 
 ### 2. Method Qualifiers
 
 Method qualifiers are load-bearing parts of the Itanium mangled name, not cosmetic source-level annotations. A `const` member function mangles with a `K` marker in the parameter list, a `volatile` one with `V`, and ref-qualified methods (`&`/`&&`) with `R`/`O`. Any edit that adds, removes, or flips one of these markers renames the symbol from the linker's perspective.
 
-Dropping `const` from `Widget::get() const` ([case22](https://github.com/napetrov/abicheck/tree/main/examples/case22_method_const_changed)) changes the symbol from `_ZNK6Widget3getEv` to `_ZN6Widget3getEv` — the leading `K` disappears, the old symbol vanishes from `.dynsym`, and every consumer hits `symbol lookup error` at load time. The failure mode is a clean `dlopen` abort rather than silent corruption, which makes it one of the easier C++ breaks to diagnose in production.
+Dropping `const` from `Widget::get() const` ([case22](../examples/case22_method_const_changed.md)) changes the symbol from `_ZNK6Widget3getEv` to `_ZN6Widget3getEv` — the leading `K` disappears, the old symbol vanishes from `.dynsym`, and every consumer hits `symbol lookup error` at load time. The failure mode is a clean `dlopen` abort rather than silent corruption, which makes it one of the easier C++ breaks to diagnose in production.
 
-Converting an instance method into a `static` one ([case21](https://github.com/napetrov/abicheck/tree/main/examples/case21_method_became_static)) is subtler: the mangled name is often identical (`_ZN6Widget3barEv` for both forms), so the linker is happy, but the calling convention silently diverges — the v1 caller passes an implicit `this` in `%rdi` that the v2 static callee never reads, and the function returns data computed from register garbage. Adding `const`/`volatile` to struct *fields* ([case30](https://github.com/napetrov/abicheck/tree/main/examples/case30_field_qualifiers)) leaves layout unchanged but reclassifies the surface as a source break, and `volatile` additionally invalidates any cached loads in already-compiled callers. Treat every qualifier edit on a public declaration as equivalent to renaming the symbol.
+Converting an instance method into a `static` one ([case21](../examples/case21_method_became_static.md)) is subtler: the mangled name is often identical (`_ZN6Widget3barEv` for both forms), so the linker is happy, but the calling convention silently diverges — the v1 caller passes an implicit `this` in `%rdi` that the v2 static callee never reads, and the function returns data computed from register garbage. Adding `const`/`volatile` to struct *fields* ([case30](../examples/case30_field_qualifiers.md)) leaves layout unchanged but reclassifies the surface as a source break, and `volatile` additionally invalidates any cached loads in already-compiled callers. Treat every qualifier edit on a public declaration as equivalent to renaming the symbol.
 
 ### 3. Templates and Inline
 
-Inline and template code lives at the boundary where the One Definition Rule meets the link model, and that boundary is where ABI assumptions get baked into *consumer* binaries without the library ever seeing them. An explicitly instantiated `Buffer<int>` in `libfoo.so` produces the mangled symbol `_ZN6BufferIiEC1Em`; adding a `capacity_` field ([case17](https://github.com/napetrov/abicheck/tree/main/examples/case17_template_abi)) keeps the symbol name identical while growing `sizeof(Buffer<int>)` from 16 to 24 bytes. The consumer stack-allocates 16 and the v2 constructor writes 24, corrupting the caller's frame — a classic stack smash with no header-level signal.
+Inline and template code lives at the boundary where the One Definition Rule meets the link model, and that boundary is where ABI assumptions get baked into *consumer* binaries without the library ever seeing them. An explicitly instantiated `Buffer<int>` in `libfoo.so` produces the mangled symbol `_ZN6BufferIiEC1Em`; adding a `capacity_` field ([case17](../examples/case17_template_abi.md)) keeps the symbol name identical while growing `sizeof(Buffer<int>)` from 16 to 24 bytes. The consumer stack-allocates 16 and the v2 constructor writes 24, corrupting the caller's frame — a classic stack smash with no header-level signal.
 
 Header-only inline definitions embed the *body* into each consumer translation unit, so the implementation that callers execute is frozen when they compile. Changing the inline implementation between releases produces ODR violations that LTO can detect and link-time surprises that LTO cannot; worse, two consumers who pulled in different versions of your header will silently disagree about what your function does.
 
-Moving a function from inline-in-header to outlined-in-`.so` ([case47](https://github.com/napetrov/abicheck/tree/main/examples/case47_inline_to_outlined)) is compatible — old binaries keep their inlined copy, new binaries call the export. The inverse transition ([case59](https://github.com/napetrov/abicheck/tree/main/examples/case59_func_became_inline)) or mixing builds where the header says outlined but the `.so` does not ([case16](https://github.com/napetrov/abicheck/tree/main/examples/case16_inline_to_non_inline)) removes the symbol from `.dynsym` and hard-fails at load. Template instantiations, inline functions, and `constexpr` bodies are part of the ABI even though they never appear in `readelf -Ws`.
+Moving a function from inline-in-header to outlined-in-`.so` ([case47](../examples/case47_inline_to_outlined.md)) is compatible — old binaries keep their inlined copy, new binaries call the export. The inverse transition ([case59](../examples/case59_func_became_inline.md)) or mixing builds where the header says outlined but the `.so` does not ([case16](../examples/case16_inline_to_non_inline.md)) removes the symbol from `.dynsym` and hard-fails at load. Template instantiations, inline functions, and `constexpr` bodies are part of the ABI even though they never appear in `readelf -Ws`.
 
 ### 4. Covariant Returns and Inline Namespaces
 
-An **inline namespace** is transparent to source-level name lookup but is mangled into every symbol declared inside it, making it the canonical Itanium mechanism for generational ABI versioning. [case71](https://github.com/napetrov/abicheck/tree/main/examples/case71_inline_namespace_moved) shows a library moving `encrypt` from `inline namespace v1` to `inline namespace v2`: source code that writes `crypto::encrypt(...)` compiles unchanged against both versions, but the emitted symbol goes from `_ZN6crypto2v17encryptE...` to `_ZN6crypto2v27encryptE...` — a clean break for pre-compiled callers.
+An **inline namespace** is transparent to source-level name lookup but is mangled into every symbol declared inside it, making it the canonical Itanium mechanism for generational ABI versioning. [case71](../examples/case71_inline_namespace_moved.md) shows a library moving `encrypt` from `inline namespace v1` to `inline namespace v2`: source code that writes `crypto::encrypt(...)` compiles unchanged against both versions, but the emitted symbol goes from `_ZN6crypto2v17encryptE...` to `_ZN6crypto2v27encryptE...` — a clean break for pre-compiled callers.
 
 This is precisely the device libstdc++ uses for its **dual ABI**. GCC 5 introduced `std::__cxx11::basic_string` alongside the legacy COW `std::string`, gated on the `_GLIBCXX_USE_CXX11_ABI` preprocessor switch; every distribution spent years untangling the resulting symbol-lookup failures as users mixed libraries built with the two flavors. The lesson is that inline namespaces are a *power tool*: wielded deliberately they enable forward evolution, but switching them unintentionally renames every symbol you export.
 
-Covariant return types interact with vtable layout directly. A derived `Circle::clone()` returning `Circle*` generates a thunk that adjusts `this` before delegating; inserting a new intermediate base class ([case72](https://github.com/napetrov/abicheck/tree/main/examples/case72_covariant_return_changed)) shifts sub-object offsets, changes the covariant's return type, and invalidates every hardcoded vtable slot in consumer binaries. Used deliberately, inline namespaces let you ship breaking changes under a new mangled surface while keeping the old one exported for compatibility; used accidentally, they are an invisible renaming of every function you declare.
+Covariant return types interact with vtable layout directly. A derived `Circle::clone()` returning `Circle*` generates a thunk that adjusts `this` before delegating; inserting a new intermediate base class ([case72](../examples/case72_covariant_return_changed.md)) shifts sub-object offsets, changes the covariant's return type, and invalidates every hardcoded vtable slot in consumer binaries. Used deliberately, inline namespaces let you ship breaking changes under a new mangled surface while keeping the old one exported for compatibility; used accidentally, they are an invisible renaming of every function you declare.
 
 ### 5. noexcept
 
-[case15](https://github.com/napetrov/abicheck/tree/main/examples/case15_noexcept_change) is classified `COMPATIBLE_WITH_RISK`, not `BREAKING`, and the reasoning is worth internalizing. Before C++17, `noexcept` was not part of the function type, so the Itanium mangler ignored it: `void reset() noexcept` and `void reset()` both mangle to `_ZN6Buffer5resetEv` and resolve to the same `.dynsym` entry. Removing `noexcept` therefore *does not* break linkage — hence not `BREAKING`.
+[case15](../examples/case15_noexcept_change.md) is classified `COMPATIBLE_WITH_RISK`, not `BREAKING`, and the reasoning is worth internalizing. Before C++17, `noexcept` was not part of the function type, so the Itanium mangler ignored it: `void reset() noexcept` and `void reset()` both mangle to `_ZN6Buffer5resetEv` and resolve to the same `.dynsym` entry. Removing `noexcept` therefore *does not* break linkage — hence not `BREAKING`.
 
 What it does break is the caller's unwinding assumption. The v1 compiler saw `noexcept` and omitted exception landing pads, cleanup frames, and `.eh_frame` entries in the call site; if the v2 implementation now throws, the exception propagates into a frame with no unwinding metadata and `std::terminate()` fires unconditionally. Every destructor that was supposed to run during stack unwinding is skipped, every `catch` block that would have handled the exception is bypassed, and the process dies.
 
@@ -141,15 +141,15 @@ abicheck also flags the associated GLIBCXX version bump that appears when `throw
 
 The System V AMD64 calling convention — and its equivalents on other Itanium-ABI platforms — passes **trivially-copyable** aggregates directly in registers (`%xmm0`/`%xmm1` for a pair of doubles, `%rdi`/`%rsi` for two pointers), but passes **non-trivially-copyable** ones by invisible reference: the caller materializes the object on the stack and hands the callee a pointer. Whether a class is trivially copyable is determined by whether it has user-provided copy/move/destructor special members — a *single line of code* can flip the register/memory decision.
 
-[case69](https://github.com/napetrov/abicheck/tree/main/examples/case69_trivial_to_nontrivial) shows `struct Point { double x, y; }` gaining an empty user-defined `~Point() {}`: the layout is unchanged, `sizeof` is unchanged, the mangled symbol is unchanged, and the dynamic linker resolves the call perfectly. But the v1 caller passes `x`, `y` in `%xmm0`, `%xmm1` while the v2 callee reads `%rdi`, `%rsi` as pointers and dereferences them — segfault or silent garbage with no diagnostic from the toolchain.
+[case69](../examples/case69_trivial_to_nontrivial.md) shows `struct Point { double x, y; }` gaining an empty user-defined `~Point() {}`: the layout is unchanged, `sizeof` is unchanged, the mangled symbol is unchanged, and the dynamic linker resolves the call perfectly. But the v1 caller passes `x`, `y` in `%xmm0`, `%xmm1` while the v2 callee reads `%rdi`, `%rsi` as pointers and dereferences them — segfault or silent garbage with no diagnostic from the toolchain.
 
 No header-diff tool that looks only at declarations will catch this; abicheck reports it as `value_abi_trait_changed` by inspecting the DWARF trivially-copyable flag. Any class you expect callers to pass by value across a library boundary must have its trivially-copyable status pinned from version 1. If cleanup might ever be needed, commit from day one to a *user-provided* destructor — either an empty body (`~T() {}`) or an out-of-line defaulted definition (`~T();` in the header, `T::~T() = default;` in the `.cpp`). An in-class `~T() = default;` on the first declaration is user-declared but *not* user-provided, so it does not make the type non-trivial and does not pin the calling convention.
 
 ### 7. Base Class Position and Layout
 
-Multiple inheritance places each base sub-object at a specific offset inside the most-derived object, and those offsets are compiled into every upcast and virtual call at the call site. [case60](https://github.com/napetrov/abicheck/tree/main/examples/case60_base_class_position_changed) shows the textbook case: swapping `Widget : Drawable, Clickable` to `Widget : Clickable, Drawable` leaves the type name and all method signatures identical, yet `static_cast<Drawable*>(widget)` now produces a pointer into the `Clickable` sub-object because the compiler applied v1's zero offset to a v2 layout that moved `Drawable` further down.
+Multiple inheritance places each base sub-object at a specific offset inside the most-derived object, and those offsets are compiled into every upcast and virtual call at the call site. [case60](../examples/case60_base_class_position_changed.md) shows the textbook case: swapping `Widget : Drawable, Clickable` to `Widget : Clickable, Drawable` leaves the type name and all method signatures identical, yet `static_cast<Drawable*>(widget)` now produces a pointer into the `Clickable` sub-object because the compiler applied v1's zero offset to a v2 layout that moved `Drawable` further down.
 
-[case37](https://github.com/napetrov/abicheck/tree/main/examples/case37_base_class) generalizes this with three independent hazards on the same class. Reordering bases changes `this`-pointer adjustments and reshuffles which vptr sits at offset 0. Converting non-virtual to `virtual` inheritance restructures the entire object: the virtual base moves to the end of the most-derived layout and a vbase-offset table is inserted to resolve it at runtime. Appending a new base class grows `sizeof` and shifts every data-member offset, just as adding a first virtual method does.
+[case37](../examples/case37_base_class.md) generalizes this with three independent hazards on the same class. Reordering bases changes `this`-pointer adjustments and reshuffles which vptr sits at offset 0. Converting non-virtual to `virtual` inheritance restructures the entire object: the virtual base moves to the end of the most-derived layout and a vbase-offset table is inserted to resolve it at runtime. Appending a new base class grows `sizeof` and shifts every data-member offset, just as adding a first virtual method does.
 
 All three variants are reported as `BASE_CLASS_POSITION_CHANGED` or `type_base_changed` when DWARF or header information is available; ELF symbol tables alone cannot see them, which is why C++ ABI checking requires either debug info or headers. Base-class composition is, along with vtable ordering, one of the two C++ design decisions you cannot revisit after publishing a library — prefer composition and Pimpl for anything you expect to evolve.
 
@@ -176,10 +176,10 @@ lives in the `DT_SONAME` entry of `.dynamic` and is set via
 `DT_NEEDED`, and at runtime `ld.so` searches for a file (usually an
 `ldconfig`-managed symlink) matching that string.
 
-[Case 05](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/README.md) covers a library built
+[Case 05](../examples/case05_soname.md) covers a library built
 without `-Wl,-soname` at all: `DT_NEEDED` points at the bare `libfoo.so`,
 which `ldconfig` cannot manage, so shipping `libfoo.so.1` later breaks
-every consumer. [Case 50](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/README.md)
+every consumer. [Case 50](../examples/case50_soname_inconsistent.md)
 is the subtler bug where a 1.x release is tagged `libfoo.so.0`: packaging
 generates dependencies on the wrong major, and the cutover forces a
 distribution-wide rebuild. Rule: SONAME major equals ABI epoch, and it
@@ -192,13 +192,13 @@ Every `.dynsym` entry has an `st_other` visibility byte: `STV_DEFAULT`
 interposable), or `STV_INTERNAL`. Without `-fvisibility=hidden`, every
 non-`static` function defaults to `STV_DEFAULT`, dragging the entire
 translation unit into the public ABI.
-[Case 06](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/README.md) is the accidental
+[Case 06](../examples/case06_visibility.md) is the accidental
 leak: `internal_helper` was never intended as public API, but lacking
 `static` consumers can resolve it — the later "cleanup" that hides it
-breaks them. [Case 53](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/README.md)
+breaks them. [Case 53](../examples/case53_namespace_pollution.md)
 is the related design error: exporting unprefixed names like `init` that
 collide in the process's flat symbol namespace.
-[Case 51](https://github.com/napetrov/abicheck/blob/main/examples/case51_protected_visibility/README.md) rounds it
+[Case 51](../examples/case51_protected_visibility.md) rounds it
 out: `DEFAULT` → `PROTECTED` is ABI-compatible for normal callers but
 silently defeats `LD_PRELOAD` interposition.
 
@@ -208,10 +208,10 @@ A version script (`-Wl,--version-script=libfoo.map`) groups symbols into
 named nodes like `LIBFOO_1.0`, recorded in `.gnu.version_d` and tagged in
 `.gnu.versym`; consumers carry matching `.gnu.version_r` entries. This lets
 one `.so` ship multiple ABI generations side by side.
-[Case 13](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/README.md) shows that
+[Case 13](../examples/case13_symbol_versioning.md) shows that
 *adding* a version script is backward compatible — old binaries have no
 `DT_VERNEED`, so `ld.so` resolves by name.
-[Case 65](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/README.md) is the
+[Case 65](../examples/case65_symbol_version_removed.md) is the
 opposite: once a node has shipped, removing it deletes every symbol it
 tagged. glibc's `GLIBC_2.0` has been append-only since 1997 — which is
 why a binary built against an old glibc still loads against a current one,
@@ -226,7 +226,7 @@ x86-64 the two you meet are System V AMD64 (Linux/macOS/BSD, args in
 `rdi, rsi, rdx, rcx, r8, r9`) and Microsoft x64 (Windows or via
 `__attribute__((ms_abi))`, args in `rcx, rdx, r8, r9`). On 32-bit x86 the
 zoo is larger: `cdecl`, `stdcall`, `fastcall`, `thiscall`, `vectorcall`.
-[Case 64](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/README.md) shows
+[Case 64](../examples/case64_calling_convention_changed.md) shows
 the attribute flipping silently: the v1 caller loads pointers into
 `rdi`/`rsi`, the v2 `ms_abi` callee reads `rcx`/`rdx`, and the function
 operates on stale register contents — zero results or a segfault.
@@ -240,18 +240,18 @@ The `PT_GNU_STACK` program header advertises whether the process stack
 must be executable, and the linker unions it across input objects — so a
 single assembly file missing its `.note.GNU-stack` annotation promotes the
 entire `.so` (and every process that loads it) to an executable stack.
-[Case 49](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/README.md) shows
+[Case 49](../examples/case49_executable_stack.md) shows
 `readelf -l` reporting `RWE` instead of `RW`; rpmlint and Debian lintian
 both reject the package.
 `DT_RPATH`/`DT_RUNPATH` hold extra linker search paths.
-[Case 52](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/README.md) shows a build system
+[Case 52](../examples/case52_rpath_leak.md) shows a build system
 baking `/home/build/myproject/lib` into the artifact: it only works on the
 build host, and anyone who can write that path gets a library-injection
 primitive. Use `$ORIGIN`-relative paths or strip `RPATH` entirely.
 
 ### Language Linkage and TLS
 
-[Case 66](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/README.md) covers
+[Case 66](../examples/case66_language_linkage_changed.md) covers
 `extern "C"` removal during a C++ modernization: source still compiles,
 but the `.dynsym` symbol flips from unmangled `parse_config` to mangled
 `_Z12parse_configPKc`, and every pre-linked consumer fails at load time.
@@ -260,7 +260,7 @@ TLS has four access models: `global-dynamic` (default for `.so`,
 `dlopen`-safe), `local-dynamic`, `initial-exec` (faster but requires
 presence at startup — `dlopen` fails), and `local-exec` (main executable
 only). Libraries intended for `dlopen` must avoid `initial-exec`.
-[Case 67](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/README.md) adds a
+[Case 67](../examples/case67_tls_var_size_changed.md) adds a
 second hazard: any exported `__thread` struct whose layout shifts corrupts
 consumers per-thread. Freeze size, layout, and access model of TLS exports
 as first-class ABI.
@@ -296,7 +296,7 @@ When a public header includes a third-party type — `std::string`, `boost::any`
 ABI contract. Upgrade the third-party library and every consumer's compiled
 size, field offsets, and vtable assumptions become wrong, even though the
 wrapper library's own source never changed.
-[Case 18](https://github.com/napetrov/abicheck/tree/main/examples/case18_dependency_leak) demonstrates this
+[Case 18](../examples/case18_dependency_leak.md) demonstrates this
 with a `ThirdPartyHandle` that grows from 4 to 8 bytes: `libfoo`'s exported
 symbols are identical, `nm` and naive `abidiff` see no difference, but a caller
 built against v1 headers allocates a 4-byte struct that the v2 library reads
@@ -314,7 +314,7 @@ containing type's size and alignment depend entirely on the unnamed member's
 contents, but the anonymous member has no stable name to refer to in a diff,
 and in C++ it changes the mangled layout without touching any source-visible
 identifier.
-[Case 36](https://github.com/napetrov/abicheck/tree/main/examples/case36_anon_struct) shows a
+[Case 36](../examples/case36_anon_struct.md) shows a
 `struct Variant { int tag; union { int i; float f; }; }` where replacing
 `float f` with `double d` inflates the union from 4 to 8 bytes and shifts the
 whole struct's size from 8 to 16, moving `i` from offset 4 to offset 8 due to
@@ -330,7 +330,7 @@ with the exact member offset delta.
 Swapping `struct` for `union`, `enum` for plain `int`, or `class` for `struct`
 at the same name — even when the size happens to match — is always an ABI
 break, because the *semantics* of member storage differ.
-[Case 55](https://github.com/napetrov/abicheck/tree/main/examples/case55_type_kind_changed) changes `Data`
+[Case 55](../examples/case55_type_kind_changed.md) changes `Data`
 from a struct with sequential fields `x, y` (size 8) to a union where `x` and
 `y` overlap at offset 0 (size 4): `sizeof` shrinks, `y`'s offset moves, and
 writing one member now clobbers the other. Even a same-size swap — for
@@ -350,7 +350,7 @@ SONAME, but it only works if *no shipped binary ever touched the reserved
 bytes*. The moment a consumer writes to reserved storage (deliberately, via a
 cast, or accidentally, via `memset(&s, 0xFF, sizeof(s))` followed by
 field-wise init), repurposing those bytes becomes a silent data corruption.
-[Case 54](https://github.com/napetrov/abicheck/tree/main/examples/case54_used_reserved_field) shows the
+[Case 54](../examples/case54_used_reserved_field.md) shows the
 *correct* pattern: v1 ships `__reserved1` and `__reserved2` at defined
 offsets; v2 renames them to `priority` and `max_retries` with the same types
 and offsets, and abicheck's `_diff_reserved_fields` detector recognizes the
@@ -367,7 +367,7 @@ contract.
 Pointer indirection is the single strongest ABI firewall available in C: a
 caller that handles only `T*` is agnostic to `sizeof(T)`, to `T`'s field
 offsets, and to the kind-tag of `T`.
-[Case 48](https://github.com/napetrov/abicheck/tree/main/examples/case48_leaf_struct_through_pointer)
+[Case 48](../examples/case48_leaf_struct_through_pointer.md)
 contrasts this with the failing case — a `Container` that *embeds* `Leaf` by
 value. When `Leaf` grows from 4 to 8 bytes, `Container::flags` shifts from
 offset 8 to offset 16; the public API still takes only `Container*`, but the

--- a/docs/examples/case01_symbol_removal.md
+++ b/docs/examples/case01_symbol_removal.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse source](../../examples/case01_symbol_removal/) |
+| **Source files** | `examples/case01_symbol_removal/` |
 
 **Category:** Symbol API | **Verdict:** 🔴 BREAKING
 
@@ -80,11 +80,11 @@ patch at once.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case01_symbol_removal/CMakeLists.txt)
-- [`app.c`](../../examples/case01_symbol_removal/app.c)
-- [`v1.c`](../../examples/case01_symbol_removal/v1.c)
-- [`v1.h`](../../examples/case01_symbol_removal/v1.h)
-- [`v2.c`](../../examples/case01_symbol_removal/v2.c)
-- [`v2.h`](../../examples/case01_symbol_removal/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case01_symbol_removal.md
+++ b/docs/examples/case01_symbol_removal.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/) |
+| **Source files** | [browse source](../../examples/case01_symbol_removal/) |
 
 **Category:** Symbol API | **Verdict:** 🔴 BREAKING
 
@@ -80,11 +80,11 @@ patch at once.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case01_symbol_removal/v2.h)
+- [`CMakeLists.txt`](../../examples/case01_symbol_removal/CMakeLists.txt)
+- [`app.c`](../../examples/case01_symbol_removal/app.c)
+- [`v1.c`](../../examples/case01_symbol_removal/v1.c)
+- [`v1.h`](../../examples/case01_symbol_removal/v1.h)
+- [`v2.c`](../../examples/case01_symbol_removal/v2.c)
+- [`v2.h`](../../examples/case01_symbol_removal/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case02_param_type_change.md
+++ b/docs/examples/case02_param_type_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_params_changed` |
-| **Source files** | [browse source](../../examples/case02_param_type_change/) |
+| **Source files** | `examples/case02_param_type_change/` |
 
 **Category:** Symbol API | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -83,11 +83,11 @@ Common in numerical libraries (BLAS, LAPACK) when precision is upgraded — `flo
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case02_param_type_change/CMakeLists.txt)
-- [`app.c`](../../examples/case02_param_type_change/app.c)
-- [`v1.c`](../../examples/case02_param_type_change/v1.c)
-- [`v1.h`](../../examples/case02_param_type_change/v1.h)
-- [`v2.c`](../../examples/case02_param_type_change/v2.c)
-- [`v2.h`](../../examples/case02_param_type_change/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case02_param_type_change.md
+++ b/docs/examples/case02_param_type_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_params_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/) |
+| **Source files** | [browse source](../../examples/case02_param_type_change/) |
 
 **Category:** Symbol API | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -83,11 +83,11 @@ Common in numerical libraries (BLAS, LAPACK) when precision is upgraded — `flo
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case02_param_type_change/v2.h)
+- [`CMakeLists.txt`](../../examples/case02_param_type_change/CMakeLists.txt)
+- [`app.c`](../../examples/case02_param_type_change/app.c)
+- [`v1.c`](../../examples/case02_param_type_change/v1.c)
+- [`v1.h`](../../examples/case02_param_type_change/v1.h)
+- [`v2.c`](../../examples/case02_param_type_change/v2.c)
+- [`v2.h`](../../examples/case02_param_type_change/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case03_compat_addition.md
+++ b/docs/examples/case03_compat_addition.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `func_added` |
-| **Source files** | [browse source](../../examples/case03_compat_addition/) |
+| **Source files** | `examples/case03_compat_addition/` |
 
 **Category:** Symbol API | **Verdict:** 🟢 COMPATIBLE (exit 4)
 
@@ -77,11 +77,11 @@ releases without bumping the SONAME, relying on this compatible-addition guarant
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case03_compat_addition/CMakeLists.txt)
-- [`app.c`](../../examples/case03_compat_addition/app.c)
-- [`v1.c`](../../examples/case03_compat_addition/v1.c)
-- [`v1.h`](../../examples/case03_compat_addition/v1.h)
-- [`v2.c`](../../examples/case03_compat_addition/v2.c)
-- [`v2.h`](../../examples/case03_compat_addition/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case03_compat_addition.md
+++ b/docs/examples/case03_compat_addition.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `func_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/) |
+| **Source files** | [browse source](../../examples/case03_compat_addition/) |
 
 **Category:** Symbol API | **Verdict:** 🟢 COMPATIBLE (exit 4)
 
@@ -77,11 +77,11 @@ releases without bumping the SONAME, relying on this compatible-addition guarant
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case03_compat_addition/v2.h)
+- [`CMakeLists.txt`](../../examples/case03_compat_addition/CMakeLists.txt)
+- [`app.c`](../../examples/case03_compat_addition/app.c)
+- [`v1.c`](../../examples/case03_compat_addition/v1.c)
+- [`v1.h`](../../examples/case03_compat_addition/v1.h)
+- [`v2.c`](../../examples/case03_compat_addition/v2.c)
+- [`v2.h`](../../examples/case03_compat_addition/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case04_no_change.md
+++ b/docs/examples/case04_no_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case04_no_change/) |
+| **Source files** | `examples/case04_no_change/` |
 
 **Category:** Symbol API | **Verdict:** ✅ NO_CHANGE (exit 0)
 
@@ -73,11 +73,11 @@ regressions: any non-zero exit from abidiff triggers a review gate.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case04_no_change/CMakeLists.txt)
-- [`app.c`](../../examples/case04_no_change/app.c)
-- [`v1.c`](../../examples/case04_no_change/v1.c)
-- [`v1.h`](../../examples/case04_no_change/v1.h)
-- [`v2.c`](../../examples/case04_no_change/v2.c)
-- [`v2.h`](../../examples/case04_no_change/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All NO_CHANGE cases](by-verdict/no-change.md) · [Category: No Change](by-category/no_change.md)._

--- a/docs/examples/case04_no_change.md
+++ b/docs/examples/case04_no_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/) |
+| **Source files** | [browse source](../../examples/case04_no_change/) |
 
 **Category:** Symbol API | **Verdict:** ✅ NO_CHANGE (exit 0)
 
@@ -73,11 +73,11 @@ regressions: any non-zero exit from abidiff triggers a review gate.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case04_no_change/v2.h)
+- [`CMakeLists.txt`](../../examples/case04_no_change/CMakeLists.txt)
+- [`app.c`](../../examples/case04_no_change/app.c)
+- [`v1.c`](../../examples/case04_no_change/v1.c)
+- [`v1.h`](../../examples/case04_no_change/v1.h)
+- [`v2.c`](../../examples/case04_no_change/v2.c)
+- [`v2.h`](../../examples/case04_no_change/v2.h)
 
 _See also: [Examples overview](index.md) · [All NO_CHANGE cases](by-verdict/no-change.md) · [Category: No Change](by-category/no_change.md)._

--- a/docs/examples/case05_soname.md
+++ b/docs/examples/case05_soname.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | `soname_missing` |
-| **Source files** | [browse source](../../examples/case05_soname/) |
+| **Source files** | `examples/case05_soname/` |
 
 **Category:** ELF/Linker | **Verdict:** 🟡 BAD PRACTICE
 
@@ -90,9 +90,9 @@ binaries won't find it and packaging tools (ldconfig, dpkg) can't manage the sym
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case05_soname/CMakeLists.txt)
-- [`app.c`](../../examples/case05_soname/app.c)
-- [`bad.c`](../../examples/case05_soname/bad.c)
-- [`good.c`](../../examples/case05_soname/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case05_soname.md
+++ b/docs/examples/case05_soname.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | `soname_missing` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/) |
+| **Source files** | [browse source](../../examples/case05_soname/) |
 
 **Category:** ELF/Linker | **Verdict:** 🟡 BAD PRACTICE
 
@@ -90,9 +90,9 @@ binaries won't find it and packaging tools (ldconfig, dpkg) can't manage the sym
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case05_soname/good.c)
+- [`CMakeLists.txt`](../../examples/case05_soname/CMakeLists.txt)
+- [`app.c`](../../examples/case05_soname/app.c)
+- [`bad.c`](../../examples/case05_soname/bad.c)
+- [`good.c`](../../examples/case05_soname/good.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case06_visibility.md
+++ b/docs/examples/case06_visibility.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, Bad practice |
 | **Detected `ChangeKind`s** | `func_visibility_changed` |
-| **Source files** | [browse source](../../examples/case06_visibility/) |
+| **Source files** | `examples/case06_visibility/` |
 
 **Category:** Visibility | **Verdict:** 🔴 BREAKING (bad practice)
 
@@ -135,9 +135,9 @@ echo "exit: $?"  # → 1
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case06_visibility/CMakeLists.txt)
-- [`app.c`](../../examples/case06_visibility/app.c)
-- [`bad.c`](../../examples/case06_visibility/bad.c)
-- [`good.c`](../../examples/case06_visibility/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case06_visibility.md
+++ b/docs/examples/case06_visibility.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, Bad practice |
 | **Detected `ChangeKind`s** | `func_visibility_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/) |
+| **Source files** | [browse source](../../examples/case06_visibility/) |
 
 **Category:** Visibility | **Verdict:** 🔴 BREAKING (bad practice)
 
@@ -135,9 +135,9 @@ echo "exit: $?"  # → 1
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case06_visibility/good.c)
+- [`CMakeLists.txt`](../../examples/case06_visibility/CMakeLists.txt)
+- [`app.c`](../../examples/case06_visibility/app.c)
+- [`bad.c`](../../examples/case06_visibility/bad.c)
+- [`good.c`](../../examples/case06_visibility/good.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case07_struct_layout.md
+++ b/docs/examples/case07_struct_layout.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_size_changed` |
-| **Source files** | [browse source](../../examples/case07_struct_layout/) |
+| **Source files** | `examples/case07_struct_layout/` |
 
 **Category:** Type Layout | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -85,11 +85,11 @@ a classic stack corruption that can corrupt control flow or cause silent data lo
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case07_struct_layout/CMakeLists.txt)
-- [`app.c`](../../examples/case07_struct_layout/app.c)
-- [`v1.c`](../../examples/case07_struct_layout/v1.c)
-- [`v1.h`](../../examples/case07_struct_layout/v1.h)
-- [`v2.c`](../../examples/case07_struct_layout/v2.c)
-- [`v2.h`](../../examples/case07_struct_layout/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case07_struct_layout.md
+++ b/docs/examples/case07_struct_layout.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_size_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/) |
+| **Source files** | [browse source](../../examples/case07_struct_layout/) |
 
 **Category:** Type Layout | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -85,11 +85,11 @@ a classic stack corruption that can corrupt control flow or cause silent data lo
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case07_struct_layout/v2.h)
+- [`CMakeLists.txt`](../../examples/case07_struct_layout/CMakeLists.txt)
+- [`app.c`](../../examples/case07_struct_layout/app.c)
+- [`v1.c`](../../examples/case07_struct_layout/v1.c)
+- [`v1.h`](../../examples/case07_struct_layout/v1.h)
+- [`v2.c`](../../examples/case07_struct_layout/v2.c)
+- [`v2.h`](../../examples/case07_struct_layout/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case08_enum_value_change.md
+++ b/docs/examples/case08_enum_value_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_member_value_changed` |
-| **Source files** | [browse source](../../examples/case08_enum_value_change/) |
+| **Source files** | `examples/case08_enum_value_change/` |
 
 **Category:** Type Layout | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -81,11 +81,11 @@ statements using the old numeric constants silently route to the wrong branch.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case08_enum_value_change/CMakeLists.txt)
-- [`app.c`](../../examples/case08_enum_value_change/app.c)
-- [`v1.c`](../../examples/case08_enum_value_change/v1.c)
-- [`v1.h`](../../examples/case08_enum_value_change/v1.h)
-- [`v2.c`](../../examples/case08_enum_value_change/v2.c)
-- [`v2.h`](../../examples/case08_enum_value_change/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case08_enum_value_change.md
+++ b/docs/examples/case08_enum_value_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_member_value_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/) |
+| **Source files** | [browse source](../../examples/case08_enum_value_change/) |
 
 **Category:** Type Layout | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -81,11 +81,11 @@ statements using the old numeric constants silently route to the wrong branch.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case08_enum_value_change/v2.h)
+- [`CMakeLists.txt`](../../examples/case08_enum_value_change/CMakeLists.txt)
+- [`app.c`](../../examples/case08_enum_value_change/app.c)
+- [`v1.c`](../../examples/case08_enum_value_change/v1.c)
+- [`v1.h`](../../examples/case08_enum_value_change/v1.h)
+- [`v2.c`](../../examples/case08_enum_value_change/v2.c)
+- [`v2.h`](../../examples/case08_enum_value_change/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case09_cpp_vtable.md
+++ b/docs/examples/case09_cpp_vtable.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_vtable_changed` |
-| **Source files** | [browse source](../../examples/case09_cpp_vtable/) |
+| **Source files** | `examples/case09_cpp_vtable/` |
 
 **Category:** C++ ABI | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -87,11 +87,11 @@ no crash, just completely wrong behavior.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case09_cpp_vtable/CMakeLists.txt)
-- [`app.cpp`](../../examples/case09_cpp_vtable/app.cpp)
-- [`v1.cpp`](../../examples/case09_cpp_vtable/v1.cpp)
-- [`v1.h`](../../examples/case09_cpp_vtable/v1.h)
-- [`v2.cpp`](../../examples/case09_cpp_vtable/v2.cpp)
-- [`v2.h`](../../examples/case09_cpp_vtable/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case09_cpp_vtable.md
+++ b/docs/examples/case09_cpp_vtable.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_vtable_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/) |
+| **Source files** | [browse source](../../examples/case09_cpp_vtable/) |
 
 **Category:** C++ ABI | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -87,11 +87,11 @@ no crash, just completely wrong behavior.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case09_cpp_vtable/v2.h)
+- [`CMakeLists.txt`](../../examples/case09_cpp_vtable/CMakeLists.txt)
+- [`app.cpp`](../../examples/case09_cpp_vtable/app.cpp)
+- [`v1.cpp`](../../examples/case09_cpp_vtable/v1.cpp)
+- [`v1.h`](../../examples/case09_cpp_vtable/v1.h)
+- [`v2.cpp`](../../examples/case09_cpp_vtable/v2.cpp)
+- [`v2.h`](../../examples/case09_cpp_vtable/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case105_concept_tightening.md
+++ b/docs/examples/case105_concept_tightening.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case105_concept_tightening/) |
+| **Source files** | `examples/case105_concept_tightening/` |
 
 **Category:** Subtle source break / regression suite | **Verdict:** 🟢 COMPATIBLE (known gap — see below)
 
@@ -110,11 +110,11 @@ g++ -std=c++20 -I. app.cpp -L. -lv2 -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case105_concept_tightening/CMakeLists.txt)
-- [`app.cpp`](../../examples/case105_concept_tightening/app.cpp)
-- [`v1.cpp`](../../examples/case105_concept_tightening/v1.cpp)
-- [`v1.h`](../../examples/case105_concept_tightening/v1.h)
-- [`v2.cpp`](../../examples/case105_concept_tightening/v2.cpp)
-- [`v2.h`](../../examples/case105_concept_tightening/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case105_concept_tightening.md
+++ b/docs/examples/case105_concept_tightening.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/) |
+| **Source files** | [browse source](../../examples/case105_concept_tightening/) |
 
 **Category:** Subtle source break / regression suite | **Verdict:** 🟢 COMPATIBLE (known gap — see below)
 
@@ -110,11 +110,11 @@ g++ -std=c++20 -I. app.cpp -L. -lv2 -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case105_concept_tightening/v2.h)
+- [`CMakeLists.txt`](../../examples/case105_concept_tightening/CMakeLists.txt)
+- [`app.cpp`](../../examples/case105_concept_tightening/app.cpp)
+- [`v1.cpp`](../../examples/case105_concept_tightening/v1.cpp)
+- [`v1.h`](../../examples/case105_concept_tightening/v1.h)
+- [`v2.cpp`](../../examples/case105_concept_tightening/v2.cpp)
+- [`v2.h`](../../examples/case105_concept_tightening/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case106_ctor_became_explicit.md
+++ b/docs/examples/case106_ctor_became_explicit.md
@@ -63,23 +63,23 @@ older baseline snapshots that predate the field.
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
 cmake --build /tmp/abicheck-examples-build \
-  --target case93_ctor_became_explicit_app case93_ctor_became_explicit_v2
+  --target case106_ctor_became_explicit_app case106_ctor_became_explicit_v2
 
-/tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1
+/tmp/abicheck-examples-build/case106_ctor_became_explicit/app_v1
 # concurrency = 4 (expect 4)
 
 # Runtime substitution is still OK: the mangled conversion-operator symbol
 # did not change.
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case106_ctor_became_explicit/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case106_ctor_became_explicit/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # concurrency = 4 (expect 4)
 
 # Source rebuild against the v2 header fails because app.cpp does `int n = ta;`.
 tmp=$(mktemp -d)
-cp examples/case93_ctor_became_explicit/app.cpp "$tmp/app.cpp"
-cp examples/case93_ctor_became_explicit/v2.h "$tmp/v1.h"
+cp examples/case106_ctor_became_explicit/app.cpp "$tmp/app.cpp"
+cp examples/case106_ctor_became_explicit/v2.h "$tmp/v1.h"
 g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
 # error: cannot convert 'mylib::task_arena' to 'int' in initialization
 ```

--- a/docs/examples/case106_ctor_became_explicit.md
+++ b/docs/examples/case106_ctor_became_explicit.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `ctor_explicit_added` |
-| **Source files** | [browse source](../../examples/case106_ctor_became_explicit/) |
+| **Source files** | `examples/case106_ctor_became_explicit/` |
 
 **Category:** Source API contract | **Verdict:** 🟠 API_BREAK
 
@@ -100,11 +100,11 @@ g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case106_ctor_became_explicit/CMakeLists.txt)
-- [`app.cpp`](../../examples/case106_ctor_became_explicit/app.cpp)
-- [`v1.cpp`](../../examples/case106_ctor_became_explicit/v1.cpp)
-- [`v1.h`](../../examples/case106_ctor_became_explicit/v1.h)
-- [`v2.cpp`](../../examples/case106_ctor_became_explicit/v2.cpp)
-- [`v2.h`](../../examples/case106_ctor_became_explicit/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case106_ctor_became_explicit.md
+++ b/docs/examples/case106_ctor_became_explicit.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `ctor_explicit_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/) |
+| **Source files** | [browse source](../../examples/case106_ctor_became_explicit/) |
 
 **Category:** Source API contract | **Verdict:** 🟠 API_BREAK
 
@@ -61,17 +61,27 @@ older baseline snapshots that predate the field.
 **Severity: BAD PRACTICE / API BREAK**
 
 ```bash
-# v1 header, v1 .so: compiles and runs.
-# Note linker order: object/source inputs must precede -l flags on modern
-# Linux toolchains (-Wl,--as-needed is the default).
-g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
-./app   # → concurrency = 4 (expect 4)
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build \
+  --target case93_ctor_became_explicit_app case93_ctor_became_explicit_v2
 
-# v2 header, v2 .so: app.cpp does `int n = ta;`, an implicit conversion
-# via `operator int() const`. v2 declares the operator `explicit`, so the
-# same app.cpp source no longer compiles:
-g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
-# → error: cannot convert 'mylib::task_arena' to 'int' in initialization
+/tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1
+# concurrency = 4 (expect 4)
+
+# Runtime substitution is still OK: the mangled conversion-operator symbol
+# did not change.
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# concurrency = 4 (expect 4)
+
+# Source rebuild against the v2 header fails because app.cpp does `int n = ta;`.
+tmp=$(mktemp -d)
+cp examples/case93_ctor_became_explicit/app.cpp "$tmp/app.cpp"
+cp examples/case93_ctor_became_explicit/v2.h "$tmp/v1.h"
+g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: cannot convert 'mylib::task_arena' to 'int' in initialization
 ```
 
 ## How to fix
@@ -90,11 +100,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case106_ctor_became_explicit/v2.h)
+- [`CMakeLists.txt`](../../examples/case106_ctor_became_explicit/CMakeLists.txt)
+- [`app.cpp`](../../examples/case106_ctor_became_explicit/app.cpp)
+- [`v1.cpp`](../../examples/case106_ctor_became_explicit/v1.cpp)
+- [`v1.h`](../../examples/case106_ctor_became_explicit/v1.h)
+- [`v2.cpp`](../../examples/case106_ctor_became_explicit/v2.cpp)
+- [`v2.h`](../../examples/case106_ctor_became_explicit/v2.h)
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case107_task_scheduler_init_removed.md
+++ b/docs/examples/case107_task_scheduler_init_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed`, `type_removed` |
-| **Source files** | [browse source](../../examples/case107_task_scheduler_init_removed/) |
+| **Source files** | `examples/case107_task_scheduler_init_removed/` |
 
 **Category:** Class Removal | **Verdict:** 🔴 BREAKING
 
@@ -92,11 +92,11 @@ migration showed the only safe path:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case107_task_scheduler_init_removed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case107_task_scheduler_init_removed/app.cpp)
-- [`v1.cpp`](../../examples/case107_task_scheduler_init_removed/v1.cpp)
-- [`v1.h`](../../examples/case107_task_scheduler_init_removed/v1.h)
-- [`v2.cpp`](../../examples/case107_task_scheduler_init_removed/v2.cpp)
-- [`v2.h`](../../examples/case107_task_scheduler_init_removed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case107_task_scheduler_init_removed.md
+++ b/docs/examples/case107_task_scheduler_init_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed`, `type_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/) |
+| **Source files** | [browse source](../../examples/case107_task_scheduler_init_removed/) |
 
 **Category:** Class Removal | **Verdict:** 🔴 BREAKING
 
@@ -18,6 +18,35 @@ An entire publicly-exported class — `task_scheduler_init` — is removed in v2
 Every consumer that referenced the class (constructed it, called its members,
 or held it by value) gets `undefined symbol` at load time, and source code
 fails to compile against the new headers.
+
+## Real Failure Demo
+
+**Severity: BREAKING**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build \
+  --target case94_task_scheduler_init_removed_app case94_task_scheduler_init_removed_v2
+
+/tmp/abicheck-examples-build/case94_task_scheduler_init_removed/app_v1
+# active = 1 (expect 1)
+# active = 0 (expect 0)
+
+# Runtime replacement: a binary linked against v1 fails when v2 is substituted
+# under the old library name.
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case94_task_scheduler_init_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case94_task_scheduler_init_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: _ZN5mylib19task_scheduler_initD1Ev
+
+# Source rebuild against the v2 header also fails because the class is gone.
+tmp=$(mktemp -d)
+cp examples/case94_task_scheduler_init_removed/app.cpp "$tmp/app.cpp"
+cp examples/case94_task_scheduler_init_removed/v2.h "$tmp/v1.h"
+g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: 'task_scheduler_init' is not a member of 'mylib'
+```
 
 ## Why this is a oneTBB-flavored break
 
@@ -63,11 +92,11 @@ migration showed the only safe path:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case107_task_scheduler_init_removed/v2.h)
+- [`CMakeLists.txt`](../../examples/case107_task_scheduler_init_removed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case107_task_scheduler_init_removed/app.cpp)
+- [`v1.cpp`](../../examples/case107_task_scheduler_init_removed/v1.cpp)
+- [`v1.h`](../../examples/case107_task_scheduler_init_removed/v1.h)
+- [`v2.cpp`](../../examples/case107_task_scheduler_init_removed/v2.cpp)
+- [`v2.h`](../../examples/case107_task_scheduler_init_removed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case108_task_class_removed.md
+++ b/docs/examples/case108_task_class_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed`, `type_removed` |
-| **Source files** | [browse source](../../examples/case108_task_class_removed/) |
+| **Source files** | `examples/case108_task_class_removed/` |
 
 **Category:** Polymorphic Class Removal | **Verdict:** 🔴 BREAKING
 
@@ -96,11 +96,11 @@ migration is:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case108_task_class_removed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case108_task_class_removed/app.cpp)
-- [`v1.cpp`](../../examples/case108_task_class_removed/v1.cpp)
-- [`v1.h`](../../examples/case108_task_class_removed/v1.h)
-- [`v2.cpp`](../../examples/case108_task_class_removed/v2.cpp)
-- [`v2.h`](../../examples/case108_task_class_removed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case108_task_class_removed.md
+++ b/docs/examples/case108_task_class_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed`, `type_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/) |
+| **Source files** | [browse source](../../examples/case108_task_class_removed/) |
 
 **Category:** Polymorphic Class Removal | **Verdict:** 🔴 BREAKING
 
@@ -25,6 +25,36 @@ This is more severe than case107 because:
 - RTTI strings (`typeinfo for mylib::task`) crossed DSO boundaries; removing
   the base silently breaks `dynamic_cast` and exception handling for any
   user exception derived from it.
+
+## Real Failure Demo
+
+**Severity: BREAKING**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build \
+  --target case95_task_class_removed_app case95_task_class_removed_v2
+
+/tmp/abicheck-examples-build/case95_task_class_removed/app_v1
+# ref_count after dec = 2 (expect 2)
+
+# Runtime replacement: the v1 binary asks for the removed v1 factory/type
+# surface and fails as soon as the missing symbol is resolved.
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case95_task_class_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case95_task_class_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: _ZN5mylib17mylib_spawn_dummyEv
+
+# Source rebuild against the v2 header also fails because the base class and
+# factory are gone.
+tmp=$(mktemp -d)
+cp examples/case95_task_class_removed/app.cpp "$tmp/app.cpp"
+cp examples/case95_task_class_removed/v2.h "$tmp/v1.h"
+g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: 'task' is not a member of 'mylib'
+# error: 'mylib_spawn_dummy' is not a member of 'mylib'
+```
 
 ## Why this is a oneTBB-flavored break
 
@@ -66,11 +96,11 @@ migration is:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case108_task_class_removed/v2.h)
+- [`CMakeLists.txt`](../../examples/case108_task_class_removed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case108_task_class_removed/app.cpp)
+- [`v1.cpp`](../../examples/case108_task_class_removed/v1.cpp)
+- [`v1.h`](../../examples/case108_task_class_removed/v1.h)
+- [`v2.cpp`](../../examples/case108_task_class_removed/v2.cpp)
+- [`v2.h`](../../examples/case108_task_class_removed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case109_flow_graph_policy_renames.md
+++ b/docs/examples/case109_flow_graph_policy_renames.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `typedef_removed`, `type_removed` |
-| **Source files** | [browse source](../../examples/case109_flow_graph_policy_renames/) |
+| **Source files** | `examples/case109_flow_graph_policy_renames/` |
 
 **Category:** Source API / oneTBB regression suite | **Verdict:** 🔴 BREAKING
 
@@ -69,11 +69,11 @@ consumer wants to silence informational additions.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case109_flow_graph_policy_renames/CMakeLists.txt)
-- [`app.cpp`](../../examples/case109_flow_graph_policy_renames/app.cpp)
-- [`v1.cpp`](../../examples/case109_flow_graph_policy_renames/v1.cpp)
-- [`v1.h`](../../examples/case109_flow_graph_policy_renames/v1.h)
-- [`v2.cpp`](../../examples/case109_flow_graph_policy_renames/v2.cpp)
-- [`v2.h`](../../examples/case109_flow_graph_policy_renames/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case109_flow_graph_policy_renames.md
+++ b/docs/examples/case109_flow_graph_policy_renames.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `typedef_removed`, `type_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/) |
+| **Source files** | [browse source](../../examples/case109_flow_graph_policy_renames/) |
 
 **Category:** Source API / oneTBB regression suite | **Verdict:** 🔴 BREAKING
 
@@ -69,11 +69,11 @@ consumer wants to silence informational additions.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case109_flow_graph_policy_renames/v2.h)
+- [`CMakeLists.txt`](../../examples/case109_flow_graph_policy_renames/CMakeLists.txt)
+- [`app.cpp`](../../examples/case109_flow_graph_policy_renames/app.cpp)
+- [`v1.cpp`](../../examples/case109_flow_graph_policy_renames/v1.cpp)
+- [`v1.h`](../../examples/case109_flow_graph_policy_renames/v1.h)
+- [`v2.cpp`](../../examples/case109_flow_graph_policy_renames/v2.cpp)
+- [`v2.h`](../../examples/case109_flow_graph_policy_renames/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case10_return_type.md
+++ b/docs/examples/case10_return_type.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_return_changed` |
-| **Source files** | [browse source](../../examples/case10_return_type/) |
+| **Source files** | `examples/case10_return_type/` |
 
 **Category:** Symbol API | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -81,11 +81,11 @@ completely wrong value. Silent data corruption for any count above `INT_MAX`.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case10_return_type/CMakeLists.txt)
-- [`app.c`](../../examples/case10_return_type/app.c)
-- [`v1.c`](../../examples/case10_return_type/v1.c)
-- [`v1.h`](../../examples/case10_return_type/v1.h)
-- [`v2.c`](../../examples/case10_return_type/v2.c)
-- [`v2.h`](../../examples/case10_return_type/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case10_return_type.md
+++ b/docs/examples/case10_return_type.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_return_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/) |
+| **Source files** | [browse source](../../examples/case10_return_type/) |
 
 **Category:** Symbol API | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -81,11 +81,11 @@ completely wrong value. Silent data corruption for any count above `INT_MAX`.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case10_return_type/v2.h)
+- [`CMakeLists.txt`](../../examples/case10_return_type/CMakeLists.txt)
+- [`app.c`](../../examples/case10_return_type/app.c)
+- [`v1.c`](../../examples/case10_return_type/v1.c)
+- [`v1.h`](../../examples/case10_return_type/v1.h)
+- [`v2.c`](../../examples/case10_return_type/v2.c)
+- [`v2.h`](../../examples/case10_return_type/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case110_concurrent_unordered_map_api_drift.md
+++ b/docs/examples/case110_concurrent_unordered_map_api_drift.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse source](../../examples/case110_concurrent_unordered_map_api_drift/) |
+| **Source files** | `examples/case110_concurrent_unordered_map_api_drift/` |
 
 **Category:** ABI + source break / oneTBB regression suite | **Verdict:** 🔴 BREAKING
 
@@ -73,11 +73,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case110_concurrent_unordered_map_api_drift/CMakeLists.txt)
-- [`app.cpp`](../../examples/case110_concurrent_unordered_map_api_drift/app.cpp)
-- [`v1.cpp`](../../examples/case110_concurrent_unordered_map_api_drift/v1.cpp)
-- [`v1.h`](../../examples/case110_concurrent_unordered_map_api_drift/v1.h)
-- [`v2.cpp`](../../examples/case110_concurrent_unordered_map_api_drift/v2.cpp)
-- [`v2.h`](../../examples/case110_concurrent_unordered_map_api_drift/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case110_concurrent_unordered_map_api_drift.md
+++ b/docs/examples/case110_concurrent_unordered_map_api_drift.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/) |
+| **Source files** | [browse source](../../examples/case110_concurrent_unordered_map_api_drift/) |
 
 **Category:** ABI + source break / oneTBB regression suite | **Verdict:** 🔴 BREAKING
 
@@ -73,11 +73,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case110_concurrent_unordered_map_api_drift/v2.h)
+- [`CMakeLists.txt`](../../examples/case110_concurrent_unordered_map_api_drift/CMakeLists.txt)
+- [`app.cpp`](../../examples/case110_concurrent_unordered_map_api_drift/app.cpp)
+- [`v1.cpp`](../../examples/case110_concurrent_unordered_map_api_drift/v1.cpp)
+- [`v1.h`](../../examples/case110_concurrent_unordered_map_api_drift/v1.h)
+- [`v2.cpp`](../../examples/case110_concurrent_unordered_map_api_drift/v2.cpp)
+- [`v2.h`](../../examples/case110_concurrent_unordered_map_api_drift/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case111_enumerable_thread_specific_lambda_ambiguity.md
+++ b/docs/examples/case111_enumerable_thread_specific_lambda_ambiguity.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | `func_added` |
-| **Source files** | [browse source](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/) |
+| **Source files** | `examples/case111_enumerable_thread_specific_lambda_ambiguity/` |
 
 **Category:** Subtle source break / oneTBB regression suite | **Verdict:** 🟢 COMPATIBLE (known gap — see below)
 
@@ -84,11 +84,11 @@ resolvability.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/CMakeLists.txt)
-- [`app.cpp`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/app.cpp)
-- [`v1.cpp`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v1.cpp)
-- [`v1.h`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v1.h)
-- [`v2.cpp`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v2.cpp)
-- [`v2.h`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case111_enumerable_thread_specific_lambda_ambiguity.md
+++ b/docs/examples/case111_enumerable_thread_specific_lambda_ambiguity.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | `func_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/) |
+| **Source files** | [browse source](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/) |
 
 **Category:** Subtle source break / oneTBB regression suite | **Verdict:** 🟢 COMPATIBLE (known gap — see below)
 
@@ -84,11 +84,11 @@ resolvability.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case111_enumerable_thread_specific_lambda_ambiguity/v2.h)
+- [`CMakeLists.txt`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/CMakeLists.txt)
+- [`app.cpp`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/app.cpp)
+- [`v1.cpp`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v1.cpp)
+- [`v1.h`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v1.h)
+- [`v2.cpp`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v2.cpp)
+- [`v2.h`](../../examples/case111_enumerable_thread_specific_lambda_ambiguity/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case112_task_arena_attach_tag.md
+++ b/docs/examples/case112_task_arena_attach_tag.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed`, `type_removed`, `enum_member_removed` |
-| **Source files** | [browse source](../../examples/case112_task_arena_attach_tag/) |
+| **Source files** | `examples/case112_task_arena_attach_tag/` |
 
 **Category:** ABI + source break / oneTBB regression suite | **Verdict:** 🔴 BREAKING
 
@@ -80,11 +80,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case112_task_arena_attach_tag/CMakeLists.txt)
-- [`app.cpp`](../../examples/case112_task_arena_attach_tag/app.cpp)
-- [`v1.cpp`](../../examples/case112_task_arena_attach_tag/v1.cpp)
-- [`v1.h`](../../examples/case112_task_arena_attach_tag/v1.h)
-- [`v2.cpp`](../../examples/case112_task_arena_attach_tag/v2.cpp)
-- [`v2.h`](../../examples/case112_task_arena_attach_tag/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case112_task_arena_attach_tag.md
+++ b/docs/examples/case112_task_arena_attach_tag.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed`, `type_removed`, `enum_member_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/) |
+| **Source files** | [browse source](../../examples/case112_task_arena_attach_tag/) |
 
 **Category:** ABI + source break / oneTBB regression suite | **Verdict:** 🔴 BREAKING
 
@@ -80,11 +80,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case112_task_arena_attach_tag/v2.h)
+- [`CMakeLists.txt`](../../examples/case112_task_arena_attach_tag/CMakeLists.txt)
+- [`app.cpp`](../../examples/case112_task_arena_attach_tag/app.cpp)
+- [`v1.cpp`](../../examples/case112_task_arena_attach_tag/v1.cpp)
+- [`v1.h`](../../examples/case112_task_arena_attach_tag/v1.h)
+- [`v2.cpp`](../../examples/case112_task_arena_attach_tag/v2.cpp)
+- [`v2.h`](../../examples/case112_task_arena_attach_tag/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case113_internal_template_signature_changed.md
+++ b/docs/examples/case113_internal_template_signature_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `internal_template_leaks_via_public_api`, `func_removed` |
-| **Source files** | [browse source](../../examples/case113_internal_template_signature_changed/) |
+| **Source files** | `examples/case113_internal_template_signature_changed/` |
 
 ## What this case demonstrates
 
@@ -40,11 +40,11 @@ churn into a single finding per stem.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case113_internal_template_signature_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case113_internal_template_signature_changed/app.cpp)
-- [`v1.cpp`](../../examples/case113_internal_template_signature_changed/v1.cpp)
-- [`v1.h`](../../examples/case113_internal_template_signature_changed/v1.h)
-- [`v2.cpp`](../../examples/case113_internal_template_signature_changed/v2.cpp)
-- [`v2.h`](../../examples/case113_internal_template_signature_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case113_internal_template_signature_changed.md
+++ b/docs/examples/case113_internal_template_signature_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `internal_template_leaks_via_public_api`, `func_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/) |
+| **Source files** | [browse source](../../examples/case113_internal_template_signature_changed/) |
 
 ## What this case demonstrates
 
@@ -40,11 +40,11 @@ churn into a single finding per stem.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case113_internal_template_signature_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case113_internal_template_signature_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case113_internal_template_signature_changed/app.cpp)
+- [`v1.cpp`](../../examples/case113_internal_template_signature_changed/v1.cpp)
+- [`v1.h`](../../examples/case113_internal_template_signature_changed/v1.h)
+- [`v2.cpp`](../../examples/case113_internal_template_signature_changed/v2.cpp)
+- [`v2.h`](../../examples/case113_internal_template_signature_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case114_cpo_kind_changed.md
+++ b/docs/examples/case114_cpo_kind_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `cpo_kind_changed` |
-| **Source files** | [browse source](../../examples/case114_cpo_kind_changed/) |
+| **Source files** | `examples/case114_cpo_kind_changed/` |
 
 ## What this case demonstrates
 
@@ -43,11 +43,11 @@ with `lib::sort` must be updated.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case114_cpo_kind_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case114_cpo_kind_changed/app.cpp)
-- [`v1.cpp`](../../examples/case114_cpo_kind_changed/v1.cpp)
-- [`v1.h`](../../examples/case114_cpo_kind_changed/v1.h)
-- [`v2.cpp`](../../examples/case114_cpo_kind_changed/v2.cpp)
-- [`v2.h`](../../examples/case114_cpo_kind_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case114_cpo_kind_changed.md
+++ b/docs/examples/case114_cpo_kind_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `cpo_kind_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/) |
+| **Source files** | [browse source](../../examples/case114_cpo_kind_changed/) |
 
 ## What this case demonstrates
 
@@ -43,11 +43,11 @@ with `lib::sort` must be updated.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case114_cpo_kind_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case114_cpo_kind_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case114_cpo_kind_changed/app.cpp)
+- [`v1.cpp`](../../examples/case114_cpo_kind_changed/v1.cpp)
+- [`v1.h`](../../examples/case114_cpo_kind_changed/v1.h)
+- [`v2.cpp`](../../examples/case114_cpo_kind_changed/v2.cpp)
+- [`v2.h`](../../examples/case114_cpo_kind_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case115_api_depends_on_consumer_env.md
+++ b/docs/examples/case115_api_depends_on_consumer_env.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `func_removed_elf_only` |
-| **Source files** | [browse source](../../examples/case115_api_depends_on_consumer_env/) |
+| **Source files** | `examples/case115_api_depends_on_consumer_env/` |
 
 ## What this case demonstrates
 
@@ -37,11 +37,11 @@ finding is layered on top by the probe-harness pipeline and reported as
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case115_api_depends_on_consumer_env/CMakeLists.txt)
-- [`app.cpp`](../../examples/case115_api_depends_on_consumer_env/app.cpp)
-- [`v1.cpp`](../../examples/case115_api_depends_on_consumer_env/v1.cpp)
-- [`v1.h`](../../examples/case115_api_depends_on_consumer_env/v1.h)
-- [`v2.cpp`](../../examples/case115_api_depends_on_consumer_env/v2.cpp)
-- [`v2.h`](../../examples/case115_api_depends_on_consumer_env/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case115_api_depends_on_consumer_env.md
+++ b/docs/examples/case115_api_depends_on_consumer_env.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `func_removed_elf_only` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/) |
+| **Source files** | [browse source](../../examples/case115_api_depends_on_consumer_env/) |
 
 ## What this case demonstrates
 
@@ -37,11 +37,11 @@ finding is layered on top by the probe-harness pipeline and reported as
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case115_api_depends_on_consumer_env/v2.h)
+- [`CMakeLists.txt`](../../examples/case115_api_depends_on_consumer_env/CMakeLists.txt)
+- [`app.cpp`](../../examples/case115_api_depends_on_consumer_env/app.cpp)
+- [`v1.cpp`](../../examples/case115_api_depends_on_consumer_env/v1.cpp)
+- [`v1.h`](../../examples/case115_api_depends_on_consumer_env/v1.h)
+- [`v2.cpp`](../../examples/case115_api_depends_on_consumer_env/v2.cpp)
+- [`v2.h`](../../examples/case115_api_depends_on_consumer_env/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case116_cxx_standard_floor_raised.md
+++ b/docs/examples/case116_cxx_standard_floor_raised.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case116_cxx_standard_floor_raised/) |
+| **Source files** | `examples/case116_cxx_standard_floor_raised/` |
 
 ## What this case demonstrates
 
@@ -42,11 +42,11 @@ fixture for the matrix-detector channel.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case116_cxx_standard_floor_raised/CMakeLists.txt)
-- [`app.cpp`](../../examples/case116_cxx_standard_floor_raised/app.cpp)
-- [`v1.cpp`](../../examples/case116_cxx_standard_floor_raised/v1.cpp)
-- [`v1.h`](../../examples/case116_cxx_standard_floor_raised/v1.h)
-- [`v2.cpp`](../../examples/case116_cxx_standard_floor_raised/v2.cpp)
-- [`v2.h`](../../examples/case116_cxx_standard_floor_raised/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All NO_CHANGE cases](by-verdict/no-change.md) · [Category: No Change](by-category/no_change.md)._

--- a/docs/examples/case116_cxx_standard_floor_raised.md
+++ b/docs/examples/case116_cxx_standard_floor_raised.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/) |
+| **Source files** | [browse source](../../examples/case116_cxx_standard_floor_raised/) |
 
 ## What this case demonstrates
 
@@ -42,11 +42,11 @@ fixture for the matrix-detector channel.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case116_cxx_standard_floor_raised/v2.h)
+- [`CMakeLists.txt`](../../examples/case116_cxx_standard_floor_raised/CMakeLists.txt)
+- [`app.cpp`](../../examples/case116_cxx_standard_floor_raised/app.cpp)
+- [`v1.cpp`](../../examples/case116_cxx_standard_floor_raised/v1.cpp)
+- [`v1.h`](../../examples/case116_cxx_standard_floor_raised/v1.h)
+- [`v2.cpp`](../../examples/case116_cxx_standard_floor_raised/v2.cpp)
+- [`v2.h`](../../examples/case116_cxx_standard_floor_raised/v2.h)
 
 _See also: [Examples overview](index.md) · [All NO_CHANGE cases](by-verdict/no-change.md) · [Category: No Change](by-category/no_change.md)._

--- a/docs/examples/case117_experimental_graduated.md
+++ b/docs/examples/case117_experimental_graduated.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `experimental_graduated`, `func_added` |
-| **Source files** | [browse source](../../examples/case117_experimental_graduated/) |
+| **Source files** | `examples/case117_experimental_graduated/` |
 
 ## What this case demonstrates
 
@@ -41,11 +41,11 @@ additive.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case117_experimental_graduated/CMakeLists.txt)
-- [`app.cpp`](../../examples/case117_experimental_graduated/app.cpp)
-- [`v1.cpp`](../../examples/case117_experimental_graduated/v1.cpp)
-- [`v1.h`](../../examples/case117_experimental_graduated/v1.h)
-- [`v2.cpp`](../../examples/case117_experimental_graduated/v2.cpp)
-- [`v2.h`](../../examples/case117_experimental_graduated/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case117_experimental_graduated.md
+++ b/docs/examples/case117_experimental_graduated.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `experimental_graduated`, `func_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/) |
+| **Source files** | [browse source](../../examples/case117_experimental_graduated/) |
 
 ## What this case demonstrates
 
@@ -41,11 +41,11 @@ additive.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case117_experimental_graduated/v2.h)
+- [`CMakeLists.txt`](../../examples/case117_experimental_graduated/CMakeLists.txt)
+- [`app.cpp`](../../examples/case117_experimental_graduated/app.cpp)
+- [`v1.cpp`](../../examples/case117_experimental_graduated/v1.cpp)
+- [`v1.h`](../../examples/case117_experimental_graduated/v1.h)
+- [`v2.cpp`](../../examples/case117_experimental_graduated/v2.cpp)
+- [`v2.h`](../../examples/case117_experimental_graduated/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case118_experimental_removed_without_replacement.md
+++ b/docs/examples/case118_experimental_removed_without_replacement.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `experimental_removed_without_replacement`, `func_removed` |
-| **Source files** | [browse source](../../examples/case118_experimental_removed_without_replacement/) |
+| **Source files** | `examples/case118_experimental_removed_without_replacement/` |
 
 ## What this case demonstrates
 
@@ -40,11 +40,11 @@ namespace-level finding is the human-readable framing.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case118_experimental_removed_without_replacement/CMakeLists.txt)
-- [`app.cpp`](../../examples/case118_experimental_removed_without_replacement/app.cpp)
-- [`v1.cpp`](../../examples/case118_experimental_removed_without_replacement/v1.cpp)
-- [`v1.h`](../../examples/case118_experimental_removed_without_replacement/v1.h)
-- [`v2.cpp`](../../examples/case118_experimental_removed_without_replacement/v2.cpp)
-- [`v2.h`](../../examples/case118_experimental_removed_without_replacement/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case118_experimental_removed_without_replacement.md
+++ b/docs/examples/case118_experimental_removed_without_replacement.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `experimental_removed_without_replacement`, `func_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/) |
+| **Source files** | [browse source](../../examples/case118_experimental_removed_without_replacement/) |
 
 ## What this case demonstrates
 
@@ -40,11 +40,11 @@ namespace-level finding is the human-readable framing.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case118_experimental_removed_without_replacement/v2.h)
+- [`CMakeLists.txt`](../../examples/case118_experimental_removed_without_replacement/CMakeLists.txt)
+- [`app.cpp`](../../examples/case118_experimental_removed_without_replacement/app.cpp)
+- [`v1.cpp`](../../examples/case118_experimental_removed_without_replacement/v1.cpp)
+- [`v1.h`](../../examples/case118_experimental_removed_without_replacement/v1.h)
+- [`v2.cpp`](../../examples/case118_experimental_removed_without_replacement/v2.cpp)
+- [`v2.h`](../../examples/case118_experimental_removed_without_replacement/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case119_inline_namespace_version_bumped.md
+++ b/docs/examples/case119_inline_namespace_version_bumped.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_namespace_version_bumped` |
-| **Source files** | [browse source](../../examples/case119_inline_namespace_version_bumped/) |
+| **Source files** | `examples/case119_inline_namespace_version_bumped/` |
 
 ## What this case demonstrates
 
@@ -45,11 +45,11 @@ new TUs at link or load time is broken.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case119_inline_namespace_version_bumped/CMakeLists.txt)
-- [`app.cpp`](../../examples/case119_inline_namespace_version_bumped/app.cpp)
-- [`v1.cpp`](../../examples/case119_inline_namespace_version_bumped/v1.cpp)
-- [`v1.h`](../../examples/case119_inline_namespace_version_bumped/v1.h)
-- [`v2.cpp`](../../examples/case119_inline_namespace_version_bumped/v2.cpp)
-- [`v2.h`](../../examples/case119_inline_namespace_version_bumped/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case119_inline_namespace_version_bumped.md
+++ b/docs/examples/case119_inline_namespace_version_bumped.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_namespace_version_bumped` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/) |
+| **Source files** | [browse source](../../examples/case119_inline_namespace_version_bumped/) |
 
 ## What this case demonstrates
 
@@ -45,11 +45,11 @@ new TUs at link or load time is broken.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case119_inline_namespace_version_bumped/v2.h)
+- [`CMakeLists.txt`](../../examples/case119_inline_namespace_version_bumped/CMakeLists.txt)
+- [`app.cpp`](../../examples/case119_inline_namespace_version_bumped/app.cpp)
+- [`v1.cpp`](../../examples/case119_inline_namespace_version_bumped/v1.cpp)
+- [`v1.h`](../../examples/case119_inline_namespace_version_bumped/v1.h)
+- [`v2.cpp`](../../examples/case119_inline_namespace_version_bumped/v2.cpp)
+- [`v2.h`](../../examples/case119_inline_namespace_version_bumped/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case11_global_var_type.md
+++ b/docs/examples/case11_global_var_type.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `var_type_changed` |
-| **Source files** | [browse source](../../examples/case11_global_var_type/) |
+| **Source files** | `examples/case11_global_var_type/` |
 
 **Category:** Type Layout | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -81,11 +81,11 @@ On little-endian x86 this reads the low 32 bits — garbage for values above `IN
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case11_global_var_type/CMakeLists.txt)
-- [`app.c`](../../examples/case11_global_var_type/app.c)
-- [`v1.c`](../../examples/case11_global_var_type/v1.c)
-- [`v1.h`](../../examples/case11_global_var_type/v1.h)
-- [`v2.c`](../../examples/case11_global_var_type/v2.c)
-- [`v2.h`](../../examples/case11_global_var_type/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case11_global_var_type.md
+++ b/docs/examples/case11_global_var_type.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `var_type_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/) |
+| **Source files** | [browse source](../../examples/case11_global_var_type/) |
 
 **Category:** Type Layout | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -81,11 +81,11 @@ On little-endian x86 this reads the low 32 bits — garbage for values above `IN
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case11_global_var_type/v2.h)
+- [`CMakeLists.txt`](../../examples/case11_global_var_type/CMakeLists.txt)
+- [`app.c`](../../examples/case11_global_var_type/app.c)
+- [`v1.c`](../../examples/case11_global_var_type/v1.c)
+- [`v1.h`](../../examples/case11_global_var_type/v1.h)
+- [`v2.c`](../../examples/case11_global_var_type/v2.c)
+- [`v2.h`](../../examples/case11_global_var_type/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case12_function_removed.md
+++ b/docs/examples/case12_function_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse source](../../examples/case12_function_removed/) |
+| **Source files** | `examples/case12_function_removed/` |
 
 **Category:** Symbol API | **Abicheck verdict:** BREAKING | **Verdict:** 🔴 BREAKING
 
@@ -86,11 +86,11 @@ The function is removed from the .so — the dynamic linker emits an undefined s
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case12_function_removed/CMakeLists.txt)
-- [`app.c`](../../examples/case12_function_removed/app.c)
-- [`v1.c`](../../examples/case12_function_removed/v1.c)
-- [`v1.h`](../../examples/case12_function_removed/v1.h)
-- [`v2.c`](../../examples/case12_function_removed/v2.c)
-- [`v2.h`](../../examples/case12_function_removed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case12_function_removed.md
+++ b/docs/examples/case12_function_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/) |
+| **Source files** | [browse source](../../examples/case12_function_removed/) |
 
 **Category:** Symbol API | **Abicheck verdict:** BREAKING | **Verdict:** 🔴 BREAKING
 
@@ -86,11 +86,11 @@ The function is removed from the .so — the dynamic linker emits an undefined s
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case12_function_removed/v2.h)
+- [`CMakeLists.txt`](../../examples/case12_function_removed/CMakeLists.txt)
+- [`app.c`](../../examples/case12_function_removed/app.c)
+- [`v1.c`](../../examples/case12_function_removed/v1.c)
+- [`v1.h`](../../examples/case12_function_removed/v1.h)
+- [`v2.c`](../../examples/case12_function_removed/v2.c)
+- [`v2.h`](../../examples/case12_function_removed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case13_symbol_versioning.md
+++ b/docs/examples/case13_symbol_versioning.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case13_symbol_versioning/) |
+| **Source files** | `examples/case13_symbol_versioning/` |
 
 **Category:** ELF/Linker  
 **Verdict:** 🟢 COMPATIBLE — `symbol_version_defined_added: LIBFOO_1.0`  
@@ -161,10 +161,10 @@ entry with size=0), but correctly captures `LIBFOO_1.0` as a **version definitio
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case13_symbol_versioning/CMakeLists.txt)
-- [`app.c`](../../examples/case13_symbol_versioning/app.c)
-- [`bad.c`](../../examples/case13_symbol_versioning/bad.c)
-- [`good.c`](../../examples/case13_symbol_versioning/good.c)
-- [`libfoo.map`](../../examples/case13_symbol_versioning/libfoo.map)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
+- `libfoo.map`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case13_symbol_versioning.md
+++ b/docs/examples/case13_symbol_versioning.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/) |
+| **Source files** | [browse source](../../examples/case13_symbol_versioning/) |
 
 **Category:** ELF/Linker  
 **Verdict:** 🟢 COMPATIBLE — `symbol_version_defined_added: LIBFOO_1.0`  
@@ -48,6 +48,25 @@ changes:
 The ELF detector sees `LIBFOO_1.0` in v2's `.gnu.version_d` section but not in v1 → version definition *added*. This is a `compatible_addition`, not a break.
 
 ---
+
+## Real Failure Demo
+
+**Severity: COMPATIBLE / VERSIONING QUALITY**
+
+The old binary keeps running when the v2 library adds GNU symbol versions, but
+the real observable difference is in ELF metadata: v1 has no version section;
+v2 exports the public ABI under `LIBFOO_1.0`.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case13_symbol_versioning_app case13_symbol_versioning_v2
+
+readelf --version-info /tmp/abicheck-examples-build/case13_symbol_versioning/libv1.so
+# No version information found in this file.
+
+readelf --version-info /tmp/abicheck-examples-build/case13_symbol_versioning/libv2.so | grep LIBFOO_1.0
+# 2 (LIBFOO_1.0) ... Name: LIBFOO_1.0
+```
 
 ## Why it is COMPATIBLE (unversioned → versioned)
 
@@ -142,10 +161,10 @@ entry with size=0), but correctly captures `LIBFOO_1.0` as a **version definitio
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/good.c)
-- [`libfoo.map`](https://github.com/napetrov/abicheck/blob/main/examples/case13_symbol_versioning/libfoo.map)
+- [`CMakeLists.txt`](../../examples/case13_symbol_versioning/CMakeLists.txt)
+- [`app.c`](../../examples/case13_symbol_versioning/app.c)
+- [`bad.c`](../../examples/case13_symbol_versioning/bad.c)
+- [`good.c`](../../examples/case13_symbol_versioning/good.c)
+- [`libfoo.map`](../../examples/case13_symbol_versioning/libfoo.map)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case14_cpp_class_size.md
+++ b/docs/examples/case14_cpp_class_size.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case14_cpp_class_size/) |
+| **Source files** | `examples/case14_cpp_class_size/` |
 
 **Category:** C++ ABI | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -93,11 +93,11 @@ adjacent variables and potentially return addresses.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case14_cpp_class_size/CMakeLists.txt)
-- [`app.cpp`](../../examples/case14_cpp_class_size/app.cpp)
-- [`v1.cpp`](../../examples/case14_cpp_class_size/v1.cpp)
-- [`v1.h`](../../examples/case14_cpp_class_size/v1.h)
-- [`v2.cpp`](../../examples/case14_cpp_class_size/v2.cpp)
-- [`v2.h`](../../examples/case14_cpp_class_size/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case14_cpp_class_size.md
+++ b/docs/examples/case14_cpp_class_size.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/) |
+| **Source files** | [browse source](../../examples/case14_cpp_class_size/) |
 
 **Category:** C++ ABI | **Verdict:** 🟡 ABI CHANGE (exit 4)
 
@@ -93,11 +93,11 @@ adjacent variables and potentially return addresses.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case14_cpp_class_size/v2.h)
+- [`CMakeLists.txt`](../../examples/case14_cpp_class_size/CMakeLists.txt)
+- [`app.cpp`](../../examples/case14_cpp_class_size/app.cpp)
+- [`v1.cpp`](../../examples/case14_cpp_class_size/v1.cpp)
+- [`v1.h`](../../examples/case14_cpp_class_size/v1.h)
+- [`v2.cpp`](../../examples/case14_cpp_class_size/v2.cpp)
+- [`v2.h`](../../examples/case14_cpp_class_size/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case15_noexcept_change.md
+++ b/docs/examples/case15_noexcept_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case15_noexcept_change/) |
+| **Source files** | `examples/case15_noexcept_change/` |
 
 **Category:** Risk | **Verdict:** 🟡 COMPATIBLE_WITH_RISK
 
@@ -172,17 +172,17 @@ new `.so`.
 
 - [C++ noexcept specifier](https://en.cppreference.com/w/cpp/language/noexcept_spec)
 - [P0012R1: noexcept as part of function type](https://wg21.link/P0012R1)
-- [`checker_policy.py` — FUNC_NOEXCEPT_REMOVED](../../examples/abicheck/checker_policy.py)
+- `checker_policy.py` — FUNC_NOEXCEPT_REMOVED`
 
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case15_noexcept_change/CMakeLists.txt)
-- [`app.cpp`](../../examples/case15_noexcept_change/app.cpp)
-- [`v1.cpp`](../../examples/case15_noexcept_change/v1.cpp)
-- [`v1.h`](../../examples/case15_noexcept_change/v1.h)
-- [`v2.cpp`](../../examples/case15_noexcept_change/v2.cpp)
-- [`v2.h`](../../examples/case15_noexcept_change/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE_WITH_RISK cases](by-verdict/compatible-risk.md) · [Category: Risk](by-category/risk.md)._

--- a/docs/examples/case15_noexcept_change.md
+++ b/docs/examples/case15_noexcept_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/) |
+| **Source files** | [browse source](../../examples/case15_noexcept_change/) |
 
 **Category:** Risk | **Verdict:** 🟡 COMPATIBLE_WITH_RISK
 
@@ -172,17 +172,17 @@ new `.so`.
 
 - [C++ noexcept specifier](https://en.cppreference.com/w/cpp/language/noexcept_spec)
 - [P0012R1: noexcept as part of function type](https://wg21.link/P0012R1)
-- [`checker_policy.py` — FUNC_NOEXCEPT_REMOVED](https://github.com/napetrov/abicheck/blob/main/abicheck/checker_policy.py)
+- [`checker_policy.py` — FUNC_NOEXCEPT_REMOVED](../../examples/abicheck/checker_policy.py)
 
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case15_noexcept_change/v2.h)
+- [`CMakeLists.txt`](../../examples/case15_noexcept_change/CMakeLists.txt)
+- [`app.cpp`](../../examples/case15_noexcept_change/app.cpp)
+- [`v1.cpp`](../../examples/case15_noexcept_change/v1.cpp)
+- [`v1.h`](../../examples/case15_noexcept_change/v1.h)
+- [`v2.cpp`](../../examples/case15_noexcept_change/v2.cpp)
+- [`v2.h`](../../examples/case15_noexcept_change/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE_WITH_RISK cases](by-verdict/compatible-risk.md) · [Category: Risk](by-category/risk.md)._

--- a/docs/examples/case16_inline_to_non_inline.md
+++ b/docs/examples/case16_inline_to_non_inline.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case16_inline_to_non_inline/) |
+| **Source files** | `examples/case16_inline_to_non_inline/` |
 
 **Verdict:** 🟢 COMPATIBLE
 ## What changes
@@ -131,11 +131,11 @@ Inline→non-inline: old binary uses inlined copy, runtime unaffected
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case16_inline_to_non_inline/CMakeLists.txt)
-- [`app.cpp`](../../examples/case16_inline_to_non_inline/app.cpp)
-- [`v1.cpp`](../../examples/case16_inline_to_non_inline/v1.cpp)
-- [`v1.hpp`](../../examples/case16_inline_to_non_inline/v1.hpp)
-- [`v2.cpp`](../../examples/case16_inline_to_non_inline/v2.cpp)
-- [`v2.hpp`](../../examples/case16_inline_to_non_inline/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case16_inline_to_non_inline.md
+++ b/docs/examples/case16_inline_to_non_inline.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/) |
+| **Source files** | [browse source](../../examples/case16_inline_to_non_inline/) |
 
 **Verdict:** 🟢 COMPATIBLE
 ## What changes
@@ -131,11 +131,11 @@ Inline→non-inline: old binary uses inlined copy, runtime unaffected
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case16_inline_to_non_inline/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case16_inline_to_non_inline/CMakeLists.txt)
+- [`app.cpp`](../../examples/case16_inline_to_non_inline/app.cpp)
+- [`v1.cpp`](../../examples/case16_inline_to_non_inline/v1.cpp)
+- [`v1.hpp`](../../examples/case16_inline_to_non_inline/v1.hpp)
+- [`v2.cpp`](../../examples/case16_inline_to_non_inline/v2.cpp)
+- [`v2.hpp`](../../examples/case16_inline_to_non_inline/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case17_template_abi.md
+++ b/docs/examples/case17_template_abi.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case17_template_abi/) |
+| **Source files** | `examples/case17_template_abi/` |
 
 **Verdict:** 🔴 BREAKING
 
@@ -138,11 +138,11 @@ Template instantiation in binary: symbol names unchanged
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case17_template_abi/CMakeLists.txt)
-- [`app.cpp`](../../examples/case17_template_abi/app.cpp)
-- [`v1.cpp`](../../examples/case17_template_abi/v1.cpp)
-- [`v1.hpp`](../../examples/case17_template_abi/v1.hpp)
-- [`v2.cpp`](../../examples/case17_template_abi/v2.cpp)
-- [`v2.hpp`](../../examples/case17_template_abi/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case17_template_abi.md
+++ b/docs/examples/case17_template_abi.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/) |
+| **Source files** | [browse source](../../examples/case17_template_abi/) |
 
 **Verdict:** 🔴 BREAKING
 
@@ -138,11 +138,11 @@ Template instantiation in binary: symbol names unchanged
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case17_template_abi/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case17_template_abi/CMakeLists.txt)
+- [`app.cpp`](../../examples/case17_template_abi/app.cpp)
+- [`v1.cpp`](../../examples/case17_template_abi/v1.cpp)
+- [`v1.hpp`](../../examples/case17_template_abi/v1.hpp)
+- [`v2.cpp`](../../examples/case17_template_abi/v2.cpp)
+- [`v2.hpp`](../../examples/case17_template_abi/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case18_dependency_leak.md
+++ b/docs/examples/case18_dependency_leak.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case18_dependency_leak/) |
+| **Source files** | `examples/case18_dependency_leak/` |
 
 **Verdict:** 🔴 BREAKING (project policy + binary layout risk)
 
@@ -174,13 +174,13 @@ Header dependency leak: binary compat, recompile fails
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case18_dependency_leak/CMakeLists.txt)
-- [`app.c`](../../examples/case18_dependency_leak/app.c)
-- [`foo_v1.h`](../../examples/case18_dependency_leak/foo_v1.h)
-- [`foo_v2.h`](../../examples/case18_dependency_leak/foo_v2.h)
-- [`libfoo_v1.c`](../../examples/case18_dependency_leak/libfoo_v1.c)
-- [`libfoo_v2.c`](../../examples/case18_dependency_leak/libfoo_v2.c)
-- [`thirdparty_v1.h`](../../examples/case18_dependency_leak/thirdparty_v1.h)
-- [`thirdparty_v2.h`](../../examples/case18_dependency_leak/thirdparty_v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `foo_v1.h`
+- `foo_v2.h`
+- `libfoo_v1.c`
+- `libfoo_v2.c`
+- `thirdparty_v1.h`
+- `thirdparty_v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case18_dependency_leak.md
+++ b/docs/examples/case18_dependency_leak.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/) |
+| **Source files** | [browse source](../../examples/case18_dependency_leak/) |
 
 **Verdict:** 🔴 BREAKING (project policy + binary layout risk)
 
@@ -174,13 +174,13 @@ Header dependency leak: binary compat, recompile fails
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/app.c)
-- [`foo_v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/foo_v1.h)
-- [`foo_v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/foo_v2.h)
-- [`libfoo_v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/libfoo_v1.c)
-- [`libfoo_v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/libfoo_v2.c)
-- [`thirdparty_v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/thirdparty_v1.h)
-- [`thirdparty_v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case18_dependency_leak/thirdparty_v2.h)
+- [`CMakeLists.txt`](../../examples/case18_dependency_leak/CMakeLists.txt)
+- [`app.c`](../../examples/case18_dependency_leak/app.c)
+- [`foo_v1.h`](../../examples/case18_dependency_leak/foo_v1.h)
+- [`foo_v2.h`](../../examples/case18_dependency_leak/foo_v2.h)
+- [`libfoo_v1.c`](../../examples/case18_dependency_leak/libfoo_v1.c)
+- [`libfoo_v2.c`](../../examples/case18_dependency_leak/libfoo_v2.c)
+- [`thirdparty_v1.h`](../../examples/case18_dependency_leak/thirdparty_v1.h)
+- [`thirdparty_v2.h`](../../examples/case18_dependency_leak/thirdparty_v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case19_enum_member_removed.md
+++ b/docs/examples/case19_enum_member_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_member_removed` |
-| **Source files** | [browse source](../../examples/case19_enum_member_removed/) |
+| **Source files** | `examples/case19_enum_member_removed/` |
 
 **Verdict:** 🔴 BREAKING
 **Verdict detail:** ABI break (symbol removed) + API break (enum value missing from header)
@@ -94,7 +94,7 @@ Enum value removal: binary compat (integers same), semantic/protocol break
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case19_enum_member_removed/CMakeLists.txt)
-- [`app.c`](../../examples/case19_enum_member_removed/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case19_enum_member_removed.md
+++ b/docs/examples/case19_enum_member_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_member_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case19_enum_member_removed/) |
+| **Source files** | [browse source](../../examples/case19_enum_member_removed/) |
 
 **Verdict:** 🔴 BREAKING
 **Verdict detail:** ABI break (symbol removed) + API break (enum value missing from header)
@@ -94,7 +94,7 @@ Enum value removal: binary compat (integers same), semantic/protocol break
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case19_enum_member_removed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case19_enum_member_removed/app.c)
+- [`CMakeLists.txt`](../../examples/case19_enum_member_removed/CMakeLists.txt)
+- [`app.c`](../../examples/case19_enum_member_removed/app.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case20_enum_member_value_changed.md
+++ b/docs/examples/case20_enum_member_value_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_member_value_changed` |
-| **Source files** | [browse source](../../examples/case20_enum_member_value_changed/) |
+| **Source files** | `examples/case20_enum_member_value_changed/` |
 
 **Verdict:** 🔴 BREAKING
 **Verdict detail:** ABI break (runtime value mismatch) + API break (enum value changed in header)
@@ -91,7 +91,7 @@ Enum value changed: integer value differs, silent wrong behavior
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case20_enum_member_value_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case20_enum_member_value_changed/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case20_enum_member_value_changed.md
+++ b/docs/examples/case20_enum_member_value_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_member_value_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case20_enum_member_value_changed/) |
+| **Source files** | [browse source](../../examples/case20_enum_member_value_changed/) |
 
 **Verdict:** 🔴 BREAKING
 **Verdict detail:** ABI break (runtime value mismatch) + API break (enum value changed in header)
@@ -91,7 +91,7 @@ Enum value changed: integer value differs, silent wrong behavior
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case20_enum_member_value_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case20_enum_member_value_changed/app.c)
+- [`CMakeLists.txt`](../../examples/case20_enum_member_value_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case20_enum_member_value_changed/app.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case21_method_became_static.md
+++ b/docs/examples/case21_method_became_static.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_static_changed` |
-| **Source files** | [browse source](../../examples/case21_method_became_static/) |
+| **Source files** | `examples/case21_method_became_static/` |
 
 **Verdict:** 🔴 BREAKING (calling convention contract)
 
@@ -66,7 +66,7 @@ No crash is required to prove ABI break — wrong results are enough.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case21_method_became_static/CMakeLists.txt)
-- [`app.cpp`](../../examples/case21_method_became_static/app.cpp)
+- `CMakeLists.txt`
+- `app.cpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case21_method_became_static.md
+++ b/docs/examples/case21_method_became_static.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_static_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case21_method_became_static/) |
+| **Source files** | [browse source](../../examples/case21_method_became_static/) |
 
 **Verdict:** 🔴 BREAKING (calling convention contract)
 
@@ -66,7 +66,7 @@ No crash is required to prove ABI break — wrong results are enough.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case21_method_became_static/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case21_method_became_static/app.cpp)
+- [`CMakeLists.txt`](../../examples/case21_method_became_static/CMakeLists.txt)
+- [`app.cpp`](../../examples/case21_method_became_static/app.cpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case22_method_const_changed.md
+++ b/docs/examples/case22_method_const_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_cv_changed` |
-| **Source files** | [browse source](../../examples/case22_method_const_changed/) |
+| **Source files** | `examples/case22_method_const_changed/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -93,7 +93,7 @@ const qualifier on method changes mangled name — symbol lookup error
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case22_method_const_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case22_method_const_changed/app.cpp)
+- `CMakeLists.txt`
+- `app.cpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case22_method_const_changed.md
+++ b/docs/examples/case22_method_const_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_cv_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case22_method_const_changed/) |
+| **Source files** | [browse source](../../examples/case22_method_const_changed/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -93,7 +93,7 @@ const qualifier on method changes mangled name — symbol lookup error
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case22_method_const_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case22_method_const_changed/app.cpp)
+- [`CMakeLists.txt`](../../examples/case22_method_const_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case22_method_const_changed/app.cpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case23_pure_virtual_added.md
+++ b/docs/examples/case23_pure_virtual_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_pure_virtual_added` |
-| **Source files** | [browse source](../../examples/case23_pure_virtual_added/) |
+| **Source files** | `examples/case23_pure_virtual_added/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -114,7 +114,7 @@ Became pure virtual: direct instantiation causes SIGABRT
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case23_pure_virtual_added/CMakeLists.txt)
-- [`app.cpp`](../../examples/case23_pure_virtual_added/app.cpp)
+- `CMakeLists.txt`
+- `app.cpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case23_pure_virtual_added.md
+++ b/docs/examples/case23_pure_virtual_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_pure_virtual_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case23_pure_virtual_added/) |
+| **Source files** | [browse source](../../examples/case23_pure_virtual_added/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -114,7 +114,7 @@ Became pure virtual: direct instantiation causes SIGABRT
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case23_pure_virtual_added/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case23_pure_virtual_added/app.cpp)
+- [`CMakeLists.txt`](../../examples/case23_pure_virtual_added/CMakeLists.txt)
+- [`app.cpp`](../../examples/case23_pure_virtual_added/app.cpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case24_union_field_removed.md
+++ b/docs/examples/case24_union_field_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `union_field_removed` |
-| **Source files** | [browse source](../../examples/case24_union_field_removed/) |
+| **Source files** | `examples/case24_union_field_removed/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -101,7 +101,7 @@ Runtime check now fails explicitly when removed union member changes data interp
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case24_union_field_removed/CMakeLists.txt)
-- [`app.c`](../../examples/case24_union_field_removed/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case24_union_field_removed.md
+++ b/docs/examples/case24_union_field_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `union_field_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case24_union_field_removed/) |
+| **Source files** | [browse source](../../examples/case24_union_field_removed/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -101,7 +101,7 @@ Runtime check now fails explicitly when removed union member changes data interp
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case24_union_field_removed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case24_union_field_removed/app.c)
+- [`CMakeLists.txt`](../../examples/case24_union_field_removed/CMakeLists.txt)
+- [`app.c`](../../examples/case24_union_field_removed/app.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case25_enum_member_added.md
+++ b/docs/examples/case25_enum_member_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `enum_member_added` |
-| **Source files** | [browse source](../../examples/case25_enum_member_added/) |
+| **Source files** | `examples/case25_enum_member_added/` |
 
 **Verdict:** 🟢 COMPATIBLE
 **abicheck verdict: COMPATIBLE (informational/warning)**
@@ -94,7 +94,7 @@ Existing values are unchanged — old binaries never see the new `YELLOW` value 
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case25_enum_member_added/CMakeLists.txt)
-- [`app.c`](../../examples/case25_enum_member_added/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case25_enum_member_added.md
+++ b/docs/examples/case25_enum_member_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `enum_member_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case25_enum_member_added/) |
+| **Source files** | [browse source](../../examples/case25_enum_member_added/) |
 
 **Verdict:** 🟢 COMPATIBLE
 **abicheck verdict: COMPATIBLE (informational/warning)**
@@ -94,7 +94,7 @@ Existing values are unchanged — old binaries never see the new `YELLOW` value 
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case25_enum_member_added/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case25_enum_member_added/app.c)
+- [`CMakeLists.txt`](../../examples/case25_enum_member_added/CMakeLists.txt)
+- [`app.c`](../../examples/case25_enum_member_added/app.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case26_union_field_added.md
+++ b/docs/examples/case26_union_field_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case26_union_field_added/) |
+| **Source files** | `examples/case26_union_field_added/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING** (TYPE_SIZE_CHANGED: union grows 4→8 bytes)
@@ -100,7 +100,7 @@ v2 now writes the newly added double field so old-layout callers observe incompa
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case26_union_field_added/CMakeLists.txt)
-- [`app.c`](../../examples/case26_union_field_added/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case26_union_field_added.md
+++ b/docs/examples/case26_union_field_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case26_union_field_added/) |
+| **Source files** | [browse source](../../examples/case26_union_field_added/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING** (TYPE_SIZE_CHANGED: union grows 4→8 bytes)
@@ -100,7 +100,7 @@ v2 now writes the newly added double field so old-layout callers observe incompa
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case26_union_field_added/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case26_union_field_added/app.c)
+- [`CMakeLists.txt`](../../examples/case26_union_field_added/CMakeLists.txt)
+- [`app.c`](../../examples/case26_union_field_added/app.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case26b_union_field_added_compatible.md
+++ b/docs/examples/case26b_union_field_added_compatible.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case26b_union_field_added_compatible/) |
+| **Source files** | `examples/case26b_union_field_added_compatible/` |
 
 **Verdict:** 🟢 COMPATIBLE
 
@@ -98,7 +98,7 @@ Verdict: **COMPATIBLE**.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case26b_union_field_added_compatible/CMakeLists.txt)
-- [`app.c`](../../examples/case26b_union_field_added_compatible/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case26b_union_field_added_compatible.md
+++ b/docs/examples/case26b_union_field_added_compatible.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case26b_union_field_added_compatible/) |
+| **Source files** | [browse source](../../examples/case26b_union_field_added_compatible/) |
 
 **Verdict:** 🟢 COMPATIBLE
 
@@ -18,6 +18,26 @@
 |---------|-----------|
 | v1 | `union Value { long l; double d; };` |
 | v2 | `union Value { long l; double d; int i; };` |
+
+## Real Failure Demo
+
+**Severity: COMPATIBLE - NO FAILURE EXPECTED**
+
+This is intentionally a non-failure demo. The app is compiled against v1, then
+run with v2 under the old SONAME. Because the added union field does not change
+`sizeof(union Value)`, the result is identical.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case27_union_field_added_compatible_app case27_union_field_added_compatible_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case27_union_field_added_compatible/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case27_union_field_added_compatible/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# after fill: v.l = 42
+# OK: union field added (no size change) is ABI-compatible
+```
 
 ## Why this is NOT a binary ABI break
 
@@ -78,7 +98,7 @@ Verdict: **COMPATIBLE**.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case26b_union_field_added_compatible/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case26b_union_field_added_compatible/app.c)
+- [`CMakeLists.txt`](../../examples/case26b_union_field_added_compatible/CMakeLists.txt)
+- [`app.c`](../../examples/case26b_union_field_added_compatible/app.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case27_symbol_binding_weakened.md
+++ b/docs/examples/case27_symbol_binding_weakened.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case27_symbol_binding_weakened/) |
+| **Source files** | `examples/case27_symbol_binding_weakened/` |
 
 **Verdict:** 🟢 COMPATIBLE
 **abicheck verdict: COMPATIBLE (informational/warning)**
@@ -98,7 +98,7 @@ WEAK symbols are still exported and resolved normally when no override exists. T
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case27_symbol_binding_weakened/CMakeLists.txt)
-- [`app.c`](../../examples/case27_symbol_binding_weakened/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case27_symbol_binding_weakened.md
+++ b/docs/examples/case27_symbol_binding_weakened.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case27_symbol_binding_weakened/) |
+| **Source files** | [browse source](../../examples/case27_symbol_binding_weakened/) |
 
 **Verdict:** 🟢 COMPATIBLE
 **abicheck verdict: COMPATIBLE (informational/warning)**
@@ -98,7 +98,7 @@ WEAK symbols are still exported and resolved normally when no override exists. T
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case27_symbol_binding_weakened/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case27_symbol_binding_weakened/app.c)
+- [`CMakeLists.txt`](../../examples/case27_symbol_binding_weakened/CMakeLists.txt)
+- [`app.c`](../../examples/case27_symbol_binding_weakened/app.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case28_typedef_opaque.md
+++ b/docs/examples/case28_typedef_opaque.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_became_opaque` |
-| **Source files** | [browse source](../../examples/case28_typedef_opaque/) |
+| **Source files** | `examples/case28_typedef_opaque/` |
 
 **Category:** Type System | **Verdict:** 🔴 BREAKING (Scenario 1: typedef_base_changed) / 🟡 API_BREAK (Scenarios 2-3)
 
@@ -124,11 +124,11 @@ echo "exit: $?"
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case28_typedef_opaque/CMakeLists.txt)
-- [`app.c`](../../examples/case28_typedef_opaque/app.c)
-- [`v1.c`](../../examples/case28_typedef_opaque/v1.c)
-- [`v1.h`](../../examples/case28_typedef_opaque/v1.h)
-- [`v2.c`](../../examples/case28_typedef_opaque/v2.c)
-- [`v2.h`](../../examples/case28_typedef_opaque/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case28_typedef_opaque.md
+++ b/docs/examples/case28_typedef_opaque.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_became_opaque` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/) |
+| **Source files** | [browse source](../../examples/case28_typedef_opaque/) |
 
 **Category:** Type System | **Verdict:** 🔴 BREAKING (Scenario 1: typedef_base_changed) / 🟡 API_BREAK (Scenarios 2-3)
 
@@ -124,11 +124,11 @@ echo "exit: $?"
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case28_typedef_opaque/v2.h)
+- [`CMakeLists.txt`](../../examples/case28_typedef_opaque/CMakeLists.txt)
+- [`app.c`](../../examples/case28_typedef_opaque/app.c)
+- [`v1.c`](../../examples/case28_typedef_opaque/v1.c)
+- [`v1.h`](../../examples/case28_typedef_opaque/v1.h)
+- [`v2.c`](../../examples/case28_typedef_opaque/v2.c)
+- [`v2.h`](../../examples/case28_typedef_opaque/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case29_ifunc_transition.md
+++ b/docs/examples/case29_ifunc_transition.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case29_ifunc_transition/) |
+| **Source files** | `examples/case29_ifunc_transition/` |
 
 **Verdict:** 🟢 COMPATIBLE
 **abicheck verdict: COMPATIBLE (informational/warning)**
@@ -106,7 +106,7 @@ IFUNC: PLT/GOT transparent to caller, runtime compat
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case29_ifunc_transition/CMakeLists.txt)
-- [`app.c`](../../examples/case29_ifunc_transition/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case29_ifunc_transition.md
+++ b/docs/examples/case29_ifunc_transition.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case29_ifunc_transition/) |
+| **Source files** | [browse source](../../examples/case29_ifunc_transition/) |
 
 **Verdict:** 🟢 COMPATIBLE
 **abicheck verdict: COMPATIBLE (informational/warning)**
@@ -106,7 +106,7 @@ IFUNC: PLT/GOT transparent to caller, runtime compat
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case29_ifunc_transition/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case29_ifunc_transition/app.c)
+- [`CMakeLists.txt`](../../examples/case29_ifunc_transition/CMakeLists.txt)
+- [`app.c`](../../examples/case29_ifunc_transition/app.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case30_field_qualifiers.md
+++ b/docs/examples/case30_field_qualifiers.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case30_field_qualifiers/) |
+| **Source files** | `examples/case30_field_qualifiers/` |
 
 **Category:** Type Qualifiers | **Verdict:** 🔴 BREAKING (policy escalated source break)
 
@@ -134,11 +134,11 @@ echo "exit: $?"
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case30_field_qualifiers/CMakeLists.txt)
-- [`app.c`](../../examples/case30_field_qualifiers/app.c)
-- [`v1.c`](../../examples/case30_field_qualifiers/v1.c)
-- [`v1.h`](../../examples/case30_field_qualifiers/v1.h)
-- [`v2.c`](../../examples/case30_field_qualifiers/v2.c)
-- [`v2.h`](../../examples/case30_field_qualifiers/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case30_field_qualifiers.md
+++ b/docs/examples/case30_field_qualifiers.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/) |
+| **Source files** | [browse source](../../examples/case30_field_qualifiers/) |
 
 **Category:** Type Qualifiers | **Verdict:** 🔴 BREAKING (policy escalated source break)
 
@@ -134,11 +134,11 @@ echo "exit: $?"
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case30_field_qualifiers/v2.h)
+- [`CMakeLists.txt`](../../examples/case30_field_qualifiers/CMakeLists.txt)
+- [`app.c`](../../examples/case30_field_qualifiers/app.c)
+- [`v1.c`](../../examples/case30_field_qualifiers/v1.c)
+- [`v1.h`](../../examples/case30_field_qualifiers/v1.h)
+- [`v2.c`](../../examples/case30_field_qualifiers/v2.c)
+- [`v2.h`](../../examples/case30_field_qualifiers/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case31_enum_rename.md
+++ b/docs/examples/case31_enum_rename.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `enum_member_renamed` |
-| **Source files** | [browse source](../../examples/case31_enum_rename/) |
+| **Source files** | `examples/case31_enum_rename/` |
 
 **Category:** Enum API | **Verdict:** 🟠 API_BREAK (binary compatible)
 
@@ -120,11 +120,11 @@ echo "exit: $?"
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case31_enum_rename/CMakeLists.txt)
-- [`app.c`](../../examples/case31_enum_rename/app.c)
-- [`v1.c`](../../examples/case31_enum_rename/v1.c)
-- [`v1.h`](../../examples/case31_enum_rename/v1.h)
-- [`v2.c`](../../examples/case31_enum_rename/v2.c)
-- [`v2.h`](../../examples/case31_enum_rename/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case31_enum_rename.md
+++ b/docs/examples/case31_enum_rename.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `enum_member_renamed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/) |
+| **Source files** | [browse source](../../examples/case31_enum_rename/) |
 
 **Category:** Enum API | **Verdict:** 🟠 API_BREAK (binary compatible)
 
@@ -120,11 +120,11 @@ echo "exit: $?"
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case31_enum_rename/v2.h)
+- [`CMakeLists.txt`](../../examples/case31_enum_rename/CMakeLists.txt)
+- [`app.c`](../../examples/case31_enum_rename/app.c)
+- [`v1.c`](../../examples/case31_enum_rename/v1.c)
+- [`v1.h`](../../examples/case31_enum_rename/v1.h)
+- [`v2.c`](../../examples/case31_enum_rename/v2.c)
+- [`v2.h`](../../examples/case31_enum_rename/v2.h)
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case32_param_defaults.md
+++ b/docs/examples/case32_param_defaults.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case32_param_defaults/) |
+| **Source files** | `examples/case32_param_defaults/` |
 
 **Category:** C++ Defaults | **Verdict:** 🟢 NO_CHANGE (binary ABI unchanged)
 
@@ -138,11 +138,11 @@ No fix needed for binary compatibility. For source compatibility:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case32_param_defaults/CMakeLists.txt)
-- [`app.cpp`](../../examples/case32_param_defaults/app.cpp)
-- [`v1.cpp`](../../examples/case32_param_defaults/v1.cpp)
-- [`v1.hpp`](../../examples/case32_param_defaults/v1.hpp)
-- [`v2.cpp`](../../examples/case32_param_defaults/v2.cpp)
-- [`v2.hpp`](../../examples/case32_param_defaults/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All NO_CHANGE cases](by-verdict/no-change.md) · [Category: No Change](by-category/no_change.md)._

--- a/docs/examples/case32_param_defaults.md
+++ b/docs/examples/case32_param_defaults.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/) |
+| **Source files** | [browse source](../../examples/case32_param_defaults/) |
 
 **Category:** C++ Defaults | **Verdict:** 🟢 NO_CHANGE (binary ABI unchanged)
 
@@ -138,11 +138,11 @@ No fix needed for binary compatibility. For source compatibility:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case32_param_defaults/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case32_param_defaults/CMakeLists.txt)
+- [`app.cpp`](../../examples/case32_param_defaults/app.cpp)
+- [`v1.cpp`](../../examples/case32_param_defaults/v1.cpp)
+- [`v1.hpp`](../../examples/case32_param_defaults/v1.hpp)
+- [`v2.cpp`](../../examples/case32_param_defaults/v2.cpp)
+- [`v2.hpp`](../../examples/case32_param_defaults/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All NO_CHANGE cases](by-verdict/no-change.md) · [Category: No Change](by-category/no_change.md)._

--- a/docs/examples/case33_pointer_level.md
+++ b/docs/examples/case33_pointer_level.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `param_pointer_level_changed` |
-| **Source files** | [browse source](../../examples/case33_pointer_level/) |
+| **Source files** | `examples/case33_pointer_level/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -72,11 +72,11 @@ Pointer level change: wrong dereference depth — SIGSEGV
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case33_pointer_level/CMakeLists.txt)
-- [`app.c`](../../examples/case33_pointer_level/app.c)
-- [`v1.c`](../../examples/case33_pointer_level/v1.c)
-- [`v1.h`](../../examples/case33_pointer_level/v1.h)
-- [`v2.c`](../../examples/case33_pointer_level/v2.c)
-- [`v2.h`](../../examples/case33_pointer_level/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case33_pointer_level.md
+++ b/docs/examples/case33_pointer_level.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `param_pointer_level_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/) |
+| **Source files** | [browse source](../../examples/case33_pointer_level/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -72,11 +72,11 @@ Pointer level change: wrong dereference depth — SIGSEGV
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case33_pointer_level/v2.h)
+- [`CMakeLists.txt`](../../examples/case33_pointer_level/CMakeLists.txt)
+- [`app.c`](../../examples/case33_pointer_level/app.c)
+- [`v1.c`](../../examples/case33_pointer_level/v1.c)
+- [`v1.h`](../../examples/case33_pointer_level/v1.h)
+- [`v2.c`](../../examples/case33_pointer_level/v2.c)
+- [`v2.h`](../../examples/case33_pointer_level/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case34_access_level.md
+++ b/docs/examples/case34_access_level.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case34_access_level/) |
+| **Source files** | `examples/case34_access_level/` |
 
 **Verdict:** 🟠 API_BREAK
 **abicheck verdict: API_BREAK** (with headers) / **NO_CHANGE** (ELF-only)
@@ -129,11 +129,11 @@ Access level narrowing: binary layout unchanged, compile fails
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case34_access_level/CMakeLists.txt)
-- [`app.cpp`](../../examples/case34_access_level/app.cpp)
-- [`v1.cpp`](../../examples/case34_access_level/v1.cpp)
-- [`v1.hpp`](../../examples/case34_access_level/v1.hpp)
-- [`v2.cpp`](../../examples/case34_access_level/v2.cpp)
-- [`v2.hpp`](../../examples/case34_access_level/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case34_access_level.md
+++ b/docs/examples/case34_access_level.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/) |
+| **Source files** | [browse source](../../examples/case34_access_level/) |
 
 **Verdict:** 🟠 API_BREAK
 **abicheck verdict: API_BREAK** (with headers) / **NO_CHANGE** (ELF-only)
@@ -41,6 +41,24 @@ private:
     void helper();         // narrowed: public → private
     int cache;             // narrowed: public → private
 };
+```
+
+## Real Failure Demo
+
+**Severity: API BREAK / COMPILE-TIME FAILURE**
+
+Old binaries still run with v2 because C++ access control is not encoded in the
+mangled symbol. The real failure appears when source using the formerly-public
+members is rebuilt against the v2 header.
+
+```bash
+tmp=$(mktemp -d)
+cp examples/case35_access_level/app.cpp "$tmp/app.cpp"
+cp examples/case35_access_level/v1.hpp "$tmp/v1.hpp"
+cp examples/case35_access_level/v2.hpp "$tmp/v2.hpp"
+g++ -std=c++17 -DUSE_V2 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: 'void Widget::helper()' is private within this context
+# error: 'int Widget::cache' is private within this context
 ```
 
 ## Why this is NOT a binary ABI break
@@ -111,11 +129,11 @@ Access level narrowing: binary layout unchanged, compile fails
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case34_access_level/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case34_access_level/CMakeLists.txt)
+- [`app.cpp`](../../examples/case34_access_level/app.cpp)
+- [`v1.cpp`](../../examples/case34_access_level/v1.cpp)
+- [`v1.hpp`](../../examples/case34_access_level/v1.hpp)
+- [`v2.cpp`](../../examples/case34_access_level/v2.cpp)
+- [`v2.hpp`](../../examples/case34_access_level/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case35_field_rename.md
+++ b/docs/examples/case35_field_rename.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `field_renamed` |
-| **Source files** | [browse source](../../examples/case35_field_rename/) |
+| **Source files** | `examples/case35_field_rename/` |
 
 **Verdict:** 🔴 BREAKING (policy escalated source break)
 **abicheck verdict: BREAKING**
@@ -92,11 +92,11 @@ Field rename: binary compat (field exists), source break (name changed)
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case35_field_rename/CMakeLists.txt)
-- [`app.c`](../../examples/case35_field_rename/app.c)
-- [`v1.c`](../../examples/case35_field_rename/v1.c)
-- [`v1.h`](../../examples/case35_field_rename/v1.h)
-- [`v2.c`](../../examples/case35_field_rename/v2.c)
-- [`v2.h`](../../examples/case35_field_rename/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case35_field_rename.md
+++ b/docs/examples/case35_field_rename.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `field_renamed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/) |
+| **Source files** | [browse source](../../examples/case35_field_rename/) |
 
 **Verdict:** 🔴 BREAKING (policy escalated source break)
 **abicheck verdict: BREAKING**
@@ -92,11 +92,11 @@ Field rename: binary compat (field exists), source break (name changed)
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case35_field_rename/v2.h)
+- [`CMakeLists.txt`](../../examples/case35_field_rename/CMakeLists.txt)
+- [`app.c`](../../examples/case35_field_rename/app.c)
+- [`v1.c`](../../examples/case35_field_rename/v1.c)
+- [`v1.h`](../../examples/case35_field_rename/v1.h)
+- [`v2.c`](../../examples/case35_field_rename/v2.c)
+- [`v2.h`](../../examples/case35_field_rename/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case36_anon_struct.md
+++ b/docs/examples/case36_anon_struct.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case36_anon_struct/) |
+| **Source files** | `examples/case36_anon_struct/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -96,11 +96,11 @@ App returns non-zero on detected offset mismatch.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case36_anon_struct/CMakeLists.txt)
-- [`app.c`](../../examples/case36_anon_struct/app.c)
-- [`v1.c`](../../examples/case36_anon_struct/v1.c)
-- [`v1.h`](../../examples/case36_anon_struct/v1.h)
-- [`v2.c`](../../examples/case36_anon_struct/v2.c)
-- [`v2.h`](../../examples/case36_anon_struct/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case36_anon_struct.md
+++ b/docs/examples/case36_anon_struct.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/) |
+| **Source files** | [browse source](../../examples/case36_anon_struct/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -96,11 +96,11 @@ App returns non-zero on detected offset mismatch.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case36_anon_struct/v2.h)
+- [`CMakeLists.txt`](../../examples/case36_anon_struct/CMakeLists.txt)
+- [`app.c`](../../examples/case36_anon_struct/app.c)
+- [`v1.c`](../../examples/case36_anon_struct/v1.c)
+- [`v1.h`](../../examples/case36_anon_struct/v1.h)
+- [`v2.c`](../../examples/case36_anon_struct/v2.c)
+- [`v2.h`](../../examples/case36_anon_struct/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case37_base_class.md
+++ b/docs/examples/case37_base_class.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_base_changed` |
-| **Source files** | [browse source](../../examples/case37_base_class/) |
+| **Source files** | `examples/case37_base_class/` |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -120,11 +120,11 @@ offsets).
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case37_base_class/CMakeLists.txt)
-- [`app.cpp`](../../examples/case37_base_class/app.cpp)
-- [`v1.cpp`](../../examples/case37_base_class/v1.cpp)
-- [`v1.hpp`](../../examples/case37_base_class/v1.hpp)
-- [`v2.cpp`](../../examples/case37_base_class/v2.cpp)
-- [`v2.hpp`](../../examples/case37_base_class/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case37_base_class.md
+++ b/docs/examples/case37_base_class.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_base_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/) |
+| **Source files** | [browse source](../../examples/case37_base_class/) |
 
 **Verdict:** 🔴 BREAKING
 **abicheck verdict: BREAKING**
@@ -120,11 +120,11 @@ offsets).
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case37_base_class/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case37_base_class/CMakeLists.txt)
+- [`app.cpp`](../../examples/case37_base_class/app.cpp)
+- [`v1.cpp`](../../examples/case37_base_class/v1.cpp)
+- [`v1.hpp`](../../examples/case37_base_class/v1.hpp)
+- [`v2.cpp`](../../examples/case37_base_class/v2.cpp)
+- [`v2.hpp`](../../examples/case37_base_class/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case38_virtual_methods.md
+++ b/docs/examples/case38_virtual_methods.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case38_virtual_methods/) |
+| **Source files** | `examples/case38_virtual_methods/` |
 
 **Category:** C++ Virtual / Deleted | **Verdict:** BREAKING
 
@@ -121,12 +121,12 @@ This app may still run after swap because it does not exercise all affected ABI 
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case38_virtual_methods/CMakeLists.txt)
-- [`app.cpp`](../../examples/case38_virtual_methods/app.cpp)
-- [`copy_ctor_demo.cpp`](../../examples/case38_virtual_methods/copy_ctor_demo.cpp)
-- [`v1.cpp`](../../examples/case38_virtual_methods/v1.cpp)
-- [`v1.hpp`](../../examples/case38_virtual_methods/v1.hpp)
-- [`v2.cpp`](../../examples/case38_virtual_methods/v2.cpp)
-- [`v2.hpp`](../../examples/case38_virtual_methods/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `copy_ctor_demo.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case38_virtual_methods.md
+++ b/docs/examples/case38_virtual_methods.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/) |
+| **Source files** | [browse source](../../examples/case38_virtual_methods/) |
 
 **Category:** C++ Virtual / Deleted | **Verdict:** BREAKING
 
@@ -121,12 +121,12 @@ This app may still run after swap because it does not exercise all affected ABI 
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/app.cpp)
-- [`copy_ctor_demo.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/copy_ctor_demo.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case38_virtual_methods/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case38_virtual_methods/CMakeLists.txt)
+- [`app.cpp`](../../examples/case38_virtual_methods/app.cpp)
+- [`copy_ctor_demo.cpp`](../../examples/case38_virtual_methods/copy_ctor_demo.cpp)
+- [`v1.cpp`](../../examples/case38_virtual_methods/v1.cpp)
+- [`v1.hpp`](../../examples/case38_virtual_methods/v1.hpp)
+- [`v2.cpp`](../../examples/case38_virtual_methods/v2.cpp)
+- [`v2.hpp`](../../examples/case38_virtual_methods/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case39_var_const.md
+++ b/docs/examples/case39_var_const.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `var_became_const` |
-| **Source files** | [browse source](../../examples/case39_var_const/) |
+| **Source files** | `examples/case39_var_const/` |
 
 **Category:** Global Variable Qualifiers | **Verdict:** 🔴 BREAKING (runtime) / NO_CHANGE in headers-only abicheck
 
@@ -125,11 +125,11 @@ Without `-H`, ELF-only mode may miss source-level type qualifiers on globals.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case39_var_const/CMakeLists.txt)
-- [`app.c`](../../examples/case39_var_const/app.c)
-- [`v1.c`](../../examples/case39_var_const/v1.c)
-- [`v1.h`](../../examples/case39_var_const/v1.h)
-- [`v2.c`](../../examples/case39_var_const/v2.c)
-- [`v2.h`](../../examples/case39_var_const/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case39_var_const.md
+++ b/docs/examples/case39_var_const.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `var_became_const` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/) |
+| **Source files** | [browse source](../../examples/case39_var_const/) |
 
 **Category:** Global Variable Qualifiers | **Verdict:** 🔴 BREAKING (runtime) / NO_CHANGE in headers-only abicheck
 
@@ -125,11 +125,11 @@ Without `-H`, ELF-only mode may miss source-level type qualifiers on globals.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case39_var_const/v2.h)
+- [`CMakeLists.txt`](../../examples/case39_var_const/CMakeLists.txt)
+- [`app.c`](../../examples/case39_var_const/app.c)
+- [`v1.c`](../../examples/case39_var_const/v1.c)
+- [`v1.h`](../../examples/case39_var_const/v1.h)
+- [`v2.c`](../../examples/case39_var_const/v2.c)
+- [`v2.h`](../../examples/case39_var_const/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case40_field_layout.md
+++ b/docs/examples/case40_field_layout.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case40_field_layout/) |
+| **Source files** | `examples/case40_field_layout/` |
 
 **Category:** Struct Field Layout | **Verdict:** BREAKING
 
@@ -113,11 +113,11 @@ This case now checks checksum mismatch to make field-layout reinterpretation obs
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case40_field_layout/CMakeLists.txt)
-- [`app.c`](../../examples/case40_field_layout/app.c)
-- [`v1.c`](../../examples/case40_field_layout/v1.c)
-- [`v1.h`](../../examples/case40_field_layout/v1.h)
-- [`v2.c`](../../examples/case40_field_layout/v2.c)
-- [`v2.h`](../../examples/case40_field_layout/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case40_field_layout.md
+++ b/docs/examples/case40_field_layout.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/) |
+| **Source files** | [browse source](../../examples/case40_field_layout/) |
 
 **Category:** Struct Field Layout | **Verdict:** BREAKING
 
@@ -113,11 +113,11 @@ This case now checks checksum mismatch to make field-layout reinterpretation obs
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case40_field_layout/v2.h)
+- [`CMakeLists.txt`](../../examples/case40_field_layout/CMakeLists.txt)
+- [`app.c`](../../examples/case40_field_layout/app.c)
+- [`v1.c`](../../examples/case40_field_layout/v1.c)
+- [`v1.h`](../../examples/case40_field_layout/v1.h)
+- [`v2.c`](../../examples/case40_field_layout/v2.c)
+- [`v2.h`](../../examples/case40_field_layout/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case41_type_changes.md
+++ b/docs/examples/case41_type_changes.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case41_type_changes/) |
+| **Source files** | `examples/case41_type_changes/` |
 
 **Category:** Type / Enum Changes | **Verdict:** BREAKING
 
@@ -120,11 +120,11 @@ bounds in public APIs — use a separate `#define` or function instead.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case41_type_changes/CMakeLists.txt)
-- [`app.c`](../../examples/case41_type_changes/app.c)
-- [`v1.c`](../../examples/case41_type_changes/v1.c)
-- [`v1.h`](../../examples/case41_type_changes/v1.h)
-- [`v2.c`](../../examples/case41_type_changes/v2.c)
-- [`v2.h`](../../examples/case41_type_changes/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case41_type_changes.md
+++ b/docs/examples/case41_type_changes.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/) |
+| **Source files** | [browse source](../../examples/case41_type_changes/) |
 
 **Category:** Type / Enum Changes | **Verdict:** BREAKING
 
@@ -120,11 +120,11 @@ bounds in public APIs — use a separate `#define` or function instead.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case41_type_changes/v2.h)
+- [`CMakeLists.txt`](../../examples/case41_type_changes/CMakeLists.txt)
+- [`app.c`](../../examples/case41_type_changes/app.c)
+- [`v1.c`](../../examples/case41_type_changes/v1.c)
+- [`v1.h`](../../examples/case41_type_changes/v1.h)
+- [`v2.c`](../../examples/case41_type_changes/v2.c)
+- [`v2.h`](../../examples/case41_type_changes/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case42_type_alignment_changed.md
+++ b/docs/examples/case42_type_alignment_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case42_type_alignment_changed/) |
+| **Source files** | `examples/case42_type_alignment_changed/` |
 
 **Category:** Type Layout / DWARF | **Verdict:** BREAKING
 
@@ -100,11 +100,11 @@ cp /tmp/abicheck-examples-build/case43_type_alignment_changed/libv2.so "$tmp/lib
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case42_type_alignment_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case42_type_alignment_changed/app.c)
-- [`bad.c`](../../examples/case42_type_alignment_changed/bad.c)
-- [`bad.h`](../../examples/case42_type_alignment_changed/bad.h)
-- [`good.c`](../../examples/case42_type_alignment_changed/good.c)
-- [`good.h`](../../examples/case42_type_alignment_changed/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case42_type_alignment_changed.md
+++ b/docs/examples/case42_type_alignment_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/) |
+| **Source files** | [browse source](../../examples/case42_type_alignment_changed/) |
 
 **Category:** Type Layout / DWARF | **Verdict:** BREAKING
 
@@ -81,15 +81,30 @@ CacheBlock* block_alloc(void) {
 - [C11 alignas / _Alignas](https://en.cppreference.com/w/c/language/_Alignas)
 - [GCC __attribute__((aligned))](https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html)
 
+## Real Failure Demo
+
+**Severity: BAD PRACTICE / ABI BREAK**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case43_type_alignment_changed_app case43_type_alignment_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case43_type_alignment_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case43_type_alignment_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# block_process = 0 (expected 4) / WRONG RESULT: alignment change caused array stride/layout mismatch
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case42_type_alignment_changed/good.h)
+- [`CMakeLists.txt`](../../examples/case42_type_alignment_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case42_type_alignment_changed/app.c)
+- [`bad.c`](../../examples/case42_type_alignment_changed/bad.c)
+- [`bad.h`](../../examples/case42_type_alignment_changed/bad.h)
+- [`good.c`](../../examples/case42_type_alignment_changed/good.c)
+- [`good.h`](../../examples/case42_type_alignment_changed/good.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case43_base_class_member_added.md
+++ b/docs/examples/case43_base_class_member_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case43_base_class_member_added/) |
+| **Source files** | `examples/case43_base_class_member_added/` |
 
 **Category:** C++ Layout | **Verdict:** 🔴 BREAKING
 
@@ -74,11 +74,11 @@ Options:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case43_base_class_member_added/CMakeLists.txt)
-- [`app.cpp`](../../examples/case43_base_class_member_added/app.cpp)
-- [`v1.cpp`](../../examples/case43_base_class_member_added/v1.cpp)
-- [`v1.hpp`](../../examples/case43_base_class_member_added/v1.hpp)
-- [`v2.cpp`](../../examples/case43_base_class_member_added/v2.cpp)
-- [`v2.hpp`](../../examples/case43_base_class_member_added/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case43_base_class_member_added.md
+++ b/docs/examples/case43_base_class_member_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/) |
+| **Source files** | [browse source](../../examples/case43_base_class_member_added/) |
 
 **Category:** C++ Layout | **Verdict:** 🔴 BREAKING
 
@@ -74,11 +74,11 @@ Options:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case43_base_class_member_added/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case43_base_class_member_added/CMakeLists.txt)
+- [`app.cpp`](../../examples/case43_base_class_member_added/app.cpp)
+- [`v1.cpp`](../../examples/case43_base_class_member_added/v1.cpp)
+- [`v1.hpp`](../../examples/case43_base_class_member_added/v1.hpp)
+- [`v2.cpp`](../../examples/case43_base_class_member_added/v2.cpp)
+- [`v2.hpp`](../../examples/case43_base_class_member_added/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case44_cyclic_type_member_added.md
+++ b/docs/examples/case44_cyclic_type_member_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case44_cyclic_type_member_added/) |
+| **Source files** | `examples/case44_cyclic_type_member_added/` |
 
 **Category:** Struct Layout | **Verdict:** 🔴 BREAKING
 
@@ -69,11 +69,11 @@ Avoid by-value passing of structs in public API:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case44_cyclic_type_member_added/CMakeLists.txt)
-- [`app.c`](../../examples/case44_cyclic_type_member_added/app.c)
-- [`v1.c`](../../examples/case44_cyclic_type_member_added/v1.c)
-- [`v1.h`](../../examples/case44_cyclic_type_member_added/v1.h)
-- [`v2.c`](../../examples/case44_cyclic_type_member_added/v2.c)
-- [`v2.h`](../../examples/case44_cyclic_type_member_added/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case44_cyclic_type_member_added.md
+++ b/docs/examples/case44_cyclic_type_member_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/) |
+| **Source files** | [browse source](../../examples/case44_cyclic_type_member_added/) |
 
 **Category:** Struct Layout | **Verdict:** 🔴 BREAKING
 
@@ -69,11 +69,11 @@ Avoid by-value passing of structs in public API:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case44_cyclic_type_member_added/v2.h)
+- [`CMakeLists.txt`](../../examples/case44_cyclic_type_member_added/CMakeLists.txt)
+- [`app.c`](../../examples/case44_cyclic_type_member_added/app.c)
+- [`v1.c`](../../examples/case44_cyclic_type_member_added/v1.c)
+- [`v1.h`](../../examples/case44_cyclic_type_member_added/v1.h)
+- [`v2.c`](../../examples/case44_cyclic_type_member_added/v2.c)
+- [`v2.h`](../../examples/case44_cyclic_type_member_added/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case45_multi_dim_array_change.md
+++ b/docs/examples/case45_multi_dim_array_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case45_multi_dim_array_change/) |
+| **Source files** | `examples/case45_multi_dim_array_change/` |
 
 **Category:** Struct Layout | **Verdict:** 🔴 BREAKING
 
@@ -66,11 +66,11 @@ abidiff v1.abi v2.abi
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case45_multi_dim_array_change/CMakeLists.txt)
-- [`app.c`](../../examples/case45_multi_dim_array_change/app.c)
-- [`v1.c`](../../examples/case45_multi_dim_array_change/v1.c)
-- [`v1.h`](../../examples/case45_multi_dim_array_change/v1.h)
-- [`v2.c`](../../examples/case45_multi_dim_array_change/v2.c)
-- [`v2.h`](../../examples/case45_multi_dim_array_change/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case45_multi_dim_array_change.md
+++ b/docs/examples/case45_multi_dim_array_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/) |
+| **Source files** | [browse source](../../examples/case45_multi_dim_array_change/) |
 
 **Category:** Struct Layout | **Verdict:** 🔴 BREAKING
 
@@ -66,11 +66,11 @@ abidiff v1.abi v2.abi
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case45_multi_dim_array_change/v2.h)
+- [`CMakeLists.txt`](../../examples/case45_multi_dim_array_change/CMakeLists.txt)
+- [`app.c`](../../examples/case45_multi_dim_array_change/app.c)
+- [`v1.c`](../../examples/case45_multi_dim_array_change/v1.c)
+- [`v1.h`](../../examples/case45_multi_dim_array_change/v1.h)
+- [`v2.c`](../../examples/case45_multi_dim_array_change/v2.c)
+- [`v2.h`](../../examples/case45_multi_dim_array_change/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case46_pointer_chain_type_change.md
+++ b/docs/examples/case46_pointer_chain_type_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case46_pointer_chain_type_change/) |
+| **Source files** | `examples/case46_pointer_chain_type_change/` |
 
 **Category:** Breaking | **Verdict:** 🔴 BREAKING
 
@@ -68,11 +68,11 @@ abidiff v1.abi v2.abi
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case46_pointer_chain_type_change/CMakeLists.txt)
-- [`app.c`](../../examples/case46_pointer_chain_type_change/app.c)
-- [`v1.c`](../../examples/case46_pointer_chain_type_change/v1.c)
-- [`v1.h`](../../examples/case46_pointer_chain_type_change/v1.h)
-- [`v2.c`](../../examples/case46_pointer_chain_type_change/v2.c)
-- [`v2.h`](../../examples/case46_pointer_chain_type_change/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case46_pointer_chain_type_change.md
+++ b/docs/examples/case46_pointer_chain_type_change.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/) |
+| **Source files** | [browse source](../../examples/case46_pointer_chain_type_change/) |
 
 **Category:** Breaking | **Verdict:** 🔴 BREAKING
 
@@ -68,11 +68,11 @@ abidiff v1.abi v2.abi
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case46_pointer_chain_type_change/v2.h)
+- [`CMakeLists.txt`](../../examples/case46_pointer_chain_type_change/CMakeLists.txt)
+- [`app.c`](../../examples/case46_pointer_chain_type_change/app.c)
+- [`v1.c`](../../examples/case46_pointer_chain_type_change/v1.c)
+- [`v1.h`](../../examples/case46_pointer_chain_type_change/v1.h)
+- [`v2.c`](../../examples/case46_pointer_chain_type_change/v2.c)
+- [`v2.h`](../../examples/case46_pointer_chain_type_change/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case47_inline_to_outlined.md
+++ b/docs/examples/case47_inline_to_outlined.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case47_inline_to_outlined/) |
+| **Source files** | `examples/case47_inline_to_outlined/` |
 
 **Category:** Compatible | **Verdict:** 🟢 COMPATIBLE
 
@@ -68,11 +68,11 @@ contexts or LTO-heavy builds) may see different behavior. Document the change.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case47_inline_to_outlined/CMakeLists.txt)
-- [`app.cpp`](../../examples/case47_inline_to_outlined/app.cpp)
-- [`v1.cpp`](../../examples/case47_inline_to_outlined/v1.cpp)
-- [`v1.hpp`](../../examples/case47_inline_to_outlined/v1.hpp)
-- [`v2.cpp`](../../examples/case47_inline_to_outlined/v2.cpp)
-- [`v2.hpp`](../../examples/case47_inline_to_outlined/v2.hpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.hpp`
+- `v2.cpp`
+- `v2.hpp`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case47_inline_to_outlined.md
+++ b/docs/examples/case47_inline_to_outlined.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/) |
+| **Source files** | [browse source](../../examples/case47_inline_to_outlined/) |
 
 **Category:** Compatible | **Verdict:** 🟢 COMPATIBLE
 
@@ -68,11 +68,11 @@ contexts or LTO-heavy builds) may see different behavior. Document the change.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/v1.cpp)
-- [`v1.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/v1.hpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/v2.cpp)
-- [`v2.hpp`](https://github.com/napetrov/abicheck/blob/main/examples/case47_inline_to_outlined/v2.hpp)
+- [`CMakeLists.txt`](../../examples/case47_inline_to_outlined/CMakeLists.txt)
+- [`app.cpp`](../../examples/case47_inline_to_outlined/app.cpp)
+- [`v1.cpp`](../../examples/case47_inline_to_outlined/v1.cpp)
+- [`v1.hpp`](../../examples/case47_inline_to_outlined/v1.hpp)
+- [`v2.cpp`](../../examples/case47_inline_to_outlined/v2.cpp)
+- [`v2.hpp`](../../examples/case47_inline_to_outlined/v2.hpp)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case48_leaf_struct_through_pointer.md
+++ b/docs/examples/case48_leaf_struct_through_pointer.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case48_leaf_struct_through_pointer/) |
+| **Source files** | `examples/case48_leaf_struct_through_pointer/` |
 
 **Category:** Breaking | **Verdict:** 🔴 BREAKING
 
@@ -74,11 +74,11 @@ propagation mechanism as this case. See `case18_dependency_leak` for the externa
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case48_leaf_struct_through_pointer/CMakeLists.txt)
-- [`app.c`](../../examples/case48_leaf_struct_through_pointer/app.c)
-- [`v1.c`](../../examples/case48_leaf_struct_through_pointer/v1.c)
-- [`v1.h`](../../examples/case48_leaf_struct_through_pointer/v1.h)
-- [`v2.c`](../../examples/case48_leaf_struct_through_pointer/v2.c)
-- [`v2.h`](../../examples/case48_leaf_struct_through_pointer/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case48_leaf_struct_through_pointer.md
+++ b/docs/examples/case48_leaf_struct_through_pointer.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/) |
+| **Source files** | [browse source](../../examples/case48_leaf_struct_through_pointer/) |
 
 **Category:** Breaking | **Verdict:** 🔴 BREAKING
 
@@ -74,11 +74,11 @@ propagation mechanism as this case. See `case18_dependency_leak` for the externa
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case48_leaf_struct_through_pointer/v2.h)
+- [`CMakeLists.txt`](../../examples/case48_leaf_struct_through_pointer/CMakeLists.txt)
+- [`app.c`](../../examples/case48_leaf_struct_through_pointer/app.c)
+- [`v1.c`](../../examples/case48_leaf_struct_through_pointer/v1.c)
+- [`v1.h`](../../examples/case48_leaf_struct_through_pointer/v1.h)
+- [`v2.c`](../../examples/case48_leaf_struct_through_pointer/v2.c)
+- [`v2.h`](../../examples/case48_leaf_struct_through_pointer/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case49_executable_stack.md
+++ b/docs/examples/case49_executable_stack.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case49_executable_stack/) |
+| **Source files** | `examples/case49_executable_stack/` |
 
 **Category:** ELF / Security | **Verdict:** BAD PRACTICE
 
@@ -118,9 +118,9 @@ readelf -W -l /tmp/abicheck-examples-build/case50_executable_stack/libv2.so | gr
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case49_executable_stack/CMakeLists.txt)
-- [`app.c`](../../examples/case49_executable_stack/app.c)
-- [`bad.c`](../../examples/case49_executable_stack/bad.c)
-- [`good.c`](../../examples/case49_executable_stack/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case49_executable_stack.md
+++ b/docs/examples/case49_executable_stack.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/) |
+| **Source files** | [browse source](../../examples/case49_executable_stack/) |
 
 **Category:** ELF / Security | **Verdict:** BAD PRACTICE
 
@@ -95,13 +95,32 @@ executable stacks.
 - [Hardening ELF binaries — execstack](https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart)
 - [Red Hat: Controlling execstack](https://access.redhat.com/solutions/2936741)
 
+## Real Failure Demo
+
+**Severity: SECURITY / BAD PRACTICE**
+
+The program still runs, but the v1 artifact requests an executable process
+stack. Hardened loaders and distro policy can reject this even when symbol ABI
+looks otherwise compatible.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case50_executable_stack_v1 case50_executable_stack_v2
+
+readelf -W -l /tmp/abicheck-examples-build/case50_executable_stack/libv1.so | grep GNU_STACK
+# GNU_STACK ... RWE
+
+readelf -W -l /tmp/abicheck-examples-build/case50_executable_stack/libv2.so | grep GNU_STACK
+# GNU_STACK ... RW
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case49_executable_stack/good.c)
+- [`CMakeLists.txt`](../../examples/case49_executable_stack/CMakeLists.txt)
+- [`app.c`](../../examples/case49_executable_stack/app.c)
+- [`bad.c`](../../examples/case49_executable_stack/bad.c)
+- [`good.c`](../../examples/case49_executable_stack/good.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case50_soname_inconsistent.md
+++ b/docs/examples/case50_soname_inconsistent.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case50_soname_inconsistent/) |
+| **Source files** | `examples/case50_soname_inconsistent/` |
 
 **Policy verdict:** 🟡 BAD PRACTICE | **ABI compatibility verdict:** COMPATIBLE
 
@@ -118,9 +118,9 @@ rejected during review because they break upgrade paths.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case50_soname_inconsistent/CMakeLists.txt)
-- [`app.c`](../../examples/case50_soname_inconsistent/app.c)
-- [`bad.c`](../../examples/case50_soname_inconsistent/bad.c)
-- [`good.c`](../../examples/case50_soname_inconsistent/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case50_soname_inconsistent.md
+++ b/docs/examples/case50_soname_inconsistent.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/) |
+| **Source files** | [browse source](../../examples/case50_soname_inconsistent/) |
 
 **Policy verdict:** 🟡 BAD PRACTICE | **ABI compatibility verdict:** COMPATIBLE
 
@@ -118,9 +118,9 @@ rejected during review because they break upgrade paths.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case50_soname_inconsistent/good.c)
+- [`CMakeLists.txt`](../../examples/case50_soname_inconsistent/CMakeLists.txt)
+- [`app.c`](../../examples/case50_soname_inconsistent/app.c)
+- [`bad.c`](../../examples/case50_soname_inconsistent/bad.c)
+- [`good.c`](../../examples/case50_soname_inconsistent/good.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case51_protected_visibility.md
+++ b/docs/examples/case51_protected_visibility.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case51_protected_visibility/) |
+| **Source files** | `examples/case51_protected_visibility/` |
 
 **Category:** ELF / Policy | **Verdict:** 🟢 COMPATIBLE
 
@@ -124,7 +124,7 @@ as an interposition policy change.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case51_protected_visibility/CMakeLists.txt)
-- [`app.c`](../../examples/case51_protected_visibility/app.c)
+- `CMakeLists.txt`
+- `app.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case51_protected_visibility.md
+++ b/docs/examples/case51_protected_visibility.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case51_protected_visibility/) |
+| **Source files** | [browse source](../../examples/case51_protected_visibility/) |
 
 **Category:** ELF / Policy | **Verdict:** 🟢 COMPATIBLE
 
@@ -124,7 +124,7 @@ as an interposition policy change.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case51_protected_visibility/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case51_protected_visibility/app.c)
+- [`CMakeLists.txt`](../../examples/case51_protected_visibility/CMakeLists.txt)
+- [`app.c`](../../examples/case51_protected_visibility/app.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case52_rpath_leak.md
+++ b/docs/examples/case52_rpath_leak.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case52_rpath_leak/) |
+| **Source files** | `examples/case52_rpath_leak/` |
 
 **Category:** ELF / Deployment | **Verdict:** BAD PRACTICE
 
@@ -123,9 +123,9 @@ as a warning for the same reason.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case52_rpath_leak/CMakeLists.txt)
-- [`app.c`](../../examples/case52_rpath_leak/app.c)
-- [`bad.c`](../../examples/case52_rpath_leak/bad.c)
-- [`good.c`](../../examples/case52_rpath_leak/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case52_rpath_leak.md
+++ b/docs/examples/case52_rpath_leak.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/) |
+| **Source files** | [browse source](../../examples/case52_rpath_leak/) |
 
 **Category:** ELF / Deployment | **Verdict:** BAD PRACTICE
 
@@ -21,6 +21,25 @@ uses `$ORIGIN`-relative paths.
 
 This is a **deployment-level bad practice**: build-directory paths in shared
 libraries break on every machine except the one where the library was built.
+
+## Real Failure Demo
+
+**Severity: SECURITY / PACKAGING RISK**
+
+The code path still runs, but v1 bakes a build-machine path into `RUNPATH`.
+That can load unintended libraries on a matching host path or fail package
+policy checks.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case53_rpath_leak_v1 case53_rpath_leak_v2
+
+readelf -d /tmp/abicheck-examples-build/case53_rpath_leak/libv1.so | grep RUNPATH
+# Library runpath: [/home/build/myproject/lib]
+
+readelf -d /tmp/abicheck-examples-build/case53_rpath_leak/libv2.so | grep RUNPATH
+# Library runpath: [$ORIGIN]
+```
 
 ## Why hardcoded RPATH is bad practice
 
@@ -104,9 +123,9 @@ as a warning for the same reason.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case52_rpath_leak/good.c)
+- [`CMakeLists.txt`](../../examples/case52_rpath_leak/CMakeLists.txt)
+- [`app.c`](../../examples/case52_rpath_leak/app.c)
+- [`bad.c`](../../examples/case52_rpath_leak/bad.c)
+- [`good.c`](../../examples/case52_rpath_leak/good.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case53_namespace_pollution.md
+++ b/docs/examples/case53_namespace_pollution.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break, Bad practice |
 | **Detected `ChangeKind`s** | `func_removed`, `func_added` |
-| **Source files** | [browse source](../../examples/case53_namespace_pollution/) |
+| **Source files** | `examples/case53_namespace_pollution/` |
 
 **Category:** API Design / Policy | **Verdict:** BREAKING (bad practice)
 
@@ -130,9 +130,9 @@ Libraries that historically did NOT prefix (like early POSIX `open`, `read`,
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case53_namespace_pollution/CMakeLists.txt)
-- [`app.c`](../../examples/case53_namespace_pollution/app.c)
-- [`bad.c`](../../examples/case53_namespace_pollution/bad.c)
-- [`good.c`](../../examples/case53_namespace_pollution/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case53_namespace_pollution.md
+++ b/docs/examples/case53_namespace_pollution.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break, Bad practice |
 | **Detected `ChangeKind`s** | `func_removed`, `func_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/) |
+| **Source files** | [browse source](../../examples/case53_namespace_pollution/) |
 
 **Category:** API Design / Policy | **Verdict:** BREAKING (bad practice)
 
@@ -21,6 +21,21 @@ v1 exports functions with extremely generic names: `init`, `process`,
 This is a **design-level bad practice**: unprefixed names in C shared libraries
 are a collision time-bomb in any non-trivial application that links multiple
 libraries.
+
+## Real Failure Demo
+
+**Severity: BREAKING / SYMBOL REMOVAL**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case54_namespace_pollution_app case54_namespace_pollution_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case54_namespace_pollution/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case54_namespace_pollution/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: process
+```
 
 ## Why namespace pollution is bad practice
 
@@ -115,9 +130,9 @@ Libraries that historically did NOT prefix (like early POSIX `open`, `read`,
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case53_namespace_pollution/good.c)
+- [`CMakeLists.txt`](../../examples/case53_namespace_pollution/CMakeLists.txt)
+- [`app.c`](../../examples/case53_namespace_pollution/app.c)
+- [`bad.c`](../../examples/case53_namespace_pollution/bad.c)
+- [`good.c`](../../examples/case53_namespace_pollution/good.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case54_used_reserved_field.md
+++ b/docs/examples/case54_used_reserved_field.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `used_reserved_field` |
-| **Source files** | [browse source](../../examples/case54_used_reserved_field/) |
+| **Source files** | `examples/case54_used_reserved_field/` |
 
 **Category:** Type Layout | **Verdict:** COMPATIBLE
 
@@ -92,11 +92,11 @@ cp /tmp/abicheck-examples-build/case55_used_reserved_field/libv2.so "$tmp/libv1.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case54_used_reserved_field/CMakeLists.txt)
-- [`app.c`](../../examples/case54_used_reserved_field/app.c)
-- [`bad.c`](../../examples/case54_used_reserved_field/bad.c)
-- [`bad.h`](../../examples/case54_used_reserved_field/bad.h)
-- [`good.c`](../../examples/case54_used_reserved_field/good.c)
-- [`good.h`](../../examples/case54_used_reserved_field/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case54_used_reserved_field.md
+++ b/docs/examples/case54_used_reserved_field.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `used_reserved_field` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/) |
+| **Source files** | [browse source](../../examples/case54_used_reserved_field/) |
 
 **Category:** Type Layout | **Verdict:** COMPATIBLE
 
@@ -71,15 +71,32 @@ typedef struct {
 
 - [Preserving ABI with reserved fields](https://www.akkadia.org/drepper/dsohowto.pdf)
 
+## Real Failure Demo
+
+**Severity: BAD PRACTICE / ABI RISK**
+
+The small app still prints the old value, but v1 consumes a reserved field that v2 expects to own. The failure is latent: future library code may reinterpret that field and corrupt caller state.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case55_used_reserved_field_app case55_used_reserved_field_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case55_used_reserved_field/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case55_used_reserved_field/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# flags = 0
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case54_used_reserved_field/good.h)
+- [`CMakeLists.txt`](../../examples/case54_used_reserved_field/CMakeLists.txt)
+- [`app.c`](../../examples/case54_used_reserved_field/app.c)
+- [`bad.c`](../../examples/case54_used_reserved_field/bad.c)
+- [`bad.h`](../../examples/case54_used_reserved_field/bad.h)
+- [`good.c`](../../examples/case54_used_reserved_field/good.c)
+- [`good.h`](../../examples/case54_used_reserved_field/good.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._

--- a/docs/examples/case55_type_kind_changed.md
+++ b/docs/examples/case55_type_kind_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_kind_changed` |
-| **Source files** | [browse source](../../examples/case55_type_kind_changed/) |
+| **Source files** | `examples/case55_type_kind_changed/` |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -74,11 +74,11 @@ cp /tmp/abicheck-examples-build/case56_type_kind_changed/libv2.so "$tmp/libv1.so
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case55_type_kind_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case55_type_kind_changed/app.c)
-- [`bad.c`](../../examples/case55_type_kind_changed/bad.c)
-- [`bad.h`](../../examples/case55_type_kind_changed/bad.h)
-- [`good.c`](../../examples/case55_type_kind_changed/good.c)
-- [`good.h`](../../examples/case55_type_kind_changed/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case55_type_kind_changed.md
+++ b/docs/examples/case55_type_kind_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_kind_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/) |
+| **Source files** | [browse source](../../examples/case55_type_kind_changed/) |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -55,15 +55,30 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 
 - [DWARF structure vs union tags](https://dwarfstd.org/doc/DWARF5.pdf)
 
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case56_type_kind_changed_app case56_type_kind_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case56_type_kind_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case56_type_kind_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# sum = 10 / WRONG RESULT: type kind changed (struct -> union)
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case55_type_kind_changed/good.h)
+- [`CMakeLists.txt`](../../examples/case55_type_kind_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case55_type_kind_changed/app.c)
+- [`bad.c`](../../examples/case55_type_kind_changed/bad.c)
+- [`bad.h`](../../examples/case55_type_kind_changed/bad.h)
+- [`good.c`](../../examples/case55_type_kind_changed/good.c)
+- [`good.h`](../../examples/case55_type_kind_changed/good.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case56_struct_packing_changed.md
+++ b/docs/examples/case56_struct_packing_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `struct_packing_changed` |
-| **Source files** | [browse source](../../examples/case56_struct_packing_changed/) |
+| **Source files** | `examples/case56_struct_packing_changed/` |
 
 **Category:** Type Layout / DWARF | **Verdict:** BREAKING
 
@@ -81,11 +81,11 @@ cp /tmp/abicheck-examples-build/case57_struct_packing_changed/libv2.so "$tmp/lib
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case56_struct_packing_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case56_struct_packing_changed/app.c)
-- [`bad.c`](../../examples/case56_struct_packing_changed/bad.c)
-- [`bad.h`](../../examples/case56_struct_packing_changed/bad.h)
-- [`good.c`](../../examples/case56_struct_packing_changed/good.c)
-- [`good.h`](../../examples/case56_struct_packing_changed/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case56_struct_packing_changed.md
+++ b/docs/examples/case56_struct_packing_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `struct_packing_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/) |
+| **Source files** | [browse source](../../examples/case56_struct_packing_changed/) |
 
 **Category:** Type Layout / DWARF | **Verdict:** BREAKING
 
@@ -62,15 +62,30 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 
 - [GCC: Structure Packing Pragmas](https://gcc.gnu.org/onlinedocs/gcc/Structure-Layout-Pragmas.html)
 
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case57_struct_packing_changed_app case57_struct_packing_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case57_struct_packing_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case57_struct_packing_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# value = 22528 / WRONG RESULT: struct packing/layout changed
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case56_struct_packing_changed/good.h)
+- [`CMakeLists.txt`](../../examples/case56_struct_packing_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case56_struct_packing_changed/app.c)
+- [`bad.c`](../../examples/case56_struct_packing_changed/bad.c)
+- [`bad.h`](../../examples/case56_struct_packing_changed/bad.h)
+- [`good.c`](../../examples/case56_struct_packing_changed/good.c)
+- [`good.h`](../../examples/case56_struct_packing_changed/good.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case57_enum_underlying_size_changed.md
+++ b/docs/examples/case57_enum_underlying_size_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_underlying_size_changed` |
-| **Source files** | [browse source](../../examples/case57_enum_underlying_size_changed/) |
+| **Source files** | `examples/case57_enum_underlying_size_changed/` |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -77,11 +77,11 @@ cp /tmp/abicheck-examples-build/case58_enum_underlying_size_changed/libv2.so "$t
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case57_enum_underlying_size_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case57_enum_underlying_size_changed/app.c)
-- [`bad.c`](../../examples/case57_enum_underlying_size_changed/bad.c)
-- [`bad.h`](../../examples/case57_enum_underlying_size_changed/bad.h)
-- [`good.c`](../../examples/case57_enum_underlying_size_changed/good.c)
-- [`good.h`](../../examples/case57_enum_underlying_size_changed/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case57_enum_underlying_size_changed.md
+++ b/docs/examples/case57_enum_underlying_size_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `enum_underlying_size_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/) |
+| **Source files** | [browse source](../../examples/case57_enum_underlying_size_changed/) |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -58,15 +58,30 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 
 - [C11 6.7.2.2: Enumeration specifiers](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
 
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case58_enum_underlying_size_changed_app case58_enum_underlying_size_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case58_enum_underlying_size_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case58_enum_underlying_size_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# color = 2; alpha = 0 / WRONG RESULT: enum underlying size/layout changed
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case57_enum_underlying_size_changed/good.h)
+- [`CMakeLists.txt`](../../examples/case57_enum_underlying_size_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case57_enum_underlying_size_changed/app.c)
+- [`bad.c`](../../examples/case57_enum_underlying_size_changed/bad.c)
+- [`bad.h`](../../examples/case57_enum_underlying_size_changed/bad.h)
+- [`good.c`](../../examples/case57_enum_underlying_size_changed/good.c)
+- [`good.h`](../../examples/case57_enum_underlying_size_changed/good.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case58_var_removed.md
+++ b/docs/examples/case58_var_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `var_removed` |
-| **Source files** | [browse source](../../examples/case58_var_removed/) |
+| **Source files** | `examples/case58_var_removed/` |
 
 **Category:** Symbol API | **Verdict:** BREAKING
 
@@ -83,9 +83,9 @@ cp /tmp/abicheck-examples-build/case59_var_removed/libv2.so "$tmp/libv1.so"
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case58_var_removed/CMakeLists.txt)
-- [`app.c`](../../examples/case58_var_removed/app.c)
-- [`bad.c`](../../examples/case58_var_removed/bad.c)
-- [`good.c`](../../examples/case58_var_removed/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case58_var_removed.md
+++ b/docs/examples/case58_var_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `var_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case58_var_removed/) |
+| **Source files** | [browse source](../../examples/case58_var_removed/) |
 
 **Category:** Symbol API | **Verdict:** BREAKING
 
@@ -64,13 +64,28 @@ Or use a version script to control when symbols are removed.
 
 - [ELF Symbol Versioning](https://www.akkadia.org/drepper/symbol-versioning)
 
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case59_var_removed_app case59_var_removed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case59_var_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case59_var_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: lib_debug_level
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case58_var_removed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case58_var_removed/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case58_var_removed/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case58_var_removed/good.c)
+- [`CMakeLists.txt`](../../examples/case58_var_removed/CMakeLists.txt)
+- [`app.c`](../../examples/case58_var_removed/app.c)
+- [`bad.c`](../../examples/case58_var_removed/bad.c)
+- [`good.c`](../../examples/case58_var_removed/good.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case59_func_became_inline.md
+++ b/docs/examples/case59_func_became_inline.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse source](../../examples/case59_func_became_inline/) |
+| **Source files** | `examples/case59_func_became_inline/` |
 
 **Category:** Symbol API | **Verdict:** BREAKING (API_BREAK)
 
@@ -112,11 +112,11 @@ cp /tmp/abicheck-examples-build/case60_func_became_inline/libv2.so "$tmp/libv1.s
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case59_func_became_inline/CMakeLists.txt)
-- [`app.c`](../../examples/case59_func_became_inline/app.c)
-- [`bad.c`](../../examples/case59_func_became_inline/bad.c)
-- [`bad.h`](../../examples/case59_func_became_inline/bad.h)
-- [`good.c`](../../examples/case59_func_became_inline/good.c)
-- [`good.h`](../../examples/case59_func_became_inline/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case59_func_became_inline.md
+++ b/docs/examples/case59_func_became_inline.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `func_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/) |
+| **Source files** | [browse source](../../examples/case59_func_became_inline/) |
 
 **Category:** Symbol API | **Verdict:** BREAKING (API_BREAK)
 
@@ -93,15 +93,30 @@ Or use a `__attribute__((weak))` symbol.
 
 - [C99 inline semantics](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
 
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case60_func_became_inline_app case60_func_became_inline_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case60_func_became_inline/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case60_func_became_inline/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: fast_abs
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case59_func_became_inline/good.h)
+- [`CMakeLists.txt`](../../examples/case59_func_became_inline/CMakeLists.txt)
+- [`app.c`](../../examples/case59_func_became_inline/app.c)
+- [`bad.c`](../../examples/case59_func_became_inline/bad.c)
+- [`bad.h`](../../examples/case59_func_became_inline/bad.h)
+- [`good.c`](../../examples/case59_func_became_inline/good.c)
+- [`good.h`](../../examples/case59_func_became_inline/good.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case60_base_class_position_changed.md
+++ b/docs/examples/case60_base_class_position_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse source](../../examples/case60_base_class_position_changed/) |
+| **Source files** | `examples/case60_base_class_position_changed/` |
 
 **Category:** C++ Layout | **Verdict:** BREAKING
 
@@ -78,9 +78,9 @@ cp /tmp/abicheck-examples-build/case61_base_class_position_changed/libv2.so "$tm
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case60_base_class_position_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case60_base_class_position_changed/app.cpp)
-- [`v1.cpp`](../../examples/case60_base_class_position_changed/v1.cpp)
-- [`v2.cpp`](../../examples/case60_base_class_position_changed/v2.cpp)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v2.cpp`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case60_base_class_position_changed.md
+++ b/docs/examples/case60_base_class_position_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | — |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case60_base_class_position_changed/) |
+| **Source files** | [browse source](../../examples/case60_base_class_position_changed/) |
 
 **Category:** C++ Layout | **Verdict:** BREAKING
 
@@ -59,13 +59,28 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 
 - [Itanium C++ ABI: class layout](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#class-types)
 
+## Real Failure Demo
+
+**Severity: BREAKING / OBJECT CORRUPTION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case61_base_class_position_changed_app case61_base_class_position_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case61_base_class_position_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case61_base_class_position_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# id = <garbage>; CORRUPTION: base-class order changed, subobject offsets mismatch
+```
+
 ---
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case60_base_class_position_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case60_base_class_position_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case60_base_class_position_changed/v1.cpp)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case60_base_class_position_changed/v2.cpp)
+- [`CMakeLists.txt`](../../examples/case60_base_class_position_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case60_base_class_position_changed/app.cpp)
+- [`v1.cpp`](../../examples/case60_base_class_position_changed/v1.cpp)
+- [`v2.cpp`](../../examples/case60_base_class_position_changed/v2.cpp)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case61_var_added.md
+++ b/docs/examples/case61_var_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `var_added` |
-| **Source files** | [browse source](../../examples/case61_var_added/) |
+| **Source files** | `examples/case61_var_added/` |
 
 **Category:** Symbol API | **Verdict:** COMPATIBLE
 
@@ -68,9 +68,9 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case61_var_added/CMakeLists.txt)
-- [`app.c`](../../examples/case61_var_added/app.c)
-- [`bad.c`](../../examples/case61_var_added/bad.c)
-- [`good.c`](../../examples/case61_var_added/good.c)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `good.c`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case61_var_added.md
+++ b/docs/examples/case61_var_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `var_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case61_var_added/) |
+| **Source files** | [browse source](../../examples/case61_var_added/) |
 
 **Category:** Symbol API | **Verdict:** COMPATIBLE
 
@@ -16,6 +16,23 @@
 
 v1 exports `lib_version`. v2 adds a new global variable `lib_build_number`.
 All existing symbols are unchanged — this is a purely additive change.
+
+## Real Failure Demo
+
+**Severity: COMPATIBLE - NO FAILURE EXPECTED**
+
+This is an additive ABI change. The old app does not reference the new global, so runtime substitution is safe.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case62_var_added_app case62_var_added_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case62_var_added/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case62_var_added/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# version = 2 / get_version() = 2
+```
 
 ## Why this is compatible
 
@@ -51,9 +68,9 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case61_var_added/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case61_var_added/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case61_var_added/bad.c)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case61_var_added/good.c)
+- [`CMakeLists.txt`](../../examples/case61_var_added/CMakeLists.txt)
+- [`app.c`](../../examples/case61_var_added/app.c)
+- [`bad.c`](../../examples/case61_var_added/bad.c)
+- [`good.c`](../../examples/case61_var_added/good.c)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case62_type_field_added_compatible.md
+++ b/docs/examples/case62_type_field_added_compatible.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `func_added` |
-| **Source files** | [browse source](../../examples/case62_type_field_added_compatible/) |
+| **Source files** | `examples/case62_type_field_added_compatible/` |
 
 **Category:** Type Layout | **Verdict:** COMPATIBLE
 
@@ -100,11 +100,11 @@ struct Widget {
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case62_type_field_added_compatible/CMakeLists.txt)
-- [`app.c`](../../examples/case62_type_field_added_compatible/app.c)
-- [`bad.c`](../../examples/case62_type_field_added_compatible/bad.c)
-- [`bad.h`](../../examples/case62_type_field_added_compatible/bad.h)
-- [`good.c`](../../examples/case62_type_field_added_compatible/good.c)
-- [`good.h`](../../examples/case62_type_field_added_compatible/good.h)
+- `CMakeLists.txt`
+- `app.c`
+- `bad.c`
+- `bad.h`
+- `good.c`
+- `good.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case62_type_field_added_compatible.md
+++ b/docs/examples/case62_type_field_added_compatible.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `func_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/) |
+| **Source files** | [browse source](../../examples/case62_type_field_added_compatible/) |
 
 **Category:** Type Layout | **Verdict:** COMPATIBLE
 
@@ -20,6 +20,23 @@ v2 adds a `priority` field at the end. Because callers only use `Session*`
 
 This is the **correct design pattern** for extensible C APIs: opaque handles +
 accessor functions allow adding fields without breaking existing consumers.
+
+## Real Failure Demo
+
+**Severity: COMPATIBLE - NO FAILURE EXPECTED**
+
+The struct is opaque to callers, so v2 can grow the private allocation without changing caller layout.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case63_type_field_added_compatible_app case63_type_field_added_compatible_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case63_type_field_added_compatible/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case63_type_field_added_compatible/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# name = test / timeout = 30
+```
 
 ## Why this is compatible
 
@@ -83,11 +100,11 @@ struct Widget {
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/app.c)
-- [`bad.c`](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/bad.c)
-- [`bad.h`](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/bad.h)
-- [`good.c`](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/good.c)
-- [`good.h`](https://github.com/napetrov/abicheck/blob/main/examples/case62_type_field_added_compatible/good.h)
+- [`CMakeLists.txt`](../../examples/case62_type_field_added_compatible/CMakeLists.txt)
+- [`app.c`](../../examples/case62_type_field_added_compatible/app.c)
+- [`bad.c`](../../examples/case62_type_field_added_compatible/bad.c)
+- [`bad.h`](../../examples/case62_type_field_added_compatible/bad.h)
+- [`good.c`](../../examples/case62_type_field_added_compatible/good.c)
+- [`good.h`](../../examples/case62_type_field_added_compatible/good.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Addition (Compatible)](by-category/addition.md)._

--- a/docs/examples/case63_bitfield_changed.md
+++ b/docs/examples/case63_bitfield_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `field_bitfield_changed` |
-| **Source files** | [browse source](../../examples/case63_bitfield_changed/) |
+| **Source files** | `examples/case63_bitfield_changed/` |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -103,11 +103,11 @@ difference is caught.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case63_bitfield_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case63_bitfield_changed/app.c)
-- [`v1.c`](../../examples/case63_bitfield_changed/v1.c)
-- [`v1.h`](../../examples/case63_bitfield_changed/v1.h)
-- [`v2.c`](../../examples/case63_bitfield_changed/v2.c)
-- [`v2.h`](../../examples/case63_bitfield_changed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case63_bitfield_changed.md
+++ b/docs/examples/case63_bitfield_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `field_bitfield_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/) |
+| **Source files** | [browse source](../../examples/case63_bitfield_changed/) |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -103,11 +103,11 @@ difference is caught.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case63_bitfield_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case63_bitfield_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case63_bitfield_changed/app.c)
+- [`v1.c`](../../examples/case63_bitfield_changed/v1.c)
+- [`v1.h`](../../examples/case63_bitfield_changed/v1.h)
+- [`v2.c`](../../examples/case63_bitfield_changed/v2.c)
+- [`v2.h`](../../examples/case63_bitfield_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case64_calling_convention_changed.md
+++ b/docs/examples/case64_calling_convention_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `calling_convention_changed` |
-| **Source files** | [browse source](../../examples/case64_calling_convention_changed/) |
+| **Source files** | `examples/case64_calling_convention_changed/` |
 
 **Category:** Function ABI | **Verdict:** BREAKING
 
@@ -125,11 +125,11 @@ DWARF `DW_AT_calling_convention` attributes between the two binary versions.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case64_calling_convention_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case64_calling_convention_changed/app.c)
-- [`v1.c`](../../examples/case64_calling_convention_changed/v1.c)
-- [`v1.h`](../../examples/case64_calling_convention_changed/v1.h)
-- [`v2.c`](../../examples/case64_calling_convention_changed/v2.c)
-- [`v2.h`](../../examples/case64_calling_convention_changed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case64_calling_convention_changed.md
+++ b/docs/examples/case64_calling_convention_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `calling_convention_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/) |
+| **Source files** | [browse source](../../examples/case64_calling_convention_changed/) |
 
 **Category:** Function ABI | **Verdict:** BREAKING
 
@@ -125,11 +125,11 @@ DWARF `DW_AT_calling_convention` attributes between the two binary versions.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case64_calling_convention_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case64_calling_convention_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case64_calling_convention_changed/app.c)
+- [`v1.c`](../../examples/case64_calling_convention_changed/v1.c)
+- [`v1.h`](../../examples/case64_calling_convention_changed/v1.h)
+- [`v2.c`](../../examples/case64_calling_convention_changed/v2.c)
+- [`v2.h`](../../examples/case64_calling_convention_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case65_symbol_version_removed.md
+++ b/docs/examples/case65_symbol_version_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `symbol_version_defined_removed` |
-| **Source files** | [browse source](../../examples/case65_symbol_version_removed/) |
+| **Source files** | `examples/case65_symbol_version_removed/` |
 
 **Category:** Symbol Versioning | **Verdict:** BREAKING
 
@@ -115,13 +115,13 @@ comparing the `.gnu.version_d` sections of the two library versions.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case65_symbol_version_removed/CMakeLists.txt)
-- [`app.c`](../../examples/case65_symbol_version_removed/app.c)
-- [`v1.c`](../../examples/case65_symbol_version_removed/v1.c)
-- [`v1.h`](../../examples/case65_symbol_version_removed/v1.h)
-- [`v1.map`](../../examples/case65_symbol_version_removed/v1.map)
-- [`v2.c`](../../examples/case65_symbol_version_removed/v2.c)
-- [`v2.h`](../../examples/case65_symbol_version_removed/v2.h)
-- [`v2.map`](../../examples/case65_symbol_version_removed/v2.map)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v1.map`
+- `v2.c`
+- `v2.h`
+- `v2.map`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case65_symbol_version_removed.md
+++ b/docs/examples/case65_symbol_version_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `symbol_version_defined_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/) |
+| **Source files** | [browse source](../../examples/case65_symbol_version_removed/) |
 
 **Category:** Symbol Versioning | **Verdict:** BREAKING
 
@@ -115,13 +115,13 @@ comparing the `.gnu.version_d` sections of the two library versions.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/v1.h)
-- [`v1.map`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/v1.map)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/v2.h)
-- [`v2.map`](https://github.com/napetrov/abicheck/blob/main/examples/case65_symbol_version_removed/v2.map)
+- [`CMakeLists.txt`](../../examples/case65_symbol_version_removed/CMakeLists.txt)
+- [`app.c`](../../examples/case65_symbol_version_removed/app.c)
+- [`v1.c`](../../examples/case65_symbol_version_removed/v1.c)
+- [`v1.h`](../../examples/case65_symbol_version_removed/v1.h)
+- [`v1.map`](../../examples/case65_symbol_version_removed/v1.map)
+- [`v2.c`](../../examples/case65_symbol_version_removed/v2.c)
+- [`v2.h`](../../examples/case65_symbol_version_removed/v2.h)
+- [`v2.map`](../../examples/case65_symbol_version_removed/v2.map)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case66_language_linkage_changed.md
+++ b/docs/examples/case66_language_linkage_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_language_linkage_changed` |
-| **Source files** | [browse source](../../examples/case66_language_linkage_changed/) |
+| **Source files** | `examples/case66_language_linkage_changed/` |
 
 **Category:** Function ABI | **Verdict:** BREAKING
 
@@ -119,11 +119,11 @@ rather than a simple removal + addition.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case66_language_linkage_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case66_language_linkage_changed/app.c)
-- [`v1.cpp`](../../examples/case66_language_linkage_changed/v1.cpp)
-- [`v1.h`](../../examples/case66_language_linkage_changed/v1.h)
-- [`v2.cpp`](../../examples/case66_language_linkage_changed/v2.cpp)
-- [`v2.h`](../../examples/case66_language_linkage_changed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case66_language_linkage_changed.md
+++ b/docs/examples/case66_language_linkage_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_language_linkage_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/) |
+| **Source files** | [browse source](../../examples/case66_language_linkage_changed/) |
 
 **Category:** Function ABI | **Verdict:** BREAKING
 
@@ -119,11 +119,11 @@ rather than a simple removal + addition.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/app.c)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case66_language_linkage_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case66_language_linkage_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case66_language_linkage_changed/app.c)
+- [`v1.cpp`](../../examples/case66_language_linkage_changed/v1.cpp)
+- [`v1.h`](../../examples/case66_language_linkage_changed/v1.h)
+- [`v2.cpp`](../../examples/case66_language_linkage_changed/v2.cpp)
+- [`v2.h`](../../examples/case66_language_linkage_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case67_tls_var_size_changed.md
+++ b/docs/examples/case67_tls_var_size_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `tls_var_size_changed` |
-| **Source files** | [browse source](../../examples/case67_tls_var_size_changed/) |
+| **Source files** | `examples/case67_tls_var_size_changed/` |
 
 **Category:** Variable ABI | **Verdict:** BREAKING
 
@@ -125,11 +125,11 @@ type) between the two library versions.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case67_tls_var_size_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case67_tls_var_size_changed/app.c)
-- [`v1.c`](../../examples/case67_tls_var_size_changed/v1.c)
-- [`v1.h`](../../examples/case67_tls_var_size_changed/v1.h)
-- [`v2.c`](../../examples/case67_tls_var_size_changed/v2.c)
-- [`v2.h`](../../examples/case67_tls_var_size_changed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case67_tls_var_size_changed.md
+++ b/docs/examples/case67_tls_var_size_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `tls_var_size_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/) |
+| **Source files** | [browse source](../../examples/case67_tls_var_size_changed/) |
 
 **Category:** Variable ABI | **Verdict:** BREAKING
 
@@ -125,11 +125,11 @@ type) between the two library versions.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case67_tls_var_size_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case67_tls_var_size_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case67_tls_var_size_changed/app.c)
+- [`v1.c`](../../examples/case67_tls_var_size_changed/v1.c)
+- [`v1.h`](../../examples/case67_tls_var_size_changed/v1.h)
+- [`v2.c`](../../examples/case67_tls_var_size_changed/v2.c)
+- [`v2.h`](../../examples/case67_tls_var_size_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case68_virtual_method_added.md
+++ b/docs/examples/case68_virtual_method_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_virtual_added` |
-| **Source files** | [browse source](../../examples/case68_virtual_method_added/) |
+| **Source files** | `examples/case68_virtual_method_added/` |
 
 **Category:** Class Layout / Vtable | **Verdict:** BREAKING
 
@@ -147,11 +147,11 @@ further evidence of the vtable-insertion break.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case68_virtual_method_added/CMakeLists.txt)
-- [`app.cpp`](../../examples/case68_virtual_method_added/app.cpp)
-- [`v1.cpp`](../../examples/case68_virtual_method_added/v1.cpp)
-- [`v1.h`](../../examples/case68_virtual_method_added/v1.h)
-- [`v2.cpp`](../../examples/case68_virtual_method_added/v2.cpp)
-- [`v2.h`](../../examples/case68_virtual_method_added/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case68_virtual_method_added.md
+++ b/docs/examples/case68_virtual_method_added.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_virtual_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/) |
+| **Source files** | [browse source](../../examples/case68_virtual_method_added/) |
 
 **Category:** Class Layout / Vtable | **Verdict:** BREAKING
 
@@ -147,11 +147,11 @@ further evidence of the vtable-insertion break.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case68_virtual_method_added/v2.h)
+- [`CMakeLists.txt`](../../examples/case68_virtual_method_added/CMakeLists.txt)
+- [`app.cpp`](../../examples/case68_virtual_method_added/app.cpp)
+- [`v1.cpp`](../../examples/case68_virtual_method_added/v1.cpp)
+- [`v1.h`](../../examples/case68_virtual_method_added/v1.h)
+- [`v2.cpp`](../../examples/case68_virtual_method_added/v2.cpp)
+- [`v2.h`](../../examples/case68_virtual_method_added/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case69_trivial_to_nontrivial.md
+++ b/docs/examples/case69_trivial_to_nontrivial.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `value_abi_trait_changed` |
-| **Source files** | [browse source](../../examples/case69_trivial_to_nontrivial/) |
+| **Source files** | `examples/case69_trivial_to_nontrivial/` |
 
 **Category:** Calling Convention | **Verdict:** BREAKING
 
@@ -123,11 +123,11 @@ they are invisible to most diff tools but cause silent corruption at runtime.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case69_trivial_to_nontrivial/CMakeLists.txt)
-- [`app.cpp`](../../examples/case69_trivial_to_nontrivial/app.cpp)
-- [`v1.cpp`](../../examples/case69_trivial_to_nontrivial/v1.cpp)
-- [`v1.h`](../../examples/case69_trivial_to_nontrivial/v1.h)
-- [`v2.cpp`](../../examples/case69_trivial_to_nontrivial/v2.cpp)
-- [`v2.h`](../../examples/case69_trivial_to_nontrivial/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case69_trivial_to_nontrivial.md
+++ b/docs/examples/case69_trivial_to_nontrivial.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `value_abi_trait_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/) |
+| **Source files** | [browse source](../../examples/case69_trivial_to_nontrivial/) |
 
 **Category:** Calling Convention | **Verdict:** BREAKING
 
@@ -123,11 +123,11 @@ they are invisible to most diff tools but cause silent corruption at runtime.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case69_trivial_to_nontrivial/v2.h)
+- [`CMakeLists.txt`](../../examples/case69_trivial_to_nontrivial/CMakeLists.txt)
+- [`app.cpp`](../../examples/case69_trivial_to_nontrivial/app.cpp)
+- [`v1.cpp`](../../examples/case69_trivial_to_nontrivial/v1.cpp)
+- [`v1.h`](../../examples/case69_trivial_to_nontrivial/v1.h)
+- [`v2.cpp`](../../examples/case69_trivial_to_nontrivial/v2.cpp)
+- [`v2.h`](../../examples/case69_trivial_to_nontrivial/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case70_flexible_array_member_changed.md
+++ b/docs/examples/case70_flexible_array_member_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `flexible_array_member_changed`, `func_return_changed` |
-| **Source files** | [browse source](../../examples/case70_flexible_array_member_changed/) |
+| **Source files** | `examples/case70_flexible_array_member_changed/` |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -125,11 +125,11 @@ only DWARF inspection of the trailing array element type reveals the break.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case70_flexible_array_member_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case70_flexible_array_member_changed/app.c)
-- [`v1.c`](../../examples/case70_flexible_array_member_changed/v1.c)
-- [`v1.h`](../../examples/case70_flexible_array_member_changed/v1.h)
-- [`v2.c`](../../examples/case70_flexible_array_member_changed/v2.c)
-- [`v2.h`](../../examples/case70_flexible_array_member_changed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case70_flexible_array_member_changed.md
+++ b/docs/examples/case70_flexible_array_member_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `flexible_array_member_changed`, `func_return_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/) |
+| **Source files** | [browse source](../../examples/case70_flexible_array_member_changed/) |
 
 **Category:** Type Layout | **Verdict:** BREAKING
 
@@ -125,11 +125,11 @@ only DWARF inspection of the trailing array element type reveals the break.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case70_flexible_array_member_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case70_flexible_array_member_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case70_flexible_array_member_changed/app.c)
+- [`v1.c`](../../examples/case70_flexible_array_member_changed/v1.c)
+- [`v1.h`](../../examples/case70_flexible_array_member_changed/v1.h)
+- [`v2.c`](../../examples/case70_flexible_array_member_changed/v2.c)
+- [`v2.h`](../../examples/case70_flexible_array_member_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case71_inline_namespace_moved.md
+++ b/docs/examples/case71_inline_namespace_moved.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_namespace_moved` |
-| **Source files** | [browse source](../../examples/case71_inline_namespace_moved/) |
+| **Source files** | `examples/case71_inline_namespace_moved/` |
 
 **Category:** Symbol ABI | **Verdict:** BREAKING
 
@@ -122,11 +122,11 @@ distributions.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case71_inline_namespace_moved/CMakeLists.txt)
-- [`app.cpp`](../../examples/case71_inline_namespace_moved/app.cpp)
-- [`v1.cpp`](../../examples/case71_inline_namespace_moved/v1.cpp)
-- [`v1.h`](../../examples/case71_inline_namespace_moved/v1.h)
-- [`v2.cpp`](../../examples/case71_inline_namespace_moved/v2.cpp)
-- [`v2.h`](../../examples/case71_inline_namespace_moved/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case71_inline_namespace_moved.md
+++ b/docs/examples/case71_inline_namespace_moved.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_namespace_moved` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/) |
+| **Source files** | [browse source](../../examples/case71_inline_namespace_moved/) |
 
 **Category:** Symbol ABI | **Verdict:** BREAKING
 
@@ -122,11 +122,11 @@ distributions.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case71_inline_namespace_moved/v2.h)
+- [`CMakeLists.txt`](../../examples/case71_inline_namespace_moved/CMakeLists.txt)
+- [`app.cpp`](../../examples/case71_inline_namespace_moved/app.cpp)
+- [`v1.cpp`](../../examples/case71_inline_namespace_moved/v1.cpp)
+- [`v1.h`](../../examples/case71_inline_namespace_moved/v1.h)
+- [`v2.cpp`](../../examples/case71_inline_namespace_moved/v2.cpp)
+- [`v2.h`](../../examples/case71_inline_namespace_moved/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case72_covariant_return_changed.md
+++ b/docs/examples/case72_covariant_return_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_base_changed`, `type_vtable_changed`, `func_return_changed` |
-| **Source files** | [browse source](../../examples/case72_covariant_return_changed/) |
+| **Source files** | `examples/case72_covariant_return_changed/` |
 
 **Category:** VTable / Inheritance | **Verdict:** BREAKING
 
@@ -130,11 +130,11 @@ hierarchies changed because the classof() chain encodes the exact hierarchy.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case72_covariant_return_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case72_covariant_return_changed/app.cpp)
-- [`v1.cpp`](../../examples/case72_covariant_return_changed/v1.cpp)
-- [`v1.h`](../../examples/case72_covariant_return_changed/v1.h)
-- [`v2.cpp`](../../examples/case72_covariant_return_changed/v2.cpp)
-- [`v2.h`](../../examples/case72_covariant_return_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case72_covariant_return_changed.md
+++ b/docs/examples/case72_covariant_return_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_base_changed`, `type_vtable_changed`, `func_return_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/) |
+| **Source files** | [browse source](../../examples/case72_covariant_return_changed/) |
 
 **Category:** VTable / Inheritance | **Verdict:** BREAKING
 
@@ -130,11 +130,11 @@ hierarchies changed because the classof() chain encodes the exact hierarchy.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case72_covariant_return_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case72_covariant_return_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case72_covariant_return_changed/app.cpp)
+- [`v1.cpp`](../../examples/case72_covariant_return_changed/v1.cpp)
+- [`v1.h`](../../examples/case72_covariant_return_changed/v1.h)
+- [`v2.cpp`](../../examples/case72_covariant_return_changed/v2.cpp)
+- [`v2.h`](../../examples/case72_covariant_return_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case73_typedef_underlying_changed.md
+++ b/docs/examples/case73_typedef_underlying_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `typedef_base_changed` |
-| **Source files** | [browse source](../../examples/case73_typedef_underlying_changed/) |
+| **Source files** | `examples/case73_typedef_underlying_changed/` |
 
 **Category:** Type ABI | **Verdict:** BREAKING
 
@@ -104,11 +104,11 @@ pools.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case73_typedef_underlying_changed/CMakeLists.txt)
-- [`app.c`](../../examples/case73_typedef_underlying_changed/app.c)
-- [`v1.c`](../../examples/case73_typedef_underlying_changed/v1.c)
-- [`v1.h`](../../examples/case73_typedef_underlying_changed/v1.h)
-- [`v2.c`](../../examples/case73_typedef_underlying_changed/v2.c)
-- [`v2.h`](../../examples/case73_typedef_underlying_changed/v2.h)
+- `CMakeLists.txt`
+- `app.c`
+- `v1.c`
+- `v1.h`
+- `v2.c`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case73_typedef_underlying_changed.md
+++ b/docs/examples/case73_typedef_underlying_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `typedef_base_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/) |
+| **Source files** | [browse source](../../examples/case73_typedef_underlying_changed/) |
 
 **Category:** Type ABI | **Verdict:** BREAKING
 
@@ -104,11 +104,11 @@ pools.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/CMakeLists.txt)
-- [`app.c`](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/app.c)
-- [`v1.c`](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/v1.c)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/v1.h)
-- [`v2.c`](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/v2.c)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case73_typedef_underlying_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case73_typedef_underlying_changed/CMakeLists.txt)
+- [`app.c`](../../examples/case73_typedef_underlying_changed/app.c)
+- [`v1.c`](../../examples/case73_typedef_underlying_changed/v1.c)
+- [`v1.h`](../../examples/case73_typedef_underlying_changed/v1.h)
+- [`v2.c`](../../examples/case73_typedef_underlying_changed/v2.c)
+- [`v2.h`](../../examples/case73_typedef_underlying_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case74_detail_base_class_changed.md
+++ b/docs/examples/case74_detail_base_class_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse source](../../examples/case74_detail_base_class_changed/) |
+| **Source files** | `examples/case74_detail_base_class_changed/` |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -116,11 +116,11 @@ private:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case74_detail_base_class_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case74_detail_base_class_changed/app.cpp)
-- [`v1.cpp`](../../examples/case74_detail_base_class_changed/v1.cpp)
-- [`v1.h`](../../examples/case74_detail_base_class_changed/v1.h)
-- [`v2.cpp`](../../examples/case74_detail_base_class_changed/v2.cpp)
-- [`v2.h`](../../examples/case74_detail_base_class_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case74_detail_base_class_changed.md
+++ b/docs/examples/case74_detail_base_class_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/) |
+| **Source files** | [browse source](../../examples/case74_detail_base_class_changed/) |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -36,6 +36,21 @@ From consumers' perspective it's a binary ABI break:
   their pre-v2 frame slots.
 - Heap-allocated objects from callers compiled against v1 headers
   under-allocate when run against v2 binaries.
+
+## Real Failure Demo
+
+**Severity: BREAKING / MEMORY CORRUPTION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case75_detail_base_class_changed_app case75_detail_base_class_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case75_detail_base_class_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case75_detail_base_class_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# *** stack smashing detected ***: terminated
+```
 
 ## Why abicheck catches it
 
@@ -101,11 +116,11 @@ private:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case74_detail_base_class_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case74_detail_base_class_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case74_detail_base_class_changed/app.cpp)
+- [`v1.cpp`](../../examples/case74_detail_base_class_changed/v1.cpp)
+- [`v1.h`](../../examples/case74_detail_base_class_changed/v1.h)
+- [`v2.cpp`](../../examples/case74_detail_base_class_changed/v2.cpp)
+- [`v2.h`](../../examples/case74_detail_base_class_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case75_detail_embedded_by_value.md
+++ b/docs/examples/case75_detail_embedded_by_value.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse source](../../examples/case75_detail_embedded_by_value/) |
+| **Source files** | `examples/case75_detail_embedded_by_value/` |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -119,11 +119,11 @@ private:
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case75_detail_embedded_by_value/CMakeLists.txt)
-- [`app.cpp`](../../examples/case75_detail_embedded_by_value/app.cpp)
-- [`v1.cpp`](../../examples/case75_detail_embedded_by_value/v1.cpp)
-- [`v1.h`](../../examples/case75_detail_embedded_by_value/v1.h)
-- [`v2.cpp`](../../examples/case75_detail_embedded_by_value/v2.cpp)
-- [`v2.h`](../../examples/case75_detail_embedded_by_value/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case75_detail_embedded_by_value.md
+++ b/docs/examples/case75_detail_embedded_by_value.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/) |
+| **Source files** | [browse source](../../examples/case75_detail_embedded_by_value/) |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -34,6 +34,23 @@ the public class:
 
 The author touched only the "internal" struct — but the binary
 interface of the *public* class moved with it.
+
+## Real Failure Demo
+
+**Severity: BREAKING / LATENT LAYOUT CORRUPTION**
+
+This minimal app does not trip the corrupted field, but the public `table` embeds a changed `detail::table_impl` by value. Any caller that copies, arrays, or inlines deeper accessors is using the old object layout.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case76_detail_embedded_by_value_app case76_detail_embedded_by_value_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case76_detail_embedded_by_value/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case76_detail_embedded_by_value/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# rows=3 cols=4 (expect 3 4)
+```
 
 ## Why abicheck catches it
 
@@ -102,11 +119,11 @@ private:
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case75_detail_embedded_by_value/v2.h)
+- [`CMakeLists.txt`](../../examples/case75_detail_embedded_by_value/CMakeLists.txt)
+- [`app.cpp`](../../examples/case75_detail_embedded_by_value/app.cpp)
+- [`v1.cpp`](../../examples/case75_detail_embedded_by_value/v1.cpp)
+- [`v1.h`](../../examples/case75_detail_embedded_by_value/v1.h)
+- [`v2.cpp`](../../examples/case75_detail_embedded_by_value/v2.cpp)
+- [`v2.h`](../../examples/case75_detail_embedded_by_value/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case76_detail_pimpl_vtable_changed.md
+++ b/docs/examples/case76_detail_pimpl_vtable_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse source](../../examples/case76_detail_pimpl_vtable_changed/) |
+| **Source files** | `examples/case76_detail_pimpl_vtable_changed/` |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -139,11 +139,11 @@ If polymorphism must remain part of the public surface, only ever
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case76_detail_pimpl_vtable_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case76_detail_pimpl_vtable_changed/app.cpp)
-- [`v1.cpp`](../../examples/case76_detail_pimpl_vtable_changed/v1.cpp)
-- [`v1.h`](../../examples/case76_detail_pimpl_vtable_changed/v1.h)
-- [`v2.cpp`](../../examples/case76_detail_pimpl_vtable_changed/v2.cpp)
-- [`v2.h`](../../examples/case76_detail_pimpl_vtable_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case76_detail_pimpl_vtable_changed.md
+++ b/docs/examples/case76_detail_pimpl_vtable_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/) |
+| **Source files** | [browse source](../../examples/case76_detail_pimpl_vtable_changed/) |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -40,6 +40,21 @@ instance now dispatches through the slot occupied at runtime by
 `progress()` — wrong return value at best, crash at worst. The
 reshuffle never touches any public *name*; only the slot indices
 move. That makes the break invisible to symbol-level tools.
+
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case77_detail_pimpl_vtable_changed_app case77_detail_pimpl_vtable_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case77_detail_pimpl_vtable_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case77_detail_pimpl_vtable_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# status=50 (expect 1)
+```
 
 ## Why abicheck catches it
 
@@ -124,11 +139,11 @@ If polymorphism must remain part of the public surface, only ever
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case76_detail_pimpl_vtable_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case76_detail_pimpl_vtable_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case76_detail_pimpl_vtable_changed/app.cpp)
+- [`v1.cpp`](../../examples/case76_detail_pimpl_vtable_changed/v1.cpp)
+- [`v1.h`](../../examples/case76_detail_pimpl_vtable_changed/v1.h)
+- [`v2.cpp`](../../examples/case76_detail_pimpl_vtable_changed/v2.cpp)
+- [`v2.h`](../../examples/case76_detail_pimpl_vtable_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case77_detail_templated_base_changed.md
+++ b/docs/examples/case77_detail_templated_base_changed.md
@@ -49,11 +49,11 @@ reachability walker follows template-instantiation edges into `detail::`.
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case78_detail_templated_base_changed_app case78_detail_templated_base_changed_v2
+cmake --build /tmp/abicheck-examples-build --target case77_detail_templated_base_changed_app case77_detail_templated_base_changed_v2
 
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case77_detail_templated_base_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case77_detail_templated_base_changed/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # *** stack smashing detected ***: terminated
 ```

--- a/docs/examples/case77_detail_templated_base_changed.md
+++ b/docs/examples/case77_detail_templated_base_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse source](../../examples/case77_detail_templated_base_changed/) |
+| **Source files** | `examples/case77_detail_templated_base_changed/` |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -109,11 +109,11 @@ the binary layout of every shipped algorithm descriptor.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case77_detail_templated_base_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case77_detail_templated_base_changed/app.cpp)
-- [`v1.cpp`](../../examples/case77_detail_templated_base_changed/v1.cpp)
-- [`v1.h`](../../examples/case77_detail_templated_base_changed/v1.h)
-- [`v2.cpp`](../../examples/case77_detail_templated_base_changed/v2.cpp)
-- [`v2.h`](../../examples/case77_detail_templated_base_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case77_detail_templated_base_changed.md
+++ b/docs/examples/case77_detail_templated_base_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/) |
+| **Source files** | [browse source](../../examples/case77_detail_templated_base_changed/) |
 
 **Category:** Internal-leak | **Verdict:** BREAKING
 
@@ -42,6 +42,21 @@ field, which grows *every instantiation* simultaneously:
 
 case74 verifies the simple inheritance edge. case77 verifies that the leak
 reachability walker follows template-instantiation edges into `detail::`.
+
+## Real Failure Demo
+
+**Severity: BREAKING / MEMORY CORRUPTION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case78_detail_templated_base_changed_app case78_detail_templated_base_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# *** stack smashing detected ***: terminated
+```
 
 ## Why abicheck catches it
 
@@ -94,11 +109,11 @@ the binary layout of every shipped algorithm descriptor.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case77_detail_templated_base_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case77_detail_templated_base_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case77_detail_templated_base_changed/app.cpp)
+- [`v1.cpp`](../../examples/case77_detail_templated_base_changed/v1.cpp)
+- [`v1.h`](../../examples/case77_detail_templated_base_changed/v1.h)
+- [`v2.cpp`](../../examples/case77_detail_templated_base_changed/v2.cpp)
+- [`v2.h`](../../examples/case77_detail_templated_base_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case79_missing_template_instantiation.md
+++ b/docs/examples/case79_missing_template_instantiation.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `instantiation_missing_from_binary` |
-| **Source files** | [browse source](../../examples/case79_missing_template_instantiation/) |
+| **Source files** | `examples/case79_missing_template_instantiation/` |
 
 **Category:** Header-vs-binary parity | **Verdict:** BREAKING
 
@@ -88,11 +88,11 @@ example.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case79_missing_template_instantiation/CMakeLists.txt)
-- [`app.cpp`](../../examples/case79_missing_template_instantiation/app.cpp)
-- [`v1.cpp`](../../examples/case79_missing_template_instantiation/v1.cpp)
-- [`v1.h`](../../examples/case79_missing_template_instantiation/v1.h)
-- [`v2.cpp`](../../examples/case79_missing_template_instantiation/v2.cpp)
-- [`v2.h`](../../examples/case79_missing_template_instantiation/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case79_missing_template_instantiation.md
+++ b/docs/examples/case79_missing_template_instantiation.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `instantiation_missing_from_binary` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/) |
+| **Source files** | [browse source](../../examples/case79_missing_template_instantiation/) |
 
 **Category:** Header-vs-binary parity | **Verdict:** BREAKING
 
@@ -37,6 +37,21 @@ In v2, the `template class descriptor<double>;` line is dropped from the
 This is the failure mode for oneDAL's "ship `float` instantiation only" build
 trim: the public combinatorics promised by `cpp/oneapi/dal/algo/*/common.hpp`
 must match the explicit instantiations in `*_instantiation.cpp`.
+
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case79_missing_template_instantiation_app case79_missing_template_instantiation_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case79_missing_template_instantiation/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case79_missing_template_instantiation/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: _ZN5mylib10descriptorIdE13set_thresholdEd
+```
 
 ## Why abicheck catches it
 
@@ -73,11 +88,11 @@ example.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case79_missing_template_instantiation/v2.h)
+- [`CMakeLists.txt`](../../examples/case79_missing_template_instantiation/CMakeLists.txt)
+- [`app.cpp`](../../examples/case79_missing_template_instantiation/app.cpp)
+- [`v1.cpp`](../../examples/case79_missing_template_instantiation/v1.cpp)
+- [`v1.h`](../../examples/case79_missing_template_instantiation/v1.h)
+- [`v2.cpp`](../../examples/case79_missing_template_instantiation/v2.cpp)
+- [`v2.h`](../../examples/case79_missing_template_instantiation/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case80_pimpl_shared_to_unique.md
+++ b/docs/examples/case80_pimpl_shared_to_unique.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse source](../../examples/case80_pimpl_shared_to_unique/) |
+| **Source files** | `examples/case80_pimpl_shared_to_unique/` |
 
 **Category:** Pimpl ABI | **Verdict:** BREAKING
 
@@ -90,11 +90,11 @@ the API" cleanup without realizing it is binary-incompatible.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case80_pimpl_shared_to_unique/CMakeLists.txt)
-- [`app.cpp`](../../examples/case80_pimpl_shared_to_unique/app.cpp)
-- [`v1.cpp`](../../examples/case80_pimpl_shared_to_unique/v1.cpp)
-- [`v1.h`](../../examples/case80_pimpl_shared_to_unique/v1.h)
-- [`v2.cpp`](../../examples/case80_pimpl_shared_to_unique/v2.cpp)
-- [`v2.h`](../../examples/case80_pimpl_shared_to_unique/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case80_pimpl_shared_to_unique.md
+++ b/docs/examples/case80_pimpl_shared_to_unique.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `internal_type_leaks_via_public_api` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/) |
+| **Source files** | [browse source](../../examples/case80_pimpl_shared_to_unique/) |
 
 **Category:** Pimpl ABI | **Verdict:** BREAKING
 
@@ -42,6 +42,23 @@ so the containing class even shrinks — the failure isn't "size grew", it is:
    move-only. Consumer code that copied a `descriptor` compiles under v1,
    refuses under v2.
 
+## Real Failure Demo
+
+**Severity: BREAKING / ABI SHAPE CHANGE**
+
+This smoke app still works because it does not copy or share ownership. The real break is that the public object field changes from shared ownership ABI to unique ownership ABI, changing size, copyability, and inline member code expectations.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case80_pimpl_shared_to_unique_app case80_pimpl_shared_to_unique_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case80_pimpl_shared_to_unique/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case80_pimpl_shared_to_unique/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# class_count = 7 (expect 7)
+```
+
 ## Why abicheck catches it
 
 The existing `type_field_type_changed` detector fires on `descriptor::impl_`
@@ -73,11 +90,11 @@ the API" cleanup without realizing it is binary-incompatible.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case80_pimpl_shared_to_unique/v2.h)
+- [`CMakeLists.txt`](../../examples/case80_pimpl_shared_to_unique/CMakeLists.txt)
+- [`app.cpp`](../../examples/case80_pimpl_shared_to_unique/app.cpp)
+- [`v1.cpp`](../../examples/case80_pimpl_shared_to_unique/v1.cpp)
+- [`v1.h`](../../examples/case80_pimpl_shared_to_unique/v1.h)
+- [`v2.cpp`](../../examples/case80_pimpl_shared_to_unique/v2.cpp)
+- [`v2.h`](../../examples/case80_pimpl_shared_to_unique/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case81_serialization_tag_reassigned.md
+++ b/docs/examples/case81_serialization_tag_reassigned.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `serialization_tag_changed` |
-| **Source files** | [browse source](../../examples/case81_serialization_tag_reassigned/) |
+| **Source files** | `examples/case81_serialization_tag_reassigned/` |
 
 **Category:** Payload ABI | **Verdict:** BREAKING
 
@@ -89,11 +89,11 @@ file format — changing them is on par with changing a wire protocol field.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case81_serialization_tag_reassigned/CMakeLists.txt)
-- [`app.cpp`](../../examples/case81_serialization_tag_reassigned/app.cpp)
-- [`v1.cpp`](../../examples/case81_serialization_tag_reassigned/v1.cpp)
-- [`v1.h`](../../examples/case81_serialization_tag_reassigned/v1.h)
-- [`v2.cpp`](../../examples/case81_serialization_tag_reassigned/v2.cpp)
-- [`v2.h`](../../examples/case81_serialization_tag_reassigned/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case81_serialization_tag_reassigned.md
+++ b/docs/examples/case81_serialization_tag_reassigned.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `serialization_tag_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/) |
+| **Source files** | [browse source](../../examples/case81_serialization_tag_reassigned/) |
 
 **Category:** Payload ABI | **Verdict:** BREAKING
 
@@ -30,6 +30,23 @@ existing saved model becomes silently corrupt:
 
 There is **no symbol change**, **no layout change**, **no link error**, **no
 load error**. Every conventional ABI checker reports COMPATIBLE.
+
+## Real Failure Demo
+
+**Severity: BREAKING / PERSISTENCE FORMAT DRIFT**
+
+Old serialized model tags now deserialize as a different model family.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case81_serialization_tag_reassigned_app case81_serialization_tag_reassigned_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case81_serialization_tag_reassigned/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case81_serialization_tag_reassigned/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# knn_model_tag = 0x1003; linear_regression = 0x1002
+```
 
 ## Why this is its own ChangeKind
 
@@ -72,11 +89,11 @@ file format — changing them is on par with changing a wire protocol field.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case81_serialization_tag_reassigned/v2.h)
+- [`CMakeLists.txt`](../../examples/case81_serialization_tag_reassigned/CMakeLists.txt)
+- [`app.cpp`](../../examples/case81_serialization_tag_reassigned/app.cpp)
+- [`v1.cpp`](../../examples/case81_serialization_tag_reassigned/v1.cpp)
+- [`v1.h`](../../examples/case81_serialization_tag_reassigned/v1.h)
+- [`v2.cpp`](../../examples/case81_serialization_tag_reassigned/v2.cpp)
+- [`v2.h`](../../examples/case81_serialization_tag_reassigned/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case82_sycl_overload_set_removed.md
+++ b/docs/examples/case82_sycl_overload_set_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `sycl_overload_set_removed` |
-| **Source files** | [browse source](../../examples/case82_sycl_overload_set_removed/) |
+| **Source files** | `examples/case82_sycl_overload_set_removed/` |
 
 **Category:** Overload-family ABI | **Verdict:** BREAKING
 
@@ -75,11 +75,11 @@ one go.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case82_sycl_overload_set_removed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case82_sycl_overload_set_removed/app.cpp)
-- [`v1.cpp`](../../examples/case82_sycl_overload_set_removed/v1.cpp)
-- [`v1.h`](../../examples/case82_sycl_overload_set_removed/v1.h)
-- [`v2.cpp`](../../examples/case82_sycl_overload_set_removed/v2.cpp)
-- [`v2.h`](../../examples/case82_sycl_overload_set_removed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case82_sycl_overload_set_removed.md
+++ b/docs/examples/case82_sycl_overload_set_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `sycl_overload_set_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/) |
+| **Source files** | [browse source](../../examples/case82_sycl_overload_set_removed/) |
 
 **Category:** Overload-family ABI | **Verdict:** BREAKING
 
@@ -30,6 +30,21 @@ Mechanically this is N×`func_removed`. Reporting it that way buries the
 signal under a wall of independent removals, making the suppression UX a
 mess (one rule per algorithm) and obscuring the deployment-level question
 ("did the SYCL surface go away?").
+
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case82_sycl_overload_set_removed_app case82_sycl_overload_set_removed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case82_sycl_overload_set_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case82_sycl_overload_set_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: _ZN5mylib7computeERN4sycl5queueERKNS_10descriptorERKNS_5tableE
+```
 
 ## Why this is its own ChangeKind
 
@@ -60,11 +75,11 @@ one go.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case82_sycl_overload_set_removed/v2.h)
+- [`CMakeLists.txt`](../../examples/case82_sycl_overload_set_removed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case82_sycl_overload_set_removed/app.cpp)
+- [`v1.cpp`](../../examples/case82_sycl_overload_set_removed/v1.cpp)
+- [`v1.h`](../../examples/case82_sycl_overload_set_removed/v1.h)
+- [`v2.cpp`](../../examples/case82_sycl_overload_set_removed/v2.cpp)
+- [`v2.h`](../../examples/case82_sycl_overload_set_removed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case83_cpu_dispatch_isa_dropped.md
+++ b/docs/examples/case83_cpu_dispatch_isa_dropped.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `cpu_dispatch_isa_dropped` |
-| **Source files** | [browse source](../../examples/case83_cpu_dispatch_isa_dropped/) |
+| **Source files** | `examples/case83_cpu_dispatch_isa_dropped/` |
 
 **Category:** Dispatch ABI | **Verdict:** COMPATIBLE_WITH_RISK
 
@@ -81,11 +81,11 @@ dispatch tables. ISA-specialized symbols have suffixes like
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case83_cpu_dispatch_isa_dropped/CMakeLists.txt)
-- [`app.cpp`](../../examples/case83_cpu_dispatch_isa_dropped/app.cpp)
-- [`v1.cpp`](../../examples/case83_cpu_dispatch_isa_dropped/v1.cpp)
-- [`v1.h`](../../examples/case83_cpu_dispatch_isa_dropped/v1.h)
-- [`v2.cpp`](../../examples/case83_cpu_dispatch_isa_dropped/v2.cpp)
-- [`v2.h`](../../examples/case83_cpu_dispatch_isa_dropped/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE_WITH_RISK cases](by-verdict/compatible-risk.md) · [Category: Risk](by-category/risk.md)._

--- a/docs/examples/case83_cpu_dispatch_isa_dropped.md
+++ b/docs/examples/case83_cpu_dispatch_isa_dropped.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | — |
 | **Detected `ChangeKind`s** | `cpu_dispatch_isa_dropped` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/) |
+| **Source files** | [browse source](../../examples/case83_cpu_dispatch_isa_dropped/) |
 
 **Category:** Dispatch ABI | **Verdict:** COMPATIBLE_WITH_RISK
 
@@ -32,6 +32,21 @@ unaffected. Consumers who linked directly against `kmeans_compute_avx512`
 (common in test scaffolding, micro-benchmarks, or external integrations
 that bypass the dispatcher for reproducibility) get unresolved symbols at
 load time.
+
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case83_cpu_dispatch_isa_dropped_app case83_cpu_dispatch_isa_dropped_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case83_cpu_dispatch_isa_dropped/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case83_cpu_dispatch_isa_dropped/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: _ZN5mylib21kmeans_compute_avx512Ei
+```
 
 ## Why a separate ChangeKind (not just N×func_removed)
 
@@ -66,11 +81,11 @@ dispatch tables. ISA-specialized symbols have suffixes like
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case83_cpu_dispatch_isa_dropped/v2.h)
+- [`CMakeLists.txt`](../../examples/case83_cpu_dispatch_isa_dropped/CMakeLists.txt)
+- [`app.cpp`](../../examples/case83_cpu_dispatch_isa_dropped/app.cpp)
+- [`v1.cpp`](../../examples/case83_cpu_dispatch_isa_dropped/v1.cpp)
+- [`v1.h`](../../examples/case83_cpu_dispatch_isa_dropped/v1.h)
+- [`v2.cpp`](../../examples/case83_cpu_dispatch_isa_dropped/v2.cpp)
+- [`v2.h`](../../examples/case83_cpu_dispatch_isa_dropped/v2.h)
 
 _See also: [Examples overview](index.md) · [All COMPATIBLE_WITH_RISK cases](by-verdict/compatible-risk.md) · [Category: Risk](by-category/risk.md)._

--- a/docs/examples/case84_bundle_soname_skew.md
+++ b/docs/examples/case84_bundle_soname_skew.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, Bad practice |
 | **Detected `ChangeKind`s** | `bundle_soname_skew` |
-| **Source files** | [browse source](../../examples/case84_bundle_soname_skew/) |
+| **Source files** | `examples/case84_bundle_soname_skew/` |
 
 **Category:** Cross-artifact ABI | **Verdict:** BREAKING
 
@@ -100,9 +100,9 @@ produces the `.so` files. The CMake integration wires this up under the
 
 ## Source files
 
-- [`gen_bundle.sh`](../../examples/case84_bundle_soname_skew/gen_bundle.sh)
-- [`onedal_core.c`](../../examples/case84_bundle_soname_skew/onedal_core.c)
-- [`onedal_dpc.c`](../../examples/case84_bundle_soname_skew/onedal_dpc.c)
-- [`onedal_thread.c`](../../examples/case84_bundle_soname_skew/onedal_thread.c)
+- `gen_bundle.sh`
+- `onedal_core.c`
+- `onedal_dpc.c`
+- `onedal_thread.c`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case84_bundle_soname_skew.md
+++ b/docs/examples/case84_bundle_soname_skew.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux |
 | **Flags** | ABI break, Bad practice |
 | **Detected `ChangeKind`s** | `bundle_soname_skew` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case84_bundle_soname_skew/) |
+| **Source files** | [browse source](../../examples/case84_bundle_soname_skew/) |
 
 **Category:** Cross-artifact ABI | **Verdict:** BREAKING
 
@@ -57,6 +57,25 @@ case84_bundle_soname_skew/
 The `compare-release` mode of abicheck ingests both directories and runs
 the cross-library aggregator.
 
+## Real Failure Demo
+
+**Severity: BREAKING / RELEASE BUNDLE SKEW**
+
+This fixture is a directory-level failure, not a single app swap. Rebuild the
+three shared libraries and run the cohort detector directly: two siblings bump
+to SONAME `.so.2`, while `libonedal_thread` stays on `.so.1`.
+
+```bash
+python3 - <<'PY'
+from abicheck.diff_onedal import bundle_members_from_directory, detect_bundle_soname_skew
+old = bundle_members_from_directory('examples/case84_bundle_soname_skew/v1')
+new = bundle_members_from_directory('examples/case84_bundle_soname_skew/v2')
+for finding in detect_bundle_soname_skew(old, new, cohort_prefix='libonedal_'):
+    print(finding.kind.value, finding.severity.value)
+PY
+# bundle_soname_skew BREAKING
+```
+
 ## Why this is its own ChangeKind
 
 Existing `soname_changed` and `soname_bump_recommended` are per-library
@@ -81,9 +100,9 @@ produces the `.so` files. The CMake integration wires this up under the
 
 ## Source files
 
-- [`gen_bundle.sh`](https://github.com/napetrov/abicheck/blob/main/examples/case84_bundle_soname_skew/gen_bundle.sh)
-- [`onedal_core.c`](https://github.com/napetrov/abicheck/blob/main/examples/case84_bundle_soname_skew/onedal_core.c)
-- [`onedal_dpc.c`](https://github.com/napetrov/abicheck/blob/main/examples/case84_bundle_soname_skew/onedal_dpc.c)
-- [`onedal_thread.c`](https://github.com/napetrov/abicheck/blob/main/examples/case84_bundle_soname_skew/onedal_thread.c)
+- [`gen_bundle.sh`](../../examples/case84_bundle_soname_skew/gen_bundle.sh)
+- [`onedal_core.c`](../../examples/case84_bundle_soname_skew/onedal_core.c)
+- [`onedal_dpc.c`](../../examples/case84_bundle_soname_skew/onedal_dpc.c)
+- [`onedal_thread.c`](../../examples/case84_bundle_soname_skew/onedal_thread.c)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case86_tag_struct_renamed.md
+++ b/docs/examples/case86_tag_struct_renamed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `tag_type_renamed` |
-| **Source files** | [browse source](../../examples/case86_tag_struct_renamed/) |
+| **Source files** | `examples/case86_tag_struct_renamed/` |
 
 **Category:** Mangling ABI | **Verdict:** BREAKING
 
@@ -96,11 +96,11 @@ shipped instantiation symbol.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case86_tag_struct_renamed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case86_tag_struct_renamed/app.cpp)
-- [`v1.cpp`](../../examples/case86_tag_struct_renamed/v1.cpp)
-- [`v1.h`](../../examples/case86_tag_struct_renamed/v1.h)
-- [`v2.cpp`](../../examples/case86_tag_struct_renamed/v2.cpp)
-- [`v2.h`](../../examples/case86_tag_struct_renamed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case86_tag_struct_renamed.md
+++ b/docs/examples/case86_tag_struct_renamed.md
@@ -46,11 +46,11 @@ v2 renames `brute_force` → `search_brute`. Mechanically:
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case85_tag_struct_renamed_app case85_tag_struct_renamed_v2
+cmake --build /tmp/abicheck-examples-build --target case86_tag_struct_renamed_app case86_tag_struct_renamed_v2
 
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case86_tag_struct_renamed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case86_tag_struct_renamed/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # ./app_v1: symbol lookup error: undefined symbol: descriptor<brute_force, classification>::descriptor()
 ```

--- a/docs/examples/case86_tag_struct_renamed.md
+++ b/docs/examples/case86_tag_struct_renamed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `tag_type_renamed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/) |
+| **Source files** | [browse source](../../examples/case86_tag_struct_renamed/) |
 
 **Category:** Mangling ABI | **Verdict:** BREAKING
 
@@ -39,6 +39,21 @@ v2 renames `brute_force` → `search_brute`. Mechanically:
 - Every explicit instantiation referencing the old tag gets a brand-new
   mangled name. Consumer binaries linked against v1 request the old
   symbol at load time and get an unresolved-symbol error.
+
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case85_tag_struct_renamed_app case85_tag_struct_renamed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: descriptor<brute_force, classification>::descriptor()
+```
 
 ## Why this is its own ChangeKind
 
@@ -81,11 +96,11 @@ shipped instantiation symbol.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case86_tag_struct_renamed/v2.h)
+- [`CMakeLists.txt`](../../examples/case86_tag_struct_renamed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case86_tag_struct_renamed/app.cpp)
+- [`v1.cpp`](../../examples/case86_tag_struct_renamed/v1.cpp)
+- [`v1.h`](../../examples/case86_tag_struct_renamed/v1.h)
+- [`v2.cpp`](../../examples/case86_tag_struct_renamed/v2.cpp)
+- [`v2.h`](../../examples/case86_tag_struct_renamed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case87_default_template_arg_changed.md
+++ b/docs/examples/case87_default_template_arg_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `default_template_arg_changed` |
-| **Source files** | [browse source](../../examples/case87_default_template_arg_changed/) |
+| **Source files** | `examples/case87_default_template_arg_changed/` |
 
 **Category:** Template ABI | **Verdict:** BREAKING
 
@@ -91,11 +91,11 @@ every explicit instantiation that didn't override that argument.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case87_default_template_arg_changed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case87_default_template_arg_changed/app.cpp)
-- [`v1.cpp`](../../examples/case87_default_template_arg_changed/v1.cpp)
-- [`v1.h`](../../examples/case87_default_template_arg_changed/v1.h)
-- [`v2.cpp`](../../examples/case87_default_template_arg_changed/v2.cpp)
-- [`v2.h`](../../examples/case87_default_template_arg_changed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case87_default_template_arg_changed.md
+++ b/docs/examples/case87_default_template_arg_changed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `default_template_arg_changed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/) |
+| **Source files** | [browse source](../../examples/case87_default_template_arg_changed/) |
 
 **Category:** Template ABI | **Verdict:** BREAKING
 
@@ -37,6 +37,21 @@ A consumer compiled against v1 emits calls to the first mangled name.
 A consumer compiled against v2 emits calls to the second. The shipped
 library can only contain one — whichever version was built. Cross-version
 linking yields unresolved symbols.
+
+## Real Failure Demo
+
+**Severity: API BREAK / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case86_default_template_arg_changed_app case86_default_template_arg_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case86_default_template_arg_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case86_default_template_arg_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: descriptor<float, minkowski_distance<float>>::dimension()
+```
 
 ## Why distinct from case32
 
@@ -76,11 +91,11 @@ every explicit instantiation that didn't override that argument.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case87_default_template_arg_changed/v2.h)
+- [`CMakeLists.txt`](../../examples/case87_default_template_arg_changed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case87_default_template_arg_changed/app.cpp)
+- [`v1.cpp`](../../examples/case87_default_template_arg_changed/v1.cpp)
+- [`v1.h`](../../examples/case87_default_template_arg_changed/v1.h)
+- [`v2.cpp`](../../examples/case87_default_template_arg_changed/v2.cpp)
+- [`v2.h`](../../examples/case87_default_template_arg_changed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case89_inline_accessor_renamed_pimpl_member.md
+++ b/docs/examples/case89_inline_accessor_renamed_pimpl_member.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_body_references_renamed_member` |
-| **Source files** | [browse source](../../examples/case89_inline_accessor_renamed_pimpl_member/) |
+| **Source files** | `examples/case89_inline_accessor_renamed_pimpl_member/` |
 
 **Category:** Pimpl ABI | **Verdict:** BREAKING
 
@@ -95,11 +95,11 @@ consumer binary already compiled against the previous header.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case89_inline_accessor_renamed_pimpl_member/CMakeLists.txt)
-- [`app.cpp`](../../examples/case89_inline_accessor_renamed_pimpl_member/app.cpp)
-- [`v1.cpp`](../../examples/case89_inline_accessor_renamed_pimpl_member/v1.cpp)
-- [`v1.h`](../../examples/case89_inline_accessor_renamed_pimpl_member/v1.h)
-- [`v2.cpp`](../../examples/case89_inline_accessor_renamed_pimpl_member/v2.cpp)
-- [`v2.h`](../../examples/case89_inline_accessor_renamed_pimpl_member/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case89_inline_accessor_renamed_pimpl_member.md
+++ b/docs/examples/case89_inline_accessor_renamed_pimpl_member.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_body_references_renamed_member` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/) |
+| **Source files** | [browse source](../../examples/case89_inline_accessor_renamed_pimpl_member/) |
 
 **Category:** Pimpl ABI | **Verdict:** BREAKING
 
@@ -42,6 +42,23 @@ is inline and has no exported symbol. There is no public-type layout change:
 `descriptor` still holds one pimpl pointer. The break lives entirely in the
 gap between *what the consumer's inline body assumes* and *what the new
 detail layout actually is*.
+
+## Real Failure Demo
+
+**Severity: BREAKING / LATENT INLINE ABI DRIFT**
+
+The tiny app happens to read the same value, but its inline accessor is compiled against the old `impl_->class_count_` member. A real v2 layout that reuses that slot for another field turns the inline read into stale or wrong data.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case87_inline_accessor_renamed_pimpl_member_app case87_inline_accessor_renamed_pimpl_member_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case87_inline_accessor_renamed_pimpl_member/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case87_inline_accessor_renamed_pimpl_member/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# class_count = 2
+```
 
 ## Why distinct from case35 + case47
 
@@ -78,11 +95,11 @@ consumer binary already compiled against the previous header.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case89_inline_accessor_renamed_pimpl_member/v2.h)
+- [`CMakeLists.txt`](../../examples/case89_inline_accessor_renamed_pimpl_member/CMakeLists.txt)
+- [`app.cpp`](../../examples/case89_inline_accessor_renamed_pimpl_member/app.cpp)
+- [`v1.cpp`](../../examples/case89_inline_accessor_renamed_pimpl_member/v1.cpp)
+- [`v1.h`](../../examples/case89_inline_accessor_renamed_pimpl_member/v1.h)
+- [`v2.cpp`](../../examples/case89_inline_accessor_renamed_pimpl_member/v2.cpp)
+- [`v2.h`](../../examples/case89_inline_accessor_renamed_pimpl_member/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case94_empty_tag_gained_state.md
+++ b/docs/examples/case94_empty_tag_gained_state.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_size_changed`, `type_field_added` |
-| **Source files** | [browse source](../../examples/case94_empty_tag_gained_state/) |
+| **Source files** | `examples/case94_empty_tag_gained_state/` |
 
 **Category:** Type Layout | **Verdict:** 🔴 BREAKING
 
@@ -83,11 +83,11 @@ specifically to avoid the silent-corruption pattern this case demonstrates.
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case94_empty_tag_gained_state/CMakeLists.txt)
-- [`app.cpp`](../../examples/case94_empty_tag_gained_state/app.cpp)
-- [`v1.cpp`](../../examples/case94_empty_tag_gained_state/v1.cpp)
-- [`v1.h`](../../examples/case94_empty_tag_gained_state/v1.h)
-- [`v2.cpp`](../../examples/case94_empty_tag_gained_state/v2.cpp)
-- [`v2.h`](../../examples/case94_empty_tag_gained_state/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case94_empty_tag_gained_state.md
+++ b/docs/examples/case94_empty_tag_gained_state.md
@@ -28,11 +28,11 @@ The smoke app does not crash, but the public by-value tag changed from empty to 
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case92_empty_tag_gained_state_app case92_empty_tag_gained_state_v2
+cmake --build /tmp/abicheck-examples-build --target case94_empty_tag_gained_state_app case94_empty_tag_gained_state_v2
 
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case94_empty_tag_gained_state/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case94_empty_tag_gained_state/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # run(7) = 14 (expect 14)
 ```

--- a/docs/examples/case94_empty_tag_gained_state.md
+++ b/docs/examples/case94_empty_tag_gained_state.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `type_size_changed`, `type_field_added` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/) |
+| **Source files** | [browse source](../../examples/case94_empty_tag_gained_state/) |
 
 **Category:** Type Layout | **Verdict:** 🔴 BREAKING
 
@@ -19,6 +19,23 @@ Any consumer compiled against v1 that passes the tag by value — into a header-
 template, an algorithm overload selector, or any function taking it by value — wrote a
 1-byte argument into what is now an 8-byte parameter slot. The callee reads partially
 uninitialized memory, then steps on subsequent stack/register state.
+
+## Real Failure Demo
+
+**Severity: BREAKING / LATENT CALL ABI DRIFT**
+
+The smoke app does not crash, but the public by-value tag changed from empty to stateful. Header-inlined algorithms compiled against v1 pass the old object shape into a v2 function expecting the wider tag.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case92_empty_tag_gained_state_app case92_empty_tag_gained_state_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# run(7) = 14 (expect 14)
+```
 
 ## Why this is a oneTBB-flavored break
 
@@ -66,11 +83,11 @@ specifically to avoid the silent-corruption pattern this case demonstrates.
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case94_empty_tag_gained_state/v2.h)
+- [`CMakeLists.txt`](../../examples/case94_empty_tag_gained_state/CMakeLists.txt)
+- [`app.cpp`](../../examples/case94_empty_tag_gained_state/app.cpp)
+- [`v1.cpp`](../../examples/case94_empty_tag_gained_state/v1.cpp)
+- [`v1.h`](../../examples/case94_empty_tag_gained_state/v1.h)
+- [`v2.cpp`](../../examples/case94_empty_tag_gained_state/v2.cpp)
+- [`v2.h`](../../examples/case94_empty_tag_gained_state/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case95_allocator_nested_typedef_removed.md
+++ b/docs/examples/case95_allocator_nested_typedef_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `typedef_removed` |
-| **Source files** | [browse source](../../examples/case95_allocator_nested_typedef_removed/) |
+| **Source files** | `examples/case95_allocator_nested_typedef_removed/` |
 
 **Category:** Source API contract | **Verdict:** 🔴 BREAKING
 
@@ -93,11 +93,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case95_allocator_nested_typedef_removed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case95_allocator_nested_typedef_removed/app.cpp)
-- [`v1.cpp`](../../examples/case95_allocator_nested_typedef_removed/v1.cpp)
-- [`v1.h`](../../examples/case95_allocator_nested_typedef_removed/v1.h)
-- [`v2.cpp`](../../examples/case95_allocator_nested_typedef_removed/v2.cpp)
-- [`v2.h`](../../examples/case95_allocator_nested_typedef_removed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case95_allocator_nested_typedef_removed.md
+++ b/docs/examples/case95_allocator_nested_typedef_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `typedef_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/) |
+| **Source files** | [browse source](../../examples/case95_allocator_nested_typedef_removed/) |
 
 **Category:** Source API contract | **Verdict:** 🔴 BREAKING
 
@@ -93,11 +93,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case95_allocator_nested_typedef_removed/v2.h)
+- [`CMakeLists.txt`](../../examples/case95_allocator_nested_typedef_removed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case95_allocator_nested_typedef_removed/app.cpp)
+- [`v1.cpp`](../../examples/case95_allocator_nested_typedef_removed/v1.cpp)
+- [`v1.h`](../../examples/case95_allocator_nested_typedef_removed/v1.h)
+- [`v2.cpp`](../../examples/case95_allocator_nested_typedef_removed/v2.cpp)
+- [`v2.h`](../../examples/case95_allocator_nested_typedef_removed/v2.h)
 
 _See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/case96_hidden_friend_removed.md
+++ b/docs/examples/case96_hidden_friend_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `hidden_friend_removed` |
-| **Source files** | [browse source](../../examples/case96_hidden_friend_removed/) |
+| **Source files** | `examples/case96_hidden_friend_removed/` |
 
 **Category:** Source API contract | **Verdict:** 🟠 API_BREAK
 
@@ -106,11 +106,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](../../examples/case96_hidden_friend_removed/CMakeLists.txt)
-- [`app.cpp`](../../examples/case96_hidden_friend_removed/app.cpp)
-- [`v1.cpp`](../../examples/case96_hidden_friend_removed/v1.cpp)
-- [`v1.h`](../../examples/case96_hidden_friend_removed/v1.h)
-- [`v2.cpp`](../../examples/case96_hidden_friend_removed/v2.cpp)
-- [`v2.h`](../../examples/case96_hidden_friend_removed/v2.h)
+- `CMakeLists.txt`
+- `app.cpp`
+- `v1.cpp`
+- `v1.h`
+- `v2.cpp`
+- `v2.h`
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/case96_hidden_friend_removed.md
+++ b/docs/examples/case96_hidden_friend_removed.md
@@ -8,7 +8,7 @@
 | **Platforms** | Linux, macOS, Windows |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `hidden_friend_removed` |
-| **Source files** | [browse on GitHub](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/) |
+| **Source files** | [browse source](../../examples/case96_hidden_friend_removed/) |
 
 **Category:** Source API contract | **Verdict:** 🟠 API_BREAK
 
@@ -106,11 +106,11 @@ g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
 
 ## Source files
 
-- [`CMakeLists.txt`](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/CMakeLists.txt)
-- [`app.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/app.cpp)
-- [`v1.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/v1.cpp)
-- [`v1.h`](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/v1.h)
-- [`v2.cpp`](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/v2.cpp)
-- [`v2.h`](https://github.com/napetrov/abicheck/blob/main/examples/case96_hidden_friend_removed/v2.h)
+- [`CMakeLists.txt`](../../examples/case96_hidden_friend_removed/CMakeLists.txt)
+- [`app.cpp`](../../examples/case96_hidden_friend_removed/app.cpp)
+- [`v1.cpp`](../../examples/case96_hidden_friend_removed/v1.cpp)
+- [`v1.h`](../../examples/case96_hidden_friend_removed/v1.h)
+- [`v2.cpp`](../../examples/case96_hidden_friend_removed/v2.cpp)
+- [`v2.h`](../../examples/case96_hidden_friend_removed/v2.h)
 
 _See also: [Examples overview](index.md) · [All API_BREAK cases](by-verdict/api-break.md) · [Category: API Break](by-category/api_break.md)._

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -33,7 +33,7 @@ Each case page starts with a metadata table (verdict, category, platforms, detec
 - **Real-world example** — historical occurrences in widely-used libraries.
 - **References** — links to relevant standards, manuals, and abicheck source.
 
-Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are linked at the bottom of every page.
+Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the bottom of every page.
 
 ## Browse by category
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -10,7 +10,7 @@ Use this catalog to:
 - Look up the **mitigation pattern** for a specific change.
 - Cross-reference detected [`ChangeKind`s](../reference/change-kinds.md) with concrete reproductions.
 
-> **Ground truth.** Expected verdicts and detected change kinds live in [`examples/ground_truth.json`](../../examples/ground_truth.json) and are the single source of truth — these pages are generated from that file plus per-case `README.md` files under [`examples/`](../../examples/).
+> **Ground truth.** Expected verdicts and detected change kinds live in `examples/ground_truth.json` and are the single source of truth — these pages are generated from that file plus per-case `README.md` files under `examples/`.
 
 ## Verdict distribution
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -10,7 +10,7 @@ Use this catalog to:
 - Look up the **mitigation pattern** for a specific change.
 - Cross-reference detected [`ChangeKind`s](../reference/change-kinds.md) with concrete reproductions.
 
-> **Ground truth.** Expected verdicts and detected change kinds live in [`examples/ground_truth.json`](https://github.com/napetrov/abicheck/blob/main/examples/ground_truth.json) and are the single source of truth — these pages are generated from that file plus per-case `README.md` files under [`examples/`](https://github.com/napetrov/abicheck/blob/main/examples/).
+> **Ground truth.** Expected verdicts and detected change kinds live in [`examples/ground_truth.json`](../../examples/ground_truth.json) and are the single source of truth — these pages are generated from that file plus per-case `README.md` files under [`examples/`](../../examples/).
 
 ## Verdict distribution
 

--- a/docs/user-guide/multi-binary.md
+++ b/docs/user-guide/multi-binary.md
@@ -361,7 +361,7 @@ for f in result.bundle_findings:
 - [ADR-023](../development/adr/023-bundle-aware-multi-binary-analysis.md) — design rationale
 - [ADR-008](../development/adr/008-full-stack-dependency-validation.md) — the resolver/binder engine the bundle layer reuses
 - Example cases:
-  [case90 — intra-bundle removed symbol](../examples/case90_bundle_intra_dep_removed.md),
-  [case91 — extern-C signature drift](../examples/case91_bundle_intra_signature_drift.md),
-  [case92 — provider migration](../examples/case92_bundle_provider_changed.md),
-  [case93 — manifest drift](../examples/case93_bundle_manifest_drift.md)
+  `case90_bundle_intra_dep_removed` — intra-bundle removed symbol,
+  `case91_bundle_intra_signature_drift` — extern-C signature drift,
+  `case92_bundle_provider_changed` — provider migration,
+  `case93_bundle_manifest_drift` — manifest drift

--- a/docs/user-guide/multi-binary.md
+++ b/docs/user-guide/multi-binary.md
@@ -361,7 +361,7 @@ for f in result.bundle_findings:
 - [ADR-023](../development/adr/023-bundle-aware-multi-binary-analysis.md) — design rationale
 - [ADR-008](../development/adr/008-full-stack-dependency-validation.md) — the resolver/binder engine the bundle layer reuses
 - Example cases:
-  [case90 — intra-bundle removed symbol](https://github.com/napetrov/abicheck/tree/main/examples/case90_bundle_intra_dep_removed),
-  [case91 — extern-C signature drift](https://github.com/napetrov/abicheck/tree/main/examples/case91_bundle_intra_signature_drift),
-  [case92 — provider migration](https://github.com/napetrov/abicheck/tree/main/examples/case92_bundle_provider_changed),
-  [case93 — manifest drift](https://github.com/napetrov/abicheck/tree/main/examples/case93_bundle_manifest_drift)
+  [case90 — intra-bundle removed symbol](../examples/case90_bundle_intra_dep_removed.md),
+  [case91 — extern-C signature drift](../examples/case91_bundle_intra_signature_drift.md),
+  [case92 — provider migration](../examples/case92_bundle_provider_changed.md),
+  [case93 — manifest drift](../examples/case93_bundle_manifest_drift.md)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 #      [APP_SOURCES app.c]
 #      [APP_INCLUDE_DIRS dir]
 #      [APP_LINK_LIBRARIES lib]
+#      [APP_COMPILE_OPTIONS ..]
 #      [PLATFORMS linux macos windows]
 #   )
 # ---------------------------------------------------------------------------
@@ -54,7 +55,7 @@ function(abicheck_add_case CASE_NAME)
   cmake_parse_arguments(PARSE_ARGV 1 ARG
     ""
     "LANG"
-    "V1_SOURCES;V2_SOURCES;V1_HEADERS;V2_HEADERS;V1_INCLUDE_DIRS;V2_INCLUDE_DIRS;V1_FORCE_INCLUDE;V2_FORCE_INCLUDE;V1_COMPILE_OPTIONS;V2_COMPILE_OPTIONS;V1_LINK_OPTIONS;V2_LINK_OPTIONS;APP_SOURCES;APP_INCLUDE_DIRS;APP_LINK_LIBRARIES;PLATFORMS"
+    "V1_SOURCES;V2_SOURCES;V1_HEADERS;V2_HEADERS;V1_INCLUDE_DIRS;V2_INCLUDE_DIRS;V1_FORCE_INCLUDE;V2_FORCE_INCLUDE;V1_COMPILE_OPTIONS;V2_COMPILE_OPTIONS;V1_LINK_OPTIONS;V2_LINK_OPTIONS;APP_SOURCES;APP_INCLUDE_DIRS;APP_LINK_LIBRARIES;APP_COMPILE_OPTIONS;PLATFORMS"
   )
 
   # --- Platform filter ---
@@ -198,6 +199,9 @@ function(abicheck_add_case CASE_NAME)
     endif()
     if(ARG_APP_LINK_LIBRARIES)
       target_link_libraries(${_app} PRIVATE ${ARG_APP_LINK_LIBRARIES})
+    endif()
+    if(ARG_APP_COMPILE_OPTIONS)
+      target_compile_options(${_app} PRIVATE ${ARG_APP_COMPILE_OPTIONS})
     endif()
     if(APPLE)
       set_target_properties(${_app} PROPERTIES

--- a/examples/case06_visibility/README.md
+++ b/examples/case06_visibility/README.md
@@ -120,4 +120,3 @@ echo "exit: $?"  # → 1
 ```
 
 **Why CRITICAL:** The consumer relies on the accidentally-exported `internal_helper` symbol. v2 hides it, so any binary that resolved the symbol at load time will now fail to link/symbolize and abort before it can handle the crash. This app shows the missing symbol and exits with failure to make the issue obvious.
-

--- a/examples/case06_visibility/README.md
+++ b/examples/case06_visibility/README.md
@@ -120,3 +120,4 @@ echo "exit: $?"  # → 1
 ```
 
 **Why CRITICAL:** The consumer relies on the accidentally-exported `internal_helper` symbol. v2 hides it, so any binary that resolved the symbol at load time will now fail to link/symbolize and abort before it can handle the crash. This app shows the missing symbol and exits with failure to make the issue obvious.
+

--- a/examples/case105_concept_tightening/CMakeLists.txt
+++ b/examples/case105_concept_tightening/CMakeLists.txt
@@ -9,5 +9,6 @@ abicheck_add_case(case105_concept_tightening
     # /std:c++20, gcc/clang use -std=c++20.
     V1_COMPILE_OPTIONS "$<IF:$<CXX_COMPILER_ID:MSVC>,/std:c++20,-std=c++20>"
     V2_COMPILE_OPTIONS "$<IF:$<CXX_COMPILER_ID:MSVC>,/std:c++20,-std=c++20>"
+    APP_COMPILE_OPTIONS "$<IF:$<CXX_COMPILER_ID:MSVC>,/std:c++20,-std=c++20>"
     PLATFORMS linux macos
 )

--- a/examples/case105_concept_tightening/app.cpp
+++ b/examples/case105_concept_tightening/app.cpp
@@ -25,9 +25,6 @@ struct wrapped {
 // (`std::same_as` is in <concepts>, but the same_as constraint is
 // satisfied by the operator's return type.)
 
-template <mylib::Addable T>
-T cs_check_addable_only();  // declaration only — proves the concept is satisfiable.
-
 int main() {
     // *** Source-break demonstration ***
     // Under v1.h, `wrapped` satisfies `Addable` and the next line
@@ -35,10 +32,9 @@ int main() {
     // and `wrapped` is not default-constructible, so the same line
     // fails to compile:
     //
-    //   error: template constraint failure for ‘template<Addable T>’
+    //   error: static assertion failed
     //   note: the expression ‘T()’ would be ill-formed
-    auto check = &cs_check_addable_only<wrapped>;
-    (void)check;
+    static_assert(mylib::Addable<wrapped>);
 
     // Runtime: call the int instantiation that the library exports.
     int r = mylib::sum(2, 3);

--- a/examples/case106_ctor_became_explicit/README.md
+++ b/examples/case106_ctor_became_explicit/README.md
@@ -53,23 +53,23 @@ older baseline snapshots that predate the field.
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
 cmake --build /tmp/abicheck-examples-build \
-  --target case93_ctor_became_explicit_app case93_ctor_became_explicit_v2
+  --target case106_ctor_became_explicit_app case106_ctor_became_explicit_v2
 
-/tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1
+/tmp/abicheck-examples-build/case106_ctor_became_explicit/app_v1
 # concurrency = 4 (expect 4)
 
 # Runtime substitution is still OK: the mangled conversion-operator symbol
 # did not change.
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case106_ctor_became_explicit/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case106_ctor_became_explicit/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # concurrency = 4 (expect 4)
 
 # Source rebuild against the v2 header fails because app.cpp does `int n = ta;`.
 tmp=$(mktemp -d)
-cp examples/case93_ctor_became_explicit/app.cpp "$tmp/app.cpp"
-cp examples/case93_ctor_became_explicit/v2.h "$tmp/v1.h"
+cp examples/case106_ctor_became_explicit/app.cpp "$tmp/app.cpp"
+cp examples/case106_ctor_became_explicit/v2.h "$tmp/v1.h"
 g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
 # error: cannot convert 'mylib::task_arena' to 'int' in initialization
 ```

--- a/examples/case106_ctor_became_explicit/README.md
+++ b/examples/case106_ctor_became_explicit/README.md
@@ -51,17 +51,27 @@ older baseline snapshots that predate the field.
 **Severity: BAD PRACTICE / API BREAK**
 
 ```bash
-# v1 header, v1 .so: compiles and runs.
-# Note linker order: object/source inputs must precede -l flags on modern
-# Linux toolchains (-Wl,--as-needed is the default).
-g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
-./app   # → concurrency = 4 (expect 4)
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build \
+  --target case93_ctor_became_explicit_app case93_ctor_became_explicit_v2
 
-# v2 header, v2 .so: app.cpp does `int n = ta;`, an implicit conversion
-# via `operator int() const`. v2 declares the operator `explicit`, so the
-# same app.cpp source no longer compiles:
-g++ -std=c++17 -I. app.cpp -L. -lmylib -o app
-# → error: cannot convert 'mylib::task_arena' to 'int' in initialization
+/tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1
+# concurrency = 4 (expect 4)
+
+# Runtime substitution is still OK: the mangled conversion-operator symbol
+# did not change.
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case93_ctor_became_explicit/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# concurrency = 4 (expect 4)
+
+# Source rebuild against the v2 header fails because app.cpp does `int n = ta;`.
+tmp=$(mktemp -d)
+cp examples/case93_ctor_became_explicit/app.cpp "$tmp/app.cpp"
+cp examples/case93_ctor_became_explicit/v2.h "$tmp/v1.h"
+g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: cannot convert 'mylib::task_arena' to 'int' in initialization
 ```
 
 ## How to fix

--- a/examples/case107_task_scheduler_init_removed/README.md
+++ b/examples/case107_task_scheduler_init_removed/README.md
@@ -9,6 +9,35 @@ Every consumer that referenced the class (constructed it, called its members,
 or held it by value) gets `undefined symbol` at load time, and source code
 fails to compile against the new headers.
 
+## Real Failure Demo
+
+**Severity: BREAKING**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build \
+  --target case94_task_scheduler_init_removed_app case94_task_scheduler_init_removed_v2
+
+/tmp/abicheck-examples-build/case94_task_scheduler_init_removed/app_v1
+# active = 1 (expect 1)
+# active = 0 (expect 0)
+
+# Runtime replacement: a binary linked against v1 fails when v2 is substituted
+# under the old library name.
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case94_task_scheduler_init_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case94_task_scheduler_init_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: _ZN5mylib19task_scheduler_initD1Ev
+
+# Source rebuild against the v2 header also fails because the class is gone.
+tmp=$(mktemp -d)
+cp examples/case94_task_scheduler_init_removed/app.cpp "$tmp/app.cpp"
+cp examples/case94_task_scheduler_init_removed/v2.h "$tmp/v1.h"
+g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: 'task_scheduler_init' is not a member of 'mylib'
+```
+
 ## Why this is a oneTBB-flavored break
 
 This is the single largest hard ABI break in TBB's history: classic TBB

--- a/examples/case108_task_class_removed/README.md
+++ b/examples/case108_task_class_removed/README.md
@@ -16,6 +16,36 @@ This is more severe than case107 because:
   the base silently breaks `dynamic_cast` and exception handling for any
   user exception derived from it.
 
+## Real Failure Demo
+
+**Severity: BREAKING**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build \
+  --target case95_task_class_removed_app case95_task_class_removed_v2
+
+/tmp/abicheck-examples-build/case95_task_class_removed/app_v1
+# ref_count after dec = 2 (expect 2)
+
+# Runtime replacement: the v1 binary asks for the removed v1 factory/type
+# surface and fails as soon as the missing symbol is resolved.
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case95_task_class_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case95_task_class_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: _ZN5mylib17mylib_spawn_dummyEv
+
+# Source rebuild against the v2 header also fails because the base class and
+# factory are gone.
+tmp=$(mktemp -d)
+cp examples/case95_task_class_removed/app.cpp "$tmp/app.cpp"
+cp examples/case95_task_class_removed/v2.h "$tmp/v1.h"
+g++ -std=c++17 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: 'task' is not a member of 'mylib'
+# error: 'mylib_spawn_dummy' is not a member of 'mylib'
+```
+
 ## Why this is a oneTBB-flavored break
 
 Classic TBB's `tbb::task` low-level API was the recommended way to write

--- a/examples/case108_task_class_removed/app.cpp
+++ b/examples/case108_task_class_removed/app.cpp
@@ -2,7 +2,7 @@
 #include <cstdio>
 
 int main() {
-    mylib::task* t = mylib_spawn_dummy();
+    mylib::task* t = mylib::mylib_spawn_dummy();
     t->set_ref_count(3);
     std::printf("ref_count after dec = %d (expect 2)\n", t->decrement_ref_count());
     delete t;

--- a/examples/case13_symbol_versioning/README.md
+++ b/examples/case13_symbol_versioning/README.md
@@ -39,6 +39,25 @@ The ELF detector sees `LIBFOO_1.0` in v2's `.gnu.version_d` section but not in v
 
 ---
 
+## Real Failure Demo
+
+**Severity: COMPATIBLE / VERSIONING QUALITY**
+
+The old binary keeps running when the v2 library adds GNU symbol versions, but
+the real observable difference is in ELF metadata: v1 has no version section;
+v2 exports the public ABI under `LIBFOO_1.0`.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case13_symbol_versioning_app case13_symbol_versioning_v2
+
+readelf --version-info /tmp/abicheck-examples-build/case13_symbol_versioning/libv1.so
+# No version information found in this file.
+
+readelf --version-info /tmp/abicheck-examples-build/case13_symbol_versioning/libv2.so | grep LIBFOO_1.0
+# 2 (LIBFOO_1.0) ... Name: LIBFOO_1.0
+```
+
 ## Why it is COMPATIBLE (unversioned → versioned)
 
 When an existing binary was linked against unversioned `foo` (v1), its ELF `DT_NEEDED`

--- a/examples/case26b_union_field_added_compatible/README.md
+++ b/examples/case26b_union_field_added_compatible/README.md
@@ -9,6 +9,26 @@
 | v1 | `union Value { long l; double d; };` |
 | v2 | `union Value { long l; double d; int i; };` |
 
+## Real Failure Demo
+
+**Severity: COMPATIBLE - NO FAILURE EXPECTED**
+
+This is intentionally a non-failure demo. The app is compiled against v1, then
+run with v2 under the old SONAME. Because the added union field does not change
+`sizeof(union Value)`, the result is identical.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case27_union_field_added_compatible_app case27_union_field_added_compatible_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case27_union_field_added_compatible/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case27_union_field_added_compatible/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# after fill: v.l = 42
+# OK: union field added (no size change) is ABI-compatible
+```
+
 ## Why this is NOT a binary ABI break
 
 Adding `int i` does **not** change `sizeof(union Value)`:

--- a/examples/case34_access_level/README.md
+++ b/examples/case34_access_level/README.md
@@ -34,6 +34,24 @@ private:
 };
 ```
 
+## Real Failure Demo
+
+**Severity: API BREAK / COMPILE-TIME FAILURE**
+
+Old binaries still run with v2 because C++ access control is not encoded in the
+mangled symbol. The real failure appears when source using the formerly-public
+members is rebuilt against the v2 header.
+
+```bash
+tmp=$(mktemp -d)
+cp examples/case35_access_level/app.cpp "$tmp/app.cpp"
+cp examples/case35_access_level/v1.hpp "$tmp/v1.hpp"
+cp examples/case35_access_level/v2.hpp "$tmp/v2.hpp"
+g++ -std=c++17 -DUSE_V2 -I"$tmp" -c "$tmp/app.cpp" -o "$tmp/app.o"
+# error: 'void Widget::helper()' is private within this context
+# error: 'int Widget::cache' is private within this context
+```
+
 ## Why this is NOT a binary ABI break
 
 Access specifiers (`public`, `private`, `protected`) are **compile-time only** in C++.

--- a/examples/case42_type_alignment_changed/README.md
+++ b/examples/case42_type_alignment_changed/README.md
@@ -70,3 +70,18 @@ CacheBlock* block_alloc(void) {
 
 - [C11 alignas / _Alignas](https://en.cppreference.com/w/c/language/_Alignas)
 - [GCC __attribute__((aligned))](https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html)
+
+## Real Failure Demo
+
+**Severity: BAD PRACTICE / ABI BREAK**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case43_type_alignment_changed_app case43_type_alignment_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case43_type_alignment_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case43_type_alignment_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# block_process = 0 (expected 4) / WRONG RESULT: alignment change caused array stride/layout mismatch
+```

--- a/examples/case49_executable_stack/README.md
+++ b/examples/case49_executable_stack/README.md
@@ -84,3 +84,22 @@ executable stacks.
 
 - [Hardening ELF binaries — execstack](https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart)
 - [Red Hat: Controlling execstack](https://access.redhat.com/solutions/2936741)
+
+## Real Failure Demo
+
+**Severity: SECURITY / BAD PRACTICE**
+
+The program still runs, but the v1 artifact requests an executable process
+stack. Hardened loaders and distro policy can reject this even when symbol ABI
+looks otherwise compatible.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case50_executable_stack_v1 case50_executable_stack_v2
+
+readelf -W -l /tmp/abicheck-examples-build/case50_executable_stack/libv1.so | grep GNU_STACK
+# GNU_STACK ... RWE
+
+readelf -W -l /tmp/abicheck-examples-build/case50_executable_stack/libv2.so | grep GNU_STACK
+# GNU_STACK ... RW
+```

--- a/examples/case52_rpath_leak/README.md
+++ b/examples/case52_rpath_leak/README.md
@@ -12,6 +12,25 @@ uses `$ORIGIN`-relative paths.
 This is a **deployment-level bad practice**: build-directory paths in shared
 libraries break on every machine except the one where the library was built.
 
+## Real Failure Demo
+
+**Severity: SECURITY / PACKAGING RISK**
+
+The code path still runs, but v1 bakes a build-machine path into `RUNPATH`.
+That can load unintended libraries on a matching host path or fail package
+policy checks.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case53_rpath_leak_v1 case53_rpath_leak_v2
+
+readelf -d /tmp/abicheck-examples-build/case53_rpath_leak/libv1.so | grep RUNPATH
+# Library runpath: [/home/build/myproject/lib]
+
+readelf -d /tmp/abicheck-examples-build/case53_rpath_leak/libv2.so | grep RUNPATH
+# Library runpath: [$ORIGIN]
+```
+
 ## Why hardcoded RPATH is bad practice
 
 - **Non-portable:** The library only works if the exact build directory exists

--- a/examples/case53_namespace_pollution/README.md
+++ b/examples/case53_namespace_pollution/README.md
@@ -12,6 +12,21 @@ This is a **design-level bad practice**: unprefixed names in C shared libraries
 are a collision time-bomb in any non-trivial application that links multiple
 libraries.
 
+## Real Failure Demo
+
+**Severity: BREAKING / SYMBOL REMOVAL**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case54_namespace_pollution_app case54_namespace_pollution_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case54_namespace_pollution/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case54_namespace_pollution/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: process
+```
+
 ## Why namespace pollution is bad practice
 
 C has no namespaces. All exported symbols from all shared libraries loaded in

--- a/examples/case54_used_reserved_field/README.md
+++ b/examples/case54_used_reserved_field/README.md
@@ -60,3 +60,20 @@ typedef struct {
 ## References
 
 - [Preserving ABI with reserved fields](https://www.akkadia.org/drepper/dsohowto.pdf)
+
+## Real Failure Demo
+
+**Severity: BAD PRACTICE / ABI RISK**
+
+The small app still prints the old value, but v1 consumes a reserved field that v2 expects to own. The failure is latent: future library code may reinterpret that field and corrupt caller state.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case55_used_reserved_field_app case55_used_reserved_field_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case55_used_reserved_field/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case55_used_reserved_field/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# flags = 0
+```

--- a/examples/case55_type_kind_changed/README.md
+++ b/examples/case55_type_kind_changed/README.md
@@ -44,3 +44,18 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 ## References
 
 - [DWARF structure vs union tags](https://dwarfstd.org/doc/DWARF5.pdf)
+
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case56_type_kind_changed_app case56_type_kind_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case56_type_kind_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case56_type_kind_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# sum = 10 / WRONG RESULT: type kind changed (struct -> union)
+```

--- a/examples/case56_struct_packing_changed/README.md
+++ b/examples/case56_struct_packing_changed/README.md
@@ -51,3 +51,18 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 ## References
 
 - [GCC: Structure Packing Pragmas](https://gcc.gnu.org/onlinedocs/gcc/Structure-Layout-Pragmas.html)
+
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case57_struct_packing_changed_app case57_struct_packing_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case57_struct_packing_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case57_struct_packing_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# value = 22528 / WRONG RESULT: struct packing/layout changed
+```

--- a/examples/case57_enum_underlying_size_changed/README.md
+++ b/examples/case57_enum_underlying_size_changed/README.md
@@ -47,3 +47,18 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 ## References
 
 - [C11 6.7.2.2: Enumeration specifiers](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
+
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case58_enum_underlying_size_changed_app case58_enum_underlying_size_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case58_enum_underlying_size_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case58_enum_underlying_size_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# color = 2; alpha = 0 / WRONG RESULT: enum underlying size/layout changed
+```

--- a/examples/case58_var_removed/README.md
+++ b/examples/case58_var_removed/README.md
@@ -53,3 +53,18 @@ Or use a version script to control when symbols are removed.
 ## References
 
 - [ELF Symbol Versioning](https://www.akkadia.org/drepper/symbol-versioning)
+
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case59_var_removed_app case59_var_removed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case59_var_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case59_var_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: lib_debug_level
+```

--- a/examples/case59_func_became_inline/README.md
+++ b/examples/case59_func_became_inline/README.md
@@ -82,3 +82,18 @@ Or use a `__attribute__((weak))` symbol.
 ## References
 
 - [C99 inline semantics](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
+
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case60_func_became_inline_app case60_func_became_inline_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case60_func_became_inline/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case60_func_became_inline/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: ./app_v1: undefined symbol: fast_abs
+```

--- a/examples/case60_base_class_position_changed/README.md
+++ b/examples/case60_base_class_position_changed/README.md
@@ -48,3 +48,18 @@ python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
 ## References
 
 - [Itanium C++ ABI: class layout](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#class-types)
+
+## Real Failure Demo
+
+**Severity: BREAKING / OBJECT CORRUPTION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case61_base_class_position_changed_app case61_base_class_position_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case61_base_class_position_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case61_base_class_position_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# id = <garbage>; CORRUPTION: base-class order changed, subobject offsets mismatch
+```

--- a/examples/case61_var_added/README.md
+++ b/examples/case61_var_added/README.md
@@ -7,6 +7,23 @@
 v1 exports `lib_version`. v2 adds a new global variable `lib_build_number`.
 All existing symbols are unchanged — this is a purely additive change.
 
+## Real Failure Demo
+
+**Severity: COMPATIBLE - NO FAILURE EXPECTED**
+
+This is an additive ABI change. The old app does not reference the new global, so runtime substitution is safe.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case62_var_added_app case62_var_added_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case62_var_added/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case62_var_added/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# version = 2 / get_version() = 2
+```
+
 ## Why this is compatible
 
 - Existing binaries never reference `lib_build_number`, so it doesn't affect them.

--- a/examples/case62_type_field_added_compatible/README.md
+++ b/examples/case62_type_field_added_compatible/README.md
@@ -11,6 +11,23 @@ v2 adds a `priority` field at the end. Because callers only use `Session*`
 This is the **correct design pattern** for extensible C APIs: opaque handles +
 accessor functions allow adding fields without breaking existing consumers.
 
+## Real Failure Demo
+
+**Severity: COMPATIBLE - NO FAILURE EXPECTED**
+
+The struct is opaque to callers, so v2 can grow the private allocation without changing caller layout.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case63_type_field_added_compatible_app case63_type_field_added_compatible_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case63_type_field_added_compatible/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case63_type_field_added_compatible/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# name = test / timeout = 30
+```
+
 ## Why this is compatible
 
 - **Callers never see the layout**: `Session` is forward-declared in the header.

--- a/examples/case74_detail_base_class_changed/README.md
+++ b/examples/case74_detail_base_class_changed/README.md
@@ -27,6 +27,21 @@ From consumers' perspective it's a binary ABI break:
 - Heap-allocated objects from callers compiled against v1 headers
   under-allocate when run against v2 binaries.
 
+## Real Failure Demo
+
+**Severity: BREAKING / MEMORY CORRUPTION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case75_detail_base_class_changed_app case75_detail_base_class_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case75_detail_base_class_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case75_detail_base_class_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# *** stack smashing detected ***: terminated
+```
+
 ## Why abicheck catches it
 
 Existing detectors already report `type_size_changed` on

--- a/examples/case75_detail_embedded_by_value/README.md
+++ b/examples/case75_detail_embedded_by_value/README.md
@@ -25,6 +25,23 @@ the public class:
 The author touched only the "internal" struct — but the binary
 interface of the *public* class moved with it.
 
+## Real Failure Demo
+
+**Severity: BREAKING / LATENT LAYOUT CORRUPTION**
+
+This minimal app does not trip the corrupted field, but the public `table` embeds a changed `detail::table_impl` by value. Any caller that copies, arrays, or inlines deeper accessors is using the old object layout.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case76_detail_embedded_by_value_app case76_detail_embedded_by_value_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case76_detail_embedded_by_value/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case76_detail_embedded_by_value/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# rows=3 cols=4 (expect 3 4)
+```
+
 ## Why abicheck catches it
 
 The existing `struct_field_added` detector flags the new field on

--- a/examples/case76_detail_pimpl_vtable_changed/README.md
+++ b/examples/case76_detail_pimpl_vtable_changed/README.md
@@ -31,6 +31,21 @@ instance now dispatches through the slot occupied at runtime by
 reshuffle never touches any public *name*; only the slot indices
 move. That makes the break invisible to symbol-level tools.
 
+## Real Failure Demo
+
+**Severity: BREAKING / WRONG RESULT**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case77_detail_pimpl_vtable_changed_app case77_detail_pimpl_vtable_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case77_detail_pimpl_vtable_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case77_detail_pimpl_vtable_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# status=50 (expect 1)
+```
+
 ## Why abicheck catches it
 
 On Linux the vtable symbol (`_ZTVN5mylib6detail15algorithm_ifaceE`)

--- a/examples/case77_detail_templated_base_changed/README.md
+++ b/examples/case77_detail_templated_base_changed/README.md
@@ -39,11 +39,11 @@ reachability walker follows template-instantiation edges into `detail::`.
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case78_detail_templated_base_changed_app case78_detail_templated_base_changed_v2
+cmake --build /tmp/abicheck-examples-build --target case77_detail_templated_base_changed_app case77_detail_templated_base_changed_v2
 
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case77_detail_templated_base_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case77_detail_templated_base_changed/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # *** stack smashing detected ***: terminated
 ```

--- a/examples/case77_detail_templated_base_changed/README.md
+++ b/examples/case77_detail_templated_base_changed/README.md
@@ -33,6 +33,21 @@ field, which grows *every instantiation* simultaneously:
 case74 verifies the simple inheritance edge. case77 verifies that the leak
 reachability walker follows template-instantiation edges into `detail::`.
 
+## Real Failure Demo
+
+**Severity: BREAKING / MEMORY CORRUPTION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case78_detail_templated_base_changed_app case78_detail_templated_base_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case78_detail_templated_base_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# *** stack smashing detected ***: terminated
+```
+
 ## Why abicheck catches it
 
 `type_size_changed` / `type_field_added` fire on each instantiation of

--- a/examples/case79_missing_template_instantiation/README.md
+++ b/examples/case79_missing_template_instantiation/README.md
@@ -28,6 +28,21 @@ This is the failure mode for oneDAL's "ship `float` instantiation only" build
 trim: the public combinatorics promised by `cpp/oneapi/dal/algo/*/common.hpp`
 must match the explicit instantiations in `*_instantiation.cpp`.
 
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case79_missing_template_instantiation_app case79_missing_template_instantiation_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case79_missing_template_instantiation/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case79_missing_template_instantiation/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: _ZN5mylib10descriptorIdE13set_thresholdEd
+```
+
 ## Why abicheck catches it
 
 A new `INSTANTIATION_MISSING_FROM_BINARY` ChangeKind is emitted when a

--- a/examples/case80_pimpl_shared_to_unique/README.md
+++ b/examples/case80_pimpl_shared_to_unique/README.md
@@ -32,6 +32,23 @@ so the containing class even shrinks — the failure isn't "size grew", it is:
    move-only. Consumer code that copied a `descriptor` compiles under v1,
    refuses under v2.
 
+## Real Failure Demo
+
+**Severity: BREAKING / ABI SHAPE CHANGE**
+
+This smoke app still works because it does not copy or share ownership. The real break is that the public object field changes from shared ownership ABI to unique ownership ABI, changing size, copyability, and inline member code expectations.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case80_pimpl_shared_to_unique_app case80_pimpl_shared_to_unique_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case80_pimpl_shared_to_unique/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case80_pimpl_shared_to_unique/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# class_count = 7 (expect 7)
+```
+
 ## Why abicheck catches it
 
 The existing `type_field_type_changed` detector fires on `descriptor::impl_`

--- a/examples/case81_serialization_tag_reassigned/README.md
+++ b/examples/case81_serialization_tag_reassigned/README.md
@@ -21,6 +21,23 @@ existing saved model becomes silently corrupt:
 There is **no symbol change**, **no layout change**, **no link error**, **no
 load error**. Every conventional ABI checker reports COMPATIBLE.
 
+## Real Failure Demo
+
+**Severity: BREAKING / PERSISTENCE FORMAT DRIFT**
+
+Old serialized model tags now deserialize as a different model family.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case81_serialization_tag_reassigned_app case81_serialization_tag_reassigned_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case81_serialization_tag_reassigned/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case81_serialization_tag_reassigned/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# knn_model_tag = 0x1003; linear_regression = 0x1002
+```
+
 ## Why this is its own ChangeKind
 
 This is a *payload-level* invariant — the binary contract between two

--- a/examples/case82_sycl_overload_set_removed/README.md
+++ b/examples/case82_sycl_overload_set_removed/README.md
@@ -21,6 +21,21 @@ signal under a wall of independent removals, making the suppression UX a
 mess (one rule per algorithm) and obscuring the deployment-level question
 ("did the SYCL surface go away?").
 
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case82_sycl_overload_set_removed_app case82_sycl_overload_set_removed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case82_sycl_overload_set_removed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case82_sycl_overload_set_removed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: _ZN5mylib7computeERN4sycl5queueERKNS_10descriptorERKNS_5tableE
+```
+
 ## Why this is its own ChangeKind
 
 A grouped finding — `SYCL_OVERLOAD_SET_REMOVED` — names the deployment

--- a/examples/case83_cpu_dispatch_isa_dropped/README.md
+++ b/examples/case83_cpu_dispatch_isa_dropped/README.md
@@ -23,6 +23,21 @@ unaffected. Consumers who linked directly against `kmeans_compute_avx512`
 that bypass the dispatcher for reproducibility) get unresolved symbols at
 load time.
 
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case83_cpu_dispatch_isa_dropped_app case83_cpu_dispatch_isa_dropped_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case83_cpu_dispatch_isa_dropped/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case83_cpu_dispatch_isa_dropped/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: _ZN5mylib21kmeans_compute_avx512Ei
+```
+
 ## Why a separate ChangeKind (not just N×func_removed)
 
 If reported as 50 independent `func_removed` findings, the deployment-level

--- a/examples/case84_bundle_soname_skew/README.md
+++ b/examples/case84_bundle_soname_skew/README.md
@@ -47,6 +47,25 @@ case84_bundle_soname_skew/
 The `compare-release` mode of abicheck ingests both directories and runs
 the cross-library aggregator.
 
+## Real Failure Demo
+
+**Severity: BREAKING / RELEASE BUNDLE SKEW**
+
+This fixture is a directory-level failure, not a single app swap. Rebuild the
+three shared libraries and run the cohort detector directly: two siblings bump
+to SONAME `.so.2`, while `libonedal_thread` stays on `.so.1`.
+
+```bash
+python3 - <<'PY'
+from abicheck.diff_onedal import bundle_members_from_directory, detect_bundle_soname_skew
+old = bundle_members_from_directory('examples/case84_bundle_soname_skew/v1')
+new = bundle_members_from_directory('examples/case84_bundle_soname_skew/v2')
+for finding in detect_bundle_soname_skew(old, new, cohort_prefix='libonedal_'):
+    print(finding.kind.value, finding.severity.value)
+PY
+# bundle_soname_skew BREAKING
+```
+
 ## Why this is its own ChangeKind
 
 Existing `soname_changed` and `soname_bump_recommended` are per-library

--- a/examples/case86_tag_struct_renamed/README.md
+++ b/examples/case86_tag_struct_renamed/README.md
@@ -36,11 +36,11 @@ v2 renames `brute_force` → `search_brute`. Mechanically:
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case85_tag_struct_renamed_app case85_tag_struct_renamed_v2
+cmake --build /tmp/abicheck-examples-build --target case86_tag_struct_renamed_app case86_tag_struct_renamed_v2
 
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case86_tag_struct_renamed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case86_tag_struct_renamed/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # ./app_v1: symbol lookup error: undefined symbol: descriptor<brute_force, classification>::descriptor()
 ```

--- a/examples/case86_tag_struct_renamed/README.md
+++ b/examples/case86_tag_struct_renamed/README.md
@@ -30,6 +30,21 @@ v2 renames `brute_force` → `search_brute`. Mechanically:
   mangled name. Consumer binaries linked against v1 request the old
   symbol at load time and get an unresolved-symbol error.
 
+## Real Failure Demo
+
+**Severity: BREAKING / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case85_tag_struct_renamed_app case85_tag_struct_renamed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case85_tag_struct_renamed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: descriptor<brute_force, classification>::descriptor()
+```
+
 ## Why this is its own ChangeKind
 
 Renaming a *non-empty* class is rare and would already trigger many

--- a/examples/case87_default_template_arg_changed/README.md
+++ b/examples/case87_default_template_arg_changed/README.md
@@ -28,6 +28,21 @@ A consumer compiled against v2 emits calls to the second. The shipped
 library can only contain one — whichever version was built. Cross-version
 linking yields unresolved symbols.
 
+## Real Failure Demo
+
+**Severity: API BREAK / LOAD-TIME FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case86_default_template_arg_changed_app case86_default_template_arg_changed_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case86_default_template_arg_changed/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case86_default_template_arg_changed/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# ./app_v1: symbol lookup error: undefined symbol: descriptor<float, minkowski_distance<float>>::dimension()
+```
+
 ## Why distinct from case32
 
 case32 covers *function* default parameter values, which are resolved at

--- a/examples/case89_inline_accessor_renamed_pimpl_member/README.md
+++ b/examples/case89_inline_accessor_renamed_pimpl_member/README.md
@@ -33,6 +33,23 @@ is inline and has no exported symbol. There is no public-type layout change:
 gap between *what the consumer's inline body assumes* and *what the new
 detail layout actually is*.
 
+## Real Failure Demo
+
+**Severity: BREAKING / LATENT INLINE ABI DRIFT**
+
+The tiny app happens to read the same value, but its inline accessor is compiled against the old `impl_->class_count_` member. A real v2 layout that reuses that slot for another field turns the inline read into stale or wrong data.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case87_inline_accessor_renamed_pimpl_member_app case87_inline_accessor_renamed_pimpl_member_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case87_inline_accessor_renamed_pimpl_member/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case87_inline_accessor_renamed_pimpl_member/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# class_count = 2
+```
+
 ## Why distinct from case35 + case47
 
 - case35 (`field_rename`) covers field renames in isolation. It does not

--- a/examples/case90_bundle_intra_dep_removed/README.md
+++ b/examples/case90_bundle_intra_dep_removed/README.md
@@ -15,8 +15,8 @@ runtime `dlopen("libalgo.so")` fails with `undefined symbol: core_mul`.
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case88_bundle_intra_dep_removed_old_libalgo case88_bundle_intra_dep_removed_new_libalgo
-PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case88_bundle_intra_dep_removed/old   /tmp/abicheck-examples-build/case88_bundle_intra_dep_removed/new   --format markdown
+cmake --build /tmp/abicheck-examples-build --target case90_bundle_intra_dep_removed_old_libalgo case90_bundle_intra_dep_removed_new_libalgo
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case90_bundle_intra_dep_removed/old   /tmp/abicheck-examples-build/case90_bundle_intra_dep_removed/new   --format markdown
 # bundle_intra_dep_removed: libalgo.so imports core_mul, but no new bundle library exports it.
 ```
 

--- a/examples/case90_bundle_intra_dep_removed/README.md
+++ b/examples/case90_bundle_intra_dep_removed/README.md
@@ -9,6 +9,17 @@ undefined reference to `core_mul` (DT_NEEDED on `libcore.so.1`, `U core_mul`
 in `.dynsym`). The new bundle no longer exports `core_mul` anywhere, so at
 runtime `dlopen("libalgo.so")` fails with `undefined symbol: core_mul`.
 
+## Real Failure Demo
+
+**Severity: BREAKING / CROSS-LIBRARY LOAD FAILURE**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case88_bundle_intra_dep_removed_old_libalgo case88_bundle_intra_dep_removed_new_libalgo
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case88_bundle_intra_dep_removed/old   /tmp/abicheck-examples-build/case88_bundle_intra_dep_removed/new   --format markdown
+# bundle_intra_dep_removed: libalgo.so imports core_mul, but no new bundle library exports it.
+```
+
 ## Why per-library compare misses it
 - `compare libcore_v1 libcore_v2` correctly flags `func_removed: core_mul`.
 - `compare libalgo_v1 libalgo_v2` reports `NO_CHANGE` — the library on its

--- a/examples/case91_bundle_intra_signature_drift/README.md
+++ b/examples/case91_bundle_intra_signature_drift/README.md
@@ -20,8 +20,8 @@ calling convention is now wrong:
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case89_bundle_intra_signature_drift_old_libalgo case89_bundle_intra_signature_drift_new_libalgo
-PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case89_bundle_intra_signature_drift/old   /tmp/abicheck-examples-build/case89_bundle_intra_signature_drift/new   --format markdown
+cmake --build /tmp/abicheck-examples-build --target case91_bundle_intra_signature_drift_old_libalgo case91_bundle_intra_signature_drift_new_libalgo
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case91_bundle_intra_signature_drift/old   /tmp/abicheck-examples-build/case91_bundle_intra_signature_drift/new   --format markdown
 # bundle_intra_dep_signature_changed: libalgo.so calls core_add but libcore.so changed its DWARF signature.
 ```
 

--- a/examples/case91_bundle_intra_signature_drift/README.md
+++ b/examples/case91_bundle_intra_signature_drift/README.md
@@ -14,6 +14,17 @@ calling convention is now wrong:
   garbage in the high halves of the registers.
 - Result: undefined behaviour or wrong values, depending on caller layout.
 
+## Real Failure Demo
+
+**Severity: BREAKING / CROSS-DSO CALLING-CONVENTION MISMATCH**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case89_bundle_intra_signature_drift_old_libalgo case89_bundle_intra_signature_drift_new_libalgo
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case89_bundle_intra_signature_drift/old   /tmp/abicheck-examples-build/case89_bundle_intra_signature_drift/new   --format markdown
+# bundle_intra_dep_signature_changed: libalgo.so calls core_add but libcore.so changed its DWARF signature.
+```
+
 ## Why per-library compare misses it
 - `compare libcore_v1 libcore_v2` correctly flags `func_params_changed`
   and `func_return_changed` on `core_add`.

--- a/examples/case92_bundle_provider_changed/README.md
+++ b/examples/case92_bundle_provider_changed/README.md
@@ -21,8 +21,8 @@ set is unchanged. The set of *providers* changed:
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case90_bundle_provider_changed_old_libutil case90_bundle_provider_changed_new_libutil
-PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case90_bundle_provider_changed/old   /tmp/abicheck-examples-build/case90_bundle_provider_changed/new   --format markdown
+cmake --build /tmp/abicheck-examples-build --target case92_bundle_provider_changed_old_libutil case92_bundle_provider_changed_new_libutil
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case92_bundle_provider_changed/old   /tmp/abicheck-examples-build/case92_bundle_provider_changed/new   --format markdown
 # bundle_provider_changed: shared_util moved from libcore.so to libutil.so.
 ```
 

--- a/examples/case92_bundle_provider_changed/README.md
+++ b/examples/case92_bundle_provider_changed/README.md
@@ -15,6 +15,17 @@ set is unchanged. The set of *providers* changed:
 | `shared_util` | libcore.so  | libutil.so  |
 | `util_double_add` | libutil.so | libutil.so |
 
+## Real Failure Demo
+
+**Severity: COMPATIBLE_WITH_RISK / PROVIDER MIGRATION**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case90_bundle_provider_changed_old_libutil case90_bundle_provider_changed_new_libutil
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case90_bundle_provider_changed/old   /tmp/abicheck-examples-build/case90_bundle_provider_changed/new   --format markdown
+# bundle_provider_changed: shared_util moved from libcore.so to libutil.so.
+```
+
 ## Why this is risk, not a hard break
 - Downstream binaries linked with `-lcore -lutil` get both; the loader
   resolves `shared_util` from whichever DSO is searched first (the new

--- a/examples/case93_bundle_manifest_drift/README.md
+++ b/examples/case93_bundle_manifest_drift/README.md
@@ -30,8 +30,8 @@ instantiated the dropped triple will fail to link.
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case91_bundle_manifest_drift_old_libcore case91_bundle_manifest_drift_new_libcore
-PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case91_bundle_manifest_drift/old   /tmp/abicheck-examples-build/case91_bundle_manifest_drift/new   --manifest examples/case91_bundle_manifest_drift/manifest.yaml   --format markdown
+cmake --build /tmp/abicheck-examples-build --target case93_bundle_manifest_drift_old_libcore case93_bundle_manifest_drift_new_libcore
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case93_bundle_manifest_drift/old   /tmp/abicheck-examples-build/case93_bundle_manifest_drift/new   --manifest examples/case93_bundle_manifest_drift/manifest.yaml   --format markdown
 # bundle_manifest_instantiation_removed: train_double_sparse is promised but no longer exported.
 ```
 

--- a/examples/case93_bundle_manifest_drift/README.md
+++ b/examples/case93_bundle_manifest_drift/README.md
@@ -24,6 +24,17 @@ In real oneDAL these are mangled C++ symbols for
 documentation is a silent contract violation: downstream code that
 instantiated the dropped triple will fail to link.
 
+## Real Failure Demo
+
+**Severity: BREAKING / MANIFEST PROMISE REMOVED**
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case91_bundle_manifest_drift_old_libcore case91_bundle_manifest_drift_new_libcore
+PYTHONPATH=. python3 -m abicheck.cli compare-release   /tmp/abicheck-examples-build/case91_bundle_manifest_drift/old   /tmp/abicheck-examples-build/case91_bundle_manifest_drift/new   --manifest examples/case91_bundle_manifest_drift/manifest.yaml   --format markdown
+# bundle_manifest_instantiation_removed: train_double_sparse is promised but no longer exported.
+```
+
 ## Why this needs a manifest
 Per-library `func_removed` detection already flags the missing symbol —
 but it can't tell whether the symbol was a *promised* part of the public

--- a/examples/case94_empty_tag_gained_state/README.md
+++ b/examples/case94_empty_tag_gained_state/README.md
@@ -18,11 +18,11 @@ The smoke app does not crash, but the public by-value tag changed from empty to 
 
 ```bash
 cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
-cmake --build /tmp/abicheck-examples-build --target case92_empty_tag_gained_state_app case92_empty_tag_gained_state_v2
+cmake --build /tmp/abicheck-examples-build --target case94_empty_tag_gained_state_app case94_empty_tag_gained_state_v2
 
 tmp=$(mktemp -d)
-cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/app_v1 "$tmp/"
-cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/libv2.so "$tmp/libv1.so"
+cp /tmp/abicheck-examples-build/case94_empty_tag_gained_state/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case94_empty_tag_gained_state/libv2.so "$tmp/libv1.so"
 (cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
 # run(7) = 14 (expect 14)
 ```

--- a/examples/case94_empty_tag_gained_state/README.md
+++ b/examples/case94_empty_tag_gained_state/README.md
@@ -10,6 +10,23 @@ template, an algorithm overload selector, or any function taking it by value —
 1-byte argument into what is now an 8-byte parameter slot. The callee reads partially
 uninitialized memory, then steps on subsequent stack/register state.
 
+## Real Failure Demo
+
+**Severity: BREAKING / LATENT CALL ABI DRIFT**
+
+The smoke app does not crash, but the public by-value tag changed from empty to stateful. Header-inlined algorithms compiled against v1 pass the old object shape into a v2 function expecting the wider tag.
+
+```bash
+cmake -S examples -B /tmp/abicheck-examples-build -DCMAKE_BUILD_TYPE=Debug
+cmake --build /tmp/abicheck-examples-build --target case92_empty_tag_gained_state_app case92_empty_tag_gained_state_v2
+
+tmp=$(mktemp -d)
+cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/app_v1 "$tmp/"
+cp /tmp/abicheck-examples-build/case92_empty_tag_gained_state/libv2.so "$tmp/libv1.so"
+(cd "$tmp" && LD_LIBRARY_PATH=. ./app_v1)
+# run(7) = 14 (expect 14)
+```
+
 ## Why this is a oneTBB-flavored break
 
 The pattern is exactly the `tbb::auto_partitioner` / `tbb::simple_partitioner` /

--- a/examples/case94_empty_tag_gained_state/app.cpp
+++ b/examples/case94_empty_tag_gained_state/app.cpp
@@ -3,8 +3,8 @@
 
 int main() {
     mylib::auto_partitioner p{};
-    auto* r = mylib_make_runner();
+    auto* r = mylib::mylib_make_runner();
     std::printf("run(7) = %d (expect 14)\n", r->run(7, p));
-    mylib_free_runner(r);
+    mylib::mylib_free_runner(r);
     return 0;
 }

--- a/scripts/gen_examples_docs.py
+++ b/scripts/gen_examples_docs.py
@@ -150,19 +150,21 @@ def _read_case(name: str, meta: dict) -> Case:
 
 
 def _rewrite_links(body: str) -> str:
-    # Rewrite source-tree links from examples/<case>/README.md so generated
-    # docs remain navigable in local/offline builds.
+    # Rewrite links from examples/<case>/README.md for generated docs. MkDocs
+    # strict mode validates Markdown links against files under docs/, so source
+    # files outside docs/ are rendered as code literals instead of links.
     def repl(m: re.Match) -> str:
         text, target = m.group(1), m.group(2)
         if target.startswith(("http://", "https://", "#", "mailto:")):
             return m.group(0)
-        # Bare filenames like v1.c, app.cpp point to the source case directory.
-        if target.startswith("../"):
-            url = posixpath.normpath(
-                f"{REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/__CASE__/{target}"
-            )
-        elif "/" not in target and "." in target:
-            url = f"{REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/__CASE__/{target}"
+        if target.startswith("../docs/"):
+            url = posixpath.normpath("../" + target.removeprefix("../docs/"))
+            return f"[{text}]({url})"
+        # Bare filenames like v1.c, app.cpp and ../ source-tree paths live
+        # outside docs/; keep the reference visible without creating a checked
+        # MkDocs link.
+        if target.startswith("../") or ("/" not in target and "." in target):
+            return f"`{text.strip('`')}`"
         else:
             url = target
         return f"[{text}]({url})"
@@ -197,7 +199,7 @@ def _meta_table(case: Case) -> str:
         f"| **Platforms** | {platforms} |\n"
         f"| **Flags** | {flag_str} |\n"
         f"| **Detected `ChangeKind`s** | {kinds} |\n"
-        f"| **Source files** | [browse source]({REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/{case.name}/) |\n"
+        f"| **Source files** | `examples/{case.name}/` |\n"
     )
 
 
@@ -208,10 +210,7 @@ def _source_links(case: Case) -> str:
     )
     if not files:
         return ""
-    lines = [
-        f"- [`{f}`]({REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/{case.name}/{f})"
-        for f in files
-    ]
+    lines = [f"- `{f}`" for f in files]
     return "## Source files\n\n" + "\n".join(lines) + "\n"
 
 
@@ -265,9 +264,9 @@ def _render_index(cases: list[Case]) -> str:
         "- Look up the **mitigation pattern** for a specific change.\n"
         "- Cross-reference detected [`ChangeKind`s](../reference/change-kinds.md) with concrete reproductions.\n\n",
         "> **Ground truth.** Expected verdicts and detected change kinds live in "
-        "[`examples/ground_truth.json`](../../examples/ground_truth.json) and are the "
+        "`examples/ground_truth.json` and are the "
         "single source of truth — these pages are generated from that file plus per-case "
-        "`README.md` files under [`examples/`](../../examples/).\n\n",
+        "`README.md` files under `examples/`.\n\n",
         "## Verdict distribution\n\n",
         "| Verdict | Count | What it means |\n",
         "|---------|-------|---------------|\n",

--- a/scripts/gen_examples_docs.py
+++ b/scripts/gen_examples_docs.py
@@ -287,7 +287,7 @@ def _render_index(cases: list[Case]) -> str:
         "- **How to fix** — the mitigation pattern, where the README documents one.\n"
         "- **Real-world example** — historical occurrences in widely-used libraries.\n"
         "- **References** — links to relevant standards, manuals, and abicheck source.\n\n"
-        "Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are linked at the bottom of every page.\n\n"
+        "Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the bottom of every page.\n\n"
     )
     lines.append("## Browse by category\n\n")
     by_cat: dict[str, list[Case]] = defaultdict(list)

--- a/scripts/gen_examples_docs.py
+++ b/scripts/gen_examples_docs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import filecmp
 import json
+import posixpath
 import re
 import shutil
 import sys
@@ -23,7 +24,7 @@ ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = ROOT / "examples"
 DOCS_EXAMPLES_DIR = ROOT / "docs" / "examples"
 GROUND_TRUTH = EXAMPLES_DIR / "ground_truth.json"
-REPO_BLOB = "https://github.com/napetrov/abicheck/blob/main"
+REPO_ROOT_FROM_DOCS_EXAMPLES = "../.."
 
 VERDICT_META = {
     "BREAKING": {
@@ -149,16 +150,19 @@ def _read_case(name: str, meta: dict) -> Case:
 
 
 def _rewrite_links(body: str) -> str:
-    # Rewrite repo-relative links like ../abicheck/... → GitHub blob URLs.
+    # Rewrite source-tree links from examples/<case>/README.md so generated
+    # docs remain navigable in local/offline builds.
     def repl(m: re.Match) -> str:
         text, target = m.group(1), m.group(2)
         if target.startswith(("http://", "https://", "#", "mailto:")):
             return m.group(0)
-        # Bare filenames like v1.c, app.cpp → point to the case directory on GitHub.
+        # Bare filenames like v1.c, app.cpp point to the source case directory.
         if target.startswith("../"):
-            url = f"{REPO_BLOB}/{target.lstrip('./')}"
+            url = posixpath.normpath(
+                f"{REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/__CASE__/{target}"
+            )
         elif "/" not in target and "." in target:
-            url = f"{REPO_BLOB}/examples/__CASE__/{target}"
+            url = f"{REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/__CASE__/{target}"
         else:
             url = target
         return f"[{text}]({url})"
@@ -193,7 +197,7 @@ def _meta_table(case: Case) -> str:
         f"| **Platforms** | {platforms} |\n"
         f"| **Flags** | {flag_str} |\n"
         f"| **Detected `ChangeKind`s** | {kinds} |\n"
-        f"| **Source files** | [browse on GitHub]({REPO_BLOB}/examples/{case.name}/) |\n"
+        f"| **Source files** | [browse source]({REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/{case.name}/) |\n"
     )
 
 
@@ -204,7 +208,10 @@ def _source_links(case: Case) -> str:
     )
     if not files:
         return ""
-    lines = [f"- [`{f}`]({REPO_BLOB}/examples/{case.name}/{f})" for f in files]
+    lines = [
+        f"- [`{f}`]({REPO_ROOT_FROM_DOCS_EXAMPLES}/examples/{case.name}/{f})"
+        for f in files
+    ]
     return "## Source files\n\n" + "\n".join(lines) + "\n"
 
 
@@ -258,9 +265,9 @@ def _render_index(cases: list[Case]) -> str:
         "- Look up the **mitigation pattern** for a specific change.\n"
         "- Cross-reference detected [`ChangeKind`s](../reference/change-kinds.md) with concrete reproductions.\n\n",
         "> **Ground truth.** Expected verdicts and detected change kinds live in "
-        f"[`examples/ground_truth.json`]({REPO_BLOB}/examples/ground_truth.json) and are the "
+        "[`examples/ground_truth.json`](../../examples/ground_truth.json) and are the "
         "single source of truth — these pages are generated from that file plus per-case "
-        f"`README.md` files under [`examples/`]({REPO_BLOB}/examples/).\n\n",
+        "`README.md` files under [`examples/`](../../examples/).\n\n",
         "## Verdict distribution\n\n",
         "| Verdict | Count | What it means |\n",
         "|---------|-------|---------------|\n",

--- a/tests/test_examples_docs.py
+++ b/tests/test_examples_docs.py
@@ -13,11 +13,11 @@ Three guarantees enforced here:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import re
 import subprocess
 import sys
-import importlib.util
 from pathlib import Path
 
 import pytest

--- a/tests/test_examples_docs.py
+++ b/tests/test_examples_docs.py
@@ -17,6 +17,7 @@ import json
 import re
 import subprocess
 import sys
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,15 @@ ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = ROOT / "examples"
 GROUND_TRUTH = EXAMPLES_DIR / "ground_truth.json"
 GEN_SCRIPT = ROOT / "scripts" / "gen_examples_docs.py"
+
+
+def _load_generator_module():
+    spec = importlib.util.spec_from_file_location("gen_examples_docs", GEN_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.pop("gen_examples_docs", None)
+    sys.modules["gen_examples_docs"] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _ground_truth_cases() -> list[str]:
@@ -77,3 +87,36 @@ def test_generator_check_passes() -> None:
         "docs/examples/ is out of date — run `python scripts/gen_examples_docs.py`.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
+
+
+def test_generator_rewrites_source_links_without_mkdocs_broken_links() -> None:
+    mod = _load_generator_module()
+
+    rewritten = mod._rewrite_links(
+        "[v1 header](v1.h) [guide](../docs/concepts/abi-stability-guide.md)"
+    )
+
+    assert "`v1 header`" in rewritten
+    assert "[guide](../concepts/abi-stability-guide.md)" in rewritten
+    assert "../../examples/" not in rewritten
+
+
+def test_generator_source_section_uses_code_literals() -> None:
+    mod = _load_generator_module()
+    case = mod.Case(
+        name="case01_symbol_removal",
+        title="Case 01: Symbol Removal",
+        verdict="BREAKING",
+        category="breaking",
+        platforms=["linux"],
+        abi_break=True,
+        api_break=False,
+        bad_practice=False,
+        expected_kinds=[],
+        body="",
+    )
+
+    source_section = mod._source_links(case)
+
+    assert "- `v1.c`" in source_section
+    assert "](" not in source_section

--- a/tests/test_explicit_ctor.py
+++ b/tests/test_explicit_ctor.py
@@ -69,9 +69,9 @@ class TestExplicitCtor:
     def test_none_on_either_side_suppresses_detector(self) -> None:
         """Tri-state: a missing `is_explicit` field (older snapshot, or a
         Function tag where the attribute is N/A) must NOT produce a finding
-        when compared against a fresh snapshot. This pins the Codex review
-        concern: defaulting unknown→implicit would cause spurious
-        CTOR_EXPLICIT_ADDED findings on every consumer upgrading abicheck.
+        when compared against a fresh snapshot. Defaulting unknown→implicit
+        would cause spurious CTOR_EXPLICIT_ADDED findings on every consumer
+        upgrading abicheck.
         """
         # old has unknown explicitness; new is explicit
         old = _snap("1.0", [_ctor("_ZN3FooC1Ei", is_explicit=None)])
@@ -125,16 +125,46 @@ class TestExplicitCtor:
             encoding="utf-8",
         )
         root = Element("GCC_XML")
-        file_el = Element("File", id="_1", name=str(source))
-        root.append(file_el)
+        root.append(Element("File", id="_1", name=str(source)))
+        root.append(Element("FundamentalType", id="_2", name="int"))
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
-        loc_el = Element("Location", file="_1", line="2")
+        loc_el = Element("Location", file="_1", line="3")
 
         assert parser._source_line_has_explicit(loc_el) is True
 
-        declaration_el = Element("Converter", file="_1", line="2")
+        declaration_el = Element("Converter", file="_1", line="3")
         assert parser._source_line_has_explicit(None, declaration_el) is True
         assert str(source) in parser._source_lines_cache
+
+    def test_castxml_converter_parse_functions_reads_operator_line_fallback(self, tmp_path) -> None:
+        source = tmp_path / "v2.h"
+        source.write_text(
+            "struct Token {\n"
+            "    explicit\n"
+            "    operator int() const;\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        root = Element("GCC_XML")
+        root.append(Element("File", id="_1", name=str(source)))
+        root.append(Element("FundamentalType", id="_2", name="int"))
+        root.append(
+            Element(
+                "Converter",
+                id="_3",
+                file="_1",
+                line="3",
+                returns="_2",
+                mangled="_ZNK5TokencviEv",
+            )
+        )
+        parser = _CastxmlParser(root, exported_dynamic={"_ZNK5TokencviEv"}, exported_static=set())
+
+        funcs = parser.parse_functions()
+
+        assert len(funcs) == 1
+        assert funcs[0].name == "operator int"
+        assert funcs[0].is_explicit is True
 
     def test_castxml_converter_fallback_preserves_unknown_on_missing_source(self) -> None:
         root = Element("GCC_XML")

--- a/tests/test_explicit_ctor.py
+++ b/tests/test_explicit_ctor.py
@@ -131,3 +131,7 @@ class TestExplicitCtor:
         loc_el = Element("Location", file="_1", line="2")
 
         assert parser._source_line_has_explicit(loc_el) is True
+
+        declaration_el = Element("Converter", file="_1", line="2")
+        assert parser._source_line_has_explicit(None, declaration_el) is True
+        assert str(source) in parser._source_lines_cache

--- a/tests/test_explicit_ctor.py
+++ b/tests/test_explicit_ctor.py
@@ -135,3 +135,15 @@ class TestExplicitCtor:
         declaration_el = Element("Converter", file="_1", line="2")
         assert parser._source_line_has_explicit(None, declaration_el) is True
         assert str(source) in parser._source_lines_cache
+
+    def test_castxml_converter_fallback_preserves_unknown_on_missing_source(self) -> None:
+        root = Element("GCC_XML")
+        root.append(Element("File", id="_1", name=""))
+        root.append(Element("File", id="_2", name="/does/not/exist.h"))
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+
+        assert parser._source_line_has_explicit(None) is None
+        assert parser._source_line_has_explicit(Element("Location", file="_missing", line="1")) is None
+        assert parser._source_line_has_explicit(Element("Location", file="_1", line="1")) is None
+        assert parser._source_line_has_explicit(Element("Location", file="_2", line="not-int")) is None
+        assert parser._source_line_has_explicit(Element("Location", file="_2", line="1")) is None

--- a/tests/test_explicit_ctor.py
+++ b/tests/test_explicit_ctor.py
@@ -4,8 +4,11 @@ Synthetic snapshots — no compiler needed. Exercises the `is_explicit` flag
 captured from DW_AT_explicit and the diff logic in diff_symbols.py.
 """
 
+from xml.etree.ElementTree import Element
+
 from abicheck.checker import compare
 from abicheck.checker_policy import API_BREAK_KINDS, RISK_KINDS, ChangeKind, Verdict
+from abicheck.dumper import _CastxmlParser
 from abicheck.model import AbiSnapshot, Function, Param, Visibility
 
 
@@ -111,3 +114,20 @@ class TestExplicitCtor:
         }
         snap = snapshot_from_dict(d)
         assert snap.functions[0].is_explicit is None
+
+    def test_castxml_converter_fallback_reads_multiline_explicit_operator(self, tmp_path) -> None:
+        source = tmp_path / "v2.h"
+        source.write_text(
+            "struct Token {\n"
+            "    explicit\n"
+            "    operator int() const;\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        root = Element("GCC_XML")
+        file_el = Element("File", id="_1", name=str(source))
+        root.append(file_el)
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        loc_el = Element("Location", file="_1", line="2")
+
+        assert parser._source_line_has_explicit(loc_el) is True


### PR DESCRIPTION
## Summary
- add Real Failure Demo sections across the remaining example case READMEs
- regenerate docs/examples from the example README sources
- include the current example renumbering/registry updates needed for the 95-case catalog
- fix case92_empty_tag_gained_state app namespace calls so the demo target builds

## Validation
- cmake --build /tmp/abicheck-examples-build -j2
- PYTHONPATH=. python tests/validate_examples.py --json
- python scripts/gen_examples_docs.py --check
- PYTHONPATH=. pytest -q tests/test_examples_docs.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of C++ explicit constructors and conversion operators by adding a source-code fallback when castxml metadata is incomplete.

* **Documentation**
  * Added "Real Failure Demo" sections throughout example documentation showing reproducible build and runtime failures.
  * Updated all documentation links to use repository-relative paths for better offline reference and local browsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napetrov/abicheck/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->