### PR TITLE
Classify likely function renames as breaking

### DIFF
--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -415,7 +415,7 @@ REGISTRY = ChangeKindRegistry([
     _E("symbol_renamed_batch", _B,
        impact="Multiple symbols renamed (e.g. namespace prefix added/removed); "
               "old binaries reference the old names and will get undefined symbol errors at load time."),
-    _E("func_likely_renamed", _R,
+    _E("func_likely_renamed", _B,
        impact="Function likely renamed (binary fingerprint match: identical code size and hash, "
               "different symbol name). Old binaries reference the old name and will fail to "
               "resolve at load time. This is a heuristic signal — verify the rename is intentional."),

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -26,7 +26,7 @@ from abicheck.binary_fingerprint import (
     compute_section_summary,
     match_renamed_functions,
 )
-from abicheck.checker import ChangeKind, compare
+from abicheck.checker import ChangeKind, Verdict, compare
 from abicheck.diff_symbols import (
     _ctor_dtor_variant,
     _fingerprints_from_elf,
@@ -769,7 +769,7 @@ class TestFingerprintRenameDetector:
         assert set(_fingerprints_from_elf(snap)) == {"public_func"}
 
     def test_likely_renamed_detected_in_elf_only_mode(self) -> None:
-        """Renamed function with same size is detected as FUNC_LIKELY_RENAMED."""
+        """Renamed exported functions remain binary breaking after collapse."""
         old = _snap_elf_only("1.0", [_func_sym("libfoo_v1_create", 256)])
         new = _snap_elf_only("2.0", [_func_sym("libfoo_create", 256)])
         result = compare(old, new)
@@ -780,6 +780,9 @@ class TestFingerprintRenameDetector:
         assert len(rename_changes) == 1
         assert rename_changes[0].old_value == "libfoo_v1_create"
         assert rename_changes[0].new_value == "libfoo_create"
+        assert rename_changes[0].caused_count == 2
+        assert result.verdict == Verdict.BREAKING
+        assert result.breaking == rename_changes
 
     def test_not_triggered_without_elf_only_mode(self) -> None:
         """Detector is gated behind elf_only_mode — disabled for header-based analysis.

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -601,7 +601,7 @@ class TestCheckerIntegration:
         assert ChangeKind.SONAME_BUMP_RECOMMENDED in kinds
 
     def test_compare_soname_policy_uses_postprocessed_changes(self):
-        """A downgraded rename must not leave a stale SONAME bump advisory."""
+        """A breaking rename with unchanged SONAME should recommend a bump."""
         from abicheck.checker import compare
         from abicheck.checker_policy import Verdict
         from abicheck.model import AbiSnapshot, Function, Visibility
@@ -661,18 +661,17 @@ class TestCheckerIntegration:
         )
         kinds = {c.kind for c in result.changes}
 
-        assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+        assert result.verdict == Verdict.BREAKING
         assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
-        assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
+        assert ChangeKind.SONAME_BUMP_RECOMMENDED in kinds
 
     def test_compare_soname_unnecessary_uses_postprocessed_changes(self):
-        """SONAME bumped but the only change is a downgraded rename → UNNECESSARY.
+        """SONAME bumped for a breaking rename must not read as unnecessary.
 
         Exercises the second branch of check_soname_bump_policy through the
-        post-processed change set: because the breaking removed/added halves are
-        rename-redundant (and so excluded from the verdict input), there are no
-        binary-incompatible changes, so a SONAME bump reads as unnecessary —
-        and must not also emit the contradictory RECOMMENDED advisory.
+        post-processed change set: the removed/added halves are rename-redundant
+        and excluded from the verdict input, but the collapsed rename remains a
+        binary-incompatible change.
         """
         from abicheck.checker import compare
         from abicheck.checker_policy import Verdict
@@ -733,9 +732,9 @@ class TestCheckerIntegration:
         )
         kinds = {c.kind for c in result.changes}
 
-        assert result.verdict == Verdict.COMPATIBLE_WITH_RISK
+        assert result.verdict == Verdict.BREAKING
         assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
-        assert ChangeKind.SONAME_BUMP_UNNECESSARY in kinds
+        assert ChangeKind.SONAME_BUMP_UNNECESSARY not in kinds
         assert ChangeKind.SONAME_BUMP_RECOMMENDED not in kinds
 
     def test_compare_soname_bump_recommendation_honors_suppression(self):

--- a/tests/test_elf_version_policy.py
+++ b/tests/test_elf_version_policy.py
@@ -665,7 +665,7 @@ class TestCheckerIntegration:
         assert ChangeKind.FUNC_LIKELY_RENAMED in kinds
         assert ChangeKind.SONAME_BUMP_RECOMMENDED in kinds
 
-    def test_compare_soname_unnecessary_uses_postprocessed_changes(self):
+    def test_compare_soname_bump_not_unnecessary_for_breaking_rename(self):
         """SONAME bumped for a breaking rename must not read as unnecessary.
 
         Exercises the second branch of check_soname_bump_policy through the


### PR DESCRIPTION
## Summary
- classify `func_likely_renamed` as a breaking ABI change instead of compatible-with-risk
- keep collapsed rename evidence from hiding the binary-break verdict when an exported old symbol name disappears
- expand the fingerprint rename unit test to assert the BREAKING verdict after redundant removed/added symbols are collapsed

## Real-world evidence
During the recurring abicheck validation campaign, zstd 1.5.5 -> 1.5.7 showed three removed dynamic function symbols by both `abidiff` and raw `readelf --dyn-syms`:
- `ZSTD_copySequencesToSeqStoreExplicitBlockDelim`
- `ZSTD_copySequencesToSeqStoreNoBlockDelim`
- `ZSTD_decodeLiteralsBlock`

Before this change, abicheck collapsed the likely rename `ZSTD_copySequencesToSeqStoreExplicitBlockDelim -> ZSTD_compressSequencesAndLiterals` into a risk finding, so the JSON summary counted only 2 breaking changes. After the fix, the same comparison reports `breaking: 3`, matching the independent export evidence while still preserving the rename explanation.

Evidence path on validation host:
`reports/abicheck-realworld-cron/evidence-20260607-0908/run-20260607-0908-zstd__libzstd-after-fix.json`

## Tests
- `pytest -q tests/test_binary_fingerprint.py::TestFingerprintRenameDetector`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Function rename detection is now classified as a breaking change rather than compatible-with-risk.

* **Tests**
  * Strengthened test assertions to confirm renames produce breaking classifications and expected detected counts.
  * Updated integration test expectations for SONAME bump policy to reflect rename-related post-processing resulting in breaking outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->