### PR TITLE
docs(adr): align ADR index status with source-of-truth ADR files

### DIFF
--- a/docs/development/adr/001-technology-stack.md
+++ b/docs/development/adr/001-technology-stack.md
@@ -1,7 +1,7 @@
 # ADR-001: Technology Stack — Python + pyelftools + castxml
 
 **Date:** 2026-03-07  
-**Status:** Accepted  
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/002-multi-binary-release-compare.md
+++ b/docs/development/adr/002-multi-binary-release-compare.md
@@ -1,7 +1,7 @@
 # ADR-002: Multi-binary / release compare UX and architecture
 
 **Date:** 2026-03-16  
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/003-data-source-architecture.md
+++ b/docs/development/adr/003-data-source-architecture.md
@@ -1,7 +1,7 @@
 # ADR-003: Data Source Architecture — Checks, Instruments, and Binary Types
 
 **Date:** 2026-03-17
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/004-report-filtering-and-deduplication.md
+++ b/docs/development/adr/004-report-filtering-and-deduplication.md
@@ -1,7 +1,7 @@
 # ADR-004: Report Filtering, Deduplication, and Leaf-Change Mode
 
 **Date:** 2026-03-17
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/005-application-compat-check.md
+++ b/docs/development/adr/005-application-compat-check.md
@@ -1,7 +1,7 @@
 # ADR-005: Application Compatibility Checking
 
 **Date:** 2026-03-17
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/006-package-level-comparison.md
+++ b/docs/development/adr/006-package-level-comparison.md
@@ -1,7 +1,7 @@
 # ADR-006: Package-Level Comparison
 
 **Date:** 2026-03-17
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/007-btf-ctf-debug-formats.md
+++ b/docs/development/adr/007-btf-ctf-debug-formats.md
@@ -1,7 +1,7 @@
 # ADR-007: BTF and CTF Debug Format Support
 
 **Date:** 2026-03-17
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/008-full-stack-dependency-validation.md
+++ b/docs/development/adr/008-full-stack-dependency-validation.md
@@ -1,7 +1,7 @@
 # ADR-008: Full-Stack Dependency Validation
 
 **Date:** 2026-03-17
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/009-verdict-system-and-exit-codes.md
+++ b/docs/development/adr/009-verdict-system-and-exit-codes.md
@@ -1,7 +1,7 @@
 # ADR-009: Verdict System and Exit Code Contract
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/010-policy-profile-system.md
+++ b/docs/development/adr/010-policy-profile-system.md
@@ -1,7 +1,7 @@
 # ADR-010: Policy Profile System
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/011-change-classification-taxonomy.md
+++ b/docs/development/adr/011-change-classification-taxonomy.md
@@ -1,7 +1,7 @@
 # ADR-011: ABI Change Classification Taxonomy
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/012-abicc-compatibility-layer.md
+++ b/docs/development/adr/012-abicc-compatibility-layer.md
@@ -1,7 +1,7 @@
 # ADR-012: ABICC Drop-In Compatibility Layer
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/013-suppression-system.md
+++ b/docs/development/adr/013-suppression-system.md
@@ -1,7 +1,7 @@
 # ADR-013: Suppression System Design
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/014-output-format-strategy.md
+++ b/docs/development/adr/014-output-format-strategy.md
@@ -1,7 +1,7 @@
 # ADR-014: Output Format Strategy
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/015-snapshot-serialization.md
+++ b/docs/development/adr/015-snapshot-serialization.md
@@ -1,7 +1,7 @@
 # ADR-015: Snapshot Serialization and Schema Versioning
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/016-visibility-model.md
+++ b/docs/development/adr/016-visibility-model.md
@@ -1,7 +1,7 @@
 # ADR-016: Three-Tier Visibility Model
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/017-github-action.md
+++ b/docs/development/adr/017-github-action.md
@@ -1,7 +1,7 @@
 # ADR-017: GitHub Action Design
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/018-cross-platform-support.md
+++ b/docs/development/adr/018-cross-platform-support.md
@@ -1,7 +1,7 @@
 # ADR-018: Cross-Platform Binary Format Support
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/019-testing-strategy.md
+++ b/docs/development/adr/019-testing-strategy.md
@@ -1,7 +1,7 @@
 # ADR-019: Testing Strategy and Parity Validation
 
 **Date:** 2026-03-18
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/020-build-context-capture.md
+++ b/docs/development/adr/020-build-context-capture.md
@@ -1,7 +1,7 @@
 # ADR-020a: Build-Context Aware Header Extraction
 
 **Date:** 2026-03-23
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/020-sycl-and-heterogeneous-stack-support.md
+++ b/docs/development/adr/020-sycl-and-heterogeneous-stack-support.md
@@ -1,7 +1,7 @@
 # ADR-020b: SYCL and Heterogeneous Computing Stack Support
 
 **Date:** 2026-03-22
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/021-debug-artifact-resolution.md
+++ b/docs/development/adr/021-debug-artifact-resolution.md
@@ -1,7 +1,7 @@
 # ADR-021a: Debug Artifact Resolution Subsystem
 
 **Date:** 2026-03-23
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/021-mcp-security-model.md
+++ b/docs/development/adr/021-mcp-security-model.md
@@ -1,7 +1,7 @@
 # ADR-021b: MCP Security Model
 
 **Date:** 2026-03-24
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/022-baseline-registry.md
+++ b/docs/development/adr/022-baseline-registry.md
@@ -1,7 +1,7 @@
 # ADR-022: Baseline Registry and Snapshot Distribution
 
 **Date:** 2026-03-23
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/023-bundle-aware-multi-binary-analysis.md
+++ b/docs/development/adr/023-bundle-aware-multi-binary-analysis.md
@@ -1,7 +1,7 @@
 # ADR-023: Bundle-aware multi-binary ABI analysis
 
 **Date:** 2026-05-20
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/024-public-abi-surface-resolution.md
+++ b/docs/development/adr/024-public-abi-surface-resolution.md
@@ -1,7 +1,7 @@
 # ADR-024: Public ABI Surface Resolution and False-Positive Traceability
 
 **Date:** 2026-05-30 (accepted 2026-05-31)
