### PR TITLE
Validate qualified-name enrichment per snapshot to prevent namespace spoofing for extern "C" symbols

### DIFF
--- a/abicheck/diff_filtering.py
+++ b/abicheck/diff_filtering.py
@@ -127,6 +127,37 @@ def _safe_index(snap: AbiSnapshot) -> bool:
     return True
 
 
+def _qualified_functions_by_mangled(snap: AbiSnapshot | None) -> dict[str, str]:
+    """Return mangled/exported function names that have C++ qualification."""
+    if snap is None or not _safe_index(snap):
+        return {}
+
+    qualified: dict[str, str] = {}
+    for mangled, fn in (getattr(snap, "_func_by_mangled", None) or {}).items():
+        fname = getattr(fn, "name", None)
+        if fname and "::" in fname and mangled not in qualified:
+            qualified[mangled] = fname
+    return qualified
+
+
+def _qualified_name_for_change(
+    c: Change,
+    old_qualified: dict[str, str],
+    new_qualified: dict[str, str],
+) -> str | None:
+    """Safely recover a C++ qualified name for a function change."""
+    if c.kind == ChangeKind.FUNC_ADDED:
+        return new_qualified.get(c.symbol)
+    if c.kind in (ChangeKind.FUNC_REMOVED, ChangeKind.FUNC_REMOVED_ELF_ONLY):
+        return old_qualified.get(c.symbol)
+
+    old_name = old_qualified.get(c.symbol)
+    new_name = new_qualified.get(c.symbol)
+    if old_name and old_name == new_name:
+        return old_name
+    return None
+
+
 def _enrich_source_locations(
     changes: list[Change],
     old: AbiSnapshot,
@@ -135,19 +166,8 @@ def _enrich_source_locations(
     """Fill in source_location and qualified_name on Changes from the model data."""
     type_loc, func_loc, var_loc = _build_location_index(old, new)
 
-    # Build mangled→qualified-name lookup so namespace-based selectors
-    # (Suppression.namespace, frozen_namespaces policy) can recover the
-    # C++ namespace of ``extern "C"`` symbols whose ``Change.symbol`` is
-    # the unqualified export name. Both snapshots are consulted because
-    # FUNC_REMOVED is only in old, FUNC_ADDED only in new.
-    qualified_lookup: dict[str, str] = {}
-    for snap in (old, new):
-        if snap is None or not _safe_index(snap):
-            continue
-        for mangled, fn in (getattr(snap, "_func_by_mangled", None) or {}).items():
-            fname = getattr(fn, "name", None)
-            if fname and "::" in fname and mangled not in qualified_lookup:
-                qualified_lookup[mangled] = fname
+    old_qualified = _qualified_functions_by_mangled(old)
+    new_qualified = _qualified_functions_by_mangled(new)
 
     for c in changes:
         if not c.source_location:
@@ -163,7 +183,7 @@ def _enrich_source_locations(
             if loc:
                 c.source_location = loc
         if not c.qualified_name:
-            qual = qualified_lookup.get(c.symbol)
+            qual = _qualified_name_for_change(c, old_qualified, new_qualified)
             if qual:
                 c.qualified_name = qual
 

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -756,26 +756,6 @@ class EscalateFrozenNamespaceViolations:
 
     name = "escalate_frozen_namespace_violations"
 
-    @staticmethod
-    def _build_qualified_lookup(old: AbiSnapshot, new: AbiSnapshot) -> dict[str, str]:
-        """Build a mangled→qualified-name map from both snapshots.
-
-        Pre-building this lookup lets :meth:`run` recover the C++ namespace
-        of ``extern "C"`` symbols whose ``Change.symbol`` is just the
-        unqualified export name.  Both snapshots are consulted because
-        FUNC_REMOVED is only in old and FUNC_ADDED only in new.
-        """
-        qualified_lookup: dict[str, str] = {}
-        for snap in (old, new):
-            if snap is None or not _safe_index(snap):
-                continue
-            func_map = getattr(snap, "_func_by_mangled", None) or {}
-            for mangled, fn in func_map.items():
-                fname = getattr(fn, "name", None)
-                if fname and "::" in fname and mangled not in qualified_lookup:
-                    qualified_lookup[mangled] = fname
-        return qualified_lookup
-
     def run(self, changes: list[Change], ctx: PipelineContext) -> list[Change]:
         if not ctx.frozen_namespaces:
             return changes
@@ -783,12 +763,17 @@ class EscalateFrozenNamespaceViolations:
         import fnmatch
 
         from .demangle import demangle
+        from .diff_filtering import (
+            _qualified_functions_by_mangled,
+            _qualified_name_for_change,
+        )
         from .internal_leak import _strip_template_args
 
         patterns = list(ctx.frozen_namespaces)
-        qualified_lookup = self._build_qualified_lookup(ctx.old, ctx.new)
+        old_qualified = _qualified_functions_by_mangled(ctx.old)
+        new_qualified = _qualified_functions_by_mangled(ctx.new)
 
-        def _match(name: str | None) -> str | None:
+        def _match(name: str | None, c: Change) -> str | None:
             if not name:
                 return None
             # Collect every plausible C++-qualified form of *name*:
@@ -802,9 +787,10 @@ class EscalateFrozenNamespaceViolations:
                 dm = demangle(name)
                 if dm:
                     forms.append(dm)
-            qual = qualified_lookup.get(name)
-            if qual:
-                forms.append(qual)
+            if name == c.symbol:
+                qual = _qualified_name_for_change(c, old_qualified, new_qualified)
+                if qual:
+                    forms.append(qual)
 
             for form in forms:
                 # Walk every ancestor prefix so ``**::detail::r1`` matches
@@ -826,7 +812,9 @@ class EscalateFrozenNamespaceViolations:
                 # overlay that synthesised a finding with the field set).
                 return
             pat = (
-                _match(c.symbol) or _match(c.caused_by_type) or _match(c.qualified_name)
+                _match(c.symbol, c)
+                or _match(c.caused_by_type, c)
+                or _match(c.qualified_name, c)
             )
             if pat is None:
                 return

--- a/tests/test_frozen_namespace.py
+++ b/tests/test_frozen_namespace.py
@@ -340,6 +340,42 @@ class TestSuppressionNamespaceSelector:
         r = compare(old, new, suppression=suppression)
         assert r.verdict == Verdict.NO_CHANGE
 
+    def test_extern_c_namespace_suppression_rejects_one_sided_spoof(self) -> None:
+        """A new-side namespace alone must not suppress an existing global export.
+
+        The C-linkage symbol is still ``dispatch`` in both snapshots, so a
+        trusted namespace suppression must not be satisfied by moving only the
+        new declaration under the suppressed C++ namespace.
+        """
+        old_fn = Function(
+            name="dispatch",
+            mangled="dispatch",
+            return_type="int",
+            params=[Param(name="n", type="int")],
+            visibility=Visibility.PUBLIC,
+            is_extern_c=True,
+        )
+        new_fn = Function(
+            name="mylib::detail::r1::dispatch",
+            mangled="dispatch",
+            return_type="long",
+            params=[Param(name="n", type="long")],
+            visibility=Visibility.PUBLIC,
+            is_extern_c=True,
+        )
+        old = _snap("1.0", [old_fn])
+        new = _snap("2.0", [new_fn])
+        suppression = SuppressionList(
+            [Suppression(namespace="**::detail::r1::*", reason="legacy churn")],
+        )
+        r = compare(old, new, suppression=suppression)
+        assert r.verdict == Verdict.BREAKING
+        assert r.suppressed_count == 0
+        assert {c.kind for c in r.changes} == {
+            ChangeKind.FUNC_RETURN_CHANGED,
+            ChangeKind.FUNC_PARAMS_CHANGED,
+        }
+
 
 # ── Regression: deep ancestor matching + extern "C" + ctx.redundant ─────
 


### PR DESCRIPTION
### Motivation
- The prior enrichment built a single mangled→qualified-name map from both old and new snapshots and attached the recovered name to every `Change` based solely on the exported symbol, which allowed a new-side C++ namespace to suppress breaking changes to an existing global `extern "C"` export.
- This change prevents an attacker-controlled header/artifact from spoofing a trusted namespace onto a stable C-linkage export and hiding real ABI breaks from suppression rules.

### Description
- Add ` _qualified_functions_by_mangled` and `_qualified_name_for_change` to `abicheck/diff_filtering.py` and use them in `_enrich_source_locations` so old/new qualified-name lookups are kept side-specific and the recovered qualified name is trusted only when appropriate (one-sided names for `FUNC_ADDED`/`FUNC_REMOVED`, and agreement required for existing-symbol changes).
- Update `EscalateFrozenNamespaceViolations` in `abicheck/post_processing.py` to use the side-aware lookup and to consult the side-validated qualified name when matching frozen-namespace patterns (matching now passes the `Change` into the matcher to apply the per-change logic).
- Add a regression test `test_extern_c_namespace_suppression_rejects_one_sided_spoof` in `tests/test_frozen_namespace.py` that verifies a new-side namespace alone does not suppress ABI breakage on a previously-global `extern "C"` symbol.

### Testing
- Ran `pytest tests/test_frozen_namespace.py -q`: all tests in that file passed (`24 passed`).
- Ran `python -m compileall abicheck tests/test_frozen_namespace.py`: compilation succeeded.
- Ran full `pytest -q`: test collection failed due to a missing test dependency (`hypothesis`), so full-suite results were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a35b4c664832b82e8a7bbb04786de)