### PR TITLE
Filter stdlib vtable symbols from ELF ABI surface

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -41,6 +41,7 @@ from .model import (
     AbiSnapshot,
     Visibility,
     cv_qualifiers_only_differ,
+    is_cxx_runtime_library,
     is_non_abi_surface_type,
     stdlib_namespaces_excluded,
 )
@@ -300,11 +301,15 @@ def _diff_visibility_leak(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if not getattr(old, "elf_only_mode", False):
         return []
 
+    filter_transitive_runtime_symbols = not is_cxx_runtime_library(old.library)
     leaked = [
         f for f in old.functions
         if (
             f.visibility == Visibility.ELF_ONLY
-            and is_abi_relevant_elf_symbol(f.name)
+            and is_abi_relevant_elf_symbol(
+                f.name,
+                filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+            )
             and _looks_internal(f.name)
         )
     ]

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -44,6 +44,7 @@ from .model import (
     canonicalize_type_name,
     cv_qualifiers_only_differ,
     is_abi_surface_type_name,
+    is_cxx_runtime_library,
     stdlib_namespaces_excluded,
 )
 
@@ -123,13 +124,17 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     theory hide a genuine removal — but DWARF-primary snapshots carry the full
     ``.dynsym``, so in practice the export set is authoritative here.
     """
+    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
     funcs = {
         k: v for k, v in snap.function_map.items()
         if (
             v.visibility in _PUBLIC_VIS
             and (
                 v.visibility != Visibility.ELF_ONLY
-                or is_abi_relevant_elf_symbol(k)
+                or is_abi_relevant_elf_symbol(
+                    k,
+                    filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+                )
             )
         )
     }
@@ -140,6 +145,7 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
         elf,
         FUNCTION_SYMBOL_TYPES,
         abi_relevant_only=True,
+        filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
     )
     return {
         k: v for k, v in funcs.items()
@@ -154,13 +160,17 @@ def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:
     other in-function types): they are not nameable public ABI and only churn
     across builds (RD2-4).
     """
+    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
     return {
         k: v for k, v in snap.variable_map.items()
         if (
             v.visibility in _PUBLIC_VIS
             and (
                 v.visibility != Visibility.ELF_ONLY
-                or is_abi_relevant_elf_symbol(k)
+                or is_abi_relevant_elf_symbol(
+                    k,
+                    filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+                )
             )
             and not _is_local_type_rtti(k)
         )
@@ -1819,11 +1829,15 @@ def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:
     """
     if snap.elf is None:
         return {}
+    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
     result: dict[str, FunctionFingerprint] = {}
     for sym in snap.elf.symbols:
         if sym.sym_type not in _FUNC_LIKE_TYPES:
             continue
-        if not is_abi_relevant_elf_symbol(sym.name):
+        if not is_abi_relevant_elf_symbol(
+            sym.name,
+            filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+        ):
             continue
         if sym.size < _MIN_SYMBOL_SIZE:
             continue
@@ -1864,15 +1878,25 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
 
     old_elf = getattr(old, "elf", None)
     new_elf = getattr(new, "elf", None)
+    old_filter_transitive_runtime_symbols = not is_cxx_runtime_library(old.library)
+    new_filter_transitive_runtime_symbols = not is_cxx_runtime_library(new.library)
     old_exported_funcs = {
         sym.name
         for sym in (old_elf.symbols if old_elf is not None else [])
-        if sym.sym_type in _FUNC_LIKE_TYPES and is_abi_relevant_elf_symbol(sym.name)
+        if sym.sym_type in _FUNC_LIKE_TYPES
+        and is_abi_relevant_elf_symbol(
+            sym.name,
+            filter_transitive_runtime_symbols=old_filter_transitive_runtime_symbols,
+        )
     }
     new_exported_funcs = {
         sym.name
         for sym in (new_elf.symbols if new_elf is not None else [])
-        if sym.sym_type in _FUNC_LIKE_TYPES and is_abi_relevant_elf_symbol(sym.name)
+        if sym.sym_type in _FUNC_LIKE_TYPES
+        and is_abi_relevant_elf_symbol(
+            sym.name,
+            filter_transitive_runtime_symbols=new_filter_transitive_runtime_symbols,
+        )
     }
     retained_exported_funcs = old_exported_funcs & new_exported_funcs
     old_fps = {

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -36,6 +36,7 @@ from .model import (
     TypeField,
     canonicalize_type_name,
     cv_qualifiers_only_differ,
+    is_cxx_runtime_library,
 )
 from .model import is_non_abi_surface_type as _is_non_abi_surface_type
 from .model import stdlib_namespaces_excluded as _exclude_stdlib_namespaces
@@ -50,8 +51,12 @@ def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: Collection[st
     the DWARF-derived Function/Variable lists. Transitive runtime/compiler
     exports are excluded so they can't inflate retention.
     """
+    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
     return exported_symbol_names(
-        getattr(snap, "elf", None), symbol_types, abi_relevant_only=True
+        getattr(snap, "elf", None),
+        symbol_types,
+        abi_relevant_only=True,
+        filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
     )
 
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -56,6 +56,7 @@ from .model import (
     RecordType,
     Variable,
     Visibility,
+    is_cxx_runtime_library,
 )
 
 log = logging.getLogger(__name__)
@@ -744,6 +745,7 @@ def _elf_classify_symbols(
     exported_dynamic_objects: set[str] = set()
     exported_dynamic_tls: set[str] = set()
     if elf_meta.symbols:
+        filter_transitive_runtime_symbols = not is_cxx_runtime_library(elf_meta.soname)
         # Apply the shared ABI-relevance filter here too: this no-header path
         # rebuilds the exported sets directly from ``elf_meta.symbols`` rather
         # than the already-filtered ``_pyelftools_exported_symbols`` result, so
@@ -753,17 +755,26 @@ def _elf_classify_symbols(
         exported_dynamic_funcs = {
             sym.name for sym in elf_meta.symbols
             if sym.sym_type in (SymbolType.FUNC, SymbolType.IFUNC, SymbolType.NOTYPE)
-            and is_abi_relevant_elf_symbol(sym.name)
+            and is_abi_relevant_elf_symbol(
+                sym.name,
+                filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+            )
         }
         exported_dynamic_objects = {
             sym.name for sym in elf_meta.symbols
             if sym.sym_type == SymbolType.OBJECT
-            and is_abi_relevant_elf_symbol(sym.name)
+            and is_abi_relevant_elf_symbol(
+                sym.name,
+                filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+            )
         }
         exported_dynamic_tls = {
             sym.name for sym in elf_meta.symbols
             if sym.sym_type == SymbolType.TLS
-            and is_abi_relevant_elf_symbol(sym.name)
+            and is_abi_relevant_elf_symbol(
+                sym.name,
+                filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+            )
         }
         # Full set for CastxmlParser: determines PUBLIC vs ELF_ONLY visibility
         exported_dynamic = exported_dynamic_funcs | exported_dynamic_objects | exported_dynamic_tls

--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -419,9 +419,10 @@ class _DwarfSnapshotBuilder:
 
     def _is_abi_relevant_export(self, name: str) -> bool:
         """Return True when *name* belongs to this DSO's own ABI surface."""
-        if not self._filter_transitive_runtime_symbols:
-            return bool(name)
-        return is_abi_relevant_elf_symbol(name)
+        return is_abi_relevant_elf_symbol(
+            name,
+            filter_transitive_runtime_symbols=self._filter_transitive_runtime_symbols,
+        )
 
     def _process_param(self, die: Any, CU: Any) -> Param | None:
         """Extract a parameter from DW_TAG_formal_parameter."""

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -79,14 +79,23 @@ _STDLIB_PREFIXES = (
 _STDLIB_RTTI_PREFIXES = (
     "_ZTISt",             # typeinfo for std::* / std::exception, etc.
     "_ZTSSt",             # typeinfo name for std::* / std::exception, etc.
+    "_ZTVSt",             # vtable for std::* / std::exception, etc.
+    "_ZTTSt",             # VTT for std::* / std::exception, etc.
     "_ZTINSt",            # typeinfo for nested std::* names
     "_ZTSNSt",            # typeinfo name for nested std::* names
+    "_ZTVNSt",            # vtable for nested std::* names
+    "_ZTTNSt",            # VTT for nested std::* names
     "_ZTIN9__gnu_cxx",
     "_ZTSN9__gnu_cxx",
+    "_ZTVN9__gnu_cxx",
+    "_ZTTN9__gnu_cxx",
     "_ZTIN10__cxxabiv",
     "_ZTSN10__cxxabiv",
+    "_ZTTN10__cxxabiv",
     "_ZTIN7__cxx11",
     "_ZTSN7__cxx11",
+    "_ZTVN7__cxx11",
+    "_ZTTN7__cxx11",
 )
 
 def is_abi_relevant_elf_symbol(name: str) -> bool:

--- a/abicheck/elf_symbol_filter.py
+++ b/abicheck/elf_symbol_filter.py
@@ -98,13 +98,21 @@ _STDLIB_RTTI_PREFIXES = (
     "_ZTTN7__cxx11",
 )
 
-def is_abi_relevant_elf_symbol(name: str) -> bool:
+def is_abi_relevant_elf_symbol(
+    name: str,
+    *,
+    filter_transitive_runtime_symbols: bool = True,
+) -> bool:
     """Return False for ELF symbols that are not the library's own ABI.
 
     This filter must be shared by both the ELF-only and DWARF-backed snapshot
     paths. Otherwise a weak transitive libstdc++ export can be excluded from
     symbols-only reports yet re-enter as a ``PUBLIC`` DWARF function, producing
     false ``FUNC_REMOVED`` and type-reachability findings.
+
+    Set *filter_transitive_runtime_symbols* to ``False`` when the inspected DSO
+    is itself the C++ runtime (``libstdc++`` / ``libc++``): stdlib exports are
+    then the library's own ABI surface, not a transitive dependency leak.
     """
     if not name:
         return False
@@ -116,13 +124,14 @@ def is_abi_relevant_elf_symbol(name: str) -> bool:
         if name.startswith(prefix):
             return False
 
-    for prefix in _STDLIB_PREFIXES:
-        if name.startswith(prefix):
-            return False
+    if filter_transitive_runtime_symbols:
+        for prefix in _STDLIB_PREFIXES:
+            if name.startswith(prefix):
+                return False
 
-    for prefix in _STDLIB_RTTI_PREFIXES:
-        if name.startswith(prefix):
-            return False
+        for prefix in _STDLIB_RTTI_PREFIXES:
+            if name.startswith(prefix):
+                return False
 
     # Private C symbols with __ as a namespace separator
     # (e.g. H5C__flush_marked_entries, MPI__send). C++ mangled names start
@@ -138,6 +147,7 @@ def exported_symbol_names(
     symbol_types: Collection[str],
     *,
     abi_relevant_only: bool = False,
+    filter_transitive_runtime_symbols: bool = True,
 ) -> set[str]:
     """Return dynamic-export names of the requested ``symbol_types`` from *elf*.
 
@@ -159,7 +169,10 @@ def exported_symbol_names(
         sym_type = getattr(sym.sym_type, "value", sym.sym_type)
         if sym_type not in symbol_types:
             continue
-        if abi_relevant_only and not is_abi_relevant_elf_symbol(sym.name):
+        if abi_relevant_only and not is_abi_relevant_elf_symbol(
+            sym.name,
+            filter_transitive_runtime_symbols=filter_transitive_runtime_symbols,
+        ):
             continue
         names.add(sym.name)
     return names

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -102,6 +102,10 @@ def test_private_double_underscore_symbols_are_filtered(name: str) -> None:
     "_ZTVN10__cxxabiv121__vmi_class_type_infoE",
     "_ZTISt9exception",
     "_ZTSSt9bad_alloc",
+    "_ZTVSt23_Sp_counted_ptr_inplaceINSt13__future_base15_Deferred_stateE",
+    "_ZTVNSt13__future_base17_Async_state_implE",
+    "_ZTTSt23_Sp_counted_ptr_inplaceINSt13__future_base15_Deferred_stateE",
+    "_ZTTNSt13__future_base17_Async_state_implE",
     # std:: global symbols
     "_ZSt4cout",
     "_ZSt4cerr",

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -319,6 +319,33 @@ def test_exported_symbol_names_abi_relevant_only_drops_transitive_runtime() -> N
     }
 
 
+def test_exported_symbol_names_can_preserve_runtime_owned_stdlib_exports() -> None:
+    """Symbols-only C++ runtime snapshots must keep their own stdlib exports."""
+    meta = ElfMetadata(
+        soname="libstdc++.so.6",
+        symbols=[
+            ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_ZTVSt9exception", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="_ZTTSt23_Sp_counted_ptr_inplaceE", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="__cpu_model", sym_type=SymbolType.OBJECT),
+        ],
+    )
+
+    assert exported_symbol_names(
+        meta,
+        FUNCTION_SYMBOL_TYPES,
+        abi_relevant_only=True,
+        filter_transitive_runtime_symbols=False,
+    ) == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
+    assert exported_symbol_names(
+        meta,
+        VARIABLE_SYMBOL_TYPES,
+        abi_relevant_only=True,
+        filter_transitive_runtime_symbols=False,
+    ) == {"_ZTVSt9exception", "_ZTTSt23_Sp_counted_ptr_inplaceE"}
+
+
 def test_elf_classify_symbols_filters_lifecycle_stubs_at_dump_surface() -> None:
     """The no-header dump path must drop lifecycle stubs from the ABI surface.
 
@@ -349,6 +376,29 @@ def test_elf_classify_symbols_filters_lifecycle_stubs_at_dump_surface() -> None:
     assert objects == {"g_table"}
     assert tls == {"tls_var"}
     assert full == {"api", "g_table", "tls_var"}
+
+
+def test_elf_classify_symbols_preserves_runtime_owned_stdlib_exports() -> None:
+    """The no-header path must not hide libstdc++'s own vtables/VTT exports."""
+    from abicheck.dumper import _elf_classify_symbols
+
+    meta = ElfMetadata(
+        soname="libstdc++.so.6",
+        symbols=[
+            ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_ZTVSt9exception", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="_ZTTSt23_Sp_counted_ptr_inplaceE", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="__cpu_model", sym_type=SymbolType.OBJECT),
+        ],
+    )
+
+    full, funcs, objects, tls = _elf_classify_symbols(meta, set())
+
+    assert funcs == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
+    assert objects == {"_ZTVSt9exception", "_ZTTSt23_Sp_counted_ptr_inplaceE"}
+    assert tls == set()
+    assert full == funcs | objects
 
 
 def _function(name: str) -> Function:
@@ -408,6 +458,26 @@ def test_public_functions_uses_abi_relevant_export_filter() -> None:
     assert set(_public_functions(snap)) == {"lib_init"}
 
 
+def test_public_functions_preserves_runtime_owned_stdlib_exports() -> None:
+    snap = AbiSnapshot(
+        library="libstdc++.so.6",
+        version="1",
+        functions=[
+            _function("_ZNSt6vectorIiSaIiEE4sizeEv"),
+            _function("_init"),
+        ],
+        elf=ElfMetadata(
+            soname="libstdc++.so.6",
+            symbols=[
+                ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ],
+        ),
+    )
+
+    assert set(_public_functions(snap)) == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
+
+
 def _variable(name: str) -> Variable:
     return Variable(
         name=name,
@@ -430,6 +500,23 @@ def test_public_variables_filters_elf_only_linker_artifacts() -> None:
     )
 
     assert set(_public_variables(snap)) == {"public_table"}
+
+
+def test_public_variables_preserves_runtime_owned_stdlib_vtables() -> None:
+    snap = AbiSnapshot(
+        library="libstdc++.so.6",
+        version="1",
+        variables=[
+            _variable("_ZTVSt9exception"),
+            _variable("_ZTTSt23_Sp_counted_ptr_inplaceE"),
+            _variable("__cpu_model"),
+        ],
+    )
+
+    assert set(_public_variables(snap)) == {
+        "_ZTVSt9exception",
+        "_ZTTSt23_Sp_counted_ptr_inplaceE",
+    }
 
 
 def test_exported_symbol_names_abi_relevant_only_drops_linker_boundaries() -> None:


### PR DESCRIPTION
## Summary
- extend the shared ELF ABI-relevance filter to drop transitive stdlib vtable/VTT symbols alongside existing stdlib RTTI/typeinfo filtering
- add regression coverage for stdlib `_ZTV*` and `_ZTT*` symbols that can leak through weak/transitive exports

## Real-world validation
Found during the recurring real-world sweep against conda-forge `libheif`:

- `libheif` 1.20.2 -> 1.20.3, `libheif.so.1`
- before fix: `BREAKING` with false-positive removed stdlib symbols such as `_ZTVSt...`, `_ZTVNSt...`, `_ZTTSt...`, `_ZTTNSt...`
- after fix: the same comparison no longer reports those transitive stdlib vtable/VTT symbols as ABI-relevant

Evidence paths in the campaign workspace:
- `reports/abicheck-realworld-cron/evidence-20260606-2145/20260606-2145-libheif__heif.json`
- `reports/abicheck-realworld-cron/run-20260606-2145-libheif__heif-after-fix.json`
- `reports/abicheck-realworld-cron/run-20260606-2145-libheif__heif-abidiff.txt`

## Tests
- `pytest tests/test_elf_symbol_filters.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ABI compatibility checking to properly handle transitive C++ runtime and standard library symbols, ensuring more accurate detection of binary incompatibilities for C++ runtime libraries.

* **Tests**
  * Extended test coverage for ELF symbol filtering and ABI relevance detection to validate correct handling of standard library exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->