### PR TITLE
feat: ADR-027 — API Surface Intelligence (Phases 2–5: A1/A2/A3/A4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **196 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
+It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **199 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary and header AST analysis on all platforms; debug-info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **192 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
+It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **196 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary and header AST analysis on all platforms; debug-info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -39,6 +39,7 @@ Bundle findings use the ``ChangeKind.BUNDLE_*`` values registered in
 suppression, severity, and reporter machinery identically to per-library
 ``Change`` entries.
 """
+
 from __future__ import annotations
 
 import logging
@@ -49,7 +50,7 @@ from typing import TYPE_CHECKING, cast
 
 from .checker_policy import ChangeKind, Verdict, compute_verdict
 from .checker_types import Change, DiffResult
-from .elf_metadata import ElfMetadata, parse_elf_metadata
+from .elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, parse_elf_metadata
 
 if TYPE_CHECKING:
     from .diff_cpp_patterns import BundleMember
@@ -61,39 +62,47 @@ log = logging.getLogger(__name__)
 # provided by the system loader, not by the bundle. Resolution against the
 # bundle is meaningless for these; ignore unresolved imports against this
 # set when emitting :class:`ChangeKind.BUNDLE_INTRA_DEP_REMOVED`.
-DEFAULT_SYSTEM_PROVIDERS: frozenset[str] = frozenset({
-    "libc.so.6", "libc.so.7",
-    "libm.so.6",
-    "libdl.so.2",
-    "libpthread.so.0",
-    "librt.so.1",
-    "libstdc++.so.6",
-    "libc++.so.1", "libc++abi.so.1",
-    "libgcc_s.so.1",
-    "libgomp.so.1",
-    "libtbb.so.12", "libtbb.so.2",
-    "libsycl.so", "libsycl.so.7", "libsycl.so.8",
-    "libOpenCL.so.1",
-    "libz.so.1",
-    "ld-linux-x86-64.so.2", "ld-linux-aarch64.so.1",
-})
+DEFAULT_SYSTEM_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "libc.so.6",
+        "libc.so.7",
+        "libm.so.6",
+        "libdl.so.2",
+        "libpthread.so.0",
+        "librt.so.1",
+        "libstdc++.so.6",
+        "libc++.so.1",
+        "libc++abi.so.1",
+        "libgcc_s.so.1",
+        "libgomp.so.1",
+        "libtbb.so.12",
+        "libtbb.so.2",
+        "libsycl.so",
+        "libsycl.so.7",
+        "libsycl.so.8",
+        "libOpenCL.so.1",
+        "libz.so.1",
+        "ld-linux-x86-64.so.2",
+        "ld-linux-aarch64.so.1",
+    }
+)
 
 
 @dataclass(frozen=True)
 class ProviderEntry:
     """One library in the bundle that exports ``symbol``."""
 
-    library: str          # e.g. "libcore.so"
-    version: str          # gnu.version_d tag, "" if unversioned
+    library: str  # e.g. "libcore.so"
+    version: str  # gnu.version_d tag, "" if unversioned
 
 
 @dataclass(frozen=True)
 class ConsumerEntry:
     """One library in the bundle that imports ``symbol``."""
 
-    library: str          # e.g. "libalgo.so"
-    version: str          # gnu.version_r required version, "" if unversioned
-    weak: bool            # True when the import is weak (unresolved is OK)
+    library: str  # e.g. "libalgo.so"
+    version: str  # gnu.version_r required version, "" if unversioned
+    weak: bool  # True when the import is weak (unresolved is OK)
 
 
 @dataclass
@@ -131,9 +140,9 @@ class BundleSnapshot:
     Holds per-library ELF metadata and the precomputed resolution graph.
     """
 
-    root: Path                                      # the release directory
-    libraries: dict[str, Path]                      # library_name -> filesystem path
-    metadata: dict[str, ElfMetadata]                # library_name -> parsed ELF metadata
+    root: Path  # the release directory
+    libraries: dict[str, Path]  # library_name -> filesystem path
+    metadata: dict[str, ElfMetadata]  # library_name -> parsed ELF metadata
     resolution: ResolutionGraph
 
     @property
@@ -170,20 +179,29 @@ class BundleFinding:
     """
 
     kind: ChangeKind
-    symbol: str                              # mangled symbol name or type name
+    symbol: str  # mangled symbol name or type name
     description: str
-    consumer_library: str | None = None      # affected library (for intra-dep findings)
-    provider_library: str | None = None      # source-of-change library
+    consumer_library: str | None = None  # affected library (for intra-dep findings)
+    provider_library: str | None = None  # source-of-change library
     old_value: str | None = None
     new_value: str | None = None
     affected_libraries: list[str] = field(default_factory=list)
+    # ADR-027 A3/D3.2 — per-finding reachability modulation, mirroring the A4
+    # Change override so a demotion reaches the bundle verdict (which lowers
+    # findings to Change and classifies via effective_category). Default None =
+    # classify by kind, i.e. today's behaviour.
+    effective_verdict: Verdict | None = None
+    modulation_reason: str | None = None
+    modulation_rule: str | None = None
 
     def to_change(self) -> Change:
         """Lower a :class:`BundleFinding` into the :class:`Change` representation.
 
         Used by the JSON/Markdown reporters that already know how to render
         ``Change`` objects. The bundle attribution fields are flattened into
-        ``description`` so they survive the lowering.
+        ``description`` so they survive the lowering. A reachability modulation
+        (D3.2) is propagated onto the lowered ``Change`` so the bundle verdict
+        and the compare-release exit code honour it.
         """
         prefix = ""
         if self.consumer_library and self.provider_library:
@@ -199,6 +217,9 @@ class BundleFinding:
             old_value=self.old_value,
             new_value=self.new_value,
             affected_symbols=list(self.affected_libraries) or None,
+            effective_verdict=self.effective_verdict,
+            modulation_reason=self.modulation_reason,
+            modulation_rule=self.modulation_rule,
         )
 
 
@@ -225,8 +246,11 @@ class BundleDiffResult:
     @property
     def per_library_verdict(self) -> Verdict:
         order = [
-            Verdict.NO_CHANGE, Verdict.COMPATIBLE, Verdict.COMPATIBLE_WITH_RISK,
-            Verdict.API_BREAK, Verdict.BREAKING,
+            Verdict.NO_CHANGE,
+            Verdict.COMPATIBLE,
+            Verdict.COMPATIBLE_WITH_RISK,
+            Verdict.API_BREAK,
+            Verdict.BREAKING,
         ]
         worst = Verdict.NO_CHANGE
         for r in self.per_library:
@@ -237,8 +261,11 @@ class BundleDiffResult:
     @property
     def verdict(self) -> Verdict:
         order = [
-            Verdict.NO_CHANGE, Verdict.COMPATIBLE, Verdict.COMPATIBLE_WITH_RISK,
-            Verdict.API_BREAK, Verdict.BREAKING,
+            Verdict.NO_CHANGE,
+            Verdict.COMPATIBLE,
+            Verdict.COMPATIBLE_WITH_RISK,
+            Verdict.API_BREAK,
+            Verdict.BREAKING,
         ]
         return max(self.per_library_verdict, self.bundle_verdict, key=order.index)
 
@@ -246,6 +273,7 @@ class BundleDiffResult:
 # ---------------------------------------------------------------------------
 # Manifest input
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class ManifestEntry:
@@ -271,12 +299,12 @@ class ManifestEntry:
       explicit instantiation matrix in their build system.
     """
 
-    symbol: str | None = None                    # literal mangled symbol
-    pattern: str | None = None                   # fnmatch glob on demangled form
-    template: str | None = None                  # C++ qualified template name
+    symbol: str | None = None  # literal mangled symbol
+    pattern: str | None = None  # fnmatch glob on demangled form
+    template: str | None = None  # C++ qualified template name
     instantiations: tuple[dict[str, str], ...] = ()  # for template form
-    library: str | None = None                   # provider when optional_provider=False
-    optional_provider: bool = True               # True = any sibling may provide
+    library: str | None = None  # provider when optional_provider=False
+    optional_provider: bool = True  # True = any sibling may provide
 
     def kind(self) -> str:
         """Return ``'symbol'``, ``'pattern'``, or ``'template'`` for diagnostics."""
@@ -323,7 +351,9 @@ class InstantiationManifest:
         return frozenset(e.symbol for e in self.entries if e.symbol is not None)
 
 
-def _expand_instantiations(template: str, instantiations: tuple[dict[str, str], ...]) -> list[str]:
+def _expand_instantiations(
+    template: str, instantiations: tuple[dict[str, str], ...]
+) -> list[str]:
     """Build demangled-form substring patterns from a template + parameter list.
 
     Returns a list of strings like ``"acme::lib::train_ops<float, method::dense, task::train>"``
@@ -347,6 +377,7 @@ def _load_manifest_data(path: Path) -> dict[str, object]:
     text = path.read_text(encoding="utf-8")
     if path.suffix.lower() in (".yaml", ".yml"):
         import yaml
+
         data = yaml.safe_load(text)
     else:
         data = json.loads(text)
@@ -371,7 +402,9 @@ def _validate_manifest_entry_shape(path: Path, raw: dict[str, object]) -> str:
     return shape_keys[0]
 
 
-def _parse_template_instantiations(path: Path, raw: dict[str, object]) -> tuple[dict[str, str], ...]:
+def _parse_template_instantiations(
+    path: Path, raw: dict[str, object]
+) -> tuple[dict[str, str], ...]:
     """Parse and coerce the 'instantiations' list from a template entry."""
     insts_raw = raw.get("instantiations", [])
     if not isinstance(insts_raw, list) or not insts_raw:
@@ -463,6 +496,7 @@ def load_manifest(path: Path) -> InstantiationManifest:
 # Bundle snapshot construction
 # ---------------------------------------------------------------------------
 
+
 def build_bundle_snapshot(libraries: dict[str, Path]) -> BundleSnapshot:
     """Parse every library in the release and build the resolution graph.
 
@@ -490,10 +524,17 @@ def build_bundle_snapshot(libraries: dict[str, Path]) -> BundleSnapshot:
             continue
         try:
             meta = parse_elf_metadata(path)
-        except Exception as exc:  # pragma: no cover — parse_elf_metadata already swallows most
+        except (
+            Exception
+        ) as exc:  # pragma: no cover — parse_elf_metadata already swallows most
             log.warning("bundle: failed to parse %s: %s", path, exc)
             continue
-        if meta is None or (not meta.soname and not meta.symbols and not meta.imports and not meta.needed):
+        if meta is None or (
+            not meta.soname
+            and not meta.symbols
+            and not meta.imports
+            and not meta.needed
+        ):
             log.debug("bundle: skipping non-ELF or empty input %s", path)
             continue
         metadata[name] = meta
@@ -568,6 +609,7 @@ def _compute_resolution_graph(
 # ---------------------------------------------------------------------------
 # Bundle diff
 # ---------------------------------------------------------------------------
+
 
 def compare_bundle(
     old: BundleSnapshot,
@@ -653,6 +695,7 @@ def compare_bundle(
 # ---------------------------------------------------------------------------
 # Detection helpers
 # ---------------------------------------------------------------------------
+
 
 def _detect_library_structural_changes(
     old: BundleSnapshot,
@@ -754,8 +797,7 @@ def _detect_intra_dep_removed(
             # bundle. This is what --bundle-system-providers controls.
             extra_needed = new.resolution.extra_needed.get(consumer.library, [])
             if extra_needed and all(
-                e in system_providers or _looks_system(e)
-                for e in extra_needed
+                e in system_providers or _looks_system(e) for e in extra_needed
             ):
                 # And the symbol itself looks system-shaped (mangled std::,
                 # well-known C runtime entry, etc.) — skip the finding.
@@ -803,7 +845,9 @@ def _detect_intra_dep_signature_changed(
             if change.kind not in relevant_kinds:
                 continue
             consumers = new.resolution.consumers_of(change.symbol)
-            consumer_libs = sorted({c.library for c in consumers if c.library != provider_lib})
+            consumer_libs = sorted(
+                {c.library for c in consumers if c.library != provider_lib}
+            )
             if not consumer_libs:
                 continue
             for consumer_lib in consumer_libs:
@@ -866,38 +910,75 @@ def _detect_intra_type_changed(
             if change.kind not in type_kinds:
                 continue
             type_name = change.symbol
-            # Look for the type name embedded in any other library's
-            # exported symbol names (mangled C++ symbols include the type).
-            crossing_consumers: list[str] = []
+            # Look for the type name embedded in another library's symbols.
+            # ADR-027 A3/D3.2 reachability filter: classify each consumer match
+            # as reaching its *public* surface (the type leaks into a symbol the
+            # consumer itself exports — full-confidence cross-DSO break) vs only
+            # its *internal* surface (the type appears only in the consumer's
+            # local/hidden symbols — demoted to risk, not dropped, because the
+            # consumer does not re-expose the type across the boundary).
             stripped = _strip_namespace_prefix(type_name)
+            consumer_reach: dict[str, bool] = {}  # consumer -> reaches public surface
             for sib_name, sib_meta in new.metadata.items():
                 if sib_name == provider_lib:
                     continue
+                public_hit = False
+                internal_hit = False
                 for sym in sib_meta.symbols:
                     if stripped and stripped in sym.name:
-                        crossing_consumers.append(sib_name)
-                        break
-            for consumer_lib in sorted(set(crossing_consumers)):
+                        if _is_public_surface_symbol(sym):
+                            public_hit = True
+                            break
+                        internal_hit = True
+                if public_hit or internal_hit:
+                    consumer_reach[sib_name] = public_hit
+            for consumer_lib in sorted(consumer_reach):
                 key = (consumer_lib, provider_lib, type_name)
                 if key in seen:
                     continue
                 seen.add(key)
-                findings.append(
-                    BundleFinding(
-                        kind=ChangeKind.BUNDLE_INTRA_TYPE_CHANGED,
-                        symbol=type_name,
-                        description=(
-                            f"{provider_lib} changed type {type_name}; the type "
-                            f"is reachable from {consumer_lib}'s exported symbols. "
-                            f"{consumer_lib}'s ABI looks unchanged in isolation, "
-                            f"but every cross-DSO use of {type_name} is affected."
-                        ),
-                        consumer_library=consumer_lib,
-                        provider_library=provider_lib,
-                        affected_libraries=[consumer_lib],
+                on_public = consumer_reach[consumer_lib]
+                finding = BundleFinding(
+                    kind=ChangeKind.BUNDLE_INTRA_TYPE_CHANGED,
+                    symbol=type_name,
+                    description=(
+                        f"{provider_lib} changed type {type_name}; the type "
+                        f"is reachable from {consumer_lib}'s exported symbols. "
+                        f"{consumer_lib}'s ABI looks unchanged in isolation, "
+                        f"but every cross-DSO use of {type_name} is affected."
                     ),
+                    consumer_library=consumer_lib,
+                    provider_library=provider_lib,
+                    affected_libraries=[consumer_lib],
                 )
+                if not on_public:
+                    # Consumer uses the type only internally → demote (disclosed,
+                    # never dropped): the cross-DSO change cannot reach the
+                    # consumer's own public ABI surface.
+                    finding.effective_verdict = Verdict.COMPATIBLE_WITH_RISK
+                    finding.modulation_reason = "consumer-internal-use"
+                    finding.modulation_rule = "bundle-reachability"
+                    finding.description = (
+                        f"{provider_lib} changed type {type_name}; {consumer_lib} "
+                        f"references it only via internal (non-exported) symbols, "
+                        f"so the change does not reach {consumer_lib}'s public ABI "
+                        f"surface — review, but not a confirmed cross-DSO break."
+                    )
+                findings.append(finding)
     return findings
+
+
+def _is_public_surface_symbol(sym: ElfSymbol) -> bool:
+    """True when *sym* is part of a library's exported public ABI surface.
+
+    A defined GLOBAL/WEAK symbol with default/protected visibility is reachable
+    by external consumers; LOCAL binding or hidden/internal visibility is not
+    (it is the DSO's private implementation). Used by the A3 reachability filter
+    to tell a real cross-DSO break from an internal-only type reference.
+    """
+    if sym.binding not in (SymbolBinding.GLOBAL, SymbolBinding.WEAK):
+        return False
+    return sym.visibility in ("default", "protected")
 
 
 def _detect_provider_changed(
@@ -913,8 +994,8 @@ def _detect_provider_changed(
     """
     findings: list[BundleFinding] = []
 
-    removed_by: dict[str, str] = {}        # symbol -> library that removed it
-    added_by: dict[str, str] = {}          # symbol -> library that added it
+    removed_by: dict[str, str] = {}  # symbol -> library that removed it
+    added_by: dict[str, str] = {}  # symbol -> library that added it
     for lib_name, diff in diff_by_library.items():
         for change in diff.changes:
             if change.kind in (
@@ -1039,7 +1120,9 @@ def _soname_skew_findings(
     findings: list[BundleFinding] = []
     for prefix in prefixes:
         for change in detect_bundle_soname_skew(
-            old_members, new_members, cohort_prefix=prefix,
+            old_members,
+            new_members,
+            cohort_prefix=prefix,
         ):
             findings.append(
                 BundleFinding(
@@ -1196,8 +1279,7 @@ def _match_target_against_index(
             matched.append(demangled)
             provider_set.add(lib_name)
     providers = [
-        ProviderEntry(library=name, version="")
-        for name in sorted(provider_set)
+        ProviderEntry(library=name, version="") for name in sorted(provider_set)
     ]
     return matched, providers
 
@@ -1228,10 +1310,7 @@ def _match_entry(
     :func:`_build_demangled_index` and pass it in to amortise the
     O(symbols) demangle pass across all targets.
     """
-    needs_index = any(
-        kind != "symbol"
-        for _, kind in _entry_targets(entry)
-    )
+    needs_index = any(kind != "symbol" for _, kind in _entry_targets(entry))
     if index is None and needs_index:
         index = _build_demangled_index(snapshot)
     out: list[tuple[str, str, list[str], list[ProviderEntry]]] = []
@@ -1284,11 +1363,15 @@ def _detect_manifest_drift(
                 )
                 continue
             if not entry.optional_provider and entry.library is not None:
-                def _matches(prov: ProviderEntry, _entry: ManifestEntry = entry) -> bool:
+
+                def _matches(
+                    prov: ProviderEntry, _entry: ManifestEntry = entry
+                ) -> bool:
                     if prov.library == _entry.library:
                         return True
                     meta = new.metadata.get(prov.library)
                     return meta is not None and meta.soname == _entry.library
+
                 if not any(_matches(p) for p in providers):
                     got = ", ".join(sorted(p.library for p in providers))
                     findings.append(
@@ -1335,16 +1418,44 @@ def _detect_manifest_drift(
 
 # Common system-provided symbols imported by almost every C/C++ DSO.
 # Avoids false-positive bundle findings for libc/libstdc++ symbols.
-DEFAULT_SYSTEM_SYMBOLS: frozenset[str] = frozenset({
-    "__libc_start_main", "__cxa_atexit", "__cxa_finalize", "__cxa_throw",
-    "__gxx_personality_v0", "__stack_chk_fail", "__stack_chk_guard",
-    "__tls_get_addr", "__errno_location", "_ITM_registerTMCloneTable",
-    "_ITM_deregisterTMCloneTable",
-    "abort", "exit", "malloc", "free", "calloc", "realloc",
-    "memcpy", "memmove", "memset", "memcmp", "strlen", "strcmp", "strncmp",
-    "strcpy", "strncpy", "strdup", "fprintf", "printf", "puts",
-    "pthread_once", "pthread_self", "pthread_create", "pthread_join",
-})
+DEFAULT_SYSTEM_SYMBOLS: frozenset[str] = frozenset(
+    {
+        "__libc_start_main",
+        "__cxa_atexit",
+        "__cxa_finalize",
+        "__cxa_throw",
+        "__gxx_personality_v0",
+        "__stack_chk_fail",
+        "__stack_chk_guard",
+        "__tls_get_addr",
+        "__errno_location",
+        "_ITM_registerTMCloneTable",
+        "_ITM_deregisterTMCloneTable",
+        "abort",
+        "exit",
+        "malloc",
+        "free",
+        "calloc",
+        "realloc",
+        "memcpy",
+        "memmove",
+        "memset",
+        "memcmp",
+        "strlen",
+        "strcmp",
+        "strncmp",
+        "strcpy",
+        "strncpy",
+        "strdup",
+        "fprintf",
+        "printf",
+        "puts",
+        "pthread_once",
+        "pthread_self",
+        "pthread_create",
+        "pthread_join",
+    }
+)
 
 
 def _looks_system(soname: str) -> bool:

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -889,6 +889,22 @@ def _detect_intra_type_changed(
     symbols. Misses extern-C function pointers that pass struct
     references (would require type-graph propagation from DWARF, future
     work — out of scope for ADR-023 first cut).
+
+    Reachability scope (ADR-027 A3 / D3.2 limitation). The public-vs-internal
+    split below is computed from ``ElfMetadata.symbols``, which is parsed from
+    ``.dynsym`` and therefore holds only **exported** (GLOBAL/WEAK,
+    non-hidden) definitions — LOCAL and hidden symbols are not retained
+    (``elf_metadata._parse_dynsym``). Consequently a consumer that references
+    the changed type **only** from its own internal/hidden functions leaves no
+    trace here: no exported symbol carries the type name, ``consumer_reach``
+    stays empty, and no finding is emitted for that consumer. The
+    ``internal_hit`` (demote-to-risk) branch therefore fires only for inputs
+    whose snapshots happen to carry local symbols (e.g. relocatable objects or
+    DWARF-derived graphs); detecting purely internal cross-DSO references from
+    a stripped shared object would require retaining non-exported symbols or a
+    full type graph, deliberately out of scope (documented per the ADR-027
+    review — the conservative miss is preferred over a parser/schema change
+    with broad blast radius).
     """
     findings: list[BundleFinding] = []
     # Dedup: one finding per (consumer, provider, type) triple — multiple

--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -888,4 +888,22 @@ REGISTRY = ChangeKindRegistry([
               "forward-declared struct) changed its underlying token type in a way "
               "callers can observe. Code that stored or compared the old handle "
               "representation now operates on an incompatible token."),
+
+    # ── API-surface metric drift (ADR-027 A1 / D1.2) ────────────────────────
+    _E("public_surface_grew", _C,
+       impact="The aggregate count of public declarations (functions, variables, "
+              "types, enums) increased between versions. Informational only — the "
+              "individual additions are reported separately; this is the net "
+              "signal for CI dashboards and release notes. Emitted only with "
+              "--surface-metrics."),
+    _E("public_surface_shrank", _C,
+       impact="The aggregate count of public declarations decreased between "
+              "versions. Informational roll-up only — individual removals are "
+              "reported (and may be breaking) on their own. Emitted only with "
+              "--surface-metrics."),
+    _E("undocumented_export_ratio_increased", _C,
+       impact="The fraction of exported symbols with no public-header declaration "
+              "(EXPORT_ONLY origin) rose between versions — a packaging-hygiene "
+              "regression: a symbol was exported without a corresponding public "
+              "header. Informational; emitted only with --surface-metrics."),
 ])

--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -859,4 +859,33 @@ REGISTRY = ChangeKindRegistry([
               "_Atomic-qualified type may differ from the unqualified type and "
               "varies across compilers, so layout and calling convention "
               "diverge and old code is miscompiled."),
+
+    # ── API-surface intelligence anti-patterns (ADR-027 A2 / D2.2) ──────────
+    _E("public_api_exposes_stl_by_value", _R,
+       impact="A public function takes or returns a `std::` type by value across "
+              "the library boundary. Standard-library layouts (string, vector, "
+              "etc.) differ across toolchains, standard-library versions, and "
+              "the C++11 dual-ABI setting, so passing one by value at the ABI "
+              "boundary is fragile: a consumer built with a different STL silently "
+              "reads the wrong layout. Pass an opaque handle or a C-style view "
+              "instead."),
+    _E("polymorphic_type_non_virtual_dtor", _R,
+       impact="A type with virtual methods (it has a vtable) is used as a factory "
+              "return or base class but declares no virtual destructor. Deleting "
+              "a derived object through a base pointer is undefined behaviour: the "
+              "derived destructor never runs and the wrong amount of memory may be "
+              "freed. Declare the base destructor `virtual`."),
+    _E("opaque_invariant_broken", _B,
+       impact="A type that was opaque (its definition hidden from callers, crossed "
+              "only by pointer) or PIMPL now exposes its layout — its complete "
+              "definition became visible in the public include closure, or a "
+              "public function began passing it by value. Callers that relied on "
+              "never seeing the layout can now `sizeof`/embed it, so the type's "
+              "size and fields have joined the ABI and any later change to them is "
+              "a hard break."),
+    _E("handle_type_changed", _B,
+       impact="An opaque handle typedef (a `void*` token or a pointer to a "
+              "forward-declared struct) changed its underlying token type in a way "
+              "callers can observe. Code that stored or compared the old handle "
+              "representation now operates on an incompatible token."),
 ])

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -181,6 +181,7 @@ def compare(
     force_public_symbols: set[str] | None = None,
     extra_changes: list[Change] | None = None,
     pattern_verdicts: bool = False,
+    surface_metrics: bool = False,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.
 
@@ -304,6 +305,17 @@ def compare(
         old, new, scope_enabled=scope_to_public_surface,
         surf_old=pp_ctx.surf_old, surf_new=pp_ctx.surf_new,
     )
+
+    # ADR-027 A1/D1.2: aggregate surface-metric drift (opt-in --surface-metrics).
+    # COMPATIBLE informational roll-ups; suppressible like any finding and never
+    # breaking, so they leave the verdict unchanged.
+    if surface_metrics:
+        from .diff_surface_metrics import diff_surface_metrics
+        for c in diff_surface_metrics(old, new):
+            if suppression is not None and suppression.is_suppressed(c):
+                suppressed.append(c)
+            else:
+                kept.append(c)
 
     # ADR-027 A4: pattern-aware verdict modulation. Runs after post-processing
     # and before the (recomputed) verdict so a demotion/raise reaches both the

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Checker — diff two AbiSnapshots, classify changes, produce a verdict."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -144,8 +145,12 @@ def _diff_advanced_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     from .dwarf_advanced import AdvancedDwarfMetadata
 
-    o: AdvancedDwarfMetadata = getattr(old, "dwarf_advanced", None) or AdvancedDwarfMetadata()
-    n: AdvancedDwarfMetadata = getattr(new, "dwarf_advanced", None) or AdvancedDwarfMetadata()
+    o: AdvancedDwarfMetadata = (
+        getattr(old, "dwarf_advanced", None) or AdvancedDwarfMetadata()
+    )
+    n: AdvancedDwarfMetadata = (
+        getattr(new, "dwarf_advanced", None) or AdvancedDwarfMetadata()
+    )
 
     _kind_map = {
         "calling_convention_changed": ChangeKind.CALLING_CONVENTION_CHANGED,
@@ -212,9 +217,14 @@ def compare(
     # PolicyFile.frozen_namespaces is threaded in so the late-stage
     # EscalateFrozenNamespaceViolations step can tag matching findings.
     from .post_processing import DEFAULT_PIPELINE
+
     frozen_ns = list(policy_file.frozen_namespaces) if policy_file is not None else []
     pp_ctx = DEFAULT_PIPELINE.run(
-        changes, old, new, suppression=suppression, frozen_namespaces=frozen_ns,
+        changes,
+        old,
+        new,
+        suppression=suppression,
+        frozen_namespaces=frozen_ns,
         scope_to_public_surface=scope_to_public_surface,
         force_public_symbols=force_public_symbols,
     )
@@ -240,8 +250,7 @@ def compare(
     # the downgraded rename back to BREAKING. They stay in redundant_changes
     # for audit (--show-redundant); they just don't drive the verdict.
     verdict_redundant = [
-        c for c in redundant
-        if not (c.caused_by_type or "").startswith("rename:")
+        c for c in redundant if not (c.caused_by_type or "").startswith("rename:")
     ]
 
     # Post-detector: SONAME bump policy check.  It needs the full semantic
@@ -262,7 +271,9 @@ def compare(
 
     _old_elf = getattr(old, "elf", None) or _ElfMetadata()
     _new_elf = getattr(new, "elf", None) or _ElfMetadata()
-    soname_changes = check_soname_bump_policy(kept + verdict_redundant, _old_elf, _new_elf)
+    soname_changes = check_soname_bump_policy(
+        kept + verdict_redundant, _old_elf, _new_elf
+    )
     if suppression is not None and soname_changes:
         visible_soname_changes: list[Change] = []
         for c in soname_changes:
@@ -276,34 +287,44 @@ def compare(
 
     all_unsuppressed = kept + verdict_redundant
 
-    verdict = policy_file.compute_verdict(all_unsuppressed) if policy_file is not None else compute_verdict(all_unsuppressed, policy=policy)
+    verdict = (
+        policy_file.compute_verdict(all_unsuppressed)
+        if policy_file is not None
+        else compute_verdict(all_unsuppressed, policy=policy)
+    )
     effective_policy = policy_file.base_policy if policy_file is not None else policy
 
     # opaque_filtered changes are visible under --show-redundant for audit, but their
     # label in the reporter is distinct from true display-dedup redundant changes.
     # redundant_count reflects only the display-dedup set; opaque_filtered is additive.
     redundant_for_report = redundant + opaque_filtered
-    true_redundant_count = len(redundant)  # dedup-only (not opaque); used for report label
+    true_redundant_count = len(
+        redundant
+    )  # dedup-only (not opaque); used for report label
 
     # Compute old_symbol_count once for downstream metrics (Bug 8)
-    old_sym_count = sum(
-        1 for f in old.functions if f.visibility in _PUBLIC_VIS
-    ) + sum(
+    old_sym_count = sum(1 for f in old.functions if f.visibility in _PUBLIC_VIS) + sum(
         1 for v in old.variables if v.visibility in _PUBLIC_VIS
     )
 
     # Compute evidence tiers and confidence from detector results.
     evidence_tiers, confidence, coverage_warnings, evidence_tier = _compute_confidence(
-        detector_results, old, new,
+        detector_results,
+        old,
+        new,
     )
 
     # ADR-024 §D5.3: structured confidence in the surface resolution itself.
     # Reuse the surfaces FilterNonPublicSurface already computed (when scoping
     # ran) to avoid repeating the type-closure walk.
     from .surface import surface_scope_confidence
+
     scope_confidence, scope_notes = surface_scope_confidence(
-        old, new, scope_enabled=scope_to_public_surface,
-        surf_old=pp_ctx.surf_old, surf_new=pp_ctx.surf_new,
+        old,
+        new,
+        scope_enabled=scope_to_public_surface,
+        surf_old=pp_ctx.surf_old,
+        surf_new=pp_ctx.surf_new,
     )
 
     # ADR-027 A1/D1.2: aggregate surface-metric drift (opt-in --surface-metrics).
@@ -311,6 +332,7 @@ def compare(
     # breaking, so they leave the verdict unchanged.
     if surface_metrics:
         from .diff_surface_metrics import diff_surface_metrics
+
         for c in diff_surface_metrics(old, new):
             if suppression is not None and suppression.is_suppressed(c):
                 suppressed.append(c)
@@ -325,18 +347,31 @@ def compare(
     pattern_modulations: list[dict[str, object]] = []
     if pattern_verdicts:
         from .pattern_verdicts import apply_pattern_verdicts
+
         pre_pattern_count = len(kept)
         pattern_modulations = apply_pattern_verdicts(
             kept, old, new, evidence_tier=evidence_tier
         )
         if suppression is not None and len(kept) > pre_pattern_count:
             retained = kept[:pre_pattern_count]
+            suppressed_synthetic: set[tuple[str, str | None]] = set()
             for c in kept[pre_pattern_count:]:
                 if suppression.is_suppressed(c):
                     suppressed.append(c)
+                    # Drop this synthetic finding's disclosure row too, so a
+                    # fully-suppressed handle/opaque/anti-pattern transition does
+                    # not linger in the pattern_modulations ledger while it is
+                    # absent from `changes` and the verdict (ADR-027 review).
+                    suppressed_synthetic.add((c.symbol, c.modulation_rule))
                 else:
                     retained.append(c)
             kept = retained
+            if suppressed_synthetic:
+                pattern_modulations = [
+                    m
+                    for m in pattern_modulations
+                    if (m.get("symbol"), m.get("rule_id")) not in suppressed_synthetic
+                ]
         if pattern_modulations:
             all_unsuppressed = kept + verdict_redundant
             verdict = (

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -180,6 +180,7 @@ def compare(
     scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
     extra_changes: list[Change] | None = None,
+    pattern_verdicts: bool = False,
 ) -> DiffResult:
     """Diff two AbiSnapshots and return a DiffResult with verdict.
 
@@ -304,6 +305,25 @@ def compare(
         surf_old=pp_ctx.surf_old, surf_new=pp_ctx.surf_new,
     )
 
+    # ADR-027 A4: pattern-aware verdict modulation. Runs after post-processing
+    # and before the (recomputed) verdict so a demotion/raise reaches both the
+    # reported findings and the exit code. Off by default (opt-in via
+    # --pattern-verdicts); a no-op that leaves `kept`/`verdict` untouched
+    # otherwise.
+    pattern_modulations: list[dict[str, object]] = []
+    if pattern_verdicts:
+        from .pattern_verdicts import apply_pattern_verdicts
+        pattern_modulations = apply_pattern_verdicts(
+            kept, old, new, evidence_tier=evidence_tier
+        )
+        if pattern_modulations:
+            all_unsuppressed = kept + verdict_redundant
+            verdict = (
+                policy_file.compute_verdict(all_unsuppressed)
+                if policy_file is not None
+                else compute_verdict(all_unsuppressed, policy=policy)
+            )
+
     return DiffResult(
         old_version=old.version,
         new_version=new.version,
@@ -329,4 +349,5 @@ def compare(
         surface_scope_confidence=scope_confidence,
         surface_scope_notes=scope_notes,
         evidence_tier=evidence_tier,
+        pattern_modulations=pattern_modulations,
     )

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -313,9 +313,18 @@ def compare(
     pattern_modulations: list[dict[str, object]] = []
     if pattern_verdicts:
         from .pattern_verdicts import apply_pattern_verdicts
+        pre_pattern_count = len(kept)
         pattern_modulations = apply_pattern_verdicts(
             kept, old, new, evidence_tier=evidence_tier
         )
+        if suppression is not None and len(kept) > pre_pattern_count:
+            retained = kept[:pre_pattern_count]
+            for c in kept[pre_pattern_count:]:
+                if suppression.is_suppressed(c):
+                    suppressed.append(c)
+                else:
+                    retained.append(c)
+            kept = retained
         if pattern_modulations:
             all_unsuppressed = kept + verdict_redundant
             verdict = (

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -364,8 +364,15 @@ def compare(
         from .pattern_verdicts import apply_pattern_verdicts
 
         pre_pattern_count = len(kept)
+        # A user policy override on a kind is authoritative: a pattern demotion
+        # must not lower it, or the aggregate verdict (which applies the
+        # override) would disagree with per-finding classification (ADR-027
+        # review). Protect every explicitly-overridden kind from demotion.
+        protected_kinds = (
+            frozenset(policy_file.overrides) if policy_file is not None else frozenset()
+        )
         pattern_modulations = apply_pattern_verdicts(
-            kept, old, new, evidence_tier=evidence_tier
+            kept, old, new, evidence_tier=evidence_tier, protected_kinds=protected_kinds
         )
         if suppression is not None and len(kept) > pre_pattern_count:
             retained = kept[:pre_pattern_count]

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -333,11 +333,26 @@ def compare(
     if surface_metrics:
         from .diff_surface_metrics import diff_surface_metrics
 
+        surface_metric_added = False
         for c in diff_surface_metrics(old, new):
             if suppression is not None and suppression.is_suppressed(c):
                 suppressed.append(c)
             else:
                 kept.append(c)
+                surface_metric_added = True
+        # These roll-ups are COMPATIBLE, never breaking, but they are still
+        # changes: appending them after `verdict` was computed above would leave
+        # a NO_CHANGE verdict alongside e.g. a `public_surface_grew` finding,
+        # making the CLI/JSON summary inconsistent with the finding set. Recompute
+        # so NO_CHANGE flips to COMPATIBLE when the only findings are these
+        # roll-ups (ADR-027 review).
+        if surface_metric_added:
+            all_unsuppressed = kept + verdict_redundant
+            verdict = (
+                policy_file.compute_verdict(all_unsuppressed)
+                if policy_file is not None
+                else compute_verdict(all_unsuppressed, policy=policy)
+            )
 
     # ADR-027 A4: pattern-aware verdict modulation. Runs after post-processing
     # and before the (recomputed) verdict so a demotion/raise reaches both the

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -471,6 +471,18 @@ class ChangeKind(str, Enum):
     BIT_INT_WIDTH_CHANGED = "bit_int_width_changed"
     ATOMIC_QUALIFIER_CHANGED = "atomic_qualifier_changed"
 
+    # ── API-surface intelligence anti-patterns (ADR-027 A2 / D2.2) ──────────
+    # Graph-shaped findings recognised from the declaration graph rather than a
+    # per-symbol diff. The two RISK kinds are single-snapshot anti-patterns
+    # (reported by `surface-report`, and at diff time only when newly
+    # introduced); the two BREAKING kinds are idiom *transitions* emitted by the
+    # A4 pattern-verdict pass when an opacity/handle guarantee callers relied on
+    # is lost.
+    PUBLIC_API_EXPOSES_STL_BY_VALUE = "public_api_exposes_stl_by_value"
+    POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR = "polymorphic_type_non_virtual_dtor"
+    OPAQUE_INVARIANT_BROKEN = "opaque_invariant_broken"
+    HANDLE_TYPE_CHANGED = "handle_type_changed"
+
 
 class HasKind(Protocol):
     kind: ChangeKind

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -483,6 +483,14 @@ class ChangeKind(str, Enum):
     OPAQUE_INVARIANT_BROKEN = "opaque_invariant_broken"
     HANDLE_TYPE_CHANGED = "handle_type_changed"
 
+    # ── API-surface metric drift (ADR-027 A1 / D1.2) ────────────────────────
+    # Aggregate, informational signals emitted only with --surface-metrics.
+    # COMPATIBLE: never breaking on their own; useful for CI dashboards and
+    # release notes.
+    PUBLIC_SURFACE_GREW = "public_surface_grew"
+    PUBLIC_SURFACE_SHRANK = "public_surface_shrank"
+    UNDOCUMENTED_EXPORT_RATIO_INCREASED = "undocumented_export_ratio_increased"
+
 
 class HasKind(Protocol):
     kind: ChangeKind

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -170,6 +170,12 @@ class DiffResult:
     # Distinct from the raw ``evidence_tiers`` list above — this is the single
     # scalar consumers should key trust decisions off of. See EvidenceTier.
     evidence_tier: EvidenceTier = EvidenceTier.ELF_ONLY
+    # ADR-027 A4 — pattern-aware verdict modulation ledger. Each entry records a
+    # demotion/raise the pattern pass made (symbol, original→new category, the
+    # rule id, the disclosed reason, the evidence tier, and the graph edges that
+    # matched). Empty unless --pattern-verdicts was enabled. Findings themselves
+    # carry the override on Change.effective_verdict; this is the audit trail.
+    pattern_modulations: list[dict[str, object]] = field(default_factory=list)
 
     def _effective_kind_sets(
         self,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from .checker import DiffResult, LibraryMetadata, compare
+from .cli_audit import echo_filtered_surface, echo_pattern_modulations
 from .cli_params import POLICY_FILE_PARAM
 from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
 from .compat.cli import compat_group
@@ -1147,6 +1148,7 @@ def _run_compare_pair(
     old_pdb_path: Path | None,
     new_pdb_path: Path | None,
     scope_to_public_surface: bool = False,
+    pattern_verdicts: bool = False,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Run compare for one old/new pair and return result + resolved snapshots."""
     # Follow GNU ld linker scripts up front so metadata/dependency analysis use
@@ -1177,6 +1179,7 @@ def _run_compare_pair(
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_to_public_surface,
+        pattern_verdicts=pattern_verdicts,
     )
     result.old_metadata = _collect_metadata(old_input)
     result.new_metadata = _collect_metadata(new_input)
@@ -1299,20 +1302,6 @@ def _merge_redundant_changes(result: DiffResult) -> None:
     result.changes = result.changes + result.redundant_changes
     result.redundant_changes = []
     result.redundant_count = 0
-
-
-def _echo_filtered_surface(result: DiffResult) -> None:
-    """Print the public-surface audit ledger (ADR-024 §D5 traceability)."""
-    n = result.out_of_surface_count
-    click.echo(
-        f"\nFiltered as non-public ABI surface ({n} "
-        f"{'finding' if n == 1 else 'findings'}, --scope-public-headers):",
-        err=True,
-    )
-    for c in result.out_of_surface_changes:
-        loc = f" [{c.source_location}]" if c.source_location else ""
-        reason = f" ({c.surface_exclusion_reason})" if c.surface_exclusion_reason else ""
-        click.echo(f"  - {c.kind.value}: {c.symbol}{loc}{reason}", err=True)
 
 
 def _warn_all_suppressed(result: DiffResult) -> None:
@@ -1519,7 +1508,7 @@ def _finalize_compare_result(
     if show_redundant and result.redundant_changes:
         _merge_redundant_changes(result)
     if show_filtered and result.out_of_surface_changes:
-        _echo_filtered_surface(result)
+        echo_filtered_surface(result)
 
     # The scoping fallback warning goes to stderr so it never corrupts the
     # machine-readable payload on stdout (which carries scope_resolved /
@@ -1722,6 +1711,16 @@ def _finalize_compare_result(
               help="Enable debuginfod network resolution for debug info (opt-in).")
 @click.option("--debuginfod-url", "debuginfod_url", default=None,
               help="debuginfod server URL (overrides DEBUGINFOD_URLS env var).")
+# ── Pattern-aware verdicts (ADR-027 A4) ──────────────────────────────────────
+@click.option("--pattern-verdicts/--no-pattern-verdicts", "pattern_verdicts",
+              default=False,
+              help="Modulate verdicts with idiom/anti-pattern evidence (ADR-027): "
+                   "demote opaque-pointer/PIMPL-hidden layout changes (header-aware "
+                   "only) and raise breaks when an opacity/handle guarantee is lost. "
+                   "Disclosed in the pattern_modulations ledger; reversible.")
+@click.option("--explain-patterns", "explain_patterns", is_flag=True, default=False,
+              help="Print idiom evidence behind each modulation (implies "
+                   "--pattern-verdicts).")
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
 def compare_cmd(
@@ -1755,6 +1754,8 @@ def compare_cmd(
     debug_roots_new: tuple[Path, ...],
     debuginfod: bool,
     debuginfod_url: str | None,
+    pattern_verdicts: bool,
+    explain_patterns: bool,
     verbose: bool,
     probe_matrix_old: Path | None = None,
     probe_matrix_new: Path | None = None,
@@ -1903,12 +1904,17 @@ def compare_cmd(
 
     extra_changes = _load_probe_matrix_changes(probe_matrix_old, probe_matrix_new)
 
+    apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_public_headers,
         force_public_symbols=force_public,
         extra_changes=extra_changes,
+        pattern_verdicts=apply_patterns,
     )
+
+    if explain_patterns:
+        echo_pattern_modulations(result)
 
     _finalize_compare_result(
         result, old_input, new_input,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -26,6 +26,7 @@ import click
 
 from .checker import DiffResult, LibraryMetadata, compare
 from .cli_audit import echo_filtered_surface, echo_pattern_modulations
+from .cli_options import adr027_compare_options
 from .cli_params import POLICY_FILE_PARAM
 from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
 from .compat.cli import compat_group
@@ -1711,16 +1712,7 @@ def _finalize_compare_result(
               help="Enable debuginfod network resolution for debug info (opt-in).")
 @click.option("--debuginfod-url", "debuginfod_url", default=None,
               help="debuginfod server URL (overrides DEBUGINFOD_URLS env var).")
-# ── Pattern-aware verdicts (ADR-027 A4) ──────────────────────────────────────
-@click.option("--pattern-verdicts/--no-pattern-verdicts", "pattern_verdicts",
-              default=False,
-              help="Modulate verdicts with idiom/anti-pattern evidence (ADR-027): "
-                   "demote opaque-pointer/PIMPL-hidden layout changes (header-aware "
-                   "only) and raise breaks when an opacity/handle guarantee is lost. "
-                   "Disclosed in the pattern_modulations ledger; reversible.")
-@click.option("--explain-patterns", "explain_patterns", is_flag=True, default=False,
-              help="Print idiom evidence behind each modulation (implies "
-                   "--pattern-verdicts).")
+@adr027_compare_options  # ADR-027: --pattern-verdicts/--explain-patterns/--surface-metrics
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
 def compare_cmd(
@@ -1756,6 +1748,7 @@ def compare_cmd(
     debuginfod_url: str | None,
     pattern_verdicts: bool,
     explain_patterns: bool,
+    surface_metrics: bool,
     verbose: bool,
     probe_matrix_old: Path | None = None,
     probe_matrix_new: Path | None = None,
@@ -1911,6 +1904,7 @@ def compare_cmd(
         force_public_symbols=force_public,
         extra_changes=extra_changes,
         pattern_verdicts=apply_patterns,
+        surface_metrics=surface_metrics,
     )
 
     if explain_patterns:

--- a/abicheck/cli_audit.py
+++ b/abicheck/cli_audit.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/abicheck/cli_audit.py
+++ b/abicheck/cli_audit.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI audit-ledger printers.
+
+Small stderr printers for the disclosure ledgers abicheck keeps so a demotion
+is always auditable: the ADR-024 public-surface ledger and the ADR-027
+pattern-aware modulation ledger. Split out of :mod:`abicheck.cli` to keep that
+module under the AI-readiness file-size cap.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from .checker_types import DiffResult
+
+
+def echo_filtered_surface(result: DiffResult) -> None:
+    """Print the public-surface audit ledger (ADR-024 §D5 traceability)."""
+    n = result.out_of_surface_count
+    click.echo(
+        f"\nFiltered as non-public ABI surface ({n} "
+        f"{'finding' if n == 1 else 'findings'}, --scope-public-headers):",
+        err=True,
+    )
+    for c in result.out_of_surface_changes:
+        loc = f" [{c.source_location}]" if c.source_location else ""
+        reason = (
+            f" ({c.surface_exclusion_reason})" if c.surface_exclusion_reason else ""
+        )
+        click.echo(f"  - {c.kind.value}: {c.symbol}{loc}{reason}", err=True)
+
+
+def echo_pattern_modulations(result: DiffResult) -> None:
+    """Print the pattern-aware modulation ledger (ADR-027 A4 --explain-patterns)."""
+    mods = result.pattern_modulations
+    if not mods:
+        click.echo("\nNo pattern-aware modulations applied.", err=True)
+        return
+    click.echo(
+        f"\nPattern-aware modulations ({len(mods)}, --pattern-verdicts):",
+        err=True,
+    )
+    for m in mods:
+        sym = m.get("symbol", "?")
+        rule = m.get("rule_id", "?")
+        reason = m.get("reason", "")
+        oc = m.get("original_category", "?")
+        nc = m.get("new_category", "?")
+        click.echo(f"  - {sym}: {oc} -> {nc} [{rule}: {reason}]", err=True)
+        edges = m.get("edges_matched") or []
+        if isinstance(edges, list):
+            for e in edges:
+                click.echo(f"      · {e}", err=True)

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable Click option groups.
+
+Stacked-decorator helpers that bundle related ``compare`` options so the large
+``cli.py`` stays under the AI-readiness file-size cap. Imported at the top of
+``cli.py`` and applied to ``compare_cmd``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+import click
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def adr027_compare_options(func: F) -> F:
+    """Add the ADR-027 API-surface-intelligence options to ``compare``.
+
+    ``--pattern-verdicts`` / ``--explain-patterns`` (A4 modulation) and
+    ``--surface-metrics`` (A1/D1.2 metric drift). Decorators apply bottom-up, so
+    they are listed here in reverse of their displayed order.
+    """
+    func = click.option(
+        "--surface-metrics",
+        "surface_metrics",
+        is_flag=True,
+        default=False,
+        help="Emit aggregate public-surface metric drift (ADR-027): "
+        "public_surface_grew/shrank, undocumented_export_ratio_increased. "
+        "Informational (COMPATIBLE).",
+    )(func)
+    func = click.option(
+        "--explain-patterns",
+        "explain_patterns",
+        is_flag=True,
+        default=False,
+        help="Print idiom evidence behind each modulation (implies "
+        "--pattern-verdicts).",
+    )(func)
+    func = click.option(
+        "--pattern-verdicts/--no-pattern-verdicts",
+        "pattern_verdicts",
+        default=False,
+        help="Modulate verdicts with idiom/anti-pattern evidence (ADR-027): "
+        "demote opaque-pointer/PIMPL-hidden layout changes (header-aware only) "
+        "and raise breaks when an opacity/handle guarantee is lost. Disclosed in "
+        "the pattern_modulations ledger; reversible.",
+    )(func)
+    return func

--- a/abicheck/cli_surface.py
+++ b/abicheck/cli_surface.py
@@ -34,7 +34,7 @@ import click
 from .cli import _write_or_echo, main
 
 if TYPE_CHECKING:
-    from .idioms import IdiomTag
+    from .idioms import AntiPattern, IdiomTag
 
 
 @main.command("surface-report")
@@ -79,6 +79,14 @@ if TYPE_CHECKING:
     "factory, create/destroy, callback).",
 )
 @click.option(
+    "--anti-patterns/--no-anti-patterns",
+    "anti_patterns",
+    default=False,
+    show_default=True,
+    help="Detect and report ABI anti-patterns (std:: types crossed by value, "
+    "polymorphic types with no virtual destructor).",
+)
+@click.option(
     "-o",
     "--output",
     type=click.Path(path_type=Path),
@@ -92,6 +100,7 @@ def surface_report_cmd(
     fmt: str,
     top: int,
     idioms: bool,
+    anti_patterns: bool,
     output: Path | None,
 ) -> None:
     """Report structural metrics for a library's public ABI surface.
@@ -118,11 +127,19 @@ def surface_report_cmd(
     metrics = compute_surface_metrics(snap, top_n=top)
 
     idiom_tags: dict[str, list[IdiomTag]] = {}
-    if idioms:
-        from .idioms import recognise_idioms
+    anti_list: list[AntiPattern] = []
+    if idioms or anti_patterns:
         from .surface_graph import build_surface_graph
 
-        idiom_tags = recognise_idioms(build_surface_graph(snap))
+        graph = build_surface_graph(snap)
+        if idioms:
+            from .idioms import recognise_idioms
+
+            idiom_tags = recognise_idioms(graph)
+        if anti_patterns:
+            from .idioms import detect_antipatterns
+
+            anti_list = detect_antipatterns(graph)
 
     if fmt == "json":
         payload = metrics.to_dict()
@@ -141,14 +158,33 @@ def surface_report_cmd(
                 ]
                 for name, tags in idiom_tags.items()
             }
+        if anti_patterns:
+            payload["anti_patterns"] = [
+                {
+                    "symbol": a.symbol,
+                    "kind": a.kind.value,
+                    "description": a.description,
+                    "evidence": a.evidence,
+                }
+                for a in anti_list
+            ]
         _write_or_echo(output, json.dumps(payload, indent=2))
         return
 
-    _write_or_echo(output, _render_text(metrics, idiom_tags if idioms else None))
+    _write_or_echo(
+        output,
+        _render_text(
+            metrics,
+            idiom_tags if idioms else None,
+            anti_list if anti_patterns else None,
+        ),
+    )
 
 
 def _render_text(
-    metrics: object, idiom_tags: dict[str, list[IdiomTag]] | None = None
+    metrics: object,
+    idiom_tags: dict[str, list[IdiomTag]] | None = None,
+    anti_list: list[AntiPattern] | None = None,
 ) -> str:
     from .surface_graph import SurfaceMetrics
 
@@ -184,4 +220,8 @@ def _render_text(
                 lines.append(
                     f"    {tag.idiom.value:<16} {name}  [{tag.confidence.value}]"
                 )
+    if anti_list:
+        lines.append("  anti-patterns detected:")
+        for a in anti_list:
+            lines.append(f"    {a.kind.value:<34} {a.symbol}")
     return "\n".join(lines) + "\n"

--- a/abicheck/diff_surface_metrics.py
+++ b/abicheck/diff_surface_metrics.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/abicheck/diff_surface_metrics.py
+++ b/abicheck/diff_surface_metrics.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Surface-metric drift detection (ADR-027 A1 / D1.2).
+
+Computes the same single-snapshot metrics as ``surface-report`` for the old and
+new snapshots and surfaces the *aggregate deltas* as informational
+``COMPATIBLE`` findings. These never drive a breaking verdict on their own — the
+individual additions/removals are already reported per-symbol; this is the net
+roll-up signal, emitted only with ``--surface-metrics``.
+"""
+
+from __future__ import annotations
+
+from .checker_policy import ChangeKind
+from .checker_types import Change
+from .model import AbiSnapshot
+from .surface_graph import SurfaceMetrics, compute_surface_metrics
+
+# Minimum rise in the undocumented-export fraction (in absolute ratio points)
+# before it is reported, so floating-point noise / a single symbol on a tiny
+# surface does not trip the signal.
+_RATIO_EPSILON = 0.01
+
+
+def _public_decl_count(m: SurfaceMetrics) -> int:
+    return m.public_functions + m.public_variables + m.public_types + m.public_enums
+
+
+def diff_surface_metrics(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    """Return informational metric-drift findings between *old* and *new*.
+
+    Deterministic and side-effect free. All emitted findings are COMPATIBLE.
+    """
+    om = compute_surface_metrics(old)
+    nm = compute_surface_metrics(new)
+    changes: list[Change] = []
+
+    old_count = _public_decl_count(om)
+    new_count = _public_decl_count(nm)
+    if new_count > old_count:
+        changes.append(
+            Change(
+                kind=ChangeKind.PUBLIC_SURFACE_GREW,
+                symbol="<surface>",
+                description=(
+                    f"public surface grew: {old_count} → {new_count} "
+                    f"declarations (+{new_count - old_count})"
+                ),
+                old_value=str(old_count),
+                new_value=str(new_count),
+            )
+        )
+    elif new_count < old_count:
+        changes.append(
+            Change(
+                kind=ChangeKind.PUBLIC_SURFACE_SHRANK,
+                symbol="<surface>",
+                description=(
+                    f"public surface shrank: {old_count} → {new_count} "
+                    f"declarations ({new_count - old_count})"
+                ),
+                old_value=str(old_count),
+                new_value=str(new_count),
+            )
+        )
+
+    if nm.undocumented_export_ratio - om.undocumented_export_ratio > _RATIO_EPSILON:
+        changes.append(
+            Change(
+                kind=ChangeKind.UNDOCUMENTED_EXPORT_RATIO_INCREASED,
+                symbol="<surface>",
+                description=(
+                    "undocumented-export ratio rose: "
+                    f"{om.undocumented_export_ratio:.1%} → "
+                    f"{nm.undocumented_export_ratio:.1%} "
+                    "(symbols exported without a public header)"
+                ),
+                old_value=f"{om.undocumented_export_ratio:.4f}",
+                new_value=f"{nm.undocumented_export_ratio:.4f}",
+            )
+        )
+
+    return changes

--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -224,6 +224,30 @@ def _recognise_pimpl(graph: SurfaceGraph, rec: RecordType) -> IdiomTag | None:
     )
 
 
+def _resolve_pointee(
+    graph: SurfaceGraph, pointee: str
+) -> tuple[RecordType | None, bool]:
+    """Resolve a pointee type name to a record, flagging short-name ambiguity.
+
+    Exact qualified identity wins. Otherwise the unqualified short name binds
+    only when exactly one snapshot type carries it; if several types share the
+    short name (e.g. ``ns1::Ctx`` + ``ns2::Ctx``), the reference is ambiguous —
+    return ``(None, True)`` so callers never bind to whichever record
+    ``types_by_name`` happened to store first (a typedef ``Ctx *`` might point
+    at the complete ``ns2::Ctx``, not the incomplete ``ns1::Ctx`` — ADR-027
+    review). A name no snapshot type carries is unknown / forward-declared:
+    ``(None, False)``.
+    """
+    exact = graph.types_by_name.get(pointee)
+    if exact is not None and exact.name == pointee:
+        return exact, False
+    short = pointee.rsplit("::", 1)[-1]
+    matches = [r for r in graph.snapshot.types if r.name.rsplit("::", 1)[-1] == short]
+    if len(matches) == 1:
+        return matches[0], False
+    return (None, True) if matches else (None, False)
+
+
 def _recognise_handle(graph: SurfaceGraph) -> dict[str, IdiomTag]:
     out: dict[str, IdiomTag] = {}
     for alias, target in sorted(graph.snapshot.typedefs.items()):
@@ -232,17 +256,20 @@ def _recognise_handle(graph: SurfaceGraph) -> dict[str, IdiomTag]:
             continue
         pointee = _strip_ptr(t)
         # void* token, or a pointer to a forward-declared / unknown struct.
-        rec = graph.types_by_name.get(pointee) or graph.types_by_name.get(
-            pointee.rsplit("::", 1)[-1]
-        )
+        # Resolve by qualified identity; an ambiguous short name does not bind.
+        rec, ambiguous = _resolve_pointee(graph, pointee)
         # A handle is an opaque *token*: void*, or a pointer to a type that is
         # genuinely incomplete (a known opaque record, or an unknown user type —
         # a forward-declared struct). A pointer to a builtin/primitive (e.g.
         # ``int *``, ``int32_t *``) is NOT an opaque handle, so excluding it
         # avoids a false ``handle_type_changed`` when its pointee width changes
-        # (ADR-027 review). A *known but complete* record is likewise not a token.
+        # (ADR-027 review). A *known but complete* record is likewise not a token,
+        # and an ambiguous short-name pointee is not provably opaque so it is not
+        # tagged (it may resolve to a complete type — ADR-027 review).
         is_token = pointee in ("void", "") or (
-            _record_is_incomplete(rec) and not _is_builtin_type(pointee)
+            not ambiguous
+            and _record_is_incomplete(rec)
+            and not _is_builtin_type(pointee)
         )
         if is_token:
             out[alias] = IdiomTag(

--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -37,8 +37,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from .checker_policy import ChangeKind, Confidence
-from .model import ParamKind, RecordType, Visibility
+from .model import ParamKind, RecordType, ScopeOrigin, Visibility
 from .surface_graph import SurfaceGraph
+
+# Provenance origins that are NOT part of the public ABI surface — a type defined
+# only in one of these is the library's private implementation (ADR-024/027).
+_NON_PUBLIC_ORIGINS = frozenset(
+    {ScopeOrigin.PRIVATE_HEADER, ScopeOrigin.SYSTEM_HEADER, ScopeOrigin.GENERATED}
+)
 
 
 class Idiom(str, Enum):
@@ -399,6 +405,15 @@ def detect_antipatterns(graph: SurfaceGraph) -> list[AntiPattern]:
 
     base_targets: set[str] = set()
     for rec in graph.snapshot.types:
+        # Only count a base when the *deriving* type is on the public surface
+        # (ADR-027 review). A polymorphic Base inherited solely by a private /
+        # system / generated record is not a public ABI risk; counting it would
+        # also let that private-inheritance evidence pre-exist in old and wrongly
+        # suppress a *newly introduced* public factory risk for the same Base in
+        # _emit_new_antipatterns(). When no public-header set was supplied every
+        # record is UNKNOWN, which is treated as in-surface (no behaviour change).
+        if rec.origin in _NON_PUBLIC_ORIGINS:
+            continue
         for b in rec.bases:
             resolved = _resolve(b)
             if resolved is not None:

--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -96,6 +96,49 @@ def _is_pointer(type_str: str) -> bool:
     return "*" in type_str
 
 
+# Primitive/builtin type words; a pointer to one of these is not an opaque
+# handle token. ``_strip_ptr`` already removes struct/class/union/cv keywords,
+# so the pointee is just the core type spelling here.
+_PRIMITIVE_WORDS = frozenset(
+    {
+        "void",
+        "bool",
+        "char",
+        "wchar_t",
+        "char8_t",
+        "char16_t",
+        "char32_t",
+        "short",
+        "int",
+        "long",
+        "float",
+        "double",
+        "signed",
+        "unsigned",
+        "_Bool",
+        "__int128",
+    }
+)
+_STDINT_RE = re.compile(
+    r"^(u?int(_least|_fast)?(8|16|32|64|max|ptr)_t|size_t|ssize_t|ptrdiff_t)$"
+)
+
+
+def _is_builtin_type(pointee: str) -> bool:
+    """True when *pointee* names a builtin/primitive (not an opaque user type).
+
+    A typedef like ``int *`` / ``int32_t *`` is a pointer to a primitive, not an
+    opaque handle token — so it must not be tagged HANDLE (ADR-027 review).
+    """
+    name = pointee.strip()
+    if not name:
+        return False
+    if _STDINT_RE.match(name):
+        return True
+    words = name.split()
+    return bool(words) and all(w in _PRIMITIVE_WORDS for w in words)
+
+
 def _record_is_incomplete(rec: RecordType | None) -> bool:
     """True when *rec* is unknown or an incomplete (forward-declared) type.
 
@@ -192,7 +235,16 @@ def _recognise_handle(graph: SurfaceGraph) -> dict[str, IdiomTag]:
         rec = graph.types_by_name.get(pointee) or graph.types_by_name.get(
             pointee.rsplit("::", 1)[-1]
         )
-        if pointee in ("void", "") or _record_is_incomplete(rec):
+        # A handle is an opaque *token*: void*, or a pointer to a type that is
+        # genuinely incomplete (a known opaque record, or an unknown user type —
+        # a forward-declared struct). A pointer to a builtin/primitive (e.g.
+        # ``int *``, ``int32_t *``) is NOT an opaque handle, so excluding it
+        # avoids a false ``handle_type_changed`` when its pointee width changes
+        # (ADR-027 review). A *known but complete* record is likewise not a token.
+        is_token = pointee in ("void", "") or (
+            _record_is_incomplete(rec) and not _is_builtin_type(pointee)
+        )
+        if is_token:
             out[alias] = IdiomTag(
                 idiom=Idiom.HANDLE,
                 confidence=Confidence.MEDIUM if pointee != "void" else Confidence.HIGH,

--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -382,24 +382,40 @@ def detect_antipatterns(graph: SurfaceGraph) -> list[AntiPattern]:
             )
 
     # POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR — polymorphic types used as base/factory.
-    base_names: set[str] = set()
+    # Resolve every base/factory target spelling to a *specific* snapshot type
+    # (exact qualified name, or short name only when unambiguous), so a factory
+    # returning ns1::Base* never tags an unrelated ns2::Base that merely shares a
+    # short name (ADR-027 review). Unresolvable / ambiguous targets are dropped.
+    all_type_names = {rec.name for rec in graph.snapshot.types}
+    by_short: dict[str, list[str]] = {}
+    for n in all_type_names:
+        by_short.setdefault(n.rsplit("::", 1)[-1], []).append(n)
+
+    def _resolve(spelling: str) -> str | None:
+        if spelling in all_type_names:
+            return spelling
+        cands = by_short.get(spelling.rsplit("::", 1)[-1], [])
+        return cands[0] if len(cands) == 1 else None
+
+    base_targets: set[str] = set()
     for rec in graph.snapshot.types:
         for b in rec.bases:
-            base_names.add(b)
-            base_names.add(b.rsplit("::", 1)[-1])
-    factory_returns: set[str] = set()
+            resolved = _resolve(b)
+            if resolved is not None:
+                base_targets.add(resolved)
+    factory_targets: set[str] = set()
     for fn in graph.snapshot.functions:
         if fn.visibility != Visibility.PUBLIC:
             continue
         if fn.return_pointer_depth >= 1 or _is_pointer(fn.return_type):
-            factory_returns.add(_strip_ptr(fn.return_type))
-            factory_returns.add(_strip_ptr(fn.return_type).rsplit("::", 1)[-1])
+            resolved = _resolve(_strip_ptr(fn.return_type))
+            if resolved is not None:
+                factory_targets.add(resolved)
     for rec in graph.snapshot.types:
         if not rec.vtable:
             continue
-        short = rec.name.rsplit("::", 1)[-1]
-        used_as_base = rec.name in base_names or short in base_names
-        used_as_factory = rec.name in factory_returns or short in factory_returns
+        used_as_base = rec.name in base_targets
+        used_as_factory = rec.name in factory_targets
         if not (used_as_base or used_as_factory):
             continue
         if _has_virtual_destructor(rec):

--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -36,8 +36,8 @@ import re
 from dataclasses import dataclass, field
 from enum import Enum
 
-from .checker_policy import Confidence
-from .model import RecordType, Visibility
+from .checker_policy import ChangeKind, Confidence
+from .model import ParamKind, RecordType, Visibility
 from .surface_graph import SurfaceGraph
 
 
@@ -303,6 +303,121 @@ def _recognise_callbacks(graph: SurfaceGraph) -> dict[str, IdiomTag]:
                     ),
                 )
     return out
+
+
+@dataclass(frozen=True)
+class AntiPattern:
+    """A single-snapshot anti-pattern finding (ADR-027 D2.2).
+
+    ``kind`` is the :class:`ChangeKind` the finding maps to; ``evidence`` lists
+    the graph edges that matched (for ``surface-report`` and the A4 ledger).
+    """
+
+    symbol: str
+    kind: ChangeKind
+    description: str
+    evidence: list[str] = field(default_factory=list)
+
+
+def _is_std_by_value(type_str: str, pointer_depth: int, kind: ParamKind) -> bool:
+    """True when *type_str* names a ``std::`` type crossed **by value**.
+
+    A pointer/reference to a ``std::`` type is fine (only the pointer crosses
+    the boundary); it is passing/returning the container itself that is fragile.
+    """
+    if "std::" not in type_str:
+        return False
+    if pointer_depth >= 1 or _is_pointer(type_str) or "&" in type_str:
+        return False
+    if kind in (ParamKind.POINTER, ParamKind.REFERENCE, ParamKind.RVALUE_REF):
+        return False
+    return True
+
+
+def _has_virtual_destructor(rec: RecordType) -> bool:
+    """Heuristic: does *rec*'s vtable carry a destructor slot?
+
+    Itanium mangles destructors with ``D0``/``D1``/``D2`` suffixes; MSVC uses
+    ``??1`` / ``vector deleting destructor``. A polymorphic type whose vtable
+    has no destructor slot has a non-virtual destructor — deleting through a
+    base pointer is UB.
+    """
+    for entry in rec.vtable:
+        if re.search(r"D[012]\b|D[012]Ev|\?\?1|deleting destructor", entry):
+            return True
+    return False
+
+
+def detect_antipatterns(graph: SurfaceGraph) -> list[AntiPattern]:
+    """Recognise single-snapshot anti-patterns over *graph* (ADR-027 D2.2).
+
+    Returns the deterministic, order-stable list of RISK-level anti-patterns:
+    public functions exposing ``std::`` types by value, and polymorphic types
+    (used as a base or factory return) lacking a virtual destructor.
+    """
+    found: list[AntiPattern] = []
+
+    # PUBLIC_API_EXPOSES_STL_BY_VALUE — per public function.
+    for fn in graph.snapshot.functions:
+        if fn.visibility != Visibility.PUBLIC:
+            continue
+        hits: list[str] = []
+        if _is_std_by_value(fn.return_type, fn.return_pointer_depth, ParamKind.VALUE):
+            hits.append(f"returns {fn.return_type} by value")
+        for p in fn.params:
+            ptype = getattr(p, "type", "") or ""
+            if _is_std_by_value(ptype, getattr(p, "pointer_depth", 0), p.kind):
+                hits.append(f"parameter {p.name!r} is {ptype} by value")
+        if hits:
+            found.append(
+                AntiPattern(
+                    symbol=fn.name,
+                    kind=ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE,
+                    description=(
+                        f"public function {fn.name} crosses the ABI boundary with "
+                        f"a std:: type by value ({'; '.join(hits)})"
+                    ),
+                    evidence=hits,
+                )
+            )
+
+    # POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR — polymorphic types used as base/factory.
+    base_names: set[str] = set()
+    for rec in graph.snapshot.types:
+        for b in rec.bases:
+            base_names.add(b)
+            base_names.add(b.rsplit("::", 1)[-1])
+    factory_returns: set[str] = set()
+    for fn in graph.snapshot.functions:
+        if fn.visibility != Visibility.PUBLIC:
+            continue
+        if fn.return_pointer_depth >= 1 or _is_pointer(fn.return_type):
+            factory_returns.add(_strip_ptr(fn.return_type))
+            factory_returns.add(_strip_ptr(fn.return_type).rsplit("::", 1)[-1])
+    for rec in graph.snapshot.types:
+        if not rec.vtable:
+            continue
+        short = rec.name.rsplit("::", 1)[-1]
+        used_as_base = rec.name in base_names or short in base_names
+        used_as_factory = rec.name in factory_returns or short in factory_returns
+        if not (used_as_base or used_as_factory):
+            continue
+        if _has_virtual_destructor(rec):
+            continue
+        role = "base class" if used_as_base else "factory return"
+        found.append(
+            AntiPattern(
+                symbol=rec.name,
+                kind=ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR,
+                description=(
+                    f"polymorphic type {rec.name} (used as {role}) has a vtable "
+                    f"but no virtual destructor — delete through base is UB"
+                ),
+                evidence=[f"{rec.name} has vtable, no destructor slot; role={role}"],
+            )
+        )
+
+    return sorted(found, key=lambda a: (a.kind.value, a.symbol))
 
 
 def recognise_idioms(graph: SurfaceGraph) -> dict[str, list[IdiomTag]]:

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -44,7 +44,7 @@ import io
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
-from .checker_policy import ChangeKind, policy_for
+from .checker_policy import ChangeKind, Verdict, policy_for
 from .checker_types import Change, DiffResult
 from .reporter import apply_show_only
 
@@ -100,6 +100,15 @@ def _is_failure(
     ``--severity-*`` overrides), its level takes precedence so that
     the JUnit output honours user-configured severity escalations.
     """
+    # Honour an A4 per-finding effective_verdict (ADR-027): a demoted opaque/
+    # PIMPL layout change reads compatible and must not be a JUnit failure.
+    eff = getattr(change, "effective_verdict", None)
+    if isinstance(eff, Verdict):
+        if eff in (Verdict.BREAKING, Verdict.API_BREAK):
+            return True
+        if eff == Verdict.COMPATIBLE_WITH_RISK:
+            return policy_for(change.kind).severity == "error"
+        return False  # COMPATIBLE / NO_CHANGE → not a failure
     if change.kind in breaking_set or change.kind in api_break_set:
         return True
     if severity_config is not None:
@@ -119,6 +128,13 @@ def _failure_type(
     risk_set: frozenset[ChangeKind],
 ) -> str:
     """Return the ``type`` attribute for a ``<failure>`` element."""
+    eff = getattr(change, "effective_verdict", None)
+    if isinstance(eff, Verdict):
+        return {
+            Verdict.BREAKING: "BREAKING",
+            Verdict.API_BREAK: "API_BREAK",
+            Verdict.COMPATIBLE_WITH_RISK: "COMPATIBLE_WITH_RISK",
+        }.get(eff, "COMPATIBLE")
     if change.kind in breaking_set:
         return "BREAKING"
     if change.kind in api_break_set:

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -60,8 +60,7 @@ if TYPE_CHECKING:
 _FUNC_KINDS = frozenset(k for k in ChangeKind if k.value.startswith("func_"))
 _VAR_KINDS = frozenset(k for k in ChangeKind if k.value.startswith("var_"))
 _TYPE_KINDS = frozenset(
-    k for k in ChangeKind
-    if k.value.startswith("type_") or k.value.startswith("union_")
+    k for k in ChangeKind if k.value.startswith("type_") or k.value.startswith("union_")
 )
 _ENUM_KINDS = frozenset(k for k in ChangeKind if k.value.startswith("enum_"))
 
@@ -82,6 +81,7 @@ def _classname_for(change: Change) -> str:
 # ---------------------------------------------------------------------------
 # Verdict → failure classification
 # ---------------------------------------------------------------------------
+
 
 def _is_failure(
     change: Change,
@@ -107,7 +107,19 @@ def _is_failure(
         if eff in (Verdict.BREAKING, Verdict.API_BREAK):
             return True
         if eff == Verdict.COMPATIBLE_WITH_RISK:
-            return policy_for(change.kind).severity == "error"
+            # A risk-*demoted* finding (e.g. the A3 bundle reachability demotion
+            # of a breaking BUNDLE_INTRA_TYPE_CHANGED) must follow its EFFECTIVE
+            # risk category, not the original breaking kind's severity. It fails
+            # only when the user escalated potential_breaking to error; by
+            # default risk is a warning, not a JUnit failure.
+            if severity_config is not None:
+                from .severity import IssueCategory, SeverityLevel
+
+                return (
+                    severity_config.level_for(IssueCategory.POTENTIAL_BREAKING)
+                    == SeverityLevel.ERROR
+                )
+            return False
         return False  # COMPATIBLE / NO_CHANGE → not a failure
     if change.kind in breaking_set or change.kind in api_break_set:
         return True
@@ -147,6 +159,7 @@ def _failure_type(
 # ---------------------------------------------------------------------------
 # Single DiffResult → <testsuite>
 # ---------------------------------------------------------------------------
+
 
 def _partition_changes(
     changes: list[Change],
@@ -231,8 +244,11 @@ def _emit_testcases(
             tc.set("classname", classname)
             if sym in change_by_symbol:
                 _maybe_add_failure(
-                    tc, change_by_symbol[sym],
-                    breaking_set, api_break_set, risk_set,
+                    tc,
+                    change_by_symbol[sym],
+                    breaking_set,
+                    api_break_set,
+                    risk_set,
                     severity_config,
                 )
     else:
@@ -242,7 +258,12 @@ def _emit_testcases(
             tc.set("name", sym)
             tc.set("classname", _classname_for(c))
             _maybe_add_failure(
-                tc, c, breaking_set, api_break_set, risk_set, severity_config,
+                tc,
+                c,
+                breaking_set,
+                api_break_set,
+                risk_set,
+                severity_config,
             )
 
 
@@ -292,7 +313,9 @@ def _build_testsuite(
 
     change_by_symbol, extra_changes = _partition_changes(changes)
     all_symbols = _collect_all_symbols(old_snapshot, show_only, change_by_symbol)
-    failure_count = _count_failures(changes, breaking_set, api_break_set, risk_set, severity_config)
+    failure_count = _count_failures(
+        changes, breaking_set, api_break_set, risk_set, severity_config
+    )
 
     total = len(all_symbols) if all_symbols else len(change_by_symbol)
 
@@ -302,8 +325,18 @@ def _build_testsuite(
     ts.set("failures", str(failure_count))
     ts.set("errors", "0")
 
-    _emit_testcases(ts, all_symbols, change_by_symbol, breaking_set, api_break_set, risk_set, severity_config)
-    _append_extra_failures(ts, extra_changes, breaking_set, api_break_set, risk_set, severity_config)
+    _emit_testcases(
+        ts,
+        all_symbols,
+        change_by_symbol,
+        breaking_set,
+        api_break_set,
+        risk_set,
+        severity_config,
+    )
+    _append_extra_failures(
+        ts, extra_changes, breaking_set, api_break_set, risk_set, severity_config
+    )
 
     return ts
 
@@ -352,6 +385,7 @@ def _add_failure(
 # Error testsuite — represent failed compare-release pairs
 # ---------------------------------------------------------------------------
 
+
 def _build_error_testsuite(library: str, error_msg: str) -> ET.Element:
     """Build a ``<testsuite>`` with a single errored testcase.
 
@@ -380,6 +414,7 @@ def _build_error_testsuite(library: str, error_msg: str) -> ET.Element:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def to_junit_xml(
     result: DiffResult,
@@ -414,8 +449,10 @@ def to_junit_xml(
     root.set("name", "abicheck")
 
     ts = _build_testsuite(
-        result, old_snapshot,
-        show_only=show_only, severity_config=severity_config,
+        result,
+        old_snapshot,
+        show_only=show_only,
+        severity_config=severity_config,
     )
     root.append(ts)
 
@@ -452,8 +489,10 @@ def to_junit_xml_multi(
 
     for result, old_snap in results:
         ts = _build_testsuite(
-            result, old_snap,
-            show_only=show_only, severity_config=severity_config,
+            result,
+            old_snap,
+            show_only=show_only,
+            severity_config=severity_config,
         )
         root.append(ts)
         total_tests += int(ts.get("tests", "0"))

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -106,21 +106,23 @@ def _is_failure(
     if isinstance(eff, Verdict):
         if eff in (Verdict.BREAKING, Verdict.API_BREAK):
             return True
-        if eff == Verdict.COMPATIBLE_WITH_RISK:
-            # A risk-*demoted* finding (e.g. the A3 bundle reachability demotion
-            # of a breaking BUNDLE_INTRA_TYPE_CHANGED) must follow its EFFECTIVE
-            # risk category, not the original breaking kind's severity. It fails
-            # only when the user escalated potential_breaking to error; by
-            # default risk is a warning, not a JUnit failure.
-            if severity_config is not None:
-                from .severity import IssueCategory, SeverityLevel
+        # COMPATIBLE_WITH_RISK / COMPATIBLE / NO_CHANGE are not hard breaks, so a
+        # JUnit failure here happens only when the user's severity preset
+        # escalates the finding's EFFECTIVE category to error. Route through the
+        # same classifier the severity-aware exit code uses
+        # (``classify_change_object``, which honours ``effective_verdict``) so the
+        # JUnit file never disagrees with the exit status — e.g. a
+        # ``--pattern-verdicts`` demotion to compatible, or the A3 bundle
+        # reachability demotion to risk, still fails under
+        # ``--severity-preset strict`` (ADR-027 review).
+        if severity_config is not None:
+            from .severity import SeverityLevel, classify_change_object
 
-                return (
-                    severity_config.level_for(IssueCategory.POTENTIAL_BREAKING)
-                    == SeverityLevel.ERROR
-                )
-            return False
-        return False  # COMPATIBLE / NO_CHANGE → not a failure
+            return (
+                severity_config.level_for(classify_change_object(change))
+                == SeverityLevel.ERROR
+            )
+        return False
     if change.kind in breaking_set or change.kind in api_break_set:
         return True
     if severity_config is not None:

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -153,11 +154,17 @@ def _verdict_label(v: Verdict) -> str:
     return v.value.lower()
 
 
-def _record_by_name(snap: AbiSnapshot, name: str) -> object | None:
-    by_name = {rec.name: rec for rec in snap.types}
-    key = _resolve_name(by_name.keys(), name)
-    return by_name.get(key) if key is not None else None
-    return None
+def _exact_record(snap: AbiSnapshot, name: str) -> object | None:
+    """Return the type record whose name matches *name* exactly, else None.
+
+    The lost-invariant transition (D2.2) must use the **same** qualified type
+    identity across snapshots — never a short-name fallback. Otherwise a removed
+    or renamed old type (e.g. ``ns1::Ctx``) could resolve to an unrelated new
+    type sharing its short name (``ns2::Ctx``) and wrongly raise
+    ``OPAQUE_INVARIANT_BROKEN`` instead of letting the normal removed/renamed
+    handling cover it (ADR-027 review).
+    """
+    return next((rec for rec in snap.types if rec.name == name), None)
 
 
 def apply_pattern_verdicts(
@@ -197,9 +204,7 @@ def apply_pattern_verdicts(
 
     # 1. Lost-invariant transitions (raises) — emitted before demotion so a type
     #    that *lost* opaqueness is never both demoted and flagged.
-    transitions = _emit_lost_invariants(
-        changes, old, new, new_graph, old_idioms, tier
-    )
+    transitions = _emit_lost_invariants(changes, old, new, new_graph, old_idioms, tier)
     changes.extend(t for t, _ in transitions)
     ledger.extend(m for _, m in transitions)
 
@@ -281,7 +286,7 @@ def _emit_lost_invariants(
     for name, tags in old_idioms.items():
         if not any(t.idiom == Idiom.OPAQUE_POINTER for t in tags):
             continue
-        new_rec = _record_by_name(new, name)
+        new_rec = _exact_record(new, name)
         if new_rec is None:
             continue  # removed entirely → handled by TYPE_REMOVED, not this
         # Opacity is lost only when callers can now observe the layout: either

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -1,0 +1,485 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pattern-aware verdict modulation (ADR-027 A4 / D4).
+
+A post-processing pass that runs after detectors produce :class:`Change`
+objects and before policy classification — the structural twin of ADR-024's
+``FilterNonPublicSurface``. It uses the idiom/anti-pattern evidence from
+:mod:`abicheck.idioms` (recomputed from both snapshots' declaration graphs) to:
+
+- **demote** a layout change on a provably-opaque or PIMPL-hidden type to
+  compatible (reason ``opaque-by-construction`` / ``pimpl-impl-hidden``), and
+- **raise** new breaks when an opacity/handle guarantee callers relied on is
+  *lost* (``OPAQUE_INVARIANT_BROKEN`` / ``HANDLE_TYPE_CHANGED``), and
+- **annotate** findings sitting on a recognised ABI anti-pattern surface.
+
+The governing contract is inherited verbatim from ADR-024: a modulation may
+**demote with a disclosed reason** or **raise** a finding; it may **never
+silently delete** one. Every modulation is recorded in the returned ledger,
+attributed to the rule that made it, and reversed by ``--no-pattern-verdicts``.
+
+Anti-hiding guards:
+
+- Demotion is gated to the ``HEADER_AWARE`` evidence tier — the idiom evidence
+  needs the AST (D4.1 "confidence floor by tier").
+- A demotion requires the idiom to hold on **both** snapshots; if opaqueness
+  was lost, the opaque demote does not fire and an ``OPAQUE_INVARIANT_BROKEN``
+  break is emitted instead (never a silent demotion).
+- A ``frozen_namespace_violation`` finding is never demoted.
+- The PIMPL demote fires only when the wrapper's *own* layout is byte-identical
+  across both snapshots and only the hidden pointee changed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from .checker_policy import ChangeKind, EvidenceTier, Verdict
+from .checker_types import Change
+from .idioms import AntiPattern, Idiom, IdiomTag, detect_antipatterns, recognise_idioms
+from .model import AbiSnapshot
+from .surface_graph import SurfaceGraph, build_surface_graph
+
+logger = logging.getLogger(__name__)
+
+# Layout-shaped findings the opaque/PIMPL demote rules may act on.
+_LAYOUT_KINDS = frozenset(
+    {
+        ChangeKind.TYPE_SIZE_CHANGED,
+        ChangeKind.TYPE_ALIGNMENT_CHANGED,
+        ChangeKind.TYPE_FIELD_REMOVED,
+        ChangeKind.TYPE_FIELD_ADDED,
+        ChangeKind.TYPE_FIELD_OFFSET_CHANGED,
+        ChangeKind.TYPE_FIELD_TYPE_CHANGED,
+        ChangeKind.TYPE_FIELD_ADDED_COMPATIBLE,
+        ChangeKind.FIELD_BITFIELD_CHANGED,
+    }
+)
+
+
+@dataclass
+class PatternModulation:
+    """One disclosed pattern-aware modulation (ADR-027 D4.3 ledger row)."""
+
+    symbol: str
+    original_category: str
+    new_category: str
+    rule_id: str
+    reason: str
+    evidence_tier: str
+    edges_matched: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "original_category": self.original_category,
+            "new_category": self.new_category,
+            "rule_id": self.rule_id,
+            "reason": self.reason,
+            "evidence_tier": self.evidence_tier,
+            "edges_matched": list(self.edges_matched),
+        }
+
+
+def _names(name: str) -> set[str]:
+    """A name plus its unqualified short form, for fuzzy idiom matching."""
+    return {name, name.rsplit("::", 1)[-1]}
+
+
+def _tags_for(idioms: dict[str, list[IdiomTag]], name: str) -> list[IdiomTag]:
+    out: list[IdiomTag] = []
+    for n in _names(name):
+        out.extend(idioms.get(n, []))
+    return out
+
+
+def _has_idiom(
+    idioms: dict[str, list[IdiomTag]], name: str, idiom: Idiom
+) -> IdiomTag | None:
+    for t in _tags_for(idioms, name):
+        if t.idiom == idiom:
+            return t
+    return None
+
+
+def _verdict_label(v: Verdict) -> str:
+    return v.value.lower()
+
+
+def _record_by_name(snap: AbiSnapshot, name: str) -> object | None:
+    short = name.rsplit("::", 1)[-1]
+    for rec in snap.types:
+        if rec.name == name or rec.name.rsplit("::", 1)[-1] == short:
+            return rec
+    return None
+
+
+def apply_pattern_verdicts(
+    changes: list[Change],
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    *,
+    evidence_tier: EvidenceTier,
+    enabled: bool = True,
+) -> list[dict[str, object]]:
+    """Modulate *changes* in place using idiom evidence; return the ledger.
+
+    Demotions set ``Change.effective_verdict`` / ``modulation_reason`` /
+    ``modulation_rule`` on the existing finding (re-categorised in place, never
+    dropped). Lost-invariant transitions are appended to *changes* as new
+    ``OPAQUE_INVARIANT_BROKEN`` / ``HANDLE_TYPE_CHANGED`` breaks. The returned
+    list is the JSON/SARIF ``pattern_modulations`` ledger.
+    """
+    if not enabled:
+        return []
+
+    old_graph = build_surface_graph(old)
+    new_graph = build_surface_graph(new)
+    old_idioms = recognise_idioms(old_graph)
+    new_idioms = recognise_idioms(new_graph)
+    old_aps = detect_antipatterns(old_graph)
+    new_aps = detect_antipatterns(new_graph)
+    tier = (
+        evidence_tier.value if isinstance(evidence_tier, EvidenceTier) else "elf_only"
+    )
+    demote_allowed = (
+        isinstance(evidence_tier, EvidenceTier)
+        and evidence_tier.rank >= EvidenceTier.HEADER_AWARE.rank
+    )
+
+    ledger: list[PatternModulation] = []
+
+    # 1. Lost-invariant transitions (raises) — emitted before demotion so a type
+    #    that *lost* opaqueness is never both demoted and flagged.
+    transitions = _emit_lost_invariants(
+        changes, old, new, old_graph, new_graph, old_idioms, new_idioms, tier
+    )
+    changes.extend(t for t, _ in transitions)
+    ledger.extend(m for _, m in transitions)
+
+    # 2. Newly-introduced anti-patterns (old clean → new dirty), as RISK findings
+    #    — pre-existing debt is not nagged about on every run (D2.2).
+    new_ap_transitions = _emit_new_antipatterns(changes, old_aps, new_aps, tier)
+    changes.extend(t for t, _ in new_ap_transitions)
+    ledger.extend(m for _, m in new_ap_transitions)
+
+    # 3. Per-finding modulation of existing changes.
+    for c in changes:
+        m = _modulate_change(
+            c, old, new, old_idioms, new_idioms, new_aps, tier, demote_allowed
+        )
+        if m is not None:
+            ledger.append(m)
+
+    return [m.to_dict() for m in ledger]
+
+
+def _emit_new_antipatterns(
+    changes: list[Change],
+    old_aps: list[AntiPattern],
+    new_aps: list[AntiPattern],
+    tier: str,
+) -> list[tuple[Change, PatternModulation]]:
+    """Emit RISK findings for anti-patterns present in new but not old."""
+    old_keys = {(a.kind, a.symbol) for a in old_aps}
+    existing = {(c.kind, c.symbol) for c in changes}
+    out: list[tuple[Change, PatternModulation]] = []
+    for ap in new_aps:
+        key = (ap.kind, ap.symbol)
+        if key in old_keys or key in existing:
+            continue
+        existing.add(key)
+        change = Change(
+            kind=ap.kind,
+            symbol=ap.symbol,
+            description=ap.description,
+            modulation_reason="anti-pattern-introduced",
+            modulation_rule="new-anti-pattern",
+        )
+        out.append(
+            (
+                change,
+                PatternModulation(
+                    symbol=ap.symbol,
+                    original_category=_verdict_label(Verdict.COMPATIBLE),
+                    new_category="risk",
+                    rule_id="new-anti-pattern",
+                    reason="anti-pattern-introduced",
+                    evidence_tier=tier,
+                    edges_matched=list(ap.evidence),
+                ),
+            )
+        )
+    return out
+
+
+def _emit_lost_invariants(
+    changes: list[Change],
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    old_graph: SurfaceGraph,
+    new_graph: SurfaceGraph,
+    old_idioms: dict[str, list[IdiomTag]],
+    new_idioms: dict[str, list[IdiomTag]],
+    tier: str,
+) -> list[tuple[Change, PatternModulation]]:
+    """OPAQUE_INVARIANT_BROKEN + HANDLE_TYPE_CHANGED (D2.2 transitions)."""
+    out: list[tuple[Change, PatternModulation]] = []
+    existing = {(c.kind, c.symbol) for c in changes}
+
+    # --- Opaque/PIMPL invariant lost --------------------------------------
+    for name, tags in old_idioms.items():
+        was_hidden = any(t.idiom in (Idiom.OPAQUE_POINTER, Idiom.PIMPL) for t in tags)
+        if not was_hidden:
+            continue
+        new_rec = _record_by_name(new, name)
+        if new_rec is None:
+            continue  # removed entirely → handled by TYPE_REMOVED, not this
+        still_opaque = bool(
+            _has_idiom(new_idioms, name, Idiom.OPAQUE_POINTER)
+            or _has_idiom(new_idioms, name, Idiom.PIMPL)
+        )
+        # Opaqueness is lost when the type is no longer recognised as
+        # opaque/PIMPL while still being present on the new surface: either its
+        # definition became visible (is_opaque False) or it gained a by-value
+        # public use.
+        definition_now_visible = getattr(new_rec, "is_opaque", False) is False
+        if still_opaque or not definition_now_visible:
+            # Either still hidden, or still incomplete (still safe) — no break.
+            if still_opaque:
+                continue
+        key = (ChangeKind.OPAQUE_INVARIANT_BROKEN, name)
+        if key in existing:
+            continue
+        edges = [f"{name} was opaque/PIMPL in old; layout now observable in new"]
+        change = Change(
+            kind=ChangeKind.OPAQUE_INVARIANT_BROKEN,
+            symbol=name,
+            description=(
+                f"{name} was an opaque/PIMPL type callers could not observe; its "
+                f"layout is now visible (definition exposed or passed by value), "
+                f"so its size/fields are now part of the ABI"
+            ),
+            modulation_reason="opaque-invariant-broken",
+            modulation_rule="lost-opaque-invariant",
+        )
+        existing.add(key)
+        logger.warning("pattern-verdict raise: %s lost opaque invariant", name)
+        out.append(
+            (
+                change,
+                PatternModulation(
+                    symbol=name,
+                    original_category=_verdict_label(Verdict.COMPATIBLE),
+                    new_category=_verdict_label(Verdict.BREAKING),
+                    rule_id="lost-opaque-invariant",
+                    reason="opaque-invariant-broken",
+                    evidence_tier=tier,
+                    edges_matched=edges,
+                ),
+            )
+        )
+
+    # --- Handle token type changed ----------------------------------------
+    for alias, tags in old_idioms.items():
+        if not any(t.idiom == Idiom.HANDLE for t in tags):
+            continue
+        if alias not in old.typedefs or alias not in new.typedefs:
+            continue
+        old_target = old.typedefs[alias].strip()
+        new_target = new.typedefs[alias].strip()
+        if old_target == new_target:
+            continue
+        key = (ChangeKind.HANDLE_TYPE_CHANGED, alias)
+        if key in existing:
+            continue
+        edges = [f"handle typedef {alias}: {old_target!r} -> {new_target!r}"]
+        change = Change(
+            kind=ChangeKind.HANDLE_TYPE_CHANGED,
+            symbol=alias,
+            description=(
+                f"opaque handle typedef {alias} changed its underlying token type "
+                f"from {old_target!r} to {new_target!r}"
+            ),
+            old_value=old_target,
+            new_value=new_target,
+            modulation_reason="handle-token-changed",
+            modulation_rule="handle-token-changed",
+        )
+        existing.add(key)
+        logger.warning("pattern-verdict raise: handle %s token type changed", alias)
+        out.append(
+            (
+                change,
+                PatternModulation(
+                    symbol=alias,
+                    original_category=_verdict_label(Verdict.COMPATIBLE),
+                    new_category=_verdict_label(Verdict.BREAKING),
+                    rule_id="handle-token-changed",
+                    reason="handle-token-changed",
+                    evidence_tier=tier,
+                    edges_matched=edges,
+                ),
+            )
+        )
+
+    return out
+
+
+def _modulate_change(
+    c: Change,
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    old_idioms: dict[str, list[IdiomTag]],
+    new_idioms: dict[str, list[IdiomTag]],
+    new_aps: list[AntiPattern],
+    tier: str,
+    demote_allowed: bool,
+) -> PatternModulation | None:
+    """Apply the per-finding modulation rules; return a ledger row or None."""
+    # Never override a frozen-namespace break or a transition we just emitted.
+    if c.frozen_namespace_violation is not None:
+        return None
+    if c.kind in (
+        ChangeKind.OPAQUE_INVARIANT_BROKEN,
+        ChangeKind.HANDLE_TYPE_CHANGED,
+        ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE,
+        ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR,
+    ):
+        return None
+    if c.effective_verdict is not None:
+        return None
+
+    if c.kind in _LAYOUT_KINDS:
+        # Rule: opaque-pointer layout (demote).
+        if demote_allowed:
+            tag_old = _has_idiom(old_idioms, c.symbol, Idiom.OPAQUE_POINTER)
+            tag_new = _has_idiom(new_idioms, c.symbol, Idiom.OPAQUE_POINTER)
+            if (
+                tag_old is not None
+                and tag_new is not None
+                and tag_old.definition_hidden
+                and tag_new.definition_hidden
+            ):
+                return _demote(
+                    c,
+                    "opaque-pointer-layout",
+                    "opaque-by-construction",
+                    tier,
+                    list(tag_new.evidence),
+                )
+            # Rule: PIMPL pointee-only (demote).
+            pimpl = _pimpl_pointee_match(c.symbol, old_idioms, new_idioms)
+            if pimpl is not None:
+                return _demote(
+                    c,
+                    "pimpl-pointee-only",
+                    "pimpl-impl-hidden",
+                    tier,
+                    pimpl,
+                )
+
+    # Rule: anti-pattern raise (annotate; never hides).
+    note = _antipattern_annotation(c, new_aps)
+    if note is not None:
+        rule_id, edges = note
+        # Pure annotation: the finding's category is unchanged (a raise can
+        # never hide), so original == new in the ledger.
+        cat = "annotated"
+        c.modulation_reason = c.modulation_reason or "anti-pattern-elevated-risk"
+        c.modulation_rule = c.modulation_rule or rule_id
+        return PatternModulation(
+            symbol=c.symbol,
+            original_category=cat,
+            new_category=cat,
+            rule_id=rule_id,
+            reason="anti-pattern-elevated-risk",
+            evidence_tier=tier,
+            edges_matched=edges,
+        )
+    return None
+
+
+def _demote(
+    c: Change,
+    rule_id: str,
+    reason: str,
+    tier: str,
+    edges: list[str],
+) -> PatternModulation:
+    original = "breaking"
+    c.effective_verdict = Verdict.COMPATIBLE
+    c.modulation_reason = reason
+    c.modulation_rule = rule_id
+    logger.warning(
+        "pattern-verdict demote: %s (%s) -> compatible [%s]",
+        c.symbol,
+        c.kind.value,
+        reason,
+    )
+    return PatternModulation(
+        symbol=c.symbol,
+        original_category=original,
+        new_category="compatible",
+        rule_id=rule_id,
+        reason=reason,
+        evidence_tier=tier,
+        edges_matched=edges,
+    )
+
+
+def _pimpl_pointee_match(
+    pointee: str,
+    old_idioms: dict[str, list[IdiomTag]],
+    new_idioms: dict[str, list[IdiomTag]],
+) -> list[str] | None:
+    """Return evidence if *pointee* is the hidden impl of a PIMPL wrapper whose
+    own layout is unchanged across both snapshots (D4.1 PIMPL guard)."""
+    short = pointee.rsplit("::", 1)[-1]
+    for wrapper, tags in old_idioms.items():
+        for t in tags:
+            if t.idiom != Idiom.PIMPL or t.hidden_pointee is None:
+                continue
+            if t.hidden_pointee not in (pointee, short):
+                continue
+            # Find the matching wrapper tag in new and require identical layout.
+            new_tag = _has_idiom(new_idioms, wrapper, Idiom.PIMPL)
+            if new_tag is None:
+                continue
+            if t.layout_signature != new_tag.layout_signature:
+                # The wrapper's own layout changed — that is a real break.
+                continue
+            return [
+                f"{pointee} is the hidden impl of PIMPL {wrapper}; "
+                f"wrapper layout byte-identical across versions"
+            ]
+    return None
+
+
+def _antipattern_annotation(
+    c: Change, new_aps: list[AntiPattern]
+) -> tuple[str, list[str]] | None:
+    """If *c* sits on a recognised ABI anti-pattern surface, return (rule, edges)."""
+    short = c.symbol.rsplit("::", 1)[-1]
+    edges: list[str] = []
+    rule_id = ""
+    for ap in new_aps:
+        if ap.symbol in (c.symbol, short) or ap.symbol.rsplit("::", 1)[-1] == short:
+            edges.extend(ap.evidence)
+            rule_id = "anti-pattern-raise"
+    if edges:
+        return rule_id, edges
+    return None

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -174,6 +174,7 @@ def apply_pattern_verdicts(
     *,
     evidence_tier: EvidenceTier,
     enabled: bool = True,
+    protected_kinds: frozenset[ChangeKind] = frozenset(),
 ) -> list[dict[str, object]]:
     """Modulate *changes* in place using idiom evidence; return the ledger.
 
@@ -182,6 +183,12 @@ def apply_pattern_verdicts(
     dropped). Lost-invariant transitions are appended to *changes* as new
     ``OPAQUE_INVARIANT_BROKEN`` / ``HANDLE_TYPE_CHANGED`` breaks. The returned
     list is the JSON/SARIF ``pattern_modulations`` ledger.
+
+    *protected_kinds* are kinds the user has explicitly reclassified via a
+    policy file. A pattern demotion never fires on such a kind: an explicit
+    user override is authoritative and must win over an automated heuristic in
+    **both** the aggregate verdict and per-finding classification (ADR-027
+    review). Raises and annotations still apply — they never hide a finding.
     """
     if not enabled:
         return []
@@ -217,7 +224,15 @@ def apply_pattern_verdicts(
     # 3. Per-finding modulation of existing changes.
     for c in changes:
         m = _modulate_change(
-            c, old, new, old_idioms, new_idioms, new_aps, tier, demote_allowed
+            c,
+            old,
+            new,
+            old_idioms,
+            new_idioms,
+            new_aps,
+            tier,
+            demote_allowed,
+            protected_kinds,
         )
         if m is not None:
             ledger.append(m)
@@ -392,6 +407,7 @@ def _modulate_change(
     new_aps: list[AntiPattern],
     tier: str,
     demote_allowed: bool,
+    protected_kinds: frozenset[ChangeKind] = frozenset(),
 ) -> PatternModulation | None:
     """Apply the per-finding modulation rules; return a ledger row or None."""
     # Never override a frozen-namespace break or a transition we just emitted.
@@ -407,7 +423,10 @@ def _modulate_change(
     if c.effective_verdict is not None:
         return None
 
-    if c.kind in _LAYOUT_KINDS:
+    # A user policy override on this kind is authoritative — never let an
+    # automated demotion lower a finding the user explicitly reclassified
+    # (ADR-027 review). Raises/annotations below still apply.
+    if c.kind in _LAYOUT_KINDS and c.kind not in protected_kinds:
         # Rule: opaque-pointer layout (demote).
         if demote_allowed:
             old_names = _type_names(old)

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -49,7 +49,14 @@ from dataclasses import dataclass, field
 
 from .checker_policy import ChangeKind, EvidenceTier, Verdict
 from .checker_types import Change
-from .idioms import AntiPattern, Idiom, IdiomTag, detect_antipatterns, recognise_idioms
+from .idioms import (
+    AntiPattern,
+    Idiom,
+    IdiomTag,
+    _public_pointer_only,
+    detect_antipatterns,
+    recognise_idioms,
+)
 from .model import AbiSnapshot
 from .surface_graph import SurfaceGraph, build_surface_graph
 
@@ -240,36 +247,44 @@ def _emit_lost_invariants(
     out: list[tuple[Change, PatternModulation]] = []
     existing = {(c.kind, c.symbol) for c in changes}
 
-    # --- Opaque/PIMPL invariant lost --------------------------------------
+    # --- Opaque invariant lost --------------------------------------------
+    # Scoped to OPAQUE_POINTER: those are the types whose *layout* callers
+    # provably could not observe. A PIMPL wrapper is already a complete,
+    # by-value-usable type, so "gains a by-value use" loses nothing for it; a
+    # change to a PIMPL wrapper's own layout is caught by the normal layout
+    # detectors (and is never demoted — see the PIMPL guard), so it needs no
+    # separate transition here.
     for name, tags in old_idioms.items():
-        was_hidden = any(t.idiom in (Idiom.OPAQUE_POINTER, Idiom.PIMPL) for t in tags)
-        if not was_hidden:
+        if not any(t.idiom == Idiom.OPAQUE_POINTER for t in tags):
             continue
         new_rec = _record_by_name(new, name)
         if new_rec is None:
             continue  # removed entirely → handled by TYPE_REMOVED, not this
-        still_opaque = bool(
-            _has_idiom(new_idioms, name, Idiom.OPAQUE_POINTER)
-            or _has_idiom(new_idioms, name, Idiom.PIMPL)
-        )
-        # Opaqueness is lost when the type is no longer recognised as
-        # opaque/PIMPL while still being present on the new surface: either its
-        # definition became visible (is_opaque False) or it gained a by-value
-        # public use.
-        definition_now_visible = getattr(new_rec, "is_opaque", False) is False
-        if still_opaque or not definition_now_visible:
-            # Either still hidden, or still incomplete (still safe) — no break.
-            if still_opaque:
-                continue
+        # Opacity is lost only when callers can now observe the layout: either
+        # the complete definition is now visible (no longer incomplete), or a
+        # public function now crosses the type by value. A type that is still
+        # incomplete and still crossed only by pointer (or no longer referenced
+        # at all) keeps its opacity — emitting a break there is a false positive
+        # (e.g. removing the last `Ctx*` use while keeping the forward decl).
+        definition_now_visible = not getattr(new_rec, "is_opaque", False)
+        referenced, only_pointer = _public_pointer_only(new_graph, name)
+        by_value_use = referenced and not only_pointer
+        if not (definition_now_visible or by_value_use):
+            continue
         key = (ChangeKind.OPAQUE_INVARIANT_BROKEN, name)
         if key in existing:
             continue
-        edges = [f"{name} was opaque/PIMPL in old; layout now observable in new"]
+        why = (
+            "definition now visible"
+            if definition_now_visible
+            else "now passed by value"
+        )
+        edges = [f"{name} was opaque in old; {why} in new"]
         change = Change(
             kind=ChangeKind.OPAQUE_INVARIANT_BROKEN,
             symbol=name,
             description=(
-                f"{name} was an opaque/PIMPL type callers could not observe; its "
+                f"{name} was an opaque type callers could not observe; its "
                 f"layout is now visible (definition exposed or passed by value), "
                 f"so its size/fields are now part of the ABI"
             ),

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -198,7 +198,7 @@ def apply_pattern_verdicts(
     # 1. Lost-invariant transitions (raises) — emitted before demotion so a type
     #    that *lost* opaqueness is never both demoted and flagged.
     transitions = _emit_lost_invariants(
-        changes, old, new, old_graph, new_graph, old_idioms, new_idioms, tier
+        changes, old, new, new_graph, old_idioms, tier
     )
     changes.extend(t for t, _ in transitions)
     ledger.extend(m for _, m in transitions)
@@ -263,10 +263,8 @@ def _emit_lost_invariants(
     changes: list[Change],
     old: AbiSnapshot,
     new: AbiSnapshot,
-    old_graph: SurfaceGraph,
     new_graph: SurfaceGraph,
     old_idioms: dict[str, list[IdiomTag]],
-    new_idioms: dict[str, list[IdiomTag]],
     tier: str,
 ) -> list[tuple[Change, PatternModulation]]:
     """OPAQUE_INVARIANT_BROKEN + HANDLE_TYPE_CHANGED (D2.2 transitions)."""

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -45,6 +45,7 @@ Anti-hiding guards:
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from .checker_policy import ChangeKind, EvidenceTier, Verdict
@@ -101,25 +102,51 @@ class PatternModulation:
         }
 
 
-def _names(name: str) -> set[str]:
-    """A name plus its unqualified short form, for fuzzy idiom matching."""
-    return {name, name.rsplit("::", 1)[-1]}
+def _resolve_name(keys: Iterable[str], name: str) -> str | None:
+    """Resolve *name* to a single key, requiring an *unambiguous* match.
+
+    Exact (fully-qualified) match always wins. Otherwise fall back to matching
+    on the unqualified short name **only when exactly one key carries it** —
+    so two public types that share a short name across different namespaces
+    (e.g. ``ns1::Ctx`` and ``ns2::Ctx``) never borrow each other's idiom
+    evidence. An ambiguous short name returns ``None`` (no match), which keeps
+    a pattern demotion from firing on the wrong type (ADR-027 review).
+    """
+    keyset = list(keys)
+    if name in keyset:
+        return name
+    short = name.rsplit("::", 1)[-1]
+    candidates = [k for k in keyset if k.rsplit("::", 1)[-1] == short]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
 
 
-def _tags_for(idioms: dict[str, list[IdiomTag]], name: str) -> list[IdiomTag]:
-    out: list[IdiomTag] = []
-    for n in _names(name):
-        out.extend(idioms.get(n, []))
-    return out
+def _tags_for(
+    idioms: dict[str, list[IdiomTag]], name: str, type_names: Iterable[str]
+) -> list[IdiomTag]:
+    # Ambiguity is judged against the *whole* type universe, not just the
+    # idiom-tagged subset: if two public types share a short name, an
+    # unqualified reference is ambiguous and must not resolve to either (even if
+    # only one happens to carry an idiom tag) — ADR-027 review.
+    key = _resolve_name(type_names, name)
+    return idioms.get(key, []) if key is not None else []
 
 
 def _has_idiom(
-    idioms: dict[str, list[IdiomTag]], name: str, idiom: Idiom
+    idioms: dict[str, list[IdiomTag]],
+    name: str,
+    idiom: Idiom,
+    type_names: Iterable[str],
 ) -> IdiomTag | None:
-    for t in _tags_for(idioms, name):
+    for t in _tags_for(idioms, name, type_names):
         if t.idiom == idiom:
             return t
     return None
+
+
+def _type_names(snap: AbiSnapshot) -> frozenset[str]:
+    return frozenset(rec.name for rec in snap.types)
 
 
 def _verdict_label(v: Verdict) -> str:
@@ -127,10 +154,9 @@ def _verdict_label(v: Verdict) -> str:
 
 
 def _record_by_name(snap: AbiSnapshot, name: str) -> object | None:
-    short = name.rsplit("::", 1)[-1]
-    for rec in snap.types:
-        if rec.name == name or rec.name.rsplit("::", 1)[-1] == short:
-            return rec
+    by_name = {rec.name: rec for rec in snap.types}
+    key = _resolve_name(by_name.keys(), name)
+    return by_name.get(key) if key is not None else None
     return None
 
 
@@ -381,8 +407,10 @@ def _modulate_change(
     if c.kind in _LAYOUT_KINDS:
         # Rule: opaque-pointer layout (demote).
         if demote_allowed:
-            tag_old = _has_idiom(old_idioms, c.symbol, Idiom.OPAQUE_POINTER)
-            tag_new = _has_idiom(new_idioms, c.symbol, Idiom.OPAQUE_POINTER)
+            old_names = _type_names(old)
+            new_names = _type_names(new)
+            tag_old = _has_idiom(old_idioms, c.symbol, Idiom.OPAQUE_POINTER, old_names)
+            tag_new = _has_idiom(new_idioms, c.symbol, Idiom.OPAQUE_POINTER, new_names)
             if (
                 tag_old is not None
                 and tag_new is not None
@@ -397,7 +425,7 @@ def _modulate_change(
                     list(tag_new.evidence),
                 )
             # Rule: PIMPL pointee-only (demote).
-            pimpl = _pimpl_pointee_match(c.symbol, old_idioms, new_idioms)
+            pimpl = _pimpl_pointee_match(c.symbol, old_idioms, new_idioms, new_names)
             if pimpl is not None:
                 return _demote(
                     c,
@@ -460,41 +488,66 @@ def _pimpl_pointee_match(
     pointee: str,
     old_idioms: dict[str, list[IdiomTag]],
     new_idioms: dict[str, list[IdiomTag]],
+    new_type_names: Iterable[str],
 ) -> list[str] | None:
     """Return evidence if *pointee* is the hidden impl of a PIMPL wrapper whose
-    own layout is unchanged across both snapshots (D4.1 PIMPL guard)."""
+    own layout is unchanged across both snapshots (D4.1 PIMPL guard).
+
+    Matching is exact-qualified first; it falls back to the unqualified short
+    name only when exactly one PIMPL wrapper has a pointee with that short name,
+    so a real break on ``ns1::Impl`` is never demoted using ``ns2::Widget``'s
+    PIMPL evidence just because both impls are spelled ``Impl`` (ADR-027 review).
+    """
     short = pointee.rsplit("::", 1)[-1]
+    exact: list[tuple[str, IdiomTag]] = []
+    short_matches: list[tuple[str, IdiomTag]] = []
     for wrapper, tags in old_idioms.items():
         for t in tags:
             if t.idiom != Idiom.PIMPL or t.hidden_pointee is None:
                 continue
-            if t.hidden_pointee not in (pointee, short):
-                continue
-            # Find the matching wrapper tag in new and require identical layout.
-            new_tag = _has_idiom(new_idioms, wrapper, Idiom.PIMPL)
-            if new_tag is None:
-                continue
-            if t.layout_signature != new_tag.layout_signature:
-                # The wrapper's own layout changed — that is a real break.
-                continue
-            return [
-                f"{pointee} is the hidden impl of PIMPL {wrapper}; "
-                f"wrapper layout byte-identical across versions"
-            ]
+            if t.hidden_pointee == pointee:
+                exact.append((wrapper, t))
+            elif t.hidden_pointee.rsplit("::", 1)[-1] == short:
+                short_matches.append((wrapper, t))
+    if exact:
+        candidates = exact
+    elif len(short_matches) == 1:
+        candidates = short_matches
+    else:
+        return None  # no match, or an ambiguous short name → do not demote
+    new_names = list(new_type_names)
+    for wrapper, t in candidates:
+        # Find the matching wrapper tag in new and require identical layout.
+        new_tag = _has_idiom(new_idioms, wrapper, Idiom.PIMPL, new_names)
+        if new_tag is None:
+            continue
+        if t.layout_signature != new_tag.layout_signature:
+            # The wrapper's own layout changed — that is a real break.
+            continue
+        return [
+            f"{pointee} is the hidden impl of PIMPL {wrapper}; "
+            f"wrapper layout byte-identical across versions"
+        ]
     return None
 
 
 def _antipattern_annotation(
     c: Change, new_aps: list[AntiPattern]
 ) -> tuple[str, list[str]] | None:
-    """If *c* sits on a recognised ABI anti-pattern surface, return (rule, edges)."""
+    """If *c* sits on a recognised ABI anti-pattern surface, return (rule, edges).
+
+    This is a pure annotation (a raise that can never hide a finding), but it
+    still matches exact-qualified first and only falls back to an unqualified
+    short name when that name is unambiguous among the anti-patterns, so the
+    disclosed evidence always belongs to the finding it annotates.
+    """
     short = c.symbol.rsplit("::", 1)[-1]
+    exact = [ap for ap in new_aps if ap.symbol == c.symbol]
+    short_aps = [ap for ap in new_aps if ap.symbol.rsplit("::", 1)[-1] == short]
+    matched = exact if exact else (short_aps if len(short_aps) == 1 else [])
+    if not matched:
+        return None
     edges: list[str] = []
-    rule_id = ""
-    for ap in new_aps:
-        if ap.symbol in (c.symbol, short) or ap.symbol.rsplit("::", 1)[-1] == short:
-            edges.extend(ap.evidence)
-            rule_id = "anti-pattern-raise"
-    if edges:
-        return rule_id, edges
-    return None
+    for ap in matched:
+        edges.extend(ap.evidence)
+    return "anti-pattern-raise", edges

--- a/abicheck/pattern_verdicts.py
+++ b/abicheck/pattern_verdicts.py
@@ -493,12 +493,19 @@ def _pimpl_pointee_match(
     """Return evidence if *pointee* is the hidden impl of a PIMPL wrapper whose
     own layout is unchanged across both snapshots (D4.1 PIMPL guard).
 
-    Matching is exact-qualified first; it falls back to the unqualified short
-    name only when exactly one PIMPL wrapper has a pointee with that short name,
-    so a real break on ``ns1::Impl`` is never demoted using ``ns2::Widget``'s
-    PIMPL evidence just because both impls are spelled ``Impl`` (ADR-027 review).
+    Matching is exact-qualified first. It falls back to the unqualified short
+    name only when (a) exactly one PIMPL wrapper has a pointee with that short
+    name **and** (b) the short name is unambiguous among the snapshot's own
+    types — because ``_recognise_pimpl`` may record an unqualified
+    ``hidden_pointee`` (``Impl *``). Without (b), a real break on ``ns1::Impl``
+    could be demoted using a wrapper whose ``Impl *`` actually meant
+    ``ns2::Impl`` (ADR-027 review).
     """
     short = pointee.rsplit("::", 1)[-1]
+    new_names = list(new_type_names)
+    pointee_unambiguous = (
+        sum(1 for n in new_names if n.rsplit("::", 1)[-1] == short) <= 1
+    )
     exact: list[tuple[str, IdiomTag]] = []
     short_matches: list[tuple[str, IdiomTag]] = []
     for wrapper, tags in old_idioms.items():
@@ -511,11 +518,10 @@ def _pimpl_pointee_match(
                 short_matches.append((wrapper, t))
     if exact:
         candidates = exact
-    elif len(short_matches) == 1:
+    elif len(short_matches) == 1 and pointee_unambiguous:
         candidates = short_matches
     else:
         return None  # no match, or an ambiguous short name → do not demote
-    new_names = list(new_type_names)
     for wrapper, t in candidates:
         # Find the matching wrapper tag in new and require identical layout.
         new_tag = _has_idiom(new_idioms, wrapper, Idiom.PIMPL, new_names)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -33,6 +33,7 @@ from .checker import (
 )
 from .checker_policy import (
     ChangeKind,
+    effective_category,
     impact_for,
 )
 from .checker_policy import (
@@ -41,6 +42,50 @@ from .checker_policy import (
 from .report_summary import build_summary, surface_breakdown
 from .schemas import REPORT_SCHEMA_VERSION
 from .semver import recommend_release
+
+_VERDICT_TO_SEVERITY_LABEL = {
+    Verdict.BREAKING: "breaking",
+    Verdict.API_BREAK: "api_break",
+    Verdict.COMPATIBLE_WITH_RISK: "risk",
+    Verdict.COMPATIBLE: "compatible",
+}
+
+
+def _effective_severity_label(
+    c: object,
+    kind_sets: tuple[
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+    ],
+) -> str:
+    """Severity label for a change, honouring its A4 ``effective_verdict``.
+
+    The one place the reporter decides a finding's severity bucket: routes
+    through :func:`effective_category` so an ADR-027 pattern-aware demotion reads
+    ``compatible`` in the JSON ``severity`` field and the ``filtered_summary``
+    counts, consistent with the verdict and exit code.
+    """
+    kind = getattr(c, "kind", None)
+    if kind is None:
+        return "unknown"
+    # An explicit A4 override wins; otherwise fall back to the exact set-based
+    # logic (which yields "unknown" for a kind moved out of every set, e.g. an
+    # override to NO_CHANGE) rather than effective_category's BREAKING fail-safe.
+    eff = getattr(c, "effective_verdict", None)
+    if isinstance(eff, Verdict):
+        return _VERDICT_TO_SEVERITY_LABEL.get(eff, "unknown")
+    breaking, api_break, compatible, risk = kind_sets
+    if kind in breaking:
+        return "breaking"
+    if kind in api_break:
+        return "api_break"
+    if kind in risk:
+        return "risk"
+    if kind in compatible:
+        return "compatible"
+    return "unknown"
 
 
 def _kind_to_severity(kind: ChangeKind, policy: str) -> str:
@@ -468,24 +513,12 @@ def _to_json_leaf(
     effective_policy = result.policy or "strict_abi"
     eff_sets = result._effective_kind_sets()
 
-    def _severity_from_sets(kind: object) -> str:
-        breaking, api_break, compatible, risk = eff_sets
-        if kind in breaking:
-            return "breaking"
-        if kind in api_break:
-            return "api_break"
-        if kind in risk:
-            return "risk"
-        if kind in compatible:
-            return "compatible"
-        return "unknown"
-
     leaf_changes_list = [
         {
             "kind": c.kind.value,
             "symbol": c.symbol,
             "description": c.description,
-            "severity": _severity_from_sets(c.kind),
+            "severity": _effective_severity_label(c, eff_sets),
             "affected_count": len(c.affected_symbols) if c.affected_symbols else 0,
             "affected_symbols": c.affected_symbols or [],
             "caused_count": c.caused_count,
@@ -633,12 +666,23 @@ def to_json(
     eff_sets = result._effective_kind_sets()
 
     if show_only:
-        eff_breaking, eff_api_break, _, eff_risk = eff_sets
         d["show_only_filter"] = show_only
         d["filtered_summary"] = {
-            "breaking": sum(1 for c in changes if c.kind in eff_breaking),
-            "source_breaks": sum(1 for c in changes if c.kind in eff_api_break),
-            "risk_changes": sum(1 for c in changes if c.kind in eff_risk),
+            "breaking": sum(
+                1
+                for c in changes
+                if effective_category(c, *eff_sets) == Verdict.BREAKING
+            ),
+            "source_breaks": sum(
+                1
+                for c in changes
+                if effective_category(c, *eff_sets) == Verdict.API_BREAK
+            ),
+            "risk_changes": sum(
+                1
+                for c in changes
+                if effective_category(c, *eff_sets) == Verdict.COMPATIBLE_WITH_RISK
+            ),
             "total_changes": len(changes),
         }
 
@@ -653,6 +697,9 @@ def to_json(
     d["changes"] = [_change_to_dict(c, policy=effective_policy, kind_sets=eff_sets) for c in changes]
     if result.redundant_count > 0:
         d["redundant_count"] = result.redundant_count
+    # ADR-027 A4 — pattern-aware modulation ledger (disclosed, reversible).
+    if result.pattern_modulations:
+        d["pattern_modulations"] = result.pattern_modulations
     d["suppression"] = {
         "file_provided": result.suppression_file_provided,
         "suppressed_count": result.suppressed_count,
@@ -707,17 +754,9 @@ def _change_to_dict(
     """Convert a Change to a JSON-serializable dict with impact and metadata."""
     kind = getattr(c, "kind", None)
     if kind and kind_sets:
-        breaking, api_break, compatible, risk = kind_sets
-        if kind in breaking:
-            severity = "breaking"
-        elif kind in api_break:
-            severity = "api_break"
-        elif kind in risk:
-            severity = "risk"
-        elif kind in compatible:
-            severity = "compatible"
-        else:
-            severity = "unknown"
+        # Route through effective_category so a per-finding A4 override (a
+        # demoted opaque/PIMPL layout change) reads compatible here too.
+        severity = _effective_severity_label(c, kind_sets)
     elif kind:
         severity = _kind_to_severity(kind, policy)
     else:
@@ -750,6 +789,14 @@ def _change_to_dict(
     caused_count = getattr(c, "caused_count", 0)
     if caused_count > 0:
         d["caused_count"] = caused_count
+    # ADR-027 A4 — disclose a pattern-aware modulation on the finding itself.
+    mod_reason = getattr(c, "modulation_reason", None)
+    if mod_reason:
+        d["modulation_reason"] = mod_reason
+        d["modulation_rule"] = getattr(c, "modulation_rule", None)
+        eff = getattr(c, "effective_verdict", None)
+        if isinstance(eff, Verdict):
+            d["effective_verdict"] = eff.value
     return d
 
 
@@ -1092,12 +1139,22 @@ def _classify_changes_by_kind(
     changes: list[Change], result: DiffResult,
 ) -> tuple[list[Change], list[Change], list[Change], list[Change]]:
     """Split *changes* into (breaking, source_breaks, risk, compatible) using the
-    effective kind sets (respects PolicyFile overrides)."""
-    breaking_set, api_break_set, compat_set, risk_set = result._effective_kind_sets()
-    breaking = [c for c in changes if c.kind in breaking_set]
-    source_breaks = [c for c in changes if c.kind in api_break_set]
-    risk = [c for c in changes if c.kind in risk_set]
-    compatible = [c for c in changes if c.kind in compat_set]
+    effective kind sets (respects PolicyFile overrides) and per-finding A4
+    ``effective_verdict`` overrides (ADR-027), so a demoted opaque/PIMPL layout
+    change lands in the compatible bucket of the text report too."""
+    sets = result._effective_kind_sets()
+    breaking = [c for c in changes if effective_category(c, *sets) == Verdict.BREAKING]
+    source_breaks = [
+        c for c in changes if effective_category(c, *sets) == Verdict.API_BREAK
+    ]
+    risk = [
+        c
+        for c in changes
+        if effective_category(c, *sets) == Verdict.COMPATIBLE_WITH_RISK
+    ]
+    compatible = [
+        c for c in changes if effective_category(c, *sets) == Verdict.COMPATIBLE
+    ]
     return breaking, source_breaks, risk, compatible
 
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -179,6 +179,11 @@ class ShowOnlyFilter:
         # leak a demoted finding it was meant to exclude.
         eff = getattr(change, "effective_verdict", None)
         if isinstance(eff, Verdict):
+            # NB: this maps to the CLI --show-only token vocabulary (hyphenated
+            # "api-break"), which intentionally differs from the JSON-field
+            # labels in _VERDICT_TO_SEVERITY_LABEL (underscored "api_break").
+            # The two are deliberately separate label spaces — keep them in sync
+            # by intent, not by sharing a dict.
             label = {
                 Verdict.BREAKING: "breaking",
                 Verdict.API_BREAK: "api-break",
@@ -233,6 +238,15 @@ class ShowOnlyFilter:
                 "anon_field_changed",
                 "used_reserved_field",
                 "frame_register_changed",
+                # ADR-027 anti-pattern: a function exposing std:: by value.
+                "public_api_exposes_stl_by_value",
+            ),
+            "types": (
+                # ADR-027 type-level idiom transitions / anti-patterns whose
+                # kind names don't match the type_/struct_/... prefixes.
+                "opaque_invariant_broken",
+                "polymorphic_type_non_virtual_dtor",
+                "handle_type_changed",
             ),
             "elf": (
                 "toolchain_flag_drift",

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -567,8 +567,8 @@ def _to_json_leaf(
     effective_policy = result.policy or "strict_abi"
     eff_sets = result._effective_kind_sets()
 
-    leaf_changes_list = [
-        {
+    def _leaf_entry(c: Change) -> dict[str, object]:
+        entry: dict[str, object] = {
             "kind": c.kind.value,
             "symbol": c.symbol,
             "description": c.description,
@@ -579,8 +579,18 @@ def _to_json_leaf(
             "old_value": getattr(c, "old_value", None),
             "new_value": getattr(c, "new_value", None),
         }
-        for c in type_changes
-    ]
+        # ADR-027 A4: keep the modulation audit trail in leaf mode too, so a
+        # demoted root type change still explains *why* it reads compatible.
+        mod_reason = getattr(c, "modulation_reason", None)
+        if mod_reason:
+            entry["modulation_reason"] = mod_reason
+            entry["modulation_rule"] = getattr(c, "modulation_rule", None)
+            eff = getattr(c, "effective_verdict", None)
+            if isinstance(eff, Verdict):
+                entry["effective_verdict"] = eff.value
+        return entry
+
+    leaf_changes_list = [_leaf_entry(c) for c in type_changes]
     non_type_list = [
         _change_to_dict(c, policy=effective_policy, kind_sets=eff_sets)
         for c in non_type_changes
@@ -609,6 +619,9 @@ def _to_json_leaf(
     d["release_recommendation"] = recommend_release(result).to_dict()
     if result.redundant_count > 0:
         d["redundant_count"] = result.redundant_count
+    # ADR-027 A4 — pattern-aware modulation ledger, carried in leaf mode too.
+    if result.pattern_modulations:
+        d["pattern_modulations"] = result.pattern_modulations
     # Confidence & evidence metadata
     d["confidence"] = result.confidence.value
     d["evidence_tier"] = result.evidence_tier.value

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -101,6 +101,7 @@ def _kind_to_severity(kind: ChangeKind, policy: str) -> str:
         return "compatible"
     return "unknown"
 
+
 _VERDICT_EMOJI = {
     Verdict.NO_CHANGE: "✅",
     Verdict.COMPATIBLE: "✅",
@@ -122,6 +123,7 @@ _VERDICT_LABEL = {
 # Show-only filter
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class ShowOnlyFilter:
     """Parsed --show-only tokens.
@@ -129,9 +131,10 @@ class ShowOnlyFilter:
     Tokens fall into three dimensions; within each dimension OR logic applies,
     across dimensions AND logic applies.
     """
+
     severities: frozenset[str]  # breaking, api-break, risk, compatible
-    elements: frozenset[str]    # functions, variables, types, enums, elf
-    actions: frozenset[str]     # added, removed, changed
+    elements: frozenset[str]  # functions, variables, types, enums, elf
+    actions: frozenset[str]  # added, removed, changed
 
     @classmethod
     def parse(cls, raw: str) -> ShowOnlyFilter:
@@ -168,6 +171,21 @@ class ShowOnlyFilter:
         if not self.severities:
             return True
         breaking_set, api_break_set, compat_set, risk_set = _policy_kind_sets(policy)
+        # Honour an A4 per-finding effective_verdict override (ADR-027): a
+        # demoted opaque/PIMPL layout change must be filtered by its *effective*
+        # category, so `--show-only=breaking` excludes it — consistent with the
+        # JSON severity field and filtered_summary counts (which already route
+        # through effective_category). Without this the severity filter would
+        # leak a demoted finding it was meant to exclude.
+        eff = getattr(change, "effective_verdict", None)
+        if isinstance(eff, Verdict):
+            label = {
+                Verdict.BREAKING: "breaking",
+                Verdict.API_BREAK: "api-break",
+                Verdict.COMPATIBLE_WITH_RISK: "risk",
+                Verdict.COMPATIBLE: "compatible",
+            }.get(eff)
+            return label in self.severities
         severity_map = {
             "breaking": breaking_set,
             "api-break": api_break_set,
@@ -185,25 +203,40 @@ class ShowOnlyFilter:
             return True
         _ELEMENT_PREFIXES: dict[str, tuple[str, ...]] = {
             "functions": (
-                "func_", "param_", "method_", "base_class_",
-                "template_", "return_pointer_level_",
+                "func_",
+                "param_",
+                "method_",
+                "base_class_",
+                "template_",
+                "return_pointer_level_",
             ),
             "variables": ("var_", "constant_"),
             "types": ("type_", "struct_", "union_", "field_", "typedef_"),
             "enums": ("enum_",),
             "elf": (
-                "soname_", "needed_", "symbol_", "rpath_", "runpath_",
-                "ifunc_", "common_", "dwarf_", "calling_convention_",
-                "compat_version_", "visibility_",
+                "soname_",
+                "needed_",
+                "symbol_",
+                "rpath_",
+                "runpath_",
+                "ifunc_",
+                "common_",
+                "dwarf_",
+                "calling_convention_",
+                "compat_version_",
+                "visibility_",
             ),
         }
         _ELEMENT_EXACT: dict[str, tuple[str, ...]] = {
             "functions": (
-                "removed_const_overload", "anon_field_changed",
-                "used_reserved_field", "frame_register_changed",
+                "removed_const_overload",
+                "anon_field_changed",
+                "used_reserved_field",
+                "frame_register_changed",
             ),
             "elf": (
-                "toolchain_flag_drift", "source_level_kind_changed",
+                "toolchain_flag_drift",
+                "source_level_kind_changed",
                 "value_abi_trait_changed",
             ),
         }
@@ -222,10 +255,18 @@ class ShowOnlyFilter:
         if not actions:
             return True
         _ADDED_SUFFIXES = ("_added", "_added_compatible")
-        _REMOVED_SUFFIXES = ("_removed", "_deleted", "_elf_only", "_elf_fallback", "_const_overload")
+        _REMOVED_SUFFIXES = (
+            "_removed",
+            "_deleted",
+            "_elf_only",
+            "_elf_fallback",
+            "_const_overload",
+        )
         if "added" in actions and any(kind_val.endswith(s) for s in _ADDED_SUFFIXES):
             return True
-        if "removed" in actions and any(kind_val.endswith(s) for s in _REMOVED_SUFFIXES):
+        if "removed" in actions and any(
+            kind_val.endswith(s) for s in _REMOVED_SUFFIXES
+        ):
             return True
         if "changed" in actions and not (
             any(kind_val.endswith(s) for s in _ADDED_SUFFIXES)
@@ -256,6 +297,7 @@ def apply_show_only(
 # ---------------------------------------------------------------------------
 # Stat mode
 # ---------------------------------------------------------------------------
+
 
 def to_stat(result: DiffResult) -> str:
     """One-line summary for CI gates."""
@@ -314,6 +356,7 @@ def to_stat_json(result: DiffResult, indent: int = 2) -> str:
 # Impact summary
 # ---------------------------------------------------------------------------
 
+
 def _build_impact_table(
     result: DiffResult,
     displayed_changes: list[Change] | None = None,
@@ -327,7 +370,9 @@ def _build_impact_table(
     """
     from .checker import _ROOT_TYPE_CHANGE_KINDS
 
-    changes = displayed_changes if displayed_changes is not None else list(result.changes)
+    changes = (
+        displayed_changes if displayed_changes is not None else list(result.changes)
+    )
 
     # Collect root type changes with their impact
     root_entries: list[tuple[str, str, int, int]] = []
@@ -335,11 +380,14 @@ def _build_impact_table(
         if c.kind in _ROOT_TYPE_CHANGE_KINDS:
             affected_count = len(c.affected_symbols) if c.affected_symbols else 0
             if affected_count > 0 or c.caused_count > 0:
-                root_entries.append((c.symbol, c.kind.value, affected_count, c.caused_count))
+                root_entries.append(
+                    (c.symbol, c.kind.value, affected_count, c.caused_count)
+                )
 
     # Count non-type direct changes
     direct_removals = sum(
-        1 for c in changes
+        1
+        for c in changes
         if c.kind.value.endswith("_removed") and c.kind not in _ROOT_TYPE_CHANGE_KINDS
     )
 
@@ -387,7 +435,11 @@ def _build_leaf_type_sections(type_changes: list[Change], policy: str) -> list[s
     breaking_set, api_break_set, _, _ = _policy_kind_sets(policy)
     breaking_types = [c for c in type_changes if c.kind in breaking_set]
     api_break_types = [c for c in type_changes if c.kind in api_break_set]
-    other_types = [c for c in type_changes if c.kind not in breaking_set and c.kind not in api_break_set]
+    other_types = [
+        c
+        for c in type_changes
+        if c.kind not in breaking_set and c.kind not in api_break_set
+    ]
 
     lines: list[str] = []
     for section_label, section_changes in [
@@ -433,7 +485,9 @@ def _to_markdown_leaf(
     changes = list(result.changes)
     if show_only:
         changes = apply_show_only(changes, show_only, policy=result.policy)
-        lines.append(f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)")
+        lines.append(
+            f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)"
+        )
         lines.append("")
 
     # Group root type changes by severity
@@ -527,7 +581,10 @@ def _to_json_leaf(
         }
         for c in type_changes
     ]
-    non_type_list = [_change_to_dict(c, policy=effective_policy, kind_sets=eff_sets) for c in non_type_changes]
+    non_type_list = [
+        _change_to_dict(c, policy=effective_policy, kind_sets=eff_sets)
+        for c in non_type_changes
+    ]
 
     d: dict[str, object] = {
         "report_schema_version": REPORT_SCHEMA_VERSION,
@@ -568,6 +625,7 @@ def _to_json_leaf(
 # ---------------------------------------------------------------------------
 # JSON output
 # ---------------------------------------------------------------------------
+
 
 def _metadata_dict(meta: object | None) -> dict[str, object] | None:
     if meta is None:
@@ -689,12 +747,15 @@ def to_json(
     # Severity-categorized summary when severity config is provided
     if severity_config is not None:
         d["severity"] = _build_severity_json(
-            changes, severity_config,
+            changes,
+            severity_config,
             all_changes=list(result.changes),
             kind_sets=eff_sets,
         )
 
-    d["changes"] = [_change_to_dict(c, policy=effective_policy, kind_sets=eff_sets) for c in changes]
+    d["changes"] = [
+        _change_to_dict(c, policy=effective_policy, kind_sets=eff_sets) for c in changes
+    ]
     if result.redundant_count > 0:
         d["redundant_count"] = result.redundant_count
     # ADR-027 A4 — pattern-aware modulation ledger (disclosed, reversible).
@@ -749,7 +810,13 @@ def _change_to_dict(
     c: object,
     *,
     policy: str = "strict_abi",
-    kind_sets: tuple[frozenset[ChangeKind], frozenset[ChangeKind], frozenset[ChangeKind], frozenset[ChangeKind]] | None = None,
+    kind_sets: tuple[
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+        frozenset[ChangeKind],
+    ]
+    | None = None,
 ) -> dict[str, object]:
     """Convert a Change to a JSON-serializable dict with impact and metadata."""
     kind = getattr(c, "kind", None)
@@ -804,6 +871,7 @@ def _change_to_dict(
 # Markdown output
 # ---------------------------------------------------------------------------
 
+
 def _fmt_size(size_bytes: int) -> str:
     """Format file size in human-readable form."""
     if size_bytes < 1024:
@@ -854,7 +922,9 @@ _SEVERITY_EMOJI = {
 }
 
 
-def _section_severity_label(severity_config: SeverityConfig | None, category_attr: str) -> str:
+def _section_severity_label(
+    severity_config: SeverityConfig | None, category_attr: str
+) -> str:
     """Return a severity label suffix like ' [ERROR]' for a report section header."""
     if severity_config is None:
         return ""
@@ -885,7 +955,11 @@ def _build_severity_summary_md(
 
     _CATEGORY_INFO: list[tuple[str, str, list[HasKind]]] = [
         ("ABI/API Incompatibilities", "abi_breaking", categorized.abi_breaking),
-        ("Potential Incompatibilities", "potential_breaking", categorized.potential_breaking),
+        (
+            "Potential Incompatibilities",
+            "potential_breaking",
+            categorized.potential_breaking,
+        ),
         ("Quality Issues", "quality_issues", categorized.quality_issues),
         ("Additions", "addition", categorized.addition),
     ]
@@ -895,7 +969,11 @@ def _build_severity_summary_md(
         level_val = level.value if hasattr(level, "value") else str(level)
         emoji = _SEVERITY_EMOJI.get(level_val, "")
         count = len(cat_changes)
-        impact = "causes non-zero exit" if level_val == "error" and count > 0 else "no exit impact"
+        impact = (
+            "causes non-zero exit"
+            if level_val == "error" and count > 0
+            else "no exit impact"
+        )
         lines.append(
             f"| {label} | {emoji} `{level_val.upper()}` | {count} | {impact} |"
         )
@@ -976,7 +1054,9 @@ def _footer_lines() -> list[str]:
     ]
 
 
-def _build_library_files_section(old_meta: LibraryMetadata | None, new_meta: LibraryMetadata | None) -> list[str]:
+def _build_library_files_section(
+    old_meta: LibraryMetadata | None, new_meta: LibraryMetadata | None
+) -> list[str]:
     """Build the '## Library Files' markdown section."""
     lines = ["## Library Files", "", "| | Old | New |", "|---|---|---|"]
     old_path = getattr(old_meta, "path", "—") if old_meta else "—"
@@ -1034,6 +1114,7 @@ def _build_severity_sections(
 
     if compatible:
         from .checker_policy import ADDITION_KINDS as _ADDITION_KINDS
+
         quality = [c for c in compatible if c.kind not in _ADDITION_KINDS]
         additions_list = [c for c in compatible if c.kind in _ADDITION_KINDS]
         if quality:
@@ -1107,7 +1188,9 @@ def to_review_digest(result: DiffResult) -> str:
         f"| ✅ {additions_label} | {summary.compatible_additions} |",
     ]
     if scoped:
-        lines.append(f"| 🔒 Filtered (internal/private) | {result.out_of_surface_count} |")
+        lines.append(
+            f"| 🔒 Filtered (internal/private) | {result.out_of_surface_count} |"
+        )
     lines.append("")
 
     rec = recommend_release(result)
@@ -1120,8 +1203,7 @@ def to_review_digest(result: DiffResult) -> str:
     # Top impacted symbols (breaking + API), capped for readability.
     breaking_set, api_break_set, _, _ = result._effective_kind_sets()
     impacted = [
-        c for c in result.changes
-        if c.kind in breaking_set or c.kind in api_break_set
+        c for c in result.changes if c.kind in breaking_set or c.kind in api_break_set
     ]
     if impacted:
         lines += ["**Top impacted symbols:**", ""]
@@ -1136,7 +1218,8 @@ def to_review_digest(result: DiffResult) -> str:
 
 
 def _classify_changes_by_kind(
-    changes: list[Change], result: DiffResult,
+    changes: list[Change],
+    result: DiffResult,
 ) -> tuple[list[Change], list[Change], list[Change], list[Change]]:
     """Split *changes* into (breaking, source_breaks, risk, compatible) using the
     effective kind sets (respects PolicyFile overrides) and per-finding A4
@@ -1191,16 +1274,21 @@ def to_markdown(
         if not demangle:
             return text
         from .demangle import demangle_text
+
         return demangle_text(text)
 
     if stat:
         return _out(to_stat(result))
 
     if report_mode == "leaf":
-        return _out(_to_markdown_leaf(
-            result, show_impact=show_impact, show_only=show_only,
-            show_recommendation=show_recommendation,
-        ))
+        return _out(
+            _to_markdown_leaf(
+                result,
+                show_impact=show_impact,
+                show_only=show_only,
+                show_recommendation=show_recommendation,
+            )
+        )
 
     v = result.verdict
     emoji = _VERDICT_EMOJI[v]
@@ -1215,7 +1303,9 @@ def to_markdown(
         changes = apply_show_only(changes, show_only, policy=result.policy)
 
     # Classify filtered changes using effective kind sets (respects PolicyFile overrides)
-    breaking, source_breaks, risk, compatible = _classify_changes_by_kind(changes, result)
+    breaking, source_breaks, risk, compatible = _classify_changes_by_kind(
+        changes, result
+    )
 
     lines: list[str] = [
         f"# ABI Report: {result.library}",
@@ -1247,18 +1337,25 @@ def to_markdown(
     # Severity configuration summary when provided
     if severity_config is not None:
         lines += _build_severity_summary_md(
-            changes, severity_config, kind_sets=result._effective_kind_sets(),
+            changes,
+            severity_config,
+            kind_sets=result._effective_kind_sets(),
         )
 
     if show_only:
-        lines.append(f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)")
+        lines.append(
+            f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)"
+        )
         lines.append("")
 
     if old_meta or new_meta:
         lines += _build_library_files_section(old_meta, new_meta)
 
     lines += _build_severity_sections(
-        breaking, source_breaks, risk, compatible,
+        breaking,
+        source_breaks,
+        risk,
+        compatible,
         severity_config=severity_config,
     )
 
@@ -1289,7 +1386,9 @@ def _append_confidence_section(lines: list[str], result: DiffResult) -> None:
     conf_val = conf.value if hasattr(conf, "value") else str(conf)
     tier_str = ", ".join(f"`{t}`" for t in tiers) if tiers else "_none_"
     etier = getattr(result, "evidence_tier", None)
-    etier_val = etier.value if (etier is not None and hasattr(etier, "value")) else str(etier)
+    etier_val = (
+        etier.value if (etier is not None and hasattr(etier, "value")) else str(etier)
+    )
     lines += [
         "## Analysis Confidence",
         "",
@@ -1385,6 +1484,7 @@ def _format_change_md(c: object) -> str:
 # Application compatibility reporters (ADR-005)
 # ---------------------------------------------------------------------------
 
+
 def appcompat_to_json(result: object, indent: int = 2) -> str:
     """Render an AppCompatResult as JSON."""
     import json as _json
@@ -1408,8 +1508,13 @@ def appcompat_to_json(result: object, indent: int = 2) -> str:
     d["missing_versions"] = list(missing_ver)
 
     breaking = getattr(result, "breaking_for_app", [])
-    appcompat_policy = getattr(getattr(result, "full_diff", None), "policy", "strict_abi") or "strict_abi"
-    d["relevant_changes"] = [_change_to_dict(c, policy=appcompat_policy) for c in breaking]
+    appcompat_policy = (
+        getattr(getattr(result, "full_diff", None), "policy", "strict_abi")
+        or "strict_abi"
+    )
+    d["relevant_changes"] = [
+        _change_to_dict(c, policy=appcompat_policy) for c in breaking
+    ]
     d["relevant_change_count"] = len(breaking)
 
     irrelevant = getattr(result, "irrelevant_for_app", [])
@@ -1429,7 +1534,9 @@ def appcompat_to_json(result: object, indent: int = 2) -> str:
             d["confidence"] = conf.value if hasattr(conf, "value") else str(conf)
             etier = getattr(full_diff, "evidence_tier", None)
             if etier is not None:
-                d["evidence_tier"] = etier.value if hasattr(etier, "value") else str(etier)
+                d["evidence_tier"] = (
+                    etier.value if hasattr(etier, "value") else str(etier)
+                )
             d["evidence_tiers"] = list(getattr(full_diff, "evidence_tiers", []) or [])
             cov_warns = getattr(full_diff, "coverage_warnings", []) or []
             if cov_warns:
@@ -1512,7 +1619,11 @@ def appcompat_to_markdown(result: object, *, show_irrelevant: bool = False) -> s
 
 
 def _appcompat_header_lines(
-    app_path: str, old_lib: str, new_lib: str, v_emoji: str, v_label: str,
+    app_path: str,
+    old_lib: str,
+    new_lib: str,
+    v_emoji: str,
+    v_label: str,
 ) -> list[str]:
     """Build the report header lines for appcompat markdown."""
     header = [
@@ -1533,7 +1644,11 @@ def _appcompat_coverage_lines(
     missing: list[object],
 ) -> list[str]:
     """Build symbol coverage section lines."""
-    lines = ["## Symbol Coverage", "", f"App requires **{required_count}** library symbols."]
+    lines = [
+        "## Symbol Coverage",
+        "",
+        f"App requires **{required_count}** library symbols.",
+    ]
     if missing:
         lines.append(
             f"**{len(missing)}** required symbol(s) missing from new version "
@@ -1556,7 +1671,9 @@ def _appcompat_missing_lines(
     lines: list[str] = []
     if missing:
         lines += ["## Missing Symbols", ""]
-        lines.append("These symbols are required by the application but absent from the new library:")
+        lines.append(
+            "These symbols are required by the application but absent from the new library:"
+        )
         lines.append("")
         for sym in missing:
             lines.append(f"- `{sym}`")
@@ -1595,7 +1712,9 @@ def _appcompat_relevant_lines(breaking: list[Change], total_changes: int) -> lis
     return []
 
 
-def _appcompat_irrelevant_lines(irrelevant: list[Change], show_irrelevant: bool) -> list[str]:
+def _appcompat_irrelevant_lines(
+    irrelevant: list[Change], show_irrelevant: bool
+) -> list[str]:
     """Build irrelevant changes section/note lines."""
     if irrelevant and not show_irrelevant:
         return [

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -51,7 +51,20 @@ def _tool_version() -> str:
         return "unknown"
 
 
+_VERDICT_TO_SARIF_LEVEL = {
+    Verdict.BREAKING: "error",
+    Verdict.API_BREAK: "error",
+    Verdict.COMPATIBLE_WITH_RISK: "warning",
+    Verdict.COMPATIBLE: "note",
+}
+
+
 def _severity(change: Change) -> str:
+    # Honour an A4 per-finding effective_verdict (ADR-027): a demoted opaque/
+    # PIMPL layout change reports as a SARIF "note", not an "error".
+    eff = getattr(change, "effective_verdict", None)
+    if isinstance(eff, Verdict):
+        return _VERDICT_TO_SARIF_LEVEL.get(eff, policy_for(change.kind).severity)
     return policy_for(change.kind).severity
 
 

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -187,8 +187,10 @@ def classify_change_object(
         return IssueCategory.ABI_BREAKING
     if verdict in (Verdict.API_BREAK, Verdict.COMPATIBLE_WITH_RISK):
         return IssueCategory.POTENTIAL_BREAKING
-    # COMPATIBLE: an addition keeps its ADDITION bucket; everything else
-    # (including a demoted break) is a quality issue, never an addition.
+    # COMPATIBLE (and the unreachable NO_CHANGE — effective_category only ever
+    # returns BREAKING/API_BREAK/RISK/COMPATIBLE): an addition keeps its
+    # ADDITION bucket; everything else (including a demoted break, or a
+    # hypothetical NO_CHANGE) is a quality issue, never an addition.
     if change.kind in ADDITION_KINDS and change.kind in sets[2]:
         return IssueCategory.ADDITION
     return IssueCategory.QUALITY_ISSUES

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -69,6 +69,8 @@ from .checker_policy import (
     RISK_KINDS,
     ChangeKind,
     HasKind,
+    Verdict,
+    effective_category,
     policy_kind_sets,
 )
 from .errors import PolicyError
@@ -163,6 +165,33 @@ def classify_change(
         return IssueCategory.QUALITY_ISSUES
     # Fail-safe: unclassified kinds are treated as breaking.
     return IssueCategory.ABI_BREAKING
+
+
+def classify_change_object(
+    change: HasKind,
+    *,
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+) -> IssueCategory:
+    """Classify a *change* honouring its per-finding ``effective_verdict`` (A4).
+
+    Routes through :func:`checker_policy.effective_category` — the single place
+    a finding's category is decided — so an ADR-027 pattern-aware demotion (a
+    ``Change`` carrying ``effective_verdict``) reads compatible in the
+    severity-aware exit code and category counts, not just the verdict. Falls
+    back to kind-based ``classify_change`` for plain stubs with no override.
+    """
+    sets = _resolve_kind_sets(policy, kind_sets)
+    verdict = effective_category(change, *sets)
+    if verdict == Verdict.BREAKING:
+        return IssueCategory.ABI_BREAKING
+    if verdict in (Verdict.API_BREAK, Verdict.COMPATIBLE_WITH_RISK):
+        return IssueCategory.POTENTIAL_BREAKING
+    # COMPATIBLE: an addition keeps its ADDITION bucket; everything else
+    # (including a demoted break) is a quality issue, never an addition.
+    if change.kind in ADDITION_KINDS and change.kind in sets[2]:
+        return IssueCategory.ADDITION
+    return IssueCategory.QUALITY_ISSUES
 
 
 # ---------------------------------------------------------------------------
@@ -374,7 +403,7 @@ def compute_exit_code(
     """
     worst = 0
     for change in changes:
-        cat = classify_change(change.kind, policy=policy, kind_sets=kind_sets)
+        cat = classify_change_object(change, policy=policy, kind_sets=kind_sets)
         if config.level_for(cat) == SeverityLevel.ERROR:
             code = _CATEGORY_EXIT_CODES[cat]
             if code > worst:
@@ -411,7 +440,7 @@ def categorize_changes(
     adds: list[HasKind] = []
 
     for c in changes:
-        cat = classify_change(c.kind, policy=policy, kind_sets=kind_sets)
+        cat = classify_change_object(c, policy=policy, kind_sets=kind_sets)
         if cat == IssueCategory.ABI_BREAKING:
             abi.append(c)
         elif cat == IssueCategory.POTENTIAL_BREAKING:

--- a/docs/concepts/api-surface-intelligence.md
+++ b/docs/concepts/api-surface-intelligence.md
@@ -1,0 +1,84 @@
+# API Surface Intelligence
+
+abicheck does not only diff symbols one at a time — it also reasons about the
+*shape* of your public API as a typed declaration graph. This page describes the
+**idiom-aware** features introduced in [ADR-027](../development/adr/027-api-surface-intelligence.md):
+the single-snapshot `surface-report`, idiom & anti-pattern recognition, and
+**pattern-aware verdicts** that modulate a diff using that knowledge.
+
+These features are **opt-in** and **auditable**. The governing rule, inherited
+from the public-surface work in ADR-024, is:
+
+> Pattern inference may **demote with a disclosed reason** or **raise** a
+> finding; it may **never silently delete** one.
+
+Every modulation is recorded, attributed to the rule that made it, and
+reversible with a flag.
+
+## `surface-report` — describe one library's surface
+
+```bash
+abicheck surface-report libfoo.so -H include/ --idioms --anti-patterns --format json
+```
+
+It reports, for a single library (no diff):
+
+- header→symbol coverage and the undocumented-export ratio,
+- per-type fan-in (the "blast radius" if a type changes),
+- recognised **idioms** (`--idioms`): opaque pointer, PIMPL, handle, factory,
+  create/destroy pairs, callback ABI, and
+- **anti-patterns** (`--anti-patterns`): `std::` types crossed by value, and
+  polymorphic types with no virtual destructor.
+
+## Idioms
+
+An *idiom* is a graph pattern recognised conservatively from declaration facts
+(pointer depth, fields, bases, vtables, typedef targets). The two that drive
+verdict modulation are:
+
+- **Opaque pointer** — a type whose complete definition is **not** visible in
+  the public include closure (it is only ever forward-declared) and that public
+  functions cross only by pointer. Callers provably cannot `sizeof` or embed it,
+  so a change to its size or fields is not an ABI break *for them*.
+- **PIMPL** — a *complete* public wrapper whose only data member is a pointer to
+  a hidden implementation type. The wrapper's own layout is part of the ABI; only
+  the hidden pointee is invisible to callers.
+
+## Pattern-aware verdicts (`--pattern-verdicts`)
+
+When enabled, a post-processing pass modulates findings using the idiom
+evidence from **both** snapshots:
+
+| Rule | Effect | Guard |
+|------|--------|-------|
+| Opaque-pointer layout | A layout change on a provably-opaque type is demoted to compatible (`opaque-by-construction`). | Only when the definition is hidden on **both** snapshots, and only at the `header_aware` evidence tier. |
+| PIMPL pointee-only | A change to the hidden impl pointee is demoted (`pimpl-impl-hidden`). | The wrapper's own layout must be byte-identical across both snapshots; a change to the wrapper stays breaking. |
+| Anti-pattern raise | A finding on an STL-by-value / non-virtual-dtor surface is annotated with elevated risk. | Pure annotation — it can never hide a finding. |
+
+And it **raises** new breaks when a guarantee callers relied on is lost:
+
+- `opaque_invariant_broken` — a type that was opaque/PIMPL now exposes its
+  layout (its definition became visible, or it is now passed by value). Emitted
+  **instead** of any silent demotion.
+- `handle_type_changed` — an opaque handle typedef's underlying token type
+  changed observably.
+
+### Auditability
+
+Every modulation is disclosed:
+
+- a `pattern_modulations` array in the JSON report
+  (`{symbol, original_category, new_category, rule_id, reason, evidence_tier,
+  edges_matched}`), and the demoted finding stays in `changes` with its
+  `effective_verdict` / `modulation_reason` recorded — re-categorised in place,
+  never dropped;
+- `--explain-patterns` prints the idiom evidence behind each modulation;
+- `--no-pattern-verdicts` (the default) disables all modulation, restoring pure
+  kind-based classification.
+
+Demotion is gated to the `header_aware` evidence tier (idioms need the AST), a
+demotion never overrides a frozen-namespace break, and a break-demotion is
+logged at `WARN`. The anti-hiding contract is enforced by the test suite:
+a real layout break on a **non**-opaque type still fires at full severity, and a
+type that *loses* opaqueness emits `opaque_invariant_broken` rather than being
+quietly demoted.

--- a/docs/concepts/api-surface-intelligence.md
+++ b/docs/concepts/api-surface-intelligence.md
@@ -82,3 +82,25 @@ logged at `WARN`. The anti-hiding contract is enforced by the test suite:
 a real layout break on a **non**-opaque type still fires at full severity, and a
 type that *loses* opaqueness emits `opaque_invariant_broken` rather than being
 quietly demoted.
+
+## Cross-library reachability (A3, multi-binary releases)
+
+In a `compare-release` / bundle run, a type changed in one library that is also
+referenced by a sibling is reported as `bundle_intra_type_changed`. A3 adds a
+**reachability filter**: if the consumer library references the changed type
+only through its *internal* (non-exported) symbols — so the change cannot reach
+the consumer's own public ABI surface — the finding is **demoted to risk**
+(reason `consumer-internal-use`), never dropped. When the type leaks into a
+symbol the consumer itself exports, the finding stays a full-confidence
+cross-DSO break. The demotion is carried on the `BundleFinding` and propagated
+onto the lowered `Change`, so the **bundle verdict** and the `compare-release`
+exit code honour it — the same demote-don't-delete contract as A4.
+
+## Surface-metric drift (A1, `--surface-metrics`)
+
+`compare --surface-metrics` emits aggregate, informational `COMPATIBLE`
+roll-ups — `public_surface_grew` / `public_surface_shrank` and
+`undocumented_export_ratio_increased` — computed from the same metrics as
+`surface-report`. They never drive a verdict on their own (the individual
+additions/removals are reported per-symbol); they are a trendable signal for CI
+dashboards and release notes.

--- a/docs/development/adr/027-api-surface-intelligence.md
+++ b/docs/development/adr/027-api-surface-intelligence.md
@@ -4,6 +4,18 @@
 **Status:** Accepted
 **Decision maker:** Nikolay Petrov
 
+> **Implementation status (2026-06-07).** Phase 0 (`surface_graph.py`),
+> Phase 1 (`surface-report` / A1 metrics), Phase 2 (`idioms.py` recognisers +
+> the four D2.2 anti-pattern `ChangeKind`s), and Phase 3 (A4 pattern-aware
+> verdicts: `pattern_verdicts.py`, the per-finding `effective_verdict` override
+> threaded through every classification site, `--pattern-verdicts` /
+> `--explain-patterns`, and the `pattern_modulations` ledger) have shipped.
+> Idiom evidence is recomputed at diff time from the persisted declaration
+> graph rather than serialized as bare tag names (D2.4 intent), so no schema
+> bump was required. **Pending:** A3 cross-library reasoning (D3, Phase 4) and
+> the metric-drift `ChangeKind`s (D1.2, Phase 5) — `--pattern-verdicts` remains
+> opt-in until the FP-rate corpus and parity lanes validate a default flip.
+
 ---
 
 ## Context

--- a/docs/development/adr/027-api-surface-intelligence.md
+++ b/docs/development/adr/027-api-surface-intelligence.md
@@ -4,17 +4,24 @@
 **Status:** Accepted
 **Decision maker:** Nikolay Petrov
 
-> **Implementation status (2026-06-07).** Phase 0 (`surface_graph.py`),
-> Phase 1 (`surface-report` / A1 metrics), Phase 2 (`idioms.py` recognisers +
-> the four D2.2 anti-pattern `ChangeKind`s), and Phase 3 (A4 pattern-aware
-> verdicts: `pattern_verdicts.py`, the per-finding `effective_verdict` override
-> threaded through every classification site, `--pattern-verdicts` /
-> `--explain-patterns`, and the `pattern_modulations` ledger) have shipped.
-> Idiom evidence is recomputed at diff time from the persisted declaration
-> graph rather than serialized as bare tag names (D2.4 intent), so no schema
-> bump was required. **Pending:** A3 cross-library reasoning (D3, Phase 4) and
-> the metric-drift `ChangeKind`s (D1.2, Phase 5) — `--pattern-verdicts` remains
-> opt-in until the FP-rate corpus and parity lanes validate a default flip.
+> **Implementation status (2026-06-07).** All phases have shipped:
+> Phase 0 (`surface_graph.py`), Phase 1 (`surface-report` / A1 metrics),
+> Phase 2 (`idioms.py` recognisers + the four D2.2 anti-pattern `ChangeKind`s),
+> Phase 3 (A4 pattern-aware verdicts: `pattern_verdicts.py`, the per-finding
+> `effective_verdict` override threaded through every classification site,
+> `--pattern-verdicts` / `--explain-patterns`, the `pattern_modulations`
+> ledger), Phase 4 (A3 cross-library: the `BUNDLE_INTRA_TYPE_CHANGED`
+> reachability filter in `bundle.py` — a cross-DSO type change a consumer uses
+> only via internal/non-exported symbols is demoted to risk via a per-finding
+> `BundleFinding.effective_verdict`, propagated onto the lowered `Change` so the
+> bundle verdict and the `compare-release` exit code honour it), and Phase 5
+> (the D1.2 metric-drift `ChangeKind`s behind `--surface-metrics`). Idiom
+> evidence is recomputed at diff time from the persisted declaration graph
+> rather than serialized as bare tag names (D2.4 intent), so no schema bump was
+> required; A3 uses ELF exported-symbol membership as the consumer public-surface
+> proxy (the bundle path carries ELF metadata, not full type graphs).
+> **Still deferred by design:** flipping `--pattern-verdicts` to default-on,
+> which the ADR gates on FP-rate + parity stability across a release cycle.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 ## Why abicheck
 
 - **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
-- **196 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
+- **199 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.
 - **ABICC drop-in** — full flag parity for migrating from `abi-compliance-checker`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 ## Why abicheck
 
 - **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
-- **192 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
+- **196 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.
 - **ABICC drop-in** — full flag parity for migrating from `abi-compliance-checker`.

--- a/docs/reference/change-kinds.md
+++ b/docs/reference/change-kinds.md
@@ -170,6 +170,15 @@ These breaks come from language-standard features or build-model choices (oneAPI
 | `bit_int_width_changed` | A public type used C23 `_BitInt(N)` and the width `N` changed, or a parameter/field/return type changed to or from `_BitInt(N)`. The width is part of the type identity and layout, so old code reads/writes the wrong number of bits and the mangled name changes. |
 | `atomic_qualifier_changed` | The `_Atomic` qualifier was added to or removed from a public field, parameter, or return type. The size, alignment, and (for some struct types) representation of atomic-qualified types can diverge from their non-atomic counterparts and across compilers (WG14), so old code misinterprets the data. |
 
+### API-surface intelligence transitions (ADR-027)
+
+These breaks are recognised from the declaration *graph* (idioms), not a single per-symbol diff. They fire when an opacity or handle guarantee that callers relied on is lost between versions. See the [API Surface Intelligence](../concepts/api-surface-intelligence.md) guide.
+
+| Kind | Description |
+|------|-------------|
+| `opaque_invariant_broken` | A type that was opaque (definition hidden from callers, crossed only by pointer) or PIMPL now exposes its layout — its complete definition became visible in the public include closure, or a public function began passing it by value. Callers can now `sizeof`/embed it, so its size and fields have joined the ABI and any later change to them is a hard break. The pattern-verdict pass emits this **instead** of silently demoting an opaque-layout change once opaqueness is lost. |
+| `handle_type_changed` | An opaque handle typedef (a `void*` token or a pointer to a forward-declared struct) changed its underlying token type in a way callers can observe. Code that stored or compared the old handle representation now operates on an incompatible token. |
+
 ## Source API Breaks (`API_BREAK`)
 
 These changes break the source-level API contract but do not affect already-compiled binaries.
@@ -259,6 +268,8 @@ library from loading in some deployment environments. Manual review is required.
 | `stack_canary_removed` | The stack-smashing protector (`-fstack-protector`) is no longer referenced (`__stack_chk_fail` / `__stack_chk_guard` absent). Stack-buffer overflows are no longer detected at runtime. Gate via `--policy-file security`. |
 | `fortify_source_weakened` | `_FORTIFY_SOURCE` fortified libc wrappers (the `*_chk` family, e.g. `__memcpy_chk`) are no longer referenced, dropping compile-time/runtime buffer-overflow checks. Gate via `--policy-file security`. |
 | `writable_executable_segment` | A loadable segment is now simultaneously writable **and** executable (a W^X violation). Injected code in that page becomes executable. Gate via `--policy-file security`. |
+| `public_api_exposes_stl_by_value` | A public function takes or returns a `std::` type by value across the library boundary. Standard-library layouts differ across toolchains, standard-library versions, and the C++11 dual-ABI setting, so a consumer built with a different STL silently reads the wrong layout. A graph-shaped anti-pattern (ADR-027 A2): reported by `surface-report`, and at diff time only when newly introduced. |
+| `polymorphic_type_non_virtual_dtor` | A type with virtual methods (it has a vtable) is used as a factory return or base class but declares no virtual destructor. Deleting a derived object through a base pointer is undefined behaviour. A graph-shaped anti-pattern (ADR-027 A2): reported by `surface-report`, and at diff time only when newly introduced. |
 
 See the [Security-hardening drift](../user-guide/security-hardening.md) guide for how to scan for these across releases.
 

--- a/docs/reference/change-kinds.md
+++ b/docs/reference/change-kinds.md
@@ -357,6 +357,16 @@ These changes are safe: they add new capabilities or carry diagnostic informatio
 | `glibcxx_dual_abi_flip_detected` | Mass symbol churn matches a libstdc++ dual ABI toggle (`_GLIBCXX_USE_CXX11_ABI`). Individual removed/added symbols are likely caused by this single root cause rather than intentional API changes — the underlying per-symbol findings are reported separately. |
 | `abi_surface_explosion` | The public ABI surface grew or shrank dramatically (e.g. a lost `-fvisibility=hidden` flag). This is a configuration/packaging signal, not a per-symbol break, but may indicate an unintended visibility regression. |
 
+### Surface-metric drift (ADR-027, opt-in `--surface-metrics`)
+
+Aggregate roll-up signals computed from the [API surface metrics](../concepts/api-surface-intelligence.md). Informational only — the individual additions/removals are reported per-symbol; these never drive a verdict on their own and are emitted only with `--surface-metrics`.
+
+| Kind | Description |
+|------|-------------|
+| `public_surface_grew` | The net count of public declarations (functions, variables, types, enums) increased between versions. A trendable signal for CI dashboards and release notes. |
+| `public_surface_shrank` | The net count of public declarations decreased between versions. A roll-up signal; the individual removals (which may be breaking) are reported separately. |
+| `undocumented_export_ratio_increased` | The fraction of exported symbols with no public-header declaration (EXPORT_ONLY origin) rose — a packaging-hygiene regression where a symbol was exported without a corresponding public header. |
+
 ### Field Qualifier Changes
 
 | Kind | Description |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Architecture: concepts/architecture.md
     - Limitations: concepts/limitations.md
     - Change Kinds: reference/change-kinds.md
+    - API Surface Intelligence: concepts/api-surface-intelligence.md
     - Exit Codes: reference/exit-codes.md
     - Platforms: reference/platforms.md
     - Tool Comparison: reference/tool-comparison.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,9 @@ paths_to_mutate = [
     "abicheck/diff_platform.py",     # ELF/DWARF/PE/Mach-O detectors
     "abicheck/diff_filtering.py",    # deduplication and redundancy logic
     "abicheck/checker_policy.py",    # verdict classification
+    "abicheck/idioms.py",            # ADR-027 idiom & anti-pattern recognisers
+    "abicheck/pattern_verdicts.py",  # ADR-027 A4 verdict modulation
+    "abicheck/surface_graph.py",     # ADR-027 declaration-graph substrate
 ]
 tests_dir = "tests/"
 runner = "python -m pytest -x -q --tb=no -m 'not integration and not libabigail and not abicc and not slow'"

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -625,6 +625,31 @@ class TestIntraTypeReachability:
         # Disclosed, never dropped.
         assert f in result.bundle_findings
 
+    def test_internal_only_demotion_not_a_junit_failure(self) -> None:
+        # A risk-demoted BUNDLE_INTRA_TYPE_CHANGED must follow its EFFECTIVE risk
+        # category in JUnit, not the original breaking kind's severity — so by
+        # default it is NOT a <failure> (Codex review).
+        from abicheck.checker_policy import (
+            API_BREAK_KINDS,
+            BREAKING_KINDS,
+            RISK_KINDS,
+        )
+        from abicheck.junit_report import _is_failure
+
+        demoted = Change(
+            kind=ChangeKind.BUNDLE_INTRA_TYPE_CHANGED,
+            symbol="DataCollection",
+            description="internal-only cross-DSO change",
+            effective_verdict=Verdict.COMPATIBLE_WITH_RISK,
+            modulation_reason="consumer-internal-use",
+        )
+        assert not _is_failure(
+            demoted,
+            frozenset(BREAKING_KINDS),
+            frozenset(API_BREAK_KINDS),
+            frozenset(RISK_KINDS),
+        )
+
 
 # ---------------------------------------------------------------------------
 # bundle_intra_dep_resolved_to_different_version (gnu.version_d drift)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -4,6 +4,7 @@ These tests use minimal in-memory ElfMetadata fixtures so they do not need
 gcc or castxml. Integration tests that build real .so files from the
 examples/case90-93 fixtures live in tests/test_bundle_examples.py.
 """
+
 from __future__ import annotations
 
 import sys
@@ -29,6 +30,7 @@ from abicheck.elf_metadata import ElfImport, ElfMetadata, ElfSymbol
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 def _meta(
     *,
     soname: str = "",
@@ -40,10 +42,13 @@ def _meta(
     """Construct a minimal ElfMetadata for testing."""
     syms = []
     for name in exports or []:
-        syms.append(ElfSymbol(
-            name=name, visibility="default",
-            version=(export_versions or {}).get(name, ""),
-        ))
+        syms.append(
+            ElfSymbol(
+                name=name,
+                visibility="default",
+                version=(export_versions or {}).get(name, ""),
+            )
+        )
     imps = []
     for name in imports or []:
         imps.append(ElfImport(name=name))
@@ -67,16 +72,22 @@ def _snapshot(libraries: dict[str, ElfMetadata]) -> BundleSnapshot:
     )
 
 
-def _diff(library: str, *changes: Change, verdict: Verdict = Verdict.BREAKING) -> DiffResult:
+def _diff(
+    library: str, *changes: Change, verdict: Verdict = Verdict.BREAKING
+) -> DiffResult:
     return DiffResult(
-        old_version="old", new_version="new",
-        library=library, changes=list(changes), verdict=verdict,
+        old_version="old",
+        new_version="new",
+        library=library,
+        changes=list(changes),
+        verdict=verdict,
     )
 
 
 # ---------------------------------------------------------------------------
 # Resolution graph
 # ---------------------------------------------------------------------------
+
 
 class TestResolutionGraph:
     def test_indexes_exports_and_imports(self) -> None:
@@ -100,10 +111,13 @@ class TestResolutionGraph:
 
     def test_skips_hidden_visibility(self) -> None:
         # Hidden exports are not part of the public surface.
-        meta = ElfMetadata(soname="lib.so", symbols=[
-            ElfSymbol(name="public_func", visibility="default"),
-            ElfSymbol(name="hidden_func", visibility="hidden"),
-        ])
+        meta = ElfMetadata(
+            soname="lib.so",
+            symbols=[
+                ElfSymbol(name="public_func", visibility="default"),
+                ElfSymbol(name="hidden_func", visibility="hidden"),
+            ],
+        )
         snap = _snapshot({"lib.so": meta})
         assert "public_func" in snap.resolution.provides
         assert "hidden_func" not in snap.resolution.provides
@@ -111,7 +125,9 @@ class TestResolutionGraph:
     def test_extra_needed_records_system_libs(self) -> None:
         # DT_NEEDED that doesn't match a sibling in the bundle goes into extra.
         meta = {
-            "libcore.so": _meta(soname="libcore.so", needed=["libc.so.6", "libalgo.so.1"]),
+            "libcore.so": _meta(
+                soname="libcore.so", needed=["libc.so.6", "libalgo.so.1"]
+            ),
             "libalgo.so": _meta(soname="libalgo.so.1"),
         }
         snap = _snapshot(meta)
@@ -123,23 +139,37 @@ class TestResolutionGraph:
 # bundle_intra_dep_removed
 # ---------------------------------------------------------------------------
 
+
 class TestIntraDepRemoved:
     def test_detects_missing_import(self) -> None:
-        old = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add", "core_mul"]),
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["core_add", "core_mul"]),
-        })
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["core_add", "core_mul"]),
-        })
+        old = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1", exports=["core_add", "core_mul"]
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["core_add", "core_mul"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["core_add", "core_mul"],
+                ),
+            }
+        )
         result = compare_bundle(old, new, per_library_results=[])
         kinds = {f.kind for f in result.bundle_findings}
         assert ChangeKind.BUNDLE_INTRA_DEP_REMOVED in kinds
         finding = next(
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
         )
         assert finding.symbol == "core_mul"
@@ -147,12 +177,16 @@ class TestIntraDepRemoved:
 
     def test_ignores_system_symbols(self) -> None:
         # libc/libstdc++ imports must not fire bundle findings.
-        new = _snapshot({
-            "libfoo.so": _meta(soname="libfoo.so.1",
-                               needed=["libcore.so.1"],
-                               imports=["__cxa_atexit", "malloc", "memcpy"]),
-            "libcore.so": _meta(soname="libcore.so.1", exports=["dummy"]),
-        })
+        new = _snapshot(
+            {
+                "libfoo.so": _meta(
+                    soname="libfoo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["__cxa_atexit", "malloc", "memcpy"],
+                ),
+                "libcore.so": _meta(soname="libcore.so.1", exports=["dummy"]),
+            }
+        )
         result = compare_bundle(new, new, per_library_results=[])
         assert not any(
             f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
@@ -160,19 +194,25 @@ class TestIntraDepRemoved:
         )
 
     def test_extends_system_providers_via_arg(self) -> None:
-        new = _snapshot({
-            "libfoo.so": _meta(soname="libfoo.so.1",
-                               needed=["libcore.so.1", "libcustom.so.1"],
-                               imports=["custom_init"]),
-            "libcore.so": _meta(soname="libcore.so.1", exports=["dummy"]),
-        })
+        new = _snapshot(
+            {
+                "libfoo.so": _meta(
+                    soname="libfoo.so.1",
+                    needed=["libcore.so.1", "libcustom.so.1"],
+                    imports=["custom_init"],
+                ),
+                "libcore.so": _meta(soname="libcore.so.1", exports=["dummy"]),
+            }
+        )
         # Without user-extended allow-list, custom_init is bundle-relevant.
         result_default = compare_bundle(new, new, per_library_results=[])
         # Note: heuristic — custom_init may already be excluded by the
         # "no intra-bundle siblings imported" path. Either way the
         # explicit allow-list must not introduce findings.
         with_extra = compare_bundle(
-            new, new, per_library_results=[],
+            new,
+            new,
+            per_library_results=[],
             system_providers=["libcustom.so.1"],
         )
         assert len(with_extra.bundle_findings) <= len(result_default.bundle_findings)
@@ -185,17 +225,20 @@ class TestIntraDepRemoved:
         # it. The unresolved import remains in .dynsym; the bundle layer
         # must still flag it (the system-symbol allow-list separately
         # filters out genuinely-external imports).
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1"),  # provider gone
-            "libalgo.so": _meta(
-                soname="libalgo.so.1",
-                needed=[],                        # DT_NEEDED stripped too
-                imports=["onedal_internal_op"],   # not a system symbol
-            ),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),  # provider gone
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=[],  # DT_NEEDED stripped too
+                    imports=["onedal_internal_op"],  # not a system symbol
+                ),
+            }
+        )
         result = compare_bundle(new, new, per_library_results=[])
         intra_removed = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
         ]
         assert len(intra_removed) == 1
@@ -207,13 +250,17 @@ class TestIntraDepRemoved:
 # bundle_intra_dep_signature_changed
 # ---------------------------------------------------------------------------
 
+
 class TestIntraDepSignatureChanged:
     def test_promotes_provider_signature_change_to_consumer(self) -> None:
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["core_add"]),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
         diff_libcore = _diff(
             "libcore.so",
             Change(
@@ -224,7 +271,8 @@ class TestIntraDepSignatureChanged:
         )
         result = compare_bundle(new, new, [diff_libcore])
         findings = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
         ]
         assert len(findings) == 1
@@ -234,19 +282,27 @@ class TestIntraDepSignatureChanged:
     def test_dedupe_params_plus_return_change(self) -> None:
         # libcore changes both params AND return of the same symbol; we
         # should emit a SINGLE bundle finding per (consumer, symbol).
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["core_add"]),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["core_add"]
+                ),
+            }
+        )
         diff = _diff(
             "libcore.so",
-            Change(kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="core_add", description=""),
-            Change(kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="core_add", description=""),
+            Change(
+                kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="core_add", description=""
+            ),
+            Change(
+                kind=ChangeKind.FUNC_RETURN_CHANGED, symbol="core_add", description=""
+            ),
         )
         result = compare_bundle(new, new, [diff])
         sig_findings = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED
         ]
         assert len(sig_findings) == 1
@@ -254,13 +310,17 @@ class TestIntraDepSignatureChanged:
     def test_no_finding_when_no_consumers(self) -> None:
         # Provider changes but no sibling imports the symbol — bundle-level
         # finding does NOT fire; the per-library diff already covers it.
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
-            "libother.so": _meta(soname="libother.so.1"),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["core_add"]),
+                "libother.so": _meta(soname="libother.so.1"),
+            }
+        )
         diff = _diff(
             "libcore.so",
-            Change(kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="core_add", description=""),
+            Change(
+                kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="core_add", description=""
+            ),
         )
         result = compare_bundle(new, new, [diff])
         assert not any(
@@ -273,27 +333,44 @@ class TestIntraDepSignatureChanged:
 # bundle_provider_changed
 # ---------------------------------------------------------------------------
 
+
 class TestProviderChanged:
     def test_detects_symbol_migration(self) -> None:
-        old = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["util_x"]),
-            "libutil.so": _meta(soname="libutil.so.1"),
-        })
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1"),
-            "libutil.so": _meta(soname="libutil.so.1", exports=["util_x"]),
-        })
+        old = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["util_x"]),
+                "libutil.so": _meta(soname="libutil.so.1"),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),
+                "libutil.so": _meta(soname="libutil.so.1", exports=["util_x"]),
+            }
+        )
         diffs = [
-            _diff("libcore.so", Change(
-                kind=ChangeKind.FUNC_REMOVED, symbol="util_x", description="",
-            )),
-            _diff("libutil.so", Change(
-                kind=ChangeKind.FUNC_ADDED, symbol="util_x", description="",
-            ), verdict=Verdict.COMPATIBLE),
+            _diff(
+                "libcore.so",
+                Change(
+                    kind=ChangeKind.FUNC_REMOVED,
+                    symbol="util_x",
+                    description="",
+                ),
+            ),
+            _diff(
+                "libutil.so",
+                Change(
+                    kind=ChangeKind.FUNC_ADDED,
+                    symbol="util_x",
+                    description="",
+                ),
+                verdict=Verdict.COMPATIBLE,
+            ),
         ]
         result = compare_bundle(old, new, diffs)
         provider_findings = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_PROVIDER_CHANGED
         ]
         assert len(provider_findings) == 1
@@ -306,14 +383,15 @@ class TestProviderChanged:
         # NOT a provider migration.
         new = _snapshot({"libcore.so": _meta(soname="libcore.so.1", exports=["x"])})
         diffs = [
-            _diff("libcore.so",
-                  Change(kind=ChangeKind.FUNC_REMOVED, symbol="y", description=""),
-                  Change(kind=ChangeKind.FUNC_ADDED, symbol="y", description="")),
+            _diff(
+                "libcore.so",
+                Change(kind=ChangeKind.FUNC_REMOVED, symbol="y", description=""),
+                Change(kind=ChangeKind.FUNC_ADDED, symbol="y", description=""),
+            ),
         ]
         result = compare_bundle(new, new, diffs)
         assert not any(
-            f.kind == ChangeKind.BUNDLE_PROVIDER_CHANGED
-            for f in result.bundle_findings
+            f.kind == ChangeKind.BUNDLE_PROVIDER_CHANGED for f in result.bundle_findings
         )
 
 
@@ -321,16 +399,22 @@ class TestProviderChanged:
 # bundle_library_removed / bundle_library_added
 # ---------------------------------------------------------------------------
 
+
 class TestLibraryStructural:
     def test_added_library_emits_addition(self) -> None:
         old = _snapshot({"libcore.so": _meta(soname="libcore.so.1")})
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1"),
-            "libnew.so": _meta(soname="libnew.so.1"),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),
+                "libnew.so": _meta(soname="libnew.so.1"),
+            }
+        )
         result = compare_bundle(old, new, [])
-        added = [f for f in result.bundle_findings
-                 if f.kind == ChangeKind.BUNDLE_LIBRARY_ADDED]
+        added = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_LIBRARY_ADDED
+        ]
         assert len(added) == 1
         assert added[0].symbol == "libnew.so"
 
@@ -338,30 +422,40 @@ class TestLibraryStructural:
         # If no sibling imported the removed library's symbols, the
         # bundle layer stays silent — the existing --fail-on-removed-library
         # flow is responsible.
-        old = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["x"]),
-            "libstandalone.so": _meta(soname="libstandalone.so.1", exports=["y"]),
-        })
+        old = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["x"]),
+                "libstandalone.so": _meta(soname="libstandalone.so.1", exports=["y"]),
+            }
+        )
         new = _snapshot({"libcore.so": _meta(soname="libcore.so.1", exports=["x"])})
         result = compare_bundle(old, new, [])
         assert not any(
-            f.kind == ChangeKind.BUNDLE_LIBRARY_REMOVED
-            for f in result.bundle_findings
+            f.kind == ChangeKind.BUNDLE_LIBRARY_REMOVED for f in result.bundle_findings
         )
 
     def test_removed_library_with_intra_consumer_fires(self) -> None:
-        old = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["util_x"]),
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["util_x"]),
-        })
-        new = _snapshot({
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["util_x"]),
-        })
+        old = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["util_x"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["util_x"]
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1", needed=["libcore.so.1"], imports=["util_x"]
+                ),
+            }
+        )
         result = compare_bundle(old, new, [])
-        removed = [f for f in result.bundle_findings
-                   if f.kind == ChangeKind.BUNDLE_LIBRARY_REMOVED]
+        removed = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_LIBRARY_REMOVED
+        ]
         assert len(removed) == 1
         assert removed[0].symbol == "libcore.so"
         assert "libalgo.so" in removed[0].affected_libraries
@@ -371,6 +465,7 @@ class TestLibraryStructural:
 # bundle_intra_type_changed (cross-DSO type drift)
 # ---------------------------------------------------------------------------
 
+
 class TestIntraTypeChanged:
     def test_type_change_visible_in_sibling_emits_finding(self) -> None:
         # libcore defines DataCollection; libalgo's mangled symbol embeds
@@ -378,17 +473,19 @@ class TestIntraTypeChanged:
         # reports type_size_changed on DataCollection and a sibling
         # exports a symbol containing that name, the bundle layer emits
         # bundle_intra_type_changed.
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=["DataCollection_ctor"],
-            ),
-            "libalgo.so": _meta(
-                soname="libalgo.so.1",
-                needed=["libcore.so.1"],
-                exports=["_Z3runP14DataCollection"],
-            ),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=["DataCollection_ctor"],
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    exports=["_Z3runP14DataCollection"],
+                ),
+            }
+        )
         diff = _diff(
             "libcore.so",
             Change(
@@ -399,7 +496,8 @@ class TestIntraTypeChanged:
         )
         result = compare_bundle(new, new, [diff])
         type_findings = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_TYPE_CHANGED
         ]
         assert len(type_findings) == 1
@@ -411,68 +509,165 @@ class TestIntraTypeChanged:
         # A single type can produce several low-level diffs (size +
         # alignment + field_removed); the bundle layer must collapse
         # those into one cross-DSO finding per (consumer, provider, type).
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1", exports=["DataCollection_ctor"],
-            ),
-            "libalgo.so": _meta(
-                soname="libalgo.so.1", needed=["libcore.so.1"],
-                exports=["_Z3runP14DataCollection"],
-            ),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=["DataCollection_ctor"],
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    exports=["_Z3runP14DataCollection"],
+                ),
+            }
+        )
         diff = _diff(
             "libcore.so",
-            Change(kind=ChangeKind.TYPE_SIZE_CHANGED,
-                   symbol="DataCollection", description=""),
-            Change(kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
-                   symbol="DataCollection", description=""),
-            Change(kind=ChangeKind.TYPE_FIELD_REMOVED,
-                   symbol="DataCollection", description=""),
+            Change(
+                kind=ChangeKind.TYPE_SIZE_CHANGED,
+                symbol="DataCollection",
+                description="",
+            ),
+            Change(
+                kind=ChangeKind.TYPE_ALIGNMENT_CHANGED,
+                symbol="DataCollection",
+                description="",
+            ),
+            Change(
+                kind=ChangeKind.TYPE_FIELD_REMOVED,
+                symbol="DataCollection",
+                description="",
+            ),
         )
         result = compare_bundle(new, new, [diff])
         type_findings = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_TYPE_CHANGED
         ]
         assert len(type_findings) == 1
 
 
 # ---------------------------------------------------------------------------
+# A3 (ADR-027 D3.2) — reachability-filtered cross-DSO type change
+# ---------------------------------------------------------------------------
+
+
+class TestIntraTypeReachability:
+    def _bundle_with_consumer(self, consumer_meta: ElfMetadata) -> BundleSnapshot:
+        return _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=["DataCollection_ctor"],
+                ),
+                "libalgo.so": consumer_meta,
+            }
+        )
+
+    def _core_diff(self) -> DiffResult:
+        return _diff(
+            "libcore.so",
+            Change(
+                kind=ChangeKind.TYPE_SIZE_CHANGED,
+                symbol="DataCollection",
+                description="sizeof changed",
+            ),
+        )
+
+    def test_public_consumer_use_stays_breaking(self) -> None:
+        # libalgo exports a symbol embedding the changed type → on its public
+        # surface → full-confidence cross-DSO break (not demoted).
+        consumer = ElfMetadata(
+            soname="libalgo.so.1",
+            needed=["libcore.so.1"],
+            symbols=[ElfSymbol(name="_Z3runP14DataCollection", visibility="default")],
+        )
+        result = compare_bundle(
+            self._bundle_with_consumer(consumer),
+            self._bundle_with_consumer(consumer),
+            [self._core_diff()],
+        )
+        f = next(
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_TYPE_CHANGED
+        )
+        assert f.effective_verdict is None
+        assert result.bundle_verdict == Verdict.BREAKING
+
+    def test_internal_only_consumer_use_demoted(self) -> None:
+        # libalgo references the type only via a hidden (non-exported) symbol →
+        # the change cannot reach its public ABI surface → demoted to risk,
+        # disclosed (never dropped), so the bundle verdict is not BREAKING.
+        consumer = ElfMetadata(
+            soname="libalgo.so.1",
+            needed=["libcore.so.1"],
+            symbols=[ElfSymbol(name="_Z3runP14DataCollection", visibility="hidden")],
+        )
+        result = compare_bundle(
+            self._bundle_with_consumer(consumer),
+            self._bundle_with_consumer(consumer),
+            [self._core_diff()],
+        )
+        f = next(
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_TYPE_CHANGED
+        )
+        assert f.effective_verdict == Verdict.COMPATIBLE_WITH_RISK
+        assert f.modulation_reason == "consumer-internal-use"
+        assert f.modulation_rule == "bundle-reachability"
+        # The demotion reaches the bundle verdict (it lowers via to_change and
+        # classifies through effective_category): risk, not a hard break.
+        assert result.bundle_verdict == Verdict.COMPATIBLE_WITH_RISK
+        # Disclosed, never dropped.
+        assert f in result.bundle_findings
+
+
+# ---------------------------------------------------------------------------
 # bundle_intra_dep_resolved_to_different_version (gnu.version_d drift)
 # ---------------------------------------------------------------------------
