### PR TITLE
Filter ELF lifecycle stubs from ABI surface

### DIFF
--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -143,7 +143,7 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     )
     return {
         k: v for k, v in funcs.items()
-        if k in exported or v.is_deleted
+        if k in exported or (v.is_deleted and not v.deleted_from_dwarf)
     }
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -587,6 +587,22 @@ def _match_old_function(
             mangled, f_old, new_map[mangled],
             params_unconfirmed=params_unconfirmed, is_llp64=is_llp64))
 
+    # A function that still exists on the new side but is ``= delete``'d is a
+    # deletion, not a removal: _detect_newly_deleted_functions reports it once
+    # as FUNC_DELETED / FUNC_DELETED_DWARF from the full function map. When a
+    # DWARF-deleted member also drops out of .dynsym, _public_functions excludes
+    # it from new_map (it is no longer exported), so without this guard the old
+    # exported peer would additionally be flagged FUNC_REMOVED here, double-
+    # reporting the same symbol. The castxml-deleted path keeps such functions
+    # in new_map and is matched above; this aligns the deleted_from_dwarf path.
+    f_new_all = new_all.get(mangled)
+    if (
+        f_new_all is not None
+        and f_new_all.is_deleted
+        and f_new_all.visibility in _PUBLIC_VIS
+    ):
+        return []
+
     # Fallback by plain name when either side uses extern "C".
     # The name->Function mapping is a MULTIMAP: only fall back when there is
     # EXACTLY ONE extern-C candidate for this name, to avoid mis-pairing

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -732,17 +732,26 @@ def _elf_classify_symbols(
     exported_dynamic_objects: set[str] = set()
     exported_dynamic_tls: set[str] = set()
     if elf_meta.symbols:
+        # Apply the shared ABI-relevance filter here too: this no-header path
+        # rebuilds the exported sets directly from ``elf_meta.symbols`` rather
+        # than the already-filtered ``_pyelftools_exported_symbols`` result, so
+        # lifecycle stubs (``_init``/``_fini``) and transitive runtime symbols
+        # would otherwise re-enter the symbol-only ABI surface as ELF_ONLY
+        # functions. Keeping it consistent with the DWARF-backed path.
         exported_dynamic_funcs = {
             sym.name for sym in elf_meta.symbols
             if sym.sym_type in (SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTYPE)
+            and is_abi_relevant_elf_symbol(sym.name)
         }
         exported_dynamic_objects = {
             sym.name for sym in elf_meta.symbols
             if sym.sym_type == SymbolType.OBJECT
+            and is_abi_relevant_elf_symbol(sym.name)
         }
         exported_dynamic_tls = {
             sym.name for sym in elf_meta.symbols
             if sym.sym_type == SymbolType.TLS
+            and is_abi_relevant_elf_symbol(sym.name)
         }
         # Full set for CastxmlParser: determines PUBLIC vs ELF_ONLY visibility
         exported_dynamic = exported_dynamic_funcs | exported_dynamic_objects | exported_dynamic_tls

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -300,6 +300,38 @@ def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> N
     }
 
 