-**Status:** Accepted
+**Status:** Accepted — implemented
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -1,7 +1,11 @@
 # ADR-035: PR-Tier Source Intelligence and Cross-Source Validation
 
 **Date:** 2026-06-14
-**Status:** Proposed
+**Status:** Proposed — partially implemented (D1–D5 shipped; tracked as G19 in
+`docs/development/usecase-registry.yaml`). D5 (build-emitted source-facts
+protocol) is `complete`; D1/D3 (deterministic level + risk-scored `auto`),
+D2 (compiler-free pattern pre-scan), D4 (cross-source validation engine), and
+D9/D10 (scan coverage report) are `partial`. D6–D8 remain planned.
 **Decision maker:** Nikolay Petrov
 
 ---

--- a/docs/development/adr/index.md
+++ b/docs/development/adr/index.md
@@ -31,13 +31,13 @@
 | [025](025-pr-diff-source-evaluation.md) | PR-Diff-Aware ABI Evaluation (Source Diff as Trigger and Localizer) | Proposed |
 | [026](026-source-only-undetectable-changes.md) | Source-Only Changes and the Evidence-Tier Boundary | Accepted |
 | [027](027-api-surface-intelligence.md) | API Surface Intelligence — Structure Metrics, Idiom Detection, Cross-Library Reasoning, Pattern-Aware Verdicts | Accepted |
-| [028](028-source-build-evidence-pack.md) | Optional Source and Build Evidence Pack Architecture | Proposed |
-| [029](029-build-graph-toolchain-context-capture.md) | Build Graph and Toolchain Context Capture | Proposed |
-| [030](030-source-abi-replay-and-linked-source-surface.md) | Source ABI Replay and Linked Source Surface | Proposed |
-| [031](031-source-implementation-graph-augmentation.md) | Source and Implementation Graph Augmentation | Proposed |
-| [032](032-evidence-extractor-plugin-interface.md) | Evidence Extractor Plugin Interface and Security Model | Proposed |
-| [033](033-ci-rollout-performance-and-validation.md) | CI Rollout, Performance, Caching, and Validation Strategy | Proposed |
+| [028](028-source-build-evidence-pack.md) | Optional Source and Build Evidence Pack Architecture | Accepted — implemented |
+| [029](029-build-graph-toolchain-context-capture.md) | Build Graph and Toolchain Context Capture | Accepted — implemented |
+| [030](030-source-abi-replay-and-linked-source-surface.md) | Source ABI Replay and Linked Source Surface | Accepted — implemented |
+| [031](031-source-implementation-graph-augmentation.md) | Source and Implementation Graph Augmentation | Accepted — implemented |
+| [032](032-evidence-extractor-plugin-interface.md) | Evidence Extractor Plugin Interface and Security Model | Accepted — implemented |
+| [033](033-ci-rollout-performance-and-validation.md) | CI Rollout, Performance, Caching, and Validation Strategy | Accepted — implemented |
 | [034](034-managed-runtime-and-non-c-abi-frontends.md) | Managed-Runtime and Non-C ABI Frontends | Proposed |
