### PR TITLE
Fix package discovery for .so DSOs with PT_INTERP

### DIFF
--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -591,6 +591,9 @@ def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool | 
 
         if e_phoff == 0 or e_phnum == 0:
             return False
+        expected_phentsize = 32 if ei_class == 1 else 56
+        if e_phentsize < expected_phentsize:
+            return None
 
         for i in range(e_phnum):
             f.seek(e_phoff + i * e_phentsize)

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import struct
 import subprocess
@@ -189,7 +190,7 @@ class TarExtractor:
             try:
                 import zstandard
             except ImportError:
-                zstandard = None
+                zstandard = None  # type: ignore[assignment]
             if zstandard is not None:
                 dctx = zstandard.ZstdDecompressor()
                 with open(zst_path, "rb") as compressed, open(tar_path, "wb") as out:
@@ -562,6 +563,12 @@ _ELF_MAGIC = b"\x7fELF"
 _ET_DYN = 3
 # Program header type PT_INTERP (interpreter segment — present in executables, absent in DSOs)
 _PT_INTERP = 3
+_SO_NAME_RE = re.compile(r"\.so(?:\.|$)", re.IGNORECASE)
+
+
+def _has_shared_object_name(path: Path | str) -> bool:
+    """Return True for .so or versioned .so.N filenames."""
+    return _SO_NAME_RE.search(Path(path).name) is not None
 
 
 def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool:
@@ -622,7 +629,7 @@ def _is_elf_shared_object(path: Path) -> bool:
                 # directly (for example Ubuntu's libcap.so.2.66).  Keep the
                 # PIE-executable guard for app-like filenames, but do not drop
                 # real versioned .so files from package discovery.
-                return ".so" in path.name.lower()
+                return _has_shared_object_name(path)
             return True
     except (OSError, struct.error):
         return False
@@ -674,10 +681,9 @@ def discover_shared_libraries(
                     rel_parts == d or rel_parts.startswith(d + "/")
                     for d in _PUBLIC_LIB_DIRS
                 )
-                # Also accept files with .so in name at any depth as a fallback
-                # for flat directory layouts (e.g. plain tar archives)
-                name_lower = fn.lower()
-                has_so_ext = ".so" in name_lower
+                # Also accept files with a .so suffix/versioned SONAME at any
+                # depth as a fallback for flat directory layouts.
+                has_so_ext = _has_shared_object_name(fn)
                 if not in_public and not has_so_ext:
                     continue
 

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -188,11 +188,11 @@ class TarExtractor:
         tar_path = staging / "payload.tar"
         try:
             try:
-                import zstandard
+                import zstandard as zstandard_mod
             except ImportError:
-                zstandard = None  # type: ignore[assignment]
-            if zstandard is not None:
-                dctx = zstandard.ZstdDecompressor()
+                zstandard_mod = None
+            if zstandard_mod is not None:
+                dctx = zstandard_mod.ZstdDecompressor()
                 with open(zst_path, "rb") as compressed, open(tar_path, "wb") as out:
                     with dctx.stream_reader(compressed) as reader:
                         shutil.copyfileobj(reader, out)
@@ -604,7 +604,12 @@ def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool | 
         if e_phoff == 0 or e_phnum == 0:
             return False
         expected_phentsize = 32 if ei_class == 1 else 56
