### PR TITLE
docs: regenerate example platform pages

### DIFF
--- a/docs/examples/case100_experimental_removed_without_replacement.md
+++ b/docs/examples/case100_experimental_removed_without_replacement.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `experimental_removed_without_replacement`, `func_removed` |
 | **Source files** | `examples/case100_experimental_removed_without_replacement/` |

--- a/docs/examples/case101_inline_namespace_version_bumped.md
+++ b/docs/examples/case101_inline_namespace_version_bumped.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `inline_namespace_version_bumped` |
 | **Source files** | `examples/case101_inline_namespace_version_bumped/` |

--- a/docs/examples/case102_frozen_runtime_signature_changed.md
+++ b/docs/examples/case102_frozen_runtime_signature_changed.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_params_changed`, `func_return_changed` |
 | **Source files** | `examples/case102_frozen_runtime_signature_changed/` |

--- a/docs/examples/case110_concurrent_unordered_map_api_drift.md
+++ b/docs/examples/case110_concurrent_unordered_map_api_drift.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `func_removed` |
 | **Source files** | `examples/case110_concurrent_unordered_map_api_drift/` |

--- a/docs/examples/case111_enumerable_thread_specific_lambda_ambiguity.md
+++ b/docs/examples/case111_enumerable_thread_specific_lambda_ambiguity.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🟢 **COMPATIBLE** |
 | **Category** | Addition (Compatible) |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | `func_added` |
 | **Source files** | `examples/case111_enumerable_thread_specific_lambda_ambiguity/` |

--- a/docs/examples/case79_missing_template_instantiation.md
+++ b/docs/examples/case79_missing_template_instantiation.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | ABI break, API break |
 | **Detected `ChangeKind`s** | `instantiation_missing_from_binary` |
 | **Source files** | `examples/case79_missing_template_instantiation/` |

--- a/docs/examples/case85_internal_template_signature_changed.md
+++ b/docs/examples/case85_internal_template_signature_changed.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | ABI break |
 | **Detected `ChangeKind`s** | `internal_template_leaks_via_public_api`, `func_removed` |
 | **Source files** | `examples/case85_internal_template_signature_changed/` |

--- a/docs/examples/case95_allocator_nested_typedef_removed.md
+++ b/docs/examples/case95_allocator_nested_typedef_removed.md
@@ -5,7 +5,7 @@
 |-------|-------|
 | **Verdict** | 🔴 **BREAKING** |
 | **Category** | Breaking |
-| **Platforms** | Linux, macOS, Windows |
+| **Platforms** | Linux, macOS |
 | **Flags** | API break |
 | **Detected `ChangeKind`s** | `typedef_removed` |
 | **Source files** | `examples/case95_allocator_nested_typedef_removed/` |


### PR DESCRIPTION
## Summary
- regenerate docs/examples pages after #288 changed platform metadata for eight advanced C++ fixtures
- fixes the main CI docs/examples drift gate before creating v0.3.0

## Validation
- python -m pytest tests/test_examples_docs.py tests/test_case_analysis_validation.py -q
- git diff --check
- python -m json.tool examples/ground_truth.json >/dev/null