### PR TITLE
fix: preserve build cwd in make and bazel evidence

### DIFF
--- a/abicheck/buildsource/adapters/bazel.py
+++ b/abicheck/buildsource/adapters/bazel.py
@@ -93,7 +93,7 @@ class BazelAdapter:
         allow_query: bool = True,
         redaction: RedactionPolicy | None = None,
     ) -> None:
-        self.workspace = Path(workspace) if workspace is not None else None
+        self.workspace = Path(workspace).resolve() if workspace is not None else None
         self.target = target
         self._cquery = cquery
         self._aquery = aquery
@@ -251,17 +251,20 @@ class BazelAdapter:
         source = source_from_argv(argv)
         if not source:
             return None
-        ctx = _extract_flags(argv, Path("."))
+        directory = self.workspace or Path(".")
+        ctx = _extract_flags(argv, directory)
         output = graph.path(action.get("primaryOutputId"))
         red_argv = self.redaction.argv(argv)
         red_source = self.redaction.path(source)
         red_output = self.redaction.path(output)
+        red_directory = self.redaction.path(str(directory)) if self.workspace is not None else ""
         return CompileUnit(
             # Derive the id from redacted values only so host-specific paths
             # never leak through the id (ADR-028 D4: normalized facts only).
             id=compile_unit_id(red_source, red_argv, red_output),
             source=red_source,
             output=red_output,
+            directory=red_directory,
             target_id=graph.target_id(action.get("targetId")),
             argv=red_argv,
             language=effective_language(argv, source),

--- a/abicheck/buildsource/adapters/make.py
+++ b/abicheck/buildsource/adapters/make.py
@@ -38,6 +38,7 @@ is not an authoritative target graph), recorded via a diagnostic.
 from __future__ import annotations
 
 import os
+import re
 import shlex
 from pathlib import Path
 
@@ -80,17 +81,31 @@ class MakeAdapter:
             return ev
 
         directory = self.build_dir or Path(".")
+        directory_stack: list[Path] = []
         for line in text.splitlines():
+            event, event_dir = _directory_event(line)
+            if event == "enter" and event_dir is not None:
+                directory_stack.append(directory)
+                directory = event_dir
+                continue
+            if event == "leave":
+                directory = directory_stack.pop() if directory_stack else (self.build_dir or Path("."))
+                continue
             cu = self._compile_unit(line, directory)
             if cu is not None:
                 ev.compile_units.append(cu)
 
         if ev.compile_units:
             ev.build_options = derive_build_options(ev.compile_units)
+            existing_sources = _count_existing_sources(ev.compile_units)
             ev.diagnostics.append(
                 f"make: {len(ev.compile_units)} compile units derived from a make "
                 "dry-run transcript — reduced confidence (not an authoritative "
                 "target graph); prefer a generated compile_commands.json"
+            )
+            ev.diagnostics.append(
+                f"make: {existing_sources}/{len(ev.compile_units)} compile-unit "
+                "source paths exist relative to their recorded directories"
             )
         return ev
 
@@ -119,6 +134,7 @@ class MakeAdapter:
         # Recursive recipes prefix the compile with `cd sub && …`; the source and
         # `-I` paths are then relative to `sub/`, not the parent build dir.
         argv, directory = _consume_cd_prefix(argv, directory)
+        argv = _truncate_shell_pipeline(argv)
         # A translation-unit compile is a `-c` (GNU) / `/c` (MSVC, clang-cl)
         # invocation that names a source; link/info/`Entering directory` lines
         # lack one of those and are skipped.
@@ -127,12 +143,16 @@ class MakeAdapter:
         source = source_from_argv(argv)
         if not source:
             return None
+        argv, _expanded_rsp = _expand_response_files(argv, directory)
         ctx = _extract_flags(argv, directory)
+        output = _output_from_argv(argv)
         red_argv = self.redaction.argv(argv)
         red_source = self.redaction.path(source)
