### PR TITLE
feat: close/advance use-case coverage gaps (G8, G5, G2, G6)

### DIFF
--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -31,8 +31,11 @@ from typing import TYPE_CHECKING
 
 from .checker import Change, DiffResult, compare
 from .checker_policy import ChangeKind, Verdict, compute_verdict
+from .model import AbiSnapshot, Visibility
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .policy_file import PolicyFile
     from .suppression import SuppressionList
 
@@ -78,6 +81,33 @@ class AppCompatResult:
 
     # Coverage
     symbol_coverage: float = 100.0  # % of app's required symbols present in new lib
+
+
+@dataclass
+class PluginHostContractResult:
+    """Result of checking a plugin upgrade against a host's load contract.
+
+    The dlopen() failure mode is two-sided: a host resolves a fixed set of
+    entry-point symbols (``dlsym``) from each plugin it loads. This is the
+    plugin-load direction of :class:`AppCompatResult` — "does plugin v2 still
+    satisfy host H's required entrypoints?" (ADR-005 / gap G5).
+    """
+
+    old_plugin: str
+    new_plugin: str
+
+    #: entry-point symbols the host resolves from the plugin (the contract).
+    required_entrypoints: set[str] = field(default_factory=set)
+    #: required entrypoints the *new* plugin no longer exports → host load break.
+    missing_entrypoints: list[str] = field(default_factory=list)
+    #: library diff changes that touch a required entrypoint.
+    breaking_for_host: list[Change] = field(default_factory=list)
+    #: full plugin v1→v2 diff (for reference / reporting).
+    full_diff: DiffResult | None = None
+    #: host-scoped verdict (BREAKING when an entrypoint is dropped/incompatible).
+    verdict: Verdict = Verdict.COMPATIBLE
+    #: % of the host's required entrypoints still provided by the new plugin.
+    coverage: float = 100.0
 
 
 # ---------------------------------------------------------------------------
