### PR TITLE
docs: ADR-035 + G19 plan — PR-tier source intelligence & cross-source validation

### DIFF
--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -333,8 +333,10 @@ Designed as a progressive ramp — value at step 1 with zero build integration,
 deeper signal as the maintainer opts in:
 
 1. **Zero-config** — `abicheck scan --binary libfoo.so --headers include/` runs
-   L0–L2 + the always-on tier and the single-release audit (D8). No compile DB,
-   no compiler, immediate hygiene findings.
+   L0/L1 + the always-on lexical tier (S3) and the single-release audit (D8) with
+   no compile DB and no compiler. L2 header-AST (castxml) is added when castxml is
+   present, otherwise reported as skipped — it is not part of the no-compiler
+   promise. Immediate hygiene findings either way.
 2. **Add a compile DB** — `--compile-db build/compile_commands.json` unlocks L3
    and POI-targeted L4/L5 (D7). Still one command.
 3. **Pick a depth** — `abicheck scan --estimate` prints projected per-level cost

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -8,8 +8,8 @@
 
 ## Context
 
-A field proposal ("Source scans в abicheck: уровни глубины, инструменты,
-кросс-чеки и интеграция с билдом") argues that source-aware analysis should
+A field proposal ("Source scans in abicheck: depth levels, tooling,
+cross-checks, and build integration") argues that source-aware analysis should
 not be an all-or-nothing "dump every translation unit's AST" mode run only at
 release/nightly. Instead it proposes a configurable ladder of source scans
 (`S0..S6`) with per-level cost, a risk-scored escalation policy, cross-source

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -75,15 +75,41 @@ concentrates:
 
 ## Decision
 
-### D1. Keep the L0–L5 numbering; do not adopt a parallel `S0..S6` scale
+### D1. Two orthogonal axes: L = evidence layer, S = source-analysis method
 
-The proposal's source ladder is folded into the existing L-layers per the
-mapping table above. A second numbering axis would fork the docs/ADR set
-(ADR-028…033) and confuse the evidence model for no capability gain. New work
-is described as *extensions of named layers*, and the **authority rule
-(ADR-028 D3) is preserved**: L0/L1/L2 artifact evidence stays authoritative for
-`BREAKING` verdicts; everything added here emits `RISK` or `API_BREAK` findings
-that explain, localize, and add confidence — never a standalone shipped break.
+There are **two different things** the proposal and abicheck talk about, and they
+must not be conflated:
+
+- **L0–L5 — evidence layers (the *what* + authority).** Where a fact comes from
+  (binary / debug / header / build / source-ABI / graph) and how much it is
+  trusted. L0–L2 stay authoritative for `BREAKING`; L3–L5 only `RISK`/`API_BREAK`
+  (ADR-028 D3). This is the user-facing depth axis and the authority axis.
+- **S0–S6 — source-analysis methods (the *how*).** Six distinct, cost-ordered
+  *techniques* for analyzing source, from a diff classifier up to a full AST.
+  These are **not** evidence layers and **not** a competing authority/selector
+  axis — they are the **pipeline of methods that produce the L3–L5 evidence**,
+  and the granularity at which coverage is reported.
+
+So the S-scale is kept as a real, named concept (source analysis is genuinely six
+graduated methods, not one "parse the AST" step), but it is *orthogonal* to L: an
+S-method runs and its output lands in an L-layer. The earlier worry — exposing
+`S0..S6` as a parallel CLI/config selector that forks the evidence model — is
+avoided by keeping the **user knob and authority on the L-axis** while S describes
+the internal provider ladder and the reporting breakdown. Mapping:
+
+| S-method | What it does | Tool | Produces (L) | Cost |
+|---|---|---|---|---|
+| **S0** diff classifier | changed-file → risk tags/score | git diff | — (drives D3/D7) | `<1%` |
+| **S1** compile-DB / flags | ABI-affecting build context | parse `compile_commands.json` etc. | **L3** | `<1%` |
+| **S2** preprocessor / includes | macro values, include/leak graph | `clang -E`/`-MM` | **L3→L5** | 1–10% |
+| **S3** lexical pattern scan | ABI-risk constructs, no semantics | regex / Tree-sitter | pre-scan facts (→L2/L5) | `<1–5%` |
+| **S4** symbol/reference index | decls/refs/inheritance/call graph | clangd-index / Kythe / CodeQL | **L5** | 5–30% |
+| **S5** targeted semantic AST | layouts, instantiations, body hashes | clang/castxml on selected TUs | **L4** (+L5 edges) | 5–40% |
+| **S6** full AST | whole-project semantic facts | clang/castxml all TUs | **L4** full-scope | 20–80% |
+
+The **authority rule (ADR-028 D3) is preserved**: whatever S-method produced a
+fact, an L3–L5 fact never alone decides a shipped `BREAKING` verdict — it
+explains, localizes, and adds confidence.
 
 ### D2. Add an always-on, compiler-free PR pre-scan tier (extends L2/L5)
 

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -281,6 +281,11 @@ a finding after the fact, the POI set is computed up front and handed to
 effect: a large project pays L4/L5 cost only on the handful of entities the
 binary/header evidence already flagged.
 
+**Floor:** the POI set **always** includes the directly-changed files/TUs
+unconditionally — the risk score only *adds* further candidates, it can never
+*remove* a changed TU. So a mis-weighted `risk_rules` profile (D3) can broaden
+the scan but cannot drop an obviously-relevant changed translation unit.
+
 ### D8. Single-release audit mode (no baseline required)
 
 The D2 pattern facts and the D4 cross-checks are **intra-version** — they need

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -218,11 +218,12 @@ replay + LibTooling/CastXML stays the supported portable path.
 ### D6. Additive `.abicheck.yml` schema for levels, budgets, and cross-checks
 
 Extend the config loaded by `buildsource/inline.py` with optional `source:
-{ budgets, layers }` (`layers` matching the existing collect API key — not a
-new `levels` spelling), `risk_rules`, and `crosschecks: { <check>:
-info|warning|error }` blocks. All additive and defaulted-off where they imply new cost; they
-map onto the existing collect-mode / evidence-policy machinery rather than
-replacing it.
+{ method, depth, budgets, layers }` (`method` is the exact S-axis selector,
+`depth` is the coarse L-axis selector, and `layers` matches the existing collect
+API key — not a new `levels` spelling), `risk_rules`, and `crosschecks:
+{ <check>: info|warning|error }` blocks. All additive and defaulted-off where
+they imply new cost; they map onto the existing collect-mode / evidence-policy
+machinery rather than replacing it.
 
 ### D7. Evidence-directed focusing: cheap facts steer the expensive scan
 

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -1,0 +1,240 @@
+# ADR-035: PR-Tier Source Intelligence and Cross-Source Validation
+
+**Date:** 2026-06-14
+**Status:** Proposed
+**Decision maker:** (pending review)
+
+---
+
+## Context
+
+A field proposal ("Source scans в abicheck: уровни глубины, инструменты,
+кросс-чеки и интеграция с билдом") argues that source-aware analysis should
+not be an all-or-nothing "dump every translation unit's AST" mode run only at
+release/nightly. Instead it proposes a configurable ladder of source scans
+(`S0..S6`) with per-level cost, a risk-scored escalation policy, cross-source
+validation, and build-integrated fact extraction — so that compatibility risk
+is caught **on the PR**, cheaply, and deeper analysis runs only when triggered.
+
+Most of that architecture already exists in abicheck. ADR-028…033 define an
+optional build/source evidence stack:
+
+- **L0/L1/L2** — artifact-authoritative binary, debug-info, and header-AST scan
+  (`dumper.py`, `dumper_castxml.py`, `elf/pe/macho_metadata.py`, `dwarf_*.py`).
+- **L3** — build/toolchain context from compile DB, CMake, Ninja, Bazel, Make
+  (`buildsource/adapters/*`, `build_evidence.py`, `build_diff.py`).
+- **L4** — scoped per-TU source-ABI replay via clang/castxml/android backends
+  with per-TU caching (`source_replay.py`, `source_extractors/*`).
+- **L5** — source/implementation graph (include/call/type/build edges, Kythe /
+  CodeQL ingest) (`source_graph.py`, `call_graph.py`, `include_graph.py`).
+- A CI complexity ladder, replay scopes (`off`/`headers-only`/`changed`/
+  `target`/`full`), per-TU + content-addressed caches, evidence policy, and
+  coverage/metrics reporting (ADR-033 D1–D10).
+
+Mapped onto that stack, the proposal's `S0..S6` scale is **not a new axis** —
+it largely re-derives the existing L-layers:
+
+| Proposal level | abicheck today | Gap |
+|---|---|---|
+| `S0` diff classifier + risk score | `recommend-collect-mode` (path → mode) | no numeric risk score / escalation thresholds / `risk_rules` config |
+| `S1` compile-DB / build-flag scan | **L3** (5 adapters, flag-drift diff) | covered |
+| `S2` preprocessor + include graph | **L5** include edges (`clang -MM`) | no per-TU macro-value capture, no private-header-leak / generated-config detection |
+| `S3` lexical/pattern scan (no compiler) | — | **missing entirely** (no compiler-free tier) |
+| `S4` symbol/reference index | **L5** call edges + Kythe/CodeQL ingest | no clangd-index integration (acceptable) |
+| `S5` targeted semantic AST | **L4** scoped replay | covered |
+| `S6` full AST | **L4** `--source-abi-scope full` | covered |
+| cross-checks (§6) | partial (`dumper` logs some leaks) | **no cross-check findings** as `ChangeKind`s |
+| build-plugin / wrapper extraction (§8) | ADR-032 extractor plugin + ADR-033 D1 "Phase 6" | **not implemented**; no dump/facts artifact protocol |
+| normalized facts, caches, coverage report | covered (ADR-030/033) | extend naming for new tiers |
+
+So three genuine gaps remain, and they are exactly where the proposal's value
+concentrates:
+
+1. **No cheap, always-on PR tier.** Every existing evidence layer (L3–L5) needs
+   a compile DB or a compiler. There is nothing that runs in `<5%` of build
+   cost on *every* PR with no toolchain (the proposal's `S0`/`S2`-macro/`S3`).
+2. **No cross-source validation engine.** abicheck holds binary exports, header
+   AST, build flags, and source facts in one snapshot but never diffs them
+   *against each other within a single version* (exported-but-not-public,
+   header built with different macros than the shipped TU, private-header leaks,
+   ODR type variants).
+3. **No build-integrated extraction or single `scan` UX.** Capability is spread
+   across `dump`/`compare`/`collect`/`compare-graph`; there is no risk → budget
+   → escalation orchestrator, and no way to ingest facts emitted *by the
+   product build* instead of re-running a frontend.
+
+---
+
+## Decision
+
+### D1. Keep the L0–L5 numbering; do not adopt a parallel `S0..S6` scale
+
+The proposal's source ladder is folded into the existing L-layers per the
+mapping table above. A second numbering axis would fork the docs/ADR set
+(ADR-028…033) and confuse the evidence model for no capability gain. New work
+is described as *extensions of named layers*, and the **authority rule
+(ADR-028 D3) is preserved**: L0/L1/L2 artifact evidence stays authoritative for
+`BREAKING` verdicts; everything added here emits `RISK` or `API_BREAK` findings
+that explain, localize, and add confidence — never a standalone shipped break.
+
+### D2. Add an always-on, compiler-free PR pre-scan tier (extends L2/L5)
+
+A new cheap tier runs on every PR over **changed + public** files, needing no
+compile DB and no compiler:
+
+- **Pattern pre-scan** (new `buildsource/pattern_scan.py`): regex/lexical scan
+  for ABI-risk constructs — `#pragma pack`, `alignas`, `__attribute__((packed|
+  visibility))`, `__declspec(dllexport|dllimport)`, `extern "C"`, calling-
+  convention macros, explicit / `extern` template instantiation, `inline
+  namespace`, public virtual methods, `operator new`/`delete`. Emits advisory
+  facts and escalation triggers, never a final verdict. Starts as a stdlib
+  regex scanner (no new dependency); Tree-sitter is an optional later backend.
+- **Preprocessor pre-scan** (extends `buildsource/include_graph.py`): when a
+  compile DB is present, capture per-TU macro values for ABI-affecting macros
+  and detect *public-header-includes-private/generated-header* leaks and
+  per-TU macro-value divergence for the same public type.
+
+These feed D3 (escalation) and D4 (cross-checks). Output is normalized facts in
+the existing `buildsource` schema, with coverage reported (ADR-033 D6/D9).
+
+### D3. Risk-scored escalation and budgeted orchestration via a `scan` command
+
+- Promote `recommend_collect_mode()` to compute a **numeric risk score** from a
+  `risk_rules` config block (path globs → weights: public header `+50`, export
+  map `+50`, ABI-affecting flag `+40`, exported-symbol definition `+30`,
+  reachable-from-public `+25`, template-instantiation change `+35`,
+  docs/tests-only `-100`). Score selects the evidence depth (thresholds map to
+  the existing `off`/`build`/`source-changed`/`source-target`/`graph-*` modes).
+- Add a **`scan`** subcommand (`abicheck/cli_scan.py`, registered per the
+  CLAUDE.md sibling-module pattern) that orchestrates: classify → always-on
+  tier (D2) → escalate L3/L4/L5 by score within a **time/TU budget** → emit one
+  coverage- and confidence-annotated report. Partial results are first-class:
+  the report states exactly which tiers ran and at what cache-hit rate, never a
+  bare "source scan failed". `scan` is a convenience front-end over existing
+  `dump`/`compare`/`collect`; it adds no new authority.
+
+### D4. Cross-source validation engine (new findings, RISK/API_BREAK tier)
+
+New `buildsource/crosscheck.py` consumes one merged snapshot and diffs its
+evidence sources against each other *within a single version*. Each check is a
+named `ChangeKind` (added per the four-step procedure in `/CLAUDE.md`,
+partitioned into `RISK_KINDS` or `API_BREAK_KINDS` — never `BREAKING_KINDS`,
+per D1). Initial set, cheapest first:
+
+| Check | Inputs | Tier |
+|---|---|---|
+| `exported_not_public` | binary exports ↔ L2 header decls | RISK |
+| `public_not_exported` | L2 header decls ↔ binary exports | RISK |
+| `header_build_context_mismatch` | L2 header macros/flags ↔ L3 build flags | API_BREAK |
+| `private_header_leak` | L5 include graph ↔ install manifest | RISK |
+| `odr_type_variant` | L4 per-TU layouts of one type | API_BREAK |
+| `public_to_internal_dependency` / behavioral risk | L5 reachability ↔ PR changed files | RISK |
+
+The §6.8 provider-agreement matrix maps directly onto the existing
+`LayerConfidence`; each finding records which providers (`public_header_ast`,
+`source_index`, `binary_exports`, `debug_info`, `build_config`) corroborate the
+entity, driving the confidence tag.
+
+### D5. Build-integrated extraction: dump/facts artifact protocol + providers
+
+Implement the proposal's §8 as concrete ADR-032 extractor providers, with the
+extended-variant §8.0 distinction made explicit:
+
+- **Flow 1 (abicheck-runs-replay)** — already supported: `dump --sources` /
+  `collect` replays selected compile commands. Stays the portable default.
+- **Flow 2 (build-emits-facts)** — new: a standardized **dump/facts artifact
+  protocol** the product build drops next to its binary, which abicheck then
+  ingests without re-running a frontend:
+
+  ```text
+  abicheck_inputs/
+    manifest.json
+    binary/…  headers/…  build/compile_commands.json
+    source_facts/*.jsonl   # preferred — normalized facts
+    raw_ast/*.json.zst     # optional, debug/forensic only
+    pp/*.macros.jsonl  deps/*.d   # optional
+  ```
+
+  This rides the existing `merge` flow (artifact-side + source-side dumps merged
+  into one baseline, ADR-028 D8 / ADR-033 amendment).
+
+- **Providers** (ADR-032 manifest extractors): a Clang plugin
+  (`-fplugin=…`, normalized facts during normal compile, no raw AST by default)
+  and a compiler wrapper (`abicheck-cc clang++ …`, companion extraction action).
+  GCC `-fdump-lang-class`/`-tinst` and MSVC remain documented fallbacks.
+
+**Canonical rule:** normalized source facts are the comparison format; raw AST
+dumps are an MVP-ingest/forensic fallback only. The Clang plugin is positioned
+as a *performance optimization* (removes the second frontend pass), never a
+requirement — it is compiler-version-sensitive, so `compile_commands.json`
+replay + LibTooling/CastXML stays the supported portable path.
+
+### D6. Additive `.abicheck.yml` schema for levels, budgets, and cross-checks
+
+Extend the config loaded by `buildsource/inline.py` with optional `source:
+{ budgets, levels }`, `risk_rules`, and `crosschecks: { <check>: info|warning|
+error }` blocks. All additive and defaulted-off where they imply new cost; they
+map onto the existing collect-mode / evidence-policy machinery rather than
+replacing it.
+
+---
+
+## Consequences
+
+**Positive**
+
+- A real always-on PR signal (D2/D3) catches ABI-affecting flag/macro changes,
+  private-header leaks, and risky source patterns without a build or a compiler.
+- The cross-check engine (D4) turns abicheck from single-source-of-truth into a
+  multi-evidence system with corroboration-based confidence and better
+  explanations — at low cost, since the inputs already sit in the snapshot.
+- Flow 2 (D5) lets vendor/closed-source consumers contribute exact-build-context
+  facts without shipping sources or letting abicheck rebuild the project.
+
+**Negative / costs**
+
+- The Clang plugin and compiler wrapper are compiler-version-sensitive and add
+  maintenance surface; mitigated by keeping them strictly optional optimizations
+  behind the portable replay path (D5) and the ADR-032 action ceiling.
+- New `ChangeKind`s (D4) must stay correctly partitioned (import-time assertion)
+  and earn corpus/FP-rate-gate coverage before they can gate, to avoid false
+  positives on legitimate internal noise.
+- `scan` (D3) adds a CLI surface; it must remain a thin orchestrator so the
+  authority rule (D1) is not diluted.
+
+**Out of scope**
+
+- Replacing or re-numbering the L0–L5 model.
+- Making any source/cross-check finding authoritative for a `BREAKING` verdict.
+- clangd-index integration (the existing call/include graph is sufficient).
+
+---
+
+## Relationship to existing ADRs
+
+- **ADR-028** — preserves the evidence-pack authority rule (D1); adds Flow 2
+  artifact protocol on the merge path (D5).
+- **ADR-029/030/031** — D2/D4 consume L3/L4/L5 outputs; no model change.
+- **ADR-032** — D5 plugin/wrapper are extractor providers under its security
+  model and action ceiling.
+- **ADR-033** — D2/D3 extend the CI ladder, replay scopes, caches, and coverage
+  reporting; D5 realizes its "Phase 6: instrumented compiler/build plugins".
+- **ADR-025** — D3 generalizes PR-diff-as-trigger into a scored escalation.
+
+See the phased work breakdown in
+[plans/g19-pr-source-intelligence.md](../plans/g19-pr-source-intelligence.md).
+
+---
+
+## References
+
+- Source-scan strategy proposal (uploaded field document, 2026-06).
+- ADR-028 — Source and Build Evidence Pack
+  ([028-source-build-evidence-pack.md](028-source-build-evidence-pack.md))
+- ADR-032 — Evidence Extractor Plugin Interface
+  ([032-evidence-extractor-plugin-interface.md](032-evidence-extractor-plugin-interface.md))
+- ADR-033 — CI Rollout, Performance, Caching, and Validation
+  ([033-ci-rollout-performance-and-validation.md](033-ci-rollout-performance-and-validation.md))
+- Clang plugins: https://clang.llvm.org/docs/ClangPlugins.html
+- LibTooling: https://clang.llvm.org/docs/LibTooling.html
+- Tree-sitter: https://tree-sitter.github.io/tree-sitter/

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -170,7 +170,7 @@ per D1). Initial set, cheapest first:
 | Check | Inputs | Tier |
 |---|---|---|
 | `exported_not_public` | binary exports ↔ L2 header decls | RISK |
-| `public_not_exported` | L2 header decls ↔ binary exports | RISK |
+| `public_not_exported` | L2 header decls that promise an external symbol ↔ binary exports | RISK |
 | `header_build_context_mismatch` | L2 header macros/flags ↔ L3 build flags | API_BREAK |
 | `private_header_leak` | L5 include graph ↔ install manifest | RISK |
 | `odr_type_variant` | L4 per-TU layouts of one type | API_BREAK |
@@ -180,6 +180,13 @@ The §6.8 provider-agreement matrix maps directly onto the existing
 `LayerConfidence`; each finding records which providers (`public_header_ast`,
 `source_index`, `binary_exports`, `debug_info`, `build_config`) corroborate the
 entity, driving the confidence tag.
+
+`public_not_exported` is intentionally narrower than "every public declaration":
+inline functions, uninstantiated templates, constexprs, type-only declarations,
+and hidden-visibility APIs are public source surface but do not promise a dynamic
+symbol. The check only compares declarations with an export obligation (for
+example exported functions/data, visibility annotations, version-script entries,
+or explicit instantiations) against binary exports.
 
 ### D5. Build-integrated extraction: dump/facts artifact protocol + providers
 

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -90,12 +90,13 @@ must not be conflated:
   axis — they are the **pipeline of methods that produce the L3–L5 evidence**,
   and the granularity at which coverage is reported.
 
-So the S-scale is kept as a real, named concept (source analysis is genuinely six
-graduated methods, not one "parse the AST" step), but it is *orthogonal* to L: an
-S-method runs and its output lands in an L-layer. The earlier worry — exposing
-`S0..S6` as a parallel CLI/config selector that forks the evidence model — is
-avoided by keeping the **user knob and authority on the L-axis** while S describes
-the internal provider ladder and the reporting breakdown. Mapping:
+So the S-scale is a real, named concept (source analysis is genuinely six
+graduated methods, not one "parse the AST" step), *orthogonal* to L: an S-method
+runs and its output lands in an L-layer. **Both axes are user-selectable** —
+`--source-method sN` pins the source-analysis method, `--depth` sets the L-layer
+ceiling; users pick whichever axis they think in. S being selectable does not
+fork the *evidence/authority* model: authority stays on the L-axis (an L3–L5 fact
+never alone gates `BREAKING`, whatever S produced it). Mapping:
 
 | S-method | What it does | Tool | Produces (L) | Cost |
 |---|---|---|---|---|
@@ -131,20 +132,28 @@ compile DB and no compiler:
 These feed D3 (escalation) and D4 (cross-checks). Output is normalized facts in
 the existing `buildsource` schema, with coverage reported (ADR-033 D6/D9).
 
-### D3. Risk-scored escalation and budgeted orchestration via a `scan` command
+### D3. Explicit deterministic level; risk-scored `auto` and budget are opt-in
 
-- Promote `recommend_collect_mode()` to compute a **numeric risk score** from a
-  `risk_rules` config block (path globs → weights: public header `+50`, export
-  map `+50`, ABI-affecting flag `+40`, exported-symbol definition `+30`,
+The level is **chosen explicitly and is deterministic** so a CI gate produces the
+same scan for the same inputs:
+
+- The user picks the level on either axis (`--source-method sN` or `--depth`,
+  D1). Each `--mode` (`pr`/`pr-deep`/`baseline`) is a **fixed preset** of (L,S),
+  not risk-varying.
+- A **numeric risk score** (from a `risk_rules` config block: public header `+50`,
+  export map `+50`, ABI-affecting flag `+40`, exported-symbol definition `+30`,
   reachable-from-public `+25`, template-instantiation change `+35`,
-  docs/tests-only `-100`). Score selects the evidence depth (thresholds map to
-  the existing `off`/`build`/`source-changed`/`source-target`/`graph-*` modes).
+  docs/tests-only `-100`) drives **two opt-in** things only: the `auto` level
+  (`--source-method auto`, local/dev convenience), and POI focusing within the
+  chosen level (D7, deterministic for a fixed diff). Risk **never** silently
+  changes the level of a CI run that pinned one.
+- A **time budget** is optional and, on overflow, **fails** (nonzero exit) — it
+  never silently shrinks scope. For gating CI, pin a level; do not use a budget.
 - Add a **`scan`** subcommand (`abicheck/cli_scan.py`, registered per the
-  CLAUDE.md sibling-module pattern) that orchestrates: classify → always-on
-  tier (D2) → escalate L3/L4/L5 by score within a **time/TU budget** → emit one
-  coverage- and confidence-annotated report. Partial results are first-class:
-  the report states exactly which tiers ran and at what cache-hit rate, never a
-  bare "source scan failed". `scan` is a convenience front-end over existing
+  CLAUDE.md sibling-module pattern) that orchestrates: classify → always-on tier
+  (D2) → run the chosen L/S level (POI-focused) → emit one coverage- and
+  confidence-annotated report stating exactly which S-method/L-layer ran, never a
+  bare "source scan failed". `scan` is a front-end over existing
   `dump`/`compare`/`collect`; it adds no new authority.
 
 ### D4. Cross-source validation engine (new findings, RISK/API_BREAK tier)
@@ -256,8 +265,9 @@ The default depth differs by *when* the scan runs:
   (`--source-abi-scope full`), all cross-checks, single-release audit, and raw
   facts archived for cache warmup. Computed once, amortized, authoritative, and
   cached in the baseline registry (ADR-022).
-- **PR / CI** → **scoped**: always-on tier (D2) every time; L3/L4/L5 escalated
-  only by risk score (D3) and the POI set (D7), within a budget, partial-ok.
+- **PR / CI** → **scoped**: always-on tier (D2) every time, plus a **fixed,
+  pinned** L/S level (the `pr` preset, or whatever the user pins), POI-focused
+  (D7). Deterministic — same inputs, same scan. `auto`/budget stay opt-in (D3).
 
 The asymmetry is the point: the baseline is produced once so it can afford full
 depth and gives the PR a rich, cached fact set to diff and focus against; the PR

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -53,14 +53,22 @@ concentrates:
 1. **No cheap, always-on PR tier.** Every existing evidence layer (L3–L5) needs
    a compile DB or a compiler. There is nothing that runs in `<5%` of build
    cost on *every* PR with no toolchain (the proposal's `S0`/`S2`-macro/`S3`).
-2. **No cross-source validation engine.** abicheck holds binary exports, header
-   AST, build flags, and source facts in one snapshot but never diffs them
-   *against each other within a single version* (exported-but-not-public,
-   header built with different macros than the shipped TU, private-header leaks,
-   ODR type variants).
+2. **No cross-source validation or evidence-directed focusing.** abicheck holds
+   binary exports, header AST, build flags, and source facts in one snapshot but
+   (a) never diffs them *against each other within a single version*
+   (exported-but-not-public, header built with different macros than the shipped
+   TU, private-header leaks, ODR type variants), and (b) never feeds the cheap
+   evidence *forward* to **target** the expensive source scan. The
+   information-sharing is one-directional today; binary/header deltas should
+   point the source scan at specific entities/TUs, not just be checked against
+   them. The cross-source checks are also valuable on a **single release** (no
+   baseline compare) — a whole class of "bad ABI hygiene" lint that justifies a
+   broader scan on its own.
 3. **No build-integrated extraction or single `scan` UX.** Capability is spread
    across `dump`/`compare`/`collect`/`compare-graph`; there is no risk → budget
-   → escalation orchestrator, and no way to ingest facts emitted *by the
+   → escalation orchestrator, no per-project cost estimate to pick a depth, no
+   stable programmatic API for the level ladder, and no way to ingest facts
+   emitted *by the
    product build* instead of re-running a frontend.
 
 ---
@@ -177,6 +185,135 @@ error }` blocks. All additive and defaulted-off where they imply new cost; they
 map onto the existing collect-mode / evidence-policy machinery rather than
 replacing it.
 
+### D7. Evidence-directed focusing: cheap facts steer the expensive scan
+
+Cross-source links are used in **two directions**, not one. D4 reads them to
+emit findings; D7 reads the *same* links *before* the expensive scan to shrink
+its scope to a **points-of-interest (POI) set**. The cheap, already-computed
+L0/L1/L2 facts (and the L0↔L2 deltas vs. baseline) decide *what* L4/L5 looks at:
+
+- exported symbol changed but the header did not → resolve its source
+  declaration and replay **only** that TU/entity;
+- header type whose layout is macro-conditional → capture macro values **only**
+  for the TUs that materialize it;
+- new/removed export with no public declaration → point the scan at the source
+  decl that emits the symbol;
+- demangled exported template symbol → seed which instantiations/TUs to replay.
+
+Mechanically this is the **reverse** of the existing `explain-finding`
+localization walk (export → decl → header → build option): instead of explaining
+a finding after the fact, the POI set is computed up front and handed to
+`source_replay` scope selection and the cross-check engine as a work-list. Net
+effect: a large project pays L4/L5 cost only on the handful of entities the
+binary/header evidence already flagged.
+
+### D8. Single-release audit mode (no baseline required)
+
+The D2 pattern facts and the D4 cross-checks are **intra-version** — they need
+exactly one build, not a compare. Expose them as a first-class **audit** that
+runs without a baseline and emits a catalog of single-release "bad ABI hygiene"
+findings: accidental ABI surface (`exported_not_public`), non-self-contained or
+private-header-leaking public headers, `header_build_context_mismatch`, ODR type
+variants across TUs, inconsistent/missing symbol visibility, unversioned exported
+symbols where a version script exists, and RTTI/typeinfo emitted for internal
+types. This is wired into the existing single-binary surface tooling
+(`surface-report`, the G11 single-binary audit) and reported as a lint with its
+own severity mapping. Because it delivers value from a single artifact, it
+justifies running a **deeper** one-time scan than a two-build PR diff would.
+
+### D9. Asymmetric defaults: full at baseline, scoped on PR
+
+The default depth differs by *when* the scan runs:
+
+- **Baseline / release publish** → **full**: full dump + full source analysis
+  (`--source-abi-scope full`), all cross-checks, single-release audit, and raw
+  facts archived for cache warmup. Computed once, amortized, authoritative, and
+  cached in the baseline registry (ADR-022).
+- **PR / CI** → **scoped**: always-on tier (D2) every time; L3/L4/L5 escalated
+  only by risk score (D3) and the POI set (D7), within a budget, partial-ok.
+
+The asymmetry is the point: the baseline is produced once so it can afford full
+depth and gives the PR a rich, cached fact set to diff and focus against; the PR
+runs on every push so it must stay cheap. Project size shifts the PR default (see
+*Sizing guidance*) — small projects can simply run full on PRs too.
+
+### D10. Programmatic API: where each level plugs in
+
+The level ladder is exposed as a typed Python API so the CLI, the MCP server,
+and CI wrappers all drive the same engine. Layering, top-down:
+
+| Layer | Where | Responsibility |
+|---|---|---|
+| CLI | `cli_scan.py`, existing `cli*.py` | argv → `ScanRequest`; render report/exit code |
+| MCP | `mcp_server.py` | expose `scan`/`audit`/`estimate` as agent tools |
+| Service | `service.py` (extend) | `run_scan(ScanRequest) -> ScanResult`; orchestrates classify → POI → escalate → collect → cross-check → report |
+| Levels | `buildsource/` providers | one provider per level, uniform protocol |
+| Facts | `buildsource/model.py`, `source_abi.py`, `build_evidence.py` | normalized fact schema (canonical I/O of every provider) |
+
+- **Provider protocol** — each level (the D2 pattern/preprocessor pre-scan, L3
+  build, L4 replay, L5 graph, the D4 cross-checks) implements a small uniform
+  interface modelled on the existing ADR-032 `DataExtractor`:
+  `capabilities()`, `estimate(ctx) -> CostEstimate`, `run(ctx, poi) -> Facts`,
+  consuming a shared `ScanContext` (paths, compile DB, changed files, budget,
+  cache) and the POI set, and returning **normalized facts only** (never raw
+  AST as primary output). This is what makes levels independently runnable
+  (ADR-033 D1) and lets external/build-emitted providers (D5) drop in via the
+  ADR-032 manifest.
+- **Request/result objects** — `ScanRequest` (binary, headers, compile DB,
+  mode, budget, risk rules, level overrides) and `ScanResult` (findings,
+  per-level `LayerCoverage`, `CostEstimate` vs. actual, confidence/provider
+  matrix). `ScanResult` is what the reporter, PR comment, SARIF, and MCP all
+  consume — one object, many renderings.
+- **`estimate` is a first-class entry point**, not a side effect: a dry-run that
+  probes the project (TU count from compile DB, header fan-out, cache state) and
+  returns the projected cost of each level for *this* project so a maintainer
+  (or CI) can choose a budget/depth. Implemented as `service.estimate_scan()`,
+  surfaced as `abicheck scan --estimate` and an MCP tool.
+
+---
+
+## Sizing guidance (defaults by project scale)
+
+Cost anchors are from §11 of the proposal (full `-fsyntax-only` ≈ 20–80% of a
+clean build; pattern/compile-DB scans `<1–5%`). These are starting defaults;
+`scan --estimate` (D10) gives the real per-project number.
+
+| Project scale | PR default | Baseline default |
+|---|---|---|
+| **Small** (≲50 TUs, builds in seconds) | full source analysis every PR is fine | full |
+| **Medium** (~50–500 TUs) | always-on tier + risk/POI-targeted L4; budget cap | full (nightly or on release) |
+| **Large** (≳500 TUs, or template/header-heavy) | always-on tier + cross-checks + POI-targeted L4 within budget; lean on cache | full on release only; warm cache from it |
+| **Header-only / template-heavy** | AST cost is header-dominated — prefer full L4 if small, else POI-targeted | full |
+
+Rule of thumb: if `scan --estimate` puts full L4 under the PR time budget, run it;
+otherwise run the always-on tier always and let risk score + POI escalate.
+
+---
+
+## Maintainer UX / adoption path
+
+Designed as a progressive ramp — value at step 1 with zero build integration,
+deeper signal as the maintainer opts in:
+
+1. **Zero-config** — `abicheck scan --binary libfoo.so --headers include/` runs
+   L0–L2 + the always-on tier and the single-release audit (D8). No compile DB,
+   no compiler, immediate hygiene findings.
+2. **Add a compile DB** — `--compile-db build/compile_commands.json` unlocks L3
+   and POI-targeted L4/L5 (D7). Still one command.
+3. **Pick a depth** — `abicheck scan --estimate` prints projected per-level cost
+   for *this* repo; the maintainer sets `source.budgets` / mode in `.abicheck.yml`
+   accordingly (D6, D10).
+4. **CI** — the GitHub Action (ADR-017) gains `mode:` + budget; PRs get a sticky
+   comment (`pr-comment`) showing findings **plus** the coverage/confidence block
+   so a partial scan is legible, never a bare "failed".
+5. **Baselines** — `baseline push` stores a full-depth baseline (D9); PRs pull and
+   diff against it, getting both the cached facts and the focusing seed for free.
+6. **Standalone audit** — `abicheck scan --audit` (or `surface-report`) as a lint
+   on a tag/release or pre-merge, independent of any baseline.
+7. **Promote to gating** — findings start advisory; once the FP-rate gate is
+   trusted for a check, the maintainer raises it to error via `crosschecks:` /
+   severity config. Adoption never starts by blocking merges.
+
 ---
 
 ## Consequences
@@ -190,6 +327,13 @@ replacing it.
   explanations — at low cost, since the inputs already sit in the snapshot.
 - Flow 2 (D5) lets vendor/closed-source consumers contribute exact-build-context
   facts without shipping sources or letting abicheck rebuild the project.
+- Evidence-directed focusing (D7) makes deep analysis affordable on large
+  projects by spending L4/L5 cost only on binary/header-flagged entities.
+- The single-release audit (D8) delivers value from one artifact — adoption
+  needs no baseline and no second build.
+- One typed `ScanRequest`/`ScanResult` API (D10) means CLI, MCP server, and CI
+  wrappers share one engine, and `--estimate` lets each project pick a depth on
+  measured cost instead of guesswork.
 
 **Negative / costs**
 
@@ -219,7 +363,13 @@ replacing it.
   model and action ceiling.
 - **ADR-033** — D2/D3 extend the CI ladder, replay scopes, caches, and coverage
   reporting; D5 realizes its "Phase 6: instrumented compiler/build plugins".
-- **ADR-025** — D3 generalizes PR-diff-as-trigger into a scored escalation.
+- **ADR-025** — D3 generalizes PR-diff-as-trigger into a scored escalation; D7
+  reverses its localization walk to *target* the scan up front.
+- **ADR-022** — D9 stores the full-depth baseline; PRs pull facts + focusing seed.
+- **ADR-017** — D2/D3/D9 surface through the Action's `mode`/budget; UX step 4.
+- **ADR-024 / `surface-report` / G11** — D8 single-release audit extends the
+  single-binary surface tooling.
+- **ADR-021b (MCP)** — D10 exposes `scan`/`audit`/`estimate` as agent tools.
 
 See the phased work breakdown in
 [plans/g19-pr-source-intelligence.md](../plans/g19-pr-source-intelligence.md).

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -112,6 +112,15 @@ The **authority rule (ADR-028 D3) is preserved**: whatever S-method produced a
 fact, an L3–L5 fact never alone decides a shipped `BREAKING` verdict — it
 explains, localizes, and adds confidence.
 
+**S-methods are independent, cost-ordered passes — not a feed-forward pipeline.**
+S5/S6 (and the S4/S5 graph edges) are their own clang/castxml passes over the
+TUs; they do **not** consume S3/S4 output. The cheap methods (S0 diff, S3
+patterns) only produce the **POI list that selects which TUs** the expensive
+S4/S5 pass parses. Consequence: whenever **sources + a compiler** are available,
+S5 runs (POI-targeted) and the L5 edges it needs exist; the only reasons S5/L5
+do not run are a **missing toolchain** or an explicit **budget/scope** exclusion
+— never "S3/S4 data was missing".
+
 ### D2. Add an always-on PR pre-scan tier (extends L2/L5)
 
 A new cheap tier runs on every PR over **changed + public** files. It has two
@@ -143,13 +152,15 @@ same scan for the same inputs:
 - The user picks the level on either axis (`--source-method sN` or `--depth`,
   D1). Each `--mode` (`pr`/`pr-deep`/`baseline`) is a **fixed preset** of (L,S),
   not risk-varying.
-- A **numeric risk score** (from a `risk_rules` config block: public header `+50`,
-  export map `+50`, ABI-affecting flag `+40`, exported-symbol definition `+30`,
-  reachable-from-public `+25`, template-instantiation change `+35`,
-  docs/tests-only `-100`) drives **two opt-in** things only: the `auto` level
+- A **numeric risk score** drives **two opt-in** things only: the `auto` level
   (`--source-method auto`, local/dev convenience), and POI focusing within the
   chosen level (D7, deterministic for a fixed diff). Risk **never** silently
-  changes the level of a CI run that pinned one.
+  changes the level of a CI run that pinned one. The score's path-glob **weights
+  are an illustrative, tunable default profile shipped as the `risk_rules` config
+  block — not a normative contract**; the spec fixes only the *ordering* of
+  signals (public header > export map > ABI flag > internal source > docs/tests).
+  Because the score only feeds opt-in `auto` + POI selection, the exact numbers
+  never affect a pinned/deterministic gate.
 - A **time budget** is optional and, on overflow, **fails** (nonzero exit) — it
   never silently shrinks scope. For gating CI, pin a level; do not use a budget.
 - Add a **`scan`** subcommand (`abicheck/cli_scan.py`, registered per the
@@ -181,12 +192,28 @@ The §6.8 provider-agreement matrix maps directly onto the existing
 `source_index`, `binary_exports`, `debug_info`, `build_config`) corroborate the
 entity, driving the confidence tag.
 
+**Coverage honesty.** A cross-check whose required layer was not collected (e.g.
+behavioral-risk needs the L5 edges from an S4/S5 pass, but the host lacked a
+compiler or budget excluded it) is reported as a **soft advisory** (`info`) that
+names the layer/method to enable (e.g. "run `--source-method s5`/`--depth
+graph`"). It is **never counted as clean** and does **not** affect the exit code.
+With sources + a compiler present this case does not arise — the check runs for
+real.
+
 `public_not_exported` is intentionally narrower than "every public declaration":
 inline functions, uninstantiated templates, constexprs, type-only declarations,
 and hidden-visibility APIs are public source surface but do not promise a dynamic
 symbol. The check only compares declarations with an export obligation (for
 example exported functions/data, visibility annotations, version-script entries,
 or explicit instantiations) against binary exports.
+
+`exported_not_public` (the reverse: a symbol is exported but no public header
+declares it) runs **only over symbols that pass the existing
+`dumper._is_abi_relevant_symbol()` filter** (which already drops compiler-emitted
+internals, transitive stdlib symbols, and private `__`-prefixed C symbols) and
+respects public-surface scoping (ADR-024). Default severity `warning`,
+suppressible through the existing suppression system — so it does not light up
+healthy libraries with intentional internal exports.
 
 ### D5. Build-integrated extraction: dump/facts artifact protocol + providers
 

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -137,9 +137,9 @@ parts with different requirements:
 - **Preprocessor pre-scan** (extends `buildsource/include_graph.py`): the
   conditional part — runs **only when a compile DB and a preprocessor (`clang
   -E`) are available** (reported as skipped otherwise). Captures per-TU macro
-  values for ABI-affecting macros
-  and detect *public-header-includes-private/generated-header* leaks and
-  per-TU macro-value divergence for the same public type.
+  values for ABI-affecting macros, detects
+  *public-header-includes-private/generated-header* leaks, and flags per-TU
+  macro-value divergence for the same public type.
 
 These feed D3 (escalation) and D4 (cross-checks). Output is normalized facts in
 the existing `buildsource` schema, with coverage reported (ADR-033 D6/D9).
@@ -339,11 +339,12 @@ and CI wrappers all drive the same engine. Layering, top-down:
   AST as primary output). This is what makes levels independently runnable
   (ADR-033 D1) and lets external/build-emitted providers (D5) drop in via the
   ADR-032 manifest.
-- **Request/result objects** — `ScanRequest` (binary, headers, compile DB,
-  mode, budget, risk rules, level overrides) and `ScanResult` (findings,
-  per-level `LayerCoverage`, `CostEstimate` vs. actual, confidence/provider
-  matrix). `ScanResult` is what the reporter, PR comment, SARIF, and MCP all
-  consume — one object, many renderings.
+- **Request/result objects** — `ScanRequest` (binaries, headers, compile DB,
+  baseline, `mode`, `source_method`/`depth`, budget, risk rules) and `ScanResult`
+  (`findings: list[Change]`, per-layer `LayerResult`/coverage, `CostEstimate`
+  projected cost compared against each layer's actual `elapsed_s`,
+  confidence/provider matrix). `ScanResult` is what the reporter, PR comment,
+  SARIF, and MCP all consume — one object, many renderings.
 - **`estimate` is a first-class entry point**, not a side effect: a dry-run that
   probes the project (TU count from compile DB, header fan-out, cache state) and
   returns the projected cost of each level for *this* project so a maintainer

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -180,8 +180,9 @@ replay + LibTooling/CastXML stays the supported portable path.
 ### D6. Additive `.abicheck.yml` schema for levels, budgets, and cross-checks
 
 Extend the config loaded by `buildsource/inline.py` with optional `source:
-{ budgets, levels }`, `risk_rules`, and `crosschecks: { <check>: info|warning|
-error }` blocks. All additive and defaulted-off where they imply new cost; they
+{ budgets, layers }` (`layers` matching the existing collect API key — not a
+new `levels` spelling), `risk_rules`, and `crosschecks: { <check>:
+info|warning|error }` blocks. All additive and defaulted-off where they imply new cost; they
 map onto the existing collect-mode / evidence-policy machinery rather than
 replacing it.
 

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -112,20 +112,23 @@ The **authority rule (ADR-028 D3) is preserved**: whatever S-method produced a
 fact, an L3–L5 fact never alone decides a shipped `BREAKING` verdict — it
 explains, localizes, and adds confidence.
 
-### D2. Add an always-on, compiler-free PR pre-scan tier (extends L2/L5)
+### D2. Add an always-on PR pre-scan tier (extends L2/L5)
 
-A new cheap tier runs on every PR over **changed + public** files, needing no
-compile DB and no compiler:
+A new cheap tier runs on every PR over **changed + public** files. It has two
+parts with different requirements:
 
-- **Pattern pre-scan** (new `buildsource/pattern_scan.py`): regex/lexical scan
+- **Pattern pre-scan** (new `buildsource/pattern_scan.py`): the **compiler-free**
+  part — needs no compile DB and no compiler. A regex/lexical scan
   for ABI-risk constructs — `#pragma pack`, `alignas`, `__attribute__((packed|
   visibility))`, `__declspec(dllexport|dllimport)`, `extern "C"`, calling-
   convention macros, explicit / `extern` template instantiation, `inline
   namespace`, public virtual methods, `operator new`/`delete`. Emits advisory
   facts and escalation triggers, never a final verdict. Starts as a stdlib
   regex scanner (no new dependency); Tree-sitter is an optional later backend.
-- **Preprocessor pre-scan** (extends `buildsource/include_graph.py`): when a
-  compile DB is present, capture per-TU macro values for ABI-affecting macros
+- **Preprocessor pre-scan** (extends `buildsource/include_graph.py`): the
+  conditional part — runs **only when a compile DB and a preprocessor (`clang
+  -E`) are available** (reported as skipped otherwise). Captures per-TU macro
+  values for ABI-affecting macros
   and detect *public-header-includes-private/generated-header* leaks and
   per-TU macro-value divergence for the same public type.
 
@@ -283,7 +286,7 @@ and CI wrappers all drive the same engine. Layering, top-down:
 |---|---|---|
 | CLI | `cli_scan.py`, existing `cli*.py` | argv → `ScanRequest`; render report/exit code |
 | MCP | `mcp_server.py` | expose `scan`/`audit`/`estimate` as agent tools |
-| Service | `service.py` (extend) | `run_scan(ScanRequest) -> ScanResult`; orchestrates classify → POI → escalate → collect → cross-check → report |
+| Service | `service.py` (extend) | `run_scan(ScanRequest) -> ScanResult`; orchestrates classify → POI → run pinned level (auto-escalate only if opted in) → collect → cross-check → report |
 | Levels | `buildsource/` providers | one provider per level, uniform protocol |
 | Facts | `buildsource/model.py`, `source_abi.py`, `build_evidence.py` | normalized fact schema (canonical I/O of every provider) |
 
@@ -317,13 +320,15 @@ clean build; pattern/compile-DB scans `<1–5%`). These are starting defaults;
 
 | Project scale | PR default | Baseline default |
 |---|---|---|
-| **Small** (≲50 TUs, builds in seconds) | full source analysis every PR is fine | full |
-| **Medium** (~50–500 TUs) | always-on tier + risk/POI-targeted L4; budget cap | full (nightly or on release) |
-| **Large** (≳500 TUs, or template/header-heavy) | always-on tier + cross-checks + POI-targeted L4 within budget; lean on cache | full on release only; warm cache from it |
-| **Header-only / template-heavy** | AST cost is header-dominated — prefer full L4 if small, else POI-targeted | full |
+| **Small** (≲50 TUs, builds in seconds) | pin full source (S6) every PR | full |
+| **Medium** (~50–500 TUs) | always-on tier + pin POI-targeted S5 | full (nightly or on release) |
+| **Large** (≳500 TUs, or template/header-heavy) | always-on tier + cross-checks + pin POI-targeted S5; lean on cache | full on release only; warm cache from it |
+| **Header-only / template-heavy** | AST cost is header-dominated — pin full S6 if small, else POI-targeted S5 | full |
 
-Rule of thumb: if `scan --estimate` puts full L4 under the PR time budget, run it;
-otherwise run the always-on tier always and let risk score + POI escalate.
+These are **pinned per-mode defaults** (deterministic), not risk-varying. Rule of
+thumb: if `scan --estimate` puts full L4/S6 under your time budget, pin it;
+otherwise pin a cheaper level (S5/S3). `--source-method auto` lets risk + POI pick
+the level for local/dev, but pin an explicit level for reproducible CI gates.
 
 ---
 
@@ -359,8 +364,10 @@ deeper signal as the maintainer opts in:
 
 **Positive**
 
-- A real always-on PR signal (D2/D3) catches ABI-affecting flag/macro changes,
-  private-header leaks, and risky source patterns without a build or a compiler.
+- A real always-on PR signal (D2/D3): risky source patterns are caught with no
+  compiler at all (pattern pre-scan); ABI-affecting flag/macro changes and
+  private-header leaks are caught from the compile DB + preprocessor when those
+  are available — all without a full build.
 - The cross-check engine (D4) turns abicheck from single-source-of-truth into a
   multi-evidence system with corroboration-based confidence and better
   explanations — at low cost, since the inputs already sit in the snapshot.

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-14
 **Status:** Proposed
-**Decision maker:** (pending review)
+**Decision maker:** Nikolay Petrov
 
 ---
 
@@ -68,8 +68,7 @@ concentrates:
    across `dump`/`compare`/`collect`/`compare-graph`; there is no risk → budget
    → escalation orchestrator, no per-project cost estimate to pick a depth, no
    stable programmatic API for the level ladder, and no way to ingest facts
-   emitted *by the
-   product build* instead of re-running a frontend.
+   *emitted by the product build* instead of re-running a frontend.
 
 ---
 

--- a/docs/development/adr/index.md
+++ b/docs/development/adr/index.md
@@ -38,4 +38,5 @@
 | [032](032-evidence-extractor-plugin-interface.md) | Evidence Extractor Plugin Interface and Security Model | Proposed |
 | [033](033-ci-rollout-performance-and-validation.md) | CI Rollout, Performance, Caching, and Validation Strategy | Proposed |
 | [034](034-managed-runtime-and-non-c-abi-frontends.md) | Managed-Runtime and Non-C ABI Frontends | Proposed |
+| [035](035-pr-tier-source-intelligence-and-crosscheck.md) | PR-Tier Source Intelligence and Cross-Source Validation | Proposed |
 | [Gap Analysis](adr-gap-analysis.md) | Decisions Needing Formal ADRs | Reference |

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -202,6 +202,27 @@ cost probe; `--audit` runs intra-version (ignores `--baseline`).
 Convenience subcommands (thin wrappers, same engine):
 `abicheck scan estimate …` ≡ `--estimate`; `abicheck scan audit …` ≡ `--audit`.
 
+### How each layer is collected (and whether it always runs)
+
+Each L-layer uses a different method; the expensive ones are scoped or gated, so
+not everything runs on every PR. The L5 graph is **not** fully built by default —
+only the cheap structural fold is, the semantic edges are budget-gated.
+
+| Layer | How collected | Compiler? | Default PR | Scope |
+|---|---|---|---|---|
+| pre-scan (D2) | regex/lexical over changed+public files | no | always | changed+public |
+| L2 headers | castxml / DWARF (existing) | no | always | public surface |
+| L3 build | parse `compile_commands.json` / CMake / Ninja / Bazel | no | always (cheap) | whole build |
+| L5 graph (structural) | fold L3 → target/file/option nodes | no | when L3 ran | whole build |
+| L4 source | clang/castxml parse actual TUs | yes | triggered | **POI-scoped** |
+| L5 graph (semantic edges) | include `clang -MM` + call `clang -ast-dump` / Kythe/CodeQL | yes | budgeted | POI / changed |
+
+**Reporting is mandatory and explicit (4a):** every run — not just partial ones —
+prints a per-layer table stating, for each layer, `collected` / `skipped (reason)`
++ how much (TUs/files) + cache-hit rate, plus the confidence per evidence source.
+A reader always sees exactly which depth was reached; there is never a bare
+"source scan ran" without the layer breakdown.
+
 ### Python API — `abicheck/service.py`
 
 ```python

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -132,41 +132,66 @@ One orchestrator command (new `cli_scan.py`). Three modes via the existing
 exit-code contract (ADR-009); `scan` with no source flags degrades to the
 always-on tier over L0–L2.
 
+**The common case is four flags** — current build (binary + headers + sources)
+vs a baseline dump:
+
+```bash
+abicheck scan --binary new/libfoo.so --headers new/include --sources . \
+              --baseline old/libfoo.abi.json
+```
+
+That is the whole basic flow. abicheck **auto-discovers** `compile_commands.json`
+inside `--sources` (or `--build-info`); if it finds one the source tier is
+high-fidelity (real flags/macros), if not it scans with defaults. Everything
+below is optional tuning with sane defaults — for CI scaling and large repos,
+not the basic flow.
+
+**Core flags**
+
 ```text
-abicheck scan [OPTIONS]
+  --binary PATH        library/artifact to scan (repeatable for bundles)
+  --headers PATH       public header file or dir (repeatable)
+  --sources PATH       source tree (compile DB auto-discovered within it)
+  --baseline PATH      previous build's dump (or built lib) to diff against
+```
 
-Inputs
-  --binary PATH                 library/artifact to scan (repeatable for bundles)
-  --headers PATH                public header file or dir (repeatable)
-  --public-header[-dir] PATH    provenance roots (ADR-015), passthrough to dump
-  --compile-db PATH             compile_commands.json → unlocks L3 + targeted L4/L5
-  --build-info PATH             build dir / pack dir (passthrough to collect)
-  --sources PATH                source tree → inline L3/L4/L5
-  --baseline REF|PATH           baseline snapshot/registry ref to diff against
-  --inputs DIR                  ingest a Flow-2 abicheck_inputs/ pack (D5)
+**Optional — inputs**
 
-Scope / escalation
-  --mode [pr|pr-deep|baseline|audit]      default pr (D9 asymmetry)
+```text
+  --public-header[-dir] PATH  provenance roots (ADR-015), passthrough to dump
+  --compile-db PATH           explicit compile_commands.json (only if not under --sources)
+  --build-info PATH           build dir / pack dir instead of a raw source tree
+  --baseline REGISTRY-REF     a baseline-registry name (ADR-022), e.g. libfoo@1.5,
+                              instead of a file — for teams using the registry
+  --inputs DIR                ingest a Flow-2 abicheck_inputs/ pack (D5)
+```
+
+**Optional — scope / escalation (defaults are fine for small/medium repos)**
+
+```text
+  --mode [pr|pr-deep|baseline|audit]   default pr (D9 asymmetry)
   --depth [auto|headers|build|source|full|graph]
-                                          cap evidence depth on the L-axis, in
-                                          increasing depth: headers=L2, build=L3,
-                                          source=L4 scoped, full=L4 full-scope,
-                                          graph=L5. auto = risk-driven. No S0..S6
-                                          selector per ADR-035 D1.
-  --changed-path PATH                     repeatable; seeds risk score + POI (D7)
-  --since GITREF                          derive changed paths from a git range
-  --budget DURATION   (e.g. 15m)          wall-clock ceiling
-  --max-tus N                             targeted-AST TU cap
-  --partial-ok / --no-partial-ok          default on; partial result is success
-  --estimate                              dry-run: print per-level cost, do nothing
-  --audit                                 single-release hygiene lint, no baseline (D8)
+                                       ceiling on how deep to go; default auto
+                                       (risk picks). headers=L2, build=L3,
+                                       source=L4, full=L4 full-scope, graph=L5.
+  --since GITREF                       focus the scan on files changed vs a git
+                                       ref (e.g. origin/main); else scans broadly
+  --changed-path PATH                  same focusing, listed by hand (repeatable)
+  --budget DURATION (e.g. 15m)         CI time ceiling; report what got covered
+  --max-tus N                          targeted-AST TU cap
+  --partial-ok / --no-partial-ok       default on; partial result is success
+  --estimate                           dry-run: print per-layer cost, scan nothing
+  --audit                              single-build hygiene lint, no baseline (D8)
+```
 
-Policy / output
-  --risk-rules PATH               override risk_rules block
-  --crosscheck KEY=LEVEL          repeatable (info|warning|error) (D4/D6)
+**Optional — policy / output**
+
+```text
+  --risk-rules PATH        override the risk_rules block
+  --crosscheck KEY=LEVEL   repeatable (info|warning|error) (D4/D6)
   --format [text|json|markdown|sarif|junit]
   --report PATH
-  -o, --output PATH               write merged snapshot/result
+  -o, --output PATH        write the merged snapshot/result
 ```
 
 Behaviour: `scan` resolves inputs → `dump`s L0–L2 → runs the always-on tier →

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -299,7 +299,7 @@ source:
              source: triggered, graph: budgeted } # L4 replay, L5 graph
 risk_rules:
   public_headers: { paths: ["include/**","public/**"], weight: 50 }
-  build_abi_flags:{ paths: ["CMakeLists.txt","cmake/**","BUILD"], weight: 40 }
+  build_abi_flags: { paths: ["CMakeLists.txt","cmake/**","BUILD"], weight: 40 }
   docs_only:      { paths: ["docs/**","*.md"], weight: -100 }
 crosschecks:
   exported_not_public: warning

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -26,9 +26,11 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
   `public_not_exported`, `header_build_context_mismatch`, `private_header_leak`
   surfaced as correctly-partitioned `RISK`/`API_BREAK` `ChangeKind`s with
   provider-corroborated confidence (ADR-035 D4).
-- **G19.3** Risk-scored escalation + `scan` command: a numeric score selects
-  evidence depth within a budget; one coverage/confidence-annotated report;
-  partial results are first-class (ADR-035 D3).
+- **G19.3** Deterministic `scan` command: the level is the pinned `--mode` preset
+  or an explicit `--source-method`/`--depth`; the numeric risk score selects depth
+  **only** under `--source-method auto` (opt-in), and `--budget` is a failure guard
+  on the chosen level (never shrinks scope). One coverage/confidence-annotated
+  report; partial results are first-class (ADR-035 D3).
 - **G19.4** Build-integrated extraction: a documented dump/facts artifact
   protocol (Flow 2) ingestible via `merge`, plus a Clang-plugin and
   compiler-wrapper provider under the ADR-032 model, normalized facts canonical
@@ -60,11 +62,14 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
 - Add the ADR-035 D4 `ChangeKind`s (RISK/API_BREAK only) following the four-step
   procedure in `/CLAUDE.md`; record corroborating providers → `LayerConfidence`.
 
-### Phase 3 — Risk score + budgeted `scan` orchestrator (G19.3)
-- Promote `source_replay.recommend_collect_mode()` to a scored function driven by
-  a `risk_rules` config block; thresholds map to existing collect-modes.
+### Phase 3 — Deterministic `scan` orchestrator (G19.3)
 - New `abicheck/cli_scan.py` (sibling-module registration per `/CLAUDE.md`):
-  classify → always-on tier → escalate within budget → single coverage report.
+  classify → always-on tier → run the **pinned** level (`--mode` preset or
+  explicit `--source-method`/`--depth`), POI-focused → single coverage report.
+- Promote `source_replay.recommend_collect_mode()` to a scored function driven by
+  a `risk_rules` config block — used **only** for `--source-method auto` (opt-in)
+  and POI focusing, never to silently change a pinned CI run. `--budget` is a
+  failure guard on the chosen level, not an escalation driver.
 
 ### Phase 3b — Evidence-directed focusing + API/estimate (G19.5, G19.7)
 - POI builder: from L0/L1/L2 deltas + risk score, produce a work-list consumed by
@@ -129,8 +134,9 @@ existing `dump`/`compare`/`collect` signatures.
 ### CLI — `abicheck scan`
 
 One orchestrator command (new `cli_scan.py`). Three modes via the existing
-exit-code contract (ADR-009); `scan` with no source flags degrades to the
-always-on tier over L0–L2.
+exit-code contract (ADR-009); `scan` with no source flags degrades to L0/L1 +
+the always-on lexical tier (L2 header-AST added only when castxml is present,
+else reported as skipped — not part of the no-compiler path).
 
 **The common case is four flags** — current build (binary + headers + sources)
 vs a baseline dump:

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -175,8 +175,9 @@ not the basic flow.
                                        deterministic. auto = risk-driven (opt-in,
                                        local/dev). See the level table below.
   --depth [headers|build|source|full|graph]
-                                       same target expressed on the L-axis
-                                       (1:1 with --source-method); pick one.
+                                       coarse L-axis selector → representative S
+                                       (lossy: can't reach S2/S3). --source-method
+                                       is precise and wins if both given.
   --since GITREF                       focus the scan on files changed vs a git
                                        ref (e.g. origin/main); else scans broadly
   --changed-path PATH                  same focusing, listed by hand (repeatable)
@@ -242,31 +243,36 @@ depth (S0…S6) was reached and into which L-layer it landed; never a bare
 ### Selecting the level: `--source-method` (S) and/or `--depth` (L)
 
 The level is an **explicit, exact target you choose** — not a ceiling, not
-auto-picked. Pick whichever axis you think in; they describe the same run:
+auto-picked. Two related knobs, **not 1:1**:
 
 ```text
-  --source-method [s0|s1|s2|s3|s4|s5|s6]   run source analysis AT this method
-  --depth [headers|build|source|full|graph]   express the target as an L ceiling
+  --source-method [s0|s1|s2|s3|s4|s5|s6]   precise: run source analysis AT this method
+  --depth [headers|build|source|full|graph]   coarse: pick by L-layer (maps to a
+                                               representative S; can't express every S)
 ```
 
-`--source-method sN` means *reach level N* for the in-scope files — deterministic:
-same inputs → same scan, every CI run. It is not a "max that may do less"; it
-always reaches N (the only way it falls short is a genuinely missing tool, e.g. no
-clang, which is **reported**, not silently downgraded). The two knobs map 1:1, so
-you never need both:
+`--source-method sN` is the **precise** knob — *reach exactly method N* for the
+in-scope files, deterministic (same inputs → same scan). It is not a "max that may
+do less"; it always reaches N (only a genuinely missing tool, e.g. no clang, makes
+it fall short, and that is **reported**, not silently downgraded).
 
-| `--source-method` | equivalent `--depth` | populates (L) |
-|---|---|---|
-| s0 | (classify only) | — |
-| s1 | build | L3 |
-| s2 | build (+macros/includes) | L3, L5 structural |
-| s3 | (pre-scan) | pre-scan facts |
-| s4 | graph | L5 semantic edges |
-| s5 | source | L4 (scoped) + L5 edges |
-| s6 | full | L4 full-scope |
+`--depth` is a **coarse convenience** for users who think in evidence layers. The
+S→L map is **lossy**, so `--depth` resolves to a *representative* S per layer and
+**cannot reach some methods**: `--depth build` runs S1 (not S2 — preprocessor
+macros/includes), and S3 (lexical pre-scan, always on anyway) has no `--depth`
+form. To pin S2 or force S3 you must use `--source-method`.
 
-If both are given and disagree, the engine takes the **higher** (more evidence),
-deterministically — never the lower. There is no `min()`/cap behaviour.
+| If you pass… | runs S | populates (L) | precise S only via `--source-method`? |
+|---|---|---|---|
+| `--depth headers` | — | L2 | — |
+| `--depth build` | S1 | L3 | S2 needs `--source-method s2` |
+| `--depth graph` | S4 | L5 edges | — |
+| `--depth source` | S5 | L4 scoped + L5 edges | — |
+| `--depth full` | S6 | L4 full-scope | — |
+| `--source-method s0..s6` | exactly that | per S | this *is* the precise knob |
+
+`--source-method` is authoritative: if both are given, it wins (it can express
+things `--depth` cannot). There is no `min()`/cap behaviour.
 
 ### Determinism for CI (no time-bound, no auto by default)
 
@@ -296,9 +302,10 @@ class ScanRequest:
     inputs_pack: Path | None = None
     baseline: str | Path | None = None
     mode: ScanMode = ScanMode.PR            # PR | PR_DEEP | BASELINE | AUDIT (fixed preset)
-    # Pick the level on either axis (1:1); SourceMethod.AUTO = opt-in risk-driven.
+    # source_method is precise (S-axis); depth is a coarse L-axis selector (lossy
+    # S→L: can't express S2/S3). source_method wins if both set. AUTO = opt-in.
     source_method: SourceMethod | None = None   # S0..S6 | AUTO; None = use mode preset
-    depth: EvidenceLayer | None = None          # same target on the L-axis; None = use mode preset
+    depth: EvidenceLayer | None = None          # coarse L target; None = use mode preset
     changed_paths: list[str] = field(default_factory=list)
     budget: Budget = Budget()               # total_timeout, max_tus, partial_ok
     risk_rules: RiskRules | None = None

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -1,0 +1,97 @@
+# G19 — PR-Tier Source Intelligence & Cross-Source Validation
+
+**ADR:** [ADR-035](../adr/035-pr-tier-source-intelligence-and-crosscheck.md)
+**Type:** Initiative plan (not a `usecase-registry.yaml` gap; multi-phase)
+**Effort:** XL (phased) · **Risk:** medium — new `ChangeKind`s and an optional
+compiler-version-sensitive plugin; mitigated by keeping everything advisory and
+behind the portable replay path.
+
+## Problem
+
+abicheck's optional build/source evidence stack (L3/L4/L5, ADR-028…033) already
+covers compile-DB scanning, scoped per-TU AST replay, and the source graph —
+but it has **no cheap always-on PR tier**, **no cross-source validation
+findings**, and **no build-integrated fact ingestion or unified `scan` UX**. A
+field proposal re-derived much of the existing stack as an `S0..S6` ladder; the
+genuinely-new value is exactly those three gaps. ADR-035 records the decision to
+close them as *extensions of the existing L-layers*, preserving the ADR-028 D3
+authority rule (L0–L2 stay authoritative for `BREAKING`).
+
+## Goal & acceptance criteria
+
+- **G19.1** Compiler-free PR pre-scan: changed+public files scanned for ABI-risk
+  patterns, emitting advisory facts + escalation triggers, no compile DB needed.
+- **G19.2** Cross-source validation: at least `exported_not_public`,
+  `public_not_exported`, `header_build_context_mismatch`, `private_header_leak`
+  surfaced as correctly-partitioned `RISK`/`API_BREAK` `ChangeKind`s with
+  provider-corroborated confidence.
+- **G19.3** Risk-scored escalation + `scan` command: a numeric score selects
+  evidence depth within a budget; one coverage/confidence-annotated report;
+  partial results are first-class.
+- **G19.4** Build-integrated extraction: a documented dump/facts artifact
+  protocol (Flow 2) ingestible via `merge`, plus a Clang-plugin and
+  compiler-wrapper provider under the ADR-032 model, normalized facts canonical.
+- **Acceptance gate:** every new `ChangeKind` passes the import-time partition
+  assertion, the AI-readiness `changekind-*` checks, and earns FP-rate-gate
+  corpus cases before it is allowed to gate.
+
+## Design (phases)
+
+### Phase 1 — Compiler-free PR pre-scan (G19.1)
+- New `abicheck/buildsource/pattern_scan.py`: stdlib-regex scanner over changed +
+  public files for the ADR-035 D2 construct list; emits normalized advisory
+  facts + escalation triggers. Tree-sitter is a pluggable later backend.
+- Extend `buildsource/include_graph.py`: per-TU ABI-macro-value capture and
+  private/generated-header-leak detection when a compile DB is present.
+
+### Phase 2 — Cross-source validation engine (G19.2)
+- New `abicheck/buildsource/crosscheck.py` consuming one merged snapshot.
+- Add the ADR-035 D4 `ChangeKind`s (RISK/API_BREAK only) following the four-step
+  procedure in `/CLAUDE.md`; record corroborating providers → `LayerConfidence`.
+
+### Phase 3 — Risk score + budgeted `scan` orchestrator (G19.3)
+- Promote `source_replay.recommend_collect_mode()` to a scored function driven by
+  a `risk_rules` config block; thresholds map to existing collect-modes.
+- New `abicheck/cli_scan.py` (sibling-module registration per `/CLAUDE.md`):
+  classify → always-on tier → escalate within budget → single coverage report.
+
+### Phase 4 — Build-integrated extraction (G19.4)
+- Define the `abicheck_inputs/` dump/facts artifact protocol; ingest via existing
+  `merge`. Normalized `source_facts/*.jsonl` preferred; raw AST debug-only.
+- Clang-plugin + `abicheck-cc` wrapper as ADR-032 manifest extractors. GCC/MSVC
+  dump fallbacks documented, not required.
+
+## Files & surfaces
+
+- New: `buildsource/pattern_scan.py`, `buildsource/crosscheck.py`,
+  `cli_scan.py`; new `ChangeKind`s in `checker_policy.py`.
+- Extend: `buildsource/include_graph.py`, `buildsource/source_replay.py`,
+  `buildsource/inline.py` (config), `reporter.py` (coverage/confidence block),
+  `pyproject.toml` (`disallow_untyped_decorators` for `cli_scan`),
+  `IMPORT_CYCLE_ALLOWLIST` if `scan` registration flags a cycle.
+
+## Tests
+
+- Unit: pattern scanner fixtures (each construct), macro-divergence and
+  header-leak detection, each cross-check finding, risk-score thresholds,
+  `scan` partial-coverage reporting.
+- FP-rate gate (`scripts/check_fp_rate.py`): internal-noise pairs stay
+  non-breaking; real cross-check breaks stay flagged — before any kind gates.
+- Pre-captured artifact-protocol fixture round-trips through `merge` (non-
+  executing, no compiler in CI), mirroring the ADR-028 D6 pattern used by G18.
+
+## Example fixtures
+
+- A `case*/` pair exercising `exported_not_public` and `header_build_context_
+  mismatch`, with `README.md` + `ground_truth.json` entries (examples gate).
+
+## Effort & risk
+
+- Phase 1–2: M each, high value/cost. Phase 3: M. Phase 4: L (plugin maintenance
+  + protocol design). Recommended order is 1 → 2 → 3 → 4; Phase 4's plugin is an
+  optimization and can trail.
+
+## Out of scope
+
+- Re-numbering or replacing L0–L5; clangd-index integration; making any
+  source/cross-check finding authoritative for a `BREAKING` verdict.

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -229,19 +229,22 @@ graduated techniques, not one AST step; each S-method runs and lands in an L-lay
 |---|---|---|---|---|---|---|
 | classify (D0/D3) | S0 | git diff → risk tags/score | no | — (drives focus) | always | changed |
 | pre-scan patterns (D2) | S3 | regex/Tree-sitter over changed+public | no | pre-scan → L2/L5 | always | changed+public |
-| L2 headers | — | castxml (headers) / DWARF (binary) | castxml for header-AST | L2 | when castxml present (else skipped, reported); DWARF L2 if debug info | public surface |
+| L2 headers | — | castxml over public headers | castxml for header-AST | L2 | when castxml present (else skipped, reported) | public surface |
+| L1 debug info | — | DWARF / PDB / dSYM from binary | no | L1 | when debug info present | binary artifact |
 | L3 build | S1 | parse `compile_commands.json` / CMake / Ninja / Bazel | no | L3 | always (cheap) | whole build |
 | preprocessor (D2) | S2 | `clang -E` macros / `-MM` includes | (cpp) | L3→L5 | when DB present | changed+public |
 | L5 graph (structural) | S2 fold | fold L3 → target/file/option nodes | no | L5 | when L3 ran | whole build |
 | L4 source | S5 / S6 | clang/castxml parse actual TUs | yes | L4 | triggered (S5); baseline (S6) | **POI-scoped** (S5) / all (S6) |
-| L5 graph (semantic) | S4 / S5 | clangd-index / call `clang -ast-dump` / Kythe/CodeQL | yes | L5 | budgeted | POI / changed |
+| L5 graph (semantic) | S4 / S5 | clangd-index / call `clang -ast-dump` / Kythe/CodeQL | yes | L5 | pinned scope or skipped for missing tools | POI / changed |
 
 The L5 graph is **not** fully built by default — only the cheap S2 structural fold
-is; the S4/S5 semantic edges are budget-gated. S6 (full AST) is baseline/manual,
-never the default PR.
+is. When `--depth graph` or an S4/S5 method is pinned, semantic edges run to the
+pinned scope or fail on budget overflow; budgets never reduce the graph scope. S6
+(full AST) is baseline/manual, never the default PR.
 
 **Reporting is mandatory and explicit (4a):** every run — not just partial ones —
-prints a table stating, for each layer **and the S-method that produced it**,
+prints a table stating, for each layer **and the S-method that produced it when
+there is one**,
 `collected` / `skipped (reason)` + how much (TUs/files) + cache-hit rate, plus the
 confidence per evidence source. A reader always sees exactly which source-analysis
 depth (S0…S6) was reached and into which L-layer it landed; never a bare
@@ -295,7 +298,8 @@ machine or the clock:
 - POI focusing (D7) only selects *which* in-scope TUs get the chosen method; for a
   fixed diff it is deterministic, so it does not affect CI consistency.
 
-`.abicheck.yml` mirror: `source.method: s5` (exact level; `auto` only if opted in).
+`.abicheck.yml` mirror: `source.method: s5` (exact level; `auto` only if opted in)
+and `source.depth: graph` (coarse L-axis selector).
 
 ### Python API — `abicheck/service.py`
 
@@ -320,7 +324,7 @@ class ScanRequest:
 
 @dataclass(frozen=True)
 class CostEstimate:
-    method: SourceMethod               # S-axis: S0..S6
+    method: SourceMethod | None        # S-axis: S0..S6; None for intrinsic L0-L2
     layer: EvidenceLayer               # L-axis it populates: L2_HEADER..L5_SOURCE_GRAPH
     tus: int
     est_seconds: float
@@ -329,7 +333,7 @@ class CostEstimate:
 
 @dataclass(frozen=True)
 class LayerResult:
-    method: SourceMethod               # which S-method ran
+    method: SourceMethod | None        # which S-method ran; None for intrinsic L0-L2
     layer: EvidenceLayer               # which L-layer it populated
     coverage: LayerCoverage            # reuse buildsource.model
     facts: int
@@ -361,11 +365,12 @@ the authority axis), and **`SourceMethod` is the S-axis** (`S0..S6` + `AUTO`) �
 *distinct* enum, not banned and not collapsed onto `EvidenceLayer` (the S→L map is
 lossy: S1≠S2 both touch L3, S3 has no L). A provider declares both the method it
 implements and the layer it populates, so a request that pins `source_method=S2`
-runs the right provider:
+runs the right provider. Intrinsic artifact/header providers set `method = None`
+because L0/L1/L2 evidence is not produced by an S-method:
 
 ```python
 class LayerProvider(Protocol):
-    method: SourceMethod                 # S-axis: which source-analysis method
+    method: SourceMethod | None          # S-axis method, or None for intrinsic L0-L2
     layer: EvidenceLayer                 # L-axis: which evidence layer it populates
     def capabilities(self) -> ProviderCapabilities: ...
     def estimate(self, ctx: ScanContext) -> CostEstimate: ...
@@ -395,9 +400,11 @@ schema as the Python API — one contract, three front-ends (CLI, MCP, library).
 
 ```yaml
 source:
+  method: s5     # exact S-axis selector; may be auto only when opt-in is intended
+  depth: source  # coarse L-axis selector; method wins if both are set
   budgets: { total_timeout: 15m, max_targeted_tus: 80, partial_ok: true }
   layers:  { headers: always, build: always,     # L2 pre-scan, L3 build
-             source: triggered, graph: budgeted } # L4 replay, L5 graph
+             source: triggered, graph: triggered } # L4 replay, L5 graph; budget overflow fails
 risk_rules:
   public_headers: { paths: ["include/**","public/**"], weight: 50 }
   build_abi_flags: { paths: ["CMakeLists.txt","cmake/**","BUILD"], weight: 40 }

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -318,7 +318,7 @@ class ScanRequest:
     source_method: SourceMethod | None = None   # S0..S6 | AUTO; None = use mode preset
     depth: EvidenceLayer | None = None          # coarse L target; None = use mode preset
     changed_paths: list[str] = field(default_factory=list)
-    budget: Budget = Budget()               # total_timeout, max_tus, partial_ok
+    budget: Budget = field(default_factory=Budget)  # total_timeout, max_tus, partial_ok
     risk_rules: RiskRules | None = None
     crosschecks: dict[str, Severity] = field(default_factory=dict)
 

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -202,26 +202,35 @@ cost probe; `--audit` runs intra-version (ignores `--baseline`).
 Convenience subcommands (thin wrappers, same engine):
 `abicheck scan estimate …` ≡ `--estimate`; `abicheck scan audit …` ≡ `--audit`.
 
-### How each layer is collected (and whether it always runs)
+### The two axes: L-layers (evidence) and S-methods (source analysis)
 
-Each L-layer uses a different method; the expensive ones are scoped or gated, so
-not everything runs on every PR. The L5 graph is **not** fully built by default —
-only the cheap structural fold is, the semantic edges are budget-gated.
+Per ADR-035 D1 these are orthogonal. **L** = where the evidence lives + authority
+(the user-facing depth/`--depth` axis). **S** = the six cost-ordered *source-
+analysis methods* that produce L3–L5 evidence (the internal provider ladder + the
+reporting granularity). Source analysis is genuinely six graduated techniques, not
+one AST step; each S-method runs and its output lands in an L-layer:
 
-| Layer | How collected | Compiler? | Default PR | Scope |
-|---|---|---|---|---|
-| pre-scan (D2) | regex/lexical over changed+public files | no | always | changed+public |
-| L2 headers | castxml / DWARF (existing) | no | always | public surface |
-| L3 build | parse `compile_commands.json` / CMake / Ninja / Bazel | no | always (cheap) | whole build |
-| L5 graph (structural) | fold L3 → target/file/option nodes | no | when L3 ran | whole build |
-| L4 source | clang/castxml parse actual TUs | yes | triggered | **POI-scoped** |
-| L5 graph (semantic edges) | include `clang -MM` + call `clang -ast-dump` / Kythe/CodeQL | yes | budgeted | POI / changed |
+| Provider | S-method | How collected | Compiler? | Produces (L) | Default PR | Scope |
+|---|---|---|---|---|---|---|
+| classify (D0/D3) | S0 | git diff → risk tags/score | no | — (drives focus) | always | changed |
+| pre-scan patterns (D2) | S3 | regex/Tree-sitter over changed+public | no | pre-scan → L2/L5 | always | changed+public |
+| L2 headers | — | castxml / DWARF (existing) | no | L2 | always | public surface |
+| L3 build | S1 | parse `compile_commands.json` / CMake / Ninja / Bazel | no | L3 | always (cheap) | whole build |
+| preprocessor (D2) | S2 | `clang -E` macros / `-MM` includes | (cpp) | L3→L5 | when DB present | changed+public |
+| L5 graph (structural) | S2 fold | fold L3 → target/file/option nodes | no | L5 | when L3 ran | whole build |
+| L4 source | S5 / S6 | clang/castxml parse actual TUs | yes | L4 | triggered (S5); baseline (S6) | **POI-scoped** (S5) / all (S6) |
+| L5 graph (semantic) | S4 / S5 | clangd-index / call `clang -ast-dump` / Kythe/CodeQL | yes | L5 | budgeted | POI / changed |
+
+The L5 graph is **not** fully built by default — only the cheap S2 structural fold
+is; the S4/S5 semantic edges are budget-gated. S6 (full AST) is baseline/manual,
+never the default PR.
 
 **Reporting is mandatory and explicit (4a):** every run — not just partial ones —
-prints a per-layer table stating, for each layer, `collected` / `skipped (reason)`
-+ how much (TUs/files) + cache-hit rate, plus the confidence per evidence source.
-A reader always sees exactly which depth was reached; there is never a bare
-"source scan ran" without the layer breakdown.
+prints a table stating, for each layer **and the S-method that produced it**,
+`collected` / `skipped (reason)` + how much (TUs/files) + cache-hit rate, plus the
+confidence per evidence source. A reader always sees exactly which source-analysis
+depth (S0…S6) was reached and into which L-layer it landed; never a bare
+"source scan ran".
 
 ### Python API — `abicheck/service.py`
 

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -208,11 +208,11 @@ Convenience subcommands (thin wrappers, same engine):
 
 ### The two axes: L-layers (evidence) and S-methods (source analysis)
 
-Per ADR-035 D1 these are orthogonal. **L** = where the evidence lives + authority
-(the user-facing depth/`--depth` axis). **S** = the six cost-ordered *source-
-analysis methods* that produce L3–L5 evidence (the internal provider ladder + the
-reporting granularity). Source analysis is genuinely six graduated techniques, not
-one AST step; each S-method runs and its output lands in an L-layer:
+Per ADR-035 D1 these are orthogonal, and **both are user-selectable**. **L** =
+where the evidence lives + authority (`--depth`). **S** = the six cost-ordered
+*source-analysis methods* that produce L3–L5 evidence (`--source-method`), also
+the granularity at which coverage is reported. Source analysis is genuinely six
+graduated techniques, not one AST step; each S-method runs and lands in an L-layer:
 
 | Provider | S-method | How collected | Compiler? | Produces (L) | Default PR | Scope |
 |---|---|---|---|---|---|---|

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -120,6 +120,158 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
   + protocol design). Recommended order is 1 → 2 → 3 → 4; Phase 4's plugin is an
   optimization and can trail.
 
+## API & CLI surface (proposed)
+
+Concrete definition of the new functionality. All additive; nothing here changes
+existing `dump`/`compare`/`collect` signatures.
+
+### CLI — `abicheck scan`
+
+One orchestrator command (new `cli_scan.py`). Three modes via the existing
+exit-code contract (ADR-009); `scan` with no source flags degrades to the
+always-on tier over L0–L2.
+
+```text
+abicheck scan [OPTIONS]
+
+Inputs
+  --binary PATH                 library/artifact to scan (repeatable for bundles)
+  --headers PATH                public header file or dir (repeatable)
+  --public-header[-dir] PATH    provenance roots (ADR-015), passthrough to dump
+  --compile-db PATH             compile_commands.json → unlocks L3 + targeted L4/L5
+  --build-info PATH             build dir / pack dir (passthrough to collect)
+  --sources PATH                source tree → inline L3/L4/L5
+  --baseline REF|PATH           baseline snapshot/registry ref to diff against
+  --inputs DIR                  ingest a Flow-2 abicheck_inputs/ pack (D5)
+
+Scope / escalation
+  --mode [pr|pr-deep|baseline|audit]      default pr (D9 asymmetry)
+  --source-scan-level [S0..S6|auto]       cap/force depth (auto = risk-driven)
+  --changed-path PATH                     repeatable; seeds risk score + POI (D7)
+  --since GITREF                          derive changed paths from a git range
+  --budget DURATION   (e.g. 15m)          wall-clock ceiling
+  --max-tus N                             targeted-AST TU cap
+  --partial-ok / --no-partial-ok          default on; partial result is success
+  --estimate                              dry-run: print per-level cost, do nothing
+  --audit                                 single-release hygiene lint, no baseline (D8)
+
+Policy / output
+  --risk-rules PATH               override risk_rules block
+  --crosscheck KEY=LEVEL          repeatable (info|warning|error) (D4/D6)
+  --format [text|json|markdown|sarif|junit]
+  --report PATH
+  -o, --output PATH               write merged snapshot/result
+```
+
+Behaviour: `scan` resolves inputs → `dump`s L0–L2 → runs the always-on tier →
+computes a risk score + POI set → escalates L3/L4/L5 within budget → (if
+`--baseline`) `compare`s → emits one `ScanResult`. `--estimate` stops after the
+cost probe; `--audit` runs intra-version (ignores `--baseline`).
+
+Convenience subcommands (thin wrappers, same engine):
+`abicheck scan estimate …` ≡ `--estimate`; `abicheck scan audit …` ≡ `--audit`.
+
+### Python API — `abicheck/service.py`
+
+```python
+@dataclass(frozen=True)
+class ScanRequest:
+    binaries: list[Path]
+    headers: list[Path] = field(default_factory=list)
+    compile_db: Path | None = None
+    sources: Path | None = None
+    inputs_pack: Path | None = None
+    baseline: str | Path | None = None
+    mode: ScanMode = ScanMode.PR            # PR | PR_DEEP | BASELINE | AUDIT
+    level_cap: SourceScanLevel | None = None  # S0..S6; None = auto
+    changed_paths: list[str] = field(default_factory=list)
+    budget: Budget = Budget()               # total_timeout, max_tus, partial_ok
+    risk_rules: RiskRules | None = None
+    crosschecks: dict[str, Severity] = field(default_factory=dict)
+
+@dataclass(frozen=True)
+class CostEstimate:
+    level: SourceScanLevel
+    tus: int
+    est_seconds: float
+    cache_hit_rate: float
+    note: str
+
+@dataclass(frozen=True)
+class LevelResult:
+    level: SourceScanLevel
+    coverage: LayerCoverage            # reuse buildsource.model
+    facts: int
+    elapsed_s: float
+    skipped_reason: str | None = None
+
+@dataclass(frozen=True)
+class ScanResult:
+    diff: DiffResult | None            # None in --audit (no baseline)
+    findings: list[DiffResult]         # incl. new crosscheck ChangeKinds (D4)
+    levels: list[LevelResult]          # per-tier coverage (D3/D10)
+    confidence: dict[str, str]         # provider-agreement matrix (§6.8)
+    estimate: list[CostEstimate]       # projected vs. actual
+    verdict: Verdict
+    exit_code: int
+
+def run_scan(req: ScanRequest) -> ScanResult: ...
+def estimate_scan(req: ScanRequest) -> list[CostEstimate]: ...   # no scanning
+def run_audit(req: ScanRequest) -> ScanResult: ...               # mode=AUDIT
+```
+
+### Per-level provider protocol — `abicheck/buildsource/`
+
+Every level (`pattern_scan`, `preprocessor`, L3 build, L4 replay, L5 graph,
+`crosscheck`) implements one interface, modelled on the ADR-032 `DataExtractor`,
+so levels are independently runnable (ADR-033 D1) and external/build-emitted
+providers (D5) drop in unchanged:
+
+```python
+class SourceLevelProvider(Protocol):
+    level: SourceScanLevel
+    def capabilities(self) -> ProviderCapabilities: ...
+    def estimate(self, ctx: ScanContext) -> CostEstimate: ...
+    def run(self, ctx: ScanContext, poi: PointsOfInterest) -> LevelFacts: ...
+
+@dataclass(frozen=True)
+class ScanContext:                      # shared, read-only inputs to every level
+    snapshot: AbiSnapshot               # L0–L2 already parsed
+    compile_db: Path | None
+    changed_paths: list[str]
+    budget: Budget
+    cache: SourceFactCache
+```
+
+`PointsOfInterest` (new `buildsource/poi.py`) is the D7 work-list — a set of
+`(symbol|entity|tu, reason)` computed from L0/L1/L2 deltas + risk score, consumed
+by `source_replay` scope selection and `crosscheck`.
+
+### MCP tools — `abicheck/mcp_server.py`
+
+Three agent tools wrapping the service API (ADR-021b security model):
+`abicheck_scan(request) -> ScanResult`, `abicheck_audit(request) -> ScanResult`,
+`abicheck_estimate(request) -> [CostEstimate]`. Same `ScanRequest`/`ScanResult`
+schema as the Python API — one contract, three front-ends (CLI, MCP, library).
+
+### Config — `.abicheck.yml` (additive)
+
+```yaml
+source:
+  budgets: { total_timeout: 15m, max_targeted_tus: 80, partial_ok: true }
+  levels:  { S0: always, S1: always, S2: always, S3: always,
+             S4: triggered, S5: triggered, S6: budgeted }
+risk_rules:
+  public_headers: { paths: ["include/**","public/**"], weight: 50 }
+  build_abi_flags:{ paths: ["CMakeLists.txt","cmake/**","BUILD"], weight: 40 }
+  docs_only:      { paths: ["docs/**","*.md"], weight: -100 }
+crosschecks:
+  exported_not_public: warning
+  header_build_context_mismatch: error
+  private_header_leak: warning
+  odr_type_variant: error
+```
+
 ## Use-case tracking
 
 Six new `planned` entries are registered in `usecase-registry.yaml` under gap

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -290,7 +290,12 @@ For reproducible gating, the scan scope is fixed by the level you pick, not by t
 machine or the clock:
 
 - **Default per `--mode` is a fixed preset**, not risk-varying: `pr` = S1 + S3
-  always-on + targeted S5; `baseline` = S6. Same commit pair → identical scan.
+  always-on + targeted S5; `baseline` = S6. **Same commit pair + same toolchain →
+  identical scan.** Determinism is toolchain-relative: S5/S6 need a compiler (and
+  castxml/clang), so a missing tool is a **reported skip**, never a silent
+  downgrade. For reproducible gates, pin the toolchain (fixed CI image) as well as
+  the level — otherwise a host without the compiler reaches a shallower depth (and
+  the report says so).
 - **`auto`** (risk-driven escalation, D3) is **opt-in** (`--source-method auto`),
   for local/dev only — never the silent CI default.
 - **`--budget`** is optional and, on overflow, **fails** (nonzero exit); it never

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -1,7 +1,8 @@
 # G19 — PR-Tier Source Intelligence & Cross-Source Validation
 
 **ADR:** [ADR-035](../adr/035-pr-tier-source-intelligence-and-crosscheck.md)
-**Type:** Initiative plan (not a `usecase-registry.yaml` gap; multi-phase)
+**Type:** Initiative plan (multi-phase); tracked by six `planned`
+`usecase-registry.yaml` entries under gap G19 (see *Use-case tracking*)
 **Effort:** XL (phased) · **Risk:** medium — new `ChangeKind`s and an optional
 compiler-version-sensitive plugin; mitigated by keeping everything advisory and
 behind the portable replay path.
@@ -146,12 +147,12 @@ Inputs
 
 Scope / escalation
   --mode [pr|pr-deep|baseline|audit]      default pr (D9 asymmetry)
-  --depth [auto|headers|build|source|graph|full]
-                                          cap evidence depth on the L-axis
-                                          (headers=L2, build=L3, source=L4,
-                                          graph=L5, full=L4 full-scope);
-                                          auto = risk-driven. No S0..S6 selector
-                                          per ADR-035 D1.
+  --depth [auto|headers|build|source|full|graph]
+                                          cap evidence depth on the L-axis, in
+                                          increasing depth: headers=L2, build=L3,
+                                          source=L4 scoped, full=L4 full-scope,
+                                          graph=L5. auto = risk-driven. No S0..S6
+                                          selector per ADR-035 D1.
   --changed-path PATH                     repeatable; seeds risk score + POI (D7)
   --since GITREF                          derive changed paths from a git range
   --budget DURATION   (e.g. 15m)          wall-clock ceiling
@@ -212,8 +213,10 @@ class LayerResult:
 
 @dataclass(frozen=True)
 class ScanResult:
-    diff: DiffResult | None            # None in --audit (no baseline)
-    findings: list[DiffResult]         # incl. new crosscheck ChangeKinds (D4)
+    diff: DiffResult | None            # whole comparison; None in --audit (no baseline)
+    findings: list[Change]             # individual Change objects, incl. new
+                                       # crosscheck ChangeKinds (D4); == diff.changes
+                                       # when a baseline is given
     layers: list[LayerResult]          # per-layer coverage (D3/D10)
     confidence: dict[str, str]         # provider-agreement matrix (§6.8)
     estimate: list[CostEstimate]       # projected vs. actual
@@ -240,7 +243,7 @@ class LayerProvider(Protocol):
     layer: EvidenceLayer
     def capabilities(self) -> ProviderCapabilities: ...
     def estimate(self, ctx: ScanContext) -> CostEstimate: ...
-    def run(self, ctx: ScanContext, poi: PointsOfInterest) -> LevelFacts: ...
+    def run(self, ctx: ScanContext, poi: PointsOfInterest) -> LayerFacts: ...
 
 @dataclass(frozen=True)
 class ScanContext:                      # shared, read-only inputs to every level

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -232,6 +232,46 @@ confidence per evidence source. A reader always sees exactly which source-analys
 depth (S0…S6) was reached and into which L-layer it landed; never a bare
 "source scan ran".
 
+### Two CLI knobs: `--depth` (L) and `--max-source-method` (S)
+
+The S-axis is controllable, but as a **cost cap**, not a parallel selector
+(ADR-035 D1: L stays the authority/primary axis):
+
+```text
+  --depth [auto|headers|build|source|full|graph]   WHAT evidence (L-axis ceiling)
+  --max-source-method [auto|s0|s1|s2|s3|s4|s5|s6]   HOW expensive source analysis
+                                                    may get (S-axis cost cap)
+```
+
+Both default `auto`. They compose by `min()`: each L-layer needs a minimum
+S-method, the engine runs the **cheapest S that yields the requested L**, and
+never exceeds the S-cap or `--budget`. Effective work =
+`min(what --depth needs, --max-source-method, --budget)`.
+
+Minimum S per L-layer:
+
+| Want (L) | Needs (min S) |
+|---|---|
+| L2 headers | — (castxml, not S-scaled) |
+| L3 build | S1 |
+| L5 structural | S2 |
+| L5 semantic edges | S4 |
+| L4 source | S5 (scoped) / S6 (full) |
+
+**Conflict rule:** if `--depth` requests a layer whose minimum S exceeds the cap,
+that layer is reported `skipped (source-method cap sN < required sM)` — never an
+error. The S-cap wins on cost; `--depth` is best-effort within it. Examples:
+
+```bash
+abicheck scan ... --max-source-method s2          # build+preprocessor, no AST; L4 skipped (cap)
+abicheck scan ... --depth source --max-source-method s3  # L4 not materialized; report says why
+abicheck scan ... --depth full --max-source-method s6    # forensic deep
+```
+
+99% of users set neither — `auto` + risk score + `--budget` pick. The S-cap is for
+guards like "this CI job must never invoke the compiler/AST". `.abicheck.yml`
+mirror: `source.max_method: s5`.
+
 ### Python API — `abicheck/service.py`
 
 ```python

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -198,10 +198,13 @@ not the basic flow.
   -o, --output PATH        write the merged snapshot/result
 ```
 
-Behaviour: `scan` resolves inputs → `dump`s L0–L2 → runs the always-on tier →
-computes a risk score + POI set → escalates L3/L4/L5 within budget → (if
-`--baseline`) `compare`s → emits one `ScanResult`. `--estimate` stops after the
-cost probe; `--audit` runs intra-version (ignores `--baseline`).
+Behaviour (deterministic by default): `scan` resolves inputs → `dump`s L0–L2 →
+runs the always-on tier → runs the **pinned** level (from `--mode`'s preset or an
+explicit `--source-method`/`--depth`), POI-focused (D7) → (if `--baseline`)
+`compare`s → emits one `ScanResult`. Risk scoring escalates the level **only** when
+`--source-method auto` is set (opt-in); a `--budget`, if set, is a failure guard
+that errors on overflow and never shrinks the pinned scope. `--estimate` stops
+after the cost probe; `--audit` runs intra-version (ignores `--baseline`).
 
 Convenience subcommands (thin wrappers, same engine):
 `abicheck scan estimate …` ≡ `--estimate`; `abicheck scan audit …` ≡ `--audit`.
@@ -292,8 +295,10 @@ class ScanRequest:
     sources: Path | None = None
     inputs_pack: Path | None = None
     baseline: str | Path | None = None
-    mode: ScanMode = ScanMode.PR            # PR | PR_DEEP | BASELINE | AUDIT
-    depth_cap: EvidenceDepth | None = None    # L-axis cap (see DataLayer); None = auto
+    mode: ScanMode = ScanMode.PR            # PR | PR_DEEP | BASELINE | AUDIT (fixed preset)
+    # Pick the level on either axis (1:1); SourceMethod.AUTO = opt-in risk-driven.
+    source_method: SourceMethod | None = None   # S0..S6 | AUTO; None = use mode preset
+    depth: EvidenceLayer | None = None          # same target on the L-axis; None = use mode preset
     changed_paths: list[str] = field(default_factory=list)
     budget: Budget = Budget()               # total_timeout, max_tus, partial_ok
     risk_rules: RiskRules | None = None
@@ -301,7 +306,8 @@ class ScanRequest:
 
 @dataclass(frozen=True)
 class CostEstimate:
-    layer: EvidenceLayer               # L-axis: L2_HEADER..L5_SOURCE_GRAPH
+    method: SourceMethod               # S-axis: S0..S6
+    layer: EvidenceLayer               # L-axis it populates: L2_HEADER..L5_SOURCE_GRAPH
     tus: int
     est_seconds: float
     cache_hit_rate: float
@@ -309,7 +315,8 @@ class CostEstimate:
 
 @dataclass(frozen=True)
 class LayerResult:
-    layer: EvidenceLayer
+    method: SourceMethod               # which S-method ran
+    layer: EvidenceLayer               # which L-layer it populated
     coverage: LayerCoverage            # reuse buildsource.model
     facts: int
     elapsed_s: float
@@ -334,17 +341,18 @@ def run_audit(req: ScanRequest) -> ScanResult: ...               # mode=AUDIT
 
 ### Per-layer provider protocol — `abicheck/buildsource/`
 
-`EvidenceLayer` / `EvidenceDepth` are L-axis enums aligned to the existing
-`buildsource.model.DataLayer` (L3_BUILD/L4_SOURCE_ABI/L5_SOURCE_GRAPH), plus an
-`L2_HEADER` member for the always-on pre-scan tier — **no `S0..S6` type**, per
-ADR-035 D1. Every provider (`pattern_scan`, `preprocessor`, L3 build, L4 replay,
-L5 graph, `crosscheck`) implements one interface, modelled on the ADR-032
-`DataExtractor`, so layers are independently runnable (ADR-033 D1) and
-external/build-emitted providers (D5) drop in unchanged:
+Two enums, one per axis (ADR-035 D1): `EvidenceLayer` is the L-axis (aligned to
+`buildsource.model.DataLayer` — L2_HEADER/L3_BUILD/L4_SOURCE_ABI/L5_SOURCE_GRAPH,
+the authority axis), and **`SourceMethod` is the S-axis** (`S0..S6` + `AUTO`) — a
+*distinct* enum, not banned and not collapsed onto `EvidenceLayer` (the S→L map is
+lossy: S1≠S2 both touch L3, S3 has no L). A provider declares both the method it
+implements and the layer it populates, so a request that pins `source_method=S2`
+runs the right provider:
 
 ```python
 class LayerProvider(Protocol):
-    layer: EvidenceLayer
+    method: SourceMethod                 # S-axis: which source-analysis method
+    layer: EvidenceLayer                 # L-axis: which evidence layer it populates
     def capabilities(self) -> ProviderCapabilities: ...
     def estimate(self, ctx: ScanContext) -> CostEstimate: ...
     def run(self, ctx: ScanContext, poi: PointsOfInterest) -> LayerFacts: ...

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -24,13 +24,23 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
 - **G19.2** Cross-source validation: at least `exported_not_public`,
   `public_not_exported`, `header_build_context_mismatch`, `private_header_leak`
   surfaced as correctly-partitioned `RISK`/`API_BREAK` `ChangeKind`s with
-  provider-corroborated confidence.
+  provider-corroborated confidence (ADR-035 D4).
 - **G19.3** Risk-scored escalation + `scan` command: a numeric score selects
   evidence depth within a budget; one coverage/confidence-annotated report;
-  partial results are first-class.
+  partial results are first-class (ADR-035 D3).
 - **G19.4** Build-integrated extraction: a documented dump/facts artifact
   protocol (Flow 2) ingestible via `merge`, plus a Clang-plugin and
-  compiler-wrapper provider under the ADR-032 model, normalized facts canonical.
+  compiler-wrapper provider under the ADR-032 model, normalized facts canonical
+  (ADR-035 D5).
+- **G19.5** Evidence-directed focusing: a POI set computed from L0/L1/L2 deltas +
+  risk score drives `source_replay` scope and the cross-check work-list, so L4/L5
+  cost falls only on flagged entities (ADR-035 D7).
+- **G19.6** Single-release audit: `scan --audit` / `surface-report` emit the
+  intra-version hygiene catalog with no baseline (ADR-035 D8).
+- **G19.7** Programmatic API + estimate: typed `ScanRequest`/`ScanResult` in
+  `service.py`, a uniform per-level provider protocol, and `scan --estimate` /
+  `service.estimate_scan()` returning per-level projected cost for the project
+  (ADR-035 D9/D10); MCP tools for `scan`/`audit`/`estimate`.
 - **Acceptance gate:** every new `ChangeKind` passes the import-time partition
   assertion, the AI-readiness `changekind-*` checks, and earns FP-rate-gate
   corpus cases before it is allowed to gate.
@@ -55,6 +65,18 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
 - New `abicheck/cli_scan.py` (sibling-module registration per `/CLAUDE.md`):
   classify → always-on tier → escalate within budget → single coverage report.
 
+### Phase 3b — Evidence-directed focusing + API/estimate (G19.5, G19.7)
+- POI builder: from L0/L1/L2 deltas + risk score, produce a work-list consumed by
+  `source_replay` scope selection and `crosscheck.py` (reverse of the
+  `explain-finding` localization walk).
+- Typed `ScanRequest`/`ScanResult` + uniform per-level provider protocol
+  (`capabilities`/`estimate`/`run(ctx, poi)`) in `service.py`; `estimate_scan()`
+  and `scan --estimate`.
+
+### Phase 3c — Single-release audit (G19.6)
+- `scan --audit` (and `surface-report` reuse): run D2 + D4 intra-version, emit the
+  hygiene catalog with no baseline; severity-mapped lint + exit code.
+
 ### Phase 4 — Build-integrated extraction (G19.4)
 - Define the `abicheck_inputs/` dump/facts artifact protocol; ingest via existing
   `merge`. Normalized `source_facts/*.jsonl` preferred; raw AST debug-only.
@@ -64,11 +86,18 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
 ## Files & surfaces
 
 - New: `buildsource/pattern_scan.py`, `buildsource/crosscheck.py`,
-  `cli_scan.py`; new `ChangeKind`s in `checker_policy.py`.
-- Extend: `buildsource/include_graph.py`, `buildsource/source_replay.py`,
-  `buildsource/inline.py` (config), `reporter.py` (coverage/confidence block),
+  `buildsource/poi.py` (evidence-directed work-list), `cli_scan.py`; new
+  `ChangeKind`s in `checker_policy.py`.
+- Extend: `service.py` (`ScanRequest`/`ScanResult`/`run_scan`/`estimate_scan` +
+  provider protocol), `buildsource/include_graph.py`,
+  `buildsource/source_replay.py` (consume POI), `buildsource/inline.py` (config),
+  `cli_surface.py` (audit reuse), `mcp_server.py` (`scan`/`audit`/`estimate`
+  tools), `reporter.py` (coverage/confidence/estimate block),
   `pyproject.toml` (`disallow_untyped_decorators` for `cli_scan`),
   `IMPORT_CYCLE_ALLOWLIST` if `scan` registration flags a cycle.
+- Tracking: new `usecase-registry.yaml` entries (see *Use-case tracking* below),
+  their `examples/case*/` + `ground_truth.json` rows, and a scorecard row in
+  `docs/development/usecase-coverage-evaluation.md`.
 
 ## Tests
 
@@ -90,6 +119,22 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
 - Phase 1–2: M each, high value/cost. Phase 3: M. Phase 4: L (plugin maintenance
   + protocol design). Recommended order is 1 → 2 → 3 → 4; Phase 4's plugin is an
   optimization and can trail.
+
+## Use-case tracking
+
+Six new `planned` entries are registered in `usecase-registry.yaml` under gap
+**G19** (with a G19 row added to `usecase-coverage-evaluation.md`). They flip to
+`partial`/`complete` as each phase lands, citing the new modules/tests/examples
+as evidence:
+
+| Use case | Axis | ADR | Phase |
+|---|---|---|---|
+| `UC-WORKFLOW-pr-source-tier` | workflow | D2/D3 | 1, 3 |
+| `UC-CHANGE-crosscheck-hygiene` | change_class | D4 | 2 |
+| `UC-WORKFLOW-single-release-audit` | workflow | D8 | 3c |
+| `UC-WORKFLOW-evidence-directed-scope` | workflow | D7 | 3b |
+| `UC-TC-build-emitted-facts` | toolchain | D5 | 4 |
+| `UC-REPORTING-scan-coverage-estimate` | reporting | D9/D10 | 3, 3b |
 
 ## Out of scope
 

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -158,7 +158,8 @@ not the basic flow.
   --binary PATH        library/artifact to scan (repeatable for bundles)
   --headers PATH       public header file or dir (repeatable)
   --sources PATH       source tree (compile DB auto-discovered within it)
-  --baseline PATH      previous build's dump (or built lib) to diff against
+  --baseline PATH|REF  previous build's dump/lib (path), OR a baseline-registry
+                       ref like libfoo@1.5 (ADR-022) — one flag, union value
 ```
 
 **Optional — inputs**
@@ -167,8 +168,6 @@ not the basic flow.
   --public-header[-dir] PATH  provenance roots (ADR-015), passthrough to dump
   --compile-db PATH           explicit compile_commands.json (only if not under --sources)
   --build-info PATH           build dir / pack dir instead of a raw source tree
-  --baseline REGISTRY-REF     a baseline-registry name (ADR-022), e.g. libfoo@1.5,
-                              instead of a file — for teams using the registry
   --inputs DIR                ingest a Flow-2 abicheck_inputs/ pack (D5)
 ```
 
@@ -190,7 +189,9 @@ not the basic flow.
   --budget DURATION (e.g. 15m)         optional guard; FAILS on overflow, never
                                        silently shrinks scope (avoid for gating CI)
   --max-tus N                          targeted-AST TU cap
-  --partial-ok / --no-partial-ok       default on; partial result is success
+  --partial-ok / --no-partial-ok       default on; a partial scan (missing tool,
+                                       skipped layer) is success. Does NOT cover
+                                       --budget overflow, which always fails.
   --estimate                           dry-run: print per-layer cost, scan nothing
   --audit                              single-build hygiene lint, no baseline (D8)
 ```

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -169,15 +169,19 @@ not the basic flow.
 **Optional — scope / escalation (defaults are fine for small/medium repos)**
 
 ```text
-  --mode [pr|pr-deep|baseline|audit]   default pr (D9 asymmetry)
-  --depth [auto|headers|build|source|full|graph]
-                                       ceiling on how deep to go; default auto
-                                       (risk picks). headers=L2, build=L3,
-                                       source=L4, full=L4 full-scope, graph=L5.
+  --mode [pr|pr-deep|baseline|audit]   fixed preset of (L,S); default pr (D9)
+  --source-method [s0|s1|s2|s3|s4|s5|s6|auto]
+                                       exact source-analysis level to reach;
+                                       deterministic. auto = risk-driven (opt-in,
+                                       local/dev). See the level table below.
+  --depth [headers|build|source|full|graph]
+                                       same target expressed on the L-axis
+                                       (1:1 with --source-method); pick one.
   --since GITREF                       focus the scan on files changed vs a git
                                        ref (e.g. origin/main); else scans broadly
   --changed-path PATH                  same focusing, listed by hand (repeatable)
-  --budget DURATION (e.g. 15m)         CI time ceiling; report what got covered
+  --budget DURATION (e.g. 15m)         optional guard; FAILS on overflow, never
+                                       silently shrinks scope (avoid for gating CI)
   --max-tus N                          targeted-AST TU cap
   --partial-ok / --no-partial-ok       default on; partial result is success
   --estimate                           dry-run: print per-layer cost, scan nothing
@@ -232,45 +236,50 @@ confidence per evidence source. A reader always sees exactly which source-analys
 depth (S0…S6) was reached and into which L-layer it landed; never a bare
 "source scan ran".
 
-### Two CLI knobs: `--depth` (L) and `--max-source-method` (S)
+### Selecting the level: `--source-method` (S) and/or `--depth` (L)
 
-The S-axis is controllable, but as a **cost cap**, not a parallel selector
-(ADR-035 D1: L stays the authority/primary axis):
+The level is an **explicit, exact target you choose** — not a ceiling, not
+auto-picked. Pick whichever axis you think in; they describe the same run:
 
 ```text
-  --depth [auto|headers|build|source|full|graph]   WHAT evidence (L-axis ceiling)
-  --max-source-method [auto|s0|s1|s2|s3|s4|s5|s6]   HOW expensive source analysis
-                                                    may get (S-axis cost cap)
+  --source-method [s0|s1|s2|s3|s4|s5|s6]   run source analysis AT this method
+  --depth [headers|build|source|full|graph]   express the target as an L ceiling
 ```
 
-Both default `auto`. They compose by `min()`: each L-layer needs a minimum
-S-method, the engine runs the **cheapest S that yields the requested L**, and
-never exceeds the S-cap or `--budget`. Effective work =
-`min(what --depth needs, --max-source-method, --budget)`.
+`--source-method sN` means *reach level N* for the in-scope files — deterministic:
+same inputs → same scan, every CI run. It is not a "max that may do less"; it
+always reaches N (the only way it falls short is a genuinely missing tool, e.g. no
+clang, which is **reported**, not silently downgraded). The two knobs map 1:1, so
+you never need both:
 
-Minimum S per L-layer:
+| `--source-method` | equivalent `--depth` | populates (L) |
+|---|---|---|
+| s0 | (classify only) | — |
+| s1 | build | L3 |
+| s2 | build (+macros/includes) | L3, L5 structural |
+| s3 | (pre-scan) | pre-scan facts |
+| s4 | graph | L5 semantic edges |
+| s5 | source | L4 (scoped) + L5 edges |
+| s6 | full | L4 full-scope |
 
-| Want (L) | Needs (min S) |
-|---|---|
-| L2 headers | — (castxml, not S-scaled) |
-| L3 build | S1 |
-| L5 structural | S2 |
-| L5 semantic edges | S4 |
-| L4 source | S5 (scoped) / S6 (full) |
+If both are given and disagree, the engine takes the **higher** (more evidence),
+deterministically — never the lower. There is no `min()`/cap behaviour.
 
-**Conflict rule:** if `--depth` requests a layer whose minimum S exceeds the cap,
-that layer is reported `skipped (source-method cap sN < required sM)` — never an
-error. The S-cap wins on cost; `--depth` is best-effort within it. Examples:
+### Determinism for CI (no time-bound, no auto by default)
 
-```bash
-abicheck scan ... --max-source-method s2          # build+preprocessor, no AST; L4 skipped (cap)
-abicheck scan ... --depth source --max-source-method s3  # L4 not materialized; report says why
-abicheck scan ... --depth full --max-source-method s6    # forensic deep
-```
+For reproducible gating, the scan scope is fixed by the level you pick, not by the
+machine or the clock:
 
-99% of users set neither — `auto` + risk score + `--budget` pick. The S-cap is for
-guards like "this CI job must never invoke the compiler/AST". `.abicheck.yml`
-mirror: `source.max_method: s5`.
+- **Default per `--mode` is a fixed preset**, not risk-varying: `pr` = S1 + S3
+  always-on + targeted S5; `baseline` = S6. Same commit pair → identical scan.
+- **`auto`** (risk-driven escalation, D3) is **opt-in** (`--source-method auto`),
+  for local/dev only — never the silent CI default.
+- **`--budget`** is optional and, on overflow, **fails** (nonzero exit); it never
+  silently shrinks scope. For gating CI, **pin a level — do not use a time bound.**
+- POI focusing (D7) only selects *which* in-scope TUs get the chosen method; for a
+  fixed diff it is deterministic, so it does not affect CI consistency.
+
+`.abicheck.yml` mirror: `source.method: s5` (exact level; `auto` only if opted in).
 
 ### Python API — `abicheck/service.py`
 

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -146,7 +146,12 @@ Inputs
 
 Scope / escalation
   --mode [pr|pr-deep|baseline|audit]      default pr (D9 asymmetry)
-  --source-scan-level [S0..S6|auto]       cap/force depth (auto = risk-driven)
+  --depth [auto|headers|build|source|graph|full]
+                                          cap evidence depth on the L-axis
+                                          (headers=L2, build=L3, source=L4,
+                                          graph=L5, full=L4 full-scope);
+                                          auto = risk-driven. No S0..S6 selector
+                                          per ADR-035 D1.
   --changed-path PATH                     repeatable; seeds risk score + POI (D7)
   --since GITREF                          derive changed paths from a git range
   --budget DURATION   (e.g. 15m)          wall-clock ceiling
@@ -183,7 +188,7 @@ class ScanRequest:
     inputs_pack: Path | None = None
     baseline: str | Path | None = None
     mode: ScanMode = ScanMode.PR            # PR | PR_DEEP | BASELINE | AUDIT
-    level_cap: SourceScanLevel | None = None  # S0..S6; None = auto
+    depth_cap: EvidenceDepth | None = None    # L-axis cap (see DataLayer); None = auto
     changed_paths: list[str] = field(default_factory=list)
     budget: Budget = Budget()               # total_timeout, max_tus, partial_ok
     risk_rules: RiskRules | None = None
@@ -191,15 +196,15 @@ class ScanRequest:
 
 @dataclass(frozen=True)
 class CostEstimate:
-    level: SourceScanLevel
+    layer: EvidenceLayer               # L-axis: L2_HEADER..L5_SOURCE_GRAPH
     tus: int
     est_seconds: float
     cache_hit_rate: float
     note: str
 
 @dataclass(frozen=True)
-class LevelResult:
-    level: SourceScanLevel
+class LayerResult:
+    layer: EvidenceLayer
     coverage: LayerCoverage            # reuse buildsource.model
     facts: int
     elapsed_s: float
@@ -209,7 +214,7 @@ class LevelResult:
 class ScanResult:
     diff: DiffResult | None            # None in --audit (no baseline)
     findings: list[DiffResult]         # incl. new crosscheck ChangeKinds (D4)
-    levels: list[LevelResult]          # per-tier coverage (D3/D10)
+    layers: list[LayerResult]          # per-layer coverage (D3/D10)
     confidence: dict[str, str]         # provider-agreement matrix (§6.8)
     estimate: list[CostEstimate]       # projected vs. actual
     verdict: Verdict
@@ -220,16 +225,19 @@ def estimate_scan(req: ScanRequest) -> list[CostEstimate]: ...   # no scanning
 def run_audit(req: ScanRequest) -> ScanResult: ...               # mode=AUDIT
 ```
 
-### Per-level provider protocol — `abicheck/buildsource/`
+### Per-layer provider protocol — `abicheck/buildsource/`
 
-Every level (`pattern_scan`, `preprocessor`, L3 build, L4 replay, L5 graph,
-`crosscheck`) implements one interface, modelled on the ADR-032 `DataExtractor`,
-so levels are independently runnable (ADR-033 D1) and external/build-emitted
-providers (D5) drop in unchanged:
+`EvidenceLayer` / `EvidenceDepth` are L-axis enums aligned to the existing
+`buildsource.model.DataLayer` (L3_BUILD/L4_SOURCE_ABI/L5_SOURCE_GRAPH), plus an
+`L2_HEADER` member for the always-on pre-scan tier — **no `S0..S6` type**, per
+ADR-035 D1. Every provider (`pattern_scan`, `preprocessor`, L3 build, L4 replay,
+L5 graph, `crosscheck`) implements one interface, modelled on the ADR-032
+`DataExtractor`, so layers are independently runnable (ADR-033 D1) and
+external/build-emitted providers (D5) drop in unchanged:
 
 ```python
-class SourceLevelProvider(Protocol):
-    level: SourceScanLevel
+class LayerProvider(Protocol):
+    layer: EvidenceLayer
     def capabilities(self) -> ProviderCapabilities: ...
     def estimate(self, ctx: ScanContext) -> CostEstimate: ...
     def run(self, ctx: ScanContext, poi: PointsOfInterest) -> LevelFacts: ...
@@ -259,8 +267,8 @@ schema as the Python API — one contract, three front-ends (CLI, MCP, library).
 ```yaml
 source:
   budgets: { total_timeout: 15m, max_targeted_tus: 80, partial_ok: true }
-  levels:  { S0: always, S1: always, S2: always, S3: always,
-             S4: triggered, S5: triggered, S6: budgeted }
+  layers:  { headers: always, build: always,     # L2 pre-scan, L3 build
+             source: triggered, graph: budgeted } # L4 replay, L5 graph
 risk_rules:
   public_headers: { paths: ["include/**","public/**"], weight: 50 }
   build_abi_flags:{ paths: ["CMakeLists.txt","cmake/**","BUILD"], weight: 40 }

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -228,7 +228,7 @@ graduated techniques, not one AST step; each S-method runs and lands in an L-lay
 |---|---|---|---|---|---|---|
 | classify (D0/D3) | S0 | git diff → risk tags/score | no | — (drives focus) | always | changed |
 | pre-scan patterns (D2) | S3 | regex/Tree-sitter over changed+public | no | pre-scan → L2/L5 | always | changed+public |
-| L2 headers | — | castxml / DWARF (existing) | no | L2 | always | public surface |
+| L2 headers | — | castxml (headers) / DWARF (binary) | castxml for header-AST | L2 | when castxml present (else skipped, reported); DWARF L2 if debug info | public surface |
 | L3 build | S1 | parse `compile_commands.json` / CMake / Ninja / Bazel | no | L3 | always (cheap) | whole build |
 | preprocessor (D2) | S2 | `clang -E` macros / `-MM` includes | (cpp) | L3→L5 | when DB present | changed+public |
 | L5 graph (structural) | S2 fold | fold L3 → target/file/option nodes | no | L5 | when L3 ran | whole build |

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -325,7 +325,7 @@ class ScanRequest:
 @dataclass(frozen=True)
 class CostEstimate:
     method: SourceMethod | None        # S-axis: S0..S6; None for intrinsic L0-L2
-    layer: EvidenceLayer               # L-axis it populates: L2_HEADER..L5_SOURCE_GRAPH
+    layer: EvidenceLayer               # L-axis it populates: L0_BINARY..L5_SOURCE_GRAPH
     tus: int
     est_seconds: float
     cache_hit_rate: float
@@ -359,14 +359,17 @@ def run_audit(req: ScanRequest) -> ScanResult: ...               # mode=AUDIT
 
 ### Per-layer provider protocol — `abicheck/buildsource/`
 
-Two enums, one per axis (ADR-035 D1): `EvidenceLayer` is the L-axis (aligned to
-`buildsource.model.DataLayer` — L2_HEADER/L3_BUILD/L4_SOURCE_ABI/L5_SOURCE_GRAPH,
-the authority axis), and **`SourceMethod` is the S-axis** (`S0..S6` + `AUTO`) — a
-*distinct* enum, not banned and not collapsed onto `EvidenceLayer` (the S→L map is
-lossy: S1≠S2 both touch L3, S3 has no L). A provider declares both the method it
-implements and the layer it populates, so a request that pins `source_method=S2`
-runs the right provider. Intrinsic artifact/header providers set `method = None`
-because L0/L1/L2 evidence is not produced by an S-method:
+Two enums, one per axis (ADR-035 D1): `EvidenceLayer` is the L-axis and includes
+all reportable layers (`L0_BINARY`, `L1_DEBUG`, `L2_HEADER`, `L3_BUILD`,
+`L4_SOURCE_ABI`, `L5_SOURCE_GRAPH`). Its L3-L5 values align with
+`buildsource.model.DataLayer`, while L0/L1/L2 are intrinsic artifact/header rows
+needed for mandatory coverage reporting. **`SourceMethod` is the S-axis**
+(`S0..S6` + `AUTO`) — a *distinct* enum, not banned and not collapsed onto
+`EvidenceLayer` (the S→L map is lossy: S1≠S2 both touch L3, S3 has no L). A
+provider declares both the method it implements and the layer it populates, so a
+request that pins `source_method=S2` runs the right provider. Intrinsic
+artifact/header providers set `method = None` because L0/L1/L2 evidence is not
+produced by an S-method:
 
 ```python
 class LayerProvider(Protocol):

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -23,6 +23,12 @@ scope**.
 | **G17** | [Real-world validation corpus](g17-real-world-corpus.md) | `UC-WORKFLOW-real-world-corpus` | M |
 | **G18** | [Bazel build-evidence](g18-bazel-build-evidence.md) | `UC-TC-bazel-build-evidence` | M |
 
+Initiative plans (cross-cutting, not tied to a single registry gap):
+
+| Plan | ADR | Effort |
+|---|---|---|
+| **G19** | [PR-tier source intelligence & cross-source validation](g19-pr-source-intelligence.md) | [ADR-035](../adr/035-pr-tier-source-intelligence-and-crosscheck.md) · XL (phased) |
+
 Completed or decided plans are retained for implementation history:
 
 | Gap | State | Reference |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -108,6 +108,7 @@ A real invocation is a point in this space:
 | **G13** | planned | Cross-architecture mismatch guardrail. |
 | **G14** | planned | CPython Limited-API / `abi3` import-contract conformance. |
 | **G15** | partial | Inline-namespace version-stamp normalization for ICU/Abseil/libstdc++-style churn. Detector landed (advisory `versioned_symbol_scheme_detected`); normalize-and-collapse preset still planned. |
+| **G19** | planned | PR-tier source intelligence (ADR-035): always-on compiler-free pre-scan + risk-scored escalation, intra-version cross-source validation findings, single-release hygiene audit, evidence-directed scan focusing, build-emitted source-facts protocol, and a typed scan API with per-project cost estimate. |
 | **G16** | partial | Header-scoped source-mode toolchain robustness. Surfaced by 21 real-world cron records. **Shipped**: actionable diagnostics for all three host-toolchain signatures (sized-float `_FloatN`, GCC `__assume__`, `--lang c` + `extern "C"`), plus a `castxml --version` probe that recommends the Clang floor (≥ 18) on a version-mismatch failure. A `-D_FloatN` shim was prototyped and **rejected** (it rewrites glibc's own `typedef float _Float32;` fallback); the durable cure is a newer-Clang castxml or the libclang extractor (G4). **Remaining**: real-host end-to-end check and a dedicated error type. |
 
 ## Proposed next steps (tracked in the registry)

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -564,9 +564,10 @@ use_cases:
     gap: G19
     plan: docs/development/plans/g19-pr-source-intelligence.md
     next_steps: >
-      ADR-035 D2/D3. Add a compiler-free pattern/preprocessor pre-scan that runs
-      on every PR over changed+public files (no compile DB, no compiler). The
-      level is deterministic: a fixed `--mode` preset or an explicit
+      ADR-035 D2/D3. Add a pre-scan that runs on every PR over changed+public
+      files: the lexical pattern scan needs no compile DB and no compiler; the
+      preprocessor macro/include capture (S2) is conditional on a compile DB +
+      `clang -E` (reported skipped otherwise). The level is deterministic: a fixed `--mode` preset or an explicit
       `--source-method`/`--depth`. A numeric risk score changes depth ONLY under
       `--source-method auto` (opt-in) and for POI focusing; `--budget` is a
       failure guard on the chosen level (errors on overflow, never shrinks scope).

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -555,3 +555,83 @@ use_cases:
       toolchain). Capture a pre-recorded `bazel aquery --output=jsonproto` from a
       small Bazel C++ project, add it as a non-executing fixture + test asserting
       non-empty BuildEvidence, then flip to partial/complete.
+
+  # ── PR-tier source intelligence & cross-source validation (ADR-035 / G19) ──
+  - id: UC-WORKFLOW-pr-source-tier
+    axis: workflow
+    name: Always-on compiler-free PR pre-scan + risk-scored budgeted escalation
+    status: planned
+    gap: G19
+    plan: docs/development/plans/g19-pr-source-intelligence.md
+    next_steps: >
+      ADR-035 D2/D3. Add a compiler-free pattern/preprocessor pre-scan that runs
+      on every PR over changed+public files (no compile DB, no compiler), a
+      numeric risk score that escalates L3/L4/L5 within a time/TU budget, and a
+      single `scan` orchestrator whose report states per-tier coverage so partial
+      results are first-class. Reuses the existing collect-mode/replay-scope and
+      evidence-policy machinery; emits RISK/API_BREAK only (authority rule).
+
+  - id: UC-CHANGE-crosscheck-hygiene
+    axis: change_class
+    name: Cross-source validation findings (intra-version ABI hygiene)
+    status: planned
+    gap: G19
+    plan: docs/development/plans/g19-pr-source-intelligence.md
+    next_steps: >
+      ADR-035 D4. New correctly-partitioned ChangeKinds that diff a single
+      snapshot's evidence sources against each other — exported_not_public,
+      public_not_exported, header_build_context_mismatch, private_header_leak,
+      odr_type_variant, public_to_internal_dependency. RISK/API_BREAK tier only;
+      each must earn FP-rate-gate corpus cases before it is allowed to gate.
+
+  - id: UC-WORKFLOW-single-release-audit
+    axis: workflow
+    name: Single-release ABI-hygiene audit (no baseline compare)
+    status: planned
+    gap: G19
+    plan: docs/development/plans/g19-pr-source-intelligence.md
+    next_steps: >
+      ADR-035 D8. Run the D2 pattern facts + D4 cross-checks intra-version, with
+      no baseline, as a `scan --audit` / surface-report lint (accidental ABI
+      surface, private-header leaks, header/build-context mismatch, ODR variants,
+      visibility/versioning hygiene). Extends the G11 single-binary audit;
+      delivers value from one artifact, so it justifies a deeper one-time scan.
+
+  - id: UC-WORKFLOW-evidence-directed-scope
+    axis: workflow
+    name: Evidence-directed scan focusing (binary/header facts steer source scan)
+    status: planned
+    gap: G19
+    plan: docs/development/plans/g19-pr-source-intelligence.md
+    next_steps: >
+      ADR-035 D7. Compute a points-of-interest work-list from L0/L1/L2 deltas +
+      risk score (reverse of the explain-finding localization walk) and hand it to
+      source_replay scope selection and the cross-check engine, so L4/L5 cost is
+      paid only on entities the cheap binary/header evidence already flagged.
+
+  - id: UC-TC-build-emitted-facts
+    axis: toolchain
+    name: Build-emitted source facts (artifact protocol + Clang plugin/wrapper)
+    status: planned
+    gap: G19
+    plan: docs/development/plans/g19-pr-source-intelligence.md
+    next_steps: >
+      ADR-035 D5. Define an `abicheck_inputs/` dump/facts artifact protocol the
+      product build drops next to its binary (normalized source_facts/*.jsonl
+      canonical; raw AST debug-only), ingestible via existing `merge`; plus a
+      Clang plugin and `abicheck-cc` compiler wrapper as ADR-032 extractor
+      providers. Lets vendor/closed builds contribute exact-build-context facts
+      without shipping sources; replay stays the portable default.
+
+  - id: UC-REPORTING-scan-coverage-estimate
+    axis: reporting
+    name: Scan coverage/confidence report + per-project cost estimate
+    status: planned
+    gap: G19
+    plan: docs/development/plans/g19-pr-source-intelligence.md
+    next_steps: >
+      ADR-035 D9/D10. A typed ScanResult carrying per-tier LayerCoverage, the
+      provider-agreement/confidence matrix, and estimate-vs-actual cost — rendered
+      by reporter/PR-comment/SARIF/MCP. `scan --estimate` (service.estimate_scan)
+      probes the project (TU count, header fan-out, cache state) and prints the
+      projected per-level cost so a maintainer/CI picks a depth on measured cost.

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -559,16 +559,19 @@ use_cases:
   # ── PR-tier source intelligence & cross-source validation (ADR-035 / G19) ──
   - id: UC-WORKFLOW-pr-source-tier
     axis: workflow
-    name: Always-on compiler-free PR pre-scan + risk-scored budgeted escalation
+    name: Always-on compiler-free PR pre-scan + deterministic level selection
     status: planned
     gap: G19
     plan: docs/development/plans/g19-pr-source-intelligence.md
     next_steps: >
       ADR-035 D2/D3. Add a compiler-free pattern/preprocessor pre-scan that runs
-      on every PR over changed+public files (no compile DB, no compiler), a
-      numeric risk score that escalates L3/L4/L5 within a time/TU budget, and a
-      single `scan` orchestrator whose report states per-tier coverage so partial
-      results are first-class. Reuses the existing collect-mode/replay-scope and
+      on every PR over changed+public files (no compile DB, no compiler). The
+      level is deterministic: a fixed `--mode` preset or an explicit
+      `--source-method`/`--depth`. A numeric risk score changes depth ONLY under
+      `--source-method auto` (opt-in) and for POI focusing; `--budget` is a
+      failure guard on the chosen level (errors on overflow, never shrinks scope).
+      A single `scan` orchestrator reports per-tier coverage so partial results
+      are first-class. Reuses the existing collect-mode/replay-scope and
       evidence-policy machinery; emits RISK/API_BREAK only (authority rule).
 
   - id: UC-CHANGE-crosscheck-hygiene

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
       - "G16: Header-scope toolchain robustness": development/plans/g16-header-scope-toolchain-robustness.md
       - "G17: Real-world validation corpus": development/plans/g17-real-world-corpus.md
       - "G18: Bazel build-evidence": development/plans/g18-bazel-build-evidence.md
+      - "G19: PR-tier source intelligence": development/plans/g19-pr-source-intelligence.md
     - ADR:
       - Overview: development/adr/index.md
       - "001: Technology Stack": development/adr/001-technology-stack.md
@@ -185,6 +186,7 @@ nav:
       - "032: Evidence Extractor Plugins": development/adr/032-evidence-extractor-plugin-interface.md
       - "033: Evidence CI Rollout": development/adr/033-ci-rollout-performance-and-validation.md
       - "034: Managed-Runtime & Non-C Frontends": development/adr/034-managed-runtime-and-non-c-abi-frontends.md
+      - "035: PR-Tier Source Intelligence & Cross-Check": development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
       - Gap Analysis: development/adr/adr-gap-analysis.md
 
 # Agent instructions are repo-internal context, not published documentation.


### PR DESCRIPTION
## What

Analyzes the uploaded source-scan strategy proposal and turns it into a concrete, grounded improvement plan for abicheck's scan process — captured as a formal ADR plus a phased plan doc.

## Key finding

~70% of the proposal's `S0..S6` source-scan ladder **already exists** in abicheck as the L0–L5 build/source evidence stack (ADR-028…033: compile-DB/CMake/Ninja/Bazel/Make adapters, scoped per-TU AST replay, source/call/include graph, per-TU caching, coverage reporting). Treating it as greenfield would mean rebuilding shipped code.

The three **genuine gaps** are where the value concentrates:
1. No cheap, always-on PR tier (every L3–L5 layer needs a compile DB or compiler).
2. No cross-source validation findings (binary exports vs. headers vs. build flags vs. source — all present in one snapshot, never diffed against each other within a version).
3. No build-integrated fact extraction or unified `scan` UX.

## Decisions (ADR-035)

- **D1** Keep L0–L5 numbering; fold `S0..S6` in (no parallel axis). Preserve ADR-028 D3 authority rule — L0–L2 stay authoritative for `BREAKING`; everything new is `RISK`/`API_BREAK`.
- **D2** Compiler-free PR pre-scan (pattern scan + preprocessor macro/include-leak), changed+public files, no toolchain.
- **D3** Risk-scored escalation + budgeted `scan` orchestrator with first-class partial coverage.
- **D4** Cross-source validation engine → new correctly-partitioned `ChangeKind`s (`exported_not_public`, `header_build_context_mismatch`, `private_header_leak`, `odr_type_variant`, …).
- **D5** Build-integrated extraction: dump/facts artifact protocol (Flow 2, ingested via existing `merge`) + Clang-plugin / compiler-wrapper providers under ADR-032; normalized facts canonical, raw AST debug-only.
- **D6** Additive `.abicheck.yml` schema for levels/budgets/cross-checks.

## Files

- `docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md` (new ADR)
- `docs/development/plans/g19-pr-source-intelligence.md` (new phased plan)
- ADR/plans `index.md` + `mkdocs.yml` nav registration

## Checks

- `python scripts/check_ai_readiness.py` → **0 errors** (only pre-existing warnings; both new docs are nav-registered).
- mkdocs not installed in this environment; links follow the existing relative-path convention and both files are in nav.

Docs-only; no code or `ChangeKind` enum changes in this PR — those are the implementation work G19 schedules.

https://claude.ai/code/session_015jXfUXjGszxczaTSNRGsEG

---
_Generated by [Claude Code](https://claude.ai/code/session_015jXfUXjGszxczaTSNRGsEG)_