### PR TITLE
fix: prevent builtin policy shadowing by local files

### DIFF
--- a/abicheck/cli_params.py
+++ b/abicheck/cli_params.py
@@ -36,8 +36,13 @@ class PolicyFileParam(click.ParamType):
         from .policies import builtin_policy_names
         from .policy_file import builtin_policy_path
 
-        p = Path(value)
-        if p.exists() or builtin_policy_path(str(value)) is not None:
+        value_str = str(value)
+        builtin = builtin_policy_path(value_str)
+        if builtin is not None:
+            return builtin
+
+        p = Path(value_str)
+        if p.exists():
             return p
         names = ", ".join(builtin_policy_names())
         raise click.BadParameter(

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -79,11 +79,15 @@ _VALID_BASE_POLICIES = VALID_BASE_POLICIES  # re-export alias for backward compa
 def builtin_policy_path(name: str) -> Path | None:
     """Resolve a bare built-in policy name (e.g. ``"security"``) to its file.
 
-    Returns the packaged ``abicheck/policies/<name>.yaml`` path if it exists,
-    else ``None``. Used so ``--policy-file security`` is turnkey without the
-    user shipping their own YAML.
+    Returns the packaged ``abicheck/policies/<name>.yaml`` path if *name*
+    exactly matches a shipped policy stem, else ``None``. Only bare names are
+    accepted so path-like values cannot traverse or accidentally resolve as
+    built-ins.
     """
-    from .policies import POLICIES_DIR
+    from .policies import POLICIES_DIR, builtin_policy_names
+
+    if name not in builtin_policy_names():
+        return None
 
     candidate = POLICIES_DIR / f"{name}.yaml"
     return candidate if candidate.is_file() else None
@@ -147,14 +151,13 @@ class PolicyFile:
                 "Install it with: pip install pyyaml"
             ) from exc
 
-        # Allow a bare built-in policy name (e.g. "security") to resolve to the
-        # packaged policy of that name. Gate on is_file() (not exists()) so a
-        # *directory* named e.g. "security/" in the CWD doesn't shadow the
-        # builtin and then make read_text() raise IsADirectoryError.
-        if not path.is_file():
-            builtin = builtin_policy_path(str(path))
-            if builtin is not None:
-                path = builtin
+        # A bare built-in policy name (e.g. "security") must resolve to the
+        # packaged policy before consulting the working directory. Otherwise an
+        # attacker-controlled checkout can shadow the built-in with a local file
+        # named "security" and silently downgrade security-hardening verdicts.
+        builtin = builtin_policy_path(str(path))
+        if builtin is not None:
+            path = builtin
 
         raw: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
         if raw is None:

--- a/tests/test_policy_file.py
+++ b/tests/test_policy_file.py
@@ -234,7 +234,7 @@ def test_unknown_builtin_policy_name_returns_none() -> None:
 def test_policy_file_param_accepts_builtin_name() -> None:
     from abicheck.cli_params import POLICY_FILE_PARAM
     out = POLICY_FILE_PARAM.convert("security", None, None)
-    assert Path(out).name == "security"
+    assert Path(out).name == "security.yaml"
 
 
 def test_policy_file_param_accepts_existing_path(tmp_path: Path) -> None:
@@ -251,6 +251,22 @@ def test_policy_file_param_rejects_unknown_name() -> None:
     from abicheck.cli_params import POLICY_FILE_PARAM
     with pytest.raises(click.BadParameter):
         POLICY_FILE_PARAM.convert("does-not-exist.yaml", None, None)
+
+
+def test_builtin_policy_name_not_shadowed_by_file(tmp_path: Path, monkeypatch) -> None:
+    """A local file named like a builtin must not shadow the shipped policy."""
+    (tmp_path / "security").write_text(
+        "base_policy: strict_abi\noverrides:\n  pie_disabled: ignore\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    pf = PolicyFile.load(Path("security"))
+
+    assert pf.source_path is not None
+    assert pf.source_path.name == "security.yaml"
+    assert pf.overrides.get(ChangeKind.PIE_DISABLED) == Verdict.BREAKING
+    assert pf.compute_verdict([_change(ChangeKind.PIE_DISABLED)]) == Verdict.BREAKING
 
 
 def test_builtin_policy_name_not_shadowed_by_directory(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- A bare built-in policy name like `security` could be shadowed by an existing local file named `security`, allowing an attacker-controlled checkout to override packaged policy YAML and silently downgrade hardening verdicts.
- The CLI type and loader previously accepted a workspace path first and returned the original `Path`, so built-in names were ambiguous and insecure.

### Description
- Resolve built-in policy names to the packaged `abicheck/policies/<name>.yaml` before consulting the working directory in `PolicyFile.load()` so shipped policies cannot be shadowed by local files (`abicheck/policy_file.py`).
- Restrict `builtin_policy_path()` to exact shipped policy stems so only bare built-in names are accepted (`abicheck/policy_file.py`).
- Update `PolicyFileParam.convert()` to prefer and return the packaged builtin path when the value matches a built-in name, falling back to existing filesystem paths only afterwards (`abicheck/cli_params.py`).
- Add a regression test ensuring a local file named `security` does not shadow the packaged `security.yaml` and update an expectation in `tests/test_policy_file.py`.

### Testing
- Ran `python -m ruff check abicheck/cli_params.py abicheck/policy_file.py tests/test_policy_file.py` which passed.
- Ran `pytest -q tests/test_policy_file.py` and the file-level tests passed (22 passed).
- Ran the full test collection `pytest -q` which failed during collection due to a missing test dependency (`hypothesis`) in the environment and is unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a247fb07c08832b815e039b8417ee53)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved built-in policy resolution to ensure stricter and more reliable policy name matching.
  * Enhanced policy file parameter handling with better validation and error messaging for unavailable policies.

* **Tests**
  * Updated CLI parameter tests to verify built-in policy name resolution.
  * Added tests confirming built-in policies are correctly prioritized over local files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->