### PR TITLE
fix(surface): classify type-level findings before symbol-name collisions

### DIFF
--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -65,6 +65,46 @@ _NEVER_FILTER_KIND_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# Findings whose ``symbol`` field identifies a type (or a member under a type)
+# rather than a function/variable symbol. These must be classified through
+# type reachability before consulting the symbol universe: in C++ especially,
+# a public type name can collide with a hidden constructor/destructor or helper
+# symbol of the same spelling.
+_TYPE_LEVEL_KIND_NAMES: frozenset[str] = frozenset(
+    {
+        "type_size_changed",
+        "type_alignment_changed",
+        "type_field_removed",
+        "type_field_added",
+        "type_field_offset_changed",
+        "type_field_type_changed",
+        "type_base_changed",
+        "type_vtable_changed",
+        "type_added",
+        "type_removed",
+        "type_field_added_compatible",
+        "enum_member_removed",
+        "enum_member_added",
+        "enum_member_value_changed",
+        "enum_last_member_value_changed",
+        "typedef_removed",
+        "typedef_base_changed",
+        "field_bitfield_changed",
+        "union_field_added",
+        "union_field_removed",
+        "union_field_type_changed",
+        "struct_size_changed",
+        "struct_field_offset_changed",
+        "struct_field_removed",
+        "struct_field_type_changed",
+        "struct_alignment_changed",
+        "enum_underlying_size_changed",
+        "struct_packing_changed",
+        "type_visibility_changed",
+        "value_abi_trait_changed",
+    }
+)
+
 # Tokens that are type qualifiers / keywords, not type names.
 _TYPE_NOISE: frozenset[str] = frozenset(
     {
@@ -456,24 +496,32 @@ def classify_change_surface(
     all_types = surf_old.all_types | surf_new.all_types
 
     sym = change.symbol or ""
+    candidates = _type_identifiers(sym) | _type_identifiers(change.caused_by_type)
+
+    # Type-level findings must not be classified via the symbol universe first:
+    # a public type such as ``Foo`` can legitimately collide with a hidden
+    # constructor/destructor/helper symbol named ``Foo``. In that case the
+    # layout change's ``symbol`` still denotes the type, so reachability decides.
+    type_level_finding = change.kind.value in _TYPE_LEVEL_KIND_NAMES
+
     # Symbol-level finding (function/variable): public iff a public symbol.
     # A confident private/system-header origin demotes even an exported
     # symbol — that is exactly the leaked-private-header case scoping targets.
-    if sym in all_symbols:
-        reason = _origin_reason(surf_old, surf_new, sym)
-        if reason is not None:
-            return False, reason
-        return (True, None) if sym in public_symbols else (False, REASON_NOT_EXPORTED)
-    if sym and "::" in sym and sym.rsplit("::", 1)[1] in all_symbols:
-        tail = sym.rsplit("::", 1)[1]
-        reason = _origin_reason(surf_old, surf_new, tail)
-        if reason is not None:
-            return False, reason
-        return (True, None) if tail in public_symbols else (False, REASON_NOT_EXPORTED)
+    if not type_level_finding:
+        if sym in all_symbols:
+            reason = _origin_reason(surf_old, surf_new, sym)
+            if reason is not None:
+                return False, reason
+            return (True, None) if sym in public_symbols else (False, REASON_NOT_EXPORTED)
+        if sym and "::" in sym and sym.rsplit("::", 1)[1] in all_symbols:
+            tail = sym.rsplit("::", 1)[1]
+            reason = _origin_reason(surf_old, surf_new, tail)
+            if reason is not None:
+                return False, reason
+            return (True, None) if tail in public_symbols else (False, REASON_NOT_EXPORTED)
 
     # Type-level finding: check the implicated type name(s). A finding is
     # in-surface if *any* implicated type is reachable from the public API.
-    candidates = _type_identifiers(sym) | _type_identifiers(change.caused_by_type)
 
     # Anti-hiding (ADR-024 §D5.2): never filter a change to an
     # internal-namespace type (``detail::``, ``impl::``, …). The internal-leak

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -165,6 +165,51 @@ class TestChangeClassification:
         )
         assert change_in_public_surface(c, s, s) is False
 
+    def test_private_qualified_symbol_tail_match_is_out_of_surface(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[_fn("api"), _fn("internal", vis=Visibility.ELF_ONLY)],
+        )
+        s = self._surf(snap)
+        c = Change(
+            kind=ChangeKind.FUNC_RETURN_CHANGED,
+            symbol="ns::internal",
+            description="",
+        )
+        assert change_in_public_surface(c, s, s) is False
+
+    def test_private_header_qualified_symbol_tail_reports_origin_reason(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[
+                _fn("api"),
+                _fn(
+                    "internal",
+                    vis=Visibility.PUBLIC,
+                    origin=ScopeOrigin.PRIVATE_HEADER,
+                ),
+            ],
+        )
+        s = self._surf(snap)
+        c = Change(
+            kind=ChangeKind.FUNC_RETURN_CHANGED,
+            symbol="ns::internal",
+            description="",
+        )
+        assert classify_change_surface(c, s, s) == (False, REASON_PRIVATE_HEADER)
+
+    def test_unknown_symbol_change_is_kept_conservatively(self):
+        snap = AbiSnapshot(library="l", version="1", functions=[_fn("api")])
+        s = self._surf(snap)
+        c = Change(
+            kind=ChangeKind.FUNC_RETURN_CHANGED,
+            symbol="missing_symbol",
+            description="",
+        )
+        assert change_in_public_surface(c, s, s) is True
+
     def test_private_type_change_is_out_of_surface(self):
         snap = AbiSnapshot(
             library="l",
@@ -187,6 +232,25 @@ class TestChangeClassification:
         )
         s = self._surf(snap)
         c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Result", description="")
+        assert change_in_public_surface(c, s, s) is True
+
+    def test_public_type_change_with_private_symbol_name_collision_is_in_surface(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[
+                _fn("api", ret="Foo *"),
+                _fn("Foo", vis=Visibility.HIDDEN, mangled="_ZL3Foov"),
+            ],
+            types=[_rec("Foo")],
+        )
+        s = self._surf(snap)
+        assert "Foo" in s.public_types
+        assert "Foo" in s.all_symbols
+        assert "Foo" not in s.public_symbols
+
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Foo", description="")
+
         assert change_in_public_surface(c, s, s) is True
 
     def test_leak_kind_never_filtered(self):
@@ -349,6 +413,40 @@ class TestScopedCompareNoFalsePositives:
         assert any("Result" in c.symbol for c in scoped.changes)
         assert scoped.verdict in (Verdict.BREAKING, Verdict.API_BREAK)
 
+    def test_public_struct_layout_change_with_private_symbol_collision_still_reported(
+        self,
+    ):
+        old = AbiSnapshot(
+            library="lib",
+            version="1",
+            functions=[
+                _fn("get_foo", ret="Foo *"),
+                _fn("Foo", vis=Visibility.HIDDEN, mangled="_ZL3Foov"),
+            ],
+            types=[_rec("Foo", size=64)],
+        )
+        new = AbiSnapshot(
+            library="lib",
+            version="2",
+            functions=[
+                _fn("get_foo", ret="Foo *"),
+                _fn("Foo", vis=Visibility.HIDDEN, mangled="_ZL3Foov"),
+            ],
+            types=[_rec("Foo", size=128)],
+        )
+
+        scoped = compare(old, new, scope_to_public_surface=True)
+
+        assert any(
+            c.kind == ChangeKind.TYPE_SIZE_CHANGED and c.symbol == "Foo"
+            for c in scoped.changes
+        )
+        assert not any(
+            c.kind == ChangeKind.TYPE_SIZE_CHANGED and c.symbol == "Foo"
+            for c in scoped.out_of_surface_changes
+        )
+        assert scoped.verdict in (Verdict.BREAKING, Verdict.API_BREAK)
+
     def test_scoping_on_by_default(self):
         # ADR-024 Phase 5: header-scoping is the default. An internal-only
         # layout change is demoted to the ledger out of the box; passing
@@ -382,7 +480,8 @@ class TestScopedCompareNoFalsePositives:
         # be filtered before DetectInternalLeaks runs, hiding the leak.
         def _mk(impl_size):
             return AbiSnapshot(
-                library="lib", version="x",
+                library="lib",
+                version="x",
                 # A public symbol so the surface is resolvable, but it does NOT
                 # reference Widget — so Widget/detail::Impl are unreachable here.
                 functions=[_fn("public_unrelated")],
@@ -395,9 +494,9 @@ class TestScopedCompareNoFalsePositives:
         old, new = _mk(64), _mk(128)
         scoped = compare(old, new, scope_to_public_surface=True)
         kinds = {c.kind for c in scoped.changes}
-        assert ChangeKind.INTERNAL_TYPE_LEAKS_VIA_PUBLIC_API in kinds, (
-            f"leak hidden by scoping; got kinds={[k.value for k in kinds]}"
-        )
+        assert (
+            ChangeKind.INTERNAL_TYPE_LEAKS_VIA_PUBLIC_API in kinds
+        ), f"leak hidden by scoping; got kinds={[k.value for k in kinds]}"
         # The internal type's change must not have been silently filtered.
         assert not any(
             "detail::Impl" in c.symbol for c in scoped.out_of_surface_changes


### PR DESCRIPTION
### Motivation
- Public-surface scoping could hide real public type layout breaks when a non-public function/variable shared the same name as a public type, so type-level findings must be classified by type reachability before consulting the symbol universe.

### Description
- Add `_TYPE_LEVEL_KIND_NAMES` as an explicit frozenset of change-kind values that identify type-level findings so they are handled specially.
- In `change_in_public_surface` compute `candidates` and detect `type_level_finding = change.kind.value in _TYPE_LEVEL_KIND_NAMES`, and only apply the symbol-level shortcut for non-type-level findings so hidden symbol name collisions cannot override type reachability.
- Preserve existing symbol-level classification for function/variable findings while ensuring type/layout changes use `public_types`/`all_types` reachability to decide inclusion.
- Add two regression tests in `tests/test_surface.py`: `test_public_type_change_with_private_symbol_name_collision_is_in_surface` and `test_public_struct_layout_change_with_private_symbol_collision_still_reported` to cover the collision scenario.

### Testing
- Ran `pytest -q tests/test_surface.py` and the targeted surface tests passed (`26 passed`).
- Ran `python -m compileall -q abicheck/surface.py tests/test_surface.py` successfully to validate syntax.
- Attempted full `pytest -q` but collection failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'hypothesis'`), so the whole test matrix was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b52c29e38832b8ab2d3d47d4f8729)