### PR TITLE
feat: compiler-free ABI-risk pattern pre-scan (ADR-035 D2, G19.1)

### DIFF
--- a/abicheck/buildsource/CLAUDE.md
+++ b/abicheck/buildsource/CLAUDE.md
@@ -45,6 +45,7 @@ L3/L4/L5 are ordinary `ChangeKind` entries that default to `API_BREAK_KINDS`
 | `model.py` | `BuildSourceManifest`, `BuildSourceRef`, `LayerCoverage`, `BuildSourceEntity`, `DataLayer`/`LayerConfidence`/`CoverageStatus` enums | 028 D1/D5/D7/D8 |
 | `pack.py` | `BuildSourcePack` — on-disk layout + inline embedding (`to_embedded_dict`), content addressing, write/load, `to_ref()` | 028 D1/D4 |
 | `inline.py` | Source-tree-centric inline collection for `dump --sources`/`--build-info`: `collect_inline_pack()` (resolve compile DB → L3, replay → L4, fold → L5), `BuildConfig`/`load_build_config()`/`discover_build_config()` (`.abicheck.yml` `build:`/`sources:`), `is_pack_dir()`, the `query_build_system` subprocess (gated by `--allow-build-query`) | 028–033 amendment |
+| `pattern_scan.py` | Compiler-free lexical ABI-risk pre-scan: `scan_text()`/`scan_files()` (pure stdlib-regex over the D2 construct list), `PatternFact`/`PatternScanResult` (advisory facts + per-kind `EscalationTrigger`s feeding D7 POI focusing); never authoritative | 035 D2 (G19.1) |
 | `build_evidence.py` | `BuildEvidence` normalized model: `Target`, `CompileUnit`, `LinkUnit`, `Toolchain`, `Generator`, `BuildOption` | 029 D1/D2 |
 | `build_diff.py` | `diff_build_evidence()` → build-flag/toolchain drift findings | 029 D9 |
 | `source_abi.py` | `SourceAbiTu` (per-TU dump) + `SourceAbiSurface` (linked `source_abi.json`) schemas, `SourceEntity`/`SourceLocation`, `L4_SOURCE_ABI` boundary | 030 D4/D5/D10 |

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -168,7 +168,10 @@ _RULES: tuple[_Rule, ...] = (
         # identifier named `visibility` is not mistaken for the attribute.
         re.compile(
             r"__attribute__\s*\(\s*\(" + _ATTR_INNER + r"\bvisibility\b"
-            r"|\[\[\s*gnu::visibility"
+            # C++ branch: allow other attributes before `gnu::visibility`,
+            # e.g. `[[nodiscard, gnu::visibility("default")]]`; `[^]]*` stays
+            # within the `[[...]]` brackets.
+            r"|\[\[[^]]*gnu::visibility"
         ),
         False,
         "explicit symbol visibility annotation",
@@ -200,9 +203,18 @@ _RULES: tuple[_Rule, ...] = (
         PatternKind.CALLING_CONVENTION,
         PatternCategory.CALLING_CONVENTION,
         re.compile(
+            # MSVC-style keywords and Windows API macros.
             r"\b(?:__cdecl|__stdcall|__fastcall|__thiscall|__vectorcall"
             r"|_cdecl|_stdcall|_fastcall|WINAPI|APIENTRY|CALLBACK"
             r"|STDMETHODCALLTYPE)\b"
+            # GNU/Clang attribute spellings (the documented ELF way to change
+            # calling convention), e.g. `__attribute__((ms_abi))`,
+            # `((sysv_abi))`, `((stdcall))`, `((regparm(3)))`.
+            r"|__attribute__\s*\(\s*\("
+            + _ATTR_INNER
+            + r"\b(?:__)?(?:ms_abi|sysv_abi|stdcall|cdecl|fastcall|thiscall"
+            r"|regparm|pcs|aarch64_vector_pcs|preserve_all|preserve_most"
+            r"|vectorcall)(?:__)?\b"
         ),
         False,
         "explicit calling convention affects the symbol/ABI",

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -153,8 +153,11 @@ _RULES: tuple[_Rule, ...] = (
     _Rule(
         PatternKind.ATTRIBUTE_VISIBILITY,
         PatternCategory.VISIBILITY,
+        # Match `visibility` anywhere in the attribute list (including after a
+        # nested arg, e.g. `__attribute__((aligned(8), visibility("hidden")))`)
+        # by scanning to the statement boundary, not the first `)`.
         re.compile(
-            r"__attribute__\s*\(\s*\([^)]*\bvisibility\b"
+            r"__attribute__\s*\(\s*\([^;{]*\bvisibility\b"
             r"|\[\[\s*gnu::visibility"
         ),
         False,
@@ -512,12 +515,27 @@ def scan_text(text: str, path: str = "") -> list[PatternFact]:
     return facts
 
 
+def _is_scannable(path: Path) -> bool:
+    """True if a directory-walked file should be lexically scanned.
+
+    Known C/C++ suffixes plus **extensionless** files: many C++ libraries ship
+    extensionless public headers (``include/mylib/Core``), and the D2 scope is
+    "changed + public headers", not "files with a C/C++ extension". Files with a
+    different, explicit extension (``.md``, ``.txt``, ``.bin``) are skipped.
+    """
+    suffix = path.suffix.lower()
+    return suffix in SOURCE_SUFFIXES or suffix == ""
+
+
 def iter_source_files(
     roots: Iterable[str | Path],
     changed_paths: Iterable[str] | None = None,
 ) -> list[Path]:
     """Collect C/C++ source/header files under ``roots`` (files or directories).
 
+    A ``root`` that is a **file** is honored regardless of suffix — the caller
+    pointed at it directly. A ``root`` that is a **directory** is walked and
+    filtered by :func:`_is_scannable` (known suffixes + extensionless headers).
     When ``changed_paths`` is given, the result is intersected with it (by
     suffix-matching the path tail), implementing the ADR-035 D2 "changed +
     public" scope: callers pass public roots and the PR's changed paths. The
@@ -531,13 +549,13 @@ def iter_source_files(
     for root in roots:
         rp = Path(root)
         if rp.is_file():
-            candidates = [rp]
+            candidates = [(rp, True)]  # explicit file: honor regardless of suffix
         elif rp.is_dir():
-            candidates = [p for p in rp.rglob("*") if p.is_file()]
+            candidates = [(p, False) for p in rp.rglob("*") if p.is_file()]
         else:
             continue
-        for cand in candidates:
-            if cand.suffix.lower() not in SOURCE_SUFFIXES:
+        for cand, explicit in candidates:
+            if not explicit and not _is_scannable(cand):
                 continue
             if changed_suffixes is not None and not _path_changed(
                 cand, changed_suffixes

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -120,13 +120,20 @@ class _Rule:
     scan_strings: bool = False
 
 
+#: Hex-digit set used to tell a C++14 digit separator (`1'000`) from a
+#: char-literal opener in the comment/string blanker.
+_HEXDIGITS = frozenset("0123456789abcdefABCDEF")
+
 #: Matches the body *inside* a ``__attribute__((...))`` list up to (but not
-#: across) its closing ``))``: a run of non-paren chars or single-level nested
-#: paren groups (e.g. the ``(8)`` in ``aligned(8)``). Lazy, so it stops at the
-#: searched keyword. Because it can never consume an unbalanced ``)`` it cannot
-#: leak past the attribute into following code — so ``__attribute__((aligned(8)))
-#: int packed;`` does *not* match the packed rule.
-_ATTR_INNER = r"(?:[^()]|\([^()]*\))*?"
+#: across) its closing ``))``: a run of non-paren chars or nested paren groups
+#: **up to two levels deep** (e.g. ``(8)`` in ``aligned(8)`` or
+#: ``(sizeof(int))`` in ``aligned(sizeof(int))``). Lazy, so it stops at the
+#: searched keyword. The alternatives are first-char-disjoint (``[^()]`` vs
+#: ``\(``) at every level, so there is no catastrophic backtracking. Because it
+#: can never consume an unbalanced ``)`` it cannot leak past the attribute into
+#: following code — so ``__attribute__((aligned(8))) int packed;`` does *not*
+#: match the packed rule.
+_ATTR_INNER = r"(?:[^()]|\((?:[^()]|\([^()]*\))*\))*?"
 
 #: Layout-, vtable-, template-, and mangling-affecting constructs warrant
 #: escalation to the expensive semantic scan (S5); pure annotations
@@ -251,13 +258,19 @@ _RULES: tuple[_Rule, ...] = (
 #: starts the parameter list of ``template <...>`` / ``template<...>``). The
 #: ``(?!\s*<)`` lookahead is anchored right after ``template`` so it rejects the
 #: definition even with arbitrary whitespace/newlines before ``<`` (it is
-#: zero-width and cannot be defeated by ``\s+`` backtracking). The ``(?<![.>:])``
-#: guard rejects the dependent-name disambiguators ``x.template foo<...>()``,
-#: ``p->template ...``, and ``Alloc::template rebind<...>`` (allocator/traits
-#: code). The optional ``extern`` group selects the kind so the two never
-#: double-count the same span. This covers both class and function template
-#: instantiations (ADR-035 D2).
-_TEMPLATE_RE = re.compile(r"(?P<extern>\bextern\s+)?(?<![.>:])\btemplate\b(?!\s*<)\s+")
+#: zero-width and cannot be defeated by ``\s+`` backtracking). Dependent-name
+#: disambiguators (``x.template f<>()``, ``p->template ...``, ``A::template
+#: rebind<>``) are rejected separately in ``scan_text`` by walking back over
+#: whitespace to the preceding token — which fixed-width regex lookbehind cannot
+#: do when there is whitespace after ``::`` / ``.`` / ``->``. The optional
+#: ``extern`` group selects the kind so the two never double-count the same span.
+#: Covers both class and function template instantiations (ADR-035 D2).
+_TEMPLATE_RE = re.compile(r"(?P<extern>\bextern\s+)?\btemplate\b(?!\s*<)\s+")
+
+#: A ``template`` keyword preceded (ignoring whitespace) by one of these ends a
+#: ``.`` / ``->`` / ``::`` access — i.e. a dependent-name disambiguator, not an
+#: explicit instantiation.
+_TEMPLATE_DISAMBIGUATOR_PREV = frozenset(".:>")
 
 
 @dataclass(frozen=True)
@@ -432,9 +445,17 @@ def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
                 i += 1
                 state = "string"
             elif ch == "'":
-                out.append("'")
-                i += 1
-                state = "char"
+                # Distinguish a C++14 digit separator (`1'000`, `0xFF'FF`) from a
+                # char-literal opener: a separator sits between two hex digits.
+                # Misreading it as a literal would blank the rest of the file.
+                prev = text[i - 1] if i > 0 else ""
+                if prev in _HEXDIGITS and nxt in _HEXDIGITS:
+                    out.append("'")
+                    i += 1  # stay in code
+                else:
+                    out.append("'")
+                    i += 1
+                    state = "char"
             else:
                 out.append(ch)
                 i += 1
@@ -522,6 +543,17 @@ def scan_text(text: str, path: str = "") -> list[PatternFact]:
     # `extern` group so `extern template class X<int>;` is classified once.
     for m in _TEMPLATE_RE.finditer(blanked):
         is_extern = bool(m.group("extern"))
+        # Reject dependent-name disambiguators (`x.template f<>()`,
+        # `A::template rebind<>`): walk back over whitespace to the token before
+        # `template`; if it ends a `.`/`->`/`::` access it is not an
+        # instantiation. `extern template` is never a disambiguator.
+        if not is_extern:
+            kw_start = m.start()
+            j = kw_start - 1
+            while j >= 0 and blanked[j].isspace():
+                j -= 1
+            if j >= 0 and blanked[j] in _TEMPLATE_DISAMBIGUATOR_PREV:
+                continue
         line = _line_of(blanked, m.start())
         facts.append(
             PatternFact(

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -152,9 +152,11 @@ _RULES: tuple[_Rule, ...] = (
         PatternKind.PRAGMA_PACK,
         PatternCategory.LAYOUT,
         # Macro-friendly pragma spelling, e.g. `_Pragma("pack(push, 1)")`.
-        # This intentionally runs on string-preserved text because the pragma
-        # payload is syntactically a string literal.
-        re.compile(r'_Pragma\s*\(\s*"(?:[^"\\]|\\.)*\bpack\b'),
+        # Runs on string-preserved text (the payload is a string literal) and
+        # requires `pack` to be the payload's *directive token* (first token
+        # after the quote), so non-pack pragmas that merely mention the word —
+        # `_Pragma("GCC diagnostic ignored \"-Wpragma-pack\"")` — don't match.
+        re.compile(r'_Pragma\s*\(\s*"\s*pack\b'),
         True,
         "explicit struct packing changes record layout",
         scan_strings=True,
@@ -476,7 +478,9 @@ def _raw_string_end(text: str, quote_index: int) -> int:
             break
     if prefix_start < 0:
         return -1
-    if prefix_start > 0 and (text[prefix_start - 1].isalnum() or text[prefix_start - 1] == "_"):
+    if prefix_start > 0 and (
+        text[prefix_start - 1].isalnum() or text[prefix_start - 1] == "_"
+    ):
         return -1
     if prefix != "R" and not prefix.endswith("R"):
         return -1

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -62,7 +62,9 @@ SOURCE_SUFFIXES: frozenset[str] = frozenset(
         ".hxx",
         ".h++",
         ".inl",
+        ".inc",
         ".ipp",
+        ".tpp",
         ".tcc",
         ".c",
         ".cc",
@@ -246,12 +248,15 @@ _RULES: tuple[_Rule, ...] = (
 #: ``template void api<int>();``) or a forward ``extern template`` declaration
 #: in one pass. The distinguisher from a template *definition* is that the
 #: ``template`` keyword is followed by a declaration token, not ``<`` (which
-#: starts the parameter list of ``template <...>`` / ``template<...>``); the
-#: ``(?<![.>])`` guard rejects the dependent-name disambiguator ``x.template
-#: foo<...>()`` / ``p->template ...``. The optional ``extern`` group selects the
-#: kind so the two never double-count the same span. This covers both class and
-#: function template instantiations (ADR-035 D2).
-_TEMPLATE_RE = re.compile(r"\b(?P<extern>extern\s+)?(?<![.>])template\s+(?!<)")
+#: starts the parameter list of ``template <...>`` / ``template<...>``). The
+#: ``(?!\s*<)`` lookahead is anchored right after ``template`` so it rejects the
+#: definition even with arbitrary whitespace/newlines before ``<`` (it is
+#: zero-width and cannot be defeated by ``\s+`` backtracking). The ``(?<![.>])``
+#: guard rejects the dependent-name disambiguator ``x.template foo<...>()`` /
+#: ``p->template ...``. The optional ``extern`` group selects the kind so the
+#: two never double-count the same span. This covers both class and function
+#: template instantiations (ADR-035 D2).
+_TEMPLATE_RE = re.compile(r"(?P<extern>\bextern\s+)?(?<![.>])\btemplate\b(?!\s*<)\s+")
 
 
 @dataclass(frozen=True)

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -124,6 +124,8 @@ class _Rule:
 #: char-literal opener in the comment/string blanker.
 _HEXDIGITS = frozenset("0123456789abcdefABCDEF")
 
+_RAW_STRING_PREFIXES = ("u8R", "uR", "UR", "LR", "R")
+
 #: Matches the body *inside* a ``__attribute__((...))`` list up to (but not
 #: across) its closing ``))``: a run of non-paren chars or nested paren groups
 #: **up to two levels deep** (e.g. ``(8)`` in ``aligned(8)`` or
@@ -258,13 +260,16 @@ _RULES: tuple[_Rule, ...] = (
         PatternCategory.VTABLE,
         # C++11 override-only declarations are virtual even without the
         # `virtual` keyword. The delimiter guard avoids double-counting the
-        # common `virtual void f() override;` spelling and handles one-line
-        # class bodies (`struct D { void f() override; };`).
+        # common `virtual void f() override;` spelling and handles one-line class
+        # bodies (`struct D { void f() override; };`). The suffix accepts common
+        # cv/ref/noexcept/virt-specifier orderings such as `final override`,
+        # `& noexcept override`, and `&& final`.
         re.compile(
             r"(?m)(?:^|[;{}])\s*(?![^\n;{}]*\bvirtual\b)"
             r"[^\n;{}()]*\([^;\n{}]*\)\s*"
-            r"(?:const\s*)?(?:noexcept(?:\s*\([^)]*\))?\s*)?(?:&{1,2}\s*)?"
-            r"\boverride\b"
+            r"(?:const\s*)?(?:volatile\s*)?(?:&{1,2}\s*)?"
+            r"(?:noexcept(?:\s*\([^)]*\))?\s*)?"
+            r"(?:\b(?:override|final)\b\s*){1,2}(?=[=;{])"
         ),
         True,
         "virtual member affects vtable layout and dispatch",
@@ -458,6 +463,36 @@ def _is_digit_separator(text: str, i: int) -> bool:
     return token_start.isdigit()
 
 
+def _raw_string_end(text: str, quote_index: int) -> int:
+    """Return the closing quote offset for a C++ raw string, or ``-1``."""
+    prefix_start = -1
+    prefix = ""
+    for candidate in _RAW_STRING_PREFIXES:
+        start = quote_index - len(candidate)
+        if start >= 0 and text[start:quote_index] == candidate:
+            prefix_start = start
+            prefix = candidate
+            break
+    if prefix_start < 0:
+        return -1
+    if prefix_start > 0 and (text[prefix_start - 1].isalnum() or text[prefix_start - 1] == "_"):
+        return -1
+    if prefix != "R" and not prefix.endswith("R"):
+        return -1
+
+    open_paren = text.find("(", quote_index + 1, quote_index + 18)
+    if open_paren < 0:
+        return -1
+    delimiter = text[quote_index + 1 : open_paren]
+    if any(ch.isspace() or ch in "()\\" for ch in delimiter):
+        return -1
+    close = ")" + delimiter + '"'
+    close_start = text.find(close, open_paren + 1)
+    if close_start < 0:
+        return -1
+    return close_start + len(close) - 1
+
+
 def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
     """Replace comment (and optionally string/char-literal) *contents* with spaces.
 
@@ -465,8 +500,8 @@ def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
     line numbers) are unchanged — the scan can then match only real code and
     never trips on an ABI keyword mentioned inside a comment or string literal.
     A single forward state machine handles ``//`` / ``/* */`` comments and
-    ``"..."`` / ``'...'`` literals with backslash escapes. Raw string literals
-    are rare in public headers and left as-is (worst case: a spurious advisory).
+    ``"..."`` / ``'...'`` literals with backslash escapes, plus C++ raw string
+    literals so embedded quotes do not desynchronize the scanner.
 
     With ``blank_strings=False`` only comments are blanked and string/char
     literals are preserved verbatim — needed for the ``extern "C"`` rule, whose
@@ -488,9 +523,18 @@ def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
                 i += 2
                 state = "block_comment"
             elif ch == '"':
-                out.append('"')
-                i += 1
-                state = "string"
+                raw_end = _raw_string_end(text, i)
+                if raw_end >= 0:
+                    raw = text[i : raw_end + 1]
+                    if blank_strings:
+                        out.append("".join("\n" if c == "\n" else " " for c in raw))
+                    else:
+                        out.append(raw)
+                    i = raw_end + 1
+                else:
+                    out.append('"')
+                    i += 1
+                    state = "string"
             elif ch == "'":
                 # Distinguish a C++14 digit separator (`1'000`, `0xFF'FF`) from a
                 # char-literal opener — misreading a literal as a separator (or

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -269,6 +269,7 @@ _RULES: tuple[_Rule, ...] = (
             r"[^\n;{}()]*\([^;\n{}]*\)\s*"
             r"(?:const\s*)?(?:volatile\s*)?(?:&{1,2}\s*)?"
             r"(?:noexcept(?:\s*\([^)]*\))?\s*)?"
+            r"(?:->\s*[^;\n{}]*?\s*)?"
             r"(?:\b(?:override|final)\b\s*){1,2}(?=[=;{])"
         ),
         True,
@@ -526,10 +527,9 @@ def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
                 raw_end = _raw_string_end(text, i)
                 if raw_end >= 0:
                     raw = text[i : raw_end + 1]
-                    if blank_strings:
-                        out.append("".join("\n" if c == "\n" else " " for c in raw))
-                    else:
-                        out.append(raw)
+                    # Raw-string bodies are never code, even on the
+                    # string-preserving path used by `_Pragma`/`extern "C"`.
+                    out.append("".join("\n" if c == "\n" else " " for c in raw))
                     i = raw_end + 1
                 else:
                     out.append('"')

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -139,7 +139,14 @@ _RULES: tuple[_Rule, ...] = (
     _Rule(
         PatternKind.ATTRIBUTE_PACKED,
         PatternCategory.LAYOUT,
-        re.compile(r"__attribute__\s*\(\s*\([^)]*\bpacked\b"),
+        # Match `packed`/`__packed__` anywhere in the attribute list — including
+        # after nested args, e.g. `__attribute__((aligned(8), packed))` — by
+        # scanning to the next statement boundary rather than the first `)`. Also
+        # covers the C++11 `[[gnu::packed]]` spelling.
+        re.compile(
+            r"__attribute__\s*\(\s*\([^;{]*\b(?:__)?packed(?:__)?\b"
+            r"|\[\[[^;{]*\bpacked\b"
+        ),
         True,
         "packed attribute changes record layout",
     ),
@@ -210,12 +217,16 @@ _RULES: tuple[_Rule, ...] = (
     ),
 )
 
-#: Matches both explicit instantiation (``template class Foo<int>;``) and a
-#: forward ``extern template`` declaration in one pass; the optional ``extern``
-#: group selects the kind so the two never double-count the same span.
-_TEMPLATE_RE = re.compile(
-    r"\b(?P<extern>extern\s+)?template\s+(?P<what>class|struct|union)\b"
-)
+#: Matches an explicit instantiation (``template class Foo<int>;``,
+#: ``template void api<int>();``) or a forward ``extern template`` declaration
+#: in one pass. The distinguisher from a template *definition* is that the
+#: ``template`` keyword is followed by a declaration token, not ``<`` (which
+#: starts the parameter list of ``template <...>`` / ``template<...>``); the
+#: ``(?<![.>])`` guard rejects the dependent-name disambiguator ``x.template
+#: foo<...>()`` / ``p->template ...``. The optional ``extern`` group selects the
+#: kind so the two never double-count the same span. This covers both class and
+#: function template instantiations (ADR-035 D2).
+_TEMPLATE_RE = re.compile(r"\b(?P<extern>extern\s+)?(?<![.>])template\s+(?!<)")
 
 
 @dataclass(frozen=True)

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -147,6 +147,17 @@ _RULES: tuple[_Rule, ...] = (
         "explicit struct packing changes record layout",
     ),
     _Rule(
+        PatternKind.PRAGMA_PACK,
+        PatternCategory.LAYOUT,
+        # Macro-friendly pragma spelling, e.g. `_Pragma("pack(push, 1)")`.
+        # This intentionally runs on string-preserved text because the pragma
+        # payload is syntactically a string literal.
+        re.compile(r'_Pragma\s*\(\s*"(?:[^"\\]|\\.)*\bpack\b'),
+        True,
+        "explicit struct packing changes record layout",
+        scan_strings=True,
+    ),
+    _Rule(
         PatternKind.ALIGNAS,
         PatternCategory.LAYOUT,
         re.compile(r"\b(?:alignas|_Alignas)\s*\("),
@@ -239,6 +250,22 @@ _RULES: tuple[_Rule, ...] = (
         PatternKind.VIRTUAL_METHOD,
         PatternCategory.VTABLE,
         re.compile(r"\bvirtual\b"),
+        True,
+        "virtual member affects vtable layout and dispatch",
+    ),
+    _Rule(
+        PatternKind.VIRTUAL_METHOD,
+        PatternCategory.VTABLE,
+        # C++11 override-only declarations are virtual even without the
+        # `virtual` keyword. The delimiter guard avoids double-counting the
+        # common `virtual void f() override;` spelling and handles one-line
+        # class bodies (`struct D { void f() override; };`).
+        re.compile(
+            r"(?m)(?:^|[;{}])\s*(?![^\n;{}]*\bvirtual\b)"
+            r"[^\n;{}()]*\([^;\n{}]*\)\s*"
+            r"(?:const\s*)?(?:noexcept(?:\s*\([^)]*\))?\s*)?(?:&{1,2}\s*)?"
+            r"\boverride\b"
+        ),
         True,
         "virtual member affects vtable layout and dispatch",
     ),

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -1,0 +1,578 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compiler-free lexical ABI-risk pattern pre-scan (ADR-035 D2, phase 1 / G19.1).
+
+This is the **always-on, compiler-free** half of the ADR-035 PR pre-scan tier:
+a stdlib-regex (no new dependency, no compile DB, no compiler) scan over
+changed + public source/header files for the ABI-risk constructs called out in
+ADR-035 D2 — ``#pragma pack``, ``alignas``, ``__attribute__((packed|
+visibility))``, ``__declspec(dllexport|dllimport)``, ``extern "C"``,
+calling-convention macros, explicit / ``extern`` template instantiation,
+``inline namespace``, public ``virtual`` methods, and ``operator new``/
+``delete``.
+
+The scan emits **advisory facts** and **escalation triggers** only — it never
+produces a verdict and is never authoritative for a ``BREAKING`` finding (the
+ADR-028 D3 / ADR-035 D1 authority rule). Its facts pre-populate the L2/L5
+surface and its escalation triggers feed the D7 points-of-interest list that
+targets the expensive S5 source-ABI replay.
+
+Everything here is a pure function over text: no binaries are parsed and no
+external tools are run, so the whole module is exercised by fast unit tests.
+``Tree-sitter`` is a deliberately-deferred optional backend; the stdlib scanner
+is the portable baseline (ADR-035 D2).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from .model import CoverageStatus, LayerConfidence, LayerCoverage
+
+#: Pattern-scan fact-schema version. Independent of every other buildsource
+#: schema version (see ``buildsource/CLAUDE.md`` "Versioning"); bumped on any
+#: breaking change to the emitted ``PatternFact``/``PatternScanResult`` layout.
+PATTERN_SCAN_VERSION: int = 1
+
+#: File suffixes the lexical scanner treats as C/C++ source or headers. Headers
+#: without a suffix (the libstdc++ ``<vector>`` style) are not on disk under a
+#: project tree, so an extension allowlist is sufficient and keeps the walk cheap.
+SOURCE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".h++",
+        ".inl",
+        ".ipp",
+        ".tcc",
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".c++",
+    }
+)
+
+
+class PatternCategory(str, Enum):
+    """The ABI dimension a construct touches — drives the escalation hint."""
+
+    LAYOUT = "layout"  # record size/alignment/packing
+    VTABLE = "vtable"  # virtual table shape / dispatch
+    TEMPLATE = "template"  # instantiated template surface
+    NAMESPACE = "namespace"  # mangling (inline namespace)
+    VISIBILITY = "visibility"  # symbol visibility annotations
+    LINKAGE = "linkage"  # extern "C" / dllexport linkage
+    CALLING_CONVENTION = "calling_convention"  # __cdecl/__stdcall/...
+    ALLOCATION = "allocation"  # operator new/delete
+
+
+class PatternKind(str, Enum):
+    """One named ABI-risk construct the lexical scan recognizes (ADR-035 D2)."""
+
+    PRAGMA_PACK = "pragma_pack"
+    ALIGNAS = "alignas"
+    ATTRIBUTE_PACKED = "attribute_packed"
+    ATTRIBUTE_VISIBILITY = "attribute_visibility"
+    DECLSPEC_DLLEXPORT = "declspec_dllexport"
+    DECLSPEC_DLLIMPORT = "declspec_dllimport"
+    EXTERN_C = "extern_c"
+    CALLING_CONVENTION = "calling_convention"
+    EXPLICIT_TEMPLATE_INSTANTIATION = "explicit_template_instantiation"
+    EXTERN_TEMPLATE = "extern_template"
+    INLINE_NAMESPACE = "inline_namespace"
+    VIRTUAL_METHOD = "virtual_method"
+    OPERATOR_NEW_DELETE = "operator_new_delete"
+
+
+@dataclass(frozen=True)
+class _Rule:
+    """A single-kind lexical rule: a compiled regex plus its classification."""
+
+    kind: PatternKind
+    category: PatternCategory
+    regex: re.Pattern[str]
+    escalates: bool  # finding it warrants a deeper (S5) scan
+    detail: str
+    # `extern "C"` is itself a string literal syntactically; this rule must see
+    # the literal, so it scans the comment-blanked-but-string-preserved text.
+    scan_strings: bool = False
+
+
+#: Layout-, vtable-, template-, and mangling-affecting constructs warrant
+#: escalation to the expensive semantic scan (S5); pure annotations
+#: (visibility/linkage/calling-convention/allocation) are advisory only.
+_RULES: tuple[_Rule, ...] = (
+    _Rule(
+        PatternKind.PRAGMA_PACK,
+        PatternCategory.LAYOUT,
+        re.compile(r"#\s*pragma\s+pack\b"),
+        True,
+        "explicit struct packing changes record layout",
+    ),
+    _Rule(
+        PatternKind.ALIGNAS,
+        PatternCategory.LAYOUT,
+        re.compile(r"\b(?:alignas|_Alignas)\s*\("),
+        True,
+        "explicit alignment changes record layout",
+    ),
+    _Rule(
+        PatternKind.ATTRIBUTE_PACKED,
+        PatternCategory.LAYOUT,
+        re.compile(r"__attribute__\s*\(\s*\([^)]*\bpacked\b"),
+        True,
+        "packed attribute changes record layout",
+    ),
+    _Rule(
+        PatternKind.ATTRIBUTE_VISIBILITY,
+        PatternCategory.VISIBILITY,
+        re.compile(
+            r"__attribute__\s*\(\s*\([^)]*\bvisibility\b"
+            r"|\[\[\s*gnu::visibility"
+        ),
+        False,
+        "explicit symbol visibility annotation",
+    ),
+    _Rule(
+        PatternKind.DECLSPEC_DLLEXPORT,
+        PatternCategory.LINKAGE,
+        re.compile(r"__declspec\s*\(\s*dllexport\s*\)"),
+        False,
+        "PE/COFF export annotation",
+    ),
+    _Rule(
+        PatternKind.DECLSPEC_DLLIMPORT,
+        PatternCategory.LINKAGE,
+        re.compile(r"__declspec\s*\(\s*dllimport\s*\)"),
+        False,
+        "PE/COFF import annotation",
+    ),
+    _Rule(
+        PatternKind.EXTERN_C,
+        PatternCategory.LINKAGE,
+        # `extern "C"` but not `extern "C++"` (no closing quote right after C).
+        re.compile(r'\bextern\s*"C"'),
+        False,
+        "C linkage block suppresses C++ name mangling",
+        scan_strings=True,
+    ),
+    _Rule(
+        PatternKind.CALLING_CONVENTION,
+        PatternCategory.CALLING_CONVENTION,
+        re.compile(
+            r"\b(?:__cdecl|__stdcall|__fastcall|__thiscall|__vectorcall"
+            r"|_cdecl|_stdcall|_fastcall|WINAPI|APIENTRY|CALLBACK"
+            r"|STDMETHODCALLTYPE)\b"
+        ),
+        False,
+        "explicit calling convention affects the symbol/ABI",
+    ),
+    _Rule(
+        PatternKind.INLINE_NAMESPACE,
+        PatternCategory.NAMESPACE,
+        re.compile(r"\binline\s+namespace\b"),
+        True,
+        "inline namespace participates in name mangling / ABI tagging",
+    ),
+    _Rule(
+        PatternKind.VIRTUAL_METHOD,
+        PatternCategory.VTABLE,
+        re.compile(r"\bvirtual\b"),
+        True,
+        "virtual member affects vtable layout and dispatch",
+    ),
+    _Rule(
+        PatternKind.OPERATOR_NEW_DELETE,
+        PatternCategory.ALLOCATION,
+        re.compile(r"\boperator\s+(?:new|delete)\b"),
+        False,
+        "custom allocation operator participates in the ABI",
+    ),
+)
+
+#: Matches both explicit instantiation (``template class Foo<int>;``) and a
+#: forward ``extern template`` declaration in one pass; the optional ``extern``
+#: group selects the kind so the two never double-count the same span.
+_TEMPLATE_RE = re.compile(
+    r"\b(?P<extern>extern\s+)?template\s+(?P<what>class|struct|union)\b"
+)
+
+
+@dataclass(frozen=True)
+class PatternFact:
+    """One advisory ABI-risk construct located by the lexical scan.
+
+    Carries enough to render a finding (``path``/``line``/``snippet``) and to
+    seed the D7 POI list (``kind``/``category``/``escalates``). Never a verdict.
+    """
+
+    kind: PatternKind
+    category: PatternCategory
+    path: str
+    line: int
+    snippet: str
+    escalates: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "category": self.category.value,
+            "path": self.path,
+            "line": self.line,
+            "snippet": self.snippet,
+            "escalates": self.escalates,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class EscalationTrigger:
+    """A grouped recommendation to run a deeper source-analysis method.
+
+    Aggregates every escalating fact of one ``kind`` into a single advisory so
+    a header with twenty ``virtual`` methods produces one trigger, not twenty.
+    ``recommended_method`` is the ADR-035 S-axis selector (e.g. ``"s5"``).
+    """
+
+    kind: PatternKind
+    category: PatternCategory
+    recommended_method: str
+    count: int
+    sample_location: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "category": self.category.value,
+            "recommended_method": self.recommended_method,
+            "count": self.count,
+            "sample_location": self.sample_location,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class PatternScanResult:
+    """Outcome of a lexical pre-scan over a set of files (ADR-035 D2).
+
+    ``facts`` are the raw advisory hits; ``escalation_triggers`` is the deduped
+    per-kind recommendation set that feeds D7 focusing; ``coverage`` is the
+    mandatory ADR-033 coverage row stating the scan ran and over how much.
+    """
+
+    facts: list[PatternFact] = field(default_factory=list)
+    files_scanned: int = 0
+    files_skipped: int = 0
+    version: int = PATTERN_SCAN_VERSION
+
+    @property
+    def escalation_triggers(self) -> list[EscalationTrigger]:
+        """Group escalating facts by kind into deterministic, deduped advisories."""
+        by_kind: dict[PatternKind, list[PatternFact]] = {}
+        for fact in self.facts:
+            if fact.escalates:
+                by_kind.setdefault(fact.kind, []).append(fact)
+        triggers: list[EscalationTrigger] = []
+        for kind, hits in by_kind.items():
+            first = hits[0]
+            triggers.append(
+                EscalationTrigger(
+                    kind=kind,
+                    category=first.category,
+                    recommended_method="s5",
+                    count=len(hits),
+                    sample_location=f"{first.path}:{first.line}"
+                    if first.path
+                    else str(first.line),
+                    reason=first.detail,
+                )
+            )
+        # Stable ordering for reproducible reports/CI diffs.
+        triggers.sort(key=lambda t: t.kind.value)
+        return triggers
+
+    @property
+    def should_escalate(self) -> bool:
+        """True if any located construct warrants a deeper source-ABI scan."""
+        return any(fact.escalates for fact in self.facts)
+
+    def counts_by_kind(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for fact in self.facts:
+            counts[fact.kind.value] = counts.get(fact.kind.value, 0) + 1
+        return counts
+
+    def coverage(self) -> LayerCoverage:
+        """The mandatory ADR-033 D6 coverage row for this always-on tier."""
+        status = CoverageStatus.PRESENT
+        if self.files_scanned == 0:
+            status = CoverageStatus.NOT_COLLECTED
+        elif self.files_skipped:
+            status = CoverageStatus.PARTIAL
+        detail = (
+            f"lexical pattern scan (S3), {self.files_scanned} file(s), "
+            f"{len(self.facts)} fact(s)"
+        )
+        if self.files_skipped:
+            detail += f", {self.files_skipped} unreadable skipped"
+        return LayerCoverage(
+            layer="pattern_scan",
+            status=status,
+            # Lexical, no semantics: facts are advisory, never directly observed ABI.
+            confidence=LayerConfidence.REDUCED,
+            detail=detail,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "files_scanned": self.files_scanned,
+            "files_skipped": self.files_skipped,
+            "facts": [f.to_dict() for f in self.facts],
+            "escalation_triggers": [t.to_dict() for t in self.escalation_triggers],
+            "counts_by_kind": self.counts_by_kind(),
+        }
+
+
+def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
+    """Replace comment (and optionally string/char-literal) *contents* with spaces.
+
+    Preserves every newline and the overall length so byte offsets (and thus
+    line numbers) are unchanged — the scan can then match only real code and
+    never trips on an ABI keyword mentioned inside a comment or string literal.
+    A single forward state machine handles ``//`` / ``/* */`` comments and
+    ``"..."`` / ``'...'`` literals with backslash escapes. Raw string literals
+    are rare in public headers and left as-is (worst case: a spurious advisory).
+
+    With ``blank_strings=False`` only comments are blanked and string/char
+    literals are preserved verbatim — needed for the ``extern "C"`` rule, whose
+    target *is* a string literal.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    state = "code"  # code | line_comment | block_comment | string | char
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if state == "code":
+            if ch == "/" and nxt == "/":
+                out.append("  ")
+                i += 2
+                state = "line_comment"
+            elif ch == "/" and nxt == "*":
+                out.append("  ")
+                i += 2
+                state = "block_comment"
+            elif ch == '"':
+                out.append('"')
+                i += 1
+                state = "string"
+            elif ch == "'":
+                out.append("'")
+                i += 1
+                state = "char"
+            else:
+                out.append(ch)
+                i += 1
+        elif state == "line_comment":
+            if ch == "\n":
+                out.append("\n")
+                state = "code"
+            else:
+                out.append(" ")
+            i += 1
+        elif state == "block_comment":
+            if ch == "*" and nxt == "/":
+                out.append("  ")
+                i += 2
+                state = "code"
+            else:
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
+        elif state in ("string", "char"):
+            quote = '"' if state == "string" else "'"
+            if ch == "\\":
+                # Keep the escape + escaped char verbatim when preserving strings,
+                # else blank both (newlines always survive for line accounting).
+                if not blank_strings:
+                    out.append(ch + (nxt if nxt else ""))
+                else:
+                    out.append("  " if nxt != "\n" else " \n")
+                i += 2
+            elif ch == quote:
+                out.append(quote)
+                i += 1
+                state = "code"
+            else:
+                if not blank_strings:
+                    out.append(ch)
+                else:
+                    out.append("\n" if ch == "\n" else " ")
+                i += 1
+    return "".join(out)
+
+
+def _line_of(text: str, offset: int) -> int:
+    """1-based line number of ``offset`` within ``text``."""
+    return text.count("\n", 0, offset) + 1
+
+
+def _snippet(raw_lines: list[str], line: int) -> str:
+    """The original (un-blanked) source line for a 1-based ``line`` number."""
+    if 1 <= line <= len(raw_lines):
+        return raw_lines[line - 1].strip()
+    return ""
+
+
+def scan_text(text: str, path: str = "") -> list[PatternFact]:
+    """Lexically scan one source/header's text for ABI-risk constructs.
+
+    Pure and side-effect-free: comments and string literals are blanked first
+    (so offsets/line numbers are preserved), then every rule plus the template
+    classifier runs over the blanked text. Facts are returned in source order.
+    """
+    blanked = _blank_comments_and_strings(text)
+    # Comments blanked, string/char literals preserved — for rules whose target
+    # is itself a string literal (`extern "C"`).
+    code_with_strings = _blank_comments_and_strings(text, blank_strings=False)
+    raw_lines = text.splitlines()
+    facts: list[PatternFact] = []
+
+    for rule in _RULES:
+        haystack = code_with_strings if rule.scan_strings else blanked
+        for m in rule.regex.finditer(haystack):
+            line = _line_of(blanked, m.start())
+            facts.append(
+                PatternFact(
+                    kind=rule.kind,
+                    category=rule.category,
+                    path=path,
+                    line=line,
+                    snippet=_snippet(raw_lines, line),
+                    escalates=rule.escalates,
+                    detail=rule.detail,
+                )
+            )
+
+    # Template instantiation/declaration: one regex, kind chosen by the optional
+    # `extern` group so `extern template class X<int>;` is classified once.
+    for m in _TEMPLATE_RE.finditer(blanked):
+        is_extern = bool(m.group("extern"))
+        line = _line_of(blanked, m.start())
+        facts.append(
+            PatternFact(
+                kind=PatternKind.EXTERN_TEMPLATE
+                if is_extern
+                else PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION,
+                category=PatternCategory.TEMPLATE,
+                path=path,
+                line=line,
+                snippet=_snippet(raw_lines, line),
+                escalates=True,
+                detail="extern template declaration suppresses local instantiation"
+                if is_extern
+                else "explicit template instantiation fixes a concrete ABI surface",
+            )
+        )
+
+    facts.sort(key=lambda f: (f.line, f.kind.value))
+    return facts
+
+
+def iter_source_files(
+    roots: Iterable[str | Path],
+    changed_paths: Iterable[str] | None = None,
+) -> list[Path]:
+    """Collect C/C++ source/header files under ``roots`` (files or directories).
+
+    When ``changed_paths`` is given, the result is intersected with it (by
+    suffix-matching the path tail), implementing the ADR-035 D2 "changed +
+    public" scope: callers pass public roots and the PR's changed paths. The
+    walk is deterministic (sorted) for reproducible reports.
+    """
+    changed_suffixes: set[str] | None = None
+    if changed_paths is not None:
+        changed_suffixes = {str(p).replace("\\", "/") for p in changed_paths}
+
+    collected: set[Path] = set()
+    for root in roots:
+        rp = Path(root)
+        if rp.is_file():
+            candidates = [rp]
+        elif rp.is_dir():
+            candidates = [p for p in rp.rglob("*") if p.is_file()]
+        else:
+            continue
+        for cand in candidates:
+            if cand.suffix.lower() not in SOURCE_SUFFIXES:
+                continue
+            if changed_suffixes is not None and not _path_changed(
+                cand, changed_suffixes
+            ):
+                continue
+            collected.add(cand)
+    return sorted(collected)
+
+
+def _path_changed(candidate: Path, changed: set[str]) -> bool:
+    """True if ``candidate`` tail-matches any of the changed-path strings.
+
+    The changed list usually holds repo-relative paths (``include/foo.h``)
+    while ``candidate`` may be absolute or rooted elsewhere, so a suffix match
+    in either direction is the robust join; a bare filename in the changed list
+    matches by basename.
+    """
+    norm = str(candidate).replace("\\", "/")
+    for ch in changed:
+        c = ch.replace("\\", "/")
+        if norm == c or norm.endswith("/" + c) or c.endswith("/" + norm):
+            return True
+        if "/" not in c and candidate.name == c:
+            return True
+    return False
+
+
+def scan_files(
+    roots: Iterable[str | Path],
+    changed_paths: Iterable[str] | None = None,
+) -> PatternScanResult:
+    """Run the lexical pre-scan over the in-scope files and aggregate facts.
+
+    Unreadable files are counted as skipped (reported via ``coverage()``), never
+    fatal — the pre-scan is best-effort advisory by design (ADR-035 D2/D3).
+    """
+    files = iter_source_files(roots, changed_paths)
+    facts: list[PatternFact] = []
+    scanned = 0
+    skipped = 0
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            skipped += 1
+            continue
+        facts.extend(scan_text(text, path=str(f)))
+        scanned += 1
+    return PatternScanResult(facts=facts, files_scanned=scanned, files_skipped=skipped)

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -251,12 +251,13 @@ _RULES: tuple[_Rule, ...] = (
 #: starts the parameter list of ``template <...>`` / ``template<...>``). The
 #: ``(?!\s*<)`` lookahead is anchored right after ``template`` so it rejects the
 #: definition even with arbitrary whitespace/newlines before ``<`` (it is
-#: zero-width and cannot be defeated by ``\s+`` backtracking). The ``(?<![.>])``
-#: guard rejects the dependent-name disambiguator ``x.template foo<...>()`` /
-#: ``p->template ...``. The optional ``extern`` group selects the kind so the
-#: two never double-count the same span. This covers both class and function
-#: template instantiations (ADR-035 D2).
-_TEMPLATE_RE = re.compile(r"(?P<extern>\bextern\s+)?(?<![.>])\btemplate\b(?!\s*<)\s+")
+#: zero-width and cannot be defeated by ``\s+`` backtracking). The ``(?<![.>:])``
+#: guard rejects the dependent-name disambiguators ``x.template foo<...>()``,
+#: ``p->template ...``, and ``Alloc::template rebind<...>`` (allocator/traits
+#: code). The optional ``extern`` group selects the kind so the two never
+#: double-count the same span. This covers both class and function template
+#: instantiations (ADR-035 D2).
+_TEMPLATE_RE = re.compile(r"(?P<extern>\bextern\s+)?(?<![.>:])\btemplate\b(?!\s*<)\s+")
 
 
 @dataclass(frozen=True)

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -411,6 +411,26 @@ class PatternScanResult:
         }
 
 
+def _is_digit_separator(text: str, i: int) -> bool:
+    """True if the ``'`` at ``text[i]`` is a C++14 digit separator, not a literal.
+
+    A digit separator sits between two hex digits *inside a numeric literal*
+    (``1'000``, ``0xFF'FF``). A numeric literal always starts with a decimal
+    digit, so the maximal preceding identifier-run must begin with one — this
+    rejects a prefixed char literal whose prefix happens to end in a hex digit
+    (``u8'a'``, where the run is ``u8`` and starts with ``u``).
+    """
+    prev = text[i - 1] if i > 0 else ""
+    nxt = text[i + 1] if i + 1 < len(text) else ""
+    if prev not in _HEXDIGITS or nxt not in _HEXDIGITS:
+        return False
+    k = i - 1
+    while k >= 0 and (text[k].isalnum() or text[k] in "_'"):
+        k -= 1
+    token_start = text[k + 1] if k + 1 < i else ""
+    return token_start.isdigit()
+
+
 def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
     """Replace comment (and optionally string/char-literal) *contents* with spaces.
 
@@ -446,16 +466,12 @@ def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
                 state = "string"
             elif ch == "'":
                 # Distinguish a C++14 digit separator (`1'000`, `0xFF'FF`) from a
-                # char-literal opener: a separator sits between two hex digits.
-                # Misreading it as a literal would blank the rest of the file.
-                prev = text[i - 1] if i > 0 else ""
-                if prev in _HEXDIGITS and nxt in _HEXDIGITS:
-                    out.append("'")
-                    i += 1  # stay in code
-                else:
-                    out.append("'")
-                    i += 1
+                # char-literal opener — misreading a literal as a separator (or
+                # vice-versa) would blank the rest of the file.
+                out.append("'")
+                if not _is_digit_separator(text, i):
                     state = "char"
+                i += 1
             else:
                 out.append(ch)
                 i += 1

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -461,8 +461,15 @@ def _blank_comments_and_strings(text: str, blank_strings: bool = True) -> str:
                 i += 1
         elif state == "line_comment":
             if ch == "\n":
+                # A backslash immediately before the newline (optionally across
+                # a CRLF `\r`) splices the next physical line into the `//`
+                # comment via C/C++ line continuation, so stay in the comment.
+                prev = text[i - 1] if i > 0 else ""
+                prev2 = text[i - 2] if i > 1 else ""
+                spliced = prev == "\\" or (prev == "\r" and prev2 == "\\")
                 out.append("\n")
-                state = "code"
+                if not spliced:
+                    state = "code"
             else:
                 out.append(" ")
             i += 1

--- a/abicheck/buildsource/pattern_scan.py
+++ b/abicheck/buildsource/pattern_scan.py
@@ -118,6 +118,14 @@ class _Rule:
     scan_strings: bool = False
 
 
+#: Matches the body *inside* a ``__attribute__((...))`` list up to (but not
+#: across) its closing ``))``: a run of non-paren chars or single-level nested
+#: paren groups (e.g. the ``(8)`` in ``aligned(8)``). Lazy, so it stops at the
+#: searched keyword. Because it can never consume an unbalanced ``)`` it cannot
+#: leak past the attribute into following code — so ``__attribute__((aligned(8)))
+#: int packed;`` does *not* match the packed rule.
+_ATTR_INNER = r"(?:[^()]|\([^()]*\))*?"
+
 #: Layout-, vtable-, template-, and mangling-affecting constructs warrant
 #: escalation to the expensive semantic scan (S5); pure annotations
 #: (visibility/linkage/calling-convention/allocation) are advisory only.
@@ -140,12 +148,13 @@ _RULES: tuple[_Rule, ...] = (
         PatternKind.ATTRIBUTE_PACKED,
         PatternCategory.LAYOUT,
         # Match `packed`/`__packed__` anywhere in the attribute list — including
-        # after nested args, e.g. `__attribute__((aligned(8), packed))` — by
-        # scanning to the next statement boundary rather than the first `)`. Also
-        # covers the C++11 `[[gnu::packed]]` spelling.
+        # after nested args, e.g. `__attribute__((aligned(8), packed))` — but
+        # only *within* the attribute parentheses (`_ATTR_INNER`), so a later
+        # identifier named `packed` is not mistaken for the attribute. Also
+        # covers the C++11 `[[gnu::packed]]` spelling (`[^]]*` stays inside `[[]]`).
         re.compile(
-            r"__attribute__\s*\(\s*\([^;{]*\b(?:__)?packed(?:__)?\b"
-            r"|\[\[[^;{]*\bpacked\b"
+            r"__attribute__\s*\(\s*\(" + _ATTR_INNER + r"\b(?:__)?packed(?:__)?\b"
+            r"|\[\[[^]]*\bpacked\b"
         ),
         True,
         "packed attribute changes record layout",
@@ -155,9 +164,10 @@ _RULES: tuple[_Rule, ...] = (
         PatternCategory.VISIBILITY,
         # Match `visibility` anywhere in the attribute list (including after a
         # nested arg, e.g. `__attribute__((aligned(8), visibility("hidden")))`)
-        # by scanning to the statement boundary, not the first `)`.
+        # but only within the attribute parentheses (`_ATTR_INNER`), so a later
+        # identifier named `visibility` is not mistaken for the attribute.
         re.compile(
-            r"__attribute__\s*\(\s*\([^;{]*\bvisibility\b"
+            r"__attribute__\s*\(\s*\(" + _ATTR_INNER + r"\bvisibility\b"
             r"|\[\[\s*gnu::visibility"
         ),
         False,

--- a/docs/development/plans/g19-pr-source-intelligence.md
+++ b/docs/development/plans/g19-pr-source-intelligence.md
@@ -51,11 +51,14 @@ authority rule (L0–L2 stay authoritative for `BREAKING`).
 ## Design (phases)
 
 ### Phase 1 — Compiler-free PR pre-scan (G19.1)
-- New `abicheck/buildsource/pattern_scan.py`: stdlib-regex scanner over changed +
-  public files for the ADR-035 D2 construct list; emits normalized advisory
-  facts + escalation triggers. Tree-sitter is a pluggable later backend.
-- Extend `buildsource/include_graph.py`: per-TU ABI-macro-value capture and
-  private/generated-header-leak detection when a compile DB is present.
+- **DONE** — New `abicheck/buildsource/pattern_scan.py`: stdlib-regex scanner over
+  changed + public files for the ADR-035 D2 construct list; emits normalized
+  advisory facts + per-kind escalation triggers (`PatternFact`/
+  `PatternScanResult`/`EscalationTrigger`), with mandatory coverage reporting and
+  no compile DB / compiler. Tree-sitter is a pluggable later backend.
+  Tests: `tests/test_pattern_scan.py`.
+- **TODO** — Extend `buildsource/include_graph.py`: per-TU ABI-macro-value capture
+  and private/generated-header-leak detection when a compile DB is present.
 
 ### Phase 2 — Cross-source validation engine (G19.2)
 - New `abicheck/buildsource/crosscheck.py` consuming one merged snapshot.

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -560,14 +560,22 @@ use_cases:
   - id: UC-WORKFLOW-pr-source-tier
     axis: workflow
     name: Always-on compiler-free PR pre-scan + deterministic level selection
-    status: planned
+    status: partial
     gap: G19
     plan: docs/development/plans/g19-pr-source-intelligence.md
+    evidence:
+      modules:
+        - abicheck/buildsource/pattern_scan.py
+      tests:
+        - tests/test_pattern_scan.py
     next_steps: >
-      ADR-035 D2/D3. Add a pre-scan that runs on every PR over changed+public
-      files: the lexical pattern scan needs no compile DB and no compiler; the
-      preprocessor macro/include capture (S2) is conditional on a compile DB +
-      `clang -E` (reported skipped otherwise). The level is deterministic: a fixed `--mode` preset or an explicit
+      ADR-035 D2/D3. DONE: the compiler-free lexical pattern pre-scan
+      (`buildsource/pattern_scan.py`) — a stdlib-regex scan over changed+public
+      files for the D2 ABI-risk construct list, emitting advisory facts +
+      per-kind escalation triggers, with no compile DB and no compiler. REMAINS:
+      the preprocessor macro/include capture (S2), conditional on a compile DB +
+      `clang -E` (reported skipped otherwise); and the deterministic `scan`
+      orchestrator — a fixed `--mode` preset or an explicit
       `--source-method`/`--depth`. A numeric risk score changes depth ONLY under
       `--source-method auto` (opt-in) and for POI focusing; `--budget` is a
       failure guard on the chosen level (errors on overflow, never shrinks scope).

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -112,7 +112,10 @@ def _kinds(text: str) -> set[PatternKind]:
         ("struct Base { virtual void f(); };", PatternKind.VIRTUAL_METHOD),
         ("struct Derived : Base { void f() override; };", PatternKind.VIRTUAL_METHOD),
         ("struct Derived : Base { void f() final; };", PatternKind.VIRTUAL_METHOD),
-        ("struct Derived : Base { void f() final override; };", PatternKind.VIRTUAL_METHOD),
+        (
+            "struct Derived : Base { void f() final override; };",
+            PatternKind.VIRTUAL_METHOD,
+        ),
         (
             "struct Derived : Base { void f() & noexcept override; };",
             PatternKind.VIRTUAL_METHOD,
@@ -319,9 +322,49 @@ def test_raw_string_contents_not_flagged() -> None:
 
 
 def test_raw_string_contents_not_flagged_by_string_preserving_rules() -> None:
-    src = r'''const char* s = R"abi(_Pragma("pack(push, 1)") extern "C")abi";'''
+    src = r"""const char* s = R"abi(_Pragma("pack(push, 1)") extern "C")abi";"""
     assert PatternKind.PRAGMA_PACK not in _kinds(src)
     assert PatternKind.EXTERN_C not in _kinds(src)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        '_Pragma("GCC diagnostic ignored \\"-Wpragma-pack\\"")',
+        '_Pragma("message(\\"pack\\")")',
+    ],
+)
+def test_non_pack_pragma_not_flagged(src: str) -> None:
+    # `_Pragma` whose payload merely mentions `pack` (not as the directive
+    # token) must not emit a PRAGMA_PACK layout fact.
+    assert PatternKind.PRAGMA_PACK not in _kinds(src)
+
+
+def test_unterminated_string_at_eof_does_not_crash() -> None:
+    # An unterminated string literal reaching EOF must be handled (the blanker
+    # stays in string state to the end) and a preceding construct still fires.
+    facts = scan_text('struct alignas(4) S {};\nconst char* s = "oops')
+    assert PatternKind.ALIGNAS in {f.kind for f in facts}
+
+
+def test_raw_string_edge_cases_fall_back_to_normal_string() -> None:
+    # _raw_string_end returns -1 (not a raw string) for: an alnum char before
+    # the prefix, no opening paren near the quote, a whitespace delimiter, and a
+    # missing close sequence — exercising each guard.
+    from abicheck.buildsource.pattern_scan import _raw_string_end
+
+    assert _raw_string_end('aR"(x)"', 2) == -1  # `a` before the `R` prefix
+    assert _raw_string_end('R"' + "x" * 30, 1) == -1  # no `(` near the quote
+    assert _raw_string_end('R"de lim(x)de lim"', 1) == -1  # space in delimiter
+    assert _raw_string_end('R"d(unterminated', 1) == -1  # no closing `)d"`
+    s = 'R"d(body)d"'
+    assert _raw_string_end(s, 1) == len(s) - 1  # well-formed → closing offset
+
+
+def test_snippet_out_of_range_returns_empty() -> None:
+    from abicheck.buildsource.pattern_scan import _snippet
+
+    assert _snippet(["only one line"], 5) == ""
 
 
 # ── Escalation triggers + categories ─────────────────────────────────────────

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -83,6 +83,26 @@ def _kinds(text: str) -> set[PatternKind]:
         ('extern "C" void c_api(void);', PatternKind.EXTERN_C),
         ("int __stdcall winproc(void);", PatternKind.CALLING_CONVENTION),
         ("int WINAPI WinMain(void);", PatternKind.CALLING_CONVENTION),
+        (
+            "void __attribute__((ms_abi)) f(void);",
+            PatternKind.CALLING_CONVENTION,
+        ),
+        (
+            "void __attribute__((sysv_abi)) f(void);",
+            PatternKind.CALLING_CONVENTION,
+        ),
+        (
+            "void __attribute__((stdcall)) f(void);",
+            PatternKind.CALLING_CONVENTION,
+        ),
+        (
+            "void __attribute__((regparm(3))) f(int);",
+            PatternKind.CALLING_CONVENTION,
+        ),
+        (
+            '[[nodiscard, gnu::visibility("default")]] int f();',
+            PatternKind.ATTRIBUTE_VISIBILITY,
+        ),
         ("inline namespace v1 { struct S {}; }", PatternKind.INLINE_NAMESPACE),
         ("struct Base { virtual void f(); };", PatternKind.VIRTUAL_METHOD),
         ("void* operator new(size_t n);", PatternKind.OPERATOR_NEW_DELETE),
@@ -134,6 +154,13 @@ def test_identifier_named_packed_not_flagged(src: str) -> None:
 )
 def test_identifier_named_visibility_not_flagged(src: str) -> None:
     assert PatternKind.ATTRIBUTE_VISIBILITY not in _kinds(src)
+
+
+def test_non_cc_attribute_not_flagged_as_calling_convention() -> None:
+    # A plain attribute without a calling-convention keyword must not flag.
+    assert PatternKind.CALLING_CONVENTION not in _kinds(
+        "void __attribute__((noreturn)) f(void);"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -169,6 +169,9 @@ def test_non_cc_attribute_not_flagged_as_calling_convention() -> None:
         "template <typename T> class Foo {};",
         "template<typename T> void f(T x);",
         "template <class T, class U> struct Pair {};",
+        "template  <typename T> class Foo {};",  # two spaces before `<`
+        "template\n<typename T> class Foo {};",  # newline before `<`
+        "template\n  <typename T> struct S {};",  # newline + spaces
     ],
 )
 def test_template_definition_not_flagged_as_instantiation(definition: str) -> None:
