### PR TITLE
Suppress DWARF-only compiler typedef and parameter-name false positives

### DIFF
--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -871,7 +871,13 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect parameter renames (same type+position, different name)."""
     changes: list[Change] = []
+    # Require *explicit* header provenance on both sides. A legacy snapshot
+    # predating the from_headers key has it inferred from a populated surface,
+    # which a DWARF-only dump also satisfies — trusting that inference here
+    # reintroduces PARAM_RENAMED/API_BREAK false positives on DWARF baselines.
     if not (old.from_headers and new.from_headers):
+        return changes
+    if old.from_headers_inferred or new.from_headers_inferred:
         return changes
     old_map = _public_functions(old)
     new_map = _public_functions(new)

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -548,6 +548,15 @@ class AbiSnapshot:
     # Used by binary-only fallback detectors that need lightweight disassembly.
     source_path: str | None = field(default=None, kw_only=True)
 
+    # Runtime-only provenance qualifier (not serialized — popped in
+    # snapshot_to_dict). True when ``from_headers`` was *inferred* for a legacy
+    # snapshot that predates the explicit ``from_headers`` key, rather than set
+    # explicitly by the dumper or loaded verbatim. Source-level detectors that
+    # must only fire on genuine header evidence (e.g. parameter renames) require
+    # ``from_headers and not from_headers_inferred`` so ambiguous legacy
+    # DWARF-only baselines do not produce false API breaks.
+    from_headers_inferred: bool = field(default=False, repr=False, compare=False)
+
     # Indexes (built lazily)
     _func_by_mangled: dict[str, Function] | None = field(default=None, repr=False, compare=False)
     _var_by_mangled: dict[str, Variable] | None = field(default=None, repr=False, compare=False)

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -75,10 +75,16 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     d.pop("_func_by_mangled", None)
     d.pop("_var_by_mangled", None)
     d.pop("_type_by_name", None)
-    # Runtime-only provenance qualifier — never persisted. ``from_headers`` is
-    # written verbatim, so a reloaded snapshot carries explicit (non-inferred)
-    # provenance.
+    # Runtime-only provenance qualifier — never persisted.
     d.pop("from_headers_inferred", None)
+    # If ``from_headers`` was only *inferred* (a legacy snapshot loaded without
+    # the explicit key), do not persist it as explicit provenance: drop the key
+    # so a reload re-runs the same inference and re-marks it inferred. Writing
+    # ``from_headers: true`` here would promote a guess to explicit header
+    # provenance on the next load, re-enabling source-level param-rename
+    # detection on DWARF-only baselines this is meant to suppress.
+    if snap.from_headers_inferred:
+        d.pop("from_headers", None)
 
     # Serialize ElfMetadata enums to strings for JSON compatibility
     if d.get("elf"):

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -75,6 +75,10 @@ def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
     d.pop("_func_by_mangled", None)
     d.pop("_var_by_mangled", None)
     d.pop("_type_by_name", None)
+    # Runtime-only provenance qualifier — never persisted. ``from_headers`` is
+    # written verbatim, so a reloaded snapshot carries explicit (non-inferred)
+    # provenance.
+    d.pop("from_headers_inferred", None)
 
     # Serialize ElfMetadata enums to strings for JSON compatibility
     if d.get("elf"):
@@ -479,10 +483,16 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     elf_only_mode = bool(d.get("elf_only_mode", False))
     if "from_headers" in d:
         from_headers = bool(d["from_headers"])
+        from_headers_inferred = False
     else:
         from_headers = (not elf_only_mode) and bool(
             funcs or variables or types or enums or typedefs
         )
+        # This provenance was guessed, not recorded. A legacy DWARF-only dump
+        # populates the same surface lists, so the inference cannot tell it
+        # apart from a header dump. Mark it inferred so source-level detectors
+        # that demand genuine header evidence (parameter renames) stay quiet.
+        from_headers_inferred = from_headers
 
     return AbiSnapshot(
         library=d["library"], version=d["version"],
@@ -493,6 +503,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         dwarf=dwarf, dwarf_advanced=dwarf_advanced, sycl=sycl,
         elf_only_mode=elf_only_mode,
         from_headers=from_headers,
+        from_headers_inferred=from_headers_inferred,
         constants=d.get("constants", {}),
         platform=d.get("platform"),
         language_profile=d.get("language_profile"),

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -131,6 +131,44 @@ class TestDeletedFromDwarfRoundTrip:
         assert snapshot_from_dict(d).functions[0].deleted_from_dwarf is False
 
 
+# ── inferred from_headers provenance ──────────────────────────────────────
+
+
+class TestInferredFromHeadersProvenance:
+    """Inferred legacy provenance must not become explicit across a re-save.
+
+    A legacy snapshot (no ``from_headers`` key) infers ``from_headers=True`` but
+    marks ``from_headers_inferred=True``. Re-serializing must NOT emit
+    ``from_headers: true`` as explicit provenance, or reloading the migrated
+    baseline would re-enable source-level param-rename detection on DWARF-only
+    surfaces.
+    """
+
+    def _legacy_dict(self) -> dict:
+        return _minimal_dict(
+            functions=[{"name": "f", "mangled": "_Z1fi", "return_type": "void"}],
+        )
+
+    def test_inferred_provenance_not_persisted_as_explicit(self) -> None:
+        loaded = snapshot_from_dict(self._legacy_dict())
+        assert loaded.from_headers is True
+        assert loaded.from_headers_inferred is True
+        # The re-emitted dict must not carry an explicit from_headers key.
+        reemitted = json.loads(snapshot_to_json(loaded))
+        assert "from_headers" not in reemitted
+        # Reloading the migrated baseline stays inferred, not explicit.
+        reloaded = snapshot_from_dict(reemitted)
+        assert reloaded.from_headers is True
+        assert reloaded.from_headers_inferred is True
+
+    def test_explicit_provenance_is_persisted(self) -> None:
+        snap = _make_snap(from_headers=True)
+        assert snap.from_headers_inferred is False
+        reemitted = json.loads(snapshot_to_json(snap))
+        assert reemitted.get("from_headers") is True
+        assert snapshot_from_dict(reemitted).from_headers_inferred is False
+
+
 # ── file-based round-trip ─────────────────────────────────────────────────
 
 

--- a/tests/test_sprint7_full_parity.py
+++ b/tests/test_sprint7_full_parity.py
@@ -549,6 +549,40 @@ class TestParamRenamed:
         assert ChangeKind.PARAM_RENAMED not in _kinds(result)
         assert result.verdict == Verdict.NO_CHANGE
 
+    def test_legacy_snapshot_inferred_headers_param_rename_not_source_break(self) -> None:
+        """Legacy snapshots predating the from_headers key infer header
+        provenance from a populated surface — but a DWARF-only dump satisfies
+        that same inference, so param renames must stay suppressed.
+
+        Reproduces the load path: a snapshot dict with no ``from_headers`` key
+        and DWARF-derived functions deserializes to from_headers=True (for
+        evidence-tier continuity) but from_headers_inferred=True, which must
+        keep PARAM_RENAMED quiet.
+        """
+        from abicheck.serialization import snapshot_from_dict
+
+        def _legacy_dict(param_name: str) -> dict:
+            return {
+                "library": "lib.so",
+                "version": "1.0",
+                "functions": [
+                    {
+                        "name": "f",
+                        "mangled": "_Z1fi",
+                        "return_type": "void",
+                        "params": [{"name": param_name, "type": "int"}],
+                    }
+                ],
+                "dwarf": {"has_dwarf": True},
+            }
+
+        old = snapshot_from_dict(_legacy_dict("arg_size"))
+        new = snapshot_from_dict(_legacy_dict("size"))
+        assert old.from_headers is True and old.from_headers_inferred is True
+        result = compare(old, new)
+        assert ChangeKind.PARAM_RENAMED not in _kinds(result)
+        assert result.verdict == Verdict.NO_CHANGE
+
     def test_no_rename_when_unchanged(self) -> None:
         old = _snap(functions=[_func("f", "_Z1fi", params=[Param("x", "int")])])
         new = _snap(functions=[_func("f", "_Z1fi", params=[Param("x", "int")])])


### PR DESCRIPTION
## Summary
- filter compiler-internal typedef aliases such as `typedef __va_list_tag __va_list_tag` from ABI type-surface diffing
- require both snapshots to be header-derived before reporting parameter renames as source API breaks
- add regressions for header-backed parameter renames, DWARF-only parameter-name noise, and the real compiler typedef spelling

## Real-world validation
Found during the 2026-06-04 17:45 PDT real-world cron batch against conda-forge `libjemalloc` 5.2.1 -> 5.3.0.

Before the fix:
- initial verdict: `BREAKING` from `type_removed: typedef __va_list_tag __va_list_tag`
- after typedef filtering only: `API_BREAK` from DWARF-only `realloc` parameter rename `arg_size -> size`
- dynamic export diff: zero removed exports
- `abidiff`: additions only, no removed or changed functions/variables

After the fix:
- rerun artifact: `reports/abicheck-realworld-cron/artifacts/20260604-1745/rerun-jemalloc-pr-branch.json`
- verdict: `COMPATIBLE_WITH_RISK`
- summary: `breaking=0`, `source_breaks=0`

## Tests
- `pytest -q tests/test_sprint7_full_parity.py::TestParamRenamed tests/test_diff_symbols_deep.py::TestParamRenamed tests/test_real_world_false_positives.py tests/test_builtins_filtered.py` -> 68 passed
- real-world rerun: `abicheck compare ...libjemalloc.so.2 ...libjemalloc.so.2 --old-version 5.2.1 --new-version 5.3.0 --format json -o .../rerun-jemalloc-pr-branch.json --recommend` -> `COMPATIBLE_WITH_RISK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parameter rename changes are now only reported when both old and new ABI snapshots originate from headers, reducing false positives
  * DWARF-only parameter renames are no longer incorrectly classified as breaking changes

* **Improvements**
  * Enhanced compiler-internal type detection to recognize typedef aliases and handle whitespace variations more robustly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->