### PR TITLE
docs: act on ABI/API guide review — cross-platform, API-only, glossary

### DIFF
--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -18,7 +18,24 @@ when it sees one.
 > [ABI Cheat Sheet](abi-cheat-sheet.md). For per-case runnable reproductions with
 > code and a real failure demo, see the
 > [Examples & Case Encyclopedia](../examples/index.md). For verdict semantics and
-> CI exit codes, see [Verdicts](verdicts.md).
+> CI exit codes, see [Verdicts](verdicts.md). For unfamiliar terms (SONAME,
+> vtable, IFUNC, install name, TLS model…), see the
+> [Glossary](abi-series/glossary.md).
+
+!!! note "Scope & assumptions"
+    - **Examples are mostly ELF/Linux and Itanium-C++-ABI flavored** unless a
+      section says otherwise. PE/COFF (Windows) and Mach-O (macOS) have their own
+      loader, export, and versioning rules — see the per-platform parallels in
+      [Part 5](abi-series/05-linker-elf.md#pecoff-and-mach-o-parallels) and the
+      [Platform Support reference](../reference/platforms.md). For example, the
+      "lookup by name" model in Part 2 is exact for ELF and for most C/C++
+      exports, but **Windows DLLs can also export/import by ordinal**, where the
+      contract is a *number*, not a name.
+    - **Detectability depends on the inputs you give abicheck** — symbols only,
+      DWARF/PDB debug info, or public headers. Some changes (e.g. `#define`
+      macros, inline/template *bodies*, uninstantiated templates) are invisible
+      to *any* artifact comparison. See the per-change matrix in
+      [Limitations](limitations.md#source-only-changes-invisible-to-binaryobject-analysis).
 
 ---
 
@@ -59,25 +76,29 @@ typical classification; the exact verdict per fixture lives in
 `examples/ground_truth.json` and the [Examples Encyclopedia](../examples/index.md).
 The **Part** column points to where the mechanism is explained.
 
+Case numbers link straight to the generated example page; the **Typical verdict**
+column says "mixed" where the verdict is case-dependent (the per-fixture verdict
+is the source of truth).
+
 | Family | Representative cases | Typical verdict | Explained in |
 |--------|---------------------|-----------------|--------------|
-| Symbol/function removal & rename | 01, 12, 58, 66 | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
-| Signature changes (params, return, pointer level) | 02, 10, 33, 46 | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
-| Global variable type/qualifier/removal | 11, 39, 58 | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
-| Struct/class layout, alignment & packing | 07, 14, 40, 42, 43, 56, 117 | 🔴 BREAKING | [Part 3](abi-series/03-type-layout.md) |
-| Enum value/underlying changes | 08, 19, 20, 57 | 🔴 BREAKING | [Part 3](abi-series/03-type-layout.md) |
-| Union layout | 24, 26 (grows) · 26b (no growth) | 🔴 / 🟢 | [Part 3](abi-series/03-type-layout.md) |
-| C++ vtable & virtual methods | 09, 23, 38, 68, 72 | 🔴 BREAKING | [Part 4](abi-series/04-cpp-abi.md) |
-| C++ qualifiers, mangling & ABI tags | 21, 22, 30, 71, 86, 101, 113 | 🔴 / 🟠 | [Part 4](abi-series/04-cpp-abi.md) |
-| Trivial → non-trivial (calling convention) | 64, 69 | 🔴 BREAKING | [Part 4](abi-series/04-cpp-abi.md) |
-| Templates, inline & ODR | 16, 17, 47, 59, 79, 85, 87 | 🔴 / 🟢 | [Part 4](abi-series/04-cpp-abi.md) |
-| Modern C/C++ contract shifts (char8_t, _BitInt, _Atomic, concepts) | 105, 114, 115, 116 | 🔴 / 🟢 | [Part 4](abi-series/04-cpp-abi.md) |
-| ELF/linker metadata (SONAME, visibility, versioning, RPATH, TLS) | 05, 06, 13, 49, 51, 52, 65, 67 | 🔴 / 🟢 | [Part 5](abi-series/05-linker-elf.md) |
-| Transitive/dependency & `detail::` leaks | 18, 48, 74–77, 80, 97, 104, 112 | 🔴 BREAKING | [Part 6](abi-series/06-transitive-breaks.md) |
-| Source-only / API-level (rename, access, explicit) | 31, 34, 96, 106 | 🟠 API_BREAK | [Parts 4](abi-series/04-cpp-abi.md) & [6](abi-series/06-transitive-breaks.md) |
-| Deployment risk (noexcept, ISA dispatch, version-require) | 15, 83 | 🟡 COMPATIBLE_WITH_RISK | [Part 4](abi-series/04-cpp-abi.md) |
-| Compatible additions & quality signals | 03, 25, 26b, 27, 29, 61, 62, 99 | 🟢 COMPATIBLE | [Part 7](abi-series/07-designing-for-stability.md) |
-| Scoped/non-public internal changes | 118, 119, 120 | ✅ NO_CHANGE | [Part 6](abi-series/06-transitive-breaks.md) |
+| Symbol/function removal & rename | [01](../examples/case01_symbol_removal.md), [12](../examples/case12_function_removed.md), [58](../examples/case58_var_removed.md), [66](../examples/case66_language_linkage_changed.md) | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
+| Signature changes (params, return, pointer level) | [02](../examples/case02_param_type_change.md), [10](../examples/case10_return_type.md), [33](../examples/case33_pointer_level.md), [46](../examples/case46_pointer_chain_type_change.md) | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
+| Global variable type/qualifier/removal | [11](../examples/case11_global_var_type.md), [39](../examples/case39_var_const.md), [58](../examples/case58_var_removed.md) | 🔴 BREAKING | [Part 2](abi-series/02-symbol-contracts.md) |
+| Struct/class layout, alignment & packing | [07](../examples/case07_struct_layout.md), [14](../examples/case14_cpp_class_size.md), [40](../examples/case40_field_layout.md), [42](../examples/case42_type_alignment_changed.md), [43](../examples/case43_base_class_member_added.md), [56](../examples/case56_struct_packing_changed.md), [117](../examples/case117_no_unique_address.md) | 🔴 BREAKING | [Part 3](abi-series/03-type-layout.md) |
+| Enum value/underlying changes | [08](../examples/case08_enum_value_change.md), [19](../examples/case19_enum_member_removed.md), [20](../examples/case20_enum_member_value_changed.md), [57](../examples/case57_enum_underlying_size_changed.md) | 🔴 BREAKING | [Part 3](abi-series/03-type-layout.md) |
+| Union layout | [24](../examples/case24_union_field_removed.md), [26](../examples/case26_union_field_added.md) (grows) · [26b](../examples/case26b_union_field_added_compatible.md) (no growth) | mixed — 🔴 if size grows, else 🟢 | [Part 3](abi-series/03-type-layout.md) |
+| C++ vtable & virtual methods | [09](../examples/case09_cpp_vtable.md), [23](../examples/case23_pure_virtual_added.md), [38](../examples/case38_virtual_methods.md), [68](../examples/case68_virtual_method_added.md), [72](../examples/case72_covariant_return_changed.md) | 🔴 BREAKING | [Part 4](abi-series/04-cpp-abi.md) |
+| C++ qualifiers, mangling & ABI tags | [21](../examples/case21_method_became_static.md), [22](../examples/case22_method_const_changed.md), [30](../examples/case30_field_qualifiers.md), [71](../examples/case71_inline_namespace_moved.md), [86](../examples/case86_tag_struct_renamed.md), [101](../examples/case101_inline_namespace_version_bumped.md), [113](../examples/case113_abi_tag_changed.md) | mixed — 🔴 BREAKING or 🟠 API_BREAK | [Part 4](abi-series/04-cpp-abi.md) |
+| Trivial → non-trivial (calling convention) | [64](../examples/case64_calling_convention_changed.md), [69](../examples/case69_trivial_to_nontrivial.md) | 🔴 BREAKING | [Part 4](abi-series/04-cpp-abi.md) |
+| Templates, inline & ODR | [16](../examples/case16_inline_to_non_inline.md), [17](../examples/case17_template_abi.md), [47](../examples/case47_inline_to_outlined.md), [59](../examples/case59_func_became_inline.md), [79](../examples/case79_missing_template_instantiation.md), [85](../examples/case85_internal_template_signature_changed.md), [87](../examples/case87_default_template_arg_changed.md) | mixed — 🔴 BREAKING or 🟢 COMPATIBLE | [Part 4](abi-series/04-cpp-abi.md) |
+| Modern C/C++ contract shifts (char8_t, _BitInt, _Atomic, concepts) | [105](../examples/case105_concept_tightening.md), [114](../examples/case114_char8t_migration.md), [115](../examples/case115_bit_int_width_changed.md), [116](../examples/case116_atomic_qualifier_changed.md) | mixed — 🔴 BREAKING or 🟢 COMPATIBLE | [Part 4 §Modern](abi-series/04-cpp-abi.md#modern-cc-and-toolchain-abi-hazards) |
+| ELF/linker metadata (SONAME, visibility, versioning, RPATH, TLS) | [05](../examples/case05_soname.md), [06](../examples/case06_visibility.md), [13](../examples/case13_symbol_versioning.md), [49](../examples/case49_executable_stack.md), [51](../examples/case51_protected_visibility.md), [52](../examples/case52_rpath_leak.md), [65](../examples/case65_symbol_version_removed.md), [67](../examples/case67_tls_var_size_changed.md) | mixed — 🔴 BREAKING or 🟢 COMPATIBLE | [Part 5](abi-series/05-linker-elf.md) |
+| Transitive/dependency & `detail::` leaks | [18](../examples/case18_dependency_leak.md), [48](../examples/case48_leaf_struct_through_pointer.md), [74](../examples/case74_detail_base_class_changed.md), [75](../examples/case75_detail_embedded_by_value.md), [76](../examples/case76_detail_pimpl_vtable_changed.md), [77](../examples/case77_detail_templated_base_changed.md), [80](../examples/case80_pimpl_shared_to_unique.md), [97](../examples/case97_api_depends_on_consumer_env.md), [104](../examples/case104_glibcxx_dual_abi_flip.md), [112](../examples/case112_lp64_ilp64.md) | 🔴 BREAKING | [Part 6](abi-series/06-transitive-breaks.md) |
+| Source-only / API-level (rename, access, explicit, default args, hidden friends) | [31](../examples/case31_enum_rename.md), [34](../examples/case34_access_level.md), [96](../examples/case96_hidden_friend_removed.md), [106](../examples/case106_ctor_became_explicit.md), [123](../examples/case123_default_argument_removed.md), [124](../examples/case124_header_constant_value_changed.md) | 🟠 API_BREAK | [Part 6 §Source-only API breaks](abi-series/06-transitive-breaks.md#source-only-api-breaks-binary-identical) |
+| Deployment risk (noexcept, ISA dispatch, version-require) | [15](../examples/case15_noexcept_change.md), [83](../examples/case83_cpu_dispatch_isa_dropped.md) | 🟡 COMPATIBLE_WITH_RISK | [Part 4](abi-series/04-cpp-abi.md) |
+| Compatible additions & quality signals | [03](../examples/case03_compat_addition.md), [25](../examples/case25_enum_member_added.md), [26b](../examples/case26b_union_field_added_compatible.md), [27](../examples/case27_symbol_binding_weakened.md), [29](../examples/case29_ifunc_transition.md), [61](../examples/case61_var_added.md), [62](../examples/case62_type_field_added_compatible.md), [99](../examples/case99_experimental_graduated.md) | 🟢 COMPATIBLE | [Part 7](abi-series/07-designing-for-stability.md) |
+| Scoped/non-public internal changes | [118](../examples/case118_internal_struct_field_added_scoped.md), [119](../examples/case119_internal_struct_field_removed_scoped.md), [120](../examples/case120_internal_struct_reordered_scoped.md) | ✅ NO_CHANGE | [Part 6](abi-series/06-transitive-breaks.md) |
 
 ---
 

--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -151,6 +151,30 @@ headers. A handful of changes remain invisible to any artifact comparison
 [Limitations → Source-only changes](limitations.md#source-only-changes-invisible-to-binaryobject-analysis)
 for the full per-change detectability matrix.
 
+#### Which input proves which family
+
+The minimum input needed to *detect* each family — and the most common reason a
+real change is missed:
+
+| Change family | Symbols only | + DWARF/PDB | + Headers | Common false negative |
+|---------------|:---:|:---:|:---:|------|
+| Exported function/variable removed or renamed | ✅ | ✅ | ✅ | symbol filtered as non-public (visibility/scope) |
+| Parameter / return / pointer-level signature change | ⚠️ partial¹ | ✅ | ✅ | stripped binary, C symbol carries no type |
+| Struct/class layout, alignment, packing, bitfields | ❌ | ✅ | ✅ | stripped **and** no headers → reported `NO_CHANGE` |
+| Enum value / underlying-type change | ❌ | ✅ | ✅ | no debug info and no headers |
+| C++ vtable / virtual-method change | ❌ | ✅ | ✅ | mangled symbols stripped or demangled-away |
+| Calling convention (trivial→non-trivial) | ⚠️ | ✅ | ⚠️ | no debug info to see triviality |
+| Source-only API (access, `explicit`, default args, renames, constants) | ❌ | ❌² | ✅ | no headers supplied (no symbol exists at all) |
+| Templates / inline bodies | ⚠️ instantiated only | ⚠️ | ⚠️ | uninstantiated / header-only body — invisible to any artifact |
+| Modern C/C++ (dual-ABI, ABI tags, `char8_t`, `_BitInt`, `_Atomic`) | ⚠️ mangling only | ✅ | ✅ | demangled view hides the tag/ABI flip |
+| SONAME / visibility / versioning / RPATH / TLS metadata | ✅ | ✅ | ✅ | platform-specific (PE/Mach-O differ — see [Part 5](abi-series/05-linker-elf.md)) |
+
+¹ C++ mangled names encode parameter types, so symbol-only catches many C++
+signature changes; C symbols do not. ² A few source-only changes (e.g. enum/field
+*renames*) are visible in DWARF too; most (default args, `explicit`, `const`
+values) leave no binary trace and require headers. The authoritative per-change
+table is in [Limitations](limitations.md#source-only-changes-invisible-to-binaryobject-analysis).
+
 ## Detection coverage and roadmap
 
 abicheck detects **190 change kinds** today (see the

--- a/docs/concepts/abi-series/01-foundations.md
+++ b/docs/concepts/abi-series/01-foundations.md
@@ -26,6 +26,16 @@ This page assumes **no prior knowledge** of linkers or loaders. If you already
 know what `.dynsym`, COPY relocations, and the dynamic loader are, skip ahead to
 [Part 2 — Symbol Contracts](02-symbol-contracts.md).
 
+!!! note "Mental model: ELF/Linux unless stated"
+    This series teaches with the **ELF/Linux** model (symbols resolved *by
+    name*, SONAME, version scripts) because it's the cleanest to reason about.
+    Windows **PE/COFF** and macOS **Mach-O** add their own mechanisms —
+    ordinal exports, import libraries, install names, compatibility versions,
+    two-level namespaces, and platform-specific C++ ABIs. Where it matters the
+    text calls it out; the consolidated map is in
+    [Part 5 §PE/COFF and Mach-O parallels](05-linker-elf.md#pecoff-and-mach-o-parallels)
+    and the [Platform Support reference](../../reference/platforms.md).
+
 ---
 
 ## 1. The build pipeline: where does a library come from?

--- a/docs/concepts/abi-series/02-symbol-contracts.md
+++ b/docs/concepts/abi-series/02-symbol-contracts.md
@@ -32,6 +32,16 @@ reference **by name**, at load time or first call. A symbol that existed at link
 time but is missing at load time is a hard error — no fallback, no default, just
 `symbol lookup error` and process termination.
 
+!!! note "Name-keyed is the ELF model (and most C/C++ exports)"
+    This "lookup by name" contract is exact for ELF and for the public C/C++
+    exports you normally care about. **Windows PE/COFF DLLs can also export and
+    import by *ordinal*** — a small integer index into the export table — in
+    which case the contract is the *number*, and renaming the symbol does not
+    break an ordinal-bound caller while reordering the export table does. Mach-O
+    uses a two-level namespace that records *which* library a name came from, so
+    the same bare name from a different install name is a different contract. See
+    [Part 5 §PE/COFF and Mach-O parallels](05-linker-elf.md#pecoff-and-mach-o-parallels).
+
 The four break classes below each violate the name-keyed contract in a different
 way:
 

--- a/docs/concepts/abi-series/03-type-layout.md
+++ b/docs/concepts/abi-series/03-type-layout.md
@@ -225,8 +225,14 @@ bytes into what v2 treats as an 8-byte cell.
       in C++; in C keep values in `int` range or add an explicit sentinel.
       Never let a new enumerator silently widen the type.
     - **Append-only evolution.** Reordering, inserting, or removing a field is
-      always breaking. Append only at the end, and only when no embedded
-      `sizeof(T)` assumption exists (union analog: case26 vs case26b).
+      always breaking. Appending at the end is *not* automatically safe either:
+      it is ABI-safe **only** when the type is never caller-allocated, embedded
+      by value, or passed by value, **or** the API has an explicit
+      size/version-negotiation contract (a `struct_size`/`abi_version` field, or
+      reserved storage the caller never sizes itself). If any consumer can
+      `sizeof(T)`, `new T`, or hold a `T` by value, appending grows the type and
+      breaks them — see [Part 7 — Reserved padding](07-designing-for-stability.md#pattern-3-reserved-padding-evolve-a-value-type-in-place)
+      (union analog: case26 vs case26b).
 
     These patterns are developed in full, with code, in
     [Part 7 — Designing for Stability](07-designing-for-stability.md).

--- a/docs/concepts/abi-series/04-cpp-abi.md
+++ b/docs/concepts/abi-series/04-cpp-abi.md
@@ -33,12 +33,20 @@ through a grammar that encodes qualifiers, namespaces, template arguments, and
 parameter types. Every struct with a user-defined destructor changes how it is
 *passed* between functions.
 
-The **Itanium C++ ABI** — used by GCC and Clang on Linux, macOS, the BSDs, and
-most embedded targets — is rigid *by design*: it guarantees cross-compiler
+The **Itanium C++ ABI** — followed by GCC and Clang on Linux, macOS, the BSDs,
+and most embedded targets — is rigid *by design*: it guarantees cross-compiler
 interoperability at the cost of making almost any visible change to a class a
 potential binary break. MSVC on Windows uses a different but equally rigid ABI
 with the same categories of pitfall. The seven sections below tour the
 mechanisms most likely to bite.
+
+!!! note "\"Itanium-style\", not gospel"
+    The Itanium C++ ABI specification states that it is *not* the authoritative
+    definition for any particular platform — each vendor pins its own details on
+    top of it (and the platform's data model). The examples below use the
+    **Itanium-style** model unless noted; treat the exact mangling, slot
+    ordering, and passing rules as illustrative of the *mechanism*, and consult
+    your toolchain's ABI document for the byte-exact contract.
 
 ---
 
@@ -294,6 +302,40 @@ though the method's source signature is unchanged.
     Reported as `base_class_position_changed` / `type_base_changed` when DWARF
     or headers are available — ELF symbol tables alone cannot see them, which
     is why C++ ABI checking *requires* debug info or headers.
+
+---
+
+## Modern C/C++ and toolchain ABI hazards
+
+The break families above predate C++11. Newer language features and toolchain
+*flags* introduce a second class of hazard: the **declaration looks unchanged in
+the header, but the bytes the compiler emits move** because a type's size,
+mangling, or passing rule shifted under it. These are the cases reviewers miss
+most often, because nothing in the diff "looks like" an ABI change.
+
+| Hazard | What silently changes | abicheck case |
+|--------|----------------------|---------------|
+| **`_GLIBCXX_USE_CXX11_ABI` flip** | libstdc++ ships *two* `std::string`/`std::list` ABIs in parallel behind the `__cxx11` inline namespace; flipping the macro re-mangles every symbol that touches those types. | [case104](../../examples/case104_glibcxx_dual_abi_flip.md) |
+| **ABI tags (`[[gnu::abi_tag]]`)** | A tag is mangled into the symbol name; adding/removing one renames the symbol with no source-visible signature change. | [case113](../../examples/case113_abi_tag_changed.md) |
+| **`char8_t` (C++20)** | `const char*` → `const char8_t*` is a *distinct type*: different mangling, and a new overload-resolution result. | [case114](../../examples/case114_char8t_migration.md) |
+| **`_BitInt(N)` width** | Changing `N` changes size/alignment and the register/stack class the value is passed in. | [case115](../../examples/case115_bit_int_width_changed.md) |
+| **`_Atomic` qualifier** | Adding/removing `_Atomic` can change size, alignment, and whether the object is passed by lock-free path. | [case116](../../examples/case116_atomic_qualifier_changed.md) |
+| **`[[no_unique_address]]`** | Lets an empty member overlap the next field; adding it shrinks the struct and shifts every following offset. | [case117](../../examples/case117_no_unique_address.md) |
+| **Concept tightening (C++20)** | Narrowing a constraint removes instantiations the consumer relied on — a *source* break with no symbol-table change for already-emitted instantiations. | [case105](../../examples/case105_concept_tightening.md) |
+| **LP64 → ILP64 / data-model drift** | `long`/pointer widths change out from under every struct and signature — a whole-ABI shift driven by the target, not the source. | [case112](../../examples/case112_lp64_ilp64.md) |
+
+Several more live only in the **build flags**, not the source, and abicheck
+surfaces them as toolchain/deployment risk when build context is captured:
+`-fno-exceptions` / `-fno-rtti` (drop EH/RTTI machinery callers may rely on),
+`-fshort-enums` (changes enum underlying size — see
+[Part 3](03-type-layout.md)), packing/alignment flags, vector-ABI flags, and
+CPU-dispatch/IFUNC selection ([case83](../../examples/case83_cpu_dispatch_isa_dropped.md),
+[case29](../../examples/case29_ifunc_transition.md)).
+
+!!! warning "Why these need debug info or headers"
+    Like the rest of Part 4, every hazard above is recoverable only when DWARF/PDB
+    *or* headers are supplied — and the dual-ABI and ABI-tag cases need the
+    *mangled* symbol names, so a stripped, name-demangled view can hide them.
 
 ---
 

--- a/docs/concepts/abi-series/05-linker-elf.md
+++ b/docs/concepts/abi-series/05-linker-elf.md
@@ -20,7 +20,9 @@
   touching a single source-level declaration.
 
 Prerequisites: [Part 1 — Foundations](01-foundations.md) (the dynamic loader).
-This page is Linux/ELF-centric; PE/COFF and Mach-O have analogous mechanisms.
+This page is Linux/ELF-centric; the
+[PE/COFF and Mach-O parallels](#pecoff-and-mach-o-parallels) section near the end
+maps every mechanism to its Windows and macOS peer.
 
 ---
 
@@ -175,6 +177,37 @@ Libraries intended to be `dlopen`ed must avoid `initial-exec`. And any exported
 `__thread` struct whose layout shifts corrupts consumers per-thread
 ([case67](../../examples/case67_tls_var_size_changed.md)) — freeze the size,
 layout, and access model of TLS exports as first-class ABI.
+
+---
+
+## PE/COFF and Mach-O parallels
+
+Everything above is the **ELF/SysV** model. Windows and macOS solve the same
+problems — identity, export surface, versioning, lazy resolution, thread-local
+storage — with different mechanisms. abicheck parses all three (PE/COFF via the
+export table + optional PDB; Mach-O via load commands + optional DWARF/dSYM);
+the table below maps each ELF concept to its peer. The full support matrix is in
+the [Platform Support reference](../../reference/platforms.md).
+
+| ELF concept | Windows PE/COFF | macOS Mach-O |
+|-------------|-----------------|--------------|
+| **Symbol lookup** by name | By **name *or ordinal*** — an integer index into the export table. Ordinal-bound callers ignore the name; reordering exports breaks them. | **Two-level namespace**: each import records the *source library*, so the same bare name from a different library is a different symbol. |
+| **SONAME** (library identity) | DLL file name + the **import library** (`.lib`) used at link time. | **Install name** (`LC_ID_DYLIB`) baked into both the dylib and its clients; `@rpath`/`@loader_path`/`@executable_path` make it relocatable. |
+| **Symbol versioning** (`GLIBC_2.x` nodes) | No symbol versions; new ABI ⇒ new DLL name or **side-by-side assemblies**. | No GNU-style version nodes; uses **compatibility version** + **current version** numbers on the dylib. |
+| **Lazy binding** (PLT/GOT) | **Delay-load** DLLs (`/DELAYLOAD`) resolve on first use. | Lazy/`__stubs` binding; **weak imports** allow a missing symbol to resolve to null at load instead of failing. |
+| **Visibility** (`-fvisibility=hidden`) | Explicit **`__declspec(dllexport)`** / `.def` file — nothing is exported unless named. | `-fvisibility=hidden` + `__attribute__((visibility))`, same as ELF. |
+| **Mangling / decoration** | MSVC name **decoration** differs from Itanium; `extern "C"` still adds leading underscores / `@N` stdcall suffixes. | Itanium C++ ABI (same as Linux Clang). |
+| **Packaging unit** | The DLL, plus its **import library** and PDB for debug info. | The dylib, optionally inside a **framework** bundle, optionally a **universal (fat) binary** carrying multiple arch slices. |
+| **CRT / allocator boundary** | Each DLL may link its **own CRT**; `malloc` in one module must not be `free`d in another — a hard cross-module rule with no ELF analog. | Single system libc; less acute, but cross-dylib `delete` of a type with an inline destructor has the same Itanium pitfalls as Linux. |
+
+!!! tip "Practical consequences for abicheck users"
+    - On **Windows**, prefer exporting **by name** and keep a stable `.def` so a
+      rebuild can't shuffle ordinals; supply the **PDB** for layout/calling-convention
+      checks (symbol-only mode sees names but not offsets).
+    - On **macOS**, treat the **install name** and **compatibility version** as
+      part of the contract, design for **weak imports** when adding symbols a
+      client may run against an older dylib, and remember a **universal binary**
+      can differ slice-by-slice — compare the matching architecture.
 
 ---
 

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -182,17 +182,30 @@ pointer or a dependency. A related family is invisible for the opposite reason:
 the change is **purely at the source level**, so the two `.so` files are
 genuinely byte-identical and *every existing binary keeps running*, but code
 that **recompiles** against the new headers fails to build or silently changes
-meaning. abicheck classifies these as 🟠 **API_BREAK** — they should fail CI if
-you promise source compatibility, but they do **not** warrant a SONAME bump.
+meaning. abicheck reports most of these as 🟠 **API_BREAK**; a few are
+conservatively **policy-escalated to 🔴 BREAKING** (notably a field rename — see
+[case35](../../examples/case35_field_rename.md)) even though the binary layout is
+unchanged. Either way the binary ABI is intact, so none of them *require* a
+SONAME bump — but they should fail CI when you promise source compatibility.
+
+!!! danger "Not this family: removing an *exported* overload is a real ABI break"
+    Removing one overload from a set is only source-only when **no exported
+    symbol disappears** — e.g. the overload was `inline`/template-only, or you
+    *added* an overload that introduces ambiguity. If the removed overload had
+    its own mangled symbol (the usual case for a non-inline member or free
+    function), that symbol vanishes from `.dynsym` and old callers fail to
+    resolve it at **load time**: that is `func_removed` → 🔴 **BREAKING** from
+    [Part 2](02-symbol-contracts.md), and it *does* warrant a SONAME bump.
+    [case82](../../examples/case82_sycl_overload_set_removed.md) is exactly this
+    binary break, not a source-only one.
 
 | Source-only change | Why existing binaries survive | Why a recompile breaks | Case |
 |--------------------|-------------------------------|------------------------|------|
 | **Default argument removed/changed** | The default was baked into the *caller's* old object code, not the library. | A new call site that omitted the argument no longer compiles (or computes a different value). | [case123](../../examples/case123_default_argument_removed.md), [case32](../../examples/case32_param_defaults.md) |
 | **Access narrowed** (`public`→`protected`/`private`) | Access control is a compile-time concept; the symbol and layout are unchanged. | A consumer that called the now-private method no longer compiles. | [case34](../../examples/case34_access_level.md) |
 | **Constructor became `explicit`** | No symbol or layout change. | Implicit conversions/brace-init at call sites stop compiling. | [case106](../../examples/case106_ctor_became_explicit.md) |
-| **Overload removed from the set** | Remaining overloads keep their own mangled symbols. | A call that resolved to the removed overload now picks a different one or fails resolution. | [case82](../../examples/case82_sycl_overload_set_removed.md) |
 | **Hidden friend removed** | Hidden friends aren't ordinary exported symbols. | ADL no longer finds the operator; the expression stops compiling. | [case96](../../examples/case96_hidden_friend_removed.md) |
-| **Enum / field / member rename** | Same value, same offset, same size. | Source that named the old identifier no longer compiles. | [case31](../../examples/case31_enum_rename.md), [case35](../../examples/case35_field_rename.md) |
+| **Enum / field / member rename** (policy-escalated to 🔴 BREAKING by default) | Same value, same offset, same size — the binary layout is unchanged. | Source that named the old identifier no longer compiles. | [case31](../../examples/case31_enum_rename.md), [case35](../../examples/case35_field_rename.md) |
 | **Header `const`/`constexpr` constant changed** | The constant had internal linkage — it was inlined into old callers, no symbol. | A recompile picks up the new value, changing behavior. | [case124](../../examples/case124_header_constant_value_changed.md) |
 | **Class became `final`** | No layout/vtable change. | A consumer that derived from it no longer compiles. | [case125](../../examples/case125_class_became_final.md) |
 | **Source-standard floor raised** (e.g. C++17→20) | Already-compiled binaries are unaffected. | A consumer stuck on the old standard can no longer build against the headers. | [case98](../../examples/case98_cxx_standard_floor_raised.md) |
@@ -207,9 +220,10 @@ you promise source compatibility, but they do **not** warrant a SONAME bump.
     matrix in [Limitations](../limitations.md#source-only-changes-invisible-to-binaryobject-analysis)).
 
     **CI guidance:** decide up front whether you promise *source* compatibility.
-    If you do, gate on 🟠 API_BREAK and treat it as a **semver-major** signal —
-    but keep the SONAME unless a 🔴 BREAKING also fired, since the binary ABI is
-    intact.
+    If you do, gate on 🟠 API_BREAK (and the policy-escalated 🔴 rename cases) and
+    treat it as a **semver-major** signal — you can keep the SONAME unless a
+    *true binary* 🔴 BREAKING (a removed/changed symbol or a layout change) also
+    fired, since these source-only changes leave the binary ABI intact.
 
 ---
 

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -205,7 +205,8 @@ SONAME bump — but they should fail CI when you promise source compatibility.
 | **Access narrowed** (`public`→`protected`/`private`) | Access control is a compile-time concept; the symbol and layout are unchanged. | A consumer that called the now-private method no longer compiles. | [case34](../../examples/case34_access_level.md) |
 | **Constructor became `explicit`** | No symbol or layout change. | Implicit conversions/brace-init at call sites stop compiling. | [case106](../../examples/case106_ctor_became_explicit.md) |
 | **Hidden friend removed** | Hidden friends aren't ordinary exported symbols. | ADL no longer finds the operator; the expression stops compiling. | [case96](../../examples/case96_hidden_friend_removed.md) |
-| **Enum / field / member rename** (policy-escalated to 🔴 BREAKING by default) | Same value, same offset, same size — the binary layout is unchanged. | Source that named the old identifier no longer compiles. | [case31](../../examples/case31_enum_rename.md), [case35](../../examples/case35_field_rename.md) |
+| **Enum / member rename** | Same value, same offset, same size — the binary layout is unchanged. | Source that named the old identifier no longer compiles. | [case31](../../examples/case31_enum_rename.md) |
+| **Struct field rename** (policy-escalated to 🔴 BREAKING by default) | Same offset and size — the binary layout is unchanged. | Source that named the old field no longer compiles. | [case35](../../examples/case35_field_rename.md) |
 | **Header `const`/`constexpr` constant changed** | The constant had internal linkage — it was inlined into old callers, no symbol. | A recompile picks up the new value, changing behavior. | [case124](../../examples/case124_header_constant_value_changed.md) |
 | **Class became `final`** | No layout/vtable change. | A consumer that derived from it no longer compiles. | [case125](../../examples/case125_class_became_final.md) |
 | **Source-standard floor raised** (e.g. C++17→20) | Already-compiled binaries are unaffected. | A consumer stuck on the old standard can no longer build against the headers. | [case98](../../examples/case98_cxx_standard_floor_raised.md) |
@@ -220,7 +221,7 @@ SONAME bump — but they should fail CI when you promise source compatibility.
     matrix in [Limitations](../limitations.md#source-only-changes-invisible-to-binaryobject-analysis)).
 
     **CI guidance:** decide up front whether you promise *source* compatibility.
-    If you do, gate on 🟠 API_BREAK (and the policy-escalated 🔴 rename cases) and
+    If you do, gate on 🟠 API_BREAK (and the policy-escalated 🔴 field-rename case) and
     treat it as a **semver-major** signal — you can keep the SONAME unless a
     *true binary* 🔴 BREAKING (a removed/changed symbol or a layout change) also
     fired, since these source-only changes leave the binary ABI intact.

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -175,6 +175,44 @@ opaque-handle C API (`FILE*`, `sqlite3*`, `git_repository*`).
 
 ---
 
+## Source-only API breaks (binary-identical)
+
+The breaks above are *transitive* — invisible because they hide behind a
+pointer or a dependency. A related family is invisible for the opposite reason:
+the change is **purely at the source level**, so the two `.so` files are
+genuinely byte-identical and *every existing binary keeps running*, but code
+that **recompiles** against the new headers fails to build or silently changes
+meaning. abicheck classifies these as 🟠 **API_BREAK** — they should fail CI if
+you promise source compatibility, but they do **not** warrant a SONAME bump.
+
+| Source-only change | Why existing binaries survive | Why a recompile breaks | Case |
+|--------------------|-------------------------------|------------------------|------|
+| **Default argument removed/changed** | The default was baked into the *caller's* old object code, not the library. | A new call site that omitted the argument no longer compiles (or computes a different value). | [case123](../../examples/case123_default_argument_removed.md), [case32](../../examples/case32_param_defaults.md) |
+| **Access narrowed** (`public`→`protected`/`private`) | Access control is a compile-time concept; the symbol and layout are unchanged. | A consumer that called the now-private method no longer compiles. | [case34](../../examples/case34_access_level.md) |
+| **Constructor became `explicit`** | No symbol or layout change. | Implicit conversions/brace-init at call sites stop compiling. | [case106](../../examples/case106_ctor_became_explicit.md) |
+| **Overload removed from the set** | Remaining overloads keep their own mangled symbols. | A call that resolved to the removed overload now picks a different one or fails resolution. | [case82](../../examples/case82_sycl_overload_set_removed.md) |
+| **Hidden friend removed** | Hidden friends aren't ordinary exported symbols. | ADL no longer finds the operator; the expression stops compiling. | [case96](../../examples/case96_hidden_friend_removed.md) |
+| **Enum / field / member rename** | Same value, same offset, same size. | Source that named the old identifier no longer compiles. | [case31](../../examples/case31_enum_rename.md), [case35](../../examples/case35_field_rename.md) |
+| **Header `const`/`constexpr` constant changed** | The constant had internal linkage — it was inlined into old callers, no symbol. | A recompile picks up the new value, changing behavior. | [case124](../../examples/case124_header_constant_value_changed.md) |
+| **Class became `final`** | No layout/vtable change. | A consumer that derived from it no longer compiles. | [case125](../../examples/case125_class_became_final.md) |
+| **Source-standard floor raised** (e.g. C++17→20) | Already-compiled binaries are unaffected. | A consumer stuck on the old standard can no longer build against the headers. | [case98](../../examples/case98_cxx_standard_floor_raised.md) |
+
+!!! note "Detectability: these need *headers*, not just the binary"
+    Most of this family leaves **no trace in the compiled object** — default
+    arguments, access levels, `explicit`, and `const`/`constexpr` values have no
+    symbol at all. Comparing stripped or symbol-only `.so` files reports
+    `NO_CHANGE` for every row above. Supply the **public headers** (castxml /
+    `header_aware` tier) to detect them; `#define` macros and uninstantiated
+    template signatures are the residual blind spot even then (see the per-change
+    matrix in [Limitations](../limitations.md#source-only-changes-invisible-to-binaryobject-analysis)).
+
+    **CI guidance:** decide up front whether you promise *source* compatibility.
+    If you do, gate on 🟠 API_BREAK and treat it as a **semver-major** signal —
+    but keep the SONAME unless a 🔴 BREAKING also fired, since the binary ABI is
+    intact.
+
+---
+
 ## How to defend against transitive breaks
 
 !!! tip "Design patterns for Part 6"

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -243,7 +243,7 @@ universal; only the spelling changes. (Loader-level details are in
 | **Mark a public export** | `__attribute__((visibility("default")))` | `__declspec(dllexport)` (and `dllimport` in consumers) | `__attribute__((visibility("default")))` |
 | **Authoritative export list** | version script (`--version-script`) | a **`.def`** file (`EXPORTS`) — and pin **ordinals** so a rebuild can't renumber | `-exported_symbols_list file.txt` |
 | **Library identity / epoch** | `-Wl,-soname,libfoo.so.1` | the **DLL file name** + its **import library** | **install name** + `-compatibility_version` / `-current_version` |
-| **Generational ABI** | new version node, keep old symbols | side-by-side DLL (new name) | bump compatibility version; ship alongside |
+| **Generational ABI** (incompatible, must coexist) | new version node, keep old symbols | side-by-side DLL (new name) | **new install name / path** (e.g. `libfoo.2.dylib`) — the install name *is* the epoch¹ |
 
 ```text
 ; libfoo.def — stable Windows export surface (pin ordinals!)
@@ -261,6 +261,19 @@ clang -dynamiclib -fvisibility=hidden *.c \
     -install_name @rpath/libfoo.1.dylib \
     -compatibility_version 1.0 -current_version 1.2 -o libfoo.1.dylib
 ```
+
+!!! warning "¹ macOS: `compatibility_version` is a floor, not an epoch"
+    Clients select a dylib by its **install name**, and `compatibility_version`
+    is only a *minimum* check — the loader rejects a runtime dylib whose
+    compatibility version is *lower* than what the client recorded at link time,
+    but a *higher* one still loads. So bumping `compatibility_version` under the
+    **same install name** does **not** let an old and a new ABI coexist: an old
+    client will happily load the new, incompatible dylib. For a breaking change
+    where both must coexist, ship under a **new install name / path** (e.g.
+    `@rpath/libfoo.2.dylib`) — that change of identity is the real epoch bump,
+    the Mach-O analog of an ELF SONAME-major or a side-by-side Windows DLL.
+    Reserve `compatibility_version` for *backward-compatible* additions within
+    one generation.
 
 !!! warning "Windows: the CRT allocation boundary"
     A DLL with its own statically-linked CRT must not hand out memory the caller

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -117,6 +117,7 @@ years through deep internal refactors. It also closes off
 [trivial→non-trivial](04-cpp-abi.md) surprises, because the public class's
 special members are declared once and pinned.
 
+<!-- markdownlint-disable MD046 -->
 !!! warning "Pimpl gotcha"
     `std::unique_ptr<Impl>` is **not** an automatic ABI firewall. Three things
     must hold:
@@ -161,6 +162,7 @@ special members are declared once and pinned.
         Impl* p_;   // layout depends on nothing but pointer size
     };
     ```
+<!-- markdownlint-enable MD046 -->
 
 ---
 

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -133,9 +133,10 @@ special members are declared once and pinned.
        re-exported the stdlib's ABI (and its dual-ABI flips — see
        [case104](../../examples/case104_glibcxx_dual_abi_flip.md)) through the
        firewall. Keep standard-library types behind the `Impl` boundary too.
-    4. **The wrapper itself is still a commitment.** Pimpl freezes `Impl`'s
-       layout, but `Widget`'s *own* size/alignment is still public — and so is
-       the *type* of the pointer member. Switching `std::unique_ptr<Impl>` to a
+    4. **The wrapper itself is still a commitment.** Pimpl keeps `Impl`'s
+       layout *out* of the public ABI — that's the whole point, so `Impl` is free
+       to change. What stays frozen is `Widget`'s *own* size/alignment and the
+       representation of its pointer member. Switching `std::unique_ptr<Impl>` to a
        raw pointer, a `shared_ptr`, or a different deleter, or adding an inline
        member function / changing a special member, is itself ABI-relevant
        ([case80](../../examples/case80_pimpl_shared_to_unique.md) shows a

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -133,6 +133,33 @@ special members are declared once and pinned.
        re-exported the stdlib's ABI (and its dual-ABI flips — see
        [case104](../../examples/case104_glibcxx_dual_abi_flip.md)) through the
        firewall. Keep standard-library types behind the `Impl` boundary too.
+    4. **The wrapper itself is still a commitment.** Pimpl freezes `Impl`'s
+       layout, but `Widget`'s *own* size/alignment is still public — and so is
+       the *type* of the pointer member. Switching `std::unique_ptr<Impl>` to a
+       raw pointer, a `shared_ptr`, or a different deleter, or adding an inline
+       member function / changing a special member, is itself ABI-relevant
+       ([case80](../../examples/case80_pimpl_shared_to_unique.md) shows a
+       `shared_ptr`→`unique_ptr` flip detected as breaking).
+
+!!! tip "Stricter variant: hide even the smart pointer"
+    For the most conservative C++ ABI, hold a **raw** `Impl*` so the public
+    class layout doesn't depend on the standard library's smart-pointer ABI at
+    all — at the cost of writing lifetime management by hand:
+
+    ```cpp
+    class Widget {
+    public:
+        Widget();
+        ~Widget();
+        Widget(Widget&&) noexcept;
+        Widget& operator=(Widget&&) noexcept;
+        Widget(const Widget&) = delete;
+        Widget& operator=(const Widget&) = delete;
+    private:
+        struct Impl;
+        Impl* p_;   // layout depends on nothing but pointer size
+    };
+    ```
 
 ---
 
@@ -203,6 +230,44 @@ names you listed enter `.dynsym` — closing off the accidental-leak hazard from
 [Part 5](05-linker-elf.md). When you genuinely need a breaking change, add a new
 node (`LIBFOO_2.0 { ... } LIBFOO_1.0;`) and keep the old symbols exported, so old
 binaries keep resolving the old implementation.
+
+### The same surface control on Windows and macOS
+
+The *principle* — export exactly what you intend, version your identity — is
+universal; only the spelling changes. (Loader-level details are in
+[Part 5 §PE/COFF and Mach-O parallels](05-linker-elf.md#pecoff-and-mach-o-parallels).)
+
+| Goal | Linux / ELF | Windows / PE | macOS / Mach-O |
+|------|-------------|--------------|----------------|
+| **Hide everything by default** | `-fvisibility=hidden` | nothing is exported unless marked | `-fvisibility=hidden` |
+| **Mark a public export** | `__attribute__((visibility("default")))` | `__declspec(dllexport)` (and `dllimport` in consumers) | `__attribute__((visibility("default")))` |
+| **Authoritative export list** | version script (`--version-script`) | a **`.def`** file (`EXPORTS`) — and pin **ordinals** so a rebuild can't renumber | `-exported_symbols_list file.txt` |
+| **Library identity / epoch** | `-Wl,-soname,libfoo.so.1` | the **DLL file name** + its **import library** | **install name** + `-compatibility_version` / `-current_version` |
+| **Generational ABI** | new version node, keep old symbols | side-by-side DLL (new name) | bump compatibility version; ship alongside |
+
+```text
+; libfoo.def — stable Windows export surface (pin ordinals!)
+LIBRARY libfoo
+EXPORTS
+    foo_compute   @1
+    foo_create    @2
+    foo_destroy   @3
+```
+
+```bash
+# macOS — explicit export list + versioned install name
+clang -dynamiclib -fvisibility=hidden *.c \
+    -exported_symbols_list exports.txt \
+    -install_name @rpath/libfoo.1.dylib \
+    -compatibility_version 1.0 -current_version 1.2 -o libfoo.1.dylib
+```
+
+!!! warning "Windows: the CRT allocation boundary"
+    A DLL with its own statically-linked CRT must not hand out memory the caller
+    `free`s (or vice versa) — `malloc`/`free` and `new`/`delete` must pair within
+    the **same** module. Expose explicit `foo_create()`/`foo_destroy()` instead
+    of letting callers `delete` your objects; this has no ELF equivalent but is a
+    hard rule on Windows.
 
 ---
 

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -118,10 +118,21 @@ years through deep internal refactors. It also closes off
 special members are declared once and pinned.
 
 !!! warning "Pimpl gotcha"
-    Declare and *out-of-line define* the destructor (and move operations) in
-    the `.cpp` where `Impl` is complete. A defaulted destructor in the header
-    forces the compiler to see `Impl`'s definition there — defeating the
-    firewall.
+    `std::unique_ptr<Impl>` is **not** an automatic ABI firewall. Three things
+    must hold:
+
+    1. **Out-of-line special members.** Declare and *define in the `.cpp`* the
+       destructor, move constructor, and move assignment (where `Impl` is
+       complete). A defaulted destructor in the header forces the compiler to
+       see `Impl`'s definition there — defeating the firewall.
+    2. **No custom deleter / completeness leak.** The default `unique_ptr`
+       deleter requires a complete type at the point of destruction; keep that
+       point out-of-line.
+    3. **Don't leak standard-library ABI.** If the public class still exposes
+       `std::string`, `std::vector`, etc. by value in its interface, you've
+       re-exported the stdlib's ABI (and its dual-ABI flips — see
+       [case104](../../examples/case104_glibcxx_dual_abi_flip.md)) through the
+       firewall. Keep standard-library types behind the `Impl` boundary too.
 
 ---
 

--- a/docs/concepts/abi-series/glossary.md
+++ b/docs/concepts/abi-series/glossary.md
@@ -1,0 +1,44 @@
+# Glossary
+
+Quick definitions for the recurring terms in the
+[ABI/API Handling series](../abi-api-handling.md). Each entry links to where the
+concept is developed in full.
+
+| Term | Meaning |
+|------|---------|
+| **ABI** (Application Binary Interface) | The binary-level contract between compiled modules: symbol names, struct layout, calling convention, vtable layout. Changing it can break *already-compiled* callers. See [Part 1](01-foundations.md). |
+| **API** (Application Programming Interface) | The source-level contract: declarations, signatures, types as written in headers. Changing it can break *recompilation* even when the ABI is intact. See [Part 6 §Source-only API breaks](06-transitive-breaks.md#source-only-api-breaks-binary-identical). |
+| **ABI epoch** | A generation of a library's binary contract. The **SONAME major** number *is* the ABI epoch; bumping it lets an incompatible new library coexist with the old one. See [Part 5](05-linker-elf.md). |
+| **ABI tag** (`[[gnu::abi_tag]]`) | A token mangled into a C++ symbol name to distinguish otherwise-identical signatures across ABI variants. Adding/removing one renames the symbol. See [case113](../../examples/case113_abi_tag_changed.md). |
+| **castxml** | The tool abicheck uses to parse C/C++ **headers** into an AST, recovering source-level facts (access, `noexcept`, default arguments, constants) that binaries don't carry. The `header_aware` tier. |
+| **Calling convention** | The rules for passing arguments and return values (registers vs stack, who cleans up). Flipping trivially-copyable → non-trivial silently changes it. See [Part 4](04-cpp-abi.md). |
+| **Copy relocation** | An ELF mechanism where an executable gets its *own* copy of a library global; growing that global's type then mismatches the copy. See [Part 5](05-linker-elf.md). |
+| **Demangling** | Translating a mangled C++ symbol (`_ZN3foo3barEi`) back to a readable signature (`foo::bar(int)`). |
+| **DWARF** | The debug-info format (Linux/macOS, from `-g`) that records struct layout, field offsets, enum values, and calling convention — the ground-truth *emitted* ABI. The `dwarf_aware` tier. |
+| **Dual ABI** (`_GLIBCXX_USE_CXX11_ABI`) | libstdc++ ships two parallel `std::string`/`std::list` ABIs behind the `__cxx11` inline namespace; the macro selects which, re-mangling affected symbols. See [case104](../../examples/case104_glibcxx_dual_abi_flip.md). |
+| **IFUNC** (indirect function) | A symbol resolved *once at load time* by a resolver that picks an implementation (e.g. by CPU features). See [case29](../../examples/case29_ifunc_transition.md). |
+| **Install name** | A Mach-O dylib's self-recorded identity (`LC_ID_DYLIB`), baked into clients at link time; the macOS analog of SONAME. `@rpath`/`@loader_path` make it relocatable. See [Part 5](05-linker-elf.md#pecoff-and-mach-o-parallels). |
+| **Interposition** | Replacing a library's symbol at load time with another definition (e.g. `LD_PRELOAD`); default visibility makes a symbol interposable. See [Part 5](05-linker-elf.md). |
+| **Mangling** | The encoding of a C++ name + qualifiers + parameter types into a unique linker symbol. Any qualifier change re-mangles, vanishing the old symbol. See [Part 4](04-cpp-abi.md). |
+| **ODR** (One Definition Rule) | C++'s requirement that every entity have exactly one definition across a program; inline/template body divergence between versions is an ODR-class hazard. See [Part 4](04-cpp-abi.md). |
+| **Opaque handle** | A type consumers only ever see as a pointer (`FILE*`, `sqlite3*`); the strongest layout firewall. See [Part 7](07-designing-for-stability.md). |
+| **Ordinal** | A Windows PE export's integer index. A caller bound by ordinal ignores the name, so reordering exports — not renaming — is what breaks it. See [Part 5](05-linker-elf.md#pecoff-and-mach-o-parallels). |
+| **PDB** | Windows program database — the debug-info format (`/Zi`) abicheck reads for PE layout and calling-convention checks. The Windows `dwarf_aware` equivalent. |
+| **Pimpl** ("pointer to implementation") | A C++ idiom that hides all data members behind one pointer to a `.cpp`-defined `Impl`, freezing `sizeof` and offsets. See [Part 7](07-designing-for-stability.md). |
+| **PLT / GOT** | The Procedure Linkage Table / Global Offset Table — ELF's lazy-binding indirection for cross-library calls and data. See [Part 1](01-foundations.md). |
+| **RPATH / RUNPATH** | Library search paths baked into a binary; absolute ones are non-portable and a security hazard. See [Part 5](05-linker-elf.md). |
+| **SONAME** | The identity an ELF library advertises (`libfoo.so.1`); the loader matches clients to it. Its major number is the ABI epoch. See [Part 5](05-linker-elf.md). |
+| **Symbol version** (version node) | A GNU ELF label (`GLIBC_2.17`) attached to a symbol so multiple ABIs of the same name coexist. Removing a node breaks clients bound to it. See [case65](../../examples/case65_symbol_version_removed.md). |
+| **Thunk** | A small generated stub that adjusts `this` (or a return value) before forwarding — used for multiple inheritance and covariant returns in vtables. See [Part 4](04-cpp-abi.md). |
+| **TLS model** | How thread-local storage is accessed (`global-dynamic`, `initial-exec`, …); a variable reached via `dlopen` needs `global-dynamic`. See [case67](../../examples/case67_tls_var_size_changed.md). |
+| **Trivially copyable** | A type the compiler may move with `memcpy` and pass in registers; adding a user destructor/copy ctor flips this, changing the calling convention. See [case69](../../examples/case69_trivial_to_nontrivial.md). |
+| **Two-level namespace** | The Mach-O scheme where each import records *which* library a symbol came from, so identical names from different libraries are distinct. See [Part 5](05-linker-elf.md#pecoff-and-mach-o-parallels). |
+| **Universal (fat) binary** | A Mach-O file bundling multiple CPU-architecture slices; compare the matching slice. See [Part 5](05-linker-elf.md#pecoff-and-mach-o-parallels). |
+| **vptr / vtable** | Each polymorphic object holds a hidden **vptr** to its class's **vtable** — a fixed-order array of function pointers. Callers hard-code slot *indices*, so reordering virtuals corrupts dispatch. See [Part 4](04-cpp-abi.md). |
+| **Weak import** | A Mach-O import allowed to resolve to null (instead of failing) when missing — lets a client built against a newer dylib still run on an older one. See [Part 5](05-linker-elf.md#pecoff-and-mach-o-parallels). |
+
+---
+
+*Back to the [series overview](../abi-api-handling.md) · the
+[ABI Cheat Sheet](../abi-cheat-sheet.md) · the
+[Examples Encyclopedia](../../examples/index.md).*

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -33,7 +33,7 @@ Two distinct paths have different maturity — don't read "MSVC" as a single sta
 | Toolchain / path | Status | Notes |
 |----------|--------|-------|
 | MinGW (GCC) | **Experimental** | Covered by current CI smoke/integration jobs. |
-| MSVC PE/COFF + PDB — *binary & verdicts* | **Validated in CI** | The `windows-msvc` lane asserts MSVC+PDB verdicts (PDB layout depth best-effort); the PE/PDB parsers have unit tests. |
+| MSVC PE/COFF + PDB — *binary & verdicts* | **Parsers unit-tested; MSVC e2e non-blocking** | The PE/PDB parsers have (blocking) unit tests. The `windows-msvc` end-to-end lane asserts MSVC+PDB verdicts (PDB layout depth best-effort) but runs `continue-on-error` (informational, does **not** block CI) until proven stable — treat MSVC verdicts as experimental. |
 | MSVC `castxml` + `cl.exe` — *native header/type analysis* | **Untested in CI** | Expected to work in many cases, but this native header path is not yet validated end-to-end. |
 
 Tracked ABICC compatibility issues for this area: **#9, #50, #56, #121**.

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -28,10 +28,13 @@ specify the PDB file location if automatic discovery fails.
 
 Windows support depends on the compiler/toolchain used for headers and binary production:
 
-| Toolchain | Status | Notes |
+Two distinct paths have different maturity — don't read "MSVC" as a single status:
+
+| Toolchain / path | Status | Notes |
 |----------|--------|-------|
 | MinGW (GCC) | **Experimental** | Covered by current CI smoke/integration jobs. |
-| MSVC (`cl.exe`) | **Untested in CI** | Expected to work in many cases, but not yet validated end-to-end in project CI. |
+| MSVC PE/COFF + PDB — *binary & verdicts* | **Validated in CI** | The `windows-msvc` lane asserts MSVC+PDB verdicts (PDB layout depth best-effort); the PE/PDB parsers have unit tests. |
+| MSVC `castxml` + `cl.exe` — *native header/type analysis* | **Untested in CI** | Expected to work in many cases, but this native header path is not yet validated end-to-end. |
 
 Tracked ABICC compatibility issues for this area: **#9, #50, #56, #121**.
 For detailed matrix + per-issue notes, see [Platform Support](../reference/platforms.md#windows-toolchain-support-matrix).

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -44,7 +44,7 @@ accordingly:
 | Platform | Binary/metadata parsing | Workflow end-to-end (compare / appcompat / …) |
 |----------|:-----------------------:|:---------------------------------------------:|
 | **Linux / ELF** | Unit **and** integration tests | **Validated in CI** (the baseline) |
-| **Windows / PE+PDB** | Unit tests for the PE/PDB parsers | **Validated in CI**: `cross-platform-e2e` lane runs `compare` on MinGW-built DLLs; `windows-msvc` lane asserts MSVC+PDB verdicts (PDB layout depth best-effort) |
+| **Windows / PE+PDB** | Unit tests for the PE/PDB parsers | **Validated in CI** for MinGW: `cross-platform-e2e` lane runs `compare` on MinGW-built DLLs. The `windows-msvc` lane additionally asserts MSVC+PDB verdicts (PDB layout depth best-effort) but runs **non-blocking** (`continue-on-error`, informational) until proven stable |
 | **macOS / Mach-O** | Unit tests for the Mach-O/ARM64 layer | **Validated in CI**: `cross-platform-e2e` lane runs `compare` on Apple-clang-built dylibs; AArch64 AAPCS64 HFA/HVA + 16-byte boundary modeled and unit-tested |
 
 Concretely: the core `compare` workflow is now exercised end-to-end on native

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - "5. Linker & ELF": concepts/abi-series/05-linker-elf.md
       - "6. Transitive Breaks": concepts/abi-series/06-transitive-breaks.md
       - "7. Designing for Stability": concepts/abi-series/07-designing-for-stability.md
+      - "Glossary": concepts/abi-series/glossary.md
     - Examples Encyclopedia: examples/index.md
     - By Verdict:
       - "BREAKING": examples/by-verdict/breaking.md


### PR DESCRIPTION
## What this does

Acts on a documentation review of the **ABI/API Handling** guide. The review was
largely written against an earlier, monolithic version of the page; the page has
since been restructured into a 7-part learning series, so this PR implements only
the feedback that is **still open** against the current docs.

### Already-resolved items (verified, no change needed)
- The "stale duplicate pages" concern (the review's top priority): there are no
  *ABI Breaks Explained* / *Breaking Cases Catalog* / *ABI Stability Guide* pages
  in `docs/` or `mkdocs.yml`. `case15_noexcept_change` is consistently
  `COMPATIBLE_WITH_RISK` across the index, by-verdict, and the case page.
- The "183 change kinds" / detection-prerequisites matrix items are already
  reflected (hub says **190**, and `limitations.md` carries a per-change
  detectability matrix).

### Implemented here
- **Hub (`abi-api-handling.md`)** — replaced the placeholder `🔴 / 🟢` verdict
  cells with explicit "mixed — …" wording; made every break-family case number a
  clickable link to its example page; added a **Scope & assumptions** admonition
  (ELF/Itanium default, detectability depends on inputs).
- **Part 4 (C++ ABI)** — new **Modern C/C++ and toolchain ABI hazards** section
  (`_GLIBCXX_USE_CXX11_ABI`, ABI tags, `char8_t`, `_BitInt`, `_Atomic`,
  `[[no_unique_address]]`, concepts, LP64/ILP64, build flags), and qualified the
  Itanium ABI as illustrative rather than authoritative.
- **Part 5 (Linker & ELF)** — new **PE/COFF and Mach-O parallels** table mapping
  every ELF concept to its Windows/macOS peer (ordinals, install name, two-level
  namespace, weak imports, delay-load, universal binaries, CRT boundary).
- **Part 6 (Transitive breaks)** — new **Source-only API breaks
  (binary-identical)** section (default args, access narrowing, `explicit`,
  overload/hidden-friend removal, renames, constants, `final`, source-standard
  floor) with CI/semver guidance.
- **Part 2** — qualified the name-keyed contract for PE ordinals / Mach-O.
- **Part 3 & 7** — sharpened the append-only safe rule and the Pimpl firewall
  caveats (out-of-line special members, deleter completeness, no stdlib leak).
- **New Glossary page**, linked from the hub and added to nav.

## Validation
- Every internal link and heading anchor validated across all 230 docs pages
  (mkdocs isn't installed in this environment; replicated its default slugify).
- `scripts/check_ai_readiness.py`: **0 errors** (nav-coverage and changekind-docs
  pass).

Docs-only change.

https://claude.ai/code/session_01Xvo95mQAGXw54dBjVfMyG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xvo95mQAGXw54dBjVfMyG5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ABI/API Handling learning series with clarifications on platform differences (Linux/Windows/macOS).
  * Added new glossary for quick reference of ABI/API terminology.
  * Expanded guidance on designing stable APIs with practical Windows and macOS examples.
  * Clarified which changes are detectable and require headers versus binary inspection.
  * Improved tables and cross-platform mapping for symbol handling and export mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->