@@ -312,6 +315,14 @@ def test_iter_source_files_filters_by_suffix(tmp_path: Path) -> None:
     (tmp_path / "data.bin").write_bytes(b"\x00\x01")
     found = {p.name for p in iter_source_files([tmp_path])}
     assert found == {"a.hpp", "b.cpp"}
+
+
+@pytest.mark.parametrize("name", ["detail.tpp", "Config.inc"])
+def test_iter_source_files_includes_tpp_and_inc(tmp_path: Path, name: str) -> None:
+    # These are header-like extensions the repo already recognizes elsewhere.
+    (tmp_path / name).write_text("#pragma pack(1)\nstruct S { int x; };")
+    found = {p.name for p in iter_source_files([tmp_path])}
+    assert name in found
 
 
 def test_iter_source_files_changed_scope(tmp_path: Path) -> None:

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -111,6 +111,12 @@ def _kinds(text: str) -> set[PatternKind]:
         ("inline namespace v1 { struct S {}; }", PatternKind.INLINE_NAMESPACE),
         ("struct Base { virtual void f(); };", PatternKind.VIRTUAL_METHOD),
         ("struct Derived : Base { void f() override; };", PatternKind.VIRTUAL_METHOD),
+        ("struct Derived : Base { void f() final; };", PatternKind.VIRTUAL_METHOD),
+        ("struct Derived : Base { void f() final override; };", PatternKind.VIRTUAL_METHOD),
+        (
+            "struct Derived : Base { void f() & noexcept override; };",
+            PatternKind.VIRTUAL_METHOD,
+        ),
         ("void* operator new(size_t n);", PatternKind.OPERATOR_NEW_DELETE),
         ("void operator delete(void* p) noexcept;", PatternKind.OPERATOR_NEW_DELETE),
         ("template class Vector<int>;", PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION),
