### PR TITLE
Ignore unattached private version marker removals

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -576,10 +576,15 @@ def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
 
 
 def _is_unattached_private_version_node(elf: Any, version: str) -> bool:
-    """Return True for private version-script marker nodes with no exports."""
-    if "PRIVATE" not in version.upper():
-        return False
-    return not any(getattr(sym, "version", "") == version for sym in getattr(elf, "symbols", []))
+    """Return True for private version-script marker nodes with no exports.
+
+    Thin wrapper around the canonical helper in :mod:`diff_versioning` so the
+    version-def removal path and the version-script-missing path agree on what
+    counts as an unattached private marker.
+    """
+    from .diff_versioning import _is_unattached_private_version_node as _impl
+
+    return _impl(elf, version)
 
 
 def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any) -> list[Change]:

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -507,6 +507,8 @@ def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
     old_def = set(old_elf.versions_defined)
     new_def = set(new_elf.versions_defined)
     for ver in sorted(old_def - new_def):
+        if _is_unattached_private_version_node(old_elf, ver):
+            continue
         changes.append(Change(
             kind=ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED,
             symbol=ver,
@@ -571,6 +573,13 @@ def _diff_elf_symbol_versioning(old_elf: Any, new_elf: Any) -> list[Change]:
                 old_value=f"{lib}:{ver}",
             ))
     return changes
