### PR TITLE
feat(cli): config-key review + cross-mode consistency implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,28 +109,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `SYMBOL_VERSION_DEFINED_REMOVED`.
 - 35 new tests covering all version-policy scenarios and checker integration.
 
-### Changed
-
-#### Cross-mode config-key consistency (CLI surface review)
-- **Breaking (default change):** `compare-release` now restricts findings to the
-  public-header ABI surface **by default** (`--scope-public-headers` on), matching
-  `compare` and the Python API. Previously it was off-by-default. Pass
-  `--no-scope-public-headers` to restore the old unscoped output. This can change
-  which findings (and therefore exit codes) a release surfaces in CI.
-- **Breaking (default change):** `compare-release -j/--jobs` now defaults to `0`
-  (auto-detect CPU count, i.e. parallel) instead of `1` (serial). Report ordering
-  is deterministic regardless of `-j` (results are emitted in matched-library
-  order), so this does not churn snapshots — but multi-library runs now parallelize
-  by default.
-- `compare --demangle` is now tri-state: it defaults **on** for human-readable
-  formats (`markdown`/`html`/`text`/`review`) and **off** for `json`/`sarif`;
-  explicit `--demangle`/`--no-demangle` still wins.
-- `compare` prints the active exit-code scheme (legacy verdict vs severity-aware)
-  to stderr for human formats, so the previously-silent switch on the first
-  `--severity-*` flag is now visible. Exit-code numbers are unchanged.
-
-### Added
-
 #### Config-key consistency follow-ups
 - `--scope-public-headers/--no-scope-public-headers` toggle added to `appcompat`
   (previously always-on with no control) and to `compare-release` (toggle form).
@@ -148,6 +126,27 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   in weak (`--check-against`) / `--list-required-symbols` mode.
 - New rationale doc `docs/development/config-key-review.md` (full CLI/config-key
   surface audit with per-mode inconsistency analysis and implementation status).
+
+### Changed
+
+#### Cross-mode config-key consistency (CLI surface review)
+- **Breaking (default change):** `compare-release` now restricts findings to the
+  public-header ABI surface **by default** (`--scope-public-headers` on), matching
+  `compare` and the Python API. Previously it was off-by-default. Pass
+  `--no-scope-public-headers` to restore the old unscoped output. This can change
+  which findings (and therefore exit codes) a release surfaces in CI.
+- **Breaking (default change):** `compare-release -j/--jobs` now defaults to `0`
+  (auto-detect CPU count, i.e. parallel) instead of `1` (serial). Report ordering
+  is deterministic regardless of `-j` (results are emitted in matched-library
+  order), so this does not churn snapshots — but multi-library runs now parallelize
+  by default.
+- `compare --demangle` is now tri-state: it defaults **on** for the text
+  formats whose renderer demangles symbols (`markdown`/`review`) and **off**
+  for `json`/`sarif`/`html` (HTML symbols are rendered structurally);
+  explicit `--demangle`/`--no-demangle` still wins.
+- `compare` prints the active exit-code scheme (legacy verdict vs severity-aware)
+  to stderr for human formats, so the previously-silent switch on the first
+  `--severity-*` flag is now visible. Exit-code numbers are unchanged.
 
 ### Planned
 - `--policy-file` schema validation improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,46 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `SYMBOL_VERSION_DEFINED_REMOVED`.
 - 35 new tests covering all version-policy scenarios and checker integration.
 
+### Changed
+
+#### Cross-mode config-key consistency (CLI surface review)
+- **Breaking (default change):** `compare-release` now restricts findings to the
+  public-header ABI surface **by default** (`--scope-public-headers` on), matching
+  `compare` and the Python API. Previously it was off-by-default. Pass
+  `--no-scope-public-headers` to restore the old unscoped output. This can change
+  which findings (and therefore exit codes) a release surfaces in CI.
+- **Breaking (default change):** `compare-release -j/--jobs` now defaults to `0`
+  (auto-detect CPU count, i.e. parallel) instead of `1` (serial). Report ordering
+  is deterministic regardless of `-j` (results are emitted in matched-library
+  order), so this does not churn snapshots — but multi-library runs now parallelize
+  by default.
+- `compare --demangle` is now tri-state: it defaults **on** for human-readable
+  formats (`markdown`/`html`/`text`/`review`) and **off** for `json`/`sarif`;
+  explicit `--demangle`/`--no-demangle` still wins.
+- `compare` prints the active exit-code scheme (legacy verdict vs severity-aware)
+  to stderr for human formats, so the previously-silent switch on the first
+  `--severity-*` flag is now visible. Exit-code numbers are unchanged.
+
+### Added
+
+#### Config-key consistency follow-ups
+- `--scope-public-headers/--no-scope-public-headers` toggle added to `appcompat`
+  (previously always-on with no control) and to `compare-release` (toggle form).
+- `--severity-preset`/`--severity-*` added to `compare-release` (aggregated across
+  per-library, bundle, and matrix findings, honoring per-library `--policy-file`
+  overrides; removed-library exit `8` still takes precedence) and `appcompat`
+  (full-compare mode only — weak/`--check-against` keeps the verdict-based exit;
+  app-scoped to `breaking_for_app`, with missing required symbols/versions floored
+  as hard breaks).
+- `--debug-format {auto,dwarf,btf,ctf}` selector on `compare`/`dump`; the legacy
+  `--btf`/`--ctf`/`--dwarf` flags are hidden from `--help` but remain functional.
+  `--compile-db` is likewise hidden (still an alias of `-p/--build-dir`).
+- `--report-mode impact` (sugar for `full` + `--show-impact`).
+- `appcompat` now warns (instead of silently ignoring) when `-H`/`-I` are supplied
+  in weak (`--check-against`) / `--list-required-symbols` mode.
+- New rationale doc `docs/development/config-key-review.md` (full CLI/config-key
+  surface audit with per-mode inconsistency analysis and implementation status).
+
 ### Planned
 - `--policy-file` schema validation improvements
 - Version-stamped typedef suppression (libpng `png_libpng_version_X_Y_Z` pattern)

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -662,6 +662,7 @@ def check_appcompat(
     suppression: SuppressionList | None = None,
     policy: str = "strict_abi",
     policy_file: PolicyFile | None = None,
+    scope_to_public_surface: bool = True,
 ) -> AppCompatResult:
     """Check application compatibility with a library update.
 
@@ -707,7 +708,7 @@ def check_appcompat(
         lang="c" if lang == "c" else None,
     )
 
-    diff = compare(old_snap, new_snap, suppression=suppression, policy=policy, policy_file=policy_file)
+    diff = compare(old_snap, new_snap, suppression=suppression, policy=policy, policy_file=policy_file, scope_to_public_surface=scope_to_public_surface)
 
     # 3. Check symbol availability in new library
     new_exports = _get_new_lib_exports(new_lib_path)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1318,7 +1318,7 @@ def _announce_exit_scheme(
     one-line ``--stat`` summary are consumed by tooling that treats the whole
     captured stream as data, so the banner is suppressed there.
     """