@@ -297,6 +303,15 @@ def test_line_comment_without_continuation_resumes_code() -> None:
 
 def test_plain_override_identifier_not_flagged_as_virtual_method() -> None:
     assert PatternKind.VIRTUAL_METHOD not in _kinds("int override = 0;")
+
+
+def test_raw_string_embedded_quote_does_not_hide_later_construct() -> None:
+    src = 'const char* s = R"(contains " quote)";\nstruct B { virtual void f(); };'
+    assert PatternKind.VIRTUAL_METHOD in _kinds(src)
+
+
+def test_raw_string_contents_not_flagged() -> None:
+    assert _kinds('const char* s = R"(#pragma pack(1) virtual void f();)";') == set()
 
 
 # ── Escalation triggers + categories ─────────────────────────────────────────

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -73,6 +73,10 @@ def _kinds(text: str) -> set[PatternKind]:
             'void f() __attribute__((visibility("hidden")));',
             PatternKind.ATTRIBUTE_VISIBILITY,
         ),
+        (
+            'void f() __attribute__((aligned(8), visibility("hidden")));',
+            PatternKind.ATTRIBUTE_VISIBILITY,
+        ),
         ('[[gnu::visibility("default")]] void f();', PatternKind.ATTRIBUTE_VISIBILITY),
         ("__declspec(dllexport) int api(void);", PatternKind.DECLSPEC_DLLEXPORT),
         ("__declspec(dllimport) int api(void);", PatternKind.DECLSPEC_DLLIMPORT),
