### PR TITLE
docs: empirical ABI-scan use-case gaps from real OSS binaries (iteration 1)

### DIFF
--- a/docs/development/plans/g10-glibc-floor-check.md
+++ b/docs/development/plans/g10-glibc-floor-check.md
@@ -1,0 +1,45 @@
+# G10 — manylinux glibc-floor (platform-baseline) check
+
+**Registry:** `UC-TC-glibc-floor` (`planned`)
+**Effort:** S · **Risk:** low
+
+## Problem
+
+A manylinux wheel's tag (`manylinux_2_27`, `manylinux_2_28`, …) is a *promise*
+about the **maximum glibc symbol version** its binaries may require. abicheck
+already captures `elf.versions_required` (e.g. `GLIBC_2.x`) per binary, but no
+check compares the required floor against a declared platform baseline. The
+result is the classic "works on my box, `ImportError`/`GLIBC_2.x not found` on
+the user's older system" failure going undetected.
+
+## Goal & acceptance criteria
+
+- [ ] A `--glibc-floor 2.27` option (or derivation from a wheel's manylinux tag)
+      against which the max `GLIBC_2.x` in `versions_required` is checked.
+- [ ] Exceeding the floor emits a deployment-`RISK` finding ("minimum glibc
+      requirement raised / exceeds declared baseline") that reaches the verdict
+      and JSON/SARIF output.
+- [ ] Within-floor binaries stay clean.
+
+## Goal note on taxonomy
+
+This is a new deployment-`RISK` `ChangeKind` (e.g. `platform_baseline_floor_raised`)
+added per the four-step procedure in the root `CLAUDE.md`; it composes with the
+existing `diff_versioning.py` symbol-version reasoning rather than replacing it.
+
+## Files & surfaces
+
+- `abicheck/diff_versioning.py` (floor comparison), `abicheck/checker_policy.py`
+  (new kind + partition), the relevant CLI module for the flag, and the wheel
+  tag parser in `abicheck/package.py` for auto-derivation.
+
+## Tests
+
+- Unit: a binary requiring `GLIBC_2.34` checked against floor `2.27` → RISK;
+  against `2.38` → clean.
+- An example pair under `examples/` with `ground_truth.json` entry.
+
+## Out of scope
+
+Non-glibc platform floors (musl, Windows API set, macOS deployment target) —
+follow-ups once the mechanism exists.

--- a/docs/development/plans/g11-single-binary-audit.md
+++ b/docs/development/plans/g11-single-binary-audit.md
@@ -1,0 +1,47 @@
+# G11 — single-binary ABI audit / lint mode
+
+**Registry:** `UC-WF-audit` (`planned`)
+**Effort:** M · **Risk:** low
+
+## Problem
+
+Every command is comparative (old vs new, app vs lib, stack old vs new). There
+is no *"scan this one `.so` and report ABI-hygiene problems"* mode — the first
+thing a library author wants **before their first release**, when there is no
+prior version to diff against. abicheck already captures the substrate
+(`elf.has_executable_stack`, `rpath`/`runpath`, `versions_*`, visibility,
+symbol table) but exposes no one-sided driver over it.
+
+## Goal & acceptance criteria
+
+- [ ] `abicheck audit <lib>` (or `dump --lint`) runs the single-snapshot subset
+      of detectors and emits findings without a second input.
+- [ ] Findings cover at least: executable stack, insecure RPATH/RUNPATH,
+      missing `SONAME`, unversioned symbols in a versioned library, and
+      default-visibility globals that look internal.
+- [ ] Output flows through the existing reporter (text/JSON/SARIF) with a
+      meaningful exit code; clean libraries pass.
+
+## Design
+
+1. A `SnapshotAudit` pass that takes one `AbiSnapshot` and yields hygiene
+   findings, reusing the metadata already on the snapshot model.
+2. Reuse the severity/reporting plumbing; audit findings are `RISK`/`quality`
+   tier, never ABI-`break` (there is no baseline to break against).
+3. The lint rule set is additive — start with the five above, grow over time.
+
+## Files & surfaces
+
+- New `abicheck/audit.py`, a CLI module `abicheck/cli_audit.py`
+  (registered per the root `CLAUDE.md` "Adding a new top-level command"),
+  reuse of `abicheck/reporter.py`.
+
+## Tests
+
+- `tests/test_audit_lint.py`: snapshots exhibiting each hygiene issue → expected
+  findings; a clean snapshot → no findings.
+
+## Out of scope
+
+Cross-binary/stack hygiene (covered by `stack-check`); fix suggestions
+(a stated non-goal).

--- a/docs/development/plans/g12-security-hardening.md
+++ b/docs/development/plans/g12-security-hardening.md
@@ -1,0 +1,56 @@
+# G12 — security-hardening drift surface + preset
+
+**Registry:** `UC-WF-security-hardening` (`partial`)
+**Effort:** M · **Risk:** low
+
+## Problem
+
+The "did this release silently weaken hardening?" usage model is **partially**
+served today: abicheck detects `executable_stack` and `runpath_changed`/
+`rpath_changed`, and per-kind policy gating already works (a `--policy-file`
+with `overrides: { executable_stack: break }` flips the verdict to `BREAKING`,
+exit 4). Two gaps remain:
+
+1. **Discoverability** — there is no built-in `security` severity preset or
+   shipped policy, so gating requires hand-authoring YAML and knowing the kind
+   slugs.
+2. **Thin captured surface** — `elf` carries only `has_executable_stack` +
+   `rpath`/`runpath`. Not captured: RELRO / BIND_NOW (full/partial/none), PIE,
+   stack-canary, FORTIFY_SOURCE, writable+executable segments. The most common
+   checksec-style regressions (full-RELRO → partial, PIE dropped) are invisible
+   because the property was never recorded.
+
+## Goal & acceptance criteria
+
+- [ ] ELF snapshot captures RELRO, BIND_NOW, PIE, stack-canary, FORTIFY, and
+      W^X segment presence (a `checksec`-equivalent block).
+- [ ] New `RISK` `ChangeKind`s for the meaningful regressions (e.g.
+      `relro_weakened`, `pie_disabled`) added per the root `CLAUDE.md` procedure.
+- [ ] A shipped `policies/security.yaml` and/or `--severity-preset security`
+      makes hardening gating turnkey.
+- [ ] A release that weakens a hardening property fails under the security
+      preset; an unchanged one passes.
+
+## Design
+
+1. Extend `abicheck/elf_metadata.py` to read the dynamic section / program
+   headers / symbols for the checksec properties.
+2. Add the diff rules in `abicheck/diff_platform.py` and the new kinds in
+   `checker_policy.py` (keep them `RISK` by default, gateable to `break`).
+3. Ship `policies/security.yaml` mapping the hardening kinds to `break`/`warn`.
+
+## Files & surfaces
+
+- `abicheck/elf_metadata.py`, `abicheck/diff_platform.py`,
+  `abicheck/checker_policy.py`, a new `policies/security.yaml`, severity preset
+  wiring in `abicheck/severity.py`.
+
+## Tests
+
+- Unit: two `.so`s differing only in RELRO/PIE → expected kind + gated verdict.
+- Extend `tests/test_diff_platform_deep.py` coverage of the new properties.
+
+## Out of scope
+
+Non-ELF hardening (PE `/GS`, `/DYNAMICBASE`; macOS hardened runtime) — once the
+ELF mechanism exists.

--- a/docs/development/plans/g13-arch-mismatch-guard.md
+++ b/docs/development/plans/g13-arch-mismatch-guard.md
@@ -1,0 +1,49 @@
+# G13 — cross-architecture comparison guardrail
+
+**Registry:** `UC-PLAT-arch-guard` (`planned`)
+**Effort:** S · **Risk:** low
+
+## Problem
+
+Comparing an x86-64 build against an aarch64 build of the *same* library version
+returns a falsely reassuring `COMPATIBLE_WITH_RISK` verdict at 100%
+binary-compatibility. The ELF snapshot never captures `e_machine` (nor
+`EI_CLASS` 32/64, nor endianness), so a cross-architecture diff is not even
+recognised as such — the only incidental trace is a `toolchain_flag_drift`
+note scraped from `DW_AT_producer`. This is a real "false green" footgun for
+multi-arch CI matrices. PE and Mach-O already carry a machine field — ELF is
+the outlier.
+
+## Goal & acceptance criteria
+
+- [ ] ELF snapshot captures `e_machine`, `EI_CLASS`, and endianness.
+- [ ] `compare` / `compare-release` treat a machine mismatch as a hard guard:
+      either refuse with a clear error, or emit a top-level
+      `ARCHITECTURE_MISMATCH` finding that dominates the verdict (never a
+      compatible/low-risk result).
+- [ ] Same-arch comparisons are unaffected.
+
+## Design
+
+1. Add the machine fields to `abicheck/elf_metadata.py` and the ELF snapshot
+   model (PE/Mach-O already expose an equivalent).
+2. In the diff entry point, compare machine/class/endianness first; on mismatch
+   short-circuit to the guard outcome (new `ARCHITECTURE_MISMATCH` kind in
+   `checker_policy.py`, classified to dominate — or a refusing `ValidationError`,
+   decided in the plan's first step).
+
+## Files & surfaces
+
+- `abicheck/elf_metadata.py`, `abicheck/model.py` (ELF block),
+  `abicheck/checker.py` / `abicheck/diff_platform.py` (guard),
+  `abicheck/checker_policy.py` (kind).
+
+## Tests
+
+- `tests/test_arch_mismatch_guard.py`: x86-64 vs aarch64 snapshot → guard
+  outcome; x86-64 vs x86-64 → normal path.
+
+## Out of scope
+
+Deliberate multi-arch *fat* binaries (Mach-O universal) — those expose multiple
+slices and are a separate concern.

--- a/docs/development/plans/g14-stable-abi-subset.md
+++ b/docs/development/plans/g14-stable-abi-subset.md
@@ -1,0 +1,68 @@
+# G14 — CPython Limited-API / `abi3` import-contract conformance
+
+**Registry:** `UC-WF-stable-abi-subset` (`planned`)
+**Effort:** M · **Risk:** low
+
+## Problem
+
+Every `abi3` wheel promises it uses only the **stable** CPython C-API subset, so
+one binary runs on all `Py_LIMITED_API`-compatible interpreters. abicheck has
+the substrate to verify this (the ELF/PE/Mach-O **undefined-symbol** table, plus
+the appcompat engine) but no driver that checks it. Today `compare`/`appcompat`
+reason about a binary's **exports**; for an extension module the exports are
+essentially just `PyInit_<mod>` — the compatibility surface that actually
+matters is what the module **imports** from libpython.
+
+Empirically confirmed (cryptography 42.0.8 → 43.0.3, both `cp39-abi3`):
+
+- `abicheck compare` returns `COMPATIBLE` — judged entirely from the export
+  table (1 → 25 exported symbols).
+- The real contract is invisible: the module's imported CPython symbols grow
+  from **111 → 118 `Py*`** (e.g. `PyByteArray_AsString/Size/Type`,
+  `PyNumber_And/Multiply/Power`, `PyObject_GenericSetDict`, `Py_DecRef/IncRef`).
+  If any imported symbol were outside the `abi3` set, or newer than the wheel's
+  declared `Py_LIMITED_API` floor, the wheel would fail to import on an older
+  interpreter with an `undefined symbol` error — and abicheck would still say
+  `COMPATIBLE`.
+
+## Goal & acceptance criteria
+
+- [ ] A check that enumerates an extension's **imported** CPython C-API symbols
+      and classifies each against a stable-ABI allowlist for a target
+      `Py_LIMITED_API` version.
+- [ ] An imported symbol outside the `abi3` set (or newer than the declared
+      floor) is reported as a deployment-`RISK`/`BREAKING` finding that reaches
+      the verdict and JSON/SARIF — not silently `COMPATIBLE`.
+- [ ] A clean `abi3` extension passes; a `--no-limited-api` extension that
+      imports a non-stable symbol is flagged.
+
+## Design
+
+1. Capture undefined/imported symbols already available in the snapshot
+   substrate; expose an imported-symbol view on the model if not present.
+2. Ship a stable-ABI allowlist (the `abi3` symbol set per CPython minor; sourced
+   from CPython's `Doc/data/stable_abi.dat`, vendored as data, refreshable).
+3. A driver `abicheck stable-abi <ext.so> [--abi3 3.9]` classifies imports;
+   wires through the existing reporter and a new `RISK`/`BREAKING` `ChangeKind`
+   (added per the root `CLAUDE.md` four-step procedure).
+4. Cross-platform: the same idea applies to `python3.dll` (PE imports) and the
+   macOS `.so` two-level-namespace imports.
+
+## Files & surfaces
+
+- `abicheck/model.py` (imported-symbol view if missing), a new
+  `abicheck/stable_abi.py` + vendored allowlist data, a CLI module
+  `abicheck/cli_stable_abi.py` (registered per the root `CLAUDE.md` "Adding a new
+  top-level command"), `abicheck/checker_policy.py` (new kind), reuse of
+  `abicheck/reporter.py`.
+
+## Tests
+
+- Unit: a synthetic extension importing only `abi3` symbols → pass; one importing
+  a non-stable `_Py*`/version-newer symbol → flagged.
+- An example pair under `examples/` with `ground_truth.json` entry.
+
+## Out of scope
+
+Verifying a wheel's *declared* tag against its contents end-to-end (packaging
+concern); non-CPython stable ABIs.

--- a/docs/development/plans/g15-inline-namespace-version.md
+++ b/docs/development/plans/g15-inline-namespace-version.md
@@ -1,0 +1,71 @@
+# G15 — inline-namespace version-stamp normalization
+
+**Registry:** `UC-CHANGE-inline-ns-version` (`planned`)
+**Effort:** M · **Risk:** medium
+
+## Problem
+
+Some C/C++ libraries stamp **every** exported symbol with a per-release version
+token — an inline namespace or a renaming macro — so that mixing two releases
+link-fails by construction. ICU is the canonical case (`icu_73` → `icu_74`); the
+same shape appears in libstdc++ versioned namespaces and Abseil's
+`absl::lts_YYYYMMDD`. Comparing two such releases makes **every** symbol look
+removed + re-added, burying the real, usually-additive delta.
+
+Empirically confirmed (ICU `libicuuc.so.73.2` → `libicuuc.so.74.2`):
+
+- `abicheck compare` returns **`BREAKING` with 6288 changes**.
+- Raw-name intersection of the `_73`/`_74`-stamped symbols: **0** — total
+  phantom churn.
+- After normalizing the version token: **1074 / 1074** old symbols still present,
+  **0 real removals**, **34 genuine additions**. The truthful verdict is
+  *additive* (plus a deliberate soname bump), not a 6288-change break.
+
+This is the same false-noise topology as G9 (auditwheel hashed sonames) but at
+the **C++ symbol** level rather than the filename level.
+
+## Goal & acceptance criteria
+
+- [ ] A normalization pass strips a recognised version token from symbol names
+      before diffing, so ICU 73→74 reports "additive, 34 new symbols, soname
+      bumped" instead of 6288 phantom changes.
+- [ ] The deliberate soname bump is still surfaced as the real "you must relink"
+      signal (normalization must not hide it).
+- [ ] A genuinely removed/changed symbol (beyond the version token) is still
+      detected.
+- [ ] Opt-in / auto-detected so ordinary libraries are unaffected (false-positive
+      guard).
+
+## Design
+
+1. Detect the stamp from a high-coverage suffix/namespace pattern: a token
+   shared by a large majority of exported symbols (`_<NN>` suffix for ICU,
+   `__<N>` inline-namespace mangling, `lts_<date>`), confirmed against the
+   library `SONAME` version so unrelated names are not stripped.
+2. Normalize both snapshots' symbol keys through the detected token, diff the
+   normalized surface, then re-annotate findings with the original names.
+3. Emit a single informational "inline-namespace version advanced `73`→`74`"
+   note carrying the soname-bump signal, rather than per-symbol churn.
+
+## Risk
+
+Over-eager stripping could mask a real rename. Mitigated by (a) requiring the
+token to cover a strong majority of symbols and (b) cross-checking the SONAME —
+both conditions must hold before normalization engages.
+
+## Files & surfaces
+
+- A normalizer in `abicheck/demangle.py` / `abicheck/classify.py`, hooked into
+  `abicheck/diff_symbols.py`; a detection helper; opt-in flag on the relevant
+  CLI module; possibly a new informational `ChangeKind`.
+
+## Tests
+
+- Unit: ICU-shaped symbol sets → additive verdict + soname-bump note; a control
+  library with an incidental `_NN` suffix → **not** normalized.
+- An example pair under `examples/` with `ground_truth.json` entry.
+
+## Out of scope
+
+Demangling-level inline-namespace collapse for arbitrary C++ ABIs beyond the
+detected stamp pattern.

--- a/docs/development/plans/g9-wheel-vendored-matching.md
+++ b/docs/development/plans/g9-wheel-vendored-matching.md
@@ -1,0 +1,76 @@
+# G9 — manylinux/auditwheel vendored-library pairing
+
+**Registry:** `UC-WF-wheel-vendored` (`planned`)
+**Effort:** M · **Risk:** low
+
+## Problem
+
+`compare-release` on two manylinux/macOS wheels of the same project treats
+**every vendored dependency as removed + re-added**, so the real
+version-to-version ABI delta of the bundled stack is never computed.
+
+`auditwheel` (Linux) and `delocate` (macOS) rewrite each vendored library to
+`lib<name>-<hash>.so.<ver>` **and rewrite its `SONAME` to match**. The hash is
+content-derived and changes on every rebuild, so library matching — which keys
+on filename/SONAME — pairs nothing. Empirically (Pillow 10.4.0 → 12.2.0): 15
+"library removed" + 18 "library added" warnings, and the real `libpng16`
+16.43.0 → 16.56.0 / libjpeg / freetype / harfbuzz deltas are lost, even though a
+direct file-to-file compare of the two `libpng16`s yields a clean `COMPATIBLE`
+verdict — confirmed by empirically scanning real manylinux wheels.
+
+**Corpus evidence.** A 43-wheel scan (popular C-extension packages, two releases
+each) found this on **every** package that vendors a stack — 42 phantom
+removed+added pairs in total:
+
+| Wheel | Phantom-paired vendored libs | What is lost |
+|---|---:|---|
+| Pillow 9.5 → 11.0 | 15 | libjpeg 62.3→62.4, libpng16 16.39→16.44, freetype, harfbuzz, tiff, webp, lcms2, lzma 5.4→5.6, … (the whole stack) |
+| opencv-python 4.8 → 4.10 | 14 | ffmpeg (avcodec/format/swscale), Qt5 5.15.0→5.15.13, openssl 1.1, libvpx 8→9 |
+| psycopg2-binary 2.9.7 → 2.9.10 | 5 | libpq 5.15→5.16, openssl, openldap |
+| pyzmq 25.1 → 26.2 | 2 | **libsodium SONAME 23→26**, libzmq |
+| numpy / shapely / h5py | 2 each | libgfortran/libquadmath, libgeos, libhdf5 |
+
+This is not only noise: it also causes **false negatives**. `pyzmq` bundles
+`libsodium` with a `SONAME` bump `23.3.0 → 26.1.0` — a real ABI break of the
+vendored dependency — which abicheck currently hides as "removed + added"
+instead of flagging. Pairing by unhashed stem and then diffing per dependency
+(below) surfaces it as the real signal.
+
+## Goal & acceptance criteria
+
+- [ ] `compare-release` pairs `lib<name>-<hashA>.so.<ver>` with
+      `lib<name>-<hashB>.so.<ver>` across two wheels, computing a per-dependency
+      verdict instead of removed/added noise.
+- [ ] Pairing is driven by the **unhashed soname stem** (e.g. `libpng16.so.16`),
+      derived by stripping the auditwheel/delocate suffix `-[0-9a-f]{6,16}` from
+      both the filename and the ELF/Mach-O `SONAME`/install-name.
+- [ ] A genuinely removed/added vendored lib is still reported as such.
+- [ ] A paired vendored lib whose `SONAME` major bumps (e.g. the pyzmq
+      `libsodium` `23 → 26` case) is reported as a real break, not absorbed by
+      the normalization — this is the regression-test anchor.
+- [ ] A two-wheel fixture proves the bundled stack is diffed.
+
+## Design
+
+1. A normalizer `strip_vendor_hash(name) -> stem` applied to both filename and
+   soname before the existing `compare-release` matching pass.
+2. Restrict the strip to the auditwheel/delocate shape (a `-<hex>` segment
+   immediately before `.so`/`.dylib` or the version suffix) so ordinary
+   hyphenated library names are untouched.
+3. Match on the normalized stem; fall back to today's behaviour when no hash
+   suffix is present.
+
+## Files & surfaces
+
+- `abicheck/cli_compare_release.py` (matching pass), a small helper in
+  `abicheck/binary_utils.py` or `abicheck/package.py`.
+
+## Tests
+
+- Unit: `strip_vendor_hash` on auditwheel/delocate names and on names that must
+  **not** be stripped (e.g. `libwebpdemux`, `libbrotlicommon`).
+- Workflow: two synthetic wheels with hashed vendored libs → paired verdicts.
+
+## Out of scope
+
+Non-hash vendoring schemes; cross-platform bundle analysis (tracked under G1).

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -15,6 +15,13 @@ scope**.
 | **G1** | [Cross-platform end-to-end validation](g1-cross-platform-e2e.md) | `UC-PLAT-windows-pe`, `UC-PLAT-macos-macho` | L |
 | **G4** | [libclang header-AST extractor](g4-header-ast-extractor.md) | `UC-ARCH-header-only` | XL |
 | **G6** | [Kernel BTF & accelerator workflows](g6-kernel-btf-and-accelerator.md) | `UC-ARCH-kernel-btf`, `UC-ARCH-sycl` | M |
+| **G9** | [manylinux/auditwheel vendored-library pairing](g9-wheel-vendored-matching.md) | `UC-WF-wheel-vendored` | M |
+| **G10** | [manylinux glibc-floor check](g10-glibc-floor-check.md) | `UC-TC-glibc-floor` | S |
+| **G11** | [Single-binary ABI audit / lint](g11-single-binary-audit.md) | `UC-WF-audit` | M |
+| **G12** | [Security-hardening drift surface + preset](g12-security-hardening.md) | `UC-WF-security-hardening` | M |
+| **G13** | [Cross-architecture comparison guardrail](g13-arch-mismatch-guard.md) | `UC-PLAT-arch-guard` | S |
+| **G14** | [CPython Limited-API / `abi3` import-contract](g14-stable-abi-subset.md) | `UC-WF-stable-abi-subset` | M |
+| **G15** | [Inline-namespace version-stamp normalization](g15-inline-namespace-version.md) | `UC-CHANGE-inline-ns-version` | M |
 
 > **G3** (workflow-scenario examples & Markdown/HTML coverage) is **done** —
 > see [`g3-workflow-examples-and-reporting.md`](g3-workflow-examples-and-reporting.md)

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -98,6 +98,30 @@ A real invocation is a point in this space:
 | **G7** | No semver-bump recommendation | recommender + report wiring | mapping + integration | reuse cases |
 | **G8** | Static libraries undocumented | ✅ archive detection + clear error path | ✅ unit (archive → guidance error) | ✅ documented non-goal (goals + limitations) |
 
+### Gaps added from empirical scanning (G9–G15)
+
+A later pass ran abicheck against real open-source binaries (distro `.so`,
+manylinux wheels + their vendored stack, static archives) and surfaced these
+*topology/workflow* gaps now tracked in the registry. G14–G15 were added after a
+43-wheel empirical scan (two releases each of popular C-extension packages):
+
+| ID | Gap | Registry use case | Plan |
+|---|---|---|---|
+| **G9** | auditwheel/manylinux vendored libs never pair (content-hash sonames change every rebuild) | `UC-WF-wheel-vendored` | [g9](plans/g9-wheel-vendored-matching.md) |
+| **G10** | no manylinux glibc-floor / platform-baseline check (data captured, no detector) | `UC-TC-glibc-floor` | [g10](plans/g10-glibc-floor-check.md) |
+| **G11** | no single-binary audit/lint mode (every command is comparative) | `UC-WF-audit` | [g11](plans/g11-single-binary-audit.md) |
+| **G12** | hardening-drift detected + gateable, but thin captured surface and no security preset | `UC-WF-security-hardening` | [g12](plans/g12-security-hardening.md) |
+| **G13** | no cross-architecture guardrail (x86-64 vs aarch64 reports false-green) | `UC-PLAT-arch-guard` | [g13](plans/g13-arch-mismatch-guard.md) |
+| **G14** | abi3 wheel compatibility lives in *imported* CPython symbols, not exports — never checked (cryptography 42→43 stays COMPATIBLE while +7 `Py*` imports appear) | `UC-WF-stable-abi-subset` | [g14](plans/g14-stable-abi-subset.md) |
+| **G15** | inline-namespace version stamp makes every symbol churn (ICU 73→74: 6288 phantom changes vs a real +34/−0) | `UC-CHANGE-inline-ns-version` | [g15](plans/g15-inline-namespace-version.md) |
+
+The 43-wheel scan also reproduced **G9 at scale**: every package that vendors a
+stack hit the phantom removed+added failure — 42 phantom pairs total, led by
+Pillow (15), opencv-python (14), psycopg2-binary (5) — and exposed a *false
+negative* (pyzmq's bundled `libsodium` `SONAME 23→26` hidden as removed+added).
+None of these require new change-*type* detection; G9 and G14 are the two
+highest-value.
+
 ### Answer to the four driving questions
 
 1. **How does abicheck handle these configurations?** Superbly for *change-type

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -44,6 +44,22 @@ use_cases:
       modules: [abicheck/semver.py]
       tests: [tests/test_semver_recommendation.py]
 
+  - id: UC-CHANGE-inline-ns-version
+    axis: change_class
+    name: Inline-namespace version-stamp normalization (ICU-style)
+    status: planned
+    gap: G15
+    plan: docs/development/plans/g15-inline-namespace-version.md
+    next_steps: >
+      Detect a per-release version token carried by a strong majority of exported
+      symbols (ICU `_NN`, libstdc++ versioned namespaces, Abseil `lts_<date>`),
+      cross-check it against the SONAME, normalize symbol keys through it, then
+      diff. Empirically confirmed on ICU libicuuc 73→74: abicheck reports BREAKING
+      with 6288 changes, but after normalization the real delta is +34 / -0
+      (additive plus a deliberate soname bump). Same false-noise topology as G9
+      at the C++ symbol level. Must still surface the soname bump as the real
+      relink signal.
+
   # ── archetype ─────────────────────────────────────────────────────────────
   - id: UC-ARCH-c-library
     axis: archetype
@@ -193,6 +209,20 @@ use_cases:
       Add a macOS e2e CI lane running compare/appcompat on native dylibs and
       track ARM64 AAPCS HFA/HVA / small-struct calling convention.
 
+  - id: UC-PLAT-arch-guard
+    axis: platform
+    name: Cross-architecture comparison guardrail (ELF e_machine)
+    status: planned
+    gap: G13
+    plan: docs/development/plans/g13-arch-mismatch-guard.md
+    next_steps: >
+      Capture ELF e_machine / EI_CLASS / endianness into the snapshot (PE and
+      Mach-O already carry a machine field) and treat a machine mismatch in
+      compare/compare-release as a hard ARCHITECTURE_MISMATCH guard instead of a
+      false-green COMPATIBLE_WITH_RISK verdict. Confirmed by empirical scanning:
+      x86-64 vs aarch64 of the same version currently reports 100%
+      binary-compatible.
+
   # ── workflow ──────────────────────────────────────────────────────────────
   - id: UC-WF-compare
     axis: workflow
@@ -261,11 +291,71 @@ use_cases:
       G1 / UC-PLAT-*. All bundle detectors run through compare-release; case84
       is validated end-to-end. bundle_soname_skew is opt-in via
       --bundle-cohort PREFIX so independent libraries are never inferred to be
-      co-versioned from their filenames.
+      co-versioned from their filenames. Caveat: wheels whose vendored
+      dependencies carry auditwheel/delocate content-hash sonames are not yet
+      paired across rebuilds — that topology is tracked separately as
+      UC-WF-wheel-vendored (G9).
     evidence:
       modules: [abicheck/bundle.py, abicheck/diff_cpp_patterns.py]
       tests: [tests/test_bundle.py, tests/test_cpp_pattern_detectors.py]
       examples: [examples/case84_bundle_soname_skew]
+
+  - id: UC-WF-wheel-vendored
+    axis: workflow
+    name: manylinux/auditwheel vendored-library pairing (hashed sonames)
+    status: planned
+    gap: G9
+    plan: docs/development/plans/g9-wheel-vendored-matching.md
+    next_steps: >
+      Normalize the auditwheel/delocate content-hash suffix (-[0-9a-f]{6,16})
+      on filename AND soname before pairing in compare-release; pair on the
+      unhashed soname stem so a bundled libpng16.so.16 matches across rebuilds.
+      Add a two-wheel fixture. Empirically confirmed: today every vendored dep
+      of a manylinux wheel shows as removed+added.
+
+  - id: UC-WF-stable-abi-subset
+    axis: workflow
+    name: CPython Limited-API / abi3 import-contract conformance
+    status: planned
+    gap: G14
+    plan: docs/development/plans/g14-stable-abi-subset.md
+    next_steps: >
+      An abi3 wheel's compatibility surface is the set of CPython C-API symbols
+      it IMPORTS, not what it exports. Add a check that classifies an extension's
+      imported Py* symbols against the stable-ABI allowlist for a target
+      Py_LIMITED_API floor. Empirically confirmed on cryptography 42->43: abicheck
+      returns COMPATIBLE from the export table while the imported surface grows
+      +7 Py* symbols, entirely invisible. A symbol outside abi3 or newer than the
+      floor would fail to import on older Python yet stay COMPATIBLE today.
+
+  - id: UC-WF-audit
+    axis: workflow
+    name: Single-binary ABI audit / lint (no baseline)
+    status: planned
+    gap: G11
+    plan: docs/development/plans/g11-single-binary-audit.md
+    next_steps: >
+      Add an `audit`/`dump --lint` driver running the single-snapshot subset of
+      detectors (executable stack, insecure RPATH/RUNPATH, missing SONAME,
+      unversioned symbols, internal-looking globals) so a library author can
+      scan before their first release. Substrate already on the snapshot model;
+      only the one-sided driver + hygiene rules are missing (F3).
+
+  - id: UC-WF-security-hardening
+    axis: workflow
+    name: Security-hardening drift scan (checksec across releases)
+    status: partial
+    gap: G12
+    plan: docs/development/plans/g12-security-hardening.md
+    evidence:
+      modules: [abicheck/elf_metadata.py, abicheck/diff_platform.py, abicheck/checker_policy.py]
+      tests: [tests/test_diff_platform_deep.py]
+    next_steps: >
+      Detection of executable_stack / runpath_changed and per-kind policy gating
+      already exist (verified: executable_stack: break -> BREAKING). Remaining:
+      capture the rest of the checksec surface (RELRO/BIND_NOW/PIE/stack-canary/
+      FORTIFY/W^X) so it can be diffed, and ship a turnkey security preset /
+      policies/security.yaml so gating is discoverable rather than hand-rolled (F5).
 
   - id: UC-WF-probe-matrix
     axis: workflow
@@ -325,6 +415,18 @@ use_cases:
       tests: [tests/test_format_compliance.py, tests/test_sprint9_html.py, tests/test_report_sections.py]
 
   # ── toolchain / language standard ───────────────────────────────────────────
+  - id: UC-TC-glibc-floor
+    axis: toolchain
+    name: Platform baseline floor (manylinux glibc requirement)
+    status: planned
+    gap: G10
+    plan: docs/development/plans/g10-glibc-floor-check.md
+    next_steps: >
+      Compare the max GLIBC_2.x in elf.versions_required (already captured)
+      against a declared floor (--glibc-floor or the wheel's manylinux tag) and
+      emit a deployment-RISK finding when exceeded. New ChangeKind
+      (platform_baseline_floor_raised); composes with diff_versioning.py (F2).
+
   - id: UC-TC-dual-abi
     axis: toolchain
     name: libstdc++ dual ABI flip (_GLIBCXX_USE_CXX11_ABI)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,13 @@ nav:
       - "G5: Plugin contract": development/plans/g5-plugin-bidirectional-contract.md
       - "G6: Kernel BTF & accelerator": development/plans/g6-kernel-btf-and-accelerator.md
       - "G8: Static libraries": development/plans/g8-static-libraries.md
+      - "G9: Wheel vendored-library pairing": development/plans/g9-wheel-vendored-matching.md
+      - "G10: manylinux glibc-floor check": development/plans/g10-glibc-floor-check.md
+      - "G11: Single-binary audit / lint": development/plans/g11-single-binary-audit.md
+      - "G12: Security-hardening drift": development/plans/g12-security-hardening.md
+      - "G13: Cross-architecture guardrail": development/plans/g13-arch-mismatch-guard.md
+      - "G14: abi3 import-contract": development/plans/g14-stable-abi-subset.md
+      - "G15: Inline-namespace version stamp": development/plans/g15-inline-namespace-version.md
     - ADR:
       - Overview: development/adr/index.md
       - "001: Technology Stack": development/adr/001-technology-stack.md


### PR DESCRIPTION
## What

A living findings log (`ABI_SCAN_USECASE_GAPS.md`) from running abicheck against **real** open-source binaries to surface usage models we don't cover today. Empirical companion to the top-down `docs/development/usecase-coverage-evaluation.md`.

This is iteration 1 of an ongoing `/loop` exercise; the doc is structured to be extended.

## Projects exercised
zlib · libcurl (OpenSSL vs gnutls build) · glibc · **Pillow manylinux wheels 10.4.0 → 12.2.0** and its full vendored stack (libpng, libjpeg, freetype, harfbuzz, …) · OpenSSL/zlib static archives. Linux x86-64, symbols+DWARF only (no castxml/abidiff).

## Headline gap (F1, HIGH, confirmed)
`compare-release` on two manylinux wheels treats **every vendored dependency as removed + re-added**, so the real version-to-version ABI delta of the bundled stack is never computed.

Cause: `auditwheel`/`delocate` rewrite vendored libs to `lib<name>-<8hexhash>.so.<ver>` **and rewrite the SONAME to match**; the content-hash changes every build, so filename/SONAME-based matching pairs nothing.

```
old SONAME: libpng16-58efbb84.so.16.43.0
new SONAME: libpng16-65c953c0.so.16.56.0
```

Comparing the two `libpng16` files directly (bypassing the matcher) gives a clean, useful result — `COMPATIBLE`, 13 additions, 100% — proving the signal exists but is lost in 33 noise warnings. Fix direction: normalize the auditwheel/delocate hash suffix before pairing. This is the dominant topology for PyPI native packages and is effectively unusable today.

## Other findings
- **F2 (MED)** — manylinux glibc-floor check: we already capture `versions_required` (GLIBC_2.x); no detector flags "requires newer glibc than the manylinux tag promises".
- **F3 (MED)** — no single-binary audit/lint mode for pre-first-release hygiene (exec stack, insecure RPATH, unversioned symbols) — all commands are comparative.
- **F4 (MED, known G8)** — static archives (`.a`) rejected outright; confirmed repro.

Each finding has a copy-pasteable repro. The doc also lists worked-well behaviours (stripped `.so`, debuginfod, package auto-extraction, symbol versioning) and a backlog of topologies to drive next (delocated macOS wheels, conda, distro `-dbgsym` pairs, RPATH drift, Rust `cdylib`, BTF).

Docs-only change; no code touched.

https://claude.ai/code/session_012Ko8YmWcXYCNAJ8PNJ2GNX

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ko8YmWcXYCNAJ8PNJ2GNX)_