### PR TITLE
Document data-source remeasurement plan

### DIFF
--- a/abicheck/binary_utils.py
+++ b/abicheck/binary_utils.py
@@ -20,6 +20,7 @@ and mcp_server.py.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 # Mach-O magic bytes — covers all variants:
@@ -38,6 +39,8 @@ _MACHO_MAGICS: frozenset[bytes] = frozenset({
 # analyses (see detect_archive / G8). Both magics are 8 bytes.
 _ARCHIVE_MAGICS: frozenset[bytes] = frozenset({b"!<arch>\n", b"!<thin>\n"})
 _ARCHIVE_MAGIC_LEN: int = 8
+_LD_SCRIPT_RE = re.compile(r"\b(?:INPUT|GROUP|OUTPUT_FORMAT)\s*\(")
+_LD_KEYWORDS = frozenset({"AS_NEEDED", "INPUT", "GROUP", "OUTPUT_FORMAT"})
 
 
 def classify_magic(magic: bytes) -> str | None:
@@ -66,6 +69,45 @@ def detect_binary_format(path: str | Path) -> str | None:
     except OSError:
         return None
     return classify_magic(magic)
+
+
+def resolve_linker_script(path: Path) -> tuple[Path | None, bool]:
+    """Resolve a GNU ld INPUT()/GROUP() script to a referenced library.
+
+    Returns ``(target, is_linker_script)``. ``target`` is ``None`` when the file
+    is not a linker script, or when no referenced library can be found.
+    """
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(8192)
+        text = raw.decode("utf-8", errors="replace")
+    except OSError:
+        return None, False
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.DOTALL)
+    if not _LD_SCRIPT_RE.search(text):
+        return None, False
+    for group in re.findall(r"(?:INPUT|GROUP)\s*\(([^)]*)\)", text):
+        for tok in group.replace(",", " ").split():
+            if tok in _LD_KEYWORDS or tok.startswith(("-l", "-L", "(")):
+                continue
+            if ".so" not in tok and not tok.endswith(".a"):
+                continue
+            candidate = Path(tok)
+            for cand in (candidate, path.parent / tok, path.parent / candidate.name):
+                if cand.is_file():
+                    return cand, True
+    return None, True
+
+
+def normalize_binary_input(path: Path) -> tuple[Path, str | None]:
+    """Detect binary format, following resolvable GNU ld linker scripts."""
+    fmt = detect_binary_format(path)
+    if fmt is not None:
+        return path, fmt
+    target, is_ld = resolve_linker_script(path)
+    if is_ld and target is not None:
+        return target, detect_binary_format(target)
+    return path, fmt
 
 
 def detect_archive(path: str | Path) -> bool:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -240,29 +240,9 @@ def _resolve_linker_script(path: Path) -> tuple[Path | None, bool]:
     even when no target file could be located); ``resolved_path`` is the first
     ``INPUT()``/``GROUP()`` member that exists next to the script, or *None*.
     """
-    try:
-        with open(path, "rb") as f:
-            raw = f.read(8192)
-        text = raw.decode("utf-8", errors="replace")
-    except OSError:
-        return None, False
-    # Strip C-style comments (real scripts start with ``/* GNU ld script */``).
-    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.DOTALL)
-    if not _LD_SCRIPT_RE.search(text):
-        return None, False
-    # Collect candidate file tokens from inside INPUT()/GROUP() groups.
-    for group in re.findall(r"(?:INPUT|GROUP)\s*\(([^)]*)\)", text):
-        for tok in group.replace(",", " ").split():
-            if tok in _LD_KEYWORDS or tok.startswith(("-l", "-L", "(")):
-                continue
-            # Only consider tokens that name a library file.
-            if ".so" not in tok and not tok.endswith(".a"):
-                continue
-            candidate = Path(tok)
-            for cand in (candidate, path.parent / tok, path.parent / candidate.name):
-                if cand.is_file():
-                    return cand, True
-    return None, True
+    from .binary_utils import resolve_linker_script
+
+    return resolve_linker_script(path)
 
 
 def _maybe_follow_linker_script(path: Path) -> Path:
@@ -760,6 +740,11 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
 
     # Source-only dump (no binary) for the parallel-baseline / merge flow.
     if so_path is None:
+        if show_data_sources:
+            raise click.UsageError(
+                "--show-data-sources requires SO_PATH; source-only dump cannot "
+                "produce binary data-source diagnostics."
+            )
         from .cli_buildsource import dump_source_only
         dump_source_only(sources, build_info, version, output, build_config, allow_build_query, git_tag, build_id, no_git, collect_mode)
         return

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -26,6 +26,7 @@ import click
 
 from .checker import DiffResult, LibraryMetadata, compare
 from .cli_audit import echo_filtered_surface, echo_pattern_modulations
+from .cli_datasources import print_data_sources as _print_data_sources
 from .cli_options import (
     adr027_compare_options,
     build_source_compare_options,
@@ -685,10 +686,10 @@ def _populate_dependency_info(
               help="Simulated LD_LIBRARY_PATH (with --follow-deps).")
 @click.option("--dwarf-only", is_flag=True, default=False,
               help="Force DWARF-only mode: use DWARF debug info as the primary "
-                   "data source even when headers are available. Enables 24/30 "
-                   "detectors without requiring castxml.")
+                   "data source even when headers are available. Enables type-aware "
+                   "artifact checks without requiring castxml.")
 @click.option("--show-data-sources", is_flag=True, default=False,
-              help="Print which data layers (L0/L1/L2) are available for the "
+              help="Print which data layers (L0-L5) are available for the "
                    "binary and exit.")
 @click.option("--debug-format", "debug_format_opt",
               type=click.Choice(["auto", "dwarf", "btf", "ctf"], case_sensitive=False), default=None,
@@ -782,7 +783,12 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
 
     # --show-data-sources: diagnostic output and exit
     if show_data_sources:
-        _print_data_sources(so_path, bool(headers))
+        _print_data_sources(
+            so_path,
+            bool(headers),
+            build_source_path=build_info,
+            sources_path=sources,
+        )
         return
 
     # Auto-detect binary format — PE/Mach-O skip the ELF/castxml path. The
@@ -952,23 +958,6 @@ def _resolve_debug_artifact(
         enable_debuginfod=debuginfod,
         debuginfod_urls=[debuginfod_url] if debuginfod_url else None,
     )
-
-
-def _print_data_sources(so_path: Path, has_headers: bool) -> None:
-    """Print data source diagnostic information for a binary."""
-    from .dwarf_snapshot import show_data_sources
-
-    binary_fmt = _detect_binary_format(so_path)
-    elf_meta = None
-    dwarf_meta = None
-
-    if binary_fmt == "elf":
-        from .dwarf_unified import parse_dwarf
-        from .elf_metadata import parse_elf_metadata
-        elf_meta = parse_elf_metadata(so_path)
-        dwarf_meta, _ = parse_dwarf(so_path)
-
-    click.echo(show_data_sources(so_path, elf_meta, dwarf_meta, has_headers))
 
 
 def _resolve_per_side_options(

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
     from .model import AbiSnapshot
     from .policy_file import PolicyFile
 
-
 @main.command("collect")
 @click.option("--binary", "binary", type=click.Path(path_type=Path), default=None,
               help="Built shared library this evidence describes (recorded as provenance).")
@@ -303,7 +302,6 @@ def collect_cmd(
         graph_detail=graph_detail,
     )
 
-
 def _collect_source_graph(
     merged: BuildEvidence,
     extractors: list[ExtractorRecord],
@@ -354,7 +352,6 @@ def _collect_source_graph(
     ))
     return graph, graph_detail
 
-
 def _enforce_strict_mode(
     extractors: list[ExtractorRecord], merged: BuildEvidence, collection_mode: str
 ) -> None:
@@ -378,7 +375,6 @@ def _enforce_strict_mode(
         f"produce valid evidence ({names}). Fix the inputs/tools, grant the "
         "needed actions, or use --collection-mode permissive."
     )
-
 
 def _echo_collection_summary(
     pack: BuildSourcePack,
@@ -407,7 +403,6 @@ def _echo_collection_summary(
         click.echo(f"  L5 source graph: {graph_detail or 'empty (no build evidence)'}")
     for diag in merged.diagnostics:
         click.echo(f"  note: {diag}", err=True)
-
 
 def _run_adapters(
     merged: BuildEvidence,
@@ -512,7 +507,6 @@ def _run_adapters(
             inputs=[DEFAULT_REDACTION.path(str(binary))],
             detail=f"{len(ev.toolchains)} toolchains, {len(ev.compile_units)} compile units",
         ))
-
 
 def _run_external_extractors(
     merged: BuildEvidence,
@@ -647,7 +641,6 @@ def _run_external_extractors(
         else:
             _purge_external_outputs(pack_root, manifest)
 
-
 def _purge_external_outputs(pack_root: Path, manifest: object) -> None:
     """Remove a failed external extractor's normalized outputs from the pack.
 
@@ -670,7 +663,6 @@ def _purge_external_outputs(pack_root: Path, manifest: object) -> None:
     norm_dir = pack_root / "normalized" / name
     if norm_dir.is_dir():
         shutil.rmtree(norm_dir, ignore_errors=True)
-
 
 def _collect_call_graph(
     graph: SourceGraphSummary,
@@ -712,7 +704,6 @@ def _collect_call_graph(
         detail=f"{added} call edges from {len(merged.compile_units)} compile units",
     ))
 
-
 def _include_map_for_replay(
     merged: BuildEvidence, clang_bin: str
 ) -> dict[str, list[str]] | None:
