### PR TITLE
fix(surface): keep value ABI trait changes symbol-scoped

### DIFF
--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -110,7 +110,6 @@ _TYPE_LEVEL_KIND_NAMES: frozenset[str] = frozenset(
         "enum_underlying_size_changed",
         "struct_packing_changed",
         "type_visibility_changed",
-        "value_abi_trait_changed",
         "type_became_final",
         "type_lost_final",
         # Fine-grained class-layout descriptor findings (layout-closure work):

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -12,6 +12,7 @@ import pytest
 from abicheck.checker import compare
 from abicheck.checker_policy import ChangeKind, Verdict
 from abicheck.checker_types import Change
+from abicheck.dwarf_advanced import AdvancedDwarfMetadata
 from abicheck.model import (
     AbiSnapshot,
     Function,
@@ -253,6 +254,26 @@ class TestChangeClassification:
 
         assert change_in_public_surface(c, s, s) is True
 
+    def test_value_abi_trait_change_uses_public_function_symbol_before_type_names(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            functions=[_fn("api", ret="Result *")],
+            types=[_rec("Result"), _rec("api")],
+        )
+        s = self._surf(snap)
+        assert "api" in s.public_symbols
+        assert "api" in s.all_types
+        assert "api" not in s.public_types
+
+        c = Change(
+            kind=ChangeKind.VALUE_ABI_TRAIT_CHANGED,
+            symbol="api",
+            description="",
+        )
+
+        assert classify_change_surface(c, s, s) == (True, None)
+
     def test_leak_kind_never_filtered(self):
         snap = AbiSnapshot(
             library="l",
@@ -462,6 +483,42 @@ class TestScopedCompareNoFalsePositives:
         )
         assert not any(
             c.kind == ChangeKind.TYPE_SIZE_CHANGED and c.symbol == "Foo"
+            for c in scoped.out_of_surface_changes
+        )
+        assert scoped.verdict in (Verdict.BREAKING, Verdict.API_BREAK)
+
+    def test_public_value_abi_trait_change_with_non_public_type_collision_still_reported(
+        self,
+    ):
+        old = AbiSnapshot(
+            library="lib",
+            version="1",
+            functions=[_fn("api", ret="Result *")],
+            types=[_rec("Result"), _rec("api")],
+        )
+        old.dwarf_advanced = AdvancedDwarfMetadata(
+            has_dwarf=True,
+            value_abi_traits={"api": "p0:trivial"},
+        )
+        new = AbiSnapshot(
+            library="lib",
+            version="2",
+            functions=[_fn("api", ret="Result *")],
+            types=[_rec("Result"), _rec("api")],
+        )
+        new.dwarf_advanced = AdvancedDwarfMetadata(
+            has_dwarf=True,
+            value_abi_traits={"api": "p0:nontrivial"},
+        )
+
+        scoped = compare(old, new, scope_to_public_surface=True)
+
+        assert any(
+            c.kind == ChangeKind.VALUE_ABI_TRAIT_CHANGED and c.symbol == "api"
+            for c in scoped.changes
+        )
+        assert not any(
+            c.kind == ChangeKind.VALUE_ABI_TRAIT_CHANGED and c.symbol == "api"
             for c in scoped.out_of_surface_changes
         )
         assert scoped.verdict in (Verdict.BREAKING, Verdict.API_BREAK)


### PR DESCRIPTION
### Motivation
- DWARF-derived `value_abi_trait_changed` findings are keyed by function linkage/name and were incorrectly treated as type-level changes, allowing a public function ABI change to be demoted by an unrelated non-public type with the same name and thus bypass ABI-gating.

### Description
- Remove `value_abi_trait_changed` from the `_TYPE_LEVEL_KIND_NAMES` set in `abicheck/surface.py` so these findings are classified via the symbol/public-symbol path instead of type-reachability.
- Add unit tests in `tests/test_surface.py` to assert that `VALUE_ABI_TRAIT_CHANGED` uses the public function symbol classification and that an end-to-end `compare()` preserves a public function `value_abi_trait_changed` finding even when a non-public type collides by name.

### Testing
- Ran the two focused new tests via `pytest -q tests/test_surface.py::TestChangeClassification::test_value_abi_trait_change_uses_public_function_symbol_before_type_names tests/test_surface.py::TestScopedCompareNoFalsePositives::test_public_value_abi_trait_change_with_non_public_type_collision_still_reported` and both passed.
- Ran `pytest -q tests/test_surface.py tests/test_sprint4_dwarf_advanced.py` and both suites passed.
- Ran the full test suite with `pytest -q` after installing the optional dev dependency `hypothesis`, resulting in `7310 passed, 319 skipped, 4 xfailed` and no regressions, and ran `ruff` import/format checks which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f7215ee84832b934add034f160270)