### PR TITLE
test: raise per-file coverage above 80% for all modules

### DIFF
--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -3,6 +3,7 @@
 All test data is synthetic — no real binaries required for the unit tests.
 Integration tests that use real ELF binaries are marked @pytest.mark.integration.
 """
+
 from __future__ import annotations
 
 import os
@@ -32,13 +33,14 @@ from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolT
 from abicheck.model import AbiSnapshot, Function, Visibility
 
 # Concrete size values for clarity (avoids importing private _MIN_SYMBOL_SIZE).
-_TINY_SIZE = 4    # below minimum threshold — should never match
+_TINY_SIZE = 4  # below minimum threshold — should never match
 _NORMAL_SIZE = 100  # comfortably above threshold
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _fp(name: str, size: int, code_hash: str = "") -> FunctionFingerprint:
     """Shorthand for creating a FunctionFingerprint."""
@@ -54,7 +56,9 @@ def _snap_elf_only(
     if functions is None:
         functions = [
             Function(
-                name=s.name, mangled=s.name, return_type="void",
+                name=s.name,
+                mangled=s.name,
+                return_type="void",
                 visibility=Visibility.ELF_ONLY,
             )
             for s in symbols
@@ -82,6 +86,7 @@ def _func_sym(name: str, size: int = _NORMAL_SIZE) -> ElfSymbol:
 # FunctionFingerprint model tests
 # ---------------------------------------------------------------------------
 
+
 class TestFunctionFingerprint:
     def test_frozen(self) -> None:
         fp = _fp("foo", 100, "abc")
@@ -104,23 +109,30 @@ class TestFunctionFingerprint:
 # BinarySummary tests
 # ---------------------------------------------------------------------------
 
+
 class TestBinarySummary:
     def test_differs_from_identical(self) -> None:
-        s = BinarySummary(sections={
-            ".text": SectionSummary(".text", 1000, "aaa"),
-            ".rodata": SectionSummary(".rodata", 200, "bbb"),
-        })
+        s = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 1000, "aaa"),
+                ".rodata": SectionSummary(".rodata", 200, "bbb"),
+            }
+        )
         assert s.differs_from(s) == {}
 
     def test_differs_from_changed(self) -> None:
-        old = BinarySummary(sections={
-            ".text": SectionSummary(".text", 1000, "aaa"),
-            ".rodata": SectionSummary(".rodata", 200, "bbb"),
-        })
-        new = BinarySummary(sections={
-            ".text": SectionSummary(".text", 1000, "ccc"),
-            ".rodata": SectionSummary(".rodata", 200, "bbb"),
-        })
+        old = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 1000, "aaa"),
+                ".rodata": SectionSummary(".rodata", 200, "bbb"),
+            }
+        )
+        new = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 1000, "ccc"),
+                ".rodata": SectionSummary(".rodata", 200, "bbb"),
+            }
+        )
         diffs = old.differs_from(new)
         assert ".text" in diffs
         assert ".rodata" not in diffs
@@ -128,39 +140,51 @@ class TestBinarySummary:
 
     def test_differs_from_sections_only_in_one(self) -> None:
         """Sections only in one binary are not reported as diffs."""
-        old = BinarySummary(sections={
-            ".text": SectionSummary(".text", 1000, "aaa"),
-        })
-        new = BinarySummary(sections={
-            ".text": SectionSummary(".text", 1000, "aaa"),
-            ".data": SectionSummary(".data", 100, "ddd"),
-        })
+        old = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 1000, "aaa"),
+            }
+        )
+        new = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 1000, "aaa"),
+                ".data": SectionSummary(".data", 100, "ddd"),
+            }
+        )
         assert old.differs_from(new) == {}
 
     def test_differs_from_bss_size_change(self) -> None:
         """Two .bss sections with same hash but different sizes are flagged."""
-        old = BinarySummary(sections={
-            ".bss": SectionSummary(".bss", 100, "same_hash"),
-        })
-        new = BinarySummary(sections={
-            ".bss": SectionSummary(".bss", 200, "same_hash"),
-        })
+        old = BinarySummary(
+            sections={
+                ".bss": SectionSummary(".bss", 100, "same_hash"),
+            }
+        )
+        new = BinarySummary(
+            sections={
+                ".bss": SectionSummary(".bss", 200, "same_hash"),
+            }
+        )
         diffs = old.differs_from(new)
         assert ".bss" in diffs
 
     def test_has_text_present(self) -> None:
-        s = BinarySummary(sections={
-            ".text": SectionSummary(".text", 42, "x"),
-        })
+        s = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 42, "x"),
+            }
+        )
         assert s.has_text is True
 
     def test_has_text_absent(self) -> None:
         assert BinarySummary().has_text is False
 
     def test_text_size(self) -> None:
-        s = BinarySummary(sections={
-            ".text": SectionSummary(".text", 42, "x"),
-        })
+        s = BinarySummary(
+            sections={
+                ".text": SectionSummary(".text", 42, "x"),
+            }
+        )
         assert s.text_size == 42
 
     def test_text_size_absent(self) -> None:
@@ -170,6 +194,7 @@ class TestBinarySummary:
 # ---------------------------------------------------------------------------
 # match_renamed_functions tests
 # ---------------------------------------------------------------------------
+
 
 class TestMatchRenamedFunctions:
     def test_no_changes(self) -> None:
@@ -311,6 +336,7 @@ class TestMatchRenamedFunctions:
 
         def plausible(o: str, n: str) -> bool:
             import difflib
+
             return difflib.SequenceMatcher(None, o, n).ratio() >= 0.5
 
         result = match_renamed_functions(old, new, name_filter=plausible)
@@ -342,6 +368,7 @@ class TestMatchRenamedFunctions:
 # ---------------------------------------------------------------------------
 # compute_function_fingerprints / compute_section_summary — file-level tests
 # ---------------------------------------------------------------------------
+
 
 class TestComputeFunctionFingerprints:
     def test_non_elf_file_returns_empty(self, tmp_path: object) -> None:
@@ -407,29 +434,36 @@ class TestComputeSectionSummary:
 # Unqualified-name extraction and rename plausibility
 # ---------------------------------------------------------------------------
 
+
 class TestUnqualifiedName:
-    @pytest.mark.parametrize("symbol,expected", [
-        ("add", "add"),                                  # plain C name
-        ("ns::Class::method", "method"),                 # qualified
-        ("ns::Class::method(int, long)", "method"),      # with params
-        ("ns::foo<bar::baz>::run()", "run"),             # '::' inside template args
-        ("ns::make<a::b, c::d>", "make<a::b, c::d>"),    # template args kept
-        ("ns::foo<bar<int>>", "foo<bar<int>>"),          # nested template args kept
-        ("void get<int>()", "get<int>"),                 # return type dropped, args kept
-        ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
-        ("Widget::operator()(int)", "operator()(int)"),        # call operator
-        ("cooperator_v1", "cooperator_v1"),              # 'operator' substring, not keyword
-        ("myoperator::foo_v1()", "foo_v1"),              # 'operator' inside qualifier
-    ])
+    @pytest.mark.parametrize(
+        "symbol,expected",
+        [
+            ("add", "add"),  # plain C name
+            ("ns::Class::method", "method"),  # qualified
+            ("ns::Class::method(int, long)", "method"),  # with params
+            ("ns::foo<bar::baz>::run()", "run"),  # '::' inside template args
+            ("ns::make<a::b, c::d>", "make<a::b, c::d>"),  # template args kept
+            ("ns::foo<bar<int>>", "foo<bar<int>>"),  # nested template args kept
+            ("void get<int>()", "get<int>"),  # return type dropped, args kept
+            ("std::ostream::operator<<(int)", "operator<<(int)"),  # operator kept whole
+            ("Widget::operator()(int)", "operator()(int)"),  # call operator
+            ("cooperator_v1", "cooperator_v1"),  # 'operator' substring, not keyword
+            ("myoperator::foo_v1()", "foo_v1"),  # 'operator' inside qualifier
+        ],
+    )
     def test_extraction(self, symbol: str, expected: str) -> None:
         assert _unqualified_name(symbol) == expected
 
-    @pytest.mark.parametrize("leaf,expected", [
-        ("get<int>", "get"),                 # simple template args
-        ("foo<bar<int>>", "foo"),            # nested template args
-        ("plain", "plain"),                  # no template args
-        ("a>", "a>"),                        # unbalanced '>' left as-is
-    ])
+    @pytest.mark.parametrize(
+        "leaf,expected",
+        [
+            ("get<int>", "get"),  # simple template args
+            ("foo<bar<int>>", "foo"),  # nested template args
+            ("plain", "plain"),  # no template args
+            ("a>", "a>"),  # unbalanced '>' left as-is
+        ],
+    )
     def test_strip_template_args(self, leaf: str, expected: str) -> None:
         assert _strip_template_args(leaf) == expected
 
@@ -445,12 +479,16 @@ class TestPlausibleRename:
     def test_same_scope_different_leaf_rejected(self) -> None:
         # Shared qualifier must not inflate the score: unrelated leaves under a
         # common scope (begin/end) are not a rename.
-        assert _plausible_rename(
-            "std::vector<int>::begin()", "std::vector<int>::end()"
-        ) is False
+        assert (
+            _plausible_rename("std::vector<int>::begin()", "std::vector<int>::end()")
+            is False
+        )
 
     def test_unrelated_rejected(self) -> None:
-        assert _plausible_rename("fixupIndexV4(X)", "SmallVectorImpl<X>::erase(X*)") is False
+        assert (
+            _plausible_rename("fixupIndexV4(X)", "SmallVectorImpl<X>::erase(X*)")
+            is False
+        )
 
     def test_same_scope_short_leaves_rejected(self) -> None:
         # get/set share only an incidental 2-char suffix once the qualifier is
@@ -490,12 +528,14 @@ class TestPlausibleRename:
         assert _plausible_rename("A::operator==(int)", "B::operator==(int)") is True
 
     def test_undemangleable_mangled_names_rejected(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # Force the no-demangler branch so the raw "_Z..." fallback is actually
         # exercised: without a demangler the leaf is the raw mangled spelling,
         # whose shared boilerplate must not be affix-scored into a false rename.
         import abicheck.demangle as demangle_mod
+
         monkeypatch.setattr(demangle_mod, "demangle", lambda _sym: None)
         assert _plausible_rename("_ZN1A3fooEv", "_ZN1B3barEv") is False
 
@@ -578,7 +618,7 @@ class TestPlausibleRename:
         assert _return_type_of("int foo<int>()") == "int"
         assert _return_type_of("unsigned int g<int>()") == "unsigned int"
         assert _return_type_of("std::vector<int> bar()") == "std::vector<int>"
-        assert _return_type_of("foo(int)") == ""           # ordinary function
+        assert _return_type_of("foo(int)") == ""  # ordinary function
         assert _return_type_of("ns::Class::method()") == ""
         assert _return_type_of("operator<<(int)") == ""
 
@@ -615,9 +655,10 @@ class TestPlausibleRename:
     def test_funcptr_return_rename_detected(self) -> None:
         # End-to-end: a versioned rename of a function-pointer-returning template
         # (foo_v1<int> -> foo_v2<int>) is a plausible rename, not removed/added.
-        assert _plausible_rename(
-            "int (*foo_v1<int>())()", "int (*foo_v2<int>())()"
-        ) is True
+        assert (
+            _plausible_rename("int (*foo_v1<int>())()", "int (*foo_v2<int>())()")
+            is True
+        )
 
     def test_same_variant_ctor_relocation_accepted(self) -> None:
         # A genuine constructor relocation to a new enclosing scope
@@ -630,12 +671,12 @@ class TestPlausibleRename:
     def test_ctor_dtor_variant_malformed_symbols_yield_none(self) -> None:
         # Defensive bail-outs: a malformed nested-name must never raise or
         # mis-report; it yields None (no suppression — the safe direction).
-        assert _ctor_dtor_variant("_ZN99FooC1Ev") is None     # length overruns
-        assert _ctor_dtor_variant("_ZN3FooIiC1Ev") is None    # template never closed
-        assert _ctor_dtor_variant("_ZN3FooI") is None         # truncated at 'I'
-        assert _ctor_dtor_variant("_ZN3FooILiC1Ev") is None   # L-literal never closed
-        assert _ctor_dtor_variant("_ZNK1A3fooEv") is None     # const member, not a ctor
-        assert _ctor_dtor_variant("not_mangled") is None      # not an _ZN name
+        assert _ctor_dtor_variant("_ZN99FooC1Ev") is None  # length overruns
+        assert _ctor_dtor_variant("_ZN3FooIiC1Ev") is None  # template never closed
+        assert _ctor_dtor_variant("_ZN3FooI") is None  # truncated at 'I'
+        assert _ctor_dtor_variant("_ZN3FooILiC1Ev") is None  # L-literal never closed
+        assert _ctor_dtor_variant("_ZNK1A3fooEv") is None  # const member, not a ctor
+        assert _ctor_dtor_variant("not_mangled") is None  # not an _ZN name
 
     def test_operator_substring_not_treated_as_operator(self) -> None:
         # Identifiers that merely contain 'operator' are ordinary names and
@@ -651,7 +692,9 @@ class TestPlausibleRename:
 
     def test_destructor_namespace_move_accepted(self) -> None:
         # The same destructor under a different scope is still a move.
-        assert _plausible_rename("ns::Widget::~Widget()", "ns2::Widget::~Widget()") is True
+        assert (
+            _plausible_rename("ns::Widget::~Widget()", "ns2::Widget::~Widget()") is True
+        )
 
     def test_plain_unqualified_names(self) -> None:
         # No '::', no template, no return type, no operator.
@@ -667,6 +710,7 @@ class TestPlausibleRename:
 # Detector integration tests (using compare())
 # ---------------------------------------------------------------------------
 
+
 class TestFingerprintRenameDetector:
     """Test the fingerprint_renames detector via the full compare() pipeline."""
 
@@ -681,10 +725,15 @@ class TestFingerprintRenameDetector:
         assert _fingerprints_from_elf(snap) == {}
 
     def test_fingerprints_from_elf_skips_non_function_symbols(self) -> None:
-        snap = _snap_elf_only("1.0", [
-            ElfSymbol(name="global_table", sym_type=SymbolType.OBJECT, size=_NORMAL_SIZE),
-            _func_sym("public_func", _NORMAL_SIZE),
-        ])
+        snap = _snap_elf_only(
+            "1.0",
+            [
+                ElfSymbol(
+                    name="global_table", sym_type=SymbolType.OBJECT, size=_NORMAL_SIZE
+                ),
+                _func_sym("public_func", _NORMAL_SIZE),
+            ],
+        )
 
         assert set(_fingerprints_from_elf(snap)) == {"public_func"}
 
@@ -694,7 +743,9 @@ class TestFingerprintRenameDetector:
         new = _snap_elf_only("2.0", [_func_sym("libfoo_create", 256)])
         result = compare(old, new)
 
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 1
         assert rename_changes[0].old_value == "libfoo_v1_create"
         assert rename_changes[0].new_value == "libfoo_create"
@@ -706,21 +757,37 @@ class TestFingerprintRenameDetector:
         regular diff pipeline while the fingerprint detector is disabled.
         """
         old = AbiSnapshot(
-            library="libtest.so.1", version="1.0",
-            functions=[Function(name="old_func", mangled="old_func",
-                                return_type="void", visibility=Visibility.PUBLIC)],
+            library="libtest.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="old_func",
+                    mangled="old_func",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
             elf=ElfMetadata(symbols=[_func_sym("old_func", 256)]),
             elf_only_mode=False,
         )
         new = AbiSnapshot(
-            library="libtest.so.1", version="2.0",
-            functions=[Function(name="new_func", mangled="new_func",
-                                return_type="void", visibility=Visibility.PUBLIC)],
+            library="libtest.so.1",
+            version="2.0",
+            functions=[
+                Function(
+                    name="new_func",
+                    mangled="new_func",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
             elf=ElfMetadata(symbols=[_func_sym("new_func", 256)]),
             elf_only_mode=False,
         )
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 0
         # Regular diff still fires
         kinds = {c.kind for c in result.changes}
@@ -730,19 +797,35 @@ class TestFingerprintRenameDetector:
     def test_not_triggered_without_elf_metadata(self) -> None:
         """Detector requires ELF metadata — disabled for PE/Mach-O."""
         old = AbiSnapshot(
-            library="libtest.so.1", version="1.0",
-            functions=[Function(name="old_func", mangled="old_func",
-                                return_type="void", visibility=Visibility.ELF_ONLY)],
+            library="libtest.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="old_func",
+                    mangled="old_func",
+                    return_type="void",
+                    visibility=Visibility.ELF_ONLY,
+                )
+            ],
             elf_only_mode=True,
         )
         new = AbiSnapshot(
-            library="libtest.so.1", version="2.0",
-            functions=[Function(name="new_func", mangled="new_func",
-                                return_type="void", visibility=Visibility.ELF_ONLY)],
+            library="libtest.so.1",
+            version="2.0",
+            functions=[
+                Function(
+                    name="new_func",
+                    mangled="new_func",
+                    return_type="void",
+                    visibility=Visibility.ELF_ONLY,
+                )
+            ],
             elf_only_mode=True,
         )
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 0
 
     def test_small_symbols_not_matched(self) -> None:
