### PR TITLE
feat: finalize ADR-029 build adapters — Bazel (D6), Make (D7), compiler-recorded metadata (D8)

### DIFF
--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -130,7 +130,9 @@ def collect_evidence_cmd(
         "headers": [red.path(str(h)) for h in headers],
         "build_dir": red.path(str(build_dir)) if build_dir else None,
     }
-    has_build = bool(merged.compile_units or merged.targets or merged.toolchains)
+    has_build = bool(
+        merged.compile_units or merged.targets or merged.toolchains or merged.link_units
+    )
     if has_build:
         pack.build_evidence = merged
     pack.manifest.coverage = _build_coverage(merged, has_build)
@@ -217,7 +219,7 @@ def _run_adapters(
         merged.merge(ev)
         inputs = [DEFAULT_REDACTION.path(str(p)) for p in (bazel_cquery, bazel_aquery) if p is not None]
         extractors.append(ExtractorRecord(
-            name="bazel", status="ok" if (ev.targets or ev.compile_units) else "partial",
+            name="bazel", status="ok" if (ev.targets or ev.compile_units or ev.link_units) else "partial",
             inputs=inputs,
             detail=(
                 f"{len(ev.targets)} targets, {len(ev.compile_units)} compile units, "

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -15,8 +15,9 @@
 """`collect-evidence` command (ADR-028 D6, ADR-029).
 
 Collects an optional EvidencePack from an existing build tree *without
-rebuilding*. The pack augments an ABI snapshot with L3 build-context evidence
-(compile DB / CMake File API / Ninja / Bazel). Per ADR-028 D6 this command never runs
+rebuilding*. The pack augments an ABI snapshot with L3 build-context evidence (compile DB /
+CMake File API / Ninja / Bazel / Make dry-run / compiler-recorded metadata).
+Per ADR-028 D6 this command never runs
 arbitrary build commands: it only reads existing build outputs and build-system
 query interfaces. Anything that builds or executes project code is a separate,
 explicit opt-in not implemented here.
@@ -68,6 +69,10 @@ if TYPE_CHECKING:
               help="Pre-captured `bazel cquery --output=jsonproto` output (configured target graph).")
 @click.option("--bazel-aquery", "bazel_aquery", type=click.Path(path_type=Path), default=None,
               help="Pre-captured `bazel aquery --output=jsonproto` output (compile/link action graph).")
+@click.option("--make-dry-run", "make_dry_run", type=click.Path(path_type=Path), default=None,
+              help="Pre-captured `make -n`/`--trace` transcript (reduced-confidence compile units).")
+@click.option("--read-compiler-record", "read_compiler_record", is_flag=True, default=False,
+              help="Recover compiler provenance from --binary (.GCC.command.line / DWARF DW_AT_producer).")
 @click.option("--build-system", "build_system", default="generic", show_default=True,
               type=click.Choice(["generic", "cmake", "ninja", "bazel", "make"], case_sensitive=False),
               help="Build system hint for the compile-DB adapter.")
@@ -85,6 +90,8 @@ def collect_evidence_cmd(
     ninja_compdb: Path | None,
     bazel_cquery: Path | None,
     bazel_aquery: Path | None,
+    make_dry_run: Path | None,
+    read_compiler_record: bool,
     build_system: str,
     output: Path,
     verbose: bool,
@@ -112,6 +119,9 @@ def collect_evidence_cmd(
         ninja_compdb=ninja_compdb,
         bazel_cquery=bazel_cquery,
         bazel_aquery=bazel_aquery,
+        make_dry_run=make_dry_run,
+        binary=binary,
+        read_compiler_record=read_compiler_record,
         build_system=build_system,
         verbose=verbose,
     )
@@ -162,6 +172,9 @@ def _run_adapters(
     ninja_compdb: Path | None,
     bazel_cquery: Path | None,
     bazel_aquery: Path | None,
+    make_dry_run: Path | None,
+    binary: Path | None,
+    read_compiler_record: bool,
     build_system: str,
     verbose: bool,
 ) -> None:
@@ -171,6 +184,7 @@ def _run_adapters(
         BazelAdapter,
         CMakeFileApiAdapter,
         CompileDbAdapter,
+        MakeAdapter,
         NinjaAdapter,
     )
 
@@ -225,6 +239,29 @@ def _run_adapters(
                 f"{len(ev.targets)} targets, {len(ev.compile_units)} compile units, "
                 f"{len(ev.link_units)} link units"
             ),
+        ))
+
+    if make_dry_run is not None or (build_system.lower() == "make" and build_dir is not None
+                                    and compile_db is None):
+        ev = MakeAdapter(build_dir, dry_run=make_dry_run).collect()
+        merged.merge(ev)
+        extractors.append(ExtractorRecord(
+            name="make", status="ok" if ev.compile_units else "partial",
+            inputs=[DEFAULT_REDACTION.path(str(make_dry_run or build_dir))],
+            detail=f"{len(ev.compile_units)} compile units (reduced confidence)",
+        ))
+
+    if read_compiler_record:
+        if binary is None:
+            raise click.UsageError("--read-compiler-record requires --binary.")
+        from .evidence.compiler_record import extract_compiler_record
+        ev = extract_compiler_record(binary)
+        merged.merge(ev)
+        extractors.append(ExtractorRecord(
+            name="compiler_record",
+            status="ok" if (ev.toolchains or ev.compile_units) else "partial",
+            inputs=[DEFAULT_REDACTION.path(str(binary))],
+            detail=f"{len(ev.toolchains)} toolchains, {len(ev.compile_units)} compile units",
         ))
 
 

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -241,13 +241,14 @@ def _run_adapters(
             ),
         ))
 
-    if make_dry_run is not None or (build_system.lower() == "make" and build_dir is not None
-                                    and compile_db is None):
+    if make_dry_run is not None:
+        # Only a pre-captured transcript — the Make adapter never runs make,
+        # because `make -n` still executes `+` recipes and `$(shell …)`.
         ev = MakeAdapter(build_dir, dry_run=make_dry_run).collect()
         merged.merge(ev)
         extractors.append(ExtractorRecord(
             name="make", status="ok" if ev.compile_units else "partial",
-            inputs=[DEFAULT_REDACTION.path(str(make_dry_run or build_dir))],
+            inputs=[DEFAULT_REDACTION.path(str(make_dry_run))],
             detail=f"{len(ev.compile_units)} compile units (reduced confidence)",
         ))
 

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -16,7 +16,7 @@
 
 Collects an optional EvidencePack from an existing build tree *without
 rebuilding*. The pack augments an ABI snapshot with L3 build-context evidence
-(compile DB / CMake File API / Ninja). Per ADR-028 D6 this command never runs
+(compile DB / CMake File API / Ninja / Bazel). Per ADR-028 D6 this command never runs
 arbitrary build commands: it only reads existing build outputs and build-system
 query interfaces. Anything that builds or executes project code is a separate,
 explicit opt-in not implemented here.
@@ -64,6 +64,10 @@ if TYPE_CHECKING:
               help="Collect Ninja compile/graph facts from --build-dir via `ninja -t` queries.")
 @click.option("--ninja-compdb", "ninja_compdb", type=click.Path(path_type=Path), default=None,
               help="Pre-captured `ninja -t compdb` output (for hermetic CI / no live ninja).")
+@click.option("--bazel-cquery", "bazel_cquery", type=click.Path(path_type=Path), default=None,
+              help="Pre-captured `bazel cquery --output=jsonproto` output (configured target graph).")
+@click.option("--bazel-aquery", "bazel_aquery", type=click.Path(path_type=Path), default=None,
+              help="Pre-captured `bazel aquery --output=jsonproto` output (compile/link action graph).")
 @click.option("--build-system", "build_system", default="generic", show_default=True,
               type=click.Choice(["generic", "cmake", "ninja", "bazel", "make"], case_sensitive=False),
               help="Build system hint for the compile-DB adapter.")
@@ -79,6 +83,8 @@ def collect_evidence_cmd(
     cmake: bool,
     ninja: bool,
     ninja_compdb: Path | None,
+    bazel_cquery: Path | None,
+    bazel_aquery: Path | None,
     build_system: str,
     output: Path,
     verbose: bool,
@@ -104,6 +110,8 @@ def collect_evidence_cmd(
         cmake=cmake,
         ninja=ninja,
         ninja_compdb=ninja_compdb,
+        bazel_cquery=bazel_cquery,
+        bazel_aquery=bazel_aquery,
         build_system=build_system,
         verbose=verbose,
     )
@@ -150,12 +158,15 @@ def _run_adapters(
     cmake: bool,
     ninja: bool,
     ninja_compdb: Path | None,
+    bazel_cquery: Path | None,
+    bazel_aquery: Path | None,
     build_system: str,
     verbose: bool,
 ) -> None:
     """Run the requested build-evidence adapters and fold them into *merged*."""
     # Import adapters lazily so `collect-evidence --help` stays cheap.
     from .evidence.adapters import (
+        BazelAdapter,
         CMakeFileApiAdapter,
         CompileDbAdapter,
         NinjaAdapter,
@@ -199,6 +210,19 @@ def _run_adapters(
             name="ninja", status="ok" if ev.compile_units else "partial",
             inputs=[DEFAULT_REDACTION.path(str(build_dir or ninja_compdb))],
             detail=f"{len(ev.compile_units)} compile units",
+        ))
+
+    if bazel_cquery is not None or bazel_aquery is not None:
+        ev = BazelAdapter(cquery=bazel_cquery, aquery=bazel_aquery).collect()
+        merged.merge(ev)
+        inputs = [DEFAULT_REDACTION.path(str(p)) for p in (bazel_cquery, bazel_aquery) if p is not None]
+        extractors.append(ExtractorRecord(
+            name="bazel", status="ok" if (ev.targets or ev.compile_units) else "partial",
+            inputs=inputs,
+            detail=(
+                f"{len(ev.targets)} targets, {len(ev.compile_units)} compile units, "
+                f"{len(ev.link_units)} link units"
+            ),
         ))
 
 

--- a/abicheck/evidence/CLAUDE.md
+++ b/abicheck/evidence/CLAUDE.md
@@ -27,6 +27,8 @@ L3/L4/L5 are ordinary `ChangeKind` entries that default to `API_BREAK_KINDS`
 | `adapters/cmake_file_api.py` | CMake File API reply → targets/toolchains/fileSets | 029 D4 |
 | `adapters/ninja.py` | Ninja `-t compdb`/`graph` (live or pre-captured) | 029 D5 |
 | `adapters/bazel.py` | Bazel `cquery`/`aquery` jsonproto → targets/compile+link units (live or pre-captured) | 029 D6 |
+| `adapters/make.py` | Make `-n`/`--trace` dry-run transcript → reduced-confidence compile units | 029 D7 |
+| `compiler_record.py` | ELF `.GCC.command.line` + DWARF `DW_AT_producer` → toolchain/options (advisory) | 029 D8 |
 
 ## Versioning
 

--- a/abicheck/evidence/CLAUDE.md
+++ b/abicheck/evidence/CLAUDE.md
@@ -26,6 +26,7 @@ L3/L4/L5 are ordinary `ChangeKind` entries that default to `API_BREAK_KINDS`
 | `adapters/compile_db.py` | `compile_commands.json` → `CompileUnit`s (reuses `build_context.py`) | 029 D3 |
 | `adapters/cmake_file_api.py` | CMake File API reply → targets/toolchains/fileSets | 029 D4 |
 | `adapters/ninja.py` | Ninja `-t compdb`/`graph` (live or pre-captured) | 029 D5 |
+| `adapters/bazel.py` | Bazel `cquery`/`aquery` jsonproto → targets/compile+link units (live or pre-captured) | 029 D6 |
 
 ## Versioning
 

--- a/abicheck/evidence/adapters/__init__.py
+++ b/abicheck/evidence/adapters/__init__.py
@@ -30,6 +30,7 @@ from .base import (
 from .bazel import BazelAdapter
 from .cmake_file_api import CMakeFileApiAdapter
 from .compile_db import CompileDbAdapter
+from .make import MakeAdapter
 from .ninja import NinjaAdapter
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     "BuildAdapter",
     "CMakeFileApiAdapter",
     "CompileDbAdapter",
+    "MakeAdapter",
     "NinjaAdapter",
     "compile_unit_id",
     "detect_language",

--- a/abicheck/evidence/adapters/__init__.py
+++ b/abicheck/evidence/adapters/__init__.py
@@ -27,12 +27,14 @@ from .base import (
     detect_language,
     extract_abi_relevant_flags,
 )
+from .bazel import BazelAdapter
 from .cmake_file_api import CMakeFileApiAdapter
 from .compile_db import CompileDbAdapter
 from .ninja import NinjaAdapter
 
 __all__ = [
     "ABI_RELEVANT_FLAG_PREFIXES",
+    "BazelAdapter",
     "BuildAdapter",
     "CMakeFileApiAdapter",
     "CompileDbAdapter",

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -81,6 +81,42 @@ def detect_language(source: str) -> str:
     return ""
 
 
+#: Value-taking compiler flags whose *operand* is not the translation unit even
+#: when it looks source-like — e.g. ``-include config.hpp`` (GNU forced header),
+#: ``-x c++``, or the MSVC/clang-cl ``/FI`` / ``/FU`` forced-include/using flags.
+#: Skipping the operand keeps :func:`source_from_argv` from mistaking a forced or
+#: precompiled header for the real source. Combined MSVC forms like
+#: ``/FIconfig.hpp`` are handled by the ``/``-prefix guard.
+SOURCE_OPERAND_FLAGS: frozenset[str] = frozenset({
+    "-include", "-imacros", "-include-pch", "-Xclang", "-x",
+    "-o", "-MF", "-MT", "-MQ", "-MJ",
+    "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
+    "/FI", "/FU",
+})
+
+
+def source_from_argv(argv: list[str]) -> str:
+    """Return the first argv token that names the compiled translation unit.
+
+    Operands of value-taking flags (e.g. ``-include foo.hpp`` / ``/FI foo.hpp``)
+    are skipped so a forced/precompiled header is never mistaken for the source
+    TU. ``-``/``/``-prefixed tokens are options (never a relative source path),
+    so they are never selected — this also covers combined forms such as
+    ``/FIconfig.hpp``. The compiler at ``argv[0]`` carries no source extension,
+    so scanning from the start is safe (and handles ``cd dir && cc …`` recipes).
+    """
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in SOURCE_OPERAND_FLAGS:
+            i += 2  # skip the flag and the operand it consumes
+            continue
+        if not arg.startswith(("-", "/")) and detect_language(arg):
+            return arg
+        i += 1
+    return ""
+
+
 def compile_unit_id(source: str, argv: list[str], output: str = "") -> str:
     """Derive a stable compile-unit id from source + normalized argv + output.
 

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -102,7 +102,14 @@ def source_from_argv(argv: list[str]) -> str:
     are skipped so a forced/precompiled header is never mistaken for the source
     TU. The compiler at ``argv[0]`` carries no source extension, so scanning
     from the start is safe (and handles ``cd dir && cc …`` recipes).
+
+    Source recognition is dialect-aware: an MSVC/clang-cl command (``/c`` present
+    or a ``cl``/``clang-cl`` driver) treats every ``/``-prefixed token as an
+    option — including combined value-taking forms like ``/FIsrc/config.hpp`` —
+    so only bare, ``C:\\``-rooted, or ``/Tp``/``/Tc``-named tokens are sources.
+    A GNU command treats ``/abs/path.cc`` as a Unix absolute source path.
     """
+    msvc = _is_msvc_command(argv)
     i = 0
     while i < len(argv):
         arg = argv[i]
@@ -118,24 +125,48 @@ def source_from_argv(argv: list[str]) -> str:
             continue
         if arg[:3] in ("/Tp", "/Tc") and detect_language(arg[3:]):
             return arg[3:]
-        if _is_source_token(arg):
+        if _is_source_token(arg, msvc):
             return arg
         i += 1
     return ""
 
 
-def _is_source_token(arg: str) -> bool:
+#: Driver basenames that mark a command as MSVC-dialect (``/`` introduces an
+#: option, not a path). ``clang-cl`` mimics ``cl`` exactly.
+_MSVC_DRIVERS: frozenset[str] = frozenset({"cl", "cl.exe", "clang-cl", "clang-cl.exe"})
+
+
+def _is_msvc_command(argv: list[str]) -> bool:
+    """True if *argv* uses MSVC/clang-cl option syntax (``/opt`` not paths).
+
+    Detected either by the ``/c`` compile marker (GNU uses ``-c``) or by a
+    ``cl``/``clang-cl`` driver basename anywhere in the leading tokens (the
+    driver may be a full path, e.g. ``C:\\VS\\bin\\cl.exe``).
+    """
+    if "/c" in argv:
+        return True
+    for arg in argv:
+        if arg in ("&&", ";"):
+            break
+        base = arg.replace("\\", "/").rsplit("/", 1)[-1].lower()
+        if base in _MSVC_DRIVERS:
+            return True
+    return False
+
+
+def _is_source_token(arg: str, msvc: bool) -> bool:
     """True if *arg* is a translation-unit source path, not a compiler option.
 
-    ``-``-prefixed tokens are always options. A ``/``-prefixed token is an
-    MSVC/clang-cl option (``/c``, ``/FIconfig.hpp``, ``/Fofoo.obj``) when it has
-    no embedded path separator; one that does (e.g. ``/work/src/foo.cc``) is a
-    Unix absolute source path and is kept.
+    ``-``-prefixed tokens are always options. In an MSVC/clang-cl command every
+    ``/``-prefixed token is an option (``/c``, ``/FIsrc/config.hpp``,
+    ``/Fofoo.obj``) regardless of an embedded ``/``. In a GNU command a
+    ``/``-prefixed token with a source extension is a Unix absolute source path
+    (e.g. ``/work/src/foo.cc``) and is kept.
     """
     if not arg or arg.startswith("-"):
         return False
-    if arg.startswith("/") and "/" not in arg[1:]:
-        return False  # MSVC/clang-cl option, not an absolute path
+    if arg.startswith("/") and msvc:
+        return False  # MSVC/clang-cl option (handled before us for /Tp,/Tc)
     return bool(detect_language(arg))
 
 

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -100,10 +100,8 @@ def source_from_argv(argv: list[str]) -> str:
 
     Operands of value-taking flags (e.g. ``-include foo.hpp`` / ``/FI foo.hpp``)
     are skipped so a forced/precompiled header is never mistaken for the source
-    TU. ``-``/``/``-prefixed tokens are options (never a relative source path),
-    so they are never selected — this also covers combined forms such as
-    ``/FIconfig.hpp``. The compiler at ``argv[0]`` carries no source extension,
-    so scanning from the start is safe (and handles ``cd dir && cc …`` recipes).
+    TU. The compiler at ``argv[0]`` carries no source extension, so scanning
+    from the start is safe (and handles ``cd dir && cc …`` recipes).
     """
     i = 0
     while i < len(argv):
@@ -111,10 +109,25 @@ def source_from_argv(argv: list[str]) -> str:
         if arg in SOURCE_OPERAND_FLAGS:
             i += 2  # skip the flag and the operand it consumes
             continue
-        if not arg.startswith(("-", "/")) and detect_language(arg):
+        if _is_source_token(arg):
             return arg
         i += 1
     return ""
+
+
+def _is_source_token(arg: str) -> bool:
+    """True if *arg* is a translation-unit source path, not a compiler option.
+
+    ``-``-prefixed tokens are always options. A ``/``-prefixed token is an
+    MSVC/clang-cl option (``/c``, ``/FIconfig.hpp``, ``/Fofoo.obj``) when it has
+    no embedded path separator; one that does (e.g. ``/work/src/foo.cc``) is a
+    Unix absolute source path and is kept.
+    """
+    if not arg or arg.startswith("-"):
+        return False
+    if arg.startswith("/") and "/" not in arg[1:]:
+        return False  # MSVC/clang-cl option, not an absolute path
+    return bool(detect_language(arg))
 
 
 def compile_unit_id(source: str, argv: list[str], output: str = "") -> str:

--- a/abicheck/evidence/adapters/base.py
+++ b/abicheck/evidence/adapters/base.py
@@ -109,6 +109,15 @@ def source_from_argv(argv: list[str]) -> str:
         if arg in SOURCE_OPERAND_FLAGS:
             i += 2  # skip the flag and the operand it consumes
             continue
+        # MSVC/clang-cl name the TU explicitly with /Tp<file> (C++) / /Tc<file>
+        # (C), or the space-separated `/Tp <file>` form. Return the bare path.
+        if arg in ("/Tp", "/Tc"):
+            if i + 1 < len(argv) and detect_language(argv[i + 1]):
+                return argv[i + 1]
+            i += 2
+            continue
+        if arg[:3] in ("/Tp", "/Tc") and detect_language(arg[3:]):
+            return arg[3:]
         if _is_source_token(arg):
             return arg
         i += 1

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -401,15 +401,21 @@ def _str_list(value: object) -> list[str]:
 
 
 def _as_text(value: str | Path | None) -> str | None:
-    """Return text content for a value that may be inline text or a file path."""
+    """Return text content for a value that may be inline text or a file path.
+
+    Files are decoded with ``errors="replace"`` so a binary ``--output=proto``
+    blob (a common mistyped-output mistake) does not raise ``UnicodeDecodeError``
+    but instead flows through as non-JSON text, letting ``_load_jsonproto`` emit
+    the "pass --output=jsonproto" diagnostic rather than crashing the command.
+    """
     if value is None:
         return None
-    if isinstance(value, Path):
-        return value.read_text(encoding="utf-8") if value.is_file() else None
-    candidate = Path(value)
+    candidate = value if isinstance(value, Path) else Path(value)
     try:
         if candidate.is_file():
-            return candidate.read_text(encoding="utf-8")
+            return candidate.read_text(encoding="utf-8", errors="replace")
     except OSError:
         pass
-    return value
+    # Not a readable file: a bare string is treated as inline text; a Path that
+    # does not point at a file yields nothing (handled as a missing input).
+    return None if isinstance(value, Path) else value

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -182,14 +182,16 @@ class BazelAdapter:
         srcs = [self.redaction.path(s) for s in attrs.get("srcs", [])]
         hdrs = [self.redaction.path(h) for h in attrs.get("hdrs", [])]
         deps = [f"target://{d}" for d in attrs.get("deps", [])]
+        rule_class = str(rule.get("ruleClass", ""))
+        outputs = _str_list(rule.get("ruleOutput"))
         return Target(
             id=f"target://{name}",
             name=name.rsplit(":", 1)[-1],
-            kind=_KIND_BY_RULE.get(str(rule.get("ruleClass", "")), TargetKind.UNKNOWN),
+            kind=_target_kind_for_rule(rule_class, attrs, outputs),
             build_system="bazel",
             source_files=srcs,
             public_headers=hdrs,
-            outputs=[self.redaction.path(o) for o in _str_list(rule.get("ruleOutput"))],
+            outputs=[self.redaction.path(o) for o in outputs],
             dependencies=deps,
             visibility="public" if hdrs else "unknown",
             # Graph facts (kind/deps/outputs) are high-confidence; header intent
@@ -399,11 +401,37 @@ def _is_link_input(path: str) -> bool:
 
 def _link_kind(output: str) -> str:
     low = output.lower()
-    if low.endswith((".so", ".dylib")) or ".so." in low:
+    if low.endswith((".so", ".dylib", ".dll")) or ".so." in low:
         return "shared_library"
     if low.endswith((".a", ".lib")):
         return "static_library"
     return "executable"
+
+
+def _target_kind_for_rule(
+    rule_class: str, attrs: dict[str, list[str]], outputs: list[str]
+) -> TargetKind:
+    """Map a cquery rule to a TargetKind, honoring ``linkshared`` cc_binaries.
+
+    A ``cc_binary`` (or ``cc_test``) built with ``linkshared = True`` — Bazel's
+    supported way to produce a shared library — emits a ``.so``/``.dll`` rather
+    than an executable, so classify it as a shared library instead of defaulting
+    every ``cc_binary`` to ``EXECUTABLE``.
+    """
+    base = _KIND_BY_RULE.get(rule_class, TargetKind.UNKNOWN)
+    if base is TargetKind.EXECUTABLE and (
+        _is_truthy(attrs.get("linkshared"))
+        or any(_link_kind(o) == "shared_library" for o in outputs)
+    ):
+        return TargetKind.SHARED_LIBRARY
+    return base
+
+
+def _is_truthy(values: list[str] | None) -> bool:
+    """True if a parsed attribute carries a truthy boolean/int value."""
+    if not values:
+        return False
+    return values[0].strip().lower() in ("true", "1")
 
 
 #: Space-separated flags whose *operand* is not the translation unit even if it
@@ -436,7 +464,12 @@ def _source_from_argv(argv: list[str]) -> str:
 
 
 def _attr_map(attributes: object) -> dict[str, list[str]]:
-    """Collapse a rule's ``attribute`` list into {name: [string-list values]}."""
+    """Collapse a rule's ``attribute`` list into {name: [scalar/list values]}.
+
+    Captures label/string lists (``srcs``/``hdrs``/``deps``) plus scalar string,
+    boolean, and int values (e.g. ``linkshared``) so callers can read them
+    uniformly as a one-element list.
+    """
     out: dict[str, list[str]] = {}
     for attr in _dicts(attributes):
         name = str(attr.get("name", ""))
@@ -445,6 +478,10 @@ def _attr_map(attributes: object) -> dict[str, list[str]]:
         values = _str_list(attr.get("stringListValue"))
         if not values and attr.get("stringValue"):
             values = [str(attr.get("stringValue"))]
+        if not values and "booleanValue" in attr:
+            values = [str(attr.get("booleanValue"))]
+        if not values and "intValue" in attr:
+            values = [str(attr.get("intValue"))]
         if values:
             out[name] = values
     return out

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -205,6 +205,10 @@ class BazelAdapter:
         attrs = _attr_map(rule.get("attribute", []))
         srcs = [self.redaction.path(s) for s in attrs.get("srcs", [])]
         hdrs = [self.redaction.path(h) for h in attrs.get("hdrs", [])]
+        # ``deps`` are Bazel labels used as graph keys: they must stay in the
+        # same (un-redacted) form as the ``target://<label>`` target ids so the
+        # dependency edges resolve. Labels are not host paths, so there is
+        # nothing to redact anyway.
         deps = [f"target://{d}" for d in attrs.get("deps", [])]
         rule_class = str(rule.get("ruleClass", ""))
         outputs = _str_list(rule.get("ruleOutput"))
@@ -476,7 +480,7 @@ _SOURCE_OPERAND_FLAGS = frozenset({
     "-include", "-imacros", "-include-pch", "-Xclang", "-x",
     "-o", "-MF", "-MT", "-MQ", "-MJ",
     "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
-    "/FI", "/FU", "/Fi", "/Fu",
+    "/FI", "/FU",
 })
 
 

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -224,10 +224,13 @@ class BazelAdapter:
         output = graph.path(action.get("primaryOutputId"))
         red_argv = self.redaction.argv(argv)
         red_source = self.redaction.path(source)
+        red_output = self.redaction.path(output)
         return CompileUnit(
-            id=compile_unit_id(red_source, red_argv, output),
+            # Derive the id from redacted values only so host-specific paths
+            # never leak through the id (ADR-028 D4: normalized facts only).
+            id=compile_unit_id(red_source, red_argv, red_output),
             source=red_source,
-            output=self.redaction.path(output),
+            output=red_output,
             target_id=graph.target_id(action.get("targetId")),
             argv=red_argv,
             language=detect_language(source),

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -352,11 +352,32 @@ def _link_kind(output: str) -> str:
     return "executable"
 
 
+#: Space-separated flags whose *operand* is not the translation unit even if it
+#: looks source-like — e.g. ``-include config.hpp`` (forced header) or ``-x c++``.
+#: Skipping the operand keeps ``_source_from_argv`` from mistaking a forced or
+#: precompiled header for the real source.
+_SOURCE_OPERAND_FLAGS = frozenset({
+    "-include", "-imacros", "-include-pch", "-Xclang", "-x",
+    "-o", "-MF", "-MT", "-MQ", "-MJ",
+    "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
+})
+
+
 def _source_from_argv(argv: list[str]) -> str:
-    """Return the first argv token that names a compilable source file."""
-    for arg in argv[1:]:
+    """Return the first argv token that names the compiled translation unit.
+
+    Operands of value-taking flags (e.g. ``-include foo.hpp``) are skipped so a
+    forced/precompiled header is never mistaken for the source TU.
+    """
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+        if arg in _SOURCE_OPERAND_FLAGS:
+            i += 2  # skip the flag and the operand it consumes
+            continue
         if not arg.startswith("-") and detect_language(arg):
             return arg
+        i += 1
     return ""
 
 

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -57,6 +57,7 @@ from .base import (
     derive_build_options,
     detect_language,
     extract_abi_relevant_flags,
+    source_from_argv,
 )
 
 # Bazel rule class → normalized TargetKind. cc_library defaults to an archive;
@@ -247,7 +248,7 @@ class BazelAdapter:
 
     def _compile_unit(self, action: dict[str, object], graph: _AqueryGraph) -> CompileUnit | None:
         argv = _action_argv(action)
-        source = _source_from_argv(argv)
+        source = source_from_argv(argv)
         if not source:
             return None
         ctx = _extract_flags(argv, Path("."))
@@ -471,19 +472,6 @@ def _is_truthy(values: list[str] | None) -> bool:
 
 
 #: Space-separated flags whose *operand* is not the translation unit even if it
-#: looks source-like — e.g. ``-include config.hpp`` (forced header) or ``-x c++``,
-#: plus the MSVC/clang-cl forced-include/forced-using flags ``/FI`` / ``/FU``.
-#: Skipping the operand keeps ``_source_from_argv`` from mistaking a forced or
-#: precompiled header for the real source. (Combined MSVC forms like
-#: ``/FIconfig.hpp`` are handled by the ``/``-prefix guard below.)
-_SOURCE_OPERAND_FLAGS = frozenset({
-    "-include", "-imacros", "-include-pch", "-Xclang", "-x",
-    "-o", "-MF", "-MT", "-MQ", "-MJ",
-    "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
-    "/FI", "/FU",
-})
-
-
 def _action_argv(action: dict[str, object]) -> list[str]:
     """Return an action's full argv, expanding ``@...params`` param files.
 
@@ -525,27 +513,6 @@ def _action_argv(action: dict[str, object]) -> list[str]:
             out.extend(args)
     out.extend(no_token)
     return out
-
-
-def _source_from_argv(argv: list[str]) -> str:
-    """Return the first argv token that names the compiled translation unit.
-
-    Operands of value-taking flags (e.g. ``-include foo.hpp`` / ``/FI foo.hpp``)
-    are skipped so a forced/precompiled header is never mistaken for the source
-    TU. ``/``-prefixed tokens are MSVC/clang-cl options (never a Bazel relative
-    exec-path source), so they are never selected — this also covers combined
-    forms such as ``/FIconfig.hpp`` and ``/Yustdafx.h``.
-    """
-    i = 1
-    while i < len(argv):
-        arg = argv[i]
-        if arg in _SOURCE_OPERAND_FLAGS:
-            i += 2  # skip the flag and the operand it consumes
-            continue
-        if not arg.startswith(("-", "/")) and detect_language(arg):
-            return arg
-        i += 1
-    return ""
 
 
 def _attr_map(attributes: object) -> dict[str, list[str]]:

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -467,13 +467,16 @@ def _is_truthy(values: list[str] | None) -> bool:
 
 
 #: Space-separated flags whose *operand* is not the translation unit even if it
-#: looks source-like — e.g. ``-include config.hpp`` (forced header) or ``-x c++``.
+#: looks source-like — e.g. ``-include config.hpp`` (forced header) or ``-x c++``,
+#: plus the MSVC/clang-cl forced-include/forced-using flags ``/FI`` / ``/FU``.
 #: Skipping the operand keeps ``_source_from_argv`` from mistaking a forced or
-#: precompiled header for the real source.
+#: precompiled header for the real source. (Combined MSVC forms like
+#: ``/FIconfig.hpp`` are handled by the ``/``-prefix guard below.)
 _SOURCE_OPERAND_FLAGS = frozenset({
     "-include", "-imacros", "-include-pch", "-Xclang", "-x",
     "-o", "-MF", "-MT", "-MQ", "-MJ",
     "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
+    "/FI", "/FU", "/Fi", "/Fu",
 })
 
 
@@ -523,8 +526,11 @@ def _action_argv(action: dict[str, object]) -> list[str]:
 def _source_from_argv(argv: list[str]) -> str:
     """Return the first argv token that names the compiled translation unit.
 
-    Operands of value-taking flags (e.g. ``-include foo.hpp``) are skipped so a
-    forced/precompiled header is never mistaken for the source TU.
+    Operands of value-taking flags (e.g. ``-include foo.hpp`` / ``/FI foo.hpp``)
+    are skipped so a forced/precompiled header is never mistaken for the source
+    TU. ``/``-prefixed tokens are MSVC/clang-cl options (never a Bazel relative
+    exec-path source), so they are never selected — this also covers combined
+    forms such as ``/FIconfig.hpp`` and ``/Yustdafx.h``.
     """
     i = 1
     while i < len(argv):
@@ -532,7 +538,7 @@ def _source_from_argv(argv: list[str]) -> str:
         if arg in _SOURCE_OPERAND_FLAGS:
             i += 2  # skip the flag and the operand it consumes
             continue
-        if not arg.startswith("-") and detect_language(arg):
+        if not arg.startswith(("-", "/")) and detect_language(arg):
             return arg
         i += 1
     return ""

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -482,13 +482,42 @@ def _action_argv(action: dict[str, object]) -> list[str]:
 
     Bazel moves the bulk of a large C++ action's command line into param files;
     with ``--include_param_files`` aquery emits their contents under
-    ``paramFiles[].arguments``. Appending them lets source/flag extraction see
-    the real translation unit and ABI options instead of just ``@file`` refs.
+    ``paramFiles[].arguments`` together with the file's ``execPath``. Each param
+    file is substituted **in place** of its matching ``@<execPath>`` argv token
+    so ordering is preserved — important because ``_extract_flags`` keeps the
+    *last* ``-std`` it sees, so appending instead of substituting could record
+    the wrong ABI flags. Param files without a known ``@token`` (or no
+    ``execPath``) are appended as a fallback so their facts are not lost.
     """
     argv = _str_list(action.get("arguments"))
-    for pf in _dicts(action.get("paramFiles")):
-        argv.extend(_str_list(pf.get("arguments")))
-    return argv
+    param_files = _dicts(action.get("paramFiles"))
+    if not param_files:
+        return argv
+
+    by_token: dict[str, list[str]] = {}
+    no_token: list[str] = []
+    for pf in param_files:
+        exec_path = str(pf.get("execPath", ""))
+        args = _str_list(pf.get("arguments"))
+        if exec_path:
+            by_token["@" + exec_path] = args
+        else:
+            no_token.extend(args)
+
+    out: list[str] = []
+    seen_tokens: set[str] = set()
+    for tok in argv:
+        if tok in by_token:
+            out.extend(by_token[tok])
+            seen_tokens.add(tok)
+        else:
+            out.append(tok)
+    # Param files whose @token never appeared in argv: append defensively.
+    for token, args in by_token.items():
+        if token not in seen_tokens:
+            out.extend(args)
+    out.extend(no_token)
+    return out
 
 
 def _source_from_argv(argv: list[str]) -> str:

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -122,6 +122,14 @@ class BazelAdapter:
         text = _as_text(value)
         if text is not None:
             return text
+        if value is not None:
+            # A pre-captured path was supplied but could not be read (e.g. a
+            # mistyped --bazel-cquery path). Surface it rather than silently
+            # producing an empty, apparently-valid pack.
+            ev.diagnostics.append(
+                f"bazel: {kind} input not found or unreadable: {self.redaction.path(str(value))}"
+            )
+            return None
         if self.workspace is not None and self.target is not None and self.allow_query:
             return self._run_bazel(kind, ev)
         return None
@@ -237,7 +245,7 @@ class BazelAdapter:
         output = graph.path(action.get("primaryOutputId"))
         if not output:
             return None
-        inputs = [p for p in graph.input_paths(action) if p.endswith((".o", ".obj", ".a"))]
+        inputs = [p for p in graph.input_paths(action) if _is_link_input(p)]
         red_output = self.redaction.path(output)
         return LinkUnit(
             id=f"link://{red_output}",
@@ -316,6 +324,20 @@ class _AqueryGraph:
             artifacts.extend(_str_list(ds.get("directArtifactIds")))
             stack.extend(_str_list(ds.get("transitiveDepSetIds")))
         return artifacts
+
+
+def _is_link_input(path: str) -> bool:
+    """True for object files and libraries a link action consumes.
+
+    Keeps object files/archives *and* shared libraries (``.so``, versioned
+    ``.so.1.2``, ``.dylib``, ``.dll``) so a binary/library that links against a
+    shared lib still records that dependency (ADR-029 D6); drops everything else
+    (headers, command files, …).
+    """
+    low = path.lower()
+    if low.endswith((".o", ".obj", ".a", ".lib", ".so", ".dylib", ".dll")):
+        return True
+    return ".so." in low  # versioned shared object, e.g. libfoo.so.1.2
 
 
 def _link_kind(output: str) -> str:

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -168,12 +168,13 @@ class BazelAdapter:
         if data is None:
             return
         # A single label can appear under several configurations (target vs exec)
-        # with different deps/attrs. Collect the rule + config first so we can
-        # disambiguate the id by configuration only for labels that actually span
-        # more than one — keeping the common single-config id plain so it still
-        # matches the label-only target ids that aquery emits.
+        # with different deps/attrs. Collect the rule + config first; the first
+        # config seen for a label is "canonical" and keeps the plain
+        # ``target://label`` id so aquery's label-only target ids still resolve to
+        # a collected Target. Additional configs are preserved under a
+        # ``#cfg:<id>`` suffix instead of being dropped.
         entries: list[tuple[dict[str, object], str]] = []
-        configs_per_label: dict[str, set[str]] = {}
+        canonical_cfg: dict[str, str] = {}
         for ct in _dicts(data.get("results")):
             target_obj = ct.get("target")
             rule = target_obj.get("rule") if isinstance(target_obj, dict) else None
@@ -184,14 +185,14 @@ class BazelAdapter:
                 continue
             cfg = str(ct.get("configurationId", "") or "")
             entries.append((rule, cfg))
-            configs_per_label.setdefault(name, set()).add(cfg)
+            canonical_cfg.setdefault(name, cfg)
 
         seen: set[str] = set()
         for rule, cfg in entries:
             target = self._target_from_rule(rule)
             if target is None:
                 continue
-            if cfg and len(configs_per_label[str(rule.get("name", ""))]) > 1:
+            if cfg and cfg != canonical_cfg.get(str(rule.get("name", ""))):
                 target.id = f"{target.id}#cfg:{cfg}"
             if target.id not in seen:
                 ev.targets.append(target)

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -167,14 +167,33 @@ class BazelAdapter:
         data = _load_jsonproto(text, "cquery", ev)
         if data is None:
             return
-        seen: set[str] = set()
+        # A single label can appear under several configurations (target vs exec)
+        # with different deps/attrs. Collect the rule + config first so we can
+        # disambiguate the id by configuration only for labels that actually span
+        # more than one — keeping the common single-config id plain so it still
+        # matches the label-only target ids that aquery emits.
+        entries: list[tuple[dict[str, object], str]] = []
+        configs_per_label: dict[str, set[str]] = {}
         for ct in _dicts(data.get("results")):
             target_obj = ct.get("target")
             rule = target_obj.get("rule") if isinstance(target_obj, dict) else None
             if not isinstance(rule, dict):
                 continue
+            name = str(rule.get("name", ""))
+            if not name:
+                continue
+            cfg = str(ct.get("configurationId", "") or "")
+            entries.append((rule, cfg))
+            configs_per_label.setdefault(name, set()).add(cfg)
+
+        seen: set[str] = set()
+        for rule, cfg in entries:
             target = self._target_from_rule(rule)
-            if target is not None and target.id not in seen:
+            if target is None:
+                continue
+            if cfg and len(configs_per_label[str(rule.get("name", ""))]) > 1:
+                target.id = f"{target.id}#cfg:{cfg}"
+            if target.id not in seen:
                 ev.targets.append(target)
                 seen.add(target.id)
 

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -1,0 +1,393 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel adapter (ADR-029 D6).
+
+Consumes Bazel's official query outputs rather than parsing ``BUILD`` files:
+
+- ``bazel cquery ... --output=jsonproto`` → the *configured* target graph
+  (target kinds, ``deps`` after ``select()``, sources, public headers);
+- ``bazel aquery ... --output=jsonproto`` → the action graph (exact compile and
+  link argv, inputs, outputs, mnemonics).
+
+Both are *analysis* queries of an existing workspace — they do not build the
+project (ADR-028 D6 / ADR-029 D10). Like the Ninja adapter, ``collect`` also
+accepts **pre-captured** query output (inline JSON text or a file path) so the
+fast lane and hermetic CI never need a live ``bazel``.
+
+Confidence rules (ADR-029 D6): ``aquery`` actions are high-confidence for
+commands/inputs/outputs and ``cquery`` is high-confidence for the configured
+target graph; public/private header *intent* is reduced confidence because it
+depends on rule-specific conventions rather than an explicit visibility model.
+
+Only the textual ``jsonproto`` form is parsed; a binary proto blob is recorded
+as a diagnostic rather than mis-read (pass ``--output=jsonproto``).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from ...build_context import _extract_flags
+from ..build_evidence import (
+    BuildEvidence,
+    CompileUnit,
+    Confidence,
+    Generator,
+    LinkUnit,
+    Target,
+    TargetKind,
+)
+from ..redaction import DEFAULT_REDACTION, RedactionPolicy
+from .base import (
+    compile_unit_id,
+    derive_build_options,
+    detect_language,
+    extract_abi_relevant_flags,
+)
+
+# Bazel rule class → normalized TargetKind. cc_library defaults to an archive;
+# its optional shared output is modelled separately by the linkstatic action.
+_KIND_BY_RULE: dict[str, TargetKind] = {
+    "cc_binary": TargetKind.EXECUTABLE,
+    "cc_test": TargetKind.EXECUTABLE,
+    "cc_library": TargetKind.STATIC_LIBRARY,
+    "cc_shared_library": TargetKind.SHARED_LIBRARY,
+    "objc_library": TargetKind.STATIC_LIBRARY,
+}
+
+#: aquery mnemonics that denote a compile action (one translation unit).
+_COMPILE_MNEMONICS = frozenset(
+    {"CppCompile", "CCompile", "CcCompile", "ObjcCompile", "ObjcppCompile", "CppModuleCompile"}
+)
+#: aquery mnemonics that denote a link/archive action (one library/executable).
+_LINK_MNEMONICS = frozenset({"CppLink", "CppArchive", "CcLink"})
+
+
+class BazelAdapter:
+    """Normalize Bazel ``cquery``/``aquery`` jsonproto into :class:`BuildEvidence`."""
+
+    name = "bazel"
+
+    def __init__(
+        self,
+        workspace: Path | str | None = None,
+        *,
+        target: str | None = None,
+        cquery: str | Path | None = None,
+        aquery: str | Path | None = None,
+        allow_query: bool = True,
+        redaction: RedactionPolicy | None = None,
+    ) -> None:
+        self.workspace = Path(workspace) if workspace is not None else None
+        self.target = target
+        self._cquery = cquery
+        self._aquery = aquery
+        self.allow_query = allow_query
+        self.redaction = redaction or DEFAULT_REDACTION
+
+    def collect(self) -> BuildEvidence:
+        ev = BuildEvidence()
+        ev.generators.append(Generator(kind="bazel"))
+
+        cq_text = self._resolve("cquery", self._cquery, ev)
+        if cq_text is not None:
+            self._collect_cquery(cq_text, ev)
+
+        aq_text = self._resolve("aquery", self._aquery, ev)
+        if aq_text is not None:
+            self._collect_aquery(aq_text, ev)
+
+        # Project per-unit ABI flags into diffable build options, same as every
+        # other adapter, so a Bazel-only pack still reports flag drift (D9).
+        ev.build_options = derive_build_options(ev.compile_units)
+        return ev
+
+    # -- input resolution ---------------------------------------------------
+
+    def _resolve(self, kind: str, value: str | Path | None, ev: BuildEvidence) -> str | None:
+        text = _as_text(value)
+        if text is not None:
+            return text
+        if self.workspace is not None and self.target is not None and self.allow_query:
+            return self._run_bazel(kind, ev)
+        return None
+
+    def _run_bazel(self, kind: str, ev: BuildEvidence) -> str | None:
+        bazel = shutil.which("bazel") or shutil.which("bazelisk")
+        if bazel is None or self.workspace is None or self.target is None:
+            ev.diagnostics.append(f"bazel: executable not found on PATH; cannot run {kind}")
+            return None
+        cmd = [bazel, kind, f"deps({self.target})", "--output=jsonproto"]
+        try:
+            # An analysis query of an existing workspace (ADR-028 D6 / D10) —
+            # never a build action.
+            proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+                cmd, cwd=str(self.workspace), capture_output=True, text=True,
+                timeout=300, check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            ev.diagnostics.append(f"bazel: {kind} failed: {exc}")
+            return None
+        if proc.returncode != 0:
+            ev.diagnostics.append(
+                f"bazel: {kind} exited {proc.returncode}: {proc.stderr.strip()[:200]}"
+            )
+            return None
+        return proc.stdout
+
+    # -- cquery: configured target graph ------------------------------------
+
+    def _collect_cquery(self, text: str, ev: BuildEvidence) -> None:
+        data = _load_jsonproto(text, "cquery", ev)
+        if data is None:
+            return
+        seen: set[str] = set()
+        for ct in _dicts(data.get("results")):
+            target_obj = ct.get("target")
+            rule = target_obj.get("rule") if isinstance(target_obj, dict) else None
+            if not isinstance(rule, dict):
+                continue
+            target = self._target_from_rule(rule)
+            if target is not None and target.id not in seen:
+                ev.targets.append(target)
+                seen.add(target.id)
+
+    def _target_from_rule(self, rule: dict[str, object]) -> Target | None:
+        name = str(rule.get("name", ""))
+        if not name:
+            return None
+        attrs = _attr_map(rule.get("attribute", []))
+        srcs = [self.redaction.path(s) for s in attrs.get("srcs", [])]
+        hdrs = [self.redaction.path(h) for h in attrs.get("hdrs", [])]
+        deps = [f"target://{d}" for d in attrs.get("deps", [])]
+        return Target(
+            id=f"target://{name}",
+            name=name.rsplit(":", 1)[-1],
+            kind=_KIND_BY_RULE.get(str(rule.get("ruleClass", "")), TargetKind.UNKNOWN),
+            build_system="bazel",
+            source_files=srcs,
+            public_headers=hdrs,
+            outputs=[self.redaction.path(o) for o in _str_list(rule.get("ruleOutput"))],
+            dependencies=deps,
+            visibility="public" if hdrs else "unknown",
+            # Graph facts (kind/deps/outputs) are high-confidence; header intent
+            # is heuristic, but the dominant target facts justify HIGH here.
+            confidence=Confidence.HIGH,
+        )
+
+    # -- aquery: action graph -----------------------------------------------
+
+    def _collect_aquery(self, text: str, ev: BuildEvidence) -> None:
+        data = _load_jsonproto(text, "aquery", ev)
+        if data is None:
+            return
+        graph = _AqueryGraph(data)
+        for action in _dicts(data.get("actions")):
+            mnemonic = str(action.get("mnemonic", ""))
+            if mnemonic in _COMPILE_MNEMONICS:
+                cu = self._compile_unit(action, graph)
+                if cu is not None:
+                    ev.compile_units.append(cu)
+            elif mnemonic in _LINK_MNEMONICS:
+                lu = self._link_unit(action, graph)
+                if lu is not None:
+                    ev.link_units.append(lu)
+
+    def _compile_unit(self, action: dict[str, object], graph: _AqueryGraph) -> CompileUnit | None:
+        argv = _str_list(action.get("arguments"))
+        source = _source_from_argv(argv)
+        if not source:
+            return None
+        ctx = _extract_flags(argv, Path("."))
+        output = graph.path(action.get("primaryOutputId"))
+        red_argv = self.redaction.argv(argv)
+        red_source = self.redaction.path(source)
+        return CompileUnit(
+            id=compile_unit_id(red_source, red_argv, output),
+            source=red_source,
+            output=self.redaction.path(output),
+            target_id=graph.target_id(action.get("targetId")),
+            argv=red_argv,
+            language=detect_language(source),
+            standard=ctx.language_standard or "",
+            defines={k: self.redaction.define_value(k, v or "") for k, v in ctx.defines.items()},
+            undefines=sorted(ctx.undefines),
+            include_paths=[self.redaction.path(str(p)) for p in ctx.include_paths],
+            system_include_paths=[self.redaction.path(str(p)) for p in ctx.system_includes],
+            sysroot=self.redaction.path(str(ctx.sysroot)) if ctx.sysroot else None,
+            target_triple=ctx.target_triple or "",
+            abi_relevant_flags=[self.redaction.arg(f) for f in extract_abi_relevant_flags(argv)],
+        )
+
+    def _link_unit(self, action: dict[str, object], graph: _AqueryGraph) -> LinkUnit | None:
+        output = graph.path(action.get("primaryOutputId"))
+        if not output:
+            return None
+        inputs = [p for p in graph.input_paths(action) if p.endswith((".o", ".obj", ".a"))]
+        red_output = self.redaction.path(output)
+        return LinkUnit(
+            id=f"link://{red_output}",
+            target_id=graph.target_id(action.get("targetId")),
+            output=red_output,
+            kind=_link_kind(output),
+            inputs=[self.redaction.path(p) for p in inputs],
+            linker_argv=self.redaction.argv(_str_list(action.get("arguments"))),
+        )
+
+
+class _AqueryGraph:
+    """Resolves aquery artifact ids to exec paths and action targets to labels.
+
+    aquery jsonproto stores paths as a deduplicated fragment tree: each artifact
+    points at a ``pathFragment`` whose ``parentId`` chain spells the exec path.
+    Inputs are referenced indirectly through ``depSetOfFiles`` nesting.
+    """
+
+    def __init__(self, data: dict[str, object]) -> None:
+        self._frag = {
+            str(f.get("id")): (str(f.get("label", "")), f.get("parentId"))
+            for f in _dicts(data.get("pathFragments"))
+        }
+        self._artifact_frag = {
+            str(a.get("id")): str(a.get("pathFragmentId"))
+            for a in _dicts(data.get("artifacts"))
+        }
+        self._labels = {
+            str(t.get("id")): str(t.get("label", ""))
+            for t in _dicts(data.get("targets"))
+        }
+        self._depsets = {
+            str(d.get("id")): d
+            for d in _dicts(data.get("depSetOfFiles"))
+        }
+
+    def path(self, artifact_id: object) -> str:
+        if artifact_id is None:
+            return ""
+        frag_id: object = self._artifact_frag.get(str(artifact_id))
+        parts: list[str] = []
+        seen: set[str] = set()
+        while frag_id is not None and str(frag_id) in self._frag and str(frag_id) not in seen:
+            seen.add(str(frag_id))
+            label, parent = self._frag[str(frag_id)]
+            if label:
+                parts.append(label)
+            frag_id = parent
+        return "/".join(reversed(parts))
+
+    def target_id(self, target_id: object) -> str:
+        label = self._labels.get(str(target_id), "") if target_id is not None else ""
+        return f"target://{label}" if label else ""
+
+    def input_paths(self, action: dict[str, object]) -> list[str]:
+        out: list[str] = []
+        for art_id in self._flatten_depsets(_str_list(action.get("inputDepSetIds"))):
+            p = self.path(art_id)
+            if p:
+                out.append(p)
+        return out
+
+    def _flatten_depsets(self, depset_ids: list[str]) -> list[str]:
+        artifacts: list[str] = []
+        seen: set[str] = set()
+        stack = list(depset_ids)
+        while stack:
+            ds_id = stack.pop()
+            if ds_id in seen:
+                continue
+            seen.add(ds_id)
+            ds = self._depsets.get(ds_id)
+            if ds is None:
+                continue
+            artifacts.extend(_str_list(ds.get("directArtifactIds")))
+            stack.extend(_str_list(ds.get("transitiveDepSetIds")))
+        return artifacts
+
+
+def _link_kind(output: str) -> str:
+    low = output.lower()
+    if low.endswith((".so", ".dylib")) or ".so." in low:
+        return "shared_library"
+    if low.endswith((".a", ".lib")):
+        return "static_library"
+    return "executable"
+
+
+def _source_from_argv(argv: list[str]) -> str:
+    """Return the first argv token that names a compilable source file."""
+    for arg in argv[1:]:
+        if not arg.startswith("-") and detect_language(arg):
+            return arg
+    return ""
+
+
+def _attr_map(attributes: object) -> dict[str, list[str]]:
+    """Collapse a rule's ``attribute`` list into {name: [string-list values]}."""
+    out: dict[str, list[str]] = {}
+    for attr in _dicts(attributes):
+        name = str(attr.get("name", ""))
+        if not name:
+            continue
+        values = _str_list(attr.get("stringListValue"))
+        if not values and attr.get("stringValue"):
+            values = [str(attr.get("stringValue"))]
+        if values:
+            out[name] = values
+    return out
+
+
+def _load_jsonproto(text: str, kind: str, ev: BuildEvidence) -> dict[str, object] | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        ev.diagnostics.append(
+            f"bazel: could not parse {kind} output as jsonproto ({exc}); "
+            "pass --output=jsonproto (binary proto is not supported)"
+        )
+        return None
+    if not isinstance(data, dict):
+        ev.diagnostics.append(f"bazel: {kind} jsonproto was not a JSON object")
+        return None
+    return data
+
+
+def _dicts(value: object) -> list[dict[str, object]]:
+    """Return only the dict members of a list (defensive jsonproto parsing)."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _str_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _as_text(value: str | Path | None) -> str | None:
+    """Return text content for a value that may be inline text or a file path."""
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        return value.read_text(encoding="utf-8") if value.is_file() else None
+    candidate = Path(value)
+    try:
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    except OSError:
+        pass
+    return value

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -140,6 +140,10 @@ class BazelAdapter:
             ev.diagnostics.append(f"bazel: executable not found on PATH; cannot run {kind}")
             return None
         cmd = [bazel, kind, f"deps({self.target})", "--output=jsonproto"]
+        if kind == "aquery":
+            # Without this, large C++ actions keep their argv in @...params files
+            # and the source/ABI flags never reach the jsonproto (ADR-029 D6).
+            cmd.append("--include_param_files")
         try:
             # An analysis query of an existing workspace (ADR-028 D6 / D10) —
             # never a build action.
@@ -218,7 +222,7 @@ class BazelAdapter:
                     ev.link_units.append(lu)
 
     def _compile_unit(self, action: dict[str, object], graph: _AqueryGraph) -> CompileUnit | None:
-        argv = _str_list(action.get("arguments"))
+        argv = _action_argv(action)
         source = _source_from_argv(argv)
         if not source:
             return None
@@ -252,7 +256,7 @@ class BazelAdapter:
             return None
         inputs = [p for p in graph.input_paths(action) if _is_link_input(p)]
         red_output = self.redaction.path(output)
-        argv = _str_list(action.get("arguments"))
+        argv = _action_argv(action)
         version_script, soname = _export_policy_from_argv(argv)
         return LinkUnit(
             id=f"link://{red_output}",
@@ -443,6 +447,20 @@ _SOURCE_OPERAND_FLAGS = frozenset({
     "-o", "-MF", "-MT", "-MQ", "-MJ",
     "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
 })
+
+
+def _action_argv(action: dict[str, object]) -> list[str]:
+    """Return an action's full argv, expanding ``@...params`` param files.
+
+    Bazel moves the bulk of a large C++ action's command line into param files;
+    with ``--include_param_files`` aquery emits their contents under
+    ``paramFiles[].arguments``. Appending them lets source/flag extraction see
+    the real translation unit and ABI options instead of just ``@file`` refs.
+    """
+    argv = _str_list(action.get("arguments"))
+    for pf in _dicts(action.get("paramFiles")):
+        argv.extend(_str_list(pf.get("arguments")))
+    return argv
 
 
 def _source_from_argv(argv: list[str]) -> str:

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -383,9 +383,10 @@ def _export_policy_from_argv(argv: list[str]) -> tuple[str, str]:
 
     Handles the common GNU/Clang spellings whether passed directly or via
     ``-Wl,`` / ``-Xlinker``: ``--version-script=FILE`` / ``--version-script FILE``
-    and ``-soname NAME`` / ``-h NAME`` / ``-soname=NAME``. These structured
-    fields feed the export-policy diff (ADR-029 D9); raw argv alone is not
-    indexed there.
+    and ``-soname NAME`` / ``-h NAME`` / ``-soname=NAME``, plus the MSVC/clang-cl
+    module-definition file ``/DEF:FILE`` / ``/DEF FILE`` (recorded as the
+    ``version_script`` export map). These structured fields feed the
+    export-policy diff (ADR-029 D9); raw argv alone is not indexed there.
     """
     tokens = _linker_tokens(argv)
     version_script = ""
@@ -393,9 +394,16 @@ def _export_policy_from_argv(argv: list[str]) -> tuple[str, str]:
     i = 0
     while i < len(tokens):
         tok = tokens[i]
+        upper = tok.upper()
         if tok.startswith("--version-script="):
             version_script = tok.split("=", 1)[1]
         elif tok == "--version-script" and i + 1 < len(tokens):
+            version_script = tokens[i + 1]
+            i += 2
+            continue
+        elif upper.startswith("/DEF:"):  # MSVC module-definition (not /DEFAULTLIB:)
+            version_script = tok.split(":", 1)[1]
+        elif upper == "/DEF" and i + 1 < len(tokens):
             version_script = tokens[i + 1]
             i += 2
             continue

--- a/abicheck/evidence/adapters/bazel.py
+++ b/abicheck/evidence/adapters/bazel.py
@@ -250,13 +250,19 @@ class BazelAdapter:
             return None
         inputs = [p for p in graph.input_paths(action) if _is_link_input(p)]
         red_output = self.redaction.path(output)
+        argv = _str_list(action.get("arguments"))
+        version_script, soname = _export_policy_from_argv(argv)
         return LinkUnit(
             id=f"link://{red_output}",
             target_id=graph.target_id(action.get("targetId")),
             output=red_output,
             kind=_link_kind(output),
             inputs=[self.redaction.path(p) for p in inputs],
-            linker_argv=self.redaction.argv(_str_list(action.get("arguments"))),
+            linker_argv=self.redaction.argv(argv),
+            # Surface export-policy facts structurally so the build-evidence diff
+            # can report LINK_EXPORT_POLICY_CHANGED (D9); empty when absent.
+            version_script=self.redaction.path(version_script) if version_script else "",
+            soname=soname,
         )
 
 
@@ -327,6 +333,54 @@ class _AqueryGraph:
             artifacts.extend(_str_list(ds.get("directArtifactIds")))
             stack.extend(_str_list(ds.get("transitiveDepSetIds")))
         return artifacts
+
+
+def _linker_tokens(argv: list[str]) -> list[str]:
+    """Flatten linker sub-options into individual tokens.
+
+    ``-Wl,a,b`` groups are split on commas; bare ``-Xlinker`` markers are
+    dropped so the linker arg they introduce becomes a plain token.
+    """
+    tokens: list[str] = []
+    for arg in argv:
+        if arg == "-Xlinker":
+            continue
+        if arg.startswith("-Wl,"):
+            tokens.extend(arg[len("-Wl,"):].split(","))
+        else:
+            tokens.append(arg)
+    return tokens
+
+
+def _export_policy_from_argv(argv: list[str]) -> tuple[str, str]:
+    """Extract (version_script, soname) from a link action's arguments.
+
+    Handles the common GNU/Clang spellings whether passed directly or via
+    ``-Wl,`` / ``-Xlinker``: ``--version-script=FILE`` / ``--version-script FILE``
+    and ``-soname NAME`` / ``-h NAME`` / ``-soname=NAME``. These structured
+    fields feed the export-policy diff (ADR-029 D9); raw argv alone is not
+    indexed there.
+    """
+    tokens = _linker_tokens(argv)
+    version_script = ""
+    soname = ""
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith("--version-script="):
+            version_script = tok.split("=", 1)[1]
+        elif tok == "--version-script" and i + 1 < len(tokens):
+            version_script = tokens[i + 1]
+            i += 2
+            continue
+        elif tok.startswith(("-soname=", "--soname=")):
+            soname = tok.split("=", 1)[1]
+        elif tok in ("-soname", "--soname", "-h") and i + 1 < len(tokens):
+            soname = tokens[i + 1]
+            i += 2
+            continue
+        i += 1
+    return version_script, soname
 
 
 def _is_link_input(path: str) -> bool:

--- a/abicheck/evidence/adapters/make.py
+++ b/abicheck/evidence/adapters/make.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Make adapter (ADR-029 D7).
+
+Make is too flexible to parse semantically with confidence, so it is supported
+as a *reduced-confidence* fallback tier:
+
+1. The preferred Make input is an existing ``compile_commands.json`` (produced
+   by Bear / compiledb / intercept-build) — fed through
+   :class:`CompileDbAdapter` with ``--build-system make``; this module is not
+   needed for that path.
+2. This adapter is the next tier: it scrapes a ``make -n`` / ``make --trace``
+   *dry-run* transcript for compiler invocations. The dry run does not build
+   anything, so it is safe by default (ADR-028 D6); a live ``make -n`` is run
+   only when a build directory is given and querying is allowed.
+
+The recovered compile units are always **reduced confidence** (a Make dry run
+is not an authoritative target graph), recorded via a diagnostic. Compiler
+wrapper / interception (Bear-style) that changes the build invocation is an
+explicit opt-in (ADR-032 D5) and is *not* implemented here.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+from ...build_context import _extract_flags
+from ..build_evidence import BuildEvidence, CompileUnit, Generator
+from ..redaction import DEFAULT_REDACTION, RedactionPolicy
+from .base import (
+    compile_unit_id,
+    derive_build_options,
+    detect_language,
+    extract_abi_relevant_flags,
+)
+
+
+class MakeAdapter:
+    """Scrape a ``make -n``/``--trace`` transcript into reduced-confidence units."""
+
+    name = "make"
+
+    def __init__(
+        self,
+        build_dir: Path | str | None = None,
+        *,
+        dry_run: str | Path | None = None,
+        allow_query: bool = True,
+        redaction: RedactionPolicy | None = None,
+    ) -> None:
+        self.build_dir = Path(build_dir) if build_dir is not None else None
+        self._dry_run = dry_run
+        self.allow_query = allow_query
+        self.redaction = redaction or DEFAULT_REDACTION
+
+    def collect(self) -> BuildEvidence:
+        ev = BuildEvidence()
+        ev.generators.append(Generator(kind="make"))
+
+        text = self._resolve(ev)
+        if text is None:
+            return ev
+
+        directory = self.build_dir or Path(".")
+        for line in text.splitlines():
+            cu = self._compile_unit(line, directory)
+            if cu is not None:
+                ev.compile_units.append(cu)
+
+        if ev.compile_units:
+            ev.build_options = derive_build_options(ev.compile_units)
+            ev.diagnostics.append(
+                f"make: {len(ev.compile_units)} compile units derived from a make "
+                "dry-run transcript — reduced confidence (not an authoritative "
+                "target graph); prefer a generated compile_commands.json"
+            )
+        return ev
+
+    # -- input resolution ---------------------------------------------------
+
+    def _resolve(self, ev: BuildEvidence) -> str | None:
+        text = _as_text(self._dry_run)
+        if text is not None:
+            return text
+        if self._dry_run is not None:
+            ev.diagnostics.append(
+                f"make: dry-run input not found or unreadable: "
+                f"{self.redaction.path(str(self._dry_run))}"
+            )
+            return None
+        if self.build_dir is not None and self.allow_query:
+            return self._run_make_dry_run(ev)
+        ev.diagnostics.append("make: no dry-run transcript provided and live query disabled")
+        return None
+
+    def _run_make_dry_run(self, ev: BuildEvidence) -> str | None:
+        make = shutil.which("make")
+        if make is None or self.build_dir is None:
+            ev.diagnostics.append("make: executable not found on PATH; cannot run dry-run")
+            return None
+        # `make -n` only prints the recipes it *would* run; it builds nothing,
+        # so this is a query of an existing tree (ADR-028 D6), not a build.
+        cmd = [make, "-n", "--print-directory", "-C", str(self.build_dir)]
+        try:
+            proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+                cmd, capture_output=True, text=True, timeout=120, check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            ev.diagnostics.append(f"make: dry-run failed: {exc}")
+            return None
+        if proc.returncode != 0:
+            ev.diagnostics.append(
+                f"make: dry-run exited {proc.returncode}: {proc.stderr.strip()[:200]}"
+            )
+            return None
+        return proc.stdout
+
+    # -- normalization ------------------------------------------------------
+
+    def _compile_unit(self, line: str, directory: Path) -> CompileUnit | None:
+        argv = _split_recipe(line)
+        # A translation-unit compile is a `-c` invocation that names a source;
+        # link/info/`Entering directory` lines lack one of those and are skipped.
+        if "-c" not in argv:
+            return None
+        source = _source_from_argv(argv)
+        if not source:
+            return None
+        ctx = _extract_flags(argv, directory)
+        red_argv = self.redaction.argv(argv)
+        red_source = self.redaction.path(source)
+        return CompileUnit(
+            id=compile_unit_id(red_source, red_argv),
+            source=red_source,
+            directory=self.redaction.path(str(directory)),
+            argv=red_argv,
+            language=detect_language(source),
+            standard=ctx.language_standard or "",
+            defines={k: self.redaction.define_value(k, v or "") for k, v in ctx.defines.items()},
+            undefines=sorted(ctx.undefines),
+            include_paths=[self.redaction.path(str(p)) for p in ctx.include_paths],
+            system_include_paths=[self.redaction.path(str(p)) for p in ctx.system_includes],
+            sysroot=self.redaction.path(str(ctx.sysroot)) if ctx.sysroot else None,
+            target_triple=ctx.target_triple or "",
+            abi_relevant_flags=[self.redaction.arg(f) for f in extract_abi_relevant_flags(argv)],
+        )
+
+
+def _split_recipe(line: str) -> list[str]:
+    """Tokenize one make recipe line, tolerating the usual ``@``/trace noise."""
+    stripped = line.strip().lstrip("@")  # make silences recipes with a leading @
+    if not stripped:
+        return []
+    try:
+        return shlex.split(stripped, posix=os.name != "nt")
+    except ValueError:
+        return []  # unbalanced quotes / non-command line — skip
+
+
+def _source_from_argv(argv: list[str]) -> str:
+    """Return the first argv token that names a compilable source file."""
+    for arg in argv:
+        if not arg.startswith(("-", "/")) and detect_language(arg):
+            return arg
+    return ""
+
+
+def _as_text(value: str | Path | None) -> str | None:
+    """Return text content for a value that may be inline text or a file path."""
+    if value is None:
+        return None
+    candidate = value if isinstance(value, Path) else Path(value)
+    try:
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        pass
+    return None if isinstance(value, Path) else value

--- a/abicheck/evidence/adapters/make.py
+++ b/abicheck/evidence/adapters/make.py
@@ -49,6 +49,7 @@ from .base import (
     derive_build_options,
     detect_language,
     extract_abi_relevant_flags,
+    source_from_argv,
 )
 
 
@@ -119,7 +120,7 @@ class MakeAdapter:
         # link/info/`Entering directory` lines lack one of those and are skipped.
         if "-c" not in argv:
             return None
-        source = _source_from_argv(argv)
+        source = source_from_argv(argv)
         if not source:
             return None
         ctx = _extract_flags(argv, directory)
@@ -151,14 +152,6 @@ def _split_recipe(line: str) -> list[str]:
         return shlex.split(stripped, posix=os.name != "nt")
     except ValueError:
         return []  # unbalanced quotes / non-command line — skip
-
-
-def _source_from_argv(argv: list[str]) -> str:
-    """Return the first argv token that names a compilable source file."""
-    for arg in argv:
-        if not arg.startswith(("-", "/")) and detect_language(arg):
-            return arg
-    return ""
 
 
 def _as_text(value: str | Path | None) -> str | None:

--- a/abicheck/evidence/adapters/make.py
+++ b/abicheck/evidence/adapters/make.py
@@ -21,22 +21,24 @@ as a *reduced-confidence* fallback tier:
    by Bear / compiledb / intercept-build) — fed through
    :class:`CompileDbAdapter` with ``--build-system make``; this module is not
    needed for that path.
-2. This adapter is the next tier: it scrapes a ``make -n`` / ``make --trace``
-   *dry-run* transcript for compiler invocations. The dry run does not build
-   anything, so it is safe by default (ADR-028 D6); a live ``make -n`` is run
-   only when a build directory is given and querying is allowed.
+2. This adapter is the next tier: it scrapes a **pre-captured** ``make -n`` /
+   ``make --trace`` transcript for compiler invocations.
+
+The adapter never *runs* Make. That is deliberate: ``make -n`` is not actually
+side-effect free — GNU Make still executes recipe lines prefixed with ``+`` and
+evaluates ``$(shell …)`` at makefile-parse time — so running it would violate
+the post-build, non-executing contract (ADR-028 D6). The caller runs the dry
+run themselves (an explicit, auditable step) and feeds the transcript via
+``--make-dry-run``. Compiler wrapper / interception (Bear-style) is a separate
+explicit opt-in (ADR-032 D5) and is not implemented here.
 
 The recovered compile units are always **reduced confidence** (a Make dry run
-is not an authoritative target graph), recorded via a diagnostic. Compiler
-wrapper / interception (Bear-style) that changes the build invocation is an
-explicit opt-in (ADR-032 D5) and is *not* implemented here.
+is not an authoritative target graph), recorded via a diagnostic.
 """
 from __future__ import annotations
 
 import os
 import shlex
-import shutil
-import subprocess
 from pathlib import Path
 
 from ...build_context import _extract_flags
@@ -51,7 +53,7 @@ from .base import (
 
 
 class MakeAdapter:
-    """Scrape a ``make -n``/``--trace`` transcript into reduced-confidence units."""
+    """Scrape a pre-captured ``make -n``/``--trace`` transcript into units."""
 
     name = "make"
 
@@ -60,12 +62,12 @@ class MakeAdapter:
         build_dir: Path | str | None = None,
         *,
         dry_run: str | Path | None = None,
-        allow_query: bool = True,
         redaction: RedactionPolicy | None = None,
     ) -> None:
+        # ``build_dir`` is only a passive directory hint for resolving relative
+        # include paths; it is never used to execute Make.
         self.build_dir = Path(build_dir) if build_dir is not None else None
         self._dry_run = dry_run
-        self.allow_query = allow_query
         self.redaction = redaction or DEFAULT_REDACTION
 
     def collect(self) -> BuildEvidence:
@@ -103,32 +105,11 @@ class MakeAdapter:
                 f"{self.redaction.path(str(self._dry_run))}"
             )
             return None
-        if self.build_dir is not None and self.allow_query:
-            return self._run_make_dry_run(ev)
-        ev.diagnostics.append("make: no dry-run transcript provided and live query disabled")
+        ev.diagnostics.append(
+            "make: no dry-run transcript provided (the adapter never runs make; "
+            "capture `make -n`/`--trace` output and pass it via --make-dry-run)"
+        )
         return None
-
-    def _run_make_dry_run(self, ev: BuildEvidence) -> str | None:
-        make = shutil.which("make")
-        if make is None or self.build_dir is None:
-            ev.diagnostics.append("make: executable not found on PATH; cannot run dry-run")
-            return None
-        # `make -n` only prints the recipes it *would* run; it builds nothing,
-        # so this is a query of an existing tree (ADR-028 D6), not a build.
-        cmd = [make, "-n", "--print-directory", "-C", str(self.build_dir)]
-        try:
-            proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
-                cmd, capture_output=True, text=True, timeout=120, check=False,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            ev.diagnostics.append(f"make: dry-run failed: {exc}")
-            return None
-        if proc.returncode != 0:
-            ev.diagnostics.append(
-                f"make: dry-run exited {proc.returncode}: {proc.stderr.strip()[:200]}"
-            )
-            return None
-        return proc.stdout
 
     # -- normalization ------------------------------------------------------
 
@@ -163,7 +144,7 @@ class MakeAdapter:
 
 def _split_recipe(line: str) -> list[str]:
     """Tokenize one make recipe line, tolerating the usual ``@``/trace noise."""
-    stripped = line.strip().lstrip("@")  # make silences recipes with a leading @
+    stripped = line.strip().lstrip("@+-")  # make recipe prefixes: @ (silent), + (force), - (ignore)
     if not stripped:
         return []
     try:

--- a/abicheck/evidence/adapters/make.py
+++ b/abicheck/evidence/adapters/make.py
@@ -116,6 +116,9 @@ class MakeAdapter:
 
     def _compile_unit(self, line: str, directory: Path) -> CompileUnit | None:
         argv = _split_recipe(line)
+        # Recursive recipes prefix the compile with `cd sub && …`; the source and
+        # `-I` paths are then relative to `sub/`, not the parent build dir.
+        argv, directory = _consume_cd_prefix(argv, directory)
         # A translation-unit compile is a `-c` (GNU) / `/c` (MSVC, clang-cl)
         # invocation that names a source; link/info/`Entering directory` lines
         # lack one of those and are skipped.
@@ -142,6 +145,19 @@ class MakeAdapter:
             target_triple=ctx.target_triple or "",
             abi_relevant_flags=[self.redaction.arg(f) for f in extract_abi_relevant_flags(argv)],
         )
+
+
+def _consume_cd_prefix(argv: list[str], directory: Path) -> tuple[list[str], Path]:
+    """Strip leading ``cd <dir> &&|;`` segments, advancing *directory* into them.
+
+    Handles chained forms like ``cd a && cd b && cc …``. An absolute ``cd``
+    target resets the directory; a relative one is joined onto it.
+    """
+    while len(argv) >= 3 and argv[0] == "cd" and argv[2] in ("&&", ";"):
+        sub = Path(argv[1])
+        directory = sub if sub.is_absolute() else directory / sub
+        argv = argv[3:]
+    return argv, directory
 
 
 def _split_recipe(line: str) -> list[str]:

--- a/abicheck/evidence/adapters/make.py
+++ b/abicheck/evidence/adapters/make.py
@@ -116,9 +116,10 @@ class MakeAdapter:
 
     def _compile_unit(self, line: str, directory: Path) -> CompileUnit | None:
         argv = _split_recipe(line)
-        # A translation-unit compile is a `-c` invocation that names a source;
-        # link/info/`Entering directory` lines lack one of those and are skipped.
-        if "-c" not in argv:
+        # A translation-unit compile is a `-c` (GNU) / `/c` (MSVC, clang-cl)
+        # invocation that names a source; link/info/`Entering directory` lines
+        # lack one of those and are skipped.
+        if "-c" not in argv and "/c" not in argv:
             return None
         source = source_from_argv(argv)
         if not source:

--- a/abicheck/evidence/compiler_record.py
+++ b/abicheck/evidence/compiler_record.py
@@ -46,6 +46,7 @@ from .adapters.base import (
     derive_build_options,
     detect_language,
     extract_abi_relevant_flags,
+    source_from_argv,
 )
 from .build_evidence import BuildEvidence, CompileUnit, Toolchain
 from .redaction import DEFAULT_REDACTION, RedactionPolicy
@@ -148,11 +149,7 @@ def _collect_command_line(elf: Any, ev: BuildEvidence, red: RedactionPolicy) -> 
 
 def _command_to_unit(argv: list[str], red: RedactionPolicy) -> CompileUnit:
     """Build a CompileUnit from a recorded command; ``source`` is "" if absent."""
-    source = ""
-    for arg in argv[1:]:
-        if not arg.startswith(("-", "/")) and detect_language(arg):
-            source = arg
-            break
+    source = source_from_argv(argv)
     ctx = _extract_flags(argv, Path("."))
     red_argv = red.argv(argv)
     red_source = red.path(source) if source else ""

--- a/abicheck/evidence/compiler_record.py
+++ b/abicheck/evidence/compiler_record.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiler-recorded metadata extractor (ADR-029 D8).
+
+Recovers compiler provenance from an *already-built* binary without rebuilding:
+
+- the GCC/Clang ``.GCC.command.line`` ELF section (emitted by
+  ``-frecord-gcc-switches`` / ``-frecord-command-line``) → the recorded compiler
+  command lines, from which ABI-relevant build options are extracted;
+- DWARF ``DW_AT_producer`` → compiler id / version (and language).
+
+These signals are **advisory** (D8): they describe how the shipped artifact was
+built, but are only authoritative when cross-checked against build-system
+metadata. The extractor never executes the binary; it only reads ELF/DWARF.
+
+The byte/string parsing is split into pure helpers (``parse_gcc_command_line``,
+``parse_producer``) so it is testable without a compiled fixture; the ELF
+wrapper degrades gracefully (diagnostic, empty evidence) on any read failure.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
+
+from ..build_context import _extract_flags
+from .adapters.base import (
+    compile_unit_id,
+    derive_build_options,
+    detect_language,
+    extract_abi_relevant_flags,
+)
+from .build_evidence import BuildEvidence, CompileUnit, Toolchain
+from .redaction import DEFAULT_REDACTION, RedactionPolicy
+
+#: GCC records command lines here under -frecord-gcc-switches / -frecord-command-line.
+_COMMAND_LINE_SECTION = ".GCC.command.line"
+
+_VERSION_RE = re.compile(r"\b(\d+\.\d+(?:\.\d+)?)\b")
+
+
+def parse_gcc_command_line(data: bytes) -> list[str]:
+    """Split a ``.GCC.command.line`` section blob into recorded command strings.
+
+    The section is a sequence of NUL-terminated strings, one per recorded
+    compiler invocation. Empty entries are dropped; decoding is lenient.
+    """
+    return [chunk.decode("utf-8", "replace") for chunk in data.split(b"\x00") if chunk]
+
+
+def parse_producer(producer: str) -> Toolchain | None:
+    """Parse a DWARF ``DW_AT_producer`` string into a :class:`Toolchain`.
+
+    Examples: ``"GNU C++17 13.2.0 -std=c++17 -O2"`` → GNU 13.2.0 CXX;
+    ``"clang version 17.0.6"`` → Clang 17.0.6.
+    """
+    producer = producer.strip()
+    if not producer:
+        return None
+    low = producer.lower()
+    if producer.startswith("GNU"):
+        compiler_id = "GNU"
+    elif "clang" in low:
+        compiler_id = "Clang"
+    elif "intel" in low or "icpx" in low or "icc" in low:
+        compiler_id = "Intel"
+    elif "rustc" in low:
+        compiler_id = "Rust"
+    else:
+        compiler_id = producer.split()[0]
+    m = _VERSION_RE.search(producer)
+    version = m.group(1) if m else ""
+    language = "CXX" if "C++" in producer else ("C" if re.search(r"\bC\d", producer) else "")
+    tid = f"toolchain://{compiler_id}-{version or 'unknown'}-dwarf".lower()
+    return Toolchain(id=tid, compiler_id=compiler_id, version=version, language=language)
+
+
+def extract_compiler_record(
+    binary: Path | str,
+    *,
+    redaction: RedactionPolicy | None = None,
+) -> BuildEvidence:
+    """Extract compiler-recorded provenance from *binary* (ELF only).
+
+    Returns build evidence carrying any recovered toolchain, compile units, and
+    ABI-relevant build options. Failure to open/parse the binary yields empty
+    evidence with a diagnostic rather than raising.
+    """
+    red = redaction or DEFAULT_REDACTION
+    ev = BuildEvidence()
+    path = Path(binary)
+    try:
+        with path.open("rb") as fh:
+            elf = ELFFile(fh)
+            _collect_command_line(elf, ev, red)
+            _collect_producer(elf, ev)
+    except (OSError, ELFError) as exc:
+        ev.diagnostics.append(f"compiler-record: cannot read {red.path(str(path))} as ELF: {exc}")
+        return ev
+
+    if ev.compile_units:
+        # Re-derive options across all recovered command lines (deduped).
+        ev.build_options = derive_build_options(ev.compile_units)
+    if ev.toolchains or ev.compile_units or ev.build_options:
+        ev.diagnostics.append(
+            "compiler-record: provenance recovered from compiler-recorded "
+            "metadata — advisory unless cross-checked against build-system evidence"
+        )
+    return ev
+
+
+def _collect_command_line(elf: Any, ev: BuildEvidence, red: RedactionPolicy) -> None:
+    section = elf.get_section_by_name(_COMMAND_LINE_SECTION)
+    if section is None:
+        return
+    for command in parse_gcc_command_line(section.data()):
+        try:
+            argv = shlex.split(command, posix=os.name != "nt")
+        except ValueError:
+            continue
+        if not argv:
+            continue
+        cu = _command_to_unit(argv, red)
+        if cu is not None:
+            ev.compile_units.append(cu)
+
+
+def _command_to_unit(argv: list[str], red: RedactionPolicy) -> CompileUnit | None:
+    source = ""
+    for arg in argv[1:]:
+        if not arg.startswith(("-", "/")) and detect_language(arg):
+            source = arg
+            break
+    if not source:
+        return None
+    ctx = _extract_flags(argv, Path("."))
+    red_argv = red.argv(argv)
+    red_source = red.path(source)
+    return CompileUnit(
+        id=compile_unit_id(red_source, red_argv),
+        source=red_source,
+        argv=red_argv,
+        language=detect_language(source),
+        standard=ctx.language_standard or "",
+        defines={k: red.define_value(k, v or "") for k, v in ctx.defines.items()},
+        undefines=sorted(ctx.undefines),
+        include_paths=[red.path(str(p)) for p in ctx.include_paths],
+        system_include_paths=[red.path(str(p)) for p in ctx.system_includes],
+        sysroot=red.path(str(ctx.sysroot)) if ctx.sysroot else None,
+        target_triple=ctx.target_triple or "",
+        abi_relevant_flags=[red.arg(f) for f in extract_abi_relevant_flags(argv)],
+    )
+
+
+def _collect_producer(elf: Any, ev: BuildEvidence) -> None:
+    if not elf.has_dwarf_info():
+        return
+    dwarf = elf.get_dwarf_info()
+    seen: set[str] = set()
+    for cu in dwarf.iter_CUs():
+        try:
+            attr = cu.get_top_DIE().attributes.get("DW_AT_producer")
+        except (KeyError, AttributeError, ELFError):
+            continue
+        if attr is None:
+            continue
+        value = attr.value
+        producer = value.decode("utf-8", "replace") if isinstance(value, bytes) else str(value)
+        toolchain = parse_producer(producer)
+        if toolchain is not None and toolchain.id not in seen:
+            ev.toolchains.append(toolchain)
+            seen.add(toolchain.id)

--- a/abicheck/evidence/compiler_record.py
+++ b/abicheck/evidence/compiler_record.py
@@ -115,9 +115,6 @@ def extract_compiler_record(
         ev.diagnostics.append(f"compiler-record: cannot read {red.path(str(path))} as ELF: {exc}")
         return ev
 
-    if ev.compile_units:
-        # Re-derive options across all recovered command lines (deduped).
-        ev.build_options = derive_build_options(ev.compile_units)
     if ev.toolchains or ev.compile_units or ev.build_options:
         ev.diagnostics.append(
             "compiler-record: provenance recovered from compiler-recorded "
@@ -130,6 +127,7 @@ def _collect_command_line(elf: Any, ev: BuildEvidence, red: RedactionPolicy) -> 
     section = elf.get_section_by_name(_COMMAND_LINE_SECTION)
     if section is None:
         return
+    parsed: list[CompileUnit] = []
     for command in parse_gcc_command_line(section.data()):
         try:
             argv = shlex.split(command, posix=os.name != "nt")
@@ -137,22 +135,27 @@ def _collect_command_line(elf: Any, ev: BuildEvidence, red: RedactionPolicy) -> 
             continue
         if not argv:
             continue
-        cu = _command_to_unit(argv, red)
-        if cu is not None:
-            ev.compile_units.append(cu)
+        unit = _command_to_unit(argv, red)
+        parsed.append(unit)
+        # Only emit a compile unit when the record names a translation unit.
+        # ``-frecord-gcc-switches`` records switches with no source — those
+        # still carry ABI options, so they feed build_options below.
+        if unit.source:
+            ev.compile_units.append(unit)
+    if parsed:
+        ev.build_options = derive_build_options(parsed)
 
 
-def _command_to_unit(argv: list[str], red: RedactionPolicy) -> CompileUnit | None:
+def _command_to_unit(argv: list[str], red: RedactionPolicy) -> CompileUnit:
+    """Build a CompileUnit from a recorded command; ``source`` is "" if absent."""
     source = ""
     for arg in argv[1:]:
         if not arg.startswith(("-", "/")) and detect_language(arg):
             source = arg
             break
-    if not source:
-        return None
     ctx = _extract_flags(argv, Path("."))
     red_argv = red.argv(argv)
-    red_source = red.path(source)
+    red_source = red.path(source) if source else ""
     return CompileUnit(
         id=compile_unit_id(red_source, red_argv),
         source=red_source,

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -73,6 +73,15 @@ abicheck compare old.abi.json new.abi.json \
   textual `jsonproto` form: a binary `--output=proto` blob is reported with a
   diagnostic rather than decoded (binary-proto ingestion is a documented
   follow-up).
+- `--make-dry-run FILE` — a pre-captured `make -n`/`make --trace` transcript.
+  Make has no authoritative target graph, so the recovered compile units are
+  **reduced confidence**; prefer a generated `compile_commands.json` when one
+  is available.
+- `--read-compiler-record` (with `--binary`) — recover compiler provenance from
+  the built binary itself: the `.GCC.command.line` ELF section
+  (`-frecord-gcc-switches` / `-frecord-command-line`) and DWARF
+  `DW_AT_producer`. These signals are **advisory** unless cross-checked against
+  build-system evidence.
 
 ## Build-evidence findings (L3)
 

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -69,7 +69,10 @@ abicheck compare old.abi.json new.abi.json \
   output (live query or pre-captured for hermetic CI).
 - `--bazel-cquery FILE` / `--bazel-aquery FILE` — pre-captured
   `bazel cquery --output=jsonproto` (configured target graph) and
-  `bazel aquery --output=jsonproto` (compile/link action graph).
+  `bazel aquery --output=jsonproto` (compile/link action graph). Use the
+  textual `jsonproto` form: a binary `--output=proto` blob is reported with a
+  diagnostic rather than decoded (binary-proto ingestion is a documented
+  follow-up).
 
 ## Build-evidence findings (L3)
 

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -67,6 +67,9 @@ abicheck compare old.abi.json new.abi.json \
   graph, public/private header file sets, toolchains).
 - `--build-dir DIR --ninja` / `--ninja-compdb FILE` — Ninja `-t compdb`/`graph`
   output (live query or pre-captured for hermetic CI).
+- `--bazel-cquery FILE` / `--bazel-aquery FILE` — pre-captured
+  `bazel cquery --output=jsonproto` (configured target graph) and
+  `bazel aquery --output=jsonproto` (compile/link action graph).
 
 ## Build-evidence findings (L3)
 

--- a/docs/development/adr/029-build-graph-toolchain-context-capture.md
+++ b/docs/development/adr/029-build-graph-toolchain-context-capture.md
@@ -223,9 +223,26 @@ bazel build //foo:libfoo --aspects=@abicheck//:abi_evidence.bzl%abi_evidence_asp
 
 `--output=jsonproto` is an accepted cquery value (alongside `proto`,
 `streamed_proto`, and `textproto`) even though the cquery prose docs only
-describe `proto`; the flag reference is authoritative. The adapter must
-accept both the JSON and binary proto forms, since older Bazel releases or
-project tooling may produce either.
+describe `proto`; the flag reference is authoritative.
+
+**MVP scope (implemented):** the adapter ingests the textual **`jsonproto`**
+form. A binary `--output=proto` blob is not decoded — it would require a
+protobuf runtime plus vendored Bazel `.proto` bindings, which this
+dependency-light tool deliberately avoids — so the adapter records a
+diagnostic asking for `--output=jsonproto` rather than failing. Binary-proto
+ingestion (for tooling that can only emit it) is a documented follow-up, not
+an MVP requirement.
+
+**Configured-graph fidelity (limitation):** when one label appears under
+several configurations, the first configuration seen is the *canonical*
+target and keeps the plain `target://<label>` id (so the label-based aquery
+action graph still links to a collected target); additional configurations
+are preserved under a `target://<label>#cfg:<id>` suffix. Dependency edges are
+read from the label-only `deps` attribute, which does not carry each
+dependency's configuration, so edges resolve to the canonical dependency
+target. Full per-configuration dependency resolution would require richer
+configured-edge output than the `jsonproto` rule attributes expose and is a
+follow-up.
 
 Collected Bazel facts:
 

--- a/docs/development/adr/029-build-graph-toolchain-context-capture.md
+++ b/docs/development/adr/029-build-graph-toolchain-context-capture.md
@@ -1,9 +1,11 @@
 # ADR-029: Build Graph and Toolchain Context Capture
 
 **Date:** 2026-06-09
-**Status:** Accepted — MVP implemented (BuildEvidence model; compile DB,
-CMake File API, Ninja, and Bazel `cquery`/`aquery` adapters; build-evidence
-diff and the six D9 change kinds)
+**Status:** Accepted — implemented (BuildEvidence model; compile DB, CMake
+File API, Ninja, Bazel `cquery`/`aquery`, and Make dry-run adapters;
+compiler-recorded metadata extractor; build-evidence diff and the six D9
+change kinds). Only Phase 7 (CI rollout + baseline registry) remains, tracked
+under ADR-033.
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/029-build-graph-toolchain-context-capture.md
+++ b/docs/development/adr/029-build-graph-toolchain-context-capture.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-06-09
 **Status:** Accepted — MVP implemented (BuildEvidence model; compile DB,
-CMake File API, and Ninja adapters; build-evidence diff and the six D9
-change kinds)
+CMake File API, Ninja, and Bazel `cquery`/`aquery` adapters; build-evidence
+diff and the six D9 change kinds)
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ module = [
     "abicheck.pdb_utils",
     "abicheck.sycl_metadata",
     "abicheck.binary_fingerprint",
+    "abicheck.evidence.compiler_record",
 ]
 disallow_untyped_calls = false
 disable_error_code = ["attr-defined"]

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -108,6 +108,44 @@ def test_bazel_cquery_builds_target_graph():
     assert len(ev.targets) == 2
 
 
+def test_bazel_linkshared_cc_binary_is_shared_library():
+    # A cc_binary with linkshared=True produces a shared library, not an exe.
+    cquery = json.dumps({"results": [{"target": {"rule": {
+        "name": "//foo:libfoo", "ruleClass": "cc_binary",
+        "attribute": [{"name": "linkshared", "type": "BOOLEAN", "booleanValue": True}],
+    }}}]})
+    ev = BazelAdapter(cquery=cquery).collect()
+    assert ev.targets[0].kind is TargetKind.SHARED_LIBRARY
+
+
+def test_bazel_cc_binary_shared_output_extension_is_shared_library():
+    # Even without linkshared, a .so ruleOutput marks the target shared.
+    cquery = json.dumps({"results": [{"target": {"rule": {
+        "name": "//foo:libfoo", "ruleClass": "cc_binary", "ruleOutput": ["//foo:libfoo.so"],
+    }}}]})
+    ev = BazelAdapter(cquery=cquery).collect()
+    assert ev.targets[0].kind is TargetKind.SHARED_LIBRARY
+
+
+def test_bazel_plain_cc_binary_stays_executable():
+    cquery = json.dumps({"results": [{"target": {"rule": {
+        "name": "//app:app", "ruleClass": "cc_binary",
+        "attribute": [{"name": "linkshared", "type": "BOOLEAN", "booleanValue": False}],
+    }}}]})
+    ev = BazelAdapter(cquery=cquery).collect()
+    assert ev.targets[0].kind is TargetKind.EXECUTABLE
+
+
+def test_bazel_dll_output_classified_as_shared_library():
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{"mnemonic": "CppLink", "arguments": ["link"], "primaryOutputId": "1"}],
+        "pathFragments": [{"id": "10", "label": "foo.dll"}],
+    })
+    ev = BazelAdapter(aquery=aquery).collect()
+    assert ev.link_units[0].kind == "shared_library"
+
+
 def test_bazel_aquery_builds_compile_and_link_units():
     ev = BazelAdapter(aquery=AQUERY).collect()
     assert len(ev.compile_units) == 1

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -259,13 +259,14 @@ def test_bazel_forced_header_not_mistaken_for_source():
 
 def test_bazel_param_file_arguments_are_expanded():
     # A C++ action whose argv is just `gcc @foo.params`: the source and flags
-    # live in paramFiles[].arguments and must be merged before extraction.
+    # live in paramFiles[].arguments and are substituted at the @token position.
     aquery = json.dumps({
         "artifacts": [{"id": "1", "pathFragmentId": "10"}],
         "actions": [{
             "mnemonic": "CppCompile",
             "arguments": ["/usr/bin/gcc", "@bazel-out/foo.params"],
-            "paramFiles": [{"arguments": ["-std=c++20", "-c", "foo.cc", "-o", "foo.o"]}],
+            "paramFiles": [{"execPath": "bazel-out/foo.params",
+                            "arguments": ["-std=c++20", "-c", "foo.cc", "-o", "foo.o"]}],
             "primaryOutputId": "1",
         }],
         "pathFragments": [{"id": "10", "label": "foo.o"}],
@@ -273,6 +274,39 @@ def test_bazel_param_file_arguments_are_expanded():
     cu = BazelAdapter(aquery=aquery).collect().compile_units[0]
     assert cu.source == "foo.cc"
     assert cu.standard == "c++20"
+
+
+def test_bazel_param_file_expanded_at_token_position():
+    # Param-file args expand at the @token position, not at the end, so a
+    # later command-line -std wins (matching the real compiler's last-wins rule).
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppCompile",
+            "arguments": ["gcc", "@out/foo.params", "-std=c++11", "-c", "foo.cc"],
+            "paramFiles": [{"execPath": "out/foo.params", "arguments": ["-std=c++20"]}],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.o"}],
+    })
+    cu = BazelAdapter(aquery=aquery).collect().compile_units[0]
+    assert cu.standard == "c++11"   # later token wins; append-at-end would give c++20
+    assert cu.source == "foo.cc"
+
+
+def test_bazel_param_file_without_execpath_falls_back_to_append():
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppCompile", "arguments": ["gcc", "@foo.params"],
+            "paramFiles": [{"arguments": ["-std=c++17", "-c", "foo.cc"]}],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.o"}],
+    })
+    cu = BazelAdapter(aquery=aquery).collect().compile_units[0]
+    assert cu.standard == "c++17"
+    assert cu.source == "foo.cc"
 
 
 def test_bazel_live_aquery_includes_param_files(monkeypatch, tmp_path):

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -211,6 +211,44 @@ def test_bazel_attr_string_value_fallback_and_executable_link():
     assert lu.inputs == ["app.o"]                # resolved through the transitive depset
 
 
+def test_bazel_link_keeps_shared_library_inputs():
+    # A binary linking against a shared lib: the .so input must be recorded,
+    # not dropped (ADR-029 D6 — aquery captures link action inputs).
+    aquery = json.dumps({
+        "artifacts": [
+            {"id": "1", "pathFragmentId": "10"},   # app/app.o
+            {"id": "2", "pathFragmentId": "11"},   # lib/libbar.so.1
+            {"id": "3", "pathFragmentId": "12"},   # app/app (output)
+            {"id": "4", "pathFragmentId": "13"},   # app/app.d (dropped)
+        ],
+        "actions": [{
+            "mnemonic": "CppLink", "arguments": ["gcc", "-o", "app/app"],
+            "primaryOutputId": "3", "inputDepSetIds": ["400"],
+        }],
+        "depSetOfFiles": [{"id": "400", "directArtifactIds": ["1", "2", "4"]}],
+        "pathFragments": [
+            {"id": "10", "label": "app.o", "parentId": "20"},
+            {"id": "11", "label": "libbar.so.1", "parentId": "21"},
+            {"id": "12", "label": "app", "parentId": "20"},
+            {"id": "13", "label": "app.d", "parentId": "20"},
+            {"id": "20", "label": "app"},
+            {"id": "21", "label": "lib"},
+        ],
+    })
+    ev = BazelAdapter(aquery=aquery).collect()
+    inputs = ev.link_units[0].inputs
+    assert "app/app.o" in inputs                  # object file
+    assert "lib/libbar.so.1" in inputs            # versioned shared library
+    assert "app/app.d" not in inputs              # non-library input dropped
+
+
+def test_bazel_missing_precaptured_file_diagnostic(tmp_path):
+    missing = tmp_path / "nope.json"
+    ev = BazelAdapter(cquery=missing).collect()
+    assert any("input not found or unreadable" in d for d in ev.diagnostics)
+    assert not ev.targets
+
+
 def test_bazel_live_query_oserror_diagnostic(monkeypatch, tmp_path):
     def boom(*_a, **_k):
         raise OSError("no bazel")

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -324,3 +324,22 @@ def test_collect_evidence_bazel_files(tmp_path):
     assert pack.build_evidence is not None
     assert any(t.build_system == "bazel" for t in pack.build_evidence.targets)
     assert any(e.name == "bazel" and e.status == "ok" for e in pack.manifest.extractors)
+
+
+def test_collect_evidence_bazel_link_only_pack_preserved(tmp_path):
+    # An aquery with only a link action (no targets/compile units) must still be
+    # written to the pack — link_units count toward build-evidence presence.
+    aq = tmp_path / "aquery.json"
+    aq.write_text(json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{"mnemonic": "CppLink", "arguments": ["gcc", "-shared"],
+                     "primaryOutputId": "1"}],
+        "pathFragments": [{"id": "10", "label": "libfoo.so"}],
+    }))
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, ["collect-evidence", "--bazel-aquery", str(aq), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is not None
+    assert len(pack.build_evidence.link_units) == 1
+    assert any(e.name == "bazel" and e.status == "ok" for e in pack.manifest.extractors)

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -242,6 +242,16 @@ def test_bazel_link_keeps_shared_library_inputs():
     assert "app/app.d" not in inputs              # non-library input dropped
 
 
+def test_bazel_binary_proto_file_diagnostic_no_crash(tmp_path):
+    # A binary `--output=proto` blob (not UTF-8): must not raise, and should
+    # surface the "pass --output=jsonproto" diagnostic instead.
+    pb = tmp_path / "aquery.pb"
+    pb.write_bytes(b"\x08\x96\x01\xff\xfe\x00proto\xc3\x28payload")
+    ev = BazelAdapter(aquery=pb).collect()
+    assert any("jsonproto" in d for d in ev.diagnostics)
+    assert not ev.compile_units and not ev.link_units
+
+
 def test_bazel_missing_precaptured_file_diagnostic(tmp_path):
     missing = tmp_path / "nope.json"
     ev = BazelAdapter(cquery=missing).collect()

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -326,6 +326,36 @@ def test_bazel_live_aquery_includes_param_files(monkeypatch, tmp_path):
     assert "--include_param_files" not in cquery_cmd  # only meaningful for aquery
 
 
+def test_bazel_msvc_forced_include_not_mistaken_for_source():
+    # MSVC/clang-cl `/FI config.hpp` (forced header) and a combined `/Yustdafx.h`
+    # must not be picked as the source; the real `foo.cc` must win.
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppCompile",
+            "arguments": ["cl.exe", "/FI", "config.hpp", "/Yustdafx.h", "/c", "foo.cc"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.obj"}],
+    })
+    cu = BazelAdapter(aquery=aquery).collect().compile_units[0]
+    assert cu.source == "foo.cc"
+
+
+def test_bazel_msvc_combined_forced_include_not_mistaken_for_source():
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppCompile",
+            "arguments": ["clang-cl", "/FIconfig.hpp", "/c", "foo.cc"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.obj"}],
+    })
+    cu = BazelAdapter(aquery=aquery).collect().compile_units[0]
+    assert cu.source == "foo.cc"
+
+
 def test_bazel_compile_action_without_source_is_skipped():
     aquery = json.dumps({
         "actions": [{"mnemonic": "CppCompile", "arguments": ["/usr/bin/gcc", "-v"]}],

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -153,6 +153,23 @@ def test_bazel_non_object_jsonproto_diagnostic():
     assert any("aquery jsonproto was not a JSON object" in d for d in ev.diagnostics)
 
 
+def test_bazel_forced_header_not_mistaken_for_source():
+    # `-include config.hpp` is a forced header, not the translation unit; the
+    # real source `foo.cc` must be selected even though config.hpp looks CXX.
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppCompile",
+            "arguments": ["/usr/bin/gcc", "-include", "config.hpp", "-x", "c++",
+                          "-c", "foo.cc", "-o", "foo.o"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.o"}],
+    })
+    ev = BazelAdapter(aquery=aquery).collect()
+    assert ev.compile_units[0].source == "foo.cc"
+
+
 def test_bazel_compile_action_without_source_is_skipped():
     aquery = json.dumps({
         "actions": [{"mnemonic": "CppCompile", "arguments": ["/usr/bin/gcc", "-v"]}],

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -146,6 +146,34 @@ def test_bazel_dll_output_classified_as_shared_library():
     assert ev.link_units[0].kind == "shared_library"
 
 
+def test_bazel_cquery_preserves_multiple_configurations():
+    # One label under two configurations (target vs exec) with different deps:
+    # both configured instances must survive, disambiguated by configurationId.
+    cquery = json.dumps({"results": [
+        {"target": {"rule": {"name": "//foo:foo", "ruleClass": "cc_library",
+            "attribute": [{"name": "deps", "type": "LABEL_LIST", "stringListValue": ["//a:a"]}]}},
+         "configurationId": 1},
+        {"target": {"rule": {"name": "//foo:foo", "ruleClass": "cc_library",
+            "attribute": [{"name": "deps", "type": "LABEL_LIST", "stringListValue": ["//b:b"]}]}},
+         "configurationId": 2},
+    ]})
+    ev = BazelAdapter(cquery=cquery).collect()
+    deps = {t.id: t.dependencies for t in ev.targets}
+    assert deps == {
+        "target:////foo:foo#cfg:1": ["target:////a:a"],
+        "target:////foo:foo#cfg:2": ["target:////b:b"],
+    }
+
+
+def test_bazel_cquery_single_config_keeps_plain_id():
+    # A label with one configuration keeps the plain label id (aquery linkage).
+    cquery = json.dumps({"results": [
+        {"target": {"rule": {"name": "//foo:foo", "ruleClass": "cc_library"}}, "configurationId": 1},
+    ]})
+    ev = BazelAdapter(cquery=cquery).collect()
+    assert ev.targets[0].id == "target:////foo:foo"
+
+
 def test_bazel_aquery_builds_compile_and_link_units():
     ev = BazelAdapter(aquery=AQUERY).collect()
     assert len(ev.compile_units) == 1

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -208,6 +208,41 @@ def test_bazel_forced_header_not_mistaken_for_source():
     assert ev.compile_units[0].source == "foo.cc"
 
 
+def test_bazel_param_file_arguments_are_expanded():
+    # A C++ action whose argv is just `gcc @foo.params`: the source and flags
+    # live in paramFiles[].arguments and must be merged before extraction.
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppCompile",
+            "arguments": ["/usr/bin/gcc", "@bazel-out/foo.params"],
+            "paramFiles": [{"arguments": ["-std=c++20", "-c", "foo.cc", "-o", "foo.o"]}],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.o"}],
+    })
+    cu = BazelAdapter(aquery=aquery).collect().compile_units[0]
+    assert cu.source == "foo.cc"
+    assert cu.standard == "c++20"
+
+
+def test_bazel_live_aquery_includes_param_files(monkeypatch, tmp_path):
+    captured: list[list[str]] = []
+    import subprocess as _sp
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        return _sp.CompletedProcess(cmd, 0, stdout=AQUERY if "aquery" in cmd else CQUERY, stderr="")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.shutil.which", lambda _x: "/usr/bin/bazel")
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.subprocess.run", fake_run)
+    BazelAdapter(workspace=tmp_path, target="//foo:foo").collect()
+    aquery_cmd = next(c for c in captured if "aquery" in c)
+    assert "--include_param_files" in aquery_cmd
+    cquery_cmd = next(c for c in captured if "cquery" in c)
+    assert "--include_param_files" not in cquery_cmd  # only meaningful for aquery
+
+
 def test_bazel_compile_action_without_source_is_skipped():
     aquery = json.dumps({
         "actions": [{"mnemonic": "CppCompile", "arguments": ["/usr/bin/gcc", "-v"]}],

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -286,6 +286,42 @@ def test_bazel_live_query_oserror_diagnostic(monkeypatch, tmp_path):
     assert any("failed" in d for d in ev.diagnostics)
 
 
+def test_bazel_link_export_policy_from_argv():
+    # version-script and soname carried in -Wl, args must populate the structured
+    # LinkUnit fields so the export-policy diff (D9) can index them.
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppLink",
+            "arguments": ["gcc", "-shared", "-o", "libfoo.so.2",
+                          "-Wl,--version-script=exports.map", "-Wl,-soname,libfoo.so.2"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "libfoo.so.2"}],
+    })
+    lu = BazelAdapter(aquery=aquery).collect().link_units[0]
+    assert lu.version_script == "exports.map"
+    assert lu.soname == "libfoo.so.2"
+
+
+def test_bazel_link_export_policy_xlinker_spelling():
+    # The -Xlinker / space-separated spelling must resolve the same fields.
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppLink",
+            "arguments": ["gcc", "-shared", "-o", "libfoo.so",
+                          "-Xlinker", "--version-script", "-Xlinker", "v.map",
+                          "-Xlinker", "-h", "-Xlinker", "libfoo.so.1"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "libfoo.so"}],
+    })
+    lu = BazelAdapter(aquery=aquery).collect().link_units[0]
+    assert lu.version_script == "v.map"
+    assert lu.soname == "libfoo.so.1"
+
+
 def test_bazel_live_query_disabled_without_workspace():
     # No pre-captured input and no workspace/target → nothing to query, no crash.
     ev = BazelAdapter(allow_query=True).collect()

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -148,7 +148,8 @@ def test_bazel_dll_output_classified_as_shared_library():
 
 def test_bazel_cquery_preserves_multiple_configurations():
     # One label under two configurations (target vs exec) with different deps:
-    # both configured instances must survive, disambiguated by configurationId.
+    # both survive. The first (canonical) config keeps the plain label id so
+    # aquery linkage resolves; the extra config is suffixed with its id.
     cquery = json.dumps({"results": [
         {"target": {"rule": {"name": "//foo:foo", "ruleClass": "cc_library",
             "attribute": [{"name": "deps", "type": "LABEL_LIST", "stringListValue": ["//a:a"]}]}},
@@ -160,9 +161,29 @@ def test_bazel_cquery_preserves_multiple_configurations():
     ev = BazelAdapter(cquery=cquery).collect()
     deps = {t.id: t.dependencies for t in ev.targets}
     assert deps == {
-        "target:////foo:foo#cfg:1": ["target:////a:a"],
-        "target:////foo:foo#cfg:2": ["target:////b:b"],
+        "target:////foo:foo": ["target:////a:a"],          # canonical (first) config
+        "target:////foo:foo#cfg:2": ["target:////b:b"],    # extra config preserved
     }
+
+
+def test_bazel_multi_config_aquery_links_to_canonical_target():
+    # Even when a label is multi-config, an aquery compile unit referencing the
+    # label-only target id must resolve to the canonical collected Target.
+    cquery = json.dumps({"results": [
+        {"target": {"rule": {"name": "//foo:foo", "ruleClass": "cc_library"}}, "configurationId": 1},
+        {"target": {"rule": {"name": "//foo:foo", "ruleClass": "cc_library"}}, "configurationId": 2},
+    ]})
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{"mnemonic": "CppCompile", "targetId": "100",
+                     "arguments": ["gcc", "-c", "foo.cc"], "primaryOutputId": "1"}],
+        "targets": [{"id": "100", "label": "//foo:foo"}],
+        "pathFragments": [{"id": "10", "label": "foo.o"}],
+    })
+    ev = BazelAdapter(cquery=cquery, aquery=aquery).collect()
+    target_ids = {t.id for t in ev.targets}
+    assert "target:////foo:foo" in target_ids                       # canonical present
+    assert ev.compile_units[0].target_id == "target:////foo:foo"    # links to it
 
 
 def test_bazel_cquery_single_config_keeps_plain_id():

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -444,6 +444,37 @@ def test_bazel_link_export_policy_xlinker_spelling():
     assert lu.soname == "libfoo.so.1"
 
 
+def test_bazel_link_export_policy_msvc_def_file():
+    # MSVC/clang-cl module-definition file is the Windows export map and must
+    # populate version_script so DLL export-policy drift is diffable (ADR-029 D9).
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppLink",
+            "arguments": ["link.exe", "/DLL", "/DEF:exports.def", "/DEFAULTLIB:libcmt", "/OUT:foo.dll"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.dll"}],
+    })
+    lu = BazelAdapter(aquery=aquery).collect().link_units[0]
+    assert lu.version_script == "exports.def"   # /DEFAULTLIB: must not be mistaken for it
+    assert lu.kind == "shared_library"
+
+
+def test_bazel_link_export_policy_msvc_def_split_form():
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{
+            "mnemonic": "CppLink",
+            "arguments": ["link.exe", "/DLL", "/DEF", "exports.def", "/OUT:foo.dll"],
+            "primaryOutputId": "1",
+        }],
+        "pathFragments": [{"id": "10", "label": "foo.dll"}],
+    })
+    lu = BazelAdapter(aquery=aquery).collect().link_units[0]
+    assert lu.version_script == "exports.def"
+
+
 def test_bazel_live_query_disabled_without_workspace():
     # No pre-captured input and no workspace/target → nothing to query, no crash.
     ev = BazelAdapter(allow_query=True).collect()

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel adapter coverage (ADR-029 D6).
+
+Exercises the cquery/aquery jsonproto normalization with pre-captured fixtures
+so no live ``bazel`` is required, plus the live-query gating and CLI wiring.
+"""
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.evidence.adapters import BazelAdapter
+from abicheck.evidence.build_evidence import TargetKind
+from abicheck.evidence.pack import EvidencePack
+
+# A configured-target graph: a cc_library with public headers + a deps edge,
+# and a cc_binary with no attributes (exercises the minimal-rule path).
+CQUERY = json.dumps({
+    "results": [
+        {
+            "target": {
+                "rule": {
+                    "name": "//foo:foo",
+                    "ruleClass": "cc_library",
+                    "attribute": [
+                        {"name": "srcs", "type": "LABEL_LIST", "stringListValue": ["//foo:foo.cc"]},
+                        {"name": "hdrs", "type": "LABEL_LIST", "stringListValue": ["//foo:foo.h"]},
+                        {"name": "deps", "type": "LABEL_LIST", "stringListValue": ["//bar:bar"]},
+                    ],
+                    "ruleOutput": ["//foo:libfoo.a"],
+                }
+            },
+            "configurationId": 1,
+        },
+        {"target": {"rule": {"name": "//app:app", "ruleClass": "cc_binary"}}},
+        {"target": {"sourceFile": {"name": "//foo:foo.cc"}}},  # non-rule, skipped
+    ]
+})
+
+# An action graph: one CppCompile and one CppLink for //foo:foo. Paths are the
+# deduplicated fragment tree aquery emits.
+AQUERY = json.dumps({
+    "artifacts": [
+        {"id": "1", "pathFragmentId": "10"},   # foo/foo.cc
+        {"id": "2", "pathFragmentId": "11"},   # foo/foo.o
+        {"id": "3", "pathFragmentId": "12"},   # foo/libfoo.so
+    ],
+    "actions": [
+        {
+            "targetId": "100",
+            "mnemonic": "CppCompile",
+            "arguments": ["/usr/bin/gcc", "-std=c++17", "-D_GLIBCXX_USE_CXX11_ABI=0",
+                          "-c", "foo/foo.cc", "-o", "foo/foo.o"],
+            "primaryOutputId": "2",
+            "inputDepSetIds": ["200"],
+        },
+        {
+            "targetId": "100",
+            "mnemonic": "CppLink",
+            "arguments": ["/usr/bin/gcc", "-shared", "-o", "foo/libfoo.so", "foo/foo.o"],
+            "primaryOutputId": "3",
+            "inputDepSetIds": ["201"],
+        },
+    ],
+    "targets": [{"id": "100", "label": "//foo:foo"}],
+    "depSetOfFiles": [
+        {"id": "200", "directArtifactIds": ["1"]},
+        {"id": "201", "directArtifactIds": ["2"]},
+    ],
+    "pathFragments": [
+        {"id": "12", "label": "libfoo.so", "parentId": "20"},
+        {"id": "11", "label": "foo.o", "parentId": "20"},
+        {"id": "10", "label": "foo.cc", "parentId": "20"},
+        {"id": "20", "label": "foo"},
+    ],
+})
+
+
+def test_bazel_cquery_builds_target_graph():
+    ev = BazelAdapter(cquery=CQUERY).collect()
+    assert ev.generators[0].kind == "bazel"
+    targets = {t.id: t for t in ev.targets}
+    foo = targets["target:////foo:foo"]
+    assert foo.kind is TargetKind.STATIC_LIBRARY
+    assert foo.name == "foo"
+    assert foo.source_files == ["//foo:foo.cc"]
+    assert foo.public_headers == ["//foo:foo.h"]
+    assert foo.dependencies == ["target:////bar:bar"]
+    assert foo.visibility == "public"
+    assert foo.outputs == ["//foo:libfoo.a"]
+    assert targets["target:////app:app"].kind is TargetKind.EXECUTABLE
+    # The non-rule sourceFile result is skipped, not turned into a target.
+    assert len(ev.targets) == 2
+
+
+def test_bazel_aquery_builds_compile_and_link_units():
+    ev = BazelAdapter(aquery=AQUERY).collect()
+    assert len(ev.compile_units) == 1
+    cu = ev.compile_units[0]
+    assert cu.source == "foo/foo.cc"
+    assert cu.output == "foo/foo.o"           # reconstructed from the fragment tree
+    assert cu.language == "CXX"
+    assert cu.standard == "c++17"
+    assert cu.target_id == "target:////foo:foo"
+
+    assert len(ev.link_units) == 1
+    lu = ev.link_units[0]
+    assert lu.output == "foo/libfoo.so"
+    assert lu.kind == "shared_library"
+    assert lu.inputs == ["foo/foo.o"]          # object-file input via the depset
+    assert lu.target_id == "target:////foo:foo"
+
+    # Per-unit ABI flags are projected into diffable build options (D9).
+    opts = {(o.key, o.value) for o in ev.build_options}
+    assert ("std:CXX", "c++17") in opts
+    assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts
+
+
+def test_bazel_combined_cquery_and_aquery():
+    ev = BazelAdapter(cquery=CQUERY, aquery=AQUERY).collect()
+    assert ev.targets and ev.compile_units and ev.link_units
+
+
+def test_bazel_empty_inputs_just_records_generator():
+    ev = BazelAdapter().collect()
+    assert [g.kind for g in ev.generators] == ["bazel"]
+    assert not ev.targets and not ev.compile_units
+
+
+def test_bazel_malformed_jsonproto_diagnostic():
+    ev = BazelAdapter(cquery="{not json").collect()
+    assert any("could not parse cquery" in d for d in ev.diagnostics)
+    assert not ev.targets
+
+
+def test_bazel_non_object_jsonproto_diagnostic():
+    ev = BazelAdapter(aquery="[1, 2, 3]").collect()
+    assert any("aquery jsonproto was not a JSON object" in d for d in ev.diagnostics)
+
+
+def test_bazel_compile_action_without_source_is_skipped():
+    aquery = json.dumps({
+        "actions": [{"mnemonic": "CppCompile", "arguments": ["/usr/bin/gcc", "-v"]}],
+    })
+    ev = BazelAdapter(aquery=aquery).collect()
+    assert not ev.compile_units
+
+
+def test_bazel_link_kind_by_extension():
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}],
+        "actions": [{"mnemonic": "CppArchive", "arguments": ["ar"], "primaryOutputId": "1"}],
+        "pathFragments": [{"id": "10", "label": "libfoo.a"}],
+    })
+    ev = BazelAdapter(aquery=aquery).collect()
+    assert ev.link_units[0].kind == "static_library"
+
+
+def test_bazel_rule_without_name_is_skipped():
+    cquery = json.dumps({"results": [{"target": {"rule": {"ruleClass": "cc_library"}}}]})
+    ev = BazelAdapter(cquery=cquery).collect()
+    assert not ev.targets
+
+
+def test_bazel_link_action_without_output_is_skipped():
+    aquery = json.dumps({"actions": [{"mnemonic": "CppLink", "arguments": ["gcc"]}]})
+    ev = BazelAdapter(aquery=aquery).collect()
+    assert not ev.link_units
+
+
+def test_bazel_attr_string_value_fallback_and_executable_link():
+    cquery = json.dumps({"results": [{"target": {"rule": {
+        "name": "//app:app", "ruleClass": "cc_binary",
+        "attribute": [{"name": "linkstatic", "type": "BOOLEAN", "stringValue": "1"}],
+    }}}]})
+    aquery = json.dumps({
+        "artifacts": [{"id": "1", "pathFragmentId": "10"}, {"id": "2", "pathFragmentId": "11"}],
+        "actions": [{
+            "mnemonic": "CppLink", "arguments": ["gcc", "-o", "app/app"],
+            "primaryOutputId": "2", "inputDepSetIds": ["300"],
+        }],
+        # Transitive depset nesting: 300 → 301 (holds the object-file artifact).
+        "depSetOfFiles": [
+            {"id": "300", "transitiveDepSetIds": ["301"]},
+            {"id": "301", "directArtifactIds": ["1"]},
+        ],
+        "pathFragments": [
+            {"id": "11", "label": "app"},
+            {"id": "10", "label": "app.o"},
+        ],
+    })
+    ev = BazelAdapter(cquery=cquery, aquery=aquery).collect()
+    assert ev.targets[0].kind is TargetKind.EXECUTABLE
+    lu = ev.link_units[0]
+    assert lu.kind == "executable"               # no .so/.a extension
+    assert lu.inputs == ["app.o"]                # resolved through the transitive depset
+
+
+def test_bazel_live_query_oserror_diagnostic(monkeypatch, tmp_path):
+    def boom(*_a, **_k):
+        raise OSError("no bazel")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.shutil.which", lambda _x: "/usr/bin/bazel")
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.subprocess.run", boom)
+    ev = BazelAdapter(workspace=tmp_path, target="//foo:foo").collect()
+    assert any("failed" in d for d in ev.diagnostics)
+
+
+def test_bazel_live_query_disabled_without_workspace():
+    # No pre-captured input and no workspace/target → nothing to query, no crash.
+    ev = BazelAdapter(allow_query=True).collect()
+    assert not ev.targets and not ev.compile_units
+
+
+def test_bazel_executable_missing_diagnostic(monkeypatch, tmp_path):
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.shutil.which", lambda _x: None)
+    ev = BazelAdapter(workspace=tmp_path, target="//foo:foo").collect()
+    assert any("executable not found" in d for d in ev.diagnostics)
+
+
+def test_bazel_live_query_invokes_subprocess(monkeypatch, tmp_path):
+    import subprocess as _sp
+
+    def fake_run(cmd, **kwargs):
+        out = CQUERY if "cquery" in cmd else AQUERY
+        return _sp.CompletedProcess(cmd, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.shutil.which", lambda _x: "/usr/bin/bazel")
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.subprocess.run", fake_run)
+    ev = BazelAdapter(workspace=tmp_path, target="//foo:foo").collect()
+    assert ev.targets and ev.compile_units
+
+
+def test_bazel_live_query_nonzero_exit_diagnostic(monkeypatch, tmp_path):
+    import subprocess as _sp
+
+    def fake_run(cmd, **kwargs):
+        return _sp.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.shutil.which", lambda _x: "/usr/bin/bazel")
+    monkeypatch.setattr("abicheck.evidence.adapters.bazel.subprocess.run", fake_run)
+    ev = BazelAdapter(workspace=tmp_path, target="//foo:foo").collect()
+    assert any("exited 1" in d for d in ev.diagnostics)
+
+
+# ── CLI wiring (collect-evidence --bazel-cquery/--bazel-aquery) ──────────────
+
+
+def test_collect_evidence_bazel_files(tmp_path):
+    cq = tmp_path / "cquery.json"
+    aq = tmp_path / "aquery.json"
+    cq.write_text(CQUERY)
+    aq.write_text(AQUERY)
+    out = tmp_path / "e"
+    result = CliRunner().invoke(
+        main,
+        ["collect-evidence", "--bazel-cquery", str(cq), "--bazel-aquery", str(aq), "-o", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is not None
+    assert any(t.build_system == "bazel" for t in pack.build_evidence.targets)
+    assert any(e.name == "bazel" and e.status == "ok" for e in pack.manifest.extractors)

--- a/tests/test_compiler_record.py
+++ b/tests/test_compiler_record.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiler-recorded metadata extractor coverage (ADR-029 D8).
+
+The pure byte/string parsers are tested directly; the ELF wrapper is exercised
+with a faked ``ELFFile`` (success path) and real pyelftools (failure paths), so
+no compiled fixture is needed on the fast lane.
+"""
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.evidence import compiler_record as cr
+from abicheck.evidence.compiler_record import (
+    extract_compiler_record,
+    parse_gcc_command_line,
+    parse_producer,
+)
+
+# ── pure parsers ─────────────────────────────────────────────────────────────
+
+
+def test_parse_gcc_command_line_splits_on_nul():
+    data = b"gcc -std=c++20 -c a.cpp\x00clang -c b.c\x00\x00"
+    assert parse_gcc_command_line(data) == ["gcc -std=c++20 -c a.cpp", "clang -c b.c"]
+
+
+@pytest.mark.parametrize("producer,cid,ver,lang", [
+    ("GNU C++17 13.2.0 -std=c++17 -O2", "GNU", "13.2.0", "CXX"),
+    ("GNU C11 12.3.0", "GNU", "12.3.0", "C"),
+    ("clang version 17.0.6 (…)", "Clang", "17.0.6", ""),
+    ("Intel(R) oneAPI 2024.1", "Intel", "2024.1", ""),
+])
+def test_parse_producer_variants(producer, cid, ver, lang):
+    tc = parse_producer(producer)
+    assert tc is not None
+    assert (tc.compiler_id, tc.version, tc.language) == (cid, ver, lang)
+
+
+def test_parse_producer_empty_is_none():
+    assert parse_producer("   ") is None
+
+
+def test_parse_producer_unknown_compiler_uses_first_token():
+    tc = parse_producer("weirdcc 5.0 stuff")
+    assert tc is not None
+    assert tc.compiler_id == "weirdcc"
+    assert tc.version == "5.0"
+
+
+# ── ELF wrapper (faked success path) ─────────────────────────────────────────
+
+
+class _FakeSection:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def data(self) -> bytes:
+        return self._data
+
+
+class _FakeAttr:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+class _FakeDIE:
+    def __init__(self, producer: bytes) -> None:
+        self.attributes = {"DW_AT_producer": _FakeAttr(producer)}
+
+
+class _FakeCU:
+    def __init__(self, die: _FakeDIE) -> None:
+        self._die = die
+
+    def get_top_DIE(self) -> _FakeDIE:
+        return self._die
+
+
+class _FakeDwarf:
+    def __init__(self, cus: list[_FakeCU]) -> None:
+        self._cus = cus
+
+    def iter_CUs(self):
+        return iter(self._cus)
+
+
+class _FakeELF:
+    def __init__(self, section: _FakeSection | None, dwarf: _FakeDwarf | None) -> None:
+        self._section = section
+        self._dwarf = dwarf
+
+    def get_section_by_name(self, name: str):
+        return self._section if name == ".GCC.command.line" else None
+
+    def has_dwarf_info(self) -> bool:
+        return self._dwarf is not None
+
+    def get_dwarf_info(self) -> _FakeDwarf | None:
+        return self._dwarf
+
+
+def test_extract_compiler_record_success(tmp_path, monkeypatch):
+    binpath = tmp_path / "libfoo.so"
+    binpath.write_bytes(b"\x7fELF placeholder")
+    fake = _FakeELF(
+        section=_FakeSection(b"gcc -std=c++20 -D_GLIBCXX_USE_CXX11_ABI=0 -c src/a.cpp\x00"),
+        dwarf=_FakeDwarf([_FakeCU(_FakeDIE(b"GNU C++17 13.2.0"))]),
+    )
+    monkeypatch.setattr(cr, "ELFFile", lambda _fh: fake)
+    ev = extract_compiler_record(binpath)
+
+    assert [t.compiler_id for t in ev.toolchains] == ["GNU"]
+    assert [(c.source, c.standard) for c in ev.compile_units] == [("src/a.cpp", "c++20")]
+    opts = {(o.key, o.value) for o in ev.build_options}
+    assert ("std:CXX", "c++20") in opts
+    assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts
+    assert any("advisory" in d for d in ev.diagnostics)
+
+
+def test_extract_compiler_record_no_section_no_dwarf(tmp_path, monkeypatch):
+    binpath = tmp_path / "bare.so"
+    binpath.write_bytes(b"\x7fELF")
+    monkeypatch.setattr(cr, "ELFFile", lambda _fh: _FakeELF(section=None, dwarf=None))
+    ev = extract_compiler_record(binpath)
+    assert not ev.toolchains and not ev.compile_units
+
+
+def test_extract_compiler_record_skips_malformed_and_sourceless_commands(tmp_path, monkeypatch):
+    binpath = tmp_path / "x.so"
+    binpath.write_bytes(b"\x7fELF")
+    # 1st entry: unbalanced quote (shlex error → skipped); 2nd: no source (skipped);
+    # 3rd: a real compile that must be kept.
+    section = _FakeSection(b'gcc -c "oops\x00gcc -v\x00gcc -std=c17 -c ok.c\x00')
+    monkeypatch.setattr(cr, "ELFFile", lambda _fh: _FakeELF(section=section, dwarf=None))
+    ev = extract_compiler_record(binpath)
+    assert [c.source for c in ev.compile_units] == ["ok.c"]
+
+
+def test_extract_compiler_record_producer_attr_absent(tmp_path, monkeypatch):
+    binpath = tmp_path / "nd.so"
+    binpath.write_bytes(b"\x7fELF")
+
+    class _NoProducerDIE:
+        attributes: dict = {}
+
+    class _NoProducerCU:
+        def get_top_DIE(self):
+            return _NoProducerDIE()
+
+    fake = _FakeELF(section=None, dwarf=_FakeDwarf([_NoProducerCU()]))
+    monkeypatch.setattr(cr, "ELFFile", lambda _fh: fake)
+    ev = extract_compiler_record(binpath)
+    assert not ev.toolchains
+
+
+def test_extract_compiler_record_not_elf(tmp_path):
+    p = tmp_path / "plain.txt"
+    p.write_text("not an ELF file")
+    ev = extract_compiler_record(p)
+    assert any("cannot read" in d for d in ev.diagnostics)
+
+
+def test_extract_compiler_record_missing_file(tmp_path):
+    ev = extract_compiler_record(tmp_path / "absent.so")
+    assert any("cannot read" in d for d in ev.diagnostics)
+
+
+# ── CLI wiring ───────────────────────────────────────────────────────────────
+
+
+def test_collect_evidence_read_compiler_record_requires_binary(tmp_path):
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, ["collect-evidence", "--read-compiler-record", "-o", str(out)])
+    assert result.exit_code != 0
+    assert "requires --binary" in result.output

--- a/tests/test_compiler_record.py
+++ b/tests/test_compiler_record.py
@@ -132,6 +132,21 @@ def test_extract_compiler_record_success(tmp_path, monkeypatch):
     assert any("advisory" in d for d in ev.diagnostics)
 
 
+def test_extract_compiler_record_switches_only_record(tmp_path, monkeypatch):
+    # -frecord-gcc-switches records switches with no source token; the ABI
+    # options must still be recovered even though no compile unit is emitted.
+    binpath = tmp_path / "switches.so"
+    binpath.write_bytes(b"\x7fELF")
+    section = _FakeSection(b"GNU C11 13.3.0 -std=c11 -D_GLIBCXX_USE_CXX11_ABI=0 -O2\x00")
+    monkeypatch.setattr(cr, "ELFFile", lambda _fh: _FakeELF(section=section, dwarf=None))
+    ev = extract_compiler_record(binpath)
+    assert not ev.compile_units  # no source → no unit
+    opts = {(o.key, o.value) for o in ev.build_options}
+    # No source token → language unknown, so the std option key is the generic "std".
+    assert ("std", "c11") in opts
+    assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts
+
+
 def test_extract_compiler_record_no_section_no_dwarf(tmp_path, monkeypatch):
     binpath = tmp_path / "bare.so"
     binpath.write_bytes(b"\x7fELF")

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -49,6 +49,12 @@ def test_make_reduced_confidence_diagnostic_and_options():
     assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts
 
 
+def test_make_forced_include_not_mistaken_for_source():
+    # `-include config.hpp` is a forced header, not the TU; foo.cc must win.
+    ev = MakeAdapter(dry_run="g++ -include config.hpp -std=c++17 -c src/foo.cc -o foo.o").collect()
+    assert [c.source for c in ev.compile_units] == ["src/foo.cc"]
+
+
 def test_make_compound_recipe_with_cd():
     ev = MakeAdapter(dry_run="cd sub && gcc -std=c17 -c sub/x.c -o sub/x.o").collect()
     assert [c.source for c in ev.compile_units] == ["sub/x.c"]

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Make adapter coverage (ADR-029 D7)."""
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.evidence.adapters import MakeAdapter
+from abicheck.evidence.pack import EvidencePack
+
+DRY_RUN = """\
+make: Entering directory '/home/user/proj'
+gcc -std=c11 -D_GLIBCXX_USE_CXX11_ABI=0 -Iinclude -c src/a.c -o build/a.o
+@g++ -std=c++20 -c src/b.cpp -o build/b.o
+cc -shared -o libfoo.so build/a.o build/b.o
+ar rcs libbar.a build/a.o
+make: Leaving directory '/home/user/proj'
+"""
+
+
+def test_make_dry_run_extracts_compile_units():
+    ev = MakeAdapter(dry_run=DRY_RUN).collect()
+    assert ev.generators[0].kind == "make"
+    units = {c.source: c for c in ev.compile_units}
+    # Only the two `-c` compile recipes become units; link/ar/info lines are skipped.
+    assert set(units) == {"src/a.c", "src/b.cpp"}
+    assert units["src/a.c"].standard == "c11"
+    assert units["src/b.cpp"].standard == "c++20"
+
+
+def test_make_reduced_confidence_diagnostic_and_options():
+    ev = MakeAdapter(dry_run=DRY_RUN).collect()
+    assert any("reduced confidence" in d for d in ev.diagnostics)
+    opts = {(o.key, o.value) for o in ev.build_options}
+    assert ("std:C", "c11") in opts
+    assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts
+
+
+def test_make_compound_recipe_with_cd():
+    ev = MakeAdapter(dry_run="cd sub && gcc -std=c17 -c sub/x.c -o sub/x.o").collect()
+    assert [c.source for c in ev.compile_units] == ["sub/x.c"]
+    assert ev.compile_units[0].standard == "c17"
+
+
+def test_make_no_compile_lines_yields_no_units():
+    ev = MakeAdapter(dry_run="echo hello\nrm -f *.o\nmake[1]: Nothing to be done").collect()
+    assert not ev.compile_units
+    assert not any("reduced confidence" in d for d in ev.diagnostics)
+
+
+def test_make_unbalanced_quotes_line_skipped():
+    ev = MakeAdapter(dry_run='gcc -c "unterminated.c').collect()
+    assert not ev.compile_units  # the malformed line is skipped, not a crash
+
+
+def test_make_missing_dry_run_file_diagnostic(tmp_path):
+    ev = MakeAdapter(dry_run=tmp_path / "nope.txt").collect()
+    assert any("not found or unreadable" in d for d in ev.diagnostics)
+
+
+def test_make_live_query_disabled_without_build_dir():
+    ev = MakeAdapter(allow_query=False).collect()
+    assert any("live query disabled" in d for d in ev.diagnostics)
+
+
+def test_make_live_query_invokes_subprocess(monkeypatch, tmp_path):
+    import subprocess as _sp
+
+    def fake_run(cmd, **kwargs):
+        return _sp.CompletedProcess(cmd, 0, stdout="gcc -std=c++17 -c m.cpp -o m.o", stderr="")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: "/usr/bin/make")
+    monkeypatch.setattr("abicheck.evidence.adapters.make.subprocess.run", fake_run)
+    ev = MakeAdapter(build_dir=tmp_path).collect()
+    assert [c.source for c in ev.compile_units] == ["m.cpp"]
+
+
+def test_make_live_query_nonzero_exit_diagnostic(monkeypatch, tmp_path):
+    import subprocess as _sp
+
+    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: "/usr/bin/make")
+    monkeypatch.setattr("abicheck.evidence.adapters.make.subprocess.run",
+                        lambda cmd, **k: _sp.CompletedProcess(cmd, 2, stdout="", stderr="boom"))
+    ev = MakeAdapter(build_dir=tmp_path).collect()
+    assert any("exited 2" in d for d in ev.diagnostics)
+
+
+def test_make_executable_missing_diagnostic(monkeypatch, tmp_path):
+    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: None)
+    ev = MakeAdapter(build_dir=tmp_path).collect()
+    assert any("executable not found" in d for d in ev.diagnostics)
+
+
+def test_make_live_query_oserror_diagnostic(monkeypatch, tmp_path):
+    def boom(*_a, **_k):
+        raise OSError("no make")
+
+    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: "/usr/bin/make")
+    monkeypatch.setattr("abicheck.evidence.adapters.make.subprocess.run", boom)
+    ev = MakeAdapter(build_dir=tmp_path).collect()
+    assert any("dry-run failed" in d for d in ev.diagnostics)
+
+
+def test_make_compile_recipe_without_source_skipped():
+    # A `-c` line with no source token (e.g. a bare preprocessor probe).
+    ev = MakeAdapter(dry_run="gcc -c -x c -").collect()
+    assert not ev.compile_units
+
+
+def test_collect_evidence_make_dry_run_cli(tmp_path):
+    dr = tmp_path / "dry.txt"
+    dr.write_text(DRY_RUN)
+    out = tmp_path / "e"
+    result = CliRunner().invoke(main, ["collect-evidence", "--make-dry-run", str(dr), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is not None
+    assert len(pack.build_evidence.compile_units) == 2
+    assert any(e.name == "make" and e.status == "ok" for e in pack.manifest.extractors)

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -74,8 +74,16 @@ def test_make_cd_prefixed_recipe_resolves_in_subdir():
     cu = ev.compile_units[0]
     assert cu.source == "foo.c"
     assert cu.standard == "c17"
-    assert cu.directory.endswith("sub")                      # advanced into cd target
-    assert any(p.endswith("sub/include") for p in cu.include_paths)  # -I resolved there
+    # Path separators differ across OSes (sub\include on Windows); normalize.
+    assert cu.directory.replace("\\", "/").endswith("sub")    # advanced into cd target
+    assert any(p.replace("\\", "/").endswith("sub/include") for p in cu.include_paths)
+
+
+def test_make_msvc_combined_forced_include_not_source():
+    # `/FIsrc/config.hpp` is a combined MSVC forced-include with an embedded
+    # path; despite the `.hpp` it must not be read as the TU — foo.cc wins.
+    ev = MakeAdapter(dry_run="cl.exe /FIsrc/config.hpp /std:c++17 /c foo.cc /Fofoo.obj").collect()
+    assert [c.source for c in ev.compile_units] == ["foo.cc"]
 
 
 def test_make_msvc_tp_explicit_source():

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -71,47 +71,21 @@ def test_make_missing_dry_run_file_diagnostic(tmp_path):
     assert any("not found or unreadable" in d for d in ev.diagnostics)
 
 
-def test_make_live_query_disabled_without_build_dir():
-    ev = MakeAdapter(allow_query=False).collect()
-    assert any("live query disabled" in d for d in ev.diagnostics)
+def test_make_never_runs_make_without_transcript():
+    # The adapter must NOT execute make (make -n still runs `+` recipes and
+    # $(shell ...)); with no transcript it just records a diagnostic.
+    import abicheck.evidence.adapters.make as make_mod
+
+    assert not hasattr(make_mod, "subprocess")  # no exec machinery imported at all
+    ev = MakeAdapter(build_dir="/some/build").collect()
+    assert not ev.compile_units
+    assert any("never runs make" in d for d in ev.diagnostics)
 
 
-def test_make_live_query_invokes_subprocess(monkeypatch, tmp_path):
-    import subprocess as _sp
-
-    def fake_run(cmd, **kwargs):
-        return _sp.CompletedProcess(cmd, 0, stdout="gcc -std=c++17 -c m.cpp -o m.o", stderr="")
-
-    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: "/usr/bin/make")
-    monkeypatch.setattr("abicheck.evidence.adapters.make.subprocess.run", fake_run)
-    ev = MakeAdapter(build_dir=tmp_path).collect()
-    assert [c.source for c in ev.compile_units] == ["m.cpp"]
-
-
-def test_make_live_query_nonzero_exit_diagnostic(monkeypatch, tmp_path):
-    import subprocess as _sp
-
-    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: "/usr/bin/make")
-    monkeypatch.setattr("abicheck.evidence.adapters.make.subprocess.run",
-                        lambda cmd, **k: _sp.CompletedProcess(cmd, 2, stdout="", stderr="boom"))
-    ev = MakeAdapter(build_dir=tmp_path).collect()
-    assert any("exited 2" in d for d in ev.diagnostics)
-
-
-def test_make_executable_missing_diagnostic(monkeypatch, tmp_path):
-    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: None)
-    ev = MakeAdapter(build_dir=tmp_path).collect()
-    assert any("executable not found" in d for d in ev.diagnostics)
-
-
-def test_make_live_query_oserror_diagnostic(monkeypatch, tmp_path):
-    def boom(*_a, **_k):
-        raise OSError("no make")
-
-    monkeypatch.setattr("abicheck.evidence.adapters.make.shutil.which", lambda _x: "/usr/bin/make")
-    monkeypatch.setattr("abicheck.evidence.adapters.make.subprocess.run", boom)
-    ev = MakeAdapter(build_dir=tmp_path).collect()
-    assert any("dry-run failed" in d for d in ev.diagnostics)
+def test_make_force_recipe_prefix_is_tokenized():
+    # `+`-prefixed recipe lines are still parsed for facts (we never run them).
+    ev = MakeAdapter(dry_run="+gcc -std=c++17 -c forced.cpp -o forced.o").collect()
+    assert [c.source for c in ev.compile_units] == ["forced.cpp"]
 
 
 def test_make_compile_recipe_without_source_skipped():

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -67,10 +67,23 @@ def test_make_msvc_slash_c_compile_marker():
     assert [c.source for c in ev.compile_units] == ["foo.cc"]
 
 
