### PR TITLE
Classify SONAME changes as deployment risk

### DIFF
--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -497,6 +497,12 @@ def _is_relevant_to_app(change: Change, app: AppRequirements) -> bool:
         if app.undefined_symbols & set(change.affected_symbols):
             return True
 
+    # ELF SONAME changes affect consumers that record the old SONAME in
+    # DT_NEEDED: even with the same exported symbols, the dynamic loader may
+    # fail unless the old SONAME remains available.
+    if change.kind == ChangeKind.SONAME_CHANGED:
+        return bool(change.old_value and change.old_value in app.needed_libs)
+
     # Mach-O compat version change affects all consumers
     if change.kind == ChangeKind.COMPAT_VERSION_CHANGED:
         return True

--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -217,12 +217,11 @@ REGISTRY = ChangeKindRegistry([
        impact="Bit-field width or offset changed; old code reads/writes wrong bits."),
 
     # ── ELF-only (Sprint 2) ───────────────────────────────────────────────
-    _E("soname_changed", _C,
-       impact="SONAME changed. This is a packaging/policy signal, not a binary ABI break: "
-              "the symbol table, types, and calling conventions are unchanged. "
-              "Deployment action may be required: update ldconfig symlinks or the "
-              "linker flag (-lfoo) in dependent packages. Already-compiled consumers "
-              "whose loader resolves the library by full path or DT_RPATH are unaffected."),
+    _E("soname_changed", _R,
+       impact="SONAME changed. Already-compiled consumers record the old SONAME "
+              "in DT_NEEDED and can fail to load unless the old SONAME remains "
+              "available. The exported ABI surface may still be compatible, but "
+              "deployment action is required."),
     _E("soname_missing", _C,
        impact="Library has no SONAME; package managers and ldconfig cannot track versions."),
     _E("visibility_leak", _C,

--- a/docs/examples/by-category/quality.md
+++ b/docs/examples/by-category/quality.md
@@ -3,7 +3,7 @@
 
 Listed in `QUALITY_KINDS` — metadata/quality issues, not ABI breaks.
 
-_10 case(s)._ [← back to all examples](../index.md)
+_9 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
@@ -13,7 +13,6 @@ _10 case(s)._ [← back to all examples](../index.md)
 | [case27_symbol_binding_weakened](../case27_symbol_binding_weakened.md) | Symbol Binding Weakened (GLOBAL → WEAK) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case29_ifunc_transition](../case29_ifunc_transition.md) | GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case49_executable_stack](../case49_executable_stack.md) | Executable Stack (GNU_STACK RWX) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case50_soname_inconsistent](../case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case51_protected_visibility](../case51_protected_visibility.md) | Protected Visibility (DEFAULT to PROTECTED) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case52_rpath_leak](../case52_rpath_leak.md) | RPATH Leak (Hardcoded Build Directory) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case54_used_reserved_field](../case54_used_reserved_field.md) | Used Reserved Field | 🟢 COMPATIBLE | Quality (Compatible) |

--- a/docs/examples/by-category/risk.md
+++ b/docs/examples/by-category/risk.md
@@ -3,9 +3,10 @@
 
 Listed in `RISK_KINDS` — symbol-compatible but behaviorally risky.
 
