### PR TITLE
Skip option operands during forced-language detection and restrict MSVC handling

### DIFF
--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -134,8 +134,13 @@ def effective_language(argv: list[str], source: str) -> str:
     (force C++) / ``/TC`` / ``/Tc<f>`` (force C) do the same. The last forcing
     token wins for a single-source TU. Falls back to :func:`detect_language` on
     the source path when nothing on the command line forces the language.
+
+    The scan is option-parser aware: operands consumed by another value-taking
+    flag (for example ``-MF -xc``) are skipped so filenames that begin with
+    language-option spellings cannot masquerade as real language overrides.
     """
     forced = ""
+    msvc = _is_msvc_command(argv)
     i = 0
     while i < len(argv):
         arg = argv[i]
@@ -144,12 +149,15 @@ def effective_language(argv: list[str], source: str) -> str:
             forced = "" if tok == "none" else _X_LANG_TO_NORMALIZED.get(tok, forced)
             i += 2
             continue
+        if arg in SOURCE_OPERAND_FLAGS:
+            i += 2  # skip the flag and the operand it consumes
+            continue
         if arg.startswith("-x") and len(arg) > 2:
             tok = arg[2:].lower()
             forced = "" if tok == "none" else _X_LANG_TO_NORMALIZED.get(tok, forced)
-        elif arg == "/TP" or arg[:3] == "/Tp":
+        elif msvc and (arg == "/TP" or arg[:3] == "/Tp"):
             forced = "CXX"
-        elif arg == "/TC" or arg[:3] == "/Tc":
+        elif msvc and (arg == "/TC" or arg[:3] == "/Tc"):
             forced = "C"
         i += 1
     return forced or detect_language(source)

--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -186,9 +186,9 @@ def source_from_argv(argv: list[str]) -> str:
     from the start is safe (and handles ``cd dir && cc …`` recipes).
 
     Source recognition is dialect-aware: an MSVC/clang-cl command (``/c`` present
-    or a ``cl``/``clang-cl`` driver) treats every ``/``-prefixed token as an
-    option — including combined value-taking forms like ``/FIsrc/config.hpp`` —
-    so only bare, ``C:\\``-rooted, or ``/Tp``/``/Tc``-named tokens are sources.
+    or a ``cl``/``clang-cl`` driver) treats known ``/``-prefixed compiler flags
+    as options — including combined value-taking forms like ``/FIsrc/config.hpp``
+    — while still allowing POSIX absolute paths such as ``/work/src/foo.cc``.
     A GNU command treats ``/abs/path.cc`` as a Unix absolute source path.
     """
     msvc = _is_msvc_command(argv)
@@ -216,6 +216,21 @@ def source_from_argv(argv: list[str]) -> str:
 #: Driver basenames that mark a command as MSVC-dialect (``/`` introduces an
 #: option, not a path). ``clang-cl`` mimics ``cl`` exactly.
 _MSVC_DRIVERS: frozenset[str] = frozenset({"cl", "cl.exe", "clang-cl", "clang-cl.exe"})
+
+_MSVC_COMBINED_OPTION_PREFIXES: tuple[str, ...] = (
+    "/d",
+    "/i",
+    "/fi",
+    "/fu",
+    "/fo",
+    "/fe",
+    "/fd",
+    "/fp",
+    "/yu",
+    "/yc",
+    "/std:",
+    "/external:",
+)
 
 
 def _is_msvc_command(argv: list[str]) -> bool:
@@ -253,17 +268,33 @@ def _is_msvc_command(argv: list[str]) -> bool:
 def _is_source_token(arg: str, msvc: bool) -> bool:
     """True if *arg* is a translation-unit source path, not a compiler option.
 
-    ``-``-prefixed tokens are always options. In an MSVC/clang-cl command every
-    ``/``-prefixed token is an option (``/c``, ``/FIsrc/config.hpp``,
-    ``/Fofoo.obj``) regardless of an embedded ``/``. In a GNU command a
-    ``/``-prefixed token with a source extension is a Unix absolute source path
-    (e.g. ``/work/src/foo.cc``) and is kept.
+    ``-``-prefixed tokens are always options. In an MSVC/clang-cl command known
+    ``/``-prefixed compiler flags (``/c``, ``/FIsrc/config.hpp``,
+    ``/Fofoo.obj``) are options, but POSIX-hosted clang-cl invocations may still
+    pass Unix absolute source paths (e.g. ``/work/src/foo.cc``), which are kept.
     """
     if not arg or arg.startswith("-"):
         return False
