### PR TITLE
docs: product-contract framing, evidence/detectability matrix, and catalog count fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ CI runs `mypy abicheck/` as a required gate. The baseline is currently **0 error
 | `import-cycles` | ERROR | No import cycles within `abicheck/` |
 | `mypy-baseline` | ERROR if drifted up | mypy error count ≤ documented baseline |
 | `examples-ground-truth` | ERROR | Every `examples/case*/` has a `README.md` and an entry in `ground_truth.json` |
+| `examples-readme-sync` | ERROR | `examples/README.md` headline count, verdict distribution, and case-index rows match `ground_truth.json` (catches missing/stale catalog rows) |
 | `mkdocs-nav-coverage` | WARN | Every `docs/**/*.md` is in `mkdocs.yml` nav or linked from another doc |
 | `banned-imports` | ERROR | No `print(...)` outside CLI/reporter modules; no `subprocess(..., shell=True)` |
 | `license-header` | WARN | Every `abicheck/**/*.py` carries the Apache-2.0 header / SPDX identifier |

--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -47,6 +47,7 @@ here for a specific problem, jump straight to the relevant part.
 
 | Part | Page | What it covers | Read it when… |
 |------|------|----------------|---------------|
+| **0** | [Compatibility as a Product Contract](abi-series/00-product-contract.md) | Public surface, SemVer mapping, contract shapes — the *framing* | …before anything else: a change is only a "break" if it breaks a promise |
 | **1** | [Foundations](abi-series/01-foundations.md) | Source → object → link → load; what a symbol is; API vs ABI | …you want the ground-up mental model (start here) |
 | **2** | [Symbol Contracts](abi-series/02-symbol-contracts.md) | Removal, rename, signature, pointer-level, globals | …a symbol disappeared or changed meaning |
 | **3** | [Type Layout](abi-series/03-type-layout.md) | Struct size/offset, alignment, enums, unions, bitfields | …you changed a struct, enum, or union |
@@ -57,7 +58,8 @@ here for a specific problem, jump straight to the relevant part.
 
 ```mermaid
 flowchart LR
-    P1["1 · Foundations"] --> P2["2 · Symbol<br/>Contracts"]
+    P0["0 · Product<br/>Contract"] --> P1["1 · Foundations"]
+    P1 --> P2["2 · Symbol<br/>Contracts"]
     P1 --> P3["3 · Type<br/>Layout"]
     P2 --> P4["4 · C++ ABI"]
     P3 --> P4
@@ -66,6 +68,25 @@ flowchart LR
     P5 --> P7["7 · Designing<br/>for Stability"]
     P6 --> P7
 ```
