### PR TITLE
docs: fix stale counts and first-run onboarding gaps from user-perspective review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ CI runs `mypy abicheck/` as a required gate. The baseline is currently **0 error
 | `changekind-partition` | ERROR | Every `ChangeKind` is in exactly one of `BREAKING_KINDS` / `API_BREAK_KINDS` / `COMPATIBLE_KINDS` / `RISK_KINDS` |
 | `changekind-detector` | WARN | Every `ChangeKind` is produced somewhere (not orphaned) |
 | `changekind-docs` | WARN | Every `ChangeKind` is mentioned in `docs/` |
+| `doc-count-sync` | ERROR on drift, WARN if anchor moved | Headline counts in docs (ChangeKind count, example-catalog size) match their source of truth (`len(ChangeKind)`, `ground_truth.json`) |
 | `import-cycles` | ERROR | No import cycles within `abicheck/` |
 | `mypy-baseline` | ERROR if drifted up | mypy error count ≤ documented baseline |
 | `examples-ground-truth` | ERROR | Every `examples/case*/` has a `README.md` and an entry in `ground_truth.json` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## What is abicheck?
 
 ABI compatibility checker for C/C++ shared libraries. Pure Python (3.10+).
-Detects 145 ABI/API change types across ELF, PE/COFF, and Mach-O binaries,
+Detects 183 ABI/API change types across ELF, PE/COFF, and Mach-O binaries,
 categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, and `RISK_KINDS` (see `ChangeKind`).
 Drop-in replacement for abi-compliance-checker (ABICC).
 
@@ -104,7 +104,7 @@ Core pipeline (in order of data flow):
 
 - `AbiSnapshot` (`model.py`) — serializable snapshot of a library's ABI surface
 - `DiffResult` (`checker_types.py`) — single detected change with kind, severity, details
-- `ChangeKind` (`checker_policy.py`) — enum of 145 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
+- `ChangeKind` (`checker_policy.py`) — enum of 183 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
 - `Verdict` (`checker.py`) — overall comparison result (compatible/source_break/breaking)
 - `LibraryMetadata` (`checker.py`) — parsed library info
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **145 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
+It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **183 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary and header AST analysis on all platforms; debug-info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 
@@ -144,13 +144,13 @@ See `abicheck.service` for the full signature, plus the [MCP server integration]
 
 ## Examples
 
-The [`examples/`](examples/README.md) directory contains **74 real-world ABI scenarios** — each with paired `v1`/`v2` source, a consumer app that demonstrates the actual failure, and a ground-truth verdict. These drive the validation snapshot below.
+The [`examples/`](examples/README.md) directory contains **121 real-world ABI/API scenarios** (116 single-library cases plus 5 multi-library bundle cases) — each with paired `v1`/`v2` source, a consumer app that demonstrates the actual failure, and a ground-truth verdict. A pinned **74-case subset** drives the reproducible validation snapshot below.
 
 ---
 
 ## Validation snapshot
 
-Accuracy on the full 74-case catalog (`01–73` + `26b`):
+Accuracy on the pinned 74-case benchmark subset (`01–73` + `26b`, drawn from the full 121-case catalog):
 
 | Configuration | Exact verdict accuracy | Scan status |
 |---|---:|---|

--- a/docs/concepts/abi-breaks-explained.md
+++ b/docs/concepts/abi-breaks-explained.md
@@ -1,6 +1,6 @@
 # Examples & Breakage Guide
 
-The `examples/` directory contains real-world ABI/API break scenarios — 74
+The `examples/` directory contains real-world ABI/API break scenarios — 121
 cases in total. Each case has paired `v1`/`v2` source files, a consumer
 (`app.c`/`app.cpp`), a CMake build, expected verdicts, and a `README.md`
 walkthrough. Run any case yourself:
@@ -26,7 +26,7 @@ For the complete list of detected change types, see the
     [by category](../examples/index.md#browse-by-category).
 
 The sections below give a *conceptual* tour of the major break families with
-representative cases. For the full catalog (all 74 cases, kept in sync
+representative cases. For the full catalog (all 116 documented cases, kept in sync
 automatically), use the Encyclopedia.
 
 ## Categories

--- a/docs/concepts/breaking-cases-catalog.md
+++ b/docs/concepts/breaking-cases-catalog.md
@@ -1,16 +1,16 @@
 # ABI Breaking Cases Catalog
 
-This catalog summarizes the **breakage patterns** behind the 74 cases under
-`examples/`. It groups cases into thematic clusters with a short description of
+This catalog summarizes the **breakage patterns** behind the 116 documented cases
+under `examples/`. It groups cases into thematic clusters with a short description of
 the risk, type, and mitigation pattern — useful for skimming the design space.
 
 For full per-case walkthroughs (code, runtime demo, fix), see the auto-generated
 **[Examples & Case Encyclopedia](../examples/index.md)**. That tree is regenerated
 from `examples/ground_truth.json` and per-case `README.md` files on every doc
-build, so it always reflects all 74 cases. The conceptual narrative — *why* ABI
+build, so it always reflects all 116 documented cases. The conceptual narrative — *why* ABI
 breaks happen — lives in [ABI Breaks Explained](abi-breaks-explained.md).
 
-For the complete list of 145 detected change types, see the
+For the complete list of 183 detected change types, see the
 [Change Kind Reference](../reference/change-kinds.md).
 
 ## 1) Symbol/API surface breaks

--- a/docs/development/adr/019-testing-strategy.md
+++ b/docs/development/adr/019-testing-strategy.md
@@ -102,7 +102,7 @@ This means:
 
 ### Example cases as tests
 
-74 real-world ABI/API scenario cases in `examples/` serve dual purpose:
+121 real-world ABI/API scenario cases in `examples/` serve dual purpose:
 
 1. **Documentation**: Each case has `README.md` with scenario description,
    expected break type, and detection evidence
@@ -178,7 +178,7 @@ tests/
   abicheck's own Tier 2 test suite provides the primary safety net
 - Conditional gating means parity regressions can land if changes don't
   touch gated paths
-- 74 example cases require C/C++ compilation, adding CI complexity
+- 121 example cases require C/C++ compilation, adding CI complexity
 
 ---
 
@@ -186,5 +186,5 @@ tests/
 
 - `.github/workflows/ci.yml` — CI pipeline definition
 - `tests/` — Test directory (120+ files, 2500+ tests)
-- `examples/` — 74 real-world ABI/API scenario cases
+- `examples/` — 121 real-world ABI/API scenario cases
 - `pyproject.toml` — pytest markers, coverage configuration

--- a/docs/examples/by-category/addition.md
+++ b/docs/examples/by-category/addition.md
@@ -10,10 +10,10 @@ _10 case(s)._ [← back to all examples](../index.md)
 | [case03_compat_addition](../case03_compat_addition.md) | Compatible Addition (New Export) | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case105_concept_tightening](../case105_concept_tightening.md) | Concept Tightening (C++20) | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case111_enumerable_thread_specific_lambda_ambiguity](../case111_enumerable_thread_specific_lambda_ambiguity.md) | enumerable_thread_specific Lambda-Init Ambiguity | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case16_inline_to_non_inline](../case16_inline_to_non_inline.md) | Case 16 — Inline → Non-inline (ODR / Symbol Appearance) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case25_enum_member_added](../case25_enum_member_added.md) | Case 25 — Enum Member Added | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case26b_union_field_added_compatible](../case26b_union_field_added_compatible.md) | Case 26b — Union Field Added (No Size Change) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case16_inline_to_non_inline](../case16_inline_to_non_inline.md) | Inline → Non-inline (ODR / Symbol Appearance) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case25_enum_member_added](../case25_enum_member_added.md) | Enum Member Added | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case26b_union_field_added_compatible](../case26b_union_field_added_compatible.md) | Union Field Added (No Size Change) | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case47_inline_to_outlined](../case47_inline_to_outlined.md) | Inline Function Moved to Outlined | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case61_var_added](../case61_var_added.md) | Global Variable Added | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case62_type_field_added_compatible](../case62_type_field_added_compatible.md) | Type Field Added (Compatible — Opaque Struct) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case99_experimental_graduated](../case99_experimental_graduated.md) | case99 — experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case99_experimental_graduated](../case99_experimental_graduated.md) | experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |

--- a/docs/examples/by-category/api_break.md
+++ b/docs/examples/by-category/api_break.md
@@ -8,6 +8,6 @@ _4 case(s)._ [← back to all examples](../index.md)
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
 | [case106_ctor_became_explicit](../case106_ctor_became_explicit.md) | Conversion Operator Became `explicit` | 🟠 API_BREAK | API Break |
