### PR TITLE
fix(diff): harden Itanium source-name length parsing

### DIFF
--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1477,8 +1477,11 @@ def _skip_source_name(symbol: str, i: int) -> int:
     j = i
     while j < len(symbol) and symbol[j].isdigit():
         j += 1
-    end = j + int(symbol[i:j])
-    return end if end <= len(symbol) else -1
+    remaining, length = len(symbol) - j, 0
+    for c in symbol[i:j]:
+        if (length := (length * 10) + (ord(c) - ord("0"))) > remaining:
+            return -1
+    return j + length
 
 
 def _skip_substitution(symbol: str, i: int) -> int:

--- a/tests/test_binary_fingerprint.py
+++ b/tests/test_binary_fingerprint.py
@@ -671,6 +671,13 @@ class TestPlausibleRename:
         assert _ctor_dtor_variant("_ZN3FooB1xC2Ev") == "C2"
         assert _plausible_rename("_ZN3FooB1xC1Ev", "_ZN3FooB1xC2Ev") is False
 
+    def test_overlong_source_name_length_is_malformed_not_crash(self) -> None:
+        # Snapshot / ELF symbol names are untrusted input.  A malformed nested
+        # name with a huge decimal source-name length must safely under-detect
+        # instead of feeding the whole digit run to int() and aborting diffing.
+        assert _ctor_dtor_variant("_ZN" + ("9" * 5000)) is None
+        assert _ctor_dtor_variant("_ZN9999999999FooC1Ev") is None
+
     def test_return_type_only_template_change_rejected(self) -> None:
         # Function templates encode the return type in the ABI symbol, so a
         # same-leaf/same-params return-type change (int foo<int>() ->


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service / crash when parsing untrusted Itanium `<source-name>` decimal lengths (previous `int()` on long digit runs could raise), while preserving ctor/dtor variant detection and safely treating malformed lengths as non-ctor under-detection.

### Description
- Replace the unchecked `int(symbol[i:j])` conversion in `_skip_source_name` with a manual decimal accumulation bounded by the remaining bytes to avoid excessive integer conversions and return `-1` for malformed/overlong lengths in `abicheck/diff_symbols.py`.
- Add a regression test `test_overlong_source_name_length_is_malformed_not_crash` to `tests/test_binary_fingerprint.py` asserting that extremely long digit runs and oversized length fields are treated as malformed (yield `None`) rather than crashing the parser.

### Testing
- Ran `pytest -q tests/test_binary_fingerprint.py` and observed the test file pass (99 passed).
- Verified interactive checks for `_ctor_dtor_variant('_ZN' + '9'*5000)` return `None` and that templated ctor/dtor variants remain detected as before.
- Ran the full test suite with `pytest -q` and observed no regressions (7304 passed, 319 skipped, 4 xfailed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5c0dc8d8832b9db24fee57d345ce)