### PR TITLE
feat(cli): add `probe` command group for build-config matrix harness (#250)

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1488,6 +1488,7 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
     cli_baseline,  # noqa: F401  — registers baseline
     cli_compare_release,  # noqa: F401  — registers compare-release
     cli_debian_symbols,  # noqa: F401  — registers debian-symbols
+    cli_probe,  # noqa: F401  — registers probe (run, compare)
     cli_stack,  # noqa: F401  — registers deps, stack-check
     cli_suggest,  # noqa: F401  — registers suggest-suppressions
 )

--- a/abicheck/cli_probe.py
+++ b/abicheck/cli_probe.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI — ``probe`` command group (build-configuration matrix harness).
+
+Wraps the library API in :mod:`abicheck.probe_harness` and
+:mod:`abicheck.diff_build_config` so the matrix-aware change kinds
+(``API_DEPENDS_ON_CONSUMER_ENV``, ``CXX_STANDARD_FLOOR_RAISED``,
+``BEHAVIOURAL_DEFAULT_CHANGED``) are reachable from the command line and
+flow through the existing reporter / SARIF / JUnit paths.
+
+Two subcommands:
+
+* ``abicheck probe run SPEC --library L --version V --out matrix.json`` —
+  compile every (configuration × probe) declared in the YAML manifest and
+  emit a :class:`~abicheck.probe_harness.MatrixSnapshot` as JSON.
+* ``abicheck probe compare OLD.json NEW.json`` — diff two matrix
+  snapshots and render the findings (json / markdown / sarif / junit).
+
+Split out of :mod:`abicheck.cli` to keep that module under the
+AI-readiness file-size limit. Imported for side-effect at the bottom of
+:mod:`abicheck.cli` so the ``@main.group("probe")`` decorator runs.
+
+The issue (#250) sketched ``abicheck compare --matrix old new``; this
+lands the same capability under a dedicated ``probe`` group instead,
+which keeps the large ``compare`` command untouched and groups the
+run/compare halves of the harness together.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from .checker_policy import compute_verdict
+from .checker_types import DiffResult
+from .cli import _write_or_echo, main
+from .diff_build_config import diff_matrix
+from .probe_harness import (
+    load_matrix_snapshot,
+    load_probe_spec,
+    run_probe_matrix,
+    write_matrix_snapshot,
+)
+
+# Verdict → process exit code, matching the legacy ``compare`` mapping
+# documented in CLAUDE.md (0 = compatible, 2 = source break, 4 = ABI break).
+_VERDICT_EXIT = {
+    "BREAKING": 4,
+    "API_BREAK": 2,
+}
+
+
+@main.group("probe")
+def probe_group() -> None:
+    """Build-configuration matrix harness (compile probes, diff matrices)."""
+
+
+@probe_group.command("run")
+@click.argument("spec", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--library",
+    "library_name",
+    required=True,
+    help="Library name to stamp into the matrix snapshot.",
+)
+@click.option(
+    "--version", required=True, help="Version label to stamp into the matrix snapshot."
+)
+@click.option(
+    "-o",
+    "--out",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the MatrixSnapshot JSON here (default: stdout).",
+)
+@click.option(
+    "--work-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory for generated .cpp/.o files (default: a temp dir).",
+)
+@click.option(
+    "--no-snapshot",
+    is_flag=True,
+    default=False,
+    help="Compile probes but skip the dumper (routing check only).",
+)
+def probe_run(
+    spec: Path,
+    library_name: str,
+    version: str,
+    out: Path | None,
+    work_dir: Path | None,
+    no_snapshot: bool,
+) -> None:
+    """Compile every (configuration × probe) in SPEC into a MatrixSnapshot."""
+    probe_spec = load_probe_spec(spec)
+    matrix = run_probe_matrix(
+        probe_spec,
+        library_name=library_name,
+        version=version,
+        work_dir=work_dir,
+        snapshot=not no_snapshot,
+    )
+
+    failures = [r for r in matrix.results if r.error]
+    summary = (
+        f"probe run: {len(probe_spec.configurations)} configuration(s) × "
+        f"{len(probe_spec.probes)} probe(s) = {len(matrix.results)} result(s), "
+        f"{len(failures)} failure(s)"
+    )
+    click.echo(summary, err=True)
+    for r in failures:
+        click.echo(f"  ! {r.configuration_id} / {r.probe_id}: {r.error}", err=True)
+
+    if out is not None:
+        write_matrix_snapshot(matrix, out)
+        click.echo(f"wrote {out}", err=True)
+    else:
+        click.echo(matrix.to_json())
+
+
+@probe_group.command("compare")
+@click.argument(
+    "old_matrix", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.argument(
+    "new_matrix", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "-f",
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "markdown", "sarif", "junit"]),
+    default="json",
+    show_default=True,
+    help="Output format for the matrix-diff findings.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the report here (default: stdout).",
+)
+@click.option(
+    "--policy",
+    default="strict_abi",
+    show_default=True,
+    help="Built-in policy profile for verdict classification.",
+)
+def probe_compare(
+    old_matrix: Path,
+    new_matrix: Path,
+    fmt: str,
+    output: Path | None,
+    policy: str,
+) -> None:
+    """Diff two MatrixSnapshots and report build-configuration findings.
+
+    Exit code follows the legacy ``compare`` mapping: 0 = compatible,
+    2 = source break, 4 = ABI break.
+    """
+    old = load_matrix_snapshot(old_matrix)
+    new = load_matrix_snapshot(new_matrix)
+    findings = diff_matrix(old, new)
+
+    result = DiffResult(
+        old_version=old.version,
+        new_version=new.version,
+        library=new.library or old.library,
+        changes=findings,
+        verdict=compute_verdict(findings, policy=policy),
+        policy=policy,
+    )
+
+    if fmt == "json":
+        from .reporter import to_json
+
+        text = to_json(result)
+    elif fmt == "markdown":
+        from .reporter import to_markdown
+
+        text = to_markdown(result)
+    elif fmt == "sarif":
+        from .sarif import to_sarif_str
+
+        text = to_sarif_str(result)
+    else:  # junit
+        from .junit_report import to_junit_xml
+
+        text = to_junit_xml(result)
+
+    _write_or_echo(output, text)
+
+    raise SystemExit(_VERDICT_EXIT.get(result.verdict.value, 0))