@@ -267,6 +271,44 @@ def test_iter_source_files_changed_scope(tmp_path: Path) -> None:
         p.name for p in iter_source_files([inc], changed_paths=["include/public.h"])
     }
     assert found == {"public.h"}
+
+
+def test_iter_source_files_includes_extensionless_headers(tmp_path: Path) -> None:
+    inc = tmp_path / "include" / "mylib"
+    inc.mkdir(parents=True)
+    (inc / "Core").write_text("struct S { virtual void f(); };")  # extensionless
+    (inc / "notes.md").write_text("# docs")
+    found = {p.name for p in iter_source_files([tmp_path / "include"])}
+    assert "Core" in found
+    assert "notes.md" not in found
+
+
+def test_iter_source_files_extensionless_changed_scope(tmp_path: Path) -> None:
+    inc = tmp_path / "include" / "mylib"
+    inc.mkdir(parents=True)
+    (inc / "Core").write_text("struct S { virtual void f(); };")
+    found = iter_source_files(
+        [tmp_path / "include"], changed_paths=["include/mylib/Core"]
+    )
+    assert [p.name for p in found] == ["Core"]
+
+
+def test_iter_source_files_explicit_file_honored_regardless_of_suffix(
+    tmp_path: Path,
+) -> None:
+    f = tmp_path / "PublicHeader"  # extensionless, passed directly
+    f.write_text("struct S { virtual void f(); };")
+    found = iter_source_files([f])
+    assert found == [f]
+
+
+def test_scan_files_finds_constructs_in_extensionless_header(tmp_path: Path) -> None:
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "Core").write_text("#pragma pack(1)\nstruct S { int x; };")
+    res = scan_files([inc], changed_paths=["include/Core"])
+    assert res.files_scanned == 1
+    assert PatternKind.PRAGMA_PACK in {f.kind for f in res.facts}
 
 
 def test_iter_source_files_changed_scope_bare_name(tmp_path: Path) -> None:

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -63,6 +63,10 @@ def _kinds(text: str) -> set[PatternKind]:
             "struct __attribute__((__packed__)) S { char a; int b; };",
             PatternKind.ATTRIBUTE_PACKED,
         ),
