### PR TITLE
fix: isolate release benchmark upload permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,15 +54,17 @@ jobs:
 
   benchmark:
     name: Release-pinned benchmark
-    # Run only for real releases; attaches a reproducible benchmark report
-    # (versions, git commit, ground-truth digest, per-tool accuracy) to the
-    # GitHub Release so the README accuracy numbers are auditable evidence.
+    # Run only for real releases; generates a reproducible benchmark report
+    # (versions, git commit, ground-truth digest, per-tool accuracy) as a
+    # read-only artifact so the README accuracy numbers are auditable evidence.
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # upload release asset
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install system deps (oracles + toolchain)
         run: |
@@ -90,8 +92,23 @@ jobs:
           path: benchmark_reports/benchmark_report.json
           retention-days: 90
 
+
+  upload-benchmark-report:
+    name: Attach benchmark report to release
+    needs: benchmark
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download benchmark report
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-report
+          path: benchmark_reports/
+
       - name: Attach benchmark report to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: benchmark_reports/benchmark_report.json
 


### PR DESCRIPTION
### Motivation

- Prevent a write-scoped repository token from being persisted and accessible to untrusted code executed during the release benchmark job. 
- Preserve the ability to generate and attach a reproducible benchmark report while reducing blast radius if a dev dependency or invoked tool is compromised.

### Description

- Change the `benchmark` job `permissions` to `contents: read` so report generation runs with read-only repository access. 
- Disable credential persistence on checkout in the `benchmark` job by setting `actions/checkout` `with: persist-credentials: false`. 
- Move the release-attachment step into a separate `upload-benchmark-report` job that `needs: benchmark`, grants only `contents: write`, downloads the artifact, and attaches it to the release. 
- Pin the release upload action to a specific commit SHA (`softprops/action-gh-release@3bb12739...`) instead of an unpinned branch to reduce supply-chain risk.

### Testing

- Validated the workflow YAML parses successfully with `yaml.safe_load` (no syntax errors). 
- Ran `python -m pytest tests/test_benchmark_smoke.py` which completed with all tests passing. 
- Ran `actionlint` against `.github/workflows/publish.yml` (installed via `go install`) and observed no actionlint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5a466cf8832b8339016c62492556)