### PR TITLE
chore: enable Caveman plugin via project-scoped .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "caveman@caveman": true
+  }
+}


### PR DESCRIPTION
## What

Adds `.claude/settings.json` to the repo, declaring the `caveman` marketplace and enabling the `caveman@caveman` plugin at the project level.

## Why

Claude Code on the web runs in cloud VMs from a fresh clone of the repo. Repo-committed config (`CLAUDE.md`, `.claude/settings.json`, `.claude/skills/`, declared plugins) is honored, but local `~/.claude` user config and user-scoped `enabledPlugins` do **not** carry over to cloud sessions. Declaring the marketplace + enabled plugin in the repo's `.claude/settings.json` is the supported way to make the plugin available across web sessions.

## Config added

```json
{
  "extraKnownMarketplaces": {
    "caveman": {
      "source": {
        "source": "github",
        "repo": "JuliusBrussee/caveman"
      }
    }
  },
  "enabledPlugins": {
    "caveman@caveman": true
  }
}
```

https://claude.ai/code/session_011aJL5xS2UFaN55gXCAAJUA

---
_Generated by [Claude Code](https://claude.ai/code/session_011aJL5xS2UFaN55gXCAAJUA)_