### PR TITLE
fix: harden real-world package validation

### DIFF
--- a/.github/workflows/realworld-validation.yml
+++ b/.github/workflows/realworld-validation.yml
@@ -1,0 +1,99 @@
+name: Real-world ABI validation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1"
+  pull_request:
+    paths:
+      - "abicheck/package.py"
+      - "abicheck/cli_compare_release.py"
+      - "abicheck/bundle.py"
+      - "tests/test_package.py"
+      - "tests/test_compare_release.py"
+      - "tests/test_bundle.py"
+      - ".github/workflows/realworld-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu-package-smoke:
+    name: Ubuntu package and bundle smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y castxml gcc g++ binutils zstd abigail-tools zlib1g-dev
+
+      - name: Install abicheck
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Focused regression tests
+        run: |
+          pytest -q \
+            tests/test_package.py::TestDebExtractorExtended \
+            tests/test_package.py::TestDebExtractorNoDataTar \
+            tests/test_compare_release.py::TestCompareReleaseIncludes \
+            tests/test_bundle.py::TestCompareReleaseBundleE2E
+
+      - name: Download Ubuntu package inputs
+        run: |
+          mkdir -p reports/realworld inputs/debs
+          cd inputs/debs
+          apt-get download zlib1g zlib1g-dev
+
+      - name: Compare a real Debian package against itself
+        run: |
+          set -euo pipefail
+          cd inputs/debs
+          runtime_deb="$(ls zlib1g_*.deb | head -1)"
+          devel_deb="$(ls zlib1g-dev_*.deb | head -1)"
+          cd ../..
+          abicheck compare-release \
+            "inputs/debs/${runtime_deb}" \
+            "inputs/debs/${runtime_deb}" \
+            --devel-pkg1 "inputs/debs/${devel_deb}" \
+            --devel-pkg2 "inputs/debs/${devel_deb}" \
+            --no-bundle-analysis \
+            --format json \
+            -o reports/realworld/zlib-deb-self.json
+          python - <<'PY'
+          import json
+          data = json.load(open("reports/realworld/zlib-deb-self.json"))
+          assert data["verdict"] in {"NO_CHANGE", "COMPATIBLE"}
+          assert "bundle_findings" not in data
+          PY
+
+      - name: Cross-check package self-compare with abidiff
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/abicheck-realworld-old /tmp/abicheck-realworld-new
+          runtime_deb="$(ls inputs/debs/zlib1g_*.deb | head -1)"
+          dpkg-deb -x "${runtime_deb}" /tmp/abicheck-realworld-old
+          dpkg-deb -x "${runtime_deb}" /tmp/abicheck-realworld-new
+          abidiff \
+            /tmp/abicheck-realworld-old/usr/lib/x86_64-linux-gnu/libz.so.1.3 \
+            /tmp/abicheck-realworld-new/usr/lib/x86_64-linux-gnu/libz.so.1.3 \
+            > reports/realworld/zlib-abidiff.txt
+
+      - name: Upload real-world validation artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: realworld-validation
+          path: reports/realworld

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -103,6 +104,31 @@ def _resolve_release_headers(
     if new_header_dir and not new_headers_only:
         new_h = [new_header_dir]
     return old_h, new_h
+
+
+def _discover_include_roots(header_dir: Path | None) -> list[Path]:
+    """Return common include roots from an extracted devel/header package."""
+    if header_dir is None:
+        return []
+    candidates = [
+        header_dir,
+        header_dir / "usr" / "include",
+        header_dir / "usr" / "local" / "include",
+    ]
+    usr_include = header_dir / "usr" / "include"
+    if usr_include.is_dir():
+        candidates.extend(p for p in usr_include.iterdir() if p.is_dir())
+    seen: set[Path] = set()
+    roots: list[Path] = []
+    for candidate in candidates:
+        if not candidate.is_dir():
+            continue
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        roots.append(candidate)
+    return roots
 
 
 def _match_release_keys(
@@ -875,6 +901,12 @@ def _strip_diff_results_and_adjust_verdict(
 @click.option("-I", "--include", "includes", multiple=True,
               type=click.Path(path_type=Path),
               help="Extra include directory for castxml.")
+@click.option("--old-include", "old_includes_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Include directory for old side only (overrides -I for old).")
+@click.option("--new-include", "new_includes_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Include directory for new side only (overrides -I for new).")
 @click.option("--old-header", "old_headers_only", multiple=True,
               type=click.Path(path_type=Path),
               help="Header for old side only (overrides -H for old).")
@@ -943,8 +975,7 @@ def _strip_diff_results_and_adjust_verdict(
               help="Declare a co-versioned library cohort by name prefix (e.g. "
                    "'libonedal_'). Repeatable. Enables the BUNDLE_SONAME_SKEW check, "
                    "which flags when some members of the cohort bump their major SONAME "
-                   "while siblings lag. Opt-in: with no --bundle-cohort, SONAME skew is "
-                   "never inferred from filenames (independent libraries are not compared).")
+                   "while siblings lag, and enables bundle-level cross-library analysis.")
 @click.option("--no-bundle-analysis", "no_bundle_analysis", is_flag=True, default=False,
               help="Skip bundle-level cross-library analysis (debug/parity escape hatch). "
                    "Bundle findings catch intra-bundle symbol removals, signature drift "
@@ -971,6 +1002,8 @@ def compare_release_cmd(
     new_dir: Path,
     headers: tuple[Path, ...],
     includes: tuple[Path, ...],
+    old_includes_only: tuple[Path, ...],
+    new_includes_only: tuple[Path, ...],
     old_headers_only: tuple[Path, ...],
     new_headers_only: tuple[Path, ...],
     old_version: str,
@@ -1067,7 +1100,8 @@ def compare_release_cmd(
             old_dir, new_dir,
             debug_info1, debug_info2, devel_pkg1, devel_pkg2,
             include_private_dso, dso_only,
-            headers, old_headers_only, new_headers_only, includes,
+            headers, old_headers_only, new_headers_only,
+            includes, old_includes_only, new_includes_only,
             _do_extract, discover_shared_libraries, is_package, _is_elf_shared_object,
         )
 
@@ -1096,7 +1130,8 @@ def compare_release_cmd(
         )
 
         bundle_result: BundleDiffResult | None = None
-        if not no_bundle_analysis:
+        bundle_requested = manifest_path is not None or bool(bundle_cohorts)
+        if not no_bundle_analysis and bundle_requested:
             bundle_result, worst_verdict = _collect_bundle_result(
                 library_results, old_map, new_map, worst_verdict,
                 manifest_path=manifest_path,
@@ -1141,6 +1176,8 @@ def _prepare_compare_release_inputs(
     old_headers_only: tuple[Path, ...],
     new_headers_only: tuple[Path, ...],
     includes: tuple[Path, ...],
+    old_includes_only: tuple[Path, ...],
+    new_includes_only: tuple[Path, ...],
     extract_if_package: Callable[[Path, Path | None, Path | None], tuple[Path, Path | None, Path | None]],
     discover_shared_libraries: Callable[..., list[Path]],
     is_package: Callable[[Path], bool],
@@ -1173,8 +1210,10 @@ def _prepare_compare_release_inputs(
     old_h, new_h = _resolve_release_headers(
         headers, old_headers_only, new_headers_only, old_header_dir, new_header_dir,
     )
-    old_inc = list(includes)
-    new_inc = list(includes)
+    old_inc = list(old_includes_only) if old_includes_only else list(includes)
+    new_inc = list(new_includes_only) if new_includes_only else list(includes)
+    old_inc.extend(_discover_include_roots(old_header_dir))
+    new_inc.extend(_discover_include_roots(new_header_dir))
     matched_keys, removed_keys, added_keys, old_map, new_map = _match_release_keys(
         old_dir, new_dir, old_map, new_map, old_files, new_files, is_package,
     )
@@ -1204,4 +1243,3 @@ def _exit_compare_release(
 
 
 # ── Suggest suppressions command ──────────────────────────────────────────────
-

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,11 +131,14 @@ class TarExtractor:
 
     def detect(self, pkg_path: Path) -> bool:
         name = pkg_path.name.lower()
-        return name.endswith((".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tgz"))
+        return name.endswith((".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst", ".tgz"))
 
     def extract(self, pkg_path: Path, target_dir: Path) -> ExtractResult:
         _log.info("Extracting tar archive: %s", pkg_path)
-        self._safe_extract(pkg_path, target_dir)
+        if pkg_path.name.lower().endswith(".tar.zst"):
+            self._safe_extract_zst_tar(pkg_path, target_dir)
+        else:
+            self._safe_extract(pkg_path, target_dir)
         return ExtractResult(lib_dir=target_dir)
 
     @staticmethod
@@ -175,6 +179,38 @@ class TarExtractor:
                 tf.extractall(path=target_dir, filter="data")  # nosec B202 — members validated above
             else:
                 tf.extractall(path=target_dir)  # nosec B202 — members validated above
+
+    @staticmethod
+    def _safe_extract_zst_tar(zst_path: Path, target_dir: Path) -> None:
+        """Extract a zstd-compressed tar archive with the normal tar safety checks."""
+        staging = Path(tempfile.mkdtemp(dir=target_dir, prefix=".abicheck-zst-"))
+        tar_path = staging / "payload.tar"
+        try:
+            try:
+                import zstandard
+            except ImportError:
+                zstandard = None
+            if zstandard is not None:
+                dctx = zstandard.ZstdDecompressor()
+                with open(zst_path, "rb") as compressed, open(tar_path, "wb") as out:
+                    with dctx.stream_reader(compressed) as reader:
+                        shutil.copyfileobj(reader, out)
+            else:
+                zstd = shutil.which("zstd")
+                if zstd is None:
+                    raise SnapshotError(
+                        "Cannot extract .tar.zst: install 'zstandard' Python package "
+                        "or 'zstd' command-line tool."
+                    )
+                subprocess.run(
+                    [zstd, "-d", "-f", str(zst_path), "-o", str(tar_path)],
+                    check=True,
+                    capture_output=True,
+                    timeout=120,
+                )
+            TarExtractor._safe_extract(tar_path, target_dir)
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
 
 
 # ── RPM extractor ────────────────────────────────────────────────────────────
@@ -331,7 +367,7 @@ class DebExtractor:
         staging = Path(tempfile.mkdtemp(dir=target_dir, prefix=".deb_staging_"))
         try:
             subprocess.run(
-                [ar, "x", str(deb_path)],
+                [ar, "x", str(deb_path.resolve())],
                 cwd=str(staging),
                 check=True,
                 capture_output=True,
@@ -351,7 +387,10 @@ class DebExtractor:
                 )
 
             # Extract data.tar.* with security checks
-            TarExtractor._safe_extract(data_tar, target_dir)
+            if data_tar.name.endswith(".tar.zst"):
+                TarExtractor._safe_extract_zst_tar(data_tar, target_dir)
+            else:
+                TarExtractor._safe_extract(data_tar, target_dir)
         finally:
             shutil.rmtree(staging, ignore_errors=True)
 
@@ -434,60 +473,7 @@ class CondaExtractor:
     @staticmethod
     def _extract_zst_tar(zst_path: Path, target_dir: Path) -> None:
         """Extract a .tar.zst file using zstd + tar or Python zstandard."""
-        # Try Python zstandard first
-        try:
-            import zstandard
-            dctx = zstandard.ZstdDecompressor()
-            with open(zst_path, "rb") as compressed:
-                with dctx.stream_reader(compressed) as reader:
-                    with tarfile.open(fileobj=reader, mode="r|") as tf:
-                        target_root = target_dir.resolve()
-                        for member in tf:
-                            _validate_member_path(member.name, target_root)
-                            if member.ischr() or member.isblk() or member.isfifo():
-                                raise ExtractionSecurityError(
-                                    member.name,
-                                    "archive contains a device or FIFO entry",
-                                )
-                            if member.issym():
-                                _validate_symlink_target(
-                                    member.name, member.linkname, target_root
-                                )
-                            elif member.islnk():
-                                _validate_member_path(
-                                    member.linkname, target_root
-                                )
-                        # Re-read for extraction (stream was consumed)
-                with open(zst_path, "rb") as compressed2:
-                    with dctx.stream_reader(compressed2) as reader2:
-                        with tarfile.open(fileobj=reader2, mode="r|") as tf2:
-                            if sys.version_info >= (3, 12):
-                                tf2.extractall(path=target_dir, filter="data")  # nosec B202
-                            else:
-                                tf2.extractall(path=target_dir)  # nosec B202
-            return
-        except ImportError:
-            pass
-
-        # Fall back to system zstd command
-        zstd = shutil.which("zstd")
-        if zstd is None:
-            raise SnapshotError(
-                "Cannot extract .tar.zst: install 'zstandard' Python package "
-                "or 'zstd' command-line tool."
-            )
-        # Decompress to tar, then extract
-        tar_path = zst_path.with_suffix("")  # strip .zst
-        subprocess.run(
-            [zstd, "-d", str(zst_path), "-o", str(tar_path)],
-            check=True,
-            capture_output=True,
-            timeout=120,
-        )
-        try:
-            TarExtractor._safe_extract(tar_path, target_dir)
-        finally:
-            tar_path.unlink(missing_ok=True)
+        TarExtractor._safe_extract_zst_tar(zst_path, target_dir)
 
 
 # ── Wheel (pip) extractor ────────────────────────────────────────────────────
@@ -551,7 +537,7 @@ def is_package(path: Path) -> bool:
         return False
     name = path.name.lower()
     if name.endswith((
-        ".rpm", ".deb", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tgz",
+        ".rpm", ".deb", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst", ".tgz",
         ".conda", ".whl",
     )):
         return True

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1144,6 +1144,7 @@ def _build_tiny_so(release_dir: Path, name: str, src: str) -> Path:
            "Mach-O ld and link.exe don't accept them. Bundle analysis "
            "itself is ELF/Linux-only per ADR-018 / ADR-023.",
 )
+@pytest.mark.integration
 class TestCompareReleaseBundleE2E:
     """Exercise compare-release end-to-end with the bundle layer enabled.
 
@@ -1203,7 +1204,8 @@ class TestCompareReleaseBundleE2E:
 
         result = CliRunner().invoke(
             main,
-            ["compare-release", str(old), str(new), "--format", "json"],
+            ["compare-release", str(old), str(new), "--format", "json",
+             "--bundle-cohort", "lib"],
         )
         # Bundle BREAKING → exit 4.
         assert result.exit_code == 4, result.output
@@ -1218,6 +1220,31 @@ class TestCompareReleaseBundleE2E:
         )
         assert intra["consumer_library"] == "libalgo.so"
         assert intra["symbol"] == "core_mul"
+
+    def test_compare_release_default_skips_bundle_analysis(self, tmp_path: Path) -> None:
+        """Plain compare-release should not emit bundle findings by default."""
+        import json as _json
+
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        old = tmp_path / "old"
+        new = tmp_path / "new"
+        old.mkdir()
+        new.mkdir()
+        _build_tiny_so(old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n")
+        _build_tiny_so(new, "libfoo.so", "int foo(void){return 1;}\n")
+
+        result = CliRunner().invoke(
+            main,
+            ["compare-release", str(old), str(new), "--format", "json"],
+        )
+        assert result.exit_code == 4, result.output
+        data = _json.loads(result.stdout)
+        assert data["libraries"][0]["verdict"] == "BREAKING"
+        assert "bundle_verdict" not in data
+        assert "bundle_findings" not in data
 
     def test_compare_release_no_bundle_analysis_opts_out(self, tmp_path: Path) -> None:
         # Same broken bundle as above; --no-bundle-analysis must
@@ -1327,7 +1354,7 @@ class TestCompareReleaseBundleE2E:
             )
 
         result = CliRunner().invoke(
-            main, ["compare-release", str(old), str(new)],
+            main, ["compare-release", str(old), str(new), "--bundle-cohort", "lib"],
         )
         assert "Bundle (Cross-Library) Findings" in result.stdout
         assert "bundle_intra_dep_removed" in result.stdout

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -13,7 +13,11 @@ from abicheck.cli import (
     _version_sort_key,
     main,
 )
-from abicheck.cli_compare_release import _extract_if_package
+from abicheck.cli_compare_release import (
+    _discover_include_roots,
+    _extract_if_package,
+    _prepare_compare_release_inputs,
+)
 from abicheck.model import (
     AbiSnapshot,
     Function,
@@ -788,3 +792,49 @@ class TestExtractIfPackage:
         assert lib_out == main_lib
         assert debug_out == extracted_debug  # .debug_dir preferred over .lib_dir
         assert header_out is None
+
+
+class TestCompareReleaseIncludes:
+    def test_discover_include_roots_for_debian_layout(self, tmp_path: Path) -> None:
+        """Devel package roots include common distro include subroots."""
+        root = tmp_path / "dev"
+        (root / "usr" / "include" / "x86_64-linux-gnu").mkdir(parents=True)
+        (root / "usr" / "include" / "libxml2").mkdir()
+        roots = _discover_include_roots(root)
+        assert root in roots
+        assert root / "usr" / "include" in roots
+        assert root / "usr" / "include" / "x86_64-linux-gnu" in roots
+        assert root / "usr" / "include" / "libxml2" in roots
+
+    def test_prepare_inputs_accepts_side_specific_includes(self, tmp_path: Path) -> None:
+        """compare-release has compare-like --old-include/--new-include plumbing."""
+        old = tmp_path / "old"
+        new = tmp_path / "new"
+        old.mkdir()
+        new.mkdir()
+        old_lib = old / "libfoo.so"
+        new_lib = new / "libfoo.so"
+        old_lib.write_text("old")
+        new_lib.write_text("new")
+        old_inc_only = tmp_path / "old-include"
+        new_inc_only = tmp_path / "new-include"
+        old_inc_only.mkdir()
+        new_inc_only.mkdir()
+
+        result = _prepare_compare_release_inputs(
+            old, new,
+            None, None, None, None,
+            False, False,
+            (), (), (),
+            (),
+            (old_inc_only,), (new_inc_only,),
+            lambda p, _dbg, _dev: (p, None, None),
+            lambda *_args, **_kwargs: [],
+            lambda _p: False,
+            lambda _p: True,
+        )
+
+        old_inc = result[4]
+        new_inc = result[5]
+        assert old_inc == [old_inc_only]
+        assert new_inc == [new_inc_only]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import struct
+import sys
 import tarfile
 import zipfile
 from pathlib import Path
@@ -1063,6 +1064,131 @@ class TestDebExtractorExtended:
         with mock.patch("abicheck.package.shutil.which", return_value=None):
             with pytest.raises(RuntimeError, match="ar not found"):
                 DebExtractor().extract(f, out)
+
+    def test_extract_data_tar_zst_uses_zstd_tar_helper(self, tmp_path: Path) -> None:
+        """DebExtractor handles modern Debian data.tar.zst payloads."""
+        f = tmp_path / "test.deb"
+        f.write_bytes(b"!<arch>\n" + b"\x00" * 100)
+        out = tmp_path / "output"
+        out.mkdir()
+
+        def fake_run(*args, **kwargs):
+            staging = Path(kwargs.get("cwd", "."))
+            (staging / "data.tar.zst").write_bytes(b"zstd payload")
+            return mock.Mock(returncode=0)
+
+        with mock.patch("abicheck.package.shutil.which", return_value="/usr/bin/ar"):
+            with mock.patch("abicheck.package.subprocess.run", side_effect=fake_run) as mock_run:
+                with mock.patch("abicheck.package.TarExtractor._safe_extract_zst_tar") as extract_zst:
+                    DebExtractor().extract(f, out)
+
+        mock_run.assert_called_once()
+        ar_cmd = mock_run.call_args.args[0]
+        assert Path(ar_cmd[2]).is_absolute()
+        extract_zst.assert_called_once()
+        assert extract_zst.call_args.args[0].name == "data.tar.zst"
+
+    def test_extract_relative_deb_path_passes_absolute_path_to_ar(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """DebExtractor changes cwd for ar, so relative input paths must be resolved."""
+        f = tmp_path / "test.deb"
+        f.write_bytes(b"!<arch>\n" + b"\x00" * 100)
+        out = tmp_path / "output"
+        out.mkdir()
+        monkeypatch.chdir(tmp_path)
+        ar_input_paths: list[Path] = []
+
+        def fake_run(args, **kwargs):
+            ar_input_paths.append(Path(args[2]))
+            staging = Path(kwargs.get("cwd", "."))
+            (staging / "data.tar.xz").write_bytes(b"tar payload")
+            return mock.Mock(returncode=0)
+
+        with mock.patch("abicheck.package.shutil.which", return_value="/usr/bin/ar"):
+            with mock.patch("abicheck.package.subprocess.run", side_effect=fake_run):
+                with mock.patch("abicheck.package.TarExtractor._safe_extract"):
+                    DebExtractor().extract(Path("test.deb"), out)
+
+        assert ar_input_paths == [f.resolve()]
+
+    def test_tar_zst_is_package(self, tmp_path: Path) -> None:
+        """Plain .tar.zst archives are recognized as package inputs."""
+        f = tmp_path / "sdk.tar.zst"
+        f.write_bytes(b"not real zstd")
+        assert TarExtractor().detect(f)
+        assert is_package(f)
+
+    def test_safe_extract_zst_tar_uses_private_staging_dir(self, tmp_path: Path) -> None:
+        """Decompression must not clobber a sibling .tar next to user input."""
+        cache = tmp_path / "cache"
+        target = tmp_path / "target"
+        cache.mkdir()
+        target.mkdir()
+        zst_path = cache / "sdk.tar.zst"
+        sibling_tar = cache / "sdk.tar"
+        zst_path.write_bytes(b"compressed")
+        sibling_tar.write_text("do not touch")
+
+        mock_zstd = mock.MagicMock()
+        mock_dctx = mock.MagicMock()
+        mock_zstd.ZstdDecompressor.return_value = mock_dctx
+
+        class FakeReader:
+            def __enter__(self):
+                return io.BytesIO(b"tar data")
+
+            def __exit__(self, *args):
+                return None
+
+        mock_dctx.stream_reader.return_value = FakeReader()
+
+        with mock.patch.dict(sys.modules, {"zstandard": mock_zstd}):
+            with mock.patch("abicheck.package.TarExtractor._safe_extract") as safe_extract:
+                TarExtractor._safe_extract_zst_tar(zst_path, target)
+
+        tar_path = safe_extract.call_args.args[0]
+        extract_target = safe_extract.call_args.args[1]
+        assert tar_path.parent.parent == target
+        assert not tar_path.exists()
+        assert not tar_path.parent.exists()
+        assert extract_target == target
+        assert sibling_tar.read_text() == "do not touch"
+
+    def test_safe_extract_zst_tar_cli_fallback_writes_to_staging_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """The zstd CLI fallback must also avoid writing next to the input."""
+        cache = tmp_path / "cache"
+        target = tmp_path / "target"
+        cache.mkdir()
+        target.mkdir()
+        zst_path = cache / "sdk.tar.zst"
+        sibling_tar = cache / "sdk.tar"
+        zst_path.write_bytes(b"compressed")
+        sibling_tar.write_text("do not touch")
+
+        real_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "zstandard":
+                raise ImportError
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            with mock.patch("abicheck.package.shutil.which", return_value="/usr/bin/zstd"):
+                with mock.patch("abicheck.package.subprocess.run") as run_zstd:
+                    with mock.patch("abicheck.package.TarExtractor._safe_extract") as safe_extract:
+                        TarExtractor._safe_extract_zst_tar(zst_path, target)
+
+        cmd = run_zstd.call_args.args[0]
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        tar_path = safe_extract.call_args.args[0]
+        assert output_path == tar_path
+        assert output_path.parent.parent == target
+        assert not output_path.parent.exists()
+        assert safe_extract.call_args.args[1] == target
+        assert sibling_tar.read_text() == "do not touch"
 
 
 # ── Conda extractor extended ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- support modern Debian/Ubuntu `data.tar.zst` and plain `.tar.zst` package extraction through the existing safe tar validation path
- make `compare-release` bundle analysis explicit via `--manifest` or `--bundle-cohort`, avoiding default false bundle findings for normal single-library package updates
- add `compare-release --old-include/--new-include` plus devel package include-root discovery for common Debian layouts
- add a non-blocking real-world CI smoke workflow that runs focused regressions and validates a real Ubuntu zlib `.deb` self-compare with artifacts

## Validation
- `../.venv/bin/python -m pytest tests/ -q -m "not integration and not libabigail and not abicc and not slow"` → 7025 passed, 19 skipped, 396 deselected, 4 xfailed
- `../.venv/bin/python -m ruff check abicheck tests`
- `../.venv/bin/python -m mypy abicheck`
- workflow YAML parsed with `yaml.safe_load`
- real Ubuntu `zlib1g` + `zlib1g-dev` self-compare: `NO_CHANGE`, no `bundle_findings`

## Notes
- This PR intentionally does not fix the oneDAL/CastXML/GCC13 real-header failures. That needs a separate focused pass around header preprocessing/provider modeling.
- Duplicate symbol warnings during real package smoke still look noisy and should be handled in a follow-up UX cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated real-world ABI validation via scheduled GitHub Actions workflow for continuous compatibility verification
  * Support for zstd-compressed tar archives and packages

* **Improvements**
  * Enhanced include directory discovery for header packages
  * Refined bundle analysis behavior—now triggered only when explicitly requested via CLI options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->