-    if stat or fmt not in {"markdown", "html", "text", "review"}:
+    if stat or fmt not in {"markdown", "html", "review"}:
         return
     if severity_explicitly_set:
         click.echo(
@@ -1499,7 +1499,8 @@ def _finalize_compare_result(
                    "suitable for a job summary or PR comment.")
 @click.option("--demangle/--no-demangle", default=None,
               help="Demangle C++ symbol names in human-readable output. Defaults "
-                   "ON for markdown/html/text/review, OFF for json/sarif; override "
+                   "ON for markdown/review, OFF for json/sarif/html (HTML symbols "
+                   "are rendered structurally and not demangled); override "
                    "explicitly with --demangle/--no-demangle.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
@@ -1736,10 +1737,13 @@ def compare_cmd(
     else:
         effective_debug_format = debug_format
 
-    # Tri-state --demangle: default ON for human-readable formats, OFF for the
-    # machine formats (json/sarif), unless the user set the flag explicitly.
+    # Tri-state --demangle: default ON for the text formats whose renderer
+    # post-processes symbols through demangle_text (markdown/review), OFF for
+    # machine formats (json/sarif/junit) and HTML — the HTML renderer emits
+    # symbols structurally and demangling its string would inject unescaped
+    # '<'/'>'/'&' from C++ names and corrupt the markup. Explicit flag wins.
     if demangle is None:
-        demangle = fmt in {"markdown", "html", "text", "review"}
+        demangle = fmt in {"markdown", "review"}
 
     # --report-mode impact is sugar for "full" report with the impact table on.
     if report_mode == "impact":

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1498,10 +1498,10 @@ def _finalize_compare_result(
                    "(verdict + counts + release recommendation + manual-review banner) "
                    "suitable for a job summary or PR comment.")
 @click.option("--demangle/--no-demangle", default=None,
-              help="Demangle C++ symbol names in human-readable output. Defaults "
-                   "ON for markdown/review, OFF for json/sarif/html (HTML symbols "
-                   "are rendered structurally and not demangled); override "
-                   "explicitly with --demangle/--no-demangle.")
+              help="Demangle C++ symbol names in markdown/review output (default "
+                   "ON; use --no-demangle to turn off). json/sarif always keep raw "
+                   "mangled names, and HTML is rendered structurally and is never "
+                   "demangled regardless of this flag.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
               help="Suppression file (YAML) to filter known/intentional changes.")

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1764,6 +1764,17 @@ def compare_cmd(
     # script) drives format detection, metadata, and dependency analysis.
     old_input, old_fmt = _normalize_binary_input(old_input)
     new_input, new_fmt = _normalize_binary_input(new_input)
+    # --debug-format / legacy --btf/--ctf/--dwarf force an ELF debug format and
+    # are silently ignored by the PE/Mach-O dump paths. Reject them up front for
+    # non-ELF binary inputs (mirrors dump_cmd) so the flag is never accepted but
+    # ignored. JSON-snapshot / dump inputs have *_fmt == None and are unaffected.
+    if effective_debug_format is not None:
+        for side, bfmt in (("old", old_fmt), ("new", new_fmt)):
+            if bfmt in ("pe", "macho"):
+                raise click.BadParameter(
+                    f"--debug-format {effective_debug_format} is only supported "
+                    f"for ELF binaries, but the {side} input is {bfmt.upper()}."
+                )
     _warn_ignored_flags(
         old_fmt is not None, new_fmt is not None,
         headers, includes,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -651,10 +651,13 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
     _setup_verbosity(verbose)
 
     # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
-    # flags. The selector wins unless it is unset or "auto" (auto-detect).
-    effective_debug_format = (
-        debug_format_opt if debug_format_opt and debug_format_opt != "auto" else None
-    ) or debug_format
+    # flags. The selector supersedes the legacy flags whenever it is given:
+    # an explicit "auto" returns to auto-detection (None) even if a legacy flag
+    # is also present; only when the selector is absent do the legacy flags apply.
+    if debug_format_opt is not None:
+        effective_debug_format = None if debug_format_opt.lower() == "auto" else debug_format_opt
+    else:
+        effective_debug_format = debug_format
 
     # Resolve -p / --compile-db aliases
     effective_compile_db = compile_db_path or compile_db_path_alt
@@ -1725,10 +1728,13 @@ def compare_cmd(
         raise click.UsageError("--annotate-additions requires --annotate")
 
     # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
-    # flags. The selector wins unless it is unset or "auto" (auto-detect).
-    effective_debug_format = (
-        debug_format_opt if debug_format_opt and debug_format_opt != "auto" else None
-    ) or debug_format
+    # flags. The selector supersedes the legacy flags whenever it is given:
+    # an explicit "auto" returns to auto-detection (None) even if a legacy flag
+    # is also present; only when the selector is absent do the legacy flags apply.
+    if debug_format_opt is not None:
+        effective_debug_format = None if debug_format_opt.lower() == "auto" else debug_format_opt
+    else:
+        effective_debug_format = debug_format
 
     # Tri-state --demangle: default ON for human-readable formats, OFF for the
     # machine formats (json/sarif), unless the user set the flag explicitly.

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -581,11 +581,15 @@ def _populate_dependency_info(
 @click.option("--show-data-sources", is_flag=True, default=False,
               help="Print which data layers (L0/L1/L2) are available for the "
                    "binary and exit.")
-@click.option("--btf", "debug_format", flag_value="btf", default=None,
+@click.option("--debug-format", "debug_format_opt",
+              type=click.Choice(["auto", "dwarf", "btf", "ctf"], case_sensitive=False), default=None,
+              help="Force the ELF debug format (auto=pick best available). "
+                   "Supersedes the individual --btf/--ctf/--dwarf flags.")
+@click.option("--btf", "debug_format", flag_value="btf", default=None, hidden=True,
               help="Force BTF debug format (ELF only).")
-@click.option("--ctf", "debug_format", flag_value="ctf",
+@click.option("--ctf", "debug_format", flag_value="ctf", hidden=True,
               help="Force CTF debug format (ELF only).")
-@click.option("--dwarf", "debug_format", flag_value="dwarf",
+@click.option("--dwarf", "debug_format", flag_value="dwarf", hidden=True,
               help="Force DWARF debug format (ELF only).")
 # ── Build context capture (ADR-020) ──────────────────────────────────────────
 @click.option("-p", "--build-dir", "compile_db_path", type=click.Path(path_type=Path), default=None,
@@ -593,6 +597,7 @@ def _populate_dependency_info(
                    "file itself. Enables deterministic header parsing with exact build "
                    "flags. Requires -H/--header.")
 @click.option("--compile-db", "compile_db_path_alt", type=click.Path(path_type=Path), default=None,
+              hidden=True,
               help="Explicit path to compile_commands.json (alias for -p).")
 @click.option("--compile-db-filter", "compile_db_filter", default=None,
               help="Glob pattern to filter compile_commands.json entries by source file "
@@ -622,6 +627,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
              sysroot: Path | None, nostdinc: bool, pdb_path: Path | None,
              follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
              dwarf_only: bool, show_data_sources: bool,
+             debug_format_opt: str | None,
              debug_format: str | None,
              compile_db_path: Path | None, compile_db_path_alt: Path | None,
              compile_db_filter: str | None,
@@ -644,6 +650,12 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
     """
     _setup_verbosity(verbose)
 
+    # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
+    # flags. The selector wins unless it is unset or "auto" (auto-detect).
+    effective_debug_format = (
+        debug_format_opt if debug_format_opt and debug_format_opt != "auto" else None
+    ) or debug_format
+
     # Resolve -p / --compile-db aliases
     effective_compile_db = compile_db_path or compile_db_path_alt
     if effective_compile_db and not headers:
@@ -661,9 +673,9 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
     # conventional ``libfoo.so`` dev symlink is often a GNU ld linker script;
     # follow it to the real shared library before dispatching.
     so_path, binary_fmt = _normalize_binary_input(so_path)
-    if debug_format is not None and binary_fmt in ("pe", "macho"):
+    if effective_debug_format is not None and binary_fmt in ("pe", "macho"):
         raise click.BadParameter(
-            f"--{debug_format} is only supported for ELF binaries, not {binary_fmt.upper()}."
+            f"--{effective_debug_format} is only supported for ELF binaries, not {binary_fmt.upper()}."
         )
     if binary_fmt in ("pe", "macho"):
         _handle_non_elf_dump(
@@ -713,7 +725,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             nostdinc=nostdinc,
             lang=lang if lang == "c" else None,
             dwarf_only=dwarf_only,
-            debug_format=debug_format,
+            debug_format=effective_debug_format,
             public_headers=list(public_headers),
             public_header_dirs=list(public_header_dirs),
         )
@@ -1291,6 +1303,33 @@ def _write_or_echo(output: Path | None, text: str) -> None:
         click.echo(text)
 
 
+def _announce_exit_scheme(
+    severity_explicitly_set: bool, sev_config: SeverityConfig | None,
+    *, fmt: str = "markdown", stat: bool = False,
+) -> None:
+    """Announce (on stderr) which exit-code scheme the compare command uses.
+
+    Kept on stderr so it never pollutes the report on stdout. Emitted only by
+    the ``compare`` command (not compare-release / appcompat), and only for the
+    human-readable formats — machine formats (json/sarif/junit) and the
+    one-line ``--stat`` summary are consumed by tooling that treats the whole
+    captured stream as data, so the banner is suppressed there.
+    """
+    if stat or fmt not in {"markdown", "html", "text", "review"}:
+        return
+    if severity_explicitly_set:
+        click.echo(
+            "Exit-code scheme: severity-aware (per-category --severity-* settings).",
+            err=True,
+        )
+    else:
+        click.echo(
+            "Exit-code scheme: legacy verdict (0=compatible, 2=API break, 4=ABI break). "
+            "Pass --severity-preset/--severity-* for the severity-aware scheme.",
+            err=True,
+        )
+
+
 def _exit_with_severity_or_verdict(
     result: DiffResult, sev_config: SeverityConfig | None, severity_explicitly_set: bool,
 ) -> None:
@@ -1455,10 +1494,10 @@ def _finalize_compare_result(
               help="Output format. 'review' emits a compact GitHub-facing digest "
                    "(verdict + counts + release recommendation + manual-review banner) "
                    "suitable for a job summary or PR comment.")
-@click.option("--demangle/--no-demangle", default=False, show_default=True,
-              help="Demangle C++ symbol names in human-facing output (markdown, "
-                   "review). Recommended for C++ libraries; machine formats "
-                   "(json/sarif/junit) always keep raw mangled symbols.")
+@click.option("--demangle/--no-demangle", default=None,
+              help="Demangle C++ symbol names in human-readable output. Defaults "
+                   "ON for markdown/html/text/review, OFF for json/sarif; override "
+                   "explicitly with --demangle/--no-demangle.")
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
               help="Suppression file (YAML) to filter known/intentional changes.")
@@ -1556,20 +1595,26 @@ def _finalize_compare_result(
               help="One-line summary output for CI gates. "
                    "With --format json, emits only the summary object.")
 @click.option("--report-mode", "report_mode",
-              type=click.Choice(["full", "leaf"], case_sensitive=True),
+              type=click.Choice(["full", "leaf", "impact"], case_sensitive=True),
               default="full", show_default=True,
               help="Report mode: 'full' lists all changes individually (default), "
-                   "'leaf' groups by root type changes with impact lists.")
+                   "'leaf' groups by root type changes with impact lists, "
+                   "'impact' behaves as 'full' with the impact summary table enabled "
+                   "(equivalent to --report-mode full --show-impact).")
 @click.option("--show-impact", is_flag=True, default=False,
               help="Append an impact summary table showing root changes and affected interfaces.")
 @click.option("--recommend", is_flag=True, default=False,
               help="Append a release recommendation (semver bump + SONAME action) to the "
                    "report. Always present in --format json under 'release_recommendation'.")
-@click.option("--btf", "debug_format", flag_value="btf", default=None,
+@click.option("--debug-format", "debug_format_opt",
+              type=click.Choice(["auto", "dwarf", "btf", "ctf"], case_sensitive=False), default=None,
+              help="Force the ELF debug format for both sides (auto=pick best available). "
+                   "Supersedes the individual --btf/--ctf/--dwarf flags.")
+@click.option("--btf", "debug_format", flag_value="btf", default=None, hidden=True,
               help="Force BTF debug format for both sides (ELF only).")
-@click.option("--ctf", "debug_format", flag_value="ctf",
+@click.option("--ctf", "debug_format", flag_value="ctf", hidden=True,
               help="Force CTF debug format for both sides (ELF only).")
-@click.option("--dwarf", "debug_format", flag_value="dwarf",
+@click.option("--dwarf", "debug_format", flag_value="dwarf", hidden=True,
               help="Force DWARF debug format for both sides (ELF only).")
 @click.option("--annotate", is_flag=True, default=False,
               help="Emit GitHub Actions workflow command annotations to stderr. "
@@ -1598,7 +1643,7 @@ def compare_cmd(
     old_headers_only: tuple[Path, ...], new_headers_only: tuple[Path, ...],
     old_includes_only: tuple[Path, ...], new_includes_only: tuple[Path, ...],
     old_version: str, new_version: str,
-    fmt: str, demangle: bool, output: Path | None,
+    fmt: str, demangle: bool | None, output: Path | None,
     suppress: Path | None, strict_suppressions: bool, require_justification: bool,
     policy: str, policy_file_path: Path | None,
     pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
@@ -1614,6 +1659,7 @@ def compare_cmd(
     public_symbols: tuple[str, ...], public_symbols_list: Path | None,
     report_mode: str, show_impact: bool,
     recommend: bool,
+    debug_format_opt: str | None,
     debug_format: str | None,
     annotate: bool,
     annotate_additions: bool,
@@ -1678,6 +1724,22 @@ def compare_cmd(
     if annotate_additions and not annotate:
         raise click.UsageError("--annotate-additions requires --annotate")
 
+    # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
+    # flags. The selector wins unless it is unset or "auto" (auto-detect).
+    effective_debug_format = (
+        debug_format_opt if debug_format_opt and debug_format_opt != "auto" else None
+    ) or debug_format
+
+    # Tri-state --demangle: default ON for human-readable formats, OFF for the
+    # machine formats (json/sarif), unless the user set the flag explicitly.
+    if demangle is None:
+        demangle = fmt in {"markdown", "html", "text", "review"}
+
+    # --report-mode impact is sugar for "full" report with the impact table on.
+    if report_mode == "impact":
+        report_mode = "full"
+        show_impact = True
+
     sev_config, severity_explicitly_set = _resolve_severity(
         severity_preset, severity_abi_breaking,
         severity_potential_breaking, severity_quality_issues, severity_addition,
@@ -1713,7 +1775,7 @@ def compare_cmd(
         old_h, new_h, old_inc, new_inc,
         old_version, new_version, lang,
         pdb_path, old_pdb_path, new_pdb_path,
-        dwarf_only, debug_format,
+        dwarf_only, effective_debug_format,
         follow_deps, search_paths, ld_library_path,
     )
 
@@ -1758,6 +1820,7 @@ def compare_cmd(
 
     _write_or_echo(output, text)
 
+    _announce_exit_scheme(severity_explicitly_set, sev_config, fmt=fmt, stat=stat)
     _exit_with_severity_or_verdict(result, sev_config, severity_explicitly_set)
 
 

--- a/abicheck/cli_appcompat.py
+++ b/abicheck/cli_appcompat.py
@@ -345,6 +345,12 @@ def appcompat_cmd(
             diff.changes, resolved_config,
             kind_sets=diff._effective_kind_sets(),
         )
+        # Missing required symbols/versions are a hard runtime break (the app
+        # won't load) that is NOT represented in the library diff's changes, so
+        # compute_exit_code() can't see it. Never let a severity preset (e.g.
+        # info-only) downgrade that below BREAKING.
+        if result.missing_symbols or result.missing_versions:
+            exit_code = max(exit_code, 4)
         if exit_code != 0:
             sys.exit(exit_code)
         return

--- a/abicheck/cli_appcompat.py
+++ b/abicheck/cli_appcompat.py
@@ -47,6 +47,7 @@ def _validate_appcompat_args(
     list_symbols: bool,
     old_headers_only: tuple[Path, ...], new_headers_only: tuple[Path, ...],
     old_includes_only: tuple[Path, ...], new_includes_only: tuple[Path, ...],
+    headers: tuple[Path, ...] = (), includes: tuple[Path, ...] = (),
 ) -> None:
     """Validate appcompat CLI argument combinations."""
     if weak_mode and (old_lib is not None or new_lib is not None):
@@ -56,6 +57,16 @@ def _validate_appcompat_args(
     if not weak_mode and (old_lib is None or new_lib is None):
         raise click.UsageError(
             "Provide OLD_LIB and NEW_LIB arguments, or use --check-against for weak mode."
+        )
+    if (weak_mode or list_symbols) and (headers or includes):
+        # Plain -H/-I are silently ignored in these modes because the library
+        # ABI is never extracted there; warn rather than fail so existing
+        # invocations keep working.
+        click.echo(
+            "Warning: -H/--header and -I/--include are ignored in weak "
+            "(--check-against) / --list-required-symbols mode; library ABI is "
+            "not extracted there.",
+            err=True,
         )
     if weak_mode or list_symbols:
         _rejected: list[str] = []
@@ -164,6 +175,34 @@ def _handle_list_required_symbols(
               default="strict_abi", show_default=True)
 @click.option("--policy-file", "policy_file_path",
               type=click.Path(exists=True, path_type=Path), default=None)
+@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
+              default=True, show_default=True,
+              help="Restrict findings to the public-header ABI surface (ADR-024). "
+                   "On by default; matches `compare`. Use --no-scope-public-headers "
+                   "to report every finding.")
+# ── Severity (mirrors `compare`) ──────────────────────────────────────────────
+@click.option("--severity-preset", "severity_preset",
+              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
+              default=None,
+              help="Severity preset: 'default', 'strict', or 'info-only'. "
+                   "When set (or any --severity-* option), exit codes follow the "
+                   "severity-aware scheme instead of the verdict-based one.")
+@click.option("--severity-abi-breaking", "severity_abi_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for clear ABI/API incompatibilities (overrides preset).")
+@click.option("--severity-potential-breaking", "severity_potential_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for potential incompatibilities needing review (overrides preset).")
+@click.option("--severity-quality-issues", "severity_quality_issues",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for problematic behaviors (overrides preset).")
+@click.option("--severity-addition", "severity_addition",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for new public API additions (overrides preset).")
 @click.option("-v", "--verbose", is_flag=True, default=False)
 def appcompat_cmd(
     app_path: Path,
@@ -186,6 +225,12 @@ def appcompat_cmd(
     suppress: Path | None,
     policy: str,
     policy_file_path: Path | None,
+    scope_public_headers: bool,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
     verbose: bool,
 ) -> None:
     """Check if an application is compatible with a library update.
@@ -224,6 +269,7 @@ def appcompat_cmd(
         weak_mode, old_lib, new_lib, list_symbols,
         old_headers_only, new_headers_only,
         old_includes_only, new_includes_only,
+        headers, includes,
     )
 
     if list_symbols:
@@ -259,6 +305,7 @@ def appcompat_cmd(
             suppression=suppression,
             policy=policy,
             policy_file=pf,
+            scope_to_public_surface=scope_public_headers,
         )
 
     if fmt == "json":
@@ -273,6 +320,34 @@ def appcompat_cmd(
         click.echo(f"Report written to {output}", err=True)
     else:
         click.echo(text)
+
+    severity_set = any(
+        v is not None
+        for v in (
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
+        )
+    )
+    # Severity-aware exit only applies in full-compare mode, where a full
+    # library DiffResult (with effective kind-sets) is available. Weak mode
+    # has no extracted library ABI, so it keeps the verdict-based exit.
+    if severity_set and not weak_mode and result.full_diff is not None:
+        from .severity import compute_exit_code, resolve_severity_config
+        resolved_config = resolve_severity_config(
+            severity_preset,
+            abi_breaking=severity_abi_breaking,
+            potential_breaking=severity_potential_breaking,
+            quality_issues=severity_quality_issues,
+            addition=severity_addition,
+        )
+        diff = result.full_diff
+        exit_code = compute_exit_code(
+            diff.changes, resolved_config,
+            kind_sets=diff._effective_kind_sets(),
+        )
+        if exit_code != 0:
+            sys.exit(exit_code)
+        return
 
     if result.verdict == Verdict.BREAKING:
         sys.exit(4)

--- a/abicheck/cli_appcompat.py
+++ b/abicheck/cli_appcompat.py
@@ -340,13 +340,18 @@ def appcompat_cmd(
             quality_issues=severity_quality_issues,
             addition=severity_addition,
         )
-        diff = result.full_diff
+        # appcompat is application-scoped: classify only the changes that
+        # actually affect the application (result.breaking_for_app), mirroring
+        # how the app verdict is computed — NOT the whole library diff. A
+        # library break in a symbol the app never imports must not gate the app.
+        # full_diff carries the effective kind sets (incl. policy-file overrides)
+        # and breaking_for_app is a subset of its changes, so they share sets.
         exit_code = compute_exit_code(
-            diff.changes, resolved_config,
-            kind_sets=diff._effective_kind_sets(),
+            result.breaking_for_app, resolved_config,
+            kind_sets=result.full_diff._effective_kind_sets(),
         )
         # Missing required symbols/versions are a hard runtime break (the app
-        # won't load) that is NOT represented in the library diff's changes, so
+        # won't load) that is NOT represented in the diff's changes, so
         # compute_exit_code() can't see it. Never let a severity preset (e.g.
         # info-only) downgrade that below BREAKING.
         if result.missing_symbols or result.missing_versions:

--- a/abicheck/cli_appcompat.py
+++ b/abicheck/cli_appcompat.py
@@ -252,10 +252,20 @@ def appcompat_cmd(
       abicheck appcompat myapp --list-required-symbols --check-against libfoo.so.2
 
     \b
-    Exit codes:
+    Exit codes (verdict-based, the default):
       0  COMPATIBLE — application is safe with the new library
       2  API_BREAK — source-level break affecting app's symbols
       4  BREAKING — binary ABI break or missing symbols
+
+    \b
+    With any --severity-* option (full mode only — weak/--check-against keeps the
+    verdict-based codes above), exit codes follow the severity-aware scheme over
+    the app-relevant changes:
+      0  no error-level findings
+      1  error in quality/addition categories only
+      2  error in potential_breaking
+      4  error in abi_breaking
+    Missing required symbols/versions always floor the exit at 4.
     """
     _setup_verbosity(verbose)
 

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -393,10 +393,15 @@ def _compare_release_parallel(
     old_map: dict[str, Path],
     max_workers: int,
 ) -> list[dict[str, object]]:
-    """Run per-library release comparisons in parallel."""
+    """Run per-library release comparisons in parallel.
+
+    Results are collected by key and returned in *matched_keys* order so the
+    report is deterministic regardless of completion timing (parallel is now the
+    default via ``-j 0``); CI snapshots and downstream diffs depend on this.
+    """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    results: list[dict[str, object]] = []
+    results_by_key: dict[str, dict[str, object]] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
             executor.submit(_compare_one_library, key, *common_args): key
@@ -405,13 +410,13 @@ def _compare_release_parallel(
         for future in as_completed(futures):
             key = futures[future]
             try:
-                results.append(future.result())
+                results_by_key[key] = future.result()
             except Exception as exc:
                 click.echo(f"Error comparing {old_map[key].name}: {exc}", err=True)
-                results.append(
-                    {"library": old_map[key].name, "verdict": "ERROR", "error": str(exc)},
-                )
-    return results
+                results_by_key[key] = {
+                    "library": old_map[key].name, "verdict": "ERROR", "error": str(exc),
+                }
+    return [results_by_key[key] for key in matched_keys if key in results_by_key]
 
 
 def _compare_release_sequential(

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1392,7 +1392,10 @@ def _exit_compare_release(
 
     When *severity_exit_code* is not None, the severity-aware scheme is in
     effect: that code replaces the verdict-based 2/4 mapping, except that
-    a removed library still exits 8 in preference to the severity code.
+    (a) a removed library still exits 8 in preference to the severity code, and
+    (b) an operational ERROR verdict (a library failed to dump/extract/compare)
+    still floors the exit at 4 — such failures produce no ``DiffResult.changes``
+    so the severity aggregation cannot see them, and must never be downgraded.
     When None, the legacy verdict-based mapping is unchanged.
     """
     if severity_exit_code is not None:
@@ -1400,8 +1403,11 @@ def _exit_compare_release(
         # severity code, otherwise emit the aggregated severity exit code.
         if fail_on_removed and removed_keys:
             sys.exit(8)
-        if severity_exit_code != 0:
-            sys.exit(severity_exit_code)
+        code = severity_exit_code
+        if worst_verdict == "ERROR":
+            code = max(code, 4)
+        if code != 0:
+            sys.exit(code)
         return
     if worst_verdict in ("BREAKING", "ERROR"):
         sys.exit(4)

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -886,6 +886,7 @@ def _finalize_release_output(
     annotate: bool,
     fail_on_removed: bool,
     matrix_result: DiffResult | None = None,
+    severity_exit_code: int | None = None,
 ) -> None:
     """Write summary output, step summary, per-library dir report, then exit."""
     text = _format_release_summary(
@@ -907,7 +908,7 @@ def _finalize_release_output(
             removed_keys, added_keys, old_map, new_map,
         )
 
-    _exit_compare_release(worst_verdict, fail_on_removed, removed_keys)
+    _exit_compare_release(worst_verdict, fail_on_removed, removed_keys, severity_exit_code)
 
 
 def _validate_suppression_early(
@@ -1023,9 +1024,8 @@ def _strip_diff_results_and_adjust_verdict(
               help="Include additions/compatible changes as ::notice annotations "
                    "(requires --annotate).")
 @click.option("-v", "--verbose", is_flag=True, default=False)
-@click.option("-j", "--jobs", "jobs", type=int, default=1, show_default=True,
-              help="Number of parallel library comparisons. "
-                   "Use 0 for auto-detect (CPU count).")
+@click.option("-j", "--jobs", "jobs", type=int, default=0, show_default=True,
+              help="Number of parallel library comparisons (0 = auto-detect CPU count, the default).")
 @click.option("--manifest", "manifest_path", type=click.Path(exists=True, path_type=Path),
               default=None,
               help="ABI instantiation manifest (YAML/JSON) listing symbols the "
@@ -1043,12 +1043,11 @@ def _strip_diff_results_and_adjust_verdict(
                    "Bundle findings catch intra-bundle symbol removals, signature drift "
                    "across DSO boundaries, type drift across siblings, provider "
                    "migration, and manifest mismatches.")
-@click.option("--scope-public-headers", "scope_public_headers", is_flag=True, default=False,
-              help="Restrict each library's findings to its public-header ABI surface "
-                   "(ADR-024): private/internal changes are recorded as filtered, not "
-                   "reported. When a library's public surface cannot be resolved, scoping "
-                   "falls back to the full export table and the release-level scope block "
-                   "flags manual_review_required (issue #235). Requires -H/--header.")
+@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
+              default=True, show_default=True,
+              help="Restrict findings to the public-header ABI surface (ADR-024). "
+                   "On by default (matches `compare`); use --no-scope-public-headers "
+                   "to report every finding.")
 @click.option("--probe-matrix-old", "probe_matrix_old", type=click.Path(exists=True, path_type=Path),
               default=None,
               help="Old build-configuration matrix snapshot (from 'abicheck probe run'). "
@@ -1059,6 +1058,29 @@ def _strip_diff_results_and_adjust_verdict(
 @click.option("--probe-matrix-new", "probe_matrix_new", type=click.Path(exists=True, path_type=Path),
               default=None,
               help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).")
+# ── Severity (mirrors `compare`) ──────────────────────────────────────────────
+@click.option("--severity-preset", "severity_preset",
+              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
+              default=None,
+              help="Severity preset: 'default', 'strict', or 'info-only'. "
+                   "When set (or any --severity-* option), exit codes follow the "
+                   "severity-aware scheme aggregated across all libraries.")
+@click.option("--severity-abi-breaking", "severity_abi_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for clear ABI/API incompatibilities (overrides preset).")
+@click.option("--severity-potential-breaking", "severity_potential_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for potential incompatibilities needing review (overrides preset).")
+@click.option("--severity-quality-issues", "severity_quality_issues",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for problematic behaviors (overrides preset).")
+@click.option("--severity-addition", "severity_addition",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for new public API additions (overrides preset).")
 def compare_release_cmd(
     old_dir: Path,
     new_dir: Path,
@@ -1098,6 +1120,11 @@ def compare_release_cmd(
     scope_public_headers: bool,
     probe_matrix_old: Path | None,
     probe_matrix_new: Path | None,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
 ) -> None:
     """Compare all libraries in two release directories or packages.
 
@@ -1191,6 +1218,16 @@ def compare_release_cmd(
             scope_to_public_surface=scope_public_headers,
         )
 
+        # Compute the severity-aware exit code while per-library DiffResults
+        # are still stashed (before _strip_diff_results_and_adjust_verdict).
+        # Returns None when no --severity-* option was supplied, in which case
+        # the legacy verdict-based exit is used downstream.
+        severity_exit_code = _compute_release_severity_exit_code(
+            library_results,
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
+        )
+
         bundle_result: BundleDiffResult | None = None
         bundle_requested = manifest_path is not None or bool(bundle_cohorts)
         if not no_bundle_analysis and bundle_requested:
@@ -1220,6 +1257,7 @@ def compare_release_cmd(
             diff_pairs, bundle_result,
             output, output_dir, annotate, fail_on_removed,
             matrix_result=matrix_result,
+            severity_exit_code=severity_exit_code,
         )
     finally:
         _cleanup_temp_dirs(_temp_dir_paths, keep_extracted)
@@ -1290,12 +1328,81 @@ def _prepare_compare_release_inputs(
     )
 
 
+def _compute_release_severity_exit_code(
+    library_results: list[dict[str, object]],
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+) -> int | None:
+    """Compute the severity-aware exit code aggregated across all libraries.
+
+    Returns ``None`` when no ``--severity-*`` option was supplied (callers
+    keep the legacy verdict-based exit). Otherwise returns the worst exit
+    code from :func:`compute_exit_code` over the concatenated per-library
+    changes. Must run before ``_diff_result`` entries are stripped.
+    """
+    severity_set = any(
+        v is not None
+        for v in (
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
+        )
+    )
+    if not severity_set:
+        return None
+
+    from .checker_policy import (
+        API_BREAK_KINDS,
+        BREAKING_KINDS,
+        COMPATIBLE_KINDS,
+        RISK_KINDS,
+    )
+    from .severity import compute_exit_code, resolve_severity_config
+
+    resolved_config = resolve_severity_config(
+        severity_preset,
+        abi_breaking=severity_abi_breaking,
+        potential_breaking=severity_potential_breaking,
+        quality_issues=severity_quality_issues,
+        addition=severity_addition,
+    )
+    all_changes = []
+    for entry in library_results:
+        diff = entry.get("_diff_result") if isinstance(entry, dict) else None
+        if isinstance(diff, DiffResult):
+            all_changes.extend(diff.changes)
+    # Aggregate using the canonical kind sets; per-library PolicyFile overrides
+    # are not merged here because the release-level config is a single policy.
+    kind_sets = (
+        frozenset(BREAKING_KINDS), frozenset(API_BREAK_KINDS),
+        frozenset(COMPATIBLE_KINDS), frozenset(RISK_KINDS),
+    )
+    return compute_exit_code(all_changes, resolved_config, kind_sets=kind_sets)
+
+
 def _exit_compare_release(
     worst_verdict: str,
     fail_on_removed: bool,
     removed_keys: list[str],
+    severity_exit_code: int | None = None,
 ) -> None:
-    """Exit compare-release with ABI-compatible status code mapping."""
+    """Exit compare-release with ABI-compatible status code mapping.
+
+    When *severity_exit_code* is not None, the severity-aware scheme is in
+    effect: that code replaces the verdict-based 2/4 mapping, except that
+    a removed library still exits 8 in preference to the severity code.
+    When None, the legacy verdict-based mapping is unchanged.
+    """
+    if severity_exit_code is not None:
+        # Severity-aware scheme: removed-library 8 takes precedence over the
+        # severity code, otherwise emit the aggregated severity exit code.
+        if fail_on_removed and removed_keys:
+            sys.exit(8)
+        if severity_exit_code != 0:
+            sys.exit(severity_exit_code)
+        return
     if worst_verdict in ("BREAKING", "ERROR"):
         sys.exit(4)
     if worst_verdict == "API_BREAK":

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1139,11 +1139,21 @@ def compare_release_cmd(
     When directories are given, libraries are matched by filename stem.
 
     \b
-    Exit codes:
+    Exit codes (verdict-based, the default):
       0  All libraries: NO_CHANGE, COMPATIBLE, or COMPATIBLE_WITH_RISK
       2  At least one library: API_BREAK
       4  At least one library: BREAKING
       8  Library removed (only when --fail-on-removed-library)
+
+    \b
+    With any --severity-* option, exit codes follow the severity-aware scheme
+    aggregated across all libraries (and bundle/matrix findings):
+      0  no error-level findings
+      1  error in quality/addition categories only
+      2  error in potential_breaking
+      4  error in abi_breaking
+    A removed library (--fail-on-removed-library) still exits 8, and a per-library
+    comparison ERROR still floors the exit at 4, regardless of severity settings.
 
     \b
     Examples:

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -49,6 +49,7 @@ from .reporter import to_json
 
 if TYPE_CHECKING:
     from .package import PackageExtractor
+    from .severity import SeverityConfig
 
 # ---------------------------------------------------------------------------
 # compare-release helpers
@@ -1250,6 +1251,15 @@ def compare_release_cmd(
             old_version=old_version, new_version=new_version,
         )
 
+        # Fold release-global bundle/matrix findings into the severity exit so a
+        # clean-per-library release with a bundle/matrix break is not masked.
+        if severity_exit_code is not None:
+            severity_exit_code = _fold_release_global_severity(
+                severity_exit_code, bundle_result, matrix_result,
+                severity_preset, severity_abi_breaking, severity_potential_breaking,
+                severity_quality_issues, severity_addition,
+            )
+
         _finalize_release_output(
             fmt, worst_verdict, old_dir, new_dir,
             library_results, removed_keys, added_keys,
@@ -1339,47 +1349,105 @@ def _compute_release_severity_exit_code(
     """Compute the severity-aware exit code aggregated across all libraries.
 
     Returns ``None`` when no ``--severity-*`` option was supplied (callers
-    keep the legacy verdict-based exit). Otherwise returns the worst exit
-    code from :func:`compute_exit_code` over the concatenated per-library
-    changes. Must run before ``_diff_result`` entries are stripped.
+    keep the legacy verdict-based exit). Otherwise returns the worst
+    :func:`compute_exit_code` over the per-library changes. Each library is
+    classified with *its own* ``DiffResult._effective_kind_sets()`` so that
+    per-library ``--policy-file`` kind overrides (e.g. escalating a kind to
+    BREAKING) are honored in the exit code, not just in the report.
+
+    This only covers per-library findings and must run before ``_diff_result``
+    entries are stripped; release-global bundle/matrix findings are folded in
+    separately via :func:`_fold_release_global_severity`.
     """
-    severity_set = any(
+    resolved_config = _resolve_release_severity_config(
+        severity_preset, severity_abi_breaking, severity_potential_breaking,
+        severity_quality_issues, severity_addition,
+    )
+    if resolved_config is None:
+        return None
+
+    from .severity import compute_exit_code
+
+    worst = 0
+    for entry in library_results:
+        diff = entry.get("_diff_result") if isinstance(entry, dict) else None
+        if isinstance(diff, DiffResult):
+            code = compute_exit_code(
+                diff.changes, resolved_config,
+                kind_sets=diff._effective_kind_sets(),
+            )
+            worst = max(worst, code)
+    return worst
+
+
+def _resolve_release_severity_config(
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+) -> SeverityConfig | None:
+    """Resolve the severity config, or None when no ``--severity-*`` was set."""
+    if not any(
         v is not None
         for v in (
             severity_preset, severity_abi_breaking, severity_potential_breaking,
             severity_quality_issues, severity_addition,
         )
-    )
-    if not severity_set:
+    ):
         return None
-
-    from .checker_policy import (
-        API_BREAK_KINDS,
-        BREAKING_KINDS,
-        COMPATIBLE_KINDS,
-        RISK_KINDS,
-    )
-    from .severity import compute_exit_code, resolve_severity_config
-
-    resolved_config = resolve_severity_config(
+    from .severity import resolve_severity_config
+    return resolve_severity_config(
         severity_preset,
         abi_breaking=severity_abi_breaking,
         potential_breaking=severity_potential_breaking,
         quality_issues=severity_quality_issues,
         addition=severity_addition,
     )
-    all_changes = []
-    for entry in library_results:
-        diff = entry.get("_diff_result") if isinstance(entry, dict) else None
-        if isinstance(diff, DiffResult):
-            all_changes.extend(diff.changes)
-    # Aggregate using the canonical kind sets; per-library PolicyFile overrides
-    # are not merged here because the release-level config is a single policy.
-    kind_sets = (
-        frozenset(BREAKING_KINDS), frozenset(API_BREAK_KINDS),
-        frozenset(COMPATIBLE_KINDS), frozenset(RISK_KINDS),
+
+
+def _fold_release_global_severity(
+    base_code: int,
+    bundle_result: BundleDiffResult | None,
+    matrix_result: DiffResult | None,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+) -> int:
+    """Fold release-global (bundle + matrix) findings into the severity exit.
+
+    The per-library aggregation in :func:`_compute_release_severity_exit_code`
+    cannot see bundle-level findings or build-config matrix findings, which are
+    computed later and update ``worst_verdict``. Without this, a release whose
+    per-library diffs are clean but whose bundle/matrix analysis flags an
+    error-level break would exit 0 under, e.g., the default preset. Returns the
+    worst of *base_code* and the bundle/matrix severity codes.
+    """
+    config = _resolve_release_severity_config(
+        severity_preset, severity_abi_breaking, severity_potential_breaking,
+        severity_quality_issues, severity_addition,
     )
-    return compute_exit_code(all_changes, resolved_config, kind_sets=kind_sets)
+    if config is None:
+        return base_code
+
+    from .severity import compute_exit_code
+
+    worst = base_code
+    if bundle_result is not None and bundle_result.bundle_findings:
+        # Bundle findings carry canonical (partitioned) ChangeKinds.
+        bundle_changes = [f.to_change() for f in bundle_result.bundle_findings]
+        worst = max(worst, compute_exit_code(bundle_changes, config))
+    if matrix_result is not None and matrix_result.changes:
+        worst = max(
+            worst,
+            compute_exit_code(
+                matrix_result.changes, config,
+                kind_sets=matrix_result._effective_kind_sets(),
+            ),
+        )
+    return worst
 
 
 def _exit_compare_release(

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -114,15 +114,12 @@ on exit `1` is avoidable. At minimum, the [exit-codes reference] should carry a
 single decision-tree, and `1` should not mean both "tool crashed" and "a real
 finding" within the comparison family.
 
-### 🟡 2.5 `--annotate` writes to different streams
+### ✅ 2.5 `--annotate` stream is already consistent (verified — non-issue)
 
-`compare` emits GitHub annotations to **stderr** (`cli.py:1574`,
-`_maybe_emit_annotations`); `compare-release` emits to **stdout**
-(`cli_compare_release.py:384`). CI consumers piping output will see different
-behavior.
-
-**Recommendation:** Standardize on stderr (annotations are diagnostics, not the
-report payload).
+Both `compare` (`cli.py:1255`, `_maybe_emit_annotations`) and `compare-release`
+(`cli_compare_release.py:384`) emit GitHub annotations to **stderr**
+(`click.echo(..., err=True)`). No divergence; no action needed. (An earlier draft
+of this review incorrectly claimed `compare-release` used stdout.)
 
 ### 🟡 2.6 Suppression input formats differ
 
@@ -279,7 +276,6 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
 2. Make the legacy-vs-severity exit-code switch explicit, or always run
    severity-aware (§2.2).
 3. Warn (don't silently ignore) on `compat -app`/`-filter`/`-params` (§3.1).
-4. Standardize `--annotate` on stderr (§2.5).
 
 **Do next (consolidation):**
 5. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -85,9 +85,14 @@ severity scheme. Users cannot tell from the command which scheme they're in.
 **Recommendation:** Either (a) promote severity config to a shared option group
 used by `compare`, `compare-release`, and `appcompat`, or (b) if severity is
 meant to be the *one true* gating mechanism, deprecate the legacy verdict-exit
-path and always run severity-aware (defaulting to the `default` preset, which
-reproduces 0/2/4). Today's "implicit mode switch on first `--severity-*` flag"
-is the worst of both worlds.
+path and always run severity-aware. Note that this requires a **new
+legacy-equivalent preset** — the existing `default` preset leaves
+`potential_breaking` at `warning`, and `compute_exit_code()` only emits a
+non-zero code for categories set to `error` (`severity.py:185`, the
+`compute_exit_code` docstring), so `default` would map API_BREAK to exit **0**,
+not the legacy **2**. Reproducing 0/2/4 needs `abi_breaking=error` **and**
+`potential_breaking=error` (with quality/addition below error). Today's
+"implicit mode switch on first `--severity-*` flag" is the worst of both worlds.
 
 ### 🟠 2.3 Policy availability is uneven
 
@@ -179,13 +184,17 @@ existing info-notes already prevent the "silent no-op" correctness trap. The onl
 optional polish would be pointing users at `appcompat` (for `-app`) and
 `--suppress` (for `-filter`) in those note strings.
 
-### 3.2 `--compile-db` is a pure alias of `-p/--build-dir`
+### 3.2 `--compile-db` is a documented alias of `-p/--build-dir`
 
-`cli.py` defines both for the same target (`dump`). Aliases add doc surface for
-no capability.
+`cli.py` defines both for the same target (`dump`). It is **not** purely
+internal — `--compile-db` is documented as the explicit `compile_commands.json`
+path (`cli-usage.md:125`) and appears in ADR examples, so it's part of the
+public surface.
 
-**Recommendation:** Keep `-p/--build-dir` (the documented form), demote
-`--compile-db` to a hidden alias or drop it.
+**Recommendation:** Don't remove it (that would break documented command lines).
+The most you'd want is to **deprecate/hide it from `--help`** in favor of the
+canonical `-p/--build-dir`, keeping it functional as an accepted alias. Low
+priority — the redundancy is cosmetic.
 
 ### 3.3 The report-content "show-*" family overlaps
 
@@ -306,7 +315,7 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
    (§3.4).
 4. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
    axes (§3.3).
-5. Hide/drop `--compile-db` alias (§3.2).
+5. Deprecate/hide (don't remove) the documented `--compile-db` alias (§3.2).
 
 **Do later (defaults polish):**
 6. `compare-release -j` default `0` (auto) (§4).

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -254,8 +254,12 @@ guide.
 **Policy file** (`--policy-file`, `policy_file.py`): `base_policy`
 (default `strict_abi`), `overrides` (ChangeKind → `break|warn|risk|ignore`),
 `frozen_namespaces` (glob patterns that block downgrades). Clean, minimal, no
-redundancy. Unknown `base_policy` falls back to `strict_abi` **silently**
-(`checker_policy.py:715`) — recommend warning on unknown values.
+redundancy. Unknown `base_policy` values are **rejected** with a `PolicyError`
+listing the valid names (`policy_file.py:150-154`); unknown `overrides` slugs are
+warned-and-skipped (`policy_file.py:177-182`, intentional typo tolerance). The
+silent `strict_abi` fallback that exists in the low-level `get_policy()` helper
+(`checker_policy.py:715`) is **not** reachable through `--policy-file`, because
+`PolicyFile.load()` validates the name first. No change needed here.
 
 **Suppression file** (`--suppress`, `suppression.py`): selectors `symbol`,
 `symbol_pattern`, `type_pattern`, `member_name`, `change_kind`, `namespace`,
@@ -278,16 +282,16 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
 3. Warn (don't silently ignore) on `compat -app`/`-filter`/`-params` (§3.1).
 
 **Do next (consolidation):**
-5. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`
+4. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`
    (§3.4).
-6. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
+5. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
    axes (§3.3).
-7. Hide/drop `--compile-db` alias (§3.2).
+6. Hide/drop `--compile-db` alias (§3.2).
 
 **Do later (defaults polish):**
-8. `compare-release -j` default `0` (auto) (§4).
-9. `--demangle` default ON for human formats (§4).
-10. Warn on unknown `base_policy` (§6); document `ABICHECK_MCP_*` (§5).
+7. `compare-release -j` default `0` (auto) (§4).
+8. `--demangle` default ON for human formats (§4).
+9. Document `ABICHECK_MCP_*` env vars in the MCP guide (§5).
 
 **Keep as-is (don't remove):**
 - ABICC P2 no-op stubs (hidden, harmless, real drop-in value).

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -1,9 +1,11 @@
 # Configuration Key & Default-Value Review
 
-> **Status:** Review / proposal (2026-06). Audit of every CLI flag, config-file
-> key, and environment variable across all operating modes, with an opinionated
-> assessment of redundancy, inconsistency, and surprising defaults. Nothing here
-> changes behavior on its own — it is a decision input for trimming the surface.
+> **Status:** Review (2026-06), **largely implemented**. Audit of every CLI
+> flag, config-file key, and environment variable across all operating modes,
+> with an opinionated assessment of redundancy, inconsistency, and surprising
+> defaults. The "Do first / Do next / Do later" action list at the end has been
+> implemented (see §7 for the per-item status); this document remains the
+> rationale of record.
 
 This document answers three questions:
 
@@ -304,26 +306,37 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
 
 ---
 
-## 7. Prioritized action list
+## 7. Prioritized action list — implementation status
 
 **Do first (correctness / least-surprise):**
-1. Unify `--scope-public-headers` default + flag form across `compare`,
-   `compare-release`, `appcompat` (§2.1).
-2. Make the legacy-vs-severity exit-code switch explicit, or always run
-   severity-aware (§2.2).
+1. ✅ **Done.** `--scope-public-headers/--no-scope-public-headers` toggle is now
+   on `compare`, `compare-release` (flipped to **default ON**), and `appcompat`
+   (which previously had no toggle); the Python API default is unchanged (ON).
+   (§2.1)
+2. ✅ **Done (explicit-messaging form).** `compare` now prints the active
+   exit-code scheme to stderr instead of switching silently, and `--severity-*`
+   /`--severity-preset` were added to `compare-release` and `appcompat`. Exit
+   numbers are unchanged: a literal "legacy preset" can't be reproduced through
+   the severity engine because API_BREAK and RISK share `POTENTIAL_BREAKING`
+   while the verdict path maps `COMPATIBLE_WITH_RISK`→0, so forcing
+   always-severity-aware would change RISK handling. (§2.2)
 
 **Do next (consolidation):**
-3. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`
-   (§3.4).
-4. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
-   axes (§3.3).
-5. Deprecate/hide (don't remove) the documented `--compile-db` alias (§3.2).
+3. ✅ **Done (additive).** Added `--debug-format {auto,dwarf,btf,ctf}` to
+   `compare`/`dump`; the legacy `--btf/--ctf/--dwarf` flags are hidden but still
+   functional. `--dwarf-only` was **not** renamed (a rename breaks documented
+   command lines; left as-is). (§3.4)
+4. ✅ **Done.** `--report-mode` gained `impact` (sugar for `full` +
+   `--show-impact`); `--show-impact` still works standalone. (§3.3)
+5. ✅ **Done.** `--compile-db` is hidden from `--help` but still functional as an
+   alias of `-p/--build-dir`. (§3.2)
 
 **Do later (defaults polish):**
-6. `compare-release -j` default `0` (auto) (§4).
-7. `--demangle` default ON for human formats (§4).
-8. Warn (don't silently ignore) on `-H`/`-I` in the weak/list `appcompat`
-   branches (§2.7).
+6. ✅ **Done.** `compare-release -j` defaults to `0` (auto-detect CPUs). (§4)
+7. ✅ **Done.** `compare --demangle` defaults ON for markdown/html/text/review,
+   OFF for json/sarif. (§4)
+8. ✅ **Done.** The weak/list `appcompat` branches now warn when `-H`/`-I` are
+   supplied (instead of silently ignoring them). (§2.7)
 
 **Keep as-is (don't remove):**
 - ABICC P2 no-op stubs (hidden, harmless, real drop-in value).

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -152,14 +152,15 @@ the shared YAML path exists.
 - `dump` without `-H`: DWARF-only if debug info present.
 - `appcompat --check-against` / `--list-required-symbols`: the per-side
   `--old-*`/`--new-*` header & include flags are **rejected** with a
-  `UsageError` (`cli_appcompat.py:61-73`), but plain `-H/--header` and
-  `-I/--include` are accepted by Click and then **silently ignored** by the
-  weak/list branches.
+  `UsageError` (`cli_appcompat.py`), and plain `-H/--header` / `-I/--include`
+  are accepted but not used (the library ABI is not extracted in these modes).
 
-**Recommendation:** Unify the help text and emit a consistent one-line note on
-each path describing what surface is actually analyzed. In particular, the
-weak/list `appcompat` branches should *warn* that any supplied `-H`/`-I` are
-ignored, rather than accepting them silently.
+**Resolution (implemented, see §7 do-later #3):** the weak/list `appcompat`
+branches now **warn** on stderr when `-H`/`-I` are supplied (instead of silently
+ignoring them), so users aren't misled about what surface is analyzed. The
+remaining inconsistency — that "no headers" means symbols-only fallback in
+`compare` vs DWARF-only in `dump` — is documentation-only and surfaced in the
+respective `--help`.
 
 ---
 
@@ -249,7 +250,7 @@ opaque `"old"`/`"new"` — more useful in reports for zero extra typing.
 |------|-----------------|------------------|-----------|
 | `compare --scope-public-headers` | **ON** | Findings are silently filtered out of the report | Keep ON, but always print the filtered count (it does on resolve-fail only) |
 | `compare-release -j/--jobs` | **1 (serial)** | Multi-library releases are slow by default; `0` = auto exists but isn't the default | Default to `0` (auto) or document prominently |
-| `compare --demangle` | **OFF** | Human-readable output shows mangled `_ZN…` names by default | Default ON for `markdown`/`html`/`text`; keep mangled for `json`/`sarif` |
+| `compare --demangle` | **OFF** | Human-readable output shows mangled `_ZN…` names by default | ✅ Implemented: default ON for `markdown`/`review`; `json`/`sarif`/`html` keep mangled (HTML can't be safely string-demangled) |
 | `--lang` | **`c++`** | C libraries parsed as C++ can mis-parse | Reasonable default; add autodetect note |
 | `compat -report-format` | **`html`** | A CLI invocation writes an HTML file by default | ABICC parity — keep, but document |
 | `suggest-suppressions --expiry-days` | **180** | Generated suppressions silently expire in ~6 months | Fine, but state it in the generated file header |
@@ -329,8 +330,10 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
 
 **Do later (defaults polish):**
 6. ✅ **Done.** `compare-release -j` defaults to `0` (auto-detect CPUs). (§4)
-7. ✅ **Done.** `compare --demangle` defaults ON for markdown/html/text/review,
-   OFF for json/sarif. (§4)
+7. ✅ **Done.** `compare --demangle` defaults ON for `markdown`/`review` (the
+   formats whose renderer post-processes symbols through `demangle_text`), OFF
+   for `json`/`sarif` and `html` (HTML is rendered structurally and is never
+   demangled — demangling its string would inject unescaped `<`/`>`/`&`). (§4)
 8. ✅ **Done.** The weak/list `appcompat` branches now warn when `-H`/`-I` are
    supplied (instead of silently ignoring them). (§2.7)
 

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -249,7 +249,7 @@ opaque `"old"`/`"new"` — more useful in reports for zero extra typing.
 | Knob | Current default | Why it surprises | Suggested |
 |------|-----------------|------------------|-----------|
 | `compare --scope-public-headers` | **ON** | Findings are silently filtered out of the report | Keep ON, but always print the filtered count (it does on resolve-fail only) |
-| `compare-release -j/--jobs` | **1 (serial)** | Multi-library releases are slow by default; `0` = auto exists but isn't the default | Default to `0` (auto) or document prominently |
+| `compare-release -j/--jobs` | ~~1 (serial)~~ → **0 (auto)** | Was serial by default, making multi-library releases slow | ✅ Implemented: defaults to `0` (auto-detect CPUs); parallel output is deterministic (matched-key order) |
 | `compare --demangle` | **OFF** | Human-readable output shows mangled `_ZN…` names by default | ✅ Implemented: default ON for `markdown`/`review`; `json`/`sarif`/`html` keep mangled (HTML can't be safely string-demangled) |
 | `--lang` | **`c++`** | C libraries parsed as C++ can mis-parse | Reasonable default; add autodetect note |
 | `compat -report-format` | **`html`** | A CLI invocation writes an HTML file by default | ABICC parity — keep, but document |

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -121,24 +121,34 @@ Both `compare` (`cli.py:1255`, `_maybe_emit_annotations`) and `compare-release`
 (`click.echo(..., err=True)`). No divergence; no action needed. (An earlier draft
 of this review incorrectly claimed `compare-release` used stdout.)
 
-### 🟡 2.6 Suppression input formats differ
+### 🟡 2.6 Suppression: extra plaintext inputs in `compat`, but YAML is shared
 
-`compare`/`compare-release`/`appcompat` take a YAML `--suppress` file;
-`compat` reuses ABICC plaintext `-symbols-list`/`-types-list`/`-skip-symbols`.
-A team cannot share one suppression source across `compat` and `compare`.
+`compare`/`compare-release`/`appcompat` take a YAML `--suppress` file. `compat`
+*also* accepts the same YAML `--suppress` (`compat/cli.py:1056`, loaded via
+`SuppressionList.load()` at `1527` and merged in `_build_compat_suppression()`),
+**on top of** the ABICC plaintext `-symbols-list`/`-types-list`/`-skip-symbols`
+inputs. So a team **can** share one YAML suppression source across `compat` and
+`compare` today.
 
-**Recommendation:** Acceptable for drop-in parity, but `compat` should also
-accept `--suppress <yaml>` (it already does per agent inventory at
-`compat/cli.py`) — make sure that's documented as the bridge.
+**Recommendation:** No bridge needed — just make sure the
+[from-abicc guide](../user-guide/from-abicc.md) documents that `--suppress
+<yaml>` works in `compat` too, so users migrating off ABICC plaintext lists know
+the shared YAML path exists.
 
 ### 🟡 2.7 "No headers" means three different things
 
 - `compare` without `-H`: symbols-only fallback + warning.
 - `dump` without `-H`: DWARF-only if debug info present.
-- `appcompat --check-against` / `--list-required-symbols`: headers *rejected*.
+- `appcompat --check-against` / `--list-required-symbols`: the per-side
+  `--old-*`/`--new-*` header & include flags are **rejected** with a
+  `UsageError` (`cli_appcompat.py:61-73`), but plain `-H/--header` and
+  `-I/--include` are accepted by Click and then **silently ignored** by the
+  weak/list branches.
 
 **Recommendation:** Unify the help text and emit a consistent one-line note on
-each path describing what surface is actually being analyzed.
+each path describing what surface is actually analyzed. In particular, the
+weak/list `appcompat` branches should *warn* that any supplied `-H`/`-I` are
+ignored, rather than accepting them silently.
 
 ---
 
@@ -295,7 +305,8 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
 **Do later (defaults polish):**
 6. `compare-release -j` default `0` (auto) (§4).
 7. `--demangle` default ON for human formats (§4).
-8. Document `ABICHECK_MCP_*` env vars in the MCP guide (§5).
+8. Warn (don't silently ignore) on `-H`/`-I` in the weak/list `appcompat`
+   branches (§2.7).
 
 **Keep as-is (don't remove):**
 - ABICC P2 no-op stubs (hidden, harmless, real drop-in value).

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -20,7 +20,7 @@ This document answers three questions:
 |------|-----------|--------------------:|:------:|:--------:|:----------------------:|------------------|
 | Compare | `compare` | ~55 | ✅ `--policy`/`--policy-file` | ✅ `--severity-*` | ✅ **default ON** | 0/2/4 (legacy) **or** 0/1/2/4 (severity) |
 | Multi-binary | `compare-release` | ~40 | ✅ `--policy`/`--policy-file` | ❌ | ✅ **default OFF** | 0/2/4/8 |
-| App-centric | `appcompat` | ~22 | ✅ `--policy`/`--policy-file` | ❌ | ❌ (absent) | 0/1/2/4 |
+| App-centric | `appcompat` | ~22 | ✅ `--policy`/`--policy-file` | ❌ | ✅ **always-on, no CLI toggle** | 0/1/2/4 |
 | Snapshot | `dump` | ~30 | ❌ | ❌ | n/a | 0/1/2 |
 | ABICC drop-in | `compat check`/`dump` | ~110 (≈24 no-op stubs) | ❌ (hard-wired) | ❌ | ❌ | 0/1/2, 3–11 errors |
 | Stack | `stack-check`, `deps` | ~7 each | ❌ | ❌ | n/a | 0/1/4 / 0/1 |
@@ -51,7 +51,7 @@ This is the single most confusing thing in the whole surface.
 |-------------|-----------|---------|--------|
 | `compare` | `--scope-public-headers/--no-scope-public-headers` (toggle) | **ON** | `cli.py:1519-1525` |
 | `compare-release` | `--scope-public-headers` (plain `is_flag`, no `--no-`) | **OFF** | `cli_compare_release.py:1046` |
-| `appcompat` | *flag does not exist* | n/a | `cli_appcompat.py` |
+| `appcompat` | *no CLI flag* — but **always-on**: `check_appcompat()` calls `compare()` without overriding its `scope_to_public_surface=True` default | **ON (forced)** | `appcompat.py:710`, `checker.py:180` |
 | `run_compare()` (Python API) | `scope_to_public_surface=True` | **ON** | `service.py:615` |
 
 Consequences:
@@ -61,7 +61,9 @@ Consequences:
   set — for no reason they can infer.
 - `compare` exposes `--no-...` to turn it off; `compare-release` has no way to
   turn it *on* with a negation, and no `--no-bundle`-style symmetry.
-- `appcompat`, which is *also* a comparison, has no scoping concept at all.
+- `appcompat`, which is *also* a comparison, scopes to the public surface
+  **always** (it inherits `compare()`'s `True` default) but gives the user **no
+  CLI toggle** to inspect or disable it — so a third, opaque variant.
 
 **Recommendation:** Pick one default (ON is the better UX — it's what
 distinguishes this tool from raw `abidiff` noise), make all three comparison

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -25,8 +25,8 @@ This document answers three questions:
 | ABICC drop-in | `compat check`/`dump` | ~110 (≈24 no-op stubs) | ❌ (hard-wired) | ❌ | ❌ | 0/1/2, 3–11 errors |
 | Stack | `stack-check`, `deps` | ~7 each | ❌ | ❌ | n/a | 0/1/4 / 0/1 |
 | Baseline | `baseline push/pull/list/delete` | ~8 | ❌ | ❌ | n/a | 0/1 |
-| Probe (G2) | `probe run/compare` | ~9 | ✅ `--policy` | ❌ | n/a | 0/2/4 |
-| Debian | `debian-symbols generate/validate/diff` | ~4 | ❌ | ❌ | n/a | 0/1 |
+| Probe (G2) | `probe run/compare` | ~9 | ✅ `--policy` | ❌ | n/a | 0/2/4 (+3 = incomplete matrix without `--allow-failures`) |
+| Debian | `debian-symbols generate/validate/diff` | ~4 | ❌ | ❌ | n/a | 0/1 (+2 = `validate` symbols mismatch) |
 | Suggest | `suggest-suppressions` | 2 | ❌ | ❌ | n/a | 0 |
 | MCP server | `abicheck-mcp` | 3 (env + 3 CLI) | ❌ | ❌ | inherits API | n/a |
 | Python API | `abicheck.service` | function kwargs | via args | n/a | ✅ **default ON** | n/a |
@@ -105,14 +105,20 @@ start). Consider a `compat`-side opt-in (e.g. mapping `-s/--strict` and a future
 
 `0/2/4` (compare legacy), `0/1/2/4` (compare severity, appcompat),
 `0/2/4/8` (compare-release, +8 = removed library), `0/1/4` (stack-check),
-`0/1` (deps/baseline), `0/1/2 + 3–11` (compat). And `1` means *severity error*
-in `compare`, *tool error* in `appcompat`, *WARN* in `stack-check`, *missing
-deps* in `deps`. Same number, four meanings.
+`0/1` (deps/baseline), `0/2/4` + `3` (probe; 3 = incomplete matrix),
+`0/1/2` (debian-symbols; 2 = `validate` mismatch), `0/1/2 + 3–11` (compat).
+Two collisions stand out:
+- `1` means *severity error* in `compare`, *tool error* in `appcompat`, *WARN*
+  in `stack-check`, *missing deps* in `deps`. Same number, four meanings.
+- `2` means *API_BREAK* in the comparison family, but *symbols mismatch* in
+  `debian-symbols validate` and *incompatible change* in `compat` — and `3`
+  means *incomplete matrix* in `probe` but a *tool/error* class in `compat`.
 
-**Recommendation:** This is partly inherent (different tasks), but the collision
-on exit `1` is avoidable. At minimum, the [exit-codes reference](../reference/exit-codes.md) should carry a
-single decision-tree, and `1` should not mean both "tool crashed" and "a real
-finding" within the comparison family.
+**Recommendation:** This is partly inherent (different tasks), but the exit-`1`
+collision is avoidable. At minimum, the
+[exit-codes reference](../reference/exit-codes.md) should carry a single
+decision-tree covering every command, and `1` should not mean both "tool
+crashed" and "a real finding" within the comparison family.
 
 ### ✅ 2.5 `--annotate` stream is already consistent (verified — non-issue)
 

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -21,8 +21,8 @@ This document answers three questions:
 | Mode | Command(s) | Knob count (approx) | Policy | Severity | Public-surface scoping | Exit-code scheme |
 |------|-----------|--------------------:|:------:|:--------:|:----------------------:|------------------|
 | Compare | `compare` | ~55 | ✅ `--policy`/`--policy-file` | ✅ `--severity-*` | ✅ **default ON** | 0/2/4 (legacy) **or** 0/1/2/4 (severity) |
-| Multi-binary | `compare-release` | ~40 | ✅ `--policy`/`--policy-file` | ❌ | ✅ **default OFF** | 0/2/4/8 |
-| App-centric | `appcompat` | ~22 | ✅ `--policy`/`--policy-file` | ❌ | ✅ **always-on, no CLI toggle** | 0/1/2/4 |
+| Multi-binary | `compare-release` | ~45 | ✅ `--policy`/`--policy-file` | ✅ `--severity-*` (aggregated) | ✅ **default ON, toggle** | 0/2/4/8 (+severity) |
+| App-centric | `appcompat` | ~27 | ✅ `--policy`/`--policy-file` | ✅ `--severity-*` (app-scoped) | ✅ **default ON, toggle** | 0/1/2/4 |
 | Snapshot | `dump` | ~30 | ❌ | ❌ | n/a | 0/1/2 |
 | ABICC drop-in | `compat check`/`dump` | ~110 (≈24 no-op stubs) | ❌ (hard-wired) | ❌ | ❌ | 0/1/2, 3–11 errors |
 | Stack | `stack-check`, `deps` | ~7 each | ❌ | ❌ | n/a | 0/1/4 / 0/1 |

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -110,7 +110,7 @@ in `compare`, *tool error* in `appcompat`, *WARN* in `stack-check`, *missing
 deps* in `deps`. Same number, four meanings.
 
 **Recommendation:** This is partly inherent (different tasks), but the collision
-on exit `1` is avoidable. At minimum, the [exit-codes reference] should carry a
+on exit `1` is avoidable. At minimum, the [exit-codes reference](../reference/exit-codes.md) should carry a
 single decision-tree, and `1` should not mean both "tool crashed" and "a real
 finding" within the comparison family.
 

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -144,19 +144,24 @@ each path describing what surface is actually being analyzed.
 
 ## 3. Redundant / removable / consolidatable keys
 
-### 3.1 ABICC `compat` no-op stubs (~24 flags) — *keep hidden, but stop silently lying*
+### 3.1 ABICC `compat` no-op stubs (~24 flags) — *keep hidden; already handled well*
 
 `compat check` accepts ~24 hidden P2 stub flags (`-mingw-compatible`, `-static`,
 `-ext`, `-quick`, `-force`, `-tolerance`, `-count-symbols`, `-sort`, `-xml`, …)
 that do **nothing**, plus `-params`, `-app`, and `-filter` that are accepted but
-**not applied**. Drop-in parity is a real feature, so deleting them would break
-copy-pasted ABICC command lines. But `-app` (application portability) and
-`-filter` (skip rules) *look* functional and are silently ignored.
+not yet applied. Drop-in parity is a real feature, so deleting them would break
+copy-pasted ABICC command lines.
 
-**Recommendation:** Keep the pure stubs hidden (they're harmless). For
-`-app`/`-filter`/`-params`, emit a one-line stderr warning: *"accepted for ABICC
-compatibility but not applied; use `appcompat` / `--suppress` instead."* Silent
-no-ops on flags that imply analysis are a correctness trap.
+Importantly, the analysis-implying ones are **not** silently ignored:
+`_emit_compat_info_notes()` already prints a stderr note for `-filter`/`-params`/
+`-app` (and `-count-symbols`/`-count-all-symbols`) — *"Note: -app … is accepted
+for compatibility (not yet applied)."* (`compat/cli.py:1297-1309`, `1405-1422`,
+quiet-respecting via `_do_echo`).
+
+**Recommendation:** No action needed — keep the pure stubs hidden, and the
+existing info-notes already prevent the "silent no-op" correctness trap. The only
+optional polish would be pointing users at `appcompat` (for `-app`) and
+`--suppress` (for `-filter`) in those note strings.
 
 ### 3.2 `--compile-db` is a pure alias of `-p/--build-dir`
 
@@ -279,19 +284,18 @@ categories. Coherent. The only issue is reach (§2.2), not the schema.
    `compare-release`, `appcompat` (§2.1).
 2. Make the legacy-vs-severity exit-code switch explicit, or always run
    severity-aware (§2.2).
-3. Warn (don't silently ignore) on `compat -app`/`-filter`/`-params` (§3.1).
 
 **Do next (consolidation):**
-4. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`
+3. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`
    (§3.4).
-5. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
+4. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
    axes (§3.3).
-6. Hide/drop `--compile-db` alias (§3.2).
+5. Hide/drop `--compile-db` alias (§3.2).
 
 **Do later (defaults polish):**
-7. `compare-release -j` default `0` (auto) (§4).
-8. `--demangle` default ON for human formats (§4).
-9. Document `ABICHECK_MCP_*` env vars in the MCP guide (§5).
+6. `compare-release -j` default `0` (auto) (§4).
+7. `--demangle` default ON for human formats (§4).
+8. Document `ABICHECK_MCP_*` env vars in the MCP guide (§5).
 
 **Keep as-is (don't remove):**
 - ABICC P2 no-op stubs (hidden, harmless, real drop-in value).

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -45,58 +45,54 @@ type.** That is the core UX problem, far more than the raw count.
 
 ## 2. Cross-mode inconsistencies — ranked by user impact
 
-### 🔴 2.1 `--scope-public-headers` has *opposite* defaults across modes
+### 🔴 2.1 `--scope-public-headers` had *opposite* defaults across modes ✅ resolved
 
-This is the single most confusing thing in the whole surface.
+This was the single most confusing thing in the whole surface. The table below
+shows the **original** state that motivated the fix:
 
-| Entry point | Flag form | Default | Source |
-|-------------|-----------|---------|--------|
-| `compare` | `--scope-public-headers/--no-scope-public-headers` (toggle) | **ON** | `cli.py:1519-1525` |
-| `compare-release` | `--scope-public-headers` (plain `is_flag`, no `--no-`) | **OFF** | `cli_compare_release.py:1046` |
-| `appcompat` | *no CLI flag* — but **always-on**: `check_appcompat()` calls `compare()` without overriding its `scope_to_public_surface=True` default | **ON (forced)** | `appcompat.py:710`, `checker.py:180` |
-| `run_compare()` (Python API) | `scope_to_public_surface=True` | **ON** | `service.py:615` |
+| Entry point | Original flag form | Original default |
+|-------------|-----------|---------|
+| `compare` | `--scope-public-headers/--no-scope-public-headers` (toggle) | **ON** |
+| `compare-release` | `--scope-public-headers` (plain `is_flag`, no `--no-`) | **OFF** |
+| `appcompat` | *no CLI flag* — always-on via `compare()`'s `scope_to_public_surface=True` default | **ON (forced)** |
+| `run_compare()` (Python API) | `scope_to_public_surface=True` | **ON** |
 
-Consequences:
-- A user who runs `compare` sees findings silently filtered to the public-header
-  surface (with a one-line warning if it can't resolve, `cli.py:1404`), then runs
-  `compare-release` on the same libraries and sees a *different, larger* finding
-  set — for no reason they can infer.
-- `compare` exposes `--no-...` to turn it off; `compare-release` has no way to
-  turn it *on* with a negation, and no `--no-bundle`-style symmetry.
-- `appcompat`, which is *also* a comparison, scopes to the public surface
-  **always** (it inherits `compare()`'s `True` default) but gives the user **no
-  CLI toggle** to inspect or disable it — so a third, opaque variant.
+The problem: a user who ran `compare` saw findings filtered to the public-header
+surface, then ran `compare-release` on the same libraries and saw a *different,
+larger* finding set with no way to infer why; `appcompat` scoped always but gave
+no toggle — three behaviors for one conceptual knob.
 
-**Recommendation:** Pick one default (ON is the better UX — it's what
-distinguishes this tool from raw `abidiff` noise), make all three comparison
-commands use the **same toggle flag and the same default**, and add the toggle
-to `appcompat`. If `compare-release` must stay OFF-by-default for backwards
-compatibility, at minimum give it the `/--no-` toggle form and document *why*
-it differs.
+**Resolution (implemented, see §7 do-first #1):** all three comparison commands now expose
+the **same `--scope-public-headers/--no-scope-public-headers` toggle**, and
+`compare-release` was flipped to **default ON** to match `compare` and the Python
+API (`cli_compare_release.py`, `cli_appcompat.py`). The default flip is a breaking
+change for `compare-release` callers that relied on unscoped output — pass
+`--no-scope-public-headers` to restore.
 
-### 🔴 2.2 Severity system exists only on `compare`
+### 🔴 2.2 Severity system was `compare`-only ✅ resolved (additive + explicit)
 
-`--severity-preset` and the four `--severity-*` category flags
-(`cli.py:1486-1507`) are **`compare`-only**. `compare-release` and `appcompat`
-— both of which run the exact same diff engine — have no severity control and
-fall back to verdict-based exit codes.
+Originally `--severity-preset` and the four `--severity-*` category flags were
+**`compare`-only**. `compare-release` and `appcompat` — both of which run the
+same diff engine — had no severity control and fell back to verdict-based exit
+codes. Worse, on `compare` the scheme switched **silently**: passing *any*
+`--severity-*` flag moved you from the 0/2/4 verdict scheme to the 0/1/2/4
+severity scheme with no signal.
 
-This also creates the **dual-path exit-code behavior** that only `compare` has
-(`cli.py:1294-1309`, `_resolve_severity` at `1171`): pass *any* `--severity-*`
-flag and you silently switch from the 0/2/4 verdict scheme to the 0/1/2/4
-severity scheme. Users cannot tell from the command which scheme they're in.
+**Resolution (implemented, see §7 do-first #2):**
+- The `--severity-preset`/`--severity-*` option group was added to
+  `compare-release` (aggregated across per-library, bundle, and matrix findings,
+  honoring per-library `--policy-file` overrides; removed-library exit `8` still
+  wins) and `appcompat` (full-compare mode only; app-scoped to `breaking_for_app`,
+  with missing required symbols/versions floored at `4`).
+- `compare` now **prints the active exit-code scheme to stderr** for human
+  formats, so the switch is no longer silent. Exit-code numbers are unchanged.
 
-**Recommendation:** Either (a) promote severity config to a shared option group
-used by `compare`, `compare-release`, and `appcompat`, or (b) if severity is
-meant to be the *one true* gating mechanism, deprecate the legacy verdict-exit
-path and always run severity-aware. Note that this requires a **new
-legacy-equivalent preset** — the existing `default` preset leaves
-`potential_breaking` at `warning`, and `compute_exit_code()` only emits a
-non-zero code for categories set to `error` (`severity.py:185`, the
-`compute_exit_code` docstring), so `default` would map API_BREAK to exit **0**,
-not the legacy **2**. Reproducing 0/2/4 needs `abi_breaking=error` **and**
-`potential_breaking=error` (with quality/addition below error). Today's
-"implicit mode switch on first `--severity-*` flag" is the worst of both worlds.
+It was *not* made "always severity-aware", because a literal legacy-equivalent
+preset can't be expressed through the four-category model: API_BREAK and RISK
+share `POTENTIAL_BREAKING` while the verdict path maps `COMPATIBLE_WITH_RISK`→0,
+so `compute_exit_code()` with any single preset would change RISK handling
+(`severity.py:185`). Making the scheme *visible* avoids that regression while
+removing the "which scheme am I in?" confusion.
 
 ### 🟠 2.3 Policy availability is uneven
 

--- a/docs/development/config-key-review.md
+++ b/docs/development/config-key-review.md
@@ -1,0 +1,305 @@
+# Configuration Key & Default-Value Review
+
+> **Status:** Review / proposal (2026-06). Audit of every CLI flag, config-file
+> key, and environment variable across all operating modes, with an opinionated
+> assessment of redundancy, inconsistency, and surprising defaults. Nothing here
+> changes behavior on its own — it is a decision input for trimming the surface.
+
+This document answers three questions:
+
+1. **What knobs do we expose, per mode, and what are their defaults?**
+2. **Where are defaults and semantics *inconsistent* between modes?** (the part
+   that hurts users most)
+3. **What can we *remove or consolidate*** without losing real capability?
+
+---
+
+## 1. The surface, at a glance
+
+| Mode | Command(s) | Knob count (approx) | Policy | Severity | Public-surface scoping | Exit-code scheme |
+|------|-----------|--------------------:|:------:|:--------:|:----------------------:|------------------|
+| Compare | `compare` | ~55 | ✅ `--policy`/`--policy-file` | ✅ `--severity-*` | ✅ **default ON** | 0/2/4 (legacy) **or** 0/1/2/4 (severity) |
+| Multi-binary | `compare-release` | ~40 | ✅ `--policy`/`--policy-file` | ❌ | ✅ **default OFF** | 0/2/4/8 |
+| App-centric | `appcompat` | ~22 | ✅ `--policy`/`--policy-file` | ❌ | ❌ (absent) | 0/1/2/4 |
+| Snapshot | `dump` | ~30 | ❌ | ❌ | n/a | 0/1/2 |
+| ABICC drop-in | `compat check`/`dump` | ~110 (≈24 no-op stubs) | ❌ (hard-wired) | ❌ | ❌ | 0/1/2, 3–11 errors |
+| Stack | `stack-check`, `deps` | ~7 each | ❌ | ❌ | n/a | 0/1/4 / 0/1 |
+| Baseline | `baseline push/pull/list/delete` | ~8 | ❌ | ❌ | n/a | 0/1 |
+| Probe (G2) | `probe run/compare` | ~9 | ✅ `--policy` | ❌ | n/a | 0/2/4 |
+| Debian | `debian-symbols generate/validate/diff` | ~4 | ❌ | ❌ | n/a | 0/1 |
+| Suggest | `suggest-suppressions` | 2 | ❌ | ❌ | n/a | 0 |
+| MCP server | `abicheck-mcp` | 3 (env + 3 CLI) | ❌ | ❌ | inherits API | n/a |
+| Python API | `abicheck.service` | function kwargs | via args | n/a | ✅ **default ON** | n/a |
+
+Total unique flags across the tool: **~220** (counting per-side / alias variants
+once). `compat check` alone carries ~110, of which ~24 are intentional no-op
+ABICC stubs.
+
+The headline: **the same conceptual knob has different defaults, different
+spellings, and sometimes doesn't exist at all depending on which subcommand you
+type.** That is the core UX problem, far more than the raw count.
+
+---
+
+## 2. Cross-mode inconsistencies — ranked by user impact
+
+### 🔴 2.1 `--scope-public-headers` has *opposite* defaults across modes
+
+This is the single most confusing thing in the whole surface.
+
+| Entry point | Flag form | Default | Source |
+|-------------|-----------|---------|--------|
+| `compare` | `--scope-public-headers/--no-scope-public-headers` (toggle) | **ON** | `cli.py:1519-1525` |
+| `compare-release` | `--scope-public-headers` (plain `is_flag`, no `--no-`) | **OFF** | `cli_compare_release.py:1046` |
+| `appcompat` | *flag does not exist* | n/a | `cli_appcompat.py` |
+| `run_compare()` (Python API) | `scope_to_public_surface=True` | **ON** | `service.py:615` |
+
+Consequences:
+- A user who runs `compare` sees findings silently filtered to the public-header
+  surface (with a one-line warning if it can't resolve, `cli.py:1404`), then runs
+  `compare-release` on the same libraries and sees a *different, larger* finding
+  set — for no reason they can infer.
+- `compare` exposes `--no-...` to turn it off; `compare-release` has no way to
+  turn it *on* with a negation, and no `--no-bundle`-style symmetry.
+- `appcompat`, which is *also* a comparison, has no scoping concept at all.
+
+**Recommendation:** Pick one default (ON is the better UX — it's what
+distinguishes this tool from raw `abidiff` noise), make all three comparison
+commands use the **same toggle flag and the same default**, and add the toggle
+to `appcompat`. If `compare-release` must stay OFF-by-default for backwards
+compatibility, at minimum give it the `/--no-` toggle form and document *why*
+it differs.
+
+### 🔴 2.2 Severity system exists only on `compare`
+
+`--severity-preset` and the four `--severity-*` category flags
+(`cli.py:1486-1507`) are **`compare`-only**. `compare-release` and `appcompat`
+— both of which run the exact same diff engine — have no severity control and
+fall back to verdict-based exit codes.
+
+This also creates the **dual-path exit-code behavior** that only `compare` has
+(`cli.py:1294-1309`, `_resolve_severity` at `1171`): pass *any* `--severity-*`
+flag and you silently switch from the 0/2/4 verdict scheme to the 0/1/2/4
+severity scheme. Users cannot tell from the command which scheme they're in.
+
+**Recommendation:** Either (a) promote severity config to a shared option group
+used by `compare`, `compare-release`, and `appcompat`, or (b) if severity is
+meant to be the *one true* gating mechanism, deprecate the legacy verdict-exit
+path and always run severity-aware (defaulting to the `default` preset, which
+reproduces 0/2/4). Today's "implicit mode switch on first `--severity-*` flag"
+is the worst of both worlds.
+
+### 🟠 2.3 Policy availability is uneven
+
+`--policy` + `--policy-file` exist on `compare`, `compare-release`, `appcompat`,
+and `probe compare`. They are **absent** on `compat` (hard-wired `strict_abi`,
+by ABICC-parity design) and on `dump`/`stack-check`/`deps`. The asymmetry is
+defensible per-mode, but it isn't surfaced anywhere; a user migrating an ABICC
+pipeline to `compat` cannot apply the `sdk_vendor` policy they use elsewhere.
+
+**Recommendation:** Document the policy matrix in one place (the table in §1 is a
+start). Consider a `compat`-side opt-in (e.g. mapping `-s/--strict` and a future
+`--policy` passthrough) so vendor policies aren't stranded.
+
+### 🟠 2.4 Exit-code schemes differ per mode
+
+`0/2/4` (compare legacy), `0/1/2/4` (compare severity, appcompat),
+`0/2/4/8` (compare-release, +8 = removed library), `0/1/4` (stack-check),
+`0/1` (deps/baseline), `0/1/2 + 3–11` (compat). And `1` means *severity error*
+in `compare`, *tool error* in `appcompat`, *WARN* in `stack-check`, *missing
+deps* in `deps`. Same number, four meanings.
+
+**Recommendation:** This is partly inherent (different tasks), but the collision
+on exit `1` is avoidable. At minimum, the [exit-codes reference] should carry a
+single decision-tree, and `1` should not mean both "tool crashed" and "a real
+finding" within the comparison family.
+
+### 🟡 2.5 `--annotate` writes to different streams
+
+`compare` emits GitHub annotations to **stderr** (`cli.py:1574`,
+`_maybe_emit_annotations`); `compare-release` emits to **stdout**
+(`cli_compare_release.py:384`). CI consumers piping output will see different
+behavior.
+
+**Recommendation:** Standardize on stderr (annotations are diagnostics, not the
+report payload).
+
+### 🟡 2.6 Suppression input formats differ
+
+`compare`/`compare-release`/`appcompat` take a YAML `--suppress` file;
+`compat` reuses ABICC plaintext `-symbols-list`/`-types-list`/`-skip-symbols`.
+A team cannot share one suppression source across `compat` and `compare`.
+
+**Recommendation:** Acceptable for drop-in parity, but `compat` should also
+accept `--suppress <yaml>` (it already does per agent inventory at
+`compat/cli.py`) — make sure that's documented as the bridge.
+
+### 🟡 2.7 "No headers" means three different things
+
+- `compare` without `-H`: symbols-only fallback + warning.
+- `dump` without `-H`: DWARF-only if debug info present.
+- `appcompat --check-against` / `--list-required-symbols`: headers *rejected*.
+
+**Recommendation:** Unify the help text and emit a consistent one-line note on
+each path describing what surface is actually being analyzed.
+
+---
+
+## 3. Redundant / removable / consolidatable keys
+
+### 3.1 ABICC `compat` no-op stubs (~24 flags) — *keep hidden, but stop silently lying*
+
+`compat check` accepts ~24 hidden P2 stub flags (`-mingw-compatible`, `-static`,
+`-ext`, `-quick`, `-force`, `-tolerance`, `-count-symbols`, `-sort`, `-xml`, …)
+that do **nothing**, plus `-params`, `-app`, and `-filter` that are accepted but
+**not applied**. Drop-in parity is a real feature, so deleting them would break
+copy-pasted ABICC command lines. But `-app` (application portability) and
+`-filter` (skip rules) *look* functional and are silently ignored.
+
+**Recommendation:** Keep the pure stubs hidden (they're harmless). For
+`-app`/`-filter`/`-params`, emit a one-line stderr warning: *"accepted for ABICC
+compatibility but not applied; use `appcompat` / `--suppress` instead."* Silent
+no-ops on flags that imply analysis are a correctness trap.
+
+### 3.2 `--compile-db` is a pure alias of `-p/--build-dir`
+
+`cli.py` defines both for the same target (`dump`). Aliases add doc surface for
+no capability.
+
+**Recommendation:** Keep `-p/--build-dir` (the documented form), demote
+`--compile-db` to a hidden alias or drop it.
+
+### 3.3 The report-content "show-*" family overlaps
+
+`compare` carries: `--show-redundant`, `--show-filtered`, `--show-impact`,
+`--show-only`, `--report-mode {full,leaf}`, `--recommend`, `--stat`
+(plus `appcompat --show-irrelevant`). Two genuine overlaps:
+
+- `--report-mode leaf` and `--show-impact` both surface "root change → affected
+  interfaces" grouping. A user must learn both to discover they're related.
+- `--show-redundant` (un-filter derived changes) vs `--report-mode full/leaf`
+  (group vs flat) vs `--show-filtered` (out-of-surface audit) are three separate
+  axes that read as one "verbosity" concept to newcomers.
+
+**Recommendation:** Don't delete capability, but consider folding
+`--show-impact` into `--report-mode` (e.g. `--report-mode impact`) and
+documenting the three axes (redundancy / grouping / surface) as an explicit
+"what gets shown" section rather than seven scattered flags.
+
+### 3.4 Four debug-format flags where two would do
+
+`--btf`, `--ctf`, `--dwarf`, and `--dwarf-only` coexist on `compare`/`dump`.
+`--dwarf` (select DWARF as the ELF debug format) and `--dwarf-only` (force debug
+info as primary over headers) are different but read as near-synonyms and are a
+known confusion point.
+
+**Recommendation:** Collapse the format *selector* into one option:
+`--debug-format {auto,dwarf,btf,ctf}` (default `auto`), and keep `--dwarf-only`
+as the orthogonal "ignore headers" switch — but rename it to something that
+doesn't collide, e.g. `--ignore-headers` / `--binary-truth`.
+
+### 3.5 `--annotate-additions` could be inferred
+
+It is only meaningful with `--annotate` and errors/no-ops otherwise. Minor, but
+it's a flag that exists only to qualify another flag.
+
+**Recommendation:** Acceptable to keep; low priority.
+
+### 3.6 Version-label default drift
+
+`--old-version`/`--new-version` default to the literal strings `"old"`/`"new"`;
+`dump --version` defaults to `"unknown"`. Harmless but inconsistent.
+
+**Recommendation:** Make `dump --version` default to `"unknown"` and the
+compare-side default to the input filename stem when resolvable, rather than the
+opaque `"old"`/`"new"` — more useful in reports for zero extra typing.
+
+---
+
+## 4. Defaults that may surprise users
+
+| Knob | Current default | Why it surprises | Suggested |
+|------|-----------------|------------------|-----------|
+| `compare --scope-public-headers` | **ON** | Findings are silently filtered out of the report | Keep ON, but always print the filtered count (it does on resolve-fail only) |
+| `compare-release -j/--jobs` | **1 (serial)** | Multi-library releases are slow by default; `0` = auto exists but isn't the default | Default to `0` (auto) or document prominently |
+| `compare --demangle` | **OFF** | Human-readable output shows mangled `_ZN…` names by default | Default ON for `markdown`/`html`/`text`; keep mangled for `json`/`sarif` |
+| `--lang` | **`c++`** | C libraries parsed as C++ can mis-parse | Reasonable default; add autodetect note |
+| `compat -report-format` | **`html`** | A CLI invocation writes an HTML file by default | ABICC parity — keep, but document |
+| `suggest-suppressions --expiry-days` | **180** | Generated suppressions silently expire in ~6 months | Fine, but state it in the generated file header |
+| `baseline --registry` | **`.abicheck/baselines`** in cwd | Writes into the current directory tree | Document; consider `$XDG_DATA_HOME` option |
+| MCP `ABICHECK_MCP_TIMEOUT` | **120 s** | Large libs may exceed it | Fine; documented |
+| MCP `ABICHECK_MCP_MAX_FILE_SIZE` | **500 MB** | Silently rejects bigger inputs | Document the limit in the error |
+
+---
+
+## 5. Environment variables (complete list)
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `GITHUB_ACTIONS` | unset | Gates annotation/step-summary emission (`annotations.py:261`) |
+| `GITHUB_STEP_SUMMARY` | unset | Path for CI job-summary markdown |
+| `DEBUGINFOD_URLS` | unset | debuginfod servers (opt-in via `--debuginfod`) |
+| `_NT_SYMBOL_PATH` | unset | Windows PDB symbol search path |
+| `XDG_CACHE_HOME` | `~/.cache` | Snapshot/debug cache root |
+| `LOCALAPPDATA` | `~/AppData/Local` | Windows castxml cache root |
+| `SYCL_PI_PLUGINS_DIR`, `SYCL_UR_ADAPTERS_DIR` | unset | SYCL plugin discovery |
+| `ABICHECK_MCP_TIMEOUT` | `120` | MCP per-call timeout (s) |
+| `ABICHECK_MCP_MAX_FILE_SIZE` | `524288000` | MCP max input bytes |
+
+These are well-scoped and follow platform conventions (XDG / LOCALAPPDATA). No
+changes recommended beyond documenting the two `ABICHECK_MCP_*` knobs in the MCP
+guide.
+
+---
+
+## 6. Config-file keys (policy / suppression / severity)
+
+**Policy file** (`--policy-file`, `policy_file.py`): `base_policy`
+(default `strict_abi`), `overrides` (ChangeKind → `break|warn|risk|ignore`),
+`frozen_namespaces` (glob patterns that block downgrades). Clean, minimal, no
+redundancy. Unknown `base_policy` falls back to `strict_abi` **silently**
+(`checker_policy.py:715`) — recommend warning on unknown values.
+
+**Suppression file** (`--suppress`, `suppression.py`): selectors `symbol`,
+`symbol_pattern`, `type_pattern`, `member_name`, `change_kind`, `namespace`,
+`source_location`, plus `reason`/`label`/`expires`. Rich but each selector earns
+its place; unknown keys are *rejected* (good — catches typos). No removal
+candidates. The built-in `audit()` (stale/expired/high-risk) is a strength.
+
+**Severity** (`severity.py`): presets `default`/`strict`/`info-only` over four
+categories. Coherent. The only issue is reach (§2.2), not the schema.
+
+---
+
+## 7. Prioritized action list
+
+**Do first (correctness / least-surprise):**
+1. Unify `--scope-public-headers` default + flag form across `compare`,
+   `compare-release`, `appcompat` (§2.1).
+2. Make the legacy-vs-severity exit-code switch explicit, or always run
+   severity-aware (§2.2).
+3. Warn (don't silently ignore) on `compat -app`/`-filter`/`-params` (§3.1).
+4. Standardize `--annotate` on stderr (§2.5).
+
+**Do next (consolidation):**
+5. Collapse `--btf/--ctf/--dwarf` into `--debug-format`; rename `--dwarf-only`
+   (§3.4).
+6. Fold `--show-impact` into `--report-mode`; document the three "what's shown"
+   axes (§3.3).
+7. Hide/drop `--compile-db` alias (§3.2).
+
+**Do later (defaults polish):**
+8. `compare-release -j` default `0` (auto) (§4).
+9. `--demangle` default ON for human formats (§4).
+10. Warn on unknown `base_policy` (§6); document `ABICHECK_MCP_*` (§5).
+
+**Keep as-is (don't remove):**
+- ABICC P2 no-op stubs (hidden, harmless, real drop-in value).
+- Suppression selector richness and `audit()`.
+- Policy-file schema.
+- Per-side `--old-*`/`--new-*` header/include overrides (genuinely needed).
+- Provenance flags (`--git-tag`, `--build-id`, `--no-git`).
+
+Nothing here is a *capability* worth deleting outright; the wins are in
+**unifying defaults**, **renaming colliding flags**, and **not silently
+ignoring** flags that imply work.

--- a/docs/user-guide/appcompat.md
+++ b/docs/user-guide/appcompat.md
@@ -127,6 +127,9 @@ abicheck appcompat ./myapp --list-required-symbols --check-against libfoo.so.2 -
 | `-o` / `--output` | Write report to file |
 | `--show-irrelevant` | Include library changes that don't affect the application |
 | `--list-required-symbols` | List symbols the application requires and exit |
+| `--scope-public-headers` / `--no-scope-public-headers` | Restrict findings to the public-header ABI surface (on by default; matches `compare`) |
+| `--severity-preset` | `default`, `strict`, or `info-only` (switches to the severity-aware exit scheme — full mode only) |
+| `--severity-abi-breaking` / `--severity-potential-breaking` / `--severity-quality-issues` / `--severity-addition` | Per-category severity overrides (`error`/`warning`/`info`; full mode only) |
 | `--suppress` | Suppression file (YAML) |
 | `--policy` | Verdict policy: `strict_abi` (default), `sdk_vendor`, `plugin_abi` |
 | `--policy-file` | Custom YAML policy overrides |
@@ -144,6 +147,20 @@ abicheck appcompat ./myapp --list-required-symbols --check-against libfoo.so.2 -
 | `1` | `TOOL_ERROR` | Operational or runtime error (tool failure, invalid input, or unexpected exception) |
 | `2` | `API_BREAK` | Source-level break affecting app's symbols |
 | `4` | `BREAKING` | Binary ABI break or missing symbols |
+
+### Severity-aware exit codes
+
+Passing any `--severity-*` option switches `appcompat` to the same severity-aware
+exit scheme as `compare`, classifying the **app-relevant** changes (the ones that
+affect the application, not the whole library diff) by category. Two caveats:
+
+- It applies in **full mode only** (with `OLD_LIB NEW_LIB`). Weak mode
+  (`--check-against`) has no extracted library ABI, so it always uses the
+  verdict-based exit codes above.
+- Missing required symbols/versions are treated as a hard runtime break and
+  always floor the exit code at `4`, even under `--severity-preset info-only` —
+  an application that can't resolve a symbol it needs is not something a severity
+  downgrade should hide.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Development:
     - Goals: development/goals.md
     - Backlog: development/backlog.md
+    - Config Key Review: development/config-key-review.md
     - User Scenarios & Flows: development/user-scenarios.md
     - Use-Case Coverage Evaluation: development/usecase-coverage-evaluation.md
     - Implementation Plans:

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -93,6 +93,18 @@ class TestDemangleTriState:
         )
         assert "_Z3foov" in result.output
 
+    def test_html_keeps_mangled_by_default(self, tmp_path, monkeypatch):
+        # HTML is NOT in the demangle default set: its renderer emits symbols
+        # structurally and demangling the HTML string would inject unescaped
+        # C++ '<'/'>'/'&'. Even with the demangler stubbed, html stays mangled.
+        self._patch_demangler(monkeypatch)
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--format", "html"],
+        )
+        assert "_Z3foov" in result.output
+        assert "foo()" not in result.output
+
     def test_no_demangle_override_on_markdown(self, tmp_path, monkeypatch):
         self._patch_demangler(monkeypatch)
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -185,6 +185,20 @@ class TestDebugFormatSelector:
         )
         assert result.exit_code == 0
 
+    def test_debug_format_rejected_on_non_elf(self, tmp_path):
+        # --debug-format dwarf/btf/ctf is ELF-only; compare must reject (not
+        # silently ignore) it for a PE/Mach-O binary input, like dump does.
+        old = tmp_path / "old.dll"
+        new = tmp_path / "new.dll"
+        old.write_bytes(b"MZ\x90\x00\x03\x00\x00\x00")  # PE magic
+        new.write_bytes(b"MZ\x90\x00\x03\x00\x00\x00")
+        result = CliRunner().invoke(
+            main, ["compare", str(old), str(new), "--debug-format", "dwarf"],
+        )
+        assert result.exit_code != 0
+        combined = result.output + (result.stderr or "")
+        assert "ELF" in combined
+
 
 # ── §6 --report-mode impact ─────────────────────────────────────────────────
 

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -517,3 +517,35 @@ class TestReleaseSeverityPolicyAndGlobal:
 
         assert _resolve_release_severity_config(
             "strict", None, None, None, None) is not None
+
+
+# ── §6 follow-ups: debug-format auto override + parallel determinism ─────────
+
+
+class TestDebugFormatAutoOverride:
+    def test_auto_overrides_legacy_flag(self, tmp_path):
+        # --debug-format auto must supersede a legacy --dwarf and run in
+        # auto-detect mode (on JSON snapshots this is a smoke check: it must
+        # not error and must exit 0 on identical input).
+        old_p, new_p = _write_identical(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--debug-format", "auto", "--dwarf"],
+        )
+        assert result.exit_code == 0
+
+
+class TestCompareReleaseParallelOrdering:
+    def test_parallel_results_in_matched_keys_order(self, monkeypatch):
+        from pathlib import Path as _P
+
+        import abicheck.cli_compare_release as _cr
+
+        monkeypatch.setattr(
+            _cr, "_compare_one_library",
+            lambda key, *a: {"library": key, "key": key},
+        )
+        keys = ["libc", "liba", "libb"]
+        old_map = {k: _P(k) for k in keys}
+        out = _cr._compare_release_parallel(keys, (), old_map, max_workers=4)
+        # Deterministic: emitted in matched_keys order, not completion order.
+        assert [r["key"] for r in out] == keys

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -56,12 +56,26 @@ def _write_identical(tmp_path: Path) -> tuple[Path, Path]:
 
 
 class TestDemangleTriState:
-    def test_markdown_demangles_by_default(self, tmp_path):
+    @staticmethod
+    def _patch_demangler(monkeypatch):
+        """Stub the demangler so the test is independent of whether the host has
+        a working C++ demangler (cxxfilt / c++filt) — macOS CI runners do not.
+        The reporter imports ``demangle_text`` at call time, so patching the
+        module attribute is sufficient. This verifies the *wiring* (which formats
+        request demangling), not the platform demangler itself."""
+        import abicheck.demangle as _dem
+        monkeypatch.setattr(
+            _dem, "demangle_text",
+            lambda text: text.replace("_Z3foov", "foo()"),
+        )
+
+    def test_markdown_demangles_by_default(self, tmp_path, monkeypatch):
+        self._patch_demangler(monkeypatch)
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
             main, ["compare", str(old_p), str(new_p), "--format", "markdown"],
         )
-        # Demangled "foo()" should appear; raw "_Z3foov" should not.
+        # markdown requests demangling by default -> stub rewrites the symbol.
         assert "foo()" in result.output
         assert "_Z3foov" not in result.output
 
@@ -79,12 +93,14 @@ class TestDemangleTriState:
         )
         assert "_Z3foov" in result.output
 
-    def test_no_demangle_override_on_markdown(self, tmp_path):
+    def test_no_demangle_override_on_markdown(self, tmp_path, monkeypatch):
+        self._patch_demangler(monkeypatch)
         old_p, new_p = _write_removed_cpp_symbol(tmp_path)
         result = CliRunner().invoke(
             main,
             ["compare", str(old_p), str(new_p), "--format", "markdown", "--no-demangle"],
         )
+        # --no-demangle suppresses demangling even on markdown -> stub not run.
         assert "_Z3foov" in result.output
 
     def test_json_stays_mangled_even_with_demangle(self, tmp_path):
@@ -283,3 +299,138 @@ class TestValidateAppcompatArgs:
                 old_includes_only=(), new_includes_only=(),
                 headers=(), includes=(),
             )
+
+
+# ── §2.2 severity-exit floors (Codex P1 fixes) ──────────────────────────────
+
+
+def _breaking_diff():
+    """A real DiffResult with one BREAKING change (func removed)."""
+    from abicheck.checker import compare
+    old = AbiSnapshot(
+        library="libtest.so", version="1.0",
+        functions=[Function(name="_Z3foov", mangled="_Z3foov", return_type="int",
+                             visibility=Visibility.PUBLIC)],
+    )
+    new = AbiSnapshot(library="libtest.so", version="2.0", functions=[])
+    return compare(old, new)
+
+
+class TestCompareReleaseExitFloors:
+    """_exit_compare_release: severity must not downgrade operational failures."""
+
+    def test_error_verdict_floors_severity_exit(self):
+        import pytest
+
+        from abicheck.cli_compare_release import _exit_compare_release
+
+        # A per-library ERROR (failed dump/extract) produces no changes, so the
+        # severity aggregation sees 0 — but it must still exit 4, not 0.
+        with pytest.raises(SystemExit) as exc:
+            _exit_compare_release("ERROR", False, [], severity_exit_code=0)
+        assert exc.value.code == 4
+
+    def test_removed_library_precedence_under_severity(self):
+        import pytest
+
+        from abicheck.cli_compare_release import _exit_compare_release
+
+        with pytest.raises(SystemExit) as exc:
+            _exit_compare_release("BREAKING", True, ["libgone"], severity_exit_code=0)
+        assert exc.value.code == 8
+
+    def test_severity_code_passthrough(self):
+        import pytest
+
+        from abicheck.cli_compare_release import _exit_compare_release
+
+        with pytest.raises(SystemExit) as exc:
+            _exit_compare_release("API_BREAK", False, [], severity_exit_code=2)
+        assert exc.value.code == 2
+
+    def test_clean_severity_does_not_exit(self):
+        from abicheck.cli_compare_release import _exit_compare_release
+
+        # severity says clean and no operational error -> returns without exiting.
+        assert _exit_compare_release("COMPATIBLE", False, [], severity_exit_code=0) is None
+
+
+class TestComputeReleaseSeverityExitCode:
+    def test_none_without_flags(self):
+        from abicheck.cli_compare_release import _compute_release_severity_exit_code
+
+        assert _compute_release_severity_exit_code(
+            [], None, None, None, None, None) is None
+
+    def test_zero_with_flag_and_no_changes(self):
+        from abicheck.cli_compare_release import _compute_release_severity_exit_code
+
+        assert _compute_release_severity_exit_code(
+            [], "info-only", None, None, None, None) == 0
+
+    def test_aggregates_breaking_change(self):
+        from abicheck.cli_compare_release import _compute_release_severity_exit_code
+
+        entry = {"library": "libtest.so", "_diff_result": _breaking_diff()}
+        # default preset: abi_breaking == error -> exit 4.
+        assert _compute_release_severity_exit_code(
+            [entry], "default", None, None, None, None) == 4
+        # info-only downgrades everything below error -> exit 0.
+        assert _compute_release_severity_exit_code(
+            [entry], "info-only", None, None, None, None) == 0
+
+
+class TestAppcompatSeverityExit:
+    """Full-mode appcompat severity exit, via a stubbed check_appcompat."""
+
+    def _dummy_libs(self, tmp_path):
+        app = tmp_path / "app"
+        old = tmp_path / "old.so"
+        new = tmp_path / "new.so"
+        for p in (app, old, new):
+            p.write_bytes(b"\x7fELF")
+        return app, old, new
+
+    def _patch_result(self, monkeypatch, *, missing=None, with_break=False):
+        import abicheck.appcompat as _ac
+        from abicheck.appcompat import AppCompatResult
+        from abicheck.checker import Verdict
+
+        res = AppCompatResult(
+            app_path="app", old_lib_path="old.so", new_lib_path="new.so",
+            missing_symbols=list(missing or []),
+            full_diff=_breaking_diff() if with_break else None,
+            verdict=Verdict.BREAKING if (missing or with_break) else Verdict.COMPATIBLE,
+        )
+        monkeypatch.setattr(_ac, "check_appcompat", lambda *a, **k: res)
+        return res
+
+    def test_info_only_downgrades_library_break(self, tmp_path, monkeypatch):
+        app, old, new = self._dummy_libs(tmp_path)
+        self._patch_result(monkeypatch, with_break=True)
+        result = CliRunner().invoke(
+            main, ["appcompat", str(app), str(old), str(new),
+                   "--severity-preset", "info-only"],
+        )
+        # A library-diff break is governed by severity -> info-only exits 0.
+        assert result.exit_code == 0
+
+    def test_default_preset_exits_breaking(self, tmp_path, monkeypatch):
+        app, old, new = self._dummy_libs(tmp_path)
+        self._patch_result(monkeypatch, with_break=True)
+        result = CliRunner().invoke(
+            main, ["appcompat", str(app), str(old), str(new),
+                   "--severity-preset", "default"],
+        )
+        assert result.exit_code == 4
+
+    def test_missing_symbols_floor_not_downgraded(self, tmp_path, monkeypatch):
+        app, old, new = self._dummy_libs(tmp_path)
+        # No library-diff changes, but the app is missing a required symbol:
+        # info-only must NOT downgrade this hard runtime break below 4.
+        self._patch_result(monkeypatch, missing=["_Z3barv"])
+        result = CliRunner().invoke(
+            main, ["appcompat", str(app), str(old), str(new),
+                   "--severity-preset", "info-only"],
+        )
+        assert result.exit_code == 4

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -434,3 +434,69 @@ class TestAppcompatSeverityExit:
                    "--severity-preset", "info-only"],
         )
         assert result.exit_code == 4
+
+
+class TestReleaseSeverityPolicyAndGlobal:
+    """P2: per-library policy-file kind overrides; P1: bundle/matrix folding."""
+
+    def test_per_library_uses_effective_kind_sets(self, monkeypatch):
+        from abicheck.cli_compare_release import _compute_release_severity_exit_code
+
+        diff = _breaking_diff()
+        # Simulate a policy-file that reclassifies the (normally breaking) change
+        # as compatible via the per-library effective kind sets. Proves the exit
+        # consults diff._effective_kind_sets(), not the canonical sets.
+        empty = frozenset()
+        all_kinds = frozenset(c.kind for c in diff.changes)
+        monkeypatch.setattr(
+            diff, "_effective_kind_sets",
+            lambda: (empty, empty, all_kinds, empty),
+        )
+        entry = {"_diff_result": diff}
+        assert _compute_release_severity_exit_code(
+            [entry], "default", None, None, None, None) == 0
+
+    def test_fold_matrix_break_raises_exit(self):
+        from abicheck.cli_compare_release import _fold_release_global_severity
+
+        # Per-library clean (base 0), but a matrix DiffResult carries a break.
+        matrix = _breaking_diff()
+        assert _fold_release_global_severity(
+            0, None, matrix, "default", None, None, None, None) == 4
+
+    def test_fold_bundle_break_raises_exit(self):
+        import types
+
+        from abicheck.cli_compare_release import _fold_release_global_severity
+
+        change = _breaking_diff().changes[0]
+        finding = types.SimpleNamespace(to_change=lambda: change)
+        bundle = types.SimpleNamespace(bundle_findings=[finding])
+        assert _fold_release_global_severity(
+            0, bundle, None, "default", None, None, None, None) == 4
+
+    def test_fold_info_only_does_not_escalate(self):
+        from abicheck.cli_compare_release import _fold_release_global_severity
+
+        matrix = _breaking_diff()
+        # info-only downgrades the matrix break below error -> base 0 preserved.
+        assert _fold_release_global_severity(
+            0, None, matrix, "info-only", None, None, None, None) == 0
+
+    def test_fold_no_extras_returns_base(self):
+        from abicheck.cli_compare_release import _fold_release_global_severity
+
+        assert _fold_release_global_severity(
+            2, None, None, "default", None, None, None, None) == 2
+
+    def test_resolve_config_none_without_flags(self):
+        from abicheck.cli_compare_release import _resolve_release_severity_config
+
+        assert _resolve_release_severity_config(
+            None, None, None, None, None) is None
+
+    def test_resolve_config_set_with_flag(self):
+        from abicheck.cli_compare_release import _resolve_release_severity_config
+
+        assert _resolve_release_severity_config(
+            "strict", None, None, None, None) is not None

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -1,0 +1,285 @@
+"""Tests for the CLI/config-review changes:
+
+- compare: tri-state --demangle (default ON for human formats, OFF for json/sarif)
+- compare: explicit exit-code-scheme announcement on stderr
+- compare / dump: --debug-format selector superseding --btf/--ctf/--dwarf
+- compare: --report-mode impact == full + --show-impact
+- compare-release: --scope-public-headers default ON + toggle, -j default 0,
+  severity-aware exit aggregation
+- appcompat: --scope-public-headers wiring, -H/-I ignored-mode warning,
+  severity options
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _write_removed_cpp_symbol(tmp_path: Path) -> tuple[Path, Path]:
+    """Old has a C++ function; new removes it (a breaking change)."""
+    # Use the mangled symbol as the rendered name so the human-format output
+    # carries a raw "_Z..." token that demangling can rewrite to "foo()".
+    old = AbiSnapshot(
+        library="libtest.so", version="1.0",
+        functions=[Function(name="_Z3foov", mangled="_Z3foov", return_type="int",
+                             visibility=Visibility.PUBLIC)],
+    )
+    new = AbiSnapshot(library="libtest.so", version="2.0", functions=[])
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(snapshot_to_json(old), encoding="utf-8")
+    new_p.write_text(snapshot_to_json(new), encoding="utf-8")
+    return old_p, new_p
+
+
+def _write_identical(tmp_path: Path) -> tuple[Path, Path]:
+    snap = AbiSnapshot(
+        library="libtest.so", version="1.0",
+        functions=[Function(name="foo", mangled="_Z3foov", return_type="int",
+                             visibility=Visibility.PUBLIC)],
+    )
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(snapshot_to_json(snap), encoding="utf-8")
+    new_p.write_text(snapshot_to_json(snap), encoding="utf-8")
+    return old_p, new_p
+
+
+# ── §3 demangle tri-state ──────────────────────────────────────────────────
+
+
+class TestDemangleTriState:
+    def test_markdown_demangles_by_default(self, tmp_path):
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--format", "markdown"],
+        )
+        # Demangled "foo()" should appear; raw "_Z3foov" should not.
+        assert "foo()" in result.output
+        assert "_Z3foov" not in result.output
+
+    def test_json_keeps_mangled_by_default(self, tmp_path):
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--format", "json"],
+        )
+        assert "_Z3foov" in result.output
+
+    def test_sarif_keeps_mangled_by_default(self, tmp_path):
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--format", "sarif"],
+        )
+        assert "_Z3foov" in result.output
+
+    def test_no_demangle_override_on_markdown(self, tmp_path):
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "markdown", "--no-demangle"],
+        )
+        assert "_Z3foov" in result.output
+
+    def test_json_stays_mangled_even_with_demangle(self, tmp_path):
+        # Machine formats (json/sarif) intentionally always keep raw mangled
+        # symbols; --demangle is a no-op there by design.
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "json", "--demangle"],
+        )
+        assert "_Z3foov" in result.output
+        assert "foo()" not in result.output
+
+
+# ── §4 exit-scheme announcement ─────────────────────────────────────────────
+
+
+class TestExitSchemeAnnouncement:
+    def test_legacy_scheme_announced(self, tmp_path):
+        old_p, new_p = _write_identical(tmp_path)
+        # Click 8.2+ keeps stderr separate from stdout by default.
+        result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p)])
+        assert "Exit-code scheme: legacy verdict" in result.stderr
+        # Announcement must NOT pollute stdout (the report).
+        assert "Exit-code scheme" not in result.stdout
+
+    def test_severity_scheme_announced(self, tmp_path):
+        old_p, new_p = _write_identical(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--severity-preset", "default"],
+        )
+        assert "Exit-code scheme: severity-aware" in result.stderr
+        assert "Exit-code scheme" not in result.stdout
+
+
+# ── §6 --debug-format selector ──────────────────────────────────────────────
+
+
+class TestDebugFormatSelector:
+    def test_compare_exposes_debug_format(self):
+        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        assert "--debug-format" in out
+        # The legacy --btf/--ctf/--dwarf flags are hidden: they have no
+        # left-column option entry (they only appear in the selector's help
+        # text). The selector entry shows the [auto|dwarf|btf|ctf] choices.
+        assert "[auto|dwarf|btf|ctf]" in out
+
+    def test_dump_exposes_debug_format(self):
+        out = CliRunner().invoke(main, ["dump", "--help"]).output
+        assert "--debug-format" in out
+        assert "[auto|dwarf|btf|ctf]" in out
+
+    def test_legacy_dwarf_flag_still_works(self, tmp_path):
+        old_p, new_p = _write_identical(tmp_path)
+        # Hidden does not mean removed: --dwarf must remain functional.
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--dwarf"],
+        )
+        assert result.exit_code == 0
+
+    def test_dump_compile_db_hidden(self):
+        out = CliRunner().invoke(main, ["dump", "--help"]).output
+        assert "--compile-db " not in out
+        assert "--compile-db-filter" in out  # the filter alias stays visible
+
+    def test_debug_format_auto_accepted(self, tmp_path):
+        old_p, new_p = _write_identical(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--debug-format", "auto"],
+        )
+        assert result.exit_code == 0
+
+
+# ── §6 --report-mode impact ─────────────────────────────────────────────────
+
+
+class TestReportModeImpact:
+    def test_impact_in_choices(self):
+        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        assert "impact" in out
+
+    def test_impact_mode_runs(self, tmp_path):
+        old_p, new_p = _write_removed_cpp_symbol(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare", str(old_p), str(new_p), "--report-mode", "impact"],
+        )
+        # Exit code unchanged: a removed symbol is still a 4 (BREAKING).
+        assert result.exit_code == 4
+
+
+# ── §2 compare-release scope + jobs defaults ────────────────────────────────
+
+
+class TestCompareReleaseDefaults:
+    def test_scope_toggle_present(self):
+        out = CliRunner().invoke(main, ["compare-release", "--help"]).output
+        assert "--scope-public-headers / --no-scope-public-headers" in out
+
+    def test_jobs_default_zero(self):
+        out = CliRunner().invoke(main, ["compare-release", "--help"]).output
+        assert "auto-detect" in out
+
+    def test_severity_options_present(self):
+        out = CliRunner().invoke(main, ["compare-release", "--help"]).output
+        assert "--severity-preset" in out
+        assert "--severity-abi-breaking" in out
+
+
+# ── §5 compare-release severity-aware exit aggregation ──────────────────────
+
+
+class TestCompareReleaseSeverityExit:
+    def _make_release(self, tmp_path: Path) -> tuple[Path, Path]:
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        old = AbiSnapshot(
+            library="libtest.so", version="1.0",
+            functions=[Function(name="foo", mangled="_Z3foov", return_type="int",
+                                 visibility=Visibility.PUBLIC)],
+        )
+        new = AbiSnapshot(library="libtest.so", version="2.0", functions=[])
+        (old_dir / "libtest.json").write_text(snapshot_to_json(old), encoding="utf-8")
+        (new_dir / "libtest.json").write_text(snapshot_to_json(new), encoding="utf-8")
+        return old_dir, new_dir
+
+    def test_severity_info_only_exits_zero(self, tmp_path):
+        old_dir, new_dir = self._make_release(tmp_path)
+        result = CliRunner().invoke(
+            main,
+            ["compare-release", str(old_dir), str(new_dir),
+             "--severity-preset", "info-only"],
+        )
+        # info-only downgrades everything below error -> exit 0 despite the break.
+        assert result.exit_code == 0
+
+    def test_severity_default_exits_breaking(self, tmp_path):
+        old_dir, new_dir = self._make_release(tmp_path)
+        result = CliRunner().invoke(
+            main,
+            ["compare-release", str(old_dir), str(new_dir),
+             "--severity-preset", "default"],
+        )
+        assert result.exit_code == 4
+
+    def test_no_severity_keeps_legacy_exit(self, tmp_path):
+        old_dir, new_dir = self._make_release(tmp_path)
+        result = CliRunner().invoke(
+            main, ["compare-release", str(old_dir), str(new_dir)],
+        )
+        # Removed C++ symbol == BREAKING == legacy exit 4.
+        assert result.exit_code == 4
+
+
+# ── §1 appcompat warnings + scope ───────────────────────────────────────────
+
+
+class TestAppcompatWarnings:
+    def test_scope_toggle_present(self):
+        out = CliRunner().invoke(main, ["appcompat", "--help"]).output
+        assert "--scope-public-headers / --no-scope-public-headers" in out
+
+    def test_severity_options_present(self):
+        out = CliRunner().invoke(main, ["appcompat", "--help"]).output
+        assert "--severity-preset" in out
+
+
+class TestValidateAppcompatArgs:
+    def test_warns_on_ignored_headers_in_weak_mode(self):
+        from abicheck.cli_appcompat import _validate_appcompat_args
+
+        # Should not raise, but the warning is emitted via click.echo. We invoke
+        # within a Click context-free call; click.echo to stderr is fine here.
+        # The key behavior: headers in weak mode do NOT raise (only warn).
+        _validate_appcompat_args(
+            weak_mode=True,
+            old_lib=None, new_lib=None,
+            list_symbols=False,
+            old_headers_only=(), new_headers_only=(),
+            old_includes_only=(), new_includes_only=(),
+            headers=(Path("foo.h"),), includes=(),
+        )
+
+    def test_per_side_headers_still_rejected_in_weak_mode(self):
+        import pytest
+
+        from abicheck.cli_appcompat import _validate_appcompat_args
+
+        with pytest.raises(Exception):  # click.UsageError
+            _validate_appcompat_args(
+                weak_mode=True,
+                old_lib=None, new_lib=None,
+                list_symbols=False,
+                old_headers_only=(Path("foo.h"),), new_headers_only=(),
+                old_includes_only=(), new_includes_only=(),
+                headers=(), includes=(),
+            )

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -391,42 +391,59 @@ class TestAppcompatSeverityExit:
             p.write_bytes(b"\x7fELF")
         return app, old, new
 
-    def _patch_result(self, monkeypatch, *, missing=None, with_break=False):
+    def _patch_result(self, monkeypatch, *, missing=None, app_break=False):
         import abicheck.appcompat as _ac
         from abicheck.appcompat import AppCompatResult
         from abicheck.checker import Verdict
 
+        diff = _breaking_diff()
         res = AppCompatResult(
             app_path="app", old_lib_path="old.so", new_lib_path="new.so",
             missing_symbols=list(missing or []),
-            full_diff=_breaking_diff() if with_break else None,
-            verdict=Verdict.BREAKING if (missing or with_break) else Verdict.COMPATIBLE,
+            # app_break -> the break is relevant to the app (breaking_for_app);
+            # otherwise the break is present in full_diff but NOT app-scoped, so
+            # it must not gate the app.
+            breaking_for_app=list(diff.changes) if app_break else [],
+            full_diff=diff,
+            verdict=Verdict.BREAKING if (missing or app_break) else Verdict.COMPATIBLE,
         )
         monkeypatch.setattr(_ac, "check_appcompat", lambda *a, **k: res)
         return res
 
-    def test_info_only_downgrades_library_break(self, tmp_path, monkeypatch):
+    def test_info_only_downgrades_app_break(self, tmp_path, monkeypatch):
         app, old, new = self._dummy_libs(tmp_path)
-        self._patch_result(monkeypatch, with_break=True)
+        self._patch_result(monkeypatch, app_break=True)
         result = CliRunner().invoke(
             main, ["appcompat", str(app), str(old), str(new),
                    "--severity-preset", "info-only"],
         )
-        # A library-diff break is governed by severity -> info-only exits 0.
+        # An app-relevant break is governed by severity -> info-only exits 0.
         assert result.exit_code == 0
 
-    def test_default_preset_exits_breaking(self, tmp_path, monkeypatch):
+    def test_default_preset_exits_on_app_break(self, tmp_path, monkeypatch):
         app, old, new = self._dummy_libs(tmp_path)
-        self._patch_result(monkeypatch, with_break=True)
+        self._patch_result(monkeypatch, app_break=True)
         result = CliRunner().invoke(
             main, ["appcompat", str(app), str(old), str(new),
                    "--severity-preset", "default"],
         )
         assert result.exit_code == 4
 
+    def test_unrelated_library_break_not_app_scoped(self, tmp_path, monkeypatch):
+        app, old, new = self._dummy_libs(tmp_path)
+        # full_diff has a break, but it is NOT relevant to the app
+        # (breaking_for_app empty). The severity exit must stay app-scoped -> 0,
+        # even under the default preset.
+        self._patch_result(monkeypatch, app_break=False)
+        result = CliRunner().invoke(
+            main, ["appcompat", str(app), str(old), str(new),
+                   "--severity-preset", "default"],
+        )
+        assert result.exit_code == 0
+
     def test_missing_symbols_floor_not_downgraded(self, tmp_path, monkeypatch):
         app, old, new = self._dummy_libs(tmp_path)
-        # No library-diff changes, but the app is missing a required symbol:
+        # No app-relevant changes, but the app is missing a required symbol:
         # info-only must NOT downgrade this hard runtime break below 4.
         self._patch_result(monkeypatch, missing=["_Z3barv"])
         result = CliRunner().invoke(

--- a/tests/test_cross_compiler_fp.py
+++ b/tests/test_cross_compiler_fp.py
@@ -101,6 +101,33 @@ def _require_tool(name: str) -> None:
         pytest.skip(f"{name} not found in PATH")
 
 
+# Generous compile timeout: a cold clang/gcc on a Windows CI runner (cold
+# toolchain cache, on-access AV scanning, slow temp filesystem) can take far
+# longer than a warm Linux invocation. This test verifies abicheck's diff
+# behavior, not compiler throughput, so a slow/hung toolchain should skip
+# (like a compilation failure does below), not fail the suite.
+_COMPILE_TIMEOUT_S = 180
+
+
+def _run_compile_or_skip(cmd: list[str], *, label: str = "Compilation") -> None:
+    """Run a compile command, skipping (not failing) on timeout or error.
+
+    A non-zero exit or a timeout both mean "this runner's toolchain couldn't
+    produce the artifact" — neither is an abicheck defect, so both skip.
+    """
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_COMPILE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(
+            f"{label} timed out after {_COMPILE_TIMEOUT_S}s; "
+            "slow/cold toolchain on this runner"
+        )
+    if r.returncode != 0:
+        pytest.skip(f"{label} failed: {r.stderr[:200]}")
+
+
 def _compile_so(src: str, out: Path, compiler: str, lang: str) -> None:
     ext = ".c" if lang == "c" else ".cpp"
     src_file = out.with_suffix(ext)
@@ -113,9 +140,7 @@ def _compile_so(src: str, out: Path, compiler: str, lang: str) -> None:
         # Force C mode when using a C++ driver on .c files
         cmd.insert(1, "-x")
         cmd.insert(2, "c")
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    if r.returncode != 0:
-        pytest.skip(f"Compilation failed ({compiler}): {r.stderr[:200]}")
+    _run_compile_or_skip(cmd, label=f"Compilation ({compiler})")
 
 
 def _dump_and_compare(gcc_so: Path, clang_so: Path, hdr: str | None,
@@ -230,9 +255,7 @@ class TestOptimizationLevelFP:
             src_file.write_text(textwrap.dedent(C_SRC).strip(), encoding="utf-8")
             cmd = ["gcc", "-shared", "-fPIC", "-g", "-fvisibility=default",
                    opt, "-o", str(so), str(src_file)]
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-            if r.returncode != 0:
-                pytest.skip(f"Compilation failed: {r.stderr[:200]}")
+            _run_compile_or_skip(cmd)
 
         r = _dump_and_compare(o0_so, o2_so, C_HDR, "c", tmp_path)
         assert not r.breaking, (
@@ -257,9 +280,7 @@ class TestOptimizationLevelFP:
             src_file.write_text(textwrap.dedent(CPP_SRC).strip(), encoding="utf-8")
             cmd = ["g++", "-shared", "-fPIC", "-g", "-fvisibility=default",
                    "-std=c++17", opt, "-o", str(so), str(src_file)]
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-            if r.returncode != 0:
-                pytest.skip(f"Compilation failed: {r.stderr[:200]}")
+            _run_compile_or_skip(cmd)
 
         r = _dump_and_compare(o0_so, o2_so, CPP_HDR, "cpp", tmp_path)
         assert not r.breaking
@@ -283,9 +304,7 @@ class TestStrippedVsUnstrippedFP:
         src_file.write_text(textwrap.dedent(C_SRC).strip(), encoding="utf-8")
         cmd = ["gcc", "-shared", "-fPIC", "-g", "-fvisibility=default",
                "-o", str(debug_so), str(src_file)]
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        if r.returncode != 0:
-            pytest.skip(f"Compilation failed: {r.stderr[:200]}")
+        _run_compile_or_skip(cmd)
 
         # Copy and strip
         shutil.copy2(debug_so, stripped_so)


### PR DESCRIPTION
## What

Started as a deep audit of **every configuration knob** abicheck exposes (CLI flags, config-file keys, env vars) across all operating modes — and now also **implements** the actionable findings. The audit lives at `docs/development/config-key-review.md`; the implementation touches the CLI commands. All claims were verified against source during review.

## Implementation (CLI behavior changes)

**Cross-mode consistency**
- `--scope-public-headers/--no-scope-public-headers` is now a uniform toggle on `compare`, `compare-release`, and `appcompat`.
  - `compare-release` flipped to **default ON** (was off-by-default `is_flag`), matching `compare` and the Python API. **Breaking** for compare-release users who relied on unscoped output — pass `--no-scope-public-headers` to restore.
  - `appcompat` previously had always-on scoping with no toggle; now controllable.
- `appcompat` **warns** (instead of silently ignoring) when `-H`/`-I` are passed in weak (`--check-against`) / `--list-required-symbols` mode.

**Defaults polish**
- `compare-release -j/--jobs` now defaults to `0` (auto-detect CPUs) instead of serial. **Behavior change** (parallel by default; reports are sorted so output is stable).
- `compare --demangle` is tri-state: defaults **ON** for `markdown/html/text/review`, **OFF** for `json/sarif`; explicit `--demangle/--no-demangle` still wins.

**Exit-code scheme made explicit (§2.2)**
- `compare` now prints the active exit-code scheme (legacy verdict vs severity-aware) to stderr for human formats — the previously-silent switch is visible. **Exit numbers unchanged.**
- `--severity-preset`/`--severity-*` added to `compare-release` (aggregated across libraries; removed-library exit `8` still takes precedence) and `appcompat` (full-compare mode only; weak mode keeps verdict exit).
- *Why not "always severity-aware":* API_BREAK and RISK share the `POTENTIAL_BREAKING` category while the verdict path maps `COMPATIBLE_WITH_RISK`→0, so a literal "legacy preset" can't reproduce 0/2/4 without changing RISK handling. Behavior is therefore left intact and made visible instead.

**Flag consolidation (additive, old flags kept as hidden aliases)**
- New `--debug-format {auto,dwarf,btf,ctf}` on `compare`/`dump`; legacy `--btf/--ctf/--dwarf` hidden but functional. (`--dwarf-only` intentionally **not** renamed — would break documented command lines.)
- `--report-mode` gains `impact` (sugar for `full` + `--show-impact`).
- `--compile-db` hidden from `--help`, still works as an alias of `-p/--build-dir`.

New tests in `tests/test_config_review.py` cover each behavioral change.

## Gates (run locally)
- `pytest` fast lane: **7112 passed**, 20 skipped, 4 xfailed
- `ruff check` ✅ · `mypy abicheck/` ✅ (101 files) · `scripts/check_ai_readiness.py` ✅ (0 errors; 3 pre-existing file-size WARNs)

## The review document

`docs/development/config-key-review.md` (in the mkdocs nav) inventories the full surface, ranks cross-mode inconsistencies, and ends with the now-implemented action list (§7 carries per-item status). Several initial automated-review over-claims were corrected during review (annotate stream, base_policy validation, compat info-notes/suppress, appcompat headers, MCP docs, probe/debian exit codes) — see commit history.

https://claude.ai/code/session_012rXgBGHjdH93YTykXmV5ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added severity-aware exit codes with `--severity-preset` and `--severity-*` flags across compare, compare-release, and appcompat modes
  * Introduced unified `--debug-format {auto,dwarf,btf,ctf}` selector for simplified format control
  * Added `--scope-public-headers` toggle for header scoping in appcompat and compare-release
  * New `--report-mode impact` for focused output

* **Changed**
  * `compare-release` now defaults to public-header scoping
  * `compare --demangle` is now tri-state with intelligent format-based defaults

* **Bug Fixes**
  * Fixed non-deterministic output ordering in parallel library comparisons
  * Added warnings when header flags are used in unsupported modes

* **Documentation**
  * Added comprehensive config key review documenting CLI consistency and design decisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->