### PR TITLE
docs: explain the scanner and its evidence sources in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@ It catches removed or renamed symbols, changed function signatures, struct layou
 
 ---
 
+## Key features
+
+- **Reads multiple sources of information.** abicheck doesn't rely on a single view of a library. It overlays up to **five independent, additive sources** — the compiled binary, its debug symbols, its public headers, its build-system data, and (optionally) its sources — and lets the strongest evidence win. Each source finds breaks the weaker ones are blind to, and *removes* false positives the weaker ones would raise. See [How it works](#how-it-works--multiple-sources-of-information) below.
+- **Detects most of what causes ABI/API breaks.** **216 change types** across functions, variables, structs/classes, enums, unions, typedefs, templates, and platform/linker metadata — removed or renamed symbols, changed signatures and parameter lists, struct/class layout drift, field-offset shifts, vtable reordering, enum value reassignment, qualifier/`noexcept`/access changes, calling-convention and packing changes, symbol-version and SONAME drift, dependency leaks, and more. Each is classified as `BREAKING`, `API_BREAK`, `COMPATIBLE_WITH_RISK`, or `COMPATIBLE`. See the [Change Kind Reference](https://napetrov.github.io/abicheck/reference/change-kinds/).
+- **Cross-platform.** Linux (ELF), Windows (PE/COFF), and macOS (Mach-O) binaries, with debug-info cross-checks from DWARF, PDB, BTF, and CTF.
+- **Built for CI.** Deterministic [exit codes](https://napetrov.github.io/abicheck/reference/exit-codes/), SARIF/JSON/Markdown/HTML/JUnit output, snapshot-based [baselines](https://napetrov.github.io/abicheck/user-guide/baseline-management/), [policy profiles](https://napetrov.github.io/abicheck/user-guide/policies/) and [suppressions](https://napetrov.github.io/abicheck/user-guide/suppressions/), and a first-class [GitHub Action](https://napetrov.github.io/abicheck/user-guide/github-action/).
+- **Public-surface scoping.** Filters findings to the library's *public* ABI surface so internal-only changes don't fail your build — fewer false positives than symbol-only tools.
+- **More than one library at a time.** Compare co-versioned multi-library releases as a single bundle ([`compare-release`](https://napetrov.github.io/abicheck/user-guide/multi-binary/)), check whether a specific application still works ([`appcompat`](https://napetrov.github.io/abicheck/user-guide/appcompat/)), or validate a binary's full dependency stack across sysroots ([`stack-check`](https://napetrov.github.io/abicheck/user-guide/cli-usage/)).
+- **Drop-in for existing tools.** A [`compat`](https://napetrov.github.io/abicheck/user-guide/from-abicc/) mode mirrors `abi-compliance-checker` flags, and migration guides cover [ABICC](https://napetrov.github.io/abicheck/user-guide/from-abicc/) and [libabigail](https://napetrov.github.io/abicheck/user-guide/from-libabigail/).
+- **Agent- and script-friendly.** Structured JSON, a [Python API](#python-api), and an [MCP server](https://napetrov.github.io/abicheck/user-guide/mcp-integration/) for AI-driven workflows. Pure Python (3.10+), no heavyweight native toolchain required for binary-only mode.
+
+---
+
+## How it works — multiple sources of information
+
+abicheck treats compatibility analysis as a question of **evidence**: the more independent sources you give it about a library, the more it can prove — and the fewer false positives it raises. There are **five layers**, ordered from the least input to the most. Each one *adds* facts the previous cannot see; none is complete on its own.
+
+| Layer | Source you provide | Read by | What it newly reveals |
+|:-----:|--------------------|---------|------------------------|
+| **L0** | **Just the binary** — a stripped `.so` / `.dll` / `.dylib` | ELF/PE/COFF/Mach-O parsers (`pyelftools`, `pefile`, `macholib`) | Exported symbols, SONAME/install-name, symbol versions, visibility, binding, `DT_NEEDED`/`LC_LOAD_DYLIB` dependencies |
+| **L1** | **+ Debug symbols** — a `-g` build or sidecar debug file | DWARF, PDB, BTF, CTF | Type **layout**: struct/class sizes, field offsets, enum *values*, vtable slots, calling convention, packing/alignment |
+| **L2** | **+ Public headers** — `-H include/` | castxml AST | Source-level **API**: signatures, overloads, access (`public`/`private`), `final`/`explicit`/`noexcept`, templates, default args, public/internal scoping |
+| **L3** | **+ Build system data & options** — `-p build/` | compile DB / CMake / Ninja / Bazel / Make | The flags the library was *actually* built with: `-std`, `_GLIBCXX_USE_CXX11_ABI`, `-fvisibility`, `-fabi-version`, toolchain/sysroot, export maps |
+| **L4** | **+ Sources** — an evidence pack | per-TU source ABI replay | Facts that never reach the binary: macro/`constexpr` values, default-argument *values*, inline/template bodies, uninstantiated templates |
+
+The layers are **independent and additive, not a fallback chain** — abicheck overlays every source you give it and computes one worst-wins verdict, under the *authority rule*: artifact-backed evidence (L0/L1/L2) is authoritative for the shipped-ABI verdict, while build/source evidence (L3/L4) *explains, localizes, scopes, or adds confidence* to a finding (and can raise its own source-/API-level findings) but never silently deletes an artifact-proven break.
+
+With less input, abicheck degrades gracefully *down the staircase* rather than failing — a stripped binary with no headers collapses toward symbol-only checking — and `abicheck dump --show-data-sources` reports exactly which layers it found. The best input you can give it is **old library + new library + matching public headers + debug info + build data**. See [Evidence & Detectability](https://napetrov.github.io/abicheck/concepts/evidence-and-detectability/) for what each source can and cannot see, and [Architecture](https://napetrov.github.io/abicheck/concepts/architecture/) for how the layers are reconciled.
+
+---
+
 ## Installation
 
 ```bash
@@ -166,7 +197,7 @@ python scripts/benchmark_comparison.py --suite pinned74
 
 ### Detection by evidence source
 
-abicheck reasons over **five sources of information** — just the binary (`L0`), debug symbols (`L1`), public headers (`L2`), build-system data & options (`L3`), and sources (`L4`) — and each one finds breaks the weaker sources are blind to. The `--evidence-tiers` mode scans the catalog at each level so you can see what every source unlocks:
+The [five sources of information](#how-it-works--multiple-sources-of-information) each find breaks the weaker sources are blind to. The `--evidence-tiers` mode scans the catalog at each level so you can measure what every source unlocks:
 
 ```bash
 python scripts/benchmark_comparison.py --evidence-tiers


### PR DESCRIPTION
## What

Updates the main `README.md` to better explain abicheck to new users, drawing on the docs and ADRs. Two new sections near the top:

- **Key features** — a scannable overview of what abicheck does: reads multiple sources of information, detects most ABI/API-breaking change types (216), cross-platform, CI-ready, public-surface scoping, multi-library/app/stack workflows, ABICC/libabigail drop-in, and agent/script-friendly integrations.
- **How it works — multiple sources of information** — promotes the five-source evidence model (L0 binary → L1 debug symbols → L2 public headers → L3 build data → L4 sources) from the bottom of the README to a prominent spot, with the per-layer "what it newly reveals" table and the authority/degradation rules.

## Why

The previous README led with installation and buried the evidence-source story under "Validation snapshot" at the very bottom. New users now see, up front, the two things that distinguish abicheck: that it reasons over **multiple independent sources of information** (each listed), and that it detects **most of the change types that cause ABI/API breaks**.

## Sources

Content is faithful to:
- `docs/concepts/architecture.md` — "Evidence layers: the five sources"
- `docs/concepts/evidence-and-detectability.md`
- ADR-003 (Data Source Architecture) and ADR-028 (authority rule)
- `docs/reference/change-kinds.md` (216 change kinds, verdict taxonomy)

No code changes; documentation only. Internal anchor links (`#how-it-works--multiple-sources-of-information`, `#python-api`) resolve within the file.

https://claude.ai/code/session_01Gn8Lr6uqHgCg4KjGqEuFHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gn8Lr6uqHgCg4KjGqEuFHN)_