### PR TITLE
docs: fix stale ChangeKind/catalog counts and document L3/L4 evidence layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## What is abicheck?
 
 ABI compatibility checker for C/C++ shared libraries. Pure Python (3.10+).
-Detects 232 ABI/API change types across ELF, PE/COFF, and Mach-O binaries,
+Detects 234 ABI/API change types across ELF, PE/COFF, and Mach-O binaries,
 categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, and `RISK_KINDS` (see `ChangeKind`).
 Drop-in replacement for abi-compliance-checker (ABICC).
 
@@ -105,7 +105,7 @@ Core pipeline (in order of data flow):
 
 - `AbiSnapshot` (`model.py`) — serializable snapshot of a library's ABI surface
 - `DiffResult` (`checker_types.py`) — single detected change with kind, severity, details
-- `ChangeKind` (`checker_policy.py`) — enum of 216 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
+- `ChangeKind` (`checker_policy.py`) — enum of 222 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
 - `Verdict` (`checker.py`) — overall comparison result (compatible/source_break/breaking)
 - `LibraryMetadata` (`checker.py`) — parsed library info
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Core pipeline (in order of data flow):
 
 - `AbiSnapshot` (`model.py`) — serializable snapshot of a library's ABI surface
 - `DiffResult` (`checker_types.py`) — single detected change with kind, severity, details
-- `ChangeKind` (`checker_policy.py`) — enum of 222 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
+- `ChangeKind` (`checker_policy.py`) — enum of 230 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
 - `Verdict` (`checker.py`) — overall comparison result (compatible/source_break/breaking)
 - `LibraryMetadata` (`checker.py`) — parsed library info
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Core pipeline (in order of data flow):
 
 - `AbiSnapshot` (`model.py`) — serializable snapshot of a library's ABI surface
 - `DiffResult` (`checker_types.py`) — single detected change with kind, severity, details
-- `ChangeKind` (`checker_policy.py`) — enum of 230 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
+- `ChangeKind` (`checker_policy.py`) — enum of 234 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
 - `Verdict` (`checker.py`) — overall comparison result (compatible/source_break/breaking)
 - `LibraryMetadata` (`checker.py`) — parsed library info
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The [`examples/`](examples/README.md) directory contains **127 real-world ABI/AP
 
 ## Validation snapshot
 
-The main validation target is the full **125-case catalog**. To scan it for the current checkout:
+The main validation target is the full **126-case catalog**. To scan it for the current checkout:
 
 ```bash
 python scripts/benchmark_comparison.py --suite all

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **232 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
+It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **234 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary and header AST analysis on all platforms; debug-info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 
@@ -20,7 +20,7 @@ It catches removed or renamed symbols, changed function signatures, struct layou
 ## Key features
 
 - **Reads multiple sources of information.** abicheck doesn't rely on a single view of a library. It overlays up to **five independent, additive sources** — the compiled binary, its debug symbols, its public headers, its build-system data, and (optionally) its sources — and lets the strongest evidence win. Each source finds breaks the weaker ones are blind to, and *removes* false positives the weaker ones would raise. See [How it works](#how-it-works--multiple-sources-of-information) below.
-- **Detects most of what causes ABI/API breaks.** **230 change types** across functions, variables, structs/classes, enums, unions, typedefs, templates, and platform/linker metadata — removed or renamed symbols, changed signatures and parameter lists, struct/class layout drift, field-offset shifts, vtable reordering, enum value reassignment, qualifier/`noexcept`/access changes, calling-convention and packing changes, symbol-version and SONAME drift, dependency leaks, and more. Each is classified as `BREAKING`, `API_BREAK`, `COMPATIBLE_WITH_RISK`, or `COMPATIBLE`. See the [Change Kind Reference](https://napetrov.github.io/abicheck/reference/change-kinds/).
+- **Detects most of what causes ABI/API breaks.** **234 change types** across functions, variables, structs/classes, enums, unions, typedefs, templates, and platform/linker metadata — removed or renamed symbols, changed signatures and parameter lists, struct/class layout drift, field-offset shifts, vtable reordering, enum value reassignment, qualifier/`noexcept`/access changes, calling-convention and packing changes, symbol-version and SONAME drift, dependency leaks, and more. Each is classified as `BREAKING`, `API_BREAK`, `COMPATIBLE_WITH_RISK`, or `COMPATIBLE`. See the [Change Kind Reference](https://napetrov.github.io/abicheck/reference/change-kinds/).
 - **Cross-platform.** Linux (ELF), Windows (PE/COFF), and macOS (Mach-O) binaries, with debug-info cross-checks from DWARF, PDB, BTF, and CTF.
 - **Built for CI.** Deterministic [exit codes](https://napetrov.github.io/abicheck/reference/exit-codes/), SARIF/JSON/Markdown/HTML/JUnit output, snapshot-based [baselines](https://napetrov.github.io/abicheck/user-guide/baseline-management/), [policy profiles](https://napetrov.github.io/abicheck/user-guide/policies/) and [suppressions](https://napetrov.github.io/abicheck/user-guide/suppressions/), and a first-class [GitHub Action](https://napetrov.github.io/abicheck/user-guide/github-action/).
 - **Public-surface scoping.** Filters findings to the library's *public* ABI surface so internal-only changes don't fail your build — fewer false positives than symbol-only tools.
@@ -181,7 +181,7 @@ The [`examples/`](examples/README.md) directory contains **127 real-world ABI/AP
 
 ## Validation snapshot
 
-The main validation target is the full **126-case catalog**. To scan it for the current checkout:
+The main validation target is the full **127-case catalog**. To scan it for the current checkout:
 
 ```bash
 python scripts/benchmark_comparison.py --suite all

