### PR TITLE
Avoid libmvec origin for C++ guard variables

### DIFF
--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -455,6 +455,15 @@ def _find_fundamental_cxx_rtti_runtime(needed_libs: list[str]) -> str | None:
     return None
 
 
+def _is_libmvec_vector_symbol(name: str) -> bool:
+    """Return true for glibc libmvec vector ABI symbols, not C++ guard vars."""
+    if not name.startswith("_ZGV"):
+        return False
+    if name.startswith("_ZGVZ"):
+        return False
+    return len(name) > 4 and name[4] in {"b", "c", "d", "e", "n"}
+
+
 # Lookup table: (prefix_tuple, finder_fn_or_None, default_if_no_finder_match)
 # When finder_fn is None, default is returned unconditionally.
 _FinderFn = Callable[[list[str]], str | None]
@@ -490,8 +499,6 @@ _ORIGIN_PREFIX_TABLE: list[tuple[tuple[str, ...], _FinderFn | None, str]] = [
     (("_Znwm", "_Znwj", "_Znam", "_Znaj", "_ZdlPv", "_ZdaPv", "_ZnwmSt", "_ZnamSt"), _find_cxx_stdlib, "libstdc++.so.6"),
     # Intel SVML
     (("__svml_",), None, "<intel-compiler-rt>"),
-    # Vectorized math functions (libmvec)
-    (("_ZGV",), None, "libmvec.so.1"),
     # x87 math helpers (libgcc.a static)
     (("ix86_",), None, "libgcc.a (static)"),
     # libm SIMD helpers
@@ -589,6 +596,9 @@ def _guess_symbol_origin(name: str, needed_libs: list[str]) -> str | None:
     """
     if _is_fundamental_cxx_rtti_symbol(name):
         return _find_fundamental_cxx_rtti_runtime(needed_libs) or "libstdc++.so.6"
+
+    if _is_libmvec_vector_symbol(name):
+        return "libmvec.so.1"
 
     for prefixes, finder_fn, default in _ORIGIN_PREFIX_TABLE:
         if name.startswith(prefixes):

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -461,7 +461,7 @@ def _is_libmvec_vector_symbol(name: str) -> bool:
         return False
     if name.startswith("_ZGVZ"):
         return False
-    return len(name) > 4 and name[4] in {"b", "c", "d", "e", "n"}
+    return len(name) > 4 and name[4] in {"b", "c", "d", "e", "n", "s"}
 
 
 # Lookup table: (prefix_tuple, finder_fn_or_None, default_if_no_finder_match)

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -153,6 +153,11 @@ class TestGuessSymbolOrigin:
         result = _guess_symbol_origin("_ZGVnN4v_sin", [])
         assert result == "libmvec.so.1"
 
+    def test_cxx_guard_variable_ZGVZ_is_native(self):
+        """_ZGVZ... is an Itanium C++ guard variable, not a libmvec symbol."""
+        result = _guess_symbol_origin("_ZGVZN4YAML3Exp9AmpersandEvE1e", [])
+        assert result is None
+
     def test_gcc_runtime_cpu_model(self):
         """__cpu_model → libgcc_s.so.1."""
         result = _guess_symbol_origin("__cpu_model", [])
@@ -490,6 +495,11 @@ class TestUpdatedAttributions:
         for name in ("_ZGVbN4v_sin", "_ZGVdN2v_cos", "_ZGVeN8v_exp"):
             result = _guess_symbol_origin(name, [])
             assert result == "libmvec.so.1", f"Expected libmvec.so.1 for {name}"
+
+    def test_ZGVN_guard_variable_not_libmvec(self):
+        """M1: Namespace-scope Itanium C++ guard variables are project-owned."""
+        result = _guess_symbol_origin("_ZGVN4test7MyClassE", [])
+        assert result is None
 
     # --- M2: operator new/delete ---
 

--- a/tests/test_symbol_origin.py
+++ b/tests/test_symbol_origin.py
@@ -149,7 +149,7 @@ class TestGuessSymbolOrigin:
         assert result == "libgcc.a (static)"
 
     def test_gcc_runtime_ZGV(self):
-        """_ZGV... → libmvec.so.1 (SIMD vectorized math, not libgcc_s)."""
+        """libmvec vector ABI symbol → libmvec.so.1 (not libgcc_s)."""
         result = _guess_symbol_origin("_ZGVnN4v_sin", [])
         assert result == "libmvec.so.1"
 
@@ -486,15 +486,20 @@ class TestUpdatedAttributions:
         assert result == "libgcc.a (static)"
 
     def test_ZGV_to_libmvec(self):
-        """M1: _ZGV* → libmvec.so.1 (vectorized math), not libgcc_s."""
+        """M1: libmvec vector ABI symbol → libmvec.so.1, not libgcc_s."""
         result = _guess_symbol_origin("_ZGVnN4v_sin", [])
         assert result == "libmvec.so.1"
 
     def test_ZGV_variants(self):
         """M1: Various _ZGV SIMD math variants."""
-        for name in ("_ZGVbN4v_sin", "_ZGVdN2v_cos", "_ZGVeN8v_exp"):
+        for name in ("_ZGVbN4v_sin", "_ZGVcN4v_sin", "_ZGVdN2v_cos", "_ZGVeN8v_exp"):
             result = _guess_symbol_origin(name, [])
             assert result == "libmvec.so.1", f"Expected libmvec.so.1 for {name}"
+
+    def test_ZGVs_sve_variant_to_libmvec(self):
+        """M1: AArch64 SVE libmvec symbols use the _ZGVs... ABI form."""
+        result = _guess_symbol_origin("_ZGVsMxv_sinf", [])
+        assert result == "libmvec.so.1"
 
     def test_ZGVN_guard_variable_not_libmvec(self):
         """M1: Namespace-scope Itanium C++ guard variables are project-owned."""


### PR DESCRIPTION
## Summary
- distinguish glibc libmvec vector ABI symbols from Itanium C++ guard variables that also start with `_ZGV`
- keep `_ZGVn...`/`_ZGVb...` vector symbols attributed to `libmvec.so.1`
- add regression coverage for `_ZGVZ...` guard variables staying native

## Real-world evidence
During the 2026-06-07 real-world validation run, yaml-cpp 0.7.0 -> 0.8.0 exported `_ZGVZN4YAML3Exp9AmpersandEvE1e`, an Itanium guard variable defined in `libyaml-cpp.so.0.8.0`. The old heuristic treated every `_ZGV*` symbol as libmvec-origin and reported a bogus `symbol_leaked_from_dependency_changed` risk with `new_value: libmvec.so.1`, even though `libyaml-cpp` does not depend on `libmvec`.

After this fix, the yaml-cpp rerun keeps the genuine libstdc++ leaked-symbol risks and drops the bogus guard-variable risk: risk changes 4 -> 3, total changes 9 -> 8.

Evidence paths in the campaign workspace:
- `reports/abicheck-realworld-cron/evidence-20260607-0940/run-20260607-0940-yaml-cpp__libyaml-cpp.json`
- `reports/abicheck-realworld-cron/evidence-20260607-0940/run-20260607-0940-yaml-cpp__libyaml-cpp-after-fix.json`

## Tests
- `pytest -q tests/test_symbol_origin.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol origin detection to more accurately identify glibc libmvec vector symbols by analyzing name patterns while correctly excluding C++ guard-variable-related symbols, reducing false positive library attribution.

* **Tests**
  * Added test cases verifying symbol origin detection correctly handles C++ guard-variable patterns and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->