### PR TITLE
Gate Go DWARF runtime filtering by context

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -41,6 +41,7 @@ from .model import (
     AbiSnapshot,
     Visibility,
     cv_qualifiers_only_differ,
+    go_runtime_types_excluded,
     is_non_abi_surface_type,
     stdlib_namespaces_excluded,
 )
@@ -1184,10 +1185,35 @@ def _diff_dwarf(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # surface), but anonymous/lambda and compiler-internal types are still
     # dropped — those are never stable ABI even for the runtime itself.
     excl = stdlib_namespaces_excluded(old, new)
-    o_structs = {k: v for k, v in o_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
-    n_structs = {k: v for k, v in n_structs.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
-    o_enums = {k: v for k, v in o_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
-    n_enums = {k: v for k, v in n_enums.items() if not is_non_abi_surface_type(k, exclude_stdlib_namespaces=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    o_structs = {
+        k: v
+        for k, v in o_structs.items()
+        if not is_non_abi_surface_type(
+            k, exclude_stdlib_namespaces=excl, exclude_go_runtime_types=go_excl
+        )
+    }
+    n_structs = {
+        k: v
+        for k, v in n_structs.items()
+        if not is_non_abi_surface_type(
+            k, exclude_stdlib_namespaces=excl, exclude_go_runtime_types=go_excl
+        )
+    }
+    o_enums = {
+        k: v
+        for k, v in o_enums.items()
+        if not is_non_abi_surface_type(
+            k, exclude_stdlib_namespaces=excl, exclude_go_runtime_types=go_excl
+        )
+    }
+    n_enums = {
+        k: v
+        for k, v in n_enums.items()
+        if not is_non_abi_surface_type(
+            k, exclude_stdlib_namespaces=excl, exclude_go_runtime_types=go_excl
+        )
+    }
 
     filtered_old = DwarfMetadata(structs=o_structs, enums=o_enums, has_dwarf=o.has_dwarf)
     filtered_new = DwarfMetadata(structs=n_structs, enums=n_enums, has_dwarf=n.has_dwarf)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -43,6 +43,7 @@ from .model import (
     Visibility,
     canonicalize_type_name,
     cv_qualifiers_only_differ,
+    go_runtime_types_excluded,
     is_abi_surface_type_name,
     stdlib_namespaces_excluded,
 )
@@ -970,8 +971,19 @@ def _diff_access_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     changes.extend(_check_method_access_changes(_public_functions(old), _public_functions(new)))
     excl = stdlib_namespaces_excluded(old, new)
-    old_types = {t.name: t for t in old.types if not t.is_union and is_abi_surface_type_name(t.name, exclude_stdlib=excl)}
-    new_types = {t.name: t for t in new.types if not t.is_union and is_abi_surface_type_name(t.name, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_types = {
+        t.name: t
+        for t in old.types
+        if not t.is_union
+        and is_abi_surface_type_name(t.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_types = {
+        t.name: t
+        for t in new.types
+        if not t.is_union
+        and is_abi_surface_type_name(t.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
     changes.extend(_check_field_access_changes(old_types, new_types))
     return changes
 
@@ -1033,8 +1045,17 @@ def _diff_anon_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect changes in anonymous struct/union members."""
     changes: list[Change] = []
     excl = stdlib_namespaces_excluded(old, new)
-    old_map = {t.name: t for t in old.types if is_abi_surface_type_name(t.name, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if is_abi_surface_type_name(t.name, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_map = {
+        t.name: t
+        for t in old.types
+        if is_abi_surface_type_name(t.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_map = {
+        t.name: t
+        for t in new.types
+        if is_abi_surface_type_name(t.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)

--- a/abicheck/diff_type_spellings.py
+++ b/abicheck/diff_type_spellings.py
@@ -33,6 +33,7 @@ from .model import (
     AbiSnapshot,
     Function,
     Visibility,
+    go_runtime_types_excluded,
     is_abi_surface_type_name,
     stdlib_namespaces_excluded,
 )
@@ -116,8 +117,17 @@ def _match_record_fields(
 ) -> Iterator[TypeSlotChange]:
     """Yield field-spelling changes for record types present in both snapshots."""
     excl = stdlib_namespaces_excluded(old, new)
-    old_types = {t.name: t for t in old.types if is_abi_surface_type_name(t.name, exclude_stdlib=excl)}
-    new_types = {t.name: t for t in new.types if is_abi_surface_type_name(t.name, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_types = {
+        t.name: t
+        for t in old.types
+        if is_abi_surface_type_name(t.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_types = {
+        t.name: t
+        for t in new.types
+        if is_abi_surface_type_name(t.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
     for name in set(old_types) & set(new_types):
         nt = new_types[name]
         new_fields = {f.name: f for f in nt.fields}

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -36,6 +36,7 @@ from .model import (
     TypeField,
     canonicalize_type_name,
     cv_qualifiers_only_differ,
+    go_runtime_types_excluded,
 )
 from .model import is_non_abi_surface_type as _is_non_abi_surface_type
 from .model import stdlib_namespaces_excluded as _exclude_stdlib_namespaces
@@ -55,14 +56,36 @@ def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: Collection[st
     )
 
 
-def _is_abi_surface_type(t: RecordType, *, exclude_stdlib: bool) -> bool:
+def _is_abi_surface_type(
+    t: RecordType,
+    *,
+    exclude_stdlib: bool,
+    exclude_go_runtime: bool,
+) -> bool:
     """True if record *t* is part of the inspected library's ABI surface.
 
     Shared by every type-level detector (records, unions, field/kind/reserved
     diffs) so std::/anonymous filtering (FP-1/FP-2) is applied consistently and
     cannot be bypassed via an alternate map-construction path.
     """
-    return not _is_non_abi_surface_type(t.name, exclude_stdlib_namespaces=exclude_stdlib)
+    return not _is_non_abi_surface_type(
+        t.name,
+        exclude_stdlib_namespaces=exclude_stdlib,
+        exclude_go_runtime_types=exclude_go_runtime,
+    )
+
+
+def _is_abi_surface_name(
+    name: str,
+    *,
+    exclude_stdlib: bool,
+    exclude_go_runtime: bool,
+) -> bool:
+    return not _is_non_abi_surface_type(
+        name,
+        exclude_stdlib_namespaces=exclude_stdlib,
+        exclude_go_runtime_types=exclude_go_runtime,
+    )
 
 
 def _has_type_evidence(snap: AbiSnapshot) -> bool:
@@ -141,8 +164,17 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # Include ALL types (including unions) for size/alignment/base/vtable checks.
     # TYPE_FIELD_* for unions is skipped below — handled by _diff_unions() instead.
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_map = {
+        t.name: t
+        for t in old.types
+        if _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_map = {
+        t.name: t
+        for t in new.types
+        if _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
     # RD2-5: don't manufacture phantom TYPE_REMOVED when the new side is stripped.
     suppress_removed = _removals_are_unconfirmed(old, new)
 
@@ -532,11 +564,16 @@ def _diff_type_vtable(name: str, t_old: RecordType, t_new: RecordType) -> list[C
 def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
+    go_excl = go_runtime_types_excluded(old, new)
     old_map: dict[str, EnumType] = {
-        e.name: e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+        e.name: e
+        for e in old.enums
+        if _is_abi_surface_name(e.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
     }
     new_map: dict[str, EnumType] = {
-        e.name: e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+        e.name: e
+        for e in new.enums
+        if _is_abi_surface_name(e.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
     }
 
     for name, e_old in old_map.items():
@@ -728,8 +765,17 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_unions = {t.name: t for t in old.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_unions = {t.name: t for t in new.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_unions = {
+        t.name: t
+        for t in old.types
+        if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_unions = {
+        t.name: t
+        for t in new.types
+        if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
 
     for name, t_old in old_unions.items():
         if name not in new_unions:
@@ -814,10 +860,11 @@ def _has_version_family_successor(name: str, new_typedefs: dict[str, str]) -> bo
 def _diff_typedefs(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
+    go_excl = go_runtime_types_excluded(old, new)
     # RD2-5: don't manufacture phantom TYPEDEF_REMOVED when the new side is stripped.
     suppress_removed = _removals_are_unconfirmed(old, new)
     for alias, old_type in old.typedefs.items():
-        if _is_non_abi_surface_type(alias, exclude_stdlib_namespaces=excl):
+        if not _is_abi_surface_name(alias, exclude_stdlib=excl, exclude_go_runtime=go_excl):
             continue
         new_type = new.typedefs.get(alias)
         if new_type is None and suppress_removed:
@@ -868,11 +915,16 @@ def _diff_enum_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect enum member renames: same value present under different name."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
+    go_excl = go_runtime_types_excluded(old, new)
     old_map: dict[str, EnumType] = {
-        e.name: e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+        e.name: e
+        for e in old.enums
+        if _is_abi_surface_name(e.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
     }
     new_map: dict[str, EnumType] = {
-        e.name: e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+        e.name: e
+        for e in new.enums
+        if _is_abi_surface_name(e.name, exclude_stdlib=excl, exclude_go_runtime=go_excl)
     }
 
     for name, e_old in old_map.items():
@@ -975,8 +1027,17 @@ def _diff_field_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect field-level const/volatile/mutable qualifier changes."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_map = {
+        t.name: t
+        for t in old.types
+        if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_map = {
+        t.name: t
+        for t in new.types
+        if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -999,8 +1060,17 @@ def _diff_field_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect field renames: same offset+type, different name."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_map = {
+        t.name: t
+        for t in old.types
+        if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_map = {
+        t.name: t
+        for t in new.types
+        if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1073,8 +1143,17 @@ def _diff_type_kind_changes(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect struct↔union kind changes (ABICC: StructToUnion / DataType_Type)."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_map = {
+        t.name: t
+        for t in old.types
+        if _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_map = {
+        t.name: t
+        for t in new.types
+        if _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1106,8 +1185,17 @@ def _diff_reserved_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    go_excl = go_runtime_types_excluded(old, new)
+    old_map = {
+        t.name: t
+        for t in old.types
+        if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
+    new_map = {
+        t.name: t
+        for t in new.types
+        if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl, exclude_go_runtime=go_excl)
+    }
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -86,7 +86,6 @@ _GO_EMBEDDED_MARKERS: tuple[str, ...] = (
     "strconv.",
 )
 _GO_GENERIC_RUNTIME_MARKERS: tuple[str, ...] = ("/", ".")
-
 # Substrings that mark an anonymous / local type with no stable cross-version
 # ABI identity — lambdas and unnamed struct/union/enum (validation/REPORT.md
 # FP-2). gcc renders these as "<lambda...>", "{lambda...}", "(anonymous ...)";
@@ -96,7 +95,66 @@ _ANONYMOUS_TYPE_MARKERS: tuple[str, ...] = (
 )
 
 
-def is_non_abi_surface_type(name: str, *, exclude_stdlib_namespaces: bool = True) -> bool:
+def _go_type_candidate(name: str) -> str:
+    return name[2:] if name.startswith("[]") else name
+
+
+def _is_go_runtime_evidence_type_name(name: str) -> bool:
+    """Return True when *name* is strong evidence that a snapshot came from Go."""
+    if not name:
+        return False
+    candidate = _go_type_candidate(name)
+    return (
+        candidate.startswith(_GO_RUNTIME_TYPE_PREFIXES)
+        or (
+            candidate.startswith("struct {")
+            and any(marker in candidate for marker in _GO_EMBEDDED_MARKERS)
+        )
+    )
+
+
+def is_go_runtime_type_name(name: str) -> bool:
+    """Return True for Go runtime/internal DWARF type names."""
+    if not name:
+        return False
+    go_candidate = _go_type_candidate(name)
+    return (
+        name.startswith(_GO_RUNTIME_TYPE_PREFIXES)
+        or go_candidate.startswith(_GO_RUNTIME_TYPE_PREFIXES)
+        or (
+            go_candidate.startswith(_GO_GENERIC_RUNTIME_TYPE_PREFIXES)
+            and any(marker in go_candidate for marker in _GO_GENERIC_RUNTIME_MARKERS)
+        )
+        or "/" in name
+        or bool(_GO_PACKAGE_QUALIFIED_RE.match(go_candidate))
+        or (
+            go_candidate.startswith("struct {")
+            and any(marker in go_candidate for marker in _GO_EMBEDDED_MARKERS)
+        )
+    )
+
+
+def go_runtime_types_excluded(old: AbiSnapshot, new: AbiSnapshot) -> bool:
+    """Return True when Go runtime/internal DWARF type filtering should run."""
+    names: list[str] = []
+    for snap in (old, new):
+        names.extend(t.name for t in snap.types)
+        names.extend(e.name for e in snap.enums)
+        names.extend(snap.typedefs)
+        names.extend(snap.typedefs.values())
+        dwarf = getattr(snap, "dwarf", None)
+        if dwarf is not None:
+            names.extend(getattr(dwarf, "structs", {}))
+            names.extend(getattr(dwarf, "enums", {}))
+    return any(_is_go_runtime_evidence_type_name(name) for name in names)
+
+
+def is_non_abi_surface_type(
+    name: str,
+    *,
+    exclude_stdlib_namespaces: bool = True,
+    exclude_go_runtime_types: bool = False,
+) -> bool:
     """Return True if *name* is a type that is never the inspected library's own
     ABI surface and must be excluded from type diffing.
 
@@ -116,21 +174,7 @@ def is_non_abi_surface_type(name: str, *, exclude_stdlib_namespaces: bool = True
         return True
     if exclude_stdlib_namespaces and name.startswith(_STDLIB_TYPE_NAMESPACE_PREFIXES):
         return True
-    go_candidate = name[2:] if name.startswith("[]") else name
-    if (
-        name.startswith(_GO_RUNTIME_TYPE_PREFIXES)
-        or go_candidate.startswith(_GO_RUNTIME_TYPE_PREFIXES)
-        or (
-            go_candidate.startswith(_GO_GENERIC_RUNTIME_TYPE_PREFIXES)
-            and any(marker in go_candidate for marker in _GO_GENERIC_RUNTIME_MARKERS)
-        )
-        or "/" in name
-        or _GO_PACKAGE_QUALIFIED_RE.match(go_candidate)
-        or (
-            go_candidate.startswith("struct {")
-            and any(marker in go_candidate for marker in _GO_EMBEDDED_MARKERS)
-        )
-    ):
+    if exclude_go_runtime_types and is_go_runtime_type_name(name):
         return True
     return any(marker in name for marker in _ANONYMOUS_TYPE_MARKERS)
 
@@ -176,14 +220,23 @@ def stdlib_namespaces_excluded(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     )
 
 
-def is_abi_surface_type_name(name: str, *, exclude_stdlib: bool) -> bool:
+def is_abi_surface_type_name(
+    name: str,
+    *,
+    exclude_stdlib: bool,
+    exclude_go_runtime: bool = False,
+) -> bool:
     """Return True if a type *name* belongs to the inspected library's ABI
     surface (i.e. is NOT filtered as std::/anonymous/compiler-internal).
 
     Convenience inverse of :func:`is_non_abi_surface_type` for use in the
     ``{t.name: t for t in snap.types if is_abi_surface_type_name(...)}`` idiom
     shared across detector modules."""
-    return not is_non_abi_surface_type(name, exclude_stdlib_namespaces=exclude_stdlib)
+    return not is_non_abi_surface_type(
+        name,
+        exclude_stdlib_namespaces=exclude_stdlib,
+        exclude_go_runtime_types=exclude_go_runtime,
+    )
 
 # ---------------------------------------------------------------------------
 # Type name canonicalization — normalise type names for reliable matching.

--- a/tests/test_bugfix_regressions.py
+++ b/tests/test_bugfix_regressions.py
@@ -15,6 +15,7 @@ import click
 import pytest
 
 from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
+from abicheck.dwarf_metadata import DwarfMetadata, StructLayout
 from abicheck.model import (
     AbiSnapshot,
     EnumMember,
@@ -26,6 +27,7 @@ from abicheck.model import (
     TypeField,
     Variable,
     Visibility,
+    go_runtime_types_excluded,
     is_non_abi_surface_type,
 )
 from abicheck.report_summary import build_summary, compatibility_metrics
@@ -123,6 +125,67 @@ class TestGoRuntimeDwarfNoise:
         assert is_non_abi_surface_type("map<int,int>") is False
         assert result.verdict is Verdict.BREAKING
         assert any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in result.changes)
+
+    def test_non_go_dotted_and_slash_type_names_are_kept(self):
+        old = _snap(types=[
+            RecordType(name="module.Type", kind="struct", size_bits=64),
+            RecordType(name="vendor/type", kind="struct", size_bits=64),
+        ])
+        new = _snap("2.0", types=[
+            RecordType(name="module.Type", kind="struct", size_bits=128),
+            RecordType(name="vendor/type", kind="struct", size_bits=128),
+        ])
+
+        result = compare(old, new)
+
+        assert go_runtime_types_excluded(old, new) is False
+        assert is_non_abi_surface_type("module.Type") is False
+        assert is_non_abi_surface_type("vendor/type") is False
+        assert result.verdict is Verdict.BREAKING
+        assert {c.symbol for c in result.changes if c.kind == ChangeKind.TYPE_SIZE_CHANGED} == {
+            "module.Type",
+            "vendor/type",
+        }
+
+    def test_go_context_keeps_native_looking_generic_templates(self):
+        old = _snap(
+            funcs=[_pub_func("AdbcDriverInit", "AdbcDriverInit")],
+            types=[
+                RecordType(name="runtime.g", kind="struct", size_bits=3520),
+                RecordType(name="map<int,int>", kind="struct", size_bits=64),
+                RecordType(name="hchan<int>", kind="struct", size_bits=64),
+            ],
+        )
+        new = _snap(
+            "2.0",
+            funcs=[_pub_func("AdbcDriverInit", "AdbcDriverInit")],
+            types=[
+                RecordType(name="runtime.g", kind="struct", size_bits=3520),
+                RecordType(name="map<int,int>", kind="struct", size_bits=128),
+                RecordType(name="hchan<int>", kind="struct", size_bits=128),
+            ],
+        )
+
+        result = compare(old, new)
+
+        assert go_runtime_types_excluded(old, new) is True
+        assert is_non_abi_surface_type("map<int,int>", exclude_go_runtime_types=True) is False
+        assert is_non_abi_surface_type("hchan<int>", exclude_go_runtime_types=True) is False
+        assert result.verdict is Verdict.BREAKING
+        assert {c.symbol for c in result.changes if c.kind == ChangeKind.TYPE_SIZE_CHANGED} == {
+            "map<int,int>",
+            "hchan<int>",
+        }
+
+    def test_go_context_detects_raw_dwarf_runtime_evidence(self):
+        old = _snap(types=[RecordType(name="map<int,int>", kind="struct", size_bits=64)])
+        old.dwarf = DwarfMetadata(structs={"runtime.g": StructLayout("runtime.g", 440)})
+        new = _snap("2.0", types=[RecordType(name="map<int,int>", kind="struct", size_bits=128)])
+
+        assert go_runtime_types_excluded(old, new) is True
+        result = compare(old, new)
+        assert result.verdict is Verdict.BREAKING
+        assert any(c.symbol == "map<int,int>" for c in result.changes)
 
 
 # ── Bug 1: Enum symbols use member-qualified format ──────────────────────────


### PR DESCRIPTION
Follow-up to #306 after team review.

This keeps the original C++ `map<int,int>` regression fix and additionally gates Go runtime/internal type filtering on snapshot-level Go evidence. That way primitive Go runtime generics such as `map<int,int>`/`hchan<int>` are filtered only for Go c-shared snapshots, while non-Go public ABI types with dotted or slash-like names remain visible.

Proof:
- `pytest -q tests/test_bugfix_regressions.py::TestGoRuntimeDwarfNoise`
- `pytest -q tests/test_real_world_false_positives.py::test_is_non_abi_surface_type_keeps_stdlib_when_requested tests/test_bugfix_regressions.py::TestGoRuntimeDwarfNoise`
- `ruff check abicheck/model.py abicheck/diff_platform.py abicheck/diff_symbols.py abicheck/diff_type_spellings.py abicheck/diff_types.py tests/test_bugfix_regressions.py`