### PR TITLE
docs: expand ABI/API handling into a 7-part learning series

### DIFF
--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -106,7 +106,7 @@ pipeline works, and [Verdicts](verdicts.md) for the exit-code semantics.
 
 ## Detection coverage and roadmap
 
-abicheck detects **184 change kinds** today (see the
+abicheck detects **180+ change kinds** today (see the
 [Change Kind Reference](../reference/change-kinds.md)), spanning every family in
 the table above — including the calling-convention, alignment/packing, bit-field,
 dual-ABI (`_GLIBCXX_USE_CXX11_ABI`), ABI-tag, `char8_t`, `_BitInt`, `_Atomic`,

--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -1,474 +1,121 @@
-# ABI/API Handling & Recommendations
+# ABI/API Handling — A Learning Series
 
-This is the single conceptual hub for understanding ABI/API change handling in
-abicheck. It combines what used to be three separate pages — the stability
-guide, the "ABI breaks explained" taxonomy, and the breaking-cases catalog —
-into one narrative: *why* breaks happen, *which families* exist, and *how to
-design for stability*. For per-case reproductions with code, runtime demos, and
-fixes, see the generated **[Examples & Case Encyclopedia](../examples/index.md)**.
+This is the **conceptual hub** for understanding ABI/API compatibility — written
+to *teach* the subject, not just catalog it. It is the front door to a seven-part
+**learning series** that starts from first principles ("what is a symbol? what
+does the loader do?") and builds up to the design patterns that keep a C/C++
+shared library compatible across releases.
+
+The series is for **two audiences at once**: developers who maintain or consume
+shared libraries, and AI agents reasoning about whether a change is safe to ship.
+Every break is explained as a *mechanism* — what the compiler baked in, what the
+loader does, what byte moves — and then as a *fix*. abicheck's verdicts and
+change kinds are woven in throughout, so the same page that teaches you *why* a
+struct-field insertion corrupts memory also tells you what abicheck will report
+when it sees one.
+
+> **Looking for something faster?** For a 2-minute scannable card, see the
+> [ABI Cheat Sheet](abi-cheat-sheet.md). For per-case runnable reproductions with
+> code and a real failure demo, see the
+> [Examples & Case Encyclopedia](../examples/index.md). For verdict semantics and
+> CI exit codes, see [Verdicts](verdicts.md).
+
+---
+
+## How to read this series
+
+The seven parts are ordered. If you're new to ABI compatibility, read them in
+sequence — each builds on the mental models established by the last. If you're
+here for a specific problem, jump straight to the relevant part.
+
+| Part | Page | What it covers | Read it when… |
+|------|------|----------------|---------------|
+| **1** | [Foundations](abi-series/01-foundations.md) | Source → object → link → load; what a symbol is; API vs ABI | …you want the ground-up mental model (start here) |
+| **2** | [Symbol Contracts](abi-series/02-symbol-contracts.md) | Removal, rename, signature, pointer-level, globals | …a symbol disappeared or changed meaning |
+| **3** | [Type Layout](abi-series/03-type-layout.md) | Struct size/offset, alignment, enums, unions, bitfields | …you changed a struct, enum, or union |
+| **4** | [C++ ABI](abi-series/04-cpp-abi.md) | Vtables, mangling, templates, `noexcept`, trivial→non-trivial, bases | …you maintain a C++ library |
+| **5** | [Linker & ELF](abi-series/05-linker-elf.md) | SONAME, visibility, versioning, calling conv., TLS, security metadata | …a load-time/linker contract changed |
+| **6** | [Transitive Breaks](abi-series/06-transitive-breaks.md) | Dependency leaks, anonymous structs, type-kind swaps, reserved fields | …the symbol table looks identical but consumers still break |
+| **7** | [Designing for Stability](abi-series/07-designing-for-stability.md) | Opaque handles, Pimpl, version scripts, CI gating — with full code | …you're designing an API to evolve safely |
+
+```mermaid
+flowchart LR
+    P1["1 · Foundations"] --> P2["2 · Symbol<br/>Contracts"]
+    P1 --> P3["3 · Type<br/>Layout"]
+    P2 --> P4["4 · C++ ABI"]
+    P3 --> P4
+    P4 --> P5["5 · Linker<br/>& ELF"]
+    P3 --> P6["6 · Transitive<br/>Breaks"]
+    P5 --> P7["7 · Designing<br/>for Stability"]
+    P6 --> P7
+```
+
+---
 
 ## Break families at a glance
 
-Every detected change maps to one of these families. The verdict column shows
-the typical classification; the exact verdict per fixture lives in
+Every detected change maps to one of these families. The verdict column shows the
+typical classification; the exact verdict per fixture lives in
 `examples/ground_truth.json` and the [Examples Encyclopedia](../examples/index.md).
+The **Part** column points to where the mechanism is explained.
 
-| Family | Representative cases | Typical verdict |
-|--------|---------------------|-----------------|
-| Symbol/function removal & rename | 01, 12, 58, 66 | 🔴 BREAKING |
-| Signature changes (params, return, pointer level) | 02, 10, 33, 46 | 🔴 BREAKING |
-| Struct/class layout, alignment & packing | 07, 14, 40, 42, 43, 56, 117 | 🔴 BREAKING |
-| Enum value/underlying changes | 08, 19, 20, 57 | 🔴 BREAKING |
-| Union layout | 24, 26 (grows) · 26b (no growth) | 🔴 / 🟢 |
-| C++ vtable & virtual methods | 09, 23, 38, 68, 72 | 🔴 BREAKING |
-| C++ qualifiers, mangling & ABI tags | 21, 22, 30, 71, 86, 101, 113 | 🔴 / 🟠 |
-| Trivial → non-trivial (calling convention) | 64, 69 | 🔴 BREAKING |
-| Templates, inline & ODR | 16, 17, 47, 59, 79, 85, 87 | 🔴 / 🟢 |
-| Modern C/C++ contract shifts (char8_t, _BitInt, _Atomic, concepts) | 105, 114, 115, 116 | 🔴 / 🟢 |
-| Transitive/dependency & `detail::` leaks | 18, 48, 74–77, 80, 97, 104, 112 | 🔴 BREAKING |
-| ELF/linker metadata (SONAME, visibility, versioning, RPATH, TLS) | 05, 06, 13, 49, 51, 52, 65, 67 | 🔴 / 🟢 |
-| Source-only / API-level (rename, access, explicit) | 31, 34, 96, 106 | 🟠 API_BREAK |
-| Deployment risk (noexcept, ISA dispatch, version-require) | 15, 83 | 🟡 COMPATIBLE_WITH_RISK |
-| Compatible additions & quality signals | 03, 25, 26b, 27, 29, 61, 62, 99 | 🟢 COMPATIBLE |
-| Scoped/non-public internal changes | 118, 119, 120 | ✅ NO_CHANGE |
+| Family | Representative cases | Typical verdict | Explained in |
+|--------|---------------------|-----------------|--------------|
+| Symbol/function removal & rename | 01, 12, 58, 66 | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
+| Signature changes (params, return, pointer level) | 02, 10, 33, 46 | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
+| Global variable type/qualifier/removal | 11, 39, 58 | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
+| Struct/class layout, alignment & packing | 07, 14, 40, 42, 43, 56, 117 | 🔴 BREAKING | [Part 3](abi-series/03-type-layout.md) |
+| Enum value/underlying changes | 08, 19, 20, 57 | 🔴 BREAKING | [Part 3](abi-series/03-type-layout.md) |
+| Union layout | 24, 26 (grows) · 26b (no growth) | 🔴 / 🟢 | [Part 3](abi-series/03-type-layout.md) |
+| C++ vtable & virtual methods | 09, 23, 38, 68, 72 | 🔴 BREAKING | [Part 4](abi-series/04-cpp-abi.md) |
+| C++ qualifiers, mangling & ABI tags | 21, 22, 30, 71, 86, 101, 113 | 🔴 / 🟠 | [Part 4](abi-series/04-cpp-abi.md) |
+| Trivial → non-trivial (calling convention) | 64, 69 | 🔴 BREAKING | [Part 4](abi-series/04-cpp-abi.md) |
+| Templates, inline & ODR | 16, 17, 47, 59, 79, 85, 87 | 🔴 / 🟢 | [Part 4](abi-series/04-cpp-abi.md) |
+| Modern C/C++ contract shifts (char8_t, _BitInt, _Atomic, concepts) | 105, 114, 115, 116 | 🔴 / 🟢 | [Part 4](abi-series/04-cpp-abi.md) |
+| ELF/linker metadata (SONAME, visibility, versioning, RPATH, TLS) | 05, 06, 13, 49, 51, 52, 65, 67 | 🔴 / 🟢 | [Part 5](abi-series/05-linker-elf.md) |
+| Transitive/dependency & `detail::` leaks | 18, 48, 74–77, 80, 97, 104, 112 | 🔴 BREAKING | [Part 6](abi-series/06-transitive-breaks.md) |
+| Source-only / API-level (rename, access, explicit) | 31, 34, 96, 106 | 🟠 API_BREAK | [Parts 4](abi-series/04-cpp-abi.md) & [6](abi-series/06-transitive-breaks.md) |
+| Deployment risk (noexcept, ISA dispatch, version-require) | 15, 83 | 🟡 COMPATIBLE_WITH_RISK | [Part 4](abi-series/04-cpp-abi.md) |
+| Compatible additions & quality signals | 03, 25, 26b, 27, 29, 61, 62, 99 | 🟢 COMPATIBLE | [Part 7](abi-series/07-designing-for-stability.md) |
+| Scoped/non-public internal changes | 118, 119, 120 | ✅ NO_CHANGE | [Part 6](abi-series/06-transitive-breaks.md) |
 
-The rest of this page explains the *mechanisms* behind these families and the
-design patterns that prevent each one. For a 2-minute scannable card, see the
-[ABI Cheat Sheet](abi-cheat-sheet.md); for verdict semantics and exit codes, see
-[Verdicts](verdicts.md).
+---
 
-## Introduction
+## The one idea to carry through all seven parts
 
-An **API** (Application Programming Interface) is a *source-level* contract: the set of declarations — function signatures, type definitions, macros, and semantic guarantees — that a consumer's source code compiles against. An **ABI** (Application Binary Interface) is the *binary-level* contract between already-compiled artifacts: the exact byte-level layout of types, symbol names and mangling, calling conventions, register usage, vtable shapes, stack-unwinding metadata, and the relocation rules that the dynamic linker relies on. An API break forces downstream code to be edited; an ABI break does not — but it silently corrupts memory, misroutes calls, or fails to resolve symbols at load time, because the consumer binary was produced under assumptions the new library no longer satisfies.
+If you remember nothing else:
 
-The cost of an ABI break compounds with the size of the ecosystem depending on the library. When `libfoo.so.1` breaks ABI without bumping its SONAME, a Linux distribution must rebuild — and re-test, re-sign, and re-ship — every reverse-dependency in the archive; Debian and Fedora each track hundreds of such transitions per release. In embedded and firmware contexts, an ABI break shipped in an OTA update can brick devices in the field when a pre-linked application loads a new system library whose struct offsets have shifted. Plugin ecosystems — audio hosts loading VST modules, game engines loading mods, browsers loading NPAPI/PPAPI components, IDEs loading extensions — fracture entirely when the host's ABI changes: third-party binaries that shipped years earlier fault on first call, and the plugin author may no longer exist to rebuild them.
-
-abicheck classifies every comparison into one of five verdicts — `NO_CHANGE`, `COMPATIBLE`, `COMPATIBLE_WITH_RISK`, `API_BREAK`, and `BREAKING` — mapped to CI exit codes so that release gates can distinguish a harmless symbol addition from a silent memory-corruption hazard. The five tiers and their exit-code semantics are documented in detail in [Verdicts](verdicts.md). This guide catalogs the concrete mechanisms by which ABI breaks occur; for a condensed checklist consult the [ABI Cheat Sheet](abi-cheat-sheet.md), and for per-case reproductions see the [Examples & Case Encyclopedia](../examples/index.md).
-
-## Part 1: Symbol Contract Breaks
-
-The dynamic linker (`ld.so` on Linux, `dyld` on macOS, the PE loader on Windows) resolves every external reference in an executable by name at load time or at first call. A symbol that existed at link time but is missing at load time is a hard error — no fallback, no default, just `symbol lookup error` and process termination. The four classes of break below each violate the name-keyed contract in a different way: by erasing the name, by keeping the name but changing what it means, by preserving type size while changing type meaning, or by letting a data symbol drift out from under consumers that baked its layout into their own binary.
-
-### Removing or renaming symbols
-
-When an executable is linked against `libfoo.so.1`, every reference to a library function is recorded as a named relocation in the binary's `.rela.plt` (for functions) or `.rela.dyn` (for data). At load time `ld.so` walks those relocations and performs `dlsym`-equivalent lookups against the library's `.dynsym` table. If the name is absent — whether v2 dropped it entirely (see [case01](../examples/case01_symbol_removal.md), where `helper` disappears) or only kept a differently-named function alongside the deletion (see [case12](../examples/case12_function_removed.md), where `fast_add` is removed and `other_func` is added) — the lookup returns `NULL` and the process aborts before `main()` under `RTLD_NOW`, or at the first PLT trampoline under the default lazy binding. A rename is the same mechanism: from the loader's viewpoint, renaming `fast_add` to `fast_add_v2` is a removal of the old name plus an addition of the new one, and every pre-existing binary still resolves against the old name. v1 of case01 exports both entry points:
-
-```c
-int compute(int x) { return x * 2; }
-int helper(int x)  { return x + 1; }
-```
-
-v2 drops `helper`, and every downstream binary that ever called it fails with `./app: symbol lookup error: ./app: undefined symbol: helper` until recompiled against v2 headers. Name identity is the only key `.dynsym` is indexed by — which is why the loader cannot distinguish a removal from a rename, and why neither is safe without a SONAME bump.
-
-### Changing function signatures
-
-Signatures are not part of the symbol name in C — `process` mangles to `process` regardless of whether it takes `(int, int)` or `(double, int)` — so the dynamic linker cheerfully binds v1 callers to v2 implementations whose parameter types disagree. The x86-64 System V ABI passes the first six integer-class arguments in `RDI, RSI, RDX, RCX, R8, R9` and the first eight floating-point arguments in `XMM0..XMM7`, with integer and FP registers assigned from independent queues; anything past those queues spills onto the stack in right-to-left order. When [case02](../examples/case02_param_type_change.md) widens the first parameter from `int` to `double`, the v1 caller loads an integer into `EDI` while the v2 callee reads an FP value from `XMM0` — two disjoint registers — and `XMM0` holds whatever garbage the caller last left there:
-
-```c
-/* v1 */ double process(int a, int b)    { return (double)(a + b); }
-/* v2 */ double process(double a, int b) { return a + b; }
-```
-
-[case10](../examples/case10_return_type.md) is the mirror failure on the return path: widening `int` → `long` makes the callee write all 64 bits of `RAX`, but v1 callers read only `EAX`, truncating `3_000_000_000` to `-1_294_967_296`. Struct-passing changes are worse still, because aggregates straddle the register/stack boundary by classification rules that depend on size, alignment, and member types — a single added `int64_t` field can push an entire argument onto the stack.
-
-### Pointer-level changes
-
-Every pointer on a 64-bit target occupies 8 bytes, so `int *` and `int **` look identical in a symbol's size on the wire. They are not identical in semantics. The v1 and v2 implementations of [case33](../examples/case33_pointer_level.md) make the contrast concrete:
-
-```c
-/* v1 */ void process(int *data)  { buf[0] = *data; }
-/* v2 */ void process(int **data) { buf[0] = **data; }
-```
-
-A v1 caller passes the address of a stack `int`; v2 treats that address as an `int *` and dereferences it again, reading the 32-bit integer value as a 64-bit pointer. The result is almost always an unmapped-page fault, but on unlucky memory layouts the synthesised "pointer" lands inside a valid mapping and the library silently reads or writes the wrong bytes — a data-corruption bug with no crash to trace back to. The same failure occurs on the return path: if `get_buffer()` grows from `int *` to `int **`, v1 callers index through a pointer-to-pointer as if it were a flat buffer and walk off into arbitrary memory.
-
-### Global variable changes
-
-Exported globals are the hardest class to refactor compatibly because the executable bakes in layout facts about the variable at link time. On ELF, a reference to an imported data symbol typically generates a **COPY relocation**: the linker allocates space in the executable's own `.bss` sized to `sizeof(v1_type)`, and at load time `ld.so` memcpy's the library's initial value into that executable-owned slot. Subsequent reads and writes on *both* sides redirect to the executable's copy. If v2 widens the type — as in [case11](../examples/case11_global_var_type.md), `int lib_version` → `long lib_version` — the executable's 4-byte slot cannot hold the 8-byte value; `ld.so` either warns about a size mismatch or silently truncates, so the app reads `705_032_704` where the library wrote `5_000_000_000`. [case58](../examples/case58_var_removed.md) removes the global outright: the COPY relocation has no target, and the process fails to start with `undefined symbol: lib_debug_level`. [case39](../examples/case39_var_const.md) shows the qualifier failure mode in two flavours: when COPY relocation is in play (typical for non-PIE executables on ELF), a mutable-in-v1 global that v2 declares `const` still lives in the app's writable `.bss` copy, so app-side writes succeed but the library's own updates never propagate to that copy — the two sides silently diverge. For PIE binaries that reach the library symbol directly through the GOT, the same change moves the variable into the library's `.rodata` and a write from app code faults with SIGSEGV. Either way the combined demo in case39 also removes `g_legacy_flag`, so the process itself fails to start with an undefined-symbol error before the divergence ever becomes observable.
-
-> **Best practice — keeping the symbol contract intact**
+> **The compiler bakes the library's ABI facts — sizes, offsets, register
+> choices, vtable slot numbers, symbol names — into every caller, as immediate
+> constants, and never re-checks them.** When the library changes one of those
+> facts in a later release, the old caller keeps using the old number. Nobody
+> re-validates it. That is why an ABI break is *silent*: no linker error, often
+> no crash, just wrong bytes at the wrong address.
 >
-> - **Deprecate, don't delete.** Mark outgoing functions `__attribute__((deprecated))` for at least one release, ship an alias (`__attribute__((alias("new_name")))`) spanning old and new names, and only remove on a SONAME bump.
-> - **Use versioned symbols.** A linker version script (`GLIBC_2.17 { global: foo; };`) lets you ship `foo@GLIBC_2.17` alongside `foo@@GLIBC_2.34`, so pre-existing binaries keep resolving to the old implementation while new links pick up the new one.
-> - **Prefer accessors over exported globals.** `int get_version(void)` is immune to COPY-relocation hazards and lets the library change storage, width, or qualifier without touching consumers.
-> - **Freeze signatures; add new entry points.** Model the `ftell` → `ftello` pattern: ship a new symbol for the new type rather than widening the existing one.
-> - **Hide layout behind opaque handles.** Publish `typedef struct foo foo_t;` with only `foo_t *` in the public header and force consumers through functions — the library then owns the struct's size and layout outright.
-
-## Part 2: Type Layout Breaks
-
-Every aggregate type published in a header is a byte-level contract: its size, its members' offsets, its alignment, and — for C++ — its vtable shape. Consumer code does not re-read that contract at load time. The compiler bakes it into every caller: `offsetof(s, field)` becomes an immediate displacement in a `mov` instruction, `sizeof(T)` becomes an allocation constant, array indexing multiplies by a stride chosen at compile time. When the library's next release shifts even one offset, every call site compiled against the old layout reads or writes at the wrong address — silently, without a linker error, usually without a crash until adjacent memory is eventually read back.
-
-### Struct/Class Size and Offsets
-
-The most common layout break is appending, inserting, or reordering a struct field. In [case07](../examples/case07_struct_layout.md), `struct Point { int x; int y; }` grows to `{ int x; int y; int z; }`. `sizeof(Point)` goes from 8 to 12, so every caller that allocates `Point` on the stack or inside another struct under-allocates; every caller passing `Point` by value sends 8 bytes while the library reads 12. In [case14](../examples/case14_cpp_class_size.md) the same failure mode strikes C++: a `char data[64]` buffer grows to `char data[128]`, `sizeof(Buffer)` doubles, and v1 callers `new Buffer()` hand the constructor a 64-byte allocation that it promptly zero-fills with 128 bytes, corrupting whatever lives next on the heap. [case43](../examples/case43_base_class_member_added.md) shows the transitive case: adding `int extra_field` to `class Base` shifts `Derived::value` from offset 12 to offset 16, so every subclass member in the ecosystem silently moves. [case40](../examples/case40_field_layout.md) bundles five field-level mutations — type widening, removal, reorder, bitfield resize, append — into a single struct to show that "just one field" changes cascade across the whole layout.
-
-### Alignment and Packing
-
-Alignment is the second axis of layout. [case42](../examples/case42_type_alignment_changed.md) changes only the alignment attribute — fields and sizes stay identical — going from `__attribute__((aligned(8)))` to `__attribute__((aligned(64)))`. v1 callers allocate `CacheBlock` on 8-byte boundaries; v2 code may emit aligned-load instructions (e.g., `vmovdqa`) and fault on misaligned access — the signal delivered varies by architecture and OS (commonly `SIGSEGV` on x86-64 Linux, `SIGBUS` on strict-alignment platforms) — and `malloc` (typically 16-byte aligned) can no longer hand out correctly-aligned storage without `aligned_alloc`. [case56](../examples/case56_struct_packing_changed.md) is the inverse: v1 has natural padding (`char tag` at 0, `int value` at 4, total 12), v2 adds `#pragma pack(1)` and eliminates all padding (`value` at offset 1, total 6). `sizeof` shrinks, every field except `tag` moves, and on strict-alignment architectures (ARM, SPARC) the unaligned `int` access traps. Because `alignas` and `#pragma pack` propagate across translation unit boundaries through the header, a single-line change in one header silently rewrites offsets for every TU that includes it.
-
-### Enum Value Stability
-
-Enumerations look like constants, but they are part of the wire format. In [case08](../examples/case08_enum_value_change.md) `{ RED=0, GREEN=1, BLUE=2 }` becomes `{ RED=0, YELLOW=1, GREEN=2, BLUE=3 }`: inserting `YELLOW` in the middle shifts `GREEN` and `BLUE` by one, so every existing binary that tested `== 1` for green now hits the yellow branch. [case20](../examples/case20_enum_member_value_changed.md) changes `ERROR = 1` to `ERROR = 99` — the same symbolic name, a different integer — which is effectively a protocol rewrite without version negotiation. [case19](../examples/case19_enum_member_removed.md) removes an enumerator: any persisted value, any database row, any network message carrying that integer becomes undefined on read. The safe counterpoint is [case25](../examples/case25_enum_member_added.md): appending `YELLOW = 3` to the end does not perturb existing values and is `COMPATIBLE`. A more insidious failure is [case57](../examples/case57_enum_underlying_size_changed.md), which adds a sentinel `= 0x100000000LL` that forces the compiler to widen the underlying type from `int` to `long`; `sizeof(Color)` jumps from 4 to 8, and every struct embedding `Color` silently grows and relocates its subsequent fields.
-
-### Union Layout
-
-Unions share offset 0 across all members, so adding a new variant does not move existing fields — but the union's size equals the largest member, and that size *does* propagate. [case26](../examples/case26_union_field_added.md) adds `double d` to `union Value { int i; float f; }`: `sizeof` grows from 4 to 8, so every stack allocation, every array stride, every embedding struct shifts. This is `TYPE_SIZE_CHANGED` and classified `BREAKING`. By contrast, [case26b](../examples/case26b_union_field_added_compatible.md) adds `int i` to `union { long l; double d; }` where `max(8, 8, 4) == 8` — the union does not grow, nothing downstream moves, and the verdict is `COMPATIBLE`. The rule is: a new union field is safe if and only if `sizeof(new_member) <= sizeof(old_union)` and `alignof(new_member) <= alignof(old_union)`. [case24](../examples/case24_union_field_removed.md) shows the other direction — removing a variant removes a supported reinterpretation, which is a semantic contract break even when the size is unchanged, because consumers compiled to write `d.f = 3.14f` have no replacement for that access path.
-
-### Bitfields and Flexible Arrays
-
-Bitfields are the most fragile layout primitive because storage-unit allocation is implementation-defined. [case63](../examples/case63_bitfield_changed.md) widens `mode` from 3 bits to 5 bits inside a 32-bit `RegMap`. `sizeof` is unchanged — naive size checks pass — but `channel`, `priority`, and `reserved` all shift two bit positions, so every v1 consumer reads corrupt values with no crash and no diagnostic. This pattern bites hardest in hardware-register maps and protocol headers, exactly the contexts where bitfields are most useful. Flexible array members have the opposite static-size profile but the same failure: [case70](../examples/case70_flexible_array_member_changed.md) changes `float data[]` to `double data[]`. The fixed header of `struct Packet` is unchanged — `sizeof(Packet)` compares equal — but every caller that allocated `sizeof(Packet) + count * sizeof(float)` now holds half the needed memory, and `p->data[i]` indexes with stride 8 instead of 4.
-
-### Pointer Chains and Arrays
-
-Multi-level type changes propagate through indirection. [case45](../examples/case45_multi_dim_array_change.md) changes `float data[4][4]` to `double data[4][4]` inside `struct Matrix`: the inner element type changes, the struct doubles from 72 to 136 bytes, the array stride doubles, and both `matrix_get` and `matrix_set` change return/parameter widths so the caller reads the wrong register. [case46](../examples/case46_pointer_chain_type_change.md) reaches further — a function returning `int **` becomes `long **`, a two-level pointer chain where only the ultimate pointee type changes. Every v1 caller that dereferences the returned chain and writes an `int` writes 4 bytes into what v2 treats as an 8-byte cell, corrupting the adjacent slot. abicheck walks pointer and array types structurally during `FUNC_RETURN_CHANGED` and `PARAM_TYPE_CHANGED` detection precisely because a surface-level "both sides return a pointer" comparison would miss these.
-
-> **Best Practice — Defending Type Layout**
->
-> - **Opaque handles.** Expose only `struct foo *` to callers; define the struct in a `.c` file. Callers cannot take `sizeof` or `offsetof`, so layout is free to change. OpenSSL 1.1.0's migration from direct `EVP_MD_CTX` access to `EVP_MD_CTX_new`/`EVP_MD_CTX_free` opaque handles is the canonical real-world precedent — it sealed off decades of accumulated struct-layout churn.
-> - **Pimpl idiom (C++).** The public class holds a single `d_ptr` to a private `Impl`; all state lives in `Impl`. `sizeof` of the public class never changes. Qt enforces this as a binary-compatibility rule across every public class in every release, which is why Qt 5.x maintained ABI for years despite internal refactors.
-> - **Reserved padding fields.** Include `void *reserved[N]` or `uint64_t _pad[N]` at the end of every public struct. Future releases can repurpose slots without changing `sizeof` or shifting offsets. POSIX `pthread_attr_t` and many kernel UAPI structs use this deliberately.
-> - **Freeze the enum underlying type.** In C++ write `enum class Color : int32_t { ... };` explicitly; in C keep all values within `int` range or add an explicit sentinel value such as `INT32_MAX`. Never let a new enumerator silently widen the type (see case57).
-> - **Never reorder or insert fields — use append-only evolution.** Reordering a field, inserting one in the middle, or removing one is always breaking. If a new field is required, append it at the end of the struct, and only when no embedded `sizeof(T)` assumption exists (see case26 vs case26b for the union analog).
-
-## Part 3: C++ ABI Specifics
-
-C++ is the language where ABI stability is hardest. Every class with a virtual method carries a hidden pointer to a statically-ordered table of function pointers; every method name is mangled through a grammar that encodes qualifiers, namespaces, template arguments, and parameter types; every struct with a user-defined destructor changes how it is passed between functions. The Itanium C++ ABI — used by GCC and Clang on Linux, macOS, the BSDs, and most embedded targets — is rigid by design: it guarantees cross-compiler interoperability at the cost of making almost any visible change to a class a potential binary break. MSVC on Windows uses a different, equally rigid ABI with the same categories of pitfalls. What follows is a tour of the seven C++ mechanisms most likely to silently corrupt a consumer binary.
-
-### 1. Vtable and Virtual Methods
-
-Every polymorphic class carries a hidden `vptr` as its first word, pointing to a per-class vtable — a static array of function pointers indexed by the order virtual methods are declared. The Itanium C++ ABI fixes this slot ordering as a public part of the class contract: callers compile `widget->resize()` into `(*widget->vptr[1])(widget)` where `1` is baked into the call site. The ordering is determined at the point of declaration, propagates unchanged into every derived class, and cannot be renegotiated after the first binary ships.
-
-Inserting a new virtual method *before* an existing one silently shifts every later slot. [case09](../examples/case09_cpp_vtable.md) demonstrates the canonical form: a new `recolor()` at slot 1 reroutes every call to `resize()` into `recolor()`, producing wrong results without a crash. Making an existing method pure-virtual ([case23](../examples/case23_pure_virtual_added.md)) replaces the slot with `__cxa_pure_virtual`, turning every old call site into an unconditional `abort()`.
-
-Adding the *first* virtual method to a previously non-polymorphic class is the most destructive variant ([case68](../examples/case68_virtual_method_added.md)): a vptr is prepended, every data member shifts by `sizeof(void*)`, and `sizeof` grows — readers of the old layout interpret the new vptr as their first field. [case38](../examples/case38_virtual_methods.md) combines virtual-insertion, pure-virtual promotion, and copy-constructor deletion in a single release to show how the hazards compound. The only safe addition is to *append* new virtual methods after every existing slot, and only when no derived classes exist in consumer binaries that would themselves need to extend the vtable.
-
-### 2. Method Qualifiers
-
-Method qualifiers are load-bearing parts of the Itanium mangled name, not cosmetic source-level annotations. A `const` member function mangles with a `K` marker in the parameter list, a `volatile` one with `V`, and ref-qualified methods (`&`/`&&`) with `R`/`O`. Any edit that adds, removes, or flips one of these markers renames the symbol from the linker's perspective.
-
-Dropping `const` from `Widget::get() const` ([case22](../examples/case22_method_const_changed.md)) changes the symbol from `_ZNK6Widget3getEv` to `_ZN6Widget3getEv` — the leading `K` disappears, the old symbol vanishes from `.dynsym`, and every consumer hits `symbol lookup error` at load time. The failure mode is a clean `dlopen` abort rather than silent corruption, which makes it one of the easier C++ breaks to diagnose in production.
-
-Converting an instance method into a `static` one ([case21](../examples/case21_method_became_static.md)) is subtler: the mangled name is often identical (`_ZN6Widget3barEv` for both forms), so the linker is happy, but the calling convention silently diverges — the v1 caller passes an implicit `this` in `%rdi` that the v2 static callee never reads, and the function returns data computed from register garbage. Adding `const`/`volatile` to struct *fields* ([case30](../examples/case30_field_qualifiers.md)) leaves layout unchanged but reclassifies the surface as a source break, and `volatile` additionally invalidates any cached loads in already-compiled callers. Treat every qualifier edit on a public declaration as equivalent to renaming the symbol.
-
-### 3. Templates and Inline
-
-Inline and template code lives at the boundary where the One Definition Rule meets the link model, and that boundary is where ABI assumptions get baked into *consumer* binaries without the library ever seeing them. An explicitly instantiated `Buffer<int>` in `libfoo.so` produces the mangled symbol `_ZN6BufferIiEC1Em`; adding a `capacity_` field ([case17](../examples/case17_template_abi.md)) keeps the symbol name identical while growing `sizeof(Buffer<int>)` from 16 to 24 bytes. The consumer stack-allocates 16 and the v2 constructor writes 24, corrupting the caller's frame — a classic stack smash with no header-level signal.
-
-Header-only inline definitions embed the *body* into each consumer translation unit, so the implementation that callers execute is frozen when they compile. Changing the inline implementation between releases produces ODR violations that LTO can detect and link-time surprises that LTO cannot; worse, two consumers who pulled in different versions of your header will silently disagree about what your function does.
-
-Moving a function from inline-in-header to outlined-in-`.so` ([case47](../examples/case47_inline_to_outlined.md)) is compatible — old binaries keep their inlined copy, new binaries call the export. The inverse transition ([case59](../examples/case59_func_became_inline.md)) or mixing builds where the header says outlined but the `.so` does not ([case16](../examples/case16_inline_to_non_inline.md)) removes the symbol from `.dynsym` and hard-fails at load. Template instantiations, inline functions, and `constexpr` bodies are part of the ABI even though they never appear in `readelf -Ws`.
-
-### 4. Covariant Returns and Inline Namespaces
-
-An **inline namespace** is transparent to source-level name lookup but is mangled into every symbol declared inside it, making it the canonical Itanium mechanism for generational ABI versioning. [case71](../examples/case71_inline_namespace_moved.md) shows a library moving `encrypt` from `inline namespace v1` to `inline namespace v2`: source code that writes `crypto::encrypt(...)` compiles unchanged against both versions, but the emitted symbol goes from `_ZN6crypto2v17encryptE...` to `_ZN6crypto2v27encryptE...` — a clean break for pre-compiled callers.
-
-This is precisely the device libstdc++ uses for its **dual ABI**. GCC 5 introduced `std::__cxx11::basic_string` alongside the legacy COW `std::string`, gated on the `_GLIBCXX_USE_CXX11_ABI` preprocessor switch; every distribution spent years untangling the resulting symbol-lookup failures as users mixed libraries built with the two flavors. The lesson is that inline namespaces are a *power tool*: wielded deliberately they enable forward evolution, but switching them unintentionally renames every symbol you export.
-
-Covariant return types interact with vtable layout directly. A derived `Circle::clone()` returning `Circle*` generates a thunk that adjusts `this` before delegating; inserting a new intermediate base class ([case72](../examples/case72_covariant_return_changed.md)) shifts sub-object offsets, changes the covariant's return type, and invalidates every hardcoded vtable slot in consumer binaries. Used deliberately, inline namespaces let you ship breaking changes under a new mangled surface while keeping the old one exported for compatibility; used accidentally, they are an invisible renaming of every function you declare.
-
-### 5. noexcept
-
-[case15](../examples/case15_noexcept_change.md) is classified `COMPATIBLE_WITH_RISK`, not `BREAKING`, and the reasoning is worth internalizing. Before C++17, `noexcept` was not part of the function type, so the Itanium mangler ignored it: `void reset() noexcept` and `void reset()` both mangle to `_ZN6Buffer5resetEv` and resolve to the same `.dynsym` entry. Removing `noexcept` therefore *does not* break linkage — hence not `BREAKING`.
-
-What it does break is the caller's unwinding assumption. The v1 compiler saw `noexcept` and omitted exception landing pads, cleanup frames, and `.eh_frame` entries in the call site; if the v2 implementation now throws, the exception propagates into a frame with no unwinding metadata and `std::terminate()` fires unconditionally. Every destructor that was supposed to run during stack unwinding is skipped, every `catch` block that would have handled the exception is bypassed, and the process dies.
-
-abicheck also flags the associated GLIBCXX version bump that appears when `throw` is introduced (`SYMBOL_VERSION_REQUIRED_ADDED`), which is a deployment-risk signal rather than a linkage failure. The `_WITH_RISK` tier exists for exactly this shape of change: binary-linkable, source-recompilable, but semantically unsafe for binaries built under the stricter old contract. C++17 promoted `noexcept` to part of the function type, but under the Itanium C++ ABI that only changes mangling in contexts where the full *function-type* is encoded — function pointers, references to functions, and templates parameterized by function type — not in the `<bare-function-type>` used for ordinary member and free-function symbols. So toggling `noexcept` on a plain declaration remains `_WITH_RISK` for those direct symbols, but the same change can escalate to `BREAKING` for callers that pass the function through a pointer or template where the `E` tag on the function-type encoding now participates in the mangled name.
-
-### 6. Trivial to Non-Trivial
-
-The System V AMD64 calling convention — and its equivalents on other Itanium-ABI platforms — passes **trivially-copyable** aggregates directly in registers (`%xmm0`/`%xmm1` for a pair of doubles, `%rdi`/`%rsi` for two pointers), but passes **non-trivially-copyable** ones by invisible reference: the caller materializes the object on the stack and hands the callee a pointer. Whether a class is trivially copyable is determined by whether it has user-provided copy/move/destructor special members — a *single line of code* can flip the register/memory decision.
-
-[case69](../examples/case69_trivial_to_nontrivial.md) shows `struct Point { double x, y; }` gaining an empty user-defined `~Point() {}`: the layout is unchanged, `sizeof` is unchanged, the mangled symbol is unchanged, and the dynamic linker resolves the call perfectly. But the v1 caller passes `x`, `y` in `%xmm0`, `%xmm1` while the v2 callee reads `%rdi`, `%rsi` as pointers and dereferences them — segfault or silent garbage with no diagnostic from the toolchain.
-
-No header-diff tool that looks only at declarations will catch this; abicheck reports it as `value_abi_trait_changed` by inspecting the DWARF trivially-copyable flag. Any class you expect callers to pass by value across a library boundary must have its trivially-copyable status pinned from version 1. If cleanup might ever be needed, commit from day one to a *user-provided* destructor — either an empty body (`~T() {}`) or an out-of-line defaulted definition (`~T();` in the header, `T::~T() = default;` in the `.cpp`). An in-class `~T() = default;` on the first declaration is user-declared but *not* user-provided, so it does not make the type non-trivial and does not pin the calling convention.
-
-### 7. Base Class Position and Layout
-
-Multiple inheritance places each base sub-object at a specific offset inside the most-derived object, and those offsets are compiled into every upcast and virtual call at the call site. [case60](../examples/case60_base_class_position_changed.md) shows the textbook case: swapping `Widget : Drawable, Clickable` to `Widget : Clickable, Drawable` leaves the type name and all method signatures identical, yet `static_cast<Drawable*>(widget)` now produces a pointer into the `Clickable` sub-object because the compiler applied v1's zero offset to a v2 layout that moved `Drawable` further down.
-
-[case37](../examples/case37_base_class.md) generalizes this with three independent hazards on the same class. Reordering bases changes `this`-pointer adjustments and reshuffles which vptr sits at offset 0. Converting non-virtual to `virtual` inheritance restructures the entire object: the virtual base moves to the end of the most-derived layout and a vbase-offset table is inserted to resolve it at runtime. Appending a new base class grows `sizeof` and shifts every data-member offset, just as adding a first virtual method does.
-
-All three variants are reported as `BASE_CLASS_POSITION_CHANGED` or `type_base_changed` when DWARF or header information is available; ELF symbol tables alone cannot see them, which is why C++ ABI checking requires either debug info or headers. Base-class composition is, along with vtable ordering, one of the two C++ design decisions you cannot revisit after publishing a library — prefer composition and Pimpl for anything you expect to evolve.
-
-> **Best Practice — Designing C++ libraries for ABI stability**
->
-> - **Interface versioning via pure-virtual interface + factory.** Expose a pure-virtual class (no data members, no inline methods) and a C-linkage factory function `create_foo()`. Consumers hold only the abstract pointer, so you can evolve the implementation class freely without touching any consumer vtable layout.
-> - **Non-Virtual Interface (NVI) pattern.** Make your public methods *non-virtual* wrappers that call a small, stable set of `virtual` hooks. You can add new public methods (non-virtual additions are ABI-compatible) without appending vtable slots, and you can change the hook set only when you intend an ABI bump.
-> - **ABI firewall via opaque pointers (Pimpl).** Put every data member into an `Impl` struct whose definition lives only in the `.cpp`; the public class holds a single `std::unique_ptr<Impl>`. `sizeof(Widget)` never changes, field offsets are invisible, and you can add, remove, or reorder internal state without ABI consequences.
-> - **Inline namespaces for generational ABI.** Wrap every public declaration in `inline namespace abi_v1 { ... }`. When you need a breaking change, ship `abi_v2` alongside `abi_v1` and keep the old symbols exported; consumers migrate on their own schedule, mirroring libstdc++ `__cxx11`.
-> - **`-fvisibility=hidden` with explicit export macros.** Compile with hidden default visibility and annotate exported declarations with a `FOO_API` macro (expanding to `__attribute__((visibility("default")))` on ELF and `__declspec(dllexport)` on PE). This shrinks the exported surface to exactly what you intend to stabilize, eliminating accidental ABI commitments on internal helpers, inline template bodies, and private vtables.
-## Part 4: ELF and Linker-Level Concerns
-
-A second contract sits between the source-level ABI and the running
-process: the one enforced by the dynamic linker. SONAME, visibility bits,
-version nodes, calling-convention attributes, and the TLS access model are
-all recorded in the `.so` and consulted at load time.
-
-### SONAME and Library Identity
-
-The SONAME is how `ld.so` answers "is this the library you asked for?". It
-lives in the `DT_SONAME` entry of `.dynamic` and is set via
-`-Wl,-soname,libfoo.so.MAJOR` at link time. When an app links against
-`libfoo.so`, the linker copies the SONAME — not the filename — into
-`DT_NEEDED`, and at runtime `ld.so` searches for a file (usually an
-`ldconfig`-managed symlink) matching that string.
-
-[Case 05](../examples/case05_soname.md) covers a library built
-without `-Wl,-soname` at all: `DT_NEEDED` points at the bare `libfoo.so`,
-which `ldconfig` cannot manage, so shipping `libfoo.so.1` later breaks
-every consumer. [Case 50](../examples/case50_soname_inconsistent.md)
-is the subtler bug where a 1.x release is tagged `libfoo.so.0`: packaging
-generates dependencies on the wrong major, and the cutover forces a
-distribution-wide rebuild. Rule: SONAME major equals ABI epoch, and it
-never silently changes.
-
-### Symbol Visibility
-
-Every `.dynsym` entry has an `st_other` visibility byte: `STV_DEFAULT`
-(public, interposable), `STV_HIDDEN`, `STV_PROTECTED` (exported but not
-interposable), or `STV_INTERNAL`. Without `-fvisibility=hidden`, every
-non-`static` function defaults to `STV_DEFAULT`, dragging the entire
-translation unit into the public ABI.
-[Case 06](../examples/case06_visibility.md) is the accidental
-leak: `internal_helper` was never intended as public API, but lacking
-`static` consumers can resolve it — the later "cleanup" that hides it
-breaks them. [Case 53](../examples/case53_namespace_pollution.md)
-is the related design error: exporting unprefixed names like `init` that
-collide in the process's flat symbol namespace.
-[Case 51](../examples/case51_protected_visibility.md) rounds it
-out: `DEFAULT` → `PROTECTED` is ABI-compatible for normal callers but
-silently defeats `LD_PRELOAD` interposition.
-
-### Symbol Versioning
-
-A version script (`-Wl,--version-script=libfoo.map`) groups symbols into
-named nodes like `LIBFOO_1.0`, recorded in `.gnu.version_d` and tagged in
-`.gnu.versym`; consumers carry matching `.gnu.version_r` entries. This lets
-one `.so` ship multiple ABI generations side by side.
-[Case 13](../examples/case13_symbol_versioning.md) shows that
-*adding* a version script is backward compatible — old binaries have no
-`DT_VERNEED`, so `ld.so` resolves by name.
-[Case 65](../examples/case65_symbol_version_removed.md) is the
-opposite: once a node has shipped, removing it deletes every symbol it
-tagged. glibc's `GLIBC_2.0` has been append-only since 1997 — which is
-why a binary built against an old glibc still loads against a current one,
-and why OpenSSL 3.0's version-node removals forced the SONAME bump from
-`libssl.so.1.1` to `.so.3`.
-
-### Calling Conventions
-
-A calling convention is the register-and-stack contract: which registers
-hold args, which are callee-saved, and how the return comes back. On
-x86-64 the two you meet are System V AMD64 (Linux/macOS/BSD, args in
-`rdi, rsi, rdx, rcx, r8, r9`) and Microsoft x64 (Windows or via
-`__attribute__((ms_abi))`, args in `rcx, rdx, r8, r9`). On 32-bit x86 the
-zoo is larger: `cdecl`, `stdcall`, `fastcall`, `thiscall`, `vectorcall`.
-[Case 64](../examples/case64_calling_convention_changed.md) shows
-the attribute flipping silently: the v1 caller loads pointers into
-`rdi`/`rsi`, the v2 `ms_abi` callee reads `rcx`/`rdx`, and the function
-operates on stale register contents — zero results or a segfault.
-`abicheck` catches it by diffing the `DW_AT_calling_convention` DWARF
-attribute; the signature is unchanged, so name-and-type-only checks miss
-it.
-
-### Security Metadata
-
-The `PT_GNU_STACK` program header advertises whether the process stack
-must be executable, and the linker unions it across input objects — so a
-single assembly file missing its `.note.GNU-stack` annotation promotes the
-entire `.so` (and every process that loads it) to an executable stack.
-[Case 49](../examples/case49_executable_stack.md) shows
-`readelf -l` reporting `RWE` instead of `RW`; rpmlint and Debian lintian
-both reject the package.
-`DT_RPATH`/`DT_RUNPATH` hold extra linker search paths.
-[Case 52](../examples/case52_rpath_leak.md) shows a build system
-baking `/home/build/myproject/lib` into the artifact: it only works on the
-build host, and anyone who can write that path gets a library-injection
-primitive. Use `$ORIGIN`-relative paths or strip `RPATH` entirely.
-
-### Language Linkage and TLS
-
-[Case 66](../examples/case66_language_linkage_changed.md) covers
-`extern "C"` removal during a C++ modernization: source still compiles,
-but the `.dynsym` symbol flips from unmangled `parse_config` to mangled
-`_Z12parse_configPKc`, and every pre-linked consumer fails at load time.
-Treat `extern "C"` blocks as part of the public ABI.
-TLS has four access models: `global-dynamic` (default for `.so`,
-`dlopen`-safe), `local-dynamic`, `initial-exec` (faster but requires
-presence at startup — `dlopen` fails), and `local-exec` (main executable
-only). Libraries intended for `dlopen` must avoid `initial-exec`.
-[Case 67](../examples/case67_tls_var_size_changed.md) adds a
-second hazard: any exported `__thread` struct whose layout shifts corrupts
-consumers per-thread. Freeze size, layout, and access model of TLS exports
-as first-class ABI.
-
-> **Best practice**
->
-> - **Version scripts as the source of truth.** A `.map` file enumerating
->   every intentional export is the canonical place to negotiate API surface.
-> - **`ABI_EXPORT` macro discipline.** Build with `-fvisibility=hidden` and
->   annotate public functions with a project-specific macro.
-> - **CI gate: `abicheck` on every PR.** Dump the previous release, compare
->   the candidate, fail on any `BREAKING` not paired with a SONAME bump.
-> - **Never link with absolute `--rpath`.** Use `$ORIGIN` or install-time
->   rewriting; absolute build paths are non-portable and a security hazard.
-> - **Declare TLS access models explicitly.** If a TLS variable is ever
->   reached via `dlopen`, pin `-ftls-model=global-dynamic`.
-
-## Part 5: Subtle and Transitive Breaks
-
-The breaks covered in this part are the ones that survive code review. The
-exported symbol table is byte-identical, every function keeps its signature, and
-`nm --dynamic` reports no diff between `libfoo.so.1` and its replacement — yet
-consumers corrupt memory on the first call. What these cases share is a
-*transitive* dependency: an ABI contract implied by a type the library doesn't
-itself define but publishes through a header, a padding field, or a nested
-member. Static analyzers that look only at the shipped `.so` miss them;
-DWARF-aware tools catch most but require debug info to travel with the binary.
-
-### Dependency Leaks
-
-When a public header includes a third-party type — `std::string`, `boost::any`,
-`tbb::task_arena`, `grpc::Status` — the library silently inherits that type's
-ABI contract. Upgrade the third-party library and every consumer's compiled
-size, field offsets, and vtable assumptions become wrong, even though the
-wrapper library's own source never changed.
-[Case 18](../examples/case18_dependency_leak.md) demonstrates this
-with a `ThirdPartyHandle` that grows from 4 to 8 bytes: `libfoo`'s exported
-symbols are identical, `nm` and naive `abidiff` see no difference, but a caller
-built against v1 headers allocates a 4-byte struct that the v2 library reads
-8 bytes from. libstdc++'s dual-ABI split (`std::string` after GCC 5) and the
-TBB 2021.3 `task_arena` re-layout both propagated through exactly this
-mechanism, fracturing every consumer who had leaked the type into its public
-API. abicheck flags this only when DWARF for the third-party type is present
-in the shipped `.so`; stripped distributions hide the hazard entirely, which
-is why the fix is structural — pimpl or opaque handles — not tooling.
-
-### Anonymous Structs
-
-C and C++ permit unnamed nested structs and unions inside a public type. The
-containing type's size and alignment depend entirely on the unnamed member's
-contents, but the anonymous member has no stable name to refer to in a diff,
-and in C++ it changes the mangled layout without touching any source-visible
-identifier.
-[Case 36](../examples/case36_anon_struct.md) shows a
-`struct Variant { int tag; union { int i; float f; }; }` where replacing
-`float f` with `double d` inflates the union from 4 to 8 bytes and shifts the
-whole struct's size from 8 to 16, moving `i` from offset 4 to offset 8 due to
-8-byte alignment. A caller allocating `sizeof(Variant) == 8` on the stack then
-calls into a v2 library that reads `i` at offset 8, four bytes past the
-allocation, and lands in uninitialized memory. The source diff is one line
-inside an anonymous scope; the ABI diff is total. abicheck traces the layout
-through DWARF's anonymous-member rules and reports it as `TYPE_SIZE_CHANGED`
-with the exact member offset delta.
-
-### Type Kind Changes
-
-Swapping `struct` for `union`, `enum` for plain `int`, or `class` for `struct`
-at the same name — even when the size happens to match — is always an ABI
-break, because the *semantics* of member storage differ.
-[Case 55](../examples/case55_type_kind_changed.md) changes `Data`
-from a struct with sequential fields `x, y` (size 8) to a union where `x` and
-`y` overlap at offset 0 (size 4): `sizeof` shrinks, `y`'s offset moves, and
-writing one member now clobbers the other. Even a same-size swap — for
-example, `enum E : int` to plain `int` in a C++ API — breaks overload
-resolution and name mangling (`E` and `int` mangle differently), so function
-symbols vanish from the new `.so`. abicheck reads DWARF's
-`DW_TAG_structure_type` vs `DW_TAG_union_type` vs `DW_TAG_enumeration_type`
-and classifies any transition as `TYPE_KIND_CHANGED` / BREAKING regardless of
-byte-for-byte size equality, because a consumer's code generation assumes the
-kind, not just the footprint.
-
-### Reserved Field Misuse
-
-Reserving padding fields for future growth — `int __reserved1`,
-`char _pad[16]` — is the standard way to extend a struct without bumping
-SONAME, but it only works if *no shipped binary ever touched the reserved
-bytes*. The moment a consumer writes to reserved storage (deliberately, via a
-cast, or accidentally, via `memset(&s, 0xFF, sizeof(s))` followed by
-field-wise init), repurposing those bytes becomes a silent data corruption.
-[Case 54](../examples/case54_used_reserved_field.md) shows the
-*correct* pattern: v1 ships `__reserved1` and `__reserved2` at defined
-offsets; v2 renames them to `priority` and `max_retries` with the same types
-and offsets, and abicheck's `_diff_reserved_fields` detector recognizes the
-naming convention (`__reserved`, `_reserved`, `__pad`, `_unused`) and
-classifies the transition as COMPATIBLE. The hazard is that there is no way
-for the library author to *verify* that no consumer ever wrote to the
-reserved slot; the safety of the pattern rests on a documented contract that
-users zero-initialize and ignore the field. Linux's `struct stat`, glibc's
-`pthread_attr_t`, and Wayland's protocol structs all rely on exactly this
-contract.
-
-### Leaf Structs Through Pointers
-
-Pointer indirection is the single strongest ABI firewall available in C: a
-caller that handles only `T*` is agnostic to `sizeof(T)`, to `T`'s field
-offsets, and to the kind-tag of `T`.
-[Case 48](../examples/case48_leaf_struct_through_pointer.md)
-contrasts this with the failing case — a `Container` that *embeds* `Leaf` by
-value. When `Leaf` grows from 4 to 8 bytes, `Container::flags` shifts from
-offset 8 to offset 16; the public API still takes only `Container*`, but the
-size change propagates through embedding, and a v1-compiled caller reads
-`flags` at the wrong offset. The fix is to replace the embedded `Leaf` with
-`Leaf*` (pointer to incomplete type declared via `struct Leaf;`): the caller's
-compilation now depends only on pointer size, which is stable per ABI, and
-the library alone controls allocation and layout. This is the mechanism
-behind every opaque-handle C API (`FILE*`, `sqlite3*`, `git_repository*`) —
-the only type that crosses the ABI boundary is a pointer, so layout evolution
-is private to the library.
-
-> **Best practice**
->
-> - **Opaque wrappers around third-party types.** Never forward-publish
->   `std::string`, `boost::any`, `tbb::task_arena`, or any vendored-dependency
->   type in your headers; wrap it in a type you own and control.
-> - **Stable DTOs at the API boundary.** Define plain structs with explicit
->   layout for every value that crosses the ABI, and treat those DTOs as a
->   versioned schema separate from the library's internal types.
-> - **Build-time abicheck in CI.** Run `abicheck compare` against the last
->   released `.so` on every PR; flag anything above `COMPATIBLE_WITH_RISK` as
->   a release blocker.
-> - **Zero reserved fields before public release**, or commit in documentation
->   to never activating them. Reserved padding that is never used is free;
->   reserved padding whose safety you can't audit is a future BREAKING
->   verdict.
-> - **Pointer-to-incomplete-type for anything you might evolve.** If you
->   can't guarantee a struct's layout for the lifetime of a SONAME, don't
->   expose the definition — expose a forward-declared tag and a
->   constructor/destructor pair.
-
-## Global recommendations
-
-Five rules subsume every mechanism above:
-
-1. **Treat public headers as ABI contracts.** Anything reachable from a public
-   header — type layout, enum values, vtable shape, exported globals — is part
-   of the binary contract whether or not you intended it to be.
-2. **Govern release identity.** Use SONAME + symbol versioning + a
-   `-fvisibility=hidden` export policy on every release; bump the SONAME major
-   on any binary-incompatible change. abicheck surfaces these as
-   `soname_bump_recommended`, `symbol_version_node_removed`,
-   `symbol_moved_version_node`, and `version_script_missing`.
-3. **Prefer opaque handles and Pimpl** over exposing mutable layouts, so the
-   library — not the consumer — owns size, offsets, and the kind-tag of a type.
-4. **Evolve additively, never in place.** Append new symbols, enum members, and
-   struct fields (where no embedded `sizeof` assumption exists); ship breaking
-   changes under a new inline-namespace or a new symbol rather than mutating an
-   existing one.
-5. **Gate every PR with abicheck in CI.** Dump the last released artifact and
-   compare the candidate; block anything above `COMPATIBLE_WITH_RISK` that is
-   not paired with a deliberate SONAME bump. See the
-   [GitHub Action](../user-guide/github-action.md) for a ready-to-paste workflow.
+> Every fix in [Part 7](abi-series/07-designing-for-stability.md) is therefore a
+> variation on a single move: **stop publishing the fact** — hide it behind a
+> pointer, a version node, or hidden visibility — so you stay free to change it.
+
+abicheck exists to catch these breaks *before* they ship: it dumps a snapshot of
+each binary, diffs them structurally, and classifies every difference into one of
+five verdicts mapped to CI exit codes. See
+[Part 1 §7](abi-series/01-foundations.md#7-where-abicheck-fits) for how that
+pipeline works, and [Verdicts](verdicts.md) for the exit-code semantics.
+
+---
 
 ## Detection coverage and roadmap
 
 abicheck detects **184 change kinds** today (see the
 [Change Kind Reference](../reference/change-kinds.md)), spanning every family in
-the table above — including the calling-convention, alignment/packing,
-bit-field, dual-ABI (`_GLIBCXX_USE_CXX11_ABI`), ABI-tag, `char8_t`, `_BitInt`,
-`_Atomic`, and CPU-dispatch cases that were once on the wishlist. Areas still
-deepening: richer cross-compiler ABI-drift modelling (GCC vs Clang vs MSVC for
-the same headers) and LTO/visibility interactions where an inlined symbol
-disappears. The authoritative, always-current taxonomy is the generated
-[Change Kind Reference](../reference/change-kinds.md) and
-[Examples Encyclopedia](../examples/index.md).
+the table above — including the calling-convention, alignment/packing, bit-field,
+dual-ABI (`_GLIBCXX_USE_CXX11_ABI`), ABI-tag, `char8_t`, `_BitInt`, `_Atomic`,
+and CPU-dispatch cases. Areas still deepening: richer cross-compiler ABI-drift
+modelling (GCC vs Clang vs MSVC for the same headers) and LTO/visibility
+interactions where an inlined symbol disappears. The authoritative, always-current
+taxonomy is the generated [Change Kind Reference](../reference/change-kinds.md)
+and [Examples Encyclopedia](../examples/index.md).
+
+---
+
+➡️ **Start the series: [Part 1 — Foundations](abi-series/01-foundations.md)**

--- a/docs/concepts/abi-series/01-foundations.md
+++ b/docs/concepts/abi-series/01-foundations.md
@@ -1,0 +1,352 @@
+# Part 1 — Foundations: From Source Code to a Running Process
+
+> **Series navigation:** **1. Foundations** ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> [3. Type Layout](03-type-layout.md) ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- The journey a `.c`/`.cpp` file takes to become a running process, and where
+  *compatibility* is decided at each step.
+- What a **symbol** really is, and the difference between a symbol that is
+  *defined* and one that is *undefined* (imported).
+- The difference between **static** and **dynamic** linking, and why dynamic
+  linking is where ABI compatibility matters.
+- The two contracts every library publishes: the **API** (source-level) and the
+  **ABI** (binary-level) — and why one break makes your compiler shout and the
+  other one corrupts memory in silence.
+- A mental model you can carry through the rest of the series: *the compiler
+  bakes the library's promises into the caller, and never re-checks them.*
+
+This page assumes **no prior knowledge** of linkers or loaders. If you already
+know what `.dynsym`, COPY relocations, and the dynamic loader are, skip ahead to
+[Part 2 — Symbol Contracts](02-symbol-contracts.md).
+
+---
+
+## 1. The build pipeline: where does a library come from?
+
+When you run `gcc foo.c -o foo`, a single command hides four distinct stages.
+Each stage hands a different *representation* of your program to the next:
+
+```mermaid
+flowchart LR
+    A["foo.c<br/>(source text)"] -->|preprocess| B["foo.i<br/>(expanded source)"]
+    B -->|compile| C["foo.s<br/>(assembly)"]
+    C -->|assemble| D["foo.o<br/>(object file<br/>+ symbol table)"]
+    D -->|link| E["a.out / libfoo.so<br/>(executable / shared object)"]
+    E -->|load + run| F["running process"]
+```
+
+1. **Preprocess.** `#include` directives are pasted in, macros expanded. This is
+   the only stage that sees your *headers* — the textual interface a library
+   publishes. Headers define the **API**.
+2. **Compile.** The preprocessed source becomes assembly for one specific
+   target (e.g. x86-64). Crucially, **this is where the compiler turns the
+   library's promises into machine code.** If a header says
+   `struct Point { int x; int y; }`, the compiler now *knows* `sizeof(Point)` is
+   8 and the field `y` lives at byte offset 4 — and it bakes those numbers
+   directly into every instruction that touches a `Point`.
+3. **Assemble.** Assembly becomes an **object file** (`.o`): machine code plus a
+   **symbol table** listing the names this file *provides* and the names it
+   *needs*.
+4. **Link.** The linker stitches object files (and libraries) together,
+   resolving each "needed" name to a "provided" one, producing an executable or
+   a shared library.
+
+The single most important idea in this entire series lives in stage 2:
+
+> **The compiler bakes the library's ABI facts into the caller and never
+> re-checks them.** Offsets, sizes, register choices, and vtable slot numbers
+> become *immediate constants* inside the caller's machine code. When the
+> library later changes one of those facts, the caller keeps using the old
+> number. Nobody re-validates it. That is why an ABI break is silent.
+
+---
+
+## 2. What is a symbol?
+
+A **symbol** is a name with an address attached — the unit the linker and loader
+trade in. Functions and global variables become symbols; local variables inside
+a function do not.
+
+Compile this file:
+
+```c
+// math.c
+int add(int a, int b) { return a + b; }   // defined here
+int counter;                              // defined here (global)
+
+extern int log_event(int code);          // declared, NOT defined here
+
+int tally(int x) {
+    counter += x;
+    return log_event(add(x, 1));          // needs add (local) + log_event (external)
+}
+```
+
+Inspect the resulting symbol table:
+
+```bash
+$ gcc -c math.c -o math.o
+$ nm math.o
+0000000000000000 T add          # T = defined, in .text (code)
+0000000000000004 C counter      # C = common/global data symbol
+                 U log_event     # U = UNDEFINED — this file needs it from elsewhere
+0000000000000014 T tally
+```
+
+Two categories matter for the rest of the series:
+
+| Kind | `nm` letter | Meaning |
+|------|-------------|---------|
+| **Defined** (exported) | `T`, `D`, `B`, `W`… | "I provide this name; here is its code/data." |
+| **Undefined** (imported) | `U` | "I use this name; somebody else must provide it." |
+
+Linking is, at its heart, **matching every `U` to a `T`/`D` somewhere**. If a
+single `U` has no match, the link (or the load) fails. The name is the *only*
+key used for matching — not the function's parameter types, not the variable's
+size. Hold onto that: it is the root cause of an entire family of breaks in
+[Part 2](02-symbol-contracts.md).
+
+### Names in C vs C++ — mangling
+
+In C, the symbol name *is* the source name: `add` stays `add`. In C++, the
+compiler **mangles** the name to encode the namespace, class, and parameter
+types, so that `int add(int,int)` and `double add(double)` can coexist:
+
+```bash
+$ echo 'namespace geo { int add(int,int){return 0;} }' | g++ -x c++ -c - -o t.o
+$ nm t.o | c++filt
+0000000000000000 T geo::add(int, int)     # mangled symbol: _ZN3geo3addEii
+```
+
+Mangling means that in C++ a **parameter type, a `const` qualifier, or a
+namespace change rewrites the symbol name** — turning a source-level edit into a
+linker-level removal. We return to this repeatedly in [Part 4](04-cpp-abi.md).
+
+---
+
+## 3. Static vs dynamic linking
+
+There are two ways the linker can satisfy your program's undefined symbols.
+
+**Static linking** copies the needed code *into* your executable at build time.
+The library's bytes become part of `a.out`. Once built, there is no further
+dependency — and no further compatibility question, because nothing can change
+underneath you.
+
+**Dynamic linking** leaves the undefined symbols *unresolved* in your
+executable and records a note that says "find these in `libfoo.so` at startup."
+The resolution happens every time the program runs.
+
+```mermaid
+flowchart TB
+    subgraph Static
+      app1["app (contains a copy of libfoo's code)"]
+    end
+    subgraph Dynamic
+      app2["app<br/>NEEDED: libfoo.so.1<br/>U: foo, bar"] -.->|resolved at load time| lib["libfoo.so.1<br/>T: foo, bar"]
+    end
+```
+
+Dynamic linking is the default on Linux, macOS, and Windows because it saves
+memory (one copy of `libc` shared by every process), allows security fixes
+without rebuilding every consumer, and enables plugins. **But it creates a
+contract that outlives the build:** the executable was compiled against
+*today's* `libfoo.so`, yet it will be resolved against *whatever* `libfoo.so` is
+installed when it runs — possibly years later, possibly a different version.
+
+> **ABI compatibility is the promise that a future `libfoo.so` can still satisfy
+> a binary built against an older one — without recompiling the binary.**
+
+The rest of this series is a catalog of the ways that promise gets broken.
+
+---
+
+## 4. The dynamic loader: what happens at startup
+
+When you launch a dynamically-linked program, a special component — the
+**dynamic loader** (`ld.so` on Linux, `dyld` on macOS, the PE loader on
+Windows) — runs *before* your `main()`. Its job:
+
+1. Read the executable's list of needed libraries (`DT_NEEDED` entries on ELF).
+2. Find and `mmap` each library into the process's address space.
+3. Walk the executable's **relocations** — the list of "patch this address once
+   you know where the symbol landed" notes — and resolve each undefined symbol
+   by looking up its name in each library's **dynamic symbol table**
+   (`.dynsym`).
+4. If any name can't be found: `symbol lookup error` and the process dies before
+   `main()`.
+
+```bash
+$ ./app
+./app: symbol lookup error: ./app: undefined symbol: helper
+```
+
+This lookup is **by name only**. The loader does not know or check that `helper`
+used to take two `int`s and now takes a `double` — it only checks that *a*
+symbol called `helper` exists. That is both the strength of dynamic linking
+(loose coupling) and the source of its most dangerous failure mode (silent
+mismatch). A symbol that resolves successfully but means something different now
+is the textbook **silent ABI break**.
+
+> **Lazy vs immediate binding.** By default, function symbols are resolved
+> *lazily* — on first call, via a trampoline (the PLT). With
+> `LD_BIND_NOW=1` or `-Wl,-z,now`, everything resolves at startup. This only
+> changes *when* a missing-symbol error surfaces, not *whether* it does.
+
+---
+
+## 5. Two contracts: API vs ABI
+
+We can now state the central distinction precisely.
+
+An **API** (Application Programming Interface) is the **source-level contract**:
+the declarations a consumer's *source code* compiles against — function
+signatures, type definitions, macros, templates, and the semantic guarantees
+that go with them. The API lives in the **headers**. You experience an API break
+at **compile time**: the build fails, the error points at a line, you fix it.
+
+An **ABI** (Application Binary Interface) is the **binary-level contract**
+between already-compiled artifacts: the exact byte layout of types, the symbol
+names and their mangling, the calling convention (which register holds which
+argument), vtable shapes, exception-unwinding metadata, and the relocation rules
+the loader relies on. The ABI lives in the **compiled `.so`/`.dll`/`.dylib` and
+the binaries built against it**. You experience an ABI break at **run time** —
+or worse, you *don't* experience it, because it corrupts memory quietly.
+
+| | **API break** | **ABI break** |
+|---|---|---|
+| Contract level | Source (headers) | Binary (compiled code) |
+| Who notices | The compiler | Nobody — until it crashes or corrupts |
+| When | Build time | Run time (or silently, never) |
+| Fix | Edit + recompile consumer | Often impossible without rebuilding *every* consumer |
+| Example | Renaming an enum member | Inserting a struct field |
+
+The asymmetry is the whole point:
+
+> **An API break forces downstream code to be edited; an ABI break does not —
+> but it silently corrupts memory, misroutes calls, or fails to resolve symbols
+> at load time, because the consumer binary was produced under assumptions the
+> new library no longer satisfies.**
+
+A change can be one, the other, both, or neither:
+
+- **API break only** — rename a function in the header but keep the old exported
+  symbol via an alias. Old binaries still link; new source won't compile against
+  the old name.
+- **ABI break only** — add a field to a struct. Source that uses the struct
+  still compiles fine; old binaries that baked in the old `sizeof` corrupt
+  memory.
+- **Both** — remove a function entirely.
+- **Neither** — change a comment, or an implementation detail behind an opaque
+  pointer.
+
+---
+
+## 6. Why ABI breaks are expensive
+
+The cost of an ABI break compounds with the size of the ecosystem depending on
+the library. When `libfoo.so.1` breaks ABI without changing its identity, the
+damage radiates:
+
+- **Linux distributions** must rebuild — and re-test, re-sign, and re-ship —
+  *every* reverse-dependency in the archive. Debian and Fedora each track
+  hundreds of such "library transitions" per release; a single unannounced ABI
+  break can stall an entire distribution's release.
+- **Embedded / firmware:** an ABI break shipped in an over-the-air update can
+  brick devices in the field, when a pre-linked application loads a new system
+  library whose struct offsets have shifted.
+- **Plugin ecosystems** — audio hosts loading VST modules, game engines loading
+  mods, browsers loading components, IDEs loading extensions — fracture
+  entirely when the host's ABI changes. Third-party binaries shipped years
+  earlier fault on first call, and the plugin author may no longer exist to
+  rebuild them.
+
+This is why mature libraries treat ABI as a versioned, gated, deliberately
+managed surface — and why a tool that can *tell you* whether a change is
+ABI-breaking before you ship belongs in your CI pipeline.
+
+---
+
+## 7. Where abicheck fits
+
+`abicheck` operationalizes everything above. It does not need your source at
+review time; it reads the *compiled* artifacts (plus debug info / headers when
+available) and reasons about the binary contract directly.
+
+```mermaid
+flowchart LR
+    old["libfoo.so.1<br/>(old release)"] -->|dump| s1["snapshot v1"]
+    new["libfoo.so.2-candidate"] -->|dump| s2["snapshot v2"]
+    s1 --> diff{{"diff + classify"}}
+    s2 --> diff
+    diff --> verdict["verdict:<br/>NO_CHANGE / COMPATIBLE /<br/>COMPATIBLE_WITH_RISK /<br/>API_BREAK / BREAKING"]
+```
+
+1. **Snapshot.** It extracts an `AbiSnapshot` from each binary — the exported
+   symbols, type layouts, vtables, calling conventions, ELF metadata, and so on.
+2. **Diff.** It compares the two snapshots structurally (walking pointer chains,
+   struct members, vtable slots — not just symbol names).
+3. **Classify.** Each detected difference is one of **184 change kinds**, and
+   each change kind is partitioned into exactly one verdict tier.
+
+The five verdicts, from safest to most severe, are:
+
+| Verdict | Meaning | Typical CI action |
+|---|---|---|
+| ✅ `NO_CHANGE` | Identical ABI/API | pass |
+| 🟢 `COMPATIBLE` | Backward-compatible (additions / quality signals) | pass |
+| 🟡 `COMPATIBLE_WITH_RISK` | Links fine, but a deployment/behavioral hazard | review |
+| 🟠 `API_BREAK` | Source won't recompile; binaries still link | review / bump minor |
+| 🔴 `BREAKING` | Existing binaries crash or corrupt at runtime | block / bump SONAME |
+
+Each verdict maps to a CI exit code so a release gate can distinguish a harmless
+symbol addition from a silent memory-corruption hazard. The full semantics and
+exit codes are in [Verdicts](../verdicts.md); a one-screen summary is the
+[ABI Cheat Sheet](../abi-cheat-sheet.md).
+
+Throughout the rest of the series, look for callouts like this:
+
+> !!! note "How abicheck sees it"
+>     Inline boxes like this name the specific **change kind** and **verdict**
+>     abicheck reports for the scenario being discussed, and how it detects it
+>     (ELF symbol table, DWARF debug info, or headers). They tie the general
+>     mechanism back to something you can run in CI.
+
+---
+
+## 8. Glossary
+
+| Term | One-line definition |
+|------|---------------------|
+| **Symbol** | A name (function or global) the linker/loader resolves to an address. |
+| **Defined / Undefined symbol** | A name this object *provides* vs *needs* (`T` vs `U` in `nm`). |
+| **`.dynsym`** | A shared object's table of dynamically-visible symbols, searched at load time. |
+| **Relocation** | A "patch this address once the symbol's location is known" note in a binary. |
+| **Dynamic loader** | `ld.so` / `dyld` / PE loader — resolves symbols and maps libraries at startup. |
+| **Mangling** | Encoding of C++ name + signature into a flat symbol string. |
+| **SONAME** | A shared object's *declared identity* (`libfoo.so.1`); the major number is the ABI epoch. |
+| **Calling convention** | The register/stack contract for passing arguments and returning values. |
+| **Vtable** | A per-class array of function pointers backing C++ virtual dispatch. |
+| **API** | Source-level contract (headers). Breaks at compile time. |
+| **ABI** | Binary-level contract (compiled artifacts). Breaks at run time, often silently. |
+
+---
+
+## Next
+
+Now that you know what a symbol is and how it's resolved, the most direct way to
+break a library is to make a symbol the loader needs *disappear* or *change
+meaning*. That is the subject of the next page.
+
+➡️ **[Part 2 — Symbol Contract Breaks](02-symbol-contracts.md)**
+
+*See also:* [ABI Cheat Sheet](../abi-cheat-sheet.md) ·
+[Verdicts](../verdicts.md) ·
+[Examples Encyclopedia](../../examples/index.md)

--- a/docs/concepts/abi-series/01-foundations.md
+++ b/docs/concepts/abi-series/01-foundations.md
@@ -293,7 +293,7 @@ flowchart LR
    symbols, type layouts, vtables, calling conventions, ELF metadata, and so on.
 2. **Diff.** It compares the two snapshots structurally (walking pointer chains,
    struct members, vtable slots — not just symbol names).
-3. **Classify.** Each detected difference is one of **184 change kinds**, and
+3. **Classify.** Each detected difference is one of **180+ change kinds**, and
    each change kind is partitioned into exactly one verdict tier.
 
 The five verdicts, from safest to most severe, are:
@@ -313,11 +313,11 @@ exit codes are in [Verdicts](../verdicts.md); a one-screen summary is the
 
 Throughout the rest of the series, look for callouts like this:
 
-> !!! note "How abicheck sees it"
->     Inline boxes like this name the specific **change kind** and **verdict**
->     abicheck reports for the scenario being discussed, and how it detects it
->     (ELF symbol table, DWARF debug info, or headers). They tie the general
->     mechanism back to something you can run in CI.
+!!! note "How abicheck sees it"
+    Inline boxes like this name the specific **change kind** and **verdict**
+    abicheck reports for the scenario being discussed, and how it detects it
+    (ELF symbol table, DWARF debug info, or headers). They tie the general
+    mechanism back to something you can run in CI.
 
 ---
 

--- a/docs/concepts/abi-series/02-symbol-contracts.md
+++ b/docs/concepts/abi-series/02-symbol-contracts.md
@@ -82,8 +82,9 @@ the loader cannot tell a removal from a rename, and why **neither is safe
 without a SONAME bump**.
 
 > !!! note "How abicheck sees it"
->     `symbol_removed` → 🔴 **BREAKING**, detected straight from the ELF/PE/Mach-O
->     symbol table — no debug info required.
+>     `func_removed` → 🔴 **BREAKING**, detected straight from the ELF/PE/Mach-O
+>     symbol table — no debug info required. (Removed exported *variables* are
+>     reported as `var_removed`; see §4.)
 >     See [case01](../../examples/case01_symbol_removal.md) (a `helper` that
 >     disappears) and [case12](../../examples/case12_function_removed.md)
 >     (`fast_add` removed while an unrelated `other_func` is added — proving the
@@ -134,7 +135,7 @@ types — so a single added `int64_t` field can push an entire argument onto the
 stack, shifting every later argument.
 
 > !!! note "How abicheck sees it"
->     `param_type_changed` / `func_return_changed` → 🔴 **BREAKING**, recovered
+>     `func_params_changed` / `func_return_changed` → 🔴 **BREAKING**, recovered
 >     from DWARF (or headers). The exported symbol name is unchanged, so a
 >     name-only `nm` diff sees nothing.
 >     [case02](../../examples/case02_param_type_change.md) (argument widening),
@@ -169,9 +170,10 @@ pointer-to-pointer as if it were a flat buffer and walk off into arbitrary
 memory.
 
 > !!! note "How abicheck sees it"
->     `param_type_changed` (pointer-depth delta) → 🔴 **BREAKING**. abicheck
->     walks the pointer chain *structurally* during diff, so it distinguishes
->     "both sides return a pointer" from "the indirection level changed."
+>     `param_pointer_level_changed` (and `return_pointer_level_changed` on the
+>     return path) → 🔴 **BREAKING**. abicheck walks the pointer chain
+>     *structurally* during diff, so it distinguishes "both sides return a
+>     pointer" from "the indirection level changed."
 >     [case33](../../examples/case33_pointer_level.md).
 
 ---
@@ -224,8 +226,8 @@ Two more flavors of the same root cause:
   PIE/GOT access the app's write faults with `SIGSEGV`.
 
 > !!! note "How abicheck sees it"
->     `global_var_type_changed` / `symbol_removed` → 🔴 **BREAKING**, detected
->     from the symbol table plus DWARF type info.
+>     `var_type_changed` / `var_removed` / `var_became_const` → 🔴 **BREAKING**,
+>     detected from the symbol table plus DWARF type info.
 >     [case11](../../examples/case11_global_var_type.md),
 >     [case58](../../examples/case58_var_removed.md),
 >     [case39](../../examples/case39_var_const.md).

--- a/docs/concepts/abi-series/02-symbol-contracts.md
+++ b/docs/concepts/abi-series/02-symbol-contracts.md
@@ -1,0 +1,271 @@
+# Part 2 — Symbol Contract Breaks
+
+> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **2. Symbol Contracts** ·
+> [3. Type Layout](03-type-layout.md) ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- Why the dynamic loader's *name-only* lookup makes symbol removal an instant,
+  hard failure — and a rename an invisible removal.
+- How a function whose **signature** changes still resolves, then reads its
+  arguments from the wrong registers.
+- Why a `int *` → `int **` change is invisible "on the wire" but catastrophic at
+  the dereference.
+- Why **exported global variables** are the hardest thing to evolve compatibly,
+  thanks to COPY relocations.
+- The five design moves that keep the symbol contract intact.
+
+Recommended prerequisite: [Part 1 — Foundations](01-foundations.md) (symbols,
+the loader, name-only resolution).
+
+---
+
+## The shared mechanism
+
+From [Part 1](01-foundations.md): the dynamic loader resolves every external
+reference **by name**, at load time or first call. A symbol that existed at link
+time but is missing at load time is a hard error — no fallback, no default, just
+`symbol lookup error` and process termination.
+
+The four break classes below each violate the name-keyed contract in a different
+way:
+
+1. by **erasing** the name (removal / rename),
+2. by **keeping** the name but changing what its arguments mean (signature),
+3. by keeping the same *size* on the wire but changing the *meaning* of the
+   bytes (pointer level),
+4. by letting a **data symbol** drift out from under consumers that baked its
+   layout into their own binary (globals).
+
+---
+
+## 1. Removing or renaming symbols
+
+### The mechanism
+
+When an executable is linked against `libfoo.so.1`, every reference to a library
+function is recorded as a **named relocation** — in `.rela.plt` for functions,
+`.rela.dyn` for data. At load time the loader walks those relocations and looks
+each name up in the library's `.dynsym`. If the name is absent, the lookup
+returns nothing and the process aborts: before `main()` under immediate binding,
+or at the first PLT trampoline under the default lazy binding.
+
+A **rename is the same event seen twice**: from the loader's viewpoint, renaming
+`fast_add` to `fast_add_v2` is a removal of the old name plus an addition of a
+new one. Every pre-existing binary still asks for `fast_add`, and it is gone.
+
+### Minimal scenario
+
+```c
+// v1 — exports two functions
+int compute(int x) { return x * 2; }
+int helper(int x)  { return x + 1; }
+
+// v2 — helper is dropped
+int compute(int x) { return x * 2; }
+```
+
+Every downstream binary that ever called `helper` now fails:
+
+```bash
+$ ./app
+./app: symbol lookup error: ./app: undefined symbol: helper
+```
+
+Name identity is the *only* key `.dynsym` is indexed by — which is exactly why
+the loader cannot tell a removal from a rename, and why **neither is safe
+without a SONAME bump**.
+
+> !!! note "How abicheck sees it"
+>     `symbol_removed` → 🔴 **BREAKING**, detected straight from the ELF/PE/Mach-O
+>     symbol table — no debug info required.
+>     See [case01](../../examples/case01_symbol_removal.md) (a `helper` that
+>     disappears) and [case12](../../examples/case12_function_removed.md)
+>     (`fast_add` removed while an unrelated `other_func` is added — proving the
+>     loader matches names, not "function count").
+
+---
+
+## 2. Changing function signatures
+
+### The mechanism
+
+In C, the signature is **not part of the symbol name**: `process` mangles to
+`process` whether it takes `(int, int)` or `(double, int)`. So the loader
+cheerfully binds a v1 caller to a v2 implementation whose parameter types
+disagree — the names match, and that's all it checks.
+
+What goes wrong lives in the **calling convention**. On the x86-64 System V ABI,
+the first integer-class arguments go in `RDI, RSI, RDX, RCX, R8, R9` and the
+first floating-point arguments go in `XMM0..XMM7`, drawn from *two independent
+queues*. Change a parameter's *class* and the caller and callee now disagree
+about *which register* holds it.
+
+### Minimal scenario — argument path
+
+```c
+/* v1 */ double process(int a, int b)    { return (double)(a + b); }
+/* v2 */ double process(double a, int b) { return a + b; }
+```
+
+The v1 caller loads an integer into `EDI`. The v2 callee reads a floating-point
+value from `XMM0` — a *different register entirely* — and `XMM0` holds whatever
+garbage the caller last left there. No crash, no diagnostic, just a wrong
+answer.
+
+### Minimal scenario — return path
+
+```c
+/* v1 */ int  get(void)  { return 3000000000; }   // caller reads EAX (32-bit)
+/* v2 */ long get(void)  { return 3000000000; }   // callee writes RAX (64-bit)
+```
+
+The v2 callee writes all 64 bits of `RAX`; the v1 caller reads only `EAX`,
+truncating `3000000000` to `-1294967296`.
+
+Struct-passing changes are worse still: aggregates straddle the register/stack
+boundary by classification rules that depend on size, alignment, and member
+types — so a single added `int64_t` field can push an entire argument onto the
+stack, shifting every later argument.
+
+> !!! note "How abicheck sees it"
+>     `param_type_changed` / `func_return_changed` → 🔴 **BREAKING**, recovered
+>     from DWARF (or headers). The exported symbol name is unchanged, so a
+>     name-only `nm` diff sees nothing.
+>     [case02](../../examples/case02_param_type_change.md) (argument widening),
+>     [case10](../../examples/case10_return_type.md) (return widening).
+
+---
+
+## 3. Pointer-level changes
+
+### The mechanism
+
+Every pointer on a 64-bit target occupies 8 bytes, so `int *` and `int **` look
+**identical** in a symbol's size on the wire. They are not identical in
+*semantics*. One level of indirection is the difference between "the address of
+an int" and "the address of (the address of an int)".
+
+### Minimal scenario
+
+```c
+/* v1 */ void process(int *data)  { buf[0] = *data; }
+/* v2 */ void process(int **data) { buf[0] = **data; }
+```
+
+A v1 caller passes the address of a stack `int`. v2 treats that address as an
+`int *` and dereferences it *again* — reading the 32-bit integer *value* as if
+it were a 64-bit pointer. The result is almost always an unmapped-page fault;
+but on an unlucky memory layout the synthesised "pointer" lands inside a valid
+mapping and the library silently reads or writes the wrong bytes — corruption
+with no crash to trace back to. The same failure occurs on the return path: if
+`get_buffer()` grows from `int *` to `int **`, callers index through a
+pointer-to-pointer as if it were a flat buffer and walk off into arbitrary
+memory.
+
+> !!! note "How abicheck sees it"
+>     `param_type_changed` (pointer-depth delta) → 🔴 **BREAKING**. abicheck
+>     walks the pointer chain *structurally* during diff, so it distinguishes
+>     "both sides return a pointer" from "the indirection level changed."
+>     [case33](../../examples/case33_pointer_level.md).
+
+---
+
+## 4. Global variable changes
+
+Exported globals are the **hardest class to refactor compatibly**, because the
+executable bakes layout facts about the variable into *its own* binary at link
+time.
+
+### The mechanism: COPY relocations
+
+On ELF, a reference to an imported data symbol from a non-PIE executable
+typically generates a **COPY relocation**. The linker allocates space *in the
+executable's own `.bss`* sized to `sizeof(v1_type)`, and at load time the loader
+`memcpy`s the library's initial value into that executable-owned slot.
+Thereafter **both sides** read and write the executable's copy.
+
+```mermaid
+flowchart LR
+    subgraph exe["app (.bss)"]
+      slot["lib_version<br/>(4 bytes, baked at link time)"]
+    end
+    subgraph lib["libfoo.so"]
+      orig["lib_version (initial value)"]
+    end
+    orig -->|"memcpy at load"| slot
+```
+
+Now widen the type:
+
+```c
+/* v1 */ int  lib_version;   // app reserved 4 bytes
+/* v2 */ long lib_version;   // library writes 8 bytes
+```
+
+The executable's 4-byte slot cannot hold the 8-byte value. The loader either
+warns about a size mismatch or silently truncates — the app reads `705032704`
+where the library wrote `5000000000`.
+
+Two more flavors of the same root cause:
+
+- **Removal** ([case58](../../examples/case58_var_removed.md)): the COPY
+  relocation has no target; the process fails to start with
+  `undefined symbol: lib_debug_level`.
+- **Qualifier flip** ([case39](../../examples/case39_var_const.md)): making a
+  mutable global `const` can move it from writable `.bss`/`.data` into the
+  library's `.rodata`. Under COPY relocation the app keeps writing its private
+  copy while the library's updates never propagate (silent divergence); under
+  PIE/GOT access the app's write faults with `SIGSEGV`.
+
+> !!! note "How abicheck sees it"
+>     `global_var_type_changed` / `symbol_removed` → 🔴 **BREAKING**, detected
+>     from the symbol table plus DWARF type info.
+>     [case11](../../examples/case11_global_var_type.md),
+>     [case58](../../examples/case58_var_removed.md),
+>     [case39](../../examples/case39_var_const.md).
+
+---
+
+## How to keep the symbol contract intact
+
+> !!! tip "Design patterns for Part 2"
+>     - **Deprecate, don't delete.** Mark outgoing functions
+>       `__attribute__((deprecated))` for at least one release, ship an alias
+>       (`__attribute__((alias("new_name")))`) spanning old and new names, and
+>       only remove on a SONAME bump.
+>     - **Use versioned symbols.** A linker version script
+>       (`GLIBC_2.17 { global: foo; };`) lets you ship `foo@GLIBC_2.17` alongside
+>       `foo@@GLIBC_2.34`, so pre-existing binaries keep resolving to the old
+>       implementation while new links pick up the new one. (See
+>       [Part 5](05-linker-elf.md).)
+>     - **Prefer accessors over exported globals.** `int get_version(void)` is
+>       immune to COPY-relocation hazards and lets the library change storage,
+>       width, or qualifier without touching consumers.
+>     - **Freeze signatures; add new entry points.** Model the
+>       `ftell` → `ftello` pattern: ship a *new* symbol for the new type rather
+>       than widening the existing one.
+>     - **Hide layout behind opaque handles.** Publish
+>       `typedef struct foo foo_t;` with only `foo_t *` in the public header and
+>       force consumers through functions — the library then owns the struct's
+>       size and layout outright. (Developed fully in
+>       [Part 7](07-designing-for-stability.md).)
+
+---
+
+## Next
+
+Symbols are the *names* that cross the boundary. The *types* those symbols carry
+have an internal byte layout that the compiler bakes into every caller — and
+shifting one offset is a whole second family of silent breaks.
+
+➡️ **[Part 3 — Type Layout Breaks](03-type-layout.md)**
+
+*See also:* [ABI Cheat Sheet](../abi-cheat-sheet.md) ·
+[Verdicts](../verdicts.md) ·
+[BREAKING examples](../../examples/by-verdict/breaking.md)

--- a/docs/concepts/abi-series/02-symbol-contracts.md
+++ b/docs/concepts/abi-series/02-symbol-contracts.md
@@ -81,14 +81,14 @@ Name identity is the *only* key `.dynsym` is indexed by — which is exactly why
 the loader cannot tell a removal from a rename, and why **neither is safe
 without a SONAME bump**.
 
-> !!! note "How abicheck sees it"
->     `func_removed` → 🔴 **BREAKING**, detected straight from the ELF/PE/Mach-O
->     symbol table — no debug info required. (Removed exported *variables* are
->     reported as `var_removed`; see §4.)
->     See [case01](../../examples/case01_symbol_removal.md) (a `helper` that
->     disappears) and [case12](../../examples/case12_function_removed.md)
->     (`fast_add` removed while an unrelated `other_func` is added — proving the
->     loader matches names, not "function count").
+!!! note "How abicheck sees it"
+    `func_removed` → 🔴 **BREAKING**, detected straight from the ELF/PE/Mach-O
+    symbol table — no debug info required. (Removed exported *variables* are
+    reported as `var_removed`; see §4.)
+    See [case01](../../examples/case01_symbol_removal.md) (a `helper` that
+    disappears) and [case12](../../examples/case12_function_removed.md)
+    (`fast_add` removed while an unrelated `other_func` is added — proving the
+    loader matches names, not "function count").
 
 ---
 
@@ -134,12 +134,12 @@ boundary by classification rules that depend on size, alignment, and member
 types — so a single added `int64_t` field can push an entire argument onto the
 stack, shifting every later argument.
 
-> !!! note "How abicheck sees it"
->     `func_params_changed` / `func_return_changed` → 🔴 **BREAKING**, recovered
->     from DWARF (or headers). The exported symbol name is unchanged, so a
->     name-only `nm` diff sees nothing.
->     [case02](../../examples/case02_param_type_change.md) (argument widening),
->     [case10](../../examples/case10_return_type.md) (return widening).
+!!! note "How abicheck sees it"
+    `func_params_changed` / `func_return_changed` → 🔴 **BREAKING**, recovered
+    from DWARF (or headers). The exported symbol name is unchanged, so a
+    name-only `nm` diff sees nothing.
+    [case02](../../examples/case02_param_type_change.md) (argument widening),
+    [case10](../../examples/case10_return_type.md) (return widening).
 
 ---
 
@@ -169,12 +169,12 @@ with no crash to trace back to. The same failure occurs on the return path: if
 pointer-to-pointer as if it were a flat buffer and walk off into arbitrary
 memory.
 
-> !!! note "How abicheck sees it"
->     `param_pointer_level_changed` (and `return_pointer_level_changed` on the
->     return path) → 🔴 **BREAKING**. abicheck walks the pointer chain
->     *structurally* during diff, so it distinguishes "both sides return a
->     pointer" from "the indirection level changed."
->     [case33](../../examples/case33_pointer_level.md).
+!!! note "How abicheck sees it"
+    `param_pointer_level_changed` (and `return_pointer_level_changed` on the
+    return path) → 🔴 **BREAKING**. abicheck walks the pointer chain
+    *structurally* during diff, so it distinguishes "both sides return a
+    pointer" from "the indirection level changed."
+    [case33](../../examples/case33_pointer_level.md).
 
 ---
 
@@ -225,38 +225,38 @@ Two more flavors of the same root cause:
   copy while the library's updates never propagate (silent divergence); under
   PIE/GOT access the app's write faults with `SIGSEGV`.
 
-> !!! note "How abicheck sees it"
->     `var_type_changed` / `var_removed` / `var_became_const` → 🔴 **BREAKING**,
->     detected from the symbol table plus DWARF type info.
->     [case11](../../examples/case11_global_var_type.md),
->     [case58](../../examples/case58_var_removed.md),
->     [case39](../../examples/case39_var_const.md).
+!!! note "How abicheck sees it"
+    `var_type_changed` / `var_removed` / `var_became_const` → 🔴 **BREAKING**,
+    detected from the symbol table plus DWARF type info.
+    [case11](../../examples/case11_global_var_type.md),
+    [case58](../../examples/case58_var_removed.md),
+    [case39](../../examples/case39_var_const.md).
 
 ---
 
 ## How to keep the symbol contract intact
 
-> !!! tip "Design patterns for Part 2"
->     - **Deprecate, don't delete.** Mark outgoing functions
->       `__attribute__((deprecated))` for at least one release, ship an alias
->       (`__attribute__((alias("new_name")))`) spanning old and new names, and
->       only remove on a SONAME bump.
->     - **Use versioned symbols.** A linker version script
->       (`GLIBC_2.17 { global: foo; };`) lets you ship `foo@GLIBC_2.17` alongside
->       `foo@@GLIBC_2.34`, so pre-existing binaries keep resolving to the old
->       implementation while new links pick up the new one. (See
->       [Part 5](05-linker-elf.md).)
->     - **Prefer accessors over exported globals.** `int get_version(void)` is
->       immune to COPY-relocation hazards and lets the library change storage,
->       width, or qualifier without touching consumers.
->     - **Freeze signatures; add new entry points.** Model the
->       `ftell` → `ftello` pattern: ship a *new* symbol for the new type rather
->       than widening the existing one.
->     - **Hide layout behind opaque handles.** Publish
->       `typedef struct foo foo_t;` with only `foo_t *` in the public header and
->       force consumers through functions — the library then owns the struct's
->       size and layout outright. (Developed fully in
->       [Part 7](07-designing-for-stability.md).)
+!!! tip "Design patterns for Part 2"
+    - **Deprecate, don't delete.** Mark outgoing functions
+      `__attribute__((deprecated))` for at least one release, ship an alias
+      (`__attribute__((alias("new_name")))`) spanning old and new names, and
+      only remove on a SONAME bump.
+    - **Use versioned symbols.** A linker version script
+      (`GLIBC_2.17 { global: foo; };`) lets you ship `foo@GLIBC_2.17` alongside
+      `foo@@GLIBC_2.34`, so pre-existing binaries keep resolving to the old
+      implementation while new links pick up the new one. (See
+      [Part 5](05-linker-elf.md).)
+    - **Prefer accessors over exported globals.** `int get_version(void)` is
+      immune to COPY-relocation hazards and lets the library change storage,
+      width, or qualifier without touching consumers.
+    - **Freeze signatures; add new entry points.** Model the
+      `ftell` → `ftello` pattern: ship a *new* symbol for the new type rather
+      than widening the existing one.
+    - **Hide layout behind opaque handles.** Publish
+      `typedef struct foo foo_t;` with only `foo_t *` in the public header and
+      force consumers through functions — the library then owns the struct's
+      size and layout outright. (Developed fully in
+      [Part 7](07-designing-for-stability.md).)
 
 ---
 

--- a/docs/concepts/abi-series/03-type-layout.md
+++ b/docs/concepts/abi-series/03-type-layout.md
@@ -1,0 +1,246 @@
+# Part 3 — Type Layout Breaks
+
+> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> **3. Type Layout** ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- Why a struct published in a header is a *byte-level contract*, and how the
+  compiler turns `offsetof` and `sizeof` into immediate constants the caller
+  never re-checks.
+- The six axes along which layout breaks: **size/offset, alignment, enum
+  values, union size, bitfields/flexible arrays, and pointer/array element
+  types**.
+- The exact rule that makes one union-field addition safe and another breaking.
+- How to design types whose layout you can evolve forever.
+
+Prerequisites: [Part 1 — Foundations](01-foundations.md). The "compiler bakes it
+in" idea from there is the engine behind everything here.
+
+---
+
+## The core mechanism: layout is a frozen constant in the caller
+
+Every aggregate type published in a header is a byte-level contract: its size,
+its members' offsets, its alignment, and — for C++ — its vtable shape. **The
+consumer does not re-read that contract at load time.** The compiler bakes it
+into every caller:
+
+- `offsetof(s, field)` becomes an *immediate displacement* in a `mov`
+  instruction.
+- `sizeof(T)` becomes an *allocation constant* (`malloc(12)`, a stack frame
+  size, an array element stride).
+- array indexing multiplies the index by a *stride chosen at compile time*.
+
+```text
+struct Point { int x; int y; };     // v1: sizeof = 8
+
+  caller code, compiled against v1:
+      mov  dword [rbp-8], 0     ; p.x  -> offset 0
+      mov  dword [rbp-4], 0     ; p.y  -> offset 4   ← "4" is now a constant in the binary
+      sub  rsp, 8               ; reserve sizeof(Point) = 8  ← "8" is now a constant too
+```
+
+When the library's next release shifts even one offset, every call site compiled
+against the old layout reads or writes at the wrong address — **silently,
+without a linker error, usually without a crash** until adjacent memory is
+eventually read back.
+
+---
+
+## 1. Struct / class size and offsets
+
+The most common layout break is appending, inserting, or reordering a field.
+
+```c
+/* v1 */ struct Point { int x; int y; };          // sizeof = 8
+/* v2 */ struct Point { int x; int y; int z; };   // sizeof = 12
+```
+
+Every caller that allocates `Point` on the stack or inside another struct now
+*under-allocates*; every caller passing `Point` by value sends 8 bytes while the
+library reads 12. The C++ analog ([case14](../../examples/case14_cpp_class_size.md))
+grows a `char data[64]` buffer to `char data[128]`: `new Buffer()` hands the
+constructor a 64-byte allocation that it zero-fills with 128 bytes, smashing
+whatever lives next on the heap.
+
+Layout breaks are also **transitive through embedding and inheritance**. Adding
+`int extra_field` to `class Base` ([case43](../../examples/case43_base_class_member_added.md))
+shifts `Derived::value` from offset 12 to 16 — *every* subclass member in the
+ecosystem silently moves.
+
+> !!! note "How abicheck sees it"
+>     `type_size_changed` / data-member offset deltas → 🔴 **BREAKING**, from
+>     DWARF or headers. [case07](../../examples/case07_struct_layout.md),
+>     [case14](../../examples/case14_cpp_class_size.md),
+>     [case40](../../examples/case40_field_layout.md) (five field-level
+>     mutations in one struct to show how "just one field" cascades).
+
+---
+
+## 2. Alignment and packing
+
+Alignment is the second axis — fields and sizes can be identical while the
+*alignment requirement* changes.
+
+```c
+/* v1 */ struct __attribute__((aligned(8)))  CacheBlock { /* ... */ };
+/* v2 */ struct __attribute__((aligned(64))) CacheBlock { /* ... */ };
+```
+
+v1 callers allocate `CacheBlock` on 8-byte boundaries. v2 code may emit
+aligned-load instructions (`vmovdqa`) and **fault on misaligned access** —
+`SIGSEGV` on x86-64 Linux, `SIGBUS` on strict-alignment platforms — and
+`malloc` (typically 16-byte aligned) can no longer hand out correctly-aligned
+storage without `aligned_alloc`.
+
+Packing is the inverse:
+[case56](../../examples/case56_struct_packing_changed.md) adds `#pragma pack(1)`,
+eliminating all padding. `sizeof` *shrinks*, every field after the first moves,
+and on ARM/SPARC the now-unaligned `int` access traps. Because `alignas` and
+`#pragma pack` propagate across translation-unit boundaries through the header, a
+**single-line change rewrites offsets for every TU that includes it.**
+
+> !!! note "How abicheck sees it"
+>     `type_alignment_changed` / `struct_packing_changed` → 🔴 **BREAKING**.
+>     [case42](../../examples/case42_type_alignment_changed.md),
+>     [case56](../../examples/case56_struct_packing_changed.md).
+
+---
+
+## 3. Enum value stability
+
+Enumerations *look* like constants, but they are part of the **wire format** —
+the integer values get persisted to disk, sent over the network, and switched
+on.
+
+```c
+/* v1 */ enum Color { RED=0, GREEN=1, BLUE=2 };
+/* v2 */ enum Color { RED=0, YELLOW=1, GREEN=2, BLUE=3 };   // inserted YELLOW
+```
+
+Inserting `YELLOW` in the middle shifts `GREEN` and `BLUE` by one. Every binary
+that tested `== 1` for green now hits the yellow branch.
+
+Three breaking variants and one safe one:
+
+| Change | Effect | Verdict |
+|--------|--------|---------|
+| Insert member in the middle ([case08](../../examples/case08_enum_value_change.md)) | shifts later values | 🔴 BREAKING |
+| Reassign a value, same name, e.g. `ERROR=1`→`ERROR=99` ([case20](../../examples/case20_enum_member_value_changed.md)) | protocol rewrite with no negotiation | 🔴 BREAKING |
+| Remove a member ([case19](../../examples/case19_enum_member_removed.md)) | persisted/transmitted value becomes undefined | 🔴 BREAKING |
+| **Append at the end** ([case25](../../examples/case25_enum_member_added.md)) | existing values unchanged | 🟢 **COMPATIBLE** |
+
+A subtler trap: [case57](../../examples/case57_enum_underlying_size_changed.md)
+adds a sentinel `= 0x100000000LL` that forces the compiler to **widen the
+underlying type** from `int` to `long`. `sizeof(Color)` jumps from 4 to 8, and
+every struct embedding `Color` silently grows and relocates its later fields.
+
+---
+
+## 4. Union layout
+
+Unions share offset 0 across all members, so adding a variant doesn't move
+existing fields — **but the union's size equals its largest member, and that
+size propagates.**
+
+```c
+/* breaking */  union Value { int i; float f; };            // sizeof 4
+                union Value { int i; float f; double d; };   // sizeof 8  ← grows
+```
+
+The rule is precise:
+
+> A new union member is **safe if and only if**
+> `sizeof(new) <= sizeof(old_union)` **and** `alignof(new) <= alignof(old_union)`.
+
+That's why [case26](../../examples/case26_union_field_added.md) (adds `double`,
+grows 4→8) is 🔴 BREAKING, while
+[case26b](../../examples/case26b_union_field_added_compatible.md) (adds `int` to a
+union already 8 bytes wide) is 🟢 COMPATIBLE. Removing a variant
+([case24](../../examples/case24_union_field_removed.md)) is a *semantic* break
+even at unchanged size: consumers compiled to write `d.f = 3.14f` have no
+replacement access path.
+
+---
+
+## 5. Bitfields and flexible arrays
+
+**Bitfields** are the most fragile layout primitive, because storage-unit
+allocation is implementation-defined.
+[case63](../../examples/case63_bitfield_changed.md) widens `mode` from 3 bits to
+5 inside a 32-bit register map. `sizeof` is *unchanged* — naive size checks pass
+— but `channel`, `priority`, and `reserved` all shift two bit positions, so
+every consumer reads corrupt values with no crash and no diagnostic. This bites
+hardest in hardware-register maps and protocol headers, exactly where bitfields
+are most used.
+
+**Flexible array members** have the opposite static-size profile, same failure:
+[case70](../../examples/case70_flexible_array_member_changed.md) changes
+`float data[]` to `double data[]`. The fixed header `sizeof(Packet)` compares
+*equal*, but every caller that allocated
+`sizeof(Packet) + count*sizeof(float)` now holds half the needed memory, and
+`p->data[i]` indexes with stride 8 instead of 4.
+
+---
+
+## 6. Pointer chains and arrays
+
+Multi-level type changes propagate through indirection.
+[case45](../../examples/case45_multi_dim_array_change.md) changes
+`float data[4][4]` to `double data[4][4]` inside a struct: the element type
+changes, the struct doubles from 72 to 136 bytes, the stride doubles, and the
+accessor functions change return/parameter widths.
+[case46](../../examples/case46_pointer_chain_type_change.md) reaches further — a
+function returning `int **` becomes `long **`, a two-level chain where only the
+ultimate pointee changes; callers that write an `int` through the chain write 4
+bytes into what v2 treats as an 8-byte cell.
+
+> !!! note "How abicheck sees it"
+>     abicheck walks pointer and array types *structurally* during
+>     `func_return_changed` and `param_type_changed` detection — a surface-level
+>     "both sides return a pointer" comparison would miss these.
+
+---
+
+## How to defend type layout
+
+> !!! tip "Design patterns for Part 3"
+>     - **Opaque handles.** Expose only `struct foo *`; define the struct in a
+>       `.c` file. Callers can't take `sizeof` or `offsetof`, so layout is free
+>       to change. OpenSSL 1.1.0's move to `EVP_MD_CTX_new`/`_free` opaque
+>       handles is the canonical precedent.
+>     - **Pimpl (C++).** The public class holds one `d_ptr` to a private `Impl`;
+>       all state lives in `Impl`, so `sizeof` of the public class never
+>       changes. Qt enforces this across every public class.
+>     - **Reserved padding.** End every public struct with `void *reserved[N]` /
+>       `uint64_t _pad[N]`; future releases repurpose slots without changing
+>       `sizeof` or shifting offsets (POSIX `pthread_attr_t`, kernel UAPI).
+>     - **Freeze the enum underlying type.** Write `enum class Color : int32_t`
+>       in C++; in C keep values in `int` range or add an explicit sentinel.
+>       Never let a new enumerator silently widen the type.
+>     - **Append-only evolution.** Reordering, inserting, or removing a field is
+>       always breaking. Append only at the end, and only when no embedded
+>       `sizeof(T)` assumption exists (union analog: case26 vs case26b).
+>
+>     These patterns are developed in full, with code, in
+>     [Part 7 — Designing for Stability](07-designing-for-stability.md).
+
+---
+
+## Next
+
+C++ adds a whole second layer of binary contract on top of plain layout:
+vtables, mangled qualifiers, templates, and the trivially-copyable trait that
+silently flips the calling convention.
+
+➡️ **[Part 4 — C++ ABI Specifics](04-cpp-abi.md)**
+
+*See also:* [ABI Cheat Sheet](../abi-cheat-sheet.md) ·
+[BREAKING examples](../../examples/by-verdict/breaking.md) ·
+[COMPATIBLE examples](../../examples/by-verdict/compatible.md)

--- a/docs/concepts/abi-series/03-type-layout.md
+++ b/docs/concepts/abi-series/03-type-layout.md
@@ -203,7 +203,7 @@ bytes into what v2 treats as an 8-byte cell.
 
 > !!! note "How abicheck sees it"
 >     abicheck walks pointer and array types *structurally* during
->     `func_return_changed` and `param_type_changed` detection — a surface-level
+>     `func_return_changed` and `func_params_changed` detection — a surface-level
 >     "both sides return a pointer" comparison would miss these.
 
 ---

--- a/docs/concepts/abi-series/03-type-layout.md
+++ b/docs/concepts/abi-series/03-type-layout.md
@@ -74,12 +74,12 @@ Layout breaks are also **transitive through embedding and inheritance**. Adding
 shifts `Derived::value` from offset 12 to 16 — *every* subclass member in the
 ecosystem silently moves.
 
-> !!! note "How abicheck sees it"
->     `type_size_changed` / data-member offset deltas → 🔴 **BREAKING**, from
->     DWARF or headers. [case07](../../examples/case07_struct_layout.md),
->     [case14](../../examples/case14_cpp_class_size.md),
->     [case40](../../examples/case40_field_layout.md) (five field-level
->     mutations in one struct to show how "just one field" cascades).
+!!! note "How abicheck sees it"
+    `type_size_changed` / data-member offset deltas → 🔴 **BREAKING**, from
+    DWARF or headers. [case07](../../examples/case07_struct_layout.md),
+    [case14](../../examples/case14_cpp_class_size.md),
+    [case40](../../examples/case40_field_layout.md) (five field-level
+    mutations in one struct to show how "just one field" cascades).
 
 ---
 
@@ -106,10 +106,10 @@ and on ARM/SPARC the now-unaligned `int` access traps. Because `alignas` and
 `#pragma pack` propagate across translation-unit boundaries through the header, a
 **single-line change rewrites offsets for every TU that includes it.**
 
-> !!! note "How abicheck sees it"
->     `type_alignment_changed` / `struct_packing_changed` → 🔴 **BREAKING**.
->     [case42](../../examples/case42_type_alignment_changed.md),
->     [case56](../../examples/case56_struct_packing_changed.md).
+!!! note "How abicheck sees it"
+    `type_alignment_changed` / `struct_packing_changed` → 🔴 **BREAKING**.
+    [case42](../../examples/case42_type_alignment_changed.md),
+    [case56](../../examples/case56_struct_packing_changed.md).
 
 ---
 
@@ -201,35 +201,35 @@ function returning `int **` becomes `long **`, a two-level chain where only the
 ultimate pointee changes; callers that write an `int` through the chain write 4
 bytes into what v2 treats as an 8-byte cell.
 
-> !!! note "How abicheck sees it"
->     abicheck walks pointer and array types *structurally* during
->     `func_return_changed` and `func_params_changed` detection — a surface-level
->     "both sides return a pointer" comparison would miss these.
+!!! note "How abicheck sees it"
+    abicheck walks pointer and array types *structurally* during
+    `func_return_changed` and `func_params_changed` detection — a surface-level
+    "both sides return a pointer" comparison would miss these.
 
 ---
 
 ## How to defend type layout
 
-> !!! tip "Design patterns for Part 3"
->     - **Opaque handles.** Expose only `struct foo *`; define the struct in a
->       `.c` file. Callers can't take `sizeof` or `offsetof`, so layout is free
->       to change. OpenSSL 1.1.0's move to `EVP_MD_CTX_new`/`_free` opaque
->       handles is the canonical precedent.
->     - **Pimpl (C++).** The public class holds one `d_ptr` to a private `Impl`;
->       all state lives in `Impl`, so `sizeof` of the public class never
->       changes. Qt enforces this across every public class.
->     - **Reserved padding.** End every public struct with `void *reserved[N]` /
->       `uint64_t _pad[N]`; future releases repurpose slots without changing
->       `sizeof` or shifting offsets (POSIX `pthread_attr_t`, kernel UAPI).
->     - **Freeze the enum underlying type.** Write `enum class Color : int32_t`
->       in C++; in C keep values in `int` range or add an explicit sentinel.
->       Never let a new enumerator silently widen the type.
->     - **Append-only evolution.** Reordering, inserting, or removing a field is
->       always breaking. Append only at the end, and only when no embedded
->       `sizeof(T)` assumption exists (union analog: case26 vs case26b).
->
->     These patterns are developed in full, with code, in
->     [Part 7 — Designing for Stability](07-designing-for-stability.md).
+!!! tip "Design patterns for Part 3"
+    - **Opaque handles.** Expose only `struct foo *`; define the struct in a
+      `.c` file. Callers can't take `sizeof` or `offsetof`, so layout is free
+      to change. OpenSSL 1.1.0's move to `EVP_MD_CTX_new`/`_free` opaque
+      handles is the canonical precedent.
+    - **Pimpl (C++).** The public class holds one `d_ptr` to a private `Impl`;
+      all state lives in `Impl`, so `sizeof` of the public class never
+      changes. Qt enforces this across every public class.
+    - **Reserved padding.** End every public struct with `void *reserved[N]` /
+      `uint64_t _pad[N]`; future releases repurpose slots without changing
+      `sizeof` or shifting offsets (POSIX `pthread_attr_t`, kernel UAPI).
+    - **Freeze the enum underlying type.** Write `enum class Color : int32_t`
+      in C++; in C keep values in `int` range or add an explicit sentinel.
+      Never let a new enumerator silently widen the type.
+    - **Append-only evolution.** Reordering, inserting, or removing a field is
+      always breaking. Append only at the end, and only when no embedded
+      `sizeof(T)` assumption exists (union analog: case26 vs case26b).
+
+    These patterns are developed in full, with code, in
+    [Part 7 — Designing for Stability](07-designing-for-stability.md).
 
 ---
 

--- a/docs/concepts/abi-series/04-cpp-abi.md
+++ b/docs/concepts/abi-series/04-cpp-abi.md
@@ -197,19 +197,32 @@ saw `noexcept`, so it omitted exception landing pads, cleanup frames, and
 into a frame with no unwinding metadata and `std::terminate()` fires
 unconditionally — every destructor skipped, every `catch` bypassed.
 
-The `_WITH_RISK` tier exists for exactly this shape: binary-linkable,
-source-recompilable, but **semantically unsafe** for binaries built under the
-stricter old contract.
+This is the deployment-risk shape: binary-linkable, source-recompilable, but
+**semantically unsafe** for binaries built under the stricter old contract — the
+kind of change that merits review rather than a silent pass.
+
+!!! note "How abicheck sees it"
+    abicheck classifies the bare change kinds `func_noexcept_removed` /
+    `func_noexcept_added` as 🟢 **COMPATIBLE** — on an ordinary member or free
+    function they alter neither layout nor the mangled symbol. case15 reaches
+    🟡 **COMPATIBLE_WITH_RISK** because *introducing `throw`* also raises a
+    libstdc++ version requirement, reported separately as
+    `symbol_version_required_added` (a RISK-tier deployment signal). So the risk
+    verdict is driven by that version-requirement finding, **not** by the
+    `noexcept` kind itself: a pure toggle with no new version requirement
+    classifies COMPATIBLE. The unwinding hazard described above is the *reason*
+    the deployment signal is worth heeding — not something abicheck infers from
+    the `noexcept` change alone.
 
 !!! note "The C++17 subtlety"
     C++17 made `noexcept` part of the function *type*, but under Itanium that
     only changes mangling where the *full function-type* is encoded — function
     pointers, references to functions, and templates parameterized by function
     type — **not** the `<bare-function-type>` used for ordinary member/free
-    symbols. So toggling `noexcept` on a plain declaration stays `_WITH_RISK`
-    for those direct symbols, but the **same change escalates to 🔴 BREAKING**
-    for callers that pass the function through a pointer or template where the
-    `E` tag now participates in the mangled name.
+    symbols. So toggling `noexcept` on a plain declaration leaves the direct
+    symbol unchanged (abicheck: 🟢 COMPATIBLE), but the **same change escalates
+    to 🔴 BREAKING** for callers that pass the function through a pointer or
+    template where the `E` tag now participates in the mangled name.
 
 ---
 

--- a/docs/concepts/abi-series/04-cpp-abi.md
+++ b/docs/concepts/abi-series/04-cpp-abi.md
@@ -129,9 +129,18 @@ The transition direction matters:
 
 | Transition | Result | Verdict |
 |------------|--------|---------|
-| inline-in-header → outlined-in-`.so` ([case47](../../examples/case47_inline_to_outlined.md)) | old binaries keep inlined copy; new export appears | 🟢 COMPATIBLE |
-| outlined → inline ([case59](../../examples/case59_func_became_inline.md)) | symbol *vanishes* from `.dynsym` | 🔴 BREAKING |
-| header says outlined but `.so` doesn't provide it ([case16](../../examples/case16_inline_to_non_inline.md)) | hard load-time failure | 🔴 BREAKING |
+| inline-in-header → outlined-in-`.so` ([case47](../../examples/case47_inline_to_outlined.md), [case16](../../examples/case16_inline_to_non_inline.md)) | old binaries keep their inlined copy; a new export simply *appears* | 🟢 COMPATIBLE (addition) |
+| outlined-in-`.so` → inline-in-header ([case59](../../examples/case59_func_became_inline.md)) | the exported symbol *vanishes* from `.dynsym` | 🔴 BREAKING |
+
+The compatible direction has a **build-order caveat** worth knowing
+([case16](../../examples/case16_inline_to_non_inline.md)): comparing old→new
+`.so` it is purely an added symbol, so the verdict is 🟢 COMPATIBLE — but a
+caller freshly compiled against the *new* header (which now expects an imported
+symbol) and then linked against the *old* `.so` (which never exported it) fails
+at link time. That is a downgrade/mismatched-build hazard, not a regression in
+the new release, and it dissolves once the symbol exists. If you *also* change
+the function's body in the same move, stale callers running their old inlined
+copy can disagree with the new export — an ODR hazard LTO sometimes catches.
 
 Template instantiations, inline functions, and `constexpr` bodies are part of
 the ABI **even though they never appear in `readelf -Ws`.**

--- a/docs/concepts/abi-series/04-cpp-abi.md
+++ b/docs/concepts/abi-series/04-cpp-abi.md
@@ -1,0 +1,303 @@
+# Part 4 — C++ ABI Specifics
+
+> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> [3. Type Layout](03-type-layout.md) ·
+> **4. C++ ABI** ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- Why C++ is the language where ABI stability is hardest, and what the *Itanium
+  C++ ABI* freezes as part of your contract.
+- The seven C++ mechanisms most likely to corrupt a consumer binary: **vtables,
+  method qualifiers, templates/inline, inline namespaces, `noexcept`,
+  trivial→non-trivial, and base-class layout**.
+- Why some of these (like `noexcept`) are *risk*, not hard *breaks* — and the
+  precise reason.
+- The four C++ design patterns that give you room to evolve.
+
+Prerequisites: [Part 2 — Symbol Contracts](02-symbol-contracts.md) (mangling,
+name-only resolution) and [Part 3 — Type Layout](03-type-layout.md) (offsets,
+`sizeof`).
+
+---
+
+## Why C++ is the hard case
+
+Every class with a virtual method carries a hidden pointer to a
+statically-ordered table of function pointers. Every method name is mangled
+through a grammar that encodes qualifiers, namespaces, template arguments, and
+parameter types. Every struct with a user-defined destructor changes how it is
+*passed* between functions.
+
+The **Itanium C++ ABI** — used by GCC and Clang on Linux, macOS, the BSDs, and
+most embedded targets — is rigid *by design*: it guarantees cross-compiler
+interoperability at the cost of making almost any visible change to a class a
+potential binary break. MSVC on Windows uses a different but equally rigid ABI
+with the same categories of pitfall. The seven sections below tour the
+mechanisms most likely to bite.
+
+---
+
+## 1. Vtables and virtual methods
+
+A polymorphic class carries a hidden `vptr` as its first word, pointing to a
+per-class **vtable** — a static array of function pointers indexed by the order
+virtual methods are *declared*. The Itanium ABI fixes this slot ordering as a
+public part of the class contract. A call compiles to a slot index baked into
+the call site:
+
+```text
+widget->resize();      // compiles to:  (*widget->vptr[1])(widget)
+                       //                               ^ slot 1 is a constant
+```
+
+Insert a new virtual method *before* an existing one and every later slot
+silently shifts:
+
+```cpp
+/* v1 */ struct Widget { virtual void resize(); };            // resize = slot 0
+/* v2 */ struct Widget { virtual void recolor();              // recolor = slot 0
+                         virtual void resize(); };            // resize  = slot 1
+```
+
+Now every old call to `resize()` (still using slot 0) dispatches to `recolor()`
+— wrong method, no crash.
+
+| Variant | Effect |
+|---------|--------|
+| Insert virtual before existing ([case09](../../examples/case09_cpp_vtable.md)) | reroutes calls to the wrong slot |
+| Make a method pure-virtual ([case23](../../examples/case23_pure_virtual_added.md)) | slot becomes `__cxa_pure_virtual` → unconditional `abort()` |
+| Add the **first** virtual to a non-polymorphic class ([case68](../../examples/case68_virtual_method_added.md)) | a vptr is *prepended*; every member shifts by `sizeof(void*)`, `sizeof` grows |
+
+The only safe addition is to **append** new virtual methods after every existing
+slot — and only when no consumer-side derived classes exist that would
+themselves extend the vtable.
+
+---
+
+## 2. Method qualifiers
+
+Qualifiers are **load-bearing parts of the mangled name**, not cosmetic
+annotations. A `const` member function mangles with a `K` marker, `volatile`
+with `V`, ref-qualifiers (`&`/`&&`) with `R`/`O`. Edit one and you rename the
+symbol.
+
+```cpp
+/* v1 */ int Widget::get() const;   // _ZNK6Widget3getEv   (note the K)
+/* v2 */ int Widget::get();         // _ZN6Widget3getEv    (K is gone)
+```
+
+The old symbol vanishes from `.dynsym`; every consumer hits `symbol lookup
+error` at load ([case22](../../examples/case22_method_const_changed.md)). This is
+one of the *easier* C++ breaks to diagnose, because it's a clean `dlopen` abort
+rather than silent corruption.
+
+The dangerous sibling is converting an instance method to `static`
+([case21](../../examples/case21_method_became_static.md)): the mangled name is
+often *identical* (`_ZN6Widget3barEv` for both), so the linker is happy — but the
+v1 caller passes an implicit `this` in `%rdi` that the static callee never reads,
+and the function computes from register garbage. Treat **every qualifier edit on
+a public declaration as renaming the symbol.**
+
+---
+
+## 3. Templates and inline
+
+Inline and template code lives where the One Definition Rule meets the link
+model — and that's where ABI assumptions get baked into the *consumer's* binary
+without the library ever seeing them.
+
+An explicitly instantiated `Buffer<int>` produces a mangled symbol like
+`_ZN6BufferIiEC1Em`. Adding a `capacity_` field
+([case17](../../examples/case17_template_abi.md)) keeps the symbol name
+*identical* while growing `sizeof(Buffer<int>)` from 16 to 24. The consumer
+stack-allocates 16; the v2 constructor writes 24 — a stack smash with no
+header-level signal.
+
+**Header-only inline definitions embed the *body* into each consumer TU**, so
+the implementation callers run is frozen when they compile. Changing an inline
+body between releases produces ODR violations (LTO sometimes catches these) and
+silent disagreements between two consumers who pulled in different header
+versions.
+
+The transition direction matters:
+
+| Transition | Result | Verdict |
+|------------|--------|---------|
+| inline-in-header → outlined-in-`.so` ([case47](../../examples/case47_inline_to_outlined.md)) | old binaries keep inlined copy; new export appears | 🟢 COMPATIBLE |
+| outlined → inline ([case59](../../examples/case59_func_became_inline.md)) | symbol *vanishes* from `.dynsym` | 🔴 BREAKING |
+| header says outlined but `.so` doesn't provide it ([case16](../../examples/case16_inline_to_non_inline.md)) | hard load-time failure | 🔴 BREAKING |
+
+Template instantiations, inline functions, and `constexpr` bodies are part of
+the ABI **even though they never appear in `readelf -Ws`.**
+
+---
+
+## 4. Covariant returns and inline namespaces
+
+An **inline namespace** is transparent to source-level name lookup but is
+mangled into every symbol declared inside it — making it the canonical Itanium
+mechanism for *generational ABI versioning*.
+
+```cpp
+namespace crypto { inline namespace v1 { void encrypt(/*...*/); } }
+// source writes crypto::encrypt(...) ; symbol = _ZN6crypto2v17encryptE...
+
+namespace crypto { inline namespace v2 { void encrypt(/*...*/); } }
+// same source compiles ; symbol = _ZN6crypto2v27encryptE...   ← different symbol
+```
+
+Source compiles unchanged against both, but pre-compiled callers can't resolve
+the new symbol ([case71](../../examples/case71_inline_namespace_moved.md)). This
+is exactly the device libstdc++ used for its **dual ABI**: GCC 5 introduced
+`std::__cxx11::basic_string` alongside the legacy COW `std::string`, gated on
+`_GLIBCXX_USE_CXX11_ABI`. Distributions spent *years* untangling the resulting
+lookup failures.
+
+**Covariant returns** interact with vtable layout directly: a `Circle::clone()`
+returning `Circle*` generates a `this`-adjusting thunk; inserting a new
+intermediate base class
+([case72](../../examples/case72_covariant_return_changed.md)) shifts sub-object
+offsets and invalidates hardcoded vtable slots.
+
+The lesson: inline namespaces are a **power tool** — wielded deliberately they
+let you ship a breaking change under a new mangled surface while keeping the old
+one exported; switched accidentally they rename every symbol you export.
+
+---
+
+## 5. `noexcept` — why this is *risk*, not a hard break
+
+[case15](../../examples/case15_noexcept_change.md) is classified
+🟡 **COMPATIBLE_WITH_RISK**, not BREAKING, and the reasoning is worth
+internalizing.
+
+Before C++17, `noexcept` was **not part of the function type**, so the Itanium
+mangler ignored it: `void reset() noexcept` and `void reset()` both mangle to
+`_ZN6Buffer5resetEv` and resolve to the *same* `.dynsym` entry. Removing
+`noexcept` therefore **does not break linkage** — hence not BREAKING.
+
+What it *does* break is the caller's **unwinding assumption**. The v1 compiler
+saw `noexcept`, so it omitted exception landing pads, cleanup frames, and
+`.eh_frame` entries at the call site. If v2 now throws, the exception propagates
+into a frame with no unwinding metadata and `std::terminate()` fires
+unconditionally — every destructor skipped, every `catch` bypassed.
+
+The `_WITH_RISK` tier exists for exactly this shape: binary-linkable,
+source-recompilable, but **semantically unsafe** for binaries built under the
+stricter old contract.
+
+> !!! note "The C++17 subtlety"
+>     C++17 made `noexcept` part of the function *type*, but under Itanium that
+>     only changes mangling where the *full function-type* is encoded — function
+>     pointers, references to functions, and templates parameterized by function
+>     type — **not** the `<bare-function-type>` used for ordinary member/free
+>     symbols. So toggling `noexcept` on a plain declaration stays `_WITH_RISK`
+>     for those direct symbols, but the **same change escalates to 🔴 BREAKING**
+>     for callers that pass the function through a pointer or template where the
+>     `E` tag now participates in the mangled name.
+
+---
+
+## 6. Trivial → non-trivial: the invisible calling-convention flip
+
+The System V AMD64 convention passes **trivially-copyable** aggregates directly
+in registers, but passes **non-trivially-copyable** ones *by invisible
+reference* — the caller materializes the object on the stack and hands the callee
+a pointer. Whether a class is trivially copyable is decided by whether it has
+*user-provided* copy/move/destructor special members. **A single line flips the
+register/memory decision.**
+
+```cpp
+/* v1 */ struct Point { double x, y; };                 // trivially copyable
+/* v2 */ struct Point { double x, y; ~Point() {} };     // user-provided dtor → non-trivial
+```
+
+Layout unchanged, `sizeof` unchanged, mangled symbol unchanged, loader perfectly
+happy. But the v1 caller passes `x, y` in `%xmm0, %xmm1` while the v2 callee
+reads `%rdi, %rsi` as *pointers* and dereferences them — segfault or silent
+garbage, with no toolchain diagnostic
+([case69](../../examples/case69_trivial_to_nontrivial.md)).
+
+> !!! note "How abicheck sees it"
+>     No header-diff tool that looks only at declarations catches this. abicheck
+>     reports `value_abi_trait_changed` by inspecting the DWARF
+>     trivially-copyable flag.
+>
+>     **Design rule:** pin the trivially-copyable status of any by-value type
+>     from version 1. If cleanup might ever be needed, commit *from day one* to
+>     a user-provided destructor — an empty body `~T() {}` or an out-of-line
+>     `T::~T() = default;` in the `.cpp`. An in-class `~T() = default;` on the
+>     first declaration is user-*declared* but not user-*provided*, so it does
+>     **not** pin the convention.
+
+---
+
+## 7. Base-class position and layout
+
+Multiple inheritance places each base sub-object at a specific offset, and those
+offsets are compiled into every upcast and virtual call.
+
+```cpp
+/* v1 */ struct Widget : Drawable, Clickable { /*...*/ };
+/* v2 */ struct Widget : Clickable, Drawable { /*...*/ };   // bases reordered
+```
+
+The type name and every method signature are identical, yet
+`static_cast<Drawable*>(widget)` now points into the `Clickable` sub-object,
+because the compiler applied v1's offset to v2's layout
+([case60](../../examples/case60_base_class_position_changed.md)).
+
+[case37](../../examples/case37_base_class.md) generalizes this with three
+independent hazards: **reordering** bases changes `this`-adjustments and which
+vptr sits at offset 0; converting non-virtual to **`virtual` inheritance**
+restructures the whole object (the virtual base moves to the end and a
+vbase-offset table is inserted); **appending** a base grows `sizeof` and shifts
+every member.
+
+> !!! note "How abicheck sees it"
+>     Reported as `base_class_position_changed` / `type_base_changed` when DWARF
+>     or headers are available — ELF symbol tables alone cannot see them, which
+>     is why C++ ABI checking *requires* debug info or headers.
+
+---
+
+## How to design C++ libraries for ABI stability
+
+> !!! tip "Design patterns for Part 4"
+>     - **Pure-virtual interface + factory.** Expose an abstract class (no data
+>       members, no inline methods) and a C-linkage `create_foo()`. Consumers
+>       hold only the abstract pointer, so you can evolve the implementation
+>       class without touching any consumer vtable.
+>     - **Non-Virtual Interface (NVI).** Public methods are *non-virtual*
+>       wrappers over a small, stable set of `virtual` hooks. You can add public
+>       methods (non-virtual additions are ABI-safe) without growing the vtable.
+>     - **Pimpl ABI firewall.** Every data member lives in an `Impl` defined in
+>       the `.cpp`; the public class holds one `std::unique_ptr<Impl>`.
+>       `sizeof(Widget)` never changes; offsets are invisible.
+>     - **Inline namespaces for generational ABI.** Wrap public declarations in
+>       `inline namespace abi_v1`. For a breaking change, ship `abi_v2` alongside
+>       and keep the old symbols exported — consumers migrate on their schedule,
+>       mirroring libstdc++ `__cxx11`.
+>     - **`-fvisibility=hidden` + export macros.** Shrink the exported surface to
+>       exactly what you intend to stabilize (see [Part 5](05-linker-elf.md)).
+>
+>     Full code for each is in
+>     [Part 7 — Designing for Stability](07-designing-for-stability.md).
+
+---
+
+## Next
+
+Underneath the language-level ABI sits a second contract enforced purely by the
+dynamic linker: SONAME identity, symbol visibility, version nodes, calling
+conventions, and TLS models — all recorded in the `.so` itself.
+
+➡️ **[Part 5 — ELF & Linker-Level Concerns](05-linker-elf.md)**
+
+*See also:* [ABI Cheat Sheet](../abi-cheat-sheet.md) ·
+[Risk examples](../../examples/by-verdict/compatible-risk.md)

--- a/docs/concepts/abi-series/04-cpp-abi.md
+++ b/docs/concepts/abi-series/04-cpp-abi.md
@@ -72,6 +72,7 @@ Now every old call to `resize()` (still using slot 0) dispatches to `recolor()`
 | Insert virtual before existing ([case09](../../examples/case09_cpp_vtable.md)) | reroutes calls to the wrong slot |
 | Make a method pure-virtual ([case23](../../examples/case23_pure_virtual_added.md)) | slot becomes `__cxa_pure_virtual` → unconditional `abort()` |
 | Add the **first** virtual to a non-polymorphic class ([case68](../../examples/case68_virtual_method_added.md)) | a vptr is *prepended*; every member shifts by `sizeof(void*)`, `sizeof` grows |
+| **Remove** a virtual method (`func_virtual_removed`) | every later slot shifts up by one, so every old call dispatches one slot off — the same reroute as insertion, in reverse |
 
 The only safe addition is to **append** new virtual methods after every existing
 slot — and only when no consumer-side derived classes exist that would
@@ -191,15 +192,15 @@ The `_WITH_RISK` tier exists for exactly this shape: binary-linkable,
 source-recompilable, but **semantically unsafe** for binaries built under the
 stricter old contract.
 
-> !!! note "The C++17 subtlety"
->     C++17 made `noexcept` part of the function *type*, but under Itanium that
->     only changes mangling where the *full function-type* is encoded — function
->     pointers, references to functions, and templates parameterized by function
->     type — **not** the `<bare-function-type>` used for ordinary member/free
->     symbols. So toggling `noexcept` on a plain declaration stays `_WITH_RISK`
->     for those direct symbols, but the **same change escalates to 🔴 BREAKING**
->     for callers that pass the function through a pointer or template where the
->     `E` tag now participates in the mangled name.
+!!! note "The C++17 subtlety"
+    C++17 made `noexcept` part of the function *type*, but under Itanium that
+    only changes mangling where the *full function-type* is encoded — function
+    pointers, references to functions, and templates parameterized by function
+    type — **not** the `<bare-function-type>` used for ordinary member/free
+    symbols. So toggling `noexcept` on a plain declaration stays `_WITH_RISK`
+    for those direct symbols, but the **same change escalates to 🔴 BREAKING**
+    for callers that pass the function through a pointer or template where the
+    `E` tag now participates in the mangled name.
 
 ---
 
@@ -223,17 +224,17 @@ reads `%rdi, %rsi` as *pointers* and dereferences them — segfault or silent
 garbage, with no toolchain diagnostic
 ([case69](../../examples/case69_trivial_to_nontrivial.md)).
 
-> !!! note "How abicheck sees it"
->     No header-diff tool that looks only at declarations catches this. abicheck
->     reports `value_abi_trait_changed` by inspecting the DWARF
->     trivially-copyable flag.
->
->     **Design rule:** pin the trivially-copyable status of any by-value type
->     from version 1. If cleanup might ever be needed, commit *from day one* to
->     a user-provided destructor — an empty body `~T() {}` or an out-of-line
->     `T::~T() = default;` in the `.cpp`. An in-class `~T() = default;` on the
->     first declaration is user-*declared* but not user-*provided*, so it does
->     **not** pin the convention.
+!!! note "How abicheck sees it"
+    No header-diff tool that looks only at declarations catches this. abicheck
+    reports `value_abi_trait_changed` by inspecting the DWARF
+    trivially-copyable flag.
+
+    **Design rule:** pin the trivially-copyable status of any by-value type
+    from version 1. If cleanup might ever be needed, commit *from day one* to
+    a user-provided destructor — an empty body `~T() {}` or an out-of-line
+    `T::~T() = default;` in the `.cpp`. An in-class `~T() = default;` on the
+    first declaration is user-*declared* but not user-*provided*, so it does
+    **not** pin the convention.
 
 ---
 
@@ -259,35 +260,43 @@ restructures the whole object (the virtual base moves to the end and a
 vbase-offset table is inserted); **appending** a base grows `sizeof` and shifts
 every member.
 
-> !!! note "How abicheck sees it"
->     Reported as `base_class_position_changed` / `type_base_changed` when DWARF
->     or headers are available — ELF symbol tables alone cannot see them, which
->     is why C++ ABI checking *requires* debug info or headers.
+A related multiple-inheritance trap is **overriding a virtual inherited from a
+*non-primary* base** — i.e. any base after the first. Because that base
+sub-object sits at a non-zero offset, the override needs a *thunk* that adjusts
+`this` back to the sub-object before dispatching. Introducing (or removing) such
+an override in a later release changes the set of thunks the vtable must carry
+and the `this`-adjustments baked into consumer call sites — a silent break even
+though the method's source signature is unchanged.
+
+!!! note "How abicheck sees it"
+    Reported as `base_class_position_changed` / `type_base_changed` when DWARF
+    or headers are available — ELF symbol tables alone cannot see them, which
+    is why C++ ABI checking *requires* debug info or headers.
 
 ---
 
 ## How to design C++ libraries for ABI stability
 
-> !!! tip "Design patterns for Part 4"
->     - **Pure-virtual interface + factory.** Expose an abstract class (no data
->       members, no inline methods) and a C-linkage `create_foo()`. Consumers
->       hold only the abstract pointer, so you can evolve the implementation
->       class without touching any consumer vtable.
->     - **Non-Virtual Interface (NVI).** Public methods are *non-virtual*
->       wrappers over a small, stable set of `virtual` hooks. You can add public
->       methods (non-virtual additions are ABI-safe) without growing the vtable.
->     - **Pimpl ABI firewall.** Every data member lives in an `Impl` defined in
->       the `.cpp`; the public class holds one `std::unique_ptr<Impl>`.
->       `sizeof(Widget)` never changes; offsets are invisible.
->     - **Inline namespaces for generational ABI.** Wrap public declarations in
->       `inline namespace abi_v1`. For a breaking change, ship `abi_v2` alongside
->       and keep the old symbols exported — consumers migrate on their schedule,
->       mirroring libstdc++ `__cxx11`.
->     - **`-fvisibility=hidden` + export macros.** Shrink the exported surface to
->       exactly what you intend to stabilize (see [Part 5](05-linker-elf.md)).
->
->     Full code for each is in
->     [Part 7 — Designing for Stability](07-designing-for-stability.md).
+!!! tip "Design patterns for Part 4"
+    - **Pure-virtual interface + factory.** Expose an abstract class (no data
+      members, no inline methods) and a C-linkage `create_foo()`. Consumers
+      hold only the abstract pointer, so you can evolve the implementation
+      class without touching any consumer vtable.
+    - **Non-Virtual Interface (NVI).** Public methods are *non-virtual*
+      wrappers over a small, stable set of `virtual` hooks. You can add public
+      methods (non-virtual additions are ABI-safe) without growing the vtable.
+    - **Pimpl ABI firewall.** Every data member lives in an `Impl` defined in
+      the `.cpp`; the public class holds one `std::unique_ptr<Impl>`.
+      `sizeof(Widget)` never changes; offsets are invisible.
+    - **Inline namespaces for generational ABI.** Wrap public declarations in
+      `inline namespace abi_v1`. For a breaking change, ship `abi_v2` alongside
+      and keep the old symbols exported — consumers migrate on their schedule,
+      mirroring libstdc++ `__cxx11`.
+    - **`-fvisibility=hidden` + export macros.** Shrink the exported surface to
+      exactly what you intend to stabilize (see [Part 5](05-linker-elf.md)).
+
+    Full code for each is in
+    [Part 7 — Designing for Stability](07-designing-for-stability.md).
 
 ---
 

--- a/docs/concepts/abi-series/05-linker-elf.md
+++ b/docs/concepts/abi-series/05-linker-elf.md
@@ -126,9 +126,9 @@ reads `rcx`/`rdx`, and the function operates on stale register contents — zero
 results or a segfault. The *signature is unchanged*, so name-and-type-only checks
 miss it.
 
-> !!! note "How abicheck sees it"
->     `calling_convention_changed` → 🔴 **BREAKING**, by diffing the
->     `DW_AT_calling_convention` DWARF attribute.
+!!! note "How abicheck sees it"
+    `calling_convention_changed` → 🔴 **BREAKING**, by diffing the
+    `DW_AT_calling_convention` DWARF attribute.
 
 ---
 
@@ -180,20 +180,20 @@ layout, and access model of TLS exports as first-class ABI.
 
 ## How to govern the linker-level contract
 
-> !!! tip "Design patterns for Part 5"
->     - **Version scripts as the source of truth.** A `.map` file enumerating
->       every intentional export is the canonical place to negotiate API surface
->       — and it doubles as your `-fvisibility=hidden` allowlist.
->     - **`ABI_EXPORT` macro discipline.** Build with `-fvisibility=hidden` and
->       annotate public functions with a project-specific macro expanding to
->       `__attribute__((visibility("default")))` (ELF) /
->       `__declspec(dllexport)` (PE).
->     - **CI gate on every PR.** Dump the previous release, compare the
->       candidate, fail on any 🔴 BREAKING not paired with a SONAME bump.
->     - **Never link with absolute `--rpath`.** Use `$ORIGIN` or install-time
->       rewriting; absolute build paths are non-portable and a security hazard.
->     - **Declare TLS access models explicitly.** If a TLS variable is ever
->       reached via `dlopen`, pin `-ftls-model=global-dynamic`.
+!!! tip "Design patterns for Part 5"
+    - **Version scripts as the source of truth.** A `.map` file enumerating
+      every intentional export is the canonical place to negotiate API surface
+      — and it doubles as your `-fvisibility=hidden` allowlist.
+    - **`ABI_EXPORT` macro discipline.** Build with `-fvisibility=hidden` and
+      annotate public functions with a project-specific macro expanding to
+      `__attribute__((visibility("default")))` (ELF) /
+      `__declspec(dllexport)` (PE).
+    - **CI gate on every PR.** Dump the previous release, compare the
+      candidate, fail on any 🔴 BREAKING not paired with a SONAME bump.
+    - **Never link with absolute `--rpath`.** Use `$ORIGIN` or install-time
+      rewriting; absolute build paths are non-portable and a security hazard.
+    - **Declare TLS access models explicitly.** If a TLS variable is ever
+      reached via `dlopen`, pin `-ftls-model=global-dynamic`.
 
 ---
 

--- a/docs/concepts/abi-series/05-linker-elf.md
+++ b/docs/concepts/abi-series/05-linker-elf.md
@@ -1,0 +1,211 @@
+# Part 5 — ELF & Linker-Level Concerns
+
+> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> [3. Type Layout](03-type-layout.md) ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> **5. Linker & ELF** ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- The *second* contract — the one enforced not by the language but by the
+  dynamic linker itself — and where it is recorded in the `.so`.
+- How **SONAME** establishes library identity, and why its major number *is* the
+  ABI epoch.
+- **Visibility**, **symbol versioning**, **calling-convention attributes**,
+  **security metadata** (executable stack, RPATH), **language linkage**, and the
+  **TLS access model** — each a load-time contract you can break without
+  touching a single source-level declaration.
+
+Prerequisites: [Part 1 — Foundations](01-foundations.md) (the dynamic loader).
+This page is Linux/ELF-centric; PE/COFF and Mach-O have analogous mechanisms.
+
+---
+
+## The second contract
+
+Above the source-level ABI sits a contract enforced by the dynamic linker:
+SONAME, visibility bits, version nodes, calling-convention attributes, and the
+TLS access model — all recorded *in the `.so`* and consulted at load time.
+You can satisfy every source-level rule from the previous pages and still break
+consumers here.
+
+---
+
+## 1. SONAME and library identity
+
+The **SONAME** is how the loader answers "is this the library you asked for?" It
+lives in the `DT_SONAME` entry of `.dynamic`, set via
+`-Wl,-soname,libfoo.so.MAJOR` at link time. When an app links against
+`libfoo.so`, the linker copies the **SONAME** — not the filename — into
+`DT_NEEDED`; at runtime the loader searches for a file (usually an
+`ldconfig`-managed symlink) matching that string.
+
+```text
+  link:   app  --(records)-->  DT_NEEDED: libfoo.so.1
+  run:    ld.so finds  libfoo.so.1 -> libfoo.so.1.4.2   (via ldconfig symlink)
+```
+
+Two failure modes:
+
+- **No SONAME at all** ([case05](../../examples/case05_soname.md)): `DT_NEEDED`
+  points at the bare `libfoo.so`, which `ldconfig` can't manage — shipping
+  `libfoo.so.1` later breaks every consumer.
+- **Wrong major** ([case50](../../examples/case50_soname_inconsistent.md)): a 1.x
+  release tagged `libfoo.so.0`; packaging generates dependencies on the wrong
+  major and the cutover forces a distribution-wide rebuild.
+
+> **Rule: SONAME major equals ABI epoch, and it never silently changes.** A
+> deliberate SONAME bump is the *correct* way to ship a breaking change —
+> `libfoo.so.1` and `libfoo.so.2` coexist on disk, and old binaries keep loading
+> the old one.
+
+---
+
+## 2. Symbol visibility
+
+Every `.dynsym` entry has an `st_other` visibility byte: `STV_DEFAULT` (public,
+interposable), `STV_HIDDEN`, `STV_PROTECTED` (exported but not interposable), or
+`STV_INTERNAL`. **Without `-fvisibility=hidden`, every non-`static` function
+defaults to `STV_DEFAULT`** — dragging the entire translation unit into your
+public ABI.
+
+| Case | Scenario | Verdict |
+|------|----------|---------|
+| [case06](../../examples/case06_visibility.md) | `internal_helper` was never meant to be public, but lacking `static` consumers resolved it; the later "cleanup" that hides it **breaks them** | 🔴 BREAKING (the removal), 🟢 quality (the original leak) |
+| [case53](../../examples/case53_namespace_pollution.md) | exporting unprefixed names like `init` that collide in the process's flat symbol namespace | 🔴 BREAKING |
+| [case51](../../examples/case51_protected_visibility.md) | `DEFAULT` → `PROTECTED`: ABI-compatible for normal callers, but silently defeats `LD_PRELOAD` interposition | 🟢 COMPATIBLE (quality) |
+
+The trap is asymmetric: leaving visibility open is a 🟢 *quality* warning today,
+but it commits you to maintaining those symbols forever — **fixing it later is a
+🔴 BREAKING removal.**
+
+---
+
+## 3. Symbol versioning
+
+A version script (`-Wl,--version-script=libfoo.map`) groups symbols into named
+nodes like `LIBFOO_1.0`, recorded in `.gnu.version_d` and tagged in
+`.gnu.versym`; consumers carry matching `.gnu.version_r` entries. This lets one
+`.so` ship multiple ABI generations side by side — the mechanism glibc uses to
+stay loadable across decades.
+
+```text
+libfoo.map:
+  LIBFOO_1.0 { global: foo; bar; local: *; };
+  LIBFOO_2.0 { global: baz; } LIBFOO_1.0;
+```
+
+- **Adding** a version script ([case13](../../examples/case13_symbol_versioning.md))
+  is backward compatible — old binaries have no `DT_VERNEED`, so the loader
+  resolves by name. 🟢 COMPATIBLE.
+- **Removing** a node ([case65](../../examples/case65_symbol_version_removed.md))
+  deletes every symbol it tagged: `version 'FOO_1.0' not found`. 🔴 BREAKING.
+
+glibc's `GLIBC_2.0` has been *append-only since 1997* — which is why a binary
+built against an old glibc still loads against a current one, and why OpenSSL
+3.0's version-node removals forced the SONAME bump from `libssl.so.1.1` to
+`.so.3`.
+
+---
+
+## 4. Calling conventions
+
+A calling convention is the register-and-stack contract: which registers hold
+args, which are callee-saved, how the return comes back. On x86-64 you meet
+System V AMD64 (Linux/macOS/BSD, args in `rdi, rsi, rdx, rcx, r8, r9`) and
+Microsoft x64 (Windows or `__attribute__((ms_abi))`, args in `rcx, rdx, r8,
+r9`). On 32-bit x86 the zoo is larger: `cdecl`, `stdcall`, `fastcall`,
+`thiscall`, `vectorcall`.
+
+[case64](../../examples/case64_calling_convention_changed.md) flips the attribute
+silently: the v1 caller loads pointers into `rdi`/`rsi`, the v2 `ms_abi` callee
+reads `rcx`/`rdx`, and the function operates on stale register contents — zero
+results or a segfault. The *signature is unchanged*, so name-and-type-only checks
+miss it.
+
+> !!! note "How abicheck sees it"
+>     `calling_convention_changed` → 🔴 **BREAKING**, by diffing the
+>     `DW_AT_calling_convention` DWARF attribute.
+
+---
+
+## 5. Security metadata
+
+Two ELF-level properties are part of the contract even though they aren't "code":
+
+- **Executable stack.** The `PT_GNU_STACK` program header advertises whether the
+  process stack must be executable; the linker *unions* it across input objects,
+  so a single assembly file missing its `.note.GNU-stack` annotation promotes the
+  entire `.so` (and every process that loads it) to an executable stack.
+  [case49](../../examples/case49_executable_stack.md): `readelf -l` reports `RWE`
+  instead of `RW`; rpmlint and Debian lintian both reject the package.
+- **RPATH/RUNPATH leaks.** `DT_RPATH`/`DT_RUNPATH` hold extra linker search
+  paths. [case52](../../examples/case52_rpath_leak.md) bakes
+  `/home/build/myproject/lib` into the artifact: it only works on the build host,
+  and anyone who can write that path gets a library-injection primitive. Use
+  `$ORIGIN`-relative paths or strip RPATH entirely.
+
+These are 🟢 *quality* findings (the binary still loads) but they are release
+blockers for distributions and a genuine security exposure.
+
+---
+
+## 6. Language linkage and TLS
+
+**Language linkage.**
+[case66](../../examples/case66_language_linkage_changed.md) removes `extern "C"`
+during a C++ modernization: the source still compiles, but the `.dynsym` symbol
+flips from unmangled `parse_config` to mangled `_Z12parse_configPKc`, and every
+pre-linked consumer fails at load. **Treat `extern "C"` blocks as part of the
+public ABI.**
+
+**Thread-Local Storage.** TLS has four access models:
+
+| Model | Property |
+|-------|----------|
+| `global-dynamic` | default for `.so`; **`dlopen`-safe** |
+| `local-dynamic` | for TLS used only within the same module |
+| `initial-exec` | faster, but requires the variable be present at startup — **`dlopen` fails** |
+| `local-exec` | main executable only |
+
+Libraries intended to be `dlopen`ed must avoid `initial-exec`. And any exported
+`__thread` struct whose layout shifts corrupts consumers per-thread
+([case67](../../examples/case67_tls_var_size_changed.md)) — freeze the size,
+layout, and access model of TLS exports as first-class ABI.
+
+---
+
+## How to govern the linker-level contract
+
+> !!! tip "Design patterns for Part 5"
+>     - **Version scripts as the source of truth.** A `.map` file enumerating
+>       every intentional export is the canonical place to negotiate API surface
+>       — and it doubles as your `-fvisibility=hidden` allowlist.
+>     - **`ABI_EXPORT` macro discipline.** Build with `-fvisibility=hidden` and
+>       annotate public functions with a project-specific macro expanding to
+>       `__attribute__((visibility("default")))` (ELF) /
+>       `__declspec(dllexport)` (PE).
+>     - **CI gate on every PR.** Dump the previous release, compare the
+>       candidate, fail on any 🔴 BREAKING not paired with a SONAME bump.
+>     - **Never link with absolute `--rpath`.** Use `$ORIGIN` or install-time
+>       rewriting; absolute build paths are non-portable and a security hazard.
+>     - **Declare TLS access models explicitly.** If a TLS variable is ever
+>       reached via `dlopen`, pin `-ftls-model=global-dynamic`.
+
+---
+
+## Next
+
+So far every break has been visible in the library's own declarations. The
+nastiest family is the one where the exported symbol table is *byte-identical*
+yet consumers still corrupt memory — breaks that travel through a *transitive*
+dependency the library doesn't even define.
+
+➡️ **[Part 6 — Subtle & Transitive Breaks](06-transitive-breaks.md)**
+
+*See also:* [ABI Cheat Sheet](../abi-cheat-sheet.md) ·
+[Platforms reference](../../reference/platforms.md) ·
+[Quality examples](../../examples/by-category/quality.md)

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -90,23 +90,36 @@ abicheck traces the layout through DWARF's anonymous-member rules and reports
 
 ## 3. Type-kind changes
 
-Swapping `struct` for `union`, `enum` for plain `int`, or `class` for `struct`
-at the same name — **even when the size happens to match** — is always an ABI
-break, because the *semantics* of member storage differ.
+Swapping the *kind* of a named type is dangerous — but not uniformly, and the
+distinction matters for what you do about it. The dividing line is **whether the
+storage model changes**:
 
-[case55](../../examples/case55_type_kind_changed.md) changes `Data` from a struct
-with sequential fields `x, y` (size 8) to a union where `x` and `y` overlap at
-offset 0 (size 4): `sizeof` shrinks, `y`'s offset moves, and writing one member
-now clobbers the other. Even a *same-size* swap — `enum E : int` → plain `int`
-in a C++ API — breaks overload resolution and name mangling (`E` and `int`
-mangle differently), so function symbols vanish from the new `.so`.
+- Anything **involving a `union`** — `struct`→`union` or the reverse — changes
+  how members are laid out (sequential vs overlapping at offset 0), so it is a
+  genuine **binary** break even when the size happens to match.
+- A bare **`struct`↔`class` keyword swap** with the same members is
+  **binary-identical**: under the Itanium ABI the two keywords differ only in
+  *default member access* and *default inheritance* — both source-level concepts.
+  Nothing about layout or mangling changes, so existing binaries keep working;
+  only fresh compiles can be affected (e.g. code that relied on the old default
+  access).
+
+[case55](../../examples/case55_type_kind_changed.md) is the breaking kind:
+`Data` goes from a struct with sequential fields `x, y` (size 8) to a union where
+`x` and `y` overlap at offset 0 (size 4): `sizeof` shrinks, `y`'s offset moves,
+and writing one member now clobbers the other. (Separately, swapping `enum E :
+int` for plain `int` in a C++ API is breaking for a different reason — `E` and
+`int` mangle differently, so function symbols that took `E` vanish from the new
+`.so`.)
 
 !!! note "How abicheck sees it"
-    abicheck reads DWARF's `DW_TAG_structure_type` vs `DW_TAG_union_type` vs
-    `DW_TAG_enumeration_type` and classifies any transition as
-    `type_kind_changed` → 🔴 **BREAKING**, regardless of byte-for-byte size
-    equality — because a consumer's *code generation* assumes the kind, not
-    just the footprint.
+    abicheck reads DWARF's `DW_TAG_structure_type` / `DW_TAG_union_type` /
+    `DW_TAG_class_type` and splits the verdict by storage model:
+
+    - **union involved** → `type_kind_changed` → 🔴 **BREAKING** (layout changes).
+    - **`struct`↔`class`, no union** → `source_level_kind_changed` → 🟠
+      **API_BREAK** — binary-identical, source-level only. Don't bump the SONAME
+      for this one; it needs at most a recompile.
 
 ---
 

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -55,11 +55,11 @@ from. libstdc++'s dual-ABI split (`std::string` after GCC 5) and TBB 2021.3's
 `task_arena` re-layout both propagated through exactly this mechanism, fracturing
 every consumer who had leaked the type into a public API.
 
-> !!! note "How abicheck sees it"
->     `type_size_changed` → 🔴 **BREAKING**, *only when DWARF for the third-party
->     type is present* in the shipped `.so`. Stripped distributions hide the
->     hazard entirely — which is why the fix is structural (pimpl / opaque
->     handles), not tooling.
+!!! note "How abicheck sees it"
+    `type_size_changed` → 🔴 **BREAKING**, *only when DWARF for the third-party
+    type is present* in the shipped `.so`. Stripped distributions hide the
+    hazard entirely — which is why the fix is structural (pimpl / opaque
+    handles), not tooling.
 
 ---
 
@@ -101,12 +101,12 @@ now clobbers the other. Even a *same-size* swap — `enum E : int` → plain `in
 in a C++ API — breaks overload resolution and name mangling (`E` and `int`
 mangle differently), so function symbols vanish from the new `.so`.
 
-> !!! note "How abicheck sees it"
->     abicheck reads DWARF's `DW_TAG_structure_type` vs `DW_TAG_union_type` vs
->     `DW_TAG_enumeration_type` and classifies any transition as
->     `type_kind_changed` → 🔴 **BREAKING**, regardless of byte-for-byte size
->     equality — because a consumer's *code generation* assumes the kind, not
->     just the footprint.
+!!! note "How abicheck sees it"
+    abicheck reads DWARF's `DW_TAG_structure_type` vs `DW_TAG_union_type` vs
+    `DW_TAG_enumeration_type` and classifies any transition as
+    `type_kind_changed` → 🔴 **BREAKING**, regardless of byte-for-byte size
+    equality — because a consumer's *code generation* assumes the kind, not
+    just the footprint.
 
 ---
 
@@ -123,14 +123,14 @@ becomes silent data corruption.
 pattern: v1 ships `__reserved1` and `__reserved2` at defined offsets; v2 renames
 them to `priority` and `max_retries` with the *same types and offsets*.
 
-> !!! note "How abicheck sees it"
->     `_diff_reserved_fields` recognizes the naming convention (`__reserved`,
->     `_reserved`, `__pad`, `_unused`) and classifies the rename → 🟢
->     **COMPATIBLE**. The catch the tool *cannot* verify: there is no way to
->     prove no consumer ever wrote to the slot — the pattern's safety rests on a
->     documented contract that users zero-initialize and ignore the field. Linux
->     `struct stat`, glibc `pthread_attr_t`, and Wayland protocol structs all
->     depend on exactly this contract.
+!!! note "How abicheck sees it"
+    `_diff_reserved_fields` recognizes the naming convention (`__reserved`,
+    `_reserved`, `__pad`, `_unused`) and classifies the rename → 🟢
+    **COMPATIBLE**. The catch the tool *cannot* verify: there is no way to
+    prove no consumer ever wrote to the slot — the pattern's safety rests on a
+    documented contract that users zero-initialize and ignore the field. Linux
+    `struct stat`, glibc `pthread_attr_t`, and Wayland protocol structs all
+    depend on exactly this contract.
 
 ---
 
@@ -164,25 +164,25 @@ opaque-handle C API (`FILE*`, `sqlite3*`, `git_repository*`).
 
 ## How to defend against transitive breaks
 
-> !!! tip "Design patterns for Part 6"
->     - **Opaque wrappers around third-party types.** Never forward-publish
->       `std::string`, `boost::any`, `tbb::task_arena`, or any
->       vendored-dependency type in your headers; wrap it in a type you own.
->     - **Stable DTOs at the API boundary.** Define plain structs with explicit
->       layout for every value that crosses the ABI, and treat those DTOs as a
->       versioned schema separate from your internal types.
->     - **Build-time abicheck in CI.** Run `abicheck compare` against the last
->       released `.so` on every PR; flag anything above `COMPATIBLE_WITH_RISK` as
->       a release blocker — and ship the build with debug info so transitive
->       layout shifts are *visible* to the tool.
->     - **Zero reserved fields before public release**, or commit in
->       documentation to never activating them. Reserved padding that is never
->       used is free; reserved padding whose safety you can't audit is a future
->       🔴 BREAKING verdict.
->     - **Pointer-to-incomplete-type for anything you might evolve.** If you
->       can't guarantee a struct's layout for the lifetime of a SONAME, expose a
->       forward-declared tag and a constructor/destructor pair — not the
->       definition.
+!!! tip "Design patterns for Part 6"
+    - **Opaque wrappers around third-party types.** Never forward-publish
+      `std::string`, `boost::any`, `tbb::task_arena`, or any
+      vendored-dependency type in your headers; wrap it in a type you own.
+    - **Stable DTOs at the API boundary.** Define plain structs with explicit
+      layout for every value that crosses the ABI, and treat those DTOs as a
+      versioned schema separate from your internal types.
+    - **Build-time abicheck in CI.** Run `abicheck compare` against the last
+      released `.so` on every PR; flag anything above `COMPATIBLE_WITH_RISK` as
+      a release blocker — and ship the build with debug info so transitive
+      layout shifts are *visible* to the tool.
+    - **Zero reserved fields before public release**, or commit in
+      documentation to never activating them. Reserved padding that is never
+      used is free; reserved padding whose safety you can't audit is a future
+      🔴 BREAKING verdict.
+    - **Pointer-to-incomplete-type for anything you might evolve.** If you
+      can't guarantee a struct's layout for the lifetime of a SONAME, expose a
+      forward-declared tag and a constructor/destructor pair — not the
+      definition.
 
 ---
 

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -1,0 +1,199 @@
+# Part 6 — Subtle & Transitive Breaks
+
+> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> [3. Type Layout](03-type-layout.md) ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> **6. Transitive Breaks** ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- The breaks that **survive code review**: the exported symbol table is
+  byte-identical, every signature is preserved, `nm --dynamic` shows no diff —
+  yet consumers corrupt memory on the first call.
+- Five mechanisms that smuggle a layout change across the boundary: **dependency
+  leaks, anonymous structs, type-kind swaps, reserved-field misuse, and embedded
+  leaf structs**.
+- Why these are precisely the cases that need DWARF-aware tooling — and why the
+  *real* fix is structural, not a better scanner.
+
+Prerequisites: [Part 3 — Type Layout](03-type-layout.md) (offsets propagate
+through embedding) and [Part 2 — Symbol Contracts](02-symbol-contracts.md).
+
+---
+
+## The common thread: a transitive contract
+
+The breaks on this page share one property: a **transitive dependency**. The ABI
+contract is implied not by anything the library itself defines, but by a type it
+*publishes through a header, a padding field, or a nested member*. Static
+analyzers that look only at the shipped `.so` miss them entirely; DWARF-aware
+tools catch most but require debug info to travel with the binary.
+
+> The recurring mental model: your public type's size and layout are the *sum* of
+> things you may not control. The moment any of those things shifts — a vendored
+> type, an anonymous member, a "reserved" byte — your `sizeof` changes, and from
+> [Part 3](03-type-layout.md) you know what a changed `sizeof` does.
+
+---
+
+## 1. Dependency leaks
+
+When a public header includes a third-party type — `std::string`, `boost::any`,
+`tbb::task_arena`, `grpc::Status` — your library silently inherits that type's
+ABI contract. Upgrade the third-party library and every consumer's compiled
+size, field offsets, and vtable assumptions become wrong, **even though your own
+source never changed.**
+
+[case18](../../examples/case18_dependency_leak.md) demonstrates this with a
+`ThirdPartyHandle` that grows from 4 to 8 bytes: `libfoo`'s exported symbols are
+identical, `nm` and a naive `abidiff` see no difference, but a caller built
+against v1 headers allocates a 4-byte struct that the v2 library reads 8 bytes
+from. libstdc++'s dual-ABI split (`std::string` after GCC 5) and TBB 2021.3's
+`task_arena` re-layout both propagated through exactly this mechanism, fracturing
+every consumer who had leaked the type into a public API.
+
+> !!! note "How abicheck sees it"
+>     `type_size_changed` → 🔴 **BREAKING**, *only when DWARF for the third-party
+>     type is present* in the shipped `.so`. Stripped distributions hide the
+>     hazard entirely — which is why the fix is structural (pimpl / opaque
+>     handles), not tooling.
+
+---
+
+## 2. Anonymous structs
+
+C and C++ permit unnamed nested structs and unions inside a public type. The
+container's size and alignment depend entirely on the unnamed member's contents,
+but the anonymous member has **no stable name** to refer to in a diff — and in
+C++ it changes the mangled layout without touching any source-visible
+identifier.
+
+```c
+/* v1 */ struct Variant { int tag; union { int i; float  f; }; };  // sizeof 8
+/* v2 */ struct Variant { int tag; union { int i; double d; }; };  // sizeof 16
+```
+
+Replacing `float f` with `double d` inflates the anonymous union from 4 to 8
+bytes and — with 8-byte alignment — shifts the whole struct from 8 to 16,
+moving `i` from offset 4 to offset 8
+([case36](../../examples/case36_anon_struct.md)). A caller allocating
+`sizeof(Variant) == 8` on the stack then calls a v2 library that reads `i` at
+offset 8 — four bytes past the allocation, into uninitialized memory. **The
+source diff is one line inside an anonymous scope; the ABI diff is total.**
+abicheck traces the layout through DWARF's anonymous-member rules and reports
+`type_size_changed` with the exact member-offset delta.
+
+---
+
+## 3. Type-kind changes
+
+Swapping `struct` for `union`, `enum` for plain `int`, or `class` for `struct`
+at the same name — **even when the size happens to match** — is always an ABI
+break, because the *semantics* of member storage differ.
+
+[case55](../../examples/case55_type_kind_changed.md) changes `Data` from a struct
+with sequential fields `x, y` (size 8) to a union where `x` and `y` overlap at
+offset 0 (size 4): `sizeof` shrinks, `y`'s offset moves, and writing one member
+now clobbers the other. Even a *same-size* swap — `enum E : int` → plain `int`
+in a C++ API — breaks overload resolution and name mangling (`E` and `int`
+mangle differently), so function symbols vanish from the new `.so`.
+
+> !!! note "How abicheck sees it"
+>     abicheck reads DWARF's `DW_TAG_structure_type` vs `DW_TAG_union_type` vs
+>     `DW_TAG_enumeration_type` and classifies any transition as
+>     `type_kind_changed` → 🔴 **BREAKING**, regardless of byte-for-byte size
+>     equality — because a consumer's *code generation* assumes the kind, not
+>     just the footprint.
+
+---
+
+## 4. Reserved-field misuse
+
+Reserving padding for future growth — `int __reserved1`, `char _pad[16]` — is
+the standard way to extend a struct without bumping SONAME, **but it only works
+if no shipped binary ever touched the reserved bytes.** The moment a consumer
+writes to reserved storage (deliberately via a cast, or accidentally via
+`memset(&s, 0xFF, sizeof(s))` before field-wise init), repurposing those bytes
+becomes silent data corruption.
+
+[case54](../../examples/case54_used_reserved_field.md) shows the **correct**
+pattern: v1 ships `__reserved1` and `__reserved2` at defined offsets; v2 renames
+them to `priority` and `max_retries` with the *same types and offsets*.
+
+> !!! note "How abicheck sees it"
+>     `_diff_reserved_fields` recognizes the naming convention (`__reserved`,
+>     `_reserved`, `__pad`, `_unused`) and classifies the rename → 🟢
+>     **COMPATIBLE**. The catch the tool *cannot* verify: there is no way to
+>     prove no consumer ever wrote to the slot — the pattern's safety rests on a
+>     documented contract that users zero-initialize and ignore the field. Linux
+>     `struct stat`, glibc `pthread_attr_t`, and Wayland protocol structs all
+>     depend on exactly this contract.
+
+---
+
+## 5. Leaf structs through pointers
+
+Pointer indirection is the single strongest ABI firewall in C: a caller that
+handles only `T*` is agnostic to `sizeof(T)`, to `T`'s field offsets, and to
+`T`'s kind-tag.
+
+[case48](../../examples/case48_leaf_struct_through_pointer.md) contrasts this with
+the failing case — a `Container` that **embeds** `Leaf` by value:
+
+```c
+/* breaking: embed by value */
+struct Container { struct Leaf leaf; int flags; };   // flags offset moves with Leaf
+
+/* safe: indirect through a pointer */
+struct Leaf;                                          // incomplete type
+struct Container { struct Leaf *leaf; int flags; };   // flags offset fixed
+```
+
+When `Leaf` grows from 4 to 8 bytes, the *embedding* version shifts
+`Container::flags` from offset 8 to 16 — the public API still takes only
+`Container*`, but the size change propagates through embedding and a v1-compiled
+caller reads `flags` at the wrong offset. The *pointer* version is immune: the
+caller's compilation depends only on pointer size (stable per ABI), and the
+library alone controls allocation and layout. This is the mechanism behind every
+opaque-handle C API (`FILE*`, `sqlite3*`, `git_repository*`).
+
+---
+
+## How to defend against transitive breaks
+
+> !!! tip "Design patterns for Part 6"
+>     - **Opaque wrappers around third-party types.** Never forward-publish
+>       `std::string`, `boost::any`, `tbb::task_arena`, or any
+>       vendored-dependency type in your headers; wrap it in a type you own.
+>     - **Stable DTOs at the API boundary.** Define plain structs with explicit
+>       layout for every value that crosses the ABI, and treat those DTOs as a
+>       versioned schema separate from your internal types.
+>     - **Build-time abicheck in CI.** Run `abicheck compare` against the last
+>       released `.so` on every PR; flag anything above `COMPATIBLE_WITH_RISK` as
+>       a release blocker — and ship the build with debug info so transitive
+>       layout shifts are *visible* to the tool.
+>     - **Zero reserved fields before public release**, or commit in
+>       documentation to never activating them. Reserved padding that is never
+>       used is free; reserved padding whose safety you can't audit is a future
+>       🔴 BREAKING verdict.
+>     - **Pointer-to-incomplete-type for anything you might evolve.** If you
+>       can't guarantee a struct's layout for the lifetime of a SONAME, expose a
+>       forward-declared tag and a constructor/destructor pair — not the
+>       definition.
+
+---
+
+## Next
+
+You've now seen every family of break. The final page turns the scattered "how
+to fix" boxes into a single, coherent design playbook — the patterns that make a
+library *evolvable*, plus the CI gate that enforces them.
+
+➡️ **[Part 7 — Designing for Stability](07-designing-for-stability.md)**
+
+*See also:* [ABI Cheat Sheet](../abi-cheat-sheet.md) ·
+[BREAKING examples](../../examples/by-verdict/breaking.md) ·
+[Limitations](../limitations.md)

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -235,9 +235,15 @@ extern "C" ICodec *codec_create();     // stable C symbol; hides the concrete ty
 
 **Why it works:** consumers hold only `ICodec*` and call through the vtable. The
 concrete implementation class — its data members, its `sizeof`, its non-virtual
-helpers — lives entirely in your `.so` and can change freely. The one rule you
-inherit from [Part 4](04-cpp-abi.md): you may only **append** virtual methods to
-`ICodec`, never insert or reorder.
+helpers — lives entirely in your `.so` and can change freely. The rule you
+inherit from [Part 4](04-cpp-abi.md): never insert or reorder virtual methods on
+`ICodec`. **Appending** is safe *only if your library owns every implementation
+of `ICodec`.* The moment downstreams are allowed to derive from it — the usual
+case for plugin or callback interfaces — even appending is breaking: an old
+plugin's vtable was compiled with the old shape, so a host call into the new slot
+dispatches past the end of that vtable. For a downstream-implementable interface,
+treat *any* vtable change as a SONAME-bump-worthy break and version the interface
+itself (a new `ICodec2`, or the inline-namespace generation pattern above).
 
 ---
 

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -1,0 +1,320 @@
+# Part 7 — Designing for Stability
+
+> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> [3. Type Layout](03-type-layout.md) ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> **7. Designing for Stability**
+
+**What you'll learn on this page**
+
+- The handful of design patterns that make a library *evolvable*, each with
+  copy-pasteable code: **opaque handles, Pimpl, reserved padding, version
+  scripts, visibility control, inline-namespace generations**.
+- Five top-level rules that subsume every mechanism in the series.
+- How to wire `abicheck` into CI as a release gate, and how to read its verdict.
+
+This is the capstone. Each previous page ended with a "how to fix" box pointing
+here; this page gives the full pattern.
+
+---
+
+## The one idea behind every pattern
+
+Every break in this series came from the same root: **a fact the library
+publishes (a size, an offset, a symbol name, a register choice, a vtable slot)
+got baked into a consumer's binary and then changed.**
+
+So every fix is a variation on a single move:
+
+> **Stop publishing the fact.** If consumers can't see a struct's layout, you can
+> change the layout. If they can't see a symbol's mangling, you can re-mangle it.
+> If they only ever hold a pointer, the size on the other end is yours forever.
+
+The patterns below are concrete ways to *not publish* a fact you'd otherwise be
+committed to for the lifetime of a SONAME.
+
+---
+
+## Pattern 1 — Opaque handles (the strongest C firewall)
+
+Expose only a pointer to an incomplete type. Define the struct in the `.c` file
+so callers can never take `sizeof` or `offsetof`.
+
+```c
+// foo.h — the public header
+typedef struct foo foo_t;        // incomplete: callers know only that foo_t exists
+
+foo_t *foo_create(void);
+void   foo_destroy(foo_t *);
+int    foo_get_version(foo_t *);
+void   foo_set_name(foo_t *, const char *);
+```
+
+```c
+// foo.c — the implementation; layout lives here and ONLY here
+struct foo {
+    int   version;
+    char  name[64];
+    void *anything_you_want_to_add_later;   // free to change forever
+};
+
+foo_t *foo_create(void) { return calloc(1, sizeof(struct foo)); }
+void   foo_destroy(foo_t *f) { free(f); }
+int    foo_get_version(foo_t *f) { return f->version; }
+```
+
+**Why it works:** the only thing crossing the ABI boundary is `foo_t *` — pointer
+size is fixed per ABI. You can add, remove, and reorder fields in `struct foo`
+across releases and no consumer is affected. This is exactly how `FILE*`,
+`sqlite3*`, and `git_repository*` stay stable for decades. It neutralizes the
+entire [Part 3](03-type-layout.md) family in one move.
+
+---
+
+## Pattern 2 — Pimpl (the C++ equivalent)
+
+The public class holds a single pointer to a privately-defined `Impl`. All state
+lives in `Impl`, so `sizeof` of the public class never changes and no field
+offset is ever visible.
+
+```cpp
+// widget.hpp — public
+class Widget {
+public:
+    Widget();
+    ~Widget();
+    Widget(Widget&&) noexcept;
+    Widget& operator=(Widget&&) noexcept;
+
+    void resize(int w, int h);
+    int  area() const;
+
+private:
+    struct Impl;                       // forward declaration only
+    std::unique_ptr<Impl> d_;          // sizeof(Widget) == sizeof(void*), forever
+};
+```
+
+```cpp
+// widget.cpp — private
+struct Widget::Impl {
+    int w = 0, h = 0;
+    std::string label;                 // safe to add: never crosses the boundary
+};
+
+Widget::Widget() : d_(std::make_unique<Impl>()) {}
+Widget::~Widget() = default;           // defined here, where Impl is complete
+void Widget::resize(int w, int h) { d_->w = w; d_->h = h; }
+int  Widget::area() const { return d_->w * d_->h; }
+```
+
+**Why it works:** `sizeof(Widget)` is one pointer regardless of how `Impl` grows.
+Qt enforces this across every public class, which is why Qt 5.x held ABI for
+years through deep internal refactors. It also closes off
+[trivial→non-trivial](04-cpp-abi.md) surprises, because the public class's
+special members are declared once and pinned.
+
+> !!! warning "Pimpl gotcha"
+>     Declare and *out-of-line define* the destructor (and move operations) in
+>     the `.cpp` where `Impl` is complete. A defaulted destructor in the header
+>     forces the compiler to see `Impl`'s definition there — defeating the
+>     firewall.
+
+---
+
+## Pattern 3 — Reserved padding (evolve a value type in place)
+
+When you *must* expose a struct by value (a C plain-old-data DTO), pre-reserve
+space so you can add fields later without changing `sizeof` or moving offsets.
+
+```c
+// v1
+typedef struct {
+    int     priority;
+    int     timeout_ms;
+    uint64_t _reserved[6];     // 48 bytes held in reserve
+} job_config_t;
+
+// v2 — consumes two reserved slots; sizeof and all prior offsets UNCHANGED
+typedef struct {
+    int     priority;
+    int     timeout_ms;
+    int     max_retries;       // was _reserved[0]'s low word
+    int     _pad;
+    uint64_t _reserved[5];
+} job_config_t;
+```
+
+**The contract you must document and consumers must honor:** zero-initialize the
+whole struct and never read or write the reserved bytes. Linux `struct stat`,
+glibc `pthread_attr_t`, and Wayland protocol structs all rely on this. The hazard
+([Part 6, reserved-field misuse](06-transitive-breaks.md)) is that you cannot
+*prove* a consumer obeyed it — so reserve generously and document loudly.
+
+---
+
+## Pattern 4 — Version scripts + visibility (own your export surface)
+
+Compile with hidden visibility and enumerate exactly what you export. Everything
+else stays internal and never becomes an ABI commitment.
+
+```c
+// foo_export.h
+#define FOO_API __attribute__((visibility("default")))
+
+FOO_API int  foo_compute(int);
+/* internal helpers carry no macro → hidden under -fvisibility=hidden */
+```
+
+```text
+# libfoo.map — the canonical list of intentional exports
+LIBFOO_1.0 {
+    global:
+        foo_compute;
+        foo_create;
+        foo_destroy;
+    local:
+        *;            # everything else is hidden
+};
+```
+
+```bash
+gcc -fvisibility=hidden -shared -fPIC *.c \
+    -Wl,--version-script=libfoo.map \
+    -Wl,-soname,libfoo.so.1 -o libfoo.so.1
+```
+
+**Why it works:** `-fvisibility=hidden` plus the `local: *` rule means only the
+names you listed enter `.dynsym` — closing off the accidental-leak hazard from
+[Part 5](05-linker-elf.md). When you genuinely need a breaking change, add a new
+node (`LIBFOO_2.0 { ... } LIBFOO_1.0;`) and keep the old symbols exported, so old
+binaries keep resolving the old implementation.
+
+---
+
+## Pattern 5 — Inline namespaces for generational C++ ABI
+
+Wrap public declarations in an inline namespace. Source ignores it; the symbol
+encodes it. When you need a breaking change, ship a new generation alongside the
+old.
+
+```cpp
+namespace mylib {
+inline namespace abi_v1 {
+    class Codec { /* v1 layout & vtable */ };
+    void process(Codec&);
+}
+}
+// consumers write mylib::Codec / mylib::process — unaware of abi_v1
+```
+
+To ship an incompatible `Codec`, add `inline namespace abi_v2 { ... }` and demote
+`abi_v1` to a *non-inline* namespace that still compiles for old TUs. New builds
+bind `abi_v2` symbols; old binaries keep resolving `abi_v1`. This is libstdc++'s
+`__cxx11` mechanism, used deliberately.
+
+---
+
+## Pattern 6 — Pure-virtual interface + factory
+
+For polymorphic C++ APIs, never expose a concrete class with data members.
+Expose an abstract interface and a C-linkage factory.
+
+```cpp
+// codec.hpp
+struct ICodec {
+    virtual ~ICodec() = default;
+    virtual int  encode(const Frame&) = 0;
+    virtual void reset() = 0;
+};
+extern "C" ICodec *codec_create();     // stable C symbol; hides the concrete type
+```
+
+**Why it works:** consumers hold only `ICodec*` and call through the vtable. The
+concrete implementation class — its data members, its `sizeof`, its non-virtual
+helpers — lives entirely in your `.so` and can change freely. The one rule you
+inherit from [Part 4](04-cpp-abi.md): you may only **append** virtual methods to
+`ICodec`, never insert or reorder.
+
+---
+
+## The five rules that subsume everything
+
+1. **Treat public headers as ABI contracts.** Anything reachable from a public
+   header — type layout, enum values, vtable shape, exported globals — is part of
+   the binary contract whether or not you intended it to be.
+2. **Govern release identity.** Use SONAME + symbol versioning + a
+   `-fvisibility=hidden` export policy on every release; bump the SONAME *major*
+   on any binary-incompatible change. abicheck surfaces the signals as
+   `soname_bump_recommended`, `symbol_version_node_removed`,
+   `symbol_moved_version_node`, and `version_script_missing`.
+3. **Prefer opaque handles and Pimpl** over exposing mutable layouts, so the
+   library — not the consumer — owns size, offsets, and the kind-tag of a type.
+4. **Evolve additively, never in place.** Append new symbols, enum members, and
+   struct fields (where no embedded `sizeof` assumption exists); ship breaking
+   changes under a new inline-namespace or a new symbol rather than mutating an
+   existing one.
+5. **Gate every PR with abicheck in CI.** Dump the last released artifact and
+   compare the candidate; block anything above `COMPATIBLE_WITH_RISK` that isn't
+   paired with a deliberate SONAME bump.
+
+---
+
+## Wiring abicheck into CI
+
+The minimal gate compares the candidate against the last released `.so`:
+
+```bash
+abicheck compare libfoo.so.old libfoo.so.new \
+  --old-header include/old/foo.h \
+  --new-header include/new/foo.h \
+  --policy strict_abi
+```
+
+It exits non-zero on any 🔴 BREAKING or 🟠 API_BREAK finding. Add
+`--suppress suppressions.yaml` to allowlist changes you've consciously accepted.
+
+For a ready-to-paste GitHub Actions workflow that dumps the previous release and
+fails the build on regressions, see the
+[GitHub Action guide](../../user-guide/github-action.md). For the full CLI surface
+and policy options, see [CLI Usage](../../user-guide/cli-usage.md) and
+[Policy Profiles](../../user-guide/policies.md).
+
+**Reading the verdict in CI:**
+
+| Verdict | Exit behavior | What to do |
+|---------|--------------|------------|
+| ✅ `NO_CHANGE` / 🟢 `COMPATIBLE` | pass | merge |
+| 🟡 `COMPATIBLE_WITH_RISK` | configurable | review the deployment risk (e.g. new GLIBC requirement, `noexcept` removal) |
+| 🟠 `API_BREAK` | non-zero | intended? bump minor and document; else revert |
+| 🔴 `BREAKING` | non-zero | bump SONAME major, or revert the change |
+
+Ship your release builds **with debug info** (or feed abicheck the public
+headers) — the [transitive breaks](06-transitive-breaks.md) in Part 6 are
+invisible to any tool working from a stripped `.so` alone.
+
+---
+
+## You've finished the series
+
+You now have the full picture: how a library becomes a running process
+([Part 1](01-foundations.md)), the four families of break
+([Parts 2–5](02-symbol-contracts.md)), the ones that hide from code review
+([Part 6](06-transitive-breaks.md)), and the patterns that make a library
+evolvable (this page).
+
+**Where to go next:**
+
+- [ABI Cheat Sheet](../abi-cheat-sheet.md) — the 2-minute scannable card of all
+  of the above.
+- [Examples & Case Encyclopedia](../../examples/index.md) — every mechanism here
+  as a minimal, runnable v1/v2 reproduction with a real failure demo.
+- [Verdicts](../verdicts.md) & [Exit Codes](../../reference/exit-codes.md) — the
+  full classification and CI-integration semantics.
+- [Change Kind Reference](../../reference/change-kinds.md) — the authoritative,
+  always-current taxonomy of every detected change.
+
+*Back to the [series overview](../abi-api-handling.md).*

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -117,11 +117,11 @@ years through deep internal refactors. It also closes off
 [trivial→non-trivial](04-cpp-abi.md) surprises, because the public class's
 special members are declared once and pinned.
 
-> !!! warning "Pimpl gotcha"
->     Declare and *out-of-line define* the destructor (and move operations) in
->     the `.cpp` where `Impl` is complete. A defaulted destructor in the header
->     forces the compiler to see `Impl`'s definition there — defeating the
->     firewall.
+!!! warning "Pimpl gotcha"
+    Declare and *out-of-line define* the destructor (and move operations) in
+    the `.cpp` where `Impl` is complete. A defaulted destructor in the header
+    forces the compiler to see `Impl`'s definition there — defeating the
+    firewall.
 
 ---
 
@@ -316,5 +316,31 @@ evolvable (this page).
   full classification and CI-integration semantics.
 - [Change Kind Reference](../../reference/change-kinds.md) — the authoritative,
   always-current taxonomy of every detected change.
+
+---
+
+## Further reading (external, authoritative)
+
+The canonical primary sources behind this series. When a claim here matters for a
+real release decision, these are where to verify it:
+
+- **[KDE — Binary Compatibility Issues With C++](https://community.kde.org/Policies/Binary_Compatibility_Issues_With_C%2B%2B)**
+  — the most widely-cited practitioner checklist of what is and isn't binary-
+  compatible in C++. Pairs directly with Parts 3–4.
+- **[Itanium C++ ABI specification](https://itanium-cxx-abi.github.io/cxx-abi/abi.html)**
+  — the authority for vtable layout, name mangling, and the trivially-copyable
+  passing rules discussed in Part 4 (GCC/Clang on Linux/macOS/BSD).
+- **[GCC / libstdc++ ABI policy and guidelines](https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html)**
+  — symbol versioning, the `_GLIBCXX_USE_CXX11_ABI` dual-ABI, and library
+  versioning practice behind Parts 5–6.
+- **[Ulrich Drepper — *How To Write Shared Libraries*](https://www.akkadia.org/drepper/dsohowto.pdf)**
+  — the definitive treatment of ELF symbol resolution, visibility, versioning,
+  and TLS that underpins Parts 1, 2, and 5.
+- **Martin Reddy — *C++ API Design* (Morgan Kaufmann, 2011)** — book-length
+  treatment of the opaque-handle / Pimpl / versioning patterns in this page.
+- **[“20 ABI-breaking changes every C++ developer should know”](https://www.acodersjourney.com/20-abi-breaking-changes/)**
+  — a concise lay summary (MSVC/DLL-flavored); this series is a strict superset
+  of its checklist and additionally covers enums, unions, bitfields, alignment,
+  TLS, and transitive/dependency leaks.
 
 *Back to the [series overview](../abi-api-handling.md).*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,15 @@ nav:
     - Tool Comparison: reference/tool-comparison.md
     - ABICC Format Compliance: reference/abicc-format-compliance.md
   - ABI/API Handling & Recommendations:
-    - Guide: concepts/abi-api-handling.md
+    - Overview: concepts/abi-api-handling.md
+    - Learning Series:
+      - "1. Foundations": concepts/abi-series/01-foundations.md
+      - "2. Symbol Contracts": concepts/abi-series/02-symbol-contracts.md
+      - "3. Type Layout": concepts/abi-series/03-type-layout.md
+      - "4. C++ ABI": concepts/abi-series/04-cpp-abi.md
+      - "5. Linker & ELF": concepts/abi-series/05-linker-elf.md
+      - "6. Transitive Breaks": concepts/abi-series/06-transitive-breaks.md
+      - "7. Designing for Stability": concepts/abi-series/07-designing-for-stability.md
     - Examples Encyclopedia: examples/index.md
     - By Verdict:
       - "BREAKING": examples/by-verdict/breaking.md


### PR DESCRIPTION
## What & why

The [ABI/API Handling](https://napetrov.github.io/abicheck/concepts/abi-api-handling/) page was a single dense reference — accurate, but organized as a catalog tied to case numbers and abicheck's internal detector names, and it jumped straight into x86-64 register allocation with no on-ramp.

This PR reworks it into an **educational series** whose goal is to *teach* how ABI/API compatibility actually works — for developers **and** AI agents — using simple scenarios that explain how breakages happen and how to fix them. The examples now serve as teaching material, not just scanner validation.

## Structure

`concepts/abi-api-handling.md` becomes the **series hub / overview** (reading-path table, break-families-at-a-glance with per-part pointers, the one core mental model, and a flow diagram). The substantive content lives in seven progressive parts under `concepts/abi-series/`:

| Part | Page | Covers |
|------|------|--------|
| 1 | Foundations | source→object→link→load, what a symbol is, the dynamic loader, API vs ABI — **assumes no prior linker/loader knowledge** |
| 2 | Symbol Contracts | removal/rename, signatures, pointer level, exported globals (COPY relocations) |
| 3 | Type Layout | struct size/offset, alignment/packing, enums, unions, bitfields, pointer/array element types |
| 4 | C++ ABI | vtables, mangled qualifiers, templates/inline, inline namespaces, `noexcept`, trivial→non-trivial, base layout |
| 5 | Linker & ELF | SONAME, visibility, symbol versioning, calling conventions, security metadata, language linkage, TLS |
| 6 | Transitive Breaks | dependency leaks, anonymous structs, type-kind swaps, reserved-field misuse, embedded leaf structs |
| 7 | Designing for Stability | opaque handles, Pimpl, reserved padding, version scripts, inline-namespace generations, CI gating — with full copy-pasteable code |

## Approach (per the requested direction)

- **From fundamentals** — Part 1 builds the mental model from zero before any break is discussed.
- **Mechanism → minimal scenario → how-to-fix** — each part explains *why* a change corrupts memory, shows a small v1/v2 diff, and ends with design patterns.
- **abicheck references kept inline** — verdicts and change kinds appear as "How abicheck sees it" callouts, and every break links to its runnable example case.
- Mermaid diagrams and admonitions used for the build pipeline, loader flow, COPY relocations, and the series map.

## Validation

- `mkdocs build --strict` passes (no broken internal links, no nav orphans).
- `python scripts/check_ai_readiness.py` reports **0 errors** (pre-existing warnings only).
- All seven pages wired into `mkdocs.yml` nav under a new **Learning Series** subsection; the ChangeKind count (184) and example references remain accurate.

https://claude.ai/code/session_01FqyFGPK6o3aDBS3bu453y9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqyFGPK6o3aDBS3bu453y9)_