+
 
 class TestVersionDrift:
     def test_default_version_drift_emits_finding(self) -> None:
         # core_fn is exported in old at GLIBCXX_3.4.20, in new at
         # GLIBCXX_3.4.30; libalgo imports it. Bundle layer flags the
         # version drift as COMPATIBLE_WITH_RISK.
-        old = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=["core_fn"],
-                export_versions={"core_fn": "GLIBCXX_3.4.20"},
-            ),
-            "libalgo.so": _meta(
-                soname="libalgo.so.1",
-                needed=["libcore.so.1"],
-                imports=["core_fn"],
-            ),
-        })
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=["core_fn"],
-                export_versions={"core_fn": "GLIBCXX_3.4.30"},
-            ),
-            "libalgo.so": _meta(
-                soname="libalgo.so.1",
-                needed=["libcore.so.1"],
-                imports=["core_fn"],
-            ),
-        })
+        old = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=["core_fn"],
+                    export_versions={"core_fn": "GLIBCXX_3.4.20"},
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["core_fn"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=["core_fn"],
+                    export_versions={"core_fn": "GLIBCXX_3.4.30"},
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["core_fn"],
+                ),
+            }
+        )
         result = compare_bundle(old, new, [])
         drift = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_INTRA_DEP_VERSION_DRIFT
         ]
         assert len(drift) == 1
