### PR TITLE
fix(dwarf): filter transitive stdlib subprograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,30 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 
+#### ELF-only function removals are now BREAKING
+- **Breaking (verdict change):** a removed *exported* function symbol with no
+  header/DWARF confirmation (`func_removed_elf_only`) is now classified
+  **BREAKING** instead of compatible. Removing a dynamic export breaks old
+  binaries that link or `dlsym()` it regardless of header evidence, matching
+  `abidiff`/ABICC. This can change a `compare`/`compat` run from compatible to
+  breaking (legacy `compare` exit `0`→`4`); the false-positive avalanche this
+  could otherwise cause is held back by the shared transitive-runtime symbol
+  filter below (those symbols no longer enter a non-runtime library's surface).
+
+### Fixed
+
+#### Transitive stdlib/runtime symbols no longer leak into the ABI surface
+- Centralized ELF ABI-relevance filtering into `abicheck/elf_symbol_filter.py`
+  and shared it across the symbols-only dumper, DWARF snapshot extraction, and
+  symbol/type diffing. Previously a weak transitive libstdc++/libc++ export
+  could be filtered from symbols-only reports yet re-enter as a `PUBLIC` DWARF
+  function, producing phantom `FUNC_REMOVED` and type-reachability findings
+  (observed on oneTBB `libtbbmalloc` 2021.5→2021.9, where `abidiff` was clean).
+- DWARF export indexing and `DW_AT_deleted` subprograms now consult the same
+  filter; libstdc++/libc++ themselves are exempt (they *own* `std::`).
+- Project-owned RTTI (`_ZTI*`/`_ZTS*` for the library's own types) is preserved;
+  only standard-library RTTI prefixes are dropped.
+
 #### Cross-mode config-key consistency (CLI surface review)
 - **Breaking (default change):** `compare-release` now restricts findings to the
   public-header ABI surface **by default** (`--scope-public-headers` on), matching

--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -122,8 +122,8 @@ REGISTRY = ChangeKindRegistry([
     # ── Function / variable changes ────────────────────────────────────────
     _E("func_removed", _B,
        impact="Old binaries call a symbol that no longer exists; dynamic linker will refuse to load or crash at call site."),
-    _E("func_removed_elf_only", _C,
-       impact="Symbol removed from ELF but was not in public headers; low risk unless dlsym() callers depend on it."),
+    _E("func_removed_elf_only", _B,
+       impact="Exported function symbol removed from the binary; old binaries that link or dlsym() it can fail even without header evidence."),
     _E("func_added", _C, is_addition=True,
        impact="New function available; existing binaries are unaffected."),
     _E("func_return_changed", _B,

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -49,7 +49,7 @@ from .change_registry import Verdict as Verdict
 class ChangeKind(str, Enum):
     # Function / variable changes
     FUNC_REMOVED = "func_removed"  # public symbol removed → BREAKING
-    FUNC_REMOVED_ELF_ONLY = "func_removed_elf_only"  # ELF-only symbol removed (visibility cleanup, not hard break)
+    FUNC_REMOVED_ELF_ONLY = "func_removed_elf_only"  # exported ELF-only function removed -> binary break
     FUNC_ADDED = "func_added"  # new public symbol → COMPATIBLE
     FUNC_RETURN_CHANGED = "func_return_changed"  # return type changed → BREAKING
     FUNC_PARAMS_CHANGED = "func_params_changed"  # parameter types changed → BREAKING

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -103,7 +103,18 @@ def _is_local_type_rtti(mangled: str) -> bool:
 
 def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     """Return public/ELF-only functions from *snap*."""
-    return {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
+    funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
+    elf = getattr(snap, "elf", None)
+    if elf is None or not elf.symbols:
+        return funcs
+    exported = {
+        sym.name
+        for sym in elf.symbols
+        if getattr(sym.sym_type, "value", sym.sym_type) in {"func", "ifunc"}
+    }
+    if not exported:
+        return funcs
+    return {k: v for k, v in funcs.items() if k in exported}
 
 
 def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:
@@ -595,8 +606,8 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # data-model-dependent integer ABI-equivalence checks below.
     is_llp64 = "pe" in (getattr(old, "platform", None), getattr(new, "platform", None))
     changes: list[Change] = []
-    old_map = {k: v for k, v in old.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
-    new_map = {k: v for k, v in new.function_map.items() if v.visibility in (Visibility.PUBLIC, Visibility.ELF_ONLY)}
+    old_map = _public_functions(old)
+    new_map = _public_functions(new)
 
     # Build a lookup of ALL functions in new snapshot (including hidden).
     new_all = new.function_map
@@ -1712,4 +1723,3 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
         )
 
     return changes
-

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -30,6 +30,7 @@ from .checker_types import Change
 from .detector_registry import registry
 from .diff_helpers import bool_transition, diff_by_key
 from .elf_metadata import SymbolType
+from .elf_symbol_filter import FUNCTION_SYMBOL_TYPES, exported_symbol_names
 from .model import (
     AbiSnapshot,
     Function,
@@ -102,16 +103,23 @@ def _is_local_type_rtti(mangled: str) -> bool:
 
 
 def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
-    """Return public/ELF-only functions from *snap*."""
+    """Return public/ELF-only functions from *snap*.
+
+    When ELF dynamic-symbol evidence is available, narrow the DWARF-derived
+    public set to names that are actually exported (or explicitly ``= delete``,
+    so an API becoming deleted stays observable). This keeps transitive
+    runtime/stdlib subprograms that slipped into the DWARF DIEs out of the diff.
+
+    The narrowing only happens when exports are present: a snapshot with no ELF
+    symbol table (``elf`` absent/empty) keeps the full DWARF set untouched.
+
+    Caveat: this trusts the ELF symbol table to be reasonably complete. A
+    *partially* captured table (e.g. only a stripped ``.symtab`` subset) could in
+    theory hide a genuine removal — but DWARF-primary snapshots carry the full
+    ``.dynsym``, so in practice the export set is authoritative here.
+    """
     funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
-    elf = getattr(snap, "elf", None)
-    if elf is None or not elf.symbols:
-        return funcs
-    exported = {
-        sym.name
-        for sym in elf.symbols
-        if getattr(sym.sym_type, "value", sym.sym_type) in {"func", "ifunc", "notype"}
-    }
+    exported = exported_symbol_names(getattr(snap, "elf", None), FUNCTION_SYMBOL_TYPES)
     if not exported:
         return funcs
     return {

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -110,11 +110,14 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     exported = {
         sym.name
         for sym in elf.symbols
-        if getattr(sym.sym_type, "value", sym.sym_type) in {"func", "ifunc"}
+        if getattr(sym.sym_type, "value", sym.sym_type) in {"func", "ifunc", "notype"}
     }
     if not exported:
         return funcs
-    return {k: v for k, v in funcs.items() if k in exported}
+    return {
+        k: v for k, v in funcs.items()
+        if k in exported or v.is_deleted
+    }
 
 
 def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -17,12 +17,17 @@ from __future__ import annotations
 
 import re
 from collections import Counter
+from collections.abc import Collection
 
 from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
 from .diff_symbols import _PUBLIC_VIS, _public_functions, _public_variables
-from .elf_symbol_filter import is_abi_relevant_elf_symbol
+from .elf_symbol_filter import (
+    FUNCTION_SYMBOL_TYPES,
+    VARIABLE_SYMBOL_TYPES,
+    exported_symbol_names,
+)
 from .model import (
     AbiSnapshot,
     EnumType,
@@ -35,23 +40,18 @@ from .model import is_non_abi_surface_type as _is_non_abi_surface_type
 from .model import stdlib_namespaces_excluded as _exclude_stdlib_namespaces
 
 
-def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: set[str]) -> set[str]:
+def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: Collection[str]) -> set[str]:
     """Return dynamic-export names from ELF metadata when available.
 
     DWARF-primary snapshots can contain public-looking subprogram DIEs that are
     not dynamic exports.  For stripped-side retention checks, the real question
     is whether the dynamic ABI surface stayed intact, so prefer ``snap.elf`` over
-    the DWARF-derived Function/Variable lists.
+    the DWARF-derived Function/Variable lists. Transitive runtime/compiler
+    exports are excluded so they can't inflate retention.
     """
-    elf = getattr(snap, "elf", None)
-    if elf is None or not elf.symbols:
-        return set()
-    return {
-        sym.name
-        for sym in elf.symbols
-        if getattr(sym.sym_type, "value", sym.sym_type) in symbol_types
-        and is_abi_relevant_elf_symbol(sym.name)
-    }
+    return exported_symbol_names(
+        getattr(snap, "elf", None), symbol_types, abi_relevant_only=True
+    )
 
 
 def _is_abi_surface_type(t: RecordType, *, exclude_stdlib: bool) -> bool:
@@ -117,15 +117,15 @@ def _removals_are_unconfirmed(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     # retention and defeat the suppression for a genuinely intact comparison.
     # Prefer functions; fall back to variables for data-only DSOs so a changed
     # variable surface still surfaces removals (CodeRabbit review on PR #275).
-    old_funcs = _exported_elf_symbol_names(old, symbol_types={"func", "ifunc", "notype"})
-    new_funcs = _exported_elf_symbol_names(new, symbol_types={"func", "ifunc", "notype"})
+    old_funcs = _exported_elf_symbol_names(old, symbol_types=FUNCTION_SYMBOL_TYPES)
+    new_funcs = _exported_elf_symbol_names(new, symbol_types=FUNCTION_SYMBOL_TYPES)
     if not old_funcs or not new_funcs:
         old_funcs = {k for k, v in old.function_map.items() if v.visibility in _PUBLIC_VIS}
         new_funcs = {k for k, v in new.function_map.items() if v.visibility in _PUBLIC_VIS}
     if old_funcs:
         return len(old_funcs & new_funcs) / len(old_funcs) >= 0.9
-    old_vars = _exported_elf_symbol_names(old, symbol_types={"object", "tls", "common", "notype"})
-    new_vars = _exported_elf_symbol_names(new, symbol_types={"object", "tls", "common", "notype"})
+    old_vars = _exported_elf_symbol_names(old, symbol_types=VARIABLE_SYMBOL_TYPES)
+    new_vars = _exported_elf_symbol_names(new, symbol_types=VARIABLE_SYMBOL_TYPES)
     if not old_vars or not new_vars:
         old_vars = {k for k, v in old.variable_map.items() if v.visibility in _PUBLIC_VIS}
         new_vars = {k for k, v in new.variable_map.items() if v.visibility in _PUBLIC_VIS}

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -22,6 +22,7 @@ from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
 from .diff_symbols import _PUBLIC_VIS, _public_functions, _public_variables
+from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .model import (
     AbiSnapshot,
     EnumType,
@@ -49,6 +50,7 @@ def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: set[str]) -> 
         sym.name
         for sym in elf.symbols
         if getattr(sym.sym_type, "value", sym.sym_type) in symbol_types
+        and is_abi_relevant_elf_symbol(sym.name)
     }
 
 
@@ -115,16 +117,16 @@ def _removals_are_unconfirmed(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     # retention and defeat the suppression for a genuinely intact comparison.
     # Prefer functions; fall back to variables for data-only DSOs so a changed
     # variable surface still surfaces removals (CodeRabbit review on PR #275).
-    old_funcs = _exported_elf_symbol_names(old, symbol_types={"func", "ifunc"})
-    new_funcs = _exported_elf_symbol_names(new, symbol_types={"func", "ifunc"})
-    if not old_funcs:
+    old_funcs = _exported_elf_symbol_names(old, symbol_types={"func", "ifunc", "notype"})
+    new_funcs = _exported_elf_symbol_names(new, symbol_types={"func", "ifunc", "notype"})
+    if not old_funcs or not new_funcs:
         old_funcs = {k for k, v in old.function_map.items() if v.visibility in _PUBLIC_VIS}
         new_funcs = {k for k, v in new.function_map.items() if v.visibility in _PUBLIC_VIS}
     if old_funcs:
         return len(old_funcs & new_funcs) / len(old_funcs) >= 0.9
     old_vars = _exported_elf_symbol_names(old, symbol_types={"object", "tls", "common", "notype"})
     new_vars = _exported_elf_symbol_names(new, symbol_types={"object", "tls", "common", "notype"})
-    if not old_vars:
+    if not old_vars or not new_vars:
         old_vars = {k for k, v in old.variable_map.items() if v.visibility in _PUBLIC_VIS}
         new_vars = {k for k, v in new.variable_map.items() if v.visibility in _PUBLIC_VIS}
     if not old_vars:

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -34,6 +34,24 @@ from .model import is_non_abi_surface_type as _is_non_abi_surface_type
 from .model import stdlib_namespaces_excluded as _exclude_stdlib_namespaces
 
 
+def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: set[str]) -> set[str]:
+    """Return dynamic-export names from ELF metadata when available.
+
+    DWARF-primary snapshots can contain public-looking subprogram DIEs that are
+    not dynamic exports.  For stripped-side retention checks, the real question
+    is whether the dynamic ABI surface stayed intact, so prefer ``snap.elf`` over
+    the DWARF-derived Function/Variable lists.
+    """
+    elf = getattr(snap, "elf", None)
+    if elf is None or not elf.symbols:
+        return set()
+    return {
+        sym.name
+        for sym in elf.symbols
+        if getattr(sym.sym_type, "value", sym.sym_type) in symbol_types
+    }
+
+
 def _is_abi_surface_type(t: RecordType, *, exclude_stdlib: bool) -> bool:
     """True if record *t* is part of the inspected library's ABI surface.
 
@@ -97,14 +115,20 @@ def _removals_are_unconfirmed(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     # retention and defeat the suppression for a genuinely intact comparison.
     # Prefer functions; fall back to variables for data-only DSOs so a changed
     # variable surface still surfaces removals (CodeRabbit review on PR #275).
-    old_funcs = {k for k, v in old.function_map.items() if v.visibility in _PUBLIC_VIS}
-    if old_funcs:
+    old_funcs = _exported_elf_symbol_names(old, symbol_types={"func", "ifunc"})
+    new_funcs = _exported_elf_symbol_names(new, symbol_types={"func", "ifunc"})
+    if not old_funcs:
+        old_funcs = {k for k, v in old.function_map.items() if v.visibility in _PUBLIC_VIS}
         new_funcs = {k for k, v in new.function_map.items() if v.visibility in _PUBLIC_VIS}
+    if old_funcs:
         return len(old_funcs & new_funcs) / len(old_funcs) >= 0.9
-    old_vars = {k for k, v in old.variable_map.items() if v.visibility in _PUBLIC_VIS}
+    old_vars = _exported_elf_symbol_names(old, symbol_types={"object", "tls", "common", "notype"})
+    new_vars = _exported_elf_symbol_names(new, symbol_types={"object", "tls", "common", "notype"})
+    if not old_vars:
+        old_vars = {k for k, v in old.variable_map.items() if v.visibility in _PUBLIC_VIS}
+        new_vars = {k for k, v in new.variable_map.items() if v.visibility in _PUBLIC_VIS}
     if not old_vars:
         return True  # no exported surface to corroborate; absence of types is just stripping
-    new_vars = {k for k, v in new.variable_map.items() if v.visibility in _PUBLIC_VIS}
     return len(old_vars & new_vars) / len(old_vars) >= 0.9
 
 
@@ -1161,4 +1185,3 @@ def _diff_const_overloads(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 new_value="const overload removed",
             ))
     return changes
-

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -47,6 +47,7 @@ from .dumper_castxml import (
 from .dumper_castxml import (
     _vt_sort_key as _vt_sort_key,
 )
+from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .errors import SnapshotError, ValidationError
 from .model import (
     AbiSnapshot,
@@ -66,38 +67,6 @@ def _castxml_available() -> bool:
 
 _HIDDEN_VIS = frozenset({"STV_HIDDEN", "STV_INTERNAL"})
 
-# ---------------------------------------------------------------------------
-# ELF-only mode: ABI-relevance filter
-# ---------------------------------------------------------------------------
-# Prefixes that identify GCC/compiler-internal symbols which may leak into
-# .dynsym through statically-linked runtime (e.g. libgcc_s, SVML).
-_GCC_INTERNAL_PREFIXES = (
-    "ix86_",
-    "x86_64_",
-    "__cpu_model",
-    "__cpu_features",
-    "_ZGV",          # GCC SIMD vector variants (e.g. _ZGVbN2v_sin)
-    "__svml_",       # Intel Short Vector Math Library
-    "__libm_sse2_",
-    "__libm_avx_",
-)
-
-# Prefixes that identify transitive C++ standard-library symbols which may
-# appear in .dynsym via weak linkage (libstdc++ / libc++).
-_STDLIB_PREFIXES = (
-    "_ZNSt",              # std:: namespace members (libstdc++)
-    "_ZNKSt",             # const std:: methods
-    "_ZNSt3__1",          # libc++ inline-namespace __1
-    "_ZdlPv",             # operator delete(void*)
-    "_ZnwSt",             # operator new(std::size_t)
-    "_ZnaSt",             # operator new[](std::size_t)
-    "_ZdaPv",             # operator delete[](void*)
-    "_ZTVN10__cxxabiv",   # vtables for RTTI (typeinfo infrastructure)
-    "_ZTI",               # typeinfo objects
-    "_ZTS",               # typeinfo strings
-    "_ZSt",               # std:: global symbols (e.g. _ZSt4cout)
-)
-
 
 def _is_abi_relevant_symbol(name: str) -> bool:
     """Return False for symbols that are NOT part of the library's public ABI.
@@ -112,32 +81,7 @@ def _is_abi_relevant_symbol(name: str) -> bool:
        naming convention and are *not* part of the public API, even though
        they may have global ELF visibility.
     """
-    if not name:
-        return False
-
-    # GCC/compiler internals
-    for prefix in _GCC_INTERNAL_PREFIXES:
-        if name.startswith(prefix):
-            return False
-
-    # Transitive libstdc++/libc++ symbols
-    for prefix in _STDLIB_PREFIXES:
-        if name.startswith(prefix):
-            return False
-
-    # Private C symbols with __ as a namespace separator
-    # (e.g. H5C__flush_marked_entries, MPI__send).
-    # Exclusions:
-    #   • C++ mangled names start with _Z — handled separately by demangler.
-    #   • System symbols start with __ or _ followed by an uppercase letter
-    #     (POSIX/C reserved) — they are already excluded because they start
-    #     with __ which would be caught if we checked name[0:2], but we want
-    #     to be precise: we only filter names that have __ *after* the first
-    #     two characters, meaning the library itself added the separator.
-    if not name.startswith("_Z") and "__" in name[2:]:
-        return False
-
-    return True
+    return is_abi_relevant_elf_symbol(name)
 
 
 def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1040,9 +1040,8 @@ def _dump_macho(
                     mangled=_normalize_macho_sym(exp.name),
                     return_type="?",
                     # ELF_ONLY: marks symbols as export-table-only (no header
-                    # confirmation).  This ensures the checker uses
-                    # FUNC_REMOVED_ELF_ONLY (compatible) rather than
-                    # FUNC_REMOVED (breaking) for visibility-cleanup removals.
+                    # confirmation). This lets the checker distinguish
+                    # binary-only removals as FUNC_REMOVED_ELF_ONLY.
                     visibility=Visibility.ELF_ONLY,
                     is_extern_c=not _normalize_macho_sym(exp.name).startswith("_Z"),
                 )

--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -55,6 +55,7 @@ from .model import (
     TypeField,
     Variable,
     Visibility,
+    is_cxx_runtime_library,
 )
 from .model import (
     is_compiler_internal_type as _is_compiler_internal,
@@ -183,8 +184,13 @@ class _DwarfSnapshotBuilder:
     """
 
     def __init__(self, elf_path: Path, elf_meta: ElfMetadata) -> None:
+        elf_path = Path(elf_path)
         self._elf_path = elf_path
         self._elf_meta = elf_meta
+        self._filter_transitive_runtime_symbols = not (
+            is_cxx_runtime_library(elf_path.name)
+            or is_cxx_runtime_library(elf_meta.soname)
+        )
 
         # Build exported symbol sets from ELF metadata, excluding
         # hidden/internal visibility symbols (not part of the public ABI)
@@ -195,7 +201,7 @@ class _DwarfSnapshotBuilder:
                 if (
                     sym.name
                     and sym.visibility not in _HIDDEN_VIS
-                    and is_abi_relevant_elf_symbol(sym.name)
+                    and self._is_abi_relevant_export(sym.name)
                 ):
                     self._exported_names.add(sym.name)
 
@@ -320,12 +326,16 @@ class _DwarfSnapshotBuilder:
         if not linkage_name:
             linkage_name = _attr_str(die, "DW_AT_MIPS_linkage_name")
         mangled = linkage_name or name
+        qualified_name = f"{scope}::{name}" if scope else name
 
         # Deleted functions intentionally bypass the exported-symbol check below
         # so a public API that becomes ``= delete`` is still observable. Do not
         # let that bypass re-admit transitive stdlib/runtime subprograms into a
         # non-runtime library's public surface.
-        if not is_abi_relevant_elf_symbol(mangled):
+        if (
+            not self._is_abi_relevant_export(mangled)
+            or not self._is_abi_relevant_export(qualified_name)
+        ):
             return
 
         # DWARF5 DW_AT_deleted: function marked as = delete by the compiler.
@@ -389,9 +399,6 @@ class _DwarfSnapshotBuilder:
         if "DW_AT_vtable_elem_location" in die.attributes:
             vtable_index = _attr_int(die, "DW_AT_vtable_elem_location")
 
-        # Build qualified name for methods
-        qualified_name = f"{scope}::{name}" if scope else name
-
         self.functions.append(Function(
             name=qualified_name if scope else name,
             mangled=mangled,
@@ -409,6 +416,12 @@ class _DwarfSnapshotBuilder:
             deleted_from_dwarf=is_deleted,
             is_explicit=is_explicit,
         ))
+
+    def _is_abi_relevant_export(self, name: str) -> bool:
+        """Return True when *name* belongs to this DSO's own ABI surface."""
+        if not self._filter_transitive_runtime_symbols:
+            return bool(name)
+        return is_abi_relevant_elf_symbol(name)
 
     def _process_param(self, die: Any, CU: Any) -> Param | None:
         """Extract a parameter from DW_TAG_formal_parameter."""

--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -42,6 +42,7 @@ from .dwarf_utils import decode_member_location as _decode_member_location
 from .dwarf_utils import has_real_dwarf_info
 from .dwarf_utils import resolve_die_ref as _resolve_ref
 from .dwarf_utils import resolve_type_die as _resolve_type_die
+from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .model import (
     AbiSnapshot,
     AccessLevel,
@@ -191,7 +192,11 @@ class _DwarfSnapshotBuilder:
         self._exported_names: set[str] = set()
         if elf_meta.symbols:
             for sym in elf_meta.symbols:
-                if sym.name and sym.visibility not in _HIDDEN_VIS:
+                if (
+                    sym.name
+                    and sym.visibility not in _HIDDEN_VIS
+                    and is_abi_relevant_elf_symbol(sym.name)
+                ):
                     self._exported_names.add(sym.name)
 
         # Build demangled export index for C++ fallback matching (FIX-B).
@@ -315,6 +320,13 @@ class _DwarfSnapshotBuilder:
         if not linkage_name:
             linkage_name = _attr_str(die, "DW_AT_MIPS_linkage_name")
         mangled = linkage_name or name
+
+        # Deleted functions intentionally bypass the exported-symbol check below
+        # so a public API that becomes ``= delete`` is still observable. Do not
+        # let that bypass re-admit transitive stdlib/runtime subprograms into a
+        # non-runtime library's public surface.
+        if not is_abi_relevant_elf_symbol(mangled):
+            return
 
         # DWARF5 DW_AT_deleted: function marked as = delete by the compiler.
         # Currently only emitted by very recent compilers (not yet in GCC/Clang mainline).

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -16,6 +16,19 @@
 """ELF ABI-relevance filtering shared by symbol and DWARF paths."""
 from __future__ import annotations
 
+from collections.abc import Collection
+from typing import Any
+
+# ELF symbol types (STT_*) that represent a callable function surface and a
+# data/variable surface respectively. ``STT_NOTYPE`` is deliberately accepted by
+# *both*: assembly stubs, IFUNC resolvers and stripped dynamic entries are
+# frequently emitted as NOTYPE, so excluding them would drop real ABI. The minor
+# over-inclusion (a NOTYPE name counting toward both sets) is harmless for the
+# membership / retention checks these sets feed. ``SymbolType`` is a ``str``
+# enum, so these string values compare equal to its members.
+FUNCTION_SYMBOL_TYPES: frozenset[str] = frozenset({"func", "ifunc", "notype"})
+VARIABLE_SYMBOL_TYPES: frozenset[str] = frozenset({"object", "tls", "common", "notype"})
+
 # Prefixes that identify GCC/compiler-internal symbols which may leak into
 # .dynsym through statically-linked runtime (e.g. libgcc_s, SVML).
 _GCC_INTERNAL_PREFIXES = (
@@ -96,3 +109,35 @@ def is_abi_relevant_elf_symbol(name: str) -> bool:
         return False
 
     return True
+
+
+def exported_symbol_names(
+    elf: Any,
+    symbol_types: Collection[str],
+    *,
+    abi_relevant_only: bool = False,
+) -> set[str]:
+    """Return dynamic-export names of the requested ``symbol_types`` from *elf*.
+
+    *elf* is an :class:`~abicheck.elf_metadata.ElfMetadata` (or ``None``).
+    Returns an empty set when no ELF symbol table is present, so callers can use
+    ``if not exported`` to fall back to a DWARF-derived view.
+
+    ``getattr(sym.sym_type, "value", sym.sym_type)`` accepts both a ``SymbolType``
+    enum member and a raw string (e.g. from a serialized snapshot). When
+    *abi_relevant_only* is set, transitive runtime / compiler-internal exports
+    are dropped via :func:`is_abi_relevant_elf_symbol`.
+    """
+    if elf is None or not getattr(elf, "symbols", None):
+        return set()
+    names: set[str] = set()
+    for sym in elf.symbols:
+        if not sym.name:
+            continue
+        sym_type = getattr(sym.sym_type, "value", sym.sym_type)
+        if sym_type not in symbol_types:
+            continue
+        if abi_relevant_only and not is_abi_relevant_elf_symbol(sym.name):
+            continue
+        names.add(sym.name)
+    return names

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -49,9 +49,20 @@ _STDLIB_PREFIXES = (
     "_ZnaSt",             # operator new[](std::size_t)
     "_ZdaPv",             # operator delete[](void*)
     "_ZTVN10__cxxabiv",   # vtables for RTTI (typeinfo infrastructure)
-    "_ZTI",               # typeinfo objects
-    "_ZTS",               # typeinfo strings
     "_ZSt",               # std:: global symbols (e.g. _ZSt4cout)
+)
+
+_STDLIB_RTTI_PREFIXES = (
+    "_ZTISt",             # typeinfo for std::* / std::exception, etc.
+    "_ZTSSt",             # typeinfo name for std::* / std::exception, etc.
+    "_ZTINSt",            # typeinfo for nested std::* names
+    "_ZTSNSt",            # typeinfo name for nested std::* names
+    "_ZTIN9__gnu_cxx",
+    "_ZTSN9__gnu_cxx",
+    "_ZTIN10__cxxabiv",
+    "_ZTSN10__cxxabiv",
+    "_ZTIN7__cxx11",
+    "_ZTSN7__cxx11",
 )
 
 
@@ -71,6 +82,10 @@ def is_abi_relevant_elf_symbol(name: str) -> bool:
             return False
 
     for prefix in _STDLIB_PREFIXES:
+        if name.startswith(prefix):
+            return False
+
+    for prefix in _STDLIB_RTTI_PREFIXES:
         if name.startswith(prefix):
             return False
 

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +32,11 @@ _GCC_INTERNAL_PREFIXES = (
 # Prefixes that identify transitive C++ standard-library symbols which may
 # appear in .dynsym via weak linkage (libstdc++ / libc++).
 _STDLIB_PREFIXES = (
+    "std::",
+    "__gnu_cxx::",
+    "__gnu_debug::",
+    "__cxxabiv1::",
+    "__cxx11::",
     "_ZNSt",              # std:: namespace members (libstdc++)
     "_ZNKSt",             # const std:: methods
     "_ZNVSt",             # volatile std:: methods

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ELF ABI-relevance filtering shared by symbol and DWARF paths."""
+from __future__ import annotations
+
+# Prefixes that identify GCC/compiler-internal symbols which may leak into
+# .dynsym through statically-linked runtime (e.g. libgcc_s, SVML).
+_GCC_INTERNAL_PREFIXES = (
+    "ix86_",
+    "x86_64_",
+    "__cpu_model",
+    "__cpu_features",
+    "_ZGV",          # GCC SIMD vector variants (e.g. _ZGVbN2v_sin)
+    "__svml_",       # Intel Short Vector Math Library
+    "__libm_sse2_",
+    "__libm_avx_",
+)
+
+# Prefixes that identify transitive C++ standard-library symbols which may
+# appear in .dynsym via weak linkage (libstdc++ / libc++).
+_STDLIB_PREFIXES = (
+    "_ZNSt",              # std:: namespace members (libstdc++)
+    "_ZNKSt",             # const std:: methods
+    "_ZNSt3__1",          # libc++ inline-namespace __1
+    "_ZdlPv",             # operator delete(void*)
+    "_ZnwSt",             # operator new(std::size_t)
+    "_ZnaSt",             # operator new[](std::size_t)
+    "_ZdaPv",             # operator delete[](void*)
+    "_ZTVN10__cxxabiv",   # vtables for RTTI (typeinfo infrastructure)
+    "_ZTI",               # typeinfo objects
+    "_ZTS",               # typeinfo strings
+    "_ZSt",               # std:: global symbols (e.g. _ZSt4cout)
+)
+
+
+def is_abi_relevant_elf_symbol(name: str) -> bool:
+    """Return False for ELF symbols that are not the library's own ABI.
+
+    This filter must be shared by both the ELF-only and DWARF-backed snapshot
+    paths. Otherwise a weak transitive libstdc++ export can be excluded from
+    symbols-only reports yet re-enter as a ``PUBLIC`` DWARF function, producing
+    false ``FUNC_REMOVED`` and type-reachability findings.
+    """
+    if not name:
+        return False
+
+    for prefix in _GCC_INTERNAL_PREFIXES:
+        if name.startswith(prefix):
+            return False
+
+    for prefix in _STDLIB_PREFIXES:
+        if name.startswith(prefix):
+            return False
+
+    # Private C symbols with __ as a namespace separator
+    # (e.g. H5C__flush_marked_entries, MPI__send). C++ mangled names start
+    # with _Z and are handled separately above.
+    if not name.startswith("_Z") and "__" in name[2:]:
+        return False
+
+    return True

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -33,6 +33,10 @@ _GCC_INTERNAL_PREFIXES = (
 _STDLIB_PREFIXES = (
     "_ZNSt",              # std:: namespace members (libstdc++)
     "_ZNKSt",             # const std:: methods
+    "_ZNVSt",             # volatile std:: methods
+    "_ZNRSt",             # ref-qualified std:: methods
+    "_ZNKRSt",            # const/ref-qualified std:: methods
+    "_ZNVRSt",            # volatile/ref-qualified std:: methods
     "_ZNSt3__1",          # libc++ inline-namespace __1
     "_ZdlPv",             # operator delete(void*)
     "_ZnwSt",             # operator new(std::size_t)

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -189,7 +189,7 @@ public."
 | Case | Behavior under this design |
 |------|----------------------------|
 | **A.** PE/Mach-O headers ignored | **Fixed (PR #259):** headers plumbed through, directories expanded, explicit warning + export-table fallback when castxml is unavailable or names don't match. |
-| **B.** Private *symbol* change/removal flagged | `header-scoped` mode: demoted to compatible/informational, recorded in the ledger as `private-header`/`not-exported`. Removal already maps to `FUNC_REMOVED_ELF_ONLY` (compatible). |
+| **B.** Private *symbol* change/removal flagged | `header-scoped` mode: demoted to compatible/informational, recorded in the ledger as `private-header`/`not-exported`. Binary-only removal maps to `FUNC_REMOVED_ELF_ONLY`, which strict ABI policy treats as breaking without header evidence. |
 | **C.** Private *field* inside a public struct changes layout | **Still a real break** — reachability (D3) keeps it in surface. Documented as *not* a false positive: it is observable to consumers. |
 | **D.** Private declaration pulled in via transitive `#include` of a public header | Excluded by provenance (D2): its `source_header` is not in the provided public-header set — *unless* it is reachable from a public API, in which case the leak guard (D5.2) reports it. |
 

--- a/docs/examples/by-category/breaking.md
+++ b/docs/examples/by-category/breaking.md
@@ -3,7 +3,7 @@
 
 Listed in `BREAKING_KINDS` — runtime ABI break.
 
-_83 case(s)._ [← back to all examples](../index.md)
+_84 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
@@ -90,3 +90,4 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case89_inline_accessor_renamed_pimpl_member](../case89_inline_accessor_renamed_pimpl_member.md) | Inline accessor references renamed pimpl member | 🔴 BREAKING | Breaking |
 | [case94_empty_tag_gained_state](../case94_empty_tag_gained_state.md) | Empty Tag Gained State | 🔴 BREAKING | Breaking |
 | [case95_allocator_nested_typedef_removed](../case95_allocator_nested_typedef_removed.md) | Allocator Nested-Typedef Removed | 🔴 BREAKING | Breaking |
+| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🔴 BREAKING | Breaking |

--- a/docs/examples/by-category/quality.md
+++ b/docs/examples/by-category/quality.md
@@ -3,7 +3,7 @@
 
 Listed in `QUALITY_KINDS` — metadata/quality issues, not ABI breaks.
 
-_11 case(s)._ [← back to all examples](../index.md)
+_10 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
@@ -17,4 +17,3 @@ _11 case(s)._ [← back to all examples](../index.md)
 | [case51_protected_visibility](../case51_protected_visibility.md) | Protected Visibility (DEFAULT to PROTECTED) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case52_rpath_leak](../case52_rpath_leak.md) | RPATH Leak (Hardcoded Build Directory) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case54_used_reserved_field](../case54_used_reserved_field.md) | Used Reserved Field | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |

--- a/docs/examples/by-verdict/breaking.md
+++ b/docs/examples/by-verdict/breaking.md
@@ -3,7 +3,7 @@
 
 ABI breaks: existing consumers will fail at runtime.
 
-_83 case(s)._ [← back to all examples](../index.md)
+_84 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
@@ -90,3 +90,4 @@ _83 case(s)._ [← back to all examples](../index.md)
 | [case89_inline_accessor_renamed_pimpl_member](../case89_inline_accessor_renamed_pimpl_member.md) | Inline accessor references renamed pimpl member | 🔴 BREAKING | Breaking |
 | [case94_empty_tag_gained_state](../case94_empty_tag_gained_state.md) | Empty Tag Gained State | 🔴 BREAKING | Breaking |
 | [case95_allocator_nested_typedef_removed](../case95_allocator_nested_typedef_removed.md) | Allocator Nested-Typedef Removed | 🔴 BREAKING | Breaking |
+| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🔴 BREAKING | Breaking |

--- a/docs/examples/by-verdict/compatible.md
+++ b/docs/examples/by-verdict/compatible.md
@@ -3,7 +3,7 @@
 
 Backward-compatible changes (additions or quality-only).
 
-_21 case(s)._ [← back to all examples](../index.md)
+_20 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
@@ -26,5 +26,4 @@ _21 case(s)._ [← back to all examples](../index.md)
 | [case54_used_reserved_field](../case54_used_reserved_field.md) | Used Reserved Field | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case61_var_added](../case61_var_added.md) | Global Variable Added | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case62_type_field_added_compatible](../case62_type_field_added_compatible.md) | Type Field Added (Compatible — Opaque Struct) | 🟢 COMPATIBLE | Addition (Compatible) |
-| [case97_api_depends_on_consumer_env](../case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case99_experimental_graduated](../case99_experimental_graduated.md) | experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |

--- a/docs/examples/case06_visibility.md
+++ b/docs/examples/case06_visibility.md
@@ -53,9 +53,9 @@ is an ABI break for any consumer that depended on them, even if the symbols
 were only exported by accident.
 
 > **Note:** In ELF-only mode (without `-H`), both removals are classified as
-> `FUNC_REMOVED_ELF_ONLY` (COMPATIBLE) because the tool cannot distinguish
-> intentional public API from accidentally-leaked internals. Use `-H` to get
-> the accurate BREAKING verdict.
+> `FUNC_REMOVED_ELF_ONLY` (BREAKING). Header-scoped mode with `-H` can still
+> distinguish intentional public API from accidentally-leaked internals, but
+> strict binary-only mode treats removed exports as ABI breaks.
 
 ## Dual nature of this case
 

--- a/docs/examples/case97_api_depends_on_consumer_env.md
+++ b/docs/examples/case97_api_depends_on_consumer_env.md
@@ -3,10 +3,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Verdict** | 🟢 **COMPATIBLE** |
-| **Category** | Quality (Compatible) |
+| **Verdict** | 🔴 **BREAKING** |
+| **Category** | Breaking |
 | **Platforms** | Linux, macOS, Windows |
-| **Flags** | — |
+| **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `func_removed_elf_only` |
 | **Source files** | `examples/case97_api_depends_on_consumer_env/` |
 
@@ -44,4 +44,4 @@ finding is layered on top by the probe-harness pipeline and reported as
 - `v2.cpp`
 - `v2.h`
 
-_See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._
+_See also: [Examples overview](index.md) · [All BREAKING cases](by-verdict/breaking.md) · [Category: Breaking](by-category/breaking.md)._

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -16,10 +16,10 @@ Use this catalog to:
 
 | Verdict | Count | What it means |
 |---------|-------|---------------|
-| 🔴 [BREAKING](by-verdict/breaking.md) | 83 | ABI breaks: existing consumers will fail at runtime. |
+| 🔴 [BREAKING](by-verdict/breaking.md) | 84 | ABI breaks: existing consumers will fail at runtime. |
 | 🟠 [API_BREAK](by-verdict/api-break.md) | 4 | Source-level / API-only breaks; recompilation fails or behavior shifts. |
 | 🟡 [COMPATIBLE_WITH_RISK](by-verdict/compatible-risk.md) | 2 | Backward-compatible at the symbol level but with behavioral risk. |
-| 🟢 [COMPATIBLE](by-verdict/compatible.md) | 21 | Backward-compatible changes (additions or quality-only). |
+| 🟢 [COMPATIBLE](by-verdict/compatible.md) | 20 | Backward-compatible changes (additions or quality-only). |
 | ✅ [NO_CHANGE](by-verdict/no-change.md) | 6 | Identical ABI/API — baseline control cases. |
 
 ## How to read a case page
@@ -39,11 +39,11 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 
 | Category | Cases | What it covers |
 |----------|-------|----------------|
-| [Breaking](by-category/breaking.md) | 83 | Listed in `BREAKING_KINDS` — runtime ABI break. |
+| [Breaking](by-category/breaking.md) | 84 | Listed in `BREAKING_KINDS` — runtime ABI break. |
 | [API Break](by-category/api_break.md) | 4 | Listed in `API_BREAK_KINDS` — source/API-level break. |
 | [Risk](by-category/risk.md) | 2 | Listed in `RISK_KINDS` — symbol-compatible but behaviorally risky. |
 | [Addition (Compatible)](by-category/addition.md) | 10 | Listed in `ADDITION_KINDS` — backward-compatible additions. |
-| [Quality (Compatible)](by-category/quality.md) | 11 | Listed in `QUALITY_KINDS` — metadata/quality issues, not ABI breaks. |
+| [Quality (Compatible)](by-category/quality.md) | 10 | Listed in `QUALITY_KINDS` — metadata/quality issues, not ABI breaks. |
 | [No Change](by-category/no_change.md) | 6 | Identical ABI/API — sanity-check baselines. |
 
 ## All cases
@@ -163,6 +163,6 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 | [case94_empty_tag_gained_state](case94_empty_tag_gained_state.md) | Empty Tag Gained State | 🔴 BREAKING | Breaking |
 | [case95_allocator_nested_typedef_removed](case95_allocator_nested_typedef_removed.md) | Allocator Nested-Typedef Removed | 🔴 BREAKING | Breaking |
 | [case96_hidden_friend_removed](case96_hidden_friend_removed.md) | Hidden Friend Operator Removed | 🟠 API_BREAK | API Break |
-| [case97_api_depends_on_consumer_env](case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case97_api_depends_on_consumer_env](case97_api_depends_on_consumer_env.md) | public API depends on consumer build environment (RISK) | 🔴 BREAKING | Breaking |
 | [case98_cxx_standard_floor_raised](case98_cxx_standard_floor_raised.md) | C++ standard floor raised (per-binary: NO_CHANGE) | ✅ NO_CHANGE | No Change |
 | [case99_experimental_graduated](case99_experimental_graduated.md) | experimental → stable graduation (compatible) | 🟢 COMPATIBLE | Addition (Compatible) |

--- a/docs/reference/change-kinds.md
+++ b/docs/reference/change-kinds.md
@@ -24,6 +24,7 @@ These changes are immediately incompatible with existing compiled binaries.
 | Kind | Description |
 |------|-------------|
 | `func_removed` | Public function removed from the exported symbol table. Callers crash at load time with an undefined symbol error. |
+| `func_removed_elf_only` | Exported function symbol removed in binary-only/symbols-only mode. Header evidence is unavailable, so strict ABI policy treats the removed dynamic export as a binary break. |
 | `func_return_changed` | Function return type changed. Callers reading the return value will interpret the wrong bytes — silent data corruption or crashes. |
 | `func_params_changed` | Function parameter types or count changed. The calling convention breaks: arguments are placed in wrong registers/stack slots. |
 | `func_virtual_added` | A non-virtual method became virtual. Changes the vtable layout: any class with this as a base will have a different vtable offset for all methods after this one. |
@@ -261,7 +262,6 @@ These changes are safe: they add new capabilities or carry diagnostic informatio
 | `var_added` | A new public global variable was exported. Existing binaries are unaffected. |
 | `type_added` | A new type was added to the public API. Additive — existing consumers are unchanged. |
 | `type_field_added_compatible` | A field was appended to a standard-layout, non-polymorphic struct. Size increases but no existing field offsets shift. Compatible only for types meeting the standard-layout criteria. |
-| `func_removed_elf_only` | An ELF-only symbol (no public header declaration) was removed. This is a visibility cleanup — not a public ABI break since headers never exposed the symbol. |
 
 ### Enum Additions
 

--- a/examples/case06_visibility/README.md
+++ b/examples/case06_visibility/README.md
@@ -43,9 +43,9 @@ is an ABI break for any consumer that depended on them, even if the symbols
 were only exported by accident.
 
 > **Note:** In ELF-only mode (without `-H`), both removals are classified as
-> `FUNC_REMOVED_ELF_ONLY` (COMPATIBLE) because the tool cannot distinguish
-> intentional public API from accidentally-leaked internals. Use `-H` to get
-> the accurate BREAKING verdict.
+> `FUNC_REMOVED_ELF_ONLY` (BREAKING). Header-scoped mode with `-H` can still
+> distinguish intentional public API from accidentally-leaked internals, but
+> strict binary-only mode treats removed exports as ABI breaks.
 
 ## Dual nature of this case
 

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -784,7 +784,7 @@
       "api_break": true,
       "bad_practice": false,
       "description": "Global variable lib_debug_level removed from export table (VAR_REMOVED)",
-      "known_gap": "macOS: Tool returns COMPATIBLE \u2014 Mach-O export table does not distinguish functions from variables; lib_debug_level detected as func_removed_elf_only instead of var_removed",
+      "known_gap": "macOS: Mach-O export table does not distinguish functions from variables, so lib_debug_level can be detected as func_removed_elf_only instead of var_removed; both are breaking under strict binary policy.",
       "expected_kinds": [
         "var_removed"
       ]
@@ -1564,17 +1564,17 @@
       ]
     },
     "case97_api_depends_on_consumer_env": {
-      "expected": "COMPATIBLE",
-      "category": "quality",
+      "expected": "BREAKING",
+      "category": "breaking",
       "platforms": [
         "linux",
         "macos",
         "windows"
       ],
-      "abi_break": false,
+      "abi_break": true,
       "api_break": false,
       "bad_practice": false,
-      "known_gap": "The single-config build harness does not exercise the matrix-aware API_DEPENDS_ON_CONSUMER_ENV detector \u2014 that detector consumes a MatrixSnapshot (multiple per-configuration snapshots) which is only produced by the `abicheck probe` subcommand (not wired into the default `compare` CLI yet). In the current single-config build, castxml dumps v1.h and v2.h WITHOUT USE_FEATURE defined, so the declared-function set is identical between v1 and v2; the underlying lib v1 still exports `extended` because v1.cpp `#define USE_FEATURE 1` before include \u2014 that surfaces as FUNC_REMOVED_ELF_ONLY (a quality-level finding) when CI builds the case, so the per-binary verdict is COMPATIBLE. The case is preserved as documentation of the macro-conditioned shape; the real BREAKING-grade finding only appears via the matrix detector.",
+      "known_gap": "The single-config build harness does not exercise the matrix-aware API_DEPENDS_ON_CONSUMER_ENV detector \u2014 that detector consumes a MatrixSnapshot (multiple per-configuration snapshots) which is only produced by the `abicheck probe` subcommand (not wired into the default `compare` CLI yet). In the current single-config build, castxml dumps v1.h and v2.h WITHOUT USE_FEATURE defined, so the declared-function set is identical between v1 and v2; the underlying lib v1 still exports `extended` because v1.cpp `#define USE_FEATURE 1` before include \u2014 that surfaces as FUNC_REMOVED_ELF_ONLY in per-binary comparison. The case is preserved as documentation of the macro-conditioned shape; the matrix detector remains the richer explanation channel.",
       "description": "Header declares `lib::extended()` only when the consumer defines `USE_FEATURE`. The v1 build defines the macro and exports extended(); v2 builds without it. The matrix-aware API_DEPENDS_ON_CONSUMER_ENV finding is the channel that exposes this when both macro states are probed.",
       "expected_kinds": [
         "func_removed_elf_only"

--- a/scripts/demo_libz.py
+++ b/scripts/demo_libz.py
@@ -79,6 +79,12 @@ def main() -> None:
             return_type="int", visibility=Visibility.PUBLIC,
         ))
 
+        # The simulated future snapshot mutates headers/functions in memory, not
+        # a real rebuilt .so. Drop stale ELF metadata so the comparison uses the
+        # synthetic header surface consistently.
+        snap_v1.elf = None
+        snap_v2.elf = None
+
         snap2_path = tmp / "libz-1.4.json"
         save_snapshot(snap_v2, snap2_path)
         print(f"  Removed : {removed}")

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -289,7 +289,7 @@ class TestVerdictPriority:
 
 
 
-def test_func_removed_elf_only_is_compatible_not_breaking() -> None:
+def test_func_removed_elf_only_is_breaking() -> None:
     old = AbiSnapshot(
         library="libfoo.so", version="1.0",
         functions=[Function(name="internal", mangled="internal", return_type="void", visibility=Visibility.ELF_ONLY)],
@@ -299,7 +299,7 @@ def test_func_removed_elf_only_is_compatible_not_breaking() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.FUNC_REMOVED_ELF_ONLY in kinds
-    assert result.verdict == Verdict.COMPATIBLE
+    assert result.verdict == Verdict.BREAKING
 
 
 # ── WS-4a: ELF visibility tracking ─────────────────────────────────────────

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -11,7 +11,12 @@ import pytest
 
 from abicheck.dumper import _is_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
-from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
+from abicheck.elf_symbol_filter import (
+    FUNCTION_SYMBOL_TYPES,
+    VARIABLE_SYMBOL_TYPES,
+    exported_symbol_names,
+)
 
 # ---------------------------------------------------------------------------
 # Bug 1: GCC / compiler-internal symbols — must be filtered
@@ -209,3 +214,52 @@ def test_dwarf_export_index_preserves_runtime_owned_stdlib_exports(tmp_path) -> 
 
     assert "_ZNSt6vectorIiSaIiEE4sizeEv" in builder._exported_names
     assert "_ZSt4cout" in builder._exported_names
+
+
+# ---------------------------------------------------------------------------
+# Shared exported_symbol_names helper (used by diff_symbols / diff_types)
+# ---------------------------------------------------------------------------
+
+
+def test_exported_symbol_names_returns_empty_without_symbols() -> None:
+    """No ELF table (None or empty) yields an empty set so callers fall back."""
+    assert exported_symbol_names(None, FUNCTION_SYMBOL_TYPES) == set()
+    assert exported_symbol_names(ElfMetadata(symbols=[]), FUNCTION_SYMBOL_TYPES) == set()
+
+
+def test_exported_symbol_names_filters_by_symbol_type() -> None:
+    """Only the requested STT_* types are returned; empty names are skipped."""
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="do_work", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="resolver", sym_type=SymbolType.IFUNC),
+            ElfSymbol(name="g_table", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="", sym_type=SymbolType.FUNC),
+        ]
+    )
+    assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES) == {"do_work", "resolver"}
+    assert exported_symbol_names(meta, VARIABLE_SYMBOL_TYPES) == {"g_table"}
+
+
+def test_exported_symbol_names_notype_counts_for_both_surfaces() -> None:
+    """STT_NOTYPE is intentionally accepted as both a func and a variable export."""
+    meta = ElfMetadata(symbols=[ElfSymbol(name="stub", sym_type=SymbolType.NOTYPE)])
+    assert "stub" in exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES)
+    assert "stub" in exported_symbol_names(meta, VARIABLE_SYMBOL_TYPES)
+
+
+def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> None:
+    """abi_relevant_only excludes transitive stdlib exports but keeps own symbols."""
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="_ZN6MyLib4CoreC1Ev", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+        ]
+    )
+    assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES) == {
+        "_ZN6MyLib4CoreC1Ev",
+        "_ZNSt6vectorIiSaIiEE4sizeEv",
+    }
+    assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES, abi_relevant_only=True) == {
+        "_ZN6MyLib4CoreC1Ev",
+    }

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -122,6 +122,8 @@ def test_stdlib_transitive_symbols_are_filtered(name: str) -> None:
     "_ZN3Foo3barEv",
     "_ZN6MyLib4CoreC1Ev",
     "_ZNK6MyLib4Core4nameEv",
+    "_ZTIN3foo3BarE",   # typeinfo for foo::Bar
+    "_ZTSN3foo3BarE",   # typeinfo name for foo::Bar
     # Regular single-underscore prefixed symbols (not double)
     "_init",
     "_fini",

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -192,3 +192,18 @@ def test_dwarf_export_index_uses_same_abi_relevance_filter(tmp_path) -> None:
     assert "_ZN6MyLib4CoreC1Ev" in builder._exported_names
     assert builder._is_exported("_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev", "std::unique_ptr") is False
     assert builder._is_exported("_ZNVSt6atomicIiEaSERKi", "std::atomic<int>::operator=") is False
+
+
+def test_dwarf_export_index_preserves_runtime_owned_stdlib_exports(tmp_path) -> None:
+    """libstdc++/libc++ own std:: symbols, so DWARF mode must not filter them."""
+    meta = ElfMetadata(
+        soname="libstdc++.so.6",
+        symbols=[
+            ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv"),
+            ElfSymbol(name="_ZSt4cout"),
+        ],
+    )
+    builder = _DwarfSnapshotBuilder(tmp_path / "libstdc++.so.6", meta)
+
+    assert "_ZNSt6vectorIiSaIiEE4sizeEv" in builder._exported_names
+    assert "_ZSt4cout" in builder._exported_names

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -78,8 +78,12 @@ def test_private_double_underscore_symbols_are_filtered(name: str) -> None:
     # libc++ inline namespace __1
     "_ZNSt3__16threadC1Ev",
     "_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6assignEPKc",
-    # const std:: methods
+    # cv/ref-qualified std:: methods
     "_ZNKSt6vectorIiSaIiEE4sizeEv",
+    "_ZNVSt6atomicIiEaSERKi",
+    "_ZNRSt6atomicIiEaSERKi",
+    "_ZNKRSt6atomicIiEcviv",
+    "_ZNVRSt6atomicIiEaSERKi",
     # operator delete / new
     "_ZdlPv",
     "_ZdlPvSt11align_val_t",
@@ -177,11 +181,14 @@ def test_dwarf_export_index_uses_same_abi_relevance_filter(tmp_path) -> None:
     meta = ElfMetadata(
         symbols=[
             ElfSymbol(name="_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev"),
+            ElfSymbol(name="_ZNVSt6atomicIiEaSERKi"),
             ElfSymbol(name="_ZN6MyLib4CoreC1Ev"),
         ]
     )
     builder = _DwarfSnapshotBuilder(tmp_path / "libfoo.so", meta)
 
     assert "_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev" not in builder._exported_names
+    assert "_ZNVSt6atomicIiEaSERKi" not in builder._exported_names
     assert "_ZN6MyLib4CoreC1Ev" in builder._exported_names
     assert builder._is_exported("_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev", "std::unique_ptr") is False
+    assert builder._is_exported("_ZNVSt6atomicIiEaSERKi", "std::atomic<int>::operator=") is False

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import pytest
 
 from abicheck.dumper import _is_abi_relevant_symbol
+from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol
 
 # ---------------------------------------------------------------------------
 # Bug 1: GCC / compiler-internal symbols — must be filtered
@@ -168,3 +170,18 @@ def test_double_underscore_boundary(name: str, expected: bool) -> None:
     assert _is_abi_relevant_symbol(name) is expected, (
         f"_is_abi_relevant_symbol({name!r}) expected {expected}"
     )
+
+
+def test_dwarf_export_index_uses_same_abi_relevance_filter(tmp_path) -> None:
+    """DWARF mode must not re-admit stdlib weak exports as public functions."""
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev"),
+            ElfSymbol(name="_ZN6MyLib4CoreC1Ev"),
+        ]
+    )
+    builder = _DwarfSnapshotBuilder(tmp_path / "libfoo.so", meta)
+
+    assert "_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev" not in builder._exported_names
+    assert "_ZN6MyLib4CoreC1Ev" in builder._exported_names
+    assert builder._is_exported("_ZNSt10unique_ptrINSt6thread6_StateEEC1Ev", "std::unique_ptr") is False

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -23,6 +23,7 @@ import pytest
 
 from abicheck.checker import compare
 from abicheck.checker_policy import Verdict
+from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
 from abicheck.model import (
     AbiSnapshot,
     AccessLevel,
@@ -198,6 +199,10 @@ def _exported_func(mangled: str):
                     visibility=Visibility.ELF_ONLY)
 
 
+def _elf_exports(*names: str, sym_type: SymbolType = SymbolType.FUNC) -> ElfMetadata:
+    return ElfMetadata(symbols=[ElfSymbol(name=name, sym_type=sym_type) for name in names])
+
+
 def test_stripped_new_side_does_not_fabricate_type_removals():
     # old: rich DWARF types + exported symbols
     old = _elf_snapshot(
@@ -275,6 +280,125 @@ def test_stripped_suppression_counts_only_exported_functions():
     assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes), (
         "internal DWARF functions must not deflate retention and re-enable the "
         f"phantom avalanche; changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_stripped_suppression_prefers_elf_exports_over_dwarf_public_functions():
+    """A DWARF snapshot may mark non-exported subprogram DIEs as PUBLIC.
+
+    The mixed-coverage retention guard must use the dynamic export table when it
+    exists, not the broader DWARF-derived function list.  This is the minimized
+    shape of the oneTBB allocator/proxy false positives from the real-world cron
+    campaign: old side has DWARF types plus public-looking internal helpers, new
+    side is symbols-only, and the real dynamic export surface is unchanged.
+    """
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function
+
+    old = _elf_snapshot(
+        functions=[
+            _exported_func("stable_api"),
+            Function(
+                name="internal_helper",
+                mangled="_ZN3tbb6detail8internalEv",
+                return_type="void",
+                visibility=Visibility.PUBLIC,
+            ),
+            Function(
+                name="atomic_helper",
+                mangled="_ZNVSt6atomicIbEaSERKS0_",
+                return_type="void",
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        types=[RecordType(name="tbb::detail::Internal", kind="class", size_bits=64)],
+    )
+    old.elf = _elf_exports("stable_api")
+    old.elf_only_mode = False
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")], types=[])
+    new.elf = _elf_exports("stable_api")
+    new.dwarf = None
+
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes), (
+        "unchanged ELF exports must suppress DWARF-only phantom type removals "
+        f"even when old DWARF lists non-exported public-looking helpers: "
+        f"{[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_stripped_suppression_with_elf_exports_still_reports_real_symbol_loss():
+    """Using ELF metadata for retention must not hide real dynamic ABI removal."""
+    from abicheck.checker_policy import BREAKING_KINDS
+
+    old = _elf_snapshot(
+        functions=[_exported_func("removed_api"), _exported_func("stable_api")],
+        types=[RecordType(name="PublicType", kind="class", size_bits=64)],
+    )
+    old.elf = _elf_exports("removed_api", "stable_api")
+    old.elf_only_mode = False
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")], types=[])
+    new.elf = _elf_exports("stable_api")
+    new.dwarf = None
+
+    result = compare(old, new)
+    assert any(c.kind in BREAKING_KINDS for c in result.changes), (
+        "real dynamic export removal must still be reported; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_function_diff_prefers_elf_exports_over_dwarf_public_helpers():
+    """DWARF-public helper functions are not binary ABI if absent from dynsym."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function
+
+    old = _elf_snapshot(
+        functions=[
+            _exported_func("stable_api"),
+            Function(
+                name="tbb::detail::d0::atomic_backoff::atomic_backoff",
+                mangled="_ZN3tbb6detail2d014atomic_backoffC4ERKS2_",
+                return_type="void",
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        types=[RecordType(name="tbb::detail::d0::atomic_backoff", kind="class", size_bits=64)],
+    )
+    old.elf = _elf_exports("stable_api")
+    old.elf_only_mode = False
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")], types=[])
+    new.elf = _elf_exports("stable_api")
+    new.dwarf = None
+
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.FUNC_REMOVED for c in result.changes), (
+        "DWARF-only public-looking helpers absent from ELF exports must not be "
+        f"reported as removed dynamic ABI: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_function_diff_with_elf_exports_still_reports_real_export_loss():
+    """The ELF export filter must not hide genuine removed dynamic functions."""
+    from abicheck.checker_policy import ChangeKind
+
+    old = _elf_snapshot(functions=[_exported_func("removed_api"), _exported_func("stable_api")])
+    old.elf = _elf_exports("removed_api", "stable_api")
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")])
+    new.elf = _elf_exports("stable_api")
+
+    result = compare(old, new)
+    assert any(
+        c.kind in (ChangeKind.FUNC_REMOVED, ChangeKind.FUNC_REMOVED_ELF_ONLY)
+        and c.symbol == "removed_api"
+        for c in result.changes
+    ), (
+        "removing a real dynamic function export must still be reported; "
+        f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
     )
 
 

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -350,6 +350,60 @@ def test_stripped_suppression_with_elf_exports_still_reports_real_symbol_loss():
     )
 
 
+def test_stripped_suppression_falls_back_when_new_side_lacks_elf_metadata():
+    """Mixed inputs can have ELF exports on one side only; use snapshot maps then."""
+    from abicheck.checker_policy import ChangeKind
+
+    old = _elf_snapshot(
+        functions=[_exported_func("stable_api")],
+        types=[RecordType(name="PublicType", kind="class", size_bits=64)],
+    )
+    old.elf = _elf_exports("stable_api")
+    old.elf_only_mode = False
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")], types=[])
+    new.elf = None
+    new.dwarf = None
+
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes), (
+        "when either side lacks ELF metadata, retention must fall back to the "
+        f"public function map; changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_stripped_suppression_ignores_transitive_stdlib_exports_in_retention():
+    """Weak stdlib/runtime leaks must not deflate stripped-side retention math."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function
+
+    std_leak = "_ZNSt6vectorIiSaIiEE4sizeEv"
+    old = _elf_snapshot(
+        functions=[
+            _exported_func("stable_api"),
+            Function(
+                name="std::vector<int>::size",
+                mangled=std_leak,
+                return_type="unsigned long",
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        types=[RecordType(name="PublicType", kind="class", size_bits=64)],
+    )
+    old.elf = _elf_exports("stable_api", std_leak)
+    old.elf_only_mode = False
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")], types=[])
+    new.elf = _elf_exports("stable_api")
+    new.dwarf = None
+
+    result = compare(old, new)
+    assert not any(c.kind == ChangeKind.TYPE_REMOVED for c in result.changes), (
+        "transitive stdlib exports are not the inspected library's retained "
+        f"surface; changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
 def test_function_diff_prefers_elf_exports_over_dwarf_public_helpers():
     """DWARF-public helper functions are not binary ABI if absent from dynsym."""
     from abicheck.checker_policy import ChangeKind
@@ -399,6 +453,53 @@ def test_function_diff_with_elf_exports_still_reports_real_export_loss():
     ), (
         "removing a real dynamic function export must still be reported; "
         f"changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_function_diff_with_elf_exports_keeps_notype_function_exports():
+    """STT_NOTYPE assembly/alias entry points are function-like dynamic ABI."""
+    from abicheck.checker_policy import ChangeKind
+
+    old = _elf_snapshot(functions=[_exported_func("asm_entry"), _exported_func("stable_api")])
+    old.elf = _elf_exports("asm_entry", "stable_api", sym_type=SymbolType.NOTYPE)
+
+    new = _elf_snapshot(functions=[_exported_func("stable_api")])
+    new.elf = _elf_exports("stable_api", sym_type=SymbolType.NOTYPE)
+
+    result = compare(old, new)
+    assert any(c.kind == ChangeKind.FUNC_REMOVED_ELF_ONLY and c.symbol == "asm_entry" for c in result.changes), (
+        "removing a NOTYPE dynamic entry point must not be hidden by the ELF "
+        f"intersection; changes: {[(c.kind.value, c.symbol) for c in result.changes]}"
+    )
+
+
+def test_function_diff_preserves_deleted_functions_missing_from_elf_exports():
+    """A newly deleted API has no new ELF export, but should be FUNC_DELETED only."""
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.model import Function
+
+    old = _elf_snapshot(functions=[_exported_func("process"), _exported_func("stable_api")])
+    old.elf = _elf_exports("process", "stable_api")
+
+    new = _elf_snapshot(
+        functions=[
+            Function(
+                name="process",
+                mangled="process",
+                return_type="void",
+                visibility=Visibility.PUBLIC,
+                is_deleted=True,
+            ),
+            _exported_func("stable_api"),
+        ]
+    )
+    new.elf = _elf_exports("stable_api")
+
+    result = compare(old, new)
+    kinds_by_symbol = [(c.kind, c.symbol) for c in result.changes]
+    assert (ChangeKind.FUNC_DELETED, "process") in kinds_by_symbol
+    assert not any(c.kind == ChangeKind.FUNC_REMOVED and c.symbol == "process" for c in result.changes), (
+        f"deleted APIs must not also be reported as removed: {[(c.kind.value, c.symbol) for c in result.changes]}"
     )
 
 

--- a/tests/test_sprint10_abicc_parity.py
+++ b/tests/test_sprint10_abicc_parity.py
@@ -132,20 +132,21 @@ class TestFuncVisibilityChanged:
         assert "_Z3apiv" in vis_changes[0].symbol
 
     def test_elf_only_symbol_absent_is_func_removed_elf_only(self) -> None:
-        """ELF_ONLY symbol absent from new snapshot → FUNC_REMOVED_ELF_ONLY (compatible).
+        """ELF_ONLY symbol absent from new snapshot → FUNC_REMOVED_ELF_ONLY.
 
-        ELF-only symbols (no header/DWARF data) that disappear could be internal
-        symbols getting properly hidden via -fvisibility=hidden.  Emitting
-        FUNC_REMOVED would produce a false BREAKING verdict in that case.
+        ELF-only symbols (no header/DWARF data) that disappear may be internal
+        symbols getting properly hidden via -fvisibility=hidden, but in strict
+        binary-only mode abicheck must still treat removed dynamic exports as
+        breaks because old binaries or dlsym() consumers may depend on them.
         Requires elf_only_mode=True on the old snapshot (set by dumper when
-        no headers are provided) to avoid false COMPATIBLE on real removals.
+        no headers are provided).
         """
         old_f = _func("sym", "_Z3symv", visibility=Visibility.ELF_ONLY)
         r = compare(_snap(functions=[old_f], elf_only_mode=True), _snap("2.0", functions=[]))
         assert any(c.kind == ChangeKind.FUNC_REMOVED_ELF_ONLY for c in r.changes)
         assert not any(c.kind == ChangeKind.FUNC_REMOVED for c in r.changes)
         assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
-        assert r.verdict == Verdict.COMPATIBLE
+        assert r.verdict == Verdict.BREAKING
 
     def test_elf_only_to_hidden_is_visibility_change(self) -> None:
         """ELF_ONLY → HIDDEN: callers that resolved the symbol dynamically break.

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -339,13 +339,14 @@ def _elf_only_snap(symbols: list[str]) -> AbiSnapshot:
 
 
 def test_visibility_leak_detected() -> None:
-    """Internal-looking ELF_ONLY symbols in old lib → VISIBILITY_LEAK."""
+    """Internal-looking ELF_ONLY symbols in old lib → VISIBILITY_LEAK plus removal breaks."""
     old = _elf_only_snap(["public_api", "internal_helper", "another_impl"])
     new = _elf_only_snap(["public_api"])
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.VISIBILITY_LEAK in kinds
-    assert result.verdict == Verdict.COMPATIBLE
+    assert ChangeKind.FUNC_REMOVED_ELF_ONLY in kinds
+    assert result.verdict == Verdict.BREAKING
 
 
 def test_visibility_leak_not_fired_without_elf_only_mode() -> None:

--- a/tests/test_stripped_degradation.py
+++ b/tests/test_stripped_degradation.py
@@ -193,7 +193,7 @@ class TestElfOnlyMode:
         )
         # In elf_only mode, removal produces FUNC_REMOVED_ELF_ONLY
         assert ChangeKind.FUNC_REMOVED_ELF_ONLY in _kinds(r)
-        assert r.verdict == Verdict.COMPATIBLE  # ELF_ONLY removal is not BREAKING
+        assert r.verdict == Verdict.BREAKING
 
     def test_elf_only_lower_confidence(self):
         """ELF-only mode should have lower confidence than header+ELF."""


### PR DESCRIPTION
## Summary
- share the ELF ABI-relevance symbol filter with DWARF snapshot extraction
- filter DWARF export indices and DW_AT_deleted subprograms so transitive stdlib/runtime subprograms do not enter non-runtime libraries as public ABI
- add regression coverage for DWARF export-index filtering

## Real-world evidence
First abicheck-realworld-cron run found oneTBB libtbbmalloc 2021.5.0 -> 2021.9.0 as a false-positive candidate: abicheck reported BREAKING while abidiff was clean.

This patch removes the bogus std:: deleted-subprogram roots: a fresh oneTBB dump now has 0 std:: DWARF functions (was 62), and the compare no longer reports the four std:: FUNC_REMOVED findings.

The broader oneTBB internal-type reachability issue remains open and is documented in reports/abicheck-realworld-cron/finding-analysis-20260602-2138.md.

## Tests
- python -m ruff check abicheck/elf_symbol_filter.py abicheck/dumper.py abicheck/dwarf_snapshot.py tests/test_elf_symbol_filters.py
- python -m pytest tests/test_elf_symbol_filters.py tests/test_real_world_false_positives.py tests/test_dwarf_coverage_gaps.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized ELF-symbol ABI-relevance filtering and applied it across DWARF extraction, dumping, and diffing to reduce false-positive ABI change reports and better reconcile stripped vs DWARF views.
  * Public/function-surface detection now consults ELF export evidence and preserves deleted-but-still-relevant entries.

* **Behavior**
  * ELF-only function removals (`func_removed_elf_only`) are now classified as BREAKING under strict policy.

* **Tests**
  * Expanded tests covering ELF export filtering, DWARF interplay, and stripped-side suppression.

* **Documentation**
  * Updated ADRs, examples, and reference docs to reflect the new classification and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->