### PR TITLE
Enforce require_evidence against both baseline and target packs

### DIFF
--- a/abicheck/buildsource/evidence_policy.py
+++ b/abicheck/buildsource/evidence_policy.py
@@ -79,7 +79,8 @@ def apply_evidence_policy(
 
 # ── D7 require_evidence gate ─────────────────────────────────────────────────
 
-# require_evidence layer key -> (human label, pack attribute proving presence).
+# require_evidence layer key -> (human label, pack attribute needed on both sides
+# to make that layer comparable).
 _REQUIRE_EVIDENCE_LAYERS: tuple[tuple[str, str, str], ...] = (
     ("build_context", "L3 build context", "build_evidence"),
     ("source_abi", "L4 source ABI replay", "source_abi"),
@@ -88,14 +89,17 @@ _REQUIRE_EVIDENCE_LAYERS: tuple[tuple[str, str, str], ...] = (
 
 
 def require_evidence_findings(
-    policy_file: PolicyFile | None, new_pack: BuildSourcePack | None
+    policy_file: PolicyFile | None,
+    old_pack: BuildSourcePack | None,
+    new_pack: BuildSourcePack | None,
 ) -> list[Change]:
-    """Emit a finding for each ADR-033 D7 ``require_evidence`` layer that is absent.
+    """Emit findings for required evidence layers unavailable to compare.
 
     A required-but-missing layer fails the run (``EVIDENCE_REQUIRED_MISSING`` is an
-    API_BREAK kind) rather than letting a silently-degraded scan pass. Evaluated
-    against the *target* (new) side's pack, since that is what the verdict speaks
-    for. No-op when the policy declares no requirements.
+    API_BREAK kind) rather than letting a silently-degraded scan pass. Evidence
+    diffs are only meaningful when both baseline (old) and target (new) sides
+    supply the layer, so the requirement is enforced against comparable evidence
+    on both sides. No-op when the policy declares no requirements.
     """
     if policy_file is None or not policy_file.require_evidence:
         return []
@@ -106,16 +110,24 @@ def require_evidence_findings(
     for key, label, attr in _REQUIRE_EVIDENCE_LAYERS:
         if not policy_file.require_evidence.get(key):
             continue
-        present = new_pack is not None and getattr(new_pack, attr, None) is not None
-        if present:
+        old_present = old_pack is not None and getattr(old_pack, attr, None) is not None
+        new_present = new_pack is not None and getattr(new_pack, attr, None) is not None
+        if old_present and new_present:
             continue
+        missing_sides = []
+        if not old_present:
+            missing_sides.append("baseline")
+        if not new_present:
+            missing_sides.append("target")
+        missing = " and ".join(missing_sides)
         findings.append(
             Change(
                 kind=ChangeKind.EVIDENCE_REQUIRED_MISSING,
                 symbol=f"evidence:{key}",
                 description=(
-                    f"Policy requires {label} evidence, but it is absent from this "
-                    "compare. Supply the missing evidence pack (collect + "
+                    f"Policy requires comparable {label} evidence, but it is "
+                    f"absent from the {missing} side of this compare. "
+                    "Supply the missing evidence pack (collect + "
                     "dump --build-info/--sources) or relax evidence_policy."
                     "require_evidence in the policy file."
                 ),

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -1477,7 +1477,7 @@ def diff_embedded_build_source(
         # is missing, so the run must fail rather than pass on zero evidence. Emit
         # a coverage-only metrics dict so attach_evidence_metrics still counts the
         # evidence_required_missing finding (Codex review) instead of dropping it.
-        req = require_evidence_findings(policy_file, None)
+        req = require_evidence_findings(policy_file, None, None)
         metrics = evidence_coverage_metrics([]) if req else {}
         return req, [], metrics
 
@@ -1539,9 +1539,10 @@ def diff_embedded_build_source(
         apply_evidence_policy(_gr, "graph_risk", policy_file)
         changes.extend(_gr)
 
-    # ADR-033 D7 require_evidence: fail if a declared-mandatory layer is absent
-    # from the target. These are API_BREAK findings (not modulated by the knobs).
-    changes.extend(require_evidence_findings(policy_file, new_pack))
+    # ADR-033 D7 require_evidence: fail if a declared-mandatory layer is not
+    # comparable on both sides. These are API_BREAK findings (not modulated by
+    # the knobs).
+    changes.extend(require_evidence_findings(policy_file, old_pack, new_pack))
 
     # Coverage/capability reflect the *target* (new) side only: the L3/L4/L5
     # diffs run only when both sides supply a layer, so reporting the old pack's

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -164,7 +164,7 @@ evidence_policy:
   source_only_findings: warn          # ignore | warn | fail-api | fail-release
   build_context_drift: warn           # ignore | warn | fail-on-abi-relevant
   graph_risk_findings: warn           # ignore | warn | fail
-  require_evidence:                    # fail the run if a required layer is absent
+  require_evidence:                    # fail if a required layer is not comparable
     build_context: false
     source_abi: false
     graph_summary: false
@@ -177,9 +177,9 @@ evidence_policy:
   escalates only genuinely ABI-relevant drift (std/visibility/packing flags,
   export policy, toolchain) to `API_BREAK`; other drift stays a risk.
 - `graph_risk_findings` — L5 reachability/impact risks. `fail` → `API_BREAK`.
-- `require_evidence` — when a listed layer is `true` but absent from the
-  compare, an `evidence_required_missing` finding (`API_BREAK`) fails the run so
-  a silently-degraded scan can't pass (ADR-033 D7).
+- `require_evidence` — when a listed layer is `true` but absent from either the
+  baseline or target side of the compare, an `evidence_required_missing` finding
+  (`API_BREAK`) fails the run so a silently-degraded scan can't pass (ADR-033 D7).
 
 Each knob is **unset by default**: leaving it out keeps the finding's normal
 category, so existing runs are unchanged. Per ADR-028 D3 these knobs never turn

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -459,8 +459,8 @@ def test_require_evidence_fails_when_layer_absent(tmp_path):
     assert payload["evidence_metrics"]["findings.evidence_required_missing.count"] == 1
 
 
-def test_require_evidence_satisfied_when_layer_present(tmp_path):
-    """When the required layer is present (build pack supplied), no finding."""
+def test_require_evidence_fails_when_layer_only_on_target_side(tmp_path):
+    """A required evidence layer must be comparable on both sides."""
     runner = CliRunner()
     ev_new = tmp_path / "new.evidence"
     runner.invoke(main, ["collect", "--compile-db", str(_write_cdb(tmp_path, "c++20")),
@@ -471,6 +471,31 @@ def test_require_evidence_satisfied_when_layer_present(tmp_path):
     new_snap = _make_snap(tmp_path, "new.json", "2.0")
     result = runner.invoke(main, [
         "compare", str(old_snap), str(new_snap), "--new-build-info", str(ev_new),
+        "--policy-file", str(pol), "--format", "json",
+    ])
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    changes = [c for c in payload["changes"] if c["kind"] == "evidence_required_missing"]
+    assert len(changes) == 1
+    assert "baseline side" in changes[0]["description"]
+
+
+def test_require_evidence_satisfied_when_layer_comparable(tmp_path):
+    """When the required layer is present on both sides, no finding."""
+    runner = CliRunner()
+    ev_old = tmp_path / "old.evidence"
+    ev_new = tmp_path / "new.evidence"
+    runner.invoke(main, ["collect", "--compile-db", str(_write_cdb(tmp_path, "c++20")),
+                         "-o", str(ev_old)])
+    runner.invoke(main, ["collect", "--compile-db", str(_write_cdb(tmp_path, "c++20")),
+                         "-o", str(ev_new)])
+    pol = tmp_path / "policy.yaml"
+    pol.write_text("evidence_policy:\n  require_evidence:\n    build_context: true\n")
+    old_snap = _make_snap(tmp_path, "old.json", "1.0")
+    new_snap = _make_snap(tmp_path, "new.json", "2.0")
+    result = runner.invoke(main, [
+        "compare", str(old_snap), str(new_snap),
+        "--old-build-info", str(ev_old), "--new-build-info", str(ev_new),
         "--policy-file", str(pol), "--format", "json",
     ])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
### Motivation
- The `require_evidence` gate previously checked only the target/new pack for a required layer, allowing a target-only evidence pack to bypass comparisons that need baseline evidence and produce a false pass.  
- Evidence diffs (L3/L4/L5) run only when both old and new sides supply a layer, so the policy must require comparable evidence on both sides to be meaningful.

### Description
- Change `require_evidence_findings()` to accept `old_pack` and `new_pack` and treat a layer as satisfied only when it is present on both sides.  
- Emit an `EVIDENCE_REQUIRED_MISSING` finding that reports which side(s) are missing (`baseline` and/or `target`) when a required layer is not comparable.  
- Update `diff_embedded_build_source()` to pass both `old_pack` and `new_pack` into the require-evidence gate, including the no-packs path.  
- Update policy documentation to describe that `require_evidence` requires comparable baseline/target evidence, and add regression tests that cover the target-only bypass and the both-sides success case.

### Testing
- Ran the new and updated tests: `pytest -q tests/test_build_source_cli.py::test_require_evidence_fails_when_layer_absent tests/test_build_source_cli.py::test_require_evidence_fails_when_layer_only_on_target_side tests/test_build_source_cli.py::test_require_evidence_satisfied_when_layer_comparable` and they passed.  
- Ran the whole file: `pytest -q tests/test_build_source_cli.py` and observed all tests in that file passed.  
- Ran static checks: `ruff check abicheck/buildsource/evidence_policy.py abicheck/cli_buildsource.py tests/test_build_source_cli.py` and the linter passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c23e15c2c832b8c25695c8cd4ae0c)