### PR TITLE
Handle versioned shared-library basenames in validation harness

### DIFF
--- a/tests/test_validation_run_matrix.py
+++ b/tests/test_validation_run_matrix.py
@@ -1,0 +1,31 @@
+"""Tests for the real-world validation harness helpers."""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+from pathlib import Path
+
+
+def _load_logical_name():
+    script = Path("validation/scripts/run_matrix.py").read_text()
+    module = ast.parse(script)
+    func = next(node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "logical_name")
+    ns = {"os": os, "re": re}
+    exec(compile(ast.Module(body=[func], type_ignores=[]), str(Path("validation/scripts/run_matrix.py")), "exec"), ns)
+    return ns["logical_name"]
+
+
+def test_logical_name_handles_standard_soname_suffixes() -> None:
+    logical_name = _load_logical_name()
+
+    assert logical_name("/pkg/lib/libprotobuf.so.33.5.0") == "libprotobuf"
+    assert logical_name("/pkg/lib/libssl.so.3") == "libssl"
+
+
+def test_logical_name_strips_version_embedded_before_so_suffix() -> None:
+    logical_name = _load_logical_name()
+
+    assert logical_name("/pkg/lib/libcapnp-1.4.0.so") == "libcapnp"
+    assert logical_name("/pkg/lib/libkj-async-1.3.0.so") == "libkj-async"

--- a/validation/scripts/run_matrix.py
+++ b/validation/scripts/run_matrix.py
@@ -14,7 +14,14 @@ relative to the repo). Each package extracts to ``<libs>/<pkg_stem>/lib/*.so*`` 
 see ``data/manifest.json`` for the conda-forge files to fetch and extract.
 """
 from __future__ import annotations
-import json, os, re, subprocess, time, glob, sys
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 VALID_DIR = Path(__file__).resolve().parent.parent          # validation/
@@ -35,7 +42,8 @@ if not os.path.isdir(EX):
 
 def logical_name(path: str) -> str:
     b = os.path.basename(path)
-    return b.split(".so")[0]
+    stem = b.split(".so")[0]
+    return re.sub(r"-(?:\d+\.)+\d+$", "", stem)
 
 def real_sos(pkgdir: str) -> dict[str, str]:
     """logical_name -> path for every real (non-symlink) ELF .so in pkgdir/lib."""


### PR DESCRIPTION
## Summary
- normalize validation harness logical DSO names for files like libcapnp-1.4.0.so
- preserve existing handling for normal SONAME suffixes like libprotobuf.so.33.5.0
- add a focused regression test without executing the scan harness at import time

## Evidence
The 20260607-1738 real-world campaign run initially missed Cap'n Proto shared libraries because old/new package files used version-embedded basenames such as libcapnp-1.3.0.so and libcapnp-1.4.0.so. Manual normalized comparisons found 11 comparable Cap'n Proto DSOs, including one abidiff-confirmed product ABI transition in libcapnp.

## Test
- pytest -q tests/test_validation_run_matrix.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying library-name normalization correctly handles standard .so version suffixes and removes embedded version segments so different package versions map consistently.

* **Bug Fixes**
  * Improved name-normalization logic to strip trailing numeric version segments from shared-library basenames, enabling reliable matching and pairing across versioned library filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->