+
+> **Cross-cutting companion:** [Evidence & Detectability](evidence-and-detectability.md)
+> explains *which inputs* (symbols, debug info, headers, app, bundle) let a tool
+> see a given change at all — read it alongside any part when you're wondering
+> "why did the tool catch this but not that?"
+
+## Pick a reading path for your role
+
+The series is ordered, but you rarely need all of it at once. These paths get
+each audience to the pages that matter for them fastest:
+
+| Audience | Recommended path |
+|----------|------------------|
+| **New C/C++ library author** | [Product Contract](abi-series/00-product-contract.md) → [Foundations](abi-series/01-foundations.md) → [Symbol Contracts](abi-series/02-symbol-contracts.md) → [Type Layout](abi-series/03-type-layout.md) → [Designing for Stability](abi-series/07-designing-for-stability.md) |
+| **C++ library maintainer** | [Foundations](abi-series/01-foundations.md) → [C++ ABI](abi-series/04-cpp-abi.md) → [Type Layout](abi-series/03-type-layout.md) → [Transitive Breaks](abi-series/06-transitive-breaks.md) → [Designing for Stability](abi-series/07-designing-for-stability.md) |
+| **CI / release engineer** | [Product Contract](abi-series/00-product-contract.md) → [Tool Comparison](../reference/tool-comparison.md) → [Policy Profiles](../user-guide/policies.md) → [Baselines](../user-guide/baseline-management.md) → [Exit Codes](../reference/exit-codes.md) → [Output Formats](../user-guide/output-formats.md) |
+| **Distribution / package maintainer** | [Linker & ELF](abi-series/05-linker-elf.md) → [Transitive Breaks](abi-series/06-transitive-breaks.md) → [Multi-Binary Releases](../user-guide/multi-binary.md) → [Application Compatibility](../user-guide/appcompat.md) |
+| **Plugin / SDK author** | [Symbol Contracts](abi-series/02-symbol-contracts.md) → [Plugin Systems](../user-guide/plugin-systems.md) → [Policy Profiles](../user-guide/policies.md) → [Product Contract §4](abi-series/00-product-contract.md#4-name-your-contract-shape) |
+| **AI agent / automated reviewer** | [Overview](abi-api-handling.md) → [Evidence & Detectability](evidence-and-detectability.md) → [Examples Encyclopedia](../examples/index.md) → [Change Kind Reference](../reference/change-kinds.md) |
 
 ---
 

--- a/docs/concepts/abi-series/00-product-contract.md
+++ b/docs/concepts/abi-series/00-product-contract.md
@@ -1,0 +1,214 @@
+# Part 0 — Compatibility as a Product Contract
+
+> **Series navigation:** **0. Product Contract** ·
+> [1. Foundations](01-foundations.md) ·
+> [2. Symbol Contracts](02-symbol-contracts.md) ·
+> [3. Type Layout](03-type-layout.md) ·
+> [4. C++ ABI](04-cpp-abi.md) ·
+> [5. Linker & ELF](05-linker-elf.md) ·
+> [6. Transitive Breaks](06-transitive-breaks.md) ·
+> [7. Designing for Stability](07-designing-for-stability.md)
+
+**What you'll learn on this page**
+
+- Why ABI/API compatibility is a **promise the product makes**, not just a
+  property a tool reads out of a binary.
+- How to write down your **public surface** — the thing the promise is about —
+  before you ever run a checker.
+- How [Semantic Versioning](https://semver.org/) turns that promise into a
+  version-number convention, and how abicheck's verdicts map onto SemVer
+  decisions.
+- Why the *same* technical change can be a release-blocking break for one
+  product and a non-event for another.
+
+This is the **prologue** to the seven-part series. The later parts teach the
+*mechanisms* (what bytes move, what the loader does). This part teaches the
+*framing* that makes those mechanisms matter: a change is only a "break" if it
+breaks something you promised.
+
+> **New here?** If you want the build/link/load mental model first, you can read
+> [Part 1 — Foundations](01-foundations.md) and come back. But most of the
+> confusion people have about ABI tools ("why did it flag this? why didn't it
+> flag that?") dissolves once the contract is written down — so start here if
+> you can.
+
+---
+
+## 1. The core idea: detection finds facts, the product decides breakage
+
+abicheck — like every ABI/API tool — gathers **evidence** (symbols, type
+layout, headers, dependencies) and reports **facts**: "function `foo` was
+removed", "struct `S` grew by 8 bytes", "the SONAME changed". Whether a given
+fact is a *break* is a separate question, and it is **not** a property of the
+binary. It is a property of the **contract** the product published.
+
+> **Detection finds facts. Policy decides whether those facts are breaking for
+> this product.**
+
+A worked example: abicheck reports `func_removed` for a symbol that disappeared.
+Is that a break?
+
+- If the symbol was part of your **promised public API** → yes, existing
+  consumers will fail to link or load. Breaking.
+- If the symbol was an **internal helper** that merely happened to be exported
+  (no visibility annotation, no version script) → it was never part of the
+  contract. Removing it is *housekeeping*, not a break — even though the symbol
+  table changed.
+
+The tool sees the same fact in both cases. Only the contract distinguishes them.
+This is why abicheck has [policy profiles](../../user-guide/policies.md) and a
+[public-surface scoping model](../../reference/change-kinds.md): they are how you
+tell the tool what your contract actually is.
+
+---
+
+## 2. Define the public surface *before* you check
+
+Before checking ABI/API stability, write down what is actually promised. The
+public surface is the union of:
+
+| Surface element | What it pins | Where abicheck sees it |
+|-----------------|--------------|------------------------|
+| **Public headers** | The source-level API: function signatures, types, macros, default arguments | Header AST (CastXML), if you pass `--old-header`/`--new-header` |
+| **Exported symbols** | The link/load-level ABI: which names a consumer can bind to | ELF `.dynsym` / PE export table / Mach-O export trie |
+| **Struct/class layout exposed in headers** | Field offsets, sizes, alignment that consumers bake in | DWARF/PDB debug info |
+| **Plugin / `dlopen` entry points** | The dynamic-loading contract between host and plugin | [Plugin manifest](../../user-guide/plugin-systems.md) |
+| **Supported platforms & architectures** | Which ABIs you ship (x86-64, arm64, …) | Per-binary; compared per-platform |
+| **Supported compilers & standard-library ABI** | e.g. the libstdc++ dual-ABI flag, MSVC version range | Build context / toolchain flags |
+| **Calling conventions & exception model** | How calls and unwinding are wired | DWARF / mangling |
+| **SONAME / install-name policy** | When the soname bumps (and consumers must relink) | ELF SONAME / Mach-O install name |
+| **Symbol-version policy** | Which versioned symbols are promised stable | ELF symbol versions (`GLIBC_2.x`-style) |
+| **Source-compatibility promise** | Whether *recompiling* against new headers must keep working | Policy choice (see [verdicts](../verdicts.md)) |
+
+!!! tip "The single most useful sentence in your project's docs"
+    > "Our public API is everything declared in `include/foo/*.h` and exported
+    > with `FOO_PUBLIC`. Everything under `detail/` or not marked `FOO_PUBLIC`
+    > is private and may change at any time."
+
+    With that sentence written down, most "is this a break?" arguments answer
+    themselves — and you can tell abicheck the same thing via
+    [public-surface scoping](../../reference/change-kinds.md) and
+    [suppressions](../../user-guide/suppressions.md).
+
+If you *don't* write this down, the default contract is brutal: **everything you
+export is part of the ABI**, because some consumer somewhere may have bound to
+it. That is exactly why accidental exports (missing `-fvisibility=hidden`, no
+version script) are a recurring source of "we broke an ABI we didn't know we
+had" — see [Part 5 — Linker & ELF](05-linker-elf.md).
+
+---
+
+## 3. Semantic Versioning: turning the promise into a number
+
+[SemVer](https://semver.org/) says a project **must declare a public API**, and
+then the version number communicates compatibility:
+
+- **MAJOR** — incompatible API/ABI changes.
+- **MINOR** — backward-compatible additions.
+- **PATCH** — backward-compatible bug fixes.
+
+That maps cleanly onto abicheck's [verdicts](../verdicts.md) — *but only after*
+the public API is declared (§2). abicheck detects the change and classifies it;
+**you** decide what the classification means for your version number and release.
+
+### abicheck verdict → SemVer action
+
+| abicheck verdict / class | Product meaning | Typical SemVer action |
+|--------------------------|-----------------|-----------------------|
+| **`BREAKING`** | Existing **binary** consumers may fail to link, load, or behave correctly | **Major** bump; SONAME/install-name bump, new symbol version, or block the release |
+| **`API_BREAK`** | **Source** users may fail to recompile, but already-built binaries may still load | **Major** bump *if source compatibility is promised*; otherwise a documented source migration |
+| **`COMPATIBLE` (addition)** | Existing users keep working; new public API added | Usually **minor** bump |
+| **`COMPATIBLE_WITH_RISK`** | ABI likely intact, but a deployment/security/runtime assumption changed | Usually a **release note** + policy review; sometimes block |
+| **`NO_CHANGE`** | No relevant public-contract change detected | **Patch** / implementation-only release |
+| **Internal / private change** | No public-contract change *if truly hidden* | **No** SemVer impact |
+
+> abicheck's `compare` mode is the only one with the full verdict vocabulary —
+> in particular the `API_BREAK` distinction between *source* breaks and *binary*
+> breaks. Legacy `compat` mode and other tools generally collapse that
+> distinction. See [Verdicts](../verdicts.md) and
+> [Tool Comparison](../../reference/tool-comparison.md).
+
+### The same change, two verdicts
+
+Because breakage is contract-relative, the *same* technical change can land in
+different rows above depending on policy:
+
+- Making a conversion constructor `explicit` is an **`API_BREAK`** (old source
+  that relied on the implicit conversion won't compile) but **not** a binary
+  break (mangled names and layout are unchanged). Under a strict
+  source-compatible SDK contract that's a major bump; under a binary-only
+  plugin contract it may be acceptable. abicheck's
+  [`sdk_vendor` vs `plugin_abi` policies](../../user-guide/policies.md) encode
+  exactly this difference.
+
+---
+
+## 4. Name your contract shape
+
+"Public surface" looks different for different kinds of products. Identify which
+shape you are before reasoning about breaks.
+
+### Traditional C shared library
+
+The contract is typically: **public headers + exported symbols + struct layout
+exposed in headers + SONAME/symbol-version policy + the supported platform
+ABI.** Already-built consumers must keep linking, loading, and calling into the
+new binary using the *old* contract. This is the case abicheck models most
+directly — there is a real binary boundary to compare.
+
+### C++ SDK
+
+Everything above, **plus**: supported compiler version range, standard library
+ABI (e.g. the libstdc++ dual-ABI flag — see
+[`case104`](../../examples/case104_glibcxx_dual_abi_flip.md)), exception model,
+RTTI, visibility rules, inline-namespace policy, template instantiation policy,
+and toolchain flags. C++ contracts are wider and more fragile;
+[Part 4 — C++ ABI](04-cpp-abi.md) covers the mechanisms.
+
+### Plugin / SDK with `dlopen`
+
+A **two-sided** ABI contract between host and plugin: fixed entry points,
+`dlopen`/`dlsym` names, callback structs, registration functions, and
+host/plugin ownership & lifetime rules. This is usually a *manually declared*
+dynamic-loading contract, not ordinary link-time ABI — so abicheck checks it
+against a [plugin manifest](../../user-guide/plugin-systems.md).
+
+### Multi-library bundle / product release
+
+The contract is **product-level**: not just whether each `.so` changed, but
+whether the *collection* still satisfies all intra-bundle dependencies, provider
+relationships, entry points, symbol versions, and manifest promises. Per-library
+comparison is necessary but **insufficient** — see
+[Part 6 — Transitive Breaks](06-transitive-breaks.md) and
+[Multi-Binary Releases](../../user-guide/multi-binary.md).
+
+> **Rule of thumb:** *For products that ship more than one public or semi-public
+> library, per-library compatibility is necessary but not sufficient. The
+> product contract is the bundle contract.*
+
+---
+
+## 5. Where this leaves you
+
+You now have the framing the rest of the series builds on:
+
+> A product **declares** a compatibility contract → abicheck **gathers
+> evidence** from binaries, headers, debug info, applications, bundles, and
+> manifests → **policy maps** the detected facts onto a release decision.
+
+Carry these two questions into every later part:
+
+1. **Was the thing that changed part of the promised public surface?** (§2)
+2. **What does my versioning policy say I must do about a change of this
+   class?** (§3)
+
+Next: [Part 1 — Foundations](01-foundations.md) shows *how* a change becomes a
+break at the machine level. If you want to know *which* evidence abicheck (or
+any other tool) needs to even see a given change, read
+[Evidence & Detectability](../evidence-and-detectability.md).
+
+---
+
+_See also: [Verdicts](../verdicts.md) · [Policy Profiles](../../user-guide/policies.md) ·
+[Evidence & Detectability](../evidence-and-detectability.md) ·
+[Examples Encyclopedia](../../examples/index.md)._

--- a/docs/concepts/abi-series/01-foundations.md
+++ b/docs/concepts/abi-series/01-foundations.md
@@ -1,6 +1,7 @@
 # Part 1 — Foundations: From Source Code to a Running Process
 
-> **Series navigation:** **1. Foundations** ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> **1. Foundations** ·
 > [2. Symbol Contracts](02-symbol-contracts.md) ·
 > [3. Type Layout](03-type-layout.md) ·
 > [4. C++ ABI](04-cpp-abi.md) ·

--- a/docs/concepts/abi-series/02-symbol-contracts.md
+++ b/docs/concepts/abi-series/02-symbol-contracts.md
@@ -1,6 +1,7 @@
 # Part 2 — Symbol Contract Breaks
 
-> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> [1. Foundations](01-foundations.md) ·
 > **2. Symbol Contracts** ·
 > [3. Type Layout](03-type-layout.md) ·
 > [4. C++ ABI](04-cpp-abi.md) ·

--- a/docs/concepts/abi-series/03-type-layout.md
+++ b/docs/concepts/abi-series/03-type-layout.md
@@ -1,6 +1,7 @@
 # Part 3 — Type Layout Breaks
 
-> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> [1. Foundations](01-foundations.md) ·
 > [2. Symbol Contracts](02-symbol-contracts.md) ·
 > **3. Type Layout** ·
 > [4. C++ ABI](04-cpp-abi.md) ·

--- a/docs/concepts/abi-series/04-cpp-abi.md
+++ b/docs/concepts/abi-series/04-cpp-abi.md
@@ -1,6 +1,7 @@
 # Part 4 — C++ ABI Specifics
 
-> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> [1. Foundations](01-foundations.md) ·
 > [2. Symbol Contracts](02-symbol-contracts.md) ·
 > [3. Type Layout](03-type-layout.md) ·
 > **4. C++ ABI** ·

--- a/docs/concepts/abi-series/05-linker-elf.md
+++ b/docs/concepts/abi-series/05-linker-elf.md
@@ -1,6 +1,7 @@
 # Part 5 — ELF & Linker-Level Concerns
 
-> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> [1. Foundations](01-foundations.md) ·
 > [2. Symbol Contracts](02-symbol-contracts.md) ·
 > [3. Type Layout](03-type-layout.md) ·
 > [4. C++ ABI](04-cpp-abi.md) ·

--- a/docs/concepts/abi-series/06-transitive-breaks.md
+++ b/docs/concepts/abi-series/06-transitive-breaks.md
@@ -1,6 +1,7 @@
 # Part 6 — Subtle & Transitive Breaks
 
-> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> [1. Foundations](01-foundations.md) ·
 > [2. Symbol Contracts](02-symbol-contracts.md) ·
 > [3. Type Layout](03-type-layout.md) ·
 > [4. C++ ABI](04-cpp-abi.md) ·

--- a/docs/concepts/abi-series/07-designing-for-stability.md
+++ b/docs/concepts/abi-series/07-designing-for-stability.md
@@ -1,6 +1,7 @@
 # Part 7 — Designing for Stability
 
-> **Series navigation:** [1. Foundations](01-foundations.md) ·
+> **Series navigation:** [0. Product Contract](00-product-contract.md) ·
+> [1. Foundations](01-foundations.md) ·
 > [2. Symbol Contracts](02-symbol-contracts.md) ·
 > [3. Type Layout](03-type-layout.md) ·
 > [4. C++ ABI](04-cpp-abi.md) ·

--- a/docs/concepts/evidence-and-detectability.md
+++ b/docs/concepts/evidence-and-detectability.md
@@ -1,0 +1,254 @@
+# Evidence & Detectability: What Each Method Can and Cannot See
+
+> **One idea drives this whole page:** *different methods observe different
+> evidence, and **no single method detects every compatibility issue.*** A tool
+> can only report what its inputs let it see. Feed it symbols only and it sees
+> symbol changes; feed it debug info and it sees layout; feed it headers and it
+> sees source-level API. Some changes (`#define` macros, inline/template
+> *bodies*, uninstantiated templates) are invisible to *any* artifact
+> comparison.
+
+This page is the conceptual companion to the practical
+[Limitations](limitations.md) and [Tool Comparison](../reference/tool-comparison.md)
+pages. It answers the question users ask most often:
+
+> "Why did tool A catch this and tool B didn't?"
+
+Almost always, the answer is **evidence**: the two tools were looking at
+different inputs.
+
+---
+
+## 1. The detectability matrix
+
+The most important table on this page. Read it as: *given only this evidence,
+what can a checker conclude — and what is it structurally blind to?*
+
+| Evidence available | Detects well | Cannot detect well |
+|--------------------|--------------|--------------------|
+| **Exported symbol table only** (stripped binary, no headers) | Removed/added exported symbols, symbol versions, visibility, SONAME/install-name, dependency (`DT_NEEDED`) changes | Struct layout, enum values, calling convention, source-only API changes, macro changes, inline/template body changes |
+| **Debug info (DWARF / PDB / BTF)** | Type layout, field offsets, enum values, class sizes, vtables, calling convention, packing/alignment | Source-only API *intent*, macros, default arguments, some template/header-only changes |
+| **Headers / AST** (CastXML / Clang) | Source signatures, overloads, default args, access/`final`/`explicit`/`noexcept`, templates visible in headers | Inline body *semantics*, macro expansion policy (unless modeled), runtime behavior |
+| **Source diff / compiler-based API extraction** | Macros, inline function bodies, `constexpr` bodies, uninstantiated templates, source-level API | The binary layout actually *emitted* into a shipped library (unless paired with the binary/debug info) |
+| **Runtime app swap / integration test** | Real loader/linker behavior and tested execution paths | Untested public API, *future* consumers, silent layout corruption (unless a test happens to expose it) |
+| **Bundle scan** (multi-library) | Cross-DSO dependency / provider / entry-point problems | Pure source compatibility and semantic behavior not represented in artifacts or manifests |
+
+### Why abicheck combines layers
+
+abicheck is strongest because it does **not** rely on a single row. It overlays
+three **independent, additive** evidence layers (see
+[Architecture](architecture.md) and ADR-003):
+
+| Layer | Evidence it contributes |
+|-------|-------------------------|
+| **Binary metadata** | ELF symbols, SONAME, versioning, visibility, dependencies (and PE/COFF + Mach-O equivalents) |
+| **Header AST** (CastXML) | Function signatures, classes, structs, vtables, enums, typedefs, templates, `noexcept`, access |
+| **Debug info** (DWARF/PDB) | Layout, offsets, enum values, calling convention, vtable slots, type cross-checks |
+
+The best input you can give it is therefore:
+
+> **old library + new library + matching public headers + debug info + build
+> context.**
+
+With less, abicheck degrades gracefully *down the matrix* — a stripped binary
+with no headers collapses toward symbol-only checking, where layout and
+source-only breaks are invisible. See
+[Recommendation: feed `.so` + debug info + headers](limitations.md#recommendation-feed-abicheck-so-debug-info-headers-for-the-best-result).
+
+---
+
+## 2. Methods compared, by the evidence they use
+
+Each method is good at what its evidence exposes and blind to the rest. None is a
+complete contract check on its own.
+
+### a. Build an app and swap the library
+
+The most realistic *consumer-level* test — but **not** a complete contract
+check. It only exercises what one app imports and runs.
+
+| Strength | Example |
+|----------|---------|
+| Loader/linker failures | App fails because a required symbol is missing |
+| Real runtime behavior | App crashes when it calls into changed ABI |
+| Consumer-specific risk | App doesn't use the removed function, so *this* app still works |
+| End-to-end deployment validation | RPATH/RUNPATH, search path, symbol versions all exercised |
+
+| It misses | Why |
+|-----------|-----|
+| Unused public APIs | The app only tests what it imports/executes |
+| Silent data corruption | Tests may pass while layout is subtly wrong |
+| Source compatibility | Binary may run, but *recompiling* may fail |
+| Future consumers | One app is not the whole public contract |
+| Header-only / source-only breaks | Existing binary doesn't exercise changed source |
+
+This maps to abicheck's [`appcompat`](../user-guide/appcompat.md) command. See
+[§4](#4-app-mode-consumer-scoped-vs-library-compare-contract-scoped) for its
+exact scope.
+
+### b. libabigail (`abidiff`)
+
+Primarily **DWARF-based**: `abidw` extracts ABI XML, `abidiff` compares it. Falls
+back to CTF/BTF or ELF symbol names; with no debug info it degrades toward
+ELF-only.
+
+- **Good for:** emitted binary ABI from debug builds (struct/class layout, type
+  changes, symbols); no headers required in the common DWARF workflow; a mature
+  ABI diff model.
+- **Limits:** stripped binaries degrade to symbol-only; a header directory is
+  mostly a *public-symbol filter*, not a full source-AST analysis, so source-only
+  changes (default args, access changes, `noexcept`) stay hard; not
+  product/bundle/app-policy oriented by default.
+
+### c. ABI Compliance Checker (ABICC)
+
+Two workflows:
+
+- **`abi-dumper` workflow** — DWARF-based dump from a debug `.so`, optional
+  public-header filter. Lacks a full AST, so it misses many source-only API
+  breaks.
+- **XML / header workflow** — GCC-compiled AST from headers. GCC-only, with
+  known slowness/reliability issues, path sensitivity, and timeouts on complex
+  C++. Lacks ELF binary metadata, so it's weaker on exported-symbol/platform
+  linker facts.
+
+Coarser verdict vocabulary than abicheck `compare` (no `API_BREAK` modeling).
+abicheck's [`compat` mode](../reference/tool-comparison.md) is a drop-in
+replacement for ABICC-style flags; new integrations should prefer `compare`.
+
+### d. abicheck
+
+The combined-evidence model above (§1). Strongest with library + headers + debug
+info + build context. See [Tool Comparison](../reference/tool-comparison.md) for
+the benchmark showing why combining ELF + CastXML + DWARF beats single-source
+tools.
+
+### e. Methods beyond ABI diff tools
+
+ABI diffing is one tool in a release-engineering kit. Complementary methods:
+
+| Method | What it adds |
+|--------|--------------|
+| Downstream rebuilds | Detect *source* API breaks by recompiling real consumers |
+| Runtime smoke / [probe tests](../user-guide/probe-harness.md) | Detect loader errors and common runtime failures |
+| [ABI/API snapshot baselines](../user-guide/baseline-management.md) | Treat release snapshots as immutable contract records |
+| Symbol-version script / export-map linting | Enforce the intended public/private boundary |
+| Header/source API extraction | Catch macros, inline definitions, template surface |
+| Fuzz / integration tests | Catch *behavioral* changes behind a stable ABI |
+| Reverse-dependency CI | Ecosystem/distribution-wide validation |
+| [Security-hardening scanners](../user-guide/security-hardening.md) | Catch non-ABI deployment regressions (RELRO/PIE/canary/FORTIFY) |
+
+The [security-hardening check](../user-guide/security-hardening.md) is the clean
+example of "not ABI, but still a release-compatibility risk": an ABI-compatible
+upgrade can weaken hardening while a normal ABI gate stays green. abicheck
+reports that as **deployment risk**, not an ABI break.
+
+---
+
+## 3. Traditional shared libraries vs header-only libraries
+
+This distinction trips people up constantly, so it gets its own section.
+
+### Traditional `.so` / `.dll` / `.dylib`
+
+There is a real **binary contract** to compare — exported symbols, symbol
+versions, dependency metadata, layout in debug info, public declarations in
+headers. abicheck's model is strongest here:
+
+> For compiled shared libraries, ABI compatibility is mainly about whether
+> existing, already-built consumers can keep linking, loading, and calling into
+> the new binary using the *old* contract.
+
+### Header-only libraries
+
+A header-only library often has **no exported library ABI** — the code is
+compiled into *each consumer*. Compatibility is therefore mostly:
+
+| Compatibility type | Meaning |
+|--------------------|---------|
+| Source API compatibility | Will existing users recompile? |
+| Generated ABI compatibility | Will rebuilt objects stay compatible with other objects? |
+| Semantic compatibility | Does inline/`constexpr`/template behavior still mean the same thing? |
+| Configuration compatibility | Do macros/features/flags produce the same public surface? |
+
+abicheck can still help in *some* cases:
+
+| Case | How abicheck helps |
+|------|--------------------|
+| Header-only API also gates a shared-library boundary | Header-AST comparison catches some API changes |
+| Explicit template instantiations shipped in a `.so` | The emitted instantiations can be checked |
+| Header constants / default args / source signatures in the AST | Some source-level API breaks are found |
+| App links a runtime helper library | [App mode](../user-guide/appcompat.md) checks the app's imported symbols |
+
+But it **cannot fully validate a pure header-only library**: implicit
+header-only template instantiations are not in any shipped artifact (the
+documented mitigation is *explicit instantiation* of public templates that form
+part of the ABI — see [Template Instantiation](limitations.md#template-instantiation)).
+
+!!! tip "Header-only compatibility strategy"
+    Use **source API extraction**, **compile tests** across supported
+    compilers/standards, **downstream rebuilds**, and **behavioral tests**. Use
+    abicheck for emitted artifacts, explicit template instantiations, or
+    companion runtime libraries — not as the sole gate for header-only code.
+
+---
+
+## 4. App mode: consumer-scoped vs library-compare: contract-scoped
+
+[`appcompat`](../user-guide/appcompat.md) answers a deliberately narrow question:
+*will **this** application still work with the new library?* It parses the app's
+required symbols, compares old/new libraries in full mode, checks new-symbol
+availability, and **filters** findings to changes that matter to that app.
+
+That scope cuts both ways:
+
+| App mode **can** say | App mode **cannot** say |
+|----------------------|-------------------------|
+| "This app doesn't import the removed symbol." | "The library is generally ABI-compatible." |
+| "This app needs symbol version X and the new lib lacks it." | "All *future* consumers are safe." |
+| "This app is unaffected by this library-wide break." | "Header-only source users can recompile." |
+| "This deployment path is OK for this app." | "No *semantic* behavior changed." |
+
+> **App mode is consumer-scoped compatibility. Library `compare` is
+> product-contract compatibility.** Use both: `compare` protects the library
+> contract; `appcompat` protects a specific consumer deployment.
+
+For header-only libraries, app mode is less central unless there's a companion
+runtime library — an existing app binary already contains the header-only code
+it compiled earlier, so swapping a library may not exercise the changed
+header-only implementation at all.
+
+---
+
+## 5. What ABI tools cannot prove
+
+Even with perfect evidence, artifact comparison has hard boundaries. These are
+**not abicheck's job** — they need tests, specs, or source-AST tooling. Treat
+this as a guard against *over-trusting* any ABI tool (see
+[Limitations](limitations.md) for the authoritative list):
+
+| Case | Why it's invisible / out of scope |
+|------|-----------------------------------|
+| **Macro-only changes** | Macros are preprocessor behavior; not in the artifact |
+| **Inline function body changed, same signature** | No exported ABI change; body is compiled into the consumer |
+| **`constexpr` behavior changed** | Source/semantic compatibility, no symbol change |
+| **Template body changed but not instantiated** | No emitted artifact to compare |
+| **Uninstantiated template signature change** | Not in the shipped `.so` unless instantiated ([`case122`](../examples/case122_template_signature_uninstantiated.md)) |
+| **Header-only change not affecting exports** | There may be no shared-library ABI surface |
+| **Stripped binary, no headers/debug** | Mostly symbol-level comparison only |
+| **Header/binary mismatch** | The tool may analyze a contract the binary wasn't built with — false results |
+| **Static archives (`.a` / `.lib`) as archive containers** | abicheck analyzes linkable images/shared libraries/objects, not archive containers ([details](limitations.md#static-import-library-archives-a-lib)) |
+| **Pure behavioral / semantic changes** | Same ABI/API, different meaning — needs tests/spec review |
+| **Ownership / lifetime / thread-safety guarantee changes** | A signature can be byte-identical while the *contract* it implements flips |
+
+The takeaway is the same one [Part 0](abi-series/00-product-contract.md) opens
+with: **a stable ABI is necessary but not sufficient for a compatible release.**
+ABI tools prove the binary contract held; behavioral compatibility still needs
+your tests and your specification.
+
+---
+
+_See also: [Part 0 — Compatibility as a Product Contract](abi-series/00-product-contract.md) ·
+[Limitations](limitations.md) · [Tool Comparison](../reference/tool-comparison.md) ·
+[Application Compatibility](../user-guide/appcompat.md) ·
+[Multi-Binary Releases](../user-guide/multi-binary.md)._

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -3,6 +3,11 @@
 `abicheck` is designed to catch real ABI and API breaks with high accuracy, but has specific
 limitations you should understand before relying on it in production.
 
+> **Conceptual companion.** This page is the *practical* boundary list. For the
+> *why* — which evidence (symbols, debug info, headers, source, runtime, bundle)
+> lets any tool see a given change at all, and what no artifact comparison can
+> prove — see [Evidence & Detectability](evidence-and-detectability.md).
+
 ---
 
 ## Platform support matrix

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -12,6 +12,11 @@ Each change kind is partitioned into exactly one classification set in
 (`QUALITY_KINDS`, hygiene/metadata). The [Examples Encyclopedia](../examples/index.md)
 groups every fixture by both verdict and category.
 
+> **A verdict is a fact; the release decision is policy.** For how these verdicts
+> map onto SemVer version bumps and product-contract decisions (and why the same
+> change can be breaking for one product and a non-event for another), see
+> [Compatibility as a Product Contract](abi-series/00-product-contract.md#3-semantic-versioning-turning-the-promise-into-a-number).
+
 > **Beyond the five core verdicts.** `compare` in severity-aware mode (any
 > `--severity-*` flag) can also report **`SEVERITY_ERROR`** with exit code `1`
 > when an addition/quality finding is promoted to error level — for example to

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -10,6 +10,11 @@ benchmark results across real-world test cases, and why the numbers come out the
 > releases. A historical 42-case snapshot is kept below only for comparison with
 > older reports.
 
+> **Why the tools disagree.** The accuracy gaps below are mostly an *evidence*
+> story: each tool sees a different subset of the binary/debug/header inputs. For
+> the conceptual model — which evidence detects which change class — see
+> [Evidence & Detectability](../concepts/evidence-and-detectability.md).
+
 ---
 
 ## How each tool analyses ABI

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — `examples/`
 
-The ABI-scenario catalog: 125 cases numbered contiguously (`01–124` +
+The ABI-scenario catalog: 126 cases numbered contiguously (`01–125` +
 `26b`), including 5 multi-library bundle cases. Each case is a minimal,
 compilable C/C++ example demonstrating a specific ABI/API pitfall.
 

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -46,5 +46,7 @@ top of this directory. **If a per-case README disagrees with
 2. Write `v1/`, `v2/`, `app.c|cpp`, and a README.
 3. Add the expected verdict to `ground_truth.json`.
 4. Run `python scripts/gen_examples_docs.py` and commit the regenerated
-   `docs/examples/caseNN_*.md`.
+   `docs/examples/caseNN_*.md` **and** the refreshed `README.md` catalog
+   (its headline/distribution/case-index regions are generated from
+   `ground_truth.json`; don't hand-edit them).
 5. Validate with `pytest tests/test_abi_examples.py -k caseNN -m integration`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
 # ABI Scenario Catalog
 
-This directory contains **122 cases** numbered contiguously (`01–121` + `26b`), including **5 multi-library bundle cases** (`84`, `90–93`, tracked separately under [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) demonstrating real-world ABI/API break scenarios. Each case is a minimal, compilable C/C++ example with:
+<!-- BEGIN GENERATED: catalog-headline (keep counts in sync with examples/ground_truth.json) -->
+This directory contains **126 cases** — `01`–`125` (contiguous) plus `26b` — including **5 multi-library bundle cases** (`84`, `90`–`93`, tracked separately under [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) demonstrating real-world ABI/API break scenarios. Each case is a minimal, compilable C/C++ example with:
+<!-- END GENERATED: catalog-headline -->
 
 - Paired `v1/` and `v2/` source + headers.
 - A consumer `app.c` / `app.cpp` that demonstrates the actual failure at runtime.
@@ -15,15 +17,19 @@ The catalog drives abicheck's benchmark and serves as an encyclopedia of ABI pit
 
 ## Verdict distribution
 
+<!-- BEGIN GENERATED: verdict-distribution (keep counts in sync with examples/ground_truth.json) -->
 | Verdict | Count | `checker_policy.py` set | Icon |
 |---------|-------|-------------------------|------|
-| BREAKING | 83 | `BREAKING_KINDS` | 🔴 |
-| API_BREAK | 4 | `API_BREAK_KINDS` | 🟠 |
+| BREAKING | 85 | `BREAKING_KINDS` | 🔴 |
+| API_BREAK | 8 | `API_BREAK_KINDS` | 🟠 |
 | COMPATIBLE_WITH_RISK | 2 | `RISK_KINDS` | 🟡 |
 | COMPATIBLE (addition) | 10 | `ADDITION_KINDS` | 🟢 |
-| COMPATIBLE (quality) | 11 | `QUALITY_KINDS` | 🟡 |
+| COMPATIBLE (quality) | 10 | `QUALITY_KINDS` | 🟡 |
 | NO_CHANGE | 6 | — | ✅ |
-| Bundle (multi-binary) | 5 | see [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md) | 🔴 |
+| Bundle (multi-binary) | 5 | see [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md) | 🔵 |
+<!-- END GENERATED: verdict-distribution -->
+
+**Single-library total: 121** (85 + 8 + 2 + 10 + 10 + 6). **Bundle cases: 5.** **Grand total: 126.**
 
 > **Verdict source of truth:** [`ground_truth.json`](ground_truth.json), which aligns with the 5-tier classification in [`abicheck/checker_policy.py`](../abicheck/checker_policy.py): `BREAKING_KINDS` → `API_BREAK_KINDS` → `RISK_KINDS` → `QUALITY_KINDS` → `ADDITION_KINDS`.
 
@@ -40,116 +46,136 @@ Some policy-escalated source/contract breaks (notably case30, case35) may keep i
 
 ## Case index
 
+<!-- BEGIN GENERATED: case-index (scripts/gen_examples_docs.py --readme) -->
 | # | Case | Category | abicheck verdict |
 |---|------|----------|-----------------|
-| [01](case01_symbol_removal/README.md) | Symbol Removal | Breaking | BREAKING 🔴 |
-| [02](case02_param_type_change/README.md) | Param Type Change | Breaking | BREAKING 🔴 |
-| [03](case03_compat_addition/README.md) | Compat Addition | Addition | COMPATIBLE 🟢 |
-| [04](case04_no_change/README.md) | No Change | No Change | NO_CHANGE ✅ |
-| [05](case05_soname/README.md) | Soname | Quality | COMPATIBLE 🟡 (bad practice) |
-| [06](case06_visibility/README.md) | Visibility | Breaking | BREAKING 🔴 (bad practice) |
-| [07](case07_struct_layout/README.md) | Struct Layout | Breaking | BREAKING 🔴 |
-| [08](case08_enum_value_change/README.md) | Enum Value Change | Breaking | BREAKING 🔴 |
-| [09](case09_cpp_vtable/README.md) | Cpp Vtable | Breaking | BREAKING 🔴 |
-| [10](case10_return_type/README.md) | Return Type | Breaking | BREAKING 🔴 |
-| [11](case11_global_var_type/README.md) | Global Var Type | Breaking | BREAKING 🔴 |
-| [12](case12_function_removed/README.md) | Function Removed | Breaking | BREAKING 🔴 |
-| [13](case13_symbol_versioning/README.md) | Symbol Versioning | Quality | COMPATIBLE 🟡 |
-| [14](case14_cpp_class_size/README.md) | Cpp Class Size | Breaking | BREAKING 🔴 |
-| [15](case15_noexcept_change/README.md) | Noexcept Change | Risk | COMPATIBLE_WITH_RISK 🟡 |
-| [16](case16_inline_to_non_inline/README.md) | Inline To Non Inline | Addition | COMPATIBLE 🟢 |
-| [17](case17_template_abi/README.md) | Template Abi | Breaking | BREAKING 🔴 |
-| [18](case18_dependency_leak/README.md) | Dependency Leak | Breaking | BREAKING 🔴 (bad practice) |
-| [19](case19_enum_member_removed/README.md) | Enum Member Removed | Breaking | BREAKING 🔴 |
-| [20](case20_enum_member_value_changed/README.md) | Enum Member Value Changed | Breaking | BREAKING 🔴 |
-| [21](case21_method_became_static/README.md) | Method Became Static | Breaking | BREAKING 🔴 |
-| [22](case22_method_const_changed/README.md) | Method Const Changed | Breaking | BREAKING 🔴 |
-| [23](case23_pure_virtual_added/README.md) | Pure Virtual Added | Breaking | BREAKING 🔴 |
-| [24](case24_union_field_removed/README.md) | Union Field Removed | Breaking | BREAKING 🔴 |
-| [25](case25_enum_member_added/README.md) | Enum Member Added | Addition | COMPATIBLE 🟢 |
-| [26](case26_union_field_added/README.md) | Union Field Added | Breaking | BREAKING 🔴 |
-| [26b](case26b_union_field_added_compatible/README.md) | Union Field Added Compatible | Addition | COMPATIBLE 🟢 |
-| [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened | Quality | COMPATIBLE 🟡 |
-| [28](case28_typedef_opaque/README.md) | Typedef Opaque | Breaking | BREAKING 🔴 |
-| [29](case29_ifunc_transition/README.md) | Ifunc Transition | Quality | COMPATIBLE 🟡 |
-| [30](case30_field_qualifiers/README.md) | Field Qualifiers | Breaking | BREAKING 🔴 |
-| [31](case31_enum_rename/README.md) | Enum Rename | API Break | API_BREAK 🟠 |
-| [32](case32_param_defaults/README.md) | Param Defaults | No Change | NO_CHANGE ✅ |
-| [33](case33_pointer_level/README.md) | Pointer Level | Breaking | BREAKING 🔴 |
-| [34](case34_access_level/README.md) | Access Level | API Break | API_BREAK 🟠 |
-| [35](case35_field_rename/README.md) | Field Rename | Breaking | BREAKING 🔴 |
-| [36](case36_anon_struct/README.md) | Anon Struct | Breaking | BREAKING 🔴 |
-| [37](case37_base_class/README.md) | Base Class | Breaking | BREAKING 🔴 |
-| [38](case38_virtual_methods/README.md) | Virtual Methods | Breaking | BREAKING 🔴 |
-| [39](case39_var_const/README.md) | Var Const | Breaking | BREAKING 🔴 |
-| [40](case40_field_layout/README.md) | Field Layout | Breaking | BREAKING 🔴 |
-| [41](case41_type_changes/README.md) | Type Changes | Breaking | BREAKING 🔴 |
-| [42](case42_type_alignment_changed/README.md) | Type Alignment Changed (alignas) | Breaking | BREAKING 🔴 |
-| [43](case43_base_class_member_added/README.md) | Base Class Member Added | Breaking | BREAKING 🔴 |
-| [44](case44_cyclic_type_member_added/README.md) | Cyclic Type Member Added | Breaking | BREAKING 🔴 |
-| [45](case45_multi_dim_array_change/README.md) | Multi-Dim Array Element Type Change | Breaking | BREAKING 🔴 |
-| [46](case46_pointer_chain_type_change/README.md) | Pointer Chain Type Change | Breaking | BREAKING 🔴 |
-| [47](case47_inline_to_outlined/README.md) | Inline to Outlined | Addition | COMPATIBLE 🟢 |
-| [48](case48_leaf_struct_through_pointer/README.md) | Leaf Struct Change Through Pointer | Breaking | BREAKING 🔴 |
-| [49](case49_executable_stack/README.md) | Executable Stack (GNU_STACK RWX) | Quality | COMPATIBLE 🟡 (bad practice) |
-| [50](case50_soname_inconsistent/README.md) | SONAME Inconsistent (Wrong Major) | Quality | COMPATIBLE 🟡 (bad practice) |
-| [51](case51_protected_visibility/README.md) | Protected Visibility (DEFAULT→PROTECTED) | Quality | COMPATIBLE 🟡 |
-| [52](case52_rpath_leak/README.md) | RPATH Leak (Hardcoded Build Dir) | Quality | COMPATIBLE 🟡 (bad practice) |
-| [53](case53_namespace_pollution/README.md) | Namespace Pollution (Generic Names) | Breaking | BREAKING 🔴 |
-| [54](case54_used_reserved_field/README.md) | Used Reserved Field | Quality | COMPATIBLE 🟡 |
-| [55](case55_type_kind_changed/README.md) | Type Kind Changed (struct→union) | Breaking | BREAKING 🔴 |
-| [56](case56_struct_packing_changed/README.md) | Struct Packing Changed (pragma pack) | Breaking | BREAKING 🔴 |
-| [57](case57_enum_underlying_size_changed/README.md) | Enum Underlying Size Changed | Breaking | BREAKING 🔴 |
-| [58](case58_var_removed/README.md) | Global Variable Removed | Breaking | BREAKING 🔴 |
-| [59](case59_func_became_inline/README.md) | Function Became Inline (outlined→inline) | Breaking | BREAKING 🔴 |
-| [60](case60_base_class_position_changed/README.md) | Base Class Position Changed (MI reorder) | Breaking | BREAKING 🔴 |
-| [61](case61_var_added/README.md) | Global Variable Added | Addition | COMPATIBLE 🟢 |
-| [62](case62_type_field_added_compatible/README.md) | Type Field Added (Opaque Struct) | Addition | COMPATIBLE 🟢 |
-| [63](case63_bitfield_changed/README.md) | Bitfield Width Changed | Breaking | BREAKING 🔴 |
-| [64](case64_calling_convention_changed/README.md) | Calling Convention Changed (ms_abi) | Breaking | BREAKING 🔴 |
-| [65](case65_symbol_version_removed/README.md) | Symbol Version Removed (ELF) | Breaking | BREAKING 🔴 |
-| [66](case66_language_linkage_changed/README.md) | Language Linkage Changed (extern "C") | Breaking | BREAKING 🔴 |
-| [67](case67_tls_var_size_changed/README.md) | TLS Variable Size Changed | Breaking | BREAKING 🔴 |
-| [68](case68_virtual_method_added/README.md) | Virtual Method Added (non-virtual → virtual) | Breaking | BREAKING 🔴 |
-| [69](case69_trivial_to_nontrivial/README.md) | Trivially Copyable → Non-Trivial (calling convention) | Breaking | BREAKING 🔴 |
-| [70](case70_flexible_array_member_changed/README.md) | Flexible Array Member Element Type Changed | Breaking | BREAKING 🔴 |
-| [71](case71_inline_namespace_moved/README.md) | Inline Namespace Moved (v1→v2) | Breaking | BREAKING 🔴 |
-| [72](case72_covariant_return_changed/README.md) | Covariant Return Type Changed (hierarchy insert) | Breaking | BREAKING 🔴 |
-| [73](case73_typedef_underlying_changed/README.md) | Typedef Underlying Type Changed (int→void*) | Breaking | BREAKING 🔴 |
-| [74](case74_detail_base_class_changed/README.md) | Internal `detail::` Base Class Layout Change (detail-namespace leak) | Breaking | BREAKING 🔴 |
-| [75](case75_detail_embedded_by_value/README.md) | Internal `detail::` Impl Embedded by Value | Breaking | BREAKING 🔴 |
-| [76](case76_detail_pimpl_vtable_changed/README.md) | Internal `detail::` Polymorphic Base Vtable Change | Breaking | BREAKING 🔴 |
-| [77](case77_detail_templated_base_changed/README.md) | Internal `detail::` Templated Base Class Layout Change | Breaking | BREAKING 🔴 |
-| [78](case78_task_arena_attach_tag/README.md) | task_arena::attach Tag Replaces Enum | Breaking | BREAKING 🔴 |
-| [79](case79_missing_template_instantiation/README.md) | Missing Template Instantiation in Shipped Binary | Breaking | BREAKING 🔴 |
-| [80](case80_pimpl_shared_to_unique/README.md) | Pimpl Alias `shared_ptr` → `unique_ptr` | Breaking | BREAKING 🔴 |
-| [81](case81_serialization_tag_reassigned/README.md) | Serialization Tag ID Reassigned (silent data corruption) | Breaking | BREAKING 🔴 |
-| [82](case82_sycl_overload_set_removed/README.md) | SYCL Overload Set Removed (DPC++ build withdrawn) | Breaking | BREAKING 🔴 |
-| [83](case83_cpu_dispatch_isa_dropped/README.md) | CPU-Dispatch ISA Family Dropped | Risk | COMPATIBLE_WITH_RISK 🟡 |
-| [84](case84_bundle_soname_skew/README.md) | Multi-Library Bundle SONAME Skew | Breaking | BREAKING 🔴 (bad practice) |
-| [85](case85_internal_template_signature_changed/README.md) | Internal Function-Template Signature Leaks via Public API | Breaking | BREAKING 🔴 |
-| [86](case86_tag_struct_renamed/README.md) | Tag Struct Renamed (empty type re-mangling) | Breaking | BREAKING 🔴 |
-| [87](case87_default_template_arg_changed/README.md) | Default Template Argument Changed | Breaking | BREAKING 🔴 |
-| [88](case88_cpo_kind_changed/README.md) | CPO Kind Changed | Breaking | BREAKING 🔴 |
-| [89](case89_inline_accessor_renamed_pimpl_member/README.md) | Inline Accessor References Renamed Pimpl Member | Breaking | BREAKING 🔴 |
-| [94](case94_empty_tag_gained_state/README.md) | Empty Tag Gained State | Breaking | BREAKING 🔴 |
-| [95](case95_allocator_nested_typedef_removed/README.md) | Allocator Nested-Typedef Removed (member_name suppression demo) | Breaking | BREAKING 🔴 |
-| [96](case96_hidden_friend_removed/README.md) | Hidden Friend Operator Removed (castxml `befriending` detection) | API Break | API_BREAK 🟠 |
-| [97](case97_api_depends_on_consumer_env/README.md) | Public API Depends on Consumer Build Environment | Quality | COMPATIBLE 🟡 (known gap) |
-| [98](case98_cxx_standard_floor_raised/README.md) | C++ Standard Floor Raised (per-binary: NO_CHANGE) | No Change | NO_CHANGE ✅ (known gap) |
-| [99](case99_experimental_graduated/README.md) | experimental → stable Graduation | Addition | COMPATIBLE 🟢 |
-| [100](case100_experimental_removed_without_replacement/README.md) | experimental:: Removed Without Replacement | Breaking | BREAKING 🔴 |
-| [101](case101_inline_namespace_version_bumped/README.md) | Inline Namespace Version Bumped | Breaking | BREAKING 🔴 |
-| [102](case102_frozen_runtime_signature_changed/README.md) | Frozen Runtime Signature Changed (frozen `detail::` ABI boundary) | Breaking | BREAKING 🔴 |
-| [103](case103_toolchain_flag_drift/README.md) | Toolchain Flag Drift (ABI-affecting compiler flags differ via `DW_AT_producer`) | Quality | COMPATIBLE 🟢 |
-| [104](case104_glibcxx_dual_abi_flip/README.md) | libstdc++ Dual-ABI Flip (`_GLIBCXX_USE_CXX11_ABI` toggle) | Breaking | BREAKING 🔴 |
-| [105](case105_concept_tightening/README.md) | Concept Tightening (C++20, known gap) | Addition | COMPATIBLE 🟢 (known gap) |
-| [106](case106_ctor_became_explicit/README.md) | Conversion Operator Became `explicit` | API Break | API_BREAK 🟠 |
-| [107](case107_task_scheduler_init_removed/README.md) | `task_scheduler_init` Removed (oneTBB 2021.1) | Breaking | BREAKING 🔴 |
-| [108](case108_task_class_removed/README.md) | `task` Class Removed (oneTBB 2021.1) | Breaking | BREAKING 🔴 |
-| [109](case109_flow_graph_policy_renames/README.md) | flow::graph Policy Tag Renames | Breaking | BREAKING 🔴 |
-| [110](case110_concurrent_unordered_map_api_drift/README.md) | concurrent_unordered_map API Drift | Breaking | BREAKING 🔴 |
-| [111](case111_enumerable_thread_specific_lambda_ambiguity/README.md) | enumerable_thread_specific Lambda-Init Ambiguity | Addition | COMPATIBLE 🟢 (known gap) |
+| [01](case01_symbol_removal/README.md) | Symbol Removal | Breaking | 🔴 BREAKING |
+| [02](case02_param_type_change/README.md) | Parameter Type Change | Breaking | 🔴 BREAKING |
+| [03](case03_compat_addition/README.md) | Compatible Addition (New Export) | Addition | 🟢 COMPATIBLE |
+| [04](case04_no_change/README.md) | No Change | No Change | ✅ NO_CHANGE |
+| [05](case05_soname/README.md) | Missing SONAME | Quality | 🟢 COMPATIBLE (bad practice) |
+| [06](case06_visibility/README.md) | Symbol Visibility Leak | Breaking | 🔴 BREAKING (bad practice) |
+| [07](case07_struct_layout/README.md) | Struct Layout Change | Breaking | 🔴 BREAKING |
+| [08](case08_enum_value_change/README.md) | Enum Value Change | Breaking | 🔴 BREAKING |
+| [09](case09_cpp_vtable/README.md) | C++ Vtable Change | Breaking | 🔴 BREAKING |
+| [10](case10_return_type/README.md) | Return Type Change | Breaking | 🔴 BREAKING |
+| [11](case11_global_var_type/README.md) | Global Variable Type Change | Breaking | 🔴 BREAKING |
+| [12](case12_function_removed/README.md) | Function Removed from Shared Library | Breaking | 🔴 BREAKING |
+| [13](case13_symbol_versioning/README.md) | Symbol Versioning Script | Quality | 🟢 COMPATIBLE |
+| [14](case14_cpp_class_size/README.md) | C++ Class Size Change | Breaking | 🔴 BREAKING |
+| [15](case15_noexcept_change/README.md) | `noexcept` Changed | Risk | 🟡 COMPATIBLE_WITH_RISK |
+| [16](case16_inline_to_non_inline/README.md) | Inline → Non-inline (ODR / Symbol Appearance) | Addition | 🟢 COMPATIBLE |
+| [17](case17_template_abi/README.md) | Template Instantiation ABI Change | Breaking | 🔴 BREAKING |
+| [18](case18_dependency_leak/README.md) | Dependency ABI Leak | Breaking | 🔴 BREAKING (bad practice) |
+| [19](case19_enum_member_removed/README.md) | Enum Member Removed | Breaking | 🔴 BREAKING |
+| [20](case20_enum_member_value_changed/README.md) | Enum Member Value Changed | Breaking | 🔴 BREAKING |
+| [21](case21_method_became_static/README.md) | Method Became Static | Breaking | 🔴 BREAKING |
+| [22](case22_method_const_changed/README.md) | Method Const Qualifier Changed | Breaking | 🔴 BREAKING |
+| [23](case23_pure_virtual_added/README.md) | Virtual Method Became Pure Virtual | Breaking | 🔴 BREAKING |
+| [24](case24_union_field_removed/README.md) | Union Field Removed | Breaking | 🔴 BREAKING |
+| [25](case25_enum_member_added/README.md) | Enum Member Added | Addition | 🟢 COMPATIBLE |
+| [26](case26_union_field_added/README.md) | Union Field Added | Breaking | 🔴 BREAKING |
+| [26b](case26b_union_field_added_compatible/README.md) | Union Field Added (No Size Change) | Addition | 🟢 COMPATIBLE |
+| [27](case27_symbol_binding_weakened/README.md) | Symbol Binding Weakened (GLOBAL → WEAK) | Quality | 🟢 COMPATIBLE |
+| [28](case28_typedef_opaque/README.md) | Typedef and Opaque Type Changes | Breaking | 🔴 BREAKING |
+| [29](case29_ifunc_transition/README.md) | GNU IFUNC Transition | Quality | 🟢 COMPATIBLE |
+| [30](case30_field_qualifiers/README.md) | Field Qualifier Changes (const, volatile) | Breaking | 🔴 BREAKING |
+| [31](case31_enum_rename/README.md) | Enum Member Rename | API Break | 🟠 API_BREAK |
+| [32](case32_param_defaults/README.md) | Parameter Default Value Changes (C++) | API Break | 🟠 API_BREAK |
+| [33](case33_pointer_level/README.md) | - Pointer Level Change | Breaking | 🔴 BREAKING |
+| [34](case34_access_level/README.md) | Access Level Changed | API Break | 🟠 API_BREAK |
+| [35](case35_field_rename/README.md) | - Field Rename | Breaking | 🔴 BREAKING |
+| [36](case36_anon_struct/README.md) | - Anonymous Struct/Union Change | Breaking | 🔴 BREAKING |
+| [37](case37_base_class/README.md) | - Base Class Changes | Breaking | 🔴 BREAKING |
+| [38](case38_virtual_methods/README.md) | Virtual Method Changes | Breaking | 🔴 BREAKING |
+| [39](case39_var_const/README.md) | Variable Const Change | Breaking | 🔴 BREAKING |
+| [40](case40_field_layout/README.md) | Field Layout Changes | Breaking | 🔴 BREAKING |
+| [41](case41_type_changes/README.md) | Type-Level Changes | Breaking | 🔴 BREAKING |
+| [42](case42_type_alignment_changed/README.md) | Type Alignment Changed (standalone alignas) | Breaking | 🔴 BREAKING |
+| [43](case43_base_class_member_added/README.md) | Base Class Member Added | Breaking | 🔴 BREAKING |
+| [44](case44_cyclic_type_member_added/README.md) | Cyclic Type Member Added | Breaking | 🔴 BREAKING |
+| [45](case45_multi_dim_array_change/README.md) | Multi-Dimensional Array Element Type Change | Breaking | 🔴 BREAKING |
+| [46](case46_pointer_chain_type_change/README.md) | Pointer Chain Type Change | Breaking | 🔴 BREAKING |
+| [47](case47_inline_to_outlined/README.md) | Inline Function Moved to Outlined | Addition | 🟢 COMPATIBLE |
+| [48](case48_leaf_struct_through_pointer/README.md) | Leaf Struct Change Propagated Through Pointer | Breaking | 🔴 BREAKING |
+| [49](case49_executable_stack/README.md) | Executable Stack (GNU_STACK RWX) | Quality | 🟢 COMPATIBLE (bad practice) |
+| [50](case50_soname_inconsistent/README.md) | SONAME Inconsistent (Wrong Major Version) | Quality | 🟢 COMPATIBLE (bad practice) |
+| [51](case51_protected_visibility/README.md) | Protected Visibility (DEFAULT to PROTECTED) | Quality | 🟢 COMPATIBLE |
+| [52](case52_rpath_leak/README.md) | RPATH Leak (Hardcoded Build Directory) | Quality | 🟢 COMPATIBLE (bad practice) |
+| [53](case53_namespace_pollution/README.md) | Namespace Pollution (Generic Symbol Names) | Breaking | 🔴 BREAKING (bad practice) |
+| [54](case54_used_reserved_field/README.md) | Used Reserved Field | Quality | 🟢 COMPATIBLE |
+| [55](case55_type_kind_changed/README.md) | Type Kind Changed (struct → union) | Breaking | 🔴 BREAKING |
+| [56](case56_struct_packing_changed/README.md) | Struct Packing Changed (pragma pack) | Breaking | 🔴 BREAKING |
+| [57](case57_enum_underlying_size_changed/README.md) | Enum Underlying Size Changed | Breaking | 🔴 BREAKING |
+| [58](case58_var_removed/README.md) | Global Variable Removed | Breaking | 🔴 BREAKING |
+| [59](case59_func_became_inline/README.md) | Function Became Inline (outlined → inline) | Breaking | 🔴 BREAKING |
+| [60](case60_base_class_position_changed/README.md) | Base Class Position Changed (Multiple Inheritance Reorder) | Breaking | 🔴 BREAKING |
+| [61](case61_var_added/README.md) | Global Variable Added | Addition | 🟢 COMPATIBLE |
+| [62](case62_type_field_added_compatible/README.md) | Type Field Added (Compatible — Opaque Struct) | Addition | 🟢 COMPATIBLE |
+| [63](case63_bitfield_changed/README.md) | Bitfield Width Changed | Breaking | 🔴 BREAKING |
+| [64](case64_calling_convention_changed/README.md) | Calling Convention Changed | Breaking | 🔴 BREAKING |
+| [65](case65_symbol_version_removed/README.md) | Symbol Version Removed | Breaking | 🔴 BREAKING |
+| [66](case66_language_linkage_changed/README.md) | Language Linkage Changed (extern "C" removed) | Breaking | 🔴 BREAKING |
+| [67](case67_tls_var_size_changed/README.md) | TLS Variable Size Changed | Breaking | 🔴 BREAKING |
+| [68](case68_virtual_method_added/README.md) | Virtual Method Added to Non-Virtual Class | Breaking | 🔴 BREAKING |
+| [69](case69_trivial_to_nontrivial/README.md) | Trivially Copyable to Non-Trivial (Calling Convention Change) | Breaking | 🔴 BREAKING |
+| [70](case70_flexible_array_member_changed/README.md) | Flexible Array Member Element Type Changed | Breaking | 🔴 BREAKING |
+| [71](case71_inline_namespace_moved/README.md) | Inline Namespace Moved | Breaking | 🔴 BREAKING |
+| [72](case72_covariant_return_changed/README.md) | Covariant Return Type Changed | Breaking | 🔴 BREAKING |
+| [73](case73_typedef_underlying_changed/README.md) | Typedef Underlying Type Changed | Breaking | 🔴 BREAKING |
+| [74](case74_detail_base_class_changed/README.md) | Internal `detail::` base class layout change leaks via public API | Breaking | 🔴 BREAKING |
+| [75](case75_detail_embedded_by_value/README.md) | Internal `detail::` impl struct embedded by value | Breaking | 🔴 BREAKING |
+| [76](case76_detail_pimpl_vtable_changed/README.md) | Internal `detail::` polymorphic base vtable change | Breaking | 🔴 BREAKING |
+| [77](case77_detail_templated_base_changed/README.md) | Internal `detail::` *templated* base class layout change | Breaking | 🔴 BREAKING |
+| [78](case78_task_arena_attach_tag/README.md) | task_arena::attach Tag Type Replaces Enum | Breaking | 🔴 BREAKING |
+| [79](case79_missing_template_instantiation/README.md) | Missing template instantiation in shipped binary | Breaking | 🔴 BREAKING |
+| [80](case80_pimpl_shared_to_unique/README.md) | Pimpl alias changed from `shared_ptr` to `unique_ptr` | Breaking | 🔴 BREAKING |
+| [81](case81_serialization_tag_reassigned/README.md) | Serialization tag ID reassigned | Breaking | 🔴 BREAKING |
+| [82](case82_sycl_overload_set_removed/README.md) | SYCL overload set removed (DPC++ build withdrawn) | Breaking | 🔴 BREAKING |
+| [83](case83_cpu_dispatch_isa_dropped/README.md) | CPU-dispatch ISA family dropped | Risk | 🟡 COMPATIBLE_WITH_RISK |
+| [84](case84_bundle_soname_skew/README.md) | Multi-library bundle SONAME skew | Bundle | 🔵 BUNDLE (bad practice) |
+| [85](case85_internal_template_signature_changed/README.md) | internal function-template signature leaks via public API (BREAKING) | Breaking | 🔴 BREAKING |
+| [86](case86_tag_struct_renamed/README.md) | Tag struct renamed (empty class re-mangling) | Breaking | 🔴 BREAKING |
+| [87](case87_default_template_arg_changed/README.md) | Default template argument changed | Breaking | 🔴 BREAKING |
+| [88](case88_cpo_kind_changed/README.md) | CPO kind changed (BREAKING) | Breaking | 🔴 BREAKING |
+| [89](case89_inline_accessor_renamed_pimpl_member/README.md) | Inline accessor references renamed pimpl member | Breaking | 🔴 BREAKING |
+| [90](case90_bundle_intra_dep_removed/README.md) | Bundle — intra-bundle removed symbol | Bundle | 🔵 BUNDLE |
+| [91](case91_bundle_intra_signature_drift/README.md) | Bundle — intra-bundle extern-C signature drift | Bundle | 🔵 BUNDLE |
+| [92](case92_bundle_provider_changed/README.md) | Bundle — symbol provider migration | Bundle | 🔵 BUNDLE |
+| [93](case93_bundle_manifest_drift/README.md) | Bundle — instantiation manifest drift | Bundle | 🔵 BUNDLE |
+| [94](case94_empty_tag_gained_state/README.md) | Empty Tag Gained State | Breaking | 🔴 BREAKING |
+| [95](case95_allocator_nested_typedef_removed/README.md) | Allocator Nested-Typedef Removed | Breaking | 🔴 BREAKING |
+| [96](case96_hidden_friend_removed/README.md) | Hidden Friend Operator Removed | API Break | 🟠 API_BREAK |
+| [97](case97_api_depends_on_consumer_env/README.md) | public API depends on consumer build environment (RISK) | Breaking | 🔴 BREAKING |
+| [98](case98_cxx_standard_floor_raised/README.md) | C++ standard floor raised (per-binary: NO_CHANGE) | No Change | ✅ NO_CHANGE |
+| [99](case99_experimental_graduated/README.md) | experimental → stable graduation (compatible) | Addition | 🟢 COMPATIBLE |
+| [100](case100_experimental_removed_without_replacement/README.md) | experimental:: removed without replacement (API break) | Breaking | 🔴 BREAKING |
+| [101](case101_inline_namespace_version_bumped/README.md) | inline namespace version bumped (BREAKING) | Breaking | 🔴 BREAKING |
+| [102](case102_frozen_runtime_signature_changed/README.md) | Frozen Runtime Signature Changed (oneTBB `detail::r1` shape) | Breaking | 🔴 BREAKING |
+| [103](case103_toolchain_flag_drift/README.md) | Toolchain flag drift (`toolchain_flag_drift`) | Quality | 🟢 COMPATIBLE (bad practice) |
+| [104](case104_glibcxx_dual_abi_flip/README.md) | libstdc++ dual-ABI flip (`glibcxx_dual_abi_flip_detected`) | Breaking | 🔴 BREAKING (bad practice) |
+| [105](case105_concept_tightening/README.md) | Concept Tightening (C++20) | Addition | 🟢 COMPATIBLE (bad practice) |
+| [106](case106_ctor_became_explicit/README.md) | Conversion Operator Became `explicit` | API Break | 🟠 API_BREAK |
+| [107](case107_task_scheduler_init_removed/README.md) | `task_scheduler_init` Removed (historical ABI break) | Breaking | 🔴 BREAKING |
+| [108](case108_task_class_removed/README.md) | `task` Class Removed (historical ABI break — vtable angle) | Breaking | 🔴 BREAKING |
+| [109](case109_flow_graph_policy_renames/README.md) | flow::graph Policy Tag Renames | Breaking | 🔴 BREAKING |
+| [110](case110_concurrent_unordered_map_api_drift/README.md) | concurrent_unordered_map API Drift | Breaking | 🔴 BREAKING |
+| [111](case111_enumerable_thread_specific_lambda_ambiguity/README.md) | enumerable_thread_specific Lambda-Init Ambiguity | Addition | 🟢 COMPATIBLE (bad practice) |
+| [112](case112_lp64_ilp64/README.md) | LP64 → ILP64 integer-model switch (oneMKL MKL_INT 32→64) | Breaking | 🔴 BREAKING |
+| [113](case113_abi_tag_changed/README.md) | ABI-tag set change ([abi:cxx11] lost on a single symbol) | Breaking | 🔴 BREAKING |
+| [114](case114_char8t_migration/README.md) | char8_t migration (C++20 char-family → char8_t) | Breaking | 🔴 BREAKING |
+| [115](case115_bit_int_width_changed/README.md) | _BitInt(N) width change (C23 64 → 128) | Breaking | 🔴 BREAKING |
+| [116](case116_atomic_qualifier_changed/README.md) | _Atomic qualifier added (C11) | Breaking | 🔴 BREAKING |
+| [117](case117_no_unique_address/README.md) | [[no_unique_address]] layout overlay (no new ChangeKind) | Breaking | 🔴 BREAKING |
+| [118](case118_internal_struct_field_added_scoped/README.md) | Internal struct gains a field (non-public, scoped) | No Change | ✅ NO_CHANGE |
+| [119](case119_internal_struct_field_removed_scoped/README.md) | Internal struct loses a field (non-public, scoped) | No Change | ✅ NO_CHANGE |
+| [120](case120_internal_struct_reordered_scoped/README.md) | Internal struct fields reordered (non-public, scoped) | No Change | ✅ NO_CHANGE |
+| [121](case121_kernel_btf_struct_field_added/README.md) | Kernel BTF struct grows a field (out-of-tree module break) | Breaking | 🔴 BREAKING |
+| [122](case122_template_signature_uninstantiated/README.md) | Uninstantiated Template Signature Change (documented gap) | No Change | ✅ NO_CHANGE |
+| [123](case123_default_argument_removed/README.md) | Default Argument Removed | API Break | 🟠 API_BREAK |
+| [124](case124_header_constant_value_changed/README.md) | Header Constant Value Changed | API Break | 🟠 API_BREAK |
+| [125](case125_class_became_final/README.md) | Class Became `final` | API Break | 🟠 API_BREAK |
+<!-- END GENERATED: case-index -->
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # ABI Scenario Catalog
 
 <!-- BEGIN GENERATED: catalog-headline (keep counts in sync with examples/ground_truth.json) -->
-This directory contains **126 cases** — `01`–`125` (contiguous) plus `26b` — including **5 multi-library bundle cases** (`84`, `90`–`93`, tracked separately under [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) demonstrating real-world ABI/API break scenarios. Each case is a minimal, compilable C/C++ example with:
+This directory contains **126 cases** (121 single-library + 5 multi-library bundle cases, the latter tracked under [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) demonstrating real-world ABI/API break scenarios. Each case is a minimal, compilable C/C++ example with:
 <!-- END GENERATED: catalog-headline -->
 
 - Paired `v1/` and `v2/` source + headers.
@@ -28,8 +28,6 @@ The catalog drives abicheck's benchmark and serves as an encyclopedia of ABI pit
 | NO_CHANGE | 6 | — | ✅ |
 | Bundle (multi-binary) | 5 | see [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md) | 🔵 |
 <!-- END GENERATED: verdict-distribution -->
-
-**Single-library total: 121** (85 + 8 + 2 + 10 + 10 + 6). **Bundle cases: 5.** **Grand total: 126.**
 
 > **Verdict source of truth:** [`ground_truth.json`](ground_truth.json), which aligns with the 5-tier classification in [`abicheck/checker_policy.py`](../abicheck/checker_policy.py): `BREAKING_KINDS` → `API_BREAK_KINDS` → `RISK_KINDS` → `QUALITY_KINDS` → `ADDITION_KINDS`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Verdicts: concepts/verdicts.md
     - Architecture: concepts/architecture.md
     - Limitations: concepts/limitations.md
+    - Evidence & Detectability: concepts/evidence-and-detectability.md
     - Change Kinds: reference/change-kinds.md
     - Exit Codes: reference/exit-codes.md
     - Platforms: reference/platforms.md
@@ -64,6 +65,7 @@ nav:
   - ABI/API Handling & Recommendations:
     - Overview: concepts/abi-api-handling.md
     - Learning Series:
+      - "0. Compatibility as a Product Contract": concepts/abi-series/00-product-contract.md
       - "1. Foundations": concepts/abi-series/01-foundations.md
       - "2. Symbol Contracts": concepts/abi-series/02-symbol-contracts.md
       - "3. Type Layout": concepts/abi-series/03-type-layout.md

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -11,7 +11,7 @@ Each must run with Python 3.10+ and the package installed in dev mode
 | `check_ai_readiness.py` | AI-readiness gate (file size, CLAUDE.md coverage, test ratio, ChangeKind invariants, mypy baseline drift, import cycles, test-assertion density). | CI (`ai-readiness`) and `pre-commit`. Exits 1 on errors. |
 | `check_fp_rate.py` | False-positive/false-negative gate for public-surface scoping (ADR-024 §7). Labelled `(old, new)` corpus; baselines FP=0/FN=0. | CI (`ai-readiness`). Mirrored in `tests/test_fp_rate_gate.py`. |
 | `check_mutation_score.py` | Mutation-score baseline-drift gate. Counts surviving `mutmut` mutants in the detector core and compares to `SURVIVOR_BASELINE`. Parser unit-tested in `tests/test_mutation_score_gate.py`. | CI (`mutation.yml`: weekly / `mutation` label / dispatch). |
-| `gen_examples_docs.py` | Regenerates `docs/examples/caseNN_*.md` from `examples/case*/README.md`. Run after adding a new example case. | manual |
+| `gen_examples_docs.py` | Regenerates `docs/examples/caseNN_*.md` from `examples/case*/README.md`, and the generated regions (headline, verdict distribution, case index) of `examples/README.md` from `ground_truth.json`. `--check` gates both. Run after adding a new example case. | manual |
 | `benchmark_comparison.py` | Benchmarks abicheck vs ABICC / libabigail across the `examples/` catalog. | manual |
 | `demo_libz.py` | End-to-end demo on libz, used by the `e2e` CI job. | CI (`e2e` job) |
 | `extract_bundle_manifest.py` | Extracts a manifest from multi-library bundles (cases 90–93). | manual |

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -749,14 +749,63 @@ def check_examples_readme_sync(f: Findings) -> None:
                 f"{int(mm.group(1))}, but ground_truth.json has {expected}.",
             )
 
-    # Every case must appear as a row linking to its per-case README.
-    for name in sorted(verdicts):
-        if f"]({name}/README.md)" not in text:
+    # Every case must appear as a case-index row, AND that row's category +
+    # verdict must match ground_truth — not merely link to the README. Parsing
+    # the row contents is what catches per-row drift the aggregate counts miss
+    # (e.g. two cases swapping verdicts while the distribution totals stay put).
+    category_label = {
+        "breaking": "Breaking",
+        "api_break": "API Break",
+        "risk": "Risk",
+        "addition": "Addition",
+        "quality": "Quality",
+        "no_change": "No Change",
+        "bundle": "Bundle",
+    }
+    # | [NN](caseXXX/README.md) | Title | Category | <icon> VERDICT (notes) |
+    row_re = re.compile(
+        r"^\|\s*\[[^\]]*\]\((case[A-Za-z0-9_]+)/README\.md\)\s*"
+        r"\|([^|\n]*)\|([^|\n]*)\|([^|\n]*)\|\s*$",
+        re.MULTILINE,
+    )
+    seen: set[str] = set()
+    for match in row_re.finditer(text):
+        name = match.group(1)
+        cat_cell = match.group(3).strip()
+        verdict_cell = match.group(4).strip()
+        meta = verdicts.get(name)
+        if meta is None:
             f.err(
                 "examples-readme-sync",
-                f"examples/README.md: case '{name}' has no index row "
-                f"(expected a link to {name}/README.md).",
+                f"examples/README.md: index row for '{name}' has no "
+                "ground_truth.json entry.",
             )
+            continue
+        seen.add(name)
+        is_bundle = meta.get("category") == "bundle"
+        want_verdict = "BUNDLE" if is_bundle else meta["expected"]
+        want_cat = category_label.get(meta.get("category"), meta.get("category"))
+        token = re.search(r"[A-Z_]{3,}", verdict_cell)
+        got_verdict = token.group(0) if token else verdict_cell
+        if got_verdict != want_verdict:
+            f.err(
+                "examples-readme-sync",
+                f"examples/README.md: case '{name}' row shows verdict "
+                f"{got_verdict!r}, but ground_truth.json says {want_verdict!r}.",
+            )
+        if cat_cell != want_cat:
+            f.err(
+                "examples-readme-sync",
+                f"examples/README.md: case '{name}' row shows category "
+                f"{cat_cell!r}, but ground_truth.json says {want_cat!r}.",
+            )
+
+    for name in sorted(set(verdicts) - seen):
+        f.err(
+            "examples-readme-sync",
+            f"examples/README.md: case '{name}' has no parseable index row "
+            f"(expected '| [..]({name}/README.md) | Title | Category | Verdict |').",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -670,6 +670,93 @@ def check_examples_ground_truth(f: Findings) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Check: examples/README.md catalog stays in sync with ground_truth.json
+# ---------------------------------------------------------------------------
+
+
+def check_examples_readme_sync(f: Findings) -> None:
+    """The hand-facing examples/README.md catalog must agree with ground_truth.
+
+    Unlike the generated docs/examples/ tree (gated by gen_examples_docs.py
+    --check), the top-level examples/README.md is GitHub-rendered and was
+    historically hand-maintained, so its headline count, per-verdict
+    distribution, and case-index rows drifted (missing newly-added cases and
+    showing stale verdicts). This check pins all three to ground_truth.json so
+    the drift can't recur silently.
+    """
+    gt_path = EXAMPLES / "ground_truth.json"
+    readme = EXAMPLES / "README.md"
+    if not gt_path.is_file() or not readme.is_file():
+        return
+    try:
+        verdicts = json.loads(_read(gt_path))["verdicts"]
+    except Exception:
+        return
+    text = _read(readme)
+
+    single = {k: v for k, v in verdicts.items() if v.get("category") != "bundle"}
+    n_bundle = len(verdicts) - len(single)
+    n_total = len(verdicts)
+
+    # Headline total.
+    m = re.search(r"contains \*\*(\d+) cases\*\*", text)
+    if m is None:
+        f.warn(
+            "examples-readme-sync",
+            "examples/README.md: headline 'contains **N cases**' anchor not found; "
+            "update the regex in check_examples_readme_sync if the wording changed.",
+        )
+    elif int(m.group(1)) != n_total:
+        f.err(
+            "examples-readme-sync",
+            f"examples/README.md: headline says {int(m.group(1))} cases, "
+            f"but ground_truth.json has {n_total}.",
+        )
+
+    # Per-verdict distribution rows (single-library cases only).
+    expected_counts: dict[str, int] = {}
+    for v in single.values():
+        expected_counts[v["expected"]] = expected_counts.get(v["expected"], 0) + 1
+    # Map the README's distribution rows to ground_truth expected verdicts.
+    # COMPATIBLE is split into addition/quality rows in the README, so sum them.
+    cat_counts: dict[str, int] = {}
+    for v in single.values():
+        cat_counts[v.get("category")] = cat_counts.get(v.get("category"), 0) + 1
+    dist_anchors = [
+        (r"\| BREAKING \| (\d+) \|", expected_counts.get("BREAKING", 0)),
+        (r"\| API_BREAK \| (\d+) \|", expected_counts.get("API_BREAK", 0)),
+        (r"\| COMPATIBLE_WITH_RISK \| (\d+) \|", expected_counts.get("COMPATIBLE_WITH_RISK", 0)),
+        (r"\| COMPATIBLE \(addition\) \| (\d+) \|", cat_counts.get("addition", 0)),
+        (r"\| COMPATIBLE \(quality\) \| (\d+) \|", cat_counts.get("quality", 0)),
+        (r"\| NO_CHANGE \| (\d+) \|", expected_counts.get("NO_CHANGE", 0)),
+        (r"\| Bundle \(multi-binary\) \| (\d+) \|", n_bundle),
+    ]
+    for pattern, expected in dist_anchors:
+        mm = re.search(pattern, text)
+        if mm is None:
+            f.warn(
+                "examples-readme-sync",
+                f"examples/README.md: distribution row {pattern!r} not found; "
+                "update check_examples_readme_sync if the table changed.",
+            )
+        elif int(mm.group(1)) != expected:
+            f.err(
+                "examples-readme-sync",
+                f"examples/README.md: distribution row {pattern!r} says "
+                f"{int(mm.group(1))}, but ground_truth.json has {expected}.",
+            )
+
+    # Every case must appear as a row linking to its per-case README.
+    for name in sorted(verdicts):
+        if f"]({name}/README.md)" not in text:
+            f.err(
+                "examples-readme-sync",
+                f"examples/README.md: case '{name}' has no index row "
+                f"(expected a link to {name}/README.md).",
+            )
+
+
+# ---------------------------------------------------------------------------
 # Check: mkdocs nav coverage
 # ---------------------------------------------------------------------------
 
@@ -987,6 +1074,7 @@ CHECKS: dict[str, Callable[[Findings], None]] = {
     "import-cycles": check_import_cycles,
     "mypy-baseline": check_mypy_baseline,
     "examples-ground-truth": check_examples_ground_truth,
+    "examples-readme-sync": check_examples_readme_sync,
     "mkdocs-nav-coverage": check_mkdocs_nav_coverage,
     "banned-imports": check_banned_imports,
     "license-header": check_license_header,

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -725,7 +725,10 @@ def check_examples_readme_sync(f: Findings) -> None:
     dist_anchors = [
         (r"\| BREAKING \| (\d+) \|", expected_counts.get("BREAKING", 0)),
         (r"\| API_BREAK \| (\d+) \|", expected_counts.get("API_BREAK", 0)),
-        (r"\| COMPATIBLE_WITH_RISK \| (\d+) \|", expected_counts.get("COMPATIBLE_WITH_RISK", 0)),
+        (
+            r"\| COMPATIBLE_WITH_RISK \| (\d+) \|",
+            expected_counts.get("COMPATIBLE_WITH_RISK", 0),
+        ),
         (r"\| COMPATIBLE \(addition\) \| (\d+) \|", cat_counts.get("addition", 0)),
         (r"\| COMPATIBLE \(quality\) \| (\d+) \|", cat_counts.get("quality", 0)),
         (r"\| NO_CHANGE \| (\d+) \|", expected_counts.get("NO_CHANGE", 0)),
@@ -964,9 +967,7 @@ def _has_direct_assertion(fn: ast.AST) -> bool:
 
 
 def _called_function_names(fn: ast.AST) -> set[str]:
-    return {
-        _call_attr_or_name(n) for n in ast.walk(fn) if isinstance(n, ast.Call)
-    }
+    return {_call_attr_or_name(n) for n in ast.walk(fn) if isinstance(n, ast.Call)}
 
 
 def check_test_assertion_density(f: Findings) -> None:
@@ -994,9 +995,7 @@ def check_test_assertion_density(f: Findings) -> None:
             if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 funcs.setdefault(node.name, node)  # first definition wins
 
-        asserting = {
-            name for name, fn in funcs.items() if _has_direct_assertion(fn)
-        }
+        asserting = {name for name, fn in funcs.items() if _has_direct_assertion(fn)}
         # Propagate: a function asserts if it calls a function that asserts.
         changed = True
         while changed:

--- a/scripts/gen_examples_docs.py
+++ b/scripts/gen_examples_docs.py
@@ -15,7 +15,7 @@ import re
 import shutil
 import sys
 import tempfile
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,7 +24,21 @@ ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = ROOT / "examples"
 DOCS_EXAMPLES_DIR = ROOT / "docs" / "examples"
 GROUND_TRUTH = EXAMPLES_DIR / "ground_truth.json"
+EXAMPLES_README = EXAMPLES_DIR / "README.md"
 REPO_ROOT_FROM_DOCS_EXAMPLES = "../.."
+
+# Short category labels used in the examples/README.md catalog index. These are
+# the exact strings the `examples-readme-sync` AI-readiness check asserts each
+# row against — keep the two in sync.
+README_CATEGORY_LABEL = {
+    "breaking": "Breaking",
+    "api_break": "API Break",
+    "risk": "Risk",
+    "addition": "Addition",
+    "quality": "Quality",
+    "no_change": "No Change",
+    "bundle": "Bundle",
+}
 
 VERDICT_META = {
     "BREAKING": {
@@ -351,6 +365,153 @@ def _render_group_index(
     return "".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# examples/README.md catalog (the GitHub-facing index, not the docs site).
+#
+# Three regions are generated between sentinel comments so the headline count,
+# verdict distribution, and 126-row case index can't drift from ground_truth.
+# Bundle cases (skipped by the docs-site generator) ARE included here, since the
+# README indexes the whole catalog.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReadmeEntry:
+    num: str  # case number as it appears in the dir name, e.g. "01", "26b", "110"
+    name: str
+    title: str
+    category: str
+    verdict: str  # ground_truth "expected", or "BUNDLE" for multi-library cases
+    bad_practice: bool
+
+
+def _case_title(name: str) -> str:
+    """Short H1 title of a per-case README (caseNN prefix stripped)."""
+    text = (EXAMPLES_DIR / name / "README.md").read_text(encoding="utf-8")
+    m = re.match(r"\s*#\s+(.+?)\n", text)
+    if not m:
+        raise ValueError(f"examples/{name}/README.md: first line must be an H1")
+    return _short_title(m.group(1).strip())
+
+
+def _load_readme_entries() -> list[ReadmeEntry]:
+    data = json.loads(GROUND_TRUTH.read_text(encoding="utf-8"))
+    entries: list[ReadmeEntry] = []
+    for name, meta in data["verdicts"].items():
+        m = re.match(r"case(\d+[a-z]?)", name)
+        if not m:
+            raise ValueError(f"unexpected case name {name!r}")
+        category = meta.get("category")
+        verdict = "BUNDLE" if category == "bundle" else meta["expected"]
+        entries.append(
+            ReadmeEntry(
+                num=m.group(1),
+                name=name,
+                title=_case_title(name),
+                category=category,
+                verdict=verdict,
+                bad_practice=bool(meta.get("bad_practice", False)),
+            )
+        )
+    entries.sort(key=lambda e: (int(re.match(r"(\d+)", e.num).group(1)), e.name))
+    return entries
+
+
+def _render_readme_headline(entries: list[ReadmeEntry]) -> str:
+    n_total = len(entries)
+    n_bundle = sum(1 for e in entries if e.category == "bundle")
+    n_single = n_total - n_bundle
+    return (
+        f"This directory contains **{n_total} cases** "
+        f"({n_single} single-library + {n_bundle} multi-library bundle cases, "
+        "the latter tracked under "
+        "[ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)) "
+        "demonstrating real-world ABI/API break scenarios. Each case is a "
+        "minimal, compilable C/C++ example with:"
+    )
+
+
+def _render_readme_distribution(entries: list[ReadmeEntry]) -> str:
+    single = [e for e in entries if e.category != "bundle"]
+    n_bundle = len(entries) - len(single)
+    by_verdict = Counter(e.verdict for e in single)
+    by_category = Counter(e.category for e in single)
+    rows = [
+        ("BREAKING", by_verdict.get("BREAKING", 0), "`BREAKING_KINDS`", "🔴"),
+        ("API_BREAK", by_verdict.get("API_BREAK", 0), "`API_BREAK_KINDS`", "🟠"),
+        (
+            "COMPATIBLE_WITH_RISK",
+            by_verdict.get("COMPATIBLE_WITH_RISK", 0),
+            "`RISK_KINDS`",
+            "🟡",
+        ),
+        (
+            "COMPATIBLE (addition)",
+            by_category.get("addition", 0),
+            "`ADDITION_KINDS`",
+            "🟢",
+        ),
+        (
+            "COMPATIBLE (quality)",
+            by_category.get("quality", 0),
+            "`QUALITY_KINDS`",
+            "🟡",
+        ),
+        ("NO_CHANGE", by_verdict.get("NO_CHANGE", 0), "—", "✅"),
+        (
+            "Bundle (multi-binary)",
+            n_bundle,
+            "see [ADR-023](../docs/development/adr/023-bundle-aware-multi-binary-analysis.md)",
+            "🔵",
+        ),
+    ]
+    lines = [
+        "| Verdict | Count | `checker_policy.py` set | Icon |",
+        "|---------|-------|-------------------------|------|",
+    ]
+    lines += [
+        f"| {label} | {count} | {kset} | {icon} |" for label, count, kset, icon in rows
+    ]
+    return "\n".join(lines)
+
+
+def _render_readme_index(entries: list[ReadmeEntry]) -> str:
+    lines = [
+        "| # | Case | Category | abicheck verdict |",
+        "|---|------|----------|-----------------|",
+    ]
+    for e in entries:
+        icon = VERDICT_META[e.verdict]["icon"] if e.verdict in VERDICT_META else "🔵"
+        cell = f"{icon} {e.verdict}"
+        if e.bad_practice:
+            cell += " (bad practice)"
+        lines.append(
+            f"| [{e.num}]({e.name}/README.md) | {e.title} "
+            f"| {README_CATEGORY_LABEL[e.category]} | {cell} |"
+        )
+    return "\n".join(lines)
+
+
+def _splice_generated(text: str, marker: str, inner: str) -> str:
+    """Replace the text between BEGIN/END GENERATED sentinels for ``marker``."""
+    begin = re.search(rf"<!-- BEGIN GENERATED: {re.escape(marker)}[^\n]*-->\n", text)
+    end = re.search(rf"\n<!-- END GENERATED: {re.escape(marker)} -->", text)
+    if not begin or not end or begin.end() > end.start():
+        raise ValueError(
+            f"examples/README.md: missing/!ordered sentinels for {marker!r}"
+        )
+    return text[: begin.end()] + inner + text[end.start() :]
+
+
+def _render_examples_readme(text: str, entries: list[ReadmeEntry]) -> str:
+    text = _splice_generated(text, "catalog-headline", _render_readme_headline(entries))
+    text = _splice_generated(
+        text, "verdict-distribution", _render_readme_distribution(entries)
+    )
+    text = _splice_generated(text, "case-index", _render_readme_index(entries))
+    return text
+
+
 def _load_cases() -> list[Case]:
     data = json.loads(GROUND_TRUTH.read_text(encoding="utf-8"))
     cases = []
@@ -466,8 +627,12 @@ def main(argv: Iterable[str] | None = None) -> int:
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     cases = _load_cases()
+    readme_entries = _load_readme_entries()
+    readme_current = EXAMPLES_README.read_text(encoding="utf-8")
+    readme_rendered = _render_examples_readme(readme_current, readme_entries)
 
     if args.check:
+        ok = True
         with tempfile.TemporaryDirectory() as tmp:
             tmp_out = Path(tmp) / "examples"
             _write_tree(tmp_out, cases)
@@ -480,13 +645,28 @@ def main(argv: Iterable[str] | None = None) -> int:
                 )
                 if DOCS_EXAMPLES_DIR.exists():
                     _print_diff(tmp_out, DOCS_EXAMPLES_DIR)
-                return 1
-        print(f"docs/examples/ is up to date ({len(cases)} cases).")
+                ok = False
+        if _normalize(readme_rendered.encode("utf-8")) != _normalize(
+            readme_current.encode("utf-8")
+        ):
+            print(
+                "examples/README.md generated regions are out of date. "
+                "Run: python scripts/gen_examples_docs.py",
+                file=sys.stderr,
+            )
+            ok = False
+        if not ok:
+            return 1
+        print(
+            f"docs/examples/ and examples/README.md are up to date ({len(cases)} cases)."
+        )
         return 0
 
     _write_tree(DOCS_EXAMPLES_DIR, cases)
+    _write(EXAMPLES_README, readme_rendered)
     print(
-        f"Generated {len(cases)} case pages in {DOCS_EXAMPLES_DIR.relative_to(ROOT)}/."
+        f"Generated {len(cases)} case pages in {DOCS_EXAMPLES_DIR.relative_to(ROOT)}/ "
+        f"and refreshed examples/README.md ({len(readme_entries)} catalog rows)."
     )
     return 0
 

--- a/tests/test_ai_readiness.py
+++ b/tests/test_ai_readiness.py
@@ -103,3 +103,62 @@ def test_main_returns_zero_on_clean_tree(car, capsys):
     """
     rc = car.main(["--skip", "mypy-baseline"])
     assert rc == 0, capsys.readouterr().out
+
+
+def test_examples_readme_sync_in_sync(car):
+    """The live examples/README.md catalog must agree with ground_truth.json."""
+    f = car.Findings()
+    car.check_examples_readme_sync(f)
+    assert f.errors == [], f"examples/README.md out of sync: {f.errors}"
+
+
+def _write_synthetic_catalog(tmp_path, *, case02_verdict_cell):
+    """Write a minimal ground_truth.json + README.md pair into tmp_path.
+
+    Two single-library cases (one BREAKING, one COMPATIBLE/addition). The
+    caller controls case02's verdict cell so a test can inject row drift.
+    """
+    import json
+
+    (tmp_path / "ground_truth.json").write_text(
+        json.dumps(
+            {
+                "verdicts": {
+                    "case01_foo": {"expected": "BREAKING", "category": "breaking"},
+                    "case02_bar": {"expected": "COMPATIBLE", "category": "addition"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "This directory contains **2 cases**.\n\n"
+        "| BREAKING | 1 |\n"
+        "| COMPATIBLE (addition) | 1 |\n\n"
+        "| [01](case01_foo/README.md) | Foo | Breaking | 🔴 BREAKING |\n"
+        f"| [02](case02_bar/README.md) | Bar | Addition | {case02_verdict_cell} |\n",
+        encoding="utf-8",
+    )
+
+
+def test_examples_readme_sync_passes_on_correct_synthetic(car, tmp_path, monkeypatch):
+    """A synthetic catalog whose rows match ground_truth yields no errors."""
+    monkeypatch.setattr(car, "EXAMPLES", tmp_path)
+    _write_synthetic_catalog(tmp_path, case02_verdict_cell="🟢 COMPATIBLE")
+    f = car.Findings()
+    car.check_examples_readme_sync(f)
+    assert f.errors == [], f.errors
+
+
+def test_examples_readme_sync_catches_swapped_row_verdict(car, tmp_path, monkeypatch):
+    """A stale per-row verdict (counts unchanged) must fail — the drift the
+    aggregate-count checks alone cannot see (Codex review, PR #318)."""
+    monkeypatch.setattr(car, "EXAMPLES", tmp_path)
+    # case02 is COMPATIBLE/addition in ground_truth, but its row claims BREAKING.
+    # The distribution counts still tally, so only row-content parsing catches it.
+    _write_synthetic_catalog(tmp_path, case02_verdict_cell="🔴 BREAKING")
+    f = car.Findings()
+    car.check_examples_readme_sync(f)
+    assert any("case02_bar" in msg and "BREAKING" in msg for _, msg in f.errors), (
+        f"expected a verdict-mismatch error for case02_bar, got {f.errors}"
+    )


### PR DESCRIPTION
## Summary

Acts on a documentation review of the published ABI/API learning docs. The review's central ask was to reframe the docs from "tool detects a change" toward "a product declares a compatibility **contract**; abicheck gathers **evidence**; **policy** maps facts to release decisions." This PR delivers that framing on the rendered MkDocs site, plus fixes a concrete catalog count-drift bug.

Everything is verified with `mkdocs build --strict` (0 warnings) and the full AI-readiness gate (0 errors).

## What changed

### 1. New published-site page — Compatibility as a Product Contract (`concepts/abi-series/00-product-contract.md`)
Added as **Part 0** of the learning series (the "contract framing" prologue the review asked for):
- Define the **public surface** before checking (headers, exported symbols, plugin entry points, supported platforms/compilers, stdlib ABI, calling conventions, SONAME/install-name policy, symbol-version policy, source-compat promise).
- **SemVer mapping** table: abicheck verdict/class → product meaning → typical SemVer action.
- The same change → two verdicts under different policies.
- **Contract shapes**: traditional C library, C++ SDK, `dlopen` plugin, multi-library bundle.
- Wired into the series nav header of all seven parts, plus the overview table + mermaid.

### 2. New published-site page — Evidence & Detectability (`concepts/evidence-and-detectability.md`)
The central **detectability matrix** the review wanted as a single reference:
- What each evidence source (symbols / debug info / headers / source / runtime / bundle) **can and cannot** detect.
- Method/tool comparison **by evidence**: build-and-swap (`appcompat`), libabigail, ABICC, abicheck, plus complementary methods (rebuilds, probes, baselines, hardening scanners).
- **Traditional vs header-only** libraries, with a header-only compatibility strategy.
- **App-mode scope** (consumer-scoped vs contract-scoped).
- An explicit **"what ABI tools cannot prove"** section.

### 3. Per-role reading paths
Added an audience → recommended-path table to the overview hub (new authors, C++ maintainers, CI/release engineers, distro maintainers, plugin authors, AI reviewers).

### 4. Cross-links from high-traffic pages
`limitations` → evidence page; `verdicts` → the SemVer mapping; `tool-comparison` → the evidence model (why tools disagree).

### 5. Catalog count-drift fix (`examples/README.md`)
The hand-maintained catalog had drifted from `examples/ground_truth.json`: it claimed **122** cases (actual **126**), a stale verdict distribution (83/4/11 vs the true 85/8/10), **3 rows with the wrong verdict** (case32, case84, case97), and **18 missing cases** (90–93, 112–125). Regenerated the headline count, verdict-distribution table, and full 126-row index from ground_truth, and corrected the stale count in `examples/CLAUDE.md`.

To stop this recurring, added an **`examples-readme-sync`** AI-readiness check (the prior `doc-count-sync` gate only anchored headline numbers in `README.md`/`getting-started.md`, so missing rows slipped through). It pins the headline count, per-verdict distribution, and presence of every case row to ground_truth.

## Notes / follow-ups
- The rendered MkDocs encyclopedia (`docs/examples/index.md`) was already correct (auto-generated); the drift was only in the GitHub-facing `examples/README.md`.
- The review also suggests new **compilable example case directories** (SemVer/header-only/appcompat/bundle/build-config) and per-example **evidence badges**. Those are calibration fixtures whose verdicts need toolchain validation (castxml/abidiff) not available in this environment, so they're intentionally **not** included here to avoid shipping unverified ground-truth. Happy to add them as a validated follow-up.

https://claude.ai/code/session_01VVP9hKZzCrJsPpPFfqTyDU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVP9hKZzCrJsPpPFfqTyDU)_