### PR TITLE
eval follow-up plan + track real-world-corpus (G17) & Bazel-evidence (G18) use cases

### DIFF
--- a/docs/development/plans/g17-real-world-corpus.md
+++ b/docs/development/plans/g17-real-world-corpus.md
@@ -1,0 +1,58 @@
+# G17 — Real-world upstream-library validation corpus
+
+**Registry:** `UC-WORKFLOW-real-world-corpus` (`partial`)
+**Effort:** M · **Risk:** medium (network to a package index; toolchain for the source tier)
+
+## Problem
+
+abicheck's correctness is exercised almost entirely by the **synthetic**
+`examples/case*` fixtures (141 minimal C/C++ cases) and unit tests. Those are
+precise but small and author-controlled. The 2026-06 field evaluation showed that
+**real upstream libraries** exercise shapes the fixtures don't: split packaging,
+multi-`.so` bundles, versioned-symbol schemes (ICU/OpenSSL/LLVM), DWARF-bearing
+release builds, and scale (LLVM ~150 MB / ~31k exported funcs). Nothing in-repo
+continuously validates abicheck against that real surface, so a regression in a
+real-world verdict would not be caught.
+
+The evaluation produced a **reproducible corpus** under `eval/`: a curated
+`manifest.yaml` (library, version pair, **expected verdict**, `.so` stem, optional
+source repo/tags), a `runner.py` that fetches from conda-forge and runs
+`abicheck dump`/`compare`, and a generated `REPORT.md` + schema'd
+`results/latest.json`. The **binary (L0/L1) tier** is validated today — 22/22
+verdicts match the manifest's `expect`. Two pieces remain.
+
+## Pointers
+
+- `eval/manifest.yaml` — curated corpus (source of truth; `source:` repo/tags
+  already present for zlib/zstd/snappy).
+- `eval/runner.py` — `run()`/`scan_one()` (binary tier); `--report-only`.
+- `eval/condafetch.py` — conda-forge fetch/extract (handles split packages, `.conda`).
+- `eval/results/latest.json` — schema'd results (`result_schema` 1).
+- Retired source-tier prototype lives in git history at
+  `eval/field-eval/scripts/bsdrive.py` (clone → configure → `dump --sources`).
+- CI lane pattern to mirror: `.github/workflows/mutation.yml` /
+  `performance.yml` (scheduled / label-triggered).
+
+## Approach
+
+1. **Source tier (D1).** Add `runner.py --tier source`: for manifest entries with
+   a `source:` block, clone at the tag, generate a compile DB (cmake configure or
+   `--build-query`), run `dump --sources --collect-mode source-target`, and record
+   L3/L4/L5 coverage + timings into `results/`. Gate on `clang`/`cmake`; skip
+   gracefully when absent.
+2. **CI lane (D2).** A scheduled / `eval`-label workflow runs the binary tier,
+   fails on any `verdict_matches_expected` drift, and uploads `results/`. Network
+   to the package index is the only external dependency.
+3. **Corpus growth.** Extend the manifest to new ecosystems (Rust `cdylib`, Go
+   `cgo`, Qt, Boost) and platforms (win-64 / osx-64 — `condafetch.py` already
+   parameterizes `subdir`).
+
+## Acceptance
+
+- `runner.py --tier source` emits an L3/L4/L5 table in `REPORT.md` for ≥3 libs.
+- A scheduled CI lane is green and turns red on an injected verdict drift.
+- Manifest carries ≥1 non-conda-C ecosystem and ≥1 non-Linux platform.
+
+## Status
+
+`partial` — binary tier validated (22/22); source tier + CI lane planned (this gap).