+        red_output = self.redaction.path(output)
         return CompileUnit(
-            id=compile_unit_id(red_source, red_argv),
+            id=compile_unit_id(red_source, red_argv, red_output),
             source=red_source,
+            output=red_output,
             directory=self.redaction.path(str(directory)),
             argv=red_argv,
             language=effective_language(argv, source),
@@ -169,6 +189,82 @@ def _split_recipe(line: str) -> list[str]:
         return shlex.split(stripped, posix=os.name != "nt")
     except ValueError:
         return []  # unbalanced quotes / non-command line — skip
+
+
+_ENTER_RE = re.compile(r"^make(?:\[\d+\])?: Entering directory ['`](.+)['`]$")
+_LEAVE_RE = re.compile(r"^make(?:\[\d+\])?: Leaving directory ['`](.+)['`]$")
+
+
+def _directory_event(line: str) -> tuple[str, Path | None]:
+    """Return make directory transitions from ``make -C`` / recursive logs."""
+    stripped = line.strip()
+    m = _ENTER_RE.match(stripped)
+    if m:
+        return "enter", Path(m.group(1))
+    if _LEAVE_RE.match(stripped):
+        return "leave", None
+    return "", None
+
+
+def _truncate_shell_pipeline(argv: list[str]) -> list[str]:
+    """Keep only the compiler invocation before shell control operators."""
+    for i, arg in enumerate(argv):
+        if arg in {"&&", ";", "||", "|"}:
+            return argv[:i]
+    return argv
+
+
+def _expand_response_files(argv: list[str], directory: Path) -> tuple[list[str], bool]:
+    """Inline readable compiler response-file tokens (``@file``)."""
+    expanded: list[str] = []
+    changed = False
+    for arg in argv:
+        if not arg.startswith("@") or len(arg) == 1:
+            expanded.append(arg)
+            continue
+        path = Path(arg[1:])
+        if not path.is_absolute():
+            path = directory / path
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            expanded.append(arg)
+            continue
+        try:
+            expanded.extend(shlex.split(text, posix=os.name != "nt"))
+            changed = True
+        except ValueError:
+            expanded.append(arg)
+    return expanded, changed
+
+
+def _output_from_argv(argv: list[str]) -> str:
+    """Extract the object output path from GNU/MSVC compile argv."""
+    out = ""
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("-o", "/Fo") and i + 1 < len(argv):
+            out = argv[i + 1]
+            i += 2
+            continue
+        if arg.startswith("-o") and len(arg) > 2:
+            out = arg[2:]
+        elif arg.startswith("/Fo") and len(arg) > 3:
+            out = arg[3:]
+        i += 1
+    return out
+
+
+def _count_existing_sources(units: list[CompileUnit]) -> int:
+    count = 0
+    for cu in units:
+        source = Path(os.path.expanduser(cu.source))
+        if not source.is_absolute() and cu.directory:
+            source = Path(os.path.expanduser(cu.directory)) / source
+        if source.is_file():
+            count += 1
+    return count
 
 
 def _as_text(value: str | Path | None) -> str | None:

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -483,7 +483,7 @@ def _run_adapters(
         ))
 
     if bazel_cquery is not None or bazel_aquery is not None:
