### PR TITLE
feat: optional source/build EvidencePack (ADR-028 Phase 0 + ADR-029 build adapters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **200 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
+It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **206 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary and header AST analysis on all platforms; debug-info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 

--- a/abicheck/change_registry.py
+++ b/abicheck/change_registry.py
@@ -909,4 +909,40 @@ REGISTRY = ChangeKindRegistry([
               "(EXPORT_ONLY origin) rose between versions — a packaging-hygiene "
               "regression: a symbol was exported without a corresponding public "
               "header. Informational; emitted only with --surface-metrics."),
+
+    # ── Build-context evidence (ADR-028 L3 / ADR-029 D9) ────────────────────
+    # Produced by the build-evidence diff over two EvidencePacks. Per ADR-028
+    # D3 these are never BREAKING on their own: a build change that actually
+    # breaks the ABI is caught by the artifact diff (L0/L1/L2) as a separate,
+    # artifact-backed finding; these explain and localize it.
+    _E("build_context_changed", _C,
+       impact="Non-ABI-relevant build metadata changed between versions (e.g. "
+              "include-path ordering, output paths, or generator version). "
+              "Informational quality signal; no ABI impact on its own."),
+    _E("abi_relevant_build_flag_changed", _R,
+       impact="An ABI-affecting compiler/build option changed (e.g. -std, "
+              "-fabi-version, _GLIBCXX_USE_CXX11_ABI, -fvisibility, -fpack-struct, "
+              "--target/-mabi, sysroot). The artifact diff decides whether the "
+              "shipped ABI actually broke; this flags the elevated risk and "
+              "localizes the cause for review."),
+    _E("header_parse_context_drift", _R,
+       impact="The public-header AST was parsed under a different context (flags, "
+              "defines, include paths) than the real build used. Header-derived "
+              "API facts may be unreliable; align the parse context (e.g. via "
+              "compile_commands.json) to restore confidence."),
+    _E("toolchain_version_changed", _R,
+       impact="The compiler, standard library, or sysroot/SDK changed between "
+              "versions. Layout, mangling, and codegen can shift even with "
+              "identical sources; review for ABI-affecting toolchain drift."),
+    _E("generated_file_dependency_unstable", _R,
+       impact="The build graph indicates a generated-file dependency risk "
+              "(e.g. missing or unstable generator dependencies). Generated "
+              "public declarations may differ from what was analyzed; rebuild "
+              "determinism is not guaranteed."),
+    _E("link_export_policy_changed", _R,
+       impact="The export policy changed — version script, export map, or .def "
+              "file. The set of exported symbols may have shifted. When this "
+              "actually removes or alters exports, the artifact diff (L0) emits "
+              "the corresponding BREAKING findings separately; this kind explains "
+              "and localizes them and does not escalate on its own."),
 ])

--- a/abicheck/checker_policy.py
+++ b/abicheck/checker_policy.py
@@ -495,6 +495,20 @@ class ChangeKind(str, Enum):
     PUBLIC_SURFACE_SHRANK = "public_surface_shrank"
     UNDOCUMENTED_EXPORT_RATIO_INCREASED = "undocumented_export_ratio_increased"
 
+    # ── Build-context evidence (ADR-028 L3 / ADR-029 D9) ────────────────────
+    # Emitted only by the build-evidence diff over two EvidencePacks. These are
+    # source/build-context findings, not artifact-backed ABI breaks: per
+    # ADR-028 D3 they default to COMPATIBLE (quality) or RISK and never to
+    # BREAKING. When a build-context change actually breaks the ABI, the
+    # artifact diff (L0/L1/L2) emits the BREAKING finding separately; these
+    # kinds explain and localize it.
+    BUILD_CONTEXT_CHANGED = "build_context_changed"  # non-ABI build metadata drift → COMPATIBLE (quality)
+    ABI_RELEVANT_BUILD_FLAG_CHANGED = "abi_relevant_build_flag_changed"  # ABI-affecting flag changed → RISK
+    HEADER_PARSE_CONTEXT_DRIFT = "header_parse_context_drift"  # headers parsed under different context than the build → RISK
+    TOOLCHAIN_VERSION_CHANGED = "toolchain_version_changed"  # compiler/stdlib/sysroot changed → RISK
+    GENERATED_FILE_DEPENDENCY_UNSTABLE = "generated_file_dependency_unstable"  # generated-file dependency risk → RISK
+    LINK_EXPORT_POLICY_CHANGED = "link_export_policy_changed"  # version script / export map / .def changed → RISK
+
 
 class HasKind(Protocol):
     kind: ChangeKind

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -176,6 +176,12 @@ class DiffResult:
     # matched). Empty unless --pattern-verdicts was enabled. Findings themselves
     # carry the override on Change.effective_verdict; this is the audit trail.
     pattern_modulations: list[dict[str, object]] = field(default_factory=list)
+    # ADR-028 D7 — evidence-coverage rows (L0–L5) for the compare, when an
+    # EvidencePack was supplied. Each entry is a serialized LayerCoverage
+    # ({layer, status, confidence, detail}). Surfaced in the JSON report so
+    # machine consumers can tell artifact-proven from build-context-only
+    # findings; empty when no evidence was involved.
+    evidence_coverage: list[dict[str, object]] = field(default_factory=list)
 
     def _effective_kind_sets(
         self,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -834,6 +834,11 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
 
+    # Record that the header AST was parsed with the real build context (ADR-029),
+    # so a later compare can suppress header-parse-context drift for this side.
+    if effective_compile_db and resolved_headers:
+        snap.parsed_with_build_context = True
+
     if follow_deps:
         _populate_dependency_info(snap, so_path, list(search_paths), sysroot, ld_library_path)
 
@@ -1860,15 +1865,15 @@ def compare_cmd(
 
     extra_changes = _load_probe_matrix_changes(probe_matrix_old, probe_matrix_new)
 
+    evidence_coverage_rows: list[dict[str, object]] = []
     if old_evidence is not None or new_evidence is not None or evidence_mode != "off":
         from .cli_evidence import collect_compare_evidence
-        # `compare` has no -p/--compile-db option, so any header AST it parses is
-        # parsed WITHOUT the build's ABI-relevant flags. Passing headers via -H
-        # does not change that — so header-parse-context drift is disclosed (not
-        # suppressed) whenever the new pack carries ABI-relevant flags. Re-dump
-        # with `dump -p` to capture build context into the snapshot itself.
-        ev_changes = collect_compare_evidence(old_evidence, new_evidence, evidence_mode, new,
-                                              old_parsed_with_context=False)
+        # Header-parse-context drift is judged from the new snapshot's own
+        # provenance (parsed_with_build_context, set by `dump -p`); compare adds
+        # no build context of its own.
+        ev_changes, evidence_coverage_rows = collect_compare_evidence(
+            old_evidence, new_evidence, evidence_mode, new,
+        )
         extra_changes = (extra_changes or []) + ev_changes if ev_changes else extra_changes
 
     apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on
@@ -1880,6 +1885,8 @@ def compare_cmd(
         pattern_verdicts=apply_patterns,
         surface_metrics=surface_metrics,
     )
+    if evidence_coverage_rows:
+        result.evidence_coverage = evidence_coverage_rows
 
     if explain_patterns:
         echo_pattern_modulations(result)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -26,7 +26,11 @@ import click
 
 from .checker import DiffResult, LibraryMetadata, compare
 from .cli_audit import echo_filtered_surface, echo_pattern_modulations
-from .cli_options import adr027_compare_options
+from .cli_options import (
+    adr027_compare_options,
+    evidence_compare_options,
+    evidence_dump_option,
+)
 from .cli_params import POLICY_FILE_PARAM
 from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
 from .compat.cli import compat_group
@@ -172,8 +176,15 @@ def _provenance_timestamp(source_date_epoch: str | None) -> str:
 def _write_snapshot_output(
     snap: AbiSnapshot,
     output: Path | None,
+    evidence_dir: Path | None = None,
 ) -> None:
-    """Serialize snapshot and write to file or stdout."""
+    """Serialize snapshot and write to file or stdout.
+
+    When *evidence_dir* is given, attach the EvidencePack reference first (D8).
+    """
+    if evidence_dir is not None:
+        from .cli_evidence import attach_evidence_pack
+        attach_evidence_pack(snap, evidence_dir)
     result = snapshot_to_json(snap)
     if output:
         _safe_write_output(output, result)
@@ -705,6 +716,7 @@ def _populate_dependency_info(
               help="Opaque build identifier (CI run ID, build number, etc.).")
 @click.option("--no-git", "no_git", is_flag=True, default=False,
               help="Do not auto-detect git commit SHA.")
+@evidence_dump_option  # ADR-028: --evidence
 def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...],
              public_headers: tuple[Path, ...], public_header_dirs: tuple[Path, ...],
              version: str, lang: str, output: Path | None,
@@ -719,7 +731,8 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
              debug_roots: tuple[Path, ...],
              debuginfod: bool, debuginfod_url: str | None,
              verbose: bool,
-             git_tag: str | None, build_id: str | None, no_git: bool) -> None:
+             git_tag: str | None, build_id: str | None, no_git: bool,
+             evidence_dir: Path | None = None) -> None:
     """Dump ABI snapshot of a shared library to JSON.
 
     \b
@@ -781,6 +794,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
             output,
             public_headers,
             public_header_dirs,
+            evidence_dir,
         )
         return
 
@@ -824,7 +838,7 @@ def dump_cmd(so_path: Path, headers: tuple[Path, ...], includes: tuple[Path, ...
         _populate_dependency_info(snap, so_path, list(search_paths), sysroot, ld_library_path)
 
     _stamp_provenance(snap, git_tag=git_tag, build_id=build_id, no_git=no_git)
-    _write_snapshot_output(snap, output)
+    _write_snapshot_output(snap, output, evidence_dir)
 
 
 def _handle_non_elf_dump(
@@ -842,6 +856,7 @@ def _handle_non_elf_dump(
     output: Path | None,
     public_headers: tuple[Path, ...] = (),
     public_header_dirs: tuple[Path, ...] = (),
+    evidence_dir: Path | None = None,
 ) -> None:
     """Handle PE/Mach-O native dump path and output writing."""
     if follow_deps:
@@ -858,7 +873,7 @@ def _handle_non_elf_dump(
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
     _stamp_provenance(snap, git_tag=git_tag, build_id=build_id, no_git=no_git)
-    _write_snapshot_output(snap, output)
+    _write_snapshot_output(snap, output, evidence_dir)
 
 
 def _resolve_build_context_flags(
@@ -1131,60 +1146,6 @@ def _load_probe_matrix_changes(
     old_matrix = load_matrix_snapshot(probe_matrix_old)
     new_matrix = load_matrix_snapshot(probe_matrix_new)
     return list(diff_matrix(old_matrix, new_matrix))
-
-
-def _run_compare_pair(
-    old_input: Path,
-    new_input: Path,
-    old_headers: list[Path],
-    new_headers: list[Path],
-    old_includes: list[Path],
-    new_includes: list[Path],
-    old_version: str,
-    new_version: str,
-    lang: str,
-    suppress: Path | None,
-    policy: str,
-    policy_file_path: Path | None,
-    old_pdb_path: Path | None,
-    new_pdb_path: Path | None,
-    scope_to_public_surface: bool = False,
-    pattern_verdicts: bool = False,
-) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
-    """Run compare for one old/new pair and return result + resolved snapshots."""
-    # Follow GNU ld linker scripts up front so metadata/dependency analysis use
-    # the resolved DSO, not the text script.
-    old_input, old_fmt = _normalize_binary_input(old_input)
-    new_input, new_fmt = _normalize_binary_input(new_input)
-
-    old = _resolve_input(
-        old_input,
-        old_headers,
-        old_includes,
-        old_version,
-        lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=old_pdb_path,
-    )
-    new = _resolve_input(
-        new_input,
-        new_headers,
-        new_includes,
-        new_version,
-        lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=new_pdb_path,
-    )
-
-    suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
-    result = compare(
-        old, new, suppression=suppression, policy=policy, policy_file=pf,
-        scope_to_public_surface=scope_to_public_surface,
-        pattern_verdicts=pattern_verdicts,
-    )
-    result.old_metadata = _collect_metadata(old_input)
-    result.new_metadata = _collect_metadata(new_input)
-    return result, old, new
 
 
 def _canonical_library_key(path: Path) -> str:
@@ -1712,6 +1673,7 @@ def _finalize_compare_result(
               help="Enable debuginfod network resolution for debug info (opt-in).")
 @click.option("--debuginfod-url", "debuginfod_url", default=None,
               help="debuginfod server URL (overrides DEBUGINFOD_URLS env var).")
+@evidence_compare_options  # ADR-028/029: --old-evidence/--new-evidence/--evidence-mode
 @adr027_compare_options  # ADR-027: --pattern-verdicts/--explain-patterns/--surface-metrics
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")
@@ -1750,6 +1712,7 @@ def compare_cmd(
     explain_patterns: bool,
     surface_metrics: bool,
     verbose: bool,
+    old_evidence: Path | None = None, new_evidence: Path | None = None, evidence_mode: str = "off",
     probe_matrix_old: Path | None = None,
     probe_matrix_new: Path | None = None,
 ) -> None:
@@ -1897,6 +1860,12 @@ def compare_cmd(
 
     extra_changes = _load_probe_matrix_changes(probe_matrix_old, probe_matrix_new)
 
+    if old_evidence is not None or new_evidence is not None or evidence_mode != "off":
+        from .cli_evidence import collect_compare_evidence
+        ev_changes = collect_compare_evidence(old_evidence, new_evidence, evidence_mode, new,
+                                              old_parsed_with_context=bool(old_h or old_headers_only))
+        extra_changes = (extra_changes or []) + ev_changes if ev_changes else extra_changes
+
     apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on
     result = compare(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
@@ -1930,7 +1899,6 @@ def compare_cmd(
 
     _announce_exit_scheme(severity_explicitly_set, sev_config, fmt=fmt, stat=stat)
     _exit_with_severity_or_verdict(result, sev_config, severity_explicitly_set)
-
 
 
 # ── ABICC compat subcommands (implementation in abicheck.compat) ─────────────
@@ -1971,8 +1939,6 @@ main.add_command(compat_group)
 
 
 
-
-
 # ---------------------------------------------------------------------------
 # Sub-command modules. Imported for side-effect so their @main.command(...)
 # decorators register the commands on the Click group above. They sit in
@@ -1983,6 +1949,7 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
     cli_baseline,  # noqa: F401  — registers baseline
     cli_compare_release,  # noqa: F401  — registers compare-release
     cli_debian_symbols,  # noqa: F401  — registers debian-symbols
+    cli_evidence,  # noqa: F401  — registers collect-evidence
     cli_plugin,  # noqa: F401  — registers plugin-check
     cli_probe,  # noqa: F401  — registers probe (run, compare)
     cli_stack,  # noqa: F401  — registers deps, stack-check

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1862,8 +1862,13 @@ def compare_cmd(
 
     if old_evidence is not None or new_evidence is not None or evidence_mode != "off":
         from .cli_evidence import collect_compare_evidence
+        # `compare` has no -p/--compile-db option, so any header AST it parses is
+        # parsed WITHOUT the build's ABI-relevant flags. Passing headers via -H
+        # does not change that — so header-parse-context drift is disclosed (not
+        # suppressed) whenever the new pack carries ABI-relevant flags. Re-dump
+        # with `dump -p` to capture build context into the snapshot itself.
         ev_changes = collect_compare_evidence(old_evidence, new_evidence, evidence_mode, new,
-                                              old_parsed_with_context=bool(old_h or old_headers_only))
+                                              old_parsed_with_context=False)
         extra_changes = (extra_changes or []) + ev_changes if ev_changes else extra_changes
 
     apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -32,12 +32,14 @@ from typing import TYPE_CHECKING
 import click
 
 from .bundle import BundleDiffResult
-from .checker import DiffResult
+from .checker import DiffResult, compare
 from .cli import (
     _build_match_map,
+    _collect_metadata,
     _collect_release_inputs,
     _load_suppression_and_policy,
-    _run_compare_pair,
+    _normalize_binary_input,
+    _resolve_input,
     _safe_write_output,
     _setup_verbosity,
     _write_or_echo,
@@ -55,6 +57,51 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # compare-release helpers
 # ---------------------------------------------------------------------------
+
+
+def _run_compare_pair(
+    old_input: Path,
+    new_input: Path,
+    old_headers: list[Path],
+    new_headers: list[Path],
+    old_includes: list[Path],
+    new_includes: list[Path],
+    old_version: str,
+    new_version: str,
+    lang: str,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
+    old_pdb_path: Path | None,
+    new_pdb_path: Path | None,
+    scope_to_public_surface: bool = False,
+    pattern_verdicts: bool = False,
+) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+    """Run compare for one old/new pair and return result + resolved snapshots."""
+    # Follow GNU ld linker scripts up front so metadata/dependency analysis use
+    # the resolved DSO, not the text script.
+    old_input, old_fmt = _normalize_binary_input(old_input)
+    new_input, new_fmt = _normalize_binary_input(new_input)
+
+    old = _resolve_input(
+        old_input, old_headers, old_includes, old_version, lang,
+        is_elf=True if old_fmt == "elf" else None, pdb_path=old_pdb_path,
+    )
+    new = _resolve_input(
+        new_input, new_headers, new_includes, new_version, lang,
+        is_elf=True if new_fmt == "elf" else None, pdb_path=new_pdb_path,
+    )
+
+    suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
+    result = compare(
+        old, new, suppression=suppression, policy=policy, policy_file=pf,
+        scope_to_public_surface=scope_to_public_surface,
+        pattern_verdicts=pattern_verdicts,
+    )
+    result.old_metadata = _collect_metadata(old_input)
+    result.new_metadata = _collect_metadata(new_input)
+    return result, old, new
+
 
 _RELEASE_VERDICT_ORDER: dict[str, int] = {
     "NO_CHANGE": 0, "COMPATIBLE": 1, "COMPATIBLE_WITH_RISK": 2,

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -268,7 +268,13 @@ def collect_compare_evidence(
     new_build = new_pack.build_evidence if new_pack else None
     if old_build is not None and new_build is not None:
         changes.extend(diff_build_evidence(old_build, new_build))
-    if new_build is not None:
+    # Header-parse-context drift only applies when the new snapshot actually
+    # carries a public-header AST (L2). A binary-only compare has no header
+    # parse context that could have drifted, so the finding would be misleading.
+    new_has_headers = bool(
+        new_snapshot.from_headers and not new_snapshot.from_headers_inferred
+    )
+    if new_build is not None and new_has_headers:
         changes.extend(check_header_parse_drift(
             new_build, headers_parsed_with_context=old_parsed_with_context,
         ))

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -1,0 +1,327 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`collect-evidence` command (ADR-028 D6, ADR-029).
+
+Collects an optional EvidencePack from an existing build tree *without
+rebuilding*. The pack augments an ABI snapshot with L3 build-context evidence
+(compile DB / CMake File API / Ninja). Per ADR-028 D6 this command never runs
+arbitrary build commands: it only reads existing build outputs and build-system
+query interfaces. Anything that builds or executes project code is a separate,
+explicit opt-in not implemented here.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from . import __version__ as _abicheck_version
+from .cli import main
+from .evidence.build_evidence import BuildEvidence
+from .evidence.model import (
+    CoverageStatus,
+    EvidenceConfidence,
+    EvidenceLayer,
+    ExtractorRecord,
+    LayerCoverage,
+)
+from .evidence.pack import EvidencePack
+
+if TYPE_CHECKING:
+    from .checker_types import Change
+    from .model import AbiSnapshot
+
+
+@main.command("collect-evidence")
+@click.option("--binary", "binary", type=click.Path(path_type=Path), default=None,
+              help="Built shared library this evidence describes (recorded as provenance).")
+@click.option("-H", "--headers", "headers", multiple=True, type=click.Path(path_type=Path),
+              help="Public header file or directory (recorded as provenance; repeat).")
+@click.option("--build-dir", "build_dir", type=click.Path(path_type=Path), default=None,
+              help="Build directory to inspect (CMake File API reply, Ninja query).")
+@click.option("--compile-db", "compile_db", type=click.Path(path_type=Path), default=None,
+              help="Path to compile_commands.json (or a directory containing it).")
+@click.option("-p", "compile_db_p", type=click.Path(path_type=Path), default=None,
+              help="Alias for --compile-db (build dir or file).")
+@click.option("--cmake", "--cmake-file-api", "cmake", is_flag=True, default=False,
+              help="Collect CMake File API facts from --build-dir (reads the reply directory; no build).")
+@click.option("--ninja", "ninja", is_flag=True, default=False,
+              help="Collect Ninja compile/graph facts from --build-dir via `ninja -t` queries.")
+@click.option("--ninja-compdb", "ninja_compdb", type=click.Path(path_type=Path), default=None,
+              help="Pre-captured `ninja -t compdb` output (for hermetic CI / no live ninja).")
+@click.option("--build-system", "build_system", default="generic", show_default=True,
+              type=click.Choice(["generic", "cmake", "ninja", "bazel", "make"], case_sensitive=False),
+              help="Build system hint for the compile-DB adapter.")
+@click.option("-o", "--output", "output", type=click.Path(path_type=Path), required=True,
+              help="Output evidence-pack directory.")
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def collect_evidence_cmd(
+    binary: Path | None,
+    headers: tuple[Path, ...],
+    build_dir: Path | None,
+    compile_db: Path | None,
+    compile_db_p: Path | None,
+    cmake: bool,
+    ninja: bool,
+    ninja_compdb: Path | None,
+    build_system: str,
+    output: Path,
+    verbose: bool,
+) -> None:
+    """Collect an optional source/build EvidencePack from an existing build tree.
+
+    \b
+    Examples:
+      abicheck collect-evidence --compile-db build/compile_commands.json -o libfoo.evidence/
+      abicheck collect-evidence -p build/ --headers include/ -o libfoo.evidence/
+      abicheck collect-evidence --build-dir build --cmake --ninja -o libfoo.evidence/
+
+    The resulting directory attaches to a snapshot with `abicheck dump --evidence`.
+    """
+    effective_compile_db = compile_db or compile_db_p
+    extractors: list[ExtractorRecord] = []
+    merged = BuildEvidence()
+
+    _run_adapters(
+        merged, extractors,
+        compile_db=effective_compile_db,
+        build_dir=build_dir,
+        cmake=cmake,
+        ninja=ninja,
+        ninja_compdb=ninja_compdb,
+        build_system=build_system,
+        verbose=verbose,
+    )
+
+    pack = EvidencePack.empty(
+        output,
+        abicheck_version=_abicheck_version,
+        created_at=_dt.datetime.now(_dt.timezone.utc).isoformat(),
+    )
+    pack.manifest.extractors = extractors
+    pack.manifest.inputs = {
+        "binary": str(binary) if binary else None,
+        "headers": [str(h) for h in headers],
+        "build_dir": str(build_dir) if build_dir else None,
+    }
+    has_build = bool(merged.compile_units or merged.targets or merged.toolchains)
+    if has_build:
+        pack.build_evidence = merged
+    pack.manifest.coverage = _build_coverage(merged, has_build)
+    pack.write()
+
+    click.echo(f"Evidence pack written to {output}")
+    click.echo(f"  content hash: {pack.content_hash()}")
+    if has_build:
+        click.echo(
+            f"  L3 build context: {len(merged.compile_units)} compile units, "
+            f"{len(merged.targets)} targets, {len(merged.toolchains)} toolchains"
+        )
+    else:
+        click.echo("  L3 build context: not collected (no adapters produced facts)")
+    for diag in merged.diagnostics:
+        click.echo(f"  note: {diag}", err=True)
+
+
+def _run_adapters(
+    merged: BuildEvidence,
+    extractors: list[ExtractorRecord],
+    *,
+    compile_db: Path | None,
+    build_dir: Path | None,
+    cmake: bool,
+    ninja: bool,
+    ninja_compdb: Path | None,
+    build_system: str,
+    verbose: bool,
+) -> None:
+    """Run the requested build-evidence adapters and fold them into *merged*."""
+    # Import adapters lazily so `collect-evidence --help` stays cheap.
+    from .evidence.adapters import (
+        CMakeFileApiAdapter,
+        CompileDbAdapter,
+        NinjaAdapter,
+    )
+
+    if compile_db is not None:
+        try:
+            ev = CompileDbAdapter(compile_db, build_system=build_system).collect()
+            merged.merge(ev)
+            extractors.append(ExtractorRecord(
+                name="compile_commands",
+                status="ok",
+                inputs=[str(compile_db)],
+                detail=f"{len(ev.compile_units)} compile units",
+            ))
+        except (OSError, ValueError) as exc:
+            extractors.append(ExtractorRecord(
+                name="compile_commands", status="failed", inputs=[str(compile_db)],
+                detail=str(exc),
+            ))
+            merged.diagnostics.append(f"compile_commands: {exc}")
+
+    if cmake:
+        if build_dir is None:
+            raise click.UsageError("--cmake requires --build-dir.")
+        ev = CMakeFileApiAdapter(build_dir).collect()
+        merged.merge(ev)
+        extractors.append(ExtractorRecord(
+            name="cmake_file_api", status="ok" if ev.targets else "partial",
+            inputs=[str(build_dir)],
+            detail=f"{len(ev.targets)} targets, {len(ev.toolchains)} toolchains",
+        ))
+
+    if ninja or ninja_compdb is not None:
+        if build_dir is None and ninja_compdb is None:
+            raise click.UsageError("--ninja requires --build-dir (or pass --ninja-compdb).")
+        adapter = NinjaAdapter(build_dir, compdb=ninja_compdb)
+        ev = adapter.collect()
+        merged.merge(ev)
+        extractors.append(ExtractorRecord(
+            name="ninja", status="ok" if ev.compile_units else "partial",
+            inputs=[str(build_dir or ninja_compdb)],
+            detail=f"{len(ev.compile_units)} compile units",
+        ))
+
+
+def _build_coverage(merged: BuildEvidence, has_build: bool) -> list[LayerCoverage]:
+    """Build the L3/L4/L5 coverage rows for the pack manifest (ADR-028 D7)."""
+    if has_build:
+        systems = sorted({g.kind for g in merged.generators}) or ["generic"]
+        l3 = LayerCoverage(
+            layer=EvidenceLayer.L3_BUILD.value,
+            status=CoverageStatus.PRESENT,
+            confidence=EvidenceConfidence.HIGH if merged.targets else EvidenceConfidence.REDUCED,
+            detail=(
+                f"{'+'.join(systems)}, {len(merged.compile_units)} compile units, "
+                f"{len(merged.targets)} targets"
+            ),
+        )
+    else:
+        l3 = LayerCoverage(layer=EvidenceLayer.L3_BUILD.value, status=CoverageStatus.NOT_COLLECTED)
+    return [
+        l3,
+        LayerCoverage(layer=EvidenceLayer.L4_SOURCE_ABI.value, status=CoverageStatus.NOT_COLLECTED),
+        LayerCoverage(layer=EvidenceLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.NOT_COLLECTED),
+    ]
+
+
+# ── Attach / compare integration (ADR-028 D6, D7; ADR-029 D9) ─────────────────
+
+
+def attach_evidence_pack(snap: AbiSnapshot, evidence_dir: Path) -> None:
+    """Attach an EvidencePack reference to *snap* (ADR-028 D8).
+
+    Loads the pack manifest, computes its content hash, and stores only the
+    lightweight reference on the snapshot. Raises a Click error if the directory
+    is not a valid pack.
+    """
+    snap.evidence_pack = _load_pack_or_raise(evidence_dir).to_ref(path_hint=str(evidence_dir))
+
+
+def collect_compare_evidence(
+    old_evidence: Path | None,
+    new_evidence: Path | None,
+    evidence_mode: str,
+    new_snapshot: AbiSnapshot,
+    *,
+    old_parsed_with_context: bool,
+) -> list[Change]:
+    """Load packs, diff their build evidence, echo coverage, return findings.
+
+    Per ADR-028 D3 the build-context findings are folded into the ordinary
+    verdict pipeline as ``extra_changes`` and never override artifact-backed
+    verdicts. The D7 coverage table is printed to stderr here (covers every
+    output format). Returns the list of build-context :class:`Change` findings.
+    """
+    from .evidence.build_diff import check_header_parse_drift, diff_build_evidence
+
+    if old_evidence is None and new_evidence is None:
+        if evidence_mode != "off":
+            click.echo(
+                f"Note: --evidence-mode {evidence_mode} requested but no evidence "
+                "packs were provided; inline collection for this mode is not yet "
+                "available. Use `abicheck collect-evidence` + --old/--new-evidence.",
+                err=True,
+            )
+        return []
+
+    old_pack = _load_pack_or_raise(old_evidence) if old_evidence else None
+    new_pack = _load_pack_or_raise(new_evidence) if new_evidence else None
+
+    changes: list[Change] = []
+    old_build = old_pack.build_evidence if old_pack else None
+    new_build = new_pack.build_evidence if new_pack else None
+    if old_build is not None and new_build is not None:
+        changes.extend(diff_build_evidence(old_build, new_build))
+    if new_build is not None:
+        changes.extend(check_header_parse_drift(
+            new_build, headers_parsed_with_context=old_parsed_with_context,
+        ))
+
+    src_pack = new_pack or old_pack
+    coverage = list(src_pack.manifest.coverage) if src_pack else []
+    if not coverage:
+        coverage = [
+            LayerCoverage(layer=layer.value, status=CoverageStatus.NOT_COLLECTED)
+            for layer in (EvidenceLayer.L3_BUILD, EvidenceLayer.L4_SOURCE_ABI, EvidenceLayer.L5_SOURCE_GRAPH)
+        ]
+    _echo_coverage(_intrinsic_coverage(new_snapshot), coverage)
+    return changes
+
+
+def _load_pack_or_raise(evidence_dir: Path) -> EvidencePack:
+    try:
+        return EvidencePack.load(evidence_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(f"Invalid evidence pack at {evidence_dir}: {exc}") from exc
+
+
+def _intrinsic_coverage(snap: AbiSnapshot) -> list[LayerCoverage]:
+    """Derive L0/L1/L2 coverage rows from a snapshot (ADR-028 D7)."""
+    def row(layer: str, present: bool, detail: str) -> LayerCoverage:
+        return LayerCoverage(
+            layer=layer,
+            status=CoverageStatus.PRESENT if present else CoverageStatus.NOT_COLLECTED,
+            confidence=EvidenceConfidence.HIGH if present else EvidenceConfidence.UNKNOWN,
+            detail=detail,
+        )
+
+    has_debug = bool(snap.dwarf or snap.dwarf_advanced)
+    has_headers = bool(snap.from_headers and not snap.from_headers_inferred)
+    return [
+        row("L0", bool(snap.elf or snap.pe or snap.macho), snap.platform or ""),
+        row("L1", has_debug, "DWARF" if has_debug else ""),
+        row("L2", has_headers, "header-scoped" if has_headers else ""),
+    ]
+
+
+def _echo_coverage(intrinsic: list[LayerCoverage], optional: list[LayerCoverage]) -> None:
+    """Print the D7 evidence-coverage table to stderr (all output formats)."""
+    names = {
+        "L0": "L0 binary metadata", "L1": "L1 debug info", "L2": "L2 public header AST",
+        "L3_build": "L3 build context", "L4_source_abi": "L4 source ABI replay",
+        "L5_source_graph": "L5 source graph summary",
+    }
+    click.echo("Evidence coverage:", err=True)
+    for cov in [*intrinsic, *optional]:
+        extra = ""
+        if cov.status != CoverageStatus.NOT_COLLECTED:
+            extra = f", {cov.confidence.value} confidence"
+            if cov.detail:
+                extra += f": {cov.detail}"
+        click.echo(f"  {names.get(cov.layer, cov.layer):<26} {cov.status.value}{extra}", err=True)

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -40,6 +40,7 @@ from .evidence.model import (
     LayerCoverage,
 )
 from .evidence.pack import EvidencePack
+from .evidence.redaction import DEFAULT_REDACTION
 
 if TYPE_CHECKING:
     from .checker_types import Change
@@ -112,11 +113,14 @@ def collect_evidence_cmd(
         abicheck_version=_abicheck_version,
         created_at=_dt.datetime.now(_dt.timezone.utc).isoformat(),
     )
+    # Redact home/workspace prefixes from provenance paths before persisting,
+    # consistent with how the rest of the evidence model redacts paths.
+    red = DEFAULT_REDACTION
     pack.manifest.extractors = extractors
     pack.manifest.inputs = {
-        "binary": str(binary) if binary else None,
-        "headers": [str(h) for h in headers],
-        "build_dir": str(build_dir) if build_dir else None,
+        "binary": red.path(str(binary)) if binary else None,
+        "headers": [red.path(str(h)) for h in headers],
+        "build_dir": red.path(str(build_dir)) if build_dir else None,
     }
     has_build = bool(merged.compile_units or merged.targets or merged.toolchains)
     if has_build:
@@ -164,12 +168,12 @@ def _run_adapters(
             extractors.append(ExtractorRecord(
                 name="compile_commands",
                 status="ok",
-                inputs=[str(compile_db)],
+                inputs=[DEFAULT_REDACTION.path(str(compile_db))],
                 detail=f"{len(ev.compile_units)} compile units",
             ))
         except (OSError, ValueError) as exc:
             extractors.append(ExtractorRecord(
-                name="compile_commands", status="failed", inputs=[str(compile_db)],
+                name="compile_commands", status="failed", inputs=[DEFAULT_REDACTION.path(str(compile_db))],
                 detail=str(exc),
             ))
             merged.diagnostics.append(f"compile_commands: {exc}")
@@ -181,7 +185,7 @@ def _run_adapters(
         merged.merge(ev)
         extractors.append(ExtractorRecord(
             name="cmake_file_api", status="ok" if ev.targets else "partial",
-            inputs=[str(build_dir)],
+            inputs=[DEFAULT_REDACTION.path(str(build_dir))],
             detail=f"{len(ev.targets)} targets, {len(ev.toolchains)} toolchains",
         ))
 
@@ -193,7 +197,7 @@ def _run_adapters(
         merged.merge(ev)
         extractors.append(ExtractorRecord(
             name="ninja", status="ok" if ev.compile_units else "partial",
-            inputs=[str(build_dir or ninja_compdb)],
+            inputs=[DEFAULT_REDACTION.path(str(build_dir or ninja_compdb))],
             detail=f"{len(ev.compile_units)} compile units",
         ))
 
@@ -238,15 +242,15 @@ def collect_compare_evidence(
     new_evidence: Path | None,
     evidence_mode: str,
     new_snapshot: AbiSnapshot,
-    *,
-    old_parsed_with_context: bool,
-) -> list[Change]:
+) -> tuple[list[Change], list[dict[str, object]]]:
     """Load packs, diff their build evidence, echo coverage, return findings.
 
     Per ADR-028 D3 the build-context findings are folded into the ordinary
     verdict pipeline as ``extra_changes`` and never override artifact-backed
     verdicts. The D7 coverage table is printed to stderr here (covers every
-    output format). Returns the list of build-context :class:`Change` findings.
+    output format) and also returned as serialized rows so the JSON report can
+    carry a structured ``evidence_coverage`` block. Returns
+    ``(changes, coverage_rows)``.
     """
     from .evidence.build_diff import check_header_parse_drift, diff_build_evidence
 
@@ -258,7 +262,7 @@ def collect_compare_evidence(
                 "available. Use `abicheck collect-evidence` + --old/--new-evidence.",
                 err=True,
             )
-        return []
+        return [], []
 
     old_pack = _load_pack_or_raise(old_evidence) if old_evidence else None
     new_pack = _load_pack_or_raise(new_evidence) if new_evidence else None
@@ -276,7 +280,8 @@ def collect_compare_evidence(
     )
     if new_build is not None and new_has_headers:
         changes.extend(check_header_parse_drift(
-            new_build, headers_parsed_with_context=old_parsed_with_context,
+            new_build,
+            headers_parsed_with_context=new_snapshot.parsed_with_build_context,
         ))
 
     src_pack = new_pack or old_pack
@@ -286,8 +291,10 @@ def collect_compare_evidence(
             LayerCoverage(layer=layer.value, status=CoverageStatus.NOT_COLLECTED)
             for layer in (EvidenceLayer.L3_BUILD, EvidenceLayer.L4_SOURCE_ABI, EvidenceLayer.L5_SOURCE_GRAPH)
         ]
-    _echo_coverage(_intrinsic_coverage(new_snapshot), coverage)
-    return changes
+    intrinsic = _intrinsic_coverage(new_snapshot)
+    _echo_coverage(intrinsic, coverage)
+    coverage_rows: list[dict[str, object]] = [c.to_dict() for c in (*intrinsic, *coverage)]
+    return changes, coverage_rows
 
 
 def _load_pack_or_raise(evidence_dir: Path) -> EvidencePack:

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -64,3 +64,53 @@ def adr027_compare_options(func: F) -> F:
         "the pattern_modulations ledger; reversible.",
     )(func)
     return func
+
+
+def evidence_dump_option(func: F) -> F:
+    """Add the ADR-028 ``--evidence`` attach option to ``dump``."""
+    from pathlib import Path
+
+    func = click.option(
+        "--evidence", "evidence_dir",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        default=None,
+        help="Attach an existing EvidencePack directory (from `abicheck "
+        "collect-evidence`) to the snapshot. Stores a lightweight, "
+        "content-addressed reference; the pack itself stays out-of-band.",
+    )(func)
+    return func
+
+
+def evidence_compare_options(func: F) -> F:
+    """Add the ADR-028/ADR-029 evidence options to ``compare``.
+
+    ``--old-evidence`` / ``--new-evidence`` attach packs whose build evidence is
+    diffed into the verdict (never overriding artifact-backed findings, ADR-028
+    D3); ``--evidence-mode`` selects the inline collection mode (ADR-033 D2).
+    Applied bottom-up, so listed in reverse of displayed order.
+    """
+    from pathlib import Path
+
+    func = click.option(
+        "--evidence-mode", "evidence_mode",
+        type=click.Choice(["off", "build", "source-changed", "source-target", "graph-summary", "graph-full"]),
+        default="off", show_default=True,
+        help="Inline evidence collection mode (ADR-033 D2). 'off' uses only "
+        "explicitly-provided --old/--new-evidence packs. Other modes are "
+        "recognized and reported in the coverage table but not yet collected "
+        "inline in this release.",
+    )(func)
+    func = click.option(
+        "--new-evidence", "new_evidence",
+        type=click.Path(exists=True, file_okay=False, path_type=Path), default=None,
+        help="EvidencePack directory for the new side.",
+    )(func)
+    func = click.option(
+        "--old-evidence", "old_evidence",
+        type=click.Path(exists=True, file_okay=False, path_type=Path), default=None,
+        help="EvidencePack directory for the old side (from `abicheck "
+        "collect-evidence`). Adds L3 build-context findings and an "
+        "evidence-coverage table; never overrides artifact-backed ABI "
+        "verdicts (ADR-028 D3).",
+    )(func)
+    return func

--- a/abicheck/evidence/CLAUDE.md
+++ b/abicheck/evidence/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md — `abicheck/evidence/`
+
+Optional source/build/graph evidence layers (ADR-028 umbrella; ADR-029–033).
+See `docs/development/adr/028-source-build-evidence-pack.md` for the
+architecture and `docs/concepts/evidence-pack.md` for the user-facing guide.
+
+## The one rule that governs everything here
+
+**Artifact-backed L0/L1/L2 evidence stays authoritative for shipped ABI
+verdicts.** Evidence from L3/L4/L5 may *explain, localize, scope, add
+confidence/provenance, or correlate* an artifact-proven break — but it must
+**never silently delete** one (ADR-028 D3). Findings produced *only* by
+L3/L4/L5 are ordinary `ChangeKind` entries that default to `API_BREAK_KINDS`
+(source-level breaks) or `RISK_KINDS` (deployment/context risk), never
+`BREAKING_KINDS` unless an artifact diff also proves the break.
+
+## Module map
+
+| Module | Role | ADR |
+|--------|------|-----|
+| `model.py` | `EvidencePackManifest`, `EvidencePackRef`, `LayerCoverage`, `EvidenceEntity`, `EvidenceLayer`/`EvidenceConfidence`/`CoverageStatus` enums | 028 D1/D5/D7/D8 |
+| `pack.py` | `EvidencePack` — on-disk layout, content addressing, write/load, `to_ref()` | 028 D1/D4 |
+| `build_evidence.py` | `BuildEvidence` normalized model: `Target`, `CompileUnit`, `LinkUnit`, `Toolchain`, `Generator`, `BuildOption` | 029 D1/D2 |
+| `build_diff.py` | `diff_build_evidence()` → build-flag/toolchain drift findings | 029 D9 |
+| `redaction.py` | `RedactionPolicy` — strip secrets/abs paths from command lines | 032 D7 |
+| `adapters/compile_db.py` | `compile_commands.json` → `CompileUnit`s (reuses `build_context.py`) | 029 D3 |
+| `adapters/cmake_file_api.py` | CMake File API reply → targets/toolchains/fileSets | 029 D4 |
+| `adapters/ninja.py` | Ninja `-t compdb`/`graph` (live or pre-captured) | 029 D5 |
+
+## Versioning
+
+Three *independent* schema versions — do not conflate:
+- `EVIDENCE_PACK_VERSION` (`model.py`) — pack manifest/layout.
+- `BUILD_EVIDENCE_VERSION` (`build_evidence.py`) — L3 normalized model.
+- `serialization.SCHEMA_VERSION` — the `AbiSnapshot`, which only stores an
+  `EvidencePackRef` (so old snapshot readers ignore it; ADR-015).
+
+## Conventions
+
+- Every dataclass carries `to_dict()`/`from_dict()` with defensive `.get()`
+  parsing so a newer/hand-edited pack never aborts a load (forward-compat).
+- Normalized facts are the only stable input to comparison/reporting; raw
+  tool output under `raw/` is provenance only (ADR-028 D4) and never feeds the
+  content hash.
+- Adapters must be **post-build and non-executing by default** (ADR-028 D6):
+  inspect existing build outputs / query interfaces only. Anything that builds
+  or runs project code is explicit opt-in (ADR-032 D5) — not implemented here.
+- Adding an L3/L4/L5 `ChangeKind`: follow the four-step procedure in the root
+  `CLAUDE.md`, place it in `API_BREAK_KINDS`/`RISK_KINDS` per the rule above,
+  and emit it from `build_diff.py` (or the relevant diff module).

--- a/abicheck/evidence/__init__.py
+++ b/abicheck/evidence/__init__.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional source/build/graph evidence layers (ADR-028).
+
+This sub-package implements the *EvidencePack* architecture: an optional,
+content-addressed, independently-versioned artifact that augments an
+``AbiSnapshot`` with build-context (L3), source ABI replay (L4), and
+source/implementation graph (L5) evidence.
+
+Authority rule (ADR-028 D3): artifact-backed L0/L1/L2 evidence remains the
+shipped-ABI source of truth. Evidence from L3/L4/L5 may *explain, localize,
+add confidence, scope, or correlate* an artifact-proven break, but must never
+silently delete it. Findings produced only by L3/L4/L5 are ordinary
+``ChangeKind`` entries that default to ``API_BREAK_KINDS`` (source breaks) or
+``RISK_KINDS`` (deployment/context risk), never ``BREAKING_KINDS`` unless an
+artifact diff also proves the break.
+
+Phase 0 (this module) ships the manifest, coverage model, on-disk pack layout,
+and snapshot reference. ADR-029 adds the build-evidence model and adapters.
+"""
+from __future__ import annotations
+
+from .build_evidence import (
+    BuildEvidence,
+    BuildOption,
+    CompileUnit,
+    Generator,
+    LinkUnit,
+    Target,
+    Toolchain,
+)
+from .model import (
+    EVIDENCE_PACK_VERSION,
+    EvidenceConfidence,
+    EvidenceEntity,
+    EvidenceLayer,
+    EvidencePackManifest,
+    EvidencePackRef,
+    ExtractorRecord,
+    LayerCoverage,
+)
+from .pack import EvidencePack
+
+__all__ = [
+    "EVIDENCE_PACK_VERSION",
+    "BuildEvidence",
+    "BuildOption",
+    "CompileUnit",
+    "EvidenceConfidence",
+    "EvidenceEntity",
+    "EvidenceLayer",
+    "EvidencePack",
+    "EvidencePackManifest",
+    "EvidencePackRef",
+    "ExtractorRecord",
+    "Generator",
+    "LayerCoverage",
+    "LinkUnit",
+    "Target",
+    "Toolchain",
+]

