### PR TITLE
Filter generated ELF and DWARF-only symbols from ABI surface

### DIFF
--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -362,6 +362,12 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             is_volatile=f.get("is_volatile", False),
             is_pure_virtual=f.get("is_pure_virtual", False),
             is_deleted=f.get("is_deleted", False),
+            # Provenance of is_deleted: True when set via DW_AT_deleted. Must be
+            # rehydrated (asdict writes it) so the public-map bypass in
+            # diff_symbols keeps DWARF-deleted unexported members out of the
+            # public surface after a dump-to-file → compare-files round-trip,
+            # rather than re-emitting FUNC_REMOVED against a stripped build.
+            deleted_from_dwarf=f.get("deleted_from_dwarf", False),
             is_inline=f.get("is_inline", False),
             is_extern_c=f.get("is_extern_c", False),
             access=AccessLevel(f.get("access", "public")),

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 
-from abicheck.model import AbiSnapshot
+from abicheck.model import AbiSnapshot, Function
 from abicheck.serialization import (
     load_snapshot,
     save_snapshot,
@@ -89,6 +89,46 @@ class TestConstantsRoundTrip:
     def test_defaults_to_empty_dict_when_absent(self) -> None:
         """Old snapshots without constants must deserialise to an empty dict."""
         assert snapshot_from_dict(_minimal_dict()).constants == {}
+
+
+# ── Function.deleted_from_dwarf ───────────────────────────────────────────
+
+
+class TestDeletedFromDwarfRoundTrip:
+    """Function.deleted_from_dwarf provenance must survive JSON round-trip.
+
+    snapshot_to_dict writes it (via asdict), but snapshot_from_dict rebuilds
+    Function manually — if it drops the key, a DWARF-deleted unexported member
+    loads as deleted_from_dwarf=False, re-entering the public surface and
+    producing FUNC_REMOVED false positives against a stripped build.
+    """
+
+    def _func(self, **kw: object) -> Function:
+        return Function(
+            name="atomic_backoff",
+            mangled="_ZN3tbb14atomic_backoffC4ERKS_",
+            return_type="void",
+            **kw,  # type: ignore[arg-type]
+        )
+
+    def test_true_survives_roundtrip(self) -> None:
+        snap = _make_snap(functions=[self._func(is_deleted=True, deleted_from_dwarf=True)])
+        j = json.loads(snapshot_to_json(snap))
+        assert j["functions"][0]["deleted_from_dwarf"] is True
+        restored = snapshot_from_dict(j)
+        assert restored.functions[0].deleted_from_dwarf is True
+        assert restored.functions[0].is_deleted is True
+
+    def test_false_survives_roundtrip(self) -> None:
+        snap = _make_snap(functions=[self._func(is_deleted=True, deleted_from_dwarf=False)])
+        restored = snapshot_from_dict(json.loads(snapshot_to_json(snap)))
+        assert restored.functions[0].deleted_from_dwarf is False
+
+    def test_defaults_to_false_when_absent(self) -> None:
+        """Legacy snapshots without the key deserialise to False."""
+        d = _minimal_dict(functions=[{"name": "f", "mangled": "f", "return_type": "void"}])
+        assert "deleted_from_dwarf" not in d["functions"][0]
+        assert snapshot_from_dict(d).functions[0].deleted_from_dwarf is False
 
 
 # ── file-based round-trip ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- filter linker-defined ELF boundary markers (`__bss_start`, `_edata`, `_end`) out of symbol-only public ABI comparisons
- keep unexported DWARF `DW_AT_deleted` special members out of public function diffs so stripped follow-up builds do not report phantom removals
- add focused regression coverage for ELF symbol filtering and mixed DWARF/stripped deleted-function comparisons

## Real-world validation
- `libev` 4.25 -> 4.33 changes from false `BREAKING` to `COMPATIBLE` after filtering linker boundary symbols
- oneTBB 2021.9.0 -> 2022.0.0: `libtbbbind_2_5`, `libtbbmalloc`, and `libtbbmalloc_proxy` no longer report false removed deleted-copy/assignment functions when old has DWARF and new is stripped

## Tests
- `pytest -q tests/test_elf_symbol_filters.py`
- `pytest -q tests/test_stripped_degradation.py tests/test_elf_symbol_filters.py`
