### PR TITLE
feat(surface): public-surface ledger + Phase 1 declaration provenance (ADR-024 / ADR-015)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
           pip install mypy
       - name: AI-readiness checks (file size, CLAUDE.md coverage, ChangeKind invariants, mypy drift, import cycles)
         run: python scripts/check_ai_readiness.py
+      - name: Install package (for FP-rate gate)
+        run: pip install -e .
+      - name: Scoping FP-rate gate (ADR-024 §7 — false positives/negatives vs baseline)
+        run: python scripts/check_fp_rate.py
 
   lint-and-types:
     runs-on: ubuntu-latest

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -178,6 +178,7 @@ def compare(
     policy: str = "strict_abi",
     policy_file: PolicyFile | None = None,
     scope_to_public_surface: bool = False,
+    force_public_symbols: set[str] | None = None,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.
 
@@ -214,6 +215,7 @@ def compare(
     pp_ctx = DEFAULT_PIPELINE.run(
         changes, old, new, suppression=suppression, frozen_namespaces=frozen_ns,
         scope_to_public_surface=scope_to_public_surface,
+        force_public_symbols=force_public_symbols,
     )
     kept = pp_ctx.kept
     redundant = pp_ctx.redundant

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -177,7 +177,7 @@ def compare(
     *,
     policy: str = "strict_abi",
     policy_file: PolicyFile | None = None,
-    scope_to_public_surface: bool = False,
+    scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -60,6 +60,11 @@ class Change:
     # Function record was found (e.g. type-level changes). Lets namespace
     # selectors match ``extern "C"`` entries whose export name is unqualified.
     qualified_name: str | None = None
+    # Set by FilterNonPublicSurface (ADR-024 §D5.1) when --scope-public-headers
+    # demotes this finding off the public surface. Carries a stable reason code
+    # (e.g. "not-exported", "non-public-type") for the audit ledger. None for
+    # in-surface findings and when scoping is off.
+    surface_exclusion_reason: str | None = None
 
 
 @dataclass

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1022,7 +1022,8 @@ def _echo_filtered_surface(result: DiffResult) -> None:
     )
     for c in result.out_of_surface_changes:
         loc = f" [{c.source_location}]" if c.source_location else ""
-        click.echo(f"  - {c.kind.value}: {c.symbol}{loc}", err=True)
+        reason = f" ({c.surface_exclusion_reason})" if c.surface_exclusion_reason else ""
+        click.echo(f"  - {c.kind.value}: {c.symbol}{loc}{reason}", err=True)
 
 
 def _warn_all_suppressed(result: DiffResult) -> None:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -415,6 +415,14 @@ def _populate_dependency_info(
               help="Public header file or directory (repeat for multiple).")
 @click.option("-I", "--include", "includes", multiple=True, type=click.Path(path_type=Path),
               help="Extra include directory for castxml.")
+# ── Declaration provenance (ADR-015) ─────────────────────────────────────────
+@click.option("--public-header", "public_headers", multiple=True, type=click.Path(path_type=Path),
+              help="Header treated as public for provenance classification (repeat for "
+                   "multiple). Declarations are tagged public/private/system in the snapshot. "
+                   "Opt-in: omitting this leaves every origin UNKNOWN.")
+@click.option("--public-header-dir", "public_header_dirs", multiple=True, type=click.Path(path_type=Path),
+              help="Directory whose headers are treated as public for provenance "
+                   "classification (repeat for multiple).")
 @click.option("--version", "version", default="unknown", show_default=True,
               help="Library version string to embed in snapshot.")
 @click.option("--lang", default="c++", show_default=True,
@@ -487,6 +495,7 @@ def _populate_dependency_info(
 @click.option("--no-git", "no_git", is_flag=True, default=False,
               help="Do not auto-detect git commit SHA.")
 def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...],
+             public_headers: tuple[Path, ...], public_header_dirs: tuple[Path, ...],
              version: str, lang: str, output: Path | None,
              gcc_path: str | None, gcc_prefix: str | None, gcc_options: str | None,
              sysroot: Path | None, nostdinc: bool, pdb_path: Path | None,
@@ -580,6 +589,8 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             lang=lang if lang == "c" else None,
             dwarf_only=dwarf_only,
             debug_format=debug_format,
+            public_headers=list(public_headers),
+            public_header_dirs=list(public_header_dirs),
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -416,11 +416,13 @@ def _populate_dependency_info(
 @click.option("-I", "--include", "includes", multiple=True, type=click.Path(path_type=Path),
               help="Extra include directory for castxml.")
 # ── Declaration provenance (ADR-015) ─────────────────────────────────────────
-@click.option("--public-header", "public_headers", multiple=True, type=click.Path(path_type=Path),
+@click.option("--public-header", "public_headers", multiple=True,
+              type=click.Path(exists=True, dir_okay=False, path_type=Path),
               help="Header treated as public for provenance classification (repeat for "
                    "multiple). Declarations are tagged public/private/system in the snapshot. "
                    "Opt-in: omitting this leaves every origin UNKNOWN.")
-@click.option("--public-header-dir", "public_header_dirs", multiple=True, type=click.Path(path_type=Path),
+@click.option("--public-header-dir", "public_header_dirs", multiple=True,
+              type=click.Path(exists=True, file_okay=False, path_type=Path),
               help="Directory whose headers are treated as public for provenance "
                    "classification (repeat for multiple).")
 @click.option("--version", "version", default="unknown", show_default=True,
@@ -543,6 +545,11 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             f"--{debug_format} is only supported for ELF binaries, not {binary_fmt.upper()}."
         )
     if binary_fmt in ("pe", "macho"):
+        if public_headers or public_header_dirs:
+            raise click.BadParameter(
+                "--public-header / --public-header-dir provenance classification is "
+                f"currently only supported for ELF inputs, not {binary_fmt.upper()}."
+            )
         _handle_non_elf_dump(
             so_path,
             binary_fmt,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -822,6 +822,24 @@ def _load_suppression_and_policy(
     return suppression, pf
 
 
+def _collect_force_public_symbols(
+    public_symbols: tuple[str, ...], symbols_list: Path | None,
+) -> set[str]:
+    """Merge --public-symbol values with a --public-symbols-list file.
+
+    The list file is one symbol per line; blank lines and ``#`` comments are
+    ignored (à la abi-compliance-checker -symbols-list). Inline trailing
+    comments are not stripped — a ``#`` must start the line to be a comment.
+    """
+    out: set[str] = {s.strip() for s in public_symbols if s.strip()}
+    if symbols_list is not None:
+        for raw in symbols_list.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if line and not line.startswith("#"):
+                out.add(line)
+    return out
+
+
 def _validate_show_only(
     ctx: click.Context, param: click.Parameter, value: str | None,
 ) -> str | None:
@@ -1331,6 +1349,16 @@ def _finalize_compare_result(
                    "leaks are never hidden.")
 @click.option("--show-filtered", "show_filtered", is_flag=True, default=False,
               help="List findings excluded by --scope-public-headers (audit trail).")
+@click.option("--public-symbol", "public_symbols", multiple=True,
+              help="Widening overlay (ADR-024 §D6): force a symbol (mangled or demangled "
+                   "name) into the public surface even when header provenance can't see it "
+                   "(asm stubs, .def exports, extern \"C\" shims, MSVC-mangling gaps). "
+                   "Repeatable. Only meaningful with --scope-public-headers.")
+@click.option("--public-symbols-list", "public_symbols_list",
+              type=click.Path(exists=True, dir_okay=False, path_type=Path), default=None,
+              help="File of symbols to force public (one per line; '#' comments and blank "
+                   "lines ignored), à la abi-compliance-checker -symbols-list. "
+                   "Merged with --public-symbol.")
 @click.option("--show-only", "show_only", default=None,
               callback=_validate_show_only, expose_value=True, is_eager=False,
               help="Comma-separated filter tokens to limit displayed changes. "
@@ -1394,6 +1422,7 @@ def compare_cmd(
     follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
     show_redundant: bool, show_only: str | None, stat: bool,
     scope_public_headers: bool, show_filtered: bool,
+    public_symbols: tuple[str, ...], public_symbols_list: Path | None,
     report_mode: str, show_impact: bool,
     debug_format: str | None,
     annotate: bool,
@@ -1500,9 +1529,18 @@ def compare_cmd(
         require_justification=require_justification,
     )
 
+    force_public = _collect_force_public_symbols(public_symbols, public_symbols_list)
+    if force_public and not scope_public_headers:
+        click.echo(
+            "Warning: --public-symbol/--public-symbols-list only take effect with "
+            "--scope-public-headers; ignoring the widening overlay.",
+            err=True,
+        )
+
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_public_headers,
+        force_public_symbols=force_public,
     )
 
     _finalize_compare_result(

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1342,11 +1342,13 @@ def _finalize_compare_result(
 @click.option("--show-redundant", is_flag=True, default=False,
               help="Disable redundancy filtering and show all changes including those "
                    "derived from root type changes.")
-@click.option("--scope-public-headers", "scope_public_headers", is_flag=True, default=False,
+@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
+              default=True, show_default=True,
               help="Restrict findings to the public-header ABI surface (ADR-024): "
                    "changes to symbols/types not reachable from public-header-declared "
                    "exported API are recorded as filtered, not reported. Internal-type "
-                   "leaks are never hidden.")
+                   "leaks are never hidden. On by default; use --no-scope-public-headers "
+                   "to report every finding regardless of surface.")
 @click.option("--show-filtered", "show_filtered", is_flag=True, default=False,
               help="List findings excluded by --scope-public-headers (audit trail).")
 @click.option("--public-symbol", "public_symbols", multiple=True,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -580,6 +580,8 @@ def dump(
     lang: str | None = None,
     dwarf_only: bool = False,
     debug_format: str | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Create an AbiSnapshot from a shared library + headers.
 
@@ -604,6 +606,11 @@ def dump(
         debug_format: Force debug format for ELF inputs: "dwarf", "btf", or "ctf".
             None = auto-detect (DWARF preferred for userspace, BTF for kernel).
             Ignored for Mach-O and PE binaries.
+        public_headers: Explicit public-header files used only to classify
+            declaration provenance (ADR-015). When empty, every declaration's
+            origin stays UNKNOWN and behaviour is unchanged.
+        public_header_dirs: Directories whose headers are treated as public
+            for provenance classification.
 
     Returns:
         AbiSnapshot with functions, variables, and types populated.
@@ -611,33 +618,38 @@ def dump(
     fmt = _detect_format(so_path)
 
     if fmt == "macho":
-        return _dump_macho(
+        snapshot = _dump_macho(
             so_path, headers, extra_includes or [], version, compiler,
             gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
             sysroot=sysroot, nostdinc=nostdinc, lang=lang,
             dwarf_only=dwarf_only,
         )
-    if fmt == "pe":
-        return _dump_pe(
+    elif fmt == "pe":
+        snapshot = _dump_pe(
             so_path, headers, extra_includes or [], version, compiler,
             gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
             sysroot=sysroot, nostdinc=nostdinc, lang=lang,
         )
-
-    if fmt != "elf":
+    elif fmt == "elf":
+        snapshot = _dump_elf(
+            so_path, headers, extra_includes or [], version, compiler,
+            gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
+            sysroot=sysroot, nostdinc=nostdinc, lang=lang,
+            dwarf_only=dwarf_only,
+            debug_format=debug_format,
+        )
+    else:
         raise ValidationError(
             f"Unrecognised binary format for {so_path}: "
             f"expected ELF, Mach-O, or PE but detected {fmt!r}. "
             f"Ensure the file is a valid shared library."
         )
 
-    return _dump_elf(
-        so_path, headers, extra_includes or [], version, compiler,
-        gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
-        sysroot=sysroot, nostdinc=nostdinc, lang=lang,
-        dwarf_only=dwarf_only,
-        debug_format=debug_format,
-    )
+    # Tag declaration provenance (source_header + origin). Always derives
+    # source_header from the parsed source location; origin is only
+    # classified when a public-header set is supplied (ADR-015, D4).
+    from .provenance import apply_provenance
+    return apply_provenance(snapshot, public_headers, public_header_dirs)
 
 
 def _is_kernel_binary(path: Path) -> bool:

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -402,6 +402,7 @@ class _CastxmlParser:
             variables.append(Variable(
                 name=name, mangled=mangled, type=type_name, visibility=vis,
                 is_const=is_const,
+                source_location=self._source_location(el),
             ))
         return variables
 
@@ -480,7 +481,29 @@ class _CastxmlParser:
             vtable=[] if is_opaque else self._build_vtable(el.get("id", "")),
             is_union=el.tag == "Union",
             is_opaque=is_opaque,
+            source_location=self._source_location(el),
         )
+
+    def _source_location(self, el: Any) -> str | None:
+        """Resolve a declaration's ``file:line`` source location.
+
+        Mirrors the function-parsing path: castxml emits the location either
+        directly as ``file``/``line`` attributes or as a ``location`` id
+        referencing a ``Location`` element. Returns ``None`` when neither is
+        present. Used to populate provenance (``source_header``/``origin``)
+        on records, variables, and enums (ADR-015 v6).
+        """
+        file_id = el.get("file", "")
+        line = el.get("line", "")
+        if not (file_id and line):
+            loc_id = el.get("location", "")
+            loc_el = self._id_map.get(loc_id) if loc_id else None
+            if loc_el is not None:
+                file_id = loc_el.get("file", "")
+                line = loc_el.get("line", "")
+        file_el = self._id_map.get(file_id) if file_id else None
+        fname = file_el.get("name", "") if file_el is not None else ""
+        return f"{fname}:{line}" if fname and line else None
 
     def _optional_int_attr(self, el: Any, attr: str) -> int | None:
         raw = el.get(attr)
@@ -657,7 +680,10 @@ class _CastxmlParser:
                     except ValueError:
                         m_val = 0
                     members.append(EnumMember(name=m_name, value=m_val))
-            enums.append(EnumType(name=name, members=members))
+            enums.append(EnumType(
+                name=name, members=members,
+                source_location=self._source_location(el),
+            ))
         return enums
 
     def _underlying_type_name(self, id_: str, depth: int = 0) -> str:

--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -696,6 +696,7 @@ class _DwarfSnapshotBuilder:
             name=qualified,
             members=members,
             underlying_type=underlying,
+            source_location=self._resolve_decl_file(die, CU),
         ))
 
     # -------------------------------------------------------------------

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -133,6 +133,22 @@ class ParamKind(str, Enum):
     RVALUE_REF = "rvalue_ref"
 
 
+class ScopeOrigin(str, Enum):
+    """Where a declaration's defining header sits relative to the
+    user-provided public-header set (ADR-015, schema v6).
+
+    Classification is opt-in: it is only meaningful when the caller
+    supplies a public-header set (``--public-header`` / ``--public-header-dir``).
+    Without one, every declaration is ``UNKNOWN`` and downstream behaviour
+    is unchanged.
+    """
+
+    PUBLIC_HEADER = "public_header"    # defined in a provided public header
+    PRIVATE_HEADER = "private_header"  # project header outside the public set
+    SYSTEM_HEADER = "system_header"    # toolchain/system header (/usr/include, ...)
+    UNKNOWN = "unknown"                # no public set, or no source location
+
+
 @dataclass
 class Param:
     name: str
@@ -184,6 +200,12 @@ class Function:
     # - None  → dumper/loader could not determine (older snapshots, DWARF-
     #           only path). Diff detectors skip when either side is None.
     is_hidden_friend: bool | None = None
+    # Provenance (ADR-015, schema v6). source_header is the defining header
+    # (source_location with the line/col stripped); origin classifies it
+    # against the provided public-header set. Both are additive: missing on
+    # older snapshots and default to None / UNKNOWN.
+    source_header: str | None = None
+    origin: ScopeOrigin = ScopeOrigin.UNKNOWN
 
 
 @dataclass
@@ -197,6 +219,9 @@ class Variable:
     value: str | None = None       # initial value (compile-time constant, if known)
     access: AccessLevel = AccessLevel.PUBLIC  # public/protected/private
     elf_visibility: ElfVisibility | None = None  # ELF st_other (populated from .dynsym)
+    # Provenance (ADR-015, schema v6) — see Function.source_header.
+    source_header: str | None = None
+    origin: ScopeOrigin = ScopeOrigin.UNKNOWN
 
 
 @dataclass
@@ -226,6 +251,9 @@ class RecordType:
     source_location: str | None = None
     is_union: bool = False
     is_opaque: bool = False       # incomplete type (forward-decl only; was complete → BREAKING)
+    # Provenance (ADR-015, schema v6) — see Function.source_header.
+    source_header: str | None = None
+    origin: ScopeOrigin = ScopeOrigin.UNKNOWN
 
 
 @dataclass
@@ -239,6 +267,10 @@ class EnumType:
     name: str
     members: list[EnumMember] = field(default_factory=list)
     underlying_type: str = "int"
+    source_location: str | None = None
+    # Provenance (ADR-015, schema v6) — see Function.source_header.
+    source_header: str | None = None
+    origin: ScopeOrigin = ScopeOrigin.UNKNOWN
 
 
 @dataclass

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -135,7 +135,8 @@ class ParamKind(str, Enum):
 
 class ScopeOrigin(str, Enum):
     """Where a declaration's defining header sits relative to the
-    user-provided public-header set (ADR-015, schema v6).
+    user-provided public-header set — the *Origin* axis of the two-axis
+    Linkage × Origin surface model (ADR-024 D1, ADR-015 schema v6).
 
     Classification is opt-in: it is only meaningful when the caller
     supplies a public-header set (``--public-header`` / ``--public-header-dir``).
@@ -146,6 +147,8 @@ class ScopeOrigin(str, Enum):
     PUBLIC_HEADER = "public_header"    # defined in a provided public header
     PRIVATE_HEADER = "private_header"  # project header outside the public set
     SYSTEM_HEADER = "system_header"    # toolchain/system header (/usr/include, ...)
+    GENERATED = "generated"            # machine-generated header (moc_*, *.pb.h, generated/ ...)
+    EXPORT_ONLY = "export_only"        # exported by the binary but absent from any header
     UNKNOWN = "unknown"                # no public set, or no source location
 
 

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -218,7 +218,7 @@ class FilterNonPublicSurface:
     def run(self, changes: list[Change], ctx: PipelineContext) -> list[Change]:
         if not ctx.scope_to_public_surface:
             return changes
-        from .surface import change_in_public_surface, compute_public_surface
+        from .surface import classify_change_surface, compute_public_surface
 
         surf_old = compute_public_surface(ctx.old)
         surf_new = compute_public_surface(ctx.new)
@@ -227,9 +227,12 @@ class FilterNonPublicSurface:
             return changes
         kept: list[Change] = []
         for c in changes:
-            if change_in_public_surface(c, surf_old, surf_new):
+            in_surface, reason = classify_change_surface(c, surf_old, surf_new)
+            if in_surface:
                 kept.append(c)
             else:
+                # Tag with the ledger reason (ADR-024 §D5.1) before demoting.
+                c.surface_exclusion_reason = reason
                 ctx.out_of_surface.append(c)
         return kept
 

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -47,6 +47,12 @@ class PipelineContext:
     # ADR-024 §D4: when True, FilterNonPublicSurface moves findings that are
     # not on the public-header-scoped ABI surface to ``out_of_surface``.
     scope_to_public_surface: bool = False
+    # ADR-024 §D6 widening overlay: symbol names (mangled or demangled) the
+    # user *guarantees* are public even when header provenance can't see them
+    # (asm stubs, .def exports, extern "C" shims, MSVC-mangling gaps). Matching
+    # findings are forced to stay in-surface under scoping. Widening only ever
+    # *keeps* a finding, so it cannot hide a break.
+    force_public_symbols: set[str] = field(default_factory=set)
     # Accumulated side-outputs
     opaque_filtered: list[Change] = field(default_factory=list)
     suppressed: list[Change] = field(default_factory=list)
@@ -202,6 +208,21 @@ class EnrichSourceLocations:
         return changes
 
 
+def _change_matches_symbols(change: Change, symbols: set[str]) -> bool:
+    """True if *change*'s symbol matches the widening allowlist.
+
+    Matches the raw symbol (mangled or demangled, as recorded on the change)
+    and — for qualified names — the trailing ``::`` segment, so an entry like
+    ``foo`` matches ``ns::foo`` as well as the exact spelling.
+    """
+    sym = change.symbol or ""
+    if not sym:
+        return False
+    if sym in symbols:
+        return True
+    return "::" in sym and sym.rsplit("::", 1)[1] in symbols
+
+
 class FilterNonPublicSurface:
     """Move findings outside the public-header surface to an audit ledger.
 
@@ -225,8 +246,14 @@ class FilterNonPublicSurface:
         if not (surf_old.resolvable or surf_new.resolvable):
             # No header-derived surface to scope against — keep everything.
             return changes
+        force_public = ctx.force_public_symbols
         kept: list[Change] = []
         for c in changes:
+            # Widening overlay (ADR-024 §D6): a user-guaranteed public symbol
+            # stays in-surface regardless of provenance/export classification.
+            if force_public and _change_matches_symbols(c, force_public):
+                kept.append(c)
+                continue
             in_surface, reason = classify_change_surface(c, surf_old, surf_new)
             if in_surface:
                 kept.append(c)
@@ -721,6 +748,7 @@ class PostProcessingPipeline:
         suppression: SuppressionList | None = None,
         frozen_namespaces: list[str] | None = None,
         scope_to_public_surface: bool = False,
+        force_public_symbols: set[str] | None = None,
     ) -> PipelineContext:
         """Run all steps, returning the final PipelineContext."""
         ctx = PipelineContext(
@@ -729,6 +757,7 @@ class PostProcessingPipeline:
             suppression=suppression,
             frozen_namespaces=list(frozen_namespaces or []),
             scope_to_public_surface=scope_to_public_surface,
+            force_public_symbols=set(force_public_symbols or set()),
         )
         for step in self.steps:
             changes = step.run(changes, ctx)

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declaration provenance — classify where a declaration's header sits
+relative to the user-provided public-header set (ADR-015, schema v6).
+
+Source locations recorded by the DWARF/castxml parsers are frequently
+absolute *build* paths (e.g. ``/build/src/foo/include/api.h``) that bear
+no resemblance to the paths the user passes on the command line.  Matching
+is therefore done on path *segments* (suffix / basename / directory
+containment) rather than by resolving real paths, which would be brittle
+when a snapshot is produced on a different machine than the public-header
+set is described on.
+
+Classification is opt-in.  When the caller supplies no public-header set,
+every declaration keeps :class:`~abicheck.model.ScopeOrigin.UNKNOWN` and
+no existing behaviour changes (decision D4 of the provenance design).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+
+from .model import AbiSnapshot, ScopeOrigin
+
+# Directory prefixes that mark a header as belonging to the toolchain or the
+# operating system rather than the project under test.  Matched as path-segment
+# subsequences so build prefixes (``/sysroot/usr/include/...``) still classify.
+_SYSTEM_HEADER_DIRS: tuple[tuple[str, ...], ...] = (
+    ("usr", "include"),
+    ("usr", "local", "include"),
+    ("usr", "lib"),
+    ("usr", "lib64"),
+    ("Library", "Developer"),  # macOS SDK / Xfwk headers
+    ("Applications", "Xcode.app"),  # macOS Xcode toolchain
+    ("Program Files",),  # Windows SDK / MSVC
+    ("VC", "Tools"),  # MSVC toolchain layout
+    ("Windows Kits",),  # Windows SDK
+)
+
+# A trailing ``:line`` or ``:line:col`` appended to a header path by the
+# parsers (e.g. ``include/api.h:42`` or ``api.h:42:9``).
+_LINE_COL_SUFFIX = re.compile(r":\d+(?::\d+)?$")
+
+
+def header_from_location(source_location: str | None) -> str | None:
+    """Strip a trailing ``:line`` / ``:line:col`` from a source location,
+    yielding just the header path.  Returns ``None`` for a falsy input."""
+    if not source_location:
+        return None
+    return _LINE_COL_SUFFIX.sub("", source_location) or None
+
+
+def _segments(path: str) -> tuple[str, ...]:
+    """Path components in posix order, dropping anchors and ``.`` parts.
+
+    Backslashes are normalised to forward slashes so Windows-style build
+    paths segment the same way as posix ones.
+    """
+    posix = path.replace("\\", "/")
+    parts = [p for p in PurePosixPath(posix).parts if p not in ("/", ".", "")]
+    return tuple(parts)
+
+
+def _contiguous_subsequence(needle: tuple[str, ...], hay: tuple[str, ...]) -> bool:
+    """True if *needle* appears as a contiguous run inside *hay*."""
+    n = len(needle)
+    if n == 0:
+        return False
+    return any(hay[i : i + n] == needle for i in range(len(hay) - n + 1))
+
+
+def _suffix_match(needle: tuple[str, ...], hay: tuple[str, ...]) -> bool:
+    """True if *hay* ends with the segments of *needle* (a path-suffix match)."""
+    n = len(needle)
+    return n > 0 and len(hay) >= n and hay[-n:] == needle
+
+
+def _matches_public(
+    header_segs: tuple[str, ...],
+    public_header_segs: list[tuple[str, ...]],
+    public_dir_segs: list[tuple[str, ...]],
+) -> bool:
+    """Suffix/basename match against public headers, plus directory
+    containment against public-header directories."""
+    basename = header_segs[-1] if header_segs else ""
+    for p in public_header_segs:
+        # Path-suffix match (build-prefix tolerant) or basename fallback.
+        # The basename fallback carries a small false-positive risk on
+        # duplicate basenames across trees — an accepted trade-off (D3).
+        if _suffix_match(p, header_segs):
+            return True
+        if basename and p and p[-1] == basename:
+            return True
+    # Directory containment: a public dir appears among the header's parent dirs.
+    parent_segs = header_segs[:-1]
+    return any(_contiguous_subsequence(d, parent_segs) for d in public_dir_segs)
+
+
+def _is_system_header(header_segs: tuple[str, ...]) -> bool:
+    return any(_contiguous_subsequence(d, header_segs) for d in _SYSTEM_HEADER_DIRS)
+
+
+def classify_origin(
+    source_header: str | None,
+    public_header_segs: list[tuple[str, ...]],
+    public_dir_segs: list[tuple[str, ...]],
+    *,
+    have_public_set: bool,
+) -> ScopeOrigin:
+    """Classify a single header path into a :class:`ScopeOrigin`.
+
+    The ``*_segs`` arguments are pre-segmented public-header inputs (see
+    :func:`build_public_set`).  When ``have_public_set`` is False the result
+    is always ``UNKNOWN`` — provenance is opt-in.
+    """
+    if not have_public_set or source_header is None:
+        return ScopeOrigin.UNKNOWN
+    header_segs = _segments(source_header)
+    if not header_segs:
+        return ScopeOrigin.UNKNOWN
+    if _matches_public(header_segs, public_header_segs, public_dir_segs):
+        return ScopeOrigin.PUBLIC_HEADER
+    if _is_system_header(header_segs):
+        return ScopeOrigin.SYSTEM_HEADER
+    return ScopeOrigin.PRIVATE_HEADER
+
+
+def build_public_set(
+    public_headers: list[Path] | list[str] | None,
+    public_header_dirs: list[Path] | list[str] | None,
+) -> tuple[list[tuple[str, ...]], list[tuple[str, ...]], bool]:
+    """Pre-segment the public-header inputs once for reuse across decls.
+
+    Returns ``(public_header_segs, public_dir_segs, have_public_set)``.
+    """
+    headers = [_segments(str(h)) for h in (public_headers or [])]
+    dirs = [_segments(str(d)) for d in (public_header_dirs or [])]
+    headers = [h for h in headers if h]
+    dirs = [d for d in dirs if d]
+    return headers, dirs, bool(headers or dirs)
+
+
+def apply_provenance(
+    snapshot: AbiSnapshot,
+    public_headers: list[Path] | list[str] | None = None,
+    public_header_dirs: list[Path] | list[str] | None = None,
+) -> AbiSnapshot:
+    """Populate ``source_header`` and ``origin`` on every declaration in
+    *snapshot*, in place, and return it.
+
+    ``source_header`` is always derived from the existing ``source_location``
+    (cheap, additive metadata).  ``origin`` is only classified when a
+    public-header set is supplied; otherwise it stays ``UNKNOWN`` so default
+    invocations are unaffected (decision D4).
+    """
+    header_segs, dir_segs, have_set = build_public_set(
+        public_headers, public_header_dirs
+    )
+
+    def _tag(decl: object) -> None:
+        loc = getattr(decl, "source_location", None)
+        sh = header_from_location(loc)
+        decl.source_header = sh  # type: ignore[attr-defined]
+        decl.origin = classify_origin(  # type: ignore[attr-defined]
+            sh,
+            header_segs,
+            dir_segs,
+            have_public_set=have_set,
+        )
+
+    for fn in snapshot.functions:
+        _tag(fn)
+    for var in snapshot.variables:
+        _tag(var)
+    for rec in snapshot.types:
+        _tag(rec)
+    for en in snapshot.enums:
+        _tag(en)
+    return snapshot

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import re
 from pathlib import Path, PurePosixPath
 
-from .model import AbiSnapshot, ScopeOrigin
+from .model import AbiSnapshot, ScopeOrigin, Visibility
 
 # Directory prefixes that mark a header as belonging to the toolchain or the
 # operating system rather than the project under test.  Matched as path-segment
@@ -48,6 +48,25 @@ _SYSTEM_HEADER_DIRS: tuple[tuple[str, ...], ...] = (
     ("Program Files",),  # Windows SDK / MSVC
     ("VC", "Tools"),  # MSVC toolchain layout
     ("Windows Kits",),  # Windows SDK
+)
+
+# Path segments that mark a header as living in a machine-generated tree.
+_GENERATED_DIR_SEGMENTS: frozenset[str] = frozenset(
+    {"generated", "_generated", ".generated", "gen", "autogen"}
+)
+
+# Basename patterns produced by common code generators (Qt moc/uic/rcc,
+# protobuf, flatbuffers, gRPC). Matched case-sensitively on the file name.
+_GENERATED_BASENAME = re.compile(
+    r"""(?x)
+    ^moc_.*\.(?:h|hpp|cpp|cc)$       # Qt meta-object compiler
+    | ^ui_.*\.h$                     # Qt uic
+    | ^qrc_.*\.(?:cpp|cc)$           # Qt rcc
+    | .*\.pb\.(?:h|cc)$              # protobuf
+    | .*\.pb\.h$                     # protobuf (header)
+    | .*_generated\.h$               # flatbuffers
+    | .*\.grpc\.pb\.(?:h|cc)$        # gRPC
+    """
 )
 
 # A trailing ``:line`` or ``:line:col`` appended to a header path by the
@@ -113,26 +132,41 @@ def _is_system_header(header_segs: tuple[str, ...]) -> bool:
     return any(_contiguous_subsequence(d, header_segs) for d in _SYSTEM_HEADER_DIRS)
 
 
+def _is_generated_header(header_segs: tuple[str, ...]) -> bool:
+    if not header_segs:
+        return False
+    if any(seg in _GENERATED_DIR_SEGMENTS for seg in header_segs[:-1]):
+        return True
+    return bool(_GENERATED_BASENAME.match(header_segs[-1]))
+
+
 def classify_origin(
     source_header: str | None,
     public_header_segs: list[tuple[str, ...]],
     public_dir_segs: list[tuple[str, ...]],
     *,
     have_public_set: bool,
+    export_only: bool = False,
 ) -> ScopeOrigin:
-    """Classify a single header path into a :class:`ScopeOrigin`.
+    """Classify a single declaration into a :class:`ScopeOrigin`.
 
     The ``*_segs`` arguments are pre-segmented public-header inputs (see
     :func:`build_public_set`).  When ``have_public_set`` is False the result
     is always ``UNKNOWN`` — provenance is opt-in.
+
+    ``export_only`` marks a declaration that the binary exports but that has
+    no header provenance (``Visibility.ELF_ONLY``); with a public set in play
+    it classifies as ``EXPORT_ONLY`` rather than ``UNKNOWN``.
     """
-    if not have_public_set or source_header is None:
+    if not have_public_set:
         return ScopeOrigin.UNKNOWN
-    header_segs = _segments(source_header)
+    header_segs = _segments(source_header) if source_header else ()
     if not header_segs:
-        return ScopeOrigin.UNKNOWN
+        return ScopeOrigin.EXPORT_ONLY if export_only else ScopeOrigin.UNKNOWN
     if _matches_public(header_segs, public_header_segs, public_dir_segs):
         return ScopeOrigin.PUBLIC_HEADER
+    if _is_generated_header(header_segs):
+        return ScopeOrigin.GENERATED
     if _is_system_header(header_segs):
         return ScopeOrigin.SYSTEM_HEADER
     return ScopeOrigin.PRIVATE_HEADER
@@ -173,12 +207,14 @@ def apply_provenance(
     def _tag(decl: object) -> None:
         loc = getattr(decl, "source_location", None)
         sh = header_from_location(loc)
+        export_only = getattr(decl, "visibility", None) == Visibility.ELF_ONLY
         decl.source_header = sh  # type: ignore[attr-defined]
         decl.origin = classify_origin(  # type: ignore[attr-defined]
             sh,
             header_segs,
             dir_segs,
             have_public_set=have_set,
+            export_only=export_only,
         )
 
     for fn in snapshot.functions:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -434,6 +434,7 @@ def _add_surface_scope(d: dict[str, object], result: DiffResult) -> None:
                 "symbol": c.symbol,
                 "description": c.description,
                 "source_location": c.source_location,
+                "reason": getattr(c, "surface_exclusion_reason", None),
             }
             for c in result.out_of_surface_changes
         ],

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -414,6 +414,32 @@ def _to_markdown_leaf(
     return "\n".join(lines)
 
 
+def _add_surface_scope(d: dict[str, object], result: DiffResult) -> None:
+    """Attach the ADR-024 §D4/D5 public-surface scope ledger to a JSON dict.
+
+    When header scoping is active, findings that fall outside the public ABI
+    surface are demoted to this audit ledger rather than dropped — disclosed
+    here (not just on stderr) so the "why was this excluded" trail is
+    machine-readable. Shared by the full and leaf JSON paths so both formats
+    carry the ledger consistently.
+    """
+    if not result.scope_to_public_surface:
+        return
+    d["surface_scope"] = {
+        "enabled": True,
+        "out_of_surface_count": result.out_of_surface_count,
+        "out_of_surface_changes": [
+            {
+                "kind": c.kind.value,
+                "symbol": c.symbol,
+                "description": c.description,
+                "source_location": c.source_location,
+            }
+            for c in result.out_of_surface_changes
+        ],
+    }
+
+
 def _to_json_leaf(
     result: DiffResult,
     indent: int = 2,
@@ -487,6 +513,7 @@ def _to_json_leaf(
     d["evidence_tiers"] = list(result.evidence_tiers)
     if result.coverage_warnings:
         d["coverage_warnings"] = list(result.coverage_warnings)
+    _add_surface_scope(d, result)
     return json.dumps(d, indent=indent)
 
 
@@ -581,24 +608,7 @@ def to_json(
             for c in result.suppressed_changes
         ],
     }
-    # ADR-024 §D4/D5: public-surface scope ledger. When header scoping is
-    # active, findings that fall outside the public ABI surface are demoted to
-    # this audit ledger rather than dropped — disclosed here (not just on
-    # stderr) so the "why was this excluded" trail is machine-readable.
-    if result.scope_to_public_surface:
-        d["surface_scope"] = {
-            "enabled": True,
-            "out_of_surface_count": result.out_of_surface_count,
-            "out_of_surface_changes": [
-                {
-                    "kind": c.kind.value,
-                    "symbol": c.symbol,
-                    "description": c.description,
-                    "source_location": c.source_location,
-                }
-                for c in result.out_of_surface_changes
-            ],
-        }
+    _add_surface_scope(d, result)
     d["detectors"] = [
         {
             "name": det.name,

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -581,6 +581,24 @@ def to_json(
             for c in result.suppressed_changes
         ],
     }
+    # ADR-024 §D4/D5: public-surface scope ledger. When header scoping is
+    # active, findings that fall outside the public ABI surface are demoted to
+    # this audit ledger rather than dropped — disclosed here (not just on
+    # stderr) so the "why was this excluded" trail is machine-readable.
+    if result.scope_to_public_surface:
+        d["surface_scope"] = {
+            "enabled": True,
+            "out_of_surface_count": result.out_of_surface_count,
+            "out_of_surface_changes": [
+                {
+                    "kind": c.kind.value,
+                    "symbol": c.symbol,
+                    "description": c.description,
+                    "source_location": c.source_location,
+                }
+                for c in result.out_of_surface_changes
+            ],
+        }
     d["detectors"] = [
         {
             "name": det.name,

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -235,6 +235,7 @@ def to_sarif(
                                         "symbol": c.symbol,
                                         "description": c.description,
                                         **({"sourceLocation": c.source_location} if c.source_location else {}),
+                                        **({"reason": c.surface_exclusion_reason} if c.surface_exclusion_reason else {}),
                                     }
                                     for c in result.out_of_surface_changes
                                 ],

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -221,6 +221,28 @@ def to_sarif(
                     **({"coverageWarnings": list(result.coverage_warnings)} if result.coverage_warnings else {}),
                     "policy": result.policy or "strict_abi",
                     **({"policyOverrides": {k.value: v.value for k, v in result.policy_file.overrides.items()}} if result.policy_file and result.policy_file.overrides else {}),
+                    # ADR-024 §D4/D5: header-scope ledger. Out-of-surface
+                    # findings are disclosed here for auditability (never
+                    # silently dropped) when --scope-public-headers is active.
+                    **(
+                        {
+                            "surfaceScope": {
+                                "enabled": True,
+                                "outOfSurfaceCount": result.out_of_surface_count,
+                                "outOfSurfaceChanges": [
+                                    {
+                                        "kind": c.kind.value,
+                                        "symbol": c.symbol,
+                                        "description": c.description,
+                                        **({"sourceLocation": c.source_location} if c.source_location else {}),
+                                    }
+                                    for c in result.out_of_surface_changes
+                                ],
+                            }
+                        }
+                        if result.scope_to_public_surface
+                        else {}
+                    ),
                 },
             }
         ],

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -119,6 +119,17 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     return converted
 
 
+def _scope_origin_or_unknown(raw: Any) -> ScopeOrigin:
+    """Deserialize a ScopeOrigin, defaulting unknown/invalid values to UNKNOWN.
+
+    A hand-edited or newer-schema snapshot may carry an origin string this
+    build does not recognize; that must not abort the whole load."""
+    try:
+        return ScopeOrigin(raw if raw is not None else "unknown")
+    except ValueError:
+        return ScopeOrigin.UNKNOWN
+
+
 def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:
     return EnumType(
         name=e["name"],
@@ -126,7 +137,7 @@ def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:
         underlying_type=e.get("underlying_type", "int"),
         source_location=e.get("source_location"),
         source_header=e.get("source_header"),
-        origin=ScopeOrigin(e.get("origin", "unknown")),
+        origin=_scope_origin_or_unknown(e.get("origin")),
     )
 
 
@@ -367,7 +378,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             is_hidden_friend=f.get("is_hidden_friend"),
             # Provenance (v6) — missing on older snapshots → None / UNKNOWN.
             source_header=f.get("source_header"),
-            origin=ScopeOrigin(f.get("origin", "unknown")),
+            origin=_scope_origin_or_unknown(f.get("origin")),
         )
         for f in d.get("functions", [])
     ]
@@ -381,7 +392,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             access=AccessLevel(v.get("access", "public")),
             elf_visibility=ElfVisibility(v["elf_visibility"]) if v.get("elf_visibility") else None,
             source_header=v.get("source_header"),
-            origin=ScopeOrigin(v.get("origin", "unknown")),
+            origin=_scope_origin_or_unknown(v.get("origin")),
         )
         for v in d.get("variables", [])
     ]
@@ -410,7 +421,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             is_union=t.get("is_union", t.get("kind") == "union"),
             is_opaque=t.get("is_opaque", False),
             source_header=t.get("source_header"),
-            origin=ScopeOrigin(t.get("origin", "unknown")),
+            origin=_scope_origin_or_unknown(t.get("origin")),
         )
         for t in d.get("types", [])
     ]

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -34,6 +34,7 @@ from .model import (
     Param,
     ParamKind,
     RecordType,
+    ScopeOrigin,
     TypeField,
     Variable,
     Visibility,
@@ -46,7 +47,8 @@ from .model import (
 # v3: pe/macho metadata fields added (multi-format support)
 # v4: provenance metadata (git_commit, git_tag, created_at, build_id)
 # v5: build_mode capture (compiler/stdlib/std normalization)
-SCHEMA_VERSION: int = 5
+# v6: declaration provenance (source_header + origin on functions/variables/types/enums; ADR-015)
+SCHEMA_VERSION: int = 6
 
 
 def _sets_to_lists(obj: Any) -> Any:
@@ -122,6 +124,9 @@ def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:
         name=e["name"],
         members=[EnumMember(name=m["name"], value=m["value"]) for m in e.get("members", [])],
         underlying_type=e.get("underlying_type", "int"),
+        source_location=e.get("source_location"),
+        source_header=e.get("source_header"),
+        origin=ScopeOrigin(e.get("origin", "unknown")),
     )
 
 
@@ -360,6 +365,9 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             # an older snapshot loads as None and suppresses the
             # HIDDEN_FRIEND_ADDED/_REMOVED transition detector.
             is_hidden_friend=f.get("is_hidden_friend"),
+            # Provenance (v6) — missing on older snapshots → None / UNKNOWN.
+            source_header=f.get("source_header"),
+            origin=ScopeOrigin(f.get("origin", "unknown")),
         )
         for f in d.get("functions", [])
     ]
@@ -372,6 +380,8 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             value=v.get("value"),
             access=AccessLevel(v.get("access", "public")),
             elf_visibility=ElfVisibility(v["elf_visibility"]) if v.get("elf_visibility") else None,
+            source_header=v.get("source_header"),
+            origin=ScopeOrigin(v.get("origin", "unknown")),
         )
         for v in d.get("variables", [])
     ]
@@ -399,6 +409,8 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             source_location=t.get("source_location"),
             is_union=t.get("is_union", t.get("kind") == "union"),
             is_opaque=t.get("is_opaque", False),
+            source_header=t.get("source_header"),
+            origin=ScopeOrigin(t.get("origin", "unknown")),
         )
         for t in d.get("types", [])
     ]

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -595,6 +595,7 @@ def run_compare(
     new_debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
     scope_to_public_surface: bool = False,
+    force_public_symbols: set[str] | None = None,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Compare two ABI inputs and return the classified diff result.
 
@@ -638,6 +639,7 @@ def run_compare(
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_to_public_surface,
+        force_public_symbols=force_public_symbols,
     )
     result.old_metadata = collect_metadata(old_input)
     result.new_metadata = collect_metadata(new_input)

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -594,7 +594,7 @@ def run_compare(
     old_debug_roots: list[Path] | None = None,
     new_debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
-    scope_to_public_surface: bool = False,
+    scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Compare two ABI inputs and return the classified diff result.

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -262,14 +262,41 @@ def change_in_public_surface(
 ) -> bool:
     """Return ``True`` if *change* concerns the public ABI surface.
 
+    Thin boolean wrapper over :func:`classify_change_surface` for callers
+    that only need the in/out decision.
+    """
+    return classify_change_surface(change, surf_old, surf_new)[0]
+
+
+# Exclusion reasons recorded on the surface ledger (ADR-024 §D5.1). These are
+# the reasons the *current* (pre-provenance) resolver can determine with
+# confidence. The provenance-dependent reasons from the ADR
+# (``private-header`` / ``system-header`` / ``mangling-fallback`` /
+# ``no-provenance``) require Phase 1 source-header tagging and are not emitted
+# yet; ``suppressed-by-user`` belongs to the separate suppression ledger.
+REASON_NOT_EXPORTED = "not-exported"        # symbol known but not in the public export set
+REASON_NON_PUBLIC_TYPE = "non-public-type"  # type reachable by no public API root
+
+
+def classify_change_surface(
+    change: Change,
+    surf_old: PublicSurface,
+    surf_new: PublicSurface,
+) -> tuple[bool, str | None]:
+    """Classify *change* against the public surface.
+
+    Returns ``(in_surface, reason)``. ``reason`` is ``None`` when the change
+    is in-surface (kept); otherwise it is a stable ledger reason code
+    explaining *why* the finding was demoted (ADR-024 §D5.1).
+
     Conservative by construction (ADR-024 §D5): leak findings, unknown
-    symbols, and unknown types all return ``True`` so scoping can only
-    ever remove findings it is *confident* are private.
+    symbols, and unknown types all stay in-surface so scoping can only ever
+    remove findings it is *confident* are private.
     """
     if change.kind.value in _NEVER_FILTER_KIND_NAMES:
-        return True
+        return True, None
     if not (surf_old.resolvable or surf_new.resolvable):
-        return True
+        return True, None
 
     public_symbols = surf_old.public_symbols | surf_new.public_symbols
     all_symbols = surf_old.all_symbols | surf_new.all_symbols
@@ -279,9 +306,10 @@ def change_in_public_surface(
     sym = change.symbol or ""
     # Symbol-level finding (function/variable): public iff a public symbol.
     if sym in all_symbols:
-        return sym in public_symbols
+        return (True, None) if sym in public_symbols else (False, REASON_NOT_EXPORTED)
     if sym and "::" in sym and sym.rsplit("::", 1)[1] in all_symbols:
-        return sym.rsplit("::", 1)[1] in public_symbols
+        tail = sym.rsplit("::", 1)[1]
+        return (True, None) if tail in public_symbols else (False, REASON_NOT_EXPORTED)
 
     # Type-level finding: check the implicated type name(s). A finding is
     # in-surface if *any* implicated type is reachable from the public API.
@@ -298,10 +326,12 @@ def change_in_public_surface(
     from .internal_leak import DEFAULT_INTERNAL_NAMESPACES, is_internal_type
 
     if any(is_internal_type(c, DEFAULT_INTERNAL_NAMESPACES) for c in candidates):
-        return True
+        return True, None
 
     known = {c for c in candidates if c in all_types}
     if not known:
         # We cannot place this finding — keep it (never hide an unknown).
-        return True
-    return bool(known & public_types)
+        return True, None
+    if known & public_types:
+        return True, None
+    return False, REASON_NON_PUBLIC_TYPE

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -354,7 +354,10 @@ def classify_change_surface(
     """
     if change.kind.value in _NEVER_FILTER_KIND_NAMES:
         return True, None
-    if not (surf_old.resolvable or surf_new.resolvable):
+    if not (surf_old.resolvable and surf_new.resolvable):
+        # If either side lacks a resolvable surface we cannot confidently
+        # place a finding as private on *both* versions — keep everything
+        # rather than risk hiding a real change from the unresolved side.
         return True, None
 
     public_symbols = surf_old.public_symbols | surf_new.public_symbols

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -49,7 +49,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from .model import Visibility
+from .model import ScopeOrigin, Visibility
 
 if TYPE_CHECKING:
     from .checker_types import Change
@@ -133,6 +133,10 @@ class PublicSurface:
     public_types: set[str] = field(default_factory=set)
     all_types: set[str] = field(default_factory=set)
     resolvable: bool = False
+    # Origin (ADR-024 D1 / ADR-015 v6) keyed by every symbol key and type
+    # name. Only populated when the snapshot was dumped with a public-header
+    # set; otherwise every value is UNKNOWN and provenance reasons never fire.
+    origin_by_key: dict[str, ScopeOrigin] = field(default_factory=dict)
 
 
 def _symbol_keys(name: str, mangled: str) -> set[str]:
@@ -141,6 +145,26 @@ def _symbol_keys(name: str, mangled: str) -> set[str]:
     if name and "::" in name:
         keys.add(name.rsplit("::", 1)[1])
     return keys
+
+
+# Origins that justify demoting a finding out of the public surface.
+_DEMOTE_ORIGINS: frozenset[ScopeOrigin] = frozenset(
+    {ScopeOrigin.PRIVATE_HEADER, ScopeOrigin.SYSTEM_HEADER}
+)
+
+
+def _merge_origin(existing: ScopeOrigin | None, new: ScopeOrigin) -> ScopeOrigin:
+    """Combine origins sharing a key. A non-demote origin (public/unknown/…)
+    always wins so we never demote a key that *any* public-header declaration
+    contributes to (conservative, ADR-024 §D5)."""
+    if existing is None or existing in _DEMOTE_ORIGINS:
+        return new if existing is None or new not in _DEMOTE_ORIGINS else existing
+    return existing
+
+
+def _record_origin(surface: PublicSurface, keys: set[str], origin: ScopeOrigin) -> None:
+    for k in keys:
+        surface.origin_by_key[k] = _merge_origin(surface.origin_by_key.get(k), origin)
 
 
 def _index_surface_types(snap: AbiSnapshot, surface: PublicSurface) -> dict[str, RecordType]:
@@ -153,10 +177,15 @@ def _index_surface_types(snap: AbiSnapshot, surface: PublicSurface) -> dict[str,
     for rec in snap.types:
         surface.all_types.add(rec.name)
         record_by_name[rec.name] = rec
+        keys = {rec.name}
         if "::" in rec.name:
-            record_by_name.setdefault(rec.name.rsplit("::", 1)[1], rec)
+            tail = rec.name.rsplit("::", 1)[1]
+            record_by_name.setdefault(tail, rec)
+            keys.add(tail)
+        _record_origin(surface, keys, getattr(rec, "origin", ScopeOrigin.UNKNOWN))
     for en in snap.enums:
         surface.all_types.add(en.name)
+        _record_origin(surface, {en.name}, getattr(en, "origin", ScopeOrigin.UNKNOWN))
     for alias in snap.typedefs:
         surface.all_types.add(alias)
     return record_by_name
@@ -173,6 +202,7 @@ def _seed_public_roots(snap: AbiSnapshot, surface: PublicSurface) -> tuple[set[s
     for fn in snap.functions:
         keys = _symbol_keys(fn.name, fn.mangled)
         surface.all_symbols |= keys
+        _record_origin(surface, keys, getattr(fn, "origin", ScopeOrigin.UNKNOWN))
         if fn.visibility == Visibility.PUBLIC:
             has_public = True
             surface.public_symbols |= keys
@@ -182,6 +212,7 @@ def _seed_public_roots(snap: AbiSnapshot, surface: PublicSurface) -> tuple[set[s
     for var in snap.variables:
         keys = _symbol_keys(var.name, var.mangled)
         surface.all_symbols |= keys
+        _record_origin(surface, keys, getattr(var, "origin", ScopeOrigin.UNKNOWN))
         if var.visibility == Visibility.PUBLIC:
             has_public = True
             surface.public_symbols |= keys
@@ -268,14 +299,42 @@ def change_in_public_surface(
     return classify_change_surface(change, surf_old, surf_new)[0]
 
 
-# Exclusion reasons recorded on the surface ledger (ADR-024 §D5.1). These are
-# the reasons the *current* (pre-provenance) resolver can determine with
-# confidence. The provenance-dependent reasons from the ADR
-# (``private-header`` / ``system-header`` / ``mangling-fallback`` /
-# ``no-provenance``) require Phase 1 source-header tagging and are not emitted
-# yet; ``suppressed-by-user`` belongs to the separate suppression ledger.
-REASON_NOT_EXPORTED = "not-exported"        # symbol known but not in the public export set
+# Exclusion reasons recorded on the surface ledger (ADR-024 §D5.1).
+# ``private-header`` / ``system-header`` are provenance-driven and only fire
+# when the snapshot was dumped with a public-header set (Phase 1, ADR-015 v6);
+# ``not-exported`` / ``non-public-type`` are the linkage/reachability reasons
+# the resolver can always determine. ``suppressed-by-user`` belongs to the
+# separate suppression ledger.
+REASON_NOT_EXPORTED = "not-exported"  # symbol known but not in the public export set
 REASON_NON_PUBLIC_TYPE = "non-public-type"  # type reachable by no public API root
+REASON_PRIVATE_HEADER = (
+    "private-header"  # decl originates in a non-public project header
+)
+REASON_SYSTEM_HEADER = "system-header"  # decl originates in a toolchain/system header
+
+# Map a demotable origin to its ledger reason code.
+_ORIGIN_REASON: dict[ScopeOrigin, str] = {
+    ScopeOrigin.PRIVATE_HEADER: REASON_PRIVATE_HEADER,
+    ScopeOrigin.SYSTEM_HEADER: REASON_SYSTEM_HEADER,
+}
+
+
+def _origin_reason(
+    surf_old: PublicSurface, surf_new: PublicSurface, key: str
+) -> str | None:
+    """Return the provenance demotion reason for *key*, or None to defer to
+    linkage/reachability. A public-header (or unknown) origin on *either* side
+    blocks demotion (conservative)."""
+    o_old = surf_old.origin_by_key.get(key, ScopeOrigin.UNKNOWN)
+    o_new = surf_new.origin_by_key.get(key, ScopeOrigin.UNKNOWN)
+    # Only demote when both sides agree the key is private/system. If either
+    # side is public/unknown/generated/export-only, keep deferring.
+    if o_old in _ORIGIN_REASON and o_new in _ORIGIN_REASON:
+        # Prefer private-header when the two disagree (the stronger signal).
+        if ScopeOrigin.PRIVATE_HEADER in (o_old, o_new):
+            return REASON_PRIVATE_HEADER
+        return REASON_SYSTEM_HEADER
+    return None
 
 
 def classify_change_surface(
@@ -305,10 +364,18 @@ def classify_change_surface(
 
     sym = change.symbol or ""
     # Symbol-level finding (function/variable): public iff a public symbol.
+    # A confident private/system-header origin demotes even an exported
+    # symbol — that is exactly the leaked-private-header case scoping targets.
     if sym in all_symbols:
+        reason = _origin_reason(surf_old, surf_new, sym)
+        if reason is not None:
+            return False, reason
         return (True, None) if sym in public_symbols else (False, REASON_NOT_EXPORTED)
     if sym and "::" in sym and sym.rsplit("::", 1)[1] in all_symbols:
         tail = sym.rsplit("::", 1)[1]
+        reason = _origin_reason(surf_old, surf_new, tail)
+        if reason is not None:
+            return False, reason
         return (True, None) if tail in public_symbols else (False, REASON_NOT_EXPORTED)
 
     # Type-level finding: check the implicated type name(s). A finding is
@@ -334,4 +401,13 @@ def classify_change_surface(
         return True, None
     if known & public_types:
         return True, None
+    # Prefer a provenance reason when every implicated type confidently
+    # originates from a private/system header; fall back to reachability.
+    type_reasons = {_origin_reason(surf_old, surf_new, c) for c in known}
+    if None not in type_reasons and type_reasons:
+        return False, (
+            REASON_PRIVATE_HEADER
+            if REASON_PRIVATE_HEADER in type_reasons
+            else REASON_SYSTEM_HEADER
+        )
     return False, REASON_NON_PUBLIC_TYPE

--- a/docs/development/adr/015-snapshot-serialization.md
+++ b/docs/development/adr/015-snapshot-serialization.md
@@ -55,7 +55,7 @@ class AbiSnapshot:
 ### 2. Integer schema versioning
 
 ```python
-SCHEMA_VERSION: int = 3
+SCHEMA_VERSION: int = 6
 ```
 
 Version history:
@@ -65,6 +65,9 @@ Version history:
 | 1 | Initial format (no `schema_version` field) | — |
 | 2 | `schema_version` field added | PR #89 |
 | 3 | `pe` and `macho` metadata fields added (multi-format support) | — |
+| 4 | Provenance metadata (`git_commit`, `git_tag`, `created_at`, `build_id`) | — |
+| 5 | `build_mode` capture (compiler/stdlib/std normalization) | — |
+| 6 | Declaration provenance: `source_header` + `origin` on functions/variables/types/enums | — |
 
 **Integer versioning** was chosen over semver because:
 
@@ -86,6 +89,31 @@ read the snapshot anyway — forward compatibility is best-effort.
 
 **Writing**: Always writes the current `SCHEMA_VERSION`. There is no option
 to write in an older format.
+
+### 3a. Declaration provenance fields (v6)
+
+`Function`, `Variable`, `RecordType`, and `EnumType` each carry two
+provenance fields:
+
+- `source_header` — the defining header path, derived from the existing
+  `source_location` with any trailing `:line` / `:line:col` stripped. Always
+  populated when a source location is available; it is descriptive metadata.
+- `origin` — a `ScopeOrigin` classification of `source_header` against the
+  user-provided public-header set:
+
+  | Value | Meaning |
+  |-------|---------|
+  | `public_header` | Header matches a `--public-header` / `--public-header-dir` input |
+  | `private_header` | A project header outside the public set |
+  | `system_header` | A toolchain/system header (`/usr/include`, MSVC, Xcode SDK, …) |
+  | `unknown` | No public set was provided, or no source location was available |
+
+Classification is **opt-in** (decision D4): without `--public-header` /
+`--public-header-dir`, every `origin` is `unknown` and downstream behaviour
+is unchanged. Matching is done on path *segments* (suffix / basename /
+directory containment) so absolute build-tree prefixes that never appear on
+the command line (e.g. `/build/abc/src/include/api.h`) still resolve against
+`include/api.h` (decision D3).
 
 ### 4. Serialization mechanics
 

--- a/docs/development/adr/015-snapshot-serialization.md
+++ b/docs/development/adr/015-snapshot-serialization.md
@@ -99,13 +99,16 @@ provenance fields:
   `source_location` with any trailing `:line` / `:line:col` stripped. Always
   populated when a source location is available; it is descriptive metadata.
 - `origin` — a `ScopeOrigin` classification of `source_header` against the
-  user-provided public-header set:
+  user-provided public-header set. This is the *Origin* axis of ADR-024's
+  two-axis Linkage × Origin surface model:
 
   | Value | Meaning |
   |-------|---------|
   | `public_header` | Header matches a `--public-header` / `--public-header-dir` input |
   | `private_header` | A project header outside the public set |
   | `system_header` | A toolchain/system header (`/usr/include`, MSVC, Xcode SDK, …) |
+  | `generated` | A machine-generated header (`moc_*`, `*.pb.h`, `generated/`, …) |
+  | `export_only` | Exported by the binary but absent from any header (no provenance) |
   | `unknown` | No public set was provided, or no source location was available |
 
 Classification is **opt-in** (decision D4): without `--public-header` /

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -222,10 +222,10 @@ The feature is only credible if we can prove it neither over- nor under-filters.
 | Phase | Scope |
 |-------|-------|
 | **0** | PE/Mach-O header plumbing + directory expansion + fallback warnings — **done (PR #259)** |
-| **1** | Provenance capture: source-header tagging in castxml/DWARF/PDB parsers; model + serialization fields (schema bump) — *future (see note)* |
-| **2** | Header-scope resolution + surface ledger + `--scope-public-headers`/`--show-filtered` (opt-in, default off) — **done** (ledger now also disclosed in JSON `surface_scope` / SARIF `surfaceScope`, not just stderr text) |
+| **1** | Provenance capture: source-header tagging in castxml/DWARF/PDB parsers; model + serialization fields (schema bump) — **done** (`source_header` + 6-way `ScopeOrigin` on functions/variables/types/enums; schema v6; castxml + DWARF populate locations; PDB pending) |
+| **2** | Header-scope resolution + surface ledger + `--scope-public-headers`/`--show-filtered` (opt-in, default off) — **done** (ledger now also disclosed in JSON `surface_scope` / SARIF `surfaceScope`, not just stderr text; provenance-driven `private-header`/`system-header` reasons now wired) |
 | **3** | Reachability closure + leak-guard integration (extend `internal_leak.py`) — **done (closure shipped; leak exemption wired)** |
-| **4** | User-control overlay: widening public allowlist; integrate suppression as the narrowing layer; precedence + anti-hiding guard |
+| **4** | User-control overlay: widening public allowlist; integrate suppression as the narrowing layer; precedence + anti-hiding guard — **done** (widening via `--public-symbol`/`--public-symbols-list`; suppression remains the narrowing layer; widening only ever *keeps*, never hides) |
 | **5** | Parity + FP-rate gates; flip default to `header-scoped` once validated — *partial:* property-based monotonicity/subset/idempotence tests shipped (`tests/test_surface_property.py`); libabigail/abicc parity and the FP-rate CI gate remain |
 
 ### Implementation note (Phase 2/3 as shipped)

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -126,6 +126,13 @@ hard `--headers-dir` drop: we keep auditability.
    the full list) of entities **included** vs **excluded/demoted**, each with a reason:
    `private-header`, `system-header`, `not-exported`, `suppressed-by-user`,
    `mangling-fallback`, `no-provenance`. Available in text, JSON, and SARIF.
+   *Shipped (partial):* the ledger is disclosed in text/JSON/SARIF, and the
+   reasons the pre-provenance resolver can determine with confidence —
+   `not-exported` (symbol not in the export set) and `non-public-type` (type
+   reachable by no public root) — are tagged per finding. The
+   provenance-dependent reasons (`private-header`, `system-header`,
+   `mangling-fallback`, `no-provenance`) await Phase 1; `suppressed-by-user`
+   lives in the separate suppression ledger.
 2. **Leak guard always wins.** If a `PRIVATE_HEADER`-origin type is reachable from a
    `PUBLIC_HEADER`+exported root, emit `INTERNAL_TYPE_LEAKS_VIA_PUBLIC_API` (extend
    `internal_leak.py`) **regardless of scoping mode**. Scoping must never suppress a leak.
@@ -239,7 +246,9 @@ captures, avoiding the schema churn of full Phase 1 provenance:
   are exempt. Disclosing the ledger in the machine-readable formats — not
   just stderr — is what makes the "demote + disclose" promise (D4/D5)
   auditable in CI, the key difference from libabigail's hard `--headers-dir`
-  drop.
+  drop. Each demoted finding is tagged with a `reason` code — `not-exported`
+  or `non-public-type`, the two the pre-provenance resolver can determine
+  confidently (`classify_change_surface` in `abicheck/surface.py`).
 
 This is wired as the opt-in `FilterNonPublicSurface` post-processing step
 (`compare(..., scope_to_public_surface=True)` /

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -216,10 +216,10 @@ The feature is only credible if we can prove it neither over- nor under-filters.
 |-------|-------|
 | **0** | PE/Mach-O header plumbing + directory expansion + fallback warnings — **done (PR #259)** |
 | **1** | Provenance capture: source-header tagging in castxml/DWARF/PDB parsers; model + serialization fields (schema bump) — *future (see note)* |
-| **2** | Header-scope resolution + surface ledger + `--scope-public-headers`/`--show-filtered` (opt-in, default off) — **done** |
+| **2** | Header-scope resolution + surface ledger + `--scope-public-headers`/`--show-filtered` (opt-in, default off) — **done** (ledger now also disclosed in JSON `surface_scope` / SARIF `surfaceScope`, not just stderr text) |
 | **3** | Reachability closure + leak-guard integration (extend `internal_leak.py`) — **done (closure shipped; leak exemption wired)** |
 | **4** | User-control overlay: widening public allowlist; integrate suppression as the narrowing layer; precedence + anti-hiding guard |
-| **5** | Parity + FP-rate gates; flip default to `header-scoped` once validated |
+| **5** | Parity + FP-rate gates; flip default to `header-scoped` once validated — *partial:* property-based monotonicity/subset/idempotence tests shipped (`tests/test_surface_property.py`); libabigail/abicc parity and the FP-rate CI gate remain |
 
 ### Implementation note (Phase 2/3 as shipped)
 
@@ -233,14 +233,21 @@ captures, avoiding the schema churn of full Phase 1 provenance:
 * **Public types** = the transitive reachability closure over those roots'
   return/parameter/field/base/typedef types (`abicheck/surface.py`).
 * Findings outside the surface are moved to an audit ledger
-  (`DiffResult.out_of_surface_changes`, surfaced by `--show-filtered`),
-  never dropped; internal-leak kinds are exempt.
+  (`DiffResult.out_of_surface_changes`, surfaced by `--show-filtered` on the
+  terminal and by the `surface_scope` (JSON) / `surfaceScope` (SARIF)
+  objects in machine-readable output), never dropped; internal-leak kinds
+  are exempt. Disclosing the ledger in the machine-readable formats — not
+  just stderr — is what makes the "demote + disclose" promise (D4/D5)
+  auditable in CI, the key difference from libabigail's hard `--headers-dir`
+  drop.
 
 This is wired as the opt-in `FilterNonPublicSurface` post-processing step
 (`compare(..., scope_to_public_surface=True)` /
 `abicheck compare --scope-public-headers`). Example cases
 `case118`–`case120` exercise it end-to-end; `tests/test_surface.py` covers
-the resolver, classifier, and anti-hiding guarantees.
+the resolver, classifier, anti-hiding guarantees, and the JSON/SARIF ledger,
+and `tests/test_surface_property.py` adds the property-based monotonicity /
+subset / order-independence guarantees from the validation strategy (§3).
 
 The remaining Phase 1 work — recording *which* header each declaration came
 from, so the surface can distinguish "private header transitively included"

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -226,7 +226,7 @@ The feature is only credible if we can prove it neither over- nor under-filters.
 | **2** | Header-scope resolution + surface ledger + `--scope-public-headers`/`--show-filtered` (opt-in, default off) — **done** (ledger now also disclosed in JSON `surface_scope` / SARIF `surfaceScope`, not just stderr text; provenance-driven `private-header`/`system-header` reasons now wired) |
 | **3** | Reachability closure + leak-guard integration (extend `internal_leak.py`) — **done (closure shipped; leak exemption wired)** |
 | **4** | User-control overlay: widening public allowlist; integrate suppression as the narrowing layer; precedence + anti-hiding guard — **done** (widening via `--public-symbol`/`--public-symbols-list`; suppression remains the narrowing layer; widening only ever *keeps*, never hides) |
-| **5** | Parity + FP-rate gates; flip default to `header-scoped` once validated — *partial:* property-based monotonicity/subset/idempotence tests shipped (`tests/test_surface_property.py`); libabigail/abicc parity and the FP-rate CI gate remain |
+| **5** | Parity + FP-rate gates; flip default to `header-scoped` once validated — **done**: property-based monotonicity/subset/idempotence/anti-hiding/widening tests (`tests/test_surface_property.py`), libabigail scoping-parity lane (`tests/test_surface_scope_parity.py`), FP-rate gate (`scripts/check_fp_rate.py`, wired into CI + fast pytest), and the default flipped to header-scoped (`--no-scope-public-headers` opts out; a no-op when no public surface resolves) |
 
 ### Implementation note (Phase 2/3 as shipped)
 

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -68,10 +68,19 @@ Use `--show-filtered` to print the ledger on the terminal.
 
 ### How it appears in each format
 
-**Text**: With `--show-filtered`, an audit block on stderr:
+Each demoted finding carries a `reason` code explaining why it was excluded:
+
+- `not-exported` — the symbol is known but not in the public export set.
+- `non-public-type` — the type is reachable from no public API root.
+
+(Provenance-derived reasons such as `private-header` / `system-header` are
+planned once per-declaration header tracking lands — see ADR-024 Phase 1.)
+
+**Text**: With `--show-filtered`, an audit block on stderr (the reason is shown
+in parentheses):
 ```
 Filtered as non-public ABI surface (1 finding, --scope-public-headers):
-  - type_size_changed: InternalCache
+  - type_size_changed: InternalCache (non-public-type)
 ```
 
 **JSON**: A top-level `surface_scope` object (present only when scoping is
@@ -83,14 +92,14 @@ active):
   "out_of_surface_changes": [
     {"kind": "type_size_changed", "symbol": "InternalCache",
      "description": "Size changed: InternalCache (64 → 128 bits)",
-     "source_location": null}
+     "source_location": null, "reason": "non-public-type"}
   ]
 }
 ```
 
 **SARIF**: A `surfaceScope` object in run-level `properties` with
 `outOfSurfaceCount` and `outOfSurfaceChanges` (same per-finding fields,
-camelCased), present only when scoping is active.
+camelCased; `reason` included when known), present only when scoping is active.
 
 ## `--show-only` filter
 

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -66,6 +66,30 @@ excluded" trail stays inspectable. Internal-type leaks are never filtered.
 
 Use `--show-filtered` to print the ledger on the terminal.
 
+### Widening the surface (`--public-symbol`)
+
+Some symbols you *do* guarantee as public can't be seen by header provenance —
+hand-written asm stubs, `.def` exports, `extern "C"` shims, or symbols whose
+MSVC mangling castxml can't match. The **widening overlay** (ADR-024 §D6) forces
+such symbols back into the public surface so their changes are reported rather
+than demoted:
+
+```bash
+# Force individual symbols (repeatable), à la abi-compliance-checker -symbols-list
+abicheck compare old.so new.so --scope-public-headers \
+    --public-symbol my_asm_stub --public-symbol _ZN3foo3barEv
+
+# Or from a file (one symbol per line; '#' comments and blank lines ignored)
+abicheck compare old.so new.so --scope-public-headers \
+    --public-symbols-list public.syms
+```
+
+Matching is on the symbol as recorded on the finding (mangled or demangled),
+plus the trailing `::` segment of a qualified name. Widening only ever *keeps* a
+finding — it can never hide a break — and only takes effect together with
+`--scope-public-headers`. It is the counterpart to suppression, which *narrows*
+the surface; the two remain separate, auditable inputs.
+
 ### How it appears in each format
 
 Each demoted finding carries a `reason` code explaining why it was excluded:

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -57,12 +57,19 @@ JUnit-specific redundancy metadata is emitted.
 
 ## Public-header surface scoping
 
-`--scope-public-headers` (ADR-024) restricts findings to the *public* ABI
+Public-header surface scoping (ADR-024) restricts findings to the *public* ABI
 surface — the symbols exported **and** declared in the public headers you
 supplied, plus the types reachable from them. Changes that fall outside that
 surface (e.g. a layout change to an internal struct no public API references)
 are **not dropped**: they are moved to an audit ledger so the "why was this
 excluded" trail stays inspectable. Internal-type leaks are never filtered.
+
+Scoping is **on by default** (ADR-024 Phase 5). When no public-header surface
+can be resolved — e.g. comparing two stripped `.so` files with no header or
+DWARF provenance — scoping is automatically a no-op and every finding is
+reported, so the default never hides anything it cannot place. Pass
+`--no-scope-public-headers` to force the unscoped report (every finding,
+regardless of surface).
 
 Use `--show-filtered` to print the ledger on the terminal.
 

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -55,6 +55,43 @@ and source sections include their own redundant counts.
 receives them, so derived changes do not appear as test cases. No
 JUnit-specific redundancy metadata is emitted.
 
+## Public-header surface scoping
+
+`--scope-public-headers` (ADR-024) restricts findings to the *public* ABI
+surface — the symbols exported **and** declared in the public headers you
+supplied, plus the types reachable from them. Changes that fall outside that
+surface (e.g. a layout change to an internal struct no public API references)
+are **not dropped**: they are moved to an audit ledger so the "why was this
+excluded" trail stays inspectable. Internal-type leaks are never filtered.
+
+Use `--show-filtered` to print the ledger on the terminal.
+
+### How it appears in each format
+
+**Text**: With `--show-filtered`, an audit block on stderr:
+```
+Filtered as non-public ABI surface (1 finding, --scope-public-headers):
+  - type_size_changed: InternalCache
+```
+
+**JSON**: A top-level `surface_scope` object (present only when scoping is
+active):
+```json
+"surface_scope": {
+  "enabled": true,
+  "out_of_surface_count": 1,
+  "out_of_surface_changes": [
+    {"kind": "type_size_changed", "symbol": "InternalCache",
+     "description": "Size changed: InternalCache (64 → 128 bits)",
+     "source_location": null}
+  ]
+}
+```
+
+**SARIF**: A `surfaceScope` object in run-level `properties` with
+`outOfSurfaceCount` and `outOfSurfaceChanges` (same per-finding fields,
+camelCased), present only when scoping is active.
+
 ## `--show-only` filter
 
 Limit displayed changes by severity, element, or action (AND across dimensions,

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -72,9 +72,16 @@ Each demoted finding carries a `reason` code explaining why it was excluded:
 
 - `not-exported` — the symbol is known but not in the public export set.
 - `non-public-type` — the type is reachable from no public API root.
+- `private-header` — the declaration originates in a project header outside
+  the public-header set.
+- `system-header` — the declaration originates in a toolchain/system header
+  (`/usr/include`, MSVC, Xcode SDK, …).
 
-(Provenance-derived reasons such as `private-header` / `system-header` are
-planned once per-declaration header tracking lands — see ADR-024 Phase 1.)
+The `private-header` / `system-header` reasons are provenance-derived: they
+only appear when the snapshots were produced with `--public-header` /
+`--public-header-dir` (ADR-015 schema v6). Without a public-header set, every
+declaration's origin is `unknown` and only the linkage/reachability reasons
+above are emitted.
 
 **Text**: With `--show-filtered`, an audit block on stderr (the reason is shown
 in parentheses):

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -78,7 +78,7 @@ planned once per-declaration header tracking lands — see ADR-024 Phase 1.)
 
 **Text**: With `--show-filtered`, an audit block on stderr (the reason is shown
 in parentheses):
-```
+```text
 Filtered as non-public ABI surface (1 finding, --scope-public-headers):
   - type_size_changed: InternalCache (non-public-type)
 ```

--- a/scripts/check_fp_rate.py
+++ b/scripts/check_fp_rate.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""False-positive / false-negative rate gate for public-header surface scoping.
+
+ADR-024 §"Validation & testing strategy" §7 asks for an FP-rate gate "analogous
+to the mypy baseline gate": track the count on a benchmark corpus and fail CI on
+regression. This is the scoping-focused, build-free counterpart — a curated
+corpus of synthetic ``(old, new)`` snapshot pairs, each labelled with its
+ground-truth intent, run through ``compare(..., scope_to_public_surface=True)``:
+
+* **internal-noise** cases (a change to a private/internal entity) must scope to
+  a non-breaking verdict — a breaking verdict here is a **false positive**;
+* **real-break** cases (a change to the public surface) must stay breaking —
+  a non-breaking verdict here is a **false negative**.
+
+The gate fails if either count drifts above its documented baseline. Both
+baselines are **0**: the corpus is chosen so a correct implementation has a
+clean sheet. Run locally with ``python scripts/check_fp_rate.py``.
+"""
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from abicheck.checker import Verdict, compare  # noqa: E402
+from abicheck.model import (  # noqa: E402
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    ScopeOrigin,
+    TypeField,
+    Visibility,
+)
+
+# Verdicts that mean "this is a public-ABI break".
+_BREAKING_VERDICTS = {Verdict.API_BREAK, Verdict.BREAKING}
+
+# Documented baselines (see ADR-024 §7). Both are 0 — the corpus is built so a
+# correct scoping implementation produces neither a false positive nor a false
+# negative. Raise deliberately (with justification) only if the corpus changes.
+FP_BASELINE = 0
+FN_BASELINE = 0
+
+
+def _fn(name, *, ret="void", params=(), vis=Visibility.PUBLIC,
+        origin=ScopeOrigin.UNKNOWN) -> Function:
+    return Function(
+        name=name,
+        mangled=f"_Z{len(name)}{name}",
+        return_type=ret,
+        params=[Param(name=f"a{i}", type=t) for i, t in enumerate(params)],
+        visibility=vis,
+        origin=origin,
+    )
+
+
+def _rec(name, *, size=64, fields=(), origin=ScopeOrigin.UNKNOWN) -> RecordType:
+    return RecordType(
+        name=name,
+        kind="struct",
+        size_bits=size,
+        fields=[TypeField(name=n, type=t) for n, t in fields],
+        origin=origin,
+    )
+
+
+def _snap(version, *, functions=(), types=(), enums=()) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfp", version=version,
+        functions=list(functions), types=list(types), enums=list(enums),
+    )
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    internal_noise: bool  # True ⇒ must scope to non-breaking; False ⇒ must stay breaking
+    build: Callable[[], tuple[AbiSnapshot, AbiSnapshot]]
+
+
+# --- internal-noise cases (a breaking verdict here is a FALSE POSITIVE) -------
+
+def _internal_struct_size() -> tuple[AbiSnapshot, AbiSnapshot]:
+    # InternalCache is referenced by no public API → its layout change is noise.
+    old = _snap("1", functions=[_fn("api", ret="Result *")],
+                types=[_rec("Result", size=64), _rec("InternalCache", size=64)])
+    new = _snap("2", functions=[_fn("api", ret="Result *")],
+                types=[_rec("Result", size=64), _rec("InternalCache", size=128)])
+    return old, new
+
+
+def _elf_only_function_removed() -> tuple[AbiSnapshot, AbiSnapshot]:
+    old = _snap("1", functions=[_fn("api"), _fn("helper", vis=Visibility.ELF_ONLY)])
+    new = _snap("2", functions=[_fn("api")])
+    return old, new
+
+
+def _private_header_type_change() -> tuple[AbiSnapshot, AbiSnapshot]:
+    # A type whose provenance is a private header (origin set as if dumped with a
+    # public-header set) — demoted with the private-header reason.
+    old = _snap("1", functions=[_fn("api", ret="Result *", origin=ScopeOrigin.PUBLIC_HEADER)],
+                types=[_rec("Result", size=64, origin=ScopeOrigin.PUBLIC_HEADER),
+                       _rec("PrivThing", size=64, origin=ScopeOrigin.PRIVATE_HEADER)])
+    new = _snap("2", functions=[_fn("api", ret="Result *", origin=ScopeOrigin.PUBLIC_HEADER)],
+                types=[_rec("Result", size=64, origin=ScopeOrigin.PUBLIC_HEADER),
+                       _rec("PrivThing", size=128, origin=ScopeOrigin.PRIVATE_HEADER)])
+    return old, new
+
+
+# --- real-break cases (a non-breaking verdict here is a FALSE NEGATIVE) -------
+
+def _public_struct_size() -> tuple[AbiSnapshot, AbiSnapshot]:
+    old = _snap("1", functions=[_fn("api", ret="Result *")], types=[_rec("Result", size=64)])
+    new = _snap("2", functions=[_fn("api", ret="Result *")], types=[_rec("Result", size=128)])
+    return old, new
+
+
+def _public_function_removed() -> tuple[AbiSnapshot, AbiSnapshot]:
+    old = _snap("1", functions=[_fn("api"), _fn("also_public")])
+    new = _snap("2", functions=[_fn("api")])
+    return old, new
+
+
+def _public_param_type_changed() -> tuple[AbiSnapshot, AbiSnapshot]:
+    old = _snap("1", functions=[_fn("api", params=("int",))])
+    new = _snap("2", functions=[_fn("api", params=("long long",))])
+    return old, new
+
+
+def _leaked_internal_via_public_api() -> tuple[AbiSnapshot, AbiSnapshot]:
+    # Reachability keeps a type used by a public function in-surface (anti-hiding):
+    # changing it is observable to consumers even if it "looks" internal.
+    old = _snap("1", functions=[_fn("api", ret="Widget *")],
+                types=[_rec("Widget", size=64, fields=[("impl", "Pixels")]),
+                       _rec("Pixels", size=64)])
+    new = _snap("2", functions=[_fn("api", ret="Widget *")],
+                types=[_rec("Widget", size=64, fields=[("impl", "Pixels")]),
+                       _rec("Pixels", size=128)])
+    return old, new
+
+
+CORPUS: list[Case] = [
+    Case("internal_struct_size", True, _internal_struct_size),
+    Case("elf_only_function_removed", True, _elf_only_function_removed),
+    Case("private_header_type_change", True, _private_header_type_change),
+    Case("public_struct_size", False, _public_struct_size),
+    Case("public_function_removed", False, _public_function_removed),
+    Case("public_param_type_changed", False, _public_param_type_changed),
+    Case("leaked_internal_via_public_api", False, _leaked_internal_via_public_api),
+]
+
+
+@dataclass
+class Outcome:
+    false_positives: list[str]
+    false_negatives: list[str]
+
+
+def evaluate(corpus: list[Case] = CORPUS) -> Outcome:
+    """Run the corpus under scoping and collect FP / FN case names."""
+    fp: list[str] = []
+    fn: list[str] = []
+    for case in corpus:
+        old, new = case.build()
+        result = compare(old, new, scope_to_public_surface=True)
+        is_breaking = result.verdict in _BREAKING_VERDICTS
+        if case.internal_noise and is_breaking:
+            fp.append(case.name)
+        elif not case.internal_noise and not is_breaking:
+            fn.append(case.name)
+    return Outcome(false_positives=fp, false_negatives=fn)
+
+
+def main() -> int:
+    outcome = evaluate()
+    n_fp, n_fn = len(outcome.false_positives), len(outcome.false_negatives)
+    print(f"FP-rate gate: {len(CORPUS)} cases — {n_fp} false positive(s), {n_fn} false negative(s)")
+    if outcome.false_positives:
+        print(f"  false positives (internal noise reported as breaking): {outcome.false_positives}")
+    if outcome.false_negatives:
+        print(f"  false negatives (real break scoped away):               {outcome.false_negatives}")
+
+    failed = False
+    if n_fp > FP_BASELINE:
+        print(f"ERROR: false positives {n_fp} exceed baseline {FP_BASELINE}")
+        failed = True
+    if n_fn > FN_BASELINE:
+        print(f"ERROR: false negatives {n_fn} exceed baseline {FN_BASELINE}")
+        failed = True
+    if not failed:
+        print("FP-rate gate: OK (within baseline)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_abicc_parity.py
+++ b/tests/test_abicc_parity.py
@@ -428,7 +428,9 @@ def _run_abicheck(
             old_snap = dump(old, headers=headers_v1, version="v1", compiler=compiler, lang=lang)
             new_snap = dump(new, headers=headers_v2, version="v2", compiler=compiler, lang=lang)
 
-        result = compare(old_snap, new_snap)
+        # Parity baseline predates default scoping (ADR-024 Phase 5); compare
+        # unscoped for an apples-to-apples verdict against abi-compliance-checker.
+        result = compare(old_snap, new_snap, scope_to_public_surface=False)
         return result.verdict.value
     except Exception as exc:  # noqa: BLE001
         return f"ERROR: {exc}"

--- a/tests/test_abicc_scenario_parity.py
+++ b/tests/test_abicc_scenario_parity.py
@@ -255,7 +255,10 @@ class TestLeafClassVirtualMethodAdditions:
                 TypeField(name="x", type="int", offset_bits=64),
             ], vtable=["_ZN4Leaf7processEv"])],
         )
-        result = compare(old, new)
+        # Verdict-parity check: the Leaf class is reachable only through its own
+        # methods (not a free function), so disable surface scoping (default-on
+        # since ADR-024) to exercise raw vtable-change detection.
+        result = compare(old, new, scope_to_public_surface=False)
         kinds = _kinds(result)
         assert ChangeKind.FUNC_VIRTUAL_ADDED in kinds or ChangeKind.TYPE_VTABLE_CHANGED in kinds
         assert result.verdict == Verdict.BREAKING
@@ -275,7 +278,7 @@ class TestLeafClassVirtualMethodAdditions:
             types=[RecordType(name="Base", kind="class",
                               vtable=["_ZN4Base3fooEv", "_ZN4Base3barEv"])],
         )
-        result = compare(old, new)
+        result = compare(old, new, scope_to_public_surface=False)
         kinds = _kinds(result)
         assert ChangeKind.TYPE_VTABLE_CHANGED in kinds or ChangeKind.FUNC_VIRTUAL_ADDED in kinds
 

--- a/tests/test_abidiff_parity.py
+++ b/tests/test_abidiff_parity.py
@@ -202,7 +202,10 @@ def _run_abicheck(
             old_snap = dump(old, headers=headers_v1, version="v1", compiler=compiler)
             new_snap = dump(new, headers=headers_v2, version="v2", compiler=compiler)
 
-        result = compare(old_snap, new_snap)
+        # Parity baseline is abidiff *without* --headers-dir (unscoped), so run
+        # abicheck unscoped too for an apples-to-apples verdict comparison
+        # (surface scoping is on by default since ADR-024 Phase 5).
+        result = compare(old_snap, new_snap, scope_to_public_surface=False)
         return result.verdict.value
     except Exception as exc:  # noqa: BLE001
         return f"ERROR: {exc}"

--- a/tests/test_abidiff_parity_extended.py
+++ b/tests/test_abidiff_parity_extended.py
@@ -154,7 +154,9 @@ def _run_abicheck(old, new, hdr_v1, hdr_v2, lang, tmp_path):
         old_snap = dump(old, headers=headers_v1, version="v1", compiler=compiler)
         new_snap = dump(new, headers=headers_v2, version="v2", compiler=compiler)
 
-    result = compare(old_snap, new_snap)
+    # Parity baseline is abidiff without --headers-dir (unscoped); run abicheck
+    # unscoped too (surface scoping is default-on since ADR-024 Phase 5).
+    result = compare(old_snap, new_snap, scope_to_public_surface=False)
     return result.verdict.value
 
 

--- a/tests/test_baseline_pinning.py
+++ b/tests/test_baseline_pinning.py
@@ -26,8 +26,8 @@ def _sample_snap(**kwargs) -> AbiSnapshot:
 # ---------------------------------------------------------------------------
 
 class TestSchemaV4:
-    def test_schema_version_is_5(self):
-        assert SCHEMA_VERSION == 5
+    def test_schema_version_is_6(self):
+        assert SCHEMA_VERSION == 6
 
     def test_provenance_fields_roundtrip(self):
         snap = _sample_snap(

--- a/tests/test_fp_rate_gate.py
+++ b/tests/test_fp_rate_gate.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fast-lane wrapper for the ADR-024 §7 scoping FP-rate gate.
+
+The gate logic lives in ``scripts/check_fp_rate.py`` so it is runnable
+standalone in CI; this mirrors it into the pytest suite (per-case for readable
+failures) so a regression is caught in the ordinary unit-test lane too.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_GATE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_fp_rate.py"
+_spec = importlib.util.spec_from_file_location("check_fp_rate", _GATE_PATH)
+assert _spec and _spec.loader
+fp_gate = importlib.util.module_from_spec(_spec)
+# Register before exec so dataclasses can resolve the module's __dict__.
+sys.modules["check_fp_rate"] = fp_gate
+_spec.loader.exec_module(fp_gate)
+
+
+@pytest.mark.parametrize("case", fp_gate.CORPUS, ids=lambda c: c.name)
+def test_scoping_case_matches_ground_truth(case):
+    from abicheck.checker import compare
+
+    old, new = case.build()
+    result = compare(old, new, scope_to_public_surface=True)
+    is_breaking = result.verdict in fp_gate._BREAKING_VERDICTS
+    if case.internal_noise:
+        assert not is_breaking, (
+            f"FALSE POSITIVE: internal-noise case {case.name!r} reported "
+            f"breaking verdict {result.verdict.value} under scoping"
+        )
+    else:
+        assert is_breaking, (
+            f"FALSE NEGATIVE: real-break case {case.name!r} scoped away to "
+            f"non-breaking verdict {result.verdict.value}"
+        )
+
+
+def test_fp_rate_within_baseline():
+    outcome = fp_gate.evaluate()
+    assert len(outcome.false_positives) <= fp_gate.FP_BASELINE, outcome.false_positives
+    assert len(outcome.false_negatives) <= fp_gate.FN_BASELINE, outcome.false_negatives

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,235 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for declaration provenance (ADR-015, schema v6)."""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.model import (
+    AbiSnapshot,
+    EnumMember,
+    EnumType,
+    Function,
+    RecordType,
+    ScopeOrigin,
+    Variable,
+)
+from abicheck.provenance import (
+    apply_provenance,
+    build_public_set,
+    classify_origin,
+    header_from_location,
+)
+from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
+
+# ── header_from_location ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "loc,expected",
+    [
+        ("include/api.h:42", "include/api.h"),
+        ("include/api.h:42:9", "include/api.h"),
+        ("/build/src/foo.hpp:1", "/build/src/foo.hpp"),
+        ("plain.h", "plain.h"),
+        ("C:\\proj\\inc\\api.h:10", "C:\\proj\\inc\\api.h"),  # drive letter colon kept
+        (None, None),
+        ("", None),
+    ],
+)
+def test_header_from_location(loc, expected):
+    assert header_from_location(loc) == expected
+
+
+# ── classify_origin ───────────────────────────────────────────────────────────
+
+
+def _classify(header, public_headers=None, public_dirs=None):
+    hs, ds, have = build_public_set(public_headers, public_dirs)
+    return classify_origin(header, hs, ds, have_public_set=have)
+
+
+def test_no_public_set_is_always_unknown():
+    # Decision D4: without a public set, everything is UNKNOWN regardless of path.
+    assert _classify("/usr/include/stdio.h") is ScopeOrigin.UNKNOWN
+    assert _classify("include/api.h") is ScopeOrigin.UNKNOWN
+
+
+def test_none_header_is_unknown_even_with_public_set():
+    assert _classify(None, public_headers=["include/api.h"]) is ScopeOrigin.UNKNOWN
+
+
+def test_exact_public_header_suffix_match_through_build_prefix():
+    # Build path carries an absolute prefix the user never typed.
+    origin = _classify(
+        "/build/abc123/src/include/api.h",
+        public_headers=["include/api.h"],
+    )
+    assert origin is ScopeOrigin.PUBLIC_HEADER
+
+
+def test_basename_fallback_match():
+    origin = _classify(
+        "/wherever/it/landed/api.h",
+        public_headers=["api.h"],
+    )
+    assert origin is ScopeOrigin.PUBLIC_HEADER
+
+
+def test_public_header_dir_containment():
+    origin = _classify(
+        "/build/proj/include/sub/widget.h",
+        public_dirs=["include"],
+    )
+    assert origin is ScopeOrigin.PUBLIC_HEADER
+
+
+def test_system_header_classified_when_set_present():
+    origin = _classify("/usr/include/stdio.h", public_headers=["include/api.h"])
+    assert origin is ScopeOrigin.SYSTEM_HEADER
+
+
+def test_system_header_with_sysroot_prefix():
+    origin = _classify(
+        "/opt/sysroot/usr/include/bits/types.h",
+        public_headers=["include/api.h"],
+    )
+    assert origin is ScopeOrigin.SYSTEM_HEADER
+
+
+def test_private_header_when_not_public_and_not_system():
+    origin = _classify(
+        "/build/proj/src/internal/impl.h",
+        public_headers=["include/api.h"],
+        public_dirs=["include"],
+    )
+    assert origin is ScopeOrigin.PRIVATE_HEADER
+
+
+def test_public_takes_precedence_over_system_path():
+    # A header that both matches the public set and lives under usr/include
+    # should classify PUBLIC (public check runs first).
+    origin = _classify(
+        "/usr/include/mylib/api.h",
+        public_dirs=["mylib"],
+    )
+    assert origin is ScopeOrigin.PUBLIC_HEADER
+
+
+# ── apply_provenance ──────────────────────────────────────────────────────────
+
+
+def _snapshot() -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfoo.so.1",
+        version="1.0",
+        functions=[
+            Function(
+                name="pub",
+                mangled="pub",
+                return_type="void",
+                source_location="/build/include/api.h:10",
+            ),
+            Function(
+                name="priv",
+                mangled="priv",
+                return_type="void",
+                source_location="/build/src/impl.h:20",
+            ),
+            Function(name="noloc", mangled="noloc", return_type="void"),
+        ],
+        variables=[
+            Variable(
+                name="g",
+                mangled="g",
+                type="int",
+                source_location="/build/include/api.h:5",
+            ),
+        ],
+        types=[
+            RecordType(
+                name="S", kind="struct", source_location="/build/include/api.h:30"
+            ),
+        ],
+        enums=[
+            EnumType(
+                name="E",
+                members=[EnumMember(name="A", value=0)],
+                source_location="/build/include/api.h:40",
+            ),
+        ],
+    )
+
+
+def test_apply_provenance_opt_in_classification():
+    snap = apply_provenance(_snapshot(), public_headers=["include/api.h"])
+    by_name = {f.name: f for f in snap.functions}
+    assert by_name["pub"].source_header == "/build/include/api.h"
+    assert by_name["pub"].origin is ScopeOrigin.PUBLIC_HEADER
+    assert by_name["priv"].origin is ScopeOrigin.PRIVATE_HEADER
+    # No source location → no header, UNKNOWN origin.
+    assert by_name["noloc"].source_header is None
+    assert by_name["noloc"].origin is ScopeOrigin.UNKNOWN
+    assert snap.variables[0].origin is ScopeOrigin.PUBLIC_HEADER
+    assert snap.types[0].origin is ScopeOrigin.PUBLIC_HEADER
+    assert snap.enums[0].origin is ScopeOrigin.PUBLIC_HEADER
+
+
+def test_apply_provenance_no_set_keeps_unknown_but_fills_header():
+    # source_header is descriptive metadata and is always populated; origin
+    # stays UNKNOWN without a public set (decision D4).
+    snap = apply_provenance(_snapshot())
+    assert snap.functions[0].source_header == "/build/include/api.h"
+    assert snap.functions[0].origin is ScopeOrigin.UNKNOWN
+    assert snap.types[0].origin is ScopeOrigin.UNKNOWN
+
+
+# ── serialization round-trip (schema v6) ──────────────────────────────────────
+
+
+def test_serialization_round_trip_preserves_provenance():
+    snap = apply_provenance(_snapshot(), public_headers=["include/api.h"])
+    d = snapshot_to_dict(snap)
+    assert d["schema_version"] == 6
+    # Enum value serialized as a plain string.
+    assert d["functions"][0]["origin"] == "public_header"
+    assert d["functions"][0]["source_header"] == "/build/include/api.h"
+
+    back = snapshot_from_dict(d)
+    assert back.functions[0].origin is ScopeOrigin.PUBLIC_HEADER
+    assert back.functions[0].source_header == "/build/include/api.h"
+    assert back.enums[0].origin is ScopeOrigin.PUBLIC_HEADER
+    assert back.enums[0].source_header == "/build/include/api.h"
+    assert back.types[0].origin is ScopeOrigin.PUBLIC_HEADER
+    assert back.variables[0].origin is ScopeOrigin.PUBLIC_HEADER
+
+
+def test_old_snapshot_without_provenance_loads_as_unknown():
+    # A pre-v6 snapshot dict has no source_header / origin keys.
+    legacy = {
+        "library": "libold.so",
+        "version": "1.0",
+        "functions": [{"name": "f", "mangled": "f", "return_type": "void"}],
+        "variables": [{"name": "v", "mangled": "v", "type": "int"}],
+        "types": [{"name": "T", "kind": "struct"}],
+        "enums": [{"name": "E", "members": []}],
+    }
+    snap = snapshot_from_dict(legacy)
+    assert snap.functions[0].origin is ScopeOrigin.UNKNOWN
+    assert snap.functions[0].source_header is None
+    assert snap.variables[0].origin is ScopeOrigin.UNKNOWN
+    assert snap.types[0].origin is ScopeOrigin.UNKNOWN
+    assert snap.enums[0].origin is ScopeOrigin.UNKNOWN

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -269,3 +269,60 @@ def test_old_snapshot_without_provenance_loads_as_unknown():
     assert snap.variables[0].origin is ScopeOrigin.UNKNOWN
     assert snap.types[0].origin is ScopeOrigin.UNKNOWN
     assert snap.enums[0].origin is ScopeOrigin.UNKNOWN
+
+
+# ── castxml dumper wires source_location onto records/variables/enums ─────────
+# (regression guard for the dumper fix; uses synthetic XML, no castxml binary)
+
+
+def _castxml_root():
+    from xml.etree.ElementTree import Element, SubElement
+
+    root = Element("CastXML")
+    f = SubElement(root, "File")
+    f.set("id", "f1")
+    f.set("name", "/build/inc/api.h")
+    # Direct file/line form on a struct.
+    s = SubElement(root, "Struct")
+    s.set("id", "_s")
+    s.set("name", "Widget")
+    s.set("size", "64")
+    s.set("align", "32")
+    s.set("file", "f1")
+    s.set("line", "12")
+    # Location-ref form on a variable.
+    loc = SubElement(root, "Location")
+    loc.set("id", "l1")
+    loc.set("file", "f1")
+    loc.set("line", "20")
+    fund = SubElement(root, "FundamentalType")
+    fund.set("id", "_int")
+    fund.set("name", "int")
+    v = SubElement(root, "Variable")
+    v.set("id", "_v")
+    v.set("name", "g_count")
+    v.set("mangled", "g_count")
+    v.set("type", "_int")
+    v.set("location", "l1")
+    # Enumeration with direct file/line.
+    e = SubElement(root, "Enumeration")
+    e.set("id", "_e")
+    e.set("name", "Color")
+    e.set("file", "f1")
+    e.set("line", "30")
+    return root
+
+
+def test_castxml_populates_source_location_on_types_vars_enums():
+    from abicheck.dumper import _CastxmlParser
+
+    root = _castxml_root()
+    parser = _CastxmlParser(
+        root, exported_dynamic={"g_count"}, exported_static={"g_count"}
+    )
+    rec = next(t for t in parser.parse_types() if t.name == "Widget")
+    assert rec.source_location == "/build/inc/api.h:12"
+    var = next(v for v in parser.parse_variables() if v.name == "g_count")
+    assert var.source_location == "/build/inc/api.h:20"
+    enum = next(e for e in parser.parse_enums() if e.name == "Color")
+    assert enum.source_location == "/build/inc/api.h:30"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -129,6 +129,42 @@ def test_public_takes_precedence_over_system_path():
     assert origin is ScopeOrigin.PUBLIC_HEADER
 
 
+@pytest.mark.parametrize(
+    "header",
+    [
+        "/build/proj/generated/messages.h",
+        "/build/proj/src/moc_widget.cpp",
+        "/build/proj/proto/service.pb.h",
+        "/build/proj/schema_generated.h",
+        "/build/proj/api.grpc.pb.h",
+    ],
+)
+def test_generated_headers_classified(header):
+    # A public set must be present (opt-in), but the generated path is neither
+    # public nor system → GENERATED.
+    origin = _classify(header, public_headers=["include/api.h"])
+    assert origin is ScopeOrigin.GENERATED
+
+
+def test_export_only_when_no_header_but_symbol_exported():
+    hs, ds, have = build_public_set(["include/api.h"], None)
+    origin = classify_origin(None, hs, ds, have_public_set=have, export_only=True)
+    assert origin is ScopeOrigin.EXPORT_ONLY
+
+
+def test_export_only_ignored_without_public_set():
+    # D4: no public set → UNKNOWN regardless of export-only linkage.
+    hs, ds, have = build_public_set(None, None)
+    origin = classify_origin(None, hs, ds, have_public_set=have, export_only=True)
+    assert origin is ScopeOrigin.UNKNOWN
+
+
+def test_no_header_not_exported_is_unknown():
+    hs, ds, have = build_public_set(["include/api.h"], None)
+    origin = classify_origin(None, hs, ds, have_public_set=have, export_only=False)
+    assert origin is ScopeOrigin.UNKNOWN
+
+
 # ── apply_provenance ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -79,7 +79,7 @@ def test_dump_tags_public_and_private_origin(tmp_path: Path) -> None:
     so = _compile_so(tmp_path)
     pub = tmp_path / "api.h"
 
-    snap = dump(so, headers=[pub], public_headers=[pub])
+    snap = dump(so, headers=[pub], compiler="cc", lang="C", public_headers=[pub])
 
     fns = {f.name: f for f in snap.functions}
     assert "public_fn" in fns, "castxml/DWARF did not surface the public function"
@@ -102,7 +102,7 @@ def test_dump_without_public_set_leaves_origin_unknown(tmp_path: Path) -> None:
     so = _compile_so(tmp_path)
     pub = tmp_path / "api.h"
 
-    snap = dump(so, headers=[pub])  # no public_headers / public_header_dirs
+    snap = dump(so, headers=[pub], compiler="cc", lang="C")  # no public set
 
     pf = {f.name: f for f in snap.functions}.get("public_fn")
     assert pf is not None

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end provenance tagging through the real dumper (castxml + gcc).
+
+These exercise the full Parse → Snapshot path: castxml/DWARF record a
+``source_location`` per declaration, which ``apply_provenance`` turns into a
+``source_header`` + ``origin`` against the supplied public-header set. They
+require castxml and gcc/g++ and are therefore marked ``integration`` (the
+suite auto-skips them when those tools are absent — see ``conftest.py``).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from abicheck.model import ScopeOrigin
+
+# gcc on macOS emits Mach-O and on Windows MinGW emits PE; the origin logic is
+# platform-independent, but this fixture builds an ELF .so, so pin to Linux.
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="provenance integration fixture builds an ELF .so (Linux gcc)",
+)
+
+
+def _compile_so(tmp: Path) -> Path:
+    """Build a tiny .so whose public API pulls a type in from a private header."""
+    (tmp / "impl.h").write_text(
+        "#ifndef IMPL_H\n#define IMPL_H\nstruct Impl { int a; int b; };\n#endif\n"
+    )
+    (tmp / "api.h").write_text(
+        "#ifndef API_H\n#define API_H\n"
+        '#include "impl.h"\n'
+        "int public_fn(struct Impl *p);\n"
+        "#endif\n"
+    )
+    src = '#include "api.h"\nint public_fn(struct Impl *p){return p?p->a:0;}\n'
+    (tmp / "api.c").write_text(src)
+    so = tmp / "libapi.so"
+    res = subprocess.run(
+        [
+            "gcc",
+            "-g",
+            "-I",
+            str(tmp),
+            "-shared",
+            "-fPIC",
+            "-o",
+            str(so),
+            str(tmp / "api.c"),
+        ],
+        capture_output=True,
+    )
+    if res.returncode != 0:
+        pytest.skip(f"gcc failed: {res.stderr.decode()[:200]}")
+    return so
+
+
+@pytest.mark.integration
+def test_dump_tags_public_and_private_origin(tmp_path: Path) -> None:
+    from abicheck.dumper import dump
+
+    so = _compile_so(tmp_path)
+    pub = tmp_path / "api.h"
+
+    snap = dump(so, headers=[pub], public_headers=[pub])
+
+    fns = {f.name: f for f in snap.functions}
+    assert "public_fn" in fns, "castxml/DWARF did not surface the public function"
+    pf = fns["public_fn"]
+    assert pf.source_header is not None and pf.source_header.endswith("api.h")
+    assert pf.origin is ScopeOrigin.PUBLIC_HEADER
+
+    # The struct pulled in from the (non-public) impl.h must be PRIVATE_HEADER.
+    impl_types = [t for t in snap.types if (t.source_header or "").endswith("impl.h")]
+    assert impl_types, "Impl type not captured from the private header"
+    assert all(t.origin is ScopeOrigin.PRIVATE_HEADER for t in impl_types)
+
+
+@pytest.mark.integration
+def test_dump_without_public_set_leaves_origin_unknown(tmp_path: Path) -> None:
+    # D4: omitting --public-header keeps every origin UNKNOWN, but source_header
+    # is still populated descriptively from the parsed source location.
+    from abicheck.dumper import dump
+
+    so = _compile_so(tmp_path)
+    pub = tmp_path / "api.h"
+
+    snap = dump(so, headers=[pub])  # no public_headers / public_header_dirs
+
+    pf = {f.name: f for f in snap.functions}.get("public_fn")
+    assert pf is not None
+    assert pf.origin is ScopeOrigin.UNKNOWN
+    assert pf.source_header is not None and pf.source_header.endswith("api.h")

--- a/tests/test_scan_accuracy.py
+++ b/tests/test_scan_accuracy.py
@@ -166,7 +166,9 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.types[0].size_bits = 128
-        result = compare(old, new)
+        # Raw detector check: Config is not wired to a public function here, so
+        # disable surface scoping (orthogonal concern, default-on since ADR-024).
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in result.changes)
 
@@ -174,7 +176,7 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.types[0].fields = [new.types[0].fields[0]]  # keep only 'width'
-        result = compare(old, new)
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.TYPE_FIELD_REMOVED for c in result.changes)
 
@@ -206,7 +208,7 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.typedefs = {}
-        result = compare(old, new)
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.TYPEDEF_REMOVED for c in result.changes)
 
@@ -214,7 +216,7 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.typedefs["ColorType"] = "int"
-        result = compare(old, new)
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.TYPEDEF_BASE_CHANGED for c in result.changes)
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -206,10 +206,13 @@ def test_sc_exit_contract(tmp_path: Path) -> None:
         members=[EnumMember("A", 0), EnumMember("RENAMED", 1)],
         underlying_type="int",
     )
+    # Mode isn't referenced by any public function here, so opt out of the
+    # default public-header scoping (ADR-024 Phase 5) to exercise the contract.
     api = _compare(
         tmp_path,
         _lib("1", [_fn("use")], enums=[e1]),
         _lib("2", [_fn("use")], enums=[e2]),
+        "--no-scope-public-headers",
     )
     assert api.exit_code == 2
     # BREAKING -> 4 (removed symbol)
@@ -237,7 +240,8 @@ def test_sc_public_surface_scope(tmp_path: Path) -> None:
     )
 
     # Without scoping the private break is a compliance error (issue #235).
-    assert _compare(tmp_path, old, new).exit_code == 4
+    # Scoping is on by default since ADR-024 Phase 5, so opt out explicitly here.
+    assert _compare(tmp_path, old, new, "--no-scope-public-headers").exit_code == 4
     # With public-header scoping it must NOT raise compliance errors: the only
     # change was to a private type, so the verdict is NO_CHANGE (exit 0). Assert
     # the verdict cell, not the word "BREAKING" (which also appears in the
@@ -360,8 +364,10 @@ def test_sc_policy_profile(tmp_path: Path) -> None:
     )
     old = _lib("1", [_fn("use")], enums=[e1])
     new = _lib("2", [_fn("use")], enums=[e2])
-    assert _compare(tmp_path, old, new).exit_code == 2  # strict_abi: API break
-    assert _compare(tmp_path, old, new, "--policy", "sdk_vendor").exit_code == 0
+    # Mode isn't referenced by a public function, so opt out of default
+    # public-header scoping (ADR-024 Phase 5) to exercise the policy contrast.
+    assert _compare(tmp_path, old, new, "--no-scope-public-headers").exit_code == 2  # strict_abi: API break
+    assert _compare(tmp_path, old, new, "--no-scope-public-headers", "--policy", "sdk_vendor").exit_code == 0
 
 
 def test_sc_scan_junit(tmp_path: Path) -> None:

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -641,3 +641,134 @@ class TestProvenanceReasons:
         # sym is in public_symbols on both sides; the public-header side blocks
         # the private-header demotion, so it stays in surface.
         assert classify_change_surface(c, s_old, s_new) == (True, None)
+
+
+# ── widening overlay (ADR-024 §D6 / Phase 4) ─────────────────────────────────
+
+
+class TestWideningOverlay:
+    """--public-symbol / force_public_symbols promote a symbol into the
+    public surface even when header provenance/export would demote it."""
+
+    def _run(self, changes, old, new, force_public):
+        from abicheck.post_processing import FilterNonPublicSurface, PipelineContext
+
+        ctx = PipelineContext(
+            old=old, new=new, scope_to_public_surface=True,
+            force_public_symbols=set(force_public),
+        )
+        kept = FilterNonPublicSurface().run(list(changes), ctx)
+        return kept, ctx.out_of_surface
+
+    def _pair(self):
+        old = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("public_api"), _fn("stub_sym", vis=Visibility.ELF_ONLY)],
+        )
+        new = AbiSnapshot(
+            library="l", version="2",
+            functions=[_fn("public_api"), _fn("stub_sym", vis=Visibility.ELF_ONLY)],
+        )
+        return old, new
+
+    def test_forced_symbol_kept_in_surface(self):
+        old, new = self._pair()
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="stub_sym", description="")
+        # Without widening: demoted (not-exported / non-public).
+        kept_off, ledger_off = self._run([c], old, new, force_public=set())
+        assert kept_off == [] and len(ledger_off) == 1
+        # With widening: kept, not on the ledger.
+        kept_on, ledger_on = self._run([c], old, new, force_public={"stub_sym"})
+        assert kept_on == [c] and ledger_on == []
+
+    def test_forced_symbol_matches_qualified_tail(self):
+        old, new = self._pair()
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="ns::stub_sym", description="")
+        kept, ledger = self._run([c], old, new, force_public={"stub_sym"})
+        assert kept == [c] and ledger == []
+
+    def test_widening_does_not_affect_unlisted_symbols(self):
+        old, new = self._pair()
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="stub_sym", description="")
+        kept, ledger = self._run([c], old, new, force_public={"other"})
+        assert kept == [] and len(ledger) == 1
+
+
+def test_collect_force_public_symbols_merges_flag_and_file(tmp_path):
+    from abicheck.cli import _collect_force_public_symbols
+
+    lst = tmp_path / "syms.txt"
+    lst.write_text("# public symbols\nfoo\n\n  bar  \n# comment\nbaz\n")
+    out = _collect_force_public_symbols(("qux", "foo"), lst)
+    assert out == {"foo", "bar", "baz", "qux"}
+
+
+def test_collect_force_public_symbols_no_file():
+    from abicheck.cli import _collect_force_public_symbols
+
+    assert _collect_force_public_symbols((), None) == set()
+    assert _collect_force_public_symbols(("a", " ", "b"), None) == {"a", "b"}
+
+
+class TestWideningCLI:
+    """End-to-end: --public-symbol re-promotes a demoted finding via the CLI."""
+
+    def _write(self, path, snap):
+        from abicheck.serialization import snapshot_to_json
+
+        path.write_text(snapshot_to_json(snap))
+
+    def _pair(self, tmp_path):
+        # InternalCache is an internal struct (no public API references it);
+        # its layout change is demoted under scoping. Widening by its name
+        # re-promotes it into the reported surface.
+        old = AbiSnapshot(
+            library="lib", version="1",
+            functions=[_fn("public_api", ret="Result *")],
+            types=[_rec("Result", size=64), _rec("InternalCache", size=64)],
+        )
+        new = AbiSnapshot(
+            library="lib", version="2",
+            functions=[_fn("public_api", ret="Result *")],
+            types=[_rec("Result", size=64), _rec("InternalCache", size=128)],
+        )
+        op, np_ = tmp_path / "old.json", tmp_path / "new.json"
+        self._write(op, old)
+        self._write(np_, new)
+        return op, np_
+
+    def test_public_symbol_flag_repromotes_finding(self, tmp_path):
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        op, np_ = self._pair(tmp_path)
+        runner = CliRunner()
+        # Scoped without widening: the internal change is filtered out of stdout.
+        scoped = runner.invoke(
+            main, ["compare", str(op), str(np_), "--scope-public-headers"]
+        )
+        assert "InternalCache" not in scoped.stdout
+        # Scoped + widened: the change is back in the report.
+        widened = runner.invoke(
+            main,
+            ["compare", str(op), str(np_), "--scope-public-headers",
+             "--public-symbol", "InternalCache"],
+        )
+        assert "InternalCache" in widened.stdout
+
+    def test_public_symbols_list_file(self, tmp_path):
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        op, np_ = self._pair(tmp_path)
+        syms = tmp_path / "public.syms"
+        syms.write_text("# guaranteed exports\nInternalCache\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["compare", str(op), str(np_), "--scope-public-headers",
+             "--public-symbols-list", str(syms)],
+        )
+        assert "InternalCache" in result.stdout

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -19,9 +19,12 @@ from abicheck.model import (
     Visibility,
 )
 from abicheck.surface import (
+    REASON_NON_PUBLIC_TYPE,
+    REASON_NOT_EXPORTED,
     PublicSurface,
     _type_identifiers,
     change_in_public_surface,
+    classify_change_surface,
     compute_public_surface,
 )
 
@@ -220,6 +223,55 @@ class TestChangeClassification:
         empty = PublicSurface()  # resolvable defaults to False
         c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Whatever", description="")
         assert change_in_public_surface(c, empty, empty) is True
+
+
+# ── classify_change_surface: ledger reason codes (ADR-024 §D5.1) ─────────────
+
+
+class TestSurfaceExclusionReason:
+    def _surf(self, snap):
+        return compute_public_surface(snap)
+
+    def test_in_surface_has_no_reason(self):
+        snap = AbiSnapshot(library="l", version="1", functions=[_fn("api")])
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="api", description="")
+        assert classify_change_surface(c, s, s) == (True, None)
+
+    def test_not_exported_symbol_reason(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[_fn("api"), _fn("internal", vis=Visibility.ELF_ONLY)],
+        )
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="internal", description="")
+        assert classify_change_surface(c, s, s) == (False, REASON_NOT_EXPORTED)
+
+    def test_non_public_type_reason(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[_fn("api", ret="Result *")],
+            types=[_rec("Result"), _rec("InternalCache")],
+        )
+        s = self._surf(snap)
+        c = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="InternalCache", description=""
+        )
+        assert classify_change_surface(c, s, s) == (False, REASON_NON_PUBLIC_TYPE)
+
+    def test_change_in_public_surface_matches_classifier(self):
+        # The boolean wrapper must agree with the tuple classifier.
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[_fn("api"), _fn("internal", vis=Visibility.ELF_ONLY)],
+        )
+        s = self._surf(snap)
+        for sym in ("api", "internal"):
+            c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol=sym, description="")
+            assert change_in_public_surface(c, s, s) == classify_change_surface(c, s, s)[0]
 
 
 # ── end-to-end via compare(scope_to_public_surface=...) ──────────────────────