--- a/docs/development/plans/g18-bazel-build-evidence.md
+++ b/docs/development/plans/g18-bazel-build-evidence.md
@@ -1,0 +1,47 @@
+# G18 — Bazel build-evidence, validated end-to-end
+
+**Registry:** `UC-TC-bazel-build-evidence` (`modeled`)
+**Effort:** M · **Risk:** medium (Bazel toolchain is heavy; jsonproto schema drift)
+
+## Problem
+
+abicheck ships a Bazel L3 adapter (`adapters/bazel.py`) that turns
+`bazel cquery`/`aquery` jsonproto into `BuildEvidence` targets / compile+link
+units — but it has **never been validated end-to-end on a real Bazel C++
+project**. The 2026-06 field evaluation hit this directly (P21): oneDAL
+(`uxlfoundation/oneDAL`) builds with **Bazel + a legacy makefile, no CMake**, so
+the L3/L4/L5 source path was unreachable without the project's full Intel
+toolchain (DPC++/oneMKL/TBB). The artifact (L0/L1) scan worked fine; the
+build/source tier could not be exercised. Status is therefore **modeled**: the
+parser exists, the coverage claim is not backed by a real run.
+
+## Pointers
+
+- `abicheck/buildsource/adapters/bazel.py` — the adapter (`cquery`/`aquery`
+  jsonproto → compile/link units; live or pre-captured).
+- `abicheck/buildsource/extractor.py` — the action model; `query_build_system`
+  is the opt-in tier a live `aquery` would fall under (ADR-032 D5).
+- `abicheck/buildsource/inline.py` `_run_build_query` — the `--allow-build-query`
+  subprocess path (could drive `bazel aquery`).
+- Field-eval evidence: `eval/FINDINGS.md` P21; `eval/FOLLOWUPS.md` §E2.
+
+## Approach
+
+1. Capture a real `bazel aquery --output=jsonproto 'mnemonic("CppCompile", //...)'`
+   (+ `cquery`) from a small, self-contained Bazel C++ project — **pre-captured**,
+   so the test is non-executing and Bazel-free in CI (ADR-028 D6).
+2. Add a fixture + unit/integration test feeding that export through
+   `adapters/bazel.py` and asserting non-empty compile/link units + a usable L3.
+3. Optionally wire a live `--build-query 'bazel aquery …'` recipe behind
+   `--allow-build-query` for users who have Bazel.
+
+## Acceptance
+
+- A committed jsonproto fixture round-trips through the adapter to non-empty
+  `BuildEvidence` (targets + compile units), asserted by a test.
+- `dump --build-info <captured-pack>` embeds the Bazel-derived L3.
+- Registry entry flips `modeled` → `partial`/`complete` with the test as evidence.
+
+## Status
+
+`modeled` — adapter code exists; no real-project validation yet (this gap).

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -20,6 +20,8 @@ scope**.
 | **G14** | [CPython Limited-API / `abi3` import-contract](g14-stable-abi-subset.md) | `UC-WF-stable-abi-subset` | M |
 | **G15** | [Inline-namespace version-stamp normalization](g15-inline-namespace-version.md) | `UC-CHANGE-inline-ns-version` | M |
 | **G16** | [Header-scope toolchain robustness](g16-header-scope-toolchain-robustness.md) | `UC-TC-header-scope-robustness` | M |
+| **G17** | [Real-world validation corpus](g17-real-world-corpus.md) | `UC-WORKFLOW-real-world-corpus` | M |
+| **G18** | [Bazel build-evidence](g18-bazel-build-evidence.md) | `UC-TC-bazel-build-evidence` | M |
 
 Completed or decided plans are retained for implementation history:
 

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -127,3 +127,5 @@ planned row from drifting away from its plan.
 | Small | G10 — glibc-floor check | [g10](plans/g10-glibc-floor-check.md) |
 | Small | G13 — cross-architecture guardrail | [g13](plans/g13-arch-mismatch-guard.md) |
 | Medium | G16 — header-scope toolchain robustness | [g16](plans/g16-header-scope-toolchain-robustness.md) |
