### PR TITLE
chore: align example platform metadata for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,13 @@ No changes yet.
 
 ### Fixed
 
+#### Windows example-platform metadata matches the validated build surface
+- Corrected the platform declarations for eight advanced C++/template example
+  fixtures (`case79`, `case85`, `case95`, `case100`, `case101`, `case102`,
+  `case110`, `case111`) from Linux/macOS/Windows to Linux/macOS. These cases
+  remain in the full catalog, but Windows CI no longer attempts CMake builds
+  for fixtures that are not validated on the Windows toolchain.
+
 #### Transitive stdlib/runtime symbols no longer leak into the ABI surface
 - Centralized ELF ABI-relevance filtering into `abicheck/elf_symbol_filter.py`
   and shared it across the symbols-only dumper, DWARF snapshot extraction, and

--- a/examples/case100_experimental_removed_without_replacement/CMakeLists.txt
+++ b/examples/case100_experimental_removed_without_replacement/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case100_experimental_removed_without_replacement
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case101_inline_namespace_version_bumped/CMakeLists.txt
+++ b/examples/case101_inline_namespace_version_bumped/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case101_inline_namespace_version_bumped
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case102_frozen_runtime_signature_changed/CMakeLists.txt
+++ b/examples/case102_frozen_runtime_signature_changed/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case102_frozen_runtime_signature_changed
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case110_concurrent_unordered_map_api_drift/CMakeLists.txt
+++ b/examples/case110_concurrent_unordered_map_api_drift/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case110_concurrent_unordered_map_api_drift
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case111_enumerable_thread_specific_lambda_ambiguity/CMakeLists.txt
+++ b/examples/case111_enumerable_thread_specific_lambda_ambiguity/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case111_enumerable_thread_specific_lambda_ambiguity
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case79_missing_template_instantiation/CMakeLists.txt
+++ b/examples/case79_missing_template_instantiation/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case79_missing_template_instantiation
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case85_internal_template_signature_changed/CMakeLists.txt
+++ b/examples/case85_internal_template_signature_changed/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case85_internal_template_signature_changed
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/case95_allocator_nested_typedef_removed/CMakeLists.txt
+++ b/examples/case95_allocator_nested_typedef_removed/CMakeLists.txt
@@ -4,5 +4,5 @@ abicheck_add_case(case95_allocator_nested_typedef_removed
     V1_HEADERS v1.h
     V2_HEADERS v2.h
     APP_SOURCES app.cpp
-    PLATFORMS linux macos windows
+    PLATFORMS linux macos
 )

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -1090,8 +1090,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": true,
       "api_break": true,
@@ -1369,8 +1368,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": false,
       "api_break": true,
@@ -1483,8 +1481,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": true,
       "api_break": true,
@@ -1499,8 +1496,7 @@
       "category": "addition",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": false,
       "api_break": false,
@@ -1535,8 +1531,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": true,
       "api_break": false,
@@ -1617,8 +1612,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": true,
       "api_break": true,
@@ -1634,8 +1628,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": true,
       "api_break": false,
@@ -1650,8 +1643,7 @@
       "category": "breaking",
       "platforms": [
         "linux",
-        "macos",
-        "windows"
+        "macos"
       ],
       "abi_break": true,
       "api_break": true,


### PR DESCRIPTION
## Summary
- mark eight advanced C++/template fixtures as Linux/macOS-only in ground_truth and CMake metadata
- keep them in the full catalog while avoiding unsupported Windows CMake builds
- document the release-gate metadata fix in the 0.3.0 changelog

## Validation
- python -m pytest tests/test_case_analysis_validation.py tests/test_benchmark_smoke.py tests/test_platform_coverage_honesty.py -q
- python -m json.tool examples/ground_truth.json >/dev/null
- git diff --check

Release context: current main CI failed only on Windows integration while building these eight fixtures, so v0.3.0 release remains blocked until this lands and main is green.