### PR TITLE
Preserve runtime-owned stdlib symbols by SONAME

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -1113,8 +1113,24 @@ def _diff_vtable_identity(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # Find vtable/typeinfo symbols by mangling convention (_ZTV, _ZTI, _ZTS)
     _RTTI_PREFIXES = ("_ZTV", "_ZTI", "_ZTS")
 
-    old_rtti = {s.name for s in o.symbols if any(s.name.startswith(p) for p in _RTTI_PREFIXES)}
-    new_rtti = {s.name for s in n.symbols if any(s.name.startswith(p) for p in _RTTI_PREFIXES)}
+    old_filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(old)
+    new_filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(new)
+    old_rtti = {
+        s.name for s in o.symbols
+        if any(s.name.startswith(p) for p in _RTTI_PREFIXES)
+        and is_abi_relevant_elf_symbol(
+            s.name,
+            filter_transitive_runtime_symbols=old_filter_transitive_runtime_symbols,
+        )
+    }
+    new_rtti = {
+        s.name for s in n.symbols
+        if any(s.name.startswith(p) for p in _RTTI_PREFIXES)
+        and is_abi_relevant_elf_symbol(
+            s.name,
+            filter_transitive_runtime_symbols=new_filter_transitive_runtime_symbols,
+        )
+    }
 
     removed_rtti = old_rtti - new_rtti
     added_rtti = new_rtti - old_rtti

--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -33,7 +33,7 @@ from .diff_platform_templates import (
 from .diff_platform_templates import (
     _template_outer as _template_outer,
 )
-from .diff_symbols import _public_functions
+from .diff_symbols import _public_functions, _should_filter_transitive_runtime_symbols
 from .diff_types import _RESERVED_FIELD_RE
 from .elf_metadata import SymbolBinding, SymbolType
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
@@ -41,7 +41,6 @@ from .model import (
     AbiSnapshot,
     Visibility,
     cv_qualifiers_only_differ,
-    is_cxx_runtime_library,
     is_non_abi_surface_type,
     stdlib_namespaces_excluded,
 )
@@ -319,7 +318,7 @@ def _diff_visibility_leak(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if not getattr(old, "elf_only_mode", False):
         return []
 
-    filter_transitive_runtime_symbols = not is_cxx_runtime_library(old.library)
+    filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(old)
     leaked = [
         f for f in old.functions
         if (

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -109,7 +109,11 @@ def _is_local_type_rtti(mangled: str) -> bool:
 
 
 def _should_filter_transitive_runtime_symbols(snap: AbiSnapshot) -> bool:
-    """Return False when *snap* identifies the inspected DSO as C++ runtime."""
+    """Return True when transitive C++ runtime symbols should be filtered.
+
+    Returns False when ``snap.library`` or the ELF SONAME identifies *snap* as
+    the C++ runtime itself, where runtime-owned symbols are the inspected ABI.
+    """
     elf = getattr(snap, "elf", None)
     return not (
         is_cxx_runtime_library(snap.library)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -108,6 +108,15 @@ def _is_local_type_rtti(mangled: str) -> bool:
     return mangled.startswith(_LOCAL_RTTI_PREFIXES)
 
 
+def _should_filter_transitive_runtime_symbols(snap: AbiSnapshot) -> bool:
+    """Return False when *snap* identifies the inspected DSO as C++ runtime."""
+    elf = getattr(snap, "elf", None)
+    return not (
+        is_cxx_runtime_library(snap.library)
+        or is_cxx_runtime_library(getattr(elf, "soname", ""))
+    )
+
+
 def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     """Return public/ELF-only functions from *snap*.
 
@@ -124,7 +133,7 @@ def _public_functions(snap: AbiSnapshot) -> dict[str, Function]:
     theory hide a genuine removal — but DWARF-primary snapshots carry the full
     ``.dynsym``, so in practice the export set is authoritative here.
     """
-    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
+    filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(snap)
     funcs = {
         k: v for k, v in snap.function_map.items()
         if (
@@ -160,7 +169,7 @@ def _public_variables(snap: AbiSnapshot) -> dict[str, Variable]:
     other in-function types): they are not nameable public ABI and only churn
     across builds (RD2-4).
     """
-    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
+    filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(snap)
     return {
         k: v for k, v in snap.variable_map.items()
         if (
@@ -1829,7 +1838,7 @@ def _fingerprints_from_elf(snap: AbiSnapshot) -> dict[str, FunctionFingerprint]:
     """
     if snap.elf is None:
         return {}
-    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
+    filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(snap)
     result: dict[str, FunctionFingerprint] = {}
     for sym in snap.elf.symbols:
         if sym.sym_type not in _FUNC_LIKE_TYPES:
@@ -1878,8 +1887,8 @@ def _diff_fingerprint_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change
 
     old_elf = getattr(old, "elf", None)
     new_elf = getattr(new, "elf", None)
-    old_filter_transitive_runtime_symbols = not is_cxx_runtime_library(old.library)
-    new_filter_transitive_runtime_symbols = not is_cxx_runtime_library(new.library)
+    old_filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(old)
+    new_filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(new)
     old_exported_funcs = {
         sym.name
         for sym in (old_elf.symbols if old_elf is not None else [])

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -22,7 +22,12 @@ from collections.abc import Collection
 from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
-from .diff_symbols import _PUBLIC_VIS, _public_functions, _public_variables
+from .diff_symbols import (
+    _PUBLIC_VIS,
+    _public_functions,
+    _public_variables,
+    _should_filter_transitive_runtime_symbols,
+)
 from .elf_symbol_filter import (
     FUNCTION_SYMBOL_TYPES,
     VARIABLE_SYMBOL_TYPES,
@@ -36,7 +41,6 @@ from .model import (
     TypeField,
     canonicalize_type_name,
     cv_qualifiers_only_differ,
-    is_cxx_runtime_library,
 )
 from .model import is_non_abi_surface_type as _is_non_abi_surface_type
 from .model import stdlib_namespaces_excluded as _exclude_stdlib_namespaces
@@ -51,7 +55,7 @@ def _exported_elf_symbol_names(snap: AbiSnapshot, *, symbol_types: Collection[st
     the DWARF-derived Function/Variable lists. Transitive runtime/compiler
     exports are excluded so they can't inflate retention.
     """
-    filter_transitive_runtime_symbols = not is_cxx_runtime_library(snap.library)
+    filter_transitive_runtime_symbols = _should_filter_transitive_runtime_symbols(snap)
     return exported_symbol_names(
         getattr(snap, "elf", None),
         symbol_types,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -733,6 +733,8 @@ def _populate_elf_visibility(snap: AbiSnapshot) -> None:
 def _elf_classify_symbols(
     elf_meta: ElfMetadata,
     exported_dynamic: set[str],
+    *,
+    library_name: str | None = None,
 ) -> tuple[set[str], set[str], set[str], set[str]]:
     """Split ELF metadata symbols into typed subsets for the no-header path.
 
@@ -745,7 +747,8 @@ def _elf_classify_symbols(
     exported_dynamic_objects: set[str] = set()
     exported_dynamic_tls: set[str] = set()
     if elf_meta.symbols:
-        filter_transitive_runtime_symbols = not is_cxx_runtime_library(elf_meta.soname)
+        runtime_name = elf_meta.soname or library_name
+        filter_transitive_runtime_symbols = not is_cxx_runtime_library(runtime_name)
         # Apply the shared ABI-relevance filter here too: this no-header path
         # rebuilds the exported sets directly from ``elf_meta.symbols`` rather
         # than the already-filtered ``_pyelftools_exported_symbols`` result, so
@@ -948,7 +951,7 @@ def _dump_elf(
 
     elf_meta = parse_elf_metadata(so_path)
     exported_dynamic, exported_dynamic_funcs, exported_dynamic_objects, exported_dynamic_tls = (
-        _elf_classify_symbols(elf_meta, exported_dynamic)
+        _elf_classify_symbols(elf_meta, exported_dynamic, library_name=so_path.name)
     )
     dwarf_meta, dwarf_adv = _resolve_debug_metadata(so_path, debug_format)
     profile_hint = _elf_lang_to_profile(lang)

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -137,8 +137,13 @@ def stdlib_namespaces_excluded(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     registered detector that consumes ``snapshot.types`` agrees on whether to
     keep std:: records (validation/REPORT.md FP-1; Codex reviews on PR #273).
     """
+    old_elf = getattr(old, "elf", None)
+    new_elf = getattr(new, "elf", None)
     return not (
-        is_cxx_runtime_library(old.library) or is_cxx_runtime_library(new.library)
+        is_cxx_runtime_library(old.library)
+        or is_cxx_runtime_library(new.library)
+        or is_cxx_runtime_library(getattr(old_elf, "soname", ""))
+        or is_cxx_runtime_library(getattr(new_elf, "soname", ""))
     )
 
 

--- a/tests/test_diff_types_deep.py
+++ b/tests/test_diff_types_deep.py
@@ -7,6 +7,7 @@ other type-related ChangeKinds that have minimal dedicated test coverage.
 from __future__ import annotations
 
 from abicheck.checker import ChangeKind, Verdict, compare
+from abicheck.elf_metadata import ElfMetadata
 from abicheck.model import (
     AbiSnapshot,
     AccessLevel,
@@ -36,6 +37,25 @@ def _pub_func(name, mangled, ret="void", params=None, **kwargs):
 
 def _kinds(result):
     return {c.kind for c in result.changes}
+
+
+def test_stdlib_type_filter_uses_elf_soname_for_runtime_snapshots() -> None:
+    old = AbiSnapshot(
+        library="old-renamed-copy.so",
+        version="1.0",
+        elf=ElfMetadata(soname="libstdc++.so.6"),
+        types=[RecordType(name="std::runtime_surface", kind="class", size_bits=64)],
+    )
+    new = AbiSnapshot(
+        library="new-renamed-copy.so",
+        version="2.0",
+        elf=ElfMetadata(soname="libstdc++.so.6"),
+        types=[RecordType(name="std::runtime_surface", kind="class", size_bits=128)],
+    )
+
+    result = compare(old, new)
+
+    assert ChangeKind.TYPE_SIZE_CHANGED in _kinds(result)
 
 
 # ── Union field changes (2-3 refs each) ──────────────────────────────────

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -249,12 +249,16 @@ def test_dwarf_export_index_preserves_runtime_owned_stdlib_exports(tmp_path) -> 
         symbols=[
             ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv"),
             ElfSymbol(name="_ZSt4cout"),
+            ElfSymbol(name="_init"),
+            ElfSymbol(name="__cpu_model"),
         ],
     )
     builder = _DwarfSnapshotBuilder(tmp_path / "libstdc++.so.6", meta)
 
     assert "_ZNSt6vectorIiSaIiEE4sizeEv" in builder._exported_names
     assert "_ZSt4cout" in builder._exported_names
+    assert "_init" not in builder._exported_names
+    assert "__cpu_model" not in builder._exported_names
 
 
 # ---------------------------------------------------------------------------
@@ -397,6 +401,31 @@ def test_elf_classify_symbols_preserves_runtime_owned_stdlib_exports() -> None:
 
     assert funcs == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
     assert objects == {"_ZTVSt9exception", "_ZTTSt23_Sp_counted_ptr_inplaceE"}
+    assert tls == set()
+    assert full == funcs | objects
+
+
+def test_elf_classify_symbols_uses_library_name_when_soname_is_missing() -> None:
+    """Symbols-only runtime dumps may need the input filename as owner context."""
+    from abicheck.dumper import _elf_classify_symbols
+
+    meta = ElfMetadata(
+        symbols=[
+            ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="_ZTVSt9exception", sym_type=SymbolType.OBJECT),
+            ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ElfSymbol(name="__cpu_model", sym_type=SymbolType.OBJECT),
+        ],
+    )
+
+    full, funcs, objects, tls = _elf_classify_symbols(
+        meta,
+        set(),
+        library_name="libstdc++.so.6",
+    )
+
+    assert funcs == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
+    assert objects == {"_ZTVSt9exception"}
     assert tls == set()
     assert full == funcs | objects
 

--- a/tests/test_elf_symbol_filters.py
+++ b/tests/test_elf_symbol_filters.py
@@ -478,6 +478,26 @@ def test_public_functions_preserves_runtime_owned_stdlib_exports() -> None:
     assert set(_public_functions(snap)) == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
 
 
+def test_public_functions_uses_elf_soname_for_runtime_context() -> None:
+    snap = AbiSnapshot(
+        library="tmp-renamed-copy.so",
+        version="1",
+        functions=[
+            _function("_ZNSt6vectorIiSaIiEE4sizeEv"),
+            _function("_init"),
+        ],
+        elf=ElfMetadata(
+            soname="libstdc++.so.6",
+            symbols=[
+                ElfSymbol(name="_ZNSt6vectorIiSaIiEE4sizeEv", sym_type=SymbolType.FUNC),
+                ElfSymbol(name="_init", sym_type=SymbolType.FUNC),
+            ],
+        ),
+    )
+
+    assert set(_public_functions(snap)) == {"_ZNSt6vectorIiSaIiEE4sizeEv"}
+
+
 def _variable(name: str) -> Variable:
     return Variable(
         name=name,
@@ -511,6 +531,24 @@ def test_public_variables_preserves_runtime_owned_stdlib_vtables() -> None:
             _variable("_ZTTSt23_Sp_counted_ptr_inplaceE"),
             _variable("__cpu_model"),
         ],
+    )
+
+    assert set(_public_variables(snap)) == {
+        "_ZTVSt9exception",
+        "_ZTTSt23_Sp_counted_ptr_inplaceE",
+    }
+
+
+def test_public_variables_uses_elf_soname_for_runtime_context() -> None:
+    snap = AbiSnapshot(
+        library="tmp-renamed-copy.so",
+        version="1",
+        variables=[
+            _variable("_ZTVSt9exception"),
+            _variable("_ZTTSt23_Sp_counted_ptr_inplaceE"),
+            _variable("__cpu_model"),
+        ],
+        elf=ElfMetadata(soname="libstdc++.so.6"),
     )
 
     assert set(_public_variables(snap)) == {

--- a/tests/test_new_detectors.py
+++ b/tests/test_new_detectors.py
@@ -448,6 +448,17 @@ class TestVtableIdentity:
         r = compare(_snap(elf=old_elf), _snap(elf=new_elf))
         assert not _has_kind(r, ChangeKind.VTABLE_SYMBOL_IDENTITY_CHANGED)
 
+    def test_transitive_stdlib_rtti_is_filtered(self):
+        """Weak stdlib RTTI churn from dependencies is not this DSO's ABI."""
+        old_elf = ElfMetadata(symbols=[
+            _elf_sym("_ZTVSt9exception", sym_type=SymbolType.OBJECT, version="VER_1"),
+        ])
+        new_elf = ElfMetadata(symbols=[
+            _elf_sym("_ZTVSt9exception", sym_type=SymbolType.OBJECT, version="VER_2"),
+        ])
+        r = compare(_snap(elf=old_elf), _snap(elf=new_elf))
+        assert not _has_kind(r, ChangeKind.VTABLE_SYMBOL_IDENTITY_CHANGED)
+
 
 # ── ABI_SURFACE_EXPLOSION ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to #313 after late review comments landed during merge.\n\nWhat changed:\n- Use either snapshot library name or ELF SONAME to detect C++ runtime snapshots in diff helpers.\n- Apply the same runtime-symbol gate to vtable/typeinfo identity detection.\n- Let ELF-only classification fall back to the input filename when DT_SONAME is missing.\n- Add regressions for renamed libstdc++ snapshots, missing SONAME runtime dumps, DWARF runtime filtering, and transitive stdlib RTTI churn.\n\nLocal validation:\n- pytest -q tests/test_elf_symbol_filters.py tests/test_new_detectors.py tests/test_diff_platform_deep.py tests/test_diff_symbols_deep.py tests/test_diff_symbols_review.py tests/test_diff_types_deep.py tests/test_bugfix_regressions.py tests/test_real_world_false_positives.py\n- ruff check abicheck/diff_symbols.py abicheck/diff_types.py abicheck/diff_platform.py abicheck/dumper.py tests/test_elf_symbol_filters.py tests/test_new_detectors.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and made runtime/stdlib ELF symbol filtering consistent across detectors to reduce false ABI reports.
  * Use ELF soname or provided library name as a reliable fallback when metadata is missing, improving RTTI and export classification.
  * Fixed edge cases where runtime-owned symbols were incorrectly included or excluded.

* **Tests**
  * Added and expanded tests to validate runtime symbol filtering and RTTI handling across ELF metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->