@@ -424,8 +476,12 @@ class TestSurfaceLedgerOutput:
         ledger = d["surface_scope"]
         assert ledger["enabled"] is True
         assert ledger["out_of_surface_count"] >= 1
-        symbols = {c["symbol"] for c in ledger["out_of_surface_changes"]}
+        entries = ledger["out_of_surface_changes"]
+        symbols = {c["symbol"] for c in entries}
         assert any("InternalCache" in s for s in symbols)
+        # ADR-024 §D5.1: each demoted finding carries a reason code.
+        internal = next(c for c in entries if "InternalCache" in c["symbol"])
+        assert internal["reason"] == REASON_NON_PUBLIC_TYPE
 
     def test_leaf_json_includes_surface_scope_ledger(self):
         # The leaf report mode takes an early-return path in to_json(); the
@@ -447,8 +503,11 @@ class TestSurfaceLedgerOutput:
         ledger = props["surfaceScope"]
         assert ledger["enabled"] is True
         assert ledger["outOfSurfaceCount"] >= 1
-        symbols = {c["symbol"] for c in ledger["outOfSurfaceChanges"]}
+        entries = ledger["outOfSurfaceChanges"]
+        symbols = {c["symbol"] for c in entries}
         assert any("InternalCache" in s for s in symbols)
