### PR TITLE
fix(probe): validate probe manifest toolchain inputs to prevent RCE

### DIFF
--- a/abicheck/package.py
+++ b/abicheck/package.py
@@ -41,7 +41,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Protocol, runtime_checkable
+from typing import IO, Any, Protocol, runtime_checkable
 
 from .errors import ExtractionSecurityError, SnapshotError
 
@@ -188,9 +188,11 @@ class TarExtractor:
         tar_path = staging / "payload.tar"
         try:
             try:
-                import zstandard as zstandard_mod
+                import zstandard
             except ImportError:
-                zstandard_mod = None
+                zstandard_mod: Any | None = None
+            else:
+                zstandard_mod = zstandard
             if zstandard_mod is not None:
                 dctx = zstandard_mod.ZstdDecompressor()
                 with open(zst_path, "rb") as compressed, open(tar_path, "wb") as out:

--- a/abicheck/probe_harness.py
+++ b/abicheck/probe_harness.py
@@ -199,12 +199,101 @@ class MatrixSnapshot:
 
 
 _CXX_STD_FLAG = "-std=c++"
-_SAFE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-_DISALLOWED_COMPILER_FLAGS = frozenset({
-    "-c", "-o", "-x", "-E", "-S", "-M", "-MD", "-MMD", "-MF", "-MT", "-MQ", "-pipe", "--"
-})
-_DISALLOWED_FLAG_PREFIXES: tuple[str, ...] = ("-o", "-x", "-MF", "-MT", "-MQ")
-_ALLOWED_COMPILER_BASENAMES: frozenset[str] = frozenset({"g++", "gcc", "clang++", "clang", "c++", "cc"})
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_SAFE_COMPILER_RE = re.compile(
+    r"^(?:[A-Za-z0-9_.+-]+-)?"
+    r"(?:g\+\+|gcc|clang\+\+|clang|c\+\+|cc)"
+    r"(?:-[0-9][A-Za-z0-9_.-]*)?$"
+)
+
+# Keep manifest-provided flags to inert compiler options. Options that make
+# GCC/Clang load plugins, specs, wrappers, or arbitrary frontend arguments are
+# deliberately omitted because they can execute local code before compilation.
+_SAFE_FLAG_PREFIXES = (
+    "-D",
+    "-I",
+    "-O",
+    "-Werror=",
+    "-Wno-",
+    "-g",
+    "-march=",
+    "-mcpu=",
+    "-mfpu=",
+    "-mtune=",
+    "-stdlib=",
+)
+_SAFE_FLAG_EXACT = {
+    "-ansi",
+    "-fexceptions",
+    "-fno-exceptions",
+    "-frtti",
+    "-fno-rtti",
+    "-fPIC",
+    "-fopenmp",
+    "-fpic",
+    "-fsycl",
+    "-pipe",
+    "-pedantic",
+    "-pthread",
+    "-Wall",
+    "-Werror",
+    "-Wextra",
+    "-Wpedantic",
+    "-m32",
+    "-m64",
+}
+
+
+def _validate_manifest_id(kind: str, value: Any) -> str:
+    if not isinstance(value, str) or not _SAFE_ID_RE.fullmatch(value):
+        raise ValueError(
+            f"probe spec {kind} must be a non-empty identifier containing only "
+            "letters, digits, '_', '.', or '-'"
+        )
+    if value in {".", ".."}:
+        raise ValueError(f"probe spec {kind} must not be {value!r}")
+    return value
+
+
+def _validate_compiler_name(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("probe spec compiler must be a non-empty string")
+    if Path(value).name != value:
+        raise ValueError(
+            "probe spec compiler must be a compiler executable name on PATH, "
+            "not a path"
+        )
+    if not _SAFE_COMPILER_RE.fullmatch(value):
+        raise ValueError(
+            "probe spec compiler must name a C/C++ compiler such as g++, gcc, "
+            "clang++, clang, c++, or cc"
+        )
+    return value
+
+
+def _validate_flag(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError("probe spec flags must be non-empty strings")
+    if value.startswith(_CXX_STD_FLAG):
+        return value
+    if value in _SAFE_FLAG_EXACT:
+        return value
+    if value.startswith(_SAFE_FLAG_PREFIXES):
+        return value
+    raise ValueError(f"probe spec compiler flag {value!r} is disallowed")
+
+
+def _validate_string_sequence(kind: str, value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list | tuple):
+        raise ValueError(f"probe spec {kind} must be a sequence of strings")
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"probe spec {kind} must be a sequence of strings")
+        out.append(item)
+    return tuple(out)
 
 
 def _parse_cxx_std(flags: list[str]) -> int | None:
@@ -216,52 +305,6 @@ def _parse_cxx_std(flags: list[str]) -> int | None:
             except ValueError:
                 return None
     return None
-
-
-
-
-def _validate_safe_component(value: Any, *, field_name: str) -> str:
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"{field_name} must be a non-empty string")
-    if not _SAFE_COMPONENT_RE.fullmatch(value):
-        raise ValueError(f"{field_name} contains unsafe characters: {value!r}")
-    if value in {".", ".."}:
-        raise ValueError(f"{field_name} cannot be '.' or '..'")
-    return value
-
-
-def _validate_compiler_name(value: Any) -> str:
-    if not isinstance(value, str) or not value:
-        raise ValueError("compiler must be a non-empty string")
-    compiler = os.path.basename(value)
-    if compiler != value:
-        raise ValueError(f"compiler must be a basename, got {value!r}")
-    if compiler.startswith("-"):
-        raise ValueError(f"compiler must not start with '-', got {value!r}")
-    if not any(
-        compiler == base or compiler.startswith(f"{base}-")
-        for base in _ALLOWED_COMPILER_BASENAMES
-    ):
-        raise ValueError(f"compiler must be a known C/C++ compiler basename, got {value!r}")
-    return compiler
-
-
-def _validate_flags(raw_flags: Any) -> tuple[str, ...]:
-    if raw_flags is None:
-        return ()
-    if not isinstance(raw_flags, list):
-        raise ValueError("flags must be a list of strings")
-    flags: list[str] = []
-    for f in raw_flags:
-        if not isinstance(f, str):
-            raise ValueError(f"flag values must be strings, got {f!r}")
-        flag_name = f.split("=", 1)[0]
-        if flag_name in _DISALLOWED_COMPILER_FLAGS or any(
-            flag_name.startswith(prefix) for prefix in _DISALLOWED_FLAG_PREFIXES
-        ):
-            raise ValueError(f"flag {f!r} is disallowed in probe configuration")
-        flags.append(f)
-    return tuple(flags)
 
 def load_probe_spec(path: str | Path) -> ProbeSpec:
     """Parse a YAML probe manifest. Accepts JSON too (a YAML subset)."""
