### PR TITLE
docs: clarify benchmark suite coverage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run benchmark
-        run: python scripts/benchmark_comparison.py --abicc-timeout 60
+        run: python scripts/benchmark_comparison.py --suite pinned74 --abicc-timeout 60
 
       - name: Upload benchmark report (workflow artifact)
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ See `abicheck.service` for the full signature, plus the [MCP server integration]
 
 ## Examples
 
-The [`examples/`](examples/README.md) directory contains **121 real-world ABI/API scenarios** (116 single-library cases plus 5 multi-library bundle cases) with ground-truth verdicts. Most are single-library `v1`/`v2` examples with a consumer app; bundle/release-level cases use release-style layouts. A pinned **74-case subset** drives the reproducible validation snapshot below.
+The [`examples/`](examples/README.md) directory contains **121 real-world ABI/API scenarios** (116 single-library cases plus 5 multi-library bundle cases) with ground-truth verdicts. Most are single-library `v1`/`v2` examples with a consumer app; bundle/release-level cases use release-style layouts. The full catalog is the development regression corpus; the table below is a smaller historical cross-tool benchmark kept stable for release-to-release comparison with libabigail and ABICC.
 
 ---
 
 ## Validation snapshot
 
-Accuracy on the pinned 74-case benchmark subset (`01–73` + `26b`, drawn from the full 121-case catalog):
+Current release-pinned cross-tool benchmark: accuracy on the historical 74-case subset (`case01`–`case73` + `case26b`, drawn from the full 121-case catalog):
 
 | Configuration | Exact verdict accuracy | Scan status |
 |---|---:|---|