+| Medium | G17 — real-world validation corpus | [g17](plans/g17-real-world-corpus.md) |
+| Medium | G18 — Bazel build-evidence | [g18](plans/g18-bazel-build-evidence.md) |

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -519,3 +519,39 @@ use_cases:
     evidence:
       examples: [examples/case98_cxx_standard_floor_raised, examples/probes/cxx_standard.yaml]
       tests: [tests/test_probe_examples.py, tests/test_diff_build_config.py]
+
+  # ── workflow: real-world validation corpus (field-eval G17) ────────────────
+  - id: UC-WORKFLOW-real-world-corpus
+    axis: workflow
+    name: Real-world upstream-library validation corpus (conda-forge)
+    status: partial
+    gap: G17
+    plan: docs/development/plans/g17-real-world-corpus.md
+    evidence:
+      modules: [eval/runner.py, eval/condafetch.py]
+      tests: [eval/manifest.yaml, eval/results/latest.json]
+    next_steps: >
+      Reproducible benchmark (eval/) of abicheck against real conda-forge
+      libraries: a curated manifest with expected verdicts, a runner that fetches
+      + scans, and a generated report. DONE: binary (L0/L1) tier — verdicts match
+      the manifest 'expect'. PLANNED: (1) a source (L3/L4/L5) tier in the runner
+      that clones at the tag and runs `dump --sources`; (2) a scheduled CI lane
+      that fails on verdict drift; (3) corpus growth to Rust/Go/Qt/Boost and
+      win-64/osx-64 subdirs.
+
+  # ── toolchain: Bazel build-evidence (field-eval P21 / G18) ─────────────────
+  - id: UC-TC-bazel-build-evidence
+    axis: toolchain
+    name: Bazel-built C++ project build evidence (L3)
+    status: modeled
+    gap: G18
+    plan: docs/development/plans/g18-bazel-build-evidence.md
+    evidence:
+      modules: [abicheck/buildsource/adapters/bazel.py]
+    next_steps: >
+      The cquery/aquery jsonproto adapter exists but is unvalidated end-to-end on
+      a real Bazel C++ project (field-eval P21: oneDAL is Bazel + makefile, no
+      CMake, so its L3/L4/L5 path was unreachable without the full Intel
+      toolchain). Capture a pre-recorded `bazel aquery --output=jsonproto` from a
+      small Bazel C++ project, add it as a non-executing fixture + test asserting
+      non-empty BuildEvidence, then flip to partial/complete.

--- a/eval/FINDINGS.md
+++ b/eval/FINDINGS.md
@@ -3,7 +3,7 @@
 > **This file is the qualitative problem log + analysis (the narrative).**
 > For **live, authoritative numbers** (verdicts, timings, surface sizes) see the
 > generated [`REPORT.md`](REPORT.md), reproduced from [`manifest.yaml`](manifest.yaml)
-> via `python eval/runner.py`. The per-iteration tables below are *illustrative
+> via `python eval/runner.py`. **Follow-up plan** (open items + pointers): [FOLLOWUPS.md](FOLLOWUPS.md). The per-iteration tables below are *illustrative
 > historical snapshots* from the exploration and are not kept in sync — trust
 > `REPORT.md` / `results/latest.json` for current figures.
 

