### PR TITLE
fix(diff): eliminate three real-world false-positive classes

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -38,6 +38,8 @@ from .elf_metadata import SymbolBinding, SymbolType
 from .model import (
     AbiSnapshot,
     Visibility,
+    is_non_abi_surface_type,
+    stdlib_namespaces_excluded,
 )
 
 # Module-level constant: ELF visibility values that form the default<->protected pair (case51).
@@ -1132,6 +1134,21 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     else:
         o_enums = o.enums
         n_enums = n.enums
+
+    # Drop standard-library / runtime / anonymous types from the DWARF layout
+    # maps. The header-scoped branch above only filters when a castxml model is
+    # present; in DWARF-only mode (no headers) it falls back to ALL DWARF types,
+    # which leaks std::/__gnu_cxx::/<lambda> records into the struct & enum
+    # layout detectors (STRUCT_FIELD_REMOVED etc.). This is the same surface
+    # gate the type differ uses (model.stdlib_namespaces_excluded), so every
+    # detector that consumes DWARF types agrees on what counts as ABI surface.
+    # Skipped when the inspected DSO *is* the C++ runtime (std:: IS its surface).
+    if stdlib_namespaces_excluded(old, new):
+        excl = True
+        o_structs = {k: v for k, v in o_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+        n_structs = {k: v for k, v in n_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+        o_enums = {k: v for k, v in o_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+        n_enums = {k: v for k, v in n_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
 
     filtered_old = DwarfMetadata(structs=o_structs, enums=o_enums, has_dwarf=o.has_dwarf)
     filtered_new = DwarfMetadata(structs=n_structs, enums=n_enums, has_dwarf=n.has_dwarf)

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -1135,20 +1135,23 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         o_enums = o.enums
         n_enums = n.enums
 
-    # Drop standard-library / runtime / anonymous types from the DWARF layout
-    # maps. The header-scoped branch above only filters when a castxml model is
-    # present; in DWARF-only mode (no headers) it falls back to ALL DWARF types,
-    # which leaks std::/__gnu_cxx::/<lambda> records into the struct & enum
-    # layout detectors (STRUCT_FIELD_REMOVED etc.). This is the same surface
-    # gate the type differ uses (model.stdlib_namespaces_excluded), so every
-    # detector that consumes DWARF types agrees on what counts as ABI surface.
-    # Skipped when the inspected DSO *is* the C++ runtime (std:: IS its surface).
-    if stdlib_namespaces_excluded(old, new):
-        excl = True
-        o_structs = {k: v for k, v in o_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
-        n_structs = {k: v for k, v in n_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
-        o_enums = {k: v for k, v in o_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
-        n_enums = {k: v for k, v in n_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+    # Drop non-ABI types from the DWARF layout maps. The header-scoped branch
+    # above only filters when a castxml model is present; in DWARF-only mode (no
+    # headers) it falls back to ALL DWARF types, which leaks
+    # std::/__gnu_cxx::/<lambda>/compiler-internal records into the struct & enum
+    # layout detectors (STRUCT_FIELD_REMOVED etc.). This is the same surface gate
+    # the type differ uses (model.stdlib_namespaces_excluded), so every detector
+    # that consumes DWARF types agrees on what counts as ABI surface.
+    #
+    # The filter ALWAYS runs: when the inspected DSO *is* the C++ runtime,
+    # ``excl`` is False so std::/__gnu_cxx:: records are kept (they ARE its
+    # surface), but anonymous/lambda and compiler-internal types are still
+    # dropped — those are never stable ABI even for the runtime itself.
+    excl = stdlib_namespaces_excluded(old, new)
+    o_structs = {k: v for k, v in o_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+    n_structs = {k: v for k, v in n_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+    o_enums = {k: v for k, v in o_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+    n_enums = {k: v for k, v in n_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
 
     filtered_old = DwarfMetadata(structs=o_structs, enums=o_enums, has_dwarf=o.has_dwarf)
     filtered_new = DwarfMetadata(structs=n_structs, enums=n_enums, has_dwarf=n.has_dwarf)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -651,6 +651,10 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
         # Param pointer depths
         for i, (p_old, p_new) in enumerate(zip(f_old.params, f_new.params)):
+            # Skip individually unresolved params ("?"): depth falls back to 0
+            # and would read as a phantom level change (matches _check_params_change).
+            if _type_unknown(p_old.type) or _type_unknown(p_new.type):
+                continue
             if p_old.pointer_depth != p_new.pointer_depth and (
                 p_old.pointer_depth > 0 or p_new.pointer_depth > 0
             ):

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -65,14 +65,27 @@ def _type_unknown(type_name: str | None) -> bool:
     return type_name is None or type_name.strip() == _UNKNOWN_TYPE
 
 
-def _params_unknown(f: Function) -> bool:
-    """True when a function's *parameter* evidence is absent, not merely its
-    return type. A stripped, symbols-only export has an unknown return ("?") and
-    no parameter DIEs at all; a DWARF/header snapshot resolves the return and
-    each parameter independently, so an unresolved return with recorded params
-    is NOT unknown params (RD2-5; Codex review on PR #275 — int→long param
-    changes under an unresolved return must still be diffed)."""
-    return _type_unknown(f.return_type) and not f.params
+def _is_stripped_symbols_only(snap: AbiSnapshot) -> bool:
+    """True when *snap* is a stripped, symbols-only dump: it exports symbols but
+    carries no type-level evidence (no records/enums/typedefs, no DWARF content)
+    and was flagged ``elf_only_mode`` by the dumper.
+
+    Used to gate *parameter* comparison (RD2-5; Codex reviews on PR #275). The
+    bare ``"?"`` sentinel is **not** a reliable per-function signal — castxml and
+    dwarf_snapshot also emit ``"?"`` for an individually unresolved return/param
+    while resolving the rest — so an empty parameter list only means "unknown
+    params" when the whole snapshot is a symbols-only stub. In a real
+    DWARF/header snapshot an empty list means "takes no arguments", and changes
+    like ``f(void)`` → ``f(int)`` must still be diffed.
+    """
+    if not getattr(snap, "elf_only_mode", False):
+        return False
+    if snap.types or snap.enums or snap.typedefs:
+        return False
+    dwarf = getattr(snap, "dwarf", None)
+    if dwarf is not None and (dwarf.structs or dwarf.enums):
+        return False
+    return bool(snap.functions or snap.variables)
 
 
 def _is_local_type_rtti(mangled: str) -> bool:
@@ -163,13 +176,20 @@ def _check_return_type_change(mangled: str, f_old: Function, f_new: Function) ->
     )]
 
 
-def _check_params_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
+def _check_params_change(
+    mangled: str, f_old: Function, f_new: Function, *, params_unconfirmed: bool = False,
+) -> list[Change]:
     """Emit a change if the parameter list was modified."""
-    # RD2-5: skip only when a side's *parameter* evidence is absent (stripped
-    # ELF export: unknown return AND no param DIEs). A DWARF/header side with an
-    # unresolved return but recorded params still has comparable params, so an
-    # int→long param change must not be dropped (Codex review on PR #275).
-    if _params_unknown(f_old) or _params_unknown(f_new):
+    # RD2-5: suppress only when one side is a stripped symbols-only stub (its
+    # empty param list is "unknown", not "zero args"), or when an individual
+    # parameter type is the unresolved "?" sentinel — diffing against unknown is
+    # meaningless. A DWARF/header side with resolved params is always compared,
+    # so int→long and f(void)→f(int) are still detected (Codex reviews, PR #275).
+    if params_unconfirmed:
+        return []
+    if any(_type_unknown(p.type) for p in f_old.params) or any(
+        _type_unknown(p.type) for p in f_new.params
+    ):
         return []
     old_params = [(canonicalize_type_name(p.type), p.kind) for p in f_old.params]
     new_params = [(canonicalize_type_name(p.type), p.kind) for p in f_new.params]
@@ -274,11 +294,13 @@ def _check_explicit_change(mangled: str, f_old: Function, f_new: Function) -> li
     )
 
 
-def _check_function_signature(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
+def _check_function_signature(
+    mangled: str, f_old: Function, f_new: Function, *, params_unconfirmed: bool = False,
+) -> list[Change]:
     """Compare signatures and qualifiers of two matched functions."""
     changes: list[Change] = []
     changes.extend(_check_return_type_change(mangled, f_old, f_new))
-    changes.extend(_check_params_change(mangled, f_old, f_new))
+    changes.extend(_check_params_change(mangled, f_old, f_new, params_unconfirmed=params_unconfirmed))
     changes.extend(_check_ref_qualifier_change(mangled, f_old, f_new))
     changes.extend(_check_linkage_change(mangled, f_old, f_new))
     changes.extend(_check_noexcept_change(mangled, f_old, f_new))
@@ -333,10 +355,11 @@ def _match_old_function(
     new_all: dict[str, Function],
     matched_by_name: set[str],
     elf_only_mode: bool,
+    params_unconfirmed: bool = False,
 ) -> list[Change]:
     """Classify a single old function: matched by mangled, extern-C fallback, or removed."""
     if mangled in new_map:
-        return list(_check_function_signature(mangled, f_old, new_map[mangled]))
+        return list(_check_function_signature(mangled, f_old, new_map[mangled], params_unconfirmed=params_unconfirmed))
 
     # Fallback by plain name when either side uses extern "C".
     # The name->Function mapping is a MULTIMAP: only fall back when there is
@@ -349,7 +372,7 @@ def _match_old_function(
         extern_c_candidates = candidates  # any single candidate is acceptable
     if len(extern_c_candidates) == 1:
         f_new = extern_c_candidates[0]
-        result = list(_check_function_signature(f_old.name, f_old, f_new))
+        result = list(_check_function_signature(f_old.name, f_old, f_new, params_unconfirmed=params_unconfirmed))
         matched_by_name.add(f_old.name)
         return result
 
@@ -396,6 +419,9 @@ def _detect_newly_deleted_functions(
 @registry.detector("functions")
 def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     elf_only_mode = getattr(old, "elf_only_mode", False)
+    # RD2-5: when one side is a stripped symbols-only stub, its parameter lists
+    # are unknown (not "zero args"), so parameter diffs are unconfirmed.
+    params_unconfirmed = _is_stripped_symbols_only(old) or _is_stripped_symbols_only(new)
     changes: list[Change] = []
     old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
     new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
@@ -414,7 +440,10 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
     for mangled, f_old in old_map.items():
         changes.extend(
-            _match_old_function(mangled, f_old, new_map, new_by_name, new_all, matched_by_name, elf_only_mode)
+            _match_old_function(
+                mangled, f_old, new_map, new_by_name, new_all, matched_by_name,
+                elf_only_mode, params_unconfirmed,
+            )
         )
 
     for mangled, f_new in new_map.items():
@@ -592,17 +621,16 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     old_map = _public_functions(old)
     new_map = _public_functions(new)
+    # RD2-5: param depths from a stripped symbols-only stub default to 0 and
+    # would read as phantom level changes; suppress them. The return depth is
+    # guarded independently by the unknown-return ("?") check below.
+    params_unconfirmed = _is_stripped_symbols_only(old) or _is_stripped_symbols_only(new)
 
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
         if f_new is None:
             continue
 
-        # RD2-5: guard each axis independently — a stripped ELF export reports
-        # an unknown return ("?") and no params, where depths default to 0 and
-        # would read as phantom level changes. Skip the return-depth check only
-        # when the return is unknown, and the param-depth loop only when the
-        # parameter evidence is absent (Codex review on PR #275).
         return_known = not (
             _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type)
         )
@@ -618,7 +646,7 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 new_value=str(f_new.return_pointer_depth),
             ))
 
-        if _params_unknown(f_old) or _params_unknown(f_new):
+        if params_unconfirmed:
             continue
 
         # Param pointer depths

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -44,6 +44,37 @@ _log = logging.getLogger(__name__)
 # Visibility levels that constitute the public ABI surface.
 _PUBLIC_VIS = (Visibility.PUBLIC, Visibility.ELF_ONLY)
 
+# Itanium RTTI artifact prefixes (typeinfo, typeinfo-name, vtable, VTT) followed
+# immediately by ``Z`` — the Itanium "local-name" production ``Z <encoding> E``.
+# An RTTI symbol of this shape belongs to a *function-local* type (a lambda
+# closure, or any class/struct declared inside a function body). Such a type can
+# never be named in a public header, so the presence/absence of its typeinfo is
+# build-dependent churn, not a public-ABI break. Filtering it here mirrors how
+# anonymous/lambda *types* are excluded from type diffing (model.is_non_abi_surface_type).
+_LOCAL_RTTI_PREFIXES = ("_ZTIZ", "_ZTSZ", "_ZTVZ", "_ZTTZ")
+
+
+# Sentinel the dumper writes for the type/return type of a symbol whose
+# signature is unknown — e.g. an ELF export from a stripped binary with no DWARF
+# or header info. Diffing a known type against "?" yields a phantom change
+# ("void → ?"), so type-bearing comparisons must treat "?" as "no evidence".
+_UNKNOWN_TYPE = "?"
+
+
+def _type_unknown(type_name: str | None) -> bool:
+    return type_name is None or type_name.strip() == _UNKNOWN_TYPE
+
+
+def _is_local_type_rtti(mangled: str) -> bool:
+    """True for typeinfo/vtable symbols of a function-local type (e.g. a lambda).
+
+    Regression: RD2-4 (validation) — protobuf patch releases churn
+    ``_ZTIZN…EUl…E_`` / ``_ZTSZN…`` typeinfo symbols for anonymous lambdas nested
+    in ``Printer::WithDefs/WithVars``; they were scored as public ``var_removed``
+    and drove a false ``BREAKING`` verdict on an ABI-compatible bump.
+    """
+    return mangled.startswith(_LOCAL_RTTI_PREFIXES)
+
 
 def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     """Return public/ELF-only functions from *snap*."""
@@ -51,8 +82,16 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
 
 
 def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:
-    """Return public/ELF-only variables from *snap*."""
-    return {k: v for k, v in snap.variable_map.items() if v.visibility in _PUBLIC_VIS}
+    """Return public/ELF-only variables from *snap*.
+
+    Excludes RTTI/vtable symbols of function-local types (lambda closures and
+    other in-function types): they are not nameable public ABI and only churn
+    across builds (RD2-4).
+    """
+    return {
+        k: v for k, v in snap.variable_map.items()
+        if v.visibility in _PUBLIC_VIS and not _is_local_type_rtti(k)
+    }
 
 
 
@@ -100,6 +139,9 @@ def _check_removed_function(
 
 def _check_return_type_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
     """Emit a change if the return type was modified."""
+    # RD2-5: a stripped side reports return_type "?"; that is unknown, not a change.
+    if _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type):
+        return []
     if canonicalize_type_name(f_old.return_type) == canonicalize_type_name(f_new.return_type):
         return []
     return [Change(
@@ -113,6 +155,11 @@ def _check_return_type_change(mangled: str, f_old: Function, f_new: Function) ->
 
 def _check_params_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
     """Emit a change if the parameter list was modified."""
+    # RD2-5: when either side's return type is the unknown sentinel ("?"), its
+    # whole signature (including params) is unresolved — a stripped ELF export.
+    # An empty param list there means "unknown", not "takes no arguments".
+    if _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type):
+        return []
     old_params = [(canonicalize_type_name(p.type), p.kind) for p in f_old.params]
     new_params = [(canonicalize_type_name(p.type), p.kind) for p in f_new.params]
     if old_params == new_params:
@@ -424,6 +471,9 @@ def _diff_inline_hidden_friends(
 
 def _check_variable(mangled: str, v_old: Variable, v_new: Variable) -> list[Change]:
     """Compare a matched pair of public variables."""
+    # RD2-5: a stripped side reports type "?"; unknown is not a type change.
+    if _type_unknown(v_old.type) or _type_unknown(v_new.type):
+        return []
     if canonicalize_type_name(v_old.type) != canonicalize_type_name(v_new.type):
         return [Change(
             kind=ChangeKind.VAR_TYPE_CHANGED,
@@ -535,6 +585,10 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     for mangled, f_old in old_map.items():
         f_new = new_map.get(mangled)
         if f_new is None:
+            continue
+        # RD2-5: skip when either signature is unknown (stripped ELF export):
+        # pointer depths default to 0 and would read as phantom level changes.
+        if _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type):
             continue
 
         # Return pointer depth

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -181,19 +181,25 @@ def _check_params_change(
 ) -> list[Change]:
     """Emit a change if the parameter list was modified."""
     # RD2-5: suppress only when one side is a stripped symbols-only stub (its
-    # empty param list is "unknown", not "zero args"), or when an individual
-    # parameter type is the unresolved "?" sentinel — diffing against unknown is
-    # meaningless. A DWARF/header side with resolved params is always compared,
-    # so int→long and f(void)→f(int) are still detected (Codex reviews, PR #275).
+    # empty param list is "unknown", not "zero args"). Otherwise compare
+    # position-by-position, ignoring only the individual parameters whose type is
+    # the unresolved "?" sentinel — diffing a known type against unknown is
+    # meaningless, but an unrelated unknown must not mask a real change on a
+    # fully-known parameter (e.g. f(?, int) -> f(?, long)). Parameter *count*
+    # changes are always real in a resolved snapshot (Codex reviews, PR #275).
     if params_unconfirmed:
         return []
-    if any(_type_unknown(p.type) for p in f_old.params) or any(
-        _type_unknown(p.type) for p in f_new.params
-    ):
-        return []
-    old_params = [(canonicalize_type_name(p.type), p.kind) for p in f_old.params]
-    new_params = [(canonicalize_type_name(p.type), p.kind) for p in f_new.params]
-    if old_params == new_params:
+    changed: bool
+    if len(f_old.params) != len(f_new.params):
+        changed = True
+    else:
+        changed = any(
+            not _type_unknown(p_old.type) and not _type_unknown(p_new.type)
+            and (canonicalize_type_name(p_old.type), p_old.kind)
+            != (canonicalize_type_name(p_new.type), p_new.kind)
+            for p_old, p_new in zip(f_old.params, f_new.params)
+        )
+    if not changed:
         return []
     return [Change(
         kind=ChangeKind.FUNC_PARAMS_CHANGED,

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -65,6 +65,16 @@ def _type_unknown(type_name: str | None) -> bool:
     return type_name is None or type_name.strip() == _UNKNOWN_TYPE
 
 
+def _params_unknown(f: Function) -> bool:
+    """True when a function's *parameter* evidence is absent, not merely its
+    return type. A stripped, symbols-only export has an unknown return ("?") and
+    no parameter DIEs at all; a DWARF/header snapshot resolves the return and
+    each parameter independently, so an unresolved return with recorded params
+    is NOT unknown params (RD2-5; Codex review on PR #275 — int→long param
+    changes under an unresolved return must still be diffed)."""
+    return _type_unknown(f.return_type) and not f.params
+
+
 def _is_local_type_rtti(mangled: str) -> bool:
     """True for typeinfo/vtable symbols of a function-local type (e.g. a lambda).
 
@@ -155,10 +165,11 @@ def _check_return_type_change(mangled: str, f_old: Function, f_new: Function) ->
 
 def _check_params_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
     """Emit a change if the parameter list was modified."""
-    # RD2-5: when either side's return type is the unknown sentinel ("?"), its
-    # whole signature (including params) is unresolved — a stripped ELF export.
-    # An empty param list there means "unknown", not "takes no arguments".
-    if _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type):
+    # RD2-5: skip only when a side's *parameter* evidence is absent (stripped
+    # ELF export: unknown return AND no param DIEs). A DWARF/header side with an
+    # unresolved return but recorded params still has comparable params, so an
+    # int→long param change must not be dropped (Codex review on PR #275).
+    if _params_unknown(f_old) or _params_unknown(f_new):
         return []
     old_params = [(canonicalize_type_name(p.type), p.kind) for p in f_old.params]
     new_params = [(canonicalize_type_name(p.type), p.kind) for p in f_new.params]
@@ -586,13 +597,17 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         f_new = new_map.get(mangled)
         if f_new is None:
             continue
-        # RD2-5: skip when either signature is unknown (stripped ELF export):
-        # pointer depths default to 0 and would read as phantom level changes.
-        if _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type):
-            continue
 
+        # RD2-5: guard each axis independently — a stripped ELF export reports
+        # an unknown return ("?") and no params, where depths default to 0 and
+        # would read as phantom level changes. Skip the return-depth check only
+        # when the return is unknown, and the param-depth loop only when the
+        # parameter evidence is absent (Codex review on PR #275).
+        return_known = not (
+            _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type)
+        )
         # Return pointer depth
-        if f_old.return_pointer_depth != f_new.return_pointer_depth and (
+        if return_known and f_old.return_pointer_depth != f_new.return_pointer_depth and (
             f_old.return_pointer_depth > 0 or f_new.return_pointer_depth > 0
         ):
             changes.append(Change(
@@ -602,6 +617,9 @@ def _diff_pointer_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 old_value=str(f_old.return_pointer_depth),
                 new_value=str(f_new.return_pointer_depth),
             ))
+
+        if _params_unknown(f_old) or _params_unknown(f_new):
+            continue
 
         # Param pointer depths
         for i, (p_old, p_new) in enumerate(zip(f_old.params, f_new.params)):

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -44,6 +44,60 @@ def _is_abi_surface_type(t: RecordType, *, exclude_stdlib: bool) -> bool:
     return not _is_non_abi_surface_type(t.name, exclude_stdlib_namespaces=exclude_stdlib)
 
 
+def _has_type_evidence(snap: AbiSnapshot) -> bool:
+    """True if *snap* carries any type-level surface (records/enums/typedefs/DWARF).
+
+    A stripped, symbols-only snapshot has none of these.
+    """
+    if snap.types or snap.enums or snap.typedefs:
+        return True
+    dwarf = getattr(snap, "dwarf", None)
+    # has_dwarf alone is not enough: a stripped binary can carry an empty
+    # .debug_* section (has_dwarf=True, zero structs/enums). Require real content.
+    return bool(dwarf is not None and (dwarf.structs or dwarf.enums))
+
+
+def _removals_are_unconfirmed(old: AbiSnapshot, new: AbiSnapshot) -> bool:
+    """True when type-level *removals* must be suppressed because the new side
+    has no type evidence to confirm them (RD2-5).
+
+    When the old binary carries DWARF/header type info but the new one is
+    *stripped, symbols-only* (``elf_only_mode``), every old type/typedef/enum
+    appears "missing" — but that is absence of *evidence*, not evidence of
+    *removal*. Reporting hundreds of phantom ``type_removed``/``typedef_removed``
+    for types that obviously still exist (``_xmlNode``, ``_IO_FILE`` …) is a
+    false-positive avalanche on an otherwise compatible bump. The ``dwarf``
+    detector already emits ``DWARF_INFO_MISSING`` for this asymmetry, so the
+    coverage gap is still disclosed; here we simply decline to manufacture
+    removal findings from it.
+
+    Detecting a genuinely *stripped* new side (vs. a build that really removed
+    types) requires care: the dumper marks small DWARF libraries ``elf_only_mode``
+    too, so that flag alone is not enough. The distinguishing fact is that a
+    stripped binary is otherwise *intact* — it still exports essentially all of
+    the old side's symbols; only its debug info is gone. A build that genuinely
+    removed a class (e.g. examples/case107) also drops that class's exported
+    methods, so symbol retention is low and the removal is still reported.
+    """
+    new_stripped_of_types = (
+        getattr(new, "elf_only_mode", False)
+        and bool(new.functions or new.variables)
+        and not _has_type_evidence(new)
+        and _has_type_evidence(old)
+    )
+    if not new_stripped_of_types:
+        return False
+    # Corroborate with symbol retention: a stripped-but-intact binary keeps
+    # (almost) all of the old side's exported functions. If most of them are
+    # gone, the library genuinely changed and removals are real.
+    old_funcs = {f.mangled for f in old.functions if f.mangled}
+    if not old_funcs:
+        return True  # no functions to corroborate; absence of types is just stripping
+    new_funcs = {f.mangled for f in new.functions if f.mangled}
+    retained = len(old_funcs & new_funcs) / len(old_funcs)
+    return retained >= 0.9
+
+
 @registry.detector("types")
 def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
@@ -52,10 +106,14 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     excl = _exclude_stdlib_namespaces(old, new)
     old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
     new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    # RD2-5: don't manufacture phantom TYPE_REMOVED when the new side is stripped.
+    suppress_removed = _removals_are_unconfirmed(old, new)
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
         if t_new is None:
+            if suppress_removed:
+                continue
             changes.append(Change(
                 kind=ChangeKind.TYPE_REMOVED,
                 symbol=name,
@@ -709,10 +767,14 @@ def _has_version_family_successor(name: str, new_typedefs: dict[str, str]) -> bo
 def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
+    # RD2-5: don't manufacture phantom TYPEDEF_REMOVED when the new side is stripped.
+    suppress_removed = _removals_are_unconfirmed(old, new)
     for alias, old_type in old.typedefs.items():
         if _is_non_abi_surface_type(alias, exclude_stdlib_namespaces=excl):
             continue
         new_type = new.typedefs.get(alias)
+        if new_type is None and suppress_removed:
+            continue
         if new_type is None:
             # Version-stamped typedefs (e.g. png_libpng_version_1_6_46) are
             # compile-time sentinels — their name encodes the version and

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -87,26 +87,25 @@ def _removals_are_unconfirmed(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     )
     if not new_stripped_of_types:
         return False
-    # Corroborate with symbol retention: a stripped-but-intact binary keeps
-    # (almost) all of the old side's exported functions. If most of them are
-    # gone, the library genuinely changed and removals are real.
+    # Corroborate with exported-symbol retention: a stripped-but-intact binary
+    # keeps (almost) all of the old side's exports; if most are gone, the library
+    # genuinely changed and removals are real.
     #
-    # Only count *exported* old functions. A DWARF-primary old snapshot also
-    # records internal/static subprograms, but the stripped new side carries
-    # dynamic exports only — counting internals would deflate retention and
-    # defeat the suppression for a genuinely intact DWARF→stripped comparison.
-    old_funcs = {
-        f.mangled for f in old.functions
-        if f.mangled and f.visibility in _PUBLIC_VIS
-    }
-    if not old_funcs:
-        return True  # no exported functions to corroborate; absence of types is just stripping
-    new_funcs = {
-        f.mangled for f in new.functions
-        if f.mangled and f.visibility in _PUBLIC_VIS
-    }
-    retained = len(old_funcs & new_funcs) / len(old_funcs)
-    return retained >= 0.9
+    # Only count *exported* symbols (PUBLIC/ELF_ONLY). A DWARF-primary old
+    # snapshot also records internal/static subprograms, but the stripped new
+    # side carries dynamic exports only — counting internals would deflate
+    # retention and defeat the suppression for a genuinely intact comparison.
+    # Prefer functions; fall back to variables for data-only DSOs so a changed
+    # variable surface still surfaces removals (CodeRabbit review on PR #275).
+    old_funcs = {k for k, v in old.function_map.items() if v.visibility in _PUBLIC_VIS}
+    if old_funcs:
+        new_funcs = {k for k, v in new.function_map.items() if v.visibility in _PUBLIC_VIS}
+        return len(old_funcs & new_funcs) / len(old_funcs) >= 0.9
+    old_vars = {k for k, v in old.variable_map.items() if v.visibility in _PUBLIC_VIS}
+    if not old_vars:
+        return True  # no exported surface to corroborate; absence of types is just stripping
+    new_vars = {k for k, v in new.variable_map.items() if v.visibility in _PUBLIC_VIS}
+    return len(old_vars & new_vars) / len(old_vars) >= 0.9
 
 
 @registry.detector("types")

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -90,10 +90,21 @@ def _removals_are_unconfirmed(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     # Corroborate with symbol retention: a stripped-but-intact binary keeps
     # (almost) all of the old side's exported functions. If most of them are
     # gone, the library genuinely changed and removals are real.
-    old_funcs = {f.mangled for f in old.functions if f.mangled}
+    #
+    # Only count *exported* old functions. A DWARF-primary old snapshot also
+    # records internal/static subprograms, but the stripped new side carries
+    # dynamic exports only — counting internals would deflate retention and
+    # defeat the suppression for a genuinely intact DWARF→stripped comparison.
+    old_funcs = {
+        f.mangled for f in old.functions
+        if f.mangled and f.visibility in _PUBLIC_VIS
+    }
     if not old_funcs:
-        return True  # no functions to corroborate; absence of types is just stripping
-    new_funcs = {f.mangled for f in new.functions if f.mangled}
+        return True  # no exported functions to corroborate; absence of types is just stripping
+    new_funcs = {
+        f.mangled for f in new.functions
+        if f.mangled and f.visibility in _PUBLIC_VIS
+    }
     retained = len(old_funcs & new_funcs) / len(old_funcs)
     return retained >= 0.9
 

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -59,18 +59,14 @@ def _breaking_symbols(result) -> set[str]:
 
 
 # ---------------------------------------------------------------------------
-# FP-3 — RTTI/typeinfo of an anonymous lambda must not be a breaking var_removed
+# FP-3 / RD2-4 — RTTI/typeinfo of an anonymous lambda must not be a breaking var_removed
 #   Real case: Protobuf 6.33.2 -> 6.33.5 (a *patch*) flagged BREAKING because
 #   `_ZTIZN6google8protobuf2io7Printer8WithDefs...EUlSt17basic_string...E_`
 #   (typeinfo for an internal lambda) "disappeared".  Lambda identity is not
-#   stable ABI.  Root cause: dumper._elf_classify_symbols() does not apply
-#   _is_abi_relevant_symbol(), and diff_symbols._var_removed has no _ZTI/_ZTS
-#   guard, so the symbol becomes a public Variable -> VAR_REMOVED (breaking).
+#   stable ABI.  Fixed in diff_symbols._public_variables: RTTI/vtable symbols of
+#   function-local types (Itanium ``_ZTIZ``/``_ZTSZ``/``_ZTVZ``/``_ZTTZ`` local-name
+#   production) are excluded from the public-variable surface.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True,
-    reason=f"known FP-3: lambda RTTI removal scored as breaking; see {REPORT}",
-)
 def test_lambda_rtti_removal_is_not_breaking():
     lambda_rtti = "_ZTIZN3foo3barEvEUlvE_"  # typeinfo of a lambda defined in foo::bar()
     lambda_rtti_name = "_ZTSZN3foo3barEvEUlvE_"
@@ -95,6 +91,28 @@ def test_lambda_rtti_removal_is_not_breaking():
     assert result.verdict not in (Verdict.BREAKING,), (
         f"removing RTTI of an anonymous lambda must not read as an ABI break; "
         f"breaking symbols: {_breaking_symbols(result)}"
+    )
+    # The lambda RTTI symbols must not surface as findings at all.
+    assert lambda_rtti not in _breaking_symbols(result)
+    assert lambda_rtti_name not in _breaking_symbols(result)
+
+
+def test_public_type_rtti_removal_is_still_breaking():
+    """Guard against over-filtering: typeinfo/vtable of a NON-local (public,
+    nameable) type must still count as a break when removed (RD2-4)."""
+    public_rtti = "_ZTIN3foo3BarE"   # typeinfo for foo::Bar (not function-local)
+    public_vtable = "_ZTVN3foo3BarE"  # vtable for foo::Bar
+    old = _elf_snapshot(
+        variables=[
+            Variable(name=public_rtti, mangled=public_rtti, type="?", visibility=Visibility.ELF_ONLY),
+            Variable(name=public_vtable, mangled=public_vtable, type="?", visibility=Visibility.ELF_ONLY),
+        ]
+    )
+    new = _elf_snapshot(variables=[])
+    result = compare(old, new)
+    breaking = _breaking_symbols(result)
+    assert public_rtti in breaking or public_vtable in breaking, (
+        "removing typeinfo/vtable of a public, nameable type must still be a break"
     )
 
 
@@ -165,16 +183,22 @@ def test_anonymous_type_removal_is_not_breaking():
 #   removals.  Real case: libxml2 2.9.7 (DWARF) -> 2.9.9 (stripped) reported
 #   1149 breaks incl. `type_removed: _xmlNode` — a core public type that still
 #   exists.  Absence of debug info on the new side is absence of *evidence*, not
-#   evidence of removal.  Root cause: diff_types emits TYPE_REMOVED whenever a
-#   type is absent from new_map, with no guard for asymmetric type coverage.
+#   evidence of removal.  Fixed in diff_types._removals_are_unconfirmed:
+#   TYPE_REMOVED/TYPEDEF_REMOVED are suppressed when the new side is a stripped
+#   binary (elf_only_mode, exports symbols, no type evidence) while the old side
+#   has type info. The dwarf detector still emits DWARF_INFO_MISSING so the
+#   coverage gap is disclosed.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=True,
-    reason=f"known FP-4: mixed DWARF/stripped fabricates removals; see {REPORT}",
-)
+def _exported_func(mangled: str):
+    from abicheck.model import Function
+    return Function(name=mangled, mangled=mangled, return_type="?",
+                    visibility=Visibility.ELF_ONLY)
+
+
 def test_stripped_new_side_does_not_fabricate_type_removals():
-    # old: rich DWARF types
+    # old: rich DWARF types + exported symbols
     old = _elf_snapshot(
+        functions=[_exported_func("xmlNewNode"), _exported_func("xmlFreeDoc")],
         types=[
             RecordType(
                 name="_xmlNode",
@@ -183,16 +207,64 @@ def test_stripped_new_side_does_not_fabricate_type_removals():
                 fields=[TypeField(name="type", type="int", offset_bits=0)],
             ),
             RecordType(name="_xmlDoc", kind="struct", size_bits=512),
-        ]
+        ],
     )
-    # new: same library, but the binary is stripped -> zero type DWARF
-    new = _elf_snapshot(types=[])
+    # new: same library, but the binary is stripped -> exports the same symbols,
+    # zero type DWARF (a real stripped .so still has a dynamic symbol table).
+    new = _elf_snapshot(
+        functions=[_exported_func("xmlNewNode"), _exported_func("xmlFreeDoc")],
+        types=[],
+    )
     new.dwarf = None
     result = compare(old, new)
     assert result.verdict not in (Verdict.BREAKING,), (
         f"types absent only because the new side is stripped must not read as "
         f"removals; breaking symbols: {_breaking_symbols(result)}"
     )
+    from abicheck.checker_policy import ChangeKind
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes)
+
+
+def test_real_removal_still_reported_when_symbols_also_dropped():
+    """The stripped-side guard must NOT hide a genuine class removal: when the
+    removed type's exported methods are also gone, symbol retention is low and
+    the removal is real (validation RD2-5; examples/case107)."""
+    from abicheck.checker_policy import BREAKING_KINDS
+    old = _elf_snapshot(
+        functions=[_exported_func("_ZN5mylib3Foo3barEv"), _exported_func("_ZN5mylib3FooC1Ev")],
+        types=[RecordType(name="mylib::Foo", kind="class", size_bits=64)],
+    )
+    # new: class and ALL its methods gone (retention 0%), only a new free fn.
+    new = _elf_snapshot(functions=[_exported_func("_ZN5mylib5otherEv")], types=[])
+    new.dwarf = None
+    result = compare(old, new)
+    assert any(c.kind in BREAKING_KINDS for c in result.changes), (
+        "removing a class together with its exported methods must still break; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_unknown_signature_not_flagged_as_change():
+    """A stripped ELF export reports return_type/type '?' — diffing a known type
+    against '?' must not fabricate func_return/params/var_type changes (RD2-5)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function, Param
+    old = _elf_snapshot(
+        functions=[Function(name="f", mangled="_Z1fi", return_type="int",
+                            params=[Param(name="a", type="int")], visibility=Visibility.PUBLIC)],
+        variables=[Variable(name="g", mangled="g", type="int", visibility=Visibility.PUBLIC)],
+    )
+    # new side: same symbols, but signature/type unknown (stripped).
+    new = _elf_snapshot(
+        functions=[Function(name="f", mangled="_Z1fi", return_type="?",
+                            params=[], visibility=Visibility.PUBLIC)],
+        variables=[Variable(name="g", mangled="g", type="?", visibility=Visibility.PUBLIC)],
+    )
+    result = compare(old, new)
+    phantom = {ChangeKind.FUNC_RETURN_CHANGED, ChangeKind.FUNC_PARAMS_CHANGED,
+               ChangeKind.VAR_TYPE_CHANGED, ChangeKind.RETURN_POINTER_LEVEL_CHANGED}
+    offenders = [c.kind.value for c in result.changes if c.kind in phantom]
+    assert offenders == [], f"unknown ('?') signatures must not be diffed: {offenders}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -310,26 +310,39 @@ def test_stripped_suppression_with_only_variable_exports():
 
 
 def test_unknown_signature_not_flagged_as_change():
-    """A stripped ELF export reports return_type/type '?' — diffing a known type
-    against '?' must not fabricate func_return/params/var_type changes (RD2-5)."""
+    """When the NEW side is a stripped symbols-only stub (return/type '?', no
+    params, no type evidence), diffing a known old signature against it must not
+    fabricate func_return/params/var_type changes (RD2-5)."""
     from abicheck.checker_policy import ChangeKind
     from abicheck.model import Function, Param
+    # old: a resolved (DWARF/header) snapshot — NOT stripped.
     old = _elf_snapshot(
         functions=[Function(name="f", mangled="_Z1fi", return_type="int",
                             params=[Param(name="a", type="int")], visibility=Visibility.PUBLIC)],
         variables=[Variable(name="g", mangled="g", type="int", visibility=Visibility.PUBLIC)],
+        types=[RecordType(name="Cfg", kind="struct", size_bits=32)],
     )
-    # new side: same symbols, but signature/type unknown (stripped).
+    old.elf_only_mode = False
+    # new: stripped symbols-only — same symbols, signatures unknown, no types.
     new = _elf_snapshot(
         functions=[Function(name="f", mangled="_Z1fi", return_type="?",
                             params=[], visibility=Visibility.PUBLIC)],
         variables=[Variable(name="g", mangled="g", type="?", visibility=Visibility.PUBLIC)],
     )
+    new.dwarf = None
     result = compare(old, new)
     phantom = {ChangeKind.FUNC_RETURN_CHANGED, ChangeKind.FUNC_PARAMS_CHANGED,
                ChangeKind.VAR_TYPE_CHANGED, ChangeKind.RETURN_POINTER_LEVEL_CHANGED}
     offenders = [c.kind.value for c in result.changes if c.kind in phantom]
     assert offenders == [], f"unknown ('?') signatures must not be diffed: {offenders}"
+
+
+def _resolved_snapshot(**kw):
+    """A resolved (DWARF/header) snapshot — elf_only_mode False, so its empty
+    parameter lists mean 'zero args', not 'unknown'."""
+    snap = _elf_snapshot(**kw)
+    snap.elf_only_mode = False
+    return snap
 
 
 def test_param_change_still_detected_when_only_return_is_unknown():
@@ -338,15 +351,53 @@ def test_param_change_still_detected_when_only_return_is_unknown():
     unknown-return guard must not swallow it (Codex review on PR #275)."""
     from abicheck.checker_policy import ChangeKind
     from abicheck.model import Function, Param
-    old = _elf_snapshot(functions=[Function(
+    old = _resolved_snapshot(functions=[Function(
         name="f", mangled="_Z1fi", return_type="?",
         params=[Param(name="a", type="int")], visibility=Visibility.PUBLIC)])
-    new = _elf_snapshot(functions=[Function(
+    new = _resolved_snapshot(functions=[Function(
         name="f", mangled="_Z1fi", return_type="?",
         params=[Param(name="a", type="long")], visibility=Visibility.PUBLIC)])
     result = compare(old, new)
     assert any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes), (
         "param int->long under an unresolved return must still be detected; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_individually_unresolved_param_type_not_diffed():
+    """In a resolved snapshot, a single parameter whose type DWARF left as '?'
+    must not be diffed against a known type (diffing against unknown is
+    meaningless), even though the function is otherwise comparable (RD2-5)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function, Param
+    old = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1fi", return_type="int",
+        params=[Param(name="a", type="int")], visibility=Visibility.PUBLIC)])
+    new = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1fi", return_type="int",
+        params=[Param(name="a", type="?")], visibility=Visibility.PUBLIC)])
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes), (
+        "a parameter with an unresolved '?' type must not be diffed; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_zero_arg_to_one_arg_detected_under_unknown_return():
+    """f(void) -> f(int) with an unresolved ('?') return in a resolved snapshot
+    must still be a parameter change: an empty list there means zero args, not
+    'unknown params' (Codex review on PR #275)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function, Param
+    old = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1fv", return_type="?", params=[],
+        visibility=Visibility.PUBLIC)])
+    new = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1fv", return_type="?",
+        params=[Param(name="a", type="int")], visibility=Visibility.PUBLIC)])
+    result = compare(old, new)
+    assert any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes), (
+        "f(void)->f(int) under an unresolved return must still be detected; "
         f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
     )
 

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -6,10 +6,13 @@ binaries (oneTBB, Protobuf, libxml2, …). They drive the public
 :func:`abicheck.checker.compare` pipeline with minimal synthetic snapshots that
 isolate the responsible mechanism.
 
-The four scenarios correspond to FP-1…FP-4 in ``validation/DESIGN_ANALYSIS.md``.
-Tests asserting behaviour that abicheck does **not** yet implement are marked
-``xfail(strict=True)`` so they flip to PASS the moment the architectural fix
-lands (and fail loudly if someone "fixes" them without removing the marker).
+These cover the FP-1…FP-4 families from ``validation/DESIGN_ANALYSIS.md`` plus
+the RD2-* refinements (std:: leaks via the DWARF struct/enum detector, lambda
+RTTI churn, mixed DWARF→stripped phantom removals, and unknown-``"?"`` signature
+handling). Each now asserts the implemented behaviour directly — the scenarios
+that were previously ``xfail(strict=True)`` placeholders are live assertions —
+and several guard-rail tests ensure the suppressions do not hide genuine breaks
+(public-type RTTI removal, low-retention class removal, real param changes).
 
 No external tools or binaries are required — these run in the default fast lane.
 """
@@ -379,6 +382,95 @@ def test_individually_unresolved_param_type_not_diffed():
     result = compare(old, new)
     assert not any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes), (
         "a parameter with an unresolved '?' type must not be diffed; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_stripped_suppression_with_no_exported_surface():
+    """When the old side has type evidence but no exported functions or
+    variables to corroborate, a stripped new side is treated as pure stripping
+    and removals are suppressed (covers the 'no exported surface' branch)."""
+    from abicheck.checker_policy import ChangeKind
+    old = _elf_snapshot(types=[RecordType(name="_xmlNode", kind="struct", size_bits=960)])
+    # new: stripped — exports a symbol (so it is recognised as a real binary)
+    # but carries no type evidence; old has no exported symbols to compare.
+    new = _elf_snapshot(
+        functions=[_exported_func("xmlNewNode")],
+        types=[],
+    )
+    new.dwarf = None
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes)
+
+
+def test_param_pointer_depth_not_diffed_for_unresolved_param():
+    """An individually unresolved ('?') parameter must not produce a phantom
+    PARAM_POINTER_LEVEL_CHANGED (depth falls back to 0) (CodeRabbit, PR #275)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function, Param
+    old = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1fPi", return_type="void",
+        params=[Param(name="p", type="int *", pointer_depth=1)],
+        visibility=Visibility.PUBLIC)])
+    new = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1fPi", return_type="void",
+        params=[Param(name="p", type="?", pointer_depth=0)],
+        visibility=Visibility.PUBLIC)])
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.PARAM_POINTER_LEVEL_CHANGED for c in result.changes), (
+        "unresolved '?' param must not yield a phantom pointer-level change; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_data_only_library_removal_still_reported_when_variables_change():
+    """For a data-only DSO (no exported functions), a stripped new side must not
+    auto-suppress removals when the exported *variable* surface also shrank — the
+    retention corroboration falls back to variables (CodeRabbit, PR #275)."""
+    from abicheck.checker_policy import ChangeKind
+    old = _elf_snapshot(
+        variables=[
+            Variable(name=f"v{i}", mangled=f"v{i}", type="int", visibility=Visibility.ELF_ONLY)
+            for i in range(10)
+        ],
+        types=[RecordType(name="Cfg", kind="struct", size_bits=64)],
+    )
+    # new: stripped of types AND most variables gone (only 1 of 10 retained) →
+    # the library genuinely changed, so the type removal must still be reported.
+    new = _elf_snapshot(
+        variables=[Variable(name="v0", mangled="v0", type="?", visibility=Visibility.ELF_ONLY)],
+        types=[],
+    )
+    new.dwarf = None
+    result = compare(old, new)
+    assert any(c.kind == ChangeKind.TYPE_REMOVED and c.symbol == "Cfg" for c in result.changes), (
+        "low variable retention must not auto-suppress a real type removal; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_data_only_library_stripped_suppresses_when_variables_retained():
+    """Mirror of the above: a data-only DSO that is merely stripped (all exported
+    variables retained) must still suppress phantom type removals."""
+    from abicheck.checker_policy import ChangeKind
+    old = _elf_snapshot(
+        variables=[
+            Variable(name=f"v{i}", mangled=f"v{i}", type="int", visibility=Visibility.ELF_ONLY)
+            for i in range(10)
+        ],
+        types=[RecordType(name="Cfg", kind="struct", size_bits=64)],
+    )
+    new = _elf_snapshot(
+        variables=[
+            Variable(name=f"v{i}", mangled=f"v{i}", type="?", visibility=Visibility.ELF_ONLY)
+            for i in range(10)
+        ],
+        types=[],
+    )
+    new.dwarf = None
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes), (
+        "a merely-stripped data-only DSO must not fabricate type removals; "
         f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
     )
 

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -332,6 +332,25 @@ def test_unknown_signature_not_flagged_as_change():
     assert offenders == [], f"unknown ('?') signatures must not be diffed: {offenders}"
 
 
+def test_param_change_still_detected_when_only_return_is_unknown():
+    """A DWARF/header snapshot can resolve params while leaving the return type
+    unknown ('?'). A real param change (int->long) must still be flagged — the
+    unknown-return guard must not swallow it (Codex review on PR #275)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function, Param
+    old = _elf_snapshot(functions=[Function(
+        name="f", mangled="_Z1fi", return_type="?",
+        params=[Param(name="a", type="int")], visibility=Visibility.PUBLIC)])
+    new = _elf_snapshot(functions=[Function(
+        name="f", mangled="_Z1fi", return_type="?",
+        params=[Param(name="a", type="long")], visibility=Visibility.PUBLIC)])
+    result = compare(old, new)
+    assert any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes), (
+        "param int->long under an unresolved return must still be detected; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # FP-1 guard rail — the std:: exclusion must NOT hide breaks when the inspected
 #   DSO *is* the C++ runtime/standard library (libstdc++/libc++).  There std::

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -403,6 +403,27 @@ def test_stripped_suppression_with_no_exported_surface():
     assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes)
 
 
+def test_param_change_on_known_param_detected_despite_unrelated_unknown():
+    """A real change on a fully-known parameter must still be flagged even when
+    another parameter in the same signature is unresolved ('?'); parameters are
+    resolved independently (Codex review on PR #275)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function, Param
+    old = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1f", return_type="void",
+        params=[Param(name="a", type="?"), Param(name="b", type="int")],
+        visibility=Visibility.PUBLIC)])
+    new = _resolved_snapshot(functions=[Function(
+        name="f", mangled="_Z1f", return_type="void",
+        params=[Param(name="a", type="?"), Param(name="b", type="long")],
+        visibility=Visibility.PUBLIC)])
+    result = compare(old, new)
+    assert any(c.kind == ChangeKind.FUNC_PARAMS_CHANGED for c in result.changes), (
+        "int->long on a known param must be detected despite an unrelated '?' param; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
 def test_param_pointer_depth_not_diffed_for_unresolved_param():
     """An individually unresolved ('?') parameter must not produce a phantom
     PARAM_POINTER_LEVEL_CHANGED (depth falls back to 0) (CodeRabbit, PR #275)."""

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -209,6 +209,7 @@ def test_stripped_new_side_does_not_fabricate_type_removals():
             RecordType(name="_xmlDoc", kind="struct", size_bits=512),
         ],
     )
+    old.typedefs = {"xmlNodePtr": "_xmlNode *", "xmlDocPtr": "_xmlDoc *"}
     # new: same library, but the binary is stripped -> exports the same symbols,
     # zero type DWARF (a real stripped .so still has a dynamic symbol table).
     new = _elf_snapshot(
@@ -223,6 +224,7 @@ def test_stripped_new_side_does_not_fabricate_type_removals():
     )
     from abicheck.checker_policy import ChangeKind
     assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes)
+    assert not any(c.kind == ChangeKind.TYPEDEF_REMOVED for c in result.changes)
 
 
 def test_real_removal_still_reported_when_symbols_also_dropped():
@@ -242,6 +244,69 @@ def test_real_removal_still_reported_when_symbols_also_dropped():
         "removing a class together with its exported methods must still break; "
         f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
     )
+
+
+def test_stripped_suppression_counts_only_exported_functions():
+    """The stripped-side retention check must ignore internal/static DWARF
+    subprograms: a DWARF-primary old snapshot records them as functions, but the
+    stripped new side only has dynamic exports. Counting internals would deflate
+    retention and defeat the suppression for an intact DWARF→stripped bump
+    (Codex review on PR #275)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function
+    exported = [_exported_func("xmlNewNode"), _exported_func("xmlFreeDoc")]
+    # old: 2 exported + many internal (HIDDEN) DWARF subprograms + rich types.
+    internal = [
+        Function(name=f"__internal_{i}", mangled=f"__internal_{i}",
+                 return_type="void", visibility=Visibility.HIDDEN)
+        for i in range(50)
+    ]
+    old = _elf_snapshot(
+        functions=exported + internal,
+        types=[RecordType(name="_xmlNode", kind="struct", size_bits=960)],
+    )
+    # new: stripped → exports the same 2 public symbols, no types, no internals.
+    new = _elf_snapshot(functions=list(exported), types=[])
+    new.dwarf = None
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes), (
+        "internal DWARF functions must not deflate retention and re-enable the "
+        f"phantom avalanche; changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_has_type_evidence_via_dwarf_structs_blocks_suppression():
+    """When the new side still carries DWARF *content* (structs), it is not
+    stripped and removals are NOT suppressed (covers the DWARF branch of the
+    type-evidence check)."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.dwarf_metadata import DwarfMetadata, StructLayout
+    old = _elf_snapshot(
+        functions=[_exported_func("api")],
+        types=[RecordType(name="Gone", kind="struct", size_bits=32)],
+    )
+    new = _elf_snapshot(functions=[_exported_func("api")], types=[])
+    # new has real DWARF content → has type evidence → not "stripped".
+    new.dwarf = DwarfMetadata(structs={"Other": StructLayout(name="Other", byte_size=4)}, has_dwarf=True)
+    result = compare(old, new)
+    assert any(c.kind == ChangeKind.TYPE_REMOVED and c.symbol == "Gone" for c in result.changes)
+
+
+def test_stripped_suppression_with_only_variable_exports():
+    """A stripped new side that exports only variables (no functions) is still
+    recognised as stripped (covers the 'no exported functions' branch)."""
+    from abicheck.checker_policy import ChangeKind
+    old = _elf_snapshot(
+        variables=[Variable(name="g", mangled="g", type="int", visibility=Visibility.ELF_ONLY)],
+        types=[RecordType(name="_xmlNode", kind="struct", size_bits=960)],
+    )
+    new = _elf_snapshot(
+        variables=[Variable(name="g", mangled="g", type="?", visibility=Visibility.ELF_ONLY)],
+        types=[],
+    )
+    new.dwarf = None
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes)
 
 
 def test_unknown_signature_not_flagged_as_change():

--- a/tests/test_sprint3_dwarf.py
+++ b/tests/test_sprint3_dwarf.py
@@ -156,6 +156,71 @@ def test_field_removed() -> None:
 
 # ── field type size changed ───────────────────────────────────────────────────
 
+def test_stdlib_struct_layout_filtered_in_dwarf_only_mode() -> None:
+    """std::/__gnu_cxx::/anonymous types leaked into DWARF (no header model)
+    must not be diffed as the inspected library's own struct layout.
+
+    Regression for validation RD2-1: the std::/anonymous surface filter was
+    wired into the type/enum/typedef detectors but NOT the DWARF struct-layout
+    detector, so e.g. ``std::__cxx11::basic_string<...>::npos`` and
+    ``std::integral_constant<...>::value`` still scored STRUCT_FIELD_REMOVED and
+    drove a false BREAKING verdict on an ABI-compatible bump.
+    """
+    leaked = {
+        "std::__cxx11::basic_string<char>": _struct(
+            "std::__cxx11::basic_string<char>", 32, fields=[
+                _field("npos", "unsigned long", 0, 8),
+                _field("_M_p", "char*", 8, 8),
+            ]),
+        "std::integral_constant<bool, false>": _struct(
+            "std::integral_constant<bool, false>", 1, fields=[_field("value", "bool", 0, 1)]),
+        "__gnu_cxx::__ops::_Iter_less_iter": _struct(
+            "__gnu_cxx::__ops::_Iter_less_iter", 8, fields=[_field("_M_x", "int", 0, 4)]),
+    }
+    # New side drops fields from every leaked std:: type (toolchain DWARF churn).
+    leaked_new = {
+        "std::__cxx11::basic_string<char>": _struct(
+            "std::__cxx11::basic_string<char>", 32, fields=[_field("_M_p", "char*", 8, 8)]),
+        "std::integral_constant<bool, false>": _struct(
+            "std::integral_constant<bool, false>", 1, fields=[]),
+        "__gnu_cxx::__ops::_Iter_less_iter": _struct(
+            "__gnu_cxx::__ops::_Iter_less_iter", 8, fields=[]),
+    }
+    old = _snap(_meta(structs=leaked))
+    new = _snap(_meta(structs=leaked_new))
+    result = compare(old, new)
+    offenders = [
+        c for c in result.changes
+        if c.kind in {
+            ChangeKind.STRUCT_FIELD_REMOVED,
+            ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+            ChangeKind.STRUCT_SIZE_CHANGED,
+        }
+        and c.symbol.startswith(("std::", "__gnu_cxx::"))
+    ]
+    assert offenders == [], f"std:: layout changes leaked as findings: {[c.symbol for c in offenders]}"
+    assert result.verdict in (Verdict.COMPATIBLE, Verdict.NO_CHANGE)
+
+
+def test_stdlib_struct_layout_kept_when_target_is_cxx_runtime() -> None:
+    """When the inspected DSO *is* the C++ runtime, std:: layout IS its own ABI
+    surface and must still be diffed (the filter must not hide real breaks)."""
+    old_s = _struct("std::__cxx11::basic_string<char>", 32, fields=[
+        _field("npos", "unsigned long", 0, 8),
+        _field("_M_p", "char*", 8, 8),
+    ])
+    new_s = _struct("std::__cxx11::basic_string<char>", 32, fields=[
+        _field("_M_p", "char*", 8, 8),
+    ])
+    old = AbiSnapshot(library="libstdc++.so.6", version="v1")
+    new = AbiSnapshot(library="libstdc++.so.6", version="v2")
+    old.dwarf = _meta(structs={"std::__cxx11::basic_string<char>": old_s})  # type: ignore[attr-defined]
+    new.dwarf = _meta(structs={"std::__cxx11::basic_string<char>": new_s})  # type: ignore[attr-defined]
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_FIELD_REMOVED in kinds
+
+
 def test_field_type_size_changed() -> None:
     # int → long (size 4 → 8)
     old_s = _struct("Foo", 8, fields=[_field("n", "int", 0, 4)])

--- a/tests/test_sprint3_dwarf.py
+++ b/tests/test_sprint3_dwarf.py
@@ -221,6 +221,30 @@ def test_stdlib_struct_layout_kept_when_target_is_cxx_runtime() -> None:
     assert ChangeKind.STRUCT_FIELD_REMOVED in kinds
 
 
+def test_anonymous_dwarf_types_filtered_even_for_cxx_runtime() -> None:
+    """Even when the target IS the C++ runtime (std:: kept), anonymous/lambda
+    types are never stable ABI and must still be filtered from the DWARF layout
+    diff (regression for the Codex review: the filter must run for runtimes too,
+    just with std:: preserved)."""
+    old = AbiSnapshot(library="libstdc++.so.6", version="v1")
+    new = AbiSnapshot(library="libstdc++.so.6", version="v2")
+    old.dwarf = _meta(structs={  # type: ignore[attr-defined]
+        "std::vector<int>": _struct("std::vector<int>", 24, fields=[_field("_M_start", "int*", 0, 8)]),
+        "<lambda(int)>": _struct("<lambda(int)>", 8, fields=[_field("__captured", "int", 0, 4)]),
+    })
+    new.dwarf = _meta(structs={  # type: ignore[attr-defined]
+        # std:: kept and unchanged; the lambda closure type "lost" its field.
+        "std::vector<int>": _struct("std::vector<int>", 24, fields=[_field("_M_start", "int*", 0, 8)]),
+        "<lambda(int)>": _struct("<lambda(int)>", 8, fields=[]),
+    })
+    result = compare(old, new)
+    offenders = [
+        c for c in result.changes
+        if c.kind == ChangeKind.STRUCT_FIELD_REMOVED and "lambda" in c.symbol
+    ]
+    assert offenders == [], f"anonymous/lambda DWARF churn must be filtered for runtimes too: {[c.symbol for c in offenders]}"
+
+
 def test_field_type_size_changed() -> None:
     # int → long (size 4 → 8)
     old_s = _struct("Foo", 8, fields=[_field("n", "int", 0, 4)])


### PR DESCRIPTION
## What

Root-cause fixes for three false-positive classes found by validating the latest `main` against real upstream release binaries (oneTBB, Protobuf, libxml2). Per the follow-up direction, this PR contains **only the code fixes + regression tests** — the validation reports were used as input data, not committed. Each fix is verified on the real binary and covered by unit tests.

## Fixes

**1. `std::` leak through the DWARF struct/enum layout detector** (`diff_platform.py`)
In DWARF-only mode (no headers), `_diff_dwarf` fell back to comparing *all* DWARF structs/enums, so `std::`/`__gnu_cxx::`/anonymous records leaked in as `STRUCT_FIELD_REMOVED` etc. — the one detector path the merged std-filter never reached. Now gated by the shared `model.stdlib_namespaces_excluded` predicate (kept off when the DSO *is* the C++ runtime).
→ oneTBB 2021.5→2021.9 `libtbb`: **19 std:: phantom breaks → 0**.

**2. Function-local RTTI scored as public `var_removed`** (`diff_symbols.py`)
typeinfo/vtable symbols of function-local types (lambda closures; Itanium `_ZTIZ`/`_ZTSZ`/`_ZTVZ`/`_ZTTZ` local-name production) are not nameable public ABI and only churn across builds. Now excluded from the public-variable surface; typeinfo/vtable of public, nameable types is unaffected.
→ Protobuf 6.33.2→6.33.5 (patch): **BREAKING (6) → COMPATIBLE_WITH_RISK (0)**.

**3. Mixed DWARF→stripped phantom-removal avalanche** (`diff_types.py` + `diff_symbols.py`)
When the new side is a stripped binary (`elf_only_mode`, still exports symbols, no type evidence) while the old side has type info, absence of a type is absence of *evidence*, not removal. `TYPE_REMOVED`/`TYPEDEF_REMOVED` are suppressed in that case — corroborated by high exported-symbol retention so a genuine class removal (where methods are also dropped, e.g. `examples/case107`) is still reported. Signature comparisons likewise treat the unknown sentinel `"?"` as no-evidence rather than a change (`func_return`/`params`/`var_type`/`pointer_level`). The `dwarf` detector still emits `DWARF_INFO_MISSING`, so the coverage gap stays disclosed.
→ libxml2 2.9.7(dwarf)→2.9.9(stripped): **1149 breaking → 1** (the one genuinely removed export, `xmlNop`).

## Tests

- `tests/test_sprint3_dwarf.py`: std:: layout filtered in DWARF-only mode; still diffed when the target is libstdc++ itself.
- `tests/test_real_world_false_positives.py`: lambda-RTTI removal not breaking; public-type RTTI removal still breaking; stripped-side type removals suppressed; genuine class removal (low symbol retention) still reported; unknown `"?"` signatures not diffed. The FP-3 and FP-4 strict-`xfail` regressions now pass and their markers are removed.

Full fast suite green (7074 passed); `ruff check` clean; `mypy` clean; AI-readiness 0 errors.

https://claude.ai/code/session_014eEb7TvLzudxgZPYC214f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce false-positive ABI changes for stripped/partial snapshots by treating unknown-type sentinels as absent, suppressing unconfirmed type/typedef removals, and skipping unresolvable parameter-pointer diffs.
  * Exclude function-local RTTI/lambda artifacts and filter standard-library/runtime anonymous types in DWARF-aware diffs (with an exception when the target is the C++ runtime).

* **Tests**
  * Added regression and guard-rail tests covering stripped-snapshot suppression, RTTI/lambda handling, DWARF stdlib filtering, and various unknown-signature/parameter-resolution cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->