-| [035](035-pr-tier-source-intelligence-and-crosscheck.md) | PR-Tier Source Intelligence and Cross-Source Validation | Proposed |
+| [035](035-pr-tier-source-intelligence-and-crosscheck.md) | PR-Tier Source Intelligence and Cross-Source Validation | Proposed — partially implemented (G19) |
 | [036](036-report-view-model.md) | Report view-model and canonical report severity | Accepted |
 | [Gap Analysis](adr-gap-analysis.md) | Decisions Needing Formal ADRs | Reference |

--- a/docs/development/adr/index.md
+++ b/docs/development/adr/index.md
@@ -2,32 +2,32 @@
 
 | # | Title | Status |
 |---|-------|--------|
-| [001](001-technology-stack.md) | Technology Stack — Python + pyelftools + castxml | Accepted |
-| [002](002-multi-binary-release-compare.md) | Multi-binary / release compare UX and architecture | Accepted |
-| [003](003-data-source-architecture.md) | Data Source Architecture — checks, instruments, and binary types (+ exploratory binary fingerprint extension) | Accepted |
-| [004](004-report-filtering-and-deduplication.md) | Report Filtering, Deduplication, and Leaf-Change Mode | Accepted |
-| [005](005-application-compat-check.md) | Application Compatibility Checking | Accepted |
-| [006](006-package-level-comparison.md) | Package-Level Comparison | Accepted |
-| [007](007-btf-ctf-debug-formats.md) | BTF and CTF Debug Format Support | Accepted |
-| [008](008-full-stack-dependency-validation.md) | Full-Stack Dependency Validation | Accepted |
-| [009](009-verdict-system-and-exit-codes.md) | Verdict System and Exit Code Contract | Accepted |
-| [010](010-policy-profile-system.md) | Policy Profile System | Accepted |
-| [011](011-change-classification-taxonomy.md) | ABI Change Classification Taxonomy | Accepted |
-| [012](012-abicc-compatibility-layer.md) | ABICC Drop-In Compatibility Layer | Accepted |
-| [013](013-suppression-system.md) | Suppression System Design | Accepted |
-| [014](014-output-format-strategy.md) | Output Format Strategy | Accepted |
-| [015](015-snapshot-serialization.md) | Snapshot Serialization and Schema Versioning | Accepted |
-| [016](016-visibility-model.md) | Three-Tier Visibility Model | Accepted |
-| [017](017-github-action.md) | GitHub Action Design | Accepted |
-| [018](018-cross-platform-support.md) | Cross-Platform Binary Format Support | Accepted |
-| [019](019-testing-strategy.md) | Testing Strategy and Parity Validation | Accepted |
-| [020a](020-build-context-capture.md) | Build-Context Aware Header Extraction | Accepted |
-| [020b](020-sycl-and-heterogeneous-stack-support.md) | SYCL and Heterogeneous Computing Stack Support | Accepted |
-| [021a](021-debug-artifact-resolution.md) | Debug Artifact Resolution Subsystem | Accepted |
-| [021b](021-mcp-security-model.md) | MCP Security Model | Accepted |
-| [022](022-baseline-registry.md) | Baseline Registry and Snapshot Distribution | Accepted |
-| [023](023-bundle-aware-multi-binary-analysis.md) | Bundle-Aware Multi-Binary ABI Analysis | Accepted |
-| [024](024-public-abi-surface-resolution.md) | Public ABI Surface Resolution and False-Positive Traceability | Accepted |
+| [001](001-technology-stack.md) | Technology Stack — Python + pyelftools + castxml | Accepted — implemented |
+| [002](002-multi-binary-release-compare.md) | Multi-binary / release compare UX and architecture | Accepted — implemented |
+| [003](003-data-source-architecture.md) | Data Source Architecture — checks, instruments, and binary types (+ exploratory binary fingerprint extension) | Accepted — implemented |
+| [004](004-report-filtering-and-deduplication.md) | Report Filtering, Deduplication, and Leaf-Change Mode | Accepted — implemented |
+| [005](005-application-compat-check.md) | Application Compatibility Checking | Accepted — implemented |
+| [006](006-package-level-comparison.md) | Package-Level Comparison | Accepted — implemented |
+| [007](007-btf-ctf-debug-formats.md) | BTF and CTF Debug Format Support | Accepted — implemented |
+| [008](008-full-stack-dependency-validation.md) | Full-Stack Dependency Validation | Accepted — implemented |
+| [009](009-verdict-system-and-exit-codes.md) | Verdict System and Exit Code Contract | Accepted — implemented |
+| [010](010-policy-profile-system.md) | Policy Profile System | Accepted — implemented |
+| [011](011-change-classification-taxonomy.md) | ABI Change Classification Taxonomy | Accepted — implemented |
+| [012](012-abicc-compatibility-layer.md) | ABICC Drop-In Compatibility Layer | Accepted — implemented |
+| [013](013-suppression-system.md) | Suppression System Design | Accepted — implemented |
+| [014](014-output-format-strategy.md) | Output Format Strategy | Accepted — implemented |
+| [015](015-snapshot-serialization.md) | Snapshot Serialization and Schema Versioning | Accepted — implemented |
+| [016](016-visibility-model.md) | Three-Tier Visibility Model | Accepted — implemented |
+| [017](017-github-action.md) | GitHub Action Design | Accepted — implemented |
+| [018](018-cross-platform-support.md) | Cross-Platform Binary Format Support | Accepted — implemented |
+| [019](019-testing-strategy.md) | Testing Strategy and Parity Validation | Accepted — implemented |
+| [020a](020-build-context-capture.md) | Build-Context Aware Header Extraction | Accepted — implemented |
+| [020b](020-sycl-and-heterogeneous-stack-support.md) | SYCL and Heterogeneous Computing Stack Support | Accepted — implemented |
+| [021a](021-debug-artifact-resolution.md) | Debug Artifact Resolution Subsystem | Accepted — implemented |
+| [021b](021-mcp-security-model.md) | MCP Security Model | Accepted — implemented |
+| [022](022-baseline-registry.md) | Baseline Registry and Snapshot Distribution | Accepted — implemented |
+| [023](023-bundle-aware-multi-binary-analysis.md) | Bundle-Aware Multi-Binary ABI Analysis | Accepted — implemented |
+| [024](024-public-abi-surface-resolution.md) | Public ABI Surface Resolution and False-Positive Traceability | Accepted — implemented |
 | [025](025-pr-diff-source-evaluation.md) | PR-Diff-Aware ABI Evaluation (Source Diff as Trigger and Localizer) | Proposed |
 | [026](026-source-only-undetectable-changes.md) | Source-Only Changes and the Evidence-Tier Boundary | Accepted |
 | [027](027-api-surface-intelligence.md) | API Surface Intelligence — Structure Metrics, Idiom Detection, Cross-Library Reasoning, Pattern-Aware Verdicts | Accepted |


