### PR TITLE
Avoid ELF-only false positives for retained wrappers and linker artifacts

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -36,6 +36,7 @@ from .diff_platform_templates import (
 from .diff_symbols import _public_functions
 from .diff_types import _RESERVED_FIELD_RE
 from .elf_metadata import SymbolBinding, SymbolType
+from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .model import (
     AbiSnapshot,
     Visibility,
@@ -281,7 +282,11 @@ def _diff_visibility_leak(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
     leaked = [
         f for f in old.functions
-        if f.visibility == Visibility.ELF_ONLY and _looks_internal(f.name)
+        if (
+            f.visibility == Visibility.ELF_ONLY
+            and is_abi_relevant_elf_symbol(f.name)
+            and _looks_internal(f.name)
+        )
     ]
     if not leaked:
         return []
@@ -1512,4 +1517,3 @@ def _diff_elf_deleted_fallback(old: AbiSnapshot, new: AbiSnapshot) -> list[Chang
 # AI-readiness file-size soft cap. Re-exported below so existing imports from
 # ``abicheck.diff_platform`` keep working.
 # Re-exports for backwards compatibility — see top-of-file imports.
-

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1713,6 +1713,19 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
     if not old_fps or not new_fps:
         return changes
 
+    new_exported_funcs = {
+        sym.name
+        for sym in new.elf.symbols
+        if sym.sym_type in _FUNC_LIKE_TYPES
+    }
+    old_fps = {
+        name: fp
+        for name, fp in old_fps.items()
+        if name not in new_exported_funcs
+    }
+    if not old_fps:
+        return changes
+
     # Matches in this path are hash-less (size-only), inferred from symbol size
     # alone since _fingerprints_from_elf has no code bytes. Pass the name-
     # similarity predicate into the matcher so it participates in candidate

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1733,9 +1733,10 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
     if not old_fps or not new_fps:
         return changes
 
+    new_elf = getattr(new, "elf", None)
     new_exported_funcs = {
         sym.name
-        for sym in new.elf.symbols
+        for sym in (new_elf.symbols if new_elf is not None else [])
         if sym.sym_type in _FUNC_LIKE_TYPES
     }
     old_fps = {

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1696,6 +1696,8 @@ def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:
     for sym in snap.elf.symbols:
         if sym.sym_type not in _FUNC_LIKE_TYPES:
             continue
+        if not is_abi_relevant_elf_symbol(sym.name):
+            continue
         if sym.size < _MIN_SYMBOL_SIZE:
             continue
         result[sym.name] = FunctionFingerprint(
@@ -1733,18 +1735,30 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
     if not old_fps or not new_fps:
         return changes
 
+    old_elf = getattr(old, "elf", None)
     new_elf = getattr(new, "elf", None)
+    old_exported_funcs = {
+        sym.name
+        for sym in (old_elf.symbols if old_elf is not None else [])
+        if sym.sym_type in _FUNC_LIKE_TYPES and is_abi_relevant_elf_symbol(sym.name)
+    }
     new_exported_funcs = {
         sym.name
         for sym in (new_elf.symbols if new_elf is not None else [])
-        if sym.sym_type in _FUNC_LIKE_TYPES
+        if sym.sym_type in _FUNC_LIKE_TYPES and is_abi_relevant_elf_symbol(sym.name)
     }
+    retained_exported_funcs = old_exported_funcs & new_exported_funcs
     old_fps = {
         name: fp
         for name, fp in old_fps.items()
-        if name not in new_exported_funcs
+        if name not in retained_exported_funcs
     }
-    if not old_fps:
+    new_fps = {
+        name: fp
+        for name, fp in new_fps.items()
+        if name not in retained_exported_funcs
+    }
+    if not old_fps or not new_fps:
         return changes
 
     # Matches in this path are hash-less (size-only), inferred from symbol size

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -119,13 +119,14 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     ``.dynsym``, so in practice the export set is authoritative here.
     """
     funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
+    elf = getattr(snap, "elf", None)
+    if elf is None or not getattr(elf, "symbols", None):
+        return funcs
     exported = exported_symbol_names(
-        getattr(snap, "elf", None),
+        elf,
         FUNCTION_SYMBOL_TYPES,
         abi_relevant_only=True,
     )
-    if not exported:
-        return funcs
     return {
         k: v for k, v in funcs.items()
         if k in exported or v.is_deleted

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -30,7 +30,11 @@ from .checker_types import Change
 from .detector_registry import registry
 from .diff_helpers import bool_transition, diff_by_key
 from .elf_metadata import SymbolType
-from .elf_symbol_filter import FUNCTION_SYMBOL_TYPES, exported_symbol_names
+from .elf_symbol_filter import (
+    FUNCTION_SYMBOL_TYPES,
+    exported_symbol_names,
+    is_abi_relevant_elf_symbol,
+)
 from .model import (
     AbiSnapshot,
     Function,
@@ -118,7 +122,16 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     theory hide a genuine removal — but DWARF-primary snapshots carry the full
     ``.dynsym``, so in practice the export set is authoritative here.
     """
-    funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
+    funcs = {
+        k: v for k, v in snap.function_map.items()
+        if (
+            v.visibility in _PUBLIC_VIS
+            and (
+                v.visibility != Visibility.ELF_ONLY
+                or is_abi_relevant_elf_symbol(k)
+            )
+        )
+    }
     elf = getattr(snap, "elf", None)
     if elf is None or not getattr(elf, "symbols", None):
         return funcs
@@ -142,7 +155,14 @@ def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:
     """
     return {
         k: v for k, v in snap.variable_map.items()
-        if v.visibility in _PUBLIC_VIS and not _is_local_type_rtti(k)
+        if (
+            v.visibility in _PUBLIC_VIS
+            and (
+                v.visibility != Visibility.ELF_ONLY
+                or is_abi_relevant_elf_symbol(k)
+            )
+            and not _is_local_type_rtti(k)
+        )
     }
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -119,7 +119,11 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     ``.dynsym``, so in practice the export set is authoritative here.
     """
     funcs = {k: v for k, v in snap.function_map.items() if v.visibility in _PUBLIC_VIS}
-    exported = exported_symbol_names(getattr(snap, "elf", None), FUNCTION_SYMBOL_TYPES)
+    exported = exported_symbol_names(
+        getattr(snap, "elf", None),
+        FUNCTION_SYMBOL_TYPES,
+        abi_relevant_only=True,
+    )
     if not exported:
         return funcs
     return {

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -84,6 +84,11 @@ def _is_abi_relevant_symbol(name: str) -> bool:
     return is_abi_relevant_elf_symbol(name)
 
 
+def _is_macho_abi_relevant_symbol(name: str) -> bool:
+    """Return whether a raw Mach-O export should enter the ABI surface."""
+    return bool(name)
+
+
 def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
     """Return (exported_dynamic, exported_static) sets of mangled symbol names.
 
@@ -997,7 +1002,7 @@ def _dump_macho(
     # Build exported symbol set from Mach-O export table
     exported_dynamic: set[str] = {
         exp.name for exp in macho_meta.exports
-        if exp.name and _is_abi_relevant_symbol(exp.name)
+        if _is_macho_abi_relevant_symbol(exp.name)
     }
 
     profile_hint: str | None = None
@@ -1025,7 +1030,7 @@ def _dump_macho(
         # using section classification from Mach-O nlist entries.
         _relevant = [
             exp for exp in macho_meta.exports
-            if exp.name and _is_abi_relevant_symbol(exp.name)
+            if _is_macho_abi_relevant_symbol(exp.name)
         ]
         macho_funcs = [exp for exp in _relevant if not exp.is_data]
         macho_vars = [exp for exp in _relevant if exp.is_data]

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -84,11 +84,6 @@ def _is_abi_relevant_symbol(name: str) -> bool:
     return is_abi_relevant_elf_symbol(name)
 
 
-def _is_macho_abi_relevant_symbol(name: str) -> bool:
-    """Return whether a raw Mach-O export should enter the ABI surface."""
-    return bool(name)
-
-
 def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
     """Return (exported_dynamic, exported_static) sets of mangled symbol names.
 
@@ -1002,7 +997,7 @@ def _dump_macho(
     # Build exported symbol set from Mach-O export table
     exported_dynamic: set[str] = {
         exp.name for exp in macho_meta.exports
-        if _is_macho_abi_relevant_symbol(exp.name)
+        if exp.name and _is_abi_relevant_symbol(exp.name)
     }
 
     profile_hint: str | None = None
@@ -1030,7 +1025,7 @@ def _dump_macho(
         # using section classification from Mach-O nlist entries.
         _relevant = [
             exp for exp in macho_meta.exports
-            if _is_macho_abi_relevant_symbol(exp.name)
+            if exp.name and _is_abi_relevant_symbol(exp.name)
         ]
         macho_funcs = [exp for exp in _relevant if not exp.is_data]
         macho_vars = [exp for exp in _relevant if exp.is_data]

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -42,6 +42,10 @@ _GCC_INTERNAL_PREFIXES = (
     "__libm_avx_",
 )
 
+# ELF lifecycle entry/exit stubs are emitted by toolchains/linkers rather than
+# by the library's public ABI contract. Treat exact names only as non-ABI.
+_ELF_LIFECYCLE_STUBS = frozenset({"_init", "_fini"})
+
 # Prefixes that identify transitive C++ standard-library symbols which may
 # appear in .dynsym via weak linkage (libstdc++ / libc++).
 _STDLIB_PREFIXES = (
@@ -88,6 +92,9 @@ def is_abi_relevant_elf_symbol(name: str) -> bool:
     false ``FUNC_REMOVED`` and type-reachability findings.
     """
     if not name:
+        return False
+
+    if name in _ELF_LIFECYCLE_STUBS:
         return False
 
     for prefix in _GCC_INTERNAL_PREFIXES:

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -42,9 +42,16 @@ _GCC_INTERNAL_PREFIXES = (
     "__libm_avx_",
 )
 
-# ELF lifecycle entry/exit stubs are emitted by toolchains/linkers rather than
-# by the library's public ABI contract. Treat exact names only as non-ABI.
-_ELF_LIFECYCLE_STUBS = frozenset({"_init", "_fini"})
+# ELF lifecycle entry/exit stubs and linker-defined section boundary symbols are
+# emitted by toolchains/linkers rather than by the library's public ABI contract.
+# Treat exact names only as non-ABI.
+_ELF_LINKER_ARTIFACTS = frozenset({
+    "_init",
+    "_fini",
+    "__bss_start",
+    "_edata",
+    "_end",
+})
 
 # Prefixes that identify transitive C++ standard-library symbols which may
 # appear in .dynsym via weak linkage (libstdc++ / libc++).
@@ -94,7 +101,7 @@ def is_abi_relevant_elf_symbol(name: str) -> bool:
     if not name:
         return False
 
-    if name in _ELF_LIFECYCLE_STUBS:
+    if name in _ELF_LINKER_ARTIFACTS:
         return False
 
     for prefix in _GCC_INTERNAL_PREFIXES:

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -20,6 +20,7 @@ from abicheck.binary_fingerprint import (
 from abicheck.checker import ChangeKind, compare
 from abicheck.diff_symbols import (
     _ctor_dtor_variant,
+    _fingerprints_from_elf,
     _param_signature_of,
     _plausible_rename,
     _return_type_of,
@@ -668,6 +669,24 @@ class TestPlausibleRename:
 
 class TestFingerprintRenameDetector:
     """Test the fingerprint_renames detector via the full compare() pipeline."""
+
+    def test_fingerprints_from_elf_handles_missing_metadata(self) -> None:
+        snap = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            elf=None,
+            elf_only_mode=True,
+        )
+
+        assert _fingerprints_from_elf(snap) == {}
+
+    def test_fingerprints_from_elf_skips_non_function_symbols(self) -> None:
+        snap = _snap_elf_only("1.0", [
+            ElfSymbol(name="global_table", sym_type=SymbolType.OBJECT, size=_NORMAL_SIZE),
+            _func_sym("public_func", _NORMAL_SIZE),
+        ])
+
+        assert set(_fingerprints_from_elf(snap)) == {"public_func"}
 
     def test_likely_renamed_detected_in_elf_only_mode(self) -> None:
         """Renamed function with same size is detected as FUNC_LIKELY_RENAMED."""

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -790,6 +790,33 @@ class TestFingerprintRenameDetector:
         kinds = {c.kind for c in result.changes}
         assert ChangeKind.FUNC_ADDED in kinds
 
+    def test_retained_export_not_used_as_rename_target(self) -> None:
+        """An unchanged exported function cannot be consumed as a rename target."""
+        old = _snap_elf_only("1.0", [
+            _func_sym("foo_v1", 128),
+            _func_sym("foo_v2", 128),
+        ])
+        new = _snap_elf_only("2.0", [
+            _func_sym("foo_v1", 128),
+        ])
+        result = compare(old, new)
+
+        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        assert rename_changes == []
+
+    def test_elf_linker_artifact_not_reported_as_rename(self) -> None:
+        """Filtered linker artifacts must not participate in fingerprint renames."""
+        old = _snap_elf_only("1.0", [
+            _func_sym("_init", 128),
+        ])
+        new = _snap_elf_only("2.0", [
+            _func_sym("lib_init", 128),
+        ])
+        result = compare(old, new)
+
+        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        assert rename_changes == []
+
     def test_unrelated_names_same_size_not_renamed(self) -> None:
         """Two unrelated functions that merely share a byte size must NOT be
         reported as a rename when no code hash is available.

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -768,6 +768,28 @@ class TestFingerprintRenameDetector:
         assert rename_changes[0].old_value == "old_only"
         assert rename_changes[0].new_value == "new_only"
 
+    def test_retained_wrapper_not_reported_as_rename(self) -> None:
+        """A retained ABI symbol that shrinks to a wrapper is not a rename.
+
+        Real libssh2 1.11.0 -> 1.11.1 keeps libssh2_session_callback_set as a
+        tiny compatibility wrapper and adds libssh2_session_callback_set2 with
+        the old implementation size. The old symbol must not be reported as a
+        loader-breaking rename because existing binaries can still resolve it.
+        """
+        old = _snap_elf_only("1.0", [
+            _func_sym("libssh2_session_callback_set", 185),
+        ])
+        new = _snap_elf_only("2.0", [
+            _func_sym("libssh2_session_callback_set", _TINY_SIZE),
+            _func_sym("libssh2_session_callback_set2", 185),
+        ])
+        result = compare(old, new)
+
+        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        assert rename_changes == []
+        kinds = {c.kind for c in result.changes}
+        assert ChangeKind.FUNC_ADDED in kinds
+
     def test_unrelated_names_same_size_not_renamed(self) -> None:
         """Two unrelated functions that merely share a byte size must NOT be
         reported as a rename when no code hash is available.

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from abicheck.diff_symbols import _public_functions
+from abicheck.diff_symbols import _public_functions, _public_variables
 from abicheck.dumper import _is_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
@@ -18,7 +18,7 @@ from abicheck.elf_symbol_filter import (
     VARIABLE_SYMBOL_TYPES,
     exported_symbol_names,
 )
-from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.model import AbiSnapshot, Function, Variable, Visibility
 
 # ---------------------------------------------------------------------------
 # Bug 1: GCC / compiler-internal symbols — must be filtered
@@ -355,3 +355,27 @@ def test_public_functions_uses_abi_relevant_export_filter() -> None:
     )
 
     assert set(_public_functions(snap)) == {"lib_init"}
+
+
+def _variable(name: str) -> Variable:
+    return Variable(
+        name=name,
+        mangled=name,
+        type="int",
+        visibility=Visibility.ELF_ONLY,
+    )
+
+
+def test_public_variables_filters_elf_only_linker_artifacts() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        variables=[
+            _variable("__bss_start"),
+            _variable("_edata"),
+            _variable("_end"),
+            _variable("public_table"),
+        ],
+    )
+
+    assert set(_public_variables(snap)) == {"public_table"}

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import pytest
 
-from abicheck.dumper import _is_abi_relevant_symbol
+from abicheck.diff_symbols import _public_functions
+from abicheck.dumper import _is_abi_relevant_symbol, _is_macho_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
 from abicheck.elf_symbol_filter import (
@@ -17,6 +18,7 @@ from abicheck.elf_symbol_filter import (
     VARIABLE_SYMBOL_TYPES,
     exported_symbol_names,
 )
+from abicheck.model import AbiSnapshot, Function, Visibility
 
 # ---------------------------------------------------------------------------
 # Bug 1: GCC / compiler-internal symbols — must be filtered
@@ -123,6 +125,15 @@ def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
     assert _is_abi_relevant_symbol(name) is False, (
         f"ELF lifecycle stub {name!r} should be filtered out"
     )
+
+
+@pytest.mark.parametrize("name", [
+    # Mach-O C exports keep a leading underscore before abicheck normalizes them.
+    "_init",
+    "_fini",
+])
+def test_macho_init_style_exports_are_not_elf_filtered(name: str) -> None:
+    assert _is_macho_abi_relevant_symbol(name) is True
 
 
 @pytest.mark.parametrize("name", [
@@ -278,3 +289,60 @@ def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> N
         "_ZN6MyLib4CoreC1Ev",
         "lib_init",
     }
+
+
+def _function(name: str) -> Function:
+    return Function(
+        name=name,
+        mangled=name,
+        return_type="void",
+        visibility=Visibility.PUBLIC,
+    )
+
+
+def test_public_functions_falls_back_without_elf_metadata() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        functions=[_function("_init"), _function("lib_init")],
+        elf=None,
+    )
+
+    assert set(_public_functions(snap)) == {"_init", "lib_init"}
+
+
+def test_public_functions_keeps_empty_filtered_elf_exports_empty() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        functions=[_function("_init"), _function("_fini")],
+        elf=ElfMetadata(
+            symbols=[
+                ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="_fini", sym_type=SymbolType.FUNC),
+            ]
+        ),
+    )
+
+    assert _public_functions(snap) == {}
+
+
+def test_public_functions_uses_abi_relevant_export_filter() -> None:
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1",
+        functions=[
+            _function("_init"),
+            _function("_ZNSt6vectorIiSaIiEE4sizeEv"),
+            _function("lib_init"),
+        ],
+        elf=ElfMetadata(
+            symbols=[
+                ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="lib_init", sym_type=SymbolType.FUNC),
+            ]
+        ),
+    )
+
+    assert set(_public_functions(snap)) == {"lib_init"}

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from abicheck.diff_symbols import _public_functions
-from abicheck.dumper import _is_abi_relevant_symbol, _is_macho_abi_relevant_symbol
+from abicheck.dumper import _is_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
 from abicheck.elf_symbol_filter import (
@@ -125,15 +125,6 @@ def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
     assert _is_abi_relevant_symbol(name) is False, (
         f"ELF lifecycle stub {name!r} should be filtered out"
     )
-
-
-@pytest.mark.parametrize("name", [
-    # Mach-O C exports keep a leading underscore before abicheck normalizes them.
-    "_init",
-    "_fini",
-])
-def test_macho_init_style_exports_are_not_elf_filtered(name: str) -> None:
-    assert _is_macho_abi_relevant_symbol(name) is True
 
 
 @pytest.mark.parametrize("name", [

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -115,6 +115,17 @@ def test_stdlib_transitive_symbols_are_filtered(name: str) -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("name", [
+    # ELF lifecycle stubs emitted by the linker/toolchain, not library API.
+    "_init",
+    "_fini",
+])
+def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
+    assert _is_abi_relevant_symbol(name) is False, (
+        f"ELF lifecycle stub {name!r} should be filtered out"
+    )
+
+
+@pytest.mark.parametrize("name", [
     # mpfr public API
     "mpfr_add",
     "mpfr_mul",
@@ -129,10 +140,7 @@ def test_stdlib_transitive_symbols_are_filtered(name: str) -> None:
     "_ZNK6MyLib4Core4nameEv",
     "_ZTIN3foo3BarE",   # typeinfo for foo::Bar
     "_ZTSN3foo3BarE",   # typeinfo name for foo::Bar
-    # Regular single-underscore prefixed symbols (not double)
-    "_init",
-    "_fini",
-    # Symbol with single underscore separator — not private
+    # Public initialization-style APIs must not be confused with lifecycle stubs.
     "my_function",
     "lib_init",
     # Empty-ish edge cases that are valid names
@@ -249,17 +257,24 @@ def test_exported_symbol_names_notype_counts_for_both_surfaces() -> None:
 
 
 def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> None:
-    """abi_relevant_only excludes transitive stdlib exports but keeps own symbols."""
+    """abi_relevant_only excludes transitive/toolchain exports but keeps own symbols."""
     meta = ElfMetadata(
         symbols=[
             ElfSymbol(name="_ZN6MyLib4CoreC1Ev", sym_type=SymbolType.FUNC),
             ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_fini", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="lib_init", sym_type=SymbolType.FUNC),
         ]
     )
     assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES) == {
         "_ZN6MyLib4CoreC1Ev",
         "_ZNSt6vectorIiSaIiEE4sizeEv",
+        "_init",
+        "_fini",
+        "lib_init",
     }
     assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES, abi_relevant_only=True) == {
         "_ZN6MyLib4CoreC1Ev",
+        "lib_init",
     }

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -128,6 +128,18 @@ def test_elf_lifecycle_stubs_are_filtered(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", [
+    # Linker-defined section boundary symbols, not callable library APIs.
+    "__bss_start",
+    "_edata",
+    "_end",
+])
+def test_elf_linker_boundary_symbols_are_filtered(name: str) -> None:
+    assert _is_abi_relevant_symbol(name) is False, (
+        f"ELF linker boundary symbol {name!r} should be filtered out"
+    )
+
+
+@pytest.mark.parametrize("name", [
     # mpfr public API
     "mpfr_add",
     "mpfr_mul",
@@ -266,6 +278,9 @@ def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> N
             ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
             ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
             ElfSymbol(name="_fini", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="__bss_start", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="_edata", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="_end", sym_type=SymbolType.NOTYPE),
             ElfSymbol(name="lib_init", sym_type=SymbolType.FUNC),
         ]
     )
@@ -274,6 +289,9 @@ def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> N
         "_ZNSt6vectorIiSaIiEE4sizeEv",
         "_init",
         "_fini",
+        "__bss_start",
+        "_edata",
+        "_end",
         "lib_init",
     }
     assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES, abi_relevant_only=True) == {

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -379,6 +379,17 @@ def test_visibility_leak_not_fired_for_clean_public_symbols() -> None:
     assert ChangeKind.VISIBILITY_LEAK not in kinds
 
 
+def test_visibility_leak_ignores_linker_artifact_symbols() -> None:
+    """Linker boundary symbols should not be counted as visibility leaks."""
+    old = _elf_only_snap(["public_api", "__bss_start", "_edata", "_end"])
+    new = _elf_only_snap(["public_api"])
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.VISIBILITY_LEAK not in kinds
+    assert ChangeKind.FUNC_REMOVED_ELF_ONLY not in kinds
+    assert result.verdict == Verdict.NO_CHANGE
+
+
 def test_symbol_version_required_added_older_is_compat() -> None:
     """Adding an OLDER version requirement (e.g. GLIBC_2.2.5 when max was GLIBC_2.34)
     is NOT breaking — callers already satisfied the higher requirement.


### PR DESCRIPTION
## Summary
- avoid ELF-only fingerprint rename candidates when the old function name is still exported by the new library
- filter exact ELF linker artifacts (`_init`, `_fini`, `__bss_start`, `_edata`, `_end`) from ELF-only public symbol surfaces
- apply the shared ABI-relevance filter to snapshot-only ELF function/variable maps and visibility-leak reporting
- add regressions for retained compatibility wrappers and linker boundary artifacts
- guard optional ELF metadata in the rename export lookup so type checks stay clean

## Real-world evidence
- libssh2 1.11.0 -> 1.11.1 kept `libssh2_session_callback_set` exported as a 6-byte wrapper and added `libssh2_session_callback_set2`; before the fix abicheck reported a false `func_likely_renamed`, and after the fix it reports `set2` as additive
- libev 4.25 -> 4.33 dropped linker boundary symbols `__bss_start`, `_edata`, and `_end`; before the fix abicheck reported `BREAKING`, while `abidiff` reported no ABI change; after the fix the real libev rerun reports `COMPATIBLE`

## Tests
- `ruff check abicheck tests`
- `mypy abicheck`
- `python scripts/check_ai_readiness.py` (0 errors, existing warnings only)
- `pytest -q tests/test_binary_fingerprint.py`
- `pytest -q tests/test_elf_symbol_filters.py tests/test_sprint2_elf.py tests/test_binary_fingerprint.py`