@@ -162,14 +162,18 @@ Accuracy on the pinned 74-case benchmark subset (`01–73` + `26b`, drawn from t
 | `ABICC(dump)` | **51/71 (71%)** | 71/74 scored |
 | `ABICC(xml)` | **50/72 (69%)** | 72/74 scored |
 
-These numbers are reproducible from `scripts/benchmark_comparison.py`, which
-writes `benchmark_reports/benchmark_report.json` with the abicheck version, git
-commit, oracle tool versions, the `ground_truth.json` SHA-256, and per-tool
-accuracy. Release workflows attach that report to future GitHub Releases. To
-generate a fresh report for the current checkout, run:
+These numbers are reproducible from `scripts/benchmark_comparison.py --suite pinned74`, which writes `benchmark_reports/benchmark_report.json` with the selected suite, abicheck version, git commit, oracle tool versions, the `ground_truth.json` SHA-256, and per-tool accuracy. Release workflows attach that pinned-suite report to future GitHub Releases.
+
+To regenerate the release-pinned cross-tool report:
 
 ```bash
-python scripts/benchmark_comparison.py   # writes benchmark_reports/benchmark_report.json
+python scripts/benchmark_comparison.py --suite pinned74
+```
+
+To scan the full 121-case catalog for the current checkout:
+
+```bash
+python scripts/benchmark_comparison.py --suite all
 ```
 
 Per-case matrix, methodology, and the pinned comparison table: [Tool Comparison & Benchmarks](https://napetrov.github.io/abicheck/reference/tool-comparison/).

--- a/README.md
+++ b/README.md
@@ -144,39 +144,27 @@ See `abicheck.service` for the full signature, plus the [MCP server integration]
 
 ## Examples
 
-The [`examples/`](examples/README.md) directory contains **121 real-world ABI/API scenarios** (116 single-library cases plus 5 multi-library bundle cases) with ground-truth verdicts. Most are single-library `v1`/`v2` examples with a consumer app; bundle/release-level cases use release-style layouts. The full catalog is the development regression corpus; the table below is a smaller historical cross-tool benchmark kept stable for release-to-release comparison with libabigail and ABICC.
+The [`examples/`](examples/README.md) directory contains **121 real-world ABI/API scenarios** (116 single-library cases plus 5 multi-library bundle cases) with ground-truth verdicts. Most are single-library `v1`/`v2` examples with a consumer app; bundle/release-level cases use release-style layouts. The full catalog is the development regression corpus; a smaller historical cross-tool subset is kept in the reference docs for release-to-release comparison with libabigail and ABICC.
 
 ---
 
 ## Validation snapshot
 
-Current release-pinned cross-tool benchmark: accuracy on the historical 74-case subset (`case01`–`case73` + `case26b`, drawn from the full 121-case catalog):
-
-| Configuration | Exact verdict accuracy | Scan status |
-|---|---:|---|
-| `abicheck compare` | **74/74 (100%)** | 74/74 completed |
-| `abicheck compat` | **71/74 (95%)** | 74/74 completed |
-| `abicheck strict` | **62/74 (83%)** | 74/74 completed |
-| `abidiff` | **22/73 (30%)** | 73/74 completed; `case16` hangs |
-| `abidiff+headers` | **22/73 (30%)** | 73/74 completed; `case16` hangs |
-| `ABICC(dump)` | **51/71 (71%)** | 71/74 scored |
-| `ABICC(xml)` | **50/72 (69%)** | 72/74 scored |
-
-These numbers are reproducible from `scripts/benchmark_comparison.py --suite pinned74`, which writes `benchmark_reports/benchmark_report.json` with the selected suite, abicheck version, git commit, oracle tool versions, the `ground_truth.json` SHA-256, and per-tool accuracy. Release workflows attach that pinned-suite report to future GitHub Releases.
-
-To regenerate the release-pinned cross-tool report:
-
-```bash
-python scripts/benchmark_comparison.py --suite pinned74
-```
-
-To scan the full 121-case catalog for the current checkout:
+The main validation target is the full **121-case catalog**. To scan it for the current checkout:
 
 ```bash
 python scripts/benchmark_comparison.py --suite all
 ```
 
-Per-case matrix, methodology, and the pinned comparison table: [Tool Comparison & Benchmarks](https://napetrov.github.io/abicheck/reference/tool-comparison/).
+The command writes `benchmark_reports/benchmark_report.json` with the selected suite, abicheck version, git commit, tool versions, the `ground_truth.json` SHA-256, and per-tool accuracy. Cases that require bundle/release harnesses or unavailable compiler features are marked as unscored instead of being folded into single-library verdict accuracy.
+
+For apples-to-apples comparison with libabigail and ABICC, release workflows also run the historical pinned cross-tool subset (`case01`-`case73` + `case26b`) and attach that report to GitHub Releases:
+
+```bash
+python scripts/benchmark_comparison.py --suite pinned74
+```
+
+Per-case matrix, methodology, full-catalog notes, and the pinned cross-tool comparison table: [Tool Comparison & Benchmarks](https://napetrov.github.io/abicheck/reference/tool-comparison/).
 
 ---
 

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -227,7 +227,7 @@ const). ABICC has no ELF pass (misses SONAME, visibility). ABICC(dump) has no AS
 
 ## Current benchmark summary (2026-05-19, 74-case subset)
 
-Release-pinned scan status from `python3 scripts/benchmark_comparison.py` on the original
+Release-pinned scan status from `python3 scripts/benchmark_comparison.py --suite pinned74` on the original
 74-case benchmark subset. ABICC runs used `--abicc-timeout 20` to keep known hangs bounded.
 
 | Tool | Cases attempted | Scored | Correct | Accuracy | Not scored / notes |
@@ -256,22 +256,26 @@ Release-pinned scan status from `python3 scripts/benchmark_comparison.py` on the
 
 ```bash
 python3 scripts/benchmark_comparison.py \
+  --suite pinned74 \
   --tools abicheck abicheck_compat abicheck_strict \
   --skip-abicc
 
 # abidiff and abidiff+headers were run on all cases except case16,
 # which hangs in both modes in this environment.
 python3 scripts/benchmark_comparison.py \
+  --suite pinned74 \
   --tools abidiff abidiff_headers \
   --skip-abicc \
   --cases case01_symbol_removal ... case73_typedef_underlying_changed
 
 timeout 600 python3 scripts/benchmark_comparison.py \
+  --suite pinned74 \
   --tools abicc_xml \
   --abicc-mode xml \
   --abicc-timeout 20
 
 timeout 600 python3 scripts/benchmark_comparison.py \
+  --suite pinned74 \
   --tools abicc_dumper \
   --abicc-mode dumper \
   --abicc-timeout 20

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -100,8 +100,13 @@ try:
 except (FileNotFoundError, json.JSONDecodeError, ValueError) as _e:
     raise SystemExit(f"ERROR: cannot load {_GT_PATH}: {_e}") from _e
 
+def _expected_or_unknown(value: object) -> str:
+    """Return a printable/scorable expected verdict, or '?' for unscored cases."""
+    return value if isinstance(value, str) and value else "?"
+
+
 EXPECTED: dict[str, str] = {
-    k: v["expected"] for k, v in _gt_data["verdicts"].items()
+    k: _expected_or_unknown(v["expected"]) for k, v in _gt_data["verdicts"].items()
 }
 # Per-tool overrides sourced from ground_truth.json:
 #   expected_compat — compat mode can't emit API_BREAK (case31, case34)
@@ -112,7 +117,7 @@ EXPECTED_COMPAT: dict[str, str] = {
     if "expected_compat" in v
 }
 EXPECTED_ABICC: dict[str, str] = {
-    k: ("COMPATIBLE" if v["expected"] == "NO_CHANGE" else v["expected"])
+    k: ("COMPATIBLE" if EXPECTED[k] == "NO_CHANGE" else EXPECTED[k])
     for k, v in _gt_data["verdicts"].items()
 }
 

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -17,6 +17,7 @@ Supports two case layouts:
 
 Usage:
     python3 scripts/benchmark_comparison.py
+    python3 scripts/benchmark_comparison.py --suite pinned74
     python3 scripts/benchmark_comparison.py --abicc-timeout 60
     python3 scripts/benchmark_comparison.py --abicc-mode dumper
     python3 scripts/benchmark_comparison.py --skip-abicc
@@ -79,6 +80,12 @@ _HAS_ABICHECK: bool = _abicheck_available()
 
 
 DEFAULT_ABICC_TIMEOUT = 120  # seconds
+
+# Historical release-pinned cross-tool benchmark:
+# cases 01-73 plus the 26b compatible-union edge case.  The full catalog can
+# grow freely, while this suite stays stable enough to compare abicheck,
+# libabigail, and ABICC across releases.
+PINNED_74_CASE_RE = re.compile(r"^case(?:0[1-9]|[1-6][0-9]|7[0-3])_|^case26b_")
 
 # Expected verdicts loaded from ground_truth.json — single source of truth.
 # To add/change a verdict, edit examples/ground_truth.json only.
@@ -460,7 +467,6 @@ def _abicheck_verdict_from_compare(stdout: str, returncode: int) -> str:
         "COMPATIBLE_WITH_RISK": "COMPATIBLE_WITH_RISK",
         "COMPATIBLE": "COMPATIBLE",
         "NO_CHANGE": "NO_CHANGE",
-        "COMPATIBLE_WITH_RISK": "COMPATIBLE_WITH_RISK",
     }.get(str(data.get("verdict", "")).upper(), "ERROR")
 
 
@@ -826,6 +832,8 @@ def parse_args() -> argparse.Namespace:
                    help="Skip abicheck compat column")
     p.add_argument("--cases", nargs="+", metavar="CASE",
                    help="Run only these case prefixes (e.g. case09 case16)")
+    p.add_argument("--suite", choices=["all", "pinned74"], default="all",
+                   help="Case suite to run: all catalog cases, or the historical 74-case release-pinned subset")
     p.add_argument("--tools", nargs="+", metavar="TOOL",
                    choices=["abicheck", "abicheck_compat", "abicheck_strict",
                             "abidiff", "abidiff_headers", "abicc_dumper", "abicc_xml"],
@@ -947,7 +955,7 @@ def _ground_truth_digest() -> str | None:
     return hashlib.sha256(gt.read_bytes()).hexdigest()
 
 
-def _collect_metadata(results: list[dict], active_tools: list[Any]) -> dict[str, Any]:
+def _collect_metadata(results: list[dict], active_tools: list[Any], suite: str) -> dict[str, Any]:
     """Assemble reproducibility metadata + machine-readable accuracy.
 
     This is the release-pinnable artifact: it records the exact inputs
@@ -976,6 +984,7 @@ def _collect_metadata(results: list[dict], active_tools: list[Any]) -> dict[str,
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "abicheck_version": abicheck_version,
         "git_commit": _git_commit(),
+        "suite": suite,
         "case_count": len(results),
         "ground_truth_sha256": _ground_truth_digest(),
         "tool_versions": {
@@ -1375,6 +1384,8 @@ def main() -> None:
     BUILD_DIR.mkdir(exist_ok=True)
 
     all_cases = sorted(d for d in EXAMPLES_DIR.iterdir() if d.is_dir() and d.name.startswith("case"))
+    if args.suite == "pinned74":
+        all_cases = [d for d in all_cases if PINNED_74_CASE_RE.match(d.name)]
     selected_tools = _resolve_selected_tools(args)
     active_tools = [t for t in TOOL_REGISTRY if t.name in selected_tools]
 
@@ -1393,7 +1404,7 @@ def main() -> None:
     summary.write_text(json.dumps(results, indent=2))
 
     # Release-pinnable artifact: metadata + accuracy + results in one file.
-    report = _collect_metadata(results, active_tools)
+    report = _collect_metadata(results, active_tools, args.suite)
     report_path = REPORT_DIR / "benchmark_report.json"
     report_path.write_text(json.dumps(report, indent=2))
 

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -38,6 +38,7 @@ def test_parse_args_defaults():
         args = mod.parse_args()
     assert args.abicc_timeout == mod.DEFAULT_ABICC_TIMEOUT
     assert args.abicc_mode == "both"
+    assert args.suite == "all"
     assert not args.skip_abicc
 
 
@@ -74,6 +75,28 @@ def test_parse_args_skip_compat_default_false():
     with patch("sys.argv", ["benchmark_comparison.py"]):
         args = mod.parse_args()
     assert args.skip_compat is False
+
+
+def test_parse_args_pinned_suite():
+    mod = _load_benchmark()
+    with patch("sys.argv", ["benchmark_comparison.py", "--suite", "pinned74"]):
+        args = mod.parse_args()
+    assert args.suite == "pinned74"
+
+
+def test_pinned_suite_matches_historical_74_cases():
+    mod = _load_benchmark()
+    cases = sorted(
+        d.name for d in (Path(__file__).parent.parent / "examples").iterdir()
+        if d.is_dir() and d.name.startswith("case")
+    )
+    pinned = [c for c in cases if mod.PINNED_74_CASE_RE.match(c)]
+
+    assert len(pinned) == 74
+    assert "case01_symbol_removal" in pinned
+    assert "case26b_union_field_added_compatible" in pinned
+    assert "case73_typedef_underlying_changed" in pinned
+    assert "case74_detail_base_class_changed" not in pinned
 
 
 # ── case64 compiler selection ────────────────────────────────────────────────
@@ -180,10 +203,11 @@ def test_collect_metadata_shape_and_accuracy():
         # SKIP rows must not be scored.
         {"case": "case04", "expected": "BREAKING", "abicheck": "SKIP", "abicheck_ms": 0},
     ]
-    meta = mod._collect_metadata(results, [_FakeTool()])
+    meta = mod._collect_metadata(results, [_FakeTool()], "pinned74")
 
     assert meta["schema"] == "abicheck-benchmark/1.0"
     assert meta["case_count"] == 4
+    assert meta["suite"] == "pinned74"
     assert "abicheck_version" in meta
     assert set(meta["tool_versions"]) >= {"abidiff", "gcc", "castxml"}
     assert meta["results"] is results

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -99,6 +99,13 @@ def test_pinned_suite_matches_historical_74_cases():
     assert "case74_detail_base_class_changed" not in pinned
 
 
+def test_null_expected_verdict_is_unscored_unknown():
+    mod = _load_benchmark()
+
+    assert mod.EXPECTED["case84_bundle_soname_skew"] == "?"
+    assert mod.EXPECTED_ABICC["case84_bundle_soname_skew"] == "?"
+
+
 # ── case64 compiler selection ────────────────────────────────────────────────
 
 def test_case64_auto_prefers_versioned_clang():


### PR DESCRIPTION
## Summary
- clarify in README that the project has a 121-case full examples catalog, while the published validation table is the historical 74-case cross-tool benchmark subset
- add `--suite {all,pinned74}` to `scripts/benchmark_comparison.py` and record the selected suite in `benchmark_report.json`
- make release publishing explicitly run `--suite pinned74`
- align the tool-comparison reference page and add smoke coverage for the suite option and 74-case selector

## Why
The README looked stale because the validation snapshot still talked only about 74 cases even though the examples catalog has 121 cases. The 74-case table is still useful as a stable release-to-release cross-tool benchmark, but it needed to be labeled that way and the full-catalog command needed to be explicit.

## Validation
- `python -m pytest tests/test_benchmark_smoke.py`
- `python -m ruff check scripts/benchmark_comparison.py tests/test_benchmark_smoke.py`
- `git diff --check`