-    if arg.startswith("/") and msvc:
+    if arg.startswith("/") and msvc and _is_msvc_option_token(arg):
         return False  # MSVC/clang-cl option (handled before us for /Tp,/Tc)
     return bool(detect_language(arg))
+
+
+def _is_msvc_option_token(arg: str) -> bool:
+    lower = arg.lower()
+    if lower in {"/c", "/tp", "/tc", "/nologo", "/showincludes", "/wx", "/gr", "/gs"}:
+        return True
+    if any(lower.startswith(prefix) for prefix in _MSVC_COMBINED_OPTION_PREFIXES):
+        return True
+    if lower.startswith("/w"):
+        suffix = lower[2:]
+        return suffix.isdigit() or suffix in {"all", "x"} or (
+            len(suffix) > 1 and suffix[0] in {"d", "e", "o"} and suffix[1:].isdigit()
+        )
+    if lower.startswith("/o"):
+        suffix = lower[2:]
+        return bool(suffix) and all(ch in "012bdfgitxys-" for ch in suffix)
+    return False
 
 
 def compile_unit_id(source: str, argv: list[str], output: str = "") -> str:

--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -233,6 +233,9 @@ def _is_msvc_command(argv: list[str]) -> bool:
         arg = argv[i]
         if arg in ("&&", ";"):
             break
+        if arg in SOURCE_OPERAND_FLAGS:
+            i += 2
+            continue
         if arg == "--driver-mode" and i + 1 < len(argv):
             if argv[i + 1].lower() == "cl":
                 return True