-| [case31_enum_rename](../case31_enum_rename.md) | Case 31 — Enum Member Rename | 🟠 API_BREAK | API Break |
-| [case34_access_level](../case34_access_level.md) | Case 34 — Access Level Changed | 🟠 API_BREAK | API Break |
+| [case31_enum_rename](../case31_enum_rename.md) | Enum Member Rename | 🟠 API_BREAK | API Break |
+| [case34_access_level](../case34_access_level.md) | Access Level Changed | 🟠 API_BREAK | API Break |
 | [case96_hidden_friend_removed](../case96_hidden_friend_removed.md) | Hidden Friend Operator Removed | 🟠 API_BREAK | API Break |

--- a/docs/examples/by-category/breaking.md
+++ b/docs/examples/by-category/breaking.md
@@ -13,8 +13,8 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case07_struct_layout](../case07_struct_layout.md) | Struct Layout Change | 🔴 BREAKING | Breaking |
 | [case08_enum_value_change](../case08_enum_value_change.md) | Enum Value Change | 🔴 BREAKING | Breaking |
 | [case09_cpp_vtable](../case09_cpp_vtable.md) | C++ Vtable Change | 🔴 BREAKING | Breaking |
-| [case100_experimental_removed_without_replacement](../case100_experimental_removed_without_replacement.md) | : removed without replacement (API break) | 🔴 BREAKING | Breaking |
-| [case101_inline_namespace_version_bumped](../case101_inline_namespace_version_bumped.md) | case101 — inline namespace version bumped (BREAKING) | 🔴 BREAKING | Breaking |
+| [case100_experimental_removed_without_replacement](../case100_experimental_removed_without_replacement.md) | experimental:: removed without replacement (API break) | 🔴 BREAKING | Breaking |
+| [case101_inline_namespace_version_bumped](../case101_inline_namespace_version_bumped.md) | inline namespace version bumped (BREAKING) | 🔴 BREAKING | Breaking |
 | [case102_frozen_runtime_signature_changed](../case102_frozen_runtime_signature_changed.md) | Frozen Runtime Signature Changed (oneTBB `detail::r1` shape) | 🔴 BREAKING | Breaking |
 | [case104_glibcxx_dual_abi_flip](../case104_glibcxx_dual_abi_flip.md) | libstdc++ dual-ABI flip (`glibcxx_dual_abi_flip_detected`) | 🔴 BREAKING | Breaking |
 | [case107_task_scheduler_init_removed](../case107_task_scheduler_init_removed.md) | `task_scheduler_init` Removed (historical ABI break) | 🔴 BREAKING | Breaking |
@@ -31,21 +31,21 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case11_global_var_type](../case11_global_var_type.md) | Global Variable Type Change | 🔴 BREAKING | Breaking |
 | [case12_function_removed](../case12_function_removed.md) | Function Removed from Shared Library | 🔴 BREAKING | Breaking |
 | [case14_cpp_class_size](../case14_cpp_class_size.md) | C++ Class Size Change | 🔴 BREAKING | Breaking |
-| [case17_template_abi](../case17_template_abi.md) | Case 17 — Template Instantiation ABI Change | 🔴 BREAKING | Breaking |
-| [case18_dependency_leak](../case18_dependency_leak.md) | Case 18 — Dependency ABI Leak | 🔴 BREAKING | Breaking |
-| [case19_enum_member_removed](../case19_enum_member_removed.md) | Case 19 — Enum Member Removed | 🔴 BREAKING | Breaking |
-| [case20_enum_member_value_changed](../case20_enum_member_value_changed.md) | Case 20 — Enum Member Value Changed | 🔴 BREAKING | Breaking |
-| [case21_method_became_static](../case21_method_became_static.md) | Case 21 — Method Became Static | 🔴 BREAKING | Breaking |
-| [case22_method_const_changed](../case22_method_const_changed.md) | Case 22 — Method Const Qualifier Changed | 🔴 BREAKING | Breaking |
-| [case23_pure_virtual_added](../case23_pure_virtual_added.md) | Case 23 — Virtual Method Became Pure Virtual | 🔴 BREAKING | Breaking |
-| [case24_union_field_removed](../case24_union_field_removed.md) | Case 24 — Union Field Removed | 🔴 BREAKING | Breaking |
-| [case26_union_field_added](../case26_union_field_added.md) | Case 26 — Union Field Added | 🔴 BREAKING | Breaking |
-| [case28_typedef_opaque](../case28_typedef_opaque.md) | Case 28 — Typedef and Opaque Type Changes | 🔴 BREAKING | Breaking |
-| [case30_field_qualifiers](../case30_field_qualifiers.md) | Case 30 — Field Qualifier Changes (const, volatile) | 🔴 BREAKING | Breaking |
-| [case33_pointer_level](../case33_pointer_level.md) | Case 33 -- Pointer Level Change | 🔴 BREAKING | Breaking |
-| [case35_field_rename](../case35_field_rename.md) | Case 35 -- Field Rename | 🔴 BREAKING | Breaking |
-| [case36_anon_struct](../case36_anon_struct.md) | Case 36 -- Anonymous Struct/Union Change | 🔴 BREAKING | Breaking |
-| [case37_base_class](../case37_base_class.md) | Case 37 -- Base Class Changes | 🔴 BREAKING | Breaking |
+| [case17_template_abi](../case17_template_abi.md) | Template Instantiation ABI Change | 🔴 BREAKING | Breaking |
+| [case18_dependency_leak](../case18_dependency_leak.md) | Dependency ABI Leak | 🔴 BREAKING | Breaking |
+| [case19_enum_member_removed](../case19_enum_member_removed.md) | Enum Member Removed | 🔴 BREAKING | Breaking |
+| [case20_enum_member_value_changed](../case20_enum_member_value_changed.md) | Enum Member Value Changed | 🔴 BREAKING | Breaking |
+| [case21_method_became_static](../case21_method_became_static.md) | Method Became Static | 🔴 BREAKING | Breaking |
+| [case22_method_const_changed](../case22_method_const_changed.md) | Method Const Qualifier Changed | 🔴 BREAKING | Breaking |
+| [case23_pure_virtual_added](../case23_pure_virtual_added.md) | Virtual Method Became Pure Virtual | 🔴 BREAKING | Breaking |
+| [case24_union_field_removed](../case24_union_field_removed.md) | Union Field Removed | 🔴 BREAKING | Breaking |
+| [case26_union_field_added](../case26_union_field_added.md) | Union Field Added | 🔴 BREAKING | Breaking |
+| [case28_typedef_opaque](../case28_typedef_opaque.md) | Typedef and Opaque Type Changes | 🔴 BREAKING | Breaking |
+| [case30_field_qualifiers](../case30_field_qualifiers.md) | Field Qualifier Changes (const, volatile) | 🔴 BREAKING | Breaking |
+| [case33_pointer_level](../case33_pointer_level.md) | - Pointer Level Change | 🔴 BREAKING | Breaking |
+| [case35_field_rename](../case35_field_rename.md) | - Field Rename | 🔴 BREAKING | Breaking |
+| [case36_anon_struct](../case36_anon_struct.md) | - Anonymous Struct/Union Change | 🔴 BREAKING | Breaking |
+| [case37_base_class](../case37_base_class.md) | - Base Class Changes | 🔴 BREAKING | Breaking |
 | [case38_virtual_methods](../case38_virtual_methods.md) | Virtual Method Changes | 🔴 BREAKING | Breaking |
 | [case39_var_const](../case39_var_const.md) | Variable Const Change | 🔴 BREAKING | Breaking |
 | [case40_field_layout](../case40_field_layout.md) | Field Layout Changes | 🔴 BREAKING | Breaking |
@@ -83,10 +83,10 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case80_pimpl_shared_to_unique](../case80_pimpl_shared_to_unique.md) | Pimpl alias changed from `shared_ptr` to `unique_ptr` | 🔴 BREAKING | Breaking |
 | [case81_serialization_tag_reassigned](../case81_serialization_tag_reassigned.md) | Serialization tag ID reassigned | 🔴 BREAKING | Breaking |
 | [case82_sycl_overload_set_removed](../case82_sycl_overload_set_removed.md) | SYCL overload set removed (DPC++ build withdrawn) | 🔴 BREAKING | Breaking |
