### PR TITLE
chore: prepare 0.3.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+No changes yet.
+
+---
+
+## [0.3.0] — 2026-06-03
+
 ### Added
 
 #### Release Recommendation (semver + SONAME)
@@ -487,4 +493,5 @@ additional capabilities.
 
 [0.1.0]: https://github.com/napetrov/abicheck/releases/tag/v0.1.0
 [0.2.0]: https://github.com/napetrov/abicheck/releases/tag/v0.2.0
-[Unreleased]: https://github.com/napetrov/abicheck/compare/v0.2.0...HEAD
+[0.3.0]: https://github.com/napetrov/abicheck/releases/tag/v0.3.0
+[Unreleased]: https://github.com/napetrov/abicheck/compare/v0.3.0...HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abicheck"
-version = "0.2.0"
+version = "0.3.0"
 description = "ABI compatibility checker for C/C++ shared libraries"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- bump package version from 0.2.0 to 0.3.0
- cut CHANGELOG.md by moving current Unreleased notes into 0.3.0 dated 2026-06-03
- reset Unreleased for post-0.3.0 changes

## Validation
- python -m build
- twine check dist/*
- pytest tests/test_benchmark_smoke.py tests/test_report_metadata.py -q
- git diff --check

This addresses the release blockers around duplicate 0.2.0 publishing and uncut changelog metadata.