### PR DESCRIPTION
## Summary

Reviewed the alignment between the **use-case registry** (`docs/development/usecase-registry.yaml`, the machine-checked source of truth for capability coverage) and the **ADR records** (`docs/development/adr/`). Found one real drift and corrected it.

### The drift

The ADR index table (`adr/index.md`) listed **ADR-028 through ADR-033 as `Proposed`**, but:

- each of those ADR files declares itself **`Accepted — implemented`** in its own status header;
- the `abicheck/buildsource/` package is fully built around them (see `buildsource/CLAUDE.md` module map → ADR column); and
- the use-case registry already cites their shipped modules and tests (e.g. G18 Bazel evidence `modeled`, G19 source-intelligence entries `partial`/`complete`).

The index was the stale summary; the ADR files are the source of truth.

### Changes

- `adr/index.md`: ADR-028…033 → **`Accepted — implemented`** (match each file's own header). ADR-035 → **`Proposed — partially implemented (G19)`**.
- `adr/035-…md`: corrected the bare `Status: Proposed` to spell out the shipped-vs-planned decision breakdown (D5 `complete`; D1/D3/D4/D2/D9/D10 `partial`; D6–D8 planned), keeping the ADR aligned with the registry's G19 rows.

ADR-025 and ADR-034 stay `Proposed` — they match their files and have no shipped implementation.

### Validation

- `pytest tests/test_usecase_registry.py` → 142 passed
- `python scripts/check_ai_readiness.py` → 0 errors (pre-existing warnings only)

No code changed; documentation status alignment only.

https://claude.ai/code/session_015wDtuBWq82GVeqwomHhWbH

---
_Generated by [Claude Code](https://claude.ai/code/session_015wDtuBWq82GVeqwomHhWbH)_