### PR TITLE
perf: fix super-linear compare bottlenecks + flexible CI scaling benchmark

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,15 +2,14 @@ name: Performance
 
 # Flexible, non-gating performance tracking for the comparison pipeline.
 #
-# Why non-gating: `compare` is known to scale super-linearly on large real
-# libraries (e.g. libonedal_core.so, ~10,550 functions, does not finish a
-# compare in 60 s) — see docs/development/performance.md. Until those
-# post-processing bottlenecks are addressed, this workflow only *measures*:
-# it runs the synthetic scaling benchmark and the `slow` perf tests, then
-# uploads the numbers and writes them to the job summary. Nothing here blocks
-# a merge.
+# The post-processing bottlenecks that made `compare` blow up on large real
+# libraries (e.g. libonedal_core.so, ~10,550 functions) are fixed — see
+# docs/development/performance.md. This workflow guards against regressions: it
+# runs the synthetic scaling benchmark and the `slow` perf tests, uploads the
+# numbers, and writes them to the job summary. It is intentionally non-gating
+# (continue-on-error) so it never blocks a merge while a budget is being tuned.
 #
-# How to turn gating on later: add `--max-seconds <budget>` and/or
+# How to turn gating on: add `--max-seconds <budget>` and/or
 # `--max-exponent <slope>` to the scaling step below and drop
 # `continue-on-error`. The thresholds are deliberately CLI flags so the budget
 # lives in this workflow, not hard-coded in the script.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,7 +30,7 @@ on:
     # Weekly, Monday 06:42 UTC — offset from other scheduled jobs.
     - cron: "42 6 * * 1"
   pull_request:
-    types: [labeled, synchronize]
+    types: [opened, reopened, synchronize, labeled]
     paths:
       - "abicheck/diff_*.py"
       - "abicheck/checker.py"
@@ -44,14 +44,15 @@ on:
 permissions:
   contents: read
 
-# Only run the PR lane when the `performance` label is present; the scheduled
-# and manual lanes always run.
+# The PR lane runs whenever a PR changes the detector core (the `paths` filter
+# above), plus on the weekly schedule and on manual dispatch. It is
+# `continue-on-error`, so auto-running on those PRs measures without blocking.
+# Adding the `performance` label re-triggers the lane on a PR (the `labeled`
+# event); for an arbitrary PR that does not touch the detector core, use
+# `workflow_dispatch` to run it on demand.
 jobs:
   scaling:
     name: Comparison scaling benchmark
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'performance')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,6 +36,8 @@ on:
       - "abicheck/checker_policy.py"
       - "abicheck/post_processing.py"
       - "abicheck/demangle.py"
+      - "abicheck/binary_fingerprint.py"
+      - "abicheck/surface.py"
       - "scripts/benchmark_scaling.py"
       - "tests/test_performance.py"
       - ".github/workflows/performance.yml"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,110 @@
+name: Performance
+
+# Flexible, non-gating performance tracking for the comparison pipeline.
+#
+# Why non-gating: `compare` is known to scale super-linearly on large real
+# libraries (e.g. libonedal_core.so, ~10,550 functions, does not finish a
+# compare in 60 s) — see docs/development/performance.md. Until those
+# post-processing bottlenecks are addressed, this workflow only *measures*:
+# it runs the synthetic scaling benchmark and the `slow` perf tests, then
+# uploads the numbers and writes them to the job summary. Nothing here blocks
+# a merge.
+#
+# How to turn gating on later: add `--max-seconds <budget>` and/or
+# `--max-exponent <slope>` to the scaling step below and drop
+# `continue-on-error`. The thresholds are deliberately CLI flags so the budget
+# lives in this workflow, not hard-coded in the script.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sizes:
+        description: "Function counts to sweep (space-separated)"
+        required: false
+        default: "500 1000 2000 4000"
+      max_seconds:
+        description: "Optional gate: fail if any compare exceeds this many seconds (blank = measure only)"
+        required: false
+        default: ""
+  schedule:
+    # Weekly, Monday 06:42 UTC — offset from other scheduled jobs.
+    - cron: "42 6 * * 1"
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - "abicheck/diff_*.py"
+      - "abicheck/checker.py"
+      - "abicheck/checker_policy.py"
+      - "abicheck/post_processing.py"
+      - "abicheck/demangle.py"
+      - "scripts/benchmark_scaling.py"
+      - "tests/test_performance.py"
+      - ".github/workflows/performance.yml"
+
+permissions:
+  contents: read
+
+# Only run the PR lane when the `performance` label is present; the scheduled
+# and manual lanes always run.
+jobs:
+  scaling:
+    name: Comparison scaling benchmark
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'performance')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          # c++filt for the ELF-only / namespace demangling scenario.
+          sudo apt-get update -qq && sudo apt-get install -y binutils
+
+      - name: Run scaling benchmark
+        run: |
+          set -euo pipefail
+          mkdir -p reports/perf
+          SIZES="${{ github.event.inputs.sizes || '500 1000 2000 4000' }}"
+          GATE=""
+          if [ -n "${{ github.event.inputs.max_seconds }}" ]; then
+            GATE="--max-seconds ${{ github.event.inputs.max_seconds }}"
+          fi
+          python scripts/benchmark_scaling.py \
+            --sizes $SIZES \
+            --repeat 2 \
+            --json-out reports/perf/scaling.json \
+            $GATE | tee reports/perf/scaling.txt
+
+      - name: Run slow perf tests
+        run: |
+          pytest tests/test_performance.py -v --tb=short -m slow
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Comparison scaling benchmark"
+            echo ""
+            echo '```'
+            cat reports/perf/scaling.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload performance artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: performance-scaling
+          path: reports/perf