+        internal = next(c for c in entries if "InternalCache" in c["symbol"])
+        assert internal["reason"] == REASON_NON_PUBLIC_TYPE
 
     def test_ledger_absent_when_scoping_off(self):
         import json

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -7,6 +7,8 @@ guarantees for backward-compatible changes to non-public API/ABI.
 
 from __future__ import annotations
 
+import pytest
+
 from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.checker_types import Change
@@ -261,7 +263,8 @@ class TestSurfaceExclusionReason:
         )
         assert classify_change_surface(c, s, s) == (False, REASON_NON_PUBLIC_TYPE)
 
-    def test_change_in_public_surface_matches_classifier(self):
+    @pytest.mark.parametrize("sym", ["api", "internal"])
+    def test_change_in_public_surface_matches_classifier(self, sym):
         # The boolean wrapper must agree with the tuple classifier.
         snap = AbiSnapshot(
             library="l",
@@ -269,9 +272,8 @@ class TestSurfaceExclusionReason:
             functions=[_fn("api"), _fn("internal", vis=Visibility.ELF_ONLY)],
         )
         s = self._surf(snap)
-        for sym in ("api", "internal"):
-            c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol=sym, description="")
-            assert change_in_public_surface(c, s, s) == classify_change_surface(c, s, s)[0]
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol=sym, description="")
+        assert change_in_public_surface(c, s, s) == classify_change_surface(c, s, s)[0]
 
 
 # ── end-to-end via compare(scope_to_public_surface=...) ──────────────────────

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -427,6 +427,18 @@ class TestSurfaceLedgerOutput:
         symbols = {c["symbol"] for c in ledger["out_of_surface_changes"]}
         assert any("InternalCache" in s for s in symbols)
 
