### PR TITLE
test(scenarios): add change-archetype, JSON-contract, and platform scenarios

### DIFF
--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -21,10 +21,10 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 | `reporting.yaml` | report formats — JSON contract, SARIF, JUnit, HTML, review digest |
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
-| `platform_coverage.yaml` | native Windows PE/macOS Mach-O compare, plugin host↔plugin contract (planned) |
+| `platform_coverage.yaml` | Linux ELF baseline (automated); native Windows PE/macOS Mach-O, plugin host↔plugin contract (planned) |
 | `archetype_coverage.yaml` | kernel-BTF, SYCL plugin, static library, header-only (planned) |
 
-There are currently **42 scenarios** (26 automated end-to-end + 16 planned).
+There are currently **44 scenarios** (28 automated end-to-end + 16 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -17,12 +17,14 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 | `ci_gating.yaml` | CI ABI gating — exit-code contract, severity gate, `--stat`, malformed-input degraded mode |
 | `compliance_scanning.yaml` | public-surface scoping (issue #235), suppression (+ expiry), policy profiles |
 | `change_archetypes.yaml` | per-archetype canonical breaks — C struct layout, C++ vtable, exported data |
+| `toolchain_coverage.yaml` | build/toolchain-driven shifts — dual-ABI flip, LP64↔ILP64, flag drift |
 | `reporting.yaml` | report formats — JSON contract, SARIF, JUnit, HTML, review digest |
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
 | `platform_coverage.yaml` | native Windows PE/macOS Mach-O compare, plugin host↔plugin contract (planned) |
+| `archetype_coverage.yaml` | kernel-BTF, SYCL plugin, static library, header-only (planned) |
 
-There are currently **35 scenarios** (23 automated end-to-end + 12 planned).
+There are currently **42 scenarios** (26 automated end-to-end + 16 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -14,13 +14,15 @@ file. `tests/test_scenarios.py` merges every `tests/scenarios/*.yaml`:
 
 | File | Group |
 |---|---|
-| `ci_gating.yaml` | CI ABI gating — exit-code contract, severity gate, `--stat` |
+| `ci_gating.yaml` | CI ABI gating — exit-code contract, severity gate, `--stat`, malformed-input degraded mode |
 | `compliance_scanning.yaml` | public-surface scoping (issue #235), suppression (+ expiry), policy profiles |
-| `reporting.yaml` | report formats — SARIF, JUnit, HTML |
+| `change_archetypes.yaml` | per-archetype canonical breaks — C struct layout, C++ vtable, exported data |
+| `reporting.yaml` | report formats — JSON contract, SARIF, JUnit, HTML, review digest |
 | `release_management.yaml` | release recommendation, offline snapshots, baseline registry |
 | `consumer_deployment.yaml` | compare-release, appcompat, stack-check/deps, ABICC, Debian, MCP (planned) |
+| `platform_coverage.yaml` | native Windows PE/macOS Mach-O compare, plugin host↔plugin contract (planned) |
 
-There are currently **27 scenarios** (18 automated end-to-end + 9 planned).
+There are currently **35 scenarios** (23 automated end-to-end + 12 planned).
 
 Add a new group by dropping in a new `*.yaml`; add a scenario by appending to an
 existing group. Scenario ids must be unique across all files.

--- a/tests/scenarios/archetype_coverage.yaml
+++ b/tests/scenarios/archetype_coverage.yaml
@@ -1,0 +1,98 @@
+# Scenario group: library-archetype coverage (planned — need real BTF/CTF
+# blobs, a SYCL plugin, an `ar` archive, or a libclang header-AST, so they are
+# defined now and automated as the G4/G6/G8 capabilities land). These close the
+# documented header-only (G4), kernel-BTF / SYCL (G6), and static-library (G8)
+# archetype gaps in the use-case registry.
+#
+# See tests/scenarios/README.md for the catalog format and how it is validated.
+schema_version: 1
+
+scenarios:
+  - id: SC-KERNEL-BTF-FIELD
+    title: Kernel struct gains a field — BTF-based ABI compare for modules
+    persona: Kernel / eBPF module maintainer
+    narrative: >
+      An out-of-tree module or eBPF program is built against a kernel's BTF. When
+      a kernel struct gains a field (changing its layout), modules compiled
+      against the old BTF are ABI-incompatible. The scanner must compare two BTF
+      blobs (module vs vmlinux, or old vs new kernel) and report the layout break.
+    flow:
+      - abicheck compare old.btf new.btf --btf
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-ARCH-kernel-btf
+    automated: false
+    status: planned
+    plan: docs/development/plans/g6-kernel-btf-and-accelerator.md
+    note: >
+      BTF/CTF parsing is unit-tested (tests/test_btf_metadata.py). Full
+      automation needs real BTF blob fixtures and a documented "module vs
+      vmlinux BTF" workflow so the compare runs end-to-end.
+
+  - id: SC-SYCL-PLUGIN-SURFACE
+    title: SYCL / accelerator plugin interface (PI/UR) surface change is caught
+    persona: Heterogeneous-runtime maintainer
+    narrative: >
+      A SYCL runtime exposes a plugin interface (PI/UR) that backends implement.
+      Removing or reshaping a plugin entrypoint breaks every backend. The scanner
+      must read the SYCL plugin surface and report the contract change at the
+      workflow level, not only via low-level symbol diffing.
+    flow:
+      - abicheck compare old.so new.so -H sycl/ --sycl
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-ARCH-sycl
+    automated: false
+    status: planned
+    plan: docs/development/plans/g6-kernel-btf-and-accelerator.md
+    note: >
+      SYCL metadata + diff is unit-tested (tests/test_diff_sycl.py) and there is
+      a change-type example (examples/case82_sycl_overload_set_removed). Full
+      automation needs a SYCL plugin fixture wired into a workflow-level run;
+      CUDA is deferred.
+
+  - id: SC-STATIC-LIB-LINK
+    title: Static library (.a/.lib) member removed — link-time API break is caught
+    persona: SDK maintainer shipping static archives
+    narrative: >
+      Some SDKs ship static archives. Removing or reshaping a public symbol in an
+      archive member breaks consumers at link time. The scanner must iterate the
+      archive members and report the link-time API break (or this archetype must
+      be documented as an explicit non-goal).
+    flow:
+      - abicheck compare old.a new.a -H include/
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-ARCH-static-lib
+    automated: false
+    status: planned
+    plan: docs/development/plans/g8-static-libraries.md
+    note: >
+      Scope is still open (iterate `ar` members vs. document as a non-goal —
+      see the G8 plan). Defined here so the decision and its workflow are tracked.
+
+  - id: SC-HEADER-ONLY-CONCEPT
+    title: Header-only library tightens a concept — source-only API break is caught
+    persona: Header-only / inline-only library maintainer
+    narrative: >
+      A header-only library has no shared object, so the contract lives entirely
+      in headers. Tightening a concept, changing a hidden friend, or altering an
+      inline signature is a source break consumers hit on recompile. The scanner
+      must extract the header AST and report the API break with no binary to diff.
+    flow:
+      - abicheck compare old/ new/ -H include/ --lang c++
+    expected:
+      exit_code: 2
+      verdict: API_BREAK
+    validates: UC-ARCH-header-only
+    automated: false
+    status: planned
+    plan: docs/development/plans/g4-header-ast-extractor.md
+    note: >
+      castxml-based extraction exists (abicheck/dumper_castxml.py) but cannot
+      resolve concept tightening / hidden friends / user-ctor mangled names
+      (dormant fixtures: cases 78/105/106/111). Full automation needs the
+      libclang-based header-AST extractor from the G4 plan.

--- a/tests/scenarios/change_archetypes.yaml
+++ b/tests/scenarios/change_archetypes.yaml
@@ -1,0 +1,62 @@
+# Scenario group: change-archetype coverage — prove the scanner catches the
+# canonical ABI break in each library archetype (pure-C layout, C++ vtable,
+# exported data), not just the function-removal case the other groups lean on.
+#
+# See tests/scenarios/README.md for the catalog format and how it is validated.
+schema_version: 1
+
+scenarios:
+  - id: SC-C-STRUCT-LAYOUT
+    title: Pure-C struct grows a field — by-value layout break is caught
+    persona: Library maintainer (pure-C library)
+    narrative: >
+      A pure-C library adds a member to a struct that a public function takes by
+      value. The struct's size changes, so every caller compiled against the old
+      layout is now ABI-incompatible. The scanner must report a binary break
+      (exit 4, type_size_changed) even though no symbol was added or removed.
+    flow:
+      - abicheck compare old.json new.json
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+      contains_kind: type_size_changed
+    validates: UC-ARCH-c-library
+    automated: true
+    test: test_sc_c_struct_layout
+
+  - id: SC-CPP-VTABLE-BREAK
+    title: C++ polymorphic class reorders its vtable — subclass break is caught
+    persona: Library maintainer (C++ library)
+    narrative: >
+      A new virtual function is inserted into a polymorphic base class, shifting
+      every later vtable slot. Subclasses and call sites compiled against the old
+      vtable now dispatch to the wrong slot — a classic silent C++ ABI break the
+      export table alone cannot see. The scanner must flag it (exit 4,
+      type_vtable_changed).
+    flow:
+      - abicheck compare old.json new.json --no-scope-public-headers
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+      contains_kind: type_vtable_changed
+    validates: UC-ARCH-cpp-library
+    automated: true
+    test: test_sc_cpp_vtable_break
+
+  - id: SC-EXPORTED-VAR-REMOVED
+    title: Exported global variable removed — data surface break is caught
+    persona: Library maintainer
+    narrative: >
+      Compatibility is not only about functions. A library drops a public
+      exported global variable; any consumer that referenced it fails to link or
+      load. The scanner must treat the data surface like the function surface and
+      report a binary break (exit 4, var_removed).
+    flow:
+      - abicheck compare old.json new.json --no-scope-public-headers
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+      contains_kind: var_removed
+    validates: UC-CHANGE-taxonomy
+    automated: true
+    test: test_sc_exported_var_removed

--- a/tests/scenarios/ci_gating.yaml
+++ b/tests/scenarios/ci_gating.yaml
@@ -82,6 +82,24 @@ scenarios:
     automated: true
     test: test_sc_ci_stat
 
+  - id: SC-MALFORMED-INPUT
+    title: Corrupt snapshot fails the run cleanly (degraded-mode contract)
+    persona: CI engineer
+    narrative: >
+      A gate is only trustworthy if its failure modes are predictable. When a
+      snapshot is corrupt or unreadable (truncated artifact, bad upload), the
+      scanner must not crash with a traceback or — worse — exit 0 and look clean.
+      It exits non-zero (1) with a clear "failed to load" diagnostic so the
+      pipeline distinguishes a tooling error from a compatibility verdict.
+    flow:
+      - abicheck compare good.json corrupt.json
+    expected:
+      exit_code: 1
+      output_contains: "Failed to load"
+    validates: UC-WF-compare
+    automated: true
+    test: test_sc_malformed_input
+
   # G2: fold build-config (probe-matrix) findings into the mainline gate.
   - id: SC-PROBE-MATRIX-GATE
     title: Build-config findings (C++ floor) gate via probe matrices in compare

--- a/tests/scenarios/platform_coverage.yaml
+++ b/tests/scenarios/platform_coverage.yaml
@@ -1,12 +1,31 @@
-# Scenario group: platform & archetype coverage (planned — need native
-# PE/Mach-O binaries or a host/plugin pair, so they are defined now and
-# automated once the cross-platform e2e lanes land). These close the
-# documented G1 (Windows/macOS e2e) and G5 (plugin contract) gaps.
+# Scenario group: platform coverage. The Linux ELF baseline is automated (it is
+# the CI-validated reference platform); the native PE/Mach-O and host/plugin
+# lanes are planned — they need native binaries, so they are defined now and
+# automated once the cross-platform e2e lanes land. These close the documented
+# G1 (Windows/macOS e2e) and G5 (plugin contract) gaps.
 #
 # See tests/scenarios/README.md for the catalog format and how it is validated.
 schema_version: 1
 
 scenarios:
+  - id: SC-LINUX-ELF-BASELINE
+    title: Linux ELF compare — the CI-validated reference platform
+    persona: Library maintainer (Linux)
+    narrative: >
+      Linux ELF is abicheck's validated baseline platform. A SONAME-versioned
+      shared object drops a public symbol; comparing the two ELF snapshots must
+      report a binary break (exit 4) and recommend a major bump / SONAME action,
+      exactly as every consumer would experience at load time. This anchors the
+      platform axis with an automated end-to-end ELF flow.
+    flow:
+      - abicheck compare old.json new.json
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-PLAT-linux-elf
+    automated: true
+    test: test_sc_linux_elf_baseline
+
   - id: SC-WINDOWS-PE-COMPARE
     title: Compare two native Windows PE/COFF DLLs (MSVC + PDB)
     persona: Windows library maintainer

--- a/tests/scenarios/platform_coverage.yaml
+++ b/tests/scenarios/platform_coverage.yaml
@@ -1,0 +1,79 @@
+# Scenario group: platform & archetype coverage (planned — need native
+# PE/Mach-O binaries or a host/plugin pair, so they are defined now and
+# automated once the cross-platform e2e lanes land). These close the
+# documented G1 (Windows/macOS e2e) and G5 (plugin contract) gaps.
+#
+# See tests/scenarios/README.md for the catalog format and how it is validated.
+schema_version: 1
+
+scenarios:
+  - id: SC-WINDOWS-PE-COMPARE
+    title: Compare two native Windows PE/COFF DLLs (MSVC + PDB)
+    persona: Windows library maintainer
+    narrative: >
+      A maintainer builds a DLL with MSVC and ships a PDB alongside it. Comparing
+      two versions must surface the same ABI breaks abicheck finds on ELF — a
+      removed exported symbol, a changed struct layout — using the PE export table
+      and PDB type info, so Windows is a first-class lane and not ELF-only.
+    flow:
+      - abicheck compare old.dll new.dll --old-pdb-path old.pdb --new-pdb-path new.pdb -H include/
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-PLAT-windows-pe
+    automated: false
+    status: planned
+    plan: docs/development/plans/g1-cross-platform-e2e.md
+    note: >
+      PE/COFF + PDB parsing is unit-tested (tests/test_pe_metadata_unit.py,
+      tests/test_pdb_metadata.py) and a smoke e2e lane exists
+      (tests/test_msvc_pdb_e2e.py, marked `msvc`). Full automation needs native
+      MSVC-built DLL/PDB fixtures so -H scoping and the export+PDB merge are
+      exercised end-to-end rather than via JSON snapshots.
+
+  - id: SC-MACOS-DYLIB-COMPARE
+    title: Compare two native macOS Mach-O dylibs (x86-64 / ARM64)
+    persona: macOS library maintainer
+    narrative: >
+      A maintainer compares two versions of a .dylib on macOS. The scanner must
+      read the Mach-O export trie and report breaks consistently with the ELF
+      lane, including ARM64 calling-convention-sensitive struct changes (HFA/HVA
+      and small-struct passing).
+    flow:
+      - abicheck compare old.dylib new.dylib -H include/
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-PLAT-macos-macho
+    automated: false
+    status: planned
+    plan: docs/development/plans/g1-cross-platform-e2e.md
+    note: >
+      Mach-O parsing is unit-tested (tests/test_macho_metadata_unit.py,
+      tests/test_macos_arm64_abi.py). Full automation needs a macOS CI lane with
+      native dylib fixtures so the export trie and ARM64 ABI paths run end-to-end.
+
+  - id: SC-PLUGIN-HOST-CONTRACT
+    title: Validate a host↔plugin dlopen contract in both directions
+    persona: Plugin platform engineer
+    narrative: >
+      A plugin host loads plugins via dlopen against a published contract. Unlike
+      a linked consumer, the contract is bidirectional: the host must keep
+      exporting the entrypoints plugins import, AND plugins must keep exporting
+      the entrypoints the host resolves. The scanner must check both directions
+      so neither side silently breaks the load contract.
+    flow:
+      - abicheck appcompat ./host plugin-v1.so plugin-v2.so --policy plugin_abi -H contract/
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+    validates: UC-ARCH-plugin
+    automated: false
+    status: planned
+    plan: docs/development/plans/g5-plugin-bidirectional-contract.md
+    note: >
+      The plugin_abi policy and consumer-scoped appcompat are unit-tested
+      (tests/test_appcompat.py, tests/test_workflow_scenarios.py). Full automation
+      needs a host/plugin example pair plus an optional host-contract check
+      (host's required entrypoints vs plugin exports) to cover the reverse
+      direction; today only the forward (plugin-exports) direction is validated.

--- a/tests/scenarios/reporting.yaml
+++ b/tests/scenarios/reporting.yaml
@@ -21,6 +21,28 @@ scenarios:
     automated: true
     test: test_sc_scan_sarif
 
+  - id: SC-CONSUME-JSON
+    title: Consume the versioned JSON report as the machine decision contract
+    persona: CI engineer / automation
+    narrative: >
+      Exit codes alone are lossy (exit 0 covers NO_CHANGE / COMPATIBLE /
+      COMPATIBLE_WITH_RISK), so any non-trivial gate — including the oneDAL
+      strict gate — keys off the JSON report instead. That report is a stable,
+      versioned contract: it must carry report_schema_version, a top-level
+      verdict, and a per-finding changes list a decision script can branch on.
+    flow:
+      - abicheck compare old.json new.json --format json -o abi.json
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+      require_summary_fields:
+        - report_schema_version
+        - verdict
+        - changes
+    validates: UC-REP-json
+    automated: true
+    test: test_sc_consume_json
+
   - id: SC-SCAN-JUNIT
     title: Produce JUnit XML for CI test dashboards
     persona: CI engineer

--- a/tests/scenarios/toolchain_coverage.yaml
+++ b/tests/scenarios/toolchain_coverage.yaml
@@ -63,3 +63,24 @@ scenarios:
     validates: UC-TC-flag-drift
     automated: true
     test: test_sc_toolchain_flag_drift
+
+  - id: SC-CXX-STD-FLOOR
+    title: Raised C++ standard floor is a per-consumer source break
+    persona: Library maintainer (header-driven C++ contract)
+    narrative: >
+      The binary surface is unchanged, but a build raises the minimum C++
+      standard a consumer must compile with (17 → 20). That is invisible to a
+      per-binary diff yet breaks every consumer still on the old standard. Feeding
+      the build-config probe matrices to compare folds CXX_STANDARD_FLOOR_RAISED
+      into the verdict, turning a NO_CHANGE binary diff into an API_BREAK (exit 2).
+      (Companion to SC-PROBE-MATRIX-GATE, which validates the probe-matrix
+      *workflow*; this scenario validates the *toolchain* use case it surfaces.)
+    flow:
+      - abicheck compare old.json new.json --probe-matrix-old old.matrix.json --probe-matrix-new new.matrix.json
+    expected:
+      exit_code: 2
+      verdict: API_BREAK
+      contains_kind: cxx_standard_floor_raised
+    validates: UC-TC-cxx-standard-floor
+    automated: true
+    test: test_sc_cxx_std_floor

--- a/tests/scenarios/toolchain_coverage.yaml
+++ b/tests/scenarios/toolchain_coverage.yaml
@@ -1,0 +1,65 @@
+# Scenario group: toolchain / language-standard coverage — prove the scanner
+# catches ABI shifts that come from how the library was *built*, not from an
+# edited declaration: a libstdc++ dual-ABI flip, an LP64<->ILP64 integer-model
+# switch, and ABI-affecting compiler-flag drift.
+#
+# See tests/scenarios/README.md for the catalog format and how it is validated.
+schema_version: 1
+
+scenarios:
+  - id: SC-DUAL-ABI-FLIP
+    title: libstdc++ dual-ABI flip is reported as one diagnostic, not symbol noise
+    persona: Library maintainer (C++ / libstdc++)
+    narrative: >
+      Toggling _GLIBCXX_USE_CXX11_ABI re-mangles every std::string / std::list
+      symbol (std::basic_string vs std::__cxx11::basic_string), so a naive diff
+      sees hundreds of add/remove pairs. The scanner must recognise the pattern
+      and emit a single glibcxx_dual_abi_flip_detected diagnostic — and it is a
+      real break (exit 4) because callers built against the other ABI won't link.
+    flow:
+      - abicheck compare old.json new.json --no-scope-public-headers
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+      contains_kind: glibcxx_dual_abi_flip_detected
+    validates: UC-TC-dual-abi
+    automated: true
+    test: test_sc_dual_abi_flip
+
+  - id: SC-INTEGER-MODEL-FLIP
+    title: LP64<->ILP64 integer-model switch (e.g. MKL_INT 32<->64) is caught
+    persona: Numerical-library maintainer
+    narrative: >
+      A library ships a 32-bit and a 64-bit integer interface (the classic
+      oneMKL MKL_INT story). Flipping the model changes the width every caller
+      passes and reads, with no symbol added or removed. The scanner must detect
+      the corroborating integer-typedef width flip and report a binary break
+      (exit 4, integer_model_changed).
+    flow:
+      - abicheck compare old.json new.json --no-scope-public-headers
+    expected:
+      exit_code: 4
+      verdict: BREAKING
+      contains_kind: integer_model_changed
+    validates: UC-TC-modern-cxx-types
+    automated: true
+    test: test_sc_integer_model_flip
+
+  - id: SC-TOOLCHAIN-FLAG-DRIFT
+    title: ABI-affecting compiler-flag drift is surfaced as a risk, not a hard fail
+    persona: Release engineer
+    narrative: >
+      Two builds of the same sources differ only in ABI-affecting compiler flags
+      (recorded in DWARF DW_AT_producer / toolchain metadata). The scanner must
+      surface toolchain_flag_drift so reviewers see the build changed — but treat
+      it as a risk signal rather than a confirmed break, so the default gate does
+      not fail (exit 0) on a flag change alone.
+    flow:
+      - abicheck compare old.json new.json --no-scope-public-headers
+    expected:
+      exit_code: 0
+      verdict: COMPATIBLE
+      contains_kind: toolchain_flag_drift
+    validates: UC-TC-flag-drift
+    automated: true
+    test: test_sc_toolchain_flag_drift

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -704,3 +704,70 @@ def test_sc_toolchain_flag_drift(tmp_path: Path) -> None:
     doc = json.loads(res.output)
     assert doc["verdict"] == "COMPATIBLE"
     assert any(c["kind"] == "toolchain_flag_drift" for c in doc["changes"])
+
+
+def test_sc_cxx_std_floor(tmp_path: Path) -> None:
+    # The toolchain use case behind the probe matrix: identical binary surfaces,
+    # but the build raises the C++ standard floor 17 → 20. A per-binary diff is
+    # NO_CHANGE; passing the probe matrices folds CXX_STANDARD_FLOOR_RAISED into
+    # the verdict, surfacing the per-consumer source break (API_BREAK, exit 2).
+    from abicheck.probe_harness import (
+        MatrixSnapshot,
+        ProbeResult,
+        write_matrix_snapshot,
+    )
+
+    same = [_fn("a")]
+    o = _save(_lib("1", list(same)), tmp_path / "o.json")
+    n = _save(_lib("2", list(same)), tmp_path / "n.json")
+    assert _cli("compare", o, n).exit_code == 0  # binary surface unchanged
+
+    def _matrix(version: str, std: int) -> MatrixSnapshot:
+        return MatrixSnapshot(
+            library="libfoo",
+            version=version,
+            spec_name="t",
+            cxx_stds={"a": std},
+            results=[
+                ProbeResult(
+                    configuration_id="a",
+                    probe_id="p0",
+                    snapshot=_lib(version, list(same)),
+                )
+            ],
+        )
+
+    om, nm = str(tmp_path / "om.json"), str(tmp_path / "nm.json")
+    write_matrix_snapshot(_matrix("1", 17), om)
+    write_matrix_snapshot(_matrix("2", 20), nm)
+    res = _cli(
+        "compare",
+        o,
+        n,
+        "--format",
+        "json",
+        "--probe-matrix-old",
+        om,
+        "--probe-matrix-new",
+        nm,
+    )
+    assert res.exit_code == 2
+    doc = json.loads(res.stdout)
+    assert doc["verdict"] == "API_BREAK"
+    assert any(c["kind"] == "cxx_standard_floor_raised" for c in doc["changes"])
+
+
+def test_sc_linux_elf_baseline(tmp_path: Path) -> None:
+    # The validated baseline platform: an explicit ELF compare (platform="elf",
+    # SONAME-versioned) where a public symbol is removed → binary break (exit 4)
+    # with a major-bump recommendation, as a consumer would hit at load time.
+    from abicheck.elf_metadata import ElfMetadata
+
+    elf = ElfMetadata(soname="libfoo.so.1")
+    old = _lib("1", [_fn("a"), _fn("b")], platform="elf", elf=elf)
+    new = _lib("2", [_fn("a")], platform="elf", elf=ElfMetadata(soname="libfoo.so.1"))
+    res = _compare(tmp_path, old, new, "--format", "json")
+    assert res.exit_code == 4
+    doc = json.loads(res.output)
+    assert doc["verdict"] == "BREAKING"
+    assert doc["release_recommendation"]["version_bump"] == "major"

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -40,6 +40,7 @@ import yaml
 from click.testing import CliRunner
 
 from abicheck.cli import main
+from abicheck.dwarf_advanced import AdvancedDwarfMetadata
 from abicheck.model import (
     AbiSnapshot,
     EnumMember,
@@ -650,3 +651,56 @@ def test_sc_exported_var_removed(tmp_path: Path) -> None:
     doc = json.loads(res.output)
     assert doc["verdict"] == "BREAKING"
     assert any(c["kind"] == "var_removed" for c in doc["changes"])
+
+
+def test_sc_dual_abi_flip(tmp_path: Path) -> None:
+    # libstdc++ dual-ABI flip: the std::string family re-mangles when
+    # _GLIBCXX_USE_CXX11_ABI toggles. A naive diff sees mass add/remove churn;
+    # the scanner must recognise the __cxx11 marker pattern and emit one grouped
+    # glibcxx_dual_abi_flip_detected (still a real break: exit 4).
+    legacy = [_fn(f"_ZN3foo3barESs{i}") for i in range(6)]  # no __cxx11 marker
+    cxx11 = [_fn(f"_ZN3foo3barENSt7__cxx1112basic_stringE{i}") for i in range(6)]
+    res = _compare(
+        tmp_path,
+        _lib("1", legacy),
+        _lib("2", cxx11),
+        "--no-scope-public-headers",
+        "--format",
+        "json",
+    )
+    assert res.exit_code == 4
+    doc = json.loads(res.output)
+    assert doc["verdict"] == "BREAKING"
+    assert any(c["kind"] == "glibcxx_dual_abi_flip_detected" for c in doc["changes"])
+
+
+def test_sc_integer_model_flip(tmp_path: Path) -> None:
+    # LP64↔ILP64 switch: an integer-named typedef (MKL_INT) flips width 32→64.
+    # No symbol added/removed, yet every caller now passes/reads the wrong width
+    # (integer_model_changed → BREAKING).
+    old = _lib("1", [_fn("solve")], typedefs={"MKL_INT": "int"})
+    new = _lib("2", [_fn("solve")], typedefs={"MKL_INT": "int64_t"})
+    res = _compare(tmp_path, old, new, "--no-scope-public-headers", "--format", "json")
+    assert res.exit_code == 4
+    doc = json.loads(res.output)
+    assert doc["verdict"] == "BREAKING"
+    assert any(c["kind"] == "integer_model_changed" for c in doc["changes"])
+
+
+def test_sc_toolchain_flag_drift(tmp_path: Path) -> None:
+    # ABI-affecting compiler flags (recorded in DWARF toolchain metadata) drift
+    # between two builds of the same sources. The scanner surfaces
+    # toolchain_flag_drift as a *risk* signal — visible, but not a confirmed
+    # break, so the default gate stays green (exit 0).
+    def _adv(flags: set[str]) -> AdvancedDwarfMetadata:
+        meta = AdvancedDwarfMetadata(has_dwarf=True)
+        meta.toolchain.abi_flags = flags
+        return meta
+
+    old = _lib("1", [_fn("a")], dwarf_advanced=_adv({"-fno-exceptions"}))
+    new = _lib("2", [_fn("a")], dwarf_advanced=_adv({"-fno-exceptions", "-ffast-math"}))
+    res = _compare(tmp_path, old, new, "--no-scope-public-headers", "--format", "json")
+    assert res.exit_code == 0
+    doc = json.loads(res.output)
+    assert doc["verdict"] == "COMPATIBLE"
+    assert any(c["kind"] == "toolchain_flag_drift" for c in doc["changes"])

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -48,6 +48,7 @@ from abicheck.model import (
     Param,
     RecordType,
     TypeField,
+    Variable,
     Visibility,
 )
 from abicheck.serialization import save_snapshot
@@ -97,6 +98,22 @@ def _fn(name: str, ret: str = "int", params: tuple[str, ...] = ()) -> Function:
         params=[Param(name=f"a{i}", type=t) for i, t in enumerate(params)],
         visibility=Visibility.PUBLIC,
     )
+
+
+def _vfn(mangled: str, vtable_index: int) -> Function:
+    return Function(
+        name=mangled,
+        mangled=mangled,
+        return_type="void",
+        params=[],
+        visibility=Visibility.PUBLIC,
+        is_virtual=True,
+        vtable_index=vtable_index,
+    )
+
+
+def _var(name: str, type: str = "int") -> Variable:
+    return Variable(name=name, mangled=name, type=type, visibility=Visibility.PUBLIC)
 
 
 def _rec(name: str, size: int = 64) -> RecordType:
@@ -387,8 +404,15 @@ def test_sc_policy_profile(tmp_path: Path) -> None:
     new = _lib("2", [_fn("use")], enums=[e2])
     # Mode isn't referenced by a public function, so opt out of default
     # public-header scoping (ADR-024 Phase 5) to exercise the policy contrast.
-    assert _compare(tmp_path, old, new, "--no-scope-public-headers").exit_code == 2  # strict_abi: API break
-    assert _compare(tmp_path, old, new, "--no-scope-public-headers", "--policy", "sdk_vendor").exit_code == 0
+    assert (
+        _compare(tmp_path, old, new, "--no-scope-public-headers").exit_code == 2
+    )  # strict_abi: API break
+    assert (
+        _compare(
+            tmp_path, old, new, "--no-scope-public-headers", "--policy", "sdk_vendor"
+        ).exit_code
+        == 0
+    )
 
 
 def test_sc_probe_matrix_into_compare(tmp_path: Path) -> None:
@@ -411,12 +435,17 @@ def test_sc_probe_matrix_into_compare(tmp_path: Path) -> None:
 
     def _matrix(version: str, std: int) -> MatrixSnapshot:
         return MatrixSnapshot(
-            library="libfoo", version=version, spec_name="t",
+            library="libfoo",
+            version=version,
+            spec_name="t",
             cxx_stds={"a": std},
-            results=[ProbeResult(
-                configuration_id="a", probe_id="p0",
-                snapshot=_lib(version, list(same)),
-            )],
+            results=[
+                ProbeResult(
+                    configuration_id="a",
+                    probe_id="p0",
+                    snapshot=_lib(version, list(same)),
+                )
+            ],
         )
 
     om = str(tmp_path / "om.json")
@@ -425,8 +454,15 @@ def test_sc_probe_matrix_into_compare(tmp_path: Path) -> None:
     write_matrix_snapshot(_matrix("2", 20), nm)
 
     res = _cli(
-        "compare", o, n, "--format", "json",
-        "--probe-matrix-old", om, "--probe-matrix-new", nm,
+        "compare",
+        o,
+        n,
+        "--format",
+        "json",
+        "--probe-matrix-old",
+        om,
+        "--probe-matrix-new",
+        nm,
     )
     assert res.exit_code == 2  # API_BREAK from the build-config finding
     doc = json.loads(res.stdout)
@@ -508,3 +544,109 @@ def test_sc_baseline_registry(tmp_path: Path) -> None:
     )
     # Gate a new build against the pinned baseline pulled from the registry.
     assert _cli("compare", pinned, v2).exit_code == 4
+
+
+def test_sc_consume_json(tmp_path: Path) -> None:
+    # The JSON report is the machine decision contract any non-trivial gate keys
+    # off (exit 0 alone is lossy). It must be a stable, versioned document with a
+    # top-level verdict and a per-finding changes list.
+    res = _compare(
+        tmp_path,
+        _lib("1", [_fn("a"), _fn("b")]),
+        _lib("2", [_fn("a")]),
+        "--format",
+        "json",
+    )
+    assert res.exit_code == 4
+    doc = json.loads(res.output)
+    assert doc["report_schema_version"]  # versioned contract
+    assert doc["verdict"] == "BREAKING"
+    assert isinstance(doc["changes"], list) and doc["changes"]
+
+
+def test_sc_malformed_input(tmp_path: Path) -> None:
+    # Degraded-mode contract: a corrupt snapshot must fail cleanly (exit 1 with a
+    # diagnostic), never crash or silently read as compatible (exit 0).
+    good = _save(_lib("1", [_fn("a")]), tmp_path / "good.json")
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{ not valid json ]", encoding="utf-8")
+    res = _cli("compare", good, str(corrupt))
+    assert res.exit_code == 1
+    assert "Failed to load" in res.output
+
+
+def test_sc_c_struct_layout(tmp_path: Path) -> None:
+    # Pure-C archetype: a public function takes Point by value; growing Point
+    # changes its size, so every caller is ABI-incompatible — no symbol added or
+    # removed, yet a binary break (type_size_changed → BREAKING).
+    def _point(size: int, fields: list[TypeField]) -> RecordType:
+        return RecordType(name="Point", kind="struct", size_bits=size, fields=fields)
+
+    pub = [_fn("use_point", ret="int", params=("Point",))]
+    old = _lib(
+        "1",
+        list(pub),
+        types=[_point(64, [TypeField("x", "int"), TypeField("y", "int")])],
+    )
+    new = _lib(
+        "2",
+        list(pub),
+        types=[
+            _point(
+                96,
+                [TypeField("x", "int"), TypeField("y", "int"), TypeField("z", "int")],
+            )
+        ],
+    )
+    res = _compare(tmp_path, old, new)
+    assert res.exit_code == 4
+    doc = json.loads(_compare(tmp_path, old, new, "--format", "json").output)
+    assert doc["verdict"] == "BREAKING"
+    assert any(c["kind"] == "type_size_changed" for c in doc["changes"])
+
+
+def test_sc_cpp_vtable_break(tmp_path: Path) -> None:
+    # C++ archetype: inserting a virtual into a polymorphic base shifts every
+    # later vtable slot — a silent dispatch break the export table cannot see.
+    def _shape(vtable: list[str]) -> RecordType:
+        return RecordType(
+            name="Shape",
+            kind="class",
+            size_bits=64,
+            fields=[TypeField("_vptr", "void*")],
+            vtable=vtable,
+        )
+
+    old = _lib(
+        "1",
+        [_vfn("_ZN5Shape4areaEv", 0), _vfn("_ZN5Shape9perimeterEv", 1)],
+        types=[_shape(["_ZN5Shape4areaEv", "_ZN5Shape9perimeterEv"])],
+    )
+    new = _lib(
+        "2",
+        [
+            _vfn("_ZN5Shape4areaEv", 0),
+            _vfn("_ZN5Shape4drawEv", 1),
+            _vfn("_ZN5Shape9perimeterEv", 2),
+        ],
+        types=[
+            _shape(["_ZN5Shape4areaEv", "_ZN5Shape4drawEv", "_ZN5Shape9perimeterEv"])
+        ],
+    )
+    res = _compare(tmp_path, old, new, "--no-scope-public-headers", "--format", "json")
+    assert res.exit_code == 4
+    doc = json.loads(res.output)
+    assert doc["verdict"] == "BREAKING"
+    assert any(c["kind"] == "type_vtable_changed" for c in doc["changes"])
+
+
+def test_sc_exported_var_removed(tmp_path: Path) -> None:
+    # Data surface: dropping a public exported global variable breaks every
+    # consumer that referenced it (var_removed → BREAKING), like a removed symbol.
+    old = _lib("1", [_fn("a")], variables=[_var("g_count")])
+    new = _lib("2", [_fn("a")], variables=[])
+    res = _compare(tmp_path, old, new, "--no-scope-public-headers", "--format", "json")
+    assert res.exit_code == 4
+    doc = json.loads(res.output)
+    assert doc["verdict"] == "BREAKING"
+    assert any(c["kind"] == "var_removed" for c in doc["changes"])


### PR DESCRIPTION
## What & why

Following the deep-evaluation of abicheck's scenario framework, this fills concrete **coverage gaps** found by cross-referencing the user-scenario catalog (`tests/scenarios/*.yaml`) against the use-case registry (`docs/development/usecase-registry.yaml`).

The catalog was workflow-heavy but **every existing scenario used function-removal as its change**, leaving several registry use cases with zero end-to-end scenario coverage:

| Registry use case | Was covered? | New scenario |
|---|---|---|
| `UC-REP-json` (versioned JSON contract) | only implicit | **SC-CONSUME-JSON** ✅ |
| `UC-ARCH-c-library` (pure-C struct layout) | no | **SC-C-STRUCT-LAYOUT** ✅ |
| `UC-ARCH-cpp-library` (vtable) | no | **SC-CPP-VTABLE-BREAK** ✅ |
| `UC-CHANGE-taxonomy` (exported data surface) | no | **SC-EXPORTED-VAR-REMOVED** ✅ |
| degraded/failure path | no | **SC-MALFORMED-INPUT** ✅ |
| `UC-PLAT-windows-pe` (G1) | no | **SC-WINDOWS-PE-COMPARE** (planned) |
| `UC-PLAT-macos-macho` (G1) | no | **SC-MACOS-DYLIB-COMPARE** (planned) |
| `UC-ARCH-plugin` (G5) | no | **SC-PLUGIN-HOST-CONTRACT** (planned) |

## Changes

- **New `tests/scenarios/change_archetypes.yaml`** — canonical break per archetype: pure-C struct grows a by-value field (`type_size_changed`), C++ vtable reorder (`type_vtable_changed`), exported global variable removed (`var_removed`).
- **New `tests/scenarios/platform_coverage.yaml`** — planned native Windows PE/PDB, macOS Mach-O, and bidirectional plugin host↔plugin contract scenarios, tied to the existing G1/G5 plans.
- **`reporting.yaml`** — `SC-CONSUME-JSON`: the JSON report is the machine decision contract any non-trivial gate (incl. the oneDAL strict gate) keys off, since exit 0 alone is lossy; asserts `report_schema_version` + `verdict` + `changes`.
- **`ci_gating.yaml`** — `SC-MALFORMED-INPUT`: degraded-mode contract — a corrupt snapshot exits 1 with a clear diagnostic, never crashes or reads as clean (exit 0).
- **`tests/test_scenarios.py`** — 5 new automated end-to-end flows (CliRunner on JSON snapshots, no castxml/gcc) + `_vfn`/`_var` helpers.
- **README** — catalog group table + count updated (27 → 35; 23 automated + 12 planned).

## Verification

- `pytest tests/test_scenarios.py` → **95 passed**
- `ruff check` + `ruff format --check` → clean
- `python scripts/check_ai_readiness.py` → **0 errors** (only pre-existing file-size warnings)

All five automated scenarios were verified to produce the asserted verdicts/kinds before wiring them in.

https://claude.ai/code/session_01UyCQF69SveNiNRp4CaSHoL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyCQF69SveNiNRp4CaSHoL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test scenarios covering C struct layout changes, C++ vtable modifications, exported variable removal, dual ABI flips, integer model changes, toolchain flag drift, and C++ standard floor raises.
  * Added JSON report schema validation and malformed input error handling.

* **Documentation**
  * Expanded test scenario catalog from 27 to 44 total scenarios (18→28 automated, 9→16 planned) with new coverage for archetypes, platforms, and toolchain variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->