### PR TITLE
refactor(diff): extract bool_transition + diff_by_key detector helpers (Tier 1)

### DIFF
--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable building blocks for diff detectors.
+
+Detectors repeat two structural patterns:
+
+* **Boolean attribute transitions** — "flag went from off→on / on→off"
+  (e.g. ``noexcept`` added/removed, ``virtual`` added/removed). Each site
+  used to hand-roll an ``if/elif`` pair around two near-identical
+  ``Change`` constructions. :func:`bool_transition` collapses that into a
+  single declarative call while preserving the bespoke wording and the
+  tri-state (``None`` means "not recorded in this snapshot") skip rule.
+
+* **Keyed map diffs** — "what was removed / added / present on both sides"
+  over two ``{key: record}`` maps. :func:`diff_by_key` factors out the
+  removed/added/common scaffold so a detector only supplies the per-bucket
+  logic.
+
+These helpers are deliberately small and behavior-preserving: they encode
+the shape that was already duplicated across the ``diff_*`` modules, not
+new policy.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from typing import TypeVar
+
+from .checker_policy import ChangeKind
+from .checker_types import Change
+
+K = TypeVar("K")
+V = TypeVar("V")
+W = TypeVar("W")
+
+# A (ChangeKind, description) pair describing one direction of a transition.
+TransitionSpec = tuple[ChangeKind, str]
+
+
+def bool_transition(
+    old_val: bool | None,
+    new_val: bool | None,
+    symbol: str,
+    *,
+    added: TransitionSpec | None = None,
+    removed: TransitionSpec | None = None,
+    added_values: tuple[str | None, str | None] = (None, None),
+    removed_values: tuple[str | None, str | None] = (None, None),
+    skip_none: bool = False,
+) -> list[Change]:
+    """Emit a :class:`Change` for a boolean attribute transition.
+
+    ``added`` fires on a ``False → True`` transition, ``removed`` on
+    ``True → False``. Each is an optional ``(kind, description)`` pair; a
+    direction with no spec is simply not reported.
+
+    ``added_values`` / ``removed_values`` supply the ``(old_value,
+    new_value)`` strings recorded on the emitted change for that direction
+    (defaulting to ``(None, None)`` for flags whose before/after wording is
+    carried entirely by the description).
+
+    When ``skip_none`` is set, a ``None`` on *either* side suppresses
+    emission. This models tri-state attributes (e.g. ``is_explicit``,
+    ``is_hidden_friend``) where ``None`` means the value was not recorded in
+    one snapshot — typically an older snapshot predating the field — and
+    must not be mistaken for ``False``.
+    """
+    if skip_none and (old_val is None or new_val is None):
+        return []
+    if not old_val and new_val and added is not None:
+        kind, description = added
+        ov, nv = added_values
+        return [Change(kind=kind, symbol=symbol, description=description, old_value=ov, new_value=nv)]
+    if old_val and not new_val and removed is not None:
+        kind, description = removed
+        ov, nv = removed_values
+        return [Change(kind=kind, symbol=symbol, description=description, old_value=ov, new_value=nv)]
+    return []
+
+
+def diff_by_key(
+    old_map: Mapping[K, V],
+    new_map: Mapping[K, W],
+    *,
+    on_removed: Callable[[K, V], Iterable[Change]] | None = None,
+    on_added: Callable[[K, W], Iterable[Change]] | None = None,
+    on_common: Callable[[K, V, W], Iterable[Change]] | None = None,
+) -> list[Change]:
+    """Diff two keyed maps, dispatching to per-bucket callbacks.
+
+    For every key present only in ``old_map`` ``on_removed(key, old)`` is
+    invoked; for keys only in ``new_map`` ``on_added(key, new)``; for keys
+    in both ``on_common(key, old, new)``. Each callback returns an iterable
+    of :class:`Change` (or nothing); omitted callbacks skip that bucket.
+
+    Removed/common keys are visited in ``old_map`` iteration order and
+    added keys in ``new_map`` order, matching the hand-written loops this
+    replaces so change ordering is unchanged.
+    """
+    changes: list[Change] = []
+    for key, old_val in old_map.items():
+        new_val = new_map.get(key)
+        if new_val is None and key not in new_map:
+            if on_removed is not None:
+                changes.extend(on_removed(key, old_val))
+        elif on_common is not None:
+            # ``new_val`` is the value for ``key``; the ``is None`` branch
+            # above only triggers when the key is genuinely absent.
+            changes.extend(on_common(key, old_val, new_map[key]))
+    for key, new_val in new_map.items():
+        if key not in old_map and on_added is not None:
+            changes.extend(on_added(key, new_val))
+    return changes

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -35,7 +35,7 @@ new policy.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 from .checker_policy import ChangeKind
 from .checker_types import Change
