### PR TITLE
feat: oneDAL review contract — scope fallback, bundle scoping, review digest, probe→compare

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -179,6 +179,7 @@ def compare(
     policy_file: PolicyFile | None = None,
     scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
+    extra_changes: list[Change] | None = None,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.
 
@@ -197,6 +198,13 @@ def compare(
 
     # Run all registered detectors via the self-registering registry.
     changes, detector_results = _detector_registry.run_all(old, new)
+
+    # Merge externally-computed findings (e.g. build-configuration / probe-matrix
+    # findings from diff_matrix(), which need multi-config inputs compare() does
+    # not have). They join the normal pipeline so suppression, reporting, and
+    # verdict composition treat them uniformly (G2: probe → compare).
+    if extra_changes:
+        changes.extend(extra_changes)
 
     # Post-detector: SONAME bump policy check (needs full change list).
     # Uses the module-level import of check_soname_bump_policy.

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -222,6 +222,10 @@ def compare(
     opaque_filtered = pp_ctx.opaque_filtered
     suppressed = pp_ctx.suppressed
     out_of_surface = pp_ctx.out_of_surface
+    # scoping is "resolved" unless it was requested and had to fall back to the
+    # full export table (issue #235: an unconfirmed scope must not read as a
+    # confidently-clean public surface).
+    scope_resolved = not (scope_to_public_surface and pp_ctx.scope_fell_back)
 
     # Verdict computed on unsuppressed semantic changes.
     # NOTE: opaque_filtered changes are intentionally excluded from verdict
@@ -269,5 +273,6 @@ def compare(
         out_of_surface_changes=out_of_surface,
         out_of_surface_count=len(out_of_surface),
         scope_to_public_surface=scope_to_public_surface,
+        scope_resolved=scope_resolved,
         evidence_tier=evidence_tier,
     )

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -117,6 +117,12 @@ class DiffResult:
     out_of_surface_changes: list[Change] = field(default_factory=list)
     out_of_surface_count: int = 0
     scope_to_public_surface: bool = False
+    # False only when --scope-public-headers was requested but the public
+    # surface could not be resolved, so scoping fell back to the full export
+    # table. A False value means compatibility is *unconfirmed* and the result
+    # needs manual review — it must never read as a confidently-clean public
+    # surface (issue #235).
+    scope_resolved: bool = True
     # Canonical analysis depth (ordered): ELF_ONLY < DWARF_AWARE < HEADER_AWARE.
     # Distinct from the raw ``evidence_tiers`` list above — this is the single
     # scalar consumers should key trust decisions off of. See EvidenceTier.

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -31,7 +31,7 @@ from .errors import AbicheckError
 from .serialization import load_snapshot, snapshot_to_json
 
 if TYPE_CHECKING:
-    from .checker_types import DiffResult
+    from .checker_types import Change, DiffResult
     from .debug_resolver import DebugArtifact
     from .policy_file import PolicyFile
     from .severity import SeverityConfig
@@ -886,6 +886,29 @@ def _collect_additions(result: DiffResult) -> list[object]:
     return [c for c in result.changes if c.kind in addition_kinds]
 
 
+def _load_probe_matrix_changes(
+    probe_matrix_old: Path | None, probe_matrix_new: Path | None,
+) -> list[Change] | None:
+    """Load build-config matrix snapshots and return diff_matrix() findings.
+
+    These findings (CXX_STANDARD_FLOOR_RAISED, API_DEPENDS_ON_CONSUMER_ENV,
+    BEHAVIOURAL_DEFAULT_CHANGED) need multi-configuration inputs the plain
+    compare() does not have, so they are computed here and merged in (G2).
+    """
+    if probe_matrix_old is None and probe_matrix_new is None:
+        return None
+    if probe_matrix_old is None or probe_matrix_new is None:
+        raise click.UsageError(
+            "--probe-matrix-old and --probe-matrix-new must be given together."
+        )
+    from .diff_build_config import diff_matrix
+    from .probe_harness import load_matrix_snapshot
+
+    old_matrix = load_matrix_snapshot(probe_matrix_old)
+    new_matrix = load_matrix_snapshot(probe_matrix_new)
+    return list(diff_matrix(old_matrix, new_matrix))
+
+
 def _run_compare_pair(
     old_input: Path,
     new_input: Path,
@@ -1379,6 +1402,16 @@ def _finalize_compare_result(
               help="File of symbols to force public (one per line; '#' comments and blank "
                    "lines ignored), à la abi-compliance-checker -symbols-list. "
                    "Merged with --public-symbol.")
+@click.option("--probe-matrix-old", "probe_matrix_old", type=click.Path(exists=True, path_type=Path),
+              default=None,
+              help="Old build-configuration matrix snapshot (from 'abicheck probe run'). "
+                   "When given with --probe-matrix-new, build-config findings "
+                   "(CXX_STANDARD_FLOOR_RAISED, API_DEPENDS_ON_CONSUMER_ENV, "
+                   "BEHAVIOURAL_DEFAULT_CHANGED) are folded into this comparison's "
+                   "verdict and report (G2: probe -> compare).")
+@click.option("--probe-matrix-new", "probe_matrix_new", type=click.Path(exists=True, path_type=Path),
+              default=None,
+              help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).")
 @click.option("--show-only", "show_only", default=None,
               callback=_validate_show_only, expose_value=True, is_eager=False,
               help="Comma-separated filter tokens to limit displayed changes. "
@@ -1457,6 +1490,8 @@ def compare_cmd(
     debuginfod: bool,
     debuginfod_url: str | None,
     verbose: bool,
+    probe_matrix_old: Path | None = None,
+    probe_matrix_new: Path | None = None,
 ) -> None:
     """Compare two ABI surfaces and report changes.
 
@@ -1561,10 +1596,13 @@ def compare_cmd(
             err=True,
         )
 
+    extra_changes = _load_probe_matrix_changes(probe_matrix_old, probe_matrix_new)
+
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_public_headers,
         force_public_symbols=force_public,
+        extra_changes=extra_changes,
     )
 
     _finalize_compare_result(

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1270,6 +1270,9 @@ def _finalize_compare_result(
     if show_filtered and result.out_of_surface_changes:
         _echo_filtered_surface(result)
 
+    # The scoping fallback warning goes to stderr so it never corrupts the
+    # machine-readable payload on stdout (which carries scope_resolved /
+    # manual_review_required for programmatic consumers).
     if result.scope_to_public_surface and not result.scope_resolved:
         click.echo(
             "Warning: --scope-public-headers could not resolve the public "

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1243,6 +1243,15 @@ def _finalize_compare_result(
     if show_filtered and result.out_of_surface_changes:
         _echo_filtered_surface(result)
 
+    if result.scope_to_public_surface and not result.scope_resolved:
+        click.echo(
+            "Warning: --scope-public-headers could not resolve the public "
+            "surface (no header-derived public symbols); fell back to the full "
+            "export table. Compatibility is UNCONFIRMED — treat this result as "
+            "manual-review-required, not a clean public surface.",
+            err=True,
+        )
+
     _warn_all_suppressed(result)
     _maybe_emit_annotations(
         result, annotate=annotate, annotate_additions=annotate_additions

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1298,8 +1298,11 @@ def _finalize_compare_result(
 @click.option("--new-version", "new_version", default="new", show_default=True,
               help="Version label for new side (used when input is a .so file).")
 # ── Compare options (unchanged) ──────────────────────────────────────────────
-@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif", "html", "junit"]),
-              default="markdown", show_default=True)
+@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif", "html", "junit", "review"]),
+              default="markdown", show_default=True,
+              help="Output format. 'review' emits a compact GitHub-facing digest "
+                   "(verdict + counts + release recommendation + manual-review banner) "
+                   "suitable for a job summary or PR comment.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
               help="Suppression file (YAML) to filter known/intentional changes.")

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -901,6 +901,7 @@ def _run_compare_pair(
     policy_file_path: Path | None,
     old_pdb_path: Path | None,
     new_pdb_path: Path | None,
+    scope_to_public_surface: bool = False,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Run compare for one old/new pair and return result + resolved snapshots."""
     old_fmt = _detect_binary_format(old_input)
@@ -926,7 +927,10 @@ def _run_compare_pair(
     )
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
-    result = compare(old, new, suppression=suppression, policy=policy, policy_file=pf)
+    result = compare(
+        old, new, suppression=suppression, policy=policy, policy_file=pf,
+        scope_to_public_surface=scope_to_public_surface,
+    )
     result.old_metadata = _collect_metadata(old_input)
     result.new_metadata = _collect_metadata(new_input)
     return result, old, new

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -69,6 +69,7 @@ _CompareReleaseCommonArgs = tuple[
     str, Path | None,
     str, Path | None,
     Path | None,
+    bool,
 ]
 
 
@@ -154,6 +155,7 @@ def _compare_one_library(
     lang: str, suppress: Path | None,
     policy: str, policy_file_path: Path | None,
     output_dir: Path | None,
+    scope_to_public_surface: bool = False,
 ) -> dict[str, object]:
     """Compare one library pair — suitable for parallel dispatch.
 
@@ -177,6 +179,7 @@ def _compare_one_library(
             old_version, new_version,
             lang, suppress, policy, policy_file_path,
             old_pdb_path=old_dbg, new_pdb_path=new_dbg,
+            scope_to_public_surface=scope_to_public_surface,
         )
         v = result.verdict.value
         entry: dict[str, object] = {
@@ -187,6 +190,11 @@ def _compare_one_library(
             "compatible_additions": len(result.compatible),
             "_diff_result": result,
         }
+        if scope_to_public_surface:
+            # Per-library public-surface scoping outcome (ADR-024, issue #235),
+            # aggregated into the release-level scope block by the formatter.
+            entry["scope_resolved"] = result.scope_resolved
+            entry["filtered_internal_count"] = result.out_of_surface_count
         if output_dir:
             lib_report_path = output_dir / f"{old_path.stem}.json"
             _safe_write_output(lib_report_path, to_json(result))
@@ -213,6 +221,7 @@ def _compare_release_libraries(
     annotate: bool = False,
     annotate_additions: bool = False,
     jobs: int = 1,
+    scope_to_public_surface: bool = False,
 ) -> tuple[list[dict[str, object]], str, list[tuple[DiffResult, AbiSnapshot]]]:
     """Compare each matched library pair and collect results.
 
@@ -236,6 +245,7 @@ def _compare_release_libraries(
         old_h, new_h, old_inc, new_inc,
         old_version, new_version,
         lang, suppress, policy, policy_file_path, output_dir,
+        scope_to_public_surface,
     )
 
     if effective_jobs > 1 and len(matched_keys) > 1:
@@ -270,6 +280,7 @@ def _compare_release_libraries(
             annotate_additions=annotate_additions,
             collect_diff_results=collect_diff_results,
             annotate=annotate,
+            scope_to_public_surface=scope_to_public_surface,
         )
         diff_pairs.extend(extra_pairs)
         all_annotations.extend(extra_annotations)
@@ -343,6 +354,7 @@ def _collect_release_extras(
     annotate_additions: bool,
     collect_diff_results: bool,
     annotate: bool,
+    scope_to_public_surface: bool = False,
 ) -> tuple[list[tuple[DiffResult, AbiSnapshot]], list[tuple[int, str]]]:
     """Collect optional re-run artifacts for JUnit and annotations."""
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] = []
@@ -359,6 +371,7 @@ def _collect_release_extras(
                 old_version, new_version,
                 lang, suppress, policy, policy_file_path,
                 old_pdb_path=old_dbg, new_pdb_path=new_dbg,
+                scope_to_public_surface=scope_to_public_surface,
             )
         except Exception as exc:
             click.echo(
@@ -468,15 +481,39 @@ def _format_release_summary(
         )
 
     if fmt == "json":
+        changed_libraries = [
+            str(lib["library"]) for lib in library_results
+            if str(lib.get("verdict")) not in ("NO_CHANGE", "ERROR")
+        ]
         summary: dict[str, object] = {
             "verdict": worst_verdict,
             "old_dir": str(old_dir),
             "new_dir": str(new_dir),
             "libraries": library_results,
+            "changed_libraries": changed_libraries,
             "unmatched_old": [old_map[k].name for k in removed_keys],
             "unmatched_new": [new_map[k].name for k in added_keys],
             "warnings": warning_msgs,
         }
+        # Release-level public-surface scoping rollup (ADR-024, issue #235).
+        # Present only when --scope-public-headers was active (per-library
+        # entries then carry a "scope_resolved" key).
+        scoped_libs = [lib for lib in library_results if "scope_resolved" in lib]
+        if scoped_libs:
+            def _as_int(v: object) -> int:
+                return v if isinstance(v, int) else 0
+            summary["scope"] = {
+                "public_headers_applied": True,
+                "manual_review_required": any(
+                    not bool(lib.get("scope_resolved", True)) for lib in scoped_libs
+                ),
+                "public_additions": sum(
+                    _as_int(lib.get("compatible_additions", 0)) for lib in scoped_libs
+                ),
+                "filtered_internal_changes": sum(
+                    _as_int(lib.get("filtered_internal_count", 0)) for lib in scoped_libs
+                ),
+            }
         if bundle_result is not None:
             summary["bundle_verdict"] = bundle_result.bundle_verdict.value
             summary["bundle_findings"] = [
@@ -817,6 +854,12 @@ def _strip_diff_results_and_adjust_verdict(
                    "Bundle findings catch intra-bundle symbol removals, signature drift "
                    "across DSO boundaries, type drift across siblings, provider "
                    "migration, and manifest mismatches.")
+@click.option("--scope-public-headers", "scope_public_headers", is_flag=True, default=False,
+              help="Restrict each library's findings to its public-header ABI surface "
+                   "(ADR-024): private/internal changes are recorded as filtered, not "
+                   "reported. When a library's public surface cannot be resolved, scoping "
+                   "falls back to the full export table and the release-level scope block "
+                   "flags manual_review_required (issue #235). Requires -H/--header.")
 def compare_release_cmd(
     old_dir: Path,
     new_dir: Path,
@@ -850,6 +893,7 @@ def compare_release_cmd(
     manifest_path: Path | None,
     bundle_system_providers: str,
     no_bundle_analysis: bool,
+    scope_public_headers: bool,
 ) -> None:
     """Compare all libraries in two release directories or packages.
 
@@ -939,6 +983,7 @@ def compare_release_cmd(
             annotate=annotate,
             annotate_additions=annotate_additions,
             jobs=jobs,
+            scope_to_public_surface=scope_public_headers,
         )
 
         bundle_result: BundleDiffResult | None = None

--- a/abicheck/compat/cli.py
+++ b/abicheck/compat/cli.py
@@ -1061,8 +1061,8 @@ def _print_summary_and_exit(
 @click.option("--strict-mode", "strict_mode",
               type=click.Choice(["full", "api"], case_sensitive=False),
               default="full",
-              help="Strict promotion mode: 'full' (COMPATIBLE+API_BREAK→BREAKING, ABICC parity) "
-                   "or 'api' (only API_BREAK→BREAKING, COMPATIBLE stays COMPATIBLE). "
+              help="Strict promotion mode: 'full' (COMPATIBLE+API_BREAK->BREAKING, ABICC parity) "
+                   "or 'api' (only API_BREAK->BREAKING, COMPATIBLE stays COMPATIBLE). "
                    "Only applies when -strict is also set.")
 @click.option("-show-retval", "show_retval", is_flag=True, default=False,
               help="Show return-value changes in report.")
@@ -1255,12 +1255,12 @@ def compat_check_cmd(  # noqa: PLR0913
 
     \b
     Exit codes mirror ABICC:
-      0 — compatible or no change (NO_CHANGE, COMPATIBLE, COMPATIBLE_WITH_RISK)
-          COMPATIBLE_WITH_RISK exits 0 — binary-compatible; risk is surfaced in report only.
+      0 - compatible or no change (NO_CHANGE, COMPATIBLE, COMPATIBLE_WITH_RISK)
+          COMPATIBLE_WITH_RISK exits 0 - binary-compatible; risk is surfaced in report only.
           With -strict, it is promoted to exit 1.
-      1 — breaking ABI change detected (BREAKING)
-      2 — source-level break (API_BREAK)
-      3-11 — classified compat-mode errors (best-effort mapping)
+      1 - breaking ABI change detected (BREAKING)
+      2 - source-level break (API_BREAK)
+      3-11 - classified compat-mode errors (best-effort mapping)
 
     Note: with -strict, API_BREAK is also promoted to exit 1.
 

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -53,6 +53,11 @@ class PipelineContext:
     # findings are forced to stay in-surface under scoping. Widening only ever
     # *keeps* a finding, so it cannot hide a break.
     force_public_symbols: set[str] = field(default_factory=set)
+    # Set True when scoping was requested but the public surface could not be
+    # resolved, so the step fell back to the full export table (keeps every
+    # finding). Consumers surface this as "manual review required" — scoping
+    # must never silently read as confident compatibility (issue #235).
+    scope_fell_back: bool = False
     # Accumulated side-outputs
     opaque_filtered: list[Change] = field(default_factory=list)
     suppressed: list[Change] = field(default_factory=list)
@@ -244,7 +249,10 @@ class FilterNonPublicSurface:
         surf_old = compute_public_surface(ctx.old)
         surf_new = compute_public_surface(ctx.new)
         if not (surf_old.resolvable or surf_new.resolvable):
-            # No header-derived surface to scope against — keep everything.
+            # No header-derived surface to scope against — keep everything and
+            # record the fallback so the verdict is not mistaken for a
+            # confidently-clean public surface (issue #235).
+            ctx.scope_fell_back = True
             return changes
         force_public = ctx.force_public_symbols
         kept: list[Change] = []

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -991,6 +991,89 @@ def _build_severity_sections(
     return lines
 
 
+# Verdict -> short merge-effect phrase for the reviewer digest.
+_VERDICT_MERGE_EFFECT = {
+    Verdict.NO_CHANGE: "no ABI/API change — safe to merge",
+    Verdict.COMPATIBLE: "backward-compatible — safe to merge",
+    Verdict.COMPATIBLE_WITH_RISK: "compatible but carries deployment risk — review advised",
+    Verdict.API_BREAK: "source-level (API) break — consumers must recompile",
+    Verdict.BREAKING: "binary (ABI) break — blocks merge under a strict gate",
+}
+
+
+def to_review_digest(result: DiffResult) -> str:
+    """Compact GitHub-facing review digest (Markdown).
+
+    A single, reviewer-oriented summary suitable for a job summary
+    ($GITHUB_STEP_SUMMARY) or a PR comment body: verdict + merge effect, a
+    counts table that separates breaking / API / risk / public additions /
+    filtered-internal, the release recommendation, a manual-review banner when
+    public-header scoping fell back (issue #235), and the top impacted symbols.
+    Distinct from to_markdown (the full report) — this is the "presentation"
+    layer over the same machine-readable decision contract.
+    """
+    summary = build_summary(result)
+    v = result.verdict
+    emoji = _VERDICT_EMOJI.get(v, "?")
+    label = _VERDICT_LABEL.get(v, v.value)
+    effect = _VERDICT_MERGE_EFFECT.get(v, "")
+
+    lines: list[str] = [
+        f"## ABI review — `{result.library}` {result.old_version} → {result.new_version}",
+        "",
+        f"**Verdict:** {emoji} `{label}` — {effect}",
+        "",
+    ]
+
+    # Manual-review banner: scoping requested but the public surface could not
+    # be confirmed, so compatibility is unconfirmed (don't overclaim).
+    if result.scope_to_public_surface and not result.scope_resolved:
+        lines += [
+            "> ⚠️ **Manual review required.** `--scope-public-headers` could not "
+            "resolve the public surface, so analysis fell back to the full export "
+            "table. Treat this result as *unconfirmed*, not a clean public surface.",
+            "",
+        ]
+
+    scoped = result.scope_to_public_surface
+    additions_label = "Public additions" if scoped else "Additions"
+    lines += [
+        "| Category | Count |",
+        "|---|---|",
+        f"| ❌ Breaking (ABI) | {summary.breaking} |",
+        f"| ⚠️ API breaks (source) | {summary.source_breaks} |",
+        f"| ⚠️ Risk findings | {summary.risk_count} |",
+        f"| ✅ {additions_label} | {summary.compatible_additions} |",
+    ]
+    if scoped:
+        lines.append(f"| 🔒 Filtered (internal/private) | {result.out_of_surface_count} |")
+    lines.append("")
+
+    rec = recommend_release(result)
+    lines += [
+        f"**Release recommendation:** `{rec.bump.value}` version bump · "
+        f"SONAME `{rec.soname.value}`",
+        "",
+    ]
+
+    # Top impacted symbols (breaking + API), capped for readability.
+    breaking_set, api_break_set, _, _ = result._effective_kind_sets()
+    impacted = [
+        c for c in result.changes
+        if c.kind in breaking_set or c.kind in api_break_set
+    ]
+    if impacted:
+        lines += ["**Top impacted symbols:**", ""]
+        for c in impacted[:10]:
+            sym = c.symbol or "?"
+            lines.append(f"- `{sym}` — {c.kind.value}")
+        if len(impacted) > 10:
+            lines.append(f"- … and {len(impacted) - 10} more")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def to_markdown(
     result: DiffResult,
     *,

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -523,6 +523,9 @@ def _to_json_leaf(
     if result.coverage_warnings:
         d["coverage_warnings"] = list(result.coverage_warnings)
     _add_surface_scope(d, result)
+    scope = _scope_dict(result)
+    if scope is not None:
+        d["scope"] = scope
     return json.dumps(d, indent=indent)
 
 
@@ -537,6 +540,35 @@ def _metadata_dict(meta: object | None) -> dict[str, object] | None:
         "path": getattr(meta, "path", ""),
         "sha256": getattr(meta, "sha256", ""),
         "size_bytes": getattr(meta, "size_bytes", 0),
+    }
+
+
+def _scope_dict(result: DiffResult) -> dict[str, object] | None:
+    """Machine-readable public-surface scoping block (ADR-024, issue #235).
+
+    Only emitted when ``--scope-public-headers`` was requested, so default
+    reports are unchanged. Records whether scoping resolved or fell back to the
+    full export table (``manual_review_required``), the public additions count,
+    and the audit ledger of findings filtered as internal/private.
+    """
+    if not result.scope_to_public_surface:
+        return None
+    summary = build_summary(result)
+    return {
+        "public_headers_applied": True,
+        "resolved": result.scope_resolved,
+        "fell_back": not result.scope_resolved,
+        "manual_review_required": not result.scope_resolved,
+        "public_additions": summary.compatible_additions,
+        "filtered_internal_count": result.out_of_surface_count,
+        "filtered_internal_changes": [
+            {
+                "kind": c.kind.value,
+                "symbol": c.symbol,
+                "description": c.description,
+            }
+            for c in result.out_of_surface_changes
+        ],
     }
 
 
@@ -646,6 +678,9 @@ def to_json(
             d["policy_file"] = str(result.policy_file.source_path)
     if show_impact:
         d["show_only_applied"] = show_only is not None
+    scope = _scope_dict(result)
+    if scope is not None:
+        d["scope"] = scope
     return json.dumps(d, indent=indent)
 
 

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -149,7 +149,34 @@
       "type": "object",
       "additionalProperties": { "type": "string" }
     },
-    "policy_file": { "type": "string" }
+    "policy_file": { "type": "string" },
+    "scope": {
+      "type": "object",
+      "description": "Public-header scoping outcome (ADR-024, issue #235). Only present when --scope-public-headers was requested. When 'resolved' is false the public surface could not be determined and analysis fell back to the full export table, so 'manual_review_required' is true and compatibility is UNCONFIRMED.",
+      "required": ["public_headers_applied", "resolved", "fell_back", "manual_review_required"],
+      "additionalProperties": true,
+      "properties": {
+        "public_headers_applied": { "type": "boolean" },
+        "resolved": { "type": "boolean" },
+        "fell_back": { "type": "boolean" },
+        "manual_review_required": { "type": "boolean" },
+        "public_additions": { "type": "integer", "minimum": 0 },
+        "filtered_internal_count": { "type": "integer", "minimum": 0 },
+        "filtered_internal_changes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["kind", "symbol", "description"],
+            "additionalProperties": true,
+            "properties": {
+              "kind": { "type": "string" },
+              "symbol": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
   },
   "$defs": {
     "fileMetadata": {

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -706,7 +706,11 @@ def render_output(
             show_only=show_only, severity_config=severity_config,
         )
 
-    _SUPPORTED_FORMATS = {"json", "sarif", "html", "junit", "markdown", "md"}
+    if fmt == "review":
+        from .reporter import to_review_digest
+        return to_review_digest(result)
+
+    _SUPPORTED_FORMATS = {"json", "sarif", "html", "junit", "markdown", "md", "review"}
     if fmt not in _SUPPORTED_FORMATS:
         raise ValidationError(f"Unsupported output format: {fmt!r} (expected one of {sorted(_SUPPORTED_FORMATS)})")
 

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -20,7 +20,7 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
 
-There are currently **26 scenarios** (17 automated end-to-end + 9 planned).
+There are currently **27 scenarios** (18 automated end-to-end + 9 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -20,7 +20,7 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
 
-There are currently **22 scenarios** (15 automated end-to-end + 7 planned).
+There are currently **25 scenarios** (15 automated end-to-end + 10 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -20,7 +20,7 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
 
-There are currently **25 scenarios** (15 automated end-to-end + 10 planned).
+There are currently **25 scenarios** (16 automated end-to-end + 9 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -20,7 +20,7 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
 
-There are currently **25 scenarios** (16 automated end-to-end + 9 planned).
+There are currently **26 scenarios** (17 automated end-to-end + 9 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/ci_gating.yaml
+++ b/tests/scenarios/ci_gating.yaml
@@ -82,6 +82,27 @@ scenarios:
     automated: true
     test: test_sc_ci_stat
 
+  # G2: fold build-config (probe-matrix) findings into the mainline gate.
+  - id: SC-PROBE-MATRIX-GATE
+    title: Build-config findings (C++ floor) gate via probe matrices in compare
+    persona: CI engineer
+    narrative: >
+      A library's binary surface is unchanged, but a build raises the minimum
+      C++ standard floor (17 → 20) — a source-level break that a per-binary diff
+      cannot see. By passing the probe build-config matrices to compare
+      (--probe-matrix-old/--probe-matrix-new), the CXX_STANDARD_FLOOR_RAISED
+      finding is folded into the same verdict and report, turning a NO_CHANGE
+      binary diff into an API_BREAK gate (exit 2).
+    flow:
+      - abicheck compare old.json new.json --probe-matrix-old old.matrix.json --probe-matrix-new new.matrix.json
+    expected:
+      exit_code: 2
+      verdict: API_BREAK
+      contains_kind: cxx_standard_floor_raised
+    validates: UC-WF-probe-matrix
+    automated: true
+    test: test_sc_probe_matrix_into_compare
+
   # oneDAL-style bundle PR gate: block confirmed public breaks, warn (don't
   # block) when analysis could not confidently confirm the public surface.
   - id: SC-ONEDAL-PR-GATE-STRICT

--- a/tests/scenarios/ci_gating.yaml
+++ b/tests/scenarios/ci_gating.yaml
@@ -81,3 +81,60 @@ scenarios:
     validates: UC-WF-compare
     automated: true
     test: test_sc_ci_stat
+
+  # oneDAL-style bundle PR gate: block confirmed public breaks, warn (don't
+  # block) when analysis could not confidently confirm the public surface.
+  - id: SC-ONEDAL-PR-GATE-STRICT
+    title: Block oneDAL PRs on public ABI/API break, warn on unconfirmed analysis
+    persona: oneDAL maintainer
+    narrative: >
+      A pull request changes oneDAL shared libraries or public headers. CI must
+      stop merges for confirmed public BREAKING or API_BREAK findings, but must
+      only warn (not block) when compatibility cannot be confidently confirmed —
+      the public-surface scope fell back, or the verdict is COMPATIBLE_WITH_RISK.
+      Because exit 0 covers NO_CHANGE / COMPATIBLE / COMPATIBLE_WITH_RISK, the
+      gate inspects the JSON `verdict` field rather than relying on exit codes
+      alone, and uses compare-release so sibling-library relationships in the
+      bundle are analysed.
+    flow:
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format json -o abi.json
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format sarif -o abi.sarif
+    expected:
+      fail_on_verdicts: [BREAKING, API_BREAK]
+      manual_review_required_on:
+        - verdict == COMPATIBLE_WITH_RISK
+        - warnings not empty
+        - public-surface scope fallback occurred
+      require_bundle_analysis: true
+      require_public_surface_scope: true
+    validates: UC-WF-bundle
+    automated: false
+    status: planned
+    plan: docs/development/plans/g2-build-config-and-bundle.md
+
+  # oneDAL-style additive surface tracking: report growth, never gate on it.
+  - id: SC-ONEDAL-PR-ADDITION-TRACKING
+    title: Report oneDAL API/ABI additions without gating the PR
+    persona: oneDAL maintainer
+    narrative: >
+      A pull request legitimately expands oneDAL's surface. CI must not block the
+      merge on additions alone, but it must clearly separate public additions
+      from internal-only growth (using public-header scoping plus the
+      --show-filtered ledger) and communicate the release impact to reviewers via
+      a job summary / PR comment rather than raw JSON.
+    flow:
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --show-filtered --format json -o abi.json
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format html -o abi.html
+    expected:
+      fail_on_verdicts: [BREAKING, API_BREAK]
+      do_not_fail_on: [COMPATIBLE]
+      require_summary_fields:
+        - public_additions
+        - filtered_internal_changes
+        - changed_libraries
+        - release_recommendation
+      github_presentation: [job_summary, pr_comment]
+    validates: UC-WF-bundle
+    automated: false
+    status: planned
+    plan: docs/development/plans/g3-workflow-examples-and-reporting.md

--- a/tests/scenarios/ci_gating.yaml
+++ b/tests/scenarios/ci_gating.yaml
@@ -98,19 +98,28 @@ scenarios:
       bundle are analysed.
     flow:
       - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format json -o abi.json
-      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format sarif -o abi.sarif
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format junit -o abi.xml
     expected:
-      fail_on_verdicts: [BREAKING, API_BREAK]
-      manual_review_required_on:
+      # Block only on CONFIRMED public breaks; when scoping fell back the result
+      # is unconfirmed and must be manual-review-only, never an auto-fail.
+      fail_when:
+        - verdict in [BREAKING, API_BREAK] and scope.manual_review_required == false
+      manual_review_when:
+        - scope.manual_review_required == true   # public surface could not be confirmed
         - verdict == COMPATIBLE_WITH_RISK
-        - warnings not empty
-        - public-surface scope fallback occurred
-      require_bundle_analysis: true
-      require_public_surface_scope: true
+      require_public_surface_scope: true   # scope block present in JSON
+      require_bundle_analysis: true        # bundle_verdict/bundle_findings present
     validates: UC-WF-bundle
     automated: false
     status: planned
     plan: docs/development/plans/g2-build-config-and-bundle.md
+    note: >
+      The scoping rollup (scope.manual_review_required / public_additions /
+      filtered_internal_changes) and changed_libraries that this gate keys off
+      are unit-tested in tests/test_compare_release.py
+      (TestCompareReleaseScopeAndChangedLibraries). Full automation needs a real
+      oneDAL bundle (multiple .so + public headers) so -H scoping is exercised
+      end-to-end rather than via JSON snapshots.
 
   # oneDAL-style additive surface tracking: report growth, never gate on it.
   - id: SC-ONEDAL-PR-ADDITION-TRACKING
@@ -123,18 +132,26 @@ scenarios:
       --show-filtered ledger) and communicate the release impact to reviewers via
       a job summary / PR comment rather than raw JSON.
     flow:
-      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --show-filtered --format json -o abi.json
-      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format html -o abi.html
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --format json -o abi.json
+      - abicheck compare-release baseline/ pr-build/ -H include/ --scope-public-headers --output-dir reports/ --format markdown
     expected:
-      fail_on_verdicts: [BREAKING, API_BREAK]
+      fail_when:
+        - verdict in [BREAKING, API_BREAK]
       do_not_fail_on: [COMPATIBLE]
+      # Real compare-release JSON keys (see _format_release_summary): the scope
+      # rollup separates public growth from internal-only growth.
       require_summary_fields:
-        - public_additions
-        - filtered_internal_changes
         - changed_libraries
-        - release_recommendation
+        - scope.public_additions
+        - scope.filtered_internal_changes
       github_presentation: [job_summary, pr_comment]
     validates: UC-WF-bundle
     automated: false
     status: planned
     plan: docs/development/plans/g3-workflow-examples-and-reporting.md
+    note: >
+      changed_libraries and the scope.public_additions / filtered_internal_changes
+      rollup are emitted today and unit-tested in tests/test_compare_release.py.
+      Per-library release_recommendation is available in the --output-dir reports
+      (single-library JSON). The job_summary / pr_comment digest is the G3
+      review-UX deliverable; full automation needs a real oneDAL bundle.

--- a/tests/scenarios/compliance_scanning.yaml
+++ b/tests/scenarios/compliance_scanning.yaml
@@ -42,25 +42,16 @@ scenarios:
       as confident compatibility). This is the "don't overclaim" companion to
       SC-PUBLIC-SURFACE-SCOPE.
     flow:
-      - abicheck compare old.json new.json --scope-public-headers
+      - abicheck compare old.json new.json --scope-public-headers --format json
       - abicheck compare old.json new.json --scope-public-headers --show-filtered
     expected:
+      exit_code: 4   # fallback keeps the break, so the gate still fires
       scope_resolved: false
-      warnings_not_empty: true
       manual_review_required: true
-      fell_back_to_full_export_table: true
+      warning_on_stderr: true
     validates: UC-WF-compare
-    automated: false
-    status: planned
-    note: >
-      Not automatable through the JSON-snapshot harness: scoping at the
-      `compare` stage resolves the public surface from snapshot reachability
-      alone (which is why SC-PUBLIC-SURFACE-SCOPE runs on JSON), so it never
-      falls back. The fallback path is triggered upstream at dump/parse time
-      with real binaries — castxml unavailable, public headers that do not
-      parse, or PE/MSVC name matching failing (see ADR-024 and the limitations
-      doc). Automating it needs a real fixture exercising one of those failure
-      modes and asserting the emitted warning + full-export-table fallback.
+    automated: true
+    test: test_sc_public_surface_scope_fallback
 
   - id: SC-ACCEPT-KNOWN-BREAK
     title: Accept a known, intentional break via a suppression file

--- a/tests/scenarios/compliance_scanning.yaml
+++ b/tests/scenarios/compliance_scanning.yaml
@@ -28,6 +28,40 @@ scenarios:
     automated: true
     test: test_sc_public_surface_scope
 
+  # The other half of issue #235: scoping is best-effort and can fall back.
+  - id: SC-PUBLIC-SURFACE-SCOPE-FALLBACK
+    title: Public-header scoping falls back and requires manual review
+    persona: Library maintainer
+    issue: 235
+    narrative: >
+      The maintainer asks for public-surface scoping, but the scope cannot be
+      resolved — castxml is unavailable, the public headers do not parse, or
+      PE/MSVC name matching fails. abicheck must NOT silently claim a clean
+      public surface. It warns, falls back to the full export table, and flags
+      that the result needs manual review (so an unconfirmed scope never reads
+      as confident compatibility). This is the "don't overclaim" companion to
+      SC-PUBLIC-SURFACE-SCOPE.
+    flow:
+      - abicheck compare old.json new.json --scope-public-headers
+      - abicheck compare old.json new.json --scope-public-headers --show-filtered
+    expected:
+      scope_resolved: false
+      warnings_not_empty: true
+      manual_review_required: true
+      fell_back_to_full_export_table: true
+    validates: UC-WF-compare
+    automated: false
+    status: planned
+    note: >
+      Not automatable through the JSON-snapshot harness: scoping at the
+      `compare` stage resolves the public surface from snapshot reachability
+      alone (which is why SC-PUBLIC-SURFACE-SCOPE runs on JSON), so it never
+      falls back. The fallback path is triggered upstream at dump/parse time
+      with real binaries — castxml unavailable, public headers that do not
+      parse, or PE/MSVC name matching failing (see ADR-024 and the limitations
+      doc). Automating it needs a real fixture exercising one of those failure
+      modes and asserting the emitted warning + full-export-table fallback.
+
   - id: SC-ACCEPT-KNOWN-BREAK
     title: Accept a known, intentional break via a suppression file
     persona: Library maintainer

--- a/tests/scenarios/reporting.yaml
+++ b/tests/scenarios/reporting.yaml
@@ -51,3 +51,23 @@ scenarios:
     validates: UC-REP-markdown-html
     automated: true
     test: test_sc_scan_html
+
+  - id: SC-REVIEW-DIGEST
+    title: Emit a GitHub review digest for a job summary / PR comment
+    persona: Reviewer / CI engineer
+    narrative: >
+      Instead of making reviewers open raw JSON, CI pipes a compact Markdown
+      digest into the GitHub job summary or a PR comment. The digest leads with
+      the verdict and merge effect, separates breaking / API / risk / additions
+      (and, when scoping is active, filtered internal changes), states the
+      release recommendation, and shows a manual-review banner when public-header
+      scoping could not be confirmed. This is the "presentation" layer over the
+      machine-readable JSON decision contract.
+    flow:
+      - "abicheck compare old.json new.json --format review >> $GITHUB_STEP_SUMMARY"
+    expected:
+      exit_code: 4
+      output_contains: "ABI review"
+    validates: UC-REP-markdown-html
+    automated: true
+    test: test_sc_review_digest

--- a/tests/test_cli_coverage_extra.py
+++ b/tests/test_cli_coverage_extra.py
@@ -159,7 +159,9 @@ class TestStatOutput:
             "compare", str(old), str(new), "--stat", "--format", "json",
         ])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        # Read stdout (not .output) so any stderr warning — e.g. the
+        # public-surface scoping fallback — does not corrupt the JSON payload.
+        data = json.loads(result.stdout)
         assert "verdict" in data
 
     def test_stat_text_output(self, tmp_path: Path) -> None:
@@ -198,7 +200,9 @@ class TestRenderOutputFormats:
             "compare", str(old), str(new), "--format", "sarif",
         ])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        # Read stdout (not .output) so any stderr warning — e.g. the
+        # public-surface scoping fallback — does not corrupt the SARIF payload.
+        data = json.loads(result.stdout)
         assert "$schema" in data
 
     # test_html_output: covered by test_cli_unit.py::TestCompareHtml

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -14,7 +14,14 @@ from abicheck.cli import (
     main,
 )
 from abicheck.cli_compare_release import _extract_if_package
-from abicheck.model import AbiSnapshot, Function, Param, Visibility
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Visibility,
+)
 from abicheck.package import ExtractResult
 from abicheck.serialization import snapshot_to_json
 
@@ -357,6 +364,77 @@ class TestOutputDir:
         summary = json.loads((out_dir / "summary.json").read_text())
         assert summary["verdict"] == "NO_CHANGE"
         assert len(summary["libraries"]) == 1
+
+
+def _rec(name: str, size: int) -> RecordType:
+    return RecordType(name=name, kind="struct", size_bits=size,
+                      fields=[TypeField(name="x", type="int")])
+
+
+class TestCompareReleaseScopeAndChangedLibraries:
+    """compare-release: changed_libraries + public-header scoping rollup (#235)."""
+
+    def test_changed_libraries_lists_only_changed(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        # libfoo breaks; libbar is identical (NO_CHANGE).
+        old_foo, new_foo = _breaking_pair("libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old_foo)
+        _write_snap(new_dir / "libfoo.json", new_foo)
+        _write_snap(old_dir / "libbar.json", _snap(library="libbar.so"))
+        _write_snap(new_dir / "libbar.json", _snap(library="libbar.so"))
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 4
+        data = json.loads(out)
+        assert data["changed_libraries"] == ["libfoo.json"]
+
+    def test_scope_block_resolved_filters_internal(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        # Public api_call(Config*) -> int; InternalCache is private (unreachable).
+        # New side adds a public function and shrinks InternalCache: the private
+        # break is filtered, the public addition is reported.
+        pub_old = Function(name="api_call", mangled="api_call", return_type="int",
+                           params=[Param(name="c", type="Config *")], visibility=Visibility.PUBLIC)
+        pub_new = Function(name="new_api", mangled="new_api", return_type="int",
+                           visibility=Visibility.PUBLIC)
+        old = AbiSnapshot(library="libfoo.so", version="1", functions=[pub_old],
+                          types=[_rec("Config", 32), _rec("InternalCache", 64)])
+        new = AbiSnapshot(library="libfoo.so", version="2", functions=[pub_old, pub_new],
+                          types=[_rec("Config", 32), _rec("InternalCache", 128)])
+        _write_snap(old_dir / "libfoo.json", old)
+        _write_snap(new_dir / "libfoo.json", new)
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir),
+                            "--scope-public-headers", "--format", "json")
+        data = json.loads(out)
+        assert data["scope"]["public_headers_applied"] is True
+        assert data["scope"]["manual_review_required"] is False
+        assert data["scope"]["filtered_internal_changes"] >= 1
+        assert data["scope"]["public_additions"] >= 1
+
+    def test_scope_fallback_flags_manual_review(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        # No public symbols -> surface unresolvable -> fall back to full export
+        # table and flag manual review (issue #235's "don't overclaim" half).
+        old = AbiSnapshot(library="libfoo.so", version="1", functions=[],
+                          types=[_rec("InternalCache", 64)])
+        new = AbiSnapshot(library="libfoo.so", version="2", functions=[],
+                          types=[_rec("InternalCache", 128)])
+        _write_snap(old_dir / "libfoo.json", old)
+        _write_snap(new_dir / "libfoo.json", new)
+        code, out = _invoke("compare-release", str(old_dir), str(new_dir),
+                            "--scope-public-headers", "--format", "json")
+        data = json.loads(out)
+        assert data["scope"]["manual_review_required"] is True
+        # The break is kept (fallback), so the library still shows as changed.
+        assert "libfoo.json" in data["changed_libraries"]
 
 
 # ── version-aware name matching ───────────────────────────────────────────────

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -34,6 +34,17 @@ class TestReviewDigest:
         assert "Public additions" in out
         assert "Filtered (internal/private)" in out
 
+    def test_top_impacted_symbols_truncated(self):
+        changes = [
+            Change(ChangeKind.FUNC_REMOVED, f"sym{i}", f"removed sym{i}")
+            for i in range(13)
+        ]
+        out = to_review_digest(_result(Verdict.BREAKING, changes=changes))
+        # Only the first 10 are listed, with a "… and N more" line.
+        assert "and 3 more" in out
+        assert "`sym0`" in out
+        assert "`sym12`" not in out
+
 
 def _result(verdict: Verdict, changes=None) -> DiffResult:
     return DiffResult(

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -2,7 +2,37 @@
 import json
 
 from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
-from abicheck.reporter import to_json, to_markdown
+from abicheck.reporter import to_json, to_markdown, to_review_digest
+
+
+class TestReviewDigest:
+    def test_breaking_digest_has_verdict_and_recommendation(self):
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "Public function removed: foo")
+        out = to_review_digest(_result(Verdict.BREAKING, changes=[c]))
+        assert "ABI review" in out
+        assert "`BREAKING`" in out
+        assert "Release recommendation:" in out
+        assert "_Z3foov" in out  # top impacted symbol
+
+    def test_manual_review_banner_on_scope_fallback(self):
+        r = _result(Verdict.BREAKING, changes=[
+            Change(ChangeKind.FUNC_REMOVED, "x", "removed"),
+        ])
+        r.scope_to_public_surface = True
+        r.scope_resolved = False
+        out = to_review_digest(r)
+        assert "Manual review required" in out
+        assert "unconfirmed" in out.lower()
+
+    def test_no_banner_when_scope_resolved(self):
+        r = _result(Verdict.COMPATIBLE)
+        r.scope_to_public_surface = True
+        r.scope_resolved = True
+        out = to_review_digest(r)
+        assert "Manual review required" not in out
+        # Scoped reports label additions as public and show the filtered row.
+        assert "Public additions" in out
+        assert "Filtered (internal/private)" in out
 
 
 def _result(verdict: Verdict, changes=None) -> DiffResult:

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -391,6 +391,49 @@ def test_sc_policy_profile(tmp_path: Path) -> None:
     assert _compare(tmp_path, old, new, "--no-scope-public-headers", "--policy", "sdk_vendor").exit_code == 0
 
 
+def test_sc_probe_matrix_into_compare(tmp_path: Path) -> None:
+    # G2: build-config findings (here a raised C++ standard floor) need a
+    # multi-config probe matrix that plain compare does not have. Passing the
+    # matrices folds those findings into the mainline gate: a comparison that is
+    # NO_CHANGE on the binary surface becomes API_BREAK once the matrix raises
+    # the floor 17 -> 20.
+    from abicheck.probe_harness import (
+        MatrixSnapshot,
+        ProbeResult,
+        write_matrix_snapshot,
+    )
+
+    same = [_fn("a")]
+    o = _save(_lib("1", list(same)), tmp_path / "o.json")
+    n = _save(_lib("2", list(same)), tmp_path / "n.json")
+    # Baseline: identical surfaces → NO_CHANGE.
+    assert _cli("compare", o, n).exit_code == 0
+
+    def _matrix(version: str, std: int) -> MatrixSnapshot:
+        return MatrixSnapshot(
+            library="libfoo", version=version, spec_name="t",
+            cxx_stds={"a": std},
+            results=[ProbeResult(
+                configuration_id="a", probe_id="p0",
+                snapshot=_lib(version, list(same)),
+            )],
+        )
+
+    om = str(tmp_path / "om.json")
+    nm = str(tmp_path / "nm.json")
+    write_matrix_snapshot(_matrix("1", 17), om)
+    write_matrix_snapshot(_matrix("2", 20), nm)
+
+    res = _cli(
+        "compare", o, n, "--format", "json",
+        "--probe-matrix-old", om, "--probe-matrix-new", nm,
+    )
+    assert res.exit_code == 2  # API_BREAK from the build-config finding
+    doc = json.loads(res.stdout)
+    assert doc["verdict"] == "API_BREAK"
+    assert any(c["kind"] == "cxx_standard_floor_raised" for c in doc["changes"])
+
+
 def test_sc_review_digest(tmp_path: Path) -> None:
     # The review digest is the GitHub-facing presentation layer: verdict +
     # merge effect, a counts table, and the release recommendation.

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -254,6 +254,27 @@ def test_sc_public_surface_scope(tmp_path: Path) -> None:
     assert "InternalCache" in filtered.output
 
 
+def test_sc_public_surface_scope_fallback(tmp_path: Path) -> None:
+    # The "don't overclaim" half of issue #235. With no Visibility.PUBLIC
+    # symbols the public surface is unresolvable, so --scope-public-headers must
+    # fall back to the full export table rather than silently report a clean
+    # public surface: the private break is KEPT, the JSON records the fallback
+    # as manual-review-required, and a warning is emitted to stderr.
+    old = _lib("1", [], types=[_rec("InternalCache", 64)])
+    new = _lib("2", [], types=[_rec("InternalCache", 128)])
+    res = _compare(tmp_path, old, new, "--scope-public-headers", "--format", "json")
+    assert res.exit_code == 4  # fallback kept the break → still gated
+    doc = json.loads(res.stdout)
+    assert doc["scope"]["resolved"] is False
+    assert doc["scope"]["fell_back"] is True
+    assert doc["scope"]["manual_review_required"] is True
+    # The private change is kept (fallback), never silently dropped.
+    blob = json.dumps(doc["changes"])
+    assert "InternalCache" in blob
+    # Human-facing warning on stderr (machine contract is the scope block above).
+    assert "could not resolve the public surface" in res.stderr
+
+
 def test_sc_scan_sarif(tmp_path: Path) -> None:
     res = _compare(
         tmp_path,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -391,6 +391,26 @@ def test_sc_policy_profile(tmp_path: Path) -> None:
     assert _compare(tmp_path, old, new, "--no-scope-public-headers", "--policy", "sdk_vendor").exit_code == 0
 
 
+def test_sc_review_digest(tmp_path: Path) -> None:
+    # The review digest is the GitHub-facing presentation layer: verdict +
+    # merge effect, a counts table, and the release recommendation.
+    res = _compare(
+        tmp_path,
+        _lib("1", [_fn("a"), _fn("b")]),
+        _lib("2", [_fn("a")]),
+        "--format",
+        "review",
+    )
+    assert res.exit_code == 4
+    out = res.output
+    assert "ABI review" in out
+    assert "`BREAKING`" in out
+    assert "Release recommendation:" in out
+    assert "| Category | Count |" in out
+    # The removed symbol is surfaced as a top impacted symbol.
+    assert "func_removed" in out
+
+
 def test_sc_scan_junit(tmp_path: Path) -> None:
     res = _compare(
         tmp_path,


### PR DESCRIPTION
## What

Started as three scenario-catalog entries; grown into the **implementation** the oneDAL/issue-#235 analysis actually calls for — the "communication contract" (public-surface truth, bundle gating, reviewer presentation) rather than new detectors. Five commits:

### 1. `scope_resolved` + fallback warning (issue #235, second half)
`--scope-public-headers` now reports when it **cannot** resolve the public surface instead of silently reading clean. `compare()` derives `scope_resolved`; JSON gains a `scope` block (`resolved` / `fell_back` / `manual_review_required` / `public_additions` / `filtered_internal_changes` ledger, documented in `compare_report.schema.json`); the CLI emits a stderr warning on fallback. Flips `SC-PUBLIC-SURFACE-SCOPE-FALLBACK` from planned → **automated**.

### 2. `compare-release` public-header scoping + bundle rollup
New `--scope-public-headers` on `compare-release` (plumbed to per-library `compare()`). JSON gains `changed_libraries` and a release-level `scope` rollup (`manual_review_required`, `public_additions`, `filtered_internal_changes`). The two oneDAL scenarios are corrected to use **only supported flags**, express **fail-vs-manual-review** correctly, and reference the **real** JSON keys (resolves the Codex review on this PR).

### 3. `--format review` — GitHub review digest
A compact Markdown digest (verdict + merge effect, counts table, release recommendation, manual-review banner, top impacted symbols) for `$GITHUB_STEP_SUMMARY` or a PR comment body — the "presentation" layer over the JSON decision contract. New automated `SC-REVIEW-DIGEST`.

### 4. probe → compare (G2)
Build-config findings (`CXX_STANDARD_FLOOR_RAISED`, `API_DEPENDS_ON_CONSUMER_ENV`, `BEHAVIOURAL_DEFAULT_CHANGED`) need multi-config matrices `compare` doesn't have. New `--probe-matrix-old/--probe-matrix-new` load the matrices and fold `diff_matrix()` findings into the same verdict/report. A `NO_CHANGE` binary diff becomes `API_BREAK` when the C++ floor rises 17→20. New automated `SC-PROBE-MATRIX-GATE`.

### 0. Scenario catalog (original ask)
The 3 workflow-truth scenarios (issue-235 fallback + two oneDAL PR-gate scenarios); fixed the invented `g9`/`g10` plan paths. Catalog now **27 scenarios (18 automated + 9 planned)**.

## Validation
- Full fast suite: **6799 passed** (0 failures)
- `ruff check`, `mypy abicheck/`: clean
- `scripts/check_ai_readiness.py`: **0 errors** (2 pre-existing `cli.py`/`compat/cli.py` size warnings)
- New JSON fields are additive (`additionalProperties: true`), non-breaking.

## Notes
- `compare-release` matrix-per-library wiring and a SARIF bundle format remain out of scope (tracked under G2/G3); the oneDAL scenarios stay `planned` because they need a real multi-`.so` + headers bundle to exercise `-H` scoping end-to-end (their mechanics are unit-tested in `tests/test_compare_release.py`).

https://claude.ai/code/session_01PuQCdziG7pHuTWVEDQTVqH