### PR TITLE
fix(source-abi): unredact macro home paths and carry unnormalized include-search flags

### DIFF
--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -156,15 +156,17 @@ _GNU_SEPARATE_INCLUDE_OPTS = frozenset({"-include", "-imacros", "-include-pch"})
 #: that swallows the following argv token (``--sysroot=/sdk … -isysroot -o``).
 #: Mirrors ``_TOOLCHAIN_PATH_FLAG_PREFIXES`` in ``adapters/base.py``.
 _STRUCTURED_TOOLCHAIN_FLAG_PREFIXES = ("--sysroot", "-isysroot", "--target", "-target")
-#: Preprocessor macro define/undef option prefixes. Their *values* are passed to
-#: the compiler verbatim (argv, no shell expansion), so a literal ``~`` in e.g.
-#: ``-DDEFAULT_DIR=~/app`` must NOT be home-expanded during replay — unlike the
-#: path operands (includes/sysroot/source), which carry redacted home prefixes.
-_MACRO_DEFINITION_PREFIXES = ("-D", "-U", "/D", "/U")
 #: MSVC/clang-cl forced-include options in their separate-operand spelling
 #: (``/FI file`` or ``-FI file``); the joined ``/FIfile`` form is handled by
 #: prefix. (https://learn.microsoft.com/cpp/build/reference/fi-name-forced-include-file)
 _MSVC_FORCED_INCLUDE_OPTS = frozenset({"/FI", "-FI"})