--- a/eval/FOLLOWUPS.md
+++ b/eval/FOLLOWUPS.md
@@ -1,0 +1,263 @@
+# abicheck field-evaluation — follow-up plan
+
+Derived from the field evaluation ([FINDINGS.md](FINDINGS.md), problems P01–P21)
+and the work already shipped on this branch. Each item carries **context**,
+**pointers** (file / function), an **approach**, **acceptance**, and a
+**cross-reference** to an existing usecase gap/plan where one already covers it.
+
+> Most C++ source-ABI findings map onto **existing** planned gaps — the eval
+> corroborates them with concrete real-world evidence rather than inventing new
+> work. Net-new items are flagged **NEW**.
+
+## Status map (P01–P21 + extras)
+
+| ID | Area | Status | Follow-up owner |
+|----|------|--------|-----------------|
+| P01 split conda pkgs | discovery | documented (field guide) | — (conda reality) |
+| P02 variant select | discovery | documented | — |
+| P03 `--show-data-sources` preview-only | UX | **OPEN** | §B1 NEW |
+| P04 `-H` hard-errors w/o castxml | env | resolved (tool present) | — |
+| P05 clang L4 empty decl tables | C++ L4 | **OPEN** | §A1 (gap **G4**) |
+| P06 serial L4 | perf | **shipped** (parallel) | §C1 (scaling validation) |
+| P07 plain DB no toolchain | discovery | documented | §E3 NEW (validate) |
+| P08 versioned-symbol noise | correctness | **shipped** (detector+collapse) | §G (gap **G15**) |
+| P09 silent autotools | discovery | **shipped** (diagnostic) | — |
+| P10 autotools bootstrap | discovery | documented | — (upstream) |
+| P11 compare rename cost | perf | **shipped** (batch-demangle) | — |
+| P12 meson `builddir` | discovery | **shipped** | — |
+| P13 L4 infeasible on monorepo | perf/scope | documented + mitigations | §E4 (retry live) |
+| P14 castxml no compile-DB `-I` | C++ L2 | **OPEN** | §A2 (gap **G16**/G4) |
+| P15 castxml ✗ libstdc++ 13 | C++ L2/L4 | **OPEN** | §A1 (gap **G4**) |
+| P16 `--lang c` aborts on extern "C" | UX | **OPEN** | §A3 (gap **G16**) |
+| P17 thin build-option normalization | discovery | **OPEN** | §B2 NEW |
+| P18 L5 coupled to L4 | UX | **shipped** (`graph-build`) | — |
+| P19 L4 needs generated headers | discovery | **shipped** (hint) | — |
+| P20 multi-`.so` pairing | discovery | documented + eval guard | §F2 NEW (FP corpus) |
+| P21 oneDAL Bazel toolchain | discovery | documented | §E2 (validate Bazel live) |
+
+---
+
+## A. C++ source-ABI unblock (the highest-leverage cluster)
+
+The single biggest gap the eval surfaced: **no real C++ source-ABI surface is
+obtainable today** on a stock toolchain. castxml ≤0.6.3 cannot parse libstdc++ 13
+(P15); the clang L4 extractor sidesteps that but emits only body fingerprints,
+**zero declarations/types** (P05). Result: L4 is empty for the C++ libraries that
+need it most. These map to existing gaps **G4** and **G16**.
+
+### A1. libclang declaration/type extractor (P15, P05) — gap **G4**
+- **Context.** `g4-header-ast-extractor.md` already plans "a libclang-based
+  header-AST extractor alongside castxml". The eval is the concrete motivation:
+  ICU/snappy yield `reachable_declarations: 0` today; castxml dies in
+  `/usr/include/c++/13/bits/basic_string.h`.
+- **Pointers.**
+  - `abicheck/buildsource/source_extractors/clang.py` — current clang extractor
+    (`extract` ~L1164); emits `SourceEntity` *body fingerprints*, not decl tables.
+  - `abicheck/buildsource/source_extractors/castxml.py` — the declaration backend
+    that breaks on modern libstdc++.
+  - `abicheck/buildsource/source_extractors/base.py` — `SourceAbiExtractor` iface.
+  - `abicheck/buildsource/source_abi.py` — `SourceAbiTu.reachable_declarations`
+    (the field that comes back empty).
+  - Registry: `UC-ARCH-header-only` / `UC-ARCH-c-library` evidence
+    `abicheck/dumper_castxml.py`.
+- **Approach.** Add a `libclang` (cindex) extractor producing real
+  `SourceEntity` decls/types/typedefs/enums from the AST (not text fingerprints);
+  prefer it over castxml when `python-clang`/`libclang` is present; fall back to
+  castxml, then to the body-fingerprint clang path. Reuse the compile-DB flags
+  per TU.
+- **Acceptance.** snappy/ICU `--sources` runs return non-zero
+  `reachable_declarations` / `reachable_types`; the 9 source-replay findings fire
+  on a real C++ lib; new integration test on a compiled C++ fixture.
+- **Effort·Risk.** L · medium (libclang version skew). **Do first — unblocks A2/A3, B, and all C++ validation.**
+
+### A2. castxml/clang inherits compile-DB include paths (P14) — gap **G16**/G4
+- **Context.** Public headers routinely `#include` *generated* headers
+  (`snappy-stubs-public.h`); the `-H` path doesn't pass the build's `-I`, so L2
+  fails `file not found` until the user adds `-I <builddir>` by hand.
+- **Pointers.**
+  - `abicheck/dumper_castxml.py` `_build_castxml_command` (~L302),
+    `extra_includes` handling (~L131/L149).
+  - `abicheck/build_context.py` — per-TU include flags already parsed
+    (`_try_consume_include` ~L250, `_try_consume_isystem` ~L262).
+  - Bridge point: the `-p`/`--compile-db` path in `abicheck/cli.py` `dump`.
+- **Approach.** When a compile DB is supplied/auto-discovered, derive `-I`/
+  `-isystem`/`-D`/`--target`/`--sysroot` from the matched compile unit and pass
+  them into the header-AST invocation automatically.
+- **Acceptance.** `dump <so> -H include/ -p build/` parses a public header that
+  includes a generated header **without** a manual `-I`.
+- **Effort·Risk.** S–M · low.
+
+### A3. `--lang c` heuristic should warn, not abort (P16) — gap **G16**
+- **Context.** `G16` already lists this (`--lang c` + `extern "C"` fails because
+  castxml drives clang C++-ish). The eval reproduced it on `zlib.h`: the "header
+  appears to contain C++ syntax" hint **aborts** instead of degrading.
+- **Pointers.** `abicheck/cli.py:644` / `:1506` (`--lang` option); the hint emit
+  in the castxml driver (`abicheck/dumper_castxml.py`); plan
+  `docs/development/plans/g16-header-scope-toolchain-robustness.md`.
+- **Approach.** Demote the heuristic to a warning + auto-retry under the other
+  language mode; never hard-fail a correct `extern "C"` header.
+- **Acceptance.** `dump zlib.h --lang c` succeeds (or warns + falls back), no abort.
+- **Effort·Risk.** S · low. Fold into the G16 work.
+
+---
+
+## B. Net-new code fixes (NEW)
+
+### B1. `--show-data-sources` is preview-only (P03) — NEW
+- **Context.** Running `dump --show-data-sources` prints the L0–L5 table but
+  **collects nothing** and embeds nothing — surprising; a user expects it to also
+  produce the snapshot.
+- **Pointers.** `abicheck/cli.py:749`/`:776` (`show_data_sources` branch),
+  `abicheck/cli_datasources.py` `print_data_sources`.
+- **Approach.** Make it additive (collect **and** print), or rename to
+  `--explain-data-sources` and emit a loud "preview only — no data embedded" line.
+- **Acceptance.** Either the snapshot is written with embedded facts, or the
+  preview-only nature is unmissable in output + `--help`.
+- **Effort·Risk.** S · low.
+
+### B2. Build-option normalization vocabulary is thin (P17) — NEW
+- **Context.** LLVM produced **6 build_options from 2,719 TUs**; zstd 0. The
+  `command`-string DB *is* shlex-parsed (`build_context.py:91`), so this is **not**
+  a parsing gap — `derive_build_options` only normalizes a small flag set
+  (std/exceptions/rtti/visibility), missing most ABI-relevant flags.
+- **Pointers.** `abicheck/build_context.py` `derive_build_options`;
+  `abicheck/buildsource/adapters/compile_db.py` (`collect` ~L53, imports
+  `derive_build_options`); `abicheck/buildsource/build_evidence.py` `BuildOption`.
+- **Approach.** Broaden the normalized vocabulary: `-fno-omit-frame-pointer`,
+  `-stdlib=`, `-D_GLIBCXX_USE_CXX11_ABI`, `-m32/-m64`, `-march`/`-mtune`,
+  sanitizers, LTO, `-fPIC`/`-fPIE`, `-fvisibility-inlines-hidden`. De-dup
+  library-wide but keep per-target divergence as drift signal.
+- **Acceptance.** LLVM/zstd L3 surfaces the real ABI-affecting flag set; a flag
+  flip between releases shows as `build_flag_changed` drift.
+- **Effort·Risk.** M · low.
+
+---
+
+## C. Performance validation
+
+### C1. P06 parallel-L4 scaling (validate) — follow-up to shipped work
+- **Context.** Parallel L4 shipped (deterministic). Measured freetype 42-TU only:
+  25.8s → 19.1s (1.35×) — modest because L3/L5/serialization are serial and the
+  TU count is small.
+- **Pointers.** `abicheck/buildsource/source_replay.py` `run_source_replay`
+  (phased parallel loop), `_l4_jobs`; `ABICHECK_L4_JOBS` env.
+- **Approach.** Benchmark on larger TU counts (zstd 92; LLVM scoped to N changed
+  TUs) to confirm the L4 fraction approaches N×; record in `eval/REPORT.md` source tier.
+- **Acceptance.** A scaling curve (jobs=1/2/4/8) on ≥2 trees in the eval report.
+- **Effort·Risk.** S · low (measurement only).
+
+---
+
+## D. eval-suite infrastructure (NEW)
+
+### D1. Add the build/source (L3/L4/L5) tier to the runner
+- **Context.** The new benchmark suite (`eval/runner.py`) runs only the binary
+  (L0/L1) tier (22/22 verdicts match). The source tier (old `bsdrive.py`
+  prototype) was not folded in.
+- **Pointers.** `eval/runner.py` (`run`, `scan_one`), `eval/manifest.yaml`
+  (`source:` repo/tags already present for zlib/zstd/snappy); the retired prototype
+  logic is in git history (`eval/field-eval/scripts/bsdrive.py`).
+- **Approach.** Add `runner.py --tier source`: for manifest entries with a
+  `source:` block, clone at the tag, configure (or `--build-query`), run
+  `dump --sources --collect-mode source-target`, record L3/L4/L5 coverage +
+  timings into `results/`. Gate on `clang`/`cmake` presence; skip gracefully.
+- **Acceptance.** `eval/REPORT.md` gains a source-tier table; reproducible.
+- **Effort·Risk.** M · medium (needs toolchain; gate on availability).
+
+### D2. Wire the suite into CI as a scheduled lane
+- **Context.** The suite is a real-world verdict **regression guard** (`expect`
+  in `manifest.yaml`); today it's manual.
+- **Pointers.** `.github/workflows/` (mirror the `mutation.yml`/`performance.yml`
+  scheduled-lane pattern); `eval/runner.py` exit on `verdict_matches_expected`
+  drift.
+- **Approach.** Weekly / label-triggered job: `pip install pyyaml`, run the binary
+  tier, fail on any `expect` drift, upload `results/`. Network-gated (anaconda.org).
+- **Acceptance.** Green scheduled lane; red on an injected verdict drift.
+- **Effort·Risk.** S–M · low.
+
+---
+
+## E. Coverage / platform validation (NEW)
+
+The entire eval was **Linux/ELF**. These are untested paths, not known bugs.
+
+### E1. PE/PDB (Windows) + Mach-O (macOS) source/build paths
+- **Pointers.** `abicheck/pe_metadata.py`, `abicheck/pdb_*.py`,
+  `abicheck/macho_metadata.py`; conda-forge ships `win-64`/`osx-64` subdirs
+  (`condafetch.py` already parameterizes `subdir`).
+- **Approach.** Extend the manifest with win-64/osx-64 entries; scan a handful of
+  the same libraries' Windows/macOS builds.
+- **Acceptance.** ≥5 PE and ≥5 Mach-O pairs scanned with sane verdicts.
+- **Effort·Risk.** M · medium (PDB/dSYM availability).
+
+### E2. Bazel adapter, live (P21)
+- **Pointers.** `abicheck/buildsource/adapters/bazel.py` (cquery/aquery jsonproto);
+  oneDAL (`uxlfoundation/oneDAL`) or protobuf (Bazel builds).
+- **Approach.** Capture a real `bazel aquery --output=jsonproto` from a small
+  Bazel C++ project, feed via `--build-info`; verify L3 compile/link units.
+- **Acceptance.** Non-empty L3 from a real aquery export.
+- **Effort·Risk.** M · medium (Bazel toolchain heavy).
+
+### E3. Cross-compiler toolchain capture (P07)
+- **Pointers.** `abicheck/buildsource/compiler_record.py`
+  (`.GCC.command.line` / `DW_AT_producer`); `adapters/cmake_file_api.py` (targets/
+  toolchains). The DWARF-bearing conda libs from the eval (libuv, openblas, bzip2)
+  are ready inputs.
+- **Approach.** Compare a gcc-built vs clang-built same library; confirm toolchain
+  identity is captured and drift surfaces.
+- **Acceptance.** Toolchain/producer recorded; gcc↔clang drift visible.
+- **Effort·Risk.** S–M · low.
+
+### E4. L4 on a monorepo, live (P13, now feasible)
+- **Context.** Bounded out earlier (hours). Now feasible with `source-changed`
+  scope + P06 parallel + the per-TU cache.
+- **Pointers.** `--collect-mode source-changed`, `run_source_replay(changed_paths=…)`,
+  `SourceAbiCache` (`--build-cache-dir`). LLVM checkout flow in git history
+  (`eval/field-eval/scripts` clone+configure).
+- **Approach.** Configure LLVM, replay only a small changed-TU set, measure.
+- **Acceptance.** Scoped L4 on LLVM completes in minutes with cached re-runs near-free.
+- **Effort·Risk.** M · medium (needs built tree for generated headers, P19).
+
+---
+
+## F. Corpus expansion (NEW)
+
+### F1. New ecosystems
+- **Context.** Only conda C/C++ libs scanned. Untested: **Rust `cdylib`, Go `cgo`,
+  Qt, Boost, libstdc++ itself**.
+- **Pointers.** `eval/manifest.yaml` (add entries); `eval/condafetch.py` already
+  handles arbitrary conda packages.
+- **Acceptance.** ≥1 each of Rust/Go/Qt/Boost in the manifest with `expect` verdicts.
+- **Effort·Risk.** S per lib · low.
+
+### F2. Grow the FP-rate corpus with eval cases
+- **Context.** The versioned-scheme and multi-`.so`-bundle (P20) shapes aren't in
+  the FP gate.
+- **Pointers.** `scripts/check_fp_rate.py` + `tests/test_fp_rate_gate.py`
+  (baselines 0/0); `examples/case141` is a ready versioned-scheme fixture.
+- **Acceptance.** Versioned-scheme + bundle pairs in the corpus, baselines stay 0/0.
+- **Effort·Risk.** S · low.
+
+---
+
+## G. G15 versioned-scheme leftovers — gap **G15** (`partial`)
+- **Context.** Detector + collapse shipped for the C suffix scheme and the C++
+  inline-namespace stamp (ICU 16428→657). Remaining per the registry `next_steps`.
+- **Pointers.** `abicheck/versioned_symbol_scheme.py` (`_NS_VER`, `_dominant_ns_token`,
+  `_scheme_key`); usecase `UC-CHANGE-inline-ns-version`.
+- **Remaining.** (1) token vocabulary: libc++ `__1`/`__2`, Abseil `lts_<date>`,
+  libstdc++ versioned namespaces (partially handled; add tests/fixtures);
+  (2) cross-check the detected token against the SONAME and still surface the bump
+  as the relink signal; (3) report the collapse count in the verdict summary.
+- **Acceptance.** libc++/Abseil pairs collapse; SONAME bump still reported; summary
+  shows "N version-renames collapsed".
+- **Effort·Risk.** M · low.
+
+---
+
+## Recommended order
+1. **A1 (G4 libclang decl extractor)** — unblocks A2/A3, all C++ validation, real L4 value.
+2. **D1 + D2 (eval source tier + CI)** — turns this research into a standing guard.
+3. **B1, B2, A3** — cheap, high-friction-removal UX/discovery fixes.
+4. **E1 (PE/Mach-O)** — close the platform-coverage hole.
+5. **C1, E2–E4, F, G** — depth & breadth as capacity allows.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,8 @@ nav:
       - "G14: abi3 import-contract": development/plans/g14-stable-abi-subset.md
       - "G15: Inline-namespace version stamp": development/plans/g15-inline-namespace-version.md
       - "G16: Header-scope toolchain robustness": development/plans/g16-header-scope-toolchain-robustness.md