+    def test_leaf_json_includes_surface_scope_ledger(self):
+        # The leaf report mode takes an early-return path in to_json(); the
+        # ledger must be present there too, not just in the full report.
+        import json
+
+        from abicheck.reporter import to_json
+
+        d = json.loads(to_json(self._scoped_result(), report_mode="leaf"))
+        assert "surface_scope" in d
+        symbols = {c["symbol"] for c in d["surface_scope"]["out_of_surface_changes"]}
+        assert any("InternalCache" in s for s in symbols)
+
     def test_sarif_includes_surface_scope_ledger(self):
         from abicheck.sarif import to_sarif
 

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -246,6 +246,20 @@ class TestSurfaceExclusionReason:
         c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="api", description="")
         assert classify_change_surface(c, s, s) == (True, None)
 
+    def test_one_sided_unresolvable_keeps_everything(self):
+        # Both sides must be resolvable before scoping demotes anything; an
+        # unresolved side means we keep the finding (anti-hiding).
+        resolvable = self._surf(
+            AbiSnapshot(
+                library="l", version="1",
+                functions=[_fn("api"), _fn("internal", vis=Visibility.ELF_ONLY)],
+            )
+        )
+        unresolvable = PublicSurface()  # resolvable defaults to False
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="internal", description="")
+        assert classify_change_surface(c, resolvable, unresolvable) == (True, None)
+        assert classify_change_surface(c, unresolvable, resolvable) == (True, None)
+
     def test_not_exported_symbol_reason(self):
         snap = AbiSnapshot(
             library="l",
@@ -444,6 +458,10 @@ class TestScopeCli:
         op, np_ = self._make_pair(tmp_path)
         runner = CliRunner()
         result = runner.invoke(main, ["compare", str(op), str(np_)])
+        # The internal struct's size change is breaking, so compare exits
+        # non-zero (2/4) — assert that so a crash (exit 1, no real output)
+        # can't masquerade as a pass.
+        assert result.exit_code in (2, 4), result.output
         # Without scoping, the internal change is a reported finding.
         assert "InternalCache" in result.stdout
 

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -386,3 +386,66 @@ class TestScopeCli:
         result = runner.invoke(main, ["compare", str(op), str(np_)])
         # Without scoping, the internal change is a reported finding.
         assert "InternalCache" in result.stdout
+
+
+# ── machine-readable surface ledger (ADR-024 §D4/D5 disclosure) ──────────────
+
+
+class TestSurfaceLedgerOutput:
+    """The out-of-surface audit ledger is disclosed in JSON and SARIF.
+
+    ADR-024 rejects libabigail's hard ``--headers-dir`` drop precisely so the
+    "why was this excluded" trail stays auditable — that trail must reach the
+    machine-readable formats, not just stderr text.
+    """
+
+    def _scoped_result(self):
+        old = AbiSnapshot(
+            library="lib",
+            version="1",
+            functions=[_fn("public_api", ret="Result *")],
+            types=[_rec("Result", size=64), _rec("InternalCache", size=64)],
+        )
+        new = AbiSnapshot(
+            library="lib",
+            version="2",
+            functions=[_fn("public_api", ret="Result *")],
+            types=[_rec("Result", size=64), _rec("InternalCache", size=128)],
+        )
+        return compare(old, new, scope_to_public_surface=True)
+
+    def test_json_includes_surface_scope_ledger(self):
+        import json
+
+        from abicheck.reporter import to_json
+
+        d = json.loads(to_json(self._scoped_result()))
+        assert "surface_scope" in d
+        ledger = d["surface_scope"]
+        assert ledger["enabled"] is True
+        assert ledger["out_of_surface_count"] >= 1
+        symbols = {c["symbol"] for c in ledger["out_of_surface_changes"]}
+        assert any("InternalCache" in s for s in symbols)
+
+    def test_sarif_includes_surface_scope_ledger(self):
+        from abicheck.sarif import to_sarif
+
+        props = to_sarif(self._scoped_result())["runs"][0]["properties"]
+        assert "surfaceScope" in props
+        ledger = props["surfaceScope"]
+        assert ledger["enabled"] is True
+        assert ledger["outOfSurfaceCount"] >= 1
+        symbols = {c["symbol"] for c in ledger["outOfSurfaceChanges"]}
+        assert any("InternalCache" in s for s in symbols)
+
+    def test_ledger_absent_when_scoping_off(self):
+        import json
+
+        from abicheck.reporter import to_json
+        from abicheck.sarif import to_sarif
+
+        old = AbiSnapshot(library="lib", version="1", functions=[_fn("public_api")])
+        new = AbiSnapshot(library="lib", version="2", functions=[_fn("public_api")])
+        res = compare(old, new)
+        assert "surface_scope" not in json.loads(to_json(res))
+        assert "surfaceScope" not in to_sarif(res)["runs"][0]["properties"]

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -17,12 +17,15 @@ from abicheck.model import (
     Function,
     Param,
     RecordType,
+    ScopeOrigin,
     TypeField,
     Visibility,
 )
 from abicheck.surface import (
     REASON_NON_PUBLIC_TYPE,
     REASON_NOT_EXPORTED,
+    REASON_PRIVATE_HEADER,
+    REASON_SYSTEM_HEADER,
     PublicSurface,
     _type_identifiers,
     change_in_public_surface,
@@ -31,23 +34,26 @@ from abicheck.surface import (
 )
 
 
-def _fn(name, ret="void", params=(), vis=Visibility.PUBLIC, mangled=None):
+def _fn(name, ret="void", params=(), vis=Visibility.PUBLIC, mangled=None,
+        origin=ScopeOrigin.UNKNOWN):
     return Function(
         name=name,
         mangled=mangled if mangled is not None else f"_Z{len(name)}{name}",
         return_type=ret,
         params=[Param(name=f"a{i}", type=t) for i, t in enumerate(params)],
         visibility=vis,
+        origin=origin,
     )
 
 
-def _rec(name, fields=(), bases=(), size=64):
+def _rec(name, fields=(), bases=(), size=64, origin=ScopeOrigin.UNKNOWN):
     return RecordType(
         name=name,
         kind="struct",
         size_bits=size,
         fields=[TypeField(name=n, type=t) for n, t in fields],
         bases=list(bases),
+        origin=origin,
     )
 
 
@@ -522,3 +528,98 @@ class TestSurfaceLedgerOutput:
         res = compare(old, new)
         assert "surface_scope" not in json.loads(to_json(res))
         assert "surfaceScope" not in to_sarif(res)["runs"][0]["properties"]
+
+
+# ── classify_change_surface: provenance reason codes (ADR-015 v6 / ADR-024 D1) ─
+
+
+class TestProvenanceReasons:
+    def _surf(self, snap):
+        return compute_public_surface(snap)
+
+    def test_private_header_symbol_demoted_even_when_exported(self):
+        # A symbol the binary exports (PUBLIC linkage) but that originates in a
+        # private header is demoted with the provenance reason — the leaked
+        # private-header case scoping targets.
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[
+                _fn("public_api", origin=ScopeOrigin.PUBLIC_HEADER),
+                _fn("leaked", origin=ScopeOrigin.PRIVATE_HEADER),
+            ],
+        )
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="leaked", description="")
+        in_surf, reason = classify_change_surface(c, s, s)
+        assert in_surf is False
+        assert reason == REASON_PRIVATE_HEADER
+
+    def test_system_header_symbol_demoted(self):
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[
+                _fn("public_api", origin=ScopeOrigin.PUBLIC_HEADER),
+                _fn("from_libc", origin=ScopeOrigin.SYSTEM_HEADER),
+            ],
+        )
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="from_libc", description="")
+        assert classify_change_surface(c, s, s) == (False, REASON_SYSTEM_HEADER)
+
+    def test_public_header_origin_kept_in_surface(self):
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("public_api", origin=ScopeOrigin.PUBLIC_HEADER)],
+        )
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="public_api", description="")
+        assert classify_change_surface(c, s, s) == (True, None)
+
+    def test_unknown_origin_falls_back_to_linkage_reason(self):
+        # No public set was used → origin UNKNOWN → provenance never fires;
+        # the linkage reason (not-exported) is emitted as before.
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[
+                _fn("public_api"),
+                _fn("hidden", vis=Visibility.ELF_ONLY),
+            ],
+        )
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="hidden", description="")
+        assert classify_change_surface(c, s, s) == (False, REASON_NOT_EXPORTED)
+
+    def test_private_header_type_finding_demoted(self):
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Result *")],
+            types=[
+                _rec("Result", origin=ScopeOrigin.PUBLIC_HEADER),
+                _rec("InternalCache", origin=ScopeOrigin.PRIVATE_HEADER),
+            ],
+        )
+        s = self._surf(snap)
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="InternalCache", description="")
+        assert classify_change_surface(c, s, s) == (False, REASON_PRIVATE_HEADER)
+
+    def test_disagreeing_sides_block_demotion(self):
+        # Public-header origin on one side blocks demotion (conservative).
+        old = AbiSnapshot(
+            library="l", version="1",
+            functions=[
+                _fn("public_api", origin=ScopeOrigin.PUBLIC_HEADER),
+                _fn("sym", origin=ScopeOrigin.PRIVATE_HEADER),
+            ],
+        )
+        new = AbiSnapshot(
+            library="l", version="2",
+            functions=[
+                _fn("public_api", origin=ScopeOrigin.PUBLIC_HEADER),
+                _fn("sym", origin=ScopeOrigin.PUBLIC_HEADER),
+            ],
+        )
+        s_old, s_new = compute_public_surface(old), compute_public_surface(new)
+        c = Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="sym", description="")
+        # sym is in public_symbols on both sides; the public-header side blocks
+        # the private-header demotion, so it stays in surface.
+        assert classify_change_surface(c, s_old, s_new) == (True, None)

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -319,7 +319,7 @@ class TestScopedCompareNoFalsePositives:
             types=[_rec("Result", size=64), _rec("InternalCache", size=128)],
         )
 