+#: GNU include-search options that take a separate directory operand and are NOT
+#: normalized into the structured ``include_paths``/``system_include_paths``
+#: buckets (those cover ``-I``/``-isystem`` only). Dropping them makes castxml
+#: search a different set of directories than the real compile (Codex review #335).
+#: Both are separate-operand only (``-iquote dir`` / ``-idirafter dir``; no joined
+#: spelling). (https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html)
+_GNU_INCLUDE_SEARCH_OPTS = frozenset({"-iquote", "-idirafter"})
 
 
 def _replay_extra_flags(
@@ -173,11 +175,13 @@ def _replay_extra_flags(
     """Carry through ABI/parse-relevant options not in the structured fields.
 
     ``abi_relevant_flags`` (e.g. ``-fms-extensions``, ``-fabi-version``,
-    ``-fvisibility``, ``-m32``) and forced-include options from ``argv`` change
-    the parsed translation unit; dropping them makes castxml parse a different TU
-    than the real build (ADR-030 D2). De-duplicated against the flags already
-    emitted from the structured fields. MSVC ``/FI`` forced includes are carried
-    only in MSVC mode so a GNU ``-F``-family flag is never mistaken for one.
+    ``-fvisibility``, ``-m32``), forced-include options, and unnormalized
+    include-search options (GNU ``-iquote``/``-idirafter``, MSVC ``/I``) from
+    ``argv`` change the parsed translation unit / header search; dropping them
+    makes castxml parse a different TU than the real build (ADR-030 D2).
+    De-duplicated against the flags already emitted from the structured fields.
+    MSVC ``/FI`` forced includes and ``/I`` search dirs are carried only in MSVC
+    mode so a GNU ``-F``/``-I``-family flag is never mistaken for one.
     """
     seen = set(already)
     out: list[str] = []
@@ -199,6 +203,15 @@ def _replay_extra_flags(
         if tok in _GNU_SEPARATE_INCLUDE_OPTS and i + 1 < len(argv):
             out += [tok, argv[i + 1]]  # -include / -imacros / -include-pch <file>
             i += 2
+        elif tok in _GNU_INCLUDE_SEARCH_OPTS and i + 1 < len(argv):
+            out += [tok, argv[i + 1]]  # -iquote / -idirafter <dir>
+            i += 2
+        elif cc_id == "msvc" and tok == "/I" and i + 1 < len(argv):
+            out += [tok, argv[i + 1]]  # MSVC /I dir (separate operand)
+            i += 2
+        elif cc_id == "msvc" and len(tok) > 2 and tok.startswith("/I"):
+            out.append(tok)  # MSVC /Idir (joined)
+            i += 1
         elif tok not in _GNU_SEPARATE_INCLUDE_OPTS and any(
             tok.startswith(opt) and len(tok) > len(opt)
             for opt in _GNU_FORCED_INCLUDE_OPTS
@@ -310,20 +323,18 @@ class CastxmlSourceExtractor:
                 castxml_bin=self.castxml_bin,
                 compiler_binary=self.compiler_binary,
             )
-            # Expand any redacted `~` in the include/system/sysroot/source/argv
-            # *path* operands the command builder emitted from the (possibly
-            # redacted) CompileUnit. Macro definitions (`-D`/`-U`, `/D`/`/U`) are
-            # left verbatim: the compiler receives a `-DDIR=~/app` value literally
-            # (argv, no shell expansion), so unredacting a legitimate literal tilde
-            # in a macro value would parse a different TU (Codex review #335, P2).
-            # Other emitted flags (`-std=`, `--target=`, `-f*`) carry no `~`, so
-            # expanding them is a no-op.
-            cmd = [
-                tok
-                if tok.startswith(_MACRO_DEFINITION_PREFIXES)
-                else _unredact_home(tok)
-                for tok in cmd
-            ]
+            # Expand any redacted `~` home prefix the command builder emitted from
+            # the (possibly redacted) CompileUnit — includes/system/sysroot/source
+            # path operands *and* macro values. A real home path used inside a
+            # macro (e.g. `-DCFG=~/build/cfg.h` consumed by `#include CFG`) must be
+            # expanded or CastXML parses a different TU / fails to find the header
+            # (Codex review #335). `_unredact_home` only rewrites a `~` that stands
+            # in for a home directory (whole token or followed by a separator), so
+            # a literal `~` mid-token (e.g. a Windows 8.3 short name, or a `~1`
+            # in a value) is left intact; the rare user-authored literal `-DDIR=~/x`
+            # being expanded is the accepted tradeoff for replaying redacted
+            # home-path macros correctly.
+            cmd = [_unredact_home(tok) for tok in cmd]
             try:
                 # Run in the compile unit's directory so relative -I/-isystem
                 # and forced-include paths resolve exactly as the real build did

--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -160,12 +160,13 @@ _STRUCTURED_TOOLCHAIN_FLAG_PREFIXES = ("--sysroot", "-isysroot", "--target", "-t
 #: (``/FI file`` or ``-FI file``); the joined ``/FIfile`` form is handled by
 #: prefix. (https://learn.microsoft.com/cpp/build/reference/fi-name-forced-include-file)
 _MSVC_FORCED_INCLUDE_OPTS = frozenset({"/FI", "-FI"})
-#: GNU include-search options that take a separate directory operand and are NOT
+#: GNU include-search options that take a directory operand and are NOT
 #: normalized into the structured ``include_paths``/``system_include_paths``
 #: buckets (those cover ``-I``/``-isystem`` only). Dropping them makes castxml
 #: search a different set of directories than the real compile (Codex review #335).
-#: Both are separate-operand only (``-iquote dir`` / ``-idirafter dir``; no joined
-#: spelling). (https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html)
+#: gcc/clang accept both the separate (``-iquote dir``) and joined
+#: (``-iquote/dir``) spellings, so both are carried through.
+#: (https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html)
 _GNU_INCLUDE_SEARCH_OPTS = frozenset({"-iquote", "-idirafter"})
 
 
@@ -204,8 +205,14 @@ def _replay_extra_flags(
             out += [tok, argv[i + 1]]  # -include / -imacros / -include-pch <file>
             i += 2
         elif tok in _GNU_INCLUDE_SEARCH_OPTS and i + 1 < len(argv):
-            out += [tok, argv[i + 1]]  # -iquote / -idirafter <dir>
+            out += [tok, argv[i + 1]]  # -iquote / -idirafter <dir> (separate)
             i += 2
+        elif tok not in _GNU_INCLUDE_SEARCH_OPTS and any(
+            tok.startswith(opt) and len(tok) > len(opt)
+            for opt in _GNU_INCLUDE_SEARCH_OPTS
+        ):
+            out.append(tok)  # -iquote/dir / -idirafter/dir (joined)
+            i += 1
         elif cc_id == "msvc" and tok == "/I" and i + 1 < len(argv):
             out += [tok, argv[i + 1]]  # MSVC /I dir (separate operand)
             i += 2

--- a/tests/test_source_extractors.py
+++ b/tests/test_source_extractors.py
@@ -233,6 +233,42 @@ def test_build_command_preserves_include_pch_operand() -> None:
     assert cmd[cmd.index("-include-pch") + 1] == "pch.h"
 
 
+def test_build_command_carries_gnu_include_search_flags() -> None:
+    # GNU -iquote/-idirafter take a separate dir operand and are NOT normalized
+    # into include_paths/system_include_paths, so the replay must carry them or
+    # castxml searches a different set of directories (Codex review #335, P2).
+    cmd = build_castxml_command(
+        _cu(argv=["g++", "-iquote", "q/dir", "-idirafter", "late/dir", "-c", "a.cpp"]),
+        Path("a.cpp"),
+        Path("o.xml"),
+    )
+    assert cmd[cmd.index("-iquote") + 1] == "q/dir"
+    assert cmd[cmd.index("-idirafter") + 1] == "late/dir"
+
+
+def test_build_command_carries_msvc_include_search_flags() -> None:
+    # MSVC /I dir (separate) and /Idir (joined) add #include search directories
+    # and are not normalized; carry them through in MSVC mode (Codex review #335).
+    cmd = build_castxml_command(
+        _cu(argv=["cl.exe", "/I", "inc dir", "/Ijoined", "-c", "a.cpp"]),
+        Path("a.cpp"),
+        Path("o.xml"),
+    )
+    assert cmd[cmd.index("/I") + 1] == "inc dir"  # separate operand preserved
+    assert "/Ijoined" in cmd  # joined form preserved
+
+
+def test_build_command_ignores_msvc_include_search_in_gnu_mode() -> None:
+    # In GNU mode a `/I`-looking token must not be mistaken for an MSVC include
+    # flag (it isn't a GNU option), so it is not carried through.
+    cmd = build_castxml_command(
+        _cu(argv=["g++", "/Ijoined", "-c", "a.cpp"]),
+        Path("a.cpp"),
+        Path("o.xml"),
+    )
+    assert "/Ijoined" not in cmd
+
+
 def test_build_command_drops_split_sysroot_flag_carried_without_operand() -> None:
     # A split `-isysroot /sdk` is normalized into compile_unit.sysroot (emitted
     # as --sysroot=/sdk), but extract_abi_relevant_flags records only the bare
@@ -352,11 +388,12 @@ def test_extract_unredacts_home_for_replay(tmp_path: Path, monkeypatch) -> None:
     assert f"{home}/proj/include" in captured["cmd"]  # type: ignore[operator]
 
 
-def test_extract_preserves_literal_tilde_in_macro_value(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    # A literal `~` in a macro *value* (e.g. -DDEFAULT_DIR=~/app) must survive
-    # replay verbatim: the compiler receives it literally (argv, no shell), so
-    # home-expanding it would parse a different TU (Codex review #335, P2). Path
-    # operands are still unredacted in the same command.
+def test_extract_unredacts_home_in_macro_value(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # A redacted home prefix inside a macro value (e.g. -DCFG=~/build/cfg.h used
+    # via `#include CFG`) is expanded for replay, like any other home-path
+    # operand, so CastXML parses the same TU the real compile did (Codex review
+    # #335). A `~` that is NOT a home-dir placeholder (mid-token, e.g. a `~1`
+    # short name) is still left intact by _unredact_home.
     import os
 
     from abicheck.evidence.source_extractors import castxml as castxml_mod
@@ -380,16 +417,17 @@ def test_extract_preserves_literal_tilde_in_macro_value(tmp_path: Path, monkeypa
         source="~/proj/src/foo.cpp",
         directory="~/proj",
         include_paths=["~/proj/include"],
-        defines={"DEFAULT_DIR": "~/app"},
+        defines={"CFG": "~/build/cfg.h", "MODE": "fast~1"},
     )
     extractor.extract(cu, public_header_roots=["foo.h"], target_id="target://x")
     home = os.path.expanduser("~")
     cmd = captured["cmd"]
-    # Macro value keeps its literal tilde...
-    assert "-DDEFAULT_DIR=~/app" in cmd  # type: ignore[operator]
-    assert f"-DDEFAULT_DIR={home}/app" not in cmd  # type: ignore[operator]
-    # ...while the include path operand is still expanded.
+    # Home-prefix placeholder in the macro value is expanded...
+    assert f"-DCFG={home}/build/cfg.h" in cmd  # type: ignore[operator]
+    # ...the include path operand too...
     assert f"{home}/proj/include" in cmd  # type: ignore[operator]
+    # ...but a mid-token `~` (not a home-dir placeholder) is left intact.
+    assert "-DMODE=fast~1" in cmd  # type: ignore[operator]
 
 
 # -- model → SourceEntity mapping (pure, D4) ---------------------------------

--- a/tests/test_source_extractors.py
+++ b/tests/test_source_extractors.py
@@ -234,8 +234,8 @@ def test_build_command_preserves_include_pch_operand() -> None:
 
 
 def test_build_command_carries_gnu_include_search_flags() -> None:
-    # GNU -iquote/-idirafter take a separate dir operand and are NOT normalized
-    # into include_paths/system_include_paths, so the replay must carry them or
+    # GNU -iquote/-idirafter take a dir operand and are NOT normalized into
+    # include_paths/system_include_paths, so the replay must carry them or
     # castxml searches a different set of directories (Codex review #335, P2).
     cmd = build_castxml_command(
         _cu(argv=["g++", "-iquote", "q/dir", "-idirafter", "late/dir", "-c", "a.cpp"]),
@@ -244,6 +244,18 @@ def test_build_command_carries_gnu_include_search_flags() -> None:
     )
     assert cmd[cmd.index("-iquote") + 1] == "q/dir"
     assert cmd[cmd.index("-idirafter") + 1] == "late/dir"
+
+
+def test_build_command_carries_joined_gnu_include_search_flags() -> None:
+    # gcc/clang also accept the joined spelling (-iquote/dir, -idirafter/dir);
+    # a compile DB recording that form must not drop the directory (Codex #338 P2).
+    cmd = build_castxml_command(
+        _cu(argv=["g++", "-iquoteq/dir", "-idirafterlate/dir", "-c", "a.cpp"]),
+        Path("a.cpp"),
+        Path("o.xml"),
+    )
+    assert "-iquoteq/dir" in cmd
+    assert "-idirafterlate/dir" in cmd
 
 
 def test_build_command_carries_msvc_include_search_flags() -> None:


### PR DESCRIPTION
Follow-up to the merged ADR-030 source-ABI replay PR (#335), addressing two castxml replay-fidelity findings from the Codex review that landed after merge.

## 1. Unredact `~` in macro values too
`extract()` previously skipped `-D`/`-U` tokens when expanding redacted home prefixes, to preserve a user-authored literal `-DDIR=~/app`. But a real home path redacted into a macro consumed as an include (e.g. `-DCFG=~/build/cfg.h` used by `#include CFG`) then stayed `~/...`, so CastXML parsed a different TU / failed to find the header.

Now all emitted tokens are unredacted. `_unredact_home` still only rewrites a `~` that stands in for a home **directory** (whole token or followed by a separator), so a mid-token `~` (Windows 8.3 short name, `~1`, …) is left intact. The rare user-authored literal `-DDIR=~/app` being expanded is the accepted tradeoff (decided in review).

## 2. Carry through unnormalized include-search flags
The L3 parser only normalizes `-I`/`-isystem` into the structured include buckets, so GNU `-iquote`/`-idirafter <dir>` and MSVC `/I dir` (separate) / `/Idir` (joined) were dropped from the replay command, making castxml search a different directory set. `_replay_extra_flags` now carries them (MSVC `/I` only in MSVC mode so a GNU `-I`-family flag is never mistaken for one).

## Tests
- A redacted home path in a macro value is expanded while a mid-token `~` is preserved.
- GNU `-iquote`/`-idirafter` and MSVC `/I` (separate + joined) are carried; a `/I`-looking token in GNU mode is not.

Local gates green: source-extractor + source-abi suites pass (68 passed, 1 skipped); ruff, mypy, and `check_ai_readiness.py` (0 errors) clean.

https://claude.ai/code/session_01WoKZ5djvktwuT9dVJeytCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoKZ5djvktwuT9dVJeytCK)_