### PR TITLE
fix(ci): sync ChangeKind count to 234 and detector count to 49

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## What is abicheck?
 
 ABI compatibility checker for C/C++ shared libraries. Pure Python (3.10+).
-Detects 232 ABI/API change types across ELF, PE/COFF, and Mach-O binaries,
+Detects 234 ABI/API change types across ELF, PE/COFF, and Mach-O binaries,
 categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, and `RISK_KINDS` (see `ChangeKind`).
 Drop-in replacement for abi-compliance-checker (ABICC).
 
@@ -105,7 +105,7 @@ Core pipeline (in order of data flow):
 
 - `AbiSnapshot` (`model.py`) — serializable snapshot of a library's ABI surface
 - `DiffResult` (`checker_types.py`) — single detected change with kind, severity, details
-- `ChangeKind` (`checker_policy.py`) — enum of 216 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
+- `ChangeKind` (`checker_policy.py`) — enum of 234 change types; categorized into `BREAKING_KINDS`, `API_BREAK_KINDS`, `COMPATIBLE_KINDS`, `RISK_KINDS`
 - `Verdict` (`checker.py`) — overall comparison result (compatible/source_break/breaking)
 - `LibraryMetadata` (`checker.py`) — parsed library info
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **abicheck** detects breaking changes in C/C++ shared libraries before they reach production. It compares two versions of a shared library — along with their public headers — and reports whether existing binaries will continue to work or break at runtime.
 
-It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **232 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
+It catches removed or renamed symbols, changed function signatures, struct layout drift, vtable reordering, enum value reassignment, and many more — **234 ABI/API change types** in total — that cause crashes, silent data corruption, or linker failures after a library upgrade.
 
 > **Platforms:** Linux (ELF), Windows (PE/COFF), macOS (Mach-O). Binary and header AST analysis on all platforms; debug-info cross-check uses DWARF (Linux, macOS) and PDB (Windows).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 ## Why abicheck
 
 - **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
-- **232 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
+- **234 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.
 - **ABICC drop-in** — full flag parity for migrating from `abi-compliance-checker`.

--- a/tests/test_architecture_refactor.py
+++ b/tests/test_architecture_refactor.py
@@ -142,9 +142,9 @@ class TestDetectorRegistry:
     """Self-registering detector registry."""
 
     def test_all_detectors_registered(self):
-        """All 48 detectors are registered via decorators."""
+        """All 49 detectors are registered via decorators."""
         registry = _get_populated_registry()
-        assert len(registry) == 48
+        assert len(registry) == 49
 
     def test_detector_names_unique(self):
         """No duplicate detector names."""
@@ -211,7 +211,7 @@ class TestDetectorRegistry:
         assert isinstance(changes, list)
         assert isinstance(results, list)
         # Results should have entries for all detectors (enabled or disabled)
-        assert len(results) == 48
+        assert len(results) == 49
 
     def test_support_check_disables_detector(self):
         """Detectors with failing support checks are disabled."""
@@ -367,7 +367,7 @@ class TestCompareUsesNewArchitecture:
         result = compare(old, new)
         assert result.verdict.value == "NO_CHANGE"
         assert result.changes == []
-        assert len(result.detector_results) == 48
+        assert len(result.detector_results) == 49
 
     def test_compare_detects_func_removal(self):
         """compare() detects function removal via registry."""


### PR DESCRIPTION
## Problem

CI on `main` has been failing since commit `5074e3c` ("feat: binary-only vtable/RTTI layout detectors + SYCL device ABI case"). That change added **two new `ChangeKind`s** (232 → 234) and **one new detector** (48 → 49) but did not update the counts that are asserted elsewhere, breaking two CI lanes:

1. **`ai-readiness` gate** — `doc-count-sync` errored because `README.md` and `docs/index.md` still claimed 232 detection rules while `len(ChangeKind) == 234`.
   ```
   ERROR: README.md: ChangeKind count says 232, but source of truth is 234.
   ERROR: docs/index.md: ChangeKind count says 232, but source of truth is 234.
   ```
2. **`unit-tests` (all OS/Python lanes)** — `tests/test_architecture_refactor.py` asserted `48` registered detectors / results, now `49`.
   ```
   FAILED test_all_detectors_registered            - assert 49 == 48
   FAILED test_run_all_returns_changes_and_results - assert 49 == 48
   FAILED test_compare_returns_valid_result        - assert 49 == 48
   FAILED test_main_returns_zero_on_clean_tree      - assert 1 == 0
   ```

## Fix

- Bump the documented ChangeKind count `232 → 234` in `README.md`, `docs/index.md`, and `CLAUDE.md` (and the stale `216` in CLAUDE.md's key-types list).
- Update the three `48 → 49` detector-count assertions in `tests/test_architecture_refactor.py`.

These are pure count-sync fixes following the legitimate detector/ChangeKind additions; no behavior changes.

## Verification

- `python scripts/check_ai_readiness.py` → `0 error(s)`
- Full fast unit suite: `9621 passed, 23 skipped, 4 xfailed`
- `ruff check` clean

https://claude.ai/code/session_01A2AU9eekNSLLVM5bSy6krZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2AU9eekNSLLVM5bSy6krZ)_