@@ -485,54 +680,74 @@ class TestVersionDrift:
 # Manifest
 # ---------------------------------------------------------------------------
 
+
 class TestManifest:
     def test_promised_symbol_missing_is_breaking(self) -> None:
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(symbol="promised_a", library="libcore.so",
-                          optional_provider=False),
-            ManifestEntry(symbol="promised_b", library=None,
-                          optional_provider=True),
-        ))
-        old = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1",
-                                exports=["promised_a", "promised_b"]),
-        })
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["promised_a"]),
-        })
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(
+                    symbol="promised_a", library="libcore.so", optional_provider=False
+                ),
+                ManifestEntry(
+                    symbol="promised_b", library=None, optional_provider=True
+                ),
+            )
+        )
+        old = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1", exports=["promised_a", "promised_b"]
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["promised_a"]),
+            }
+        )
         result = compare_bundle(old, new, [], manifest=manifest)
         kinds = [f.kind for f in result.bundle_findings]
         assert ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED in kinds
         missing = next(
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
         )
         assert missing.symbol == "promised_b"
 
     def test_wrong_provider_when_required(self) -> None:
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(symbol="x", library="libcore.so", optional_provider=False),
-        ))
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1"),
-            "libother.so": _meta(soname="libother.so.1", exports=["x"]),
-        })
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(
+                    symbol="x", library="libcore.so", optional_provider=False
+                ),
+            )
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),
+                "libother.so": _meta(soname="libother.so.1", exports=["x"]),
+            }
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         wrong = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
         ]
         assert len(wrong) == 1
         assert "libother.so" in (wrong[0].new_value or "")
 
     def test_optional_provider_accepts_any_sibling(self) -> None:
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(symbol="x", library=None, optional_provider=True),
-        ))
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1"),
-            "libother.so": _meta(soname="libother.so.1", exports=["x"]),
-        })
+        manifest = InstantiationManifest(
+            entries=(ManifestEntry(symbol="x", library=None, optional_provider=True),)
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),
+                "libother.so": _meta(soname="libother.so.1", exports=["x"]),
+            }
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         assert not any(
             f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
@@ -557,9 +772,7 @@ class TestManifest:
     def test_load_manifest_json(self, tmp_path: Path) -> None:
         path = tmp_path / "m.json"
         path.write_text(
-            '{"version": 1, "provides": ['
-            '{"symbol": "x", "library": "libfoo.so.1"}'
-            ']}',
+            '{"version": 1, "provides": [{"symbol": "x", "library": "libfoo.so.1"}]}',
         )
         m = load_manifest(path)
         assert m.entries[0].symbol == "x"
@@ -593,13 +806,15 @@ class TestManifest:
         path.write_text(
             '{"version": 1, "provides": ['
             '{"symbol": "ok_func", "library": "libfoo.so.1"}'
-            ']}',
+            "]}",
         )
         m = load_manifest(path)
         assert len(m.entries) == 1
         assert m.entries[0].symbol == "ok_func"
 
-    def test_load_manifest_rejects_string_optional_provider(self, tmp_path: Path) -> None:
+    def test_load_manifest_rejects_string_optional_provider(
+        self, tmp_path: Path
+    ) -> None:
         # YAML quote-ifies bool-looking strings; users hand-editing
         # `optional_provider: "false"` (string) would silently get
         # parsed as truthy by bool() — validate strictly instead.
@@ -607,7 +822,7 @@ class TestManifest:
         path.write_text(
             '{"version": 1, "provides": ['
             '{"symbol": "x", "library": "lib.so.1", "optional_provider": "false"}'
-            ']}',
+            "]}",
         )
         with pytest.raises(ValueError, match="optional_provider.*must be a boolean"):
             load_manifest(path)
@@ -615,9 +830,7 @@ class TestManifest:
     def test_load_manifest_rejects_int_optional_provider(self, tmp_path: Path) -> None:
         path = tmp_path / "inty.json"
         path.write_text(
-            '{"version": 1, "provides": ['
-            '{"symbol": "x", "optional_provider": 1}'
-            ']}',
+            '{"version": 1, "provides": [{"symbol": "x", "optional_provider": 1}]}',
         )
         with pytest.raises(ValueError, match="optional_provider.*must be a boolean"):
             load_manifest(path)
@@ -627,7 +840,7 @@ class TestManifest:
         path.write_text(
             "version: 1\n"
             "provides:\n"
-            "  - pattern: \"oneapi::dal::train_ops<*>*\"\n"
+            '  - pattern: "oneapi::dal::train_ops<*>*"\n'
             "    library: libonedal_core.so.1\n"
             "    optional_provider: false\n",
         )
@@ -643,8 +856,8 @@ class TestManifest:
             "provides:\n"
             "  - template: oneapi::dal::train_ops\n"
             "    instantiations:\n"
-            "      - {Float: float,  Method: \"method::dense\", Task: \"task::train\"}\n"
-            "      - {Float: double, Method: \"method::dense\", Task: \"task::train\"}\n",
+            '      - {Float: float,  Method: "method::dense", Task: "task::train"}\n'
+            '      - {Float: double, Method: "method::dense", Task: "task::train"}\n',
         )
         m = load_manifest(path)
         assert m.entries[0].template == "oneapi::dal::train_ops"