@@ -734,7 +725,6 @@ def _include_map_for_replay(
     for diag in extractor.diagnostics:
         merged.diagnostics.append(f"source_abi_include_graph: {diag}")
     return includes or None
-
 
 def _collect_include_graph(
     graph: SourceGraphSummary,
@@ -770,7 +760,6 @@ def _collect_include_graph(
         status="ok" if added else "partial",
         detail=f"{added} include edges from {len(includes)} compile units",
     ))
-
 
 def _ingest_graph_backends(
     graph: SourceGraphSummary,
@@ -821,7 +810,6 @@ def _ingest_graph_backends(
                 name="graph_backend:codeql", status="ok" if added else "partial",
                 inputs=[DEFAULT_REDACTION.path(str(codeql_results))], detail=f"{added} edges ingested",
             ))
-
 
 def _build_coverage(
     merged: BuildEvidence,
@@ -888,7 +876,6 @@ def _build_coverage(
         l5 = LayerCoverage(layer=DataLayer.L5_SOURCE_GRAPH.value, status=CoverageStatus.NOT_COLLECTED)
     return [l3, l4, l5]
 
-
 def _exported_symbols_from_binary(binary: Path | None) -> list[str]:
     """Best-effort exported (mangled) symbol names from ``binary`` for D5 linking.
 
@@ -911,7 +898,6 @@ def _exported_symbols_from_binary(binary: Path | None) -> list[str]:
     syms = {fn.mangled for fn in snap.functions if fn.mangled}
     syms |= {v.mangled for v in snap.variables if getattr(v, "mangled", "")}
     return sorted(syms)
-
 
 def _collect_source_abi(
     merged: BuildEvidence,
@@ -1018,7 +1004,6 @@ def _collect_source_abi(
         + (f", {len(diagnostics)} TU(s) failed (partial coverage)" if diagnostics else "")
     )
 
-
 def _collect_source_abi_android(
     android_dump: Path | None,
     extractors: list[ExtractorRecord],
@@ -1062,13 +1047,10 @@ def _collect_source_abi_android(
         f"{len(surface.reachable_types)} types"
     )
 
-
 # ── Attach / compare integration (ADR-028 D6, D7; ADR-029 D9) ─────────────────
-
 
 def _layer_value(layer: object) -> str:
     return layer.value if hasattr(layer, "value") else str(layer)
-
 
 def _filter_pack_layers(
     pack: BuildSourcePack | None, layers: tuple[str, ...]
@@ -1086,7 +1068,6 @@ def _filter_pack_layers(
     if "L5" not in layers:
         pack.source_graph = None
     return pack
-
 
 def _combine_packs(
     bi_pack: BuildSourcePack | None,
@@ -1209,7 +1190,6 @@ def _combine_packs(
         source_graph=source_graph,  # type: ignore[arg-type]
     )
 
-
 def embed_build_source(
     snap: AbiSnapshot,
     build_info: Path | None,
@@ -1292,7 +1272,6 @@ def embed_build_source(
     hint = str(sources) if sources is not None else str(build_info)
     snap.build_source_pack = merged.to_ref(path_hint=hint)
 
-
 def dump_source_only(
     sources: Path | None,
     build_info: Path | None,
@@ -1329,7 +1308,6 @@ def dump_source_only(
     _write_snapshot_output(
         snap, output, build_info, sources, build_config, allow_build_query, collect_mode
     )
-
 
 @main.command("merge")
 @click.argument("inputs", nargs=-1, required=True, type=click.Path(exists=True, dir_okay=False, path_type=Path))
@@ -1401,7 +1379,6 @@ def merge_cmd(inputs: tuple[Path, ...], output: Path, verbose: bool) -> None:
             }:
                 click.echo(f"  {cov.layer}: {cov.status.value}", err=True)
 
-
 def _resolve_side_pack(
     build_info: Path | None,
     sources: Path | None,
@@ -1424,7 +1401,6 @@ def _resolve_side_pack(
     # L3, --sources wins for L4/L5, the embedded payload backfills, and the
     # coverage manifest is rebuilt per-layer from the supplying pack.
     return _combine_packs(bi_pack, src_pack, embedded)
-
 
 def diff_embedded_build_source(
     old_build_info: Path | None,
@@ -1546,23 +1522,22 @@ def diff_embedded_build_source(
     # Coverage/capability reflect the *target* (new) side only: the L3/L4/L5
     # diffs run only when both sides supply a layer, so reporting the old pack's
     # coverage when the new side has none would over-claim that source/build
-    # checks ran for this scan (Codex review). new_pack's manifest already
-    # carries one honest row per managed layer (_combine_packs); when the new
-    # side has no pack at all, every managed layer is not_collected.
-    if new_pack is not None:
-        coverage = list(new_pack.manifest.coverage)
-    else:
-        coverage = [
-            LayerCoverage(layer=layer.value, status=CoverageStatus.NOT_COLLECTED)
-            for layer in (DataLayer.L3_BUILD, DataLayer.L4_SOURCE_ABI, DataLayer.L5_SOURCE_GRAPH)
-        ]
+    # checks ran for this scan (Codex review). The side-by-side table below
+    # still exposes old/new asymmetry to humans.
+    coverage = _optional_coverage(new_pack)
     intrinsic = _intrinsic_coverage(new_snapshot)
     _echo_coverage(intrinsic, coverage)
+    if old_snapshot is not None:
+        _echo_compare_side_coverage(
+            _intrinsic_coverage(old_snapshot),
+            _optional_coverage(old_pack),
+            intrinsic,
+            coverage,
+        )
     _echo_capabilities(intrinsic, coverage)
     coverage_rows: list[dict[str, object]] = [c.to_dict() for c in (*intrinsic, *coverage)]
     metrics = evidence_coverage_metrics(coverage)
     return changes, coverage_rows, metrics
-
 
 def prepare_embedded_build_source(
     old_snapshot: AbiSnapshot,
@@ -1611,7 +1586,6 @@ def prepare_embedded_build_source(
         extra_changes = (extra_changes or []) + ev_changes
     return extra_changes, coverage_rows, metrics, ev_changes
 
-
 def attach_evidence_metrics(
     result: DiffResult,
     metrics: dict[str, object],
@@ -1637,13 +1611,11 @@ def attach_evidence_metrics(
     result.evidence_metrics = metrics
     echo_evidence_metrics(metrics)
 
-
 def _load_pack_or_raise(evidence_dir: Path) -> BuildSourcePack:
     try:
         return BuildSourcePack.load(evidence_dir)
     except (FileNotFoundError, ValueError) as exc:
         raise click.ClickException(f"Invalid evidence pack at {evidence_dir}: {exc}") from exc
-
 
 def _intrinsic_coverage(snap: AbiSnapshot) -> list[LayerCoverage]:
     """Derive L0/L1/L2 coverage rows from a snapshot (ADR-028 D7)."""
@@ -1663,6 +1635,13 @@ def _intrinsic_coverage(snap: AbiSnapshot) -> list[LayerCoverage]:
         row("L2", has_headers, "header-scoped" if has_headers else ""),
     ]
 
+def _optional_coverage(pack: BuildSourcePack | None) -> list[LayerCoverage]:
+    if pack is not None:
+        return list(pack.manifest.coverage)
+    return [
+        LayerCoverage(layer=layer.value, status=CoverageStatus.NOT_COLLECTED)
+        for layer in (DataLayer.L3_BUILD, DataLayer.L4_SOURCE_ABI, DataLayer.L5_SOURCE_GRAPH)
+    ]
 
 # Human-readable layer names, ordered shallow→deep, shared by the coverage
 # table and the asymmetry finding so both speak the same vocabulary.
@@ -1671,7 +1650,6 @@ _LAYER_NAMES: dict[str, str] = {
     "L3_build": "L3 build context", "L4_source_abi": "L4 source ABI replay",
     "L5_source_graph": "L5 source graph summary",
 }
-
 
 def _echo_coverage(intrinsic: list[LayerCoverage], optional: list[LayerCoverage]) -> None:
     """Print the D7 evidence-coverage table to stderr (all output formats)."""
@@ -1684,6 +1662,26 @@ def _echo_coverage(intrinsic: list[LayerCoverage], optional: list[LayerCoverage]
                 extra += f": {cov.detail}"
         click.echo(f"  {_LAYER_NAMES.get(cov.layer, cov.layer):<26} {cov.status.value}{extra}", err=True)
 
+def _echo_compare_side_coverage(
+    old_intrinsic: list[LayerCoverage],
+    old_optional: list[LayerCoverage],
+    new_intrinsic: list[LayerCoverage],
+    new_optional: list[LayerCoverage],
+) -> None:
+    """Print old/new layer coverage so mixed-evidence compares are explicit."""
+    old_by_layer = {c.layer: c for c in (*old_intrinsic, *old_optional)}
+    new_by_layer = {c.layer: c for c in (*new_intrinsic, *new_optional)}
+    click.echo("Evidence coverage by side:", err=True)
+    for layer, name in _LAYER_NAMES.items():
+        old = old_by_layer.get(layer)
+        new = new_by_layer.get(layer)
+        old_status = old.status.value if old is not None else "not_collected"
+        new_status = new.status.value if new is not None else "not_collected"
+        marker = " (asymmetric)" if old_status != new_status else ""
+        click.echo(
+            f"  {name:<26} old={old_status:<13} new={new_status}{marker}",
+            err=True,
+        )
 
 def _layer_presence(snap: AbiSnapshot, pack: BuildSourcePack | None) -> dict[str, bool]:
     """Map every evidence layer id → present? for one side of the compare.
@@ -1702,7 +1700,6 @@ def _layer_presence(snap: AbiSnapshot, pack: BuildSourcePack | None) -> dict[str
     if pack is not None and pack.build_evidence is not None:
         present[DataLayer.L3_BUILD.value] = True
     return present
-
 
 def _detect_coverage_asymmetry(
     old_snap: AbiSnapshot,
@@ -1755,7 +1752,6 @@ def _detect_coverage_asymmetry(
         )
     ]
 
-
 #: One row per check category: (label, evidence layer that enables it, the
 #: question it answers, and why it is off when that layer is absent). This is the
 #: "what is and is not being checked, and why" report (ADR-028 D7): the tiers run
@@ -1780,7 +1776,6 @@ _CHECK_CAPABILITIES: tuple[tuple[str, str, str, str], ...] = (
      "from the source graph summary",
      "no graph evidence: cross-symbol impact is not analyzed"),
 )
-
 
 def _echo_capabilities(
     intrinsic: list[LayerCoverage], optional: list[LayerCoverage]
@@ -1807,9 +1802,7 @@ def _echo_capabilities(
         else:
             click.echo(f"  [off] {label} — {why_off}", err=True)
 
-
 # ── compare-graph: structural graph-to-graph diff (ADR-031 D6, D8) ────────────
-
 
 def _load_source_graph(path: Path) -> SourceGraphSummary:
     """Load a source graph summary from a JSON file or an evidence-pack dir.
@@ -1848,7 +1841,6 @@ def _load_source_graph(path: Path) -> SourceGraphSummary:
             "(expected top-level 'nodes' and 'edges' lists)."
         )
     return SourceGraphSummary.from_dict(data)
-
 
 @main.command("compare-graph")
 @click.argument("old", type=click.Path(path_type=Path))
@@ -1917,7 +1909,6 @@ def compare_graph_cmd(old: Path, new: Path, fmt: str) -> None:
         for c in findings:
             click.echo(f"  [{c.kind.value}] {c.symbol}: {c.description}")
 
-
 @main.command("explain-finding")
 @click.option("--sources", "sources", type=click.Path(path_type=Path), required=True,
               help="Source/graph pack directory (or a source_graph_summary.json) to explain through.")
@@ -1968,7 +1959,6 @@ def explain_finding_cmd(
     ]
     for label, values in rows:
         click.echo(f"  {label}: {', '.join(values) if values else '(none in graph)'}")
-
 
 def _resolve_symbol_from_report(report: Path, finding_id: str) -> str:
     """Resolve a symbol from a `compare --format json` report finding.

--- a/abicheck/cli_datasources.py
+++ b/abicheck/cli_datasources.py
@@ -21,10 +21,12 @@ def print_data_sources(
     sources_path: Path | None = None,
 ) -> None:
     """Print data source diagnostic information for a binary."""
-    from .binary_utils import detect_binary_format
+    from .binary_utils import detect_binary_format, normalize_binary_input
     from .dwarf_snapshot import show_data_sources
 
-    binary_fmt = detect_binary_format(so_path)
+    normalized_path, binary_fmt = normalize_binary_input(so_path)
+    if binary_fmt is None:
+        binary_fmt = detect_binary_format(normalized_path)
     elf_meta = None
     dwarf_meta = None
     build_source_pack = None
@@ -33,14 +35,15 @@ def print_data_sources(
         from .dwarf_unified import parse_dwarf
         from .elf_metadata import parse_elf_metadata
 
-        elf_meta = parse_elf_metadata(so_path)
-        dwarf_meta, _ = parse_dwarf(so_path)
+        elf_meta = parse_elf_metadata(normalized_path)
+        dwarf_meta, _ = parse_dwarf(normalized_path)
 
     if build_source_path is not None or sources_path is not None:
         from .buildsource.inline import is_pack_dir
         from .buildsource.pack import BuildSourcePack
 
         def load_pack(path: Path, label: str) -> BuildSourcePack | None:
+            """Load a build-source pack when the input is already collected."""
             if not is_pack_dir(path):
                 click.echo(
                     f"{label} input: {path} "
@@ -69,7 +72,7 @@ def print_data_sources(
 
     click.echo(
         show_data_sources(
-            so_path, elf_meta, dwarf_meta, has_headers, build_source_pack
+            normalized_path, elf_meta, dwarf_meta, has_headers, build_source_pack
         )
     )
 
@@ -78,6 +81,7 @@ def _combine_diagnostic_packs(
     build_info_pack: BuildSourcePack | None,
     sources_pack: BuildSourcePack | None,
 ) -> BuildSourcePack | None:
+    """Combine split build-info and source packs for diagnostic reporting."""
     from .buildsource.model import CoverageStatus, DataLayer, LayerCoverage
     from .buildsource.pack import BuildSourcePack
 
@@ -92,8 +96,18 @@ def _combine_diagnostic_packs(
     combined.source_graph = sources_pack.source_graph or build_info_pack.source_graph
     combined.manifest = copy.deepcopy(build_info_pack.manifest)
 
+    layer_payload = {
+        DataLayer.L3_BUILD.value: "build_evidence",
+        DataLayer.L4_SOURCE_ABI.value: "source_abi",
+        DataLayer.L5_SOURCE_GRAPH.value: "source_graph",
+    }
+
     def row_for(layer: str, *packs: BuildSourcePack) -> LayerCoverage | None:
+        """Return coverage from the pack that supplied the requested layer."""
+        payload_attr = layer_payload.get(layer)
         for pack in packs:
+            if payload_attr and not getattr(pack, payload_attr):
+                continue
             row = next(
                 (c for c in pack.manifest.coverage if c.layer == layer),
                 None,

--- a/abicheck/cli_datasources.py
+++ b/abicheck/cli_datasources.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""CLI helpers for data-source diagnostics."""
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from .buildsource.model import LayerCoverage
+    from .buildsource.pack import BuildSourcePack
+
+
+def print_data_sources(
+    so_path: Path,
+    has_headers: bool,
+    build_source_path: Path | None = None,
+    sources_path: Path | None = None,
+) -> None:
+    """Print data source diagnostic information for a binary."""
+    from .binary_utils import detect_binary_format
+    from .dwarf_snapshot import show_data_sources
+
+    binary_fmt = detect_binary_format(so_path)
+    elf_meta = None
+    dwarf_meta = None
+    build_source_pack = None
+
+    if binary_fmt == "elf":
+        from .dwarf_unified import parse_dwarf
+        from .elf_metadata import parse_elf_metadata
+
+        elf_meta = parse_elf_metadata(so_path)
+        dwarf_meta, _ = parse_dwarf(so_path)
+
+    if build_source_path is not None or sources_path is not None:
+        from .buildsource.inline import is_pack_dir
+        from .buildsource.pack import BuildSourcePack
+
+        def load_pack(path: Path, label: str) -> BuildSourcePack | None:
+            if not is_pack_dir(path):
+                click.echo(
+                    f"{label} input: {path} "
+                    "(not collected in --show-data-sources; run dump without "
+                    "--show-data-sources to embed inline L3/L4/L5 facts)",
+                    err=True,
+                )
+                return None
+            try:
+                return BuildSourcePack.load(path)
+            except Exception as exc:
+                raise click.ClickException(
+                    f"Invalid {label} build-source pack: {exc}"
+                ) from exc
+
+        build_info_pack = (
+            load_pack(build_source_path, "Build-info")
+            if build_source_path is not None else None
+        )
+        sources_pack = (
+            load_pack(sources_path, "Sources")
+            if sources_path is not None else None
+        )
+
+        build_source_pack = _combine_diagnostic_packs(build_info_pack, sources_pack)
+
+    click.echo(
+        show_data_sources(
+            so_path, elf_meta, dwarf_meta, has_headers, build_source_pack
+        )
+    )
+
+
+def _combine_diagnostic_packs(
+    build_info_pack: BuildSourcePack | None,
+    sources_pack: BuildSourcePack | None,
+) -> BuildSourcePack | None:
+    from .buildsource.model import CoverageStatus, DataLayer, LayerCoverage
+    from .buildsource.pack import BuildSourcePack
+
+    if build_info_pack is None:
+        return sources_pack
+    if sources_pack is None:
+        return build_info_pack
+
+    combined = BuildSourcePack.empty(Path(""))
+    combined.build_evidence = build_info_pack.build_evidence or sources_pack.build_evidence
+    combined.source_abi = sources_pack.source_abi or build_info_pack.source_abi
+    combined.source_graph = sources_pack.source_graph or build_info_pack.source_graph
+    combined.manifest = copy.deepcopy(build_info_pack.manifest)
+
+    def row_for(layer: str, *packs: BuildSourcePack) -> LayerCoverage | None:
+        for pack in packs:
+            row = next(
+                (c for c in pack.manifest.coverage if c.layer == layer),
+                None,
+            )
+            if row is not None:
+                return copy.deepcopy(row)
+        return None
+
+    coverage = [
+        copy.deepcopy(c)
+        for c in build_info_pack.manifest.coverage
+        if c.layer not in {
+            DataLayer.L3_BUILD.value,
+            DataLayer.L4_SOURCE_ABI.value,
+            DataLayer.L5_SOURCE_GRAPH.value,
+        }
+    ]
+    for layer, present, packs in (
+        (
+            DataLayer.L3_BUILD.value,
+            combined.build_evidence is not None,
+            (build_info_pack, sources_pack),
+        ),
+        (
+            DataLayer.L4_SOURCE_ABI.value,
+            combined.source_abi is not None,
+            (sources_pack, build_info_pack),
+        ),
+        (
+            DataLayer.L5_SOURCE_GRAPH.value,
+            combined.source_graph is not None,
+            (sources_pack, build_info_pack),
+        ),
+    ):
+        row = row_for(layer, *packs)
+        if row is None:
+            row = LayerCoverage(
+                layer=layer,
+                status=CoverageStatus.PRESENT if present else CoverageStatus.NOT_COLLECTED,
+            )
+        coverage.append(row)
+    combined.manifest.coverage = coverage
+    return combined

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1088,8 +1088,8 @@ def _dump_elf(
 
     # ADR-003: Updated fallback chain
     # --dwarf-only → force DWARF mode regardless of headers
-    # no headers + DWARF available → DWARF-only mode (24/30 detectors)
-    # no headers + no DWARF → symbols-only mode (6/30 detectors)
+    # no headers + DWARF available -> DWARF-only mode with type-aware checks
+    # no headers + no DWARF -> symbols-only mode
     dwarf_only_types: list[RecordType] = []
     if dwarf_only or (not headers and dwarf_meta.has_dwarf):
         snap, dwarf_only_types = _try_dwarf_snapshot(

--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -16,7 +16,7 @@
 
 ADR-003: When no headers are provided but DWARF debug info is present,
 this module builds a full AbiSnapshot from DWARF .debug_info, enabling
-24/30 detectors (vs 6 in symbol-only mode).
+type-aware artifact checks that are unavailable in symbol-only mode.
 
 DWARF provides: function signatures, struct/class layouts, enum definitions,
 variables, typedefs, inheritance, vtable entries, templates.
@@ -63,6 +63,7 @@ from .model import (
 )
 
 if TYPE_CHECKING:
+    from .buildsource.pack import BuildSourcePack
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .elf_metadata import ElfMetadata
@@ -124,6 +125,7 @@ def show_data_sources(
     elf_meta: ElfMetadata | None,
     dwarf_meta: DwarfMetadata | None,
     has_headers: bool,
+    build_source_pack: BuildSourcePack | None = None,
 ) -> str:
     """Generate human-readable data source diagnostic output.
 
@@ -151,23 +153,81 @@ def show_data_sources(
 
     # L2: Header AST
     if has_headers:
-        lines.append("  L2 Header AST:      available (castxml)")
+        lines.append("  L2 Header AST:      available (CastXML/header inputs)")
     else:
-        lines.append("  L2 Header AST:      not available (no -H provided)")
+        lines.append("  L2 Header AST:      not collected (no -H provided)")
+
+    # L3-L5: Optional build/source pack layers.
+    if build_source_pack is None:
+        lines.append("  L3 Build context:   not collected (no build-source pack)")
+        lines.append("  L4 Source ABI:      not collected (no build-source pack)")
+        lines.append("  L5 Source graph:    not collected (no build-source pack)")
+    else:
+        lines.append(_evidence_layer_line(build_source_pack, "L3 Build context", "build_evidence"))
+        lines.append(_evidence_layer_line(build_source_pack, "L4 Source ABI", "source_abi"))
+        lines.append(_evidence_layer_line(build_source_pack, "L5 Source graph", "source_graph"))
 
     lines.append("")
 
     # Mode determination
     if has_headers:
-        lines.append("Using: Headers mode (30/30 detectors active)")
+        lines.append("Using: Headers mode (artifact + public header evidence)")
     elif dwarf_meta is not None and dwarf_meta.has_dwarf:
-        lines.append("Using: DWARF-only mode (24/30 detectors active)")
-        lines.append("Missing: #define constants, default parameter values")
+        lines.append("Using: DWARF-only mode (artifact debug evidence)")
+        lines.append("Missing: #define constants, default parameter values, header intent")
     else:
-        lines.append("Using: Symbols-only mode (6/30 detectors active)")
+        lines.append("Using: Symbols-only mode (artifact symbol evidence)")
         lines.append("Missing: type information, function signatures")
 
     return "\n".join(lines)
+
+
+def _evidence_layer_line(build_source_pack: BuildSourcePack, label: str, attr: str) -> str:
+    coverage = {
+        row.layer: row
+        for row in getattr(getattr(build_source_pack, "manifest", None), "coverage", [])
+    }
+    layer_id = {
+        "build_evidence": "L3_build",
+        "source_abi": "L4_source_abi",
+        "source_graph": "L5_source_graph",
+    }[attr]
+    row = coverage.get(layer_id)
+    payload = getattr(build_source_pack, attr, None)
+    payload_summary = _evidence_payload_summary(payload) if payload is not None else None
+    if row is not None:
+        if row.status.value != "present" or payload_summary is None:
+            return f"  {label}: {_coverage_row_summary(row)}"
+        return f"  {label}: {payload_summary}"
+    if payload_summary is not None:
+        return f"  {label}: {payload_summary}"
+    return f"  {label}: not collected"
+
+
+def _coverage_row_summary(row: object) -> str:
+    status = getattr(getattr(row, "status", None), "value", None) or str(getattr(row, "status", "not_collected"))
+    detail = getattr(row, "detail", "")
+    suffix = f" ({detail})" if detail else ""
+    return f"{status}{suffix}"
+
+
+def _evidence_payload_summary(payload: object) -> str | None:
+    counts: list[str] = []
+    for attr, label in (
+        ("compile_units", "compile units"),
+        ("targets", "targets"),
+        ("reachable_declarations", "declarations"),
+        ("reachable_types", "types"),
+        ("reachable_macros", "macros"),
+        ("nodes", "nodes"),
+        ("edges", "edges"),
+    ):
+        items = getattr(payload, attr, None)
+        if items:
+            counts.append(f"{len(items)} {label}")
+    if counts:
+        return "present (" + ", ".join(counts[:3]) + ")"
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/development/data-source-process-remediation-plan.md
+++ b/docs/development/data-source-process-remediation-plan.md
@@ -301,10 +301,14 @@ Gate:
     schema `run_matrix.v2`.
   - `validation/data/results.meta.json` records run-level metadata: runner,
     command, platform, manifest pair count, comparison count, and observed
-    evidence modes.
+    evidence modes and comparison-status counts.
   - Each real-world record includes component, case id, platform, mode,
     L0-L5/source-layer coverage, old/new source layers, evidence asymmetry,
-    runtime, expected verdict, actual verdict, exit code, and stderr.
+    runtime, expected verdict, actual verdict, normalized compatibility-axis
+    verdicts, comparison status, exit code, and stderr.
+  - Real-world release gating is based on expectation mismatch or missing
+    verdict, not raw exit code, because expected `BREAKING` / `API_BREAK`
+    verdicts legitimately return non-zero from `abicheck compare`.
 - Current validation inventory is treated as the starting corpus, not the final corpus:
   - 129 synthetic cases in `examples/ground_truth.json`
   - 11 curated real-world package pairs in `validation/data/manifest.json`

--- a/docs/development/data-source-process-remediation-plan.md
+++ b/docs/development/data-source-process-remediation-plan.md
@@ -1,0 +1,456 @@
+# Data Source Process Remediation Plan
+
+**Date:** 2026-06-11
+**Status:** Draft plan
+**Scope:** Update abicheck L0-L5 data-source model, documentation, runtime diagnostics, and real-world validation process.
+
+## Verification Summary
+
+The current documentation and process are obsolete.
+
+Verified drift:
+
+- `docs/development/adr/003-data-source-architecture.md` still describes a three-layer L0/L1/L2 architecture and a fixed "30 detectors" matrix.
+- Runtime diagnostics previously exposed the old L0/L1/L2 language:
+  - `abicheck/dwarf_snapshot.py::show_data_sources`
+  - `abicheck/cli.py::_print_data_sources`
+  - PR #351 now has the first runtime-diagnostic implementation slices:
+    `dump --show-data-sources` reports L0-L5 and can load
+    `--build-info <pack>` or `--sources <pack>` for L3/L4/L5 status, and
+    compare now emits old/new L0-L5 evidence coverage side by side.
+- The current codebase already has evidence and platform support beyond ADR-003:
+  - canonical ordered `evidence_tier` plus raw `evidence_tiers`
+  - ELF, PE, Mach-O metadata
+  - DWARF, advanced DWARF, BTF, CTF, PDB
+  - debug artifact resolution
+  - BuildSourcePack L3/L4/L5 coverage rows, inline snapshot embedding, and content-addressed pack references
+  - build-context capture from compile DB, CMake File API, Ninja, Bazel, Make,
+    compiler records, and external extractor manifests
+  - source ABI replay through clang, CastXML, or Android header-ABI dumps
+  - source graph summaries with optional include/call/Kythe/CodeQL augmentations
+  - public surface scoping
+  - package, bundle, stack, and appcompat analysis paths
+  - SYCL and heterogeneous stack support
+- Existing ADRs partially cover the later work (`007`, `018`, `020`, `021`,
+  `023`, `024`, `026`, `027`, `028`, `029`, `030`, `031`, `032`), but there is
+  no current canonical process that ties the sources, gates, and validation
+  matrix together.
+
+## Target L0-L5 Model
+
+Replace the old L0/L1/L2-only mental model with a canonical L0-L5 taxonomy:
+
+- **L0: Binary identity and loader metadata**
+  - ELF, PE, Mach-O, SONAME/install-name, exported symbols, imports/dependencies, version nodes, binding, visibility, relocation/loader facts.
+- **L1: Debug and binary type metadata**
+  - DWARF, advanced DWARF, BTF, CTF, PDB, dSYM/debuglink/build-id resolved artifacts.
+- **L2: Declared public API surface**
+  - headers, CastXML AST, public include roots, source-location filtering, constants, default parameters, templates, typedef spelling.
+- **L3: Build, toolchain, packaging, and distribution context**
+  - compile commands, CMake/Ninja/Bazel/Make facts, compiler flags, target triples,
+    language standards, ABI macros, generated files, package metadata,
+    debug/devel package pairing, bundle membership, and trusted external
+    extractor outputs.
+- **L4: Source ABI replay**
+  - per-TU source/header replay under real build context; public declarations,
+    types, macros, default arguments, inline/template/constexpr bodies, Android
+    header-ABI dumps, and source-only API findings.
+- **L5: Source/implementation graph**
+  - compact target/source/header/compile-unit/build-option graph, optional
+    include/call/Kythe/CodeQL augmentation, graph-to-graph diff, finding
+    localization, and impact/reachability explanation.
+
+This taxonomy should become the single vocabulary used by ADRs, CLI diagnostics, JSON/SARIF/HTML reports, validation reports, and release-process gates.
+Consumer/appcompat, bundle, stack, baseline, suppression, and policy inputs are
+impact/report contexts that can consume L0-L5 findings; they are not a separate
+canonical evidence layer.
+
+## Gaps To Address
+
+1. **Documentation drift**
+   - ADR-003 is no longer the source of truth for available sources or detector coverage.
+   - Later ADRs describe pieces of the current architecture but do not define one canonical end-to-end process.
+   - User-facing limitations and verdict docs do not clearly explain when evidence is incomplete, asymmetric, or degraded.
+
+2. **Runtime diagnostics drift**
+   - `--show-data-sources` now has the first L0-L5 implementation in PR #351.
+   - Compare diagnostics now print old/new L0-L5 evidence coverage side by side
+     and mark asymmetric rows.
+   - Remaining diagnostics still need richer debug artifact provenance, package
+     pairing, appcompat context, and source/package-specific detail.
+   - Detector-count language is brittle because detector coverage now depends on platform, evidence, surface, policy, and mode.
+
+3. **Report/schema semantics**
+   - JSON already exposes `evidence_tier` and `evidence_tiers`, and compare
+     reports can carry L0-L5 coverage rows, but the process does not fully
+     define how those map to user-visible confidence and warnings.
+   - Reports need explicit coverage warnings for missing headers, missing debug artifacts, stripped binaries, mismatched package/debug/devel inputs, and asymmetric evidence.
+   - Mixed rich-to-poor comparisons must be marked as lower-confidence/manual-review where appropriate instead of producing hard false positives.
+
+4. **Validation gaps**
+   - Existing tests cover many unit paths, but the remeasurement process is not organized by evidence mode.
+   - Real-world validation should measure accuracy by L0-only, L1-only, L0+L1,
+     L0+L2, L0+L1+L2, L3 build/package context, L4 source ABI replay, L5 source
+     graph, and consumer/appcompat impact context.
+   - Known false-positive families need regression gates, especially rich-to-poor evidence transitions.
+
+## Work Plan
+
+### 1. Create the canonical source/process spec
+
+Deliverables:
+
+- New or replacement architecture document defining L0-L5.
+- Cross-reference from ADR-003 to the new canonical document, or supersede ADR-003 with a newer ADR.
+- Update ADR index and relevant ADR backreferences.
+
+Required content:
+
+- Source taxonomy and responsibilities.
+- Source precedence and merge rules.
+- Provenance fields and confidence semantics.
+- Platform matrix for ELF, PE/PDB, Mach-O/dSYM, BTF, CTF.
+- User-facing explanations for incomplete evidence and manual-review results.
+
+Gate:
+
+- `rg "L0/L1/L2|30 detectors|24/30|6/30" docs validation README.md mkdocs.yml abicheck tests` shows no stale canonical claims except historical notes explicitly marked as historical.
+
+### 2. Update runtime data-source diagnostics
+
+Deliverables:
+
+- Replace old `--show-data-sources` output with L0-L5 output.
+- Include old/new comparison evidence summary where a compare command has both sides.
+- Replace fixed detector counts with capability/coverage categories.
+
+Suggested output sections:
+
+- L0 binary metadata: present/missing, format, exported-symbol count, version info.
+- L1 debug/type metadata: present/missing, resolved artifact path, debug format, counts.
+- L2 declared API surface: headers/include roots, source filtering status, CastXML status.
+- L3 build/package context: compile DB, build-system adapters, compiler/build
+  facts, package identity, and devel/debug package match.
+- L4 source ABI replay: extractor backend, replay scope, declarations/types/
+  macros/default arguments/inline bodies collected, and partial replay failures.
+- L5 source graph: graph summary, include/call/Kythe/CodeQL augmentation status,
+  graph-diff availability, and localization support.
+- Impact context: appcompat/bundle/stack/baseline/policy inputs that can consume
+  or scope L0-L5 findings.
+- Coverage warnings: missing/asymmetric/degraded evidence.
+
+Gate:
+
+- CLI tests assert L0-L5 output for no-debug, DWARF, headers, evidence-pack
+  present/absent, package/debug, and appcompat-impact cases.
+
+### 3. Normalize report evidence semantics
+
+Deliverables:
+
+- Define exact mapping between raw `evidence_tiers`, canonical `evidence_tier`,
+  and L0-L5 coverage.
+- Add or update report fields only if current fields cannot express the model safely.
+- Ensure Markdown, JSON, SARIF, HTML, stack, bundle, and appcompat reports use consistent terminology.
+
+Rules to encode:
+
+- `evidence_tier` remains the ordered confidence scalar for analysis depth.
+- L0-L5 coverage is a capability/provenance vector, not a single ordered scalar.
+- Missing source layers must become explicit `coverage_warnings`.
+- Asymmetric evidence must lower confidence or require manual review for source-dependent findings.
+
+Gate:
+
+- Schema tests and reporter tests cover full evidence, symbols-only, debug-only, header-only, and asymmetric comparisons.
+
+### 4. Fix asymmetric rich-to-poor behavior
+
+Deliverables:
+
+- Audit detectors that can misclassify missing evidence as removed API/type data.
+- Add degradation logic for old-rich/new-poor, old-poor/new-rich, and source-family mismatch cases.
+- Suppress or downgrade source-dependent removals when the new side simply lacks the evidence needed to observe them.
+
+Initial high-risk areas:
+
+- type removals from missing DWARF/header data
+- function signature changes when one side is symbol-only
+- enum/typedef/constant changes when L2 is missing
+- source-only API changes when L4 is missing
+- graph-derived localization/impact changes when L5 is missing
+
+Gate:
+
+- Known false-positive cases stop producing phantom removal avalanches.
+- Regression corpus includes TBB 2021.9 -> 2022.0 and libxml2 2.9.7 -> 2.9.9, plus oneDAL/oneTBB source-built runs with matched public headers and toolchain.
+
+### 5. Expand validation and remeasurement matrix
+
+Deliverables:
+
+- Validation runner that records mode, platform, source layers, evidence asymmetry, component, case id, verdict, runtime, and known expected outcome.
+- Published remeasurement report with per-mode false positives, false negatives, verdict accuracy, runtime, and residual risks.
+- Full example-suite remeasurement across every case in `examples/ground_truth.json` before and after source/process changes.
+- Full component-suite remeasurement for source-specific implementation areas:
+  - ELF/symbol/versioning/surface
+  - DWARF/advanced DWARF/debug resolver
+  - BTF/CTF/PDB/PE/Mach-O
+  - headers/CastXML/public-surface scoping
+  - build context and package extraction
+  - bundle, stack, and appcompat
+  - report/schema/SARIF/HTML/JUnit output
+  - policy, baseline, suppression, and confidence/evidence logic
+
+Required mode matrix:
+
+- L0-only
+- L1-only
+- L0+L1
+- L0+L2
+- L0+L1+L2
+- L3 package/build-context enriched
+- L4 source-ABI replay enriched
+- L5 source-graph enriched
+- consumer/appcompat/bundle/stack impact-context enriched
+- asymmetric rich-to-poor and poor-to-rich evidence
+- cross-mode snapshot comparisons:
+  - L0 snapshot vs L0+L1 snapshot
+  - L0 snapshot vs L0+L2 snapshot
+  - L0+L1 snapshot vs L0+L1+L2 snapshot
+  - L0+L1+L2 snapshot vs L0+L1+L2+L3+L4+L5 snapshot
+  - old-rich/new-poor and old-poor/new-rich for every source-dependent detector family
+
+Required platform matrix:
+
+- ELF/Linux
+- PE/PDB/Windows
+- Mach-O/dSYM/macOS
+- kernel/BTF
+- CTF sample
+- stripped and split-debug packages
+
+Required example artifact variants:
+
+- **Stripped binary with headers**: build the same example library, strip DWARF/type
+  debug sections, still pass the public headers, and assert that L0+L2 findings
+  remain active while L1-dependent findings degrade with explicit warnings.
+- **Regular release binary with headers**: build without debug info but without
+  post-build stripping, pass public headers, and assert behavior matches the
+  intended L0+L2 profile rather than accidentally relying on compiler-emitted
+  debug metadata.
+- **Debug binary with headers**: current `tests/validate_examples.py` mostly
+  exercises this profile because it builds examples with `-g`/`Debug` and passes
+  discovered `v1`/`v2` headers to `abicheck dump`.
+- **Build information and source access**: collect L3 build context, L4 source
+  ABI replay, and L5 source graph evidence for selected examples. These must be
+  measured as separate variants because they exercise `collect`,
+  build-system adapters, source ABI replay, and source graph paths rather than
+  the current synthetic example dump/compare harness.
+
+Runner support:
+
+- `tests/validate_examples.py --artifact-variant debug-headers` keeps the
+  previous default behavior.
+- `--artifact-variant release-headers` builds without debug flags and still
+  passes headers.
+- `--artifact-variant stripped-headers` builds debug artifacts, strips debug
+  info, and still passes headers.
+- `--artifact-variant build-source` collects L3/L4/L5 evidence with
+  `collect --compile-db --source-abi --source-abi-extractor castxml
+  --source-graph summary`, then compares with old/new build-source packs.
+- `--artifact-variant all` runs all four variants for every selected example.
+- JSON output uses schema `validate_examples.v2` and records platform, command,
+  selected variants, ground-truth corpus size, per-case runtime, component,
+  mode, source layers, evidence asymmetry, expected verdict, actual verdict,
+  and manual-review allowance. This makes full synthetic remeasurement artifacts
+  comparable across runs.
+
+Build/source capability coverage to add after the current `build-source` smoke:
+
+- L3: `--compile-db`, `--build-dir --cmake`, `--build-dir --ninja`,
+  `--ninja-compdb`, `--bazel-cquery`, `--bazel-aquery`, `--make-dry-run`,
+  `--read-compiler-record`, and `--extractor-manifest` with
+  `--collection-mode permissive|strict|audit`.
+- L4: `--source-abi-extractor clang|castxml|android`,
+  `--source-abi-scope headers-only|changed|target|full`,
+  `--source-abi-cache`, `--changed-path`, and partial-coverage degradation when
+  a replay backend is unavailable or some translation units fail.
+- L5: `--source-graph summary`, `--include-graph`, `--call-graph`,
+  `--kythe-entries`, and `--codeql-results`, with graph-diff and localization
+  evidence kept separate from artifact-proven ABI breaks.
+
+Gate:
+
+- Remeasurement report is generated from checked-in validation metadata.
+  - `validation/scripts/summarize_remeasurement.py` consumes
+    `validate_examples.v2`, `component_suites.v1`, and `run_matrix.v2`
+    artifacts and writes schema `remeasurement_summary.v1`.
+  - The summary records section counts, total records, blocking failures,
+    status/verdict/mode/source-layer counts, and component-suite blockers.
+- Each measured case records expected verdict, actual verdict, evidence coverage, and whether manual review is acceptable.
+- `python tests/validate_examples.py --json` runs all non-skipped example cases from `examples/ground_truth.json`.
+- `pytest` component suites for every source family above are run or explicitly marked blocked with missing platform/tooling reason.
+  - `validation/scripts/run_component_suites.py` writes schema
+    `component_suites.v1` records for each source-family suite.
+  - Each component-suite record includes component, suite/case id, platform,
+    supported platforms, source layers, pytest command, runtime, status,
+    pass/fail/error/skip/warning counts, and blocked reasons.
+- `validation/scripts/run_matrix.py` remeasures all package pairs in `validation/data/manifest.json` once binaries are available through `ABICHECK_VALIDATION_LIBS`.
+  - `validation/data/results.json` keeps the per-comparison records and now uses
+    schema `run_matrix.v2`.
+  - `validation/data/results.meta.json` records run-level metadata: runner,
+    command, platform, manifest pair count, comparison count, and observed
+    evidence modes.
+  - Each real-world record includes component, case id, platform, mode,
+    L0-L5/source-layer coverage, old/new source layers, evidence asymmetry,
+    runtime, expected verdict, actual verdict, exit code, and stderr.
+- Current validation inventory is treated as the starting corpus, not the final corpus:
+  - 129 synthetic cases in `examples/ground_truth.json`
+  - 11 curated real-world package pairs in `validation/data/manifest.json`
+  - 33 current real-world shared-library comparisons in `validation/data/results.json`
+  - current observed real-world evidence modes: `sym->sym`, `dwarf->sym`, `dwarf->dwarf`
+- Remeasurement must fail the release gate if any previously passing example, component suite, or real-world known-FP regression changes verdict without an accepted explanation.
+
+### 6. Update user docs and process docs
+
+Deliverables:
+
+- Update limitations, verdicts, architecture, and relevant user-guide pages.
+- Add "how to get better evidence" guidance:
+  - install debug symbols
+  - provide public headers
+  - provide `compile_commands.json` or build-system metadata
+  - collect source ABI replay with clang, CastXML, or Android header-ABI dumps
+  - collect source graph summaries for impact/localization
+  - provide package/bundle/appcompat context for consumer-impact triage
+  - avoid comparing rich evidence to stripped artifacts without warnings
+- Add troubleshooting for `--show-data-sources`.
+
+Gate:
+
+- User-facing docs explain what abicheck can and cannot prove in each evidence mode.
+
+### 7. Add CI and release gates
+
+Deliverables:
+
+- CI check for stale source taxonomy phrases.
+- Unit tests for L0-L5 diagnostics and report coverage fields.
+- Real-world validation job or manual release checklist entry.
+
+Release gate:
+
+- No release with changed detector/source behavior unless:
+  - docs are updated,
+  - `--show-data-sources` remains accurate,
+  - validation matrix is remeasured or explicitly waived with reason,
+  - known FP/FN corpus does not regress.
+
+## Suggested Implementation Order
+
+1. Land canonical L0-L5 spec and mark ADR-003 historical/superseded.
+2. Update `--show-data-sources` and CLI tests. First slices done in PR #351:
+   L0-L5 dump diagnostics plus compare-side old/new evidence summaries.
+   Remaining work is broader debug/source/package/appcompat context output.
+3. Normalize report wording and schema semantics.
+4. Add asymmetric evidence degradation tests and fixes.
+5. Build validation matrix metadata and runner.
+6. Remeasure real-world corpus and publish results.
+7. Update user docs and CI/release gates.
+
+## Required Remeasurement Commands
+
+Run these as the minimum proof set for this workstream. A blocked command must be recorded with the missing tool, platform, binary corpus, or fixture reason.
+
+Synthetic examples:
+
+```bash
+python tests/validate_examples.py --json
+python tests/validate_examples.py --artifact-variant all --json
+pytest -q tests/test_example_autodiscovery.py tests/test_validate_examples_unit.py
+```
+
+Source-family component suites:
+
+```bash
+python validation/scripts/run_component_suites.py --all --output validation/data/component_suites.json
+pytest -q \
+  tests/test_elf_metadata_unit.py \
+  tests/test_elf_parse_integration.py \
+  tests/test_elf_symbol_filters.py \
+  tests/test_elf_version_policy.py \
+  tests/test_surface.py \
+  tests/test_surface_scope_parity.py \
+  tests/test_confidence_evidence.py \
+  tests/test_stripped_degradation.py \
+  tests/test_dwarf_snapshot.py \
+  tests/test_dwarf_metadata_coverage.py \
+  tests/test_dwarf_unified.py \
+  tests/test_debug_resolver.py \
+  tests/test_btf_metadata.py \
+  tests/test_btf_integration.py \
+  tests/test_ctf_metadata.py \
+  tests/test_pdb_metadata.py \
+  tests/test_pdb_parser.py \
+  tests/test_pe_metadata_unit.py \
+  tests/test_macho_metadata_unit.py \
+  tests/test_build_context.py \
+  tests/test_package.py \
+  tests/test_package_extractor_matrix.py \
+  tests/test_bundle.py \
+  tests/test_stack_checker.py \
+  tests/test_appcompat.py \
+  tests/test_appcompat_examples.py \
+  tests/test_report_schema.py \
+  tests/test_reporter.py \
+  tests/test_sarif.py \
+  tests/test_junit_report.py \
+  tests/test_policy_changekind_matrix.py \
+  tests/test_policy_file.py \
+  tests/test_baseline.py \
+  tests/test_suppression_matrix.py
+```
+
+Known false-positive and real-world gates:
+
+```bash
+pytest -q tests/test_real_world_false_positives.py tests/test_realworld_scan.py tests/test_fp_rate_gate.py
+ABICHECK_VALIDATION_LIBS=validation/libs/ex python validation/scripts/run_matrix.py
+python validation/scripts/summarize_remeasurement.py \
+  --examples results/validate_examples.json \
+  --components validation/data/component_suites.json \
+  --real-world validation/data/results.json \
+  --real-world-meta validation/data/results.meta.json \
+  --output validation/data/remeasurement_summary.json \
+  --fail-on-blocking
+python tests/check_validate_results.py
+python tests/summarize_validate_results.py
+```
+
+Cross-platform/platform-specific gates:
+
+```bash
+pytest -q tests/test_cross_platform_fixtures.py tests/test_cross_platform_integration.py
+pytest -q tests/test_windows_toolchain_smoke.py tests/test_msvc_pdb_e2e.py
+pytest -q tests/test_macos_arm64_abi.py
+pytest -q tests/test_workflow_kernel_accel.py
+```
+
+Expected artifacts:
+
+- `validation/data/results.json` regenerated from the current manifest.
+- `validation/data/runs/*.json` regenerated for each measured shared-library comparison.
+- `validation/data/component_suites.json` generated from component-suite runs.
+- `validation/data/remeasurement_summary.json` generated from examples,
+  component suites, and real-world matrix artifacts.
+
+## Definition Of Done
+
+- One canonical L0-L5 source model is linked from architecture docs, ADR index, user docs, and diagnostics.
+- CLI diagnostics and reports no longer imply that L0/L1/L2 are the whole process.
+- Mixed evidence comparisons are clearly warned, downgraded, or routed to manual review when confidence is insufficient.
+- Remeasurement covers evidence modes, platforms, package/debug/devel flows,
+  source replay, source graph, and appcompat/bundle impact context.
+- Known false positives are tracked as regression gates.
+- Release process requires data-source/process docs and validation evidence to stay in sync with implementation.

--- a/docs/development/data-source-remeasurement-status-2026-06-11.md
+++ b/docs/development/data-source-remeasurement-status-2026-06-11.md
@@ -200,11 +200,12 @@ Implemented in PR #351:
   schema `run_matrix.v2`.
 - Real-world records include component, case id, platform, logical library,
   mode, old/new source layers, evidence asymmetry, runtime, expected verdict,
-  actual verdict, exit code, stderr, summary counts, release recommendation, and
-  optional layer coverage.
+  actual verdict, normalized compatibility-axis verdicts, comparison status,
+  exit code, stderr, summary counts, release recommendation, and optional layer
+  coverage.
 - Real-world run metadata is written to `validation/data/results.meta.json`
   with runner, command, platform, manifest pair count, comparison count, and
-  observed evidence modes.
+  observed evidence modes and comparison-status counts.
 - `validation/scripts/run_component_suites.py` now emits component-suite
   records with schema `component_suites.v1`.
 - Component-suite records include suite/case id, platform, supported platforms,
@@ -214,7 +215,11 @@ Implemented in PR #351:
   `validate_examples.v2`, `component_suites.v1`, and `run_matrix.v2` artifacts
   and emits `remeasurement_summary.v1`.
 - The combined summary records total records, blocking failures,
-  status/verdict/mode/source-layer counts, and component-suite blocked reasons.
+  status/verdict/mode/source-layer counts, real-world expectation mismatches,
+  real-world run errors, and component-suite blocked reasons.
+- Real-world summaries no longer count expected non-zero compare exit codes as
+  blocking failures; expected `BREAKING` / `API_BREAK` outcomes are scored by
+  expected-vs-actual verdict status instead.
 
 Smoke proof:
 

--- a/docs/development/data-source-remeasurement-status-2026-06-11.md
+++ b/docs/development/data-source-remeasurement-status-2026-06-11.md
@@ -1,0 +1,311 @@
+# Data Source Remeasurement Status - 2026-06-11
+
+**Task:** `remeasure-all`
+**Scope:** First local proof pass for the L0-L5 data-source/process remediation work.
+
+## Environment
+
+- Repo: `/home/openclaw/.openclaw/workspace-abicheck/repo`
+- Command prefix needed locally: `PYTHONPATH=.`
+- Available tools:
+  - `castxml`: `/home/openclaw/.local/bin/castxml`
+  - `gcc`: `/usr/bin/gcc`
+  - `g++`: `/usr/bin/g++`
+  - `cmake`: `/usr/bin/cmake`
+  - `pytest`: `9.0.2`
+
+## Full Synthetic Example Remeasurement
+
+Command:
+
+```bash
+PYTHONPATH=. python tests/validate_examples.py --json
+```
+
+Result:
+
+- Exit code: `1`
+- Total cases: `129`
+- PASS: `104`
+- XFAIL: `5`
+- SKIP: `7`
+- FAIL: `10`
+- ERROR: `3`
+
+Unexpected FAIL cases:
+
+- `case01_symbol_removal`: expected `BREAKING`, got `NO_CHANGE`
+- `case02_param_type_change`: expected `BREAKING`, got `NO_CHANGE`
+- `case03_compat_addition`: expected `COMPATIBLE`, got `NO_CHANGE`
+- `case102_frozen_runtime_signature_changed`: expected `BREAKING`, got `NO_CHANGE`
+- `case10_return_type`: expected `BREAKING`, got `NO_CHANGE`
+- `case12_function_removed`: expected `BREAKING`, got `NO_CHANGE`
+- `case33_pointer_level`: expected `BREAKING`, got `NO_CHANGE`
+- `case46_pointer_chain_type_change`: expected `BREAKING`, got `NO_CHANGE`
+- `case59_func_became_inline`: expected `BREAKING`, got `NO_CHANGE`
+- `case66_language_linkage_changed`: expected `BREAKING`, got `NO_CHANGE`
+
+Unexpected ERROR cases:
+
+- `case126_sycl_device_impl_ptr`: `dump v1 failed`; CastXML failed while processing `v1.h`
+- `case80_pimpl_shared_to_unique`: `dump v1 failed`; CastXML failed while processing `v1.h`
+- `case89_inline_accessor_renamed_pimpl_member`: `dump v1 failed`; CastXML failed while processing `v1.h`
+
+Known expected non-pass buckets:
+
+- XFAIL: 5 known gaps from `examples/ground_truth.json`
+- SKIP: 7 platform/tooling/layout skips, including bundle cases delegated to bundle tests and BTF fixture delegated to kernel workflow tests
+
+## Real-World Matrix Status
+
+Command planned:
+
+```bash
+ABICHECK_VALIDATION_LIBS=validation/libs/ex python validation/scripts/run_matrix.py
+```
+
+Status:
+
+- Blocked locally: `validation/libs/ex` is not present.
+- This matches `validation/README.md`: real binaries are intentionally not committed and must be fetched/extracted from `validation/data/manifest.json`.
+
+Current checked-in real-world inventory:
+
+- Manifest pairs: 11
+- Current result records: 33 shared-library comparisons
+- Current evidence modes in `validation/data/results.json`:
+  - `sym->sym`: 25
+  - `dwarf->sym`: 5
+  - `dwarf->dwarf`: 3
+
+## Dirty Worktree Context
+
+Pre-existing modified files not touched by this task:
+
+- `abicheck/elf_symbol_filter.py`
+- `tests/test_elf_symbol_filters.py`
+- `validation/data/results.json`
+
+`validation/data/results.json` was intentionally restored to the `main` version
+in PR #351 after review. The refreshed local real-world output had not been
+paired with a regenerated `validation/REPORT.md`, so keeping it in the PR would
+make the checked-in report and result artifact contradict each other.
+
+Files added/updated by this task:
+
+- `docs/development/data-source-process-remediation-plan.md`
+- `docs/development/data-source-remeasurement-status-2026-06-11.md`
+
+## Next Required Steps
+
+1. Investigate the 10 `NO_CHANGE` false negatives from full example validation.
+2. Investigate the 2 CastXML errors in pimpl-related examples.
+3. Run component suites listed in `data-source-process-remediation-plan.md`.
+4. Fetch/extract the real-world conda packages from `validation/data/manifest.json` and rerun `validation/scripts/run_matrix.py`.
+5. Extend report/validation outputs beyond current `sym/dwarf` labels to explicit L0-L5 coverage.
+   First runtime diagnostic slices are now implemented for `--show-data-sources`
+   with L3/L4/L5 build-source pack reporting, plus compare-side old/new L0-L5
+   coverage summaries.
+6. Run the newly enabled artifact-variant matrix across all examples:
+   `python tests/validate_examples.py --artifact-variant all --json`.
+   The runner now supports debug+headers, release+headers, stripped+headers,
+   and build/source-evidence variants; the full all-example matrix still needs
+   to be measured and triaged.
+
+## Example Artifact Variant Enablement
+
+Implemented in PR #351:
+
+- `debug-headers`: existing default; builds Debug/`-g` where applicable and
+  passes discovered public headers.
+- `release-headers`: builds without debug flags / with Release CMake profile
+  and still passes headers.
+- `stripped-headers`: builds with debug info, strips debug sections, and still
+  passes headers.
+- `build-source`: builds with headers, collects L3/L4/L5 evidence through
+  `collect --compile-db --source-abi --source-abi-extractor castxml
+  --source-graph summary`, and compares with old/new build-source packs.
+
+Smoke proof:
+
+```bash
+PYTHONPATH=. python tests/validate_examples.py case04 --artifact-variant all --json
+```
+
+Result: `PASS=4`, one pass for each variant.
+
+## Runtime Data-Source Diagnostic Implementation
+
+Implemented in PR #351:
+
+- `abicheck dump --show-data-sources` now reports L0-L5 availability instead
+  of only L0/L1/L2.
+- `abicheck dump --show-data-sources --build-info <pack>` loads the build-source pack
+  and reports L3 build context, L4 source ABI, and L5 source graph status.
+- Historical fixed detector-count claims were removed from live diagnostic
+  output; the CLI now describes the active evidence mode and missing evidence
+  boundaries.
+- `abicheck compare` now prints old/new L0-L5 evidence coverage side by side
+  when build/source coverage is in play. Asymmetric rows are visibly marked in
+  stderr while the existing JSON `layer_coverage` field remains target/new-side
+  focused for backward compatibility.
+
+Targeted proof:
+
+```bash
+PYTHONPATH=. pytest -q tests/test_dwarf_snapshot.py -k show_data_sources
+PYTHONPATH=. pytest -q tests/test_dwarf_coverage_gaps.py -k show_data_sources
+ruff check abicheck/dwarf_snapshot.py abicheck/cli.py tests/test_dwarf_snapshot.py
+```
+
+Result: all passed.
+
+Additional implementation proof after compare-side summary:
+
+```bash
+PYTHONPATH=. pytest -q tests/test_build_source_cli.py::test_compare_with_evidence_emits_coverage_and_findings tests/test_build_source_cli.py::test_compare_asymmetric_old_only_reports_target_not_collected tests/test_layer_coverage.py::test_compare_cli_reports_coverage_asymmetry tests/test_dwarf_snapshot.py::TestShowDataSources tests/test_dwarf_snapshot.py::TestPrintDataSourcesDirect tests/test_validate_examples_unit.py
+PYTHONPATH=. python tests/validate_examples.py case04 --artifact-variant all --json
+ruff check --no-cache abicheck tests
+mypy abicheck
+python scripts/check_ai_readiness.py
+```
+
+Result: targeted pytest `29 passed`; case04 artifact variants `PASS=4`; ruff
+clean; mypy clean; AI-readiness `0` errors and `13` warnings.
+
+Additional PR-review fix proof:
+
+```bash
+PYTHONPATH=. python tests/validate_examples.py case04 --artifact-variant all --json
+PYTHONPATH=. python tests/validate_examples.py case103 --artifact-variant build-source --json
+PYTHONPATH=. python tests/validate_examples.py case104 --artifact-variant build-source --json
+PYTHONPATH=. python tests/validate_examples.py case104 --artifact-variant release-headers --json
+```
+
+Result: case04 `PASS=4`; case103 build-source `PASS=1` with expected
+`COMPATIBLE_WITH_RISK` from L3 toolchain-flag evidence; case104 build-source
+`PASS=1`; case104 release-headers `PASS=1`.
+
+## Remeasurement Artifact Readiness
+
+Implemented in PR #351:
+
+- `tests/validate_examples.py --json` now emits schema `validate_examples.v2`.
+- Top-level metadata records runner, command, platform, selected cases,
+  `examples/ground_truth.json` corpus size, and selected artifact variants.
+- Each result records component, case id, platform, mode, source layers,
+  evidence asymmetry, runtime seconds, expected verdict, actual verdict, status,
+  and whether manual review is acceptable.
+- `validation/scripts/run_matrix.py` now emits real-world matrix records with
+  schema `run_matrix.v2`.
+- Real-world records include component, case id, platform, logical library,
+  mode, old/new source layers, evidence asymmetry, runtime, expected verdict,
+  actual verdict, exit code, stderr, summary counts, release recommendation, and
+  optional layer coverage.
+- Real-world run metadata is written to `validation/data/results.meta.json`
+  with runner, command, platform, manifest pair count, comparison count, and
+  observed evidence modes.
+- `validation/scripts/run_component_suites.py` now emits component-suite
+  records with schema `component_suites.v1`.
+- Component-suite records include suite/case id, platform, supported platforms,
+  source layers, pytest command, runtime, status, pytest summary counts, and
+  explicit blocked reasons for missing files or optional dependencies.
+- `validation/scripts/summarize_remeasurement.py` now consumes
+  `validate_examples.v2`, `component_suites.v1`, and `run_matrix.v2` artifacts
+  and emits `remeasurement_summary.v1`.
+- The combined summary records total records, blocking failures,
+  status/verdict/mode/source-layer counts, and component-suite blocked reasons.
+
+Smoke proof:
+
+```bash
+PYTHONPATH=. python tests/validate_examples.py case04 --artifact-variant all --json
+PYTHONPATH=. pytest -q tests/test_validate_examples_unit.py
+PYTHONPATH=. pytest -q tests/test_validation_run_matrix.py
+PYTHONPATH=. pytest -q tests/test_validation_component_suites.py
+PYTHONPATH=. pytest -q tests/test_validation_remeasurement_summary.py
+PYTHONPATH=. python validation/scripts/run_component_suites.py --suite report-policy --dry-run --output /tmp/component_suites.json
+```
+
+Result: case04 `PASS=4`; validate-example unit tests `20 passed`;
+run-matrix unit tests `5 passed`; component-suite unit tests `4 passed`;
+remeasurement-summary unit tests `4 passed`; component-suite dry-run wrote one
+planned suite record.
+
+## Plan Refresh For Current Build/Source Capabilities
+
+Updated in PR #351 after the first implementation slice:
+
+- The remediation plan now uses the current L0-L5 BuildSourcePack model instead
+  of the older L0-L4 draft.
+- L3 is explicitly build/toolchain/package context: compile DB, CMake, Ninja,
+  Bazel, Make, compiler-record recovery, and external extractor manifests.
+- L4 is explicitly source ABI replay: clang, CastXML, or Android header-ABI
+  dumps, replay scopes, cache, changed-path filtering, and partial-coverage
+  degradation.
+- L5 is explicitly source graph: summary graph plus optional include/call,
+  Kythe, and CodeQL augmentation for graph diff and localization.
+- Consumer/appcompat/bundle/stack/policy inputs are recorded as impact/report
+  context that consumes L0-L5 findings, not as a separate canonical evidence
+  layer.
+
+## Component Suite Status
+
+Initial component-suite command:
+
+```bash
+PYTHONPATH=. pytest -q tests/test_elf_metadata_unit.py tests/test_elf_parse_integration.py tests/test_elf_symbol_filters.py tests/test_elf_version_policy.py tests/test_surface.py tests/test_surface_scope_parity.py tests/test_confidence_evidence.py tests/test_stripped_degradation.py tests/test_dwarf_snapshot.py tests/test_dwarf_metadata_coverage.py tests/test_dwarf_unified.py tests/test_debug_resolver.py tests/test_btf_metadata.py tests/test_btf_integration.py tests/test_ctf_metadata.py tests/test_pdb_metadata.py tests/test_pdb_parser.py tests/test_pe_metadata_unit.py tests/test_macho_metadata_unit.py tests/test_build_context.py tests/test_package.py tests/test_package_extractor_matrix.py tests/test_bundle.py tests/test_stack_checker.py tests/test_appcompat.py tests/test_appcompat_examples.py tests/test_report_schema.py tests/test_reporter.py tests/test_sarif.py tests/test_junit_report.py tests/test_policy_changekind_matrix.py tests/test_policy_file.py tests/test_baseline.py tests/test_suppression_matrix.py
+```
+
+Result:
+
+- Exit code: `2`
+- Blocked during test collection: `tests/test_pe_metadata_unit.py`
+- Blocker: missing Python dependency `pefile`
+
+Second component-suite command excluded `tests/test_pe_metadata_unit.py` but kept the rest of the local/Linux component list.
+
+Result:
+
+- Exit code: `1`
+- Passed: `1641`
+- Skipped: `5`
+- Failed: `10`
+- Warnings: `12`
+
+Likely real failures:
+
+- `tests/test_surface_scope_parity.py::test_internal_type_change_scoped_out_by_both`
+  - expected non-breaking scoped result, got `BREAKING`
+- `tests/test_surface_scope_parity.py::test_public_type_change_breaking_for_both`
+  - expected breaking public type change, got `NO_CHANGE`
+
+Tooling/dependency failures from missing `pefile`:
+
+- `tests/test_macho_metadata_unit.py::TestCliIntegration::test_dump_native_binary_pe`
+- `tests/test_macho_metadata_unit.py::TestCliIntegration::test_dump_native_binary_pe_empty_exports_raises`
+- `tests/test_appcompat.py::TestParsePeAppRequirements::test_named_imports`
+- `tests/test_appcompat.py::TestParsePeAppRequirements::test_ordinal_only_imports`
+- `tests/test_appcompat.py::TestParsePeAppRequirements::test_filter_by_dll_name`
+- `tests/test_appcompat.py::TestParsePeAppRequirements::test_pe_parse_error`
+- `tests/test_appcompat.py::TestParsePeAppRequirements::test_no_import_directory`
+- `tests/test_appcompat.py::TestGetNewLibExports::test_pe_exports`
+
+Known false-positive / real-world scan gate:
+
+```bash
+PYTHONPATH=. pytest -q tests/test_real_world_false_positives.py tests/test_realworld_scan.py tests/test_fp_rate_gate.py
+```
+
+Result:
+
+- Exit code: `1`
+- Passed: `67`
+- Failed: `2`
+
+Failures:
+
+- `tests/test_realworld_scan.py::TestRealWorldCompatibleRelease::test_compatible_release`
+  - expected `FUNC_ADDED` for `compress_reset`; observed only `ENUM_MEMBER_ADDED`
+- `tests/test_realworld_scan.py::TestRealWorldBreakingRelease::test_breaking_release`
+  - expected `FUNC_REMOVED` for `compress_bound`; observed type layout changes but no function removal

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1120,6 +1120,18 @@ def test_dump_with_no_binary_and_no_inputs_errors():
     assert "source-only" in result.output
 
 
+def test_dump_show_data_sources_requires_binary(tmp_path):
+    tree = tmp_path / "src"
+    tree.mkdir()
+
+    result = CliRunner().invoke(
+        main, ["dump", "--show-data-sources", "--sources", str(tree)]
+    )
+
+    assert result.exit_code != 0
+    assert "--show-data-sources requires SO_PATH" in result.output
+
+
 def test_dump_source_only_then_merge_with_binary(tmp_path):
     """End-to-end: source-only dump + binary dump combine via `merge`."""
     from abicheck.elf_metadata import ElfMetadata

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -200,6 +200,9 @@ def test_compare_with_evidence_emits_coverage_and_findings(tmp_path):
     assert result.exit_code in (0, 2, 4), result.output
     # D7 coverage table is emitted to stderr.
     assert "Evidence coverage:" in result.stderr
+    assert "Evidence coverage by side:" in result.stderr
+    assert "old=present" in result.stderr
+    assert "new=present" in result.stderr
     assert "L3 build context" in result.stderr
     # The -std drift surfaces as an ABI-relevant build-flag finding (RISK).
     assert "COMPATIBLE_WITH_RISK" in result.stdout or "Deployment Risk" in result.stdout
@@ -245,6 +248,11 @@ def test_compare_asymmetric_old_only_reports_target_not_collected(tmp_path):
     payload = json.loads(result.stdout)
     cov = {row["layer"]: row for row in payload["layer_coverage"]}
     assert cov["L3_build"]["status"] == "not_collected"
+    assert "Evidence coverage by side:" in result.stderr
+    assert "L3 build context" in result.stderr
+    assert "old=present" in result.stderr
+    assert "new=not_collected" in result.stderr
+    assert "(asymmetric)" in result.stderr
 
 
 def test_compare_json_without_evidence_omits_coverage(tmp_path):

--- a/tests/test_dwarf_snapshot.py
+++ b/tests/test_dwarf_snapshot.py
@@ -1341,6 +1341,7 @@ class TestCLIInProcess:
 
 # ── _print_data_sources direct call ──────────────────────────────────────────
 
+@pytest.mark.integration
 @pytest.mark.skipif(not _HAS_GCC, reason="GCC not available")
 class TestPrintDataSourcesDirect:
     """Direct call to _print_data_sources for coverage."""
@@ -1439,6 +1440,41 @@ class TestPrintDataSourcesDirect:
         assert "L3 Build context: present (1 compile units, 1 targets)" in out
         assert "L4 Source ABI: present (1 declarations)" in out
         assert "L5 Source graph: present (1 nodes)" in out
+
+    def test_print_data_sources_uses_fallback_pack_coverage(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        c_src = tmp_path / "lib.c"
+        c_src.write_text("int bar(void) { return 1; }\n")
+        so_path = tmp_path / "libtest.so"
+        subprocess.run(
+            [_GCC, "-shared", "-fPIC", "-g", "-o", str(so_path), str(c_src)],
+            capture_output=True, check=True, timeout=30,
+        )
+        full_pack = BuildSourcePack.empty(tmp_path / "full-pack")
+        full_pack.build_evidence = BuildEvidence(
+            targets=[Target(id="target://libtest", name="libtest")],
+            compile_units=[CompileUnit(id="cu://lib.c", source="lib.c")],
+        )
+        full_pack.source_abi = SourceAbiSurface(
+            reachable_declarations=[
+                SourceEntity(id="source://bar", kind="function", qualified_name="bar")
+            ]
+        )
+        full_pack.write()
+        manifest_only = BuildSourcePack.empty(tmp_path / "manifest-only")
+        manifest_only.write()
+
+        from abicheck.cli import _print_data_sources
+
+        _print_data_sources(
+            so_path,
+            has_headers=True,
+            build_source_path=full_pack.root,
+            sources_path=manifest_only.root,
+        )
+        out = capsys.readouterr().out
+        assert "L4 Source ABI: present (1 declarations)" in out
 
     def test_print_data_sources_with_raw_build_source_input(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_dwarf_snapshot.py
+++ b/tests/test_dwarf_snapshot.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 import pytest
 
+from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit, Target
+from abicheck.buildsource.model import CoverageStatus, DataLayer, LayerCoverage
+from abicheck.buildsource.pack import BuildSourcePack
+from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity
+from abicheck.buildsource.source_graph import GraphNode, SourceGraphSummary
 from abicheck.dwarf_advanced import AdvancedDwarfMetadata
 from abicheck.dwarf_metadata import DwarfMetadata, StructLayout
 from abicheck.dwarf_snapshot import (
@@ -228,7 +233,56 @@ class TestShowDataSources:
         assert "L0 Binary metadata: ELF" in output
         assert "L1 Debug info:      DWARF" in output
         assert "L2 Header AST:      available" in output
-        assert "Headers mode (30/30 detectors" in output
+        assert "L3 Build context:   not collected" in output
+        assert "Headers mode (artifact + public header evidence)" in output
+
+    def test_evidence_layers(self, tmp_path: Path) -> None:
+        elf = _elf_meta_with_symbols(["foo"])
+        pack = BuildSourcePack.empty(tmp_path / "evidence")
+        pack.build_evidence = BuildEvidence(
+            targets=[Target(id="target://libtest", name="libtest")],
+            compile_units=[CompileUnit(id="cu://lib.c", source="lib.c")],
+        )
+        pack.source_abi = SourceAbiSurface(
+            reachable_declarations=[
+                SourceEntity(id="source://foo", kind="function", qualified_name="foo")
+            ]
+        )
+        pack.source_graph = SourceGraphSummary(
+            nodes=[GraphNode(id="file://lib.c", kind="file", label="lib.c")]
+        )
+
+        output = show_data_sources(
+            Path("libtest.so"),
+            elf,
+            None,
+            has_headers=True,
+            build_source_pack=pack,
+        )
+        assert "L3 Build context: present (1 compile units, 1 targets)" in output
+        assert "L4 Source ABI: present (1 declarations)" in output
+        assert "L5 Source graph: present (1 nodes)" in output
+
+    def test_partial_evidence_manifest_is_preserved(self, tmp_path: Path) -> None:
+        elf = _elf_meta_with_symbols(["foo"])
+        pack = BuildSourcePack.empty(tmp_path / "evidence")
+        pack.source_abi = SourceAbiSurface(library="libtest.so")
+        pack.manifest.coverage = [
+            LayerCoverage(
+                layer=DataLayer.L4_SOURCE_ABI.value,
+                status=CoverageStatus.PARTIAL,
+                detail="extractor unavailable",
+            )
+        ]
+
+        output = show_data_sources(
+            Path("libtest.so"),
+            elf,
+            None,
+            has_headers=True,
+            build_source_pack=pack,
+        )
+        assert "L4 Source ABI: partial (extractor unavailable)" in output
 
     def test_dwarf_only_mode(self) -> None:
         elf = _elf_meta_with_symbols(["foo"])
@@ -1291,7 +1345,7 @@ class TestCLIInProcess:
 class TestPrintDataSourcesDirect:
     """Direct call to _print_data_sources for coverage."""
 
-    def test_print_data_sources(self, tmp_path: Path) -> None:
+    def test_print_data_sources(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         c_src = tmp_path / "lib.c"
         c_src.write_text("int bar(void) { return 1; }\n")
         so_path = tmp_path / "libtest.so"
@@ -1302,10 +1356,12 @@ class TestPrintDataSourcesDirect:
 
         from abicheck.cli import _print_data_sources
 
-        # _print_data_sources uses click.echo; just ensure it doesn't crash
         _print_data_sources(so_path, has_headers=False)
+        out = capsys.readouterr().out
+        assert "Data sources for libtest.so" in out
+        assert "L3 Build context:   not collected" in out
 
-    def test_print_data_sources_with_headers(self, tmp_path: Path) -> None:
+    def test_print_data_sources_with_headers(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         c_src = tmp_path / "lib.c"
         c_src.write_text("int bar(void) { return 1; }\n")
         so_path = tmp_path / "libtest.so"
@@ -1317,6 +1373,90 @@ class TestPrintDataSourcesDirect:
         from abicheck.cli import _print_data_sources
 
         _print_data_sources(so_path, has_headers=True)
+        out = capsys.readouterr().out
+        assert "L2 Header AST:      available" in out
+        assert "Headers mode (artifact + public header evidence)" in out
+
+    def test_print_data_sources_with_build_source_pack(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        c_src = tmp_path / "lib.c"
+        c_src.write_text("int bar(void) { return 1; }\n")
+        so_path = tmp_path / "libtest.so"
+        subprocess.run(
+            [_GCC, "-shared", "-fPIC", "-g", "-o", str(so_path), str(c_src)],
+            capture_output=True, check=True, timeout=30,
+        )
+        pack = BuildSourcePack.empty(tmp_path / "pack")
+        pack.build_evidence = BuildEvidence(
+            targets=[Target(id="target://libtest", name="libtest")],
+            compile_units=[CompileUnit(id="cu://lib.c", source="lib.c")],
+        )
+        pack.write()
+
+        from abicheck.cli import _print_data_sources
+
+        _print_data_sources(so_path, has_headers=True, build_source_path=pack.root)
+        out = capsys.readouterr().out
+        assert "L3 Build context: present (1 compile units, 1 targets)" in out
+
+    def test_print_data_sources_combines_build_info_and_sources(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        c_src = tmp_path / "lib.c"
+        c_src.write_text("int bar(void) { return 1; }\n")
+        so_path = tmp_path / "libtest.so"
+        subprocess.run(
+            [_GCC, "-shared", "-fPIC", "-g", "-o", str(so_path), str(c_src)],
+            capture_output=True, check=True, timeout=30,
+        )
+        build_pack = BuildSourcePack.empty(tmp_path / "build-pack")
+        build_pack.build_evidence = BuildEvidence(
+            targets=[Target(id="target://libtest", name="libtest")],
+            compile_units=[CompileUnit(id="cu://lib.c", source="lib.c")],
+        )
+        build_pack.write()
+        source_pack = BuildSourcePack.empty(tmp_path / "source-pack")
+        source_pack.source_abi = SourceAbiSurface(
+            reachable_declarations=[
+                SourceEntity(id="source://bar", kind="function", qualified_name="bar")
+            ]
+        )
+        source_pack.source_graph = SourceGraphSummary(
+            nodes=[GraphNode(id="file://lib.c", kind="file", label="lib.c")]
+        )
+        source_pack.write()
+
+        from abicheck.cli import _print_data_sources
+
+        _print_data_sources(
+            so_path,
+            has_headers=True,
+            build_source_path=build_pack.root,
+            sources_path=source_pack.root,
+        )
+        out = capsys.readouterr().out
+        assert "L3 Build context: present (1 compile units, 1 targets)" in out
+        assert "L4 Source ABI: present (1 declarations)" in out
+        assert "L5 Source graph: present (1 nodes)" in out
+
+    def test_print_data_sources_with_raw_build_source_input(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        c_src = tmp_path / "lib.c"
+        c_src.write_text("int bar(void) { return 1; }\n")
+        so_path = tmp_path / "libtest.so"
+        subprocess.run(
+            [_GCC, "-shared", "-fPIC", "-g", "-o", str(so_path), str(c_src)],
+            capture_output=True, check=True, timeout=30,
+        )
+
+        from abicheck.cli import _print_data_sources
+
+        _print_data_sources(so_path, has_headers=True, build_source_path=tmp_path)
+        captured = capsys.readouterr()
+        assert "L3 Build context:   not collected" in captured.out
+        assert "not collected in --show-data-sources" in captured.err
 
 
 # ── Error handling tests ─────────────────────────────────────────────────────

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -16,9 +16,17 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from tests.validate_examples import (  # noqa: E402
+    ARTIFACT_VARIANTS,
+    DEFAULT_ARTIFACT_VARIANT,
     CaseResult,
     _build_info_path,
+    _evaluate_verdict,
+    _json_payload,
     _normalize_verdict,
+    _result_to_json,
+    _selected_variants,
+    _source_layers_for_result,
+    _write_source_compile_db,
     main,
 )
 
@@ -56,6 +64,17 @@ class TestNormalizeVerdict:
     @pytest.mark.parametrize("verdict", sorted(_VALID_VERDICTS))
     def test_normalizes_verdict(self, verdict: str) -> None:
         assert _normalize_verdict(verdict) == self._EXPECTED_NORMALIZED[verdict]
+
+    def test_quality_risk_can_satisfy_compatible_expected(self) -> None:
+        result = _evaluate_verdict(
+            "case103",
+            "COMPATIBLE",
+            "COMPATIBLE_WITH_RISK",
+            None,
+            allow_risk_for_compatible=True,
+        )
+
+        assert result.status == "PASS"
 
 
 # ── ground_truth.json structural integrity ────────────────────────────────
@@ -168,12 +187,14 @@ class TestMainCategoryFilter:
         captured: list[str] = []
 
         def fake_run(
-            name: str, entry: dict, tmp_base: Path, fail_fast: bool = False
+            name: str,
+            entry: dict,
+            tmp_base: Path,
+            fail_fast: bool = False,
+            variant: str = DEFAULT_ARTIFACT_VARIANT,
         ) -> CaseResult:
             captured.append(name)
-            return CaseResult(
-                name, "PASS", entry.get("expected"), entry.get("expected"), ""
-            )
+            return CaseResult(name, "PASS", entry.get("expected"), entry.get("expected"), "", variant)
 
         with patch.object(ve, "run_case", side_effect=fake_run):
             main(["--category", "breaking", "--json"])
@@ -237,3 +258,132 @@ class TestMainExitCodes:
         monkeypatch.setattr(shutil, "which", lambda _t: None)
         rc = main(["--json"])
         assert rc == 2
+
+
+class TestArtifactVariants:
+    def test_default_variant_selector(self) -> None:
+        assert _selected_variants(DEFAULT_ARTIFACT_VARIANT) == (DEFAULT_ARTIFACT_VARIANT,)
+
+    def test_all_variant_selector(self) -> None:
+        assert _selected_variants("all") == ARTIFACT_VARIANTS
+
+    def test_main_passes_selected_variant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tests.validate_examples as ve
+
+        gt_file = _make_gt(
+            tmp_path,
+            {"case01": {"expected": "BREAKING", "category": "breaking"}},
+        )
+        monkeypatch.setattr(ve, "GROUND_TRUTH", gt_file)
+        monkeypatch.setattr(ve, "EXAMPLES_DIR", tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda t: f"/usr/bin/{t}")
+
+        captured: list[str] = []
+
+        def fake_run(
+            name: str,
+            entry: dict,
+            tmp_base: Path,
+            fail_fast: bool = False,
+            variant: str = DEFAULT_ARTIFACT_VARIANT,
+        ) -> CaseResult:
+            captured.append(variant)
+            return CaseResult(name, "PASS", entry.get("expected"), entry.get("expected"), "", variant)
+
+        with patch.object(ve, "run_case", side_effect=fake_run):
+            rc = main(["--artifact-variant", "stripped-headers", "--json"])
+
+        assert rc == 0
+        assert captured == ["stripped-headers"]
+
+    def test_source_compile_db_preserves_cmake_flags(self, tmp_path: Path) -> None:
+        src = tmp_path / "case104" / "v1.cpp"
+        src.parent.mkdir()
+        src.write_text("int f() { return 0; }\n")
+        cmake_build = tmp_path / "cmake_build"
+        cmake_build.mkdir()
+        compile_db = cmake_build / "compile_commands.json"
+        compile_db.write_text(json.dumps([{
+            "directory": str(cmake_build),
+            "file": str(src),
+            "arguments": [
+                "c++", "-D_GLIBCXX_USE_CXX11_ABI=0", "-std=c++20",
+                "-c", str(src),
+            ],
+        }]))
+
+        out = _write_source_compile_db(
+            tmp_path,
+            "old",
+            src,
+            src.parent,
+            fallback_compiler="c++",
+            target_suffix="v1",
+        )
+
+        entries = json.loads(out.read_text())
+        assert entries[0]["arguments"] == [
+            "c++", "-D_GLIBCXX_USE_CXX11_ABI=0", "-std=c++20",
+            "-c", str(src),
+        ]
+
+    def test_result_json_includes_remeasurement_metadata(self) -> None:
+        result = CaseResult(
+            "case04_no_change",
+            "PASS",
+            "NO_CHANGE",
+            "NO_CHANGE",
+            "",
+            "build-source",
+            1.25,
+        )
+
+        payload = _result_to_json(result)
+
+        assert payload["component"] == "synthetic-example"
+        assert payload["case_id"] == "case04_no_change"
+        assert payload["mode"] == "build-source"
+        assert payload["source_layers"] == ["L0", "L1", "L2", "L3", "L4", "L5"]
+        assert payload["evidence_asymmetry"] == "symmetric"
+        assert payload["seconds"] == 1.25
+
+    def test_source_layers_reflect_actual_headers(self, tmp_path: Path) -> None:
+        header = tmp_path / "v1.h"
+        header.write_text("int f(void);\n")
+        pack = tmp_path / "pack"
+        pack.mkdir()
+
+        assert _source_layers_for_result(
+            "debug-headers",
+            v1_hdr=header,
+            v2_hdr=None,
+            old_build_source=None,
+            new_build_source=None,
+        ) == ("L0", "L1")
+        assert _source_layers_for_result(
+            "build-source",
+            v1_hdr=header,
+            v2_hdr=header,
+            old_build_source=pack,
+            new_build_source=pack,
+        ) == ("L0", "L1", "L2", "L3", "L4", "L5")
+
+    def test_json_payload_includes_run_metadata(self) -> None:
+        result = CaseResult("case01", "FAIL", "BREAKING", "NO_CHANGE", "mismatch")
+
+        payload = _json_payload(
+            [result],
+            names=["case01"],
+            variants=("debug-headers",),
+            argv=["case01", "--json"],
+            total_ground_truth_cases=129,
+        )
+
+        assert payload["schema_version"] == "validate_examples.v2"
+        assert payload["runner"] == "tests/validate_examples.py"
+        assert payload["selected_cases"] == 1
+        assert payload["ground_truth_cases"] == 129
+        assert payload["artifact_variants"] == ["debug-headers"]
+        assert payload["summary"] == {"FAIL": 1}

--- a/tests/test_validation_component_suites.py
+++ b/tests/test_validation_component_suites.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 _SCRIPT = Path("validation/scripts/run_component_suites.py")
@@ -51,6 +52,32 @@ def test_dry_run_record_has_remeasurement_metadata() -> None:
         "-q",
     ]
     assert record["blocked_reasons"] == []
+
+
+def test_unsupported_platform_is_blocked(monkeypatch) -> None:
+    runner = _load_runner()
+    monkeypatch.setattr(runner, "platform_tag", lambda: "windows")
+
+    record = runner.run_suite("elf-symbol-surface", dry_run=False, pytest_args=[])
+
+    assert record["status"] == "blocked"
+    assert record["exit_code"] is None
+    assert "unsupported platform: windows" in record["blocked_reasons"][0]
+
+
+def test_pytest_timeout_is_failed(monkeypatch) -> None:
+    runner = _load_runner()
+
+    def fake_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=600)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    record = runner.run_suite("report-policy", dry_run=False, pytest_args=[])
+
+    assert record["status"] == "failed"
+    assert record["exit_code"] == 124
+    assert "pytest timed out after 600s" in record["blocked_reasons"]
 
 
 def test_report_summarizes_suite_statuses() -> None:

--- a/tests/test_validation_component_suites.py
+++ b/tests/test_validation_component_suites.py
@@ -1,0 +1,84 @@
+"""Tests for the component-suite remeasurement runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT = Path("validation/scripts/run_component_suites.py")
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("run_component_suites", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_parse_pytest_counts_handles_mixed_summary() -> None:
+    runner = _load_runner()
+
+    counts = runner.parse_pytest_counts(
+        "== 12 failed, 34 passed, 5 skipped, 2 warnings in 1.23s =="
+    )
+
+    assert counts == {
+        "passed": 34,
+        "failed": 12,
+        "skipped": 5,
+        "warnings": 2,
+    }
+
+
+def test_dry_run_record_has_remeasurement_metadata() -> None:
+    runner = _load_runner()
+
+    record = runner.run_suite("report-policy", dry_run=True, pytest_args=[])
+
+    assert record["schema_version"] == "component_suites.v1"
+    assert record["component"] == "component-suite"
+    assert record["case_id"] == "report-policy"
+    assert record["status"] == "planned"
+    assert record["platform"]
+    assert record["source_layers"] == ["L0", "L1", "L2", "L3", "L4", "L5"]
+    assert "tests/test_reporter.py" in record["tests"]
+    assert record["command"][:4] == [
+        runner.sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+    ]
+    assert record["blocked_reasons"] == []
+
+
+def test_report_summarizes_suite_statuses() -> None:
+    runner = _load_runner()
+    records = [
+        {"status": "planned"},
+        {"status": "planned"},
+        {"status": "blocked"},
+    ]
+
+    report = runner.make_report(records)
+
+    assert report["schema_version"] == "component_suites.v1"
+    assert report["runner"] == "validation/scripts/run_component_suites.py"
+    assert report["suite_count"] == 3
+    assert report["status_counts"] == {"blocked": 1, "planned": 2}
+    assert report["records"] == records
+
+
+def test_main_writes_json_report(tmp_path: Path) -> None:
+    runner = _load_runner()
+    out = tmp_path / "component_suites.json"
+
+    rc = runner.main(["--suite", "report-policy", "--dry-run", "--output", str(out)])
+
+    assert rc == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["schema_version"] == "component_suites.v1"
+    assert data["suite_count"] == 1
+    assert data["records"][0]["suite"] == "report-policy"
+    assert data["records"][0]["status"] == "planned"

--- a/tests/test_validation_remeasurement_summary.py
+++ b/tests/test_validation_remeasurement_summary.py
@@ -117,7 +117,7 @@ def test_summarizes_real_world_artifact(tmp_path: Path) -> None:
                     "mode": "dwarf->sym",
                     "got": "API_BREAK",
                     "expected": "COMPATIBLE",
-                    "comparison_status": "ABICHECK_STRICTER",
+                    "comparison_status": "abicheck_stricter",
                     "source_layers": ["L0", "L1"],
                     "exit_code": 2,
                 },
@@ -201,6 +201,13 @@ def test_main_writes_combined_summary(tmp_path: Path) -> None:
     assert rc == 0
     data = json.loads(out.read_text(encoding="utf-8"))
     assert data["schema_version"] == "remeasurement_summary.v1"
+    assert data["command"] == [
+        summary.sys.executable,
+        "--examples",
+        str(examples),
+        "--output",
+        str(out),
+    ]
     assert data["section_count"] == 1
     assert data["total_records"] == 1
     assert data["blocking_failures"] == 0

--- a/tests/test_validation_remeasurement_summary.py
+++ b/tests/test_validation_remeasurement_summary.py
@@ -108,16 +108,18 @@ def test_summarizes_real_world_artifact(tmp_path: Path) -> None:
                     "mode": "sym->sym",
                     "got": "COMPATIBLE",
                     "expected": "COMPATIBLE",
+                    "comparison_status": "MATCH",
                     "source_layers": ["L0"],
                     "exit_code": 0,
                 },
                 {
                     "schema_version": "run_matrix.v2",
                     "mode": "dwarf->sym",
-                    "got": "BREAKING",
+                    "got": "API_BREAK",
                     "expected": "COMPATIBLE",
+                    "comparison_status": "ABICHECK_STRICTER",
                     "source_layers": ["L0", "L1"],
-                    "exit_code": 1,
+                    "exit_code": 2,
                 },
             ]
         )
@@ -137,10 +139,41 @@ def test_summarizes_real_world_artifact(tmp_path: Path) -> None:
     assert section["component"] == "real-world-matrix"
     assert section["schema_version"] == "run_matrix.v2"
     assert section["mode_counts"] == {"dwarf->sym": 1, "sym->sym": 1}
-    assert section["verdict_counts"] == {"BREAKING": 1, "COMPATIBLE": 1}
+    assert section["verdict_counts"] == {"API_BREAK": 1, "COMPATIBLE": 1}
     assert section["expected_counts"] == {"COMPATIBLE": 2}
+    assert section["comparison_status_counts"] == {
+        "ABICHECK_STRICTER": 1,
+        "MATCH": 1,
+    }
     assert section["source_layer_counts"] == {"L0": 2, "L1": 1}
+    assert section["run_errors"] == 0
+    assert section["expectation_mismatches"] == 1
     assert section["blocking_failures"] == 1
+
+
+def test_real_world_summary_infers_status_for_older_artifacts(tmp_path: Path) -> None:
+    summary = _load_summary()
+    artifact = tmp_path / "results.json"
+    artifact.write_text(
+        json.dumps(
+            [
+                {
+                    "mode": "sym->sym",
+                    "verdict": "API_BREAK",
+                    "expectation": "BREAKING",
+                    "source_layers": ["L0"],
+                    "exit_code": 2,
+                }
+            ]
+        )
+    )
+
+    section = summary.summarize_real_world(artifact)
+
+    assert section["comparison_status_counts"] == {"MATCH": 1}
+    assert section["verdict_counts"] == {"API_BREAK": 1}
+    assert section["expected_counts"] == {"BREAKING": 1}
+    assert section["blocking_failures"] == 0
 
 
 def test_main_writes_combined_summary(tmp_path: Path) -> None:

--- a/tests/test_validation_remeasurement_summary.py
+++ b/tests/test_validation_remeasurement_summary.py
@@ -1,0 +1,173 @@
+"""Tests for the combined remeasurement summary generator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT = Path("validation/scripts/summarize_remeasurement.py")
+
+
+def _load_summary():
+    spec = importlib.util.spec_from_file_location("summarize_remeasurement", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_summarizes_example_artifact(tmp_path: Path) -> None:
+    summary = _load_summary()
+    artifact = tmp_path / "validate_examples.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "validate_examples.v2",
+                "runner": "tests/validate_examples.py",
+                "platform": "linux",
+                "command": ["python", "tests/validate_examples.py", "--json"],
+                "summary": {"PASS": 1, "ERROR": 1},
+                "results": [
+                    {
+                        "status": "PASS",
+                        "mode": "debug-headers",
+                        "source_layers": ["L0", "L1", "L2"],
+                    },
+                    {
+                        "status": "ERROR",
+                        "mode": "build-source",
+                        "source_layers": ["L0", "L1", "L2", "L3", "L4", "L5"],
+                    },
+                ],
+            }
+        )
+    )
+
+    section = summary.summarize_examples(artifact)
+
+    assert section["schema_version"] == "validate_examples.v2"
+    assert section["component"] == "synthetic-example"
+    assert section["total"] == 2
+    assert section["status_counts"] == {"ERROR": 1, "PASS": 1}
+    assert section["mode_counts"] == {"build-source": 1, "debug-headers": 1}
+    assert section["source_layer_counts"]["L5"] == 1
+    assert section["blocking_failures"] == 1
+
+
+def test_summarizes_component_artifact(tmp_path: Path) -> None:
+    summary = _load_summary()
+    artifact = tmp_path / "component_suites.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "component_suites.v1",
+                "runner": "validation/scripts/run_component_suites.py",
+                "platform": "linux",
+                "status_counts": {"blocked": 1, "planned": 1},
+                "records": [
+                    {
+                        "suite": "report-policy",
+                        "status": "planned",
+                        "source_layers": ["L0", "L1"],
+                    },
+                    {
+                        "suite": "debug-metadata",
+                        "status": "blocked",
+                        "source_layers": ["L1"],
+                        "blocked_reasons": ["missing Python dependency: pefile"],
+                    },
+                ],
+            }
+        )
+    )
+
+    section = summary.summarize_components(artifact)
+
+    assert section["component"] == "component-suite"
+    assert section["status_counts"] == {"blocked": 1, "planned": 1}
+    assert section["suite_counts"] == {"debug-metadata": 1, "report-policy": 1}
+    assert section["blocked"] == [
+        {
+            "suite": "debug-metadata",
+            "blocked_reasons": ["missing Python dependency: pefile"],
+        }
+    ]
+    assert section["blocking_failures"] == 1
+
+
+def test_summarizes_real_world_artifact(tmp_path: Path) -> None:
+    summary = _load_summary()
+    artifact = tmp_path / "results.json"
+    meta = tmp_path / "results.meta.json"
+    artifact.write_text(
+        json.dumps(
+            [
+                {
+                    "schema_version": "run_matrix.v2",
+                    "mode": "sym->sym",
+                    "got": "COMPATIBLE",
+                    "expected": "COMPATIBLE",
+                    "source_layers": ["L0"],
+                    "exit_code": 0,
+                },
+                {
+                    "schema_version": "run_matrix.v2",
+                    "mode": "dwarf->sym",
+                    "got": "BREAKING",
+                    "expected": "COMPATIBLE",
+                    "source_layers": ["L0", "L1"],
+                    "exit_code": 1,
+                },
+            ]
+        )
+    )
+    meta.write_text(
+        json.dumps(
+            {
+                "schema_version": "run_matrix.v2",
+                "runner": "validation/scripts/run_matrix.py",
+                "platform": "linux",
+            }
+        )
+    )
+
+    section = summary.summarize_real_world(artifact, meta)
+
+    assert section["component"] == "real-world-matrix"
+    assert section["schema_version"] == "run_matrix.v2"
+    assert section["mode_counts"] == {"dwarf->sym": 1, "sym->sym": 1}
+    assert section["verdict_counts"] == {"BREAKING": 1, "COMPATIBLE": 1}
+    assert section["expected_counts"] == {"COMPATIBLE": 2}
+    assert section["source_layer_counts"] == {"L0": 2, "L1": 1}
+    assert section["blocking_failures"] == 1
+
+
+def test_main_writes_combined_summary(tmp_path: Path) -> None:
+    summary = _load_summary()
+    examples = tmp_path / "examples.json"
+    out = tmp_path / "summary.json"
+    examples.write_text(
+        json.dumps(
+            {
+                "schema_version": "validate_examples.v2",
+                "summary": {"PASS": 1},
+                "results": [
+                    {
+                        "status": "PASS",
+                        "mode": "debug-headers",
+                        "source_layers": ["L0"],
+                    }
+                ],
+            }
+        )
+    )
+
+    rc = summary.main(["--examples", str(examples), "--output", str(out)])
+
+    assert rc == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["schema_version"] == "remeasurement_summary.v1"
+    assert data["section_count"] == 1
+    assert data["total_records"] == 1
+    assert data["blocking_failures"] == 0

--- a/tests/test_validation_run_matrix.py
+++ b/tests/test_validation_run_matrix.py
@@ -54,6 +54,16 @@ def test_run_matrix_records_source_layer_asymmetry() -> None:
     assert run_matrix.evidence_asymmetry("sym->dwarf") == "old-poor/new-rich"
 
 
+def test_run_matrix_scores_expected_vs_actual_verdicts() -> None:
+    run_matrix = _load_run_matrix()
+
+    assert run_matrix.normalize_verdict("COMPATIBLE_WITH_RISK") == "COMPATIBLE"
+    assert run_matrix.normalize_verdict("API_BREAK") == "BREAKING"
+    assert run_matrix.comparison_status("BREAKING", "API_BREAK") == "MATCH"
+    assert run_matrix.comparison_status("COMPATIBLE", "BREAKING") == "ABICHECK_STRICTER"
+    assert run_matrix.comparison_status("BREAKING", "NO_CHANGE") == "ABICHECK_WEAKER"
+
+
 def test_run_matrix_record_has_remeasurement_metadata() -> None:
     run_matrix = _load_run_matrix()
     row = {
@@ -92,6 +102,9 @@ def test_run_matrix_record_has_remeasurement_metadata() -> None:
     assert rec["evidence_asymmetry"] == "old-rich/new-poor"
     assert rec["seconds"] == 1.23
     assert rec["got"] == "COMPATIBLE_WITH_RISK"
+    assert rec["normalized_expected"] == "COMPATIBLE"
+    assert rec["normalized_got"] == "COMPATIBLE"
+    assert rec["comparison_status"] == "MATCH"
     assert rec["counts"] == {"breaking": 0, "risk": 2}
     assert rec["release_recommendation"] == "manual_review"
     assert rec["layer_coverage"] == [{"layer": "L0"}, {"layer": "L1"}]
@@ -101,7 +114,10 @@ def test_run_matrix_run_metadata_summarizes_modes() -> None:
     run_matrix = _load_run_matrix()
 
     meta = run_matrix.make_run_metadata(
-        [{"mode": "sym->sym"}, {"mode": "dwarf->sym"}],
+        [
+            {"mode": "sym->sym", "comparison_status": "MATCH"},
+            {"mode": "dwarf->sym", "comparison_status": "ABICHECK_WEAKER"},
+        ],
         [{"pair": "A"}, {"pair": "B"}],
     )
 
@@ -111,4 +127,5 @@ def test_run_matrix_run_metadata_summarizes_modes() -> None:
     assert meta["manifest_pairs"] == 2
     assert meta["comparisons"] == 2
     assert meta["modes"] == ["dwarf->sym", "sym->sym"]
+    assert meta["comparison_status_counts"] == {"ABICHECK_WEAKER": 1, "MATCH": 1}
     assert meta["results_file"] == "validation/data/results.json"

--- a/tests/test_validation_run_matrix.py
+++ b/tests/test_validation_run_matrix.py
@@ -11,6 +11,7 @@ import importlib.util
 from pathlib import Path
 
 _SCRIPT = Path("validation/scripts/conda_harness.py")
+_RUN_MATRIX_SCRIPT = Path("validation/scripts/run_matrix.py")
 
 
 def _load_logical_name():
@@ -19,6 +20,14 @@ def _load_logical_name():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod.logical_name
+
+
+def _load_run_matrix():
+    spec = importlib.util.spec_from_file_location("run_matrix", _RUN_MATRIX_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def test_logical_name_handles_standard_soname_suffixes() -> None:
@@ -33,3 +42,73 @@ def test_logical_name_strips_version_embedded_before_so_suffix() -> None:
 
     assert logical_name("/pkg/lib/libcapnp-1.4.0.so") == "libcapnp"
     assert logical_name("/pkg/lib/libkj-async-1.3.0.so") == "libkj-async"
+
+
+def test_run_matrix_records_source_layer_asymmetry() -> None:
+    run_matrix = _load_run_matrix()
+
+    assert run_matrix.side_layers("sym") == ["L0"]
+    assert run_matrix.side_layers("dwarf") == ["L0", "L1"]
+    assert run_matrix.evidence_asymmetry("sym->sym") == "symmetric"
+    assert run_matrix.evidence_asymmetry("dwarf->sym") == "old-rich/new-poor"
+    assert run_matrix.evidence_asymmetry("sym->dwarf") == "old-poor/new-rich"
+
+
+def test_run_matrix_record_has_remeasurement_metadata() -> None:
+    run_matrix = _load_run_matrix()
+    row = {
+        "pair": "TBB_2021_2022",
+        "library": "oneTBB",
+        "old_ver": "2021.9",
+        "new_ver": "2022.0",
+        "expectation": "COMPATIBLE_WITH_RISK",
+        "note": "known risk pair",
+    }
+
+    rec = run_matrix.make_record(
+        row,
+        logical="libtbb",
+        old_path="/old/libtbb.so",
+        new_path="/new/libtbb.so",
+        mode="dwarf->sym",
+        exit_code=0,
+        seconds=1.234,
+        stderr="",
+        data={
+            "verdict": "COMPATIBLE_WITH_RISK",
+            "summary": {"breaking": 0, "risk": 2},
+            "release_recommendation": "manual_review",
+            "layer_coverage": [{"layer": "L0"}, {"layer": "L1"}],
+        },
+    )
+
+    assert rec["schema_version"] == "run_matrix.v2"
+    assert rec["component"] == "real-world-matrix"
+    assert rec["case_id"] == "TBB_2021_2022__libtbb"
+    assert rec["platform"]
+    assert rec["source_layers"] == ["L0", "L1"]
+    assert rec["old_source_layers"] == ["L0", "L1"]
+    assert rec["new_source_layers"] == ["L0"]
+    assert rec["evidence_asymmetry"] == "old-rich/new-poor"
+    assert rec["seconds"] == 1.23
+    assert rec["got"] == "COMPATIBLE_WITH_RISK"
+    assert rec["counts"] == {"breaking": 0, "risk": 2}
+    assert rec["release_recommendation"] == "manual_review"
+    assert rec["layer_coverage"] == [{"layer": "L0"}, {"layer": "L1"}]
+
+
+def test_run_matrix_run_metadata_summarizes_modes() -> None:
+    run_matrix = _load_run_matrix()
+
+    meta = run_matrix.make_run_metadata(
+        [{"mode": "sym->sym"}, {"mode": "dwarf->sym"}],
+        [{"pair": "A"}, {"pair": "B"}],
+    )
+
+    assert meta["schema_version"] == "run_matrix.v2"
+    assert meta["runner"] == "validation/scripts/run_matrix.py"
+    assert meta["platform"]
+    assert meta["manifest_pairs"] == 2
+    assert meta["comparisons"] == 2
+    assert meta["modes"] == ["dwarf->sym", "sym->sym"]
+    assert meta["results_file"] == "validation/data/results.json"

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2024 CodeRabbit Inc.
+
 # pylint: disable=too-many-branches,too-many-statements,too-many-locals,too-many-arguments,too-many-return-statements
 """validate_examples.py — standalone CLI validation of all abicheck example cases.
 
@@ -28,12 +31,29 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import NamedTuple
 
 REPO_DIR = Path(__file__).parent.parent
 EXAMPLES_DIR = REPO_DIR / "examples"
 GROUND_TRUTH = EXAMPLES_DIR / "ground_truth.json"
+
+ARTIFACT_VARIANTS = (
+    "debug-headers",
+    "release-headers",
+    "stripped-headers",
+    "build-source",
+)
+DEFAULT_ARTIFACT_VARIANT = "debug-headers"
+JSON_SCHEMA_VERSION = "validate_examples.v2"
+
+SOURCE_LAYERS_BY_VARIANT = {
+    "debug-headers": ("L0", "L1", "L2"),
+    "release-headers": ("L0", "L2"),
+    "stripped-headers": ("L0", "L2"),
+    "build-source": ("L0", "L1", "L2", "L3", "L4", "L5"),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +74,7 @@ CURRENT_PLATFORM = _current_platform()
 
 
 def _shared_lib_suffix() -> str:
+    """Return the shared-library suffix for the current platform."""
     if sys.platform == "darwin":
         return ".dylib"
     if sys.platform == "win32":
@@ -91,6 +112,9 @@ class CaseResult(NamedTuple):
     expected: str | None
     got: str | None
     message: str
+    variant: str = DEFAULT_ARTIFACT_VARIANT
+    seconds: float = 0.0
+    source_layers: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +202,7 @@ def _find_sources(
     return None
 
 
-def _compile(src: Path, out: Path) -> str | None:
+def _compile(src: Path, out: Path, *, variant: str = DEFAULT_ARTIFACT_VARIANT) -> str | None:
     """Compile src → shared lib. Returns error string on failure, None on success."""
     is_cpp = src.suffix == ".cpp"
     compiler = _find_compiler(is_cpp)
@@ -186,13 +210,16 @@ def _compile(src: Path, out: Path) -> str | None:
         return f"no {'C++' if is_cpp else 'C'} compiler found"
 
     if compiler == "cl":
-        args = [compiler, "/LD", "/Zi", "/Fe:" + str(out), str(src)]
+        args = [compiler, "/LD", "/Fe:" + str(out), str(src)]
+        args.insert(2, "/O2" if variant == "release-headers" else "/Zi")
     elif sys.platform == "darwin":
-        args = [compiler, "-dynamiclib", "-g", "-Og", "-fvisibility=default",
+        opt_flags = ["-O2"] if variant == "release-headers" else ["-g", "-Og"]
+        args = [compiler, "-dynamiclib", *opt_flags, "-fvisibility=default",
                 "-install_name", "@rpath/lib.dylib",
                 "-o", str(out), str(src)]
     else:
-        args = [compiler, "-shared", "-fPIC", "-g", "-Og", "-fvisibility=default",
+        opt_flags = ["-O2"] if variant == "release-headers" else ["-g", "-Og"]
+        args = [compiler, "-shared", "-fPIC", *opt_flags, "-fvisibility=default",
                 "-o", str(out), str(src)]
 
     r = subprocess.run(args, capture_output=True, text=True, timeout=30)
@@ -222,7 +249,12 @@ def _find_built_lib(directory: Path, name: str) -> Path | None:
     return None
 
 
-def _build_with_cmake(case_dir: Path, build_dir: Path) -> tuple[Path | None, Path | None, str]:
+def _build_with_cmake(
+    case_dir: Path,
+    build_dir: Path,
+    *,
+    variant: str = DEFAULT_ARTIFACT_VARIANT,
+) -> tuple[Path | None, Path | None, str]:
     """Build a case using CMake. Returns (v1_lib, v2_lib, error_msg)."""
     cmake = shutil.which("cmake")
     if not cmake:
@@ -230,10 +262,12 @@ def _build_with_cmake(case_dir: Path, build_dir: Path) -> tuple[Path | None, Pat
 
     case_name = case_dir.name
     case_out = build_dir / case_name
+    build_type = "Release" if variant == "release-headers" else "Debug"
 
     r = subprocess.run(
         [cmake, "-S", str(case_dir.parent), "-B", str(build_dir),
-         "-DCMAKE_BUILD_TYPE=Debug"],
+         f"-DCMAKE_BUILD_TYPE={build_type}",
+         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
         capture_output=True, text=True, timeout=60,
     )
     if r.returncode != 0:
@@ -243,7 +277,7 @@ def _build_with_cmake(case_dir: Path, build_dir: Path) -> tuple[Path | None, Pat
     v2_target = f"{case_name}_v2"
     r = subprocess.run(
         [cmake, "--build", str(build_dir), "--target", v1_target, v2_target,
-         "--config", "Debug"],
+         "--config", build_type],
         capture_output=True, text=True, timeout=120,
     )
     if r.returncode != 0:
@@ -277,6 +311,8 @@ def _build_libs(
     tmp: Path,
     v1_src: Path,
     v2_src: Path,
+    *,
+    variant: str = DEFAULT_ARTIFACT_VARIANT,
 ) -> tuple[Path | None, Path | None, str | None]:
     """Build v1 and v2 shared libraries. Returns (v1_so, v2_so, error_or_skip).
 
@@ -288,9 +324,13 @@ def _build_libs(
 
     if has_cmake_file and has_cmake:
         cmake_build = tmp / "cmake_build"
-        v1_so, v2_so, err = _build_with_cmake(case_dir, cmake_build)
+        v1_so, v2_so, err = _build_with_cmake(case_dir, cmake_build, variant=variant)
         if err:
             return None, None, err
+        if variant == "stripped-headers":
+            strip_err = _strip_debug_info(v1_so, v2_so)
+            if strip_err:
+                return None, None, strip_err
         return v1_so, v2_so, None
 
     if has_cmake_file and not has_cmake:
@@ -303,13 +343,35 @@ def _build_libs(
     # Direct compilation (no CMakeLists.txt, or cmake absent but no special flags)
     v1_so = tmp / f"libv1{SHARED_LIB_SUFFIX}"
     v2_so = tmp / f"libv2{SHARED_LIB_SUFFIX}"
-    err = _compile(v1_src, v1_so)
+    err = _compile(v1_src, v1_so, variant=variant)
     if err:
         return None, None, f"compile v1 failed: {err[:200]}"
-    err = _compile(v2_src, v2_so)
+    err = _compile(v2_src, v2_so, variant=variant)
     if err:
         return None, None, f"compile v2 failed: {err[:200]}"
+    if variant == "stripped-headers":
+        strip_err = _strip_debug_info(v1_so, v2_so)
+        if strip_err:
+            return None, None, strip_err
     return v1_so, v2_so, None
+
+
+def _strip_debug_info(*libs: Path) -> str | None:
+    """Strip debug information from built libraries for release-with-headers checks."""
+    strip = shutil.which("strip")
+    if not strip:
+        return "SKIP:strip tool not found"
+    if sys.platform == "win32":
+        return (
+            "SKIP:Windows PE/PDB require a different strip tool/flags "
+            "(not implemented)"
+        )
+    flags = ["-S"] if sys.platform == "darwin" else ["-g"]
+    for lib in libs:
+        r = subprocess.run([strip, *flags, str(lib)], capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            return f"strip failed for {lib.name}: {r.stderr[:200]}"
+    return None
 
 
 def _build_info_path(
@@ -338,6 +400,8 @@ def _dump_and_compare(
     v1_hdr: Path | None,
     v2_hdr: Path | None,
     scope_public_headers: bool = False,
+    old_build_source: Path | None = None,
+    new_build_source: Path | None = None,
     case_dir: Path | None = None,
     build_info: bool = False,
 ) -> tuple[str | None, str | None]:
@@ -349,6 +413,9 @@ def _dump_and_compare(
     cmd1 = [sys.executable, "-m", "abicheck.cli", "dump", str(v1_so), "-o", str(snap1)]
     if v1_hdr and Path(v1_hdr).exists():
         cmd1 += ["-H", str(v1_hdr)]
+        old_compile_db = tmp / "old_compile_commands.json"
+        if old_build_source is not None and old_compile_db.exists():
+            cmd1 += ["-p", str(old_compile_db)]
     bi1 = _build_info_path(case_dir, "v1", build_info)
     if bi1 is not None:
         cmd1 += ["--build-info", str(bi1)]
@@ -360,6 +427,9 @@ def _dump_and_compare(
     cmd2 = [sys.executable, "-m", "abicheck.cli", "dump", str(v2_so), "-o", str(snap2)]
     if v2_hdr and Path(v2_hdr).exists():
         cmd2 += ["-H", str(v2_hdr)]
+        new_compile_db = tmp / "new_compile_commands.json"
+        if new_build_source is not None and new_compile_db.exists():
+            cmd2 += ["-p", str(new_compile_db)]
     bi2 = _build_info_path(case_dir, "v2", build_info)
     if bi2 is not None:
         cmd2 += ["--build-info", str(bi2)]
@@ -370,6 +440,16 @@ def _dump_and_compare(
     compare_cmd = [
         sys.executable, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json",
     ]
+    if old_build_source is not None:
+        compare_cmd += [
+            "--old-build-info", str(old_build_source),
+            "--old-sources", str(old_build_source),
+        ]
+    if new_build_source is not None:
+        compare_cmd += [
+            "--new-build-info", str(new_build_source),
+            "--new-sources", str(new_build_source),
+        ]
     # Scoping is on by default since ADR-024 Phase 5; ground_truth.json verdicts
     # are authored unscoped unless the case opts in, so be explicit either way.
     compare_cmd.append(
@@ -386,14 +466,178 @@ def _dump_and_compare(
         return None, f"invalid JSON from compare: {rc.stdout[:200]}"
 
 
+def _write_compile_db(
+    db_path: Path,
+    *,
+    src: Path,
+    case_dir: Path,
+    compiler: str,
+) -> None:
+    """Write a minimal compile_commands.json for source-evidence validation."""
+    args = [compiler, "-I", str(case_dir), "-c", str(src)]
+    db_path.write_text(json.dumps([{
+        "directory": str(case_dir),
+        "file": str(src),
+        "arguments": args,
+    }]))
+
+
+def _write_source_compile_db(
+    tmp: Path,
+    side: str,
+    src: Path,
+    case_dir: Path,
+    fallback_compiler: str,
+    target_suffix: str,
+) -> Path:
+    """Write a side-specific compile DB, preserving CMake flags when available."""
+    out = tmp / f"{side}_compile_commands.json"
+    cmake_db = tmp / "cmake_build" / "compile_commands.json"
+    if cmake_db.exists():
+        entries = json.loads(cmake_db.read_text())
+        src_resolved = src.resolve()
+        case_resolved = case_dir.resolve()
+
+        def entry_file(entry: dict) -> Path:
+            return Path(str(entry.get("file", ""))).expanduser()
+
+        def same_source(entry: dict) -> bool:
+            try:
+                return entry_file(entry).resolve() == src_resolved
+            except OSError:
+                return False
+
+        def same_case_source(entry: dict) -> bool:
+            path = entry_file(entry)
+            try:
+                resolved = path.resolve()
+            except OSError:
+                return False
+            return (
+                resolved.name == src.name
+                and resolved.parent == case_resolved
+            )
+
+        def same_side_target(entry: dict) -> bool:
+            args = [str(a) for a in entry.get("arguments", [])]
+            command = str(entry.get("command", ""))
+            needle = f"{case_dir.name}_{target_suffix}"
+            return needle in " ".join([*args, command])
+
+        selected = [
+            e for e in entries
+            if same_side_target(e)
+        ]
+        if not selected:
+            selected = [
+                e for e in entries
+                if same_source(e)
+            ]
+        if not selected:
+            selected = [
+                e for e in entries
+                if same_case_source(e)
+            ]
+        if selected:
+            out.write_text(json.dumps(selected, indent=2))
+            return out
+    _write_compile_db(out, src=src, case_dir=case_dir, compiler=fallback_compiler)
+    return out
+
+
+def _registered_cli_command(*args: str) -> list[str]:
+    """Run abicheck CLI with plugin-style commands registered in subprocesses."""
+    return [
+        sys.executable,
+        "-c",
+        (
+            "import sys; import abicheck.cli_buildsource; "
+            "from abicheck.cli import main; "
+            "main(args=sys.argv[1:], prog_name='abicheck')"
+        ),
+        *args,
+    ]
+
+
+def _collect_build_source_evidence(
+    tmp: Path,
+    case_dir: Path,
+    v1_src: Path,
+    v2_src: Path,
+    v1_so: Path,
+    v2_so: Path,
+) -> tuple[Path | None, Path | None, str | None]:
+    """Collect L3/L4/L5 build-source packs for the build-source artifact variant."""
+    if not shutil.which("castxml"):
+        return None, None, "SKIP:castxml not found for source-ABI replay"
+
+    results: list[Path] = []
+    for side, src, binary in (("old", v1_src, v1_so), ("new", v2_src, v2_so)):
+        compiler = _find_compiler(src.suffix == ".cpp")
+        if not compiler:
+            return None, None, f"SKIP:no compiler found for {side} source evidence"
+        db_path = _write_source_compile_db(
+            tmp,
+            side,
+            src,
+            case_dir,
+            fallback_compiler=compiler,
+            target_suffix="v1" if side == "old" else "v2",
+        )
+        out_dir = tmp / f"{side}.buildsource"
+        cmd = _registered_cli_command(
+            "collect",
+            "--binary", str(binary),
+            "--compile-db", str(db_path),
+            "--source-root", str(case_dir),
+            "--source-abi",
+            "--source-abi-extractor", "castxml",
+            "--source-abi-scope", "full",
+            "--source-graph", "summary",
+            "-o", str(out_dir),
+        )
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+        if r.returncode != 0:
+            detail = (r.stderr or r.stdout)[:300]
+            return None, None, f"collect {side} failed: {detail}"
+        results.append(out_dir)
+    return results[0], results[1], None
+
+
+def _source_layers_for_result(
+    variant: str,
+    *,
+    v1_hdr: Path | None,
+    v2_hdr: Path | None,
+    old_build_source: Path | None,
+    new_build_source: Path | None,
+) -> tuple[str, ...]:
+    """Return the evidence layers actually supplied for this case result."""
+    layers = ["L0"]
+    if variant in {"debug-headers", "build-source"}:
+        layers.append("L1")
+    if v1_hdr and v1_hdr.exists() and v2_hdr and v2_hdr.exists():
+        layers.append("L2")
+    if old_build_source is not None and new_build_source is not None:
+        layers.extend(["L3", "L4", "L5"])
+    return tuple(layers)
+
+
 def _evaluate_verdict(
     name: str,
     expected_raw: str | None,
     got: str,
     known_gap: str | None,
+    allow_risk_for_compatible: bool = False,
 ) -> CaseResult:
     """Compare *got* verdict against *expected_raw* and return a CaseResult."""
     expected = expected_raw or "UNKNOWN"
+    if (
+        allow_risk_for_compatible
+        and expected == "COMPATIBLE"
+        and got == "COMPATIBLE_WITH_RISK"
+    ):
+        return CaseResult(name, "PASS", expected_raw, got, "")
     if _normalize_verdict(got) == _normalize_verdict(expected):
         return CaseResult(name, "PASS", expected_raw, got, "")
     if known_gap:
@@ -473,38 +717,68 @@ def run_case(
     entry: dict,
     tmp_base: Path,
     fail_fast: bool = False,
+    variant: str = DEFAULT_ARTIFACT_VARIANT,
 ) -> CaseResult:
+    """Build, compare, and evaluate one example case."""
     expected_raw = entry.get("expected")
     known_gap = entry.get("known_gap")
 
     skip_result = _check_case_preconditions(name, entry)
     if skip_result is not None:
-        return skip_result
+        return skip_result._replace(variant=variant)
 
     resolved = _resolve_case_sources(name, expected_raw)
     if isinstance(resolved, CaseResult):
-        return resolved
+        return resolved._replace(variant=variant)
     case_dir, (v1_src, v2_src, v1_hdr, v2_hdr) = resolved
 
     tmp = tmp_base / name
+    if variant != DEFAULT_ARTIFACT_VARIANT:
+        tmp = tmp_base / f"{name}__{variant}"
     tmp.mkdir(parents=True)
 
     # Build
-    v1_so, v2_so, build_err = _build_libs(name, case_dir, tmp, v1_src, v2_src)
+    v1_so, v2_so, build_err = _build_libs(
+        name, case_dir, tmp, v1_src, v2_src, variant=variant
+    )
     if build_err is not None:
-        return _handle_build_error(name, expected_raw, build_err)
+        res = _handle_build_error(name, expected_raw, build_err)
+        return res._replace(variant=variant)
+
+    old_build_source = new_build_source = None
+    if variant == "build-source":
+        old_build_source, new_build_source, ev_err = _collect_build_source_evidence(
+            tmp, case_dir, v1_src, v2_src, v1_so, v2_so
+        )
+        if ev_err is not None:
+            if ev_err.startswith("SKIP:"):
+                return CaseResult(name, "SKIP", expected_raw, None, ev_err[5:], variant)
+            return CaseResult(name, "ERROR", expected_raw, None, ev_err, variant)
 
     # Dump + compare
     got, dc_err = _dump_and_compare(
         tmp, v1_so, v2_so, v1_hdr, v2_hdr,
         scope_public_headers=bool(entry.get("scope_public_headers", False)),
+        old_build_source=old_build_source,
+        new_build_source=new_build_source,
         case_dir=case_dir,
         build_info=bool(entry.get("build_info", False)),
     )
     if dc_err is not None:
-        return CaseResult(name, "ERROR", expected_raw, None, dc_err)
+        return CaseResult(name, "ERROR", expected_raw, None, dc_err, variant)
 
-    return _evaluate_verdict(name, expected_raw, got, known_gap)
+    allow_risk = bool(entry.get("bad_practice") or entry.get("category") == "quality")
+    source_layers = _source_layers_for_result(
+        variant,
+        v1_hdr=v1_hdr,
+        v2_hdr=v2_hdr,
+        old_build_source=old_build_source,
+        new_build_source=new_build_source,
+    )
+    return _evaluate_verdict(
+        name, expected_raw, got, known_gap,
+        allow_risk_for_compatible=allow_risk,
+    )._replace(variant=variant, source_layers=source_layers)
 
 
 # ---------------------------------------------------------------------------
@@ -537,34 +811,87 @@ def _run_all_cases(
     *,
     fail_fast: bool = False,
     json_out: bool = False,
+    variants: tuple[str, ...] = (DEFAULT_ARTIFACT_VARIANT,),
 ) -> list[CaseResult]:
     """Iterate over *names*, run each case, print progress, and return results."""
     results: list[CaseResult] = []
     with tempfile.TemporaryDirectory(prefix="validate_examples_") as tmp_root:
         tmp_base = Path(tmp_root)
-        for name in names:
-            res = run_case(name, verdicts[name], tmp_base)
-            results.append(res)
-            if not json_out:
-                icon = {"PASS": "\u2705", "FAIL": "\u274c", "XFAIL": "\u26a0\ufe0f ",
-                        "SKIP": "\u23ed\ufe0f ", "ERROR": "\U0001f4a5"}.get(res.status, "?")
-                msg = f"  {res.message}" if res.message else ""
-                print(f"{icon} {res.name:<42}  {res.status}{msg}")
-            if fail_fast and res.status == "FAIL":
-                break
+        for variant in variants:
+            for name in names:
+                started = time.perf_counter()
+                res = run_case(name, verdicts[name], tmp_base, variant=variant)
+                res = res._replace(seconds=round(time.perf_counter() - started, 3))
+                results.append(res)
+                if not json_out:
+                    icon = {"PASS": "\u2705", "FAIL": "\u274c", "XFAIL": "\u26a0\ufe0f ",
+                            "SKIP": "\u23ed\ufe0f ", "ERROR": "\U0001f4a5"}.get(res.status, "?")
+                    msg = f"  {res.message}" if res.message else ""
+                    print(f"{icon} {res.name:<42}  {res.status} [{res.variant}]{msg}")
+                if fail_fast and res.status == "FAIL":
+                    return results
     return results
 
 
-def _print_summary(results: list[CaseResult], *, json_out: bool) -> int:
-    """Print summary of *results* and return exit code (0=pass, 1=fail)."""
+def _summary_counts(results: list[CaseResult]) -> dict[str, int]:
+    """Count result statuses."""
     counts: dict[str, int] = {}
     for r in results:
         counts[r.status] = counts.get(r.status, 0) + 1
+    return counts
+
+
+def _result_to_json(r: CaseResult) -> dict[str, object]:
+    """Convert a case result to the JSON artifact schema."""
+    d = r._asdict()
+    d["component"] = "synthetic-example"
+    d["case_id"] = r.name
+    d["platform"] = CURRENT_PLATFORM
+    d["mode"] = r.variant
+    d["source_layers"] = list(
+        r.source_layers or SOURCE_LAYERS_BY_VARIANT.get(r.variant, ())
+    )
+    d["evidence_asymmetry"] = "symmetric"
+    d["manual_review_ok"] = r.status in {"XFAIL", "SKIP"}
+    return d
+
+
+def _json_payload(
+    results: list[CaseResult],
+    *,
+    names: list[str],
+    variants: tuple[str, ...],
+    argv: list[str],
+    total_ground_truth_cases: int,
+) -> dict[str, object]:
+    """Build the top-level JSON payload for a validation run."""
+    return {
+        "schema_version": JSON_SCHEMA_VERSION,
+        "runner": "tests/validate_examples.py",
+        "platform": CURRENT_PLATFORM,
+        "command": [sys.executable, "tests/validate_examples.py", *argv],
+        "ground_truth_cases": total_ground_truth_cases,
+        "selected_cases": len(names),
+        "artifact_variants": list(variants),
+        "summary": _summary_counts(results),
+        "results": [_result_to_json(r) for r in results],
+    }
+
+
+def _print_summary(
+    results: list[CaseResult],
+    *,
+    json_out: bool,
+    json_payload: dict[str, object] | None = None,
+) -> int:
+    """Print summary of *results* and return exit code (0=pass, 1=fail)."""
+    counts = _summary_counts(results)
 
     if json_out:
-        print(json.dumps({
+        print(json.dumps(json_payload or {
+            "schema_version": JSON_SCHEMA_VERSION,
             "summary": counts,
-            "results": [r._asdict() for r in results],
+            "results": [_result_to_json(r) for r in results],
         }, indent=2))
     else:
         total = len(results)
@@ -582,7 +909,15 @@ def _print_summary(results: list[CaseResult], *, json_out: bool) -> int:
     return 1 if failures else 0
 
 
+def _selected_variants(raw: str) -> tuple[str, ...]:
+    """Resolve the CLI artifact-variant selector."""
+    if raw == "all":
+        return ARTIFACT_VARIANTS
+    return (raw,)
+
+
 def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for validating example cases."""
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("filters", nargs="*",
@@ -593,6 +928,15 @@ def main(argv: list[str] | None = None) -> int:
                     help="Machine-readable JSON output")
     ap.add_argument("--category", metavar="CAT",
                     help="Filter by category: breaking, compatible, bad_practice, api_break")
+    ap.add_argument(
+        "--artifact-variant",
+        choices=(*ARTIFACT_VARIANTS, "all"),
+        default=DEFAULT_ARTIFACT_VARIANT,
+        help=(
+            "Example artifact profile to validate: debug-headers (current default), "
+            "release-headers, stripped-headers, build-source, or all."
+        ),
+    )
     args = ap.parse_args(argv)
 
     prereq_err = _check_prerequisites()
@@ -612,9 +956,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.category:
         names = [n for n in names if verdicts[n].get("category") == args.category]
 
+    variants = _selected_variants(args.artifact_variant)
     results = _run_all_cases(names, verdicts,
-                             fail_fast=args.fail_fast, json_out=args.json_out)
-    return _print_summary(results, json_out=args.json_out)
+                             fail_fast=args.fail_fast, json_out=args.json_out,
+                             variants=variants)
+    payload = _json_payload(
+        results,
+        names=names,
+        variants=variants,
+        argv=list(argv) if argv is not None else sys.argv[1:],
+        total_ground_truth_cases=len(verdicts),
+    )
+    return _print_summary(results, json_out=args.json_out, json_payload=payload)
 
 
 if __name__ == "__main__":

--- a/validation/README.md
+++ b/validation/README.md
@@ -14,7 +14,8 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
 - `data/manifest.json` — the curated version-pair matrix (exact upstream files)
 - `data/results.json` — raw per-`.so` comparison results (`run_matrix.v2`
   records include mode, platform, source layers, evidence asymmetry, runtime,
-  expected verdict, and actual verdict)
+  expected verdict, actual verdict, normalized compatibility-axis verdicts, and
+  comparison status)
 - `data/results.meta.json` — run-level metadata emitted by `scripts/run_matrix.py`
 - `data/component_suites.json` — component-suite run metadata emitted by
   `scripts/run_component_suites.py`
@@ -27,6 +28,12 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
   component remeasurement artifacts
 - `scripts/summarize_remeasurement.py` — combines example, component-suite, and
   real-world artifacts into the release-gate summary
+
+For `run_matrix.v2`, non-zero `abicheck compare` exit codes are not failures by
+themselves: expected `BREAKING` / `API_BREAK` outcomes legitimately exit
+non-zero. Release-gate summaries score the normalized expected vs actual verdict
+instead, with `ABICHECK_STRICTER`, `ABICHECK_WEAKER`, and missing-verdict run
+errors counted as blocking real-world remeasurement failures.
 
 Binaries are intentionally not committed; reproduce them from `data/manifest.json`
 (conda-forge, `https://conda.anaconda.org/conda-forge/linux-64/<file>`).

--- a/validation/README.md
+++ b/validation/README.md
@@ -12,10 +12,21 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
   FP-3/FP-4 are guarded by strict-xfail regression tests in
   `tests/test_real_world_false_positives.py`.
 - `data/manifest.json` — the curated version-pair matrix (exact upstream files)
-- `data/results.json` — raw per-`.so` comparison results
+- `data/results.json` — raw per-`.so` comparison results (`run_matrix.v2`
+  records include mode, platform, source layers, evidence asymmetry, runtime,
+  expected verdict, and actual verdict)
+- `data/results.meta.json` — run-level metadata emitted by `scripts/run_matrix.py`
+- `data/component_suites.json` — component-suite run metadata emitted by
+  `scripts/run_component_suites.py`
+- `data/remeasurement_summary.json` — combined summary emitted by
+  `scripts/summarize_remeasurement.py`
 - `data/false_positive_evidence.json` — false-positive exemplars
 - `suppress_internal.yaml` — internal-namespace suppression used in the report
 - `scripts/run_matrix.py` — reproducible harness
+- `scripts/run_component_suites.py` — pytest suite harness for source-family
+  component remeasurement artifacts
+- `scripts/summarize_remeasurement.py` — combines example, component-suite, and
+  real-world artifacts into the release-gate summary
 
 Binaries are intentionally not committed; reproduce them from `data/manifest.json`
 (conda-forge, `https://conda.anaconda.org/conda-forge/linux-64/<file>`).

--- a/validation/scripts/run_component_suites.py
+++ b/validation/scripts/run_component_suites.py
@@ -94,6 +94,7 @@ SUMMARY_PATTERNS = {
 
 
 def platform_tag() -> str:
+    """Return the platform tag used in component-suite records."""
     system = platform.system().lower()
     if system == "darwin":
         return "macos"
@@ -101,6 +102,7 @@ def platform_tag() -> str:
 
 
 def optional_dependency_blocker(test_path: str) -> str | None:
+    """Return a blocker reason for optional dependencies needed by a test."""
     if test_path in {
         "tests/test_pe_metadata_unit.py",
         "tests/test_pdb_metadata.py",
@@ -111,6 +113,7 @@ def optional_dependency_blocker(test_path: str) -> str | None:
 
 
 def missing_blockers(tests: list[str]) -> list[str]:
+    """Return missing-file and dependency blockers for a test list."""
     blockers = []
     for test_path in tests:
         if not (ROOT / test_path).exists():
@@ -123,6 +126,7 @@ def missing_blockers(tests: list[str]) -> list[str]:
 
 
 def parse_pytest_counts(output: str) -> dict[str, int]:
+    """Extract pytest summary counts from combined stdout/stderr."""
     counts: dict[str, int] = {}
     for key, pattern in SUMMARY_PATTERNS.items():
         match = pattern.search(output)
@@ -143,6 +147,7 @@ def suite_record(
     stderr: str = "",
     blockers: list[str] | None = None,
 ) -> dict[str, object]:
+    """Build one component-suite result record."""
     output = f"{stdout}\n{stderr}"
     return {
         "schema_version": SCHEMA_VERSION,
@@ -164,9 +169,25 @@ def suite_record(
 
 
 def run_suite(name: str, *, dry_run: bool, pytest_args: list[str]) -> dict[str, object]:
+    """Run or plan one named component suite."""
     suite = SUITES[name]
     tests = list(suite["tests"])
+    supported_platforms = list(suite["platforms"])
     command = [sys.executable, "-m", "pytest", "-q", *pytest_args, *tests]
+    current_platform = platform_tag()
+    if current_platform not in supported_platforms:
+        return suite_record(
+            name,
+            suite,
+            status="blocked",
+            command=command,
+            exit_code=None,
+            seconds=0.0,
+            blockers=[
+                f"unsupported platform: {current_platform} "
+                f"(supported: {', '.join(str(p) for p in supported_platforms)})"
+            ],
+        )
     blockers = missing_blockers(tests)
     if blockers:
         return suite_record(
@@ -189,7 +210,29 @@ def run_suite(name: str, *, dry_run: bool, pytest_args: list[str]) -> dict[str, 
         )
 
     start = time.time()
-    proc = subprocess.run(command, cwd=ROOT, capture_output=True, text=True)
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return suite_record(
+            name,
+            suite,
+            status="failed",
+            command=command,
+            exit_code=124,
+            seconds=time.time() - start,
+            stdout=exc.stdout or "",
+            stderr=(
+                f"pytest timed out after {exc.timeout}s\n"
+                f"{exc.stderr or ''}"
+            ),
+            blockers=[f"pytest timed out after {exc.timeout}s"],
+        )
     status = "passed" if proc.returncode == 0 else "failed"
     return suite_record(
         name,
@@ -204,6 +247,7 @@ def run_suite(name: str, *, dry_run: bool, pytest_args: list[str]) -> dict[str, 
 
 
 def make_report(records: list[dict[str, object]]) -> dict[str, object]:
+    """Build the component-suite run report."""
     return {
         "schema_version": SCHEMA_VERSION,
         "runner": "validation/scripts/run_component_suites.py",
@@ -219,6 +263,7 @@ def make_report(records: list[dict[str, object]]) -> dict[str, object]:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--suite", action="append", choices=sorted(SUITES))
     parser.add_argument("--all", action="store_true", help="run all component suites")
@@ -235,6 +280,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for component-suite remeasurement."""
     args = parse_args(sys.argv[1:] if argv is None else argv)
     names = sorted(SUITES) if args.all or not args.suite else args.suite
     records = [

--- a/validation/scripts/run_component_suites.py
+++ b/validation/scripts/run_component_suites.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Run source-family component suites and emit remeasurement metadata."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import platform
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCHEMA_VERSION = "component_suites.v1"
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = ROOT / "validation" / "data" / "component_suites.json"
+
+SUITES: dict[str, dict[str, object]] = {
+    "elf-symbol-surface": {
+        "source_layers": ["L0", "L1", "L2"],
+        "platforms": ["linux"],
+        "tests": [
+            "tests/test_elf_metadata_unit.py",
+            "tests/test_elf_parse_integration.py",
+            "tests/test_elf_symbol_filters.py",
+            "tests/test_elf_version_policy.py",
+            "tests/test_surface.py",
+            "tests/test_surface_scope_parity.py",
+            "tests/test_confidence_evidence.py",
+            "tests/test_stripped_degradation.py",
+        ],
+    },
+    "debug-metadata": {
+        "source_layers": ["L1"],
+        "platforms": ["linux"],
+        "tests": [
+            "tests/test_dwarf_snapshot.py",
+            "tests/test_dwarf_metadata_coverage.py",
+            "tests/test_dwarf_unified.py",
+            "tests/test_debug_resolver.py",
+            "tests/test_btf_metadata.py",
+            "tests/test_btf_integration.py",
+            "tests/test_ctf_metadata.py",
+            "tests/test_pdb_metadata.py",
+            "tests/test_pdb_parser.py",
+            "tests/test_pe_metadata_unit.py",
+            "tests/test_macho_metadata_unit.py",
+        ],
+    },
+    "build-source-package": {
+        "source_layers": ["L3", "L4", "L5"],
+        "platforms": ["linux", "macos", "windows"],
+        "tests": [
+            "tests/test_build_context.py",
+            "tests/test_package.py",
+            "tests/test_package_extractor_matrix.py",
+        ],
+    },
+    "impact-context": {
+        "source_layers": ["L0", "L1", "L2", "L3", "L4", "L5"],
+        "platforms": ["linux", "macos", "windows"],
+        "tests": [
+            "tests/test_bundle.py",
+            "tests/test_stack_checker.py",
+            "tests/test_appcompat.py",
+            "tests/test_appcompat_examples.py",
+        ],
+    },
+    "report-policy": {
+        "source_layers": ["L0", "L1", "L2", "L3", "L4", "L5"],
+        "platforms": ["linux", "macos", "windows"],
+        "tests": [
+            "tests/test_report_schema.py",
+            "tests/test_reporter.py",
+            "tests/test_sarif.py",
+            "tests/test_junit_report.py",
+            "tests/test_policy_changekind_matrix.py",
+            "tests/test_policy_file.py",
+            "tests/test_baseline.py",
+            "tests/test_suppression_matrix.py",
+        ],
+    },
+}
+
+SUMMARY_PATTERNS = {
+    "passed": re.compile(r"(\d+) passed"),
+    "failed": re.compile(r"(\d+) failed"),
+    "errors": re.compile(r"(\d+) errors?"),
+    "skipped": re.compile(r"(\d+) skipped"),
+    "warnings": re.compile(r"(\d+) warnings?"),
+}
+
+
+def platform_tag() -> str:
+    system = platform.system().lower()
+    if system == "darwin":
+        return "macos"
+    return system or sys.platform
+
+
+def optional_dependency_blocker(test_path: str) -> str | None:
+    if test_path in {
+        "tests/test_pe_metadata_unit.py",
+        "tests/test_pdb_metadata.py",
+        "tests/test_pdb_parser.py",
+    } and importlib.util.find_spec("pefile") is None:
+        return "missing Python dependency: pefile"
+    return None
+
+
+def missing_blockers(tests: list[str]) -> list[str]:
+    blockers = []
+    for test_path in tests:
+        if not (ROOT / test_path).exists():
+            blockers.append(f"missing test file: {test_path}")
+            continue
+        dep_blocker = optional_dependency_blocker(test_path)
+        if dep_blocker:
+            blockers.append(dep_blocker)
+    return sorted(set(blockers))
+
+
+def parse_pytest_counts(output: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key, pattern in SUMMARY_PATTERNS.items():
+        match = pattern.search(output)
+        if match:
+            counts[key] = int(match.group(1))
+    return counts
+
+
+def suite_record(
+    name: str,
+    suite: dict[str, object],
+    *,
+    status: str,
+    command: list[str],
+    exit_code: int | None,
+    seconds: float,
+    stdout: str = "",
+    stderr: str = "",
+    blockers: list[str] | None = None,
+) -> dict[str, object]:
+    output = f"{stdout}\n{stderr}"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "component": "component-suite",
+        "case_id": name,
+        "suite": name,
+        "platform": platform_tag(),
+        "python": platform.python_version(),
+        "source_layers": suite["source_layers"],
+        "supported_platforms": suite["platforms"],
+        "tests": suite["tests"],
+        "command": command,
+        "status": status,
+        "exit_code": exit_code,
+        "seconds": round(seconds, 2),
+        "counts": parse_pytest_counts(output),
+        "blocked_reasons": blockers or [],
+    }
+
+
+def run_suite(name: str, *, dry_run: bool, pytest_args: list[str]) -> dict[str, object]:
+    suite = SUITES[name]
+    tests = list(suite["tests"])
+    command = [sys.executable, "-m", "pytest", "-q", *pytest_args, *tests]
+    blockers = missing_blockers(tests)
+    if blockers:
+        return suite_record(
+            name,
+            suite,
+            status="blocked",
+            command=command,
+            exit_code=None,
+            seconds=0.0,
+            blockers=blockers,
+        )
+    if dry_run:
+        return suite_record(
+            name,
+            suite,
+            status="planned",
+            command=command,
+            exit_code=None,
+            seconds=0.0,
+        )
+
+    start = time.time()
+    proc = subprocess.run(command, cwd=ROOT, capture_output=True, text=True)
+    status = "passed" if proc.returncode == 0 else "failed"
+    return suite_record(
+        name,
+        suite,
+        status=status,
+        command=command,
+        exit_code=proc.returncode,
+        seconds=time.time() - start,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
+
+
+def make_report(records: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "runner": "validation/scripts/run_component_suites.py",
+        "platform": platform_tag(),
+        "command": [sys.executable, *sys.argv],
+        "suite_count": len(records),
+        "status_counts": {
+            status: sum(1 for record in records if record["status"] == status)
+            for status in sorted({str(record["status"]) for record in records})
+        },
+        "records": records,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", action="append", choices=sorted(SUITES))
+    parser.add_argument("--all", action="store_true", help="run all component suites")
+    parser.add_argument("--dry-run", action="store_true", help="emit planned records")
+    parser.add_argument("--json", action="store_true", help="print report JSON")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--pytest-arg",
+        action="append",
+        default=[],
+        help="extra argument passed to pytest before test paths",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    names = sorted(SUITES) if args.all or not args.suite else args.suite
+    records = [
+        run_suite(name, dry_run=args.dry_run, pytest_args=args.pytest_arg)
+        for name in names
+    ]
+    report = make_report(records)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(report, indent=2))
+    if any(record["status"] == "failed" for record in records):
+        return 1
+    if any(record["status"] == "blocked" for record in records):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/scripts/run_matrix.py
+++ b/validation/scripts/run_matrix.py
@@ -39,6 +39,7 @@ from conda_harness import logical_name  # noqa: E402
 
 
 def platform_tag() -> str:
+    """Return the platform tag used in remeasurement records."""
     if sys.platform.startswith("linux"):
         return "linux"
     if sys.platform == "darwin":
@@ -65,17 +66,20 @@ def real_sos(pkgdir: str, ex_root: str = EX) -> dict[str, str]:
 
 
 def has_dwarf(path: str) -> bool:
+    """Return whether an ELF binary appears to contain DWARF debug info."""
     r = subprocess.run(["readelf", "-S", path], capture_output=True, text=True)
     return "debug_info" in r.stdout
 
 
 def run(cmd: list[str]) -> tuple[int, str, str, float]:
+    """Run a subprocess and return exit code, stdout, stderr, and seconds."""
     t = time.time()
     p = subprocess.run(cmd, capture_output=True, text=True)
     return p.returncode, p.stdout, p.stderr, time.time() - t
 
 
 def side_layers(side: str) -> list[str]:
+    """Map a side evidence mode to the available source layers."""
     layers = ["L0"]
     if side == "dwarf":
         layers.append("L1")
@@ -83,6 +87,7 @@ def side_layers(side: str) -> list[str]:
 
 
 def evidence_asymmetry(mode: str) -> str:
+    """Classify old/new evidence richness for a mode string."""
     old_side, new_side = mode.split("->", 1)
     old_layers = side_layers(old_side)
     new_layers = side_layers(new_side)
@@ -128,6 +133,7 @@ def make_record(
     stderr: str,
     data: dict | None,
 ) -> dict:
+    """Build a versioned per-comparison remeasurement record."""
     old_side, new_side = mode.split("->", 1)
     rec = {
         "schema_version": SCHEMA_VERSION,
@@ -182,6 +188,7 @@ def make_record(
 
 
 def run_matrix(manifest: list[dict], *, ex_root: str = EX, out_dir: str = OUT) -> list[dict]:
+    """Run all manifest comparisons and return per-library records."""
     results = []
     os.makedirs(f"{out_dir}/runs", exist_ok=True)  # per-library JSONs (gitignored)
     for m in manifest:
@@ -218,7 +225,8 @@ def run_matrix(manifest: list[dict], *, ex_root: str = EX, out_dir: str = OUT) -
             data = None
             if os.path.exists(jpath):
                 try:
-                    data = json.load(open(jpath))
+                    with open(jpath, encoding="utf-8") as fh:
+                        data = json.load(fh)
                 except Exception as e:
                     se += f"\n[harness] json parse failed: {e}"
             rec = make_record(
@@ -241,6 +249,7 @@ def run_matrix(manifest: list[dict], *, ex_root: str = EX, out_dir: str = OUT) -
 
 
 def make_run_metadata(results: list[dict], manifest: list[dict]) -> dict:
+    """Build run-level metadata for a real-world matrix run."""
     return {
         "schema_version": SCHEMA_VERSION,
         "runner": "validation/scripts/run_matrix.py",
@@ -262,6 +271,7 @@ def make_run_metadata(results: list[dict], manifest: list[dict]) -> dict:
 
 
 def main() -> int:
+    """CLI entrypoint for the curated real-world matrix runner."""
     if not MANIFEST.is_file():
         print(f"manifest not found: {MANIFEST}", file=sys.stderr)
         return 2
@@ -274,14 +284,13 @@ def main() -> int:
         )
         return 2
 
-    manifest = json.load(open(MANIFEST))
+    with open(MANIFEST, encoding="utf-8") as fh:
+        manifest = json.load(fh)
     results = run_matrix(manifest)
-    json.dump(results, open(f"{OUT}/results.json", "w"), indent=2)
-    json.dump(
-        make_run_metadata(results, manifest),
-        open(f"{OUT}/results.meta.json", "w"),
-        indent=2,
-    )
+    with open(f"{OUT}/results.json", "w", encoding="utf-8") as fh:
+        json.dump(results, fh, indent=2)
+    with open(f"{OUT}/results.meta.json", "w", encoding="utf-8") as fh:
+        json.dump(make_run_metadata(results, manifest), fh, indent=2)
     print(f"\n{len(results)} comparisons -> {OUT}/results.json")
     print(f"Run metadata -> {OUT}/results.meta.json")
     return 0

--- a/validation/scripts/run_matrix.py
+++ b/validation/scripts/run_matrix.py
@@ -30,6 +30,8 @@ EX = os.environ.get("ABICHECK_VALIDATION_LIBS", str(VALID_DIR / "libs" / "ex"))
 OUT = str(DATA)
 MANIFEST = DATA / "manifest.json"
 SCHEMA_VERSION = "run_matrix.v2"
+BREAKING_VERDICTS = {"BREAKING", "API_BREAK"}
+COMPATIBLE_VERDICTS = {"COMPATIBLE", "COMPATIBLE_WITH_RISK", "NO_CHANGE"}
 
 # Share the logical-library-name helper with the unified harness (validate.py).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -91,6 +93,29 @@ def evidence_asymmetry(mode: str) -> str:
     return "old-poor/new-rich"
 
 
+def normalize_verdict(verdict: str | None) -> str:
+    """Collapse abicheck verdicts to the manifest's compatibility axis."""
+    normalized = (verdict or "").strip().upper()
+    if normalized in BREAKING_VERDICTS:
+        return "BREAKING"
+    if normalized in COMPATIBLE_VERDICTS:
+        return "COMPATIBLE"
+    return "UNKNOWN"
+
+
+def comparison_status(expected: str | None, actual: str | None) -> str:
+    """Score a measured verdict against the curated manifest expectation."""
+    expected_norm = normalize_verdict(expected)
+    actual_norm = normalize_verdict(actual)
+    if expected_norm == "UNKNOWN" or actual_norm == "UNKNOWN":
+        return "UNCOMPARABLE"
+    if expected_norm == actual_norm:
+        return "MATCH"
+    if actual_norm == "BREAKING" and expected_norm == "COMPATIBLE":
+        return "ABICHECK_STRICTER"
+    return "ABICHECK_WEAKER"
+
+
 def make_record(
     manifest_row: dict,
     *,
@@ -150,6 +175,9 @@ def make_record(
         rec["release_recommendation"] = data.get("release_recommendation")
         if "layer_coverage" in data:
             rec["layer_coverage"] = data["layer_coverage"]
+    rec["normalized_expected"] = normalize_verdict(rec.get("expected"))
+    rec["normalized_got"] = normalize_verdict(rec.get("got"))
+    rec["comparison_status"] = comparison_status(rec.get("expected"), rec.get("got"))
     return rec
 
 
@@ -221,6 +249,14 @@ def make_run_metadata(results: list[dict], manifest: list[dict]) -> dict:
         "manifest_pairs": len(manifest),
         "comparisons": len(results),
         "modes": sorted({str(r.get("mode", "")) for r in results}),
+        "comparison_status_counts": {
+            status: sum(
+                1
+                for record in results
+                if record.get("comparison_status") == status
+            )
+            for status in sorted({str(r.get("comparison_status", "")) for r in results})
+        },
         "results_file": "validation/data/results.json",
     }
 

--- a/validation/scripts/run_matrix.py
+++ b/validation/scripts/run_matrix.py
@@ -29,26 +29,27 @@ DATA = VALID_DIR / "data"
 EX = os.environ.get("ABICHECK_VALIDATION_LIBS", str(VALID_DIR / "libs" / "ex"))
 OUT = str(DATA)
 MANIFEST = DATA / "manifest.json"
-os.makedirs(f"{OUT}/runs", exist_ok=True)  # per-library JSONs (gitignored)
+SCHEMA_VERSION = "run_matrix.v2"
 
 # Share the logical-library-name helper with the unified harness (validate.py).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from conda_harness import logical_name  # noqa: E402
 
-if not MANIFEST.is_file():
-    sys.exit(f"manifest not found: {MANIFEST}")
-if not os.path.isdir(EX):
-    sys.exit(
-        f"extracted-libraries dir not found: {EX}\n"
-        "Fetch+extract the packages in data/manifest.json (binaries are not "
-        "committed), then set ABICHECK_VALIDATION_LIBS to their parent directory."
-    )
+
+def platform_tag() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform == "win32":
+        return "windows"
+    return sys.platform
 
 
-def real_sos(pkgdir: str) -> dict[str, str]:
+def real_sos(pkgdir: str, ex_root: str = EX) -> dict[str, str]:
     """logical_name -> path for every real (non-symlink) ELF .so in pkgdir/lib."""
     out = {}
-    for p in glob.glob(f"{EX}/{pkgdir}/lib/*.so*"):
+    for p in glob.glob(f"{ex_root}/{pkgdir}/lib/*.so*"):
         if os.path.islink(p):
             continue
         try:
@@ -72,81 +73,183 @@ def run(cmd: list[str]) -> tuple[int, str, str, float]:
     return p.returncode, p.stdout, p.stderr, time.time() - t
 
 
-manifest = json.load(open(MANIFEST))
-results = []
-for m in manifest:
-    old_dir = m["old_file"].replace(".conda", "").replace(".tar.bz2", "")
-    new_dir = m["new_file"].replace(".conda", "").replace(".tar.bz2", "")
-    old = real_sos(old_dir)
-    new = real_sos(new_dir)
-    common = sorted(set(old) & set(new))
-    for lname in common:
-        op, np = old[lname], new[lname]
-        mode = (
-            ("dwarf" if has_dwarf(op) else "sym")
-            + "->"
-            + ("dwarf" if has_dwarf(np) else "sym")
-        )
-        tag = f"{m['pair']}__{lname}"
-        jpath = f"{OUT}/runs/{tag}.json"
-        cmd = [
-            "abicheck",
-            "compare",
-            op,
-            np,
-            "--old-version",
-            m["old_ver"],
-            "--new-version",
-            m["new_ver"],
-            "--format",
-            "json",
-            "-o",
-            jpath,
-            "--recommend",
-        ]
-        rc, so, se, dt = run(cmd)
-        data = None
-        if os.path.exists(jpath):
-            try:
-                data = json.load(open(jpath))
-            except Exception as e:
-                se += f"\n[harness] json parse failed: {e}"
-        rec = {
-            "tag": tag,
-            "pair": m["pair"],
-            "library": m["library"],
-            "logical": lname,
-            "old_ver": m["old_ver"],
-            "new_ver": m["new_ver"],
-            "expectation": m["expectation"],
-            "note": m["note"],
-            "mode": mode,
-            "old_path": op,
-            "new_path": np,
-            "exit_code": rc,
-            "seconds": round(dt, 2),
-            "stderr": se.strip(),
-        }
-        if data:
-            summ = data.get("summary", {}) if isinstance(data, dict) else {}
-            rec["verdict"] = data.get("verdict") or summ.get("verdict")
-            rec["counts"] = {
-                k: summ.get(k)
-                for k in (
-                    "total",
-                    "breaking",
-                    "api_break",
-                    "compatible",
-                    "risk",
-                    "added",
-                    "removed",
-                    "changed",
-                )
-                if k in summ
-            }
-            rec["release_recommendation"] = data.get("release_recommendation")
-        results.append(rec)
-        print(f"{tag:48} {mode:11} exit={rc} {dt:5.1f}s verdict={rec.get('verdict')}")
+def side_layers(side: str) -> list[str]:
+    layers = ["L0"]
+    if side == "dwarf":
+        layers.append("L1")
+    return layers
 
-json.dump(results, open(f"{OUT}/results.json", "w"), indent=2)
-print(f"\n{len(results)} comparisons -> {OUT}/results.json")
+
+def evidence_asymmetry(mode: str) -> str:
+    old_side, new_side = mode.split("->", 1)
+    old_layers = side_layers(old_side)
+    new_layers = side_layers(new_side)
+    if old_layers == new_layers:
+        return "symmetric"
+    if len(old_layers) > len(new_layers):
+        return "old-rich/new-poor"
+    return "old-poor/new-rich"
+
+
+def make_record(
+    manifest_row: dict,
+    *,
+    logical: str,
+    old_path: str,
+    new_path: str,
+    mode: str,
+    exit_code: int,
+    seconds: float,
+    stderr: str,
+    data: dict | None,
+) -> dict:
+    old_side, new_side = mode.split("->", 1)
+    rec = {
+        "schema_version": SCHEMA_VERSION,
+        "component": "real-world-matrix",
+        "case_id": f"{manifest_row['pair']}__{logical}",
+        "tag": f"{manifest_row['pair']}__{logical}",
+        "pair": manifest_row["pair"],
+        "library": manifest_row["library"],
+        "logical": logical,
+        "platform": platform_tag(),
+        "old_ver": manifest_row["old_ver"],
+        "new_ver": manifest_row["new_ver"],
+        "expectation": manifest_row["expectation"],
+        "expected": manifest_row["expectation"],
+        "note": manifest_row["note"],
+        "mode": mode,
+        "source_layers": sorted(set(side_layers(old_side)) | set(side_layers(new_side))),
+        "old_source_layers": side_layers(old_side),
+        "new_source_layers": side_layers(new_side),
+        "evidence_asymmetry": evidence_asymmetry(mode),
+        "old_path": old_path,
+        "new_path": new_path,
+        "exit_code": exit_code,
+        "seconds": round(seconds, 2),
+        "stderr": stderr.strip(),
+    }
+    if data:
+        summ = data.get("summary", {}) if isinstance(data, dict) else {}
+        rec["verdict"] = data.get("verdict") or summ.get("verdict")
+        rec["got"] = rec["verdict"]
+        rec["counts"] = {
+            k: summ.get(k)
+            for k in (
+                "total",
+                "breaking",
+                "api_break",
+                "compatible",
+                "risk",
+                "added",
+                "removed",
+                "changed",
+            )
+            if k in summ
+        }
+        rec["release_recommendation"] = data.get("release_recommendation")
+        if "layer_coverage" in data:
+            rec["layer_coverage"] = data["layer_coverage"]
+    return rec
+
+
+def run_matrix(manifest: list[dict], *, ex_root: str = EX, out_dir: str = OUT) -> list[dict]:
+    results = []
+    os.makedirs(f"{out_dir}/runs", exist_ok=True)  # per-library JSONs (gitignored)
+    for m in manifest:
+        old_dir = m["old_file"].replace(".conda", "").replace(".tar.bz2", "")
+        new_dir = m["new_file"].replace(".conda", "").replace(".tar.bz2", "")
+        old = real_sos(old_dir, ex_root)
+        new = real_sos(new_dir, ex_root)
+        common = sorted(set(old) & set(new))
+        for lname in common:
+            op, np = old[lname], new[lname]
+            mode = (
+                ("dwarf" if has_dwarf(op) else "sym")
+                + "->"
+                + ("dwarf" if has_dwarf(np) else "sym")
+            )
+            tag = f"{m['pair']}__{lname}"
+            jpath = f"{out_dir}/runs/{tag}.json"
+            cmd = [
+                "abicheck",
+                "compare",
+                op,
+                np,
+                "--old-version",
+                m["old_ver"],
+                "--new-version",
+                m["new_ver"],
+                "--format",
+                "json",
+                "-o",
+                jpath,
+                "--recommend",
+            ]
+            rc, _stdout, se, dt = run(cmd)
+            data = None
+            if os.path.exists(jpath):
+                try:
+                    data = json.load(open(jpath))
+                except Exception as e:
+                    se += f"\n[harness] json parse failed: {e}"
+            rec = make_record(
+                m,
+                logical=lname,
+                old_path=op,
+                new_path=np,
+                mode=mode,
+                exit_code=rc,
+                seconds=dt,
+                stderr=se,
+                data=data,
+            )
+            results.append(rec)
+            print(
+                f"{tag:48} {mode:11} exit={rc} {dt:5.1f}s "
+                f"verdict={rec.get('verdict')}"
+            )
+    return results
+
+
+def make_run_metadata(results: list[dict], manifest: list[dict]) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "runner": "validation/scripts/run_matrix.py",
+        "platform": platform_tag(),
+        "command": [sys.executable, *sys.argv],
+        "manifest_pairs": len(manifest),
+        "comparisons": len(results),
+        "modes": sorted({str(r.get("mode", "")) for r in results}),
+        "results_file": "validation/data/results.json",
+    }
+
+
+def main() -> int:
+    if not MANIFEST.is_file():
+        print(f"manifest not found: {MANIFEST}", file=sys.stderr)
+        return 2
+    if not os.path.isdir(EX):
+        print(
+            f"extracted-libraries dir not found: {EX}\n"
+            "Fetch+extract the packages in data/manifest.json (binaries are not "
+            "committed), then set ABICHECK_VALIDATION_LIBS to their parent directory.",
+            file=sys.stderr,
+        )
+        return 2
+
+    manifest = json.load(open(MANIFEST))
+    results = run_matrix(manifest)
+    json.dump(results, open(f"{OUT}/results.json", "w"), indent=2)
+    json.dump(
+        make_run_metadata(results, manifest),
+        open(f"{OUT}/results.meta.json", "w"),
+        indent=2,
+    )
+    print(f"\n{len(results)} comparisons -> {OUT}/results.json")
+    print(f"Run metadata -> {OUT}/results.meta.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/scripts/summarize_remeasurement.py
+++ b/validation/scripts/summarize_remeasurement.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "remeasurement_summary.v1"
+BREAKING_VERDICTS = {"BREAKING", "API_BREAK"}
+COMPATIBLE_VERDICTS = {"COMPATIBLE", "COMPATIBLE_WITH_RISK", "NO_CHANGE"}
 
 
 def load_json(path: Path) -> Any:
@@ -19,6 +21,40 @@ def load_json(path: Path) -> Any:
 
 def count_values(records: list[dict[str, Any]], field: str) -> dict[str, int]:
     return dict(sorted(Counter(str(record.get(field, "")) for record in records).items()))
+
+
+def count_first_value(
+    records: list[dict[str, Any]], primary: str, fallback: str
+) -> dict[str, int]:
+    values = [
+        str(record.get(primary) or record.get(fallback) or "")
+        for record in records
+    ]
+    return dict(sorted(Counter(values).items()))
+
+
+def normalize_verdict(verdict: str | None) -> str:
+    normalized = (verdict or "").strip().upper()
+    if normalized in BREAKING_VERDICTS:
+        return "BREAKING"
+    if normalized in COMPATIBLE_VERDICTS:
+        return "COMPATIBLE"
+    return "UNKNOWN"
+
+
+def comparison_status(record: dict[str, Any]) -> str:
+    status = record.get("comparison_status")
+    if status:
+        return str(status)
+    expected = normalize_verdict(record.get("expected") or record.get("expectation"))
+    actual = normalize_verdict(record.get("got") or record.get("verdict"))
+    if expected == "UNKNOWN" or actual == "UNKNOWN":
+        return "UNCOMPARABLE"
+    if expected == actual:
+        return "MATCH"
+    if actual == "BREAKING" and expected == "COMPATIBLE":
+        return "ABICHECK_STRICTER"
+    return "ABICHECK_WEAKER"
 
 
 def summarize_examples(path: Path) -> dict[str, Any]:
@@ -75,6 +111,18 @@ def summarize_real_world(path: Path, meta_path: Path | None = None) -> dict[str,
     if not isinstance(records, list):
         raise ValueError(f"{path} must contain a list of real-world records")
     meta = load_json(meta_path) if meta_path and meta_path.exists() else {}
+    statuses = [comparison_status(record) for record in records]
+    status_counts = dict(sorted(Counter(statuses).items()))
+    run_errors = sum(
+        1
+        for record in records
+        if comparison_status(record) == "UNCOMPARABLE"
+        and not (record.get("got") or record.get("verdict"))
+    )
+    expectation_mismatches = sum(
+        status_counts.get(status, 0)
+        for status in ("ABICHECK_STRICTER", "ABICHECK_WEAKER")
+    )
     return {
         "artifact": str(path),
         "metadata_artifact": str(meta_path) if meta_path else None,
@@ -86,12 +134,13 @@ def summarize_real_world(path: Path, meta_path: Path | None = None) -> dict[str,
         "command": meta.get("command"),
         "total": len(records),
         "mode_counts": count_values(records, "mode"),
-        "verdict_counts": count_values(records, "got"),
-        "expected_counts": count_values(records, "expected"),
+        "verdict_counts": count_first_value(records, "got", "verdict"),
+        "expected_counts": count_first_value(records, "expected", "expectation"),
+        "comparison_status_counts": status_counts,
         "source_layer_counts": layer_counts(records),
-        "blocking_failures": sum(
-            1 for record in records if int(record.get("exit_code") or 0) != 0
-        ),
+        "run_errors": run_errors,
+        "expectation_mismatches": expectation_mismatches,
+        "blocking_failures": run_errors + expectation_mismatches,
     }
 
 

--- a/validation/scripts/summarize_remeasurement.py
+++ b/validation/scripts/summarize_remeasurement.py
@@ -13,19 +13,28 @@ from typing import Any
 SCHEMA_VERSION = "remeasurement_summary.v1"
 BREAKING_VERDICTS = {"BREAKING", "API_BREAK"}
 COMPATIBLE_VERDICTS = {"COMPATIBLE", "COMPATIBLE_WITH_RISK", "NO_CHANGE"}
+COMPARISON_STATUSES = {
+    "MATCH",
+    "UNCOMPARABLE",
+    "ABICHECK_STRICTER",
+    "ABICHECK_WEAKER",
+}
 
 
 def load_json(path: Path) -> Any:
+    """Load JSON from a UTF-8 file."""
     return json.loads(path.read_text(encoding="utf-8"))
 
 
 def count_values(records: list[dict[str, Any]], field: str) -> dict[str, int]:
+    """Count stringified values for a field across records."""
     return dict(sorted(Counter(str(record.get(field, "")) for record in records).items()))
 
 
 def count_first_value(
     records: list[dict[str, Any]], primary: str, fallback: str
 ) -> dict[str, int]:
+    """Count a primary field with fallback support for older artifacts."""
     values = [
         str(record.get(primary) or record.get(fallback) or "")
         for record in records
@@ -34,6 +43,7 @@ def count_first_value(
 
 
 def normalize_verdict(verdict: str | None) -> str:
+    """Collapse abicheck verdicts to a compatible/breaking axis."""
     normalized = (verdict or "").strip().upper()
     if normalized in BREAKING_VERDICTS:
         return "BREAKING"
@@ -43,9 +53,12 @@ def normalize_verdict(verdict: str | None) -> str:
 
 
 def comparison_status(record: dict[str, Any]) -> str:
+    """Return canonical expected-vs-actual comparison status for a record."""
     status = record.get("comparison_status")
     if status:
-        return str(status)
+        normalized_status = str(status).strip().upper()
+        if normalized_status in COMPARISON_STATUSES:
+            return normalized_status
     expected = normalize_verdict(record.get("expected") or record.get("expectation"))
     actual = normalize_verdict(record.get("got") or record.get("verdict"))
     if expected == "UNKNOWN" or actual == "UNKNOWN":
@@ -58,6 +71,7 @@ def comparison_status(record: dict[str, Any]) -> str:
 
 
 def summarize_examples(path: Path) -> dict[str, Any]:
+    """Summarize a validate_examples.v2 artifact."""
     data = load_json(path)
     records = list(data.get("results", []))
     return {
@@ -78,6 +92,7 @@ def summarize_examples(path: Path) -> dict[str, Any]:
 
 
 def summarize_components(path: Path) -> dict[str, Any]:
+    """Summarize a component_suites.v1 artifact."""
     data = load_json(path)
     records = list(data.get("records", []))
     blocked = [
@@ -107,6 +122,7 @@ def summarize_components(path: Path) -> dict[str, Any]:
 
 
 def summarize_real_world(path: Path, meta_path: Path | None = None) -> dict[str, Any]:
+    """Summarize run_matrix real-world records."""
     records = load_json(path)
     if not isinstance(records, list):
         raise ValueError(f"{path} must contain a list of real-world records")
@@ -145,6 +161,7 @@ def summarize_real_world(path: Path, meta_path: Path | None = None) -> dict[str,
 
 
 def layer_counts(records: list[dict[str, Any]]) -> dict[str, int]:
+    """Count evidence/source layer mentions across records."""
     counts: Counter[str] = Counter()
     for record in records:
         for layer in record.get("source_layers", []) or []:
@@ -152,10 +169,16 @@ def layer_counts(records: list[dict[str, Any]]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
-def make_summary(sections: list[dict[str, Any]]) -> dict[str, Any]:
+def make_summary(
+    sections: list[dict[str, Any]], command_argv: list[str] | None = None
+) -> dict[str, Any]:
+    """Build the combined remeasurement summary payload."""
     return {
         "schema_version": SCHEMA_VERSION,
-        "command": [sys.executable, *sys.argv],
+        "command": [
+            sys.executable,
+            *(command_argv if command_argv is not None else sys.argv[1:]),
+        ],
         "section_count": len(sections),
         "total_records": sum(int(section.get("total", 0)) for section in sections),
         "blocking_failures": sum(
@@ -166,6 +189,7 @@ def make_summary(sections: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--examples", type=Path)
     parser.add_argument("--components", type=Path)
@@ -177,7 +201,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(sys.argv[1:] if argv is None else argv)
+    """CLI entrypoint for combined remeasurement summaries."""
+    command_argv = sys.argv[1:] if argv is None else argv
+    args = parse_args(command_argv)
     sections = []
     if args.examples:
         sections.append(summarize_examples(args.examples))
@@ -185,7 +211,7 @@ def main(argv: list[str] | None = None) -> int:
         sections.append(summarize_components(args.components))
     if args.real_world:
         sections.append(summarize_real_world(args.real_world, args.real_world_meta))
-    summary = make_summary(sections)
+    summary = make_summary(sections, command_argv=command_argv)
     text = json.dumps(summary, indent=2) + "\n"
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/validation/scripts/summarize_remeasurement.py
+++ b/validation/scripts/summarize_remeasurement.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Summarize remeasurement artifacts from examples, components, and real world."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "remeasurement_summary.v1"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def count_values(records: list[dict[str, Any]], field: str) -> dict[str, int]:
+    return dict(sorted(Counter(str(record.get(field, "")) for record in records).items()))
+
+
+def summarize_examples(path: Path) -> dict[str, Any]:
+    data = load_json(path)
+    records = list(data.get("results", []))
+    return {
+        "artifact": str(path),
+        "schema_version": data.get("schema_version"),
+        "component": "synthetic-example",
+        "runner": data.get("runner"),
+        "platform": data.get("platform"),
+        "command": data.get("command"),
+        "total": len(records),
+        "status_counts": dict(sorted(data.get("summary", {}).items())),
+        "mode_counts": count_values(records, "mode"),
+        "source_layer_counts": layer_counts(records),
+        "blocking_failures": sum(
+            1 for record in records if record.get("status") in {"FAIL", "ERROR"}
+        ),
+    }
+
+
+def summarize_components(path: Path) -> dict[str, Any]:
+    data = load_json(path)
+    records = list(data.get("records", []))
+    blocked = [
+        {
+            "suite": record.get("suite"),
+            "blocked_reasons": record.get("blocked_reasons", []),
+        }
+        for record in records
+        if record.get("status") == "blocked"
+    ]
+    return {
+        "artifact": str(path),
+        "schema_version": data.get("schema_version"),
+        "component": "component-suite",
+        "runner": data.get("runner"),
+        "platform": data.get("platform"),
+        "command": data.get("command"),
+        "total": len(records),
+        "status_counts": dict(sorted(data.get("status_counts", {}).items())),
+        "suite_counts": count_values(records, "suite"),
+        "source_layer_counts": layer_counts(records),
+        "blocked": blocked,
+        "blocking_failures": sum(
+            1 for record in records if record.get("status") in {"failed", "blocked"}
+        ),
+    }
+
+
+def summarize_real_world(path: Path, meta_path: Path | None = None) -> dict[str, Any]:
+    records = load_json(path)
+    if not isinstance(records, list):
+        raise ValueError(f"{path} must contain a list of real-world records")
+    meta = load_json(meta_path) if meta_path and meta_path.exists() else {}
+    return {
+        "artifact": str(path),
+        "metadata_artifact": str(meta_path) if meta_path else None,
+        "schema_version": meta.get("schema_version")
+        or next((record.get("schema_version") for record in records), None),
+        "component": "real-world-matrix",
+        "runner": meta.get("runner"),
+        "platform": meta.get("platform"),
+        "command": meta.get("command"),
+        "total": len(records),
+        "mode_counts": count_values(records, "mode"),
+        "verdict_counts": count_values(records, "got"),
+        "expected_counts": count_values(records, "expected"),
+        "source_layer_counts": layer_counts(records),
+        "blocking_failures": sum(
+            1 for record in records if int(record.get("exit_code") or 0) != 0
+        ),
+    }
+
+
+def layer_counts(records: list[dict[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        for layer in record.get("source_layers", []) or []:
+            counts[str(layer)] += 1
+    return dict(sorted(counts.items()))
+
+
+def make_summary(sections: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "command": [sys.executable, *sys.argv],
+        "section_count": len(sections),
+        "total_records": sum(int(section.get("total", 0)) for section in sections),
+        "blocking_failures": sum(
+            int(section.get("blocking_failures", 0)) for section in sections
+        ),
+        "sections": sections,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--examples", type=Path)
+    parser.add_argument("--components", type=Path)
+    parser.add_argument("--real-world", type=Path)
+    parser.add_argument("--real-world-meta", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--fail-on-blocking", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    sections = []
+    if args.examples:
+        sections.append(summarize_examples(args.examples))
+    if args.components:
+        sections.append(summarize_components(args.components))
+    if args.real_world:
+        sections.append(summarize_real_world(args.real_world, args.real_world_meta))
+    summary = make_summary(sections)
+    text = json.dumps(summary, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    if args.fail_on_blocking and summary["blocking_failures"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the data-source remediation plan with required full remeasurement coverage
- add the 2026-06-11 remeasurement status/proof artifact
- refresh validation/data/results.json with the available remeasurement output

## Scope notes
- based on fresh origin/main (3f91034e)
- intentionally did not include the local elf_symbol_filter.py / tests/test_elf_symbol_filters.py copies because applying them over fresh main would roll back newer main changes

## Verification
- git diff --cached --check
- python -m json.tool validation/data/results.json >/dev/null

## Known follow-up
- full real-world matrix remains blocked locally until validation/libs/ex is populated
- earlier full examples run: 126 total, PASS=102, XFAIL=5, SKIP=7, FAIL=10, ERROR=2
- component suites from the recorded pass: 1641 passed, 5 skipped, 10 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dump/diagnostics command now shows richer data-source evidence and side-by-side coverage with asymmetric marking.
  * Test runner supports artifact variants and a new artifact-variant option; per-variant timing and richer JSON output.

* **Documentation**
  * Added a remediation plan standardizing L0–L5 data-source taxonomy and a remeasurement status report documenting progress and next steps.

* **Validation / Reporting**
  * New/updated validation tools produce richer run-matrix and remeasurement summary artifacts and aggregated JSON reports.

* **Tests**
  * Expanded test suite to cover new diagnostics, coverage reporting, remeasurement summaries, and runner behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->