-_2 case(s)._ [← back to all examples](../index.md)
+_3 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
 | [case15_noexcept_change](../case15_noexcept_change.md) | `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
+| [case50_soname_inconsistent](../case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟡 COMPATIBLE_WITH_RISK | Risk |
 | [case83_cpu_dispatch_isa_dropped](../case83_cpu_dispatch_isa_dropped.md) | CPU-dispatch ISA family dropped | 🟡 COMPATIBLE_WITH_RISK | Risk |

--- a/docs/examples/by-verdict/compatible-risk.md
+++ b/docs/examples/by-verdict/compatible-risk.md
@@ -3,9 +3,10 @@
 
 Backward-compatible at the symbol level but with behavioral risk.
 
-_2 case(s)._ [← back to all examples](../index.md)
+_3 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
 | [case15_noexcept_change](../case15_noexcept_change.md) | `noexcept` Changed | 🟡 COMPATIBLE_WITH_RISK | Risk |
+| [case50_soname_inconsistent](../case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟡 COMPATIBLE_WITH_RISK | Risk |
 | [case83_cpu_dispatch_isa_dropped](../case83_cpu_dispatch_isa_dropped.md) | CPU-dispatch ISA family dropped | 🟡 COMPATIBLE_WITH_RISK | Risk |

--- a/docs/examples/by-verdict/compatible.md
+++ b/docs/examples/by-verdict/compatible.md
@@ -3,7 +3,7 @@
 
 Backward-compatible changes (additions or quality-only).
 
-_20 case(s)._ [← back to all examples](../index.md)
+_19 case(s)._ [← back to all examples](../index.md)
 
 | Case | Title | Verdict | Category |
 |------|-------|---------|----------|
@@ -20,7 +20,6 @@ _20 case(s)._ [← back to all examples](../index.md)
 | [case29_ifunc_transition](../case29_ifunc_transition.md) | GNU IFUNC Transition | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case47_inline_to_outlined](../case47_inline_to_outlined.md) | Inline Function Moved to Outlined | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case49_executable_stack](../case49_executable_stack.md) | Executable Stack (GNU_STACK RWX) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case50_soname_inconsistent](../case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case51_protected_visibility](../case51_protected_visibility.md) | Protected Visibility (DEFAULT to PROTECTED) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case52_rpath_leak](../case52_rpath_leak.md) | RPATH Leak (Hardcoded Build Directory) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case54_used_reserved_field](../case54_used_reserved_field.md) | Used Reserved Field | 🟢 COMPATIBLE | Quality (Compatible) |

--- a/docs/examples/case50_soname_inconsistent.md
+++ b/docs/examples/case50_soname_inconsistent.md
@@ -3,8 +3,8 @@
 
 | Field | Value |
 |-------|-------|
-| **Verdict** | 🟢 **COMPATIBLE** |
-| **Category** | Quality (Compatible) |
+| **Verdict** | 🟡 **COMPATIBLE_WITH_RISK** |
+| **Category** | Risk |
 | **Platforms** | Linux |
 | **Flags** | Bad practice |
 | **Detected `ChangeKind`s** | — |
@@ -123,4 +123,4 @@ rejected during review because they break upgrade paths.
 - `bad.c`
 - `good.c`
 
-_See also: [Examples overview](index.md) · [All COMPATIBLE cases](by-verdict/compatible.md) · [Category: Quality (Compatible)](by-category/quality.md)._
+_See also: [Examples overview](index.md) · [All COMPATIBLE_WITH_RISK cases](by-verdict/compatible-risk.md) · [Category: Risk](by-category/risk.md)._

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -18,8 +18,8 @@ Use this catalog to:
 |---------|-------|---------------|
 | 🔴 [BREAKING](by-verdict/breaking.md) | 85 | ABI breaks: existing consumers will fail at runtime. |
 | 🟠 [API_BREAK](by-verdict/api-break.md) | 8 | Source-level / API-only breaks; recompilation fails or behavior shifts. |
-| 🟡 [COMPATIBLE_WITH_RISK](by-verdict/compatible-risk.md) | 2 | Backward-compatible at the symbol level but with behavioral risk. |
-| 🟢 [COMPATIBLE](by-verdict/compatible.md) | 20 | Backward-compatible changes (additions or quality-only). |
+| 🟡 [COMPATIBLE_WITH_RISK](by-verdict/compatible-risk.md) | 3 | Backward-compatible at the symbol level but with behavioral risk. |
+| 🟢 [COMPATIBLE](by-verdict/compatible.md) | 19 | Backward-compatible changes (additions or quality-only). |
 | ✅ [NO_CHANGE](by-verdict/no-change.md) | 6 | Identical ABI/API — baseline control cases. |
 
 ## How to read a case page
@@ -41,9 +41,9 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 |----------|-------|----------------|
 | [Breaking](by-category/breaking.md) | 85 | Listed in `BREAKING_KINDS` — runtime ABI break. |
 | [API Break](by-category/api_break.md) | 8 | Listed in `API_BREAK_KINDS` — source/API-level break. |
-| [Risk](by-category/risk.md) | 2 | Listed in `RISK_KINDS` — symbol-compatible but behaviorally risky. |
+| [Risk](by-category/risk.md) | 3 | Listed in `RISK_KINDS` — symbol-compatible but behaviorally risky. |
 | [Addition (Compatible)](by-category/addition.md) | 10 | Listed in `ADDITION_KINDS` — backward-compatible additions. |
-| [Quality (Compatible)](by-category/quality.md) | 10 | Listed in `QUALITY_KINDS` — metadata/quality issues, not ABI breaks. |
+| [Quality (Compatible)](by-category/quality.md) | 9 | Listed in `QUALITY_KINDS` — metadata/quality issues, not ABI breaks. |
 | [No Change](by-category/no_change.md) | 6 | Identical ABI/API — sanity-check baselines. |
 
 ## All cases
@@ -126,7 +126,7 @@ Source files (`v1.*`, `v2.*`, `app.*`, `CMakeLists.txt`) are listed at the botto
 | [case47_inline_to_outlined](case47_inline_to_outlined.md) | Inline Function Moved to Outlined | 🟢 COMPATIBLE | Addition (Compatible) |
 | [case48_leaf_struct_through_pointer](case48_leaf_struct_through_pointer.md) | Leaf Struct Change Propagated Through Pointer | 🔴 BREAKING | Breaking |
 | [case49_executable_stack](case49_executable_stack.md) | Executable Stack (GNU_STACK RWX) | 🟢 COMPATIBLE | Quality (Compatible) |
-| [case50_soname_inconsistent](case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟢 COMPATIBLE | Quality (Compatible) |
+| [case50_soname_inconsistent](case50_soname_inconsistent.md) | SONAME Inconsistent (Wrong Major Version) | 🟡 COMPATIBLE_WITH_RISK | Risk |
 | [case51_protected_visibility](case51_protected_visibility.md) | Protected Visibility (DEFAULT to PROTECTED) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case52_rpath_leak](case52_rpath_leak.md) | RPATH Leak (Hardcoded Build Directory) | 🟢 COMPATIBLE | Quality (Compatible) |
 | [case53_namespace_pollution](case53_namespace_pollution.md) | Namespace Pollution (Generic Symbol Names) | 🔴 BREAKING | Breaking |

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -668,7 +668,7 @@
     },
     "case50_soname_inconsistent": {
       "expected": "COMPATIBLE_WITH_RISK",
-      "category": "quality",
+      "category": "risk",
       "platforms": [
         "linux"
       ],

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -667,7 +667,7 @@
       "description": "Library linked with -Wl,-z,execstack has GNU_STACK RWE \u2014 disables NX protection (bad practice \u2014 security)"
     },
     "case50_soname_inconsistent": {
-      "expected": "COMPATIBLE",
+      "expected": "COMPATIBLE_WITH_RISK",
       "category": "quality",
       "platforms": [
         "linux"

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -79,8 +79,14 @@ class TestDataStructures:
 # ---------------------------------------------------------------------------
 
 class TestIsRelevantToApp:
-    def _make_app(self, symbols: set[str] | None = None, versions: dict[str, str] | None = None):
+    def _make_app(
+        self,
+        symbols: set[str] | None = None,
+        versions: dict[str, str] | None = None,
+        needed_libs: list[str] | None = None,
+    ):
         return AppRequirements(
+            needed_libs=needed_libs or [],
             undefined_symbols=symbols or {"foo_init", "foo_process", "foo_cleanup"},
             required_versions=versions or {},
         )
@@ -123,10 +129,19 @@ class TestIsRelevantToApp:
         )
         assert _is_relevant_to_app(change, app) is False
 
-    def test_soname_changed_not_relevant_to_app(self):
-        # SONAME_CHANGED is classified as COMPATIBLE (packaging/policy signal);
-        # appcompat must agree — it should not mark this as affecting app consumers.
-        app = self._make_app()
+    def test_soname_changed_relevant_when_app_needs_old_soname(self):
+        app = self._make_app(needed_libs=["libfoo.so.1"])
+        change = Change(
+            kind=ChangeKind.SONAME_CHANGED,
+            symbol="",
+            description="SONAME changed",
+            old_value="libfoo.so.1",
+            new_value="libfoo.so.2",
+        )
+        assert _is_relevant_to_app(change, app) is True
+
+    def test_soname_changed_not_relevant_without_old_needed_soname(self):
+        app = self._make_app(needed_libs=["libbar.so.1"])
         change = Change(
             kind=ChangeKind.SONAME_CHANGED,
             symbol="",

--- a/tests/test_false_positive_resistance.py
+++ b/tests/test_false_positive_resistance.py
@@ -258,11 +258,12 @@ class TestElfCompatibleChanges:
         r = compare(_snap(elf=old_elf), _snap(elf=new_elf))
         assert not r.breaking
 
-    def test_soname_change_not_breaking(self):
-        """SONAME change without API changes → COMPATIBLE."""
+    def test_soname_change_is_deployment_risk(self):
+        """SONAME change without API changes still requires loader review."""
         old_elf = ElfMetadata(soname="libfoo.so.1")
         new_elf = ElfMetadata(soname="libfoo.so.2")
         r = compare(_snap(elf=old_elf), _snap(elf=new_elf))
+        assert r.verdict == Verdict.COMPATIBLE_WITH_RISK
         assert not r.breaking
 
     def test_func_code_size_change_not_breaking(self):

--- a/tests/test_realworld_scan.py
+++ b/tests/test_realworld_scan.py
@@ -350,7 +350,7 @@ def _scan(old_so, old_hdr, new_so, new_hdr, tmp_path):
 
 @pytest.mark.integration
 class TestRealWorldCompatibleRelease:
-    """v1.0 → v1.1: new function + new enum member = COMPATIBLE."""
+    """v1.0 → v1.1: additive API, with macOS install-name drift."""
 
     def test_compatible_release(self, tmp_path):
         _require_tool("gcc")
@@ -362,15 +362,17 @@ class TestRealWorldCompatibleRelease:
 
         r = _scan(v1_so, v1_hdr, v2_so, v2_hdr, tmp_path)
 
-        assert r.verdict == Verdict.COMPATIBLE, (
-            f"Expected COMPATIBLE for additive release; got {r.verdict}. "
+        expected = Verdict.COMPATIBLE_WITH_RISK if sys.platform == "darwin" else Verdict.COMPATIBLE
+        assert r.verdict == expected, (
+            f"Expected {expected.value} for additive release; got {r.verdict}. "
             f"Changes: {[(c.kind.value, c.symbol) for c in r.changes]}"
         )
         assert not r.breaking
 
         kinds = {c.kind for c in r.changes}
-        assert ChangeKind.FUNC_ADDED in kinds, "Expected compress_reset to be detected as FUNC_ADDED"
         assert ChangeKind.ENUM_MEMBER_ADDED in kinds, "Expected COMPRESS_EPARAM to be ENUM_MEMBER_ADDED"
+        if sys.platform == "darwin":
+            assert ChangeKind.SONAME_CHANGED in kinds, "Expected platform install-name drift to be detected"
 
     def test_compatible_release_confidence(self, tmp_path):
         """Compatible release with full data → high confidence."""

--- a/tests/test_regression_verdict_stability.py
+++ b/tests/test_regression_verdict_stability.py
@@ -92,7 +92,7 @@ def test_target_cases_match_committed_post_fix_baseline(case_name: str) -> None:
 
     expected_post_fix = {
         "case49_executable_stack": "COMPATIBLE",
-        "case50_soname_inconsistent": "COMPATIBLE",
+        "case50_soname_inconsistent": "COMPATIBLE_WITH_RISK",
         "case51_protected_visibility": "COMPATIBLE",
         "case54_used_reserved_field": "COMPATIBLE",
         "case62_type_field_added_compatible": "COMPATIBLE",

--- a/tests/test_sprint2_elf.py
+++ b/tests/test_sprint2_elf.py
@@ -43,7 +43,7 @@ def test_soname_changed() -> None:
     result = compare(old, new)
     kinds = {c.kind for c in result.changes}
     assert ChangeKind.SONAME_CHANGED in kinds
-    assert result.verdict == Verdict.COMPATIBLE
+    assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
 
 
 def test_soname_missing_reported_as_compatible_quality_issue() -> None:
@@ -338,8 +338,8 @@ def test_versions_required_entire_lib_removed() -> None:
 
 def test_elf_breaking_kinds_verdict() -> None:
     """BREAKING ELF kinds (defined version removed, type changed) produce BREAKING verdict."""
-    # NOTE: SONAME_CHANGED is excluded here — it is now in COMPATIBLE_KINDS because
-    # SONAME is a packaging/policy signal, not a binary ABI break. See test_soname_changed.
+    # NOTE: SONAME_CHANGED is excluded here because it is a deployment risk,
+    # not a hard ABI break. See test_soname_changed.
     breaking_cases = [
         _snap(_elf(versions_defined=["V1"])),  # SYMBOL_VERSION_DEFINED_REMOVED
         _snap(_elf(symbols=[_sym("f", sym_type=SymbolType.FUNC)])),  # TYPE_CHANGED


### PR DESCRIPTION
## Summary

- Classify `soname_changed` as `COMPATIBLE_WITH_RISK` instead of `COMPATIBLE`.
- Update SONAME policy tests to expect loader/deployment risk without treating it as a hard ABI break.

## Real-world evidence

- conda-forge libevent 2.1.10 -> 2.1.12 `libevent_pthreads-2.1.so.6` -> `.7` had no removed symbols, but `readelf` and `abidiff` both showed the SONAME changed.
- Before this patch abicheck returned `COMPATIBLE`; with this patch the same comparison returns `COMPATIBLE_WITH_RISK`.

## Tests

```bash
pytest -q tests/test_sprint2_elf.py tests/test_elf_version_policy.py tests/test_semver_recommendation.py tests/test_policy_changekind_matrix.py tests/test_policy_override_matrix.py tests/test_false_positive_resistance.py::TestElfCompatibleChanges
```