--- a/abicheck/cli_probe.py
+++ b/abicheck/cli_probe.py
@@ -62,6 +62,12 @@ _VERDICT_EXIT = {
     "API_BREAK": 2,
 }
 
+# Exit code for a comparison that could not be trusted because one of the
+# input matrices contained failed probe results (e.g. a missing compiler).
+# Distinct from the verdict codes so callers can tell "incomplete input"
+# apart from "compatible".
+_EXIT_INCOMPLETE_MATRIX = 3
+
 
 @main.group("probe")
 def probe_group() -> None:
@@ -162,20 +168,56 @@ def probe_run(
     show_default=True,
     help="Built-in policy profile for verdict classification.",
 )
+@click.option(
+    "--allow-failures",
+    is_flag=True,
+    default=False,
+    help="Diff even when an input matrix contains failed probe results "
+    "(by default the comparison is rejected as untrustworthy).",
+)
 def probe_compare(
     old_matrix: Path,
     new_matrix: Path,
     fmt: str,
     output: Path | None,
     policy: str,
+    allow_failures: bool,
 ) -> None:
     """Diff two MatrixSnapshots and report build-configuration findings.
 
     Exit code follows the legacy ``compare`` mapping: 0 = compatible,
-    2 = source break, 4 = ABI break.
+    2 = source break, 4 = ABI break. A third code (3) is returned when an
+    input matrix contains failed probe results and ``--allow-failures``
+    was not given — the env-dependence detector only sees successful
+    snapshots, so diffing an incomplete matrix could silently report
+    "compatible".
     """
     old = load_matrix_snapshot(old_matrix)
     new = load_matrix_snapshot(new_matrix)
