### PR TITLE
Fix surface scoping for field-level type changes

### DIFF
--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -105,6 +105,23 @@ _TYPE_LEVEL_KIND_NAMES: frozenset[str] = frozenset(
     }
 )
 
+_FIELD_LEVEL_TYPE_KIND_NAMES: frozenset[str] = frozenset(
+    {
+        "type_field_removed",
+        "type_field_added",
+        "type_field_offset_changed",
+        "type_field_type_changed",
+        "type_field_added_compatible",
+        "field_bitfield_changed",
+        "union_field_added",
+        "union_field_removed",
+        "union_field_type_changed",
+        "struct_field_offset_changed",
+        "struct_field_removed",
+        "struct_field_type_changed",
+    }
+)
+
 # Tokens that are type qualifiers / keywords, not type names.
 _TYPE_NOISE: frozenset[str] = frozenset(
     {
@@ -496,13 +513,18 @@ def classify_change_surface(
     all_types = surf_old.all_types | surf_new.all_types
 
     sym = change.symbol or ""
-    candidates = _type_identifiers(sym) | _type_identifiers(change.caused_by_type)
-
     # Type-level findings must not be classified via the symbol universe first:
     # a public type such as ``Foo`` can legitimately collide with a hidden
     # constructor/destructor/helper symbol named ``Foo``. In that case the
     # layout change's ``symbol`` still denotes the type, so reachability decides.
     type_level_finding = change.kind.value in _TYPE_LEVEL_KIND_NAMES
+    if type_level_finding and change.kind.value in _FIELD_LEVEL_TYPE_KIND_NAMES and "::" in sym:
+        # Field-level findings are encoded as ``Type::field``. Classifying the
+        # full string as a type keeps private fields in-surface as "unknown";
+        # use the owner type for reachability/provenance decisions.
+        candidates = {sym.rsplit("::", 1)[0]} | _type_identifiers(change.caused_by_type)
+    else:
+        candidates = _type_identifiers(sym) | _type_identifiers(change.caused_by_type)
 
     # Symbol-level finding (function/variable): public iff a public symbol.
     # A confident private/system-header origin demotes even an exported

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -105,8 +105,9 @@ _TYPE_LEVEL_KIND_NAMES: frozenset[str] = frozenset(
     }
 )
 
-_FIELD_LEVEL_TYPE_KIND_NAMES: frozenset[str] = frozenset(
+_MEMBER_LEVEL_TYPE_KIND_NAMES: frozenset[str] = frozenset(
     {
+        # Struct/union field findings, encoded as ``Type::field``.
         "type_field_removed",
         "type_field_added",
         "type_field_offset_changed",
@@ -119,7 +120,23 @@ _FIELD_LEVEL_TYPE_KIND_NAMES: frozenset[str] = frozenset(
         "struct_field_offset_changed",
         "struct_field_removed",
         "struct_field_type_changed",
+        # Enum member findings, encoded as ``Enum::member`` — same owner-qualified
+        # shape, so they must reclassify by the owning enum just like fields do.
+        "enum_member_removed",
+        "enum_member_added",
+        "enum_member_value_changed",
+        "enum_last_member_value_changed",
     }
+)
+
+# Owner-qualified member findings are a strict subset of type-level findings:
+# the owner-type reclassification in classify_change_surface() only runs inside
+# the type-level branch, so any member kind missing from _TYPE_LEVEL_KIND_NAMES
+# would silently never be reclassified. Guard the invariant at import time so a
+# future kind cannot drift out of sync.
+assert _MEMBER_LEVEL_TYPE_KIND_NAMES <= _TYPE_LEVEL_KIND_NAMES, (
+    "member-level kinds must also be type-level: "
+    f"{_MEMBER_LEVEL_TYPE_KIND_NAMES - _TYPE_LEVEL_KIND_NAMES}"
 )
 
 # Tokens that are type qualifiers / keywords, not type names.
@@ -518,10 +535,13 @@ def classify_change_surface(
     # constructor/destructor/helper symbol named ``Foo``. In that case the
     # layout change's ``symbol`` still denotes the type, so reachability decides.
     type_level_finding = change.kind.value in _TYPE_LEVEL_KIND_NAMES
-    if type_level_finding and change.kind.value in _FIELD_LEVEL_TYPE_KIND_NAMES and "::" in sym:
-        # Field-level findings are encoded as ``Type::field``. Classifying the
-        # full string as a type keeps private fields in-surface as "unknown";
-        # use the owner type for reachability/provenance decisions.
+    if change.kind.value in _MEMBER_LEVEL_TYPE_KIND_NAMES and "::" in sym:
+        # Member-level findings are owner-qualified: ``Type::field`` (struct/union
+        # field) or ``Enum::member`` (enum member). Classifying the full string as
+        # a type keeps a private member's churn in-surface as an "unknown" type;
+        # use the owner type for reachability/provenance decisions. (Membership in
+        # this set implies type_level_finding — see the import-time assert above —
+        # so a qualified *type name* like ``ns::Foo`` is never mis-split here.)
         candidates = {sym.rsplit("::", 1)[0]} | _type_identifiers(change.caused_by_type)
     else:
         candidates = _type_identifiers(sym) | _type_identifiers(change.caused_by_type)

--- a/tests/test_scan_accuracy.py
+++ b/tests/test_scan_accuracy.py
@@ -184,7 +184,9 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.enums[0].members = [m for m in new.enums[0].members if m.name != "BLUE"]
-        result = compare(old, new)
+        # Raw detector check: Color is not wired to a public function here, so
+        # disable surface scoping (orthogonal concern, default-on since ADR-024).
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.ENUM_MEMBER_REMOVED for c in result.changes)
 
@@ -192,7 +194,9 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.enums[0].members[1] = EnumMember(name="GREEN", value=42)
-        result = compare(old, new)
+        # Raw detector check: Color is not wired to a public function here, so
+        # disable surface scoping (orthogonal concern, default-on since ADR-024).
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.BREAKING
         assert any(c.kind == ChangeKind.ENUM_MEMBER_VALUE_CHANGED for c in result.changes)
 
@@ -200,7 +204,9 @@ class TestSingleMutationDetection:
         old = _base_snap()
         new = copy.deepcopy(old)
         new.enums[0].members.append(EnumMember(name="YELLOW", value=3))
-        result = compare(old, new)
+        # Raw detector check: Color is not wired to a public function here, so
+        # disable surface scoping (orthogonal concern, default-on since ADR-024).
+        result = compare(old, new, scope_to_public_surface=False)
         assert result.verdict == Verdict.COMPATIBLE
         assert any(c.kind == ChangeKind.ENUM_MEMBER_ADDED for c in result.changes)
 

--- a/tests/test_surface_confidence.py
+++ b/tests/test_surface_confidence.py
@@ -192,6 +192,27 @@ class TestExportOnlyAntiHiding:
         in_surf, _ = classify_change_surface(c, s, s)
         assert in_surf is False
 
+    def test_field_level_private_type_uses_owner_for_surface(self):
+        # Real-world regression: p11-kit DWARF reports
+        # ``p11_virtual::funcs`` while ``p11_virtual`` is internal and not
+        # reachable from any public API root. Treating the full field spelling
+        # as an unknown type kept the private layout change as BREAKING.
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *")],
+            types=[_rec("Public"), _rec("p11_virtual")],
+        )
+        s = compute_public_surface(snap)
+        assert "p11_virtual" not in s.public_types
+        c = Change(
+            kind=ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+            symbol="p11_virtual::funcs",
+            description="Field type changed",
+        )
+        in_surf, reason = classify_change_surface(c, s, s)
+        assert in_surf is False
+        assert reason == REASON_NON_PUBLIC_TYPE
+
 
 # ── ledger disclosure (JSON + SARIF) ──────────────────────────────────────────
 

--- a/tests/test_surface_confidence.py
+++ b/tests/test_surface_confidence.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind
 from abicheck.checker_types import Change
 from abicheck.model import (
     AbiSnapshot,
+    EnumType,
     Function,
     Param,
     RecordType,
@@ -212,6 +215,56 @@ class TestExportOnlyAntiHiding:
         in_surf, reason = classify_change_surface(c, s, s)
         assert in_surf is False
         assert reason == REASON_NON_PUBLIC_TYPE
+
+    @pytest.mark.parametrize("kind, symbol", [
+        # Struct/union field findings (``Type::field``).
+        (ChangeKind.STRUCT_FIELD_TYPE_CHANGED, "p11_virtual::funcs"),
+        (ChangeKind.STRUCT_FIELD_REMOVED, "p11_virtual::funcs"),
+        (ChangeKind.TYPE_FIELD_OFFSET_CHANGED, "p11_virtual::funcs"),
+        (ChangeKind.UNION_FIELD_TYPE_CHANGED, "p11_virtual::funcs"),
+        # Enum member findings (``Enum::member``) — same owner-qualified shape,
+        # and ENUM_MEMBER_REMOVED/VALUE_CHANGED are BREAKING, so a private enum's
+        # member churn would otherwise read as a public break (the gap this fix
+        # closes alongside struct fields).
+        (ChangeKind.ENUM_MEMBER_REMOVED, "p11_secret::SECRET"),
+        (ChangeKind.ENUM_MEMBER_VALUE_CHANGED, "p11_secret::SECRET"),
+    ])
+    def test_member_level_private_owner_demoted(self, kind, symbol):
+        # Owner-qualified member findings must be classified by the owning type,
+        # not the full ``Owner::member`` spelling (which is never a known type
+        # name and so used to stay in-surface as an "unknown").
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *")],
+            types=[_rec("Public"), _rec("p11_virtual")],
+            enums=[EnumType(name="p11_secret")],
+        )
+        s = compute_public_surface(snap)
+        assert "p11_virtual" not in s.public_types
+        assert "p11_secret" not in s.public_types
+        c = Change(kind=kind, symbol=symbol, description="member change")
+        in_surf, reason = classify_change_surface(c, s, s)
+        assert in_surf is False
+        assert reason == REASON_NON_PUBLIC_TYPE
+
+    def test_member_level_public_owner_stays_in_surface(self):
+        # The owner reclassification must not over-demote: a member change on a
+        # public, reachable type stays in-surface.
+        snap = AbiSnapshot(
+            library="l", version="1",
+            functions=[_fn("api", ret="Public *")],
+            types=[_rec("Public")],
+        )
+        s = compute_public_surface(snap)
+        assert "Public" in s.public_types
+        c = Change(
+            kind=ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+            symbol="Public::field",
+            description="Field type changed",
+        )
+        in_surf, reason = classify_change_surface(c, s, s)
+        assert in_surf is True
+        assert reason is None
 
 
 # ── ledger disclosure (JSON + SARIF) ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a real-world false-positive BREAKING verdict where field-level DWARF type findings such as `p11_virtual::funcs` were classified against the full field spelling instead of the owning type. Because `p11_virtual::funcs` is not a known type name, the surface classifier kept it as an unknown in-surface finding even though the owner type `p11_virtual` is internal/private.

Changes:

- classify field-level type findings by their owner type before public-surface reachability checks
- keep public/unknown anti-hiding behavior for non-field type findings unchanged
- add a regression test for private field-level owner demotion

## Real-world evidence

Found during the recurring real-world validation campaign:

- p11-kit 0.25.10 -> 0.26.2 (conda-forge `libp11-kit.so.0`)

Pre-fix abicheck reported:

- `verdict: BREAKING`
- one visible `struct_field_type_changed` for `p11_virtual::funcs`
- no removed dynamic exports
- `abidiff` exit 0

ELF evidence shows the related `p11_virtual_*` functions/data are LOCAL symbols, not dynamic exports. Post-fix reruns move the internal field/type churn into the out-of-surface audit ledger and report `NO_CHANGE`, exit 0.

Local artifacts are recorded under `reports/abicheck-realworld-cron/artifacts/20260603-0241/`:

- initial JSON: `runs/P11KIT_0_25_10_to_0_26_2__libp11-kit.json`
- libabigail: `libabigail/P11KIT_0_25_10_to_0_26_2__libp11-kit.abidiff.txt`
- export diff: `exports/P11KIT_0_25_10_to_0_26_2__libp11-kit.removed.txt`
- post-fix rerun: `rerun-after-field-surface-fix-main/P11KIT_0_25_10_to_0_26_2__libp11-kit.json`

## Tests

- `pytest -q tests/test_surface_confidence.py tests/test_report_filtering.py`
- p11-kit real-world rerun: exits 0 and reports `NO_CHANGE`

Verification gap:

- `tests/test_surface_property.py` could not be collected in this environment because `hypothesis` is not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced field-level type change detection to properly resolve types through their owning context for accurate public surface classification.

* **Tests**
  * Added regression test validating field-level type change handling for non-public types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->