@@ -291,21 +334,24 @@ def parse_probe_spec(data: dict[str, Any]) -> ProbeSpec:
 
     configs: list[ProbeConfiguration] = []
     for c in data["configurations"]:
-        flags = _validate_flags(c.get("flags", []))
+        raw_flags = _validate_string_sequence("flags", c.get("flags", []))
+        flags = tuple(_validate_flag(f) for f in raw_flags)
         configs.append(ProbeConfiguration(
-            id=_validate_safe_component(c["id"], field_name="configuration id"),
+            id=_validate_manifest_id("configuration id", c["id"]),
             compiler=_validate_compiler_name(c["compiler"]),
             flags=flags,
             defines=dict(c.get("defines", {})),
-            include_dirs=tuple(c.get("include_dirs", [])),
+            include_dirs=_validate_string_sequence(
+                "include_dirs", c.get("include_dirs", [])
+            ),
             cxx_std=_parse_cxx_std(list(flags)),
         ))
 
     probes: list[Probe] = []
     for p in data["probes"]:
         probes.append(Probe(
-            name=_validate_safe_component(p["name"], field_name="probe name"),
-            headers=tuple(p.get("headers", [])),
+            name=_validate_manifest_id("probe name", p["name"]),
+            headers=_validate_string_sequence("headers", p.get("headers", [])),
             body=p["body"],
         ))
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -19,10 +19,9 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from .checker_policy import HasKind
     from .severity import KindSets, SeverityConfig
 
 from .checker import (
@@ -33,6 +32,7 @@ from .checker import (
 )
 from .checker_policy import (
     ChangeKind,
+    HasKind,
     impact_for,
 )
 from .checker_policy import (
@@ -863,11 +863,14 @@ def _change_to_dict(
 ) -> dict[str, object]:
     """Convert a Change to a JSON-serializable dict with impact and metadata."""
     kind = getattr(c, "kind", None)
-    if kind and kind_sets:
+    if isinstance(kind, ChangeKind) and kind_sets:
         from .severity import effective_verdict_for_change
 
         verdict = effective_verdict_for_change(
-            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+            cast(HasKind, c),
+            policy=policy,
+            kind_sets=kind_sets,
+            policy_file=policy_file,
         )
         severity = _VERDICT_TO_SEVERITY_LABEL.get(verdict, "unknown")
     elif kind:

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
+from typing import cast
 
 from .checker_policy import (
     ADDITION_KINDS,
@@ -219,7 +220,7 @@ def effective_verdict_for_change(
         base_policy = getattr(policy_file, "base_policy", policy)
         base_sets = _resolve_kind_sets(base_policy, None)
         base_v = effective_category(change, *base_sets)
-        override_v = overrides[kind]
+        override_v = cast(Verdict, overrides[kind])
         if (
             _has_frozen_namespace_violation(change)
             and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)

--- a/tests/test_cli_probe.py
+++ b/tests/test_cli_probe.py
@@ -289,6 +289,39 @@ class TestProbeRun:
         assert data["library"] == "onedpl"
         assert data["version"] == "2022.0"
 
+    def test_run_rejects_manifest_command_execution(
+        self, tmp_path: Path
+    ) -> None:
+        marker = tmp_path / "pwned"
+        spec = tmp_path / "evil.yaml"
+        spec.write_text(
+            "name: evil\n"
+            "configurations:\n"
+            "  - id: shcfg\n"
+            "    compiler: /bin/sh\n"
+            f"    flags: ['-c', 'touch {marker}']\n"
+            "probes:\n"
+            "  - name: smoke\n"
+            "    headers: []\n"
+            "    body: |\n"
+            "      void probe() {}\n"
+        )
+        result = CliRunner().invoke(
+            main,
+            [
+                "probe",
+                "run",
+                str(spec),
+                "--library",
+                "evil",
+                "--version",
+                "1.0",
+                "--no-snapshot",
+            ],
+        )
+        assert result.exit_code != 0
+        assert not marker.exists()
+
     def test_run_reports_failures_on_stderr(self, tmp_path: Path, monkeypatch) -> None:
         from abicheck import cli_probe
         from abicheck.probe_harness import MatrixSnapshot, ProbeResult

--- a/tests/test_probe_harness.py
+++ b/tests/test_probe_harness.py
@@ -60,6 +60,41 @@ class TestParseProbeSpec:
         with pytest.raises(ValueError, match="missing required"):
             parse_probe_spec({"name": "x", "configurations": []})
 
+    @pytest.mark.parametrize("compiler", ["/bin/sh", "python3", "sh"])
+    def test_rejects_non_compiler_executables(self, compiler: str) -> None:
+        with pytest.raises(ValueError, match="compiler"):
+            parse_probe_spec({
+                "name": "test",
+                "configurations": [
+                    {"id": "c1", "compiler": compiler, "flags": ["-std=c++20"]},
+                ],
+                "probes": [{"name": "p", "headers": [], "body": ""}],
+            })
+
+    @pytest.mark.parametrize("flag", ["-c", "-wrapper", "-fplugin=evil.so", "-Xclang"])
+    def test_rejects_command_execution_flags(self, flag: str) -> None:
+        with pytest.raises(ValueError, match="flag"):
+            parse_probe_spec({
+                "name": "test",
+                "configurations": [
+                    {"id": "c1", "compiler": "g++", "flags": [flag]},
+                ],
+                "probes": [{"name": "p", "headers": [], "body": ""}],
+            })
+
+    @pytest.mark.parametrize("identifier", ["../escape", "subdir/p", ".", "..", ""])
+    def test_rejects_path_like_generated_file_identifiers(
+        self, identifier: str
+    ) -> None:
+        with pytest.raises(ValueError, match="identifier|must not"):
+            parse_probe_spec({
+                "name": "test",
+                "configurations": [
+                    {"id": identifier, "compiler": "g++", "flags": ["-std=c++20"]},
+                ],
+                "probes": [{"name": "p", "headers": [], "body": ""}],
+            })
+
     def test_defines_and_includes(self) -> None:
         spec = parse_probe_spec({
             "name": "test",


### PR DESCRIPTION
### Motivation
- The probe harness accepted manifest-controlled `compiler` and `flags` which made `abicheck probe run` able to execute arbitrary local commands when fed a malicious spec.

### Description
- Add validators and sanitisation in `abicheck/probe_harness.py` to validate configuration/probe identifiers, compiler executable names, flag strings, and string sequences before they are used.
- Introduce safe-name and safe-compiler regexes and an allowlist for flag prefixes/exact flags (`_SAFE_ID_RE`, `_SAFE_COMPILER_RE`, `_SAFE_FLAG_PREFIXES`, `_SAFE_FLAG_EXACT`) and helper functions `_validate_manifest_id`, `_validate_compiler_name`, `_validate_flag`, and `_validate_string_sequence`.
- Wire the validators into `parse_probe_spec` so `id`, `compiler`, `flags`, `include_dirs`, probe `name`, and `headers` are checked while preserving valid manifest behaviour.
- Add unit and CLI regression tests in `tests/test_probe_harness.py` and `tests/test_cli_probe.py` that assert rejection of interpreter/compiler paths, dangerous flags, and path-like identifiers.

### Testing
- Ran `python3 -m pytest tests/test_probe_harness.py tests/test_cli_probe.py -q` and the modified tests passed (`42 passed`).
- Ran linting and static checks with `python3 -m ruff` and `python3 -m mypy` against the changed files and they reported no issues.
- Ran the full test suite with `python3 -m pytest -q` where a pre-existing performance threshold test failed due to timing (one long-running performance test exceeded its asserted 5s limit), which is unrelated to the manifest validation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b4f132008832b83969335de7b4e25)