-        unscoped = compare(old, new)
+        unscoped = compare(old, new, scope_to_public_surface=False)
         scoped = compare(old, new, scope_to_public_surface=True)
 
         # Without scoping the internal layout change shows up...
@@ -349,7 +349,10 @@ class TestScopedCompareNoFalsePositives:
         assert any("Result" in c.symbol for c in scoped.changes)
         assert scoped.verdict in (Verdict.BREAKING, Verdict.API_BREAK)
 
-    def test_scoping_off_by_default(self):
+    def test_scoping_on_by_default(self):
+        # ADR-024 Phase 5: header-scoping is the default. An internal-only
+        # layout change is demoted to the ledger out of the box; passing
+        # scope_to_public_surface=False restores the unscoped report.
         old = AbiSnapshot(
             library="lib",
             version="1",
@@ -363,8 +366,13 @@ class TestScopedCompareNoFalsePositives:
             types=[_rec("Result", size=64), _rec("InternalCache", size=128)],
         )
         default = compare(old, new)
-        assert default.out_of_surface_count == 0
-        assert default.scope_to_public_surface is False
+        assert default.scope_to_public_surface is True
+        assert default.out_of_surface_count >= 1
+        assert not any("InternalCache" in c.symbol for c in default.changes)
+
+        unscoped = compare(old, new, scope_to_public_surface=False)
+        assert unscoped.out_of_surface_count == 0
+        assert any("InternalCache" in c.symbol for c in unscoped.changes)
 
     def test_internal_leak_still_detected_under_scoping(self):
         # End-to-end anti-hiding guarantee: a detail:: type that leaks via a