-        if e_phentsize < expected_phentsize:
+        # The program-header entry size is fixed by ELF class (32 bytes for
+        # ELFCLASS32, 56 for ELFCLASS64). Any mismatch — undersized *or*
+        # oversized — means the layout we read p_type from at fixed offsets is
+        # not trustworthy, so treat it as inconclusive rather than risk
+        # misclassifying the file.
+        if e_phentsize != expected_phentsize:
             return None
 
         for i in range(e_phnum):

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -656,6 +656,7 @@ def discover_shared_libraries(
     for dirpath, _dirnames, filenames in os.walk(extract_dir, followlinks=False):
         for fn in filenames:
             fp = Path(dirpath) / fn
+            elf_path = fp
             if fp.is_symlink():
                 # Follow symlinks only to check the target, don't add symlinks themselves
                 # unless the target is a real shared object
@@ -663,10 +664,11 @@ def discover_shared_libraries(
                     real = fp.resolve()
                     if not real.exists():
                         continue
+                    elf_path = real
                 except OSError:
                     continue
 
-            if not _is_elf_shared_object(fp):
+            if not _is_elf_shared_object(elf_path):
                 continue
 
             # Filter by path convention unless --include-private-dso

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -563,12 +563,24 @@ _ELF_MAGIC = b"\x7fELF"
 _ET_DYN = 3
 # Program header type PT_INTERP (interpreter segment — present in executables, absent in DSOs)
 _PT_INTERP = 3
-_SO_NAME_RE = re.compile(r"\.so(?:$|\.\d+(?:\.\d+)*)$", re.IGNORECASE)
+_SO_NAME_RE = re.compile(r"^(?P<stem>.+)\.so(?P<version>(?:\.[A-Za-z0-9]+)*)$", re.IGNORECASE)
+_NUMERIC_SO_VERSION_RE = re.compile(r"(?:\.\d+)+$")
+_ALNUM_SO_VERSION_RE = re.compile(r"(?:\.[A-Za-z0-9]+)+$")
 
 
 def _has_shared_object_name(path: Path | str) -> bool:
-    """Return True for .so or numeric-versioned .so.N filenames."""
-    return _SO_NAME_RE.search(Path(path).name) is not None
+    """Return True for .so or versioned SONAME-style filenames."""
+    match = _SO_NAME_RE.match(Path(path).name)
+    if match is None:
+        return False
+    version = match.group("version")
+    if not version:
+        return True
+    if _NUMERIC_SO_VERSION_RE.fullmatch(version):
+        return True
+    return match.group("stem").lower().startswith("lib") and (
+        _ALNUM_SO_VERSION_RE.fullmatch(version) is not None
+    )
 
 
 def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool | None:

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -563,7 +563,7 @@ _ELF_MAGIC = b"\x7fELF"
 _ET_DYN = 3
 # Program header type PT_INTERP (interpreter segment — present in executables, absent in DSOs)
 _PT_INTERP = 3
-_SO_NAME_RE = re.compile(r"\.so(?:$|\.\d)", re.IGNORECASE)
+_SO_NAME_RE = re.compile(r"\.so(?:$|\.\d+(?:\.\d+)*)$", re.IGNORECASE)
 
 
 def _has_shared_object_name(path: Path | str) -> bool:
@@ -571,7 +571,7 @@ def _has_shared_object_name(path: Path | str) -> bool:
     return _SO_NAME_RE.search(Path(path).name) is not None
 
 
-def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool:
+def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool | None:
     """Check if an ELF file has a PT_INTERP program header (i.e. is an executable)."""
     try:
         if ei_class == 1:  # 32-bit
@@ -599,7 +599,7 @@ def _has_interp_segment(f: IO[bytes], ei_class: int, byte_order: str) -> bool:
                 return True
         return False
     except (OSError, struct.error):
-        return False
+        return None
 
 
 def _is_elf_shared_object(path: Path) -> bool:
@@ -623,6 +623,8 @@ def _is_elf_shared_object(path: Path) -> bool:
             # Distinguish PIE executables from true shared objects:
             # executables have a PT_INTERP segment, shared objects don't.
             has_interp = _has_interp_segment(f, ei_class, byte_order)
+            if has_interp is None:
+                return False
             if has_interp:
                 # A few distro runtime DSOs are ET_DYN, named like libraries,
                 # and intentionally carry PT_INTERP so they can be invoked

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -563,11 +563,11 @@ _ELF_MAGIC = b"\x7fELF"
 _ET_DYN = 3
 # Program header type PT_INTERP (interpreter segment — present in executables, absent in DSOs)
 _PT_INTERP = 3
-_SO_NAME_RE = re.compile(r"\.so(?:\.|$)", re.IGNORECASE)
+_SO_NAME_RE = re.compile(r"\.so(?:$|\.\d)", re.IGNORECASE)
 
 
 def _has_shared_object_name(path: Path | str) -> bool:
-    """Return True for .so or versioned .so.N filenames."""
+    """Return True for .so or numeric-versioned .so.N filenames."""
     return _SO_NAME_RE.search(Path(path).name) is not None
 
 

--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -615,7 +615,15 @@ def _is_elf_shared_object(path: Path) -> bool:
 
             # Distinguish PIE executables from true shared objects:
             # executables have a PT_INTERP segment, shared objects don't.
-            return not _has_interp_segment(f, ei_class, byte_order)
+            has_interp = _has_interp_segment(f, ei_class, byte_order)
+            if has_interp:
+                # A few distro runtime DSOs are ET_DYN, named like libraries,
+                # and intentionally carry PT_INTERP so they can be invoked
+                # directly (for example Ubuntu's libcap.so.2.66).  Keep the
+                # PIE-executable guard for app-like filenames, but do not drop
+                # real versioned .so files from package discovery.
+                return ".so" in path.name.lower()
+            return True
     except (OSError, struct.error):
         return False
 

--- a/tests/test_bugfix_regression.py
+++ b/tests/test_bugfix_regression.py
@@ -276,6 +276,23 @@ class TestBug5PieDetection:
         _make_elf_pie_with_interp(exe)
         assert _is_elf_shared_object(exe) is False
 
+    def test_oversized_phentsize_is_inconclusive(self, tmp_path: Path):
+        """A mismatched (oversized) e_phentsize must reject, not misclassify.
+
+        The program-header entry size is fixed by ELF class (56 for ELFCLASS64).
+        An oversized value means the fixed-offset p_type reads are unreliable, so
+        _has_interp_segment returns None and _is_elf_shared_object returns False
+        rather than guessing.
+        """
+        from abicheck.package import _is_elf_shared_object
+        so = tmp_path / "libweird.so"
+        _make_elf_pie_with_interp(so)
+        data = bytearray(so.read_bytes())
+        # e_phentsize is a 2-byte field at offset 54 in a 64-bit ELF header.
+        struct.pack_into("<H", data, 54, 64)  # oversized (should be 56)
+        so.write_bytes(bytes(data))
+        assert _is_elf_shared_object(so) is False
+
     def test_static_exec_et_exec_is_not_shared_object(self, tmp_path: Path):
         from abicheck.package import _is_elf_shared_object
         exe = tmp_path / "app"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -446,6 +446,12 @@ class TestIsElfSharedObject:
         _make_minimal_elf_dso_with_interp(f)
         assert _is_elf_shared_object(f) is True
 
+    def test_alphanumeric_versioned_lib_dso_with_interp(self, tmp_path: Path) -> None:
+        for name in ("libtidy.so.5deb1.6.0", "libstemmer.so.0d.0.0"):
+            f = tmp_path / name
+            _make_minimal_elf_dso_with_interp(f)
+            assert _is_elf_shared_object(f) is True
+
     def test_pie_like_name_with_interp(self, tmp_path: Path) -> None:
         f = tmp_path / "capsh"
         _make_minimal_elf_dso_with_interp(f)
@@ -549,6 +555,16 @@ class TestDiscoverSharedLibraries:
         result = discover_shared_libraries(tmp_path)
         assert len(result) == 1
         assert result[0].name == "libfoo.so"
+
+    def test_finds_alphanumeric_versioned_libs_in_flat_layout(
+        self, tmp_path: Path
+    ) -> None:
+        _make_minimal_elf_so(tmp_path / "libtidy.so.5deb1.6.0")
+        _make_minimal_elf_so(tmp_path / "libstemmer.so.0d.0.0")
+        result = discover_shared_libraries(tmp_path)
+        names = [p.name for p in result]
+        assert "libtidy.so.5deb1.6.0" in names
+        assert "libstemmer.so.0d.0.0" in names
 
     def test_skips_flat_layout_name_containing_so_without_boundary(
         self, tmp_path: Path

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -100,6 +100,22 @@ def _make_malformed_elf_dso_with_missing_phdr(path: Path) -> None:
     path.write_bytes(bytes(elf))
 
 
+def _make_malformed_elf_dso_with_invalid_phentsize(path: Path) -> None:
+    """Write ET_DYN ELF with an invalid program-header entry size."""
+    elf = bytearray(64)
+    elf[0:4] = b"\x7fELF"
+    elf[4] = 2  # EI_CLASS = ELFCLASS64
+    elf[5] = 1  # EI_DATA = ELFDATA2LSB
+    elf[6] = 1  # EI_VERSION = EV_CURRENT
+    struct.pack_into("<H", elf, 16, 3)  # e_type = ET_DYN
+    struct.pack_into("<H", elf, 18, 0x3E)  # e_machine = EM_X86_64
+    struct.pack_into("<I", elf, 20, 1)  # e_version
+    struct.pack_into("<Q", elf, 32, 64)  # e_phoff
+    struct.pack_into("<H", elf, 54, 0)  # e_phentsize = invalid
+    struct.pack_into("<H", elf, 56, 1)  # e_phnum
+    path.write_bytes(bytes(elf) + b"\x00" * 4)
+
+
 def _make_tar(archive_path: Path, files: dict[str, bytes]) -> None:
     """Create a tar.gz archive with given file contents."""
     with tarfile.open(archive_path, "w:gz") as tf:
@@ -454,6 +470,11 @@ class TestIsElfSharedObject:
     def test_malformed_program_header_table_is_rejected(self, tmp_path: Path) -> None:
         f = tmp_path / "libbad.so"
         _make_malformed_elf_dso_with_missing_phdr(f)
+        assert _is_elf_shared_object(f) is False
+
+    def test_invalid_program_header_entry_size_is_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "libbad.so"
+        _make_malformed_elf_dso_with_invalid_phentsize(f)
         assert _is_elf_shared_object(f) is False
 
     def test_non_elf(self, tmp_path: Path) -> None:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -971,6 +971,34 @@ class TestDiscoverSharedLibrariesExtended:
         assert "libfoo.so" in names
         assert "libfoo.so.1.0" in names
 
+    def test_symlink_to_interp_executable_is_skipped(self, tmp_path: Path) -> None:
+        """A .so symlink to a PT_INTERP executable should not be included."""
+        bin_dir = tmp_path / "usr" / "bin"
+        lib_dir = tmp_path / "usr" / "lib"
+        bin_dir.mkdir(parents=True)
+        lib_dir.mkdir(parents=True)
+        app = bin_dir / "app"
+        _make_minimal_elf_dso_with_interp(app)
+        link = lib_dir / "libapp.so"
+        link.symlink_to("../bin/app")
+
+        result = discover_shared_libraries(tmp_path)
+        assert link not in result
+
+    def test_symlink_to_interp_dso_is_included(self, tmp_path: Path) -> None:
+        """A .so symlink to a PT_INTERP DSO should still be included."""
+        lib_dir = tmp_path / "usr" / "lib"
+        lib_dir.mkdir(parents=True)
+        real = lib_dir / "libcap.so.2.66"
+        _make_minimal_elf_dso_with_interp(real)
+        link = lib_dir / "libcap.so"
+        link.symlink_to("libcap.so.2.66")
+
+        result = discover_shared_libraries(tmp_path)
+        names = [p.name for p in result]
+        assert "libcap.so" in names
+        assert "libcap.so.2.66" in names
+
     def test_usr_local_lib(self, tmp_path: Path) -> None:
         """DSOs in usr/local/lib should be found."""
         lib_dir = tmp_path / "usr" / "local" / "lib"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -419,6 +419,11 @@ class TestIsElfSharedObject:
         _make_minimal_elf_dso_with_interp(f)
         assert _is_elf_shared_object(f) is False
 
+    def test_pie_name_containing_so_without_boundary_is_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "app.solver"
+        _make_minimal_elf_dso_with_interp(f)
+        assert _is_elf_shared_object(f) is False
+
     def test_non_elf(self, tmp_path: Path) -> None:
         f = tmp_path / "text.txt"
         f.write_text("hello")
@@ -491,6 +496,13 @@ class TestDiscoverSharedLibraries:
         result = discover_shared_libraries(tmp_path)
         assert len(result) == 1
         assert result[0].name == "libfoo.so"
+
+    def test_skips_flat_layout_name_containing_so_without_boundary(
+        self, tmp_path: Path
+    ) -> None:
+        _make_minimal_elf_so(tmp_path / "tool.something")
+        result = discover_shared_libraries(tmp_path)
+        assert result == []
 
     def test_empty_directory(self, tmp_path: Path) -> None:
         result = discover_shared_libraries(tmp_path)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -84,6 +84,22 @@ def _make_minimal_elf_dso_with_interp(path: Path) -> None:
     path.write_bytes(bytes(elf) + bytes(phdr))
 
 
+def _make_malformed_elf_dso_with_missing_phdr(path: Path) -> None:
+    """Write ET_DYN ELF header that advertises a missing program header."""
+    elf = bytearray(64)
+    elf[0:4] = b"\x7fELF"
+    elf[4] = 2  # EI_CLASS = ELFCLASS64
+    elf[5] = 1  # EI_DATA = ELFDATA2LSB
+    elf[6] = 1  # EI_VERSION = EV_CURRENT
+    struct.pack_into("<H", elf, 16, 3)  # e_type = ET_DYN
+    struct.pack_into("<H", elf, 18, 0x3E)  # e_machine = EM_X86_64
+    struct.pack_into("<I", elf, 20, 1)  # e_version
+    struct.pack_into("<Q", elf, 32, 64)  # e_phoff
+    struct.pack_into("<H", elf, 54, 56)  # e_phentsize
+    struct.pack_into("<H", elf, 56, 1)  # e_phnum
+    path.write_bytes(bytes(elf))
+
+
 def _make_tar(archive_path: Path, files: dict[str, bytes]) -> None:
     """Create a tar.gz archive with given file contents."""
     with tarfile.open(archive_path, "w:gz") as tf:
@@ -429,6 +445,17 @@ class TestIsElfSharedObject:
         _make_minimal_elf_dso_with_interp(f)
         assert _is_elf_shared_object(f) is False
 
+    def test_pie_name_with_partial_version_so_suffix_is_rejected(self, tmp_path: Path) -> None:
+        for name in ("app.so.1.tmp", "app.so.1a"):
+            f = tmp_path / name
+            _make_minimal_elf_dso_with_interp(f)
+            assert _is_elf_shared_object(f) is False
+
+    def test_malformed_program_header_table_is_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "libbad.so"
+        _make_malformed_elf_dso_with_missing_phdr(f)
+        assert _is_elf_shared_object(f) is False
+
     def test_non_elf(self, tmp_path: Path) -> None:
         f = tmp_path / "text.txt"
         f.write_text("hello")
@@ -511,6 +538,12 @@ class TestDiscoverSharedLibraries:
 
     def test_skips_flat_layout_non_versioned_so_suffix(self, tmp_path: Path) -> None:
         _make_minimal_elf_so(tmp_path / "tool.so.tmp")
+        result = discover_shared_libraries(tmp_path)
+        assert result == []
+
+    def test_skips_flat_layout_partial_version_so_suffix(self, tmp_path: Path) -> None:
+        _make_minimal_elf_so(tmp_path / "tool.so.1a")
+        _make_minimal_elf_so(tmp_path / "tool.so.1.tmp")
         result = discover_shared_libraries(tmp_path)
         assert result == []
 
@@ -981,6 +1014,22 @@ class TestDiscoverSharedLibrariesExtended:
         _make_minimal_elf_dso_with_interp(app)
         link = lib_dir / "libapp.so"
         link.symlink_to("../bin/app")
+
+        result = discover_shared_libraries(tmp_path)
+        assert link not in result
+
+    def test_symlink_to_partial_version_interp_executable_is_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """A .so symlink to a malformed-version PT_INTERP executable is skipped."""
+        bin_dir = tmp_path / "usr" / "bin"
+        lib_dir = tmp_path / "usr" / "lib"
+        bin_dir.mkdir(parents=True)
+        lib_dir.mkdir(parents=True)
+        app = bin_dir / "app.so.1.tmp"
+        _make_minimal_elf_dso_with_interp(app)
+        link = lib_dir / "libapp.so"
+        link.symlink_to("../bin/app.so.1.tmp")
 
         result = discover_shared_libraries(tmp_path)
         assert link not in result

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -424,6 +424,11 @@ class TestIsElfSharedObject:
         _make_minimal_elf_dso_with_interp(f)
         assert _is_elf_shared_object(f) is False
 
+    def test_pie_name_with_non_versioned_so_suffix_is_rejected(self, tmp_path: Path) -> None:
+        f = tmp_path / "app.so.tmp"
+        _make_minimal_elf_dso_with_interp(f)
+        assert _is_elf_shared_object(f) is False
+
     def test_non_elf(self, tmp_path: Path) -> None:
         f = tmp_path / "text.txt"
         f.write_text("hello")
@@ -501,6 +506,11 @@ class TestDiscoverSharedLibraries:
         self, tmp_path: Path
     ) -> None:
         _make_minimal_elf_so(tmp_path / "tool.something")
+        result = discover_shared_libraries(tmp_path)
+        assert result == []
+
+    def test_skips_flat_layout_non_versioned_so_suffix(self, tmp_path: Path) -> None:
+        _make_minimal_elf_so(tmp_path / "tool.so.tmp")
         result = discover_shared_libraries(tmp_path)
         assert result == []
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -63,6 +63,27 @@ def _make_minimal_elf_exec(path: Path) -> None:
     path.write_bytes(e_ident + e_type + rest)
 
 
+def _make_minimal_elf_dso_with_interp(path: Path) -> None:
+    """Write a minimal ET_DYN ELF with a PT_INTERP program header."""
+    elf = bytearray(64)
+    elf[0:4] = b"\x7fELF"
+    elf[4] = 2  # EI_CLASS = ELFCLASS64
+    elf[5] = 1  # EI_DATA = ELFDATA2LSB
+    elf[6] = 1  # EI_VERSION = EV_CURRENT
+    struct.pack_into("<H", elf, 16, 3)  # e_type = ET_DYN
+    struct.pack_into("<H", elf, 18, 0x3E)  # e_machine = EM_X86_64
+    struct.pack_into("<I", elf, 20, 1)  # e_version
+    struct.pack_into("<Q", elf, 32, 64)  # e_phoff
+    struct.pack_into("<H", elf, 54, 56)  # e_phentsize
+    struct.pack_into("<H", elf, 56, 1)  # e_phnum
+
+    phdr = bytearray(56)
+    struct.pack_into("<I", phdr, 0, 3)  # p_type = PT_INTERP
+    struct.pack_into("<I", phdr, 4, 4)  # p_flags = PF_R
+    struct.pack_into("<Q", phdr, 48, 1)  # p_align
+    path.write_bytes(bytes(elf) + bytes(phdr))
+
+
 def _make_tar(archive_path: Path, files: dict[str, bytes]) -> None:
     """Create a tar.gz archive with given file contents."""
     with tarfile.open(archive_path, "w:gz") as tf:
@@ -388,6 +409,16 @@ class TestIsElfSharedObject:
         _make_minimal_elf_exec(f)
         assert _is_elf_shared_object(f) is False
 
+    def test_so_named_dso_with_interp(self, tmp_path: Path) -> None:
+        f = tmp_path / "libcap.so.2.66"
+        _make_minimal_elf_dso_with_interp(f)
+        assert _is_elf_shared_object(f) is True
+
+    def test_pie_like_name_with_interp(self, tmp_path: Path) -> None:
+        f = tmp_path / "capsh"
+        _make_minimal_elf_dso_with_interp(f)
+        assert _is_elf_shared_object(f) is False
+
     def test_non_elf(self, tmp_path: Path) -> None:
         f = tmp_path / "text.txt"
         f.write_text("hello")
@@ -424,6 +455,17 @@ class TestDiscoverSharedLibraries:
         names = [p.name for p in result]
         assert "libfoo.so" in names
         assert "myapp" not in names
+
+    def test_finds_so_named_dso_with_interp(self, tmp_path: Path) -> None:
+        lib_dir = tmp_path / "usr" / "lib"
+        lib_dir.mkdir(parents=True)
+        _make_minimal_elf_dso_with_interp(lib_dir / "libcap.so.2.66")
+        _make_minimal_elf_dso_with_interp(lib_dir / "capsh")
+
+        result = discover_shared_libraries(tmp_path)
+        names = [p.name for p in result]
+        assert "libcap.so.2.66" in names
+        assert "capsh" not in names
 
     def test_skips_private_by_default(self, tmp_path: Path) -> None:
         # A DSO in a non-standard path without .so in name


### PR DESCRIPTION
## Summary
- keep rejecting app-like PIE executables during package discovery
- accept ET_DYN files with .so names even when they carry PT_INTERP, matching distro DSOs such as Ubuntu libcap.so.2.66
- add regression coverage for the accepted .so case and rejected executable-like case

## Real-world evidence
- Ubuntu Noble libcap2 1:2.66-5ubuntu2 -> 1:2.66-5ubuntu2.4
- before: compare-release --dso-only returned rc=0, verdict NO_CHANGE, libraries=[] with warning 'no matching library pairs found'
- direct DSO checks found libcap.so.2.66 and libpsx.so.2.66; abicheck and abidiff both reported compatible/no removed exports
- after: compare-release --dso-only reports 2 libraries and verdict COMPATIBLE

Artifacts are recorded in the abicheck real-world cron report under artifacts/20260605-1955/.

## Tests
- pytest -q tests/test_package.py tests/test_bugfix_regression.py::TestBug5PieDetection
- real libcap compare-release branch verification artifact: artifacts/20260605-1955/package-mode/libcap_compare-release_branch-verify.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shared library detection with improved filename pattern matching for accurate identification
  * Strengthened handling of ambiguous ELF files to prevent misclassification
  * Improved symlink validation during library discovery to safely handle broken or missing references
  * Better error resilience when processing malformed archive extractions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->