--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -234,6 +234,14 @@ headers. A handful of changes remain invisible to any artifact comparison
 [Limitations → Source-only changes](limitations.md#source-only-changes-invisible-to-binaryobject-analysis)
 for the full per-change detectability matrix.
 
+These three tiers are artifact layers **L0–L2**. Two optional layers go
+further without overriding an artifact-proven break: **L3** build context
+(`-p build/`) pins the exact ABI-affecting flags, and **L4** source/evidence
+packs recover several of the otherwise-invisible source-only facts above
+(macro/`constexpr` values, uninstantiated templates). See [Source & Build
+Evidence Packs](evidence-pack.md) and the full [L0–L4
+model](evidence-and-detectability.md).
+
 #### Which input proves which family
 
 The minimum input needed to *detect* each family — and the most common reason a

--- a/docs/concepts/evidence-and-detectability.md
+++ b/docs/concepts/evidence-and-detectability.md
@@ -70,7 +70,15 @@ the per-case evidence each example needs is benchmarked in
 
 ### Why call it "evidence"?
 
-The word is deliberate — it is a **forensic metaphor**, not decoration. abicheck
+First, concretely: "evidence" is just the umbrella term for the **sources of
+information** in the table above. The artifact sources are the binary (L0), its
+debug info (L1), and its public headers (L2); the additional sources are the
+project's **build-system data** (L3 — compile flags, toolchain, target graph),
+its **source tree** (L4 — per-TU source ABI replay), and a **source/build graph**
+(L5 — include/type/call reachability). When the docs say "build/source evidence
+(L3/L4/L5)", that is exactly what they mean.
+
+The umbrella word is a deliberate **forensic metaphor**, not decoration: abicheck
 treats "is this compatible?" as something it must **prove from facts**, the way a
 case is built from evidence, rather than as a single computation over one data
 source. Three properties of evidence are exactly the properties abicheck needs,

--- a/docs/concepts/evidence-and-detectability.md
+++ b/docs/concepts/evidence-and-detectability.md
@@ -68,6 +68,38 @@ the per-case evidence each example needs is benchmarked in
 > exactly which layers it had via the `--show-data-sources` / `evidence_coverage`
 > report.
 
+### Why call it "evidence"?
+
+The word is deliberate — it is a **forensic metaphor**, not decoration. abicheck
+treats "is this compatible?" as something it must **prove from facts**, the way a
+case is built from evidence, rather than as a single computation over one data
+source. Three properties of evidence are exactly the properties abicheck needs,
+and "tier" or "level" would imply the wrong ones:
+
+- **Independent and partial.** Each source contributes *some* facts and none is
+  complete on its own — a binary shows symbols but not layout, headers show API
+  but not what was actually built. Evidence is **additive and overlaid**, not a
+  ranked ladder you fall back down. (Call them "tiers" and readers assume a
+  fallback chain; they aren't one.)
+- **Different authority.** Just like physical vs. circumstantial evidence in a
+  courtroom, not all of it carries equal weight. **Artifact evidence (L0–L2) is
+  what was actually built and shipped, so it is *authoritative*** — only it can
+  declare a binary `BREAKING`. **Build/source evidence (L3/L4/L5) is
+  *corroborating*** — it explains, localizes, scopes, adds confidence, removes
+  false positives, and can raise its *own* source-/API-level findings, but it can
+  **never overturn or silently delete an artifact-proven break**. This is the
+  *authority rule* ([ADR-028](../development/adr/028-source-build-evidence-pack.md)).
+- **Honest about what it had.** Because the verdict is only as strong as the
+  evidence behind it, every run reports the evidence it actually collected (the
+  `evidence_coverage` table and the "checks enabled… and why others are not"
+  capability report). The output literally says *"here is the evidence I had, so
+  here is what I could and couldn't check."*
+
+So "evidence" + the authority rule is the mental model that lets abicheck keep
+*adding* sources for more accuracy without ever letting a weaker source override
+a proven break.
+
+
 ---
 
 ## 1. The detectability matrix

--- a/docs/concepts/evidence-and-detectability.md
+++ b/docs/concepts/evidence-and-detectability.md
@@ -25,7 +25,10 @@ A release engineer can hand a compatibility checker up to **five different
 sources of information** about a library, ordered from the least to the most.
 Each one *adds* facts the previous cannot see; none of them is complete on its
 own. abicheck names them with the layer codes `L0`–`L4` used throughout the
-docs (and emitted by `abicheck dump --show-data-sources`):
+docs. You can see which **artifact** layers (`L0`–`L2`) a given input exposes
+with `abicheck dump --show-data-sources`; the build/source layers (`L3`/`L4`)
+are not reported there — they surface in the pack-aware `compare`
+`evidence_coverage` table once you supply an EvidencePack:
 
 | # | Source you provide | Layer | abicheck input | What it newly reveals |
 |---|--------------------|:-----:|----------------|------------------------|

--- a/docs/concepts/evidence-pack.md
+++ b/docs/concepts/evidence-pack.md
@@ -67,6 +67,55 @@ pipeline, and `explain-finding` localizes a single finding through the graph.
 > artifact-backed tiers (L0–L2) remain fully authoritative — the comparison is
 > never aborted.
 
+## How the data flows
+
+Two independent producers feed one decision engine. The **artifact pipeline**
+(always on, authoritative) turns each binary into an `AbiSnapshot`; the
+**evidence pipeline** (optional, post-build, never rebuilds) collects an
+out-of-band `EvidencePack`. At `compare` time both are diffed and reconciled
+under the [authority rule](#the-authority-rule-the-one-rule-that-matters):
+
+```mermaid
+flowchart TD
+    subgraph artifact["Artifact pipeline — authoritative"]
+      BIN["binary (.so/.dll/.dylib)"] --> P["format parser<br/>ELF / PE / Mach-O"]
+      P --> L0["L0 binary metadata"]
+      L0 --> L1["+ L1 DWARF/PDB/BTF/CTF"]
+      L1 --> L2["+ L2 castxml header AST"]
+      L2 --> SNAP["AbiSnapshot (JSON)"]
+    end
+
+    subgraph evidence["Evidence pipeline — corroborating, post-build"]
+      BT["build tree (no rebuild)"] --> CE["collect-evidence"]
+      CE --> L3["L3 build facts<br/>compile DB / CMake / Ninja / Bazel / Make"]
+      CE --> L4["L4 source ABI replay<br/>clang (--source-abi)"]
+      CE --> L5["L5 graph summary<br/>(--source-graph)"]
+      L3 --> PACK["EvidencePack<br/>(content-addressed, out-of-band)"]
+      L4 --> PACK
+      L5 --> PACK
+    end
+
+    SNAP --> CMP{{"compare"}}
+    PACK -. "pass explicitly:<br/>--old/--new-evidence" .-> CMP
+    CMP --> DIFFA["diff artifact layers<br/>L0/L1/L2 → can prove BREAKING"]
+    CMP --> DIFFE["diff evidence layers<br/>L3/L4/L5 → API_BREAK / risk only"]
+    DIFFA --> REC["reconcile (worst-wins +<br/>authority rule: L3/L4/L5 never<br/>deletes an artifact-proven break)"]
+    DIFFE --> REC
+    REC --> OUT["Verdict + evidence-coverage table + capability report"]
+```
+
+Three consequences fall out of this shape, all by design:
+
+- The pack is a **sidecar**. `dump --evidence` stores only a content-addressed
+  *reference* on the snapshot; the pack directory stays out-of-band, and
+  `compare` does **not** follow that reference — you hand the packs in explicitly
+  with `--old-evidence` / `--new-evidence`.
+- Collection is **post-build and read-only**: it reads existing build outputs and
+  build-system query interfaces; it never rebuilds your project or runs arbitrary
+  commands.
+- The verdict is only as strong as the evidence behind it, so every pack-aware
+  run prints the `evidence_coverage` table and the capability report below.
+
 ## Workflow
 
 The default path is unchanged. Evidence is **post-build and opt-in** — it never
@@ -184,6 +233,48 @@ decides or suppresses an artifact-proven ABI break.
   (`-frecord-gcc-switches` / `-frecord-command-line`) and DWARF
   `DW_AT_producer`. These signals are **advisory** unless cross-checked against
   build-system evidence.
+
+### Worked example: a CMake library, end to end
+
+Two releases of `libfoo`, each built with CMake. The goal is a full
+**L0+L1+L2+L3(+L4)** compare so a build-flag change or a source-only API change
+is caught alongside the binary diff.
+
+```bash
+# --- For EACH release (old and new), at build time ---
+# 1. Build with -g and export the compile database (one extra CMake flag).
+cmake -S libfoo-1.0 -B build-old -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build build-old
+
+# 2. Collect the evidence pack from the existing build tree (no rebuild).
+#    Add --source-abi for L4 (needs clang); drop it for L3-only.
+abicheck collect-evidence \
+    --compile-db build-old/compile_commands.json \
+    --build-dir build-old --cmake \
+    --source-abi \
+    --output libfoo-1.0.evidence/
+
+# 3. Snapshot the built library WITH headers and the build context.
+#    -p bakes the L3 build flags into how the headers are parsed, and records
+#    parsed_with_build_context so the later compare won't flag header drift.
+abicheck dump build-old/libfoo.so -H libfoo-1.0/include -p build-old \
+    --version 1.0 -o libfoo-1.0.abi.json
+
+# (repeat steps 1-3 for the new release → libfoo-2.0.abi.json + libfoo-2.0.evidence/)
+
+# --- At compare time (CI), pass BOTH snapshots AND both packs ---
+abicheck compare libfoo-1.0.abi.json libfoo-2.0.abi.json \
+    --old-evidence libfoo-1.0.evidence/ \
+    --new-evidence libfoo-2.0.evidence/
+```
+
+The compare prints the [coverage table and capability report](#evidence-coverage)
+first, so you can confirm every layer landed before trusting the verdict — if a
+row says `not_collected` or `[off]`, that is exactly the input or tool to add.
+Keep the `*.evidence/` directories next to the snapshots (e.g. as CI artifacts):
+the snapshot only stores a reference, so a compare without the packs silently
+drops the L3/L4 findings.
 
 ## External CLI extractors & the security model (ADR-032)
 

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -192,6 +192,14 @@ This combination gives you all three tiers at once:
   `final`, access, ref-qualifiers, `noexcept`/`explicit`, **default-argument
   values**, and **`const`/`constexpr` constant values** (which have no symbol).
 
+These three artifact tiers are layers **L0–L2** of the [five-source evidence
+model](evidence-and-detectability.md). Two further layers refine the result
+without ever overriding an artifact-proven break: **L3** build context
+(`-p build/`, the exact ABI-affecting flags) and **L4** source/evidence packs
+(`--old-evidence`/`--new-evidence`, recovering macro/`constexpr` and
+uninstantiated-template facts). They are optional but raise confidence and
+localize findings — see [Source & Build Evidence Packs](evidence-pack.md).
+
 Comparing a **stripped release binary with no headers** gives only `elf_only`
 coverage (symbol add/remove) and will silently miss every layout and
 source-level break above. If you ship stripped, build a **debug copy purely as an

--- a/docs/development/abicc-parity-status.md
+++ b/docs/development/abicc-parity-status.md
@@ -1,6 +1,6 @@
 # ABI Checker Gap Analysis — abicheck vs ABICC vs libabigail
 
-> Generated: 2026-03-09; content reviewed 2026-06-07. The scenario matrix is a historical ABICC/libabigail parity snapshot; the current ChangeKind total is **222** — see the [Change Kind Reference](../reference/change-kinds.md) for the authoritative list.
+> Generated: 2026-03-09; content reviewed 2026-06-07. The scenario matrix is a historical ABICC/libabigail parity snapshot; the current ChangeKind total is **230** — see the [Change Kind Reference](../reference/change-kinds.md) for the authoritative list.
 > abicheck version: HEAD of `napetrov/abicheck`  
 > Compared against: ABICC (lvc/abi-compliance-checker) + libabigail (abidiff/abidw)
 
@@ -11,7 +11,7 @@
 - **abicheck covers:** ~55/55 de-duplicated ABI break scenarios (~100%) after recent releases
 - **Key differentiator:** abicheck uses multi-tier analysis (castxml headers + ELF symbols + DWARF layout) -- works on **release builds** with headers + `.so`, no debug symbols required for core checks. ABICC needs GCC `-fdump-lang-spec`, abidiff needs DWARF debug info.
 - **Closed gaps:** All original P0/P1/P2 scenarios are now detected, including enum rename, field/param rename, field qualifiers (const/volatile/mutable), pointer level changes, access level changes, param default value tracking, and anonymous struct/union fields.
-- **Coverage: exceeds ABICC** — the original ABICC-equivalent matrix remains covered, and the full current catalog has grown to 222 ChangeKinds.
+- **Coverage: exceeds ABICC** — the original ABICC-equivalent matrix remains covered, and the full current catalog has grown to 230 ChangeKinds.
 - **Test coverage:** ChangeKind assertion coverage is enforced by `tests/test_changekind_completeness.py`; parity and example coverage now live in the expanded `tests/` and `examples/` suites.
 
 > Note: ABICC has 90+ rules total, but many are sub-rules of the same scenario. The 55-row coverage table below is the expanded scenario count for the current implementation.

--- a/docs/development/abicc-parity-status.md
+++ b/docs/development/abicc-parity-status.md
@@ -1,6 +1,6 @@
 # ABI Checker Gap Analysis — abicheck vs ABICC vs libabigail
 
-> Generated: 2026-03-09; content reviewed 2026-06-07. The scenario matrix is a historical ABICC/libabigail parity snapshot; the current ChangeKind total is **192** — see the [Change Kind Reference](../reference/change-kinds.md) for the authoritative list.
+> Generated: 2026-03-09; content reviewed 2026-06-07. The scenario matrix is a historical ABICC/libabigail parity snapshot; the current ChangeKind total is **222** — see the [Change Kind Reference](../reference/change-kinds.md) for the authoritative list.
 > abicheck version: HEAD of `napetrov/abicheck`  
 > Compared against: ABICC (lvc/abi-compliance-checker) + libabigail (abidiff/abidw)
 
@@ -11,7 +11,7 @@
 - **abicheck covers:** ~55/55 de-duplicated ABI break scenarios (~100%) after recent releases
 - **Key differentiator:** abicheck uses multi-tier analysis (castxml headers + ELF symbols + DWARF layout) -- works on **release builds** with headers + `.so`, no debug symbols required for core checks. ABICC needs GCC `-fdump-lang-spec`, abidiff needs DWARF debug info.
 - **Closed gaps:** All original P0/P1/P2 scenarios are now detected, including enum rename, field/param rename, field qualifiers (const/volatile/mutable), pointer level changes, access level changes, param default value tracking, and anonymous struct/union fields.
-- **Coverage: exceeds ABICC** — the original ABICC-equivalent matrix remains covered, and the full current catalog has grown to 192 ChangeKinds.
+- **Coverage: exceeds ABICC** — the original ABICC-equivalent matrix remains covered, and the full current catalog has grown to 222 ChangeKinds.
 - **Test coverage:** ChangeKind assertion coverage is enforced by `tests/test_changekind_completeness.py`; parity and example coverage now live in the expanded `tests/` and `examples/` suites.
 
 > Note: ABICC has 90+ rules total, but many are sub-rules of the same scenario. The 55-row coverage table below is the expanded scenario count for the current implementation.

--- a/docs/development/abicc-parity-status.md
+++ b/docs/development/abicc-parity-status.md
@@ -1,6 +1,6 @@
 # ABI Checker Gap Analysis — abicheck vs ABICC vs libabigail
 
-> Generated: 2026-03-09; content reviewed 2026-06-07. The scenario matrix is a historical ABICC/libabigail parity snapshot; the current ChangeKind total is **230** — see the [Change Kind Reference](../reference/change-kinds.md) for the authoritative list.
+> Generated: 2026-03-09; content reviewed 2026-06-07. The scenario matrix is a historical ABICC/libabigail parity snapshot; the current ChangeKind total is **234** — see the [Change Kind Reference](../reference/change-kinds.md) for the authoritative list.
 > abicheck version: HEAD of `napetrov/abicheck`  
 > Compared against: ABICC (lvc/abi-compliance-checker) + libabigail (abidiff/abidw)
 
@@ -11,7 +11,7 @@
 - **abicheck covers:** ~55/55 de-duplicated ABI break scenarios (~100%) after recent releases
 - **Key differentiator:** abicheck uses multi-tier analysis (castxml headers + ELF symbols + DWARF layout) -- works on **release builds** with headers + `.so`, no debug symbols required for core checks. ABICC needs GCC `-fdump-lang-spec`, abidiff needs DWARF debug info.
 - **Closed gaps:** All original P0/P1/P2 scenarios are now detected, including enum rename, field/param rename, field qualifiers (const/volatile/mutable), pointer level changes, access level changes, param default value tracking, and anonymous struct/union fields.
-- **Coverage: exceeds ABICC** — the original ABICC-equivalent matrix remains covered, and the full current catalog has grown to 230 ChangeKinds.
+- **Coverage: exceeds ABICC** — the original ABICC-equivalent matrix remains covered, and the full current catalog has grown to 234 ChangeKinds.
 - **Test coverage:** ChangeKind assertion coverage is enforced by `tests/test_changekind_completeness.py`; parity and example coverage now live in the expanded `tests/` and `examples/` suites.
 
 > Note: ABICC has 90+ rules total, but many are sub-rules of the same scenario. The 55-row coverage table below is the expanded scenario count for the current implementation.

--- a/docs/development/abicc-test-coverage-comparison.md
+++ b/docs/development/abicc-test-coverage-comparison.md
@@ -1,8 +1,8 @@
 # ABICC vs Abicheck: Test Coverage Comparison
 
-> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **222**, see the [Change Kind Reference](../reference/change-kinds.md).
+> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **230**, see the [Change Kind Reference](../reference/change-kinds.md).
 > Source: ABICC `RulesBin.xml` (196 rules), `RulesSrc.xml` (100 rules + `Removed_Const_Overload`), `RegTests.pm` (~153 C++ + ~102 C named scenarios)
-> Target: abicheck `examples/` (126 cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**222 kinds** today; the per-rule mappings below were written against an earlier snapshot)
+> Target: abicheck `examples/` (126 cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**230 kinds** today; the per-rule mappings below were written against an earlier snapshot)
 >
 > **Analysis modes:** Abicheck uses **both** header comparison (via castxml) **and** binary analysis (ELF/DWARF).
 > The `dump()` function combines castxml header parsing (types, functions, enums, typedefs, constants) with
@@ -22,7 +22,7 @@
 | ABICC RegTests.pm named scenarios | ~255 (~153 C++ + ~102 C) |
 | ABICC de-duplicated scenarios | ~66 |
 | **Abicheck covers (has ChangeKind + tests)** | **66/66 (100%)** |
-| Abicheck ChangeKind enum members | **222** (this table's per-rule mappings reflect an earlier snapshot) |
+| Abicheck ChangeKind enum members | **230** (this table's per-rule mappings reflect an earlier snapshot) |
 | All ChangeKinds have assertion tests | **Yes** (enforced by `test_changekind_completeness.py`) |
 | Abicheck example cases | 126 |
 | ABICC scenarios NOT in abicheck | **0** |
@@ -373,6 +373,6 @@ These detectors exist in abicheck but have no ABICC equivalent:
 
 **0 remaining gaps.** All ABICC de-duplicated detection scenarios are covered by abicheck with dedicated ChangeKinds and explicit assertion tests, including the `TypedefToFunction` scenario (covered in `test_changekind_completeness.py`).
 
-**All ChangeKinds (222 today) have assertion-level test coverage**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
+**All ChangeKinds (230 today) have assertion-level test coverage**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
 
 **Inline function scenarios (4):** `RemovedInlineMethod`, `removedInlineFunction`, `functionBecameInline`, `RemovedInlineVirtualFunction` — these ABICC scenarios detect inline function removal via header comparison. In abicheck, inline functions declared in headers are parsed by castxml but filtered against ELF `.dynsym` (inline functions have no exported symbol). If headers are provided, castxml captures the declaration; detection depends on whether the symbol was previously exported. Virtual inline function removal is still detected via vtable changes (`TYPE_VTABLE_CHANGED`). These are classified as **edge cases** rather than gaps, since the typical ABI contract concerns exported symbols.

--- a/docs/development/abicc-test-coverage-comparison.md
+++ b/docs/development/abicc-test-coverage-comparison.md
@@ -1,8 +1,8 @@
 # ABICC vs Abicheck: Test Coverage Comparison
 
-> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **192**, see the [Change Kind Reference](../reference/change-kinds.md).
+> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **222**, see the [Change Kind Reference](../reference/change-kinds.md).
 > Source: ABICC `RulesBin.xml` (196 rules), `RulesSrc.xml` (100 rules + `Removed_Const_Overload`), `RegTests.pm` (~153 C++ + ~102 C named scenarios)
-> Target: abicheck `examples/` (126 cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**192 kinds** today; the per-rule mappings below were written against an earlier snapshot)
+> Target: abicheck `examples/` (126 cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**222 kinds** today; the per-rule mappings below were written against an earlier snapshot)
 >
 > **Analysis modes:** Abicheck uses **both** header comparison (via castxml) **and** binary analysis (ELF/DWARF).
 > The `dump()` function combines castxml header parsing (types, functions, enums, typedefs, constants) with
@@ -22,7 +22,7 @@
 | ABICC RegTests.pm named scenarios | ~255 (~153 C++ + ~102 C) |
 | ABICC de-duplicated scenarios | ~66 |
 | **Abicheck covers (has ChangeKind + tests)** | **66/66 (100%)** |
-| Abicheck ChangeKind enum members | **192** (this table's per-rule mappings reflect an earlier snapshot) |
+| Abicheck ChangeKind enum members | **222** (this table's per-rule mappings reflect an earlier snapshot) |
 | All ChangeKinds have assertion tests | **Yes** (enforced by `test_changekind_completeness.py`) |
 | Abicheck example cases | 126 |
 | ABICC scenarios NOT in abicheck | **0** |
@@ -373,6 +373,6 @@ These detectors exist in abicheck but have no ABICC equivalent:
 
 **0 remaining gaps.** All ABICC de-duplicated detection scenarios are covered by abicheck with dedicated ChangeKinds and explicit assertion tests, including the `TypedefToFunction` scenario (covered in `test_changekind_completeness.py`).
 
-**All ChangeKinds (192 today) have assertion-level test coverage**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
+**All ChangeKinds (222 today) have assertion-level test coverage**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
 
 **Inline function scenarios (4):** `RemovedInlineMethod`, `removedInlineFunction`, `functionBecameInline`, `RemovedInlineVirtualFunction` — these ABICC scenarios detect inline function removal via header comparison. In abicheck, inline functions declared in headers are parsed by castxml but filtered against ELF `.dynsym` (inline functions have no exported symbol). If headers are provided, castxml captures the declaration; detection depends on whether the symbol was previously exported. Virtual inline function removal is still detected via vtable changes (`TYPE_VTABLE_CHANGED`). These are classified as **edge cases** rather than gaps, since the typical ABI contract concerns exported symbols.

--- a/docs/development/abicc-test-coverage-comparison.md
+++ b/docs/development/abicc-test-coverage-comparison.md
@@ -1,8 +1,8 @@
 # ABICC vs Abicheck: Test Coverage Comparison
 
-> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **230**, see the [Change Kind Reference](../reference/change-kinds.md).
+> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **234**, see the [Change Kind Reference](../reference/change-kinds.md).
 > Source: ABICC `RulesBin.xml` (196 rules), `RulesSrc.xml` (100 rules + `Removed_Const_Overload`), `RegTests.pm` (~153 C++ + ~102 C named scenarios)
-> Target: abicheck `examples/` (126 cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**230 kinds** today; the per-rule mappings below were written against an earlier snapshot)
+> Target: abicheck `examples/` (127 cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**234 kinds** today; the per-rule mappings below were written against an earlier snapshot)
 >
 > **Analysis modes:** Abicheck uses **both** header comparison (via castxml) **and** binary analysis (ELF/DWARF).
 > The `dump()` function combines castxml header parsing (types, functions, enums, typedefs, constants) with
@@ -22,9 +22,9 @@
 | ABICC RegTests.pm named scenarios | ~255 (~153 C++ + ~102 C) |
 | ABICC de-duplicated scenarios | ~66 |
 | **Abicheck covers (has ChangeKind + tests)** | **66/66 (100%)** |
-| Abicheck ChangeKind enum members | **230** (this table's per-rule mappings reflect an earlier snapshot) |
+| Abicheck ChangeKind enum members | **234** (this table's per-rule mappings reflect an earlier snapshot) |
 | All ChangeKinds have assertion tests | **Yes** (enforced by `test_changekind_completeness.py`) |
-| Abicheck example cases | 126 |
+| Abicheck example cases | 127 |
 | ABICC scenarios NOT in abicheck | **0** |
 
 ---
@@ -373,6 +373,6 @@ These detectors exist in abicheck but have no ABICC equivalent:
 
 **0 remaining gaps.** All ABICC de-duplicated detection scenarios are covered by abicheck with dedicated ChangeKinds and explicit assertion tests, including the `TypedefToFunction` scenario (covered in `test_changekind_completeness.py`).
 
-**All ChangeKinds (230 today) have assertion-level test coverage**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
+**All ChangeKinds (234 today) have assertion-level test coverage**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
 
 **Inline function scenarios (4):** `RemovedInlineMethod`, `removedInlineFunction`, `functionBecameInline`, `RemovedInlineVirtualFunction` — these ABICC scenarios detect inline function removal via header comparison. In abicheck, inline functions declared in headers are parsed by castxml but filtered against ELF `.dynsym` (inline functions have no exported symbol). If headers are provided, castxml captures the declaration; detection depends on whether the symbol was previously exported. Virtual inline function removal is still detected via vtable changes (`TYPE_VTABLE_CHANGED`). These are classified as **edge cases** rather than gaps, since the typical ABI contract concerns exported symbols.

--- a/docs/development/goals.md
+++ b/docs/development/goals.md
@@ -15,7 +15,7 @@ Support everything ABICC currently does so existing users and pipelines can migr
 - JSON/HTML/Markdown reports with equivalent verdict semantics
 - Support for suppression files
 
-**Done:** 222 ChangeKinds implemented; YAML suppression files fully supported; ABICC compat CLI supports `-symbols-list` and `-types-list` whitelist flags (plain-text, one name per line); XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags; auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
+**Done:** 230 ChangeKinds implemented; YAML suppression files fully supported; ABICC compat CLI supports `-symbols-list` and `-types-list` whitelist flags (plain-text, one name per line); XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags; auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
 
 ---
 
@@ -105,7 +105,7 @@ Public documentation at <https://napetrov.github.io/abicheck/>:
 
 | Goal | Status |
 |------|--------|
-| G1: ABICC drop-in | Done — 222 ChangeKinds, compat CLI, suppression files, XML reports |
+| G1: ABICC drop-in | Done — 230 ChangeKinds, compat CLI, suppression files, XML reports |
 | G2: Known gaps | DWARF layout, toolchain flags, AST-DWARF dedup, confidence tracking, canonical evidence tier (ELF_ONLY/DWARF_AWARE/HEADER_AWARE) done |
 | G3: libabigail tests | Done — ~54 parity test functions + 126 example cases |
 | G4: Agent-friendly | Done — JSON, SARIF, exit codes, snapshots, MCP server, GitHub Action |

--- a/docs/development/goals.md
+++ b/docs/development/goals.md
@@ -15,7 +15,7 @@ Support everything ABICC currently does so existing users and pipelines can migr
 - JSON/HTML/Markdown reports with equivalent verdict semantics
 - Support for suppression files
 
-**Done:** 192 ChangeKinds implemented; YAML suppression files fully supported; ABICC compat CLI supports `-symbols-list` and `-types-list` whitelist flags (plain-text, one name per line); XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags; auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
+**Done:** 222 ChangeKinds implemented; YAML suppression files fully supported; ABICC compat CLI supports `-symbols-list` and `-types-list` whitelist flags (plain-text, one name per line); XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags; auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
 
 ---
 
@@ -105,7 +105,7 @@ Public documentation at <https://napetrov.github.io/abicheck/>:
 
 | Goal | Status |
 |------|--------|
-| G1: ABICC drop-in | Done — 192 ChangeKinds, compat CLI, suppression files, XML reports |
+| G1: ABICC drop-in | Done — 222 ChangeKinds, compat CLI, suppression files, XML reports |
 | G2: Known gaps | DWARF layout, toolchain flags, AST-DWARF dedup, confidence tracking, canonical evidence tier (ELF_ONLY/DWARF_AWARE/HEADER_AWARE) done |
 | G3: libabigail tests | Done — ~54 parity test functions + 126 example cases |
 | G4: Agent-friendly | Done — JSON, SARIF, exit codes, snapshots, MCP server, GitHub Action |

--- a/docs/development/goals.md
+++ b/docs/development/goals.md
@@ -15,7 +15,7 @@ Support everything ABICC currently does so existing users and pipelines can migr
 - JSON/HTML/Markdown reports with equivalent verdict semantics
 - Support for suppression files
 
-**Done:** 230 ChangeKinds implemented; YAML suppression files fully supported; ABICC compat CLI supports `-symbols-list` and `-types-list` whitelist flags (plain-text, one name per line); XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags; auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
+**Done:** 234 ChangeKinds implemented; YAML suppression files fully supported; ABICC compat CLI supports `-symbols-list` and `-types-list` whitelist flags (plain-text, one name per line); XML report generation for ABICC-compatible output; ABICC compat CLI with all major flags; auto-forwarding `abicheck compat <flags>` to `compat check`; test parity for ABICC 2.3.
 
 ---
 
@@ -105,7 +105,7 @@ Public documentation at <https://napetrov.github.io/abicheck/>:
 
 | Goal | Status |
 |------|--------|
-| G1: ABICC drop-in | Done — 230 ChangeKinds, compat CLI, suppression files, XML reports |
+| G1: ABICC drop-in | Done — 234 ChangeKinds, compat CLI, suppression files, XML reports |
 | G2: Known gaps | DWARF layout, toolchain flags, AST-DWARF dedup, confidence tracking, canonical evidence tier (ELF_ONLY/DWARF_AWARE/HEADER_AWARE) done |
 | G3: libabigail tests | Done — ~54 parity test functions + 126 example cases |
 | G4: Agent-friendly | Done — JSON, SARIF, exit codes, snapshots, MCP server, GitHub Action |

--- a/docs/development/report-comparison.md
+++ b/docs/development/report-comparison.md
@@ -94,7 +94,7 @@ struct Point — 2 changes:
 
 | Information                     | abicheck | ABICC | abidiff |
 |---------------------------------|----------|-------|---------|
-| Change kind/type classification | `type_size_changed` (machine-parseable enum, 222 values) | Narrative text only | Narrative text |
+| Change kind/type classification | `type_size_changed` (machine-parseable enum, 230 values) | Narrative text only | Narrative text |
 | Affected symbol/type name       | Yes (`"symbol": "Leaf"`) | Yes (in HTML sections) | Yes (as context for function) |
 | Old value                       | Yes (`"old_value": "32"`) | Yes (in text) | Yes (in text) |
 | New value                       | Yes (`"new_value": "64"`) | Yes (in text) | Yes (in text) |

--- a/docs/development/report-comparison.md
+++ b/docs/development/report-comparison.md
@@ -94,7 +94,7 @@ struct Point — 2 changes:
 
 | Information                     | abicheck | ABICC | abidiff |
 |---------------------------------|----------|-------|---------|
-| Change kind/type classification | `type_size_changed` (machine-parseable enum, 192 values) | Narrative text only | Narrative text |
+| Change kind/type classification | `type_size_changed` (machine-parseable enum, 222 values) | Narrative text only | Narrative text |
 | Affected symbol/type name       | Yes (`"symbol": "Leaf"`) | Yes (in HTML sections) | Yes (as context for function) |
 | Old value                       | Yes (`"old_value": "32"`) | Yes (in text) | Yes (in text) |
 | New value                       | Yes (`"new_value": "64"`) | Yes (in text) | Yes (in text) |

--- a/docs/development/report-comparison.md
+++ b/docs/development/report-comparison.md
@@ -94,7 +94,7 @@ struct Point — 2 changes:
 
 | Information                     | abicheck | ABICC | abidiff |
 |---------------------------------|----------|-------|---------|
-| Change kind/type classification | `type_size_changed` (machine-parseable enum, 230 values) | Narrative text only | Narrative text |
+| Change kind/type classification | `type_size_changed` (machine-parseable enum, 234 values) | Narrative text only | Narrative text |
 | Affected symbol/type name       | Yes (`"symbol": "Leaf"`) | Yes (in HTML sections) | Yes (as context for function) |
 | Old value                       | Yes (`"old_value": "32"`) | Yes (in text) | Yes (in text) |
 | New value                       | Yes (`"new_value": "64"`) | Yes (in text) | Yes (in text) |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -21,7 +21,7 @@ map across all three.
 ## Headline
 
 abicheck is **exceptionally deep on the change-taxonomy axis and comparatively
-thin on the breadth axes.** The "what changed" dimension — **222 `ChangeKind`s**
+thin on the breadth axes.** The "what changed" dimension — **230 `ChangeKind`s**
 in a 5-tier policy model, **126 calibrated example cases**, ABICC + libabigail
 parity — is essentially complete and has diminishing returns.
 
@@ -67,7 +67,7 @@ A real invocation is a point in this space:
 
 | Use case | Status | Notes |
 |---|---|---|
-| Change taxonomy | `complete` | 222 kinds; 126 cases; parity tests |
+| Change taxonomy | `complete` | 230 kinds; 126 cases; parity tests |
 | **Release recommendation (semver + SONAME)** | `complete` | semver bump + SONAME action emitted in reports |
 | C / C++ archetypes | `complete` | 35 C + 52 C++ example pairs |
 | Linux ELF platform | `complete` | the CI-validated baseline |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -21,7 +21,7 @@ map across all three.
 ## Headline
 
 abicheck is **exceptionally deep on the change-taxonomy axis and comparatively
-thin on the breadth axes.** The "what changed" dimension — **192 `ChangeKind`s**
+thin on the breadth axes.** The "what changed" dimension — **222 `ChangeKind`s**
 in a 5-tier policy model, **126 calibrated example cases**, ABICC + libabigail
 parity — is essentially complete and has diminishing returns.
 
@@ -67,7 +67,7 @@ A real invocation is a point in this space:
 
 | Use case | Status | Notes |
 |---|---|---|
-| Change taxonomy | `complete` | 192 kinds; 126 cases; parity tests |
+| Change taxonomy | `complete` | 222 kinds; 126 cases; parity tests |
 | **Release recommendation (semver + SONAME)** | `complete` | semver bump + SONAME action emitted in reports |
 | C / C++ archetypes | `complete` | 35 C + 52 C++ example pairs |
 | Linux ELF platform | `complete` | the CI-validated baseline |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -21,7 +21,7 @@ map across all three.
 ## Headline
 
 abicheck is **exceptionally deep on the change-taxonomy axis and comparatively
-thin on the breadth axes.** The "what changed" dimension — **230 `ChangeKind`s**
+thin on the breadth axes.** The "what changed" dimension — **234 `ChangeKind`s**
 in a 5-tier policy model, **126 calibrated example cases**, ABICC + libabigail
 parity — is essentially complete and has diminishing returns.
 
@@ -67,7 +67,7 @@ A real invocation is a point in this space:
 
 | Use case | Status | Notes |
 |---|---|---|
-| Change taxonomy | `complete` | 230 kinds; 126 cases; parity tests |
+| Change taxonomy | `complete` | 234 kinds; 127 cases; parity tests |
 | **Release recommendation (semver + SONAME)** | `complete` | semver bump + SONAME action emitted in reports |
 | C / C++ archetypes | `complete` | 35 C + 52 C++ example pairs |
 | Linux ELF platform | `complete` | the CI-validated baseline |

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -29,7 +29,7 @@ use_cases:
   # ── change_class ──────────────────────────────────────────────────────────
   - id: UC-CHANGE-taxonomy
     axis: change_class
-    name: ABI/API change taxonomy (192 ChangeKinds, 5-tier policy)
+    name: ABI/API change taxonomy (222 ChangeKinds, 5-tier policy)
     status: complete
     evidence:
       modules: [abicheck/change_registry.py, abicheck/checker_policy.py]

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -29,7 +29,7 @@ use_cases:
   # ── change_class ──────────────────────────────────────────────────────────
   - id: UC-CHANGE-taxonomy
     axis: change_class
-    name: ABI/API change taxonomy (222 ChangeKinds, 5-tier policy)
+    name: ABI/API change taxonomy (230 ChangeKinds, 5-tier policy)
     status: complete
     evidence:
       modules: [abicheck/change_registry.py, abicheck/checker_policy.py]

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -29,7 +29,7 @@ use_cases:
   # ── change_class ──────────────────────────────────────────────────────────
   - id: UC-CHANGE-taxonomy
     axis: change_class
-    name: ABI/API change taxonomy (230 ChangeKinds, 5-tier policy)
+    name: ABI/API change taxonomy (234 ChangeKinds, 5-tier policy)
     status: complete
     evidence:
       modules: [abicheck/change_registry.py, abicheck/checker_policy.py]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,7 +114,7 @@ If you're unsure, start with `abicheck compare` — it's the default workflow.
 
 **Best first run:** compare two shared libraries with their public headers — it
 gives abicheck the most evidence to work with (see the
-[input-quality ladder](#input-quality-what-each-tier-catches) below).
+[input-quality ladder](#input-quality-the-five-evidence-layers-l0l4) below).
 
 The repo includes 127 ABI scenario examples. Most are single-library cases with
 paired `v1`/`v2` sources and headers; bundle/release-level cases use
@@ -169,25 +169,37 @@ abicheck compare libfoo.so.1 libfoo.so.2 -H include/
 If no headers are provided for ELF inputs, abicheck falls back to **symbols-only** mode
 and prints a warning (weaker analysis: may miss type/signature ABI breaks).
 
-### Input quality: what each tier catches
+### Input quality: the five evidence layers (L0–L4)
 
-How much abicheck can *prove* depends on what you give it. More evidence catches
-more breaks — start at the tier your artifacts allow and add headers + debug info
+How much abicheck can *prove* depends on what you give it. It overlays up to
+**five independent, additive sources** — labelled `L0`–`L4` — and lets the
+strongest evidence win. Start at the layer your artifacts allow and add more
 when you need more confidence:
 
-| Inputs | Confidence | What it catches |
-|---|---|---|
-| Binaries only | **Low** | Symbol add/remove, basic metadata |
-| Binaries + debug info | **Medium** | Layout, enum, calling convention, emitted ABI |
-| Binaries + headers | **High** | Public API surface, source-level API, inline/template surface |
-| Binaries + debug info + headers + build flags | **Best** | The most accurate practical setup |
+| Layer | Inputs (flags) | Confidence | What it newly catches |
+|:--:|---|---|---|
+| **L0** | Binary only | **Low** | Symbol add/remove, SONAME, visibility, basic metadata |
+| **L1** | + debug info (`-g` build / sidecar) | **Medium** | Struct/class layout, field offsets, enum *values*, vtable slots, calling convention |
+| **L2** | + headers (`-H include/`) | **High** | Public API surface: signatures, overloads, access, `noexcept`, templates, public/internal scoping |
+| **L3** | + build data (`-p build/`) | **Higher** | The flags the library was *actually* built with: `-std`, `_GLIBCXX_USE_CXX11_ABI`, `-fvisibility`, sysroot, export maps |
+| **L4** | + sources (`--evidence pack/`) | **Best** | Facts that never reach the binary: macro/`constexpr` values, default-argument *values*, uninstantiated templates |
 
-This is why the header flags matter. The
-[ABI/API Handling overview](concepts/abi-api-handling.md) explains the full
-picture: debug info **plus** headers is the highest-coverage setup, while
-stripped binaries without headers only give symbol-level coverage. For stripped
-production builds, point abicheck at separate debug files (`--debug-root1/2`) or
-fetch them with `--debuginfod` — see
+The layers are **additive, not a fallback chain**: artifact-backed evidence
+(L0/L1/L2) is authoritative for the shipped-ABI verdict, while build/source
+evidence (L3/L4) *explains, localizes, and scopes* a finding (and can raise its
+own source-level findings) but never silently deletes an artifact-proven break.
+With less input, abicheck degrades gracefully *down the staircase* rather than
+failing — a stripped binary with no headers collapses toward symbol-only
+checking.
+
+Run `abicheck dump libfoo.so --show-data-sources` to see which layers abicheck
+found for a binary. For the full picture see [Evidence &
+Detectability](concepts/evidence-and-detectability.md) and the per-layer
+[Tool Modes](user-guide/tool-modes.md#abicheck-native-modes-by-evidence-source-l0l4)
+reference; build data (L3) and source evidence packs (L4) are documented under
+[CLI Usage → Evidence packs](user-guide/cli-usage.md#evidence-packs-build-source-context-l3-l4).
+For stripped production builds, point abicheck at separate debug files
+(`--debug-root1/2`) or fetch them with `--debuginfod` — see
 [CLI Usage](user-guide/cli-usage.md#debug-artifact-resolution).
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,7 +182,7 @@ when you need more confidence:
 | **L1** | + debug info (`-g` build / sidecar) | **Medium** | Struct/class layout, field offsets, enum *values*, vtable slots, calling convention |
 | **L2** | + headers (`-H include/`) | **High** | Public API surface: signatures, overloads, access, `noexcept`, templates, public/internal scoping |
 | **L3** | + build data (`-p build/`) | **Higher** | The flags the library was *actually* built with: `-std`, `_GLIBCXX_USE_CXX11_ABI`, `-fvisibility`, sysroot, export maps |
-| **L4** | + sources (`--evidence pack/`) | **Best** | Facts that never reach the binary: macro/`constexpr` values, default-argument *values*, uninstantiated templates |
+| **L4** | + sources (evidence pack via `compare --old-evidence/--new-evidence`) | **Best** | Facts that never reach the binary: macro/`constexpr` values, default-argument *values*, uninstantiated templates |
 
 The layers are **additive, not a fallback chain**: artifact-backed evidence
 (L0/L1/L2) is authoritative for the shipped-ABI verdict, while build/source

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 ## Why abicheck
 
 - **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
-- **232 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
+- **234 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.
 - **ABICC drop-in** — full flag parity for migrating from `abi-compliance-checker`.

--- a/docs/user-guide/choose-your-workflow.md
+++ b/docs/user-guide/choose-your-workflow.md
@@ -45,22 +45,28 @@ behave**, and **which report** to produce.
 ## 2) How much accuracy do you need?
 
 The single biggest lever on what abicheck can *prove* is the quality of the
-inputs you give it. More evidence catches more breaks. Start at the tier your
-artifacts allow, and add headers + debug info when you need more confidence.
+inputs you give it — its five additive evidence layers, **L0–L4**. More
+evidence catches more breaks. Start at the layer your artifacts allow, and add
+more when you need more confidence.
 
-| Inputs | Confidence | What it catches |
-|---|---|---|
-| Binaries only | **Low** | Symbol add/remove, SONAME/version changes, basic metadata |
-| Binaries + debug info | **Medium** | The above, plus struct layout, enum values, calling convention, emitted-ABI type changes |
-| Binaries + headers | **High** | The above, plus the declared public API surface, source-level API breaks, inline/template-related surface |
-| Binaries + debug info + headers + build flags | **Best** | The most accurate practical setup — the full public + emitted ABI surface |
+| Layer | Inputs | Confidence | What it newly catches |
+|:--:|---|---|---|
+| **L0** | Binaries only | **Low** | Symbol add/remove, SONAME/version changes, basic metadata |
+| **L1** | + debug info | **Medium** | Struct layout, field offsets, enum values, calling convention, emitted-ABI type changes |
+| **L2** | + headers | **High** | Declared public API surface, source-level API breaks, inline/template-related surface |
+| **L3** | + build flags (`-p build/`) | **Higher** | The exact ABI-affecting flags the library was built with (`-std`, `_GLIBCXX_USE_CXX11_ABI`, `-fvisibility`, …) |
+| **L4** | + sources (evidence pack) | **Best** | Facts that never reach the binary: macro/`constexpr` values, default-argument values, uninstantiated templates |
 
-abicheck reports which tier it actually used as the **`evidence_tier`** field
-(`elf_only` → `dwarf_aware` → `header_aware`) so you can calibrate trust in any
-given run. See [Output Formats → Analysis confidence and evidence
-tier](output-formats.md#analysis-confidence-and-evidence-tier) and the
-[ABI/API Handling overview](../concepts/abi-api-handling.md) for the full
-explanation of why headers and debug info change what abicheck can prove.
+abicheck reports the **artifact** depth it reached (L0–L2) as the
+**`evidence_tier`** field (`elf_only` → `dwarf_aware` → `header_aware`) so you
+can calibrate trust in any given run; build/source evidence (L3/L4) is reported
+separately in the evidence-coverage table rather than promoting this scalar. See
+[Output Formats → Analysis confidence and evidence
+tier](output-formats.md#analysis-confidence-and-evidence-tier), the per-layer
+[Tool Modes](tool-modes.md#abicheck-native-modes-by-evidence-source-l0l4)
+reference, and [Evidence &
+Detectability](../concepts/evidence-and-detectability.md) for the full
+explanation of why each source changes what abicheck can prove.
 
 **Rules of thumb:**
 

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -106,11 +106,15 @@ Available cross-compilation flags:
 - `--sysroot` — alternative system root directory
 - `--nostdinc` — do not search standard system include paths
 
-#### Build-context capture (`compile_commands.json`)
+#### Build-context capture (`compile_commands.json`) — evidence layer L3
 
-Modern build systems (CMake, Meson, Ninja) generate a `compile_commands.json`
-file that captures the exact compiler flags for every source file. abicheck
-can ingest this file directly, eliminating manual flag specification:
+This is **evidence layer L3** in abicheck's [five-source evidence
+model](../concepts/evidence-and-detectability.md): on top of the binary (L0),
+debug info (L1), and headers (L2), it feeds abicheck the flags the library was
+*actually* built with. Modern build systems (CMake, Meson, Ninja) generate a
+`compile_commands.json` file that captures the exact compiler flags for every
+source file. abicheck can ingest this file directly, eliminating manual flag
+specification:
 
 ```bash
 # Generate compile_commands.json during build
@@ -139,6 +143,53 @@ explicit flags take precedence.
 abicheck dump libfoo.so -H include/ -p build/ \
     --gcc-options "-DEXTRA_DEFINE=1"
 ```
+
+#### Evidence packs — build & source context (L3 / L4)
+
+The build context above (L3) and **source evidence** (L4) can also be bundled
+into a reusable *evidence pack* — a post-build, opt-in artifact that abicheck
+reads alongside your binaries. A pack never rebuilds your project or runs
+arbitrary commands; it reads existing build outputs and build-system query
+interfaces only. Packs let L3/L4 evidence travel with a baseline snapshot or be
+diffed at compare time. See [Source & Build Evidence
+Packs](../concepts/evidence-pack.md) for the full model.
+
+```bash
+# 1. Collect a pack from an existing build tree (no rebuild).
+abicheck collect-evidence \
+    --compile-db build/compile_commands.json \
+    --build-dir build --cmake \
+    --output libfoo.evidence/
+
+# 2a. Attach it to a snapshot at dump time…
+abicheck dump build/libfoo.so -H include/ \
+    --evidence libfoo.evidence/ -o libfoo.abi.json
+
+# 2b. …or diff two packs at compare time.
+abicheck compare old.abi.json new.abi.json \
+    --old-evidence old.evidence/ --new-evidence new.evidence/
+```
+
+| Flag | Command | Description |
+|------|---------|-------------|
+| `--evidence <dir>` | `dump` | Attach an evidence pack to the snapshot (content-addressed ref) |
+| `--old-evidence <dir>` / `--new-evidence <dir>` | `compare` | Diff per-side packs into the verdict — adds L3 build-context findings and an evidence-coverage table |
+| `--evidence-mode <mode>` | `compare` | Inline collection mode (`off` by default; uses only the explicitly-provided packs) |
+
+To additionally capture **L4 source ABI replay** (macro/`constexpr` values,
+default-argument values, uninstantiated templates), add `--source-abi` to
+`collect-evidence`. L4 requires `clang` (or castxml for the declaration subset);
+if it is missing, abicheck **degrades gracefully** — L4 is marked partial and
+the artifact-backed tiers (L0–L2) remain fully authoritative. Build/source
+evidence (L3/L4) *explains, localizes, and scopes* findings or raises its own
+source-level findings, but it **never silently deletes an artifact-proven
+break** (the *authority rule*, ADR-028 D3).
+
+!!! tip "Diagnosing which layers you have"
+    Run `abicheck dump libfoo.so --show-data-sources` to print which evidence
+    layers (L0 binary metadata, L1 debug info, L2 header AST) abicheck found for
+    a binary, then exit — useful for confirming a stripped build really is
+    missing its debug info before you trust a symbols-only verdict.
 
 #### Debug artifact resolution
 

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -185,7 +185,7 @@ abicheck compare old.abi.json new.abi.json \
 |------|---------|-------------|
 | `--evidence <dir>` | `dump` | Record a content-addressed *reference* to a pack on the snapshot (the pack stays out-of-band; still pass it to `compare` to use its findings) |
 | `--old-evidence <dir>` / `--new-evidence <dir>` | `compare` | Load and diff per-side packs into the verdict — adds L3 build-context findings and an evidence-coverage table |
-| `--evidence-mode <mode>` | `compare` | Inline collection mode (`off` by default; uses only the explicitly-provided packs) |
+| `--evidence-mode <mode>` | `compare` | Inline collection mode. Defaults to `off`, which uses only the explicitly-provided `--old-evidence`/`--new-evidence` packs. **Other modes are currently recognized and reported in the coverage table but not yet collected inline** — pass packs explicitly to get L3/L4 findings in this release. |
 
 To additionally capture **L4 source ABI replay** (macro/`constexpr` values,
 default-argument values, uninstantiated templates), add `--source-abi` to

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -150,8 +150,7 @@ The build context above (L3) and **source evidence** (L4) can also be bundled
 into a reusable *evidence pack* — a post-build, opt-in artifact that abicheck
 reads alongside your binaries. A pack never rebuilds your project or runs
 arbitrary commands; it reads existing build outputs and build-system query
-interfaces only. Packs let L3/L4 evidence travel with a baseline snapshot or be
-diffed at compare time. See [Source & Build Evidence
+interfaces only. See [Source & Build Evidence
 Packs](../concepts/evidence-pack.md) for the full model.
 
 ```bash
@@ -161,19 +160,31 @@ abicheck collect-evidence \
     --build-dir build --cmake \
     --output libfoo.evidence/
 
-# 2a. Attach it to a snapshot at dump time…
+# 2a. Record a content-addressed reference to the pack on a snapshot…
+#     (the pack directory itself stays out-of-band — keep it around).
 abicheck dump build/libfoo.so -H include/ \
     --evidence libfoo.evidence/ -o libfoo.abi.json
 
-# 2b. …or diff two packs at compare time.
+# 2b. …and pass the pack directories explicitly at compare time to get
+#     their L3/L4 findings.
 abicheck compare old.abi.json new.abi.json \
     --old-evidence old.evidence/ --new-evidence new.evidence/
 ```
 
+!!! warning "Packs do not travel inside a snapshot"
+    `dump --evidence` records only a lightweight, content-addressed
+    *reference* on the snapshot — the pack directory stays out-of-band, and
+    `compare` does **not** follow that reference. To get pack-based L3/L4
+    findings you must **preserve the pack directory** and pass it explicitly
+    via `--old-evidence` / `--new-evidence`. If you archive only the dumped
+    JSON and later run `abicheck compare old.json new.json` without the packs,
+    you get the snapshot's intrinsic layers (L0–L2, plus any L3 build *flags*
+    baked in at dump time via `-p`) but not the pack's L3/L4 findings.
+
 | Flag | Command | Description |
 |------|---------|-------------|
-| `--evidence <dir>` | `dump` | Attach an evidence pack to the snapshot (content-addressed ref) |
-| `--old-evidence <dir>` / `--new-evidence <dir>` | `compare` | Diff per-side packs into the verdict — adds L3 build-context findings and an evidence-coverage table |
+| `--evidence <dir>` | `dump` | Record a content-addressed *reference* to a pack on the snapshot (the pack stays out-of-band; still pass it to `compare` to use its findings) |
+| `--old-evidence <dir>` / `--new-evidence <dir>` | `compare` | Load and diff per-side packs into the verdict — adds L3 build-context findings and an evidence-coverage table |
 | `--evidence-mode <mode>` | `compare` | Inline collection mode (`off` by default; uses only the explicitly-provided packs) |
 
 To additionally capture **L4 source ABI replay** (macro/`constexpr` values,

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -39,6 +39,23 @@ automatically, then runs ABI comparison and reports results.
 | `old-include` | no | Include dirs for old side only |
 | `new-include` | no | Include dirs for new side only |
 
+!!! note "Evidence layers in the Action"
+    The Action drives the same [five-layer evidence
+    model](../concepts/evidence-and-detectability.md) as the CLI. The inputs
+    above cover **L0** (`old-library`/`new-library`), **L1** (debug info —
+    embedded, or `debug-info1`/`debug-info2` packages in `compare-release`
+    mode), and **L2** (`header`/`include`). To add **L3** build context
+    (`-p build/`) or an **L4** [source/build evidence
+    pack](../concepts/evidence-pack.md), capture them with the CLI first and
+    pass the resulting snapshot as `old-library`/`new-library`:
+
+    ```bash
+    abicheck dump build/libfoo.so -H include/ -p build/ \
+        --evidence libfoo.evidence/ -o abi-baseline.json
+    ```
+
+    The snapshot carries the L3/L4 evidence into the Action run.
+
 ### Application compatibility inputs (appcompat mode)
 
 | Input | Required | Description |

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -44,17 +44,26 @@ automatically, then runs ABI comparison and reports results.
     model](../concepts/evidence-and-detectability.md) as the CLI. The inputs
     above cover **L0** (`old-library`/`new-library`), **L1** (debug info —
     embedded, or `debug-info1`/`debug-info2` packages in `compare-release`
-    mode), and **L2** (`header`/`include`). To add **L3** build context
-    (`-p build/`) or an **L4** [source/build evidence
-    pack](../concepts/evidence-pack.md), capture them with the CLI first and
-    pass the resulting snapshot as `old-library`/`new-library`:
+    mode), and **L2** (`header`/`include`).
+
+    **L3** build context (`-p build/`) can be folded in by pre-dumping a
+    snapshot with the CLI — the build flags are applied at dump time, so the
+    resulting snapshot is parsed with the correct ABI-affecting options — and
+    passing that JSON as `old-library`/`new-library`:
 
     ```bash
-    abicheck dump build/libfoo.so -H include/ -p build/ \
-        --evidence libfoo.evidence/ -o abi-baseline.json
+    abicheck dump build/libfoo.so -H include/ -p build/ -o abi-baseline.json
     ```
 
-    The snapshot carries the L3/L4 evidence into the Action run.
+    Full **evidence packs** (`--evidence` / `--old-evidence` / `--new-evidence`)
+    and **L4** source ABI replay are **CLI-only** today: `dump --evidence`
+    stores only a lightweight, content-addressed *reference* (the pack stays
+    out-of-band), and the Action's `compare` has no `--old-evidence` /
+    `--new-evidence` wiring — so a dumped snapshot does **not** carry pack-based
+    L3/L4 findings into an Action run. To use them, run `abicheck compare …
+    --old-evidence … --new-evidence …` as a plain CLI step in your workflow
+    instead of through this Action. See [Source & Build Evidence
+    Packs](../concepts/evidence-pack.md).
 
 ### Application compatibility inputs (appcompat mode)
 

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -234,6 +234,14 @@ The `evidence_tier` scalar collapses the raw sources into a single ordered label
   present. The richest tier, and the only one that can reason about
   declared-but-not-emitted API, inline/template changes, and macro contracts.
 
+These three values correspond to the **artifact** evidence layers **L0–L2**.
+Build data (**L3**, `-p build/`) and source/evidence packs (**L4**,
+`--old-evidence`/`--new-evidence`) do **not** promote this scalar — they add
+findings and an evidence-coverage table alongside it, under the authority rule
+(L3/L4 never overrides an artifact-proven verdict). See [Evidence &
+Detectability](../concepts/evidence-and-detectability.md) for the full L0–L4
+model.
+
 ```json
 {
   "verdict": "BREAKING",

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -235,12 +235,22 @@ The `evidence_tier` scalar collapses the raw sources into a single ordered label
   declared-but-not-emitted API, inline/template changes, and macro contracts.
 
 These three values correspond to the **artifact** evidence layers **L0–L2**.
-Build data (**L3**, `-p build/`) and source/evidence packs (**L4**,
-`--old-evidence`/`--new-evidence`) do **not** promote this scalar — they add
-findings and an evidence-coverage table alongside it, under the authority rule
-(L3/L4 never overrides an artifact-proven verdict). See [Evidence &
-Detectability](../concepts/evidence-and-detectability.md) for the full L0–L4
-model.
+The higher layers do **not** promote this scalar, and they differ in what they
+produce:
+
+- **`dump -p build/`** only bakes the build context into *how* the headers are
+  parsed and records `parsed_with_build_context` on the snapshot. On its own it
+  adds **no** L3 findings and **no** evidence-coverage table — a plain
+  `compare old.json new.json` of two `-p`-dumped snapshots still reports only the
+  L0–L2 artifact verdict.
+- **Build/source evidence packs (L3/L4)** are what add build-diff/source-diff
+  **findings** and the `evidence_coverage` table, and only when you pass them at
+  compare time via `--old-evidence`/`--new-evidence` (or a non-off
+  `--evidence-mode`). These findings follow the authority rule — L3/L4 never
+  overrides an artifact-proven verdict.
+
+See [Evidence & Detectability](../concepts/evidence-and-detectability.md) for the
+full L0–L4 model.
 
 ```json
 {

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -406,15 +406,39 @@ def check_doc_count_sync(f: Findings) -> None:
         ),
         (
             ROOT / "README.md",
+            "ChangeKind count (feature bullet)",
+            n_kinds,
+            r"\*\*(\d+) change types\*\*",
+        ),
+        (
+            ROOT / "README.md",
             "catalog size",
             n_catalog,
             r"contains \*\*(\d+) real-world ABI/API scenarios",
+        ),
+        (
+            ROOT / "README.md",
+            "catalog size (validation target)",
+            n_catalog,
+            r"the full \*\*(\d+)-case catalog\*\*",
         ),
         (
             DOCS / "getting-started.md",
             "catalog size",
             n_catalog,
             r"repo includes (\d+) ABI scenario examples",
+        ),
+        (
+            DOCS / "development/abicc-parity-status.md",
+            "ChangeKind count (current total)",
+            n_kinds,
+            r"current ChangeKind total is \*\*(\d+)\*\*",
+        ),
+        (
+            DOCS / "development/abicc-test-coverage-comparison.md",
+            "ChangeKind count (current total)",
+            n_kinds,
+            r"current ChangeKind total is \*\*(\d+)\*\*",
         ),
     ]
 

--- a/tests/test_architecture_refactor.py
+++ b/tests/test_architecture_refactor.py
@@ -142,9 +142,9 @@ class TestDetectorRegistry:
     """Self-registering detector registry."""
 
     def test_all_detectors_registered(self):
-        """All 48 detectors are registered via decorators."""
+        """All 49 detectors are registered via decorators."""
         registry = _get_populated_registry()
-        assert len(registry) == 48
+        assert len(registry) == 49
 
     def test_detector_names_unique(self):
         """No duplicate detector names."""
@@ -211,7 +211,7 @@ class TestDetectorRegistry:
         assert isinstance(changes, list)
         assert isinstance(results, list)
         # Results should have entries for all detectors (enabled or disabled)
-        assert len(results) == 48
+        assert len(results) == 49
 
     def test_support_check_disables_detector(self):
         """Detectors with failing support checks are disabled."""
@@ -367,7 +367,7 @@ class TestCompareUsesNewArchitecture:
         result = compare(old, new)
         assert result.verdict.value == "NO_CHANGE"
         assert result.changes == []
-        assert len(result.detector_results) == 48
+        assert len(result.detector_results) == 49
 
     def test_compare_detects_func_removal(self):
         """compare() detects function removal via registry."""


### PR DESCRIPTION
## Documentation review: count drift + missing L3/L4 evidence docs

A pass over the docs surfaced two classes of problems: **stale headline counts** that contradict the source of truth (and each other), and **missing coverage of the L3/L4 evidence layers** for users running scans. This PR fixes the factual errors and fills the L3/L4 gaps.

> **Rebased onto latest `main`.** `main` grew the `ChangeKind` enum, so the live source of truth is now **`len(ChangeKind) == 230`** (was 222 at first push). All counts in this PR are synced to **230** / catalog **126**.

### 1. Stale counts (now corrected to source of truth: 230 / 126)

| Where | Was | Now |
|---|---|---|
| `README.md` feature bullet | 216 → (222) | **230** |
| `README.md` validation target | 125-case | **126**-case |
| `CLAUDE.md` (×2) | 216 | **230** |
| 7 development docs (parity, coverage, goals, registry, report-comparison) | 192 | **230** |

The README lead paragraph and `docs/index.md` are pinned to the live count by the `doc-count-sync` gate, so they were already at the current value; this PR brings the *non-anchored* references into line and adds new anchors so they can't drift again.

### 2. Gate hardening so it can't drift again
`doc-count-sync` in `scripts/check_ai_readiness.py` only pinned a couple of specific phrasings — which is exactly why "216", "125-case", and "192" slipped through. Added anchors for the README feature-bullet count, the validation-target catalog count, and the "current ChangeKind total is **N**" lines in the parity docs.

### 3. L3/L4 evidence layers now documented for scans
The five-layer model (L0 binary → L1 debug → L2 headers → L3 build data → L4 sources) was prominent in the README/concepts but absent from the pages users actually follow to run a scan. Updated for consistency with the canonical model:

- **`cli-usage.md`** — framed build-context capture as **L3**, and added an *Evidence packs (L3/L4)* section documenting `collect-evidence`, `--evidence`, `--old/--new-evidence`, `--evidence-mode`, `--show-data-sources`, the clang requirement for L4, and the authority rule. Clarified (per review) that `dump --evidence` stores only an out-of-band ref and that pack findings load only via `compare --old/--new-evidence`.
- **`getting-started.md`** — replaced the informal input-quality table with the full **L0–L4** table; L4 row names the compare-time evidence flags.
- **`github-action.md`** — Action inputs cover **L0–L2** (plus debug-info packages for L1); L3 via a pre-dumped snapshot, evidence packs / L4 are CLI-only (no `--old/--new-evidence` wiring in the Action).
- **`choose-your-workflow.md`, `output-formats.md`, `limitations.md`, `abi-api-handling.md`** — aligned their source-comparison tables: the `evidence_tier` scalar covers artifact layers **L0–L2**; L3/L4 add findings + a coverage table without promoting the scalar or overriding an artifact-proven verdict.

### Validation
- `mkdocs build --strict` passes (all new anchors/links resolve).
- `python scripts/check_ai_readiness.py` → 0 errors (the `doc-count-sync` anchors validate against the live 230/126).

### Review fixes folded in (Codex)
- Action note no longer claims snapshots carry evidence packs into Actions (packs are CLI-only).
- cli-usage warns packs don't travel inside a snapshot; pack dir must be preserved and passed to `compare`.
- `--evidence-mode` row notes non-`off` modes aren't collected inline yet.
- getting-started L4 row names `compare --old/--new-evidence` instead of the `dump`-only `--evidence`.

### Not done here (flagged for follow-up)
Lower-priority L3/L4 cross-links remain absent from `verdicts.md`, `multi-binary.md`, `appcompat.md`, `baseline-management.md`, and `platforms.md`; and a few secondary commands (`pr-comment`, `surface`, `audit`) are still undocumented in the CLI reference. Happy to take these in a follow-up.

https://claude.ai/code/session_01Af8dBiXkrPf34mVcRw9ZaJ