### PR TITLE
Filter Go runtime DWARF type churn

### DIFF
--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -68,6 +68,8 @@ _GO_RUNTIME_TYPE_PREFIXES: tuple[str, ...] = (
     "internal/",
     "go.shape.",
     "noalg.",
+)
+_GO_GENERIC_RUNTIME_TYPE_PREFIXES: tuple[str, ...] = (
     "hchan<",
     "sudog<",
     "map<",
@@ -83,6 +85,7 @@ _GO_EMBEDDED_MARKERS: tuple[str, ...] = (
     "sync.",
     "strconv.",
 )
+_GO_GENERIC_RUNTIME_MARKERS: tuple[str, ...] = ("/", ".")
 
 # Substrings that mark an anonymous / local type with no stable cross-version
 # ABI identity — lambdas and unnamed struct/union/enum (validation/REPORT.md
@@ -117,6 +120,10 @@ def is_non_abi_surface_type(name: str, *, exclude_stdlib_namespaces: bool = True
     if (
         name.startswith(_GO_RUNTIME_TYPE_PREFIXES)
         or go_candidate.startswith(_GO_RUNTIME_TYPE_PREFIXES)
+        or (
+            go_candidate.startswith(_GO_GENERIC_RUNTIME_TYPE_PREFIXES)
+            and any(marker in go_candidate for marker in _GO_GENERIC_RUNTIME_MARKERS)
+        )
         or "/" in name
         or _GO_PACKAGE_QUALIFIED_RE.match(go_candidate)
         or (

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -58,6 +58,32 @@ _STDLIB_TYPE_NAMESPACE_PREFIXES: tuple[str, ...] = (
     "std::", "__gnu_cxx::", "__gnu_debug::", "__cxxabiv1::", "__cxx11::",
 )
 
+# Go c-shared libraries embed DWARF for the Go runtime and internal packages.
+# Those implementation types are not part of the C ABI exposed through the
+# shared object's dynamic symbol table; comparing their layouts across Go
+# toolchain releases produces the same sort of runtime-owned noise as std::
+# layout churn in C++ consumers.
+_GO_RUNTIME_TYPE_PREFIXES: tuple[str, ...] = (
+    "runtime.",
+    "internal/",
+    "go.shape.",
+    "noalg.",
+    "hchan<",
+    "sudog<",
+    "map<",
+    "table<",
+    "groupReference<",
+)
+_GO_PACKAGE_QUALIFIED_RE = _re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+")
+_GO_EMBEDDED_MARKERS: tuple[str, ...] = (
+    "runtime.",
+    "go.shape.",
+    "internal/",
+    "main.",
+    "sync.",
+    "strconv.",
+)
+
 # Substrings that mark an anonymous / local type with no stable cross-version
 # ABI identity — lambdas and unnamed struct/union/enum (validation/REPORT.md
 # FP-2). gcc renders these as "<lambda...>", "{lambda...}", "(anonymous ...)";
@@ -86,6 +112,18 @@ def is_non_abi_surface_type(name: str, *, exclude_stdlib_namespaces: bool = True
     if name in COMPILER_INTERNAL_TYPES:
         return True
     if exclude_stdlib_namespaces and name.startswith(_STDLIB_TYPE_NAMESPACE_PREFIXES):
+        return True
+    go_candidate = name[2:] if name.startswith("[]") else name
+    if (
+        name.startswith(_GO_RUNTIME_TYPE_PREFIXES)
+        or go_candidate.startswith(_GO_RUNTIME_TYPE_PREFIXES)
+        or "/" in name
+        or _GO_PACKAGE_QUALIFIED_RE.match(go_candidate)
+        or (
+            go_candidate.startswith("struct {")
+            and any(marker in go_candidate for marker in _GO_EMBEDDED_MARKERS)
+        )
+    ):
         return True
     return any(marker in name for marker in _ANONYMOUS_TYPE_MARKERS)
 

--- a/tests/test_bugfix_regressions.py
+++ b/tests/test_bugfix_regressions.py
@@ -26,6 +26,7 @@ from abicheck.model import (
     TypeField,
     Variable,
     Visibility,
+    is_non_abi_surface_type,
 )
 from abicheck.report_summary import build_summary, compatibility_metrics
 
@@ -112,6 +113,16 @@ class TestGoRuntimeDwarfNoise:
 
         assert result.verdict is Verdict.NO_CHANGE
         assert not any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in result.changes)
+
+    def test_global_cpp_map_template_type_is_kept(self):
+        old = _snap(types=[RecordType(name="map<int,int>", kind="struct", size_bits=64)])
+        new = _snap("2.0", types=[RecordType(name="map<int,int>", kind="struct", size_bits=128)])
+
+        result = compare(old, new)
+
+        assert is_non_abi_surface_type("map<int,int>") is False
+        assert result.verdict is Verdict.BREAKING
+        assert any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in result.changes)
 
 
 # ── Bug 1: Enum symbols use member-qualified format ──────────────────────────

--- a/tests/test_bugfix_regressions.py
+++ b/tests/test_bugfix_regressions.py
@@ -22,6 +22,8 @@ from abicheck.model import (
     Function,
     Param,
     ParamKind,
+    RecordType,
+    TypeField,
     Variable,
     Visibility,
 )
@@ -51,6 +53,65 @@ def _pub_func(name: str, mangled: str, ret: str = "void", params=None) -> Functi
 
 def _pub_var(name: str) -> Variable:
     return Variable(name=name, mangled=name, type="int", visibility=Visibility.PUBLIC)
+
+
+class TestGoRuntimeDwarfNoise:
+    """Go runtime/internal DWARF types are not the exported C ABI surface."""
+
+    def test_go_runtime_type_churn_does_not_break_c_shared_library(self):
+        old = _snap(
+            funcs=[_pub_func("AdbcDriverInit", "AdbcDriverInit")],
+            types=[
+                RecordType(
+                    name="runtime.g",
+                    kind="struct",
+                    size_bits=3520,
+                    fields=[TypeField(name="goid", type="uint64", offset_bits=1280)],
+                ),
+                RecordType(
+                    name="internal/abi.SwissMapType",
+                    kind="struct",
+                    size_bits=64,
+                ),
+                RecordType(
+                    name="google.golang.org/grpc/internal/channelz.Identifier",
+                    kind="struct",
+                    size_bits=128,
+                ),
+                RecordType(
+                    name="map<net/http.http2FrameType,string>",
+                    kind="struct",
+                    size_bits=256,
+                ),
+            ],
+        )
+        new = _snap(
+            "2.0",
+            funcs=[_pub_func("AdbcDriverInit", "AdbcDriverInit")],
+            types=[
+                RecordType(
+                    name="runtime.g",
+                    kind="struct",
+                    size_bits=3648,
+                    fields=[TypeField(name="goid", type="uint64", offset_bits=1216)],
+                ),
+                RecordType(
+                    name="google.golang.org/grpc/internal/channelz.Identifier",
+                    kind="struct",
+                    size_bits=192,
+                ),
+                RecordType(
+                    name="map<net/http.http2FrameType,string>",
+                    kind="struct",
+                    size_bits=320,
+                ),
+            ],
+        )
+
+        result = compare(old, new)
+
+        assert result.verdict is Verdict.NO_CHANGE
+        assert not any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in result.changes)
 
 
 # ── Bug 1: Enum symbols use member-qualified format ──────────────────────────


### PR DESCRIPTION
## Summary
- filter Go runtime/internal/package DWARF type names out of the ABI type surface, matching the existing treatment for runtime-owned C++ stdlib types
- add a regression test for c-shared Go libraries where exported C ABI is unchanged but Go runtime/package DWARF layouts churn

## Real-world validation
- ADBC BigQuery driver 1.10.0 -> 1.11.0 originally reported BREAKING with 3354 breaking changes from Go runtime/internal/package DWARF types and no removed dynamic exports
- abidiff only reported SONAME changed from libadbc_driver_bigquery.so.110 to .111
- after the fix, the same comparison reports COMPATIBLE with 0 breaking changes and only compatible additions/SONAME policy notes
- evidence: /home/openclaw/.openclaw/workspace-abicheck/reports/abicheck-realworld-cron/artifacts/20260606-1019/runs/LIBADBC-DRIVER-BIGQUERY_1.10.0_TO_1.11.0__libadbc-driver-bigquery.after-fix3.json

## Tests
- pytest -q tests/test_bugfix_regressions.py::TestGoRuntimeDwarfNoise
- pytest -q tests/test_bugfix_regressions.py::TestGoRuntimeDwarfNoise tests/test_internal_leak.py::TestIsInternalType tests/test_detector_oracle.py
