### PR TITLE
fix: eliminate false-positive classes and ABI-checking issues found by scanning real binaries

### DIFF
--- a/abicheck/binary_fingerprint.py
+++ b/abicheck/binary_fingerprint.py
@@ -374,14 +374,18 @@ def _fuzzy_partners(
     for new_name, new_fp in new_candidates.items():
         if new_name in used_new or new_fp.size == 0:
             continue
-        if name_filter is not None and not name_filter(old_fp.name, new_name):
-            continue
         # If both have code hashes but they differ, skip
         if old_fp.code_hash and new_fp.code_hash and old_fp.code_hash != new_fp.code_hash:
             continue
         size_diff = abs(old_fp.size - new_fp.size) / max(old_fp.size, new_fp.size)
-        if size_diff <= _SIZE_TOLERANCE_RATIO:
-            partners.append((new_name, new_fp))
+        if size_diff > _SIZE_TOLERANCE_RATIO:
+            continue
+        # Name similarity is the most expensive gate (demangle + bracket scan),
+        # so apply it last — only to size-eligible partners, not the whole
+        # cross-product.
+        if name_filter is not None and not name_filter(old_fp.name, new_name):
+            continue
+        partners.append((new_name, new_fp))
     return partners
 
 

--- a/abicheck/binary_fingerprint.py
+++ b/abicheck/binary_fingerprint.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -339,18 +340,22 @@ def _match_size(
         if old_name in matched_old:
             continue
         size_matches = [
-            (n, fp) for n, fp in new_by_size.get(old_fp.size, [])
-            if n not in used_new and (name_filter is None or name_filter(old_name, n))
+            (n, fp)
+            for n, fp in new_by_size.get(old_fp.size, [])
+            if n not in used_new
+            # A same-size candidate with a conflicting code hash can never match
+            # — exclude it before the ambiguity check so it does not block the
+            # one eligible partner and drop a real rename.
+            and not (old_fp.code_hash and fp.code_hash and old_fp.code_hash != fp.code_hash)
+            and (name_filter is None or name_filter(old_name, n))
         ]
         # Only match if there's exactly one candidate at this size
         # (ambiguous matches are not reliable)
         if len(size_matches) != 1:
             continue
         new_name, new_fp = size_matches[0]
-        # If both have code hashes but they differ, skip
-        if old_fp.code_hash and new_fp.code_hash and old_fp.code_hash != new_fp.code_hash:
-            continue
-        # 0.8 when either side lacks a code hash (size match only)
+        # 0.8 when either side lacks a code hash (size match only); conflicting
+        # code hashes were already excluded from size_matches above.
         out.append(RenameCandidate(
             old_name=old_name,
             new_name=new_name,

--- a/abicheck/binary_fingerprint.py
+++ b/abicheck/binary_fingerprint.py
@@ -33,6 +33,7 @@ import hashlib
 import logging
 import os
 import stat
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO
@@ -219,6 +220,7 @@ def compute_section_summary(binary_path: str | Path) -> BinarySummary:
 def match_renamed_functions(
     old_fps: dict[str, FunctionFingerprint],
     new_fps: dict[str, FunctionFingerprint],
+    name_filter: Callable[[str, str], bool] | None = None,
 ) -> list[RenameCandidate]:
     """Find likely renamed functions by matching fingerprints.
 
@@ -239,6 +241,14 @@ def match_renamed_functions(
     shared libraries (< 10k symbols).
 
     Matches are returned sorted by confidence (highest first).
+
+    ``name_filter`` (optional): a predicate ``(old_name, new_name) -> bool``
+    consulted during candidate *selection* for the hash-less size/fuzzy passes
+    (3 and 4 above). When supplied, an old symbol only considers new partners
+    the predicate accepts, so an implausible same-size symbol cannot greedily
+    consume a partner that a plausible rename should claim. Exact (code-hash)
+    matches ignore the filter — identical code is strong evidence regardless of
+    name. When omitted, matching behaves exactly as before.
     """
     old_only = set(old_fps) - set(new_fps)
     new_only = set(new_fps) - set(old_fps)
@@ -264,8 +274,8 @@ def match_renamed_functions(
     used_new: set[str] = set()
     candidates = _match_exact(old_candidates, new_by_hash, used_new)
     matched_old = {c.old_name for c in candidates}
-    candidates += _match_size(old_candidates, new_by_size, used_new, matched_old)
-    candidates += _match_fuzzy(old_candidates, new_candidates, used_new, matched_old)
+    candidates += _match_size(old_candidates, new_by_size, used_new, matched_old, name_filter)
+    candidates += _match_fuzzy(old_candidates, new_candidates, used_new, matched_old, name_filter)
 
     # Sort by confidence descending
     candidates.sort(key=lambda c: (-c.confidence, c.old_name))
@@ -321,6 +331,7 @@ def _match_size(
     new_by_size: dict[int, list[tuple[str, FunctionFingerprint]]],
     used_new: set[str],
     matched_old: set[str],
+    name_filter: Callable[[str, str], bool] | None = None,
 ) -> list[RenameCandidate]:
     """Pass 2: size-only matches (same size, unique among remaining candidates)."""
     out: list[RenameCandidate] = []
@@ -329,7 +340,7 @@ def _match_size(
             continue
         size_matches = [
             (n, fp) for n, fp in new_by_size.get(old_fp.size, [])
-            if n not in used_new
+            if n not in used_new and (name_filter is None or name_filter(old_name, n))
         ]
         # Only match if there's exactly one candidate at this size
         # (ambiguous matches are not reliable)
@@ -356,11 +367,14 @@ def _fuzzy_partners(
     old_fp: FunctionFingerprint,
     new_candidates: dict[str, FunctionFingerprint],
     used_new: set[str],
+    name_filter: Callable[[str, str], bool] | None = None,
 ) -> list[tuple[str, FunctionFingerprint]]:
     """New candidates whose size is within tolerance of ``old_fp`` and unused."""
     partners: list[tuple[str, FunctionFingerprint]] = []
     for new_name, new_fp in new_candidates.items():
         if new_name in used_new or new_fp.size == 0:
+            continue
+        if name_filter is not None and not name_filter(old_fp.name, new_name):
             continue
         # If both have code hashes but they differ, skip
         if old_fp.code_hash and new_fp.code_hash and old_fp.code_hash != new_fp.code_hash:
@@ -376,13 +390,14 @@ def _match_fuzzy(
     new_candidates: dict[str, FunctionFingerprint],
     used_new: set[str],
     matched_old: set[str],
+    name_filter: Callable[[str, str], bool] | None = None,
 ) -> list[RenameCandidate]:
     """Pass 3: fuzzy size matches (within tolerance, unique match only)."""
     out: list[RenameCandidate] = []
     for old_name, old_fp in sorted(old_candidates.items()):
         if old_name in matched_old or old_fp.size == 0:
             continue
-        fuzzy_matches = _fuzzy_partners(old_fp, new_candidates, used_new)
+        fuzzy_matches = _fuzzy_partners(old_fp, new_candidates, used_new, name_filter)
         if len(fuzzy_matches) == 1:
             new_name, new_fp = fuzzy_matches[0]
             out.append(RenameCandidate(

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -35,6 +35,15 @@ from .detectors import DetectorResult
 from .model import AbiSnapshot
 from .policy_file import PolicyFile
 
+# Marker appended to a ``SYMBOL_VERSION_ALIAS_CHANGED`` description when the old
+# default symbol version is NOT retained as a non-default alias (so consumers of
+# the old version fail to resolve). Shared between the producer
+# (``diff_platform._diff_symbol_version_aliases``) and the cross-detector dedup
+# (``diff_filtering._deduplicate_cross_detector``), which only collapses an
+# alias-change into a co-reported node-move in this not-retained case — when the
+# old alias IS retained the alias-change is compatible and must survive.
+SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER = "old version NOT retained as alias"
+
 
 @dataclass
 class Change:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -121,11 +121,18 @@ def _stamp_provenance(
     build_id: str | None,
     no_git: bool,
 ) -> None:
-    """Fill provenance metadata on a snapshot (mutates in place)."""
-    import datetime
+    """Fill provenance metadata on a snapshot (mutates in place).
+
+    ``created_at`` honours ``SOURCE_DATE_EPOCH`` (the reproducible-builds
+    standard): when set to a Unix timestamp, that fixed time is used instead of
+    the wall clock, so two dumps of an identical library are byte-identical —
+    enabling content-addressable caching and reproducible-build verification.
+    An unset or malformed value falls back to the current time.
+    """
+    import os
     import subprocess
 
-    snap.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    snap.created_at = _provenance_timestamp(os.environ.get("SOURCE_DATE_EPOCH"))
     snap.git_tag = git_tag
     snap.build_id = build_id
 
@@ -139,6 +146,22 @@ def _stamp_provenance(
                 snap.git_commit = result.stdout.strip()
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass  # git not available or not a repo — leave as None
+
+
+def _provenance_timestamp(source_date_epoch: str | None) -> str:
+    """ISO-8601 UTC timestamp, honouring ``SOURCE_DATE_EPOCH`` when valid."""
+    import datetime
+
+    if source_date_epoch:
+        try:
+            epoch = int(source_date_epoch.strip())
+        except ValueError:
+            pass
+        else:
+            return datetime.datetime.fromtimestamp(
+                epoch, tz=datetime.timezone.utc
+            ).isoformat()
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
 def _write_snapshot_output(

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -19,7 +19,7 @@ import logging
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -491,7 +491,45 @@ def _collect_metadata(path: Path) -> LibraryMetadata | None:
     )
 
 
-@click.group()
+# Exit code for an invalid invocation (bad arguments, unknown option, invalid
+# option value, unreadable/unrecognised input path). Chosen as sysexits.h
+# ``EX_USAGE`` so it sits *outside* the compare/compat result space
+# {0, 1, 2, 4} — a CI script can therefore tell "you called me wrong" apart
+# from a real ABI verdict. Click defaults ``UsageError`` to exit 2, which
+# collides with ``compare``'s documented "2 = source break"; this remaps it.
+_EXIT_USAGE_ERROR = 64
+
+
+class _AbicheckGroup(click.Group):
+    """Root group that maps Click *usage* errors to a dedicated exit code.
+
+    Click exits 2 for ``UsageError`` / ``BadParameter`` (bad arguments, unknown
+    options, invalid option values, missing/unreadable input paths), which
+    collides with ``compare``'s documented ``2 = source break`` result. Remap
+    just that code to ``_EXIT_USAGE_ERROR`` so an invalid invocation is never
+    mistaken for an ABI verdict. Other ``ClickException``s (exit 1, used for
+    operational failures such as malformed input or an expired strict waiver),
+    verdict exits (``SystemExit`` 2/4), and the ``compat`` error scheme (3–11)
+    are deliberately left untouched.
+    """
+
+    def main(self, *args: Any, standalone_mode: bool = True, **kwargs: Any) -> Any:  # type: ignore[override]
+        if not standalone_mode:
+            return super().main(*args, standalone_mode=False, **kwargs)  # type: ignore[call-overload]
+        try:
+            super().main(*args, standalone_mode=False, **kwargs)  # type: ignore[call-overload]
+        except click.exceptions.Abort:
+            click.echo("Aborted!", err=True)
+            sys.exit(1)
+        except click.exceptions.ClickException as exc:
+            exc.show()
+            # Only Click's usage-error code (2) collides with a compare verdict.
+            sys.exit(_EXIT_USAGE_ERROR if exc.exit_code == 2 else exc.exit_code)
+        else:
+            sys.exit(0)
+
+
+@click.group(cls=_AbicheckGroup)
 @click.version_option(
     version=_abicheck_version,
     prog_name="abicheck",
@@ -1670,6 +1708,10 @@ def compare_cmd(
       1  Error-level findings in addition or quality_issues only
       2  Error-level findings in potential_breaking (but not abi_breaking)
       4  Error-level findings in abi_breaking
+    \b
+    Invalid invocation (bad arguments/options, unreadable or unrecognised
+    input) exits 64, outside the result space above, so it is never mistaken
+    for an ABI verdict.
 
     \b
     Examples:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -155,12 +156,13 @@ def _provenance_timestamp(source_date_epoch: str | None) -> str:
     if source_date_epoch:
         try:
             epoch = int(source_date_epoch.strip())
-        except ValueError:
-            pass
-        else:
             return datetime.datetime.fromtimestamp(
                 epoch, tz=datetime.timezone.utc
             ).isoformat()
+        except (ValueError, OverflowError, OSError):
+            # Non-numeric or out-of-range epoch — fall back to wall clock
+            # rather than aborting the dump.
+            pass
     return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 

--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -889,9 +889,29 @@ def _deduplicate_cross_detector(changes: list[Change]) -> list[Change]:
         ChangeKind.SYMBOL_VERSION_NODE_REMOVED: "version_def_removal",
         ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED: "version_def_removal",
     }
+    # A symbol-version-node bump (e.g. LLVM_17 -> LLVM_18.1 applied to every
+    # symbol during a major release) makes BOTH version detectors fire per
+    # symbol with the same old->new transition: SYMBOL_MOVED_VERSION_NODE (the
+    # node label moved) and SYMBOL_VERSION_ALIAS_CHANGED (the default version
+    # changed, old not retained as an alias). They describe one event; drop the
+    # alias-change duplicate where a node move already covers the same
+    # (symbol, old -> new), keeping the node-level change. Halves the
+    # version-bump noise on real libraries (libLLVM 17->18: ~46k instead of
+    # ~92k risk findings).
+    moved_transitions: set[tuple[str, object, object]] = {
+        (c.symbol, c.old_value, c.new_value)
+        for c in changes
+        if c.kind is ChangeKind.SYMBOL_MOVED_VERSION_NODE
+    }
+
     seen: set[tuple[str, str]] = set()
     result: list[Change] = []
     for c in changes:
+        if (
+            c.kind is ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED
+            and (c.symbol, c.old_value, c.new_value) in moved_transitions
+        ):
+            continue
         cat = _DEDUP_CATEGORIES.get(c.kind)
         if cat is not None:
             key = (cat, c.symbol)

--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import re
 
 from .checker_policy import ChangeKind, Confidence, EvidenceTier
-from .checker_types import Change
+from .checker_types import SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER, Change
 from .detectors import DetectorResult
 from .diff_symbols import _PUBLIC_VIS, _public_functions
 from .model import AbiSnapshot, Function
@@ -913,8 +913,15 @@ def _deduplicate_cross_detector(changes: list[Change]) -> list[Change]:
     seen: set[tuple[str, str]] = set()
     result: list[Change] = []
     for c in changes:
+        # Only collapse the alias-change into a co-reported node-move when the
+        # old default version is NOT retained as an alias — that is the case the
+        # node-move already fully describes. When the old alias IS retained the
+        # alias-change carries distinct, *compatible* information (old consumers
+        # still resolve) that the node-move's "will not find this symbol"
+        # wording would otherwise misrepresent, so it must survive.
         if (
             c.kind is ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED
+            and SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER in (c.description or "")
             and (c.symbol, c.old_value, c.new_value) in moved_transitions
         ):
             continue

--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -898,7 +898,7 @@ def _deduplicate_cross_detector(changes: list[Change]) -> list[Change]:
     # (symbol, old -> new), keeping the node-level change. Halves the
     # version-bump noise on real libraries (libLLVM 17->18: ~46k instead of
     # ~92k risk findings).
-    moved_transitions: set[tuple[str, object, object]] = {
+    moved_transitions: set[tuple[str, str | None, str | None]] = {
         (c.symbol, c.old_value, c.new_value)
         for c in changes
         if c.kind is ChangeKind.SYMBOL_MOVED_VERSION_NODE

--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -898,6 +898,12 @@ def _deduplicate_cross_detector(changes: list[Change]) -> list[Change]:
     # (symbol, old -> new), keeping the node-level change. Halves the
     # version-bump noise on real libraries (libLLVM 17->18: ~46k instead of
     # ~92k risk findings).
+    #
+    # The match keys on (symbol, old_value, new_value): both detectors live in
+    # diff_versioning.py and populate old_value/new_value with the same version
+    # node labels for one bump, so the tuples coincide. If that ever diverges
+    # the dedup simply no-ops (both findings are kept) — a missed dedup, never a
+    # dropped real change — so this stays a safe, best-effort filter.
     moved_transitions: set[tuple[str, str | None, str | None]] = {
         (c.symbol, c.old_value, c.new_value)
         for c in changes

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import Any
 
 from .checker_policy import ChangeKind
-from .checker_types import Change
+from .checker_types import SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER, Change
 from .detector_registry import registry
 from .diff_platform_templates import (
     _diff_template_inner_types as _diff_template_inner_types,
@@ -781,7 +781,7 @@ def _diff_symbol_version_aliases(old: AbiSnapshot, new: AbiSnapshot) -> list[Cha
             f"(@@{old_ver} → @@{new_ver})"
         )
         if not retained:
-            desc += " — old version NOT retained as alias"
+            desc += f" — {SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER}"
         changes.append(Change(
             kind=ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED,
             symbol=sym_name,

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -15,6 +15,7 @@
 "Platform-specific ABI diff detectors (ELF, PE, Mach-O, DWARF)."
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from .checker_policy import ChangeKind
@@ -1162,6 +1163,12 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     return changes
 
 
+# Synthesized placeholder names for anonymous/unnamed aggregate member types,
+# which differ across DWARF / castxml / PDB readers (``<unnamed-tag>``,
+# ``<unnamed-type-u>``, ``<anonymous union>``, ``<unnamed struct at …>``, …).
+_ANON_TYPE_RE = re.compile(r"<\s*(?:unnamed|anonymous)\b", re.IGNORECASE)
+
+
 def _normalize_type_name(name: str) -> str:
     """Normalize a C/C++ type name for stable DWARF↔castxml comparison.
 
@@ -1188,6 +1195,15 @@ def _normalize_type_name(name: str) -> str:
     s = _re.sub(r"^(const|volatile)(\s+(const|volatile))?\s+", "", s).strip()
     # Remove struct/class/union tag keyword
     s = _re.sub(r"^(struct|class|union)\s+", "", s).strip()
+    # Anonymous/unnamed member types have no stable name across DWARF / castxml /
+    # PDB extraction — the same anonymous union can be spelled "<unnamed-tag>" by
+    # one reader and "Parent::<unnamed-type-u>" by another (observed on the
+    # Windows SDK _TP_CALLBACK_ENVIRON_V3::u between two MSVC builds). Comparing
+    # those placeholders is meaningless, so collapse any of them to one token.
+    # A genuine change to a *differently sized* anonymous type is still caught by
+    # the separate byte_size comparison, so this does not mask real drift.
+    if _ANON_TYPE_RE.search(s):
+        return "<anonymous>"
     return s
 
 

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -1197,20 +1197,26 @@ def _normalize_type_name(name: str) -> str:
     s = _re.sub(r"[\s*&]+$", "", s).strip()
     # Remove leading CV-qualifiers
     s = _re.sub(r"^(const|volatile)(\s+(const|volatile))?\s+", "", s).strip()
-    # Remove struct/class/union tag keyword
-    s = _re.sub(r"^(struct|class|union)\s+", "", s).strip()
+    # Remove struct/class/union tag keyword, remembering it: for an anonymous
+    # placeholder spelled with a *leading* tag ("union <anonymous>") the tag
+    # carries the aggregate kind, which must survive the collapse below.
+    lead = _re.match(r"^(struct|class|union)\s+", s)
+    lead_kind = lead.group(1) if lead else None
+    if lead:
+        s = s[lead.end():].strip()
     # Anonymous/unnamed member types have no stable *name* across DWARF / castxml
     # / PDB extraction — the same anonymous union can be spelled "<unnamed-tag>"
     # by one reader and "Parent::<unnamed-type-u>" by another (observed on the
     # Windows SDK _TP_CALLBACK_ENVIRON_V3::u between two MSVC builds). Collapse
-    # those placeholders to a token keyed on the aggregate *kind* when the
-    # placeholder names one, so the unstable identifier suffix no longer drives a
-    # false positive while a genuine kind change (anonymous union → anonymous
-    # struct) is still reported. Size drift remains caught by the separate
-    # byte_size comparison.
+    # those placeholders to a token keyed on the aggregate *kind* — taken from
+    # the placeholder itself ("<anonymous union>") or the leading tag ("union
+    # <anonymous>") — so the unstable identifier suffix no longer drives a false
+    # positive while a genuine kind change (anonymous union → anonymous struct)
+    # is still reported. Size drift remains caught by the separate byte_size
+    # comparison.
     anon = _ANON_TYPE_RE.search(s)
     if anon is not None:
-        kind = anon.group(1)
+        kind = anon.group(1) or lead_kind
         return f"<anonymous {kind.lower()}>" if kind else "<anonymous>"
     return s
 

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -1166,7 +1166,11 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 # Synthesized placeholder names for anonymous/unnamed aggregate member types,
 # which differ across DWARF / castxml / PDB readers (``<unnamed-tag>``,
 # ``<unnamed-type-u>``, ``<anonymous union>``, ``<unnamed struct at …>``, …).
-_ANON_TYPE_RE = re.compile(r"<\s*(?:unnamed|anonymous)\b", re.IGNORECASE)
+# The aggregate *kind* (when the placeholder names one) is captured so a real
+# union→struct change is preserved while the unstable identifier suffix is not.
+_ANON_TYPE_RE = re.compile(
+    r"<\s*(?:unnamed|anonymous)(?:\s+(union|struct|class|enum)\b)?", re.IGNORECASE
+)
 
 
 def _normalize_type_name(name: str) -> str:
@@ -1195,15 +1199,19 @@ def _normalize_type_name(name: str) -> str:
     s = _re.sub(r"^(const|volatile)(\s+(const|volatile))?\s+", "", s).strip()
     # Remove struct/class/union tag keyword
     s = _re.sub(r"^(struct|class|union)\s+", "", s).strip()
-    # Anonymous/unnamed member types have no stable name across DWARF / castxml /
-    # PDB extraction — the same anonymous union can be spelled "<unnamed-tag>" by
-    # one reader and "Parent::<unnamed-type-u>" by another (observed on the
-    # Windows SDK _TP_CALLBACK_ENVIRON_V3::u between two MSVC builds). Comparing
-    # those placeholders is meaningless, so collapse any of them to one token.
-    # A genuine change to a *differently sized* anonymous type is still caught by
-    # the separate byte_size comparison, so this does not mask real drift.
-    if _ANON_TYPE_RE.search(s):
-        return "<anonymous>"
+    # Anonymous/unnamed member types have no stable *name* across DWARF / castxml
+    # / PDB extraction — the same anonymous union can be spelled "<unnamed-tag>"
+    # by one reader and "Parent::<unnamed-type-u>" by another (observed on the
+    # Windows SDK _TP_CALLBACK_ENVIRON_V3::u between two MSVC builds). Collapse
+    # those placeholders to a token keyed on the aggregate *kind* when the
+    # placeholder names one, so the unstable identifier suffix no longer drives a
+    # false positive while a genuine kind change (anonymous union → anonymous
+    # struct) is still reported. Size drift remains caught by the separate
+    # byte_size comparison.
+    anon = _ANON_TYPE_RE.search(s)
+    if anon is not None:
+        kind = anon.group(1)
+        return f"<anonymous {kind.lower()}>" if kind else "<anonymous>"
     return s
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1012,20 +1012,20 @@ def _diff_var_access(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 _FUNC_LIKE_TYPES = frozenset({SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTYPE})
 
-# Minimum unqualified-name similarity required to accept a *hash-less* (size-only
-# / fuzzy) rename match. When no code hash is available — the only mode the
-# snapshot/elf_only path can reach — a "rename" is inferred purely from a
-# coincidental symbol-size collision. On a large library that produces nonsense
-# pairings of completely unrelated functions that merely happen to share a byte
-# size (observed on real libLLVM release-to-release diffs: e.g. fixupIndexV4 ->
-# SmallVectorImpl<...>). A genuine rename or namespace relocation preserves the
-# function's *unqualified* leaf name, so comparing leaf names (not whole
-# qualified spellings, whose shared namespace/class prefix would dominate the
-# score and let e.g. std::vector<int>::begin vs ::end pass) discriminates real
-# renames from coincidences. Measured on real libLLVM 17->18: genuine moves
-# score ~1.0, unrelated same-size pairs <=0.13. The 0.6 floor also rejects
-# distinct short leaves under a shared scope (e.g. begin/end at 0.5).
-_RENAME_NAME_SIMILARITY_MIN = 0.6
+# Minimum shared leading/trailing run (in characters) between two unqualified
+# leaf names for a *hash-less* (size-only / fuzzy) match to count as a rename.
+# When no code hash is available — the only mode the snapshot/elf_only path can
+# reach — a "rename" is inferred purely from a coincidental symbol-size
+# collision, which on a large library pairs completely unrelated functions that
+# merely share a byte size (observed on real libLLVM diffs: e.g. fixupIndexV4 ->
+# SmallVectorImpl<...>). A genuine rename or namespace relocation keeps a
+# substantial common prefix or suffix token in the *unqualified* leaf name
+# (foo_v1->foo_v2, old_only->new_only), whereas distinct leaves — even under a
+# shared scope (Class::get vs Class::set, ::begin vs ::end, get<int> vs
+# set<int>) — share at most one or two incidental characters. Requiring a
+# >=3-char shared affix cleanly separates the two on measured data (genuine
+# renames share 4-20, unrelated pairs 0-2).
+_RENAME_MIN_SHARED_AFFIX = 3
 
 
 def _unqualified_name(symbol: str) -> str:
@@ -1033,10 +1033,17 @@ def _unqualified_name(symbol: str) -> str:
 
     Matching-safe alternative to ``demangle.base_name`` (which is documented
     display-only and mis-parses operators / templates). Demangles when a
-    demangler is available, then strips the parameter list and the
-    namespace/class qualifier using *bracket-depth tracking* so that ``::`` and
-    ``(`` inside template arguments are ignored, and keeps the whole
-    ``operator...`` token intact.
+    demangler is available, then, using *bracket-depth tracking* so that ``::``,
+    ``(`` and spaces inside template arguments are ignored:
+
+    * keeps the whole ``operator...`` token intact;
+    * drops the parameter list;
+    * drops the namespace/class qualifier (segment after the last top-level
+      ``::``);
+    * drops a leading return type (global function templates demangle as
+      ``ret name<args>(...)``);
+    * drops trailing template arguments, so instantiations of one template
+      (``get<int>`` / ``get<long>``) share a leaf.
     """
     from .demangle import demangle
 
@@ -1072,29 +1079,64 @@ def _unqualified_name(symbol: str) -> str:
             i += 2
             continue
         i += 1
-    return s[last:].strip()
+    s = s[last:].strip()
+    # Drop a leading return type: take the part after the last top-level space
+    # (e.g. ``void get<int>`` -> ``get<int>``).
+    depth = 0
+    sp = -1
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == " " and depth == 0:
+            sp = i
+    if sp != -1:
+        s = s[sp + 1:]
+    # Drop trailing template arguments (``get<int>`` -> ``get``).
+    if s.endswith(">"):
+        depth = 0
+        for i in range(len(s) - 1, -1, -1):
+            if s[i] == ">":
+                depth += 1
+            elif s[i] == "<":
+                depth -= 1
+                if depth == 0:
+                    s = s[:i]
+                    break
+    return s.strip()
+
+
+def _shared_affix_len(a: str, b: str) -> int:
+    """Length of the longer of the common leading / common trailing run."""
+    def common_prefix(x: str, y: str) -> int:
+        n = 0
+        for cx, cy in zip(x, y):
+            if cx != cy:
+                break
+            n += 1
+        return n
+    return max(common_prefix(a, b), common_prefix(a[::-1], b[::-1]))
 
 
 def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
     Compares the *unqualified* leaf names (see ``_unqualified_name``). A rename
-    or namespace relocation keeps the leaf name (identical leaf → score 1.0),
-    while unrelated functions that merely share a byte size — including
-    different methods under a common scope such as ``Class::get`` vs
-    ``Class::set`` — score low because the shared qualifier is discounted. Used
+    or namespace relocation keeps the leaf name (identical leaf) or a
+    substantial common prefix/suffix token; unrelated functions that merely
+    share a byte size — including different methods under a common scope such as
+    ``Class::get`` vs ``Class::set`` — share at most a character or two because
+    the qualifier and any return type / template arguments are stripped. Used
     only to gate hash-less matches, where size alone is not evidence of identity.
     """
     if old_name == new_name:
         return True
-
-    import difflib
-
     a = _unqualified_name(old_name)
     b = _unqualified_name(new_name)
     if a == b:
         return True
-    return difflib.SequenceMatcher(None, a, b).ratio() >= _RENAME_NAME_SIMILARITY_MIN
+    return _shared_affix_len(a, b) >= _RENAME_MIN_SHARED_AFFIX
 
 
 def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -162,12 +162,81 @@ def _check_removed_function(
     )
 
 
-def _check_return_type_change(mangled: str, f_old: Function, f_new: Function) -> list[Change]:
+# Scalar integer spellings whose width/signedness are data-model *independent*,
+# mapped to (bit-width, is_signed). Used to recognise ABI-equivalent integer
+# type changes (e.g. ``long`` ↔ ``long long`` on LP64, ``size_t`` ↔
+# ``unsigned long``): a name-only change between two spellings with the same
+# width and signedness is not a binary ABI break — the calling convention and
+# storage are identical. ``size_t``/``ptrdiff_t``/pointer-width types are 64-bit
+# on every supported 64-bit target (LP64 and LLP64).
+_FIXED_SCALAR_REPR: dict[str, tuple[int, bool]] = {
+    "int": (32, True), "signed int": (32, True), "signed": (32, True),
+    "int32_t": (32, True),
+    "unsigned int": (32, False), "unsigned": (32, False), "uint32_t": (32, False),
+    "long long": (64, True), "long long int": (64, True),
+    "signed long long": (64, True), "int64_t": (64, True),
+    "unsigned long long": (64, False), "long long unsigned int": (64, False),
+    "uint64_t": (64, False),
+    "short": (16, True), "short int": (16, True), "int16_t": (16, True),
+    "unsigned short": (16, False), "short unsigned int": (16, False),
+    "uint16_t": (16, False),
+    "signed char": (8, True), "int8_t": (8, True),
+    "unsigned char": (8, False), "uint8_t": (8, False),
+    "size_t": (64, False), "uintptr_t": (64, False),
+    "ssize_t": (64, True), "ptrdiff_t": (64, True), "intptr_t": (64, True),
+}
+# The ``long`` family: 64-bit under LP64 (Linux/macOS), 32-bit under LLP64
+# (Windows) — resolved against the snapshot's data model.
+_LONG_SIGNED_SPELLINGS = frozenset({"long", "long int", "signed long"})
+_LONG_UNSIGNED_SPELLINGS = frozenset({"unsigned long", "long unsigned int"})
+
+
+def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[int, bool] | None:
+    """Map a *bare* integer spelling to (bit-width, is_signed), or None.
+
+    Returns None for anything that is not a plain integer scalar (pointers,
+    references, templates, cv-qualified or unknown spellings), so equivalence is
+    only ever asserted between two unambiguous integer names.
+    """
+    t = " ".join(type_name.split())
+    if not t or any(c in t for c in "*&<>([,") or "const" in t or "volatile" in t:
+        return None
+    fixed = _FIXED_SCALAR_REPR.get(t)
+    if fixed is not None:
+        return fixed
+    if t in _LONG_SIGNED_SPELLINGS:
+        return (32 if is_llp64 else 64, True)
+    if t in _LONG_UNSIGNED_SPELLINGS:
+        return (32 if is_llp64 else 64, False)
+    return None
+
+
+def _abi_equivalent_scalar(old_type: str, new_type: str, is_llp64: bool) -> bool:
+    """Whether two integer spellings have identical binary representation.
+
+    True only when both resolve to the same width *and* signedness on the
+    target data model — i.e. the change is a spelling/typedef difference, not a
+    binary ABI break (``size_t`` ↔ ``unsigned long``, ``long`` ↔ ``long long``
+    on LP64). A signedness difference (``long`` ↔ ``unsigned long``) is *not*
+    equivalent and is still reported.
+    """
+    old_r = _scalar_repr(old_type, is_llp64)
+    return old_r is not None and old_r == _scalar_repr(new_type, is_llp64)
+
+
+def _check_return_type_change(
+    mangled: str, f_old: Function, f_new: Function, *, is_llp64: bool = False,
+) -> list[Change]:
     """Emit a change if the return type was modified."""
     # RD2-5: a stripped side reports return_type "?"; that is unknown, not a change.
     if _type_unknown(f_old.return_type) or _type_unknown(f_new.return_type):
         return []
     if canonicalize_type_name(f_old.return_type) == canonicalize_type_name(f_new.return_type):
+        return []
+    # A name-only change between ABI-equivalent integer spellings (e.g.
+    # long -> long long, size_t -> unsigned long on LP64) is not a binary ABI
+    # break: same width, signedness, and calling convention.
+    if _abi_equivalent_scalar(f_old.return_type, f_new.return_type, is_llp64):
         return []
     return [Change(
         kind=ChangeKind.FUNC_RETURN_CHANGED,
@@ -178,8 +247,22 @@ def _check_return_type_change(mangled: str, f_old: Function, f_new: Function) ->
     )]
 
 
+def _params_differ(p_old: Param, p_new: Param, is_llp64: bool) -> bool:
+    """Whether two positionally-matched parameters differ in an ABI-relevant way."""
+    if _type_unknown(p_old.type) or _type_unknown(p_new.type):
+        return False  # diffing a known type against unknown is meaningless
+    if p_old.kind != p_new.kind:
+        return True
+    if canonicalize_type_name(p_old.type) == canonicalize_type_name(p_new.type):
+        return False
+    # Same kind, different spelling: not a change if the integer types are
+    # ABI-equivalent (long -> long long, size_t -> unsigned long on LP64).
+    return not _abi_equivalent_scalar(p_old.type, p_new.type, is_llp64)
+
+
 def _check_params_change(
-    mangled: str, f_old: Function, f_new: Function, *, params_unconfirmed: bool = False,
+    mangled: str, f_old: Function, f_new: Function, *,
+    params_unconfirmed: bool = False, is_llp64: bool = False,
 ) -> list[Change]:
     """Emit a change if the parameter list was modified."""
     # RD2-5: suppress only when one side is a stripped symbols-only stub (its
@@ -196,9 +279,7 @@ def _check_params_change(
         changed = True
     else:
         changed = any(
-            not _type_unknown(p_old.type) and not _type_unknown(p_new.type)
-            and (canonicalize_type_name(p_old.type), p_old.kind)
-            != (canonicalize_type_name(p_new.type), p_new.kind)
+            _params_differ(p_old, p_new, is_llp64)
             for p_old, p_new in zip(f_old.params, f_new.params)
         )
     if not changed:
@@ -303,12 +384,14 @@ def _check_explicit_change(mangled: str, f_old: Function, f_new: Function) -> li
 
 
 def _check_function_signature(
-    mangled: str, f_old: Function, f_new: Function, *, params_unconfirmed: bool = False,
+    mangled: str, f_old: Function, f_new: Function, *,
+    params_unconfirmed: bool = False, is_llp64: bool = False,
 ) -> list[Change]:
     """Compare signatures and qualifiers of two matched functions."""
     changes: list[Change] = []
-    changes.extend(_check_return_type_change(mangled, f_old, f_new))
-    changes.extend(_check_params_change(mangled, f_old, f_new, params_unconfirmed=params_unconfirmed))
+    changes.extend(_check_return_type_change(mangled, f_old, f_new, is_llp64=is_llp64))
+    changes.extend(_check_params_change(
+        mangled, f_old, f_new, params_unconfirmed=params_unconfirmed, is_llp64=is_llp64))
     changes.extend(_check_ref_qualifier_change(mangled, f_old, f_new))
     changes.extend(_check_linkage_change(mangled, f_old, f_new))
     changes.extend(_check_noexcept_change(mangled, f_old, f_new))
@@ -364,10 +447,13 @@ def _match_old_function(
     matched_by_name: set[str],
     elf_only_mode: bool,
     params_unconfirmed: bool = False,
+    is_llp64: bool = False,
 ) -> list[Change]:
     """Classify a single old function: matched by mangled, extern-C fallback, or removed."""
     if mangled in new_map:
-        return list(_check_function_signature(mangled, f_old, new_map[mangled], params_unconfirmed=params_unconfirmed))
+        return list(_check_function_signature(
+            mangled, f_old, new_map[mangled],
+            params_unconfirmed=params_unconfirmed, is_llp64=is_llp64))
 
     # Fallback by plain name when either side uses extern "C".
     # The name->Function mapping is a MULTIMAP: only fall back when there is
@@ -380,7 +466,9 @@ def _match_old_function(
         extern_c_candidates = candidates  # any single candidate is acceptable
     if len(extern_c_candidates) == 1:
         f_new = extern_c_candidates[0]
-        result = list(_check_function_signature(f_old.name, f_old, f_new, params_unconfirmed=params_unconfirmed))
+        result = list(_check_function_signature(
+            f_old.name, f_old, f_new,
+            params_unconfirmed=params_unconfirmed, is_llp64=is_llp64))
         matched_by_name.add(f_old.name)
         return result
 
@@ -430,6 +518,10 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # RD2-5: when one side is a stripped symbols-only stub, its parameter lists
     # are unknown (not "zero args"), so parameter diffs are unconfirmed.
     params_unconfirmed = _is_stripped_symbols_only(old) or _is_stripped_symbols_only(new)
+    # LLP64 (Windows/PE): ``long`` is 32-bit, so e.g. long<->long long is a real
+    # width change there; under LP64 (ELF/Mach-O) it is not. Resolves the
+    # data-model-dependent integer ABI-equivalence checks below.
+    is_llp64 = "pe" in (getattr(old, "platform", None), getattr(new, "platform", None))
     changes: list[Change] = []
     old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
     new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
@@ -450,7 +542,7 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         changes.extend(
             _match_old_function(
                 mangled, f_old, new_map, new_by_name, new_all, matched_by_name,
-                elf_only_mode, params_unconfirmed,
+                elf_only_mode, params_unconfirmed, is_llp64,
             )
         )
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1136,13 +1136,16 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     b = _unqualified_name(new_name)
     if a == b:
         return True
-    # Operator names all share the literal ``operator`` token, which would
-    # otherwise count as a similarity affix and pair distinct operators
-    # (``operator+`` vs ``operator-``). Require an exact spelling match for
-    # operators — handled by the ``a == b`` check above, so anything reaching
-    # here with an operator leaf is a genuinely different operator.
-    if a.startswith("operator") or b.startswith("operator"):
-        return False
+    # Operator leaves all share the literal ``operator`` token, and a
+    # destructor leaf (``~Widget``) shares the class name with that class's
+    # constructor leaf (``Widget``); in both cases an affix match would pair
+    # genuinely different ABI functions (operator+ vs operator-, ctor vs dtor).
+    # Require an exact spelling match for these — handled by the ``a == b``
+    # check above, so anything of this kind reaching here is a different
+    # operator/destructor and must be rejected.
+    for leaf in (a, b):
+        if leaf.startswith("operator") or leaf.startswith("~"):
+            return False
     return _shared_affix_len(a, b) >= _RENAME_MIN_SHARED_AFFIX
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1136,6 +1136,13 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     b = _unqualified_name(new_name)
     if a == b:
         return True
+    # Operator names all share the literal ``operator`` token, which would
+    # otherwise count as a similarity affix and pair distinct operators
+    # (``operator+`` vs ``operator-``). Require an exact spelling match for
+    # operators — handled by the ``a == b`` check above, so anything reaching
+    # here with an operator leaf is a genuinely different operator.
+    if a.startswith("operator") or b.startswith("operator"):
+        return False
     return _shared_affix_len(a, b) >= _RENAME_MIN_SHARED_AFFIX
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1464,13 +1464,16 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     if old_name == new_name:
         return True
     # Itanium ctor/dtor variants (C1/C2/C3, D0/D1/D2) demangle to the same leaf
-    # but are distinct exported symbols. A pair whose variant codes differ
-    # (e.g. complete-object C1 vs base-object C2) is never a rename, even if
-    # sizes collide; a genuine ctor/dtor relocation keeps the same variant.
-    # (Checked on the raw mangled name, so it catches the case the demangler
-    # would otherwise collapse to an identical leaf.)
+    # but are distinct exported symbols. A pair is a plausible ctor/dtor rename
+    # only when BOTH sides are the *same* variant (a genuine relocation keeps
+    # it). Any mismatch is rejected: differing variants (complete-object C1 vs
+    # base-object C2), and — crucially — a one-sided match where only one side
+    # is a ctor/dtor (e.g. removed ctor ``A::A()`` vs added ordinary method
+    # ``B::A()`` both reduce to leaf ``A()``), since a constructor ABI symbol
+    # cannot be satisfied by an ordinary member. (Checked on the raw mangled
+    # name, so it catches the case the demangler collapses to an identical leaf.)
     ov, nv = _ctor_dtor_variant(old_name), _ctor_dtor_variant(new_name)
-    if ov is not None and nv is not None and ov != nv:
+    if (ov is not None or nv is not None) and ov != nv:
         return False
     # Demangle each name exactly once and reuse the result for both the leaf and
     # the parameter signature (rather than relying on the demangle LRU cache,

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1183,11 +1183,12 @@ def _ctor_dtor_variant(symbol: str) -> str | None:
     balanced ``I…E`` ``<template-args>`` block that follows a templated class
     name), then checks whether the remainder *begins* with a ``<ctor-dtor-name>``
     code. This distinguishes a real constructor (``_ZN6WidgetC1Ev`` -> ``C1``,
-    ``_ZN3FooIiEC1Ev`` = ``Foo<int>::Foo()`` -> ``C1``) from an ordinary member
-    whose identifier merely contains the characters (``_ZN1A6fooC1EEv`` =
-    ``A::fooC1E()`` -> None). Encodings this simple parser does not model
-    (substitutions, exotic template arguments) yield None — safe, since the only
-    consequence is not suppressing a (rare) templated-ctor variant pair.
+    ``_ZN3FooIiEC1Ev`` = ``Foo<int>::Foo()`` -> ``C1``, ``_ZN3FooI3ErrEC1Ev`` =
+    ``Foo<Err>::Foo()`` -> ``C1``) from an ordinary member whose identifier
+    merely contains the characters (``_ZN1A6fooC1EEv`` = ``A::fooC1E()`` ->
+    None). Encodings this simple parser does not model (exotic template
+    arguments) yield None — safe, since the only consequence is not suppressing
+    a (rare) templated-ctor variant pair.
     """
     if not symbol.startswith("_ZN"):
         return None
@@ -1201,35 +1202,82 @@ def _ctor_dtor_variant(symbol: str) -> str | None:
     # class name (``_ZN3FooIiEC1Ev``) places the args before the ctor/dtor code.
     while i < len(symbol):
         if symbol[i].isdigit():
-            j = i
-            while j < len(symbol) and symbol[j].isdigit():
-                j += 1
-            length = int(symbol[i:j])
-            i = j + length
-            if i > len(symbol):
+            i = _skip_source_name(symbol, i)
+            if i < 0:
                 return None  # malformed length — bail out
         elif symbol[i] == "I":
-            # Skip a balanced <template-args> block. Productions that open with a
-            # trailing ``E`` — I template-args, N nested-name, F function-type,
-            # L expr-primary literal — count as openers; ``E`` closes one.
-            depth = 0
-            while i < len(symbol):
-                c = symbol[i]
-                if c in "INFL":
-                    depth += 1
-                elif c == "E":
-                    depth -= 1
-                    i += 1
-                    if depth == 0:
-                        break
-                    continue
-                i += 1
-            if depth != 0:
-                return None  # unbalanced — bail out
+            i = _skip_template_args(symbol, i)
+            if i < 0:
+                return None  # unbalanced / unmodeled — bail out
         else:
             break
     m = _CTOR_DTOR_CODE_RE.match(symbol[i:])
     return m.group(1) if m else None
+
+
+def _skip_source_name(symbol: str, i: int) -> int:
+    """Skip an Itanium ``<source-name>`` (``<decimal-length><identifier>``)
+    starting at ``symbol[i]``; return the index past it, or -1 if malformed."""
+    j = i
+    while j < len(symbol) and symbol[j].isdigit():
+        j += 1
+    end = j + int(symbol[i:j])
+    return end if end <= len(symbol) else -1
+
+
+def _skip_template_args(symbol: str, i: int) -> int:
+    """Skip a balanced Itanium ``<template-args>`` block (``I…E``) starting at
+    ``symbol[i]`` (an ``I``); return the index past the matching ``E``, or -1.
+
+    The block content must be parsed, not merely scanned for ``E``: a
+    length-prefixed ``<source-name>`` argument (``Foo<Err>`` = ``...I3ErrE...``)
+    contains an ``E`` *inside* its identifier that would otherwise close the
+    block early, and an expr-primary literal (``Foo<5>`` = ``...ILi5EE...``)
+    carries its own terminating ``E``. So source-names, substitutions, and
+    literals are consumed whole; only ``I``/``N``/``F`` openers and their ``E``
+    terminators move the nesting depth. Constructs this does not model yield -1.
+    """
+    n = len(symbol)
+    depth = 0
+    while i < n:
+        c = symbol[i]
+        if c.isdigit():
+            # <source-name>: consume the identifier whole so its characters
+            # (which may include E/I/N/F/L) are not read as structure.
+            i = _skip_source_name(symbol, i)
+            if i < 0:
+                return -1
+        elif c == "S":
+            # <substitution>: ``S_`` / ``S<seq-id>_`` (seq-id is base-36) or a
+            # special two-char form (``St``, ``Ss``, …). Consume so its digits
+            # are not mistaken for a source-name length.
+            i += 1
+            if i < n and (symbol[i].isdigit() or symbol[i].isupper()):
+                while i < n and symbol[i] != "_":
+                    i += 1
+                i += 1  # consume the closing '_'
+            else:
+                i += 1  # special two-char substitution
+        elif c == "L":
+            # <expr-primary> literal: ``L<type><value>E``. Scan to its own
+            # terminating ``E`` literally — its value digits are not lengths.
+            i += 1
+            while i < n and symbol[i] != "E":
+                i += 1
+            if i >= n:
+                return -1
+            i += 1  # consume the literal's 'E'
+        elif c in "INF":
+            depth += 1
+            i += 1
+        elif c == "E":
+            depth -= 1
+            i += 1
+            if depth == 0:
+                return i
+        else:
+            i += 1
+    return -1  # unbalanced
 
 
 def _unqualified_name(symbol: str) -> str:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from .binary_fingerprint import (
@@ -1027,6 +1028,12 @@ _FUNC_LIKE_TYPES = frozenset({SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTY
 # renames share 4-20, unrelated pairs 0-2).
 _RENAME_MIN_SHARED_AFFIX = 3
 
+# The C++ ``operator`` keyword as a whole token: not preceded or followed by an
+# identifier character, so substrings like ``cooperator`` or ``operator_v1``
+# (ordinary identifiers) and ``myoperator::foo`` (operator inside a qualifier)
+# are not mistaken for an operator function name.
+_OPERATOR_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])operator(?![A-Za-z0-9_])")
+
 
 def _unqualified_name(symbol: str) -> str:
     """Extract the unqualified (leaf) function name from a symbol, robustly.
@@ -1051,11 +1058,14 @@ def _unqualified_name(symbol: str) -> str:
 
     s = demangle(symbol) or symbol
     # An operator name encodes punctuation (``<<``, ``()``, ``[]``) that defeats
-    # bracket tracking, so handle it first: keep everything from ``operator`` to
-    # the end. It is stable and symmetric, which is all the matcher needs.
-    op = s.find("operator")
-    if op != -1:
-        return s[op:].strip()
+    # bracket tracking, so handle it first: keep everything from the ``operator``
+    # token to the end. It is stable and symmetric, which is all the matcher
+    # needs. Match ``operator`` only as a whole token so ordinary identifiers
+    # that merely contain the substring (``cooperator``, ``operator_v1``) are
+    # not misclassified.
+    op = _OPERATOR_TOKEN_RE.search(s)
+    if op is not None:
+        return s[op.start():].strip()
     # Truncate at the parameter-list '(' that sits at template depth 0.
     depth = 0
     for i, ch in enumerate(s):
@@ -1150,7 +1160,7 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     # check above, so anything of this kind reaching here is a different
     # operator/destructor and must be rejected.
     for leaf in (a, b):
-        if leaf.startswith("operator") or leaf.startswith("~"):
+        if _OPERATOR_TOKEN_RE.match(leaf) is not None or leaf.startswith("~"):
             return False
     base_a = _strip_template_args(a)
     base_b = _strip_template_args(b)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1012,42 +1012,88 @@ def _diff_var_access(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 _FUNC_LIKE_TYPES = frozenset({SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTYPE})
 
-# Minimum base-name similarity required to accept a *hash-less* (size-only /
-# fuzzy) rename match. When no code hash is available — the only mode the
+# Minimum unqualified-name similarity required to accept a *hash-less* (size-only
+# / fuzzy) rename match. When no code hash is available — the only mode the
 # snapshot/elf_only path can reach — a "rename" is inferred purely from a
 # coincidental symbol-size collision. On a large library that produces nonsense
 # pairings of completely unrelated functions that merely happen to share a byte
 # size (observed on real libLLVM release-to-release diffs: e.g. fixupIndexV4 ->
-# SmallVectorImpl<...>). A genuine rename or namespace relocation preserves most
-# of the qualified spelling (e.g. llvm::CompileUnit::markEverythingAsKept ->
-# llvm::dwarf_linker::classic::CompileUnit::markEverythingAsKept), so requiring
-# whole-name similarity discriminates real renames from coincidences. Measured
-# on real libLLVM 17->18 symbols: genuine namespace moves score ~0.75-1.0,
-# unrelated same-size pairs <=0.48.
-_RENAME_NAME_SIMILARITY_MIN = 0.5
+# SmallVectorImpl<...>). A genuine rename or namespace relocation preserves the
+# function's *unqualified* leaf name, so comparing leaf names (not whole
+# qualified spellings, whose shared namespace/class prefix would dominate the
+# score and let e.g. std::vector<int>::begin vs ::end pass) discriminates real
+# renames from coincidences. Measured on real libLLVM 17->18: genuine moves
+# score ~1.0, unrelated same-size pairs <=0.13. The 0.6 floor also rejects
+# distinct short leaves under a shared scope (e.g. begin/end at 0.5).
+_RENAME_NAME_SIMILARITY_MIN = 0.6
+
+
+def _unqualified_name(symbol: str) -> str:
+    """Extract the unqualified (leaf) function name from a symbol, robustly.
+
+    Matching-safe alternative to ``demangle.base_name`` (which is documented
+    display-only and mis-parses operators / templates). Demangles when a
+    demangler is available, then strips the parameter list and the
+    namespace/class qualifier using *bracket-depth tracking* so that ``::`` and
+    ``(`` inside template arguments are ignored, and keeps the whole
+    ``operator...`` token intact.
+    """
+    from .demangle import demangle
+
+    s = demangle(symbol) or symbol
+    # An operator name encodes punctuation (``<<``, ``()``, ``[]``) that defeats
+    # bracket tracking, so handle it first: keep everything from ``operator`` to
+    # the end. It is stable and symmetric, which is all the matcher needs.
+    op = s.find("operator")
+    if op != -1:
+        return s[op:].strip()
+    # Truncate at the parameter-list '(' that sits at template depth 0.
+    depth = 0
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == "(" and depth == 0:
+            s = s[:i]
+            break
+    # Take the segment after the last '::' that sits at template depth 0.
+    depth = 0
+    last = 0
+    i = 0
+    while i < len(s) - 1:
+        ch = s[i]
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == ":" and s[i + 1] == ":" and depth == 0:
+            last = i + 2
+            i += 2
+            continue
+        i += 1
+    return s[last:].strip()
 
 
 def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
-    Compares the *whole* names — demangled when a demangler is available,
-    otherwise the raw (mangled) spelling. Both are matching-safe representations:
-    unlike ``demangle.base_name`` (a display-only, best-effort unqualified-name
-    extractor that is explicitly unreliable for ``operator<<``, ``operator()``,
-    and templates containing ``::``), the full spelling has no parser to mislead
-    it. A namespace move keeps most of the string; an unrelated function that
-    merely shares a byte size does not. Used only to gate hash-less matches,
-    where size alone is not evidence of identity.
+    Compares the *unqualified* leaf names (see ``_unqualified_name``). A rename
+    or namespace relocation keeps the leaf name (identical leaf → score 1.0),
+    while unrelated functions that merely share a byte size — including
+    different methods under a common scope such as ``Class::get`` vs
+    ``Class::set`` — score low because the shared qualifier is discounted. Used
+    only to gate hash-less matches, where size alone is not evidence of identity.
     """
     if old_name == new_name:
         return True
 
     import difflib
 
-    from .demangle import demangle
-
-    a = demangle(old_name) or old_name
-    b = demangle(new_name) or new_name
+    a = _unqualified_name(old_name)
+    b = _unqualified_name(new_name)
+    if a == b:
+        return True
     return difflib.SequenceMatcher(None, a, b).ratio() >= _RENAME_NAME_SIMILARITY_MIN
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1339,10 +1339,57 @@ def _unqualified_name(symbol: str) -> str:
     return _unqualified_name_of(demangle(symbol) or symbol)
 
 
+def _unwrap_funcptr_declarator(s: str) -> str:
+    """Unwrap a function-pointer/-reference *return* declarator so the real
+    function name is visible.
+
+    A C++ function that returns a function pointer demangles to declarator
+    syntax — ``RET (*name(args))(fnptr-args)``, e.g. ``int (*foo<int>())()`` —
+    where the first top-level ``(`` opens the declarator group, *not* the
+    parameter list. Left as-is, leaf extraction would stop at that ``(`` and
+    collapse the name to the return type. When ``s`` has this shape (the first
+    top-level ``(`` is immediately followed by ``*``/``&``), return the inner
+    ``name(args)`` so the normal leaf/parameter logic sees the real name;
+    otherwise return ``s`` unchanged. Ordinary parameter lists (whose first char
+    is a type or ``)``, never ``*``/``&`` at the very front) are left intact, as
+    are functions that merely *take* a function-pointer parameter.
+    """
+    depth = 0  # <> template depth — ignore '(' inside template arguments
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == "(" and depth == 0:
+            j = i + 1
+            while j < len(s) and s[j] == " ":
+                j += 1
+            if j >= len(s) or s[j] not in "*&":
+                return s  # ordinary parameter list, not a pointer declarator
+            # Find the ')' matching this declarator-group '(' (bracket-aware).
+            pdepth = 0
+            tdepth = 0
+            for k in range(i, len(s)):
+                c = s[k]
+                if c == "<":
+                    tdepth += 1
+                elif c == ">":
+                    tdepth = max(0, tdepth - 1)
+                elif c == "(" and tdepth == 0:
+                    pdepth += 1
+                elif c == ")" and tdepth == 0:
+                    pdepth -= 1
+                    if pdepth == 0:
+                        return s[i + 1:k].lstrip("*& ")
+            return s  # unbalanced — leave alone
+    return s
+
+
 def _unqualified_name_of(s: str) -> str:
     """Leaf-name core of ``_unqualified_name`` operating on an already-demangled
     (or raw, when no demangler is available) string. Split out so callers that
     need both the leaf and the parameter signature can demangle once."""
+    s = _unwrap_funcptr_declarator(s)
     # An operator name encodes punctuation (``<<``, ``()``, ``[]``) that defeats
     # bracket tracking, so handle it first: keep everything from the ``operator``
     # token to the end. It is stable and symmetric, which is all the matcher
@@ -1436,6 +1483,7 @@ def _param_signature(symbol: str) -> str:
 def _param_signature_of(s: str) -> str:
     """Parameter-signature core of ``_param_signature`` operating on an
     already-demangled (or raw) string."""
+    s = _unwrap_funcptr_declarator(s)
     depth = 0
     for i, ch in enumerate(s):
         if ch == "<":

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1041,9 +1041,11 @@ def _unqualified_name(symbol: str) -> str:
     * drops the namespace/class qualifier (segment after the last top-level
       ``::``);
     * drops a leading return type (global function templates demangle as
-      ``ret name<args>(...)``);
-    * drops trailing template arguments, so instantiations of one template
-      (``get<int>`` / ``get<long>``) share a leaf.
+      ``ret name<args>(...)``).
+
+    Trailing template arguments are *kept*: a specialization like ``foo<int>``
+    is a distinct ABI symbol from ``foo<long>``, so they must not collapse to a
+    shared leaf (that would mis-report a specialization swap as a rename).
     """
     from .demangle import demangle
 
@@ -1093,18 +1095,21 @@ def _unqualified_name(symbol: str) -> str:
             sp = i
     if sp != -1:
         s = s[sp + 1:]
-    # Drop trailing template arguments (``get<int>`` -> ``get``).
-    if s.endswith(">"):
+    return s.strip()
+
+
+def _strip_template_args(leaf: str) -> str:
+    """Drop trailing template arguments from a leaf (``get<int>`` -> ``get``)."""
+    if leaf.endswith(">"):
         depth = 0
-        for i in range(len(s) - 1, -1, -1):
-            if s[i] == ">":
+        for i in range(len(leaf) - 1, -1, -1):
+            if leaf[i] == ">":
                 depth += 1
-            elif s[i] == "<":
+            elif leaf[i] == "<":
                 depth -= 1
                 if depth == 0:
-                    s = s[:i]
-                    break
-    return s.strip()
+                    return leaf[:i]
+    return leaf
 
 
 def _shared_affix_len(a: str, b: str) -> int:
@@ -1123,12 +1128,13 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
     Compares the *unqualified* leaf names (see ``_unqualified_name``). A rename
-    or namespace relocation keeps the leaf name (identical leaf) or a
-    substantial common prefix/suffix token; unrelated functions that merely
-    share a byte size — including different methods under a common scope such as
-    ``Class::get`` vs ``Class::set`` — share at most a character or two because
-    the qualifier and any return type / template arguments are stripped. Used
-    only to gate hash-less matches, where size alone is not evidence of identity.
+    or namespace relocation keeps the leaf name (identical leaf, template
+    arguments included) or a substantial common prefix/suffix token; unrelated
+    functions that merely share a byte size — including different methods under
+    a common scope (``Class::get`` vs ``Class::set``) and different template
+    specializations of one name (``foo<int>`` vs ``foo<long>``) — are rejected.
+    Used only to gate hash-less matches, where size alone is not evidence of
+    identity.
     """
     if old_name == new_name:
         return True
@@ -1146,7 +1152,14 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     for leaf in (a, b):
         if leaf.startswith("operator") or leaf.startswith("~"):
             return False
-    return _shared_affix_len(a, b) >= _RENAME_MIN_SHARED_AFFIX
+    base_a = _strip_template_args(a)
+    base_b = _strip_template_args(b)
+    # Same base name but different (non-equal) leaves means the template
+    # arguments differ: distinct specializations are distinct ABI symbols, not a
+    # rename — a consumer of foo<int> still fails to link against foo<long>.
+    if base_a == base_b:
+        return False
+    return _shared_affix_len(base_a, base_b) >= _RENAME_MIN_SHARED_AFFIX
 
 
 def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1152,6 +1152,19 @@ _RENAME_MIN_SHARED_AFFIX = 3
 # are not mistaken for an operator function name.
 _OPERATOR_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])operator(?![A-Za-z0-9_])")
 
+# Itanium constructor/destructor variant codes: ``C1``/``C2``/``C3`` (complete /
+# base / allocating constructor) and ``D0``/``D1``/``D2`` (deleting / complete /
+# base destructor), each terminating a nested-name (``...C1E...``). These
+# variants demangle to the *same* leaf yet are distinct exported symbols.
+_CTOR_DTOR_VARIANT_RE = re.compile(r"(C[123]|D[012])E")
+
+
+def _ctor_dtor_variant(symbol: str) -> str | None:
+    """Return the Itanium ctor/dtor variant code (e.g. ``C1``) in a mangled
+    name, or None when the symbol is not a constructor/destructor."""
+    m = _CTOR_DTOR_VARIANT_RE.search(symbol)
+    return m.group(1) if m else None
+
 
 def _unqualified_name(symbol: str) -> str:
     """Extract the unqualified (leaf) function name from a symbol, robustly.
@@ -1290,6 +1303,15 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     """
     if old_name == new_name:
         return True
+    # Itanium ctor/dtor variants (C1/C2/C3, D0/D1/D2) demangle to the same leaf
+    # but are distinct exported symbols. A pair whose variant codes differ
+    # (e.g. complete-object C1 vs base-object C2) is never a rename, even if
+    # sizes collide; a genuine ctor/dtor relocation keeps the same variant.
+    # (Checked on the raw mangled name, so it catches the case the demangler
+    # would otherwise collapse to an identical leaf.)
+    ov, nv = _ctor_dtor_variant(old_name), _ctor_dtor_variant(new_name)
+    if ov is not None and nv is not None and ov != nv:
+        return False
     a = _unqualified_name(old_name)
     b = _unqualified_name(new_name)
     # Undemangleable mangled names: when no demangler is available the leaf is

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -201,13 +201,25 @@ _PTR_UNSIGNED_SPELLINGS = frozenset({"size_t", "uintptr_t"})
 def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[object, bool] | None:
     """Map a *bare* integer spelling to (width, is_signed), or None.
 
-    Width is an ``int`` (fixed bit count) or the sentinel ``"long"`` for the
-    data-model-dependent ``long`` family (and, on non-LLP64, the pointer-width
-    typedefs that co-vary with it). The sentinel is never equal to any fixed
-    width, so a distinct built-in change such as ``int`` vs ``long`` is reported
-    even where the widths coincide. Returns None for anything that is not a
-    plain integer scalar (pointers, references, templates, cv-qualified or
-    unknown spellings).
+    Width is an ``int`` (fixed bit count) or one of two abstract sentinels for
+    data-model-dependent spellings whose absolute width the snapshot does not
+    record:
+
+    * ``"ptr"`` — pointer-width types (``size_t``, ``ptrdiff_t``, …). Their
+      absolute width is unknown (64-bit on LP64/LLP64, 32-bit on ILP32 and
+      32-bit Windows), so they must never be equated with a *fixed* width such
+      as ``uint64_t``. Used on every platform.
+    * ``"long"`` — the ``long`` family on LLP64 only, where ``long`` is 32-bit
+      and thus a distinct representation from the 64-bit pointer-width types.
+
+    On non-LLP64 the ``long`` family co-varies with the pointer-width types
+    (``size_t`` *is* ``unsigned long`` there), so it shares the ``"ptr"``
+    sentinel — making ``size_t`` ↔ ``unsigned long`` a non-break while keeping
+    ``long`` ↔ ``long long`` (sentinel vs fixed 64) reportable. Neither
+    sentinel ever equals a fixed width, so a distinct built-in change such as
+    ``int`` vs ``long`` is reported even where the widths coincide. Returns
+    None for anything that is not a plain integer scalar (pointers, references,
+    templates, cv-qualified or unknown spellings).
     """
     t = " ".join(type_name.split())
     if not t or any(c in t for c in "*&<>([,") or "const" in t or "volatile" in t:
@@ -215,22 +227,22 @@ def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[object, bool] | None:
     fixed = _FIXED_SCALAR_REPR.get(t)
     if fixed is not None:
         return fixed
-    # The ``long`` family is its own distinct built-in: it must never be equated
-    # with a fixed-width spelling, even where the widths happen to coincide
-    # (e.g. ``int`` vs ``long`` are both 32-bit on LLP64 but are different
-    # types, and changing one to the other is a real signature change). Map it
-    # to a dedicated, platform-independent sentinel.
+    # The ``long`` family is its own distinct built-in. On LLP64 it is 32-bit
+    # and must stay distinct from both fixed widths and the 64-bit pointer-width
+    # types, so it gets its own ``"long"`` sentinel. Elsewhere it co-varies with
+    # the pointer-width types and shares the ``"ptr"`` sentinel.
     if t in _LONG_SIGNED_SPELLINGS:
-        return ("long", True)
+        return ("long", True) if is_llp64 else ("ptr", True)
     if t in _LONG_UNSIGNED_SPELLINGS:
-        return ("long", False)
-    # Pointer-width typedefs co-vary with the ``long`` family on non-LLP64
-    # (``size_t`` *is* ``unsigned long`` there), but are a fixed 64-bit under
-    # LLP64 (where ``long`` is 32-bit and thus a different representation).
+        return ("long", False) if is_llp64 else ("ptr", False)
+    # Pointer-width typedefs have an unknown absolute width on every platform
+    # (64-bit on LP64/LLP64, 32-bit on ILP32 and 32-bit Windows), so they map to
+    # the ``"ptr"`` sentinel and are never equated with a fixed width such as
+    # ``uint64_t``.
     if t in _PTR_SIGNED_SPELLINGS:
-        return (64, True) if is_llp64 else ("long", True)
+        return ("ptr", True)
     if t in _PTR_UNSIGNED_SPELLINGS:
-        return (64, False) if is_llp64 else ("long", False)
+        return ("ptr", False)
     return None
 
 
@@ -1167,12 +1179,14 @@ def _ctor_dtor_variant(symbol: str) -> str | None:
     name, or None when the symbol is not a constructor/destructor.
 
     Parses the ``_ZN`` nested-name: skips implicit-object cv/ref qualifiers,
-    consumes the ``<len><identifier>`` ``<source-name>`` components, then checks
-    whether the remainder *begins* with a ``<ctor-dtor-name>`` code. This
-    distinguishes a real constructor (``_ZN6WidgetC1Ev`` -> ``C1``) from an
-    ordinary member whose identifier merely contains the characters
-    (``_ZN1A6fooC1EEv`` = ``A::fooC1E()`` -> None). Encodings this simple parser
-    does not model (templates, substitutions) yield None — safe, since the only
+    consumes the ``<len><identifier>`` ``<source-name>`` components (skipping any
+    balanced ``I…E`` ``<template-args>`` block that follows a templated class
+    name), then checks whether the remainder *begins* with a ``<ctor-dtor-name>``
+    code. This distinguishes a real constructor (``_ZN6WidgetC1Ev`` -> ``C1``,
+    ``_ZN3FooIiEC1Ev`` = ``Foo<int>::Foo()`` -> ``C1``) from an ordinary member
+    whose identifier merely contains the characters (``_ZN1A6fooC1EEv`` =
+    ``A::fooC1E()`` -> None). Encodings this simple parser does not model
+    (substitutions, exotic template arguments) yield None — safe, since the only
     consequence is not suppressing a (rare) templated-ctor variant pair.
     """
     if not symbol.startswith("_ZN"):
@@ -1182,15 +1196,38 @@ def _ctor_dtor_variant(symbol: str) -> str | None:
     # R lvalue-ref, O rvalue-ref).
     while i < len(symbol) and symbol[i] in "KVrRO":
         i += 1
-    # Consume <source-name> components: <decimal-length><identifier>.
-    while i < len(symbol) and symbol[i].isdigit():
-        j = i
-        while j < len(symbol) and symbol[j].isdigit():
-            j += 1
-        length = int(symbol[i:j])
-        i = j + length
-        if i > len(symbol):
-            return None  # malformed length — bail out
+    # Consume <prefix> components: <source-name> (<decimal-length><identifier>),
+    # each optionally followed by a <template-args> block ``I…E``. A templated
+    # class name (``_ZN3FooIiEC1Ev``) places the args before the ctor/dtor code.
+    while i < len(symbol):
+        if symbol[i].isdigit():
+            j = i
+            while j < len(symbol) and symbol[j].isdigit():
+                j += 1
+            length = int(symbol[i:j])
+            i = j + length
+            if i > len(symbol):
+                return None  # malformed length — bail out
+        elif symbol[i] == "I":
+            # Skip a balanced <template-args> block. Productions that open with a
+            # trailing ``E`` — I template-args, N nested-name, F function-type,
+            # L expr-primary literal — count as openers; ``E`` closes one.
+            depth = 0
+            while i < len(symbol):
+                c = symbol[i]
+                if c in "INFL":
+                    depth += 1
+                elif c == "E":
+                    depth -= 1
+                    i += 1
+                    if depth == 0:
+                        break
+                    continue
+                i += 1
+            if depth != 0:
+                return None  # unbalanced — bail out
+        else:
+            break
     m = _CTOR_DTOR_CODE_RE.match(symbol[i:])
     return m.group(1) if m else None
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1161,9 +1161,19 @@ _CTOR_DTOR_VARIANT_RE = re.compile(r"(C[123]|D[012])E")
 
 def _ctor_dtor_variant(symbol: str) -> str | None:
     """Return the Itanium ctor/dtor variant code (e.g. ``C1``) in a mangled
-    name, or None when the symbol is not a constructor/destructor."""
-    m = _CTOR_DTOR_VARIANT_RE.search(symbol)
-    return m.group(1) if m else None
+    name, or None when the symbol is not a constructor/destructor.
+
+    Ctor/dtor variant codes only occur inside a *nested-name* encoding
+    (``_ZN...C1E...``), so the check is anchored to ``_ZN`` — otherwise an
+    ordinary function whose identifier merely contains ``C1E``/``D1E`` (e.g.
+    the free function ``_Z6fooC1Ev`` = ``fooC1E()``) would be misread as a
+    constructor. The variant is the *last* such code in the nested name (the
+    ctor/dtor follows the class-name prefix).
+    """
+    if not symbol.startswith("_ZN"):
+        return None
+    matches = _CTOR_DTOR_VARIANT_RE.findall(symbol)
+    return matches[-1] if matches else None
 
 
 def _unqualified_name(symbol: str) -> str:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -197,6 +197,38 @@ _LONG_UNSIGNED_SPELLINGS = frozenset({"unsigned long", "long unsigned int"})
 _PTR_SIGNED_SPELLINGS = frozenset({"ssize_t", "ptrdiff_t", "intptr_t"})
 _PTR_UNSIGNED_SPELLINGS = frozenset({"size_t", "uintptr_t"})
 
+# The words that make up a C integer built-in's declaration specifiers. A
+# spelling composed *only* of these can be reordered freely by the language
+# (``unsigned long int`` ≡ ``long unsigned int`` ≡ ``unsigned long``), and
+# different toolchains/headers emit different orderings, so they are normalized
+# to one canonical form before lookup. Typedefs (``size_t``) and fixed-width
+# names (``uint32_t``) contain other words and pass through unchanged.
+_INT_SPECIFIER_WORDS = frozenset({"signed", "unsigned", "short", "long", "int", "char"})
+
+
+def _canonical_int_spelling(t: str) -> str:
+    """Canonicalize a bare integer built-in spelling (specifier order and the
+    redundant trailing ``int`` are not significant), or return ``t`` unchanged
+    when it is not a pure specifier spelling (typedef, fixed-width, …)."""
+    words = t.split()
+    if not words or any(w not in _INT_SPECIFIER_WORDS for w in words):
+        return t
+    unsigned = "unsigned" in words
+    if "char" in words:
+        if unsigned:
+            return "unsigned char"
+        if "signed" in words:
+            return "signed char"
+        return t  # bare ``char`` — sign is implementation-defined, leave as-is
+    if "short" in words:
+        return "unsigned short" if unsigned else "short"
+    longs = words.count("long")
+    if longs >= 2:
+        return "unsigned long long" if unsigned else "long long"
+    if longs == 1:
+        return "unsigned long" if unsigned else "long"
+    return "unsigned int" if unsigned else "int"
+
 
 def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[object, bool] | None:
     """Map a *bare* integer spelling to (width, is_signed), or None.
@@ -224,6 +256,9 @@ def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[object, bool] | None:
     t = " ".join(type_name.split())
     if not t or any(c in t for c in "*&<>([,") or "const" in t or "volatile" in t:
         return None
+    # Fold legal specifier-order variants (``unsigned long int`` -> ``unsigned
+    # long``) so a toolchain's spelling choice is not mistaken for an ABI change.
+    t = _canonical_int_spelling(t)
     fixed = _FIXED_SCALAR_REPR.get(t)
     if fixed is not None:
         return fixed

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1134,15 +1134,39 @@ def _shared_affix_len(a: str, b: str) -> int:
     return max(common_prefix(a, b), common_prefix(a[::-1], b[::-1]))
 
 
+def _param_signature(symbol: str) -> str:
+    """The parameter-list portion of a symbol (``foo(int)`` -> ``(int)``).
+
+    Empty when there is no parameter list — a plain C symbol, a variable, or a
+    mangled C++ symbol with no demangler available. A genuine rename or
+    namespace relocation keeps the parameters; a parameter change is a distinct
+    ABI symbol, so comparing this lets the gate reject ``foo(int)`` -> ``foo(long)``.
+    """
+    from .demangle import demangle
+
+    s = demangle(symbol) or symbol
+    depth = 0
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == "(" and depth == 0:
+            return s[i:]
+    return ""
+
+
 def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
     Compares the *unqualified* leaf names (see ``_unqualified_name``). A rename
     or namespace relocation keeps the leaf name (identical leaf, template
-    arguments included) or a substantial common prefix/suffix token; unrelated
-    functions that merely share a byte size — including different methods under
-    a common scope (``Class::get`` vs ``Class::set``) and different template
-    specializations of one name (``foo<int>`` vs ``foo<long>``) — are rejected.
+    arguments included) or a substantial common prefix/suffix token **and** the
+    same parameter list; unrelated functions that merely share a byte size are
+    rejected. Rejected cases include different methods under a common scope
+    (``Class::get`` vs ``Class::set``), different template specializations of
+    one name (``foo<int>`` vs ``foo<long>``), and same-name parameter changes
+    (``foo(int)`` vs ``foo(long)``) — all of which are distinct ABI symbols.
     Used only to gate hash-less matches, where size alone is not evidence of
     identity.
     """
@@ -1150,26 +1174,29 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
         return True
     a = _unqualified_name(old_name)
     b = _unqualified_name(new_name)
-    if a == b:
-        return True
-    # Operator leaves all share the literal ``operator`` token, and a
-    # destructor leaf (``~Widget``) shares the class name with that class's
-    # constructor leaf (``Widget``); in both cases an affix match would pair
-    # genuinely different ABI functions (operator+ vs operator-, ctor vs dtor).
-    # Require an exact spelling match for these — handled by the ``a == b``
-    # check above, so anything of this kind reaching here is a different
-    # operator/destructor and must be rejected.
+    # Operator leaves include their parameters and share the literal
+    # ``operator`` token; a destructor leaf (``~Widget``) shares the class name
+    # with that class's constructor leaf (``Widget``). For both, an affix match
+    # would pair genuinely different ABI functions (operator+ vs operator-, ctor
+    # vs dtor), so accept only an exact leaf match.
     for leaf in (a, b):
         if _OPERATOR_TOKEN_RE.match(leaf) is not None or leaf.startswith("~"):
-            return False
+            return a == b
+    # A rename/relocation preserves the parameter list; a parameter change is a
+    # different ABI symbol (foo(int) -> foo(long)), not a rename.
+    params_match = _param_signature(old_name) == _param_signature(new_name)
+    if a == b:
+        # Same unqualified name + template args: a rename only if the parameters
+        # also match (else it is a signature change).
+        return params_match
     base_a = _strip_template_args(a)
     base_b = _strip_template_args(b)
-    # Same base name but different (non-equal) leaves means the template
-    # arguments differ: distinct specializations are distinct ABI symbols, not a
-    # rename — a consumer of foo<int> still fails to link against foo<long>.
+    # Same base name but different leaves means the template arguments differ:
+    # distinct specializations are distinct ABI symbols, not a rename — a
+    # consumer of foo<int> still fails to link against foo<long>.
     if base_a == base_b:
         return False
-    return _shared_affix_len(base_a, base_b) >= _RENAME_MIN_SHARED_AFFIX
+    return params_match and _shared_affix_len(base_a, base_b) >= _RENAME_MIN_SHARED_AFFIX
 
 
 def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1253,7 +1253,13 @@ def _unqualified_name(symbol: str) -> str:
     """
     from .demangle import demangle
 
-    s = demangle(symbol) or symbol
+    return _unqualified_name_of(demangle(symbol) or symbol)
+
+
+def _unqualified_name_of(s: str) -> str:
+    """Leaf-name core of ``_unqualified_name`` operating on an already-demangled
+    (or raw, when no demangler is available) string. Split out so callers that
+    need both the leaf and the parameter signature can demangle once."""
     # An operator name encodes punctuation (``<<``, ``()``, ``[]``) that defeats
     # bracket tracking, so handle it first: keep everything from the ``operator``
     # token to the end. It is stable and symmetric, which is all the matcher
@@ -1341,7 +1347,12 @@ def _param_signature(symbol: str) -> str:
     """
     from .demangle import demangle
 
-    s = demangle(symbol) or symbol
+    return _param_signature_of(demangle(symbol) or symbol)
+
+
+def _param_signature_of(s: str) -> str:
+    """Parameter-signature core of ``_param_signature`` operating on an
+    already-demangled (or raw) string."""
     depth = 0
     for i, ch in enumerate(s):
         if ch == "<":
@@ -1378,8 +1389,15 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     ov, nv = _ctor_dtor_variant(old_name), _ctor_dtor_variant(new_name)
     if ov is not None and nv is not None and ov != nv:
         return False
-    a = _unqualified_name(old_name)
-    b = _unqualified_name(new_name)
+    # Demangle each name exactly once and reuse the result for both the leaf and
+    # the parameter signature (rather than relying on the demangle LRU cache,
+    # which can thrash on libraries with > 16k symbols).
+    from .demangle import demangle
+
+    da = demangle(old_name) or old_name
+    db = demangle(new_name) or new_name
+    a = _unqualified_name_of(da)
+    b = _unqualified_name_of(db)
     # Undemangleable mangled names: when no demangler is available the leaf is
     # the raw Itanium spelling, whose shared boilerplate (``_ZN``, type codes,
     # …) would inflate the affix score and pair unrelated symbols. Demangling is
@@ -1397,7 +1415,7 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
             return a == b
     # A rename/relocation preserves the parameter list; a parameter change is a
     # different ABI symbol (foo(int) -> foo(long)), not a rename.
-    params_match = _param_signature(old_name) == _param_signature(new_name)
+    params_match = _param_signature_of(da) == _param_signature_of(db)
     if a == b:
         # Same unqualified name + template args: a rename only if the parameters
         # also match (else it is a signature change).

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1174,6 +1175,13 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
         return True
     a = _unqualified_name(old_name)
     b = _unqualified_name(new_name)
+    # Undemangleable mangled names: when no demangler is available the leaf is
+    # the raw Itanium spelling, whose shared boilerplate (``_ZN``, type codes,
+    # …) would inflate the affix score and pair unrelated symbols. Demangling is
+    # optional for this package, so treat such names conservatively — accept
+    # only an exact match (rejected here, since removed/added names differ).
+    if a.startswith("_Z") or b.startswith("_Z"):
+        return a == b
     # Operator leaves include their parameters and share the literal
     # ``operator`` token; a destructor leaf (``~Widget``) shares the class name
     # with that class's constructor leaf (``Widget``). For both, an affix match

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1018,28 +1018,36 @@ _FUNC_LIKE_TYPES = frozenset({SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTY
 # coincidental symbol-size collision. On a large library that produces nonsense
 # pairings of completely unrelated functions that merely happen to share a byte
 # size (observed on real libLLVM release-to-release diffs: e.g. fixupIndexV4 ->
-# SmallVectorImpl<...>). A genuine rename or namespace relocation keeps the
-# function's unqualified base name (e.g. CompileUnit::dump ->
-# dwarf_linker::classic::CompileUnit::dump), so requiring base-name similarity
-# discriminates real renames (ratio ~1.0) from coincidences (ratio < 0.3).
+# SmallVectorImpl<...>). A genuine rename or namespace relocation preserves most
+# of the qualified spelling (e.g. llvm::CompileUnit::markEverythingAsKept ->
+# llvm::dwarf_linker::classic::CompileUnit::markEverythingAsKept), so requiring
+# whole-name similarity discriminates real renames from coincidences. Measured
+# on real libLLVM 17->18 symbols: genuine namespace moves score ~0.75-1.0,
+# unrelated same-size pairs <=0.48.
 _RENAME_NAME_SIMILARITY_MIN = 0.5
 
 
 def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
-    Compares the *unqualified* base names (demangled when possible) so a
-    namespace move scores ~1.0 while unrelated functions score low. Used only
-    to gate hash-less matches, where size alone is not evidence of identity.
+    Compares the *whole* names — demangled when a demangler is available,
+    otherwise the raw (mangled) spelling. Both are matching-safe representations:
+    unlike ``demangle.base_name`` (a display-only, best-effort unqualified-name
+    extractor that is explicitly unreliable for ``operator<<``, ``operator()``,
+    and templates containing ``::``), the full spelling has no parser to mislead
+    it. A namespace move keeps most of the string; an unrelated function that
+    merely shares a byte size does not. Used only to gate hash-less matches,
+    where size alone is not evidence of identity.
     """
+    if old_name == new_name:
+        return True
+
     import difflib
 
-    from .demangle import base_name
+    from .demangle import demangle
 
-    a = base_name(old_name)
-    b = base_name(new_name)
-    if a == b:
-        return True
+    a = demangle(old_name) or old_name
+    b = demangle(new_name) or new_name
     return difflib.SequenceMatcher(None, a, b).ratio() >= _RENAME_NAME_SIMILARITY_MIN
 
 
@@ -1095,15 +1103,13 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
     if not old_fps or not new_fps:
         return changes
 
-    candidates = match_renamed_functions(old_fps, new_fps)
+    # Matches in this path are hash-less (size-only), inferred from symbol size
+    # alone since _fingerprints_from_elf has no code bytes. Pass the name-
+    # similarity predicate into the matcher so it participates in candidate
+    # *selection*: a coincidental same-size symbol can neither be reported as a
+    # rename nor greedily consume a partner that a plausible rename should claim.
+    candidates = match_renamed_functions(old_fps, new_fps, name_filter=_plausible_rename)
     for c in candidates:
-        # Hash-less matches (the only kind this path can produce, since
-        # _fingerprints_from_elf has no code bytes) are inferred from symbol
-        # size alone. Require name similarity so coincidental size collisions
-        # between unrelated functions are not reported as renames.
-        if not c.old_fingerprint.code_hash and not c.new_fingerprint.code_hash:
-            if not _plausible_rename(c.old_name, c.new_name):
-                continue
         conf_pct = int(c.confidence * 100)
         changes.append(Change(
             kind=ChangeKind.FUNC_LIKELY_RENAMED,

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1244,6 +1244,11 @@ def _ctor_dtor_variant(symbol: str) -> str | None:
             i = _skip_template_args(symbol, i)
             if i < 0:
                 return None  # unbalanced / unmodeled — bail out
+        elif symbol[i] == "S":
+            # A standard/standard-library substitution can open the prefix, e.g.
+            # ``_ZNSt6vectorIiEC1Ev`` (St = std::) — consume it before the
+            # source-name components so the ctor/dtor code is still found.
+            i = _skip_substitution(symbol, i)
         else:
             break
     m = _CTOR_DTOR_CODE_RE.match(symbol[i:])
@@ -1258,6 +1263,24 @@ def _skip_source_name(symbol: str, i: int) -> int:
         j += 1
     end = j + int(symbol[i:j])
     return end if end <= len(symbol) else -1
+
+
+def _skip_substitution(symbol: str, i: int) -> int:
+    """Skip an Itanium ``<substitution>`` starting at ``symbol[i]`` (an ``S``);
+    return the index past it.
+
+    Handles ``S_``, ``S<seq-id>_`` (seq-id is base-36 ``[0-9A-Z]``), and the
+    special two-character abbreviations (``St`` std, ``Ss`` std::string, ``Sa``,
+    ``Sb``, ``Si``, ``So``, ``Sd``). Consuming it whole keeps any digits in a
+    seq-id from being misread as a ``<source-name>`` length.
+    """
+    n = len(symbol)
+    i += 1  # consume 'S'
+    if i < n and (symbol[i].isdigit() or symbol[i].isupper()):
+        while i < n and symbol[i] != "_":
+            i += 1
+        return i + 1  # consume the closing '_'
+    return i + 1  # special two-char abbreviation (St, Ss, …) or bare 'S_'
 
 
 def _skip_template_args(symbol: str, i: int) -> int:
@@ -1283,16 +1306,9 @@ def _skip_template_args(symbol: str, i: int) -> int:
             if i < 0:
                 return -1
         elif c == "S":
-            # <substitution>: ``S_`` / ``S<seq-id>_`` (seq-id is base-36) or a
-            # special two-char form (``St``, ``Ss``, …). Consume so its digits
-            # are not mistaken for a source-name length.
-            i += 1
-            if i < n and (symbol[i].isdigit() or symbol[i].isupper()):
-                while i < n and symbol[i] != "_":
-                    i += 1
-                i += 1  # consume the closing '_'
-            else:
-                i += 1  # special two-char substitution
+            # <substitution>: consume whole so its digits are not mistaken for a
+            # source-name length.
+            i = _skip_substitution(symbol, i)
         elif c == "L":
             # <expr-primary> literal: ``L<type><value>E``. Scan to its own
             # terminating ``E`` literally — its value digits are not lengths.

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1154,26 +1154,45 @@ _OPERATOR_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])operator(?![A-Za-z0-9_])")
 
 # Itanium constructor/destructor variant codes: ``C1``/``C2``/``C3`` (complete /
 # base / allocating constructor) and ``D0``/``D1``/``D2`` (deleting / complete /
-# base destructor), each terminating a nested-name (``...C1E...``). These
-# variants demangle to the *same* leaf yet are distinct exported symbols.
-_CTOR_DTOR_VARIANT_RE = re.compile(r"(C[123]|D[012])E")
+# base destructor). These variants demangle to the *same* leaf yet are distinct
+# exported symbols. A ``<ctor-dtor-name>`` is a real grammar production — it is
+# NOT a length-prefixed ``<source-name>`` — so it must be located by parsing the
+# nested-name's length-prefixed components, not by substring search (an ordinary
+# identifier such as ``fooC1E`` would otherwise match).
+_CTOR_DTOR_CODE_RE = re.compile(r"^(C[123]|D[012])E")
 
 
 def _ctor_dtor_variant(symbol: str) -> str | None:
-    """Return the Itanium ctor/dtor variant code (e.g. ``C1``) in a mangled
+    """Return the Itanium ctor/dtor variant code (e.g. ``C1``) for a mangled
     name, or None when the symbol is not a constructor/destructor.
 
-    Ctor/dtor variant codes only occur inside a *nested-name* encoding
-    (``_ZN...C1E...``), so the check is anchored to ``_ZN`` — otherwise an
-    ordinary function whose identifier merely contains ``C1E``/``D1E`` (e.g.
-    the free function ``_Z6fooC1Ev`` = ``fooC1E()``) would be misread as a
-    constructor. The variant is the *last* such code in the nested name (the
-    ctor/dtor follows the class-name prefix).
+    Parses the ``_ZN`` nested-name: skips implicit-object cv/ref qualifiers,
+    consumes the ``<len><identifier>`` ``<source-name>`` components, then checks
+    whether the remainder *begins* with a ``<ctor-dtor-name>`` code. This
+    distinguishes a real constructor (``_ZN6WidgetC1Ev`` -> ``C1``) from an
+    ordinary member whose identifier merely contains the characters
+    (``_ZN1A6fooC1EEv`` = ``A::fooC1E()`` -> None). Encodings this simple parser
+    does not model (templates, substitutions) yield None — safe, since the only
+    consequence is not suppressing a (rare) templated-ctor variant pair.
     """
     if not symbol.startswith("_ZN"):
         return None
-    matches = _CTOR_DTOR_VARIANT_RE.findall(symbol)
-    return matches[-1] if matches else None
+    i = 3
+    # Skip implicit-object cv-/ref-qualifiers (K const, V volatile, r restrict,
+    # R lvalue-ref, O rvalue-ref).
+    while i < len(symbol) and symbol[i] in "KVrRO":
+        i += 1
+    # Consume <source-name> components: <decimal-length><identifier>.
+    while i < len(symbol) and symbol[i].isdigit():
+        j = i
+        while j < len(symbol) and symbol[j].isdigit():
+            j += 1
+        length = int(symbol[i:j])
+        i = j + length
+        if i > len(symbol):
+            return None  # malformed length — bail out
+    m = _CTOR_DTOR_CODE_RE.match(symbol[i:])
+    return m.group(1) if m else None
 
 
 def _unqualified_name(symbol: str) -> str:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -162,14 +162,11 @@ def _check_removed_function(
     )
 
 
-# Scalar integer spellings whose width/signedness are data-model *independent*,
-# mapped to (bit-width, is_signed). Used to recognise ABI-equivalent integer
-# type changes (e.g. ``long`` ↔ ``long long`` on LP64, ``size_t`` ↔
-# ``unsigned long``): a name-only change between two spellings with the same
-# width and signedness is not a binary ABI break — the calling convention and
-# storage are identical. ``size_t``/``ptrdiff_t``/pointer-width types are 64-bit
-# on every supported 64-bit target (LP64 and LLP64).
-_FIXED_SCALAR_REPR: dict[str, tuple[int, bool]] = {
+# Integer spellings whose width is *fixed* regardless of data model, mapped to
+# (bit-width, is_signed). A name-only change between two spellings with the same
+# representation is not a binary ABI break — storage and calling convention are
+# identical.
+_FIXED_SCALAR_REPR: dict[str, tuple[object, bool]] = {
     "int": (32, True), "signed int": (32, True), "signed": (32, True),
     "int32_t": (32, True),
     "unsigned int": (32, False), "unsigned": (32, False), "uint32_t": (32, False),
@@ -182,21 +179,35 @@ _FIXED_SCALAR_REPR: dict[str, tuple[int, bool]] = {
     "uint16_t": (16, False),
     "signed char": (8, True), "int8_t": (8, True),
     "unsigned char": (8, False), "uint8_t": (8, False),
-    "size_t": (64, False), "uintptr_t": (64, False),
-    "ssize_t": (64, True), "ptrdiff_t": (64, True), "intptr_t": (64, True),
 }
-# The ``long`` family: 64-bit under LP64 (Linux/macOS), 32-bit under LLP64
-# (Windows) — resolved against the snapshot's data model.
+# Data-model-dependent spellings. On LP64 (Linux/macOS 64-bit) the ``long``
+# family and the pointer-width types are all 64-bit; on ILP32 they are all
+# 32-bit; on LLP64 (Windows) ``long`` is 32-bit while the pointer-width types
+# stay 64-bit. The snapshot does not record target bitness, so for non-LLP64
+# targets we cannot tell LP64 from ILP32 — but the ``long`` family and the
+# pointer-width family *co-vary* there (both equal the pointer size), so they
+# are equivalent to each other yet NOT to a fixed-width spelling (e.g. ``long``
+# vs ``long long`` is a real width change on ILP32 and must not be suppressed).
+# A shared ``"long"`` width sentinel captures exactly that: it is equal to
+# itself (same sign) but never to a concrete bit-width, so ``size_t`` ↔
+# ``unsigned long`` is suppressed on non-LLP64 while ``int`` ↔ ``long`` and
+# ``long`` ↔ ``long long`` stay reportable everywhere.
 _LONG_SIGNED_SPELLINGS = frozenset({"long", "long int", "signed long"})
 _LONG_UNSIGNED_SPELLINGS = frozenset({"unsigned long", "long unsigned int"})
+_PTR_SIGNED_SPELLINGS = frozenset({"ssize_t", "ptrdiff_t", "intptr_t"})
+_PTR_UNSIGNED_SPELLINGS = frozenset({"size_t", "uintptr_t"})
 
 
-def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[int, bool] | None:
-    """Map a *bare* integer spelling to (bit-width, is_signed), or None.
+def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[object, bool] | None:
+    """Map a *bare* integer spelling to (width, is_signed), or None.
 
-    Returns None for anything that is not a plain integer scalar (pointers,
-    references, templates, cv-qualified or unknown spellings), so equivalence is
-    only ever asserted between two unambiguous integer names.
+    Width is an ``int`` (fixed bit count) or the sentinel ``"long"`` for the
+    data-model-dependent ``long`` family (and, on non-LLP64, the pointer-width
+    typedefs that co-vary with it). The sentinel is never equal to any fixed
+    width, so a distinct built-in change such as ``int`` vs ``long`` is reported
+    even where the widths coincide. Returns None for anything that is not a
+    plain integer scalar (pointers, references, templates, cv-qualified or
+    unknown spellings).
     """
     t = " ".join(type_name.split())
     if not t or any(c in t for c in "*&<>([,") or "const" in t or "volatile" in t:
@@ -204,10 +215,22 @@ def _scalar_repr(type_name: str, is_llp64: bool) -> tuple[int, bool] | None:
     fixed = _FIXED_SCALAR_REPR.get(t)
     if fixed is not None:
         return fixed
+    # The ``long`` family is its own distinct built-in: it must never be equated
+    # with a fixed-width spelling, even where the widths happen to coincide
+    # (e.g. ``int`` vs ``long`` are both 32-bit on LLP64 but are different
+    # types, and changing one to the other is a real signature change). Map it
+    # to a dedicated, platform-independent sentinel.
     if t in _LONG_SIGNED_SPELLINGS:
-        return (32 if is_llp64 else 64, True)
+        return ("long", True)
     if t in _LONG_UNSIGNED_SPELLINGS:
-        return (32 if is_llp64 else 64, False)
+        return ("long", False)
+    # Pointer-width typedefs co-vary with the ``long`` family on non-LLP64
+    # (``size_t`` *is* ``unsigned long`` there), but are a fixed 64-bit under
+    # LLP64 (where ``long`` is 32-bit and thus a different representation).
+    if t in _PTR_SIGNED_SPELLINGS:
+        return (64, True) if is_llp64 else ("long", True)
+    if t in _PTR_UNSIGNED_SPELLINGS:
+        return (64, False) if is_llp64 else ("long", False)
     return None
 
 
@@ -216,9 +239,11 @@ def _abi_equivalent_scalar(old_type: str, new_type: str, is_llp64: bool) -> bool
 
     True only when both resolve to the same width *and* signedness on the
     target data model — i.e. the change is a spelling/typedef difference, not a
-    binary ABI break (``size_t`` ↔ ``unsigned long``, ``long`` ↔ ``long long``
-    on LP64). A signedness difference (``long`` ↔ ``unsigned long``) is *not*
-    equivalent and is still reported.
+    binary ABI break (e.g. ``size_t`` ↔ ``unsigned long``). A signedness
+    difference (``long`` ↔ ``unsigned long``) is not equivalent, and a
+    data-model-dependent spelling is never equated with a fixed width
+    (``long`` ↔ ``long long`` stays a reportable change, since it is a real
+    width change on ILP32 and the snapshot does not record target bitness).
     """
     old_r = _scalar_repr(old_type, is_llp64)
     return old_r is not None and old_r == _scalar_repr(new_type, is_llp64)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1012,6 +1012,36 @@ def _diff_var_access(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
 _FUNC_LIKE_TYPES = frozenset({SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTYPE})
 
+# Minimum base-name similarity required to accept a *hash-less* (size-only /
+# fuzzy) rename match. When no code hash is available — the only mode the
+# snapshot/elf_only path can reach — a "rename" is inferred purely from a
+# coincidental symbol-size collision. On a large library that produces nonsense
+# pairings of completely unrelated functions that merely happen to share a byte
+# size (observed on real libLLVM release-to-release diffs: e.g. fixupIndexV4 ->
+# SmallVectorImpl<...>). A genuine rename or namespace relocation keeps the
+# function's unqualified base name (e.g. CompileUnit::dump ->
+# dwarf_linker::classic::CompileUnit::dump), so requiring base-name similarity
+# discriminates real renames (ratio ~1.0) from coincidences (ratio < 0.3).
+_RENAME_NAME_SIMILARITY_MIN = 0.5
+
+
+def _plausible_rename(old_name: str, new_name: str) -> bool:
+    """Whether two symbol names are similar enough to credibly be a rename.
+
+    Compares the *unqualified* base names (demangled when possible) so a
+    namespace move scores ~1.0 while unrelated functions score low. Used only
+    to gate hash-less matches, where size alone is not evidence of identity.
+    """
+    import difflib
+
+    from .demangle import base_name
+
+    a = base_name(old_name)
+    b = base_name(new_name)
+    if a == b:
+        return True
+    return difflib.SequenceMatcher(None, a, b).ratio() >= _RENAME_NAME_SIMILARITY_MIN
+
 
 def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:
     """Build FunctionFingerprint dict from ELF metadata (size-only, no code hash).
@@ -1067,6 +1097,13 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
 
     candidates = match_renamed_functions(old_fps, new_fps)
     for c in candidates:
+        # Hash-less matches (the only kind this path can produce, since
+        # _fingerprints_from_elf has no code bytes) are inferred from symbol
+        # size alone. Require name similarity so coincidental size collisions
+        # between unrelated functions are not reported as renames.
+        if not c.old_fingerprint.code_hash and not c.new_fingerprint.code_hash:
+            if not _plausible_rename(c.old_name, c.new_name):
+                continue
         conf_pct = int(c.confidence * 100)
         changes.append(Change(
             kind=ChangeKind.FUNC_LIKELY_RENAMED,

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1249,6 +1249,17 @@ def _ctor_dtor_variant(symbol: str) -> str | None:
             # ``_ZNSt6vectorIiEC1Ev`` (St = std::) — consume it before the
             # source-name components so the ctor/dtor code is still found.
             i = _skip_substitution(symbol, i)
+        elif symbol[i] == "B":
+            # ABI-tag component ``B<source-name>`` on the class name, e.g.
+            # ``_ZN3FooB1xC1Ev`` (Foo[abi:x]). Consume it so the ctor/dtor code
+            # that follows is still reached.
+            i += 1
+            if i < len(symbol) and symbol[i].isdigit():
+                i = _skip_source_name(symbol, i)
+                if i < 0:
+                    return None  # malformed ABI tag — bail out
+            else:
+                break  # not a well-formed ABI tag
         else:
             break
     m = _CTOR_DTOR_CODE_RE.match(symbol[i:])
@@ -1511,6 +1522,43 @@ def _param_signature_of(s: str) -> str:
     return ""
 
 
+def _return_type_of(s: str) -> str:
+    """The leading return type of a demangled name, or "" when there is none.
+
+    A return type appears in demangled output only when it is part of the
+    mangled ABI symbol — chiefly C++ function-template instantiations
+    (``int foo<int>()``) — so for ordinary functions this is empty and the
+    comparison in ``_plausible_rename`` is a no-op. It is the run before the
+    last top-level space that precedes the (qualified) function name, with
+    template ``<…>`` and ``::`` kept intact (``unsigned int foo<int>()`` ->
+    ``unsigned int``; ``std::vector<int> bar()`` -> ``std::vector<int>``).
+    """
+    s = _unwrap_funcptr_declarator(s)
+    if _OPERATOR_TOKEN_RE.search(s):
+        return ""  # operator spellings carry no separable leading return type
+    # Truncate at the parameter-list '(' at template depth 0.
+    depth = 0
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == "(" and depth == 0:
+            s = s[:i]
+            break
+    # The return type, if any, is everything before the last top-level space.
+    depth = 0
+    sp = -1
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == " " and depth == 0:
+            sp = i
+    return s[:sp].strip() if sp != -1 else ""
+
+
 def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
@@ -1563,13 +1611,19 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     for leaf in (a, b):
         if _OPERATOR_TOKEN_RE.match(leaf) is not None or leaf.startswith("~"):
             return a == b
-    # A rename/relocation preserves the parameter list; a parameter change is a
-    # different ABI symbol (foo(int) -> foo(long)), not a rename.
-    params_match = _param_signature_of(da) == _param_signature_of(db)
+    # A rename/relocation preserves the full signature: parameters AND — for
+    # the function templates whose mangling encodes it — the return type. A
+    # change to either is a distinct ABI symbol (foo(int) -> foo(long), or
+    # int foo<int>() -> long foo<int>()), not a rename. Ordinary (non-template)
+    # functions demangle without a return type, so that check is a no-op there.
+    sig_match = (
+        _param_signature_of(da) == _param_signature_of(db)
+        and _return_type_of(da) == _return_type_of(db)
+    )
     if a == b:
-        # Same unqualified name + template args: a rename only if the parameters
-        # also match (else it is a signature change).
-        return params_match
+        # Same unqualified name + template args: a rename only if the signature
+        # also matches (else it is a signature change).
+        return sig_match
     base_a = _strip_template_args(a)
     base_b = _strip_template_args(b)
     # Same base name but different leaves means the template arguments differ:
@@ -1577,7 +1631,7 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     # consumer of foo<int> still fails to link against foo<long>.
     if base_a == base_b:
         return False
-    return params_match and _shared_affix_len(base_a, base_b) >= _RENAME_MIN_SHARED_AFFIX
+    return sig_match and _shared_affix_len(base_a, base_b) >= _RENAME_MIN_SHARED_AFFIX
 
 
 def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -357,6 +357,16 @@ def detect_overload_set_rerouted(
         added = new_sigs - old_sigs
         if not (removed and added):
             continue
+        # Re-routing is only possible within a genuine overload set — i.e. at
+        # least one side carries two or more distinct overloads under the same
+        # name, so a call that bound to a removed overload can silently rebind
+        # to a *different* surviving/added one. A name that maps to a single
+        # function on both sides (1→1) is just a signature change (already
+        # reported as FUNC_PARAMS_CHANGED); C has no overloading at all, so
+        # such a name can never re-route. Skip it to avoid a spurious RISK
+        # finding that double-counts the same change.
+        if len(old_sigs) < 2 and len(new_sigs) < 2:
+            continue
         changes.append(Change(
             kind=ChangeKind.OVERLOAD_SET_REROUTED,
             symbol=stem,

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -358,14 +358,20 @@ def detect_overload_set_rerouted(
         if not (removed and added):
             continue
         # Re-routing is only possible within a genuine overload set — i.e. at
-        # least one side carries two or more distinct overloads under the same
-        # name, so a call that bound to a removed overload can silently rebind
-        # to a *different* surviving/added one. A name that maps to a single
-        # function on both sides (1→1) is just a signature change (already
-        # reported as FUNC_PARAMS_CHANGED); C has no overloading at all, so
-        # such a name can never re-route. Skip it to avoid a spurious RISK
-        # finding that double-counts the same change.
-        if len(old_sigs) < 2 and len(new_sigs) < 2:
+        # least one side carries two or more overloads under the same name, so a
+        # call that bound to a removed overload can silently rebind to a
+        # *different* surviving/added one. A name that maps to a single function
+        # on both sides (1→1) is just a signature change (already reported as
+        # FUNC_PARAMS_CHANGED); C has no overloading at all, so such a name can
+        # never re-route. Skip it to avoid a spurious RISK finding that
+        # double-counts the same change.
+        #
+        # Count actual overloads (Function entries), not distinct parameter-type
+        # tuples: C++ overloads may differ only in implicit-object cv/ref
+        # qualifiers (e.g. `f(int)` vs `f(int) const`), which share a param-type
+        # tuple but are separate overloads. Keying on the tuple would
+        # under-count them and wrongly suppress a real overload-set change.
+        if len(old_by_stem[stem]) < 2 and len(new_by_stem[stem]) < 2:
             continue
         changes.append(Change(
             kind=ChangeKind.OVERLOAD_SET_REROUTED,

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -346,13 +346,37 @@ def detect_overload_set_rerouted(
             out[stem].append(f)
         return out
 
+    def _overload_key(f: Function) -> tuple[object, ...]:
+        # An overload is distinguished by its parameter types *and* its
+        # implicit-object cv/ref qualifiers. Two member functions f(int) and
+        # f(int) const are separate overloads sharing a parameter-type tuple;
+        # keying on params alone would hide the removal/addition of one of them
+        # in a mixed change (e.g. {f(int), f(int) const} -> {f(int), f(long)}).
+        return (
+            tuple(p.type for p in f.params),
+            f.is_const,
+            f.is_volatile,
+            f.ref_qualifier,
+        )
+
+    def _fmt_key(key: tuple[object, ...]) -> str:
+        params, is_const, is_volatile, ref_qual = key
+        sig = "(" + ", ".join(params) + ")"  # type: ignore[arg-type]
+        if is_const:
+            sig += " const"
+        if is_volatile:
+            sig += " volatile"
+        if ref_qual:
+            sig += f" {ref_qual}"
+        return sig
+
     old_by_stem = _by_stem(old)
     new_by_stem = _by_stem(new)
 
     changes: list[Change] = []
     for stem in sorted(set(old_by_stem) & set(new_by_stem)):
-        old_sigs = {tuple(p.type for p in f.params) for f in old_by_stem[stem]}
-        new_sigs = {tuple(p.type for p in f.params) for f in new_by_stem[stem]}
+        old_sigs = {_overload_key(f) for f in old_by_stem[stem]}
+        new_sigs = {_overload_key(f) for f in new_by_stem[stem]}
         removed = old_sigs - new_sigs
         added = new_sigs - old_sigs
         if not (removed and added):
@@ -364,13 +388,9 @@ def detect_overload_set_rerouted(
         # on both sides (1→1) is just a signature change (already reported as
         # FUNC_PARAMS_CHANGED); C has no overloading at all, so such a name can
         # never re-route. Skip it to avoid a spurious RISK finding that
-        # double-counts the same change.
-        #
-        # Count actual overloads (Function entries), not distinct parameter-type
-        # tuples: C++ overloads may differ only in implicit-object cv/ref
-        # qualifiers (e.g. `f(int)` vs `f(int) const`), which share a param-type
-        # tuple but are separate overloads. Keying on the tuple would
-        # under-count them and wrongly suppress a real overload-set change.
+        # double-counts the same change. Count actual overloads (Function
+        # entries) so cv/ref-only overloads (which share a parameter-type tuple)
+        # are not under-counted.
         if len(old_by_stem[stem]) < 2 and len(new_by_stem[stem]) < 2:
             continue
         changes.append(Change(
@@ -383,8 +403,8 @@ def detect_overload_set_rerouted(
                 f"resolved to a removed overload may silently re-route to "
                 f"a different overload."
             ),
-            old_value=str(sorted(["(" + ", ".join(t) + ")" for t in old_sigs])),
-            new_value=str(sorted(["(" + ", ".join(t) + ")" for t in new_sigs])),
+            old_value=str(sorted(_fmt_key(k) for k in old_sigs)),
+            new_value=str(sorted(_fmt_key(k) for k in new_sigs)),
         ))
 
     return changes

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -530,11 +530,21 @@ class TestPlausibleRename:
         # Nested template args and non-type (literal) params still balance.
         assert _ctor_dtor_variant("_ZN3FooIN2ns1XEEC1Ev") == "C1"
         assert _ctor_dtor_variant("_ZN3FooILi5EEC1Ev") == "C1"
+        # A class-type template argument whose identifier *contains* 'E'
+        # (Foo<Err> = _ZN3FooI3ErrEC1Ev): the 'E' inside the 3-char source-name
+        # 'Err' must not close the template-args block early.
+        assert _ctor_dtor_variant("_ZN3FooI3ErrEC1Ev") == "C1"
+        assert _ctor_dtor_variant("_ZN3FooI3ErrEC2Ev") == "C2"
+        # Substitution and special-substitution template arguments balance too.
+        assert _ctor_dtor_variant("_ZN3FooIS_EC1Ev") == "C1"
+        assert _ctor_dtor_variant("_ZN3FooISsEC1Ev") == "C1"
 
     def test_templated_class_ctor_variant_pair_rejected(self) -> None:
         # C1 vs C2 of the same templated class are distinct ABI symbols, not a
         # rename — the variant guard must fire even with template args present.
         assert _plausible_rename("_ZN3FooIiEC1Ev", "_ZN3FooIiEC2Ev") is False
+        # Same, for a class-type argument containing an 'E' in its identifier.
+        assert _plausible_rename("_ZN3FooI3ErrEC1Ev", "_ZN3FooI3ErrEC2Ev") is False
 
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -18,6 +18,7 @@ from abicheck.binary_fingerprint import (
     match_renamed_functions,
 )
 from abicheck.checker import ChangeKind, compare
+from abicheck.diff_symbols import _plausible_rename, _unqualified_name
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
 from abicheck.model import AbiSnapshot, Function, Visibility
 
@@ -391,6 +392,46 @@ class TestComputeSectionSummary:
             pass
         result = compute_section_summary(p)
         assert result.sections == {}
+
+
+# ---------------------------------------------------------------------------
+# Unqualified-name extraction and rename plausibility
+# ---------------------------------------------------------------------------
+
+class TestUnqualifiedName:
+    @pytest.mark.parametrize("symbol,expected", [
+        ("add", "add"),                                  # plain C name
+        ("ns::Class::method", "method"),                 # qualified
+        ("ns::Class::method(int, long)", "method"),      # with params
+        ("ns::foo<bar::baz>::run()", "run"),             # '::' inside template args
+        ("ns::make<a::b, c::d>", "make<a::b, c::d>"),    # no params, template tail kept
+        ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
+        ("Widget::operator()(int)", "operator()(int)"),        # call operator
+    ])
+    def test_extraction(self, symbol: str, expected: str) -> None:
+        assert _unqualified_name(symbol) == expected
+
+
+class TestPlausibleRename:
+    def test_identical_symbol(self) -> None:
+        assert _plausible_rename("foo", "foo") is True
+
+    def test_namespace_move_same_leaf(self) -> None:
+        # Different qualifier, same leaf → plausible.
+        assert _plausible_rename("a::b::run()", "a::c::d::run()") is True
+
+    def test_same_scope_different_leaf_rejected(self) -> None:
+        # Shared qualifier must not inflate the score: unrelated leaves under a
+        # common scope (begin/end) are not a rename.
+        assert _plausible_rename(
+            "std::vector<int>::begin()", "std::vector<int>::end()"
+        ) is False
+
+    def test_unrelated_rejected(self) -> None:
+        assert _plausible_rename("fixupIndexV4(X)", "SmallVectorImpl<X>::erase(X*)") is False
+
+    def test_version_suffix_rename_accepted(self) -> None:
+        assert _plausible_rename("libfoo_v1_create", "libfoo_create") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -546,6 +546,21 @@ class TestPlausibleRename:
         # Same, for a class-type argument containing an 'E' in its identifier.
         assert _plausible_rename("_ZN3FooI3ErrEC1Ev", "_ZN3FooI3ErrEC2Ev") is False
 
+    def test_one_sided_ctor_match_rejected(self) -> None:
+        # Only one side is a ctor/dtor: a removed constructor A::A()
+        # (_ZN1AC1Ev) vs an added ordinary member B::A() (_ZN1B1AEv) both
+        # reduce to leaf 'A()', but a constructor ABI symbol cannot be
+        # satisfied by an ordinary method — reject rather than call it a rename.
+        assert _plausible_rename("_ZN1AC1Ev", "_ZN1B1AEv") is False
+        assert _plausible_rename("_ZN1B1AEv", "_ZN1AC1Ev") is False
+        # Likewise a destructor vs an ordinary same-leaf member.
+        assert _plausible_rename("_ZN1AD1Ev", "_ZN1B1AEv") is False
+
+    def test_same_variant_ctor_relocation_accepted(self) -> None:
+        # A genuine constructor relocation keeps the same variant code, so a
+        # move to a new enclosing scope (A::A() -> ns::A::A()) still matches.
+        assert _plausible_rename("_ZN1AC1Ev", "_ZN2ns1AC1Ev") is True
+
     def test_ctor_dtor_variant_malformed_symbols_yield_none(self) -> None:
         # Defensive bail-outs: a malformed nested-name must never raise or
         # mis-report; it yields None (no suppression — the safe direction).

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -405,6 +405,8 @@ class TestUnqualifiedName:
         ("ns::Class::method(int, long)", "method"),      # with params
         ("ns::foo<bar::baz>::run()", "run"),             # '::' inside template args
         ("ns::make<a::b, c::d>", "make"),                # trailing template args dropped
+        ("ns::foo<bar<int>>", "foo"),                    # nested trailing template args
+        ("a>", "a>"),                                    # unbalanced '>' left as-is
         ("void get<int>()", "get"),                      # return type + template dropped
         ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
         ("Widget::operator()(int)", "operator()(int)"),        # call operator
@@ -446,6 +448,24 @@ class TestPlausibleRename:
 
     def test_version_suffix_rename_accepted(self) -> None:
         assert _plausible_rename("libfoo_v1_create", "libfoo_create") is True
+
+    def test_distinct_operators_rejected(self) -> None:
+        # The shared 'operator' token must not count as a similarity affix.
+        assert _plausible_rename("C::operator+()", "C::operator-()") is False
+        assert _plausible_rename("C::operator<<(int)", "C::operator>>(int)") is False
+
+    def test_same_operator_accepted(self) -> None:
+        # Identical operator spelling is an exact-leaf match.
+        assert _plausible_rename("A::operator==(int)", "B::operator==(int)") is True
+
+    def test_plain_unqualified_names(self) -> None:
+        # No '::', no template, no return type, no operator.
+        assert _plausible_rename("process_request", "process_reply") is True
+        assert _plausible_rename("alpha", "omega") is False
+
+    def test_prefix_of_other_accepted(self) -> None:
+        # One leaf is a full prefix of the other (shared run spans the shorter).
+        assert _plausible_rename("init", "initialize") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -413,6 +413,8 @@ class TestUnqualifiedName:
         ("void get<int>()", "get<int>"),                 # return type dropped, args kept
         ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
         ("Widget::operator()(int)", "operator()(int)"),        # call operator
+        ("cooperator_v1", "cooperator_v1"),              # 'operator' substring, not keyword
+        ("myoperator::foo_v1()", "foo_v1"),              # 'operator' inside qualifier
     ])
     def test_extraction(self, symbol: str, expected: str) -> None:
         assert _unqualified_name(symbol) == expected
@@ -470,6 +472,12 @@ class TestPlausibleRename:
     def test_same_operator_accepted(self) -> None:
         # Identical operator spelling is an exact-leaf match.
         assert _plausible_rename("A::operator==(int)", "B::operator==(int)") is True
+
+    def test_operator_substring_not_treated_as_operator(self) -> None:
+        # Identifiers that merely contain 'operator' are ordinary names and
+        # must still match on affix, not be forced to exact-only.
+        assert _plausible_rename("cooperator_v1", "cooperator_v2") is True
+        assert _plausible_rename("myoperator::run_v1()", "myoperator::run_v2()") is True
 
     def test_constructor_destructor_pair_rejected(self) -> None:
         # ctor leaf 'Widget' and dtor leaf '~Widget' share the class-name

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -546,6 +546,16 @@ class TestPlausibleRename:
         # Same, for a class-type argument containing an 'E' in its identifier.
         assert _plausible_rename("_ZN3FooI3ErrEC1Ev", "_ZN3FooI3ErrEC2Ev") is False
 
+    def test_ctor_dtor_variant_malformed_symbols_yield_none(self) -> None:
+        # Defensive bail-outs: a malformed nested-name must never raise or
+        # mis-report; it yields None (no suppression — the safe direction).
+        assert _ctor_dtor_variant("_ZN99FooC1Ev") is None     # length overruns
+        assert _ctor_dtor_variant("_ZN3FooIiC1Ev") is None    # template never closed
+        assert _ctor_dtor_variant("_ZN3FooI") is None         # truncated at 'I'
+        assert _ctor_dtor_variant("_ZN3FooILiC1Ev") is None   # L-literal never closed
+        assert _ctor_dtor_variant("_ZNK1A3fooEv") is None     # const member, not a ctor
+        assert _ctor_dtor_variant("not_mangled") is None      # not an _ZN name
+
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and
         # must still match on affix, not be forced to exact-only.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -404,7 +404,8 @@ class TestUnqualifiedName:
         ("ns::Class::method", "method"),                 # qualified
         ("ns::Class::method(int, long)", "method"),      # with params
         ("ns::foo<bar::baz>::run()", "run"),             # '::' inside template args
-        ("ns::make<a::b, c::d>", "make<a::b, c::d>"),    # no params, template tail kept
+        ("ns::make<a::b, c::d>", "make"),                # trailing template args dropped
+        ("void get<int>()", "get"),                      # return type + template dropped
         ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
         ("Widget::operator()(int)", "operator()(int)"),        # call operator
     ])
@@ -429,6 +430,19 @@ class TestPlausibleRename:
 
     def test_unrelated_rejected(self) -> None:
         assert _plausible_rename("fixupIndexV4(X)", "SmallVectorImpl<X>::erase(X*)") is False
+
+    def test_same_scope_short_leaves_rejected(self) -> None:
+        # get/set share only an incidental 2-char suffix once the qualifier is
+        # stripped, below the shared-affix floor.
+        assert _plausible_rename("Class::get()", "Class::set()") is False
+
+    def test_template_instantiations_same_leaf_accepted(self) -> None:
+        # Same function template, different instantiation → same leaf.
+        assert _plausible_rename("void get<int>()", "void get<long>()") is True
+
+    def test_unrelated_templates_same_return_rejected(self) -> None:
+        # Shared return type and template args must not inflate the score.
+        assert _plausible_rename("void get<int>()", "void set<int>()") is False
 
     def test_version_suffix_rename_accepted(self) -> None:
         assert _plausible_rename("libfoo_v1_create", "libfoo_create") is True

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -458,6 +458,16 @@ class TestPlausibleRename:
         # Identical operator spelling is an exact-leaf match.
         assert _plausible_rename("A::operator==(int)", "B::operator==(int)") is True
 
+    def test_constructor_destructor_pair_rejected(self) -> None:
+        # ctor leaf 'Widget' and dtor leaf '~Widget' share the class-name
+        # affix but are different ABI functions, not a rename. (Demangled forms
+        # are used so the test is independent of c++filt availability.)
+        assert _plausible_rename("Widget::Widget()", "Widget::~Widget()") is False
+
+    def test_destructor_namespace_move_accepted(self) -> None:
+        # The same destructor under a different scope is still a move.
+        assert _plausible_rename("ns::Widget::~Widget()", "ns2::Widget::~Widget()") is True
+
     def test_plain_unqualified_names(self) -> None:
         # No '::', no template, no return type, no operator.
         assert _plausible_rename("process_request", "process_reply") is True

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -659,12 +659,15 @@ class TestFingerprintRenameDetector:
 
     def test_namespace_relocation_detected(self) -> None:
         """A genuine namespace move keeps the unqualified base name, so a
-        hash-less size match is still reported as a rename."""
+        hash-less size match is still reported as a rename. Uses already-
+        demangled spellings so the test is independent of c++filt/cxxfilt
+        availability (without a demangler, raw _Z names are treated
+        conservatively and a real move can't be inferred — by design)."""
         old = _snap_elf_only("1.0", [
-            _func_sym("_ZN4llvm11CompileUnit20markEverythingAsKeptEv", 256),
+            _func_sym("llvm::CompileUnit::markEverythingAsKept()", 256),
         ])
         new = _snap_elf_only("2.0", [
-            _func_sym("_ZN4llvm12dwarf_linker7classic11CompileUnit20markEverythingAsKeptEv", 256),
+            _func_sym("llvm::dwarf_linker::classic::CompileUnit::markEverythingAsKept()", 256),
         ])
         result = compare(old, new)
         rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -541,6 +541,18 @@ class TestPlausibleRename:
         assert _ctor_dtor_variant("_ZN3FooIS_EC1Ev") == "C1"
         assert _ctor_dtor_variant("_ZN3FooISsEC1Ev") == "C1"
 
+    def test_std_substitution_prefix_ctor_variant_detected(self) -> None:
+        # A standard-substitution abbreviation can open the prefix: St = std::,
+        # so std::vector<int>::vector() = _ZNSt6vectorIiEC1Ev. The variant code
+        # must still be found after consuming the substitution.
+        assert _ctor_dtor_variant("_ZNSt6vectorIiEC1Ev") == "C1"
+        assert _ctor_dtor_variant("_ZNSt6vectorIiEC2Ev") == "C2"
+        assert _ctor_dtor_variant("_ZNSsC1Ev") == "C1"  # Ss = std::string
+        # A non-ctor std:: member is still not a variant.
+        assert _ctor_dtor_variant("_ZNSt6vectorIiE3fooEv") is None
+        # C1 vs C2 of a std container are distinct ABI symbols, not a rename.
+        assert _plausible_rename("_ZNSt6vectorIiEC1Ev", "_ZNSt6vectorIiEC2Ev") is False
+
     def test_templated_class_ctor_variant_pair_rejected(self) -> None:
         # C1 vs C2 of the same templated class are distinct ABI symbols, not a
         # rename — the variant guard must fire even with template args present.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -478,6 +478,38 @@ class TestFingerprintRenameDetector:
         assert rename_changes[0].old_value == "old_only"
         assert rename_changes[0].new_value == "new_only"
 
+    def test_unrelated_names_same_size_not_renamed(self) -> None:
+        """Two unrelated functions that merely share a byte size must NOT be
+        reported as a rename when no code hash is available.
+
+        Regression for false renames observed on real libLLVM diffs, where
+        size-only matching paired completely unrelated mangled symbols (e.g.
+        ``fixupIndexV4`` -> ``SmallVectorImpl<...>``) purely because they hit a
+        unique size bucket. Without code-identity evidence, dissimilar names are
+        a coincidence, not a rename."""
+        old = _snap_elf_only("1.0", [
+            _func_sym("_Z12fixupIndexV4RKN4llvm11DWARFObjectE", 256),
+        ])
+        new = _snap_elf_only("2.0", [
+            _func_sym("_ZN4llvm15SmallVectorImplINS_11CompileUnitEE5eraseEPS2_", 256),
+        ])
+        result = compare(old, new)
+        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        assert rename_changes == []
+
+    def test_namespace_relocation_detected(self) -> None:
+        """A genuine namespace move keeps the unqualified base name, so a
+        hash-less size match is still reported as a rename."""
+        old = _snap_elf_only("1.0", [
+            _func_sym("_ZN4llvm11CompileUnit20markEverythingAsKeptEv", 256),
+        ])
+        new = _snap_elf_only("2.0", [
+            _func_sym("_ZN4llvm12dwarf_linker7classic11CompileUnit20markEverythingAsKeptEv", 256),
+        ])
+        result = compare(old, new)
+        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        assert len(rename_changes) == 1
+
     def test_fuzzy_match_appears_in_compare_output(self) -> None:
         """A fuzzy size match (within 5%) makes it through the full pipeline."""
         old = _snap_elf_only("1.0", [_func_sym("old_func", _NORMAL_SIZE)])

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -461,6 +461,17 @@ class TestPlausibleRename:
         # Shared return type and template args must not inflate the score.
         assert _plausible_rename("void get<int>()", "void set<int>()") is False
 
+    def test_same_name_param_change_rejected(self) -> None:
+        # foo(int) and foo(long) are distinct mangled symbols (different
+        # parameters), so a same-size collision is a signature change, not a
+        # rename — a consumer of foo(int) still fails to link against foo(long).
+        assert _plausible_rename("foo(int)", "foo(long)") is False
+        assert _plausible_rename("ns::Cls::run(int)", "ns::Cls::run(double)") is False
+
+    def test_namespace_move_same_params_accepted(self) -> None:
+        # Same function (name + parameters), different scope → a relocation.
+        assert _plausible_rename("ns1::foo(int)", "ns2::foo(int)") is True
+
     def test_version_suffix_rename_accepted(self) -> None:
         assert _plausible_rename("libfoo_v1_create", "libfoo_create") is True
 

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -502,6 +502,13 @@ class TestPlausibleRename:
         assert _plausible_rename("_ZN6WidgetC1Ev", "_ZN6WidgetC2Ev") is False
         assert _plausible_rename("_ZN6WidgetD1Ev", "_ZN6WidgetD0Ev") is False
 
+    def test_free_function_with_ctor_like_name_not_rejected(self) -> None:
+        # A free function whose identifier merely contains 'C1E'/'C2E'
+        # (_Z6fooC1Ev = fooC1E()) is NOT a constructor variant — it is a
+        # non-nested (_Z, not _ZN) mangling, so the variant guard must not block
+        # a legitimate fooC1E -> fooC2E rename.
+        assert _plausible_rename("_Z6fooC1Ev", "_Z6fooC2Ev") is True
+
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and
         # must still match on affix, not be forced to exact-only.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -484,9 +484,14 @@ class TestPlausibleRename:
         # Identical operator spelling is an exact-leaf match.
         assert _plausible_rename("A::operator==(int)", "B::operator==(int)") is True
 
-    def test_undemangleable_mangled_names_rejected(self) -> None:
-        # Without a demangler the leaf is the raw mangled spelling; its shared
-        # boilerplate must not be affix-scored into a false rename.
+    def test_undemangleable_mangled_names_rejected(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Force the no-demangler branch so the raw "_Z..." fallback is actually
+        # exercised: without a demangler the leaf is the raw mangled spelling,
+        # whose shared boilerplate must not be affix-scored into a false rename.
+        import abicheck.demangle as demangle_mod
+        monkeypatch.setattr(demangle_mod, "demangle", lambda _sym: None)
         assert _plausible_rename("_ZN1A3fooEv", "_ZN1B3barEv") is False
 
     def test_operator_substring_not_treated_as_operator(self) -> None:

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -18,7 +18,11 @@ from abicheck.binary_fingerprint import (
     match_renamed_functions,
 )
 from abicheck.checker import ChangeKind, compare
-from abicheck.diff_symbols import _plausible_rename, _unqualified_name
+from abicheck.diff_symbols import (
+    _plausible_rename,
+    _strip_template_args,
+    _unqualified_name,
+)
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
 from abicheck.model import AbiSnapshot, Function, Visibility
 
@@ -404,15 +408,23 @@ class TestUnqualifiedName:
         ("ns::Class::method", "method"),                 # qualified
         ("ns::Class::method(int, long)", "method"),      # with params
         ("ns::foo<bar::baz>::run()", "run"),             # '::' inside template args
-        ("ns::make<a::b, c::d>", "make"),                # trailing template args dropped
-        ("ns::foo<bar<int>>", "foo"),                    # nested trailing template args
-        ("a>", "a>"),                                    # unbalanced '>' left as-is
-        ("void get<int>()", "get"),                      # return type + template dropped
+        ("ns::make<a::b, c::d>", "make<a::b, c::d>"),    # template args kept
+        ("ns::foo<bar<int>>", "foo<bar<int>>"),          # nested template args kept
+        ("void get<int>()", "get<int>"),                 # return type dropped, args kept
         ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
         ("Widget::operator()(int)", "operator()(int)"),        # call operator
     ])
     def test_extraction(self, symbol: str, expected: str) -> None:
         assert _unqualified_name(symbol) == expected
+
+    @pytest.mark.parametrize("leaf,expected", [
+        ("get<int>", "get"),                 # simple template args
+        ("foo<bar<int>>", "foo"),            # nested template args
+        ("plain", "plain"),                  # no template args
+        ("a>", "a>"),                        # unbalanced '>' left as-is
+    ])
+    def test_strip_template_args(self, leaf: str, expected: str) -> None:
+        assert _strip_template_args(leaf) == expected
 
 
 class TestPlausibleRename:
@@ -438,9 +450,10 @@ class TestPlausibleRename:
         # stripped, below the shared-affix floor.
         assert _plausible_rename("Class::get()", "Class::set()") is False
 
-    def test_template_instantiations_same_leaf_accepted(self) -> None:
-        # Same function template, different instantiation → same leaf.
-        assert _plausible_rename("void get<int>()", "void get<long>()") is True
+    def test_template_specializations_rejected(self) -> None:
+        # foo<int> and foo<long> are distinct ABI symbols (different mangled
+        # names), so swapping one for the other is not a rename.
+        assert _plausible_rename("void get<int>()", "void get<long>()") is False
 
     def test_unrelated_templates_same_return_rejected(self) -> None:
         # Shared return type and template args must not inflate the score.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -287,6 +287,27 @@ class TestMatchRenamedFunctions:
         assert result[0].old_name == "a"
         assert result[0].new_name == "c"
 
+    def test_name_filter_participates_in_selection(self) -> None:
+        """When a size bucket has one added symbol and several removed symbols,
+        the name filter must steer candidate *selection*, not just discard a
+        greedily-chosen pair afterward. An unrelated removed name that sorts
+        first must not consume the partner a plausible rename should claim."""
+        old = {
+            # 'aaa_unrelated' sorts before 'foo_v1' and shares the size bucket
+            "aaa_unrelated": _fp("aaa_unrelated", 256),
+            "foo_v1": _fp("foo_v1", 256),
+        }
+        new = {"foo_v2": _fp("foo_v2", 256)}
+
+        def plausible(o: str, n: str) -> bool:
+            import difflib
+            return difflib.SequenceMatcher(None, o, n).ratio() >= 0.5
+
+        result = match_renamed_functions(old, new, name_filter=plausible)
+        assert len(result) == 1
+        assert result[0].old_name == "foo_v1"
+        assert result[0].new_name == "foo_v2"
+
     def test_empty_inputs(self) -> None:
         assert match_renamed_functions({}, {}) == []
         assert match_renamed_functions({"a": _fp("a", 100)}, {}) == []
@@ -496,6 +517,23 @@ class TestFingerprintRenameDetector:
         result = compare(old, new)
         rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
         assert rename_changes == []
+
+    def test_collision_does_not_hide_plausible_rename(self) -> None:
+        """A real rename in a crowded size bucket is still found even when an
+        unrelated same-size symbol sorts earlier — the similarity check drives
+        selection, so the unrelated symbol cannot consume the partner."""
+        old = _snap_elf_only("1.0", [
+            _func_sym("aaa_unrelated_function", 256),
+            _func_sym("foo_v1_dosomething", 256),
+        ])
+        new = _snap_elf_only("2.0", [
+            _func_sym("foo_v2_dosomething", 256),
+        ])
+        result = compare(old, new)
+        renames = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        assert len(renames) == 1
+        assert renames[0].old_value == "foo_v1_dosomething"
+        assert renames[0].new_value == "foo_v2_dosomething"
 
     def test_namespace_relocation_detected(self) -> None:
         """A genuine namespace move keeps the unqualified base name, so a

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -484,6 +484,11 @@ class TestPlausibleRename:
         # Identical operator spelling is an exact-leaf match.
         assert _plausible_rename("A::operator==(int)", "B::operator==(int)") is True
 
+    def test_undemangleable_mangled_names_rejected(self) -> None:
+        # Without a demangler the leaf is the raw mangled spelling; its shared
+        # boilerplate must not be affix-scored into a false rename.
+        assert _plausible_rename("_ZN1A3fooEv", "_ZN1B3barEv") is False
+
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and
         # must still match on affix, not be forced to exact-only.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -520,6 +520,22 @@ class TestPlausibleRename:
         # Namespaced constructor is still detected.
         assert _ctor_dtor_variant("_ZN2ns6WidgetC1Ev") == "C1"
 
+    def test_templated_class_ctor_variant_detected(self) -> None:
+        # A templated class places its <template-args> (I…E) between the class
+        # name and the ctor/dtor code; the parser must skip the balanced block.
+        # _ZN3FooIiEC1Ev = Foo<int>::Foo().
+        assert _ctor_dtor_variant("_ZN3FooIiEC1Ev") == "C1"
+        assert _ctor_dtor_variant("_ZN3FooIiEC2Ev") == "C2"
+        assert _ctor_dtor_variant("_ZN3FooIiED1Ev") == "D1"
+        # Nested template args and non-type (literal) params still balance.
+        assert _ctor_dtor_variant("_ZN3FooIN2ns1XEEC1Ev") == "C1"
+        assert _ctor_dtor_variant("_ZN3FooILi5EEC1Ev") == "C1"
+
+    def test_templated_class_ctor_variant_pair_rejected(self) -> None:
+        # C1 vs C2 of the same templated class are distinct ABI symbols, not a
+        # rename — the variant guard must fire even with template args present.
+        assert _plausible_rename("_ZN3FooIiEC1Ev", "_ZN3FooIiEC2Ev") is False
+
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and
         # must still match on affix, not be forced to exact-only.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -19,6 +19,7 @@ from abicheck.binary_fingerprint import (
 )
 from abicheck.checker import ChangeKind, compare
 from abicheck.diff_symbols import (
+    _ctor_dtor_variant,
     _plausible_rename,
     _strip_template_args,
     _unqualified_name,
@@ -502,12 +503,22 @@ class TestPlausibleRename:
         assert _plausible_rename("_ZN6WidgetC1Ev", "_ZN6WidgetC2Ev") is False
         assert _plausible_rename("_ZN6WidgetD1Ev", "_ZN6WidgetD0Ev") is False
 
-    def test_free_function_with_ctor_like_name_not_rejected(self) -> None:
+    def test_free_function_with_ctor_like_name_not_a_ctor_variant(self) -> None:
         # A free function whose identifier merely contains 'C1E'/'C2E'
         # (_Z6fooC1Ev = fooC1E()) is NOT a constructor variant — it is a
-        # non-nested (_Z, not _ZN) mangling, so the variant guard must not block
-        # a legitimate fooC1E -> fooC2E rename.
-        assert _plausible_rename("_Z6fooC1Ev", "_Z6fooC2Ev") is True
+        # non-nested (_Z, not _ZN) mangling, so the variant guard must not fire.
+        # (Asserted on _ctor_dtor_variant directly so the check is independent
+        # of demangler availability; a real ctor IS a nested _ZN name.)
+        assert _ctor_dtor_variant("_Z6fooC1Ev") is None
+        assert _ctor_dtor_variant("_Z6fooC2Ev") is None
+        assert _ctor_dtor_variant("_ZN6WidgetC1Ev") == "C1"
+        # A nested MEMBER named fooC1E (_ZN1A6fooC1EEv = A::fooC1E()) is also not
+        # a constructor — the length-prefix parser must not be fooled by the
+        # 'C1E' substring inside the source-name component.
+        assert _ctor_dtor_variant("_ZN1A6fooC1EEv") is None
+        assert _ctor_dtor_variant("_ZN1A6fooC2EEv") is None
+        # Namespaced constructor is still detected.
+        assert _ctor_dtor_variant("_ZN2ns6WidgetC1Ev") == "C1"
 
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -22,6 +22,7 @@ from abicheck.diff_symbols import (
     _ctor_dtor_variant,
     _param_signature_of,
     _plausible_rename,
+    _return_type_of,
     _strip_template_args,
     _unqualified_name,
     _unqualified_name_of,
@@ -552,6 +553,33 @@ class TestPlausibleRename:
         assert _ctor_dtor_variant("_ZNSt6vectorIiE3fooEv") is None
         # C1 vs C2 of a std container are distinct ABI symbols, not a rename.
         assert _plausible_rename("_ZNSt6vectorIiEC1Ev", "_ZNSt6vectorIiEC2Ev") is False
+
+    def test_abi_tag_prefix_ctor_variant_detected(self) -> None:
+        # An ABI-tag component B<source-name> sits on the class name before the
+        # ctor/dtor code: Foo[abi:x]::Foo() = _ZN3FooB1xC1Ev. The variant must
+        # still be found after consuming the tag, so C1/C2 are not a rename.
+        assert _ctor_dtor_variant("_ZN3FooB1xC1Ev") == "C1"
+        assert _ctor_dtor_variant("_ZN3FooB1xC2Ev") == "C2"
+        assert _plausible_rename("_ZN3FooB1xC1Ev", "_ZN3FooB1xC2Ev") is False
+
+    def test_return_type_only_template_change_rejected(self) -> None:
+        # Function templates encode the return type in the ABI symbol, so a
+        # same-leaf/same-params return-type change (int foo<int>() ->
+        # long foo<int>()) is a distinct symbol, not a rename. Demangled-style
+        # inputs keep the test independent of c++filt availability.
+        assert _plausible_rename("int foo<int>()", "long foo<int>()") is False
+        assert _plausible_rename("void g<int>()", "int g<int>()") is False
+        # An ordinary (non-template) rename has no return type either side, so
+        # the check is a no-op and a genuine relocation still matches.
+        assert _plausible_rename("ns::Widget::run()", "ns2::Widget::run()") is True
+
+    def test_return_type_of_extraction(self) -> None:
+        assert _return_type_of("int foo<int>()") == "int"
+        assert _return_type_of("unsigned int g<int>()") == "unsigned int"
+        assert _return_type_of("std::vector<int> bar()") == "std::vector<int>"
+        assert _return_type_of("foo(int)") == ""           # ordinary function
+        assert _return_type_of("ns::Class::method()") == ""
+        assert _return_type_of("operator<<(int)") == ""
 
     def test_templated_class_ctor_variant_pair_rejected(self) -> None:
         # C1 vs C2 of the same templated class are distinct ABI symbols, not a

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -494,6 +494,14 @@ class TestPlausibleRename:
         monkeypatch.setattr(demangle_mod, "demangle", lambda _sym: None)
         assert _plausible_rename("_ZN1A3fooEv", "_ZN1B3barEv") is False
 
+    def test_ctor_dtor_variant_pairs_rejected(self) -> None:
+        # Itanium ctor/dtor variants demangle to the same leaf but are distinct
+        # exported symbols; a size collision between them is not a rename.
+        # Deterministic regardless of demangler availability (checked on the
+        # raw mangled name).
+        assert _plausible_rename("_ZN6WidgetC1Ev", "_ZN6WidgetC2Ev") is False
+        assert _plausible_rename("_ZN6WidgetD1Ev", "_ZN6WidgetD0Ev") is False
+
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and
         # must still match on affix, not be forced to exact-only.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -557,9 +557,12 @@ class TestPlausibleRename:
         assert _plausible_rename("_ZN1AD1Ev", "_ZN1B1AEv") is False
 
     def test_same_variant_ctor_relocation_accepted(self) -> None:
-        # A genuine constructor relocation keeps the same variant code, so a
-        # move to a new enclosing scope (A::A() -> ns::A::A()) still matches.
-        assert _plausible_rename("_ZN1AC1Ev", "_ZN2ns1AC1Ev") is True
+        # A genuine constructor relocation to a new enclosing scope
+        # (A::A() -> ns::A::A()) is still a plausible rename — the tightened
+        # guard must not reject same-kind ctors. Demangled-style names are used
+        # so the test is independent of c++filt/cxxfilt availability (raw _Z
+        # names without a demangler fall to the conservative exact-only gate).
+        assert _plausible_rename("A::A()", "ns::A::A()") is True
 
     def test_ctor_dtor_variant_malformed_symbols_yield_none(self) -> None:
         # Defensive bail-outs: a malformed nested-name must never raise or

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -20,9 +20,11 @@ from abicheck.binary_fingerprint import (
 from abicheck.checker import ChangeKind, compare
 from abicheck.diff_symbols import (
     _ctor_dtor_variant,
+    _param_signature_of,
     _plausible_rename,
     _strip_template_args,
     _unqualified_name,
+    _unqualified_name_of,
 )
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
 from abicheck.model import AbiSnapshot, Function, Visibility
@@ -555,6 +557,26 @@ class TestPlausibleRename:
         assert _plausible_rename("_ZN1B1AEv", "_ZN1AC1Ev") is False
         # Likewise a destructor vs an ordinary same-leaf member.
         assert _plausible_rename("_ZN1AD1Ev", "_ZN1B1AEv") is False
+
+    def test_funcptr_return_declarator_name_extracted(self) -> None:
+        # A function returning a function pointer demangles to declarator syntax
+        # (int (*foo<int>())()) where the first top-level '(' opens the
+        # declarator group, not the parameter list. The real name must be
+        # recovered for leaf/param extraction (demangled-style inputs keep the
+        # test independent of c++filt availability).
+        assert _unqualified_name_of("int (*foo_v1<int>())()") == "foo_v1<int>"
+        assert _param_signature_of("int (*foo_v1<int>())()") == "()"
+        # A function that merely *takes* a function-pointer parameter must be
+        # left intact (the '(' there is the real parameter list).
+        assert _unqualified_name_of("void foo(int (*)())") == "foo"
+        assert _param_signature_of("void foo(int (*)())") == "(int (*)())"
+
+    def test_funcptr_return_rename_detected(self) -> None:
+        # End-to-end: a versioned rename of a function-pointer-returning template
+        # (foo_v1<int> -> foo_v2<int>) is a plausible rename, not removed/added.
+        assert _plausible_rename(
+            "int (*foo_v1<int>())()", "int (*foo_v2<int>())()"
+        ) is True
 
     def test_same_variant_ctor_relocation_accepted(self) -> None:
         # A genuine constructor relocation to a new enclosing scope

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -344,10 +344,13 @@ class TestCompatGroupStructure:
 
     def test_compat_no_subcommand_shows_usage(self):
         """'abicheck compat' without a subcommand shows usage."""
+        from abicheck.cli import _EXIT_USAGE_ERROR
+
         runner = CliRunner()
         result = runner.invoke(main, ["compat"])
-        # Click shows usage and exits with code 2 when no subcommand given
-        assert result.exit_code == 2
+        # Missing subcommand → Click usage error, remapped to the dedicated
+        # usage-error code (outside the compare result space {0,1,2,4}).
+        assert result.exit_code == _EXIT_USAGE_ERROR
         assert "Usage" in result.output or "check" in result.output
 
     def test_compat_dump_help(self):

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -417,4 +417,8 @@ class TestNoFailOnAdditionsFlag:
 
         runner = CliRunner()
         result = runner.invoke(main, ["compare", str(p), str(p), "--fail-on-additions"])
-        assert result.exit_code == 2  # Click returns 2 for unrecognised options
+        # Unrecognised option → Click usage error, remapped to the dedicated
+        # usage-error code (outside the compare result space {0,1,2,4}) so it is
+        # not mistaken for a "2 = source break" verdict.
+        from abicheck.cli import _EXIT_USAGE_ERROR
+        assert result.exit_code == _EXIT_USAGE_ERROR

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -239,6 +239,24 @@ class TestOverloadSetRerouted:
         ])
         assert detect_overload_set_rerouted(old, new) == []
 
+    def test_volatile_and_ref_qualifiers_rendered(self) -> None:
+        """Overloads differing by volatile / ref-qualifier are distinct members
+        and the rendered old/new values surface those qualifiers."""
+        f_vol = _fn("lib::g", mangled="_ZVo", params=[("a", "int")])
+        f_vol.is_volatile = True
+        f_ref = _fn("lib::g", mangled="_ZRo", params=[("a", "int")])
+        f_ref.ref_qualifier = "&"
+        old = _snap(funcs=[
+            _fn("lib::g", mangled="_Zo", params=[("a", "int")]),
+            f_vol,
+            f_ref,
+        ])
+        new = _snap(funcs=[_fn("lib::g", mangled="_Zn", params=[("a", "long")])])
+        changes = detect_overload_set_rerouted(old, new)
+        assert len(changes) == 1
+        assert "volatile" in changes[0].old_value
+        assert "&" in changes[0].old_value
+
     def test_cv_ref_only_overload_set_still_fires(self) -> None:
         """Overloads that differ only in implicit-object cv/ref qualifiers share
         a parameter-type tuple but are distinct overloads. A genuine overload

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -239,6 +239,23 @@ class TestOverloadSetRerouted:
         ])
         assert detect_overload_set_rerouted(old, new) == []
 
+    def test_cv_ref_only_overload_set_still_fires(self) -> None:
+        """Overloads that differ only in implicit-object cv/ref qualifiers share
+        a parameter-type tuple but are distinct overloads. A genuine overload
+        set (e.g. `f(int)` + `f(int) const`) replaced by `f(long)` must still
+        fire OVERLOAD_SET_REROUTED — the guard counts actual overloads, not
+        distinct parameter-type tuples."""
+        old = _snap(funcs=[
+            _fn("lib::f", mangled="_ZN3lib1fEi", params=[("a", "int")]),
+            _fn("lib::f", mangled="_ZNK3lib1fEi", params=[("a", "int")]),  # const
+        ])
+        new = _snap(funcs=[
+            _fn("lib::f", mangled="_ZN3lib1fEl", params=[("a", "long")]),
+        ])
+        changes = detect_overload_set_rerouted(old, new)
+        assert len(changes) == 1
+        assert changes[0].kind == ChangeKind.OVERLOAD_SET_REROUTED
+
     def test_single_function_signature_change_no_finding(self) -> None:
         """A name that maps to exactly one function on both sides is not an
         overload set — a 1→1 signature change cannot re-route to a different

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -239,6 +239,20 @@ class TestOverloadSetRerouted:
         ])
         assert detect_overload_set_rerouted(old, new) == []
 
+    def test_single_function_signature_change_no_finding(self) -> None:
+        """A name that maps to exactly one function on both sides is not an
+        overload set — a 1→1 signature change cannot re-route to a different
+        overload, so it must not produce a spurious OVERLOAD_SET_REROUTED
+        finding (it is already reported as FUNC_PARAMS_CHANGED). This also
+        covers every plain C function, which can never be overloaded."""
+        old = _snap(funcs=[
+            _fn("add", mangled="add", params=[("a", "int"), ("b", "int")]),
+        ])
+        new = _snap(funcs=[
+            _fn("add", mangled="add", params=[("a", "long"), ("b", "int")]),
+        ])
+        assert detect_overload_set_rerouted(old, new) == []
+
 
 # ---------------------------------------------------------------------------
 # MANDATORY_TEMPLATE_PARAM_ADDED

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -245,11 +245,33 @@ class TestOverloadSetRerouted:
         set (e.g. `f(int)` + `f(int) const`) replaced by `f(long)` must still
         fire OVERLOAD_SET_REROUTED — the guard counts actual overloads, not
         distinct parameter-type tuples."""
+        f_const = _fn("lib::f", mangled="_ZNK3lib1fEi", params=[("a", "int")])
+        f_const.is_const = True
         old = _snap(funcs=[
             _fn("lib::f", mangled="_ZN3lib1fEi", params=[("a", "int")]),
-            _fn("lib::f", mangled="_ZNK3lib1fEi", params=[("a", "int")]),  # const
+            f_const,
         ])
         new = _snap(funcs=[
+            _fn("lib::f", mangled="_ZN3lib1fEl", params=[("a", "long")]),
+        ])
+        changes = detect_overload_set_rerouted(old, new)
+        assert len(changes) == 1
+        assert changes[0].kind == ChangeKind.OVERLOAD_SET_REROUTED
+
+    def test_cv_ref_only_removal_in_mixed_change_fires(self) -> None:
+        """Membership diff must use the cv/ref-aware overload key, not just
+        parameter-type tuples. {f(int), f(int) const} -> {f(int), f(long)}
+        removes the `const` overload and adds `f(long)`; with a param-only key
+        the shared `(int)` tuple would hide the removal and the reroute would be
+        missed. The const overload's disappearance must be detected."""
+        f_const = _fn("lib::f", mangled="_ZNK3lib1fEi", params=[("a", "int")])
+        f_const.is_const = True
+        old = _snap(funcs=[
+            _fn("lib::f", mangled="_ZN3lib1fEi", params=[("a", "int")]),
+            f_const,
+        ])
+        new = _snap(funcs=[
+            _fn("lib::f", mangled="_ZN3lib1fEi", params=[("a", "int")]),
             _fn("lib::f", mangled="_ZN3lib1fEl", params=[("a", "long")]),
         ])
         changes = detect_overload_set_rerouted(old, new)

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -11,7 +11,10 @@ Covers:
 from __future__ import annotations
 
 from abicheck.checker_policy import ChangeKind
-from abicheck.checker_types import Change
+from abicheck.checker_types import (
+    SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER,
+    Change,
+)
 from abicheck.diff_versioning import (
     _build_version_node_map,
     check_soname_bump_policy,
@@ -648,7 +651,12 @@ class TestVersionNodeBumpDeduplication:
             Change(
                 kind=ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED,
                 symbol="foo",
-                description="default version changed",
+                # Not-retained case (old default gone): genuinely redundant with
+                # the node move, so it carries the marker and is collapsed.
+                description=(
+                    "default version changed — "
+                    + SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER
+                ),
                 old_value="LLVM_17",
                 new_value="LLVM_18.1",
             ),
@@ -658,6 +666,34 @@ class TestVersionNodeBumpDeduplication:
         # The alias-change duplicate is dropped; the node-level change is kept
         # (one finding for one version-node bump, not two).
         assert kinds == [ChangeKind.SYMBOL_MOVED_VERSION_NODE]
+
+    def test_retained_alias_change_survives_matching_node_move(self) -> None:
+        from abicheck.diff_filtering import _deduplicate_cross_detector
+
+        # Old default is RETAINED as a non-default alias: the alias-change is
+        # compatible and distinct from the node move's "will not find" wording,
+        # so it must NOT be collapsed even though the transition matches.
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_MOVED_VERSION_NODE,
+                symbol="foo",
+                description="moved",
+                old_value="LIBA_1",
+                new_value="LIBA_2",
+            ),
+            Change(
+                kind=ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED,
+                symbol="foo",
+                description="Default symbol version changed: foo (@@LIBA_1 → @@LIBA_2)",
+                old_value="LIBA_1",
+                new_value="LIBA_2",
+            ),
+        ]
+        kept = _deduplicate_cross_detector(changes)
+        kinds = {c.kind for c in kept}
+        assert ChangeKind.SYMBOL_MOVED_VERSION_NODE in kinds
+        assert ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED in kinds
+        assert len(kept) == 2
 
     def test_moved_node_kept_without_matching_alias(self) -> None:
         from abicheck.diff_filtering import _deduplicate_cross_detector

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -629,3 +629,71 @@ class TestCheckerIntegration:
         result = compare(old, new)
         kinds = {c.kind for c in result.changes}
         assert ChangeKind.VERSION_SCRIPT_MISSING in kinds
+
+
+class TestVersionNodeBumpDeduplication:
+    """A version-node bump must not be double-counted per symbol."""
+
+    def test_moved_node_and_alias_change_deduplicated(self) -> None:
+        from abicheck.diff_filtering import _deduplicate_cross_detector
+
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_MOVED_VERSION_NODE,
+                symbol="foo",
+                description="moved",
+                old_value="LLVM_17",
+                new_value="LLVM_18.1",
+            ),
+            Change(
+                kind=ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED,
+                symbol="foo",
+                description="default version changed",
+                old_value="LLVM_17",
+                new_value="LLVM_18.1",
+            ),
+        ]
+        kept = _deduplicate_cross_detector(changes)
+        kinds = [c.kind for c in kept]
+        # The alias-change duplicate is dropped; the node-level change is kept
+        # (one finding for one version-node bump, not two).
+        assert kinds == [ChangeKind.SYMBOL_MOVED_VERSION_NODE]
+
+    def test_moved_node_kept_without_matching_alias(self) -> None:
+        from abicheck.diff_filtering import _deduplicate_cross_detector
+
+        # No alias change for this transition → the node move stands on its own.
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_MOVED_VERSION_NODE,
+                symbol="foo",
+                description="moved",
+                old_value="LIBA_1",
+                new_value="LIBA_2",
+            ),
+        ]
+        kept = _deduplicate_cross_detector(changes)
+        assert [c.kind for c in kept] == [ChangeKind.SYMBOL_MOVED_VERSION_NODE]
+
+    def test_moved_node_kept_when_alias_transition_differs(self) -> None:
+        from abicheck.diff_filtering import _deduplicate_cross_detector
+
+        # Alias change exists for the symbol but a different transition → keep both.
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_MOVED_VERSION_NODE,
+                symbol="foo",
+                description="moved",
+                old_value="LIBA_1",
+                new_value="LIBA_2",
+            ),
+            Change(
+                kind=ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED,
+                symbol="foo",
+                description="alias",
+                old_value="LIBA_1",
+                new_value="LIBA_3",
+            ),
+        ]
+        kept = _deduplicate_cross_detector(changes)
+        assert ChangeKind.SYMBOL_MOVED_VERSION_NODE in {c.kind for c in kept}

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -696,4 +696,8 @@ class TestVersionNodeBumpDeduplication:
             ),
         ]
         kept = _deduplicate_cross_detector(changes)
-        assert ChangeKind.SYMBOL_MOVED_VERSION_NODE in {c.kind for c in kept}
+        kinds = {c.kind for c in kept}
+        # Transitions differ, so both findings are kept (no de-duplication).
+        assert ChangeKind.SYMBOL_MOVED_VERSION_NODE in kinds
+        assert ChangeKind.SYMBOL_VERSION_ALIAS_CHANGED in kinds
+        assert len(kept) == 2

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -363,10 +363,12 @@ class TestCliPolicy:
     def test_policy_invalid_case_rejected(self, tmp_path: Any) -> None:
         from click.testing import CliRunner
 
-        from abicheck.cli import main
+        from abicheck.cli import _EXIT_USAGE_ERROR, main
         old_p, new_p = self._write_snapshots(tmp_path)
         result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "SDK_VENDOR"])
-        assert result.exit_code == 2
+        # Invalid option value → Click usage error, remapped to the dedicated
+        # usage-error code so it is not mistaken for a "2 = source break" verdict.
+        assert result.exit_code == _EXIT_USAGE_ERROR
 
     def test_policy_file_forwarded_to_compare(self, tmp_path: Any) -> None:
         from click.testing import CliRunner

--- a/tests/test_integer_abi_equivalence.py
+++ b/tests/test_integer_abi_equivalence.py
@@ -26,8 +26,32 @@ from __future__ import annotations
 import pytest
 
 from abicheck.checker import ChangeKind, Verdict, compare
-from abicheck.diff_symbols import _abi_equivalent_scalar
+from abicheck.diff_symbols import _abi_equivalent_scalar, _canonical_int_spelling
 from abicheck.model import AbiSnapshot, Function, Param, Visibility
+
+
+@pytest.mark.parametrize("spelling,expected", [
+    # Specifier-order / redundant-int variants fold to one canonical form.
+    ("unsigned long int", "unsigned long"),
+    ("long unsigned int", "unsigned long"),
+    ("int long unsigned", "unsigned long"),
+    ("signed long int", "long"),
+    ("long long unsigned int", "unsigned long long"),
+    ("signed long long int", "long long"),
+    ("unsigned short int", "unsigned short"),
+    ("signed int", "int"),
+    ("unsigned", "unsigned int"),
+    # char keeps its three distinct forms; bare ``char`` sign is impl-defined.
+    ("signed char", "signed char"),
+    ("unsigned char", "unsigned char"),
+    ("char", "char"),
+    # Non-specifier spellings (typedefs, fixed-width) pass through untouched.
+    ("size_t", "size_t"),
+    ("uint32_t", "uint32_t"),
+    ("", ""),
+])
+def test_canonical_int_spelling(spelling: str, expected: str) -> None:
+    assert _canonical_int_spelling(spelling) == expected
 
 
 @pytest.mark.parametrize("a,b", [

--- a/tests/test_integer_abi_equivalence.py
+++ b/tests/test_integer_abi_equivalence.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ABI-equivalent integer type changes must not be reported as binary breaks.
+
+On LP64, ``size_t`` is ``unsigned long`` and both ``long`` / ``long long`` are
+64-bit, so a name-only change between such spellings is not a binary ABI break.
+A real width change (``int`` -> ``size_t``) or a signedness change
+(``long`` -> ``unsigned long``) must still be reported.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.diff_symbols import _abi_equivalent_scalar
+from abicheck.model import AbiSnapshot, Function, Param, Visibility
+
+
+@pytest.mark.parametrize("a,b", [
+    ("long", "long long"),
+    ("long int", "long long int"),
+    ("unsigned long", "size_t"),
+    ("long unsigned int", "size_t"),
+    ("unsigned long", "uint64_t"),
+    ("long", "int64_t"),
+    ("int", "int32_t"),
+    ("unsigned int", "uint32_t"),
+])
+def test_lp64_equivalent(a: str, b: str) -> None:
+    assert _abi_equivalent_scalar(a, b, is_llp64=False)
+
+
+@pytest.mark.parametrize("a,b", [
+    ("int", "long"),                  # 32 vs 64
+    ("int", "size_t"),                # 32 vs 64
+    ("long", "unsigned long"),        # signedness differs
+    ("size_t", "ssize_t"),            # signedness differs
+    ("long*", "long long*"),          # pointers are not bare scalars
+    ("int", "float"),                 # float not modelled
+])
+def test_lp64_not_equivalent(a: str, b: str) -> None:
+    assert not _abi_equivalent_scalar(a, b, is_llp64=False)
+
+
+def test_llp64_long_vs_long_long_differs() -> None:
+    # On Windows LLP64 long is 32-bit, so long != long long there.
+    assert not _abi_equivalent_scalar("long", "long long", is_llp64=True)
+    # size_t stays pointer-width (64) on LLP64, unsigned long is 32 → differ.
+    assert not _abi_equivalent_scalar("unsigned long", "size_t", is_llp64=True)
+
+
+def _fn(ret: str) -> Function:
+    return Function(name="f", mangled="f", return_type=ret,
+                    params=[], visibility=Visibility.PUBLIC)
+
+
+def _snap(ver: str, ret: str) -> AbiSnapshot:
+    return AbiSnapshot(library="lib.so", version=ver, platform="elf",
+                       functions=[_fn(ret)])
+
+
+def test_return_long_to_long_long_compatible() -> None:
+    r = compare(_snap("1", "long"), _snap("2", "long long"))
+    assert ChangeKind.FUNC_RETURN_CHANGED not in {c.kind for c in r.changes}
+    assert r.verdict in (Verdict.NO_CHANGE, Verdict.COMPATIBLE)
+
+
+def test_return_int_to_size_t_still_breaking() -> None:
+    # 32 -> 64 bit is a real representation change.
+    r = compare(_snap("1", "int"), _snap("2", "size_t"))
+    assert ChangeKind.FUNC_RETURN_CHANGED in {c.kind for c in r.changes}
+
+
+def _fn_param(ptype: str) -> Function:
+    return Function(name="g", mangled="g", return_type="void",
+                    params=[Param(name="a", type=ptype)], visibility=Visibility.PUBLIC)
+
+
+def test_param_size_t_to_unsigned_long_compatible() -> None:
+    old = AbiSnapshot(library="l", version="1", platform="elf", functions=[_fn_param("size_t")])
+    new = AbiSnapshot(library="l", version="2", platform="elf", functions=[_fn_param("unsigned long")])
+    r = compare(old, new)
+    assert ChangeKind.FUNC_PARAMS_CHANGED not in {c.kind for c in r.changes}
+
+
+def test_param_int_to_long_still_breaking() -> None:
+    old = AbiSnapshot(library="l", version="1", platform="elf", functions=[_fn_param("int")])
+    new = AbiSnapshot(library="l", version="2", platform="elf", functions=[_fn_param("long")])
+    r = compare(old, new)
+    assert ChangeKind.FUNC_PARAMS_CHANGED in {c.kind for c in r.changes}

--- a/tests/test_integer_abi_equivalence.py
+++ b/tests/test_integer_abi_equivalence.py
@@ -31,35 +31,44 @@ from abicheck.model import AbiSnapshot, Function, Param, Visibility
 
 
 @pytest.mark.parametrize("a,b", [
-    ("long", "long long"),
-    ("long int", "long long int"),
+    # Pointer-width spellings co-vary on any non-LLP64 target (long == size).
     ("unsigned long", "size_t"),
     ("long unsigned int", "size_t"),
-    ("unsigned long", "uint64_t"),
-    ("long", "int64_t"),
+    ("size_t", "uintptr_t"),
+    ("long", "ptrdiff_t"),
+    ("ssize_t", "ptrdiff_t"),
+    ("long", "long int"),
+    # Fixed-width spellings, data-model independent.
     ("int", "int32_t"),
     ("unsigned int", "uint32_t"),
+    ("long long", "int64_t"),
+    ("unsigned long long", "uint64_t"),
 ])
-def test_lp64_equivalent(a: str, b: str) -> None:
+def test_nonllp64_equivalent(a: str, b: str) -> None:
     assert _abi_equivalent_scalar(a, b, is_llp64=False)
 
 
 @pytest.mark.parametrize("a,b", [
-    ("int", "long"),                  # 32 vs 64
-    ("int", "size_t"),                # 32 vs 64
+    ("int", "long"),                  # 32 vs pointer-width
+    ("int", "size_t"),                # 32 vs pointer-width
     ("long", "unsigned long"),        # signedness differs
     ("size_t", "ssize_t"),            # signedness differs
+    # Data-model-dependent vs fixed width: equal only on LP64, a real width
+    # change on ILP32 — and the snapshot does not record bitness, so these are
+    # conservatively reported rather than suppressed.
+    ("long", "long long"),
+    ("long", "int64_t"),
+    ("unsigned long", "uint64_t"),
     ("long*", "long long*"),          # pointers are not bare scalars
     ("int", "float"),                 # float not modelled
 ])
-def test_lp64_not_equivalent(a: str, b: str) -> None:
+def test_nonllp64_not_equivalent(a: str, b: str) -> None:
     assert not _abi_equivalent_scalar(a, b, is_llp64=False)
 
 
-def test_llp64_long_vs_long_long_differs() -> None:
-    # On Windows LLP64 long is 32-bit, so long != long long there.
+def test_llp64_differs() -> None:
+    # On Windows LLP64 long is 32-bit while size_t/pointer types stay 64-bit.
     assert not _abi_equivalent_scalar("long", "long long", is_llp64=True)
-    # size_t stays pointer-width (64) on LLP64, unsigned long is 32 → differ.
     assert not _abi_equivalent_scalar("unsigned long", "size_t", is_llp64=True)
 
 
@@ -68,20 +77,29 @@ def _fn(ret: str) -> Function:
                     params=[], visibility=Visibility.PUBLIC)
 
 
-def _snap(ver: str, ret: str) -> AbiSnapshot:
-    return AbiSnapshot(library="lib.so", version=ver, platform="elf",
+def _snap(ver: str, ret: str, platform: str = "elf") -> AbiSnapshot:
+    return AbiSnapshot(library="lib.so", version=ver, platform=platform,
                        functions=[_fn(ret)])
 
 
-def test_return_long_to_long_long_compatible() -> None:
-    r = compare(_snap("1", "long"), _snap("2", "long long"))
+def test_return_unsigned_long_to_size_t_compatible() -> None:
+    # size_t IS unsigned long on LP64 (and co-varies on ILP32) → not a break.
+    r = compare(_snap("1", "unsigned long"), _snap("2", "size_t"))
     assert ChangeKind.FUNC_RETURN_CHANGED not in {c.kind for c in r.changes}
     assert r.verdict in (Verdict.NO_CHANGE, Verdict.COMPATIBLE)
 
 
 def test_return_int_to_size_t_still_breaking() -> None:
-    # 32 -> 64 bit is a real representation change.
+    # 32 -> pointer-width is a real representation change.
     r = compare(_snap("1", "int"), _snap("2", "size_t"))
+    assert ChangeKind.FUNC_RETURN_CHANGED in {c.kind for c in r.changes}
+
+
+def test_return_long_to_long_long_reported_unknown_bitness() -> None:
+    # long vs long long is only ABI-equal on LP64; on ILP32 it is a real width
+    # change. The snapshot does not record bitness, so it is conservatively
+    # reported rather than silently suppressed.
+    r = compare(_snap("1", "long"), _snap("2", "long long"))
     assert ChangeKind.FUNC_RETURN_CHANGED in {c.kind for c in r.changes}
 
 
@@ -90,15 +108,39 @@ def _fn_param(ptype: str) -> Function:
                     params=[Param(name="a", type=ptype)], visibility=Visibility.PUBLIC)
 
 
+def _snap_param(ver: str, ptype: str, platform: str = "elf") -> AbiSnapshot:
+    return AbiSnapshot(library="l", version=ver, platform=platform,
+                       functions=[_fn_param(ptype)])
+
+
 def test_param_size_t_to_unsigned_long_compatible() -> None:
-    old = AbiSnapshot(library="l", version="1", platform="elf", functions=[_fn_param("size_t")])
-    new = AbiSnapshot(library="l", version="2", platform="elf", functions=[_fn_param("unsigned long")])
-    r = compare(old, new)
+    r = compare(_snap_param("1", "size_t"), _snap_param("2", "unsigned long"))
     assert ChangeKind.FUNC_PARAMS_CHANGED not in {c.kind for c in r.changes}
 
 
 def test_param_int_to_long_still_breaking() -> None:
-    old = AbiSnapshot(library="l", version="1", platform="elf", functions=[_fn_param("int")])
-    new = AbiSnapshot(library="l", version="2", platform="elf", functions=[_fn_param("long")])
-    r = compare(old, new)
+    r = compare(_snap_param("1", "int"), _snap_param("2", "long"))
     assert ChangeKind.FUNC_PARAMS_CHANGED in {c.kind for c in r.changes}
+
+
+# ── End-to-end LLP64 (platform="pe") — is_llp64 derived from snapshot ─────────
+
+def test_llp64_return_long_to_long_long_breaking() -> None:
+    r = compare(_snap("1", "long", platform="pe"), _snap("2", "long long", platform="pe"))
+    assert ChangeKind.FUNC_RETURN_CHANGED in {c.kind for c in r.changes}
+
+
+def test_llp64_return_unsigned_long_to_size_t_breaking() -> None:
+    # On LLP64 unsigned long is 32-bit but size_t is 64-bit → a real change.
+    r = compare(_snap("1", "unsigned long", platform="pe"), _snap("2", "size_t", platform="pe"))
+    assert ChangeKind.FUNC_RETURN_CHANGED in {c.kind for c in r.changes}
+
+
+def test_int_to_long_param_breaking_on_both_models() -> None:
+    # int vs long are distinct built-ins; the change is reported regardless of
+    # data model (mirrors examples/case102: a frozen extern-C signature widened
+    # from int to long must stay a FUNC_PARAMS_CHANGED on Windows too, where
+    # both are 32-bit).
+    for platform in ("elf", "pe"):
+        r = compare(_snap_param("1", "int", platform), _snap_param("2", "long", platform))
+        assert ChangeKind.FUNC_PARAMS_CHANGED in {c.kind for c in r.changes}, platform

--- a/tests/test_integer_abi_equivalence.py
+++ b/tests/test_integer_abi_equivalence.py
@@ -72,6 +72,23 @@ def test_llp64_differs() -> None:
     assert not _abi_equivalent_scalar("unsigned long", "size_t", is_llp64=True)
 
 
+@pytest.mark.parametrize("is_llp64", [False, True])
+def test_pointer_width_never_equated_with_fixed_width(is_llp64: bool) -> None:
+    # A pointer-width typedef has an unknown absolute width on every platform
+    # (32-bit on ILP32 / 32-bit Windows, 64-bit on LP64 / LLP64), so it must
+    # never be treated as ABI-equal to a fixed-width spelling such as uint64_t.
+    # On 32-bit Windows size_t is 32-bit, so equating it with uint64_t would be
+    # a false negative.
+    assert not _abi_equivalent_scalar("size_t", "uint64_t", is_llp64=is_llp64)
+    assert not _abi_equivalent_scalar("ptrdiff_t", "int64_t", is_llp64=is_llp64)
+
+
+def test_pointer_width_typedefs_equivalent_to_each_other() -> None:
+    # size_t and uintptr_t are both pointer-width unsigned on every platform.
+    assert _abi_equivalent_scalar("size_t", "uintptr_t", is_llp64=False)
+    assert _abi_equivalent_scalar("size_t", "uintptr_t", is_llp64=True)
+
+
 def _fn(ret: str) -> Function:
     return Function(name="f", mangled="f", return_type=ret,
                     params=[], visibility=Visibility.PUBLIC)
@@ -136,11 +153,11 @@ def test_llp64_return_unsigned_long_to_size_t_breaking() -> None:
     assert ChangeKind.FUNC_RETURN_CHANGED in {c.kind for c in r.changes}
 
 
-def test_int_to_long_param_breaking_on_both_models() -> None:
+@pytest.mark.parametrize("platform", ["elf", "pe"])
+def test_int_to_long_param_breaking_on_both_models(platform: str) -> None:
     # int vs long are distinct built-ins; the change is reported regardless of
     # data model (mirrors examples/case102: a frozen extern-C signature widened
     # from int to long must stay a FUNC_PARAMS_CHANGED on Windows too, where
     # both are 32-bit).
-    for platform in ("elf", "pe"):
-        r = compare(_snap_param("1", "int", platform), _snap_param("2", "long", platform))
-        assert ChangeKind.FUNC_PARAMS_CHANGED in {c.kind for c in r.changes}, platform
+    r = compare(_snap_param("1", "int", platform), _snap_param("2", "long", platform))
+    assert ChangeKind.FUNC_PARAMS_CHANGED in {c.kind for c in r.changes}, platform

--- a/tests/test_integer_abi_equivalence.py
+++ b/tests/test_integer_abi_equivalence.py
@@ -89,6 +89,28 @@ def test_pointer_width_typedefs_equivalent_to_each_other() -> None:
     assert _abi_equivalent_scalar("size_t", "uintptr_t", is_llp64=True)
 
 
+@pytest.mark.parametrize("a,b", [
+    # Legal specifier-order / redundant-``int`` variants are the same type:
+    # different toolchains spell them differently and it is not an ABI change.
+    ("size_t", "unsigned long int"),       # vs GCC's "long unsigned int"
+    ("unsigned long", "unsigned long int"),
+    ("uint16_t", "unsigned short int"),
+    ("uint64_t", "unsigned long long int"),
+    ("int64_t", "signed long long int"),
+    ("ptrdiff_t", "signed long int"),
+    ("size_t", "int long unsigned"),       # arbitrary specifier order
+])
+def test_specifier_order_variants_equivalent_nonllp64(a: str, b: str) -> None:
+    assert _abi_equivalent_scalar(a, b, is_llp64=False)
+
+
+def test_specifier_order_variants_still_distinguish_real_changes() -> None:
+    # Normalization must not collapse genuinely different widths/signs.
+    assert not _abi_equivalent_scalar("unsigned long int", "unsigned int", is_llp64=False)
+    assert not _abi_equivalent_scalar("unsigned long int", "long int", is_llp64=False)
+    assert not _abi_equivalent_scalar("unsigned short int", "unsigned long long int", is_llp64=False)
+
+
 def _fn(ret: str) -> Function:
     return Function(name="f", mangled="f", return_type=ret,
                     params=[], visibility=Visibility.PUBLIC)

--- a/tests/test_nested_struct_tag.py
+++ b/tests/test_nested_struct_tag.py
@@ -128,6 +128,53 @@ class TestNestedStructTagNormalization:
         kinds = {c.kind for c in changes}
         assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED not in kinds
 
+    def test_anonymous_member_type_name_mismatch_not_a_change(self) -> None:
+        """An anonymous union member named "<unnamed-tag>" by one reader and
+        "Parent::<unnamed-type-u>" by another (same size) must NOT emit
+        STRUCT_FIELD_TYPE_CHANGED — the placeholder names have no stable
+        identity. (Mirrors the Windows SDK _TP_CALLBACK_ENVIRON_V3::u case that
+        differs between two MSVC builds.)"""
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
+
+        old_meta = self._make_meta("_TP_CALLBACK_ENVIRON_V3", "u", "<unnamed-tag>")
+        new_meta = self._make_meta(
+            "_TP_CALLBACK_ENVIRON_V3", "u", "_TP_CALLBACK_ENVIRON_V3::<unnamed-type-u>"
+        )
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED not in kinds, (
+            "anonymous-member placeholder rename must not be a field type change"
+        )
+
+    def test_anonymous_member_size_drift_still_detected(self) -> None:
+        """A genuine size change of an anonymous member is still caught (the
+        name collapse only suppresses unstable-name noise, not real drift)."""
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
+
+        old_meta = DwarfMetadata(
+            structs={"Outer": StructLayout(name="Outer", byte_size=8, fields=[
+                FieldInfo(name="u", type_name="<unnamed-tag>", byte_offset=0, byte_size=4)])},
+            has_dwarf=True,
+        )
+        new_meta = DwarfMetadata(
+            structs={"Outer": StructLayout(name="Outer", byte_size=8, fields=[
+                FieldInfo(name="u", type_name="<unnamed-type-u>", byte_offset=0, byte_size=8)])},
+            has_dwarf=True,
+        )
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds, (
+            "size drift of an anonymous member must still be reported"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Reserved-field reuse: type matching (architecture review fix #4)

--- a/tests/test_nested_struct_tag.py
+++ b/tests/test_nested_struct_tag.py
@@ -193,6 +193,24 @@ class TestNestedStructTagNormalization:
             "anonymous union → anonymous struct must still be a field type change"
         )
 
+    def test_anonymous_kind_change_with_leading_tag_still_detected(self) -> None:
+        """The aggregate kind may sit *before* the placeholder ("union
+        <anonymous>"); the leading tag, stripped by the tag-keyword
+        normalization, must still drive the kind so union → struct is reported."""
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
+
+        old_meta = self._make_meta("Outer", "u", "union <anonymous>")
+        new_meta = self._make_meta("Outer", "u", "struct <anonymous>")
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds, (
+            "leading-tag 'union <anonymous>' → 'struct <anonymous>' must be detected"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Reserved-field reuse: type matching (architecture review fix #4)

--- a/tests/test_nested_struct_tag.py
+++ b/tests/test_nested_struct_tag.py
@@ -175,6 +175,24 @@ class TestNestedStructTagNormalization:
             "size drift of an anonymous member must still be reported"
         )
 
+    def test_anonymous_aggregate_kind_change_still_detected(self) -> None:
+        """A same-size anonymous *kind* change (union → struct) is ABI-relevant
+        and must still be reported — the placeholder collapse preserves the
+        aggregate keyword, so it is not masked."""
+        from abicheck.checker import (
+            ChangeKind,
+            _diff_struct_layouts,  # type: ignore[attr-defined]
+        )
+
+        old_meta = self._make_meta("Outer", "u", "<anonymous union>")
+        new_meta = self._make_meta("Outer", "u", "<anonymous struct>")
+
+        changes = _diff_struct_layouts(old_meta, new_meta)
+        kinds = {c.kind for c in changes}
+        assert ChangeKind.STRUCT_FIELD_TYPE_CHANGED in kinds, (
+            "anonymous union → anonymous struct must still be a field type change"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Reserved-field reuse: type matching (architecture review fix #4)

--- a/tests/test_reproducible_dump.py
+++ b/tests/test_reproducible_dump.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SOURCE_DATE_EPOCH support for reproducible snapshot timestamps."""
+
+from __future__ import annotations
+
+from abicheck.cli import _provenance_timestamp
+
+
+def test_source_date_epoch_fixed() -> None:
+    # 2021-01-01T00:00:00Z
+    assert _provenance_timestamp("1609459200") == "2021-01-01T00:00:00+00:00"
+
+
+def test_source_date_epoch_deterministic() -> None:
+    assert _provenance_timestamp("1700000000") == _provenance_timestamp("1700000000")
+
+
+def test_source_date_epoch_whitespace_tolerated() -> None:
+    assert _provenance_timestamp("  1609459200\n") == "2021-01-01T00:00:00+00:00"
+
+
+def test_malformed_epoch_falls_back_to_now() -> None:
+    # Non-numeric → current time (just assert it produces a valid ISO string,
+    # not the fixed epoch).
+    out = _provenance_timestamp("not-a-number")
+    assert out and out != "2021-01-01T00:00:00+00:00"
+
+
+def test_unset_epoch_uses_now() -> None:
+    out = _provenance_timestamp(None)
+    assert out  # current wall-clock ISO timestamp

--- a/tests/test_reproducible_dump.py
+++ b/tests/test_reproducible_dump.py
@@ -40,6 +40,13 @@ def test_malformed_epoch_falls_back_to_now() -> None:
     assert out and out != "2021-01-01T00:00:00+00:00"
 
 
+def test_out_of_range_epoch_falls_back_to_now() -> None:
+    # An absurd out-of-range epoch makes datetime.fromtimestamp raise
+    # OverflowError/OSError; it must fall back rather than abort the dump.
+    out = _provenance_timestamp("99999999999999999999")
+    assert out and out != "2021-01-01T00:00:00+00:00"
+
+
 def test_unset_epoch_uses_now() -> None:
     out = _provenance_timestamp(None)
     assert out  # current wall-clock ISO timestamp


### PR DESCRIPTION
## Summary

Found by scanning **real** binaries — 931 system shared libraries, 437 `/usr/bin` ELF executables, genuine cross-version `libLLVM` 17/18/20 release diffs, ~300 Ubuntu 22.04→24.04 library version pairs, and purpose-built GCC libraries. This PR fixes the false-positive classes and ABI-checking issues that surfaced, each with regression tests.

## Robustness confirmed (no bugs)
- `dump` over 459 distinct real `.so` → 0 crashes; `deps` over 437 ELF executables → 0 failures.
- Self-compare oracle over 459 libs → 0 false-positive diffs.
- All output formats (json/markdown/sarif/junit/html) render and validate.

## Detector false-positive fixes

**1. `OVERLOAD_SET_REROUTED` mis-fired on non-overloaded / 1→1 signature changes.** Plain C functions (which can't be overloaded) and any single function whose signature changed were flagged with a spurious RISK finding that double-counted the change. Now requires a genuine overload set (≥2 overloads under the same name), with a cv/ref-aware overload key so member overloads differing only by `const`/`volatile`/ref-qualifier are counted correctly.

**2. Hash-less rename detection paired unrelated functions by size alone.** In snapshot/elf_only mode there are no code bytes, so renames were inferred purely from a coincidental symbol-size collision. On libLLVM 17→18 this manufactured **137** "likely renamed" findings, ~**105** of them nonsense (`fixupIndexV4`→`SmallVectorImpl<…>`). Now gated on unqualified-name similarity that participates in candidate *selection*, with the name signal hardened across review against operators, constructors/destructors, templates/specializations, same-name parameter changes, embedded `operator` substrings, and undemangleable raw mangled names — all verified by tests. Drops the 105 bogus pairings while keeping all 32 real namespace moves.

## ABI-checking issues fixed (previously documented for follow-up)

**3. Same-width integer type changes were flagged as binary BREAKING.** `unsigned long` → `size_t` and `long` → `long long` are byte-identical on LP64, yet were reported as binary breaks (inconsistent with `diff_integer_model`, which already buckets them together). A data-model-aware scalar model (width + signedness, `long` family resolved per LP64/LLP64) now treats ABI-equivalent integer return/param changes as compatible. Real width changes (`int`→`size_t`) and signedness changes (`long`→`unsigned long`) are still reported; PE/LLP64 keeps `long` 32-bit.

**4. `compare` exit-code 2 collided with usage errors.** Click exits 2 for bad arguments/options/paths — identical to compare's documented `2 = source break`, so CI couldn't tell an invalid invocation from a verdict. Usage errors now map to **64** (sysexits `EX_USAGE`), outside the result space `{0,1,2,4}`. Verdict exits and the `compat` 3–11 scheme are untouched; documented in the compare help.

**5. Non-reproducible dumps.** `dump` embedded a wall-clock `created_at`, so two dumps of an identical library were never byte-identical (defeating content-addressable caching / reproducible builds). `created_at` now honours **`SOURCE_DATE_EPOCH`**; verified two such dumps of libexpat are byte-identical.

**6. Version-node bump double-counting.** A routine symbol-version namespace bump (`LLVM_17`→`LLVM_18.1`) made both `SYMBOL_MOVED_VERSION_NODE` and `SYMBOL_VERSION_ALIAS_CHANGED` fire per symbol — ~46k of each (~92k redundant RISK findings) on libLLVM 17→18. De-duplicated to the node-level finding; total findings on that diff drop 107,664 → 61,420.

## Validation
Full fast suite **7156 passed**; `ruff`, `mypy`, `scripts/check_ai_readiness.py` (0 errors) all clean. All review comments from Codex and CodeRabbit addressed with fixes + tests.

https://claude.ai/code/session_01XQh3HrJF7s7vaLeKpWesPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognize platform data-model differences for certain integer-type name changes; CLI supports reproducible snapshot timestamps and remapped usage-error exit behavior.

* **Bug Fixes**
  * Reduce false-positive renames via name-plausibility checks; improve overload-set reporting to respect cv/ref qualifiers; suppress redundant version-change noise; tighten matching logic for size-only/fuzzy rename selection.

* **Tests**
  * Extensive new tests for rename heuristics, integer-ABI equivalence, overload detection, CLI exit behavior, and reproducible timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->