### PR TITLE
refactor: resolve all 7 CodeFactor findings (complexity + Bandit)

### DIFF
--- a/abicheck/cli_appcompat.py
+++ b/abicheck/cli_appcompat.py
@@ -69,22 +69,33 @@ def _validate_appcompat_args(
             err=True,
         )
     if weak_mode or list_symbols:
-        _rejected: list[str] = []
-        if old_headers_only:
-            _rejected.append("--old-header")
-        if new_headers_only:
-            _rejected.append("--new-header")
-        if old_includes_only:
-            _rejected.append("--old-include")
-        if new_includes_only:
-            _rejected.append("--new-include")
-        if _rejected:
-            mode_label = "--check-against" if weak_mode else "--list-required-symbols"
-            raise click.UsageError(
-                f"{', '.join(_rejected)} cannot be used with {mode_label}. "
-                f"Per-side header/include flags are only supported in full "
-                f"comparison mode (OLD_LIB NEW_LIB)."
-            )
+        _reject_per_side_flags(
+            weak_mode,
+            old_headers_only, new_headers_only,
+            old_includes_only, new_includes_only,
+        )
+
+
+def _reject_per_side_flags(
+    weak_mode: bool,
+    old_headers_only: tuple[Path, ...], new_headers_only: tuple[Path, ...],
+    old_includes_only: tuple[Path, ...], new_includes_only: tuple[Path, ...],
+) -> None:
+    """Reject per-side header/include flags in weak / list-symbols modes."""
+    _flags = (
+        ("--old-header", old_headers_only),
+        ("--new-header", new_headers_only),
+        ("--old-include", old_includes_only),
+        ("--new-include", new_includes_only),
+    )
+    _rejected = [name for name, value in _flags if value]
+    if _rejected:
+        mode_label = "--check-against" if weak_mode else "--list-required-symbols"
+        raise click.UsageError(
+            f"{', '.join(_rejected)} cannot be used with {mode_label}. "
+            f"Per-side header/include flags are only supported in full "
+            f"comparison mode (OLD_LIB NEW_LIB)."
+        )
 
 
 def _handle_list_required_symbols(

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -567,86 +567,132 @@ def _format_release_summary(
 ) -> str:
     """Format the release comparison summary as JSON, markdown, or JUnit XML."""
     if fmt == "junit":
-        from .junit_report import to_junit_xml_multi
-        pairs: list[tuple[DiffResult, AbiSnapshot | None]] = list(diff_pairs or [])
-        # Release-global matrix findings ride in as their own synthetic
-        # testsuite so CI dashboards reading the JUnit report see the failure.
-        if matrix_result is not None:
-            pairs.append((matrix_result, None))
-        error_libs = [
-            entry for entry in library_results
-            if entry.get("verdict") == "ERROR"
-        ]
-        return to_junit_xml_multi(
-            pairs, error_libraries=error_libs if error_libs else None,
-        )
-
+        return _format_release_junit(diff_pairs, matrix_result, library_results)
     if fmt == "json":
-        changed_libraries = [
-            str(lib["library"]) for lib in library_results
-            if str(lib.get("verdict")) not in ("NO_CHANGE", "ERROR")
-        ]
-        summary: dict[str, object] = {
-            "verdict": worst_verdict,
-            "old_dir": str(old_dir),
-            "new_dir": str(new_dir),
-            "libraries": library_results,
-            "changed_libraries": changed_libraries,
-            "unmatched_old": [old_map[k].name for k in removed_keys],
-            "unmatched_new": [new_map[k].name for k in added_keys],
-            "warnings": warning_msgs,
-        }
-        # Release-level public-surface scoping rollup (ADR-024, issue #235).
-        # Present only when --scope-public-headers was active (per-library
-        # entries then carry a "scope_resolved" key).
-        scoped_libs = [lib for lib in library_results if "scope_resolved" in lib]
-        if scoped_libs:
-            def _as_int(v: object) -> int:
-                return v if isinstance(v, int) else 0
-            summary["scope"] = {
-                "public_headers_applied": True,
-                "manual_review_required": any(
-                    not bool(lib.get("scope_resolved", True)) for lib in scoped_libs
-                ),
-                "public_additions": sum(
-                    _as_int(lib.get("compatible_additions", 0)) for lib in scoped_libs
-                ),
-                "filtered_internal_changes": sum(
-                    _as_int(lib.get("filtered_internal_count", 0)) for lib in scoped_libs
-                ),
-            }
-        if bundle_result is not None:
-            summary["bundle_verdict"] = bundle_result.bundle_verdict.value
-            summary["bundle_findings"] = [
-                {
-                    "kind": f.kind.value,
-                    "symbol": f.symbol,
-                    "consumer_library": f.consumer_library,
-                    "provider_library": f.provider_library,
-                    "description": f.description,
-                    "old_value": f.old_value,
-                    "new_value": f.new_value,
-                    "affected_libraries": list(f.affected_libraries),
-                }
-                for f in bundle_result.bundle_findings
-            ]
-        if matrix_result is not None:
-            # Release-global build-configuration findings (G2: probe matrix).
-            # `.changes` is post-suppression, so suppressed findings are
-            # excluded here just as they are from the verdict.
-            summary["matrix_verdict"] = matrix_result.verdict.value
-            summary["matrix_findings"] = [
-                {
-                    "kind": c.kind.value,
-                    "symbol": c.symbol,
-                    "description": c.description,
-                    "old_value": c.old_value,
-                    "new_value": c.new_value,
-                }
-                for c in matrix_result.changes
-            ]
-        return json.dumps(summary, indent=2)
+        return _format_release_json(
+            worst_verdict, old_dir, new_dir, library_results,
+            removed_keys, added_keys, old_map, new_map, warning_msgs,
+            bundle_result, matrix_result,
+        )
+    return _format_release_markdown(
+        worst_verdict, old_dir, new_dir, library_results,
+        removed_keys, added_keys, old_map, new_map, bundle_result, matrix_result,
+    )
 
+
+def _format_release_junit(
+    diff_pairs: list[tuple[DiffResult, AbiSnapshot]] | None,
+    matrix_result: DiffResult | None,
+    library_results: list[dict[str, object]],
+) -> str:
+    """Render the release summary as a JUnit XML report."""
+    from .junit_report import to_junit_xml_multi
+    pairs: list[tuple[DiffResult, AbiSnapshot | None]] = list(diff_pairs or [])
+    # Release-global matrix findings ride in as their own synthetic
+    # testsuite so CI dashboards reading the JUnit report see the failure.
+    if matrix_result is not None:
+        pairs.append((matrix_result, None))
+    error_libs = [
+        entry for entry in library_results
+        if entry.get("verdict") == "ERROR"
+    ]
+    return to_junit_xml_multi(
+        pairs, error_libraries=error_libs if error_libs else None,
+    )
+
+
+def _format_release_json(
+    worst_verdict: str,
+    old_dir: Path, new_dir: Path,
+    library_results: list[dict[str, object]],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
+    warning_msgs: list[str],
+    bundle_result: BundleDiffResult | None,
+    matrix_result: DiffResult | None,
+) -> str:
+    """Render the release summary as a JSON document."""
+    changed_libraries = [
+        str(lib["library"]) for lib in library_results
+        if str(lib.get("verdict")) not in ("NO_CHANGE", "ERROR")
+    ]
+    summary: dict[str, object] = {
+        "verdict": worst_verdict,
+        "old_dir": str(old_dir),
+        "new_dir": str(new_dir),
+        "libraries": library_results,
+        "changed_libraries": changed_libraries,
+        "unmatched_old": [old_map[k].name for k in removed_keys],
+        "unmatched_new": [new_map[k].name for k in added_keys],
+        "warnings": warning_msgs,
+    }
+    # Release-level public-surface scoping rollup (ADR-024, issue #235).
+    # Present only when --scope-public-headers was active (per-library
+    # entries then carry a "scope_resolved" key).
+    scoped_libs = [lib for lib in library_results if "scope_resolved" in lib]
+    if scoped_libs:
+        summary["scope"] = _release_json_scope(scoped_libs)
+    if bundle_result is not None:
+        summary["bundle_verdict"] = bundle_result.bundle_verdict.value
+        summary["bundle_findings"] = [
+            {
+                "kind": f.kind.value,
+                "symbol": f.symbol,
+                "consumer_library": f.consumer_library,
+                "provider_library": f.provider_library,
+                "description": f.description,
+                "old_value": f.old_value,
+                "new_value": f.new_value,
+                "affected_libraries": list(f.affected_libraries),
+            }
+            for f in bundle_result.bundle_findings
+        ]
+    if matrix_result is not None:
+        # Release-global build-configuration findings (G2: probe matrix).
+        # `.changes` is post-suppression, so suppressed findings are
+        # excluded here just as they are from the verdict.
+        summary["matrix_verdict"] = matrix_result.verdict.value
+        summary["matrix_findings"] = [
+            {
+                "kind": c.kind.value,
+                "symbol": c.symbol,
+                "description": c.description,
+                "old_value": c.old_value,
+                "new_value": c.new_value,
+            }
+            for c in matrix_result.changes
+        ]
+    return json.dumps(summary, indent=2)
+
+
+def _release_json_scope(scoped_libs: list[dict[str, object]]) -> dict[str, object]:
+    """Build the release-level public-surface scoping rollup for JSON output."""
+    def _as_int(v: object) -> int:
+        return v if isinstance(v, int) else 0
+    return {
+        "public_headers_applied": True,
+        "manual_review_required": any(
+            not bool(lib.get("scope_resolved", True)) for lib in scoped_libs
+        ),
+        "public_additions": sum(
+            _as_int(lib.get("compatible_additions", 0)) for lib in scoped_libs
+        ),
+        "filtered_internal_changes": sum(
+            _as_int(lib.get("filtered_internal_count", 0)) for lib in scoped_libs
+        ),
+    }
+
+
+def _format_release_markdown(
+    worst_verdict: str,
+    old_dir: Path, new_dir: Path,
+    library_results: list[dict[str, object]],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
+    bundle_result: BundleDiffResult | None,
+    matrix_result: DiffResult | None,
+) -> str:
+    """Render the release summary as a Markdown document."""
     _VERDICT_EMOJI = {
         "NO_CHANGE": "✅", "COMPATIBLE": "✅", "COMPATIBLE_WITH_RISK": "⚠️",
         "API_BREAK": "⚠️", "BREAKING": "❌", "ERROR": "💥",
@@ -665,49 +711,78 @@ def _format_release_summary(
             f"| **Bundle** | {bundle_em} `{bundle_result.bundle_verdict.value}` "
             f"({bundle_count} cross-library finding{'s' if bundle_count != 1 else ''}) |",
         )
-    lines += [
+    lines += _release_md_libraries_table(library_results, _VERDICT_EMOJI)
+    lines += _release_md_changed_libraries(removed_keys, added_keys, old_map, new_map)
+    lines += _release_md_bundle_findings(bundle_result)
+    lines += _release_md_matrix_findings(matrix_result)
+    return "\n".join(lines)
+
+
+def _release_md_libraries_table(
+    library_results: list[dict[str, object]], emoji: dict[str, str],
+) -> list[str]:
+    """Markdown per-library results table."""
+    lines = [
         "", "## Libraries", "",
         "| Library | Verdict | Breaking | Source | Risk | Additions |",
         "|---|---|---|---|---|---|",
     ]
     for lib in library_results:
-        em = _VERDICT_EMOJI.get(str(lib["verdict"]), "?")
+        em = emoji.get(str(lib["verdict"]), "?")
         lines.append(
             f"| `{lib['library']}` | {em} `{lib['verdict']}` "
             f"| {lib.get('breaking', '—')} | {lib.get('source_breaks', '—')} "
             f"| {lib.get('risk_changes', '—')} | {lib.get('compatible_additions', '—')} |"
         )
+    return lines
+
+
+def _release_md_changed_libraries(
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
+) -> list[str]:
+    """Markdown sections listing removed/added libraries."""
+    lines: list[str] = []
     if removed_keys:
         lines += ["", "## ⚠️ Removed Libraries", ""]
-        for k in removed_keys:
-            lines.append(f"- `{old_map[k].name}`")
+        lines += [f"- `{old_map[k].name}`" for k in removed_keys]
     if added_keys:
         lines += ["", "## ℹ️ Added Libraries", ""]
-        for k in added_keys:
-            lines.append(f"- `{new_map[k].name}`")
-    if bundle_result is not None and bundle_result.bundle_findings:
-        lines += ["", "## 🔗 Bundle (Cross-Library) Findings", ""]
-        for f in bundle_result.bundle_findings:
-            # Library-scoped findings (bundle_library_added /
-            # bundle_library_removed) carry the library name in
-            # `symbol`; manifest/import findings carry the symbol.
-            # Both are non-empty in practice, but guard against future
-            # finding shapes with no symbol attribution.
-            lines.append(
-                f"- **{f.kind.value}**"
-                + (f" — `{f.symbol}`" if f.symbol else "")
-                + (f" (consumer: `{f.consumer_library}`)" if f.consumer_library else "")
-                + (f" (provider: `{f.provider_library}`)" if f.provider_library else ""),
-            )
-            lines.append(f"  - {f.description}")
-    if matrix_result is not None and matrix_result.changes:
-        lines += ["", "## 🛠️ Build-Configuration (Matrix) Findings", ""]
-        for c in matrix_result.changes:
-            lines.append(
-                f"- **{c.kind.value}**" + (f" — `{c.symbol}`" if c.symbol else ""),
-            )
-            lines.append(f"  - {c.description}")
-    return "\n".join(lines)
+        lines += [f"- `{new_map[k].name}`" for k in added_keys]
+    return lines
+
+
+def _release_md_bundle_findings(bundle_result: BundleDiffResult | None) -> list[str]:
+    """Markdown section for cross-library (bundle) findings."""
+    if bundle_result is None or not bundle_result.bundle_findings:
+        return []
+    lines = ["", "## 🔗 Bundle (Cross-Library) Findings", ""]
+    for f in bundle_result.bundle_findings:
+        # Library-scoped findings (bundle_library_added /
+        # bundle_library_removed) carry the library name in `symbol`;
+        # manifest/import findings carry the symbol. Both are non-empty in
+        # practice, but guard against future finding shapes with no attribution.
+        lines.append(
+            f"- **{f.kind.value}**"
+            + (f" — `{f.symbol}`" if f.symbol else "")
+            + (f" (consumer: `{f.consumer_library}`)" if f.consumer_library else "")
+            + (f" (provider: `{f.provider_library}`)" if f.provider_library else ""),
+        )
+        lines.append(f"  - {f.description}")
+    return lines
+
+
+def _release_md_matrix_findings(matrix_result: DiffResult | None) -> list[str]:
+    """Markdown section for build-configuration (matrix) findings."""
+    if matrix_result is None or not matrix_result.changes:
+        return []
+    lines = ["", "## 🛠️ Build-Configuration (Matrix) Findings", ""]
+    for c in matrix_result.changes:
+        lines.append(
+            f"- **{c.kind.value}**" + (f" — `{c.symbol}`" if c.symbol else ""),
+        )
+        lines.append(f"  - {c.description}")
+    return lines
 
 
 def _write_release_summary_file(

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1454,22 +1454,34 @@ def _unwrap_funcptr_declarator(s: str) -> str:
             if j >= len(s) or s[j] not in "*&":
                 return s  # ordinary parameter list, not a pointer declarator
             # Find the ')' matching this declarator-group '(' (bracket-aware).
-            pdepth = 0
-            tdepth = 0
-            for k in range(i, len(s)):
-                c = s[k]
-                if c == "<":
-                    tdepth += 1
-                elif c == ">":
-                    tdepth = max(0, tdepth - 1)
-                elif c == "(" and tdepth == 0:
-                    pdepth += 1
-                elif c == ")" and tdepth == 0:
-                    pdepth -= 1
-                    if pdepth == 0:
-                        return s[i + 1:k].lstrip("*& ")
-            return s  # unbalanced — leave alone
+            close = _match_declarator_group(s, i)
+            if close is None:
+                return s  # unbalanced — leave alone
+            return s[i + 1:close].lstrip("*& ")
     return s
+
+
+def _match_declarator_group(s: str, open_idx: int) -> int | None:
+    """Return the index of the ``)`` matching the ``(`` at *open_idx*, or None.
+
+    Bracket-aware: ``(``/``)`` nested inside template arguments (``<...>``) do
+    not affect the paren depth.
+    """
+    pdepth = 0
+    tdepth = 0
+    for k in range(open_idx, len(s)):
+        c = s[k]
+        if c == "<":
+            tdepth += 1
+        elif c == ">":
+            tdepth = max(0, tdepth - 1)
+        elif c == "(" and tdepth == 0:
+            pdepth += 1
+        elif c == ")" and tdepth == 0:
+            pdepth -= 1
+            if pdepth == 0:
+                return k
+    return None
 
 
 def _unqualified_name_of(s: str) -> str:
@@ -1486,7 +1498,14 @@ def _unqualified_name_of(s: str) -> str:
     op = _OPERATOR_TOKEN_RE.search(s)
     if op is not None:
         return s[op.start():].strip()
-    # Truncate at the parameter-list '(' that sits at template depth 0.
+    s = _truncate_at_param_list(s)
+    s = _after_last_top_level_scope(s).strip()
+    s = _drop_leading_return_type(s)
+    return s.strip()
+
+
+def _truncate_at_param_list(s: str) -> str:
+    """Drop everything from the parameter-list ``(`` at template depth 0 on."""
     depth = 0
     for i, ch in enumerate(s):
         if ch == "<":
@@ -1494,9 +1513,12 @@ def _unqualified_name_of(s: str) -> str:
         elif ch == ">":
             depth = max(0, depth - 1)
         elif ch == "(" and depth == 0:
-            s = s[:i]
-            break
-    # Take the segment after the last '::' that sits at template depth 0.
+            return s[:i]
+    return s
+
+
+def _after_last_top_level_scope(s: str) -> str:
+    """Return the segment after the last ``::`` that sits at template depth 0."""
     depth = 0
     last = 0
     i = 0
@@ -1511,9 +1533,12 @@ def _unqualified_name_of(s: str) -> str:
             i += 2
             continue
         i += 1
-    s = s[last:].strip()
-    # Drop a leading return type: take the part after the last top-level space
-    # (e.g. ``void get<int>`` -> ``get<int>``).
+    return s[last:]
+
+
+def _drop_leading_return_type(s: str) -> str:
+    """Drop a leading return type by taking the part after the last top-level
+    space (e.g. ``void get<int>`` -> ``get<int>``)."""
     depth = 0
     sp = -1
     for i, ch in enumerate(s):
@@ -1524,8 +1549,8 @@ def _unqualified_name_of(s: str) -> str:
         elif ch == " " and depth == 0:
             sp = i
     if sp != -1:
-        s = s[sp + 1:]
-    return s.strip()
+        return s[sp + 1:]
+    return s
 
 
 def _strip_template_args(leaf: str) -> str:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1088,6 +1088,35 @@ def to_review_digest(result: DiffResult) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _classify_changes_by_kind(
+    changes: list[Change], result: DiffResult,
+) -> tuple[list[Change], list[Change], list[Change], list[Change]]:
+    """Split *changes* into (breaking, source_breaks, risk, compatible) using the
+    effective kind sets (respects PolicyFile overrides)."""
+    breaking_set, api_break_set, compat_set, risk_set = result._effective_kind_sets()
+    breaking = [c for c in changes if c.kind in breaking_set]
+    source_breaks = [c for c in changes if c.kind in api_break_set]
+    risk = [c for c in changes if c.kind in risk_set]
+    compatible = [c for c in changes if c.kind in compat_set]
+    return breaking, source_breaks, risk, compatible
+
+
+def _build_internal_rtti_note(breaking: list[Change]) -> list[str]:
+    """Build the up-front note when breaking findings are mostly RTTI/internal
+    churn. Returns an empty list when there is nothing to note."""
+    _bd = surface_breakdown(breaking)
+    if not (_bd.rtti or _bd.internal):
+        return []
+    return [
+        f"> ℹ️ **{_bd.rtti + _bd.internal} of {_bd.total} breaking findings are "
+        f"internal/RTTI churn** ({_bd.rtti} RTTI, {_bd.internal} "
+        "internal-namespace) — typically a missing `-fvisibility=hidden`, not "
+        f"public-API breaks. Genuine public-surface breaking findings: "
+        f"**{_bd.public}**.",
+        "",
+    ]
+
+
 def to_markdown(
     result: DiffResult,
     *,
@@ -1129,11 +1158,7 @@ def to_markdown(
         changes = apply_show_only(changes, show_only, policy=result.policy)
 
     # Classify filtered changes using effective kind sets (respects PolicyFile overrides)
-    breaking_set, api_break_set, compat_set, risk_set = result._effective_kind_sets()
-    breaking = [c for c in changes if c.kind in breaking_set]
-    source_breaks = [c for c in changes if c.kind in api_break_set]
-    risk = [c for c in changes if c.kind in risk_set]
-    compatible = [c for c in changes if c.kind in compat_set]
+    breaking, source_breaks, risk, compatible = _classify_changes_by_kind(changes, result)
 
     lines: list[str] = [
         f"# ABI Report: {result.library}",
@@ -1153,16 +1178,7 @@ def to_markdown(
     # When most of the breaking count is RTTI / internal-namespace churn, say so
     # up front — otherwise a huge count from a library lacking -fvisibility=hidden
     # buries the handful of genuine public-API breaks.
-    _bd = surface_breakdown(breaking)
-    if _bd.rtti or _bd.internal:
-        lines += [
-            f"> ℹ️ **{_bd.rtti + _bd.internal} of {_bd.total} breaking findings are "
-            f"internal/RTTI churn** ({_bd.rtti} RTTI, {_bd.internal} "
-            "internal-namespace) — typically a missing `-fvisibility=hidden`, not "
-            f"public-API breaks. Genuine public-surface breaking findings: "
-            f"**{_bd.public}**.",
-            "",
-        ]
+    lines += _build_internal_rtti_note(breaking)
 
     _append_confidence_section(lines, result)
 

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -555,21 +555,49 @@ def classify_change_surface(
     # A confident private/system-header origin demotes even an exported
     # symbol — that is exactly the leaked-private-header case scoping targets.
     if not type_level_finding:
-        if sym in all_symbols:
-            reason = _origin_reason(surf_old, surf_new, sym)
-            if reason is not None:
-                return False, reason
-            return (True, None) if sym in public_symbols else (False, REASON_NOT_EXPORTED)
-        if sym and "::" in sym and sym.rsplit("::", 1)[1] in all_symbols:
-            tail = sym.rsplit("::", 1)[1]
-            reason = _origin_reason(surf_old, surf_new, tail)
-            if reason is not None:
-                return False, reason
-            return (True, None) if tail in public_symbols else (False, REASON_NOT_EXPORTED)
+        verdict = _classify_symbol_level(
+            sym, all_symbols, public_symbols, surf_old, surf_new,
+        )
+        if verdict is not None:
+            return verdict
 
-    # Type-level finding: check the implicated type name(s). A finding is
-    # in-surface if *any* implicated type is reachable from the public API.
+    return _classify_type_level(
+        candidates, all_types, public_types, surf_old, surf_new,
+    )
 
+
+def _classify_symbol_level(
+    sym: str,
+    all_symbols: frozenset[str] | set[str],
+    public_symbols: frozenset[str] | set[str],
+    surf_old: PublicSurface,
+    surf_new: PublicSurface,
+) -> tuple[bool, str | None] | None:
+    """Classify a symbol-level finding, or return None to fall through to
+    type-level reachability (the symbol is unknown to the surface)."""
+    if sym in all_symbols:
+        reason = _origin_reason(surf_old, surf_new, sym)
+        if reason is not None:
+            return False, reason
+        return (True, None) if sym in public_symbols else (False, REASON_NOT_EXPORTED)
+    if sym and "::" in sym and sym.rsplit("::", 1)[1] in all_symbols:
+        tail = sym.rsplit("::", 1)[1]
+        reason = _origin_reason(surf_old, surf_new, tail)
+        if reason is not None:
+            return False, reason
+        return (True, None) if tail in public_symbols else (False, REASON_NOT_EXPORTED)
+    return None
+
+
+def _classify_type_level(
+    candidates: set[str],
+    all_types: frozenset[str] | set[str],
+    public_types: frozenset[str] | set[str],
+    surf_old: PublicSurface,
+    surf_new: PublicSurface,
+) -> tuple[bool, str | None]:
+    """Classify a finding by the implicated type name(s). A finding is
+    in-surface if *any* implicated type is reachable from the public API."""
     # Anti-hiding (ADR-024 §D5.2): never filter a change to an
     # internal-namespace type (``detail::``, ``impl::``, …). The internal-leak
     # detector (post_processing.DetectInternalLeaks) runs *after* this step and
@@ -592,19 +620,36 @@ def classify_change_surface(
     # Prefer a provenance reason when every implicated type confidently
     # originates from a private/system header; this is a *confident* demotion
     # and applies even without typed roots (it is the leaked-private case).
+    header_reason = _confident_header_reason(known, surf_old, surf_new)
+    if header_reason is not None:
+        return False, header_reason
+    return _demote_by_reachability(known, surf_old, surf_new)
+
+
+def _confident_header_reason(
+    known: set[str], surf_old: PublicSurface, surf_new: PublicSurface,
+) -> str | None:
+    """Reason when every implicated type confidently originates from a
+    private/system header, else None."""
     type_reasons = {_origin_reason(surf_old, surf_new, c) for c in known}
-    if None not in type_reasons and type_reasons:
-        return False, (
-            REASON_PRIVATE_HEADER
-            if REASON_PRIVATE_HEADER in type_reasons
-            else REASON_SYSTEM_HEADER
-        )
-    # Beyond this point the only basis to demote is type-reachability. That is
-    # trustworthy *only* when the surface has real typed roots to walk from.
-    # An export-table-only snapshot (e.g. a PE binary whose header scoping fell
-    # back to the export table — functions are ``return_type="?"``) has none,
-    # so every type looks "unreachable". Demoting on that basis would hide a
-    # genuine public ABI break, including a change to a PUBLIC_HEADER type
+    if None in type_reasons or not type_reasons:
+        return None
+    return (
+        REASON_PRIVATE_HEADER
+        if REASON_PRIVATE_HEADER in type_reasons
+        else REASON_SYSTEM_HEADER
+    )
+
+
+def _demote_by_reachability(
+    known: set[str], surf_old: PublicSurface, surf_new: PublicSurface,
+) -> tuple[bool, str | None]:
+    """Final demotion stage: the only remaining basis is type-reachability."""
+    # That is trustworthy *only* when the surface has real typed roots to walk
+    # from. An export-table-only snapshot (e.g. a PE binary whose header scoping
+    # fell back to the export table — functions are ``return_type="?"``) has
+    # none, so every type looks "unreachable". Demoting on that basis would hide
+    # a genuine public ABI break, including a change to a PUBLIC_HEADER type
     # recovered from a PDB. Keep the finding in that case (ADR-024 §D5.2).
     if not (surf_old.has_typed_roots and surf_new.has_typed_roots):
         return True, None

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -21,12 +21,14 @@ from abicheck.checker import ChangeKind, compare
 from abicheck.diff_symbols import (
     _ctor_dtor_variant,
     _fingerprints_from_elf,
+    _match_declarator_group,
     _param_signature_of,
     _plausible_rename,
     _return_type_of,
     _strip_template_args,
     _unqualified_name,
     _unqualified_name_of,
+    _unwrap_funcptr_declarator,
 )
 from abicheck.elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, SymbolType
 from abicheck.model import AbiSnapshot, Function, Visibility
@@ -611,6 +613,27 @@ class TestPlausibleRename:
         # left intact (the '(' there is the real parameter list).
         assert _unqualified_name_of("void foo(int (*)())") == "foo"
         assert _param_signature_of("void foo(int (*)())") == "(int (*)())"
+
+    def test_funcptr_declarator_edge_cases(self) -> None:
+        # A space between the declarator-group '(' and the '*'/'&' is still a
+        # pointer-return declarator: the name must be unwrapped (exercises the
+        # whitespace-skip loop that sits between the '(' and the sigil).
+        assert _unwrap_funcptr_declarator("int ( *foo())()") == "foo()"
+        assert _unwrap_funcptr_declarator("int (  &bar())()") == "bar()"
+        # A declarator group whose ')' never closes is left untouched rather
+        # than truncated (the unbalanced bail-out).
+        assert _unwrap_funcptr_declarator("int (*foo(") == "int (*foo("
+        # An empty string and an ordinary parameter list are both returned as-is.
+        assert _unwrap_funcptr_declarator("") == ""
+        assert _unwrap_funcptr_declarator("foo(int)") == "foo(int)"
+
+    def test_match_declarator_group(self) -> None:
+        # Balanced: returns the index of the matching ')'.
+        assert _match_declarator_group("(*x())", 0) == 5
+        # Parens nested in template arguments do not affect paren depth.
+        assert _match_declarator_group("(*x<(int)>())", 0) == 12
+        # Unbalanced: no matching ')' yields None.
+        assert _match_declarator_group("(*x", 0) is None
 
     def test_funcptr_return_rename_detected(self) -> None:
         # End-to-end: a versioned rename of a function-pointer-returning template

--- a/tests/test_detector_properties.py
+++ b/tests/test_detector_properties.py
@@ -294,12 +294,22 @@ def _loadable_fixtures() -> list[Path]:
     out: list[Path] = []
     for pat in ("action/*.json", "schema/*.json"):
         for p in sorted(glob.glob(str(_FIXTURE_ROOT / pat))):
-            try:
-                load_snapshot(Path(p))
-            except Exception:
-                continue  # not a full snapshot schema — skip
-            out.append(Path(p))
+            # A fixture that does not deserialize into a full snapshot schema
+            # (bad JSON, missing/typed-wrong keys, unreadable file) is simply
+            # not a candidate — skip it. Exception types are named explicitly
+            # so an unexpected failure still surfaces instead of being swallowed.
+            if _is_loadable_snapshot(Path(p)):
+                out.append(Path(p))
     return out
+
+
+def _is_loadable_snapshot(path: Path) -> bool:
+    """Return True iff *path* deserializes into a full snapshot schema."""
+    try:
+        load_snapshot(path)
+    except (OSError, ValueError, KeyError, TypeError, AttributeError):
+        return False
+    return True
 
 
 _REAL_SNAPSHOTS = _loadable_fixtures()


### PR DESCRIPTION
## What

Resolves all **7 issues** currently reported on [CodeFactor](https://www.codefactor.io/repository/github/napetrov/abicheck/issues) — 6 "Complex Method" findings and 1 Bandit "Try/Except/Continue".

| # | Issue | Location | Fix |
|---|-------|----------|-----|
| 1 | Complex Method | `reporter.py` `to_markdown` | extract `_classify_changes_by_kind`, `_build_internal_rtti_note` |
| 2 | Complex Method | `diff_symbols.py` `_unwrap_funcptr_declarator` | extract `_match_declarator_group` |
| 3 | Complex Method | `diff_symbols.py` `_unqualified_name_of` | extract `_truncate_at_param_list`, `_after_last_top_level_scope`, `_drop_leading_return_type` |
| 4 | Complex Method | `cli_compare_release.py` `_format_release_summary` | split into `_format_release_junit/_json/_markdown` + section builders |
| 5 | Complex Method | `surface.py` `classify_change_surface` | extract `_classify_symbol_level`, `_classify_type_level`, `_confident_header_reason`, `_demote_by_reachability` |
| 6 | Complex Method | `cli_appcompat.py` `_validate_appcompat_args` | extract `_reject_per_side_flags` |
| 7 | Bandit B112 (try/except/continue) | `tests/test_detector_properties.py` | replace bare `except Exception: continue` with `_is_loadable_snapshot` helper that names expected exception types |

## How it was verified

CodeFactor's complexity engine is proprietary, so I calibrated against the values it reported (16–19 for the flagged functions) and confirmed every refactored function and new helper now lands **well inside the safe zone** — below the complexity of pre-existing functions in the same files that CodeFactor did **not** flag (e.g. `_to_markdown_leaf`, `appcompat_to_markdown`, `_compare_release_libraries`). All refactors are pure extractions with no behavioural change.

## Checks

- `ruff check abicheck/ tests/` — pass
- `mypy abicheck/` — clean (0 errors)
- `python scripts/check_ai_readiness.py` — 0 errors
- Full fast suite — **7472 passed**, 21 skipped, 4 xfailed

https://claude.ai/code/session_01Wc5g3wksdaYvnFZTQK7J27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wc5g3wksdaYvnFZTQK7J27)_