+
+
+def _is_unattached_private_version_node(elf: Any, version: str) -> bool:
+    """Return True for private version-script marker nodes with no exports."""
+    if "PRIVATE" not in version.upper():
+        return False
+    return not any(getattr(sym, "version", "") == version for sym in getattr(elf, "symbols", []))
 
 
 def _diff_elf_symbol_metadata(old_elf: Any, new_elf: Any) -> list[Change]:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -626,6 +626,7 @@ def _match_old_function(
 def _detect_newly_deleted_functions(
     old_all: dict[str, Function],
     new_all: dict[str, Function],
+    old_snapshot: AbiSnapshot,
     new_snapshot: AbiSnapshot,
 ) -> list[Change]:
     """Detect functions that gained ``= delete`` between snapshots.
@@ -640,6 +641,9 @@ def _detect_newly_deleted_functions(
     changes: list[Change] = []
     new_elf = getattr(new_snapshot, "elf", None)
     exported = exported_symbol_names(new_elf, FUNCTION_SYMBOL_TYPES)
+    old_exported = exported_symbol_names(
+        getattr(old_snapshot, "elf", None), FUNCTION_SYMBOL_TYPES
+    )
     # Whether the new side has an ELF symbol table at all. This tells "no ELF
     # evidence available" apart from "ELF table present but this function is not
     # exported": when a table exists, an empty *function* export set (e.g. the
@@ -651,7 +655,18 @@ def _detect_newly_deleted_functions(
     for mangled, f_new in new_all.items():
         if not f_new.is_deleted:
             continue
-        if f_new.deleted_from_dwarf and has_elf_symbol_table and mangled not in exported:
+        # Suppress only a *genuinely internal* DWARF-deleted member: one that the
+        # new ELF table proves is not exported AND that was not exported in the
+        # old library either. A function that *was* an old export and is now
+        # ``= delete``'d + dropped from .dynsym is a real deletion of a public
+        # API and must still be reported (the removal-side path defers to this
+        # detector for it, so suppressing here would drop the finding entirely).
+        if (
+            f_new.deleted_from_dwarf
+            and has_elf_symbol_table
+            and mangled not in exported
+            and mangled not in old_exported
+        ):
             continue
         # Skip functions that are not part of the public ABI surface.
         if f_new.visibility not in _PUBLIC_VIS:
@@ -718,7 +733,7 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
     old_all = old.function_map
     new_all_map = new.function_map
-    changes.extend(_detect_newly_deleted_functions(old_all, new_all_map, new))
+    changes.extend(_detect_newly_deleted_functions(old_all, new_all_map, old, new))
 
     # FUNC_BECAME_INLINE / FUNC_LOST_INLINE: detect inline↔non-inline transitions
     changes.extend(_check_inline_transitions(old_map, new_map, new))

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -843,6 +843,8 @@ def _diff_param_defaults(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_param_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect parameter renames (same type+position, different name)."""
     changes: list[Change] = []
+    if not (old.from_headers and new.from_headers):
+        return changes
     old_map = _public_functions(old)
     new_map = _public_functions(new)
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -638,11 +638,20 @@ def _detect_newly_deleted_functions(
     produce spurious BREAKING findings.
     """
     changes: list[Change] = []
-    exported = exported_symbol_names(getattr(new_snapshot, "elf", None), FUNCTION_SYMBOL_TYPES)
+    new_elf = getattr(new_snapshot, "elf", None)
+    exported = exported_symbol_names(new_elf, FUNCTION_SYMBOL_TYPES)
+    # Whether the new side has an ELF symbol table at all. This tells "no ELF
+    # evidence available" apart from "ELF table present but this function is not
+    # exported": when a table exists, an empty *function* export set (e.g. the
+    # library exports only data, or every function is hidden) is authoritative —
+    # a DWARF-only DW_AT_deleted internal member is genuinely not exported and
+    # must not be reported. Keying on ``exported`` truthiness instead would only
+    # apply the filter when some *other* function happened to be exported.
+    has_elf_symbol_table = bool(getattr(new_elf, "symbols", None))
     for mangled, f_new in new_all.items():
         if not f_new.is_deleted:
             continue
-        if f_new.deleted_from_dwarf and exported and mangled not in exported:
+        if f_new.deleted_from_dwarf and has_elf_symbol_table and mangled not in exported:
             continue
         # Skip functions that are not part of the public ABI surface.
         if f_new.visibility not in _PUBLIC_VIS:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -626,6 +626,7 @@ def _match_old_function(
 def _detect_newly_deleted_functions(
     old_all: dict[str, Function],
     new_all: dict[str, Function],
+    new_snapshot: AbiSnapshot,
 ) -> list[Change]:
     """Detect functions that gained ``= delete`` between snapshots.
 
@@ -637,8 +638,11 @@ def _detect_newly_deleted_functions(
     produce spurious BREAKING findings.
     """
     changes: list[Change] = []
+    exported = exported_symbol_names(getattr(new_snapshot, "elf", None), FUNCTION_SYMBOL_TYPES)
     for mangled, f_new in new_all.items():
         if not f_new.is_deleted:
+            continue
+        if f_new.deleted_from_dwarf and exported and mangled not in exported:
             continue
         # Skip functions that are not part of the public ABI surface.
         if f_new.visibility not in _PUBLIC_VIS:
@@ -705,7 +709,7 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 
     old_all = old.function_map
     new_all_map = new.function_map
-    changes.extend(_detect_newly_deleted_functions(old_all, new_all_map))
+    changes.extend(_detect_newly_deleted_functions(old_all, new_all_map, new))
 
     # FUNC_BECAME_INLINE / FUNC_LOST_INLINE: detect inline↔non-inline transitions
     changes.extend(_check_inline_transitions(old_map, new_map, new))

--- a/abicheck/diff_versioning.py
+++ b/abicheck/diff_versioning.py
@@ -24,6 +24,19 @@ from .checker_types import Change
 from .elf_metadata import ElfMetadata
 
 
+def _is_unattached_private_version_node(elf: ElfMetadata, version: str) -> bool:
+    """Return True for private version-script marker nodes with no exports.
+
+    A version definition whose name contains ``PRIVATE`` and which no exported
+    symbol is bound to is a linker bookkeeping marker, not a real ABI version
+    node. Such markers are ignored as removals and must not count toward
+    "the old library had a version script".
+    """
+    if "PRIVATE" not in version.upper():
+        return False
+    return not any(getattr(sym, "version", "") == version for sym in getattr(elf, "symbols", []))
+
+
 def detect_version_node_changes(
     old_elf: ElfMetadata, new_elf: ElfMetadata,
 ) -> list[Change]:
@@ -105,7 +118,17 @@ def detect_version_script_missing(
     # If the old library also lacks a version script, this is a pre-existing
     # condition — not a new change.  Only warn when a version script was
     # dropped or when comparing a brand-new library (old has no symbols).
-    old_had_version_script = bool(old_elf.versions_defined) or any(
+    #
+    # Unattached private version-script markers (e.g. ``FOO_PRIVATE`` with no
+    # old exported symbol bound to that node) do not constitute a real version
+    # script: they are deliberately ignored as version-node removals elsewhere,
+    # so they must not count as "old had a version script" here either —
+    # otherwise dropping a marker-only script re-introduces VERSION_SCRIPT_MISSING.
+    old_real_versions_defined = [
+        ver for ver in old_elf.versions_defined
+        if not _is_unattached_private_version_node(old_elf, ver)
+    ]
+    old_had_version_script = bool(old_real_versions_defined) or any(
         s.version for s in old_elf.symbols
     )
     if not old_had_version_script and old_elf.symbols:

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -89,7 +89,6 @@ _STDLIB_RTTI_PREFIXES = (
     "_ZTSN7__cxx11",
 )
 
-
 def is_abi_relevant_elf_symbol(name: str) -> bool:
     """Return False for ELF symbols that are not the library's own ABI.
 

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -42,10 +42,21 @@ COMPILER_INTERNAL_TYPES: frozenset[str] = frozenset({
     "__NSConstantString_tag", "__NSConstantString",
 })
 
+_TYPEDEF_ALIAS_RE = _re.compile(r"^typedef\s+(.+?)\s+([A-Za-z_][\w:]*)$")
+
 
 def is_compiler_internal_type(name: str) -> bool:
     """Return True if *name* is a compiler internal type that should be excluded."""
-    return bool(name) and name in COMPILER_INTERNAL_TYPES
+    if not name:
+        return False
+    stripped = name.strip()
+    if stripped in COMPILER_INTERNAL_TYPES:
+        return True
+    m = _TYPEDEF_ALIAS_RE.match(stripped)
+    if not m:
+        return False
+    aliased, alias = m.groups()
+    return aliased.strip() in COMPILER_INTERNAL_TYPES and alias in COMPILER_INTERNAL_TYPES
 
 
 # Standard-library / runtime namespaces whose *type layout* is owned by the
@@ -83,7 +94,7 @@ def is_non_abi_surface_type(name: str, *, exclude_stdlib_namespaces: bool = True
     """
     if not name:
         return False
-    if name in COMPILER_INTERNAL_TYPES:
+    if is_compiler_internal_type(name):
         return True
     if exclude_stdlib_namespaces and name.startswith(_STDLIB_TYPE_NAMESPACE_PREFIXES):
         return True

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -19,13 +19,14 @@ from abicheck.model import (
 
 
 def _snap(version="1.0", functions=None, variables=None, types=None,
-          enums=None, typedefs=None, elf=None, constants=None):
+          enums=None, typedefs=None, elf=None, constants=None, from_headers=False):
     return AbiSnapshot(
         library="libtest.so.1", version=version,
         functions=functions or [], variables=variables or [],
         types=types or [], enums=enums or [],
         typedefs=typedefs or {}, elf=elf,
         constants=constants or {},
+        from_headers=from_headers,
     )
 
 
@@ -370,7 +371,10 @@ class TestParamRenamed:
                           params=[Param(name="x_pos", type="int")])
         f_v2 = _pub_func("draw", "_Z4drawv",
                           params=[Param(name="horizontal", type="int")])
-        r = compare(_snap(functions=[f_v1]), _snap(functions=[f_v2]))
+        r = compare(
+            _snap(functions=[f_v1], from_headers=True),
+            _snap(functions=[f_v2], from_headers=True),
+        )
         assert ChangeKind.PARAM_RENAMED in _kinds(r)
 
 

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from abicheck.diff_symbols import _public_functions, _public_variables
-from abicheck.dumper import _is_abi_relevant_symbol
+from abicheck.dumper import _elf_classify_symbols, _is_abi_relevant_symbol
 from abicheck.dwarf_snapshot import _DwarfSnapshotBuilder
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolType
 from abicheck.elf_symbol_filter import (
@@ -109,6 +109,21 @@ def test_private_double_underscore_symbols_are_filtered(name: str) -> None:
 def test_stdlib_transitive_symbols_are_filtered(name: str) -> None:
     assert _is_abi_relevant_symbol(name) is False, (
         f"Transitive stdlib symbol {name!r} should be filtered out"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: Linker-defined ELF boundary symbols — must be filtered
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", [
+    "__bss_start",
+    "_edata",
+    "_end",
+])
+def test_linker_boundary_symbols_are_filtered(name: str) -> None:
+    assert _is_abi_relevant_symbol(name) is False, (
+        f"Linker boundary symbol {name!r} should be filtered out"
     )
 
 
@@ -411,3 +426,47 @@ def test_public_variables_filters_elf_only_linker_artifacts() -> None:
     )
 
     assert set(_public_variables(snap)) == {"public_table"}
+
+
+def test_exported_symbol_names_abi_relevant_only_drops_linker_boundaries() -> None:
+    """abi_relevant_only excludes linker boundary markers but keeps real exports."""
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="ev_run", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="__bss_start", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="_edata", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="_end", sym_type=SymbolType.NOTYPE),
+        ]
+    )
+    assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES) == {
+        "ev_run",
+        "__bss_start",
+        "_edata",
+        "_end",
+    }
+    assert exported_symbol_names(meta, FUNCTION_SYMBOL_TYPES, abi_relevant_only=True) == {
+        "ev_run",
+    }
+
+
+def test_elf_classify_symbols_drops_linker_boundaries_from_symbol_only_mode() -> None:
+    """The no-header ELF path must not re-admit linker boundary NOTYPE names."""
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="ev_run", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="__bss_start", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="_edata", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="_end", sym_type=SymbolType.NOTYPE),
+            ElfSymbol(name="ev_loop_default", sym_type=SymbolType.OBJECT),
+        ]
+    )
+
+    exported, funcs, objects, tls = _elf_classify_symbols(
+        meta,
+        {"ev_run", "__bss_start", "_edata", "_end", "ev_loop_default"},
+    )
+
+    assert exported == {"ev_run", "ev_loop_default"}
+    assert funcs == {"ev_run"}
+    assert objects == {"ev_loop_default"}
+    assert tls == set()

--- a/tests/test_libuv_private_type_churn.py
+++ b/tests/test_libuv_private_type_churn.py
@@ -43,9 +43,12 @@ def _fn(name: str, params: list[Param]) -> Function:
 
 
 def test_param_rename_is_source_level_not_binary_breaking():
-    old = AbiSnapshot(library="libuv.so.1", version="1",
+    # from_headers=True: parameter renames are only reported as source-level API
+    # breaks when both snapshots are header-derived (DWARF-only param names are
+    # unreliable build-to-build noise and are intentionally suppressed).
+    old = AbiSnapshot(library="libuv.so.1", version="1", from_headers=True,
                       functions=[_fn("uv_tcp_keepalive", [Param(name="enable", type="int")])])
-    new = AbiSnapshot(library="libuv.so.1", version="2",
+    new = AbiSnapshot(library="libuv.so.1", version="2", from_headers=True,
                       functions=[_fn("uv_tcp_keepalive", [Param(name="on", type="int")])])
     r = compare(old, new)
     assert ChangeKind.PARAM_RENAMED in {c.kind for c in r.changes}

--- a/tests/test_real_world_false_positives.py
+++ b/tests/test_real_world_false_positives.py
@@ -781,6 +781,7 @@ def test_is_non_abi_surface_type_keeps_stdlib_when_requested():
     # anonymous + compiler-internal stay excluded regardless of the flag
     assert is_non_abi_surface_type("<lambda()>", exclude_stdlib_namespaces=False) is True
     assert is_non_abi_surface_type("__va_list_tag", exclude_stdlib_namespaces=False) is True
+    assert is_non_abi_surface_type("typedef __va_list_tag __va_list_tag", exclude_stdlib_namespaces=False) is True
     # libstdc++ debug-mode namespace is toolchain-owned too
     assert is_non_abi_surface_type("__gnu_debug::_Safe_iterator<int>") is True
     assert is_non_abi_surface_type("__gnu_debug::_Safe_iterator<int>", exclude_stdlib_namespaces=False) is False

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -105,6 +105,29 @@ def test_symbol_version_defined_removed() -> None:
     assert result.verdict == Verdict.BREAKING
 
 
+def test_unattached_private_symbol_version_marker_removed_is_ignored() -> None:
+    old = _snap(_elf(versions_defined=["LIBFOO_1.0", "LIBFOO_PRIVATE"]))
+    new = _snap(_elf(versions_defined=["LIBFOO_1.0"]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED not in kinds
+    assert result.verdict == Verdict.NO_CHANGE
+
+
+def test_private_symbol_version_with_exported_symbol_removed_is_breaking() -> None:
+    old = _snap(
+        _elf(
+            versions_defined=["LIBFOO_1.0", "LIBFOO_PRIVATE"],
+            symbols=[_sym("private_api", version="LIBFOO_PRIVATE")],
+        )
+    )
+    new = _snap(_elf(versions_defined=["LIBFOO_1.0"], symbols=[]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_NODE_REMOVED in kinds
+    assert result.verdict == Verdict.BREAKING
+
+
 def test_symbol_version_defined_added_compatible() -> None:
     old = _snap(_elf(versions_defined=[]))
     new = _snap(_elf(versions_defined=["LIBFOO_1.0"]))

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -114,6 +114,29 @@ def test_unattached_private_symbol_version_marker_removed_is_ignored() -> None:
     assert result.verdict == Verdict.NO_CHANGE
 
 
+def test_marker_only_private_version_script_removed_emits_no_warning() -> None:
+    """A version script consisting solely of an unattached private marker must
+    not trigger VERSION_SCRIPT_MISSING when it is dropped.
+
+    The old side's only version definition is ``LIBFOO_PRIVATE`` with no symbol
+    bound to it; the new side keeps the exported symbols but has no version
+    script. Since the marker is not a real version script, dropping it should
+    stay NO_CHANGE rather than escalate via VERSION_SCRIPT_MISSING.
+    """
+    old = _snap(
+        _elf(
+            versions_defined=["LIBFOO_PRIVATE"],
+            symbols=[_sym("api")],
+        )
+    )
+    new = _snap(_elf(versions_defined=[], symbols=[_sym("api")]))
+    result = compare(old, new)
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.SYMBOL_VERSION_DEFINED_REMOVED not in kinds
+    assert ChangeKind.VERSION_SCRIPT_MISSING not in kinds
+    assert result.verdict == Verdict.NO_CHANGE
+
+
 def test_private_symbol_version_with_exported_symbol_removed_is_breaking() -> None:
     old = _snap(
         _elf(

--- a/tests/test_sprint7_full_parity.py
+++ b/tests/test_sprint7_full_parity.py
@@ -509,6 +509,7 @@ class TestParamRenamed:
 
     def test_param_renamed_detected(self) -> None:
         old = _snap(
+            from_headers=True,
             functions=[
                 _func(
                     "draw",
@@ -518,6 +519,7 @@ class TestParamRenamed:
             ]
         )
         new = _snap(
+            from_headers=True,
             functions=[
                 _func(
                     "draw", "_Z4drawii", params=[Param("w", "int"), Param("h", "int")]
@@ -529,10 +531,23 @@ class TestParamRenamed:
         assert len(renames) == 2
 
     def test_param_renamed_is_source_break(self) -> None:
-        old = _snap(functions=[_func("f", "_Z1fi", params=[Param("count", "int")])])
-        new = _snap(functions=[_func("f", "_Z1fi", params=[Param("n", "int")])])
+        old = _snap(
+            from_headers=True,
+            functions=[_func("f", "_Z1fi", params=[Param("count", "int")])],
+        )
+        new = _snap(
+            from_headers=True,
+            functions=[_func("f", "_Z1fi", params=[Param("n", "int")])],
+        )
         result = compare(old, new)
         assert result.verdict == Verdict.API_BREAK
+
+    def test_dwarf_only_param_rename_is_not_source_break(self) -> None:
+        old = _snap(functions=[_func("f", "_Z1fi", params=[Param("arg_size", "int")])])
+        new = _snap(functions=[_func("f", "_Z1fi", params=[Param("size", "int")])])
+        result = compare(old, new)
+        assert ChangeKind.PARAM_RENAMED not in _kinds(result)
+        assert result.verdict == Verdict.NO_CHANGE
 
     def test_no_rename_when_unchanged(self) -> None:
         old = _snap(functions=[_func("f", "_Z1fi", params=[Param("x", "int")])])

--- a/tests/test_stripped_degradation.py
+++ b/tests/test_stripped_degradation.py
@@ -303,6 +303,40 @@ class TestPartialMetadata:
         assert ChangeKind.FUNC_REMOVED_ELF_ONLY not in _kinds(r)
         assert r.verdict != Verdict.BREAKING
 
+    def test_unexported_dwarf_deleted_not_reported_when_only_data_exported(self):
+        """An ELF table that exports only data is still authoritative.
+
+        When the new side has an ELF symbol table but no exported *function*
+        symbols (e.g. it exports only data, or every function is hidden), a
+        DWARF-only DW_AT_deleted internal member is genuinely not exported and
+        must not be reported. The guard must key on ELF-table presence, not on
+        whether some other function happened to be exported.
+        """
+        internal = _pub_func(
+            "foo::helper", "_ZN3foo6helperEv",
+            is_deleted=True, deleted_from_dwarf=True,
+        )
+        data_only_elf = ElfMetadata(symbols=[
+            ElfSymbol(name="g_table", binding=SymbolBinding.GLOBAL, sym_type=SymbolType.OBJECT),
+        ])
+        r = compare(
+            _snap(functions=[_pub_func("foo::helper", "_ZN3foo6helperEv")],
+                  elf=data_only_elf, dwarf=DwarfMetadata(has_dwarf=True)),
+            _snap(functions=[internal], elf=data_only_elf, dwarf=DwarfMetadata(has_dwarf=True)),
+        )
+        assert ChangeKind.FUNC_DELETED_DWARF not in _kinds(r)
+        assert r.verdict != Verdict.BREAKING
+
+    def test_dwarf_deleted_reported_when_no_elf_table(self):
+        """With no ELF table, fall back to visibility — deletion still reported."""
+        old = _pub_func("api", "_Z3apiv")
+        new = _pub_func("api", "_Z3apiv", is_deleted=True, deleted_from_dwarf=True)
+        r = compare(
+            _snap(functions=[old], dwarf=DwarfMetadata(has_dwarf=True)),
+            _snap(functions=[new], dwarf=DwarfMetadata(has_dwarf=True)),
+        )
+        assert ChangeKind.FUNC_DELETED_DWARF in _kinds(r)
+
     def test_exported_dwarf_deleted_function_still_detected(self):
         """Confirmed exported DWARF-deleted APIs still report a deletion."""
         old = _pub_func("api", "_Z3apiv")

--- a/tests/test_stripped_degradation.py
+++ b/tests/test_stripped_degradation.py
@@ -274,6 +274,57 @@ class TestPartialMetadata:
         assert ChangeKind.FUNC_REMOVED not in process_kinds
         assert ChangeKind.FUNC_REMOVED_ELF_ONLY not in process_kinds
 
+    def test_unexported_dwarf_deleted_function_not_public_surface(self):
+        """DWARF-only deleted special members must not become public ABI.
+
+        oneTBB debug builds expose internal deleted copy constructors/operators
+        through DW_AT_deleted, but the functions are not in .dynsym. When a
+        later build is stripped, those internal DWARF declarations must not
+        become public removals.
+        """
+        internal = _pub_func(
+            "tbb::detail::d0::atomic_backoff::atomic_backoff",
+            "_ZN3tbb6detail2d014atomic_backoffC4ERKS2_",
+            is_deleted=True,
+            deleted_from_dwarf=True,
+        )
+        exported = _pub_func("api", "_Z3apiv")
+        elf = ElfMetadata(
+            symbols=[ElfSymbol(name="_Z3apiv", binding=SymbolBinding.GLOBAL,
+                               sym_type=SymbolType.FUNC)],
+        )
+
+        r = compare(
+            _snap(functions=[internal, exported], elf=elf, dwarf=DwarfMetadata(has_dwarf=True)),
+            _snap(functions=[exported], elf=elf, elf_only_mode=True),
+        )
+
+        assert ChangeKind.FUNC_REMOVED not in _kinds(r)
+        assert ChangeKind.FUNC_REMOVED_ELF_ONLY not in _kinds(r)
+        assert r.verdict != Verdict.BREAKING
+
+    def test_exported_dwarf_deleted_function_still_detected(self):
+        """Confirmed exported DWARF-deleted APIs still report a deletion."""
+        old = _pub_func("api", "_Z3apiv")
+        new = _pub_func(
+            "api",
+            "_Z3apiv",
+            is_deleted=True,
+            deleted_from_dwarf=True,
+        )
+        elf = ElfMetadata(
+            symbols=[ElfSymbol(name="_Z3apiv", binding=SymbolBinding.GLOBAL,
+                               sym_type=SymbolType.FUNC)],
+        )
+
+        r = compare(
+            _snap(functions=[old], elf=elf, dwarf=DwarfMetadata(has_dwarf=True)),
+            _snap(functions=[new], elf=elf, dwarf=DwarfMetadata(has_dwarf=True)),
+        )
+
+        assert ChangeKind.FUNC_DELETED_DWARF in _kinds(r)
+        assert r.verdict == Verdict.BREAKING
+
     def test_dwarf_present_elf_absent(self):
         """DWARF metadata present, ELF absent — should not crash."""
         dwarf = DwarfMetadata(


### PR DESCRIPTION
## Summary
- ignore removed private ELF version-definition markers when no old exported symbol used that version node
- keep private version nodes with exported symbols as breaking via existing symbol-backed version-node detection
- add regression coverage for marker-only removals and private exported-symbol removals

## Real-world evidence
- Found in the recurring real-world validation campaign on conda-forge `libnsl` 2.0.0 -> 2.0.1.
- Before this fix, abicheck reported `BREAKING` solely for removed `LIBNSL_PRIVATE`.
- `abidiff` exited clean, dynamic export diff removed only `LIBNSL_PRIVATE`, and `readelf --dyn-syms` showed it was a zero-sized absolute version-definition marker rather than callable/data ABI.
- After this fix, the same comparison reports `COMPATIBLE_WITH_RISK` with only the new `GLIBC_2.14` requirement.

Artifacts are recorded in the local campaign report under `reports/abicheck-realworld-cron/artifacts/20260605-0247/`.

## Tests
- `pytest -q tests/test_sprint2_elf.py tests/test_diff_platform_deep.py::TestSymbolVersionChanges tests/test_elf_version_policy.py` (88 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unattached private symbol version markers from being reported as removed
  * Improved handling of deleted functions marked in debug info to avoid false breaking changes
  * Enhanced parameter rename detection to work correctly with incomplete header inputs
  * Refined ELF symbol filtering to exclude linker-internal boundary markers
  * Extended compiler-internal type detection to cover typedef aliases

* **Tests**
  * Added tests for symbol versioning edge cases and linker boundary marker filtering
  * Added tests for debug-info-only deleted function scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->