@@ -457,7 +465,11 @@ class TestScopeCli:
 
         op, np_ = self._make_pair(tmp_path)
         runner = CliRunner()
-        result = runner.invoke(main, ["compare", str(op), str(np_)])
+        # Scoping is on by default now, so --no-scope-public-headers is needed
+        # to surface the internal-struct change.
+        result = runner.invoke(
+            main, ["compare", str(op), str(np_), "--no-scope-public-headers"]
+        )
         # The internal struct's size change is breaking, so compare exits
         # non-zero (2/4) — assert that so a crash (exit 1, no real output)
         # can't masquerade as a pass.
@@ -543,7 +555,7 @@ class TestSurfaceLedgerOutput:
 
         old = AbiSnapshot(library="lib", version="1", functions=[_fn("public_api")])
         new = AbiSnapshot(library="lib", version="2", functions=[_fn("public_api")])
-        res = compare(old, new)
+        res = compare(old, new, scope_to_public_surface=False)
         assert "surface_scope" not in json.loads(to_json(res))
         assert "surfaceScope" not in to_sarif(res)["runs"][0]["properties"]
 

--- a/tests/test_surface_property.py
+++ b/tests/test_surface_property.py
@@ -13,6 +13,10 @@ header-scope filter only ever *removes or demotes* findings and never
   *public* findings.
 * **Subset** — the scoped finding set is a subset of the universe of
   findings the unscoped run produces (filtering relocates, never invents).