@@ -655,10 +868,7 @@ class TestManifest:
     def test_load_manifest_rejects_multiple_shape_keys(self, tmp_path: Path) -> None:
         path = tmp_path / "mixed.yaml"
         path.write_text(
-            "version: 1\n"
-            "provides:\n"
-            "  - symbol: foo\n"
-            "    pattern: \"foo*\"\n",
+            'version: 1\nprovides:\n  - symbol: foo\n    pattern: "foo*"\n',
         )
         with pytest.raises(ValueError, match="conflicting fields"):
             load_manifest(path)
@@ -666,9 +876,7 @@ class TestManifest:
     def test_load_manifest_rejects_missing_shape_key(self, tmp_path: Path) -> None:
         path = tmp_path / "empty.yaml"
         path.write_text(
-            "version: 1\n"
-            "provides:\n"
-            "  - library: libfoo.so.1\n",
+            "version: 1\nprovides:\n  - library: libfoo.so.1\n",
         )
         with pytest.raises(ValueError, match="must have one of 'symbol'"):
             load_manifest(path)
@@ -676,9 +884,7 @@ class TestManifest:
     def test_load_manifest_template_needs_instantiations(self, tmp_path: Path) -> None:
         path = tmp_path / "no-insts.yaml"
         path.write_text(
-            "version: 1\n"
-            "provides:\n"
-            "  - template: oneapi::dal::train_ops\n",
+            "version: 1\nprovides:\n  - template: oneapi::dal::train_ops\n",
         )
         with pytest.raises(ValueError, match="non-empty 'instantiations:'"):
             load_manifest(path)