-| [case85_internal_template_signature_changed](../case85_internal_template_signature_changed.md) | case85 — internal function-template signature leaks via public API (BREAKING) | 🔴 BREAKING | Breaking |
+| [case85_internal_template_signature_changed](../case85_internal_template_signature_changed.md) | internal function-template signature leaks via public API (BREAKING) | 🔴 BREAKING | Breaking |
 | [case86_tag_struct_renamed](../case86_tag_struct_renamed.md) | Tag struct renamed (empty class re-mangling) | 🔴 BREAKING | Breaking |
 | [case87_default_template_arg_changed](../case87_default_template_arg_changed.md) | Default template argument changed | 🔴 BREAKING | Breaking |
-| [case88_cpo_kind_changed](../case88_cpo_kind_changed.md) | case88 — CPO kind changed (BREAKING) | 🔴 BREAKING | Breaking |
+| [case88_cpo_kind_changed](../case88_cpo_kind_changed.md) | CPO kind changed (BREAKING) | 🔴 BREAKING | Breaking |
 | [case89_inline_accessor_renamed_pimpl_member](../case89_inline_accessor_renamed_pimpl_member.md) | Inline accessor references renamed pimpl member | 🔴 BREAKING | Breaking |
 | [case94_empty_tag_gained_state](../case94_empty_tag_gained_state.md) | Empty Tag Gained State | 🔴 BREAKING | Breaking |
 | [case95_allocator_nested_typedef_removed](../case95_allocator_nested_typedef_removed.md) | Allocator Nested-Typedef Removed | 🔴 BREAKING | Breaking |

--- a/docs/examples/by-category/no_change.md
+++ b/docs/examples/by-category/no_change.md
@@ -11,5 +11,5 @@ _6 case(s)._ [← back to all examples](../index.md)
 | [case118_internal_struct_field_added_scoped](../case118_internal_struct_field_added_scoped.md) | Internal struct gains a field (non-public, scoped) | ✅ NO_CHANGE | No Change |
 | [case119_internal_struct_field_removed_scoped](../case119_internal_struct_field_removed_scoped.md) | Internal struct loses a field (non-public, scoped) | ✅ NO_CHANGE | No Change |
 | [case120_internal_struct_reordered_scoped](../case120_internal_struct_reordered_scoped.md) | Internal struct fields reordered (non-public, scoped) | ✅ NO_CHANGE | No Change |
-| [case32_param_defaults](../case32_param_defaults.md) | Case 32 — Parameter Default Value Changes (C++) | ✅ NO_CHANGE | No Change |
-| [case98_cxx_standard_floor_raised](../case98_cxx_standard_floor_raised.md) | NO_CHANGE) | ✅ NO_CHANGE | No Change |
+| [case32_param_defaults](../case32_param_defaults.md) | Parameter Default Value Changes (C++) | ✅ NO_CHANGE | No Change |
+| [case98_cxx_standard_floor_raised](../case98_cxx_standard_floor_raised.md) | C++ standard floor raised (per-binary: NO_CHANGE) | ✅ NO_CHANGE | No Change |

--- a/docs/examples/by-category/quality.md
+++ b/docs/examples/by-category/quality.md
@@ -10,11 +10,11 @@ _11 case(s)._ [← back to all examples](../index.md)
 | [case05_soname](../case05_soname.md) | Missing SONAME | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case103_toolchain_flag_drift](../case103_toolchain_flag_drift.md) | Toolchain flag drift (`toolchain_flag_drift`) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case13_symbol_versioning](../case13_symbol_versioning.md) | Symbol Versioning Script | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case27_symbol_binding_weakened](../case27_symbol_binding_weakened.md) | Case 27 — Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case29_ifunc_transition](../case29_ifunc_transition.md) | Case 29 — GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case27_symbol_binding_weakened](../case27_symbol_binding_weakened.md) | Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case29_ifunc_transition](../case29_ifunc_transition.md) | GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case49_executable_stack](../case49_executable_stack.md) | Executable Stack (GNU_STACK RWX) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case50_soname_inconsistent](../case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case51_protected_visibility](../case51_protected_visibility.md) | Protected Visibility (DEFAULT to PROTECTED) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case52_rpath_leak](../case52_rpath_leak.md) | RPATH Leak (Hardcoded Build Directory) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case54_used_reserved_field](../case54_used_reserved_field.md) | Used Reserved Field | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | case97 — public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |

--- a/docs/examples/by-category/risk.md
+++ b/docs/examples/by-category/risk.md
@@ -7,5 +7,5 @@ _2 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
-| [case15_noexcept_change](../case15_noexcept_change.md) | Case 15 — `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
+| [case15_noexcept_change](../case15_noexcept_change.md) | `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
 | [case83_cpu_dispatch_isa_dropped](../case83_cpu_dispatch_isa_dropped.md) | CPU-dispatch ISA family dropped | 🟡 COMPATIBLE_WITH_RISK | Risk |

--- a/docs/examples/by-verdict/api-break.md
+++ b/docs/examples/by-verdict/api-break.md
@@ -8,6 +8,6 @@ _4 case(s)._ [← back to all examples](../index.md)
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
 | [case106_ctor_became_explicit](../case106_ctor_became_explicit.md) | Conversion Operator Became `explicit` | 🟠 API_BREAK | API Break |
-| [case31_enum_rename](../case31_enum_rename.md) | Case 31 — Enum Member Rename | 🟠 API_BREAK | API Break |
-| [case34_access_level](../case34_access_level.md) | Case 34 — Access Level Changed | 🟠 API_BREAK | API Break |
+| [case31_enum_rename](../case31_enum_rename.md) | Enum Member Rename | 🟠 API_BREAK | API Break |
+| [case34_access_level](../case34_access_level.md) | Access Level Changed | 🟠 API_BREAK | API Break |
 | [case96_hidden_friend_removed](../case96_hidden_friend_removed.md) | Hidden Friend Operator Removed | 🟠 API_BREAK | API Break |

--- a/docs/examples/by-verdict/breaking.md
+++ b/docs/examples/by-verdict/breaking.md
@@ -13,8 +13,8 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case07_struct_layout](../case07_struct_layout.md) | Struct Layout Change | 🔴 BREAKING | Breaking |
 | [case08_enum_value_change](../case08_enum_value_change.md) | Enum Value Change | 🔴 BREAKING | Breaking |
 | [case09_cpp_vtable](../case09_cpp_vtable.md) | C++ Vtable Change | 🔴 BREAKING | Breaking |
-| [case100_experimental_removed_without_replacement](../case100_experimental_removed_without_replacement.md) | : removed without replacement (API break) | 🔴 BREAKING | Breaking |
-| [case101_inline_namespace_version_bumped](../case101_inline_namespace_version_bumped.md) | case101 — inline namespace version bumped (BREAKING) | 🔴 BREAKING | Breaking |
+| [case100_experimental_removed_without_replacement](../case100_experimental_removed_without_replacement.md) | experimental:: removed without replacement (API break) | 🔴 BREAKING | Breaking |
+| [case101_inline_namespace_version_bumped](../case101_inline_namespace_version_bumped.md) | inline namespace version bumped (BREAKING) | 🔴 BREAKING | Breaking |
 | [case102_frozen_runtime_signature_changed](../case102_frozen_runtime_signature_changed.md) | Frozen Runtime Signature Changed (oneTBB `detail::r1` shape) | 🔴 BREAKING | Breaking |
 | [case104_glibcxx_dual_abi_flip](../case104_glibcxx_dual_abi_flip.md) | libstdc++ dual-ABI flip (`glibcxx_dual_abi_flip_detected`) | 🔴 BREAKING | Breaking |
 | [case107_task_scheduler_init_removed](../case107_task_scheduler_init_removed.md) | `task_scheduler_init` Removed (historical ABI break) | 🔴 BREAKING | Breaking |
@@ -31,21 +31,21 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case11_global_var_type](../case11_global_var_type.md) | Global Variable Type Change | 🔴 BREAKING | Breaking |
 | [case12_function_removed](../case12_function_removed.md) | Function Removed from Shared Library | 🔴 BREAKING | Breaking |
 | [case14_cpp_class_size](../case14_cpp_class_size.md) | C++ Class Size Change | 🔴 BREAKING | Breaking |
