### PR TITLE
Fix Rust C FFI policy: keep exported-symbol renames as BREAKING

### DIFF
--- a/abicheck/policies/rust_c_ffi.yaml
+++ b/abicheck/policies/rust_c_ffi.yaml
@@ -16,7 +16,8 @@
 #
 # Kept strict (NOT overridden) because they are real for a repr(C)/extern "C"
 # surface: func_removed, func_params_changed, func_return_changed,
-# type_size_changed, struct_field_offset_changed, var_removed, var_type_changed.
+# func_likely_renamed, symbol_renamed_batch, type_size_changed,
+# struct_field_offset_changed, var_removed, var_type_changed.
 base_policy: strict_abi
 
 overrides:
@@ -32,5 +33,3 @@ overrides:
   abi_tag_changed: risk
   char8t_migration: risk
   func_noexcept_removed: risk
-  symbol_renamed_batch: risk
-  func_likely_renamed: risk

--- a/tests/test_builtin_profiles.py
+++ b/tests/test_builtin_profiles.py
@@ -91,3 +91,13 @@ def test_rust_c_ffi_keeps_c_layout_break_strict() -> None:
     pf = PolicyFile.load(builtin_policy_path("rust_c_ffi"))
     verdict = pf.compute_verdict([_change(ChangeKind.TYPE_SIZE_CHANGED)])
     assert verdict == Verdict.BREAKING
+
+
+def test_rust_c_ffi_keeps_exported_symbol_renames_strict() -> None:
+    """Renaming a #[no_mangle]/#[export_name] symbol breaks old C consumers."""
+    pf = PolicyFile.load(builtin_policy_path("rust_c_ffi"))
+
+    assert ChangeKind.SYMBOL_RENAMED_BATCH not in pf.overrides
+    assert ChangeKind.FUNC_LIKELY_RENAMED not in pf.overrides
+    assert pf.compute_verdict([_change(ChangeKind.SYMBOL_RENAMED_BATCH)]) == Verdict.BREAKING
+    assert pf.compute_verdict([_change(ChangeKind.FUNC_LIKELY_RENAMED)]) == Verdict.BREAKING


### PR DESCRIPTION
### Motivation
- The `rust_c_ffi` built-in profile incorrectly downgraded exported-symbol rename kinds (`symbol_renamed_batch`, `func_likely_renamed`) to `risk`, which can let real ABI-breaking symbol renames pass CI with exit code 0. 
- The profile should preserve strict C-FFI invariants so changes to `#[no_mangle]`/`#[export_name]` symbols remain `BREAKING` and continue to fail the ABI gate.

### Description
- Removed the `symbol_renamed_batch` and `func_likely_renamed` overrides from `abicheck/policies/rust_c_ffi.yaml` so those kinds now inherit the `strict_abi` breaking severity. 
- Updated the policy comment to list `func_likely_renamed` and `symbol_renamed_batch` among the C-relevant checks kept strict in `rust_c_ffi.yaml`. 
- Added a regression test `test_rust_c_ffi_keeps_exported_symbol_renames_strict` in `tests/test_builtin_profiles.py` that asserts the profile does not override these kinds and that they compute to `Verdict.BREAKING`.

### Testing
- Ran `pytest tests/test_builtin_profiles.py` which includes the new regression; the full suite reported `21 passed` and completed successfully. 
- The new unit test `test_rust_c_ffi_keeps_exported_symbol_renames_strict` verifies the intended behavior and passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b7f062aac832b90196a8e1f8a0475)