@@ -688,21 +894,27 @@ class TestManifest:
 # Pattern and template matching against the bundle
 # ---------------------------------------------------------------------------
 
+
 class TestManifestPatternMatching:
     def test_pattern_matches_mangled_extern_c_symbols(self) -> None:
         # extern "C" symbols aren't demangled (demangle returns None for
         # them); the matcher falls back to the mangled name. This means
         # patterns work uniformly for C and C++ symbols.
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=["onedal_train_float_dense", "onedal_train_float_sparse",
-                         "onedal_predict_float_dense"],
-            ),
-        })
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(pattern="onedal_train_*", optional_provider=True),
-        ))
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=[
+                        "onedal_train_float_dense",
+                        "onedal_train_float_sparse",
+                        "onedal_predict_float_dense",
+                    ],
+                ),
+            }
+        )
+        manifest = InstantiationManifest(
+            entries=(ManifestEntry(pattern="onedal_train_*", optional_provider=True),)
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         assert not any(
             f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
@@ -711,12 +923,13 @@ class TestManifestPatternMatching:
 
     def test_pattern_with_no_match_emits_removed(self) -> None:
         new = _snapshot({"libcore.so": _meta(soname="libcore.so.1")})
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(pattern="onedal_train_*", optional_provider=True),
-        ))
+        manifest = InstantiationManifest(
+            entries=(ManifestEntry(pattern="onedal_train_*", optional_provider=True),)
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         removed = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
         ]
         assert len(removed) == 1