-| [case17_template_abi](../case17_template_abi.md) | Case 17 — Template Instantiation ABI Change | 🔴 BREAKING | Breaking |
-| [case18_dependency_leak](../case18_dependency_leak.md) | Case 18 — Dependency ABI Leak | 🔴 BREAKING | Breaking |
-| [case19_enum_member_removed](../case19_enum_member_removed.md) | Case 19 — Enum Member Removed | 🔴 BREAKING | Breaking |
-| [case20_enum_member_value_changed](../case20_enum_member_value_changed.md) | Case 20 — Enum Member Value Changed | 🔴 BREAKING | Breaking |
-| [case21_method_became_static](../case21_method_became_static.md) | Case 21 — Method Became Static | 🔴 BREAKING | Breaking |
-| [case22_method_const_changed](../case22_method_const_changed.md) | Case 22 — Method Const Qualifier Changed | 🔴 BREAKING | Breaking |
-| [case23_pure_virtual_added](../case23_pure_virtual_added.md) | Case 23 — Virtual Method Became Pure Virtual | 🔴 BREAKING | Breaking |
-| [case24_union_field_removed](../case24_union_field_removed.md) | Case 24 — Union Field Removed | 🔴 BREAKING | Breaking |
-| [case26_union_field_added](../case26_union_field_added.md) | Case 26 — Union Field Added | 🔴 BREAKING | Breaking |
-| [case28_typedef_opaque](../case28_typedef_opaque.md) | Case 28 — Typedef and Opaque Type Changes | 🔴 BREAKING | Breaking |
-| [case30_field_qualifiers](../case30_field_qualifiers.md) | Case 30 — Field Qualifier Changes (const, volatile) | 🔴 BREAKING | Breaking |
-| [case33_pointer_level](../case33_pointer_level.md) | Case 33 -- Pointer Level Change | 🔴 BREAKING | Breaking |
-| [case35_field_rename](../case35_field_rename.md) | Case 35 -- Field Rename | 🔴 BREAKING | Breaking |
-| [case36_anon_struct](../case36_anon_struct.md) | Case 36 -- Anonymous Struct/Union Change | 🔴 BREAKING | Breaking |
-| [case37_base_class](../case37_base_class.md) | Case 37 -- Base Class Changes | 🔴 BREAKING | Breaking |
+| [case17_template_abi](../case17_template_abi.md) | Template Instantiation ABI Change | 🔴 BREAKING | Breaking |
+| [case18_dependency_leak](../case18_dependency_leak.md) | Dependency ABI Leak | 🔴 BREAKING | Breaking |
+| [case19_enum_member_removed](../case19_enum_member_removed.md) | Enum Member Removed | 🔴 BREAKING | Breaking |
+| [case20_enum_member_value_changed](../case20_enum_member_value_changed.md) | Enum Member Value Changed | 🔴 BREAKING | Breaking |
+| [case21_method_became_static](../case21_method_became_static.md) | Method Became Static | 🔴 BREAKING | Breaking |
+| [case22_method_const_changed](../case22_method_const_changed.md) | Method Const Qualifier Changed | 🔴 BREAKING | Breaking |
+| [case23_pure_virtual_added](../case23_pure_virtual_added.md) | Virtual Method Became Pure Virtual | 🔴 BREAKING | Breaking |
+| [case24_union_field_removed](../case24_union_field_removed.md) | Union Field Removed | 🔴 BREAKING | Breaking |
+| [case26_union_field_added](../case26_union_field_added.md) | Union Field Added | 🔴 BREAKING | Breaking |
+| [case28_typedef_opaque](../case28_typedef_opaque.md) | Typedef and Opaque Type Changes | 🔴 BREAKING | Breaking |
+| [case30_field_qualifiers](../case30_field_qualifiers.md) | Field Qualifier Changes (const, volatile) | 🔴 BREAKING | Breaking |
+| [case33_pointer_level](../case33_pointer_level.md) | - Pointer Level Change | 🔴 BREAKING | Breaking |
+| [case35_field_rename](../case35_field_rename.md) | - Field Rename | 🔴 BREAKING | Breaking |
+| [case36_anon_struct](../case36_anon_struct.md) | - Anonymous Struct/Union Change | 🔴 BREAKING | Breaking |
+| [case37_base_class](../case37_base_class.md) | - Base Class Changes | 🔴 BREAKING | Breaking |
 | [case38_virtual_methods](../case38_virtual_methods.md) | Virtual Method Changes | 🔴 BREAKING | Breaking |
 | [case39_var_const](../case39_var_const.md) | Variable Const Change | 🔴 BREAKING | Breaking |
 | [case40_field_layout](../case40_field_layout.md) | Field Layout Changes | 🔴 BREAKING | Breaking |
@@ -83,10 +83,10 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case80_pimpl_shared_to_unique](../case80_pimpl_shared_to_unique.md) | Pimpl alias changed from `shared_ptr` to `unique_ptr` | 🔴 BREAKING | Breaking |
 | [case81_serialization_tag_reassigned](../case81_serialization_tag_reassigned.md) | Serialization tag ID reassigned | 🔴 BREAKING | Breaking |
 | [case82_sycl_overload_set_removed](../case82_sycl_overload_set_removed.md) | SYCL overload set removed (DPC++ build withdrawn) | 🔴 BREAKING | Breaking |
-| [case85_internal_template_signature_changed](../case85_internal_template_signature_changed.md) | case85 — internal function-template signature leaks via public API (BREAKING) | 🔴 BREAKING | Breaking |
+| [case85_internal_template_signature_changed](../case85_internal_template_signature_changed.md) | internal function-template signature leaks via public API (BREAKING) | 🔴 BREAKING | Breaking |
 | [case86_tag_struct_renamed](../case86_tag_struct_renamed.md) | Tag struct renamed (empty class re-mangling) | 🔴 BREAKING | Breaking |
 | [case87_default_template_arg_changed](../case87_default_template_arg_changed.md) | Default template argument changed | 🔴 BREAKING | Breaking |
-| [case88_cpo_kind_changed](../case88_cpo_kind_changed.md) | case88 — CPO kind changed (BREAKING) | 🔴 BREAKING | Breaking |
+| [case88_cpo_kind_changed](../case88_cpo_kind_changed.md) | CPO kind changed (BREAKING) | 🔴 BREAKING | Breaking |
 | [case89_inline_accessor_renamed_pimpl_member](../case89_inline_accessor_renamed_pimpl_member.md) | Inline accessor references renamed pimpl member | 🔴 BREAKING | Breaking |
 | [case94_empty_tag_gained_state](../case94_empty_tag_gained_state.md) | Empty Tag Gained State | 🔴 BREAKING | Breaking |
 | [case95_allocator_nested_typedef_removed](../case95_allocator_nested_typedef_removed.md) | Allocator Nested-Typedef Removed | 🔴 BREAKING | Breaking |

--- a/docs/examples/by-verdict/compatible-risk.md
+++ b/docs/examples/by-verdict/compatible-risk.md
@@ -7,5 +7,5 @@ _2 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
-| [case15_noexcept_change](../case15_noexcept_change.md) | Case 15 — `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
+| [case15_noexcept_change](../case15_noexcept_change.md) | `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
 | [case83_cpu_dispatch_isa_dropped](../case83_cpu_dispatch_isa_dropped.md) | CPU-dispatch ISA family dropped | 🟡 COMPATIBLE_WITH_RISK | Risk |

--- a/docs/examples/by-verdict/compatible.md
+++ b/docs/examples/by-verdict/compatible.md
@@ -13,11 +13,11 @@ _21 case(s)._ [← back to all examples](../index.md)
 | [case105_concept_tightening](../case105_concept_tightening.md) | Concept Tightening (C++20) | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case111_enumerable_thread_specific_lambda_ambiguity](../case111_enumerable_thread_specific_lambda_ambiguity.md) | enumerable_thread_specific Lambda-Init Ambiguity | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case13_symbol_versioning](../case13_symbol_versioning.md) | Symbol Versioning Script | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case16_inline_to_non_inline](../case16_inline_to_non_inline.md) | Case 16 — Inline → Non-inline (ODR / Symbol Appearance) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case25_enum_member_added](../case25_enum_member_added.md) | Case 25 — Enum Member Added | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case26b_union_field_added_compatible](../case26b_union_field_added_compatible.md) | Case 26b — Union Field Added (No Size Change) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case27_symbol_binding_weakened](../case27_symbol_binding_weakened.md) | Case 27 — Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case29_ifunc_transition](../case29_ifunc_transition.md) | Case 29 — GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case16_inline_to_non_inline](../case16_inline_to_non_inline.md) | Inline → Non-inline (ODR / Symbol Appearance) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case25_enum_member_added](../case25_enum_member_added.md) | Enum Member Added | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case26b_union_field_added_compatible](../case26b_union_field_added_compatible.md) | Union Field Added (No Size Change) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case27_symbol_binding_weakened](../case27_symbol_binding_weakened.md) | Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case29_ifunc_transition](../case29_ifunc_transition.md) | GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case47_inline_to_outlined](../case47_inline_to_outlined.md) | Inline Function Moved to Outlined | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case49_executable_stack](../case49_executable_stack.md) | Executable Stack (GNU_STACK RWX) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case50_soname_inconsistent](../case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟢 COMPATIBLE | Quality (Compatible) |
@@ -26,5 +26,5 @@ _21 case(s)._ [← back to all examples](../index.md)
 | [case54_used_reserved_field](../case54_used_reserved_field.md) | Used Reserved Field | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case61_var_added](../case61_var_added.md) | Global Variable Added | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case62_type_field_added_compatible](../case62_type_field_added_compatible.md) | Type Field Added (Compatible — Opaque Struct) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | case97 — public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case99_experimental_graduated](../case99_experimental_graduated.md) | case99 — experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case99_experimental_graduated](../case99_experimental_graduated.md) | experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |

