### PR TITLE
refactor: clear CodeFactor "Complex Method" findings (6 functions)

### DIFF
--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -148,6 +148,44 @@ def _build_version_index(
     return ver_idx_to_lib
 
 
+def _symbol_version_index(versym_section: object | None, idx: int) -> int:
+    """Return the .gnu.version index for symbol *idx* (1 = unversioned/global)."""
+    if versym_section is None:
+        return 1
+    try:
+        ver_entry = versym_section.get_symbol(idx)
+        ver_ndx = ver_entry.entry["ndx"]
+        if isinstance(ver_ndx, str):
+            return 0 if ver_ndx == "VER_NDX_LOCAL" else 1
+        return int(ver_ndx) & 0x7FFF  # Mask off hidden bit.
+    except (IndexError, KeyError):
+        return 1
+
+
+def _symbol_from_target_library(
+    sym_name: str,
+    binding: str,
+    ver_ndx: int,
+    reqs: AppRequirements,
+    library_soname: str,
+    ver_idx_to_lib: dict[int, str],
+    versym_section: object | None,
+) -> bool:
+    """Return whether an undefined symbol is imported from the target library."""
+    if not library_soname:
+        return True
+    from .elf_metadata import _guess_symbol_origin
+
+    # With versioning, a concrete version index (>= 2) maps directly to a lib.
+    if versym_section is not None and ver_ndx >= 2:
+        return ver_idx_to_lib.get(ver_ndx, "") == library_soname
+    # Otherwise fall back to a heuristic on the symbol name / weak binding.
+    origin = _guess_symbol_origin(sym_name, reqs.needed_libs)
+    if origin is not None:
+        return origin == library_soname
+    return binding != "STB_WEAK"
+
+
 def _collect_undefined_symbols(
     elf: object,
     reqs: AppRequirements,
@@ -158,52 +196,27 @@ def _collect_undefined_symbols(
     """Read undefined symbols from .dynsym, filtered by target library."""
     from elftools.elf.sections import SymbolTableSection
 
-    def _version_index_for_symbol(idx: int) -> int:
-        if versym_section is None:
-            return 1
-        try:
-            ver_entry = versym_section.get_symbol(idx)
-            ver_ndx = ver_entry.entry["ndx"]
-            if isinstance(ver_ndx, str):
-                return 0 if ver_ndx == "VER_NDX_LOCAL" else 1
-            return int(ver_ndx) & 0x7FFF  # Mask off hidden bit.
-        except (IndexError, KeyError):
-            return 1
-
-    def _is_symbol_from_target_library(sym_name: str, binding: str, ver_ndx: int) -> bool:
-        if not library_soname:
-            return True
-        from .elf_metadata import _guess_symbol_origin
-        if versym_section is None:
-            origin = _guess_symbol_origin(sym_name, reqs.needed_libs)
-            if origin is not None:
-                return origin == library_soname
-            return binding != "STB_WEAK"
-        if ver_ndx >= 2:
-            source_lib = ver_idx_to_lib.get(ver_ndx, "")
-            return source_lib == library_soname
-
-        origin = _guess_symbol_origin(sym_name, reqs.needed_libs)
-        if origin is not None:
-            return origin == library_soname
-        return binding != "STB_WEAK"
-
     for section in elf.iter_sections():
-        if isinstance(section, SymbolTableSection) and section.name == ".dynsym":
-            for idx, sym in enumerate(section.iter_symbols()):
-                if sym.entry.st_shndx != "SHN_UNDEF":
-                    continue
-                if not sym.name:
-                    continue
-                binding = sym.entry.st_info.bind
-                if binding not in ("STB_GLOBAL", "STB_WEAK"):
-                    continue
-
-                ver_ndx = _version_index_for_symbol(idx)
-                if not _is_symbol_from_target_library(sym.name, binding, ver_ndx):
-                    continue
-
-                reqs.undefined_symbols.add(sym.name)
+        if not (isinstance(section, SymbolTableSection) and section.name == ".dynsym"):
+            continue
+        for idx, sym in enumerate(section.iter_symbols()):
+            if sym.entry.st_shndx != "SHN_UNDEF" or not sym.name:
+                continue
+            binding = sym.entry.st_info.bind
+            if binding not in ("STB_GLOBAL", "STB_WEAK"):
+                continue
+            ver_ndx = _symbol_version_index(versym_section, idx)
+            if not _symbol_from_target_library(
+                sym.name,
+                binding,
+                ver_ndx,
+                reqs,
+                library_soname,
+                ver_idx_to_lib,
+                versym_section,
+            ):
+                continue
+            reqs.undefined_symbols.add(sym.name)
 
 
 def _parse_elf_app_requirements(

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1117,6 +1117,99 @@ def _exit_with_severity_or_verdict(
             sys.exit(2)
 
 
+def _log_one_side_debug(
+    label: str, binary: Path, droots: list[Path],
+    *,
+    debuginfod: bool, debuginfod_url: str | None,
+) -> None:
+    """Resolve and log debug info for a single binary side, if applicable."""
+    if _detect_binary_format(binary) is None or not (droots or debuginfod):
+        return
+    from .debug_resolver import resolve_debug_info
+
+    artifact = resolve_debug_info(
+        binary,
+        debug_roots=droots or None,
+        enable_debuginfod=debuginfod,
+        debuginfod_urls=[debuginfod_url] if debuginfod_url else None,
+    )
+    if artifact:
+        click.echo(f"Debug info ({label}): {artifact.source}", err=True)
+
+
+def _log_debug_resolution(
+    old_input: Path, new_input: Path,
+    resolved_old_debug: list[Path], resolved_new_debug: list[Path],
+    *,
+    debuginfod: bool, debuginfod_url: str | None,
+) -> None:
+    """Resolve and log per-side debug info (debug roots / debuginfod), if any."""
+    if not (resolved_old_debug or resolved_new_debug or debuginfod):
+        return
+    _log_one_side_debug(
+        "old", old_input, resolved_old_debug,
+        debuginfod=debuginfod, debuginfod_url=debuginfod_url,
+    )
+    _log_one_side_debug(
+        "new", new_input, resolved_new_debug,
+        debuginfod=debuginfod, debuginfod_url=debuginfod_url,
+    )
+
+
+def _resolve_compare_snapshots(
+    old_input: Path, new_input: Path,
+    old_fmt: str | None, new_fmt: str | None,
+    old_h: list[Path], new_h: list[Path],
+    old_inc: list[Path], new_inc: list[Path],
+    old_version: str, new_version: str, lang: str,
+    pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
+    dwarf_only: bool, debug_format: str | None,
+    follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
+) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Load both ABI snapshots and (optionally) populate ELF dependency info."""
+    old = _resolve_input(
+        old_input, old_h, old_inc, old_version, lang,
+        is_elf=True if old_fmt == "elf" else None,
+        pdb_path=old_pdb_path if old_pdb_path else pdb_path,
+        dwarf_only=dwarf_only,
+        debug_format=debug_format,
+    )
+    new = _resolve_input(
+        new_input, new_h, new_inc, new_version, lang,
+        is_elf=True if new_fmt == "elf" else None,
+        pdb_path=new_pdb_path if new_pdb_path else pdb_path,
+        dwarf_only=dwarf_only,
+        debug_format=debug_format,
+    )
+    if follow_deps:
+        if old_fmt == "elf":
+            _populate_dependency_info(old, old_input, list(search_paths), None, ld_library_path)
+        if new_fmt == "elf":
+            _populate_dependency_info(new, new_input, list(search_paths), None, ld_library_path)
+    return old, new
+
+
+def _finalize_compare_result(
+    result: DiffResult, old_input: Path, new_input: Path,
+    *,
+    show_redundant: bool, show_filtered: bool,
+    annotate: bool, annotate_additions: bool,
+) -> None:
+    """Attach metadata and emit redundancy/filter/suppression/annotation output."""
+    result.old_metadata = _collect_metadata(old_input)
+    result.new_metadata = _collect_metadata(new_input)
+
+    if show_redundant and result.redundant_changes:
+        _merge_redundant_changes(result)
+    if show_filtered and result.out_of_surface_changes:
+        _echo_filtered_surface(result)
+
+    _warn_all_suppressed(result)
+    _maybe_emit_annotations(
+        result, annotate=annotate, annotate_additions=annotate_additions
+    )
+
+
 @main.command("compare")
 @click.argument("old_input", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_input", type=click.Path(exists=True, path_type=Path))
@@ -1364,46 +1457,22 @@ def compare_cmd(
         old_includes_only, new_includes_only,
     )
 
-    resolved_old_pdb = old_pdb_path if old_pdb_path else pdb_path
-    resolved_new_pdb = new_pdb_path if new_pdb_path else pdb_path
-
     # Resolve per-side debug roots: --debug-root1 overrides --debug-root for old, etc.
     resolved_old_debug = list(debug_roots_old) if debug_roots_old else list(debug_roots)
     resolved_new_debug = list(debug_roots_new) if debug_roots_new else list(debug_roots)
-
-    # Log debug resolution if roots are specified
-    if resolved_old_debug or resolved_new_debug or debuginfod:
-        from .debug_resolver import resolve_debug_info
-        for label, binary, droots in [
-            ("old", old_input, resolved_old_debug),
-            ("new", new_input, resolved_new_debug),
-        ]:
-            if _detect_binary_format(binary) is not None and (droots or debuginfod):
-                artifact = resolve_debug_info(
-                    binary,
-                    debug_roots=droots or None,
-                    enable_debuginfod=debuginfod,
-                    debuginfod_urls=[debuginfod_url] if debuginfod_url else None,
-                )
-                if artifact:
-                    click.echo(
-                        f"Debug info ({label}): {artifact.source}",
-                        err=True,
-                    )
-
-    old = _resolve_input(
-        old_input, old_h, old_inc, old_version, lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=resolved_old_pdb,
-        dwarf_only=dwarf_only,
-        debug_format=debug_format,
+    _log_debug_resolution(
+        old_input, new_input,
+        resolved_old_debug, resolved_new_debug,
+        debuginfod=debuginfod, debuginfod_url=debuginfod_url,
     )
-    new = _resolve_input(
-        new_input, new_h, new_inc, new_version, lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=resolved_new_pdb,
-        dwarf_only=dwarf_only,
-        debug_format=debug_format,
+
+    old, new = _resolve_compare_snapshots(
+        old_input, new_input, old_fmt, new_fmt,
+        old_h, new_h, old_inc, new_inc,
+        old_version, new_version, lang,
+        pdb_path, old_pdb_path, new_pdb_path,
+        dwarf_only, debug_format,
+        follow_deps, search_paths, ld_library_path,
     )
 
     suppression, pf = _load_suppression_and_policy(
@@ -1412,29 +1481,16 @@ def compare_cmd(
         require_justification=require_justification,
     )
 
-    if follow_deps:
-        if old_fmt == "elf":
-            _populate_dependency_info(old, old_input, list(search_paths), None, ld_library_path)
-        if new_fmt == "elf":
-            _populate_dependency_info(new, new_input, list(search_paths), None, ld_library_path)
-
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_public_headers,
     )
 
-    result.old_metadata = _collect_metadata(old_input)
-    result.new_metadata = _collect_metadata(new_input)
-
-    if show_redundant and result.redundant_changes:
-        _merge_redundant_changes(result)
-
-    if show_filtered and result.out_of_surface_changes:
-        _echo_filtered_surface(result)
-
-    _warn_all_suppressed(result)
-
-    _maybe_emit_annotations(result, annotate=annotate, annotate_additions=annotate_additions)
+    _finalize_compare_result(
+        result, old_input, new_input,
+        show_redundant=show_redundant, show_filtered=show_filtered,
+        annotate=annotate, annotate_additions=annotate_additions,
+    )
 
     text = _render_output(
         fmt, result, old, new,

--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -517,6 +517,44 @@ _ENUM_DEDUP_KINDS = frozenset({
 })
 
 
+def _type_used_by_value(type_str: str, bare_re: re.Pattern[str]) -> bool:
+    """True if ``type_str`` names the type without a trailing ``*``."""
+    if not bare_re.search(type_str):
+        return False
+    stripped = type_str.replace("const", "").replace("volatile", "").strip()
+    for token in stripped.split(","):
+        token = token.strip()
+        if bare_re.search(token) and "*" not in token:
+            # Token contains the bare type name without a pointer dereference.
+            # This covers both by-value (T) and reference (T&) semantics —
+            # both allow the caller to hold/inspect the type's size.
+            return True
+    return False
+
+
+def _public_function_uses_type_by_value(snap: AbiSnapshot, bare_re: re.Pattern[str]) -> bool:
+    """True if any PUBLIC function uses the type (matched by *bare_re*) by value."""
+    for f in snap.functions:
+        if f.visibility not in _PUBLIC_VIS:
+            continue
+        if _type_used_by_value(f.return_type, bare_re):
+            return True
+        for p in f.params:
+            if _type_used_by_value(p.type, bare_re):
+                return True
+    return False
+
+
+def _public_variable_uses_type_by_value(snap: AbiSnapshot, bare_re: re.Pattern[str]) -> bool:
+    """True if any PUBLIC variable uses the type (matched by *bare_re*) by value."""
+    for v in snap.variables:
+        if v.visibility not in _PUBLIC_VIS:
+            continue
+        if _type_used_by_value(v.type, bare_re):
+            return True
+    return False
+
+
 def _is_pointer_only_type(
     type_name: str, snap: AbiSnapshot,
     _re_cache: dict[str, re.Pattern[str]] | None = None,
@@ -538,42 +576,8 @@ def _is_pointer_only_type(
         if _re_cache is not None:
             _re_cache[type_name] = bare_re
 
-    def _is_by_value(type_str: str) -> bool:
-        """True if ``type_str`` names the type without a trailing ``*``."""
-        if not bare_re.search(type_str):
-            return False
-        stripped = type_str.replace("const", "").replace("volatile", "").strip()
-        for token in stripped.split(","):
-            token = token.strip()
-            if bare_re.search(token) and "*" not in token:
-                # Token contains the bare type name without a pointer dereference.
-                # This covers both by-value (T) and reference (T&) semantics —
-                # both allow the caller to hold/inspect the type's size.
-                return True
+    if _public_function_uses_type_by_value(snap, bare_re) or _public_variable_uses_type_by_value(snap, bare_re):
         return False
-
-    def _public_function_uses_by_value() -> bool:
-        for f in snap.functions:
-            if f.visibility not in _PUBLIC_VIS:
-                continue
-            if _is_by_value(f.return_type):
-                return True
-            for p in f.params:
-                if _is_by_value(p.type):
-                    return True
-        return False
-
-    def _public_variable_uses_by_value() -> bool:
-        for v in snap.variables:
-            if v.visibility not in _PUBLIC_VIS:
-                continue
-            if _is_by_value(v.type):
-                return True
-        return False
-
-    if _public_function_uses_by_value() or _public_variable_uses_by_value():
-        return False
-
     return True
 
 

--- a/abicheck/diff_integer_model.py
+++ b/abicheck/diff_integer_model.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
-from .model import AbiSnapshot, Visibility
+from .model import AbiSnapshot, Function, Visibility
 
 # Canonical integer-width buckets. A change that moves a spelling from one
 # bucket to a *different* bucket (and is not a sign-only change) is a width flip.
@@ -77,31 +77,14 @@ def _int_width_bucket(type_str: object, is_llp64: bool = False) -> str | None:
     return _INT_WIDTH_BUCKETS.get(t)
 
 
-@registry.detector("integer_model")
-def _diff_integer_model(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
-    """Detect an LP64<->ILP64 integer-model switch (e.g. oneMKL MKL_INT 32<->64).
-
-    Conservative, mirrors the glibcxx dual-ABI detector: only fires when a
-    meaningful number of public integer parameters/returns flip width together,
-    OR a public integer-named typedef changes its underlying width. Reports ONE
-    grouped diagnostic; per-symbol findings are still emitted separately by the
-    symbol diff.
-    """
-    changes: list[Change] = []
-
-    # Windows/LLP64: ``long`` is 32-bit, so int<->long is NOT a model flip there.
-    is_llp64 = "pe" in (old.platform, new.platform)
-
-    old_map = {f.mangled: f for f in old.functions if f.visibility == Visibility.PUBLIC}
-    new_map = {f.mangled: f for f in new.functions if f.visibility == Visibility.PUBLIC}
-    common = set(old_map) & set(new_map)
-
-    flips = 0  # integer slots that moved to a different width bucket
-    total = 0  # integer slots present (same kind) in both versions
-    up = 0     # 32 -> 64 transitions
-    down = 0   # 64 -> 32 transitions
-
-    for key in common:
+def _scan_function_integer_flips(
+    old_map: dict[str, Function],
+    new_map: dict[str, Function],
+    is_llp64: bool,
+) -> tuple[int, int, int, int]:
+    """Return (flips, total, up, down) over matched public functions' int slots."""
+    flips = total = up = down = 0
+    for key in set(old_map) & set(new_map):
         of, nf = old_map[key], new_map[key]
         slots: list[tuple[object, object]] = [(of.return_type, nf.return_type)]
         for op, npm in zip(of.params, nf.params):
@@ -118,10 +101,15 @@ def _diff_integer_model(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     up += 1
                 elif ob == "64" and nb == "32":
                     down += 1
+    return flips, total, up, down
 
-    # Typedef corroboration: an integer-named typedef whose underlying width
-    # changed bucket (typedefs are name -> underlying-type-string in the model).
+
+def _scan_typedef_integer_flips(
+    old: AbiSnapshot, new: AbiSnapshot, is_llp64: bool
+) -> tuple[list[str], int, int]:
+    """Return (descriptions, up, down) for integer-named typedefs that changed width."""
     typedef_flips: list[str] = []
+    up = down = 0
     for name, old_under in old.typedefs.items():
         new_under = new.typedefs.get(name)
         if new_under is None:
@@ -136,19 +124,18 @@ def _diff_integer_model(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 up += 1
             else:
                 down += 1
+    return typedef_flips, up, down
 
-    # Conservative thresholds (like the dual-ABI detector): require either a
-    # meaningful count + ratio of flips, or a corroborating integer typedef.
-    enough_func_flips = flips >= 4 and total > 0 and flips >= total * 0.5
-    if not enough_func_flips and not typedef_flips:
-        return changes
 
-    direction = (
-        "LP64 → ILP64 (32-bit → 64-bit)"
-        if up >= down
-        else "ILP64 → LP64 (64-bit → 32-bit)"
-    )
+def _integer_model_direction(up: int, down: int) -> str:
+    """Return the human-readable transition direction string."""
+    if up >= down:
+        return "LP64 → ILP64 (32-bit → 64-bit)"
+    return "ILP64 → LP64 (64-bit → 32-bit)"
 
+
+def _integer_model_detail(flips: int, total: int, typedef_flips: list[str]) -> str:
+    """Build the detail sentence describing what flipped width."""
     detail_bits = []
     if flips:
         detail_bits.append(
@@ -158,9 +145,40 @@ def _diff_integer_model(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         detail_bits.append(
             "integer typedef(s) resized: " + ", ".join(sorted(typedef_flips))
         )
-    detail = "; ".join(detail_bits)
+    return "; ".join(detail_bits)
 
-    changes.append(Change(
+
+@registry.detector("integer_model")
+def _diff_integer_model(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    """Detect an LP64<->ILP64 integer-model switch (e.g. oneMKL MKL_INT 32<->64).
+
+    Conservative, mirrors the glibcxx dual-ABI detector: only fires when a
+    meaningful number of public integer parameters/returns flip width together,
+    OR a public integer-named typedef changes its underlying width. Reports ONE
+    grouped diagnostic; per-symbol findings are still emitted separately by the
+    symbol diff.
+    """
+    # Windows/LLP64: ``long`` is 32-bit, so int<->long is NOT a model flip there.
+    is_llp64 = "pe" in (old.platform, new.platform)
+
+    old_map = {f.mangled: f for f in old.functions if f.visibility == Visibility.PUBLIC}
+    new_map = {f.mangled: f for f in new.functions if f.visibility == Visibility.PUBLIC}
+
+    flips, total, up, down = _scan_function_integer_flips(old_map, new_map, is_llp64)
+    typedef_flips, typedef_up, typedef_down = _scan_typedef_integer_flips(old, new, is_llp64)
+    up += typedef_up
+    down += typedef_down
+
+    # Conservative thresholds (like the dual-ABI detector): require either a
+    # meaningful count + ratio of flips, or a corroborating integer typedef.
+    enough_func_flips = flips >= 4 and total > 0 and flips >= total * 0.5
+    if not enough_func_flips and not typedef_flips:
+        return []
+
+    direction = _integer_model_direction(up, down)
+    detail = _integer_model_detail(flips, total, typedef_flips)
+
+    return [Change(
         kind=ChangeKind.INTEGER_MODEL_CHANGED,
         symbol="__integer_model",
         description=(
@@ -171,6 +189,4 @@ def _diff_integer_model(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         ),
         old_value=f"{down} narrowing / {up} widening transitions",
         new_value=direction,
-    ))
-
-    return changes
+    )]

--- a/abicheck/diff_type_spellings.py
+++ b/abicheck/diff_type_spellings.py
@@ -42,64 +42,89 @@ class TypeSlotChange:
     new_type: str
 
 
+def _spelling_differ(a: object, b: object) -> bool:
+    # Only compare plain string spellings; guard against None/other shapes
+    # so a malformed snapshot cannot crash (and thus disable) the caller.
+    return isinstance(a, str) and isinstance(b, str) and a != b
+
+
+def _emit_function_slot_changes(of: Function, nf: Function) -> Iterator[TypeSlotChange]:
+    """Yield changed return-type / parameter-type slots for a matched pair."""
+    if _spelling_differ(of.return_type, nf.return_type):
+        yield TypeSlotChange(of.name, "return type", of.return_type, nf.return_type)
+    for op, npm in zip(of.params, nf.params):
+        if _spelling_differ(op.type, npm.type):
+            pname = op.name or npm.name or "?"
+            yield TypeSlotChange(of.name, f"parameter '{pname}'", op.type, npm.type)
+
+
+def _pair_leftover_functions_by_name(
+    leftover_old: list[Function], leftover_new: list[Function]
+) -> Iterator[TypeSlotChange]:
+    """Pair functions whose mangled name changed, by unambiguous demangled name.
+
+    A type migration such as char->char8_t, ->_BitInt(N), or an _Atomic
+    qualifier change *alters the mangled name itself* (e.g. PKc->PKDu), so the
+    two symbols never share a mangled key and the primary pass misses them
+    (Codex review P2). Pair leftover functions by their demangled name, but only
+    when that name is unambiguous on both sides (exactly one unmatched old and
+    one unmatched new) so overload sets are never mispaired.
+    """
+    from collections import defaultdict
+
+    old_by_name: dict[str, list[Function]] = defaultdict(list)
+    for f in leftover_old:
+        if f.name:
+            old_by_name[f.name].append(f)
+    new_by_name: dict[str, list[Function]] = defaultdict(list)
+    for f in leftover_new:
+        if f.name:
+            new_by_name[f.name].append(f)
+    for nm, olist in old_by_name.items():
+        nlist = new_by_name.get(nm)
+        if len(olist) == 1 and nlist and len(nlist) == 1:
+            yield from _emit_function_slot_changes(olist[0], nlist[0])
+
+
+def _match_functions_by_mangled(
+    old: AbiSnapshot, new: AbiSnapshot
+) -> Iterator[TypeSlotChange]:
+    """Yield slot changes for public functions sharing a mangled name, plus
+    pair leftovers (mangled name changed) by unambiguous demangled name."""
+    old_fns = {f.mangled: f for f in old.functions if f.visibility == Visibility.PUBLIC}
+    new_fns = {f.mangled: f for f in new.functions if f.visibility == Visibility.PUBLIC}
+    matched_new: set[str] = set()
+    for key in set(old_fns) & set(new_fns):
+        matched_new.add(key)
+        yield from _emit_function_slot_changes(old_fns[key], new_fns[key])
+
+    # Fallback: pair functions whose mangled name changed (char8_t/_BitInt/_Atomic).
+    leftover_old = [f for k, f in old_fns.items() if k not in set(new_fns)]
+    leftover_new = [f for k, f in new_fns.items() if k not in matched_new]
+    if leftover_old and leftover_new:
+        yield from _pair_leftover_functions_by_name(leftover_old, leftover_new)
+
+
+def _match_record_fields(
+    old: AbiSnapshot, new: AbiSnapshot
+) -> Iterator[TypeSlotChange]:
+    """Yield field-spelling changes for record types present in both snapshots."""
+    old_types = {t.name: t for t in old.types}
+    new_types = {t.name: t for t in new.types}
+    for name in set(old_types) & set(new_types):
+        nt = new_types[name]
+        new_fields = {f.name: f for f in nt.fields}
+        for ofield in old_types[name].fields:
+            nfield = new_fields.get(ofield.name)
+            if nfield is not None and _spelling_differ(ofield.type, nfield.type):
+                yield TypeSlotChange(name, f"field '{ofield.name}'", ofield.type, nfield.type)
+
+
 def iter_type_slot_changes(old: AbiSnapshot, new: AbiSnapshot) -> Iterator[TypeSlotChange]:
     """Yield every public function/field type slot whose spelling changed.
 
     Matching is by mangled name (functions) and type name (records); only slots
     present in both versions with a differing spelling are yielded.
     """
-    def _differ(a: object, b: object) -> bool:
-        # Only compare plain string spellings; guard against None/other shapes
-        # so a malformed snapshot cannot crash (and thus disable) the caller.
-        return isinstance(a, str) and isinstance(b, str) and a != b
-
-    def _emit(of: Function, nf: Function) -> Iterator[TypeSlotChange]:
-        if _differ(of.return_type, nf.return_type):
-            yield TypeSlotChange(of.name, "return type", of.return_type, nf.return_type)
-        for op, npm in zip(of.params, nf.params):
-            if _differ(op.type, npm.type):
-                pname = op.name or npm.name or "?"
-                yield TypeSlotChange(of.name, f"parameter '{pname}'", op.type, npm.type)
-
-    # ── Functions: return type + positional parameters ──────────────────────
-    old_fns = {f.mangled: f for f in old.functions if f.visibility == Visibility.PUBLIC}
-    new_fns = {f.mangled: f for f in new.functions if f.visibility == Visibility.PUBLIC}
-    matched_new: set[str] = set()
-    for key in set(old_fns) & set(new_fns):
-        matched_new.add(key)
-        yield from _emit(old_fns[key], new_fns[key])
-
-    # Fallback: a type migration such as char->char8_t, ->_BitInt(N), or an
-    # _Atomic qualifier change *alters the mangled name itself* (e.g. PKc->PKDu),
-    # so the two symbols never share a mangled key and the pass above misses
-    # them (Codex review P2). Pair any leftover functions by their demangled
-    # name, but only when that name is unambiguous on both sides (exactly one
-    # unmatched old and one unmatched new) so overload sets are never mispaired.
-    leftover_old = [f for k, f in old_fns.items() if k not in set(new_fns)]
-    leftover_new = [f for k, f in new_fns.items() if k not in matched_new]
-    if leftover_old and leftover_new:
-        from collections import defaultdict
-
-        old_by_name: dict[str, list[Function]] = defaultdict(list)
-        for f in leftover_old:
-            if f.name:
-                old_by_name[f.name].append(f)
-        new_by_name: dict[str, list[Function]] = defaultdict(list)
-        for f in leftover_new:
-            if f.name:
-                new_by_name[f.name].append(f)
-        for nm, olist in old_by_name.items():
-            nlist = new_by_name.get(nm)
-            if len(olist) == 1 and nlist and len(nlist) == 1:
-                yield from _emit(olist[0], nlist[0])
-
-    # ── Record types: field spellings ───────────────────────────────────────
-    old_types = {t.name: t for t in old.types}
-    new_types = {t.name: t for t in new.types}
-    for name in set(old_types) & set(new_types):
-        ot, nt = old_types[name], new_types[name]
-        new_fields = {f.name: f for f in nt.fields}
-        for ofield in ot.fields:
-            nfield = new_fields.get(ofield.name)
-            if nfield is not None and _differ(ofield.type, nfield.type):
-                yield TypeSlotChange(name, f"field '{ofield.name}'", ofield.type, nfield.type)
+    yield from _match_functions_by_mangled(old, new)
+    yield from _match_record_fields(old, new)

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -143,16 +143,12 @@ def _symbol_keys(name: str, mangled: str) -> set[str]:
     return keys
 
 
-def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
-    """Compute the public-ABI surface of *snap*.
+def _index_surface_types(snap: AbiSnapshot, surface: PublicSurface) -> dict[str, RecordType]:
+    """Populate ``surface.all_types`` and return a name -> record index.
 
-    Public roots are :data:`Visibility.PUBLIC` functions/variables. The
-    public type set is the transitive closure over the types they
-    reference (returns, params, fields, bases, typedef targets).
+    Records are indexed by both their full name and (for namespaced types) the
+    trailing ``::`` segment, so the closure walk can match either encoding.
     """
-    surface = PublicSurface()
-
-    # Build the type universe and a name -> record index for closure walks.
     record_by_name: dict[str, RecordType] = {}
     for rec in snap.types:
         surface.all_types.add(rec.name)
@@ -163,8 +159,15 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
         surface.all_types.add(en.name)
     for alias in snap.typedefs:
         surface.all_types.add(alias)
+    return record_by_name
 
-    # Seed roots from public symbols; collect the type names they touch.
+
+def _seed_public_roots(snap: AbiSnapshot, surface: PublicSurface) -> tuple[set[str], bool]:
+    """Record public symbols on *surface*; return (seed type names, has_public).
+
+    Seeds the type-closure work-list from the return/parameter/variable types of
+    every :data:`Visibility.PUBLIC` function and variable.
+    """
     seed_types: set[str] = set()
     has_public = False
     for fn in snap.functions:
@@ -183,15 +186,20 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
             has_public = True
             surface.public_symbols |= keys
             seed_types |= _type_identifiers(var.type)
+    return seed_types, has_public
 
-    # Scoping only makes sense when we actually have header-derived public
-    # visibility. Without headers every symbol is ELF_ONLY (ADR-016) and a
-    # surface filter would hide everything — so declare it unresolvable.
-    surface.resolvable = has_public and not getattr(snap, "elf_only_mode", False)
-    if not surface.resolvable:
-        return surface
 
-    # Transitive closure over the record/typedef graph.
+def _walk_type_closure(
+    snap: AbiSnapshot,
+    surface: PublicSurface,
+    record_by_name: dict[str, RecordType],
+    seed_types: set[str],
+) -> None:
+    """Transitive closure over the record/typedef graph; fills public_types.
+
+    Follows typedef targets, record fields, and base classes from each seed
+    type, marking every reachable known type as part of the public surface.
+    """
     queue = list(seed_types)
     seen: set[str] = set()
     while queue:
@@ -218,6 +226,32 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
             for ident in _type_identifiers(base):
                 if ident not in seen:
                     queue.append(ident)
+
+
+def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
+    """Compute the public-ABI surface of *snap*.
+
+    Public roots are :data:`Visibility.PUBLIC` functions/variables. The
+    public type set is the transitive closure over the types they
+    reference (returns, params, fields, bases, typedef targets).
+    """
+    surface = PublicSurface()
+
+    # Build the type universe and a name -> record index for closure walks.
+    record_by_name = _index_surface_types(snap, surface)
+
+    # Seed roots from public symbols; collect the type names they touch.
+    seed_types, has_public = _seed_public_roots(snap, surface)
+
+    # Scoping only makes sense when we actually have header-derived public
+    # visibility. Without headers every symbol is ELF_ONLY (ADR-016) and a
+    # surface filter would hide everything — so declare it unresolvable.
+    surface.resolvable = has_public and not getattr(snap, "elf_only_mode", False)
+    if not surface.resolvable:
+        return surface
+
+    # Transitive closure over the record/typedef graph.
+    _walk_type_closure(snap, surface, record_by_name, seed_types)
     return surface
 
 


### PR DESCRIPTION
## Summary

Clears all six open **CodeFactor "Complex Method"** findings
(https://www.codefactor.io/repository/github/napetrov/abicheck/issues). Each
flagged function's cyclomatic complexity is reduced by extracting cohesive,
named helpers — pure refactors with **no behavior change**.

## Results (radon cyclomatic complexity)

| File | Function | Before (CodeFactor) | After (radon) |
|------|----------|:---:|:---:|
| `diff_type_spellings.py` | `iter_type_slot_changes` | 17 | **A (1)** |
| `surface.py` | `compute_public_surface` | 23 | **A (3)** |
| `diff_filtering.py` | `_is_pointer_only_type` | 18 | **B (6)** |
| `appcompat.py` | `_collect_undefined_symbols` | 16 | **B (9)** |
| `diff_integer_model.py` | `_diff_integer_model` | 21 | **B (9)** |
| `cli.py` | `compare_cmd` | 16 | **B (6)** |

All six are now radon rank **A/B** (CC < 11).

## What changed

Helpers extracted (each a small, single-purpose function):

- **`diff_type_spellings.py`** — `_match_functions_by_mangled`, `_match_record_fields`, `_emit_function_slot_changes`, `_pair_leftover_functions_by_name`, `_spelling_differ`
- **`diff_integer_model.py`** — `_scan_function_integer_flips`, `_scan_typedef_integer_flips`, `_integer_model_direction`, `_integer_model_detail`
- **`surface.py`** — `_index_surface_types`, `_seed_public_roots`, `_walk_type_closure`
- **`appcompat.py`** — `_symbol_version_index`, `_symbol_from_target_library`
- **`diff_filtering.py`** — `_type_used_by_value`, `_public_function_uses_type_by_value`, `_public_variable_uses_type_by_value`
- **`cli.py`** — `_log_debug_resolution` / `_log_one_side_debug`, `_resolve_compare_snapshots`, `_finalize_compare_result`

## Verification (all green)

- `radon cc`: all six flagged functions at rank A/B
- `pytest` (fast suite): **6550 passed**, 16 skipped, 4 xfailed
- `ruff check abicheck tests`: clean
- `mypy abicheck`: clean (no issues in 97 source files)
- `python scripts/check_ai_readiness.py`: 0 errors (pre-existing soft-limit
  size warnings on `cli.py` / `compat/cli.py` only)

https://claude.ai/code/session_0126nkXQGV2AiYs22hdHE5n2

---
_Generated by [Claude Code](https://claude.ai/code/session_0126nkXQGV2AiYs22hdHE5n2)_