### PR TITLE
ci: add AgentReady repository readiness scan workflow

### DIFF
--- a/.github/workflows/agentready.yml
+++ b/.github/workflows/agentready.yml
@@ -1,0 +1,67 @@
+name: AgentReady
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Repository Scan
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: agentready
+        uses: napetrov/agentready@main
+        with:
+          mode: scan
+          job-summary: true
+          upload-sarif: true
+      - name: Upload SARIF
+        if: always() && steps.agentready.outputs.sarif-report-path
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.agentready.outputs.sarif-report-path }}
+          category: agentready
+
+  diff:
+    name: PR Readiness Diff
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: agentready
+        uses: napetrov/agentready@main
+        with:
+          mode: diff
+          base-ref: origin/${{ github.base_ref }}
+          head-ref: HEAD
+          fail-on-regression: true
+          job-summary: true
+          pr-comment: true
+          upload-sarif: true
+      - name: Upload SARIF
+        if: always() && steps.agentready.outputs.sarif-report-path
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.agentready.outputs.sarif-report-path }}
+          category: agentready

--- a/.github/workflows/agentready.yml
+++ b/.github/workflows/agentready.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -45,6 +46,7 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow (`.github/workflows/agentready.yml`) that runs the [`napetrov/agentready`](https://github.com/napetrov/agentready) AI-readiness scanner on the repo.

## What it does

Two jobs, selected by event:

- **`scan`** — runs on push to `main`, the weekly schedule, and manual dispatch. Full-repository `scan` mode, writes a job summary, and uploads SARIF to code scanning.
- **`diff`** — runs on pull requests. `diff` mode against the PR base branch with `fail-on-regression: true`, posts a sticky PR comment with the readiness report, and uploads SARIF.

## Notes

- Triggers/permissions/cron mirror the existing `security.yml` conventions (push+PR to `main`, weekly Monday 06:00 schedule, `workflow_dispatch`).
- `fetch-depth: 0` is set so diff mode can resolve the base ref.
- SARIF upload uses a dedicated `agentready` category so findings don't collide with CodeQL.
- The PR-comment job carries `pull-requests: write`; the SARIF jobs carry `security-events: write`.

https://claude.ai/code/session_01RE6yuupFjP9P9CComLkg9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE6yuupFjP9P9CComLkg9v)_