### PR TITLE
Fix stale SONAME bump verdict after rename filtering

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -206,15 +206,6 @@ def compare(
     if extra_changes:
         changes.extend(extra_changes)
 
-    # Post-detector: SONAME bump policy check (needs full change list).
-    # Uses the module-level import of check_soname_bump_policy.
-    from .elf_metadata import ElfMetadata as _ElfMetadata
-
-    _old_elf = getattr(old, "elf", None) or _ElfMetadata()
-    _new_elf = getattr(new, "elf", None) or _ElfMetadata()
-    soname_changes = check_soname_bump_policy(changes, _old_elf, _new_elf)
-    changes.extend(soname_changes)
-
     # Run the post-processing pipeline (filtering, dedup, enrichment, suppression).
     # PolicyFile.frozen_namespaces is threaded in so the late-stage
     # EscalateFrozenNamespaceViolations step can tag matching findings.
@@ -238,7 +229,27 @@ def compare(
     # Verdict computed on unsuppressed semantic changes.
     # NOTE: opaque_filtered changes are intentionally excluded from verdict
     # (they are compatibility-preserving noise, e.g. opaque handle size drift).
-    all_unsuppressed = kept + redundant
+    verdict_redundant = [
+        c for c in redundant
+        if not (c.caused_by_type or "").startswith("rename:")
+    ]
+    all_unsuppressed = kept + verdict_redundant
+
+    # Post-detector: SONAME bump policy check.  It needs the full semantic
+    # change list, but that list must already have passed through
+    # post-processing.  Raw detector findings can be downgraded or made
+    # redundant there (for example FUNC_REMOVED/FUNC_ADDED collapsed into
+    # FUNC_LIKELY_RENAMED); evaluating SONAME policy too early leaves stale
+    # bump recommendations on non-breaking results.
+    from .elf_metadata import ElfMetadata as _ElfMetadata
+
+    _old_elf = getattr(old, "elf", None) or _ElfMetadata()
+    _new_elf = getattr(new, "elf", None) or _ElfMetadata()
+    soname_changes = check_soname_bump_policy(all_unsuppressed, _old_elf, _new_elf)
+    if soname_changes:
+        kept.extend(soname_changes)
+        all_unsuppressed = kept + verdict_redundant
+
     verdict = policy_file.compute_verdict(all_unsuppressed) if policy_file is not None else compute_verdict(all_unsuppressed, policy=policy)
     effective_policy = policy_file.base_policy if policy_file is not None else policy
 

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -246,6 +246,14 @@ def compare(
     _old_elf = getattr(old, "elf", None) or _ElfMetadata()
     _new_elf = getattr(new, "elf", None) or _ElfMetadata()
     soname_changes = check_soname_bump_policy(all_unsuppressed, _old_elf, _new_elf)
+    if suppression is not None and soname_changes:
+        visible_soname_changes: list[Change] = []
+        for c in soname_changes:
+            if suppression.is_suppressed(c):
+                suppressed.append(c)
+            else:
+                visible_soname_changes.append(c)
+        soname_changes = visible_soname_changes
     if soname_changes:
         kept.extend(soname_changes)
         all_unsuppressed = kept + verdict_redundant

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -229,11 +229,18 @@ def compare(
     # Verdict computed on unsuppressed semantic changes.
     # NOTE: opaque_filtered changes are intentionally excluded from verdict
     # (they are compatibility-preserving noise, e.g. opaque handle size drift).
+    #
+    # rename: redundant changes are excluded too. When SuppressRenamedPairs
+    # collapses a FUNC_REMOVED/FUNC_ADDED pair into a FUNC_LIKELY_RENAMED, it
+    # moves the removed/added halves into `redundant` tagged "rename:…". The
+    # surviving FUNC_LIKELY_RENAMED (a RISK kind, in `kept`) is what should
+    # drive the verdict; counting the redundant FUNC_REMOVED would re-escalate
+    # the downgraded rename back to BREAKING. They stay in redundant_changes
+    # for audit (--show-redundant); they just don't drive the verdict.
     verdict_redundant = [
         c for c in redundant
         if not (c.caused_by_type or "").startswith("rename:")
     ]
-    all_unsuppressed = kept + verdict_redundant
 
     # Post-detector: SONAME bump policy check.  It needs the full semantic
     # change list, but that list must already have passed through
@@ -241,11 +248,19 @@ def compare(
     # redundant there (for example FUNC_REMOVED/FUNC_ADDED collapsed into
     # FUNC_LIKELY_RENAMED); evaluating SONAME policy too early leaves stale
     # bump recommendations on non-breaking results.
+    #
+    # The advisory is a synthetic, library-level meta-finding (symbol
+    # "DT_SONAME"), not a per-symbol diff, so it deliberately bypasses the rest
+    # of the post-processing pipeline: its breaking-change *input* is already
+    # surface-scoped/deduped (it comes from `kept`), and the only pipeline step
+    # that meaningfully applies to the advisory itself — user suppression — is
+    # re-applied explicitly below. Surface scoping, dedup and enrichment steps
+    # have nothing to act on for a DT_SONAME advisory.
     from .elf_metadata import ElfMetadata as _ElfMetadata
 
     _old_elf = getattr(old, "elf", None) or _ElfMetadata()
     _new_elf = getattr(new, "elf", None) or _ElfMetadata()
-    soname_changes = check_soname_bump_policy(all_unsuppressed, _old_elf, _new_elf)
+    soname_changes = check_soname_bump_policy(kept + verdict_redundant, _old_elf, _new_elf)
     if suppression is not None and soname_changes:
         visible_soname_changes: list[Change] = []
         for c in soname_changes:
@@ -256,7 +271,8 @@ def compare(
         soname_changes = visible_soname_changes
     if soname_changes:
         kept.extend(soname_changes)
-        all_unsuppressed = kept + verdict_redundant
+
+    all_unsuppressed = kept + verdict_redundant
 
     verdict = policy_file.compute_verdict(all_unsuppressed) if policy_file is not None else compute_verdict(all_unsuppressed, policy=policy)
     effective_policy = policy_file.base_policy if policy_file is not None else policy

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -600,6 +600,71 @@ class TestCheckerIntegration:
         # The function removal is breaking; soname unchanged -> recommendation
         assert ChangeKind.SONAME_BUMP_RECOMMENDED in kinds
 
+    def test_compare_soname_policy_uses_postprocessed_changes(self):
+        """A downgraded rename must not leave a stale SONAME bump advisory."""
+        from abicheck.checker import compare
+        from abicheck.checker_policy import Verdict
+        from abicheck.model import AbiSnapshot, Function, Visibility
+
+        old = AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="old_name",
+                    mangled="old_name",
+                    return_type="void",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+            elf=ElfMetadata(soname="libfoo.so.1", symbols=[_sym("old_name")]),
+        )
+        new = AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.1",
+            functions=[
+                Function(
+                    name="new_name",
+                    mangled="new_name",
+                    return_type="void",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+            elf=ElfMetadata(soname="libfoo.so.1", symbols=[_sym("new_name")]),
+        )
+        result = compare(
+            old,
+            new,
+            extra_changes=[
+                Change(
+                    kind=ChangeKind.FUNC_REMOVED,
+                    symbol="old_name",
+                    description="Function removed: old_name",
+                    old_value="old_name",
+                ),
+                Change(
+                    kind=ChangeKind.FUNC_ADDED,
+                    symbol="new_name",
+                    description="Function added: new_name",
+                    new_value="new_name",
+                ),
+                Change(
+                    kind=ChangeKind.FUNC_LIKELY_RENAMED,
+                    symbol="old_name",
+                    description="Function likely renamed: old_name -> new_name",
+                    old_value="old_name",
+                    new_value="new_name",
+                ),
+            ],
+        )
+        kinds = {c.kind for c in result.changes}
+
+        assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+        assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
+        assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
+
     def test_compare_version_script_missing(self):
         """Full pipeline: version script dropped -> warning fires."""
         from abicheck.model import AbiSnapshot

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -665,6 +665,79 @@ class TestCheckerIntegration:
         assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
         assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
 
+    def test_compare_soname_unnecessary_uses_postprocessed_changes(self):
+        """SONAME bumped but the only change is a downgraded rename → UNNECESSARY.
+
+        Exercises the second branch of check_soname_bump_policy through the
+        post-processed change set: because the breaking removed/added halves are
+        rename-redundant (and so excluded from the verdict input), there are no
+        binary-incompatible changes, so a SONAME bump reads as unnecessary —
+        and must not also emit the contradictory RECOMMENDED advisory.
+        """
+        from abicheck.checker import compare
+        from abicheck.checker_policy import Verdict
+        from abicheck.model import AbiSnapshot, Function, Visibility
+
+        old = AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="old_name",
+                    mangled="old_name",
+                    return_type="void",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+            elf=ElfMetadata(soname="libfoo.so.1", symbols=[_sym("old_name")]),
+        )
+        new = AbiSnapshot(
+            library="libfoo.so.2",
+            version="2.0",
+            functions=[
+                Function(
+                    name="new_name",
+                    mangled="new_name",
+                    return_type="void",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+            elf=ElfMetadata(soname="libfoo.so.2", symbols=[_sym("new_name")]),
+        )
+        result = compare(
+            old,
+            new,
+            extra_changes=[
+                Change(
+                    kind=ChangeKind.FUNC_REMOVED,
+                    symbol="old_name",
+                    description="Function removed: old_name",
+                    old_value="old_name",
+                ),
+                Change(
+                    kind=ChangeKind.FUNC_ADDED,
+                    symbol="new_name",
+                    description="Function added: new_name",
+                    new_value="new_name",
+                ),
+                Change(
+                    kind=ChangeKind.FUNC_LIKELY_RENAMED,
+                    symbol="old_name",
+                    description="Function likely renamed: old_name -> new_name",
+                    old_value="old_name",
+                    new_value="new_name",
+                ),
+            ],
+        )
+        kinds = {c.kind for c in result.changes}
+
+        assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+        assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
+        assert ChangeKind.SONAME_BUMP_UNNECESSARY in kinds
+        assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
+
     def test_compare_soname_bump_recommendation_honors_suppression(self):
         """Late-generated SONAME advisories must still pass suppression."""
         from abicheck.checker import compare

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -665,6 +665,49 @@ class TestCheckerIntegration:
         assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
         assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
 
+    def test_compare_soname_bump_recommendation_honors_suppression(self):
+        """Late-generated SONAME advisories must still pass suppression."""
+        from abicheck.checker import compare
+        from abicheck.model import AbiSnapshot, Function, Visibility
+        from abicheck.suppression import Suppression, SuppressionList
+
+        old = AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="removed_func",
+                    mangled="removed_func",
+                    return_type="void",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+            elf=ElfMetadata(soname="libfoo.so.1", symbols=[_sym("removed_func")]),
+        )
+        new = AbiSnapshot(
+            library="libfoo.so.1",
+            version="2.0",
+            functions=[],
+            elf=ElfMetadata(soname="libfoo.so.1", symbols=[]),
+        )
+        suppression = SuppressionList([
+            Suppression(
+                symbol="DT_SONAME",
+                change_kind=ChangeKind.SONAME_BUMP_RECOMMENDED.value,
+                reason="tracked separately",
+            )
+        ])
+
+        result = compare(old, new, suppression=suppression)
+        kinds = {c.kind for c in result.changes}
+        suppressed_kinds = {c.kind for c in result.suppressed_changes}
+
+        assert ChangeKind.FUNC_REMOVED in kinds
+        assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
+        assert ChangeKind.SONAME_BUMP_RECOMMENDED in suppressed_kinds
+        assert result.suppressed_count == 1
+
     def test_compare_version_script_missing(self):
         """Full pipeline: version script dropped -> warning fires."""
         from abicheck.model import AbiSnapshot


### PR DESCRIPTION
## Summary

Fixes a real-world false-positive BREAKING verdict where raw removed/added symbols were downgraded to `func_likely_renamed`, but still left behind a stale SONAME bump recommendation and exit 4.

Changes:

- run SONAME bump policy after the post-processing pipeline, not before it
- keep rename-suppressed removed/added findings auditable, but exclude `rename:` redundant findings from verdict-driving redundant changes
- add a regression covering the postprocessed rename path

## Real-world evidence

Found during the recurring real-world validation campaign:

- c-ares 1.14.0 -> 1.18.1 (`libcares.so`)
- libssh2 1.9.0 -> 1.10.0 (`libssh2.so`)

Pre-fix, both reported:

- `verdict: BREAKING`
- `summary.breaking: 0`
- `binary_compatibility_pct: 100.0`
- release recommendation `version_bump: major`, `soname_action: bump_missing`

Independent cross-checks showed one removed internal-looking exported symbol in each case, matching abicheck's own `func_likely_renamed` risk downgrade rather than a report-visible breaking finding.

Post-fix reruns report `COMPATIBLE_WITH_RISK`, exit 0, and `soname_action: no_bump_needed`.

Artifacts are recorded in the local campaign ledger under `reports/abicheck-realworld-cron/artifacts/20260603-0008/`.

## Tests

- `ruff check abicheck/checker.py tests/test_elf_version_policy.py`
- `pytest -q tests/test_elf_version_policy.py::TestCheckerIntegration::test_compare_soname_policy_uses_postprocessed_changes tests/test_elf_version_policy.py::TestCheckerIntegration::test_compare_soname_bump_recommended tests/test_semver_recommendation.py::test_breaking_with_soname_bump_recommended_flags_missing_bump tests/test_exit_codes.py::test_exit_0_compatible_with_risk`
- `pytest -q tests/test_elf_version_policy.py tests/test_semver_recommendation.py tests/test_exit_codes.py tests/test_real_world_false_positives.py`