@@ -728,30 +941,35 @@ class TestManifestPatternMatching:
         # demangling), the matcher falls back to the mangled name; we
         # set up symbol names that contain the substring so the test
         # doesn't depend on cxxfilt availability.
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=[
-                    "ns::T<float, dense>_ctor",   # carries the expanded form
-                    "ns::T<double, sparse>_ctor",
-                ],
-            ),
-        })
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(
-                template="ns::T",
-                instantiations=({"P1": "float", "P2": "dense"},),
-                optional_provider=True,
-            ),
-            ManifestEntry(
-                template="ns::T",
-                instantiations=({"P1": "int", "P2": "dense"},),  # not exported
-                optional_provider=True,
-            ),
-        ))
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=[
+                        "ns::T<float, dense>_ctor",  # carries the expanded form
+                        "ns::T<double, sparse>_ctor",
+                    ],
+                ),
+            }
+        )
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(
+                    template="ns::T",
+                    instantiations=({"P1": "float", "P2": "dense"},),
+                    optional_provider=True,
+                ),
+                ManifestEntry(
+                    template="ns::T",
+                    instantiations=({"P1": "int", "P2": "dense"},),  # not exported
+                    optional_provider=True,
+                ),
+            )
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         removed = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
         ]
         # First entry must NOT fire (float,dense is present);
@@ -766,31 +984,36 @@ class TestManifestPatternMatching:
         # Previously the matcher pooled all expansions and declared the
         # entry satisfied iff *any* matched — masking partial regressions
         # where, say, two of four promised instantiations were dropped.
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=[
-                    "ns::T<float, dense>_ctor",
-                    "ns::T<double, dense>_ctor",
-                    # <float, sparse> and <double, sparse> NOT exported
-                ],
-            ),
-        })
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(
-                template="ns::T",
-                instantiations=(
-                    {"P1": "float", "P2": "dense"},   # exported
-                    {"P1": "float", "P2": "sparse"},  # MISSING
-                    {"P1": "double", "P2": "dense"},  # exported
-                    {"P1": "double", "P2": "sparse"}, # MISSING
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=[
+                        "ns::T<float, dense>_ctor",
+                        "ns::T<double, dense>_ctor",
+                        # <float, sparse> and <double, sparse> NOT exported
+                    ],
                 ),
-                optional_provider=True,
-            ),
-        ))
+            }
+        )
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(
+                    template="ns::T",
+                    instantiations=(
+                        {"P1": "float", "P2": "dense"},  # exported
+                        {"P1": "float", "P2": "sparse"},  # MISSING
+                        {"P1": "double", "P2": "dense"},  # exported
+                        {"P1": "double", "P2": "sparse"},  # MISSING
+                    ),
+                    optional_provider=True,
+                ),
+            )
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         removed = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
         ]
         # Exactly two findings, one for each missing instantiation.
@@ -802,7 +1025,8 @@ class TestManifestPatternMatching:
         assert all("ns::T<float, dense>" not in f.symbol for f in removed)
 
     def test_demangle_invoked_once_per_symbol_across_many_targets(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # Performance regression guard: _detect_manifest_drift should
         # build the demangle index once per snapshot and reuse it
@@ -816,6 +1040,7 @@ class TestManifestPatternMatching:
         # _build_demangled_index by patching the module-level demangle
         # if it's imported inside the function.
         import abicheck.demangle as demangle_mod
+
         original_demangle = demangle_mod.demangle
 
         def counting_demangle(name: str) -> str | None:
@@ -824,33 +1049,37 @@ class TestManifestPatternMatching:
 
         monkeypatch.setattr(demangle_mod, "demangle", counting_demangle)
 
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=[
-                    "ns::T<float, dense>_ctor",
-                    "ns::T<float, sparse>_ctor",
-                    "ns::T<double, dense>_ctor",
-                    "ns::T<double, sparse>_ctor",
-                    "unrelated_symbol_1",
-                    "unrelated_symbol_2",
-                ],
-            ),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=[
+                        "ns::T<float, dense>_ctor",
+                        "ns::T<float, sparse>_ctor",
+                        "ns::T<double, dense>_ctor",
+                        "ns::T<double, sparse>_ctor",
+                        "unrelated_symbol_1",
+                        "unrelated_symbol_2",
+                    ],
+                ),
+            }
+        )
         n_symbols = sum(len(m.symbols) for m in new.metadata.values())
 
         # Manifest with many targets — naïve scaling would multiply.
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(
-                template="ns::T",
-                instantiations=tuple(
-                    {"P1": p1, "P2": p2}
-                    for p1 in ("float", "double", "int", "long")
-                    for p2 in ("dense", "sparse", "csr", "csc")
-                ),  # 16 targets
-                optional_provider=True,
-            ),
-        ))
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(
+                    template="ns::T",
+                    instantiations=tuple(
+                        {"P1": p1, "P2": p2}
+                        for p1 in ("float", "double", "int", "long")
+                        for p2 in ("dense", "sparse", "csr", "csc")
+                    ),  # 16 targets
+                    optional_provider=True,
+                ),
+            )
+        )
         compare_bundle(new, new, [], manifest=manifest)
         # Expected: one full pass per snapshot (old + new), each
         # producing n_symbols demangle calls. No per-target rescans.
@@ -865,19 +1094,23 @@ class TestManifestPatternMatching:
         # layer must accept either; if the manifest names libcore.so.1
         # (a SONAME) and the candidate provider's SONAME matches, that's
         # a hit, no spurious BUNDLE_MANIFEST_INSTANTIATION_REMOVED.
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(
-                symbol="train_v2",
-                library="libcore.so.1",        # SONAME, not filename key
-                optional_provider=False,
-            ),
-        ))
-        new = _snapshot({
-            "libcore.so": _meta(
-                soname="libcore.so.1",
-                exports=["train_v2"],
-            ),
-        })
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(
+                    symbol="train_v2",
+                    library="libcore.so.1",  # SONAME, not filename key
+                    optional_provider=False,
+                ),
+            )
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1",
+                    exports=["train_v2"],
+                ),
+            }
+        )
         result = compare_bundle(new, new, [], manifest=manifest)
         assert not any(
             f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_REMOVED
@@ -888,16 +1121,21 @@ class TestManifestPatternMatching:
         # Symbol present in new manifest, absent from old bundle exports
         # but present in new bundle. Bundle layer emits
         # BUNDLE_MANIFEST_INSTANTIATION_ADDED.
-        manifest = InstantiationManifest(entries=(
-            ManifestEntry(symbol="new_train", library=None, optional_provider=True),
-        ))
+        manifest = InstantiationManifest(
+            entries=(
+                ManifestEntry(symbol="new_train", library=None, optional_provider=True),
+            )
+        )
         old = _snapshot({"libcore.so": _meta(soname="libcore.so.1")})
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["new_train"]),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["new_train"]),
+            }
+        )
         result = compare_bundle(old, new, [], manifest=manifest)
         added = [
-            f for f in result.bundle_findings
+            f
+            for f in result.bundle_findings
             if f.kind == ChangeKind.BUNDLE_MANIFEST_INSTANTIATION_ADDED
         ]
         assert len(added) == 1
@@ -908,6 +1146,7 @@ class TestManifestPatternMatching:
 # system_providers allow-list (--bundle-system-providers flag)
 # ---------------------------------------------------------------------------
 
+
 class TestSystemProvidersAllowList:
     def test_user_extended_providers_suppresses_finding(self) -> None:
         # A consumer imports an out-of-bundle symbol; DT_NEEDED includes
@@ -916,19 +1155,23 @@ class TestSystemProvidersAllowList:
         # --bundle-system-providers extension the symbol fires.
         # With it, the symbol is treated as system-provided and the
         # finding is suppressed.
-        new = _snapshot({
-            "libfoo.so": _meta(
-                soname="libfoo.so.1",
-                needed=["libcore.so.1", "libcustom.so.1"],
-                imports=["__cxa_atexit"],   # known system symbol
-            ),
-            "libcore.so": _meta(soname="libcore.so.1", exports=["dummy"]),
-        })
+        new = _snapshot(
+            {
+                "libfoo.so": _meta(
+                    soname="libfoo.so.1",
+                    needed=["libcore.so.1", "libcustom.so.1"],
+                    imports=["__cxa_atexit"],  # known system symbol
+                ),
+                "libcore.so": _meta(soname="libcore.so.1", exports=["dummy"]),
+            }
+        )
         # Even without the extension, __cxa_atexit is on the default
         # symbol allow-list and the finding is suppressed.
         baseline = compare_bundle(new, new, per_library_results=[])
         with_extras = compare_bundle(
-            new, new, per_library_results=[],
+            new,
+            new,
+            per_library_results=[],
             system_providers=["libcustom.so.1"],
         )
         # Sanity: neither path should report __cxa_atexit as missing.
@@ -944,14 +1187,20 @@ class TestSystemProvidersAllowList:
 # Verdict aggregation
 # ---------------------------------------------------------------------------
 
+
 class TestVerdictAggregation:
     def test_bundle_verdict_promotes_aggregate(self) -> None:
         # All per-library diffs are NO_CHANGE; bundle finding alone forces BREAKING.
-        new = _snapshot({
-            "libcore.so": _meta(soname="libcore.so.1", exports=["x"]),
-            "libalgo.so": _meta(soname="libalgo.so.1", needed=["libcore.so.1"],
-                                imports=["x", "missing_sym"]),
-        })
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["x"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["x", "missing_sym"],
+                ),
+            }
+        )
         result = compare_bundle(new, new, [])
         # The bundle layer should flag missing_sym as removed.
         assert result.bundle_verdict == Verdict.BREAKING
@@ -975,10 +1224,12 @@ class TestVerdictAggregation:
 # Non-ELF inputs
 # ---------------------------------------------------------------------------
 
+
 class TestNonElfInputs:
     def test_skips_non_elf_files_silently(self, tmp_path: Path) -> None:
         # Should not raise, should not produce findings.
         from abicheck.bundle import build_bundle_snapshot
+
         json_file = tmp_path / "libnotelf.so"
         json_file.write_text('{"library": "fake", "version": "1"}')
         snap = build_bundle_snapshot({"libnotelf.so": json_file})
@@ -987,11 +1238,13 @@ class TestNonElfInputs:
 
     def test_path_looks_like_elf_handles_missing(self, tmp_path: Path) -> None:
         from abicheck.bundle import _path_looks_like_elf
+
         # Non-existent path — OSError → False, no raise.
         assert _path_looks_like_elf(tmp_path / "does-not-exist.so") is False
 
     def test_path_looks_like_elf_accepts_magic(self, tmp_path: Path) -> None:
         from abicheck.bundle import _path_looks_like_elf
+
         p = tmp_path / "fake.so"
         p.write_bytes(b"\x7fELF" + b"\0" * 12)
         assert _path_looks_like_elf(p) is True
@@ -1002,6 +1255,7 @@ class TestNonElfInputs:
         # parse_elf_metadata path in build_bundle_snapshot (otherwise
         # bypassed by the in-memory _snapshot helper used elsewhere).
         from abicheck.bundle import build_bundle_snapshot