--- a/abicheck/evidence/adapters/__init__.py
+++ b/abicheck/evidence/adapters/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build-system evidence adapters (ADR-029 D3–D7).
+
+Each adapter ingests one build-system surface and emits the shared, neutral
+``BuildEvidence`` model. Adapters are post-build and non-executing by default
+(ADR-028 D6): they read existing build outputs and pre-captured query output.
+"""
+from __future__ import annotations
+
+from .base import (
+    ABI_RELEVANT_FLAG_PREFIXES,
+    BuildAdapter,
+    compile_unit_id,
+    detect_language,
+    extract_abi_relevant_flags,
+)
+from .cmake_file_api import CMakeFileApiAdapter
+from .compile_db import CompileDbAdapter
+from .ninja import NinjaAdapter
+
+__all__ = [
+    "ABI_RELEVANT_FLAG_PREFIXES",
+    "BuildAdapter",
+    "CMakeFileApiAdapter",
+    "CompileDbAdapter",
+    "NinjaAdapter",
+    "compile_unit_id",
+    "detect_language",
+    "extract_abi_relevant_flags",
+]

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -97,16 +97,29 @@ def compile_unit_id(source: str, argv: list[str], output: str = "") -> str:
 
 
 def extract_abi_relevant_flags(argv: list[str]) -> list[str]:
-    """Return the subset of *argv* that is ABI/API-affecting (ADR-029 D9)."""
+    """Return the subset of *argv* that is ABI/API-affecting (ADR-029 D9).
+
+    Handles both the combined ``-DKEY=VALUE`` define form and the split
+    ``['-D', 'KEY=VALUE']`` form; split ABI macros are normalized to the
+    combined token so downstream option derivation parses them uniformly.
+    """
     out: list[str] = []
-    for arg in argv:
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
         if arg.startswith(ABI_RELEVANT_FLAG_PREFIXES):
             out.append(arg)
+        elif arg in ("-D", "/D") and i + 1 < len(argv):
+            # Split form: -D KEY[=VALUE]. Normalize to the combined token.
+            nxt = argv[i + 1]
+            if nxt.split("=", 1)[0] in _ABI_RELEVANT_DEFINES:
+                out.append(arg + nxt)
+            i += 2
+            continue
         elif arg.startswith(("-D", "/D")):
-            body = arg[2:]
-            key = body.split("=", 1)[0]
-            if key in _ABI_RELEVANT_DEFINES:
+            if arg[2:].split("=", 1)[0] in _ABI_RELEVANT_DEFINES:
                 out.append(arg)
+        i += 1
     return out
 
 

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared adapter contract and helpers (ADR-029).
+
+The :class:`BuildAdapter` protocol is the minimal contract every build-system
+adapter implements; the free functions are the normalization helpers shared
+across adapters (language detection, compile-unit identity, ABI-flag
+extraction). Keeping these here avoids each adapter re-deriving them.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Protocol, runtime_checkable
+
+from ..build_evidence import BuildEvidence
+
+# Source-file extension → normalized language token.
+_LANG_BY_EXT: dict[str, str] = {
+    ".c": "C",
+    ".i": "C",
+    ".cc": "CXX", ".cpp": "CXX", ".cxx": "CXX", ".c++": "CXX", ".cp": "CXX",
+    ".ii": "CXX", ".hpp": "CXX", ".hh": "CXX", ".hxx": "CXX",
+    ".m": "OBJC", ".mm": "OBJCXX",
+    ".cu": "CUDA",
+}
+
+#: ABI/API-affecting compiler-flag prefixes (ADR-029 D9). Drift in any of these
+#: is treated as a risk signal by the build-evidence diff, not mere noise.
+ABI_RELEVANT_FLAG_PREFIXES: tuple[str, ...] = (
+    "-std=", "/std:",
+    "--target=", "-target", "-mabi=", "/arch:", "-m32", "-m64",
+    "--sysroot", "-isysroot",
+    "-fvisibility", "-fvisibility-inlines-hidden",
+    "-fpack-struct", "/Zp", "-fshort-enums", "-fshort-wchar",
+    "-fabi-version", "-fno-rtti", "-frtti", "-fno-exceptions", "-fexceptions",
+    "-flto", "-fno-lto", "-fwhole-program-vtables",
+)
+
+#: Macro defines whose value is ABI-relevant even though they're plain -D flags.
+_ABI_RELEVANT_DEFINES: tuple[str, ...] = (
+    "_GLIBCXX_USE_CXX11_ABI",
+    "_ITERATOR_DEBUG_LEVEL",
+    "_LIBCPP_ABI_VERSION",
+)
+
+
+@runtime_checkable
+class BuildAdapter(Protocol):
+    """Contract for a build-system evidence adapter (ADR-028 D6, ADR-032).
+
+    ``name`` is the stable extractor identifier recorded in the manifest.
+    ``collect`` returns normalized :class:`BuildEvidence`; it must never run
+    build commands or execute project code by default — it only reads existing
+    build outputs and pre-captured query output.
+    """
+
+    name: str
+
+    def collect(self) -> BuildEvidence:
+        ...
+
+
+def detect_language(source: str) -> str:
+    """Return the normalized language token for a source path ("C"/"CXX"/...)."""
+    lower = source.lower()
+    for ext, lang in _LANG_BY_EXT.items():
+        if lower.endswith(ext):
+            return lang
+    return ""
+
+
+def compile_unit_id(source: str, argv: list[str], output: str = "") -> str:
+    """Derive a stable compile-unit id from source + normalized argv + output.
+
+    The argv hash lets the same source compiled under two configurations
+    produce two distinct units (ADR-029 D3), while staying stable across runs.
+    """
+    h = hashlib.sha256()
+    h.update(source.encode("utf-8"))
+    h.update(b"\0")
+    h.update("\0".join(argv).encode("utf-8"))
+    h.update(b"\0")
+    h.update(output.encode("utf-8"))
+    return f"cu://{source}#cfg:{h.hexdigest()[:12]}"
+
+
+def extract_abi_relevant_flags(argv: list[str]) -> list[str]:
+    """Return the subset of *argv* that is ABI/API-affecting (ADR-029 D9)."""
+    out: list[str] = []
+    for arg in argv:
+        if arg.startswith(ABI_RELEVANT_FLAG_PREFIXES):
+            out.append(arg)
+        elif arg.startswith(("-D", "/D")):
+            body = arg[2:]
+            key = body.split("=", 1)[0]
+            if key in _ABI_RELEVANT_DEFINES:
+                out.append(arg)
+    return out

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import hashlib
 from typing import Protocol, runtime_checkable
 
-from ..build_evidence import BuildEvidence
+from ..build_evidence import BuildEvidence, BuildOption, CompileUnit
 
 # Source-file extension → normalized language token.
 _LANG_BY_EXT: dict[str, str] = {
@@ -107,4 +107,42 @@ def extract_abi_relevant_flags(argv: list[str]) -> list[str]:
             key = body.split("=", 1)[0]
             if key in _ABI_RELEVANT_DEFINES:
                 out.append(arg)
+    return out
+
+
+def derive_build_options(compile_units: list[CompileUnit]) -> list[BuildOption]:
+    """Project each compile unit's ABI-relevant flags into global BuildOptions.
+
+    Shared by every adapter so a pack always carries the ``build_options`` the
+    build-evidence diff (ADR-029 D9) reads — without this, a Ninja-only pack
+    would record per-unit ``abi_relevant_flags`` but no diffable options. The
+    unit fields are already redacted, so no further redaction happens here.
+    De-duplicated across units so a flag shared by 100 TUs records once.
+    """
+    out: list[BuildOption] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(key: str, value: str, *, raw: str) -> None:
+        sig = (key, value)
+        if sig in seen:
+            return
+        seen.add(sig)
+        out.append(BuildOption(key=key, value=value, abi_relevant=True, raw=raw))
+
+    for cu in compile_units:
+        if cu.standard:
+            # Per-language key so a mixed C/C++ project keeps std:C and std:CXX
+            # distinct (otherwise one masks the other in the diff).
+            std_key = f"std:{cu.language}" if cu.language else "std"
+            add(std_key, cu.standard, raw=f"-std={cu.standard}")
+        if cu.target_triple:
+            add("target", cu.target_triple, raw=cu.target_triple)
+        if cu.sysroot:
+            add("sysroot", cu.sysroot, raw=cu.sysroot)
+        for flag in cu.abi_relevant_flags:
+            if flag.startswith(("-D", "/D")):
+                key, _, value = flag[2:].partition("=")
+                add(f"define:{key}", value, raw=flag)
+            elif not flag.startswith("-std="):
+                add(flag.split("=", 1)[0], flag, raw=flag)
     return out

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -156,8 +156,17 @@ def derive_build_options(compile_units: list[CompileUnit]) -> list[BuildOption]:
             if flag.startswith(("-D", "/D")):
                 key, _, value = flag[2:].partition("=")
                 add(f"define:{key}", value, raw=flag)
-            elif flag.startswith(_STRUCTURED_FLAG_PREFIXES):
-                # std/sysroot/target are already emitted from the normalized
+            elif flag.startswith(_STD_FLAG_PREFIXES):
+                # Language standard. GCC ``-std=`` is already captured via
+                # cu.standard above; MSVC ``/std:`` is not parsed into
+                # cu.standard, so normalize it into the same std:<lang> option
+                # here (only when the structured field didn't already set it).
+                if not cu.standard:
+                    sep = "=" if "=" in flag else ":"
+                    std_val = flag.split(sep, 1)[1] if sep in flag else flag
+                    add(f"std:{cu.language}" if cu.language else "std", std_val, raw=flag)
+            elif flag.startswith(_TOOLCHAIN_PATH_FLAG_PREFIXES):
+                # sysroot/target are already emitted from the normalized
                 # structured fields above. Re-adding the raw flag would
                 # double-count and make split (``--sysroot /sdk``) vs combined
                 # (``--sysroot=/sdk``) spelling look like a change.
@@ -167,8 +176,12 @@ def derive_build_options(compile_units: list[CompileUnit]) -> list[BuildOption]:
     return out
 
 
-#: Flag prefixes whose value is already captured as a structured BuildOption
-#: (std / target / sysroot), so the raw flag must not also become an option.
-_STRUCTURED_FLAG_PREFIXES: tuple[str, ...] = (
-    "-std=", "/std:", "--sysroot", "-isysroot", "--target", "-target",
+#: Language-standard flag prefixes (GCC ``-std=`` / MSVC ``/std:``).
+_STD_FLAG_PREFIXES: tuple[str, ...] = ("-std=", "/std:")
+
+#: Value-taking toolchain flags already captured as structured target/sysroot
+#: options, so the raw flag must not also become an option (split vs combined
+#: spelling would otherwise read as a change).
+_TOOLCHAIN_PATH_FLAG_PREFIXES: tuple[str, ...] = (
+    "--sysroot", "-isysroot", "--target", "-target",
 )

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -156,6 +156,19 @@ def derive_build_options(compile_units: list[CompileUnit]) -> list[BuildOption]:
             if flag.startswith(("-D", "/D")):
                 key, _, value = flag[2:].partition("=")
                 add(f"define:{key}", value, raw=flag)
-            elif not flag.startswith("-std="):
+            elif flag.startswith(_STRUCTURED_FLAG_PREFIXES):
+                # std/sysroot/target are already emitted from the normalized
+                # structured fields above. Re-adding the raw flag would
+                # double-count and make split (``--sysroot /sdk``) vs combined
+                # (``--sysroot=/sdk``) spelling look like a change.
+                continue
+            else:
                 add(flag.split("=", 1)[0], flag, raw=flag)
     return out
+
+
+#: Flag prefixes whose value is already captured as a structured BuildOption
+#: (std / target / sysroot), so the raw flag must not also become an option.
+_STRUCTURED_FLAG_PREFIXES: tuple[str, ...] = (
+    "-std=", "/std:", "--sysroot", "-isysroot", "--target", "-target",
+)

--- a/abicheck/evidence/adapters/cmake_file_api.py
+++ b/abicheck/evidence/adapters/cmake_file_api.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CMake File API adapter (ADR-029 D4).
+
+Reads the CMake File API *reply* directory
+(``<build>/.cmake/api/v1/reply/``) — never parses ``CMakeLists.txt``. The
+codemodel gives the target graph; ``fileSets`` give public/private header
+intent; ``toolchains`` give compiler provenance. This is pure on-disk JSON
+reading: no build, no execution (ADR-028 D6).
+
+The reply directory is produced when a *query* file exists before configure
+(e.g. ``<build>/.cmake/api/v1/query/codemodel-v2``). Adapters do not write
+queries or run CMake by default; if the reply is absent, ``collect`` returns
+empty evidence with a diagnostic.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..build_evidence import (
+    BuildEvidence,
+    Confidence,
+    Generator,
+    Target,
+    TargetKind,
+    Toolchain,
+)
+from ..redaction import DEFAULT_REDACTION, RedactionPolicy
+
+# CMake target type → normalized TargetKind.
+_KIND_BY_TYPE: dict[str, TargetKind] = {
+    "EXECUTABLE": TargetKind.EXECUTABLE,
+    "STATIC_LIBRARY": TargetKind.STATIC_LIBRARY,
+    "SHARED_LIBRARY": TargetKind.SHARED_LIBRARY,
+    "MODULE_LIBRARY": TargetKind.SHARED_LIBRARY,
+    "OBJECT_LIBRARY": TargetKind.OBJECT_LIBRARY,
+    "INTERFACE_LIBRARY": TargetKind.INTERFACE,
+}
+
+_REPLY_REL = Path(".cmake/api/v1/reply")
+
+
+class CMakeFileApiAdapter:
+    """Normalize a CMake File API reply into :class:`BuildEvidence`."""
+
+    name = "cmake_file_api"
+
+    def __init__(
+        self,
+        build_dir: Path | str,
+        *,
+        redaction: RedactionPolicy | None = None,
+    ) -> None:
+        self.build_dir = Path(build_dir)
+        self.reply_dir = self.build_dir / _REPLY_REL
+        self.redaction = redaction or DEFAULT_REDACTION
+
+    def collect(self) -> BuildEvidence:
+        ev = BuildEvidence()
+        if not self.reply_dir.is_dir():
+            ev.diagnostics.append(
+                f"cmake_file_api: no reply directory at {self.reply_dir} "
+                "(query not registered before configure); skipping"
+            )
+            return ev
+
+        index = self._load_index()
+        if index is None:
+            ev.diagnostics.append("cmake_file_api: no index-*.json in reply directory")
+            return ev
+
+        objects = {obj.get("kind"): obj for obj in index.get("objects", [])}
+        self._collect_generator(index, ev)
+        self._collect_toolchains(objects.get("toolchains"), ev)
+        self._collect_codemodel(objects.get("codemodel"), ev)
+        return ev
+
+    # -- index --------------------------------------------------------------
+
+    def _load_index(self) -> dict[str, Any] | None:
+        candidates = sorted(self.reply_dir.glob("index-*.json"))
+        if not candidates:
+            return None
+        return _read(candidates[-1])  # latest by lexical (timestamped) name
+
+    def _ref(self, json_file: str) -> dict[str, Any] | None:
+        if not json_file:
+            return None
+        path = self.reply_dir / json_file
+        return _read(path) if path.is_file() else None
+
+    # -- generator ----------------------------------------------------------
+
+    def _collect_generator(self, index: dict[str, Any], ev: BuildEvidence) -> None:
+        cmake = index.get("cmake", {})
+        gen = cmake.get("generator", {})
+        ev.generators.append(
+            Generator(
+                kind="cmake",
+                version=str(cmake.get("version", {}).get("string", "")),
+                generator=str(gen.get("name", "")),
+            )
+        )
+
+    # -- toolchains ---------------------------------------------------------
+
+    def _collect_toolchains(self, ref: dict[str, Any] | None, ev: BuildEvidence) -> None:
+        obj = self._ref(ref.get("jsonFile", "")) if ref else None
+        if obj is None:
+            return
+        for tc in obj.get("toolchains", []):
+            compiler = tc.get("compiler", {})
+            lang = str(tc.get("language", ""))
+            ev.toolchains.append(
+                Toolchain(
+                    id=f"toolchain://{compiler.get('id', 'unknown')}-{lang}".lower(),
+                    path=self.redaction.path(str(compiler.get("path", ""))),
+                    compiler_id=str(compiler.get("id", "")),
+                    version=str(compiler.get("version", "")),
+                    language=lang,
+                    implicit_include_dirs=[
+                        self.redaction.path(str(d.get("path", "")))
+                        for d in compiler.get("implicit", {}).get("includeDirectories", [])
+                    ],
+                    target_triple=str(compiler.get("target", "")),
+                )
+            )
+
+    # -- codemodel ----------------------------------------------------------
+
+    def _collect_codemodel(self, ref: dict[str, Any] | None, ev: BuildEvidence) -> None:
+        obj = self._ref(ref.get("jsonFile", "")) if ref else None
+        if obj is None:
+            return
+        seen: set[str] = set()
+        for config in obj.get("configurations", []):
+            for target_ref in config.get("targets", []):
+                detail = self._ref(target_ref.get("jsonFile", ""))
+                if detail is None:
+                    continue
+                target = self._target_from_detail(detail)
+                if target.id not in seen:
+                    ev.targets.append(target)
+                    seen.add(target.id)
+
+    def _target_from_detail(self, detail: dict[str, Any]) -> Target:
+        name = str(detail.get("name", ""))
+        kind = _KIND_BY_TYPE.get(str(detail.get("type", "")), TargetKind.UNKNOWN)
+        outputs = [
+            self.redaction.path(str(a.get("path", "")))
+            for a in detail.get("artifacts", [])
+        ]
+        deps = [
+            f"target://{str(d.get('id', '')).split('::')[0]}"
+            for d in detail.get("dependencies", [])
+        ]
+        public_headers, private_headers, sources = self._partition_sources(detail)
+        return Target(
+            id=f"target://{name}",
+            name=name,
+            kind=kind,
+            build_system="cmake",
+            source_files=sources,
+            public_headers=public_headers,
+            private_headers=private_headers,
+            outputs=outputs,
+            dependencies=deps,
+            visibility=_visibility_for(public_headers, private_headers),
+            confidence=Confidence.HIGH,
+        )
+
+    def _partition_sources(
+        self, detail: dict[str, Any]
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Split a target's sources into public headers, private headers, sources.
+
+        Uses ``fileSets`` (CMake >= 3.23) for header visibility when present;
+        falls back to extension heuristics otherwise.
+        """
+        file_sets = detail.get("fileSets", [])
+        public: list[str] = []
+        private: list[str] = []
+        sources: list[str] = []
+        for src in detail.get("sources", []):
+            path = self.redaction.path(str(src.get("path", "")))
+            if not path:
+                continue
+            fs_index = src.get("fileSetIndex")
+            if isinstance(fs_index, int) and 0 <= fs_index < len(file_sets):
+                fs = file_sets[fs_index]
+                if str(fs.get("type", "")).upper() == "HEADERS":
+                    vis = str(fs.get("visibility", "")).upper()
+                    (public if vis in ("PUBLIC", "INTERFACE") else private).append(path)
+                    continue
+            if path.lower().endswith((".h", ".hh", ".hpp", ".hxx", ".h++")):
+                private.append(path)
+            else:
+                sources.append(path)
+        return public, private, sources
+
+
+def _visibility_for(public_headers: list[str], private_headers: list[str]) -> str:
+    if public_headers:
+        return "public"
+    if private_headers:
+        return "private"
+    return "unknown"
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None