--- a/docs/examples/by-verdict/no-change.md
+++ b/docs/examples/by-verdict/no-change.md
@@ -11,5 +11,5 @@ _6 case(s)._ [← back to all examples](../index.md)
 | [case118_internal_struct_field_added_scoped](../case118_internal_struct_field_added_scoped.md) | Internal struct gains a field (non-public, scoped) | ✅ NO_CHANGE | No Change |
 | [case119_internal_struct_field_removed_scoped](../case119_internal_struct_field_removed_scoped.md) | Internal struct loses a field (non-public, scoped) | ✅ NO_CHANGE | No Change |
 | [case120_internal_struct_reordered_scoped](../case120_internal_struct_reordered_scoped.md) | Internal struct fields reordered (non-public, scoped) | ✅ NO_CHANGE | No Change |
-| [case32_param_defaults](../case32_param_defaults.md) | Case 32 — Parameter Default Value Changes (C++) | ✅ NO_CHANGE | No Change |
-| [case98_cxx_standard_floor_raised](../case98_cxx_standard_floor_raised.md) | NO_CHANGE) | ✅ NO_CHANGE | No Change |
+| [case32_param_defaults](../case32_param_defaults.md) | Parameter Default Value Changes (C++) | ✅ NO_CHANGE | No Change |
+| [case98_cxx_standard_floor_raised](../case98_cxx_standard_floor_raised.md) | C++ standard floor raised (per-binary: NO_CHANGE) | ✅ NO_CHANGE | No Change |

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -59,8 +59,8 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 | [case07_struct_layout](case07_struct_layout.md) | Struct Layout Change | 🔴 BREAKING | Breaking |
 | [case08_enum_value_change](case08_enum_value_change.md) | Enum Value Change | 🔴 BREAKING | Breaking |
 | [case09_cpp_vtable](case09_cpp_vtable.md) | C++ Vtable Change | 🔴 BREAKING | Breaking |
-| [case100_experimental_removed_without_replacement](case100_experimental_removed_without_replacement.md) | : removed without replacement (API break) | 🔴 BREAKING | Breaking |
-| [case101_inline_namespace_version_bumped](case101_inline_namespace_version_bumped.md) | case101 — inline namespace version bumped (BREAKING) | 🔴 BREAKING | Breaking |
+| [case100_experimental_removed_without_replacement](case100_experimental_removed_without_replacement.md) | experimental:: removed without replacement (API break) | 🔴 BREAKING | Breaking |
+| [case101_inline_namespace_version_bumped](case101_inline_namespace_version_bumped.md) | inline namespace version bumped (BREAKING) | 🔴 BREAKING | Breaking |
 | [case102_frozen_runtime_signature_changed](case102_frozen_runtime_signature_changed.md) | Frozen Runtime Signature Changed (oneTBB `detail::r1` shape) | 🔴 BREAKING | Breaking |
 | [case103_toolchain_flag_drift](case103_toolchain_flag_drift.md) | Toolchain flag drift (`toolchain_flag_drift`) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case104_glibcxx_dual_abi_flip](case104_glibcxx_dual_abi_flip.md) | libstdc++ dual-ABI flip (`glibcxx_dual_abi_flip_detected`) | 🔴 BREAKING | Breaking |
@@ -85,30 +85,30 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 | [case12_function_removed](case12_function_removed.md) | Function Removed from Shared Library | 🔴 BREAKING | Breaking |
 | [case13_symbol_versioning](case13_symbol_versioning.md) | Symbol Versioning Script | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case14_cpp_class_size](case14_cpp_class_size.md) | C++ Class Size Change | 🔴 BREAKING | Breaking |
-| [case15_noexcept_change](case15_noexcept_change.md) | Case 15 — `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
-| [case16_inline_to_non_inline](case16_inline_to_non_inline.md) | Case 16 — Inline → Non-inline (ODR / Symbol Appearance) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case17_template_abi](case17_template_abi.md) | Case 17 — Template Instantiation ABI Change | 🔴 BREAKING | Breaking |
-| [case18_dependency_leak](case18_dependency_leak.md) | Case 18 — Dependency ABI Leak | 🔴 BREAKING | Breaking |
-| [case19_enum_member_removed](case19_enum_member_removed.md) | Case 19 — Enum Member Removed | 🔴 BREAKING | Breaking |
-| [case20_enum_member_value_changed](case20_enum_member_value_changed.md) | Case 20 — Enum Member Value Changed | 🔴 BREAKING | Breaking |
-| [case21_method_became_static](case21_method_became_static.md) | Case 21 — Method Became Static | 🔴 BREAKING | Breaking |
-| [case22_method_const_changed](case22_method_const_changed.md) | Case 22 — Method Const Qualifier Changed | 🔴 BREAKING | Breaking |
-| [case23_pure_virtual_added](case23_pure_virtual_added.md) | Case 23 — Virtual Method Became Pure Virtual | 🔴 BREAKING | Breaking |
-| [case24_union_field_removed](case24_union_field_removed.md) | Case 24 — Union Field Removed | 🔴 BREAKING | Breaking |
-| [case25_enum_member_added](case25_enum_member_added.md) | Case 25 — Enum Member Added | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case26_union_field_added](case26_union_field_added.md) | Case 26 — Union Field Added | 🔴 BREAKING | Breaking |
-| [case26b_union_field_added_compatible](case26b_union_field_added_compatible.md) | Case 26b — Union Field Added (No Size Change) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case27_symbol_binding_weakened](case27_symbol_binding_weakened.md) | Case 27 — Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case28_typedef_opaque](case28_typedef_opaque.md) | Case 28 — Typedef and Opaque Type Changes | 🔴 BREAKING | Breaking |
-| [case29_ifunc_transition](case29_ifunc_transition.md) | Case 29 — GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case30_field_qualifiers](case30_field_qualifiers.md) | Case 30 — Field Qualifier Changes (const, volatile) | 🔴 BREAKING | Breaking |
-| [case31_enum_rename](case31_enum_rename.md) | Case 31 — Enum Member Rename | 🟠 API_BREAK | API Break |
-| [case32_param_defaults](case32_param_defaults.md) | Case 32 — Parameter Default Value Changes (C++) | ✅ NO_CHANGE | No Change |
-| [case33_pointer_level](case33_pointer_level.md) | Case 33 -- Pointer Level Change | 🔴 BREAKING | Breaking |
-| [case34_access_level](case34_access_level.md) | Case 34 — Access Level Changed | 🟠 API_BREAK | API Break |
-| [case35_field_rename](case35_field_rename.md) | Case 35 -- Field Rename | 🔴 BREAKING | Breaking |
-| [case36_anon_struct](case36_anon_struct.md) | Case 36 -- Anonymous Struct/Union Change | 🔴 BREAKING | Breaking |
-| [case37_base_class](case37_base_class.md) | Case 37 -- Base Class Changes | 🔴 BREAKING | Breaking |
+| [case15_noexcept_change](case15_noexcept_change.md) | `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
+| [case16_inline_to_non_inline](case16_inline_to_non_inline.md) | Inline → Non-inline (ODR / Symbol Appearance) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case17_template_abi](case17_template_abi.md) | Template Instantiation ABI Change | 🔴 BREAKING | Breaking |
+| [case18_dependency_leak](case18_dependency_leak.md) | Dependency ABI Leak | 🔴 BREAKING | Breaking |
+| [case19_enum_member_removed](case19_enum_member_removed.md) | Enum Member Removed | 🔴 BREAKING | Breaking |
+| [case20_enum_member_value_changed](case20_enum_member_value_changed.md) | Enum Member Value Changed | 🔴 BREAKING | Breaking |
+| [case21_method_became_static](case21_method_became_static.md) | Method Became Static | 🔴 BREAKING | Breaking |
+| [case22_method_const_changed](case22_method_const_changed.md) | Method Const Qualifier Changed | 🔴 BREAKING | Breaking |
+| [case23_pure_virtual_added](case23_pure_virtual_added.md) | Virtual Method Became Pure Virtual | 🔴 BREAKING | Breaking |
+| [case24_union_field_removed](case24_union_field_removed.md) | Union Field Removed | 🔴 BREAKING | Breaking |
+| [case25_enum_member_added](case25_enum_member_added.md) | Enum Member Added | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case26_union_field_added](case26_union_field_added.md) | Union Field Added | 🔴 BREAKING | Breaking |
+| [case26b_union_field_added_compatible](case26b_union_field_added_compatible.md) | Union Field Added (No Size Change) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case27_symbol_binding_weakened](case27_symbol_binding_weakened.md) | Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case28_typedef_opaque](case28_typedef_opaque.md) | Typedef and Opaque Type Changes | 🔴 BREAKING | Breaking |
+| [case29_ifunc_transition](case29_ifunc_transition.md) | GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case30_field_qualifiers](case30_field_qualifiers.md) | Field Qualifier Changes (const, volatile) | 🔴 BREAKING | Breaking |
+| [case31_enum_rename](case31_enum_rename.md) | Enum Member Rename | 🟠 API_BREAK | API Break |
+| [case32_param_defaults](case32_param_defaults.md) | Parameter Default Value Changes (C++) | ✅ NO_CHANGE | No Change |
+| [case33_pointer_level](case33_pointer_level.md) | - Pointer Level Change | 🔴 BREAKING | Breaking |
+| [case34_access_level](case34_access_level.md) | Access Level Changed | 🟠 API_BREAK | API Break |
+| [case35_field_rename](case35_field_rename.md) | - Field Rename | 🔴 BREAKING | Breaking |
+| [case36_anon_struct](case36_anon_struct.md) | - Anonymous Struct/Union Change | 🔴 BREAKING | Breaking |
+| [case37_base_class](case37_base_class.md) | - Base Class Changes | 🔴 BREAKING | Breaking |
 | [case38_virtual_methods](case38_virtual_methods.md) | Virtual Method Changes | 🔴 BREAKING | Breaking |
 | [case39_var_const](case39_var_const.md) | Variable Const Change | 🔴 BREAKING | Breaking |
 | [case40_field_layout](case40_field_layout.md) | Field Layout Changes | 🔴 BREAKING | Breaking |
