### PR TITLE
Avoid marking project RTTI as leaked libstdc++ symbols

### DIFF
--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -450,7 +450,27 @@ _ORIGIN_PREFIX_TABLE: list[tuple[tuple[str, ...], _FinderFn | None, str]] = [
     # libc++ inline namespace __1 — must be checked BEFORE generic _ZNSt
     (("_ZNSt3__1", "_ZNKSt3__1"), _find_libcxx, "libc++.so.1"),
     # C++ stdlib symbols (libstdc++ / libc++)
-    (("_ZNSt", "_ZNKSt", "_ZSt", "_ZTI", "_ZTS", "_ZTVN10__cxxabiv"), _find_cxx_stdlib, "libstdc++.so.6"),
+    (
+        (
+            "_ZNSt",
+            "_ZNKSt",
+            "_ZSt",
+            "_ZTISt",
+            "_ZTSSt",
+            "_ZTVSt",
+            "_ZTINSt",
+            "_ZTSNSt",
+            "_ZTVNSt",
+            "_ZTIN9__gnu_cxx",
+            "_ZTSN9__gnu_cxx",
+            "_ZTVN9__gnu_cxx",
+            "_ZTIN10__cxxabiv",
+            "_ZTSN10__cxxabiv",
+            "_ZTVN10__cxxabiv",
+        ),
+        _find_cxx_stdlib,
+        "libstdc++.so.6",
+    ),
     # C++ operator new / delete (Itanium ABI)
     (("_Znwm", "_Znwj", "_Znam", "_Znaj", "_ZdlPv", "_ZdaPv", "_ZnwmSt", "_ZnamSt"), _find_cxx_stdlib, "libstdc++.so.6"),
     # Intel SVML

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -538,7 +538,7 @@ _FUNDAMENTAL_CXX_RTTI_MULTI_CHAR_TYPE_CODES: frozenset[str] = frozenset({
     "De",  # decimal128
 })
 
-_CXX_SIZED_FLOAT_TYPE_CODE_RE = re.compile(r"DF[0-9]+_")
+_CXX_SIZED_FLOAT_TYPE_CODE_RE = re.compile(r"DF[0-9]+(?:_|[A-Za-z]+)")
 
 _FUNDAMENTAL_CXX_RTTI_TYPE_MODIFIERS: frozenset[str] = frozenset({
     "P",  # pointer

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -443,6 +444,17 @@ def _find_cxx_stdlib(needed_libs: list[str]) -> str | None:
     return None
 
 
+def _find_fundamental_cxx_rtti_runtime(needed_libs: list[str]) -> str | None:
+    """Find the C++ runtime that owns fundamental RTTI, excluding libc++abi."""
+    for lib in needed_libs:
+        if "stdc++" in os.path.basename(lib):
+            return lib
+    for lib in needed_libs:
+        if os.path.basename(lib).startswith("libc++."):
+            return lib
+    return None
+
+
 # Lookup table: (prefix_tuple, finder_fn_or_None, default_if_no_finder_match)
 # When finder_fn is None, default is returned unconditionally.
 _FinderFn = Callable[[list[str]], str | None]
@@ -458,6 +470,9 @@ _ORIGIN_PREFIX_TABLE: list[tuple[tuple[str, ...], _FinderFn | None, str]] = [
             "_ZTISt",
             "_ZTSSt",
             "_ZTVSt",
+            "_ZTIS",
+            "_ZTSS",
+            "_ZTVS",
             "_ZTINSt",
             "_ZTSNSt",
             "_ZTVNSt",
@@ -523,6 +538,8 @@ _FUNDAMENTAL_CXX_RTTI_MULTI_CHAR_TYPE_CODES: frozenset[str] = frozenset({
     "De",  # decimal128
 })
 
+_CXX_SIZED_FLOAT_TYPE_CODE_RE = re.compile(r"DF[0-9]+_")
+
 _FUNDAMENTAL_CXX_RTTI_TYPE_MODIFIERS: frozenset[str] = frozenset({
     "P",  # pointer
     "R",  # lvalue reference
@@ -539,6 +556,8 @@ def _is_fundamental_cxx_type_encoding(encoding: str) -> bool:
         if encoding in _FUNDAMENTAL_CXX_RTTI_SINGLE_CHAR_TYPE_CODES:
             return True
         if encoding in _FUNDAMENTAL_CXX_RTTI_MULTI_CHAR_TYPE_CODES:
+            return True
+        if _CXX_SIZED_FLOAT_TYPE_CODE_RE.fullmatch(encoding):
             return True
         if encoding[0] not in _FUNDAMENTAL_CXX_RTTI_TYPE_MODIFIERS:
             return False
@@ -569,7 +588,7 @@ def _guess_symbol_origin(name: str, needed_libs: list[str]) -> str | None:
     :class:`ElfSymbol`; it is informational and never suppresses real changes.
     """
     if _is_fundamental_cxx_rtti_symbol(name):
-        return _find_cxx_stdlib(needed_libs) or "libstdc++.so.6"
+        return _find_fundamental_cxx_rtti_runtime(needed_libs) or "libstdc++.so.6"
 
     for prefixes, finder_fn, default in _ORIGIN_PREFIX_TABLE:
         if name.startswith(prefixes):

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -488,7 +488,7 @@ _ORIGIN_PREFIX_TABLE: list[tuple[tuple[str, ...], _FinderFn | None, str]] = [
 ]
 
 
-_FUNDAMENTAL_CXX_RTTI_TYPE_CODES: frozenset[str] = frozenset({
+_FUNDAMENTAL_CXX_RTTI_SINGLE_CHAR_TYPE_CODES: frozenset[str] = frozenset({
     "v",   # void
     "w",   # wchar_t
     "b",   # bool
@@ -510,17 +510,47 @@ _FUNDAMENTAL_CXX_RTTI_TYPE_CODES: frozenset[str] = frozenset({
     "e",   # long double
     "g",   # __float128
     "z",   # ellipsis
+})
+
+_FUNDAMENTAL_CXX_RTTI_MULTI_CHAR_TYPE_CODES: frozenset[str] = frozenset({
     "Dn",  # std::nullptr_t
+    "Du",  # char8_t
     "Di",  # char32_t
     "Ds",  # char16_t
+    "Dh",  # half-precision floating point
+    "Df",  # decimal32
+    "Dd",  # decimal64
+    "De",  # decimal128
 })
+
+_FUNDAMENTAL_CXX_RTTI_TYPE_MODIFIERS: frozenset[str] = frozenset({
+    "P",  # pointer
+    "R",  # lvalue reference
+    "O",  # rvalue reference
+    "K",  # const qualifier
+    "V",  # volatile qualifier
+    "r",  # restrict qualifier
+})
+
+
+def _is_fundamental_cxx_type_encoding(encoding: str) -> bool:
+    """Return True for builtin Itanium C++ type encodings and simple wrappers."""
+    while encoding:
+        if encoding in _FUNDAMENTAL_CXX_RTTI_SINGLE_CHAR_TYPE_CODES:
+            return True
+        if encoding in _FUNDAMENTAL_CXX_RTTI_MULTI_CHAR_TYPE_CODES:
+            return True
+        if encoding[0] not in _FUNDAMENTAL_CXX_RTTI_TYPE_MODIFIERS:
+            return False
+        encoding = encoding[1:]
+    return False
 
 
 def _is_fundamental_cxx_rtti_symbol(name: str) -> bool:
     """Return True for libstdc++ RTTI/typeinfo-name symbols for builtin types."""
     if not (name.startswith("_ZTI") or name.startswith("_ZTS")):
         return False
-    return name[4:] in _FUNDAMENTAL_CXX_RTTI_TYPE_CODES
+    return _is_fundamental_cxx_type_encoding(name[4:])
 
 
 def _guess_symbol_origin(name: str, needed_libs: list[str]) -> str | None:

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -488,6 +488,41 @@ _ORIGIN_PREFIX_TABLE: list[tuple[tuple[str, ...], _FinderFn | None, str]] = [
 ]
 
 
+_FUNDAMENTAL_CXX_RTTI_TYPE_CODES: frozenset[str] = frozenset({
+    "v",   # void
+    "w",   # wchar_t
+    "b",   # bool
+    "c",   # char
+    "a",   # signed char
+    "h",   # unsigned char
+    "s",   # short
+    "t",   # unsigned short
+    "i",   # int
+    "j",   # unsigned int
+    "l",   # long
+    "m",   # unsigned long
+    "x",   # long long
+    "y",   # unsigned long long
+    "n",   # __int128
+    "o",   # unsigned __int128
+    "f",   # float
+    "d",   # double
+    "e",   # long double
+    "g",   # __float128
+    "z",   # ellipsis
+    "Dn",  # std::nullptr_t
+    "Di",  # char32_t
+    "Ds",  # char16_t
+})
+
+
+def _is_fundamental_cxx_rtti_symbol(name: str) -> bool:
+    """Return True for libstdc++ RTTI/typeinfo-name symbols for builtin types."""
+    if not (name.startswith("_ZTI") or name.startswith("_ZTS")):
+        return False
+    return name[4:] in _FUNDAMENTAL_CXX_RTTI_TYPE_CODES
+
+
 def _guess_symbol_origin(name: str, needed_libs: list[str]) -> str | None:
     """Guess which dependency library a symbol likely originates from.
 
@@ -503,6 +538,9 @@ def _guess_symbol_origin(name: str, needed_libs: list[str]) -> str | None:
     itself.  The result is used to annotate the ``origin_lib`` field of
     :class:`ElfSymbol`; it is informational and never suppresses real changes.
     """
+    if _is_fundamental_cxx_rtti_symbol(name):
+        return _find_cxx_stdlib(needed_libs) or "libstdc++.so.6"
+
     for prefixes, finder_fn, default in _ORIGIN_PREFIX_TABLE:
         if name.startswith(prefixes):
             if finder_fn is not None:

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -80,6 +80,9 @@ class TestGuessSymbolOrigin:
             "_ZTIDF32_",      # typeinfo for _Float32
             "_ZTIPDF16_",     # typeinfo for _Float16*
             "_ZTIPKDF128_",   # typeinfo for _Float128 const*
+            "_ZTIDF16b",      # typeinfo for std::bfloat16_t
+            "_ZTIPDF32x",     # typeinfo for _Float32x*
+            "_ZTIPKDF64x",    # typeinfo for _Float64x const*
         ],
     )
     def test_cxx_fundamental_rtti_returns_libstdcxx(self, symbol):

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -56,6 +56,16 @@ class TestGuessSymbolOrigin:
         result = _guess_symbol_origin("_ZTSSt11logic_error", [])
         assert result == "libstdc++.so.6"
 
+    def test_native_project_typeinfo_returns_none(self):
+        """Project-owned RTTI symbols must not be attributed to libstdc++."""
+        result = _guess_symbol_origin("_ZTIN11flatbuffers13FileNameSaverE", ["libstdc++.so.6"])
+        assert result is None
+
+    def test_native_project_typeinfo_name_returns_none(self):
+        """Project-owned typeinfo-name symbols must not be attributed to libstdc++."""
+        result = _guess_symbol_origin("_ZTSN11flatbuffers13FileNameSaverE", ["libstdc++.so.6"])
+        assert result is None
+
     def test_cxx_abi_vtable_returns_libstdcxx(self):
         """_ZTVN10__cxxabiv... → libstdc++ (C++ ABI vtable)."""
         result = _guess_symbol_origin("_ZTVN10__cxxabiv117__class_type_infoE", [])

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -8,6 +8,8 @@ Covers:
 """
 from __future__ import annotations
 
+import pytest
+
 from abicheck.checker_policy import (
     API_BREAK_KINDS,
     BREAKING_KINDS,
@@ -56,19 +58,30 @@ class TestGuessSymbolOrigin:
         result = _guess_symbol_origin("_ZTSSt11logic_error", [])
         assert result == "libstdc++.so.6"
 
-    def test_cxx_fundamental_typeinfo_returns_libstdcxx(self):
-        """_ZTIi → libstdc++ (typeinfo for int)."""
-        result = _guess_symbol_origin("_ZTIi", [])
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            "_ZTIi",     # typeinfo for int
+            "_ZTSi",     # typeinfo-name for int
+            "_ZTIPi",    # typeinfo for int*
+            "_ZTSPi",    # typeinfo-name for int*
+            "_ZTIPKi",   # typeinfo for int const*
+            "_ZTSPKi",   # typeinfo-name for int const*
+            "_ZTIDu",    # typeinfo for char8_t
+            "_ZTSDu",    # typeinfo-name for char8_t
+            "_ZTIDh",    # typeinfo for half
+            "_ZTIDf",    # typeinfo for decimal32
+        ],
+    )
+    def test_cxx_fundamental_rtti_returns_libstdcxx(self, symbol):
+        """Fundamental RTTI symbols are owned by the C++ runtime."""
+        result = _guess_symbol_origin(symbol, [])
         assert result == "libstdc++.so.6"
 
-    def test_cxx_fundamental_typeinfo_name_returns_libstdcxx(self):
-        """_ZTSi → libstdc++ (typeinfo-name for int)."""
-        result = _guess_symbol_origin("_ZTSi", [])
-        assert result == "libstdc++.so.6"
-
-    def test_cxx_fundamental_typeinfo_prefers_needed_libcxx(self):
+    @pytest.mark.parametrize("symbol", ["_ZTIi", "_ZTSi"])
+    def test_cxx_fundamental_rtti_prefers_needed_libcxx(self, symbol):
         """Fundamental RTTI attribution still honors the runtime in DT_NEEDED."""
-        result = _guess_symbol_origin("_ZTIi", ["libc++.so.1"])
+        result = _guess_symbol_origin(symbol, ["libc++.so.1"])
         assert result == "libc++.so.1"
 
     def test_native_project_typeinfo_returns_none(self):
@@ -79,6 +92,18 @@ class TestGuessSymbolOrigin:
     def test_native_project_typeinfo_name_returns_none(self):
         """Project-owned typeinfo-name symbols must not be attributed to libstdc++."""
         result = _guess_symbol_origin("_ZTSN11flatbuffers13FileNameSaverE", ["libstdc++.so.6"])
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            "_ZTIPN11flatbuffers13FileNameSaverE",
+            "_ZTSPN11flatbuffers13FileNameSaverE",
+        ],
+    )
+    def test_native_project_pointer_rtti_returns_none(self, symbol):
+        """Pointer RTTI for project types must not be attributed to libstdc++."""
+        result = _guess_symbol_origin(symbol, ["libstdc++.so.6"])
         assert result is None
 
     def test_cxx_abi_vtable_returns_libstdcxx(self):

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -58,6 +58,12 @@ class TestGuessSymbolOrigin:
         result = _guess_symbol_origin("_ZTSSt11logic_error", [])
         assert result == "libstdc++.so.6"
 
+    @pytest.mark.parametrize("symbol", ["_ZTISi", "_ZTSSi", "_ZTVSi"])
+    def test_cxx_stdlib_substitution_rtti_returns_libstdcxx(self, symbol):
+        """RTTI/vtable symbols using Itanium std substitutions are stdlib-owned."""
+        result = _guess_symbol_origin(symbol, [])
+        assert result == "libstdc++.so.6"
+
     @pytest.mark.parametrize(
         "symbol",
         [
@@ -71,6 +77,9 @@ class TestGuessSymbolOrigin:
             "_ZTSDu",    # typeinfo-name for char8_t
             "_ZTIDh",    # typeinfo for half
             "_ZTIDf",    # typeinfo for decimal32
+            "_ZTIDF32_",      # typeinfo for _Float32
+            "_ZTIPDF16_",     # typeinfo for _Float16*
+            "_ZTIPKDF128_",   # typeinfo for _Float128 const*
         ],
     )
     def test_cxx_fundamental_rtti_returns_libstdcxx(self, symbol):
@@ -83,6 +92,11 @@ class TestGuessSymbolOrigin:
         """Fundamental RTTI attribution still honors the runtime in DT_NEEDED."""
         result = _guess_symbol_origin(symbol, ["libc++.so.1"])
         assert result == "libc++.so.1"
+
+    def test_cxx_fundamental_rtti_does_not_select_libcxxabi(self):
+        """libc++abi should not be reported as the C++ stdlib owner."""
+        result = _guess_symbol_origin("_ZTIi", ["libc++abi.so.1"])
+        assert result == "libstdc++.so.6"
 
     def test_native_project_typeinfo_returns_none(self):
         """Project-owned RTTI symbols must not be attributed to libstdc++."""

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -56,6 +56,21 @@ class TestGuessSymbolOrigin:
         result = _guess_symbol_origin("_ZTSSt11logic_error", [])
         assert result == "libstdc++.so.6"
 
+    def test_cxx_fundamental_typeinfo_returns_libstdcxx(self):
+        """_ZTIi → libstdc++ (typeinfo for int)."""
+        result = _guess_symbol_origin("_ZTIi", [])
+        assert result == "libstdc++.so.6"
+
+    def test_cxx_fundamental_typeinfo_name_returns_libstdcxx(self):
+        """_ZTSi → libstdc++ (typeinfo-name for int)."""
+        result = _guess_symbol_origin("_ZTSi", [])
+        assert result == "libstdc++.so.6"
+
+    def test_cxx_fundamental_typeinfo_prefers_needed_libcxx(self):
+        """Fundamental RTTI attribution still honors the runtime in DT_NEEDED."""
+        result = _guess_symbol_origin("_ZTIi", ["libc++.so.1"])
+        assert result == "libc++.so.1"
+
     def test_native_project_typeinfo_returns_none(self):
         """Project-owned RTTI symbols must not be attributed to libstdc++."""
         result = _guess_symbol_origin("_ZTIN11flatbuffers13FileNameSaverE", ["libstdc++.so.6"])


### PR DESCRIPTION
## Summary
- Narrow C++ runtime-origin detection so `_ZTI*`/`_ZTS*` symbols are only attributed to libstdc++ for actual std/gnu/cxxabi namespaces.
- Keep project-owned RTTI/typeinfo symbols, such as FlatBuffers classes, classified as native exports.
- Add unit tests for FlatBuffers-style project RTTI and typeinfo-name symbols.

## Real-world validation
- Before fix: `flatbuffers 25.9.23 -> 25.12.19` reported `COMPATIBLE_WITH_RISK` with six `symbol_leaked_from_dependency_changed` findings for `_ZTI*`/`_ZTS*` FlatBuffers class symbols.
- After fix: the same conda-forge DSO comparison reports `COMPATIBLE` with `risk_changes: 0`; new RTTI/typeinfo symbols remain compatible additions.
- Evidence: `reports/abicheck-realworld-cron/evidence-20260607-0111/run-20260607-0111-flatbuffers__libflatbuffers-after-origin-fix.json` in the validation workspace.

## Tests
- `pytest tests/test_symbol_origin.py`
- Real-world FlatBuffers compare via `PYTHONPATH=/home/openclaw/.openclaw/workspace-abicheck/repo-rtti-origin-fix python -m abicheck.cli compare ... --format json --recommend`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of C++ standard-library symbols, including special handling for fundamental C++ RTTI/typeinfo so they map to the correct standard library (prefers libc++ when present) and project-owned RTTI/typeinfo are not misattributed.

* **Tests**
  * Added tests covering fundamental RTTI/typeinfo attribution and ensuring project-owned RTTI/pointer-typeinfo return no external origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->