### PR TITLE
fix(evidence): preserve option-only compiler records; cover dialect-aware source detection

### DIFF
--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -141,7 +141,8 @@ def collect_evidence_cmd(
         "build_dir": red.path(str(build_dir)) if build_dir else None,
     }
     has_build = bool(
-        merged.compile_units or merged.targets or merged.toolchains or merged.link_units
+        merged.compile_units or merged.targets or merged.toolchains
+        or merged.link_units or merged.build_options
     )
     if has_build:
         pack.build_evidence = merged

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared adapter helpers — dialect-aware source detection (ADR-029)."""
+from __future__ import annotations
+
+from abicheck.evidence.adapters.base import (
+    _is_msvc_command,
+    source_from_argv,
+)
+
+
+def test_msvc_command_detected_by_slash_c():
+    assert _is_msvc_command(["cl.exe", "/c", "foo.cc"]) is True
+
+
+def test_msvc_command_detected_by_driver_basename_without_slash_c():
+    # No `/c` marker — a clang-cl/cl driver basename alone marks MSVC dialect,
+    # even when the driver is a full path.
+    assert _is_msvc_command(["clang-cl", "/FIconfig.hpp", "foo.cc"]) is True
+    assert _is_msvc_command([r"C:\VS\bin\cl.exe", "foo.cc"]) is True
+
+
+def test_msvc_command_scan_stops_at_shell_separator():
+    # The driver scan must not cross a `&&`/`;` into a following command, so a
+    # GNU compile chained after `cd` stays GNU dialect.
+    assert _is_msvc_command(["cd", "sub", "&&", "gcc", "-c", "x.c"]) is False
+
+
+def test_source_from_argv_msvc_combined_forced_include_rejected():
+    # /FIconfig.hpp is a combined forced-include option, never the TU.
+    assert source_from_argv(["clang-cl", "/FIconfig.hpp", "foo.cc"]) == "foo.cc"
+
+
+def test_source_from_argv_tp_space_separated_form():
+    # `/Tp <file>` (space-separated) names the C++ TU explicitly.
+    assert source_from_argv(["cl.exe", "/c", "/Tp", "foo.cc", "/Fofoo.obj"]) == "foo.cc"
+
+
+def test_source_from_argv_tp_without_valid_operand_is_skipped():
+    # A trailing `/Tp` with no source-like operand consumes its slot and yields
+    # no source (rather than misreading the next option).
+    assert source_from_argv(["cl.exe", "/c", "/Tp"]) == ""
+
+
+def test_source_from_argv_gnu_absolute_path_kept_behind_cd_prefix():
+    # source_from_argv tolerates a `cd dir && cc …` argv: the GNU absolute path
+    # is still recovered and the `&&` does not flip the command to MSVC dialect.
+    assert source_from_argv(["cd", "sub", "&&", "gcc", "-c", "/work/src/x.c"]) == "/work/src/x.c"

--- a/tests/test_compiler_record.py
+++ b/tests/test_compiler_record.py
@@ -203,3 +203,26 @@ def test_collect_evidence_read_compiler_record_requires_binary(tmp_path):
     result = CliRunner().invoke(main, ["collect-evidence", "--read-compiler-record", "-o", str(out)])
     assert result.exit_code != 0
     assert "requires --binary" in result.output
+
+
+def test_collect_evidence_preserves_option_only_compiler_record(tmp_path, monkeypatch):
+    # A stripped ELF whose only provenance is `.GCC.command.line` switches (no
+    # source TU, no DWARF producer) yields build_options but no units/toolchains.
+    # The pack must still persist that build evidence rather than drop it.
+    from abicheck.evidence.pack import EvidencePack
+
+    binpath = tmp_path / "switches.so"
+    binpath.write_bytes(b"\x7fELF")
+    section = _FakeSection(b"GNU C11 13.3.0 -std=c11 -D_GLIBCXX_USE_CXX11_ABI=0 -O2\x00")
+    monkeypatch.setattr(cr, "ELFFile", lambda _fh: _FakeELF(section=section, dwarf=None))
+
+    out = tmp_path / "e"
+    result = CliRunner().invoke(
+        main, ["collect-evidence", "--read-compiler-record", "--binary", str(binpath), "-o", str(out)]
+    )
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert pack.build_evidence is not None  # option-only evidence not dropped
+    assert not pack.build_evidence.compile_units and not pack.build_evidence.toolchains
+    opts = {(o.key, o.value) for o in pack.build_evidence.build_options}
+    assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts


### PR DESCRIPTION
Follow-up to #330 (ADR-029 D7/D8), which merged before these review fixes landed.

## What

- **`cli_evidence.py`** — `has_build` now includes `merged.build_options`. An option-only compiler record (a stripped ELF carrying `.GCC.command.line` switches but no source TU and no DWARF `DW_AT_producer`) populates `build_options` only; previously the presence check ignored that, so `pack.build_evidence` was never written and the recovered ABI-relevant options were silently lost. (Addresses Codex P2 on `cli_evidence.py:144`.)
- **`tests/test_compiler_record.py`** — CLI regression test proving an option-only record round-trips into `pack.build_evidence.build_options`.
- **`tests/test_adapter_base.py`** (new) — direct coverage for the dialect-aware `source_from_argv` / `_is_msvc_command` branches: combined MSVC `/FIsrc/config.hpp` rejection, space-separated `/Tp <file>` form, driver-basename MSVC detection without `/c`, and the shell-separator (`&&`/`;`) scan stop.

## Why

The dialect-aware source detection (combined MSVC `/FI` no longer mistaken for the TU; GNU absolute paths still kept) and the option-only preservation both came out of post-merge automated review on #330. Splitting them into this follow-up keeps the fixes reviewable on their own.

## Verification

- Fast unit lane: 8599 passed, 22 skipped, 4 xfailed
- `ruff check`, `mypy abicheck/`, `scripts/check_ai_readiness.py` — all clean (0 errors)

https://claude.ai/code/session_018wxhaKyctyPmQng4WEFXvq

---
_Generated by [Claude Code](https://claude.ai/code/session_018wxhaKyctyPmQng4WEFXvq)_