### PR TITLE
feat(source-abi): complete ADR-030 — clang backend, Android adapter, replay scoping, CLI wiring

### DIFF
--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -767,8 +767,8 @@ _CHECK_CAPABILITIES: tuple[tuple[str, str, str, str], ...] = (
      "from build-system data (compile DB / CMake / Ninja / Bazel)",
      "no build data: flag/toolchain regressions are not detected"),
     ("Macros, default args, inline/template/constexpr bodies", "L4_source_abi",
-     "from source ABI replay (requires clang)",
-     "no sources/clang: source-only API changes are not detected"),
+     "from source ABI replay (requires a source extractor: clang, castxml, or android)",
+     "no source replay evidence: source-only API changes are not detected"),
     ("Impact / call / reachability graph", "L5_source_graph",
      "from the source graph summary",
      "no graph evidence: cross-symbol impact is not analyzed"),
@@ -785,10 +785,13 @@ def _echo_capabilities(
     (binary only → +debug → +headers → +build data → +sources), which checks ran
     and the concrete reason each disabled one is off.
     """
+    # Only a PRESENT layer enables its checks: a PARTIAL layer (e.g. L4 when clang
+    # was missing or every TU failed, so no entities were extracted) ran but
+    # produced nothing, and must read as [off], not [on] (CodeRabbit review).
     present = {
         c.layer
         for c in (*intrinsic, *optional)
-        if c.status != CoverageStatus.NOT_COLLECTED
+        if c.status == CoverageStatus.PRESENT
     }
     click.echo("Checks enabled for this scan (and why others are not):", err=True)
     for label, layer, how, why_off in _CHECK_CAPABILITIES:

--- a/abicheck/cli_evidence.py
+++ b/abicheck/cli_evidence.py
@@ -42,9 +42,15 @@ from .evidence.model import (
 )
 from .evidence.pack import EvidencePack
 from .evidence.redaction import DEFAULT_REDACTION
+from .evidence.source_replay import REPLAY_SCOPES
 
 if TYPE_CHECKING:
     from .checker_types import Change
+    from .evidence.source_abi import SourceAbiSurface
+    from .evidence.source_extractors import (
+        CastxmlSourceExtractor,
+        ClangSourceExtractor,
+    )
     from .model import AbiSnapshot
 
 
@@ -76,6 +82,27 @@ if TYPE_CHECKING:
 @click.option("--build-system", "build_system", default="generic", show_default=True,
               type=click.Choice(["generic", "cmake", "ninja", "bazel", "make"], case_sensitive=False),
               help="Build system hint for the compile-DB adapter.")
+@click.option("--source-abi", "source_abi", is_flag=True, default=False,
+              help="Collect L4 source ABI replay (parses sources/headers). REQUIRES clang "
+                   "(or castxml/an Android dump); without the tool this fails gracefully and "
+                   "source-only checks stay disabled.")
+@click.option("--source-abi-extractor", "source_abi_extractor", default="clang", show_default=True,
+              type=click.Choice(["clang", "castxml", "android"], case_sensitive=False),
+              help="L4 backend: clang (inline/template/constexpr bodies + default args), "
+                   "castxml (declarations/types/const values only), or android (reuse a "
+                   "pre-captured header-abi .lsdump/.sdump).")
+@click.option("--source-abi-scope", "source_abi_scope", default="target", show_default=True,
+              type=click.Choice(list(REPLAY_SCOPES), case_sensitive=False),
+              help="Which translation units to replay (ADR-030 D7): off | headers-only | "
+                   "changed | target | full.")
+@click.option("--source-abi-target", "source_abi_target", default="", help="Target id to scope replay to (e.g. target://libfoo).")
+@click.option("--changed-path", "changed_paths", multiple=True, type=str,
+              help="Changed file path for --source-abi-scope changed (repeat).")
+@click.option("--android-dump", "android_dump", type=click.Path(path_type=Path), default=None,
+              help="Pre-captured Android header-abi .lsdump/.sdump JSON (for --source-abi-extractor android).")
+@click.option("--source-abi-cache", "source_abi_cache", type=click.Path(path_type=Path), default=None,
+              help="Directory for the per-TU source ABI dump cache (ADR-030 D8).")
+@click.option("--clang-bin", "clang_bin", default="clang", show_default=True, help="clang binary to use for source ABI replay.")
 @click.option("-o", "--output", "output", type=click.Path(path_type=Path), required=True,
               help="Output evidence-pack directory.")
 @click.option("-v", "--verbose", is_flag=True, default=False)
@@ -93,6 +120,14 @@ def collect_evidence_cmd(
     make_dry_run: Path | None,
     read_compiler_record: bool,
     build_system: str,
+    source_abi: bool,
+    source_abi_extractor: str,
+    source_abi_scope: str,
+    source_abi_target: str,
+    changed_paths: tuple[str, ...],
+    android_dump: Path | None,
+    source_abi_cache: Path | None,
+    clang_bin: str,
     output: Path,
     verbose: bool,
 ) -> None:
@@ -126,6 +161,23 @@ def collect_evidence_cmd(
         verbose=verbose,
     )
 
+    surface: SourceAbiSurface | None = None
+    source_detail = ""
+    if source_abi:
+        surface, source_detail = _collect_source_abi(
+            merged, extractors,
+            extractor=source_abi_extractor,
+            scope=source_abi_scope,
+            target_id=source_abi_target,
+            changed_paths=list(changed_paths),
+            android_dump=android_dump,
+            cache_dir=source_abi_cache,
+            clang_bin=clang_bin,
+            headers=headers,
+            binary=binary,
+            verbose=verbose,
+        )
+
     pack = EvidencePack.empty(
         output,
         abicheck_version=_abicheck_version,
@@ -146,7 +198,9 @@ def collect_evidence_cmd(
     )
     if has_build:
         pack.build_evidence = merged
-    pack.manifest.coverage = _build_coverage(merged, has_build)
+    if surface is not None:
+        pack.source_abi = surface
+    pack.manifest.coverage = _build_coverage(merged, has_build, surface, source_detail)
     pack.write()
 
     click.echo(f"Evidence pack written to {output}")
@@ -158,6 +212,8 @@ def collect_evidence_cmd(
         )
     else:
         click.echo("  L3 build context: not collected (no adapters produced facts)")
+    if source_abi:
+        click.echo(f"  L4 source ABI replay: {source_detail}")
     for diag in merged.diagnostics:
         click.echo(f"  note: {diag}", err=True)
 
@@ -267,7 +323,12 @@ def _run_adapters(
         ))
 
 
-def _build_coverage(merged: BuildEvidence, has_build: bool) -> list[LayerCoverage]:
+def _build_coverage(
+    merged: BuildEvidence,
+    has_build: bool,
+    surface: SourceAbiSurface | None = None,
+    source_detail: str = "",
+) -> list[LayerCoverage]:
     """Build the L3/L4/L5 coverage rows for the pack manifest (ADR-028 D7)."""
     if has_build:
         systems = sorted({g.kind for g in merged.generators}) or ["generic"]
@@ -282,11 +343,197 @@ def _build_coverage(merged: BuildEvidence, has_build: bool) -> list[LayerCoverag
         )
     else:
         l3 = LayerCoverage(layer=EvidenceLayer.L3_BUILD.value, status=CoverageStatus.NOT_COLLECTED)
+    # L4 is PRESENT when at least one TU parsed into the surface, PARTIAL when
+    # replay ran but every TU failed/was empty (e.g. clang missing), else
+    # NOT_COLLECTED. The surface keeps decls/types only when extraction worked.
+    if surface is not None:
+        # PRESENT when the surface actually carries reachable entities; PARTIAL
+        # when replay ran but yielded nothing (tool missing, all TUs failed, or
+        # no public surface matched) — never silently NOT_COLLECTED, so the
+        # capability report can explain the gap.
+        any_entities = bool(
+            surface.reachable_declarations or surface.reachable_types
+            or surface.reachable_macros or surface.reachable_templates
+            or surface.reachable_inline_bodies
+        )
+        if any_entities:
+            l4 = LayerCoverage(
+                layer=EvidenceLayer.L4_SOURCE_ABI.value, status=CoverageStatus.PRESENT,
+                confidence=EvidenceConfidence.HIGH, detail=source_detail,
+            )
+        else:
+            l4 = LayerCoverage(
+                layer=EvidenceLayer.L4_SOURCE_ABI.value, status=CoverageStatus.PARTIAL,
+                confidence=EvidenceConfidence.REDUCED, detail=source_detail,
+            )
+    else:
+        l4 = LayerCoverage(layer=EvidenceLayer.L4_SOURCE_ABI.value, status=CoverageStatus.NOT_COLLECTED)
     return [
         l3,
-        LayerCoverage(layer=EvidenceLayer.L4_SOURCE_ABI.value, status=CoverageStatus.NOT_COLLECTED),
+        l4,
         LayerCoverage(layer=EvidenceLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.NOT_COLLECTED),
     ]
+
+
+def _exported_symbols_from_binary(binary: Path | None) -> list[str]:
+    """Best-effort exported (mangled) symbol names from ``binary`` for D5 linking.
+
+    Used so the source-decl → binary-symbol mapping (and
+    ``source_decl_binary_symbol_mismatch``) is populated. Failures are swallowed
+    (returns ``[]``): the other eight source findings do not need symbols, so a
+    binary that cannot be parsed must not block L4 collection.
+    """
+    if binary is None or not Path(binary).is_file():
+        return []
+    try:
+        from .service import detect_binary_format, run_dump
+
+        fmt = detect_binary_format(Path(binary))
+        if not fmt:
+            return []
+        snap = run_dump(Path(binary), fmt)
+    except Exception:  # noqa: BLE001 - best-effort; never fail collection on this
+        return []
+    syms = {fn.mangled for fn in snap.functions if fn.mangled}
+    syms |= {v.mangled for v in snap.variables if getattr(v, "mangled", "")}
+    return sorted(syms)
+
+
+def _collect_source_abi(
+    merged: BuildEvidence,
+    extractors: list[ExtractorRecord],
+    *,
+    extractor: str,
+    scope: str,
+    target_id: str,
+    changed_paths: list[str],
+    android_dump: Path | None,
+    cache_dir: Path | None,
+    clang_bin: str,
+    headers: tuple[Path, ...],
+    binary: Path | None,
+    verbose: bool,
+) -> tuple[SourceAbiSurface | None, str]:
+    """Run L4 source ABI replay and return ``(surface, human-readable detail)``.
+
+    Never raises on a missing tool: a clang-less environment yields a partial
+    surface and a clear note, keeping artifact tiers authoritative (ADR-028 D3).
+    """
+    from .evidence.source_abi import SourceAbiSurface
+    from .evidence.source_replay import (
+        SourceAbiCache,
+        public_header_roots_for,
+        run_source_replay,
+    )
+
+    exported = _exported_symbols_from_binary(binary)
+    library = str(binary) if binary else ""
+    # Header roots: explicit --headers win; else pull from the build targets.
+    roots = [str(h) for h in headers] or public_header_roots_for(merged, target_id)
+
+    if extractor == "android":
+        return _collect_source_abi_android(
+            android_dump, extractors, target_id=target_id,
+            exported=exported, library=library, roots=roots,
+        )
+
+    impl: ClangSourceExtractor | CastxmlSourceExtractor
+    if extractor == "clang":
+        from .evidence.source_extractors import ClangSourceExtractor
+        impl = ClangSourceExtractor(clang_bin=clang_bin)
+        tool_name = clang_bin
+    else:
+        from .evidence.source_extractors import CastxmlSourceExtractor
+        impl = CastxmlSourceExtractor()
+        tool_name = "castxml"
+
+    if not merged.compile_units:
+        extractors.append(ExtractorRecord(
+            name=f"source_abi:{extractor}", status="partial",
+            detail="no compile units in build evidence; collect L3 first (e.g. --compile-db)",
+        ))
+        return (
+            SourceAbiSurface(library=library, target_id=target_id),
+            "skipped: no L3 build context (need compile units to replay)",
+        )
+    if not impl.available():
+        extractors.append(ExtractorRecord(
+            name=f"source_abi:{extractor}", status="failed",
+            detail=f"{tool_name} not found in PATH; source-only checks disabled",
+        ))
+        return (
+            SourceAbiSurface(library=library, target_id=target_id),
+            f"unavailable: {tool_name} not on PATH — source-only checks disabled "
+            "(macros, default args, inline/template/constexpr bodies). Install "
+            f"{tool_name} or omit --source-abi.",
+        )
+
+    cache = SourceAbiCache(cache_dir) if cache_dir else None
+    surface, diagnostics = run_source_replay(
+        merged, impl, scope=scope, changed_paths=changed_paths,
+        target_id=target_id, library=library, exported_symbols=exported,
+        public_header_roots=roots, cache=cache,
+    )
+    for diag in diagnostics:
+        merged.diagnostics.append(f"source_abi: {diag}")
+    parsed = int(surface.coverage.get("compile_units_parsed", 0) or 0)
+    selected = int(surface.coverage.get("compile_units_selected", 0) or 0)
+    extractors.append(ExtractorRecord(
+        name=f"source_abi:{extractor}",
+        status="ok" if parsed else "partial",
+        detail=f"scope={scope}, {parsed}/{selected} TUs parsed, {len(diagnostics)} failures",
+    ))
+    return surface, (
+        f"{extractor} extractor, scope={scope}: parsed {parsed}/{selected} TUs, "
+        f"{len(surface.reachable_declarations)} decls, {len(surface.reachable_types)} types, "
+        f"{len(surface.reachable_inline_bodies)} inline bodies, "
+        f"{len(surface.reachable_templates)} templates"
+        + (f", {len(diagnostics)} TU(s) failed (partial coverage)" if diagnostics else "")
+    )
+
+
+def _collect_source_abi_android(
+    android_dump: Path | None,
+    extractors: list[ExtractorRecord],
+    *,
+    target_id: str,
+    exported: list[str],
+    library: str,
+    roots: list[str],
+) -> tuple[SourceAbiSurface | None, str]:
+    """Normalize a pre-captured Android header-abi dump into a linked surface (D9)."""
+    from .evidence.source_abi import SourceAbiSurface
+    from .evidence.source_extractors import (
+        AndroidHeaderAbiAdapter,
+        SourceExtractionError,
+    )
+    from .evidence.source_link import link_source_abi
+
+    if android_dump is None:
+        raise click.UsageError(
+            "--source-abi-extractor android requires --android-dump <file.lsdump|.sdump>."
+        )
+    adapter = AndroidHeaderAbiAdapter()
+    try:
+        tu = adapter.load(android_dump, target_id=target_id, public_header_roots=roots)
+    except SourceExtractionError as exc:
+        extractors.append(ExtractorRecord(
+            name="source_abi:android", status="failed",
+            inputs=[DEFAULT_REDACTION.path(str(android_dump))], detail=str(exc),
+        ))
+        return SourceAbiSurface(library=library, target_id=target_id), f"failed: {exc}"
+    surface = link_source_abi(
+        [tu], exported_symbols=exported, library=library, target_id=target_id,
+    )
+    extractors.append(ExtractorRecord(
+        name="source_abi:android", status="ok",
+        inputs=[DEFAULT_REDACTION.path(str(android_dump))],
+        detail=f"{len(surface.reachable_declarations)} decls, {len(surface.reachable_types)} types",
+    ))
+    return surface, (
+        f"android dump: {len(surface.reachable_declarations)} decls, "
+        f"{len(surface.reachable_types)} types"
+    )
 
 
 # ── Attach / compare integration (ADR-028 D6, D7; ADR-029 D9) ─────────────────
@@ -361,6 +608,15 @@ def collect_compare_evidence(
             _detect_coverage_asymmetry(old_snapshot, old_pack, new_snapshot, new_pack)
         )
 
+    # L4 source ABI replay diff (ADR-030 D6): both packs must carry a source
+    # surface. Per ADR-028 D3 these are ordinary API_BREAK/RISK findings folded
+    # into the verdict pipeline — never sole authority for a BREAKING verdict.
+    old_surface = old_pack.source_abi if old_pack else None
+    new_surface = new_pack.source_abi if new_pack else None
+    if old_surface is not None and new_surface is not None:
+        from .evidence.source_diff import diff_source_abi
+        changes.extend(diff_source_abi(old_surface, new_surface))
+
     src_pack = new_pack or old_pack
     coverage = list(src_pack.manifest.coverage) if src_pack else []
     if not coverage:
@@ -370,6 +626,7 @@ def collect_compare_evidence(
         ]
     intrinsic = _intrinsic_coverage(new_snapshot)
     _echo_coverage(intrinsic, coverage)
+    _echo_capabilities(intrinsic, coverage)
     coverage_rows: list[dict[str, object]] = [c.to_dict() for c in (*intrinsic, *coverage)]
     return changes, coverage_rows
 
@@ -490,3 +747,52 @@ def _detect_coverage_asymmetry(
             new_value="not collected on target",
         )
     ]
+
+
+#: One row per check category: (label, evidence layer that enables it, the
+#: question it answers, and why it is off when that layer is absent). This is the
+#: "what is and is not being checked, and why" report (ADR-028 D7): the tiers run
+#: from a bare binary up through debug symbols, headers, build data, and sources.
+_CHECK_CAPABILITIES: tuple[tuple[str, str, str, str], ...] = (
+    ("Symbol presence & linkage (added/removed/SONAME)", "L0",
+     "from the binary's dynamic symbol table",
+     "needs the built binary"),
+    ("Type layout, members, vtables, signatures", "L1",
+     "from DWARF/PDB debug info",
+     "no debug info: checks limited to symbol-level, not struct/member/layout"),
+    ("API decls absent from the symbol table; public-surface scoping", "L2",
+     "from the public header AST",
+     "no headers: header-only/inline-API declarations are invisible"),
+    ("Build-flag & toolchain drift (visibility, std, ABI flags)", "L3_build",
+     "from build-system data (compile DB / CMake / Ninja / Bazel)",
+     "no build data: flag/toolchain regressions are not detected"),
+    ("Macros, default args, inline/template/constexpr bodies", "L4_source_abi",
+     "from source ABI replay (requires clang)",
+     "no sources/clang: source-only API changes are not detected"),
+    ("Impact / call / reachability graph", "L5_source_graph",
+     "from the source graph summary",
+     "no graph evidence: cross-symbol impact is not analyzed"),
+)
+
+
+def _echo_capabilities(
+    intrinsic: list[LayerCoverage], optional: list[LayerCoverage]
+) -> None:
+    """Print exactly which check categories are enabled — and why others are not.
+
+    Driven by the evidence coverage (ADR-028 D7): each check category is gated on
+    one evidence layer, so the user sees, for the inputs they actually provided
+    (binary only → +debug → +headers → +build data → +sources), which checks ran
+    and the concrete reason each disabled one is off.
+    """
+    present = {
+        c.layer
+        for c in (*intrinsic, *optional)
+        if c.status != CoverageStatus.NOT_COLLECTED
+    }
+    click.echo("Checks enabled for this scan (and why others are not):", err=True)
+    for label, layer, how, why_off in _CHECK_CAPABILITIES:
+        if layer in present:
+            click.echo(f"  [on]  {label} — {how}", err=True)
+        else:
+            click.echo(f"  [off] {label} — {why_off}", err=True)

--- a/abicheck/evidence/CLAUDE.md
+++ b/abicheck/evidence/CLAUDE.md
@@ -25,7 +25,8 @@ L3/L4/L5 are ordinary `ChangeKind` entries that default to `API_BREAK_KINDS`
 | `source_abi.py` | `SourceAbiTu` (per-TU dump) + `SourceAbiSurface` (linked `source_abi.json`) schemas, `SourceEntity`/`SourceLocation`, `L4_SOURCE_ABI` boundary | 030 D4/D5/D10 |
 | `source_link.py` | `link_source_abi()` — fold per-TU dumps into a per-library surface; map decls→exported symbols; ODR detection | 030 D5 |
 | `source_diff.py` | `diff_source_abi()` → the 9 source-replay findings (macros/default-args/inline/template/constexpr/…); never BREAKING | 030 D6 |
-| `source_extractors/` | `SourceAbiExtractor` interface + `CastxmlSourceExtractor` (parse a TU under its `CompileUnit` context → `SourceAbiTu`) | 030 D3 (phase 2) |
+| `source_extractors/` | `SourceAbiExtractor` interface + castxml (phase 2), clang (phase 5, body fingerprints), Android adapter (phase 6) | 030 D3 |
+| `source_replay.py` | `select_compile_units()` (D7 scopes), `SourceAbiCache` (D8 per-TU cache), `run_source_replay()` driver, `scope_for_ci_mode()` | 030 D7/D8 (phase 7) |
 | `redaction.py` | `RedactionPolicy` — strip secrets/abs paths from command lines | 032 D7 |
 | `adapters/compile_db.py` | `compile_commands.json` → `CompileUnit`s (reuses `build_context.py`) | 029 D3 |
 | `adapters/cmake_file_api.py` | CMake File API reply → targets/toolchains/fileSets | 029 D4 |

--- a/abicheck/evidence/__init__.py
+++ b/abicheck/evidence/__init__.py
@@ -61,18 +61,30 @@ from .source_abi import (
 )
 from .source_diff import diff_source_abi
 from .source_extractors import (
+    AndroidHeaderAbiAdapter,
     CastxmlSourceExtractor,
+    ClangSourceExtractor,
     SourceAbiExtractor,
     SourceExtractionError,
 )
 from .source_link import link_source_abi
+from .source_replay import (
+    REPLAY_SCOPES,
+    SourceAbiCache,
+    run_source_replay,
+    scope_for_ci_mode,
+    select_compile_units,
+)
 
 __all__ = [
     "EVIDENCE_PACK_VERSION",
+    "REPLAY_SCOPES",
     "SOURCE_ABI_VERSION",
+    "AndroidHeaderAbiAdapter",
     "BuildEvidence",
     "BuildOption",
     "CastxmlSourceExtractor",
+    "ClangSourceExtractor",
     "CompileUnit",
     "EvidenceConfidence",
     "EvidenceEntity",
@@ -84,6 +96,7 @@ __all__ = [
     "Generator",
     "LayerCoverage",
     "LinkUnit",
+    "SourceAbiCache",
     "SourceAbiExtractor",
     "SourceAbiSurface",
     "SourceAbiTu",
@@ -94,4 +107,7 @@ __all__ = [
     "Toolchain",
     "diff_source_abi",
     "link_source_abi",
+    "run_source_replay",
+    "scope_for_ci_mode",
+    "select_compile_units",
 ]

--- a/abicheck/evidence/source_abi.py
+++ b/abicheck/evidence/source_abi.py
@@ -225,6 +225,11 @@ class SourceAbiTu:
     constexpr_values: list[SourceEntity] = field(default_factory=list)
     source_edges: list[dict[str, Any]] = field(default_factory=list)
     diagnostics: list[str] = field(default_factory=list)
+    #: Every file the extractor actually read for this TU — the source plus all
+    #: transitively included headers (public, private, generated, forced). The
+    #: per-TU cache (ADR-030 D8) hashes these so an edit to *any* included header
+    #: invalidates a stale dump, not just an edit to the configured public roots.
+    read_files: list[str] = field(default_factory=list)
 
     def all_entities(self) -> list[SourceEntity]:
         """Flatten every entity list, preserving the per-kind grouping order."""
@@ -261,6 +266,7 @@ class SourceAbiTu:
             "constexpr_values": [e.to_dict() for e in self.constexpr_values],
             "source_edges": list(self.source_edges),
             "diagnostics": list(self.diagnostics),
+            "read_files": list(self.read_files),
         }
 
     @classmethod
@@ -286,6 +292,7 @@ class SourceAbiTu:
             constexpr_values=_ents("constexpr_values"),
             source_edges=list(d.get("source_edges", [])),
             diagnostics=list(d.get("diagnostics", [])),
+            read_files=list(d.get("read_files", [])),
         )
 
 

--- a/abicheck/evidence/source_abi.py
+++ b/abicheck/evidence/source_abi.py
@@ -274,6 +274,15 @@ class SourceAbiTu:
         def _ents(key: str) -> list[SourceEntity]:
             return [SourceEntity.from_dict(e) for e in d.get(key, [])]
 
+        # Defensive: a newer/hand-edited pack may carry ``read_files: null`` or a
+        # stray string; ``list(...)`` on those raises or yields a char list, which
+        # would poison cache dependency tracking (CodeRabbit review). Coerce to a
+        # clean list of non-empty strings.
+        rf_raw = d.get("read_files")
+        read_files = (
+            [str(p) for p in rf_raw if p] if isinstance(rf_raw, list) else []
+        )
+
         return cls(
             schema_version=int(d.get("schema_version", SOURCE_ABI_VERSION)),
             tu_id=str(d.get("tu_id", "")),
@@ -292,7 +301,7 @@ class SourceAbiTu:
             constexpr_values=_ents("constexpr_values"),
             source_edges=list(d.get("source_edges", [])),
             diagnostics=list(d.get("diagnostics", [])),
-            read_files=list(d.get("read_files", [])),
+            read_files=read_files,
         )
 
 

--- a/abicheck/evidence/source_diff.py
+++ b/abicheck/evidence/source_diff.py
@@ -79,8 +79,36 @@ def _by_identity(entities: list[SourceEntity]) -> dict[str, SourceEntity]:
     (or the bare qualified name when there is no signature), so each overload —
     including unmangled ones like castxml's constructors — is matched to its own
     counterpart.
+
+    When two entities share one identity — clang emits both the in-class
+    *declaration* (which carries the default argument) and the out-of-line inline
+    *definition* (no default) of the same constructor/method — prefer the one
+    that carries the richer value/body/type information, so a default-argument
+    change on an inline-defined member is not masked by the value-less definition
+    overwriting it (Codex review #339, P2).
     """
-    return {e.identity(): e for e in entities if e.identity()}
+    out: dict[str, SourceEntity] = {}
+    for e in entities:
+        key = e.identity()
+        if not key:
+            continue
+        prev = out.get(key)
+        if prev is None or _richer(e, prev):
+            out[key] = e
+    return out
+
+
+def _richer(candidate: SourceEntity, current: SourceEntity) -> bool:
+    """Whether ``candidate`` carries more comparable detail than ``current``.
+
+    Breaks identity collisions toward the entity that actually bears the
+    value/body/type fingerprint the diff compares, rather than keeping the last
+    one seen.
+    """
+    def _score(e: SourceEntity) -> int:
+        return sum(bool(v) for v in (e.value, e.body_hash, e.type_hash))
+
+    return _score(candidate) > _score(current)
 
 
 def diff_source_abi(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:

--- a/abicheck/evidence/source_extractors/CLAUDE.md
+++ b/abicheck/evidence/source_extractors/CLAUDE.md
@@ -11,7 +11,10 @@ and the diff (`../source_diff.py`) compares two surfaces.
 | Module | Role | ADR |
 |--------|------|-----|
 | `base.py` | `SourceAbiExtractor` protocol (ADR-032 interface), `SourceExtractionError`, and the **pure** model→`SourceEntity` mapping + `assemble_source_tu()` | 030 D3/D4 |
+| `_argv.py` | **Shared** compile-context → argv helpers (launcher unwrap, MSVC detection, `~` un-redaction, forced-include/abi-flag carry-through), reused by castxml + clang | 030 D2 |
 | `castxml.py` | `CastxmlSourceExtractor` + pure `build_castxml_command()`; reuses `dumper_castxml._CastxmlParser` | 030 D3 (phase 2) |
+| `clang.py` | `ClangSourceExtractor` + pure `build_clang_command()` / `source_abi_from_clang_ast()`; `clang -ast-dump=json` → inline/template/constexpr **body** fingerprints + default args | 030 D3 (phase 5) |
+| `android.py` | `AndroidHeaderAbiAdapter` + pure `parse_android_dump()`; normalize a pre-captured `.sdump`/`.lsdump` into a `SourceAbiTu` | 030 D9 (phase 6) |
 
 ## The one rule
 
@@ -25,10 +28,15 @@ recorded as **partial** L4 coverage — they never abort the artifact comparison
 - **Keep the tool call thin.** The context→argv builder and the model→entity
   mapping are pure and unit-testable *without* the external tool; only the
   `extract()` orchestration shells out. Tests for the pure halves are default
-  (fast) lane; tests that actually run castxml are `@pytest.mark.integration`.
-- castxml is good for declarations / types / public const-constexpr values but
-  weak for function bodies and macros (ADR-030 D3 table). Inline/template *body*
-  fingerprints are the Clang backend's job (phase 5), not castxml's.
-- The heavy `dumper_castxml` import is done lazily inside `extract()` so the
-  lightweight evidence layer does not pull in the dumper model graph at import
-  time (and to keep the import-cycle gate green).
+  (fast) lane; tests that actually run castxml/clang are `@pytest.mark.integration`.
+- **castxml** is good for declarations / types / public const-constexpr values
+  but weak for function bodies and macros (ADR-030 D3 table). **clang** is the
+  *source-based* backend that adds inline/template/constexpr *body* fingerprints
+  and default arguments — it **requires clang on PATH** and degrades to partial
+  coverage when it is absent (the source tier is the one tier gated on a C++
+  front-end). For a GCC project, clang replays the GCC build's flags; a TU using
+  a GCC-only extension clang rejects degrades to partial coverage, never a hard
+  failure.
+- The heavy `dumper_castxml` import is done lazily inside castxml's `extract()`;
+  clang's `_CastxmlParser`-free path imports `provenance` lazily for the same
+  reason (keep the lightweight evidence layer's import graph thin / cycle-free).

--- a/abicheck/evidence/source_extractors/__init__.py
+++ b/abicheck/evidence/source_extractors/__init__.py
@@ -51,6 +51,8 @@ from .clang import (
     CLANG_EXTRACTOR_VERSION,
     ClangSourceExtractor,
     build_clang_command,
+    build_clang_macro_command,
+    macros_from_preprocessor,
     source_abi_from_clang_ast,
 )
 
@@ -66,6 +68,8 @@ __all__ = [
     "assemble_source_tu",
     "build_castxml_command",
     "build_clang_command",
+    "build_clang_macro_command",
+    "macros_from_preprocessor",
     "parse_android_dump",
     "source_abi_from_clang_ast",
 ]

--- a/abicheck/evidence/source_extractors/__init__.py
+++ b/abicheck/evidence/source_extractors/__init__.py
@@ -15,13 +15,28 @@
 """Source ABI extractors (ADR-030 D3) — backends that fill a ``SourceAbiTu``.
 
 One normalized contract (:class:`SourceAbiExtractor`, ADR-032) with several
-backends: castxml replay now (:class:`CastxmlSourceExtractor`), Clang LibTooling
-and Android adapters later. The shared, tool-independent model→entity mapping
-lives in ``base``.
+backends behind it:
+
+- :class:`CastxmlSourceExtractor` (phase 2) — declarations / types / public
+  const-constexpr values; reuses the existing castxml parser.
+- :class:`ClangSourceExtractor` (phase 5) — the *source-based* backend that adds
+  inline/template/constexpr **body** fingerprints and default arguments via
+  ``clang -ast-dump=json``. Requires clang; degrades to partial coverage if it
+  is absent.
+- :class:`AndroidHeaderAbiAdapter` (phase 6) — reuse Android header-checker
+  ``.sdump``/``.lsdump`` dumps, normalized into the abicheck schema (ADR-030 D9).
+
+The shared, tool-independent model→entity mapping lives in ``base``; the shared
+compile-context → argv helpers live in ``_argv``.
 """
 
 from __future__ import annotations
 
+from .android import (
+    ANDROID_EXTRACTOR_VERSION,
+    AndroidHeaderAbiAdapter,
+    parse_android_dump,
+)
 from .base import (
     SourceAbiExtractor,
     SourceExtractionError,
@@ -32,12 +47,25 @@ from .castxml import (
     CastxmlSourceExtractor,
     build_castxml_command,
 )
+from .clang import (
+    CLANG_EXTRACTOR_VERSION,
+    ClangSourceExtractor,
+    build_clang_command,
+    source_abi_from_clang_ast,
+)
 
 __all__ = [
+    "ANDROID_EXTRACTOR_VERSION",
     "CASTXML_EXTRACTOR_VERSION",
+    "CLANG_EXTRACTOR_VERSION",
+    "AndroidHeaderAbiAdapter",
     "CastxmlSourceExtractor",
+    "ClangSourceExtractor",
     "SourceAbiExtractor",
     "SourceExtractionError",
     "assemble_source_tu",
     "build_castxml_command",
+    "build_clang_command",
+    "parse_android_dump",
+    "source_abi_from_clang_ast",
 ]

--- a/abicheck/evidence/source_extractors/_argv.py
+++ b/abicheck/evidence/source_extractors/_argv.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Sequence
 
 from ..build_evidence import CompileUnit
 
@@ -94,6 +95,32 @@ def unredact_home(value: str) -> str:
     if not home or home == "~":
         return value
     return re.sub(r"~(?=[\\/]|$)", lambda _m: home, value)
+
+
+def split_public_roots(roots: Sequence[str]) -> tuple[list[str], list[str]]:
+    """Partition public-header roots into ``(file_roots, dir_roots)``.
+
+    The CLI accepts a public header *file or directory* (``--headers include/``).
+    ``provenance.build_public_set`` needs files and directories in separate
+    arguments — a directory passed as a "header" file never suffix-matches a decl
+    under it (``include`` vs ``include/api.h``), so the whole public include tree
+    would be classified non-public and dropped (Codex review #339, P2). A root is
+    a directory when it ends in a path separator or resolves to a directory on
+    disk (un-redacting a ``~`` home placeholder first, ADR-032 D7). The original
+    (unexpanded) root string is kept for segment matching, which compares against
+    the paths the compiler actually reports.
+    """
+    files: list[str] = []
+    dirs: list[str] = []
+    for root in roots:
+        if not root:
+            continue
+        expanded = os.path.expanduser(unredact_home(root))
+        if root.endswith(("/", "\\")) or os.path.isdir(expanded):
+            dirs.append(root)
+        else:
+            files.append(root)
+    return files, dirs
 
 
 def resolve_read_files(files: set[str], directory: str) -> list[str]:

--- a/abicheck/evidence/source_extractors/_argv.py
+++ b/abicheck/evidence/source_extractors/_argv.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared compile-context → argv helpers for source ABI extractors (ADR-030 D2).
+
+Every extractor backend must replay a translation unit under the *same* compile
+context the real build used — same compiler emulation, language standard,
+defines, include paths, forced includes, sysroot/target, and ABI-relevant flags
+(ADR-030 D2). castxml (phase 2) and clang (phase 5) need identical logic for the
+fiddly parts — unwrapping ``ccache``/``sccache`` launchers, detecting MSVC mode
+from a (possibly Windows, possibly cross) compiler path, carrying argv-only
+forced includes, and reversing the redaction policy's ``~`` home placeholder for
+the replay only (ADR-032 D7). Keeping that here means one tested implementation,
+not one per backend.
+
+Pure and tool-independent: nothing here shells out.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from ..build_evidence import CompileUnit
+
+#: Languages that make the GNU fallback compiler ``g++`` rather than ``gcc``.
+CXX_LANGS = frozenset({"cxx", "c++", "cpp"})
+#: Compiler basenames that mean the extractor should run in MSVC mode.
+MSVC_BINARIES = frozenset({"cl", "cl.exe", "clang-cl", "clang-cl.exe"})
+#: Compiler-launcher wrappers that prefix the real compiler in a build action
+#: (``ccache clang++ -c foo.cpp``). The extractor must emulate the real compiler,
+#: not the launcher, which would otherwise run without its compiler operand.
+COMPILER_LAUNCHERS = frozenset(
+    {"ccache", "sccache", "distcc", "icecc", "icerun", "buildcache"}
+)
+#: Preprocessor macro define/undef option prefixes. Their *values* reach the
+#: compiler verbatim (argv, no shell expansion), so a literal ``~`` in e.g.
+#: ``-DDEFAULT_DIR=~/app`` must NOT be home-expanded during replay — unlike the
+#: path operands (includes/sysroot/source), which carry redacted home prefixes.
+MACRO_DEFINITION_PREFIXES = ("-D", "-U", "/D", "/U")
+#: Value-taking toolchain flags already normalized into the structured
+#: ``sysroot``/``target_triple`` fields. They must NOT be carried through from
+#: ``abi_relevant_flags``: the adapter records only the bare option token for the
+#: split spelling (``-isysroot /sdk`` → just ``-isysroot``, operand dropped), so
+#: re-appending it dangles and swallows the following argv token.
+STRUCTURED_TOOLCHAIN_FLAG_PREFIXES = ("--sysroot", "-isysroot", "--target", "-target")
+#: GNU forced-include options. Only ``-include``/``-imacros`` also have a joined
+#: ``-include<file>`` spelling; ``-include-pch`` is separate-operand only (clang
+#: ``-include-pch <file>``) and must not be read as a joined ``-include``.
+_GNU_FORCED_INCLUDE_OPTS = frozenset({"-include", "-imacros"})
+_GNU_SEPARATE_INCLUDE_OPTS = frozenset({"-include", "-imacros", "-include-pch"})
+#: MSVC/clang-cl forced-include options in their separate-operand spelling
+#: (``/FI file`` or ``-FI file``); the joined ``/FIfile`` form is handled by
+#: prefix.
+_MSVC_FORCED_INCLUDE_OPTS = frozenset({"/FI", "-FI"})
+#: GNU include-search options that take a directory operand and are NOT
+#: normalized into the structured ``include_paths``/``system_include_paths``
+#: buckets (those cover ``-I``/``-isystem`` only). Dropping them makes the
+#: extractor search a different set of directories than the real compile (Codex
+#: review #335). Both the separate (``-iquote dir``) and joined (``-iquote/dir``)
+#: spellings are carried through.
+#: (https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html)
+_GNU_INCLUDE_SEARCH_OPTS = frozenset({"-iquote", "-idirafter"})
+
+
+def unredact_home(value: str) -> str:
+    """Expand a redacted home placeholder (``~``) back to the real home dir.
+
+    The evidence redaction policy (ADR-032 D7) rewrites the user's home prefix
+    to ``~`` wherever it appears before persisting paths/argv. ``subprocess``
+    does not expand ``~`` (no shell), so replaying a redacted ``CompileUnit``
+    would treat ``~/...`` / ``-I~/...`` as literal paths and fail. Reverse the
+    substitution for the replay only (persisted values stay redacted).
+
+    Only a ``~`` that stands in for a home *directory* is expanded: the
+    placeholder is always either the whole token or immediately followed by a
+    path separator. A ``~`` followed by anything else is untouched, so Windows
+    8.3 short names such as ``RUNNER~1`` are never mangled.
+    """
+    if "~" not in value:
+        return value
+    home = os.path.expanduser("~")
+    if not home or home == "~":
+        return value
+    return re.sub(r"~(?=[\\/]|$)", lambda _m: home, value)
+
+
+def basename(path: str) -> str:
+    """Final path component, splitting on both ``/`` and ``\\`` (host-independent).
+
+    ``Path(path).name`` on POSIX does not treat ``\\`` as a separator, so a
+    Windows compiler path from a cross/off-Windows compile database
+    (``C:\\VS\\bin\\cl.exe``) would otherwise return the whole string and miss
+    MSVC-mode detection.
+    """
+    return re.split(r"[\\/]", path)[-1]
+
+
+def strip_launchers(argv: list[str]) -> list[str]:
+    """Drop leading compiler-launcher tokens (``ccache``/``sccache``/…)."""
+    i = 0
+    while i < len(argv) and basename(argv[i]).lower().removesuffix(
+        ".exe"
+    ) in COMPILER_LAUNCHERS:
+        i += 1
+    return argv[i:]
+
+
+def pick_compiler_binary(compile_unit: CompileUnit, override: str | None) -> str:
+    """Pick the compiler binary an extractor should emulate for this TU.
+
+    Prefers the compiler actually recorded in the build action (``argv[0]``,
+    after unwrapping any launcher) so a clang/clang-cl/cross TU is replayed
+    against its real builtin include paths, target defaults, and accepted flags.
+    Falls back to g++/gcc by language when no command is available; an explicit
+    ``override`` always wins.
+    """
+    if override:
+        return override
+    argv = strip_launchers(compile_unit.argv)
+    if argv and argv[0] and not argv[0].startswith("-"):
+        return argv[0]
+    return "g++" if compile_unit.language.lower() in CXX_LANGS else "gcc"
+
+
+def is_msvc_mode(cc_bin: str) -> bool:
+    """Whether the compiler basename means MSVC (``cl``/``clang-cl``) mode."""
+    return basename(cc_bin).lower() in MSVC_BINARIES
+
+
+def replay_extra_flags(
+    compile_unit: CompileUnit, already: list[str], cc_id: str
+) -> list[str]:
+    """Carry through ABI/parse-relevant options not in the structured fields.
+
+    ``abi_relevant_flags`` (e.g. ``-fms-extensions``, ``-fabi-version``,
+    ``-fvisibility``, ``-m32``), forced-include options, and unnormalized
+    include-search options (GNU ``-iquote``/``-idirafter``, MSVC ``/I``) from
+    ``argv`` change the parsed translation unit / header search; dropping them
+    makes the extractor parse a different TU than the real build (ADR-030 D2).
+    De-duplicated against the flags already emitted from the structured fields.
+    MSVC ``/FI`` forced includes and ``/I`` search dirs are carried only in MSVC
+    mode so a GNU ``-F``/``-I``-family flag is never mistaken for one.
+    """
+    seen = set(already)
+    out: list[str] = []
+    for flag in compile_unit.abi_relevant_flags:
+        if flag.startswith(STRUCTURED_TOOLCHAIN_FLAG_PREFIXES):
+            continue
+        if flag not in seen:
+            out.append(flag)
+            seen.add(flag)
+    argv = compile_unit.argv
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in _GNU_SEPARATE_INCLUDE_OPTS and i + 1 < len(argv):
+            out += [tok, argv[i + 1]]  # -include / -imacros / -include-pch <file>
+            i += 2
+        elif tok in _GNU_INCLUDE_SEARCH_OPTS and i + 1 < len(argv):
+            out += [tok, argv[i + 1]]  # -iquote / -idirafter <dir> (separate)
+            i += 2
+        elif tok not in _GNU_INCLUDE_SEARCH_OPTS and any(
+            tok.startswith(opt) and len(tok) > len(opt)
+            for opt in _GNU_INCLUDE_SEARCH_OPTS
+        ):
+            out.append(tok)  # -iquote/dir / -idirafter/dir (joined)
+            i += 1
+        elif cc_id == "msvc" and tok == "/I" and i + 1 < len(argv):
+            out += [tok, argv[i + 1]]  # MSVC /I dir (separate operand)
+            i += 2
+        elif cc_id == "msvc" and len(tok) > 2 and tok.startswith("/I"):
+            out.append(tok)  # MSVC /Idir (joined)
+            i += 1
+        elif tok not in _GNU_SEPARATE_INCLUDE_OPTS and any(
+            tok.startswith(opt) and len(tok) > len(opt)
+            for opt in _GNU_FORCED_INCLUDE_OPTS
+        ):
+            out.append(tok)  # -includefile / -imacrosfile (joined)
+            i += 1
+        elif cc_id == "msvc" and tok in _MSVC_FORCED_INCLUDE_OPTS and i + 1 < len(argv):
+            out += [tok, argv[i + 1]]  # /FI file (separate operand)
+            i += 2
+        elif (
+            cc_id == "msvc"
+            and len(tok) > 3
+            and (tok.startswith("/FI") or tok.startswith("-FI"))
+        ):
+            out.append(tok)  # /FIfile (joined)
+            i += 1
+        else:
+            i += 1
+    return out

--- a/abicheck/evidence/source_extractors/_argv.py
+++ b/abicheck/evidence/source_extractors/_argv.py
@@ -96,6 +96,27 @@ def unredact_home(value: str) -> str:
     return re.sub(r"~(?=[\\/]|$)", lambda _m: home, value)
 
 
+def resolve_read_files(files: set[str], directory: str) -> list[str]:
+    """Absolute, de-duplicated read-file paths resolved against ``directory``.
+
+    An extractor records the files it read (``SourceAbiTu.read_files``) for the
+    per-TU cache dependency set (ADR-030 D8). A compiler emits *relative* paths
+    for headers found via a relative ``-I``, which the cache — running in a
+    possibly different CWD — could not otherwise read, silently dropping the
+    dependency. Resolve each against the TU's build directory (un-redacting a
+    ``~`` home placeholder first, ADR-032 D7) so the path matches the CWD the
+    tool actually ran in.
+    """
+    base = unredact_home(directory) if directory else ""
+    out: set[str] = set()
+    for f in files:
+        path = os.path.expanduser(unredact_home(f))
+        if not os.path.isabs(path) and base:
+            path = os.path.join(base, path)
+        out.add(os.path.normpath(path))
+    return sorted(out)
+
+
 def basename(path: str) -> str:
     """Final path component, splitting on both ``/`` and ``\\`` (host-independent).
 

--- a/abicheck/evidence/source_extractors/android.py
+++ b/abicheck/evidence/source_extractors/android.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Android header-checker adapter (ADR-030 D6 table, D9; phase 6).
+
+A reference adapter that reuses Android's VNDK header-checker output
+(``header-abi-dumper`` ``.sdump`` / ``header-abi-linker`` ``.lsdump``) as an L4
+source ABI backend. Per ADR-030 D9 the Android intermediate formats are
+documented implementation details, so they are **never** the stable contract:
+this adapter normalizes them into abicheck's own :class:`SourceAbiTu`, and the
+raw dump is preserved only as provenance (``raw/android-header-abi/``).
+
+Default behaviour is **non-executing** (ADR-028 D6): the adapter consumes a
+*pre-captured* dump file produced by an existing Android build. Actually running
+``header-abi-dumper`` is opt-in (:meth:`AndroidHeaderAbiAdapter.run_dumper`),
+since it compiles a header.
+
+The dump JSON shape follows AOSP ``vndk/tools/header-checker`` (records / enums /
+functions / global vars keyed by ``linker_set_key`` mangled names). Parsing is
+defensive ``.get()`` access so a newer/hand-edited dump never aborts a load.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from ..model import EvidenceConfidence
+from ..source_abi import SourceAbiTu, SourceEntity, SourceLocation
+from .base import SourceExtractionError
+
+#: Adapter schema/behaviour version, recorded in the dump provenance.
+ANDROID_EXTRACTOR_VERSION = "0.1"
+
+
+def _hash(*parts: str) -> str:
+    blob = "\x00".join(parts).encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def _str(value: Any) -> str:
+    return value if isinstance(value, str) else ("" if value is None else str(value))
+
+
+def _location(path: str) -> SourceLocation:
+    # header-abi dumps the public ABI surface (filtered by export/version script),
+    # so every entity is treated as public-header origin.
+    return SourceLocation(path=path, origin="PUBLIC_HEADER")
+
+
+def _record_entity(rec: dict[str, Any]) -> SourceEntity:
+    name = _str(rec.get("name") or rec.get("linker_set_key"))
+    fields = rec.get("fields") or []
+    field_repr = ";".join(
+        f"{_str(f.get('field_name'))}:{_str(f.get('referenced_type'))}"
+        f"@{f.get('field_offset', 0)}"
+        for f in fields
+        if isinstance(f, dict)
+    )
+    type_repr = f"record|size={rec.get('size', 0)}|{field_repr}"
+    return SourceEntity(
+        id=_hash("record", name, type_repr),
+        kind="record",
+        qualified_name=name,
+        type_hash=_hash("type", type_repr),
+        source_location=_location(_str(rec.get("source_file"))),
+        visibility="public_header",
+        api_relevant=True,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def _enum_entity(en: dict[str, Any]) -> SourceEntity:
+    name = _str(en.get("name") or en.get("linker_set_key"))
+    members = en.get("enum_fields") or []
+    type_repr = f"{_str(en.get('underlying_type'))}|" + ",".join(
+        f"{_str(m.get('name'))}={m.get('enum_field_value', 0)}"
+        for m in members
+        if isinstance(m, dict)
+    )
+    return SourceEntity(
+        id=_hash("enum", name, type_repr),
+        kind="enum",
+        qualified_name=name,
+        type_hash=_hash("type", type_repr),
+        source_location=_location(_str(en.get("source_file"))),
+        visibility="public_header",
+        api_relevant=True,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def _function_entity(fn: dict[str, Any]) -> SourceEntity:
+    name = _str(fn.get("function_name") or fn.get("linker_set_key"))
+    mangled = _str(fn.get("linker_set_key"))
+    params = fn.get("parameters") or []
+    param_types = ",".join(
+        _str(p.get("referenced_type")) for p in params if isinstance(p, dict)
+    )
+    sig = f"{_str(fn.get('return_type'))}({param_types})"
+    return SourceEntity(
+        id=_hash("function", mangled or name, sig),
+        kind="function",
+        qualified_name=name,
+        mangled_name=mangled if mangled and mangled != name else "",
+        signature_hash=_hash("sig", sig),
+        source_location=_location(_str(fn.get("source_file"))),
+        visibility="public_header",
+        api_relevant=True,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def _global_var_entity(var: dict[str, Any]) -> SourceEntity:
+    name = _str(var.get("name") or var.get("linker_set_key"))
+    mangled = _str(var.get("linker_set_key"))
+    return SourceEntity(
+        id=_hash("variable", mangled or name, _str(var.get("referenced_type"))),
+        kind="variable",
+        qualified_name=name,
+        mangled_name=mangled if mangled and mangled != name else "",
+        type_hash=_hash("type", _str(var.get("referenced_type"))),
+        source_location=_location(_str(var.get("source_file"))),
+        visibility="public_header",
+        api_relevant=True,
+        confidence=EvidenceConfidence.HIGH,
+    )
+
+
+def parse_android_dump(
+    data: dict[str, Any],
+    *,
+    source: str = "",
+    target_id: str = "",
+    tu_id: str = "",
+    public_header_roots: list[str] | None = None,
+) -> SourceAbiTu:
+    """Normalize an Android ``.sdump``/``.lsdump`` JSON object into a SourceAbiTu (D9).
+
+    Pure: any producer of the dump dict (a pre-captured file, or a test fixture)
+    reuses this. Records/enums route to ``types``; functions to ``functions``;
+    global vars to ``variables``. Android does not emit inline/template bodies or
+    macros, so those buckets stay empty (the Clang backend, phase 5, owns them).
+    """
+    records = [r for r in (data.get("record_types") or []) if isinstance(r, dict)]
+    enums = [e for e in (data.get("enum_types") or []) if isinstance(e, dict)]
+    functions = [f for f in (data.get("functions") or []) if isinstance(f, dict)]
+    global_vars = [g for g in (data.get("global_vars") or []) if isinstance(g, dict)]
+    return SourceAbiTu(
+        tu_id=tu_id or (f"cu://{source}" if source else "android-header-abi"),
+        target_id=target_id,
+        extractor={"name": "android-header-abi", "version": ANDROID_EXTRACTOR_VERSION},
+        source=source,
+        public_header_roots=list(public_header_roots or []),
+        types=(
+            [_record_entity(r) for r in records] + [_enum_entity(e) for e in enums]
+        ),
+        functions=[_function_entity(f) for f in functions],
+        variables=[_global_var_entity(g) for g in global_vars],
+    )
+
+
+class AndroidHeaderAbiAdapter:
+    """Reuse Android header-checker dumps as an L4 source ABI backend (D9, phase 6).
+
+    Default mode consumes a *pre-captured* dump (non-executing, ADR-028 D6):
+
+        >>> adapter = AndroidHeaderAbiAdapter()
+        >>> tu = adapter.load(Path("libfoo.lsdump"))
+
+    Running ``header-abi-dumper`` to produce a fresh dump is opt-in via
+    :meth:`run_dumper`, since it compiles a header.
+    """
+
+    name = "android-header-abi"
+    version = ANDROID_EXTRACTOR_VERSION
+
+    def __init__(self, *, dumper_bin: str = "header-abi-dumper", timeout: int = 180) -> None:
+        self.dumper_bin = dumper_bin
+        self.timeout = timeout
+
+    def available(self) -> bool:
+        return shutil.which(self.dumper_bin) is not None
+
+    def load(
+        self,
+        dump_path: Path | str,
+        *,
+        target_id: str = "",
+        public_header_roots: list[str] | None = None,
+    ) -> SourceAbiTu:
+        """Load and normalize a pre-captured ``.sdump``/``.lsdump`` JSON dump."""
+        path = Path(dump_path)
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise SourceExtractionError(f"cannot read Android dump {path}: {exc}") from exc
+        except ValueError as exc:
+            raise SourceExtractionError(
+                f"Android dump {path} is not JSON (a raw protobuf .sdump must be "
+                f"produced with `-output-format Json`): {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise SourceExtractionError(
+                f"Android dump {path} must be a JSON object, got {type(data).__name__}"
+            )
+        return parse_android_dump(
+            data,
+            source=_str(data.get("source_file")) or path.stem,
+            target_id=target_id,
+            public_header_roots=public_header_roots,
+        )
+
+    def run_dumper(
+        self,
+        header: Path | str,
+        *,
+        output: Path | str,
+        clang_argv: list[str] | None = None,
+        target_id: str = "",
+        public_header_roots: list[str] | None = None,
+    ) -> SourceAbiTu:
+        """Opt-in: run ``header-abi-dumper`` on a header, then normalize (ADR-032 D5).
+
+        This compiles the header, so it is never invoked by default collection.
+        Requires the Android tool on ``PATH``.
+        """
+        if not self.available():
+            raise SourceExtractionError(
+                f"{self.dumper_bin} not found in PATH; pass a pre-captured dump to "
+                "load() instead, or install the Android header-checker tools."
+            )
+        out = Path(output)
+        cmd = [self.dumper_bin, str(header), "-o", str(out), "-output-format", "Json"]
+        if clang_argv:
+            cmd += ["--", *clang_argv]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=self.timeout, check=False
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SourceExtractionError(
+                f"header-abi-dumper timed out after {self.timeout}s on {header}"
+            ) from exc
+        if result.returncode != 0 or not out.is_file():
+            raise SourceExtractionError(
+                f"header-abi-dumper failed on {header} (exit {result.returncode}): "
+                f"{result.stderr[:1000]}"
+            )
+        return self.load(
+            out, target_id=target_id, public_header_roots=public_header_roots
+        )

--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -44,6 +44,7 @@ from ._argv import (
     pick_compiler_binary,
     replay_extra_flags,
     resolve_read_files,
+    split_public_roots,
     unredact_home,
 )
 from .base import SourceExtractionError, assemble_source_tu
@@ -218,12 +219,16 @@ class CastxmlSourceExtractor:
         from ...model import EnumType, Function, RecordType, ScopeOrigin, Variable
         from ...provenance import build_public_set, is_generated_header, tag_provenance
 
+        # A public root may be a directory (`--headers include/`); split it from
+        # file roots so a decl under the directory is classified public, not
+        # dropped (Codex review #339, P2).
+        file_roots, dir_roots = split_public_roots(public_header_roots)
         parser = _CastxmlParser(
             root,
             set(),
             set(),
-            public_header_paths=list(public_header_roots),
-            public_dir_paths=[],
+            public_header_paths=file_roots,
+            public_dir_paths=dir_roots,
         )
         functions = parser.parse_functions()
         records = parser.parse_types()
@@ -235,9 +240,7 @@ class CastxmlSourceExtractor:
         # classify here against the public-header set. Without this every public
         # declaration would map to api_relevant=False and the linker would drop
         # it, leaving L4 with only the self-scoped constants (ADR-024 D1).
-        header_segs, dir_segs, have_set = build_public_set(
-            list(public_header_roots), []
-        )
+        header_segs, dir_segs, have_set = build_public_set(file_roots, dir_roots)
         decls: list[Function | RecordType | EnumType | Variable] = [
             *functions,
             *records,

--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -40,9 +40,6 @@ from defusedxml import ElementTree as DefusedET
 from ..build_evidence import CompileUnit
 from ..source_abi import SourceAbiTu
 from ._argv import (
-    MACRO_DEFINITION_PREFIXES as _MACRO_DEFINITION_PREFIXES,
-)
-from ._argv import (
     is_msvc_mode,
     pick_compiler_binary,
     replay_extra_flags,

--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -282,7 +282,7 @@ class CastxmlSourceExtractor:
             if is_generated_header(header)
         }
 
-        return assemble_source_tu(
+        tu = assemble_source_tu(
             compile_unit,
             public_header_roots=public_header_roots,
             target_id=target_id,
@@ -304,3 +304,14 @@ class CastxmlSourceExtractor:
             # carry full type-change coverage with correct provenance.
             typedefs={},
         )
+        # Record every file castxml parsed (the GCC_XML <File> table) so the
+        # per-TU cache (ADR-030 D8) invalidates on an edit to any transitively
+        # included header, not just the configured public roots (Codex #339, P1).
+        tu.read_files = sorted(
+            {
+                name
+                for el in root.findall(".//File")
+                if (name := el.get("name"))
+            }
+        )
+        return tu

--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -28,8 +28,6 @@ context→argv builder is pure and unit-testable; only :meth:`extract` shells ou
 
 from __future__ import annotations
 
-import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -41,203 +39,33 @@ from defusedxml import ElementTree as DefusedET
 
 from ..build_evidence import CompileUnit
 from ..source_abi import SourceAbiTu
+from ._argv import (
+    MACRO_DEFINITION_PREFIXES as _MACRO_DEFINITION_PREFIXES,
+)
+from ._argv import (
+    is_msvc_mode,
+    pick_compiler_binary,
+    replay_extra_flags,
+    unredact_home,
+)
 from .base import SourceExtractionError, assemble_source_tu
 
 #: castxml extractor schema/behaviour version, recorded in the dump provenance.
 CASTXML_EXTRACTOR_VERSION = "0.1"
 
-_CXX_LANGS = frozenset({"cxx", "c++", "cpp"})
-#: Compiler basenames that mean castxml should run in MSVC mode.
-_MSVC_BINARIES = frozenset({"cl", "cl.exe", "clang-cl", "clang-cl.exe"})
-
-
-def _unredact_home(value: str) -> str:
-    """Expand a redacted home placeholder (``~``) back to the real home dir.
-
-    The evidence redaction policy (ADR-032 D7) rewrites the user's home prefix to
-    ``~`` *wherever it appears* before persisting paths/argv. ``subprocess`` does
-    not expand ``~`` (no shell), so replaying a redacted ``CompileUnit`` would
-    treat ``~/...`` / ``-I~/...`` as literal paths and fail for any home-directory
-    build. Reverse the substitution for the *replay only* (persisted values stay
-    redacted) by mirroring how redaction applied it — replacing ``~`` with the
-    current home. A no-op when there is no ``~`` (live/unredacted units) or no
-    resolvable home.
-
-    Only a ``~`` that stands in for a home *directory* is expanded: the
-    placeholder is always either the whole token or immediately followed by a
-    path separator (``/`` or ``\\``). A ``~`` followed by anything else is left
-    untouched, so Windows 8.3 short names such as ``RUNNER~1`` in a freshly
-    created temp path are never mangled into ``RUNNER<home>1``.
-    """
-    if "~" not in value:
-        return value
-    home = os.path.expanduser("~")
-    if not home or home == "~":
-        return value
-    # Expand `~` only when it is the redaction placeholder for a home directory:
-    # the whole token, or followed by a path separator. `re.sub` with a function
-    # replacement avoids backslashes in `home` being read as group references.
-    return re.sub(r"~(?=[\\/]|$)", lambda _m: home, value)
-
-
-def _basename(path: str) -> str:
-    """Final path component, splitting on both ``/`` and ``\\``.
-
-    ``Path(path).name`` on a POSIX host does not treat ``\\`` as a separator, so
-    a Windows compiler path from a cross/off-Windows compile database
-    (``C:\\VS\\bin\\cl.exe``) would otherwise return the whole string and miss
-    MSVC-mode detection. Splitting on both separators makes the basename
-    host-independent.
-    """
-    return re.split(r"[\\/]", path)[-1]
-
-
-#: Compiler-launcher wrappers that prefix the real compiler in a build action
-#: (``ccache clang++ -c foo.cpp``). castxml must emulate the real compiler, not
-#: the launcher, which would otherwise be invoked without its compiler operand.
-_COMPILER_LAUNCHERS = frozenset(
-    {"ccache", "sccache", "distcc", "icecc", "icerun", "buildcache"}
-)
-
-
-def _strip_launchers(argv: list[str]) -> list[str]:
-    """Drop leading compiler-launcher tokens (``ccache``/``sccache``/…).
-
-    A launcher is recognized by basename (``/usr/bin/ccache`` → ``ccache``,
-    ``ccache.exe`` → ``ccache``) so the real compiler that follows it is the one
-    castxml emulates.
-    """
-    i = 0
-    while i < len(argv) and _basename(argv[i]).lower().removesuffix(
-        ".exe"
-    ) in _COMPILER_LAUNCHERS:
-        i += 1
-    return argv[i:]
-
-
-def _compiler_binary(compile_unit: CompileUnit, override: str | None) -> str:
-    """Pick the compiler binary castxml should emulate for this TU.
-
-    Prefers the compiler actually recorded in the build action (``argv[0]``,
-    after unwrapping any ``ccache``/``sccache`` launcher) so a
-    clang/clang-cl/cross TU is replayed against its real builtin include paths,
-    target defaults, and accepted flags — castxml invokes this binary to
-    discover them. Falls back to g++/gcc by language only when no command is
-    available (and an explicit ``override`` always wins).
-    """
-    if override:
-        return override
-    argv = _strip_launchers(compile_unit.argv)
-    if argv and argv[0] and not argv[0].startswith("-"):
-        return argv[0]
-    return "g++" if compile_unit.language.lower() in _CXX_LANGS else "gcc"
+#: Backwards-compatible aliases — the compile-context → argv helpers now live in
+#: the shared ``_argv`` module (reused by the clang backend, phase 5) but are
+#: re-exported here under their historical private names so existing call sites
+#: and tests keep working.
+_unredact_home = unredact_home
+_compiler_binary = pick_compiler_binary
+_replay_extra_flags = replay_extra_flags
 
 
 def _std_flag(standard: str, cc_id: str) -> list[str]:
     if not standard:
         return []
     return [f"/std:{standard}"] if cc_id == "msvc" else [f"-std={standard}"]
-
-
-#: GNU options that take a path operand and change *what* gets parsed (forced
-#: includes / macro files). Carried through from argv since they are not
-#: normalized into the structured CompileUnit fields. Only ``-include`` and
-#: ``-imacros`` also have a joined ``-include<file>`` spelling; ``-include-pch``
-#: is separate-operand only (clang ``-include-pch <file>``) and must not be
-#: treated as a joined ``-include`` or its operand will be dropped.
-_GNU_FORCED_INCLUDE_OPTS = frozenset({"-include", "-imacros"})
-_GNU_SEPARATE_INCLUDE_OPTS = frozenset({"-include", "-imacros", "-include-pch"})
-#: Value-taking toolchain flags already normalized into the structured
-#: ``sysroot``/``target_triple`` fields and re-emitted by
-#: :func:`build_castxml_command` as ``--sysroot=``/``--target=``. They must NOT
-#: be carried through from ``abi_relevant_flags``: the adapter records only the
-#: bare option token for the split spelling (``-isysroot /sdk`` → just
-#: ``-isysroot``, operand dropped), so re-appending it yields a dangling option
-#: that swallows the following argv token (``--sysroot=/sdk … -isysroot -o``).
-#: Mirrors ``_TOOLCHAIN_PATH_FLAG_PREFIXES`` in ``adapters/base.py``.
-_STRUCTURED_TOOLCHAIN_FLAG_PREFIXES = ("--sysroot", "-isysroot", "--target", "-target")
-#: MSVC/clang-cl forced-include options in their separate-operand spelling
-#: (``/FI file`` or ``-FI file``); the joined ``/FIfile`` form is handled by
-#: prefix. (https://learn.microsoft.com/cpp/build/reference/fi-name-forced-include-file)
-_MSVC_FORCED_INCLUDE_OPTS = frozenset({"/FI", "-FI"})
-#: GNU include-search options that take a directory operand and are NOT
-#: normalized into the structured ``include_paths``/``system_include_paths``
-#: buckets (those cover ``-I``/``-isystem`` only). Dropping them makes castxml
-#: search a different set of directories than the real compile (Codex review #335).
-#: gcc/clang accept both the separate (``-iquote dir``) and joined
-#: (``-iquote/dir``) spellings, so both are carried through.
-#: (https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html)
-_GNU_INCLUDE_SEARCH_OPTS = frozenset({"-iquote", "-idirafter"})
-
-
-def _replay_extra_flags(
-    compile_unit: CompileUnit, already: list[str], cc_id: str
-) -> list[str]:
-    """Carry through ABI/parse-relevant options not in the structured fields.
-
-    ``abi_relevant_flags`` (e.g. ``-fms-extensions``, ``-fabi-version``,
-    ``-fvisibility``, ``-m32``), forced-include options, and unnormalized
-    include-search options (GNU ``-iquote``/``-idirafter``, MSVC ``/I``) from
-    ``argv`` change the parsed translation unit / header search; dropping them
-    makes castxml parse a different TU than the real build (ADR-030 D2).
-    De-duplicated against the flags already emitted from the structured fields.
-    MSVC ``/FI`` forced includes and ``/I`` search dirs are carried only in MSVC
-    mode so a GNU ``-F``/``-I``-family flag is never mistaken for one.
-    """
-    seen = set(already)
-    out: list[str] = []
-    for flag in compile_unit.abi_relevant_flags:
-        # Value-taking toolchain flags (sysroot/target) are already normalized
-        # into the structured fields and re-emitted by build_castxml_command. The
-        # adapter records only the bare option token for the split spelling
-        # (operand dropped), so carrying it through would dangle and swallow the
-        # next argv token. Skip them here (see prefix-set docstring).
-        if flag.startswith(_STRUCTURED_TOOLCHAIN_FLAG_PREFIXES):
-            continue
-        if flag not in seen:
-            out.append(flag)
-            seen.add(flag)
-    argv = compile_unit.argv
-    i = 0
-    while i < len(argv):
-        tok = argv[i]
-        if tok in _GNU_SEPARATE_INCLUDE_OPTS and i + 1 < len(argv):
-            out += [tok, argv[i + 1]]  # -include / -imacros / -include-pch <file>
-            i += 2
-        elif tok in _GNU_INCLUDE_SEARCH_OPTS and i + 1 < len(argv):
-            out += [tok, argv[i + 1]]  # -iquote / -idirafter <dir> (separate)
-            i += 2
-        elif tok not in _GNU_INCLUDE_SEARCH_OPTS and any(
-            tok.startswith(opt) and len(tok) > len(opt)
-            for opt in _GNU_INCLUDE_SEARCH_OPTS
-        ):
-            out.append(tok)  # -iquote/dir / -idirafter/dir (joined)
-            i += 1
-        elif cc_id == "msvc" and tok == "/I" and i + 1 < len(argv):
-            out += [tok, argv[i + 1]]  # MSVC /I dir (separate operand)
-            i += 2
-        elif cc_id == "msvc" and len(tok) > 2 and tok.startswith("/I"):
-            out.append(tok)  # MSVC /Idir (joined)
-            i += 1
-        elif tok not in _GNU_SEPARATE_INCLUDE_OPTS and any(
-            tok.startswith(opt) and len(tok) > len(opt)
-            for opt in _GNU_FORCED_INCLUDE_OPTS
-        ):
-            out.append(tok)  # -includefile / -imacrosfile (joined)
-            i += 1
-        elif cc_id == "msvc" and tok in _MSVC_FORCED_INCLUDE_OPTS and i + 1 < len(argv):
-            out += [tok, argv[i + 1]]  # /FI file (separate operand)
-            i += 2
-        elif (
-            cc_id == "msvc"
-            and len(tok) > 3
-            and (tok.startswith("/FI") or tok.startswith("-FI"))
-        ):
-            out.append(tok)  # /FIfile (joined)
-            i += 1
-        else:
-            i += 1
-    return out
 
 
 def build_castxml_command(
@@ -254,8 +82,8 @@ def build_castxml_command(
     system-include paths, sysroot, and target triple, so source replay sees the
     headers the compiler actually saw under the flags it actually used.
     """
-    cc_bin = _compiler_binary(compile_unit, compiler_binary)
-    cc_id = "msvc" if _basename(cc_bin).lower() in _MSVC_BINARIES else "gnu"
+    cc_bin = pick_compiler_binary(compile_unit, compiler_binary)
+    cc_id = "msvc" if is_msvc_mode(cc_bin) else "gnu"
 
     cmd = [castxml_bin, "--castxml-output=1", f"--castxml-cc-{cc_id}", cc_bin]
     cmd += _std_flag(compile_unit.standard, cc_id)
@@ -280,6 +108,7 @@ class CastxmlSourceExtractor:
     """Produce a :class:`SourceAbiTu` from one compile unit via castxml (D3)."""
 
     name = "castxml-source"
+    version = CASTXML_EXTRACTOR_VERSION
 
     def __init__(
         self,

--- a/abicheck/evidence/source_extractors/castxml.py
+++ b/abicheck/evidence/source_extractors/castxml.py
@@ -43,6 +43,7 @@ from ._argv import (
     is_msvc_mode,
     pick_compiler_binary,
     replay_extra_flags,
+    resolve_read_files,
     unredact_home,
 )
 from .base import SourceExtractionError, assemble_source_tu
@@ -304,11 +305,10 @@ class CastxmlSourceExtractor:
         # Record every file castxml parsed (the GCC_XML <File> table) so the
         # per-TU cache (ADR-030 D8) invalidates on an edit to any transitively
         # included header, not just the configured public roots (Codex #339, P1).
-        tu.read_files = sorted(
-            {
-                name
-                for el in root.findall(".//File")
-                if (name := el.get("name"))
-            }
+        # Resolve to absolute against the build directory so the cache (run in a
+        # different CWD) can read a relative castxml <File> path (Codex P2).
+        tu.read_files = resolve_read_files(
+            {name for el in root.findall(".//File") if (name := el.get("name"))},
+            compile_unit.directory,
         )
         return tu

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -61,6 +61,7 @@ from ._argv import (
     pick_compiler_binary,
     replay_extra_flags,
     resolve_read_files,
+    split_public_roots,
     unredact_home,
 )
 from .base import SourceExtractionError
@@ -397,8 +398,13 @@ class _ClassifyContext:
     def __init__(self, public_header_roots: list[str]) -> None:
         from ...provenance import build_public_set
 
+        # A public root may be a *directory* (`--headers include/`). Feeding it to
+        # build_public_set as a header file would never match a decl under it
+        # (`include` vs `include/api.h`), dropping the whole public include tree;
+        # split file roots from directory roots first (Codex review #339, P2).
+        file_roots, dir_roots = split_public_roots(public_header_roots)
         self.header_segs, self.dir_segs, self.have_set = build_public_set(
-            list(public_header_roots), []
+            file_roots, dir_roots
         )
 
     def classify(self, file: str) -> tuple[str, str, bool]:

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -669,10 +669,9 @@ def _emit_function(
     sig = _signature(node)
     mangled = _mangled(node)
     loc = _location(file, _node_line(node), origin)
-    is_inline = bool(node.get("inline")) or bool(node.get("constexpr"))
     # A function entity always carries the signature + default-argument value so
-    # default_argument_changed fires; an inline/constexpr body additionally
-    # yields an inline-body fingerprint for inline_body_changed.
+    # default_argument_changed fires; a body present in a public header
+    # additionally yields an inline-body fingerprint for inline_body_changed.
     tu.functions.append(
         SourceEntity(
             id=_hash("function", mangled or name, sig),
@@ -687,7 +686,13 @@ def _emit_function(
             confidence=EvidenceConfidence.HIGH,
         )
     )
-    if is_inline and _has_body(node):
+    # Any function/method *defined* in a public header (it has a CompoundStmt
+    # body) ships that body to consumers — whether explicitly inline/constexpr,
+    # an in-class member (implicitly inline, no `inline` key in clang's JSON), or
+    # a header out-of-line definition. Fingerprint the body whenever one is
+    # present, so an implicitly-inline method body change fires inline_body_changed
+    # (Codex review #339, P2).
+    if _has_body(node):
         body = next(
             c for c in node["inner"] if isinstance(c, dict) and c.get("kind") == "CompoundStmt"
         )

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -56,7 +57,6 @@ from ..build_evidence import CompileUnit
 from ..model import EvidenceConfidence
 from ..source_abi import SourceAbiTu, SourceEntity, SourceLocation
 from ._argv import (
-    MACRO_DEFINITION_PREFIXES,
     is_msvc_mode,
     pick_compiler_binary,
     replay_extra_flags,
@@ -68,8 +68,19 @@ from .base import SourceExtractionError
 #: folded into the per-TU cache key (ADR-030 D8).
 CLANG_EXTRACTOR_VERSION = "0.1"
 
-#: AST node kinds clang emits for the entities we fingerprint.
-_FUNCTION_NODE_KINDS = frozenset({"FunctionDecl", "CXXMethodDecl"})
+#: AST node kinds clang emits for the entities we fingerprint. Includes the C++
+#: special members (constructor/destructor/conversion) so a change to a public
+#: ``Widget(int n = 1)`` default, or an inline constructor body edit, is detected
+#: — not just ordinary functions/methods (Codex review #339, P2).
+_FUNCTION_NODE_KINDS = frozenset(
+    {
+        "FunctionDecl",
+        "CXXMethodDecl",
+        "CXXConstructorDecl",
+        "CXXDestructorDecl",
+        "CXXConversionDecl",
+    }
+)
 _TEMPLATE_NODE_KINDS = frozenset({"FunctionTemplateDecl", "ClassTemplateDecl"})
 #: Decl contexts we descend into to reach members/nested decls, tracking the
 #: enclosing scope name so a member's qualified name is built (``ns::Cls::f``).
@@ -100,25 +111,20 @@ def _std_flag(standard: str, msvc: bool) -> list[str]:
     return [f"/std:{standard}"] if msvc else [f"-std={standard}"]
 
 
-def build_clang_command(
-    compile_unit: CompileUnit,
-    source: Path,
-    *,
-    clang_bin: str = "clang",
-    compiler_binary: str | None = None,
-) -> list[str]:
-    """Build the ``clang -ast-dump=json`` argv for a compile unit's context (D2).
+def _clang_context_args(
+    compile_unit: CompileUnit, compiler_binary: str | None
+) -> tuple[list[str], bool]:
+    """The shared compile-context argv prefix (no mode tail / source) and msvc flag.
 
     Mirrors the compile unit's language standard, defines/undefines, include and
-    system-include paths, sysroot, target triple, and ABI-relevant flags, so the
-    source replay parses the same translation unit the real build compiled. A
-    clang-cl/MSVC compile unit is driven through clang's ``cl`` driver mode.
+    system-include paths, sysroot, target triple, and ABI-relevant flags, so both
+    the AST pass and the macro pass parse the same TU the real build compiled.
     """
     cc_bin = pick_compiler_binary(compile_unit, compiler_binary)
     msvc = is_msvc_mode(cc_bin)
     cc_id = "msvc" if msvc else "gnu"
 
-    cmd = [clang_bin]
+    cmd: list[str] = []
     if msvc:
         cmd.append("--driver-mode=cl")
     # Force the language so a header replayed directly still parses as C/C++.
@@ -136,17 +142,60 @@ def build_clang_command(
     for inc in compile_unit.include_paths:
         cmd += [inc_opt, inc]
     for inc in compile_unit.system_include_paths:
-        cmd += (["/I", inc] if msvc else ["-isystem", inc])
+        cmd += ["/I", inc] if msvc else ["-isystem", inc]
     if compile_unit.sysroot and not msvc:
         cmd.append(f"--sysroot={compile_unit.sysroot}")
     if compile_unit.target_triple and not msvc:
         cmd.append(f"--target={compile_unit.target_triple}")
     cmd += replay_extra_flags(compile_unit, cmd, cc_id)
+    return cmd, msvc
+
+
+def build_clang_command(
+    compile_unit: CompileUnit,
+    source: Path,
+    *,
+    clang_bin: str = "clang",
+    compiler_binary: str | None = None,
+) -> list[str]:
+    """Build the ``clang -ast-dump=json`` argv for a compile unit's context (D2).
+
+    A clang-cl/MSVC compile unit is driven through clang's ``cl`` driver mode.
+    """
+    cmd, _msvc = _clang_context_args(compile_unit, compiler_binary)
     # Syntax-only AST dump to stdout as JSON. -ferror-limit=0 keeps parsing past
     # recoverable errors so a single bad decl does not blank the whole dump.
-    cmd += ["-fsyntax-only", "-ferror-limit=0", "-Xclang", "-ast-dump=json"]
-    cmd.append(str(source))
-    return cmd
+    return [
+        clang_bin,
+        *cmd,
+        "-fsyntax-only",
+        "-ferror-limit=0",
+        "-Xclang",
+        "-ast-dump=json",
+        str(source),
+    ]
+
+
+def build_clang_macro_command(
+    compile_unit: CompileUnit,
+    source: Path,
+    *,
+    clang_bin: str = "clang",
+    compiler_binary: str | None = None,
+) -> list[str]:
+    """Build the ``clang -E -dD`` argv that dumps macro definitions (ADR-030 D6).
+
+    The JSON AST carries no preprocessor macros, so a separate preprocess pass
+    (``-E -dD``: emit ``#define`` directives with line markers) is needed for
+    ``public_macro_value_changed`` to ever fire (Codex review #339, P2). Same
+    compile context as the AST pass so the macro set matches the real build.
+    """
+    cmd, msvc = _clang_context_args(compile_unit, compiler_binary)
+    # /E + /d1PP? No portable clang-cl spelling for -dD; use the GNU options via
+    # the driver regardless (clang accepts -Xclang for the dump). -P drops line
+    # markers, so we keep them (no -P) to attribute each macro to its file.
+    preprocess = ["/E"] if msvc else ["-E"]
+    return [clang_bin, *cmd, *preprocess, "-dD", "-ferror-limit=0", str(source)]
 
 
 def _hash(*parts: str) -> str:
@@ -357,6 +406,93 @@ class _ClassifyContext:
         if origin == ScopeOrigin.GENERATED:
             return "private_header", "PRIVATE_HEADER", False
         return "unknown", "UNKNOWN", False
+
+
+#: A ``-E`` line marker: ``# <line> "<file>" [flags]`` — sets the current file.
+_LINE_MARKER_RE = re.compile(r'^#\s+\d+\s+"([^"]*)"')
+#: A C identifier (a macro name).
+_MACRO_NAME_RE = re.compile(r"[A-Za-z_]\w*")
+
+
+def _parse_define(rest: str) -> tuple[str, str] | None:
+    """Parse the text after ``#define `` into ``(name, normalized-value)``.
+
+    Keeps the function-like parameter list as part of the value (``(a,b) body``),
+    so a change to either the parameters or the body reads as a value change.
+    """
+    m = _MACRO_NAME_RE.match(rest)
+    if not m:
+        return None
+    name = m.group(0)
+    i = m.end()
+    params = ""
+    if i < len(rest) and rest[i] == "(":  # function-like macro
+        depth = 0
+        j = i
+        while j < len(rest):
+            if rest[j] == "(":
+                depth += 1
+            elif rest[j] == ")":
+                depth -= 1
+            j += 1
+            if depth == 0:
+                break
+        params = rest[i:j]
+        i = j
+    body = rest[i:].strip()
+    value = re.sub(r"\s+", " ", f"{params} {body}".strip())
+    return name, value
+
+
+def macros_from_preprocessor(
+    text: str, public_header_roots: list[str]
+) -> tuple[list[SourceEntity], list[str]]:
+    """Parse ``clang -E -dD`` output into public-header macro entities (ADR-030 D6).
+
+    Pure: tracks the current file from ``#`` line markers, records the final
+    definition of each macro (honoring later ``#undef``), and keeps only macros
+    whose declaring file is on the public source surface — builtin/command-line
+    and system macros carry ``<built-in>``/system files and are filtered out.
+
+    Returns ``(macro entities, public macro-declaring files)``; the file list
+    feeds the per-TU cache dependency set so a macro-only header edit invalidates
+    the dump (Codex review #339, P1).
+    """
+    ctx = _ClassifyContext(public_header_roots)
+    current = ""
+    defs: dict[str, tuple[str, str]] = {}  # name -> (value, file)
+    for line in text.splitlines():
+        marker = _LINE_MARKER_RE.match(line)
+        if marker:
+            current = marker.group(1)
+            continue
+        if line.startswith("#define "):
+            parsed = _parse_define(line[len("#define ") :])
+            if parsed:
+                defs[parsed[0]] = (parsed[1], current)
+        elif line.startswith("#undef "):
+            defs.pop(line[len("#undef ") :].strip(), None)
+
+    entities: list[SourceEntity] = []
+    files: set[str] = set()
+    for name, (value, file) in sorted(defs.items()):
+        visibility, origin, public = ctx.classify(file)
+        if not public:
+            continue
+        files.add(file)
+        entities.append(
+            SourceEntity(
+                id=_hash("macro", name, value),
+                kind="macro",
+                qualified_name=name,
+                value=value,
+                source_location=_location(file, 0, origin),
+                visibility=visibility,
+                api_relevant=True,
+                confidence=EvidenceConfidence.HIGH,
+            )
+        )
+    return entities, sorted(files)
 
 
 def source_abi_from_clang_ast(
@@ -643,29 +779,11 @@ class ClangSourceExtractor:
         if not source.is_absolute() and directory:
             source = Path(directory) / source
 
-        cmd = build_clang_command(
-            compile_unit,
-            source,
-            clang_bin=self.clang_bin,
-            compiler_binary=self.compiler_binary,
+        ast_cmd = build_clang_command(
+            compile_unit, source,
+            clang_bin=self.clang_bin, compiler_binary=self.compiler_binary,
         )
-        cmd = [
-            tok if tok.startswith(MACRO_DEFINITION_PREFIXES) else unredact_home(tok)
-            for tok in cmd
-        ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout,
-                check=False,
-                cwd=directory or None,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise SourceExtractionError(
-                f"clang timed out after {self.timeout}s on {compile_unit.source}"
-            ) from exc
+        result = self._run(ast_cmd, directory, compile_unit.source)
         if not result.stdout.strip():
             raise SourceExtractionError(
                 f"clang produced no AST for {compile_unit.source} "
@@ -685,10 +803,68 @@ class ClangSourceExtractor:
             diags.append(
                 f"clang exited {result.returncode} (recovered): {result.stderr[:300]}"
             )
-        return source_abi_from_clang_ast(
-            ast_root,
-            compile_unit,
-            public_header_roots,
-            target_id,
-            diagnostics=diags,
+        tu = source_abi_from_clang_ast(
+            ast_root, compile_unit, public_header_roots, target_id, diagnostics=diags,
         )
+        self._attach_macros(tu, compile_unit, source, directory, public_header_roots)
+        return tu
+
+    def _run(
+        self, cmd: list[str], directory: str, source_label: str
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a clang command in the TU directory, un-redacting redacted paths.
+
+        Every token is un-redacted, including macro values: a home path used
+        inside a macro (e.g. ``-DCFG=~/build/cfg.h`` consumed by ``#include CFG``)
+        must be expanded or clang parses a different TU / cannot find the header.
+        ``unredact_home`` only rewrites a ``~`` standing in for a home directory,
+        so a literal ``~`` mid-token is left intact (mirrors castxml, PR #336).
+        """
+        cmd = [unredact_home(tok) for tok in cmd]
+        try:
+            return subprocess.run(
+                cmd, capture_output=True, text=True, timeout=self.timeout,
+                check=False, cwd=directory or None,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SourceExtractionError(
+                f"clang timed out after {self.timeout}s on {source_label}"
+            ) from exc
+
+    def _attach_macros(
+        self,
+        tu: SourceAbiTu,
+        compile_unit: CompileUnit,
+        source: Path,
+        directory: str,
+        public_header_roots: list[str],
+    ) -> None:
+        """Run the ``-E -dD`` preprocessor pass and fold public macros into the TU.
+
+        Best-effort: the JSON AST has no macros, so this second pass is what makes
+        ``public_macro_value_changed`` possible (Codex review #339, P2). A failure
+        here only records a diagnostic (partial macro coverage) — it never discards
+        the AST-derived dump or aborts the comparison (ADR-028 D7).
+        """
+        macro_cmd = build_clang_macro_command(
+            compile_unit, source,
+            clang_bin=self.clang_bin, compiler_binary=self.compiler_binary,
+        )
+        try:
+            result = self._run(macro_cmd, directory, compile_unit.source)
+        except SourceExtractionError as exc:
+            tu.diagnostics.append(f"macro pass skipped: {exc}")
+            return
+        if result.returncode != 0 and not result.stdout.strip():
+            tu.diagnostics.append(
+                f"macro pass produced no output (exit {result.returncode})"
+            )
+            return
+        macros, macro_files = macros_from_preprocessor(
+            result.stdout, public_header_roots
+        )
+        tu.macros = macros
+        # A header that only defines macros contributes no AST node, so add its
+        # path to the cache dependency set or a macro-only edit would be a stale
+        # hit (Codex review #339, P1).
+        tu.read_files = sorted(set(tu.read_files) | set(macro_files))

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -499,17 +499,28 @@ def macros_from_preprocessor(
     whose declaring file is on the public source surface — builtin/command-line
     and system macros carry ``<built-in>``/system files and are filtered out.
 
-    Returns ``(macro entities, public macro-declaring files)``; the file list
-    feeds the per-TU cache dependency set so a macro-only header edit invalidates
-    the dump (Codex review #339, P1).
+    Returns ``(macro entities, every real file the preprocessor read)``. The file
+    list feeds the per-TU cache dependency set, so it must contain *all* files
+    the preprocessor touched — not just the public macro-declaring ones — or a
+    macro-only *private* header (e.g. ``detail/config.h`` whose ``#define`` gates
+    an ``#if`` in a public header) would never invalidate the dump: it
+    contributes no public macro entity and no clang AST node, so an edit to it
+    would otherwise pass cache validation and reuse stale facts (Codex review
+    #339, P2; P1 covered only the public ones).
     """
     ctx = _ClassifyContext(public_header_roots)
     current = ""
     defs: dict[str, tuple[str, str]] = {}  # name -> (value, file)
+    # Every real file named by a `#` line marker — the complete set the
+    # preprocessor read. `<built-in>`/`<command line>`/`<scratch space>`
+    # pseudo-files are not real dependencies and are skipped.
+    touched: set[str] = set()
     for line in _unfold_continuations(text.splitlines()):
         marker = _LINE_MARKER_RE.match(line)
         if marker:
             current = marker.group(1)
+            if current and not current.startswith("<"):
+                touched.add(current)
             continue
         if line.startswith("#define "):
             parsed = _parse_define(line[len("#define ") :])
@@ -519,12 +530,10 @@ def macros_from_preprocessor(
             defs.pop(line[len("#undef ") :].strip(), None)
 
     entities: list[SourceEntity] = []
-    files: set[str] = set()
     for name, (value, file) in sorted(defs.items()):
         visibility, origin, public = ctx.classify(file)
         if not public:
             continue
-        files.add(file)
         entities.append(
             SourceEntity(
                 id=_hash("macro", name, value),
@@ -537,7 +546,7 @@ def macros_from_preprocessor(
                 confidence=EvidenceConfidence.HIGH,
             )
         )
-    return entities, sorted(files)
+    return entities, sorted(touched)
 
 
 def source_abi_from_clang_ast(

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -1,0 +1,628 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Clang source ABI extractor (ADR-030 D3, phase 5).
+
+This is the *source-based* L4 backend. It parses a translation unit under its
+real per-TU build context (ADR-030 D2) with ``clang -Xclang -ast-dump=json`` and
+derives the fingerprints that final binary/debug artifacts under-represent and
+that castxml (phase 2) cannot produce:
+
+- inline function bodies (``inline_body_changed``);
+- function/class **template** bodies, instantiated or not
+  (``template_body_changed`` / ``uninstantiated_template_removed``);
+- ``constexpr`` values (``constexpr_value_changed``);
+- public default arguments (``default_argument_changed``).
+
+**Requires clang.** Source ABI replay is the one tier that depends on a C++
+front-end being present. When ``clang`` is not on ``PATH`` the extractor raises
+:class:`SourceExtractionError`; callers record that as *partial L4 coverage*
+(ADR-028 D7) and the artifact tiers (L0–L2) stay authoritative — abicheck never
+aborts a comparison because the source tier is unavailable.
+
+No new Python dependency is added (ADR-001): clang is an optional external tool,
+discovered at runtime exactly like castxml. For a GCC-built project clang
+replays the **GCC build's flags** (standard, defines, include paths, target,
+sysroot) so it parses the same headers under the same macros; a TU using a
+GCC-only extension clang rejects degrades to partial coverage rather than a hard
+failure (ADR-030 Consequences).
+
+The argv builder and the JSON-AST → :class:`SourceAbiTu` mapping are pure and
+unit-tested without clang installed; only :meth:`ClangSourceExtractor.extract`
+shells out (integration-marked).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from ..build_evidence import CompileUnit
+from ..model import EvidenceConfidence
+from ..source_abi import SourceAbiTu, SourceEntity, SourceLocation
+from ._argv import (
+    MACRO_DEFINITION_PREFIXES,
+    is_msvc_mode,
+    pick_compiler_binary,
+    replay_extra_flags,
+    unredact_home,
+)
+from .base import SourceExtractionError
+
+#: clang extractor schema/behaviour version, recorded in the dump provenance and
+#: folded into the per-TU cache key (ADR-030 D8).
+CLANG_EXTRACTOR_VERSION = "0.1"
+
+#: AST node kinds clang emits for the entities we fingerprint.
+_FUNCTION_NODE_KINDS = frozenset({"FunctionDecl", "CXXMethodDecl"})
+_TEMPLATE_NODE_KINDS = frozenset({"FunctionTemplateDecl", "ClassTemplateDecl"})
+#: Decl contexts we descend into to reach members/nested decls, tracking the
+#: enclosing scope name so a member's qualified name is built (``ns::Cls::f``).
+_SCOPE_NODE_KINDS = frozenset(
+    {"NamespaceDecl", "CXXRecordDecl", "ClassTemplateDecl", "LinkageSpecDecl"}
+)
+#: Literal nodes whose ``value`` is a stable, human-meaningful constexpr value.
+_LITERAL_NODE_KINDS = frozenset(
+    {
+        "IntegerLiteral",
+        "FloatingLiteral",
+        "CharacterLiteral",
+        "StringLiteral",
+        "CXXBoolLiteralExpr",
+        "FixedPointLiteral",
+    }
+)
+#: Scalar node keys that survive into the structural body fingerprint. Volatile
+#: keys (``id`` pointer values, ``loc``/``range`` offsets, ``previousDecl``) are
+#: dropped so the hash is stable across builds/checkouts (mirrors the build-root
+#: independence of ``SourceEntity.identity()``).
+_FINGERPRINT_SCALAR_KEYS = ("kind", "name", "value", "opcode", "castKind")
+
+
+def _std_flag(standard: str, msvc: bool) -> list[str]:
+    if not standard:
+        return []
+    return [f"/std:{standard}"] if msvc else [f"-std={standard}"]
+
+
+def build_clang_command(
+    compile_unit: CompileUnit,
+    source: Path,
+    *,
+    clang_bin: str = "clang",
+    compiler_binary: str | None = None,
+) -> list[str]:
+    """Build the ``clang -ast-dump=json`` argv for a compile unit's context (D2).
+
+    Mirrors the compile unit's language standard, defines/undefines, include and
+    system-include paths, sysroot, target triple, and ABI-relevant flags, so the
+    source replay parses the same translation unit the real build compiled. A
+    clang-cl/MSVC compile unit is driven through clang's ``cl`` driver mode.
+    """
+    cc_bin = pick_compiler_binary(compile_unit, compiler_binary)
+    msvc = is_msvc_mode(cc_bin)
+    cc_id = "msvc" if msvc else "gnu"
+
+    cmd = [clang_bin]
+    if msvc:
+        cmd.append("--driver-mode=cl")
+    # Force the language so a header replayed directly still parses as C/C++.
+    lang = "c++" if compile_unit.language.lower() in ("cxx", "c++", "cpp") else "c"
+    if not msvc:
+        cmd += ["-x", lang]
+    cmd += _std_flag(compile_unit.standard, msvc)
+    define_opt = "/D" if msvc else "-D"
+    undef_opt = "/U" if msvc else "-U"
+    for key, value in compile_unit.defines.items():
+        cmd.append(f"{define_opt}{key}={value}" if value else f"{define_opt}{key}")
+    for undef in compile_unit.undefines:
+        cmd.append(f"{undef_opt}{undef}")
+    inc_opt = "/I" if msvc else "-I"
+    for inc in compile_unit.include_paths:
+        cmd += [inc_opt, inc]
+    for inc in compile_unit.system_include_paths:
+        cmd += (["/I", inc] if msvc else ["-isystem", inc])
+    if compile_unit.sysroot and not msvc:
+        cmd.append(f"--sysroot={compile_unit.sysroot}")
+    if compile_unit.target_triple and not msvc:
+        cmd.append(f"--target={compile_unit.target_triple}")
+    cmd += replay_extra_flags(compile_unit, cmd, cc_id)
+    # Syntax-only AST dump to stdout as JSON. -ferror-limit=0 keeps parsing past
+    # recoverable errors so a single bad decl does not blank the whole dump.
+    cmd += ["-fsyntax-only", "-ferror-limit=0", "-Xclang", "-ast-dump=json"]
+    cmd.append(str(source))
+    return cmd
+
+
+def _hash(*parts: str) -> str:
+    blob = "\x00".join(parts).encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def _canonical(node: Any) -> Any:
+    """Reduce a clang AST node to a build-root-stable structural form for hashing.
+
+    Keeps only structural scalars (``kind``/``name``/``value``/``opcode``/
+    ``castKind``) plus the node's ``type.qualType`` and its recursively
+    canonicalized children, dropping pointer ids and source locations so a pure
+    body edit changes the hash while a rebuild/relocation does not.
+    """
+    if not isinstance(node, dict):
+        return node
+    out: dict[str, Any] = {}
+    for key in _FINGERPRINT_SCALAR_KEYS:
+        if key in node:
+            out[key] = node[key]
+    type_obj = node.get("type")
+    if isinstance(type_obj, dict) and "qualType" in type_obj:
+        out["type"] = type_obj["qualType"]
+    inner = node.get("inner")
+    if isinstance(inner, list):
+        out["inner"] = [_canonical(child) for child in inner]
+    return out
+
+
+def _subtree_hash(node: dict[str, Any]) -> str:
+    return _hash("clang-ast", json.dumps(_canonical(node), sort_keys=True))
+
+
+def _node_file(node: dict[str, Any], current: str) -> str:
+    """The declaring file for a node, honoring clang's sticky-``file`` JSON.
+
+    clang omits a node's ``loc.file`` when it matches the previous node in source
+    order, so the file must be threaded through the traversal; ``current`` is the
+    last file seen.
+    """
+    loc = node.get("loc")
+    if isinstance(loc, dict):
+        f = loc.get("file")
+        if isinstance(f, str) and f:
+            return f
+        # An expansion of a macro carries spellingLoc/expansionLoc instead.
+        for sub in ("expansionLoc", "spellingLoc"):
+            s = loc.get(sub)
+            if isinstance(s, dict):
+                sf = s.get("file")
+                if isinstance(sf, str) and sf:
+                    return sf
+    return current
+
+
+def _node_line(node: dict[str, Any]) -> int:
+    loc = node.get("loc")
+    if isinstance(loc, dict):
+        line = loc.get("line")
+        if isinstance(line, int):
+            return line
+        exp = loc.get("expansionLoc")
+        if isinstance(exp, dict):
+            exp_line = exp.get("line")
+            if isinstance(exp_line, int):
+                return exp_line
+    return 0
+
+
+def _has_body(node: dict[str, Any]) -> bool:
+    return any(
+        isinstance(c, dict) and c.get("kind") == "CompoundStmt"
+        for c in node.get("inner", [])
+    )
+
+
+def _literal_value(node: dict[str, Any]) -> str | None:
+    """First literal value found anywhere under ``node`` (the constexpr value)."""
+    if node.get("kind") in _LITERAL_NODE_KINDS and "value" in node:
+        return str(node["value"])
+    for child in node.get("inner", []):
+        if isinstance(child, dict):
+            found = _literal_value(child)
+            if found is not None:
+                return found
+    return None
+
+
+def _default_arg_repr(node: dict[str, Any]) -> str:
+    """Normalized default-argument string for a function's parameters.
+
+    A ``ParmVarDecl`` with a default argument carries a ``CXXDefaultArgExpr``-free
+    initializer in its ``inner``; we represent each defaulted parameter as
+    ``name=<value-or-fingerprint>`` so both presence and value changes surface.
+    """
+    parts: list[str] = []
+    for child in node.get("inner", []):
+        if not isinstance(child, dict) or child.get("kind") != "ParmVarDecl":
+            continue
+        init = [
+            g
+            for g in child.get("inner", [])
+            if isinstance(g, dict) and g.get("kind") != "ParmVarDecl"
+        ]
+        if not child.get("init") and not init:
+            continue
+        pname = child.get("name", "")
+        value = None
+        for expr in init:
+            value = _literal_value(expr)
+            if value is not None:
+                break
+        rep = value if value is not None else (
+            _subtree_hash(init[0]) if init else "default"
+        )
+        parts.append(f"{pname}={rep}")
+    return ",".join(parts)
+
+
+def _signature(node: dict[str, Any]) -> str:
+    type_obj = node.get("type")
+    if isinstance(type_obj, dict):
+        return str(type_obj.get("qualType", ""))
+    return ""
+
+
+def _mangled(node: dict[str, Any]) -> str:
+    mangled = node.get("mangledName")
+    name = node.get("name", "")
+    if isinstance(mangled, str) and mangled and mangled != name:
+        return mangled
+    return ""
+
+
+def _qualified(scope: list[str], name: str) -> str:
+    return "::".join([*scope, name]) if scope else name
+
+
+class _ClassifyContext:
+    """Public-surface classification for clang file paths (ADR-024 / ADR-030)."""
+
+    def __init__(self, public_header_roots: list[str]) -> None:
+        from ...provenance import build_public_set
+
+        self.header_segs, self.dir_segs, self.have_set = build_public_set(
+            list(public_header_roots), []
+        )
+
+    def classify(self, file: str) -> tuple[str, str, bool]:
+        """Return ``(visibility, origin_label, api_relevant)`` for a file.
+
+        Mirrors the castxml extractor: a header that is both public and generated
+        stays public but is marked ``GENERATED`` (so ``generated_header_changed``
+        owns it); a generated *private* header (not in the public set) is demoted
+        off the public surface.
+        """
+        from ...model import ScopeOrigin
+        from ...provenance import classify_origin, is_generated_header
+
+        origin = classify_origin(
+            file, self.header_segs, self.dir_segs, have_public_set=self.have_set
+        )
+        if origin == ScopeOrigin.PUBLIC_HEADER and is_generated_header(file):
+            return "generated", "GENERATED", True
+        if origin == ScopeOrigin.PUBLIC_HEADER:
+            return "public_header", "PUBLIC_HEADER", True
+        if origin == ScopeOrigin.GENERATED:
+            return "private_header", "PRIVATE_HEADER", False
+        return "unknown", "UNKNOWN", False
+
+
+def source_abi_from_clang_ast(
+    ast_root: dict[str, Any],
+    compile_unit: CompileUnit,
+    public_header_roots: list[str],
+    target_id: str,
+    *,
+    diagnostics: list[str] | None = None,
+) -> SourceAbiTu:
+    """Map a clang JSON AST root to a normalized :class:`SourceAbiTu` (D4).
+
+    Pure: any producer of the clang AST JSON (the extractor below, or a fixture
+    in a test) reuses this. Emits only public-surface entities so the linker does
+    not have to filter private/system decls.
+    """
+    ctx = _ClassifyContext(public_header_roots)
+    tu = SourceAbiTu(
+        tu_id=compile_unit.id,
+        target_id=target_id or compile_unit.target_id,
+        extractor={"name": "clang-source", "version": CLANG_EXTRACTOR_VERSION},
+        compile_context_hash=_hash(
+            "ctx",
+            compile_unit.standard,
+            compile_unit.target_triple,
+            compile_unit.sysroot or "",
+            ",".join(f"{k}={v}" for k, v in sorted(compile_unit.defines.items())),
+            ",".join(compile_unit.include_paths),
+        ),
+        source=compile_unit.source,
+        public_header_roots=list(public_header_roots),
+        diagnostics=list(diagnostics or []),
+    )
+    _walk(ast_root, ctx, tu, scope=[], current_file="")
+    return tu
+
+
+def _walk(
+    node: dict[str, Any],
+    ctx: _ClassifyContext,
+    tu: SourceAbiTu,
+    *,
+    scope: list[str],
+    current_file: str,
+) -> None:
+    """Pre-order traversal that emits public entities, tracking file + scope."""
+    if not isinstance(node, dict):
+        return
+    file = _node_file(node, current_file)
+    kind = node.get("kind")
+    name = node.get("name", "") or ""
+
+    if kind in _FUNCTION_NODE_KINDS and name:
+        _emit_function(node, ctx, tu, scope, file)
+    elif kind in _TEMPLATE_NODE_KINDS and name:
+        # The template's body is captured whole in its fingerprint; do not
+        # descend into the templated pattern, or its inner FunctionDecl/Record
+        # would be re-emitted as a duplicate non-template entity.
+        _emit_template(node, ctx, tu, scope, file)
+        return
+    elif kind == "VarDecl" and name and node.get("constexpr"):
+        _emit_constexpr(node, ctx, tu, scope, file)
+    elif kind in ("CXXRecordDecl", "EnumDecl") and name:
+        _emit_type(node, ctx, tu, scope, file)
+
+    # Descend, extending the scope name stack for namespaces/records so members
+    # get a fully-qualified name.
+    child_scope = scope
+    if kind in _SCOPE_NODE_KINDS and name:
+        child_scope = [*scope, name]
+    for child in node.get("inner", []):
+        if isinstance(child, dict):
+            file = _node_file(child, file)
+            _walk(child, ctx, tu, scope=child_scope, current_file=file)
+
+
+def _location(file: str, line: int, origin_label: str) -> SourceLocation:
+    return SourceLocation(path=file, line=line, origin=origin_label)
+
+
+def _emit_function(
+    node: dict[str, Any],
+    ctx: _ClassifyContext,
+    tu: SourceAbiTu,
+    scope: list[str],
+    file: str,
+) -> None:
+    visibility, origin, public = ctx.classify(file)
+    if not public:
+        return
+    name = _qualified(scope, str(node.get("name", "")))
+    sig = _signature(node)
+    mangled = _mangled(node)
+    loc = _location(file, _node_line(node), origin)
+    is_inline = bool(node.get("inline")) or bool(node.get("constexpr"))
+    # A function entity always carries the signature + default-argument value so
+    # default_argument_changed fires; an inline/constexpr body additionally
+    # yields an inline-body fingerprint for inline_body_changed.
+    tu.functions.append(
+        SourceEntity(
+            id=_hash("function", mangled or name, sig),
+            kind="function",
+            qualified_name=name,
+            mangled_name=mangled,
+            signature_hash=_hash("sig", sig),
+            value=_default_arg_repr(node),
+            source_location=loc,
+            visibility=visibility,
+            api_relevant=True,
+            confidence=EvidenceConfidence.HIGH,
+        )
+    )
+    if is_inline and _has_body(node):
+        body = next(
+            c for c in node["inner"] if isinstance(c, dict) and c.get("kind") == "CompoundStmt"
+        )
+        tu.inline_bodies.append(
+            SourceEntity(
+                id=_hash("inline", mangled or name, sig),
+                kind="inline",
+                qualified_name=name,
+                mangled_name=mangled,
+                signature_hash=_hash("sig", sig),
+                body_hash=_subtree_hash(body),
+                source_location=loc,
+                visibility=visibility,
+                api_relevant=True,
+                confidence=EvidenceConfidence.HIGH,
+            )
+        )
+
+
+def _emit_template(
+    node: dict[str, Any],
+    ctx: _ClassifyContext,
+    tu: SourceAbiTu,
+    scope: list[str],
+    file: str,
+) -> None:
+    visibility, origin, public = ctx.classify(file)
+    if not public:
+        return
+    name = _qualified(scope, str(node.get("name", "")))
+    tu.templates.append(
+        SourceEntity(
+            id=_hash("template", name),
+            kind="template",
+            qualified_name=name,
+            body_hash=_subtree_hash(node),
+            source_location=_location(file, _node_line(node), origin),
+            visibility=visibility,
+            api_relevant=True,
+            confidence=EvidenceConfidence.HIGH,
+        )
+    )
+
+
+def _emit_constexpr(
+    node: dict[str, Any],
+    ctx: _ClassifyContext,
+    tu: SourceAbiTu,
+    scope: list[str],
+    file: str,
+) -> None:
+    visibility, origin, public = ctx.classify(file)
+    if not public:
+        return
+    name = _qualified(scope, str(node.get("name", "")))
+    value = _literal_value(node)
+    if value is None:
+        value = _subtree_hash(node)
+    tu.constexpr_values.append(
+        SourceEntity(
+            id=_hash("constexpr", name, value),
+            kind="constexpr",
+            qualified_name=name,
+            mangled_name=_mangled(node),
+            value=value,
+            source_location=_location(file, _node_line(node), origin),
+            visibility=visibility,
+            api_relevant=True,
+            confidence=EvidenceConfidence.HIGH,
+        )
+    )
+
+
+def _emit_type(
+    node: dict[str, Any],
+    ctx: _ClassifyContext,
+    tu: SourceAbiTu,
+    scope: list[str],
+    file: str,
+) -> None:
+    # Only definitions (a record with members / an enum with constants) carry a
+    # meaningful type hash; a forward declaration has no `inner`, so skip it to
+    # avoid a false same-name/empty-hash ODR signal.
+    if not node.get("inner"):
+        return
+    visibility, origin, public = ctx.classify(file)
+    if not public:
+        return
+    name = _qualified(scope, str(node.get("name", "")))
+    kind = "record" if node.get("kind") == "CXXRecordDecl" else "enum"
+    tu.types.append(
+        SourceEntity(
+            id=_hash("type", name),
+            kind=kind,
+            qualified_name=name,
+            type_hash=_subtree_hash(node),
+            source_location=_location(file, _node_line(node), origin),
+            visibility=visibility,
+            api_relevant=True,
+            confidence=EvidenceConfidence.HIGH,
+        )
+    )
+
+
+class ClangSourceExtractor:
+    """Produce a :class:`SourceAbiTu` from one compile unit via clang (D3, phase 5).
+
+    Requires ``clang`` on ``PATH``; :meth:`extract` raises
+    :class:`SourceExtractionError` otherwise, which callers record as partial L4
+    coverage (ADR-028 D7) without aborting the artifact comparison.
+    """
+
+    name = "clang-source"
+    version = CLANG_EXTRACTOR_VERSION
+
+    def __init__(
+        self,
+        *,
+        clang_bin: str = "clang",
+        compiler_binary: str | None = None,
+        timeout: int = 180,
+    ) -> None:
+        self.clang_bin = clang_bin
+        self.compiler_binary = compiler_binary
+        self.timeout = timeout
+
+    def available(self) -> bool:
+        return shutil.which(self.clang_bin) is not None
+
+    def extract(
+        self,
+        compile_unit: CompileUnit,
+        *,
+        public_header_roots: list[str],
+        target_id: str = "",
+    ) -> SourceAbiTu:
+        if not self.available():
+            raise SourceExtractionError(
+                f"{self.clang_bin} not found in PATH; source ABI replay (L4) requires "
+                "clang. Install clang to enable source-only checks (macros, default "
+                "arguments, inline/template/constexpr bodies), or omit --source-abi."
+            )
+        directory = unredact_home(compile_unit.directory)
+        source = Path(unredact_home(compile_unit.source))
+        if not source.is_absolute() and directory:
+            source = Path(directory) / source
+
+        cmd = build_clang_command(
+            compile_unit,
+            source,
+            clang_bin=self.clang_bin,
+            compiler_binary=self.compiler_binary,
+        )
+        cmd = [
+            tok if tok.startswith(MACRO_DEFINITION_PREFIXES) else unredact_home(tok)
+            for tok in cmd
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                check=False,
+                cwd=directory or None,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SourceExtractionError(
+                f"clang timed out after {self.timeout}s on {compile_unit.source}"
+            ) from exc
+        if not result.stdout.strip():
+            raise SourceExtractionError(
+                f"clang produced no AST for {compile_unit.source} "
+                f"(exit {result.returncode}): {result.stderr[:1000]}"
+            )
+        try:
+            ast_root = json.loads(result.stdout)
+        except ValueError as exc:
+            raise SourceExtractionError(
+                f"clang AST for {compile_unit.source} was not valid JSON: {exc}"
+            ) from exc
+        # A non-zero exit with usable JSON means clang recovered from some errors;
+        # record it as a diagnostic (partial coverage) rather than discarding the
+        # dump (ADR-028 D7).
+        diags: list[str] = []
+        if result.returncode != 0:
+            diags.append(
+                f"clang exited {result.returncode} (recovered): {result.stderr[:300]}"
+            )
+        return source_abi_from_clang_ast(
+            ast_root,
+            compile_unit,
+            public_header_roots,
+            target_id,
+            diagnostics=diags,
+        )

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -217,6 +217,23 @@ def _node_line(node: dict[str, Any]) -> int:
     return 0
 
 
+#: Single-child wrapper expression nodes to descend through before deciding
+#: whether an initializer is a lone literal — so `42` reads as the literal "42"
+#: while a compound expression is fingerprinted whole.
+_WRAPPER_EXPR_KINDS = frozenset(
+    {
+        "ImplicitCastExpr",
+        "CStyleCastExpr",
+        "CXXStaticCastExpr",
+        "ConstantExpr",
+        "ExprWithCleanups",
+        "ParenExpr",
+        "CXXFunctionalCastExpr",
+        "MaterializeTemporaryExpr",
+    }
+)
+
+
 def _has_body(node: dict[str, Any]) -> bool:
     return any(
         isinstance(c, dict) and c.get("kind") == "CompoundStmt"
@@ -224,45 +241,68 @@ def _has_body(node: dict[str, Any]) -> bool:
     )
 
 
-def _literal_value(node: dict[str, Any]) -> str | None:
-    """First literal value found anywhere under ``node`` (the constexpr value)."""
-    if node.get("kind") in _LITERAL_NODE_KINDS and "value" in node:
-        return str(node["value"])
-    for child in node.get("inner", []):
-        if isinstance(child, dict):
-            found = _literal_value(child)
-            if found is not None:
-                return found
-    return None
+def _unwrap_expr(node: dict[str, Any]) -> dict[str, Any]:
+    """Descend through single-child wrapper expressions (casts, ConstantExpr…)."""
+    cur = node
+    while isinstance(cur, dict) and cur.get("kind") in _WRAPPER_EXPR_KINDS:
+        inner = [c for c in cur.get("inner", []) if isinstance(c, dict)]
+        if len(inner) != 1:
+            break
+        cur = inner[0]
+    return cur
+
+
+def _init_expr(node: dict[str, Any]) -> dict[str, Any] | None:
+    """The initializer expression child of a Var/Parm decl, or ``None``.
+
+    A decl's ``inner`` holds attributes/nested decls plus, last, the initializer
+    expression; pick the last child that is not itself a decl/attribute/comment.
+    """
+    candidates = [
+        c
+        for c in node.get("inner", [])
+        if isinstance(c, dict)
+        and not str(c.get("kind", "")).endswith(("Decl", "Attr", "Comment"))
+    ]
+    return candidates[-1] if candidates else None
+
+
+def _expr_value(node: dict[str, Any]) -> str:
+    """A value string that changes iff the whole initializer expression changes.
+
+    A lone literal (after stripping wrapper casts) keeps its human-readable value
+    (``42``); any compound expression (``1 + 2``, a call, a braced-init) is
+    fingerprinted as a whole, so ``1 + 2`` and ``1 + 3`` are distinguished. The
+    earlier "first literal under the AST" heuristic collapsed them and missed the
+    change (Codex review #339, P2).
+    """
+    core = _unwrap_expr(node)
+    if (
+        isinstance(core, dict)
+        and core.get("kind") in _LITERAL_NODE_KINDS
+        and "value" in core
+    ):
+        return str(core["value"])
+    return _subtree_hash(node)
 
 
 def _default_arg_repr(node: dict[str, Any]) -> str:
     """Normalized default-argument string for a function's parameters.
 
-    A ``ParmVarDecl`` with a default argument carries a ``CXXDefaultArgExpr``-free
-    initializer in its ``inner``; we represent each defaulted parameter as
-    ``name=<value-or-fingerprint>`` so both presence and value changes surface.
+    Each defaulted parameter is rendered ``name=<value-or-fingerprint>`` so both
+    presence and value changes surface. The value covers the *whole* default
+    expression (not just its first literal), so ``x = 1 + 2`` → ``x = 1 + 3`` is
+    detected (Codex review #339, P2).
     """
     parts: list[str] = []
     for child in node.get("inner", []):
         if not isinstance(child, dict) or child.get("kind") != "ParmVarDecl":
             continue
-        init = [
-            g
-            for g in child.get("inner", [])
-            if isinstance(g, dict) and g.get("kind") != "ParmVarDecl"
-        ]
-        if not child.get("init") and not init:
+        init = _init_expr(child)
+        if not child.get("init") and init is None:
             continue
         pname = child.get("name", "")
-        value = None
-        for expr in init:
-            value = _literal_value(expr)
-            if value is not None:
-                break
-        rep = value if value is not None else (
-            _subtree_hash(init[0]) if init else "default"
-        )
+        rep = _expr_value(init) if init is not None else "default"
         parts.append(f"{pname}={rep}")
     return ",".join(parts)
 
@@ -351,7 +391,34 @@ def source_abi_from_clang_ast(
         diagnostics=list(diagnostics or []),
     )
     _walk(ast_root, ctx, tu, scope=[], current_file="")
+    # Record every file that contributed a node, so the per-TU cache (D8)
+    # invalidates on an edit to any transitively included header — not just the
+    # configured public roots (Codex review #339, P1).
+    tu.read_files = sorted(_collect_files(ast_root))
     return tu
+
+
+def _collect_files(node: Any, files: set[str] | None = None) -> set[str]:
+    """Every distinct file path referenced anywhere in the clang AST.
+
+    clang's ``file`` field is sticky (omitted when unchanged from the prior node
+    in source order), so each file it parsed is named at least once at its first
+    contributing node; the set of explicit mentions is the read-file set.
+    """
+    if files is None:
+        files = set()
+    if isinstance(node, dict):
+        loc = node.get("loc")
+        if isinstance(loc, dict):
+            for key in ("file", "expansionLoc", "spellingLoc", "includedFrom"):
+                val = loc.get(key)
+                if isinstance(val, str) and val:
+                    files.add(val)
+                elif isinstance(val, dict) and isinstance(val.get("file"), str):
+                    files.add(val["file"])
+        for child in node.get("inner", []):
+            _collect_files(child, files)
+    return files
 
 
 def _walk(
@@ -485,9 +552,8 @@ def _emit_constexpr(
     if not public:
         return
     name = _qualified(scope, str(node.get("name", "")))
-    value = _literal_value(node)
-    if value is None:
-        value = _subtree_hash(node)
+    init = _init_expr(node)
+    value = _expr_value(init) if init is not None else _subtree_hash(node)
     tu.constexpr_values.append(
         SourceEntity(
             id=_hash("constexpr", name, value),

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -220,6 +220,13 @@ def _canonical(node: Any) -> Any:
     type_obj = node.get("type")
     if isinstance(type_obj, dict) and "qualType" in type_obj:
         out["type"] = type_obj["qualType"]
+    # A DeclRefExpr stores the referenced entity (e.g. another constant) in
+    # ``referencedDecl``; without its name a value change `kOld` -> `kNew` of the
+    # same type would hash identically and the constexpr/default-arg change would
+    # be missed (Codex review #339, P2).
+    ref = node.get("referencedDecl")
+    if isinstance(ref, dict) and ref.get("name"):
+        out["ref"] = ref["name"]
     inner = node.get("inner")
     if isinstance(inner, list):
         out["inner"] = [_canonical(child) for child in inner]
@@ -338,21 +345,25 @@ def _expr_value(node: dict[str, Any]) -> str:
 def _default_arg_repr(node: dict[str, Any]) -> str:
     """Normalized default-argument string for a function's parameters.
 
-    Each defaulted parameter is rendered ``name=<value-or-fingerprint>`` so both
-    presence and value changes surface. The value covers the *whole* default
-    expression (not just its first literal), so ``x = 1 + 2`` → ``x = 1 + 3`` is
-    detected (Codex review #339, P2).
+    Each defaulted parameter is rendered ``p<position>=<value-or-fingerprint>`` so
+    both presence and value changes surface. The *position* (not the parameter
+    name) keys the entry, so a pure parameter rename keeping the same default —
+    ``f(int x = 1)`` → ``f(int y = 1)`` — is not a change (callers that omit the
+    argument get the same value). The value covers the *whole* default expression
+    (not just its first literal), so ``1 + 2`` → ``1 + 3`` is detected (Codex
+    review #339, P2).
     """
     parts: list[str] = []
+    position = -1
     for child in node.get("inner", []):
         if not isinstance(child, dict) or child.get("kind") != "ParmVarDecl":
             continue
+        position += 1
         init = _init_expr(child)
         if not child.get("init") and init is None:
             continue
-        pname = child.get("name", "")
         rep = _expr_value(init) if init is not None else "default"
-        parts.append(f"{pname}={rep}")
+        parts.append(f"p{position}={rep}")
     return ",".join(parts)
 
 

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -607,6 +607,29 @@ def _collect_files(node: Any, files: set[str] | None = None) -> set[str]:
     return files
 
 
+#: C++ access specifiers that hide a member from consumers. A private/protected
+#: member cannot be called or its inline body relied on, so it must stay off the
+#: L4 public surface even when declared in a public header (Codex review #339,
+#: P2). ``""``/``"none"``/``"public"`` mean "no restriction" (free functions,
+#: namespace-scope decls, public members).
+_NON_PUBLIC_ACCESS = frozenset({"private", "protected"})
+
+
+def _is_accessible(access: str) -> bool:
+    """Whether a decl with this C++ member-access is reachable by consumers."""
+    return access not in _NON_PUBLIC_ACCESS
+
+
+def _default_member_access(record: dict[str, Any]) -> str:
+    """Default member access for a record's body before any ``AccessSpecDecl``.
+
+    ``class`` defaults to private; ``struct``/``union`` default to public
+    (clang records this as ``tagUsed``). Determines the access of members that
+    appear before the first explicit ``public:``/``private:`` section.
+    """
+    return "private" if record.get("tagUsed") == "class" else "public"
+
+
 def _walk(
     node: dict[str, Any],
     ctx: _ClassifyContext,
@@ -614,6 +637,7 @@ def _walk(
     *,
     scope: list[str],
     current_file: str,
+    access: str = "public",
 ) -> str:
     """Pre-order traversal that emits public entities, tracking file + scope.
 
@@ -623,24 +647,32 @@ def _walk(
     sibling — otherwise a sibling that omits ``loc.file`` after a nested file
     switch is attributed to the wrong header, flipping public/private
     classification (CodeRabbit review).
+
+    ``access`` is the C++ member access that applies to ``node`` (established by
+    the enclosing record's default + ``AccessSpecDecl`` sections, or carried on
+    the node itself in newer clang). A private/protected member is never emitted
+    and its whole subtree stays non-public, matching the castxml path (Codex
+    review #339, P2).
     """
     if not isinstance(node, dict):
         return current_file
     file = _node_file(node, current_file)
     kind = node.get("kind")
     name = node.get("name", "") or ""
+    accessible = _is_accessible(access)
 
-    if kind in _FUNCTION_NODE_KINDS and name:
+    if kind in _FUNCTION_NODE_KINDS and name and accessible:
         _emit_function(node, ctx, tu, scope, file)
     elif kind in _TEMPLATE_NODE_KINDS and name:
         # The template's body is captured whole in its fingerprint; do not
         # descend into the templated pattern, or its inner FunctionDecl/Record
         # would be re-emitted as a duplicate non-template entity.
-        _emit_template(node, ctx, tu, scope, file)
+        if accessible:
+            _emit_template(node, ctx, tu, scope, file)
         return file
-    elif kind == "VarDecl" and name and node.get("constexpr"):
+    elif kind == "VarDecl" and name and node.get("constexpr") and accessible:
         _emit_constexpr(node, ctx, tu, scope, file)
-    elif kind in ("CXXRecordDecl", "EnumDecl") and name:
+    elif kind in ("CXXRecordDecl", "EnumDecl") and name and accessible:
         _emit_type(node, ctx, tu, scope, file)
 
     # Descend, extending the scope name stack for namespaces/records so members
@@ -648,12 +680,34 @@ def _walk(
     child_scope = scope
     if kind in _SCOPE_NODE_KINDS and name:
         child_scope = [*scope, name]
+    # Access applying to this node's children: a private/protected subtree stays
+    # hidden wholesale; a record opens with its tag default; any other context
+    # (namespace, linkage spec, TU) imposes no restriction.
+    if not accessible:
+        running_access = access
+    elif kind == "CXXRecordDecl":
+        running_access = _default_member_access(node)
+    else:
+        running_access = "public"
     for child in node.get("inner", []):
-        if isinstance(child, dict):
-            # Thread the last file seen in each child's subtree forward so the
-            # next sibling inherits it (clang's sticky loc.file), not just the
-            # child's own loc.file.
-            file = _walk(child, ctx, tu, scope=child_scope, current_file=file)
+        if not isinstance(child, dict):
+            continue
+        if accessible and child.get("kind") == "AccessSpecDecl":
+            # `public:` / `private:` / `protected:` switches the running access
+            # for subsequent siblings in this record body.
+            running_access = child.get("access", running_access)
+            continue
+        # Thread the last file seen in each child's subtree forward so the next
+        # sibling inherits it (clang's sticky loc.file). Honor an explicit
+        # per-decl `access` when clang emits one, else the running section access.
+        file = _walk(
+            child,
+            ctx,
+            tu,
+            scope=child_scope,
+            current_file=file,
+            access=child.get("access", running_access),
+        )
     return file
 
 

--- a/abicheck/evidence/source_extractors/clang.py
+++ b/abicheck/evidence/source_extractors/clang.py
@@ -60,6 +60,7 @@ from ._argv import (
     is_msvc_mode,
     pick_compiler_binary,
     replay_extra_flags,
+    resolve_read_files,
     unredact_home,
 )
 from .base import SourceExtractionError
@@ -191,11 +192,15 @@ def build_clang_macro_command(
     compile context as the AST pass so the macro set matches the real build.
     """
     cmd, msvc = _clang_context_args(compile_unit, compiler_binary)
-    # /E + /d1PP? No portable clang-cl spelling for -dD; use the GNU options via
-    # the driver regardless (clang accepts -Xclang for the dump). -P drops line
-    # markers, so we keep them (no -P) to attribute each macro to its file.
-    preprocess = ["/E"] if msvc else ["-E"]
-    return [clang_bin, *cmd, *preprocess, "-dD", "-ferror-limit=0", str(source)]
+    # cl-driver mode ignores -dD; clang-cl's `/d1PP` is the documented "retain
+    # macro definitions in /E mode" flag, so a Windows/clang-cl build still emits
+    # #define directives for macros_from_preprocessor (Codex review #339, P2). We
+    # keep the line markers (no -P / no /EP) to attribute each macro to its file.
+    if msvc:
+        preprocess = ["/E", "/d1PP"]
+    else:
+        preprocess = ["-E", "-dD"]
+    return [clang_bin, *cmd, *preprocess, "-ferror-limit=0", str(source)]
 
 
 def _hash(*parts: str) -> str:
@@ -455,6 +460,29 @@ def _parse_define(rest: str) -> tuple[str, str] | None:
     return name, value
 
 
+def _unfold_continuations(lines: list[str]) -> list[str]:
+    """Join backslash-continued physical lines into single logical lines.
+
+    A multi-line macro (``#define FOO(x) \\`` then its body) is split by
+    ``splitlines()``; without unfolding, only the first physical line — usually
+    ending in ``\\`` — is captured and the rest of the body is dropped, hiding
+    any edit below the first line from ``public_macro_value_changed`` (CodeRabbit
+    review). ``#`` line markers never carry a trailing backslash, so they are
+    unaffected.
+    """
+    out: list[str] = []
+    pending: str | None = None
+    for line in lines:
+        chunk = line[:-1] if line.endswith("\\") else line
+        pending = chunk if pending is None else pending + " " + chunk.lstrip()
+        if not line.endswith("\\"):
+            out.append(pending)
+            pending = None
+    if pending is not None:
+        out.append(pending)
+    return out
+
+
 def macros_from_preprocessor(
     text: str, public_header_roots: list[str]
 ) -> tuple[list[SourceEntity], list[str]]:
@@ -472,7 +500,7 @@ def macros_from_preprocessor(
     ctx = _ClassifyContext(public_header_roots)
     current = ""
     defs: dict[str, tuple[str, str]] = {}  # name -> (value, file)
-    for line in text.splitlines():
+    for line in _unfold_continuations(text.splitlines()):
         marker = _LINE_MARKER_RE.match(line)
         if marker:
             current = marker.group(1)
@@ -540,8 +568,13 @@ def source_abi_from_clang_ast(
     _walk(ast_root, ctx, tu, scope=[], current_file="")
     # Record every file that contributed a node, so the per-TU cache (D8)
     # invalidates on an edit to any transitively included header — not just the
-    # configured public roots (Codex review #339, P1).
-    tu.read_files = sorted(_collect_files(ast_root))
+    # configured public roots (Codex review #339, P1). Resolve to absolute paths
+    # against the TU's build directory: clang emits *relative* paths for headers
+    # found via relative -I, which the cache (running in a different CWD) could
+    # not otherwise read, silently dropping the dependency (Codex review, P2).
+    tu.read_files = resolve_read_files(
+        _collect_files(ast_root), compile_unit.directory
+    )
     return tu
 
 
@@ -575,10 +608,18 @@ def _walk(
     *,
     scope: list[str],
     current_file: str,
-) -> None:
-    """Pre-order traversal that emits public entities, tracking file + scope."""
+) -> str:
+    """Pre-order traversal that emits public entities, tracking file + scope.
+
+    Returns the last file seen anywhere in this node's subtree. clang's
+    ``loc.file`` is sticky (omitted when unchanged from the previous node in
+    source order), so the last file a child's *subtree* saw must flow to the next
+    sibling — otherwise a sibling that omits ``loc.file`` after a nested file
+    switch is attributed to the wrong header, flipping public/private
+    classification (CodeRabbit review).
+    """
     if not isinstance(node, dict):
-        return
+        return current_file
     file = _node_file(node, current_file)
     kind = node.get("kind")
     name = node.get("name", "") or ""
@@ -590,7 +631,7 @@ def _walk(
         # descend into the templated pattern, or its inner FunctionDecl/Record
         # would be re-emitted as a duplicate non-template entity.
         _emit_template(node, ctx, tu, scope, file)
-        return
+        return file
     elif kind == "VarDecl" and name and node.get("constexpr"):
         _emit_constexpr(node, ctx, tu, scope, file)
     elif kind in ("CXXRecordDecl", "EnumDecl") and name:
@@ -603,8 +644,11 @@ def _walk(
         child_scope = [*scope, name]
     for child in node.get("inner", []):
         if isinstance(child, dict):
-            file = _node_file(child, file)
-            _walk(child, ctx, tu, scope=child_scope, current_file=file)
+            # Thread the last file seen in each child's subtree forward so the
+            # next sibling inherits it (clang's sticky loc.file), not just the
+            # child's own loc.file.
+            file = _walk(child, ctx, tu, scope=child_scope, current_file=file)
+    return file
 
 
 def _location(file: str, line: int, origin_label: str) -> SourceLocation:
@@ -866,16 +910,23 @@ class ClangSourceExtractor:
         except SourceExtractionError as exc:
             tu.diagnostics.append(f"macro pass skipped: {exc}")
             return
-        if result.returncode != 0 and not result.stdout.strip():
+        # A non-zero exit means clang stopped on a preprocessing error; it may
+        # still have emitted some markers/defines. Record the partial coverage so
+        # the capability report does not overstate L4 macro coverage, mirroring
+        # the AST pass (CodeRabbit review).
+        if result.returncode != 0:
             tu.diagnostics.append(
-                f"macro pass produced no output (exit {result.returncode})"
+                f"macro pass exited {result.returncode} (partial): "
+                f"{result.stderr[:300]}"
             )
+        if not result.stdout.strip():
             return
         macros, macro_files = macros_from_preprocessor(
             result.stdout, public_header_roots
         )
         tu.macros = macros
         # A header that only defines macros contributes no AST node, so add its
-        # path to the cache dependency set or a macro-only edit would be a stale
-        # hit (Codex review #339, P1).
-        tu.read_files = sorted(set(tu.read_files) | set(macro_files))
+        # path (resolved against the build directory) to the cache dependency set
+        # or a macro-only edit would be a stale hit (Codex review #339, P1/P2).
+        resolved = resolve_read_files(set(macro_files), compile_unit.directory)
+        tu.read_files = sorted(set(tu.read_files) | set(resolved))

--- a/abicheck/evidence/source_replay.py
+++ b/abicheck/evidence/source_replay.py
@@ -48,6 +48,11 @@ from pathlib import Path
 
 from .build_evidence import BuildEvidence, CompileUnit, Target
 from .source_abi import SOURCE_ABI_VERSION, SourceAbiSurface, SourceAbiTu
+from .source_extractors._argv import (
+    is_msvc_mode,
+    pick_compiler_binary,
+    replay_extra_flags,
+)
 from .source_extractors.base import SourceAbiExtractor, SourceExtractionError
 from .source_link import link_source_abi
 
@@ -338,12 +343,31 @@ def compute_tu_cache_key(
         "inc:" + ",".join(compile_unit.include_paths),
         "sysinc:" + ",".join(compile_unit.system_include_paths),
         "flags:" + ",".join(compile_unit.abi_relevant_flags),
+        # The argv-only replay flags the extractor actually carries — forced
+        # includes (`-include`/`-imacros`/`/FI`) and unnormalized include-search
+        # paths (`-iquote`/`-idirafter`/`/I`). These change *what* clang parses but
+        # live in argv, not the structured fields, so without them a compile
+        # command that swaps `-include old.h` for `-include new.h` would reuse a
+        # stale cached dump (Codex review #339, P2).
+        "replay:" + ",".join(_replay_flags_for_key(compile_unit)),
         "roots:" + ",".join(sorted(public_header_roots)),
     ]
     for root in sorted(public_header_roots):
         parts.append(f"hdr:{_norm(root)}:{_digest_path(root)}")
     blob = "\x00".join(parts).encode("utf-8")
     return hashlib.sha256(blob).hexdigest()
+
+
+def _replay_flags_for_key(compile_unit: CompileUnit) -> list[str]:
+    """The exact replay flags an extractor would carry from argv, for the cache key.
+
+    Mirrors :func:`source_extractors._argv.replay_extra_flags` so the key folds in
+    forced-include / include-search options that change the parsed TU but are not
+    captured by the structured ``CompileUnit`` fields (Codex review #339, P2).
+    """
+    cc_bin = pick_compiler_binary(compile_unit, None)
+    cc_id = "msvc" if is_msvc_mode(cc_bin) else "gnu"
+    return replay_extra_flags(compile_unit, [], cc_id)
 
 
 class SourceAbiCache:

--- a/abicheck/evidence/source_replay.py
+++ b/abicheck/evidence/source_replay.py
@@ -217,16 +217,19 @@ def _select_changed(
             seen.add(cu.id)
     if picked:
         return picked
-    # Fail open (ADR-025 D3): a changed *header* we cannot map to any TU — e.g.
-    # compile-DB-only evidence with no Target/header metadata to scope by — must
+    # Fail open (ADR-025 D3): a changed *header* we could not map to any TU must
     # not silently select nothing, or source-only header changes
-    # (macros/defaults/constexpr/inline bodies) vanish from PR-mode replay.
-    # Conservatively replay every TU when a header changed and there is no target
-    # header metadata that could have scoped it.
-    has_target_header_meta = any(
-        t.public_headers or t.private_headers for t in build.targets
-    )
-    if not has_target_header_meta and any(_looks_like_header(c) for c in changed):
+    # (macros/defaults/constexpr/inline bodies) vanish from PR-mode replay. The
+    # include graph is not recorded in BuildEvidence, and a target's
+    # public/private header metadata lists only its *own* headers — not the
+    # transitive private headers it pulls in (e.g. include/detail/config.h
+    # included by a public header but listed on no target). Such a header is
+    # owned by nobody, so scoping by header metadata alone drops it even when
+    # other targets *do* carry header metadata. Conservatively replay every TU
+    # whenever a header changed; the per-TU dump cache (D8) then skips the TUs
+    # whose recorded read_files did not actually change, so the fan-out costs
+    # nothing for unaffected units (Codex review #339, P2).
+    if any(_looks_like_header(c) for c in changed):
         return list(build.compile_units)
     return []
 

--- a/abicheck/evidence/source_replay.py
+++ b/abicheck/evidence/source_replay.py
@@ -185,6 +185,15 @@ def _select_target(build: BuildEvidence, target_id: str) -> list[CompileUnit]:
     return attached or list(build.compile_units)
 
 
+#: C/C++ header extensions used to tell a changed *header* (whose including TUs
+#: we cannot enumerate without a build graph) from a changed source file.
+_HEADER_EXTS = (".h", ".hpp", ".hh", ".hxx", ".h++", ".inc", ".ipp", ".tcc", ".inl")
+
+
+def _looks_like_header(path: str) -> bool:
+    return _norm(path).lower().endswith(_HEADER_EXTS)
+
+
 def _select_changed(
     build: BuildEvidence, changed: frozenset[str]
 ) -> list[CompileUnit]:
@@ -201,7 +210,20 @@ def _select_changed(
         if _path_matches(cu.source, changed) or cu.target_id in owning_targets:
             picked.append(cu)
             seen.add(cu.id)
-    return picked
+    if picked:
+        return picked
+    # Fail open (ADR-025 D3): a changed *header* we cannot map to any TU — e.g.
+    # compile-DB-only evidence with no Target/header metadata to scope by — must
+    # not silently select nothing, or source-only header changes
+    # (macros/defaults/constexpr/inline bodies) vanish from PR-mode replay.
+    # Conservatively replay every TU when a header changed and there is no target
+    # header metadata that could have scoped it.
+    has_target_header_meta = any(
+        t.public_headers or t.private_headers for t in build.targets
+    )
+    if not has_target_header_meta and any(_looks_like_header(c) for c in changed):
+        return list(build.compile_units)
+    return []
 
 
 def public_header_roots_for(build: BuildEvidence, target_id: str = "") -> list[str]:

--- a/abicheck/evidence/source_replay.py
+++ b/abicheck/evidence/source_replay.py
@@ -322,6 +322,12 @@ def compute_tu_cache_key(
         str(schema_version),
         extractor_name,
         extractor_version,
+        # Source *location* (not just content): two distinct TUs with identical
+        # contents must not collide — a relative `#include "local.h"` and
+        # `__FILE__` depend on the file's path, so a content-only key could reuse
+        # another TU's dump and read_files (CodeRabbit review).
+        "src_path:" + source.as_posix(),
+        "cwd:" + _norm(os.path.expanduser(compile_unit.directory or "")),
         compile_unit.standard,
         compile_unit.target_triple,
         compile_unit.sysroot or "",
@@ -374,15 +380,24 @@ class SourceAbiCache:
             return None
         if not isinstance(entry, dict):
             return None
+        # A non-dict deps payload is a malformed entry → miss, never a failure
+        # (CodeRabbit review): keep the "corrupt entry is a miss" contract.
+        deps = entry.get("deps") or {}
+        if not isinstance(deps, dict):
+            return None
         # Re-validate every recorded dependency: a changed/missing included file
         # invalidates the dump even though the preliminary key still matches.
-        for dep_path, dep_hash in (entry.get("deps") or {}).items():
+        for dep_path, dep_hash in deps.items():
             if _dep_digest(dep_path) != dep_hash:
                 return None
         tu_data = entry.get("tu")
         if not isinstance(tu_data, dict):
             return None
-        return SourceAbiTu.from_dict(tu_data)
+        try:
+            return SourceAbiTu.from_dict(tu_data)
+        except (KeyError, TypeError, ValueError):
+            # A structurally bad payload is a miss, not a crash that aborts replay.
+            return None
 
     def put(self, key: str | None, tu: SourceAbiTu) -> None:
         if not key:

--- a/abicheck/evidence/source_replay.py
+++ b/abicheck/evidence/source_replay.py
@@ -1,0 +1,431 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Source ABI replay orchestration: scope selection, per-TU cache, driver (ADR-030 D7, D8).
+
+This is the *phase 7* layer that ties the phase-2 extractors, the phase-3 linker,
+and the phase-4 diff into one runnable pipeline over an ADR-029
+:class:`BuildEvidence` tree, without forcing a full re-parse of every translation
+unit:
+
+- :func:`select_compile_units` implements the D7 replay scopes
+  (``off``/``headers-only``/``changed``/``target``/``full``) — a pure function of
+  the build evidence plus a changed-path set / target id. The user-facing CI
+  evidence modes (ADR-033 D2) map onto these scopes.
+- :class:`SourceAbiCache` implements the D8 per-TU cache. The cache key folds the
+  extractor identity, the source/header *content* hashes, and the normalized
+  compile-context hash, so a TU is re-parsed only when something that could
+  change its dump changed. Invalidation prefers false misses over false hits
+  (ADR-033 D5): when the source content cannot be read the TU is treated as
+  uncacheable and always re-extracted.
+- :func:`run_source_replay` drives extraction over the selected units (through
+  the cache when given), links the per-TU dumps into one
+  :class:`SourceAbiSurface`, and records extractor failures as diagnostics
+  (partial L4 coverage, ADR-028 D7) instead of aborting.
+
+Linking and diffing stay cheap and uncached (ADR-030 D8); only the per-TU dumps
+are cached.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from .build_evidence import BuildEvidence, CompileUnit, Target
+from .source_abi import SOURCE_ABI_VERSION, SourceAbiSurface, SourceAbiTu
+from .source_extractors.base import SourceAbiExtractor, SourceExtractionError
+from .source_link import link_source_abi
+
+#: The ADR-030 D7 replay scopes, in increasing breadth. ``off`` parses nothing;
+#: ``full`` parses every compile unit in the build evidence.
+REPLAY_SCOPES = ("off", "headers-only", "changed", "target", "full")
+
+#: Map the user-facing CI evidence modes (ADR-033 D2) to a replay scope. The CI
+#: mode selects which evidence layers run; internally it sets the replay scope
+#: (ADR-033 D2 mapping table). ``graph-*`` modes reuse the source scopes since
+#: the graph layer (ADR-031) builds on the same L4 facts.
+CI_MODE_TO_SCOPE: dict[str, str] = {
+    "off": "off",
+    "build": "off",
+    "source-changed": "changed",
+    "source-target": "target",
+    "graph-summary": "changed",
+    "graph-full": "target",
+}
+
+
+def scope_for_ci_mode(mode: str) -> str:
+    """Return the ADR-030 replay scope for an ADR-033 CI evidence mode.
+
+    Unknown modes fall back to ``off`` (fail safe: no replay rather than a
+    surprise full parse).
+    """
+    return CI_MODE_TO_SCOPE.get(mode, "off")
+
+
+# -- scope selection (ADR-030 D7) --------------------------------------------
+
+
+def _norm(path: str) -> str:
+    """Normalize a path for cross-source comparison: forward slashes, no ``./``."""
+    p = path.replace("\\", "/")
+    while p.startswith("./"):
+        p = p[2:]
+    return p
+
+
+def _path_matches(candidate: str, changed: frozenset[str]) -> bool:
+    """Whether ``candidate`` refers to one of the ``changed`` paths.
+
+    Build-evidence paths are frequently absolute (``/work/src/foo.cpp``) while a
+    PR's changed-path set is repo-relative (``src/foo.cpp``); match when either
+    is a path-component suffix of the other so the two spellings line up without
+    a false hit on a mere basename collision (``foo.cpp`` vs ``other/foo.cpp``
+    only match when the whole relative tail agrees).
+    """
+    if not candidate:
+        return False
+    c = _norm(candidate)
+    for ch in changed:
+        n = _norm(ch)
+        if c == n or c.endswith("/" + n) or n.endswith("/" + c):
+            return True
+    return False
+
+
+def _target_owns_changed_header(target: Target, changed: frozenset[str]) -> bool:
+    """Whether a target lists a public/private header among the changed paths."""
+    return any(
+        _path_matches(h, changed)
+        for h in (*target.public_headers, *target.private_headers)
+    )
+
+
+def _units_for_target(build: BuildEvidence, target_id: str) -> list[CompileUnit]:
+    return [cu for cu in build.compile_units if cu.target_id == target_id]
+
+
+def select_compile_units(
+    build: BuildEvidence,
+    *,
+    scope: str,
+    changed_paths: Iterable[str] = (),
+    target_id: str = "",
+) -> list[CompileUnit]:
+    """Select which compile units to replay for an ADR-030 D7 ``scope``.
+
+    Pure: a function of the build evidence plus the changed-path set / target id.
+
+    - ``off`` — nothing.
+    - ``headers-only`` — a representative subset for fast public-API coverage:
+      the first compile unit (by id) of each target that declares public
+      headers. Falls back to every unit when no target carries public headers
+      (no build graph to scope by). This trades completeness for speed; a TU
+      that includes the public headers yields their declarations regardless of
+      which TU it is.
+    - ``changed`` — units whose source is a changed path, unioned with every unit
+      of any target that owns a changed header (a header edit can change the ABI
+      of every TU that includes it). PR mode (ADR-025 changed-path signal).
+    - ``target`` — units of ``target_id`` (release-baseline mode). When no target
+      is given, every unit attached to some target, falling back to all units.
+    - ``full`` — every compile unit (nightly/deep mode).
+    """
+    if scope not in REPLAY_SCOPES:
+        raise ValueError(
+            f"unknown replay scope {scope!r}; expected one of {REPLAY_SCOPES}"
+        )
+    units = build.compile_units
+    if scope == "off":
+        return []
+    if scope == "full":
+        return list(units)
+    if scope == "headers-only":
+        return _select_headers_only(build)
+    if scope == "target":
+        return _select_target(build, target_id)
+    return _select_changed(build, frozenset(changed_paths))
+
+
+def _select_headers_only(build: BuildEvidence) -> list[CompileUnit]:
+    by_target: dict[str, list[CompileUnit]] = {}
+    for cu in build.compile_units:
+        by_target.setdefault(cu.target_id, []).append(cu)
+    targets_with_headers = {t.id for t in build.targets if t.public_headers}
+    picked: list[CompileUnit] = []
+    for tid in sorted(targets_with_headers):
+        group = sorted(by_target.get(tid, []), key=lambda c: c.id)
+        if group:
+            picked.append(group[0])
+    # No target declares public headers (or none of them own a compile unit):
+    # there is nothing to scope by, so fall back to a full parse rather than
+    # silently producing an empty surface.
+    return picked or list(build.compile_units)
+
+
+def _select_target(build: BuildEvidence, target_id: str) -> list[CompileUnit]:
+    if target_id:
+        return _units_for_target(build, target_id)
+    target_ids = {t.id for t in build.targets}
+    attached = [cu for cu in build.compile_units if cu.target_id in target_ids]
+    return attached or list(build.compile_units)
+
+
+def _select_changed(
+    build: BuildEvidence, changed: frozenset[str]
+) -> list[CompileUnit]:
+    if not changed:
+        return []
+    owning_targets = {
+        t.id for t in build.targets if _target_owns_changed_header(t, changed)
+    }
+    picked: list[CompileUnit] = []
+    seen: set[str] = set()
+    for cu in build.compile_units:
+        if cu.id in seen:
+            continue
+        if _path_matches(cu.source, changed) or cu.target_id in owning_targets:
+            picked.append(cu)
+            seen.add(cu.id)
+    return picked
+
+
+def public_header_roots_for(build: BuildEvidence, target_id: str = "") -> list[str]:
+    """Collect the public-header set from the build targets (D5 linker input).
+
+    Restricted to ``target_id`` when given, else the union across all targets.
+    De-duplicated and sorted for determinism.
+    """
+    roots: set[str] = set()
+    for target in build.targets:
+        if target_id and target.id != target_id:
+            continue
+        roots.update(target.public_headers)
+    return sorted(roots)
+
+
+# -- per-TU cache (ADR-030 D8) -----------------------------------------------
+
+
+def _resolve_source(compile_unit: CompileUnit) -> Path | None:
+    """Best-effort absolute path to a compile unit's source on disk.
+
+    Expands a leading ``~`` home placeholder (the evidence redaction policy,
+    ADR-032 D7) and joins a relative source against the unit's ``directory``.
+    Returns ``None`` when the resolved path does not point at a readable file —
+    the caller then treats the TU as uncacheable (prefer a false miss, D8).
+    """
+    raw = os.path.expanduser(compile_unit.source) if compile_unit.source else ""
+    if not raw:
+        return None
+    path = Path(raw)
+    if not path.is_absolute() and compile_unit.directory:
+        path = Path(os.path.expanduser(compile_unit.directory)) / path
+    return path if path.is_file() else None
+
+
+def _digest_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _digest_path(raw: str) -> str:
+    """Content digest of a header root, whether it is a file or a directory.
+
+    A directory root folds in every contained file's path+content so adding,
+    removing, or editing any header under it invalidates the key. An
+    unreadable/missing root contributes only its (redacted) path string, so two
+    runs that both cannot see it still agree — it is the *source* being
+    unreadable, handled separately, that makes a TU uncacheable.
+    """
+    expanded = os.path.expanduser(raw) if raw else ""
+    p = Path(expanded) if expanded else None
+    if p and p.is_file():
+        return _digest_file(p)
+    if p and p.is_dir():
+        h = hashlib.sha256()
+        for child in sorted(p.rglob("*")):
+            if child.is_file():
+                h.update(child.as_posix().encode("utf-8"))
+                h.update(_digest_file(child).encode("utf-8"))
+        return h.hexdigest()
+    return "path:" + _norm(raw)
+
+
+def compute_tu_cache_key(
+    *,
+    extractor_name: str,
+    extractor_version: str,
+    compile_unit: CompileUnit,
+    public_header_roots: Sequence[str],
+    schema_version: int = SOURCE_ABI_VERSION,
+) -> str | None:
+    """Compute the D8 per-TU cache key, or ``None`` if the TU is uncacheable.
+
+    Folds the extractor identity/version, the source-file content hash, each
+    public-header-root content hash, the normalized compile-context hash, the
+    public-header root set, language standard / target / sysroot, and the source
+    schema version — exactly the D8 inputs. Returns ``None`` when the source
+    content cannot be read, so the driver re-extracts rather than risk a false
+    cache hit on stale content (ADR-033 D5).
+    """
+    source = _resolve_source(compile_unit)
+    if source is None:
+        return None
+    parts = [
+        "abicheck-source-abi-cache",
+        str(schema_version),
+        extractor_name,
+        extractor_version,
+        compile_unit.standard,
+        compile_unit.target_triple,
+        compile_unit.sysroot or "",
+        compile_unit.language,
+        "src:" + _digest_file(source),
+        "defs:" + ",".join(f"{k}={v}" for k, v in sorted(compile_unit.defines.items())),
+        "undefs:" + ",".join(sorted(compile_unit.undefines)),
+        "inc:" + ",".join(compile_unit.include_paths),
+        "sysinc:" + ",".join(compile_unit.system_include_paths),
+        "flags:" + ",".join(compile_unit.abi_relevant_flags),
+        "roots:" + ",".join(sorted(public_header_roots)),
+    ]
+    for root in sorted(public_header_roots):
+        parts.append(f"hdr:{_norm(root)}:{_digest_path(root)}")
+    blob = "\x00".join(parts).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+class SourceAbiCache:
+    """A content-addressed on-disk cache of per-TU :class:`SourceAbiTu` dumps (D8).
+
+    Keys come from :func:`compute_tu_cache_key`; values are the normalized dump
+    JSON. The cache is intentionally dumb — parsing is the expensive step, so a
+    plain keyed file store is enough, and linking is recomputed each run.
+    """
+
+    def __init__(self, cache_dir: Path | str) -> None:
+        self.cache_dir = Path(cache_dir)
+
+    def _path(self, key: str) -> Path:
+        return self.cache_dir / f"{key}.json"
+
+    def get(self, key: str | None) -> SourceAbiTu | None:
+        if not key:
+            return None
+        path = self._path(key)
+        if not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            # A corrupt/half-written cache entry is a miss, never a failure.
+            return None
+        return SourceAbiTu.from_dict(data)
+
+    def put(self, key: str | None, tu: SourceAbiTu) -> None:
+        if not key:
+            return
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        tmp = self._path(key).with_suffix(".json.tmp")
+        tmp.write_text(
+            json.dumps(tu.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        # Atomic publish so a concurrent reader never sees a partial file.
+        tmp.replace(self._path(key))
+
+
+# -- replay driver -----------------------------------------------------------
+
+
+def run_source_replay(
+    build: BuildEvidence,
+    extractor: SourceAbiExtractor,
+    *,
+    scope: str = "target",
+    changed_paths: Iterable[str] = (),
+    target_id: str = "",
+    library: str = "",
+    exported_symbols: Iterable[str] = (),
+    public_header_roots: Sequence[str] | None = None,
+    forced_public: Iterable[str] = (),
+    cache: SourceAbiCache | None = None,
+) -> tuple[SourceAbiSurface, list[str]]:
+    """Run source ABI replay over a build tree and return the linked surface.
+
+    Drives ``extractor`` over the units selected for ``scope`` (D7), routing each
+    through ``cache`` when given (D8), links the per-TU dumps against the library's
+    exported symbols and public-header set (D5), and returns
+    ``(surface, diagnostics)``. Per-TU extractor failures are recorded as
+    diagnostics — partial L4 coverage (ADR-028 D7) — and never abort the run.
+
+    An empty selection (e.g. ``scope='off'`` or a ``changed`` scope with no
+    matching paths) yields an empty surface and no diagnostics.
+    """
+    roots = (
+        list(public_header_roots)
+        if public_header_roots is not None
+        else public_header_roots_for(build, target_id)
+    )
+    units = select_compile_units(
+        build, scope=scope, changed_paths=changed_paths, target_id=target_id
+    )
+    tus: list[SourceAbiTu] = []
+    diagnostics: list[str] = []
+    for cu in units:
+        key = (
+            compute_tu_cache_key(
+                extractor_name=getattr(extractor, "name", "source"),
+                extractor_version=_extractor_version(extractor),
+                compile_unit=cu,
+                public_header_roots=roots,
+            )
+            if cache is not None
+            else None
+        )
+        tu = cache.get(key) if cache is not None else None
+        if tu is None:
+            try:
+                tu = extractor.extract(
+                    cu, public_header_roots=roots, target_id=target_id
+                )
+            except SourceExtractionError as exc:
+                diagnostics.append(f"{cu.source or cu.id}: {exc}")
+                continue
+            if cache is not None:
+                cache.put(key, tu)
+        tus.append(tu)
+
+    surface = link_source_abi(
+        tus,
+        exported_symbols=exported_symbols,
+        library=library,
+        target_id=target_id,
+        forced_public=forced_public,
+    )
+    surface.coverage["replay_scope"] = scope
+    surface.coverage["compile_units_selected"] = len(units)
+    surface.coverage["compile_units_parsed"] = len(tus)
+    surface.coverage["extractor_failures"] = len(diagnostics)
+    return surface, diagnostics
+
+
+def _extractor_version(extractor: SourceAbiExtractor) -> str:
+    """Pull a version string off an extractor for the cache key, if it exposes one."""
+    return str(getattr(extractor, "version", "") or "")

--- a/abicheck/evidence/source_replay.py
+++ b/abicheck/evidence/source_replay.py
@@ -282,9 +282,15 @@ def compute_tu_cache_key(
     Folds the extractor identity/version, the source-file content hash, each
     public-header-root content hash, the normalized compile-context hash, the
     public-header root set, language standard / target / sysroot, and the source
-    schema version — exactly the D8 inputs. Returns ``None`` when the source
-    content cannot be read, so the driver re-extracts rather than risk a false
-    cache hit on stale content (ADR-033 D5).
+    schema version. Returns ``None`` when the source content cannot be read, so
+    the driver re-extracts rather than risk a false cache hit on stale content
+    (ADR-033 D5).
+
+    This is the *preliminary* key: it cannot see a TU's transitively included
+    private/forced headers before parsing. :class:`SourceAbiCache` closes that gap
+    by additionally re-validating the content hashes of every file the extractor
+    recorded reading (``SourceAbiTu.read_files``), so the full D8 "transitive
+    included … header hashes" requirement is met across key + dependency check.
     """
     source = _resolve_source(compile_unit)
     if source is None:
@@ -315,9 +321,16 @@ def compute_tu_cache_key(
 class SourceAbiCache:
     """A content-addressed on-disk cache of per-TU :class:`SourceAbiTu` dumps (D8).
 
-    Keys come from :func:`compute_tu_cache_key`; values are the normalized dump
-    JSON. The cache is intentionally dumb — parsing is the expensive step, so a
-    plain keyed file store is enough, and linking is recomputed each run.
+    Keys come from :func:`compute_tu_cache_key` (source + roots + compile context).
+    Because that key cannot see a TU's *transitive* private/forced includes before
+    parsing, each entry also stores a **dependency map** — the content hash of
+    every file the extractor actually read (`SourceAbiTu.read_files`). On lookup
+    those hashes are re-validated, so an edit to any included header — not just a
+    configured public root — is a cache miss and forces re-extraction (Codex
+    review #339, P1; ADR-030 D8 "transitive included … header hashes"). A
+    missing/unreadable dependency also misses (prefer a false miss over a false
+    hit, ADR-033 D5). Parsing is the expensive step, so linking is still
+    recomputed each run rather than cached.
     """
 
     def __init__(self, cache_dir: Path | str) -> None:
@@ -333,22 +346,52 @@ class SourceAbiCache:
         if not path.is_file():
             return None
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            entry = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             # A corrupt/half-written cache entry is a miss, never a failure.
             return None
-        return SourceAbiTu.from_dict(data)
+        if not isinstance(entry, dict):
+            return None
+        # Re-validate every recorded dependency: a changed/missing included file
+        # invalidates the dump even though the preliminary key still matches.
+        for dep_path, dep_hash in (entry.get("deps") or {}).items():
+            if _dep_digest(dep_path) != dep_hash:
+                return None
+        tu_data = entry.get("tu")
+        if not isinstance(tu_data, dict):
+            return None
+        return SourceAbiTu.from_dict(tu_data)
 
     def put(self, key: str | None, tu: SourceAbiTu) -> None:
         if not key:
             return
+        deps: dict[str, str] = {}
+        for dep_path in tu.read_files:
+            digest = _dep_digest(dep_path)
+            if digest is not None:
+                deps[dep_path] = digest
+        entry = {"tu": tu.to_dict(), "deps": deps}
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         tmp = self._path(key).with_suffix(".json.tmp")
         tmp.write_text(
-            json.dumps(tu.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            json.dumps(entry, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         # Atomic publish so a concurrent reader never sees a partial file.
         tmp.replace(self._path(key))
+
+
+def _dep_digest(path: str) -> str | None:
+    """Content digest of a dependency file, or ``None`` if it cannot be read.
+
+    A ``None`` (missing/unreadable) dependency makes the entry miss on lookup —
+    preferring a false miss over a false hit (ADR-033 D5)."""
+    try:
+        fp = Path(os.path.expanduser(path)) if path else None
+        if fp is None or not fp.is_file():
+            return None
+        return _digest_file(fp)
+    except OSError:
+        return None
 
 
 # -- replay driver -----------------------------------------------------------

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -35,11 +35,19 @@ unless an artifact diff also proves the break. They flow through the normal
 | **L4** | per-TU source ABI replay | Source-visible ABI/API facts | API/source-risk evidence; never sole shipped-ABI authority |
 | **L5** | Clang/Kythe/CodeQL graph summaries | Include/type/call/build reasoning | Explanation, localization, impact |
 
-L3 is implemented today (ADR-029). L4's schema, linker, source-replay diff, and
-the **castxml** per-TU extractor are implemented (ADR-030 phases 1–4 — see
-[L4 findings](#source-abi-replay-findings-l4)); the Clang and Android extractors
-(for inline/template body fingerprints) are the remaining ADR-030 work. L5 is
-planned (ADR-031).
+L3 and L4 are implemented today (ADR-029, ADR-030). L4 ships three extractor
+backends — **clang** (the source-based default: inline/template/constexpr body
+fingerprints + default arguments), **castxml** (declarations/types/const values),
+and an **Android** header-checker adapter — plus the linker, source-replay diff,
+replay scopes, and per-TU cache (see [L4 findings](#source-abi-replay-findings-l4)).
+L5 is planned (ADR-031).
+
+> **Source ABI replay (L4) requires clang** (or castxml for the declaration
+> subset, or a pre-captured Android dump). It is the one tier gated on a C++
+> front-end. If the tool is missing, abicheck **fails gracefully**: L4 is marked
+> partial, the source-only checks are reported as disabled, and the
+> artifact-backed tiers (L0–L2) remain fully authoritative — the comparison is
+> never aborted.
 
 ## Workflow
 
@@ -62,6 +70,26 @@ abicheck dump build/libfoo.so -H include/ \
 abicheck compare old.abi.json new.abi.json \
   --old-evidence old.evidence/ --new-evidence new.evidence/
 ```
+
+To additionally collect **L4 source ABI replay**, add `--source-abi` (requires
+clang). The replay scope (ADR-030 D7) decides how many translation units are
+parsed:
+
+```bash
+abicheck collect-evidence \
+  --compile-db build/compile_commands.json \
+  --source-abi \
+  --source-abi-extractor clang \          # clang (default) | castxml | android
+  --source-abi-scope target \             # off | headers-only | changed | target | full
+  --source-abi-cache .abicache/source \   # optional per-TU dump cache (ADR-030 D8)
+  --output libfoo.evidence/
+```
+
+- `--source-abi-scope changed --changed-path src/foo.cpp` replays only changed
+  TUs (and TUs of any target whose public header changed) — PR mode.
+- `--source-abi-extractor android --android-dump libfoo.lsdump` reuses a
+  pre-captured Android `header-abi-dumper`/`header-abi-linker` dump instead of
+  running a compiler.
 
 `collect-evidence` accepts:
 
@@ -147,13 +175,36 @@ Evidence coverage:
   L1 debug info              present, high confidence: DWARF
   L2 public header AST       present, high confidence: header-scoped
   L3 build context           present, high confidence: cmake+ninja, 142 compile units, 1 target
-  L4 source ABI replay       not_collected
+  L4 source ABI replay       present, high confidence: clang extractor, scope=target, parsed 142/142 TUs
   L5 source graph summary    not_collected
 ```
 
 The same rows are emitted as a structured `evidence_coverage` array in the
 `--format json` report (schema `report_schema_version` 1.2+), so machine
 consumers can key off layer status and confidence.
+
+### What is being checked — and what is not, and why
+
+Right below the coverage table, every pack-aware compare prints a **capability
+report** that translates the available evidence into the concrete *check
+categories* it enables — and, for each disabled category, the precise reason.
+This makes the cumulative picture explicit as you add inputs (binary → +debug
+info → +headers → +build data → +sources):
+
+```text
+Checks enabled for this scan (and why others are not):
+  [on]  Symbol presence & linkage (added/removed/SONAME) — from the binary's dynamic symbol table
+  [on]  Type layout, members, vtables, signatures — from DWARF/PDB debug info
+  [on]  API decls absent from the symbol table; public-surface scoping — from the public header AST
+  [on]  Build-flag & toolchain drift (visibility, std, ABI flags) — from build-system data
+  [off] Macros, default args, inline/template/constexpr bodies — no sources/clang: source-only API changes are not detected
+  [off] Impact / call / reachability graph — no graph evidence: cross-symbol impact is not analyzed
+```
+
+Each category is gated on exactly one evidence layer, so a `[off]` line tells you
+exactly which input (or tool) to add to enable it — e.g. installing clang and
+passing `--source-abi` turns on the macro / default-argument / inline-body /
+template-body / constexpr checks.
 
 ### Header parse context
 

--- a/docs/development/adr/030-source-abi-replay-and-linked-source-surface.md
+++ b/docs/development/adr/030-source-abi-replay-and-linked-source-surface.md
@@ -1,7 +1,7 @@
 # ADR-030: Source ABI Replay and Linked Source Surface
 
 **Date:** 2026-06-09
-**Status:** Accepted — partially implemented (phases 1–4)
+**Status:** Accepted — implemented (phases 1–7)
 **Decision maker:** Nikolay Petrov
 
 ---
@@ -317,7 +317,7 @@ compatibility risk, and feeds the evidence coverage report (ADR-028 D7).
 
 ### Implementation status
 
-Phases 1–4 are implemented, in `abicheck/evidence/`:
+All seven phases are implemented, in `abicheck/evidence/`:
 
 - **Phase 1** — `source_abi.py`: the `SourceAbiTu` (D4) and `SourceAbiSurface`
   (D5) normalized schemas with `to_dict`/`from_dict` round-trips and the
@@ -327,20 +327,49 @@ Phases 1–4 are implemented, in `abicheck/evidence/`:
   (ADR-032) and `CastxmlSourceExtractor`, which parses a translation unit under
   its real per-TU `CompileUnit` build context (D2) and emits a `SourceAbiTu`.
   It reuses the existing castxml XML parser, so no new dependency is added
-  (ADR-001). The context→argv builder and the model→entity mapping are pure and
-  unit-tested; the castxml run itself is integration-marked. castxml covers
-  declarations, types, and public const/constexpr values; inline/template *body*
-  fingerprints await the Clang backend (phase 5, per the D3 table).
+  (ADR-001). castxml covers declarations, types, and public const/constexpr
+  values; inline/template *body* fingerprints are the Clang backend's job
+  (phase 5, per the D3 table).
 - **Phase 3** — `source_link.py` (`link_source_abi`): merges per-TU dumps into a
   per-library surface, mapping public source declarations to exported binary
   symbols and detecting ODR conflicts (D5).
 - **Phase 4** — `source_diff.py` (`diff_source_abi`): the nine D6 `ChangeKind`s,
   partitioned `API_BREAK`/`RISK` per ADR-028 D3 (never `BREAKING`), registered
   in `change_registry.py`.
+- **Phase 5** — `source_extractors/clang.py` (`ClangSourceExtractor`): the
+  *source-based* backend. It parses a TU under its build context with
+  `clang -Xclang -ast-dump=json` and derives the fingerprints castxml cannot —
+  inline function bodies, function/class **template** bodies, `constexpr` values,
+  and default arguments. **Source ABI replay requires clang**; when it is absent
+  the extractor raises `SourceExtractionError`, recorded as *partial* L4 coverage
+  (ADR-028 D7) — the artifact tiers stay authoritative and the comparison never
+  aborts. No new Python dependency (ADR-001): clang is an optional runtime tool,
+  discovered like castxml. For a GCC-built project clang replays the GCC build's
+  flags (a TU using a GCC-only extension clang rejects degrades to partial
+  coverage). The argv builder and the JSON-AST→`SourceAbiTu` mapping are pure and
+  unit-tested; only the clang run is integration-marked. Shared compile-context →
+  argv logic lives in `source_extractors/_argv.py`, reused by both castxml and
+  clang.
+- **Phase 6** — `source_extractors/android.py` (`AndroidHeaderAbiAdapter`):
+  reuses Android's VNDK header-checker `.sdump`/`.lsdump` output as an L4 backend,
+  normalized into the abicheck `SourceAbiTu` (D9). Default behaviour consumes a
+  *pre-captured* dump (non-executing, ADR-028 D6); running `header-abi-dumper` is
+  opt-in (ADR-032 D5). Raw dumps are not the stable contract.
+- **Phase 7** — `source_replay.py`: the `off`/`headers-only`/`changed`/`target`/
+  `full` replay scopes (D7) as a pure `select_compile_units`, the per-TU
+  `SourceAbiCache` keyed on the D8 inputs (extractor identity, source + header
+  *content* hashes, normalized compile context; uncacheable → re-extract, ADR-033
+  D5), and the `run_source_replay` driver that ties extraction → linking →
+  partial-coverage diagnostics together. `scope_for_ci_mode` maps the ADR-033 D2
+  CI modes onto these scopes.
 
-Remaining: the Clang LibTooling dumper (phase 5, for inline/template/constexpr
-body fingerprints), the Android `header-abi-dumper` adapter (phase 6), and PR
-changed-mode scoping + per-TU caching (phase 7).
+The pipeline is wired into the CLI: `collect-evidence --source-abi
+[--source-abi-extractor clang|castxml|android] [--source-abi-scope ...]` writes
+`source/source_abi.json`, and `compare --old/--new-evidence` diffs the two
+surfaces (`diff_source_abi`) and folds the findings into the verdict pipeline.
+The compare output prints an explicit **capability report** — which check
+categories are enabled and, for each disabled one, why (no binary / no debug
+info / no headers / no build data / no sources-or-clang).
 
 ---
 

--- a/docs/development/adr/030-source-abi-replay-and-linked-source-surface.md
+++ b/docs/development/adr/030-source-abi-replay-and-linked-source-surface.md
@@ -371,6 +371,47 @@ The compare output prints an explicit **capability report** — which check
 categories are enabled and, for each disabled one, why (no binary / no debug
 info / no headers / no build data / no sources-or-clang).
 
+### Known limitations / follow-ups
+
+The phases above are implemented and wired, but the following are deliberately
+deferred and should be handled in later work. None of them weaken the authority
+rule (L4 never gates a shipped-ABI `BREAKING` verdict on its own, ADR-028 D3);
+they are coverage/precision gaps, not correctness holes.
+
+1. **Validation corpus not yet committed.** The "Validation" section below calls
+   for an `examples/case*` fixture corpus (public macro / default-argument /
+   inline / template / constexpr changes, extending the ADR-026 `case122`
+   calibration fixture), an L4-vs-L2 declaration/type-shape agreement check, an
+   L4-vs-L0 exported-symbol cross-check, and performance tests for the `changed`
+   and `target` scopes. The behaviours are covered by unit + integration tests,
+   but the ground-truth example cases and perf benchmarks are still to be added.
+2. **Macros are clang-only.** `public_macro_value_changed` is produced only by
+   the clang backend's `-E -dD` preprocessor pass. The castxml and Android
+   backends do not extract macros, so a macros-only run on those backends has no
+   macro coverage. Include-guard macros (`#ifndef FOO_H`) also surface as
+   (harmless, empty-valued) macro entities — a small-noise source a future filter
+   could suppress.
+3. **Typedef / alias entities are not modeled by clang.** The clang backend emits
+   `record`/`enum` types but not `TypedefDecl`/`TypeAliasDecl`; castxml omits
+   typedefs entirely (no per-entry provenance, see `castxml.py`). A public
+   typedef whose underlying type changes is therefore not surfaced as an L4
+   finding. Add provenance-aware typedef extraction (clang is the natural home).
+4. **Scope selection is approximate without a full include graph.** `headers-only`
+   picks one representative compile unit per target rather than the minimal set
+   that covers every public header, and `changed` maps a changed header to TUs
+   via target ownership (falling back to all TUs when there is no target/header
+   metadata, ADR-025 D3). A precise mapping needs a per-TU include graph
+   (depfiles or the L5 graph layer, ADR-031).
+5. **Inline auto-collection during `compare --evidence-mode` is still a stub.**
+   `compare` consumes pre-built packs via `--old/--new-evidence`; it does not yet
+   run `collect-evidence` inline for a requested evidence mode. That inline
+   collection is **ADR-033 D2** scope, tracked there, not in this ADR.
+6. **clang AST replay is a structural fingerprinter, not a full semantic ABI
+   model.** Bodies/values are hashed from a build-root-stable canonical form of
+   the clang JSON AST; this reliably detects *changes* but does not produce a
+   semantic ABI diff of the body itself. The Clang LibTooling backend in the D3
+   table remains the longer-term path for richer source-location/AST fidelity.
+
 ---
 
 ## Validation

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -301,3 +301,93 @@ def test_compare_source_abi_findings_and_capabilities(tmp_path):
     assert "[off]" in result.stderr
     # Macros/default-args/bodies row references its source/clang requirement.
     assert "inline/template/constexpr" in result.stderr
+
+
+def _fake_clang_extractor():
+    """A drop-in ClangSourceExtractor replacement that needs no real clang."""
+    from abicheck.evidence.source_abi import SourceAbiTu, SourceEntity, SourceLocation
+
+    class _Fake:
+        name = "clang-source"
+        version = "0.1"
+
+        def __init__(self, **kw):
+            pass
+
+        def available(self):
+            return True
+
+        def extract(self, cu, *, public_header_roots, target_id=""):
+            ent = SourceEntity(
+                id="e", kind="function", qualified_name="add",
+                mangled_name="_Z3addi", signature_hash="sig", value="p0=1",
+                source_location=SourceLocation(path="include/foo.h", origin="PUBLIC_HEADER"),
+                visibility="public_header", api_relevant=True,
+            )
+            return SourceAbiTu(
+                tu_id=cu.id, source=cu.source,
+                public_header_roots=list(public_header_roots), functions=[ent],
+            )
+
+    return _Fake
+
+
+def test_collect_evidence_source_abi_success(tmp_path, monkeypatch):
+    """The clang collection path writes a populated L4 surface and PRESENT row."""
+    import abicheck.evidence.source_extractors as se
+    monkeypatch.setattr(se, "ClangSourceExtractor", _fake_clang_extractor())
+
+    cdb = _write_cdb(tmp_path, "c++17")
+    out = tmp_path / "ev"
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--compile-db", str(cdb),
+        "--source-abi", "--source-abi-scope", "full",
+        "--source-abi-cache", str(tmp_path / "cache"),
+        "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    assert "L4 source ABI replay: clang extractor" in result.output
+    pack = EvidencePack.load(out)
+    assert pack.source_abi is not None
+    assert any(e.qualified_name == "add" for e in pack.source_abi.reachable_declarations)
+    cov = pack.manifest.coverage_for("L4_source_abi")
+    assert cov is not None and cov.status.value == "present"
+
+
+def test_collect_evidence_source_abi_castxml_unavailable(tmp_path):
+    """The castxml backend degrades gracefully when castxml is absent."""
+    cdb = _write_cdb(tmp_path, "c++17")
+    out = tmp_path / "ev"
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--compile-db", str(cdb),
+        "--source-abi", "--source-abi-extractor", "castxml",
+        "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    # Either castxml ran (present) or it was unavailable (graceful) — both fine,
+    # but the run must not crash and must record an L4 row.
+    pack = EvidencePack.load(out)
+    cov = pack.manifest.coverage_for("L4_source_abi")
+    assert cov is not None and cov.status.value in ("present", "partial")
+
+
+def test_collect_evidence_source_abi_without_compile_units(tmp_path):
+    """--source-abi with no L3 build context reports the missing prerequisite."""
+    out = tmp_path / "ev"
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--source-abi", "--source-abi-extractor", "clang",
+        "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    assert "no L3 build context" in result.output
+
+
+def test_exported_symbols_from_binary_edge_cases(tmp_path):
+    from pathlib import Path
+
+    from abicheck.cli_evidence import _exported_symbols_from_binary
+    assert _exported_symbols_from_binary(None) == []
+    assert _exported_symbols_from_binary(Path(tmp_path / "missing")) == []
+    junk = tmp_path / "x.txt"
+    junk.write_text("not a binary")
+    assert _exported_symbols_from_binary(junk) == []

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -294,8 +294,17 @@ def test_compare_source_abi_findings_and_capabilities(tmp_path):
         "--format", "json",
     ])
     assert result.exit_code in (0, 2, 4), result.output
+    payload = json.loads(result.stdout)
     # The source-replay finding is folded into the verdict pipeline.
     assert "default_argument_changed" in result.stdout.lower()
+    # Authority rule (ADR-028 D3): a source-only L4 finding with no artifact-backed
+    # break must NOT escalate to a breaking verdict — it stays API/source-level.
+    assert payload["verdict"] != "breaking"
+    kinds = {f.get("kind") for f in payload.get("changes", [])}
+    assert "default_argument_changed" in kinds
+    # And the L4 finding is partitioned as an API break, never a BREAKING kind.
+    from abicheck.checker_policy import BREAKING_KINDS, ChangeKind
+    assert ChangeKind.DEFAULT_ARGUMENT_CHANGED not in BREAKING_KINDS
     # The capability report names what is on/off and why.
     assert "Checks enabled for this scan" in result.stderr
     assert "[off]" in result.stderr

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -205,3 +205,99 @@ def test_compare_without_evidence_is_unchanged(tmp_path):
     result = CliRunner().invoke(main, ["compare", str(old_snap), str(new_snap)])
     assert result.exit_code == 0, result.output
     assert "Evidence coverage:" not in result.stderr
+
+
+# -- L4 source ABI replay (ADR-030 phases 5-7 + CLI wiring) ------------------
+
+
+def test_collect_evidence_source_abi_graceful_without_tool(tmp_path):
+    """Source ABI replay degrades gracefully when the tool is missing.
+
+    The user message must be explicit that clang is required and that source-only
+    checks are disabled (never abort the collection).
+    """
+    cdb = _write_cdb(tmp_path, "c++17")
+    out = tmp_path / "ev"
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--compile-db", str(cdb),
+        "--source-abi", "--source-abi-scope", "full",
+        "--clang-bin", "clang-definitely-not-installed-xyz",
+        "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    assert "source-only checks disabled" in result.output
+    pack = EvidencePack.load(out)
+    cov = pack.manifest.coverage_for("L4_source_abi")
+    # Replay ran but the tool was absent → partial, not present (and not silent).
+    assert cov is not None and cov.status.value == "partial"
+
+
+def test_collect_evidence_source_abi_android_dump(tmp_path):
+    """The Android backend normalizes a pre-captured dump into the pack (D9)."""
+    dump = tmp_path / "libfoo.lsdump"
+    dump.write_text(json.dumps({
+        "source_file": "include/foo.h",
+        "functions": [{"function_name": "foo", "linker_set_key": "_Z3foov", "return_type": "void"}],
+        "record_types": [{"name": "Foo", "size": 8, "source_file": "include/foo.h"}],
+    }))
+    out = tmp_path / "ev"
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--source-abi", "--source-abi-extractor", "android",
+        "--android-dump", str(dump), "-o", str(out),
+    ])
+    assert result.exit_code == 0, result.output
+    pack = EvidencePack.load(out)
+    assert pack.source_abi is not None
+    assert any(e.qualified_name == "Foo" for e in pack.source_abi.reachable_types)
+    cov = pack.manifest.coverage_for("L4_source_abi")
+    assert cov is not None and cov.status.value == "present"
+
+
+def test_collect_evidence_android_requires_dump(tmp_path):
+    result = CliRunner().invoke(main, [
+        "collect-evidence", "--source-abi", "--source-abi-extractor", "android",
+        "-o", str(tmp_path / "ev"),
+    ])
+    assert result.exit_code != 0
+    assert "requires --android-dump" in result.output
+
+
+def _ev_with_default_arg(tmp_path, name, default):
+    """Write an evidence pack whose L4 surface has one function with a default arg."""
+    from abicheck.evidence.source_abi import SourceAbiTu, SourceEntity, SourceLocation
+    from abicheck.evidence.source_link import link_source_abi
+
+    ent = SourceEntity(
+        id="id", kind="function", qualified_name="add", mangled_name="_Z3addii",
+        signature_hash="sig", value=default,
+        source_location=SourceLocation(path="include/foo.h", origin="PUBLIC_HEADER"),
+        visibility="public_header", api_relevant=True,
+    )
+    tu = SourceAbiTu(tu_id="cu://a", functions=[ent], public_header_roots=["include/foo.h"])
+    pack = EvidencePack.empty(tmp_path / name)
+    pack.source_abi = link_source_abi([tu], library="libfoo.so")
+    pack.write()
+    return tmp_path / name
+
+
+def test_compare_source_abi_findings_and_capabilities(tmp_path):
+    """An L4 default-argument change surfaces as a finding, and the capability
+    report explains which checks ran and which did not (the user's ask)."""
+    ev_old = _ev_with_default_arg(tmp_path, "old.evidence", "x=1")
+    ev_new = _ev_with_default_arg(tmp_path, "new.evidence", "x=2")
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+
+    result = CliRunner().invoke(main, [
+        "compare", str(old_snap), str(new_snap),
+        "--old-evidence", str(ev_old), "--new-evidence", str(ev_new),
+        "--format", "json",
+    ])
+    assert result.exit_code in (0, 2, 4), result.output
+    # The source-replay finding is folded into the verdict pipeline.
+    assert "default_argument_changed" in result.stdout.lower()
+    # The capability report names what is on/off and why.
+    assert "Checks enabled for this scan" in result.stderr
+    assert "[off]" in result.stderr
+    # Macros/default-args/bodies row references its source/clang requirement.
+    assert "inline/template/constexpr" in result.stderr

--- a/tests/test_source_extractors_android.py
+++ b/tests/test_source_extractors_android.py
@@ -119,3 +119,65 @@ def test_run_dumper_requires_tool() -> None:
     assert adapter.available() is False
     with pytest.raises(SourceExtractionError, match="not found in PATH"):
         adapter.run_dumper("foo.h", output="out.sdump")
+
+
+def test_run_dumper_success(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from abicheck.evidence.source_extractors import android as android_mod
+
+    adapter = AndroidHeaderAbiAdapter()
+    monkeypatch.setattr(adapter, "available", lambda: True)
+    out = tmp_path / "o.sdump"
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(cmd, **kw):  # type: ignore[no-untyped-def]
+        # The dumper writes its JSON output to the -o path.
+        assert "-output-format" in cmd and "Json" in cmd
+        out.write_text(json.dumps(_dump()))
+        return _Result()
+
+    monkeypatch.setattr(android_mod.subprocess, "run", fake_run)
+    tu = adapter.run_dumper(
+        tmp_path / "foo.h", output=out, clang_argv=["-std=c++17"], target_id="t"
+    )
+    assert any(e.qualified_name == "Foo" for e in tu.types)
+
+
+def test_run_dumper_failure(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from abicheck.evidence.source_extractors import android as android_mod
+
+    adapter = AndroidHeaderAbiAdapter()
+    monkeypatch.setattr(adapter, "available", lambda: True)
+
+    class _Result:
+        returncode = 2
+        stderr = "dump error"
+        stdout = ""
+
+    monkeypatch.setattr(android_mod.subprocess, "run", lambda cmd, **kw: _Result())
+    with pytest.raises(SourceExtractionError, match="failed"):
+        adapter.run_dumper("foo.h", output=tmp_path / "o.sdump")
+
+
+def test_run_dumper_timeout(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import subprocess as sp
+
+    from abicheck.evidence.source_extractors import android as android_mod
+
+    adapter = AndroidHeaderAbiAdapter(timeout=1)
+    monkeypatch.setattr(adapter, "available", lambda: True)
+
+    def fake_run(cmd, **kw):  # type: ignore[no-untyped-def]
+        raise sp.TimeoutExpired(cmd, 1)
+
+    monkeypatch.setattr(android_mod.subprocess, "run", fake_run)
+    with pytest.raises(SourceExtractionError, match="timed out"):
+        adapter.run_dumper("foo.h", output=tmp_path / "o.sdump")
+
+
+def test_load_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(SourceExtractionError, match="cannot read"):
+        AndroidHeaderAbiAdapter().load(tmp_path / "nope.lsdump")

--- a/tests/test_source_extractors_android.py
+++ b/tests/test_source_extractors_android.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ADR-030 phase-6 Android header-abi adapter.
+
+The normalizer is pure and tested in the fast lane; loading a pre-captured dump
+needs only a JSON file on disk (no Android tools).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from abicheck.evidence.source_abi import SourceAbiTu
+from abicheck.evidence.source_diff import diff_source_abi
+from abicheck.evidence.source_extractors import (
+    AndroidHeaderAbiAdapter,
+    SourceExtractionError,
+    parse_android_dump,
+)
+from abicheck.evidence.source_link import link_source_abi
+
+
+def _dump(record_size: int = 8) -> dict:
+    return {
+        "source_file": "include/foo.h",
+        "record_types": [
+            {
+                "name": "Foo", "size": record_size, "linker_set_key": "_ZTI3Foo",
+                "source_file": "include/foo.h",
+                "fields": [{"field_name": "a", "referenced_type": "int", "field_offset": 0}],
+            }
+        ],
+        "enum_types": [
+            {"name": "E", "enum_fields": [{"name": "A", "enum_field_value": 0}]}
+        ],
+        "functions": [
+            {
+                "function_name": "foo", "linker_set_key": "_Z3foov",
+                "return_type": "void", "parameters": [{"referenced_type": "int"}],
+            }
+        ],
+        "global_vars": [{"name": "g", "linker_set_key": "g", "referenced_type": "int"}],
+    }
+
+
+def test_parse_routes_entities_to_buckets() -> None:
+    tu = parse_android_dump(_dump(), target_id="target://libfoo")
+    assert tu.extractor["name"] == "android-header-abi"
+    assert {(e.qualified_name, e.kind) for e in tu.types} == {("Foo", "record"), ("E", "enum")}
+    assert [(e.qualified_name, e.mangled_name) for e in tu.functions] == [("foo", "_Z3foov")]
+    assert [e.qualified_name for e in tu.variables] == ["g"]
+    # Android emits no inline/template bodies or macros (clang's job, phase 5).
+    assert tu.inline_bodies == [] and tu.templates == [] and tu.macros == []
+    # Round-trips through the normalized schema.
+    assert SourceAbiTu.from_dict(tu.to_dict()).tu_id == tu.tu_id
+
+
+def test_parse_is_defensive_against_missing_keys() -> None:
+    # A sparse/hand-edited dump must never abort the load (forward-compat).
+    tu = parse_android_dump({"record_types": [{}], "functions": [{}]})
+    assert len(tu.types) == 1 and len(tu.functions) == 1
+
+
+def test_record_size_change_detected_end_to_end() -> None:
+    old = link_source_abi([parse_android_dump(_dump(8), target_id="t")])
+    new = link_source_abi([parse_android_dump(_dump(16), target_id="t")])
+    # A record layout change shows up as an odr_source_conflict only across TUs;
+    # here it is the type_hash that differs — assert the surfaces actually differ.
+    old_hash = {e.qualified_name: e.type_hash for e in old.reachable_types}
+    new_hash = {e.qualified_name: e.type_hash for e in new.reachable_types}
+    assert old_hash["Foo"] != new_hash["Foo"]
+    # No spurious findings for an unchanged enum.
+    assert diff_source_abi(old, new) == [] or all(
+        c.symbol != "E" for c in diff_source_abi(old, new)
+    )
+
+
+def test_adapter_load_reads_json_dump(tmp_path: Path) -> None:
+    path = tmp_path / "libfoo.lsdump"
+    path.write_text(json.dumps(_dump()))
+    tu = AndroidHeaderAbiAdapter().load(path, target_id="target://libfoo")
+    assert any(e.qualified_name == "Foo" for e in tu.types)
+    assert tu.source == "include/foo.h"
+
+
+def test_adapter_load_rejects_non_json(tmp_path: Path) -> None:
+    # A raw protobuf .sdump (not produced with -output-format Json) is rejected
+    # with an actionable message rather than a confusing parse error.
+    path = tmp_path / "raw.sdump"
+    path.write_text("\x08\x01 not json")
+    with pytest.raises(SourceExtractionError, match="output-format Json"):
+        AndroidHeaderAbiAdapter().load(path)
+
+
+def test_adapter_load_rejects_non_object(tmp_path: Path) -> None:
+    path = tmp_path / "arr.lsdump"
+    path.write_text("[1, 2, 3]")
+    with pytest.raises(SourceExtractionError, match="JSON object"):
+        AndroidHeaderAbiAdapter().load(path)
+
+
+def test_run_dumper_requires_tool() -> None:
+    adapter = AndroidHeaderAbiAdapter(dumper_bin="header-abi-dumper-nope")
+    assert adapter.available() is False
+    with pytest.raises(SourceExtractionError, match="not found in PATH"):
+        adapter.run_dumper("foo.h", output="out.sdump")

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -579,9 +579,34 @@ def test_macros_from_preprocessor_scopes_to_public_headers() -> None:
     # Public-header macros captured (object- and function-like)...
     assert by_name["FOO_SIZE"] == "16"
     assert by_name["ADD"] == "(a,b) ((a)+(b))"
-    # ...while builtin and system macros are filtered out.
+    # ...while builtin and system macros are filtered out of the *entities*.
     assert "__STDC__" not in by_name and "SYS_ONLY" not in by_name
-    assert files == ["include/foo.h"]
+    # The cache-dependency file list, by contrast, is the *complete* set of real
+    # files the preprocessor read — including the system header that declared
+    # only a non-public macro — so a macro-only private/system header edit
+    # invalidates the dump (Codex #339 P2). The <built-in> pseudo-file is skipped.
+    assert files == ["/usr/include/sys.h", "include/foo.h", "src/foo.cpp"]
+
+
+def test_macros_track_private_macro_only_header_as_cache_dep() -> None:
+    # A private header that defines a macro gating an #if in a public header is
+    # seen only by the preprocessor (no public macro entity, no AST node), but it
+    # must still be a cache dependency so editing it invalidates the dump.
+    from abicheck.evidence.source_extractors import macros_from_preprocessor
+
+    text = (
+        '# 1 "include/api.h" 1\n'
+        '# 1 "include/detail/config.h" 1\n'
+        "#define ENABLE_X 1\n"  # private gating macro — not on the public surface
+        '# 2 "include/api.h" 2\n'
+        "#define API_VERSION 3\n"
+    )
+    macros, files = macros_from_preprocessor(text, ["include/api.h"])
+    names = {e.qualified_name for e in macros}
+    # Private gating macro is filtered out of the entities...
+    assert "ENABLE_X" not in names and "API_VERSION" in names
+    # ...but its header is still tracked as a cache dependency.
+    assert "include/detail/config.h" in files
 
 
 def test_macros_unfold_line_continuations() -> None:

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -232,10 +232,13 @@ def test_ast_constexpr_change_detected_end_to_end() -> None:
 def test_ast_records_read_files_for_cache_deps() -> None:
     # Codex #339 P1: the TU records every file it read so the per-TU cache can
     # invalidate on a transitive-include edit. Both the public and private
-    # headers that contributed nodes appear.
+    # headers that contributed nodes appear. Paths are OS-normalized (backslashes
+    # on Windows), so compare against os.path.normpath.
+    import os
+
     tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "t")
-    assert "include/foo.h" in tu.read_files
-    assert "src/internal.h" in tu.read_files
+    assert os.path.normpath("include/foo.h") in tu.read_files
+    assert os.path.normpath("src/internal.h") in tu.read_files
 
 
 def _constexpr_ast(rhs_literal: str) -> dict:
@@ -377,6 +380,32 @@ def _ctor_ast(default: str, *, with_definition: bool = False) -> dict:
         {"kind": "CXXRecordDecl", "name": "Widget", "loc": {"file": "include/foo.h"},
          "inner": inner},
     ]}
+
+
+def test_implicit_inline_method_body_is_fingerprinted() -> None:
+    # Codex #339 P2: an in-class method definition (CompoundStmt, no `inline`
+    # key) is implicitly inline — a body change must fire inline_body_changed.
+    def ast(retval: str) -> dict:
+        return {"kind": "TranslationUnitDecl", "inner": [{
+            "kind": "CXXRecordDecl", "name": "W", "loc": {"file": "include/foo.h"},
+            "inner": [{
+                "kind": "CXXMethodDecl", "name": "f", "mangledName": "_ZN1W1fEv",
+                "type": {"qualType": "int ()"},
+                # No "inline" key — clang omits it for in-class definitions.
+                "inner": [{"kind": "CompoundStmt", "inner": [{
+                    "kind": "ReturnStmt", "inner": [
+                        {"kind": "IntegerLiteral", "value": retval}]}]}],
+            }],
+        }]}
+
+    old = source_abi_from_clang_ast(ast("1"), _cu(), ["include/foo.h"], "t")
+    new = source_abi_from_clang_ast(ast("2"), _cu(), ["include/foo.h"], "t")
+    assert {e.qualified_name for e in old.inline_bodies} == {"W::f"}
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "inline_body_changed" in kinds
 
 
 def test_constructor_default_argument_change_detected() -> None:

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -305,6 +305,120 @@ def test_default_argument_compound_expression_change_is_detected() -> None:
     assert "default_argument_changed" in kinds
 
 
+def _ctor_ast(default: str, *, with_definition: bool = False) -> dict:
+    """A public ``Widget(int n = <default>)`` constructor decl, optionally also its
+    out-of-line inline definition (which carries no default)."""
+    inner = [
+        {
+            "kind": "CXXConstructorDecl", "name": "Widget", "loc": {"file": "include/foo.h"},
+            "mangledName": "_ZN6WidgetC1Ei", "type": {"qualType": "void (int)"},
+            "inner": [{
+                "kind": "ParmVarDecl", "name": "n", "type": {"qualType": "int"},
+                "init": "c", "inner": [{"kind": "IntegerLiteral", "value": default}],
+            }],
+        }
+    ]
+    if with_definition:
+        inner.append({
+            "kind": "CXXConstructorDecl", "name": "Widget", "loc": {"file": "include/foo.h"},
+            "mangledName": "_ZN6WidgetC1Ei", "type": {"qualType": "void (int)"},
+            "inner": [
+                {"kind": "ParmVarDecl", "name": "n", "type": {"qualType": "int"}},
+                {"kind": "CompoundStmt", "inner": []},
+            ],
+        })
+    return {"kind": "TranslationUnitDecl", "inner": [
+        {"kind": "CXXRecordDecl", "name": "Widget", "loc": {"file": "include/foo.h"},
+         "inner": inner},
+    ]}
+
+
+def test_constructor_default_argument_change_detected() -> None:
+    # Codex #339 P2: a CXXConstructorDecl must route through _emit_function so a
+    # constructor default-argument change is detected (was previously skipped).
+    old = source_abi_from_clang_ast(_ctor_ast("1"), _cu(), ["include/foo.h"], "t")
+    new = source_abi_from_clang_ast(_ctor_ast("2"), _cu(), ["include/foo.h"], "t")
+    assert any("Widget::Widget" in e.qualified_name for e in old.functions)
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "default_argument_changed" in kinds
+
+
+def test_inline_defined_constructor_default_change_not_masked() -> None:
+    # When the header carries both the declaration (with the default) and the
+    # out-of-line inline definition (no default), the value-less definition must
+    # not overwrite the default-bearing declaration in the diff (Codex #339 P2).
+    old = source_abi_from_clang_ast(
+        _ctor_ast("1", with_definition=True), _cu(), ["include/foo.h"], "t"
+    )
+    new = source_abi_from_clang_ast(
+        _ctor_ast("2", with_definition=True), _cu(), ["include/foo.h"], "t"
+    )
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "default_argument_changed" in kinds
+
+
+# -- macro extraction (-E -dD, pure parser) ----------------------------------
+
+
+def test_macros_from_preprocessor_scopes_to_public_headers() -> None:
+    from abicheck.evidence.source_extractors import macros_from_preprocessor
+
+    text = (
+        '# 1 "src/foo.cpp"\n'
+        '# 1 "<built-in>" 1\n'
+        "#define __STDC__ 1\n"
+        '# 1 "include/foo.h" 1\n'
+        "#define FOO_SIZE 16\n"
+        "#define ADD(a,b) ((a)+(b))\n"
+        '# 1 "/usr/include/sys.h" 1\n'
+        "#define SYS_ONLY 9\n"
+    )
+    macros, files = macros_from_preprocessor(text, ["include/foo.h"])
+    by_name = {e.qualified_name: e.value for e in macros}
+    # Public-header macros captured (object- and function-like)...
+    assert by_name["FOO_SIZE"] == "16"
+    assert by_name["ADD"] == "(a,b) ((a)+(b))"
+    # ...while builtin and system macros are filtered out.
+    assert "__STDC__" not in by_name and "SYS_ONLY" not in by_name
+    assert files == ["include/foo.h"]
+
+
+def test_macros_honor_undef() -> None:
+    from abicheck.evidence.source_extractors import macros_from_preprocessor
+
+    text = (
+        '# 1 "include/foo.h" 1\n'
+        "#define TMP 1\n"
+        "#undef TMP\n"
+        "#define KEEP 2\n"
+    )
+    macros, _ = macros_from_preprocessor(text, ["include/foo.h"])
+    names = {e.qualified_name for e in macros}
+    assert "TMP" not in names and "KEEP" in names
+
+
+def test_public_macro_value_change_detected_end_to_end() -> None:
+    from abicheck.evidence.source_abi import SourceAbiTu
+    from abicheck.evidence.source_extractors import macros_from_preprocessor
+
+    def surface(value: str):  # type: ignore[no-untyped-def]
+        macros, _ = macros_from_preprocessor(
+            f'# 1 "include/foo.h" 1\n#define FOO_SIZE {value}\n', ["include/foo.h"]
+        )
+        return link_source_abi([SourceAbiTu(tu_id="cu://a", macros=macros)])
+
+    changes = diff_source_abi(surface("16"), surface("32"))
+    by_kind = {c.kind.value: c for c in changes}
+    assert "public_macro_value_changed" in by_kind
+    assert by_kind["public_macro_value_changed"].old_value == "16"
+
+
 def test_forward_declaration_emits_no_type() -> None:
     ast = {
         "kind": "TranslationUnitDecl",

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -186,6 +186,39 @@ def test_ast_mapping_extracts_each_entity_kind() -> None:
     assert SourceAbiTu.from_dict(tu.to_dict()).tu_id == tu.tu_id
 
 
+def test_directory_header_root_classifies_decls_as_public(tmp_path: Path) -> None:
+    # Codex #339 P2: `--headers include/` (a directory root) must classify a decl
+    # reported under it (include/foo.h) as public, not drop the whole tree.
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "foo.h").write_text("int x;\n")
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [{
+            "kind": "FunctionDecl", "name": "pub",
+            "loc": {"file": str(inc / "foo.h")},
+            "mangledName": "_Z3pubv", "type": {"qualType": "void ()"},
+        }],
+    }
+    # The public root is the directory itself.
+    tu = source_abi_from_clang_ast(ast, _cu(), [str(inc)], "t")
+    assert any(e.qualified_name == "pub" for e in tu.functions)
+
+
+def test_trailing_slash_root_treated_as_directory() -> None:
+    # A root with a trailing separator is a directory even if it does not exist
+    # on disk, so a decl under it is public.
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [{
+            "kind": "FunctionDecl", "name": "pub", "loc": {"file": "include/api.h"},
+            "mangledName": "_Z3pubv", "type": {"qualType": "void ()"},
+        }],
+    }
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/"], "t")
+    assert any(e.qualified_name == "pub" for e in tu.functions)
+
+
 def test_ast_mapping_excludes_private_header_decls() -> None:
     tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "target://libfoo")
     # `priv` lives in src/internal.h, not the public set → never emitted.

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -32,6 +32,7 @@ from abicheck.evidence.source_extractors import (
     ClangSourceExtractor,
     SourceExtractionError,
     build_clang_command,
+    build_clang_macro_command,
     source_abi_from_clang_ast,
 )
 from abicheck.evidence.source_link import link_source_abi
@@ -172,7 +173,9 @@ def test_ast_mapping_extracts_each_entity_kind() -> None:
     tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "target://libfoo")
     assert tu.extractor["name"] == "clang-source"
     funcs = {e.qualified_name: e for e in tu.functions}
-    assert funcs["ns::add"].value == "y=1"  # default argument captured
+    # Default argument captured, keyed by parameter *position* (p1 = 2nd param),
+    # not name — a rename keeping the same default is not a change.
+    assert funcs["ns::add"].value == "p1=1"
     assert funcs["ns::add"].mangled_name == "_ZN2ns3addEii"
     assert {e.qualified_name for e in tu.inline_bodies} == {"ns::add"}
     assert tu.inline_bodies[0].body_hash.startswith("sha256:")
@@ -417,6 +420,149 @@ def test_public_macro_value_change_detected_end_to_end() -> None:
     by_kind = {c.kind.value: c for c in changes}
     assert "public_macro_value_changed" in by_kind
     assert by_kind["public_macro_value_changed"].old_value == "16"
+
+
+def test_param_rename_with_same_default_is_not_a_change() -> None:
+    # Codex #339 P2: a pure parameter rename keeping the same default value must
+    # NOT fire default_argument_changed (callers omitting the arg get the same
+    # value). The comparable value is keyed by position, not name.
+    def fn(pname: str) -> dict:
+        return {"kind": "TranslationUnitDecl", "inner": [{
+            "kind": "FunctionDecl", "name": "f", "loc": {"file": "include/foo.h"},
+            "mangledName": "_Z1fi", "type": {"qualType": "void (int)"},
+            "inner": [{
+                "kind": "ParmVarDecl", "name": pname, "type": {"qualType": "int"},
+                "init": "c", "inner": [{"kind": "IntegerLiteral", "value": "1"}],
+            }],
+        }]}
+
+    old = source_abi_from_clang_ast(fn("x"), _cu(), ["include/foo.h"], "t")
+    new = source_abi_from_clang_ast(fn("y"), _cu(), ["include/foo.h"], "t")
+    assert old.functions[0].value == new.functions[0].value == "p0=1"
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "default_argument_changed" not in kinds
+
+
+def test_constexpr_referencing_changed_constant_is_detected() -> None:
+    # Codex #339 P2: a constexpr initialized from another named constant
+    # (DeclRefExpr) that changes kOld -> kNew (same type) must be detected;
+    # _canonical now preserves the referenced declaration name.
+    def ast(ref: str) -> dict:
+        return {"kind": "TranslationUnitDecl", "inner": [{
+            "kind": "VarDecl", "name": "N", "loc": {"file": "include/foo.h"},
+            "constexpr": True, "type": {"qualType": "const int"},
+            "inner": [{
+                "kind": "ConstantExpr", "type": {"qualType": "const int"},
+                "inner": [{
+                    "kind": "DeclRefExpr", "type": {"qualType": "const int"},
+                    "referencedDecl": {"kind": "VarDecl", "name": ref},
+                }],
+            }],
+        }]}
+
+    old = source_abi_from_clang_ast(ast("kOld"), _cu(), ["include/foo.h"], "t")
+    new = source_abi_from_clang_ast(ast("kNew"), _cu(), ["include/foo.h"], "t")
+    assert old.constexpr_values[0].value != new.constexpr_values[0].value
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "constexpr_value_changed" in kinds
+
+
+# -- extractor subprocess orchestration (mocked clang) -----------------------
+
+
+class _Result:
+    def __init__(self, rc: int, out: str, err: str = "") -> None:
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = err
+
+
+def _patch_run(monkeypatch, handler) -> ClangSourceExtractor:  # type: ignore[no-untyped-def]
+    from abicheck.evidence.source_extractors import clang as clang_mod
+
+    extractor = ClangSourceExtractor()
+    monkeypatch.setattr(extractor, "available", lambda: True)
+    monkeypatch.setattr(clang_mod.subprocess, "run", handler)
+    return extractor
+
+
+def test_extract_runs_macro_pass(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import json
+
+    calls: list[list[str]] = []
+
+    def handler(cmd, **kw):  # type: ignore[no-untyped-def]
+        calls.append(cmd)
+        if "-ast-dump=json" in cmd:
+            return _Result(0, json.dumps(_ast()))
+        return _Result(0, '# 1 "include/foo.h" 1\n#define FOO_SIZE 16\n')
+
+    extractor = _patch_run(monkeypatch, handler)
+    tu = extractor.extract(
+        _cu(source="foo.cpp"), public_header_roots=["include/foo.h"], target_id="t"
+    )
+    assert len(calls) == 2  # AST pass + macro pass
+    assert any(e.qualified_name == "FOO_SIZE" for e in tu.macros)
+
+
+def test_extract_macro_pass_failure_is_diagnostic(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import json
+
+    def handler(cmd, **kw):  # type: ignore[no-untyped-def]
+        if "-ast-dump=json" in cmd:
+            return _Result(0, json.dumps(_ast()))
+        return _Result(1, "", "macro boom")
+
+    extractor = _patch_run(monkeypatch, handler)
+    tu = extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+    assert tu.macros == []
+    assert any("macro pass" in d for d in tu.diagnostics)
+
+
+def test_extract_records_recovered_ast_exit(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import json
+
+    def handler(cmd, **kw):  # type: ignore[no-untyped-def]
+        if "-ast-dump=json" in cmd:
+            return _Result(1, json.dumps(_ast()), "warning: recovered")
+        return _Result(0, "")
+
+    extractor = _patch_run(monkeypatch, handler)
+    tu = extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+    assert any("recovered" in d for d in tu.diagnostics)
+
+
+def test_extract_timeout_raises(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import subprocess as sp
+
+    def handler(cmd, **kw):  # type: ignore[no-untyped-def]
+        raise sp.TimeoutExpired(cmd, 1)
+
+    extractor = _patch_run(monkeypatch, handler)
+    extractor.timeout = 1
+    with pytest.raises(SourceExtractionError, match="timed out"):
+        extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+
+
+def test_extract_invalid_json_raises(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    extractor = _patch_run(monkeypatch, lambda cmd, **kw: _Result(0, "{not json"))
+    with pytest.raises(SourceExtractionError, match="not valid JSON"):
+        extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+
+
+def test_build_clang_macro_command_gnu_and_msvc() -> None:
+    gnu = build_clang_macro_command(_cu(standard="c++17"), Path("a.cpp"))
+    assert "-E" in gnu and "-dD" in gnu and gnu[-1] == str(Path("a.cpp"))
+    msvc = build_clang_macro_command(
+        _cu(standard="c++20"), Path("a.cpp"), compiler_binary="clang-cl"
+    )
+    assert "--driver-mode=cl" in msvc and "/E" in msvc and "-dD" in msvc
 
 
 def test_forward_declaration_emits_no_type() -> None:

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -226,6 +226,93 @@ def test_ast_mapping_excludes_private_header_decls() -> None:
     assert "priv" not in all_names
 
 
+def _record_ast(tag: str, members: list[dict]) -> dict:
+    """A clang AST with one record (``tag`` = class/struct) in a public header."""
+    return {
+        "kind": "TranslationUnitDecl",
+        "inner": [{
+            "kind": "CXXRecordDecl", "name": "C", "tagUsed": tag,
+            "loc": {"file": "include/foo.h", "line": 1},
+            "inner": members,
+        }],
+    }
+
+
+def _method(name: str, *, default: str | None = None, body: bool = False) -> dict:
+    inner: list[dict] = []
+    if default is not None:
+        inner.append({
+            "kind": "ParmVarDecl", "name": "x", "type": {"qualType": "int"},
+            "init": "c", "inner": [{"kind": "IntegerLiteral", "value": default}],
+        })
+    if body:
+        inner.append({"kind": "CompoundStmt", "inner": []})
+    return {
+        "kind": "CXXMethodDecl", "name": name, "loc": {"line": 3},
+        "type": {"qualType": "int (int)"}, "inner": inner,
+    }
+
+
+def test_class_default_private_members_excluded() -> None:
+    # A `class` defaults to private; a member before any `public:` is hidden and
+    # must not reach the L4 surface (Codex #339 P2).
+    ast = _record_ast("class", [_method("secret", default="1", body=True)])
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    assert all(e.qualified_name != "C::secret" for e in tu.all_entities())
+
+
+def test_struct_default_public_members_emitted() -> None:
+    # A `struct` defaults to public, so its members are part of the surface.
+    ast = _record_ast("struct", [_method("visible", default="1", body=True)])
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    assert any(e.qualified_name == "C::visible" for e in tu.functions)
+    assert any(e.qualified_name == "C::visible" for e in tu.inline_bodies)
+
+
+def test_access_spec_section_switches_visibility() -> None:
+    # `public:` exposes following members; `private:` hides them again.
+    ast = _record_ast("class", [
+        {"kind": "AccessSpecDecl", "access": "public"},
+        _method("api", default="1"),
+        {"kind": "AccessSpecDecl", "access": "private"},
+        _method("impl", default="2"),
+    ])
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    names = {e.qualified_name for e in tu.functions}
+    assert "C::api" in names
+    assert "C::impl" not in names
+
+
+def test_explicit_per_decl_access_honored() -> None:
+    # Newer clang stamps `access` on each member decl; a private one is dropped
+    # even in a struct (default public).
+    ast = _record_ast("struct", [
+        dict(_method("api", default="1"), access="public"),
+        dict(_method("impl", default="2"), access="private"),
+    ])
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    names = {e.qualified_name for e in tu.functions}
+    assert "C::api" in names
+    assert "C::impl" not in names
+
+
+def test_members_of_private_nested_class_excluded() -> None:
+    # A private nested class is not public, so its (struct-default-public)
+    # members stay off the surface too.
+    nested = {
+        "kind": "CXXRecordDecl", "name": "Impl", "tagUsed": "struct",
+        "loc": {"line": 4}, "inner": [_method("run", default="1")],
+    }
+    ast = _record_ast("class", [
+        {"kind": "AccessSpecDecl", "access": "private"},
+        nested,
+    ])
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    names = {e.qualified_name for e in tu.all_entities()}
+    assert "C::Impl" not in names
+    assert "C::Impl::run" not in names
+
+
 def test_ast_mapping_template_not_double_counted_as_function() -> None:
     # The templated pattern FunctionDecl inside FunctionTemplateDecl must not also
     # surface as a plain function entity.

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -265,6 +265,49 @@ def _constexpr_ast(rhs_literal: str) -> dict:
     }
 
 
+def test_walk_threads_sticky_file_across_siblings() -> None:
+    # CodeRabbit: clang's loc.file is sticky. After a child subtree switches file,
+    # a following sibling that omits loc.file must inherit the *last seen* file
+    # (not the parent's own file), or it is misclassified public/private.
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "CXXRecordDecl", "name": "Outer",
+                "loc": {"file": "include/pub.h"},
+                "inner": [
+                    {"kind": "FieldDecl", "name": "a", "type": {"qualType": "int"}},
+                    # Nested decl switches the current file to a private header.
+                    {"kind": "CXXRecordDecl", "name": "Nested",
+                     "loc": {"file": "src/detail/priv.h"},
+                     "inner": [{"kind": "FieldDecl", "name": "b",
+                                "type": {"qualType": "int"}}]},
+                ],
+            },
+            # Sibling omits loc.file → inherits the last seen file (priv.h),
+            # so it is private and must NOT land on the public surface.
+            {"kind": "FunctionDecl", "name": "leaked",
+             "mangledName": "_Z6leakedv", "type": {"qualType": "void ()"}},
+        ],
+    }
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/pub.h"], "t")
+    assert "leaked" not in {e.qualified_name for e in tu.functions}
+    # Outer (public) is still captured.
+    assert any("Outer" in e.qualified_name for e in tu.types)
+
+
+def test_read_files_resolved_against_build_directory() -> None:
+    # CodeRabbit/Codex P2: relative read_files (clang emits these for headers
+    # found via a relative -I) are resolved to absolute against the TU directory
+    # so the cache can read them from a different CWD.
+    import os
+
+    tu = source_abi_from_clang_ast(
+        _ast(), _cu(directory="/work/proj"), ["include/foo.h"], "t"
+    )
+    assert os.path.normpath("/work/proj/include/foo.h") in tu.read_files
+
+
 def test_constexpr_compound_expression_change_is_detected() -> None:
     # Codex #339 P2: `1 + 2` and `1 + 3` must not collapse to the same "1".
     old = source_abi_from_clang_ast(_constexpr_ast("2"), _cu(), ["include/foo.h"], "t")
@@ -390,6 +433,24 @@ def test_macros_from_preprocessor_scopes_to_public_headers() -> None:
     # ...while builtin and system macros are filtered out.
     assert "__STDC__" not in by_name and "SYS_ONLY" not in by_name
     assert files == ["include/foo.h"]
+
+
+def test_macros_unfold_line_continuations() -> None:
+    # CodeRabbit: a backslash-continued macro must be parsed whole, so an edit
+    # below the first physical line is still visible to the value comparison.
+    from abicheck.evidence.source_extractors import macros_from_preprocessor
+
+    text = (
+        '# 1 "include/foo.h" 1\n'
+        "#define BIG(a, b) \\\n"
+        "    ((a) + \\\n"
+        "     (b))\n"
+    )
+    macros, _ = macros_from_preprocessor(text, ["include/foo.h"])
+    by_name = {e.qualified_name: e.value for e in macros}
+    assert "BIG" in by_name
+    # The whole body is captured (both continuation lines), not just "(a, b)".
+    assert "(a) +" in by_name["BIG"] and "(b)" in by_name["BIG"]
 
 
 def test_macros_honor_undef() -> None:
@@ -562,7 +623,9 @@ def test_build_clang_macro_command_gnu_and_msvc() -> None:
     msvc = build_clang_macro_command(
         _cu(standard="c++20"), Path("a.cpp"), compiler_binary="clang-cl"
     )
-    assert "--driver-mode=cl" in msvc and "/E" in msvc and "-dD" in msvc
+    # cl-driver mode ignores -dD; clang-cl's /d1PP retains macro defs in /E mode.
+    assert "--driver-mode=cl" in msvc and "/E" in msvc and "/d1PP" in msvc
+    assert "-dD" not in msvc
 
 
 def test_forward_declaration_emits_no_type() -> None:

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ADR-030 phase-5 clang source ABI extractor.
+
+The argv builder and the JSON-AST → SourceAbiTu mapping are pure and tested in
+the fast lane; the end-to-end clang run is marked ``integration``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from abicheck.evidence.build_evidence import CompileUnit
+from abicheck.evidence.source_abi import SourceAbiTu
+from abicheck.evidence.source_diff import diff_source_abi
+from abicheck.evidence.source_extractors import (
+    ClangSourceExtractor,
+    SourceExtractionError,
+    build_clang_command,
+    source_abi_from_clang_ast,
+)
+from abicheck.evidence.source_link import link_source_abi
+
+
+def _cu(**kw: object) -> CompileUnit:
+    base: dict[str, object] = {
+        "id": "cu://src/foo.cpp#cfg",
+        "source": "src/foo.cpp",
+        "language": "CXX",
+        "standard": "c++17",
+    }
+    base.update(kw)
+    return CompileUnit(**base)  # type: ignore[arg-type]
+
+
+# -- build_clang_command (pure, D2) ------------------------------------------
+
+
+def test_build_command_reflects_compile_context() -> None:
+    cu = _cu(
+        defines={"FOO": "1", "BARE": ""},
+        undefines=["NDEBUG"],
+        include_paths=["include"],
+        system_include_paths=["/opt/sdk/include"],
+        sysroot="/sysroot",
+        target_triple="aarch64-linux-gnu",
+    )
+    cmd = build_clang_command(cu, Path("src/foo.cpp"), clang_bin="clang")
+    assert cmd[0] == "clang"
+    assert "-x" in cmd and cmd[cmd.index("-x") + 1] == "c++"
+    assert "-std=c++17" in cmd
+    assert "-DFOO=1" in cmd and "-DBARE" in cmd and "-UNDEBUG" in cmd
+    assert cmd[cmd.index("-I") + 1] == "include"
+    assert cmd[cmd.index("-isystem") + 1] == "/opt/sdk/include"
+    assert "--sysroot=/sysroot" in cmd
+    assert "--target=aarch64-linux-gnu" in cmd
+    # The AST dump invocation and the source operand come last.
+    assert "-fsyntax-only" in cmd
+    assert cmd[cmd.index("-ast-dump=json")] == "-ast-dump=json"
+    assert cmd[-1] == str(Path("src/foo.cpp"))
+
+
+def test_build_command_c_language() -> None:
+    cmd = build_clang_command(_cu(language="C", standard="c11"), Path("a.c"))
+    assert cmd[cmd.index("-x") + 1] == "c"
+    assert "-std=c11" in cmd
+
+
+def test_build_command_msvc_driver_mode() -> None:
+    cmd = build_clang_command(
+        _cu(standard="c++20", defines={"WIN": "1"}, include_paths=["inc"]),
+        Path("a.cpp"),
+        compiler_binary="clang-cl",
+    )
+    assert "--driver-mode=cl" in cmd
+    assert "/std:c++20" in cmd
+    assert "/DWIN=1" in cmd
+    assert cmd[cmd.index("/I") + 1] == "inc"
+    # No --target in cl mode (clang-cl rejects the GNU spelling here).
+    assert not any(a.startswith("--target=") for a in cmd)
+
+
+def test_build_command_carries_abi_flags_and_unwraps_launcher() -> None:
+    cu = _cu(
+        argv=["ccache", "clang++", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fvisibility=hidden"],
+    )
+    cmd = build_clang_command(cu, Path("foo.cpp"))
+    assert "-fvisibility=hidden" in cmd
+    assert "ccache" not in cmd
+
+
+# -- source_abi_from_clang_ast (pure, D4) ------------------------------------
+
+
+def _ast() -> dict:
+    """A small clang JSON AST root covering each entity kind we extract."""
+    return {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "NamespaceDecl",
+                "name": "ns",
+                "loc": {"file": "include/foo.h", "line": 1},
+                "inner": [
+                    {
+                        "kind": "FunctionDecl",
+                        "name": "add",
+                        "loc": {"line": 3},
+                        "mangledName": "_ZN2ns3addEii",
+                        "type": {"qualType": "int (int, int)"},
+                        "inline": True,
+                        "inner": [
+                            {"kind": "ParmVarDecl", "name": "x", "type": {"qualType": "int"}},
+                            {
+                                "kind": "ParmVarDecl", "name": "y", "type": {"qualType": "int"},
+                                "init": "c",
+                                "inner": [{"kind": "IntegerLiteral", "value": "1"}],
+                            },
+                            {
+                                "kind": "CompoundStmt",
+                                "inner": [{"kind": "ReturnStmt", "inner": [
+                                    {"kind": "DeclRefExpr", "name": "x"}]}],
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "VarDecl", "name": "kMax", "loc": {"line": 9},
+                        "constexpr": True, "type": {"qualType": "const int"},
+                        "inner": [{"kind": "IntegerLiteral", "value": "42"}],
+                    },
+                    {
+                        "kind": "CXXRecordDecl", "name": "Widget", "loc": {"line": 12},
+                        "inner": [{"kind": "FieldDecl", "name": "a", "type": {"qualType": "int"}}],
+                    },
+                    {
+                        "kind": "FunctionTemplateDecl", "name": "maxv", "loc": {"line": 20},
+                        "inner": [
+                            {"kind": "TemplateTypeParmDecl", "name": "T"},
+                            {"kind": "FunctionDecl", "name": "maxv",
+                             "inner": [{"kind": "CompoundStmt", "inner": []}]},
+                        ],
+                    },
+                ],
+            },
+            {
+                "kind": "FunctionDecl", "name": "priv",
+                "loc": {"file": "src/internal.h", "line": 2},
+                "type": {"qualType": "void ()"}, "inline": True,
+                "inner": [{"kind": "CompoundStmt", "inner": []}],
+            },
+        ],
+    }
+
+
+def test_ast_mapping_extracts_each_entity_kind() -> None:
+    tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "target://libfoo")
+    assert tu.extractor["name"] == "clang-source"
+    funcs = {e.qualified_name: e for e in tu.functions}
+    assert funcs["ns::add"].value == "y=1"  # default argument captured
+    assert funcs["ns::add"].mangled_name == "_ZN2ns3addEii"
+    assert {e.qualified_name for e in tu.inline_bodies} == {"ns::add"}
+    assert tu.inline_bodies[0].body_hash.startswith("sha256:")
+    assert {e.qualified_name: e.value for e in tu.constexpr_values} == {"ns::kMax": "42"}
+    assert {e.qualified_name for e in tu.types} == {"ns::Widget"}
+    assert {e.qualified_name for e in tu.templates} == {"ns::maxv"}
+    # Round-trips through the normalized schema.
+    assert SourceAbiTu.from_dict(tu.to_dict()).tu_id == tu.tu_id
+
+
+def test_ast_mapping_excludes_private_header_decls() -> None:
+    tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "target://libfoo")
+    # `priv` lives in src/internal.h, not the public set → never emitted.
+    all_names = {e.qualified_name for e in tu.all_entities()}
+    assert "priv" not in all_names
+
+
+def test_ast_mapping_template_not_double_counted_as_function() -> None:
+    # The templated pattern FunctionDecl inside FunctionTemplateDecl must not also
+    # surface as a plain function entity.
+    tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "target://libfoo")
+    assert "ns::maxv" not in {e.qualified_name for e in tu.functions}
+
+
+def test_ast_body_hash_is_stable_and_change_detected() -> None:
+    base = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "t")
+    # Same AST again → identical body hash (build-root independent / deterministic).
+    again = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "t")
+    assert base.inline_bodies[0].body_hash == again.inline_bodies[0].body_hash
+
+    # Edit the inline body → inline_body_changed fires via the linker+diff.
+    mutated = _ast()
+    fn = mutated["inner"][0]["inner"][0]
+    fn["inner"][-1]["inner"][0]["inner"][0]["name"] = "y"  # return x -> return y
+    new = source_abi_from_clang_ast(mutated, _cu(), ["include/foo.h"], "t")
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([base]), link_source_abi([new]))
+    }
+    assert "inline_body_changed" in kinds
+
+
+def test_ast_constexpr_change_detected_end_to_end() -> None:
+    old = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "t")
+    mutated = _ast()
+    mutated["inner"][0]["inner"][1]["inner"][0]["value"] = "43"  # kMax 42 -> 43
+    new = source_abi_from_clang_ast(mutated, _cu(), ["include/foo.h"], "t")
+    changes = diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    by_kind = {c.kind.value: c for c in changes}
+    assert "constexpr_value_changed" in by_kind
+    assert by_kind["constexpr_value_changed"].old_value == "42"
+
+
+def test_forward_declaration_emits_no_type() -> None:
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {"kind": "CXXRecordDecl", "name": "Fwd", "loc": {"file": "include/foo.h"}},
+        ],
+    }
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    assert tu.types == []  # forward decl (no inner members) → skipped
+
+
+# -- extractor orchestration -------------------------------------------------
+
+
+def test_extract_raises_when_clang_unavailable() -> None:
+    extractor = ClangSourceExtractor(clang_bin="clang-does-not-exist-xyz")
+    assert extractor.available() is False
+    with pytest.raises(SourceExtractionError, match="requires"):
+        extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+
+
+def test_extract_parses_fake_clang_json(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # Mock clang so the extract() success path runs without the tool installed.
+    import json
+
+    from abicheck.evidence.source_extractors import clang as clang_mod
+
+    extractor = ClangSourceExtractor()
+    monkeypatch.setattr(extractor, "available", lambda: True)
+    captured: dict[str, object] = {}
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps(_ast())
+
+    def _fake_run(cmd, **kw):  # type: ignore[no-untyped-def]
+        captured["cwd"] = kw.get("cwd")
+        return _Result()
+
+    monkeypatch.setattr(clang_mod.subprocess, "run", _fake_run)
+    cu = _cu(source="src/foo.cpp", directory=str(tmp_path))
+    tu = extractor.extract(cu, public_header_roots=["include/foo.h"], target_id="target://x")
+    assert captured["cwd"] == str(tmp_path)
+    assert any(e.qualified_name == "ns::add" for e in tu.functions)
+
+
+def test_extract_raises_on_empty_clang_output(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from abicheck.evidence.source_extractors import clang as clang_mod
+
+    extractor = ClangSourceExtractor()
+    monkeypatch.setattr(extractor, "available", lambda: True)
+
+    class _Result:
+        returncode = 1
+        stderr = "fatal error: 'foo.h' file not found"
+        stdout = ""
+
+    monkeypatch.setattr(clang_mod.subprocess, "run", lambda cmd, **kw: _Result())
+    with pytest.raises(SourceExtractionError, match="no AST"):
+        extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+
+
+# -- end-to-end via real clang (integration) ---------------------------------
+
+
+@pytest.mark.integration
+def test_clang_extractor_end_to_end(tmp_path: Path) -> None:
+    extractor = ClangSourceExtractor()
+    if not extractor.available():
+        pytest.skip("clang not installed")
+    header = tmp_path / "foo.h"
+    header.write_text(
+        textwrap.dedent(
+            """
+            #ifndef FOO_H
+            #define FOO_H
+            namespace ns {
+            inline int add(int x, int y = 1) { return x + y; }
+            constexpr int kAnswer = 42;
+            template <typename T> T maxv(T a, T b) { return a < b ? b : a; }
+            }
+            #endif
+            """
+        )
+    )
+    src = tmp_path / "foo.cpp"
+    src.write_text('#include "foo.h"\n')
+    cu = CompileUnit(id="cu://foo.cpp", source=str(src), language="CXX", standard="c++17")
+    tu = extractor.extract(cu, public_header_roots=[str(header)], target_id="target://libfoo")
+    names = {e.qualified_name for e in tu.all_entities()}
+    assert any("add" in n for n in names)
+    assert any("kAnswer" in e.qualified_name for e in tu.constexpr_values)
+    assert any("maxv" in e.qualified_name for e in tu.templates)
+    # The inline body fingerprint is populated (clang's job, not castxml's).
+    assert any("add" in e.qualified_name and e.body_hash for e in tu.inline_bodies)

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -226,6 +226,85 @@ def test_ast_constexpr_change_detected_end_to_end() -> None:
     assert by_kind["constexpr_value_changed"].old_value == "42"
 
 
+def test_ast_records_read_files_for_cache_deps() -> None:
+    # Codex #339 P1: the TU records every file it read so the per-TU cache can
+    # invalidate on a transitive-include edit. Both the public and private
+    # headers that contributed nodes appear.
+    tu = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "t")
+    assert "include/foo.h" in tu.read_files
+    assert "src/internal.h" in tu.read_files
+
+
+def _constexpr_ast(rhs_literal: str) -> dict:
+    """A constexpr `N = 1 + <rhs>` (a compound expression, not a lone literal)."""
+    return {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "VarDecl", "name": "N", "loc": {"file": "include/foo.h"},
+                "constexpr": True, "type": {"qualType": "const int"},
+                "inner": [
+                    {
+                        "kind": "ConstantExpr", "value": "x",
+                        "inner": [
+                            {
+                                "kind": "BinaryOperator", "opcode": "+",
+                                "inner": [
+                                    {"kind": "IntegerLiteral", "value": "1"},
+                                    {"kind": "IntegerLiteral", "value": rhs_literal},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_constexpr_compound_expression_change_is_detected() -> None:
+    # Codex #339 P2: `1 + 2` and `1 + 3` must not collapse to the same "1".
+    old = source_abi_from_clang_ast(_constexpr_ast("2"), _cu(), ["include/foo.h"], "t")
+    new = source_abi_from_clang_ast(_constexpr_ast("3"), _cu(), ["include/foo.h"], "t")
+    assert old.constexpr_values[0].value != new.constexpr_values[0].value
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "constexpr_value_changed" in kinds
+
+
+def test_default_argument_compound_expression_change_is_detected() -> None:
+    def ast(rhs: str) -> dict:
+        return {
+            "kind": "TranslationUnitDecl",
+            "inner": [{
+                "kind": "FunctionDecl", "name": "f", "loc": {"file": "include/foo.h"},
+                "mangledName": "_Z1fi", "type": {"qualType": "void (int)"},
+                "inner": [{
+                    "kind": "ParmVarDecl", "name": "x", "type": {"qualType": "int"},
+                    "init": "c",
+                    "inner": [{
+                        "kind": "BinaryOperator", "opcode": "+",
+                        "inner": [
+                            {"kind": "IntegerLiteral", "value": "1"},
+                            {"kind": "IntegerLiteral", "value": rhs},
+                        ],
+                    }],
+                }],
+            }],
+        }
+
+    old = source_abi_from_clang_ast(ast("2"), _cu(), ["include/foo.h"], "t")
+    new = source_abi_from_clang_ast(ast("3"), _cu(), ["include/foo.h"], "t")
+    assert old.functions[0].value != new.functions[0].value
+    kinds = {
+        c.kind.value
+        for c in diff_source_abi(link_source_abi([old]), link_source_abi([new]))
+    }
+    assert "default_argument_changed" in kinds
+
+
 def test_forward_declaration_emits_no_type() -> None:
     ast = {
         "kind": "TranslationUnitDecl",

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -352,6 +352,41 @@ def test_cache_get_ignores_bad_tu_payload(tmp_path: Path) -> None:
     assert cache.get("k") is None
 
 
+def test_cache_key_changes_with_argv_forced_include(tmp_path: Path) -> None:
+    # Codex #339 P2: a forced-include change lives only in argv (not the
+    # structured fields), so the key must fold in the replayed argv flags or a
+    # `-include old.h` -> `-include new.h` swap would reuse a stale dump.
+    src = tmp_path / "a.cpp"
+    src.write_text("int a;\n")
+    old = _cu("cu://x", str(src), argv=["clang++", "-include", "old.h", "-c", "a.cpp"])
+    new = _cu("cu://x", str(src), argv=["clang++", "-include", "new.h", "-c", "a.cpp"])
+    k_old = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=old, public_header_roots=[],
+    )
+    k_new = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=new, public_header_roots=[],
+    )
+    assert k_old and k_new and k_old != k_new
+
+
+def test_cache_key_changes_with_iquote_path(tmp_path: Path) -> None:
+    src = tmp_path / "a.cpp"
+    src.write_text("int a;\n")
+    a = _cu("cu://x", str(src), argv=["clang++", "-iquote", "dirA", "-c", "a.cpp"])
+    b = _cu("cu://x", str(src), argv=["clang++", "-iquote", "dirB", "-c", "a.cpp"])
+    ka = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=a, public_header_roots=[],
+    )
+    kb = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=b, public_header_roots=[],
+    )
+    assert ka and kb and ka != kb
+
+
 def test_cache_key_includes_source_location(tmp_path: Path) -> None:
     # CodeRabbit: two distinct TUs with identical content must not collide.
     src_a = tmp_path / "a" / "foo.cpp"

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -158,6 +158,33 @@ def test_scope_changed_empty_paths_selects_nothing() -> None:
     assert select_compile_units(_build(), scope="changed", changed_paths=[]) == []
 
 
+def test_scope_changed_falls_back_for_header_without_target_metadata() -> None:
+    # Codex #339 P2: compile-DB-only evidence (compile units, no Target records),
+    # a changed *header* that maps to no TU must fail open to all TUs, not select
+    # nothing — else source-only header changes vanish from PR-mode replay.
+    build = BuildEvidence(
+        compile_units=[_cu("cu://a", "src/a.cpp"), _cu("cu://b", "src/b.cpp")]
+    )
+    units = select_compile_units(build, scope="changed", changed_paths=["include/api.h"])
+    assert {u.id for u in units} == {"cu://a", "cu://b"}
+
+
+def test_scope_changed_non_header_no_match_stays_empty() -> None:
+    # A changed *non-header* that matches no source must NOT trigger the
+    # fail-open header fallback (no over-broad replay for an unrelated file).
+    build = BuildEvidence(compile_units=[_cu("cu://a", "src/a.cpp")])
+    assert select_compile_units(build, scope="changed", changed_paths=["README.md"]) == []
+
+
+def test_scope_changed_header_with_target_metadata_does_not_overselect() -> None:
+    # When targets DO carry header metadata, a header that no target owns scopes
+    # to nothing (the metadata is authoritative — no fail-open needed).
+    units = select_compile_units(
+        _build(), scope="changed", changed_paths=["include/unowned.h"]
+    )
+    assert units == []
+
+
 def test_unknown_scope_raises() -> None:
     with pytest.raises(ValueError, match="unknown replay scope"):
         select_compile_units(_build(), scope="bogus")
@@ -284,6 +311,54 @@ def test_cache_invalidates_when_dependency_deleted(tmp_path: Path) -> None:
     cache.put("k1", SourceAbiTu(tu_id="cu://x", read_files=[str(hdr)]))
     hdr.unlink()  # a vanished dependency must miss, not hit (prefer false miss)
     assert cache.get("k1") is None
+
+
+def test_cache_get_ignores_corrupt_entry(tmp_path: Path) -> None:
+    cache = SourceAbiCache(tmp_path / "cache")
+    cache.cache_dir.mkdir(parents=True)
+    (cache.cache_dir / "k.json").write_text("{ not valid json")
+    assert cache.get("k") is None  # corrupt entry is a miss, never an error
+
+
+def test_cache_get_ignores_non_object_entry(tmp_path: Path) -> None:
+    cache = SourceAbiCache(tmp_path / "cache")
+    cache.cache_dir.mkdir(parents=True)
+    (cache.cache_dir / "k.json").write_text("[1, 2, 3]")
+    assert cache.get("k") is None
+
+
+def test_cache_key_changes_with_header_directory_content(tmp_path: Path) -> None:
+    # A header *root that is a directory* folds in every contained file's content,
+    # so editing any header under it invalidates the key (_digest_path dir branch).
+    src = tmp_path / "a.cpp"
+    src.write_text("int a;\n")
+    inc = tmp_path / "inc"
+    inc.mkdir()
+    (inc / "h.h").write_text("int x;\n")
+    cu = _cu("cu://x", str(src))
+    k1 = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[str(inc)],
+    )
+    (inc / "h.h").write_text("int x; int y;\n")
+    k2 = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[str(inc)],
+    )
+    assert k1 and k2 and k1 != k2
+
+
+def test_cache_key_uses_path_string_for_missing_root(tmp_path: Path) -> None:
+    # A missing header root contributes only its path string (the source being
+    # readable is what makes the TU cacheable; an absent root is not a miss-maker).
+    src = tmp_path / "a.cpp"
+    src.write_text("int a;\n")
+    cu = _cu("cu://x", str(src))
+    key = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=["does/not/exist.h"],
+    )
+    assert key is not None
 
 
 # -- driver ------------------------------------------------------------------

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -327,6 +327,50 @@ def test_cache_get_ignores_non_object_entry(tmp_path: Path) -> None:
     assert cache.get("k") is None
 
 
+def test_cache_get_ignores_non_dict_deps(tmp_path: Path) -> None:
+    # CodeRabbit: a malformed entry (deps not a dict) is a miss, never a crash.
+    import json as _json
+
+    cache = SourceAbiCache(tmp_path / "cache")
+    cache.cache_dir.mkdir(parents=True)
+    (cache.cache_dir / "k.json").write_text(
+        _json.dumps({"deps": "not-a-dict", "tu": {"tu_id": "x"}})
+    )
+    assert cache.get("k") is None
+
+
+def test_cache_get_ignores_bad_tu_payload(tmp_path: Path) -> None:
+    # A structurally bad `tu` payload (missing required entity id) is a miss.
+    import json as _json
+
+    cache = SourceAbiCache(tmp_path / "cache")
+    cache.cache_dir.mkdir(parents=True)
+    # An entity dict without "id" makes SourceEntity.from_dict raise KeyError.
+    (cache.cache_dir / "k.json").write_text(
+        _json.dumps({"deps": {}, "tu": {"tu_id": "x", "functions": [{}]}})
+    )
+    assert cache.get("k") is None
+
+
+def test_cache_key_includes_source_location(tmp_path: Path) -> None:
+    # CodeRabbit: two distinct TUs with identical content must not collide.
+    src_a = tmp_path / "a" / "foo.cpp"
+    src_b = tmp_path / "b" / "foo.cpp"
+    src_a.parent.mkdir()
+    src_b.parent.mkdir()
+    src_a.write_text("int x;\n")
+    src_b.write_text("int x;\n")  # identical content, different location
+    key_a = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=_cu("cu://a", str(src_a)), public_header_roots=[],
+    )
+    key_b = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=_cu("cu://b", str(src_b)), public_header_roots=[],
+    )
+    assert key_a and key_b and key_a != key_b
+
+
 def test_cache_key_changes_with_header_directory_content(tmp_path: Path) -> None:
     # A header *root that is a directory* folds in every contained file's content,
     # so editing any header under it invalidates the key (_digest_path dir branch).

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -176,13 +176,17 @@ def test_scope_changed_non_header_no_match_stays_empty() -> None:
     assert select_compile_units(build, scope="changed", changed_paths=["README.md"]) == []
 
 
-def test_scope_changed_header_with_target_metadata_does_not_overselect() -> None:
-    # When targets DO carry header metadata, a header that no target owns scopes
-    # to nothing (the metadata is authoritative — no fail-open needed).
+def test_scope_changed_unowned_header_fails_open_despite_target_metadata() -> None:
+    # Codex #339 P2: even when targets carry header metadata, a changed header
+    # that no target owns must fail open to all TUs, not select nothing. Target
+    # public/private header lists name a target's *own* headers, not the
+    # transitive private headers it includes (e.g. a config header pulled in by
+    # a public header), so an unowned header can still affect any TU. The per-TU
+    # cache then skips units whose read_files did not actually change.
     units = select_compile_units(
-        _build(), scope="changed", changed_paths=["include/unowned.h"]
+        _build(), scope="changed", changed_paths=["include/detail/config.h"]
     )
-    assert units == []
+    assert {u.id for u in units} == {u.id for u in _build().compile_units}
 
 
 def test_unknown_scope_raises() -> None:

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -262,6 +262,30 @@ def test_cache_roundtrip_and_miss(tmp_path: Path) -> None:
     cache.put(None, tu)  # no-op, must not raise
 
 
+def test_cache_invalidates_when_included_header_changes(tmp_path: Path) -> None:
+    # Codex #339 P1: a TU that included a private header (not a configured root)
+    # must miss the cache once that header changes, or stale inline/default/
+    # constexpr facts are linked and a real source ABI change is silently lost.
+    hdr = tmp_path / "detail" / "config.h"
+    hdr.parent.mkdir()
+    hdr.write_text("#define N 1\n")
+    cache = SourceAbiCache(tmp_path / "cache")
+    tu = SourceAbiTu(tu_id="cu://x", read_files=[str(hdr)])
+    cache.put("k1", tu)
+    assert cache.get("k1") is not None  # unchanged dependency → hit
+    hdr.write_text("#define N 2\n")  # edit the transitively included header
+    assert cache.get("k1") is None  # changed dependency → miss (re-extract)
+
+
+def test_cache_invalidates_when_dependency_deleted(tmp_path: Path) -> None:
+    hdr = tmp_path / "h.h"
+    hdr.write_text("x\n")
+    cache = SourceAbiCache(tmp_path / "cache")
+    cache.put("k1", SourceAbiTu(tu_id="cu://x", read_files=[str(hdr)]))
+    hdr.unlink()  # a vanished dependency must miss, not hit (prefer false miss)
+    assert cache.get("k1") is None
+
+
 # -- driver ------------------------------------------------------------------
 
 

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -1,0 +1,320 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ADR-030 phase-7 source ABI replay orchestration.
+
+Scope selection, the per-TU cache, and the replay driver are pure (no real
+extractor); a fake extractor stands in so the whole pipeline is exercised in the
+fast lane.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.evidence.build_evidence import BuildEvidence, CompileUnit, Target
+from abicheck.evidence.source_abi import SourceAbiTu, SourceEntity, SourceLocation
+from abicheck.evidence.source_extractors.base import SourceExtractionError
+from abicheck.evidence.source_replay import (
+    CI_MODE_TO_SCOPE,
+    REPLAY_SCOPES,
+    SourceAbiCache,
+    compute_tu_cache_key,
+    public_header_roots_for,
+    run_source_replay,
+    scope_for_ci_mode,
+    select_compile_units,
+)
+
+
+def _cu(cu_id: str, source: str, target_id: str = "", **kw: object) -> CompileUnit:
+    return CompileUnit(id=cu_id, source=source, target_id=target_id, language="CXX", **kw)  # type: ignore[arg-type]
+
+
+def _build() -> BuildEvidence:
+    return BuildEvidence(
+        targets=[
+            Target(
+                id="target://libfoo",
+                public_headers=["include/foo.h"],
+                private_headers=["src/internal.h"],
+            ),
+            Target(id="target://libbar", public_headers=["include/bar.h"]),
+        ],
+        compile_units=[
+            _cu("cu://a", "src/a.cpp", "target://libfoo"),
+            _cu("cu://b", "src/b.cpp", "target://libfoo"),
+            _cu("cu://c", "src/c.cpp", "target://libbar"),
+            _cu("cu://d", "src/d.cpp", ""),  # not attached to a target
+        ],
+    )
+
+
+class _FakeExtractor:
+    """A SourceAbiExtractor that records calls and returns a canned per-TU dump."""
+
+    name = "fake-source"
+    version = "9.9"
+
+    def __init__(self, fail_for: set[str] | None = None) -> None:
+        self.calls: list[str] = []
+        self.fail_for = fail_for or set()
+
+    def extract(self, compile_unit, *, public_header_roots, target_id=""):  # type: ignore[no-untyped-def]
+        self.calls.append(compile_unit.id)
+        if compile_unit.id in self.fail_for:
+            raise SourceExtractionError(f"boom for {compile_unit.id}")
+        ent = SourceEntity(
+            id=f"id::{compile_unit.id}",
+            kind="function",
+            qualified_name=f"fn_{compile_unit.source}",
+            mangled_name=f"_Z{len(compile_unit.id)}",
+            source_location=SourceLocation(path="include/foo.h", origin="PUBLIC_HEADER"),
+            visibility="public_header",
+            api_relevant=True,
+        )
+        return SourceAbiTu(
+            tu_id=compile_unit.id,
+            target_id=target_id or compile_unit.target_id,
+            extractor={"name": self.name, "version": self.version},
+            source=compile_unit.source,
+            public_header_roots=list(public_header_roots),
+            functions=[ent],
+        )
+
+
+# -- scope selection ---------------------------------------------------------
+
+
+def test_scope_off_selects_nothing() -> None:
+    assert select_compile_units(_build(), scope="off") == []
+
+
+def test_scope_full_selects_every_unit() -> None:
+    units = select_compile_units(_build(), scope="full")
+    assert {u.id for u in units} == {"cu://a", "cu://b", "cu://c", "cu://d"}
+
+
+def test_scope_target_selects_units_of_target() -> None:
+    units = select_compile_units(_build(), scope="target", target_id="target://libfoo")
+    assert {u.id for u in units} == {"cu://a", "cu://b"}
+
+
+def test_scope_target_without_id_uses_attached_units() -> None:
+    # No explicit target: every unit attached to *some* target (drops cu://d).
+    units = select_compile_units(_build(), scope="target")
+    assert {u.id for u in units} == {"cu://a", "cu://b", "cu://c"}
+
+
+def test_scope_headers_only_picks_one_unit_per_header_target() -> None:
+    units = select_compile_units(_build(), scope="headers-only")
+    # First (by id) unit of each target that declares public headers.
+    assert {u.id for u in units} == {"cu://a", "cu://c"}
+
+
+def test_scope_headers_only_falls_back_when_no_public_headers() -> None:
+    build = BuildEvidence(compile_units=[_cu("cu://x", "x.cpp")])
+    # No targets/public headers to scope by → fall back to all units.
+    assert {u.id for u in select_compile_units(build, scope="headers-only")} == {"cu://x"}
+
+
+def test_scope_changed_matches_source_paths() -> None:
+    units = select_compile_units(
+        _build(), scope="changed", changed_paths=["src/b.cpp"]
+    )
+    assert {u.id for u in units} == {"cu://b"}
+
+
+def test_scope_changed_includes_units_of_target_owning_changed_header() -> None:
+    # Editing a public header of libfoo pulls in every libfoo TU (they include it).
+    units = select_compile_units(
+        _build(), scope="changed", changed_paths=["include/foo.h"]
+    )
+    assert {u.id for u in units} == {"cu://a", "cu://b"}
+
+
+def test_scope_changed_matches_absolute_vs_relative_paths() -> None:
+    build = BuildEvidence(
+        compile_units=[_cu("cu://abs", "/work/repo/src/a.cpp", "target://t")]
+    )
+    units = select_compile_units(build, scope="changed", changed_paths=["src/a.cpp"])
+    assert {u.id for u in units} == {"cu://abs"}
+
+
+def test_scope_changed_empty_paths_selects_nothing() -> None:
+    assert select_compile_units(_build(), scope="changed", changed_paths=[]) == []
+
+
+def test_unknown_scope_raises() -> None:
+    with pytest.raises(ValueError, match="unknown replay scope"):
+        select_compile_units(_build(), scope="bogus")
+
+
+def test_public_header_roots_collected_from_targets() -> None:
+    assert public_header_roots_for(_build()) == ["include/bar.h", "include/foo.h"]
+    assert public_header_roots_for(_build(), "target://libfoo") == ["include/foo.h"]
+
+
+# -- CI mode mapping (ADR-033 D2) --------------------------------------------
+
+
+def test_ci_mode_to_scope_mapping() -> None:
+    assert scope_for_ci_mode("source-changed") == "changed"
+    assert scope_for_ci_mode("source-target") == "target"
+    assert scope_for_ci_mode("build") == "off"
+    # Every mapped scope is a real replay scope.
+    assert set(CI_MODE_TO_SCOPE.values()) <= set(REPLAY_SCOPES)
+
+
+def test_ci_mode_unknown_fails_safe_to_off() -> None:
+    assert scope_for_ci_mode("totally-unknown") == "off"
+
+
+# -- per-TU cache (ADR-030 D8) -----------------------------------------------
+
+
+def test_cache_key_is_none_when_source_unreadable() -> None:
+    # No file on disk → uncacheable (prefer a false miss over a false hit, D8).
+    key = compute_tu_cache_key(
+        extractor_name="clang-source",
+        extractor_version="0.1",
+        compile_unit=_cu("cu://x", "does/not/exist.cpp"),
+        public_header_roots=[],
+    )
+    assert key is None
+
+
+def test_cache_key_changes_with_source_content(tmp_path: Path) -> None:
+    src = tmp_path / "foo.cpp"
+    src.write_text("int a;\n")
+    cu = _cu("cu://x", str(src))
+    k1 = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[],
+    )
+    src.write_text("int a; int b;\n")
+    k2 = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[],
+    )
+    assert k1 and k2 and k1 != k2
+
+
+def test_cache_key_changes_with_extractor_and_flags(tmp_path: Path) -> None:
+    src = tmp_path / "foo.cpp"
+    src.write_text("int a;\n")
+    cu = _cu("cu://x", str(src), standard="c++17")
+    base = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[],
+    )
+    other_tool = compute_tu_cache_key(
+        extractor_name="castxml-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[],
+    )
+    cu_flag = _cu("cu://x", str(src), standard="c++17", abi_relevant_flags=["-m32"])
+    flagged = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu_flag, public_header_roots=[],
+    )
+    assert base != other_tool != flagged != base
+
+
+def test_cache_key_changes_with_header_content(tmp_path: Path) -> None:
+    src = tmp_path / "foo.cpp"
+    src.write_text("int a;\n")
+    hdr = tmp_path / "foo.h"
+    hdr.write_text("int x;\n")
+    cu = _cu("cu://x", str(src))
+    k1 = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[str(hdr)],
+    )
+    hdr.write_text("int x; int y;\n")
+    k2 = compute_tu_cache_key(
+        extractor_name="clang-source", extractor_version="0.1",
+        compile_unit=cu, public_header_roots=[str(hdr)],
+    )
+    assert k1 and k2 and k1 != k2
+
+
+def test_cache_roundtrip_and_miss(tmp_path: Path) -> None:
+    cache = SourceAbiCache(tmp_path / "cache")
+    assert cache.get("missing") is None
+    assert cache.get(None) is None  # uncacheable key is always a miss
+    tu = SourceAbiTu(tu_id="cu://x", functions=[SourceEntity(id="e", kind="function")])
+    cache.put("k1", tu)
+    loaded = cache.get("k1")
+    assert loaded is not None and loaded.tu_id == "cu://x"
+    cache.put(None, tu)  # no-op, must not raise
+
+
+# -- driver ------------------------------------------------------------------
+
+
+def test_run_source_replay_links_selected_units() -> None:
+    extractor = _FakeExtractor()
+    surface, diagnostics = run_source_replay(
+        _build(), extractor, scope="target", target_id="target://libfoo",
+        public_header_roots=["include/foo.h"],
+    )
+    assert diagnostics == []
+    assert extractor.calls == ["cu://a", "cu://b"]
+    assert len(surface.reachable_declarations) == 2
+    assert surface.coverage["replay_scope"] == "target"
+    assert surface.coverage["compile_units_parsed"] == 2
+
+
+def test_run_source_replay_records_failures_as_diagnostics() -> None:
+    extractor = _FakeExtractor(fail_for={"cu://b"})
+    surface, diagnostics = run_source_replay(
+        _build(), extractor, scope="target", target_id="target://libfoo",
+        public_header_roots=["include/foo.h"],
+    )
+    # cu://b failed → recorded as a diagnostic, cu://a still linked (partial L4).
+    assert len(diagnostics) == 1 and "cu://b" in diagnostics[0]
+    assert len(surface.reachable_declarations) == 1
+    assert surface.coverage["extractor_failures"] == 1
+
+
+def test_run_source_replay_off_scope_is_empty() -> None:
+    extractor = _FakeExtractor()
+    surface, diagnostics = run_source_replay(_build(), extractor, scope="off")
+    assert extractor.calls == [] and diagnostics == []
+    assert surface.reachable_declarations == []
+
+
+def test_run_source_replay_uses_cache_to_skip_reextraction(tmp_path: Path) -> None:
+    # A real on-disk source so the cache key is computable.
+    src = tmp_path / "a.cpp"
+    src.write_text("int a;\n")
+    build = BuildEvidence(
+        targets=[Target(id="target://t", public_headers=["foo.h"])],
+        compile_units=[_cu("cu://a", str(src), "target://t")],
+    )
+    cache = SourceAbiCache(tmp_path / "cache")
+    first = _FakeExtractor()
+    run_source_replay(
+        build, first, scope="full", public_header_roots=[], cache=cache,
+    )
+    assert first.calls == ["cu://a"]
+    # Second run hits the cache: the extractor is never called again.
+    second = _FakeExtractor()
+    surface, _ = run_source_replay(
+        build, second, scope="full", public_header_roots=[], cache=cache,
+    )
+    assert second.calls == []
+    assert len(surface.reachable_declarations) == 1


### PR DESCRIPTION
## What & why

Completes **ADR-030 (Source ABI Replay and Linked Source Surface)**. The ADR was previously implemented only through phases 1–4, and even those existed as a library layer that **no CLI command actually invoked**. This PR adds the remaining phases (5–7) and wires the whole L4 pipeline end-to-end, so source ABI replay is now reachable from `collect-evidence` / `compare`.

No new `ChangeKind`s — phases 5/6 feed the existing nine source-replay kinds.

## Phases implemented

**Phase 5 — `ClangSourceExtractor`** (`evidence/source_extractors/clang.py`): the *source-based* backend. Parses a TU under its real per-TU build context with `clang -Xclang -ast-dump=json` and derives the fingerprints castxml can't — **inline function bodies, function/class template bodies, `constexpr` values, and default arguments**.
- **Requires clang.** Absent clang → `SourceExtractionError` → *partial* L4 coverage; artifact tiers (L0–L2) stay authoritative and the comparison never aborts.
- **No new Python dependency** (ADR-001): clang is an optional runtime tool, discovered like castxml.
- **GCC projects**: clang replays the GCC build's flags; a TU using a GCC-only extension clang rejects degrades to partial coverage, never a hard failure.
- Pure argv builder + JSON-AST→`SourceAbiTu` mapping are unit-tested; the clang run is `integration`-marked.

**Phase 6 — `AndroidHeaderAbiAdapter`** (`evidence/source_extractors/android.py`): reuses Android header-checker `.sdump`/`.lsdump` output, normalized into the abicheck `SourceAbiTu` (D9). Non-executing by default (consumes a pre-captured dump); running `header-abi-dumper` is opt-in (ADR-032 D5).

**Phase 7 — `source_replay.py`**: the `off`/`headers-only`/`changed`/`target`/`full` replay scopes (D7) as a pure `select_compile_units`; a content-addressed per-TU `SourceAbiCache` keyed on the D8 inputs (extractor identity, source + header *content* hashes, normalized compile context; uncacheable → re-extract, ADR-033 D5); the `run_source_replay` driver (extract → link → partial-coverage diagnostics); and `scope_for_ci_mode` mapping the ADR-033 D2 CI modes.

**Refactor**: shared compile-context → argv logic factored into `evidence/source_extractors/_argv.py`, reused by castxml and clang. castxml keeps its historical private names (`_unredact_home`, …) as re-export aliases so existing call sites/tests are unchanged.

## CLI wiring + capability reporting

- `collect-evidence --source-abi [--source-abi-extractor clang|castxml|android] [--source-abi-scope ...] [--source-abi-cache DIR]` writes `source/source_abi.json`.
- `compare --old/--new-evidence` diffs the two surfaces (`diff_source_abi`) and folds findings into the verdict pipeline (never sole `BREAKING` authority, ADR-028 D3).
- New **capability report** printed by compare: which check categories are enabled and, for each disabled one, *why* — across the tiers (no binary / no debug info / no headers / no build data / no sources-or-clang):

```
Checks enabled for this scan (and why others are not):
  [on]  Symbol presence & linkage (added/removed/SONAME) — from the binary's dynamic symbol table
  [on]  Type layout, members, vtables, signatures — from DWARF/PDB debug info
  [on]  API decls absent from the symbol table; public-surface scoping — from the public header AST
  [on]  Build-flag & toolchain drift (visibility, std, ABI flags) — from build-system data
  [off] Macros, default args, inline/template/constexpr bodies — no sources/clang: source-only API changes are not detected
  [off] Impact / call / reachability graph — no graph evidence: cross-symbol impact is not analyzed
```

## Docs

- ADR-030 status → **implemented (phases 1–7)**, with a per-phase implementation note.
- `docs/concepts/evidence-pack.md`: source-abi workflow, the **requires-clang / graceful-degradation** note, and the capability-report section.
- Evidence `CLAUDE.md` module maps updated.

## Testing

- New: `tests/test_source_replay.py` (scope selection, cache, driver), `tests/test_source_extractors_clang.py` (argv builder + AST mapping + integration), `tests/test_source_extractors_android.py` (normalizer + adapter), plus CLI tests in `tests/test_evidence_cli.py` (graceful degradation, Android dump, source-diff findings, capability report).
- Verified locally: full fast suite **8781 passed**; `ruff check`, `mypy abicheck/`, and `scripts/check_ai_readiness.py` all clean. The clang path is exercised end-to-end (clang present in the dev container): inline-body fingerprints, constexpr values, templates, and default args all extracted; a default-arg change surfaces as `default_argument_changed` through the compare pipeline.

https://claude.ai/code/session_01YE8CA9TvytovpzrvfePyTa

---
_Generated by [Claude Code](https://claude.ai/code/session_01YE8CA9TvytovpzrvfePyTa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * collect-evidence gains optional L4 "source ABI replay" (--source-abi) with selectable extractors (clang, castxml, android), scope options (off/headers-only/changed/target/full), Android dump input, per-TU cache, and clang binary override.
  * Capability report now shows which check categories are enabled/disabled with reasons; L4 coverage is reported as PRESENT/PARTIAL/NOT_COLLECTED.

* **Documentation**
  * Evidence Pack guide and ADR updated with CLI examples and L4 replay details.

* **Tests**
  * Expanded test coverage for source replay, clang/android extractors, caching, and CLI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->