### PR TITLE
Restore bundle analysis by default in compare-release

### DIFF
--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1197,7 +1197,7 @@ def _strip_diff_results_and_adjust_verdict(
               help="Declare a co-versioned library cohort by name prefix (e.g. "
                    "'libfoo_'). Repeatable. Enables the BUNDLE_SONAME_SKEW check, "
                    "which flags when some members of the cohort bump their major SONAME "
-                   "while siblings lag, and enables bundle-level cross-library analysis.")
+                   "while siblings lag.")
 @click.option("--no-bundle-analysis", "no_bundle_analysis", is_flag=True, default=False,
               help="Skip bundle-level cross-library analysis (debug/parity escape hatch). "
                    "Bundle findings catch intra-bundle symbol removals, signature drift "
@@ -1403,8 +1403,7 @@ def compare_release_cmd(
         )
 
         bundle_result: BundleDiffResult | None = None
-        bundle_requested = manifest_path is not None or bool(bundle_cohorts)
-        if not no_bundle_analysis and bundle_requested:
+        if not no_bundle_analysis:
             bundle_result, worst_verdict = _collect_bundle_result(
                 library_results, old_map, new_map, worst_verdict,
                 manifest_path=manifest_path,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1453,7 +1453,7 @@ class TestCompareReleaseBundleE2E:
     parsing path.
     """
 
-    def test_compare_release_emits_bundle_findings(self, tmp_path: Path) -> None:
+    def test_compare_release_emits_bundle_findings_by_default(self, tmp_path: Path) -> None:
         # libcore drops core_mul between old and new; libalgo still
         # imports it. Bundle layer must catch this; the CLI must surface
         # the bundle_verdict and bundle_findings in JSON output.
@@ -1518,15 +1518,7 @@ class TestCompareReleaseBundleE2E:
 
         result = CliRunner().invoke(
             main,
-            [
-                "compare-release",
-                str(old),
-                str(new),
-                "--format",
-                "json",
-                "--bundle-cohort",
-                "lib",
-            ],
+            ["compare-release", str(old), str(new), "--format", "json"],
         )
         # Bundle BREAKING → exit 4.
         assert result.exit_code == 4, result.output
@@ -1543,38 +1535,9 @@ class TestCompareReleaseBundleE2E:
         assert intra["consumer_library"] == "libalgo.so"
         assert intra["symbol"] == "core_mul"
 
-    def test_compare_release_default_skips_bundle_analysis(
-        self, tmp_path: Path
-    ) -> None:
-        """Plain compare-release should not emit bundle findings by default."""
-        import json as _json
-
-        from click.testing import CliRunner
-
-        from abicheck.cli import main
-
-        old = tmp_path / "old"
-        new = tmp_path / "new"
-        old.mkdir()
-        new.mkdir()
-        _build_tiny_so(
-            old, "libfoo.so", "int foo(void){return 1;}\nint bar(void){return 2;}\n"
-        )
-        _build_tiny_so(new, "libfoo.so", "int foo(void){return 1;}\n")
-
-        result = CliRunner().invoke(
-            main,
-            ["compare-release", str(old), str(new), "--format", "json"],
-        )
-        assert result.exit_code == 4, result.output
-        data = _json.loads(result.stdout)
-        assert data["libraries"][0]["verdict"] == "BREAKING"
-        assert "bundle_verdict" not in data
-        assert "bundle_findings" not in data
-
     def test_compare_release_no_bundle_analysis_opts_out(self, tmp_path: Path) -> None:
-        # Same broken bundle as above; --no-bundle-analysis must
-        # suppress bundle findings and report only per-library results.
+        # --no-bundle-analysis must suppress bundle output and report only
+        # per-library results.
         import json as _json
 
         from click.testing import CliRunner


### PR DESCRIPTION
### Motivation
- A recent change introduced an opt-in gate that skipped bundle-level cross-library analysis unless `--manifest` or `--bundle-cohort` was supplied, which can silently omit runtime-breaking cross-library ABI issues from the default `compare-release` CI path.

### Description
- Remove the `bundle_requested` opt-in guard so bundle analysis is executed whenever `--no-bundle-analysis` is not set by calling `_collect_bundle_result` unconditionally in that branch of `compare_release_cmd` (`abicheck/cli_compare_release.py`).
- Update the `--bundle-cohort` help text to document that cohorts enable SONAME skew checks only and do not control overall bundle analysis (`abicheck/cli_compare_release.py`).
- Update the bundle E2E regression test to assert that the plain/default `compare-release` invocation emits bundle findings (`tests/test_bundle.py`) by renaming and adjusting `test_compare_release_emits_bundle_findings` to reflect default behavior and removing the regression that expected bundle analysis to be skipped by default.
- Modified files: `abicheck/cli_compare_release.py`, `tests/test_bundle.py`.

### Testing
- Ran the bundle E2E class with `pytest tests/test_bundle.py::TestCompareReleaseBundleE2E`, which was skipped (7 tests skipped) due to missing external tool `castxml` in the environment.
- Ran the main comparison and package test suites with `pytest tests/test_compare_release.py tests/test_package.py`, which succeeded (`178 passed`).
- Combined test runs reported the bundle E2E tests skipped for missing tooling and the rest of the test-suite passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d07a5a054832bb64e70304168a9f1)