### PR TITLE
fix: ignore ELF lifecycle stubs in symbol diffs

### DIFF
--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -119,13 +119,14 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     ``.dynsym``, so in practice the export set is authoritative here.
     """
     funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
+    elf = getattr(snap, "elf", None)
+    if elf is None or not getattr(elf, "symbols", None):
+        return funcs
     exported = exported_symbol_names(
-        getattr(snap, "elf", None),
+        elf,
         FUNCTION_SYMBOL_TYPES,
         abi_relevant_only=True,
     )
-    if not exported:
-        return funcs
     return {
         k: v for k, v in funcs.items()
         if k in exported or v.is_deleted

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -119,7 +119,11 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     ``.dynsym``, so in practice the export set is authoritative here.
     """
     funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
-    exported = exported_symbol_names(getattr(snap, "elf", None), FUNCTION_SYMBOL_TYPES)
+    exported = exported_symbol_names(
+        getattr(snap, "elf", None),
+        FUNCTION_SYMBOL_TYPES,
+        abi_relevant_only=True,
+    )
     if not exported:
         return funcs
     return {

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -84,6 +84,11 @@ def _is_abi_relevant_symbol(name: str) -> bool:
     return is_abi_relevant_elf_symbol(name)
 
 
+def _is_macho_abi_relevant_symbol(name: str) -> bool:
+    """Return whether a raw Mach-O export should enter the ABI surface."""
+    return bool(name)
+
+
 def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
     """Return (exported_dynamic, exported_static) sets of mangled symbol names.
 
@@ -997,7 +1002,7 @@ def _dump_macho(
     # Build exported symbol set from Mach-O export table
     exported_dynamic: set[str] = {
         exp.name for exp in macho_meta.exports
-        if exp.name and _is_abi_relevant_symbol(exp.name)
+        if _is_macho_abi_relevant_symbol(exp.name)
     }
 
     profile_hint: str | None = None
@@ -1025,7 +1030,7 @@ def _dump_macho(
         # using section classification from Mach-O nlist entries.
         _relevant = [
             exp for exp in macho_meta.exports
-            if exp.name and _is_abi_relevant_symbol(exp.name)
+            if _is_macho_abi_relevant_symbol(exp.name)
         ]
         macho_funcs = [exp for exp in _relevant if not exp.is_data]
         macho_vars = [exp for exp in _relevant if exp.is_data]

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -84,11 +84,6 @@ def _is_abi_relevant_symbol(name: str) -> bool:
     return is_abi_relevant_elf_symbol(name)
 
 
-def _is_macho_abi_relevant_symbol(name: str) -> bool:
-    """Return whether a raw Mach-O export should enter the ABI surface."""
-    return bool(name)
-
-
 def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
     """Return (exported_dynamic, exported_static) sets of mangled symbol names.
 
@@ -1002,7 +997,7 @@ def _dump_macho(
     # Build exported symbol set from Mach-O export table
     exported_dynamic: set[str] = {
         exp.name for exp in macho_meta.exports
-        if _is_macho_abi_relevant_symbol(exp.name)
+        if exp.name and _is_abi_relevant_symbol(exp.name)
     }
 
     profile_hint: str | None = None
@@ -1030,7 +1025,7 @@ def _dump_macho(
         # using section classification from Mach-O nlist entries.
         _relevant = [
             exp for exp in macho_meta.exports
-            if _is_macho_abi_relevant_symbol(exp.name)
+            if exp.name and _is_abi_relevant_symbol(exp.name)
         ]
         macho_funcs = [exp for exp in _relevant if not exp.is_data]
         macho_vars = [exp for exp in _relevant if exp.is_data]

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -42,6 +42,10 @@ _GCC_INTERNAL_PREFIXES = (
     "__libm_avx_",
 )
 
+# ELF lifecycle entry/exit stubs are emitted by toolchains/linkers rather than
+# by the library's public ABI contract. Treat exact names only as non-ABI.
+_ELF_LIFECYCLE_STUBS = frozenset({"_init", "_fini"})
+
 # Prefixes that identify transitive C++ standard-library symbols which may
 # appear in .dynsym via weak linkage (libstdc++ / libc++).
 _STDLIB_PREFIXES = (
@@ -88,6 +92,9 @@ def is_abi_relevant_elf_symbol(name: str) -> bool:
     false ``FUNC_REMOVED`` and type-reachability findings.
     """
     if not name:
+        return False
+
+    if name in _ELF_LIFECYCLE_STUBS:
         return False
 
     for prefix in _GCC_INTERNAL_PREFIXES:

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import pytest
 
-from abicheck.dumper import _is_abi_relevant_symbol
+from abicheck.diff_symbols import _public_functions
+from abicheck.dumper import _is_abi_relevant_symbol, _is_macho_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
 from abicheck.elf_symbol_filter import (
@@ -17,6 +18,7 @@ from abicheck.elf_symbol_filter import (
     VARIABLE_SYMBOL_TYPES,
     exported_symbol_names,
 )
+from abicheck.model import AbiSnapshot, Function, Visibility
 
 # ---------------------------------------------------------------------------
 # Bug 1: GCC / compiler-internal symbols — must be filtered
@@ -123,6 +125,15 @@ def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
     assert _is_abi_relevant_symbol(name) is False, (
         f"ELF lifecycle stub {name!r} should be filtered out"
     )
+
+
+@pytest.mark.parametrize("name", [
+    # Mach-O C exports keep a leading underscore before abicheck normalizes them.
+    "_init",
+    "_fini",
+])
+def test_macho_init_style_exports_are_not_elf_filtered(name: str) -> None:
+    assert _is_macho_abi_relevant_symbol(name) is True
 
 
 @pytest.mark.parametrize("name", [
@@ -278,3 +289,60 @@ def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> N
         "_ZN6MyLib4CoreC1Ev",
         "lib_init",
     }
+
+
+def _function(name: str) -> Function:
+    return Function(
+        name=name,
+        mangled=name,
+        return_type="void",
+        visibility=Visibility.PUBLIC,
+    )
+
+
+def test_public_functions_falls_back_without_elf_metadata() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        functions=[_function("_init"), _function("lib_init")],
+        elf=None,
+    )
+
+    assert set(_public_functions(snap)) == {"_init", "lib_init"}
+
+
+def test_public_functions_keeps_empty_filtered_elf_exports_empty() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        functions=[_function("_init"), _function("_fini")],
+        elf=ElfMetadata(
+            symbols=[
+                ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="_fini", sym_type=SymbolType.FUNC),
+            ]
+        ),
+    )
+
+    assert _public_functions(snap) == {}
+
+
+def test_public_functions_uses_abi_relevant_export_filter() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        functions=[
+            _function("_init"),
+            _function("_ZNSt6vectorIiSaIiEE4sizeEv"),
+            _function("lib_init"),
+        ],
+        elf=ElfMetadata(
+            symbols=[
+                ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="lib_init", sym_type=SymbolType.FUNC),
+            ]
+        ),
+    )
+
+    assert set(_public_functions(snap)) == {"lib_init"}

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from abicheck.diff_symbols import _public_functions
-from abicheck.dumper import _is_abi_relevant_symbol, _is_macho_abi_relevant_symbol
+from abicheck.dumper import _is_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
 from abicheck.elf_symbol_filter import (
@@ -125,15 +125,6 @@ def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
     assert _is_abi_relevant_symbol(name) is False, (
         f"ELF lifecycle stub {name!r} should be filtered out"
     )
-
-
-@pytest.mark.parametrize("name", [
-    # Mach-O C exports keep a leading underscore before abicheck normalizes them.
-    "_init",
-    "_fini",
-])
-def test_macho_init_style_exports_are_not_elf_filtered(name: str) -> None:
-    assert _is_macho_abi_relevant_symbol(name) is True
 
 
 @pytest.mark.parametrize("name", [

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -115,6 +115,17 @@ def test_stdlib_transitive_symbols_are_filtered(name: str) -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("name", [
+    # ELF lifecycle stubs emitted by the linker/toolchain, not library API.
+    "_init",
+    "_fini",
+])
+def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
+    assert _is_abi_relevant_symbol(name) is False, (
+        f"ELF lifecycle stub {name!r} should be filtered out"
+    )
+
+
+@pytest.mark.parametrize("name", [
     # mpfr public API
     "mpfr_add",
     "mpfr_mul",
@@ -129,10 +140,7 @@ def test_stdlib_transitive_symbols_are_filtered(name: str) -> None:
     "_ZNK6MyLib4Core4nameEv",
     "_ZTIN3foo3BarE",   # typeinfo for foo::Bar
     "_ZTSN3foo3BarE",   # typeinfo name for foo::Bar
-    # Regular single-underscore prefixed symbols (not double)
-    "_init",
-    "_fini",
-    # Symbol with single underscore separator — not private
+    # Public initialization-style APIs must not be confused with lifecycle stubs.
     "my_function",
     "lib_init",
     # Empty-ish edge cases that are valid names
@@ -249,17 +257,24 @@ def test_exported_symbol_names_notype_counts_for_both_surfaces() -> None:
 
 
 def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> None:
-    """abi_relevant_only excludes transitive stdlib exports but keeps own symbols."""
+    """abi_relevant_only excludes transitive/toolchain exports but keeps own symbols."""
     meta = ElfMetadata(
         symbols=[
             ElfSymbol(name="_ZN6MyLib4CoreC1Ev", sym_type=SymbolType.FUNC),
             ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_fini", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="lib_init", sym_type=SymbolType.FUNC),
         ]
     )
     assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES) == {
         "_ZN6MyLib4CoreC1Ev",
         "_ZNSt6vectorIiSaIiEE4sizeEv",
+        "_init",
+        "_fini",
+        "lib_init",
     }
     assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES, abi_relevant_only=True) == {
         "_ZN6MyLib4CoreC1Ev",
+        "lib_init",
     }


### PR DESCRIPTION
## Summary
- filters exact ELF lifecycle stubs `_init` and `_fini` out of ABI-relevant symbol sets
- applies the ABI-relevance filter when diffing exported ELF functions
- adds regression coverage that preserves real init-style APIs like `lib_init`

## Real-world evidence
- PCRE2 10.46 -> 10.47 (`libpcre2-8`, `libpcre2-16`, `libpcre2-32`, `libpcre2-posix`) removed only `_init`/`_fini` plus compatible additions.
- Pre-fix abicheck reported the three main DSOs as `BREAKING` solely due to those stubs.
- Post-fix rerun reports the main DSOs `COMPATIBLE`; `libpcre2-posix` remains `COMPATIBLE_WITH_RISK` only for the symbol-version requirement change.

Artifacts: `/home/openclaw/.openclaw/workspace-abicheck/reports/abicheck-realworld-cron/artifacts/20260603-1709/`

## Verification
- `pytest -q tests/test_elf_symbol_filters.py tests/test_checker.py::test_func_removed_elf_only_is_breaking tests/test_sprint10_abicc_parity.py::TestFuncVisibilityChanged::test_elf_only_symbol_absent_is_func_removed_elf_only`
- post-fix PCRE2 rerun under `artifacts/20260603-1709/rerun-after-lifecycle-stub-filter-v2/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced ABI compatibility detection to properly exclude internal ELF lifecycle symbols from the public API surface, ensuring more accurate identification of meaningful API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->