+
         candidate = None
         for p in (
             "/lib/x86_64-linux-gnu/libc.so.6",
@@ -1022,6 +1276,7 @@ class TestNonElfInputs:
 # ---------------------------------------------------------------------------
 # BundleSnapshot.is_intra_bundle_provider
 # ---------------------------------------------------------------------------
+
 
 class TestIsIntraBundleProvider:
     def test_matches_filename(self) -> None:
@@ -1046,10 +1301,12 @@ class TestIsIntraBundleProvider:
         assert snap.is_intra_bundle_provider("libother.so") is False
 
     def test_library_names_property(self) -> None:
-        snap = _snapshot({
-            "libb.so": _meta(soname="libb.so.1"),
-            "liba.so": _meta(soname="liba.so.1"),
-        })
+        snap = _snapshot(
+            {
+                "libb.so": _meta(soname="libb.so.1"),
+                "liba.so": _meta(soname="liba.so.1"),
+            }
+        )
         assert snap.library_names == ["liba.so", "libb.so"]
 
 
@@ -1057,9 +1314,11 @@ class TestIsIntraBundleProvider:
 # BundleFinding.to_change lowering
 # ---------------------------------------------------------------------------
 
+
 class TestBundleFindingToChange:
     def test_lowering_with_both_consumer_and_provider(self) -> None:
         from abicheck.bundle import BundleFinding
+
         f = BundleFinding(
             kind=ChangeKind.BUNDLE_INTRA_DEP_SIGNATURE_CHANGED,
             symbol="core_add",
@@ -1074,6 +1333,7 @@ class TestBundleFindingToChange:
 
     def test_lowering_provider_only(self) -> None:
         from abicheck.bundle import BundleFinding
+
         f = BundleFinding(
             kind=ChangeKind.BUNDLE_LIBRARY_REMOVED,
             symbol="libcore.so",
@@ -1085,6 +1345,7 @@ class TestBundleFindingToChange:
 
     def test_lowering_consumer_only(self) -> None:
         from abicheck.bundle import BundleFinding
+
         f = BundleFinding(
             kind=ChangeKind.BUNDLE_INTRA_DEP_REMOVED,
             symbol="core_mul",
@@ -1096,6 +1357,7 @@ class TestBundleFindingToChange:
 
     def test_lowering_neither(self) -> None:
         from abicheck.bundle import BundleFinding
+
         f = BundleFinding(
             kind=ChangeKind.BUNDLE_LIBRARY_ADDED,
             symbol="libnew.so",
@@ -1109,6 +1371,7 @@ class TestBundleFindingToChange:
 # End-to-end compare-release with bundle analysis enabled
 # ---------------------------------------------------------------------------
 
+
 def _build_tiny_so(release_dir: Path, name: str, src: str) -> Path:
     """Compile *src* into ``release_dir/name`` (a .so file).
 
@@ -1119,6 +1382,7 @@ def _build_tiny_so(release_dir: Path, name: str, src: str) -> Path:
     """
     import shutil
     import subprocess
+
     gcc = shutil.which("gcc")
     if gcc is None:
         pytest.skip("gcc unavailable; cannot build bundle E2E fixture")
@@ -1129,9 +1393,19 @@ def _build_tiny_so(release_dir: Path, name: str, src: str) -> Path:
     out = release_dir / name
     soname = name.split(".so")[0] + ".so.1"
     res = subprocess.run(
-        [gcc, "-shared", "-fPIC", "-g", "-O0", str(src_path),
-         "-o", str(out), f"-Wl,-soname,{soname}"],
-        capture_output=True, text=True,
+        [
+            gcc,
+            "-shared",
+            "-fPIC",
+            "-g",
+            "-O0",
+            str(src_path),
+            "-o",
+            str(out),
+            f"-Wl,-soname,{soname}",
+        ],
+        capture_output=True,
+        text=True,
     )
     if res.returncode != 0:
         pytest.fail(f"gcc failed for {name}: {res.stderr}")
@@ -1141,8 +1415,8 @@ def _build_tiny_so(release_dir: Path, name: str, src: str) -> Path:
 @pytest.mark.skipif(
     sys.platform != "linux",
     reason="Uses GNU ld flags (-Wl,-soname, -Wl,--no-as-needed); "
-           "Mach-O ld and link.exe don't accept them. Bundle analysis "
-           "itself is ELF/Linux-only per ADR-018 / ADR-023.",
+    "Mach-O ld and link.exe don't accept them. Bundle analysis "
+    "itself is ELF/Linux-only per ADR-018 / ADR-023.",
 )
 @pytest.mark.integration
 class TestCompareReleaseBundleE2E:
@@ -1169,13 +1443,15 @@ class TestCompareReleaseBundleE2E:
         old.mkdir()
         new.mkdir()
         _build_tiny_so(
-            old, "libcore.so",
+            old,
+            "libcore.so",
             "int core_add(int a, int b){return a+b;}\n"
             "int core_mul(int a, int b){return a*b;}\n",
         )
         _build_tiny_so(
-            new, "libcore.so",
-            "int core_add(int a, int b){return a+b;}\n",   # core_mul removed
+            new,
+            "libcore.so",
+            "int core_add(int a, int b){return a+b;}\n",  # core_mul removed
         )
         # libalgo: byte-identical in old and new, still imports core_mul.
         algo_src = (
@@ -1191,21 +1467,41 @@ class TestCompareReleaseBundleE2E:
             src_file.write_text(algo_src)
             import shutil as _shutil
             import subprocess as _sub
+
             gcc = _shutil.which("gcc")
             if gcc is None:
                 pytest.skip("gcc unavailable; cannot build bundle E2E fixture")
             _sub.run(
-                [gcc, "-shared", "-fPIC", "-g", "-O0", str(src_file),
-                 "-o", str(side / "libalgo.so"),
-                 "-L", str(side), "-Wl,--no-as-needed", "-lcore",
-                 "-Wl,-soname,libalgo.so.1"],
-                check=True, capture_output=True,
+                [
+                    gcc,
+                    "-shared",
+                    "-fPIC",
+                    "-g",
+                    "-O0",
+                    str(src_file),
+                    "-o",
+                    str(side / "libalgo.so"),
+                    "-L",
+                    str(side),
+                    "-Wl,--no-as-needed",
+                    "-lcore",
+                    "-Wl,-soname,libalgo.so.1",
+                ],
+                check=True,
+                capture_output=True,
             )
 
         result = CliRunner().invoke(
             main,
-            ["compare-release", str(old), str(new), "--format", "json",
-             "--bundle-cohort", "lib"],
+            [
+                "compare-release",
+                str(old),
+                str(new),
+                "--format",
+                "json",
+                "--bundle-cohort",
+                "lib",
+            ],
         )
         # Bundle BREAKING → exit 4.
         assert result.exit_code == 4, result.output
@@ -1215,13 +1511,16 @@ class TestCompareReleaseBundleE2E:
         assert "bundle_intra_dep_removed" in kinds
         # The consumer attribution must point at libalgo.so.
         intra = next(
-            f for f in data["bundle_findings"]
+            f
+            for f in data["bundle_findings"]
             if f["kind"] == "bundle_intra_dep_removed"
         )
         assert intra["consumer_library"] == "libalgo.so"
         assert intra["symbol"] == "core_mul"
 
-    def test_compare_release_default_skips_bundle_analysis(self, tmp_path: Path) -> None:
+    def test_compare_release_default_skips_bundle_analysis(
+        self, tmp_path: Path
+    ) -> None:
         """Plain compare-release should not emit bundle findings by default."""
         import json as _json
 
@@ -1233,7 +1532,9 @@ class TestCompareReleaseBundleE2E:
         new = tmp_path / "new"
         old.mkdir()
         new.mkdir()
-        _build_tiny_so(old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n")
+        _build_tiny_so(
+            old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n"
+        )
         _build_tiny_so(new, "libfoo.so", "int foo(void){return 1;}\n")
 
         result = CliRunner().invoke(
@@ -1259,13 +1560,21 @@ class TestCompareReleaseBundleE2E:
         new = tmp_path / "new"
         old.mkdir()
         new.mkdir()
-        _build_tiny_so(old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n")
+        _build_tiny_so(
+            old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n"
+        )
         _build_tiny_so(new, "libfoo.so", "int foo(void){return 1;}\n")
 
         result = CliRunner().invoke(
             main,
-            ["compare-release", str(old), str(new),
-             "--no-bundle-analysis", "--format", "json"],
+            [
+                "compare-release",
+                str(old),
+                str(new),
+                "--no-bundle-analysis",
+                "--format",
+                "json",
+            ],
         )
         data = _json.loads(result.stdout)
         # bundle_verdict / bundle_findings must NOT be present.
@@ -1273,7 +1582,8 @@ class TestCompareReleaseBundleE2E:
         assert "bundle_findings" not in data
 
     def test_compare_release_with_manifest_emits_manifest_finding(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         # Manifest lists `bar` as a promise; new bundle drops it.
         import json as _json
@@ -1286,7 +1596,9 @@ class TestCompareReleaseBundleE2E:
         new = tmp_path / "new"
         old.mkdir()
         new.mkdir()
-        _build_tiny_so(old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n")
+        _build_tiny_so(
+            old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n"
+        )
         _build_tiny_so(new, "libfoo.so", "int foo(void){return 1;}\n")
 
         manifest = tmp_path / "manifest.yaml"
@@ -1303,15 +1615,23 @@ class TestCompareReleaseBundleE2E:
 
         result = CliRunner().invoke(
             main,
-            ["compare-release", str(old), str(new),
-             "--manifest", str(manifest), "--format", "json"],
+            [
+                "compare-release",
+                str(old),
+                str(new),
+                "--manifest",
+                str(manifest),
+                "--format",
+                "json",
+            ],
         )
         data = _json.loads(result.stdout)
         kinds = {f["kind"] for f in data["bundle_findings"]}
         assert "bundle_manifest_instantiation_removed" in kinds
 
     def test_compare_release_markdown_shows_bundle_section(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         # Bundle finding must show up in the markdown summary output.
         from click.testing import CliRunner
@@ -1323,12 +1643,14 @@ class TestCompareReleaseBundleE2E:
         old.mkdir()
         new.mkdir()
         _build_tiny_so(
-            old, "libcore.so",
+            old,
+            "libcore.so",
             "int core_add(int a, int b){return a+b;}\n"
             "int core_mul(int a, int b){return a*b;}\n",
         )
         _build_tiny_so(
-            new, "libcore.so",
+            new,
+            "libcore.so",
             "int core_add(int a, int b){return a+b;}\n",
         )
         algo_src = (
@@ -1342,25 +1664,42 @@ class TestCompareReleaseBundleE2E:
             src_file.write_text(algo_src)
             import shutil as _shutil
             import subprocess as _sub
+
             gcc = _shutil.which("gcc")
             if gcc is None:
                 pytest.skip("gcc unavailable; cannot build bundle E2E fixture")
             _sub.run(
-                [gcc, "-shared", "-fPIC", "-g", "-O0", str(src_file),
-                 "-o", str(side / "libalgo.so"),
-                 "-L", str(side), "-Wl,--no-as-needed", "-lcore",
-                 "-Wl,-soname,libalgo.so.1"],
-                check=True, capture_output=True,
+                [
+                    gcc,
+                    "-shared",
+                    "-fPIC",
+                    "-g",
+                    "-O0",
+                    str(src_file),
+                    "-o",
+                    str(side / "libalgo.so"),
+                    "-L",
+                    str(side),
+                    "-Wl,--no-as-needed",
+                    "-lcore",
+                    "-Wl,-soname,libalgo.so.1",
+                ],
+                check=True,
+                capture_output=True,
             )
 
         result = CliRunner().invoke(
-            main, ["compare-release", str(old), str(new), "--bundle-cohort", "lib"],
+            main,
+            ["compare-release", str(old), str(new), "--bundle-cohort", "lib"],
         )
         assert "Bundle (Cross-Library) Findings" in result.stdout
         assert "bundle_intra_dep_removed" in result.stdout
 
     def _build_versioned_so(
-        self, release_dir: Path, src: Path, soname: str,
+        self,
+        release_dir: Path,
+        src: Path,
+        soname: str,
     ) -> None:
         """Compile *src* into ``release_dir`` with an explicit ``-soname``.
 
@@ -1369,20 +1708,32 @@ class TestCompareReleaseBundleE2E:
         """
         import shutil
         import subprocess
+
         gcc = shutil.which("gcc")
         if gcc is None:
             pytest.skip("gcc unavailable; cannot build bundle E2E fixture")
         out = release_dir / soname
         res = subprocess.run(
-            [gcc, "-shared", "-fPIC", "-g", "-O0", str(src),
-             "-o", str(out), f"-Wl,-soname,{soname}"],
-            capture_output=True, text=True,
+            [
+                gcc,
+                "-shared",
+                "-fPIC",
+                "-g",
+                "-O0",
+                str(src),
+                "-o",
+                str(out),
+                f"-Wl,-soname,{soname}",
+            ],
+            capture_output=True,
+            text=True,
         )
         if res.returncode != 0:
             pytest.fail(f"gcc failed for {soname}: {res.stderr}")
 
     def test_compare_release_emits_soname_skew_for_case84(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         # Reproduce examples/case84_bundle_soname_skew end-to-end: core+dpc
         # bump SONAME .so.1 -> .so.2 while thread (deliberately) lags at .so.1.
@@ -1395,8 +1746,7 @@ class TestCompareReleaseBundleE2E:
         from abicheck.cli import main
 
         case_dir = (
-            Path(__file__).parent.parent
-            / "examples" / "case84_bundle_soname_skew"
+            Path(__file__).parent.parent / "examples" / "case84_bundle_soname_skew"
         )
         old = tmp_path / "v1"
         new = tmp_path / "v2"
@@ -1404,17 +1754,28 @@ class TestCompareReleaseBundleE2E:
         new.mkdir()
         # v1: all three at .so.1
         self._build_versioned_so(old, case_dir / "onedal_core.c", "libonedal_core.so.1")
-        self._build_versioned_so(old, case_dir / "onedal_thread.c", "libonedal_thread.so.1")
+        self._build_versioned_so(
+            old, case_dir / "onedal_thread.c", "libonedal_thread.so.1"
+        )
         self._build_versioned_so(old, case_dir / "onedal_dpc.c", "libonedal_dpc.so.1")
         # v2: core + dpc bumped to .so.2, thread lags at .so.1
         self._build_versioned_so(new, case_dir / "onedal_core.c", "libonedal_core.so.2")
-        self._build_versioned_so(new, case_dir / "onedal_thread.c", "libonedal_thread.so.1")
+        self._build_versioned_so(
+            new, case_dir / "onedal_thread.c", "libonedal_thread.so.1"
+        )
         self._build_versioned_so(new, case_dir / "onedal_dpc.c", "libonedal_dpc.so.2")
 
         result = CliRunner().invoke(
             main,
-            ["compare-release", str(old), str(new), "--format", "json",
-             "--bundle-cohort", "libonedal_"],
+            [
+                "compare-release",
+                str(old),
+                str(new),
+                "--format",
+                "json",
+                "--bundle-cohort",
+                "libonedal_",
+            ],
         )
         # Bundle BREAKING → exit 4 (matches ground_truth.json case84 == BREAKING).
         assert result.exit_code == 4, result.output
@@ -1423,14 +1784,14 @@ class TestCompareReleaseBundleE2E:
         kinds = {f["kind"] for f in data["bundle_findings"]}
         assert "bundle_soname_skew" in kinds
         skew = next(
-            f for f in data["bundle_findings"]
-            if f["kind"] == "bundle_soname_skew"
+            f for f in data["bundle_findings"] if f["kind"] == "bundle_soname_skew"
         )
         # The lagging member must be attributed.
         assert any("libonedal_thread" in lib for lib in skew["affected_libraries"])
 
     def test_compare_release_lockstep_bump_has_no_skew(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         # Negative control: when the whole cohort bumps in lockstep there is
         # no skew finding (the detector must not fire on a clean release).
@@ -1441,23 +1802,33 @@ class TestCompareReleaseBundleE2E:
         from abicheck.cli import main
 
         case_dir = (
-            Path(__file__).parent.parent
-            / "examples" / "case84_bundle_soname_skew"
+            Path(__file__).parent.parent / "examples" / "case84_bundle_soname_skew"
         )
         old = tmp_path / "v1"
         new = tmp_path / "v2"
         old.mkdir()
         new.mkdir()
         self._build_versioned_so(old, case_dir / "onedal_core.c", "libonedal_core.so.1")
-        self._build_versioned_so(old, case_dir / "onedal_thread.c", "libonedal_thread.so.1")
+        self._build_versioned_so(
+            old, case_dir / "onedal_thread.c", "libonedal_thread.so.1"
+        )
         # v2: BOTH bump to .so.2 — lockstep, no skew.
         self._build_versioned_so(new, case_dir / "onedal_core.c", "libonedal_core.so.2")
-        self._build_versioned_so(new, case_dir / "onedal_thread.c", "libonedal_thread.so.2")
+        self._build_versioned_so(
+            new, case_dir / "onedal_thread.c", "libonedal_thread.so.2"
+        )
 
         result = CliRunner().invoke(
             main,
-            ["compare-release", str(old), str(new), "--format", "json",
-             "--bundle-cohort", "libonedal_"],
+            [
+                "compare-release",
+                str(old),
+                str(new),
+                "--format",
+                "json",
+                "--bundle-cohort",
+                "libonedal_",
+            ],
         )
         data = _json.loads(result.stdout)
         kinds = {f["kind"] for f in data.get("bundle_findings", [])}
@@ -1473,20 +1844,24 @@ class TestCompareReleaseBundleE2E:
         from abicheck.cli import main
 
         case_dir = (
-            Path(__file__).parent.parent
-            / "examples" / "case84_bundle_soname_skew"
+            Path(__file__).parent.parent / "examples" / "case84_bundle_soname_skew"
         )
         old = tmp_path / "v1"
         new = tmp_path / "v2"
         old.mkdir()
         new.mkdir()
         self._build_versioned_so(old, case_dir / "onedal_core.c", "libonedal_core.so.1")
-        self._build_versioned_so(old, case_dir / "onedal_thread.c", "libonedal_thread.so.1")
+        self._build_versioned_so(
+            old, case_dir / "onedal_thread.c", "libonedal_thread.so.1"
+        )
         self._build_versioned_so(new, case_dir / "onedal_core.c", "libonedal_core.so.2")
-        self._build_versioned_so(new, case_dir / "onedal_thread.c", "libonedal_thread.so.1")
+        self._build_versioned_so(
+            new, case_dir / "onedal_thread.c", "libonedal_thread.so.1"
+        )
 
         result = CliRunner().invoke(
-            main, ["compare-release", str(old), str(new), "--format", "json"],
+            main,
+            ["compare-release", str(old), str(new), "--format", "json"],
         )
         data = _json.loads(result.stdout)
         kinds = {f["kind"] for f in data.get("bundle_findings", [])}
@@ -1496,6 +1871,7 @@ class TestCompareReleaseBundleE2E:
 # ---------------------------------------------------------------------------
 # Cohort-scoped SONAME skew logic (pure, no compiler / no disk)
 # ---------------------------------------------------------------------------
+
 
 class TestSonameSkewCohortScoping:
     """Unit tests for the opt-in `_soname_skew_findings` / `_detect_soname_skew`.
@@ -1508,12 +1884,14 @@ class TestSonameSkewCohortScoping:
     @staticmethod
     def _member(library: str, major: int):
         from abicheck.diff_cpp_patterns import BundleMember
+
         return BundleMember(library=library, soname=library, soname_major=major)
 
     def test_no_cohort_declared_emits_nothing(self) -> None:
         # The opt-in default: even a real skew layout produces no finding when
         # no cohort prefix is declared.
         from abicheck.bundle import _soname_skew_findings
+
         old = [
             self._member("libonedal_core.so.1", 1),
             self._member("libonedal_thread.so.1", 1),
@@ -1526,6 +1904,7 @@ class TestSonameSkewCohortScoping:
 
     def test_skew_within_declared_cohort_is_flagged(self) -> None:
         from abicheck.bundle import _soname_skew_findings
+
         old = [
             self._member("libonedal_core.so.1", 1),
             self._member("libonedal_thread.so.1", 1),
@@ -1546,6 +1925,7 @@ class TestSonameSkewCohortScoping:
         # Declaring only the libfoo_core cohort must not drag libfoo_plugin in,
         # and declaring nothing emits nothing.
         from abicheck.bundle import _soname_skew_findings
+
         old = [
             self._member("libfoo_core.so.1", 1),
             self._member("libfoo_plugin.so.1", 1),
@@ -1561,6 +1941,7 @@ class TestSonameSkewCohortScoping:
 
     def test_lockstep_bump_within_cohort_is_clean(self) -> None:
         from abicheck.bundle import _soname_skew_findings
+
         old = [
             self._member("libonedal_core.so.1", 1),
             self._member("libonedal_thread.so.1", 1),
@@ -1576,6 +1957,7 @@ class TestSonameSkewCohortScoping:
         # var) must NOT degrade into "compare every DSO": independent libfoo
         # bumping while libbar stays must stay clean.
         from abicheck.bundle import _soname_skew_findings
+
         old = [self._member("libfoo.so.1", 1), self._member("libbar.so.1", 1)]
         new = [self._member("libfoo.so.2", 2), self._member("libbar.so.1", 1)]
         assert _soname_skew_findings(old, new, [""]) == []

--- a/tests/test_changekind_completeness.py
+++ b/tests/test_changekind_completeness.py
@@ -256,6 +256,11 @@ ASSERTED_CHANGE_KINDS: set[ChangeKind] = {
     ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR,
     ChangeKind.OPAQUE_INVARIANT_BROKEN,
     ChangeKind.HANDLE_TYPE_CHANGED,
+    # API-surface metric drift (ADR-027 D1.2) — exercised in
+    # tests/test_surface_metrics_drift.py.
+    ChangeKind.PUBLIC_SURFACE_GREW,
+    ChangeKind.PUBLIC_SURFACE_SHRANK,
+    ChangeKind.UNDOCUMENTED_EXPORT_RATIO_INCREASED,
 }
 
 

--- a/tests/test_changekind_completeness.py
+++ b/tests/test_changekind_completeness.py
@@ -249,6 +249,13 @@ ASSERTED_CHANGE_KINDS: set[ChangeKind] = {
     ChangeKind.CHAR8T_MIGRATION,
     ChangeKind.BIT_INT_WIDTH_CHANGED,
     ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+    # API-surface intelligence anti-patterns (ADR-027) — exercised in
+    # tests/test_idioms.py (detection) and tests/test_pattern_verdicts.py
+    # (diff-time transitions and modulation).
+    ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE,
+    ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR,
+    ChangeKind.OPAQUE_INVARIANT_BROKEN,
+    ChangeKind.HANDLE_TYPE_CHANGED,
 }
 
 

--- a/tests/test_idioms.py
+++ b/tests/test_idioms.py
@@ -549,6 +549,37 @@ def test_detect_non_virtual_dtor_base() -> None:
     )
 
 
+def test_antipattern_ambiguous_short_name_not_cross_matched() -> None:
+    # Codex P2: a factory returns ns1::Base*; ns2::Base is a different
+    # polymorphic type with no virtual dtor. The short name "Base" must NOT make
+    # ns2::Base look like a factory return → no false RISK finding.
+    snap = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="make",
+                mangled="make",
+                return_type="ns1::Base*",
+                visibility=Visibility.PUBLIC,
+                return_pointer_depth=1,
+            ),
+        ],
+        types=[
+            RecordType(name="ns1::Base", kind="class", vtable=["_ZN3ns14BaseD0Ev"]),
+            RecordType(name="ns2::Base", kind="class", vtable=["_ZN3ns24Base3fooEv"]),
+        ],
+    )
+    aps = _antipatterns(snap)
+    # ns2::Base is unrelated to the ns1::Base factory and must not be flagged.
+    assert not any(
+        a.kind == ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR
+        and a.symbol == "ns2::Base"
+        for a in aps
+    )
+
+
 def test_virtual_dtor_base_not_flagged() -> None:
     base = RecordType(
         name="Base",

--- a/tests/test_idioms.py
+++ b/tests/test_idioms.py
@@ -16,7 +16,8 @@
 
 from __future__ import annotations
 
-from abicheck.idioms import Idiom, recognise_idioms
+from abicheck.checker_policy import ChangeKind
+from abicheck.idioms import Idiom, detect_antipatterns, recognise_idioms
 from abicheck.model import (
     AbiSnapshot,
     AccessLevel,
@@ -487,6 +488,83 @@ def test_opaque_ignores_hidden_functions() -> None:
     assert any(t.idiom == Idiom.OPAQUE_POINTER for t in _tags(snap).get("Ctx", []))
 
 
+def _antipatterns(snap: AbiSnapshot) -> list:
+    return detect_antipatterns(build_surface_graph(snap))
+
+
+def test_detect_stl_by_value_parameter() -> None:
+    snap = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="sink",
+                mangled="_Z4sinkNSt6stringE",
+                return_type="void",
+                params=[Param(name="s", type="std::string", pointer_depth=0)],
+                visibility=Visibility.PUBLIC,
+            )
+        ],
+    )
+    aps = _antipatterns(snap)
+    assert any(
+        a.kind == ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE and a.symbol == "sink"
+        for a in aps
+    )
+
+
+def test_stl_by_pointer_is_not_flagged() -> None:
+    snap = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="ok",
+                mangled="ok",
+                return_type="void",
+                params=[Param(name="s", type="std::string*", pointer_depth=1)],
+                visibility=Visibility.PUBLIC,
+            )
+        ],
+    )
+    assert not _antipatterns(snap)
+
+
+def test_detect_non_virtual_dtor_base() -> None:
+    base = RecordType(
+        name="Base",
+        kind="class",
+        vtable=["_ZN4Base3fooEv"],  # a virtual method, but no D0/D1/D2 dtor slot
+    )
+    derived = RecordType(name="Derived", kind="class", bases=["Base"])
+    snap = AbiSnapshot(
+        library="l", version="1", from_headers=True, types=[base, derived]
+    )
+    aps = _antipatterns(snap)
+    assert any(
+        a.kind == ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR and a.symbol == "Base"
+        for a in aps
+    )
+
+
+def test_virtual_dtor_base_not_flagged() -> None:
+    base = RecordType(
+        name="Base",
+        kind="class",
+        vtable=["_ZN4BaseD0Ev", "_ZN4Base3fooEv"],  # has a destructor slot
+    )
+    derived = RecordType(name="Derived", kind="class", bases=["Base"])
+    snap = AbiSnapshot(
+        library="l", version="1", from_headers=True, types=[base, derived]
+    )
+    assert not any(
+        a.kind == ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR
+        for a in _antipatterns(snap)
+    )
+
+
 def test_surface_report_idioms_json(tmp_path) -> None:
     import json as _json
 
@@ -505,3 +583,37 @@ def test_surface_report_idioms_json(tmp_path) -> None:
     assert "Ctx" in data["idioms"]
     assert data["idioms"]["Ctx"][0]["idiom"] == "opaque_pointer"
     assert data["idioms"]["Ctx"][0]["definition_hidden"] is True
+
+
+def test_surface_report_antipatterns_json(tmp_path) -> None:
+    import json as _json
+
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+    from abicheck.serialization import save_snapshot
+
+    snap = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="sink",
+                mangled="_Z4sinkNSt6stringE",
+                return_type="void",
+                params=[Param(name="s", type="std::string", pointer_depth=0)],
+                visibility=Visibility.PUBLIC,
+            )
+        ],
+    )
+    p = tmp_path / "lib.abi.json"
+    save_snapshot(snap, p)
+    result = CliRunner().invoke(
+        main, ["surface-report", str(p), "--anti-patterns", "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    data = _json.loads(result.output)
+    assert any(
+        a["kind"] == "public_api_exposes_stl_by_value" for a in data["anti_patterns"]
+    )

--- a/tests/test_idioms.py
+++ b/tests/test_idioms.py
@@ -185,6 +185,37 @@ def test_handle_typedef() -> None:
     assert any(t.idiom == Idiom.HANDLE for t in tags.get("ImplPtr", []))
 
 
+def test_handle_ambiguous_short_pointee_not_tagged() -> None:
+    # ADR-027 review: when an unqualified handle pointee short name matches
+    # several namespaced types — one incomplete, one complete — the typedef is
+    # not provably opaque (it may point at the complete one), so it must not be
+    # tagged HANDLE (which would drive a synthetic handle_type_changed break).
+    snap = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        typedefs={"h": "Ctx *"},
+        types=[
+            RecordType(name="ns1::Ctx", kind="struct", is_opaque=True),
+            RecordType(name="ns2::Ctx", kind="struct", is_opaque=False),
+        ],
+    )
+    assert not any(t.idiom == Idiom.HANDLE for t in _tags(snap).get("h", []))
+
+
+def test_handle_unambiguous_short_pointee_still_tagged() -> None:
+    # Control: a single incomplete type with that short name is unambiguous, so
+    # the short-name fallback still recognises the opaque handle.
+    snap = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        typedefs={"h": "Ctx *"},
+        types=[RecordType(name="ns1::Ctx", kind="struct", is_opaque=True)],
+    )
+    assert any(t.idiom == Idiom.HANDLE for t in _tags(snap).get("h", []))
+
+
 def test_factory_returns_polymorphic_pointer() -> None:
     snap = AbiSnapshot(
         library="l",

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -777,6 +777,27 @@ class TestSeverityConfig:
         ts = root.find("testsuite")
         assert ts.get("failures") == "1"
 
+    def test_demoted_compatible_fails_under_strict_preset(self) -> None:
+        """ADR-027 review: a --pattern-verdicts demotion to COMPATIBLE must
+        still be a JUnit failure under a strict severity preset, matching the
+        severity-aware exit code (classify_change_object → QUALITY_ISSUES →
+        error). Otherwise CI consuming the JUnit file misses the failure that
+        the exit status reports."""
+        from abicheck.severity import PRESET_STRICT
+
+        demoted = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Ctx", description="size"
+        )
+        demoted.effective_verdict = Verdict.COMPATIBLE
+        result = _make_result([demoted], verdict=Verdict.COMPATIBLE)
+        # Default preset: quality issues are warnings → testcase passes.
+        default_xml = _parse(to_junit_xml(result))
+        assert default_xml.find("testsuite").get("failures") == "0"
+        # Strict preset: quality issues escalate to error → failure, agreeing
+        # with the nonzero severity-aware exit code.
+        strict_xml = _parse(to_junit_xml(result, severity_config=PRESET_STRICT))
+        assert strict_xml.find("testsuite").get("failures") == "1"
+
     def test_severity_config_demotes_breaking_to_pass(self) -> None:
         """When severity_config marks abi_breaking as 'warning', additions
         that were BREAKING still fail (breaking_set takes priority)."""

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -483,6 +483,68 @@ def test_new_antipattern_emitted_as_risk() -> None:
     assert any(m["rule_id"] == "new-anti-pattern" for m in ledger)
 
 
+def test_private_inheritance_does_not_suppress_new_public_factory_risk() -> None:
+    # Codex P2: old has a polymorphic Base (no virtual dtor) inherited only by a
+    # PRIVATE_HEADER record (not a public risk). New adds the first public factory
+    # returning Base*. The new *public* risk must be emitted — the private-
+    # inheritance evidence must not pre-seed old_aps and suppress it.
+    from abicheck.model import RecordType as _RT
+    from abicheck.model import ScopeOrigin
+
+    base = _RT(name="Base", kind="class", vtable=["_ZN4Base3fooEv"])
+
+    def old_snap() -> AbiSnapshot:
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            types=[
+                base,
+                _RT(
+                    name="Impl",
+                    kind="class",
+                    bases=["Base"],
+                    origin=ScopeOrigin.PRIVATE_HEADER,
+                ),
+            ],
+        )
+
+    def new_snap() -> AbiSnapshot:
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(
+                    name="make",
+                    mangled="make",
+                    return_type="Base*",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                    return_pointer_depth=1,
+                )
+            ],
+            types=[
+                base,
+                _RT(
+                    name="Impl",
+                    kind="class",
+                    bases=["Base"],
+                    origin=ScopeOrigin.PRIVATE_HEADER,
+                ),
+            ],
+        )
+
+    changes: list[Change] = []
+    apply_pattern_verdicts(
+        changes, old_snap(), new_snap(), evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert any(
+        c.kind == ChangeKind.POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR and c.symbol == "Base"
+        for c in changes
+    )
+
+
 def test_preexisting_antipattern_not_re_emitted() -> None:
     # Present in BOTH snapshots → pre-existing debt, not nagged about.
     def snap() -> AbiSnapshot:

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -547,6 +547,17 @@ def test_cross_output_completeness_for_demoted_finding() -> None:
     demoted.modulation_reason = "opaque-by-construction"
     demoted.modulation_rule = "opaque-pointer-layout"
     result.changes.append(demoted)
+    result.pattern_modulations = [
+        {
+            "symbol": "Ctx",
+            "original_category": "breaking",
+            "new_category": "compatible",
+            "rule_id": "opaque-pointer-layout",
+            "reason": "opaque-by-construction",
+            "evidence_tier": "header_aware",
+            "edges_matched": [],
+        }
+    ]
 
     # 1. verdict / compute_verdict exit path
     assert demoted in result.compatible
@@ -578,6 +589,18 @@ def test_cross_output_completeness_for_demoted_finding() -> None:
     results = sarif["runs"][0]["results"]
     size_results = [r for r in results if r["ruleId"] == "type_size_changed"]
     assert size_results and all(r["level"] == "note" for r in size_results)
+
+    # 5b. Leaf-mode JSON keeps the modulation audit trail (Codex P2): the
+    # demoted root type change carries effective_verdict/modulation_reason and
+    # the top-level pattern_modulations ledger is present.
+    leaf = json.loads(to_json(result, report_mode="leaf"))
+    leaf_entry = next(
+        c for c in leaf["leaf_changes"] if c["kind"] == "type_size_changed"
+    )
+    assert leaf_entry["severity"] == "compatible"
+    assert leaf_entry["effective_verdict"] == "COMPATIBLE"
+    assert leaf_entry["modulation_reason"] == "opaque-by-construction"
+    assert "pattern_modulations" in leaf
 
     # 6. JUnit: demoted finding is not a failure
     xml = to_junit_xml(result)

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -1,0 +1,477 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ADR-027 A4 pattern-aware verdict modulation.
+
+Focus is the anti-hiding contract: a modulation may demote-with-reason or
+raise, never silently delete a real break. Includes the cross-output
+completeness regression guard (a demoted finding must read compatible in every
+sink and contribute to neither exit-code path).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from abicheck import checker
+from abicheck.checker_policy import ChangeKind, EvidenceTier, Verdict
+from abicheck.checker_types import Change
+from abicheck.model import (
+    AbiSnapshot,
+    AccessLevel,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Visibility,
+)
+from abicheck.pattern_verdicts import apply_pattern_verdicts
+
+# ---------------------------------------------------------------------------
+# Snapshot builders
+# ---------------------------------------------------------------------------
+
+
+def _opaque_snapshot(
+    *, opaque: bool, size: int | None, by_value: bool = False
+) -> AbiSnapshot:
+    fields = (
+        []
+        if opaque
+        else [TypeField(name="x", type="int", offset_bits=0, access=AccessLevel.PUBLIC)]
+    )
+    use_param = (
+        Param(name="c", type="Ctx", pointer_depth=0)
+        if by_value
+        else Param(name="c", type="Ctx*", pointer_depth=1)
+    )
+    return AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="open",
+                mangled="open",
+                return_type="Ctx*",
+                params=[],
+                visibility=Visibility.PUBLIC,
+                return_pointer_depth=1,
+            ),
+            Function(
+                name="use",
+                mangled="use",
+                return_type="void",
+                params=[use_param],
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        types=[
+            RecordType(
+                name="Ctx",
+                kind="struct",
+                is_opaque=opaque,
+                size_bits=size,
+                fields=fields,
+            )
+        ],
+    )
+
+
+def _layout_change(symbol: str = "Ctx") -> Change:
+    return Change(
+        kind=ChangeKind.TYPE_SIZE_CHANGED,
+        symbol=symbol,
+        description="size changed",
+        old_value="64",
+        new_value="128",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Opaque-pointer demote (D4.1)
+# ---------------------------------------------------------------------------
+
+
+def test_opaque_layout_demoted_at_header_tier() -> None:
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=True, size=None)
+    changes = [_layout_change()]
+    ledger = apply_pattern_verdicts(
+        changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert changes[0].effective_verdict == Verdict.COMPATIBLE
+    assert changes[0].modulation_reason == "opaque-by-construction"
+    assert changes[0].modulation_rule == "opaque-pointer-layout"
+    assert any(m["rule_id"] == "opaque-pointer-layout" for m in ledger)
+    assert ledger[0]["original_category"] == "breaking"
+    assert ledger[0]["new_category"] == "compatible"
+
+
+@pytest.mark.parametrize("tier", [EvidenceTier.ELF_ONLY, EvidenceTier.DWARF_AWARE])
+def test_demotion_refused_below_header_tier(tier: EvidenceTier) -> None:
+    # Confidence floor by tier (D4.1): idiom demotion needs the AST.
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=True, size=None)
+    changes = [_layout_change()]
+    ledger = apply_pattern_verdicts(changes, old, new, evidence_tier=tier)
+    assert changes[0].effective_verdict is None
+    assert not any(m["rule_id"] == "opaque-pointer-layout" for m in ledger)
+
+
+def test_disabled_is_noop() -> None:
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=True, size=None)
+    changes = [_layout_change()]
+    ledger = apply_pattern_verdicts(
+        changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE, enabled=False
+    )
+    assert ledger == []
+    assert changes[0].effective_verdict is None
+
+
+def test_frozen_namespace_never_demoted() -> None:
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=True, size=None)
+    c = _layout_change()
+    c.frozen_namespace_violation = "myns::*"
+    apply_pattern_verdicts([c], old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
+    assert c.effective_verdict is None
+
+
+# ---------------------------------------------------------------------------
+# Lost opaque invariant → OPAQUE_INVARIANT_BROKEN (D2.2, never silent)
+# ---------------------------------------------------------------------------
+
+
+def test_lost_opaqueness_emits_break_not_silent_demotion() -> None:
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=False, size=128)  # definition now visible
+    changes: list[Change] = [_layout_change()]
+    ledger = apply_pattern_verdicts(
+        changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    kinds = {c.kind for c in changes}
+    assert ChangeKind.OPAQUE_INVARIANT_BROKEN in kinds
+    broken = next(c for c in changes if c.kind == ChangeKind.OPAQUE_INVARIANT_BROKEN)
+    assert broken.effective_verdict is None  # a real BREAKING kind, not demoted
+    # The layout change itself must NOT have been silently demoted.
+    layout = next(c for c in changes if c.kind == ChangeKind.TYPE_SIZE_CHANGED)
+    assert layout.effective_verdict is None
+    assert any(m["rule_id"] == "lost-opaque-invariant" for m in ledger)
+
+
+def test_lost_opaqueness_by_value_use() -> None:
+    old = _opaque_snapshot(opaque=True, size=None)
+    # Still incomplete, but now crossed by value publicly → opacity lost.
+    new = _opaque_snapshot(opaque=False, size=128, by_value=True)
+    changes: list[Change] = []
+    apply_pattern_verdicts(changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
+    assert any(c.kind == ChangeKind.OPAQUE_INVARIANT_BROKEN for c in changes)
+
+
+# ---------------------------------------------------------------------------
+# PIMPL pointee-only vs wrapper layout (D4.1 guard)
+# ---------------------------------------------------------------------------
+
+
+def _pimpl_snapshot(*, wrapper_size: int, impl_size: int | None) -> AbiSnapshot:
+    wrapper = RecordType(
+        name="Widget",
+        kind="class",
+        is_opaque=False,
+        size_bits=wrapper_size,
+        alignment_bits=64,
+        fields=[
+            TypeField(
+                name="impl", type="Impl*", offset_bits=0, access=AccessLevel.PRIVATE
+            )
+        ],
+    )
+    impl = RecordType(name="Impl", kind="class", is_opaque=True, size_bits=impl_size)
+    return AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="make",
+                mangled="make",
+                return_type="Widget*",
+                params=[],
+                visibility=Visibility.PUBLIC,
+                return_pointer_depth=1,
+            )
+        ],
+        types=[wrapper, impl],
+    )
+
+
+def test_pimpl_pointee_change_demoted() -> None:
+    old = _pimpl_snapshot(wrapper_size=64, impl_size=None)
+    new = _pimpl_snapshot(wrapper_size=64, impl_size=None)
+    change = Change(
+        kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Impl", description="impl grew"
+    )
+    apply_pattern_verdicts([change], old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
+    assert change.effective_verdict == Verdict.COMPATIBLE
+    assert change.modulation_rule == "pimpl-pointee-only"
+
+
+def test_pimpl_wrapper_layout_change_not_demoted() -> None:
+    # The wrapper's own layout changed (64 -> 128): callers can sizeof it, so a
+    # change to the wrapper is a real break and must NOT be demoted.
+    old = _pimpl_snapshot(wrapper_size=64, impl_size=None)
+    new = _pimpl_snapshot(wrapper_size=128, impl_size=None)
+    change = Change(
+        kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="Widget", description="wrapper grew"
+    )
+    apply_pattern_verdicts([change], old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
+    assert change.effective_verdict is None
+
+
+# ---------------------------------------------------------------------------
+# Handle token change → HANDLE_TYPE_CHANGED
+# ---------------------------------------------------------------------------
+
+
+def _handle_snapshot(target: str) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="use",
+                mangled="use",
+                return_type="void",
+                params=[Param(name="h", type="my_handle_t", pointer_depth=0)],
+                visibility=Visibility.PUBLIC,
+            )
+        ],
+        typedefs={"my_handle_t": target},
+    )
+
+
+def test_new_antipattern_emitted_as_risk() -> None:
+    # Old has no by-value std param; new introduces one → RISK finding emitted.
+    def snap(by_value: bool) -> AbiSnapshot:
+        ptype = "std::string" if by_value else "std::string*"
+        depth = 0 if by_value else 1
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(
+                    name="sink",
+                    mangled="sink",
+                    return_type="void",
+                    params=[Param(name="s", type=ptype, pointer_depth=depth)],
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+        )
+
+    changes: list[Change] = []
+    ledger = apply_pattern_verdicts(
+        changes, snap(False), snap(True), evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert any(c.kind == ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE for c in changes)
+    assert any(m["rule_id"] == "new-anti-pattern" for m in ledger)
+
+
+def test_preexisting_antipattern_not_re_emitted() -> None:
+    # Present in BOTH snapshots → pre-existing debt, not nagged about.
+    def snap() -> AbiSnapshot:
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(
+                    name="sink",
+                    mangled="sink",
+                    return_type="void",
+                    params=[Param(name="s", type="std::string", pointer_depth=0)],
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+        )
+
+    changes: list[Change] = []
+    apply_pattern_verdicts(
+        changes, snap(), snap(), evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert not any(
+        c.kind == ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE for c in changes
+    )
+
+
+def test_handle_token_change_emits_break() -> None:
+    old = _handle_snapshot("struct Foo *")
+    new = _handle_snapshot("struct Bar *")
+    changes: list[Change] = []
+    ledger = apply_pattern_verdicts(
+        changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert any(c.kind == ChangeKind.HANDLE_TYPE_CHANGED for c in changes)
+    assert any(m["rule_id"] == "handle-token-changed" for m in ledger)
+
+
+def test_antipattern_annotation_on_existing_change() -> None:
+    # A change sitting on an STL-by-value surface gets an annotation (raise),
+    # never a demotion: category unchanged, but disclosed in the ledger.
+    def snap() -> AbiSnapshot:
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(
+                    name="sink",
+                    mangled="sink",
+                    return_type="void",
+                    params=[Param(name="s", type="std::string", pointer_depth=0)],
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+        )
+
+    change = Change(
+        kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="sink", description="params changed"
+    )
+    ledger = apply_pattern_verdicts(
+        [change], snap(), snap(), evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert change.effective_verdict is None  # raise never demotes
+    assert change.modulation_reason == "anti-pattern-elevated-risk"
+    assert any(m["rule_id"] == "anti-pattern-raise" for m in ledger)
+
+
+def _save(snap: AbiSnapshot, path) -> None:
+    from abicheck.serialization import save_snapshot
+
+    save_snapshot(snap, path)
+
+
+def test_cli_explain_patterns(tmp_path) -> None:
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    old = _handle_snapshot("struct Foo *")
+    new = _handle_snapshot("struct Bar *")
+    op = tmp_path / "old.abi.json"
+    np = tmp_path / "new.abi.json"
+    out = tmp_path / "report.json"
+    _save(old, op)
+    _save(new, np)
+    res = CliRunner().invoke(
+        main,
+        [
+            "compare",
+            str(op),
+            str(np),
+            "--pattern-verdicts",
+            "--explain-patterns",
+            "--format",
+            "json",
+            "-o",
+            str(out),
+        ],
+    )
+    assert res.exit_code in (0, 2, 4), res.output
+    payload = json.loads(out.read_text())
+    assert any(
+        m["rule_id"] == "handle-token-changed" for m in payload["pattern_modulations"]
+    )
+    # --explain-patterns prints the ledger (with evidence edges).
+    combined = res.output + (res.stderr if res.stderr_bytes else "")
+    assert "Pattern-aware modulations" in combined
+    assert "handle-token-changed" in combined
+
+
+def test_cli_no_modulations_message(tmp_path) -> None:
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    # Identical snapshots → no changes, no modulations → the "none" branch.
+    snap = _handle_snapshot("struct Foo *")
+    p = tmp_path / "s.abi.json"
+    _save(snap, p)
+    res = CliRunner().invoke(main, ["compare", str(p), str(p), "--explain-patterns"])
+    assert res.exit_code == 0, res.output
+    combined = res.output + (res.stderr if res.stderr_bytes else "")
+    assert "No pattern-aware modulations applied." in combined
+
+
+# ---------------------------------------------------------------------------
+# Cross-output completeness (validation matrix §2)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_output_completeness_for_demoted_finding() -> None:
+    from abicheck.junit_report import to_junit_xml
+    from abicheck.reporter import to_json
+    from abicheck.sarif import to_sarif_str
+    from abicheck.severity import PRESET_DEFAULT, compute_exit_code
+
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=True, size=None)
+    result = checker.compare(
+        old, new, scope_to_public_surface=False, pattern_verdicts=True
+    )
+    # Force a demoted layout finding into the result so every sink is exercised
+    # even though the existing opaque filter also handles pure size drift.
+    demoted = _layout_change()
+    demoted.effective_verdict = Verdict.COMPATIBLE
+    demoted.modulation_reason = "opaque-by-construction"
+    demoted.modulation_rule = "opaque-pointer-layout"
+    result.changes.append(demoted)
+
+    # 1. verdict / compute_verdict exit path
+    assert demoted in result.compatible
+    assert demoted not in result.breaking
+
+    # 2. JSON `changes` + severity field
+    payload = json.loads(to_json(result))
+    entry = next(c for c in payload["changes"] if c["kind"] == "type_size_changed")
+    assert entry["severity"] == "compatible"
+    assert entry["effective_verdict"] == "COMPATIBLE"
+    assert entry["modulation_reason"] == "opaque-by-construction"
+
+    # 3. JSON filtered_summary (show_only path)
+    payload2 = json.loads(to_json(result, show_only="breaking"))
+    # the demoted finding must not be counted as breaking
+    assert payload2["filtered_summary"]["breaking"] == 0
+
+    # 4. severity-aware exit code path
+    assert compute_exit_code([demoted], PRESET_DEFAULT) == 0
+
+    # 5. SARIF level = note, not error
+    sarif = json.loads(to_sarif_str(result))
+    results = sarif["runs"][0]["results"]
+    size_results = [r for r in results if r["ruleId"] == "type_size_changed"]
+    assert size_results and all(r["level"] == "note" for r in size_results)
+
+    # 6. JUnit: demoted finding is not a failure
+    xml = to_junit_xml(result)
+    assert (
+        "type_size_changed" not in xml
+        or "<failure" not in xml.split("type_size_changed")[1][:200]
+    )

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -229,10 +229,66 @@ def test_lost_opaqueness_emits_break_not_silent_demotion() -> None:
     assert any(m["rule_id"] == "lost-opaque-invariant" for m in ledger)
 
 
+def test_removed_opaque_with_same_short_name_not_flagged() -> None:
+    # Codex P2: old ns1::Ctx is opaque and removed; new has an unrelated
+    # ns2::Ctx (single, same short name). The lost-invariant transition must
+    # require exact qualified identity, so no OPAQUE_INVARIANT_BROKEN fires for
+    # ns1::Ctx (the removal is covered by normal type-removed handling).
+    old = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="open",
+                mangled="open",
+                return_type="ns1::Ctx*",
+                params=[],
+                visibility=Visibility.PUBLIC,
+                return_pointer_depth=1,
+            ),
+        ],
+        types=[RecordType(name="ns1::Ctx", kind="struct", is_opaque=True)],
+    )
+    new = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            Function(
+                name="other",
+                mangled="other",
+                return_type="void",
+                params=[Param(name="c", type="ns2::Ctx", pointer_depth=0)],
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        types=[
+            RecordType(
+                name="ns2::Ctx",
+                kind="struct",
+                is_opaque=False,
+                size_bits=64,
+                fields=[
+                    TypeField(
+                        name="x", type="int", offset_bits=0, access=AccessLevel.PUBLIC
+                    )
+                ],
+            )
+        ],
+    )
+    changes: list[Change] = []
+    apply_pattern_verdicts(changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
+    assert not any(c.kind == ChangeKind.OPAQUE_INVARIANT_BROKEN for c in changes)
+
+
 def test_lost_opaqueness_by_value_use() -> None:
     old = _opaque_snapshot(opaque=True, size=None)
-    # Still incomplete, but now crossed by value publicly → opacity lost.
-    new = _opaque_snapshot(opaque=False, size=128, by_value=True)
+    # Still incomplete (opaque=True), but now crossed by value publicly → opacity
+    # lost. Keeping it incomplete isolates the *by-value* detection path: the
+    # break must fire even though the definition is still hidden (Codex/CodeRabbit
+    # review — opaque=False would let it pass via visibility instead).
+    new = _opaque_snapshot(opaque=True, size=None, by_value=True)
     changes: list[Change] = []
     apply_pattern_verdicts(changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
     assert any(c.kind == ChangeKind.OPAQUE_INVARIANT_BROKEN for c in changes)
@@ -648,6 +704,20 @@ def test_cross_output_completeness_for_demoted_finding() -> None:
     assert leaf_entry["effective_verdict"] == "COMPATIBLE"
     assert leaf_entry["modulation_reason"] == "opaque-by-construction"
     assert "pattern_modulations" in leaf
+
+    # 5c. Element filter (--show-only) must not drop ADR-027 kinds that don't
+    # match the prefix table (Codex P2). A type-level invariant break is kept
+    # under --show-only=types.
+    from abicheck.reporter import ShowOnlyFilter
+
+    inv = Change(
+        kind=ChangeKind.OPAQUE_INVARIANT_BROKEN, symbol="Ctx", description="lost"
+    )
+    assert ShowOnlyFilter.parse("types").matches(inv)
+    stl = Change(
+        kind=ChangeKind.PUBLIC_API_EXPOSES_STL_BY_VALUE, symbol="f", description="stl"
+    )
+    assert ShowOnlyFilter.parse("functions").matches(stl)
 
     # 6. JUnit: demoted finding is not a failure
     xml = to_junit_xml(result)

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -583,6 +583,16 @@ def test_handle_token_change_emits_break() -> None:
     assert any(m["rule_id"] == "handle-token-changed" for m in ledger)
 
 
+def test_builtin_pointer_typedef_is_not_a_handle() -> None:
+    # Codex P2: typedef int *ptr_t is a pointer to a builtin, NOT an opaque
+    # handle token. A width change int* -> long* must not emit handle_type_changed.
+    old = _handle_snapshot("int *")
+    new = _handle_snapshot("long *")
+    changes: list[Change] = []
+    apply_pattern_verdicts(changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE)
+    assert not any(c.kind == ChangeKind.HANDLE_TYPE_CHANGED for c in changes)
+
+
 def test_pattern_generated_change_respects_suppression() -> None:
     suppression = SuppressionList(
         [
@@ -635,6 +645,33 @@ def _save(snap: AbiSnapshot, path) -> None:
     from abicheck.serialization import save_snapshot
 
     save_snapshot(snap, path)
+
+
+def test_suppressed_synthetic_finding_pruned_from_ledger() -> None:
+    # Codex P2: when a synthetic pattern finding is suppressed, its
+    # pattern_modulations ledger row must be pruned too — otherwise the JSON /
+    # --explain-patterns ledger reports a raise that is absent from changes.
+    from abicheck.suppression import Suppression, SuppressionList
+
+    old = _handle_snapshot("struct Foo *")
+    new = _handle_snapshot("struct Bar *")
+    supp = SuppressionList(
+        [
+            Suppression(symbol="my_handle_t", change_kind="handle_type_changed"),
+            Suppression(symbol="my_handle_t", change_kind="typedef_base_changed"),
+        ]
+    )
+    result = checker.compare(
+        old, new, suppression=supp, scope_to_public_surface=False, pattern_verdicts=True
+    )
+    assert not any(c.kind == ChangeKind.HANDLE_TYPE_CHANGED for c in result.changes)
+    assert any(
+        c.kind == ChangeKind.HANDLE_TYPE_CHANGED for c in result.suppressed_changes
+    )
+    # The ledger row for the suppressed handle transition must be gone.
+    assert not any(
+        m["rule_id"] == "handle-token-changed" for m in result.pattern_modulations
+    )
 
 
 def test_cli_explain_patterns(tmp_path) -> None:

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -122,6 +122,25 @@ def test_opaque_layout_demoted_at_header_tier() -> None:
     assert ledger[0]["new_category"] == "compatible"
 
 
+def test_policy_override_protects_kind_from_demotion() -> None:
+    # ADR-027 review: an explicit user policy override on a kind is
+    # authoritative and must win over an automated pattern demotion, so the
+    # aggregate verdict (which applies the override) stays consistent with
+    # per-finding classification. A demote never fires on a protected kind.
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = _opaque_snapshot(opaque=True, size=None)
+    changes = [_layout_change()]
+    ledger = apply_pattern_verdicts(
+        changes,
+        old,
+        new,
+        evidence_tier=EvidenceTier.HEADER_AWARE,
+        protected_kinds=frozenset({ChangeKind.TYPE_SIZE_CHANGED}),
+    )
+    assert changes[0].effective_verdict is None  # not demoted
+    assert not any(m["rule_id"] == "opaque-pointer-layout" for m in ledger)
+
+
 @pytest.mark.parametrize("tier", [EvidenceTier.ELF_ONLY, EvidenceTier.DWARF_AWARE])
 def test_demotion_refused_below_header_tier(tier: EvidenceTier) -> None:
     # Confidence floor by tier (D4.1): idiom demotion needs the AST.

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -317,6 +317,53 @@ def test_pimpl_pointee_change_demoted() -> None:
     assert change.modulation_rule == "pimpl-pointee-only"
 
 
+def test_pimpl_ambiguous_pointee_short_name_not_demoted() -> None:
+    # Codex P2: a wrapper records an unqualified hidden_pointee "Impl", but the
+    # snapshot has two Impl types (ns1::Impl, ns2::Impl). A real break on
+    # ns1::Impl must NOT be demoted via the wrapper whose Impl* is ambiguous.
+    def snap() -> AbiSnapshot:
+        wrapper = RecordType(
+            name="Widget",
+            kind="class",
+            is_opaque=False,
+            size_bits=64,
+            alignment_bits=64,
+            fields=[
+                TypeField(
+                    name="impl", type="Impl*", offset_bits=0, access=AccessLevel.PRIVATE
+                )
+            ],
+        )
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(
+                    name="make",
+                    mangled="make",
+                    return_type="Widget*",
+                    params=[],
+                    visibility=Visibility.PUBLIC,
+                    return_pointer_depth=1,
+                )
+            ],
+            types=[
+                wrapper,
+                RecordType(name="ns1::Impl", kind="class", is_opaque=True),
+                RecordType(name="ns2::Impl", kind="class", is_opaque=True),
+            ],
+        )
+
+    change = Change(
+        kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="ns1::Impl", description="grew"
+    )
+    apply_pattern_verdicts(
+        [change], snap(), snap(), evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert change.effective_verdict is None  # ambiguous pointee → not demoted
+
+
 def test_pimpl_wrapper_layout_change_not_demoted() -> None:
     # The wrapper's own layout changed (64 -> 128): callers can sizeof it, so a
     # change to the wrapper is a real break and must NOT be demoted.

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -183,6 +183,37 @@ def test_lost_opaqueness_by_value_use() -> None:
     assert any(c.kind == ChangeKind.OPAQUE_INVARIANT_BROKEN for c in changes)
 
 
+def test_still_hidden_opaque_not_flagged() -> None:
+    # Codex P2: the type stays incomplete in new but its last public Ctx* use
+    # was removed (so it's no longer *recognised* as an opaque idiom). Opacity
+    # is intact — the forward declaration is still all callers can see — so this
+    # must NOT emit a false OPAQUE_INVARIANT_BROKEN.
+    old = _opaque_snapshot(opaque=True, size=None)
+    new = AbiSnapshot(
+        library="l",
+        version="1",
+        from_headers=True,
+        functions=[
+            # No more public function references Ctx; only the forward decl
+            # remains. Ctx is still incomplete (is_opaque=True).
+            Function(
+                name="unrelated",
+                mangled="unrelated",
+                return_type="void",
+                params=[],
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+        types=[RecordType(name="Ctx", kind="struct", is_opaque=True)],
+    )
+    changes: list[Change] = []
+    ledger = apply_pattern_verdicts(
+        changes, old, new, evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    assert not any(c.kind == ChangeKind.OPAQUE_INVARIANT_BROKEN for c in changes)
+    assert not any(m["rule_id"] == "lost-opaque-invariant" for m in ledger)
+
+
 # ---------------------------------------------------------------------------
 # PIMPL pointee-only vs wrapper layout (D4.1 guard)
 # ---------------------------------------------------------------------------
@@ -455,10 +486,16 @@ def test_cross_output_completeness_for_demoted_finding() -> None:
     assert entry["effective_verdict"] == "COMPATIBLE"
     assert entry["modulation_reason"] == "opaque-by-construction"
 
-    # 3. JSON filtered_summary (show_only path)
+    # 3. JSON filtered_summary (show_only path) — and the show-only *filter*
+    # itself must exclude the demoted finding by its effective category (Codex
+    # P2): a demoted type_size_changed must not leak into `changes` under
+    # --show-only=breaking while filtered_summary reports breaking: 0.
     payload2 = json.loads(to_json(result, show_only="breaking"))
-    # the demoted finding must not be counted as breaking
     assert payload2["filtered_summary"]["breaking"] == 0
+    assert all(c["kind"] != "type_size_changed" for c in payload2["changes"])
+    # Conversely it IS selected under --show-only=compatible.
+    payload3 = json.loads(to_json(result, show_only="compatible"))
+    assert any(c["kind"] == "type_size_changed" for c in payload3["changes"])
 
     # 4. severity-aware exit code path
     assert compute_exit_code([demoted], PRESET_DEFAULT) == 0

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -39,6 +39,7 @@ from abicheck.model import (
     Visibility,
 )
 from abicheck.pattern_verdicts import apply_pattern_verdicts
+from abicheck.suppression import Suppression, SuppressionList
 
 # ---------------------------------------------------------------------------
 # Snapshot builders
@@ -361,6 +362,24 @@ def test_handle_token_change_emits_break() -> None:
     )
     assert any(c.kind == ChangeKind.HANDLE_TYPE_CHANGED for c in changes)
     assert any(m["rule_id"] == "handle-token-changed" for m in ledger)
+
+
+def test_pattern_generated_change_respects_suppression() -> None:
+    suppression = SuppressionList(
+        [
+            Suppression(symbol="my_handle_t", change_kind="typedef_base_changed"),
+            Suppression(symbol="my_handle_t", change_kind="handle_type_changed"),
+        ]
+    )
+    result = checker.compare(
+        _handle_snapshot("struct Foo *"),
+        _handle_snapshot("struct Bar *"),
+        suppression=suppression,
+        pattern_verdicts=True,
+    )
+    assert result.verdict == Verdict.NO_CHANGE
+    assert ChangeKind.HANDLE_TYPE_CHANGED not in {c.kind for c in result.changes}
+    assert ChangeKind.HANDLE_TYPE_CHANGED in {c.kind for c in result.suppressed_changes}
 
 
 def test_antipattern_annotation_on_existing_change() -> None:

--- a/tests/test_pattern_verdicts.py
+++ b/tests/test_pattern_verdicts.py
@@ -153,6 +153,60 @@ def test_frozen_namespace_never_demoted() -> None:
     assert c.effective_verdict is None
 
 
+def test_ambiguous_short_name_not_demoted() -> None:
+    # Codex P2: ns1::Ctx has a real size change; only ns2::Ctx is opaque. The
+    # unqualified short name "Ctx" is ambiguous across namespaces, so ns2::Ctx's
+    # opaque evidence must NOT demote the ns1::Ctx break.
+    def snap() -> AbiSnapshot:
+        return AbiSnapshot(
+            library="l",
+            version="1",
+            from_headers=True,
+            functions=[
+                Function(  # ns2::Ctx is opaque (incomplete, pointer-only)
+                    name="ns2_use",
+                    mangled="ns2_use",
+                    return_type="void",
+                    params=[Param(name="c", type="ns2::Ctx*", pointer_depth=1)],
+                    visibility=Visibility.PUBLIC,
+                ),
+                Function(  # ns1::Ctx is a complete, by-value public type
+                    name="ns1_use",
+                    mangled="ns1_use",
+                    return_type="void",
+                    params=[Param(name="c", type="ns1::Ctx", pointer_depth=0)],
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+            types=[
+                RecordType(name="ns2::Ctx", kind="struct", is_opaque=True),
+                RecordType(
+                    name="ns1::Ctx",
+                    kind="struct",
+                    is_opaque=False,
+                    size_bits=64,
+                    fields=[
+                        TypeField(
+                            name="x",
+                            type="int",
+                            offset_bits=0,
+                            access=AccessLevel.PUBLIC,
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    change = Change(
+        kind=ChangeKind.TYPE_SIZE_CHANGED, symbol="ns1::Ctx", description="grew"
+    )
+    apply_pattern_verdicts(
+        [change], snap(), snap(), evidence_tier=EvidenceTier.HEADER_AWARE
+    )
+    # ns1::Ctx is not opaque; its break must stand despite ns2::Ctx being opaque.
+    assert change.effective_verdict is None
+
+
 # ---------------------------------------------------------------------------
 # Lost opaque invariant → OPAQUE_INVARIANT_BROKEN (D2.2, never silent)
 # ---------------------------------------------------------------------------

--- a/tests/test_surface_metrics_drift.py
+++ b/tests/test_surface_metrics_drift.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ADR-027 A1/D1.2 surface-metric drift (--surface-metrics)."""
+
+from __future__ import annotations
+
+from abicheck import checker
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.diff_surface_metrics import diff_surface_metrics
+from abicheck.model import AbiSnapshot, Function, ScopeOrigin, Visibility
+
+
+def _snap(
+    func_names: list[str], *, export_only: list[str] | None = None
+) -> AbiSnapshot:
+    export_only = export_only or []
+    fns = [
+        Function(
+            name=n,
+            mangled=n,
+            return_type="void",
+            params=[],
+            visibility=Visibility.PUBLIC,
+            origin=(
+                ScopeOrigin.EXPORT_ONLY
+                if n in export_only
+                else ScopeOrigin.PUBLIC_HEADER
+            ),
+        )
+        for n in func_names
+    ]
+    return AbiSnapshot(library="l", version="1", from_headers=True, functions=fns)
+
+
+def test_public_surface_grew() -> None:
+    old = _snap(["a", "b"])
+    new = _snap(["a", "b", "c"])
+    kinds = {c.kind for c in diff_surface_metrics(old, new)}
+    assert ChangeKind.PUBLIC_SURFACE_GREW in kinds
+    assert ChangeKind.PUBLIC_SURFACE_SHRANK not in kinds
+
+
+def test_public_surface_shrank() -> None:
+    old = _snap(["a", "b", "c"])
+    new = _snap(["a"])
+    kinds = {c.kind for c in diff_surface_metrics(old, new)}
+    assert ChangeKind.PUBLIC_SURFACE_SHRANK in kinds
+
+
+def test_no_drift_when_count_stable() -> None:
+    old = _snap(["a", "b"])
+    new = _snap(["a", "b"])
+    assert diff_surface_metrics(old, new) == []
+
+
+def test_undocumented_ratio_increased() -> None:
+    # old: 0/3 undocumented; new: 2/3 undocumented → ratio rises.
+    old = _snap(["a", "b", "c"])
+    new = _snap(["a", "b", "c"], export_only=["b", "c"])
+    kinds = {c.kind for c in diff_surface_metrics(old, new)}
+    assert ChangeKind.UNDOCUMENTED_EXPORT_RATIO_INCREASED in kinds
+
+
+def test_metric_kinds_are_compatible() -> None:
+    # They must never break the verdict on their own.
+    old = _snap(["a"])
+    new = _snap(["a", "b", "c"], export_only=["b", "c"])
+    result = checker.compare(
+        old, new, scope_to_public_surface=False, surface_metrics=True
+    )
+    metric_kinds = {
+        ChangeKind.PUBLIC_SURFACE_GREW,
+        ChangeKind.UNDOCUMENTED_EXPORT_RATIO_INCREASED,
+    }
+    emitted = {c.kind for c in result.changes}
+    assert metric_kinds & emitted  # at least the grow + ratio findings present
+    # All metric findings classify compatible; verdict stays non-breaking.
+    assert result.verdict in (Verdict.COMPATIBLE, Verdict.NO_CHANGE)
+
+
+def test_surface_metrics_off_by_default() -> None:
+    old = _snap(["a"])
+    new = _snap(["a", "b", "c"])
+    result = checker.compare(old, new, scope_to_public_surface=False)
+    assert not any(
+        c.kind in (ChangeKind.PUBLIC_SURFACE_GREW, ChangeKind.PUBLIC_SURFACE_SHRANK)
+        for c in result.changes
+    )
+
+
+def test_metric_findings_suppressible(tmp_path) -> None:
+    from abicheck.suppression import Suppression, SuppressionList
+
+    old = _snap(["a"])
+    new = _snap(["a", "b", "c"])
+    supp = SuppressionList(
+        [Suppression(symbol="<surface>", change_kind="public_surface_grew")]
+    )
+    result = checker.compare(
+        old, new, suppression=supp, scope_to_public_surface=False, surface_metrics=True
+    )
+    assert not any(c.kind == ChangeKind.PUBLIC_SURFACE_GREW for c in result.changes)
+    assert any(
+        c.kind == ChangeKind.PUBLIC_SURFACE_GREW for c in result.suppressed_changes
+    )

--- a/tests/test_surface_metrics_drift.py
+++ b/tests/test_surface_metrics_drift.py
@@ -100,7 +100,7 @@ def test_surface_metrics_off_by_default() -> None:
     )
 
 
-def test_metric_findings_suppressible(tmp_path) -> None:
+def test_metric_findings_suppressible() -> None:
     from abicheck.suppression import Suppression, SuppressionList
 
     old = _snap(["a"])

--- a/tests/test_surface_metrics_drift.py
+++ b/tests/test_surface_metrics_drift.py
@@ -86,8 +86,24 @@ def test_metric_kinds_are_compatible() -> None:
     }
     emitted = {c.kind for c in result.changes}
     assert metric_kinds & emitted  # at least the grow + ratio findings present
-    # All metric findings classify compatible; verdict stays non-breaking.
-    assert result.verdict in (Verdict.COMPATIBLE, Verdict.NO_CHANGE)
+    # All metric findings classify compatible; verdict stays non-breaking. Since
+    # changes were emitted it must be COMPATIBLE, not NO_CHANGE (ADR-027 review:
+    # the verdict is recomputed after the surface-metrics roll-ups are appended).
+    assert result.verdict == Verdict.COMPATIBLE
+
+
+def test_surface_metrics_recompute_verdict_not_no_change() -> None:
+    # Regression: surface-metric roll-ups are appended after the verdict is first
+    # computed. Without a recompute the verdict would stay NO_CHANGE while
+    # `changes` carries a public_surface_grew finding — an inconsistent report.
+    old = _snap(["a"])
+    new = _snap(["a", "b", "c"])
+    result = checker.compare(
+        old, new, scope_to_public_surface=False, surface_metrics=True
+    )
+    assert any(c.kind == ChangeKind.PUBLIC_SURFACE_GREW for c in result.changes)
+    assert result.verdict == Verdict.COMPATIBLE
+    assert result.verdict != Verdict.NO_CHANGE
 
 
 def test_surface_metrics_off_by_default() -> None:


### PR DESCRIPTION
## Summary

Implements the remaining phases of [ADR-027 — API Surface Intelligence](https://github.com/napetrov/abicheck/blob/main/docs/development/adr/027-api-surface-intelligence.md), building on the previously-landed A4 core (the per-finding `effective_verdict` override). **All ADR-027 phases are now implemented** (Phases 0–5); the only intentional non-item is flipping `--pattern-verdicts` to default-on, which the ADR itself defers until FP-rate + parity validation across a release cycle.

7 new `ChangeKind`s (192 → 199).

### A2 — anti-pattern recognition (D2.2)
| Kind | Category | Source |
|------|----------|--------|
| `public_api_exposes_stl_by_value` | RISK | single-snapshot (`surface-report --anti-patterns`; diff-time when newly introduced) |
| `polymorphic_type_non_virtual_dtor` | RISK | single-snapshot |
| `opaque_invariant_broken` | BREAKING | idiom transition (opacity lost) |
| `handle_type_changed` | BREAKING | idiom transition (handle token changed) |

`idioms.detect_antipatterns()` recognises the RISK pair; `surface-report` gains `--anti-patterns`. Base/factory targets resolve to a specific snapshot type (exact qualified, or unambiguous short) so same-short-name types across namespaces don't cross-match.

### A4 — pattern-aware verdicts (D4)
New `pattern_verdicts.py` modulation pass (after post-processing, before the recomputed verdict — the structural twin of ADR-024's `FilterNonPublicSurface`):
- **Demote** opaque-pointer / PIMPL-pointee layout changes (`effective_verdict` + disclosed reason). Guards: gated to `header_aware`, idiom must hold on **both** snapshots, never overrides a frozen-namespace break, PIMPL demote only when the wrapper's own layout is byte-identical, and all matching requires exact-or-unambiguous qualified type identity.
- **Raise** `opaque_invariant_broken` / `handle_type_changed` when a guarantee is lost — emitted **instead** of any silent demotion (only when the definition becomes visible or a by-value use appears; a still-incomplete type is left alone).
- Emit newly-introduced anti-patterns as RISK; annotate findings on an anti-pattern surface (pure raise).

The `effective_verdict` override is honoured at **every** classification site (reporter JSON `severity` + `filtered_summary` + leaf + text splits + `--show-only` filter, `severity.compute_exit_code`/`categorize_changes`, SARIF level, JUnit failure), enforced by a cross-output completeness test. Synthetic pattern findings are run through user suppressions before the verdict is recomputed.

### A3 — cross-library reasoning (D3.2)
Tightens the existing `BUNDLE_INTRA_TYPE_CHANGED` (no parallel `CROSS_LIBRARY_*` family). `BundleFinding` gains `effective_verdict`/`modulation_reason`/`modulation_rule`, propagated onto the lowered `Change` so the demotion reaches `bundle_verdict` and the `compare-release` exit code. A cross-DSO type change a consumer references only via internal (non-exported) symbols is **demoted to risk** (`consumer-internal-use`), never dropped; when the type leaks into a symbol the consumer exports it stays a full break. ELF exported-symbol membership is the public-surface proxy (the bundle path carries ELF metadata, not full type graphs).

### A1 metric drift — Phase 5 (D1.2)
`compare --surface-metrics` (opt-in) emits aggregate `COMPATIBLE` roll-ups: `public_surface_grew` / `public_surface_shrank`, `undocumented_export_ratio_increased`. Never breaking on their own.

### CLI / disclosure
- `--pattern-verdicts/--no-pattern-verdicts`, `--explain-patterns`, `--surface-metrics` (grouped via `cli_options.adr027_compare_options`).
- `pattern_modulations` ledger in JSON (full **and** leaf mode); per-finding modulation fields disclosed on each change. Audit-ledger printers in `cli_audit.py`.

> Idiom evidence is recomputed at diff time from the persisted declaration graph (D2.4 intent) — no schema bump. Older/ELF-only snapshots degrade to "no idiom evidence" → modulation simply doesn't fire (safe default).

## Testing & gates
- New `tests/test_pattern_verdicts.py`, `tests/test_surface_metrics_drift.py`, anti-pattern tests in `test_idioms.py`, A3 reachability tests in `test_bundle.py`.
- `ruff check`, `mypy`, `check_ai_readiness.py` (0 errors), `check_fp_rate.py` (0/0), `mkdocs build --strict` all clean.
- Fast lane: **8341 passed**, coverage **95.75%** (≥ 95% floor). New modules added to the `mutmut` target set.

## Review feedback
All Codex review comments addressed (lost-invariant scope, `--show-only` effective-verdict filtering, pattern-finding suppression, short-name ambiguity in idiom matching / PIMPL pointee / anti-patterns, leaf-JSON modulation metadata).

https://claude.ai/code/session_018PZ3j6YJhPN9TywDxQ8MPf

---
_Generated by [Claude Code](https://claude.ai/code/session_018PZ3j6YJhPN9TywDxQ8MPf)_