--- a/abicheck/evidence/adapters/compile_db.py
+++ b/abicheck/evidence/adapters/compile_db.py
@@ -24,9 +24,14 @@ from __future__ import annotations
 from pathlib import Path
 
 from ...build_context import _extract_flags, load_compile_db
-from ..build_evidence import BuildEvidence, BuildOption, CompileUnit
+from ..build_evidence import BuildEvidence, CompileUnit
 from ..redaction import DEFAULT_REDACTION, RedactionPolicy
-from .base import compile_unit_id, detect_language, extract_abi_relevant_flags
+from .base import (
+    compile_unit_id,
+    derive_build_options,
+    detect_language,
+    extract_abi_relevant_flags,
+)
 
 
 class CompileDbAdapter:
@@ -48,7 +53,6 @@ class CompileDbAdapter:
     def collect(self) -> BuildEvidence:
         entries = load_compile_db(self.compile_db)
         ev = BuildEvidence()
-        seen_options: set[tuple[str, str]] = set()
         for entry in entries:
             argv = list(entry.arguments)
             ctx = _extract_flags(argv, entry.directory)
@@ -71,49 +75,5 @@ class CompileDbAdapter:
                 abi_relevant_flags=[self.redaction.arg(f) for f in abi_flags],
             )
             ev.compile_units.append(cu)
-            _collect_options(cu, seen_options, ev.build_options, self.redaction)
+        ev.build_options = derive_build_options(ev.compile_units)
         return ev
-
-
-def _collect_options(
-    cu: CompileUnit,
-    seen: set[tuple[str, str]],
-    out: list[BuildOption],
-    redaction: RedactionPolicy,
-) -> None:
-    """Project a compile unit's ABI-relevant flags into global BuildOptions.
-
-    De-duplicated across units so a flag shared by 100 TUs records once. The
-    build-evidence diff compares these option records between packs (ADR-029 D9).
-    """
-    if cu.standard:
-        # Key the language standard per-language so a mixed C/C++ project keeps
-        # std:C and std:CXX distinct (otherwise one masks the other in the diff).
-        std_key = f"std:{cu.language}" if cu.language else "std"
-        _add_option(out, seen, std_key, cu.standard, abi_relevant=True, raw=f"-std={cu.standard}")
-    if cu.target_triple:
-        _add_option(out, seen, "target", cu.target_triple, abi_relevant=True, raw=cu.target_triple)
-    if cu.sysroot:
-        _add_option(out, seen, "sysroot", cu.sysroot, abi_relevant=True, raw=cu.sysroot)
-    for flag in cu.abi_relevant_flags:
-        if flag.startswith(("-D", "/D")):
-            key, _, value = flag[2:].partition("=")
-            _add_option(out, seen, f"define:{key}", value, abi_relevant=True, raw=flag)
-        elif not flag.startswith("-std="):
-            _add_option(out, seen, flag.split("=", 1)[0], flag, abi_relevant=True, raw=flag)
-
-
-def _add_option(
-    out: list[BuildOption],
-    seen: set[tuple[str, str]],
-    key: str,
-    value: str,
-    *,
-    abi_relevant: bool,
-    raw: str,
-) -> None:
-    sig = (key, value)
-    if sig in seen:
-        return
-    seen.add(sig)
-    out.append(BuildOption(key=key, value=value, abi_relevant=abi_relevant, raw=raw))

--- a/abicheck/evidence/adapters/compile_db.py
+++ b/abicheck/evidence/adapters/compile_db.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""compile_commands.json adapter (ADR-029 D3).
+
+The universal low-friction L3 input. Reuses the ADR-020a parser in
+``build_context.py`` (which already handles ``arguments`` vs ``command``,
+``directory``-relative resolution, and ABI-flag extraction) and projects each
+entry into a normalized :class:`CompileUnit`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from ...build_context import _extract_flags, load_compile_db
+from ..build_evidence import BuildEvidence, BuildOption, CompileUnit
+from ..redaction import DEFAULT_REDACTION, RedactionPolicy
+from .base import compile_unit_id, detect_language, extract_abi_relevant_flags
+
+
+class CompileDbAdapter:
+    """Normalize a ``compile_commands.json`` into :class:`BuildEvidence`."""
+
+    name = "compile_commands"
+
+    def __init__(
+        self,
+        compile_db: Path | str,
+        *,
+        build_system: str = "generic",
+        redaction: RedactionPolicy | None = None,
+    ) -> None:
+        self.compile_db = Path(compile_db)
+        self.build_system = build_system
+        self.redaction = redaction or DEFAULT_REDACTION
+
+    def collect(self) -> BuildEvidence:
+        entries = load_compile_db(self.compile_db)
+        ev = BuildEvidence()
+        seen_options: set[tuple[str, str]] = set()
+        for entry in entries:
+            argv = list(entry.arguments)
+            ctx = _extract_flags(argv, entry.directory)
+            source = str(entry.file)
+            abi_flags = extract_abi_relevant_flags(argv)
+            red_argv = self.redaction.argv(argv)
+            cu = CompileUnit(
+                id=compile_unit_id(self.redaction.path(source), red_argv),
+                source=self.redaction.path(source),
+                directory=self.redaction.path(str(entry.directory)),
+                argv=red_argv,
+                language=detect_language(source),
+                standard=ctx.language_standard or "",
+                defines={k: (v or "") for k, v in ctx.defines.items()},
+                undefines=sorted(ctx.undefines),
+                include_paths=[self.redaction.path(str(p)) for p in ctx.include_paths],
+                system_include_paths=[self.redaction.path(str(p)) for p in ctx.system_includes],
+                sysroot=self.redaction.path(str(ctx.sysroot)) if ctx.sysroot else None,
+                target_triple=ctx.target_triple or "",
+                abi_relevant_flags=[self.redaction.arg(f) for f in abi_flags],
+            )
+            ev.compile_units.append(cu)
+            _collect_options(cu, seen_options, ev.build_options, self.redaction)
+        return ev
+
+
+def _collect_options(
+    cu: CompileUnit,
+    seen: set[tuple[str, str]],
+    out: list[BuildOption],
+    redaction: RedactionPolicy,
+) -> None:
+    """Project a compile unit's ABI-relevant flags into global BuildOptions.
+
+    De-duplicated across units so a flag shared by 100 TUs records once. The
+    build-evidence diff compares these option records between packs (ADR-029 D9).
+    """
+    if cu.standard:
+        # Key the language standard per-language so a mixed C/C++ project keeps
+        # std:C and std:CXX distinct (otherwise one masks the other in the diff).
+        std_key = f"std:{cu.language}" if cu.language else "std"
+        _add_option(out, seen, std_key, cu.standard, abi_relevant=True, raw=f"-std={cu.standard}")
+    if cu.target_triple:
+        _add_option(out, seen, "target", cu.target_triple, abi_relevant=True, raw=cu.target_triple)
+    if cu.sysroot:
+        _add_option(out, seen, "sysroot", cu.sysroot, abi_relevant=True, raw=cu.sysroot)
+    for flag in cu.abi_relevant_flags:
+        if flag.startswith(("-D", "/D")):
+            key, _, value = flag[2:].partition("=")
+            _add_option(out, seen, f"define:{key}", value, abi_relevant=True, raw=flag)
+        elif not flag.startswith("-std="):
+            _add_option(out, seen, flag.split("=", 1)[0], flag, abi_relevant=True, raw=flag)
+
+
+def _add_option(
+    out: list[BuildOption],
+    seen: set[tuple[str, str]],
+    key: str,
+    value: str,
+    *,
+    abi_relevant: bool,
+    raw: str,
+) -> None:
+    sig = (key, value)
+    if sig in seen:
+        return
+    seen.add(sig)
+    out.append(BuildOption(key=key, value=value, abi_relevant=abi_relevant, raw=raw))

--- a/abicheck/evidence/adapters/compile_db.py
+++ b/abicheck/evidence/adapters/compile_db.py
@@ -66,7 +66,7 @@ class CompileDbAdapter:
                 argv=red_argv,
                 language=detect_language(source),
                 standard=ctx.language_standard or "",
-                defines={k: (v or "") for k, v in ctx.defines.items()},
+                defines={k: self.redaction.define_value(k, v or "") for k, v in ctx.defines.items()},
                 undefines=sorted(ctx.undefines),
                 include_paths=[self.redaction.path(str(p)) for p in ctx.include_paths],
                 system_include_paths=[self.redaction.path(str(p)) for p in ctx.system_includes],

--- a/abicheck/evidence/adapters/ninja.py
+++ b/abicheck/evidence/adapters/ninja.py
@@ -160,7 +160,7 @@ class NinjaAdapter:
             argv=red_argv,
             language=detect_language(source),
             standard=ctx.language_standard or "",
-            defines={k: (v or "") for k, v in ctx.defines.items()},
+            defines={k: self.redaction.define_value(k, v or "") for k, v in ctx.defines.items()},
             undefines=sorted(ctx.undefines),
             include_paths=[self.redaction.path(str(p)) for p in ctx.include_paths],
             system_include_paths=[self.redaction.path(str(p)) for p in ctx.system_includes],

--- a/abicheck/evidence/adapters/ninja.py
+++ b/abicheck/evidence/adapters/ninja.py
@@ -36,7 +36,12 @@ from pathlib import Path
 from ...build_context import _extract_flags
 from ..build_evidence import BuildEvidence, CompileUnit, Generator
 from ..redaction import DEFAULT_REDACTION, RedactionPolicy
-from .base import compile_unit_id, detect_language, extract_abi_relevant_flags
+from .base import (
+    compile_unit_id,
+    derive_build_options,
+    detect_language,
+    extract_abi_relevant_flags,
+)
 
 
 class NinjaAdapter:
@@ -79,6 +84,9 @@ class NinjaAdapter:
             cu = self._compile_unit(raw)
             if cu is not None:
                 ev.compile_units.append(cu)
+        # Project per-unit ABI flags into diffable build options (same as the
+        # compile-DB adapter) so a Ninja-only pack still reports flag drift.
+        ev.build_options = derive_build_options(ev.compile_units)
 
         graph_text = self._resolve_graph(ev)
         if graph_text:

--- a/abicheck/evidence/adapters/ninja.py
+++ b/abicheck/evidence/adapters/ninja.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ninja adapter (ADR-029 D5).
+
+Uses Ninja's own ``-t`` tools rather than parsing ``.ninja`` syntax. ``-t
+compdb`` (run with no rule arguments and filtered to compiler invocations, per
+D5) yields a compile_commands.json-format database that normalizes through the
+same path as :class:`CompileDbAdapter`. ``-t graph`` gives an approximate
+dependency graph.
+
+Running ``ninja -t`` is a *query* of an existing build tree (allowed by default
+under ADR-028 D6), not a build. To stay testable on the fast lane and to
+support hermetic CI, the adapter also accepts **pre-captured** tool output:
+pass ``compdb`` / ``graph`` as JSON/DOT text or a file path instead of letting
+it shell out.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from ...build_context import _extract_flags
+from ..build_evidence import BuildEvidence, CompileUnit, Generator
+from ..redaction import DEFAULT_REDACTION, RedactionPolicy
+from .base import compile_unit_id, detect_language, extract_abi_relevant_flags
+
+
+class NinjaAdapter:
+    """Normalize Ninja ``-t`` tool output into :class:`BuildEvidence`."""
+
+    name = "ninja"
+
+    def __init__(
+        self,
+        build_dir: Path | str | None = None,
+        *,
+        compdb: str | Path | None = None,
+        graph: str | Path | None = None,
+        allow_query: bool = True,
+        redaction: RedactionPolicy | None = None,
+    ) -> None:
+        self.build_dir = Path(build_dir) if build_dir is not None else None
+        self._compdb = compdb
+        self._graph = graph
+        self.allow_query = allow_query
+        self.redaction = redaction or DEFAULT_REDACTION
+
+    def collect(self) -> BuildEvidence:
+        ev = BuildEvidence()
+        ev.generators.append(Generator(kind="ninja"))
+
+        compdb_text = self._resolve_compdb(ev)
+        if compdb_text is None:
+            return ev
+        try:
+            entries = json.loads(compdb_text)
+        except json.JSONDecodeError as exc:
+            ev.diagnostics.append(f"ninja: could not parse compdb output: {exc}")
+            return ev
+        if not isinstance(entries, list):
+            ev.diagnostics.append("ninja: compdb output was not a JSON array")
+            return ev
+
+        for raw in entries:
+            cu = self._compile_unit(raw)
+            if cu is not None:
+                ev.compile_units.append(cu)
+
+        graph_text = self._resolve_graph(ev)
+        if graph_text:
+            ev.diagnostics.append(
+                f"ninja: dependency graph captured ({len(graph_text.splitlines())} edges/nodes)"
+            )
+        return ev
+
+    # -- compdb -------------------------------------------------------------
+
+    def _resolve_compdb(self, ev: BuildEvidence) -> str | None:
+        text = _as_text(self._compdb)
+        if text is not None:
+            return text
+        if self.build_dir is not None and self.allow_query:
+            return self._run_ninja_tool(["-t", "compdb"], ev)
+        ev.diagnostics.append("ninja: no compdb provided and live query disabled")
+        return None
+
+    def _resolve_graph(self, ev: BuildEvidence) -> str | None:
+        text = _as_text(self._graph)
+        if text is not None:
+            return text
+        if self.build_dir is not None and self.allow_query:
+            return self._run_ninja_tool(["-t", "graph"], ev)
+        return None
+
+    def _run_ninja_tool(self, tool_args: list[str], ev: BuildEvidence) -> str | None:
+        ninja = shutil.which("ninja")
+        if ninja is None or self.build_dir is None:
+            ev.diagnostics.append("ninja: executable not found on PATH; cannot query")
+            return None
+        cmd = [ninja, "-C", str(self.build_dir), *tool_args]
+        try:
+            # A query of an existing build (ADR-028 D6) — never a build action.
+            proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+                cmd, capture_output=True, text=True, timeout=120, check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            ev.diagnostics.append(f"ninja: {' '.join(tool_args)} failed: {exc}")
+            return None
+        if proc.returncode != 0:
+            ev.diagnostics.append(
+                f"ninja: {' '.join(tool_args)} exited {proc.returncode}: {proc.stderr.strip()[:200]}"
+            )
+            return None
+        return proc.stdout
+
+    # -- normalization ------------------------------------------------------
+
+    def _compile_unit(self, raw: object) -> CompileUnit | None:
+        if not isinstance(raw, dict):
+            return None
+        directory = Path(str(raw.get("directory", ".")))
+        source = str(raw.get("file", ""))
+        if not source:
+            return None
+        argv = _argv_of(raw)
+        # D5: -t compdb with no rule args dumps every build statement; keep only
+        # entries that look like compiler invocations (have a recognized source).
+        if not detect_language(source):
+            return None
+        ctx = _extract_flags(argv, directory)
+        red_argv = self.redaction.argv(argv)
+        red_source = self.redaction.path(source)
+        return CompileUnit(
+            id=compile_unit_id(red_source, red_argv, str(raw.get("output", ""))),
+            source=red_source,
+            output=self.redaction.path(str(raw.get("output", ""))),
+            directory=self.redaction.path(str(directory)),
+            argv=red_argv,
+            language=detect_language(source),
+            standard=ctx.language_standard or "",
+            defines={k: (v or "") for k, v in ctx.defines.items()},
+            undefines=sorted(ctx.undefines),
+            include_paths=[self.redaction.path(str(p)) for p in ctx.include_paths],
+            system_include_paths=[self.redaction.path(str(p)) for p in ctx.system_includes],
+            sysroot=self.redaction.path(str(ctx.sysroot)) if ctx.sysroot else None,
+            target_triple=ctx.target_triple or "",
+            abi_relevant_flags=[self.redaction.arg(f) for f in extract_abi_relevant_flags(argv)],
+        )
+
+
+def _argv_of(raw: dict[str, object]) -> list[str]:
+    import os
+    import shlex
+
+    args = raw.get("arguments")
+    if isinstance(args, list):
+        return [str(a) for a in args]
+    command = raw.get("command")
+    if isinstance(command, str):
+        return shlex.split(command, posix=os.name != "nt")
+    return []
+
+
+def _as_text(value: str | Path | None) -> str | None:
+    """Return text content for a value that may be inline text or a file path."""
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        return value.read_text(encoding="utf-8") if value.is_file() else None
+    # A str: treat as a file path if it points at a real file, else inline text.
+    candidate = Path(value)
+    try:
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    except OSError:
+        pass
+    return value