@@ -43,6 +43,11 @@ from .checker_types import Change
 K = TypeVar("K")
 V = TypeVar("V")
 W = TypeVar("W")
+
+# Sentinel distinguishing "key absent" from "key present with value None".
+# Typed as Any so it can stand in for a ``W`` in the get() default without
+# upsetting the type checker.
+_MISSING: Any = object()
 
 # A (ChangeKind, description) pair describing one direction of a transition.
 TransitionSpec = tuple[ChangeKind, str]
@@ -110,14 +115,12 @@ def diff_by_key(
     """
     changes: list[Change] = []
     for key, old_val in old_map.items():
-        new_val = new_map.get(key)
-        if new_val is None and key not in new_map:
+        new_val = new_map.get(key, _MISSING)
+        if new_val is _MISSING:
             if on_removed is not None:
                 changes.extend(on_removed(key, old_val))
         elif on_common is not None:
-            # ``new_val`` is the value for ``key``; the ``is None`` branch
-            # above only triggers when the key is genuinely absent.
-            changes.extend(on_common(key, old_val, new_map[key]))
+            changes.extend(on_common(key, old_val, cast(W, new_val)))
     for key, new_val in new_map.items():
         if key not in old_map and on_added is not None:
             changes.extend(on_added(key, new_val))

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -26,6 +26,7 @@ from .binary_fingerprint import (
 from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
+from .diff_helpers import bool_transition, diff_by_key
 from .elf_metadata import SymbolType
 from .model import (
     AbiSnapshot,
@@ -155,36 +156,20 @@ def _check_linkage_change(mangled: str, f_old: Function, f_new: Function) -> lis
 
 def _check_noexcept_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
     """Emit a change if the noexcept specifier was added or removed."""
-    if f_old.is_noexcept and not f_new.is_noexcept:
-        return [Change(
-            kind=ChangeKind.FUNC_NOEXCEPT_REMOVED,
-            symbol=mangled,
-            description=f"noexcept specifier removed: {f_old.name}",
-        )]
-    if not f_old.is_noexcept and f_new.is_noexcept:
-        return [Change(
-            kind=ChangeKind.FUNC_NOEXCEPT_ADDED,
-            symbol=mangled,
-            description=f"noexcept specifier added: {f_old.name}",
-        )]
-    return []
+    return bool_transition(
+        f_old.is_noexcept, f_new.is_noexcept, mangled,
+        added=(ChangeKind.FUNC_NOEXCEPT_ADDED, f"noexcept specifier added: {f_old.name}"),
+        removed=(ChangeKind.FUNC_NOEXCEPT_REMOVED, f"noexcept specifier removed: {f_old.name}"),
+    )
 
 
 def _check_virtual_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
     """Emit a change if the virtual specifier was added or removed."""
-    if not f_old.is_virtual and f_new.is_virtual:
-        return [Change(
-            kind=ChangeKind.FUNC_VIRTUAL_ADDED,
-            symbol=mangled,
-            description=f"Function became virtual: {f_old.name}",
-        )]
-    if f_old.is_virtual and not f_new.is_virtual:
-        return [Change(
-            kind=ChangeKind.FUNC_VIRTUAL_REMOVED,
-            symbol=mangled,
-            description=f"Function is no longer virtual: {f_old.name}",
-        )]
-    return []
+    return bool_transition(
+        f_old.is_virtual, f_new.is_virtual, mangled,
+        added=(ChangeKind.FUNC_VIRTUAL_ADDED, f"Function became virtual: {f_old.name}"),
+        removed=(ChangeKind.FUNC_VIRTUAL_REMOVED, f"Function is no longer virtual: {f_old.name}"),
+    )
 
 
 def _check_hidden_friend_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
@@ -200,25 +185,14 @@ def _check_hidden_friend_change(mangled: str, f_old: Function, f_new: Function) 
     are picked up by ``_check_hidden_friend_additions_removals``
     below by matching on (name, params) rather than mangled name.
     """
-    if f_old.is_hidden_friend is None or f_new.is_hidden_friend is None:
-        return []
-    if not f_old.is_hidden_friend and f_new.is_hidden_friend:
-        return [Change(
-            kind=ChangeKind.HIDDEN_FRIEND_ADDED,
-            symbol=mangled,
-            description=f"Function became an in-class friend declaration: {f_old.name}",
-            old_value="non-friend",
-            new_value="hidden friend",
-        )]
-    if f_old.is_hidden_friend and not f_new.is_hidden_friend:
-        return [Change(
-            kind=ChangeKind.HIDDEN_FRIEND_REMOVED,
-            symbol=mangled,
-            description=f"Function is no longer an in-class friend declaration: {f_old.name}",
-            old_value="hidden friend",
-            new_value="non-friend",
-        )]
-    return []
+    return bool_transition(
+        f_old.is_hidden_friend, f_new.is_hidden_friend, mangled,
+        skip_none=True,
+        added=(ChangeKind.HIDDEN_FRIEND_ADDED, f"Function became an in-class friend declaration: {f_old.name}"),
+        added_values=("non-friend", "hidden friend"),
+        removed=(ChangeKind.HIDDEN_FRIEND_REMOVED, f"Function is no longer an in-class friend declaration: {f_old.name}"),
+        removed_values=("hidden friend", "non-friend"),
+    )
 
 
 def _check_explicit_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
@@ -230,25 +204,14 @@ def _check_explicit_change(mangled: str, f_old: Function, f_new: Function) -> li
     N/A. Skipping in that case avoids false API_BREAK findings produced
     purely by snapshot schema evolution.
     """
-    if f_old.is_explicit is None or f_new.is_explicit is None:
-        return []
-    if not f_old.is_explicit and f_new.is_explicit:
-        return [Change(
-            kind=ChangeKind.CTOR_EXPLICIT_ADDED,
-            symbol=mangled,
-            description=f"Constructor/conversion gained `explicit` specifier: {f_old.name}",
-            old_value="implicit",
-            new_value="explicit",
-        )]
-    if f_old.is_explicit and not f_new.is_explicit:
-        return [Change(
-            kind=ChangeKind.CTOR_EXPLICIT_REMOVED,
-            symbol=mangled,
-            description=f"Constructor/conversion lost `explicit` specifier: {f_old.name}",
-            old_value="explicit",
-            new_value="implicit",
-        )]
-    return []
+    return bool_transition(
+        f_old.is_explicit, f_new.is_explicit, mangled,
+        skip_none=True,
+        added=(ChangeKind.CTOR_EXPLICIT_ADDED, f"Constructor/conversion gained `explicit` specifier: {f_old.name}"),
+        added_values=("implicit", "explicit"),
+        removed=(ChangeKind.CTOR_EXPLICIT_REMOVED, f"Constructor/conversion lost `explicit` specifier: {f_old.name}"),
+        removed_values=("explicit", "implicit"),
+    )
 
 
 def _check_function_signature(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
@@ -457,53 +420,42 @@ def _diff_inline_hidden_friends(
     return changes
 
 
+def _check_variable(mangled: str, v_old: Variable, v_new: Variable) -> list[Change]:
+    """Compare a matched pair of public variables."""
+    if canonicalize_type_name(v_old.type) != canonicalize_type_name(v_new.type):
+        return [Change(
+            kind=ChangeKind.VAR_TYPE_CHANGED,
+            symbol=mangled,
+            description=f"Variable type changed: {v_old.name}",
+            old_value=v_old.type, new_value=v_new.type,
+        )]
+    # const-qualification transitions only matter when the type is unchanged.
+    return bool_transition(
+        v_old.is_const, v_new.is_const, mangled,
+        added=(ChangeKind.VAR_BECAME_CONST, f"Variable became const-qualified: {v_old.name} (writes now → SIGSEGV)"),
+        added_values=("non-const", "const"),
+        removed=(ChangeKind.VAR_LOST_CONST, f"Variable lost const qualifier: {v_old.name} (ODR / inlining break)"),
+        removed_values=("const", "non-const"),
+    )
+
+
 @registry.detector("variables")
 def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
-    changes: list[Change] = []
-    old_map = _public_variables(old)
-    new_map = _public_variables(new)
-
-    for mangled, v_old in old_map.items():
-        if mangled not in new_map:
-            changes.append(Change(
-                kind=ChangeKind.VAR_REMOVED,
-                symbol=mangled,
-                description=f"Public variable removed: {v_old.name}",
-            ))
-        elif canonicalize_type_name(old_map[mangled].type) != canonicalize_type_name(new_map[mangled].type):
-            changes.append(Change(
-                kind=ChangeKind.VAR_TYPE_CHANGED,
-                symbol=mangled,
-                description=f"Variable type changed: {v_old.name}",
-                old_value=v_old.type, new_value=new_map[mangled].type,
-            ))
-        else:
-            v_new = new_map[mangled]
-            if not v_old.is_const and v_new.is_const:
-                changes.append(Change(
-                    kind=ChangeKind.VAR_BECAME_CONST,
-                    symbol=mangled,
-                    description=f"Variable became const-qualified: {v_old.name} (writes now → SIGSEGV)",
-                    old_value="non-const",
-                    new_value="const",
-                ))
-            elif v_old.is_const and not v_new.is_const:
-                changes.append(Change(
-                    kind=ChangeKind.VAR_LOST_CONST,
-                    symbol=mangled,
-                    description=f"Variable lost const qualifier: {v_old.name} (ODR / inlining break)",
-                    old_value="const",
-                    new_value="non-const",
-                ))
-
-    for mangled, v_new in new_map.items():
-        if mangled not in old_map:
-            changes.append(Change(
-                kind=ChangeKind.VAR_ADDED,
-                symbol=mangled,
-                description=f"New public variable: {v_new.name}",
-            ))
-    return changes
+    return diff_by_key(
+        _public_variables(old),
+        _public_variables(new),
+        on_removed=lambda mangled, v_old: [Change(
+            kind=ChangeKind.VAR_REMOVED,
+            symbol=mangled,
+            description=f"Public variable removed: {v_old.name}",
+        )],
+        on_added=lambda mangled, v_new: [Change(
+            kind=ChangeKind.VAR_ADDED,
+            symbol=mangled,
+            description=f"New public variable: {v_new.name}",
+        )],
+        on_common=_check_variable,
+    )
 
 
 @registry.detector("param_defaults")

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -439,21 +439,29 @@ def _check_variable(mangled: str, v_old: Variable, v_new: Variable) -> list[Chan
     )
 
 
+def _var_removed(mangled: str, v_old: Variable) -> list[Change]:
+    return [Change(
+        kind=ChangeKind.VAR_REMOVED,
+        symbol=mangled,
+        description=f"Public variable removed: {v_old.name}",
+    )]
+
+
+def _var_added(mangled: str, v_new: Variable) -> list[Change]:
+    return [Change(
+        kind=ChangeKind.VAR_ADDED,
+        symbol=mangled,
+        description=f"New public variable: {v_new.name}",
+    )]
+
+
 @registry.detector("variables")
 def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     return diff_by_key(
         _public_variables(old),
         _public_variables(new),
-        on_removed=lambda mangled, v_old: [Change(
-            kind=ChangeKind.VAR_REMOVED,
-            symbol=mangled,
-            description=f"Public variable removed: {v_old.name}",
-        )],
-        on_added=lambda mangled, v_new: [Change(
-            kind=ChangeKind.VAR_ADDED,
-            symbol=mangled,
-            description=f"New public variable: {v_new.name}",
-        )],
+        on_removed=_var_removed,
+        on_added=_var_added,
         on_common=_check_variable,
     )
 

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -89,6 +89,18 @@ class TestDiffByKey:
         out = diff_by_key(old, new, on_added=lambda k, v: [self._change(k)])
         assert [c.symbol for c in out] == ["b"]
 
+    def test_common_key_with_no_on_common_is_skipped(self) -> None:
+        # A key present in both maps but with on_common omitted must fall
+        # through silently (covers the elif-not-taken branch).
+        old = {"a": 1, "b": 2}
+        new = {"a": 1, "c": 3}
+        out = diff_by_key(
+            old, new,
+            on_removed=lambda k, v: [self._change(f"removed:{k}")],
+            on_added=lambda k, v: [self._change(f"added:{k}")],
+        )
+        assert [c.symbol for c in out] == ["removed:b", "added:c"]
+
     def test_preserves_map_iteration_order(self) -> None:
         old = {"z": 1, "y": 1, "x": 1}
         new = {"z": 1, "y": 1, "x": 1}

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the reusable diff building blocks in ``diff_helpers``."""
+from __future__ import annotations
+
+from abicheck.checker_policy import ChangeKind
+from abicheck.checker_types import Change
+from abicheck.diff_helpers import bool_transition, diff_by_key
+
+ADDED = (ChangeKind.FUNC_VIRTUAL_ADDED, "added")
+REMOVED = (ChangeKind.FUNC_VIRTUAL_REMOVED, "removed")
+
+
+class TestBoolTransition:
+    def test_false_to_true_emits_added(self) -> None:
+        out = bool_transition(False, True, "sym", added=ADDED, removed=REMOVED)
+        assert [c.kind for c in out] == [ChangeKind.FUNC_VIRTUAL_ADDED]
+        assert out[0].symbol == "sym"
+        assert out[0].description == "added"
+
+    def test_true_to_false_emits_removed(self) -> None:
+        out = bool_transition(True, False, "sym", added=ADDED, removed=REMOVED)
+        assert [c.kind for c in out] == [ChangeKind.FUNC_VIRTUAL_REMOVED]
+
+    def test_no_change_emits_nothing(self) -> None:
+        assert bool_transition(True, True, "sym", added=ADDED, removed=REMOVED) == []
+        assert bool_transition(False, False, "sym", added=ADDED, removed=REMOVED) == []
+
+    def test_direction_without_spec_is_silent(self) -> None:
+        # Only `added` registered: a removal transition produces nothing.
+        assert bool_transition(True, False, "sym", added=ADDED) == []
+        assert bool_transition(False, True, "sym", added=ADDED)[0].kind == ADDED[0]
+
+    def test_values_are_carried_through(self) -> None:
+        out = bool_transition(
+            False, True, "sym",
+            added=ADDED,
+            added_values=("non-virtual", "virtual"),
+        )
+        assert out[0].old_value == "non-virtual"
+        assert out[0].new_value == "virtual"
+
+    def test_default_values_are_none(self) -> None:
+        out = bool_transition(False, True, "sym", added=ADDED)
+        assert out[0].old_value is None
+        assert out[0].new_value is None
+
+    def test_skip_none_suppresses_on_either_side(self) -> None:
+        assert bool_transition(None, True, "sym", added=ADDED, skip_none=True) == []
+        assert bool_transition(False, None, "sym", added=ADDED, skip_none=True) == []
+        assert bool_transition(None, None, "sym", added=ADDED, skip_none=True) == []
+
+    def test_without_skip_none_treats_none_as_falsey(self) -> None:
+        # None on the old side behaves like False -> True transition fires.
+        out = bool_transition(None, True, "sym", added=ADDED)
+        assert out[0].kind == ADDED[0]
+
+
+class TestDiffByKey:
+    def _change(self, key: str) -> Change:
+        return Change(kind=ChangeKind.VAR_ADDED, symbol=key, description=key)
+
+    def test_dispatches_each_bucket(self) -> None:
+        old = {"a": 1, "b": 2}
+        new = {"b": 2, "c": 3}
+        out = diff_by_key(
+            old, new,
+            on_removed=lambda k, v: [self._change(f"removed:{k}")],
+            on_added=lambda k, v: [self._change(f"added:{k}")],
+            on_common=lambda k, o, n: [self._change(f"common:{k}")],
+        )
+        assert [c.symbol for c in out] == ["removed:a", "common:b", "added:c"]
+
+    def test_omitted_callbacks_skip_bucket(self) -> None:
+        old = {"a": 1}
+        new = {"b": 2}
+        out = diff_by_key(old, new, on_added=lambda k, v: [self._change(k)])
+        assert [c.symbol for c in out] == ["b"]
+
+    def test_preserves_map_iteration_order(self) -> None:
+        old = {"z": 1, "y": 1, "x": 1}
+        new = {"z": 1, "y": 1, "x": 1}
+        out = diff_by_key(old, new, on_common=lambda k, o, n: [self._change(k)])
+        assert [c.symbol for c in out] == ["z", "y", "x"]
+
+    def test_callback_returning_empty_is_fine(self) -> None:
+        old = {"a": 1}
+        new = {"a": 1}
+        out = diff_by_key(old, new, on_common=lambda k, o, n: [])
+        assert out == []
+
+    def test_falsey_value_present_key_routes_to_common(self) -> None:
+        # A key whose value is falsey (0) must still count as "present" and
+        # route to on_common, not on_removed.
+        old = {"a": 0}
+        new = {"a": 0}
+        out = diff_by_key(
+            old, new,
+            on_removed=lambda k, v: [self._change(f"removed:{k}")],
+            on_common=lambda k, o, n: [self._change(f"common:{k}")],
+        )
+        assert [c.symbol for c in out] == ["common:a"]

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -52,6 +52,15 @@ class TestBoolTransition:
         assert out[0].old_value == "non-virtual"
         assert out[0].new_value == "virtual"
 
+    def test_removed_values_are_carried_through(self) -> None:
+        out = bool_transition(
+            True, False, "sym",
+            removed=REMOVED,
+            removed_values=("virtual", "non-virtual"),
+        )
+        assert out[0].old_value == "virtual"
+        assert out[0].new_value == "non-virtual"
+
     def test_default_values_are_none(self) -> None:
         out = bool_transition(False, True, "sym", added=ADDED)
         assert out[0].old_value is None


### PR DESCRIPTION
## What & why

Follow-up to an architecture evaluation of the detection logic. The
finding: the *top-level* design is already sound (decorator-based detector
registry + single-declaration `ChangeKind` registry + set-based verdicts).
The real smell the "tree of if cases" impression points at is **leaf-level
boilerplate duplication** inside individual detectors — not a fragile
dispatch tree.

This is **Tier 1**: extract the two repeated shapes into small,
behavior-preserving building blocks. No policy or classification change.

## Changes

New module `abicheck/diff_helpers.py`:

- **`bool_transition(...)`** — collapses the hand-rolled `if/elif` pairs
  around near-identical `Change` constructions (a flag going off→on / on→off).
  Preserves each site's bespoke wording and the tri-state rule (`None` =
  "not recorded in this snapshot") via `skip_none`. Applied to the
  `noexcept`, `virtual`, hidden-friend, `explicit`, and variable const-ness
  transitions in `diff_symbols.py`.
- **`diff_by_key(...)`** — factors out the removed / added / common map-diff
  scaffold so a detector only supplies per-bucket callbacks. The
  `variables` detector now uses it, with matched-pair logic moved to a small
  `_check_variable` helper. Iteration order is unchanged (removed/common in
  old-map order, added in new-map order), so emitted change ordering is
  identical.

## Verification

- Full fast suite: **6370 passed**, 16 skipped (`pytest -m "not integration
  and not libabigail and not abicc and not slow and not golden"`).
- New `tests/test_diff_helpers.py`: **13 tests** covering both helpers,
  including the tri-state skip and the falsey-value-as-present-key edge case.
- `ruff check`, `mypy abicheck/`, and `scripts/check_ai_readiness.py` all
  clean (0 errors / 0 warnings).

## Scope / non-goals

Deliberately stops at Tier 1. The map-diff scaffold can later extend to the
`functions` and `types` detectors, and a per-record field-comparator table
was considered but left out to avoid trading readability for uniformity.

https://claude.ai/code/session_01XMfP2fSXzyREMoZFUuRJ6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMfP2fSXzyREMoZFUuRJ6S)_