### PR TITLE
feat(surface): close ADR-024 tails — PDB provenance, ledger reasons, scope confidence

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -260,6 +260,12 @@ def compare(
         detector_results, old, new,
     )
 
+    # ADR-024 §D5.3: structured confidence in the surface resolution itself.
+    from .surface import surface_scope_confidence
+    scope_confidence, scope_notes = surface_scope_confidence(
+        old, new, scope_enabled=scope_to_public_surface,
+    )
+
     return DiffResult(
         old_version=old.version,
         new_version=new.version,
@@ -282,5 +288,7 @@ def compare(
         out_of_surface_count=len(out_of_surface),
         scope_to_public_surface=scope_to_public_surface,
         scope_resolved=scope_resolved,
+        surface_scope_confidence=scope_confidence,
+        surface_scope_notes=scope_notes,
         evidence_tier=evidence_tier,
     )

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -261,9 +261,12 @@ def compare(
     )
 
     # ADR-024 §D5.3: structured confidence in the surface resolution itself.
+    # Reuse the surfaces FilterNonPublicSurface already computed (when scoping
+    # ran) to avoid repeating the type-closure walk.
     from .surface import surface_scope_confidence
     scope_confidence, scope_notes = surface_scope_confidence(
         old, new, scope_enabled=scope_to_public_surface,
+        surf_old=pp_ctx.surf_old, surf_new=pp_ctx.surf_new,
     )
 
     return DiffResult(

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -123,6 +123,14 @@ class DiffResult:
     # needs manual review — it must never read as a confidently-clean public
     # surface (issue #235).
     scope_resolved: bool = True
+    # ADR-024 §D5.3 — structured confidence in the surface resolution itself
+    # (distinct from ``confidence`` above, which is the overall verdict trust).
+    # "high" with no notes = clean header-scoped run; "reduced" with one or more
+    # structured note codes (e.g. "mangling-fallback", "no-provenance") when the
+    # surface had to be resolved less reliably. Disclosed in the JSON/SARIF
+    # surface ledger so the "demote + disclose" promise stays auditable.
+    surface_scope_confidence: str = "high"
+    surface_scope_notes: list[str] = field(default_factory=list)
     # Canonical analysis depth (ordered): ELF_ONLY < DWARF_AWARE < HEADER_AWARE.
     # Distinct from the raw ``evidence_tiers`` list above — this is the single
     # scalar consumers should key trust decisions off of. See EvidenceTier.

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -209,6 +209,21 @@ def _dump_elf(
         raise click.ClickException(f"Failed to dump '{path}': {exc}") from exc
 
 
+def _apply_native_provenance(
+    snap: AbiSnapshot,
+    public_headers: list[Path] | None,
+    public_header_dirs: list[Path] | None,
+) -> AbiSnapshot:
+    """Tag declaration provenance on a PE/Mach-O snapshot (ADR-024 Phase 1).
+
+    Mirrors the ELF path (``dumper.create_snapshot``), which always runs
+    ``apply_provenance``. A no-op when no public-header set is supplied —
+    every origin stays ``UNKNOWN`` and behaviour is unchanged.
+    """
+    from .provenance import apply_provenance
+    return apply_provenance(snap, public_headers, public_header_dirs)
+
+
 def _dump_native_binary(
     path: Path, binary_fmt: str,
     headers: list[Path], includes: list[Path],
@@ -217,6 +232,8 @@ def _dump_native_binary(
     pdb_path: Path | None = None,
     dwarf_only: bool = False,
     debug_format: str | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Dump ABI snapshot from a native binary (ELF, PE, or Mach-O).
 
@@ -225,6 +242,10 @@ def _dump_native_binary(
     For PE/Mach-O, headers are optional: when supplied they scope the ABI
     surface to declarations in those public headers (best-effort, via castxml),
     otherwise the export table provides the symbol surface.
+
+    ``public_headers`` / ``public_header_dirs`` classify declaration provenance
+    (ADR-024 Phase 1). For PE they also let the PDB-derived types carry a
+    ``ScopeOrigin``; an empty set keeps every origin ``UNKNOWN`` (no-op).
     """
     if binary_fmt == "elf":
         return _dump_elf(path, headers, includes, version, lang,
@@ -233,23 +254,25 @@ def _dump_native_binary(
     if binary_fmt == "pe":
         from .service import _dump_pe
         try:
-            return _dump_pe(
+            snap = _dump_pe(
                 path, version,
                 headers=headers, includes=includes, lang=lang,
                 pdb_path=pdb_path,
             )
         except AbicheckError as exc:
             raise click.ClickException(str(exc)) from exc
+        return _apply_native_provenance(snap, public_headers, public_header_dirs)
 
     if binary_fmt == "macho":
         from .service import _dump_macho
         try:
-            return _dump_macho(
+            snap = _dump_macho(
                 path, version,
                 headers=headers, includes=includes, lang=lang,
             )
         except AbicheckError as exc:
             raise click.ClickException(str(exc)) from exc
+        return _apply_native_provenance(snap, public_headers, public_header_dirs)
 
     fmt_labels = {"elf": "ELF", "pe": "PE (Windows DLL)", "macho": "Mach-O (macOS dylib)"}
     raise click.ClickException(f"Unsupported binary format: {fmt_labels.get(binary_fmt, binary_fmt)}")
@@ -545,11 +568,6 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             f"--{debug_format} is only supported for ELF binaries, not {binary_fmt.upper()}."
         )
     if binary_fmt in ("pe", "macho"):
-        if public_headers or public_header_dirs:
-            raise click.BadParameter(
-                "--public-header / --public-header-dir provenance classification is "
-                f"currently only supported for ELF inputs, not {binary_fmt.upper()}."
-            )
         _handle_non_elf_dump(
             so_path,
             binary_fmt,
@@ -563,6 +581,8 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             build_id,
             no_git,
             output,
+            public_headers,
+            public_header_dirs,
         )
         return
 
@@ -622,6 +642,8 @@ def _handle_non_elf_dump(
     build_id: str | None,
     no_git: bool,
     output: Path | None,
+    public_headers: tuple[Path, ...] = (),
+    public_header_dirs: tuple[Path, ...] = (),
 ) -> None:
     """Handle PE/Mach-O native dump path and output writing."""
     if follow_deps:
@@ -630,6 +652,8 @@ def _handle_non_elf_dump(
         snap = _dump_native_binary(
             so_path, binary_fmt, list(headers), list(includes), version, lang,
             pdb_path=pdb_path,
+            public_headers=list(public_headers),
+            public_header_dirs=list(public_header_dirs),
         )
     except click.ClickException:
         raise

--- a/abicheck/dwarf_metadata.py
+++ b/abicheck/dwarf_metadata.py
@@ -93,6 +93,11 @@ class StructLayout:
     alignment: int = 0                      # DW_AT_alignment (DWARF 5; 0 = unknown)
     fields: list[FieldInfo] = field(default_factory=list)
     is_union: bool = False
+    # Defining source header, when the debug info records it. DWARF leaves this
+    # None (decl-file is resolved on the DIE path); the PDB pipeline fills it
+    # from LF_UDT_SRC_LINE / LF_UDT_MOD_SRC_LINE so provenance (ADR-024 Phase 1)
+    # works for Windows binaries.
+    decl_file: str | None = None
 
 
 @dataclass
@@ -101,6 +106,8 @@ class EnumInfo:
     name: str
     underlying_byte_size: int               # sizeof underlying integer type
     members: dict[str, int] = field(default_factory=dict)  # name → value
+    # Defining source header — see StructLayout.decl_file (ADR-024 Phase 1).
+    decl_file: str | None = None
 
 
 @dataclass

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -318,6 +318,18 @@ class AbiSnapshot:
     # Populated by detect_profile() in pipeline or by the dumper.
     language_profile: str | None = None  # "c" | "cpp" | "sycl" | None
 
+    # ADR-024 §D5.3 — structured confidence signal for header-scope resolution.
+    # Set by the dumper when public-header scoping was *requested* but could not
+    # be applied as intended, so the surface had to fall back to the export
+    # table. The previously bare ``UserWarning`` (PR #259) is retained for human
+    # output; this field makes the same fact machine-readable so the surface
+    # ledger can disclose reduced confidence. None = scoping succeeded or was
+    # never requested. Recognised values:
+    #   "castxml-unavailable" — castxml missing / header parse failed
+    #   "mangling-fallback"   — headers parsed but no declared symbol matched the
+    #                            export table (typically MSVC C++ name mangling)
+    scope_fallback: str | None = None
+
     # Full-stack dependency info (populated by --follow-deps)
     dependency_info: DependencyInfo | None = field(default=None)
 

--- a/abicheck/pdb_metadata.py
+++ b/abicheck/pdb_metadata.py
@@ -115,13 +115,17 @@ def parse_pdb_debug_info(
     meta = DwarfMetadata(has_dwarf=True)
     adv = AdvancedDwarfMetadata(has_dwarf=True)
 
+    # UDT name → defining source file (ADR-024 Phase 1 provenance), parsed from
+    # the IPI stream. Empty when the PDB carries no IPI / source-line records.
+    src_files = pdb.udt_source_files
+
     try:
-        _extract_struct_layouts(pdb.types, meta, adv)
+        _extract_struct_layouts(pdb.types, meta, adv, src_files)
     except Exception as exc:  # noqa: BLE001
         log.warning("parse_pdb_debug_info: struct extraction failed: %s", exc)
 
     try:
-        _extract_enums(pdb.types, meta)
+        _extract_enums(pdb.types, meta, src_files)
     except Exception as exc:  # noqa: BLE001
         log.warning("parse_pdb_debug_info: enum extraction failed: %s", exc)
 
@@ -141,6 +145,7 @@ def _extract_struct_layouts(
     types: TypeDatabase,
     meta: DwarfMetadata,
     adv: AdvancedDwarfMetadata | None = None,
+    src_files: dict[str, str] | None = None,
 ) -> None:
     """Extract struct/class/union layouts from TPI into DwarfMetadata.structs.
 
@@ -178,6 +183,7 @@ def _extract_struct_layouts(
             alignment=0,  # PDB doesn't store explicit alignment
             fields=fields,
             is_union=cv_struct.is_union,
+            decl_file=(src_files or {}).get(cv_struct.name),
         )
 
         meta.structs[cv_struct.name] = layout
@@ -227,7 +233,11 @@ def _extract_fields(types: TypeDatabase, cv_struct: CvStruct) -> list[FieldInfo]
 # Phase 2: Enum types
 # ---------------------------------------------------------------------------
 
-def _extract_enums(types: TypeDatabase, meta: DwarfMetadata) -> None:
+def _extract_enums(
+    types: TypeDatabase,
+    meta: DwarfMetadata,
+    src_files: dict[str, str] | None = None,
+) -> None:
     """Extract enum types from TPI into DwarfMetadata.enums."""
     for ti, cv_enum in types.all_enums().items():
         if not _is_user_visible(cv_enum.name, cv_enum.is_forward_ref):
@@ -245,6 +255,7 @@ def _extract_enums(types: TypeDatabase, meta: DwarfMetadata) -> None:
             name=cv_enum.name,
             underlying_byte_size=underlying_size,
             members=members,
+            decl_file=(src_files or {}).get(cv_enum.name),
         )
 
         if cv_enum.name not in meta.enums:

--- a/abicheck/pdb_model.py
+++ b/abicheck/pdb_model.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge PDB-derived :class:`DwarfMetadata` layouts into model types.
+
+On the ELF path, model :class:`~abicheck.model.RecordType` / ``EnumType``
+objects are built directly from DWARF DIEs (``dwarf_snapshot.py``), which
+already resolve a ``decl_file``.  The PE/PDB path has no such builder — PDB
+layout detail lives in a parallel :class:`DwarfMetadata` consumed by the
+layout detectors — so declared types never reach the model, and therefore
+never reach public-surface resolution (``surface.py``).
+
+This module converts those PDB layouts into model types, carrying the
+``decl_file`` recorded by ``pdb_metadata`` (from ``LF_UDT_SRC_LINE`` /
+``LF_UDT_MOD_SRC_LINE``) onto ``source_location`` so that
+``apply_provenance`` can classify their ``ScopeOrigin`` (ADR-024 Phase 1).
+
+It is intentionally narrow: the dumper only calls it on the PE
+header-scoping *fallback* branch (headers requested, castxml could not
+resolve a surface — the MSVC C++-mangling gap), keeping default PE diffs
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .model import EnumMember, EnumType, RecordType, TypeField
+
+if TYPE_CHECKING:
+    from .dwarf_metadata import DwarfMetadata
+
+# Map an enum's underlying integer byte size to a representative type name,
+# matching the model's default of ``"int"`` when the size is unknown/atypical.
+_ENUM_UNDERLYING_BY_SIZE: dict[int, str] = {
+    1: "char",
+    2: "short",
+    4: "int",
+    8: "long long",
+}
+
+
+def _record_from_layout(name: str, layout: object) -> RecordType:
+    byte_size = getattr(layout, "byte_size", 0) or 0
+    is_union = bool(getattr(layout, "is_union", False))
+    alignment = getattr(layout, "alignment", 0) or 0
+    fields: list[TypeField] = []
+    for fi in getattr(layout, "fields", []) or []:
+        bit_size = getattr(fi, "bit_size", 0) or 0
+        offset_bits = (getattr(fi, "byte_offset", 0) or 0) * 8 + (
+            getattr(fi, "bit_offset", 0) or 0
+        )
+        fields.append(
+            TypeField(
+                name=fi.name,
+                type=fi.type_name,
+                offset_bits=offset_bits,
+                is_bitfield=bit_size > 0,
+                bitfield_bits=bit_size if bit_size > 0 else None,
+            )
+        )
+    return RecordType(
+        name=name,
+        kind="union" if is_union else "struct",
+        size_bits=byte_size * 8 if byte_size else None,
+        alignment_bits=alignment * 8 if alignment else None,
+        fields=fields,
+        is_union=is_union,
+        source_location=getattr(layout, "decl_file", None),
+    )
+
+
+def _enum_from_info(name: str, info: object) -> EnumType:
+    size = getattr(info, "underlying_byte_size", 0) or 0
+    members = [
+        EnumMember(name=mname, value=mval)
+        for mname, mval in (getattr(info, "members", {}) or {}).items()
+    ]
+    return EnumType(
+        name=name,
+        members=members,
+        underlying_type=_ENUM_UNDERLYING_BY_SIZE.get(size, "int"),
+        source_location=getattr(info, "decl_file", None),
+    )
+
+
+def model_types_from_dwarf_metadata(
+    meta: DwarfMetadata | None,
+) -> tuple[list[RecordType], list[EnumType]]:
+    """Convert PDB/DWARF layout metadata into model record/enum types.
+
+    Returns ``([], [])`` when *meta* is empty.  ``source_location`` is set to
+    each layout's ``decl_file`` (``None`` when the debug info did not record
+    one), so downstream :func:`apply_provenance` can tag a ``ScopeOrigin``.
+    Iteration order follows the source dict insertion order for determinism.
+    """
+    if meta is None or not getattr(meta, "has_dwarf", False):
+        return [], []
+    records = [_record_from_layout(name, layout) for name, layout in meta.structs.items()]
+    enums = [_enum_from_info(name, info) for name, info in meta.enums.items()]
+    return records, enums

--- a/abicheck/pdb_parser.py
+++ b/abicheck/pdb_parser.py
@@ -85,6 +85,11 @@ LF_VBCLASS = 0x1401
 LF_IVBCLASS = 0x1402
 LF_METHOD = 0x150F
 
+# IPI (stream 4) "id" leaf records — carry source-file provenance for UDTs.
+LF_STRING_ID = 0x1605        # { substr_list_id: u32, name: char[] }
+LF_UDT_SRC_LINE = 0x1606     # { udt_ti: u32, src_string_id: u32, line: u32 }
+LF_UDT_MOD_SRC_LINE = 0x1607  # { udt_ti: u32, src_string_id: u32, line: u32, mod: u16 }
+
 # Numeric leaf constants
 LF_NUMERIC = 0x8000
 LF_CHAR = 0x8000
@@ -405,6 +410,56 @@ def parse_tpi_stream(data: bytes) -> TpiStream:
         type_index_end=ti_end,
         records=records,
     )
+
+
+def _read_id_string(data: bytes, off: int) -> str:
+    """Read a NUL-terminated UTF-8 string from *data* at *off* (best effort).
+
+    Unlike :func:`_read_cstring` this returns only the decoded string (the IPI
+    ``LF_STRING_ID`` payload ends with the name, so no trailing offset needed).
+    """
+    end = data.find(b"\x00", off)
+    raw = data[off:] if end < 0 else data[off:end]
+    return raw.decode("utf-8", errors="replace")
+
+
+def extract_udt_source_files(ipi: TpiStream) -> dict[int, str]:
+    """Map each UDT's TPI type index to its defining source file.
+
+    Walks the IPI stream (same record layout as TPI, stream 4): collects
+    ``LF_STRING_ID`` records (id → string) then resolves ``LF_UDT_SRC_LINE`` /
+    ``LF_UDT_MOD_SRC_LINE`` records, each of which ties a TPI UDT type index to
+    a source-file string id.  Returns ``{udt_tpi_ti: source_file}``.
+
+    This is the provenance signal MSVC records for user-defined types — the
+    PDB equivalent of DWARF ``DW_AT_decl_file`` (ADR-024 Phase 1).  Malformed
+    records are skipped rather than fatal.
+    """
+    string_by_id: dict[int, str] = {}
+    src_line_recs: list[tuple[int, int]] = []  # (udt_ti, src_string_id)
+
+    for rec in ipi.records:
+        data = rec.data
+        try:
+            if rec.leaf == LF_STRING_ID:
+                # { substr_list_id: u32, name: char[] }
+                if len(data) >= 4:
+                    string_by_id[rec.type_index] = _read_id_string(data, 4)
+            elif rec.leaf in (LF_UDT_SRC_LINE, LF_UDT_MOD_SRC_LINE):
+                # Both start with { udt_ti: u32, src_string_id: u32, ... }
+                if len(data) >= 8:
+                    udt_ti, src_id = struct.unpack_from("<II", data, 0)
+                    src_line_recs.append((udt_ti, src_id))
+        except struct.error:  # pragma: no cover - defensive
+            continue
+
+    out: dict[int, str] = {}
+    for udt_ti, src_id in src_line_recs:
+        src = string_by_id.get(src_id)
+        if src:
+            # First definition wins (matches the ODR convention used elsewhere).
+            out.setdefault(udt_ti, src)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -1160,6 +1215,10 @@ class PdbFile:
     tpi: TpiStream | None = None
     dbi: DbiStream | None = None
     types: TypeDatabase | None = None
+    ipi: TpiStream | None = None
+    # UDT name → defining source file, from the IPI UDT_SRC_LINE records
+    # (ADR-024 Phase 1 provenance). Empty when the PDB has no IPI stream.
+    udt_source_files: dict[str, str] = field(default_factory=dict)
 
 
 def parse_pdb(path: Path) -> PdbFile:
@@ -1193,4 +1252,36 @@ def parse_pdb(path: Path) -> PdbFile:
             except (ValueError, struct.error) as exc:
                 log.debug("Failed to parse DBI stream from %s: %s", path, exc)
 
+    # Parse IPI stream (stream 4) for UDT source-file provenance — non-fatal.
+    if pdb.types is not None and msf.stream_count() > _IPI_STREAM:
+        ipi_data = msf.stream_data(_IPI_STREAM)
+        if ipi_data:
+            try:
+                pdb.ipi = parse_tpi_stream(ipi_data)
+                pdb.udt_source_files = _resolve_udt_source_files(pdb.ipi, pdb.types)
+            except (ValueError, struct.error) as exc:
+                log.debug("Failed to parse IPI stream from %s: %s", path, exc)
+
     return pdb
+
+
+def _resolve_udt_source_files(
+    ipi: TpiStream, types: TypeDatabase
+) -> dict[str, str]:
+    """Resolve the IPI UDT-source map (ti → file) to a UDT *name* → file map."""
+    by_ti = extract_udt_source_files(ipi)
+    if not by_ti:
+        return {}
+    name_by_ti: dict[int, str] = {}
+    for ti, cv in types.all_structs().items():
+        if cv.name:
+            name_by_ti[ti] = cv.name
+    for ti, cv_enum in types.all_enums().items():
+        if cv_enum.name:
+            name_by_ti[ti] = cv_enum.name
+    out: dict[str, str] = {}
+    for ti, src in by_ti.items():
+        name = name_by_ti.get(ti)
+        if name:
+            out.setdefault(name, src)
+    return out

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from .checker_types import Change
     from .model import AbiSnapshot
     from .suppression import SuppressionList
+    from .surface import PublicSurface
 
 
 @dataclass
@@ -58,6 +59,11 @@ class PipelineContext:
     # finding). Consumers surface this as "manual review required" — scoping
     # must never silently read as confident compatibility (issue #235).
     scope_fell_back: bool = False
+    # Public surfaces computed by FilterNonPublicSurface, cached here so the
+    # caller can reuse them (e.g. surface_scope_confidence) instead of repeating
+    # the type-closure walk. None when scoping was not run.
+    surf_old: PublicSurface | None = None
+    surf_new: PublicSurface | None = None
     # Accumulated side-outputs
     opaque_filtered: list[Change] = field(default_factory=list)
     suppressed: list[Change] = field(default_factory=list)
@@ -248,6 +254,9 @@ class FilterNonPublicSurface:
 
         surf_old = compute_public_surface(ctx.old)
         surf_new = compute_public_surface(ctx.new)
+        # Cache for reuse (surface_scope_confidence) — avoids a second walk.
+        ctx.surf_old = surf_old
+        ctx.surf_new = surf_new
         if not (surf_old.resolvable or surf_new.resolvable):
             # No header-derived surface to scope against — keep everything and
             # record the fallback so the verdict is not mistaken for a

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -433,6 +433,9 @@ def _add_surface_scope(d: dict[str, object], result: DiffResult) -> None:
         return
     d["surface_scope"] = {
         "enabled": True,
+        # ADR-024 §D5.3 — structured confidence in the resolution itself.
+        "confidence": result.surface_scope_confidence,
+        "notes": list(result.surface_scope_notes),
         "out_of_surface_count": result.out_of_surface_count,
         "out_of_surface_changes": [
             {

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -228,6 +228,8 @@ def to_sarif(
                         {
                             "surfaceScope": {
                                 "enabled": True,
+                                "confidence": result.surface_scope_confidence,
+                                "notes": list(result.surface_scope_notes),
                                 "outOfSurfaceCount": result.out_of_surface_count,
                                 "outOfSurfaceChanges": [
                                     {

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -474,6 +474,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         constants=d.get("constants", {}),
         platform=d.get("platform"),
         language_profile=d.get("language_profile"),
+        scope_fallback=d.get("scope_fallback"),
         dependency_info=dep_info,
         # Provenance metadata (v4)
         git_commit=d.get("git_commit"),

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .errors import AbicheckError, SnapshotError, ValidationError
-from .model import AbiSnapshot, Function, Visibility
+from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
 from .reporter import to_json, to_markdown, to_stat, to_stat_json
 from .serialization import load_snapshot
 
@@ -328,14 +328,16 @@ def _try_header_scoped_dump(
     includes: list[Path],
     version: str,
     lang: str,
-) -> AbiSnapshot | None:
+) -> tuple[AbiSnapshot | None, str | None]:
     """Attempt a castxml header-scoped dump for a PE/Mach-O binary.
 
-    Returns the header-scoped snapshot when castxml is available *and* at least
-    one declared symbol matched the export table.  Returns ``None`` (after
+    Returns ``(snapshot, None)`` when castxml is available *and* at least one
+    declared symbol matched the export table.  Returns ``(None, reason)`` (after
     emitting a ``UserWarning``) when scoping is unavailable or had no effect, so
-    the caller can fall back to export-table mode.  This mirrors the public-API
-    scoping that ``abidw --headers-dir`` / abi-dumper apply for ELF.
+    the caller can fall back to export-table mode and record the structured
+    confidence signal (ADR-024 §D5.3).  ``reason`` is one of
+    ``"castxml-unavailable"`` / ``"mangling-fallback"``.  This mirrors the
+    public-API scoping that ``abidw --headers-dir`` / abi-dumper apply for ELF.
     """
     from .dumper import _dump_macho as _dumper_macho
     from .dumper import _dump_pe as _dumper_pe
@@ -362,7 +364,7 @@ def _try_header_scoped_dump(
             UserWarning,
             stacklevel=2,
         )
-        return None
+        return None, "castxml-unavailable"
 
     if not _has_matched_public_surface(snap):
         warnings.warn(
@@ -374,8 +376,8 @@ def _try_header_scoped_dump(
             UserWarning,
             stacklevel=2,
         )
-        return None
-    return snap
+        return None, "mangling-fallback"
+    return snap, None
 
 
 def _extract_pdb_debug(
@@ -439,8 +441,9 @@ def _dump_pe(
 
     dwarf_meta, dwarf_adv = _extract_pdb_debug(path, pdb_path)
 
+    scope_fallback: str | None = None
     if headers:
-        scoped = _try_header_scoped_dump(
+        scoped, scope_fallback = _try_header_scoped_dump(
             "pe", path, headers, includes or [], version, lang,
         )
         if scoped is not None:
@@ -461,12 +464,25 @@ def _dump_pe(
         for exp in pe_meta.exports
     ]
 
+    # ADR-024 Phase 1 (PDB provenance): when header scoping was requested but
+    # castxml could not resolve a surface (commonly the MSVC C++-mangling gap),
+    # recover declared types — *with their defining source header* — from the
+    # PDB debug info so that --public-header scoping still has a provenance
+    # signal to classify against. Bounded to this fallback branch so default
+    # PE diffs (no --header) are unaffected.
+    pdb_types: list[RecordType] = []
+    pdb_enums: list[EnumType] = []
+    if headers and dwarf_meta is not None:
+        from .pdb_model import model_types_from_dwarf_metadata
+        pdb_types, pdb_enums = model_types_from_dwarf_metadata(dwarf_meta)
+
     return AbiSnapshot(
         library=path.name, version=version,
-        functions=funcs, pe=pe_meta,
+        functions=funcs, types=pdb_types, enums=pdb_enums, pe=pe_meta,
         dwarf=dwarf_meta,
         dwarf_advanced=dwarf_adv,
         platform="pe",
+        scope_fallback=scope_fallback,
     )
 
 
@@ -496,8 +512,9 @@ def _dump_macho(
             "Verify the file is a valid dynamic library."
         )
 
+    scope_fallback: str | None = None
     if headers:
-        scoped = _try_header_scoped_dump(
+        scoped, scope_fallback = _try_header_scoped_dump(
             "macho", path, headers, includes or [], version, lang,
         )
         if scoped is not None:
@@ -515,6 +532,7 @@ def _dump_macho(
         library=path.name, version=version,
         functions=funcs, macho=macho_meta,
         platform="macho",
+        scope_fallback=scope_fallback,
     )
 
 

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -137,6 +137,11 @@ class PublicSurface:
     # name. Only populated when the snapshot was dumped with a public-header
     # set; otherwise every value is UNKNOWN and provenance reasons never fire.
     origin_by_key: dict[str, ScopeOrigin] = field(default_factory=dict)
+    # True when *any* declaration carried a non-UNKNOWN origin — i.e. the
+    # snapshot was dumped with a public-header set so provenance is available.
+    # Lets the classifier distinguish a confident reachability demotion from one
+    # made without provenance to confirm it (ADR-024 §D5.1 ``no-provenance``).
+    has_provenance: bool = False
 
 
 def _symbol_keys(name: str, mangled: str) -> set[str]:
@@ -274,6 +279,13 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
     # Seed roots from public symbols; collect the type names they touch.
     seed_types, has_public = _seed_public_roots(snap, surface)
 
+    # Provenance is available iff some declaration was classified to a real
+    # origin (only happens when the snapshot was dumped with a public-header
+    # set). Used by the classifier to emit the ``no-provenance`` ledger reason.
+    surface.has_provenance = any(
+        o != ScopeOrigin.UNKNOWN for o in surface.origin_by_key.values()
+    )
+
     # Scoping only makes sense when we actually have header-derived public
     # visibility. Without headers every symbol is ELF_ONLY (ADR-016) and a
     # surface filter would hide everything — so declare it unresolvable.
@@ -284,6 +296,49 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
     # Transitive closure over the record/typedef graph.
     _walk_type_closure(snap, surface, record_by_name, seed_types)
     return surface
+
+
+# Scope-level confidence notes (ADR-024 §D5.3). Unlike the per-finding
+# exclusion reasons below, these qualify the *whole* surface resolution: they
+# flag that the resolved surface (and therefore every demotion decision made
+# against it) is less trustworthy than a clean header-scoped run.
+SCOPE_NOTE_MANGLING_FALLBACK = "mangling-fallback"      # MSVC C++ name-mangling gap
+SCOPE_NOTE_CASTXML_UNAVAILABLE = "castxml-unavailable"  # castxml missing / parse failed
+SCOPE_NOTE_NO_PROVENANCE = "no-provenance"              # surface resolved without provenance
+
+
+def surface_scope_confidence(
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    *,
+    scope_enabled: bool,
+) -> tuple[str, list[str]]:
+    """Summarise confidence in the header-scope resolution (ADR-024 §D5.3).
+
+    Returns ``(confidence, notes)`` where *confidence* is ``"high"`` or
+    ``"reduced"`` and *notes* is a deduplicated, order-stable list of structured
+    note codes. ``"high"`` with no notes is the clean case. The dumper records
+    the per-snapshot ``scope_fallback`` signal (castxml/mangling); a resolvable
+    surface that nonetheless lacks provenance adds ``no-provenance``.
+    """
+    notes: list[str] = []
+
+    def _add(code: str | None) -> None:
+        if code and code not in notes:
+            notes.append(code)
+
+    for snap in (old, new):
+        _add(getattr(snap, "scope_fallback", None))
+
+    if scope_enabled:
+        s_old = compute_public_surface(old)
+        s_new = compute_public_surface(new)
+        if (s_old.resolvable or s_new.resolvable) and not (
+            s_old.has_provenance or s_new.has_provenance
+        ):
+            _add(SCOPE_NOTE_NO_PROVENANCE)
+
+    return ("reduced" if notes else "high"), notes
 
 
 def change_in_public_surface(
@@ -311,6 +366,10 @@ REASON_PRIVATE_HEADER = (
     "private-header"  # decl originates in a non-public project header
 )
 REASON_SYSTEM_HEADER = "system-header"  # decl originates in a toolchain/system header
+# A type was demoted by reachability while provenance *was* available for the
+# snapshot but not for this type — the demotion is reachability-based, not
+# provenance-confirmed (reduced confidence; ADR-024 §D5.1 / §D5.3).
+REASON_NO_PROVENANCE = "no-provenance"
 
 # Map a demotable origin to its ledger reason code.
 _ORIGIN_REASON: dict[ScopeOrigin, str] = {
@@ -413,4 +472,13 @@ def classify_change_surface(
             if REASON_PRIVATE_HEADER in type_reasons
             else REASON_SYSTEM_HEADER
         )
+    # Reachability demotion. If provenance was available for the snapshot but
+    # none of the implicated types carried it, disclose the reduced confidence
+    # (ADR-024 §D5.3) rather than implying a provenance-confirmed verdict.
+    if surf_old.has_provenance and surf_new.has_provenance and all(
+        surf_old.origin_by_key.get(c, ScopeOrigin.UNKNOWN) == ScopeOrigin.UNKNOWN
+        and surf_new.origin_by_key.get(c, ScopeOrigin.UNKNOWN) == ScopeOrigin.UNKNOWN
+        for c in known
+    ):
+        return False, REASON_NO_PROVENANCE
     return False, REASON_NON_PUBLIC_TYPE

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -98,6 +98,16 @@ _TYPE_NOISE: frozenset[str] = frozenset(
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_:]*")
 
 
+def _is_real_type(type_str: str | None) -> bool:
+    """True when *type_str* is a parsed type, not the export-only sentinel.
+
+    Export-table-only dumps (e.g. a PE binary whose header scoping fell back)
+    record ``return_type="?"`` and no parameters. Such roots carry no real
+    type information, so the reachability closure cannot trust them.
+    """
+    return bool(type_str) and type_str != "?"
+
+
 def _type_identifiers(type_str: str | None) -> set[str]:
     """Extract candidate record/enum/typedef names from a type string.
 
@@ -142,6 +152,14 @@ class PublicSurface:
     # Lets the classifier distinguish a confident reachability demotion from one
     # made without provenance to confirm it (ADR-024 §D5.1 ``no-provenance``).
     has_provenance: bool = False
+    # True when at least one public root carried real signature type info
+    # (a parameter or a return/variable type other than the export-only
+    # sentinel ``"?"``). When False the snapshot is export-table-only (e.g. a
+    # PE binary whose header scoping fell back), so the type-reachability
+    # closure has no roots and **cannot** be trusted to demote a type as
+    # "unreachable" — doing so would hide a real break (ADR-024 §D5.2). Only
+    # confident provenance (private/system header) may demote in that case.
+    has_typed_roots: bool = False
 
 
 def _symbol_keys(name: str, mangled: str) -> set[str]:
@@ -211,6 +229,8 @@ def _seed_public_roots(snap: AbiSnapshot, surface: PublicSurface) -> tuple[set[s
         if fn.visibility == Visibility.PUBLIC:
             has_public = True
             surface.public_symbols |= keys
+            if fn.params or _is_real_type(fn.return_type):
+                surface.has_typed_roots = True
             seed_types |= _type_identifiers(fn.return_type)
             for p in fn.params:
                 seed_types |= _type_identifiers(getattr(p, "type", None))
@@ -221,6 +241,8 @@ def _seed_public_roots(snap: AbiSnapshot, surface: PublicSurface) -> tuple[set[s
         if var.visibility == Visibility.PUBLIC:
             has_public = True
             surface.public_symbols |= keys
+            if _is_real_type(var.type):
+                surface.has_typed_roots = True
             seed_types |= _type_identifiers(var.type)
     return seed_types, has_public
 
@@ -333,9 +355,11 @@ def surface_scope_confidence(
     if scope_enabled:
         s_old = compute_public_surface(old)
         s_new = compute_public_surface(new)
-        if (s_old.resolvable or s_new.resolvable) and not (
-            s_old.has_provenance or s_new.has_provenance
-        ):
+        # Flag reduced confidence when *any* resolvable side was scoped without
+        # provenance — a mixed comparison (one side has provenance, the other
+        # resolvable side does not) is still only half-trustworthy, so the note
+        # must fire unless every resolvable side carries provenance.
+        if any(s.resolvable and not s.has_provenance for s in (s_old, s_new)):
             _add(SCOPE_NOTE_NO_PROVENANCE)
 
     return ("reduced" if notes else "high"), notes
@@ -464,7 +488,8 @@ def classify_change_surface(
     if known & public_types:
         return True, None
     # Prefer a provenance reason when every implicated type confidently
-    # originates from a private/system header; fall back to reachability.
+    # originates from a private/system header; this is a *confident* demotion
+    # and applies even without typed roots (it is the leaked-private case).
     type_reasons = {_origin_reason(surf_old, surf_new, c) for c in known}
     if None not in type_reasons and type_reasons:
         return False, (
@@ -472,6 +497,15 @@ def classify_change_surface(
             if REASON_PRIVATE_HEADER in type_reasons
             else REASON_SYSTEM_HEADER
         )
+    # Beyond this point the only basis to demote is type-reachability. That is
+    # trustworthy *only* when the surface has real typed roots to walk from.
+    # An export-table-only snapshot (e.g. a PE binary whose header scoping fell
+    # back to the export table — functions are ``return_type="?"``) has none,
+    # so every type looks "unreachable". Demoting on that basis would hide a
+    # genuine public ABI break, including a change to a PUBLIC_HEADER type
+    # recovered from a PDB. Keep the finding in that case (ADR-024 §D5.2).
+    if not (surf_old.has_typed_roots and surf_new.has_typed_roots):
+        return True, None
     # Reachability demotion. If provenance was available for the snapshot but
     # none of the implicated types carried it, disclose the reduced confidence
     # (ADR-024 §D5.3) rather than implying a provenance-confirmed verdict.

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -334,6 +334,8 @@ def surface_scope_confidence(
     new: AbiSnapshot,
     *,
     scope_enabled: bool,
+    surf_old: PublicSurface | None = None,
+    surf_new: PublicSurface | None = None,
 ) -> tuple[str, list[str]]:
     """Summarise confidence in the header-scope resolution (ADR-024 §D5.3).
 
@@ -342,6 +344,11 @@ def surface_scope_confidence(
     note codes. ``"high"`` with no notes is the clean case. The dumper records
     the per-snapshot ``scope_fallback`` signal (castxml/mangling); a resolvable
     surface that nonetheless lacks provenance adds ``no-provenance``.
+
+    ``surf_old`` / ``surf_new`` may be passed when the caller has already run
+    :func:`compute_public_surface` (e.g. the ``FilterNonPublicSurface`` pipeline
+    step) to avoid repeating the type-closure walk; otherwise they are computed
+    on demand.
     """
     notes: list[str] = []
 
@@ -353,8 +360,8 @@ def surface_scope_confidence(
         _add(getattr(snap, "scope_fallback", None))
 
     if scope_enabled:
-        s_old = compute_public_surface(old)
-        s_new = compute_public_surface(new)
+        s_old = surf_old if surf_old is not None else compute_public_surface(old)
+        s_new = surf_new if surf_new is not None else compute_public_surface(new)
         # Flag reduced confidence when *any* resolvable side was scoped without
         # provenance — a mixed comparison (one side has provenance, the other
         # resolvable side does not) is still only half-trustworthy, so the note

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -1,7 +1,7 @@
 # ADR-024: Public ABI Surface Resolution and False-Positive Traceability
 
-**Date:** 2026-05-30
-**Status:** Proposed
+**Date:** 2026-05-30 (accepted 2026-05-31)
+**Status:** Accepted
 **Decision maker:** Nikolay Petrov
 
 ---
@@ -126,19 +126,27 @@ hard `--headers-dir` drop: we keep auditability.
    the full list) of entities **included** vs **excluded/demoted**, each with a reason:
    `private-header`, `system-header`, `not-exported`, `suppressed-by-user`,
    `mangling-fallback`, `no-provenance`. Available in text, JSON, and SARIF.
-   *Shipped (partial):* the ledger is disclosed in text/JSON/SARIF, and the
-   reasons the pre-provenance resolver can determine with confidence —
+   *Shipped:* the ledger is disclosed in text/JSON/SARIF. Per-finding reasons:
    `not-exported` (symbol not in the export set) and `non-public-type` (type
-   reachable by no public root) — are tagged per finding. The
-   provenance-dependent reasons (`private-header`, `system-header`,
-   `mangling-fallback`, `no-provenance`) await Phase 1; `suppressed-by-user`
-   lives in the separate suppression ledger.
+   reachable by no public root) are the linkage/reachability reasons;
+   `private-header` / `system-header` are tagged once provenance is available
+   (Phase 1). `no-provenance` marks a reachability demotion made while
+   provenance existed for the snapshot but not for the demoted type. The
+   scope-level confidence signal (`surface_scope.confidence` /
+   `surfaceScope.confidence`, with structured `notes`) discloses
+   `mangling-fallback` / `castxml-unavailable` (recorded by the dumper as the
+   snapshot's `scope_fallback`) and `no-provenance` — see §D5.3.
+   `suppressed-by-user` lives in the separate suppression ledger.
 2. **Leak guard always wins.** If a `PRIVATE_HEADER`-origin type is reachable from a
    `PUBLIC_HEADER`+exported root, emit `INTERNAL_TYPE_LEAKS_VIA_PUBLIC_API` (extend
    `internal_leak.py`) **regardless of scoping mode**. Scoping must never suppress a leak.
 3. **Confidence is explicit.** Distinguish full-confidence (provenance + types known) from
    reduced-confidence (export-only, mangling fallback, missing provenance). The PE/Mach-O
    `UserWarning` fallbacks from PR #259 become structured confidence signals.
+   *Shipped:* the dumper records a machine-readable `scope_fallback`
+   (`"castxml-unavailable"` / `"mangling-fallback"`) on the snapshot alongside
+   the human `UserWarning`; the comparison surfaces a `surface_scope.confidence`
+   of `"high"` / `"reduced"` plus structured `notes` in the JSON/SARIF ledger.
 4. **No silent suppression of breaks.** When a *user* control (suppression/allowlist) would
    hide a finding that is `abi_breaking`, require an explicit acknowledgment (e.g. a
    `reason:` field) and emit a warning in the ledger. Suppressing breakage should be a
@@ -222,7 +230,7 @@ The feature is only credible if we can prove it neither over- nor under-filters.
 | Phase | Scope |
 |-------|-------|
 | **0** | PE/Mach-O header plumbing + directory expansion + fallback warnings — **done (PR #259)** |
-| **1** | Provenance capture: source-header tagging in castxml/DWARF/PDB parsers; model + serialization fields (schema bump) — **done** (`source_header` + 6-way `ScopeOrigin` on functions/variables/types/enums; schema v6; castxml + DWARF populate locations; PDB pending) |
+| **1** | Provenance capture: source-header tagging in castxml/DWARF/PDB parsers; model + serialization fields (schema bump) — **done** (`source_header` + 6-way `ScopeOrigin` on functions/variables/types/enums; schema v6; castxml + DWARF + **PDB** populate locations — PDB via `LF_UDT_SRC_LINE`/`LF_UDT_MOD_SRC_LINE` in the IPI stream, bridged to model types by `pdb_model.py`; `--public-header` now accepted for PE/Mach-O. Windows end-to-end is validated by the `msvc` CI lane; the parser/metadata/bridge layers carry synthetic-buffer unit tests on every platform) |
 | **2** | Header-scope resolution + surface ledger + `--scope-public-headers`/`--show-filtered` (opt-in, default off) — **done** (ledger now also disclosed in JSON `surface_scope` / SARIF `surfaceScope`, not just stderr text; provenance-driven `private-header`/`system-header` reasons now wired) |
 | **3** | Reachability closure + leak-guard integration (extend `internal_leak.py`) — **done (closure shipped; leak exemption wired)** |
 | **4** | User-control overlay: widening public allowlist; integrate suppression as the narrowing layer; precedence + anti-hiding guard — **done** (widening via `--public-symbol`/`--public-symbols-list`; suppression remains the narrowing layer; widening only ever *keeps*, never hides) |
@@ -258,11 +266,25 @@ the resolver, classifier, anti-hiding guarantees, and the JSON/SARIF ledger,
 and `tests/test_surface_property.py` adds the property-based monotonicity /
 subset / order-independence guarantees from the validation strategy (§3).
 
-The remaining Phase 1 work — recording *which* header each declaration came
-from, so the surface can distinguish "private header transitively included"
-from "public header" independently of reachability — is still future work
-and is what unlocks the per-finding `private-header` ledger reason and the
-widening/narrowing user overlay (Phase 4).
+Phase 1 (recording *which* header each declaration came from, so the surface
+can distinguish "private header transitively included" from "public header"
+independently of reachability) has since shipped across castxml, DWARF, and
+PDB. On the PE path PDB carries this via the IPI `LF_UDT_SRC_LINE` /
+`LF_UDT_MOD_SRC_LINE` records, parsed in `pdb_parser.py`, threaded onto
+`DwarfMetadata` as `decl_file`, and bridged into model `RecordType`/`EnumType`
+by `pdb_model.py` so `apply_provenance` can classify a `ScopeOrigin`. The
+bridge is invoked only on the PE header-scoping *fallback* branch (headers
+requested but castxml could not resolve a surface — the MSVC C++-mangling
+gap), keeping default PE diffs unchanged. This unlocks the per-finding
+`private-header` ledger reason and the widening/narrowing user overlay
+(Phase 4) on Windows binaries too.
+
+The one acknowledged residual is the MSVC C++-name-mangling gap itself
+(§D5.3 / Consequences): when castxml cannot match a mangled C++ export, the PE
+surface still falls back to the export table — now disclosed as a
+`mangling-fallback` confidence note rather than silently. PDB provenance
+narrows the impact (declared types still carry their header) but does not, on
+its own, close the mangling gap.
 
 ---
 

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -107,12 +107,28 @@ Each demoted finding carries a `reason` code explaining why it was excluded:
   the public-header set.
 - `system-header` — the declaration originates in a toolchain/system header
   (`/usr/include`, MSVC, Xcode SDK, …).
+- `no-provenance` — a type demoted by reachability while provenance *was*
+  available for the snapshot but not for this type, so the demotion is
+  reachability-based rather than provenance-confirmed (reduced confidence).
 
 The `private-header` / `system-header` reasons are provenance-derived: they
 only appear when the snapshots were produced with `--public-header` /
-`--public-header-dir` (ADR-015 schema v6). Without a public-header set, every
-declaration's origin is `unknown` and only the linkage/reachability reasons
-above are emitted.
+`--public-header-dir` (ADR-015 schema v6). `--public-header` is supported for
+ELF, PE (provenance from PDB `LF_UDT_SRC_LINE`), and Mach-O inputs. Without a
+public-header set, every declaration's origin is `unknown` and only the
+linkage/reachability reasons above are emitted.
+
+### Scope-resolution confidence
+
+The ledger also carries a structured **confidence** in the surface resolution
+itself (ADR-024 §D5.3), distinct from the overall verdict confidence:
+
+- `confidence`: `"high"` (a clean header-scoped run) or `"reduced"`.
+- `notes`: structured codes explaining any reduction —
+  `mangling-fallback` / `castxml-unavailable` (header scoping was requested on a
+  PE/Mach-O binary but fell back to the export table; recorded on the snapshot
+  as `scope_fallback`), or `no-provenance` (the surface resolved without any
+  declaration provenance).
 
 **Text**: With `--show-filtered`, an audit block on stderr (the reason is shown
 in parentheses):
@@ -126,6 +142,8 @@ active):
 ```json
 "surface_scope": {
   "enabled": true,
+  "confidence": "high",
+  "notes": [],
   "out_of_surface_count": 1,
   "out_of_surface_changes": [
     {"kind": "type_size_changed", "symbol": "InternalCache",
@@ -136,8 +154,9 @@ active):
 ```
 
 **SARIF**: A `surfaceScope` object in run-level `properties` with
-`outOfSurfaceCount` and `outOfSurfaceChanges` (same per-finding fields,
-camelCased; `reason` included when known), present only when scoping is active.
+`confidence`, `notes`, `outOfSurfaceCount`, and `outOfSurfaceChanges` (same
+per-finding fields, camelCased; `reason` included when known), present only
+when scoping is active.
 
 ## `--show-only` filter
 

--- a/tests/test_pdb_parser.py
+++ b/tests/test_pdb_parser.py
@@ -186,6 +186,7 @@ def _build_dbi_stream(
 def _build_minimal_pdb(
     tpi_records: list[tuple[int, bytes]] | None = None,
     dbi_data: bytes | None = None,
+    ipi_records: list[tuple[int, bytes]] | None = None,
 ) -> bytes:
     """Construct a minimal valid PDB 7.0 file in memory.
 
@@ -194,6 +195,10 @@ def _build_minimal_pdb(
     - Block 1: FPM1
     - Block 2: FPM2
     - Blocks 3+: stream directory and stream data
+
+    When *ipi_records* is provided, a stream 4 (IPI) is appended carrying those
+    records (same on-disk layout as TPI), enabling UDT source-file provenance
+    tests (ADR-024 Phase 1).
     """
     tpi_data = _build_tpi_stream(tpi_records or [])
     dbi_data = dbi_data or _build_dbi_stream()
@@ -211,6 +216,8 @@ def _build_minimal_pdb(
         tpi_data,   # Stream 2 (TPI)
         dbi_data,   # Stream 3 (DBI)
     ]
+    if ipi_records is not None:
+        streams.append(_build_tpi_stream(ipi_records))  # Stream 4 (IPI)
 
     # Allocate blocks for each stream
     # First 3 blocks: superblock, FPM1, FPM2

--- a/tests/test_pdb_provenance.py
+++ b/tests/test_pdb_provenance.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright The abicheck Authors.
+"""PDB declaration-provenance extraction (ADR-024 Phase 1).
+
+Exercises the source-file (``decl_file``) plumbing end to end at the layers
+that are testable on Linux without MSVC: the IPI ``LF_UDT_SRC_LINE`` parser,
+the ``DwarfMetadata`` ``decl_file`` field, and the ``DwarfMetadata`` → model
+type bridge that lets PDB-derived types reach public-surface resolution.
+"""
+from __future__ import annotations
+
+import struct
+
+from abicheck.dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
+from abicheck.model import ScopeOrigin
+from abicheck.pdb_model import model_types_from_dwarf_metadata
+from abicheck.pdb_parser import (
+    LF_STRING_ID,
+    LF_UDT_MOD_SRC_LINE,
+    LF_UDT_SRC_LINE,
+    extract_udt_source_files,
+    parse_tpi_stream,
+)
+from abicheck.provenance import apply_provenance
+
+
+def _build_ipi_stream(records: list[tuple[int, bytes]]) -> bytes:
+    """Build an IPI stream (identical record layout to TPI)."""
+    ti_begin = 0x1000
+    ti_end = ti_begin + len(records)
+    rec_data = b""
+    for leaf, payload in records:
+        rec_len = 2 + len(payload)
+        rec_bytes = struct.pack("<HH", rec_len, leaf) + payload
+        pad = (4 - (len(rec_bytes) % 4)) % 4
+        rec_bytes += b"\x00" * pad
+        rec_data += rec_bytes
+    header = struct.pack(
+        "<IIIII", 20040203, 56, ti_begin, ti_end, len(rec_data)
+    )
+    header += b"\x00" * (56 - len(header))
+    return header + rec_data
+
+
+def _string_id(name: str) -> bytes:
+    # { substr_list_id: u32, name: char[] }
+    return struct.pack("<I", 0) + name.encode() + b"\x00"
+
+
+def _udt_src_line(udt_ti: int, src_id: int, line: int) -> bytes:
+    return struct.pack("<III", udt_ti, src_id, line)
+
+
+def _udt_mod_src_line(udt_ti: int, src_id: int, line: int, mod: int) -> bytes:
+    return struct.pack("<IIIH", udt_ti, src_id, line, mod)
+
+
+class TestExtractUdtSourceFiles:
+    def test_resolves_src_line_via_string_id(self) -> None:
+        # IPI: ti 0x1000 = LF_STRING_ID("api.h"); ti 0x1001 ties UDT 0x2000 → it.
+        ipi = parse_tpi_stream(
+            _build_ipi_stream(
+                [
+                    (LF_STRING_ID, _string_id("api.h")),
+                    (LF_UDT_SRC_LINE, _udt_src_line(0x2000, 0x1000, 42)),
+                ]
+            )
+        )
+        assert extract_udt_source_files(ipi) == {0x2000: "api.h"}
+
+    def test_mod_src_line_also_resolved(self) -> None:
+        ipi = parse_tpi_stream(
+            _build_ipi_stream(
+                [
+                    (LF_STRING_ID, _string_id("detail/private.h")),
+                    (LF_UDT_MOD_SRC_LINE, _udt_mod_src_line(0x2001, 0x1000, 7, 3)),
+                ]
+            )
+        )
+        assert extract_udt_source_files(ipi) == {0x2001: "detail/private.h"}
+
+    def test_unresolvable_string_id_skipped(self) -> None:
+        # src id 0x1999 has no LF_STRING_ID record → entry dropped, not crash.
+        ipi = parse_tpi_stream(
+            _build_ipi_stream(
+                [(LF_UDT_SRC_LINE, _udt_src_line(0x2000, 0x1999, 1))]
+            )
+        )
+        assert extract_udt_source_files(ipi) == {}
+
+    def test_first_definition_wins(self) -> None:
+        ipi = parse_tpi_stream(
+            _build_ipi_stream(
+                [
+                    (LF_STRING_ID, _string_id("first.h")),
+                    (LF_STRING_ID, _string_id("second.h")),
+                    (LF_UDT_SRC_LINE, _udt_src_line(0x2000, 0x1000, 1)),
+                    (LF_UDT_SRC_LINE, _udt_src_line(0x2000, 0x1001, 2)),
+                ]
+            )
+        )
+        assert extract_udt_source_files(ipi) == {0x2000: "first.h"}
+
+
+class TestDwarfMetadataDeclFile:
+    def test_struct_layout_carries_decl_file(self) -> None:
+        layout = StructLayout(name="Vec3", byte_size=12, decl_file="include/api.h")
+        assert layout.decl_file == "include/api.h"
+
+    def test_decl_file_defaults_none(self) -> None:
+        assert StructLayout(name="X", byte_size=4).decl_file is None
+        assert EnumInfo(name="E", underlying_byte_size=4).decl_file is None
+
+
+class TestModelBridge:
+    def test_record_source_location_from_decl_file(self) -> None:
+        meta = DwarfMetadata(has_dwarf=True)
+        meta.structs["Vec3"] = StructLayout(
+            name="Vec3",
+            byte_size=12,
+            fields=[FieldInfo(name="x", type_name="float", byte_offset=0, byte_size=4)],
+            decl_file="include/api.h",
+        )
+        meta.enums["Color"] = EnumInfo(
+            name="Color",
+            underlying_byte_size=4,
+            members={"RED": 0, "GREEN": 1},
+            decl_file="include/api.h",
+        )
+        records, enums = model_types_from_dwarf_metadata(meta)
+        assert len(records) == 1 and len(enums) == 1
+        assert records[0].name == "Vec3"
+        assert records[0].source_location == "include/api.h"
+        assert records[0].size_bits == 96
+        assert records[0].fields[0].offset_bits == 0
+        assert enums[0].source_location == "include/api.h"
+        assert enums[0].underlying_type == "int"
+
+    def test_empty_metadata_yields_nothing(self) -> None:
+        assert model_types_from_dwarf_metadata(None) == ([], [])
+        assert model_types_from_dwarf_metadata(DwarfMetadata()) == ([], [])
+
+    def test_bridge_feeds_provenance_classification(self) -> None:
+        # The decl_file → source_location bridge lets apply_provenance classify
+        # a PDB-derived type's ScopeOrigin against a public-header set — the
+        # whole point of PDB provenance (ADR-024 Phase 1) on the PE path.
+        from abicheck.model import AbiSnapshot
+
+        meta = DwarfMetadata(has_dwarf=True)
+        meta.structs["PublicType"] = StructLayout(
+            name="PublicType", byte_size=8, decl_file="include/api.h"
+        )
+        meta.structs["PrivateType"] = StructLayout(
+            name="PrivateType", byte_size=8, decl_file="src/internal.h"
+        )
+        records, enums = model_types_from_dwarf_metadata(meta)
+        snap = AbiSnapshot(library="lib.dll", version="1", types=records, enums=enums)
+        apply_provenance(snap, public_headers=["include/api.h"], public_header_dirs=None)
+        by_name = {t.name: t for t in snap.types}
+        assert by_name["PublicType"].origin == ScopeOrigin.PUBLIC_HEADER
+        assert by_name["PrivateType"].origin == ScopeOrigin.PRIVATE_HEADER

--- a/tests/test_pdb_provenance.py
+++ b/tests/test_pdb_provenance.py
@@ -10,18 +10,31 @@ type bridge that lets PDB-derived types reach public-surface resolution.
 from __future__ import annotations
 
 import struct
+from pathlib import Path
 
 from abicheck.dwarf_metadata import DwarfMetadata, EnumInfo, FieldInfo, StructLayout
 from abicheck.model import ScopeOrigin
+from abicheck.pdb_metadata import parse_pdb_debug_info
 from abicheck.pdb_model import model_types_from_dwarf_metadata
 from abicheck.pdb_parser import (
+    LF_FIELDLIST,
     LF_STRING_ID,
+    LF_STRUCTURE,
     LF_UDT_MOD_SRC_LINE,
     LF_UDT_SRC_LINE,
+    TypeDatabase,
+    _resolve_udt_source_files,
     extract_udt_source_files,
     parse_tpi_stream,
 )
 from abicheck.provenance import apply_provenance
+from tests.test_pdb_parser import (
+    _build_minimal_pdb,
+    _build_tpi_stream,
+    _make_lf_fieldlist,
+    _make_lf_member,
+    _make_lf_structure,
+)
 
 
 def _build_ipi_stream(records: list[tuple[int, bytes]]) -> bytes:
@@ -88,6 +101,29 @@ class TestExtractUdtSourceFiles:
         )
         assert extract_udt_source_files(ipi) == {}
 
+    def test_resolve_to_udt_name(self) -> None:
+        # _resolve_udt_source_files maps the IPI ti→file map onto UDT *names*
+        # via the TPI TypeDatabase (struct Vec3 at ti 0x1001).
+        tpi = parse_tpi_stream(
+            _build_tpi_stream(
+                [
+                    (LF_FIELDLIST, _make_lf_fieldlist([_make_lf_member(0, 0x74, 0, "x")])),
+                    (LF_STRUCTURE, _make_lf_structure(1, 0, 0x1000, 4, "Vec3")),
+                ]
+            )
+        )
+        types = TypeDatabase(tpi)
+        types.parse_all()
+        ipi = parse_tpi_stream(
+            _build_ipi_stream(
+                [
+                    (LF_STRING_ID, _string_id("include/vec.h")),
+                    (LF_UDT_SRC_LINE, _udt_src_line(0x1001, 0x1000, 5)),
+                ]
+            )
+        )
+        assert _resolve_udt_source_files(ipi, types) == {"Vec3": "include/vec.h"}
+
     def test_first_definition_wins(self) -> None:
         ipi = parse_tpi_stream(
             _build_ipi_stream(
@@ -139,6 +175,154 @@ class TestModelBridge:
     def test_empty_metadata_yields_nothing(self) -> None:
         assert model_types_from_dwarf_metadata(None) == ([], [])
         assert model_types_from_dwarf_metadata(DwarfMetadata()) == ([], [])
+
+    def test_bitfield_and_union_branches(self) -> None:
+        meta = DwarfMetadata(has_dwarf=True)
+        meta.structs["Flags"] = StructLayout(
+            name="Flags",
+            byte_size=4,
+            alignment=4,
+            is_union=False,
+            fields=[
+                FieldInfo(name="a", type_name="unsigned int", byte_offset=0,
+                          byte_size=4, bit_offset=0, bit_size=1),
+            ],
+        )
+        meta.structs["U"] = StructLayout(name="U", byte_size=8, is_union=True)
+        records, _ = model_types_from_dwarf_metadata(meta)
+        by_name = {r.name: r for r in records}
+        assert by_name["Flags"].alignment_bits == 32
+        assert by_name["Flags"].fields[0].is_bitfield is True
+        assert by_name["Flags"].fields[0].bitfield_bits == 1
+        assert by_name["U"].kind == "union" and by_name["U"].is_union is True
+
+
+class TestHeaderScopeFallback:
+    """The structured ``scope_fallback`` signal (ADR-024 §D5.3) returned by
+    service._try_header_scoped_dump when PE/Mach-O header scoping cannot apply.
+    """
+
+    def test_castxml_unavailable_fallback(self, tmp_path, monkeypatch):
+        import warnings as _w
+
+        import abicheck.dumper as dumper
+        from abicheck import service
+
+        hdr = tmp_path / "api.h"
+        hdr.write_text("int f(void);\n")
+
+        def _boom(*a, **k):
+            raise RuntimeError("castxml not found")
+
+        monkeypatch.setattr(dumper, "_dump_pe", _boom)
+        with _w.catch_warnings():
+            _w.simplefilter("ignore")
+            snap, reason = service._try_header_scoped_dump(
+                "pe", tmp_path / "lib.dll", [hdr], [], "1", "c++"
+            )
+        assert snap is None
+        assert reason == "castxml-unavailable"
+
+    def test_mangling_fallback(self, tmp_path, monkeypatch):
+        import warnings as _w
+
+        import abicheck.dumper as dumper
+        from abicheck import service
+        from abicheck.model import AbiSnapshot, Function, Visibility
+
+        hdr = tmp_path / "api.h"
+        hdr.write_text("int f(void);\n")
+
+        # A snapshot whose declared symbols never matched the export table:
+        # no PUBLIC-visibility symbols → _has_matched_public_surface is False.
+        def _unmatched(*a, **k):
+            return AbiSnapshot(
+                library="lib.dll", version="1",
+                functions=[Function(name="f", mangled="f", return_type="int",
+                                    visibility=Visibility.HIDDEN)],
+            )
+
+        monkeypatch.setattr(dumper, "_dump_pe", _unmatched)
+        with _w.catch_warnings():
+            _w.simplefilter("ignore")
+            snap, reason = service._try_header_scoped_dump(
+                "pe", tmp_path / "lib.dll", [hdr], [], "1", "c++"
+            )
+        assert snap is None
+        assert reason == "mangling-fallback"
+
+    def test_scoped_success_returns_no_fallback(self, tmp_path, monkeypatch):
+        import abicheck.dumper as dumper
+        from abicheck import service
+        from abicheck.model import AbiSnapshot, Function, Visibility
+
+        hdr = tmp_path / "api.h"
+        hdr.write_text("int f(void);\n")
+
+        def _matched(*a, **k):
+            return AbiSnapshot(
+                library="lib.dll", version="1",
+                functions=[Function(name="f", mangled="f", return_type="int",
+                                    visibility=Visibility.PUBLIC)],
+            )
+
+        monkeypatch.setattr(dumper, "_dump_pe", _matched)
+        snap, reason = service._try_header_scoped_dump(
+            "pe", tmp_path / "lib.dll", [hdr], [], "1", "c++"
+        )
+        assert snap is not None
+        assert reason is None
+
+
+class TestParsePdbEndToEnd:
+    def test_decl_file_flows_through_parse_pdb(self, tmp_path: Path) -> None:
+        # Full path: parse_pdb parses the IPI stream, resolves UDT→source, and
+        # pdb_metadata tags StructLayout.decl_file (ADR-024 Phase 1, PE path).
+        tpi = [
+            (LF_FIELDLIST, _make_lf_fieldlist([_make_lf_member(0, 0x74, 0, "x")])),
+            (LF_STRUCTURE, _make_lf_structure(1, 0, 0x1000, 4, "Vec3")),  # ti 0x1001
+        ]
+        ipi = [
+            (LF_STRING_ID, _string_id("include/vec.h")),                 # ti 0x1000
+            (LF_UDT_SRC_LINE, _udt_src_line(0x1001, 0x1000, 9)),
+        ]
+        pdb = tmp_path / "e2e.pdb"
+        pdb.write_bytes(_build_minimal_pdb(tpi_records=tpi, ipi_records=ipi))
+        meta, _adv = parse_pdb_debug_info(pdb)
+        assert "Vec3" in meta.structs
+        assert meta.structs["Vec3"].decl_file == "include/vec.h"
+
+    def test_no_ipi_leaves_decl_file_none(self, tmp_path: Path) -> None:
+        tpi = [
+            (LF_FIELDLIST, _make_lf_fieldlist([_make_lf_member(0, 0x74, 0, "x")])),
+            (LF_STRUCTURE, _make_lf_structure(1, 0, 0x1000, 4, "Vec3")),
+        ]
+        pdb = tmp_path / "noipi.pdb"
+        pdb.write_bytes(_build_minimal_pdb(tpi_records=tpi))  # no IPI stream
+        meta, _adv = parse_pdb_debug_info(pdb)
+        assert meta.structs["Vec3"].decl_file is None
+
+    def test_cli_apply_native_provenance(self) -> None:
+        # The CLI wrapper threads a PE/Mach-O snapshot through apply_provenance
+        # (lifting the old ELF-only restriction).
+        from abicheck.cli import _apply_native_provenance
+        from abicheck.model import AbiSnapshot
+
+        meta = DwarfMetadata(has_dwarf=True)
+        meta.structs["PublicType"] = StructLayout(
+            name="PublicType", byte_size=8, decl_file="include/api.h"
+        )
+        records, enums = model_types_from_dwarf_metadata(meta)
+        snap = AbiSnapshot(library="lib.dll", version="1", types=records, enums=enums)
+        out = _apply_native_provenance(snap, [Path("include/api.h")], None)
+        assert out.types[0].origin == ScopeOrigin.PUBLIC_HEADER
+        # No public set → no-op (origin stays UNKNOWN).
+        snap2 = AbiSnapshot(
+            library="lib.dll", version="1",
+            types=model_types_from_dwarf_metadata(meta)[0],
+        )
+        out2 = _apply_native_provenance(snap2, None, None)
+        assert out2.types[0].origin == ScopeOrigin.UNKNOWN
 
     def test_bridge_feeds_provenance_classification(self) -> None:
         # The decl_file → source_location bridge lets apply_provenance classify

--- a/tests/test_pdb_provenance.py
+++ b/tests/test_pdb_provenance.py
@@ -17,6 +17,7 @@ from abicheck.model import ScopeOrigin
 from abicheck.pdb_metadata import parse_pdb_debug_info
 from abicheck.pdb_model import model_types_from_dwarf_metadata
 from abicheck.pdb_parser import (
+    LF_ENUM,
     LF_FIELDLIST,
     LF_STRING_ID,
     LF_STRUCTURE,
@@ -31,6 +32,8 @@ from abicheck.provenance import apply_provenance
 from tests.test_pdb_parser import (
     _build_minimal_pdb,
     _build_tpi_stream,
+    _make_lf_enum,
+    _make_lf_enumerate,
     _make_lf_fieldlist,
     _make_lf_member,
     _make_lf_structure,
@@ -123,6 +126,36 @@ class TestExtractUdtSourceFiles:
             )
         )
         assert _resolve_udt_source_files(ipi, types) == {"Vec3": "include/vec.h"}
+
+    def test_resolve_enum_udt_name(self) -> None:
+        # The enum branch of _resolve_udt_source_files: an LF_ENUM at ti 0x1001.
+        tpi = parse_tpi_stream(
+            _build_tpi_stream(
+                [
+                    (LF_FIELDLIST, _make_lf_fieldlist([_make_lf_enumerate(0, 0, "A")])),
+                    (LF_ENUM, _make_lf_enum(1, 0, 0x74, 0x1000, "Color")),
+                ]
+            )
+        )
+        types = TypeDatabase(tpi)
+        types.parse_all()
+        ipi = parse_tpi_stream(
+            _build_ipi_stream(
+                [
+                    (LF_STRING_ID, _string_id("include/color.h")),
+                    (LF_UDT_SRC_LINE, _udt_src_line(0x1001, 0x1000, 3)),
+                ]
+            )
+        )
+        assert _resolve_udt_source_files(ipi, types) == {"Color": "include/color.h"}
+
+    def test_resolve_empty_when_no_src_lines(self) -> None:
+        # No UDT_SRC_LINE records → empty map (early-return branch).
+        tpi = parse_tpi_stream(_build_tpi_stream([]))
+        types = TypeDatabase(tpi)
+        types.parse_all()
+        ipi = parse_tpi_stream(_build_ipi_stream([(LF_STRING_ID, _string_id("x.h"))]))
+        assert _resolve_udt_source_files(ipi, types) == {}
 
     def test_first_definition_wins(self) -> None:
         ipi = parse_tpi_stream(
@@ -343,3 +376,53 @@ class TestParsePdbEndToEnd:
         by_name = {t.name: t for t in snap.types}
         assert by_name["PublicType"].origin == ScopeOrigin.PUBLIC_HEADER
         assert by_name["PrivateType"].origin == ScopeOrigin.PRIVATE_HEADER
+
+
+class TestDumpPeFallbackBuildsPdbTypes:
+    """service._dump_pe recovers PDB-derived model types (with provenance) on
+    the header-scoping fallback branch (ADR-024 Phase 1, PE path)."""
+
+    def test_pdb_types_built_on_mangling_fallback(self, tmp_path, monkeypatch):
+        import types as _t
+        import warnings as _w
+
+        from abicheck import service
+        from abicheck.model import ScopeOrigin as _SO
+
+        hdr = tmp_path / "api.h"
+        hdr.write_text("struct Widget { int x; };\n")
+
+        # Fake PE metadata: one named export, valid machine.
+        fake_pe = _t.SimpleNamespace(
+            machine="AMD64",
+            exports=[_t.SimpleNamespace(name="Api", ordinal=1)],
+        )
+        monkeypatch.setattr(
+            "abicheck.pe_metadata.parse_pe_metadata", lambda p: fake_pe
+        )
+        # PDB debug info with a public-header type.
+        meta = DwarfMetadata(has_dwarf=True)
+        meta.structs["Widget"] = StructLayout(
+            name="Widget", byte_size=4, decl_file="api.h"
+        )
+        monkeypatch.setattr(service, "_extract_pdb_debug", lambda p, pp: (meta, None))
+        # Header scoping falls back (castxml/mangling gap).
+        monkeypatch.setattr(
+            service, "_try_header_scoped_dump", lambda *a, **k: (None, "mangling-fallback")
+        )
+
+        with _w.catch_warnings():
+            _w.simplefilter("ignore")
+            snap = service._dump_pe(
+                tmp_path / "lib.dll", "1", headers=[hdr], includes=[], lang="c++"
+            )
+        # PDB type recovered into the model with its source header, and the
+        # structured fallback signal recorded.
+        assert snap.scope_fallback == "mangling-fallback"
+        names = {t.name: t for t in snap.types}
+        assert "Widget" in names
+        assert names["Widget"].source_location == "api.h"
+        # apply_provenance (run by the CLI wrapper) would then classify it; here
+        # we confirm the type reached the model so provenance is possible.
+        apply_provenance(snap, public_headers=[hdr], public_header_dirs=None)
+        assert names["Widget"].origin == _SO.PUBLIC_HEADER

--- a/tests/test_surface_confidence.py
+++ b/tests/test_surface_confidence.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright The abicheck Authors.
+"""Surface-scope structured confidence + the ``no-provenance`` ledger reason.
+
+Covers ADR-024 §D5.3: the dumper records a structured ``scope_fallback`` on the
+snapshot when header scoping had to fall back, and the surface resolver flags a
+reachability demotion made without provenance. Both are disclosed (confidence +
+notes) in the JSON/SARIF surface ledger so "demote + disclose" stays auditable.
+"""
+from __future__ import annotations
+
+import json
+
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind
+from abicheck.checker_types import Change
+from abicheck.model import (
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    ScopeOrigin,
+    Visibility,
+)
+from abicheck.reporter import to_json
+from abicheck.sarif import to_sarif
+from abicheck.surface import (
+    REASON_NO_PROVENANCE,
+    REASON_NON_PUBLIC_TYPE,
+    classify_change_surface,
+    compute_public_surface,
+    surface_scope_confidence,
+)
+
+
+def _fn(name, ret="void", params=(), vis=Visibility.PUBLIC, origin=ScopeOrigin.UNKNOWN):
+    return Function(
+        name=name,
+        mangled=f"_Z{len(name)}{name}",
+        return_type=ret,
+        params=[Param(name=f"a{i}", type=t) for i, t in enumerate(params)],
+        visibility=vis,
+        origin=origin,
+    )
+
+
+def _rec(name, size=64, origin=ScopeOrigin.UNKNOWN):
+    return RecordType(name=name, kind="struct", size_bits=size, origin=origin)
+
+
+# ── scope_fallback → notes / confidence ──────────────────────────────────────
+
+
+class TestScopeFallbackConfidence:
+    def test_mangling_fallback_recorded(self):
+        old = AbiSnapshot(library="l.dll", version="1", scope_fallback="mangling-fallback")
+        new = AbiSnapshot(library="l.dll", version="2", scope_fallback="mangling-fallback")
+        conf, notes = surface_scope_confidence(old, new, scope_enabled=True)
+        assert conf == "reduced"
+        assert notes == ["mangling-fallback"]
+
+    def test_castxml_unavailable_recorded(self):
+        old = AbiSnapshot(library="l.dll", version="1", scope_fallback="castxml-unavailable")
+        new = AbiSnapshot(library="l.dll", version="2")
+        conf, notes = surface_scope_confidence(old, new, scope_enabled=False)
+        assert conf == "reduced"
+        assert notes == ["castxml-unavailable"]
+
+    def test_clean_run_is_high_confidence(self):
+        old = AbiSnapshot(library="l", version="1", functions=[_fn("api", origin=ScopeOrigin.PUBLIC_HEADER)])
+        new = AbiSnapshot(library="l", version="2", functions=[_fn("api", origin=ScopeOrigin.PUBLIC_HEADER)])
+        conf, notes = surface_scope_confidence(old, new, scope_enabled=True)
+        assert conf == "high"
+        assert notes == []
+
+    def test_no_provenance_note_when_surface_lacks_origins(self):
+        # Resolvable surface (a PUBLIC symbol exists) but every origin is UNKNOWN
+        # → the resolution is reachability-only; disclose reduced confidence.
+        old = AbiSnapshot(library="l", version="1", functions=[_fn("api")])
+        new = AbiSnapshot(library="l", version="2", functions=[_fn("api")])
+        # Force resolvable surface: a PUBLIC function with a non-elf-only mode.
+        conf, notes = surface_scope_confidence(old, new, scope_enabled=True)
+        assert conf == "reduced"
+        assert notes == [REASON_NO_PROVENANCE]
+
+    def test_notes_deduplicated_and_ordered(self):
+        old = AbiSnapshot(library="l", version="1", scope_fallback="mangling-fallback")
+        new = AbiSnapshot(library="l", version="2", scope_fallback="mangling-fallback")
+        _, notes = surface_scope_confidence(old, new, scope_enabled=False)
+        assert notes == ["mangling-fallback"]  # both sides collapse to one
+
+
+# ── no-provenance reason on a reachability demotion ───────────────────────────
+
+
+class TestNoProvenanceReason:
+    def test_reachability_demotion_with_provenance_present(self):
+        # One type carries provenance (public header); an unreferenced type with
+        # no origin is demoted by reachability → no-provenance (not plain
+        # non-public-type), disclosing the demotion was not provenance-confirmed.
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *", origin=ScopeOrigin.PUBLIC_HEADER)],
+            types=[
+                _rec("Public", origin=ScopeOrigin.PUBLIC_HEADER),
+                _rec("Orphan", origin=ScopeOrigin.UNKNOWN),
+            ],
+        )
+        s = compute_public_surface(snap)
+        assert s.has_provenance is True
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Orphan", description="")
+        assert classify_change_surface(c, s, s) == (False, REASON_NO_PROVENANCE)
+
+    def test_reachability_demotion_without_provenance_stays_non_public(self):
+        # No provenance anywhere → keep the plain reachability reason (regression
+        # guard for the pre-Phase-1 behaviour).
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *")],
+            types=[_rec("Public"), _rec("Orphan")],
+        )
+        s = compute_public_surface(snap)
+        assert s.has_provenance is False
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Orphan", description="")
+        assert classify_change_surface(c, s, s) == (False, REASON_NON_PUBLIC_TYPE)
+
+
+# ── ledger disclosure (JSON + SARIF) ──────────────────────────────────────────
+
+
+class TestLedgerConfidenceDisclosure:
+    def _result_with_fallback(self):
+        old = AbiSnapshot(
+            library="l.dll", version="1",
+            functions=[_fn("api", ret="Public *", origin=ScopeOrigin.PUBLIC_HEADER)],
+            types=[_rec("Public", size=64, origin=ScopeOrigin.PUBLIC_HEADER)],
+            scope_fallback="mangling-fallback",
+        )
+        new = AbiSnapshot(
+            library="l.dll", version="2",
+            functions=[_fn("api", ret="Public *", origin=ScopeOrigin.PUBLIC_HEADER)],
+            types=[_rec("Public", size=128, origin=ScopeOrigin.PUBLIC_HEADER)],
+            scope_fallback="mangling-fallback",
+        )
+        return compare(old, new, scope_to_public_surface=True)
+
+    def test_json_ledger_includes_confidence_and_notes(self):
+        d = json.loads(to_json(self._result_with_fallback()))
+        ledger = d["surface_scope"]
+        assert ledger["confidence"] == "reduced"
+        assert "mangling-fallback" in ledger["notes"]
+
+    def test_sarif_ledger_includes_confidence_and_notes(self):
+        props = to_sarif(self._result_with_fallback())["runs"][0]["properties"]
+        ledger = props["surfaceScope"]
+        assert ledger["confidence"] == "reduced"
+        assert "mangling-fallback" in ledger["notes"]
+
+    def test_clean_result_high_confidence(self):
+        old = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *", origin=ScopeOrigin.PUBLIC_HEADER)],
+            types=[_rec("Public", size=64, origin=ScopeOrigin.PUBLIC_HEADER)],
+        )
+        new = AbiSnapshot(
+            library="l", version="2",
+            functions=[_fn("api", ret="Public *", origin=ScopeOrigin.PUBLIC_HEADER)],
+            types=[_rec("Public", size=64, origin=ScopeOrigin.PUBLIC_HEADER)],
+        )
+        d = json.loads(to_json(compare(old, new, scope_to_public_surface=True)))
+        assert d["surface_scope"]["confidence"] == "high"
+        assert d["surface_scope"]["notes"] == []

--- a/tests/test_surface_confidence.py
+++ b/tests/test_surface_confidence.py
@@ -125,6 +125,74 @@ class TestNoProvenanceReason:
         assert classify_change_surface(c, s, s) == (False, REASON_NON_PUBLIC_TYPE)
 
 
+# ── anti-hiding: export-only snapshots have no trustworthy type roots ─────────
+
+
+class TestExportOnlyAntiHiding:
+    """A PE binary whose header scoping fell back to the export table has
+    functions with ``return_type="?"`` and no params, so the reachability
+    closure has no roots. Demoting a type as "unreachable" there would hide a
+    real public ABI break (ADR-024 §D5.2 / Codex P1). The classifier must keep
+    such type findings unless provenance *confirms* they are private/system.
+    """
+
+    def _export_only_fn(self, name):
+        # Mirrors service._dump_pe export-table functions.
+        return Function(name=name, mangled=name, return_type="?", visibility=Visibility.PUBLIC)
+
+    def test_public_header_type_not_hidden_on_fallback(self):
+        # A PUBLIC_HEADER PDB type whose layout changed must stay in surface
+        # even though no typed function reaches it.
+        old = AbiSnapshot(
+            library="l.dll", version="1",
+            functions=[self._export_only_fn("Api")],
+            types=[_rec("Widget", size=64, origin=ScopeOrigin.PUBLIC_HEADER)],
+        )
+        new = AbiSnapshot(
+            library="l.dll", version="2",
+            functions=[self._export_only_fn("Api")],
+            types=[_rec("Widget", size=128, origin=ScopeOrigin.PUBLIC_HEADER)],
+        )
+        s_old, s_new = compute_public_surface(old), compute_public_surface(new)
+        assert s_old.has_typed_roots is False
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Widget", description="")
+        # Kept in surface — NOT demoted as non-public-type.
+        assert classify_change_surface(c, s_old, s_new) == (True, None)
+
+    def test_private_header_type_still_demoted_on_fallback(self):
+        # Confident provenance still demotes — anti-hiding does not block a
+        # genuinely private type.
+        old = AbiSnapshot(
+            library="l.dll", version="1",
+            functions=[self._export_only_fn("Api")],
+            types=[_rec("Internal", size=64, origin=ScopeOrigin.PRIVATE_HEADER)],
+        )
+        new = AbiSnapshot(
+            library="l.dll", version="2",
+            functions=[self._export_only_fn("Api")],
+            types=[_rec("Internal", size=128, origin=ScopeOrigin.PRIVATE_HEADER)],
+        )
+        s_old, s_new = compute_public_surface(old), compute_public_surface(new)
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Internal", description="")
+        in_surf, reason = classify_change_surface(c, s_old, s_new)
+        assert in_surf is False
+        assert reason == "private-header"
+
+    def test_typed_roots_still_demote_unreachable_type(self):
+        # Regression guard: with real typed roots, reachability demotion is
+        # still active (this is the normal castxml/ELF path).
+        old = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *")],
+            types=[_rec("Public"), _rec("Unreached")],
+        )
+        s = compute_public_surface(old)
+        assert s.has_typed_roots is True
+        c = Change(kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Unreached", description="")
+        in_surf, _ = classify_change_surface(c, s, s)
+        assert in_surf is False
+
+
 # ── ledger disclosure (JSON + SARIF) ──────────────────────────────────────────
 
 

--- a/tests/test_surface_property.py
+++ b/tests/test_surface_property.py
@@ -276,8 +276,15 @@ def test_widening_only_repromotes_never_hides_or_invents(
         scope_to_public_surface=True, force_public_symbols=forced,
     )
 
-    # Re-promotion only adds to the reported set …
-    assert _change_keys(scoped.changes) <= _change_keys(widened.changes)
+    # Re-promotion keeps every scoped change *reported* — as a normal or a
+    # redundant change. Widening can relabel a change between the two buckets
+    # (re-promoting a root finding absorbs its now-redundant dependents, e.g. a
+    # type removal absorbing a function whose return type was that type), but it
+    # never pushes a kept finding back into the ledger. The total universe is
+    # asserted unchanged below; here we only forbid a kept→hidden transition.
+    assert _change_keys(scoped.changes) <= (
+        _change_keys(widened.changes) | _change_keys(widened.redundant_changes)
+    )
     # … only removes from the ledger …
     assert _change_keys(widened.out_of_surface_changes) <= _change_keys(
         scoped.out_of_surface_changes


### PR DESCRIPTION
## Summary

Finishes the remaining ADR-024 ("Public ABI Surface Resolution") loose ends and moves the ADR from **Proposed → Accepted**. Four tails were outstanding; all are now done.

### 1. PDB provenance (Phase 1) — the main gap
The ELF/castxml paths already tagged declaration provenance, but PDB did not (`source_header`/`origin` were never populated on Windows).

- Parse the IPI stream's `LF_UDT_SRC_LINE` / `LF_UDT_MOD_SRC_LINE` (+ `LF_STRING_ID`) records to map each user-defined type to its defining source file (`pdb_parser.extract_udt_source_files`).
- Carry it as `decl_file` on `DwarfMetadata` `StructLayout` / `EnumInfo`.
- Bridge PDB-derived layouts into model `RecordType` / `EnumType` with their `source_location` (new `pdb_model.py`), invoked on the PE header-scoping **fallback** branch so it stays bounded and default PE diffs are unchanged.
- Lift the CLI block that rejected `--public-header` / `--public-header-dir` for PE/Mach-O, and run `apply_provenance` for those formats. This lets `apply_provenance` classify a `ScopeOrigin` for PDB types, completing PDB → model → surface.

### 2. Missing ledger reason codes (D5.1)
- New `no-provenance` per-finding reason: a reachability demotion made while provenance *was* available for the snapshot but not for the demoted type (reduced confidence, not a confident verdict).

### 3. Structured confidence signals (D5.3)
- The dumper records a machine-readable `scope_fallback` (`castxml-unavailable` / `mangling-fallback`) on the snapshot, alongside the existing `UserWarning`.
- The surface ledger now discloses `confidence` (`high` / `reduced`) plus structured `notes` in both JSON (`surface_scope`) and SARIF (`surfaceScope`).

### 4. ADR status
- ADR-024 → **Accepted**; Phase 1 PDB marked done; D5.1/D5.3 notes updated; `output-formats.md` documents the new reason and the confidence/notes fields.

## Testing
- `tests/test_pdb_provenance.py` — IPI source-line parser, `decl_file` plumbing, and the `DwarfMetadata` → model bridge feeding `apply_provenance` (synthetic buffers, runs on Linux).
- `tests/test_surface_confidence.py` — `scope_fallback`/`no-provenance` notes, the `no-provenance` reason, and JSON/SARIF ledger disclosure.
- Full fast suite: **6859 passed**. `ruff`, `mypy`, AI-readiness gate, and FP-rate gate all clean.

## Caveat
The PDB end-to-end path (PDB → model → surface) is validated here only at the parser/metadata/bridge layers via synthetic-buffer unit tests — there is no MSVC/`.pdb` fixture in this environment. Full Windows e2e remains covered by the `msvc` CI lane. The MSVC C++ name-mangling gap is unchanged (now disclosed as a `mangling-fallback` confidence note rather than silently).

https://claude.ai/code/session_012G3DF54BFGqsNwpEYjSErZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012G3DF54BFGqsNwpEYjSErZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public-ABI surface resolution now emits structured scope-confidence and notes; provenance-aware demotion refines type reachability and keeps findings when header-typed roots are missing
  * Declaration provenance from debug data is captured and attached to native snapshots; scope-fallback is recorded

* **Bug Fixes**
  * Improved PE/Mach-O dump behavior when public-header scoping is requested, including provenance-backed fallbacks

* **Documentation**
  * User guide and ADR updated to document confidence, notes, and fallback reasons in JSON/SARIF

* **Tests**
  * Added coverage for provenance extraction, scope-confidence, fallbacks, and ledger serialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->