--- a/abicheck/evidence/build_diff.py
+++ b/abicheck/evidence/build_diff.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from ..checker_policy import ChangeKind
 from ..checker_types import Change
-from .build_evidence import BuildEvidence, BuildOption
+from .build_evidence import BuildEvidence
 
 #: Canonical option keys whose drift specifically indicates a toolchain change
 #: (compiler/stdlib/sysroot), routed to TOOLCHAIN_VERSION_CHANGED rather than
@@ -87,33 +87,53 @@ def diff_build_evidence(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
 # -- build options -----------------------------------------------------------
 
 
-def _option_map(ev: BuildEvidence) -> dict[str, BuildOption]:
-    return {opt.key: opt for opt in ev.build_options}
+def _option_index(ev: BuildEvidence) -> tuple[dict[str, set[str]], set[str]]:
+    """Index build options as key -> {values} plus the set of ABI-relevant keys.
+
+    A multi-config compile DB legitimately carries several values for one key
+    (e.g. ``std:CXX`` = c++17 and c++20). Indexing by a *set of values* keeps
+    every variant so the diff is order-independent and never drops an added or
+    removed variant (whereas a key -> single-option map collapsed them).
+    """
+    values: dict[str, set[str]] = {}
+    abi_keys: set[str] = set()
+    for opt in ev.build_options:
+        values.setdefault(opt.key, set()).add(opt.value)
+        if opt.abi_relevant:
+            abi_keys.add(opt.key)
+    return values, abi_keys
+
+
+def _fmt_values(values: set[str]) -> str | None:
+    """Render a value set for a finding's old/new fields (None when empty)."""
+    if not values:
+        return None
+    return ", ".join(sorted(values))
 
 
 def _diff_options(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
-    old_opts = _option_map(old)
-    new_opts = _option_map(new)
+    old_vals, old_abi = _option_index(old)
+    new_vals, new_abi = _option_index(new)
     changes: list[Change] = []
 
-    for key in sorted(set(old_opts) | set(new_opts)):
-        o = old_opts.get(key)
-        n = new_opts.get(key)
-        old_val = o.value if o else None
-        new_val = n.value if n else None
-        if old_val == new_val and (o is not None) == (n is not None):
+    for key in sorted(set(old_vals) | set(new_vals)):
+        ov = old_vals.get(key, set())
+        nv = new_vals.get(key, set())
+        if ov == nv:
             continue
 
-        abi_relevant = (o.abi_relevant if o else False) or (n.abi_relevant if n else False)
+        old_disp = _fmt_values(ov)
+        new_disp = _fmt_values(nv)
+        abi_relevant = key in old_abi or key in new_abi
         # Toolchain-shaped options route to the dedicated toolchain finding.
         if key in _TOOLCHAIN_OPTION_KEYS and abi_relevant:
             changes.append(
                 Change(
                     kind=ChangeKind.TOOLCHAIN_VERSION_CHANGED,
                     symbol=f"build-option:{key}",
-                    description=f"Toolchain option {key!r} changed: {old_val!r} -> {new_val!r}",
-                    old_value=old_val,
-                    new_value=new_val,
+                    description=f"Toolchain option {key!r} changed: {old_disp!r} -> {new_disp!r}",
+                    old_value=old_disp,
+                    new_value=new_disp,
                 )
             )
             continue
@@ -123,14 +143,14 @@ def _diff_options(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
             if abi_relevant
             else ChangeKind.BUILD_CONTEXT_CHANGED
         )
-        verb = "added" if old_val is None else "removed" if new_val is None else "changed"
+        verb = "added" if not ov else "removed" if not nv else "changed"
         changes.append(
             Change(
                 kind=kind,
                 symbol=f"build-option:{key}",
-                description=f"Build option {key!r} {verb}: {old_val!r} -> {new_val!r}",
-                old_value=old_val,
-                new_value=new_val,
+                description=f"Build option {key!r} {verb}: {old_disp!r} -> {new_disp!r}",
+                old_value=old_disp,
+                new_value=new_disp,
             )
         )
     return changes

--- a/abicheck/evidence/build_diff.py
+++ b/abicheck/evidence/build_diff.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build-evidence diff and findings (ADR-029 D9).
+
+Compares the ``BuildEvidence`` of two evidence packs and classifies build-flag,
+toolchain, export-policy, and generated-file drift. Per ADR-028 D3 these
+findings are never ``BREAKING`` on their own: a build change that actually
+breaks the shipped ABI is caught separately by the artifact diff (L0/L1/L2);
+these kinds explain and localize it.
+"""
+from __future__ import annotations
+
+from ..checker_policy import ChangeKind
+from ..checker_types import Change
+from .build_evidence import BuildEvidence, BuildOption
+
+#: Canonical option keys whose drift specifically indicates a toolchain change
+#: (compiler/stdlib/sysroot), routed to TOOLCHAIN_VERSION_CHANGED rather than
+#: the generic ABI-flag finding.
+_TOOLCHAIN_OPTION_KEYS = frozenset({"target", "sysroot"})
+
+
+def check_header_parse_drift(
+    build_evidence: BuildEvidence,
+    *,
+    headers_parsed_with_context: bool,
+) -> list[Change]:
+    """Flag when the header AST was parsed without the real build context.
+
+    This is the ADR-020a problem generalized (ADR-029 D9): when L3 build
+    evidence shows ABI-relevant compile flags (``-std``, ABI macros, etc.) but
+    the L2 public-header AST was parsed *without* those flags, header-derived
+    API facts may be unreliable. Returns a single RISK finding in that case.
+
+    ``headers_parsed_with_context`` is True when the dump consumed the build's
+    ``compile_commands.json`` (ADR-020a ``-p``/``--compile-db``); when False and
+    ABI-relevant flags exist, the parse context drifted.
+    """
+    if headers_parsed_with_context:
+        return []
+    abi_flags = sorted(
+        {opt.key for opt in build_evidence.build_options if opt.abi_relevant}
+    )
+    if not abi_flags:
+        return []
+    return [
+        Change(
+            kind=ChangeKind.HEADER_PARSE_CONTEXT_DRIFT,
+            symbol="header-parse:context",
+            description=(
+                "Public headers were parsed without the build's ABI-relevant "
+                f"context ({', '.join(abi_flags)}); header-derived API facts may "
+                "be unreliable. Re-run the dump with the build's "
+                "compile_commands.json (-p/--compile-db) to restore confidence."
+            ),
+            new_value=", ".join(abi_flags),
+        )
+    ]
+
+
+def diff_build_evidence(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
+    """Return build-context findings for the old→new build-evidence transition.
+
+    The result is an ordinary list of :class:`Change` objects ready to fold
+    into a ``DiffResult`` and run through the existing verdict/policy pipeline.
+    """
+    changes: list[Change] = []
+    changes.extend(_diff_options(old, new))
+    changes.extend(_diff_toolchains(old, new))
+    changes.extend(_diff_export_policy(old, new))
+    changes.extend(_diff_generated_files(old, new))
+    return changes
+
+
+# -- build options -----------------------------------------------------------
+
+
+def _option_map(ev: BuildEvidence) -> dict[str, BuildOption]:
+    return {opt.key: opt for opt in ev.build_options}
+
+
+def _diff_options(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
+    old_opts = _option_map(old)
+    new_opts = _option_map(new)
+    changes: list[Change] = []
+
+    for key in sorted(set(old_opts) | set(new_opts)):
+        o = old_opts.get(key)
+        n = new_opts.get(key)
+        old_val = o.value if o else None
+        new_val = n.value if n else None
+        if old_val == new_val and (o is not None) == (n is not None):
+            continue
+
+        abi_relevant = (o.abi_relevant if o else False) or (n.abi_relevant if n else False)
+        # Toolchain-shaped options route to the dedicated toolchain finding.
+        if key in _TOOLCHAIN_OPTION_KEYS and abi_relevant:
+            changes.append(
+                Change(
+                    kind=ChangeKind.TOOLCHAIN_VERSION_CHANGED,
+                    symbol=f"build-option:{key}",
+                    description=f"Toolchain option {key!r} changed: {old_val!r} -> {new_val!r}",
+                    old_value=old_val,
+                    new_value=new_val,
+                )
+            )
+            continue
+
+        kind = (
+            ChangeKind.ABI_RELEVANT_BUILD_FLAG_CHANGED
+            if abi_relevant
+            else ChangeKind.BUILD_CONTEXT_CHANGED
+        )
+        verb = "added" if old_val is None else "removed" if new_val is None else "changed"
+        changes.append(
+            Change(
+                kind=kind,
+                symbol=f"build-option:{key}",
+                description=f"Build option {key!r} {verb}: {old_val!r} -> {new_val!r}",
+                old_value=old_val,
+                new_value=new_val,
+            )
+        )
+    return changes
+
+
+# -- toolchains --------------------------------------------------------------
+
+
+def _toolchain_fingerprints(ev: BuildEvidence) -> dict[str, str]:
+    """Map language → "compiler_id version target" fingerprint."""
+    out: dict[str, str] = {}
+    for tc in ev.toolchains:
+        key = tc.language or tc.id
+        out[key] = f"{tc.compiler_id} {tc.version} {tc.target_triple}".strip()
+    return out
+
+
+def _diff_toolchains(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
+    old_fp = _toolchain_fingerprints(old)
+    new_fp = _toolchain_fingerprints(new)
+    changes: list[Change] = []
+    for lang in sorted(set(old_fp) & set(new_fp)):
+        if old_fp[lang] != new_fp[lang]:
+            changes.append(
+                Change(
+                    kind=ChangeKind.TOOLCHAIN_VERSION_CHANGED,
+                    symbol=f"toolchain:{lang}",
+                    description=(
+                        f"Toolchain for {lang} changed: "
+                        f"{old_fp[lang]!r} -> {new_fp[lang]!r}"
+                    ),
+                    old_value=old_fp[lang],
+                    new_value=new_fp[lang],
+                )
+            )
+    return changes
+
+
+# -- export policy -----------------------------------------------------------
+
+
+def _export_policy(ev: BuildEvidence) -> dict[str, str]:
+    """Map target id → version-script/export-map fingerprint from link units."""
+    out: dict[str, str] = {}
+    for lu in ev.link_units:
+        if lu.version_script or lu.soname:
+            out[lu.target_id or lu.id] = f"{lu.version_script}|{lu.soname}"
+    return out
+
+
+def _diff_export_policy(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
+    old_ep = _export_policy(old)
+    new_ep = _export_policy(new)
+    changes: list[Change] = []
+    for target in sorted(set(old_ep) | set(new_ep)):
+        ov = old_ep.get(target)
+        nv = new_ep.get(target)
+        if ov != nv:
+            changes.append(
+                Change(
+                    kind=ChangeKind.LINK_EXPORT_POLICY_CHANGED,
+                    symbol=f"link:{target}",
+                    description=(
+                        f"Export policy for {target} changed: {ov!r} -> {nv!r}. "
+                        "If exported symbols were removed, see the artifact diff "
+                        "for the authoritative breaking findings."
+                    ),
+                    old_value=ov,
+                    new_value=nv,
+                )
+            )
+    return changes
+
+
+# -- generated files ---------------------------------------------------------
+
+
+def _diff_generated_files(old: BuildEvidence, new: BuildEvidence) -> list[Change]:
+    """Flag generated-file dependency instability surfaced in diagnostics.
+
+    Ninja's ``missingdeps`` tool (ADR-029 D5) and similar signals land in
+    ``diagnostics``; a new instability signal in the new pack is a risk.
+    """
+    changes: list[Change] = []
+    marker = "missingdeps"
+    old_has = any(marker in d for d in old.diagnostics)
+    new_has = any(marker in d for d in new.diagnostics)
+    if new_has and not old_has:
+        changes.append(
+            Change(
+                kind=ChangeKind.GENERATED_FILE_DEPENDENCY_UNSTABLE,
+                symbol="build-graph:generated-files",
+                description=(
+                    "Build graph reports missing/unstable generated-file "
+                    "dependencies in the new build; generated public "
+                    "declarations may differ from what was analyzed."
+                ),
+            )
+        )
+    return changes

--- a/abicheck/evidence/build_evidence.py
+++ b/abicheck/evidence/build_evidence.py
@@ -357,7 +357,13 @@ class BuildEvidence:
         _merge_by_id(self.compile_units, other.compile_units)
         _merge_by_id(self.link_units, other.link_units)
         self.generated_files = sorted(set(self.generated_files) | set(other.generated_files))
-        self.build_options.extend(other.build_options)
+        # De-duplicate build options by (key, value) so running two adapters on
+        # one tree (e.g. compile DB + Ninja) doesn't store the same option twice.
+        seen_opts = {(o.key, o.value) for o in self.build_options}
+        for opt in other.build_options:
+            if (opt.key, opt.value) not in seen_opts:
+                self.build_options.append(opt)
+                seen_opts.add((opt.key, opt.value))
         self.diagnostics.extend(other.diagnostics)
         self.raw_artifacts = sorted(set(self.raw_artifacts) | set(other.raw_artifacts))
 

--- a/abicheck/evidence/build_evidence.py
+++ b/abicheck/evidence/build_evidence.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build-system-neutral build evidence model (ADR-029 D1, D2).
+
+``BuildEvidence`` is abicheck's own normalized schema for L3 build context.
+Adapters for compile_commands.json, CMake File API, Ninja, Bazel, and Make
+(ADR-029 D3–D7) all emit into this model; external formats never become the
+stable public schema (ADR-028 D4). Stored as ``build/build_evidence.json``
+inside an evidence pack.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+#: Build-evidence schema version, independent of the pack/snapshot versions.
+BUILD_EVIDENCE_VERSION: int = 1
+
+
+class TargetKind(str, Enum):
+    SHARED_LIBRARY = "shared_library"
+    STATIC_LIBRARY = "static_library"
+    OBJECT_LIBRARY = "object_library"
+    EXECUTABLE = "executable"
+    INTERFACE = "interface"
+    UNKNOWN = "unknown"
+
+
+class Confidence(str, Enum):
+    HIGH = "high"
+    REDUCED = "reduced"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class Generator:
+    """A build-system generator that produced the tree (ADR-029 D1)."""
+
+    kind: str = "generic"           # cmake | ninja | bazel | make | generic
+    version: str = ""
+    generator: str = ""             # e.g. CMake's backend "Ninja"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "version": self.version, "generator": self.generator}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Generator:
+        return cls(
+            kind=str(d.get("kind", "generic")),
+            version=str(d.get("version", "")),
+            generator=str(d.get("generator", "")),
+        )
+
+
+@dataclass
+class Toolchain:
+    """A compiler/toolchain referenced by compile units (ADR-029 D4, D8)."""
+
+    id: str                         # "toolchain://gcc-14-cxx"
+    path: str = ""
+    compiler_id: str = ""           # "GNU" | "Clang" | "MSVC"
+    version: str = ""
+    language: str = ""              # "C" | "CXX"
+    implicit_include_dirs: list[str] = field(default_factory=list)
+    implicit_link_dirs: list[str] = field(default_factory=list)
+    target_triple: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "path": self.path,
+            "compiler_id": self.compiler_id,
+            "version": self.version,
+            "language": self.language,
+            "implicit_include_dirs": list(self.implicit_include_dirs),
+            "implicit_link_dirs": list(self.implicit_link_dirs),
+            "target_triple": self.target_triple,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Toolchain:
+        return cls(
+            id=str(d["id"]),
+            path=str(d.get("path", "")),
+            compiler_id=str(d.get("compiler_id", "")),
+            version=str(d.get("version", "")),
+            language=str(d.get("language", "")),
+            implicit_include_dirs=list(d.get("implicit_include_dirs", [])),
+            implicit_link_dirs=list(d.get("implicit_link_dirs", [])),
+            target_triple=str(d.get("target_triple", "")),
+        )
+
+
+@dataclass
+class Target:
+    """A build target: library/executable mapping (ADR-029 D2)."""
+
+    id: str                         # "target://libfoo"
+    name: str = ""
+    kind: TargetKind = TargetKind.UNKNOWN
+    build_system: str = "generic"
+    source_files: list[str] = field(default_factory=list)
+    public_headers: list[str] = field(default_factory=list)
+    private_headers: list[str] = field(default_factory=list)
+    outputs: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+    visibility: str = "unknown"     # public | private | interface | unknown
+    confidence: Confidence = Confidence.UNKNOWN
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "kind": self.kind.value,
+            "build_system": self.build_system,
+            "source_files": list(self.source_files),
+            "public_headers": list(self.public_headers),
+            "private_headers": list(self.private_headers),
+            "outputs": list(self.outputs),
+            "dependencies": list(self.dependencies),
+            "visibility": self.visibility,
+            "confidence": self.confidence.value,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Target:
+        return cls(
+            id=str(d["id"]),
+            name=str(d.get("name", "")),
+            kind=_target_kind(d.get("kind")),
+            build_system=str(d.get("build_system", "generic")),
+            source_files=list(d.get("source_files", [])),
+            public_headers=list(d.get("public_headers", [])),
+            private_headers=list(d.get("private_headers", [])),
+            outputs=list(d.get("outputs", [])),
+            dependencies=list(d.get("dependencies", [])),
+            visibility=str(d.get("visibility", "unknown")),
+            confidence=_confidence(d.get("confidence")),
+        )
+
+
+@dataclass
+class CompileUnit:
+    """One translation-unit compile action (ADR-029 D2, D3)."""
+
+    id: str                         # "cu://src/foo.cpp#cfg:abc123"
+    source: str = ""
+    output: str = ""
+    directory: str = ""
+    target_id: str = ""
+    compiler: str = ""              # "toolchain://gcc-14-cxx"
+    argv: list[str] = field(default_factory=list)
+    language: str = ""              # "C" | "CXX"
+    standard: str = ""              # "c++20"
+    defines: dict[str, str] = field(default_factory=dict)
+    undefines: list[str] = field(default_factory=list)
+    include_paths: list[str] = field(default_factory=list)
+    system_include_paths: list[str] = field(default_factory=list)
+    sysroot: str | None = None
+    target_triple: str = ""
+    abi_relevant_flags: list[str] = field(default_factory=list)
+    raw_ref: str = ""               # content-addressed path under raw/
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "source": self.source,
+            "output": self.output,
+            "directory": self.directory,
+            "target_id": self.target_id,
+            "compiler": self.compiler,
+            "argv": list(self.argv),
+            "language": self.language,
+            "standard": self.standard,
+            "defines": dict(self.defines),
+            "undefines": list(self.undefines),
+            "include_paths": list(self.include_paths),
+            "system_include_paths": list(self.system_include_paths),
+            "sysroot": self.sysroot,
+            "target_triple": self.target_triple,
+            "abi_relevant_flags": list(self.abi_relevant_flags),
+            "raw_ref": self.raw_ref,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CompileUnit:
+        return cls(
+            id=str(d["id"]),
+            source=str(d.get("source", "")),
+            output=str(d.get("output", "")),
+            directory=str(d.get("directory", "")),
+            target_id=str(d.get("target_id", "")),
+            compiler=str(d.get("compiler", "")),
+            argv=list(d.get("argv", [])),
+            language=str(d.get("language", "")),
+            standard=str(d.get("standard", "")),
+            defines=dict(d.get("defines", {})),
+            undefines=list(d.get("undefines", [])),
+            include_paths=list(d.get("include_paths", [])),
+            system_include_paths=list(d.get("system_include_paths", [])),
+            sysroot=d.get("sysroot"),
+            target_triple=str(d.get("target_triple", "")),
+            abi_relevant_flags=list(d.get("abi_relevant_flags", [])),
+            raw_ref=str(d.get("raw_ref", "")),
+        )
+
+
+@dataclass
+class LinkUnit:
+    """One link action producing a shared/static library or executable (D2)."""
+
+    id: str                         # "link://libfoo.so"
+    target_id: str = ""
+    output: str = ""
+    kind: str = "shared_library"
+    inputs: list[str] = field(default_factory=list)
+    linker_argv: list[str] = field(default_factory=list)
+    version_script: str = ""        # exports.map / .def / version script
+    soname: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "target_id": self.target_id,
+            "output": self.output,
+            "kind": self.kind,
+            "inputs": list(self.inputs),
+            "linker_argv": list(self.linker_argv),
+            "version_script": self.version_script,
+            "soname": self.soname,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LinkUnit:
+        return cls(
+            id=str(d["id"]),
+            target_id=str(d.get("target_id", "")),
+            output=str(d.get("output", "")),
+            kind=str(d.get("kind", "shared_library")),
+            inputs=list(d.get("inputs", [])),
+            linker_argv=list(d.get("linker_argv", [])),
+            version_script=str(d.get("version_script", "")),
+            soname=str(d.get("soname", "")),
+        )
+
+
+@dataclass
+class BuildOption:
+    """A normalized, ABI-relevant build option (ADR-029 D9).
+
+    ``key`` is a canonical option name (e.g. "std", "define:FOO",
+    "visibility", "glibcxx_use_cxx11_abi"); ``value`` is the normalized value.
+    ``abi_relevant`` marks options whose drift the build-evidence diff treats
+    as a risk signal rather than mere quality noise.
+    """
+
+    key: str
+    value: str = ""
+    abi_relevant: bool = False
+    scope: str = "global"           # global | target:<id> | compile-unit:<id>
+    raw: str = ""                   # original flag text, redacted
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "value": self.value,
+            "abi_relevant": self.abi_relevant,
+            "scope": self.scope,
+            "raw": self.raw,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOption:
+        return cls(
+            key=str(d["key"]),
+            value=str(d.get("value", "")),
+            abi_relevant=bool(d.get("abi_relevant", False)),
+            scope=str(d.get("scope", "global")),
+            raw=str(d.get("raw", "")),
+        )
+
+
+@dataclass
+class BuildEvidence:
+    """Top-level normalized build evidence (ADR-029 D1)."""
+
+    schema_version: int = BUILD_EVIDENCE_VERSION
+    source_root: str = ""           # "repo://root" — redacted
+    build_root: str = ""            # "build://root" — redacted
+    generators: list[Generator] = field(default_factory=list)
+    toolchains: list[Toolchain] = field(default_factory=list)
+    targets: list[Target] = field(default_factory=list)
+    compile_units: list[CompileUnit] = field(default_factory=list)
+    link_units: list[LinkUnit] = field(default_factory=list)
+    generated_files: list[str] = field(default_factory=list)
+    build_options: list[BuildOption] = field(default_factory=list)
+    diagnostics: list[str] = field(default_factory=list)
+    raw_artifacts: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_root": self.source_root,
+            "build_root": self.build_root,
+            "generators": [g.to_dict() for g in self.generators],
+            "toolchains": [t.to_dict() for t in self.toolchains],
+            "targets": [t.to_dict() for t in self.targets],
+            "compile_units": [c.to_dict() for c in self.compile_units],
+            "link_units": [link.to_dict() for link in self.link_units],
+            "generated_files": list(self.generated_files),
+            "build_options": [o.to_dict() for o in self.build_options],
+            "diagnostics": list(self.diagnostics),
+            "raw_artifacts": list(self.raw_artifacts),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildEvidence:
+        return cls(
+            schema_version=int(d.get("schema_version", BUILD_EVIDENCE_VERSION)),
+            source_root=str(d.get("source_root", "")),
+            build_root=str(d.get("build_root", "")),
+            generators=[Generator.from_dict(g) for g in d.get("generators", [])],
+            toolchains=[Toolchain.from_dict(t) for t in d.get("toolchains", [])],
+            targets=[Target.from_dict(t) for t in d.get("targets", [])],
+            compile_units=[CompileUnit.from_dict(c) for c in d.get("compile_units", [])],
+            link_units=[LinkUnit.from_dict(link) for link in d.get("link_units", [])],
+            generated_files=list(d.get("generated_files", [])),
+            build_options=[BuildOption.from_dict(o) for o in d.get("build_options", [])],
+            diagnostics=list(d.get("diagnostics", [])),
+            raw_artifacts=list(d.get("raw_artifacts", [])),
+        )
+
+    def merge(self, other: BuildEvidence) -> None:
+        """Fold another adapter's output into this one (in place).
+
+        Used by ``collect-evidence`` when several adapters run against the same
+        tree (e.g. CMake File API for targets + compile DB for exact argv).
+        De-duplicates by entity id so a compile unit collected twice is kept
+        once (CMake File API wins on target facts, compile DB on argv).
+        """
+        self.generators.extend(other.generators)
+        _merge_by_id(self.toolchains, other.toolchains)
+        _merge_by_id(self.targets, other.targets)
+        _merge_by_id(self.compile_units, other.compile_units)
+        _merge_by_id(self.link_units, other.link_units)
+        self.generated_files = sorted(set(self.generated_files) | set(other.generated_files))
+        self.build_options.extend(other.build_options)
+        self.diagnostics.extend(other.diagnostics)
+        self.raw_artifacts = sorted(set(self.raw_artifacts) | set(other.raw_artifacts))
+
+
+def _merge_by_id(dst: list[Any], src: list[Any]) -> None:
+    seen = {item.id for item in dst}
+    for item in src:
+        if item.id not in seen:
+            dst.append(item)
+            seen.add(item.id)
+
+
+def _target_kind(raw: Any) -> TargetKind:
+    try:
+        return TargetKind(raw if raw is not None else "unknown")
+    except ValueError:
+        return TargetKind.UNKNOWN
+
+
+def _confidence(raw: Any) -> Confidence:
+    try:
+        return Confidence(raw if raw is not None else "unknown")
+    except ValueError:
+        return Confidence.UNKNOWN

--- a/abicheck/evidence/model.py
+++ b/abicheck/evidence/model.py
@@ -1,0 +1,281 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EvidencePack manifest and coverage model (ADR-028 D1, D5, D7, D8).
+
+These dataclasses are the abicheck-owned, JSON-serializable schema for the
+evidence pack. They version *independently* from the ABI snapshot schema
+(``EVIDENCE_PACK_VERSION`` here vs. ``serialization.SCHEMA_VERSION``) so that
+heavyweight source graphs and raw build dumps never bloat ordinary ABI dumps.
+
+Nothing here parses binaries or runs external tools — the model is pure data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+#: Evidence-pack schema version. Bumped on any breaking change to the manifest
+#: or normalized-fact layout. Independent of ``serialization.SCHEMA_VERSION``
+#: (ADR-028 D8): the snapshot only stores a lightweight reference.
+EVIDENCE_PACK_VERSION: int = 1
+
+
+class EvidenceLayer(str, Enum):
+    """Optional evidence layers added by ADR-028 on top of L0/L1/L2.
+
+    L0 (binary), L1 (debug info), and L2 (header AST) are intrinsic to the
+    ``AbiSnapshot`` and are not represented here; they are reported directly
+    from the snapshot. These three are the *optional* augmentation layers.
+    """
+
+    L3_BUILD = "L3_build"           # build context: compile DB, CMake, Ninja, Bazel, Make
+    L4_SOURCE_ABI = "L4_source_abi"  # per-TU source ABI replay (ADR-030)
+    L5_SOURCE_GRAPH = "L5_source_graph"  # include/type/call/build graph (ADR-031)
+
+
+class EvidenceConfidence(str, Enum):
+    """Confidence qualifier for an evidence layer or joined entity (ADR-028 D5).
+
+    ``HIGH`` — facts are directly observed (e.g. exact compile command, exported
+    symbol). ``REDUCED`` — facts are inferred or partial (e.g. public/private
+    header intent without rule metadata). ``UNKNOWN`` — provenance could not be
+    established.
+    """
+
+    HIGH = "high"
+    REDUCED = "reduced"
+    UNKNOWN = "unknown"
+
+
+class CoverageStatus(str, Enum):
+    """Collection status for an evidence layer in the coverage table (D7)."""
+
+    PRESENT = "present"            # collected in full
+    PARTIAL = "partial"           # collected for a subset (e.g. changed headers only)
+    NOT_COLLECTED = "not_collected"  # extractor not run / unavailable
+
+
+@dataclass
+class LayerCoverage:
+    """One row of the evidence-coverage table (ADR-028 D7).
+
+    Reported across all output formats so users can tell which findings are
+    artifact-proven vs. build-context-only vs. source/graph-assisted.
+    """
+
+    layer: str                      # EvidenceLayer value OR "L0"/"L1"/"L2" for intrinsic layers
+    status: CoverageStatus = CoverageStatus.NOT_COLLECTED
+    confidence: EvidenceConfidence = EvidenceConfidence.UNKNOWN
+    detail: str = ""                # human-readable note, e.g. "CMake+Ninja, 142 compile units"
+
+    @property
+    def present(self) -> bool:
+        return self.status in (CoverageStatus.PRESENT, CoverageStatus.PARTIAL)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "layer": self.layer,
+            "status": self.status.value,
+            "confidence": self.confidence.value,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LayerCoverage:
+        return cls(
+            layer=str(d["layer"]),
+            status=_coverage_status(d.get("status")),
+            confidence=_confidence(d.get("confidence")),
+            detail=str(d.get("detail", "")),
+        )
+
+
+@dataclass
+class EvidenceEntity:
+    """Cross-layer canonical identity joining build/source/debug/binary facts.
+
+    The ``entity_id`` is a stable content hash. ``binary_refs`` and
+    ``build_refs`` are the join keys back to L0 symbols and L3 build targets
+    (ADR-028 D5). Phase 0 defines the model; extractors populate it.
+    """
+
+    entity_id: str                  # "sha256:..."
+    kind: str                       # function|variable|record|enum|typedef|macro|file|target|compile_unit|binary_symbol|build_option
+    names: dict[str, str] = field(default_factory=dict)  # source_qualified, mangled, demangled, usr
+    locations: list[dict[str, Any]] = field(default_factory=list)  # {path, line, column, origin}
+    binary_refs: list[str] = field(default_factory=list)  # "elf:symbol:_ZN..."
+    build_refs: list[str] = field(default_factory=list)   # "target://libfoo", "compile-unit://src/bar.cpp"
+    confidence: EvidenceConfidence = EvidenceConfidence.UNKNOWN
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entity_id": self.entity_id,
+            "kind": self.kind,
+            "names": dict(self.names),
+            "locations": list(self.locations),
+            "binary_refs": list(self.binary_refs),
+            "build_refs": list(self.build_refs),
+            "confidence": self.confidence.value,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> EvidenceEntity:
+        return cls(
+            entity_id=str(d["entity_id"]),
+            kind=str(d.get("kind", "")),
+            names=dict(d.get("names", {})),
+            locations=list(d.get("locations", [])),
+            binary_refs=list(d.get("binary_refs", [])),
+            build_refs=list(d.get("build_refs", [])),
+            confidence=_confidence(d.get("confidence")),
+        )
+
+
+@dataclass
+class ExtractorRecord:
+    """Provenance for one extractor run, recorded in the manifest (D8)."""
+
+    name: str                       # e.g. "compile_commands", "cmake_file_api", "ninja"
+    version: str = ""               # extractor/tool version
+    status: str = "ok"             # ok | partial | failed | skipped
+    inputs: list[str] = field(default_factory=list)   # redacted input descriptors
+    artifacts: list[str] = field(default_factory=list)  # content-addressed paths under raw/ or normalized/
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "status": self.status,
+            "inputs": list(self.inputs),
+            "artifacts": list(self.artifacts),
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ExtractorRecord:
+        return cls(
+            name=str(d["name"]),
+            version=str(d.get("version", "")),
+            status=str(d.get("status", "ok")),
+            inputs=list(d.get("inputs", [])),
+            artifacts=list(d.get("artifacts", [])),
+            detail=str(d.get("detail", "")),
+        )
+
+
+@dataclass
+class EvidencePackManifest:
+    """The pack ``manifest.json`` (ADR-028 D8).
+
+    ``source_root`` is redaction-aware: the real path is never stored, only a
+    repo hash (ADR-032 D7). ``coverage`` carries one ``LayerCoverage`` per
+    optional layer; intrinsic L0/L1/L2 coverage is computed from the snapshot
+    at report time, not stored here.
+    """
+
+    evidence_pack_version: int = EVIDENCE_PACK_VERSION
+    abicheck_version: str = ""
+    created_at: str = ""            # ISO 8601
+    source_root: dict[str, Any] = field(
+        default_factory=lambda: {"path_redacted": True, "repo_hash": ""}
+    )
+    inputs: dict[str, Any] = field(default_factory=dict)
+    extractors: list[ExtractorRecord] = field(default_factory=list)
+    artifacts: list[str] = field(default_factory=list)  # content-addressed artifact digests
+    coverage: list[LayerCoverage] = field(default_factory=list)
+    redaction: dict[str, Any] = field(default_factory=dict)
+
+    def coverage_for(self, layer: EvidenceLayer | str) -> LayerCoverage | None:
+        key = layer.value if isinstance(layer, EvidenceLayer) else layer
+        for c in self.coverage:
+            if c.layer == key:
+                return c
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "evidence_pack_version": self.evidence_pack_version,
+            "abicheck_version": self.abicheck_version,
+            "created_at": self.created_at,
+            "source_root": dict(self.source_root),
+            "inputs": dict(self.inputs),
+            "extractors": [e.to_dict() for e in self.extractors],
+            "artifacts": list(self.artifacts),
+            "coverage": [c.to_dict() for c in self.coverage],
+            "redaction": dict(self.redaction),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> EvidencePackManifest:
+        ver = int(d.get("evidence_pack_version", EVIDENCE_PACK_VERSION))
+        return cls(
+            evidence_pack_version=ver,
+            abicheck_version=str(d.get("abicheck_version", "")),
+            created_at=str(d.get("created_at", "")),
+            source_root=dict(d.get("source_root", {"path_redacted": True, "repo_hash": ""})),
+            inputs=dict(d.get("inputs", {})),
+            extractors=[ExtractorRecord.from_dict(e) for e in d.get("extractors", [])],
+            artifacts=list(d.get("artifacts", [])),
+            coverage=[LayerCoverage.from_dict(c) for c in d.get("coverage", [])],
+            redaction=dict(d.get("redaction", {})),
+        )
+
+
+@dataclass
+class EvidencePackRef:
+    """Lightweight reference stored *inside* the ``AbiSnapshot`` (ADR-028 D8).
+
+    Keeps old snapshot readers functional (ADR-015): this is an optional field,
+    and the heavyweight pack lives out-of-band, content-addressed by
+    ``content_hash``.
+    """
+
+    schema_version: int = EVIDENCE_PACK_VERSION
+    content_hash: str = ""          # "sha256:..." of the pack manifest+artifacts
+    path_hint: str = ""             # e.g. "libfoo.evidence/" — advisory only
+    coverage_summary: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "content_hash": self.content_hash,
+            "path_hint": self.path_hint,
+            "coverage_summary": dict(self.coverage_summary),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> EvidencePackRef:
+        return cls(
+            schema_version=int(d.get("schema_version", EVIDENCE_PACK_VERSION)),
+            content_hash=str(d.get("content_hash", "")),
+            path_hint=str(d.get("path_hint", "")),
+            coverage_summary=dict(d.get("coverage_summary", {})),
+        )
+
+
+def _confidence(raw: Any) -> EvidenceConfidence:
+    try:
+        return EvidenceConfidence(raw if raw is not None else "unknown")
+    except ValueError:
+        return EvidenceConfidence.UNKNOWN
+
+
+def _coverage_status(raw: Any) -> CoverageStatus:
+    try:
+        return CoverageStatus(raw if raw is not None else "not_collected")
+    except ValueError:
+        return CoverageStatus.NOT_COLLECTED

--- a/abicheck/evidence/pack.py
+++ b/abicheck/evidence/pack.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""On-disk EvidencePack: directory layout, content addressing, I/O (ADR-028 D1, D4).
+
+Layout::
+
+    <pack>/
+      manifest.json
+      build/build_evidence.json              # optional (ADR-029)
+      source/source_abi.json                 # optional (ADR-030)
+      graph/source_graph_summary.json        # optional (ADR-031)
+      toolchain/toolchain_fingerprints.json  # optional
+      raw/<extractor>/<content-addressed>    # external tool output, for provenance
+      normalized/<extractor>/<json>          # abicheck-owned normalized facts
+
+Raw artifacts are for debugging/reproducibility only; normalized facts are the
+only stable input to comparison and reporting (ADR-028 D4).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .build_evidence import BuildEvidence
+from .model import EvidencePackManifest, EvidencePackRef
+
+MANIFEST_NAME = "manifest.json"
+BUILD_EVIDENCE_REL = "build/build_evidence.json"
+
+#: Sub-directories created for every pack so adapters have a stable place to
+#: write. Empty directories are harmless and keep the layout self-documenting.
+_PACK_SUBDIRS = ("build", "source", "graph", "toolchain", "raw", "normalized")
+
+
+@dataclass
+class EvidencePack:
+    """In-memory view of an evidence pack rooted at ``root``.
+
+    ``manifest`` is always present (Phase 0 supports an empty, manifest-only
+    pack). ``build_evidence`` is the ADR-029 L3 payload, ``None`` until a build
+    adapter runs.
+    """
+
+    root: Path
+    manifest: EvidencePackManifest = field(default_factory=EvidencePackManifest)
+    build_evidence: BuildEvidence | None = None
+
+    # -- construction -------------------------------------------------------
+
+    @classmethod
+    def empty(cls, root: Path | str, abicheck_version: str = "", created_at: str = "") -> EvidencePack:
+        """Create a manifest-only pack in memory (not yet written)."""
+        manifest = EvidencePackManifest(
+            abicheck_version=abicheck_version,
+            created_at=created_at,
+        )
+        return cls(root=Path(root), manifest=manifest)
+
+    @classmethod
+    def load(cls, root: Path | str) -> EvidencePack:
+        """Load a pack from disk. Raises ``FileNotFoundError`` if no manifest."""
+        root = Path(root)
+        manifest_path = root / MANIFEST_NAME
+        if not manifest_path.is_file():
+            raise FileNotFoundError(
+                f"No evidence-pack manifest at {manifest_path}. "
+                f"Expected a directory produced by `abicheck collect-evidence`."
+            )
+        manifest = EvidencePackManifest.from_dict(_read_json(manifest_path))
+        build_evidence: BuildEvidence | None = None
+        be_path = root / BUILD_EVIDENCE_REL
+        if be_path.is_file():
+            build_evidence = BuildEvidence.from_dict(_read_json(be_path))
+        return cls(root=root, manifest=manifest, build_evidence=build_evidence)
+
+    # -- persistence --------------------------------------------------------
+
+    def write(self) -> Path:
+        """Write the pack to ``root`` and return the manifest path.
+
+        Recomputes ``manifest.artifacts`` from on-disk normalized payloads so
+        the content hash is stable and reproducible.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        for sub in _PACK_SUBDIRS:
+            (self.root / sub).mkdir(parents=True, exist_ok=True)
+
+        # Write normalized build evidence first so it is hashed as an artifact.
+        if self.build_evidence is not None:
+            be_path = self.root / BUILD_EVIDENCE_REL
+            be_path.parent.mkdir(parents=True, exist_ok=True)
+            _write_json(be_path, self.build_evidence.to_dict())
+
+        # Record content-addressed digests of the normalized payloads.
+        self.manifest.artifacts = self._artifact_digests()
+        _write_json(self.root / MANIFEST_NAME, self.manifest.to_dict())
+        return self.root / MANIFEST_NAME
+
+    def _artifact_digests(self) -> list[str]:
+        """Return sorted ``sha256:<hex>`` digests of normalized payload files.
+
+        Only normalized/canonical files contribute to the content hash; raw/
+        provenance dumps are intentionally excluded so the same logical
+        evidence hashes identically regardless of which tool produced it.
+        """
+        digests: list[str] = []
+        be_path = self.root / BUILD_EVIDENCE_REL
+        if be_path.is_file():
+            digests.append("sha256:" + _file_sha256(be_path))
+        normalized = self.root / "normalized"
+        if normalized.is_dir():
+            for p in sorted(normalized.rglob("*")):
+                if p.is_file():
+                    digests.append("sha256:" + _file_sha256(p))
+        return sorted(set(digests))
+
+    # -- content addressing -------------------------------------------------
+
+    def content_hash(self) -> str:
+        """Stable ``sha256:<hex>`` over the manifest identity + artifact digests.
+
+        Excludes volatile fields (``created_at``) so two packs with identical
+        evidence collected at different times hash the same.
+        """
+        ident = {
+            "evidence_pack_version": self.manifest.evidence_pack_version,
+            "artifacts": sorted(self.manifest.artifacts or self._artifact_digests()),
+            "coverage": [c.to_dict() for c in self.manifest.coverage],
+            "extractors": [e.name + "@" + e.version for e in self.manifest.extractors],
+        }
+        blob = json.dumps(ident, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+    def to_ref(self, path_hint: str = "") -> EvidencePackRef:
+        """Build the lightweight snapshot reference (ADR-028 D8)."""
+        return EvidencePackRef(
+            schema_version=self.manifest.evidence_pack_version,
+            content_hash=self.content_hash(),
+            path_hint=path_hint or str(self.root),
+            coverage_summary={
+                c.layer: {"status": c.status.value, "confidence": c.confidence.value}
+                for c in self.manifest.coverage
+            },
+        )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object, got {type(data).__name__}")
+    return data
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/abicheck/evidence/pack.py
+++ b/abicheck/evidence/pack.py
@@ -101,10 +101,16 @@ class EvidencePack:
             (self.root / sub).mkdir(parents=True, exist_ok=True)
 
         # Write normalized build evidence first so it is hashed as an artifact.
+        # When the new run produced no build evidence, remove any stale file left
+        # by an earlier collection into the same directory — otherwise load() and
+        # the content hash would keep using evidence the new manifest says was
+        # not collected.
+        be_path = self.root / BUILD_EVIDENCE_REL
         if self.build_evidence is not None:
-            be_path = self.root / BUILD_EVIDENCE_REL
             be_path.parent.mkdir(parents=True, exist_ok=True)
             _write_json(be_path, self.build_evidence.to_dict())
+        elif be_path.is_file():
+            be_path.unlink()
 
         # Record content-addressed digests of the normalized payloads.
         self.manifest.artifacts = self._artifact_digests()

--- a/abicheck/evidence/redaction.py
+++ b/abicheck/evidence/redaction.py
@@ -55,14 +55,20 @@ class RedactionPolicy:
                 self.home_replacements = {home: "~"}
 
     def path(self, value: str) -> str:
-        """Redact a single path-like string."""
+        """Redact home-prefix occurrences in a path-like or flag token.
+
+        Replaces the home prefix wherever it appears, not only at the start, so
+        combined compiler flags that embed a workspace path (``-I/home/u/inc``,
+        ``-DROOT=/home/u/sdk``) are redacted in the persisted ``argv`` just like
+        the standalone path fields.
+        """
         if not value:
             return value
         out = value
         if self.redact_home:
             for prefix, placeholder in self.home_replacements.items():
-                if prefix and out.startswith(prefix):
-                    out = placeholder + out[len(prefix):]
+                if prefix:
+                    out = out.replace(prefix, placeholder)
         return out
 
     def arg(self, value: str) -> str:

--- a/abicheck/evidence/redaction.py
+++ b/abicheck/evidence/redaction.py
@@ -91,7 +91,32 @@ class RedactionPolicy:
         return self.path(value)
 
     def argv(self, args: list[str]) -> list[str]:
-        return [self.arg(a) for a in args]
+        """Redact a full argument list, handling split ``-D KEY=VALUE`` form.
+
+        A secret macro may be passed as a single ``-DKEY=secret`` token (handled
+        by :meth:`arg`) or as two tokens ``['-D', 'KEY=secret']``; the latter
+        needs lookahead so the value token is redacted before it is persisted in
+        ``CompileUnit.argv``.
+        """
+        out: list[str] = []
+        i = 0
+        while i < len(args):
+            a = args[i]
+            if (
+                self.redact_secrets
+                and a in ("-D", "/D")
+                and i + 1 < len(args)
+                and "=" in args[i + 1]
+            ):
+                key, _, _ = args[i + 1].partition("=")
+                if _SECRET_DEFINE_RE.search(key):
+                    out.append(a)
+                    out.append(key + "=" + _REDACTED)
+                    i += 2
+                    continue
+            out.append(self.arg(a))
+            i += 1
+        return out
 
 
 #: Default policy used when an adapter is given no explicit policy.

--- a/abicheck/evidence/redaction.py
+++ b/abicheck/evidence/redaction.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Redaction of secrets and user-specific paths from build evidence (ADR-032 D7).
+
+Source/build command lines routinely embed absolute home paths, environment
+values, and occasionally secrets (tokens passed as ``-D``). Redaction is
+mandatory before any command line or path is persisted in an evidence pack
+(ADR-028 "Negative/risks"). This is a *minimal* policy for the ADR-029 MVP;
+ADR-032 specifies the full capability/redaction model.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+
+# Flags whose *value* is a likely secret (token/password). The value is
+# replaced wholesale; the flag itself is kept so option-drift detection still
+# sees that the option is present.
+_SECRET_DEFINE_RE = re.compile(
+    r"(?i)(TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|AUTH)",
+)
+
+_REDACTED = "<redacted>"
+
+
+@dataclass
+class RedactionPolicy:
+    """Replace home directories and obvious secrets in argv/paths.
+
+    ``home_replacements`` maps an absolute prefix to a stable placeholder so the
+    same logical tree redacts identically across machines (stable content hash).
+    """
+
+    redact_home: bool = True
+    redact_secrets: bool = True
+    home_replacements: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.redact_home and not self.home_replacements:
+            home = os.path.expanduser("~")
+            if home and home != "~":
+                self.home_replacements = {home: "~"}
+
+    def path(self, value: str) -> str:
+        """Redact a single path-like string."""
+        if not value:
+            return value
+        out = value
+        if self.redact_home:
+            for prefix, placeholder in self.home_replacements.items():
+                if prefix and out.startswith(prefix):
+                    out = placeholder + out[len(prefix):]
+        return out
+
+    def arg(self, value: str) -> str:
+        """Redact a single command-line argument."""
+        if not value:
+            return value
+        if self.redact_secrets and value.startswith(("-D", "/D")):
+            # -DKEY=VALUE / -DKEY — redact the value of secret-looking macros.
+            body = value[2:]
+            if "=" in body:
+                key, _, _ = body.partition("=")
+                if _SECRET_DEFINE_RE.search(key):
+                    return value[:2] + key + "=" + _REDACTED
+        return self.path(value)
+
+    def argv(self, args: list[str]) -> list[str]:
+        return [self.arg(a) for a in args]
+
+
+#: Default policy used when an adapter is given no explicit policy.
+DEFAULT_REDACTION = RedactionPolicy()

--- a/abicheck/evidence/redaction.py
+++ b/abicheck/evidence/redaction.py
@@ -78,6 +78,18 @@ class RedactionPolicy:
                     return value[:2] + key + "=" + _REDACTED
         return self.path(value)
 
+    def define_value(self, key: str, value: str) -> str:
+        """Redact a macro *value* stored under define name *key*.
+
+        Mirrors :meth:`arg` for the structured ``defines`` dict (adapters store
+        defines as ``{name: value}``, not ``-DNAME=value`` strings). A
+        secret-looking macro name redacts the whole value; otherwise home-path
+        prefixes in the value are still normalized.
+        """
+        if self.redact_secrets and value and _SECRET_DEFINE_RE.search(key):
+            return _REDACTED
+        return self.path(value)
+
     def argv(self, args: list[str]) -> list[str]:
         return [self.arg(a) for a in args]
 

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .elf_metadata import ElfMetadata
+    from .evidence.model import EvidencePackRef
     from .macho_metadata import MachoMetadata
     from .pe_metadata import PeMetadata
     from .sycl_metadata import SyclMetadata
@@ -561,6 +562,14 @@ class AbiSnapshot:
     # Keyword-only (placed after all other fields) to prevent accidental positional binding.
     # Used by binary-only fallback detectors that need lightweight disassembly.
     source_path: str | None = field(default=None, kw_only=True)
+
+    # ADR-028 (schema v7) — optional reference to an out-of-band EvidencePack
+    # carrying L3/L4/L5 source/build/graph evidence. Only a lightweight
+    # reference (content hash + coverage summary) lives in the snapshot; the
+    # heavyweight pack is content-addressed on disk and versions independently
+    # (EVIDENCE_PACK_VERSION). None when no evidence was collected. Old readers
+    # ignore this optional field (ADR-015 backward-compatibility).
+    evidence_pack: EvidencePackRef | None = field(default=None, kw_only=True)
 
     # Runtime-only provenance qualifier (not serialized — popped in
     # snapshot_to_dict). True when ``from_headers`` was *inferred* for a legacy

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -571,6 +571,14 @@ class AbiSnapshot:
     # ignore this optional field (ADR-015 backward-compatibility).
     evidence_pack: EvidencePackRef | None = field(default=None, kw_only=True)
 
+    # ADR-029 — True when this snapshot's public-header AST was parsed using the
+    # real build context (a compile_commands.json supplied to `dump -p`), so the
+    # declared API facts reflect the build's ABI-relevant flags. Lets the
+    # build-evidence diff suppress HEADER_PARSE_CONTEXT_DRIFT when the headers
+    # were in fact parsed with that context. Defaults False (older snapshots and
+    # context-free dumps); ignored by old readers (additive optional field).
+    parsed_with_build_context: bool = field(default=False, kw_only=True)
+
     # Runtime-only provenance qualifier (not serialized — popped in
     # snapshot_to_dict). True when ``from_headers`` was *inferred* for a legacy
     # snapshot that predates the explicit ``from_headers`` key, rather than set

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -746,6 +746,11 @@ def to_json(
         }
     # Release recommendation (semver bump + soname action) — additive, machine-facing.
     d["release_recommendation"] = recommend_release(result).to_dict()
+    # Evidence coverage (ADR-028 D7) — L0–L5 rows when an EvidencePack was
+    # supplied; lets consumers tell artifact-proven from build-context-only
+    # findings. Additive, present only when evidence was involved.
+    if getattr(result, "evidence_coverage", None):
+        d["evidence_coverage"] = result.evidence_coverage
     effective_policy = result.policy or "strict_abi"
     d["policy"] = effective_policy
     eff_sets = result._effective_kind_sets()

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -41,7 +41,8 @@ from typing import Any
 
 #: SemVer-style (MAJOR.MINOR) version of the compare-report JSON schema.
 #: 1.1 — added the optional ``release_recommendation`` object (additive).
-REPORT_SCHEMA_VERSION = "1.1"
+#: 1.2 — added the optional ``evidence_coverage`` array (ADR-028 D7; additive).
+REPORT_SCHEMA_VERSION = "1.2"
 
 _SCHEMA_DIR = Path(__file__).resolve().parent
 COMPARE_REPORT_SCHEMA_PATH = _SCHEMA_DIR / "compare_report.schema.json"

--- a/abicheck/schemas/build_evidence.schema.json
+++ b/abicheck/schemas/build_evidence.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://napetrov.github.io/abicheck/schemas/build_evidence.schema.json",
+  "title": "abicheck BuildEvidence (L3)",
+  "description": "Schema for build/build_evidence.json inside an EvidencePack: abicheck's build-system-neutral normalized L3 build context (ADR-029). External build-system formats (CMake File API, Ninja -t output, Bazel proto) are normalized into this model; they never become the stable public schema.",
+  "type": "object",
+  "required": ["schema_version"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {"type": "integer", "minimum": 1},
+    "source_root": {"type": "string"},
+    "build_root": {"type": "string"},
+    "generators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {"type": "string"},
+          "version": {"type": "string"},
+          "generator": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "toolchains": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {"type": "string"},
+          "compiler_id": {"type": "string"},
+          "version": {"type": "string"},
+          "language": {"type": "string"},
+          "target_triple": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "kind": {"type": "string", "enum": ["shared_library", "static_library", "object_library", "executable", "interface", "unknown"]},
+          "build_system": {"type": "string"},
+          "source_files": {"type": "array", "items": {"type": "string"}},
+          "public_headers": {"type": "array", "items": {"type": "string"}},
+          "private_headers": {"type": "array", "items": {"type": "string"}},
+          "outputs": {"type": "array", "items": {"type": "string"}},
+          "dependencies": {"type": "array", "items": {"type": "string"}},
+          "visibility": {"type": "string"},
+          "confidence": {"type": "string", "enum": ["high", "reduced", "unknown"]}
+        },
+        "additionalProperties": true
+      }
+    },
+    "compile_units": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {"type": "string"},
+          "source": {"type": "string"},
+          "output": {"type": "string"},
+          "target_id": {"type": "string"},
+          "language": {"type": "string"},
+          "standard": {"type": "string"},
+          "defines": {"type": "object", "additionalProperties": {"type": "string"}},
+          "include_paths": {"type": "array", "items": {"type": "string"}},
+          "abi_relevant_flags": {"type": "array", "items": {"type": "string"}}
+        },
+        "additionalProperties": true
+      }
+    },
+    "link_units": {"type": "array", "items": {"type": "object", "additionalProperties": true}},
+    "generated_files": {"type": "array", "items": {"type": "string"}},
+    "build_options": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key"],
+        "properties": {
+          "key": {"type": "string"},
+          "value": {"type": "string"},
+          "abi_relevant": {"type": "boolean"},
+          "scope": {"type": "string"},
+          "raw": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "diagnostics": {"type": "array", "items": {"type": "string"}},
+    "raw_artifacts": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -110,6 +110,21 @@
         "rationale": { "type": "string" }
       }
     },
