### PR TITLE
fix(source-abi): preserve API break for generated constexpr changes

### DIFF
--- a/abicheck/buildsource/source_diff.py
+++ b/abicheck/buildsource/source_diff.py
@@ -263,6 +263,11 @@ def _diff_generated(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
         new_b = _by_identity(new_bucket)
         for key in sorted(set(old_b) & set(new_b)):
             ov, nv = old_b[key], new_b[key]
+            # A generated constexpr value change is still a baked-in public
+            # constant change, so keep the stronger constexpr_value_changed
+            # finding instead of downgrading it to generated_header_changed.
+            if nv.kind == "constexpr":
+                continue
             if _is_generated(nv) and _entity_changed(ov, nv):
                 name = nv.qualified_name
                 changes.append(
@@ -379,13 +384,6 @@ def _diff_declarations(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Cha
         ov, nv = old_d[key], new_d[key]
         name = nv.qualified_name
 
-        # Generated entities are reported as generated_header_changed by
-        # _diff_generated (which also covers the reachable_types bucket); skip
-        # them here so they are not double-reported as a constexpr/default-arg
-        # change.
-        if _is_generated(nv):
-            continue
-
         if nv.kind == "constexpr":
             if ov.value != nv.value:
                 changes.append(
@@ -402,6 +400,14 @@ def _diff_declarations(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Cha
                         source_location=_loc(nv),
                     )
                 )
+            continue
+
+        # Generated entities are reported as generated_header_changed by
+        # _diff_generated (which also covers the reachable_types bucket); skip
+        # them here so they are not double-reported as a default-argument
+        # change. Generated constexpr value changes are handled above because
+        # they remain source/API breaks even when declared in generated headers.
+        if _is_generated(nv):
             continue
 
         # Default-argument change: same type signature, different normalized

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -571,6 +571,38 @@ def test_diff_generated_header_changed() -> None:
     assert [c.kind for c in changes] == [ChangeKind.GENERATED_HEADER_CHANGED]
 
 
+def test_diff_generated_constant_value_change_is_api_break() -> None:
+    # A generated public constexpr still behaves like a baked-in constant for
+    # consumers. Preserve constexpr_value_changed so legacy ABI gates see the
+    # API_BREAK severity, while removals remain covered by generated headers.
+    old = _surface(
+        reachable_declarations=[
+            _entity(
+                "cfg::KMax",
+                "constexpr",
+                visibility="generated",
+                origin="GENERATED",
+                value="64",
+            )
+        ]
+    )
+    new = _surface(
+        reachable_declarations=[
+            _entity(
+                "cfg::KMax",
+                "constexpr",
+                visibility="generated",
+                origin="GENERATED",
+                value="128",
+            )
+        ]
+    )
+    changes = diff_source_abi(old, new)
+    assert [c.kind for c in changes] == [ChangeKind.CONSTEXPR_VALUE_CHANGED]
+    assert changes[0].old_value == "64"
+    assert changes[0].new_value == "128"
+
+
 def test_diff_generated_constant_removed_detected() -> None:
     # A constexpr declared in a *generated* header that is removed in the new
     # version must surface as generated_header_changed. A namespace-scope


### PR DESCRIPTION
### Motivation
- A recent change marked constants from generated public headers as `generated`, which caused value changes to be classified as `generated_header_changed` (lower-severity) instead of `constexpr_value_changed` (an `API_BREAK`), weakening legacy exit-code gating for baked-in constexpr values.
- The intent is to keep removals of generated entities handled by the generated-header path while preserving the stronger API-break semantics for changed `constexpr` values so CI gates behave correctly.

### Description
- In `abicheck/evidence/source_diff.py` special-case `constexpr` in `_diff_generated` so generated `constexpr` value changes are not consumed by the generated-header path and can still be reported as `CONSTEXPR_VALUE_CHANGED`.
- In `abicheck/evidence/source_diff.py` move the generated-entity `continue` in `_diff_declarations` to after the `constexpr` branch so `constexpr` changes are handled first and other generated declarations are still skipped for default-arg handling.
- Add a regression unit test `test_diff_generated_constant_value_change_is_api_break` in `tests/test_source_abi.py` to assert that a generated `constexpr` value change produces `ChangeKind.CONSTEXPR_VALUE_CHANGED` with the expected old/new values.

### Testing
- Ran the targeted tests: `pytest -q tests/test_source_abi.py::test_diff_generated_constant_value_change_is_api_break tests/test_source_abi.py::test_diff_generated_constant_removed_detected tests/test_source_abi.py::test_diff_generated_header_changed tests/test_source_abi.py::test_diff_constexpr_value_changed` and all 4 passed.
- Ran the package-level tests: `pytest -q tests/test_source_abi.py tests/test_source_extractors.py` and observed `70 passed, 1 skipped`.
- Running the full test suite `pytest -q` aborts during collection due to a missing optional test dependency (`hypothesis`) in the environment, which is unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29d65ec61c832ba0fbcda52ff727ba)