+      - "G17: Real-world validation corpus": development/plans/g17-real-world-corpus.md
+      - "G18: Bazel build-evidence": development/plans/g18-bazel-build-evidence.md
     - ADR:
       - Overview: development/adr/index.md
       - "001: Technology Stack": development/adr/001-technology-stack.md


### PR DESCRIPTION
## What

Follow-up to the merged field-evaluation work (#378). **No product-code changes** —
docs + use-case registry only. Two deliverables:

### 1. Remaining-work summary — `eval/FOLLOWUPS.md`
A detailed plan for every open item the field evaluation surfaced (P01–P21):
each with **context · code pointers (file/function) · approach · acceptance ·
effort·risk**, and mapped to existing gaps where they overlap so we don't
duplicate planned work:
- **P15/P05** (no real C++ source-ABI surface — castxml ✗ libstdc++; clang L4 emits
  empty decl tables) → existing gap **G4** (libclang extractor) — *the unblocker*.
- **P14/P16** (compile-DB `-I` inheritance; `--lang c` abort) → existing gap **G16**.
- versioned-scheme leftovers → existing gap **G15**.
- Net-new: `--show-data-sources` UX (P03), build-option vocabulary (P17), eval
  source-tier + CI lane, PE/Mach-O + Bazel + cross-compiler validation, corpus growth.

### 2. Two newly-tracked use cases (registry + plans)
- **`UC-WORKFLOW-real-world-corpus`** (G17, `partial`) — the `eval/` benchmark
  suite (manifest + runner + generated report). Binary tier validated; source
  tier + CI lane planned. Plan: `g17-real-world-corpus.md`.
- **`UC-TC-bazel-build-evidence`** (G18, `modeled`) — `adapters/bazel.py` exists
  but is unvalidated end-to-end on a real Bazel project (P21 oneDAL). Plan:
  `g18-bazel-build-evidence.md`.

Both wired through registry entry + plan file + eval-doc gap row + plans-index
row + mkdocs nav; `tests/test_usecase_registry.py` green, `check_ai_readiness.py`
0 errors.

## Why
Turns the one-off evaluation into a tracked, machine-checked backlog: the
registry now reflects the real coverage gaps, and `FOLLOWUPS.md` is the actionable
to-do with pointers.

https://claude.ai/code/session_01KKbowdUSUt79wNqvZ71PJD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKbowdUSUt79wNqvZ71PJD)_