--- a/abicheck/binary_fingerprint.py
+++ b/abicheck/binary_fingerprint.py
@@ -283,15 +283,17 @@ def match_renamed_functions(
     used_new: set[str] = set()
     candidates = _match_exact(old_candidates, new_by_hash, used_new)
     matched_old = {c.old_name for c in candidates}
-    # The name-similarity predicate is the expensive per-pair gate. When the
-    # candidate sets are large enough that passes 2/3 would degrade to an
-    # O(removed×added) name-filter scan, a *unique* size match cannot exist
-    # anyway, so applying the predicate is pure waste: drop it (pass 2 still
-    # runs as cheap size-uniqueness) and skip the fuzzy pass entirely.
-    small_enough = len(old_candidates) * len(new_candidates) <= _FUZZY_MAX_PAIRS
-    pass_filter = name_filter if small_enough else None
-    candidates += _match_size(old_candidates, new_by_size, used_new, matched_old, pass_filter)
-    if small_enough:
+    # Pass 2 (size-only) ALWAYS keeps the name predicate: matching a removed
+    # symbol to an unrelated same-size added one would mislabel a real
+    # removal/addition as a rename and hide an ABI break. The predicate cost is
+    # bounded by the size-bucket short-circuit in _match_size, so it stays cheap
+    # for the spread-out symbol sizes real libraries have.
+    candidates += _match_size(old_candidates, new_by_size, used_new, matched_old, name_filter)
+    # Pass 3 (fuzzy) is the only O(removed×added) pass and is a low-confidence
+    # heuristic, so skip it entirely when the candidate sets are large enough
+    # that a *unique* fuzzy match could not be meaningful anyway. Skipping fuzzy
+    # only forgoes speculative rename matches — it never hides a break.
+    if len(old_candidates) * len(new_candidates) <= _FUZZY_MAX_PAIRS:
         candidates += _match_fuzzy(old_candidates, new_by_size, used_new, matched_old, name_filter)
 
     # Sort by confidence descending

--- a/abicheck/binary_fingerprint.py
+++ b/abicheck/binary_fingerprint.py
@@ -151,6 +151,14 @@ _MIN_SYMBOL_SIZE = 8
 # Maximum relative size difference for fuzzy matching (no code hash).
 _SIZE_TOLERANCE_RATIO = 0.05  # 5%
 
+# Upper bound on removed×added pairs before the fuzzy pass (pass 3) is skipped.
+# The fuzzy pass requires a *unique* size+name match, so when both the removed
+# and added sets are large its O(removed×added) name-similarity scan cannot
+# produce reliable matches anyway (everything is ambiguous). Skipping it keeps
+# a mass-rename / fully-stripped comparison from blowing up — the exact and
+# size-unique passes (1 and 2) still run.
+_FUZZY_MAX_PAIRS = 2_000_000
+
 # Sections to include in BinarySummary for ABI-relevant triage.
 _ABI_SECTIONS = frozenset({
     ".text", ".rodata", ".data", ".bss", ".data.rel.ro",
@@ -275,8 +283,16 @@ def match_renamed_functions(
     used_new: set[str] = set()
     candidates = _match_exact(old_candidates, new_by_hash, used_new)
     matched_old = {c.old_name for c in candidates}
-    candidates += _match_size(old_candidates, new_by_size, used_new, matched_old, name_filter)
-    candidates += _match_fuzzy(old_candidates, new_candidates, used_new, matched_old, name_filter)
+    # The name-similarity predicate is the expensive per-pair gate. When the
+    # candidate sets are large enough that passes 2/3 would degrade to an
+    # O(removed×added) name-filter scan, a *unique* size match cannot exist
+    # anyway, so applying the predicate is pure waste: drop it (pass 2 still
+    # runs as cheap size-uniqueness) and skip the fuzzy pass entirely.
+    small_enough = len(old_candidates) * len(new_candidates) <= _FUZZY_MAX_PAIRS
+    pass_filter = name_filter if small_enough else None
+    candidates += _match_size(old_candidates, new_by_size, used_new, matched_old, pass_filter)
+    if small_enough:
+        candidates += _match_fuzzy(old_candidates, new_by_size, used_new, matched_old, name_filter)
 
     # Sort by confidence descending
     candidates.sort(key=lambda c: (-c.confidence, c.old_name))
@@ -339,16 +355,23 @@ def _match_size(
     for old_name, old_fp in sorted(old_candidates.items()):
         if old_name in matched_old:
             continue
-        size_matches = [
-            (n, fp)
-            for n, fp in new_by_size.get(old_fp.size, [])
-            if n not in used_new
+        # Only a *unique* same-size candidate matches, so stop once a second one
+        # is found — this keeps a crowded size bucket from triggering an
+        # O(bucket) name-filter scan per old symbol.
+        size_matches: list[tuple[str, FunctionFingerprint]] = []
+        for n, fp in new_by_size.get(old_fp.size, []):
+            if n in used_new:
+                continue
             # A same-size candidate with a conflicting code hash can never match
             # — exclude it before the ambiguity check so it does not block the
             # one eligible partner and drop a real rename.
-            and not (old_fp.code_hash and fp.code_hash and old_fp.code_hash != fp.code_hash)
-            and (name_filter is None or name_filter(old_name, n))
-        ]
+            if old_fp.code_hash and fp.code_hash and old_fp.code_hash != fp.code_hash:
+                continue
+            if name_filter is not None and not name_filter(old_name, n):
+                continue
+            size_matches.append((n, fp))
+            if len(size_matches) > 1:
+                break
         # Only match if there's exactly one candidate at this size
         # (ambiguous matches are not reliable)
         if len(size_matches) != 1:
@@ -370,33 +393,49 @@ def _match_size(
 
 def _fuzzy_partners(
     old_fp: FunctionFingerprint,
-    new_candidates: dict[str, FunctionFingerprint],
+    new_by_size: dict[int, list[tuple[str, FunctionFingerprint]]],
     used_new: set[str],
     name_filter: Callable[[str, str], bool] | None = None,
 ) -> list[tuple[str, FunctionFingerprint]]:
-    """New candidates whose size is within tolerance of ``old_fp`` and unused."""
+    """New candidates whose size is within tolerance of ``old_fp`` and unused.
+
+    Only the sizes inside the tolerance window are scanned (via *new_by_size*)
+    instead of every new candidate, so a symbol with a distinctive size pays
+    O(window) rather than O(all candidates). The caller only needs to know
+    whether there is exactly one partner, so we stop after finding a second.
+    """
     partners: list[tuple[str, FunctionFingerprint]] = []
-    for new_name, new_fp in new_candidates.items():
-        if new_name in used_new or new_fp.size == 0:
-            continue
-        # If both have code hashes but they differ, skip
-        if old_fp.code_hash and new_fp.code_hash and old_fp.code_hash != new_fp.code_hash:
-            continue
-        size_diff = abs(old_fp.size - new_fp.size) / max(old_fp.size, new_fp.size)
-        if size_diff > _SIZE_TOLERANCE_RATIO:
-            continue
-        # Name similarity is the most expensive gate (demangle + bracket scan),
-        # so apply it last — only to size-eligible partners, not the whole
-        # cross-product.
-        if name_filter is not None and not name_filter(old_fp.name, new_name):
-            continue
-        partners.append((new_name, new_fp))
+    size = old_fp.size
+    if size == 0:
+        return partners
+    # new sizes satisfying abs(size-new)/max(size,new) <= tol lie within
+    # [size*(1-tol), size/(1-tol)]; widen by 1 each way to absorb int rounding.
+    lo = int(size * (1 - _SIZE_TOLERANCE_RATIO)) - 1
+    hi = int(size / (1 - _SIZE_TOLERANCE_RATIO)) + 1
+    for s in range(lo, hi + 1):
+        for new_name, new_fp in new_by_size.get(s, ()):
+            if new_name in used_new or new_fp.size == 0:
+                continue
+            # If both have code hashes but they differ, skip
+            if old_fp.code_hash and new_fp.code_hash and old_fp.code_hash != new_fp.code_hash:
+                continue
+            if abs(size - new_fp.size) / max(size, new_fp.size) > _SIZE_TOLERANCE_RATIO:
+                continue
+            # Name similarity is the most expensive gate (demangle + bracket
+            # scan), so apply it last — only to size-eligible partners.
+            if name_filter is not None and not name_filter(old_fp.name, new_name):
+                continue
+            partners.append((new_name, new_fp))
+            if len(partners) > 1:
+                # The caller matches only on a unique partner; two is enough to
+                # know it is not unique.
+                return partners
     return partners
 
 
 def _match_fuzzy(
     old_candidates: dict[str, FunctionFingerprint],
-    new_candidates: dict[str, FunctionFingerprint],
+    new_by_size: dict[int, list[tuple[str, FunctionFingerprint]]],
     used_new: set[str],
     matched_old: set[str],
     name_filter: Callable[[str, str], bool] | None = None,
@@ -406,7 +445,7 @@ def _match_fuzzy(
     for old_name, old_fp in sorted(old_candidates.items()):
         if old_name in matched_old or old_fp.size == 0:
             continue
-        fuzzy_matches = _fuzzy_partners(old_fp, new_candidates, used_new, name_filter)
+        fuzzy_matches = _fuzzy_partners(old_fp, new_by_size, used_new, name_filter)
         if len(fuzzy_matches) == 1:
             new_name, new_fp = fuzzy_matches[0]
             out.append(RenameCandidate(

--- a/abicheck/binary_fingerprint.py
+++ b/abicheck/binary_fingerprint.py
@@ -30,6 +30,7 @@ opens files as given and does not sanitize or restrict path traversal.
 """
 from __future__ import annotations
 
+import bisect
 import hashlib
 import logging
 import os
@@ -396,15 +397,18 @@ def _match_size(
 def _fuzzy_partners(
     old_fp: FunctionFingerprint,
     new_by_size: dict[int, list[tuple[str, FunctionFingerprint]]],
+    sorted_sizes: list[int],
     used_new: set[str],
     name_filter: Callable[[str, str], bool] | None = None,
 ) -> list[tuple[str, FunctionFingerprint]]:
     """New candidates whose size is within tolerance of ``old_fp`` and unused.
 
-    Only the sizes inside the tolerance window are scanned (via *new_by_size*)
-    instead of every new candidate, so a symbol with a distinctive size pays
-    O(window) rather than O(all candidates). The caller only needs to know
-    whether there is exactly one partner, so we stop after finding a second.
+    Only the *populated* candidate sizes inside the tolerance window are
+    scanned: a binary search over the pre-sorted size keys picks the window so
+    cost depends on the number of candidate sizes, not the symbol's byte size
+    (a multi-MB function would otherwise sweep millions of empty sizes). The
+    caller only needs to know whether there is exactly one partner, so we stop
+    after finding a second.
     """
     partners: list[tuple[str, FunctionFingerprint]] = []
     size = old_fp.size
@@ -414,7 +418,9 @@ def _fuzzy_partners(
     # [size*(1-tol), size/(1-tol)]; widen by 1 each way to absorb int rounding.
     lo = int(size * (1 - _SIZE_TOLERANCE_RATIO)) - 1
     hi = int(size / (1 - _SIZE_TOLERANCE_RATIO)) + 1
-    for s in range(lo, hi + 1):
+    left = bisect.bisect_left(sorted_sizes, lo)
+    right = bisect.bisect_right(sorted_sizes, hi)
+    for s in sorted_sizes[left:right]:
         for new_name, new_fp in new_by_size.get(s, ()):
             if new_name in used_new or new_fp.size == 0:
                 continue
@@ -444,10 +450,13 @@ def _match_fuzzy(
 ) -> list[RenameCandidate]:
     """Pass 3: fuzzy size matches (within tolerance, unique match only)."""
     out: list[RenameCandidate] = []
+    # Sorted size keys, computed once, so each old symbol's tolerance window is
+    # a binary-search slice over populated sizes rather than a dense range.
+    sorted_sizes = sorted(new_by_size)
     for old_name, old_fp in sorted(old_candidates.items()):
         if old_name in matched_old or old_fp.size == 0:
             continue
-        fuzzy_matches = _fuzzy_partners(old_fp, new_by_size, used_new, name_filter)
+        fuzzy_matches = _fuzzy_partners(old_fp, new_by_size, sorted_sizes, used_new, name_filter)
         if len(fuzzy_matches) == 1:
             new_name, new_fp = fuzzy_matches[0]
             out.append(RenameCandidate(

--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -152,20 +152,25 @@ def _all_ancestors(
 def _resolve_ancestor_functions(
     tname: str,
     ancestors: set[str],
-    type_to_funcs: dict[str, list[str]],
-    type_to_mangled: dict[str, list[str]],
+    type_to_funcs: dict[str, set[str]],
+    type_to_mangled: dict[str, set[str]],
     old_pub: dict[str, Function],
     ancestor_func_cache: dict[str, list[tuple[str, str]]],
 ) -> None:
-    """Scan ancestor types and extend type_to_funcs/type_to_mangled for *tname*."""
+    """Union ancestor-type functions into type_to_funcs/type_to_mangled for *tname*.
+
+    Sets (not lists) are used so a type reachable through many ancestors does
+    not accumulate the same function name repeatedly — list accumulation here
+    made deeply-nested type graphs grow super-quadratically.
+    """
     for parent in ancestors:
         if parent in type_to_funcs:
-            type_to_funcs[tname].extend(type_to_funcs[parent])
-            type_to_mangled[tname].extend(type_to_mangled.get(parent, []))
+            type_to_funcs[tname].update(type_to_funcs[parent])
+            type_to_mangled[tname].update(type_to_mangled.get(parent, set()))
         elif parent in ancestor_func_cache:
             for fname, mname in ancestor_func_cache[parent]:
-                type_to_funcs[tname].append(fname)
-                type_to_mangled[tname].append(mname)
+                type_to_funcs[tname].add(fname)
+                type_to_mangled[tname].add(mname)
         else:
             parent_funcs: list[tuple[str, str]] = []
             for _m, func in old_pub.items():
@@ -174,8 +179,8 @@ def _resolve_ancestor_functions(
                     parent_funcs.append((func.name, func.mangled))
             ancestor_func_cache[parent] = parent_funcs
             for fname, mname in parent_funcs:
-                type_to_funcs[tname].append(fname)
-                type_to_mangled[tname].append(mname)
+                type_to_funcs[tname].add(fname)
+                type_to_mangled[tname].add(mname)
 
 
 def _collect_function_type_refs(func: Function) -> set[str]:
@@ -192,16 +197,16 @@ def _collect_function_type_refs(func: Function) -> set[str]:
 def _build_type_to_funcs(
     affected_types: set[str],
     old_pub: dict[str, Function],
-) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
-    """Build type→(demangled, mangled) function name lists from public functions."""
-    type_to_funcs: dict[str, list[str]] = {t: [] for t in affected_types}
-    type_to_mangled: dict[str, list[str]] = {t: [] for t in affected_types}
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Build type→(demangled, mangled) function name sets from public functions."""
+    type_to_funcs: dict[str, set[str]] = {t: set() for t in affected_types}
+    type_to_mangled: dict[str, set[str]] = {t: set() for t in affected_types}
     for _mangled, func in old_pub.items():
         func_types_used = _collect_function_type_refs(func)
         for tname in affected_types:
             if any(tname in ft for ft in func_types_used):
-                type_to_funcs[tname].append(func.name)
-                type_to_mangled[tname].append(func.mangled)
+                type_to_funcs[tname].add(func.name)
+                type_to_mangled[tname].add(func.mangled)
     return type_to_funcs, type_to_mangled
 
 
@@ -221,17 +226,17 @@ def _build_type_embed_index(
 
 def _assign_affected_symbols_to_changes(
     type_changes: list[Change],
-    type_to_funcs: dict[str, list[str]],
-    type_to_mangled: dict[str, list[str]],
+    type_to_funcs: dict[str, set[str]],
+    type_to_mangled: dict[str, set[str]],
 ) -> None:
     """Populate Change.affected_symbols from the type-to-function mappings."""
     for c in type_changes:
         type_name = _root_type_name(c)
-        funcs = type_to_funcs.get(type_name, [])
-        mangled_funcs = type_to_mangled.get(type_name, [])
+        funcs = type_to_funcs.get(type_name, set())
+        mangled_funcs = type_to_mangled.get(type_name, set())
         if funcs:
             # Store both demangled and mangled names for cross-format matching
-            c.affected_symbols = sorted(set(funcs) | set(mangled_funcs))
+            c.affected_symbols = sorted(funcs | mangled_funcs)
 
 
 def _enrich_affected_symbols(

--- a/abicheck/diff_namespaces.py
+++ b/abicheck/diff_namespaces.py
@@ -127,19 +127,28 @@ def _strip_experimental(
     return qualified, None
 
 
-def _qualified_function_name(name: str, mangled: str) -> str:
+def _qualified_function_name(
+    name: str, mangled: str, demangled: dict[str, str] | None = None
+) -> str:
     """Return the best-effort qualified declaration name for a function.
 
     Header-derived snapshots populate ``Function.name`` with the
     qualified declaration name (``acme::lib::sort``). ELF-only mode
     leaves ``Function.name`` set to the mangled string; in that case we
-    fall back to lazy demangling of the mangled name. We import
-    ``demangle_batch`` lazily so that snapshots containing no functions
-    (a common case in unit-test fixtures) do not pay the import cost.
+    fall back to demangling of the mangled name.
+
+    When iterating all functions of a snapshot, pass a *demangled* map
+    (from :func:`_batch_demangle_public`) so the whole snapshot is demangled in
+    a single batched ``c++filt`` call instead of one subprocess per symbol —
+    the per-symbol path is what makes namespace detection explode on large
+    stripped libraries. The lazy single-symbol fallback is kept for callers
+    that have no batch (and is itself memoised in ``demangle_batch``).
     """
     if "::" in name or "<" in name:
         return name
     if mangled.startswith("_Z"):
+        if demangled is not None:
+            return demangled.get(mangled, name)
         from .demangle import demangle_batch
         return demangle_batch([mangled]).get(mangled, name)
     return name
@@ -173,11 +182,12 @@ def _index_funcs_by_stable_key(
     ``experimental::`` don't get reported.
     """
     from .model import Visibility
+    demangled = _batch_demangle_public(snap)
     out: dict[tuple[str, str], list[str]] = {}
     for f in snap.functions:
         if f.visibility != Visibility.PUBLIC:
             continue
-        qname = _qualified_function_name(f.name, f.mangled)
+        qname = _qualified_function_name(f.name, f.mangled, demangled)
         segs = _segments(qname)
         if not segs:
             continue
@@ -377,11 +387,12 @@ def _looks_like_std_reexport(
 def _collect_public_declared_names(snap: AbiSnapshot) -> set[str]:
     """Return the set of qualified declared names of public functions in *snap*."""
     from .model import Visibility
+    demangled = _batch_demangle_public(snap)
     out: set[str] = set()
     for f in snap.functions:
         if f.visibility != Visibility.PUBLIC:
             continue
-        qname = _qualified_function_name(f.name, f.mangled)
+        qname = _qualified_function_name(f.name, f.mangled, demangled)
         if qname:
             out.add(qname)
     return out
@@ -441,7 +452,7 @@ def detect_std_reexport_removed(
     for f in old.functions:
         if f.visibility != Visibility.PUBLIC:
             continue
-        declared = _qualified_function_name(f.name, f.mangled)
+        declared = _qualified_function_name(f.name, f.mangled, demangled)
         if not declared or declared in seen or declared in new_declared:
             continue
         underlying = demangled.get(f.mangled, "")
@@ -531,11 +542,12 @@ def _index_versioned(
 def _collect_versioned_entries(snap: AbiSnapshot) -> list[tuple[str, str]]:
     """Return ``[(qualified_name, "function"|"type"), …]`` for *snap*."""
     from .model import Visibility
+    demangled = _batch_demangle_public(snap)
     items: list[tuple[str, str]] = []
     for f in snap.functions:
         if f.visibility != Visibility.PUBLIC:
             continue
-        qname = _qualified_function_name(f.name, f.mangled)
+        qname = _qualified_function_name(f.name, f.mangled, demangled)
         if qname:
             items.append((qname, "function"))
     for t in snap.types:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -16,8 +16,10 @@
 """Symbol-level ABI diff detectors (functions, variables, parameters)."""
 from __future__ import annotations
 
+import bisect
 import logging
 import re
+from functools import lru_cache
 from typing import Any
 
 from .binary_fingerprint import (
@@ -1152,18 +1154,30 @@ def _find_rename_pairs(
     old_map: dict[str, Function],
     new_map: dict[str, Function],
 ) -> list[tuple[str, str]]:
-    """Return (old_name, new_name) pairs where new_name has a common prefix added to old_name."""
+    """Return (old_name, new_name) pairs where new_name has a common prefix added to old_name.
+
+    The match condition is ``a_name.endswith(r_name)`` with ``a_name`` strictly
+    longer (a prefix was prepended). The old ``endswith("_" + r_name)`` branch
+    was redundant — any name ending with ``"_" + r_name`` already ends with
+    ``r_name``. To avoid the O(removed × added) cross-product, index the added
+    names *reversed* so the suffix test becomes a prefix lookup: a binary search
+    locates the contiguous block of reversed added names that start with the
+    reversed removed name. Both ``removed`` and the reversed index are iterated
+    in sorted order, so the result is deterministic.
+    """
+    rev_index = sorted((new_map[a_sym].name[::-1], new_map[a_sym].name) for a_sym in added)
+    rev_keys = [k for k, _ in rev_index]
     pairs: list[tuple[str, str]] = []
-    for r_sym in removed:
+    for r_sym in sorted(removed):
         r_name = old_map[r_sym].name
-        for a_sym in added:
-            a_name = new_map[a_sym].name
-            if a_name.endswith(r_name) and len(a_name) > len(r_name):
+        rk = r_name[::-1]
+        i = bisect.bisect_left(rev_keys, rk)
+        while i < len(rev_keys) and rev_keys[i].startswith(rk):
+            a_name = rev_index[i][1]
+            if len(a_name) > len(r_name):
                 pairs.append((r_name, a_name))
                 break
-            if a_name.endswith("_" + r_name) and len(a_name) > len(r_name) + 1:
-                pairs.append((r_name, a_name))
-                break
+            i += 1
     return pairs
 
 
@@ -1756,6 +1770,28 @@ def _return_type_of(s: str) -> str:
     return s[:sp].strip() if sp != -1 else ""
 
 
+@lru_cache(maxsize=65536)
+def _rename_name_parse(name: str) -> tuple[str | None, str, str, str]:
+    """Per-name pieces used by :func:`_plausible_rename`, demangled once.
+
+    Returns ``(ctor_dtor_variant, leaf, param_signature, return_type)``. The
+    name-similarity gate compares every removed symbol against every size-
+    eligible added one, so the same name is parsed many times; caching the
+    per-name derivation keeps that gate from re-demangling and re-parsing the
+    same symbol on each pair (the dominant cost of rename detection on large
+    ELF-only libraries). Bounded so it cannot grow without limit.
+    """
+    from .demangle import demangle
+
+    d = demangle(name) or name
+    return (
+        _ctor_dtor_variant(name),
+        _unqualified_name_of(d),
+        _param_signature_of(d),
+        _return_type_of(d),
+    )
+
+
 def _plausible_rename(old_name: str, new_name: str) -> bool:
     """Whether two symbol names are similar enough to credibly be a rename.
 
@@ -1781,18 +1817,10 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     # ``B::A()`` both reduce to leaf ``A()``), since a constructor ABI symbol
     # cannot be satisfied by an ordinary member. (Checked on the raw mangled
     # name, so it catches the case the demangler collapses to an identical leaf.)
-    ov, nv = _ctor_dtor_variant(old_name), _ctor_dtor_variant(new_name)
+    ov, a, pa, ra = _rename_name_parse(old_name)
+    nv, b, pb, rb = _rename_name_parse(new_name)
     if (ov is not None or nv is not None) and ov != nv:
         return False
-    # Demangle each name exactly once and reuse the result for both the leaf and
-    # the parameter signature (rather than relying on the demangle LRU cache,
-    # which can thrash on libraries with > 16k symbols).
-    from .demangle import demangle
-
-    da = demangle(old_name) or old_name
-    db = demangle(new_name) or new_name
-    a = _unqualified_name_of(da)
-    b = _unqualified_name_of(db)
     # Undemangleable mangled names: when no demangler is available the leaf is
     # the raw Itanium spelling, whose shared boilerplate (``_ZN``, type codes,
     # …) would inflate the affix score and pair unrelated symbols. Demangling is
@@ -1813,10 +1841,7 @@ def _plausible_rename(old_name: str, new_name: str) -> bool:
     # change to either is a distinct ABI symbol (foo(int) -> foo(long), or
     # int foo<int>() -> long foo<int>()), not a rename. Ordinary (non-template)
     # functions demangle without a return type, so that check is a no-op there.
-    sig_match = (
-        _param_signature_of(da) == _param_signature_of(db)
-        and _return_type_of(da) == _return_type_of(db)
-    )
+    sig_match = pa == pb and ra == rb
     if a == b:
         # Same unqualified name + template args: a rename only if the signature
         # also matches (else it is a signature change).

--- a/abicheck/diff_type_spellings.py
+++ b/abicheck/diff_type_spellings.py
@@ -105,7 +105,10 @@ def _match_functions_by_mangled(
         yield from _emit_function_slot_changes(old_fns[key], new_fns[key])
 
     # Fallback: pair functions whose mangled name changed (char8_t/_BitInt/_Atomic).
-    leftover_old = [f for k, f in old_fns.items() if k not in set(new_fns)]
+    # Precompute the new-key set once — rebuilding it inside the comprehension
+    # is O(functions) per element, i.e. quadratic.
+    new_keys = set(new_fns)
+    leftover_old = [f for k, f in old_fns.items() if k not in new_keys]
     leftover_new = [f for k, f in new_fns.items() if k not in matched_new]
     if leftover_old and leftover_new:
         yield from _pair_leftover_functions_by_name(leftover_old, leftover_new)

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -250,7 +250,11 @@ class FilterNonPublicSurface:
     def run(self, changes: list[Change], ctx: PipelineContext) -> list[Change]:
         if not ctx.scope_to_public_surface:
             return changes
-        from .surface import classify_change_surface, compute_public_surface
+        from .surface import (
+            classify_change_surface,
+            compute_public_surface,
+            surface_unions,
+        )
 
         surf_old = compute_public_surface(ctx.old)
         surf_new = compute_public_surface(ctx.new)
@@ -264,6 +268,10 @@ class FilterNonPublicSurface:
             ctx.scope_fell_back = True
             return changes
         force_public = ctx.force_public_symbols
+        # Compute the old∪new surface universes once for the whole pass; doing
+        # this per change is O(findings × surface) and makes large comparisons
+        # quadratic.
+        unions = surface_unions(surf_old, surf_new)
         kept: list[Change] = []
         for c in changes:
             # Widening overlay (ADR-024 §D6): a user-guaranteed public symbol
@@ -271,7 +279,7 @@ class FilterNonPublicSurface:
             if force_public and _change_matches_symbols(c, force_public):
                 kept.append(c)
                 continue
-            in_surface, reason = classify_change_surface(c, surf_old, surf_new)
+            in_surface, reason = classify_change_surface(c, surf_old, surf_new, unions=unions)
             if in_surface:
                 kept.append(c)
             else:

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -530,10 +530,39 @@ def _origin_reason(
     return None
 
 
+@dataclass(frozen=True)
+class SurfaceUnions:
+    """The four old∪new surface universes used to classify a finding.
+
+    These depend only on the surface *pair*, not on the individual change, so
+    when classifying many findings against the same surfaces they should be
+    computed once and reused — recomputing the unions per change is
+    O(findings × surface) and makes large comparisons quadratic. Build with
+    :func:`surface_unions` and pass to :func:`classify_change_surface`.
+    """
+
+    public_symbols: frozenset[str]
+    all_symbols: frozenset[str]
+    public_types: frozenset[str]
+    all_types: frozenset[str]
+
+
+def surface_unions(surf_old: PublicSurface, surf_new: PublicSurface) -> SurfaceUnions:
+    """Compute the old∪new surface universes once for a surface pair."""
+    return SurfaceUnions(
+        public_symbols=frozenset(surf_old.public_symbols | surf_new.public_symbols),
+        all_symbols=frozenset(surf_old.all_symbols | surf_new.all_symbols),
+        public_types=frozenset(surf_old.public_types | surf_new.public_types),
+        all_types=frozenset(surf_old.all_types | surf_new.all_types),
+    )
+
+
 def classify_change_surface(
     change: Change,
     surf_old: PublicSurface,
     surf_new: PublicSurface,
+    *,
+    unions: SurfaceUnions | None = None,
 ) -> tuple[bool, str | None]:
     """Classify *change* against the public surface.
 
@@ -544,6 +573,11 @@ def classify_change_surface(
     Conservative by construction (ADR-024 §D5): leak findings, unknown
     symbols, and unknown types all stay in-surface so scoping can only ever
     remove findings it is *confident* are private.
+
+    When classifying many changes against the same surface pair, pass a
+    precomputed *unions* (see :func:`surface_unions`) to avoid recomputing the
+    four old∪new set unions on every call — that recomputation is what makes a
+    large comparison quadratic in the number of findings.
     """
     if change.kind.value in _NEVER_FILTER_KIND_NAMES:
         return True, None
@@ -553,10 +587,12 @@ def classify_change_surface(
         # rather than risk hiding a real change from the unresolved side.
         return True, None
 
-    public_symbols = surf_old.public_symbols | surf_new.public_symbols
-    all_symbols = surf_old.all_symbols | surf_new.all_symbols
-    public_types = surf_old.public_types | surf_new.public_types
-    all_types = surf_old.all_types | surf_new.all_types
+    if unions is None:
+        unions = surface_unions(surf_old, surf_new)
+    public_symbols = unions.public_symbols
+    all_symbols = unions.all_symbols
+    public_types = unions.public_types
+    all_types = unions.all_types
 
     sym = change.symbol or ""
     # Type-level findings must not be classified via the symbol universe first:

--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -89,8 +89,9 @@ runs the scaling benchmark and the `slow` performance tests. It is deliberately
 
 - Triggers: weekly schedule, manual `workflow_dispatch` (with size / budget
   inputs), and **automatically on any PR that changes the detector core**
-  (`abicheck/diff_*.py`, `checker.py`, `post_processing.py`, `demangle.py`, the
-  benchmark script, or the perf test). Adding the **`performance`** label
+  (`abicheck/diff_*.py`, `checker.py`, `post_processing.py`, `demangle.py`,
+  `binary_fingerprint.py`, `surface.py`, the benchmark script, or the perf
+  test). Adding the **`performance`** label
   re-triggers the lane; for a PR that does not touch the detector core, run it
   on demand with `workflow_dispatch`.
 - `continue-on-error: true` — it never blocks a merge.

--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -1,0 +1,152 @@
+# Comparison Performance
+
+This page evaluates the runtime cost of comparing **real, large** shared
+libraries and documents the tooling that tracks it in CI.
+
+## TL;DR
+
+- **Dump scales fine.** Snapshotting `libonedal_core.so` (~10,550 exported
+  functions) takes ~5 s.
+- **Compare does not.** On the same library, `compare` did **not finish within
+  60 s**. The cost is in the *post-processing* detectors, not the core symbol
+  diff.
+- Two bottlenecks dominate, both super-linear in the number of functions:
+  1. A **`c++filt` subprocess storm** in namespace detection — one subprocess
+     spawn per unique mangled symbol instead of one batched call.
+  2. An **O(functions × types) substring scan** in opaque/pointer-only type
+     filtering.
+- Because of this, **performance gating is intentionally off**. CI *measures*
+  and reports; it does not block. See [CI integration](#ci-integration) for how
+  to enable a budget once the bottlenecks are fixed.
+
+## How to reproduce
+
+No real binary, compiler, or castxml required — the scaling harness synthesises
+`AbiSnapshot` pairs that exercise the expensive paths:
+
+```bash
+# Sweep the default sizes across all scenarios and print a table.
+python scripts/benchmark_scaling.py
+
+# Focus the realistic hot path and emit machine-readable JSON.
+python scripts/benchmark_scaling.py --scenario type_churn \
+    --sizes 1000 2000 4000 8000 --json-out reports/perf/scaling.json
+```
+
+The harness defines three workloads:
+
+| Scenario | What it stresses | Represents |
+|----------|------------------|------------|
+| `add_remove` | Core symbol diff only (control group) | Functions added/removed, no type churn |
+| `type_churn` | Affected-symbol enrichment, opaque/pointer-only filtering | Header-aware compare where types changed |
+| `elf_namespace` | Namespace detectors + demangling | Stripped, ELF-only real library |
+
+## Measured scaling
+
+`type_churn`, single-threaded, Python 3.11 (representative numbers — absolute
+times vary by machine):
+
+| functions | type changes | seconds |
+|----------:|-------------:|--------:|
+| 500       | 100          | ~1.0 |
+| 1000      | 100          | ~1.2 |
+| 2000      | 200          | ~3.5 |
+| 4000      | 400          | ~8.7 |
+
+Per-change cost roughly **doubles** as the library grows 4×, i.e. growth is
+super-linear (empirical log-log exponent ≈ 1.3–1.4 over this range, trending
+higher as the affected-type set grows). Extrapolating to ~10,550 functions with
+the much larger affected-type set of a real numeric library comfortably exceeds
+a 60 s budget — matching the observed `libonedal_core.so` timeout.
+
+## Where the time goes
+
+`cProfile` of `compare` on the 4000-function `type_churn` workload
+(~15 s total, dominated by `post_processing.run`):
+
+### 1. `c++filt` subprocess storm (largest cost)
+
+```
+cumtime  function
+  9.28s  diff_namespaces.detect_experimental_namespace_changes
+  9.05s   └─ _index_funcs_by_stable_key
+  8.88s      └─ _qualified_function_name        (24,000 calls)
+  8.84s         └─ demangle.demangle_batch      (64,001 calls)
+  7.54s            └─ _batch_phase3_cppfilt     (4,000 subprocess spawns!)
+```
+
+`abicheck/diff_namespaces.py:130` (`_qualified_function_name`) calls
+`demangle_batch([mangled])` **one symbol at a time**. `demangle_batch` is
+explicitly designed to demangle a *whole batch* in a single `c++filt`
+subprocess and memoise the result, but feeding it single-element lists defeats
+that: each unique symbol triggers its own subprocess spawn. On a stripped
+library where every function name must be demangled, this is thousands of
+process spawns.
+
+**Fix direction:** in `_index_funcs_by_stable_key`
+(`abicheck/diff_namespaces.py:166`), collect every `f.mangled` up front and call
+`demangle_batch(all_mangled)` **once**, then look results up from the returned
+dict. This turns N spawns into 1 and is the single highest-leverage change.
+
+### 2. O(functions × types) substring scan
+
+```
+cumtime  function
+ 10.25s  diff_filtering._filter_opaque_size_changes
+  9.00s   └─ _is_pointer_only_type              (per candidate opaque type)
+  8.94s      └─ _public_function_uses_type_by_value  (full function scan each)
+```
+
+`abicheck/diff_filtering.py:535` (`_public_function_uses_type_by_value`) scans
+**all** public functions for **each** candidate type, doing substring matching
+on every return type and parameter. The same shape recurs in
+`_build_type_to_funcs` (`diff_filtering.py:192`) and
+`_build_type_embed_index` (`diff_filtering.py:208`): each iterates
+`functions × affected_types` with `in` substring tests rather than an inverted
+index.
+
+**Fix direction:** build a single **inverted index** once per compare —
+`type_name → [functions that reference it]` — by scanning each function's type
+references one time, then have the opaque/enrichment/embed passes look up that
+index instead of re-scanning all functions. This collapses the repeated
+O(functions × types) passes to roughly O(functions + types).
+
+## Recommendations (ordered by leverage)
+
+1. **Batch demangling in namespace detection.** Single highest-leverage fix;
+   removes thousands of subprocess spawns. Low risk — pure call-site change.
+2. **Build one inverted type→functions index** and reuse it across
+   `_enrich_affected_symbols`, the opaque-size filter, and the embed index.
+3. **Short-circuit detectors that don't apply.** Skip namespace detection when
+   no `experimental`-style namespaces are present; skip opaque filtering when
+   there are no size/opaque changes.
+4. **Only then consider a performance gate** in CI (a `--max-seconds` budget on
+   `type_churn`), once a stable post-fix baseline exists.
+
+These are tracked as a performance bottleneck to be addressed upstream before
+gating is enabled.
+
+## CI integration
+
+[`.github/workflows/performance.yml`](https://github.com/napetrov/abicheck/blob/main/.github/workflows/performance.yml)
+runs the scaling benchmark and the `slow` performance tests. It is deliberately
+**flexible and non-gating**:
+
+- Triggers: weekly schedule, manual `workflow_dispatch` (with size / budget
+  inputs), and on PRs carrying the **`performance`** label or touching the
+  detector core.
+- `continue-on-error: true` — it never blocks a merge.
+- Publishes the scaling table to the job summary and uploads the JSON.
+
+**Turning gating on later:** the thresholds are CLI flags, not hard-coded, so a
+budget lives in the workflow rather than the script. Add
+`--max-seconds <budget>` and/or `--max-exponent <slope>` to the benchmark step
+and remove `continue-on-error`. The harness exits non-zero when a comparison
+exceeds the budget or the tail (largest-two-size) scaling exponent exceeds the
+allowed slope.
+
+A `slow` regression guard also lives in
+[`tests/test_performance.py`](https://github.com/napetrov/abicheck/blob/main/tests/test_performance.py)
+(`TestTypeChurnScaling`): it runs in the existing slow lane with generous
+thresholds, so a regression to genuine O(n²) fails fast without flaking on
+normal drift.

--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -133,8 +133,11 @@ runs the scaling benchmark and the `slow` performance tests. It is deliberately
 **flexible and non-gating**:
 
 - Triggers: weekly schedule, manual `workflow_dispatch` (with size / budget
-  inputs), and on PRs carrying the **`performance`** label or touching the
-  detector core.
+  inputs), and **automatically on any PR that changes the detector core**
+  (`abicheck/diff_*.py`, `checker.py`, `post_processing.py`, `demangle.py`, the
+  benchmark script, or the perf test). Adding the **`performance`** label
+  re-triggers the lane on such a PR; for a PR that does not touch the detector
+  core, run it on demand with `workflow_dispatch`.
 - `continue-on-error: true` — it never blocks a merge.
 - Publishes the scaling table to the job summary and uploads the JSON.
 

--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -1,130 +1,85 @@
 # Comparison Performance
 
-This page evaluates the runtime cost of comparing **real, large** shared
-libraries and documents the tooling that tracks it in CI.
+This page documents the runtime cost of comparing **real, large** shared
+libraries, the bottlenecks that were found and fixed, and the tooling that
+guards against regressions in CI.
 
 ## TL;DR
 
 - **Dump scales fine.** Snapshotting `libonedal_core.so` (~10,550 exported
   functions) takes ~5 s.
-- **Compare does not.** On the same library, `compare` did **not finish within
-  60 s**. The cost is in the *post-processing* detectors, not the core symbol
-  diff.
-- Two bottlenecks dominate, both super-linear in the number of functions:
-  1. A **`c++filt` subprocess storm** in namespace detection — one subprocess
-     spawn per unique mangled symbol instead of one batched call.
-  2. An **O(functions × types) substring scan** in opaque/pointer-only type
-     filtering.
-- Because of this, **performance gating is intentionally off**. CI *measures*
-  and reports; it does not block. See [CI integration](#ci-integration) for how
-  to enable a budget once the bottlenecks are fixed.
+- **Compare used to blow up.** On the same library, `compare` did **not finish
+  within 60 s**. The cost was entirely in the *post-processing* detectors, not
+  the core symbol diff. A profiling sweep found **six** super-linear paths —
+  several quadratic, one effectively cubic — all now fixed (see
+  [What was fixed](#what-was-fixed)).
+- A synthetic scaling harness (`scripts/benchmark_scaling.py`) reproduces each
+  path **without** a real binary, compiler, or castxml, and a `slow` regression
+  test guards the realistic hot path.
+
+## What was fixed
+
+Every fix preserves detector behaviour (the full unit suite, the FP-rate gate,
+and the metamorphic/oracle detector tests all stay green); they only change how
+the work is organised.
+
+| # | Path | Was | Fix | Result |
+|---|------|-----|-----|--------|
+| 1 | Public-surface scoping (`surface.classify_change_surface`) | Recomputed four old∪new set unions **per finding** → O(findings × surface). Made *every* comparison quadratic. | Compute the unions once per pass (`surface_unions`) and reuse. | `add_remove` 4000: **9.1 s → 0.32 s** (linear) |
+| 2 | Namespace detection (`diff_namespaces`) | `demangle_batch` called **one symbol at a time** → one `c++filt` subprocess per symbol. | Batch-demangle each snapshot once (`_batch_demangle_public`) and thread the map through. | `elf_namespace` 4000: **5.2 s → 0.33 s** (linear) |
+| 3 | Variable / symbol diffing | Quadratic via the same per-finding surface unions (#1). | Fixed by #1. | `var_churn` 4000: **2.1 s → 0.06 s** (linear) |
+| 4 | Batch-rename heuristic (`diff_symbols._find_rename_pairs`) | O(removed × added) suffix scan. | Reversed-name index + binary search (`endswith` → reversed prefix lookup). | folded into `add_remove` win |
+| 5 | Type-spelling fallback (`diff_type_spellings`) | Rebuilt a `set(...)` inside a comprehension → O(n²). | Hoist the set once. | folded into `add_remove` win |
+| 6 | Affected-symbol enrichment / ancestor closure (`diff_filtering`) | Transitive ancestor function **lists** accumulated duplicates, then re-sorted per change → effectively cubic on nested type graphs. | Use sets (dedup on union); sort once. | `nested_types` n=200: **>60 s → 0.16 s** |
+| 7 | ELF-only rename matching (`binary_fingerprint`, `diff_symbols._plausible_rename`) | O(removed × added) name-similarity scan; the name predicate re-demangled both names per pair. | Scan only the size-tolerance window via the existing size index; cache the per-name parse; cap the heuristic pass for mass-rename inputs. | `rename_churn` n=1000: **13.2 s → 2.1 s**, larger inputs bounded |
+
+The one remaining super-linear path is the **opaque-handle size filter**
+(`diff_filtering._filter_opaque_size_changes`), O(candidates × functions). It is
+left as-is: it only triggers on the narrow "compatible struct growth of a
+pointer-only handle" pattern, so the candidate count is small for real
+libraries, and `type_churn` (which forces *every* struct into that pattern) is
+already down from 8.8 s to 1.4 s at 4000 functions as a side effect of the other
+fixes.
 
 ## How to reproduce
 
-No real binary, compiler, or castxml required — the scaling harness synthesises
-`AbiSnapshot` pairs that exercise the expensive paths:
+No real binary, compiler, or castxml required — the harness synthesises
+`AbiSnapshot` pairs that exercise each path:
 
 ```bash
-# Sweep the default sizes across all scenarios and print a table.
+# Sweep all scenarios and print a table with a scaling exponent per scenario.
 python scripts/benchmark_scaling.py
 
-# Focus the realistic hot path and emit machine-readable JSON.
+# Focus one path and emit machine-readable JSON.
 python scripts/benchmark_scaling.py --scenario type_churn \
-    --sizes 1000 2000 4000 8000 --json-out reports/perf/scaling.json
+    --sizes 1000 2000 4000 --json-out reports/perf/scaling.json
 ```
 
-The harness defines three workloads:
+Scenarios (`add_remove` is the linear control; the rest target a specific
+former bottleneck):
 
-| Scenario | What it stresses | Represents |
-|----------|------------------|------------|
-| `add_remove` | Core symbol diff only (control group) | Functions added/removed, no type churn |
-| `type_churn` | Affected-symbol enrichment, opaque/pointer-only filtering | Header-aware compare where types changed |
-| `elf_namespace` | Namespace detectors + demangling | Stripped, ELF-only real library |
+| Scenario | Stresses |
+|----------|----------|
+| `add_remove` | Core symbol diff + surface scoping (control) |
+| `type_churn` | Affected-symbol enrichment, opaque filtering |
+| `elf_namespace` | Namespace detection + demangling (stripped lib) |
+| `var_churn` | Public-surface classification |
+| `rename_churn` | ELF-only fingerprint rename matching |
+| `nested_types` | Transitive type-ancestor closure |
 
-## Measured scaling
+## Measured scaling (after fixes)
 
-`type_churn`, single-threaded, Python 3.11 (representative numbers — absolute
-times vary by machine):
+All scenarios are linear or bounded at the sizes a real library reaches
+(per-change cost roughly flat):
 
-| functions | type changes | seconds |
-|----------:|-------------:|--------:|
-| 500       | 100          | ~1.0 |
-| 1000      | 100          | ~1.2 |
-| 2000      | 200          | ~3.5 |
-| 4000      | 400          | ~8.7 |
-
-Per-change cost roughly **doubles** as the library grows 4×, i.e. growth is
-super-linear (empirical log-log exponent ≈ 1.3–1.4 over this range, trending
-higher as the affected-type set grows). Extrapolating to ~10,550 functions with
-the much larger affected-type set of a real numeric library comfortably exceeds
-a 60 s budget — matching the observed `libonedal_core.so` timeout.
-
-## Where the time goes
-
-`cProfile` of `compare` on the 4000-function `type_churn` workload
-(~15 s total, dominated by `post_processing.run`):
-
-### 1. `c++filt` subprocess storm (largest cost)
-
-```
-cumtime  function
-  9.28s  diff_namespaces.detect_experimental_namespace_changes
-  9.05s   └─ _index_funcs_by_stable_key
-  8.88s      └─ _qualified_function_name        (24,000 calls)
-  8.84s         └─ demangle.demangle_batch      (64,001 calls)
-  7.54s            └─ _batch_phase3_cppfilt     (4,000 subprocess spawns!)
-```
-
-`abicheck/diff_namespaces.py:130` (`_qualified_function_name`) calls
-`demangle_batch([mangled])` **one symbol at a time**. `demangle_batch` is
-explicitly designed to demangle a *whole batch* in a single `c++filt`
-subprocess and memoise the result, but feeding it single-element lists defeats
-that: each unique symbol triggers its own subprocess spawn. On a stripped
-library where every function name must be demangled, this is thousands of
-process spawns.
-
-**Fix direction:** in `_index_funcs_by_stable_key`
-(`abicheck/diff_namespaces.py:166`), collect every `f.mangled` up front and call
-`demangle_batch(all_mangled)` **once**, then look results up from the returned
-dict. This turns N spawns into 1 and is the single highest-leverage change.
-
-### 2. O(functions × types) substring scan
-
-```
-cumtime  function
- 10.25s  diff_filtering._filter_opaque_size_changes
-  9.00s   └─ _is_pointer_only_type              (per candidate opaque type)
-  8.94s      └─ _public_function_uses_type_by_value  (full function scan each)
-```
-
-`abicheck/diff_filtering.py:535` (`_public_function_uses_type_by_value`) scans
-**all** public functions for **each** candidate type, doing substring matching
-on every return type and parameter. The same shape recurs in
-`_build_type_to_funcs` (`diff_filtering.py:192`) and
-`_build_type_embed_index` (`diff_filtering.py:208`): each iterates
-`functions × affected_types` with `in` substring tests rather than an inverted
-index.
-
-**Fix direction:** build a single **inverted index** once per compare —
-`type_name → [functions that reference it]` — by scanning each function's type
-references one time, then have the opaque/enrichment/embed passes look up that
-index instead of re-scanning all functions. This collapses the repeated
-O(functions × types) passes to roughly O(functions + types).
-
-## Recommendations (ordered by leverage)
-
-1. **Batch demangling in namespace detection.** Single highest-leverage fix;
-   removes thousands of subprocess spawns. Low risk — pure call-site change.
-2. **Build one inverted type→functions index** and reuse it across
-   `_enrich_affected_symbols`, the opaque-size filter, and the embed index.
-3. **Short-circuit detectors that don't apply.** Skip namespace detection when
-   no `experimental`-style namespaces are present; skip opaque filtering when
-   there are no size/opaque changes.
-4. **Only then consider a performance gate** in CI (a `--max-seconds` budget on
-   `type_churn`), once a stable post-fix baseline exists.
-
-These are tracked as a performance bottleneck to be addressed upstream before
-gating is enabled.
+| Scenario | 4000 functions (or cap) | tail exponent |
+|----------|------------------------:|--------------:|
+| `add_remove`   | 0.32 s | ~0.9 (linear) |
+| `var_churn`    | 0.06 s | ~1.0 (linear) |
+| `elf_namespace`| 0.33 s | ~1.1 (linear) |
+| `type_churn`   | 1.39 s | ~1.7 (opaque filter residual) |
+| `rename_churn` | 2.1 s @ n=1000, capped above | bounded |
+| `nested_types` | 0.70 s @ n=400 | inherent for deep chains |
 
 ## CI integration
 
@@ -136,20 +91,20 @@ runs the scaling benchmark and the `slow` performance tests. It is deliberately
   inputs), and **automatically on any PR that changes the detector core**
   (`abicheck/diff_*.py`, `checker.py`, `post_processing.py`, `demangle.py`, the
   benchmark script, or the perf test). Adding the **`performance`** label
-  re-triggers the lane on such a PR; for a PR that does not touch the detector
-  core, run it on demand with `workflow_dispatch`.
+  re-triggers the lane; for a PR that does not touch the detector core, run it
+  on demand with `workflow_dispatch`.
 - `continue-on-error: true` — it never blocks a merge.
 - Publishes the scaling table to the job summary and uploads the JSON.
 
-**Turning gating on later:** the thresholds are CLI flags, not hard-coded, so a
-budget lives in the workflow rather than the script. Add
-`--max-seconds <budget>` and/or `--max-exponent <slope>` to the benchmark step
-and remove `continue-on-error`. The harness exits non-zero when a comparison
-exceeds the budget or the tail (largest-two-size) scaling exponent exceeds the
-allowed slope.
+**Turning gating on:** now that the catastrophic paths are fixed, a budget can be
+enforced by adding `--max-seconds <budget>` and/or `--max-exponent <slope>` to
+the benchmark step and removing `continue-on-error`. The thresholds are CLI
+flags so the budget lives in the workflow, not the script. The harness exits
+non-zero when a comparison exceeds the budget or the tail (largest-two-size)
+scaling exponent exceeds the allowed slope.
 
 A `slow` regression guard also lives in
 [`tests/test_performance.py`](https://github.com/napetrov/abicheck/blob/main/tests/test_performance.py)
 (`TestTypeChurnScaling`): it runs in the existing slow lane with generous
-thresholds, so a regression to genuine O(n²) fails fast without flaking on
+thresholds, so a regression back to genuine O(n²) fails fast without flaking on
 normal drift.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - Contributing:
       - Codebase Overview: development/codebase-overview.md
       - Testing: development/testing.md
+      - Performance: development/performance.md
       - Troubleshooting: troubleshooting.md
       - Config Key Review: development/config-key-review.md
     - Roadmap & Status:

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -13,6 +13,7 @@ Each must run with Python 3.10+ and the package installed in dev mode
 | `check_mutation_score.py` | Mutation-score baseline-drift gate. Counts surviving `mutmut` mutants in the detector core and compares to `SURVIVOR_BASELINE`. Parser unit-tested in `tests/test_mutation_score_gate.py`. | CI (`mutation.yml`: weekly / `mutation` label / dispatch). |
 | `gen_examples_docs.py` | Regenerates `docs/examples/caseNN_*.md` from `examples/case*/README.md`, and the generated regions (headline, verdict distribution, case index) of `examples/README.md` from `ground_truth.json`. `--check` gates both. Run after adding a new example case. | manual |
 | `benchmark_comparison.py` | Benchmarks abicheck vs ABICC / libabigail across the `examples/` catalog. | manual |
+| `benchmark_scaling.py` | Synthetic scaling benchmark for the `compare` pipeline — sweeps snapshot sizes, times `compare()`, reports a scaling exponent. Pure-Python (no compiler/castxml). Non-gating by default; `--max-seconds` / `--max-exponent` turn it into a gate. See `docs/development/performance.md`. | CI (`performance.yml`: weekly / `performance` label / dispatch); manual |
 | `demo_libz.py` | End-to-end demo on libz, used by the `e2e` CI job. | CI (`e2e` job) |
 | `extract_bundle_manifest.py` | Extracts a manifest from multi-library bundles (cases 90–93). | manual |
 

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -152,15 +152,19 @@ def _build_elf_namespace(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
     emulate a stripped library where only the mangled symbol is known.
     """
 
-    def mangled(ns: str, leaf: str, i: int) -> str:
-        # _ZN12experimental4sortEi style; the exact mangling need not be valid
-        # for the demangler to attempt it — it just must start with _Z.
-        return f"_ZN{len(ns)}{ns}{len(leaf)}{leaf}{i}Ei"
+    def mangled(ns: str, i: int) -> str:
+        # Valid Itanium nested-name mangling: _ZN<len>ns<len>leafEi, e.g.
+        # _ZN12experimental5fn123Ei -> experimental::fn123(int). The index must
+        # be inside the encoded identifier (and counted in its length) or the
+        # name is invalid and c++filt leaves it unchanged, so the namespace
+        # detectors would never see the `experimental` segment.
+        leaf = f"fn{i}"
+        return f"_ZN{len(ns)}{ns}{len(leaf)}{leaf}Ei"
 
     old_funcs, new_funcs = [], []
     for i in range(n_funcs):
         ns = "experimental" if i % 2 == 0 else "stablelib"
-        m = mangled(ns, "fn", i)
+        m = mangled(ns, i)
         old_funcs.append(
             Function(name=m, mangled=m, return_type="int", visibility=Visibility.PUBLIC)
         )

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -2,14 +2,15 @@
 """Scaling benchmark for the abicheck comparison pipeline.
 
 Real libraries can be large: ``libonedal_core.so`` exports ~10,550 functions.
-The snapshot/``dump`` step scales fine (~5 s for that library), but ``compare``
-can blow up super-linearly on the post-processing detectors (affected-symbol
-enrichment, opaque-type filtering, namespace pattern detection). This harness
-makes that visible *without* needing a real binary, castxml, or a compiler: it
-synthesises ``AbiSnapshot`` pairs of increasing size that exercise the
-expensive code paths, times :func:`abicheck.checker.compare`, and reports an
-empirical scaling exponent so a regression (or an improvement) shows up as a
-single number.
+The snapshot/``dump`` step scales fine (~5 s for that library); ``compare`` used
+to blow up super-linearly on the post-processing detectors (surface scoping,
+affected-symbol enrichment, namespace demangling, fingerprint rename matching).
+Those paths are now fixed (see ``docs/development/performance.md``), and this
+harness guards against regressions *without* needing a real binary, castxml, or
+a compiler: it synthesises ``AbiSnapshot`` pairs of increasing size that
+exercise each formerly-expensive path, times :func:`abicheck.checker.compare`,
+and reports an empirical scaling exponent so a regression (or an improvement)
+shows up as a single number.
 
 It is intentionally **flexible**: by default it only measures and prints, so it
 is safe to run unconditionally in CI as an informational job. Pass
@@ -56,12 +57,19 @@ if str(REPO_DIR) not in sys.path:
     sys.path.insert(0, str(REPO_DIR))
 
 from abicheck.checker import compare  # noqa: E402
+from abicheck.elf_metadata import (  # noqa: E402
+    ElfMetadata,
+    ElfSymbol,
+    SymbolBinding,
+    SymbolType,
+)
 from abicheck.model import (  # noqa: E402
     AbiSnapshot,
     Function,
     Param,
     RecordType,
     TypeField,
+    Variable,
     Visibility,
 )
 
@@ -168,10 +176,136 @@ def _build_elf_namespace(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
     return old, new
 
 
-SCENARIOS: dict[str, Callable[[int], tuple[AbiSnapshot, AbiSnapshot]]] = {
-    "add_remove": _build_add_remove,
-    "type_churn": _build_type_churn,
-    "elf_namespace": _build_elf_namespace,
+def _build_var_churn(n_vars: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Many public variables that all change type.
+
+    Isolates the public-surface classification path, which recomputes set
+    unions per change — quadratic in the number of findings regardless of
+    types or functions.
+    """
+    old = AbiSnapshot(
+        library="libscale.so",
+        version="1.0",
+        variables=[
+            Variable(
+                name=f"v{i}", mangled=f"v{i}", type="int", visibility=Visibility.PUBLIC
+            )
+            for i in range(n_vars)
+        ],
+    )
+    new = AbiSnapshot(
+        library="libscale.so",
+        version="2.0",
+        variables=[
+            Variable(
+                name=f"v{i}", mangled=f"v{i}", type="long", visibility=Visibility.PUBLIC
+            )
+            for i in range(n_vars)
+        ],
+    )
+    return old, new
+
+
+def _build_rename_churn(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Stripped (ELF-only) library where every symbol is renamed.
+
+    Old and new export disjoint, similarly-sized function symbols, so the
+    fingerprint rename matcher's size gate admits the whole cross-product and
+    the O(removed x added) name-similarity pass dominates — even when (as here)
+    it ultimately reports no confident rename.
+    """
+
+    def elf(prefix: str) -> ElfMetadata:
+        return ElfMetadata(
+            soname="libscale.so",
+            symbols=[
+                ElfSymbol(
+                    name=f"_Z3{prefix}v{i}",
+                    binding=SymbolBinding.GLOBAL,
+                    sym_type=SymbolType.FUNC,
+                    # Spread sizes the way a real stripped library does, so the
+                    # size-bucketed rename matcher behaves realistically (a few
+                    # symbols per size) rather than all-collide in one bucket.
+                    size=16 + (i * 7) % 4096,
+                )
+                for i in range(n_funcs)
+            ],
+        )
+
+    old = AbiSnapshot(
+        library="libscale.so", version="1.0", elf=elf("old"), elf_only_mode=True
+    )
+    new = AbiSnapshot(
+        library="libscale.so", version="2.0", elf=elf("new"), elf_only_mode=True
+    )
+    return old, new
+
+
+def _build_nested_types(n_types: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Chain of embedded types (each embeds the previous) — every one changes.
+
+    Stresses the transitive type-ancestor closure in affected-symbol
+    enrichment: each type's ancestor set is rescanned against all functions and
+    the per-ancestor function lists accumulate, so cost grows super-quadratically
+    with the depth of the embedding graph. Capped at a small size by design.
+    """
+    types_old, types_new = [], []
+    for i in range(n_types):
+        prev = f"Type_{i - 1}" if i else "int"
+        base = [
+            TypeField(name="inner", type=prev, offset_bits=0),
+            TypeField(name="a", type="int", offset_bits=64),
+        ]
+        grown = base + [TypeField(name="b", type="int", offset_bits=96)]
+        types_old.append(
+            RecordType(name=f"Type_{i}", kind="struct", size_bits=128, fields=base)
+        )
+        types_new.append(
+            RecordType(name=f"Type_{i}", kind="struct", size_bits=160, fields=grown)
+        )
+    funcs = [
+        Function(
+            name=f"f_{i}",
+            mangled=f"_Z3f_{i}P6Type_{i % n_types}",
+            return_type="int",
+            params=[Param(name="p", type=f"Type_{i % n_types} *")],
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n_types)
+    ]
+    old = AbiSnapshot(
+        library="libscale.so", version="1.0", functions=list(funcs), types=types_old
+    )
+    new = AbiSnapshot(
+        library="libscale.so", version="2.0", functions=list(funcs), types=types_new
+    )
+    return old, new
+
+
+@dataclass
+class Scenario:
+    build: Callable[[int], tuple[AbiSnapshot, AbiSnapshot]]
+    # Per-scenario default sweep. Some scenarios are intentionally pathological
+    # (known super-linear paths) and must use a smaller sweep than the linear
+    # control scenarios. An explicit ``--sizes`` overrides this.
+    sizes: tuple[int, ...] = DEFAULT_SIZES
+    # Hard safety cap: sizes above this are skipped even if requested via
+    # ``--sizes``, so a known-pathological scenario can't be made to hang.
+    max_size: int = 1_000_000
+    # True if the scenario only does meaningful work with a demangler present.
+    needs_demangler: bool = False
+
+
+SCENARIOS: dict[str, Scenario] = {
+    "add_remove": Scenario(_build_add_remove),
+    "type_churn": Scenario(_build_type_churn),
+    "elf_namespace": Scenario(_build_elf_namespace, needs_demangler=True),
+    "var_churn": Scenario(_build_var_churn),
+    # Quadratic paths — keep the sweeps small so a default run stays bounded.
+    "rename_churn": Scenario(
+        _build_rename_churn, sizes=(250, 500, 1000), max_size=1200
+    ),
+    "nested_types": Scenario(_build_nested_types, sizes=(100, 200, 400), max_size=500),
 }
 
 
@@ -195,10 +329,12 @@ def _has_demangler() -> bool:
 
 
 def measure(scenario: str, sizes: list[int], repeat: int) -> list[Point]:
-    build = SCENARIOS[scenario]
+    spec = SCENARIOS[scenario]
     points: list[Point] = []
     for n in sizes:
-        old, new = build(n)
+        if n > spec.max_size:
+            continue
+        old, new = spec.build(n)
         best = math.inf
         changes = 0
         for _ in range(repeat):
@@ -289,8 +425,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--sizes",
         type=int,
         nargs="+",
-        default=list(DEFAULT_SIZES),
-        help=f"Function counts to sweep (default: {' '.join(map(str, DEFAULT_SIZES))})",
+        default=None,
+        help="Sizes to sweep, overriding each scenario's tuned default "
+        f"(linear scenarios default to {' '.join(map(str, DEFAULT_SIZES))})",
     )
     p.add_argument(
         "--repeat",
@@ -333,12 +470,20 @@ def main(argv: list[str] | None = None) -> int:
     failures: list[str] = []
 
     for scenario in scenarios:
-        if scenario == "elf_namespace" and not _has_demangler():
+        spec = SCENARIOS[scenario]
+        if spec.needs_demangler and not _has_demangler():
             print(
                 f"\nScenario: {scenario}  SKIP (no c++filt/cxxfilt demangler available)"
             )
             continue
-        points = measure(scenario, args.sizes, args.repeat)
+        sizes = args.sizes if args.sizes is not None else list(spec.sizes)
+        points = measure(scenario, sizes, args.repeat)
+        if not points:
+            print(
+                f"\nScenario: {scenario}  SKIP (all requested sizes exceed its cap "
+                f"of {SCENARIOS[scenario].max_size})"
+            )
+            continue
         exponent = scaling_exponent(points)
         tail = tail_exponent(points)
         _print_table(scenario, points, exponent, tail)

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Scaling benchmark for the abicheck comparison pipeline.
+
+Real libraries can be large: ``libonedal_core.so`` exports ~10,550 functions.
+The snapshot/``dump`` step scales fine (~5 s for that library), but ``compare``
+can blow up super-linearly on the post-processing detectors (affected-symbol
+enrichment, opaque-type filtering, namespace pattern detection). This harness
+makes that visible *without* needing a real binary, castxml, or a compiler: it
+synthesises ``AbiSnapshot`` pairs of increasing size that exercise the
+expensive code paths, times :func:`abicheck.checker.compare`, and reports an
+empirical scaling exponent so a regression (or an improvement) shows up as a
+single number.
+
+It is intentionally **flexible**: by default it only measures and prints, so it
+is safe to run unconditionally in CI as an informational job. Pass
+``--max-seconds`` and/or ``--max-exponent`` to turn it into a gate once the
+known bottlenecks are addressed and a stable budget exists.
+
+Scenarios
+---------
+``add_remove``   Cheap baseline — functions added/removed, no type churn. This
+                 is what ``tests/test_performance.py`` already covers; it stays
+                 near-linear and is the control group.
+``type_churn``   Every function takes a changed struct by pointer, so the
+                 affected-symbol enrichment and opaque-type filters must relate
+                 each type change back to the functions that use it. This is the
+                 realistic hot path for a header-aware compare.
+``elf_namespace`` ELF-only style: functions carry mangled (``_Z...``) names with
+                 no qualified ``name``, forcing the namespace detectors to
+                 demangle. Mirrors comparing stripped real libraries. Requires a
+                 demangler (``c++filt`` / ``cxxfilt``); skipped if unavailable.
+
+Usage
+-----
+    python3 scripts/benchmark_scaling.py
+    python3 scripts/benchmark_scaling.py --scenario type_churn --sizes 1000 2000 4000
+    python3 scripts/benchmark_scaling.py --json-out reports/scaling.json
+    # Gating mode (opt-in):
+    python3 scripts/benchmark_scaling.py --scenario type_churn --max-seconds 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+if str(REPO_DIR) not in sys.path:
+    sys.path.insert(0, str(REPO_DIR))
+
+from abicheck.checker import compare  # noqa: E402
+from abicheck.model import (  # noqa: E402
+    AbiSnapshot,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Visibility,
+)
+
+DEFAULT_SIZES = (500, 1000, 2000, 4000)
+
+
+# ── Snapshot builders (one per scenario) ──────────────────────────────────────
+def _build_add_remove(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Half the functions are removed, an equal number added. No type churn."""
+    old_funcs = [
+        Function(
+            name=f"func_{i}",
+            mangled=f"_Z6func_{i}v",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n_funcs)
+    ]
+    new_funcs = old_funcs[: n_funcs // 2] + [
+        Function(
+            name=f"newfn_{i}",
+            mangled=f"_Z6newfn_{i}v",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n_funcs // 2)
+    ]
+    old = AbiSnapshot(library="libscale.so", version="1.0", functions=old_funcs)
+    new = AbiSnapshot(library="libscale.so", version="2.0", functions=new_funcs)
+    return old, new
+
+
+def _build_type_churn(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Every function takes a struct by pointer; every struct grows a field.
+
+    Forces the affected-symbol enrichment and opaque/pointer-only filters to
+    relate each of the ``n_types`` changed types back to the functions that
+    reference it — the O(functions x types) path.
+    """
+    n_types = max(50, n_funcs // 20)
+    types_old, types_new = [], []
+    for i in range(n_types):
+        base = [
+            TypeField(name="a", type="int", offset_bits=0),
+            TypeField(name="b", type="int", offset_bits=32),
+        ]
+        grown = base + [TypeField(name="c", type="int", offset_bits=64)]
+        types_old.append(
+            RecordType(name=f"Type_{i}", kind="struct", size_bits=64, fields=base)
+        )
+        types_new.append(
+            RecordType(name=f"Type_{i}", kind="struct", size_bits=96, fields=grown)
+        )
+    funcs = []
+    for i in range(n_funcs):
+        t = f"Type_{i % n_types}"
+        funcs.append(
+            Function(
+                name=f"use_{t}_{i}",
+                mangled=f"_Z4use_{i}P{t}",
+                return_type="int",
+                params=[Param(name="p", type=f"{t} *")],
+                visibility=Visibility.PUBLIC,
+            )
+        )
+    old = AbiSnapshot(
+        library="libscale.so", version="1.0", functions=list(funcs), types=types_old
+    )
+    new = AbiSnapshot(
+        library="libscale.so", version="2.0", functions=list(funcs), types=types_new
+    )
+    return old, new
+
+
+def _build_elf_namespace(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """ELF-only style: mangled names, no qualified ``name`` — forces demangling.
+
+    Half the functions live in an ``experimental`` namespace so the namespace
+    pattern detectors actually run. ``name`` is set equal to ``mangled`` to
+    emulate a stripped library where only the mangled symbol is known.
+    """
+
+    def mangled(ns: str, leaf: str, i: int) -> str:
+        # _ZN12experimental4sortEi style; the exact mangling need not be valid
+        # for the demangler to attempt it — it just must start with _Z.
+        return f"_ZN{len(ns)}{ns}{len(leaf)}{leaf}{i}Ei"
+
+    old_funcs, new_funcs = [], []
+    for i in range(n_funcs):
+        ns = "experimental" if i % 2 == 0 else "stablelib"
+        m = mangled(ns, "fn", i)
+        old_funcs.append(
+            Function(name=m, mangled=m, return_type="int", visibility=Visibility.PUBLIC)
+        )
+        # New side keeps the same symbols plus a few removals to trigger work.
+        if i % 17 != 0:
+            new_funcs.append(
+                Function(
+                    name=m, mangled=m, return_type="int", visibility=Visibility.PUBLIC
+                )
+            )
+    old = AbiSnapshot(library="libscale.so", version="1.0", functions=old_funcs)
+    new = AbiSnapshot(library="libscale.so", version="2.0", functions=new_funcs)
+    return old, new
+
+
+SCENARIOS: dict[str, Callable[[int], tuple[AbiSnapshot, AbiSnapshot]]] = {
+    "add_remove": _build_add_remove,
+    "type_churn": _build_type_churn,
+    "elf_namespace": _build_elf_namespace,
+}
+
+
+# ── Measurement ───────────────────────────────────────────────────────────────
+@dataclass
+class Point:
+    size: int
+    seconds: float
+    changes: int
+
+
+def _has_demangler() -> bool:
+    if shutil.which("c++filt"):
+        return True
+    try:
+        import cxxfilt  # noqa: F401
+
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def measure(scenario: str, sizes: list[int], repeat: int) -> list[Point]:
+    build = SCENARIOS[scenario]
+    points: list[Point] = []
+    for n in sizes:
+        old, new = build(n)
+        best = math.inf
+        changes = 0
+        for _ in range(repeat):
+            t0 = time.monotonic()
+            result = compare(old, new)
+            dt = time.monotonic() - t0
+            best = min(best, dt)
+            changes = len(result.changes)
+        points.append(Point(size=n, seconds=round(best, 4), changes=changes))
+    return points
+
+
+def scaling_exponent(points: list[Point]) -> float | None:
+    """Least-squares slope of log(seconds) vs log(size).
+
+    ~1.0 means linear, ~2.0 means quadratic. Returns None if there are fewer
+    than two usable (positive-time) points.
+    """
+    pts = [(math.log(p.size), math.log(p.seconds)) for p in points if p.seconds > 0]
+    if len(pts) < 2:
+        return None
+    n = len(pts)
+    sx = sum(x for x, _ in pts)
+    sy = sum(y for _, y in pts)
+    sxx = sum(x * x for x, _ in pts)
+    sxy = sum(x * y for x, y in pts)
+    denom = n * sxx - sx * sx
+    if denom == 0:
+        return None
+    return (n * sxy - sx * sy) / denom
+
+
+def tail_exponent(points: list[Point]) -> float | None:
+    """Local log-log slope between the two largest sizes.
+
+    Fixed per-run costs (imports, demangler warm-up) flatten the full-range
+    least-squares fit at small sizes, hiding super-linear growth. The slope
+    between the two largest points is a cleaner asymptotic signal, so the
+    optional ``--max-exponent`` gate keys off this value.
+    """
+    usable = sorted((p for p in points if p.seconds > 0), key=lambda p: p.size)
+    if len(usable) < 2:
+        return None
+    a, b = usable[-2], usable[-1]
+    if a.size == b.size or a.seconds <= 0 or b.seconds <= 0:
+        return None
+    return math.log(b.seconds / a.seconds) / math.log(b.size / a.size)
+
+
+# ── Reporting ─────────────────────────────────────────────────────────────────
+def _classify(exponent: float | None) -> str:
+    if exponent is None:
+        return "n/a"
+    if exponent < 1.3:
+        return "linear"
+    if exponent < 1.7:
+        return "super-linear"
+    return "≈quadratic+"
+
+
+def _print_table(
+    scenario: str, points: list[Point], exponent: float | None, tail: float | None
+) -> None:
+    print(f"\nScenario: {scenario}")
+    print(f"  {'size':>8} {'changes':>9} {'seconds':>10} {'us/change':>11}")
+    for p in points:
+        per = (p.seconds / p.changes * 1e6) if p.changes else float("nan")
+        print(f"  {p.size:>8} {p.changes:>9} {p.seconds:>10.3f} {per:>11.1f}")
+    if exponent is not None:
+        print(
+            f"  full-range exponent (log-log fit): {exponent:.2f}  [{_classify(exponent)}]"
+        )
+    if tail is not None:
+        print(f"  tail exponent (largest two sizes): {tail:.2f}  [{_classify(tail)}]")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--scenario",
+        choices=[*SCENARIOS, "all"],
+        default="all",
+        help="Workload to run (default: all available)",
+    )
+    p.add_argument(
+        "--sizes",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_SIZES),
+        help=f"Function counts to sweep (default: {' '.join(map(str, DEFAULT_SIZES))})",
+    )
+    p.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="Repetitions per size; the fastest run is kept (default: 1)",
+    )
+    p.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="Write the full result set as JSON to this path",
+    )
+    p.add_argument(
+        "--max-seconds",
+        type=float,
+        default=None,
+        help="GATE: fail if any single comparison exceeds this many seconds",
+    )
+    p.add_argument(
+        "--max-exponent",
+        type=float,
+        default=None,
+        help="GATE: fail if the log-log scaling exponent exceeds this value",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    scenarios = list(SCENARIOS) if args.scenario == "all" else [args.scenario]
+    report: dict[str, object] = {
+        "schema": "abicheck-scaling/1.0",
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "sizes": args.sizes,
+        "repeat": args.repeat,
+        "scenarios": {},
+    }
+    failures: list[str] = []
+
+    for scenario in scenarios:
+        if scenario == "elf_namespace" and not _has_demangler():
+            print(
+                f"\nScenario: {scenario}  SKIP (no c++filt/cxxfilt demangler available)"
+            )
+            continue
+        points = measure(scenario, args.sizes, args.repeat)
+        exponent = scaling_exponent(points)
+        tail = tail_exponent(points)
+        _print_table(scenario, points, exponent, tail)
+        report["scenarios"][scenario] = {  # type: ignore[index]
+            "points": [asdict(p) for p in points],
+            "exponent": exponent,
+            "tail_exponent": tail,
+        }
+
+        if args.max_seconds is not None:
+            worst = max(points, key=lambda p: p.seconds)
+            if worst.seconds > args.max_seconds:
+                failures.append(
+                    f"{scenario}: {worst.seconds:.2f}s at size={worst.size} "
+                    f"exceeds --max-seconds={args.max_seconds}"
+                )
+        if (
+            args.max_exponent is not None
+            and tail is not None
+            and tail > args.max_exponent
+        ):
+            failures.append(
+                f"{scenario}: tail scaling exponent {tail:.2f} "
+                f"exceeds --max-exponent={args.max_exponent}"
+            )
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.json_out}")
+
+    if failures:
+        print("\nPERFORMANCE GATE FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -396,6 +396,22 @@ class TestMatchRenamedFunctions:
         new = {"new_func": _fp("new_func", 104)}  # 4% diff → fuzzy-only
         assert match_renamed_functions(old, new) == []
 
+    def test_fuzzy_window_scans_only_populated_sizes(self) -> None:
+        """A very large removed symbol with only distant candidates resolves via
+        the bisected size window — no match, and cost independent of byte size."""
+        old = {"old_big": _fp("old_big", 50_000_000)}
+        new = {f"new_{i}": _fp(f"new_{i}", 1000 + i) for i in range(5)}
+        # Candidates are far outside the ±5% window → no rename.
+        assert match_renamed_functions(old, new) == []
+
+    def test_fuzzy_window_matches_within_tolerance_large_size(self) -> None:
+        """A within-tolerance partner is still found for a large symbol."""
+        old = {"old_big": _fp("old_big", 1_000_000)}
+        new = {"new_big": _fp("new_big", 1_000_001)}  # 1 byte apart
+        result = match_renamed_functions(old, new)
+        assert len(result) == 1
+        assert result[0].confidence == 0.5
+
     def test_empty_inputs(self) -> None:
         assert match_renamed_functions({}, {}) == []
         assert match_renamed_functions({"a": _fp("a", 100)}, {}) == []

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -354,6 +354,48 @@ class TestMatchRenamedFunctions:
         assert result[0].old_name == "foo_v1"
         assert result[0].new_name == "foo_v2"
 
+    def test_size_only_match_respects_name_filter(self) -> None:
+        """A unique same-size pair with *unrelated* names must NOT be reported
+        as a rename when the name filter rejects it — otherwise a real
+        removal/addition would be mislabelled as a rename and hide a break."""
+        old = {"completely_unrelated": _fp("completely_unrelated", 128)}
+        new = {"nothing_alike": _fp("nothing_alike", 128)}
+
+        def never(_o: str, _n: str) -> bool:
+            return False
+
+        assert match_renamed_functions(old, new, name_filter=never) == []
+
+    def test_name_filter_kept_over_fuzzy_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Above the fuzzy-pass pair cap the *size* pass still applies the name
+        filter, so a same-size pair with unrelated names is not a false rename
+        (the cap only skips the speculative fuzzy pass, never hides a break)."""
+        import abicheck.binary_fingerprint as bf
+
+        # Force the cap so old×new (1×1) exceeds it.
+        monkeypatch.setattr(bf, "_FUZZY_MAX_PAIRS", 0)
+        old = {"old_unrelated": _fp("old_unrelated", 200)}
+        new = {"new_distinct": _fp("new_distinct", 200)}
+
+        # With a rejecting filter the size-only match must be suppressed even
+        # though the fuzzy pass is capped out.
+        assert match_renamed_functions(old, new, name_filter=lambda o, n: False) == []
+        # With no filter, the size-only (pass 2) match still fires — the cap
+        # only gates the fuzzy pass.
+        result = match_renamed_functions(old, new)
+        assert len(result) == 1
+        assert result[0].confidence == 0.8
+
+    def test_fuzzy_pass_skipped_over_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A within-tolerance (non-equal size) pair is a fuzzy-only match; above
+        the cap the fuzzy pass is skipped, so no candidate is produced."""
+        import abicheck.binary_fingerprint as bf
+
+        monkeypatch.setattr(bf, "_FUZZY_MAX_PAIRS", 0)
+        old = {"old_func": _fp("old_func", _NORMAL_SIZE)}
+        new = {"new_func": _fp("new_func", 104)}  # 4% diff → fuzzy-only
+        assert match_renamed_functions(old, new) == []
+
     def test_empty_inputs(self) -> None:
         assert match_renamed_functions({}, {}) == []
         assert match_renamed_functions({"a": _fp("a", 100)}, {}) == []

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -14,6 +14,7 @@ from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
 from abicheck.model import (
     AbiSnapshot,
     Function,
+    Param,
     RecordType,
     TypeField,
     Visibility,
@@ -212,6 +213,84 @@ class TestManyChangeKinds:
 
         sarif = to_sarif_str(diff)
         assert len(sarif) > 0
+
+
+# ===========================================================================
+# 4b. Type-churn scaling regression guard
+# ===========================================================================
+
+
+def _build_type_churn(n_funcs: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Snapshot pair where every public function takes a *changed* struct by
+    pointer.
+
+    Unlike the add/remove workload above, this exercises the post-processing
+    detectors that relate each type change back to the functions that use it
+    (affected-symbol enrichment, opaque/pointer-only filtering, namespace
+    detection). That O(functions x types) path — not the core symbol diff — is
+    what makes ``compare`` blow up on large real libraries
+    (see docs/development/performance.md). Mirrors
+    ``scripts/benchmark_scaling.py``'s ``type_churn`` scenario.
+    """
+    n_types = max(50, n_funcs // 20)
+    types_old, types_new = [], []
+    for i in range(n_types):
+        base = [
+            TypeField(name="a", type="int", offset_bits=0),
+            TypeField(name="b", type="int", offset_bits=32),
+        ]
+        grown = base + [TypeField(name="c", type="int", offset_bits=64)]
+        types_old.append(RecordType(name=f"Type_{i}", kind="struct", size_bits=64, fields=base))
+        types_new.append(RecordType(name=f"Type_{i}", kind="struct", size_bits=96, fields=grown))
+    funcs = [
+        Function(
+            name=f"use_Type_{i % n_types}_{i}",
+            mangled=f"_Z4use_{i}P6Type_{i % n_types}",
+            return_type="int",
+            params=[Param(name="p", type=f"Type_{i % n_types} *")],
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n_funcs)
+    ]
+    old = AbiSnapshot(library="libperf.so", version="1.0", functions=list(funcs), types=types_old)
+    new = AbiSnapshot(library="libperf.so", version="2.0", functions=list(funcs), types=types_new)
+    return old, new
+
+
+class TestTypeChurnScaling:
+    """Guard the realistic hot path that the add/remove benchmark does not hit.
+
+    Thresholds are deliberately generous: these tests catch a catastrophic
+    regression (e.g. a detector becoming truly O(n^2)), not a few-percent
+    drift, so they stay stable across CI runner speeds.
+    """
+
+    def test_type_churn_2000_functions_completes(self) -> None:
+        old, new = _build_type_churn(2000)
+        start = time.monotonic()
+        result = compare(old, new)
+        elapsed = time.monotonic() - start
+
+        # ~3.5s locally; allow a wide margin for slow shared CI runners.
+        assert elapsed < 30.0, f"type-churn compare took {elapsed:.2f}s, expected < 30s"
+        assert result.verdict == Verdict.BREAKING
+        assert len(result.changes) > 0
+
+    def test_type_churn_scaling_stays_subquadratic(self) -> None:
+        import math
+
+        timings: list[tuple[int, float]] = []
+        for n in (1000, 2000):
+            old, new = _build_type_churn(n)
+            start = time.monotonic()
+            compare(old, new)
+            timings.append((n, max(time.monotonic() - start, 1e-3)))
+
+        (n1, t1), (n2, t2) = timings
+        exponent = math.log(t2 / t1) / math.log(n2 / n1)
+        # True quadratic would be ~2.0; current behaviour is ~1.3. A regression
+        # to genuine O(n^2) (exponent >= 1.9) should fail this guard.
+        assert exponent < 1.9, f"compare scaling exponent {exponent:.2f} regressed toward O(n^2)"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Why

Comparing large **real** libraries exposed a real performance problem. On
`libonedal_core.so` (~10,550 functions), `dump` is fine (~5 s) but `compare`
**did not finish within 60 s**. This PR profiles that, **fixes the
bottlenecks**, and adds a flexible CI scaling benchmark to guard against
regressions.

## Bottlenecks found and fixed

A profiling sweep across realistic workload shapes found **six** super-linear
paths in the *post-processing* detectors (not the core diff). All are fixed;
detector behaviour is unchanged — the full unit suite (8522 tests), the FP-rate
gate (0/0), and the metamorphic/oracle detector tests all stay green.

| # | Path | Was | Fix |
|---|------|-----|-----|
| 1 | `surface.classify_change_surface` | 4 old∪new set unions **per finding** → O(findings×surface); made *every* compare quadratic | compute unions once per pass (`surface_unions`) |
| 2 | `diff_namespaces` demangling | one `c++filt` subprocess **per symbol** | batch-demangle each snapshot once |
| 3 | `diff_symbols._find_rename_pairs` | O(removed×added) suffix scan | reversed-name index + binary search |
| 4 | `diff_type_spellings` | rebuilt a `set()` inside a comprehension | hoist once |
| 5 | `diff_filtering` ancestor closure | duplicate function **lists** + per-change re-sort → ~cubic on nested types | use sets |
| 6 | `binary_fingerprint` / `_plausible_rename` | O(removed×added) name scan, re-demangling per pair | size-window scan + cached per-name parse + cap for mass-rename |

### Measured (n=4000 unless noted)

| Scenario | Before | After |
|---|---:|---:|
| `add_remove` | 9.1 s | **0.32 s** (linear) |
| `var_churn` | 2.1 s | **0.06 s** (linear) |
| `elf_namespace` | 5.2 s | **0.33 s** (linear) |
| `type_churn` | 8.8 s | **1.4 s** |
| `nested_types` (n=200) | >60 s (≈cubic) | **0.16 s** |
| `rename_churn` (n=1000) | 13.2 s | **2.1 s** + bounded above |

The one remaining super-linear path is the narrow opaque-handle size filter
(`_filter_opaque_size_changes`), left as-is because its candidate count is small
for real libraries and `type_churn` already dropped 6.4× as a side effect.

## Tooling (measurement, also flexible/non-gating)

- **`scripts/benchmark_scaling.py`** — pure-Python synthetic scaling harness
  (no compiler/castxml). Six scenarios, per-scenario size sweeps + safety caps,
  log-log scaling exponent, JSON output. Non-gating by default; opt-in
  `--max-seconds` / `--max-exponent` flags turn it into a gate.
- **`.github/workflows/performance.yml`** — runs automatically on detector-core
  PRs (plus schedule / dispatch / `performance` label), `continue-on-error`,
  publishes the table to the job summary. Never blocks a merge.
- **`tests/test_performance.py`** — `slow` `TestTypeChurnScaling` guard that
  catches a regression back to genuine O(n²).
- **`docs/development/performance.md`** — full evaluation, the fix table, and
  how to enable gating.

## Verification

- `pytest` (fast lane): **8522 passed**
- `scripts/check_fp_rate.py`: 0 FP / 0 FN
- detector property + oracle + perf tests: pass
- `ruff check` + `mypy abicheck/` clean; AI-readiness 0 errors

https://claude.ai/code/session_017i2ZWZ1yab1b1d8j1rtmda