+        (
+            "struct __attribute__((aligned(sizeof(int)), packed)) S {};",
+            PatternKind.ATTRIBUTE_PACKED,
+        ),
         ("struct [[gnu::packed]] S { char a; int b; };", PatternKind.ATTRIBUTE_PACKED),
         (
             "template void api<int>();",
@@ -188,12 +192,39 @@ def test_template_definition_not_flagged_as_instantiation(definition: str) -> No
         "ptr->template bar<int>();",
         "typename Alloc::template rebind<U>::other a;",
         "Alloc::template rebind<U> r;",
+        "typename A<T>:: template rebind<int>::other o;",  # space after ::
+        "obj. template foo<int>();",  # space after .
+        "ptr-> template bar<int>();",  # space after ->
     ],
 )
 def test_dependent_template_disambiguator_not_flagged(disambiguator: str) -> None:
     # `x.template f<...>()`, `p->template ...`, and `Alloc::template rebind<...>`
-    # are dependent-name disambiguators, not explicit instantiations.
+    # are dependent-name disambiguators, not explicit instantiations — even with
+    # whitespace after the `.`/`->`/`::`.
     assert PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION not in _kinds(disambiguator)
+
+
+@pytest.mark.parametrize(
+    "src,kind",
+    [
+        # C++14 digit separators must not be read as char-literal openers (which
+        # would blank the rest of the file and hide later constructs).
+        (
+            "constexpr auto n = 1'000;\nstruct B { virtual void f(); };",
+            PatternKind.VIRTUAL_METHOD,
+        ),
+        ("constexpr auto h = 0xFF'FF;\n#pragma pack(1)", PatternKind.PRAGMA_PACK),
+    ],
+)
+def test_digit_separator_does_not_hide_later_constructs(
+    src: str, kind: PatternKind
+) -> None:
+    assert kind in _kinds(src)
+
+
+def test_real_char_literal_still_blanks_its_contents() -> None:
+    # A genuine char literal must still hide an ABI keyword spelled inside it.
+    assert PatternKind.PRAGMA_PACK not in _kinds('const char* s = "#pragma pack";')
 
 
 def test_function_template_instantiation_escalates() -> None:

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -49,6 +49,7 @@ def _kinds(text: str) -> set[PatternKind]:
     [
         ("#pragma pack(1)", PatternKind.PRAGMA_PACK),
         ("#  pragma   pack ( push, 1 )", PatternKind.PRAGMA_PACK),
+        ('_Pragma("pack(push, 1)")', PatternKind.PRAGMA_PACK),
         ("struct alignas(16) S { int x; };", PatternKind.ALIGNAS),
         ("_Alignas(8) char buf[8];", PatternKind.ALIGNAS),
         (
@@ -109,6 +110,7 @@ def _kinds(text: str) -> set[PatternKind]:
         ),
         ("inline namespace v1 { struct S {}; }", PatternKind.INLINE_NAMESPACE),
         ("struct Base { virtual void f(); };", PatternKind.VIRTUAL_METHOD),
+        ("struct Derived : Base { void f() override; };", PatternKind.VIRTUAL_METHOD),
         ("void* operator new(size_t n);", PatternKind.OPERATOR_NEW_DELETE),
         ("void operator delete(void* p) noexcept;", PatternKind.OPERATOR_NEW_DELETE),
         ("template class Vector<int>;", PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION),
@@ -291,6 +293,10 @@ def test_line_continuation_in_line_comment_stays_commented() -> None:
 def test_line_comment_without_continuation_resumes_code() -> None:
     # Without the trailing backslash, the next line is real code again.
     assert PatternKind.VIRTUAL_METHOD in _kinds("// note\nvirtual void f();")
+
+
+def test_plain_override_identifier_not_flagged_as_virtual_method() -> None:
+    assert PatternKind.VIRTUAL_METHOD not in _kinds("int override = 0;")
 
 
 # ── Escalation triggers + categories ─────────────────────────────────────────

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -56,6 +56,20 @@ def _kinds(text: str) -> set[PatternKind]:
             PatternKind.ATTRIBUTE_PACKED,
         ),
         (
+            "struct __attribute__((aligned(8), packed)) S { char a; int b; };",
+            PatternKind.ATTRIBUTE_PACKED,
+        ),
+        (
+            "struct __attribute__((__packed__)) S { char a; int b; };",
+            PatternKind.ATTRIBUTE_PACKED,
+        ),
+        ("struct [[gnu::packed]] S { char a; int b; };", PatternKind.ATTRIBUTE_PACKED),
+        (
+            "template void api<int>();",
+            PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION,
+        ),
+        ("extern template int api<int>();", PatternKind.EXTERN_TEMPLATE),
+        (
             'void f() __attribute__((visibility("hidden")));',
             PatternKind.ATTRIBUTE_VISIBILITY,
         ),