+
+    # Guard against a false "compatible" verdict over an incomplete
+    # matrix. ``diff_matrix`` skips results with no snapshot, so a matrix
+    # whose probes all failed to compile (e.g. a missing compiler) would
+    # diff clean and exit 0 with high confidence. Refuse by default.
+    old_failed = [r for r in old.results if r.error]
+    new_failed = [r for r in new.results if r.error]
+    if (old_failed or new_failed) and not allow_failures:
+        for label, failed in (("old", old_failed), ("new", new_failed)):
+            for r in failed:
+                click.echo(
+                    f"  ! {label} {r.configuration_id} / {r.probe_id}: {r.error}",
+                    err=True,
+                )
+        click.echo(
+            f"probe compare: {len(old_failed)} failed result(s) in old matrix, "
+            f"{len(new_failed)} in new matrix. Refusing to diff an incomplete "
+            f"matrix — a clean result would be misleading. Re-run `probe run` "
+            f"with a working toolchain, or pass --allow-failures to diff the "
+            f"successful subset.",
+            err=True,
+        )
+        raise SystemExit(_EXIT_INCOMPLETE_MATRIX)
+
     findings = diff_matrix(old, new)
 
     result = DiffResult(
@@ -186,6 +228,19 @@ def probe_compare(
         verdict=compute_verdict(findings, policy=policy),
         policy=policy,
     )
+
+    # When proceeding over a partial matrix (--allow-failures), the
+    # env-dependence findings cover only the successful subset, so flag
+    # the reduced trust rather than letting the report claim high
+    # confidence.
+    if old_failed or new_failed:
+        from .checker_policy import Confidence
+
+        result.confidence = Confidence.LOW
+        result.coverage_warnings = [
+            f"{len(old_failed) + len(new_failed)} probe result(s) failed; "
+            f"env-dependence findings cover only the successful subset."
+        ]
 
     if fmt == "json":
         from .reporter import to_json

--- a/docs/user-guide/probe-harness.md
+++ b/docs/user-guide/probe-harness.md
@@ -1,0 +1,106 @@
+# Probe Harness (build-configuration matrix)
+
+Some ABI hazards are invisible to a single-binary comparison because the
+library's public surface depends on **how the consumer builds against
+it** — the language standard, the active backend macro, the compiler.
+oneDPL is the canonical example: the same header tree exposes different
+declarations under `ONEDPL_USE_TBB_BACKEND` vs `ONEDPL_USE_DPCPP_BACKEND`,
+and raises its C++ standard floor between releases.
+
+The probe harness compiles a small matrix of *consumer* translation
+units (probes) under several *configurations* and diffs the resulting
+matrices across two versions. It surfaces three change kinds:
+
+| Change kind | Meaning |
+|---|---|
+| `API_DEPENDS_ON_CONSUMER_ENV` | A public declaration exists under some configurations but not others, *within a single version*. The public API depends on the consumer's toolchain. |
+| `CXX_STANDARD_FLOOR_RAISED` | The minimum C++ standard across configurations rose between releases. Consumers still on the old standard get a degraded API. |
+| `BEHAVIOURAL_DEFAULT_CHANGED` | A value in the manifest's `defaults:` section changed — source compiles unchanged, runtime behaviour silently differs. |
+
+## Manifest
+
+A probe spec is a YAML file with `configurations`, `probes`, and an
+optional `defaults` map. See
+[`examples/probes/onedpl.yaml`](https://github.com/napetrov/abicheck/blob/main/examples/probes/onedpl.yaml)
+for a complete oneDPL manifest:
+
+```yaml
+name: onedpl
+configurations:
+  - id: gcc13_cxx17_tbb
+    compiler: g++-13
+    flags: [-std=c++17, -O0, -fopenmp]
+    defines: {ONEDPL_USE_TBB_BACKEND: "1"}
+    include_dirs: [/opt/oneapi/dpl/2023/include]
+  - id: gcc13_cxx20_omp
+    compiler: g++-13
+    flags: [-std=c++20, -O0, -fopenmp]
+    defines: {ONEDPL_USE_OPENMP_BACKEND: "1"}
+    include_dirs: [/opt/oneapi/dpl/2023/include]
+probes:
+  - name: sort
+    headers: [oneapi/dpl/execution, oneapi/dpl/algorithm]
+    body: |
+      void probe_sort(int* a, int* b) {
+          oneapi::dpl::sort(oneapi::dpl::execution::par, a, b);
+      }
+defaults:
+  backend: tbb
+  execution_policy: par
+```
+
+The `-std=c++NN` flag is parsed automatically to populate each
+configuration's C++ standard floor.
+
+## `abicheck probe run`
+
+Compile every (configuration × probe) pair and emit a `MatrixSnapshot`:
+
+```bash
+abicheck probe run examples/probes/onedpl.yaml \
+    --library onedpl --version 2022.0 --out onedpl-2022.json
+```
+
+| Option | Purpose |
+|---|---|
+| `--library` | Library name stamped into the snapshot (required). |
+| `--version` | Version label stamped into the snapshot (required). |
+| `-o, --out` | Write the JSON here (default: stdout). |
+| `--work-dir` | Keep generated `.cpp`/`.o` files here (default: temp dir). |
+| `--no-snapshot` | Compile only; skip the dumper (routing check). |
+
+Per-configuration compile failures (e.g. a compiler missing from `PATH`)
+are captured in the snapshot as per-result errors and summarised on
+stderr — the run does not abort.
+
+## `abicheck probe compare`
+
+Diff two matrix snapshots and report the findings through the standard
+reporter / SARIF / JUnit paths:
+
+```bash
+abicheck probe compare onedpl-2022.json onedpl-2023.json -f markdown
+```
+
+| Option | Purpose |
+|---|---|
+| `-f, --format` | `json` (default), `markdown`, `sarif`, or `junit`. |
+| `-o, --output` | Write the report here (default: stdout). |
+| `--policy` | Built-in policy profile for verdict classification. |
+
+The exit code follows the legacy `compare` mapping: `0` = compatible,
+`2` = source break, `4` = ABI break.
+
+## Python API
+
+The same capability is available programmatically:
+
+```python
+from abicheck.probe_harness import load_probe_spec, run_probe_matrix
+from abicheck.diff_build_config import diff_matrix
+
+spec = load_probe_spec("examples/probes/onedpl.yaml")
+old = run_probe_matrix(spec, library_name="onedpl", version="2022.0")
+new = run_probe_matrix(spec, library_name="onedpl", version="2023.0")
+findings = diff_matrix(old, new)
+```

--- a/docs/user-guide/probe-harness.md
+++ b/docs/user-guide/probe-harness.md
@@ -87,9 +87,25 @@ abicheck probe compare onedpl-2022.json onedpl-2023.json -f markdown
 | `-f, --format` | `json` (default), `markdown`, `sarif`, or `junit`. |
 | `-o, --output` | Write the report here (default: stdout). |
 | `--policy` | Built-in policy profile for verdict classification. |
+| `--allow-failures` | Diff even when an input matrix has failed probe results. |
 
 The exit code follows the legacy `compare` mapping: `0` = compatible,
 `2` = source break, `4` = ABI break.
+
+### Incomplete matrices
+
+The `API_DEPENDS_ON_CONSUMER_ENV` detector only inspects probes that
+compiled successfully. If a `probe run` produced failures — most commonly
+a compiler missing from `PATH` — every result for that configuration
+carries an error and no snapshot. Diffing two such matrices would skip
+the failed results and could report `NO_CHANGE` / exit `0`, silently
+marking an *untested* matrix as compatible.
+
+To avoid that false-negative, `probe compare` **rejects** an input matrix
+that contains failed results, printing the failures and exiting with code
+`3`. Pass `--allow-failures` to diff the successful subset anyway; the
+report is then marked low-confidence with a coverage warning naming how
+many results were skipped.
 
 ## Python API
 

--- a/examples/probes/onedpl.yaml
+++ b/examples/probes/onedpl.yaml
@@ -1,0 +1,61 @@
+# oneDPL probe-harness manifest.
+#
+# A real-world build-configuration matrix for Intel oneDPL. Each
+# configuration compiles the same probe TUs under a different
+# (compiler, language standard, backend) combination so abicheck can
+# detect public-surface divergence that depends on the *consumer's*
+# environment rather than on a source change.
+#
+# Usage:
+#   abicheck probe run examples/probes/onedpl.yaml \
+#       --library onedpl --version 2022.0 --out onedpl-2022.json
+#   abicheck probe run examples/probes/onedpl.yaml \
+#       --library onedpl --version 2023.0 --out onedpl-2023.json
+#   abicheck probe compare onedpl-2022.json onedpl-2023.json
+#
+# The include_dirs below point at a typical oneAPI install; adjust them
+# to your toolchain. Configurations whose compiler is absent from PATH
+# are reported as per-result errors rather than aborting the run.
+name: onedpl
+
+configurations:
+  - id: gcc13_cxx17_tbb
+    compiler: g++-13
+    flags: [-std=c++17, -O0, -fopenmp]
+    defines:
+      ONEDPL_USE_TBB_BACKEND: "1"
+    include_dirs: [/opt/oneapi/dpl/2023/include]
+
+  - id: gcc13_cxx20_omp
+    compiler: g++-13
+    flags: [-std=c++20, -O0, -fopenmp]
+    defines:
+      ONEDPL_USE_OPENMP_BACKEND: "1"
+    include_dirs: [/opt/oneapi/dpl/2023/include]
+
+  - id: clang17_cxx20_dpc
+    compiler: clang++-17
+    flags: [-std=c++20, -fsycl]
+    defines:
+      ONEDPL_USE_DPCPP_BACKEND: "1"
+    include_dirs: [/opt/oneapi/dpl/2023/include]
+
+probes:
+  - name: sort
+    headers: [oneapi/dpl/execution, oneapi/dpl/algorithm]
+    body: |
+      void probe_sort(int* a, int* b) {
+          oneapi::dpl::sort(oneapi::dpl::execution::par, a, b);
+      }
+
+  - name: experimental_ranges
+    headers: [oneapi/dpl/ranges]
+    body: |
+      void probe_ranges(int* a, int* b) {
+          oneapi::dpl::experimental::ranges::sort(
+              oneapi::dpl::experimental::ranges::views::all(a));
+      }
+
+defaults:
+  backend: tbb
+  execution_policy: par

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
     - Severity Configuration: user-guide/severity.md
     - Output Formats: user-guide/output-formats.md
     - Multi-Binary Releases: user-guide/multi-binary.md
+    - Probe Harness: user-guide/probe-harness.md
     - Baseline Management: user-guide/baseline-management.md
     - Local Compare: user-guide/local-compare.md
     - MCP Integration: user-guide/mcp-integration.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ module = [
     "abicheck.cli_compare_release",
     "abicheck.cli_debian_symbols",
     "abicheck.cli_baseline",
+    "abicheck.cli_probe",
     "abicheck.cli_stack",
     "abicheck.cli_suggest",
     "abicheck.compat.cli",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -448,6 +448,7 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         frozenset({"cli", "cli_baseline"}),
         frozenset({"cli", "cli_debian_symbols"}),
         frozenset({"cli", "cli_appcompat"}),
+        frozenset({"cli", "cli_probe"}),
         frozenset({"cli", "cli_stack"}),
         frozenset({"cli", "cli_suggest"}),
     }

--- a/tests/test_cli_probe.py
+++ b/tests/test_cli_probe.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI tests for the ``probe`` command group (``cli_probe.py``).
+
+The matrix harness is exercised at the snapshot level (synthetic
+``MatrixSnapshot`` JSON) so these tests need no compiler — compilation
+itself is covered by ``test_probe_harness.py``. ``probe run`` is driven
+with ``run_probe_matrix`` monkeypatched for the same reason.
+"""
+
+from __future__ import annotations
+
+import json
+import xml.dom.minidom as minidom
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+
+
+def _write_matrix(
+    path: Path,
+    *,
+    version: str,
+    cxx_stds: dict[str, int | None],
+    defaults: dict[str, str],
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "library": "onedpl",
+                "version": version,
+                "spec_name": "onedpl",
+                "cxx_stds": cxx_stds,
+                "defaults": defaults,
+                "results": [],
+            }
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# probe compare
+# ---------------------------------------------------------------------------
+
+
+class TestProbeCompare:
+    def _matrices(self, tmp_path: Path) -> tuple[Path, Path]:
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        _write_matrix(
+            old,
+            version="1.0",
+            cxx_stds={"a": 17, "b": 20},
+            defaults={"backend": "tbb", "execution_policy": "seq"},
+        )
+        _write_matrix(
+            new,
+            version="2.0",
+            cxx_stds={"b": 20, "c": 23},
+            defaults={"backend": "tbb", "execution_policy": "par"},
+        )
+        return old, new
+
+    def test_json_reports_both_findings(self, tmp_path: Path) -> None:
+        old, new = self._matrices(tmp_path)
+        result = CliRunner().invoke(main, ["probe", "compare", str(old), str(new)])
+        # API_BREAK (floor raised) → exit 2
+        assert result.exit_code == 2, result.output
+        payload = json.loads(result.output)
+        kinds = {c["kind"] for c in payload["changes"]}
+        assert "cxx_standard_floor_raised" in kinds
+        assert "behavioural_default_changed" in kinds
+
+    def test_markdown_format(self, tmp_path: Path) -> None:
+        old, new = self._matrices(tmp_path)
+        result = CliRunner().invoke(
+            main, ["probe", "compare", str(old), str(new), "-f", "markdown"]
+        )
+        assert result.exit_code == 2
+        assert "cxx_standard_floor_raised" in result.output
+
+    def test_sarif_format_is_valid(self, tmp_path: Path) -> None:
+        old, new = self._matrices(tmp_path)
+        result = CliRunner().invoke(
+            main, ["probe", "compare", str(old), str(new), "-f", "sarif"]
+        )
+        assert result.exit_code == 2
+        doc = json.loads(result.output)
+        assert len(doc["runs"][0]["results"]) == 2
+
+    def test_junit_format_is_valid_xml(self, tmp_path: Path) -> None:
+        old, new = self._matrices(tmp_path)
+        result = CliRunner().invoke(
+            main, ["probe", "compare", str(old), str(new), "-f", "junit"]
+        )
+        assert result.exit_code == 2
+        minidom.parseString(result.output)  # raises on malformed XML
+
+    def test_output_to_file(self, tmp_path: Path) -> None:
+        old, new = self._matrices(tmp_path)
+        out = tmp_path / "report.json"
+        result = CliRunner().invoke(
+            main, ["probe", "compare", str(old), str(new), "-o", str(out)]
+        )
+        assert result.exit_code == 2
+        assert json.loads(out.read_text())["changes"]
+
+    def test_no_changes_exit_zero(self, tmp_path: Path) -> None:
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        same = {"backend": "tbb"}
+        _write_matrix(old, version="1.0", cxx_stds={"a": 20}, defaults=same)
+        _write_matrix(new, version="2.0", cxx_stds={"a": 20}, defaults=same)
+        result = CliRunner().invoke(main, ["probe", "compare", str(old), str(new)])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["verdict"] in ("NO_CHANGE", "COMPATIBLE")
+
+
+# ---------------------------------------------------------------------------
+# probe run
+# ---------------------------------------------------------------------------
+
+
+class TestProbeRun:
+    def _spec(self, tmp_path: Path) -> Path:
+        spec = tmp_path / "spec.yaml"
+        spec.write_text(
+            "name: onedpl\n"
+            "configurations:\n"
+            "  - id: gcc_cxx20\n"
+            "    compiler: g++\n"
+            "    flags: [-std=c++20]\n"
+            "probes:\n"
+            "  - name: sort\n"
+            "    headers: [vector]\n"
+            "    body: |\n"
+            "      void probe() {}\n"
+            "defaults:\n"
+            "  backend: tbb\n"
+        )
+        return spec
+
+    def test_run_writes_matrix(self, tmp_path: Path, monkeypatch) -> None:
+        from abicheck import cli_probe
+        from abicheck.probe_harness import MatrixSnapshot, ProbeResult
+
+        def fake_run(spec, *, library_name, version, work_dir, snapshot):
+            return MatrixSnapshot(
+                library=library_name,
+                version=version,
+                spec_name=spec.name,
+                cxx_stds={"gcc_cxx20": 20},
+                defaults=dict(spec.defaults),
+                results=[ProbeResult("gcc_cxx20", "sort", error=None)],
+            )
+
+        monkeypatch.setattr(cli_probe, "run_probe_matrix", fake_run)
+        out = tmp_path / "m.json"
+        result = CliRunner().invoke(
+            main,
+            [
+                "probe",
+                "run",
+                str(self._spec(tmp_path)),
+                "--library",
+                "onedpl",
+                "--version",
+                "2022.0",
+                "--out",
+                str(out),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert data["library"] == "onedpl"
+        assert data["version"] == "2022.0"
+
+    def test_run_reports_failures_on_stderr(self, tmp_path: Path, monkeypatch) -> None:
+        from abicheck import cli_probe
+        from abicheck.probe_harness import MatrixSnapshot, ProbeResult
+
+        def fake_run(spec, *, library_name, version, work_dir, snapshot):
+            return MatrixSnapshot(
+                library=library_name,
+                version=version,
+                spec_name=spec.name,
+                results=[
+                    ProbeResult("c", "p", error="compiler 'g++' not found on PATH")
+                ],
+            )
+
+        monkeypatch.setattr(cli_probe, "run_probe_matrix", fake_run)
+        # No --out → matrix JSON on stdout, run summary + per-failure
+        # lines on stderr. The summary names the failure count and the
+        # offending configuration/probe so it is actionable.
+        result = CliRunner().invoke(
+            main,
+            [
+                "probe",
+                "run",
+                str(self._spec(tmp_path)),
+                "--library",
+                "onedpl",
+                "--version",
+                "1.0",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "1 failure(s)" in result.output
+        assert "not found on PATH" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Shipped oneDPL manifest parses
+# ---------------------------------------------------------------------------
+
+
+def test_onedpl_example_spec_parses() -> None:
+    from abicheck.probe_harness import load_probe_spec
+
+    spec_path = (
+        Path(__file__).resolve().parent.parent / "examples" / "probes" / "onedpl.yaml"
+    )
+    spec = load_probe_spec(spec_path)
+    assert spec.name == "onedpl"
+    assert len(spec.configurations) == 3
+    assert len(spec.probes) == 2
+    assert spec.defaults["execution_policy"] == "par"
+    # -std=c++NN parsing populated the floor for each configuration.
+    assert {c.cxx_std for c in spec.configurations} == {17, 20}

--- a/tests/test_cli_probe.py
+++ b/tests/test_cli_probe.py
@@ -23,10 +23,10 @@ with ``run_probe_matrix`` monkeypatched for the same reason.
 from __future__ import annotations
 
 import json
-import xml.dom.minidom as minidom
 from pathlib import Path
 
 from click.testing import CliRunner
+from defusedxml.ElementTree import fromstring as xml_fromstring
 
 from abicheck.cli import main
 
@@ -132,7 +132,7 @@ class TestProbeCompare:
             main, ["probe", "compare", str(old), str(new), "-f", "junit"]
         )
         assert result.exit_code == 2
-        minidom.parseString(result.output)  # raises on malformed XML
+        xml_fromstring(result.output)  # raises on malformed XML
 
     def test_output_to_file(self, tmp_path: Path) -> None:
         old, new = self._matrices(tmp_path)

--- a/tests/test_cli_probe.py
+++ b/tests/test_cli_probe.py
@@ -52,6 +52,30 @@ def _write_matrix(
     )
 
 
+def _write_failed_matrix(path: Path, *, version: str) -> None:
+    """A matrix whose only probe result failed to compile (no snapshot)."""
+    path.write_text(
+        json.dumps(
+            {
+                "library": "onedpl",
+                "version": version,
+                "spec_name": "onedpl",
+                "cxx_stds": {"gcc_cxx20": 20},
+                "defaults": {"backend": "tbb"},
+                "results": [
+                    {
+                        "configuration_id": "gcc_cxx20",
+                        "probe_id": "sort",
+                        "object_path": None,
+                        "snapshot": None,
+                        "error": "compiler 'g++' not found on PATH",
+                    }
+                ],
+            }
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # probe compare
 # ---------------------------------------------------------------------------
@@ -128,6 +152,82 @@ class TestProbeCompare:
         result = CliRunner().invoke(main, ["probe", "compare", str(old), str(new)])
         assert result.exit_code == 0, result.output
         assert json.loads(result.output)["verdict"] in ("NO_CHANGE", "COMPATIBLE")
+
+
+class TestProbeCompareIncompleteMatrix:
+    """An all-failed matrix (e.g. missing compiler) must not diff clean."""
+
+    def test_failed_results_rejected_with_exit_3(self, tmp_path: Path) -> None:
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        _write_failed_matrix(old, version="1.0")
+        _write_failed_matrix(new, version="2.0")
+        result = CliRunner().invoke(main, ["probe", "compare", str(old), str(new)])
+        assert result.exit_code == 3, result.output
+        assert "Refusing to diff an incomplete matrix" in result.output
+        assert "not found on PATH" in result.output
+
+    def test_failure_in_only_one_matrix_still_rejected(self, tmp_path: Path) -> None:
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        _write_matrix(
+            old, version="1.0", cxx_stds={"a": 20}, defaults={"backend": "tbb"}
+        )
+        _write_failed_matrix(new, version="2.0")
+        result = CliRunner().invoke(main, ["probe", "compare", str(old), str(new)])
+        assert result.exit_code == 3, result.output
+
+    def test_allow_failures_diffs_and_marks_low_confidence(
+        self, tmp_path: Path
+    ) -> None:
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        # Defaults differ → a real finding survives, but the matrix is partial.
+        _write_failed_matrix(old, version="1.0")
+        new.write_text(
+            json.dumps(
+                {
+                    "library": "onedpl",
+                    "version": "2.0",
+                    "spec_name": "onedpl",
+                    "cxx_stds": {"gcc_cxx20": 20},
+                    "defaults": {"backend": "openmp"},
+                    "results": [
+                        {
+                            "configuration_id": "gcc_cxx20",
+                            "probe_id": "sort",
+                            "object_path": None,
+                            "snapshot": None,
+                            "error": "compiler 'g++' not found on PATH",
+                        }
+                    ],
+                }
+            )
+        )
+        result = CliRunner().invoke(
+            main, ["probe", "compare", str(old), str(new), "--allow-failures"]
+        )
+        # behavioural_default_changed is risk → verdict not API_BREAK → exit 0.
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["confidence"] == "low"
+        assert any(
+            c["kind"] == "behavioural_default_changed" for c in payload["changes"]
+        )
+
+    def test_clean_matrix_unaffected(self, tmp_path: Path) -> None:
+        # A matrix with no failed results is diffed normally (high confidence).
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        _write_matrix(
+            old, version="1.0", cxx_stds={"a": 20}, defaults={"backend": "tbb"}
+        )
+        _write_matrix(
+            new, version="2.0", cxx_stds={"a": 20}, defaults={"backend": "tbb"}
+        )
+        result = CliRunner().invoke(main, ["probe", "compare", str(old), str(new)])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["confidence"] == "high"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the two highest-priority follow-ups from **#250** (items 1 & 2). The probe-harness library (`probe_harness.py`) and matrix-diff library (`diff_build_config.py`) shipped in #247 but were reachable **only from Python** — their three change kinds were library-only. This PR adds the CLI surface and a real-world manifest so they work end to end.

### `abicheck probe` command group (#250 item 1)

New `abicheck/cli_probe.py` registering two subcommands:

- **`abicheck probe run SPEC --library L --version V --out matrix.json`** — compiles every *(configuration × probe)* declared in a YAML manifest and emits a `MatrixSnapshot`. Per-configuration compile failures (e.g. a compiler missing from `PATH`) are captured per-result and summarised on stderr; the run doesn't abort.
- **`abicheck probe compare OLD.json NEW.json -f {json,markdown,sarif,junit}`** — runs `diff_matrix` and renders the findings through the **existing reporter / SARIF / JUnit paths**, surfacing `API_DEPENDS_ON_CONSUMER_ENV`, `CXX_STANDARD_FLOOR_RAISED`, and `BEHAVIOURAL_DEFAULT_CHANGED`. Exit code follows the legacy `compare` mapping (0 = compatible, 2 = source break, 4 = ABI break).

### oneDPL probe-spec (#250 item 2)

- `examples/probes/onedpl.yaml` — the oneDPL build-configuration matrix manifest (gcc/clang × C++17/20 × TBB/OpenMP/DPC++ backends).
- `docs/user-guide/probe-harness.md` — user-guide page documenting the manifest format, both subcommands, and the Python API; wired into the mkdocs nav.

### Design note

#250 sketched `abicheck compare --matrix old new`. This lands the same capability under a dedicated **`probe`** group instead, which keeps the ~2,600-line `compare` command untouched and groups the run/compare halves of the harness together. Registration follows the repo's split-module convention (side-effect import at the tail of `cli.py`, plus the matching `pyproject.toml` mypy override and ai-readiness import-cycle allowlist entry).

## Test plan

- `tests/test_cli_probe.py` — 9 new tests: both subcommands, all four output formats (json/markdown/sarif/junit valid), file output, exit-code mapping, failure reporting, and a parse-check on the shipped oneDPL manifest.
- `ruff check abicheck/ tests/` — clean
- `mypy abicheck/` — clean (95 files)
- `python scripts/check_ai_readiness.py` — 0 errors, 0 warnings
- `mkdocs build --strict` — exit 0 (new page in nav)
- Fast suite — **6434 passed**, 16 skipped, 4 xfailed (+9 from this PR)

## Not in scope (remaining #250 items)

- **Item 3** — `case111_std_reexport_removed` example (lowest priority; detector already unit-tested).
- **Item 4** — further detector extractions from `diff_onedal.py` (the issue recommends one PR per extraction).

https://claude.ai/code/session_01LBrjaUeJKYD9S9JJhWqyc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBrjaUeJKYD9S9JJhWqyc5)_