@@ -790,4 +820,84 @@ def check_against(
         full_diff=None,
         verdict=verdict,
         symbol_coverage=coverage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plugin host↔plugin load contract (the dlopen direction) — gap G5
+# ---------------------------------------------------------------------------
+
+def _snapshot_export_names(snap: AbiSnapshot) -> set[str]:
+    """Names a host could resolve from a plugin via ``dlsym``.
+
+    Exported functions and variables, indexed by both their source name and
+    their mangled name so an ``extern "C"`` entrypoint (matched by plain name)
+    and a C++ symbol (matched by mangled name) both resolve.
+    """
+    names: set[str] = set()
+    for fn in snap.functions:
+        if fn.visibility is Visibility.PUBLIC:
+            names.add(fn.name)
+            if fn.mangled:
+                names.add(fn.mangled)
+    for var in snap.variables:
+        if var.visibility is Visibility.PUBLIC:
+            names.add(var.name)
+            mangled = getattr(var, "mangled", None)
+            if mangled:
+                names.add(mangled)
+    return names
+
+
+def check_plugin_host_contract(
+    old_plugin: AbiSnapshot,
+    new_plugin: AbiSnapshot,
+    required_entrypoints: Iterable[str],
+    *,
+    suppression: SuppressionList | None = None,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+) -> PluginHostContractResult:
+    """Check whether a plugin upgrade still satisfies a host's load contract.
+
+    Given two snapshots of a plugin (old/new) and the set of entry-point
+    symbols a *host* resolves from it (a manifest, or symbols a host binary
+    exports back to the plugin), report whether the new plugin still satisfies
+    the host — the plugin-load mirror of :func:`check_appcompat`.
+
+    The host's required entrypoints are exactly the "undefined symbols" it
+    resolves from the plugin, so this reuses appcompat's consumer-scoping
+    (:func:`_partition_app_changes`) and verdict logic
+    (:func:`_compute_appcompat_verdict`): a dropped or incompatible entrypoint
+    is ``BREAKING`` for the host even when the wider library verdict differs.
+    """
+    required = set(required_entrypoints)
+
+    diff = compare(
+        old_plugin, new_plugin,
+        suppression=suppression, policy=policy, policy_file=policy_file,
+    )
+
+    new_exports = _snapshot_export_names(new_plugin)
+    missing = sorted(e for e in required if e not in new_exports)
+
+    # Reuse the app-scoping machinery: the contract is a set of required
+    # ("undefined") symbols, identical in shape to an app's symbol needs.
+    host_reqs = AppRequirements(undefined_symbols=set(required))
+    breaking_for_host, _ = _partition_app_changes(diff, host_reqs)
+
+    verdict = _compute_appcompat_verdict(
+        missing, [], breaking_for_host, len(required), policy, policy_file,
+    )
+    coverage = _compute_symbol_coverage(new_exports, len(required), len(missing))
+
+    return PluginHostContractResult(
+        old_plugin=old_plugin.library or "old",
+        new_plugin=new_plugin.library or "new",
+        required_entrypoints=required,
+        missing_entrypoints=missing,
+        breaking_for_host=breaking_for_host,
+        full_diff=diff,
+        verdict=verdict,
+        coverage=coverage,
     )

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -844,6 +844,15 @@ def _resolvable_symbol_names(name: str, mangled: str | None) -> set[str]:
     return {name}
 
 
+#: Visibilities that correspond to a symbol actually exported from the binary.
+#: PUBLIC is the header/DWARF-aware default; ELF_ONLY is how a symbols-only dump
+#: (a stripped binary with no headers/DWARF — the common `plugin-check old.so
+#: new.so` case) represents an exported `.dynsym` entry. HIDDEN is not exported.
+_EXPORTED_VISIBILITIES: frozenset[Visibility] = frozenset(
+    {Visibility.PUBLIC, Visibility.ELF_ONLY}
+)
+
+
 def _snapshot_export_names(snap: AbiSnapshot) -> set[str]:
     """Linker-symbol names a host could resolve from a plugin via ``dlsym``.
 
@@ -851,13 +860,17 @@ def _snapshot_export_names(snap: AbiSnapshot) -> set[str]:
     plus the plain source name only for ``extern "C"`` / C symbols where it
     equals the mangled name. A demangled C++ name is deliberately excluded so a
     contract listing it is reported as *missing*, matching ``dlsym`` reality.
+
+    Both header/DWARF-aware (``PUBLIC``) and symbols-only (``ELF_ONLY``) exports
+    count: running ``plugin-check`` on real stripped binaries without headers is
+    the common case, and there every export is ``ELF_ONLY``.
     """
     names: set[str] = set()
     for fn in snap.functions:
-        if fn.visibility is Visibility.PUBLIC:
+        if fn.visibility in _EXPORTED_VISIBILITIES:
             names |= _resolvable_symbol_names(fn.name, fn.mangled)
     for var in snap.variables:
-        if var.visibility is Visibility.PUBLIC:
+        if var.visibility in _EXPORTED_VISIBILITIES:
             names |= _resolvable_symbol_names(var.name, getattr(var, "mangled", None))
     return names
 

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -827,25 +827,38 @@ def check_against(
 # Plugin host↔plugin load contract (the dlopen direction) — gap G5
 # ---------------------------------------------------------------------------
 
-def _snapshot_export_names(snap: AbiSnapshot) -> set[str]:
-    """Names a host could resolve from a plugin via ``dlsym``.
+def _resolvable_symbol_names(name: str, mangled: str | None) -> set[str]:
+    """The names ``dlsym`` could actually resolve for one exported entity.
 
-    Exported functions and variables, indexed by both their source name and
-    their mangled name so an ``extern "C"`` entrypoint (matched by plain name)
-    and a C++ symbol (matched by mangled name) both resolve.
+    ``dlsym`` resolves the *linker* symbol — the mangled name. The source
+    ``name`` is only resolvable when it *is* the linker symbol (``extern "C"``
+    or C, where ``mangled == name``); a demangled C++ name like ``foo(int)`` is
+    NOT a dlsym key and must not count as satisfying a host contract. When no
+    mangled name is recorded, fall back to ``name`` as the best available key.
+    """
+    if mangled:
+        names = {mangled}
+        if name == mangled:
+            names.add(name)
+        return names
+    return {name}
+
+
+def _snapshot_export_names(snap: AbiSnapshot) -> set[str]:
+    """Linker-symbol names a host could resolve from a plugin via ``dlsym``.
+
+    Exported functions and variables, keyed by their mangled (linker) symbol —
+    plus the plain source name only for ``extern "C"`` / C symbols where it
+    equals the mangled name. A demangled C++ name is deliberately excluded so a
+    contract listing it is reported as *missing*, matching ``dlsym`` reality.
     """
     names: set[str] = set()
     for fn in snap.functions:
         if fn.visibility is Visibility.PUBLIC:
-            names.add(fn.name)
-            if fn.mangled:
-                names.add(fn.mangled)
+            names |= _resolvable_symbol_names(fn.name, fn.mangled)
     for var in snap.variables:
         if var.visibility is Visibility.PUBLIC:
-            names.add(var.name)
-            mangled = getattr(var, "mangled", None)
-            if mangled:
-                names.add(mangled)
+            names |= _resolvable_symbol_names(var.name, getattr(var, "mangled", None))
     return names
 
 

--- a/abicheck/binary_utils.py
+++ b/abicheck/binary_utils.py
@@ -31,10 +31,13 @@ _MACHO_MAGICS: frozenset[bytes] = frozenset({
     b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca",  # fat archive 64
 })
 
-# Unix `ar` archive magic — shared by static libraries (`.a`) and MSVC/COFF
-# import/static libraries (`.lib`). Both are member archives, not the kind of
-# single linkable image abicheck analyses (see detect_archive / G8).
-_ARCHIVE_MAGIC: bytes = b"!<arch>\n"
+# Unix `ar` archive magics — shared by static libraries (`.a`) and MSVC/COFF
+# import/static libraries (`.lib`). `!<arch>\n` is the standard archive;
+# `!<thin>\n` is a GNU thin archive (`ar rcT`, members referenced by path).
+# Both are member archives, not the kind of single linkable image abicheck
+# analyses (see detect_archive / G8). Both magics are 8 bytes.
+_ARCHIVE_MAGICS: frozenset[bytes] = frozenset({b"!<arch>\n", b"!<thin>\n"})
+_ARCHIVE_MAGIC_LEN: int = 8
 
 
 def classify_magic(magic: bytes) -> str | None:
@@ -69,13 +72,14 @@ def detect_archive(path: str | Path) -> bool:
     """Return True if ``path`` is a Unix `ar` archive (`.a` / `.lib`).
 
     Static libraries and COFF import libraries are member archives sharing the
-    ``!<arch>\\n`` magic. abicheck analyses single linkable images (shared
-    libraries / objects), so the service layer uses this to fail deliberately
-    with guidance rather than late with a misleading "unknown format" error.
+    ``!<arch>\\n`` magic; GNU *thin* archives (``ar rcT``) use ``!<thin>\\n``.
+    abicheck analyses single linkable images (shared libraries / objects), so
+    the service layer uses this to fail deliberately with guidance rather than
+    late with a misleading "unknown format" error.
     """
     try:
         with open(path, "rb") as f:
-            magic = f.read(len(_ARCHIVE_MAGIC))
+            magic = f.read(_ARCHIVE_MAGIC_LEN)
     except OSError:
         return False
-    return magic == _ARCHIVE_MAGIC
+    return magic in _ARCHIVE_MAGICS

--- a/abicheck/binary_utils.py
+++ b/abicheck/binary_utils.py
@@ -31,6 +31,11 @@ _MACHO_MAGICS: frozenset[bytes] = frozenset({
     b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca",  # fat archive 64
 })
 
+# Unix `ar` archive magic — shared by static libraries (`.a`) and MSVC/COFF
+# import/static libraries (`.lib`). Both are member archives, not the kind of
+# single linkable image abicheck analyses (see detect_archive / G8).
+_ARCHIVE_MAGIC: bytes = b"!<arch>\n"
+
 
 def classify_magic(magic: bytes) -> str | None:
     """Classify binary format from the first 4 (or more) magic bytes.
@@ -58,3 +63,19 @@ def detect_binary_format(path: str | Path) -> str | None:
     except OSError:
         return None
     return classify_magic(magic)
+
+
+def detect_archive(path: str | Path) -> bool:
+    """Return True if ``path`` is a Unix `ar` archive (`.a` / `.lib`).
+
+    Static libraries and COFF import libraries are member archives sharing the
+    ``!<arch>\\n`` magic. abicheck analyses single linkable images (shared
+    libraries / objects), so the service layer uses this to fail deliberately
+    with guidance rather than late with a misleading "unknown format" error.
+    """
+    try:
+        with open(path, "rb") as f:
+            magic = f.read(len(_ARCHIVE_MAGIC))
+    except OSError:
+        return False
+    return magic == _ARCHIVE_MAGIC

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -467,6 +467,18 @@ def _resolve_input(
             "shared library named in its INPUT(...) directive directly."
         )
 
+    # Static / import library archives (.a / .lib) are member containers, not a
+    # single linkable image — a deliberate non-goal (see
+    # docs/concepts/limitations.md). Reject with actionable guidance.
+    from .binary_utils import detect_archive
+    if detect_archive(path):
+        raise click.UsageError(
+            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
+            "does not analyse — it compares single linkable images (shared libraries "
+            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
+            "resulting object files or the shared library built from them instead."
+        )
+
     raise click.UsageError(
         f"Cannot detect format of '{path}'. "
         "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1975,6 +1975,7 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
     cli_baseline,  # noqa: F401  — registers baseline
     cli_compare_release,  # noqa: F401  — registers compare-release
     cli_debian_symbols,  # noqa: F401  — registers debian-symbols
+    cli_plugin,  # noqa: F401  — registers plugin-check
     cli_probe,  # noqa: F401  — registers probe (run, compare)
     cli_stack,  # noqa: F401  — registers deps, stack-check
     cli_suggest,  # noqa: F401  — registers suggest-suppressions

--- a/abicheck/cli_plugin.py
+++ b/abicheck/cli_plugin.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI — ``plugin-check`` host↔plugin load-contract command (gap G5).
+
+Answers the plugin-load direction of ``appcompat``: "does plugin v2 still
+satisfy host H's required entrypoints?" A host ``dlopen``s a plugin and
+resolves a fixed set of entry-point symbols via ``dlsym``; whether a plugin's
+symbol churn breaks *that host* depends on the host's required set, not the
+library-wide verdict.
+
+Split out of :mod:`abicheck.cli` and imported for side-effect at the bottom of
+that module so the ``@main.command("plugin-check")`` decorator runs.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from .checker import Verdict
+from .cli import (
+    _load_suppression_and_policy,
+    _resolve_input,
+    _safe_write_output,
+    _setup_verbosity,
+    main,
+)
+
+
+def _load_required_entrypoints(
+    require: tuple[str, ...], host_contract: Path | None,
+) -> set[str]:
+    """Collect the host's required entrypoints from ``--require`` flags and an
+    optional manifest file (one symbol per line; ``#`` comments and blanks
+    ignored)."""
+    entrypoints: set[str] = set(require)
+    if host_contract is not None:
+        for raw in host_contract.read_text(encoding="utf-8").splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if line:
+                entrypoints.add(line)
+    return entrypoints
+
+
+def _render_plugin_result_markdown(result: object) -> str:
+    from .appcompat import PluginHostContractResult
+    assert isinstance(result, PluginHostContractResult)
+    lines = [
+        "# Plugin host-contract check",
+        "",
+        f"- **Old plugin:** {result.old_plugin}",
+        f"- **New plugin:** {result.new_plugin}",
+        f"- **Required entrypoints:** {len(result.required_entrypoints)}",
+        f"- **Entrypoint coverage:** {result.coverage:.1f}%",
+        f"- **Verdict:** {result.verdict.value.upper()}",
+        "",
+    ]
+    if result.missing_entrypoints:
+        lines.append("## Missing entrypoints (host load break)")
+        lines.append("")
+        lines += [f"- `{sym}`" for sym in result.missing_entrypoints]
+        lines.append("")
+    if result.breaking_for_host:
+        lines.append("## Incompatible changes affecting the host")
+        lines.append("")
+        lines += [
+            f"- `{c.symbol}` — {c.kind.value}" for c in result.breaking_for_host
+        ]
+        lines.append("")
+    if not result.missing_entrypoints and not result.breaking_for_host:
+        lines.append("All required entrypoints are still satisfied by the new plugin.")
+    return "\n".join(lines)
+
+
+def _render_plugin_result_json(result: object) -> str:
+    from .appcompat import PluginHostContractResult
+    assert isinstance(result, PluginHostContractResult)
+    return json.dumps(
+        {
+            "old_plugin": result.old_plugin,
+            "new_plugin": result.new_plugin,
+            "required_entrypoints": sorted(result.required_entrypoints),
+            "missing_entrypoints": result.missing_entrypoints,
+            "breaking_for_host": [
+                {"symbol": c.symbol, "kind": c.kind.value}
+                for c in result.breaking_for_host
+            ],
+            "coverage": result.coverage,
+            "verdict": result.verdict.value,
+        },
+        indent=2,
+    )
+
+
+@main.command("plugin-check")
+@click.argument("old_plugin", type=click.Path(exists=True, path_type=Path))
+@click.argument("new_plugin", type=click.Path(exists=True, path_type=Path))
+@click.option("-r", "--require", "require", multiple=True, metavar="SYMBOL",
+              help="An entry-point symbol the host resolves from the plugin "
+                   "(repeatable).")
+@click.option("--host-contract", "host_contract",
+              type=click.Path(exists=True, path_type=Path), default=None,
+              help="Manifest file listing required entrypoints, one per line "
+                   "(# comments allowed).")
+@click.option("--lang", default="c++", show_default=True,
+              type=click.Choice(["c++", "c"], case_sensitive=False),
+              help="Language mode (used only when dumping plugin binaries).")
+@click.option("--format", "fmt", type=click.Choice(["markdown", "json"]),
+              default="markdown", show_default=True)
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
+@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Suppression file (YAML).")
+@click.option("--policy", "policy",
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
+              default="plugin_abi", show_default=True,
+              help="Verdict policy; plugin_abi is the natural default for "
+                   "in-process host/plugin builds.")
+@click.option("--policy-file", "policy_file_path",
+              type=click.Path(exists=True, path_type=Path), default=None)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def plugin_check_cmd(
+    old_plugin: Path,
+    new_plugin: Path,
+    require: tuple[str, ...],
+    host_contract: Path | None,
+    lang: str,
+    fmt: str,
+    output: Path | None,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
+    verbose: bool,
+) -> None:
+    """Check whether a plugin upgrade still satisfies a host's load contract.
+
+    A host ``dlopen``s a plugin and resolves a fixed set of entry-point symbols.
+    Given the old and new plugin (binary or JSON snapshot) and the host's
+    required entrypoints, report whether the new plugin still satisfies the
+    host — the plugin-load direction of ``appcompat``.
+
+    \b
+    Examples:
+      abicheck plugin-check plugin.v1.so plugin.v2.so -r plugin_init -r plugin_run
+      abicheck plugin-check plugin.v1.so plugin.v2.so --host-contract host.syms
+
+    \b
+    Exit codes (host-scoped verdict):
+      0  COMPATIBLE — the new plugin still satisfies the host
+      2  API_BREAK — source-level break affecting a required entrypoint
+      4  BREAKING — a required entrypoint was dropped or is ABI-incompatible
+    """
+    _setup_verbosity(verbose)
+
+    entrypoints = _load_required_entrypoints(require, host_contract)
+    if not entrypoints:
+        raise click.UsageError(
+            "No required entrypoints given. Provide --require SYMBOL (repeatable) "
+            "and/or --host-contract FILE."
+        )
+
+    from .appcompat import check_plugin_host_contract
+
+    old_snap = _resolve_input(old_plugin, [], [], "old", lang)
+    new_snap = _resolve_input(new_plugin, [], [], "new", lang)
+    suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
+
+    result = check_plugin_host_contract(
+        old_snap, new_snap, entrypoints,
+        suppression=suppression, policy=policy, policy_file=pf,
+    )
+
+    text = _render_plugin_result_json(result) if fmt == "json" else _render_plugin_result_markdown(result)
+
+    if output:
+        _safe_write_output(output, text)
+        click.echo(f"Report written to {output}", err=True)
+    else:
+        click.echo(text)
+
+    if result.verdict == Verdict.BREAKING:
+        sys.exit(4)
+    elif result.verdict == Verdict.API_BREAK:
+        sys.exit(2)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -583,6 +583,15 @@ def dump(
             debug_format=debug_format,
         )
     else:
+        from .binary_utils import detect_archive
+        if detect_archive(so_path):
+            raise ValidationError(
+                f"'{so_path}' is a static/import library archive (.a/.lib), which "
+                "abicheck does not analyse — it compares single linkable images "
+                "(shared libraries and objects). Extract the members (e.g. "
+                "`ar x lib.a`) and compare the resulting object files or the shared "
+                "library built from them instead."
+            )
         raise ValidationError(
             f"Unrecognised binary format for {so_path}: "
             f"expected ELF, Mach-O, or PE but detected {fmt!r}. "

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -203,6 +203,7 @@ def _parse(f: IO[bytes], so_path: Path) -> ElfMetadata:
     # _correlate_symbol_versions does not need to re-iterate all sections.
     ver_sym_section: GNUVerSymSection | None = None
     dynsym_section: SymbolTableSection | None = None
+    symtab_section: SymbolTableSection | None = None
 
     for section in elf.iter_sections():
         try:
@@ -219,10 +220,26 @@ def _parse(f: IO[bytes], so_path: Path) -> ElfMetadata:
             elif isinstance(section, SymbolTableSection) and section.name == ".dynsym":
                 _parse_dynsym(section, meta)
                 dynsym_section = section
+            elif isinstance(section, SymbolTableSection) and section.name == ".symtab":
+                # Captured but not parsed yet — only used as a fallback for
+                # relocatable objects (.o) that have no .dynsym (see below).
+                symtab_section = section
         except Exception as exc:  # noqa: BLE001
             # Partial-success: log malformed section, keep results from other sections.
             log.warning("parse_elf_metadata: skipping malformed section %r in %s: %s",
                         section.name, so_path, exc)
+
+    # Relocatable objects (ET_REL `.o`, e.g. a probe-built object) carry no
+    # `.dynsym` — their symbol surface lives in `.symtab`. Fall back to it so the
+    # defined GLOBAL/WEAK symbols of a `.o` are captured (the same classification
+    # `_parse_dynsym` applies to a `.dynsym`). A normal shared library always has
+    # `.dynsym`, so this never alters DSO parsing.
+    if dynsym_section is None and symtab_section is not None:
+        try:
+            _parse_dynsym(symtab_section, meta)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("parse_elf_metadata: skipping malformed .symtab in %s: %s",
+                        so_path, exc)
 
     # Merge: verdef entries take priority over verneed on index collision.
     ver_index_map: dict[int, tuple[str, str, bool]] = {**verneed_index_map, **verdef_index_map}

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -390,6 +390,19 @@ def _resolve_input(
     if head.startswith("{"):
         return load_snapshot(path)
 
+    # Static / import library archives (.a / .lib) are member containers, not a
+    # single linkable image — a deliberate non-goal (see
+    # docs/concepts/limitations.md). Reject with actionable guidance, matching
+    # the CLI/service/dumper paths.
+    from .binary_utils import detect_archive
+    if detect_archive(path):
+        raise AbicheckError(
+            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
+            "does not analyse — it compares single linkable images (shared libraries "
+            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
+            "resulting object files or the shared library built from them instead."
+        )
+
     raise AbicheckError(
         "Cannot detect input format. "
         "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -185,6 +185,19 @@ def resolve_input(
         except (ValueError, KeyError, UnicodeDecodeError, OSError) as exc:
             raise SnapshotError(f"Failed to load JSON snapshot '{path}': {exc}") from exc
 
+    # Static / import libraries (`.a`, `.lib`) are member archives, not single
+    # linkable images. abicheck does not analyse archives (by design — see
+    # docs/concepts/limitations.md); fail with actionable guidance rather than a
+    # generic "unknown format" error.
+    from .binary_utils import detect_archive
+    if detect_archive(path):
+        raise ValidationError(
+            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
+            "does not analyse — it compares single linkable images (shared libraries "
+            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
+            "resulting object files or the shared library built from them instead."
+        )
+
     raise ValidationError(
         f"Cannot detect format of '{path}'. "
         "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -120,6 +120,43 @@ changes that don't affect exported symbols will not be detected.
 
 ---
 
+## Static / import library archives (`.a`, `.lib`)
+
+`abicheck` analyses **single linkable images** — shared libraries (`.so`,
+`.dll`, `.dylib`) and individual object files. It does **not** analyse static
+or import library archives (`.a` on Unix, `.lib` on Windows). This is a
+deliberate non-goal (see [Project Goals → Non-goals](../development/goals.md#non-goals)),
+for two reasons:
+
+- A static library has **no runtime ABI surface**: no `SONAME`, no dynamic
+  symbol table, no symbol versioning — the very signals abicheck's verdict
+  semantics are built on. Only object-level symbol/type information would
+  apply, and a link-time API check over the union of members is a different
+  tool with different semantics.
+- Archives are **member containers** (`ar` format, magic `!<arch>\n`), not a
+  single image; both `.a` and MSVC `.lib` share this format.
+
+Handing a `.a`/`.lib` to `dump` or `compare` produces a **clear, actionable
+error** rather than a misleading "unknown format" message or a traceback:
+
+```text
+'libfoo.a' is a static/import library archive (.a/.lib), which abicheck does
+not analyse — it compares single linkable images (shared libraries and
+objects). Extract the members (e.g. `ar x lib.a`) and compare the resulting
+object files or the shared library built from them instead.
+```
+
+**Mitigation:** extract the archive members and compare the resulting object
+files, or compare the shared library built from the same sources:
+
+```bash
+ar x libfoo-old.a && ar x libfoo-new.a   # then compare the .o members
+# or, preferred:
+abicheck compare libfoo-old.so libfoo-new.so -H include/foo.h
+```
+
+---
+
 ## Dependency Limitations & Known Bugs
 
 Known issues in third-party dependencies that affect `abicheck` behavior.

--- a/docs/development/goals.md
+++ b/docs/development/goals.md
@@ -117,3 +117,10 @@ Public documentation at <https://napetrov.github.io/abicheck/>:
 - Runtime instrumentation or dynamic analysis — abicheck is a static offline tool.
 - Source-level refactoring suggestions — it reports *what* broke, not how to fix your code.
 - Support for languages other than C/C++ (Rust, Go, etc.) — out of scope for now.
+- Static / import library archives (`.a`, `.lib`) — abicheck compares single
+  linkable images (shared libraries and objects), not `ar` member archives. A
+  static library has no runtime ABI surface (no SONAME, no dynamic symbol
+  table); link-time API checking over archive members is a deliberate non-goal.
+  Extract members (`ar x lib.a`) and compare the resulting objects, or the
+  shared library built from them, instead. See
+  [limitations](../concepts/limitations.md#static-import-library-archives-a-lib).

--- a/docs/development/plans/g2-build-config-and-bundle.md
+++ b/docs/development/plans/g2-build-config-and-bundle.md
@@ -35,10 +35,12 @@ Two capabilities exist but are not reachable from the mainline gate:
       `tests/test_cli_split_modules.py`.
 - [x] Case 98 (`CXX_STANDARD_FLOOR_RAISED`) reaches its intended verdict through
       the mainline command (JSON + SARIF), not only `probe compare`. Case 97
-      (`API_DEPENDS_ON_CONSUMER_ENV`) — detector unit-tested; end-to-end is
-      blocked by a separate harness gap (the dumper reads `.dynsym`, which a
-      relocatable probe `.o` lacks, so a probe's symbol surface is not yet
-      captured). Tracked in the registry `next_steps` for `UC-WF-probe-matrix`.
+      (`API_DEPENDS_ON_CONSUMER_ENV`) now also fires end-to-end: the harness gap
+      is closed — `parse_elf_metadata` falls back to `.symtab` when a relocatable
+      probe `.o` has no `.dynsym`, so the object's defined global symbols are
+      captured and the detector fires over the real compiled surface, reaching
+      the mainline `compare` output (`tests/test_probe_examples.py`,
+      `tests/test_elf_object_surface.py`).
 - [x] `compare-release` emits `bundle_soname_skew`; case84 lost `skip: true`
       and is validated end-to-end (`tests/test_bundle.py::TestCompareReleaseBundleE2E`).
       The check is **opt-in** via `--bundle-cohort PREFIX` (repeatable): cohorts

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -15,7 +15,6 @@ scope**.
 | **G1** | [Cross-platform end-to-end validation](g1-cross-platform-e2e.md) | `UC-PLAT-windows-pe`, `UC-PLAT-macos-macho` | L |
 | **G2** | [Build-config matrix → `compare`, and bundle completion](g2-build-config-and-bundle.md) | `UC-WF-probe-matrix`, `UC-WF-bundle`, `UC-TC-cxx-standard-floor` | M |
 | **G4** | [libclang header-AST extractor](g4-header-ast-extractor.md) | `UC-ARCH-header-only` | XL |
-| **G5** | [Plugin host↔plugin contract](g5-plugin-bidirectional-contract.md) | `UC-ARCH-plugin` | M |
 | **G6** | [Kernel BTF & accelerator workflows](g6-kernel-btf-and-accelerator.md) | `UC-ARCH-kernel-btf`, `UC-ARCH-sycl` | M |
 
 > **G3** (workflow-scenario examples & Markdown/HTML coverage) is **done** —
@@ -27,6 +26,9 @@ scope**.
 > **G8** ([static-library stance](g8-static-libraries.md)) is **decided**
 > (option A — non-goal): the CLI now detects `.a`/`.lib` archives and rejects
 > them with guidance, and `UC-ARCH-static-lib` is `by_design_excluded`.
+> **G5** ([plugin host↔plugin contract](g5-plugin-bidirectional-contract.md)) is
+> **done**: the `plugin-check` CLI + `check_plugin_host_contract` API close the
+> dlopen direction, and `UC-ARCH-plugin` is `complete`.
 
 ## How to pick up a plan
 

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -13,16 +13,17 @@ scope**.
 | Gap | Plan | Registry use cases | Effort |
 |---|---|---|---|
 | **G1** | [Cross-platform end-to-end validation](g1-cross-platform-e2e.md) | `UC-PLAT-windows-pe`, `UC-PLAT-macos-macho` | L |
-| **G2** | [Build-config matrix → `compare`, and bundle completion](g2-build-config-and-bundle.md) | `UC-WF-probe-matrix`, `UC-WF-bundle`, `UC-TC-cxx-standard-floor` | M |
 | **G4** | [libclang header-AST extractor](g4-header-ast-extractor.md) | `UC-ARCH-header-only` | XL |
 | **G6** | [Kernel BTF & accelerator workflows](g6-kernel-btf-and-accelerator.md) | `UC-ARCH-kernel-btf`, `UC-ARCH-sycl` | M |
 
 > **G3** (workflow-scenario examples & Markdown/HTML coverage) is **done** —
 > see [`g3-workflow-examples-and-reporting.md`](g3-workflow-examples-and-reporting.md)
-> and the evaluation doc. **G2** is largely done: the matrix folds into
-> `compare`/`compare-release` and the bundle soname-skew is wired + validated;
-> the one residual is end-to-end `API_DEPENDS_ON_CONSUMER_ENV` (probe `.o`
-> surface capture). **G7** (release recommendation) is **done** too.
+> and the evaluation doc. **G2** ([build-config matrix](g2-build-config-and-bundle.md))
+> is **done**: the matrix folds into `compare`/`compare-release`, the bundle
+> soname-skew is wired + validated, and both `CXX_STANDARD_FLOOR_RAISED` and
+> `API_DEPENDS_ON_CONSUMER_ENV` fire end-to-end (the latter unblocked by the
+> relocatable-object `.symtab` surface capture). **G7** (release recommendation)
+> is **done** too.
 > **G8** ([static-library stance](g8-static-libraries.md)) is **decided**
 > (option A — non-goal): the CLI now detects `.a`/`.lib` archives and rejects
 > them with guidance, and `UC-ARCH-static-lib` is `by_design_excluded`.

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -17,7 +17,6 @@ scope**.
 | **G4** | [libclang header-AST extractor](g4-header-ast-extractor.md) | `UC-ARCH-header-only` | XL |
 | **G5** | [Plugin host↔plugin contract](g5-plugin-bidirectional-contract.md) | `UC-ARCH-plugin` | M |
 | **G6** | [Kernel BTF & accelerator workflows](g6-kernel-btf-and-accelerator.md) | `UC-ARCH-kernel-btf`, `UC-ARCH-sycl` | M |
-| **G8** | [Static-library stance](g8-static-libraries.md) | `UC-ARCH-static-lib` | S (decision) |
 
 > **G3** (workflow-scenario examples & Markdown/HTML coverage) is **done** —
 > see [`g3-workflow-examples-and-reporting.md`](g3-workflow-examples-and-reporting.md)
@@ -25,6 +24,9 @@ scope**.
 > `compare`/`compare-release` and the bundle soname-skew is wired + validated;
 > the one residual is end-to-end `API_DEPENDS_ON_CONSUMER_ENV` (probe `.o`
 > surface capture). **G7** (release recommendation) is **done** too.
+> **G8** ([static-library stance](g8-static-libraries.md)) is **decided**
+> (option A — non-goal): the CLI now detects `.a`/`.lib` archives and rejects
+> them with guidance, and `UC-ARCH-static-lib` is `by_design_excluded`.
 
 ## How to pick up a plan
 

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -79,7 +79,7 @@ A real invocation is a point in this space:
 | Bundle / multi-library | `complete` | all detectors run via `compare-release`; case84 validated e2e (Linux-only by design; cross-platform → G1) |
 | Plugin (host↔plugin) | `complete` | **G5 closed**: `plugin-check` CLI + `check_plugin_host_contract` API + plugin_abi policy |
 | Header-only / inline-only | `planned` | castxml can't emit concept bodies / ctor mangled names (G4; cases 78/105/106/111 dormant) |
-| Kernel / eBPF (BTF/CTF) | `modeled` | parsers exist; no workflow/example (G6) |
+| Kernel / eBPF (BTF/CTF) | `partial` | **G6 advanced**: BTF struct-change + SYCL entrypoint-drop run through `compare` end-to-end; example fixture pending |
 | Static libraries (`.a`/`.lib`) | `by_design_excluded` | **G8 decided (option A)**: non-goal; CLI rejects archives with guidance |
 | FFI consumers (Rust/Go/Python) | `by_design_excluded` | C ABI covered; other languages a stated non-goal |
 
@@ -94,7 +94,7 @@ A real invocation is a point in this space:
 | **G3** | Catalog only exercises `compare`; Markdown/HTML test coverage thin | — | ✅ appcompat-from-catalog + stack-check sysroot e2e + Markdown/HTML structural coverage | scenarios asserted in new tests |
 | **G4** | Header-only / inline-only (detector frontier) | libclang header-AST extractor | unblock cases 78/105/106/111 | reuse dormant fixtures |
 | **G5** | Plugin host↔plugin contract is one-directional | ✅ `check_plugin_host_contract` + `plugin-check` CLI | ✅ scenario + CLI tests | compiled host/plugin demo optional |
-| **G6** | Kernel/eBPF use case is parser-only | small workflow glue | BTF compare scenario | vmlinux/module fixture |
+| **G6** | Kernel/eBPF use case is parser-only | ✅ BTF/SYCL run through `compare` | ✅ workflow scenarios (real BTF parse) | committed BTF-blob example pending |
 | **G7** | No semver-bump recommendation | recommender + report wiring | mapping + integration | reuse cases |
 | **G8** | Static libraries undocumented | ✅ archive detection + clear error path | ✅ unit (archive → guidance error) | ✅ documented non-goal (goals + limitations) |
 
@@ -167,8 +167,14 @@ Summary (see the plans for detail):
 - **G4:** a libclang-based header-AST extractor alongside castxml to unblock
   concept tightening, hidden friends, and user-ctor mangled names (cases
   78/105/106/111).
-- **G6:** a BTF fixture pair (kernel struct gains a field) exercised through
-  `compare`, plus a documented "module vs `vmlinux` BTF" workflow.
+- **G6 (advanced):** the BTF struct-change and SYCL entrypoint-drop workflows
+  now run through `compare` end-to-end (real BTF bytes parsed by
+  `parse_btf_from_bytes`; SYCL findings reach the JSON/Markdown reports) in
+  `tests/test_workflow_kernel_accel.py`, documented in
+  [`user-guide/kernel-btf.md`](../user-guide/kernel-btf.md). Remaining: a
+  committed BTF-blob example under `examples/` with a `ground_truth.json` entry
+  (and a `pahole`/`bpftool` integration fixture); CTF and a UR-adapter workflow
+  are still open.
 
 **G8 is now decided (option A — done):** static/import library archives are a
 non-goal. `abicheck/binary_utils.py::detect_archive` recognises the `!<arch>\n`

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -77,7 +77,7 @@ A real invocation is a point in this space:
 | Reporting: Markdown/HTML | `complete` | structural coverage across verdict tiers + sections + escaping (G3 done) |
 | Build-config matrix (`probe`) | `partial` | wired into `compare` via `--probe-matrix-old/new`; CXX floor proven e2e; API_DEPENDS still blocked on `.o` surface capture (G2) |
 | Bundle / multi-library | `complete` | all detectors run via `compare-release`; case84 validated e2e (Linux-only by design; cross-platform → G1) |
-| Plugin (host↔plugin) | `partial` | policy + scenario tests; no bidirectional CLI/fixture (G5) |
+| Plugin (host↔plugin) | `complete` | **G5 closed**: `plugin-check` CLI + `check_plugin_host_contract` API + plugin_abi policy |
 | Header-only / inline-only | `planned` | castxml can't emit concept bodies / ctor mangled names (G4; cases 78/105/106/111 dormant) |
 | Kernel / eBPF (BTF/CTF) | `modeled` | parsers exist; no workflow/example (G6) |
 | Static libraries (`.a`/`.lib`) | `by_design_excluded` | **G8 decided (option A)**: non-goal; CLI rejects archives with guidance |
@@ -93,7 +93,7 @@ A real invocation is a point in this space:
 | **G2** | Build-config matrix siloed in `probe` | ✅ folded into `compare`/`compare-release` (`--probe-matrix-old/new`); bundle soname-skew wired | ✅ CXX floor e2e + case84 bundle e2e (`API_DEPENDS` e2e still pending `.o` surface capture) | ✅ `feature_macro.yaml`, `cxx_standard.yaml` |
 | **G3** | Catalog only exercises `compare`; Markdown/HTML test coverage thin | — | ✅ appcompat-from-catalog + stack-check sysroot e2e + Markdown/HTML structural coverage | scenarios asserted in new tests |
 | **G4** | Header-only / inline-only (detector frontier) | libclang header-AST extractor | unblock cases 78/105/106/111 | reuse dormant fixtures |
-| **G5** | Plugin host↔plugin contract is one-directional | optional host-contract check | bidirectional scenario | host/plugin fixture |
+| **G5** | Plugin host↔plugin contract is one-directional | ✅ `check_plugin_host_contract` + `plugin-check` CLI | ✅ scenario + CLI tests | compiled host/plugin demo optional |
 | **G6** | Kernel/eBPF use case is parser-only | small workflow glue | BTF compare scenario | vmlinux/module fixture |
 | **G7** | No semver-bump recommendation | recommender + report wiring | mapping + integration | reuse cases |
 | **G8** | Static libraries undocumented | ✅ archive detection + clear error path | ✅ unit (archive → guidance error) | ✅ documented non-goal (goals + limitations) |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -80,7 +80,7 @@ A real invocation is a point in this space:
 | Plugin (host↔plugin) | `partial` | policy + scenario tests; no bidirectional CLI/fixture (G5) |
 | Header-only / inline-only | `planned` | castxml can't emit concept bodies / ctor mangled names (G4; cases 78/105/106/111 dormant) |
 | Kernel / eBPF (BTF/CTF) | `modeled` | parsers exist; no workflow/example (G6) |
-| Static libraries (`.a`/`.lib`) | `planned` | scope decision pending (G8) |
+| Static libraries (`.a`/`.lib`) | `by_design_excluded` | **G8 decided (option A)**: non-goal; CLI rejects archives with guidance |
 | FFI consumers (Rust/Go/Python) | `by_design_excluded` | C ABI covered; other languages a stated non-goal |
 
 ---
@@ -96,7 +96,7 @@ A real invocation is a point in this space:
 | **G5** | Plugin host↔plugin contract is one-directional | optional host-contract check | bidirectional scenario | host/plugin fixture |
 | **G6** | Kernel/eBPF use case is parser-only | small workflow glue | BTF compare scenario | vmlinux/module fixture |
 | **G7** | No semver-bump recommendation | recommender + report wiring | mapping + integration | reuse cases |
-| **G8** | Static libraries undocumented | (optional `ar` iteration) | — | document the stance |
+| **G8** | Static libraries undocumented | ✅ archive detection + clear error path | ✅ unit (archive → guidance error) | ✅ documented non-goal (goals + limitations) |
 
 ### Answer to the four driving questions
 
@@ -169,5 +169,10 @@ Summary (see the plans for detail):
   78/105/106/111).
 - **G6:** a BTF fixture pair (kernel struct gains a field) exercised through
   `compare`, plus a documented "module vs `vmlinux` BTF" workflow.
-- **G8:** decide whether `.a`/`.lib` archive iteration is in scope; document the
-  outcome either way.
+
+**G8 is now decided (option A — done):** static/import library archives are a
+non-goal. `abicheck/binary_utils.py::detect_archive` recognises the `!<arch>\n`
+magic and `service.resolve_input` rejects `.a`/`.lib` inputs with actionable
+guidance; the stance is documented in [`goals.md`](goals.md) (Non-goals) and
+[`concepts/limitations.md`](../concepts/limitations.md), and the registry entry
+is `by_design_excluded`.

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -75,7 +75,7 @@ A real invocation is a point in this space:
 | MCP server | `complete` | unit-tested (mocks, Linux) |
 | Reporting: JSON/SARIF/JUnit | `complete` | versioned schema + 34 SARIF / 55 JUnit tests |
 | Reporting: Markdown/HTML | `complete` | structural coverage across verdict tiers + sections + escaping (G3 done) |
-| Build-config matrix (`probe`) | `partial` | wired into `compare` via `--probe-matrix-old/new`; CXX floor proven e2e; API_DEPENDS still blocked on `.o` surface capture (G2) |
+| Build-config matrix (`probe`) | `complete` | **G2 closed**: wired into `compare`; both CXX floor and API_DEPENDS proven e2e (`.o` `.symtab` surface capture fixed) |
 | Bundle / multi-library | `complete` | all detectors run via `compare-release`; case84 validated e2e (Linux-only by design; cross-platform → G1) |
 | Plugin (host↔plugin) | `complete` | **G5 closed**: `plugin-check` CLI + `check_plugin_host_contract` API + plugin_abi policy |
 | Header-only / inline-only | `planned` | castxml can't emit concept bodies / ctor mangled names (G4; cases 78/105/106/111 dormant) |
@@ -90,7 +90,7 @@ A real invocation is a point in this space:
 | ID | Gap | Code | Tests | Examples |
 |---|---|:--:|:--:|:--:|
 | **G1** | Cross-platform is aspirational, not validated (Win/macOS) | ARM64 AAPCS, MSVC mangling fidelity | PE/Mach-O **e2e** in CI | label tags honestly |
-| **G2** | Build-config matrix siloed in `probe` | ✅ folded into `compare`/`compare-release` (`--probe-matrix-old/new`); bundle soname-skew wired | ✅ CXX floor e2e + case84 bundle e2e (`API_DEPENDS` e2e still pending `.o` surface capture) | ✅ `feature_macro.yaml`, `cxx_standard.yaml` |
+| **G2** | Build-config matrix siloed in `probe` | ✅ folded into `compare`/`compare-release` (`--probe-matrix-old/new`); bundle soname-skew wired; `.o` `.symtab` surface capture | ✅ CXX floor + API_DEPENDS e2e + case84 bundle e2e | ✅ `feature_macro.yaml`, `cxx_standard.yaml` |
 | **G3** | Catalog only exercises `compare`; Markdown/HTML test coverage thin | — | ✅ appcompat-from-catalog + stack-check sysroot e2e + Markdown/HTML structural coverage | scenarios asserted in new tests |
 | **G4** | Header-only / inline-only (detector frontier) | libclang header-AST extractor | unblock cases 78/105/106/111 | reuse dormant fixtures |
 | **G5** | Plugin host↔plugin contract is one-directional | ✅ `check_plugin_host_contract` + `plugin-check` CLI | ✅ scenario + CLI tests | compiled host/plugin demo optional |
@@ -161,9 +161,11 @@ Summary (see the plans for detail):
 - **G1 (CI):** add Windows (MinGW) and macOS smoke jobs that run `compare` /
   `appcompat` on a handful of native PE/Mach-O fixtures; promote the most
   reliable `known_gap` cases to validated once green.
-- **G2:** an opt-in `compare --probe-spec spec.yaml` that runs the matrix
-  harness and folds `API_DEPENDS_ON_CONSUMER_ENV` /
-  `CXX_STANDARD_FLOOR_RAISED` / `BEHAVIOURAL_DEFAULT_CHANGED` into the verdict.
+- **G2 (closed):** matrix findings fold into `compare`/`compare-release` via
+  `--probe-matrix-old/--probe-matrix-new`. Both `CXX_STANDARD_FLOOR_RAISED` and
+  `API_DEPENDS_ON_CONSUMER_ENV` now fire end-to-end through the mainline command
+  — the latter unblocked by capturing a relocatable probe `.o`'s symbol surface
+  (`parse_elf_metadata` falls back to `.symtab` when there is no `.dynsym`).
 - **G4:** a libclang-based header-AST extractor alongside castxml to unblock
   concept tightening, hidden friends, and user-ctor mangled names (cases
   78/105/106/111).

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -98,15 +98,20 @@ use_cases:
   - id: UC-ARCH-kernel-btf
     axis: archetype
     name: Kernel / eBPF modules (BTF/CTF)
-    status: modeled
+    status: partial
     gap: G6
     plan: docs/development/plans/g6-kernel-btf-and-accelerator.md
     evidence:
       modules: [abicheck/btf_metadata.py, abicheck/ctf_metadata.py]
-      tests: [tests/test_btf_metadata.py]
+      tests: [tests/test_btf_metadata.py, tests/test_workflow_kernel_accel.py]
+      docs: [docs/user-guide/kernel-btf.md]
     next_steps: >
-      Add a BTF compare scenario (kernel struct gains a field) and a documented
-      "module vs vmlinux BTF" workflow; parsers exist but no end-to-end flow.
+      The "module vs vmlinux BTF" workflow is now exercised end-to-end through
+      compare (real BTF bytes → parse_btf_from_bytes → layout detectors →
+      BREAKING) in tests/test_workflow_kernel_accel.py, and documented in
+      docs/user-guide/kernel-btf.md. Remaining: a committed BTF-blob example
+      under examples/ with a ground_truth.json entry and a pahole/bpftool-based
+      integration fixture; CTF has no workflow scenario yet.
 
   - id: UC-ARCH-sycl
     axis: archetype
@@ -116,9 +121,15 @@ use_cases:
     plan: docs/development/plans/g6-kernel-btf-and-accelerator.md
     evidence:
       modules: [abicheck/sycl_metadata.py, abicheck/diff_sycl.py]
-      tests: [tests/test_diff_sycl.py]
+      tests: [tests/test_diff_sycl.py, tests/test_workflow_kernel_accel.py]
       examples: [examples/case82_sycl_overload_set_removed]
-    next_steps: Wire SYCL plugin detection into a workflow-level scenario; CUDA deferred.
+      docs: [docs/user-guide/kernel-btf.md]
+    next_steps: >
+      SYCL plugin-interface detection is now driven through the standard
+      compare + report path at the workflow level (a dropped PI entrypoint →
+      BREAKING, reaching the JSON/Markdown reports) in
+      tests/test_workflow_kernel_accel.py. Remaining: a UR-adapter workflow
+      fixture; CUDA device code (.cubin/PTX) stays deferred.
 
   - id: UC-ARCH-static-lib
     axis: archetype

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -116,12 +116,21 @@ use_cases:
   - id: UC-ARCH-static-lib
     axis: archetype
     name: Static libraries (.a / .lib)
-    status: planned
-    gap: G8
-    plan: docs/development/plans/g8-static-libraries.md
-    next_steps: >
-      Decide scope: either iterate `ar` archive members for link-time API
-      checking, or document static libraries as an explicit non-goal.
+    status: by_design_excluded
+    note: >
+      G8 decision (option A): static/import library archives are a non-goal.
+      abicheck compares single linkable images (shared libraries + objects); an
+      `ar` archive (.a / .lib, magic `!<arch>\n`) has no runtime ABI surface
+      (no SONAME, no dynamic symbol table, no symbol versioning). The CLI now
+      detects archives and fails with actionable guidance (extract members or
+      compare the shared library) instead of a misleading "unknown format"
+      error. See docs/development/goals.md (Non-goals),
+      docs/concepts/limitations.md, and the plan
+      docs/development/plans/g8-static-libraries.md.
+    evidence:
+      modules: [abicheck/binary_utils.py, abicheck/service.py]
+      tests: [tests/test_compare_input_modes.py, tests/test_service_unit.py]
+      docs: [docs/concepts/limitations.md]
 
   - id: UC-ARCH-ffi-consumers
     axis: archetype

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -64,16 +64,23 @@ use_cases:
   - id: UC-ARCH-plugin
     axis: archetype
     name: Plugin host↔plugin load contract (dlopen)
-    status: partial
-    gap: G5
-    plan: docs/development/plans/g5-plugin-bidirectional-contract.md
+    status: complete
+    note: >
+      G5 closed: first-class host-contract check
+      (appcompat.check_plugin_host_contract) answers "does plugin v2 still
+      satisfy host H's required entrypoints?" — the plugin-load mirror of
+      appcompat, reusing its consumer-scoping. Exposed via the `plugin-check`
+      CLI (binary or JSON-snapshot inputs, --require / --host-contract manifest)
+      and the Python API, with the plugin_abi policy as the default. Validated
+      end-to-end through snapshot-driven scenario tests and CLI tests; the
+      host-safe-vs-host-breaking distinction (a library-wide BREAKING drop the
+      host never resolves stays COMPATIBLE for the host) is asserted. A compiled
+      host/plugin binary demo in examples/ remains optional (needs the
+      integration toolchain) and is not required for the capability.
     evidence:
-      modules: [abicheck/appcompat.py]
-      tests: [tests/test_workflow_scenarios.py]
-    next_steps: >
-      Add a bidirectional host/plugin example fixture and an optional
-      host-contract check (host's required entrypoints vs plugin exports);
-      today only the plugin_abi policy + consumer-scoped scenario tests exist.
+      modules: [abicheck/appcompat.py, abicheck/cli_plugin.py]
+      tests: [tests/test_workflow_scenarios.py, tests/test_cli_plugin.py]
+      docs: [docs/user-guide/plugin-systems.md]
 
   - id: UC-ARCH-header-only
     axis: archetype

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -270,20 +270,21 @@ use_cases:
   - id: UC-WF-probe-matrix
     axis: workflow
     name: Build-configuration matrix (probe harness)
-    status: partial
-    gap: G2
-    plan: docs/development/plans/g2-build-config-and-bundle.md
+    status: complete
+    note: >
+      G2 closed. Matrix findings fold into `compare`/`compare-release` via
+      --probe-matrix-old/--probe-matrix-new. Both build-config kinds are now
+      proven end-to-end through the mainline command:
+      CXX_STANDARD_FLOOR_RAISED and — after the relocatable-object symbol-surface
+      fix — API_DEPENDS_ON_CONSUMER_ENV. parse_elf_metadata now falls back to
+      `.symtab` when a `.o` has no `.dynsym`, so a probe object's defined global
+      symbols are captured and the env-dependence detector fires over the real
+      compiled surface (tests/test_probe_examples.py +
+      tests/test_elf_object_surface.py).
     evidence:
-      modules: [abicheck/probe_harness.py, abicheck/diff_build_config.py]
-      tests: [tests/test_probe_harness.py, tests/test_probe_examples.py]
+      modules: [abicheck/probe_harness.py, abicheck/diff_build_config.py, abicheck/elf_metadata.py]
+      tests: [tests/test_probe_harness.py, tests/test_probe_examples.py, tests/test_elf_object_surface.py]
       examples: [examples/probes/onedpl.yaml, examples/probes/cxx_standard.yaml, examples/probes/feature_macro.yaml]
-    next_steps: >
-      Matrix findings now fold into `compare`/`compare-release` via
-      --probe-matrix-old/--probe-matrix-new (CXX_STANDARD_FLOOR_RAISED is proven
-      end-to-end through the mainline command in tests/test_probe_examples.py).
-      Remaining gap: capturing a probe's *symbol surface* from a relocatable .o
-      so API_DEPENDS_ON_CONSUMER_ENV fires end-to-end too (the dumper currently
-      reads .dynsym, which a .o lacks); the detector itself is unit-tested.
 
   # ── reporting ─────────────────────────────────────────────────────────────
   - id: UC-REP-json

--- a/docs/user-guide/kernel-btf.md
+++ b/docs/user-guide/kernel-btf.md
@@ -1,0 +1,69 @@
+# Kernel & eBPF (BTF) Workflows
+
+The Linux kernel and out-of-tree modules describe their type layout with
+**BTF** (BPF Type Format) rather than full DWARF. `abicheck` parses BTF from the
+`.BTF` ELF section and feeds it through the **same layout detectors** as DWARF,
+so struct/enum layout changes are detected format-agnostically.
+
+The canonical use case is the **out-of-tree module ABI break**: *does this
+module's view of a kernel struct still match the kernel it loads into?*
+
+---
+
+## Extracting & comparing BTF
+
+`abicheck` reads BTF directly from any ELF that carries a `.BTF` section
+(`vmlinux`, a `*.ko` module, or a BTF blob). Force the BTF debug format with
+`--debug-format btf`:
+
+```bash
+# Two kernels / two module builds — compare their BTF type layout:
+abicheck compare vmlinux-5.10 vmlinux-5.11 --debug-format btf
+```
+
+A kernel struct that **gains or loses a field**, or whose field **type/offset
+changes**, surfaces as the usual layout findings (`struct_size_changed`,
+`struct_field_offset_changed`, …) with a `BREAKING` verdict — exactly as a
+DWARF struct change would.
+
+### Module vs `vmlinux` BTF
+
+To check an out-of-tree module against the kernel it targets, compare the
+module's BTF against the target kernel's BTF for the structs the module touches:
+
+```bash
+# Old kernel the module was built against vs the new kernel it will load into:
+abicheck compare vmlinux-built-against vmlinux-target --debug-format btf
+```
+
+If a struct the module embeds or passes by value changed layout between the two
+kernels, the module's compiled assumptions are stale and the comparison reports
+a binary break.
+
+### Generating BTF
+
+BTF is emitted by the kernel build (`CONFIG_DEBUG_INFO_BTF`) and can be produced
+or extracted for individual objects with `pahole -J` or
+`bpftool btf dump file <elf>`. Any ELF with a `.BTF` section works as a
+`compare` input.
+
+---
+
+## Accelerator stacks (SYCL / oneAPI)
+
+`abicheck` understands the **SYCL plugin interface** (PI / UR): the set of
+plugin entry points (`piPluginInit`, `urAdapterGet`, …), plugin libraries,
+and backend/driver requirements that a runtime loads. A dropped or renamed
+plugin entrypoint is a runtime-load break and is reported through the standard
+`compare` path:
+
+```bash
+abicheck compare libsycl.so.7 libsycl.so.8
+```
+
+Removing a PI entrypoint (`sycl_pi_entrypoint_removed`) or a whole plugin
+(`sycl_plugin_removed`) yields a `BREAKING` verdict that flows into the JSON,
+SARIF, and Markdown reports like any other finding.
+
+> **Scope:** CUDA device code (`.cubin`/PTX) is explicitly out of scope; see
+> [Limitations](../concepts/limitations.md).

--- a/docs/user-guide/plugin-systems.md
+++ b/docs/user-guide/plugin-systems.md
@@ -1,0 +1,92 @@
+# Plugin Systems (host ↔ plugin)
+
+Plugin architectures have a **two-sided ABI contract** that neither `compare`
+nor `appcompat` fully captures on its own:
+
+- A **host** `dlopen`s each plugin and resolves a fixed set of **entry-point
+  symbols** (`dlsym("plugin_init")`, …). If a plugin upgrade drops or changes
+  one of those, the host fails to load it — *regardless* of the plugin's
+  library-wide verdict.
+- The host and plugin are usually built **in-process**, so some changes that
+  `strict_abi` flags (e.g. calling-convention nuances) are not relevant.
+
+`abicheck` addresses both sides:
+
+| Concern | Tool |
+|---------|------|
+| Does plugin **v2** still satisfy the host's required entrypoints? | `abicheck plugin-check` |
+| Downgrade in-process-only ABI noise to the right severity | `--policy plugin_abi` |
+
+---
+
+## `plugin-check` — the host's load contract
+
+Give the old and new plugin (binary **or** JSON snapshot) plus the host's
+required entrypoints, and `plugin-check` reports whether the new plugin still
+satisfies the host — the plugin-load mirror of `appcompat`.
+
+```bash
+# Entrypoints listed inline:
+abicheck plugin-check plugin.v1.so plugin.v2.so -r plugin_init -r plugin_run
+
+# …or from a manifest file (one symbol per line, '#' comments allowed):
+abicheck plugin-check plugin.v1.so plugin.v2.so --host-contract host.syms
+```
+
+A `host.syms` manifest is just the symbols the host resolves:
+
+```text
+plugin_init
+plugin_run     # core entrypoint
+plugin_shutdown
+```
+
+### What it reports
+
+- **Missing entrypoints** — required symbols the new plugin no longer exports
+  (a hard load break).
+- **Incompatible changes affecting the host** — diff changes that touch a
+  required entrypoint (e.g. a signature change), scoped exactly like
+  `appcompat` scopes changes to an application's used symbols.
+- A host-scoped **verdict** and entrypoint **coverage** percentage.
+
+A library-wide `BREAKING` drop of a symbol the host never resolves leaves the
+host **COMPATIBLE** — that consumer-scoped distinction is the whole point.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | `COMPATIBLE` — the new plugin still satisfies the host |
+| `2` | `API_BREAK` — source-level break affecting a required entrypoint |
+| `4` | `BREAKING` — a required entrypoint was dropped or is ABI-incompatible |
+
+---
+
+## `plugin_abi` policy
+
+For in-process host/plugin builds, use the `plugin_abi` policy (the default for
+`plugin-check`) so calling-convention–style findings that do not matter for a
+co-built host/plugin pair are weighted appropriately:
+
+```bash
+abicheck compare plugin.v1.so plugin.v2.so --policy plugin_abi
+abicheck plugin-check plugin.v1.so plugin.v2.so -r plugin_init --policy plugin_abi
+```
+
+See [Policy Profiles](policies.md) for the full policy model.
+
+---
+
+## Python API
+
+```python
+from abicheck.appcompat import check_plugin_host_contract
+from abicheck.service import resolve_input
+
+old = resolve_input("plugin.v1.so")
+new = resolve_input("plugin.v2.so")
+result = check_plugin_host_contract(old, new, {"plugin_init", "plugin_run"})
+
+print(result.verdict, result.missing_entrypoints, result.coverage)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Severity Configuration: user-guide/severity.md
     - Output Formats: user-guide/output-formats.md
     - Multi-Binary Releases: user-guide/multi-binary.md
+    - Kernel & eBPF (BTF): user-guide/kernel-btf.md
     - Probe Harness: user-guide/probe-harness.md
     - Baseline Management: user-guide/baseline-management.md
     - Local Compare: user-guide/local-compare.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - CLI Usage: user-guide/cli-usage.md
     - Tool Modes: user-guide/tool-modes.md
     - Application Compatibility: user-guide/appcompat.md
+    - Plugin Systems: user-guide/plugin-systems.md
     - Policy Profiles: user-guide/policies.md
     - Suppressions: user-guide/suppressions.md
     - Severity Configuration: user-guide/severity.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ module = [
     "abicheck.cli_compare_release",
     "abicheck.cli_debian_symbols",
     "abicheck.cli_baseline",
+    "abicheck.cli_plugin",
     "abicheck.cli_probe",
     "abicheck.cli_stack",
     "abicheck.cli_suggest",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -529,6 +529,7 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         frozenset({"cli", "cli_baseline"}),
         frozenset({"cli", "cli_debian_symbols"}),
         frozenset({"cli", "cli_appcompat"}),
+        frozenset({"cli", "cli_plugin"}),
         frozenset({"cli", "cli_probe"}),
         frozenset({"cli", "cli_stack"}),
         frozenset({"cli", "cli_suggest"}),

--- a/tests/test_cli_plugin.py
+++ b/tests/test_cli_plugin.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI tests for the ``plugin-check`` host-contract command (gap G5).
+
+Driven entirely through committed JSON snapshots so they run in the fast
+(pure-Python) suite — no plugin binaries or toolchain required.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+def _plugin_snapshot(tmp_path: Path, name: str, version: str, symbols: list[str]) -> Path:
+    snap = AbiSnapshot(
+        library="libplugin.so",
+        version=version,
+        functions=[
+            Function(name=s, mangled=s, return_type="int", visibility=Visibility.PUBLIC)
+            for s in symbols
+        ],
+    )
+    path = tmp_path / name
+    path.write_text(snapshot_to_json(snap))
+    return path
+
+
+def test_plugin_check_breaks_on_dropped_entrypoint(tmp_path: Path) -> None:
+    old = _plugin_snapshot(tmp_path, "p1.json", "1.0", ["plugin_init", "plugin_run", "aux"])
+    new = _plugin_snapshot(tmp_path, "p2.json", "2.0", ["plugin_init", "aux"])  # drops plugin_run
+
+    result = CliRunner().invoke(main, [
+        "plugin-check", str(old), str(new), "-r", "plugin_init", "-r", "plugin_run",
+    ])
+    assert result.exit_code == 4, result.output
+    assert "BREAKING" in result.output
+    assert "plugin_run" in result.output
+
+
+def test_plugin_check_compatible_when_contract_satisfied(tmp_path: Path) -> None:
+    old = _plugin_snapshot(tmp_path, "p1.json", "1.0", ["plugin_init", "plugin_run"])
+    # Drops an auxiliary symbol the host never resolves → host is safe.
+    new = _plugin_snapshot(tmp_path, "p2.json", "2.0", ["plugin_init", "plugin_run"])
+
+    result = CliRunner().invoke(main, [
+        "plugin-check", str(old), str(new), "-r", "plugin_init", "-r", "plugin_run",
+    ])
+    assert result.exit_code == 0, result.output
+    assert "COMPATIBLE" in result.output
+
+
+def test_plugin_check_json_output_and_host_contract_file(tmp_path: Path) -> None:
+    old = _plugin_snapshot(tmp_path, "p1.json", "1.0", ["plugin_init", "plugin_run", "aux"])
+    new = _plugin_snapshot(tmp_path, "p2.json", "2.0", ["plugin_init", "aux"])
+    contract = tmp_path / "host.syms"
+    contract.write_text("plugin_init\nplugin_run  # core entrypoint\n# a comment line\n\n")
+
+    result = CliRunner().invoke(main, [
+        "plugin-check", str(old), str(new),
+        "--host-contract", str(contract), "--format", "json",
+    ])
+    assert result.exit_code == 4, result.output
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "BREAKING"
+    assert payload["missing_entrypoints"] == ["plugin_run"]
+    assert sorted(payload["required_entrypoints"]) == ["plugin_init", "plugin_run"]
+    assert payload["coverage"] == 50.0
+
+
+def test_plugin_check_requires_entrypoints(tmp_path: Path) -> None:
+    old = _plugin_snapshot(tmp_path, "p1.json", "1.0", ["plugin_init"])
+    new = _plugin_snapshot(tmp_path, "p2.json", "2.0", ["plugin_init"])
+
+    result = CliRunner().invoke(main, ["plugin-check", str(old), str(new)])
+    assert result.exit_code != 0
+    assert "No required entrypoints" in result.output

--- a/tests/test_cli_plugin.py
+++ b/tests/test_cli_plugin.py
@@ -85,6 +85,20 @@ def test_plugin_check_json_output_and_host_contract_file(tmp_path: Path) -> None
     assert payload["coverage"] == 50.0
 
 
+def test_plugin_check_writes_output_file(tmp_path: Path) -> None:
+    old = _plugin_snapshot(tmp_path, "p1.json", "1.0", ["plugin_init", "plugin_run"])
+    new = _plugin_snapshot(tmp_path, "p2.json", "2.0", ["plugin_init", "plugin_run"])
+    out = tmp_path / "report.md"
+
+    result = CliRunner().invoke(main, [
+        "plugin-check", str(old), str(new), "-r", "plugin_init", "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert "host-contract" in out.read_text().lower()
+    assert "Report written to" in result.output
+
+
 def test_plugin_check_requires_entrypoints(tmp_path: Path) -> None:
     old = _plugin_snapshot(tmp_path, "p1.json", "1.0", ["plugin_init"])
     new = _plugin_snapshot(tmp_path, "p2.json", "2.0", ["plugin_init"])

--- a/tests/test_compare_input_modes.py
+++ b/tests/test_compare_input_modes.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from abicheck.binary_utils import detect_binary_format
+from abicheck.binary_utils import detect_archive, detect_binary_format
 from abicheck.cli import _resolve_input, main
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.serialization import snapshot_to_json
@@ -97,6 +97,38 @@ class TestDetectBinaryFormat:
         p.write_bytes(b"\xfe\xed\xfa\xce" + b"\x00" * 64)
         assert detect_binary_format(p) == "macho"
 
+    def test_ar_archive_is_not_a_binary_format(self, tmp_path):
+        """ar archives (.a/.lib) are not single linkable images — detect_binary_format
+        returns None for them (they are handled separately via detect_archive)."""
+        p = tmp_path / "libfoo.a"
+        p.write_bytes(b"!<arch>\n" + b"\x00" * 64)
+        assert detect_binary_format(p) is None
+
+
+class TestDetectArchive:
+    def test_static_archive_detected(self, tmp_path):
+        p = tmp_path / "libfoo.a"
+        p.write_bytes(b"!<arch>\n" + b"\x00" * 64)
+        assert detect_archive(p) is True
+
+    def test_coff_import_library_detected(self, tmp_path):
+        # MSVC .lib import/static libraries share the ar magic.
+        p = tmp_path / "foo.lib"
+        p.write_bytes(b"!<arch>\n" + b"\x00" * 64)
+        assert detect_archive(p) is True
+
+    def test_elf_is_not_archive(self, tmp_path):
+        p = _write_fake_elf(tmp_path / "lib.so")
+        assert detect_archive(p) is False
+
+    def test_nonexistent_is_not_archive(self, tmp_path):
+        assert detect_archive(tmp_path / "missing") is False
+
+    def test_short_file_is_not_archive(self, tmp_path):
+        p = tmp_path / "short"
+        p.write_bytes(b"!<ar")
+        assert detect_archive(p) is False
+
 
 # ── _resolve_input tests ────────────────────────────────────────────────
 
@@ -118,6 +150,14 @@ class TestResolveInput:
         p = tmp_path / "mystery.dat"
         p.write_text("not json, not perl, not elf", encoding="utf-8")
         with pytest.raises(Exception, match="Cannot detect format"):
+            _resolve_input(p, headers=[], includes=[], version="1.0", lang="c++")
+
+    def test_static_archive_raises_with_guidance(self, tmp_path):
+        """A `.a`/`.lib` archive is rejected with actionable guidance at the CLI
+        layer (G8 non-goal), not the generic 'Cannot detect format' error."""
+        p = tmp_path / "libfoo.a"
+        p.write_bytes(b"!<arch>\n" + b"\x00" * 16)
+        with pytest.raises(Exception, match="static/import library archive"):
             _resolve_input(p, headers=[], includes=[], version="1.0", lang="c++")
 
     def test_malformed_json_raises_click_exception(self, tmp_path):

--- a/tests/test_compare_input_modes.py
+++ b/tests/test_compare_input_modes.py
@@ -117,6 +117,12 @@ class TestDetectArchive:
         p.write_bytes(b"!<arch>\n" + b"\x00" * 64)
         assert detect_archive(p) is True
 
+    def test_gnu_thin_archive_detected(self, tmp_path):
+        # GNU thin archives (`ar rcT`) use the `!<thin>\n` magic.
+        p = tmp_path / "libfoo.a"
+        p.write_bytes(b"!<thin>\n" + b"\x00" * 64)
+        assert detect_archive(p) is True
+
     def test_elf_is_not_archive(self, tmp_path):
         p = _write_fake_elf(tmp_path / "lib.so")
         assert detect_archive(p) is False

--- a/tests/test_dumper_coverage.py
+++ b/tests/test_dumper_coverage.py
@@ -489,6 +489,26 @@ class TestDetectFormat:
         from abicheck.dumper import _detect_format
         assert _detect_format(tmp_path / "nonexistent.so") == "unknown"
 
+    def test_ar_archive_is_unknown(self, tmp_path: Path) -> None:
+        # ar archives are not a single linkable image; _detect_format does not
+        # classify them (dump() rejects them separately with guidance — G8).
+        from abicheck.dumper import _detect_format
+        f = tmp_path / "libfoo.a"
+        f.write_bytes(b"!<arch>\n" + b"\x00" * 16)
+        assert _detect_format(f) == "unknown"
+
+
+class TestDumpRejectsArchive:
+    """dump() rejects static/import library archives with actionable guidance."""
+
+    def test_static_archive_raises(self, tmp_path: Path) -> None:
+        from abicheck.dumper import dump
+        from abicheck.errors import ValidationError
+        f = tmp_path / "libfoo.a"
+        f.write_bytes(b"!<arch>\n" + b"\x00" * 16)
+        with pytest.raises(ValidationError, match="static/import library archive"):
+            dump(f, [], None, "1.0", "c++")
+
 
 # ── _dump_macho / _dump_pe via dump() routing ───────────────────────────────
 

--- a/tests/test_elf_metadata_unit.py
+++ b/tests/test_elf_metadata_unit.py
@@ -430,8 +430,30 @@ class TestParseFull:
         assert len(meta.symbols) == 1
         assert meta.symbols[0].name == "good_fn"
 
-    def test_symtab_section_not_dynsym_ignored(self):
-        """SymbolTableSection with name != '.dynsym' is not parsed."""
+    def test_symtab_ignored_when_dynsym_present(self):
+        """When a `.dynsym` exists (a normal DSO), `.symtab` is not parsed —
+        `.dynsym` is the authoritative export surface."""
+        from elftools.elf.sections import SymbolTableSection
+
+        dynsym = MagicMock(spec=SymbolTableSection)
+        dynsym.name = ".dynsym"
+        dynsym.iter_symbols.return_value = []
+        symtab = MagicMock(spec=SymbolTableSection)
+        symtab.name = ".symtab"
+        symtab.iter_symbols.return_value = []
+
+        elf = MagicMock()
+        elf.iter_sections.return_value = [dynsym, symtab]
+
+        f = MagicMock()
+        with patch("abicheck.elf_metadata.ELFFile", return_value=elf):
+            _parse(f, Path("test.so"))
+
+        symtab.iter_symbols.assert_not_called()  # .dynsym wins
+
+    def test_symtab_parsed_as_fallback_without_dynsym(self):
+        """A relocatable `.o` has no `.dynsym`; `.symtab` is parsed as the
+        fallback symbol surface (G2 — probe object-file capture)."""
         from elftools.elf.sections import SymbolTableSection
 
         symtab = MagicMock(spec=SymbolTableSection)
@@ -443,10 +465,10 @@ class TestParseFull:
 
         f = MagicMock()
         with patch("abicheck.elf_metadata.ELFFile", return_value=elf):
-            meta = _parse(f, Path("test.so"))
+            meta = _parse(f, Path("probe.o"))
 
-        symtab.iter_symbols.assert_not_called()
-        assert meta.symbols == []
+        symtab.iter_symbols.assert_called()  # fallback parses .symtab
+        assert meta.symbols == []  # the mock yields no symbols
 
 
 # ── Constant correctness ────────────────────────────────────────────────

--- a/tests/test_elf_object_surface.py
+++ b/tests/test_elf_object_surface.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Relocatable-object (`.o`) symbol-surface capture — G2.
+
+A relocatable object carries no `.dynsym`; `parse_elf_metadata` falls back to
+`.symtab` so a probe-built `.o`'s defined global symbols are captured (which
+unblocks `API_DEPENDS_ON_CONSUMER_ENV` end-to-end). This needs only a C
+compiler (stock `cc`), so — like `test_probe_examples.py` — it runs in the
+default lane and self-skips when no compiler is available, rather than using
+the castxml-gated ``integration`` marker.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from abicheck.elf_metadata import SymbolBinding, parse_elf_metadata
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="relocatable-object ELF capture is exercised on Linux (cc emits ELF)",
+)
+
+
+def _compile_object(src: str, out: Path) -> None:
+    cc = shutil.which("cc")
+    if cc is None:
+        pytest.skip("cc unavailable; cannot compile relocatable object")
+    res = subprocess.run(
+        [cc, "-c", "-x", "c", "-", "-o", str(out)],
+        input=src.encode(), capture_output=True,
+    )
+    if res.returncode != 0:
+        pytest.skip(f"cc failed: {res.stderr.decode()[:200]}")
+
+
+def test_symtab_fallback_captures_object_global_symbols(tmp_path: Path) -> None:
+    obj = tmp_path / "probe.o"
+    _compile_object(
+        """
+        int public_api(int x) { return x + 1; }
+        static int helper(int y) { return y; }
+        int uses_helper(void) { return helper(0); }
+        """,
+        obj,
+    )
+    meta = parse_elf_metadata(obj)
+    names = {s.name for s in meta.symbols}
+
+    assert "public_api" in names
+    assert "uses_helper" in names
+    # static symbols are local → never part of the exported surface
+    assert "helper" not in names
+    # captured entries are GLOBAL-bound defined symbols
+    assert all(
+        s.binding is not SymbolBinding.LOCAL for s in meta.symbols
+    )
+
+
+def test_symtab_fallback_excludes_undefined_references(tmp_path: Path) -> None:
+    """An undefined reference (e.g. a libc call) is an import, not an export."""
+    obj = tmp_path / "ref.o"
+    _compile_object(
+        """
+        extern int external_thing(int);
+        int my_api(int x) { return external_thing(x); }
+        """,
+        obj,
+    )
+    meta = parse_elf_metadata(obj)
+    exported = {s.name for s in meta.symbols}
+
+    assert "my_api" in exported
+    assert "external_thing" not in exported  # undefined → import, not export
+    assert "external_thing" in {i.name for i in meta.imports}

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1151,6 +1151,15 @@ class TestResolveInput:
         with pytest.raises(AbicheckError, match="Cannot detect input format"):
             _resolve_input(f, [], [], "1.0", "c++")
 
+    def test_static_archive_raises_with_guidance(self, tmp_path: Path):
+        """A `.a`/`.lib` archive is rejected with the static-archive guidance
+        through the MCP resolver too (G8), not the generic 'Cannot detect input
+        format' fallback."""
+        f = tmp_path / "libfoo.a"
+        f.write_bytes(b"!<arch>\n" + b"\x00" * 16)
+        with pytest.raises(AbicheckError, match="static/import library archive"):
+            _resolve_input(f, [], [], "1.0", "c++")
+
 
 # ===================================================================
 # main()

--- a/tests/test_probe_examples.py
+++ b/tests/test_probe_examples.py
@@ -26,7 +26,10 @@ from pathlib import Path
 
 import pytest
 
-from abicheck.diff_build_config import diff_matrix
+from abicheck.diff_build_config import (
+    detect_api_depends_on_consumer_env,
+    diff_matrix,
+)
 from abicheck.probe_harness import (
     load_probe_spec,
     run_probe_matrix,
@@ -193,15 +196,15 @@ def test_cxx_standard_floor_raised_through_compare_release(tmp_path: Path) -> No
     assert "matrix_findings" not in json.loads(res_clean.stdout)
 
 
-def test_feature_macro_spec_compiles_cleanly(tmp_path: Path) -> None:
-    """feature_macro.yaml compiles under stock ``cc`` for every config.
+def test_feature_macro_api_depends_fires_end_to_end(tmp_path: Path) -> None:
+    """feature_macro.yaml → API_DEPENDS_ON_CONSUMER_ENV fires end-to-end (G2).
 
-    This is the ``feature-macro C library`` manifest from plan G2. We
-    assert the matrix runs without per-configuration compile errors so the
-    shipped fixture cannot rot. The API_DEPENDS_ON_CONSUMER_ENV *detector*
-    is unit-tested in tests/test_diff_build_config.py; capturing a probe's
-    surface from a relocatable ``.o`` is a separate harness gap, so here we
-    only assert the diff machinery runs end-to-end without raising.
+    ``extra_api`` is compiled only under the ``with_extra`` configuration
+    (``-DENABLE_EXTRA``), so the probe harness sees it present in some
+    configurations and absent in others. This is the use case that was
+    previously blocked because a relocatable probe ``.o`` carries no
+    ``.dynsym`` — now captured via the ``.symtab`` fallback in
+    ``elf_metadata`` — so the detector fires over the real compiled surface.
     """
     if shutil.which("cc") is None:
         pytest.skip("cc unavailable; cannot compile probe matrix")
@@ -216,6 +219,48 @@ def test_feature_macro_spec_compiles_cleanly(tmp_path: Path) -> None:
     )
     compile_errors = [r.error for r in m_old.results if r.error]
     assert not compile_errors, compile_errors
-    # diff_matrix must run cleanly over real matrices (no exceptions).
-    changes = diff_matrix(m_old, m_new)
-    assert isinstance(changes, list)
+
+    # The relocatable .o surface is now captured, so the detector sees
+    # extra_api diverge across configurations.
+    findings = detect_api_depends_on_consumer_env(m_old)
+    assert "extra_api" in {c.symbol for c in findings}
+    # diff_matrix carries the same finding (no exceptions over real matrices).
+    assert isinstance(diff_matrix(m_old, m_new), list)
+
+
+def test_feature_macro_api_depends_reaches_mainline_compare(tmp_path: Path) -> None:
+    """The matrix finding reaches the mainline ``compare`` JSON via
+    ``--probe-matrix-old/--probe-matrix-new`` (not only ``probe compare``)."""
+    if shutil.which("cc") is None:
+        pytest.skip("cc unavailable; cannot compile probe matrix")
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    spec = load_probe_spec(PROBES_DIR / "feature_macro.yaml")
+    m_old = run_probe_matrix(
+        spec, library_name="featuredemo", version="1.0", work_dir=tmp_path / "old",
+    )
+    m_new = run_probe_matrix(
+        spec, library_name="featuredemo", version="2.0", work_dir=tmp_path / "new",
+    )
+    old_matrix = tmp_path / "fm-1.0.json"
+    new_matrix = tmp_path / "fm-2.0.json"
+    write_matrix_snapshot(m_old, old_matrix)
+    write_matrix_snapshot(m_new, new_matrix)
+
+    old_so = tmp_path / "libfeaturedemo.so.1"
+    new_so = tmp_path / "libfeaturedemo.so.2"
+    _build_trivial_so(old_so, "libfeaturedemo.so.1")
+    _build_trivial_so(new_so, "libfeaturedemo.so.2")
+
+    res = CliRunner().invoke(
+        main,
+        ["compare", str(old_so), str(new_so),
+         "--probe-matrix-old", str(old_matrix),
+         "--probe-matrix-new", str(new_matrix),
+         "--format", "json"],
+    )
+    data = json.loads(res.stdout)
+    kinds = {c["kind"] for c in data.get("changes", [])}
+    assert "api_depends_on_consumer_env" in kinds

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -195,6 +195,17 @@ class TestResolveInput:
                 with pytest.raises(ValidationError, match="Cannot detect format"):
                     resolve_input(p, is_elf=False)
 
+    def test_static_archive_raises_with_guidance(self, tmp_path):
+        """A `.a`/`.lib` ar archive fails deliberately with actionable guidance
+        (G8 — static libraries are a by-design non-goal), not a generic
+        'Cannot detect format' error."""
+        p = tmp_path / "libfoo.a"
+        # Minimal ar archive: magic + an (empty) member header is not required —
+        # the magic alone is what resolve_input branches on.
+        p.write_bytes(b"!<arch>\n" + b"\x00" * 16)
+        with pytest.raises(ValidationError, match="static/import library archive"):
+            resolve_input(p)
+
 
 # ── run_dump() ──────────────────────────────────────────────────────────────
 

--- a/tests/test_workflow_kernel_accel.py
+++ b/tests/test_workflow_kernel_accel.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Workflow-level scenarios for kernel (BTF) and accelerator (SYCL) stacks — G6.
+
+The BTF and SYCL *parsers* are unit-tested elsewhere; these tests drive the
+canonical *workflows* end-to-end through the standard ``compare`` + report path
+so the use cases are validated as flows, not just parsers:
+
+- **Kernel / eBPF (BTF):** a kernel struct gains a field (the out-of-tree
+  "module vs ``vmlinux`` BTF" break). Real BTF bytes are parsed by
+  :func:`parse_btf_from_bytes`, converted to the checker's type metadata, and
+  run through ``compare`` — the layout detectors fire format-agnostically.
+- **SYCL / heterogeneous (PI/UR):** a plugin-interface entrypoint is dropped,
+  driven through ``compare`` and the reporter (not just the ``diff_sycl`` unit
+  detector).
+
+See docs/development/usecase-coverage-evaluation.md (gap G6) and
+docs/user-guide/kernel-btf.md.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from abicheck.btf_metadata import (
+    BTF_KIND_INT,
+    BTF_KIND_STRUCT,
+    BTF_MAGIC,
+    BTF_VERSION,
+    parse_btf_from_bytes,
+)
+from abicheck.checker import compare
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.model import AbiSnapshot
+from abicheck.reporter import to_json, to_markdown
+from abicheck.sycl_metadata import SyclMetadata, SyclPluginInfo
+
+# ── BTF blob builder (minimal, self-contained) ───────────────────────────────
+
+
+class _BtfBlob:
+    """Build a minimal BTF blob: one INT type plus one struct."""
+
+    def __init__(self) -> None:
+        self._strings = bytearray(b"\x00")
+        self._types: list[bytes] = []
+        self._offsets: dict[str, int] = {"": 0}
+
+    def _str(self, s: str) -> int:
+        if s in self._offsets:
+            return self._offsets[s]
+        off = len(self._strings)
+        self._strings.extend(s.encode() + b"\x00")
+        self._offsets[s] = off
+        return off
+
+    def _add(self, name: str, kind: int, vlen: int, size: int, extra: bytes = b"") -> int:
+        info = (kind << 24) | (vlen & 0xFFFF)
+        self._types.append(struct.pack("<III", self._str(name) if name else 0, info, size) + extra)
+        return len(self._types)
+
+    def build_struct(self, struct_name: str, n_fields: int) -> bytes:
+        """A struct with ``n_fields`` int members (each 4 bytes / 32 bits)."""
+        self._add("int", BTF_KIND_INT, 0, 4, extra=struct.pack("<I", 32))
+        members = b""
+        for i in range(n_fields):
+            members += struct.pack("<III", self._str(f"f{i}"), 1, i * 32)
+        self._add(struct_name, BTF_KIND_STRUCT, n_fields, n_fields * 4, extra=members)
+        type_data = b"".join(self._types)
+        str_data = bytes(self._strings)
+        header = struct.pack(
+            "<HBBIIIII", BTF_MAGIC, BTF_VERSION, 0, 24,
+            0, len(type_data), len(type_data), len(str_data),
+        )
+        return header + type_data + str_data
+
+
+def _btf_snapshot(version: str, struct_name: str, n_fields: int) -> AbiSnapshot:
+    meta = parse_btf_from_bytes(_BtfBlob().build_struct(struct_name, n_fields))
+    return AbiSnapshot(library="vmlinux", version=version, dwarf=meta.to_dwarf_metadata())
+
+
+# ── Scenario: kernel struct layout change via BTF ─────────────────────────────
+
+
+def test_btf_struct_gains_field_is_breaking_through_compare() -> None:
+    """A kernel struct that gains a field is an out-of-tree-module ABI break and
+    flows through ``compare`` as a layout change with the real BTF parser."""
+    old = _btf_snapshot("5.10", "task_state", n_fields=2)
+    new = _btf_snapshot("5.11", "task_state", n_fields=3)  # gains a field
+
+    result = compare(old, new)
+
+    assert result.verdict is Verdict.BREAKING
+    kinds = {c.kind for c in result.changes}
+    assert ChangeKind.STRUCT_SIZE_CHANGED in kinds
+
+
+def test_btf_identical_structs_are_no_change() -> None:
+    old = _btf_snapshot("5.10", "task_state", n_fields=3)
+    new = _btf_snapshot("5.10", "task_state", n_fields=3)
+
+    result = compare(old, new)
+    assert result.verdict in (Verdict.NO_CHANGE, Verdict.COMPATIBLE)
+    assert not any(c.kind is ChangeKind.STRUCT_SIZE_CHANGED for c in result.changes)
+
+
+# ── Scenario: SYCL plugin-interface change ────────────────────────────────────
+
+
+def _sycl_snapshot(version: str, entry_points: list[str]) -> AbiSnapshot:
+    plugin = SyclPluginInfo(
+        name="level_zero",
+        library="libpi_level_zero.so",
+        interface_type="pi",
+        pi_version="1.2",
+        entry_points=entry_points,
+        backend_type="level_zero",
+    )
+    sycl = SyclMetadata(
+        implementation="dpcpp",
+        runtime_version="",
+        pi_version="1.2",
+        plugins=[plugin],
+        plugin_search_paths=["/usr/lib/sycl"],
+    )
+    return AbiSnapshot(library="libsycl.so", version=version, sycl=sycl)
+
+
+def test_sycl_entrypoint_drop_is_breaking_and_reaches_reports() -> None:
+    old = _sycl_snapshot("1", ["piPluginInit", "piPlatformsGet", "piDevicesGet"])
+    new = _sycl_snapshot("2", ["piPluginInit", "piPlatformsGet"])  # drops piDevicesGet
+
+    result = compare(old, new)
+    assert result.verdict is Verdict.BREAKING
+    assert any(c.kind is ChangeKind.SYCL_PI_ENTRYPOINT_REMOVED for c in result.changes)
+
+    # The finding reaches the standard report path (JSON + Markdown), not just
+    # the diff_sycl unit detector.
+    import json as _json
+    payload = _json.loads(to_json(result))
+    assert payload["verdict"] == "BREAKING"
+    assert "piDevicesGet" in to_markdown(result)
+
+
+def test_sycl_additive_entrypoint_is_not_breaking() -> None:
+    old = _sycl_snapshot("1", ["piPluginInit", "piPlatformsGet"])
+    new = _sycl_snapshot("2", ["piPluginInit", "piPlatformsGet", "piDevicesGet"])
+
+    result = compare(old, new)
+    assert result.verdict is not Verdict.BREAKING

--- a/tests/test_workflow_scenarios.py
+++ b/tests/test_workflow_scenarios.py
@@ -27,6 +27,7 @@ See docs/development/usecase-coverage-evaluation.md (gap G3 / G5).
 
 from __future__ import annotations
 
+from abicheck.appcompat import check_plugin_host_contract
 from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.model import AbiSnapshot, EnumMember, EnumType, Function, Visibility
@@ -130,6 +131,56 @@ def test_plugin_drop_outside_host_contract_is_library_breaking_but_host_safe() -
     assert removed & HOST_REQUIRED_ENTRYPOINTS == set()  # host unaffected
     # Library-wide verdict is still breaking for whoever *did* use plugin_debug.
     assert result.verdict is Verdict.BREAKING
+
+
+# ── Scenario C2: first-class host-contract check (gap G5) ─────────────────────
+#
+# The same insight as Scenario C, but driven through the first-class
+# `check_plugin_host_contract` API rather than re-deriving removed-symbol sets
+# inline — the plugin-load mirror of `appcompat`.
+
+
+def test_host_contract_check_breaks_when_required_entrypoint_dropped() -> None:
+    plugin_v1 = _lib("1.0", ["plugin_init", "plugin_run", "plugin_debug"])
+    plugin_v2 = _lib("2.0", ["plugin_init", "plugin_debug"])  # drops plugin_run
+
+    result = check_plugin_host_contract(
+        plugin_v1, plugin_v2, HOST_REQUIRED_ENTRYPOINTS,
+    )
+
+    assert result.verdict is Verdict.BREAKING
+    assert result.missing_entrypoints == ["plugin_run"]
+    assert result.coverage == 50.0
+    # The drop shows up as a host-relevant change, not just a library-wide one.
+    assert any(c.symbol == "plugin_run" for c in result.breaking_for_host)
+
+
+def test_host_contract_check_safe_when_drop_outside_contract() -> None:
+    """A library-BREAKING drop the host never resolves leaves the host intact."""
+    plugin_v1 = _lib("1.0", ["plugin_init", "plugin_run", "plugin_debug"])
+    plugin_v2 = _lib("2.0", ["plugin_init", "plugin_run"])  # drops plugin_debug only
+
+    # The library-wide verdict is BREAKING …
+    assert compare(plugin_v1, plugin_v2).verdict is Verdict.BREAKING
+    # … but the host's load contract is fully satisfied.
+    result = check_plugin_host_contract(
+        plugin_v1, plugin_v2, HOST_REQUIRED_ENTRYPOINTS,
+    )
+    assert result.verdict is Verdict.COMPATIBLE
+    assert result.missing_entrypoints == []
+    assert result.coverage == 100.0
+
+
+def test_host_contract_check_additive_plugin_is_compatible() -> None:
+    plugin_v1 = _lib("1.0", ["plugin_init", "plugin_run"])
+    plugin_v2 = _lib("1.1", ["plugin_init", "plugin_run", "plugin_extra"])
+
+    result = check_plugin_host_contract(
+        plugin_v1, plugin_v2, HOST_REQUIRED_ENTRYPOINTS,
+    )
+    assert result.verdict is Verdict.COMPATIBLE
+    assert result.missing_entrypoints == []
+    assert result.coverage == 100.0
 
 
 # ── Scenario D: policy-scoped release decision ───────────────────────────────

--- a/tests/test_workflow_scenarios.py
+++ b/tests/test_workflow_scenarios.py
@@ -240,6 +240,37 @@ def test_snapshot_export_names_covers_vars_and_unmangled() -> None:
     assert "internal_state" not in names
 
 
+def _elf_only_lib(version: str, symbols: list[str]) -> AbiSnapshot:
+    """A symbols-only snapshot, as produced by dumping a stripped binary with
+    no headers/DWARF: every export is Visibility.ELF_ONLY."""
+    fns = [
+        Function(name=s, mangled=s, return_type="int", visibility=Visibility.ELF_ONLY)
+        for s in symbols
+    ]
+    return AbiSnapshot(
+        library="libplugin.so", version=version, functions=fns, elf_only_mode=True,
+    )
+
+
+def test_host_contract_check_counts_elf_only_exports() -> None:
+    """plugin-check on real stripped binaries (no headers) sees ELF_ONLY
+    exports; those must count as satisfying the contract (regression: a
+    compatible binary-only plugin previously came out BREAKING / 0% coverage)."""
+    plugin_v1 = _elf_only_lib("1.0", ["plugin_init", "plugin_run"])
+    plugin_v2 = _elf_only_lib("2.0", ["plugin_init", "plugin_run"])
+
+    ok = check_plugin_host_contract(plugin_v1, plugin_v2, HOST_REQUIRED_ENTRYPOINTS)
+    assert ok.verdict is Verdict.COMPATIBLE
+    assert ok.missing_entrypoints == []
+    assert ok.coverage == 100.0
+
+    # Dropping a required entrypoint is still BREAKING in symbols-only mode.
+    plugin_v3 = _elf_only_lib("3.0", ["plugin_init"])
+    broke = check_plugin_host_contract(plugin_v1, plugin_v3, HOST_REQUIRED_ENTRYPOINTS)
+    assert broke.verdict is Verdict.BREAKING
+    assert broke.missing_entrypoints == ["plugin_run"]
+
+
 # ── Scenario D: policy-scoped release decision ───────────────────────────────
 
 

--- a/tests/test_workflow_scenarios.py
+++ b/tests/test_workflow_scenarios.py
@@ -183,6 +183,63 @@ def test_host_contract_check_additive_plugin_is_compatible() -> None:
     assert result.coverage == 100.0
 
 
+def _cpp_lib(version: str) -> AbiSnapshot:
+    """A plugin exporting a C++ entrypoint: source name != mangled linker name."""
+    fn = Function(
+        name="plugin_run(int)", mangled="_Z10plugin_runi",
+        return_type="int", visibility=Visibility.PUBLIC,
+    )
+    return AbiSnapshot(library="libplugin.so", version=version, functions=[fn])
+
+
+def test_host_contract_demangled_cpp_name_is_not_a_dlsym_export() -> None:
+    """A C++ entrypoint is only resolvable by its mangled linker symbol; a
+    contract listing the demangled source name must be reported as missing
+    (dlsym cannot resolve `plugin_run(int)`)."""
+    plugin = _cpp_lib("1.0")
+
+    by_demangled = check_plugin_host_contract(plugin, plugin, {"plugin_run(int)"})
+    assert by_demangled.verdict is Verdict.BREAKING
+    assert by_demangled.missing_entrypoints == ["plugin_run(int)"]
+
+    by_mangled = check_plugin_host_contract(plugin, plugin, {"_Z10plugin_runi"})
+    assert by_mangled.verdict is Verdict.COMPATIBLE
+    assert by_mangled.missing_entrypoints == []
+
+
+def test_snapshot_export_names_covers_vars_and_unmangled() -> None:
+    """The resolvable-export set includes exported variables and falls back to
+    the plain name when no mangled symbol is recorded."""
+    from abicheck.appcompat import _snapshot_export_names
+    from abicheck.model import Variable
+
+    snap = AbiSnapshot(
+        library="libplugin.so",
+        version="1.0",
+        functions=[
+            # extern "C": name == mangled → plain name resolvable
+            Function(name="plugin_init", mangled="plugin_init",
+                     return_type="int", visibility=Visibility.PUBLIC),
+            # no mangled recorded → fall back to name
+            Function(name="legacy_entry", mangled="",
+                     return_type="int", visibility=Visibility.PUBLIC),
+            # non-public → never a dlsym export
+            Function(name="internal_helper", mangled="internal_helper",
+                     return_type="int", visibility=Visibility.HIDDEN),
+        ],
+        variables=[
+            Variable(name="plugin_table", mangled="plugin_table", type="void*",
+                     visibility=Visibility.PUBLIC),
+            Variable(name="internal_state", mangled="internal_state", type="int",
+                     visibility=Visibility.HIDDEN),
+        ],
+    )
+    names = _snapshot_export_names(snap)
+    assert {"plugin_init", "legacy_entry", "plugin_table"} <= names
+    assert "internal_helper" not in names
+    assert "internal_state" not in names
+
+
 # ── Scenario D: policy-scoped release decision ───────────────────────────────
 
 


### PR DESCRIPTION
Closes/advances several gaps from the [Use-Case Coverage Evaluation](https://github.com/napetrov/abicheck/blob/main/docs/development/usecase-coverage-evaluation.md), driven by the machine-checked `usecase-registry.yaml` (its test fails if a coverage claim cites evidence that doesn't exist). **23 of 30** use cases are now `complete` + **2** `by_design_excluded`; 5 remain open (G1, G4, and the G6 remainder).

## G8 — Static-library stance → `by_design_excluded`
Static/import library archives (`.a`/`.lib`, incl. GNU thin `!<thin>` and MSVC `.lib`) are a documented non-goal. `binary_utils.detect_archive()` recognises the magic; all four input paths (`cli._resolve_input`, `service.resolve_input`, `dumper.dump`, `mcp_server._resolve_input`) reject archives with **actionable guidance**. Docs: `goals.md`, `concepts/limitations.md`.

## G5 — Plugin host↔plugin load contract → `complete`
`appcompat.check_plugin_host_contract()` answers *"does plugin v2 still satisfy host H's required entrypoints?"* — the dlopen mirror of `appcompat`, reusing its consumer-scoping. Only **dlsym-resolvable** (mangled / extern-C) symbols count as exports. New **`plugin-check`** CLI (`--require` / `--host-contract`, `plugin_abi` default) + Python API. Docs: `user-guide/plugin-systems.md`.

## G2 — Build-config matrix → `complete`
The last residual is closed: `parse_elf_metadata` now falls back to **`.symtab`** when a relocatable probe `.o` has no `.dynsym`, so the object's symbol surface is captured. **`API_DEPENDS_ON_CONSUMER_ENV`** now fires end-to-end through the mainline `compare --probe-matrix-old/new` (joining `CXX_STANDARD_FLOOR_RAISED`). Normal DSO parsing is unchanged.

## G6 — Kernel BTF + SYCL workflows → advanced (`UC-ARCH-kernel-btf` modeled→partial)
Both run end-to-end through `compare` + the reporter: a BTF kernel struct gaining a field (`struct_size_changed` + BREAKING, real `parse_btf_from_bytes`) and a dropped SYCL PI entrypoint (`sycl_pi_entrypoint_removed` + BREAKING, reaching JSON/Markdown). Docs: `user-guide/kernel-btf.md`.

## Validation
- `pytest` fast suite: **7502 passed**
- `ruff` / `mypy` / `mkdocs build --strict`: clean
- `scripts/check_ai_readiness.py`: **0 errors**

## Still open (tracked in the registry/plans)
**G1** (Windows/macOS e2e — needs native CI runners), **G4** (libclang header-AST extractor), and the **G6 remainder** (committed BTF-blob example fixture + pahole/bpftool integration; CTF & UR-adapter workflows).

https://claude.ai/code/session_01MFZp6DjCA3f8RTLD3s1vAn