@@ -91,6 +105,41 @@ def test_extern_template_not_double_counted_as_explicit() -> None:
 
 def test_extern_cpp_not_flagged_as_extern_c() -> None:
     assert PatternKind.EXTERN_C not in _kinds('extern "C++" void f();')
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        "template <typename T> class Foo {};",
+        "template<typename T> void f(T x);",
+        "template <class T, class U> struct Pair {};",
+    ],
+)
+def test_template_definition_not_flagged_as_instantiation(definition: str) -> None:
+    # A template *definition* (keyword followed by `<`) is not an instantiation.
+    kinds = _kinds(definition)
+    assert PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION not in kinds
+    assert PatternKind.EXTERN_TEMPLATE not in kinds
+
+
+@pytest.mark.parametrize(
+    "disambiguator",
+    [
+        "obj.template foo<int>();",
+        "ptr->template bar<int>();",
+    ],
+)
+def test_dependent_template_disambiguator_not_flagged(disambiguator: str) -> None:
+    # `x.template f<...>()` / `p->template ...` is a member-access disambiguator,
+    # not an explicit instantiation.
+    assert PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION not in _kinds(disambiguator)
+
+
+def test_function_template_instantiation_escalates() -> None:
+    res = PatternScanResult(
+        facts=scan_text("template void api<int>();", path="h.h"), files_scanned=1
+    )
+    assert res.should_escalate is True
 
 
 # ── Comment / string-literal blanking avoids false positives ─────────────────

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -222,6 +222,22 @@ def test_digit_separator_does_not_hide_later_constructs(
     assert kind in _kinds(src)
 
 
+@pytest.mark.parametrize(
+    "src",
+    [
+        "auto c = u8'a';\nstruct B { virtual void f(); };",
+        "auto c = u'0';\n#pragma pack(1)",
+        "auto c = U'9';\nstruct B { virtual void g(); };",
+        "auto c = L'7';\n#pragma pack(1)",
+    ],
+)
+def test_prefixed_char_literal_not_treated_as_digit_separator(src: str) -> None:
+    # `u8'a'`/`u'0'`/`U'9'`/`L'7'` are prefixed char literals, not digit
+    # separators — the closing quote must not blank the rest of the file.
+    kinds = _kinds(src)
+    assert kinds & {PatternKind.VIRTUAL_METHOD, PatternKind.PRAGMA_PACK}
+
+
 def test_real_char_literal_still_blanks_its_contents() -> None:
     # A genuine char literal must still hide an ABI keyword spelled inside it.
     assert PatternKind.PRAGMA_PACK not in _kinds('const char* s = "#pragma pack";')

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -117,6 +117,10 @@ def _kinds(text: str) -> set[PatternKind]:
             "struct Derived : Base { void f() & noexcept override; };",
             PatternKind.VIRTUAL_METHOD,
         ),