-def test_make_compound_recipe_with_cd():
-    ev = MakeAdapter(dry_run="cd sub && gcc -std=c17 -c sub/x.c -o sub/x.o").collect()
-    assert [c.source for c in ev.compile_units] == ["sub/x.c"]
-    assert ev.compile_units[0].standard == "c17"
+def test_make_cd_prefixed_recipe_resolves_in_subdir():
+    # `cd sub && …` makes the source and -I paths relative to sub/, not the parent.
+    ev = MakeAdapter(build_dir="/proj/build",
+                     dry_run="cd sub && gcc -Iinclude -std=c17 -c foo.c -o foo.o").collect()
+    cu = ev.compile_units[0]
+    assert cu.source == "foo.c"
+    assert cu.standard == "c17"
+    assert cu.directory.endswith("sub")                      # advanced into cd target
+    assert any(p.endswith("sub/include") for p in cu.include_paths)  # -I resolved there
+
+
+def test_make_msvc_tp_explicit_source():
+    # MSVC/clang-cl name the TU via /Tp<file> (C++) / /Tc<file> (C).
+    ev = MakeAdapter(dry_run="cl.exe /c /TpSrc/foo.cc /Fofoo.obj").collect()
+    assert [c.source for c in ev.compile_units] == ["Src/foo.cc"]
+    ev2 = MakeAdapter(dry_run="cl.exe /c /Tcfoo.c").collect()
+    assert [c.source for c in ev2.compile_units] == ["foo.c"]
 
 
 def test_make_no_compile_lines_yields_no_units():

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -55,6 +55,18 @@ def test_make_forced_include_not_mistaken_for_source():
     assert [c.source for c in ev.compile_units] == ["src/foo.cc"]
 
 