--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -223,16 +223,27 @@ def _is_msvc_command(argv: list[str]) -> bool:
 
     Detected either by the ``/c`` compile marker (GNU uses ``-c``) or by a
     ``cl``/``clang-cl`` driver basename anywhere in the leading tokens (the
-    driver may be a full path, e.g. ``C:\\VS\\bin\\cl.exe``).
+    driver may be a full path, e.g. ``C:\\VS\\bin\\cl.exe``), or by clang's
+    explicit ``--driver-mode=cl`` spelling.
     """
     if "/c" in argv:
         return True
-    for arg in argv:
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
         if arg in ("&&", ";"):
             break
+        if arg == "--driver-mode" and i + 1 < len(argv):
+            if argv[i + 1].lower() == "cl":
+                return True
+            i += 2
+            continue
+        if arg.lower() == "--driver-mode=cl":
+            return True
         base = arg.replace("\\", "/").rsplit("/", 1)[-1].lower()
         if base in _MSVC_DRIVERS:
             return True
+        i += 1
     return False
 
 

--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -218,8 +218,6 @@ def source_from_argv(argv: list[str]) -> str:
 _MSVC_DRIVERS: frozenset[str] = frozenset({"cl", "cl.exe", "clang-cl", "clang-cl.exe"})
 
 _MSVC_COMBINED_OPTION_PREFIXES: tuple[str, ...] = (
-    "/d",
-    "/i",
     "/fi",
     "/fu",
     "/fo",
@@ -283,6 +281,8 @@ def _is_source_token(arg: str, msvc: bool) -> bool:
 def _is_msvc_option_token(arg: str) -> bool:
     lower = arg.lower()
     if lower in {"/c", "/tp", "/tc", "/nologo", "/showincludes", "/wx", "/gr", "/gs"}:
+        return True
+    if arg.startswith(("/D", "/I")):
         return True
     if any(lower.startswith(prefix) for prefix in _MSVC_COMBINED_OPTION_PREFIXES):
         return True

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -553,6 +553,14 @@ def test_effective_language_ignores_option_operands(argv, source, expected):
     assert effective_language(argv, source) == expected
 
 
+def test_driver_mode_operand_does_not_make_unix_paths_msvc() -> None:
+    from abicheck.buildsource.adapters.base import source_from_argv
+
+    assert source_from_argv([
+        "gcc", "-MMD", "-MF", "--driver-mode=cl", "-c", "/tmp/foo.c",
+    ]) == "/tmp/foo.c"
+
+
 def test_redundant_objcxx_forced_language_is_no_op_drift(tmp_path):
     # Codex P2: clang++ -x objective-c++ on a .mm TU must stay OBJCXX, not collapse
     # to CXX — otherwise std:OBJCXX->std:CXX reads as false build-flag drift.

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -561,6 +561,22 @@ def test_driver_mode_operand_does_not_make_unix_paths_msvc() -> None:
     ]) == "/tmp/foo.c"
 
 
+def test_clang_driver_mode_keeps_absolute_posix_source() -> None:
+    from abicheck.buildsource.adapters.base import source_from_argv
+
+    assert source_from_argv([
+        "clang", "--driver-mode=cl", "-c", "/work/src/foo.cc", "/Fofoo.obj",
+    ]) == "/work/src/foo.cc"
+
+
+def test_clang_driver_mode_skips_combined_msvc_source_like_options() -> None:
+    from abicheck.buildsource.adapters.base import source_from_argv
+
+    assert source_from_argv([
+        "clang", "--driver-mode=cl", "-c", "/FI/work/src/config.hpp", "foo.cc",
+    ]) == "foo.cc"
+
+
 def test_redundant_objcxx_forced_language_is_no_op_drift(tmp_path):
     # Codex P2: clang++ -x objective-c++ on a .mm TU must stay OBJCXX, not collapse
     # to CXX — otherwise std:OBJCXX->std:CXX reads as false build-flag drift.

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -534,6 +534,22 @@ def test_effective_language_honors_forced_language(argv, source, expected):
     assert effective_language(argv, source) == expected
 
 
+@pytest.mark.parametrize("argv, source, expected", [
+    # The token after a value-taking option is data, even when it looks like a
+    # combined GNU -x language option.
+    (["g++", "-c", "foo.cpp", "-MF", "-xc", "-fno-exceptions"], "foo.cpp", "CXX"),
+    (["g++", "-o", "-xc", "-xc++", "-c", "foo.c"], "foo.c", "CXX"),
+    (["g++", "-D", "-xc", "-c", "foo.cpp"], "foo.cpp", "CXX"),
+    # Slash /Tp and /Tc only force language for MSVC/clang-cl commands, not GNU
+    # commands or operands consumed by another MSVC option.
+    (["gcc", "-c", "foo.cpp", "/Tcnot_source.c"], "foo.cpp", "CXX"),
+    (["cl", "/c", "/FI", "/Tcconfig.hpp", "foo.cpp"], "foo.cpp", "CXX"),
+])
+def test_effective_language_ignores_option_operands(argv, source, expected):
+    from abicheck.buildsource.adapters.base import effective_language
+    assert effective_language(argv, source) == expected
+
+
 def test_redundant_objcxx_forced_language_is_no_op_drift(tmp_path):
     # Codex P2: clang++ -x objective-c++ on a .mm TU must stay OBJCXX, not collapse
     # to CXX — otherwise std:OBJCXX->std:CXX reads as false build-flag drift.
@@ -575,6 +591,28 @@ def test_compile_db_forced_language_drives_runtime_mode_key(tmp_path):
     new = _db(["-fno-exceptions"])  # explicit off
     # The forced language must record exceptions:CXX (not exceptions:C).
     assert old.compile_units[0].language == "CXX"
+    changes = diff_build_evidence(old, new)
+    assert any(c.kind is ChangeKind.EXCEPTIONS_MODE_CHANGED for c in changes)
+
+
+def test_compile_db_depfile_operand_cannot_hide_cxx_exceptions_flip(tmp_path):
+    # `-MF -xc` writes a depfile literally named `-xc`; it must not be treated
+    # as `-x c` and downgrade a C++ TU to C.
+    def _db(extra_flags):
+        p = tmp_path / f"cc_{abs(hash(tuple(extra_flags)))}.json"
+        entries = [{
+            "directory": str(tmp_path),
+            "file": "foo.cpp",
+            "arguments": ["g++", "-MMD", "-MF", "-xc", *extra_flags, "-c", "foo.cpp"],
+        }]
+        p.write_text(json.dumps(entries))
+        return CompileDbAdapter(p).collect()
+
+    old = _db([])
+    new = _db(["-fno-exceptions"])
+
+    assert new.compile_units[0].language == "CXX"
+    assert ("exceptions:CXX", "off") in {(o.key, o.value) for o in new.build_options}
     changes = diff_build_evidence(old, new)
     assert any(c.kind is ChangeKind.EXCEPTIONS_MODE_CHANGED for c in changes)
 

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -522,6 +522,9 @@ def test_runtime_mode_flags_normalize_to_canonical_keys():
     (["cl", "/c", "/Tpfoo.c"], "foo.c", "CXX"),
     (["cl", "/c", "/TC", "foo.cpp"], "foo.cpp", "C"),
     (["cl", "/c", "/Tcfoo.cpp"], "foo.cpp", "C"),
+    # clang in CL-driver mode honors the same /TP and /TC language forcing.
+    (["clang", "--driver-mode=cl", "-c", "/TP", "foo.c"], "foo.c", "CXX"),
+    (["clang", "--driver-mode", "cl", "-c", "/TC", "foo.cpp"], "foo.cpp", "C"),
     # Unknown -x language leaves the extension-derived language intact.
     (["clang", "-x", "assembler", "-c", "foo.cpp"], "foo.cpp", "CXX"),
     # Forced Objective-C/Objective-C++ keep their own tokens (match .m/.mm

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -564,9 +564,10 @@ def test_driver_mode_operand_does_not_make_unix_paths_msvc() -> None:
 def test_clang_driver_mode_keeps_absolute_posix_source() -> None:
     from abicheck.buildsource.adapters.base import source_from_argv
 
-    assert source_from_argv([
-        "clang", "--driver-mode=cl", "-c", "/work/src/foo.cc", "/Fofoo.obj",
-    ]) == "/work/src/foo.cc"
+    for source in ("/work/src/foo.cc", "/data/foo.cc", "/include/foo.cc"):
+        assert source_from_argv([
+            "clang", "--driver-mode=cl", "-c", source, "/Fofoo.obj",
+        ]) == source
 
 
 def test_clang_driver_mode_skips_combined_msvc_source_like_options() -> None:
@@ -574,6 +575,9 @@ def test_clang_driver_mode_skips_combined_msvc_source_like_options() -> None:
 
     assert source_from_argv([
         "clang", "--driver-mode=cl", "-c", "/FI/work/src/config.hpp", "foo.cc",
+    ]) == "foo.cc"
+    assert source_from_argv([
+        "clang", "--driver-mode=cl", "-c", "/Iinclude", "/DNAME=foo.cc", "foo.cc",
     ]) == "foo.cc"
 
 


### PR DESCRIPTION
### Motivation
- A language-forcing parser treated any token starting with `-x` or MSVC `/Tp`/`/Tc` as directive tokens even when those tokens were operands of prior value-taking flags, allowing inputs like `-MF -xc` to misclassify a TU as C and hide ABI-relevant runtime-mode changes. 
- The codebase already lists value-taking flags in `SOURCE_OPERAND_FLAGS` but `effective_language()` did not consult it, creating an integrity bypass for build metadata-derived decisions.

### Description
- Update `effective_language(argv, source)` to be option-parser aware by skipping operands of flags in `SOURCE_OPERAND_FLAGS` so tokens like `-xc` consumed by `-MF` are not interpreted as `-x c` language overrides. 
- Limit MSVC-style `/TP`/`/Tp`/`/TC`/`/Tc` handling to commands detected as MSVC/`clang-cl` dialect via `_is_msvc_command(argv)` to avoid false positives on GNU commands or operands. 
- Add explanatory docstring note about option-aware scanning and mark the `msvc` check in `effective_language`. 
- Add regression tests in `tests/test_build_source_pack.py` that cover value-taking operands (`-MF -xc`, `-D -xc`, `-o -xc`), MSVC operand cases, and a compile-database depfile PoC ensuring `-MF -xc` cannot hide a C++ `-fno-exceptions` flip.

### Testing
- Ran targeted tests with `pytest tests/test_build_source_pack.py -q` and the updated pack tests passed. 
- Ran the full test suite with `pytest -q`, and the suite completed successfully: `10162 passed, 357 skipped, 4 xfailed` (with warnings). 
- No test regressions were observed and the new tests exercise the previously vulnerable scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c2af53708832bbdd95a6cd891f247)