+def test_elf_classify_symbols_filters_lifecycle_stubs_at_dump_surface() -> None:
+    """The no-header dump path must drop lifecycle stubs from the ABI surface.
+
+    ``_elf_classify_symbols`` rebuilds the exported sets directly from
+    ``elf_meta.symbols`` (not the already-filtered
+    ``_pyelftools_exported_symbols`` result). Without the shared
+    ABI-relevance filter, ``_init``/``_fini`` and transitive runtime symbols
+    re-enter ELF-only snapshots as ``ELF_ONLY`` functions.
+    """
+    from abicheck.dumper import _elf_classify_symbols
+
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_fini", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="api", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="g_table", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="__cpu_model", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="tls_var", sym_type=SymbolType.TLS),
+        ]
+    )
+
+    full, funcs, objects, tls = _elf_classify_symbols(meta, {"api"})
+
+    assert funcs == {"api"}
+    assert "_init" not in full and "_fini" not in full
+    assert objects == {"g_table"}
+    assert tls == {"tls_var"}
+    assert full == {"api", "g_table", "tls_var"}
+
+
 def _function(name: str) -> Function:
     return Function(
         name=name,

--- a/tests/test_stripped_degradation.py
+++ b/tests/test_stripped_degradation.py
@@ -240,6 +240,40 @@ class TestPartialMetadata:
         assert "elf" in r.evidence_tiers
         assert "dwarf" not in r.evidence_tiers
 
+    def test_dwarf_deleted_dropped_from_dynsym_reported_once(self):
+        """A DWARF-deleted export that also leaves .dynsym is one event.
+
+        When a function gains ``= delete`` (DW_AT_deleted) and disappears from
+        .dynsym while the DSO still exports other functions, _public_functions
+        drops it from new_map (no longer exported). Without deduplication the
+        old exported peer would be flagged FUNC_REMOVED *and*
+        _detect_newly_deleted_functions would flag FUNC_DELETED_DWARF for the
+        same symbol. It must be reported once, as the deletion.
+        """
+        old_elf = ElfMetadata(symbols=[
+            ElfSymbol(name="_Z7processv", binding=SymbolBinding.GLOBAL, sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_Z4keepv", binding=SymbolBinding.GLOBAL, sym_type=SymbolType.FUNC),
+        ])
+        new_elf = ElfMetadata(symbols=[
+            ElfSymbol(name="_Z4keepv", binding=SymbolBinding.GLOBAL, sym_type=SymbolType.FUNC),
+        ])
+        old = _snap(
+            functions=[_pub_func("process", "_Z7processv"), _pub_func("keep", "_Z4keepv")],
+            elf=old_elf, dwarf=DwarfMetadata(has_dwarf=True),
+        )
+        new = _snap(
+            functions=[
+                _pub_func("keep", "_Z4keepv"),
+                _pub_func("process", "_Z7processv", is_deleted=True, deleted_from_dwarf=True),
+            ],
+            elf=new_elf, dwarf=DwarfMetadata(has_dwarf=True),
+        )
+        r = compare(old, new)
+        process_kinds = {c.kind for c in r.changes if c.symbol == "_Z7processv"}
+        assert ChangeKind.FUNC_DELETED_DWARF in process_kinds
+        assert ChangeKind.FUNC_REMOVED not in process_kinds
+        assert ChangeKind.FUNC_REMOVED_ELF_ONLY not in process_kinds
+
     def test_dwarf_present_elf_absent(self):
         """DWARF metadata present, ELF absent — should not crash."""
         dwarf = DwarfMetadata(


### PR DESCRIPTION
## Summary
- filters exact ELF lifecycle stubs `_init` and `_fini` out of the ABI-relevant ELF symbol surface
- makes DWARF/public-function narrowing distinguish no ELF evidence from ELF evidence where every function export was filtered
- adds regression coverage for symbol-only and DWARF-backed paths while preserving real APIs such as `lib_init`

## Real-world validation
During the 2026-06-05 04:17 abicheck real-world cron scan, PCRE2 10.46 -> 10.47 reported `BREAKING` for all four shared libraries solely because `_init` and `_fini` disappeared.

Evidence from the scan:
- `artifacts/20260605-0417-fill/runs/PCRE2_10.46_TO_10.47__libpcre2-8.json`
- `artifacts/20260605-0417-fill/libabigail/PCRE2_10.46_TO_10.47__libpcre2-8.abidiff.txt`
- export diff intentionally excluded `_init`/`_fini` and showed no removed public export names

After this fix, reruns on the extracted real package pair produced:
- libpcre2-8: `COMPATIBLE`
- libpcre2-16: `COMPATIBLE`
- libpcre2-32: `COMPATIBLE`
- libpcre2-posix: `COMPATIBLE_WITH_RISK` due only to the new `PCRE2_10.47` symbol-version requirement

Verification artifacts are recorded under `/home/openclaw/.openclaw/workspace-abicheck/reports/abicheck-realworld-cron/artifacts/20260605-0417-fill/runs/*after-final-fix.json`.

## Tests
- `pytest -q tests/test_elf_symbol_filters.py tests/test_stripped_degradation.py::TestElfOnlyMode`