@@ -750,7 +833,9 @@ class TestFingerprintRenameDetector:
         old = _snap_elf_only("1.0", [_func_sym("stub_old", _TINY_SIZE)])
         new = _snap_elf_only("2.0", [_func_sym("stub_new", _TINY_SIZE)])
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 0
 
     def test_different_sizes_not_matched(self) -> None:
@@ -758,7 +843,9 @@ class TestFingerprintRenameDetector:
         old = _snap_elf_only("1.0", [_func_sym("func_old", _NORMAL_SIZE)])
         new = _snap_elf_only("2.0", [_func_sym("func_new", 200)])
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 0
 
     def test_multiple_renames_detected(self) -> None:
@@ -769,7 +856,9 @@ class TestFingerprintRenameDetector:
         new = _snap_elf_only("2.0", new_syms)
         result = compare(old, new)
 
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 2
         rename_pairs = {(c.old_value, c.new_value) for c in rename_changes}
         assert ("v1_init", "v2_init") in rename_pairs
@@ -782,7 +871,9 @@ class TestFingerprintRenameDetector:
         new = _snap_elf_only("2.0", [shared_sym, _func_sym("new_only", 128)])
         result = compare(old, new)
 
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 1
         assert rename_changes[0].old_value == "old_only"
         assert rename_changes[0].new_value == "new_only"
@@ -795,45 +886,69 @@ class TestFingerprintRenameDetector:
         the old implementation size. The old symbol must not be reported as a
         loader-breaking rename because existing binaries can still resolve it.
         """
-        old = _snap_elf_only("1.0", [
-            _func_sym("libssh2_session_callback_set", 185),
-        ])
-        new = _snap_elf_only("2.0", [
-            _func_sym("libssh2_session_callback_set", _TINY_SIZE),
-            _func_sym("libssh2_session_callback_set2", 185),
-        ])
+        old = _snap_elf_only(
+            "1.0",
+            [
+                _func_sym("libssh2_session_callback_set", 185),
+            ],
+        )
+        new = _snap_elf_only(
+            "2.0",
+            [
+                _func_sym("libssh2_session_callback_set", _TINY_SIZE),
+                _func_sym("libssh2_session_callback_set2", 185),
+            ],
+        )
         result = compare(old, new)
 
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert rename_changes == []
         kinds = {c.kind for c in result.changes}
         assert ChangeKind.FUNC_ADDED in kinds
 
     def test_retained_export_not_used_as_rename_target(self) -> None:
         """An unchanged exported function cannot be consumed as a rename target."""
-        old = _snap_elf_only("1.0", [
-            _func_sym("foo_v1", 128),
-            _func_sym("foo_v2", 128),
-        ])
-        new = _snap_elf_only("2.0", [
-            _func_sym("foo_v1", 128),
-        ])
+        old = _snap_elf_only(
+            "1.0",
+            [
+                _func_sym("foo_v1", 128),
+                _func_sym("foo_v2", 128),
+            ],
+        )
+        new = _snap_elf_only(
+            "2.0",
+            [
+                _func_sym("foo_v1", 128),
+            ],
+        )
         result = compare(old, new)
 
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert rename_changes == []
 
     def test_elf_linker_artifact_not_reported_as_rename(self) -> None:
         """Filtered linker artifacts must not participate in fingerprint renames."""
-        old = _snap_elf_only("1.0", [
-            _func_sym("_init", 128),
-        ])
-        new = _snap_elf_only("2.0", [
-            _func_sym("lib_init", 128),
-        ])
+        old = _snap_elf_only(
+            "1.0",
+            [
+                _func_sym("_init", 128),
+            ],
+        )
+        new = _snap_elf_only(
+            "2.0",
+            [
+                _func_sym("lib_init", 128),
+            ],
+        )
         result = compare(old, new)
 
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert rename_changes == []
 
     def test_unrelated_names_same_size_not_renamed(self) -> None:
@@ -845,29 +960,47 @@ class TestFingerprintRenameDetector:
         ``fixupIndexV4`` -> ``SmallVectorImpl<...>``) purely because they hit a
         unique size bucket. Without code-identity evidence, dissimilar names are
         a coincidence, not a rename."""
-        old = _snap_elf_only("1.0", [
-            _func_sym("_Z12fixupIndexV4RKN4llvm11DWARFObjectE", 256),
-        ])
-        new = _snap_elf_only("2.0", [
-            _func_sym("_ZN4llvm15SmallVectorImplINS_11CompileUnitEE5eraseEPS2_", 256),
-        ])
+        old = _snap_elf_only(
+            "1.0",
+            [
+                _func_sym("_Z12fixupIndexV4RKN4llvm11DWARFObjectE", 256),
+            ],
+        )
+        new = _snap_elf_only(
+            "2.0",
+            [
+                _func_sym(
+                    "_ZN4llvm15SmallVectorImplINS_11CompileUnitEE5eraseEPS2_", 256
+                ),
+            ],
+        )
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert rename_changes == []
 
     def test_collision_does_not_hide_plausible_rename(self) -> None:
         """A real rename in a crowded size bucket is still found even when an
         unrelated same-size symbol sorts earlier — the similarity check drives
         selection, so the unrelated symbol cannot consume the partner."""
-        old = _snap_elf_only("1.0", [
-            _func_sym("aaa_unrelated_function", 256),
-            _func_sym("foo_v1_dosomething", 256),
-        ])
-        new = _snap_elf_only("2.0", [
-            _func_sym("foo_v2_dosomething", 256),
-        ])
+        old = _snap_elf_only(
+            "1.0",
+            [
+                _func_sym("aaa_unrelated_function", 256),
+                _func_sym("foo_v1_dosomething", 256),
+            ],
+        )
+        new = _snap_elf_only(
+            "2.0",
+            [
+                _func_sym("foo_v2_dosomething", 256),
+            ],
+        )
         result = compare(old, new)
-        renames = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        renames = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(renames) == 1
         assert renames[0].old_value == "foo_v1_dosomething"
         assert renames[0].new_value == "foo_v2_dosomething"
@@ -878,14 +1011,25 @@ class TestFingerprintRenameDetector:
         demangled spellings so the test is independent of c++filt/cxxfilt
         availability (without a demangler, raw _Z names are treated
         conservatively and a real move can't be inferred — by design)."""
-        old = _snap_elf_only("1.0", [
-            _func_sym("llvm::CompileUnit::markEverythingAsKept()", 256),
-        ])
-        new = _snap_elf_only("2.0", [
-            _func_sym("llvm::dwarf_linker::classic::CompileUnit::markEverythingAsKept()", 256),
-        ])
+        old = _snap_elf_only(
+            "1.0",
+            [
+                _func_sym("llvm::CompileUnit::markEverythingAsKept()", 256),
+            ],
+        )
+        new = _snap_elf_only(
+            "2.0",
+            [
+                _func_sym(
+                    "llvm::dwarf_linker::classic::CompileUnit::markEverythingAsKept()",
+                    256,
+                ),
+            ],
+        )
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 1
 
     def test_fuzzy_match_appears_in_compare_output(self) -> None:
@@ -893,38 +1037,55 @@ class TestFingerprintRenameDetector:
         old = _snap_elf_only("1.0", [_func_sym("old_func", _NORMAL_SIZE)])
         new = _snap_elf_only("2.0", [_func_sym("new_func", 104)])  # 4% diff
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 1
         assert "50%" in rename_changes[0].description
 
     def test_fires_when_only_new_is_elf_only(self) -> None:
         """Detector fires when only the *new* snapshot is elf_only_mode."""
         old = AbiSnapshot(
-            library="libtest.so.1", version="1.0",
-            functions=[Function(name="old_func", mangled="old_func",
-                                return_type="void", visibility=Visibility.ELF_ONLY)],
+            library="libtest.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="old_func",
+                    mangled="old_func",
+                    return_type="void",
+                    visibility=Visibility.ELF_ONLY,
+                )
+            ],
             elf=ElfMetadata(symbols=[_func_sym("old_func", 256)]),
             elf_only_mode=False,
         )
         new = _snap_elf_only("2.0", [_func_sym("new_func", 256)])
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 1
 
     def test_notype_symbols_included(self) -> None:
         """NOTYPE symbols (assembly-heavy or stripped) participate in rename matching."""
         notype_old = ElfSymbol(
-            name="asm_func_old", binding=SymbolBinding.GLOBAL,
-            sym_type=SymbolType.NOTYPE, size=256,
+            name="asm_func_old",
+            binding=SymbolBinding.GLOBAL,
+            sym_type=SymbolType.NOTYPE,
+            size=256,
         )
         notype_new = ElfSymbol(
-            name="asm_func_new", binding=SymbolBinding.GLOBAL,
-            sym_type=SymbolType.NOTYPE, size=256,
+            name="asm_func_new",
+            binding=SymbolBinding.GLOBAL,
+            sym_type=SymbolType.NOTYPE,
+            size=256,
         )
         old = _snap_elf_only("1.0", [notype_old])
         new = _snap_elf_only("2.0", [notype_new])
         result = compare(old, new)
-        rename_changes = [c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED]
+        rename_changes = [
+            c for c in result.changes if c.kind == ChangeKind.FUNC_LIKELY_RENAMED
+        ]
         assert len(rename_changes) == 1
         assert rename_changes[0].old_value == "asm_func_old"
         assert rename_changes[0].new_value == "asm_func_new"
@@ -944,7 +1105,10 @@ class TestFingerprintRenameDetector:
         assert ChangeKind.FUNC_ADDED not in kept_kinds
         # The suppressed changes should appear in redundant_changes
         redundant_kinds = {c.kind for c in result.redundant_changes}