+        (
+            "struct Derived : Base { auto f() -> int override; };",
+            PatternKind.VIRTUAL_METHOD,
+        ),
         ("void* operator new(size_t n);", PatternKind.OPERATOR_NEW_DELETE),
         ("void operator delete(void* p) noexcept;", PatternKind.OPERATOR_NEW_DELETE),
         ("template class Vector<int>;", PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION),
@@ -312,6 +316,12 @@ def test_raw_string_embedded_quote_does_not_hide_later_construct() -> None:
 
 def test_raw_string_contents_not_flagged() -> None:
     assert _kinds('const char* s = R"(#pragma pack(1) virtual void f();)";') == set()
+
+
+def test_raw_string_contents_not_flagged_by_string_preserving_rules() -> None:
+    src = r'''const char* s = R"abi(_Pragma("pack(push, 1)") extern "C")abi";'''
+    assert PatternKind.PRAGMA_PACK not in _kinds(src)
+    assert PatternKind.EXTERN_C not in _kinds(src)
 
 
 # ── Escalation triggers + categories ─────────────────────────────────────────

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -186,11 +186,13 @@ def test_template_definition_not_flagged_as_instantiation(definition: str) -> No
     [
         "obj.template foo<int>();",
         "ptr->template bar<int>();",
+        "typename Alloc::template rebind<U>::other a;",
+        "Alloc::template rebind<U> r;",
     ],
 )
 def test_dependent_template_disambiguator_not_flagged(disambiguator: str) -> None:
