### PR TITLE
feat: sticky PR comment for ABI/API findings in GitHub Action

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1963,6 +1963,7 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
     cli_debian_symbols,  # noqa: F401  — registers debian-symbols
     cli_evidence,  # noqa: F401  — registers collect-evidence
     cli_plugin,  # noqa: F401  — registers plugin-check
+    cli_pr_comment,  # noqa: F401  — registers pr-comment
     cli_probe,  # noqa: F401  — registers probe (run, compare)
     cli_stack,  # noqa: F401  — registers deps, stack-check
     cli_suggest,  # noqa: F401  — registers suggest-suppressions

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -612,6 +612,8 @@ def _format_release_summary(
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] | None = None,
     bundle_result: BundleDiffResult | None = None,
     matrix_result: DiffResult | None = None,
+    severity_config: SeverityConfig | None = None,
+    severity_exit_code: int | None = None,
 ) -> str:
     """Format the release comparison summary as JSON, markdown, or JUnit XML."""
     if fmt == "junit":
@@ -621,6 +623,8 @@ def _format_release_summary(
             worst_verdict, old_dir, new_dir, library_results,
             removed_keys, added_keys, old_map, new_map, warning_msgs,
             bundle_result, matrix_result,
+            severity_config=severity_config,
+            severity_exit_code=severity_exit_code,
         )
     return _format_release_markdown(
         worst_verdict, old_dir, new_dir, library_results,
@@ -658,6 +662,8 @@ def _format_release_json(
     warning_msgs: list[str],
     bundle_result: BundleDiffResult | None,
     matrix_result: DiffResult | None,
+    severity_config: SeverityConfig | None = None,
+    severity_exit_code: int | None = None,
 ) -> str:
     """Render the release summary as a JSON document."""
     changed_libraries = [
@@ -674,6 +680,19 @@ def _format_release_json(
         "unmatched_new": [new_map[k].name for k in added_keys],
         "warnings": warning_msgs,
     }
+    # Severity config block (present only when --severity-* was active), mirroring
+    # compare mode so downstream consumers (e.g. the PR-comment renderer) can see
+    # which categories are gated to error and bucket findings accordingly.
+    if severity_config is not None:
+        summary["severity"] = {
+            "config": {
+                "abi_breaking": severity_config.abi_breaking.value,
+                "potential_breaking": severity_config.potential_breaking.value,
+                "quality_issues": severity_config.quality_issues.value,
+                "addition": severity_config.addition.value,
+            },
+            "exit_code": severity_exit_code,
+        }
     # Release-level public-surface scoping rollup (ADR-024, issue #235).
     # Present only when --scope-public-headers was active (per-library
     # entries then carry a "scope_resolved" key).
@@ -1016,6 +1035,7 @@ def _finalize_release_output(
     fail_on_removed: bool,
     matrix_result: DiffResult | None = None,
     severity_exit_code: int | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> None:
     """Write summary output, step summary, per-library dir report, then exit."""
     text = _format_release_summary(
@@ -1025,6 +1045,8 @@ def _finalize_release_output(
         diff_pairs=diff_pairs if fmt == "junit" else None,
         bundle_result=bundle_result,
         matrix_result=matrix_result,
+        severity_config=severity_config,
+        severity_exit_code=severity_exit_code,
     )
     _write_or_echo(output, text)
 
@@ -1361,6 +1383,10 @@ def compare_release_cmd(
         # are still stashed (before _strip_diff_results_and_adjust_verdict).
         # Returns None when no --severity-* option was supplied, in which case
         # the legacy verdict-based exit is used downstream.
+        severity_config = _resolve_release_severity_config(
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
+        )
         severity_exit_code = _compute_release_severity_exit_code(
             library_results,
             severity_preset, severity_abi_breaking, severity_potential_breaking,
@@ -1406,6 +1432,7 @@ def compare_release_cmd(
             output, output_dir, annotate, fail_on_removed,
             matrix_result=matrix_result,
             severity_exit_code=severity_exit_code,
+            severity_config=severity_config,
         )
     finally:
         _cleanup_temp_dirs(_temp_dir_paths, keep_extracted)

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -20,6 +20,7 @@ AI-readiness file-size limit. Imported for side-effect at the bottom
 of :mod:`abicheck.cli` so the ``@main.command("compare-release")``
 decorator runs.
 """
+
 from __future__ import annotations
 
 import json
@@ -84,17 +85,31 @@ def _run_compare_pair(
     new_input, new_fmt = _normalize_binary_input(new_input)
 
     old = _resolve_input(
-        old_input, old_headers, old_includes, old_version, lang,
-        is_elf=True if old_fmt == "elf" else None, pdb_path=old_pdb_path,
+        old_input,
+        old_headers,
+        old_includes,
+        old_version,
+        lang,
+        is_elf=True if old_fmt == "elf" else None,
+        pdb_path=old_pdb_path,
     )
     new = _resolve_input(
-        new_input, new_headers, new_includes, new_version, lang,
-        is_elf=True if new_fmt == "elf" else None, pdb_path=new_pdb_path,
+        new_input,
+        new_headers,
+        new_includes,
+        new_version,
+        lang,
+        is_elf=True if new_fmt == "elf" else None,
+        pdb_path=new_pdb_path,
     )
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
     result = compare(
-        old, new, suppression=suppression, policy=policy, policy_file=pf,
+        old,
+        new,
+        suppression=suppression,
+        policy=policy,
+        policy_file=pf,
         scope_to_public_surface=scope_to_public_surface,
         pattern_verdicts=pattern_verdicts,
     )
@@ -104,29 +119,42 @@ def _run_compare_pair(
 
 
 _RELEASE_VERDICT_ORDER: dict[str, int] = {
-    "NO_CHANGE": 0, "COMPATIBLE": 1, "COMPATIBLE_WITH_RISK": 2,
-    "API_BREAK": 3, "BREAKING": 4, "ERROR": 5,
+    "NO_CHANGE": 0,
+    "COMPATIBLE": 1,
+    "COMPATIBLE_WITH_RISK": 2,
+    "API_BREAK": 3,
+    "BREAKING": 4,
+    "ERROR": 5,
 }
 
 
 _CompareReleaseCommonArgs = tuple[
-    dict[str, Path], dict[str, Path],
-    Path | None, Path | None,
+    dict[str, Path],
+    dict[str, Path],
+    Path | None,
+    Path | None,
     Callable[[Path, Path], Path | None],
-    list[Path], list[Path],
-    list[Path], list[Path],
-    str, str,
-    str, Path | None,
-    str, Path | None,
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
+    str,
+    str,
+    str,
+    Path | None,
+    str,
+    Path | None,
     Path | None,
     bool,
 ]
 
 
 def _discover_files(
-    input_dir: Path, lib_dir: Path,
+    input_dir: Path,
+    lib_dir: Path,
     include_private: bool,
-    discover_shared_libraries: Callable[..., list[Path]], is_package: Callable[[Path], bool],
+    discover_shared_libraries: Callable[..., list[Path]],
+    is_package: Callable[[Path], bool],
 ) -> list[Path]:
     """Discover library files from a directory or extracted package."""
     if is_package(input_dir):
@@ -181,15 +209,20 @@ def _discover_include_roots(header_dir: Path | None) -> list[Path]:
 
 
 def _match_release_keys(
-    old_dir: Path, new_dir: Path,
-    old_map: dict[str, Path], new_map: dict[str, Path],
-    old_files: list[Path], new_files: list[Path],
+    old_dir: Path,
+    new_dir: Path,
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
+    old_files: list[Path],
+    new_files: list[Path],
     is_package: Callable[[Path], bool],
 ) -> tuple[list[str], list[str], list[str], dict[str, Path], dict[str, Path]]:
     """Match library keys between old and new, handling direct file pairs."""
     direct_file_pair = (
-        old_dir.is_file() and new_dir.is_file()
-        and not is_package(old_dir) and not is_package(new_dir)
+        old_dir.is_file()
+        and new_dir.is_file()
+        and not is_package(old_dir)
+        and not is_package(new_dir)
     )
     if direct_file_pair:
         matched_keys = ["__direct_pair__"]
@@ -205,8 +238,11 @@ def _match_release_keys(
 
 def _collect_release_warnings(
     warning_msgs: list[str],
-    matched_keys: list[str], removed_keys: list[str], added_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
+    matched_keys: list[str],
+    removed_keys: list[str],
+    added_keys: list[str],
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
 ) -> None:
     """Collect warning messages for unmatched libraries."""
     for k in removed_keys:
@@ -221,14 +257,21 @@ def _collect_release_warnings(
 
 def _compare_one_library(
     key: str,
-    old_map: dict[str, Path], new_map: dict[str, Path],
-    old_debug_dir: Path | None, new_debug_dir: Path | None,
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
+    old_debug_dir: Path | None,
+    new_debug_dir: Path | None,
     resolve_debug_info: Callable[[Path, Path], Path | None],
-    old_h: list[Path], new_h: list[Path],
-    old_inc: list[Path], new_inc: list[Path],
-    old_version: str, new_version: str,
-    lang: str, suppress: Path | None,
-    policy: str, policy_file_path: Path | None,
+    old_h: list[Path],
+    new_h: list[Path],
+    old_inc: list[Path],
+    new_inc: list[Path],
+    old_version: str,
+    new_version: str,
+    lang: str,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
     output_dir: Path | None,
     scope_to_public_surface: bool = False,
 ) -> dict[str, object]:
@@ -249,20 +292,38 @@ def _compare_one_library(
         old_dbg = resolve_debug_info(old_path, old_debug_dir) if old_debug_dir else None
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
         result, _, _ = _run_compare_pair(
-            old_path, new_path,
-            old_h, new_h, old_inc, new_inc,
-            old_version, new_version,
-            lang, suppress, policy, policy_file_path,
-            old_pdb_path=old_dbg, new_pdb_path=new_dbg,
+            old_path,
+            new_path,
+            old_h,
+            new_h,
+            old_inc,
+            new_inc,
+            old_version,
+            new_version,
+            lang,
+            suppress,
+            policy,
+            policy_file_path,
+            old_pdb_path=old_dbg,
+            new_pdb_path=new_dbg,
             scope_to_public_surface=scope_to_public_surface,
         )
         v = result.verdict.value
+        # compatible_additions historically counts *all* compatible changes
+        # (additions + quality issues). Emit the quality subset separately so
+        # downstream consumers (e.g. the PR-comment renderer) can gate the two
+        # categories independently under --severity-quality-issues.
+        from .checker_policy import ADDITION_KINDS
+
+        n_quality = sum(1 for c in result.compatible if c.kind not in ADDITION_KINDS)
         entry: dict[str, object] = {
-            "library": old_path.name, "verdict": v,
+            "library": old_path.name,
+            "verdict": v,
             "breaking": len(result.breaking),
             "source_breaks": len(result.source_breaks),
             "risk_changes": len(result.risk),
             "compatible_additions": len(result.compatible),
+            "quality_issues": n_quality,
             "_diff_result": result,
         }
         if scope_to_public_surface:
@@ -275,7 +336,11 @@ def _compare_one_library(
             _safe_write_output(lib_report_path, to_json(result))
         return entry
     except (click.ClickException, click.UsageError) as exc:
-        return {"library": old_path.name, "verdict": "ERROR", "error": exc.format_message()}
+        return {
+            "library": old_path.name,
+            "verdict": "ERROR",
+            "error": exc.format_message(),
+        }
     except Exception as exc:
         return {"library": old_path.name, "verdict": "ERROR", "error": str(exc)}
 
@@ -308,14 +373,12 @@ def _suppress_lockstep_soname_findings(
         if not isinstance(result, DiffResult):
             continue
         unnecessary = [
-            c for c in result.changes
-            if c.kind == ChangeKind.SONAME_BUMP_UNNECESSARY
+            c for c in result.changes if c.kind == ChangeKind.SONAME_BUMP_UNNECESSARY
         ]
         if not unnecessary:
             continue
         result.changes = [
-            c for c in result.changes
-            if c.kind != ChangeKind.SONAME_BUMP_UNNECESSARY
+            c for c in result.changes if c.kind != ChangeKind.SONAME_BUMP_UNNECESSARY
         ]
         suppressed += len(unnecessary)
         # Recompute the cached per-library counts after the mutation.
@@ -331,14 +394,21 @@ def _suppress_lockstep_soname_findings(
 
 def _compare_release_libraries(
     matched_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
-    old_debug_dir: Path | None, new_debug_dir: Path | None,
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
+    old_debug_dir: Path | None,
+    new_debug_dir: Path | None,
     resolve_debug_info: Callable[[Path, Path], Path | None],
-    old_h: list[Path], new_h: list[Path],
-    old_inc: list[Path], new_inc: list[Path],
-    old_version: str, new_version: str,
-    lang: str, suppress: Path | None,
-    policy: str, policy_file_path: Path | None,
+    old_h: list[Path],
+    new_h: list[Path],
+    old_inc: list[Path],
+    new_inc: list[Path],
+    old_version: str,
+    new_version: str,
+    lang: str,
+    suppress: Path | None,
+    policy: str,
+    policy_file_path: Path | None,
     output_dir: Path | None,
     collect_diff_results: bool = False,
     *,
@@ -365,16 +435,30 @@ def _compare_release_libraries(
     all_annotations: list[tuple[int, str]] = []
 
     common_args = (
-        old_map, new_map, old_debug_dir, new_debug_dir, resolve_debug_info,
-        old_h, new_h, old_inc, new_inc,
-        old_version, new_version,
-        lang, suppress, policy, policy_file_path, output_dir,
+        old_map,
+        new_map,
+        old_debug_dir,
+        new_debug_dir,
+        resolve_debug_info,
+        old_h,
+        new_h,
+        old_inc,
+        new_inc,
+        old_version,
+        new_version,
+        lang,
+        suppress,
+        policy,
+        policy_file_path,
+        output_dir,
         scope_to_public_surface,
     )
 
     if effective_jobs > 1 and len(matched_keys) > 1:
         library_results.extend(
-            _compare_release_parallel(matched_keys, common_args, old_map, effective_jobs),
+            _compare_release_parallel(
+                matched_keys, common_args, old_map, effective_jobs
+            ),
         )
     else:
         library_results.extend(
@@ -387,14 +471,20 @@ def _compare_release_libraries(
         v = str(entry["verdict"])
         if v == "ERROR":
             if "error" in entry:
-                click.echo(f"Error comparing {entry['library']}: {entry['error']}", err=True)
-        if _RELEASE_VERDICT_ORDER.get(v, 0) > _RELEASE_VERDICT_ORDER.get(worst_verdict, 0):
+                click.echo(
+                    f"Error comparing {entry['library']}: {entry['error']}", err=True
+                )
+        if _RELEASE_VERDICT_ORDER.get(v, 0) > _RELEASE_VERDICT_ORDER.get(
+            worst_verdict, 0
+        ):
             worst_verdict = v
 
     # Cross-library coupling: a coordinated SONAME bump across the release is not
     # "unnecessary" just because one member had no break of its own.
     suppressed_soname = _suppress_lockstep_soname_findings(
-        library_results, worst_verdict, output_dir,
+        library_results,
+        worst_verdict,
+        output_dir,
     )
     if suppressed_soname:
         click.echo(
@@ -409,11 +499,22 @@ def _compare_release_libraries(
     # are sequential-only features)
     if collect_diff_results or annotate:
         extra_pairs, extra_annotations = _collect_release_extras(
-            matched_keys, old_map, new_map,
-            old_debug_dir, new_debug_dir, resolve_debug_info,
-            old_h, new_h, old_inc, new_inc,
-            old_version, new_version, lang,
-            suppress, policy, policy_file_path,
+            matched_keys,
+            old_map,
+            new_map,
+            old_debug_dir,
+            new_debug_dir,
+            resolve_debug_info,
+            old_h,
+            new_h,
+            old_inc,
+            new_inc,
+            old_version,
+            new_version,
+            lang,
+            suppress,
+            policy,
+            policy_file_path,
             annotate_additions=annotate_additions,
             collect_diff_results=collect_diff_results,
             annotate=annotate,
@@ -462,7 +563,9 @@ def _compare_release_parallel(
             except Exception as exc:
                 click.echo(f"Error comparing {old_map[key].name}: {exc}", err=True)
                 results_by_key[key] = {
-                    "library": old_map[key].name, "verdict": "ERROR", "error": str(exc),
+                    "library": old_map[key].name,
+                    "verdict": "ERROR",
+                    "error": str(exc),
                 }
     return [results_by_key[key] for key in matched_keys if key in results_by_key]
 
@@ -508,11 +611,20 @@ def _collect_release_extras(
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
         try:
             result, old_snap, _ = _run_compare_pair(
-                old_path, new_path,
-                old_h, new_h, old_inc, new_inc,
-                old_version, new_version,
-                lang, suppress, policy, policy_file_path,
-                old_pdb_path=old_dbg, new_pdb_path=new_dbg,
+                old_path,
+                new_path,
+                old_h,
+                new_h,
+                old_inc,
+                new_inc,
+                old_version,
+                new_version,
+                lang,
+                suppress,
+                policy,
+                policy_file_path,
+                old_pdb_path=old_dbg,
+                new_pdb_path=new_dbg,
                 scope_to_public_surface=scope_to_public_surface,
             )
         except Exception as exc:
@@ -589,7 +701,9 @@ def _run_bundle_analysis(
     ]
     try:
         return compare_bundle(
-            old_snap, new_snap, per_lib_results,
+            old_snap,
+            new_snap,
+            per_lib_results,
             manifest=manifest,
             system_providers=system_extra or None,
             cohorts=list(bundle_cohorts) or None,
@@ -603,11 +717,15 @@ def _run_bundle_analysis(
 
 
 def _format_release_summary(
-    fmt: str, worst_verdict: str,
-    old_dir: Path, new_dir: Path,
+    fmt: str,
+    worst_verdict: str,
+    old_dir: Path,
+    new_dir: Path,
     library_results: list[dict[str, object]],
-    removed_keys: list[str], added_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
+    removed_keys: list[str],
+    added_keys: list[str],
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
     warning_msgs: list[str],
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] | None = None,
     bundle_result: BundleDiffResult | None = None,
@@ -620,15 +738,31 @@ def _format_release_summary(
         return _format_release_junit(diff_pairs, matrix_result, library_results)
     if fmt == "json":
         return _format_release_json(
-            worst_verdict, old_dir, new_dir, library_results,
-            removed_keys, added_keys, old_map, new_map, warning_msgs,
-            bundle_result, matrix_result,
+            worst_verdict,
+            old_dir,
+            new_dir,
+            library_results,
+            removed_keys,
+            added_keys,
+            old_map,
+            new_map,
+            warning_msgs,
+            bundle_result,
+            matrix_result,
             severity_config=severity_config,
             severity_exit_code=severity_exit_code,
         )
     return _format_release_markdown(
-        worst_verdict, old_dir, new_dir, library_results,
-        removed_keys, added_keys, old_map, new_map, bundle_result, matrix_result,
+        worst_verdict,
+        old_dir,
+        new_dir,
+        library_results,
+        removed_keys,
+        added_keys,
+        old_map,
+        new_map,
+        bundle_result,
+        matrix_result,
     )
 
 
@@ -639,26 +773,28 @@ def _format_release_junit(
 ) -> str:
     """Render the release summary as a JUnit XML report."""
     from .junit_report import to_junit_xml_multi
+
     pairs: list[tuple[DiffResult, AbiSnapshot | None]] = list(diff_pairs or [])
     # Release-global matrix findings ride in as their own synthetic
     # testsuite so CI dashboards reading the JUnit report see the failure.
     if matrix_result is not None:
         pairs.append((matrix_result, None))
-    error_libs = [
-        entry for entry in library_results
-        if entry.get("verdict") == "ERROR"
-    ]
+    error_libs = [entry for entry in library_results if entry.get("verdict") == "ERROR"]
     return to_junit_xml_multi(
-        pairs, error_libraries=error_libs if error_libs else None,
+        pairs,
+        error_libraries=error_libs if error_libs else None,
     )
 
 
 def _format_release_json(
     worst_verdict: str,
-    old_dir: Path, new_dir: Path,
+    old_dir: Path,
+    new_dir: Path,
     library_results: list[dict[str, object]],
-    removed_keys: list[str], added_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
+    removed_keys: list[str],
+    added_keys: list[str],
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
     warning_msgs: list[str],
     bundle_result: BundleDiffResult | None,
     matrix_result: DiffResult | None,
@@ -667,7 +803,8 @@ def _format_release_json(
 ) -> str:
     """Render the release summary as a JSON document."""
     changed_libraries = [
-        str(lib["library"]) for lib in library_results
+        str(lib["library"])
+        for lib in library_results
         if str(lib.get("verdict")) not in ("NO_CHANGE", "ERROR")
     ]
     summary: dict[str, object] = {
@@ -734,8 +871,10 @@ def _format_release_json(
 
 def _release_json_scope(scoped_libs: list[dict[str, object]]) -> dict[str, object]:
     """Build the release-level public-surface scoping rollup for JSON output."""
+
     def _as_int(v: object) -> int:
         return v if isinstance(v, int) else 0
+
     return {
         "public_headers_applied": True,
         "manual_review_required": any(
@@ -752,21 +891,30 @@ def _release_json_scope(scoped_libs: list[dict[str, object]]) -> dict[str, objec
 
 def _format_release_markdown(
     worst_verdict: str,
-    old_dir: Path, new_dir: Path,
+    old_dir: Path,
+    new_dir: Path,
     library_results: list[dict[str, object]],
-    removed_keys: list[str], added_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
+    removed_keys: list[str],
+    added_keys: list[str],
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
     bundle_result: BundleDiffResult | None,
     matrix_result: DiffResult | None,
 ) -> str:
     """Render the release summary as a Markdown document."""
     _VERDICT_EMOJI = {
-        "NO_CHANGE": "✅", "COMPATIBLE": "✅", "COMPATIBLE_WITH_RISK": "⚠️",
-        "API_BREAK": "⚠️", "BREAKING": "❌", "ERROR": "💥",
+        "NO_CHANGE": "✅",
+        "COMPATIBLE": "✅",
+        "COMPATIBLE_WITH_RISK": "⚠️",
+        "API_BREAK": "⚠️",
+        "BREAKING": "❌",
+        "ERROR": "💥",
     }
     lines: list[str] = [
-        "# ABI Release Comparison", "",
-        "| | |", "|---|---|",
+        "# ABI Release Comparison",
+        "",
+        "| | |",
+        "|---|---|",
         f"| **Old** | `{old_dir}` |",
         f"| **New** | `{new_dir}` |",
         f"| **Verdict** | {_VERDICT_EMOJI.get(worst_verdict, '?')} `{worst_verdict}` |",
@@ -786,11 +934,14 @@ def _format_release_markdown(
 
 
 def _release_md_libraries_table(
-    library_results: list[dict[str, object]], emoji: dict[str, str],
+    library_results: list[dict[str, object]],
+    emoji: dict[str, str],
 ) -> list[str]:
     """Markdown per-library results table."""
     lines = [
-        "", "## Libraries", "",
+        "",
+        "## Libraries",
+        "",
         "| Library | Verdict | Breaking | Source | Risk | Additions |",
         "|---|---|---|---|---|---|",
     ]
@@ -805,8 +956,10 @@ def _release_md_libraries_table(
 
 
 def _release_md_changed_libraries(
-    removed_keys: list[str], added_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
+    removed_keys: list[str],
+    added_keys: list[str],
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
 ) -> list[str]:
     """Markdown sections listing removed/added libraries."""
     lines: list[str] = []
@@ -853,10 +1006,13 @@ def _release_md_matrix_findings(matrix_result: DiffResult | None) -> list[str]:
 
 
 def _write_release_summary_file(
-    output_dir: Path, worst_verdict: str,
+    output_dir: Path,
+    worst_verdict: str,
     library_results: list[dict[str, object]],
-    removed_keys: list[str], added_keys: list[str],
-    old_map: dict[str, Path], new_map: dict[str, Path],
+    removed_keys: list[str],
+    added_keys: list[str],
+    old_map: dict[str, Path],
+    new_map: dict[str, Path],
 ) -> None:
     """Write per-library summary JSON to output directory."""
     summary_data: dict[str, object] = {
@@ -903,7 +1059,9 @@ def _extract_if_package(
     if debug_pkg is not None:
         dbg_ext = detect_extractor(debug_pkg)
         if dbg_ext is None:
-            raise click.ClickException(f"Unrecognized debug package format: {debug_pkg}")
+            raise click.ClickException(
+                f"Unrecognized debug package format: {debug_pkg}"
+            )
         dbg_target = make_temp_dir("abicheck_dbg_")
         dbg_result = dbg_ext.extract(debug_pkg, dbg_target)
         debug_dir = dbg_result.debug_dir or dbg_result.lib_dir
@@ -911,7 +1069,9 @@ def _extract_if_package(
     if devel_pkg is not None:
         dev_ext = detect_extractor(devel_pkg)
         if dev_ext is None:
-            raise click.ClickException(f"Unrecognized devel package format: {devel_pkg}")
+            raise click.ClickException(
+                f"Unrecognized devel package format: {devel_pkg}"
+            )
         dev_target = make_temp_dir("abicheck_dev_")
         dev_result = dev_ext.extract(devel_pkg, dev_target)
         header_dir = dev_result.header_dir or dev_result.lib_dir
@@ -935,14 +1095,18 @@ def _collect_bundle_result(
         if isinstance(diff, DiffResult):
             stashed_diffs.append(diff)
     bundle_result = _run_bundle_analysis(
-        old_map, new_map, stashed_diffs,
+        old_map,
+        new_map,
+        stashed_diffs,
         manifest_path=manifest_path,
         bundle_system_providers=bundle_system_providers,
         bundle_cohorts=bundle_cohorts,
     )
     if bundle_result is not None:
         bv = bundle_result.bundle_verdict.value
-        if _RELEASE_VERDICT_ORDER.get(bv, 0) > _RELEASE_VERDICT_ORDER.get(worst_verdict, 0):
+        if _RELEASE_VERDICT_ORDER.get(bv, 0) > _RELEASE_VERDICT_ORDER.get(
+            worst_verdict, 0
+        ):
             worst_verdict = bv
     return bundle_result, worst_verdict
 
@@ -999,7 +1163,9 @@ def _collect_matrix_result(
         extra_changes=matrix_changes,
     )
     matrix_verdict = result.verdict.value
-    if _RELEASE_VERDICT_ORDER.get(matrix_verdict, 0) > _RELEASE_VERDICT_ORDER.get(worst_verdict, 0):
+    if _RELEASE_VERDICT_ORDER.get(matrix_verdict, 0) > _RELEASE_VERDICT_ORDER.get(
+        worst_verdict, 0
+    ):
         worst_verdict = matrix_verdict
     return result, worst_verdict
 
@@ -1039,9 +1205,16 @@ def _finalize_release_output(
 ) -> None:
     """Write summary output, step summary, per-library dir report, then exit."""
     text = _format_release_summary(
-        fmt, worst_verdict, old_dir, new_dir,
-        library_results, removed_keys, added_keys,
-        old_map, new_map, warning_msgs,
+        fmt,
+        worst_verdict,
+        old_dir,
+        new_dir,
+        library_results,
+        removed_keys,
+        added_keys,
+        old_map,
+        new_map,
+        warning_msgs,
         diff_pairs=diff_pairs if fmt == "junit" else None,
         bundle_result=bundle_result,
         matrix_result=matrix_result,
@@ -1055,11 +1228,18 @@ def _finalize_release_output(
 
     if output_dir:
         _write_release_summary_file(
-            output_dir, worst_verdict, library_results,
-            removed_keys, added_keys, old_map, new_map,
+            output_dir,
+            worst_verdict,
+            library_results,
+            removed_keys,
+            added_keys,
+            old_map,
+            new_map,
         )
 
-    _exit_compare_release(worst_verdict, fail_on_removed, removed_keys, severity_exit_code)
+    _exit_compare_release(
+        worst_verdict, fail_on_removed, removed_keys, severity_exit_code
+    )
 
 
 def _validate_suppression_early(
@@ -1077,7 +1257,9 @@ def _validate_suppression_early(
     """
     if suppress is not None and (strict_suppressions or require_justification):
         _load_suppression_and_policy(
-            suppress, policy, policy_file_path,
+            suppress,
+            policy,
+            policy_file_path,
             strict_suppressions=strict_suppressions,
             require_justification=require_justification,
         )
@@ -1101,7 +1283,9 @@ def _strip_diff_results_and_adjust_verdict(
     for entry in library_results:
         if isinstance(entry, dict):
             entry.pop("_diff_result", None)
-    if removed_keys and _RELEASE_VERDICT_ORDER.get(worst_verdict, 0) < _RELEASE_VERDICT_ORDER.get("COMPATIBLE_WITH_RISK", 0):
+    if removed_keys and _RELEASE_VERDICT_ORDER.get(
+        worst_verdict, 0
+    ) < _RELEASE_VERDICT_ORDER.get("COMPATIBLE_WITH_RISK", 0):
         worst_verdict = "COMPATIBLE_WITH_RISK"
     return worst_verdict
 
@@ -1109,129 +1293,289 @@ def _strip_diff_results_and_adjust_verdict(
 @main.command("compare-release")
 @click.argument("old_dir", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_dir", type=click.Path(exists=True, path_type=Path))
-@click.option("-H", "--header", "headers", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header file or directory applied to both sides.")
-@click.option("-I", "--include", "includes", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Extra include directory for castxml.")
-@click.option("--old-include", "old_includes_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Include directory for old side only (overrides -I for old).")
-@click.option("--new-include", "new_includes_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Include directory for new side only (overrides -I for new).")
-@click.option("--old-header", "old_headers_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Header for old side only (overrides -H for old).")
-@click.option("--new-header", "new_headers_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Header for new side only (overrides -H for new).")
-@click.option("--old-version", "old_version", default="old", show_default=True,
-              help="Version label for old side.")
-@click.option("--new-version", "new_version", default="new", show_default=True,
-              help="Version label for new side.")
-@click.option("--lang", default="c++", show_default=True,
-              type=click.Choice(["c++", "c"], case_sensitive=False))
-@click.option("--format", "fmt",
-              type=click.Choice(["json", "markdown", "junit"]),
-              default="markdown", show_default=True)
-@click.option("-o", "--output", type=click.Path(path_type=Path), default=None,
-              help="Output file for summary report (default: stdout).")
-@click.option("--output-dir", "output_dir", type=click.Path(path_type=Path), default=None,
-              help="Directory to write per-library reports.")
-@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Suppression file (YAML).")
-@click.option("--strict-suppressions", is_flag=True, default=False,
-              help="Fail with exit code 1 if any suppression rule has expired.")
-@click.option("--require-justification", is_flag=True, default=False,
-              help="Require every suppression rule to have a non-empty 'reason' field.")
-@click.option("--policy", "policy",
-              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
-              default="strict_abi", show_default=True)
-@click.option("--policy-file", "policy_file_path",
-              type=POLICY_FILE_PARAM, default=None)
-@click.option("--fail-on-removed-library/--no-fail-on-removed-library",
-              "fail_on_removed", default=False,
-              help="Exit 8 when a library present in old_dir is absent in new_dir.")
-@click.option("--debug-info1", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Debug info package for old side (RPM/Deb/tar).")
-@click.option("--debug-info2", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Debug info package for new side (RPM/Deb/tar).")
-@click.option("--devel-pkg1", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Development package with headers for old side.")
-@click.option("--devel-pkg2", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Development package with headers for new side.")
-@click.option("--dso-only", is_flag=True, default=False,
-              help="Only compare shared objects, skip executables.")
-@click.option("--include-private-dso", is_flag=True, default=False,
-              help="Include private (non-public) shared objects from non-standard paths.")
-@click.option("--keep-extracted", is_flag=True, default=False,
-              help="Keep extracted temporary files for debugging.")
-@click.option("--annotate", is_flag=True, default=False,
-              help="Emit GitHub Actions workflow command annotations to stdout. "
-                   "Only effective when GITHUB_ACTIONS=true.")
-@click.option("--annotate-additions", is_flag=True, default=False,
-              help="Include additions/compatible changes as ::notice annotations "
-                   "(requires --annotate).")
+@click.option(
+    "-H",
+    "--header",
+    "headers",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Public header file or directory applied to both sides.",
+)
+@click.option(
+    "-I",
+    "--include",
+    "includes",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Extra include directory for castxml.",
+)
+@click.option(
+    "--old-include",
+    "old_includes_only",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Include directory for old side only (overrides -I for old).",
+)
+@click.option(
+    "--new-include",
+    "new_includes_only",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Include directory for new side only (overrides -I for new).",
+)
+@click.option(
+    "--old-header",
+    "old_headers_only",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Header for old side only (overrides -H for old).",
+)
+@click.option(
+    "--new-header",
+    "new_headers_only",
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Header for new side only (overrides -H for new).",
+)
+@click.option(
+    "--old-version",
+    "old_version",
+    default="old",
+    show_default=True,
+    help="Version label for old side.",
+)
+@click.option(
+    "--new-version",
+    "new_version",
+    default="new",
+    show_default=True,
+    help="Version label for new side.",
+)
+@click.option(
+    "--lang",
+    default="c++",
+    show_default=True,
+    type=click.Choice(["c++", "c"], case_sensitive=False),
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "markdown", "junit"]),
+    default="markdown",
+    show_default=True,
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output file for summary report (default: stdout).",
+)
+@click.option(
+    "--output-dir",
+    "output_dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory to write per-library reports.",
+)
+@click.option(
+    "--suppress",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Suppression file (YAML).",
+)
+@click.option(
+    "--strict-suppressions",
+    is_flag=True,
+    default=False,
+    help="Fail with exit code 1 if any suppression rule has expired.",
+)
+@click.option(
+    "--require-justification",
+    is_flag=True,
+    default=False,
+    help="Require every suppression rule to have a non-empty 'reason' field.",
+)
+@click.option(
+    "--policy",
+    "policy",
+    type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
+    default="strict_abi",
+    show_default=True,
+)
+@click.option("--policy-file", "policy_file_path", type=POLICY_FILE_PARAM, default=None)
+@click.option(
+    "--fail-on-removed-library/--no-fail-on-removed-library",
+    "fail_on_removed",
+    default=False,
+    help="Exit 8 when a library present in old_dir is absent in new_dir.",
+)
+@click.option(
+    "--debug-info1",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Debug info package for old side (RPM/Deb/tar).",
+)
+@click.option(
+    "--debug-info2",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Debug info package for new side (RPM/Deb/tar).",
+)
+@click.option(
+    "--devel-pkg1",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Development package with headers for old side.",
+)
+@click.option(
+    "--devel-pkg2",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Development package with headers for new side.",
+)
+@click.option(
+    "--dso-only",
+    is_flag=True,
+    default=False,
+    help="Only compare shared objects, skip executables.",
+)
+@click.option(
+    "--include-private-dso",
+    is_flag=True,
+    default=False,
+    help="Include private (non-public) shared objects from non-standard paths.",
+)
+@click.option(
+    "--keep-extracted",
+    is_flag=True,
+    default=False,
+    help="Keep extracted temporary files for debugging.",
+)
+@click.option(
+    "--annotate",
+    is_flag=True,
+    default=False,
+    help="Emit GitHub Actions workflow command annotations to stdout. "
+    "Only effective when GITHUB_ACTIONS=true.",
+)
+@click.option(
+    "--annotate-additions",
+    is_flag=True,
+    default=False,
+    help="Include additions/compatible changes as ::notice annotations "
+    "(requires --annotate).",
+)
 @click.option("-v", "--verbose", is_flag=True, default=False)
-@click.option("-j", "--jobs", "jobs", type=int, default=0, show_default=True,
-              help="Number of parallel library comparisons (0 = auto-detect CPU count, the default).")
-@click.option("--manifest", "manifest_path", type=click.Path(exists=True, path_type=Path),
-              default=None,
-              help="ABI instantiation manifest (YAML/JSON) listing symbols the "
-                   "release publicly promises. See ADR-023.")
-@click.option("--bundle-system-providers", "bundle_system_providers", default="",
-              help="Comma-separated extra sonames to treat as system-provided "
-                   "(extends the built-in libc/libstdc++/libgcc/libtbb allow-list).")
-@click.option("--bundle-cohort", "bundle_cohorts", multiple=True, metavar="PREFIX",
-              help="Declare a co-versioned library cohort by name prefix (e.g. "
-                   "'libfoo_'). Repeatable. Enables the BUNDLE_SONAME_SKEW check, "
-                   "which flags when some members of the cohort bump their major SONAME "
-                   "while siblings lag, and enables bundle-level cross-library analysis.")
-@click.option("--no-bundle-analysis", "no_bundle_analysis", is_flag=True, default=False,
-              help="Skip bundle-level cross-library analysis (debug/parity escape hatch). "
-                   "Bundle findings catch intra-bundle symbol removals, signature drift "
-                   "across DSO boundaries, type drift across siblings, provider "
-                   "migration, and manifest mismatches.")
-@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
-              default=True, show_default=True,
-              help="Restrict findings to the public-header ABI surface (ADR-024). "
-                   "On by default (matches `compare`); use --no-scope-public-headers "
-                   "to report every finding.")
-@click.option("--probe-matrix-old", "probe_matrix_old", type=click.Path(exists=True, path_type=Path),
-              default=None,
-              help="Old build-configuration matrix snapshot (from 'abicheck probe run'). "
-                   "When given with --probe-matrix-new, build-config findings "
-                   "(CXX_STANDARD_FLOOR_RAISED, API_DEPENDS_ON_CONSUMER_ENV, "
-                   "BEHAVIOURAL_DEFAULT_CHANGED) are folded into this release's "
-                   "verdict and report (G2: probe -> compare-release).")
-@click.option("--probe-matrix-new", "probe_matrix_new", type=click.Path(exists=True, path_type=Path),
-              default=None,
-              help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).")
+@click.option(
+    "-j",
+    "--jobs",
+    "jobs",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Number of parallel library comparisons (0 = auto-detect CPU count, the default).",
+)
+@click.option(
+    "--manifest",
+    "manifest_path",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="ABI instantiation manifest (YAML/JSON) listing symbols the "
+    "release publicly promises. See ADR-023.",
+)
+@click.option(
+    "--bundle-system-providers",
+    "bundle_system_providers",
+    default="",
+    help="Comma-separated extra sonames to treat as system-provided "
+    "(extends the built-in libc/libstdc++/libgcc/libtbb allow-list).",
+)
+@click.option(
+    "--bundle-cohort",
+    "bundle_cohorts",
+    multiple=True,
+    metavar="PREFIX",
+    help="Declare a co-versioned library cohort by name prefix (e.g. "
+    "'libfoo_'). Repeatable. Enables the BUNDLE_SONAME_SKEW check, "
+    "which flags when some members of the cohort bump their major SONAME "
+    "while siblings lag, and enables bundle-level cross-library analysis.",
+)
+@click.option(
+    "--no-bundle-analysis",
+    "no_bundle_analysis",
+    is_flag=True,
+    default=False,
+    help="Skip bundle-level cross-library analysis (debug/parity escape hatch). "
+    "Bundle findings catch intra-bundle symbol removals, signature drift "
+    "across DSO boundaries, type drift across siblings, provider "
+    "migration, and manifest mismatches.",
+)
+@click.option(
+    "--scope-public-headers/--no-scope-public-headers",
+    "scope_public_headers",
+    default=True,
+    show_default=True,
+    help="Restrict findings to the public-header ABI surface (ADR-024). "
+    "On by default (matches `compare`); use --no-scope-public-headers "
+    "to report every finding.",
+)
+@click.option(
+    "--probe-matrix-old",
+    "probe_matrix_old",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Old build-configuration matrix snapshot (from 'abicheck probe run'). "
+    "When given with --probe-matrix-new, build-config findings "
+    "(CXX_STANDARD_FLOOR_RAISED, API_DEPENDS_ON_CONSUMER_ENV, "
+    "BEHAVIOURAL_DEFAULT_CHANGED) are folded into this release's "
+    "verdict and report (G2: probe -> compare-release).",
+)
+@click.option(
+    "--probe-matrix-new",
+    "probe_matrix_new",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).",
+)
 # ── Severity (mirrors `compare`) ──────────────────────────────────────────────
-@click.option("--severity-preset", "severity_preset",
-              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
-              default=None,
-              help="Severity preset: 'default', 'strict', or 'info-only'. "
-                   "When set (or any --severity-* option), exit codes follow the "
-                   "severity-aware scheme aggregated across all libraries.")
-@click.option("--severity-abi-breaking", "severity_abi_breaking",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for clear ABI/API incompatibilities (overrides preset).")
-@click.option("--severity-potential-breaking", "severity_potential_breaking",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for potential incompatibilities needing review (overrides preset).")
-@click.option("--severity-quality-issues", "severity_quality_issues",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for problematic behaviors (overrides preset).")
-@click.option("--severity-addition", "severity_addition",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for new public API additions (overrides preset).")
+@click.option(
+    "--severity-preset",
+    "severity_preset",
+    type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
+    default=None,
+    help="Severity preset: 'default', 'strict', or 'info-only'. "
+    "When set (or any --severity-* option), exit codes follow the "
+    "severity-aware scheme aggregated across all libraries.",
+)
+@click.option(
+    "--severity-abi-breaking",
+    "severity_abi_breaking",
+    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+    default=None,
+    help="Severity for clear ABI/API incompatibilities (overrides preset).",
+)
+@click.option(
+    "--severity-potential-breaking",
+    "severity_potential_breaking",
+    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+    default=None,
+    help="Severity for potential incompatibilities needing review (overrides preset).",
+)
+@click.option(
+    "--severity-quality-issues",
+    "severity_quality_issues",
+    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+    default=None,
+    help="Severity for problematic behaviors (overrides preset).",
+)
+@click.option(
+    "--severity-addition",
+    "severity_addition",
+    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+    default=None,
+    help="Severity for new public API additions (overrides preset).",
+)
 def compare_release_cmd(
     old_dir: Path,
     new_dir: Path,
@@ -1334,25 +1678,56 @@ def compare_release_cmd(
         _temp_dir_paths.append(path)
         return Path(path)
 
-    def _do_extract(input_path: Path, debug_pkg: Path | None, devel_pkg: Path | None) -> tuple[Path, Path | None, Path | None]:
-        return _extract_if_package(input_path, debug_pkg, devel_pkg, _make_temp_dir, is_package, detect_extractor)
+    def _do_extract(
+        input_path: Path, debug_pkg: Path | None, devel_pkg: Path | None
+    ) -> tuple[Path, Path | None, Path | None]:
+        return _extract_if_package(
+            input_path,
+            debug_pkg,
+            devel_pkg,
+            _make_temp_dir,
+            is_package,
+            detect_extractor,
+        )
 
     # Validate suppression file early (before per-library loop)
-    _validate_suppression_early(suppress, policy, policy_file_path, strict_suppressions, require_justification)
+    _validate_suppression_early(
+        suppress, policy, policy_file_path, strict_suppressions, require_justification
+    )
 
     try:
         (
-            old_debug_dir, new_debug_dir,
-            old_h, new_h, old_inc, new_inc,
-            old_map, new_map, warning_msgs,
-            matched_keys, removed_keys, added_keys,
+            old_debug_dir,
+            new_debug_dir,
+            old_h,
+            new_h,
+            old_inc,
+            new_inc,
+            old_map,
+            new_map,
+            warning_msgs,
+            matched_keys,
+            removed_keys,
+            added_keys,
         ) = _prepare_compare_release_inputs(
-            old_dir, new_dir,
-            debug_info1, debug_info2, devel_pkg1, devel_pkg2,
-            include_private_dso, dso_only,
-            headers, old_headers_only, new_headers_only,
-            includes, old_includes_only, new_includes_only,
-            _do_extract, discover_shared_libraries, is_package, _is_elf_shared_object,
+            old_dir,
+            new_dir,
+            debug_info1,
+            debug_info2,
+            devel_pkg1,
+            devel_pkg2,
+            include_private_dso,
+            dso_only,
+            headers,
+            old_headers_only,
+            new_headers_only,
+            includes,
+            old_includes_only,
+            new_includes_only,
+            _do_extract,
+            discover_shared_libraries,
+            is_package,
+            _is_elf_shared_object,
         )
 
         if fmt != "json":
@@ -1366,11 +1741,22 @@ def compare_release_cmd(
         # needs old AbiSnapshot too. Bundle analysis reuses the
         # _diff_result stashed in each library entry from the first pass.
         library_results, worst_verdict, diff_pairs = _compare_release_libraries(
-            matched_keys, old_map, new_map,
-            old_debug_dir, new_debug_dir, resolve_debug_info,
-            old_h, new_h, old_inc, new_inc,
-            old_version, new_version,
-            lang, suppress, policy, policy_file_path,
+            matched_keys,
+            old_map,
+            new_map,
+            old_debug_dir,
+            new_debug_dir,
+            resolve_debug_info,
+            old_h,
+            new_h,
+            old_inc,
+            new_inc,
+            old_version,
+            new_version,
+            lang,
+            suppress,
+            policy,
+            policy_file_path,
             output_dir,
             collect_diff_results=(fmt == "junit"),
             annotate=annotate,
@@ -1384,52 +1770,84 @@ def compare_release_cmd(
         # Returns None when no --severity-* option was supplied, in which case
         # the legacy verdict-based exit is used downstream.
         severity_config = _resolve_release_severity_config(
-            severity_preset, severity_abi_breaking, severity_potential_breaking,
-            severity_quality_issues, severity_addition,
+            severity_preset,
+            severity_abi_breaking,
+            severity_potential_breaking,
+            severity_quality_issues,
+            severity_addition,
         )
         severity_exit_code = _compute_release_severity_exit_code(
             library_results,
-            severity_preset, severity_abi_breaking, severity_potential_breaking,
-            severity_quality_issues, severity_addition,
+            severity_preset,
+            severity_abi_breaking,
+            severity_potential_breaking,
+            severity_quality_issues,
+            severity_addition,
         )
 
         bundle_result: BundleDiffResult | None = None
         bundle_requested = manifest_path is not None or bool(bundle_cohorts)
         if not no_bundle_analysis and bundle_requested:
             bundle_result, worst_verdict = _collect_bundle_result(
-                library_results, old_map, new_map, worst_verdict,
+                library_results,
+                old_map,
+                new_map,
+                worst_verdict,
                 manifest_path=manifest_path,
                 bundle_system_providers=bundle_system_providers,
                 bundle_cohorts=bundle_cohorts,
             )
 
         # Strip _diff_result from entries and bump verdict for removed libraries.
-        worst_verdict = _strip_diff_results_and_adjust_verdict(library_results, removed_keys, worst_verdict)
+        worst_verdict = _strip_diff_results_and_adjust_verdict(
+            library_results, removed_keys, worst_verdict
+        )
 
         # Build-configuration matrix findings (G2: probe -> compare-release).
         # These are release-global, not per-library, so they fold into the
         # worst-of verdict and surface as their own report section.
         matrix_result, worst_verdict = _collect_matrix_result(
-            probe_matrix_old, probe_matrix_new, policy, worst_verdict,
-            suppress=suppress, policy_file_path=policy_file_path,
-            old_version=old_version, new_version=new_version,
+            probe_matrix_old,
+            probe_matrix_new,
+            policy,
+            worst_verdict,
+            suppress=suppress,
+            policy_file_path=policy_file_path,
+            old_version=old_version,
+            new_version=new_version,
         )
 
         # Fold release-global bundle/matrix findings into the severity exit so a
         # clean-per-library release with a bundle/matrix break is not masked.
         if severity_exit_code is not None:
             severity_exit_code = _fold_release_global_severity(
-                severity_exit_code, bundle_result, matrix_result,
-                severity_preset, severity_abi_breaking, severity_potential_breaking,
-                severity_quality_issues, severity_addition,
+                severity_exit_code,
+                bundle_result,
+                matrix_result,
+                severity_preset,
+                severity_abi_breaking,
+                severity_potential_breaking,
+                severity_quality_issues,
+                severity_addition,
             )
 
         _finalize_release_output(
-            fmt, worst_verdict, old_dir, new_dir,
-            library_results, removed_keys, added_keys,
-            old_map, new_map, warning_msgs,
-            diff_pairs, bundle_result,
-            output, output_dir, annotate, fail_on_removed,
+            fmt,
+            worst_verdict,
+            old_dir,
+            new_dir,
+            library_results,
+            removed_keys,
+            added_keys,
+            old_map,
+            new_map,
+            warning_msgs,
+            diff_pairs,
+            bundle_result,
+            output,
+            output_dir,
+            annotate,
+            fail_on_removed,
             matrix_result=matrix_result,
             severity_exit_code=severity_exit_code,
             severity_config=severity_config,
@@ -1453,53 +1871,100 @@ def _prepare_compare_release_inputs(
     includes: tuple[Path, ...],
     old_includes_only: tuple[Path, ...],
     new_includes_only: tuple[Path, ...],
-    extract_if_package: Callable[[Path, Path | None, Path | None], tuple[Path, Path | None, Path | None]],
+    extract_if_package: Callable[
+        [Path, Path | None, Path | None], tuple[Path, Path | None, Path | None]
+    ],
     discover_shared_libraries: Callable[..., list[Path]],
     is_package: Callable[[Path], bool],
     is_elf_shared_object: Callable[[Path], bool],
 ) -> tuple[
-    Path | None, Path | None,
-    list[Path], list[Path], list[Path], list[Path],
-    dict[str, Path], dict[str, Path], list[str],
-    list[str], list[str], list[str],
+    Path | None,
+    Path | None,
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
+    dict[str, Path],
+    dict[str, Path],
+    list[str],
+    list[str],
+    list[str],
+    list[str],
 ]:
     """Prepare inputs/maps/keys for compare-release command."""
     old_lib_dir, old_debug_dir, old_header_dir = extract_if_package(
-        old_dir, debug_info1, devel_pkg1,
+        old_dir,
+        debug_info1,
+        devel_pkg1,
     )
     new_lib_dir, new_debug_dir, new_header_dir = extract_if_package(
-        new_dir, debug_info2, devel_pkg2,
+        new_dir,
+        debug_info2,
+        devel_pkg2,
     )
     old_files = _discover_files(
-        old_dir, old_lib_dir, include_private_dso, discover_shared_libraries, is_package,
+        old_dir,
+        old_lib_dir,
+        include_private_dso,
+        discover_shared_libraries,
+        is_package,
     )
     new_files = _discover_files(
-        new_dir, new_lib_dir, include_private_dso, discover_shared_libraries, is_package,
+        new_dir,
+        new_lib_dir,
+        include_private_dso,
+        discover_shared_libraries,
+        is_package,
     )
     if dso_only:
         old_files = [f for f in old_files if is_elf_shared_object(f)]
         new_files = [f for f in new_files if is_elf_shared_object(f)]
     old_map, old_warns = _build_match_map(old_files)
     new_map, new_warns = _build_match_map(new_files)
-    warning_msgs: list[str] = [f"Warning: {warning}" for warning in (old_warns + new_warns)]
+    warning_msgs: list[str] = [
+        f"Warning: {warning}" for warning in (old_warns + new_warns)
+    ]
     old_h, new_h = _resolve_release_headers(
-        headers, old_headers_only, new_headers_only, old_header_dir, new_header_dir,
+        headers,
+        old_headers_only,
+        new_headers_only,
+        old_header_dir,
+        new_header_dir,
     )
     old_inc = list(old_includes_only) if old_includes_only else list(includes)
     new_inc = list(new_includes_only) if new_includes_only else list(includes)
     old_inc.extend(_discover_include_roots(old_header_dir))
     new_inc.extend(_discover_include_roots(new_header_dir))
     matched_keys, removed_keys, added_keys, old_map, new_map = _match_release_keys(
-        old_dir, new_dir, old_map, new_map, old_files, new_files, is_package,
+        old_dir,
+        new_dir,
+        old_map,
+        new_map,
+        old_files,
+        new_files,
+        is_package,
     )
     _collect_release_warnings(
-        warning_msgs, matched_keys, removed_keys, added_keys, old_map, new_map,
+        warning_msgs,
+        matched_keys,
+        removed_keys,
+        added_keys,
+        old_map,
+        new_map,
     )
     return (
-        old_debug_dir, new_debug_dir,
-        old_h, new_h, old_inc, new_inc,
-        old_map, new_map, warning_msgs,
-        matched_keys, removed_keys, added_keys,
+        old_debug_dir,
+        new_debug_dir,
+        old_h,
+        new_h,
+        old_inc,
+        new_inc,
+        old_map,
+        new_map,
+        warning_msgs,
+        matched_keys,
+        removed_keys,
+        added_keys,
     )
 
 
@@ -1525,8 +1990,11 @@ def _compute_release_severity_exit_code(
     separately via :func:`_fold_release_global_severity`.
     """
     resolved_config = _resolve_release_severity_config(
-        severity_preset, severity_abi_breaking, severity_potential_breaking,
-        severity_quality_issues, severity_addition,
+        severity_preset,
+        severity_abi_breaking,
+        severity_potential_breaking,
+        severity_quality_issues,
+        severity_addition,
     )
     if resolved_config is None:
         return None
@@ -1538,7 +2006,8 @@ def _compute_release_severity_exit_code(
         diff = entry.get("_diff_result") if isinstance(entry, dict) else None
         if isinstance(diff, DiffResult):
             code = compute_exit_code(
-                diff.changes, resolved_config,
+                diff.changes,
+                resolved_config,
                 kind_sets=diff._effective_kind_sets(),
             )
             worst = max(worst, code)
@@ -1556,12 +2025,16 @@ def _resolve_release_severity_config(
     if not any(
         v is not None
         for v in (
-            severity_preset, severity_abi_breaking, severity_potential_breaking,
-            severity_quality_issues, severity_addition,
+            severity_preset,
+            severity_abi_breaking,
+            severity_potential_breaking,
+            severity_quality_issues,
+            severity_addition,
         )
     ):
         return None
     from .severity import resolve_severity_config
+
     return resolve_severity_config(
         severity_preset,
         abi_breaking=severity_abi_breaking,
@@ -1591,8 +2064,11 @@ def _fold_release_global_severity(
     worst of *base_code* and the bundle/matrix severity codes.
     """
     config = _resolve_release_severity_config(
-        severity_preset, severity_abi_breaking, severity_potential_breaking,
-        severity_quality_issues, severity_addition,
+        severity_preset,
+        severity_abi_breaking,
+        severity_potential_breaking,
+        severity_quality_issues,
+        severity_addition,
     )
     if config is None:
         return base_code
@@ -1608,7 +2084,8 @@ def _fold_release_global_severity(
         worst = max(
             worst,
             compute_exit_code(
-                matrix_result.changes, config,
+                matrix_result.changes,
+                config,
                 kind_sets=matrix_result._effective_kind_sets(),
             ),
         )

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -20,7 +20,6 @@ AI-readiness file-size limit. Imported for side-effect at the bottom
 of :mod:`abicheck.cli` so the ``@main.command("compare-release")``
 decorator runs.
 """
-
 from __future__ import annotations
 
 import json
@@ -85,31 +84,17 @@ def _run_compare_pair(
     new_input, new_fmt = _normalize_binary_input(new_input)
 
     old = _resolve_input(
-        old_input,
-        old_headers,
-        old_includes,
-        old_version,
-        lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=old_pdb_path,
+        old_input, old_headers, old_includes, old_version, lang,
+        is_elf=True if old_fmt == "elf" else None, pdb_path=old_pdb_path,
     )
     new = _resolve_input(
-        new_input,
-        new_headers,
-        new_includes,
-        new_version,
-        lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=new_pdb_path,
+        new_input, new_headers, new_includes, new_version, lang,
+        is_elf=True if new_fmt == "elf" else None, pdb_path=new_pdb_path,
     )
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
     result = compare(
-        old,
-        new,
-        suppression=suppression,
-        policy=policy,
-        policy_file=pf,
+        old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_to_public_surface,
         pattern_verdicts=pattern_verdicts,
     )
@@ -119,42 +104,29 @@ def _run_compare_pair(
 
 
 _RELEASE_VERDICT_ORDER: dict[str, int] = {
-    "NO_CHANGE": 0,
-    "COMPATIBLE": 1,
-    "COMPATIBLE_WITH_RISK": 2,
-    "API_BREAK": 3,
-    "BREAKING": 4,
-    "ERROR": 5,
+    "NO_CHANGE": 0, "COMPATIBLE": 1, "COMPATIBLE_WITH_RISK": 2,
+    "API_BREAK": 3, "BREAKING": 4, "ERROR": 5,
 }
 
 
 _CompareReleaseCommonArgs = tuple[
-    dict[str, Path],
-    dict[str, Path],
-    Path | None,
-    Path | None,
+    dict[str, Path], dict[str, Path],
+    Path | None, Path | None,
     Callable[[Path, Path], Path | None],
-    list[Path],
-    list[Path],
-    list[Path],
-    list[Path],
-    str,
-    str,
-    str,
-    Path | None,
-    str,
-    Path | None,
+    list[Path], list[Path],
+    list[Path], list[Path],
+    str, str,
+    str, Path | None,
+    str, Path | None,
     Path | None,
     bool,
 ]
 
 
 def _discover_files(
-    input_dir: Path,
-    lib_dir: Path,
+    input_dir: Path, lib_dir: Path,
     include_private: bool,
-    discover_shared_libraries: Callable[..., list[Path]],
-    is_package: Callable[[Path], bool],
+    discover_shared_libraries: Callable[..., list[Path]], is_package: Callable[[Path], bool],
 ) -> list[Path]:
     """Discover library files from a directory or extracted package."""
     if is_package(input_dir):
@@ -209,20 +181,15 @@ def _discover_include_roots(header_dir: Path | None) -> list[Path]:
 
 
 def _match_release_keys(
-    old_dir: Path,
-    new_dir: Path,
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
-    old_files: list[Path],
-    new_files: list[Path],
+    old_dir: Path, new_dir: Path,
+    old_map: dict[str, Path], new_map: dict[str, Path],
+    old_files: list[Path], new_files: list[Path],
     is_package: Callable[[Path], bool],
 ) -> tuple[list[str], list[str], list[str], dict[str, Path], dict[str, Path]]:
     """Match library keys between old and new, handling direct file pairs."""
     direct_file_pair = (
-        old_dir.is_file()
-        and new_dir.is_file()
-        and not is_package(old_dir)
-        and not is_package(new_dir)
+        old_dir.is_file() and new_dir.is_file()
+        and not is_package(old_dir) and not is_package(new_dir)
     )
     if direct_file_pair:
         matched_keys = ["__direct_pair__"]
@@ -238,11 +205,8 @@ def _match_release_keys(
 
 def _collect_release_warnings(
     warning_msgs: list[str],
-    matched_keys: list[str],
-    removed_keys: list[str],
-    added_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
+    matched_keys: list[str], removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
 ) -> None:
     """Collect warning messages for unmatched libraries."""
     for k in removed_keys:
@@ -257,21 +221,14 @@ def _collect_release_warnings(
 
 def _compare_one_library(
     key: str,
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
-    old_debug_dir: Path | None,
-    new_debug_dir: Path | None,
+    old_map: dict[str, Path], new_map: dict[str, Path],
+    old_debug_dir: Path | None, new_debug_dir: Path | None,
     resolve_debug_info: Callable[[Path, Path], Path | None],
-    old_h: list[Path],
-    new_h: list[Path],
-    old_inc: list[Path],
-    new_inc: list[Path],
-    old_version: str,
-    new_version: str,
-    lang: str,
-    suppress: Path | None,
-    policy: str,
-    policy_file_path: Path | None,
+    old_h: list[Path], new_h: list[Path],
+    old_inc: list[Path], new_inc: list[Path],
+    old_version: str, new_version: str,
+    lang: str, suppress: Path | None,
+    policy: str, policy_file_path: Path | None,
     output_dir: Path | None,
     scope_to_public_surface: bool = False,
 ) -> dict[str, object]:
@@ -292,20 +249,11 @@ def _compare_one_library(
         old_dbg = resolve_debug_info(old_path, old_debug_dir) if old_debug_dir else None
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
         result, _, _ = _run_compare_pair(
-            old_path,
-            new_path,
-            old_h,
-            new_h,
-            old_inc,
-            new_inc,
-            old_version,
-            new_version,
-            lang,
-            suppress,
-            policy,
-            policy_file_path,
-            old_pdb_path=old_dbg,
-            new_pdb_path=new_dbg,
+            old_path, new_path,
+            old_h, new_h, old_inc, new_inc,
+            old_version, new_version,
+            lang, suppress, policy, policy_file_path,
+            old_pdb_path=old_dbg, new_pdb_path=new_dbg,
             scope_to_public_surface=scope_to_public_surface,
         )
         v = result.verdict.value
@@ -314,11 +262,9 @@ def _compare_one_library(
         # downstream consumers (e.g. the PR-comment renderer) can gate the two
         # categories independently under --severity-quality-issues.
         from .checker_policy import ADDITION_KINDS
-
         n_quality = sum(1 for c in result.compatible if c.kind not in ADDITION_KINDS)
         entry: dict[str, object] = {
-            "library": old_path.name,
-            "verdict": v,
+            "library": old_path.name, "verdict": v,
             "breaking": len(result.breaking),
             "source_breaks": len(result.source_breaks),
             "risk_changes": len(result.risk),
@@ -336,11 +282,7 @@ def _compare_one_library(
             _safe_write_output(lib_report_path, to_json(result))
         return entry
     except (click.ClickException, click.UsageError) as exc:
-        return {
-            "library": old_path.name,
-            "verdict": "ERROR",
-            "error": exc.format_message(),
-        }
+        return {"library": old_path.name, "verdict": "ERROR", "error": exc.format_message()}
     except Exception as exc:
         return {"library": old_path.name, "verdict": "ERROR", "error": str(exc)}
 
@@ -373,19 +315,23 @@ def _suppress_lockstep_soname_findings(
         if not isinstance(result, DiffResult):
             continue
         unnecessary = [
-            c for c in result.changes if c.kind == ChangeKind.SONAME_BUMP_UNNECESSARY
+            c for c in result.changes
+            if c.kind == ChangeKind.SONAME_BUMP_UNNECESSARY
         ]
         if not unnecessary:
             continue
         result.changes = [
-            c for c in result.changes if c.kind != ChangeKind.SONAME_BUMP_UNNECESSARY
+            c for c in result.changes
+            if c.kind != ChangeKind.SONAME_BUMP_UNNECESSARY
         ]
         suppressed += len(unnecessary)
         # Recompute the cached per-library counts after the mutation.
+        from .checker_policy import ADDITION_KINDS
         entry["breaking"] = len(result.breaking)
         entry["source_breaks"] = len(result.source_breaks)
         entry["risk_changes"] = len(result.risk)
         entry["compatible_additions"] = len(result.compatible)
+        entry["quality_issues"] = sum(1 for c in result.compatible if c.kind not in ADDITION_KINDS)
         if output_dir is not None:
             lib_report_path = output_dir / f"{Path(str(entry['library'])).stem}.json"
             _safe_write_output(lib_report_path, to_json(result))
@@ -394,21 +340,14 @@ def _suppress_lockstep_soname_findings(
 
 def _compare_release_libraries(
     matched_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
-    old_debug_dir: Path | None,
-    new_debug_dir: Path | None,
+    old_map: dict[str, Path], new_map: dict[str, Path],
+    old_debug_dir: Path | None, new_debug_dir: Path | None,
     resolve_debug_info: Callable[[Path, Path], Path | None],
-    old_h: list[Path],
-    new_h: list[Path],
-    old_inc: list[Path],
-    new_inc: list[Path],
-    old_version: str,
-    new_version: str,
-    lang: str,
-    suppress: Path | None,
-    policy: str,
-    policy_file_path: Path | None,
+    old_h: list[Path], new_h: list[Path],
+    old_inc: list[Path], new_inc: list[Path],
+    old_version: str, new_version: str,
+    lang: str, suppress: Path | None,
+    policy: str, policy_file_path: Path | None,
     output_dir: Path | None,
     collect_diff_results: bool = False,
     *,
@@ -435,30 +374,16 @@ def _compare_release_libraries(
     all_annotations: list[tuple[int, str]] = []
 
     common_args = (
-        old_map,
-        new_map,
-        old_debug_dir,
-        new_debug_dir,
-        resolve_debug_info,
-        old_h,
-        new_h,
-        old_inc,
-        new_inc,
-        old_version,
-        new_version,
-        lang,
-        suppress,
-        policy,
-        policy_file_path,
-        output_dir,
+        old_map, new_map, old_debug_dir, new_debug_dir, resolve_debug_info,
+        old_h, new_h, old_inc, new_inc,
+        old_version, new_version,
+        lang, suppress, policy, policy_file_path, output_dir,
         scope_to_public_surface,
     )
 
     if effective_jobs > 1 and len(matched_keys) > 1:
         library_results.extend(
-            _compare_release_parallel(
-                matched_keys, common_args, old_map, effective_jobs
-            ),
+            _compare_release_parallel(matched_keys, common_args, old_map, effective_jobs),
         )
     else:
         library_results.extend(
@@ -471,20 +396,14 @@ def _compare_release_libraries(
         v = str(entry["verdict"])
         if v == "ERROR":
             if "error" in entry:
-                click.echo(
-                    f"Error comparing {entry['library']}: {entry['error']}", err=True
-                )
-        if _RELEASE_VERDICT_ORDER.get(v, 0) > _RELEASE_VERDICT_ORDER.get(
-            worst_verdict, 0
-        ):
+                click.echo(f"Error comparing {entry['library']}: {entry['error']}", err=True)
+        if _RELEASE_VERDICT_ORDER.get(v, 0) > _RELEASE_VERDICT_ORDER.get(worst_verdict, 0):
             worst_verdict = v
 
     # Cross-library coupling: a coordinated SONAME bump across the release is not
     # "unnecessary" just because one member had no break of its own.
     suppressed_soname = _suppress_lockstep_soname_findings(
-        library_results,
-        worst_verdict,
-        output_dir,
+        library_results, worst_verdict, output_dir,
     )
     if suppressed_soname:
         click.echo(
@@ -499,22 +418,11 @@ def _compare_release_libraries(
     # are sequential-only features)
     if collect_diff_results or annotate:
         extra_pairs, extra_annotations = _collect_release_extras(
-            matched_keys,
-            old_map,
-            new_map,
-            old_debug_dir,
-            new_debug_dir,
-            resolve_debug_info,
-            old_h,
-            new_h,
-            old_inc,
-            new_inc,
-            old_version,
-            new_version,
-            lang,
-            suppress,
-            policy,
-            policy_file_path,
+            matched_keys, old_map, new_map,
+            old_debug_dir, new_debug_dir, resolve_debug_info,
+            old_h, new_h, old_inc, new_inc,
+            old_version, new_version, lang,
+            suppress, policy, policy_file_path,
             annotate_additions=annotate_additions,
             collect_diff_results=collect_diff_results,
             annotate=annotate,
@@ -563,9 +471,7 @@ def _compare_release_parallel(
             except Exception as exc:
                 click.echo(f"Error comparing {old_map[key].name}: {exc}", err=True)
                 results_by_key[key] = {
-                    "library": old_map[key].name,
-                    "verdict": "ERROR",
-                    "error": str(exc),
+                    "library": old_map[key].name, "verdict": "ERROR", "error": str(exc),
                 }
     return [results_by_key[key] for key in matched_keys if key in results_by_key]
 
@@ -611,20 +517,11 @@ def _collect_release_extras(
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
         try:
             result, old_snap, _ = _run_compare_pair(
-                old_path,
-                new_path,
-                old_h,
-                new_h,
-                old_inc,
-                new_inc,
-                old_version,
-                new_version,
-                lang,
-                suppress,
-                policy,
-                policy_file_path,
-                old_pdb_path=old_dbg,
-                new_pdb_path=new_dbg,
+                old_path, new_path,
+                old_h, new_h, old_inc, new_inc,
+                old_version, new_version,
+                lang, suppress, policy, policy_file_path,
+                old_pdb_path=old_dbg, new_pdb_path=new_dbg,
                 scope_to_public_surface=scope_to_public_surface,
             )
         except Exception as exc:
@@ -701,9 +598,7 @@ def _run_bundle_analysis(
     ]
     try:
         return compare_bundle(
-            old_snap,
-            new_snap,
-            per_lib_results,
+            old_snap, new_snap, per_lib_results,
             manifest=manifest,
             system_providers=system_extra or None,
             cohorts=list(bundle_cohorts) or None,
@@ -717,15 +612,11 @@ def _run_bundle_analysis(
 
 
 def _format_release_summary(
-    fmt: str,
-    worst_verdict: str,
-    old_dir: Path,
-    new_dir: Path,
+    fmt: str, worst_verdict: str,
+    old_dir: Path, new_dir: Path,
     library_results: list[dict[str, object]],
-    removed_keys: list[str],
-    added_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
     warning_msgs: list[str],
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] | None = None,
     bundle_result: BundleDiffResult | None = None,
@@ -738,31 +629,15 @@ def _format_release_summary(
         return _format_release_junit(diff_pairs, matrix_result, library_results)
     if fmt == "json":
         return _format_release_json(
-            worst_verdict,
-            old_dir,
-            new_dir,
-            library_results,
-            removed_keys,
-            added_keys,
-            old_map,
-            new_map,
-            warning_msgs,
-            bundle_result,
-            matrix_result,
+            worst_verdict, old_dir, new_dir, library_results,
+            removed_keys, added_keys, old_map, new_map, warning_msgs,
+            bundle_result, matrix_result,
             severity_config=severity_config,
             severity_exit_code=severity_exit_code,
         )
     return _format_release_markdown(
-        worst_verdict,
-        old_dir,
-        new_dir,
-        library_results,
-        removed_keys,
-        added_keys,
-        old_map,
-        new_map,
-        bundle_result,
-        matrix_result,
+        worst_verdict, old_dir, new_dir, library_results,
+        removed_keys, added_keys, old_map, new_map, bundle_result, matrix_result,
     )
 
 
@@ -773,28 +648,26 @@ def _format_release_junit(
 ) -> str:
     """Render the release summary as a JUnit XML report."""
     from .junit_report import to_junit_xml_multi
-
     pairs: list[tuple[DiffResult, AbiSnapshot | None]] = list(diff_pairs or [])
     # Release-global matrix findings ride in as their own synthetic
     # testsuite so CI dashboards reading the JUnit report see the failure.
     if matrix_result is not None:
         pairs.append((matrix_result, None))
-    error_libs = [entry for entry in library_results if entry.get("verdict") == "ERROR"]
+    error_libs = [
+        entry for entry in library_results
+        if entry.get("verdict") == "ERROR"
+    ]
     return to_junit_xml_multi(
-        pairs,
-        error_libraries=error_libs if error_libs else None,
+        pairs, error_libraries=error_libs if error_libs else None,
     )
 
 
 def _format_release_json(
     worst_verdict: str,
-    old_dir: Path,
-    new_dir: Path,
+    old_dir: Path, new_dir: Path,
     library_results: list[dict[str, object]],
-    removed_keys: list[str],
-    added_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
     warning_msgs: list[str],
     bundle_result: BundleDiffResult | None,
     matrix_result: DiffResult | None,
@@ -803,8 +676,7 @@ def _format_release_json(
 ) -> str:
     """Render the release summary as a JSON document."""
     changed_libraries = [
-        str(lib["library"])
-        for lib in library_results
+        str(lib["library"]) for lib in library_results
         if str(lib.get("verdict")) not in ("NO_CHANGE", "ERROR")
     ]
     summary: dict[str, object] = {
@@ -871,10 +743,8 @@ def _format_release_json(
 
 def _release_json_scope(scoped_libs: list[dict[str, object]]) -> dict[str, object]:
     """Build the release-level public-surface scoping rollup for JSON output."""
-
     def _as_int(v: object) -> int:
         return v if isinstance(v, int) else 0
-
     return {
         "public_headers_applied": True,
         "manual_review_required": any(
@@ -891,30 +761,21 @@ def _release_json_scope(scoped_libs: list[dict[str, object]]) -> dict[str, objec
 
 def _format_release_markdown(
     worst_verdict: str,
-    old_dir: Path,
-    new_dir: Path,
+    old_dir: Path, new_dir: Path,
     library_results: list[dict[str, object]],
-    removed_keys: list[str],
-    added_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
     bundle_result: BundleDiffResult | None,
     matrix_result: DiffResult | None,
 ) -> str:
     """Render the release summary as a Markdown document."""
     _VERDICT_EMOJI = {
-        "NO_CHANGE": "✅",
-        "COMPATIBLE": "✅",
-        "COMPATIBLE_WITH_RISK": "⚠️",
-        "API_BREAK": "⚠️",
-        "BREAKING": "❌",
-        "ERROR": "💥",
+        "NO_CHANGE": "✅", "COMPATIBLE": "✅", "COMPATIBLE_WITH_RISK": "⚠️",
+        "API_BREAK": "⚠️", "BREAKING": "❌", "ERROR": "💥",
     }
     lines: list[str] = [
-        "# ABI Release Comparison",
-        "",
-        "| | |",
-        "|---|---|",
+        "# ABI Release Comparison", "",
+        "| | |", "|---|---|",
         f"| **Old** | `{old_dir}` |",
         f"| **New** | `{new_dir}` |",
         f"| **Verdict** | {_VERDICT_EMOJI.get(worst_verdict, '?')} `{worst_verdict}` |",
@@ -934,14 +795,11 @@ def _format_release_markdown(
 
 
 def _release_md_libraries_table(
-    library_results: list[dict[str, object]],
-    emoji: dict[str, str],
+    library_results: list[dict[str, object]], emoji: dict[str, str],
 ) -> list[str]:
     """Markdown per-library results table."""
     lines = [
-        "",
-        "## Libraries",
-        "",
+        "", "## Libraries", "",
         "| Library | Verdict | Breaking | Source | Risk | Additions |",
         "|---|---|---|---|---|---|",
     ]
@@ -956,10 +814,8 @@ def _release_md_libraries_table(
 
 
 def _release_md_changed_libraries(
-    removed_keys: list[str],
-    added_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
 ) -> list[str]:
     """Markdown sections listing removed/added libraries."""
     lines: list[str] = []
@@ -1006,13 +862,10 @@ def _release_md_matrix_findings(matrix_result: DiffResult | None) -> list[str]:
 
 
 def _write_release_summary_file(
-    output_dir: Path,
-    worst_verdict: str,
+    output_dir: Path, worst_verdict: str,
     library_results: list[dict[str, object]],
-    removed_keys: list[str],
-    added_keys: list[str],
-    old_map: dict[str, Path],
-    new_map: dict[str, Path],
+    removed_keys: list[str], added_keys: list[str],
+    old_map: dict[str, Path], new_map: dict[str, Path],
 ) -> None:
     """Write per-library summary JSON to output directory."""
     summary_data: dict[str, object] = {
@@ -1059,9 +912,7 @@ def _extract_if_package(
     if debug_pkg is not None:
         dbg_ext = detect_extractor(debug_pkg)
         if dbg_ext is None:
-            raise click.ClickException(
-                f"Unrecognized debug package format: {debug_pkg}"
-            )
+            raise click.ClickException(f"Unrecognized debug package format: {debug_pkg}")
         dbg_target = make_temp_dir("abicheck_dbg_")
         dbg_result = dbg_ext.extract(debug_pkg, dbg_target)
         debug_dir = dbg_result.debug_dir or dbg_result.lib_dir
@@ -1069,9 +920,7 @@ def _extract_if_package(
     if devel_pkg is not None:
         dev_ext = detect_extractor(devel_pkg)
         if dev_ext is None:
-            raise click.ClickException(
-                f"Unrecognized devel package format: {devel_pkg}"
-            )
+            raise click.ClickException(f"Unrecognized devel package format: {devel_pkg}")
         dev_target = make_temp_dir("abicheck_dev_")
         dev_result = dev_ext.extract(devel_pkg, dev_target)
         header_dir = dev_result.header_dir or dev_result.lib_dir
@@ -1095,18 +944,14 @@ def _collect_bundle_result(
         if isinstance(diff, DiffResult):
             stashed_diffs.append(diff)
     bundle_result = _run_bundle_analysis(
-        old_map,
-        new_map,
-        stashed_diffs,
+        old_map, new_map, stashed_diffs,
         manifest_path=manifest_path,
         bundle_system_providers=bundle_system_providers,
         bundle_cohorts=bundle_cohorts,
     )
     if bundle_result is not None:
         bv = bundle_result.bundle_verdict.value
-        if _RELEASE_VERDICT_ORDER.get(bv, 0) > _RELEASE_VERDICT_ORDER.get(
-            worst_verdict, 0
-        ):
+        if _RELEASE_VERDICT_ORDER.get(bv, 0) > _RELEASE_VERDICT_ORDER.get(worst_verdict, 0):
             worst_verdict = bv
     return bundle_result, worst_verdict
 
@@ -1163,9 +1008,7 @@ def _collect_matrix_result(
         extra_changes=matrix_changes,
     )
     matrix_verdict = result.verdict.value
-    if _RELEASE_VERDICT_ORDER.get(matrix_verdict, 0) > _RELEASE_VERDICT_ORDER.get(
-        worst_verdict, 0
-    ):
+    if _RELEASE_VERDICT_ORDER.get(matrix_verdict, 0) > _RELEASE_VERDICT_ORDER.get(worst_verdict, 0):
         worst_verdict = matrix_verdict
     return result, worst_verdict
 
@@ -1205,16 +1048,9 @@ def _finalize_release_output(
 ) -> None:
     """Write summary output, step summary, per-library dir report, then exit."""
     text = _format_release_summary(
-        fmt,
-        worst_verdict,
-        old_dir,
-        new_dir,
-        library_results,
-        removed_keys,
-        added_keys,
-        old_map,
-        new_map,
-        warning_msgs,
+        fmt, worst_verdict, old_dir, new_dir,
+        library_results, removed_keys, added_keys,
+        old_map, new_map, warning_msgs,
         diff_pairs=diff_pairs if fmt == "junit" else None,
         bundle_result=bundle_result,
         matrix_result=matrix_result,
@@ -1228,18 +1064,11 @@ def _finalize_release_output(
 
     if output_dir:
         _write_release_summary_file(
-            output_dir,
-            worst_verdict,
-            library_results,
-            removed_keys,
-            added_keys,
-            old_map,
-            new_map,
+            output_dir, worst_verdict, library_results,
+            removed_keys, added_keys, old_map, new_map,
         )
 
-    _exit_compare_release(
-        worst_verdict, fail_on_removed, removed_keys, severity_exit_code
-    )
+    _exit_compare_release(worst_verdict, fail_on_removed, removed_keys, severity_exit_code)
 
 
 def _validate_suppression_early(
@@ -1257,9 +1086,7 @@ def _validate_suppression_early(
     """
     if suppress is not None and (strict_suppressions or require_justification):
         _load_suppression_and_policy(
-            suppress,
-            policy,
-            policy_file_path,
+            suppress, policy, policy_file_path,
             strict_suppressions=strict_suppressions,
             require_justification=require_justification,
         )
@@ -1283,9 +1110,7 @@ def _strip_diff_results_and_adjust_verdict(
     for entry in library_results:
         if isinstance(entry, dict):
             entry.pop("_diff_result", None)
-    if removed_keys and _RELEASE_VERDICT_ORDER.get(
-        worst_verdict, 0
-    ) < _RELEASE_VERDICT_ORDER.get("COMPATIBLE_WITH_RISK", 0):
+    if removed_keys and _RELEASE_VERDICT_ORDER.get(worst_verdict, 0) < _RELEASE_VERDICT_ORDER.get("COMPATIBLE_WITH_RISK", 0):
         worst_verdict = "COMPATIBLE_WITH_RISK"
     return worst_verdict
 
@@ -1293,289 +1118,129 @@ def _strip_diff_results_and_adjust_verdict(
 @main.command("compare-release")
 @click.argument("old_dir", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_dir", type=click.Path(exists=True, path_type=Path))
-@click.option(
-    "-H",
-    "--header",
-    "headers",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Public header file or directory applied to both sides.",
-)
-@click.option(
-    "-I",
-    "--include",
-    "includes",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Extra include directory for castxml.",
-)
-@click.option(
-    "--old-include",
-    "old_includes_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Include directory for old side only (overrides -I for old).",
-)
-@click.option(
-    "--new-include",
-    "new_includes_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Include directory for new side only (overrides -I for new).",
-)
-@click.option(
-    "--old-header",
-    "old_headers_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Header for old side only (overrides -H for old).",
-)
-@click.option(
-    "--new-header",
-    "new_headers_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Header for new side only (overrides -H for new).",
-)
-@click.option(
-    "--old-version",
-    "old_version",
-    default="old",
-    show_default=True,
-    help="Version label for old side.",
-)
-@click.option(
-    "--new-version",
-    "new_version",
-    default="new",
-    show_default=True,
-    help="Version label for new side.",
-)
-@click.option(
-    "--lang",
-    default="c++",
-    show_default=True,
-    type=click.Choice(["c++", "c"], case_sensitive=False),
-)
-@click.option(
-    "--format",
-    "fmt",
-    type=click.Choice(["json", "markdown", "junit"]),
-    default="markdown",
-    show_default=True,
-)
-@click.option(
-    "-o",
-    "--output",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Output file for summary report (default: stdout).",
-)
-@click.option(
-    "--output-dir",
-    "output_dir",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Directory to write per-library reports.",
-)
-@click.option(
-    "--suppress",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Suppression file (YAML).",
-)
-@click.option(
-    "--strict-suppressions",
-    is_flag=True,
-    default=False,
-    help="Fail with exit code 1 if any suppression rule has expired.",
-)
-@click.option(
-    "--require-justification",
-    is_flag=True,
-    default=False,
-    help="Require every suppression rule to have a non-empty 'reason' field.",
-)
-@click.option(
-    "--policy",
-    "policy",
-    type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
-    default="strict_abi",
-    show_default=True,
-)
-@click.option("--policy-file", "policy_file_path", type=POLICY_FILE_PARAM, default=None)
-@click.option(
-    "--fail-on-removed-library/--no-fail-on-removed-library",
-    "fail_on_removed",
-    default=False,
-    help="Exit 8 when a library present in old_dir is absent in new_dir.",
-)
-@click.option(
-    "--debug-info1",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Debug info package for old side (RPM/Deb/tar).",
-)
-@click.option(
-    "--debug-info2",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Debug info package for new side (RPM/Deb/tar).",
-)
-@click.option(
-    "--devel-pkg1",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Development package with headers for old side.",
-)
-@click.option(
-    "--devel-pkg2",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Development package with headers for new side.",
-)
-@click.option(
-    "--dso-only",
-    is_flag=True,
-    default=False,
-    help="Only compare shared objects, skip executables.",
-)
-@click.option(
-    "--include-private-dso",
-    is_flag=True,
-    default=False,
-    help="Include private (non-public) shared objects from non-standard paths.",
-)
-@click.option(
-    "--keep-extracted",
-    is_flag=True,
-    default=False,
-    help="Keep extracted temporary files for debugging.",
-)
-@click.option(
-    "--annotate",
-    is_flag=True,
-    default=False,
-    help="Emit GitHub Actions workflow command annotations to stdout. "
-    "Only effective when GITHUB_ACTIONS=true.",
-)
-@click.option(
-    "--annotate-additions",
-    is_flag=True,
-    default=False,
-    help="Include additions/compatible changes as ::notice annotations "
-    "(requires --annotate).",
-)
+@click.option("-H", "--header", "headers", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Public header file or directory applied to both sides.")
+@click.option("-I", "--include", "includes", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Extra include directory for castxml.")
+@click.option("--old-include", "old_includes_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Include directory for old side only (overrides -I for old).")
+@click.option("--new-include", "new_includes_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Include directory for new side only (overrides -I for new).")
+@click.option("--old-header", "old_headers_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Header for old side only (overrides -H for old).")
+@click.option("--new-header", "new_headers_only", multiple=True,
+              type=click.Path(path_type=Path),
+              help="Header for new side only (overrides -H for new).")
+@click.option("--old-version", "old_version", default="old", show_default=True,
+              help="Version label for old side.")
+@click.option("--new-version", "new_version", default="new", show_default=True,
+              help="Version label for new side.")
+@click.option("--lang", default="c++", show_default=True,
+              type=click.Choice(["c++", "c"], case_sensitive=False))
+@click.option("--format", "fmt",
+              type=click.Choice(["json", "markdown", "junit"]),
+              default="markdown", show_default=True)
+@click.option("-o", "--output", type=click.Path(path_type=Path), default=None,
+              help="Output file for summary report (default: stdout).")
+@click.option("--output-dir", "output_dir", type=click.Path(path_type=Path), default=None,
+              help="Directory to write per-library reports.")
+@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Suppression file (YAML).")
+@click.option("--strict-suppressions", is_flag=True, default=False,
+              help="Fail with exit code 1 if any suppression rule has expired.")
+@click.option("--require-justification", is_flag=True, default=False,
+              help="Require every suppression rule to have a non-empty 'reason' field.")
+@click.option("--policy", "policy",
+              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
+              default="strict_abi", show_default=True)
+@click.option("--policy-file", "policy_file_path",
+              type=POLICY_FILE_PARAM, default=None)
+@click.option("--fail-on-removed-library/--no-fail-on-removed-library",
+              "fail_on_removed", default=False,
+              help="Exit 8 when a library present in old_dir is absent in new_dir.")
+@click.option("--debug-info1", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Debug info package for old side (RPM/Deb/tar).")
+@click.option("--debug-info2", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Debug info package for new side (RPM/Deb/tar).")
+@click.option("--devel-pkg1", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Development package with headers for old side.")
+@click.option("--devel-pkg2", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Development package with headers for new side.")
+@click.option("--dso-only", is_flag=True, default=False,
+              help="Only compare shared objects, skip executables.")
+@click.option("--include-private-dso", is_flag=True, default=False,
+              help="Include private (non-public) shared objects from non-standard paths.")
+@click.option("--keep-extracted", is_flag=True, default=False,
+              help="Keep extracted temporary files for debugging.")
+@click.option("--annotate", is_flag=True, default=False,
+              help="Emit GitHub Actions workflow command annotations to stdout. "
+                   "Only effective when GITHUB_ACTIONS=true.")
+@click.option("--annotate-additions", is_flag=True, default=False,
+              help="Include additions/compatible changes as ::notice annotations "
+                   "(requires --annotate).")
 @click.option("-v", "--verbose", is_flag=True, default=False)
-@click.option(
-    "-j",
-    "--jobs",
-    "jobs",
-    type=int,
-    default=0,
-    show_default=True,
-    help="Number of parallel library comparisons (0 = auto-detect CPU count, the default).",
-)
-@click.option(
-    "--manifest",
-    "manifest_path",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="ABI instantiation manifest (YAML/JSON) listing symbols the "
-    "release publicly promises. See ADR-023.",
-)
-@click.option(
-    "--bundle-system-providers",
-    "bundle_system_providers",
-    default="",
-    help="Comma-separated extra sonames to treat as system-provided "
-    "(extends the built-in libc/libstdc++/libgcc/libtbb allow-list).",
-)
-@click.option(
-    "--bundle-cohort",
-    "bundle_cohorts",
-    multiple=True,
-    metavar="PREFIX",
-    help="Declare a co-versioned library cohort by name prefix (e.g. "
-    "'libfoo_'). Repeatable. Enables the BUNDLE_SONAME_SKEW check, "
-    "which flags when some members of the cohort bump their major SONAME "
-    "while siblings lag, and enables bundle-level cross-library analysis.",
-)
-@click.option(
-    "--no-bundle-analysis",
-    "no_bundle_analysis",
-    is_flag=True,
-    default=False,
-    help="Skip bundle-level cross-library analysis (debug/parity escape hatch). "
-    "Bundle findings catch intra-bundle symbol removals, signature drift "
-    "across DSO boundaries, type drift across siblings, provider "
-    "migration, and manifest mismatches.",
-)
-@click.option(
-    "--scope-public-headers/--no-scope-public-headers",
-    "scope_public_headers",
-    default=True,
-    show_default=True,
-    help="Restrict findings to the public-header ABI surface (ADR-024). "
-    "On by default (matches `compare`); use --no-scope-public-headers "
-    "to report every finding.",
-)
-@click.option(
-    "--probe-matrix-old",
-    "probe_matrix_old",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Old build-configuration matrix snapshot (from 'abicheck probe run'). "
-    "When given with --probe-matrix-new, build-config findings "
-    "(CXX_STANDARD_FLOOR_RAISED, API_DEPENDS_ON_CONSUMER_ENV, "
-    "BEHAVIOURAL_DEFAULT_CHANGED) are folded into this release's "
-    "verdict and report (G2: probe -> compare-release).",
-)
-@click.option(
-    "--probe-matrix-new",
-    "probe_matrix_new",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).",
-)
+@click.option("-j", "--jobs", "jobs", type=int, default=0, show_default=True,
+              help="Number of parallel library comparisons (0 = auto-detect CPU count, the default).")
+@click.option("--manifest", "manifest_path", type=click.Path(exists=True, path_type=Path),
+              default=None,
+              help="ABI instantiation manifest (YAML/JSON) listing symbols the "
+                   "release publicly promises. See ADR-023.")
+@click.option("--bundle-system-providers", "bundle_system_providers", default="",
+              help="Comma-separated extra sonames to treat as system-provided "
+                   "(extends the built-in libc/libstdc++/libgcc/libtbb allow-list).")
+@click.option("--bundle-cohort", "bundle_cohorts", multiple=True, metavar="PREFIX",
+              help="Declare a co-versioned library cohort by name prefix (e.g. "
+                   "'libfoo_'). Repeatable. Enables the BUNDLE_SONAME_SKEW check, "
+                   "which flags when some members of the cohort bump their major SONAME "
+                   "while siblings lag, and enables bundle-level cross-library analysis.")
+@click.option("--no-bundle-analysis", "no_bundle_analysis", is_flag=True, default=False,
+              help="Skip bundle-level cross-library analysis (debug/parity escape hatch). "
+                   "Bundle findings catch intra-bundle symbol removals, signature drift "
+                   "across DSO boundaries, type drift across siblings, provider "
+                   "migration, and manifest mismatches.")
+@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
+              default=True, show_default=True,
+              help="Restrict findings to the public-header ABI surface (ADR-024). "
+                   "On by default (matches `compare`); use --no-scope-public-headers "
+                   "to report every finding.")
+@click.option("--probe-matrix-old", "probe_matrix_old", type=click.Path(exists=True, path_type=Path),
+              default=None,
+              help="Old build-configuration matrix snapshot (from 'abicheck probe run'). "
+                   "When given with --probe-matrix-new, build-config findings "
+                   "(CXX_STANDARD_FLOOR_RAISED, API_DEPENDS_ON_CONSUMER_ENV, "
+                   "BEHAVIOURAL_DEFAULT_CHANGED) are folded into this release's "
+                   "verdict and report (G2: probe -> compare-release).")
+@click.option("--probe-matrix-new", "probe_matrix_new", type=click.Path(exists=True, path_type=Path),
+              default=None,
+              help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).")
 # ── Severity (mirrors `compare`) ──────────────────────────────────────────────
-@click.option(
-    "--severity-preset",
-    "severity_preset",
-    type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
-    default=None,
-    help="Severity preset: 'default', 'strict', or 'info-only'. "
-    "When set (or any --severity-* option), exit codes follow the "
-    "severity-aware scheme aggregated across all libraries.",
-)
-@click.option(
-    "--severity-abi-breaking",
-    "severity_abi_breaking",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for clear ABI/API incompatibilities (overrides preset).",
-)
-@click.option(
-    "--severity-potential-breaking",
-    "severity_potential_breaking",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for potential incompatibilities needing review (overrides preset).",
-)
-@click.option(
-    "--severity-quality-issues",
-    "severity_quality_issues",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for problematic behaviors (overrides preset).",
-)
-@click.option(
-    "--severity-addition",
-    "severity_addition",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for new public API additions (overrides preset).",
-)
+@click.option("--severity-preset", "severity_preset",
+              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
+              default=None,
+              help="Severity preset: 'default', 'strict', or 'info-only'. "
+                   "When set (or any --severity-* option), exit codes follow the "
+                   "severity-aware scheme aggregated across all libraries.")
+@click.option("--severity-abi-breaking", "severity_abi_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for clear ABI/API incompatibilities (overrides preset).")
+@click.option("--severity-potential-breaking", "severity_potential_breaking",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for potential incompatibilities needing review (overrides preset).")
+@click.option("--severity-quality-issues", "severity_quality_issues",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for problematic behaviors (overrides preset).")
+@click.option("--severity-addition", "severity_addition",
+              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+              default=None,
+              help="Severity for new public API additions (overrides preset).")
 def compare_release_cmd(
     old_dir: Path,
     new_dir: Path,
@@ -1678,56 +1343,25 @@ def compare_release_cmd(
         _temp_dir_paths.append(path)
         return Path(path)
 
-    def _do_extract(
-        input_path: Path, debug_pkg: Path | None, devel_pkg: Path | None
-    ) -> tuple[Path, Path | None, Path | None]:
-        return _extract_if_package(
-            input_path,
-            debug_pkg,
-            devel_pkg,
-            _make_temp_dir,
-            is_package,
-            detect_extractor,
-        )
+    def _do_extract(input_path: Path, debug_pkg: Path | None, devel_pkg: Path | None) -> tuple[Path, Path | None, Path | None]:
+        return _extract_if_package(input_path, debug_pkg, devel_pkg, _make_temp_dir, is_package, detect_extractor)
 
     # Validate suppression file early (before per-library loop)
-    _validate_suppression_early(
-        suppress, policy, policy_file_path, strict_suppressions, require_justification
-    )
+    _validate_suppression_early(suppress, policy, policy_file_path, strict_suppressions, require_justification)
 
     try:
         (
-            old_debug_dir,
-            new_debug_dir,
-            old_h,
-            new_h,
-            old_inc,
-            new_inc,
-            old_map,
-            new_map,
-            warning_msgs,
-            matched_keys,
-            removed_keys,
-            added_keys,
+            old_debug_dir, new_debug_dir,
+            old_h, new_h, old_inc, new_inc,
+            old_map, new_map, warning_msgs,
+            matched_keys, removed_keys, added_keys,
         ) = _prepare_compare_release_inputs(
-            old_dir,
-            new_dir,
-            debug_info1,
-            debug_info2,
-            devel_pkg1,
-            devel_pkg2,
-            include_private_dso,
-            dso_only,
-            headers,
-            old_headers_only,
-            new_headers_only,
-            includes,
-            old_includes_only,
-            new_includes_only,
-            _do_extract,
-            discover_shared_libraries,
-            is_package,
-            _is_elf_shared_object,
+            old_dir, new_dir,
+            debug_info1, debug_info2, devel_pkg1, devel_pkg2,
+            include_private_dso, dso_only,
+            headers, old_headers_only, new_headers_only,
+            includes, old_includes_only, new_includes_only,
+            _do_extract, discover_shared_libraries, is_package, _is_elf_shared_object,
         )
 
         if fmt != "json":
@@ -1741,22 +1375,11 @@ def compare_release_cmd(
         # needs old AbiSnapshot too. Bundle analysis reuses the
         # _diff_result stashed in each library entry from the first pass.
         library_results, worst_verdict, diff_pairs = _compare_release_libraries(
-            matched_keys,
-            old_map,
-            new_map,
-            old_debug_dir,
-            new_debug_dir,
-            resolve_debug_info,
-            old_h,
-            new_h,
-            old_inc,
-            new_inc,
-            old_version,
-            new_version,
-            lang,
-            suppress,
-            policy,
-            policy_file_path,
+            matched_keys, old_map, new_map,
+            old_debug_dir, new_debug_dir, resolve_debug_info,
+            old_h, new_h, old_inc, new_inc,
+            old_version, new_version,
+            lang, suppress, policy, policy_file_path,
             output_dir,
             collect_diff_results=(fmt == "junit"),
             annotate=annotate,
@@ -1770,84 +1393,52 @@ def compare_release_cmd(
         # Returns None when no --severity-* option was supplied, in which case
         # the legacy verdict-based exit is used downstream.
         severity_config = _resolve_release_severity_config(
-            severity_preset,
-            severity_abi_breaking,
-            severity_potential_breaking,
-            severity_quality_issues,
-            severity_addition,
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
         )
         severity_exit_code = _compute_release_severity_exit_code(
             library_results,
-            severity_preset,
-            severity_abi_breaking,
-            severity_potential_breaking,
-            severity_quality_issues,
-            severity_addition,
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
         )
 
         bundle_result: BundleDiffResult | None = None
         bundle_requested = manifest_path is not None or bool(bundle_cohorts)
         if not no_bundle_analysis and bundle_requested:
             bundle_result, worst_verdict = _collect_bundle_result(
-                library_results,
-                old_map,
-                new_map,
-                worst_verdict,
+                library_results, old_map, new_map, worst_verdict,
                 manifest_path=manifest_path,
                 bundle_system_providers=bundle_system_providers,
                 bundle_cohorts=bundle_cohorts,
             )
 
         # Strip _diff_result from entries and bump verdict for removed libraries.
-        worst_verdict = _strip_diff_results_and_adjust_verdict(
-            library_results, removed_keys, worst_verdict
-        )
+        worst_verdict = _strip_diff_results_and_adjust_verdict(library_results, removed_keys, worst_verdict)
 
         # Build-configuration matrix findings (G2: probe -> compare-release).
         # These are release-global, not per-library, so they fold into the
         # worst-of verdict and surface as their own report section.
         matrix_result, worst_verdict = _collect_matrix_result(
-            probe_matrix_old,
-            probe_matrix_new,
-            policy,
-            worst_verdict,
-            suppress=suppress,
-            policy_file_path=policy_file_path,
-            old_version=old_version,
-            new_version=new_version,
+            probe_matrix_old, probe_matrix_new, policy, worst_verdict,
+            suppress=suppress, policy_file_path=policy_file_path,
+            old_version=old_version, new_version=new_version,
         )
 
         # Fold release-global bundle/matrix findings into the severity exit so a
         # clean-per-library release with a bundle/matrix break is not masked.
         if severity_exit_code is not None:
             severity_exit_code = _fold_release_global_severity(
-                severity_exit_code,
-                bundle_result,
-                matrix_result,
-                severity_preset,
-                severity_abi_breaking,
-                severity_potential_breaking,
-                severity_quality_issues,
-                severity_addition,
+                severity_exit_code, bundle_result, matrix_result,
+                severity_preset, severity_abi_breaking, severity_potential_breaking,
+                severity_quality_issues, severity_addition,
             )
 
         _finalize_release_output(
-            fmt,
-            worst_verdict,
-            old_dir,
-            new_dir,
-            library_results,
-            removed_keys,
-            added_keys,
-            old_map,
-            new_map,
-            warning_msgs,
-            diff_pairs,
-            bundle_result,
-            output,
-            output_dir,
-            annotate,
-            fail_on_removed,
+            fmt, worst_verdict, old_dir, new_dir,
+            library_results, removed_keys, added_keys,
+            old_map, new_map, warning_msgs,
+            diff_pairs, bundle_result,
+            output, output_dir, annotate, fail_on_removed,
             matrix_result=matrix_result,
             severity_exit_code=severity_exit_code,
             severity_config=severity_config,
@@ -1871,100 +1462,53 @@ def _prepare_compare_release_inputs(
     includes: tuple[Path, ...],
     old_includes_only: tuple[Path, ...],
     new_includes_only: tuple[Path, ...],
-    extract_if_package: Callable[
-        [Path, Path | None, Path | None], tuple[Path, Path | None, Path | None]
-    ],
+    extract_if_package: Callable[[Path, Path | None, Path | None], tuple[Path, Path | None, Path | None]],
     discover_shared_libraries: Callable[..., list[Path]],
     is_package: Callable[[Path], bool],
     is_elf_shared_object: Callable[[Path], bool],
 ) -> tuple[
-    Path | None,
-    Path | None,
-    list[Path],
-    list[Path],
-    list[Path],
-    list[Path],
-    dict[str, Path],
-    dict[str, Path],
-    list[str],
-    list[str],
-    list[str],
-    list[str],
+    Path | None, Path | None,
+    list[Path], list[Path], list[Path], list[Path],
+    dict[str, Path], dict[str, Path], list[str],
+    list[str], list[str], list[str],
 ]:
     """Prepare inputs/maps/keys for compare-release command."""
     old_lib_dir, old_debug_dir, old_header_dir = extract_if_package(
-        old_dir,
-        debug_info1,
-        devel_pkg1,
+        old_dir, debug_info1, devel_pkg1,
     )
     new_lib_dir, new_debug_dir, new_header_dir = extract_if_package(
-        new_dir,
-        debug_info2,
-        devel_pkg2,
+        new_dir, debug_info2, devel_pkg2,
     )
     old_files = _discover_files(
-        old_dir,
-        old_lib_dir,
-        include_private_dso,
-        discover_shared_libraries,
-        is_package,
+        old_dir, old_lib_dir, include_private_dso, discover_shared_libraries, is_package,
     )
     new_files = _discover_files(
-        new_dir,
-        new_lib_dir,
-        include_private_dso,
-        discover_shared_libraries,
-        is_package,
+        new_dir, new_lib_dir, include_private_dso, discover_shared_libraries, is_package,
     )
     if dso_only:
         old_files = [f for f in old_files if is_elf_shared_object(f)]
         new_files = [f for f in new_files if is_elf_shared_object(f)]
     old_map, old_warns = _build_match_map(old_files)
     new_map, new_warns = _build_match_map(new_files)
-    warning_msgs: list[str] = [
-        f"Warning: {warning}" for warning in (old_warns + new_warns)
-    ]
+    warning_msgs: list[str] = [f"Warning: {warning}" for warning in (old_warns + new_warns)]
     old_h, new_h = _resolve_release_headers(
-        headers,
-        old_headers_only,
-        new_headers_only,
-        old_header_dir,
-        new_header_dir,
+        headers, old_headers_only, new_headers_only, old_header_dir, new_header_dir,
     )
     old_inc = list(old_includes_only) if old_includes_only else list(includes)
     new_inc = list(new_includes_only) if new_includes_only else list(includes)
     old_inc.extend(_discover_include_roots(old_header_dir))
     new_inc.extend(_discover_include_roots(new_header_dir))
     matched_keys, removed_keys, added_keys, old_map, new_map = _match_release_keys(
-        old_dir,
-        new_dir,
-        old_map,
-        new_map,
-        old_files,
-        new_files,
-        is_package,
+        old_dir, new_dir, old_map, new_map, old_files, new_files, is_package,
     )
     _collect_release_warnings(
-        warning_msgs,
-        matched_keys,
-        removed_keys,
-        added_keys,
-        old_map,
-        new_map,
+        warning_msgs, matched_keys, removed_keys, added_keys, old_map, new_map,
     )
     return (
-        old_debug_dir,
-        new_debug_dir,
-        old_h,
-        new_h,
-        old_inc,
-        new_inc,
-        old_map,
-        new_map,
-        warning_msgs,
-        matched_keys,
-        removed_keys,
-        added_keys,
+        old_debug_dir, new_debug_dir,
+        old_h, new_h, old_inc, new_inc,
+        old_map, new_map, warning_msgs,
+        matched_keys, removed_keys, added_keys,
     )
 
 
@@ -1990,11 +1534,8 @@ def _compute_release_severity_exit_code(
     separately via :func:`_fold_release_global_severity`.
     """
     resolved_config = _resolve_release_severity_config(
-        severity_preset,
-        severity_abi_breaking,
-        severity_potential_breaking,
-        severity_quality_issues,
-        severity_addition,
+        severity_preset, severity_abi_breaking, severity_potential_breaking,
+        severity_quality_issues, severity_addition,
     )
     if resolved_config is None:
         return None
@@ -2006,8 +1547,7 @@ def _compute_release_severity_exit_code(
         diff = entry.get("_diff_result") if isinstance(entry, dict) else None
         if isinstance(diff, DiffResult):
             code = compute_exit_code(
-                diff.changes,
-                resolved_config,
+                diff.changes, resolved_config,
                 kind_sets=diff._effective_kind_sets(),
             )
             worst = max(worst, code)
@@ -2025,16 +1565,12 @@ def _resolve_release_severity_config(
     if not any(
         v is not None
         for v in (
-            severity_preset,
-            severity_abi_breaking,
-            severity_potential_breaking,
-            severity_quality_issues,
-            severity_addition,
+            severity_preset, severity_abi_breaking, severity_potential_breaking,
+            severity_quality_issues, severity_addition,
         )
     ):
         return None
     from .severity import resolve_severity_config
-
     return resolve_severity_config(
         severity_preset,
         abi_breaking=severity_abi_breaking,
@@ -2064,11 +1600,8 @@ def _fold_release_global_severity(
     worst of *base_code* and the bundle/matrix severity codes.
     """
     config = _resolve_release_severity_config(
-        severity_preset,
-        severity_abi_breaking,
-        severity_potential_breaking,
-        severity_quality_issues,
-        severity_addition,
+        severity_preset, severity_abi_breaking, severity_potential_breaking,
+        severity_quality_issues, severity_addition,
     )
     if config is None:
         return base_code
@@ -2084,8 +1617,7 @@ def _fold_release_global_severity(
         worst = max(
             worst,
             compute_exit_code(
-                matrix_result.changes,
-                config,
+                matrix_result.changes, config,
                 kind_sets=matrix_result._effective_kind_sets(),
             ),
         )

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -60,7 +60,7 @@ from .cli import _write_or_echo, main
     default=None,
     help="Write the comment markdown (default: stdout).",
 )
-def pr_comment_cmd(  # pylint: disable=too-many-arguments
+def pr_comment_cmd(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     report: Path,
     sha: str,
     detail: str,

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI — ``pr-comment`` command.
+
+Renders a sticky GitHub PR-comment body from a JSON report produced by
+``compare`` / ``compare-release`` / ``appcompat``. Split out of
+:mod:`abicheck.cli` and imported for side-effect at the bottom of that module
+so the ``@main.command("pr-comment")`` decorator runs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from .cli import _write_or_echo, main
+
+
+@main.command("pr-comment")
+@click.argument("report", type=click.Path(exists=True, path_type=Path))
+@click.option("--sha", default="", help="Commit SHA being scanned (PR head).")
+@click.option(
+    "--detail",
+    type=click.Choice(["summary", "standard", "full"]),
+    default="standard",
+    show_default=True,
+    help="How much per-change detail to include in the comment.",
+)
+@click.option(
+    "--on",
+    "post_on",
+    type=click.Choice(["always", "changes", "never"]),
+    default="changes",
+    show_default=True,
+    help="When to emit a comment body: always, only on changes, or never.",
+)
+@click.option(
+    "--run-label",
+    default=None,
+    help="Run label shown in the footer, e.g. 'run #128'.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the comment markdown (default: stdout).",
+)
+def pr_comment_cmd(
+    report: Path,
+    sha: str,
+    detail: str,
+    post_on: str,
+    run_label: str | None,
+    output: Path | None,
+) -> None:
+    """Render a sticky PR-comment body from a JSON REPORT.
+
+    REPORT is a JSON file from 'abicheck compare|compare-release|appcompat
+    --format json'. When --on=never, or --on=changes and the report has no
+    changes, nothing is written (an empty --output file is produced) so the
+    caller can skip posting.
+
+    \b
+    Example:
+      abicheck compare old.json new.so -H include/ --format json -o report.json
+      abicheck pr-comment report.json --sha "$GITHUB_SHA" -o comment.md
+    """
+    from .pr_comment import build_model, render_comment, should_post
+
+    try:
+        data = json.loads(Path(report).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise click.ClickException(f"Cannot read JSON report: {e}") from e
+
+    if not isinstance(data, dict):
+        raise click.ClickException("JSON report must be an object")
+
+    model = build_model(data)
+    if not should_post(model, post_on):
+        # Nothing to post — leave an empty file so a `-s` check skips posting.
+        if output is not None:
+            Path(output).write_text("", encoding="utf-8")
+        return
+
+    body = render_comment(model, sha=sha, detail=detail, run_label=run_label)
+    _write_or_echo(output, body)

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -54,6 +54,12 @@ from .cli import _write_or_echo, main
     help="Run label shown in the footer, e.g. 'run #128'.",
 )
 @click.option(
+    "--report-url",
+    default=None,
+    help="URL of the full report/run, linked in the footer and used when the "
+    "comment is condensed or truncated to fit GitHub's size limit.",
+)
+@click.option(
     "--gate-api-break",
     is_flag=True,
     default=False,
@@ -73,6 +79,7 @@ def pr_comment_cmd(
     detail: str,
     post_on: str,
     run_label: str | None,
+    report_url: str | None,
     gate_api_break: bool,
     output: Path | None,
 ) -> None:
@@ -105,5 +112,7 @@ def pr_comment_cmd(
             Path(output).write_text("", encoding="utf-8")
         return
 
-    body = render_comment(model, sha=sha, detail=detail, run_label=run_label)
+    body = render_comment(
+        model, sha=sha, detail=detail, run_label=run_label, report_url=report_url
+    )
     _write_or_echo(output, body)

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -91,7 +91,7 @@ def pr_comment_cmd(
     from .pr_comment import build_model, render_comment, should_post
 
     try:
-        data = json.loads(Path(report).read_text(encoding="utf-8"))
+        data = json.loads(report.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
         raise click.ClickException(f"Cannot read JSON report: {e}") from e
 

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -60,7 +60,7 @@ from .cli import _write_or_echo, main
     default=None,
     help="Write the comment markdown (default: stdout).",
 )
-def pr_comment_cmd(
+def pr_comment_cmd(  # pylint: disable=too-many-arguments
     report: Path,
     sha: str,
     detail: str,

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -54,6 +54,13 @@ from .cli import _write_or_echo, main
     help="Run label shown in the footer, e.g. 'run #128'.",
 )
 @click.option(
+    "--gate-api-break",
+    is_flag=True,
+    default=False,
+    help="Treat API/source breaks as breaking (mirror fail-on-api-break, which "
+    "turns the check red on them).",
+)
+@click.option(
     "-o",
     "--output",
     type=click.Path(path_type=Path),
@@ -66,6 +73,7 @@ def pr_comment_cmd(
     detail: str,
     post_on: str,
     run_label: str | None,
+    gate_api_break: bool,
     output: Path | None,
 ) -> None:
     """Render a sticky PR-comment body from a JSON REPORT.
@@ -90,7 +98,7 @@ def pr_comment_cmd(
     if not isinstance(data, dict):
         raise click.ClickException("JSON report must be an object")
 
-    model = build_model(data)
+    model = build_model(data, gate_api_break=gate_api_break)
     if not should_post(model, post_on):
         # Nothing to post — leave an empty file so a `-s` check skips posting.
         if output is not None:

--- a/abicheck/cli_pr_comment.py
+++ b/abicheck/cli_pr_comment.py
@@ -60,7 +60,7 @@ from .cli import _write_or_echo, main
     default=None,
     help="Write the comment markdown (default: stdout).",
 )
-def pr_comment_cmd(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def pr_comment_cmd(
     report: Path,
     sha: str,
     detail: str,

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -318,21 +318,28 @@ def _release_lib_row(
 
     Source breaks count as breaking when fail-on-api-break is set or
     potential_breaking is gated to error; risk only when potential_breaking is
-    error; additions only when the addition category is error. Otherwise source
-    breaks + risk are review and additions are safe.
+    error; additions and quality issues only when their own category is gated to
+    error. Otherwise source breaks + risk are review and additions + quality are
+    safe.
     """
     src = _as_int(lib.get("source_breaks"))
     risk = _as_int(lib.get("risk_changes"))
-    add = _as_int(lib.get("compatible_additions"))
+    # compatible_additions is the *total* compatible count; quality_issues is the
+    # subset that is not an addition. Fall back to treating all as additions when
+    # the (older) report omits quality_issues.
+    quality = _as_int(lib.get("quality_issues"))
+    additions = max(_as_int(lib.get("compatible_additions")) - quality, 0)
     pot_err = levels.get("potential_breaking") == "error"
     add_err = levels.get("addition") == "error"
+    qual_err = levels.get("quality_issues") == "error"
 
     nb = _as_int(lib.get("breaking"))
     nr = 0
     ns = 0
     nb, nr = (nb + src, nr) if (gate_api_break or pot_err) else (nb, nr + src)
     nb, nr = (nb + risk, nr) if pot_err else (nb, nr + risk)
-    nb, ns = (nb + add, ns) if add_err else (nb, ns + add)
+    nb, ns = (nb + additions, ns) if add_err else (nb, ns + additions)
+    nb, ns = (nb + quality, ns) if qual_err else (nb, ns + quality)
     return str(lib.get("library", "?")), str(lib.get("verdict", "?")), nb, nr, ns
 
 

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -148,32 +148,60 @@ def _detail_text(change: dict[str, object]) -> str:
     return desc
 
 
+def _severity_levels(report: dict[str, object]) -> dict[str, str]:
+    """Resolved per-category severity levels from the report, or ``{}``.
+
+    Present when the comparison ran with a severity config (``--severity-*`` /
+    preset). A category set to ``error`` turns the check red, so the comment
+    must file that category's findings under Breaking to match — this covers
+    ``severity-addition: error`` and any preset/extra-arg path uniformly.
+    """
+    sev = report.get("severity")
+    if isinstance(sev, dict):
+        cfg = sev.get("config")
+        if isinstance(cfg, dict):
+            return {str(k): str(v) for k, v in cfg.items()}
+    return {}
+
+
+def _finding_category(severity: str, kind: str) -> str:
+    """Map a finding's severity label + kind to a severity-config category."""
+    if severity == "breaking":
+        return "abi_breaking"
+    if severity in ("api_break", "risk"):
+        return "potential_breaking"
+    if kind.endswith("_added"):
+        return "addition"
+    return "quality_issues"
+
+
 def _bucket_changes(
     changes: object,
     gate_api_break: bool = False,
+    levels: dict[str, str] | None = None,
 ) -> tuple[list[Finding], list[Finding], list[Finding]]:
     breaking: list[Finding] = []
     review: list[Finding] = []
     safe: list[Finding] = []
     target = {"breaking": breaking, "review": review, "safe": safe}
-    # When the step gates on API breaks (fail-on-api-break), the check goes red
-    # on them, so the comment must file them under Breaking to match — risk
-    # findings are never gated and stay in review.
-    sev_map = (
-        {**_SEVERITY_BUCKET, "api_break": "breaking"}
-        if gate_api_break
-        else _SEVERITY_BUCKET
-    )
+    levels = levels or {}
     if isinstance(changes, list):
         for c in changes:
             if not isinstance(c, dict):
                 continue
             sev = str(c.get("severity", "unknown"))
-            bucket = sev_map.get(sev, "review")
+            kind = str(c.get("kind", ""))
+            bucket = _SEVERITY_BUCKET.get(sev, "review")
+            # fail-on-api-break turns the check red on API breaks (only) …
+            if gate_api_break and sev == "api_break":
+                bucket = "breaking"
+            # … and a severity category set to error turns it red too.
+            if levels.get(_finding_category(sev, kind)) == "error":
+                bucket = "breaking"
             loc = c.get("source_location")
             target[bucket].append(
                 Finding(
-                    kind=str(c.get("kind", "")),
+                    kind=kind,
                     symbol=str(c.get("symbol", "")),
                     detail=_detail_text(c),
                     location=str(loc) if loc else None,
@@ -185,7 +213,9 @@ def _bucket_changes(
 def _from_compare(
     report: dict[str, object], gate_api_break: bool = False
 ) -> CommentModel:
-    breaking, review, safe = _bucket_changes(report.get("changes"), gate_api_break)
+    breaking, review, safe = _bucket_changes(
+        report.get("changes"), gate_api_break, _severity_levels(report)
+    )
     return CommentModel(
         mode="compare",
         subject=str(report.get("library", "library")),
@@ -202,7 +232,7 @@ def _from_appcompat(
     report: dict[str, object], gate_api_break: bool = False
 ) -> CommentModel:
     breaking, review, safe = _bucket_changes(
-        report.get("relevant_changes"), gate_api_break
+        report.get("relevant_changes"), gate_api_break, _severity_levels(report)
     )
     missing = report.get("missing_symbols")
     if isinstance(missing, list):
@@ -273,29 +303,42 @@ def _append_release_global_row(
     )
 
 
+def _release_lib_row(
+    lib: dict[str, object], gate_api_break: bool, levels: dict[str, str]
+) -> tuple[str, str, int, int, int]:
+    """Per-library (name, verdict, breaking, review, safe) counts.
+
+    Source breaks count as breaking when fail-on-api-break is set or
+    potential_breaking is gated to error; risk only when potential_breaking is
+    error; additions only when the addition category is error. Otherwise source
+    breaks + risk are review and additions are safe.
+    """
+    src = _as_int(lib.get("source_breaks"))
+    risk = _as_int(lib.get("risk_changes"))
+    add = _as_int(lib.get("compatible_additions"))
+    pot_err = levels.get("potential_breaking") == "error"
+    add_err = levels.get("addition") == "error"
+
+    nb = _as_int(lib.get("breaking"))
+    nr = 0
+    ns = 0
+    nb, nr = (nb + src, nr) if (gate_api_break or pot_err) else (nb, nr + src)
+    nb, nr = (nb + risk, nr) if pot_err else (nb, nr + risk)
+    nb, ns = (nb + add, ns) if add_err else (nb, ns + add)
+    return str(lib.get("library", "?")), str(lib.get("verdict", "?")), nb, nr, ns
+
+
 def _from_release(
     report: dict[str, object], gate_api_break: bool = False
 ) -> CommentModel:
     rows: list[tuple[str, str, int, int, int]] = []
+    levels = _severity_levels(report)
     libraries = report.get("libraries")
     if isinstance(libraries, list):
         for lib in libraries:
             if not isinstance(lib, dict):
                 continue
-            # Review = source breaks + risk findings: a library that is
-            # COMPATIBLE_WITH_RISK with only risk_changes must still count as a
-            # change so `--on changes` posts the warning-tone comment. When the
-            # step gates on API breaks, source breaks count as breaking instead.
-            src = _as_int(lib.get("source_breaks"))
-            rows.append(
-                (
-                    str(lib.get("library", "?")),
-                    str(lib.get("verdict", "?")),
-                    _as_int(lib.get("breaking")) + (src if gate_api_break else 0),
-                    (0 if gate_api_break else src) + _as_int(lib.get("risk_changes")),
-                    _as_int(lib.get("compatible_additions")),
-                )
-            )
+            rows.append(_release_lib_row(lib, gate_api_break, levels))
     n_libs = len(rows)
     _append_release_global_row(
         rows,

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -1,0 +1,431 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sticky GitHub PR-comment rendering.
+
+Renders a single, updatable PR comment from an abicheck JSON report
+(``compare``, ``compare-release`` or ``appcompat`` mode). The comment is a
+*content* channel and is independent of the check's red/green gate: ABI/API
+breaks turn the step red via exit codes (see ``action/run.sh``), while this
+comment groups every finding into three buckets so a reviewer sees, in one
+place:
+
+* **Breaking** — clear ABI breaks (and gated source breaks);
+* **Needs review** — source breaks / risk a human should sign off on;
+* **Safe** — additions and policy/surface-scoped compatible removals.
+
+"Safe" here is a pure mirror of the severity the checker already assigned
+(``severity`` field in the JSON, which honours public-surface scoping and the
+active policy) — this module never re-classifies anything.
+
+The body carries a hidden HTML :data:`MARKER` so the action can find and
+update the same comment across runs, and surfaces the scanned commit SHA in
+both the header and the footer.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+# Hidden marker used to find-and-update the sticky comment across runs.
+MARKER = "<!-- abicheck-sticky-report -->"
+
+DETAIL_LEVELS = ("summary", "standard", "full")
+POST_MODES = ("always", "changes", "never")
+
+# Severity tokens emitted in the JSON report (`reporter._effective_severity_label`)
+# routed into the three reviewer-facing buckets.
+_SEVERITY_BUCKET = {
+    "breaking": "breaking",
+    "api_break": "review",
+    "risk": "review",
+    "compatible": "safe",
+    "unknown": "review",
+}
+
+# Per-detail row caps for the "standard" level (full = uncapped).
+_STANDARD_ROW_CAP = 25
+_SAFE_SYMBOLS_PER_KIND = 12
+
+_VERDICT_EMOJI = {
+    "BREAKING": "❌",
+    "API_BREAK": "⚠️",
+    "COMPATIBLE_WITH_RISK": "⚠️",
+    "COMPATIBLE": "✅",
+    "NO_CHANGE": "✅",
+    "ERROR": "🛑",
+}
+
+
+@dataclass
+class Finding:
+    """A single change, normalised for the comment."""
+
+    kind: str
+    symbol: str
+    detail: str = ""
+    location: str | None = None
+
+
+@dataclass
+class CommentModel:
+    """Mode-agnostic view of a report, ready to render."""
+
+    mode: str  # "compare" | "release" | "appcompat"
+    subject: str
+    old_label: str
+    new_label: str
+    policy: str
+    breaking: list[Finding] = field(default_factory=list)
+    review: list[Finding] = field(default_factory=list)
+    safe: list[Finding] = field(default_factory=list)
+    # release mode only: (library, verdict, n_breaking, n_review, n_safe)
+    library_rows: list[tuple[str, str, int, int, int]] = field(default_factory=list)
+    removed_libraries: list[str] = field(default_factory=list)
+    added_libraries: list[str] = field(default_factory=list)
+
+    @property
+    def counts(self) -> tuple[int, int, int]:
+        """(breaking, needs-review, safe) totals across the report."""
+        if self.mode == "release":
+            return (
+                sum(r[2] for r in self.library_rows),
+                sum(r[3] for r in self.library_rows),
+                sum(r[4] for r in self.library_rows),
+            )
+        return len(self.breaking), len(self.review), len(self.safe)
+
+    @property
+    def total_changes(self) -> int:
+        b, r, s = self.counts
+        return b + r + s
+
+
+# ---------------------------------------------------------------------------
+# Parsing — JSON report → CommentModel
+# ---------------------------------------------------------------------------
+
+
+def _basename(path: object) -> str:
+    s = str(path or "").rstrip("/")
+    return s.rsplit("/", 1)[-1] or str(path or "")
+
+
+def _detail_text(change: dict[str, object]) -> str:
+    desc = str(change.get("description", "") or "").strip()
+    old, new = change.get("old_value"), change.get("new_value")
+    if old not in (None, "") and new not in (None, ""):
+        delta = f"{old} → {new}"
+        return f"{desc} ({delta})" if desc else delta
+    return desc
+
+
+def _bucket_changes(
+    changes: object,
+) -> tuple[list[Finding], list[Finding], list[Finding]]:
+    breaking: list[Finding] = []
+    review: list[Finding] = []
+    safe: list[Finding] = []
+    target = {"breaking": breaking, "review": review, "safe": safe}
+    if isinstance(changes, list):
+        for c in changes:
+            if not isinstance(c, dict):
+                continue
+            sev = str(c.get("severity", "unknown"))
+            bucket = _SEVERITY_BUCKET.get(sev, "review")
+            loc = c.get("source_location")
+            target[bucket].append(
+                Finding(
+                    kind=str(c.get("kind", "")),
+                    symbol=str(c.get("symbol", "")),
+                    detail=_detail_text(c),
+                    location=str(loc) if loc else None,
+                )
+            )
+    return breaking, review, safe
+
+
+def _from_compare(report: dict[str, object]) -> CommentModel:
+    breaking, review, safe = _bucket_changes(report.get("changes"))
+    return CommentModel(
+        mode="compare",
+        subject=str(report.get("library", "library")),
+        old_label=str(report.get("old_version", "old")),
+        new_label=str(report.get("new_version", "new")),
+        policy=str(report.get("policy", "strict_abi")),
+        breaking=breaking,
+        review=review,
+        safe=safe,
+    )
+
+
+def _from_appcompat(report: dict[str, object]) -> CommentModel:
+    breaking, review, safe = _bucket_changes(report.get("relevant_changes"))
+    missing = report.get("missing_symbols")
+    if isinstance(missing, list):
+        for sym in missing:
+            breaking.append(
+                Finding(
+                    kind="symbol_missing",
+                    symbol=str(sym),
+                    detail="required symbol not provided by new library",
+                )
+            )
+    return CommentModel(
+        mode="appcompat",
+        subject=_basename(report.get("application", "application")),
+        old_label=_basename(report.get("old_library", "old")),
+        new_label=_basename(report.get("new_library", "new")),
+        policy="strict_abi",
+        breaking=breaking,
+        review=review,
+        safe=safe,
+    )
+
+
+def _from_release(report: dict[str, object]) -> CommentModel:
+    rows: list[tuple[str, str, int, int, int]] = []
+    libraries = report.get("libraries")
+    if isinstance(libraries, list):
+        for lib in libraries:
+            if not isinstance(lib, dict):
+                continue
+            rows.append(
+                (
+                    str(lib.get("library", "?")),
+                    str(lib.get("verdict", "?")),
+                    _as_int(lib.get("breaking")),
+                    _as_int(lib.get("source_breaks")),
+                    _as_int(lib.get("compatible_additions")),
+                )
+            )
+    removed = report.get("unmatched_old")
+    added = report.get("unmatched_new")
+    n = len(rows)
+    return CommentModel(
+        mode="release",
+        subject=f"{n} librar{'y' if n == 1 else 'ies'}",
+        old_label=_basename(report.get("old_dir", "old")),
+        new_label=_basename(report.get("new_dir", "new")),
+        policy="strict_abi",
+        library_rows=rows,
+        removed_libraries=[str(x) for x in removed]
+        if isinstance(removed, list)
+        else [],
+        added_libraries=[str(x) for x in added] if isinstance(added, list) else [],
+    )
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def build_model(report: dict[str, object]) -> CommentModel:
+    """Detect the report shape and normalise it into a :class:`CommentModel`."""
+    if isinstance(report.get("libraries"), list):
+        return _from_release(report)
+    if "application" in report or isinstance(report.get("relevant_changes"), list):
+        return _from_appcompat(report)
+    return _from_compare(report)
+
+
+def should_post(model: CommentModel, on: str) -> bool:
+    """Whether a comment should be posted given the ``--on`` policy."""
+    if on == "never":
+        return False
+    if on == "always":
+        return True
+    # on == "changes"
+    return (
+        model.total_changes > 0
+        or bool(model.removed_libraries)
+        or bool(model.added_libraries)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering — CommentModel → markdown
+# ---------------------------------------------------------------------------
+
+
+def _esc(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _header(model: CommentModel) -> tuple[str, str]:
+    b, r, s = model.counts
+    if model.removed_libraries:
+        return "❌", "LIBRARY REMOVED"
+    if b:
+        return "❌", "ABI BREAKING"
+    if r:
+        return "⚠️", "Review recommended"
+    if s:
+        return "✅", "Compatible — safe changes only"
+    return "✅", "No ABI changes"
+
+
+def _findings_table(
+    title: str,
+    findings: list[Finding],
+    detail: str,
+    *,
+    open_default: bool,
+) -> list[str]:
+    if not findings:
+        return []
+    cap = None if detail == "full" else _STANDARD_ROW_CAP
+    is_open = " open" if (detail == "full" or open_default) else ""
+    shown = findings if cap is None else findings[:cap]
+    out = [
+        f"<details{is_open}><summary>{title} ({len(findings)})</summary>",
+        "",
+        "| Change | Symbol | Detail |",
+        "|---|---|---|",
+    ]
+    for f in shown:
+        loc = f" · `{_esc(f.location)}`" if f.location else ""
+        cell = (_esc(f.detail) + loc) if f.detail else _esc(f.location or "—")
+        out.append(f"| `{_esc(f.kind)}` | `{_esc(f.symbol)}` | {cell} |")
+    if cap is not None and len(findings) > cap:
+        out.append(f"| … | … | _{len(findings) - cap} more_ |")
+    out += ["</details>", ""]
+    return out
+
+
+def _safe_section(findings: list[Finding], detail: str) -> list[str]:
+    if not findings:
+        return []
+    is_open = " open" if detail == "full" else ""
+    out = [f"<details{is_open}><summary>✅ Safe ({len(findings)})</summary>", ""]
+    if detail == "full":
+        out += ["| Change | Symbol | Detail |", "|---|---|---|"]
+        for f in findings:
+            out.append(f"| `{_esc(f.kind)}` | `{_esc(f.symbol)}` | {_esc(f.detail)} |")
+    else:
+        groups: OrderedDict[str, list[str]] = OrderedDict()
+        for f in findings:
+            groups.setdefault(f.kind, []).append(f.symbol)
+        parts: list[str] = []
+        for kind, syms in groups.items():
+            shown = syms[:_SAFE_SYMBOLS_PER_KIND]
+            more = (
+                f" _(+{len(syms) - _SAFE_SYMBOLS_PER_KIND})_"
+                if len(syms) > _SAFE_SYMBOLS_PER_KIND
+                else ""
+            )
+            joined = ", ".join(f"`{_esc(x)}`" for x in shown)
+            parts.append(f"`{_esc(kind)}`: {joined}{more}")
+        out.append(" · ".join(parts))
+    out += ["", "</details>", ""]
+    return out
+
+
+def _release_table(model: CommentModel, detail: str) -> list[str]:
+    rows = model.library_rows
+    if not rows:
+        return []
+    is_open = " open" if detail == "full" else ""
+    ordered = sorted(rows, key=lambda r: (-r[2], -r[3], -r[4], r[0]))
+    cap = None if detail == "full" else _STANDARD_ROW_CAP
+    shown = ordered if cap is None else ordered[:cap]
+    out = [
+        f"<details{is_open}><summary>Per-library results ({len(rows)})</summary>",
+        "",
+        "| Library | Verdict | Breaking | Review | Safe |",
+        "|---|---|---|---|---|",
+    ]
+    for name, verdict, nb, nr, ns in shown:
+        em = _VERDICT_EMOJI.get(verdict, "•")
+        out.append(f"| `{_esc(name)}` | {em} {_esc(verdict)} | {nb} | {nr} | {ns} |")
+    if cap is not None and len(ordered) > cap:
+        out.append(f"| … | … | | | _{len(ordered) - cap} more_ |")
+    out += ["</details>", ""]
+    return out
+
+
+def render_comment(
+    model: CommentModel,
+    *,
+    sha: str = "",
+    detail: str = "standard",
+    run_label: str | None = None,
+    timestamp: datetime | None = None,
+) -> str:
+    """Render the full sticky-comment markdown body (including :data:`MARKER`)."""
+    if detail not in DETAIL_LEVELS:
+        detail = "standard"
+    ts = timestamp or datetime.now(timezone.utc)
+    emoji, title = _header(model)
+    b, r, s = model.counts
+    short_sha = (sha or "")[:7]
+
+    head_ref = f"**Head `{short_sha}`**" if short_sha else "**Head**"
+    context = (
+        f"{head_ref} vs `{model.old_label}` · `{model.policy}` · `{model.subject}`"
+    )
+
+    lines: list[str] = [
+        MARKER,
+        "",
+        f"## {emoji} abicheck — {title}",
+        "",
+        context,
+        "",
+        f"**{b} breaking** · {r} needs review · {s} safe",
+        "",
+    ]
+
+    if model.removed_libraries:
+        listed = ", ".join(f"`{_esc(x)}`" for x in model.removed_libraries)
+        lines += [f"> ⛔ Libraries removed: {listed}", ""]
+    if model.added_libraries:
+        listed = ", ".join(f"`{_esc(x)}`" for x in model.added_libraries)
+        lines += [f"> ➕ New libraries: {listed}", ""]
+
+    if detail != "summary":
+        if model.mode == "release":
+            lines += _release_table(model, detail)
+        else:
+            lines += _findings_table(
+                "❌ Breaking", model.breaking, detail, open_default=bool(model.breaking)
+            )
+            lines += _findings_table(
+                "⚠️ Needs review",
+                model.review,
+                detail,
+                open_default=(not model.breaking and bool(model.review)),
+            )
+            lines += _safe_section(model.safe, detail)
+
+    footer = f"<sub>Updated {ts.strftime('%Y-%m-%d %H:%M UTC')}"
+    if run_label:
+        footer += f" · {run_label}"
+    if short_sha:
+        footer += f" · commit {short_sha}"
+    footer += "</sub>"
+    lines += [footer, ""]
+
+    return "\n".join(lines)

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -77,6 +77,19 @@ _VERDICT_BUCKET = {
 # Per-detail row caps for the "standard" level (full = uncapped).
 _STANDARD_ROW_CAP = 25
 _SAFE_SYMBOLS_PER_KIND = 12
+# Member symbols listed inline in an aggregated (API-grouped) Breaking/Review row.
+_GROUP_MEMBERS_INLINE = 8
+
+# GitHub rejects issue/PR comment bodies longer than 65,536 characters. Render
+# within a budget below that; if the body overflows, downgrade the detail level
+# (full → standard → summary) and finally hard-truncate so we never exceed it.
+GITHUB_COMMENT_LIMIT = 65536
+_BODY_BUDGET = 64000
+_DETAIL_DOWNGRADE = {
+    "full": ("full", "standard", "summary"),
+    "standard": ("standard", "summary"),
+    "summary": ("summary",),
+}
 
 _VERDICT_EMOJI = {
     "BREAKING": "❌",
@@ -482,6 +495,62 @@ def _header(model: CommentModel) -> tuple[str, str]:
     return "✅", "No ABI changes"
 
 
+def _strip_templates(s: str) -> str:
+    """Drop balanced ``<...>`` template arguments (best-effort, for grouping)."""
+    out: list[str] = []
+    depth = 0
+    for ch in s:
+        if ch == "<":
+            depth += 1
+            continue
+        if ch == ">":
+            if depth > 0:
+                depth -= 1
+            continue
+        if depth == 0:
+            out.append(ch)
+    return "".join(out)
+
+
+def _api_group(symbol: str) -> str:
+    """Enclosing API (namespace/type or free-function family) of a symbol.
+
+    Strips template arguments and the parameter list, then drops the trailing
+    ``::name`` so overloads, template instantiations and members of the same
+    type/namespace collapse to one key. Free functions collapse their overloads
+    to the bare name; distinct names stay distinct.
+    """
+    s = _strip_templates(symbol).strip()
+    paren = s.find("(")
+    if paren != -1:
+        s = s[:paren].strip()
+    if "::" in s:
+        s = s.rsplit("::", 1)[0].strip()
+    return s or symbol.strip()
+
+
+def _group_by_api(findings: list[Finding]) -> OrderedDict[str, list[Finding]]:
+    groups: OrderedDict[str, list[Finding]] = OrderedDict()
+    for f in findings:
+        groups.setdefault(_api_group(f.symbol), []).append(f)
+    return groups
+
+
+def _flat_row(f: Finding) -> str:
+    loc = f" · `{_esc(f.location)}`" if f.location else ""
+    cell = (_esc(f.detail) + loc) if f.detail else _esc(f.location or "—")
+    return f"| `{_esc(f.kind)}` | `{_esc(f.symbol)}` | {cell} |"
+
+
+def _group_row(key: str, members: list[Finding]) -> str:
+    kinds = ", ".join(f"`{_esc(k)}`" for k in dict.fromkeys(m.kind for m in members))
+    syms = [m.symbol for m in members]
+    shown = syms[:_GROUP_MEMBERS_INLINE]
+    more = f" +{len(syms) - _GROUP_MEMBERS_INLINE} more" if len(syms) > _GROUP_MEMBERS_INLINE else ""
+    members_cell = ", ".join(f"`{_esc(x)}`" for x in shown) + more
+    return f"| {kinds} | `{_esc(key)}` ({len(members)}) | {members_cell} |"
+
+
 def _findings_table(
     title: str,
     findings: list[Finding],
@@ -491,21 +560,27 @@ def _findings_table(
 ) -> list[str]:
     if not findings:
         return []
-    cap = None if detail == "full" else _STANDARD_ROW_CAP
     is_open = " open" if (detail == "full" or open_default) else ""
-    shown = findings if cap is None else findings[:cap]
     out = [
         f"<details{is_open}><summary>{title} ({len(findings)})</summary>",
         "",
         "| Change | Symbol | Detail |",
         "|---|---|---|",
     ]
-    for f in shown:
-        loc = f" · `{_esc(f.location)}`" if f.location else ""
-        cell = (_esc(f.detail) + loc) if f.detail else _esc(f.location or "—")
-        out.append(f"| `{_esc(f.kind)}` | `{_esc(f.symbol)}` | {cell} |")
-    if cap is not None and len(findings) > cap:
-        out.append(f"| … | … | _{len(findings) - cap} more_ |")
+    if detail == "full":
+        # Full detail keeps every change as its own per-symbol row (no rollup).
+        out += [_flat_row(f) for f in findings]
+        out += ["</details>", ""]
+        return out
+    # Standard: roll up by enclosing API so mass changes stay scannable —
+    # singletons render as a normal per-symbol row, families aggregate.
+    groups = _group_by_api(findings)
+    keys = list(groups)
+    for key in keys[:_STANDARD_ROW_CAP]:
+        members = groups[key]
+        out.append(_flat_row(members[0]) if len(members) == 1 else _group_row(key, members))
+    if len(keys) > _STANDARD_ROW_CAP:
+        out.append(f"| … | … | _{len(keys) - _STANDARD_ROW_CAP} more_ |")
     out += ["</details>", ""]
     return out
 
@@ -607,14 +682,46 @@ def _body_sections(model: CommentModel, detail: str) -> list[str]:
     return out
 
 
-def _footer_block(ts: datetime, run_label: str | None, short_sha: str) -> list[str]:
+def _footer_block(
+    ts: datetime, run_label: str | None, short_sha: str, report_url: str | None = None
+) -> list[str]:
     footer = f"<sub>Updated {ts.strftime('%Y-%m-%d %H:%M UTC')}"
     if run_label:
         footer += f" · {run_label}"
     if short_sha:
         footer += f" · commit {short_sha}"
+    if report_url:
+        footer += f" · [full report]({report_url})"
     footer += "</sub>"
     return [footer, ""]
+
+
+def _render_body(
+    model: CommentModel,
+    short_sha: str,
+    ts: datetime,
+    detail: str,
+    run_label: str | None,
+    report_url: str | None,
+    *,
+    condensed: bool,
+) -> str:
+    lines = _header_block(model, short_sha)
+    if condensed:
+        note = "> ℹ️ _Condensed to fit GitHub's comment size limit"
+        note += f" — see the [full report]({report_url})._" if report_url else "._"
+        lines += [note, ""]
+    lines += _library_notes(model)
+    if detail != "summary":
+        lines += _body_sections(model, detail)
+    lines += _footer_block(ts, run_label, short_sha, report_url)
+    return "\n".join(lines)
+
+
+def _truncate_to_budget(body: str, report_url: str | None) -> str:
+    suffix = "\n\n<sub>… comment truncated to fit GitHub's size limit"
+    suffix += f" — see the [full report]({report_url}).</sub>" if report_url else ".</sub>"
+    return body[: max(_BODY_BUDGET - len(suffix), 0)] + suffix
 
 
 def render_comment(
@@ -624,15 +731,24 @@ def render_comment(
     detail: str = "standard",
     run_label: str | None = None,
     timestamp: datetime | None = None,
+    report_url: str | None = None,
 ) -> str:
-    """Render the full sticky-comment markdown body (including :data:`MARKER`)."""
+    """Render the full sticky-comment markdown body (including :data:`MARKER`).
+
+    The body is kept under GitHub's 65,536-character comment limit: if the
+    requested detail overflows, the detail level is downgraded
+    (full → standard → summary) and, as a last resort, the body is truncated —
+    always pointing at the full report when *report_url* is supplied.
+    """
     if detail not in DETAIL_LEVELS:
         detail = "standard"
     ts = timestamp or datetime.now(timezone.utc)
     short_sha = (sha or "")[:7]
-    lines = _header_block(model, short_sha)
-    lines += _library_notes(model)
-    if detail != "summary":
-        lines += _body_sections(model, detail)
-    lines += _footer_block(ts, run_label, short_sha)
-    return "\n".join(lines)
+    body = ""
+    for i, level in enumerate(_DETAIL_DOWNGRADE[detail]):
+        body = _render_body(
+            model, short_sha, ts, level, run_label, report_url, condensed=(i > 0)
+        )
+        if len(body) <= _BODY_BUDGET:
+            return body
+    return _truncate_to_budget(body, report_url)

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -40,6 +40,14 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
+from .checker_policy import ADDITION_KINDS
+
+# Kind value strings that constitute new public-API surface (the severity
+# "addition" category). Sourced from the authoritative ADDITION_KINDS so kinds
+# that don't end in "_added" (e.g. type_field_added_compatible,
+# experimental_graduated) are classified correctly.
+_ADDITION_KIND_VALUES = frozenset(k.value for k in ADDITION_KINDS)
+
 # Hidden marker used to find-and-update the sticky comment across runs.
 MARKER = "<!-- abicheck-sticky-report -->"
 
@@ -170,7 +178,7 @@ def _finding_category(severity: str, kind: str) -> str:
         return "abi_breaking"
     if severity in ("api_break", "risk"):
         return "potential_breaking"
-    if kind.endswith("_added"):
+    if kind in _ADDITION_KIND_VALUES:
         return "addition"
     return "quality_issues"
 

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -115,6 +115,7 @@ class CommentModel:  # pylint: disable=too-many-instance-attributes
 
     @property
     def total_changes(self) -> int:
+        """Total number of changes across all three buckets."""
         b, r, s = self.counts
         return b + r + s
 
@@ -187,6 +188,18 @@ def _from_appcompat(report: dict[str, object]) -> CommentModel:
                     kind="symbol_missing",
                     symbol=str(sym),
                     detail="required symbol not provided by new library",
+                )
+            )
+    # A missing required version tag is breaking for the app too (appcompat
+    # treats it the same as a missing symbol), so it must register as a change.
+    missing_versions = report.get("missing_versions")
+    if isinstance(missing_versions, list):
+        for ver in missing_versions:
+            breaking.append(
+                Finding(
+                    kind="version_missing",
+                    symbol=str(ver),
+                    detail="required symbol version not provided by new library",
                 )
             )
     return CommentModel(

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -56,6 +56,16 @@ _SEVERITY_BUCKET = {
     "unknown": "review",
 }
 
+# Verdict strings → reviewer bucket, for release-global findings (bundle /
+# probe-matrix) that carry no per-item severity, only a section verdict.
+_VERDICT_BUCKET = {
+    "BREAKING": "breaking",
+    "API_BREAK": "review",
+    "COMPATIBLE_WITH_RISK": "review",
+    "COMPATIBLE": "safe",
+    "NO_CHANGE": "safe",
+}
+
 # Per-detail row caps for the "standard" level (full = uncapped).
 _STANDARD_ROW_CAP = 25
 _SAFE_SYMBOLS_PER_KIND = 12
@@ -214,6 +224,35 @@ def _from_appcompat(report: dict[str, object]) -> CommentModel:
     )
 
 
+def _append_release_global_row(
+    rows: list[tuple[str, str, int, int, int]],
+    name: str,
+    verdict: object,
+    findings: object,
+) -> None:
+    """Fold a release-global check (bundle / probe-matrix) into the rows.
+
+    These findings live at the top level of the report and fold into the
+    release verdict; without this a clean per-library release that breaks only
+    at the bundle/matrix level would report zero changes and skip the comment.
+    The findings carry no per-item severity, so they are bucketed by the
+    section's own verdict.
+    """
+    if not isinstance(findings, list) or not findings:
+        return
+    bucket = _VERDICT_BUCKET.get(str(verdict or ""), "review")
+    n = len(findings)
+    rows.append(
+        (
+            name,
+            str(verdict or "?"),
+            n if bucket == "breaking" else 0,
+            n if bucket == "review" else 0,
+            n if bucket == "safe" else 0,
+        )
+    )
+
+
 def _from_release(report: dict[str, object]) -> CommentModel:
     rows: list[tuple[str, str, int, int, int]] = []
     libraries = report.get("libraries")
@@ -234,12 +273,24 @@ def _from_release(report: dict[str, object]) -> CommentModel:
                     _as_int(lib.get("compatible_additions")),
                 )
             )
+    n_libs = len(rows)
+    _append_release_global_row(
+        rows,
+        "(bundle checks)",
+        report.get("bundle_verdict"),
+        report.get("bundle_findings"),
+    )
+    _append_release_global_row(
+        rows,
+        "(build-config matrix)",
+        report.get("matrix_verdict"),
+        report.get("matrix_findings"),
+    )
     removed = report.get("unmatched_old")
     added = report.get("unmatched_new")
-    n = len(rows)
     return CommentModel(
         mode="release",
-        subject=f"{n} librar{'y' if n == 1 else 'ies'}",
+        subject=f"{n_libs} librar{'y' if n_libs == 1 else 'ies'}",
         old_label=_basename(report.get("old_dir", "old")),
         new_label=_basename(report.get("new_dir", "new")),
         policy="strict_abi",

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -282,6 +282,7 @@ def _append_release_global_row(
     verdict: object,
     findings: object,
     gate_api_break: bool = False,
+    levels: dict[str, str] | None = None,
 ) -> None:
     """Fold a release-global check (bundle / probe-matrix) into the rows.
 
@@ -289,7 +290,10 @@ def _append_release_global_row(
     release verdict; without this a clean per-library release that breaks only
     at the bundle/matrix level would report zero changes and skip the comment.
     The findings carry no per-item severity, so they are bucketed by the
-    section's own verdict.
+    section's own verdict — but a severity gate set to error promotes the
+    matching section to Breaking (mirroring the per-library path), since
+    ``_fold_release_global_severity`` can turn the check red on exactly these
+    global findings.
     """
     if not isinstance(findings, list) or not findings:
         return
@@ -299,6 +303,16 @@ def _append_release_global_row(
         else _VERDICT_BUCKET
     )
     bucket = verdict_map.get(str(verdict or ""), "review")
+    levels = levels or {}
+    # A compatible section (additions / quality) gated to error, or a risk
+    # section under potential_breaking=error, turns the check red — file it
+    # under Breaking so the comment matches.
+    if bucket == "safe" and (
+        levels.get("addition") == "error" or levels.get("quality_issues") == "error"
+    ):
+        bucket = "breaking"
+    elif bucket == "review" and levels.get("potential_breaking") == "error":
+        bucket = "breaking"
     n = len(findings)
     rows.append(
         (
@@ -366,6 +380,7 @@ def _from_release(
         report.get("bundle_verdict"),
         report.get("bundle_findings"),
         gate_api_break,
+        levels,
     )
     _append_release_global_row(
         rows,
@@ -373,6 +388,7 @@ def _from_release(
         report.get("matrix_verdict"),
         report.get("matrix_findings"),
         gate_api_break,
+        levels,
     )
     removed = report.get("unmatched_old")
     added = report.get("unmatched_new")

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -320,8 +320,13 @@ def _release_lib_row(
     potential_breaking is gated to error; risk only when potential_breaking is
     error; additions and quality issues only when their own category is gated to
     error. Otherwise source breaks + risk are review and additions + quality are
-    safe.
+    safe. A library whose comparison errored carries no count fields, so it is
+    counted as one breaking finding to reflect the failed comparison.
     """
+    name = str(lib.get("library", "?"))
+    verdict = str(lib.get("verdict", "?"))
+    if verdict == "ERROR":
+        return name, verdict, 1, 0, 0
     src = _as_int(lib.get("source_breaks"))
     risk = _as_int(lib.get("risk_changes"))
     # compatible_additions is the *total* compatible count; quality_issues is the
@@ -340,7 +345,7 @@ def _release_lib_row(
     nb, nr = (nb + risk, nr) if pot_err else (nb, nr + risk)
     nb, ns = (nb + additions, ns) if add_err else (nb, ns + additions)
     nb, ns = (nb + quality, ns) if qual_err else (nb, ns + quality)
-    return str(lib.get("library", "?")), str(lib.get("verdict", "?")), nb, nr, ns
+    return name, verdict, nb, nr, ns
 
 
 def _from_release(

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -289,11 +289,10 @@ def _append_release_global_row(
     These findings live at the top level of the report and fold into the
     release verdict; without this a clean per-library release that breaks only
     at the bundle/matrix level would report zero changes and skip the comment.
-    The findings carry no per-item severity, so they are bucketed by the
-    section's own verdict — but a severity gate set to error promotes the
-    matching section to Breaking (mirroring the per-library path), since
-    ``_fold_release_global_severity`` can turn the check red on exactly these
-    global findings.
+    Findings are bucketed by the section's own verdict, but each carries its
+    ``kind`` — so when a compatible section is gated, the additions and quality
+    issues are classified per finding and only the gated category is promoted to
+    Breaking, matching what ``_fold_release_global_severity`` actually computes.
     """
     if not isinstance(findings, list) or not findings:
         return
@@ -304,16 +303,29 @@ def _append_release_global_row(
     )
     bucket = verdict_map.get(str(verdict or ""), "review")
     levels = levels or {}
-    # A compatible section (additions / quality) gated to error, or a risk
-    # section under potential_breaking=error, turns the check red — file it
-    # under Breaking so the comment matches.
-    if bucket == "safe" and (
-        levels.get("addition") == "error" or levels.get("quality_issues") == "error"
-    ):
-        bucket = "breaking"
-    elif bucket == "review" and levels.get("potential_breaking") == "error":
-        bucket = "breaking"
     n = len(findings)
+    # A risk section under potential_breaking=error turns the check red.
+    if bucket == "review" and levels.get("potential_breaking") == "error":
+        bucket = "breaking"
+    # A compatible section is additions + quality; classify each finding by its
+    # kind and promote only the gated category to Breaking (addition and quality
+    # gates are not interchangeable).
+    if bucket == "safe":
+        add_err = levels.get("addition") == "error"
+        qual_err = levels.get("quality_issues") == "error"
+        if add_err or qual_err:
+            nb = sum(
+                1
+                for f in findings
+                if isinstance(f, dict)
+                and (
+                    add_err
+                    if str(f.get("kind", "")) in _ADDITION_KIND_VALUES
+                    else qual_err
+                )
+            )
+            rows.append((name, str(verdict or "?"), nb, 0, n - nb))
+            return
     rows.append(
         (
             name,

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -91,12 +91,11 @@ class Finding:
 
 
 @dataclass
-class CommentModel:  # pylint: disable=too-many-instance-attributes
+class CommentModel:
     """Mode-agnostic view of a report, ready to render.
 
     A plain data container aggregating the report's header fields, the three
-    reviewer buckets, and the release-mode rollup — the attribute count is
-    inherent to the DTO, not a complexity smell.
+    reviewer buckets, and the release-mode rollup.
     """
 
     mode: str  # "compare" | "release" | "appcompat"

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -150,17 +150,26 @@ def _detail_text(change: dict[str, object]) -> str:
 
 def _bucket_changes(
     changes: object,
+    gate_api_break: bool = False,
 ) -> tuple[list[Finding], list[Finding], list[Finding]]:
     breaking: list[Finding] = []
     review: list[Finding] = []
     safe: list[Finding] = []
     target = {"breaking": breaking, "review": review, "safe": safe}
+    # When the step gates on API breaks (fail-on-api-break), the check goes red
+    # on them, so the comment must file them under Breaking to match — risk
+    # findings are never gated and stay in review.
+    sev_map = (
+        {**_SEVERITY_BUCKET, "api_break": "breaking"}
+        if gate_api_break
+        else _SEVERITY_BUCKET
+    )
     if isinstance(changes, list):
         for c in changes:
             if not isinstance(c, dict):
                 continue
             sev = str(c.get("severity", "unknown"))
-            bucket = _SEVERITY_BUCKET.get(sev, "review")
+            bucket = sev_map.get(sev, "review")
             loc = c.get("source_location")
             target[bucket].append(
                 Finding(
@@ -173,8 +182,10 @@ def _bucket_changes(
     return breaking, review, safe
 
 
-def _from_compare(report: dict[str, object]) -> CommentModel:
-    breaking, review, safe = _bucket_changes(report.get("changes"))
+def _from_compare(
+    report: dict[str, object], gate_api_break: bool = False
+) -> CommentModel:
+    breaking, review, safe = _bucket_changes(report.get("changes"), gate_api_break)
     return CommentModel(
         mode="compare",
         subject=str(report.get("library", "library")),
@@ -187,8 +198,12 @@ def _from_compare(report: dict[str, object]) -> CommentModel:
     )
 
 
-def _from_appcompat(report: dict[str, object]) -> CommentModel:
-    breaking, review, safe = _bucket_changes(report.get("relevant_changes"))
+def _from_appcompat(
+    report: dict[str, object], gate_api_break: bool = False
+) -> CommentModel:
+    breaking, review, safe = _bucket_changes(
+        report.get("relevant_changes"), gate_api_break
+    )
     missing = report.get("missing_symbols")
     if isinstance(missing, list):
         for sym in missing:
@@ -228,6 +243,7 @@ def _append_release_global_row(
     name: str,
     verdict: object,
     findings: object,
+    gate_api_break: bool = False,
 ) -> None:
     """Fold a release-global check (bundle / probe-matrix) into the rows.
 
@@ -239,7 +255,12 @@ def _append_release_global_row(
     """
     if not isinstance(findings, list) or not findings:
         return
-    bucket = _VERDICT_BUCKET.get(str(verdict or ""), "review")
+    verdict_map = (
+        {**_VERDICT_BUCKET, "API_BREAK": "breaking"}
+        if gate_api_break
+        else _VERDICT_BUCKET
+    )
+    bucket = verdict_map.get(str(verdict or ""), "review")
     n = len(findings)
     rows.append(
         (
@@ -252,7 +273,9 @@ def _append_release_global_row(
     )
 
 
-def _from_release(report: dict[str, object]) -> CommentModel:
+def _from_release(
+    report: dict[str, object], gate_api_break: bool = False
+) -> CommentModel:
     rows: list[tuple[str, str, int, int, int]] = []
     libraries = report.get("libraries")
     if isinstance(libraries, list):
@@ -261,14 +284,15 @@ def _from_release(report: dict[str, object]) -> CommentModel:
                 continue
             # Review = source breaks + risk findings: a library that is
             # COMPATIBLE_WITH_RISK with only risk_changes must still count as a
-            # change so `--on changes` posts the warning-tone comment.
+            # change so `--on changes` posts the warning-tone comment. When the
+            # step gates on API breaks, source breaks count as breaking instead.
+            src = _as_int(lib.get("source_breaks"))
             rows.append(
                 (
                     str(lib.get("library", "?")),
                     str(lib.get("verdict", "?")),
-                    _as_int(lib.get("breaking")),
-                    _as_int(lib.get("source_breaks"))
-                    + _as_int(lib.get("risk_changes")),
+                    _as_int(lib.get("breaking")) + (src if gate_api_break else 0),
+                    (0 if gate_api_break else src) + _as_int(lib.get("risk_changes")),
                     _as_int(lib.get("compatible_additions")),
                 )
             )
@@ -278,12 +302,14 @@ def _from_release(report: dict[str, object]) -> CommentModel:
         "(bundle checks)",
         report.get("bundle_verdict"),
         report.get("bundle_findings"),
+        gate_api_break,
     )
     _append_release_global_row(
         rows,
         "(build-config matrix)",
         report.get("matrix_verdict"),
         report.get("matrix_findings"),
+        gate_api_break,
     )
     removed = report.get("unmatched_old")
     added = report.get("unmatched_new")
@@ -314,13 +340,19 @@ def _as_int(value: object) -> int:
     return 0
 
 
-def build_model(report: dict[str, object]) -> CommentModel:
-    """Detect the report shape and normalise it into a :class:`CommentModel`."""
+def build_model(
+    report: dict[str, object], gate_api_break: bool = False
+) -> CommentModel:
+    """Detect the report shape and normalise it into a :class:`CommentModel`.
+
+    When *gate_api_break* is set (the action's ``fail-on-api-break``), API/source
+    breaks are filed under Breaking so the comment matches the now-red check.
+    """
     if isinstance(report.get("libraries"), list):
-        return _from_release(report)
+        return _from_release(report, gate_api_break)
     if "application" in report or isinstance(report.get("relevant_changes"), list):
-        return _from_appcompat(report)
-    return _from_compare(report)
+        return _from_appcompat(report, gate_api_break)
+    return _from_compare(report, gate_api_break)
 
 
 def should_post(model: CommentModel, on: str) -> bool:

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -81,8 +81,13 @@ class Finding:
 
 
 @dataclass
-class CommentModel:
-    """Mode-agnostic view of a report, ready to render."""
+class CommentModel:  # pylint: disable=too-many-instance-attributes
+    """Mode-agnostic view of a report, ready to render.
+
+    A plain data container aggregating the report's header fields, the three
+    reviewer buckets, and the release-mode rollup — the attribute count is
+    inherent to the DTO, not a complexity smell.
+    """
 
     mode: str  # "compare" | "release" | "appcompat"
     subject: str
@@ -203,12 +208,16 @@ def _from_release(report: dict[str, object]) -> CommentModel:
         for lib in libraries:
             if not isinstance(lib, dict):
                 continue
+            # Review = source breaks + risk findings: a library that is
+            # COMPATIBLE_WITH_RISK with only risk_changes must still count as a
+            # change so `--on changes` posts the warning-tone comment.
             rows.append(
                 (
                     str(lib.get("library", "?")),
                     str(lib.get("verdict", "?")),
                     _as_int(lib.get("breaking")),
-                    _as_int(lib.get("source_breaks")),
+                    _as_int(lib.get("source_breaks"))
+                    + _as_int(lib.get("risk_changes")),
                     _as_int(lib.get("compatible_additions")),
                 )
             )
@@ -366,6 +375,62 @@ def _release_table(model: CommentModel, detail: str) -> list[str]:
     return out
 
 
+def _header_block(model: CommentModel, short_sha: str) -> list[str]:
+    emoji, title = _header(model)
+    b, r, s = model.counts
+    head_ref = f"**Head `{short_sha}`**" if short_sha else "**Head**"
+    context = (
+        f"{head_ref} vs `{model.old_label}` · `{model.policy}` · `{model.subject}`"
+    )
+    return [
+        MARKER,
+        "",
+        f"## {emoji} abicheck — {title}",
+        "",
+        context,
+        "",
+        f"**{b} breaking** · {r} needs review · {s} safe",
+        "",
+    ]
+
+
+def _library_notes(model: CommentModel) -> list[str]:
+    out: list[str] = []
+    if model.removed_libraries:
+        listed = ", ".join(f"`{_esc(x)}`" for x in model.removed_libraries)
+        out += [f"> ⛔ Libraries removed: {listed}", ""]
+    if model.added_libraries:
+        listed = ", ".join(f"`{_esc(x)}`" for x in model.added_libraries)
+        out += [f"> ➕ New libraries: {listed}", ""]
+    return out
+
+
+def _body_sections(model: CommentModel, detail: str) -> list[str]:
+    if model.mode == "release":
+        return _release_table(model, detail)
+    out = _findings_table(
+        "❌ Breaking", model.breaking, detail, open_default=bool(model.breaking)
+    )
+    out += _findings_table(
+        "⚠️ Needs review",
+        model.review,
+        detail,
+        open_default=(not model.breaking and bool(model.review)),
+    )
+    out += _safe_section(model.safe, detail)
+    return out
+
+
+def _footer_block(ts: datetime, run_label: str | None, short_sha: str) -> list[str]:
+    footer = f"<sub>Updated {ts.strftime('%Y-%m-%d %H:%M UTC')}"
+    if run_label:
+        footer += f" · {run_label}"
+    if short_sha:
+        footer += f" · commit {short_sha}"
+    footer += "</sub>"
+    return [footer, ""]
+
+
 def render_comment(
     model: CommentModel,
     *,
@@ -378,54 +443,10 @@ def render_comment(
     if detail not in DETAIL_LEVELS:
         detail = "standard"
     ts = timestamp or datetime.now(timezone.utc)
-    emoji, title = _header(model)
-    b, r, s = model.counts
     short_sha = (sha or "")[:7]
-
-    head_ref = f"**Head `{short_sha}`**" if short_sha else "**Head**"
-    context = (
-        f"{head_ref} vs `{model.old_label}` · `{model.policy}` · `{model.subject}`"
-    )
-
-    lines: list[str] = [
-        MARKER,
-        "",
-        f"## {emoji} abicheck — {title}",
-        "",
-        context,
-        "",
-        f"**{b} breaking** · {r} needs review · {s} safe",
-        "",
-    ]
-
-    if model.removed_libraries:
-        listed = ", ".join(f"`{_esc(x)}`" for x in model.removed_libraries)
-        lines += [f"> ⛔ Libraries removed: {listed}", ""]
-    if model.added_libraries:
-        listed = ", ".join(f"`{_esc(x)}`" for x in model.added_libraries)
-        lines += [f"> ➕ New libraries: {listed}", ""]
-
+    lines = _header_block(model, short_sha)
+    lines += _library_notes(model)
     if detail != "summary":
-        if model.mode == "release":
-            lines += _release_table(model, detail)
-        else:
-            lines += _findings_table(
-                "❌ Breaking", model.breaking, detail, open_default=bool(model.breaking)
-            )
-            lines += _findings_table(
-                "⚠️ Needs review",
-                model.review,
-                detail,
-                open_default=(not model.breaking and bool(model.review)),
-            )
-            lines += _safe_section(model.safe, detail)
-
-    footer = f"<sub>Updated {ts.strftime('%Y-%m-%d %H:%M UTC')}"
-    if run_label:
-        footer += f" · {run_label}"
-    if short_sha:
-        footer += f" · commit {short_sha}"
-    footer += "</sub>"
-    lines += [footer, ""]
-
+        lines += _body_sections(model, detail)
+    lines += _footer_block(ts, run_label, short_sha)
     return "\n".join(lines)

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -479,7 +479,21 @@ def should_post(model: CommentModel, on: str) -> bool:
 
 
 def _esc(value: object) -> str:
-    return str(value).replace("|", "\\|").replace("\n", " ").strip()
+    # Sanitise for a single markdown table cell: escape pipes, neutralise
+    # backticks (which would break the surrounding code span) and flatten
+    # newlines. C/C++ symbols never contain backticks, so this is defensive.
+    return (
+        str(value)
+        .replace("|", "\\|")
+        .replace("`", "ˋ")
+        .replace("\n", " ")
+        .strip()
+    )
+
+
+def _md_url(url: str) -> str:
+    """Percent-encode characters that would break a markdown ``(url)`` target."""
+    return url.replace("(", "%28").replace(")", "%29").replace(" ", "%20")
 
 
 def _header(model: CommentModel) -> tuple[str, str]:
@@ -530,6 +544,7 @@ def _api_group(symbol: str) -> str:
 
 
 def _group_by_api(findings: list[Finding]) -> OrderedDict[str, list[Finding]]:
+    """Group findings by their enclosing API, preserving first-seen order."""
     groups: OrderedDict[str, list[Finding]] = OrderedDict()
     for f in findings:
         groups.setdefault(_api_group(f.symbol), []).append(f)
@@ -537,12 +552,14 @@ def _group_by_api(findings: list[Finding]) -> OrderedDict[str, list[Finding]]:
 
 
 def _flat_row(f: Finding) -> str:
+    """Render one finding as a per-symbol table row."""
     loc = f" · `{_esc(f.location)}`" if f.location else ""
     cell = (_esc(f.detail) + loc) if f.detail else _esc(f.location or "—")
     return f"| `{_esc(f.kind)}` | `{_esc(f.symbol)}` | {cell} |"
 
 
 def _group_row(key: str, members: list[Finding]) -> str:
+    """Render an API family as a single aggregated row (kinds, key, members)."""
     kinds = ", ".join(f"`{_esc(k)}`" for k in dict.fromkeys(m.kind for m in members))
     syms = [m.symbol for m in members]
     shown = syms[:_GROUP_MEMBERS_INLINE]
@@ -691,7 +708,7 @@ def _footer_block(
     if short_sha:
         footer += f" · commit {short_sha}"
     if report_url:
-        footer += f" · [full report]({report_url})"
+        footer += f" · [full report]({_md_url(report_url)})"
     footer += "</sub>"
     return [footer, ""]
 
@@ -706,10 +723,11 @@ def _render_body(
     *,
     condensed: bool,
 ) -> str:
+    """Render the comment body at one detail level (optionally condensed)."""
     lines = _header_block(model, short_sha)
     if condensed:
         note = "> ℹ️ _Condensed to fit GitHub's comment size limit"
-        note += f" — see the [full report]({report_url})._" if report_url else "._"
+        note += f" — see the [full report]({_md_url(report_url)})._" if report_url else "._"
         lines += [note, ""]
     lines += _library_notes(model)
     if detail != "summary":
@@ -719,8 +737,13 @@ def _render_body(
 
 
 def _truncate_to_budget(body: str, report_url: str | None) -> str:
+    """Hard-cut an over-budget body, appending a truncation note + report link."""
     suffix = "\n\n<sub>… comment truncated to fit GitHub's size limit"
-    suffix += f" — see the [full report]({report_url}).</sub>" if report_url else ".</sub>"
+    suffix += (
+        f" — see the [full report]({_md_url(report_url)}).</sub>"
+        if report_url
+        else ".</sub>"
+    )
     return body[: max(_BODY_BUDGET - len(suffix), 0)] + suffix
 
 

--- a/action.yml
+++ b/action.yml
@@ -300,7 +300,8 @@ outputs:
       BREAKING, or ERROR. SEVERITY_ERROR is produced when
       --severity-addition=error detects new public API additions
       (compare mode only).
-      For compare-release: COMPATIBLE, API_BREAK, BREAKING,
+      For compare-release: COMPATIBLE, SEVERITY_ERROR (with --severity-*
+      via extra-args), API_BREAK, BREAKING,
       REMOVED_LIBRARY (when fail-on-removed-library is set), or ERROR.
       For appcompat: COMPATIBLE, API_BREAK, BREAKING, or ERROR.
       For dump: COMPATIBLE or ERROR.

--- a/action.yml
+++ b/action.yml
@@ -254,6 +254,44 @@ inputs:
     description: 'Write a markdown summary to the GitHub Actions Job Summary. Ignored for dump mode.'
     required: false
     default: 'true'
+  pr-comment:
+    description: >
+      Post a sticky ABI report comment on the pull request (compare,
+      compare-release and appcompat modes). The comment is a content channel
+      and never changes the check's red/green state — breaks still gate via
+      fail-on-breaking / fail-on-api-break. Defaults to 'true', but is a no-op
+      unless the workflow is triggered by a pull_request event and a token with
+      'pull-requests: write' is available.
+    required: false
+    default: 'true'
+  pr-comment-mode:
+    description: >
+      'update' (default) keeps a single sticky comment and edits it in place on
+      every run; 'new' posts a fresh comment each run. Either way the scanned
+      head SHA is shown in the comment.
+    required: false
+    default: 'update'
+  pr-comment-on:
+    description: >
+      When to comment: 'changes' (default) only comments when there is at least
+      one ABI/API change, 'always' comments every run (including a clean
+      "no changes" result), 'never' disables the comment.
+    required: false
+    default: 'changes'
+  pr-comment-detail:
+    description: >
+      Detail level of the comment body: 'summary' (verdict + counts only),
+      'standard' (default; per-symbol tables for breaking/review, grouped safe
+      list) or 'full' (every change with locations, all sections expanded).
+    required: false
+    default: 'standard'
+  github-token:
+    description: >
+      Token used to post the PR comment and to auto-fetch release baselines.
+      Defaults to the workflow token; requires 'pull-requests: write' for the
+      comment.
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   verdict:
@@ -358,6 +396,11 @@ runs:
         INPUT_INCLUDE_PRIVATE_DSO: ${{ inputs.include-private-dso }}
         INPUT_KEEP_EXTRACTED: ${{ inputs.keep-extracted }}
         INPUT_FAIL_ON_REMOVED_LIBRARY: ${{ inputs.fail-on-removed-library }}
+        INPUT_PR_COMMENT: ${{ inputs.pr-comment }}
+        INPUT_PR_COMMENT_MODE: ${{ inputs.pr-comment-mode }}
+        INPUT_PR_COMMENT_ON: ${{ inputs.pr-comment-on }}
+        INPUT_PR_COMMENT_DETAIL: ${{ inputs.pr-comment-detail }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: bash "${{ github.action_path }}/action/run.sh"
 
     # ── 5. Upload SARIF ──────────────────────────────────────────────────────

--- a/action/run.sh
+++ b/action/run.sh
@@ -667,11 +667,19 @@ _maybe_post_pr_comment() {
     PR_GATE_ARGS+=(--gate-api-break)
   fi
 
+  # Link the workflow run (where the full JSON/SARIF report is uploaded as an
+  # artifact) so a condensed/truncated comment always points at the full detail.
+  local run_url=""
+  if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+    run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  fi
+
   abicheck pr-comment "$PR_JSON" \
     --sha "${head_sha:-${GITHUB_SHA:-}}" \
     --detail "${INPUT_PR_COMMENT_DETAIL:-standard}" \
     --on "${INPUT_PR_COMMENT_ON:-changes}" \
     --run-label "run #${GITHUB_RUN_NUMBER:-?}" \
+    ${run_url:+--report-url "$run_url"} \
     ${PR_GATE_ARGS[@]+"${PR_GATE_ARGS[@]}"} \
     -o "$PR_BODY" || true
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -596,6 +596,16 @@ _build_json_cmd() {
       --format | -o | --output | --output-file)
         ((i++))  # skip the flag's value too
         ;;
+      --show-only)
+        # Display filter ("limit displayed changes", does NOT affect exit codes).
+        # Keeping it would hide gated breaks from the comment while the check
+        # still fails red — drop it (and its value) so the comment sees the
+        # full change set the gate acted on.
+        ((i++))  # skip the flag's value too
+        ;;
+      --show-only=*)
+        : # same display filter, inline value form — drop it for the re-run.
+        ;;
       --stat)
         : # display-only flag (no value); it suppresses the changes array in
           # JSON, which the comment parser needs — drop it for the re-run.

--- a/action/run.sh
+++ b/action/run.sh
@@ -574,6 +574,94 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Sticky PR comment (content channel — never changes the red/green gate)
+# ---------------------------------------------------------------------------
+# Rebuild the run command with `--format json` so the comment renderer has a
+# structured report, regardless of the format chosen for the main output.
+_build_json_cmd() {
+  PR_CMD_JSON=()
+  local i
+  for ((i = 0; i < ${#CMD[@]}; i++)); do
+    case "${CMD[$i]}" in
+      --format | -o | --output | --output-file)
+        ((i++))  # skip the flag's value too
+        ;;
+      *)
+        PR_CMD_JSON+=("${CMD[$i]}")
+        ;;
+    esac
+  done
+  PR_CMD_JSON+=(--format json -o "$PR_JSON")
+}
+
+_maybe_post_pr_comment() {
+  [[ "${INPUT_PR_COMMENT:-true}" == "true" ]] || return 0
+  case "$MODE" in
+    compare | compare-release | appcompat) ;;
+    *) return 0 ;;
+  esac
+  [[ "${INPUT_PR_COMMENT_ON:-changes}" == "never" ]] && return 0
+  [[ "$VERDICT" == "ERROR" ]] && return 0
+  case "${GITHUB_EVENT_NAME:-}" in
+    pull_request | pull_request_target) ;;
+    *)
+      echo "abicheck: not a pull_request event; skipping PR comment."
+      return 0
+      ;;
+  esac
+
+  local event="${GITHUB_EVENT_PATH:-}"
+  local pr_number="" head_sha=""
+  if [[ -n "$event" && -f "$event" ]] && command -v jq >/dev/null 2>&1; then
+    pr_number=$(jq -r '.pull_request.number // empty' "$event" 2>/dev/null)
+    head_sha=$(jq -r '.pull_request.head.sha // empty' "$event" 2>/dev/null)
+  fi
+  if [[ -z "$pr_number" ]]; then
+    echo "::warning::abicheck: could not determine the PR number; skipping PR comment."
+    return 0
+  fi
+
+  echo "::group::abicheck PR comment"
+  PR_JSON=$(mktemp --suffix=.json)
+  PR_BODY=$(mktemp --suffix=.md)
+  _build_json_cmd
+  # Re-run for JSON; a non-zero exit here is expected on breaks — the report
+  # file is still written, so we ignore the status.
+  "${PR_CMD_JSON[@]}" >/dev/null 2>/dev/null || true
+  if [[ ! -s "$PR_JSON" ]]; then
+    echo "::warning::abicheck: no JSON report produced; skipping PR comment."
+    echo "::endgroup::"
+    return 0
+  fi
+
+  abicheck pr-comment "$PR_JSON" \
+    --sha "${head_sha:-${GITHUB_SHA:-}}" \
+    --detail "${INPUT_PR_COMMENT_DETAIL:-standard}" \
+    --on "${INPUT_PR_COMMENT_ON:-changes}" \
+    --run-label "run #${GITHUB_RUN_NUMBER:-?}" \
+    -o "$PR_BODY" || true
+
+  if [[ ! -s "$PR_BODY" ]]; then
+    echo "abicheck: no comment to post (no changes / --on=${INPUT_PR_COMMENT_ON:-changes})."
+    echo "::endgroup::"
+    return 0
+  fi
+
+  if [[ "${INPUT_PR_COMMENT_MODE:-update}" == "new" ]]; then
+    gh pr comment "$pr_number" --body-file "$PR_BODY" \
+      || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
+  else
+    # Sticky: edit the action's previous comment in place; create if none yet.
+    gh pr comment "$pr_number" --body-file "$PR_BODY" --edit-last 2>/dev/null \
+      || gh pr comment "$pr_number" --body-file "$PR_BODY" \
+      || echo "::warning::abicheck: failed to post/update PR comment (need 'pull-requests: write')."
+  fi
+  echo "::endgroup::"
+}
+
+_maybe_post_pr_comment
+
+# ---------------------------------------------------------------------------
 # Determine final exit code based on user preferences
 # ---------------------------------------------------------------------------
 FINAL_EXIT=0

--- a/action/run.sh
+++ b/action/run.sh
@@ -586,6 +586,10 @@ _build_json_cmd() {
       --format | -o | --output | --output-file)
         ((i++))  # skip the flag's value too
         ;;
+      --stat)
+        : # display-only flag (no value); it suppresses the changes array in
+          # JSON, which the comment parser needs — drop it for the re-run.
+        ;;
       *)
         PR_CMD_JSON+=("${CMD[$i]}")
         ;;

--- a/action/run.sh
+++ b/action/run.sh
@@ -413,8 +413,10 @@ elif [[ "$MODE" == "appcompat" ]]; then
   fi
 
 elif [[ "$MODE" == "compare-release" ]]; then
-  # compare-release exit codes: 0=compatible, 2=API_BREAK, 4=BREAKING, 8=REMOVED_LIBRARY
-  # No severity support — exit code 1 is always a CLI error.
+  # compare-release exit codes: 0=compatible, 2=API_BREAK, 4=BREAKING,
+  # 8=REMOVED_LIBRARY. With --severity-* options (e.g. via extra-args) the CLI
+  # follows the severity-aware scheme, where exit 1 is a severity error (not a
+  # CLI failure) — distinguish the two via stderr.
   if [[ $ABICHECK_EXIT -eq 2 ]] && echo "$STDERR_CONTENT" | grep -qE '(^Usage:|^Error:|^Try )'; then
     VERDICT="ERROR"
     echo "::error::abicheck compare-release failed due to a CLI argument or configuration error (exit code 2)."
@@ -422,6 +424,14 @@ elif [[ "$MODE" == "compare-release" ]]; then
   else
     case $ABICHECK_EXIT in
       0) VERDICT="COMPATIBLE" ;;
+      1)
+        if _is_cli_error; then
+          VERDICT="ERROR"
+          echo "::error::abicheck compare-release failed due to a CLI error (exit code 1)."
+        else
+          VERDICT="SEVERITY_ERROR"
+        fi
+        ;;
       2) VERDICT="API_BREAK" ;;
       4) VERDICT="BREAKING" ;;
       8) VERDICT="REMOVED_LIBRARY" ;;
@@ -775,6 +785,12 @@ elif [[ "$MODE" == "compare-release" ]]; then
 
   if [[ "$VERDICT" == "REMOVED_LIBRARY" ]]; then
     echo "::error::Library removed between old and new package. Set fail-on-removed-library: false to allow."
+    FINAL_EXIT=1
+  fi
+
+  # Severity-aware exit 1 (from --severity-* via extra-args), as in compare mode.
+  if [[ "$VERDICT" == "SEVERITY_ERROR" ]]; then
+    echo "::error::Severity-level error detected by abicheck."
     FINAL_EXIT=1
   fi
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -636,8 +636,10 @@ _maybe_post_pr_comment() {
   fi
 
   echo "::group::abicheck PR comment"
-  PR_JSON=$(mktemp --suffix=.json)
-  PR_BODY=$(mktemp --suffix=.md)
+  # Template-based mktemp (X's at the end) — portable across GNU and BSD/macOS,
+  # unlike the GNU-only --suffix option.
+  PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
+  PR_BODY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-body.XXXXXX")
   _build_json_cmd
   # Re-run for JSON; a non-zero exit here is expected on breaks — the report
   # file is still written, so we ignore the status.
@@ -665,6 +667,11 @@ _maybe_post_pr_comment() {
 
   if [[ ! -s "$PR_BODY" ]]; then
     echo "abicheck: no comment to post (no changes / --on=${INPUT_PR_COMMENT_ON:-changes})."
+    # Sticky mode: clear any prior comment so a once-dirty PR that is now clean
+    # doesn't keep showing a stale BREAKING report.
+    if [[ "${INPUT_PR_COMMENT_MODE:-update}" != "new" ]]; then
+      _delete_sticky_pr_comment "$pr_number"
+    fi
     echo "::endgroup::"
     return 0
   fi
@@ -682,6 +689,24 @@ _create_pr_comment() {
   local repo="$1" pr_number="$2" body_file="$3"
   jq -Rs '{body: .}' "$body_file" \
     | gh api -X POST "repos/$repo/issues/$pr_number/comments" --input - >/dev/null
+}
+
+_delete_sticky_pr_comment() {
+  # Remove OUR previous sticky comment (located by marker) so a once-dirty PR
+  # that is now clean stops showing a stale report.
+  local pr_number="$1"
+  local repo="${GITHUB_REPOSITORY:-}"
+  if [[ -z "$repo" ]] || ! command -v jq >/dev/null 2>&1; then
+    return 0
+  fi
+  local existing_id
+  existing_id=$(gh api --paginate "repos/$repo/issues/$pr_number/comments" \
+    --jq ".[] | select(.body | contains(\"$PR_COMMENT_MARKER\")) | .id" 2>/dev/null | tail -1)
+  if [[ -n "$existing_id" ]]; then
+    if gh api -X DELETE "repos/$repo/issues/comments/$existing_id" >/dev/null 2>&1; then
+      echo "abicheck: cleared stale sticky comment $existing_id (no current changes)."
+    fi
+  fi
 }
 
 _gh_pr_comment_fallback() {

--- a/action/run.sh
+++ b/action/run.sh
@@ -588,6 +588,23 @@ fi
 # ---------------------------------------------------------------------------
 # Rebuild the run command with `--format json` so the comment renderer has a
 # structured report, regardless of the format chosen for the main output.
+_can_reuse_primary_json() {
+  # Reuse the primary run's output as the comment's JSON report instead of
+  # re-running the comparison — but only when it is a faithful, unfiltered
+  # report. It must already be JSON, written to a non-empty file, and free of
+  # display filters (--show-only / --stat) that hide gated changes from the
+  # comment (which _build_json_cmd strips for exactly that reason).
+  [[ "${FORMAT:-}" == "json" ]] || return 1
+  [[ -n "${OUTPUT_FILE:-}" && -s "${OUTPUT_FILE:-}" ]] || return 1
+  local arg
+  for arg in ${CMD[@]+"${CMD[@]}"}; do
+    case "$arg" in
+      --show-only | --show-only=* | --stat) return 1 ;;
+    esac
+  done
+  return 0
+}
+
 _build_json_cmd() {
   PR_CMD_JSON=()
   local i
@@ -650,10 +667,16 @@ _maybe_post_pr_comment() {
   # unlike the GNU-only --suffix option.
   PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
   PR_BODY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-body.XXXXXX")
-  _build_json_cmd
-  # Re-run for JSON; a non-zero exit here is expected on breaks — the report
-  # file is still written, so we ignore the status.
-  "${PR_CMD_JSON[@]}" >/dev/null 2>/dev/null || true
+  if _can_reuse_primary_json; then
+    # The primary run already produced a faithful JSON report — reuse it instead
+    # of re-running the whole comparison.
+    cp "$OUTPUT_FILE" "$PR_JSON"
+  else
+    _build_json_cmd
+    # Re-run for JSON; a non-zero exit here is expected on breaks — the report
+    # file is still written, so we ignore the status.
+    "${PR_CMD_JSON[@]}" >/dev/null 2>/dev/null || true
+  fi
   if [[ ! -s "$PR_JSON" ]]; then
     echo "::warning::abicheck: no JSON report produced; skipping PR comment."
     echo "::endgroup::"

--- a/action/run.sh
+++ b/action/run.sh
@@ -662,7 +662,7 @@ _maybe_post_pr_comment() {
     --detail "${INPUT_PR_COMMENT_DETAIL:-standard}" \
     --on "${INPUT_PR_COMMENT_ON:-changes}" \
     --run-label "run #${GITHUB_RUN_NUMBER:-?}" \
-    "${PR_GATE_ARGS[@]}" \
+    ${PR_GATE_ARGS[@]+"${PR_GATE_ARGS[@]}"} \
     -o "$PR_BODY" || true
 
   if [[ ! -s "$PR_BODY" ]]; then

--- a/action/run.sh
+++ b/action/run.sh
@@ -647,16 +647,53 @@ _maybe_post_pr_comment() {
     return 0
   fi
 
-  if [[ "${INPUT_PR_COMMENT_MODE:-update}" == "new" ]]; then
-    gh pr comment "$pr_number" --body-file "$PR_BODY" \
-      || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
-  else
-    # Sticky: edit the action's previous comment in place; create if none yet.
-    gh pr comment "$pr_number" --body-file "$PR_BODY" --edit-last 2>/dev/null \
-      || gh pr comment "$pr_number" --body-file "$PR_BODY" \
-      || echo "::warning::abicheck: failed to post/update PR comment (need 'pull-requests: write')."
-  fi
+  _post_pr_comment "$pr_number" "$PR_BODY"
   echo "::endgroup::"
+}
+
+# Hidden marker the renderer embeds; used to find OUR sticky comment.
+PR_COMMENT_MARKER="<!-- abicheck-sticky-report -->"
+
+_create_pr_comment() {
+  # Create a fresh comment from a body file via the REST API (jq builds the
+  # JSON payload so arbitrary markdown is escaped safely).
+  local repo="$1" pr_number="$2" body_file="$3"
+  jq -Rs '{body: .}' "$body_file" \
+    | gh api -X POST "repos/$repo/issues/$pr_number/comments" --input - >/dev/null
+}
+
+_post_pr_comment() {
+  local pr_number="$1" body_file="$2"
+  local repo="${GITHUB_REPOSITORY:-}"
+  local mode="${INPUT_PR_COMMENT_MODE:-update}"
+
+  # Fresh comment per run, or missing prerequisites for marker matching → just
+  # create one via the porcelain command.
+  if [[ "$mode" == "new" || -z "$repo" ]] || ! command -v jq >/dev/null 2>&1; then
+    gh pr comment "$pr_number" --body-file "$body_file" \
+      || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
+    return 0
+  fi
+
+  # Sticky: locate OUR previous comment by its hidden marker (not merely the
+  # last comment by this token, which could belong to other automation) and
+  # edit that specific comment in place.
+  local existing_id
+  existing_id=$(gh api --paginate "repos/$repo/issues/$pr_number/comments" \
+    --jq ".[] | select(.body | contains(\"$PR_COMMENT_MARKER\")) | .id" 2>/dev/null | tail -1)
+
+  if [[ -n "$existing_id" ]]; then
+    if jq -Rs '{body: .}' "$body_file" \
+        | gh api -X PATCH "repos/$repo/issues/comments/$existing_id" --input - >/dev/null 2>&1; then
+      echo "abicheck: updated sticky comment $existing_id."
+      return 0
+    fi
+    echo "::warning::abicheck: could not update comment $existing_id; posting a new one."
+  fi
+
+  _create_pr_comment "$repo" "$pr_number" "$body_file" 2>/dev/null \
+    || gh pr comment "$pr_number" --body-file "$body_file" \
+    || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
 }
 
 _maybe_post_pr_comment

--- a/action/run.sh
+++ b/action/run.sh
@@ -634,11 +634,19 @@ _maybe_post_pr_comment() {
     return 0
   fi
 
+  # Mirror the step's gate: when fail-on-api-break is set, API/source breaks
+  # turn the check red, so the comment must file them under Breaking too.
+  PR_GATE_ARGS=()
+  if [[ "${INPUT_FAIL_ON_API_BREAK:-false}" == "true" ]]; then
+    PR_GATE_ARGS+=(--gate-api-break)
+  fi
+
   abicheck pr-comment "$PR_JSON" \
     --sha "${head_sha:-${GITHUB_SHA:-}}" \
     --detail "${INPUT_PR_COMMENT_DETAIL:-standard}" \
     --on "${INPUT_PR_COMMENT_ON:-changes}" \
     --run-label "run #${GITHUB_RUN_NUMBER:-?}" \
+    "${PR_GATE_ARGS[@]}" \
     -o "$PR_BODY" || true
 
   if [[ ! -s "$PR_BODY" ]]; then
@@ -662,38 +670,52 @@ _create_pr_comment() {
     | gh api -X POST "repos/$repo/issues/$pr_number/comments" --input - >/dev/null
 }
 
+_gh_pr_comment_fallback() {
+  # Porcelain fallback. Pass -R when we know the repo so it works without a
+  # local checkout of the PR's repository (or after checking out a different one).
+  local pr_number="$1" body_file="$2" repo="$3"
+  if [[ -n "$repo" ]]; then
+    gh pr comment "$pr_number" -R "$repo" --body-file "$body_file" \
+      || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
+  else
+    gh pr comment "$pr_number" --body-file "$body_file" \
+      || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
+  fi
+}
+
 _post_pr_comment() {
   local pr_number="$1" body_file="$2"
   local repo="${GITHUB_REPOSITORY:-}"
   local mode="${INPUT_PR_COMMENT_MODE:-update}"
 
-  # Fresh comment per run, or missing prerequisites for marker matching → just
-  # create one via the porcelain command.
-  if [[ "$mode" == "new" || -z "$repo" ]] || ! command -v jq >/dev/null 2>&1; then
-    gh pr comment "$pr_number" --body-file "$body_file" \
-      || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
+  # Without a known repo or jq we cannot use the REST path; fall back to the
+  # porcelain command (which then resolves the repo from the local checkout).
+  if [[ -z "$repo" ]] || ! command -v jq >/dev/null 2>&1; then
+    _gh_pr_comment_fallback "$pr_number" "$body_file" "$repo"
     return 0
   fi
 
-  # Sticky: locate OUR previous comment by its hidden marker (not merely the
-  # last comment by this token, which could belong to other automation) and
-  # edit that specific comment in place.
-  local existing_id
-  existing_id=$(gh api --paginate "repos/$repo/issues/$pr_number/comments" \
-    --jq ".[] | select(.body | contains(\"$PR_COMMENT_MARKER\")) | .id" 2>/dev/null | tail -1)
-
-  if [[ -n "$existing_id" ]]; then
-    if jq -Rs '{body: .}' "$body_file" \
-        | gh api -X PATCH "repos/$repo/issues/comments/$existing_id" --input - >/dev/null 2>&1; then
-      echo "abicheck: updated sticky comment $existing_id."
-      return 0
+  # Sticky (update) mode: locate OUR previous comment by its hidden marker (not
+  # merely the last comment by this token, which could belong to other
+  # automation) and edit that specific comment in place.
+  if [[ "$mode" != "new" ]]; then
+    local existing_id
+    existing_id=$(gh api --paginate "repos/$repo/issues/$pr_number/comments" \
+      --jq ".[] | select(.body | contains(\"$PR_COMMENT_MARKER\")) | .id" 2>/dev/null | tail -1)
+    if [[ -n "$existing_id" ]]; then
+      if jq -Rs '{body: .}' "$body_file" \
+          | gh api -X PATCH "repos/$repo/issues/comments/$existing_id" --input - >/dev/null 2>&1; then
+        echo "abicheck: updated sticky comment $existing_id."
+        return 0
+      fi
+      echo "::warning::abicheck: could not update comment $existing_id; posting a new one."
     fi
-    echo "::warning::abicheck: could not update comment $existing_id; posting a new one."
   fi
 
+  # Create via the REST API (repo-qualified, so it works without a local clone
+  # of the PR repo); fall back to the porcelain command with -R if that fails.
   _create_pr_comment "$repo" "$pr_number" "$body_file" 2>/dev/null \
-    || gh pr comment "$pr_number" --body-file "$body_file" \
-    || echo "::warning::abicheck: failed to post PR comment (need 'pull-requests: write')."
+    || _gh_pr_comment_fallback "$pr_number" "$body_file" "$repo"
 }
 
 _maybe_post_pr_comment

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -106,6 +106,11 @@ extra-args: '--strict-suppressions --require-justification'
 | `severity-addition` | — | Severity for additions: `error`, `warning`, or `info` (compare mode only) |
 | `extra-args` | `''` | Additional CLI arguments passed to abicheck |
 | `add-job-summary` | `true` | Write summary to Job Summary panel (ignored for dump mode) |
+| `pr-comment` | `true` | Post a sticky ABI report comment on the PR (compare/compare-release/appcompat). No-op outside `pull_request` events. |
+| `pr-comment-mode` | `update` | `update` keeps one comment and edits it in place; `new` posts a fresh comment each run |
+| `pr-comment-on` | `changes` | When to comment: `changes`, `always`, or `never` |
+| `pr-comment-detail` | `standard` | Comment detail: `summary`, `standard`, or `full` |
+| `github-token` | `${{ github.token }}` | Token for the PR comment and baseline auto-fetch (needs `pull-requests: write`) |
 
 ### Package comparison inputs (compare-release mode)
 
@@ -525,6 +530,51 @@ See [GitHub PR Annotations](annotations.md) for full details.
           new-header: include/foo.h
           extra-args: --annotate
 ```
+
+### Sticky PR comment
+
+On `pull_request` runs the action posts a single, self-updating comment that
+groups every finding into **Breaking**, **Needs review**, and **Safe** sections
+and shows the scanned head SHA. It is a *content* channel only — it never
+changes the check's red/green state, which is still driven by `fail-on-breaking`
+/ `fail-on-api-break` / `severity-*`. This means review-needed items (source
+breaks, risk, additions) surface as a green check with a `⚠️ Review recommended`
+comment, while real ABI breaks turn the check red **and** post a `❌` comment.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write   # required for the comment
+jobs:
+  abi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: napetrov/abicheck@v0.3.0
+        with:
+          old-library: baseline.json
+          new-library: build/libfoo.so
+          new-header: include/foo.h
+          # all optional — these are the defaults:
+          pr-comment: true
+          pr-comment-mode: update      # one sticky comment, edited each run
+          pr-comment-on: changes       # skip the comment when nothing changed
+          pr-comment-detail: standard  # per-symbol tables for breaking/review
+```
+
+Behavior knobs:
+
+- `pr-comment-mode: new` posts a fresh comment per run instead of editing the
+  previous one (use when you want a per-commit history in the thread).
+- `pr-comment-on: always` comments every run, including a clean *No ABI changes*
+  result; `never` disables it.
+- `pr-comment-detail: full` lists every change with source locations and expands
+  all sections; `summary` reduces the comment to the verdict and counts.
+
+"Safe" mirrors whatever the checker already classified as compatible — so
+public-header surface scoping (`--scope-public-headers`) and policy profiles
+(e.g. `sdk_vendor` demoting a removal) flow through automatically; the comment
+never re-classifies anything.
 
 ### Conditional failure
 

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -571,6 +571,15 @@ Behavior knobs:
 - `pr-comment-detail: full` lists every change with source locations and expands
   all sections; `summary` reduces the comment to the verdict and counts.
 
+On large diffs the `standard` view stays readable by rolling related changes up
+to their enclosing API — overloads, template instantiations and members of the
+same type/namespace collapse into one row showing the family and a member count
+(distinct symbols keep their own row; `full` keeps every change separate). The
+body is always kept under GitHub's 65,536-character comment limit: if it would
+overflow, the detail level is automatically reduced (and, as a last resort, the
+body is truncated), with a link back to the **full report** uploaded as the
+workflow-run artifact so nothing is lost.
+
 "Safe" mirrors whatever the checker already classified as compatible — so
 public-header surface scoping (`--scope-public-headers`) and policy profiles
 (e.g. `sdk_vendor` demoting a removal) flow through automatically; the comment

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -576,6 +576,10 @@ public-header surface scoping (`--scope-public-headers`) and policy profiles
 (e.g. `sdk_vendor` demoting a removal) flow through automatically; the comment
 never re-classifies anything.
 
+The comment also tracks the gate: with `fail-on-api-break: true` (which turns
+the check red on source/API breaks), those findings are filed under **Breaking**
+in the comment to match, rather than **Needs review**.
+
 ### Conditional failure
 
 Allow API breaks but block binary ABI breaks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ module = [
     "abicheck.cli_baseline",
     "abicheck.cli_evidence",
     "abicheck.cli_plugin",
+    "abicheck.cli_pr_comment",
     "abicheck.cli_probe",
     "abicheck.cli_stack",
     "abicheck.cli_suggest",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -531,6 +531,7 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         frozenset({"cli", "cli_evidence"}),
         frozenset({"cli", "cli_appcompat"}),
         frozenset({"cli", "cli_plugin"}),
+        frozenset({"cli", "cli_pr_comment"}),
         frozenset({"cli", "cli_probe"}),
         frozenset({"cli", "cli_stack"}),
         frozenset({"cli", "cli_suggest"}),

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -16,6 +16,7 @@ from abicheck.cli import (
 from abicheck.cli_compare_release import (
     _discover_include_roots,
     _extract_if_package,
+    _format_release_json,
     _prepare_compare_release_inputs,
 )
 from abicheck.model import (
@@ -929,3 +930,26 @@ class TestLockstepSonameCoupling:
         _suppress_lockstep_soname_findings([umbrella, core], "BREAKING", tmp_path)
         data = json.loads((tmp_path / "libonedal.so.json").read_text())
         assert all(c["kind"] != "soname_bump_unnecessary" for c in data["changes"])
+
+
+def test_release_json_emits_severity_block() -> None:
+    """compare-release JSON carries a severity config block when --severity-* is
+    active, so the PR-comment renderer can mirror the gate (issue #342 follow-up).
+    """
+    from abicheck.severity import resolve_severity_config
+
+    cfg = resolve_severity_config("default", addition="error")
+    out = _format_release_json(
+        "COMPATIBLE", Path("/o"), Path("/n"), [], [], [], {}, {}, [], None, None,
+        severity_config=cfg, severity_exit_code=1,
+    )
+    data = json.loads(out)
+    assert data["severity"]["config"]["addition"] == "error"
+    assert data["severity"]["exit_code"] == 1
+
+
+def test_release_json_omits_severity_block_without_config() -> None:
+    out = _format_release_json(
+        "COMPATIBLE", Path("/o"), Path("/n"), [], [], [], {}, {}, [], None, None,
+    )
+    assert "severity" not in json.loads(out)

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -598,6 +598,55 @@ def test_standard_truncates_large_breaking_table():
     assert "more_" not in full
 
 
+def test_api_rollup_collapses_overload_and_member_families():
+    # Many members of one type / overloads of one function collapse to a single
+    # aggregated row in standard mode (mass-change readability).
+    changes = [
+        {"kind": "func_params_changed", "symbol": f"Widget::resize(int{i})",
+         "description": "sig", "severity": "breaking"}
+        for i in range(12)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    # one aggregated row labelled with the enclosing type and the member count
+    assert "`Widget` (12)" in body
+    # but full detail keeps every member as its own row (no rollup)
+    full = render_comment(build_model(_compare_report(changes)), sha="x", detail="full")
+    assert "`Widget` (12)" not in full
+    assert "Widget::resize(int0)" in full
+
+
+def test_api_rollup_keeps_distinct_symbols_flat():
+    # Distinct, unrelated symbols are not aggregated — each keeps its own row.
+    model = build_model(_compare_report())
+    body = render_comment(model, sha="x")
+    # both distinct breaking symbols keep their own flat row (no aggregation)
+    assert "`foo_init`" in body
+    assert "`struct Ctx`" in body
+
+
+def test_comment_stays_under_github_size_limit():
+    from abicheck.pr_comment import GITHUB_COMMENT_LIMIT
+
+    changes = [
+        {"kind": "func_removed", "symbol": f"ns{i}::free_{i}",
+         "description": "x" * 200, "severity": "breaking"}
+        for i in range(4000)
+    ]
+    body = render_comment(
+        build_model(_compare_report(changes)), sha="x", detail="full",
+        report_url="https://example/run/1",
+    )
+    assert len(body) <= GITHUB_COMMENT_LIMIT
+    assert body.startswith(MARKER)  # header survives the downgrade/truncate
+
+
+def test_report_url_linked_in_footer():
+    body = render_comment(
+        build_model(_compare_report()), sha="x", report_url="https://example/run/9"
+    )
+    assert "[full report](https://example/run/9)" in body
+
+
 def test_release_render_lists_removed_libraries():
     body = render_comment(build_model(_release_report()), sha="cafe1234")
     assert "Libraries removed" in body

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -308,6 +308,69 @@ def test_gate_api_break_release_source_breaks_count_as_breaking():
     assert ungated.counts == (0, 3, 0)  # source_breaks + risk → review
 
 
+def test_severity_addition_error_files_additions_as_breaking():
+    # With severity-addition: error the check goes red on additions, so the
+    # comment must file them under Breaking (auto-detected from the report's
+    # severity config), not Safe.
+    report = _compare_report(
+        [
+            {
+                "kind": "func_added",
+                "symbol": "foo_new",
+                "description": "new",
+                "severity": "compatible",
+            },
+        ]
+    )
+    report["severity"] = {
+        "config": {
+            "abi_breaking": "error",
+            "potential_breaking": "warning",
+            "quality_issues": "warning",
+            "addition": "error",
+        },
+        "categories": {},
+        "exit_code": 1,
+    }
+    gated = build_model(report)
+    assert gated.counts == (1, 0, 0)  # addition → breaking
+    assert "ABI BREAKING" in render_comment(gated, sha="x")
+    # without the severity config, the same addition stays safe
+    plain = _compare_report(
+        [
+            {
+                "kind": "func_added",
+                "symbol": "foo_new",
+                "description": "new",
+                "severity": "compatible",
+            }
+        ]
+    )
+    assert build_model(plain).counts == (0, 0, 1)
+
+
+def test_severity_addition_error_release_additions_breaking():
+    report = {
+        "verdict": "COMPATIBLE",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "lib.so",
+                "verdict": "COMPATIBLE",
+                "breaking": 0,
+                "source_breaks": 0,
+                "risk_changes": 0,
+                "compatible_additions": 4,
+            },
+        ],
+        "severity": {"config": {"addition": "error"}, "exit_code": 1},
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    assert build_model(report).counts == (4, 0, 0)
+
+
 def test_malformed_changes_are_skipped():
     model = build_model(
         {

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -624,6 +624,57 @@ def test_api_rollup_keeps_distinct_symbols_flat():
     assert "`struct Ctx`" in body
 
 
+def test_api_rollup_strips_template_args():
+    # Template instantiations of the same type collapse to one enclosing group.
+    changes = [
+        {"kind": "func_params_changed", "symbol": "Vec<int>::push(int)",
+         "description": "s", "severity": "breaking"},
+        {"kind": "func_params_changed", "symbol": "Vec<float>::push(float)",
+         "description": "s", "severity": "breaking"},
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    assert "`Vec` (2)" in body
+
+
+def test_group_row_caps_inline_members():
+    # An aggregated row lists members up to a cap, then "+N more".
+    changes = [
+        {"kind": "func_params_changed", "symbol": f"Api::call(int{i})",
+         "description": "s", "severity": "breaking"}
+        for i in range(11)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    assert "`Api` (11)" in body
+    assert "+3 more" in body  # 11 members, 8 inline
+
+
+def test_large_diff_condensed_note_links_report():
+    # full overflows → auto-downgrade to standard with a condensed note + link.
+    changes = [
+        {"kind": "func_removed", "symbol": f"ns{i}::f", "description": "x" * 300,
+         "severity": "breaking"} for i in range(2000)
+    ]
+    body = render_comment(
+        build_model(_compare_report(changes)), sha="x", detail="full",
+        report_url="https://e/run/2",
+    )
+    assert "Condensed to fit" in body
+    assert "https://e/run/2" in body
+
+
+def test_comment_hard_truncated_when_even_summary_overflows(monkeypatch):
+    import abicheck.pr_comment as pc
+
+    monkeypatch.setattr(pc, "_BODY_BUDGET", 220)
+    body = render_comment(
+        build_model(_compare_report()), sha="x", detail="full",
+        report_url="https://e/run/1",
+    )
+    assert "truncated to fit" in body
+    assert "https://e/run/1" in body
+    assert len(body) <= pc._BODY_BUDGET
+
+
 def test_comment_stays_under_github_size_limit():
     from abicheck.pr_comment import GITHUB_COMMENT_LIMIT
 

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -199,6 +199,24 @@ def test_appcompat_missing_symbols_count_as_breaking():
     assert any(f.symbol == "foo_legacy" for f in model.breaking)
 
 
+def test_appcompat_missing_version_counts_as_breaking():
+    # An app broken solely by a missing version tag must still register a change
+    # so `--on changes` posts the comment.
+    report = {
+        "application": "/opt/app/bin/myapp",
+        "old_library": "/lib/libfoo.so.1",
+        "new_library": "/lib/libfoo.so.2",
+        "verdict": "BREAKING",
+        "missing_symbols": [],
+        "missing_versions": ["LIBFOO_2.0"],
+        "relevant_changes": [],
+    }
+    model = build_model(report)
+    assert model.counts == (1, 0, 0)
+    assert should_post(model, "changes") is True
+    assert any(f.symbol == "LIBFOO_2.0" for f in model.breaking)
+
+
 def test_malformed_changes_are_skipped():
     model = build_model(
         {

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -368,6 +368,35 @@ def test_severity_addition_error_classifies_non_added_kinds():
         assert build_model(report).counts == (1, 0, 0), kind
 
 
+def test_severity_quality_error_release_quality_breaking():
+    # compatible_additions conflates additions + quality; a quality-only gate
+    # must move the quality subset (not the additions) to Breaking.
+    report = {
+        "verdict": "COMPATIBLE_WITH_RISK",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "lib.so",
+                "verdict": "COMPATIBLE_WITH_RISK",
+                "breaking": 0,
+                "source_breaks": 0,
+                "risk_changes": 0,
+                "compatible_additions": 5,
+                "quality_issues": 2,
+            },
+        ],
+        "severity": {
+            "config": {"quality_issues": "error", "addition": "info"},
+            "exit_code": 1,
+        },
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    # quality (2) → breaking, additions (5-2=3) → safe
+    assert build_model(report).counts == (2, 0, 3)
+
+
 def test_severity_addition_error_release_additions_breaking():
     report = {
         "verdict": "COMPATIBLE",

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -349,6 +349,25 @@ def test_severity_addition_error_files_additions_as_breaking():
     assert build_model(plain).counts == (0, 0, 1)
 
 
+def test_severity_addition_error_classifies_non_added_kinds():
+    # Addition kinds that don't end in "_added" must still be treated as
+    # additions (sourced from ADDITION_KINDS), so severity-addition: error files
+    # them under Breaking rather than Safe/quality.
+    for kind in ("type_field_added_compatible", "experimental_graduated"):
+        report = _compare_report(
+            [
+                {
+                    "kind": kind,
+                    "symbol": "s",
+                    "description": "d",
+                    "severity": "compatible",
+                }
+            ]
+        )
+        report["severity"] = {"config": {"addition": "error"}, "exit_code": 1}
+        assert build_model(report).counts == (1, 0, 0), kind
+
+
 def test_severity_addition_error_release_additions_breaking():
     report = {
         "verdict": "COMPATIBLE",

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the sticky PR-comment renderer and the ``pr-comment`` CLI."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from abicheck.pr_comment import (
+    MARKER,
+    CommentModel,
+    build_model,
+    render_comment,
+    should_post,
+)
+
+
+def _compare_report(changes: list[dict] | None = None) -> dict:
+    return {
+        "verdict": "BREAKING",
+        "library": "libfoo.so",
+        "old_version": "v1.2.0",
+        "new_version": "v1.3.0",
+        "policy": "strict_abi",
+        "changes": changes
+        if changes is not None
+        else [
+            {
+                "kind": "func_removed",
+                "symbol": "foo_init",
+                "description": "removed",
+                "severity": "breaking",
+                "source_location": "foo.h:20",
+            },
+            {
+                "kind": "type_size_changed",
+                "symbol": "struct Ctx",
+                "description": "grew",
+                "old_value": "16",
+                "new_value": "24",
+                "severity": "breaking",
+            },
+            {
+                "kind": "enum_member_added",
+                "symbol": "Color::PURPLE",
+                "description": "closed enum",
+                "severity": "api_break",
+            },
+            {
+                "kind": "func_added",
+                "symbol": "foo_v2",
+                "description": "new",
+                "severity": "compatible",
+            },
+            {
+                "kind": "type_added",
+                "symbol": "struct CtxV2",
+                "description": "new",
+                "severity": "compatible",
+            },
+        ],
+    }
+
+
+def _release_report() -> dict:
+    return {
+        "verdict": "BREAKING",
+        "old_dir": "/tmp/old",
+        "new_dir": "/tmp/new",
+        "libraries": [
+            {
+                "library": "libfoo.so.1",
+                "verdict": "BREAKING",
+                "breaking": 2,
+                "source_breaks": 0,
+                "compatible_additions": 1,
+            },
+            {
+                "library": "libbar.so.2",
+                "verdict": "COMPATIBLE",
+                "breaking": 0,
+                "source_breaks": 0,
+                "compatible_additions": 3,
+            },
+        ],
+        "unmatched_old": ["libgone.so.1"],
+        "unmatched_new": [],
+    }
+
+
+def _appcompat_report() -> dict:
+    return {
+        "application": "/opt/app/bin/myapp",
+        "old_library": "/lib/libfoo.so.1",
+        "new_library": "/lib/libfoo.so.2",
+        "verdict": "BREAKING",
+        "missing_symbols": ["foo_legacy", "foo_old"],
+        "relevant_changes": [
+            {
+                "kind": "func_params_changed",
+                "symbol": "foo_run",
+                "description": "signature changed",
+                "severity": "breaking",
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shape detection + bucketing
+# ---------------------------------------------------------------------------
+
+
+def test_compare_buckets_by_severity():
+    model = build_model(_compare_report())
+    assert model.mode == "compare"
+    assert model.counts == (2, 1, 2)
+    assert {f.symbol for f in model.breaking} == {"foo_init", "struct Ctx"}
+    assert [f.symbol for f in model.review] == ["Color::PURPLE"]
+    assert {f.symbol for f in model.safe} == {"foo_v2", "struct CtxV2"}
+
+
+def test_compare_detail_text_renders_value_delta():
+    model = build_model(_compare_report())
+    size_change = next(f for f in model.breaking if f.symbol == "struct Ctx")
+    assert "16 → 24" in size_change.detail
+
+
+def test_release_shape_detected_and_summed():
+    model = build_model(_release_report())
+    assert model.mode == "release"
+    # breaking=2, review(source_breaks)=0, safe(additions)=1+3=4
+    assert model.counts == (2, 0, 4)
+    assert model.removed_libraries == ["libgone.so.1"]
+    assert len(model.library_rows) == 2
+
+
+def test_appcompat_missing_symbols_count_as_breaking():
+    model = build_model(_appcompat_report())
+    assert model.mode == "appcompat"
+    # 1 relevant breaking change + 2 missing symbols
+    assert model.counts == (3, 0, 0)
+    assert model.subject == "myapp"
+    assert any(f.symbol == "foo_legacy" for f in model.breaking)
+
+
+def test_malformed_changes_are_skipped():
+    model = build_model(
+        {
+            "changes": [
+                "not-a-dict",
+                {"kind": "func_added", "symbol": "x", "severity": "compatible"},
+            ]
+        }
+    )
+    assert model.counts == (0, 0, 1)
+
+
+# ---------------------------------------------------------------------------
+# should_post
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "on,changes,expected",
+    [
+        ("never", True, False),
+        ("always", False, True),
+        ("changes", True, True),
+        ("changes", False, False),
+    ],
+)
+def test_should_post(on, changes, expected):
+    report = _compare_report([] if not changes else None)
+    model = build_model(report)
+    assert should_post(model, on) is expected
+
+
+def test_should_post_changes_true_when_library_removed():
+    model = build_model(_release_report())
+    # zero per-library would still post because a library was removed
+    model.library_rows = []
+    assert should_post(model, "changes") is True
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_marker_header_sha_and_counts():
+    body = render_comment(
+        build_model(_compare_report()),
+        sha="a1b2c3d4e5f6",
+        detail="standard",
+        run_label="run #128",
+    )
+    assert body.startswith(MARKER)
+    assert "## ❌ abicheck — ABI BREAKING" in body
+    assert "a1b2c3d" in body  # short sha in header
+    assert "commit a1b2c3d" in body  # and footer
+    assert "**2 breaking** · 1 needs review · 2 safe" in body
+    assert "run #128" in body
+
+
+def test_render_header_review_when_no_breaking():
+    report = _compare_report(
+        [
+            {
+                "kind": "enum_member_added",
+                "symbol": "E::X",
+                "description": "d",
+                "severity": "api_break",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="deadbeef")
+    assert "Review recommended" in body
+    assert "⚠️" in body
+
+
+def test_render_header_safe_only():
+    report = _compare_report(
+        [
+            {
+                "kind": "func_added",
+                "symbol": "g",
+                "description": "d",
+                "severity": "compatible",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="deadbeef")
+    assert "Compatible — safe changes only" in body
+
+
+def test_render_header_no_changes():
+    body = render_comment(build_model(_compare_report([])), sha="deadbeef")
+    assert "No ABI changes" in body
+
+
+def test_summary_detail_has_no_tables():
+    body = render_comment(build_model(_compare_report()), sha="x", detail="summary")
+    assert "<details" not in body
+    assert "**2 breaking**" in body
+
+
+def test_full_detail_expands_all_sections():
+    body = render_comment(build_model(_compare_report()), sha="x", detail="full")
+    # every <details> opens expanded in full mode
+    assert "<details><summary>" not in body
+    assert body.count("<details open>") == 3
+
+
+def test_standard_truncates_large_breaking_table():
+    changes = [
+        {
+            "kind": "func_removed",
+            "symbol": f"sym_{i}",
+            "description": "removed",
+            "severity": "breaking",
+        }
+        for i in range(40)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    assert "more_" in body  # truncation marker
+    # full mode keeps everything
+    full = render_comment(build_model(_compare_report(changes)), sha="x", detail="full")
+    assert "more_" not in full
+
+
+def test_release_render_lists_removed_libraries():
+    body = render_comment(build_model(_release_report()), sha="cafe1234")
+    assert "Libraries removed" in body
+    assert "libgone.so.1" in body
+    assert "Per-library results (2)" in body
+
+
+def test_pipe_characters_escaped_in_cells():
+    report = _compare_report(
+        [
+            {
+                "kind": "func_params_changed",
+                "symbol": "f(int|long)",
+                "description": "a|b",
+                "severity": "breaking",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="x")
+    assert "f(int\\|long)" in body
+
+
+def test_empty_model_renders_clean_verdict():
+    model = CommentModel(
+        mode="compare", subject="lib", old_label="o", new_label="n", policy="strict_abi"
+    )
+    body = render_comment(model, sha="")
+    assert "No ABI changes" in body
+    assert MARKER in body
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args):
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    return CliRunner().invoke(main, args)
+
+
+def test_cli_pr_comment_writes_body(tmp_path):
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_compare_report()), encoding="utf-8")
+    out = tmp_path / "comment.md"
+    result = _run_cli(["pr-comment", str(report), "--sha", "abc1234", "-o", str(out)])
+    assert result.exit_code == 0
+    body = out.read_text(encoding="utf-8")
+    assert MARKER in body
+    assert "ABI BREAKING" in body
+
+
+def test_cli_pr_comment_skip_writes_empty_file(tmp_path):
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_compare_report([])), encoding="utf-8")
+    out = tmp_path / "comment.md"
+    result = _run_cli(["pr-comment", str(report), "--on", "changes", "-o", str(out)])
+    assert result.exit_code == 0
+    # nothing to post → empty file so the action's `-s` check skips
+    assert out.read_text(encoding="utf-8") == ""
+
+
+def test_cli_pr_comment_invalid_json_errors(tmp_path):
+    report = tmp_path / "bad.json"
+    report.write_text("{not json", encoding="utf-8")
+    result = _run_cli(["pr-comment", str(report)])
+    assert result.exit_code != 0
+    assert "Cannot read JSON report" in result.output
+
+
+def test_cli_pr_comment_non_object_errors(tmp_path):
+    report = tmp_path / "arr.json"
+    report.write_text("[1, 2, 3]", encoding="utf-8")
+    result = _run_cli(["pr-comment", str(report)])
+    assert result.exit_code != 0
+    assert "must be an object" in result.output

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -256,6 +256,58 @@ def test_appcompat_missing_version_counts_as_breaking():
     assert any(f.symbol == "LIBFOO_2.0" for f in model.breaking)
 
 
+def test_gate_api_break_files_api_break_as_breaking():
+    # With fail-on-api-break, the check goes red on api_break, so the comment
+    # must file it under Breaking (not review) to match.
+    report = _compare_report(
+        [
+            {
+                "kind": "enum_member_added",
+                "symbol": "E::X",
+                "description": "d",
+                "severity": "api_break",
+            },
+            {
+                "kind": "type_field_added",
+                "symbol": "S",
+                "description": "d",
+                "severity": "risk",
+            },
+        ]
+    )
+    gated = build_model(report, gate_api_break=True)
+    assert gated.counts == (1, 1, 0)  # api_break → breaking, risk stays review
+    body = render_comment(gated, sha="x")
+    assert "ABI BREAKING" in body
+    # default (ungated) keeps api_break in review
+    ungated = build_model(report)
+    assert ungated.counts == (0, 2, 0)
+
+
+def test_gate_api_break_release_source_breaks_count_as_breaking():
+    report = {
+        "verdict": "API_BREAK",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "lib.so",
+                "verdict": "API_BREAK",
+                "breaking": 0,
+                "source_breaks": 2,
+                "risk_changes": 1,
+                "compatible_additions": 0,
+            },
+        ],
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    gated = build_model(report, gate_api_break=True)
+    assert gated.counts == (2, 1, 0)  # source_breaks → breaking, risk → review
+    ungated = build_model(report)
+    assert ungated.counts == (0, 3, 0)  # source_breaks + risk → review
+
+
 def test_malformed_changes_are_skipped():
     model = build_model(
         {

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -691,6 +691,25 @@ def test_comment_stays_under_github_size_limit():
     assert body.startswith(MARKER)  # header survives the downgrade/truncate
 
 
+def test_backtick_in_symbol_neutralised():
+    # A backtick in a symbol must not break the surrounding markdown code span.
+    report = _compare_report(
+        [{"kind": "func_removed", "symbol": "weird`sym", "description": "d",
+          "severity": "breaking"}]
+    )
+    body = render_comment(build_model(report), sha="x")
+    assert "weird`sym" not in body
+    assert "weirdˋsym" in body
+
+
+def test_report_url_parens_percent_encoded():
+    # Parentheses in the report URL would terminate the markdown link target.
+    body = render_comment(
+        build_model(_compare_report()), sha="x", report_url="https://e/run(1)"
+    )
+    assert "https://e/run%281%29" in body
+
+
 def test_report_url_linked_in_footer():
     body = render_comment(
         build_model(_compare_report()), sha="x", report_url="https://example/run/9"

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -213,6 +213,22 @@ def test_release_bundle_findings_register_as_change():
     assert "build-config matrix" in body
 
 
+def test_release_errored_library_counts_as_breaking():
+    # A library whose comparison errored has no count fields; it must still
+    # register as a change so the failed comparison is reflected in the comment.
+    report = {
+        "verdict": "ERROR",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [{"library": "libbad.so", "verdict": "ERROR", "error": "boom"}],
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert model.counts == (1, 0, 0)
+    assert should_post(model, "changes") is True
+
+
 def test_release_added_libraries_rendered():
     report = {
         "verdict": "COMPATIBLE",

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -79,8 +79,8 @@ def _compare_report(changes: list[dict] | None = None) -> dict:
 def _release_report() -> dict:
     return {
         "verdict": "BREAKING",
-        "old_dir": "/tmp/old",
-        "new_dir": "/tmp/new",
+        "old_dir": "/pkg/old",
+        "new_dir": "/pkg/new",
         "libraries": [
             {
                 "library": "libfoo.so.1",
@@ -154,8 +154,8 @@ def test_release_risk_only_library_counts_as_review():
     # as a change so `--on changes` posts the warning-tone comment.
     report = {
         "verdict": "COMPATIBLE_WITH_RISK",
-        "old_dir": "/tmp/old",
-        "new_dir": "/tmp/new",
+        "old_dir": "/pkg/old",
+        "new_dir": "/pkg/new",
         "libraries": [
             {
                 "library": "librisk.so.1",
@@ -216,8 +216,8 @@ def test_release_bundle_findings_register_as_change():
 def test_release_added_libraries_rendered():
     report = {
         "verdict": "COMPATIBLE",
-        "old_dir": "/tmp/old",
-        "new_dir": "/tmp/new",
+        "old_dir": "/pkg/old",
+        "new_dir": "/pkg/new",
         "libraries": [],
         "unmatched_old": [],
         "unmatched_new": ["libnew.so.1"],

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -213,6 +213,29 @@ def test_release_bundle_findings_register_as_change():
     assert "build-config matrix" in body
 
 
+def test_release_global_compatible_finding_gated_to_breaking():
+    # A global (bundle/matrix) COMPATIBLE section buckets as Safe by verdict, but
+    # when a severity gate (addition error) turned the check red on exactly that
+    # finding, it must be filed under Breaking.
+    report = {
+        "verdict": "COMPATIBLE",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [],
+        "matrix_verdict": "COMPATIBLE",
+        "matrix_findings": [
+            {"kind": "func_added", "symbol": "probe_new", "description": "x"},
+        ],
+        "severity": {"config": {"addition": "error"}, "exit_code": 1},
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    # the global compatible finding is promoted to breaking, not safe
+    assert model.counts == (1, 0, 0)
+    assert should_post(model, "changes") is True
+
+
 def test_release_errored_library_counts_as_breaking():
     # A library whose comparison errored has no count fields; it must still
     # register as a change so the failed comparison is reflected in the comment.

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -213,11 +213,8 @@ def test_release_bundle_findings_register_as_change():
     assert "build-config matrix" in body
 
 
-def test_release_global_compatible_finding_gated_to_breaking():
-    # A global (bundle/matrix) COMPATIBLE section buckets as Safe by verdict, but
-    # when a severity gate (addition error) turned the check red on exactly that
-    # finding, it must be filed under Breaking.
-    report = {
+def _release_global_report(config: dict) -> dict:
+    return {
         "verdict": "COMPATIBLE",
         "old_dir": "/o",
         "new_dir": "/n",
@@ -225,15 +222,33 @@ def test_release_global_compatible_finding_gated_to_breaking():
         "matrix_verdict": "COMPATIBLE",
         "matrix_findings": [
             {"kind": "func_added", "symbol": "probe_new", "description": "x"},
+            {"kind": "soname_bump_unnecessary", "symbol": "libp", "description": "y"},
         ],
-        "severity": {"config": {"addition": "error"}, "exit_code": 1},
+        "severity": {"config": config, "exit_code": 1},
         "unmatched_old": [],
         "unmatched_new": [],
     }
-    model = build_model(report)
-    # the global compatible finding is promoted to breaking, not safe
-    assert model.counts == (1, 0, 0)
+
+
+def test_release_global_addition_gate_promotes_only_additions():
+    # addition gated → only the func_added finding is Breaking; the quality
+    # finding stays Safe (gates are not interchangeable).
+    model = build_model(_release_global_report({"addition": "error"}))
+    assert model.counts == (1, 0, 1)
+
+
+def test_release_global_quality_gate_promotes_only_quality():
+    # quality gated → only the soname_bump_unnecessary finding is Breaking; the
+    # addition (func_added) stays Safe even though it's in the same section.
+    model = build_model(_release_global_report({"quality_issues": "error"}))
+    assert model.counts == (1, 0, 1)
     assert should_post(model, "changes") is True
+
+
+def test_release_global_ungated_compatible_stays_safe():
+    # No matching gate → the whole compatible section stays Safe.
+    model = build_model(_release_global_report({"potential_breaking": "error"}))
+    assert model.counts == (0, 0, 2)
 
 
 def test_release_errored_library_counts_as_breaking():

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -174,6 +174,45 @@ def test_release_risk_only_library_counts_as_review():
     assert should_post(model, "changes") is True
 
 
+def test_release_bundle_findings_register_as_change():
+    # A clean per-library release that breaks only at the bundle/matrix level
+    # must still register a change so the comment is posted.
+    report = {
+        "verdict": "BREAKING",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "libok.so",
+                "verdict": "COMPATIBLE",
+                "breaking": 0,
+                "source_breaks": 0,
+                "compatible_additions": 0,
+            },
+        ],
+        "bundle_verdict": "BREAKING",
+        "bundle_findings": [
+            {"kind": "soname_mismatch", "symbol": "libfoo", "description": "x"},
+            {"kind": "soname_mismatch", "symbol": "libbar", "description": "y"},
+        ],
+        "matrix_verdict": "API_BREAK",
+        "matrix_findings": [
+            {"kind": "macro_guarded", "symbol": "FOO", "description": "z"},
+        ],
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    # 2 bundle breaks, 1 matrix review, 0 per-library changes
+    assert model.counts == (2, 1, 0)
+    assert should_post(model, "changes") is True
+    # the per-library library count excludes the synthetic global rows
+    assert model.subject == "1 library"
+    body = render_comment(model, sha="abc1234")
+    assert "bundle checks" in body
+    assert "build-config matrix" in body
+
+
 def test_release_added_libraries_rendered():
     report = {
         "verdict": "COMPATIBLE",

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -364,6 +364,71 @@ def test_pipe_characters_escaped_in_cells():
     assert "f(int\\|long)" in body
 
 
+def test_finding_with_only_location_renders_location_cell():
+    report = _compare_report(
+        [
+            {
+                "kind": "func_removed",
+                "symbol": "f",
+                "description": "",
+                "severity": "breaking",
+                "source_location": "foo.h:9",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="x")
+    assert "foo.h:9" in body
+
+
+def test_safe_section_caps_symbols_per_kind():
+    changes = [
+        {
+            "kind": "func_added",
+            "symbol": f"add_{i}",
+            "description": "new",
+            "severity": "compatible",
+        }
+        for i in range(20)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    assert "(+8)" in body  # 20 symbols, cap 12 → "+8" more
+
+
+def test_release_full_detail_table_with_rows():
+    body = render_comment(build_model(_release_report()), sha="x", detail="full")
+    assert "Per-library results (2)" in body
+    assert "libfoo.so.1" in body and "libbar.so.2" in body
+
+
+def test_release_summary_detail_omits_table():
+    body = render_comment(build_model(_release_report()), sha="x", detail="summary")
+    assert "Per-library results" not in body
+    assert "**2 breaking**" in body
+
+
+def test_release_skips_non_dict_library_entries():
+    report = {
+        "verdict": "COMPATIBLE",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            "not-a-dict",
+            {
+                "library": "ok.so",
+                "verdict": "COMPATIBLE",
+                "breaking": 0,
+                "source_breaks": 0,
+                "compatible_additions": 1,
+            },
+        ],
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert len(model.library_rows) == 1
+    assert model.counts == (0, 0, 1)
+
+
 def test_empty_model_renders_clean_verdict():
     model = CommentModel(
         mode="compare", subject="lib", old_label="o", new_label="n", policy="strict_abi"

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -149,6 +149,47 @@ def test_release_shape_detected_and_summed():
     assert len(model.library_rows) == 2
 
 
+def test_release_risk_only_library_counts_as_review():
+    # A COMPATIBLE_WITH_RISK library with only risk_changes must still register
+    # as a change so `--on changes` posts the warning-tone comment.
+    report = {
+        "verdict": "COMPATIBLE_WITH_RISK",
+        "old_dir": "/tmp/old",
+        "new_dir": "/tmp/new",
+        "libraries": [
+            {
+                "library": "librisk.so.1",
+                "verdict": "COMPATIBLE_WITH_RISK",
+                "breaking": 0,
+                "source_breaks": 0,
+                "risk_changes": 3,
+                "compatible_additions": 0,
+            },
+        ],
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert model.counts == (0, 3, 0)
+    assert should_post(model, "changes") is True
+
+
+def test_release_added_libraries_rendered():
+    report = {
+        "verdict": "COMPATIBLE",
+        "old_dir": "/tmp/old",
+        "new_dir": "/tmp/new",
+        "libraries": [],
+        "unmatched_old": [],
+        "unmatched_new": ["libnew.so.1"],
+    }
+    model = build_model(report)
+    assert model.added_libraries == ["libnew.so.1"]
+    body = render_comment(model, sha="abc1234", detail="full")
+    assert "New libraries" in body
+    assert "libnew.so.1" in body
+
+
 def test_appcompat_missing_symbols_count_as_breaking():
     model = build_model(_appcompat_report())
     assert model.mode == "appcompat"


### PR DESCRIPTION
## What & why

Today the GitHub Action reports through the step's red/green check, the Job
Summary (which lives on the Actions run page, **not** the PR conversation),
inline `--annotate` annotations, and optional SARIF. There was **no PR
comment** mechanism and no way to surface "needs a human decision" findings
distinctly from hard breaks.

This adds a **single, self-updating PR comment** that groups every finding into
three buckets and shows the scanned head SHA:

| Outcome | Check color | Comment |
|---|---|---|
| `BREAKING` (and `API_BREAK` when `fail-on-api-break: true`) | ❌ red | `❌ ABI BREAKING` |
| Needs review — source breaks / risk not gated | ✅ green | `⚠️ Review recommended` |
| Safe — additions + policy/surface-scoped compatible removals | ✅ green | `✅ Compatible` |

The comment is a **content channel only** — it never changes the red/green gate
(still driven by `fail-on-breaking` / `fail-on-api-break` / `severity-*`). So
review-needed items show up as a green check **with** a warning-tone comment,
exactly as requested, while real ABI breaks turn the check red and post a `❌`
comment.

### Design decisions (locked with the requester)
- **Warning state** → green check + sticky comment (composite actions can't set
  a native neutral check conclusion).
- **"Safe"** → a pure mirror of the severity the checker already assigned, so
  public-header surface scoping (`--scope-public-headers`) and policy profiles
  (e.g. `sdk_vendor` demoting a removal) flow through automatically. No
  re-classification in the renderer.
- **Detail** → `standard` by default (per-symbol tables for breaking/review,
  grouped safe list).

## New action inputs (additive; defaults shown)

| Input | Default | Meaning |
|---|---|---|
| `pr-comment` | `true` | post/update the sticky comment (no-op outside `pull_request`) |
| `pr-comment-mode` | `update` | one sticky comment edited in place vs. `new` per run |
| `pr-comment-on` | `changes` | `always` / `changes` / `never` |
| `pr-comment-detail` | `standard` | `summary` / `standard` / `full` |
| `github-token` | `${{ github.token }}` | needs `pull-requests: write` |

## Implementation

- `abicheck/pr_comment.py` — schema-tolerant renderer for `compare` /
  `compare-release` / `appcompat` JSON → markdown with a hidden sticky marker
  (`<!-- abicheck-sticky-report -->`) for find-and-update.
- `abicheck/cli_pr_comment.py` — `abicheck pr-comment` command (sibling-module
  registration per `CLAUDE.md`; wired into `cli.py`, `pyproject.toml`, and the
  import-cycle allowlist).
- `action.yml` + `action/run.sh` — new inputs, a JSON re-run to feed the
  renderer, and post/update via `gh pr comment` (`--edit-last`, create if none).
- `docs/user-guide/github-action.md` — inputs table rows + a usage section.

## Example comment (standard detail)

```markdown
## ❌ abicheck — ABI BREAKING

**Head `a1b2c3d`** vs `v1.2.0` · `strict_abi` · `libfoo.so`
**2 breaking** · 1 needs review · 3 safe

❌ Breaking (2)
| func_removed | foo_init | removed from public API · foo.h:20 |
| type_size_changed | struct Ctx | 16 → 24 |
⚠️ Needs review (1)
| enum_member_added | Color::PURPLE | new value in closed enum |
✅ Safe (3)
func_added: foo_v2, foo_reset · type_added: struct CtxV2
```

## Testing & gates
- `tests/test_pr_comment.py` — 24 tests (shape detection, bucketing,
  `should_post`, detail levels, truncation, pipe escaping, CLI command).
- Full fast suite green (8790 passed). `ruff`, `ruff format`, `mypy abicheck/`
  (0 errors, 135 files), and `scripts/check_ai_readiness.py` (0 errors) all
  clean. `action/run.sh` passes `bash -n`; `action.yml` validates as YAML.

## Notes / follow-ups
- The comment body is generated from a second `--format json` run of the same
  comparison; this is the simplest robust path across all three modes. A future
  optimization could reuse the primary run's output when JSON was already
  requested.
- A true neutral/yellow Check conclusion (via the Checks API) was intentionally
  left out per the locked design; can be added later if desired.

https://claude.ai/code/session_015xyqaGa2EALfUFGoMm6p3E

---
_Generated by [Claude Code](https://claude.ai/code/session_015xyqaGa2EALfUFGoMm6p3E)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added `pr-comment` CLI command to post sticky ABI reports on pull requests
  - GitHub Action now supports posting and updating sticky PR comments with categorized findings (Breaking, Needs review, Safe)
  - New configurable action inputs: `pr-comment`, `pr-comment-mode`, `pr-comment-on`, `pr-comment-detail`, `github-token`

* **Documentation**
  - Added GitHub Action user guide with sticky PR comment feature documentation and examples

* **Tests**
  - Added comprehensive test suite for PR comment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->