-        assert ChangeKind.FUNC_REMOVED_ELF_ONLY in redundant_kinds or ChangeKind.FUNC_REMOVED in redundant_kinds
+        assert (
+            ChangeKind.FUNC_REMOVED_ELF_ONLY in redundant_kinds
+            or ChangeKind.FUNC_REMOVED in redundant_kinds
+        )
 
     def test_pass1_ambiguous_exact_match_skipped(self) -> None:
         """Pass 1: multiple new symbols with same hash+size → no 1.0 confidence match."""
@@ -957,3 +1121,267 @@ class TestFingerprintRenameDetector:
         # No exact match due to ambiguity; may fall through to pass 2 or 3
         exact = [r for r in result if r.confidence == 1.0]
         assert len(exact) == 0
+
+
+# ---------------------------------------------------------------------------
+# Internal ELF-parsing helpers (mocked pyelftools — no real binaries needed)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from elftools.elf.sections import SymbolTableSection  # noqa: E402
+
+from abicheck.binary_fingerprint import (  # noqa: E402
+    _compute_code_hash,
+    _extract_fingerprints,
+    _extract_section_summary,
+)
+
+
+def _make_sym(
+    name,
+    *,
+    typ="STT_FUNC",
+    shndx=1,
+    bind="STB_GLOBAL",
+    vis="STV_DEFAULT",
+    size=_NORMAL_SIZE,
+    value=0x1000,
+):
+    sym = MagicMock()
+    sym.name = name
+    sym.entry.st_info.type = typ
+    sym.entry.st_shndx = shndx
+    sym.entry.st_info.bind = bind
+    sym.entry.st_other.visibility = vis
+    sym.entry.st_size = size
+    sym.entry.st_value = value
+    return sym
+
+
+def _make_dynsym(symbols):
+    section = MagicMock(spec=SymbolTableSection)
+    section.name = ".dynsym"
+    section.iter_symbols.return_value = symbols
+    return section
+
+
+class TestExtractFingerprints:
+    def test_no_dynsym_returns_empty(self) -> None:
+        elf = MagicMock()
+        other = MagicMock(spec=SymbolTableSection)
+        other.name = ".symtab"  # not .dynsym
+        elf.iter_sections.return_value = [other]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            assert _extract_fingerprints(MagicMock(), object()) == {}
+
+    def test_exported_func_collected(self) -> None:
+        elf = MagicMock()
+        elf.iter_sections.return_value = [_make_dynsym([_make_sym("foo")])]
+        # No code hash: get_section returns a NOBITS section
+        sec = MagicMock()
+        sec.header.sh_type = "SHT_NOBITS"
+        elf.get_section.return_value = sec
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            result = _extract_fingerprints(MagicMock(), object())
+        assert "foo" in result
+        assert result["foo"].size == _NORMAL_SIZE
+        assert result["foo"].code_hash == ""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"typ": "STT_OBJECT"},  # not a FUNC
+            {"shndx": "SHN_UNDEF"},  # undefined
+            {"shndx": "SHN_ABS"},  # absolute
+            {"bind": "STB_LOCAL"},  # local binding
+            {"vis": "STV_HIDDEN"},  # hidden
+            {"vis": "STV_INTERNAL"},  # internal
+            {"size": _TINY_SIZE},  # below min size
+        ],
+    )
+    def test_filtered_symbols(self, kwargs) -> None:
+        elf = MagicMock()
+        elf.iter_sections.return_value = [_make_dynsym([_make_sym("x", **kwargs)])]
+        sec = MagicMock()
+        sec.header.sh_type = "SHT_NOBITS"
+        elf.get_section.return_value = sec
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            assert _extract_fingerprints(MagicMock(), object()) == {}
+
+    def test_empty_name_skipped(self) -> None:
+        elf = MagicMock()
+        elf.iter_sections.return_value = [_make_dynsym([_make_sym("")])]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            assert _extract_fingerprints(MagicMock(), object()) == {}
+
+    def test_string_shndx_section_index_zero(self) -> None:
+        elf = MagicMock()
+        elf.iter_sections.return_value = [
+            _make_dynsym([_make_sym("foo", shndx="SHN_COMMON")])
+        ]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            result = _extract_fingerprints(MagicMock(), object())
+        # SHN_COMMON is not UNDEF/ABS so it passes the filter; shndx is a string
+        assert result["foo"].section_index == 0
+        assert result["foo"].code_hash == ""  # non-int shndx → no hash
+
+
+class TestComputeCodeHash:
+    def test_non_int_shndx_returns_empty(self) -> None:
+        assert _compute_code_hash(MagicMock(), MagicMock(), "SHN_ABS", {}) == ""
+
+    def test_nobits_section_returns_empty(self) -> None:
+        elf = MagicMock()
+        sec = MagicMock()
+        sec.header.sh_type = "SHT_NOBITS"
+        elf.get_section.return_value = sec
+        assert _compute_code_hash(elf, _make_sym("x"), 1, {}) == ""
+
+    def test_section_too_large_returns_empty(self) -> None:
+        from abicheck.binary_fingerprint import _MAX_SECTION_SIZE
+
+        elf = MagicMock()
+        sec = MagicMock()
+        sec.name = ".text"
+        sec.header.sh_type = "SHT_PROGBITS"
+        sec.header.sh_size = _MAX_SECTION_SIZE + 1
+        elf.get_section.return_value = sec
+        assert _compute_code_hash(elf, _make_sym("x"), 1, {}) == ""
+
+    def test_valid_code_hash(self) -> None:
+        import hashlib
+
+        elf = MagicMock()
+        sec = MagicMock()
+        sec.name = ".text"
+        sec.header.sh_type = "SHT_PROGBITS"
+        sec.header.sh_size = 256
+        sec.header.sh_addr = 0x1000
+        sec.data.return_value = b"\xaa" * 256
+        elf.get_section.return_value = sec
+        sym = _make_sym("foo", value=0x1010, size=16)
+        result = _compute_code_hash(elf, sym, 1, {})
+        expected = hashlib.sha256(b"\xaa" * 16).hexdigest()
+        assert result == expected
+
+    def test_offset_out_of_bounds_returns_empty(self) -> None:
+        elf = MagicMock()
+        sec = MagicMock()
+        sec.name = ".text"
+        sec.header.sh_type = "SHT_PROGBITS"
+        sec.header.sh_size = 16
+        sec.header.sh_addr = 0x1000
+        sec.data.return_value = b"\x00" * 16
+        elf.get_section.return_value = sec
+        # symbol before section start → negative offset
+        sym = _make_sym("foo", value=0x0, size=16)
+        assert _compute_code_hash(elf, sym, 1, {}) == ""
+
+    def test_uses_section_cache(self) -> None:
+        import hashlib
+
+        elf = MagicMock()
+        cache = {1: (0x1000, 256, b"\xbb" * 256)}
+        sym = _make_sym("foo", value=0x1000, size=8)
+        result = _compute_code_hash(elf, sym, 1, cache)
+        assert result == hashlib.sha256(b"\xbb" * 8).hexdigest()
+        elf.get_section.assert_not_called()
+
+    def test_exception_returns_empty(self) -> None:
+        elf = MagicMock()
+        elf.get_section.side_effect = IndexError("bad index")
+        assert _compute_code_hash(elf, _make_sym("x"), 99, {}) == ""
+
+
+class TestExtractSectionSummary:
+    def _section(self, name, *, sh_type="SHT_PROGBITS", sh_size=64, data=b"\x01" * 64):
+        sec = MagicMock()
+        sec.name = name
+        sec.header.sh_type = sh_type
+        sec.header.sh_size = sh_size
+        sec.data.return_value = data
+        return sec
+
+    def test_collects_abi_sections(self) -> None:
+        import hashlib
+
+        elf = MagicMock()
+        elf.iter_sections.return_value = [
+            self._section(".text"),
+            self._section(".note.foo"),  # ignored — not ABI relevant
+        ]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            summary = _extract_section_summary(MagicMock())
+        assert ".text" in summary.sections
+        assert ".note.foo" not in summary.sections
+        assert (
+            summary.sections[".text"].content_hash
+            == hashlib.sha256(b"\x01" * 64).hexdigest()
+        )
+
+    def test_bss_uses_empty_hash(self) -> None:
+        from abicheck.binary_fingerprint import _EMPTY_HASH
+
+        elf = MagicMock()
+        elf.iter_sections.return_value = [
+            self._section(".bss", sh_type="SHT_NOBITS", sh_size=128),
+        ]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            summary = _extract_section_summary(MagicMock())
+        assert summary.sections[".bss"].content_hash == _EMPTY_HASH
+        assert summary.sections[".bss"].size == 128
+
+    def test_oversize_section_skipped(self) -> None:
+        from abicheck.binary_fingerprint import _MAX_SECTION_SIZE
+
+        elf = MagicMock()
+        elf.iter_sections.return_value = [
+            self._section(".data", sh_size=_MAX_SECTION_SIZE + 1),
+        ]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            summary = _extract_section_summary(MagicMock())
+        assert ".data" not in summary.sections
+
+    def test_unreadable_section_skipped(self) -> None:
+        elf = MagicMock()
+        sec = self._section(".rodata")
+        sec.data.side_effect = ValueError("cannot read")
+        elf.iter_sections.return_value = [sec]
+        with patch("abicheck.binary_fingerprint.ELFFile", return_value=elf):
+            summary = _extract_section_summary(MagicMock())
+        assert ".rodata" not in summary.sections
+
+
+class TestPublicFunctionsNonRegularFile:
+    def test_fingerprints_char_device_returns_empty(self) -> None:
+        # /dev/null is a character device — not a regular file (TOCTOU guard).
+        if not os.path.exists("/dev/null"):
+            pytest.skip("/dev/null not available")
+        assert compute_function_fingerprints("/dev/null") == {}
+
+    def test_section_summary_char_device_returns_empty(self) -> None:
+        if not os.path.exists("/dev/null"):
+            pytest.skip("/dev/null not available")
+        assert compute_section_summary("/dev/null").sections == {}
+
+    def test_section_summary_truncated_elf_returns_empty(
+        self, tmp_path: object
+    ) -> None:
+        p = os.path.join(str(tmp_path), "trunc.so")
+        with open(p, "wb") as f:
+            f.write(b"\x7fELF")
+        assert compute_section_summary(p).sections == {}
+
+    def test_section_summary_success_path(self, tmp_path: object) -> None:
+        # ELF magic so the seek/extract path runs; patch the extractor.
+        p = os.path.join(str(tmp_path), "ok.so")
+        with open(p, "wb") as f:
+            f.write(b"\x7fELF" + b"\x00" * 60)
+        sentinel = BinarySummary(sections={".text": SectionSummary(".text", 1, "h")})
+        with patch(
+            "abicheck.binary_fingerprint._extract_section_summary",
+            return_value=sentinel,
+        ):
+            result = compute_section_summary(p)
+        assert result is sentinel

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -6,14 +6,22 @@ Integration tests that use real ELF binaries are marked @pytest.mark.integration
 
 from __future__ import annotations
 
