### PR TITLE
fix: map package public headers to build include roots

### DIFF
--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -52,10 +52,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from ..build_evidence import CompileUnit
@@ -73,7 +74,7 @@ from .base import SourceExtractionError
 
 #: clang extractor schema/behaviour version, recorded in the dump provenance and
 #: folded into the per-TU cache key (ADR-030 D8).
-CLANG_EXTRACTOR_VERSION = "0.1"
+CLANG_EXTRACTOR_VERSION = "0.3"
 
 #: AST node kinds clang emits for the entities we fingerprint. Includes the C++
 #: special members (constructor/destructor/conversion) so a change to a public
@@ -110,6 +111,21 @@ _LITERAL_NODE_KINDS = frozenset(
 #: dropped so the hash is stable across builds/checkouts (mirrors the build-root
 #: independence of ``SourceEntity.identity()``).
 _FINGERPRINT_SCALAR_KEYS = ("kind", "name", "value", "opcode", "castKind")
+_PUBLIC_ROOT_SAMPLE_LIMIT = 128
+_PUBLIC_ROOT_WHOLE_DIR_MIN_MATCHES = 2
+_PUBLIC_FILE_ROOT_SUFFIX_LIMIT = 6
+_PUBLIC_HEADER_SUFFIXES = (
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".h++",
+    ".inc",
+    ".inl",
+    ".ipp",
+    ".tcc",
+    ".tpp",
+)
 
 
 #: Header extensions that are typically *generated* by the build (TableGen `.inc`,
@@ -588,9 +604,10 @@ class _ClassifyContext:
         # (`include` vs `include/api.h`), dropping the whole public include tree;
         # split file roots from directory roots first (Codex review #339, P2).
         file_roots, dir_roots = split_public_roots(public_header_roots)
-        self.header_segs, self.dir_segs, self.have_set = build_public_set(
-            file_roots, dir_roots
-        )
+        self.exact_header_segs = [_file_segments(root) for root in file_roots]
+        self.exact_header_segs = [seg for seg in self.exact_header_segs if seg]
+        _, self.dir_segs, self.have_set = build_public_set([], dir_roots)
+        self.have_set = self.have_set or bool(self.exact_header_segs)
 
     def classify(self, file: str) -> tuple[str, str, bool]:
         """Return ``(visibility, origin_label, api_relevant)`` for a file.
@@ -603,8 +620,12 @@ class _ClassifyContext:
         from ...model import ScopeOrigin
         from ...provenance import classify_origin, is_generated_header
 
+        if _matches_exact_public_header(file, self.exact_header_segs):
+            if is_generated_header(file):
+                return "generated", "GENERATED", True
+            return "public_header", "PUBLIC_HEADER", True
         origin = classify_origin(
-            file, self.header_segs, self.dir_segs, have_public_set=self.have_set
+            file, [], self.dir_segs, have_public_set=self.have_set
         )
         if origin == ScopeOrigin.PUBLIC_HEADER and is_generated_header(file):
             return "generated", "GENERATED", True
@@ -613,6 +634,260 @@ class _ClassifyContext:
         if origin == ScopeOrigin.GENERATED:
             return "private_header", "PRIVATE_HEADER", False
         return "unknown", "UNKNOWN", False
+
+
+def _file_segments(path: str) -> tuple[str, ...]:
+    posix = path.replace("\\", "/")
+    return tuple(p for p in PurePosixPath(posix).parts if p not in ("/", ".", ""))
+
+
+def _matches_exact_public_header(
+    header: str, exact_header_segs: list[tuple[str, ...]]
+) -> bool:
+    header_segs = _file_segments(header)
+    return any(
+        len(header_segs) >= len(root) and header_segs[-len(root) :] == root
+        for root in exact_header_segs
+    )
+
+
+def _header_samples(root: str) -> tuple[bool, list[Path]]:
+    """Relative header names under an existing public root, bounded for speed.
+
+    Package/public roots often point at an installed SDK include tree while the
+    compile unit reads the corresponding build-tree include directory. A small
+    deterministic sample is enough to recognize that equivalence without hashing
+    or scanning the entire SDK for every TU.
+    """
+    p = Path(unredact_home(root)).expanduser()
+    if p.is_file() and _looks_like_public_header(p):
+        return True, _path_suffixes(p, _PUBLIC_FILE_ROOT_SUFFIX_LIMIT)
+    if not p.is_dir():
+        return False, []
+    out: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(p):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            child = Path(dirpath) / filename
+            if not _looks_like_public_header(child):
+                continue
+            out.append(child.relative_to(p))
+            if len(out) >= _PUBLIC_ROOT_SAMPLE_LIMIT:
+                return False, out
+    return False, out
+
+
+def _path_suffixes(path: Path, limit: int) -> list[Path]:
+    parts = tuple(part for part in path.parts if part not in (path.anchor, "/", ""))
+    return [Path(*parts[-n:]) for n in range(min(limit, len(parts)), 0, -1)]
+
+
+def _looks_like_public_header(path: Path) -> bool:
+    return path.suffix.lower() in _PUBLIC_HEADER_SUFFIXES or not path.suffix
+
+
+def _compile_unit_include_dir(raw_inc: str, compile_unit: CompileUnit) -> Path:
+    inc = Path(unredact_home(raw_inc)).expanduser()
+    if inc.is_absolute():
+        return inc
+    directory = Path(unredact_home(compile_unit.directory or ".")).expanduser()
+    return directory / inc
+
+
+def _compile_unit_include_roots(
+    compile_unit: CompileUnit, compiler_binary: str | None = None
+) -> list[tuple[str, Path]]:
+    roots = [
+        (raw, _compile_unit_include_dir(raw, compile_unit))
+        for raw in compile_unit.include_paths
+    ]
+    roots.extend(
+        (raw, _compile_unit_include_dir(raw, compile_unit))
+        for raw in compile_unit.system_include_paths
+    )
+    cc_bin = pick_compiler_binary(compile_unit, compiler_binary)
+    cc_id = "msvc" if is_msvc_mode(cc_bin) else "gnu"
+    replay_flags = replay_extra_flags(compile_unit, [], cc_id)
+    i = 0
+    while i < len(replay_flags):
+        tok = replay_flags[i]
+        raw: str | None = None
+        if tok in {"-iquote", "-idirafter"} and i + 1 < len(replay_flags):
+            raw = replay_flags[i + 1]
+            i += 2
+        elif tok.startswith("-iquote") and len(tok) > len("-iquote"):
+            raw = tok[len("-iquote") :]
+            i += 1
+        elif tok.startswith("-idirafter") and len(tok) > len("-idirafter"):
+            raw = tok[len("-idirafter") :]
+            i += 1
+        elif cc_id == "msvc" and tok in {"/I", "-I"} and i + 1 < len(replay_flags):
+            raw = replay_flags[i + 1]
+            i += 2
+        elif (
+            cc_id == "msvc"
+            and len(tok) > 2
+            and (tok.startswith("/I") or tok.startswith("-I"))
+        ):
+            raw = tok[2:]
+            i += 1
+        else:
+            i += 1
+        if raw:
+            roots.append((raw, _compile_unit_include_dir(raw, compile_unit)))
+    return roots
+
+
+def _root_spelling(raw_inc: str, resolved_inc: Path, rel: Path | None) -> str:
+    base = _include_spelling_base(raw_inc, resolved_inc)
+    if rel is not None:
+        return str(base / rel)
+    return _dir_spelling(base)
+
+
+def _include_spelling_base(raw_inc: str, resolved_inc: Path) -> Path:
+    raw_path = Path(raw_inc)
+    raw_unredacted = Path(unredact_home(raw_inc)).expanduser()
+    return (
+        resolved_inc
+        if raw_path.is_absolute() or raw_unredacted.is_absolute()
+        else raw_path
+    )
+
+
+def _dir_spelling(path: Path) -> str:
+    spelling = str(path)
+    return spelling if path.is_absolute() or spelling.endswith(("/", "\\")) else spelling + "/"
+
+
+def _can_promote_whole_root(raw_inc: str, matched: list[Path]) -> bool:
+    raw_path = Path(raw_inc)
+    # A dot include root has no useful public path segments (`./` is dropped by
+    # provenance); keep matched files instead of a whole-root marker.
+    if str(raw_path) in {"", "."}:
+        return False
+    return len(matched) >= _PUBLIC_ROOT_WHOLE_DIR_MIN_MATCHES
+
+
+def _is_dot_include_root(raw_inc: str) -> bool:
+    return str(Path(raw_inc)) in {"", "."}
+
+
+def _is_full_single_header_mirror(samples: list[Path], matched: list[Path]) -> bool:
+    return len(samples) == 1 and len(matched) == 1
+
+
+def _strip_leading_sample_dir(samples: list[Path]) -> list[Path]:
+    stripped: list[Path] = []
+    for rel in samples:
+        parts = rel.parts
+        if len(parts) <= 1:
+            continue
+        stripped.append(Path(*parts[1:]))
+    return stripped
+
+
+def _mirror_dir_candidate(
+    raw_inc: str, inc: Path, prefix: Path | None, *, for_cache: bool
+) -> str:
+    if prefix is None:
+        return str(inc) if for_cache else _root_spelling(raw_inc, inc, None)
+    if for_cache:
+        return str(inc / prefix)
+    return _dir_spelling(_include_spelling_base(raw_inc, inc) / prefix)
+
+
+def _equivalent_public_roots_for_unit(
+    public_header_roots: list[str],
+    compile_unit: CompileUnit,
+    *,
+    for_cache: bool = False,
+    compiler_binary: str | None = None,
+) -> list[str]:
+    """Add build include dirs that mirror an installed public-header root.
+
+    L4 replay parses the source checkout/build tree, but release/package
+    validation commonly passes `-H` roots from an extracted package. Those paths
+    are different absolute trees even when they contain the same public headers,
+    so pure segment matching classifies every AST declaration as non-public.
+    When an include path contains the same relative public headers as an existing
+    public root, treat that include path as an equivalent public root for this TU.
+    """
+    roots = list(public_header_roots)
+    seen = {unredact_home(r) for r in roots}
+    samples_by_root: dict[str, tuple[bool, list[Path], list[Path]]] = {}
+    for root in public_header_roots:
+        is_file_root, samples = _header_samples(root)
+        if samples:
+            root_path = Path(unredact_home(root)).expanduser()
+            samples_by_root[root] = (
+                is_file_root,
+                [] if is_file_root else _path_suffixes(root_path, _PUBLIC_FILE_ROOT_SUFFIX_LIMIT),
+                samples,
+            )
+    if not samples_by_root:
+        return roots
+
+    for raw_inc, inc in _compile_unit_include_roots(compile_unit, compiler_binary):
+        whole_root = str(inc) if for_cache else _root_spelling(raw_inc, inc, None)
+        if not inc.is_dir() or whole_root in seen:
+            continue
+        for is_file_root, root_prefixes, samples in samples_by_root.values():
+            matched = [rel for rel in samples if (inc / rel).is_file()]
+            if is_file_root and matched:
+                matched = matched[:1]
+            prefix: Path | None = None
+            prefixed_match_found = False
+            if not is_file_root and root_prefixes:
+                for candidate_prefix in root_prefixes:
+                    prefixed = [candidate_prefix / rel for rel in samples]
+                    prefixed_matched = [rel for rel in prefixed if (inc / rel).is_file()]
+                    if _can_promote_whole_root(
+                        raw_inc, prefixed_matched
+                    ) or _is_full_single_header_mirror(samples, prefixed_matched):
+                        matched = prefixed_matched
+                        prefix = candidate_prefix
+                        prefixed_match_found = True
+                        break
+                if not prefixed_match_found and not _can_promote_whole_root(raw_inc, matched):
+                    stripped = _strip_leading_sample_dir(samples)
+                    stripped_matched = [rel for rel in stripped if (inc / rel).is_file()]
+                    if _can_promote_whole_root(
+                        raw_inc, stripped_matched
+                    ) or _is_full_single_header_mirror(samples, stripped_matched):
+                        matched = stripped_matched
+                        prefix = None
+            if for_cache:
+                for rel in matched:
+                    candidate = str(inc / rel)
+                    if candidate not in seen:
+                        roots.append(candidate)
+                        seen.add(candidate)
+                continue
+            if is_file_root or (
+                _is_dot_include_root(raw_inc)
+                and len(matched) >= _PUBLIC_ROOT_WHOLE_DIR_MIN_MATCHES
+            ):
+                for rel in matched:
+                    candidate = _root_spelling(raw_inc, inc, rel)
+                    if candidate not in seen:
+                        roots.append(candidate)
+                        seen.add(candidate)
+                continue
+            if _is_full_single_header_mirror(samples, matched):
+                candidate = _root_spelling(raw_inc, inc, matched[0])
+                if candidate not in seen:
+                    roots.append(candidate)
+                    seen.add(candidate)
+                continue
+            if not _can_promote_whole_root(raw_inc, matched):
+                continue
+            if matched:
+                candidate = _mirror_dir_candidate(raw_inc, inc, prefix, for_cache=for_cache)
+                if candidate not in seen:
+                    roots.append(candidate)
+                    seen.add(candidate)
+    return roots
 
 
 #: A ``-E`` line marker: ``# <line> "<file>" [flags]`` — sets the current file.
@@ -1251,6 +1526,16 @@ class ClangSourceExtractor:
     def available(self) -> bool:
         return shutil.which(self.clang_bin) is not None
 
+    def effective_public_header_roots_for_cache(
+        self, compile_unit: CompileUnit, public_header_roots: list[str]
+    ) -> list[str]:
+        return _equivalent_public_roots_for_unit(
+            public_header_roots,
+            compile_unit,
+            for_cache=True,
+            compiler_binary=self.compiler_binary,
+        )
+
     def extract(
         self,
         compile_unit: CompileUnit,
@@ -1295,10 +1580,13 @@ class ClangSourceExtractor:
                 f"clang exited {result.returncode} (recovered): {result.stderr[:300]}"
                 + _missing_generated_header_hint(result.stderr)
             )
-        tu = source_abi_from_clang_ast(
-            ast_root, compile_unit, public_header_roots, target_id, diagnostics=diags,
+        effective_public_roots = _equivalent_public_roots_for_unit(
+            public_header_roots, compile_unit, compiler_binary=self.compiler_binary
         )
-        self._attach_macros(tu, compile_unit, source, directory, public_header_roots)
+        tu = source_abi_from_clang_ast(
+            ast_root, compile_unit, effective_public_roots, target_id, diagnostics=diags,
+        )
+        self._attach_macros(tu, compile_unit, source, directory, effective_public_roots)
         return tu
 
     def _run(

--- a/abicheck/buildsource/source_replay.py
+++ b/abicheck/buildsource/source_replay.py
@@ -809,16 +809,15 @@ def run_source_replay(
     results: list[SourceAbiTu | None] = [None] * len(units)
     misses: list[int] = []
     for i, cu in enumerate(units):
-        key = (
-            compute_tu_cache_key(
+        key = None
+        if cache is not None:
+            key_roots = _cache_public_header_roots(extractor, cu, roots)
+            key = compute_tu_cache_key(
                 extractor_name=getattr(extractor, "name", "source"),
                 extractor_version=_extractor_version(extractor),
                 compile_unit=cu,
-                public_header_roots=roots,
+                public_header_roots=key_roots,
             )
-            if cache is not None
-            else None
-        )
         keys.append(key)
         cached = cache.get(key, digest_memo) if cache is not None else None
         if cached is not None:
@@ -972,3 +971,15 @@ def _extract_one(
 def _extractor_version(extractor: SourceAbiExtractor) -> str:
     """Pull a version string off an extractor for the cache key, if it exposes one."""
     return str(getattr(extractor, "version", "") or "")
+
+
+def _cache_public_header_roots(
+    extractor: SourceAbiExtractor,
+    compile_unit: CompileUnit,
+    public_header_roots: list[str],
+) -> list[str]:
+    """Let extractors fold probe-dependent public-root expansion into D8 keys."""
+    hook = getattr(extractor, "effective_public_header_roots_for_cache", None)
+    if not callable(hook):
+        return public_header_roots
+    return list(hook(compile_unit, public_header_roots))

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -35,6 +35,10 @@ from abicheck.buildsource.source_extractors import (
     build_clang_macro_command,
     source_abi_from_clang_ast,
 )
+from abicheck.buildsource.source_extractors.clang import (
+    _equivalent_public_roots_for_unit,
+    _path_suffixes,
+)
 from abicheck.buildsource.source_link import link_source_abi
 
 
@@ -80,6 +84,492 @@ def test_build_command_c_language() -> None:
     cmd = build_clang_command(_cu(language="C", standard="c11"), Path("a.c"))
     assert cmd[cmd.index("-x") + 1] == "c"
     assert "-std=c11" in cmd
+
+
+def test_public_package_root_maps_to_equivalent_build_include_dir(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "opt" / "dal" / "include"
+    build_include = tmp_path / "src" / "__release" / "daal" / "latest" / "include"
+    system_build_include = tmp_path / "src" / "__release" / "sys" / "include"
+    (package_include / "oneapi").mkdir(parents=True)
+    (build_include / "oneapi").mkdir(parents=True)
+    (system_build_include / "oneapi").mkdir(parents=True)
+    (package_include / "oneapi" / "dal.hpp").write_text("// package header\n")
+    (package_include / "oneapi" / "version.hpp").write_text("// package header\n")
+    (build_include / "oneapi" / "dal.hpp").write_text("// build header\n")
+    (build_include / "oneapi" / "version.hpp").write_text("// build header\n")
+    (system_build_include / "oneapi" / "dal.hpp").write_text("// system build header\n")
+    (system_build_include / "oneapi" / "version.hpp").write_text("// system build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(
+            include_paths=[str(build_include), str(tmp_path / "other" / "include")],
+            system_include_paths=[str(system_build_include)],
+        ),
+    )
+
+    assert roots == [str(package_include), str(build_include), str(system_build_include)]
+
+
+def test_public_package_root_maps_relative_include_against_compile_directory(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_dir = tmp_path / "build"
+    build_include = build_dir / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_include / "api" / "one.h").write_text("// build header\n")
+    (build_include / "api" / "two.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(directory=str(build_dir), include_paths=["include"]),
+    )
+
+    assert roots == [str(package_include), "include/"]
+
+    cache_roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(directory=str(build_dir), include_paths=["include"]),
+        for_cache=True,
+    )
+    assert cache_roots == [
+        str(package_include),
+        str(build_include / "api" / "one.h"),
+        str(build_include / "api" / "two.h"),
+    ]
+
+
+def test_relative_mirror_directory_root_classifies_clang_relative_locations() -> None:
+    tu = source_abi_from_clang_ast(
+        {
+            "kind": "TranslationUnitDecl",
+            "inner": [
+                {
+                    "kind": "FunctionDecl",
+                    "name": "api_fn",
+                    "loc": {"file": "include/api/one.h", "line": 1},
+                    "type": {"qualType": "void ()"},
+                }
+            ],
+        },
+        _cu(directory="/build", include_paths=["include"]),
+        ["include/"],
+        "target://lib",
+    )
+
+    assert [fn.qualified_name for fn in tu.functions] == ["api_fn"]
+
+
+def test_public_package_root_weak_match_does_not_promote_directory(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "version.h").write_text("// package header\n")
+    (package_include / "api" / "feature.h").write_text("// package header\n")
+    (build_include / "api" / "version.h").write_text("// coincidental build header\n")
+    (build_include / "api" / "private.h").write_text("// private sibling\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include)]
+
+
+def test_public_package_root_probes_argv_only_include_dirs(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_dir = tmp_path / "build"
+    build_include = build_dir / "quote"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_include / "api" / "one.h").write_text("// build header\n")
+    (build_include / "api" / "two.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(directory=str(build_dir), argv=["clang++", "-iquote", "quote", "-c", "x.cpp"]),
+    )
+
+    assert roots == [str(package_include), "quote/"]
+
+
+def test_clang_cache_roots_include_absolute_mirror_probes(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_dir = tmp_path / "build"
+    build_include = build_dir / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_include / "api" / "one.h").write_text("// build header\n")
+    (build_include / "api" / "two.h").write_text("// build header\n")
+
+    roots = ClangSourceExtractor().effective_public_header_roots_for_cache(
+        _cu(directory=str(build_dir), include_paths=["include"]),
+        [str(package_include)],
+    )
+
+    assert roots == [
+        str(package_include),
+        str(build_include / "api" / "one.h"),
+        str(build_include / "api" / "two.h"),
+    ]
+
+
+def test_clang_compiler_override_probes_msvc_argv_include_dirs(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_include / "api" / "one.h").write_text("// build header\n")
+    (build_include / "api" / "two.h").write_text("// build header\n")
+
+    roots = (
+        ClangSourceExtractor(compiler_binary="clang-cl")
+        .effective_public_header_roots_for_cache(
+            _cu(argv=["ccache", "wrapped-cxx", "/I", str(build_include), "/c", "x.cpp"]),
+            [str(package_include)],
+        )
+    )
+
+    assert roots == [
+        str(package_include),
+        str(build_include / "api" / "one.h"),
+        str(build_include / "api" / "two.h"),
+    ]
+
+
+def test_public_package_root_samples_extensionless_headers(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "Eigen").mkdir(parents=True)
+    (build_include / "Eigen").mkdir(parents=True)
+    (package_include / "Eigen" / "Core").write_text("// package header\n")
+    (package_include / "Eigen" / "Dense").write_text("// package header\n")
+    (build_include / "Eigen" / "Core").write_text("// build header\n")
+    (build_include / "Eigen" / "Dense").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include), str(build_include)]
+
+
+def test_public_package_root_samples_lowercase_extensionless_headers(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "boost").mkdir(parents=True)
+    (build_include / "boost").mkdir(parents=True)
+    (package_include / "boost" / "config").write_text("// package header\n")
+    (package_include / "boost" / "version").write_text("// package header\n")
+    (build_include / "boost" / "config").write_text("// build header\n")
+    (build_include / "boost" / "version").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include), str(build_include)]
+
+
+def test_public_package_subdir_root_maps_to_equivalent_build_subdir(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_include / "api" / "one.h").write_text("// build header\n")
+    (build_include / "api" / "two.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "api")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include / "api"), str(build_include / "api")]
+
+
+def test_public_root_suffix_candidates_are_relative() -> None:
+    suffixes = _path_suffixes(Path("/pkg/include/api"), 6)
+
+    assert suffixes[0] == Path("pkg/include/api")
+    assert all(not suffix.is_absolute() for suffix in suffixes)
+
+
+def test_public_subdir_root_prefers_prefixed_mirror_over_parent(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_include / "api" / "one.h").write_text("// real mirror\n")
+    (build_include / "api" / "two.h").write_text("// real mirror\n")
+    (build_include / "one.h").write_text("// coincidental top-level header\n")
+    (build_include / "two.h").write_text("// coincidental top-level header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "api")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include / "api"), str(build_include / "api")]
+
+
+def test_multiple_public_subdir_roots_map_to_same_build_include(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    for dirname in ("api", "other"):
+        (package_include / dirname).mkdir(parents=True)
+        (build_include / dirname).mkdir(parents=True)
+        (package_include / dirname / "one.h").write_text("// package header\n")
+        (package_include / dirname / "two.h").write_text("// package header\n")
+        (build_include / dirname / "one.h").write_text("// build header\n")
+        (build_include / dirname / "two.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "api"), str(package_include / "other")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [
+        str(package_include / "api"),
+        str(package_include / "other"),
+        str(build_include / "api"),
+        str(build_include / "other"),
+    ]
+
+
+def test_nested_public_subdir_root_preserves_prefix_in_build_include(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "oneapi" / "dal").mkdir(parents=True)
+    (build_include / "oneapi" / "dal").mkdir(parents=True)
+    (package_include / "oneapi" / "dal" / "one.hpp").write_text("// package header\n")
+    (package_include / "oneapi" / "dal" / "two.hpp").write_text("// package header\n")
+    (build_include / "oneapi" / "dal" / "one.hpp").write_text("// build header\n")
+    (build_include / "oneapi" / "dal" / "two.hpp").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "oneapi" / "dal")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [
+        str(package_include / "oneapi" / "dal"),
+        str(build_include / "oneapi" / "dal"),
+    ]
+
+
+def test_installed_include_namespace_prefix_can_map_to_build_include(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "src" / "cpp" / "daal" / "include"
+    (package_include / "dal" / "services").mkdir(parents=True)
+    (build_include / "services").mkdir(parents=True)
+    (package_include / "dal" / "services" / "base.h").write_text("// package header\n")
+    (package_include / "dal" / "services" / "status.h").write_text("// package header\n")
+    (build_include / "services" / "base.h").write_text("// build header\n")
+    (build_include / "services" / "status.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include), str(build_include)]
+
+    cache_roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+        for_cache=True,
+    )
+
+    assert cache_roots == [
+        str(package_include),
+        str(build_include / "services" / "base.h"),
+        str(build_include / "services" / "status.h"),
+    ]
+
+
+def test_single_header_public_dir_maps_to_mirrored_parent_dir(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "only.h").write_text("// package header\n")
+    (build_include / "api" / "only.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include), str(build_include / "api" / "only.h")]
+
+
+def test_single_header_public_subdir_maps_to_mirrored_subdir(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "oneapi" / "dal").mkdir(parents=True)
+    (build_include / "oneapi" / "dal").mkdir(parents=True)
+    (package_include / "oneapi" / "dal" / "only.hpp").write_text("// package header\n")
+    (build_include / "oneapi" / "dal" / "only.hpp").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "oneapi" / "dal")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [
+        str(package_include / "oneapi" / "dal"),
+        str(build_include / "oneapi" / "dal" / "only.hpp"),
+    ]
+
+
+def test_exact_file_roots_do_not_match_unrelated_same_basename(tmp_path: Path) -> None:
+    tu = source_abi_from_clang_ast(
+        {
+            "kind": "TranslationUnitDecl",
+            "inner": [
+                {
+                    "kind": "FunctionDecl",
+                    "name": "public_fn",
+                    "loc": {"file": str(tmp_path / "build" / "api" / "version.h"), "line": 1},
+                    "type": {"qualType": "void ()"},
+                },
+                {
+                    "kind": "FunctionDecl",
+                    "name": "private_fn",
+                    "loc": {"file": str(tmp_path / "build" / "private" / "version.h"), "line": 1},
+                    "type": {"qualType": "void ()"},
+                },
+            ],
+        },
+        _cu(),
+        [str(tmp_path / "build" / "api" / "version.h")],
+        "target://lib",
+    )
+
+    assert [fn.qualified_name for fn in tu.functions] == ["public_fn"]
+
+
+def test_public_file_root_uses_strongest_mirror_suffix(tmp_path: Path) -> None:
+    package_header = tmp_path / "pkg" / "include" / "api" / "version.h"
+    build_include = tmp_path / "build" / "include"
+    package_header.parent.mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    package_header.write_text("// package header\n")
+    (build_include / "api" / "version.h").write_text("// public mirror\n")
+    (build_include / "version.h").write_text("// unrelated private header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_header)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_header), str(build_include / "api" / "version.h")]
+
+
+def test_public_package_root_does_not_promote_dot_include_root(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_dir = tmp_path / "build"
+    (package_include / "api").mkdir(parents=True)
+    (build_dir / "api").mkdir(parents=True)
+    (package_include / "api" / "one.h").write_text("// package header\n")
+    (package_include / "api" / "two.h").write_text("// package header\n")
+    (build_dir / "api" / "one.h").write_text("// build header\n")
+    (build_dir / "api" / "two.h").write_text("// build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(directory=str(build_dir), include_paths=["."]),
+    )
+
+    assert roots == [
+        str(package_include),
+        str(Path("api") / "one.h"),
+        str(Path("api") / "two.h"),
+    ]
+
+
+def test_public_package_root_samples_template_include_fragments(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "detail.inc").write_text("// package fragment\n")
+    (package_include / "api" / "body.tcc").write_text("// package fragment\n")
+    (build_include / "api" / "detail.inc").write_text("// build fragment\n")
+    (build_include / "api" / "body.tcc").write_text("// build fragment\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include)],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include), str(build_include)]
+
+
+def test_public_package_file_root_maps_to_equivalent_build_file_only(tmp_path: Path) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    package_include.mkdir(parents=True)
+    build_include.mkdir(parents=True)
+    (package_include / "foo.h").write_text("// public package header\n")
+    (build_include / "foo.h").write_text("// public build header\n")
+    (build_include / "detail_impl.h").write_text("// private sibling\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "foo.h")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [str(package_include / "foo.h"), str(build_include / "foo.h")]
+
+
+def test_public_package_nested_file_root_maps_to_equivalent_build_file(
+    tmp_path: Path,
+) -> None:
+    package_include = tmp_path / "pkg" / "include"
+    build_include = tmp_path / "build" / "include"
+    (package_include / "api").mkdir(parents=True)
+    (build_include / "api").mkdir(parents=True)
+    (package_include / "api" / "foo.h").write_text("// public package header\n")
+    (build_include / "api" / "foo.h").write_text("// public build header\n")
+
+    roots = _equivalent_public_roots_for_unit(
+        [str(package_include / "api" / "foo.h")],
+        _cu(include_paths=[str(build_include)]),
+    )
+
+    assert roots == [
+        str(package_include / "api" / "foo.h"),
+        str(build_include / "api" / "foo.h"),
+    ]
 
 
 def test_build_command_msvc_driver_mode() -> None:


### PR DESCRIPTION
## Summary
- teach the clang source ABI extractor to treat build include directories as equivalent public roots when they contain the same relative headers as an installed/package public root
- bump the clang extractor version so source ABI caches do not reuse old zero-public-surface dumps
- add a regression test for package include -> build include mapping

## Proof
- python -m pytest tests/test_source_extractors_clang.py tests/test_source_replay.py -q (114 passed)
- git diff --check
- oneDAL 2026.0 package-only -H smoke on one changed TU: L3 861 compile units; L4 parsed 1/1; exported_symbols=9204; public_header_declarations=370; reachable_declarations=192; matched_symbols=76; extractor_failures=0

## Notes
Before this fix, the same package-only -H smoke parsed the TU but classified all source/build headers as UNKNOWN, yielding public_header_declarations=0, reachable_declarations=0, matched_symbols=0.