@@ -155,14 +155,14 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 | [case81_serialization_tag_reassigned](case81_serialization_tag_reassigned.md) | Serialization tag ID reassigned | 🔴 BREAKING | Breaking |
 | [case82_sycl_overload_set_removed](case82_sycl_overload_set_removed.md) | SYCL overload set removed (DPC++ build withdrawn) | 🔴 BREAKING | Breaking |
 | [case83_cpu_dispatch_isa_dropped](case83_cpu_dispatch_isa_dropped.md) | CPU-dispatch ISA family dropped | 🟡 COMPATIBLE_WITH_RISK | Risk |
-| [case85_internal_template_signature_changed](case85_internal_template_signature_changed.md) | case85 — internal function-template signature leaks via public API (BREAKING) | 🔴 BREAKING | Breaking |
+| [case85_internal_template_signature_changed](case85_internal_template_signature_changed.md) | internal function-template signature leaks via public API (BREAKING) | 🔴 BREAKING | Breaking |
 | [case86_tag_struct_renamed](case86_tag_struct_renamed.md) | Tag struct renamed (empty class re-mangling) | 🔴 BREAKING | Breaking |
 | [case87_default_template_arg_changed](case87_default_template_arg_changed.md) | Default template argument changed | 🔴 BREAKING | Breaking |
-| [case88_cpo_kind_changed](case88_cpo_kind_changed.md) | case88 — CPO kind changed (BREAKING) | 🔴 BREAKING | Breaking |
+| [case88_cpo_kind_changed](case88_cpo_kind_changed.md) | CPO kind changed (BREAKING) | 🔴 BREAKING | Breaking |
 | [case89_inline_accessor_renamed_pimpl_member](case89_inline_accessor_renamed_pimpl_member.md) | Inline accessor references renamed pimpl member | 🔴 BREAKING | Breaking |
 | [case94_empty_tag_gained_state](case94_empty_tag_gained_state.md) | Empty Tag Gained State | 🔴 BREAKING | Breaking |
 | [case95_allocator_nested_typedef_removed](case95_allocator_nested_typedef_removed.md) | Allocator Nested-Typedef Removed | 🔴 BREAKING | Breaking |
 | [case96_hidden_friend_removed](case96_hidden_friend_removed.md) | Hidden Friend Operator Removed | 🟠 API_BREAK | API Break |
-| [case97_api_depends_on_consumer_env](case97_api_depends_on_consumer_env.md) | case97 — public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case98_cxx_standard_floor_raised](case98_cxx_standard_floor_raised.md) | NO_CHANGE) | ✅ NO_CHANGE | No Change |
-| [case99_experimental_graduated](case99_experimental_graduated.md) | case99 — experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |
+| [case97_api_depends_on_consumer_env](case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case98_cxx_standard_floor_raised](case98_cxx_standard_floor_raised.md) | C++ standard floor raised (per-binary: NO_CHANGE) | ✅ NO_CHANGE | No Change |
+| [case99_experimental_graduated](case99_experimental_graduated.md) | experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,10 +36,16 @@ conda install -c conda-forge abicheck
 ### Requirements
 
 - Python 3.10+
-- `castxml` + C/C++ compiler — for header AST analysis (optional but recommended, all platforms)
+- `castxml` + a C/C++ compiler — **required for header AST analysis** (all platforms)
 
-All Python dependencies (`pyelftools`, `pefile`, `macholib`) come with `abicheck` install.
-Without `castxml`, abicheck still works in binary-only mode.
+All Python dependencies (`pyelftools`, `pefile`, `macholib`) come with the `abicheck` install.
+
+> **Important:** `pip install abicheck` does **not** install `castxml`. Any command
+> that takes headers (`--old-header` / `--new-header` / `-H`) needs `castxml` on
+> your `PATH` — without it those commands fail with `castxml not found`. Install it
+> with the system/conda packages below (the conda-forge package pulls it in
+> automatically). If you have no `castxml`, run **binary-only mode** by omitting the
+> header flags — abicheck falls back to DWARF/symbols analysis (weaker, but works).
 
 #### Option A: system packages
 
@@ -52,6 +58,12 @@ sudo apt-get update && sudo apt-get install -y castxml gcc g++
 # macOS
 brew install castxml
 # plus Xcode Command Line Tools for clang
+```
+
+```powershell
+# Windows (PowerShell, as administrator)
+choco install castxml
+# plus MSVC Build Tools (cl.exe) for PE/PDB debug-info analysis
 ```
 
 #### Option B: conda-forge (recommended for reproducible envs)
@@ -77,7 +89,7 @@ pip install -e .
 
 ## 2) First check (using repo examples)
 
-The repo includes 74 ABI scenario examples with paired `v1`/`v2` sources and headers.
+The repo includes 121 ABI scenario examples with paired `v1`/`v2` sources and headers.
 Browse them in the [Examples & Case Encyclopedia](examples/index.md),
 or pick one and run it locally:
 
@@ -92,10 +104,19 @@ gcc -shared -fPIC -g v2.c -o libv2.so
 ```
 
 ```bash
-# Compare
+# Compare (header-aware — needs castxml; see Requirements above)
 abicheck compare libv1.so libv2.so --old-header v1.h --new-header v2.h
 # Verdict: BREAKING (symbol 'helper' was removed)
 ```
