### PR TITLE
fix(internal-leak): follow typedef aliases

### DIFF
--- a/abicheck/internal_leak.py
+++ b/abicheck/internal_leak.py
@@ -392,10 +392,26 @@ def _enqueue_record_children(
             queue.append((cand, new_path + [f"field:{fld.name}"]))
 
 
+def _enqueue_typedef_targets(
+    typename: str,
+    typedefs: dict[str, str],
+    path: list[str],
+    queue: collections.deque[tuple[str, list[str]]],
+) -> None:
+    """Enqueue the underlying type candidates for a typedef alias."""
+    target = typedefs.get(typename)
+    if not target:
+        return
+    for cand in _candidate_type_names(target):
+        if cand and cand != typename:
+            queue.append((cand, path + [f"typedef:{typename}"]))
+
+
 def _bfs_collect_paths(
     queue: collections.deque[tuple[str, list[str]]],
     type_map: dict[str, RecordType],
     internal_set: set[str],
+    typedefs: dict[str, str] | None = None,
 ) -> dict[str, list[list[str]]]:
     """Drive the BFS walk; return raw (un-deduped) internal-type paths."""
     paths: dict[str, list[list[str]]] = collections.defaultdict(list)
@@ -423,6 +439,8 @@ def _bfs_collect_paths(
                 paths[typename].append(list(path + [typename]))
             continue
         visited.add(key)
+
+        _enqueue_typedef_targets(typename, typedefs or {}, path, queue)
 
         if is_internal_type(typename, internal_set):
             paths[typename].append(list(path + [typename]))
@@ -466,6 +484,7 @@ def compute_leak_paths(
 
       - Every public function's return type and parameter types
       - Every public variable's type
+      - Typedef/using targets reached from those public signatures
       - For each visited type, its bases (and virtual bases) and the types
         of its non-pointer, non-reference fields
 
@@ -483,7 +502,7 @@ def compute_leak_paths(
     _seed_queue_from_variables(snap, queue)
     _seed_queue_from_public_types(type_map, internal_set, queue, is_dwarf_fallback=is_dwarf_fallback)
 
-    paths = _bfs_collect_paths(queue, type_map, internal_set)
+    paths = _bfs_collect_paths(queue, type_map, internal_set, snap.typedefs)
     return _dedup_paths(paths)
 
 

--- a/tests/test_internal_churn_demotion.py
+++ b/tests/test_internal_churn_demotion.py
@@ -194,6 +194,44 @@ def test_non_matching_frozen_namespace_still_demotes():
     assert r.out_of_surface_count >= 1
 
 
+def test_public_typedef_to_internal_type_is_not_demoted():
+    pub_fn = Function(
+        name="make", mangled="make", return_type="PublicImpl",
+        params=[], visibility=Visibility.PUBLIC,
+    )
+    old = AbiSnapshot(
+        library="lib.so.1", version="1", functions=[pub_fn],
+        types=[
+            RecordType(name="ns::detail::Impl", kind="struct", size_bits=32,
+                       fields=[TypeField(name="x", type="int", offset_bits=0)]),
+        ],
+        typedefs={"PublicImpl": "ns::detail::Impl"},
+    )
+    new = AbiSnapshot(
+        library="lib.so.1", version="2", functions=[pub_fn],
+        types=[
+            RecordType(name="ns::detail::Impl", kind="struct", size_bits=64,
+                       fields=[TypeField(name="x", type="long long", offset_bits=0)]),
+        ],
+        typedefs={"PublicImpl": "ns::detail::Impl"},
+    )
+
+    r = compare(old, new)
+
+    assert r.verdict == Verdict.BREAKING
+    assert any(c.kind == ChangeKind.TYPE_SIZE_CHANGED for c in r.changes)
+    assert any(
+        c.kind == ChangeKind.INTERNAL_TYPE_LEAKS_VIA_PUBLIC_API
+        and c.symbol == "ns::detail::Impl"
+        for c in r.changes
+    )
+    assert not any(
+        c.symbol == "ns::detail::Impl"
+        and c.surface_exclusion_reason == REASON_PRIVATE_INTERNAL_UNREACHABLE
+        for c in r.out_of_surface_changes
+    )
+
+
 def test_reachable_internal_type_still_leaks_and_breaks():
     # When the internal type IS reachable from the public API (embedded by value
     # in a public struct returned by a public function), the leak detector keeps

--- a/tests/test_internal_leak.py
+++ b/tests/test_internal_leak.py
@@ -130,6 +130,7 @@ def _snap(
     functions: list[Function] | None = None,
     variables: list[Variable] | None = None,
     types: list[RecordType] | None = None,
+    typedefs: dict[str, str] | None = None,
 ) -> AbiSnapshot:
     return AbiSnapshot(
         library=library,
@@ -137,6 +138,7 @@ def _snap(
         functions=list(functions or []),
         variables=list(variables or []),
         types=list(types or []),
+        typedefs=dict(typedefs or {}),
     )
 
 
@@ -219,6 +221,26 @@ class TestComputeLeakPaths:
         )
         paths = compute_leak_paths(snap)
         assert "ns::detail::Helper" in paths
+
+    def test_via_public_typedef_return_type(self) -> None:
+        snap = _snap(
+            functions=[_public_fn("make", "PublicImpl", [])],
+            types=[RecordType(name="ns::detail::Impl", kind="struct")],
+            typedefs={"PublicImpl": "ns::detail::Impl"},
+        )
+        paths = compute_leak_paths(snap)
+        assert "ns::detail::Impl" in paths
+        joined = " ".join(" ".join(p) for p in paths["ns::detail::Impl"])
+        assert "typedef:PublicImpl" in joined
+
+    def test_via_chained_public_typedef_return_type(self) -> None:
+        snap = _snap(
+            functions=[_public_fn("make", "PublicImpl", [])],
+            types=[RecordType(name="ns::detail::Impl", kind="struct")],
+            typedefs={"PublicImpl": "ImplAlias", "ImplAlias": "ns::detail::Impl"},
+        )
+        paths = compute_leak_paths(snap)
+        assert "ns::detail::Impl" in paths
 
     def test_via_template_argument_in_return(self) -> None:
         snap = _snap(


### PR DESCRIPTION
### Motivation
- The demotion step (`DemoteUnreachableInternalChurn`) assumed that absence of an `INTERNAL_TYPE_LEAKS_VIA_PUBLIC_API` finding meant an internal type was unreachable, but the leak detector did not follow `typedef`/`using` aliases from public function/variable signatures.
- That gap allowed a public typedef to expose an internal type to be missed and have layout changes demoted to the audit ledger, producing false `NO_CHANGE`/compatible verdicts for real public ABI breaks.

### Description
- Teach the internal-leak BFS to follow typedef/using alias targets by adding `_enqueue_typedef_targets` and invoking it from `_bfs_collect_paths` so typedef targets reached from public signatures are enqueued and walked.
- Thread `snap.typedefs` into the BFS by extending `_bfs_collect_paths` and passing `snap.typedefs` from `compute_leak_paths` so public typedef aliases are resolved during reachability analysis.
- Add regression tests: `tests/test_internal_leak.py` gains `test_via_public_typedef_return_type` and `test_via_chained_public_typedef_return_type`, and `tests/test_internal_churn_demotion.py` gains `test_public_typedef_to_internal_type_is_not_demoted` to ensure typedef-exposed internal types surface as leaks and are not demoted.
- Add `typedefs` support to the synthetic `_snap` helper used by the unit tests and update the reachability docstring to note typedef targets are followed.

### Testing
- Ran `pytest -q tests/test_internal_leak.py tests/test_internal_churn_demotion.py` and observed all tests in those modules passed (`54 passed`).
- Ran `python -m py_compile abicheck/internal_leak.py tests/test_internal_leak.py tests/test_internal_churn_demotion.py` with no syntax errors.
- Running the full test suite with `pytest -q` in this environment failed during collection due to missing test dependency `hypothesis` (environment issue), not related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22521efc14832b9f90a77c973d5478)