+* **Anti-hiding** (§4, "the most important") — a layout break on a type
+  reachable from a public API always remains a reported finding.
+* **Widening** (§D6) — force-including every demoted symbol only moves
+  findings from the ledger back into the report; it never hides or invents.
 
 These run on synthetic snapshots (no castxml/gcc) but are Hypothesis-driven
 and therefore carry the ``slow`` marker like the other property suites.
@@ -206,3 +210,77 @@ def test_scoped_findings_subset_of_unscoped_universe(old: AbiSnapshot, new: AbiS
     assert _all_finding_keys(scoped) <= universe
     # And the reported (kept) scoped findings are themselves within that universe.
     assert _change_keys(scoped.changes) <= universe
+
+
+# ---------------------------------------------------------------------------
+# Anti-hiding — a break on a public-header type always survives scoping
+# (ADR-024 §"Validation & testing strategy" §4, "the most important")
+# ---------------------------------------------------------------------------
+
+
+@given(
+    type_name=st.sampled_from(_TYPE_POOL),
+    old_size=st.sampled_from([32, 64]),
+    new_size=st.sampled_from([128, 256]),
+)
+@settings(max_examples=40)
+def test_public_type_break_is_never_hidden_by_scoping(
+    type_name: str, old_size: int, new_size: int
+):
+    """A layout change to a type reachable from a PUBLIC function must remain a
+    reported finding under scoping — it is observable to consumers."""
+    def _pair(size: int, version: str) -> AbiSnapshot:
+        return AbiSnapshot(
+            library="lib",
+            version=version,
+            functions=[
+                Function(
+                    name="pub_api",
+                    mangled="_Z7pub_apiv",
+                    return_type=f"{type_name} *",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+            types=[RecordType(name=type_name, kind="struct", size_bits=size)],
+        )
+
+    old, new = _pair(old_size, "1"), _pair(new_size, "2")
+    scoped = compare(old, new, scope_to_public_surface=True)
+
+    reported = _change_keys(scoped.changes)
+    demoted = _change_keys(scoped.out_of_surface_changes)
+    # The public type's change is reported and was NOT demoted to the ledger.
+    assert any(sym == type_name for _, sym in reported)
+    assert not any(sym == type_name for _, sym in demoted)
+
+
+# ---------------------------------------------------------------------------
+# Widening overlay (ADR-024 §D6 / Phase 4) — re-promotion never hides or invents
+# ---------------------------------------------------------------------------
+
+
+@given(old=_snapshot_st(version="1"), new=_snapshot_st(version="2"))
+@settings(max_examples=75)
+def test_widening_only_repromotes_never_hides_or_invents(
+    old: AbiSnapshot, new: AbiSnapshot
+):
+    """Force-including every demoted symbol moves findings from the ledger back
+    into the report and changes nothing else: kept grows, the ledger shrinks,
+    and the overall universe is identical (widening can only ever *keep*)."""
+    scoped = compare(copy.deepcopy(old), copy.deepcopy(new), scope_to_public_surface=True)
+    forced = {c.symbol for c in scoped.out_of_surface_changes if c.symbol}
+
+    widened = compare(
+        copy.deepcopy(old), copy.deepcopy(new),
+        scope_to_public_surface=True, force_public_symbols=forced,
+    )
+
+    # Re-promotion only adds to the reported set …
+    assert _change_keys(scoped.changes) <= _change_keys(widened.changes)
+    # … only removes from the ledger …
+    assert _change_keys(widened.out_of_surface_changes) <= _change_keys(
+        scoped.out_of_surface_changes
+    )
+    # … and never invents a finding the scoped run did not already have.
+    assert _all_finding_keys(widened) == _all_finding_keys(scoped)

--- a/tests/test_surface_property.py
+++ b/tests/test_surface_property.py
@@ -1,0 +1,208 @@
+"""Property-based tests for ADR-024 public-ABI surface scoping.
+
+ADR-024 §"Validation & testing strategy" §3 calls for property-based
+guarantees — described there as among the most important — that the
+header-scope filter only ever *removes or demotes* findings and never
+*invents* them:
+
+* **Order-independence / idempotence** — the resolved surface does not
+  depend on the order of functions/types in the snapshot, and resolving
+  twice yields the same answer.
+* **Monotonicity** — adding a purely-private (``ELF_ONLY``) symbol, or an
+  internal type that no public API references, never changes the set of
+  *public* findings.
+* **Subset** — the scoped finding set is a subset of the universe of
+  findings the unscoped run produces (filtering relocates, never invents).
+
+These run on synthetic snapshots (no castxml/gcc) but are Hypothesis-driven
+and therefore carry the ``slow`` marker like the other property suites.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from abicheck.checker import compare
+from abicheck.checker_types import Change
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Visibility,
+)
+from abicheck.surface import compute_public_surface
+
+pytestmark = pytest.mark.slow
+
+
+# ---------------------------------------------------------------------------
+# Strategies — small, surface-relevant snapshots
+# ---------------------------------------------------------------------------
+
+# A fixed pool of type names keeps the reachability graph dense enough that
+# the public/private split is actually exercised (some types reachable, some
+# orphaned) rather than every type being trivially unreferenced.
+_TYPE_POOL = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"]
+_type_ref_st = st.sampled_from(_TYPE_POOL + ["int", "void"])
+_ident_st = st.sampled_from([f"sym{i}" for i in range(8)])
+
+
+@st.composite
+def _record_st(draw, name: str) -> RecordType:
+    fields = draw(
+        st.lists(
+            st.tuples(st.sampled_from(["f0", "f1", "f2"]), _type_ref_st),
+            min_size=0,
+            max_size=3,
+        )
+    )
+    bases = draw(st.lists(st.sampled_from(_TYPE_POOL), min_size=0, max_size=2))
+    return RecordType(
+        name=name,
+        kind="struct",
+        size_bits=draw(st.sampled_from([32, 64, 128])),
+        fields=[TypeField(name=n, type=t) for n, t in fields],
+        bases=bases,
+    )
+
+
+@st.composite
+def _function_st(draw, name: str) -> Function:
+    params = draw(st.lists(_type_ref_st, min_size=0, max_size=3))
+    return Function(
+        name=name,
+        mangled=f"_Z{len(name)}{name}",
+        return_type=draw(_type_ref_st),
+        params=[Param(name=f"a{i}", type=t) for i, t in enumerate(params)],
+        # Mix of exported-public and ELF-only so the surface is non-trivial.
+        visibility=draw(st.sampled_from([Visibility.PUBLIC, Visibility.ELF_ONLY])),
+    )
+
+
+@st.composite
+def _snapshot_st(draw, *, version: str) -> AbiSnapshot:
+    fn_names = draw(st.lists(_ident_st, min_size=1, max_size=5, unique=True))
+    type_names = draw(st.lists(st.sampled_from(_TYPE_POOL), min_size=0, max_size=5, unique=True))
+    return AbiSnapshot(
+        library="lib",
+        version=version,
+        functions=[draw(_function_st(n)) for n in fn_names],
+        types=[draw(_record_st(n)) for n in type_names],
+    )
+
+
+def _change_keys(changes: list[Change]) -> set[tuple[str, str]]:
+    return {(c.kind.value, c.symbol) for c in changes}
+
+
+def _all_finding_keys(result) -> set[tuple[str, str]]:
+    """Every finding the run produced, wherever it landed.
+
+    Scoping relocates findings between buckets (e.g. a redundant root that is
+    filtered out leaves its dependents in ``changes``), so the meaningful
+    universe is the union of all buckets, not just ``changes``.
+    """
+    return (
+        _change_keys(result.changes)
+        | _change_keys(result.redundant_changes)
+        | _change_keys(result.suppressed_changes)
+        | _change_keys(result.out_of_surface_changes)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Order-independence / idempotence of surface resolution
+# ---------------------------------------------------------------------------
+
+
+@given(snap=_snapshot_st(version="1"))
+@settings(max_examples=75)
+def test_surface_resolution_is_order_independent(snap: AbiSnapshot):
+    """Resolved surface is invariant under reordering functions/types."""
+    base = compute_public_surface(snap)
+
+    shuffled = copy.deepcopy(snap)
+    shuffled.functions.reverse()
+    shuffled.types.reverse()
+    other = compute_public_surface(shuffled)
+
+    assert base.resolvable == other.resolvable
+    assert base.public_symbols == other.public_symbols
+    assert base.public_types == other.public_types
+    assert base.all_symbols == other.all_symbols
+    assert base.all_types == other.all_types
+
+
+@given(snap=_snapshot_st(version="1"))
+@settings(max_examples=50)
+def test_surface_resolution_is_idempotent(snap: AbiSnapshot):
+    """Resolving the same snapshot twice yields identical surfaces."""
+    a = compute_public_surface(snap)
+    b = compute_public_surface(snap)
+    assert a.public_symbols == b.public_symbols
+    assert a.public_types == b.public_types
+    assert a.resolvable == b.resolvable
+
+
+# ---------------------------------------------------------------------------
+# Monotonicity — adding purely-private entities changes no public finding
+# ---------------------------------------------------------------------------
+
+
+@given(
+    old=_snapshot_st(version="1"),
+    new=_snapshot_st(version="2"),
+    extra_name=st.sampled_from(["_priv_a", "_priv_b", "_priv_c"]),
+)
+@settings(max_examples=75)
+def test_adding_private_symbol_preserves_public_findings(
+    old: AbiSnapshot, new: AbiSnapshot, extra_name: str
+):
+    """Adding an ELF-only symbol to both sides leaves scoped findings unchanged."""
+    before = compare(copy.deepcopy(old), copy.deepcopy(new), scope_to_public_surface=True)
+
+    old2 = copy.deepcopy(old)
+    new2 = copy.deepcopy(new)
+    priv = Function(
+        name=extra_name,
+        mangled=f"_Zpriv{extra_name}",
+        return_type="void",
+        params=[],
+        visibility=Visibility.ELF_ONLY,
+    )
+    old2.functions.append(priv)
+    new2.functions.append(copy.deepcopy(priv))
+
+    after = compare(old2, new2, scope_to_public_surface=True)
+
+    # The public (reported) findings are identical — the private symbol is
+    # invisible to the public surface on both sides, so it produces nothing.
+    assert _change_keys(before.changes) == _change_keys(after.changes)
+
+
+# ---------------------------------------------------------------------------
+# Subset — scoping never invents a finding
+# ---------------------------------------------------------------------------
+
+
+@given(old=_snapshot_st(version="1"), new=_snapshot_st(version="2"))
+@settings(max_examples=100)
+def test_scoped_findings_subset_of_unscoped_universe(old: AbiSnapshot, new: AbiSnapshot):
+    """Every scoped finding also appears somewhere in the unscoped run.
+
+    ADR-024 §D4: header scoping only removes/demotes findings; it must never
+    surface a (kind, symbol) the unscoped comparison did not produce.
+    """
+    unscoped = compare(copy.deepcopy(old), copy.deepcopy(new))
+    scoped = compare(copy.deepcopy(old), copy.deepcopy(new), scope_to_public_surface=True)
+
+    universe = _all_finding_keys(unscoped)
+    assert _all_finding_keys(scoped) <= universe
+    # And the reported (kept) scoped findings are themselves within that universe.
+    assert _change_keys(scoped.changes) <= universe

--- a/tests/test_surface_property.py
+++ b/tests/test_surface_property.py
@@ -203,7 +203,7 @@ def test_scoped_findings_subset_of_unscoped_universe(old: AbiSnapshot, new: AbiS
     ADR-024 §D4: header scoping only removes/demotes findings; it must never
     surface a (kind, symbol) the unscoped comparison did not produce.
     """
-    unscoped = compare(copy.deepcopy(old), copy.deepcopy(new))
+    unscoped = compare(copy.deepcopy(old), copy.deepcopy(new), scope_to_public_surface=False)
     scoped = compare(copy.deepcopy(old), copy.deepcopy(new), scope_to_public_surface=True)
 
     universe = _all_finding_keys(unscoped)

--- a/tests/test_surface_scope_parity.py
+++ b/tests/test_surface_scope_parity.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parity: abicheck ``--scope-public-headers`` vs libabigail ``abidiff
+--headers-dir1/2`` (ADR-024 §"Validation & testing strategy" §2).
+
+Both tools restrict findings to the public-header ABI surface. These tests
+assert the two agree on the headline verdict for the two clear-cut cases:
+
+* a change to an **internal** type (defined outside the public headers and not
+  reachable from any public API) is scoped out by both → compatible;
+* a change to a **public-header** type reachable from a public API is in-surface
+  for both → breaking.
+
+Requires ``abidiff`` (libabigail), ``gcc``, and ``castxml``; marked
+``libabigail`` so the default fast suite skips it. abidiff's header-scoping is
+version-sensitive, so an abidiff *error* exit (bit 0) skips rather than fails —
+we only assert parity when abidiff actually produced a verdict.
+"""
+from __future__ import annotations
+
+import subprocess
+import textwrap
+import warnings
+from pathlib import Path
+
+import pytest
+
+from tests._libabigail import decode_exit_code
+from tests._libabigail import require_tool as _require_tool
+
+pytestmark = pytest.mark.libabigail
+
+_BIT_ERROR = 1
+
+
+def _compile(src: str, out: Path, *, include: Path | None = None) -> None:
+    src_file = out.with_suffix(".c")
+    src_file.write_text(textwrap.dedent(src).strip() + "\n", encoding="utf-8")
+    cmd = ["gcc", "-shared", "-fPIC", "-g", "-fvisibility=default",
+           "-o", str(out), str(src_file)]
+    if include is not None:
+        cmd += ["-I", str(include)]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if r.returncode != 0:
+        pytest.skip(f"compile failed: {r.stderr[:200]}")
+
+
+def _abidiff_headers(old: Path, new: Path, hdr_dir: Path) -> str:
+    """abidiff scoped to *hdr_dir*; returns the verdict, or skips on tool error."""
+    r = subprocess.run(
+        ["abidiff", "--no-show-locs",
+         "--headers-dir1", str(hdr_dir), "--headers-dir2", str(hdr_dir),
+         str(old), str(new)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if r.returncode & _BIT_ERROR:
+        pytest.skip(f"abidiff errored (header-scoping unsupported?): {r.stderr[:200]}")
+    return decode_exit_code(r.returncode, zero_verdict="NO_CHANGE")
+
+
+def _abicheck_scoped(old: Path, new: Path, pub_header: Path) -> str:
+    from abicheck.checker import compare
+    from abicheck.dumper import dump
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        old_snap = dump(old, headers=[pub_header], version="v1", compiler="cc", lang="C")
+        new_snap = dump(new, headers=[pub_header], version="v2", compiler="cc", lang="C")
+    result = compare(old_snap, new_snap, scope_to_public_surface=True)
+    return result.verdict.value
+
+
+def _is_breaking(verdict: str) -> bool:
+    return "BREAK" in verdict.upper()
+
+
+@pytest.mark.integration
+def test_internal_type_change_scoped_out_by_both(tmp_path: Path) -> None:
+    """An internal struct's layout change is scoped out by both tools."""
+    _require_tool("abidiff")
+    _require_tool("gcc")
+
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "api.h").write_text("#ifndef API_H\n#define API_H\nint compute(int x);\n#endif\n")
+
+    # struct Cache lives only in the .c (outside public headers) and is touched
+    # solely by a static helper — neither tool should treat it as public.
+    base = """
+        struct Cache {{ int a;{extra} }};
+        static int helper(struct Cache *c) {{ return c->a; }}
+        int compute(int x) {{ struct Cache c = {{ x }}; return helper(&c); }}
+    """
+    v1 = tmp_path / "libv1.so"
+    v2 = tmp_path / "libv2.so"
+    _compile(base.format(extra=""), v1, include=inc)
+    _compile(base.format(extra=" int b;"), v2, include=inc)
+
+    ac = _abicheck_scoped(v1, v2, inc / "api.h")
+    ad = _abidiff_headers(v1, v2, inc)
+    assert not _is_breaking(ac), f"abicheck unexpectedly breaking: {ac}"
+    assert not _is_breaking(ad), f"abidiff unexpectedly breaking: {ad}"
+
+
+@pytest.mark.integration
+def test_public_type_change_breaking_for_both(tmp_path: Path) -> None:
+    """A public-header struct passed by value changing size breaks for both."""
+    _require_tool("abidiff")
+    _require_tool("gcc")
+
+    # Separate per-version include dirs so each .so is built (and dumped /
+    # scoped) against its own header revision.
+    inc1, inc2 = tmp_path / "inc1", tmp_path / "inc2"
+    inc1.mkdir()
+    inc2.mkdir()
+
+    def _header(dir_: Path, extra: str) -> Path:
+        h = dir_ / "api.h"
+        h.write_text(
+            "#ifndef API_H\n#define API_H\n"
+            f"struct Point {{ int x; int y;{extra} }};\n"
+            "int dist(struct Point p);\n#endif\n"
+        )
+        return h
+
+    src = '#include "api.h"\nint dist(struct Point p) { return p.x + p.y; }\n'
+    h1 = _header(inc1, "")
+    h2 = _header(inc2, " int z;")  # extra member ⇒ size change, by-value param
+    v1, v2 = tmp_path / "libv1.so", tmp_path / "libv2.so"
+    _compile(src, v1, include=inc1)
+    _compile(src, v2, include=inc2)
+
+    from abicheck.checker import compare
+    from abicheck.dumper import dump
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        old_snap = dump(v1, headers=[h1], version="v1", compiler="cc", lang="C")
+        new_snap = dump(v2, headers=[h2], version="v2", compiler="cc", lang="C")
+    ac = compare(old_snap, new_snap, scope_to_public_surface=True).verdict.value
+
+    r = subprocess.run(
+        ["abidiff", "--no-show-locs",
+         "--headers-dir1", str(inc1), "--headers-dir2", str(inc2),
+         str(v1), str(v2)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if r.returncode & _BIT_ERROR:
+        pytest.skip(f"abidiff errored: {r.stderr[:200]}")
+    ad = decode_exit_code(r.returncode, zero_verdict="NO_CHANGE")
+
+    assert _is_breaking(ac), f"abicheck should be breaking: {ac}"
+    assert _is_breaking(ad), f"abidiff should be breaking: {ad}"

--- a/tests/test_workflow_scenarios.py
+++ b/tests/test_workflow_scenarios.py
@@ -153,11 +153,14 @@ def test_enum_rename_recommendation_follows_policy() -> None:
     old = _lib("1.0", ["use_mode"], enums=[_enum("MODE_B")])
     new = _lib("2.0", ["use_mode"], enums=[_enum("MODE_RENAMED")])
 
-    strict = compare(old, new, policy="strict_abi")
+    # Mode isn't referenced by a public function in this synthetic fixture, so
+    # opt out of default public-header scoping (ADR-024 Phase 5) to exercise the
+    # policy-aware recommender on the enum rename itself.
+    strict = compare(old, new, policy="strict_abi", scope_to_public_surface=False)
     assert strict.verdict is Verdict.API_BREAK
     assert recommend_release(strict).bump is SemverBump.MAJOR
 
-    vendor = compare(old, new, policy="sdk_vendor")
+    vendor = compare(old, new, policy="sdk_vendor", scope_to_public_surface=False)
     assert vendor.verdict is Verdict.COMPATIBLE
     rec = recommend_release(vendor)
     assert rec.bump is not SemverBump.MAJOR

--- a/tests/test_xml_parity.py
+++ b/tests/test_xml_parity.py
@@ -207,7 +207,9 @@ class TestXmlCrossToolParity:
             warnings.simplefilter("ignore")
             old_snap = dump(v1_so, headers=[h1], version="1.0", compiler="cc")
             new_snap = dump(v2_so, headers=[h2], version="2.0", compiler="cc")
-        result = compare(old_snap, new_snap)
+        # Parity expectations predate default scoping (ADR-024 Phase 5); compare
+        # unscoped to keep the established XML/abicc verdicts apples-to-apples.
+        result = compare(old_snap, new_snap, scope_to_public_surface=False)
         abicheck_xml_str = generate_xml_report(
             result, lib_name="libtest",
             old_version="1.0", new_version="2.0",
@@ -275,7 +277,7 @@ class TestXmlCrossToolParity:
             warnings.simplefilter("ignore")
             old_snap = dump(v1_so, headers=[h], version="1.0", compiler="cc")
             new_snap = dump(v2_so, headers=[h], version="1.0", compiler="cc")
-        result = compare(old_snap, new_snap)
+        result = compare(old_snap, new_snap, scope_to_public_surface=False)
         xml_str = generate_xml_report(
             result, lib_name="libtest",
             old_version="1.0", new_version="1.0",

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -343,8 +343,11 @@ def _dump_and_compare(
     compare_cmd = [
         sys.executable, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json",
     ]
-    if scope_public_headers:
-        compare_cmd.append("--scope-public-headers")
+    # Scoping is on by default since ADR-024 Phase 5; ground_truth.json verdicts
+    # are authored unscoped unless the case opts in, so be explicit either way.
+    compare_cmd.append(
+        "--scope-public-headers" if scope_public_headers else "--no-scope-public-headers"
+    )
     rc = subprocess.run(
         compare_cmd,
         capture_output=True, text=True, timeout=60,


### PR DESCRIPTION
## Summary

This branch carries the Public ABI Surface work in stacked pieces:

### A. Machine-readable surface ledger (ADR-024, D5.1 / D4 disclosure)
ADR-024 rejects libabigail's hard `--headers-dir` *drop* in favor of **demote + disclose**: out-of-surface findings are recorded, never silently dropped.
- `reporter.to_json`: top-level `surface_scope` object (count + per-finding `kind`/`symbol`/`description`/`source_location`/`reason`) when `--scope-public-headers` is active.
- `sarif.to_sarif`: run-level `surfaceScope` property mirroring it.
- Hypothesis property suite: scoping only ever *removes/demotes*, never *invents* findings (idempotence, monotonicity, subset).

### B. Declaration provenance — full Origin model (ADR-015 schema v6 / ADR-024 D1)
The *Origin* axis of the two-axis Linkage × Origin surface model.
- Tags every `Function`/`Variable`/`RecordType`/`EnumType` with:
  - `source_header` — defining header (`source_location` minus `:line:col`); always populated when known.
  - `origin` — a 6-value `ScopeOrigin`: `public_header` / `private_header` / `system_header` / `generated` / `export_only` / `unknown`.
- New `--public-header` / `--public-header-dir` flags on `dump`, threaded through `dumper.dump()` and applied as a post-pass (`abicheck/provenance.py`).
- **Opt-in (D4):** without a public set every `origin` is `unknown` and behaviour is unchanged.
- **Segment-based matching (D3):** suffix / basename / dir-containment, so absolute build-tree prefixes resolve against the headers the user typed. `generated` detects `moc_*`/`*.pb.h`/`generated/` trees; `export_only` marks `ELF_ONLY` linkage with no header.
- `SCHEMA_VERSION` 5 → 6, backward-compatible loading (missing keys → `None` / `unknown`).

### C. Provenance-driven ledger reasons (ADR-024 D5.1)
- `surface.PublicSurface` carries an origin-by-key map; `classify_change_surface` emits the new **`private-header`** / **`system-header`** reason codes when *both* snapshot sides confidently agree a decl originates outside the public set. A public/unknown origin on either side blocks demotion (conservative, D5) — so this is a strict refinement and a no-op without a public set.
- Integration tests (castxml + gcc; auto-skipped when absent) verify end-to-end tagging: public-header fn → `PUBLIC_HEADER`, type pulled from a private header → `PRIVATE_HEADER`, origin stays `UNKNOWN` without a public set.

## Testing
- Full fast suite: **6593 passed**, 16 skipped, 4 xfailed.
- `ruff check`, `mypy abicheck/` (0 errors), `scripts/check_ai_readiness.py` (0 errors) all clean.

## Still open in ADR-024 (out of scope here)
- Phase 4 widening allowlist / force-include overlay.
- Phase 5 libabigail/abicc parity tests for scoping + the FP-rate CI gate.

https://claude.ai/code/session_01QabpHz8Ssm91jNon2fSWGP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QabpHz8Ssm91jNon2fSWGP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--scope-public-headers` CLI flag to filter findings outside the public ABI surface; excluded findings are moved to an audit ledger rather than dropped.
  * Added `--public-header` and `--public-header-dir` CLI options for declaration provenance tracking.
  * Excluded findings now tagged with stable reason codes (`not-exported`, `non-public-type`, `private-header`, `system-header`).
  * Enhanced JSON/SARIF reports with machine-readable surface scope disclosure, including exclusion ledgers and reason details.
  * Snapshot schema bumped to v6 with declaration provenance support.

* **Documentation**
  * Added public-header surface scoping documentation with format-specific examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->