+
+> **No `castxml`?** The command above will fail with `castxml not found`. Either
+> install castxml (see [Requirements](#requirements)), or run the same comparison
+> in binary-only mode by dropping the header flags — it still catches the removed
+> symbol from the ELF/DWARF metadata:
+>
+> ```bash
+> abicheck compare libv1.so libv2.so   # binary-only fallback, no castxml needed
+> ```
 
 For your own library:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 ## Why abicheck
 
 - **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
-- **145 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
+- **183 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.
 - **ABICC drop-in** — full flag parity for migrating from `abi-compliance-checker`.
@@ -24,8 +24,8 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 
 **Evaluating or comparing tools?**
 
-- [Tool Comparison & Benchmarks](reference/tool-comparison.md) — abicheck vs `abidiff` vs ABICC on a 74-case catalog.
-- [Examples & Case Encyclopedia](examples/index.md) — all 74 cases with code, runtime demo, and fixes.
+- [Tool Comparison & Benchmarks](reference/tool-comparison.md) — abicheck vs `abidiff` vs ABICC on a pinned 74-case benchmark subset.
+- [Examples & Case Encyclopedia](examples/index.md) — all 116 documented cases with code, runtime demo, and fixes.
 - [ABI Breaks Explained](concepts/abi-breaks-explained.md) — real-world scenarios with code.
 - [Limitations](concepts/limitations.md) — what abicheck does *not* catch.
 

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -4,9 +4,11 @@ This document explains how each ABI checking tool works, what analysis method it
 benchmark results across real-world test cases, and why the numbers come out the way they do.
 
 > **Note:** abicheck detects 100+ change types (see [Change Kind Reference](change-kinds.md)).
-> The current cross-tool benchmark covers the full 74-case `examples/` catalog
-> (`case01`-`case73` + `case26b`). A historical 42-case snapshot is kept below
-> only for comparison with older reports.
+> The current cross-tool benchmark covers a pinned 74-case subset of the
+> `examples/` catalog (`case01`-`case73` + `case26b`); the full catalog now has
+> 121 cases. The subset is pinned so accuracy numbers stay reproducible across
+> releases. A historical 42-case snapshot is kept below only for comparison with
+> older reports.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,59 @@
 # Troubleshooting
 
-Use this page when results look surprising (false positive, false negative, or unexpected verdict).
+Use this page when a run fails to start (setup/environment) or when results look
+surprising (false positive, false negative, or unexpected verdict).
+
+---
+
+## 0) Setup & environment failures
+
+### "castxml not found in PATH"
+
+Header AST analysis requires `castxml`. `pip install abicheck` does **not** install it,
+so any command that passes headers (`--old-header` / `--new-header` / `-H`) fails with
+this error until `castxml` is on your `PATH`.
+
+```bash
+# Ubuntu / Debian
+sudo apt-get install -y castxml gcc g++
+# macOS
+brew install castxml
+# Windows (PowerShell, admin)
+choco install castxml
+# conda (any OS) — bundles castxml + compiler automatically
+conda install -c conda-forge abicheck
+```
+
+No castxml and can't install it? Run **binary-only mode** by omitting the header flags —
+abicheck falls back to DWARF/symbols analysis (weaker, but catches symbol- and
+layout-level breaks):
+
+```bash
+abicheck compare old.so new.so   # no -H / --*-header → binary-only fallback
+```
+
+### "command not found: abicheck" or wrong tool runs
+
+Some distros ship unrelated tools with similar names (`abi-compliance-checker`
+wrappers in Debian `devscripts`, or `abicheck` in Fedora's `libabigail-tools`).
+Confirm you're running this project:
+
+```bash
+abicheck --version   # should print: abicheck X.Y.Z (napetrov/abicheck)
+```
+
+If a different tool shadows it, invoke via the module form: `python -m abicheck`.
+
+### Header parsing fails or finds nothing
+
+If castxml runs but reports parse errors or an empty surface, the inputs usually
+don't match the build environment of the analyzed `.so`:
+
+- Pass the same include dirs the library was built with: `-I include/ -I deps/include/`.
+- Pass the same preprocessor macros: `--gcc-options "-DFEATURE_X=1 -DNDEBUG"`.
+- Best option: feed the real build flags from `compile_commands.json` with `-p build/`
+  (see [CLI Usage → Build-context capture](user-guide/cli-usage.md)).
+- For pure C libraries, add `--lang c` (the default is `c++`).
 
 ---
 

--- a/docs/user-guide/mcp-integration.md
+++ b/docs/user-guide/mcp-integration.md
@@ -221,7 +221,7 @@ from disk instead.
 
 ### `abi_list_changes` — List detectable change kinds
 
-Enumerates all 145 `ChangeKind` values with their impact classification. See
+Enumerates all 183 `ChangeKind` values with their impact classification. See
 the [Change Kinds Reference](../reference/change-kinds.md) for canonical
 documentation of each kind.
 
@@ -235,7 +235,7 @@ documentation of each kind.
 
 ```json
 {
-  "count": 145,
+  "count": 183,
   "change_kinds": [
     {
       "kind": "func_removed",

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — `examples/`
 
-The ABI-scenario catalog: 112 cases numbered contiguously (`01–111` +
-`26b`), including 4 multi-library bundle cases. Each case is a minimal,
+The ABI-scenario catalog: 121 cases numbered contiguously (`01–120` +
+`26b`), including 5 multi-library bundle cases. Each case is a minimal,
 compilable C/C++ example demonstrating a specific ABI/API pitfall.
 
 Read `README.md` in this directory first — it indexes every case and

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # ABI Scenario Catalog
 
-This directory contains **112 cases** numbered contiguously (`01–111` + `26b`), including **4 multi-library bundle cases** (`90–93`, tracked separately under [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) demonstrating real-world ABI/API break scenarios. Each case is a minimal, compilable C/C++ example with:
+This directory contains **121 cases** numbered contiguously (`01–120` + `26b`), including **5 multi-library bundle cases** (`84`, `90–93`, tracked separately under [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) demonstrating real-world ABI/API break scenarios. Each case is a minimal, compilable C/C++ example with:
 
 - Paired `v1/` and `v2/` source + headers.
 - A consumer `app.c` / `app.cpp` that demonstrates the actual failure at runtime.
@@ -17,13 +17,13 @@ The catalog drives abicheck's benchmark and serves as an encyclopedia of ABI pit
 
 | Verdict | Count | `checker_policy.py` set | Icon |
 |---------|-------|-------------------------|------|
-| BREAKING | 78 | `BREAKING_KINDS` | 🔴 |
+| BREAKING | 83 | `BREAKING_KINDS` | 🔴 |
 | API_BREAK | 4 | `API_BREAK_KINDS` | 🟠 |
 | COMPATIBLE_WITH_RISK | 2 | `RISK_KINDS` | 🟡 |
 | COMPATIBLE (addition) | 10 | `ADDITION_KINDS` | 🟢 |
 | COMPATIBLE (quality) | 11 | `QUALITY_KINDS` | 🟡 |
-| NO_CHANGE | 3 | — | ✅ |
-| Bundle (multi-binary) | 4 | see [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md) | 🔴 |
+| NO_CHANGE | 6 | — | ✅ |
+| Bundle (multi-binary) | 5 | see [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md) | 🔴 |
 
 > **Verdict source of truth:** [`ground_truth.json`](ground_truth.json), which aligns with the 5-tier classification in [`abicheck/checker_policy.py`](../abicheck/checker_policy.py): `BREAKING_KINDS` → `API_BREAK_KINDS` → `RISK_KINDS` → `QUALITY_KINDS` → `ADDITION_KINDS`.
 

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -357,6 +357,87 @@ def check_changekind_docs(f: Findings) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Check: headline counts in docs stay in sync with source-of-truth
+# ---------------------------------------------------------------------------
+
+
+def check_doc_count_sync(f: Findings) -> None:
+    """Keep hand-written headline counts in sync with their source of truth.
+
+    Two numbers historically drifted across the docs: the number of `ChangeKind`
+    values ("N change types") and the size of the example catalog
+    (`examples/ground_truth.json`). Each anchor below pins a specific sentence to
+    a computed value:
+
+    - ERROR if the anchor sentence is present but the number is wrong (the real
+      drift bug — forces docs to be updated when a ChangeKind or case is added).
+    - WARN if the anchor sentence can no longer be found (wording changed, so the
+      guard silently stopped covering that spot — update the regex here).
+    """
+    try:
+        from abicheck.checker_policy import ChangeKind
+    except Exception:
+        # Package not importable (e.g. pre-install lane) — skip silently, like
+        # the other ChangeKind checks.
+        return
+
+    n_kinds = len(list(ChangeKind))
+
+    gt_path = EXAMPLES / "ground_truth.json"
+    try:
+        verdicts = json.loads(_read(gt_path))["verdicts"]
+    except Exception:
+        return
+    n_catalog = len(verdicts)
+
+    # (file, human label, expected value, regex capturing the documented number)
+    anchors = [
+        (
+            ROOT / "README.md",
+            "ChangeKind count",
+            n_kinds,
+            r"\*\*(\d+) ABI/API change types\*\*",
+        ),
+        (
+            DOCS / "index.md",
+            "ChangeKind count",
+            n_kinds,
+            r"\*\*(\d+) detection rules\*\*",
+        ),
+        (
+            ROOT / "README.md",
+            "catalog size",
+            n_catalog,
+            r"contains \*\*(\d+) real-world ABI/API scenarios",
+        ),
+        (
+            DOCS / "getting-started.md",
+            "catalog size",
+            n_catalog,
+            r"repo includes (\d+) ABI scenario examples",
+        ),
+    ]
+
+    for path, label, expected, pattern in anchors:
+        text = _read(path)
+        m = re.search(pattern, text)
+        if m is None:
+            f.warn(
+                "doc-count-sync",
+                f"{_rel(path)}: {label} anchor not found (pattern {pattern!r}); "
+                "update the regex in check_doc_count_sync if the wording changed.",
+            )
+            continue
+        found = int(m.group(1))
+        if found != expected:
+            f.err(
+                "doc-count-sync",
+                f"{_rel(path)}: {label} says {found}, but source of truth is {expected}. "
+                "Update the doc (or the source) so they agree.",
+            )
+
+
+# ---------------------------------------------------------------------------
 # Check: import-cycle detection
 # ---------------------------------------------------------------------------
 
@@ -795,6 +876,7 @@ CHECKS: dict[str, Callable[[Findings], None]] = {
     "changekind-partition": check_changekind_partition,
     "changekind-detector": check_changekind_detector_crossref,
     "changekind-docs": check_changekind_docs,
+    "doc-count-sync": check_doc_count_sync,
     "import-cycles": check_import_cycles,
     "mypy-baseline": check_mypy_baseline,
     "examples-ground-truth": check_examples_ground_truth,

--- a/scripts/gen_examples_docs.py
+++ b/scripts/gen_examples_docs.py
@@ -109,6 +109,19 @@ WARNING = (
     "Source: examples/<case>/README.md + examples/ground_truth.json. -->\n"
 )
 
+# Strip a leading "caseNN" / "Case NN" / "caseNNb" token (and its trailing
+# separator) from a title for use in compact index tables. Anchored so it only
+# removes the case-number prefix — titles that legitimately contain a colon
+# (e.g. "... (per-binary: NO_CHANGE)" or "experimental:: removed ...") keep the
+# rest of the text intact.
+_CASE_PREFIX_RE = re.compile(r"^\s*case\s*\d+[a-z]?\s*(?:[-—:]\s*)?", re.IGNORECASE)
+
+
+def _short_title(title: str) -> str:
+    """Title with any leading caseNN prefix removed (for index table rows)."""
+    stripped = _CASE_PREFIX_RE.sub("", title, count=1).strip()
+    return stripped or title
+
 
 @dataclass
 class Case:
@@ -243,7 +256,7 @@ def _case_row(case: Case) -> str:
     vinfo = VERDICT_META[case.verdict]
     return (
         f"| [{case.name}]({case.name}.md) "
-        f"| {case.title.split(':', 1)[-1].strip()} "
+        f"| {_short_title(case.title)} "
         f"| {vinfo['icon']} {vinfo['label']} "
         f"| {CATEGORY_META[case.category]['label']} |"
     )
@@ -331,7 +344,7 @@ def _render_group_index(
         vinfo = VERDICT_META[c.verdict]
         lines.append(
             f"| [{c.name}](../{c.name}.md) "
-            f"| {c.title.split(':', 1)[-1].strip()} "
+            f"| {_short_title(c.title)} "
             f"| {vinfo['icon']} {vinfo['label']} "
             f"| {CATEGORY_META[c.category]['label']} |\n"
         )

--- a/tests/test_examples_docs.py
+++ b/tests/test_examples_docs.py
@@ -120,3 +120,43 @@ def test_generator_source_section_uses_code_literals() -> None:
 
     assert "- `v1.c`" in source_section
     assert "](" not in source_section
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        # Leading caseNN prefix (various separators) is stripped for table rows.
+        (
+            "case101 — inline namespace version bumped (BREAKING)",
+            "inline namespace version bumped (BREAKING)",
+        ),
+        (
+            "Case 17 — Template Instantiation ABI Change",
+            "Template Instantiation ABI Change",
+        ),
+        (
+            "Case 26b — Union Field Added (No Size Change)",
+            "Union Field Added (No Size Change)",
+        ),
+        ("Case 01: Symbol Removal", "Symbol Removal"),
+        # Regression guard: a title with internal colons keeps the trailing text
+        # (the old `split(':', 1)[-1]` heuristic mangled these).
+        (
+            "case98 — C++ standard floor raised (per-binary: NO_CHANGE)",
+            "C++ standard floor raised (per-binary: NO_CHANGE)",
+        ),
+        (
+            "case100 — experimental:: removed without replacement (API break)",
+            "experimental:: removed without replacement (API break)",
+        ),
+        # Titles without a caseNN prefix are left untouched, even if they start
+        # with the word "case" (no trailing number) or contain a colon.
+        ("Symbol Removal", "Symbol Removal"),
+        ("Case-insensitive lookup changed", "Case-insensitive lookup changed"),
+    ],
+)
+def test_short_title_strips_case_prefix_but_keeps_inner_colons(
+    title: str, expected: str
+) -> None:
+    mod = _load_generator_module()
+    assert mod._short_title(title) == expected


### PR DESCRIPTION
## Summary

A documentation review from a new-user perspective (installed the tool, ran the tutorials, checked links, counted cases) surfaced a set of factual inconsistencies and a first-run trap. This PR fixes them. All changes are docs + one generator-script fix; no library behavior changes.

### 1. Reconcile the example-catalog counts (standardized on `ground_truth.json`)
The same catalog was described with four different numbers across the docs (74 / 112 / 116 / 121). Reality, per `examples/ground_truth.json`:
- **121** total cases (`01–120` + `26b`)
- **116** single-library cases documented in the encyclopedia
- **5** multi-library bundle cases (`84`, `90–93`, tracked under ADR-023)
- The cross-tool benchmark legitimately runs on a **pinned 74-case subset** (`01–73` + `26b`) for reproducibility — now labeled as such instead of "the full catalog".

Updated: `README.md`, `docs/index.md`, `docs/getting-started.md`, `examples/README.md` (incl. verdict-distribution table), `examples/CLAUDE.md`, `docs/concepts/breaking-cases-catalog.md`, `docs/concepts/abi-breaks-explained.md`, `docs/reference/tool-comparison.md`, `docs/development/adr/019-testing-strategy.md`.

### 2. Correct the "145 change types" claim → **183**
`ChangeKind` actually has 183 members today (the partition over `BREAKING_KINDS`/`API_BREAK_KINDS`/`COMPATIBLE_KINDS`/`RISK_KINDS` covers all 183, enforced by the readiness gate). Fixed in `README.md`, `docs/index.md`, `CLAUDE.md`, `docs/concepts/breaking-cases-catalog.md`, and `docs/user-guide/mcp-integration.md` (the `abi_list_changes` example output).

### 3. Fix garbled generated case titles
`scripts/gen_examples_docs.py` shortened index-table titles with `title.split(':', 1)[-1]`, which mangled any title containing a colon — e.g. `case98` rendered as `NO_CHANGE)` and `case100` as `: removed without replacement (API break)`. Replaced with an anchored `caseNN`-prefix strip (`_short_title`) that leaves internal colons intact, and regenerated the `docs/examples/` tree. The `--check` drift gate passes.

### 4. Fix the first-run castxml trap
`pip install abicheck` does not install `castxml`, but the first Getting Started command passes headers and hard-fails with `castxml not found` (the binary-only fallback only triggers when no headers are passed). Getting Started now states this explicitly, shows the binary-only fallback command, and adds a Windows install snippet.

### 5. Beef up Troubleshooting
Added a "Setup & environment failures" section: `castxml not found`, the `abicheck` name-collision note (Debian/Fedora tools) with `python -m abicheck`, and header/macro/include parity guidance.

## Validation
- `python scripts/gen_examples_docs.py --check` → up to date (116 cases)
- `python scripts/check_ai_readiness.py` → 0 errors
- `pytest tests/test_examples_docs.py` → 125 passed
- Internal markdown links: 0 broken (mkdocs `--strict` will pass)
- Verified the documented binary-only fallback (`abicheck compare old.so new.so`) returns `BREAKING` on `case01`

## Note
A few remaining `145` references live in contributor-only analysis docs (`docs/development/goals.md`, `usecase-registry.yaml`, `usecase-coverage-evaluation.md`). Those are point-in-time roadmap/analysis documents and were left untouched to avoid rewriting historical milestone records; they can be refreshed separately.

https://claude.ai/code/session_01JLSSEauhMRttxYU9JmsEtH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLSSEauhMRttxYU9JmsEtH)_