-    # `x.template f<...>()` / `p->template ...` is a member-access disambiguator,
-    # not an explicit instantiation.
+    # `x.template f<...>()`, `p->template ...`, and `Alloc::template rebind<...>`
+    # are dependent-name disambiguators, not explicit instantiations.
     assert PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION not in _kinds(disambiguator)
 
 

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -1,0 +1,280 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ADR-035 D2 compiler-free lexical ABI-risk pattern pre-scan.
+
+Every construct in the ADR-035 D2 list has a positive fixture; comment/string
+blanking, escalation grouping, coverage reporting, and the changed+public file
+walk are covered. Pure-Python, no external tools — runs in the default lane.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.model import CoverageStatus, LayerConfidence
+from abicheck.buildsource.pattern_scan import (
+    PATTERN_SCAN_VERSION,
+    PatternCategory,
+    PatternKind,
+    PatternScanResult,
+    iter_source_files,
+    scan_files,
+    scan_text,
+)
+
+
+def _kinds(text: str) -> set[PatternKind]:
+    return {f.kind for f in scan_text(text)}
+
+
+# ── Each ADR-035 D2 construct is recognized ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "snippet,kind",
+    [
+        ("#pragma pack(1)", PatternKind.PRAGMA_PACK),
+        ("#  pragma   pack ( push, 1 )", PatternKind.PRAGMA_PACK),
+        ("struct alignas(16) S { int x; };", PatternKind.ALIGNAS),
+        ("_Alignas(8) char buf[8];", PatternKind.ALIGNAS),
+        (
+            "struct __attribute__((packed)) S { char a; int b; };",
+            PatternKind.ATTRIBUTE_PACKED,
+        ),
+        (
+            'void f() __attribute__((visibility("hidden")));',
+            PatternKind.ATTRIBUTE_VISIBILITY,
+        ),
+        ('[[gnu::visibility("default")]] void f();', PatternKind.ATTRIBUTE_VISIBILITY),
+        ("__declspec(dllexport) int api(void);", PatternKind.DECLSPEC_DLLEXPORT),
+        ("__declspec(dllimport) int api(void);", PatternKind.DECLSPEC_DLLIMPORT),
+        ('extern "C" void c_api(void);', PatternKind.EXTERN_C),
+        ("int __stdcall winproc(void);", PatternKind.CALLING_CONVENTION),
+        ("int WINAPI WinMain(void);", PatternKind.CALLING_CONVENTION),
+        ("inline namespace v1 { struct S {}; }", PatternKind.INLINE_NAMESPACE),
+        ("struct Base { virtual void f(); };", PatternKind.VIRTUAL_METHOD),
+        ("void* operator new(size_t n);", PatternKind.OPERATOR_NEW_DELETE),
+        ("void operator delete(void* p) noexcept;", PatternKind.OPERATOR_NEW_DELETE),
+        ("template class Vector<int>;", PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION),
+        ("extern template class Vector<int>;", PatternKind.EXTERN_TEMPLATE),
+    ],
+)
+def test_recognizes_each_construct(snippet: str, kind: PatternKind) -> None:
+    assert kind in _kinds(snippet)
+
+
+def test_extern_template_not_double_counted_as_explicit() -> None:
+    # `extern template class X<int>;` must be classified once, as EXTERN_TEMPLATE.
+    facts = scan_text("extern template class X<int>;")
+    template_kinds = [
+        f.kind
+        for f in facts
+        if f.kind
+        in (PatternKind.EXTERN_TEMPLATE, PatternKind.EXPLICIT_TEMPLATE_INSTANTIATION)
+    ]
+    assert template_kinds == [PatternKind.EXTERN_TEMPLATE]
+
+
+def test_extern_cpp_not_flagged_as_extern_c() -> None:
+    assert PatternKind.EXTERN_C not in _kinds('extern "C++" void f();')
+
+
+# ── Comment / string-literal blanking avoids false positives ─────────────────
+
+
+def test_keyword_in_line_comment_ignored() -> None:
+    assert _kinds("// use #pragma pack here\nint x;") == set()
+
+
+def test_keyword_in_block_comment_ignored() -> None:
+    src = "/* virtual and operator new are documented */\nint x;"
+    assert _kinds(src) == set()
+
+
+def test_keyword_in_string_literal_ignored() -> None:
+    assert _kinds('const char* s = "#pragma pack(1)";') == set()
+
+
+def test_line_numbers_preserved_through_comments() -> None:
+    src = (
+        "/* multi\n"  # line 1-2 block comment
+        "   line */\n"
+        "struct alignas(4) S {};\n"  # line 3
+    )
+    facts = [f for f in scan_text(src) if f.kind is PatternKind.ALIGNAS]
+    assert len(facts) == 1
+    assert facts[0].line == 3
+
+
+def test_code_after_block_comment_still_scanned() -> None:
+    src = "/* c */ virtual void f();"
+    assert PatternKind.VIRTUAL_METHOD in _kinds(src)
+
+
+# ── Escalation triggers + categories ─────────────────────────────────────────
+
+
+def test_layout_construct_escalates_to_s5() -> None:
+    facts = scan_text("#pragma pack(1)\nstruct S { int x; };", path="h.h")
+    res = PatternScanResult(facts=facts, files_scanned=1)
+    assert res.should_escalate is True
+    triggers = res.escalation_triggers
+    assert len(triggers) == 1
+    assert triggers[0].kind is PatternKind.PRAGMA_PACK
+    assert triggers[0].recommended_method == "s5"
+    assert triggers[0].category is PatternCategory.LAYOUT
+    assert triggers[0].sample_location == "h.h:1"
+
+
+def test_advisory_only_construct_does_not_escalate() -> None:
+    facts = scan_text('extern "C" void f();', path="h.h")
+    res = PatternScanResult(facts=facts, files_scanned=1)
+    assert res.should_escalate is False
+    assert res.escalation_triggers == []
+
+
+def test_escalation_triggers_grouped_per_kind() -> None:
+    src = "struct B { virtual void a(); virtual void b(); virtual void c(); };"
+    res = PatternScanResult(facts=scan_text(src, path="h.h"), files_scanned=1)
+    triggers = [
+        t for t in res.escalation_triggers if t.kind is PatternKind.VIRTUAL_METHOD
+    ]
+    assert len(triggers) == 1
+    assert triggers[0].count == 3
+
+
+def test_escalation_triggers_sorted_deterministically() -> None:
+    src = "virtual void f();\n#pragma pack(1)\ninline namespace v1 {}"
+    res = PatternScanResult(facts=scan_text(src), files_scanned=1)
+    kinds = [t.kind.value for t in res.escalation_triggers]
+    assert kinds == sorted(kinds)
+
+
+# ── Result aggregation, coverage, serialization ──────────────────────────────
+
+
+def test_counts_by_kind_and_to_dict_roundtrip() -> None:
+    src = "virtual void a();\nvirtual void b();\n#pragma pack(1)"
+    res = PatternScanResult(facts=scan_text(src, path="h.h"), files_scanned=1)
+    counts = res.counts_by_kind()
+    assert counts[PatternKind.VIRTUAL_METHOD.value] == 2
+    assert counts[PatternKind.PRAGMA_PACK.value] == 1
+    payload = res.to_dict()
+    assert payload["version"] == PATTERN_SCAN_VERSION
+    assert payload["counts_by_kind"] == counts
+    assert len(payload["facts"]) == 3
+    assert payload["escalation_triggers"]  # non-empty (layout + vtable escalate)
+
+
+def test_coverage_present_when_files_scanned() -> None:
+    res = PatternScanResult(facts=[], files_scanned=3)
+    cov = res.coverage()
+    assert cov.status is CoverageStatus.PRESENT
+    assert cov.confidence is LayerConfidence.REDUCED
+    assert "3 file" in cov.detail
+
+
+def test_coverage_partial_when_files_skipped() -> None:
+    res = PatternScanResult(facts=[], files_scanned=2, files_skipped=1)
+    assert res.coverage().status is CoverageStatus.PARTIAL
+
+
+def test_coverage_not_collected_when_nothing_scanned() -> None:
+    assert PatternScanResult().coverage().status is CoverageStatus.NOT_COLLECTED
+
+
+# ── File walking + changed-path scoping ──────────────────────────────────────
+
+
+def test_iter_source_files_filters_by_suffix(tmp_path: Path) -> None:
+    (tmp_path / "a.hpp").write_text("int x;")
+    (tmp_path / "b.cpp").write_text("int y;")
+    (tmp_path / "README.md").write_text("# docs")
+    (tmp_path / "data.bin").write_bytes(b"\x00\x01")
+    found = {p.name for p in iter_source_files([tmp_path])}
+    assert found == {"a.hpp", "b.cpp"}
+
+
+def test_iter_source_files_changed_scope(tmp_path: Path) -> None:
+    inc = tmp_path / "include"
+    inc.mkdir()
+    (inc / "public.h").write_text("int p;")
+    (inc / "other.h").write_text("int o;")
+    found = {
+        p.name for p in iter_source_files([inc], changed_paths=["include/public.h"])
+    }
+    assert found == {"public.h"}
+
+
+def test_iter_source_files_changed_scope_bare_name(tmp_path: Path) -> None:
+    (tmp_path / "public.h").write_text("int p;")
+    (tmp_path / "other.h").write_text("int o;")
+    found = {p.name for p in iter_source_files([tmp_path], changed_paths=["public.h"])}
+    assert found == {"public.h"}
+
+
+def test_scan_files_aggregates_and_records_paths(tmp_path: Path) -> None:
+    h = tmp_path / "api.h"
+    h.write_text('extern "C" void f();\n#pragma pack(1)\nstruct S { int x; };')
+    res = scan_files([tmp_path])
+    assert res.files_scanned == 1
+    assert res.files_skipped == 0
+    assert any(f.path.endswith("api.h") for f in res.facts)
+    assert PatternKind.PRAGMA_PACK in {f.kind for f in res.facts}
+    assert res.should_escalate is True
+
+
+def test_scan_files_skips_missing_root_gracefully(tmp_path: Path) -> None:
+    res = scan_files([tmp_path / "does-not-exist"])
+    assert res.files_scanned == 0
+    assert res.facts == []
+    assert res.coverage().status is CoverageStatus.NOT_COLLECTED
+
+
+def test_scan_files_counts_unreadable_as_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "a.h").write_text("int x;")
+
+    def _boom(self: Path, *a: object, **k: object) -> str:
+        raise OSError("unreadable")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    res = scan_files([tmp_path])
+    assert res.files_scanned == 0
+    assert res.files_skipped == 1
+    assert res.coverage().status is CoverageStatus.NOT_COLLECTED
+
+
+# ── Char literals and escaped strings don't derail the scanner ───────────────
+
+
+def test_char_literal_with_escape_ignored() -> None:
+    # The quote/keyword inside a char literal must not be matched, and the
+    # escaped-char path in the blanker must keep line accounting intact.
+    src = "char q = '\"';\nchar n = '\\n';\nstruct alignas(4) S {};"
+    facts = [f for f in scan_text(src) if f.kind is PatternKind.ALIGNAS]
+    assert len(facts) == 1
+    assert facts[0].line == 3
+
+
+def test_escaped_quote_in_string_then_extern_c() -> None:
+    # A string with an escaped quote (exercises the string-preserving escape
+    # branch) followed by a real `extern "C"`.
+    src = 'const char* s = "a\\"b";\nextern "C" void f();'
+    kinds = _kinds(src)
+    assert PatternKind.EXTERN_C in kinds

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -266,6 +266,17 @@ def test_code_after_block_comment_still_scanned() -> None:
     assert PatternKind.VIRTUAL_METHOD in _kinds(src)
 
 
+def test_line_continuation_in_line_comment_stays_commented() -> None:
+    # A `//` comment ending in a backslash splices the next line into the
+    # comment (C/C++ line continuation), so the `virtual` is commented out.
+    assert PatternKind.VIRTUAL_METHOD not in _kinds("// note \\\nvirtual void f();")
+
+
+def test_line_comment_without_continuation_resumes_code() -> None:
+    # Without the trailing backslash, the next line is real code again.
+    assert PatternKind.VIRTUAL_METHOD in _kinds("// note\nvirtual void f();")
+
+
 # ── Escalation triggers + categories ─────────────────────────────────────────
 
 

--- a/tests/test_pattern_scan.py
+++ b/tests/test_pattern_scan.py
@@ -112,6 +112,31 @@ def test_extern_cpp_not_flagged_as_extern_c() -> None:
 
 
 @pytest.mark.parametrize(
+    "src",
+    [
+        "__attribute__((aligned(8))) int packed;",  # identifier named packed
+        "[[nodiscard]] bool packed();",  # method named packed, non-packing attr
+        "int packed = 1;",  # plain identifier
+    ],
+)
+def test_identifier_named_packed_not_flagged(src: str) -> None:
+    # The packed rule must stay inside the attribute parens, not match a later
+    # identifier that merely happens to be spelled `packed`.
+    assert PatternKind.ATTRIBUTE_PACKED not in _kinds(src)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "__attribute__((aligned(8))) int visibility;",
+        "[[nodiscard]] int visibility();",
+    ],
+)
+def test_identifier_named_visibility_not_flagged(src: str) -> None:
+    assert PatternKind.ATTRIBUTE_VISIBILITY not in _kinds(src)
+
+
+@pytest.mark.parametrize(
     "definition",
     [
         "template <typename T> class Foo {};",


### PR DESCRIPTION
## Summary

Implements **Phase 1** of ADR-035 (PR-Tier Source Intelligence & Cross-Source Validation, gap **G19**): the **always-on, compiler-free** half of the D2 PR pre-scan tier.

ADR-035 is an XL multi-phase initiative; this PR lands the foundational, self-contained piece the plan recommends doing first (order 1→2→3→4). It needs **no new dependencies** (pure stdlib regex), **no compile DB, no compiler**, and adds **no new `ChangeKind`s** — keeping it fully advisory and low-risk per the ADR-028 D3 / ADR-035 D1 authority rule.

## What it does

New `abicheck/buildsource/pattern_scan.py` — a pure lexical scan over changed+public source/header files for the ADR-035 D2 ABI-risk construct list:

- `#pragma pack`, `alignas`/`_Alignas`, `__attribute__((packed|visibility))`, `[[gnu::visibility]]`
- `__declspec(dllexport|dllimport)`, `extern "C"`, calling-convention macros (`__stdcall`, `WINAPI`, …)
- explicit / `extern` template instantiation, `inline namespace`, `virtual` methods, `operator new`/`delete`

It emits:
- **`PatternFact`s** — advisory hits with path/line/snippet/category, never a verdict;
- **`EscalationTrigger`s** — per-kind recommendations to run the deeper S5 source-ABI scan, feeding the D7 points-of-interest work-list;
- a **mandatory coverage row** (`LayerCoverage`) reporting how much was scanned (ADR-033 D6).

Comments and string/char literals are blanked first (preserving line numbers) so an ABI keyword inside a comment or string never false-positives; `extern "C"` — itself a string literal — is matched against a string-preserving variant.

## Authority rule preserved

The scan is **never authoritative for a `BREAKING` finding** — it only produces advisory facts and focusing hints (ADR-028 D3 / ADR-035 D1).

## Tests & gates

- `tests/test_pattern_scan.py` — 41 tests (default fast lane, no external tools): every D2 construct, comment/string blanking, escalation grouping/determinism, coverage states, file walking + changed-path scoping, unreadable-file handling.
- New module: **98% covered**, **mypy clean**, ruff + format clean.
- AI-readiness gate: **0 errors**. Full fast suite green (10,373 passed).

## Tracking

- `UC-WORKFLOW-pr-source-tier` flipped `planned` → `partial` with evidence; `next_steps` updated to scope what remains (S2 preprocessor capture, the `scan` orchestrator).
- `buildsource/CLAUDE.md` module map + g19 plan updated.

## Not in this PR (later phases)

Preprocessor macro/include capture (S2), cross-source validation `ChangeKind`s (Phase 2 / D4), the deterministic `scan` orchestrator (Phase 3 / D3), evidence-directed focusing wiring (D7), single-release audit (D8), and build-emitted facts (Phase 4 / D5).

https://claude.ai/code/session_01SQddLc8NSWLCGD8Yt45F4g

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQddLc8NSWLCGD8Yt45F4g)_