+import hashlib
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
+from elftools.elf.sections import SymbolTableSection
 
 from abicheck.binary_fingerprint import (
+    _EMPTY_HASH,
+    _MAX_SECTION_SIZE,
     BinarySummary,
     FunctionFingerprint,
     SectionSummary,
+    _compute_code_hash,
+    _extract_fingerprints,
+    _extract_section_summary,
     compute_function_fingerprints,
     compute_section_summary,
     match_renamed_functions,
@@ -1127,16 +1135,6 @@ class TestFingerprintRenameDetector:
 # Internal ELF-parsing helpers (mocked pyelftools — no real binaries needed)
 # ---------------------------------------------------------------------------
 
-from unittest.mock import MagicMock, patch  # noqa: E402
-
-from elftools.elf.sections import SymbolTableSection  # noqa: E402
-
-from abicheck.binary_fingerprint import (  # noqa: E402
-    _compute_code_hash,
-    _extract_fingerprints,
-    _extract_section_summary,
-)
-
 
 def _make_sym(
     name,
@@ -1239,7 +1237,6 @@ class TestComputeCodeHash:
         assert _compute_code_hash(elf, _make_sym("x"), 1, {}) == ""
 
     def test_section_too_large_returns_empty(self) -> None:
-        from abicheck.binary_fingerprint import _MAX_SECTION_SIZE
 
         elf = MagicMock()
         sec = MagicMock()
@@ -1250,7 +1247,6 @@ class TestComputeCodeHash:
         assert _compute_code_hash(elf, _make_sym("x"), 1, {}) == ""
 
     def test_valid_code_hash(self) -> None:
-        import hashlib
 
         elf = MagicMock()
         sec = MagicMock()
@@ -1279,7 +1275,6 @@ class TestComputeCodeHash:
         assert _compute_code_hash(elf, sym, 1, {}) == ""
 
     def test_uses_section_cache(self) -> None:
-        import hashlib
 
         elf = MagicMock()
         cache = {1: (0x1000, 256, b"\xbb" * 256)}
@@ -1304,7 +1299,6 @@ class TestExtractSectionSummary:
         return sec
 
     def test_collects_abi_sections(self) -> None:
-        import hashlib
 
         elf = MagicMock()
         elf.iter_sections.return_value = [
@@ -1321,7 +1315,6 @@ class TestExtractSectionSummary:
         )
 
     def test_bss_uses_empty_hash(self) -> None:
-        from abicheck.binary_fingerprint import _EMPTY_HASH
 
         elf = MagicMock()
         elf.iter_sections.return_value = [
@@ -1333,7 +1326,6 @@ class TestExtractSectionSummary:
         assert summary.sections[".bss"].size == 128
 
     def test_oversize_section_skipped(self) -> None:
-        from abicheck.binary_fingerprint import _MAX_SECTION_SIZE
 
         elf = MagicMock()
         elf.iter_sections.return_value = [

--- a/tests/test_ctf_metadata.py
+++ b/tests/test_ctf_metadata.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for CTF (Compact C Type Format) parser."""
+
 from __future__ import annotations
 
 import struct
@@ -52,6 +53,7 @@ from abicheck.ctf_metadata import (
 # Helpers to build synthetic CTF v3 blobs
 # ---------------------------------------------------------------------------
 
+
 class CtfBuilder:
     """Helper to construct synthetic CTF v3 binary blobs for testing."""
 
@@ -68,8 +70,15 @@ class CtfBuilder:
         self._str_offsets[s] = off
         return off
 
-    def add_type(self, name: str, kind: int, vlen: int, size_or_type: int,
-                 extra: bytes = b"", isroot: bool = False) -> int:
+    def add_type(
+        self,
+        name: str,
+        kind: int,
+        vlen: int,
+        size_or_type: int,
+        extra: bytes = b"",
+        isroot: bool = False,
+    ) -> int:
         """Add a CTF v3 type entry, return its 1-based type ID."""
         name_off = self.add_string(name) if name else 0
         # v3 info: isroot(1) + kind(5) in upper byte, vlen(16) in lower
@@ -93,15 +102,17 @@ class CtfBuilder:
         flags = CTF_F_COMPRESS if compress else 0
 
         header = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, flags)
-        header += struct.pack("<IIIIIIII",
-                              0,  # parent_label
-                              0,  # parent_name
-                              label_off,
-                              object_off,
-                              func_off,
-                              type_off,
-                              str_off,
-                              str_len)
+        header += struct.pack(
+            "<IIIIIIII",
+            0,  # parent_label
+            0,  # parent_name
+            label_off,
+            object_off,
+            func_off,
+            type_off,
+            str_off,
+            str_len,
+        )
 
         body = type_data + str_data
 
@@ -119,6 +130,7 @@ class CtfBuilder:
 # String table
 # ---------------------------------------------------------------------------
 
+
 class TestReadString:
     def test_basic(self) -> None:
         data = b"hello\x00world\x00"
@@ -135,6 +147,7 @@ class TestReadString:
 # ---------------------------------------------------------------------------
 # Header parsing
 # ---------------------------------------------------------------------------
+
 
 class TestParseHeader:
     def test_valid_header(self) -> None:
@@ -158,6 +171,7 @@ class TestParseHeader:
 # Full parse: structs
 # ---------------------------------------------------------------------------
 
+
 class TestCtfStructs:
     def test_simple_struct(self) -> None:
         b = CtfBuilder()
@@ -169,8 +183,8 @@ class TestCtfStructs:
         # v3 small struct member: name_off(4) + packed(type<<16 | bit_offset)(4)
         m1_name = b.add_string("x")
         m2_name = b.add_string("y")
-        members = struct.pack("<II", m1_name, (1 << 16) | 0)     # type=1, offset=0
-        members += struct.pack("<II", m2_name, (1 << 16) | 32)   # type=1, offset=32
+        members = struct.pack("<II", m1_name, (1 << 16) | 0)  # type=1, offset=0
+        members += struct.pack("<II", m2_name, (1 << 16) | 32)  # type=1, offset=32
         b.add_type("point", CTF_K_STRUCT, 2, 8, extra=members)
 
         meta = parse_ctf_from_bytes(b.build())
@@ -212,6 +226,7 @@ class TestCtfStructs:
 # Full parse: enums
 # ---------------------------------------------------------------------------
 
+
 class TestCtfEnums:
     def test_simple_enum(self) -> None:
         b = CtfBuilder()
@@ -243,6 +258,7 @@ class TestCtfEnums:
 # Full parse: typedefs
 # ---------------------------------------------------------------------------
 
+
 class TestCtfTypedefs:
     def test_typedef(self) -> None:
         b = CtfBuilder()
@@ -257,6 +273,7 @@ class TestCtfTypedefs:
 # ---------------------------------------------------------------------------
 # Compression
 # ---------------------------------------------------------------------------
+
 
 class TestCtfCompression:
     def test_compressed_ctf(self) -> None:
@@ -278,6 +295,7 @@ class TestCtfCompression:
 # to_dwarf_metadata conversion
 # ---------------------------------------------------------------------------
 
+
 class TestToDwarfMetadata:
     def test_conversion(self) -> None:
         b = CtfBuilder()
@@ -298,6 +316,7 @@ class TestToDwarfMetadata:
 # Error handling / graceful degradation
 # ---------------------------------------------------------------------------
 
+
 class TestCtfErrorHandling:
     def test_empty_data(self) -> None:
         meta = parse_ctf_from_bytes(b"")
@@ -311,6 +330,7 @@ class TestCtfErrorHandling:
 # ---------------------------------------------------------------------------
 # TypeMetadataSource protocol
 # ---------------------------------------------------------------------------
+
 
 class TestTypeMetadataSourceProtocol:
     def test_protocol_methods(self) -> None:
@@ -335,6 +355,7 @@ class TestTypeMetadataSourceProtocol:
 
     def test_isinstance_check(self) -> None:
         from abicheck.type_metadata import TypeMetadataSource
+
         meta = CtfMetadata(has_ctf=True)
         assert isinstance(meta, TypeMetadataSource)
 
@@ -342,6 +363,7 @@ class TestTypeMetadataSourceProtocol:
 # ---------------------------------------------------------------------------
 # CtfMetadata accessor methods
 # ---------------------------------------------------------------------------
+
 
 class TestCtfMetadataAccessors:
     def test_get_function_proto(self) -> None:
@@ -362,7 +384,13 @@ class TestCtfMetadataAccessors:
 
     def test_isroot_property(self) -> None:
         from abicheck.ctf_metadata import CtfType
-        t = CtfType(type_id=1, name_off=0, info=(1 << 31) | (CTF_K_INTEGER << 24), size_or_type=4)
+
+        t = CtfType(
+            type_id=1,
+            name_off=0,
+            info=(1 << 31) | (CTF_K_INTEGER << 24),
+            size_or_type=4,
+        )
         assert t.isroot is True
         t2 = CtfType(type_id=2, name_off=0, info=(CTF_K_INTEGER << 24), size_or_type=4)
         assert t2.isroot is False
@@ -371,6 +399,7 @@ class TestCtfMetadataAccessors:
 # ---------------------------------------------------------------------------
 # Parse info functions
 # ---------------------------------------------------------------------------
+
 
 class TestParseInfo:
     def test_parse_info_v2(self) -> None:
@@ -393,6 +422,7 @@ class TestParseInfo:
 # ---------------------------------------------------------------------------
 # _extra_data_size coverage
 # ---------------------------------------------------------------------------
+
 
 class TestCtfExtraDataSize:
     def test_integer(self) -> None:
@@ -455,13 +485,23 @@ class TestCtfExtraDataSize:
 # Decompression
 # ---------------------------------------------------------------------------
 
+
 class TestDecompression:
     def test_decompress_not_needed(self) -> None:
         from abicheck.ctf_metadata import CtfHeader
+
         hdr = CtfHeader(
-            magic=CTF_MAGIC, version=CTF_VERSION_3, flags=0,
-            parent_label=0, parent_name=0, label_off=0, object_off=0,
-            func_off=0, type_off=0, str_off=0, str_len=0,
+            magic=CTF_MAGIC,
+            version=CTF_VERSION_3,
+            flags=0,
+            parent_label=0,
+            parent_name=0,
+            label_off=0,
+            object_off=0,
+            func_off=0,
+            type_off=0,
+            str_off=0,
+            str_len=0,
         )
         data = b"some data"
         result = _decompress_if_needed(data, hdr)
@@ -470,10 +510,19 @@ class TestDecompression:
     def test_decompress_exceeds_size_limit(self) -> None:
         """Zip bomb guard: decompression must fail when output exceeds 256 MiB."""
         from abicheck.ctf_metadata import CtfHeader
+
         hdr = CtfHeader(
-            magic=CTF_MAGIC, version=CTF_VERSION_3, flags=CTF_F_COMPRESS,
-            parent_label=0, parent_name=0, label_off=0, object_off=0,
-            func_off=0, type_off=0, str_off=0, str_len=0,
+            magic=CTF_MAGIC,
+            version=CTF_VERSION_3,
+            flags=CTF_F_COMPRESS,
+            parent_label=0,
+            parent_name=0,
+            label_off=0,
+            object_off=0,
+            func_off=0,
+            type_off=0,
+            str_off=0,
+            str_len=0,
         )
         # Build a zlib-compressed blob of zeros that decompresses to ~300 MiB.
         # Zeros compress extremely well, so the compressed payload is tiny.
@@ -486,13 +535,24 @@ class TestDecompression:
 
     def test_decompress_bad_data(self) -> None:
         from abicheck.ctf_metadata import CtfHeader
+
         hdr = CtfHeader(
-            magic=CTF_MAGIC, version=CTF_VERSION_3, flags=CTF_F_COMPRESS,
-            parent_label=0, parent_name=0, label_off=0, object_off=0,
-            func_off=0, type_off=0, str_off=0, str_len=0,
+            magic=CTF_MAGIC,
+            version=CTF_VERSION_3,
+            flags=CTF_F_COMPRESS,
+            parent_label=0,
+            parent_name=0,
+            label_off=0,
+            object_off=0,
+            func_off=0,
+            type_off=0,
+            str_off=0,
+            str_len=0,
         )
         # Preamble + garbage (not valid zlib)
-        data = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, CTF_F_COMPRESS) + b"garbage"
+        data = (
+            struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, CTF_F_COMPRESS) + b"garbage"
+        )
         with pytest.raises(ValueError, match="decompression failed"):
             _decompress_if_needed(data, hdr)
 
@@ -500,6 +560,7 @@ class TestDecompression:
 # ---------------------------------------------------------------------------
 # Type resolver extended coverage
 # ---------------------------------------------------------------------------
+
 
 class TestCtfTypeResolverExtended:
     def test_pointer_name(self) -> None:
@@ -509,7 +570,7 @@ class TestCtfTypeResolverExtended:
         # Pointer: size_or_type = type id of pointee
         # In v3, info = kind << 24
         name_off = 0
-        info = (CTF_K_POINTER << 24)
+        info = CTF_K_POINTER << 24
         entry = struct.pack("<III", name_off, info, 1)  # points to int (id=1)
         b._type_entries.append(entry)
 
@@ -578,6 +639,7 @@ class TestCtfTypeResolverExtended:
 # Header edge cases
 # ---------------------------------------------------------------------------
 
+
 class TestCtfHeaderExtended:
     def test_unsupported_version(self) -> None:
         data = struct.pack("<HBB", CTF_MAGIC, 99, 0) + b"\x00" * 40
@@ -602,6 +664,7 @@ class TestCtfHeaderExtended:
 # ---------------------------------------------------------------------------
 # CTF error/edge cases
 # ---------------------------------------------------------------------------
+
 
 class TestCtfEdgeCases:
     def test_anonymous_enum_skipped(self) -> None:
@@ -673,6 +736,7 @@ class TestCtfEdgeCases:
 # ---------------------------------------------------------------------------
 # Resolver coverage through struct member type resolution
 # ---------------------------------------------------------------------------
+
 
 class TestCtfResolverThroughExtraction:
     """Test resolver name/size paths by creating structs with typed members."""
@@ -951,3 +1015,350 @@ class TestCtfResolverThroughExtraction:
 
         meta = parse_ctf_from_bytes(b.build())
         assert meta.structs["s"].fields[0].byte_size == 12
+
+
+# ---------------------------------------------------------------------------
+# CTF v2 format coverage (v2 builder + direct parser tests)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from abicheck.ctf_metadata import (  # noqa: E402
+    _CTF_V2_LSTRUCT_THRESH,
+    CtfType,
+    _parse_types,
+    _read_ctf_section,
+    parse_ctf_metadata,
+)
+
+
+class CtfV2Builder:
+    """Helper to construct synthetic CTF *v2* binary blobs for testing."""
+
+    def __init__(self) -> None:
+        self._strings = bytearray(b"\x00")
+        self._type_entries: list[bytes] = []
+        self._str_offsets: dict[str, int] = {"": 0}
+
+    def add_string(self, s: str) -> int:
+        if s in self._str_offsets:
+            return self._str_offsets[s]
+        off = len(self._strings)
+        self._strings.extend(s.encode("utf-8") + b"\x00")
+        self._str_offsets[s] = off
+        return off
+
+    def add_type(
+        self,
+        name: str,
+        kind: int,
+        vlen: int,
+        size_or_type: int,
+        extra: bytes = b"",
+        isroot: bool = False,
+    ) -> int:
+        name_off = self.add_string(name) if name else 0
+        # v2 info: kind(5) << 11 | isroot << 10 | vlen(10)
+        info = (kind << 11) | (int(isroot) << 10) | (vlen & 0x3FF)
+        entry = struct.pack("<I", name_off) + struct.pack("<H", info)
+        if (
+            kind in (CTF_K_STRUCT, CTF_K_UNION)
+            and size_or_type >= _CTF_V2_LSTRUCT_THRESH
+        ):
+            # short marker >= threshold, followed by real 4-byte size
+            entry += struct.pack("<H", _CTF_V2_LSTRUCT_THRESH) + struct.pack(
+                "<I", size_or_type
+            )
+        else:
+            entry += struct.pack("<H", size_or_type)
+        entry += extra
+        self._type_entries.append(entry)
+        return len(self._type_entries)
+
+    def build(self) -> bytes:
+        type_data = b"".join(self._type_entries)
+        str_data = bytes(self._strings)
+        header = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_2, 0)
+        header += struct.pack(
+            "<IIIIIIII", 0, 0, 0, 0, 0, 0, len(type_data), len(str_data)
+        )
+        return header + type_data + str_data
+
+
+class TestCtfV2Parsing:
+    def test_v2_integer(self) -> None:
+        b = CtfV2Builder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        meta = parse_ctf_from_bytes(b.build())
+        assert meta.has_ctf
+        assert meta.type_count == 1
+
+    def test_v2_small_struct(self) -> None:
+        b = CtfV2Builder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        m_name = b.add_string("x")
+        # v2 small member: name(2) + off_val(2); type in bits 10-15, offset bits 0-9
+        m_off_val = (1 << 10) | 0  # type=1, offset=0
+        members = struct.pack("<HH", m_name, m_off_val)
+        b.add_type("S", CTF_K_STRUCT, 1, 4, extra=members)
+        meta = parse_ctf_from_bytes(b.build())
+        assert "S" in meta.structs
+        assert meta.structs["S"].fields[0].name == "x"
+
+    def test_v2_large_struct(self) -> None:
+        b = CtfV2Builder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        m_name = b.add_string("y")
+        # v2 large member: name(2) + type(2) + off_hi(2) + off_lo(2)
+        members = struct.pack("<HHHH", m_name, 1, 0, 0)
+        b.add_type("Big", CTF_K_STRUCT, 1, 0x2000, extra=members)
+        meta = parse_ctf_from_bytes(b.build())
+        assert "Big" in meta.structs
+        assert meta.structs["Big"].fields[0].name == "y"
+
+    def test_v2_array_name_and_size(self) -> None:
+        b = CtfV2Builder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        # v2 array extra: contents(2) + index(2) + nelems(2)
+        array_extra = struct.pack("<HHH", 1, 1, 4)
+        b.add_type("", CTF_K_ARRAY, 0, 0, extra=array_extra)
+        m_name = b.add_string("arr")
+        members = struct.pack("<HH", m_name, (2 << 10) | 0)  # type=2 (array)
+        b.add_type("Holder", CTF_K_STRUCT, 1, 16, extra=members)
+        meta = parse_ctf_from_bytes(b.build())
+        fld = meta.structs["Holder"].fields[0]
+        assert fld.type_name == "int[4]"
+        assert fld.byte_size == 16  # 4 ints * 4 bytes
+
+
+class TestParseTypesTruncation:
+    def test_v3_truncated_header_breaks(self) -> None:
+        # Fewer than 12 bytes → loop breaks immediately.
+        assert _parse_types(b"\x00" * 8, CTF_VERSION_3) == [
+            CtfType(type_id=0, name_off=0, info=0, size_or_type=0)
+        ]
+
+    def test_v2_truncated_header_breaks(self) -> None:
+        # Fewer than 6 bytes → loop breaks immediately.
+        result = _parse_types(b"\x00" * 4, CTF_VERSION_2)
+        assert len(result) == 1  # only the null type
+
+    def test_v2_truncated_size_field_breaks(self) -> None:
+        # name(4) + info(2) present, but no room for size_or_type short.
+        data = struct.pack("<I", 0) + struct.pack("<H", (CTF_K_POINTER << 11))
+        result = _parse_types(data, CTF_VERSION_2)
+        assert len(result) == 1
+
+    def test_v3_truncated_extra_breaks(self) -> None:
+        # A v3 integer claims 4 bytes of extra but none are present.
+        info = CTF_K_INTEGER << 24
+        data = struct.pack("<III", 0, info, 4)  # no extra encoding word follows
+        result = _parse_types(data, CTF_VERSION_3)
+        assert len(result) == 1  # type truncated → skipped
+
+
+class TestResolverEdgeCases:
+    def test_integer_missing_encoding_size_zero(self) -> None:
+        from abicheck.ctf_metadata import _TypeResolver
+
+        # Integer type with no extra encoding word → size resolves to 0.
+        t = CtfType(
+            type_id=1, name_off=0, info=(CTF_K_INTEGER << 24), size_or_type=4, extra=b""
+        )
+        resolver = _TypeResolver([CtfType(0, 0, 0, 0), t], b"\x00", CTF_VERSION_3)
+        assert resolver.size(1) == 0
+
+    def test_float_missing_encoding_size_zero(self) -> None:
+        from abicheck.ctf_metadata import _TypeResolver
+
+        t = CtfType(
+            type_id=1, name_off=0, info=(CTF_K_FLOAT << 24), size_or_type=4, extra=b""
+        )
+        resolver = _TypeResolver([CtfType(0, 0, 0, 0), t], b"\x00", CTF_VERSION_3)
+        assert resolver.size(1) == 0
+
+    def test_array_v2_short_extra_size_zero(self) -> None:
+        from abicheck.ctf_metadata import _TypeResolver
+
+        # v2 array with too-short extra → size guard returns 0.
+        t = CtfType(
+            type_id=1, name_off=0, info=(CTF_K_ARRAY << 24), size_or_type=0, extra=b""
+        )
+        resolver = _TypeResolver([CtfType(0, 0, 0, 0), t], b"\x00", CTF_VERSION_2)
+        assert resolver.size(1) == 0
+
+    def test_cyclic_name_resolution(self) -> None:
+        # Build a typedef that points to itself → name resolution must not recurse forever.
+        from abicheck.ctf_metadata import _TypeResolver
+
+        # type 1 is a typedef whose target is itself (id 1).
+        t1 = CtfType(type_id=1, name_off=0, info=(CTF_K_TYPEDEF << 24), size_or_type=1)
+        resolver = _TypeResolver([CtfType(0, 0, 0, 0), t1], b"\x00", CTF_VERSION_3)
+        # Recursion guard returns "..." when re-entered.
+        assert resolver.name(1) is not None
+
+    def test_cyclic_size_resolution(self) -> None:
+        from abicheck.ctf_metadata import _TypeResolver
+
+        t1 = CtfType(type_id=1, name_off=0, info=(CTF_K_TYPEDEF << 24), size_or_type=1)
+        resolver = _TypeResolver([CtfType(0, 0, 0, 0), t1], b"\x00", CTF_VERSION_3)
+        assert resolver.size(1) == 0  # guard breaks the cycle
+
+    def test_array_unparseable_name_fallback(self) -> None:
+        from abicheck.ctf_metadata import _TypeResolver
+
+        # Array with too-short extra → name falls back to "[]".
+        arr = CtfType(
+            type_id=1, name_off=0, info=(CTF_K_ARRAY << 24), size_or_type=0, extra=b""
+        )
+        resolver = _TypeResolver([CtfType(0, 0, 0, 0), arr], b"\x00", CTF_VERSION_3)
+        assert resolver._resolve_name_array(arr) == "[]"
+
+
+class TestEnumTruncation:
+    def test_enum_truncated_members(self) -> None:
+        from abicheck.ctf_metadata import _extract_enums
+
+        # vlen claims 2 entries but only one (8 bytes) of extra is provided,
+        # so the member loop breaks early on the second iteration.
+        # str_data: offset 1 = "E" (type name), offset 3 = "A" (member name).
+        str_data = b"\x00E\x00A\x00"
+        entries = struct.pack("<Ii", 3, 0)  # one entry: name_off=3 ("A"), value=0
+        t = CtfType(
+            type_id=1,
+            name_off=1,
+            info=(CTF_K_ENUM << 24) | 2,
+            size_or_type=4,
+            extra=entries,
+        )
+        enums = _extract_enums([CtfType(0, 0, 0, 0), t], str_data)
+        assert enums["E"].members == {"A": 0}
+
+
+class TestReadCtfSection:
+    def test_reads_dot_ctf(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        section = MagicMock()
+        section.data.return_value = b"CTFDATA"
+        elf = MagicMock()
+        elf.get_section_by_name.side_effect = lambda n: section if n == ".ctf" else None
+        with patch("elftools.elf.elffile.ELFFile", return_value=elf):
+            assert _read_ctf_section(f) == b"CTFDATA"
+
+    def test_reads_sunw_ctf(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        section = MagicMock()
+        section.data.return_value = b"SUNW"
+        elf = MagicMock()
+        elf.get_section_by_name.side_effect = lambda n: (
+            section if n == ".SUNW_ctf" else None
+        )
+        with patch("elftools.elf.elffile.ELFFile", return_value=elf):
+            assert _read_ctf_section(f) == b"SUNW"
+
+    def test_no_ctf_section_returns_none(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        elf = MagicMock()
+        elf.get_section_by_name.return_value = None
+        with patch("elftools.elf.elffile.ELFFile", return_value=elf):
+            assert _read_ctf_section(f) is None
+
+
+class TestParseCtfMetadata:
+    def test_read_error_returns_empty(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF")
+        with patch(
+            "abicheck.ctf_metadata._read_ctf_section", side_effect=OSError("boom")
+        ):
+            meta = parse_ctf_metadata(f)
+        assert not meta.has_ctf
+
+    def test_no_section_returns_empty(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF")
+        with patch("abicheck.ctf_metadata._read_ctf_section", return_value=None):
+            meta = parse_ctf_metadata(f)
+        assert not meta.has_ctf
+
+    def test_success_delegates_to_parse_bytes(self, tmp_path) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF")
+        with patch("abicheck.ctf_metadata._read_ctf_section", return_value=b.build()):
+            meta = parse_ctf_metadata(f)
+        assert meta.has_ctf
+
+
+class TestParseCtfFromBytesErrorPaths:
+    def test_decompression_failure_returns_empty(self) -> None:
+        # Compress flag set but body is not valid zlib data.
+        header = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, CTF_F_COMPRESS)
+        header += struct.pack("<IIIIIIII", 0, 0, 0, 0, 0, 0, 0, 0)
+        data = header + b"not zlib compressed garbage"
+        meta = parse_ctf_from_bytes(data)
+        assert not meta.has_ctf
+
+    def test_section_bounds_exceed_data(self) -> None:
+        # str_off/str_len point past the end of the data.
+        header = struct.pack("<HBB", CTF_MAGIC, CTF_VERSION_3, 0)
+        header += struct.pack("<IIIIIIII", 0, 0, 0, 0, 0, 0, 1000, 1000)
+        meta = parse_ctf_from_bytes(header)
+        assert not meta.has_ctf
+
+    def test_struct_extraction_failure_is_caught(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        data = b.build()
+        with patch(
+            "abicheck.ctf_metadata._extract_structs", side_effect=RuntimeError("boom")
+        ):
+            meta = parse_ctf_from_bytes(data)
+        # Header still parsed; struct extraction error swallowed.
+        assert meta.has_ctf
+        assert meta.structs == {}
+
+    def test_enum_extraction_failure_is_caught(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        data = b.build()
+        with patch(
+            "abicheck.ctf_metadata._extract_enums", side_effect=RuntimeError("boom")
+        ):
+            meta = parse_ctf_from_bytes(data)
+        assert meta.has_ctf
+        assert meta.enums == {}
+
+    def test_typedef_extraction_failure_is_caught(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        data = b.build()
+        with patch(
+            "abicheck.ctf_metadata._extract_typedefs", side_effect=RuntimeError("boom")
+        ):
+            meta = parse_ctf_from_bytes(data)
+        assert meta.has_ctf
+        assert meta.typedefs == {}
+
+    def test_type_parsing_failure_returns_empty(self) -> None:
+        b = CtfBuilder()
+        int_enc = struct.pack("<I", 32)
+        b.add_type("int", CTF_K_INTEGER, 0, 4, extra=int_enc)
+        data = b.build()
+        with patch(
+            "abicheck.ctf_metadata._parse_types", side_effect=struct.error("boom")
+        ):
+            meta = parse_ctf_from_bytes(data)
+        assert not meta.has_ctf

--- a/tests/test_ctf_metadata.py
+++ b/tests/test_ctf_metadata.py
@@ -18,10 +18,12 @@ from __future__ import annotations
 
 import struct
 import zlib
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from abicheck.ctf_metadata import (
+    _CTF_V2_LSTRUCT_THRESH,
     CTF_F_COMPRESS,
     CTF_K_ARRAY,
     CTF_K_CONST,
@@ -40,13 +42,19 @@ from abicheck.ctf_metadata import (
     CTF_VERSION_2,
     CTF_VERSION_3,
     CtfMetadata,
+    CtfType,
     _decompress_if_needed,
     _extra_data_size,
+    _extract_enums,
     _parse_header,
     _parse_info_v2,
     _parse_info_v3,
+    _parse_types,
+    _read_ctf_section,
     _read_string,
+    _TypeResolver,
     parse_ctf_from_bytes,
+    parse_ctf_metadata,
 )
 
 # ---------------------------------------------------------------------------
@@ -1021,16 +1029,6 @@ class TestCtfResolverThroughExtraction:
 # CTF v2 format coverage (v2 builder + direct parser tests)
 # ---------------------------------------------------------------------------
 
-from unittest.mock import MagicMock, patch  # noqa: E402
-
-from abicheck.ctf_metadata import (  # noqa: E402
-    _CTF_V2_LSTRUCT_THRESH,
-    CtfType,
-    _parse_types,
-    _read_ctf_section,
-    parse_ctf_metadata,
-)
-
 
 class CtfV2Builder:
     """Helper to construct synthetic CTF *v2* binary blobs for testing."""
@@ -1163,7 +1161,6 @@ class TestParseTypesTruncation:
 
 class TestResolverEdgeCases:
     def test_integer_missing_encoding_size_zero(self) -> None:
-        from abicheck.ctf_metadata import _TypeResolver
 
         # Integer type with no extra encoding word → size resolves to 0.
         t = CtfType(
@@ -1173,7 +1170,6 @@ class TestResolverEdgeCases:
         assert resolver.size(1) == 0
 
     def test_float_missing_encoding_size_zero(self) -> None:
-        from abicheck.ctf_metadata import _TypeResolver
 
         t = CtfType(
             type_id=1, name_off=0, info=(CTF_K_FLOAT << 24), size_or_type=4, extra=b""
@@ -1182,7 +1178,6 @@ class TestResolverEdgeCases:
         assert resolver.size(1) == 0
 
     def test_array_v2_short_extra_size_zero(self) -> None:
-        from abicheck.ctf_metadata import _TypeResolver
 
         # v2 array with too-short extra → size guard returns 0.
         t = CtfType(
@@ -1193,7 +1188,6 @@ class TestResolverEdgeCases:
 
     def test_cyclic_name_resolution(self) -> None:
         # Build a typedef that points to itself → name resolution must not recurse forever.
-        from abicheck.ctf_metadata import _TypeResolver
 
         # type 1 is a typedef whose target is itself (id 1).
         t1 = CtfType(type_id=1, name_off=0, info=(CTF_K_TYPEDEF << 24), size_or_type=1)
@@ -1202,14 +1196,12 @@ class TestResolverEdgeCases:
         assert resolver.name(1) is not None
 
     def test_cyclic_size_resolution(self) -> None:
-        from abicheck.ctf_metadata import _TypeResolver
 
         t1 = CtfType(type_id=1, name_off=0, info=(CTF_K_TYPEDEF << 24), size_or_type=1)
         resolver = _TypeResolver([CtfType(0, 0, 0, 0), t1], b"\x00", CTF_VERSION_3)
         assert resolver.size(1) == 0  # guard breaks the cycle
 
     def test_array_unparseable_name_fallback(self) -> None:
-        from abicheck.ctf_metadata import _TypeResolver
 
         # Array with too-short extra → name falls back to "[]".
         arr = CtfType(
@@ -1221,7 +1213,6 @@ class TestResolverEdgeCases:
 
 class TestEnumTruncation:
     def test_enum_truncated_members(self) -> None:
-        from abicheck.ctf_metadata import _extract_enums
 
         # vlen claims 2 entries but only one (8 bytes) of extra is provided,
         # so the member loop breaks early on the second iteration.

--- a/tests/test_debug_resolver.py
+++ b/tests/test_debug_resolver.py
@@ -77,8 +77,10 @@ class TestDebugArtifact:
 
     def test_multi_source_description(self) -> None:
         a = DebugArtifact(
-            dwarf_path=Path("/a"), dsym_path=Path("/b"),
-            pdb_path=Path("/c"), source="test",
+            dwarf_path=Path("/a"),
+            dsym_path=Path("/b"),
+            pdb_path=Path("/c"),
+            source="test",
         )
         desc = a.description
         assert "DWARF" in desc
@@ -172,19 +174,26 @@ class TestBuildIdTreeResolver:
         assert result is None
 
     def test_no_build_id(self) -> None:
-        assert BuildIdTreeResolver().resolve(Path("/usr/lib/libfoo.so"), build_id=None) is None
+        assert (
+            BuildIdTreeResolver().resolve(Path("/usr/lib/libfoo.so"), build_id=None)
+            is None
+        )
 
     def test_short_build_id(self) -> None:
         assert BuildIdTreeResolver().resolve(Path("/x"), build_id="ab") is None
 
     def test_invalid_build_id(self) -> None:
-        assert BuildIdTreeResolver().resolve(Path("/x"), build_id="../etc/passwd") is None
+        assert (
+            BuildIdTreeResolver().resolve(Path("/x"), build_id="../etc/passwd") is None
+        )
         assert BuildIdTreeResolver().resolve(Path("/x"), build_id="UPPER") is None
 
     def test_no_debug_roots_uses_defaults(self) -> None:
         # With no debug_roots and non-existent defaults, returns None
         result = BuildIdTreeResolver().resolve(
-            Path("/x"), build_id="abcdef1234567890", debug_roots=[],
+            Path("/x"),
+            build_id="abcdef1234567890",
+            debug_roots=[],
         )
         assert result is None
 
@@ -195,7 +204,9 @@ class TestBuildIdTreeResolver:
 
 
 class TestPathMirrorResolver:
-    @pytest.mark.skipif(sys.platform == "win32", reason="Path mirror is a Unix/Linux convention")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Path mirror is a Unix/Linux convention"
+    )
     def test_found_appended_debug(self, tmp_path: Path) -> None:
         debug_root = tmp_path / "debug"
         binary_path = tmp_path / "usr" / "lib" / "libfoo.so"
@@ -210,12 +221,16 @@ class TestPathMirrorResolver:
         mirror_debug.parent.mkdir(parents=True, exist_ok=True)
         mirror_debug.write_bytes(b"\x7fELF")
 
-        result = PathMirrorResolver().resolve(binary_path=binary_path, debug_roots=[debug_root])
+        result = PathMirrorResolver().resolve(
+            binary_path=binary_path, debug_roots=[debug_root]
+        )
         assert result is not None
         assert result.dwarf_path == mirror_debug
         assert "path mirror" in result.source
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Path mirror is a Unix/Linux convention")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Path mirror is a Unix/Linux convention"
+    )
     def test_found_replaced_suffix(self, tmp_path: Path) -> None:
         """Test .so -> .debug suffix replacement."""
         debug_root = tmp_path / "debug"
@@ -231,19 +246,29 @@ class TestPathMirrorResolver:
         replaced.parent.mkdir(parents=True, exist_ok=True)
         replaced.write_bytes(b"\x7fELF")
 
-        result = PathMirrorResolver().resolve(binary_path=binary_path, debug_roots=[debug_root])
+        result = PathMirrorResolver().resolve(
+            binary_path=binary_path, debug_roots=[debug_root]
+        )
         assert result is not None
         assert "path mirror" in result.source
 
     def test_not_found(self, tmp_path: Path) -> None:
         binary_path = tmp_path / "libfoo.so"
         binary_path.write_bytes(b"\x7fELF")
-        assert PathMirrorResolver().resolve(binary_path=binary_path, debug_roots=[tmp_path]) is None
+        assert (
+            PathMirrorResolver().resolve(
+                binary_path=binary_path, debug_roots=[tmp_path]
+            )
+            is None
+        )
 
     def test_no_roots(self, tmp_path: Path) -> None:
         binary_path = tmp_path / "libfoo.so"
         binary_path.write_bytes(b"\x7fELF")
-        assert PathMirrorResolver().resolve(binary_path=binary_path, debug_roots=[]) is None
+        assert (
+            PathMirrorResolver().resolve(binary_path=binary_path, debug_roots=[])
+            is None
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +308,9 @@ class TestDSYMResolver:
         debug_root = tmp_path / "symbols"
         dsym_dir, dwarf_file = self._make_dsym(debug_root, "libfoo.dylib")
 
-        result = DSYMResolver().resolve(binary_path=binary_path, debug_roots=[debug_root])
+        result = DSYMResolver().resolve(
+            binary_path=binary_path, debug_roots=[debug_root]
+        )
         assert result is not None
         assert result.dsym_path == dsym_dir
         assert result.dwarf_path == dwarf_file
@@ -300,11 +327,15 @@ class TestDSYMResolver:
         fw_dwarf.write_bytes(b"\xcf\xfa\xed\xfe")
 
         result = DSYMResolver().resolve(binary_path=binary_path)
-        assert result is not None or result is None  # May or may not match depending on structure
+        assert (
+            result is not None or result is None
+        )  # May or may not match depending on structure
 
     def test_dsym_dwarf_path_not_dir(self, tmp_path: Path) -> None:
         """_dsym_dwarf_path returns None for non-directory."""
-        assert DSYMResolver._dsym_dwarf_path(tmp_path / "nonexistent.dSYM", "foo") is None
+        assert (
+            DSYMResolver._dsym_dwarf_path(tmp_path / "nonexistent.dSYM", "foo") is None
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -331,11 +362,15 @@ class TestPDBResolver:
         pdb.parent.mkdir(parents=True)
         pdb.write_bytes(b"PDB data")
 
-        result = PDBResolver().resolve(binary_path=binary_path, debug_roots=[debug_root])
+        result = PDBResolver().resolve(
+            binary_path=binary_path, debug_roots=[debug_root]
+        )
         assert result is not None
         assert result.pdb_path == pdb
 
-    def test_nt_symbol_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_nt_symbol_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         binary_path = tmp_path / "foo.dll"
         binary_path.write_bytes(b"MZ")
         sym_dir = tmp_path / "symbols"
@@ -391,7 +426,8 @@ class TestSplitDwarfResolver:
         dwp.write_bytes(b"DWP data")
 
         result = SplitDwarfResolver().resolve(
-            binary_path=binary_path, debug_roots=[debug_root],
+            binary_path=binary_path,
+            debug_roots=[debug_root],
         )
         assert result is not None
         assert result.dwp_path == dwp
@@ -403,7 +439,9 @@ class TestSplitDwarfResolver:
         result = SplitDwarfResolver().resolve(binary_path=binary_path)
         assert result is None
 
-    def test_search_dirs_includes_comp_dir_and_debug_roots(self, tmp_path: Path) -> None:
+    def test_search_dirs_includes_comp_dir_and_debug_roots(
+        self, tmp_path: Path
+    ) -> None:
         binary_path = tmp_path / "libfoo.so"
         binary_path.write_bytes(b"\x7fELF")
         comp_dir = tmp_path / "build"
@@ -433,7 +471,9 @@ class TestSplitDwarfResolver:
         assert artifact.dwo_dir == search_dir
         assert "split DWARF" in artifact.source
 
-    def test_collect_dwo_names_returns_none_on_parse_error(self, tmp_path: Path, monkeypatch) -> None:
+    def test_collect_dwo_names_returns_none_on_parse_error(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         binary_path = tmp_path / "libfoo.so"
         binary_path.write_bytes(b"\x7fELF")
 
@@ -601,7 +641,8 @@ class TestResolveDebugInfo:
 
     def test_with_debuginfod_disabled(self, tmp_path: Path) -> None:
         result = resolve_debug_info(
-            tmp_path / "nope.so", enable_debuginfod=False,
+            tmp_path / "nope.so",
+            enable_debuginfod=False,
         )
         assert result is None
 
@@ -622,7 +663,9 @@ class TestResolveDebugInfo:
 
 class TestFormatDataSources:
     def test_with_artifact(self) -> None:
-        artifact = DebugArtifact(dwarf_path=Path("/debug/libfoo.debug"), source="build-id tree")
+        artifact = DebugArtifact(
+            dwarf_path=Path("/debug/libfoo.debug"), source="build-id tree"
+        )
         output = format_data_sources(Path("/lib/libfoo.so"), artifact, has_headers=True)
         assert "build-id tree" in output
         assert "Headers:    available" in output
@@ -639,3 +682,308 @@ class TestFormatDataSources:
     def test_headers_available(self) -> None:
         output = format_data_sources(Path("/x"), None, has_headers=True)
         assert "available" in output
+
+
+# ---------------------------------------------------------------------------
+# Tests: extract_build_id / EmbeddedDwarfResolver / SplitDwarf with ELF mocks
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+class TestExtractBuildIdElfMock:
+    def _patch_elf(self, sections):
+        elf = MagicMock()
+        elf.iter_sections.return_value = sections
+        return patch("elftools.elf.elffile.ELFFile", return_value=elf)
+
+    def _note_section(self, notes):
+        from elftools.elf.sections import NoteSection
+
+        sec = MagicMock(spec=NoteSection)
+        sec.iter_notes.return_value = notes
+        return sec
+
+    def test_build_id_from_bytes_desc(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        note = {"n_type": "NT_GNU_BUILD_ID", "n_desc": b"\xab\xcd"}
+        with self._patch_elf([self._note_section([note])]):
+            assert extract_build_id(f) == "abcd"
+
+    def test_build_id_from_str_desc(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        note = {"n_type": "NT_GNU_BUILD_ID", "n_desc": "DEADbeef"}
+        with self._patch_elf([self._note_section([note])]):
+            assert extract_build_id(f) == "deadbeef"
+
+    def test_non_note_section_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        plain = MagicMock()  # not a NoteSection instance
+        with self._patch_elf([plain]):
+            assert extract_build_id(f) is None
+
+    def test_wrong_note_type_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        note = {"n_type": "NT_OTHER", "n_desc": b"\x01"}
+        with self._patch_elf([self._note_section([note])]):
+            assert extract_build_id(f) is None
+
+    def test_import_error_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF")
+        real_import = __import__
+
+        def fake_import(name, *a, **k):
+            if "elftools" in name:
+                raise ImportError("no elftools")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        assert extract_build_id(f) is None
+
+
+class TestEmbeddedDwarfResolverFound:
+    def test_embedded_dwarf_found(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        elf = MagicMock()
+        debug_info = MagicMock()
+        debug_info.data_size = 1234
+        elf.get_section_by_name.return_value = debug_info
+        with patch("elftools.elf.elffile.ELFFile", return_value=elf):
+            artifact = EmbeddedDwarfResolver().resolve(f)
+        assert artifact is not None
+        assert artifact.dwarf_path == f
+        assert "embedded" in artifact.source.lower()
+
+    def test_empty_debug_info_returns_none(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        elf = MagicMock()
+        debug_info = MagicMock()
+        debug_info.data_size = 0
+        elf.get_section_by_name.return_value = debug_info
+        with patch("elftools.elf.elffile.ELFFile", return_value=elf):
+            assert EmbeddedDwarfResolver().resolve(f) is None
+
+    def test_import_error_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF")
+        real_import = __import__
+
+        def fake_import(name, *a, **k):
+            if "elftools" in name:
+                raise ImportError("no elftools")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+        assert EmbeddedDwarfResolver().resolve(f) is None
+
+
+class TestCollectDwoNames:
+    def _top_die(self, attrs):
+        die = MagicMock()
+        die.attributes = attrs
+        return die
+
+    def _attr(self, value):
+        a = MagicMock()
+        a.value = value
+        return a
+
+    def test_collects_dwo_names_and_comp_dirs(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        cu = MagicMock()
+        cu.get_top_DIE.return_value = self._top_die(
+            {
+                "DW_AT_GNU_dwo_name": self._attr(b"foo.dwo"),
+                "DW_AT_comp_dir": self._attr(b"/build/dir"),
+            }
+        )
+        dwarf = MagicMock()
+        dwarf.iter_CUs.return_value = [cu]
+        elf = MagicMock()
+        elf.get_dwarf_info.return_value = dwarf
+        with (
+            patch("elftools.elf.elffile.ELFFile", return_value=elf),
+            patch("abicheck.dwarf_utils.has_real_dwarf_info", return_value=True),
+        ):
+            result = SplitDwarfResolver._collect_dwo_names_and_comp_dirs(f)
+        assert result is not None
+        dwo_names, comp_dirs = result
+        assert "foo.dwo" in dwo_names
+        assert "/build/dir" in comp_dirs
+
+    def test_no_dwarf_info_returns_empty(self, tmp_path: Path) -> None:
+        f = tmp_path / "libfoo.so"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        elf = MagicMock()
+        with (
+            patch("elftools.elf.elffile.ELFFile", return_value=elf),
+            patch("abicheck.dwarf_utils.has_real_dwarf_info", return_value=False),
+        ):
+            result = SplitDwarfResolver._collect_dwo_names_and_comp_dirs(f)
+        assert result == ([], set())
+
+    def test_resolve_finds_dwo_dir(self, tmp_path: Path) -> None:
+        binary = tmp_path / "libfoo.so"
+        binary.write_bytes(b"\x7fELF" + b"\x00" * 60)
+        (tmp_path / "foo.dwo").write_bytes(b"dwo")
+        with patch.object(
+            SplitDwarfResolver,
+            "_collect_dwo_names_and_comp_dirs",
+            return_value=(["foo.dwo"], set()),
+        ):
+            artifact = SplitDwarfResolver().resolve(binary)
+        assert artifact is not None
+        assert artifact.dwo_dir == tmp_path
+
+
+class TestFindFrameworkRootNone:
+    def test_no_framework_returns_none(self, tmp_path: Path) -> None:
+        binary = tmp_path / "plain" / "libfoo.dylib"
+        assert DSYMResolver._find_framework_root(binary) is None
+
+
+class TestPdbResolverEmptySymbolPathEntry:
+    def test_empty_entry_skipped(self, tmp_path: Path, monkeypatch) -> None:
+        binary = tmp_path / "foo.dll"
+        binary.write_bytes(b"MZ")
+        sym_dir = tmp_path / "syms"
+        sym_dir.mkdir()
+        (sym_dir / "foo.pdb").write_bytes(b"PDB")
+        # Leading ';' and whitespace entries are skipped.
+        monkeypatch.setenv("_NT_SYMBOL_PATH", f" ; ;{sym_dir}")
+        artifact = PDBResolver().resolve(binary)
+        assert artifact is not None
+        assert artifact.pdb_path == sym_dir / "foo.pdb"
+
+
+# ---------------------------------------------------------------------------
+# Tests: DebuginfodResolver network helpers (no real network)
+# ---------------------------------------------------------------------------
+
+
+class TestDebuginfodNetwork:
+    def test_safe_urlopen_rejects_bad_scheme(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported URL scheme"):
+            DebuginfodResolver._safe_urlopen("file:///etc/passwd")
+
+    def test_safe_urlopen_allows_https(self) -> None:
+        fake_resp = MagicMock()
+        with patch("urllib.request.urlopen", return_value=fake_resp) as mock_open:
+            result = DebuginfodResolver._safe_urlopen("https://example.com/x")
+        assert result is fake_resp
+        mock_open.assert_called_once()
+
+    def test_url_allowed_https(self) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        assert resolver._url_allowed("https://example.com") is True
+
+    def test_url_allowed_http_with_insecure(self) -> None:
+        resolver = DebuginfodResolver(server_urls=["http://x"], allow_insecure=True)
+        assert resolver._url_allowed("http://example.com") is True
+
+    def test_url_allowed_http_rejected_by_default(self) -> None:
+        resolver = DebuginfodResolver(server_urls=["http://x"])
+        assert resolver._url_allowed("http://example.com") is False
+
+    def _resp(self, status=200, data=b"\x7fELF" + b"\x00" * 20):
+        resp = MagicMock()
+        resp.status = status
+        resp.read.return_value = data
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_fetch_data_success(self) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        with patch.object(resolver, "_safe_urlopen", return_value=self._resp()):
+            data = resolver._fetch_data("https://x/buildid/aa/debuginfo")
+        assert data == b"\x7fELF" + b"\x00" * 20
+
+    def test_fetch_data_non_200(self) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        with patch.object(
+            resolver, "_safe_urlopen", return_value=self._resp(status=404)
+        ):
+            assert resolver._fetch_data("https://x/y") is None
+
+    def test_fetch_data_oversize(self) -> None:
+        from abicheck.debug_resolver import _MAX_DEBUGINFOD_SIZE
+
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        big = b"\x00" * (_MAX_DEBUGINFOD_SIZE + 1)
+        with patch.object(resolver, "_safe_urlopen", return_value=self._resp(data=big)):
+            assert resolver._fetch_data("https://x/y") is None
+
+    def test_atomic_cache_write(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        dest = tmp_path / "sub" / "out.debug"
+        resolver._atomic_cache_write(dest, b"hello")
+        assert dest.read_bytes() == b"hello"
+
+    def test_atomic_cache_write_cleans_up_on_error(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        dest = tmp_path / "out.debug"
+        with patch("os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError):
+                resolver._atomic_cache_write(dest, b"data")
+        # No leftover temp files in the directory.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_fetch_one_url_disallowed_scheme(self) -> None:
+        resolver = DebuginfodResolver(server_urls=["http://x"])
+        result = resolver._fetch_one_url("http://x", "abcd1234", Path("/tmp/c"))
+        assert result is None
+
+    def test_fetch_one_url_success(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"], cache_dir=tmp_path)
+        cached = tmp_path / "out.debug"
+        with patch.object(
+            resolver, "_fetch_data", return_value=b"\x7fELF" + b"\x00" * 20
+        ):
+            artifact = resolver._fetch_one_url("https://x", "abcd1234", cached)
+        assert artifact is not None
+        assert artifact.dwarf_path == cached
+        assert cached.read_bytes() == b"\x7fELF" + b"\x00" * 20
+
+    def test_fetch_one_url_no_data(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        with patch.object(resolver, "_fetch_data", return_value=None):
+            assert (
+                resolver._fetch_one_url("https://x", "abcd1234", tmp_path / "c") is None
+            )
+
+    def test_fetch_one_url_not_elf(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        with patch.object(
+            resolver, "_fetch_data", return_value=b"NOTELF" + b"\x00" * 20
+        ):
+            assert (
+                resolver._fetch_one_url("https://x", "abcd1234", tmp_path / "c") is None
+            )
+
+    def test_fetch_one_url_handles_oserror(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"])
+        with patch.object(resolver, "_fetch_data", side_effect=OSError("net down")):
+            assert (
+                resolver._fetch_one_url("https://x", "abcd1234", tmp_path / "c") is None
+            )
+
+    def test_resolve_fetches_from_server(self, tmp_path: Path) -> None:
+        resolver = DebuginfodResolver(
+            server_urls=["https://example.com"],
+            cache_dir=tmp_path / "cache",
+        )
+        with patch.object(
+            resolver, "_fetch_data", return_value=b"\x7fELF" + b"\x00" * 20
+        ):
+            artifact = resolver.resolve(Path("/x"), build_id="abcdef1234567890")
+        assert artifact is not None
+        assert "debuginfod" in artifact.source

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``python -m abicheck`` entry point (abicheck/__main__.py)."""
+
+from __future__ import annotations
+
+import runpy
+import sys
+
+import pytest
+
+
+def test_main_module_reexports_main() -> None:
+    import abicheck.__main__ as entry
+    from abicheck.cli import main
+
+    assert entry.main is main
+
+
+def test_run_as_module_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Running the module as ``__main__`` calls the Click group.
+
+    ``--help`` makes Click exit cleanly with SystemExit(0), which exercises
+    the ``if __name__ == "__main__": main()`` guard.
+    """
+    monkeypatch.setattr(sys, "argv", ["abicheck", "--help"])
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module("abicheck.__main__", run_name="__main__")
+    assert exc_info.value.code == 0

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -24,6 +24,9 @@ def test_run_as_module_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     the ``if __name__ == "__main__": main()`` guard.
     """
     monkeypatch.setattr(sys, "argv", ["abicheck", "--help"])
+    # Drop the cached submodule so run_module executes it fresh as __main__
+    # without the "found in sys.modules" RuntimeWarning.
+    monkeypatch.delitem(sys.modules, "abicheck.__main__", raising=False)
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_module("abicheck.__main__", run_name="__main__")
     assert exc_info.value.code == 0

--- a/tests/test_sycl_metadata.py
+++ b/tests/test_sycl_metadata.py
@@ -1,0 +1,377 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for abicheck.sycl_metadata — SYCL plugin/runtime metadata extraction.
+
+ELF parsing is exercised with mocked pyelftools (no real binaries needed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from abicheck.sycl_metadata import (
+    _PI_SYMBOL_RE,
+    SyclMetadata,
+    SyclPluginInfo,
+    _default_plugin_search_paths,
+    _detect_backend_type,
+    _detect_pi_version_from_symbols,
+    _detect_sycl_implementation,
+    _detect_ur_version_from_symbols,
+    _extract_plugin_symbols,
+    _is_plugin_candidate,
+    discover_sycl_plugins,
+    parse_sycl_metadata,
+    parse_sycl_plugin,
+)
+
+# ---------------------------------------------------------------------------
+# ELF mocking helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sym(name, *, bind="STB_GLOBAL", shndx=1, vis="STV_DEFAULT"):
+    sym = MagicMock()
+    sym.name = name
+    sym.entry = {
+        "st_info": {"bind": bind},
+        "st_shndx": shndx,
+        "st_other": {"visibility": vis},
+    }
+    return sym
+
+
+def _make_dynsym(symbols):
+    from elftools.elf.sections import SymbolTableSection
+
+    sec = MagicMock(spec=SymbolTableSection)
+    sec.name = ".dynsym"
+    sec.iter_symbols.return_value = symbols
+    return sec
+
+
+def _patch_elf(sections):
+    elf = MagicMock()
+    elf.iter_sections.return_value = sections
+    return patch("elftools.elf.elffile.ELFFile", return_value=elf)
+
+
+def _write_elf(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"\x7fELF" + b"\x00" * 60)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _extract_plugin_symbols
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPluginSymbols:
+    def test_collects_matching_symbols(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        syms = [_make_sym("piPluginInit"), _make_sym("piDevicesGet")]
+        with _patch_elf([_make_dynsym(syms)]):
+            result = _extract_plugin_symbols(so, _PI_SYMBOL_RE)
+        assert result == ["piDevicesGet", "piPluginInit"]  # sorted
+
+    def test_non_regular_file_returns_empty(self) -> None:
+        # /dev/null is a char device — TOCTOU guard rejects it.
+        import os
+
+        if not os.path.exists("/dev/null"):
+            pytest.skip("/dev/null missing")
+        assert _extract_plugin_symbols(Path("/dev/null"), _PI_SYMBOL_RE) == []
+
+    def test_skips_non_symbol_table_section(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        plain = MagicMock()  # not a SymbolTableSection
+        with _patch_elf([plain]):
+            assert _extract_plugin_symbols(so, _PI_SYMBOL_RE) == []
+
+    def test_skips_non_dynsym_table(self, tmp_path: Path) -> None:
+        from elftools.elf.sections import SymbolTableSection
+
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        sec = MagicMock(spec=SymbolTableSection)
+        sec.name = ".symtab"
+        sec.iter_symbols.return_value = [_make_sym("piPluginInit")]
+        with _patch_elf([sec]):
+            assert _extract_plugin_symbols(so, _PI_SYMBOL_RE) == []
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"bind": "STB_LOCAL"},
+            {"shndx": "SHN_UNDEF"},
+            {"vis": "STV_HIDDEN"},
+            {"vis": "STV_INTERNAL"},
+        ],
+    )
+    def test_filtered_symbols(self, tmp_path: Path, kwargs) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        with _patch_elf([_make_dynsym([_make_sym("piPluginInit", **kwargs)])]):
+            assert _extract_plugin_symbols(so, _PI_SYMBOL_RE) == []
+
+    def test_empty_name_skipped(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        with _patch_elf([_make_dynsym([_make_sym("")])]):
+            assert _extract_plugin_symbols(so, _PI_SYMBOL_RE) == []
+
+    def test_non_matching_pattern_skipped(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        with _patch_elf([_make_dynsym([_make_sym("not_a_pi_symbol")])]):
+            assert _extract_plugin_symbols(so, _PI_SYMBOL_RE) == []
+
+    def test_parse_error_returns_empty(self, tmp_path: Path) -> None:
+        from elftools.common.exceptions import ELFError
+
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        with patch("elftools.elf.elffile.ELFFile", side_effect=ELFError("bad")):
+            assert _extract_plugin_symbols(so, _PI_SYMBOL_RE) == []
+
+
+# ---------------------------------------------------------------------------
+# version + backend detection helpers
+# ---------------------------------------------------------------------------
+
+
+class TestVersionDetection:
+    def test_pi_1_2(self) -> None:
+        assert (
+            _detect_pi_version_from_symbols(["piextUSMHostAlloc", "piextQueueCreate"])
+            == "1.2"
+        )
+
+    def test_pi_1_1(self) -> None:
+        assert _detect_pi_version_from_symbols(["piextDeviceSelect"]) == "1.1"
+
+    def test_pi_1_0(self) -> None:
+        assert _detect_pi_version_from_symbols(["piPluginInit"]) == "1.0"
+
+    def test_pi_unknown(self) -> None:
+        assert _detect_pi_version_from_symbols(["piRandom"]) == ""
+
+    def test_ur_0_10(self) -> None:
+        assert _detect_ur_version_from_symbols(["urBindlessImagesCreate"]) == "0.10"
+
+    def test_ur_0_9(self) -> None:
+        assert _detect_ur_version_from_symbols(["urVirtualMemReserve"]) == "0.9"
+
+    def test_ur_0_8(self) -> None:
+        assert _detect_ur_version_from_symbols(["urCommandBufferCreateExp"]) == "0.8"
+
+    def test_ur_0_7(self) -> None:
+        assert _detect_ur_version_from_symbols(["urAdapterGet"]) == "0.7"
+
+    def test_ur_unknown(self) -> None:
+        assert _detect_ur_version_from_symbols(["urRandom"]) == ""
+
+    def test_backend_known(self) -> None:
+        assert _detect_backend_type("cuda") == "cuda"
+
+    def test_backend_unknown_passthrough(self) -> None:
+        assert _detect_backend_type("weird") == "weird"
+
+
+# ---------------------------------------------------------------------------
+# parse_sycl_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestParseSyclPlugin:
+    def test_pi_plugin(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        with patch(
+            "abicheck.sycl_metadata._extract_plugin_symbols",
+            return_value=["piPluginInit", "piextUSMHostAlloc", "piextQueueCreate"],
+        ):
+            plugin = parse_sycl_plugin(so)
+        assert plugin is not None
+        assert plugin.name == "cuda"
+        assert plugin.interface_type == "pi"
+        assert plugin.pi_version == "1.2"
+        assert plugin.backend_type == "cuda"
+
+    def test_pi_plugin_missing_init(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libpi_cuda.so")
+        with patch(
+            "abicheck.sycl_metadata._extract_plugin_symbols", return_value=["piFoo"]
+        ):
+            assert parse_sycl_plugin(so) is None
+
+    def test_ur_plugin(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libur_adapter_level_zero.so")
+        with patch(
+            "abicheck.sycl_metadata._extract_plugin_symbols",
+            return_value=["urAdapterGet", "urVirtualMemReserve"],
+        ):
+            plugin = parse_sycl_plugin(so)
+        assert plugin is not None
+        assert plugin.name == "level_zero"
+        assert plugin.interface_type == "ur"
+        assert plugin.pi_version == "0.9"
+
+    def test_ur_plugin_missing_adapter_get(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libur_adapter_opencl.so")
+        with patch(
+            "abicheck.sycl_metadata._extract_plugin_symbols", return_value=["urFoo"]
+        ):
+            assert parse_sycl_plugin(so) is None
+
+    def test_non_plugin_name(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libsomething.so")
+        assert parse_sycl_plugin(so) is None
+
+
+# ---------------------------------------------------------------------------
+# discovery / candidate matching
+# ---------------------------------------------------------------------------
+
+
+class TestPluginCandidate:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("libpi_cuda.so", True),
+            ("libur_adapter_opencl.so", True),
+            ("libsycl.so", False),
+            ("random.txt", False),
+        ],
+    )
+    def test_is_candidate(self, name, expected) -> None:
+        assert _is_plugin_candidate(name) is expected
+
+
+class TestDiscoverSyclPlugins:
+    def test_discovers_and_dedups(self, tmp_path: Path) -> None:
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        d1.mkdir()
+        d2.mkdir()
+        (d1 / "libpi_cuda.so").write_bytes(b"\x7fELF")
+        (d2 / "libpi_cuda.so").write_bytes(b"\x7fELF")  # duplicate name
+        (d1 / "notaplugin.so").write_bytes(b"x")
+
+        fake = SyclPluginInfo(name="cuda", library="libpi_cuda.so")
+        with patch(
+            "abicheck.sycl_metadata.parse_sycl_plugin", return_value=fake
+        ) as mock_parse:
+            plugins = discover_sycl_plugins([d1, d2])
+        # Deduplicated by filename → parsed only once.
+        assert len(plugins) == 1
+        assert mock_parse.call_count == 1
+
+    def test_skips_missing_dir(self, tmp_path: Path) -> None:
+        assert discover_sycl_plugins([tmp_path / "nope"]) == []
+
+    def test_skips_subdirectories(self, tmp_path: Path) -> None:
+        # An entry that is a directory (not a file) is skipped.
+        (tmp_path / "libpi_cuda.so").mkdir()
+        assert discover_sycl_plugins([tmp_path]) == []
+
+    def test_parse_returns_none_excluded(self, tmp_path: Path) -> None:
+        (tmp_path / "libpi_cuda.so").write_bytes(b"\x7fELF")
+        with patch("abicheck.sycl_metadata.parse_sycl_plugin", return_value=None):
+            assert discover_sycl_plugins([tmp_path]) == []
+
+
+# ---------------------------------------------------------------------------
+# _detect_sycl_implementation / _default_plugin_search_paths
+# ---------------------------------------------------------------------------
+
+
+class TestDetectImplementation:
+    def test_dpcpp_libsycl(self, tmp_path: Path) -> None:
+        (tmp_path / "libsycl.so").write_bytes(b"x")
+        assert _detect_sycl_implementation(tmp_path) == "dpcpp"
+
+    def test_dpcpp_versioned(self, tmp_path: Path) -> None:
+        (tmp_path / "libsycl.so.7").write_bytes(b"x")
+        assert _detect_sycl_implementation(tmp_path) == "dpcpp"
+
+    def test_adaptivecpp(self, tmp_path: Path) -> None:
+        (tmp_path / "libacpp-rt.so").write_bytes(b"x")
+        assert _detect_sycl_implementation(tmp_path) == "adaptivecpp"
+
+    def test_adaptivecpp_hipsycl(self, tmp_path: Path) -> None:
+        (tmp_path / "libhipsycl-rt.so.1").write_bytes(b"x")
+        assert _detect_sycl_implementation(tmp_path) == "adaptivecpp"
+
+    def test_none(self, tmp_path: Path) -> None:
+        assert _detect_sycl_implementation(tmp_path) == ""
+
+
+class TestDefaultPluginSearchPaths:
+    def test_from_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("SYCL_PI_PLUGINS_DIR", "/pi/dir")
+        monkeypatch.setenv("SYCL_UR_ADAPTERS_DIR", "/ur/dir")
+        paths = _default_plugin_search_paths()
+        assert Path("/pi/dir") in paths
+        assert Path("/ur/dir") in paths
+
+    def test_empty_when_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv("SYCL_PI_PLUGINS_DIR", raising=False)
+        monkeypatch.delenv("SYCL_UR_ADAPTERS_DIR", raising=False)
+        assert _default_plugin_search_paths() == []
+
+
+# ---------------------------------------------------------------------------
+# parse_sycl_metadata (top-level)
+# ---------------------------------------------------------------------------
+
+
+class TestParseSyclMetadata:
+    def test_no_implementation_returns_none(self, tmp_path: Path) -> None:
+        assert parse_sycl_metadata(tmp_path) is None
+
+    def test_full_metadata(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.delenv("SYCL_PI_PLUGINS_DIR", raising=False)
+        monkeypatch.delenv("SYCL_UR_ADAPTERS_DIR", raising=False)
+        (tmp_path / "libsycl.so").write_bytes(b"x")
+        sycl_sub = tmp_path / "sycl"
+        sycl_sub.mkdir()
+        extra = tmp_path / "extra"
+        extra.mkdir()
+
+        plugins = [
+            SyclPluginInfo(name="cuda", library="libpi_cuda.so", pi_version="1.2"),
+            SyclPluginInfo(name="opencl", library="libpi_opencl.so", pi_version="1.10"),
+        ]
+        with patch(
+            "abicheck.sycl_metadata.discover_sycl_plugins", return_value=plugins
+        ):
+            meta = parse_sycl_metadata(tmp_path, extra_plugin_paths=[extra])
+        assert meta is not None
+        assert meta.implementation == "dpcpp"
+        # Tuple-based max: "1.10" > "1.2".
+        assert meta.pi_version == "1.10"
+        assert str(sycl_sub) in meta.plugin_search_paths
+        assert str(extra) in meta.plugin_search_paths
+
+    def test_no_versions(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.delenv("SYCL_PI_PLUGINS_DIR", raising=False)
+        monkeypatch.delenv("SYCL_UR_ADAPTERS_DIR", raising=False)
+        (tmp_path / "libsycl.so").write_bytes(b"x")
+        plugins = [SyclPluginInfo(name="cuda", library="libpi_cuda.so", pi_version="")]
+        with patch(
+            "abicheck.sycl_metadata.discover_sycl_plugins", return_value=plugins
+        ):
+            meta = parse_sycl_metadata(tmp_path)
+        assert meta is not None
+        assert meta.pi_version == ""
+
+
+class TestSyclMetadataModel:
+    def test_plugin_map_keys(self) -> None:
+        pi = SyclPluginInfo(name="cuda", library="libpi_cuda.so", interface_type="pi")
+        ur = SyclPluginInfo(
+            name="cuda", library="libur_adapter_cuda.so", interface_type="ur"
+        )
+        meta = SyclMetadata(plugins=[pi, ur])
+        m = meta.plugin_map
+        assert m[("pi", "cuda")] is pi
+        assert m[("ur", "cuda")] is ur


### PR DESCRIPTION
## Summary

Every source file is now at **≥80%** line+branch coverage. Previously five files were below the floor; this PR adds targeted unit tests to lift them, raising overall coverage from **92% → 93%**.

| File | Before | After |
|------|--------|-------|
| `abicheck/__main__.py` | 60% | 100% |
| `abicheck/binary_fingerprint.py` | 64% | ~96% |
| `abicheck/debug_resolver.py` | 73% | ~96% |
| `abicheck/sycl_metadata.py` | 76% | ~96% |
| `abicheck/ctf_metadata.py` | 79% | ~91% |

After this change the lowest-covered file is `compat/cli.py` at 82%.

## What was added

- **`binary_fingerprint.py`** — tests for the internal ELF-parsing helpers (`_extract_fingerprints`, `_compute_code_hash`, `_extract_section_summary`) using mocked pyelftools, plus the non-regular-file (char-device) TOCTOU guard and the truncated-ELF path on the public `compute_*` entry points.
- **`debug_resolver.py`** — build-id note extraction, embedded/split-DWARF resolution, framework-root and `_NT_SYMBOL_PATH` edge cases, and the full debuginfod network path (`_safe_urlopen`, `_url_allowed`, `_fetch_data`, `_atomic_cache_write`, `_fetch_one_url`) — all without real network access.
- **`sycl_metadata.py`** — new `tests/test_sycl_metadata.py` covering plugin symbol extraction, PI/UR version heuristics, plugin discovery + dedup, implementation detection, and `parse_sycl_metadata`.
- **`ctf_metadata.py`** — a CTF **v2** blob builder plus direct parser/resolver tests for v2 layouts, truncation guards, cyclic type resolution, enum truncation, `_read_ctf_section`, `parse_ctf_metadata`, and `parse_ctf_from_bytes` error paths.
- **`__main__.py`** — exercises the `python -m abicheck` entry-point guard.

## Notes

- All new tests are pure-Python (mocked binaries) and run in the default fast lane — **no new external-tool dependencies**.
- `ruff check`, `ruff format --check`, and `python scripts/check_ai_readiness.py` (0 errors) all pass.
- Full fast suite: **7602 passed, 21 skipped, 4 xfailed**.

https://claude.ai/code/session_01AN6qXAP8kmmPPy1CHPKFx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN6qXAP8kmmPPy1CHPKFx9)_