### PR TITLE
fix: treat ELF-only function removals as breaking

### DIFF
--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -122,8 +122,8 @@ REGISTRY = ChangeKindRegistry([
     # ── Function / variable changes ────────────────────────────────────────
     _E("func_removed", _B,
        impact="Old binaries call a symbol that no longer exists; dynamic linker will refuse to load or crash at call site."),
-    _E("func_removed_elf_only", _C,
-       impact="Symbol removed from ELF but was not in public headers; low risk unless dlsym() callers depend on it."),
+    _E("func_removed_elf_only", _B,
+       impact="Exported ELF function disappeared; old binaries or dlsym() callers that bind it can fail even when no public-header evidence is available."),
     _E("func_added", _C, is_addition=True,
        impact="New function available; existing binaries are unaffected."),
     _E("func_return_changed", _B,

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -49,7 +49,7 @@ from .change_registry import Verdict as Verdict
 class ChangeKind(str, Enum):
     # Function / variable changes
     FUNC_REMOVED = "func_removed"  # public symbol removed → BREAKING
-    FUNC_REMOVED_ELF_ONLY = "func_removed_elf_only"  # ELF-only symbol removed (visibility cleanup, not hard break)
+    FUNC_REMOVED_ELF_ONLY = "func_removed_elf_only"  # exported ELF-only function removed -> BREAKING
     FUNC_ADDED = "func_added"  # new public symbol → COMPATIBLE
     FUNC_RETURN_CHANGED = "func_return_changed"  # return type changed → BREAKING
     FUNC_PARAMS_CHANGED = "func_params_changed"  # parameter types changed → BREAKING

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -289,7 +289,7 @@ class TestVerdictPriority:
 
 
 
-def test_func_removed_elf_only_is_compatible_not_breaking() -> None:
+def test_func_removed_elf_only_is_breaking() -> None:
     old = AbiSnapshot(
         library="libfoo.so", version="1.0",
         functions=[Function(name="internal", mangled="internal", return_type="void", visibility=Visibility.ELF_ONLY)],
@@ -299,7 +299,7 @@ def test_func_removed_elf_only_is_compatible_not_breaking() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.FUNC_REMOVED_ELF_ONLY in kinds
-    assert result.verdict == Verdict.COMPATIBLE
+    assert result.verdict == Verdict.BREAKING
 
 
 # ── WS-4a: ELF visibility tracking ─────────────────────────────────────────

--- a/tests/test_sprint10_abicc_parity.py
+++ b/tests/test_sprint10_abicc_parity.py
@@ -132,20 +132,18 @@ class TestFuncVisibilityChanged:
         assert "_Z3apiv" in vis_changes[0].symbol
 
     def test_elf_only_symbol_absent_is_func_removed_elf_only(self) -> None:
-        """ELF_ONLY symbol absent from new snapshot → FUNC_REMOVED_ELF_ONLY (compatible).
+        """ELF_ONLY symbol absent from new snapshot → FUNC_REMOVED_ELF_ONLY (breaking).
 
-        ELF-only symbols (no header/DWARF data) that disappear could be internal
-        symbols getting properly hidden via -fvisibility=hidden.  Emitting
-        FUNC_REMOVED would produce a false BREAKING verdict in that case.
-        Requires elf_only_mode=True on the old snapshot (set by dumper when
-        no headers are provided) to avoid false COMPATIBLE on real removals.
+        Exported ELF functions remain binary ABI surface even when no
+        header/DWARF data proves public-header membership.  Disappearing
+        symbols can break old binaries or dlsym() callers that bind them.
         """
         old_f = _func("sym", "_Z3symv", visibility=Visibility.ELF_ONLY)
         r = compare(_snap(functions=[old_f], elf_only_mode=True), _snap("2.0", functions=[]))
         assert any(c.kind == ChangeKind.FUNC_REMOVED_ELF_ONLY for c in r.changes)
         assert not any(c.kind == ChangeKind.FUNC_REMOVED for c in r.changes)
         assert not any(c.kind == ChangeKind.FUNC_VISIBILITY_CHANGED for c in r.changes)
-        assert r.verdict == Verdict.COMPATIBLE
+        assert r.verdict == Verdict.BREAKING
 
     def test_elf_only_to_hidden_is_visibility_change(self) -> None:
         """ELF_ONLY → HIDDEN: callers that resolved the symbol dynamically break.


### PR DESCRIPTION
## Summary
- Classify removed ELF-only exported functions as breaking ABI changes.
- Update policy comments and regression expectations.
- Keep the existing distinct change kind while raising its default severity.

## Real-world evidence
- HarfBuzz libharfbuzz-vector 13.2.1 -> 14.2.1 removed 4 exported hb_vector_svg_* functions; previous verdict was COMPATIBLE, abidiff exited 12, after the fix verdict is BREAKING.
- KRB5 libgssapi_krb5 1.21.3 -> 1.22.2 removed gss_krb5int_unseal_token_v3; previous verdict was only COMPATIBLE_WITH_RISK, abidiff exited 12, after the fix verdict is BREAKING.
- KRB5 libkrb5support 1.21.3 -> 1.22.2 removed k5_secure_getenv; previous verdict was only COMPATIBLE_WITH_RISK, abidiff exited 12, after the fix verdict is BREAKING.

Artifacts are under the recurring validation report tree: reports/abicheck-realworld-cron/artifacts/20260603-1043/.

## Verification
- pytest -q tests/test_checker.py tests/test_sprint10_abicc_parity.py
- pytest -q tests/test_policy_changekind_matrix.py tests/test_policy_registry_and_summary.py tests/test_policy_override_matrix.py tests/test_policy_file.py
- ruff check abicheck/change_registry.py abicheck/checker_policy.py tests/test_checker.py tests/test_sprint10_abicc_parity.py
- Real-world reruns for HarfBuzz vector, KRB5 gssapi, and KRB5 support after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ABI compatibility classification: ELF-only function removals are now properly identified as breaking changes rather than compatible changes, improving detection of potential runtime failures from symbol disappearance.

* **Documentation**
  * Updated compatibility checker documentation and tests to reflect that ELF-only function removals are breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->