+    "evidence_coverage": {
+      "type": "array",
+      "description": "Optional source/build evidence coverage (ADR-028 D7). One row per layer (L0 binary, L1 debug, L2 header AST, L3 build context, L4 source ABI, L5 source graph), present only when an EvidencePack was supplied to compare. Lets consumers distinguish artifact-proven from build-context-only findings.",
+      "items": {
+        "type": "object",
+        "required": ["layer", "status"],
+        "additionalProperties": true,
+        "properties": {
+          "layer": { "type": "string" },
+          "status": { "type": "string", "enum": ["present", "partial", "not_collected"] },
+          "confidence": { "type": "string", "enum": ["high", "reduced", "unknown"] },
+          "detail": { "type": "string" }
+        }
+      }
+    },
     "detectors": {
       "type": "array",
       "items": {

--- a/abicheck/schemas/evidence_pack.schema.json
+++ b/abicheck/schemas/evidence_pack.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://napetrov.github.io/abicheck/schemas/evidence_pack.schema.json",
+  "title": "abicheck EvidencePack manifest",
+  "description": "Schema for the manifest.json at the root of an EvidencePack directory produced by `abicheck collect-evidence` (ADR-028). The pack is content-addressed and versioned independently of the ABI snapshot schema via evidence_pack_version. The snapshot stores only a lightweight reference (see the evidence_pack property of an AbiSnapshot).",
+  "type": "object",
+  "required": ["evidence_pack_version"],
+  "additionalProperties": true,
+  "properties": {
+    "evidence_pack_version": {
+      "type": "integer",
+      "description": "Schema version of the pack manifest/layout. Independent of the ABI snapshot schema_version.",
+      "minimum": 1
+    },
+    "abicheck_version": {"type": "string"},
+    "created_at": {"type": "string", "description": "ISO 8601 timestamp; excluded from the content hash."},
+    "source_root": {
+      "type": "object",
+      "description": "Redaction-aware source-root descriptor (ADR-032 D7): the real path is never stored.",
+      "properties": {
+        "path_redacted": {"type": "boolean"},
+        "repo_hash": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "inputs": {"type": "object", "additionalProperties": true},
+    "extractors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {"type": "string"},
+          "version": {"type": "string"},
+          "status": {"type": "string", "enum": ["ok", "partial", "failed", "skipped"]},
+          "inputs": {"type": "array", "items": {"type": "string"}},
+          "artifacts": {"type": "array", "items": {"type": "string"}},
+          "detail": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "description": "Content-addressed sha256 digests of the normalized payload files.",
+      "items": {"type": "string"}
+    },
+    "coverage": {
+      "type": "array",
+      "description": "Evidence-coverage rows for the optional layers (ADR-028 D7).",
+      "items": {
+        "type": "object",
+        "required": ["layer", "status"],
+        "properties": {
+          "layer": {"type": "string", "description": "Layer key, e.g. L3_build, L4_source_abi, L5_source_graph."},
+          "status": {"type": "string", "enum": ["present", "partial", "not_collected"]},
+          "confidence": {"type": "string", "enum": ["high", "reduced", "unknown"]},
+          "detail": {"type": "string"}
+        },
+        "additionalProperties": true
+      }
+    },
+    "redaction": {"type": "object", "additionalProperties": true}
+  }
+}

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -48,7 +48,8 @@ from .model import (
 # v4: provenance metadata (git_commit, git_tag, created_at, build_id)
 # v5: build_mode capture (compiler/stdlib/std normalization)
 # v6: declaration provenance (source_header + origin on functions/variables/types/enums; ADR-015)
-SCHEMA_VERSION: int = 6
+# v7: optional evidence_pack reference (ADR-028; lightweight ref to an out-of-band EvidencePack)
+SCHEMA_VERSION: int = 7
 
 
 def _sets_to_lists(obj: Any) -> Any:
@@ -486,6 +487,15 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     # leave as None so build-mode-aware detectors fall back to "unknown".
     build_mode = _build_mode_from_dict(d.get("build_mode"))
 
+    # Evidence-pack reference (schema v7, ADR-028). Optional: a missing key on
+    # an older snapshot loads as None. A malformed (non-dict) value is ignored
+    # rather than aborting the load, consistent with the rest of this loader.
+    ep_raw = d.get("evidence_pack")
+    evidence_pack = None
+    if isinstance(ep_raw, dict):
+        from .evidence.model import EvidencePackRef
+        evidence_pack = EvidencePackRef.from_dict(ep_raw)
+
     # from_headers provenance (added alongside the HEADER_AWARE tier-honesty
     # fix). An absent key means a legacy snapshot dumped before the field
     # existed: preserve the prior evidence-tier behavior by inferring header
@@ -529,6 +539,8 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         build_id=d.get("build_id"),
         # Build-mode capture (v5)
         build_mode=build_mode,
+        # Evidence-pack reference (v7)
+        evidence_pack=evidence_pack,
     )
 
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -541,6 +541,9 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
         build_mode=build_mode,
         # Evidence-pack reference (v7)
         evidence_pack=evidence_pack,
+        # Build-context parse provenance (v7, ADR-029) — absent on older
+        # snapshots loads as False.
+        parsed_with_build_context=bool(d.get("parsed_with_build_context", False)),
     )
 
 

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -1,0 +1,119 @@
+# Source & Build Evidence Packs
+
+abicheck primarily compares **built artifacts** — binaries (L0), debug info
+(L1), and public headers (L2). An **EvidencePack** is an *optional* sidecar
+that augments a snapshot with **source and build evidence** (ADR-028): build
+context (L3), and — in later releases — source ABI replay (L4) and source
+graph summaries (L5).
+
+The pack exists to give the existing ABI/API decision engine **more facts** —
+to reduce false positives, explain and localize breaks, and detect
+source/API risks artifact comparison cannot see. It does **not** turn abicheck
+into a general static analyzer.
+
+## The authority rule (the one rule that matters)
+
+> **Artifact-backed L0/L1/L2 evidence remains authoritative for shipped-ABI
+> verdicts.** Source/build evidence (L3/L4/L5) may *explain, localize, scope,
+> add confidence/provenance, or correlate* an artifact-proven break — but it
+> **never silently deletes** one.
+
+Findings produced *only* by build/source evidence are ordinary
+[change kinds](../reference/change-kinds.md) that default to **`API_BREAK`**
+(source-level breaks) or **risk** (deployment/context risk), never **breaking**
+unless an artifact diff also proves the break. They flow through the normal
+[verdict](verdicts.md) computation with worst-verdict-wins.
+
+## Evidence layers
+
+| Layer | Source | Purpose | Verdict authority |
+|---|---|---|---|
+| L0 | ELF/PE/Mach-O | Exported binary ABI facts | Authoritative |
+| L1 | DWARF/PDB/BTF/CTF | Layout/type/calling-convention | Authoritative when matched to binary |
+| L2 | castxml/public headers | Public API declarations | Authoritative for header-visible API |
+| **L3** | compile DB, CMake, Ninja, Bazel, Make | Toolchain, flags, target graph, generated-file provenance | Context/confidence |
+| **L4** | per-TU source ABI replay | Source-visible ABI/API facts | API/source-risk evidence; never sole shipped-ABI authority |
+| **L5** | Clang/Kythe/CodeQL graph summaries | Include/type/call/build reasoning | Explanation, localization, impact |
+
+L3 is implemented today (ADR-029); L4/L5 are planned (ADR-030/031).
+
+## Workflow
+
+The default path is unchanged. Evidence is **post-build and opt-in** — it never
+rebuilds your project or runs arbitrary commands; it reads existing build
+outputs and build-system query interfaces only.
+
+```bash
+# 1. Collect an evidence pack from an existing build tree (no rebuild).
+abicheck collect-evidence \
+  --compile-db build/compile_commands.json \
+  --build-dir build --cmake \
+  --output libfoo.evidence/
+
+# 2a. Attach it to a snapshot (stores a lightweight content-addressed ref).
+abicheck dump build/libfoo.so -H include/ \
+  --evidence libfoo.evidence/ -o libfoo.abi.json
+
+# 2b. Or compare two snapshots together with their packs.
+abicheck compare old.abi.json new.abi.json \
+  --old-evidence old.evidence/ --new-evidence new.evidence/
+```
+
+`collect-evidence` accepts:
+
+- `--compile-db PATH` / `-p DIR` — a `compile_commands.json` (the universal,
+  low-friction input).
+- `--build-dir DIR --cmake` — the CMake File API *reply* directory (target
+  graph, public/private header file sets, toolchains).
+- `--build-dir DIR --ninja` / `--ninja-compdb FILE` — Ninja `-t compdb`/`graph`
+  output (live query or pre-captured for hermetic CI).
+
+## Build-evidence findings (L3)
+
+When two packs are compared, abicheck diffs their normalized build evidence and
+emits these change kinds (ADR-029 D9):
+
+| Kind | Category | Meaning |
+|---|---|---|
+| `build_context_changed` | compatible (quality) | Non-ABI build metadata changed |
+| `abi_relevant_build_flag_changed` | risk | An ABI-affecting flag changed (`-std`, `_GLIBCXX_USE_CXX11_ABI`, `-fvisibility`, `-fpack-struct`, `-fabi-version`, …) |
+| `header_parse_context_drift` | risk | Headers were parsed under a different context than the real build |
+| `toolchain_version_changed` | risk | Compiler/stdlib/sysroot changed |
+| `generated_file_dependency_unstable` | risk | Build graph indicates generated-file dependency risk |
+| `link_export_policy_changed` | risk | Version script / export map / `.def` file changed |
+
+None of these escalate to *breaking* on their own. When an export-policy change
+actually removes exported symbols, the artifact diff (L0) emits the breaking
+`symbol_removed` finding separately; `link_export_policy_changed` explains and
+localizes it.
+
+## Evidence coverage
+
+Every compare run that involves a pack prints an **evidence-coverage table** so
+you can tell which findings are artifact-proven vs. build-context-only:
+
+```text
+Evidence coverage:
+  L0 binary metadata         present, high confidence
+  L1 debug info              present, high confidence: DWARF
+  L2 public header AST       present, high confidence: header-scoped
+  L3 build context           present, high confidence: cmake+ninja, 142 compile units, 1 target
+  L4 source ABI replay       not_collected
+  L5 source graph summary    not_collected
+```
+
+## Schema & storage
+
+- The pack is **content-addressed** and **versioned independently**
+  (`evidence_pack_version`) from the ABI snapshot schema, so it never bloats an
+  ordinary dump. The snapshot stores only a lightweight `evidence_pack`
+  reference (content hash + coverage summary); old readers ignore it.
+- Every extractor writes both a **raw** artifact (under `raw/`, for
+  provenance/debugging) and an abicheck-owned **normalized** fact model (e.g.
+  `build/build_evidence.json`). Only normalized facts feed comparison and the
+  content hash.
+- Command lines and paths are **redacted** (home prefixes, secret-looking
+  `-D` macros) before they are persisted.
+
+See ADR-028 (umbrella) and ADR-029 (build context) under
+[Development → ADRs](../development/adr/index.md) for the full design.

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -102,6 +102,18 @@ Evidence coverage:
   L5 source graph summary    not_collected
 ```
 
+The same rows are emitted as a structured `evidence_coverage` array in the
+`--format json` report (schema `report_schema_version` 1.2+), so machine
+consumers can key off layer status and confidence.
+
+### Header parse context
+
+`header_parse_context_drift` fires when the new side carries a public-header AST
+that was **not** parsed with the build's ABI-relevant flags. To avoid this,
+dump the snapshot with the build's compile database — `abicheck dump … -p build/`
+records `parsed_with_build_context` on the snapshot, and a later `compare`
+honors it and suppresses the drift finding.
+
 ## Schema & storage
 
 - The pack is **content-addressed** and **versioned independently**

--- a/docs/development/adr/028-source-build-evidence-pack.md
+++ b/docs/development/adr/028-source-build-evidence-pack.md
@@ -1,7 +1,8 @@
 # ADR-028: Optional Source and Build Evidence Pack Architecture
 
 **Date:** 2026-06-09
-**Status:** Proposed
+**Status:** Accepted — Phase 0 implemented (EvidencePack model, manifest,
+coverage, snapshot reference, CLI surface, coverage reporting)
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/029-build-graph-toolchain-context-capture.md
+++ b/docs/development/adr/029-build-graph-toolchain-context-capture.md
@@ -1,7 +1,9 @@
 # ADR-029: Build Graph and Toolchain Context Capture
 
 **Date:** 2026-06-09
-**Status:** Proposed
+**Status:** Accepted — MVP implemented (BuildEvidence model; compile DB,
+CMake File API, and Ninja adapters; build-evidence diff and the six D9
+change kinds)
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 ## Why abicheck
 
 - **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
-- **200 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
+- **206 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.
 - **ABICC drop-in** — full flag parity for migrating from `abi-compliance-checker`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - Architecture: concepts/architecture.md
     - Limitations: concepts/limitations.md
     - Evidence & Detectability: concepts/evidence-and-detectability.md
+    - Source & Build Evidence Packs: concepts/evidence-pack.md
     - Change Kinds: reference/change-kinds.md
     - API Surface Intelligence: concepts/api-surface-intelligence.md
     - Exit Codes: reference/exit-codes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ module = [
     "abicheck.cli_compare_release",
     "abicheck.cli_debian_symbols",
     "abicheck.cli_baseline",
+    "abicheck.cli_evidence",
     "abicheck.cli_plugin",
     "abicheck.cli_probe",
     "abicheck.cli_stack",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -528,6 +528,7 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         frozenset({"cli", "cli_compare_release"}),
         frozenset({"cli", "cli_baseline"}),
         frozenset({"cli", "cli_debian_symbols"}),
+        frozenset({"cli", "cli_evidence"}),
         frozenset({"cli", "cli_appcompat"}),
         frozenset({"cli", "cli_plugin"}),
         frozenset({"cli", "cli_probe"}),

--- a/tests/test_baseline_pinning.py
+++ b/tests/test_baseline_pinning.py
@@ -26,8 +26,8 @@ def _sample_snap(**kwargs) -> AbiSnapshot:
 # ---------------------------------------------------------------------------
 
 class TestSchemaV4:
-    def test_schema_version_is_6(self):
-        assert SCHEMA_VERSION == 6
+    def test_schema_version_is_7(self):
+        assert SCHEMA_VERSION == 7
 
     def test_provenance_fields_roundtrip(self):
         snap = _sample_snap(

--- a/tests/test_changekind_completeness.py
+++ b/tests/test_changekind_completeness.py
@@ -30,8 +30,10 @@ from abicheck.model import (
 # corresponding scenario) must be updated – the meta-test below will fail
 # until that happens.
 ASSERTED_CHANGE_KINDS: set[ChangeKind] = {
+    ChangeKind.ABI_RELEVANT_BUILD_FLAG_CHANGED,
     ChangeKind.ANON_FIELD_CHANGED,
     ChangeKind.BASE_CLASS_POSITION_CHANGED,
+    ChangeKind.BUILD_CONTEXT_CHANGED,
     ChangeKind.BASE_CLASS_VIRTUAL_CHANGED,
     ChangeKind.CALLING_CONVENTION_CHANGED,
     ChangeKind.COMMON_SYMBOL_RISK,
@@ -69,8 +71,11 @@ ASSERTED_CHANGE_KINDS: set[ChangeKind] = {
     ChangeKind.FUNC_VIRTUAL_BECAME_PURE,
     ChangeKind.FUNC_VIRTUAL_REMOVED,
     ChangeKind.FUNC_VISIBILITY_CHANGED,
+    ChangeKind.GENERATED_FILE_DEPENDENCY_UNSTABLE,
+    ChangeKind.HEADER_PARSE_CONTEXT_DRIFT,
     ChangeKind.IFUNC_INTRODUCED,
     ChangeKind.IFUNC_REMOVED,
+    ChangeKind.LINK_EXPORT_POLICY_CHANGED,
     ChangeKind.METHOD_ACCESS_CHANGED,
     ChangeKind.NEEDED_ADDED,
     ChangeKind.NEEDED_REMOVED,
@@ -112,6 +117,7 @@ ASSERTED_CHANGE_KINDS: set[ChangeKind] = {
     ChangeKind.VECTOR_ABI_CHANGED,
     ChangeKind.TYPEDEF_BASE_CHANGED,
     ChangeKind.TYPEDEF_REMOVED,
+    ChangeKind.TOOLCHAIN_VERSION_CHANGED,
     ChangeKind.TYPE_ADDED,
     ChangeKind.TYPE_ALIGNMENT_CHANGED,
     ChangeKind.TYPE_BASE_CHANGED,

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -52,6 +52,30 @@ def test_collect_evidence_creates_pack(tmp_path):
     assert cov is not None and cov.status.value == "present"
 
 
+def test_collect_evidence_redacts_manifest_paths(tmp_path, monkeypatch):
+    """Codex: provenance paths in manifest.json are home-redacted before write."""
+    # Pretend tmp_path is under the user's home so redaction rewrites it.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from abicheck.evidence.redaction import RedactionPolicy
+    monkeypatch.setattr(
+        "abicheck.cli_evidence.DEFAULT_REDACTION",
+        RedactionPolicy(home_replacements={str(tmp_path): "~"}),
+    )
+    cdb = _write_cdb(tmp_path, "c++20")
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--compile-db", str(cdb), "--binary", str(tmp_path / "libfoo.so"),
+        "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    manifest = json.loads((out / "manifest.json").read_text())
+    # No absolute tmp_path leaks into the manifest provenance.
+    blob = json.dumps(manifest)
+    assert str(tmp_path) not in blob
+    assert manifest["inputs"]["binary"].startswith("~")
+    assert any(e["inputs"] and e["inputs"][0].startswith("~") for e in manifest["extractors"])
+
+
 def test_collect_evidence_requires_output(tmp_path):
     cdb = _write_cdb(tmp_path, "c++20")
     result = CliRunner().invoke(main, ["collect-evidence", "--compile-db", str(cdb)])
@@ -133,6 +157,36 @@ def test_compare_with_evidence_emits_coverage_and_findings(tmp_path):
     assert "L3 build context" in result.stderr
     # The -std drift surfaces as an ABI-relevant build-flag finding (RISK).
     assert "COMPATIBLE_WITH_RISK" in result.stdout or "Deployment Risk" in result.stdout
+
+
+def test_compare_json_carries_evidence_coverage_block(tmp_path):
+    """ADR-028 D7: the JSON report carries a structured evidence_coverage block."""
+    cdb = _write_cdb(tmp_path, "c++20")
+    ev_new = tmp_path / "new.evidence"
+    runner = CliRunner()
+    runner.invoke(main, ["collect-evidence", "--compile-db", str(cdb), "-o", str(ev_new)])
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+
+    result = runner.invoke(main, [
+        "compare", str(old_snap), str(new_snap), "--new-evidence", str(ev_new),
+        "--format", "json",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    payload = json.loads(result.stdout)
+    assert payload["report_schema_version"] == "1.2"
+    cov = {row["layer"]: row for row in payload["evidence_coverage"]}
+    assert set(cov) >= {"L0", "L1", "L2", "L3_build", "L4_source_abi", "L5_source_graph"}
+    assert cov["L3_build"]["status"] == "present"
+
+
+def test_compare_json_without_evidence_omits_coverage(tmp_path):
+    """No evidence → no evidence_coverage key (additive, opt-in)."""
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+    result = CliRunner().invoke(main, ["compare", str(old_snap), str(new_snap), "--format", "json"])
+    assert result.exit_code == 0, result.output
+    assert "evidence_coverage" not in json.loads(result.stdout)
 
 
 def test_compare_evidence_mode_without_packs_is_noted(tmp_path):

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI tests for `collect-evidence`, `dump --evidence`, and
+`compare --old/--new-evidence` (ADR-028 D6 / ADR-029)."""
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.evidence.pack import EvidencePack
+from abicheck.model import AbiSnapshot
+from abicheck.serialization import load_snapshot, save_snapshot
+
+
+def _write_cdb(tmp_path, std):
+    cdb = [{
+        "directory": str(tmp_path),
+        "file": "src/foo.cpp",
+        "arguments": ["c++", f"-std={std}", "-Iinclude", "-c", "src/foo.cpp"],
+    }]
+    p = tmp_path / f"cc_{std}.json"
+    p.write_text(json.dumps(cdb))
+    return p
+
+
+def test_collect_evidence_creates_pack(tmp_path):
+    cdb = _write_cdb(tmp_path, "c++20")
+    out = tmp_path / "libfoo.evidence"
+    result = CliRunner().invoke(
+        main, ["collect-evidence", "--compile-db", str(cdb), "-o", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Evidence pack written" in result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is not None
+    assert len(pack.build_evidence.compile_units) == 1
+    cov = pack.manifest.coverage_for("L3_build")
+    assert cov is not None and cov.status.value == "present"
+
+
+def test_collect_evidence_requires_output(tmp_path):
+    cdb = _write_cdb(tmp_path, "c++20")
+    result = CliRunner().invoke(main, ["collect-evidence", "--compile-db", str(cdb)])
+    assert result.exit_code != 0
+    assert "output" in result.output.lower() or "missing" in result.output.lower()
+
+
+def test_collect_evidence_cmake_requires_build_dir(tmp_path):
+    result = CliRunner().invoke(
+        main, ["collect-evidence", "--cmake", "-o", str(tmp_path / "e")],
+    )
+    assert result.exit_code != 0
+    assert "build-dir" in result.output
+
+
+def test_dump_attach_evidence_ref(tmp_path):
+    # Build an evidence pack first.
+    cdb = _write_cdb(tmp_path, "c++20")
+    ev_dir = tmp_path / "e"
+    CliRunner().invoke(main, ["collect-evidence", "--compile-db", str(cdb), "-o", str(ev_dir)])
+
+    # Attach it to an existing snapshot via dump on a JSON snapshot is not
+    # supported (dump takes a binary), so attach directly through the helper
+    # path exercised by `dump --evidence`: load pack and to_ref.
+    pack = EvidencePack.load(ev_dir)
+    snap = AbiSnapshot(library="libfoo.so", version="1.0")
+    snap.evidence_pack = pack.to_ref(path_hint=str(ev_dir))
+    out = tmp_path / "snap.json"
+    save_snapshot(snap, out)
+
+    reloaded = load_snapshot(out)
+    assert reloaded.evidence_pack is not None
+    assert reloaded.evidence_pack.content_hash == pack.content_hash()
+
+
+def test_dump_invalid_evidence_dir_errors(tmp_path):
+    # A directory with no manifest is not a valid pack.
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    snap = AbiSnapshot(library="l", version="1")
+    save_snapshot(snap, tmp_path / "s.json")
+    # Exercise the attach helper directly (dump needs a real binary).
+    import click
+    import pytest
+
+    from abicheck.cli_evidence import attach_evidence_pack
+
+    with pytest.raises(click.ClickException):
+        attach_evidence_pack(snap, bad)
+
+
+def _make_snap(tmp_path, name, version):
+    snap = AbiSnapshot(library="libfoo.so", version=version, from_headers=True)
+    p = tmp_path / name
+    save_snapshot(snap, p)
+    return p
+
+
+def test_compare_with_evidence_emits_coverage_and_findings(tmp_path):
+    old_cdb = _write_cdb(tmp_path, "c++17")
+    new_cdb = _write_cdb(tmp_path, "c++20")
+    ev_old = tmp_path / "old.evidence"
+    ev_new = tmp_path / "new.evidence"
+    runner = CliRunner()
+    runner.invoke(main, ["collect-evidence", "--compile-db", str(old_cdb), "-o", str(ev_old)])
+    runner.invoke(main, ["collect-evidence", "--compile-db", str(new_cdb), "-o", str(ev_new)])
+
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+
+    result = runner.invoke(main, [
+        "compare", str(old_snap), str(new_snap),
+        "--old-evidence", str(ev_old), "--new-evidence", str(ev_new),
+        "--format", "markdown",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    # D7 coverage table is emitted to stderr.
+    assert "Evidence coverage:" in result.stderr
+    assert "L3 build context" in result.stderr
+    # The -std drift surfaces as an ABI-relevant build-flag finding (RISK).
+    assert "COMPATIBLE_WITH_RISK" in result.stdout or "Deployment Risk" in result.stdout
+
+
+def test_compare_evidence_mode_without_packs_is_noted(tmp_path):
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+    result = CliRunner().invoke(main, [
+        "compare", str(old_snap), str(new_snap), "--evidence-mode", "build",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    assert "evidence-mode build" in result.stderr
+
+
+def test_compare_without_evidence_is_unchanged(tmp_path):
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+    result = CliRunner().invoke(main, ["compare", str(old_snap), str(new_snap)])
+    assert result.exit_code == 0, result.output
+    assert "Evidence coverage:" not in result.stderr

--- a/tests/test_evidence_coverage.py
+++ b/tests/test_evidence_coverage.py
@@ -1,0 +1,360 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Round-trip, edge-case, and adapter-path coverage for the EvidencePack
+modules (ADR-028 / ADR-029). Complements test_evidence_pack.py and
+test_evidence_cli.py."""
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from abicheck.checker_policy import ChangeKind
+from abicheck.cli import main
+from abicheck.evidence.adapters import CMakeFileApiAdapter, NinjaAdapter
+from abicheck.evidence.adapters.base import derive_build_options
+from abicheck.evidence.build_diff import diff_build_evidence
+from abicheck.evidence.build_evidence import (
+    BuildEvidence,
+    BuildOption,
+    CompileUnit,
+    Confidence,
+    Generator,
+    LinkUnit,
+    Target,
+    TargetKind,
+    Toolchain,
+)
+from abicheck.evidence.model import (
+    CoverageStatus,
+    EvidenceConfidence,
+    EvidenceEntity,
+    EvidenceLayer,
+    EvidencePackManifest,
+    ExtractorRecord,
+    LayerCoverage,
+)
+from abicheck.evidence.pack import EvidencePack
+
+# ── BuildEvidence model round-trips (ADR-029 D1/D2) ──────────────────────────
+
+
+def test_build_evidence_full_roundtrip():
+    ev = BuildEvidence(
+        source_root="repo://root",
+        build_root="build://root",
+        generators=[Generator(kind="cmake", version="3.28", generator="Ninja")],
+        toolchains=[Toolchain(id="t", compiler_id="GNU", version="14", language="CXX",
+                              implicit_include_dirs=["/usr/include"], target_triple="x86_64-linux-gnu")],
+        targets=[Target(id="target://foo", name="foo", kind=TargetKind.SHARED_LIBRARY,
+                        build_system="cmake", source_files=["a.cpp"], public_headers=["a.h"],
+                        outputs=["libfoo.so"], dependencies=["target://bar"],
+                        visibility="public", confidence=Confidence.HIGH)],
+        compile_units=[CompileUnit(id="cu://a", source="a.cpp", language="CXX", standard="c++20",
+                                   defines={"FOO": "1"}, include_paths=["inc"],
+                                   abi_relevant_flags=["-std=c++20"])],
+        link_units=[LinkUnit(id="link://foo", target_id="target://foo", output="libfoo.so",
+                             version_script="exports.map", soname="libfoo.so.1")],
+        generated_files=["gen.h"],
+        build_options=[BuildOption(key="std:CXX", value="c++20", abi_relevant=True, raw="-std=c++20")],
+        diagnostics=["note"],
+        raw_artifacts=["raw/x"],
+    )
+    ev2 = BuildEvidence.from_dict(json.loads(json.dumps(ev.to_dict())))
+    assert ev2.to_dict() == ev.to_dict()
+    assert ev2.targets[0].kind is TargetKind.SHARED_LIBRARY
+    assert ev2.toolchains[0].implicit_include_dirs == ["/usr/include"]
+    assert ev2.link_units[0].soname == "libfoo.so.1"
+
+
+def test_target_kind_and_confidence_unknown_fallback():
+    t = Target.from_dict({"id": "x", "kind": "bogus", "confidence": "weird"})
+    assert t.kind is TargetKind.UNKNOWN
+    assert t.confidence is Confidence.UNKNOWN
+
+
+def test_build_evidence_merge_combines_options_and_dedups_generated():
+    a = BuildEvidence(generated_files=["g1"], build_options=[BuildOption("std:C", "c11")])
+    b = BuildEvidence(generated_files=["g1", "g2"], build_options=[BuildOption("std:CXX", "c++20")])
+    a.merge(b)
+    assert a.generated_files == ["g1", "g2"]
+    assert {o.key for o in a.build_options} == {"std:C", "std:CXX"}
+
+
+def test_derive_build_options_dedups_across_units():
+    units = [
+        CompileUnit(id="1", language="CXX", standard="c++20", abi_relevant_flags=["-fvisibility=hidden"]),
+        CompileUnit(id="2", language="CXX", standard="c++20", abi_relevant_flags=["-fvisibility=hidden"]),
+        CompileUnit(id="3", language="CXX", standard="c++20", target_triple="x86_64-linux-gnu",
+                    sysroot="/sdk"),
+    ]
+    opts = derive_build_options(units)
+    keys = {o.key for o in opts}
+    assert keys == {"std:CXX", "sysroot", "target", "-fvisibility"}
+    # -fvisibility=hidden appeared in two units but records once.
+    assert sum(o.key == "-fvisibility" for o in opts) == 1
+
+
+# ── model.py round-trips & fallbacks (ADR-028 D5/D7) ─────────────────────────
+
+
+def test_evidence_entity_roundtrip():
+    e = EvidenceEntity(
+        entity_id="sha256:1", kind="function",
+        names={"mangled": "_Z3foov"}, locations=[{"path": "a.h", "line": 1}],
+        binary_refs=["elf:symbol:_Z3foov"], build_refs=["target://foo"],
+        confidence=EvidenceConfidence.HIGH,
+    )
+    e2 = EvidenceEntity.from_dict(e.to_dict())
+    assert e2.to_dict() == e.to_dict()
+
+
+def test_extractor_record_roundtrip():
+    r = ExtractorRecord(name="ninja", version="1.12", status="partial",
+                        inputs=["build/"], artifacts=["raw/x"], detail="fallback")
+    assert ExtractorRecord.from_dict(r.to_dict()).to_dict() == r.to_dict()
+
+
+def test_layer_coverage_present_and_roundtrip():
+    c = LayerCoverage(layer="L3_build", status=CoverageStatus.PARTIAL,
+                      confidence=EvidenceConfidence.REDUCED, detail="changed only")
+    assert c.present is True
+    c2 = LayerCoverage.from_dict(c.to_dict())
+    assert c2.status is CoverageStatus.PARTIAL and c2.present
+
+
+def test_layer_coverage_invalid_enums_fall_back():
+    c = LayerCoverage.from_dict({"layer": "L3_build", "status": "bogus", "confidence": "weird"})
+    assert c.status is CoverageStatus.NOT_COLLECTED
+    assert c.confidence is EvidenceConfidence.UNKNOWN
+    assert c.present is False
+
+
+def test_manifest_coverage_for_lookup():
+    m = EvidencePackManifest(coverage=[LayerCoverage(layer="L3_build", status=CoverageStatus.PRESENT)])
+    assert m.coverage_for(EvidenceLayer.L3_BUILD) is not None
+    assert m.coverage_for(EvidenceLayer.L4_SOURCE_ABI) is None
+    assert m.coverage_for("L3_build") is not None
+
+
+# ── pack.py with build evidence ──────────────────────────────────────────────
+
+
+def test_pack_load_with_build_evidence(tmp_path):
+    pack = EvidencePack.empty(tmp_path / "p")
+    pack.build_evidence = BuildEvidence(
+        compile_units=[CompileUnit(id="cu://a", source="a.cpp", language="CXX", standard="c++20")],
+        build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)],
+    )
+    pack.write()
+    loaded = EvidencePack.load(tmp_path / "p")
+    assert loaded.build_evidence is not None
+    assert loaded.build_evidence.compile_units[0].standard == "c++20"
+    # The build evidence contributes an artifact digest to the content hash.
+    assert loaded.manifest.artifacts
+    assert loaded.content_hash().startswith("sha256:")
+
+
+def test_pack_to_ref_coverage_summary(tmp_path):
+    pack = EvidencePack.empty(tmp_path / "p")
+    pack.manifest.coverage = [LayerCoverage(layer="L3_build", status=CoverageStatus.PRESENT,
+                                            confidence=EvidenceConfidence.HIGH)]
+    pack.write()
+    ref = pack.to_ref()
+    assert ref.coverage_summary["L3_build"]["status"] == "present"
+
+
+# ── CMake adapter additional paths (ADR-029 D4) ──────────────────────────────
+
+
+def test_cmake_no_index(tmp_path):
+    reply = tmp_path / "build" / ".cmake" / "api" / "v1" / "reply"
+    reply.mkdir(parents=True)
+    ev = CMakeFileApiAdapter(tmp_path / "build").collect()
+    assert any("no index" in d for d in ev.diagnostics)
+
+
+def test_cmake_header_extension_fallback_without_filesets(tmp_path):
+    reply = tmp_path / "build" / ".cmake" / "api" / "v1" / "reply"
+    reply.mkdir(parents=True)
+    (reply / "codemodel-v2-x.json").write_text(json.dumps({
+        "configurations": [{"targets": [{"jsonFile": "t.json"}]}],
+    }))
+    (reply / "t.json").write_text(json.dumps({
+        "name": "foo", "type": "STATIC_LIBRARY",
+        "sources": [{"path": "a.cpp"}, {"path": "a.h"}],
+    }))
+    (reply / "index-x.json").write_text(json.dumps({
+        "cmake": {"version": {"string": "3.28"}},
+        "objects": [{"kind": "codemodel", "jsonFile": "codemodel-v2-x.json"}],
+    }))
+    ev = CMakeFileApiAdapter(tmp_path / "build").collect()
+    t = ev.targets[0]
+    assert t.kind is TargetKind.STATIC_LIBRARY
+    assert t.private_headers == ["a.h"]  # extension heuristic
+    assert t.source_files == ["a.cpp"]
+    assert t.visibility == "private"
+
+
+# ── Ninja adapter additional paths (ADR-029 D5) ──────────────────────────────
+
+
+def test_ninja_command_string_and_bad_entries(tmp_path):
+    compdb = json.dumps([
+        {"directory": str(tmp_path), "file": "a.cpp", "command": "c++ -std=c++17 -c a.cpp"},
+        "not-a-dict",
+        {"directory": str(tmp_path)},  # no file
+    ])
+    ev = NinjaAdapter(compdb=compdb).collect()
+    assert len(ev.compile_units) == 1
+    assert ev.compile_units[0].standard == "c++17"
+
+
+def test_ninja_malformed_json_diagnostic():
+    ev = NinjaAdapter(compdb="{not json").collect()
+    assert any("could not parse" in d for d in ev.diagnostics)
+
+
+def test_ninja_non_array_diagnostic():
+    ev = NinjaAdapter(compdb='{"a": 1}').collect()
+    assert any("not a JSON array" in d for d in ev.diagnostics)
+
+
+def test_ninja_precaptured_graph_diagnostic(tmp_path):
+    compdb = json.dumps([{"directory": str(tmp_path), "file": "a.cpp",
+                          "arguments": ["c++", "-c", "a.cpp"]}])
+    ev = NinjaAdapter(compdb=compdb, graph="digraph { a -> b }").collect()
+    assert any("dependency graph captured" in d for d in ev.diagnostics)
+
+
+def test_ninja_live_query_disabled_diagnostic(tmp_path):
+    ev = NinjaAdapter(build_dir=tmp_path, allow_query=False).collect()
+    assert any("live query disabled" in d for d in ev.diagnostics)
+
+
+def test_ninja_executable_missing_diagnostic(tmp_path, monkeypatch):
+    monkeypatch.setattr("abicheck.evidence.adapters.ninja.shutil.which", lambda _x: None)
+    ev = NinjaAdapter(build_dir=tmp_path, allow_query=True).collect()
+    assert any("executable not found" in d for d in ev.diagnostics)
+
+
+def test_ninja_query_invokes_subprocess(tmp_path, monkeypatch):
+    """Drive the live-query path with a stubbed ninja that returns a compdb."""
+    import subprocess as _sp
+
+    compdb = json.dumps([{"directory": str(tmp_path), "file": "a.cpp",
+                          "arguments": ["c++", "-std=c++20", "-c", "a.cpp"]}])
+
+    def fake_run(cmd, **kwargs):
+        out = compdb if "compdb" in cmd else "digraph {}"
+        return _sp.CompletedProcess(cmd, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.ninja.shutil.which", lambda _x: "/usr/bin/ninja")
+    monkeypatch.setattr("abicheck.evidence.adapters.ninja.subprocess.run", fake_run)
+    ev = NinjaAdapter(build_dir=tmp_path).collect()
+    assert len(ev.compile_units) == 1
+    assert any(o.key == "std:CXX" for o in ev.build_options)
+
+
+def test_ninja_query_nonzero_exit_diagnostic(tmp_path, monkeypatch):
+    import subprocess as _sp
+
+    def fake_run(cmd, **kwargs):
+        return _sp.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.ninja.shutil.which", lambda _x: "/usr/bin/ninja")
+    monkeypatch.setattr("abicheck.evidence.adapters.ninja.subprocess.run", fake_run)
+    ev = NinjaAdapter(build_dir=tmp_path).collect()
+    assert any("exited 1" in d for d in ev.diagnostics)
+
+
+# ── build_diff additional branches (ADR-029 D9) ──────────────────────────────
+
+
+def test_diff_option_added_and_removed():
+    old = BuildEvidence(build_options=[BuildOption("warn", "on")])
+    new = BuildEvidence(build_options=[BuildOption("opt", "fast")])
+    kinds = {c.kind for c in diff_build_evidence(old, new)}
+    # 'warn' removed and 'opt' added — both non-abi → build_context_changed.
+    assert ChangeKind.BUILD_CONTEXT_CHANGED in kinds
+
+
+def test_diff_no_change_when_equal():
+    ev = BuildEvidence(build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)])
+    import copy
+    assert diff_build_evidence(ev, copy.deepcopy(ev)) == []
+
+
+# ── collect-evidence CLI variants (ADR-028 D6) ───────────────────────────────
+
+
+def test_collect_evidence_empty_pack_when_no_adapters(tmp_path):
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, ["collect-evidence", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "not collected" in result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is None
+    cov = pack.manifest.coverage_for("L3_build")
+    assert cov is not None and cov.status is CoverageStatus.NOT_COLLECTED
+
+
+def test_collect_evidence_failed_compile_db_records_extractor(tmp_path):
+    bad = tmp_path / "missing.json"
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, ["collect-evidence", "--compile-db", str(bad), "-o", str(out)])
+    # The adapter failure is recorded as a diagnostic/extractor status, not a crash.
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert any(e.name == "compile_commands" and e.status == "failed"
+               for e in pack.manifest.extractors)
+
+
+def test_collect_evidence_ninja_compdb(tmp_path):
+    compdb = tmp_path / "compdb.json"
+    compdb.write_text(json.dumps([{"directory": str(tmp_path), "file": "a.cpp",
+                                   "arguments": ["c++", "-std=c++20", "-c", "a.cpp"]}]))
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, ["collect-evidence", "--ninja-compdb", str(compdb), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is not None
+    assert any(o.key == "std:CXX" for o in pack.build_evidence.build_options)
+
+
+def test_compare_drift_fires_without_compile_db_context(tmp_path):
+    """Codex fix: compare has no -p, so a new pack with ABI flags discloses
+    HEADER_PARSE_CONTEXT_DRIFT even when -H headers are passed."""
+    from abicheck.model import AbiSnapshot
+    from abicheck.serialization import save_snapshot
+
+    new_cdb = tmp_path / "cc.json"
+    new_cdb.write_text(json.dumps([{"directory": str(tmp_path), "file": "a.cpp",
+                                    "arguments": ["c++", "-std=c++20", "-c", "a.cpp"]}]))
+    ev_new = tmp_path / "new.evidence"
+    runner = CliRunner()
+    runner.invoke(main, ["collect-evidence", "--compile-db", str(new_cdb), "-o", str(ev_new)])
+
+    for v in ("old", "new"):
+        save_snapshot(AbiSnapshot(library="libfoo.so", version=v, from_headers=True),
+                      tmp_path / f"{v}.json")
+
+    result = runner.invoke(main, [
+        "compare", str(tmp_path / "old.json"), str(tmp_path / "new.json"),
+        "-H", str(tmp_path),  # headers present, but NOT parsed with -p
+        "--new-evidence", str(ev_new), "--format", "json",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    assert "header_parse_context_drift" in result.stdout

--- a/tests/test_evidence_coverage.py
+++ b/tests/test_evidence_coverage.py
@@ -315,6 +315,28 @@ def test_diff_no_change_when_equal():
     assert diff_build_evidence(ev, copy.deepcopy(ev)) == []
 
 
+def test_derive_build_options_skips_structurally_captured_flags():
+    """Codex: split vs combined sysroot/target must not double-count.
+
+    --sysroot/-target are captured as the normalized structured sysroot/target
+    options; the raw flag (split or combined spelling) must not also appear, or
+    an identical build looks changed.
+    """
+    split = derive_build_options([CompileUnit(
+        id="1", language="CXX", sysroot="/sdk", target_triple="x86_64-linux-gnu",
+        abi_relevant_flags=["--sysroot", "-target"],
+    )])
+    combined = derive_build_options([CompileUnit(
+        id="1", language="CXX", sysroot="/sdk", target_triple="x86_64-linux-gnu",
+        abi_relevant_flags=["--sysroot=/sdk", "--target=x86_64-linux-gnu"],
+    )])
+    assert {(o.key, o.value) for o in split} == {("sysroot", "/sdk"), ("target", "x86_64-linux-gnu")}
+    assert {(o.key, o.value) for o in split} == {(o.key, o.value) for o in combined}
+    old = BuildEvidence(build_options=split)
+    new = BuildEvidence(build_options=combined)
+    assert diff_build_evidence(old, new) == []
+
+
 def test_diff_preserves_multiple_values_for_same_key():
     """Codex P2: a removed variant of a multi-config option is not masked."""
     old = BuildEvidence(build_options=[
@@ -404,6 +426,34 @@ def test_compare_drift_fires_without_compile_db_context(tmp_path):
     ])
     assert result.exit_code in (0, 2, 4), result.output
     assert "header_parse_context_drift" in result.stdout
+
+
+def test_compare_drift_suppressed_when_dumped_with_build_context(tmp_path):
+    """A snapshot dumped with `-p` (parsed_with_build_context) suppresses drift."""
+    from abicheck.model import AbiSnapshot
+    from abicheck.serialization import save_snapshot
+
+    new_cdb = tmp_path / "cc.json"
+    new_cdb.write_text(json.dumps([{"directory": str(tmp_path), "file": "a.cpp",
+                                    "arguments": ["c++", "-std=c++20", "-c", "a.cpp"]}]))
+    ev_new = tmp_path / "new.evidence"
+    runner = CliRunner()
+    runner.invoke(main, ["collect-evidence", "--compile-db", str(new_cdb), "-o", str(ev_new)])
+
+    # New side was dumped WITH the build's compile DB → no drift.
+    save_snapshot(AbiSnapshot(library="libfoo.so", version="old", from_headers=True),
+                  tmp_path / "old.json")
+    save_snapshot(
+        AbiSnapshot(library="libfoo.so", version="new", from_headers=True,
+                    parsed_with_build_context=True),
+        tmp_path / "new.json",
+    )
+    result = runner.invoke(main, [
+        "compare", str(tmp_path / "old.json"), str(tmp_path / "new.json"),
+        "--new-evidence", str(ev_new), "--format", "json",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    assert "header_parse_context_drift" not in result.stdout
 
 
 def test_compare_binary_only_skips_header_drift(tmp_path):

--- a/tests/test_evidence_coverage.py
+++ b/tests/test_evidence_coverage.py
@@ -315,6 +315,36 @@ def test_diff_no_change_when_equal():
     assert diff_build_evidence(ev, copy.deepcopy(ev)) == []
 
 
+def test_derive_build_options_captures_msvc_std_flag():
+    """Codex: MSVC /std: is normalized into the std:<lang> option (not dropped).
+
+    `_extract_flags` only fills cu.standard from GCC `-std=`, so without this the
+    /std: change would be invisible on Windows/MSVC builds.
+    """
+    old = derive_build_options([CompileUnit(
+        id="1", language="CXX", standard="", abi_relevant_flags=["/std:c++17"],
+    )])
+    new = derive_build_options([CompileUnit(
+        id="1", language="CXX", standard="", abi_relevant_flags=["/std:c++20"],
+    )])
+    assert {(o.key, o.value) for o in old} == {("std:CXX", "c++17")}
+    assert {(o.key, o.value) for o in new} == {("std:CXX", "c++20")}
+    changes = diff_build_evidence(BuildEvidence(build_options=old), BuildEvidence(build_options=new))
+    assert any(
+        c.kind is ChangeKind.ABI_RELEVANT_BUILD_FLAG_CHANGED
+        and c.old_value == "c++17" and c.new_value == "c++20"
+        for c in changes
+    )
+
+
+def test_derive_build_options_gcc_std_no_double_emit():
+    """GCC -std= is captured once via the structured field, not duplicated."""
+    opts = derive_build_options([CompileUnit(
+        id="1", language="CXX", standard="c++20", abi_relevant_flags=["-std=c++20"],
+    )])
+    assert sum(o.key == "std:CXX" for o in opts) == 1
+
+
 def test_derive_build_options_skips_structurally_captured_flags():
     """Codex: split vs combined sysroot/target must not double-count.
 

--- a/tests/test_evidence_coverage.py
+++ b/tests/test_evidence_coverage.py
@@ -167,6 +167,24 @@ def test_pack_load_with_build_evidence(tmp_path):
     assert loaded.content_hash().startswith("sha256:")
 
 
+def test_pack_rewrite_removes_stale_build_evidence(tmp_path):
+    """Codex P2: a rerun with no build evidence must drop the old L3 file."""
+    root = tmp_path / "p"
+    first = EvidencePack.empty(root)
+    first.build_evidence = BuildEvidence(
+        compile_units=[CompileUnit(id="cu://a", source="a.cpp", language="CXX", standard="c++20")],
+    )
+    first.write()
+    assert (root / "build" / "build_evidence.json").is_file()
+
+    # Rerun into the same directory producing no build evidence.
+    second = EvidencePack.empty(root)
+    second.build_evidence = None
+    second.write()
+    assert not (root / "build" / "build_evidence.json").exists()
+    assert EvidencePack.load(root).build_evidence is None
+
+
 def test_pack_to_ref_coverage_summary(tmp_path):
     pack = EvidencePack.empty(tmp_path / "p")
     pack.manifest.coverage = [LayerCoverage(layer="L3_build", status=CoverageStatus.PRESENT,
@@ -295,6 +313,34 @@ def test_diff_no_change_when_equal():
     ev = BuildEvidence(build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)])
     import copy
     assert diff_build_evidence(ev, copy.deepcopy(ev)) == []
+
+
+def test_diff_preserves_multiple_values_for_same_key():
+    """Codex P2: a removed variant of a multi-config option is not masked."""
+    old = BuildEvidence(build_options=[
+        BuildOption("std:CXX", "c++17", abi_relevant=True),
+        BuildOption("std:CXX", "c++20", abi_relevant=True),
+    ])
+    new = BuildEvidence(build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)])
+    changes = diff_build_evidence(old, new)
+    assert len(changes) == 1
+    c = changes[0]
+    assert c.kind is ChangeKind.ABI_RELEVANT_BUILD_FLAG_CHANGED
+    assert c.old_value == "c++17, c++20"
+    assert c.new_value == "c++20"
+
+
+def test_diff_multi_value_order_independent():
+    """Same value sets in different unit order produce no finding."""
+    a = BuildEvidence(build_options=[
+        BuildOption("std:CXX", "c++17", abi_relevant=True),
+        BuildOption("std:CXX", "c++20", abi_relevant=True),
+    ])
+    b = BuildEvidence(build_options=[
+        BuildOption("std:CXX", "c++20", abi_relevant=True),
+        BuildOption("std:CXX", "c++17", abi_relevant=True),
+    ])
+    assert diff_build_evidence(a, b) == []
 
 
 # ── collect-evidence CLI variants (ADR-028 D6) ───────────────────────────────

--- a/tests/test_evidence_coverage.py
+++ b/tests/test_evidence_coverage.py
@@ -404,3 +404,28 @@ def test_compare_drift_fires_without_compile_db_context(tmp_path):
     ])
     assert result.exit_code in (0, 2, 4), result.output
     assert "header_parse_context_drift" in result.stdout
+
+
+def test_compare_binary_only_skips_header_drift(tmp_path):
+    """Codex: a binary-only new side (no header AST) must NOT emit drift."""
+    from abicheck.model import AbiSnapshot
+    from abicheck.serialization import save_snapshot
+
+    new_cdb = tmp_path / "cc.json"
+    new_cdb.write_text(json.dumps([{"directory": str(tmp_path), "file": "a.cpp",
+                                    "arguments": ["c++", "-std=c++20", "-c", "a.cpp"]}]))
+    ev_new = tmp_path / "new.evidence"
+    runner = CliRunner()
+    runner.invoke(main, ["collect-evidence", "--compile-db", str(new_cdb), "-o", str(ev_new)])
+
+    # Binary-only snapshots: from_headers is False, so there is no L2 AST.
+    for v in ("old", "new"):
+        save_snapshot(AbiSnapshot(library="libfoo.so", version=v, from_headers=False),
+                      tmp_path / f"{v}.json")
+
+    result = runner.invoke(main, [
+        "compare", str(tmp_path / "old.json"), str(tmp_path / "new.json"),
+        "--new-evidence", str(ev_new), "--format", "json",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    assert "header_parse_context_drift" not in result.stdout

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -401,6 +401,32 @@ def test_compile_db_redacts_secret_define(tmp_path):
     assert defines["FOO"] == "1"
 
 
+def test_redaction_argv_redacts_split_define_secret():
+    """Split -D form ['-D', 'KEY=secret'] must redact the value token."""
+    pol = RedactionPolicy(redact_home=False)
+    out = pol.argv(["c++", "-D", "API_TOKEN=hunter2", "-D", "FOO=1", "-c", "a.cpp"])
+    assert "API_TOKEN=<redacted>" in out
+    assert "hunter2" not in " ".join(out)
+    assert "FOO=1" in out
+
+
+def test_compile_db_split_define_secret_not_leaked_in_argv(tmp_path):
+    """End-to-end: split-form secret never reaches CompileUnit.argv."""
+    from abicheck.evidence.adapters import CompileDbAdapter
+
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(json.dumps([{
+        "directory": str(tmp_path), "file": "a.cpp",
+        "arguments": ["c++", "-D", "API_TOKEN=hunter2", "-D", "_GLIBCXX_USE_CXX11_ABI=0", "-c", "a.cpp"],
+    }]))
+    ev = CompileDbAdapter(cdb).collect()
+    cu = ev.compile_units[0]
+    assert "hunter2" not in " ".join(cu.argv)
+    assert cu.defines["API_TOKEN"] == "<redacted>"
+    # The split-form ABI macro is still captured as a diffable option.
+    assert any(o.key == "define:_GLIBCXX_USE_CXX11_ABI" for o in ev.build_options)
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -423,6 +449,21 @@ def test_extract_abi_relevant_flags():
     assert "-fvisibility=hidden" in flags
     assert "-O2" not in flags
     assert "-DFOO=1" not in flags
+
+
+def test_extract_abi_relevant_flags_split_define_form():
+    """Split ['-D', 'KEY=VAL'] ABI macros are captured and normalized."""
+    flags = extract_abi_relevant_flags(
+        ["c++", "-D", "_GLIBCXX_USE_CXX11_ABI=0", "-D", "FOO=1", "-std=c++20"]
+    )
+    assert "-D_GLIBCXX_USE_CXX11_ABI=0" in flags  # normalized to combined form
+    assert "-std=c++20" in flags
+    assert not any("FOO" in f for f in flags)
+
+
+def test_extract_abi_relevant_flags_trailing_bare_define():
+    """A trailing bare -D with no following token does not crash."""
+    assert extract_abi_relevant_flags(["c++", "-D"]) == []
 
 
 # ── BuildEvidence merge ──────────────────────────────────────────────────────

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -378,6 +378,30 @@ def test_redaction_rewrites_home_prefix():
     assert pol.path("/home/alice/proj/foo.cpp") == "~/proj/foo.cpp"
 
 
+def test_redaction_rewrites_embedded_home_paths_in_argv():
+    """Combined flags that embed a home path are redacted in argv (Codex)."""
+    pol = RedactionPolicy(home_replacements={"/home/alice": "~"})
+    assert pol.path("-I/home/alice/proj/include") == "-I~/proj/include"
+    assert pol.path("-DMYROOT=/home/alice/sdk") == "-DMYROOT=~/sdk"
+    red = pol.argv(["c++", "-I/home/alice/inc", "-DMYROOT=/home/alice/sdk", "-c", "a.cpp"])
+    assert not any("/home/alice" in tok for tok in red)
+
+
+def test_compile_db_redacts_embedded_home_paths_in_argv(tmp_path):
+    """End-to-end: embedded home paths never reach CompileUnit.argv."""
+    from abicheck.evidence.adapters import CompileDbAdapter
+
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(json.dumps([{
+        "directory": str(tmp_path), "file": "a.cpp",
+        "arguments": ["c++", "-I/home/alice/proj/include", "-c", "a.cpp"],
+    }]))
+    ev = CompileDbAdapter(
+        cdb, redaction=RedactionPolicy(home_replacements={"/home/alice": "~"}),
+    ).collect()
+    assert not any("/home/alice" in tok for tok in ev.compile_units[0].argv)
+
+
 def test_redaction_define_value_redacts_secret_macro():
     pol = RedactionPolicy(home_replacements={"/home/bob": "~"})
     assert pol.define_value("API_TOKEN", "hunter2") == "<redacted>"

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -378,6 +378,29 @@ def test_redaction_rewrites_home_prefix():
     assert pol.path("/home/alice/proj/foo.cpp") == "~/proj/foo.cpp"
 
 
+def test_redaction_define_value_redacts_secret_macro():
+    pol = RedactionPolicy(home_replacements={"/home/bob": "~"})
+    assert pol.define_value("API_TOKEN", "hunter2") == "<redacted>"
+    assert pol.define_value("SECRET_KEY", "abc") == "<redacted>"
+    # Non-secret macros keep their value but still get home-path normalization.
+    assert pol.define_value("FOO", "1") == "1"
+    assert pol.define_value("PREFIX", "/home/bob/install") == "~/install"
+
+
+def test_compile_db_redacts_secret_define(tmp_path):
+    from abicheck.evidence.adapters import CompileDbAdapter
+
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(json.dumps([{
+        "directory": str(tmp_path), "file": "a.cpp",
+        "arguments": ["c++", "-DAPI_TOKEN=hunter2", "-DFOO=1", "-c", "a.cpp"],
+    }]))
+    ev = CompileDbAdapter(cdb).collect()
+    defines = ev.compile_units[0].defines
+    assert defines["API_TOKEN"] == "<redacted>"
+    assert defines["FOO"] == "1"
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -1,0 +1,427 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the optional source/build EvidencePack (ADR-028) and the
+build-evidence adapters/diff (ADR-029)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from abicheck.checker_policy import (
+    BREAKING_KINDS,
+    COMPATIBLE_KINDS,
+    RISK_KINDS,
+    ChangeKind,
+)
+from abicheck.evidence import (
+    BuildEvidence,
+    EvidencePack,
+    EvidencePackManifest,
+    EvidencePackRef,
+)
+from abicheck.evidence.adapters import (
+    CMakeFileApiAdapter,
+    CompileDbAdapter,
+    NinjaAdapter,
+    compile_unit_id,
+    detect_language,
+    extract_abi_relevant_flags,
+)
+from abicheck.evidence.build_diff import check_header_parse_drift, diff_build_evidence
+from abicheck.evidence.build_evidence import (
+    BuildOption,
+    Generator,
+    LinkUnit,
+    Toolchain,
+)
+from abicheck.evidence.model import CoverageStatus, EvidenceLayer
+from abicheck.evidence.redaction import RedactionPolicy
+from abicheck.model import AbiSnapshot
+from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
+
+# ── Pack model & content addressing ──────────────────────────────────────────
+
+
+def test_empty_pack_write_load_roundtrip(tmp_path):
+    pack = EvidencePack.empty(tmp_path / "p.evidence", abicheck_version="9.9", created_at="t0")
+    pack.write()
+    loaded = EvidencePack.load(tmp_path / "p.evidence")
+    assert loaded.manifest.abicheck_version == "9.9"
+    # All standard subdirs were created.
+    for sub in ("build", "source", "graph", "toolchain", "raw", "normalized"):
+        assert (tmp_path / "p.evidence" / sub).is_dir()
+
+
+def test_load_missing_manifest_raises(tmp_path):
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(FileNotFoundError):
+        EvidencePack.load(tmp_path / "empty")
+
+
+def test_content_hash_is_stable_across_created_at(tmp_path):
+    """Two packs with identical evidence but different timestamps hash equal."""
+    p1 = EvidencePack.empty(tmp_path / "a", created_at="2026-01-01")
+    p1.write()
+    p2 = EvidencePack.empty(tmp_path / "b", created_at="2099-12-31")
+    p2.write()
+    assert p1.content_hash() == p2.content_hash()
+    assert p1.content_hash().startswith("sha256:")
+
+
+def test_content_hash_changes_with_build_evidence(tmp_path):
+    p1 = EvidencePack.empty(tmp_path / "a")
+    p1.write()
+    p2 = EvidencePack.empty(tmp_path / "b")
+    p2.build_evidence = BuildEvidence(build_options=[BuildOption(key="std:CXX", value="c++20")])
+    p2.write()
+    assert p1.content_hash() != p2.content_hash()
+
+
+def test_to_ref_roundtrip(tmp_path):
+    pack = EvidencePack.empty(tmp_path / "p")
+    pack.manifest.coverage = []
+    pack.write()
+    ref = pack.to_ref(path_hint="p.evidence/")
+    ref2 = EvidencePackRef.from_dict(ref.to_dict())
+    assert ref2.content_hash == ref.content_hash
+    assert ref2.path_hint == "p.evidence/"
+
+
+def test_manifest_dict_roundtrip():
+    m = EvidencePackManifest(abicheck_version="1.0")
+    m2 = EvidencePackManifest.from_dict(m.to_dict())
+    assert m2.abicheck_version == "1.0"
+    assert m2.evidence_pack_version == m.evidence_pack_version
+
+
+def test_unknown_manifest_keys_are_ignored():
+    """A newer pack with unknown keys still loads (forward-compat)."""
+    raw = {"evidence_pack_version": 1, "future_field": {"x": 1}, "coverage": []}
+    m = EvidencePackManifest.from_dict(raw)
+    assert m.evidence_pack_version == 1
+
+
+# ── Snapshot integration (schema v7) ─────────────────────────────────────────
+
+
+def test_snapshot_v7_evidence_ref_roundtrip():
+    snap = AbiSnapshot(
+        library="libfoo.so", version="1.0",
+        evidence_pack=EvidencePackRef(content_hash="sha256:abc", path_hint="e/"),
+    )
+    d = snapshot_to_dict(snap)
+    assert d["schema_version"] == 7
+    assert d["evidence_pack"]["content_hash"] == "sha256:abc"
+    back = snapshot_from_dict(d)
+    assert back.evidence_pack is not None
+    assert back.evidence_pack.content_hash == "sha256:abc"
+
+
+def test_snapshot_without_evidence_serializes_none():
+    snap = AbiSnapshot(library="l", version="1")
+    d = snapshot_to_dict(snap)
+    assert d["evidence_pack"] is None
+    assert snapshot_from_dict(d).evidence_pack is None
+
+
+def test_legacy_v6_snapshot_without_evidence_key_loads():
+    """Backward-compat (ADR-015): a v6 snapshot has no evidence_pack key."""
+    d = snapshot_to_dict(AbiSnapshot(library="l", version="1"))
+    d["schema_version"] = 6
+    d.pop("evidence_pack", None)
+    assert snapshot_from_dict(d).evidence_pack is None
+
+
+def test_malformed_evidence_ref_is_ignored():
+    d = snapshot_to_dict(AbiSnapshot(library="l", version="1"))
+    d["evidence_pack"] = "not-a-dict"
+    assert snapshot_from_dict(d).evidence_pack is None
+
+
+# ── compile_commands.json adapter (ADR-029 D3) ───────────────────────────────
+
+
+def _write_cdb(tmp_path, entries):
+    p = tmp_path / "compile_commands.json"
+    p.write_text(json.dumps(entries))
+    return p
+
+
+def test_compile_db_adapter_normalizes_units(tmp_path):
+    cdb = _write_cdb(tmp_path, [
+        {"directory": str(tmp_path), "file": "src/foo.cpp",
+         "arguments": ["c++", "-std=c++20", "-DFOO=1", "-Iinclude", "-c", "src/foo.cpp"]},
+        {"directory": str(tmp_path), "file": "src/bar.c",
+         "command": "cc -std=c11 -Iinclude -c src/bar.c"},
+    ])
+    ev = CompileDbAdapter(cdb, build_system="cmake").collect()
+    assert len(ev.compile_units) == 2
+    cxx = next(c for c in ev.compile_units if c.language == "CXX")
+    assert cxx.standard == "c++20"
+    assert cxx.defines.get("FOO") == "1"
+    assert "-std=c++20" in cxx.abi_relevant_flags
+    # Per-language standard keys keep C and C++ distinct.
+    keys = {o.key for o in ev.build_options}
+    assert "std:CXX" in keys and "std:C" in keys
+
+
+def test_compile_db_supports_command_string_form(tmp_path):
+    cdb = _write_cdb(tmp_path, [
+        {"directory": str(tmp_path), "file": "a.cpp", "command": "c++ -std=c++17 -c a.cpp"},
+    ])
+    ev = CompileDbAdapter(cdb).collect()
+    assert ev.compile_units[0].standard == "c++17"
+
+
+def test_glibcxx_abi_define_is_abi_relevant(tmp_path):
+    cdb = _write_cdb(tmp_path, [
+        {"directory": str(tmp_path), "file": "a.cpp",
+         "arguments": ["c++", "-D_GLIBCXX_USE_CXX11_ABI=0", "-c", "a.cpp"]},
+    ])
+    ev = CompileDbAdapter(cdb).collect()
+    keys = {o.key for o in ev.build_options}
+    assert "define:_GLIBCXX_USE_CXX11_ABI" in keys
+
+
+# ── Ninja adapter (ADR-029 D5) ───────────────────────────────────────────────
+
+
+def test_ninja_adapter_from_precaptured_compdb(tmp_path):
+    compdb = json.dumps([
+        {"directory": str(tmp_path), "file": "a.cpp", "output": "a.o",
+         "arguments": ["c++", "-std=c++20", "-c", "a.cpp"]},
+        # A non-compiler statement (no recognized source ext) is filtered out.
+        {"directory": str(tmp_path), "file": "link.stamp", "arguments": ["touch", "link.stamp"]},
+    ])
+    ev = NinjaAdapter(compdb=compdb).collect()
+    assert len(ev.compile_units) == 1
+    assert ev.compile_units[0].standard == "c++20"
+    assert any(g.kind == "ninja" for g in ev.generators)
+
+
+def test_ninja_adapter_no_input_emits_diagnostic():
+    ev = NinjaAdapter(build_dir=None).collect()
+    assert ev.compile_units == []
+    assert any("no compdb" in d for d in ev.diagnostics)
+
+
+# ── CMake File API adapter (ADR-029 D4) ──────────────────────────────────────
+
+
+def _make_cmake_reply(build_dir):
+    reply = build_dir / ".cmake" / "api" / "v1" / "reply"
+    reply.mkdir(parents=True)
+    (reply / "codemodel-v2-x.json").write_text(json.dumps({
+        "configurations": [{"targets": [{"jsonFile": "target-foo.json"}]}],
+    }))
+    (reply / "target-foo.json").write_text(json.dumps({
+        "name": "foo",
+        "type": "SHARED_LIBRARY",
+        "artifacts": [{"path": "libfoo.so"}],
+        "dependencies": [{"id": "bar::@abc"}],
+        "fileSets": [
+            {"type": "HEADERS", "visibility": "PUBLIC"},
+            {"type": "HEADERS", "visibility": "PRIVATE"},
+        ],
+        "sources": [
+            {"path": "src/foo.cpp"},
+            {"path": "include/foo.h", "fileSetIndex": 0},
+            {"path": "src/foo_impl.h", "fileSetIndex": 1},
+        ],
+    }))
+    (reply / "toolchains-v1-x.json").write_text(json.dumps({
+        "toolchains": [
+            {"language": "CXX", "compiler": {"id": "GNU", "version": "14.1", "path": "/usr/bin/c++"}},
+        ],
+    }))
+    (reply / "index-2026.json").write_text(json.dumps({
+        "cmake": {"version": {"string": "3.28"}, "generator": {"name": "Ninja"}},
+        "objects": [
+            {"kind": "codemodel", "jsonFile": "codemodel-v2-x.json"},
+            {"kind": "toolchains", "jsonFile": "toolchains-v1-x.json"},
+        ],
+    }))
+    return build_dir
+
+
+def test_cmake_file_api_adapter(tmp_path):
+    build = _make_cmake_reply(tmp_path / "build")
+    ev = CMakeFileApiAdapter(build).collect()
+    assert len(ev.targets) == 1
+    t = ev.targets[0]
+    assert t.id == "target://foo"
+    assert t.kind.value == "shared_library"
+    assert t.public_headers == ["include/foo.h"]
+    assert t.private_headers == ["src/foo_impl.h"]
+    assert t.source_files == ["src/foo.cpp"]
+    assert t.dependencies == ["target://bar"]
+    assert t.visibility == "public"
+    assert any(g.kind == "cmake" and g.generator == "Ninja" for g in ev.generators)
+    assert ev.toolchains and ev.toolchains[0].version == "14.1"
+
+
+def test_cmake_file_api_missing_reply_is_graceful(tmp_path):
+    ev = CMakeFileApiAdapter(tmp_path / "no-build").collect()
+    assert ev.targets == []
+    assert any("no reply directory" in d for d in ev.diagnostics)
+
+
+# ── Build-evidence diff & findings (ADR-029 D9) ──────────────────────────────
+
+
+def test_diff_emits_abi_relevant_build_flag_changed():
+    old = BuildEvidence(build_options=[BuildOption("std:CXX", "c++17", abi_relevant=True)])
+    new = BuildEvidence(build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)])
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.ABI_RELEVANT_BUILD_FLAG_CHANGED for c in changes)
+
+
+def test_diff_emits_build_context_changed_for_non_abi_flag():
+    old = BuildEvidence(build_options=[BuildOption("warnings", "on", abi_relevant=False)])
+    new = BuildEvidence(build_options=[BuildOption("warnings", "off", abi_relevant=False)])
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.BUILD_CONTEXT_CHANGED for c in changes)
+
+
+def test_diff_emits_toolchain_version_changed():
+    old = BuildEvidence(toolchains=[Toolchain(id="t", compiler_id="GNU", version="13", language="CXX")])
+    new = BuildEvidence(toolchains=[Toolchain(id="t", compiler_id="GNU", version="14", language="CXX")])
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.TOOLCHAIN_VERSION_CHANGED for c in changes)
+
+
+def test_diff_emits_toolchain_change_for_sysroot_option():
+    old = BuildEvidence(build_options=[BuildOption("sysroot", "/a", abi_relevant=True)])
+    new = BuildEvidence(build_options=[BuildOption("sysroot", "/b", abi_relevant=True)])
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.TOOLCHAIN_VERSION_CHANGED for c in changes)
+
+
+def test_diff_emits_link_export_policy_changed():
+    old = BuildEvidence(link_units=[LinkUnit(id="l", target_id="t", version_script="v1.map")])
+    new = BuildEvidence(link_units=[LinkUnit(id="l", target_id="t", version_script="v2.map")])
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.LINK_EXPORT_POLICY_CHANGED for c in changes)
+
+
+def test_diff_emits_generated_file_dependency_unstable():
+    old = BuildEvidence()
+    new = BuildEvidence(diagnostics=["ninja: missingdeps reported 3 entries"])
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.GENERATED_FILE_DEPENDENCY_UNSTABLE for c in changes)
+
+
+def test_header_parse_drift_flagged_without_context():
+    ev = BuildEvidence(build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)])
+    changes = check_header_parse_drift(ev, headers_parsed_with_context=False)
+    assert len(changes) == 1
+    assert changes[0].kind is ChangeKind.HEADER_PARSE_CONTEXT_DRIFT
+
+
+def test_header_parse_drift_silent_with_context():
+    ev = BuildEvidence(build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)])
+    assert check_header_parse_drift(ev, headers_parsed_with_context=True) == []
+
+
+def test_diff_identical_evidence_is_empty():
+    ev = BuildEvidence(
+        build_options=[BuildOption("std:CXX", "c++20", abi_relevant=True)],
+        toolchains=[Toolchain(id="t", compiler_id="GNU", version="14", language="CXX")],
+    )
+    import copy
+    assert diff_build_evidence(ev, copy.deepcopy(ev)) == []
+
+
+# ── ChangeKind partition (ADR-028 D3) ────────────────────────────────────────
+
+
+def test_build_context_kinds_never_breaking():
+    """ADR-028 D3: source/build-only kinds are RISK or quality, never BREAKING."""
+    risk = {
+        ChangeKind.ABI_RELEVANT_BUILD_FLAG_CHANGED,
+        ChangeKind.HEADER_PARSE_CONTEXT_DRIFT,
+        ChangeKind.TOOLCHAIN_VERSION_CHANGED,
+        ChangeKind.GENERATED_FILE_DEPENDENCY_UNSTABLE,
+        ChangeKind.LINK_EXPORT_POLICY_CHANGED,
+    }
+    for k in risk:
+        assert k in RISK_KINDS
+        assert k not in BREAKING_KINDS
+    assert ChangeKind.BUILD_CONTEXT_CHANGED in COMPATIBLE_KINDS
+    assert ChangeKind.BUILD_CONTEXT_CHANGED not in BREAKING_KINDS
+
+
+# ── Redaction (ADR-032 D7) ───────────────────────────────────────────────────
+
+
+def test_redaction_strips_secret_define():
+    pol = RedactionPolicy(redact_home=False)
+    assert pol.arg("-DAPI_TOKEN=hunter2") == "-DAPI_TOKEN=<redacted>"
+    assert pol.arg("-DFOO=1") == "-DFOO=1"
+
+
+def test_redaction_rewrites_home_prefix():
+    pol = RedactionPolicy(home_replacements={"/home/alice": "~"})
+    assert pol.path("/home/alice/proj/foo.cpp") == "~/proj/foo.cpp"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def test_detect_language():
+    assert detect_language("a.cpp") == "CXX"
+    assert detect_language("a.c") == "C"
+    assert detect_language("a.txt") == ""
+
+
+def test_compile_unit_id_is_config_sensitive():
+    a = compile_unit_id("a.cpp", ["-std=c++17"])
+    b = compile_unit_id("a.cpp", ["-std=c++20"])
+    assert a != b
+    assert compile_unit_id("a.cpp", ["-std=c++17"]) == a  # stable
+
+
+def test_extract_abi_relevant_flags():
+    flags = extract_abi_relevant_flags(["-std=c++20", "-O2", "-fvisibility=hidden", "-DFOO=1"])
+    assert "-std=c++20" in flags
+    assert "-fvisibility=hidden" in flags
+    assert "-O2" not in flags
+    assert "-DFOO=1" not in flags
+
+
+# ── BuildEvidence merge ──────────────────────────────────────────────────────
+
+
+def test_build_evidence_merge_dedups_by_id():
+    a = BuildEvidence(generators=[Generator(kind="cmake")])
+    b = BuildEvidence(
+        generators=[Generator(kind="ninja")],
+        toolchains=[Toolchain(id="t1", language="CXX")],
+    )
+    a.merge(b)
+    a.merge(b)  # idempotent on ids
+    assert len(a.toolchains) == 1
+    assert len(a.generators) == 3  # generators are appended, not id-deduped
+
+
+def test_coverage_status_default_round_trip():
+    cov = EvidencePack.empty("/tmp/x").manifest.coverage_for(EvidenceLayer.L3_BUILD)
+    assert cov is None  # empty pack has no coverage rows until populated
+
+
+def test_coverage_status_enum_values():
+    assert CoverageStatus.PRESENT.value == "present"
+    assert CoverageStatus.NOT_COLLECTED.value == "not_collected"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -239,7 +239,7 @@ def test_apply_provenance_no_set_keeps_unknown_but_fills_header():
 def test_serialization_round_trip_preserves_provenance():
     snap = apply_provenance(_snapshot(), public_headers=["include/api.h"])
     d = snapshot_to_dict(snap)
-    assert d["schema_version"] == 6
+    assert d["schema_version"] == 7
     # Enum value serialized as a plain string.
     assert d["functions"][0]["origin"] == "public_header"
     assert d["functions"][0]["source_header"] == "/build/include/api.h"


### PR DESCRIPTION
## Summary

Implements **ADR-028 Phase 0** (the EvidencePack foundation) plus the **ADR-029 build-adapter MVP**. An *EvidencePack* is an optional, content-addressed, independently-versioned sidecar that augments an `AbiSnapshot` with source/build evidence (L3/L4/L5) — without bloating ordinary ABI dumps.

The umbrella ADR-028 is a six-ADR set (028–033). This PR lands the skeleton that 030–033 hang off, plus the first real evidence layer (L3 build context).

### The authority rule (ADR-028 D3)

Artifact-backed **L0/L1/L2 evidence stays authoritative** for shipped-ABI verdicts. Build/source-only findings *explain, localize, scope, and add confidence* — they default to `API_BREAK` or **risk** and **never** escalate to `BREAKING` unless an artifact diff agrees.

## What's included

**ADR-028 Phase 0 (foundation)**
- New `abicheck/evidence/` sub-package: pack manifest, coverage model (L0–L5), cross-layer entity identity, on-disk layout, content addressing, redaction (ADR-032 D7, minimal).
- `AbiSnapshot` gains an optional `evidence_pack` reference; snapshot schema **v6 → v7** (backward-compatible — old readers ignore the new optional field, per ADR-015).
- JSON schemas for the pack manifest and build evidence.
- CLI: `collect-evidence`; `dump --evidence`; `compare --old-evidence/--new-evidence/--evidence-mode`; an **evidence-coverage table** emitted across all output formats (D7).

**ADR-029 (build context, MVP)**
- `BuildEvidence` normalized, build-system-neutral model (targets, compile/link units, toolchains, build options).
- Adapters — post-build and **non-executing by default** (D6):
  - `compile_commands.json` (reuses the ADR-020a `build_context.py` parser),
  - CMake File API reply directory (target graph, public/private header file sets, toolchains),
  - Ninja `-t compdb`/`graph` (live query or pre-captured for hermetic CI).
- Build-evidence diff with **six new `ChangeKind`s** (D9): `build_context_changed` (quality), and the risk kinds `abi_relevant_build_flag_changed`, `header_parse_context_drift`, `toolchain_version_changed`, `generated_file_dependency_unstable`, `link_export_policy_changed`.

**Refactor**
- Moved `_run_compare_pair` into `cli_compare_release.py` (its only caller) so `cli.py` stays under the 2000-line AI-readiness cap after the new wiring.

**Docs**
- `concepts/evidence-pack.md` (wired into mkdocs nav); ADR-028/029 marked Accepted; ChangeKind headline count synced (206).

## Testing

- `tests/test_evidence_pack.py` + `tests/test_evidence_cli.py` — 44 cases: pack I/O, content-hash stability (timestamp-independent), schema-v7 round-trip + v6 backward-compat, all three adapters, the diff and all six findings, redaction, and the full CLI surface.
- Full fast suite: **8475 passed**. `mypy` clean, `ruff check` clean, AI-readiness **0 errors**, FP-rate within baseline, `mkdocs build --strict` passes.

## Scope / follow-ups

This is Phase 0 + the ADR-029 build MVP. Deferred to later ADRs: Bazel/Make adapters and compiler-recorded metadata (ADR-029 D6–D8), source ABI replay (ADR-030, L4), source/implementation graph (ADR-031, L5), the full plugin/capability model (ADR-032), and baseline-registry storage + CI rollout (ADR-033). `--evidence-mode` values other than `off` are accepted and reported but inline collection beyond explicitly-provided packs is not yet wired.

https://claude.ai/code/session_01Vozc3KxWQeFQ1HdyW1agYD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vozc3KxWQeFQ1HdyW1agYD)_