+def test_make_absolute_posix_source_path():
+    # An absolute Unix source path must be recognized (not mistaken for an option).
+    ev = MakeAdapter(dry_run="gcc -std=c11 -c /work/src/foo.c -o /work/build/foo.o").collect()
+    assert [c.source for c in ev.compile_units] == ["/work/src/foo.c"]
+
+
+def test_make_msvc_slash_c_compile_marker():
+    # MSVC/clang-cl recipes use `/c` (and `/Fo<obj>`) rather than `-c`.
+    ev = MakeAdapter(dry_run="cl.exe /std:c++17 /c foo.cc /Fofoo.obj").collect()
+    assert [c.source for c in ev.compile_units] == ["foo.cc"]
+
+
 def test_make_compound_recipe_with_cd():
     ev = MakeAdapter(dry_run="cd sub && gcc -std=c17 -c sub/x.c -o sub/x.o").collect()
     assert [c.source for c in ev.compile_units] == ["sub/x.c"]


### PR DESCRIPTION
## Summary

Finalizes the **ADR-029 adapter set**, adding the last three build-graph
ingestion paths on top of the already-merged MVP (BuildEvidence model,
compile-DB / CMake File API / Ninja adapters, the build-evidence diff, and the
six D9 change kinds, #328). All normalize into the shared, build-system-neutral
`BuildEvidence` model and never run/execute project code.

### D6 — Bazel adapter (`abicheck/evidence/adapters/bazel.py`)
Consumes Bazel's official query outputs rather than parsing `BUILD` files:
- `bazel cquery --output=jsonproto` → configured target graph (kinds, `deps`
  after `select()`, sources, public headers; multi-configuration aware).
- `bazel aquery --output=jsonproto` → action graph (exact compile/link argv,
  exec paths reconstructed from the `pathFragment` tree, `depSetOfFiles`-resolved
  inputs, param-file expansion, export-policy `version_script`/`soname`/`.def`).
- Pre-captured `--bazel-cquery`/`--bazel-aquery` input by default; live query is
  opt-in and non-executing. Textual `jsonproto` only (binary proto → diagnostic).

### D7 — Make adapter (`abicheck/evidence/adapters/make.py`)
Scrapes a `make -n`/`--trace` **dry-run** transcript for compiler invocations
into **reduced-confidence** compile units (a dry run builds nothing; live
`make -n` is opt-in). Tolerates `@`-silenced recipes, `cd dir && …` compounds,
trace/info lines, and malformed lines. Wired via `--make-dry-run`. The preferred
Make input remains a generated `compile_commands.json` (`--build-system make`).

### D8 — compiler-recorded metadata (`abicheck/evidence/compiler_record.py`)
Recovers provenance from an already-built ELF without rebuilding: the
`.GCC.command.line` section (`-frecord-gcc-switches`/`-frecord-command-line`) →
ABI-relevant build options, and DWARF `DW_AT_producer` → compiler id/version.
**Advisory** unless cross-checked against build-system evidence. Wired via
`--read-compiler-record` (with `--binary`).

## Scope / remaining
This completes ADR-029 decisions **D1–D10**. Only **Phase 7 (CI rollout +
baseline registry)** remains, which the implementation plan tracks under
**ADR-033** — intentionally out of scope here. Two D6 items stay documented
limitations (binary `--output=proto` decoding; per-configuration dependency-edge
fidelity).

## Validation
- `pytest` fast lane: **8588 passed** (8552 prior + 36 new), 0 failures.
- `ruff check`, `mypy abicheck/` (127 files), `scripts/check_ai_readiness.py`: clean (0 errors).
- New modules: Bazel 95%, Make 97%, compiler_record 95% line+branch in isolation.

## Review history
Addressed 13 Codex P2 findings (source selection, export policy, param files,
multi-config, link-kind, …) plus a CodeRabbit redaction fix and two
self-review nits.

https://claude.ai/code/session_018wxhaKyctyPmQng4WEFXvq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pre-captured Bazel build context via `--bazel-cquery` and `--bazel-aquery` CLI options.
  * Added Make dry-run transcript support via new `--dry-run` option for build context extraction.
  * Added compiler-recorded metadata extraction from ELF binaries via `--read-compiler-record` option.

* **Documentation**
  * Updated evidence-pack guide with Bazel and Make adapter usage.
  * Expanded architecture decision record with expanded build context capture scope and adapter limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->