-        ev = BazelAdapter(cquery=bazel_cquery, aquery=bazel_aquery).collect()
+        ev = BazelAdapter(workspace=build_dir, cquery=bazel_cquery, aquery=bazel_aquery).collect()
         merged.merge(ev)
         inputs = [DEFAULT_REDACTION.path(str(p)) for p in (bazel_cquery, bazel_aquery) if p is not None]
         extractors.append(ExtractorRecord(

--- a/tests/test_bazel_adapter.py
+++ b/tests/test_bazel_adapter.py
@@ -277,6 +277,11 @@ def test_bazel_param_file_arguments_are_expanded():
     assert cu.standard == "c++20"
 
 
+def test_bazel_workspace_sets_compile_unit_directory(tmp_path):
+    cu = BazelAdapter(workspace=tmp_path, aquery=AQUERY).collect().compile_units[0]
+    assert Path(cu.directory).expanduser() == tmp_path.resolve()
+
+
 def test_bazel_param_file_expanded_at_token_position():
     # Param-file args expand at the @token position, not at the end, so a
     # later command-line -std wins (matching the real compiler's last-wins rule).
@@ -595,6 +600,27 @@ def test_collect_evidence_bazel_files(tmp_path):
     assert pack.build_evidence is not None
     assert any(t.build_system == "bazel" for t in pack.build_evidence.targets)
     assert any(e.name == "bazel" and e.status == "ok" for e in pack.manifest.extractors)
+
+
+def test_collect_evidence_bazel_files_uses_build_dir_as_workspace(tmp_path):
+    aq = tmp_path / "aquery.json"
+    aq.write_text(AQUERY)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    out = tmp_path / "e"
+    result = CliRunner().invoke(
+        main,
+        [
+            "collect",
+            "--build-dir", str(workspace),
+            "--bazel-aquery", str(aq),
+            "-o", str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    pack = BuildSourcePack.load(out)
+    assert pack.build_evidence is not None
+    assert Path(pack.build_evidence.compile_units[0].directory).expanduser() == workspace.resolve()
 
 
 def test_collect_evidence_bazel_link_only_pack_preserved(tmp_path):

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -15,6 +15,8 @@
 """Make adapter coverage (ADR-029 D7)."""
 from __future__ import annotations
 
+from pathlib import Path
+
 from click.testing import CliRunner
 
 from abicheck.buildsource.adapters import MakeAdapter
@@ -77,6 +79,44 @@ def test_make_cd_prefixed_recipe_resolves_in_subdir():
     # Path separators differ across OSes (sub\include on Windows); normalize.
     assert cu.directory.replace("\\", "/").endswith("sub")    # advanced into cd target
     assert any(p.replace("\\", "/").endswith("sub/include") for p in cu.include_paths)
+
+
+def test_make_entering_directory_sets_compile_cwd(tmp_path):
+    src = tmp_path / "src" / "foo.cc"
+    src.parent.mkdir()
+    src.write_text("int f() { return 0; }\n")
+    dry = (
+        f"make: Entering directory '{tmp_path}'\n"
+        "g++ -std=c++17 -c src/foo.cc -o build/foo.o\n"
+        f"make: Leaving directory '{tmp_path}'\n"
+    )
+    cu = MakeAdapter(dry_run=dry).collect().compile_units[0]
+    assert Path(cu.directory).expanduser() == tmp_path
+    assert (Path(cu.directory).expanduser() / cu.source).is_file()
+
+
+def test_make_expands_response_file_and_truncates_shell_suffix(tmp_path):
+    src = tmp_path / "src" / "foo.cc"
+    inc = tmp_path / "include"
+    build = tmp_path / "build"
+    src.parent.mkdir()
+    inc.mkdir()
+    build.mkdir()
+    src.write_text("int f() { return 0; }\n")
+    rsp = build / "inc.rsp"
+    rsp.write_text("-Iinclude -DMODE=1\n")
+    dry = (
+        f"make: Entering directory '{tmp_path}'\n"
+        "g++ @build/inc.rsp -std=c++17 -c src/foo.cc "
+        "-obuild/foo.o && sed -n ignored.d\n"
+        f"make: Leaving directory '{tmp_path}'\n"
+    )
+    cu = MakeAdapter(dry_run=dry).collect().compile_units[0]
+    assert "&&" not in cu.argv
+    assert "@build/inc.rsp" not in cu.argv
+    assert cu.defines["MODE"] == "1"
+    assert cu.output == "build/foo.o"
+    assert any(Path(p).expanduser() == inc for p in cu.include_paths)
 
 
 def test_make_msvc_combined_forced_include_not_source():


### PR DESCRIPTION
## Summary
- preserve Make dry-run cwd from make Entering directory logs and record source-existence diagnostics
- normalize Make compile recipes by trimming shell suffixes, expanding response files, and capturing joined output flags
- preserve Bazel workspace cwd for pre-captured aquery/cquery collection via --build-dir

## Proof
- PYTHONPATH=. python -m pytest tests/test_make_adapter.py tests/test_bazel_adapter.py tests/test_source_replay.py -q
- git diff --check
- oneDAL Make smoke: 861/861 sources exist, 861 units with include paths, no shell suffix in argv
- oneDAL Bazel smoke: 1519/1519 sources exist, 1519 units with include paths
- oneDAL L4 changed-TU smoke: parsed 1/1, extractor_failures=0