### PR TITLE
Honor frozen-namespace downgrade guard in severity exits

### DIFF
--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -28,7 +28,6 @@ from .checker_policy import (
     Confidence,
     EvidenceTier,
     Verdict,
-    effective_category,
 )
 from .checker_policy import (
     policy_kind_sets as _policy_kind_sets,
@@ -227,40 +226,47 @@ class DiffResult:
                 sets[idx].add(kind)
         return frozenset(b), frozenset(a), frozenset(c), frozenset(r)
 
+    def _effective_verdict_for_change(self, change: Change) -> Verdict:
+        """Return the per-change verdict, including frozen namespace guards."""
+        from .severity import effective_verdict_for_change
+
+        return effective_verdict_for_change(
+            change,
+            policy=self.policy,
+            kind_sets=self._effective_kind_sets(),
+            policy_file=self.policy_file,
+        )
+
     @property
     def breaking(self) -> list[Change]:
         """Changes classified as BREAKING under the active policy."""
-        sets = self._effective_kind_sets()
         return [
-            c for c in self.changes if effective_category(c, *sets) == Verdict.BREAKING
+            c for c in self.changes
+            if self._effective_verdict_for_change(c) == Verdict.BREAKING
         ]
 
     @property
     def source_breaks(self) -> list[Change]:
         """Changes classified as API_BREAK under the active policy."""
-        sets = self._effective_kind_sets()
         return [
-            c for c in self.changes if effective_category(c, *sets) == Verdict.API_BREAK
+            c for c in self.changes
+            if self._effective_verdict_for_change(c) == Verdict.API_BREAK
         ]
 
     @property
     def compatible(self) -> list[Change]:
         """Changes classified as COMPATIBLE under the active policy."""
-        sets = self._effective_kind_sets()
         return [
-            c
-            for c in self.changes
-            if effective_category(c, *sets) == Verdict.COMPATIBLE
+            c for c in self.changes
+            if self._effective_verdict_for_change(c) == Verdict.COMPATIBLE
         ]
 
     @property
     def risk(self) -> list[Change]:
         """Changes classified as COMPATIBLE_WITH_RISK under the active policy."""
-        sets = self._effective_kind_sets()
         return [
-            c
-            for c in self.changes
-            if effective_category(c, *sets) == Verdict.COMPATIBLE_WITH_RISK
+            c for c in self.changes
+            if self._effective_verdict_for_change(c) == Verdict.COMPATIBLE_WITH_RISK
         ]
 
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1362,7 +1362,13 @@ def _exit_with_severity_or_verdict(
     if severity_explicitly_set:
         assert sev_config is not None
         eff_sets = result._effective_kind_sets()
-        exit_code = compute_exit_code(result.changes, sev_config, kind_sets=eff_sets)
+        exit_code = compute_exit_code(
+            result.changes,
+            sev_config,
+            policy=result.policy,
+            kind_sets=eff_sets,
+            policy_file=result.policy_file,
+        )
         if exit_code != 0:
             sys.exit(exit_code)
     else:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -33,7 +33,6 @@ from .checker import (
 )
 from .checker_policy import (
     ChangeKind,
-    effective_category,
     impact_for,
 )
 from .checker_policy import (
@@ -766,17 +765,18 @@ def to_json(
             "breaking": sum(
                 1
                 for c in changes
-                if effective_category(c, *eff_sets) == Verdict.BREAKING
+                if result._effective_verdict_for_change(c) == Verdict.BREAKING
             ),
             "source_breaks": sum(
                 1
                 for c in changes
-                if effective_category(c, *eff_sets) == Verdict.API_BREAK
+                if result._effective_verdict_for_change(c) == Verdict.API_BREAK
             ),
             "risk_changes": sum(
                 1
                 for c in changes
-                if effective_category(c, *eff_sets) == Verdict.COMPATIBLE_WITH_RISK
+                if result._effective_verdict_for_change(c)
+                == Verdict.COMPATIBLE_WITH_RISK
             ),
             "total_changes": len(changes),
         }
@@ -787,11 +787,16 @@ def to_json(
             changes,
             severity_config,
             all_changes=list(result.changes),
+            policy=result.policy,
             kind_sets=eff_sets,
+            policy_file=result.policy_file,
         )
 
     d["changes"] = [
-        _change_to_dict(c, policy=effective_policy, kind_sets=eff_sets) for c in changes
+        _change_to_dict(
+            c, policy=effective_policy, kind_sets=eff_sets, policy_file=result.policy_file,
+        )
+        for c in changes
     ]
     if result.redundant_count > 0:
         d["redundant_count"] = result.redundant_count
@@ -854,13 +859,17 @@ def _change_to_dict(
         frozenset[ChangeKind],
     ]
     | None = None,
+    policy_file: object | None = None,
 ) -> dict[str, object]:
     """Convert a Change to a JSON-serializable dict with impact and metadata."""
     kind = getattr(c, "kind", None)
     if kind and kind_sets:
-        # Route through effective_category so a per-finding A4 override (a
-        # demoted opaque/PIMPL layout change) reads compatible here too.
-        severity = _effective_severity_label(c, kind_sets)
+        from .severity import effective_verdict_for_change
+
+        verdict = effective_verdict_for_change(
+            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        )
+        severity = _VERDICT_TO_SEVERITY_LABEL.get(verdict, "unknown")
     elif kind:
         severity = _kind_to_severity(kind, policy)
     else:
@@ -977,12 +986,16 @@ def _build_severity_summary_md(
     changes: list[Change],
     severity_config: SeverityConfig,
     *,
+    policy: str | None = None,
     kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> list[str]:
     """Build a severity configuration summary table for markdown output."""
     from .severity import SeverityLevel, categorize_changes
 
-    categorized = categorize_changes(changes, kind_sets=kind_sets)
+    categorized = categorize_changes(
+        changes, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
     lines = [
         "## Severity Configuration",
         "",
@@ -1024,7 +1037,9 @@ def _build_severity_json(
     severity_config: SeverityConfig,
     *,
     all_changes: list[Change] | None = None,
+    policy: str | None = None,
     kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> dict[str, object]:
     """Build severity information for JSON output.
 
@@ -1036,7 +1051,9 @@ def _build_severity_json(
     """
     from .severity import SeverityLevel, categorize_changes, compute_exit_code
 
-    categorized = categorize_changes(changes, kind_sets=kind_sets)
+    categorized = categorize_changes(
+        changes, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
 
     config_dict: dict[str, str] = {}
     for attr in ("abi_breaking", "potential_breaking", "quality_issues", "addition"):
@@ -1065,7 +1082,13 @@ def _build_severity_json(
     # Exit code uses the full unfiltered change set so --show-only
     # does not affect it.
     exit_changes = all_changes if all_changes is not None else changes
-    exit_code = compute_exit_code(exit_changes, severity_config, kind_sets=kind_sets)
+    exit_code = compute_exit_code(
+        exit_changes,
+        severity_config,
+        policy=policy,
+        kind_sets=kind_sets,
+        policy_file=policy_file,
+    )
 
     return {
         "config": config_dict,
@@ -1262,18 +1285,22 @@ def _classify_changes_by_kind(
     effective kind sets (respects PolicyFile overrides) and per-finding A4
     ``effective_verdict`` overrides (ADR-027), so a demoted opaque/PIMPL layout
     change lands in the compatible bucket of the text report too."""
-    sets = result._effective_kind_sets()
-    breaking = [c for c in changes if effective_category(c, *sets) == Verdict.BREAKING]
+    breaking = [
+        c for c in changes
+        if result._effective_verdict_for_change(c) == Verdict.BREAKING
+    ]
     source_breaks = [
-        c for c in changes if effective_category(c, *sets) == Verdict.API_BREAK
+        c for c in changes
+        if result._effective_verdict_for_change(c) == Verdict.API_BREAK
     ]
     risk = [
         c
         for c in changes
-        if effective_category(c, *sets) == Verdict.COMPATIBLE_WITH_RISK
+        if result._effective_verdict_for_change(c) == Verdict.COMPATIBLE_WITH_RISK
     ]
     compatible = [
-        c for c in changes if effective_category(c, *sets) == Verdict.COMPATIBLE
+        c for c in changes
+        if result._effective_verdict_for_change(c) == Verdict.COMPATIBLE
     ]
     return breaking, source_breaks, risk, compatible
 
@@ -1376,7 +1403,9 @@ def to_markdown(
         lines += _build_severity_summary_md(
             changes,
             severity_config,
+            policy=result.policy,
             kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
         )
 
     if show_only:

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -181,8 +181,67 @@ def classify_change_object(
     severity-aware exit code and category counts, not just the verdict. Falls
     back to kind-based ``classify_change`` for plain stubs with no override.
     """
+    return classify_effective_change(change, policy=policy, kind_sets=kind_sets)
+
+
+_VERDICT_ORDER = [
+    Verdict.NO_CHANGE,
+    Verdict.COMPATIBLE,
+    Verdict.COMPATIBLE_WITH_RISK,
+    Verdict.API_BREAK,
+    Verdict.BREAKING,
+]
+
+
+def _has_frozen_namespace_violation(change: HasKind) -> bool:
+    """Return True only for a real frozen-namespace tag string."""
+    fnv = getattr(change, "frozen_namespace_violation", None)
+    return isinstance(fnv, str) and bool(fnv)
+
+
+def effective_verdict_for_change(
+    change: HasKind,
+    *,
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
+) -> Verdict:
+    """Return the effective verdict for one change.
+
+    Policy-file overrides usually move an entire ``ChangeKind`` into another
+    verdict bucket. Frozen-namespace violations are deliberately per-change: if
+    an override would downgrade a tagged finding below the base-policy verdict,
+    the override is ignored for that one finding.
+    """
+    kind = change.kind
+    overrides = getattr(policy_file, "overrides", None) if policy_file is not None else None
+    if overrides and kind in overrides:
+        base_policy = getattr(policy_file, "base_policy", policy)
+        base_sets = _resolve_kind_sets(base_policy, None)
+        base_v = effective_category(change, *base_sets)
+        override_v = overrides[kind]
+        if (
+            _has_frozen_namespace_violation(change)
+            and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)
+        ):
+            return base_v
+        return override_v
     sets = _resolve_kind_sets(policy, kind_sets)
-    verdict = effective_category(change, *sets)
+    return effective_category(change, *sets)
+
+
+def classify_effective_change(
+    change: HasKind,
+    *,
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
+) -> IssueCategory:
+    """Classify one change, preserving per-finding verdict guards."""
+    sets = _resolve_kind_sets(policy, kind_sets)
+    verdict = effective_verdict_for_change(
+        change, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
     if verdict == Verdict.BREAKING:
         return IssueCategory.ABI_BREAKING
     if verdict in (Verdict.API_BREAK, Verdict.COMPATIBLE_WITH_RISK):
@@ -391,6 +450,7 @@ def compute_exit_code(
     *,
     policy: str | None = None,
     kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> int:
     """Compute the process exit code based on severity configuration.
 
@@ -399,13 +459,17 @@ def compute_exit_code(
     - severity configured as ``error``.
 
     *kind_sets* (from ``DiffResult._effective_kind_sets()``) includes
-    PolicyFile overrides and takes precedence over *policy*.
+    PolicyFile overrides and takes precedence over *policy*. When
+    *policy_file* is provided, frozen-namespace downgrade guards are applied
+    per change before classifying severity.
 
     Returns 0 if no category at error level has findings.
     """
     worst = 0
     for change in changes:
-        cat = classify_change_object(change, policy=policy, kind_sets=kind_sets)
+        cat = classify_effective_change(
+            change, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        )
         if config.level_for(cat) == SeverityLevel.ERROR:
             code = _CATEGORY_EXIT_CODES[cat]
             if code > worst:
@@ -434,6 +498,7 @@ def categorize_changes(
     *,
     policy: str | None = None,
     kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> CategorizedChanges:
     """Partition changes into the four issue categories."""
     abi: list[HasKind] = []
@@ -442,7 +507,9 @@ def categorize_changes(
     adds: list[HasKind] = []
 
     for c in changes:
-        cat = classify_change_object(c, policy=policy, kind_sets=kind_sets)
+        cat = classify_effective_change(
+            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        )
         if cat == IssueCategory.ABI_BREAKING:
             abi.append(c)
         elif cat == IssueCategory.POTENTIAL_BREAKING:

--- a/tests/test_frozen_namespace.py
+++ b/tests/test_frozen_namespace.py
@@ -231,6 +231,79 @@ class TestFrozenNamespaceBlocksDowngrade:
         r = compare(old, new, policy_file=pf)
         assert r.verdict == Verdict.COMPATIBLE
 
+    def test_severity_exit_code_honors_frozen_downgrade_guard(self) -> None:
+        """Severity-aware CI exits must preserve the same frozen-namespace
+        downgrade guard as the legacy verdict path."""
+        from abicheck.severity import PRESET_DEFAULT, compute_exit_code
+
+        old = _snap("1.0", [
+            _fn("ns::detail::r1::dispatch", "_ZN2ns6detail2r18dispatchEi",
+                params=[Param(name="n", type="int")]),
+        ])
+        new = _snap("2.0", [
+            _fn("ns::detail::r1::dispatch", "_ZN2ns6detail2r18dispatchEi",
+                params=[Param(name="n", type="long")]),
+        ])
+        pf = PolicyFile(
+            base_policy="strict_abi",
+            overrides={ChangeKind.FUNC_PARAMS_CHANGED: Verdict.COMPATIBLE},
+            frozen_namespaces=["**::detail::r1::*"],
+        )
+        r = compare(old, new, policy_file=pf)
+
+        assert r.verdict == Verdict.BREAKING
+        assert any(
+            c.kind == ChangeKind.FUNC_PARAMS_CHANGED
+            and c.frozen_namespace_violation == "**::detail::r1::*"
+            for c in r.changes
+        )
+        assert compute_exit_code(
+            r.changes,
+            PRESET_DEFAULT,
+            policy=r.policy,
+            kind_sets=r._effective_kind_sets(),
+            policy_file=r.policy_file,
+        ) == 4
+
+        from abicheck.cli import _exit_with_severity_or_verdict
+
+        with pytest.raises(SystemExit) as excinfo:
+            _exit_with_severity_or_verdict(r, PRESET_DEFAULT, True)
+        assert excinfo.value.code == 4
+        assert len(r.breaking) >= 1
+
+    def test_severity_exit_code_still_allows_non_frozen_downgrade(self) -> None:
+        """The per-change guard must not make all overrides ineffective."""
+        from abicheck.severity import PRESET_DEFAULT, compute_exit_code
+
+        old = _snap("1.0", [
+            _fn("ns::pub::dispatch", "_ZN2ns3pub8dispatchEi",
+                params=[Param(name="n", type="int")]),
+        ])
+        new = _snap("2.0", [
+            _fn("ns::pub::dispatch", "_ZN2ns3pub8dispatchEi",
+                params=[Param(name="n", type="long")]),
+        ])
+        pf = PolicyFile(
+            base_policy="strict_abi",
+            overrides={
+                ChangeKind.FUNC_PARAMS_CHANGED: Verdict.COMPATIBLE,
+                ChangeKind.OVERLOAD_SET_REROUTED: Verdict.COMPATIBLE,
+            },
+            frozen_namespaces=["**::detail::r1::*"],
+        )
+        r = compare(old, new, policy_file=pf)
+
+        assert r.verdict == Verdict.COMPATIBLE
+        assert compute_exit_code(
+            r.changes,
+            PRESET_DEFAULT,
+            policy=r.policy,
+            kind_sets=r._effective_kind_sets(),
+            policy_file=r.policy_file,
+        ) == 0
+        assert r.breaking == []
+
 
 # ── Suppression namespace selector ─────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Severity-based exit code and reporting paths applied `PolicyFile.overrides` globally by ChangeKind and ignored per-change `Change.frozen_namespace_violation`, allowing a frozen-namespace downgrade guard to be bypassed when `--severity-*` options or presets were used.
- The intent is to preserve the new frozen-namespace protection (no downgrade of tagged findings) across all consumers: legacy verdict, severity exit-code computation, JSON/Markdown reports, and CLI behavior.

### Description
- Add per-change effective verdict logic in `abicheck/severity.py` (`effective_verdict_for_change` and `classify_effective_change`) that applies the policy-file downgrade guard for changes carrying `frozen_namespace_violation` before mapping kinds → verdict → category.
- Thread `policy_file` into severity helpers and use per-change classification in `compute_exit_code` so severity-aware exit codes honor frozen-namespace tags.
- Add `DiffResult._effective_verdict_for_change` and change `DiffResult.breaking`, `source_breaks`, `compatible`, and `risk` to use the per-change verdict so summaries reflect the frozen-namespace guard.
- Update reporter (`abicheck/reporter.py`) to classify changes per-change (for markdown/JSON severity summaries and `changes` output) and to pass `policy_file` into severity helpers and JSON builders; adjust `_change_to_dict` to use the per-change effective verdict for the `severity` field.
- Update CLI (`abicheck/cli.py`) to pass `result.policy_file` into `compute_exit_code` when `--severity-*` flags are used so the CLI exit path cannot bypass the guard.
- Add regression tests in `tests/test_frozen_namespace.py` to assert that severity exit code and the CLI exit behavior preserve the frozen-namespace downgrade guard while non-frozen overrides still apply normally.

### Testing
- Ran unit tests for the changed areas with `pytest tests/test_frozen_namespace.py tests/test_severity.py tests/test_reporter.py -q`, all tests passed (`25`/`281` as applicable) and the new regression tests succeeded.
- Ran the broader non-integration test selection `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden" -q`, which completed successfully in the final run (281 passed); an earlier collection attempt failed due to a missing optional `hypothesis` test dependency in the environment but this did not affect the focused regression coverage.
- Ran style/type checks with `ruff check abicheck tests/test_frozen_namespace.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a34e1259c832b9049c7c842653c45)