### PR TITLE
refactor: C7-tail — extract cli_resolve leaf + unify input resolution on service

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -38,11 +38,24 @@ from .cli_options import (
     build_source_dump_options,
 )
 from .cli_params import POLICY_FILE_PARAM, _load_suppression_and_policy
-from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
+from .cli_resolve import (
+    _apply_native_provenance,
+    _detect_binary_format,
+    _dump_elf,
+    _dump_native_binary,
+    _expand_header_inputs,
+    _is_supported_compare_input,
+    _maybe_follow_linker_script,
+    _normalize_binary_input,
+    _populate_dependency_info,
+    _resolve_compare_snapshots,
+    _resolve_input,
+    _resolve_linker_script,
+    _sniff_text_format,
+)
 from .compat.cli import compat_group
-from .dumper import dump
 from .errors import AbicheckError
-from .serialization import load_snapshot, snapshot_to_json
+from .serialization import snapshot_to_json
 
 if TYPE_CHECKING:
     from .checker_types import Change, DiffResult
@@ -52,49 +65,29 @@ if TYPE_CHECKING:
 from . import __version__ as _abicheck_version
 from .model import AbiSnapshot
 
-# Number of bytes to read when sniffing file format (covers ELF magic + JSON/Perl head)
-_SNIFF_BYTES = 256
+# Input-resolution & native-dump dispatch helpers now live in the cli_resolve
+# leaf module. They are re-exported here (declared in __all__ so the re-export
+# is explicit for mypy's no-implicit-reexport and for ruff) to keep existing
+# ``from abicheck.cli import _resolve_input`` call sites — sibling cli_* modules,
+# mcp_server, and the test-suite — working unchanged. New code should import
+# these from ``abicheck.cli_resolve`` directly.
+__all__ = [
+    "_apply_native_provenance",
+    "_detect_binary_format",
+    "_dump_elf",
+    "_dump_native_binary",
+    "_expand_header_inputs",
+    "_is_supported_compare_input",
+    "_maybe_follow_linker_script",
+    "_normalize_binary_input",
+    "_populate_dependency_info",
+    "_resolve_compare_snapshots",
+    "_resolve_input",
+    "_resolve_linker_script",
+    "_sniff_text_format",
+]
 
 _logger = logging.getLogger("abicheck")
-
-_HEADER_EXTS = {".h", ".hh", ".hpp", ".hxx", ".ipp", ".tpp", ".inc"}
-
-
-def _expand_header_inputs(inputs: list[Path]) -> list[Path]:
-    """Expand header inputs where each item can be a file or a directory.
-
-    Directories are scanned recursively for known header extensions.
-    """
-    out: list[Path] = []
-    for p in inputs:
-        if not p.exists():
-            raise click.ClickException(f"Header file not found or not a file: {p}")
-        if p.is_file():
-            out.append(p)
-            continue
-        if p.is_dir():
-            found = [
-                f for f in p.rglob("*")
-                if f.is_file() and f.suffix.lower() in _HEADER_EXTS
-            ]
-            if not found:
-                raise click.ClickException(
-                    f"Header directory contains no supported header files: {p}"
-                )
-            out.extend(sorted(found))
-            continue
-        raise click.ClickException(f"Header path is neither file nor directory: {p}")
-
-    # Deduplicate while preserving deterministic order
-    seen: set[str] = set()
-    deduped: list[Path] = []
-    for h in out:
-        k = str(h.resolve())
-        if k in seen:
-            continue
-        seen.add(k)
-        deduped.append(h)
-    return deduped
 
 
 def _setup_verbosity(verbose: bool) -> None:
@@ -103,15 +96,6 @@ def _setup_verbosity(verbose: bool) -> None:
     handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
     _logger.addHandler(handler)
     _logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
-
-
-def _detect_binary_format(path: Path) -> str | None:
-    """Detect binary format from magic bytes.
-
-    Returns 'elf', 'pe', 'macho', or None for non-binary / unknown.
-    """
-    from .binary_utils import detect_binary_format
-    return detect_binary_format(path)
 
 
 def _safe_write_output(output: Path, text: str) -> None:
@@ -215,299 +199,6 @@ def _write_snapshot_output(
         click.echo(result)
 
 
-def _sniff_text_format(path: Path) -> str:
-    """Read a small header chunk and return 'json', 'perl', or 'unknown'."""
-    try:
-        with open(path, "rb") as f:
-            raw = f.read(_SNIFF_BYTES)
-        head = raw.decode("utf-8", errors="replace").lstrip()
-    except OSError:
-        return "unknown"
-    # Check Perl dump BEFORE JSON — a Perl dump can start with $VAR1 = {
-    # which would incorrectly match the JSON heuristic after the '{'
-    if looks_like_perl_dump(head):
-        return "perl"
-    if head.startswith("{"):
-        return "json"
-    return "unknown"
-
-
-# GNU ld linker-script directives. The conventional ``libfoo.so`` development
-# symlink is frequently a tiny ASCII script such as ``INPUT(libfoo.so.1)`` or
-# ``GROUP ( /usr/lib/libfoo.so.1 AS_NEEDED ( ... ) )`` rather than an ELF file.
-_LD_SCRIPT_RE = re.compile(r"\b(?:INPUT|GROUP|OUTPUT_FORMAT)\s*\(")
-# Keywords that may appear as bare tokens inside INPUT()/GROUP() — never files.
-_LD_KEYWORDS = frozenset({"AS_NEEDED", "INPUT", "GROUP", "OUTPUT_FORMAT"})
-
-
-def _resolve_linker_script(path: Path) -> tuple[Path | None, bool]:
-    """Resolve a GNU ld linker script to the shared library it points at.
-
-    Returns ``(resolved_path, is_linker_script)``. ``is_linker_script`` is True
-    when *path* looks like a GNU ld script (so callers can emit a targeted hint
-    even when no target file could be located); ``resolved_path`` is the first
-    ``INPUT()``/``GROUP()`` member that exists next to the script, or *None*.
-    """
-    from .binary_utils import resolve_linker_script
-
-    return resolve_linker_script(path)
-
-
-def _maybe_follow_linker_script(path: Path) -> Path:
-    """Return the linker-script target if *path* is a resolvable GNU ld script.
-
-    Emits a one-line note when it follows a script; otherwise returns *path*
-    unchanged. Used by entry points that dispatch on binary format directly
-    (e.g. ``dump``) rather than through :func:`_resolve_input`.
-    """
-    target, is_ld = _resolve_linker_script(path)
-    if is_ld and target is not None and target.resolve() != path.resolve():
-        click.echo(
-            f"Note: '{path}' is a GNU ld linker script; following its "
-            f"INPUT()/GROUP() directive to '{target}'.",
-            err=True,
-        )
-        return target
-    return path
-
-
-def _normalize_binary_input(path: Path) -> tuple[Path, str | None]:
-    """Detect a binary input's format, following GNU ld linker scripts.
-
-    Returns ``(resolved_path, format)``. When *path* is a linker script that
-    resolves to a real shared library, the resolved path and *its* format are
-    returned so downstream metadata collection and dependency analysis operate
-    on the actual DSO rather than the text script.
-    """
-    fmt = _detect_binary_format(path)
-    if fmt is None:
-        resolved = _maybe_follow_linker_script(path)
-        if resolved != path:
-            return resolved, _detect_binary_format(resolved)
-    return path, fmt
-
-
-
-def _dump_elf(
-    path: Path, headers: list[Path], includes: list[Path],
-    version: str, lang: str, *, dwarf_only: bool = False,
-    debug_format: str | None = None,
-) -> AbiSnapshot:
-    """Dump ABI snapshot from an ELF binary."""
-    resolved_headers = _expand_header_inputs(headers) if headers else []
-    if not resolved_headers and not dwarf_only:
-        click.echo(
-            f"Warning: '{path}' — no headers provided. "
-            "Will use DWARF debug info if available, else symbols-only mode.",
-            err=True,
-        )
-    if resolved_headers and not dwarf_only:
-        for inc in includes:
-            if not inc.exists() or not inc.is_dir():
-                raise click.ClickException(f"Include directory not found or not a directory: {inc}")
-    elif includes and not dwarf_only:
-        click.echo(
-            "Warning: --include paths are ignored without headers.",
-            err=True,
-        )
-    compiler = "cc" if lang == "c" else "c++"
-    try:
-        return dump(
-            so_path=path,
-            headers=resolved_headers,
-            extra_includes=includes,
-            version=version,
-            compiler=compiler,
-            lang=lang if lang == "c" else None,
-            dwarf_only=dwarf_only,
-            debug_format=debug_format,
-        )
-    except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
-        raise click.ClickException(f"Failed to dump '{path}': {exc}") from exc
-
-
-def _apply_native_provenance(
-    snap: AbiSnapshot,
-    public_headers: list[Path] | None,
-    public_header_dirs: list[Path] | None,
-) -> AbiSnapshot:
-    """Tag declaration provenance on a PE/Mach-O snapshot (ADR-024 Phase 1).
-
-    Mirrors the ELF path (``dumper.create_snapshot``), which always runs
-    ``apply_provenance``. A no-op when no public-header set is supplied —
-    every origin stays ``UNKNOWN`` and behaviour is unchanged.
-    """
-    from .provenance import apply_provenance
-    return apply_provenance(snap, public_headers, public_header_dirs)
-
-
-def _dump_native_binary(
-    path: Path, binary_fmt: str,
-    headers: list[Path], includes: list[Path],
-    version: str, lang: str,
-    *,
-    pdb_path: Path | None = None,
-    dwarf_only: bool = False,
-    debug_format: str | None = None,
-    public_headers: list[Path] | None = None,
-    public_header_dirs: list[Path] | None = None,
-) -> AbiSnapshot:
-    """Dump ABI snapshot from a native binary (ELF, PE, or Mach-O).
-
-    For ELF, headers are required for full AST analysis unless dwarf_only
-    is set or DWARF debug info is available (ADR-003 fallback chain).
-    For PE/Mach-O, headers are optional: when supplied they scope the ABI
-    surface to declarations in those public headers (best-effort, via castxml),
-    otherwise the export table provides the symbol surface.
-
-    ``public_headers`` / ``public_header_dirs`` classify declaration provenance
-    (ADR-024 Phase 1). For PE they also let the PDB-derived types carry a
-    ``ScopeOrigin``; an empty set keeps every origin ``UNKNOWN`` (no-op).
-    """
-    if binary_fmt == "elf":
-        return _dump_elf(path, headers, includes, version, lang,
-                         dwarf_only=dwarf_only, debug_format=debug_format)
-
-    if binary_fmt == "pe":
-        from .service import _dump_pe
-        try:
-            snap = _dump_pe(
-                path, version,
-                headers=headers, includes=includes, lang=lang,
-                pdb_path=pdb_path,
-            )
-        except AbicheckError as exc:
-            raise click.ClickException(str(exc)) from exc
-        return _apply_native_provenance(snap, public_headers, public_header_dirs)
-
-    if binary_fmt == "macho":
-        from .service import _dump_macho
-        try:
-            snap = _dump_macho(
-                path, version,
-                headers=headers, includes=includes, lang=lang,
-            )
-        except AbicheckError as exc:
-            raise click.ClickException(str(exc)) from exc
-        return _apply_native_provenance(snap, public_headers, public_header_dirs)
-
-    fmt_labels = {"elf": "ELF", "pe": "PE (Windows DLL)", "macho": "Mach-O (macOS dylib)"}
-    raise click.ClickException(f"Unsupported binary format: {fmt_labels.get(binary_fmt, binary_fmt)}")
-
-
-def _resolve_input(
-    path: Path,
-    headers: list[Path],
-    includes: list[Path],
-    version: str,
-    lang: str,
-    *,
-    is_elf: bool | None = None,
-    pdb_path: Path | None = None,
-    dwarf_only: bool = False,
-    debug_format: str | None = None,
-) -> AbiSnapshot:
-    """Auto-detect input type and return an AbiSnapshot.
-
-    Detection order:
-    1. Native binary (ELF / PE / Mach-O, detected by magic bytes)
-    2. ABICC Perl dump (``$VAR1`` prefix) → :func:`import_abicc_perl_dump`
-    3. JSON snapshot (``{`` prefix) → :func:`load_snapshot`
-
-    Args:
-        path: Path to the input file.
-        headers: Public header files (required for ELF inputs).
-        includes: Extra include directories (used for ELF inputs).
-        version: Version label to embed in the resulting snapshot.
-        lang: Language mode for castxml (``c++`` or ``c``).
-        is_elf: Pre-computed ELF detection result; if *None*, detection is
-            performed here (avoids a second ``open()`` when the caller already
-            knows the result).
-        dwarf_only: If True, force DWARF-only mode (ADR-003).
-        debug_format: Force debug format ("dwarf", "btf", "ctf") or None for auto.
-    """
-    # Fast path: caller already knows it's ELF
-    if is_elf is True:
-        return _dump_native_binary(
-            path, "elf", headers, includes, version, lang,
-            dwarf_only=dwarf_only,
-            debug_format=debug_format,
-        )
-
-    # Detect binary format from magic bytes
-    binary_fmt = _detect_binary_format(path) if is_elf is None else None
-    if binary_fmt is not None:
-        return _dump_native_binary(
-            path, binary_fmt, headers, includes, version, lang,
-            pdb_path=pdb_path,
-            dwarf_only=dwarf_only,
-            debug_format=debug_format,
-        )
-
-    # Raw kernel type-info blob (a bare BTF/CTF section, e.g. from
-    # `bpftool btf dump file <elf> format raw`): parse directly.
-    from .service import _resolve_raw_typeinfo
-    raw_typeinfo = _resolve_raw_typeinfo(path, version)
-    if raw_typeinfo is not None:
-        return raw_typeinfo
-
-    # Text-based formats: detect by sniffing only a small header chunk
-    fmt = _sniff_text_format(path)
-
-    if fmt == "perl":
-        try:
-            return import_abicc_perl_dump(path)
-        except (ValueError, KeyError, UnicodeDecodeError, OSError, AbicheckError) as exc:
-            raise click.ClickException(
-                f"Failed to import ABICC Perl dump '{path}': {exc}"
-            ) from exc
-
-    if fmt == "json":
-        try:
-            return load_snapshot(path)
-        except (ValueError, KeyError, UnicodeDecodeError, OSError) as exc:
-            raise click.ClickException(
-                f"Failed to load JSON snapshot '{path}': {exc}"
-            ) from exc
-
-    # GNU ld linker script (e.g. the ``libfoo.so`` dev symlink is the text
-    # ``INPUT(libfoo.so.1)``): follow it to the real shared library.
-    target, is_ld_script = _resolve_linker_script(path)
-    if is_ld_script:
-        if target is not None and target.resolve() != path.resolve():
-            click.echo(
-                f"Note: '{path}' is a GNU ld linker script; following its "
-                f"INPUT()/GROUP() directive to '{target}'.",
-                err=True,
-            )
-            return _resolve_input(
-                target, headers, includes, version, lang,
-                dwarf_only=dwarf_only, debug_format=debug_format,
-            )
-        raise click.UsageError(
-            f"'{path}' is a GNU ld linker script (INPUT/GROUP), not a binary, "
-            "and its target could not be located next to it. Pass the actual "
-            "shared library named in its INPUT(...) directive directly."
-        )
-
-    # Static / import library archives (.a / .lib) are member containers, not a
-    # single linkable image — a deliberate non-goal (see
-    # docs/concepts/limitations.md). Reject with actionable guidance.
-    from .binary_utils import detect_archive
-    if detect_archive(path):
-        raise click.UsageError(
-            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
-            "does not analyse — it compares single linkable images (shared libraries "
-            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
-            "resulting object files or the shared library built from them instead."
-        )
-
-    raise click.UsageError(
-        f"Cannot detect format of '{path}'. "
-        "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."
-    )
-
-
 def _collect_metadata(path: Path) -> LibraryMetadata | None:
     """Compute SHA-256 and file size for a library artifact.
 
@@ -574,56 +265,6 @@ class _AbicheckGroup(click.Group):
 )
 def main() -> None:
     """abicheck — ABI compatibility checker for C/C++ shared libraries."""
-
-
-def _populate_dependency_info(
-    snap: AbiSnapshot, so_path: Path,
-    search_paths: list[Path], sysroot: Path | None, ld_library_path: str,
-) -> None:
-    """Resolve transitive deps and store DependencyInfo in the snapshot."""
-    from .binder import BindingStatus, compute_bindings
-    from .model import DependencyInfo
-    from .resolver import resolve_dependencies
-
-    graph = resolve_dependencies(
-        so_path,
-        search_paths=search_paths or None,
-        sysroot=sysroot,
-        ld_library_path=ld_library_path,
-    )
-    bindings = compute_bindings(graph)
-
-    summary: dict[str, int] = {}
-    for b in bindings:
-        summary[b.status.value] = summary.get(b.status.value, 0) + 1
-
-    missing = [
-        {"consumer": b.consumer, "symbol": b.symbol, "version": b.version}
-        for b in bindings if b.status == BindingStatus.MISSING
-    ]
-
-    snap.dependency_info = DependencyInfo(
-        nodes=[
-            {
-                "path": str(node.path),
-                "soname": node.soname,
-                "needed": node.needed,
-                "depth": node.depth,
-                "resolution_reason": node.resolution_reason,
-            }
-            for node in sorted(graph.nodes.values(), key=lambda n: (n.depth, n.soname))
-        ],
-        edges=[
-            {"consumer": consumer, "provider": provider}
-            for consumer, provider in graph.edges
-        ],
-        unresolved=[
-            {"consumer": consumer, "soname": soname}
-            for consumer, soname in graph.unresolved
-        ],
-        bindings_summary=summary,
-        missing_symbols=missing,
-    )
 
 
 @main.command("dump")
@@ -1110,20 +751,6 @@ def _version_sort_key(path: Path, canonical_key: str) -> tuple[list[tuple[int, i
     return parsed, lower
 
 
-def _is_supported_compare_input(path: Path) -> bool:
-    """Return True for files accepted by compare-release directory scanning.
-
-    Delegates to :func:`abicheck.classify.is_supported_compare_input` which
-    runs a composable classifier pipeline (binary extensions → magic bytes →
-    ABI JSON fingerprint → Perl dump → fallback sniff).
-
-    To add support for a new ABI snapshot format, edit ``abicheck/classify.py``
-    rather than this function.
-    """
-    from .classify import is_supported_compare_input
-    return is_supported_compare_input(path)
-
-
 def _collect_release_inputs(path: Path) -> list[Path]:
     """Collect compare-able inputs from a file or directory."""
     if path.is_file():
@@ -1179,7 +806,6 @@ def _resolve_severity(
         addition=addition,
     )
     return config, explicitly_set
-
 
 
 def _merge_redundant_changes(result: DiffResult) -> None:
@@ -1355,39 +981,6 @@ def _log_debug_resolution(
         "new", new_input, resolved_new_debug,
         debuginfod=debuginfod, debuginfod_url=debuginfod_url,
     )
-
-
-def _resolve_compare_snapshots(
-    old_input: Path, new_input: Path,
-    old_fmt: str | None, new_fmt: str | None,
-    old_h: list[Path], new_h: list[Path],
-    old_inc: list[Path], new_inc: list[Path],
-    old_version: str, new_version: str, lang: str,
-    pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
-    dwarf_only: bool, debug_format: str | None,
-    follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
-) -> tuple[AbiSnapshot, AbiSnapshot]:
-    """Load both ABI snapshots and (optionally) populate ELF dependency info."""
-    old = _resolve_input(
-        old_input, old_h, old_inc, old_version, lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=old_pdb_path if old_pdb_path else pdb_path,
-        dwarf_only=dwarf_only,
-        debug_format=debug_format,
-    )
-    new = _resolve_input(
-        new_input, new_h, new_inc, new_version, lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=new_pdb_path if new_pdb_path else pdb_path,
-        dwarf_only=dwarf_only,
-        debug_format=debug_format,
-    )
-    if follow_deps:
-        if old_fmt == "elf":
-            _populate_dependency_info(old, old_input, list(search_paths), None, ld_library_path)
-        if new_fmt == "elf":
-            _populate_dependency_info(new, new_input, list(search_paths), None, ld_library_path)
-    return old, new
 
 
 def _finalize_compare_result(
@@ -1900,8 +1493,6 @@ from .compat.cli import (  # noqa: E402,F401
 # fmt: on
 
 main.add_command(compat_group)
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -41,7 +41,6 @@ from .cli_params import POLICY_FILE_PARAM, _load_suppression_and_policy
 from .cli_resolve import (
     _apply_native_provenance,
     _detect_binary_format,
-    _dump_elf,
     _dump_native_binary,
     _expand_header_inputs,
     _is_supported_compare_input,
@@ -74,7 +73,6 @@ from .model import AbiSnapshot
 __all__ = [
     "_apply_native_provenance",
     "_detect_binary_format",
-    "_dump_elf",
     "_dump_native_binary",
     "_expand_header_inputs",
     "_is_supported_compare_input",

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -1,0 +1,563 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Input resolution & native-dump dispatch for the CLI.
+
+This is the leaf module of the ``compare`` / ``dump`` input pipeline: given a
+path, it detects the format (ELF / PE / Mach-O / JSON snapshot / ABICC Perl
+dump / GNU ld linker script), follows linker scripts, dispatches native dumps
+to the per-format builders, and loads or builds the resulting
+:class:`~abicheck.model.AbiSnapshot`.
+
+It is imported (and re-exported) by :mod:`abicheck.cli`; it deliberately does
+**not** import ``cli`` so the dependency runs one way (``cli`` → ``cli_resolve``)
+and stays cycle-free. Errors surface as ``click`` exceptions because every
+caller is a CLI entry point — the parallel, framework-free contract lives in
+:func:`abicheck.service.resolve_input` (which raises ``SnapshotError`` /
+``ValidationError`` instead).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
+from .dumper import dump
+from .errors import AbicheckError
+from .serialization import load_snapshot
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .model import AbiSnapshot
+
+_HEADER_EXTS = {".h", ".hh", ".hpp", ".hxx", ".ipp", ".tpp", ".inc"}
+
+# Number of bytes to read when sniffing file format (covers ELF magic + JSON/Perl head)
+_SNIFF_BYTES = 256
+
+
+def _expand_header_inputs(inputs: list[Path]) -> list[Path]:
+    """Expand header inputs where each item can be a file or a directory.
+
+    Directories are scanned recursively for known header extensions.
+    """
+    out: list[Path] = []
+    for p in inputs:
+        if not p.exists():
+            raise click.ClickException(f"Header file not found or not a file: {p}")
+        if p.is_file():
+            out.append(p)
+            continue
+        if p.is_dir():
+            found = [
+                f
+                for f in p.rglob("*")
+                if f.is_file() and f.suffix.lower() in _HEADER_EXTS
+            ]
+            if not found:
+                raise click.ClickException(
+                    f"Header directory contains no supported header files: {p}"
+                )
+            out.extend(sorted(found))
+            continue
+        raise click.ClickException(f"Header path is neither file nor directory: {p}")
+
+    # Deduplicate while preserving deterministic order
+    seen: set[str] = set()
+    deduped: list[Path] = []
+    for h in out:
+        k = str(h.resolve())
+        if k in seen:
+            continue
+        seen.add(k)
+        deduped.append(h)
+    return deduped
+
+
+def _sniff_text_format(path: Path) -> str:
+    """Read a small header chunk and return 'json', 'perl', or 'unknown'."""
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(_SNIFF_BYTES)
+        head = raw.decode("utf-8", errors="replace").lstrip()
+    except OSError:
+        return "unknown"
+    # Check Perl dump BEFORE JSON — a Perl dump can start with $VAR1 = {
+    # which would incorrectly match the JSON heuristic after the '{'
+    if looks_like_perl_dump(head):
+        return "perl"
+    if head.startswith("{"):
+        return "json"
+    return "unknown"
+
+
+def _detect_binary_format(path: Path) -> str | None:
+    """Detect binary format from magic bytes.
+
+    Returns 'elf', 'pe', 'macho', or None for non-binary / unknown.
+    """
+    from .binary_utils import detect_binary_format
+
+    return detect_binary_format(path)
+
+
+def _resolve_linker_script(path: Path) -> tuple[Path | None, bool]:
+    """Resolve a GNU ld linker script to the shared library it points at.
+
+    Returns ``(resolved_path, is_linker_script)``. ``is_linker_script`` is True
+    when *path* looks like a GNU ld script (so callers can emit a targeted hint
+    even when no target file could be located); ``resolved_path`` is the first
+    ``INPUT()``/``GROUP()`` member that exists next to the script, or *None*.
+    """
+    from .binary_utils import resolve_linker_script
+
+    return resolve_linker_script(path)
+
+
+def _maybe_follow_linker_script(path: Path) -> Path:
+    """Return the linker-script target if *path* is a resolvable GNU ld script.
+
+    Emits a one-line note when it follows a script; otherwise returns *path*
+    unchanged. Used by entry points that dispatch on binary format directly
+    (e.g. ``dump``) rather than through :func:`_resolve_input`.
+    """
+    target, is_ld = _resolve_linker_script(path)
+    if is_ld and target is not None and target.resolve() != path.resolve():
+        click.echo(
+            f"Note: '{path}' is a GNU ld linker script; following its "
+            f"INPUT()/GROUP() directive to '{target}'.",
+            err=True,
+        )
+        return target
+    return path
+
+
+def _normalize_binary_input(path: Path) -> tuple[Path, str | None]:
+    """Detect a binary input's format, following GNU ld linker scripts.
+
+    Returns ``(resolved_path, format)``. When *path* is a linker script that
+    resolves to a real shared library, the resolved path and *its* format are
+    returned so downstream metadata collection and dependency analysis operate
+    on the actual DSO rather than the text script.
+    """
+    fmt = _detect_binary_format(path)
+    if fmt is None:
+        resolved = _maybe_follow_linker_script(path)
+        if resolved != path:
+            return resolved, _detect_binary_format(resolved)
+    return path, fmt
+
+
+def _dump_elf(
+    path: Path,
+    headers: list[Path],
+    includes: list[Path],
+    version: str,
+    lang: str,
+    *,
+    dwarf_only: bool = False,
+    debug_format: str | None = None,
+) -> AbiSnapshot:
+    """Dump ABI snapshot from an ELF binary."""
+    resolved_headers = _expand_header_inputs(headers) if headers else []
+    if not resolved_headers and not dwarf_only:
+        click.echo(
+            f"Warning: '{path}' — no headers provided. "
+            "Will use DWARF debug info if available, else symbols-only mode.",
+            err=True,
+        )
+    if resolved_headers and not dwarf_only:
+        for inc in includes:
+            if not inc.exists() or not inc.is_dir():
+                raise click.ClickException(
+                    f"Include directory not found or not a directory: {inc}"
+                )
+    elif includes and not dwarf_only:
+        click.echo(
+            "Warning: --include paths are ignored without headers.",
+            err=True,
+        )
+    compiler = "cc" if lang == "c" else "c++"
+    try:
+        return dump(
+            so_path=path,
+            headers=resolved_headers,
+            extra_includes=includes,
+            version=version,
+            compiler=compiler,
+            lang=lang if lang == "c" else None,
+            dwarf_only=dwarf_only,
+            debug_format=debug_format,
+        )
+    except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
+        raise click.ClickException(f"Failed to dump '{path}': {exc}") from exc
+
+
+def _apply_native_provenance(
+    snap: AbiSnapshot,
+    public_headers: list[Path] | None,
+    public_header_dirs: list[Path] | None,
+) -> AbiSnapshot:
+    """Tag declaration provenance on a PE/Mach-O snapshot (ADR-024 Phase 1).
+
+    Mirrors the ELF path (``dumper.create_snapshot``), which always runs
+    ``apply_provenance``. A no-op when no public-header set is supplied —
+    every origin stays ``UNKNOWN`` and behaviour is unchanged.
+    """
+    from .provenance import apply_provenance
+
+    return apply_provenance(snap, public_headers, public_header_dirs)
+
+
+def _dump_native_binary(
+    path: Path,
+    binary_fmt: str,
+    headers: list[Path],
+    includes: list[Path],
+    version: str,
+    lang: str,
+    *,
+    pdb_path: Path | None = None,
+    dwarf_only: bool = False,
+    debug_format: str | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
+) -> AbiSnapshot:
+    """Dump ABI snapshot from a native binary (ELF, PE, or Mach-O).
+
+    For ELF, headers are required for full AST analysis unless dwarf_only
+    is set or DWARF debug info is available (ADR-003 fallback chain).
+    For PE/Mach-O, headers are optional: when supplied they scope the ABI
+    surface to declarations in those public headers (best-effort, via castxml),
+    otherwise the export table provides the symbol surface.
+
+    ``public_headers`` / ``public_header_dirs`` classify declaration provenance
+    (ADR-024 Phase 1). For PE they also let the PDB-derived types carry a
+    ``ScopeOrigin``; an empty set keeps every origin ``UNKNOWN`` (no-op).
+    """
+    if binary_fmt == "elf":
+        return _dump_elf(
+            path,
+            headers,
+            includes,
+            version,
+            lang,
+            dwarf_only=dwarf_only,
+            debug_format=debug_format,
+        )
+
+    if binary_fmt == "pe":
+        from .service import _dump_pe
+
+        try:
+            snap = _dump_pe(
+                path,
+                version,
+                headers=headers,
+                includes=includes,
+                lang=lang,
+                pdb_path=pdb_path,
+            )
+        except AbicheckError as exc:
+            raise click.ClickException(str(exc)) from exc
+        return _apply_native_provenance(snap, public_headers, public_header_dirs)
+
+    if binary_fmt == "macho":
+        from .service import _dump_macho
+
+        try:
+            snap = _dump_macho(
+                path,
+                version,
+                headers=headers,
+                includes=includes,
+                lang=lang,
+            )
+        except AbicheckError as exc:
+            raise click.ClickException(str(exc)) from exc
+        return _apply_native_provenance(snap, public_headers, public_header_dirs)
+
+    fmt_labels = {
+        "elf": "ELF",
+        "pe": "PE (Windows DLL)",
+        "macho": "Mach-O (macOS dylib)",
+    }
+    raise click.ClickException(
+        f"Unsupported binary format: {fmt_labels.get(binary_fmt, binary_fmt)}"
+    )
+
+
+def _resolve_input(
+    path: Path,
+    headers: list[Path],
+    includes: list[Path],
+    version: str,
+    lang: str,
+    *,
+    is_elf: bool | None = None,
+    pdb_path: Path | None = None,
+    dwarf_only: bool = False,
+    debug_format: str | None = None,
+) -> AbiSnapshot:
+    """Auto-detect input type and return an AbiSnapshot.
+
+    Detection order:
+    1. Native binary (ELF / PE / Mach-O, detected by magic bytes)
+    2. ABICC Perl dump (``$VAR1`` prefix) → :func:`import_abicc_perl_dump`
+    3. JSON snapshot (``{`` prefix) → :func:`load_snapshot`
+
+    Args:
+        path: Path to the input file.
+        headers: Public header files (required for ELF inputs).
+        includes: Extra include directories (used for ELF inputs).
+        version: Version label to embed in the resulting snapshot.
+        lang: Language mode for castxml (``c++`` or ``c``).
+        is_elf: Pre-computed ELF detection result; if *None*, detection is
+            performed here (avoids a second ``open()`` when the caller already
+            knows the result).
+        dwarf_only: If True, force DWARF-only mode (ADR-003).
+        debug_format: Force debug format ("dwarf", "btf", "ctf") or None for auto.
+    """
+    # Fast path: caller already knows it's ELF
+    if is_elf is True:
+        return _dump_native_binary(
+            path,
+            "elf",
+            headers,
+            includes,
+            version,
+            lang,
+            dwarf_only=dwarf_only,
+            debug_format=debug_format,
+        )
+
+    # Detect binary format from magic bytes
+    binary_fmt = _detect_binary_format(path) if is_elf is None else None
+    if binary_fmt is not None:
+        return _dump_native_binary(
+            path,
+            binary_fmt,
+            headers,
+            includes,
+            version,
+            lang,
+            pdb_path=pdb_path,
+            dwarf_only=dwarf_only,
+            debug_format=debug_format,
+        )
+
+    # Raw kernel type-info blob (a bare BTF/CTF section, e.g. from
+    # `bpftool btf dump file <elf> format raw`): parse directly.
+    from .service import _resolve_raw_typeinfo
+
+    raw_typeinfo = _resolve_raw_typeinfo(path, version)
+    if raw_typeinfo is not None:
+        return raw_typeinfo
+
+    # Text-based formats: detect by sniffing only a small header chunk
+    fmt = _sniff_text_format(path)
+
+    if fmt == "perl":
+        try:
+            return import_abicc_perl_dump(path)
+        except (
+            ValueError,
+            KeyError,
+            UnicodeDecodeError,
+            OSError,
+            AbicheckError,
+        ) as exc:
+            raise click.ClickException(
+                f"Failed to import ABICC Perl dump '{path}': {exc}"
+            ) from exc
+
+    if fmt == "json":
+        try:
+            return load_snapshot(path)
+        except (ValueError, KeyError, UnicodeDecodeError, OSError) as exc:
+            raise click.ClickException(
+                f"Failed to load JSON snapshot '{path}': {exc}"
+            ) from exc
+
+    # GNU ld linker script (e.g. the ``libfoo.so`` dev symlink is the text
+    # ``INPUT(libfoo.so.1)``): follow it to the real shared library.
+    target, is_ld_script = _resolve_linker_script(path)
+    if is_ld_script:
+        if target is not None and target.resolve() != path.resolve():
+            click.echo(
+                f"Note: '{path}' is a GNU ld linker script; following its "
+                f"INPUT()/GROUP() directive to '{target}'.",
+                err=True,
+            )
+            return _resolve_input(
+                target,
+                headers,
+                includes,
+                version,
+                lang,
+                dwarf_only=dwarf_only,
+                debug_format=debug_format,
+            )
+        raise click.UsageError(
+            f"'{path}' is a GNU ld linker script (INPUT/GROUP), not a binary, "
+            "and its target could not be located next to it. Pass the actual "
+            "shared library named in its INPUT(...) directive directly."
+        )
+
+    # Static / import library archives (.a / .lib) are member containers, not a
+    # single linkable image — a deliberate non-goal (see
+    # docs/concepts/limitations.md). Reject with actionable guidance.
+    from .binary_utils import detect_archive
+
+    if detect_archive(path):
+        raise click.UsageError(
+            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
+            "does not analyse — it compares single linkable images (shared libraries "
+            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
+            "resulting object files or the shared library built from them instead."
+        )
+
+    raise click.UsageError(
+        f"Cannot detect format of '{path}'. "
+        "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."
+    )
+
+
+def _populate_dependency_info(
+    snap: AbiSnapshot,
+    so_path: Path,
+    search_paths: list[Path],
+    sysroot: Path | None,
+    ld_library_path: str,
+) -> None:
+    """Resolve transitive deps and store DependencyInfo in the snapshot."""
+    from .binder import BindingStatus, compute_bindings
+    from .model import DependencyInfo
+    from .resolver import resolve_dependencies
+
+    graph = resolve_dependencies(
+        so_path,
+        search_paths=search_paths or None,
+        sysroot=sysroot,
+        ld_library_path=ld_library_path,
+    )
+    bindings = compute_bindings(graph)
+
+    summary: dict[str, int] = {}
+    for b in bindings:
+        summary[b.status.value] = summary.get(b.status.value, 0) + 1
+
+    missing = [
+        {"consumer": b.consumer, "symbol": b.symbol, "version": b.version}
+        for b in bindings
+        if b.status == BindingStatus.MISSING
+    ]
+
+    snap.dependency_info = DependencyInfo(
+        nodes=[
+            {
+                "path": str(node.path),
+                "soname": node.soname,
+                "needed": node.needed,
+                "depth": node.depth,
+                "resolution_reason": node.resolution_reason,
+            }
+            for node in sorted(graph.nodes.values(), key=lambda n: (n.depth, n.soname))
+        ],
+        edges=[
+            {"consumer": consumer, "provider": provider}
+            for consumer, provider in graph.edges
+        ],
+        unresolved=[
+            {"consumer": consumer, "soname": soname}
+            for consumer, soname in graph.unresolved
+        ],
+        bindings_summary=summary,
+        missing_symbols=missing,
+    )
+
+
+def _is_supported_compare_input(path: Path) -> bool:
+    """Return True for files accepted by compare-release directory scanning.
+
+    Delegates to :func:`abicheck.classify.is_supported_compare_input` which
+    runs a composable classifier pipeline (binary extensions → magic bytes →
+    ABI JSON fingerprint → Perl dump → fallback sniff).
+
+    To add support for a new ABI snapshot format, edit ``abicheck/classify.py``
+    rather than this function.
+    """
+    from .classify import is_supported_compare_input
+
+    return is_supported_compare_input(path)
+
+
+def _resolve_compare_snapshots(
+    old_input: Path,
+    new_input: Path,
+    old_fmt: str | None,
+    new_fmt: str | None,
+    old_h: list[Path],
+    new_h: list[Path],
+    old_inc: list[Path],
+    new_inc: list[Path],
+    old_version: str,
+    new_version: str,
+    lang: str,
+    pdb_path: Path | None,
+    old_pdb_path: Path | None,
+    new_pdb_path: Path | None,
+    dwarf_only: bool,
+    debug_format: str | None,
+    follow_deps: bool,
+    search_paths: tuple[Path, ...],
+    ld_library_path: str,
+) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Load both ABI snapshots and (optionally) populate ELF dependency info."""
+    old = _resolve_input(
+        old_input,
+        old_h,
+        old_inc,
+        old_version,
+        lang,
+        is_elf=True if old_fmt == "elf" else None,
+        pdb_path=old_pdb_path if old_pdb_path else pdb_path,
+        dwarf_only=dwarf_only,
+        debug_format=debug_format,
+    )
+    new = _resolve_input(
+        new_input,
+        new_h,
+        new_inc,
+        new_version,
+        lang,
+        is_elf=True if new_fmt == "elf" else None,
+        pdb_path=new_pdb_path if new_pdb_path else pdb_path,
+        dwarf_only=dwarf_only,
+        debug_format=debug_format,
+    )
+    if follow_deps:
+        if old_fmt == "elf":
+            _populate_dependency_info(
+                old, old_input, list(search_paths), None, ld_library_path
+            )
+        if new_fmt == "elf":
+            _populate_dependency_info(
+                new, new_input, list(search_paths), None, ld_library_path
+            )
+    return old, new

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -35,15 +35,23 @@ from typing import TYPE_CHECKING
 
 import click
 
-from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
-from .dumper import dump
-from .errors import AbicheckError
-from .serialization import load_snapshot
+from .compat.abicc_dump_import import looks_like_perl_dump
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from .model import AbiSnapshot
+
+
+def _click_notify(message: str) -> None:
+    """Emit a service-layer progress note to stderr via click.
+
+    Passed as the ``notify`` callback to :func:`abicheck.service.resolve_input` /
+    :func:`abicheck.service.run_dump` so their user-facing notes (linker-script
+    following, "no headers provided", "--include ignored") reach the CLI's stderr
+    exactly as they did when this logic lived in the CLI.
+    """
+    click.echo(message, err=True)
 
 _HEADER_EXTS = {".h", ".hh", ".hpp", ".hxx", ".ipp", ".tpp", ".inc"}
 
@@ -163,51 +171,6 @@ def _normalize_binary_input(path: Path) -> tuple[Path, str | None]:
     return path, fmt
 
 
-def _dump_elf(
-    path: Path,
-    headers: list[Path],
-    includes: list[Path],
-    version: str,
-    lang: str,
-    *,
-    dwarf_only: bool = False,
-    debug_format: str | None = None,
-) -> AbiSnapshot:
-    """Dump ABI snapshot from an ELF binary."""
-    resolved_headers = _expand_header_inputs(headers) if headers else []
-    if not resolved_headers and not dwarf_only:
-        click.echo(
-            f"Warning: '{path}' — no headers provided. "
-            "Will use DWARF debug info if available, else symbols-only mode.",
-            err=True,
-        )
-    if resolved_headers and not dwarf_only:
-        for inc in includes:
-            if not inc.exists() or not inc.is_dir():
-                raise click.ClickException(
-                    f"Include directory not found or not a directory: {inc}"
-                )
-    elif includes and not dwarf_only:
-        click.echo(
-            "Warning: --include paths are ignored without headers.",
-            err=True,
-        )
-    compiler = "cc" if lang == "c" else "c++"
-    try:
-        return dump(
-            so_path=path,
-            headers=resolved_headers,
-            extra_includes=includes,
-            version=version,
-            compiler=compiler,
-            lang=lang if lang == "c" else None,
-            dwarf_only=dwarf_only,
-            debug_format=debug_format,
-        )
-    except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
-        raise click.ClickException(f"Failed to dump '{path}': {exc}") from exc
-
-
 def _apply_native_provenance(
     snap: AbiSnapshot,
     public_headers: list[Path] | None,
@@ -238,68 +201,41 @@ def _dump_native_binary(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
-    """Dump ABI snapshot from a native binary (ELF, PE, or Mach-O).
+    """Dump an ABI snapshot from a native binary (ELF, PE, or Mach-O).
 
-    For ELF, headers are required for full AST analysis unless dwarf_only
-    is set or DWARF debug info is available (ADR-003 fallback chain).
-    For PE/Mach-O, headers are optional: when supplied they scope the ABI
-    surface to declarations in those public headers (best-effort, via castxml),
-    otherwise the export table provides the symbol surface.
+    Thin CLI wrapper over :func:`abicheck.service.run_dump` — the single source
+    of truth for native dumping. It supplies a ``click.echo`` notifier so the
+    "no headers" / "--include ignored" notes still reach stderr, and translates
+    the framework-free errors into the CLI's ``click`` exceptions, preserving
+    exit codes: ``ValidationError`` (unusable input / bad arguments) →
+    :class:`click.UsageError` (exit 64); ``SnapshotError`` (operational failure)
+    → :class:`click.ClickException` (exit 1).
 
     ``public_headers`` / ``public_header_dirs`` classify declaration provenance
-    (ADR-024 Phase 1). For PE they also let the PDB-derived types carry a
-    ``ScopeOrigin``; an empty set keeps every origin ``UNKNOWN`` (no-op).
+    (ADR-024 Phase 1) on PE/Mach-O snapshots; a no-op for ELF and when empty.
     """
-    if binary_fmt == "elf":
-        return _dump_elf(
+    from . import service
+    from .errors import SnapshotError, ValidationError
+
+    try:
+        return service.run_dump(
             path,
+            binary_fmt,
             headers,
             includes,
             version,
             lang,
+            pdb_path=pdb_path,
             dwarf_only=dwarf_only,
             debug_format=debug_format,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+            notify=_click_notify,
         )
-
-    if binary_fmt == "pe":
-        from .service import _dump_pe
-
-        try:
-            snap = _dump_pe(
-                path,
-                version,
-                headers=headers,
-                includes=includes,
-                lang=lang,
-                pdb_path=pdb_path,
-            )
-        except AbicheckError as exc:
-            raise click.ClickException(str(exc)) from exc
-        return _apply_native_provenance(snap, public_headers, public_header_dirs)
-
-    if binary_fmt == "macho":
-        from .service import _dump_macho
-
-        try:
-            snap = _dump_macho(
-                path,
-                version,
-                headers=headers,
-                includes=includes,
-                lang=lang,
-            )
-        except AbicheckError as exc:
-            raise click.ClickException(str(exc)) from exc
-        return _apply_native_provenance(snap, public_headers, public_header_dirs)
-
-    fmt_labels = {
-        "elf": "ELF",
-        "pe": "PE (Windows DLL)",
-        "macho": "Mach-O (macOS dylib)",
-    }
-    raise click.ClickException(
-        f"Unsupported binary format: {fmt_labels.get(binary_fmt, binary_fmt)}"
-    )
+    except ValidationError as exc:
+        raise click.UsageError(str(exc)) from exc
+    except SnapshotError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _resolve_input(
@@ -316,10 +252,14 @@ def _resolve_input(
 ) -> AbiSnapshot:
     """Auto-detect input type and return an AbiSnapshot.
 
-    Detection order:
-    1. Native binary (ELF / PE / Mach-O, detected by magic bytes)
-    2. ABICC Perl dump (``$VAR1`` prefix) → :func:`import_abicc_perl_dump`
-    3. JSON snapshot (``{`` prefix) → :func:`load_snapshot`
+    Thin CLI wrapper over :func:`abicheck.service.resolve_input` — the single
+    source of truth for format detection, linker-script following, and native
+    dumping. It supplies a ``click.echo`` notifier so progress notes reach
+    stderr unchanged, and maps the framework-free errors to ``click`` exceptions
+    so exit codes are preserved: ``ValidationError`` (unrecognised / unusable
+    input) → :class:`click.UsageError` (exit 64); ``SnapshotError`` (operational
+    failure loading or building the snapshot) → :class:`click.ClickException`
+    (exit 1).
 
     Args:
         path: Path to the input file.
@@ -327,115 +267,31 @@ def _resolve_input(
         includes: Extra include directories (used for ELF inputs).
         version: Version label to embed in the resulting snapshot.
         lang: Language mode for castxml (``c++`` or ``c``).
-        is_elf: Pre-computed ELF detection result; if *None*, detection is
-            performed here (avoids a second ``open()`` when the caller already
-            knows the result).
+        is_elf: Pre-computed ELF detection result; if *None*, the service layer
+            detects the format from magic bytes.
         dwarf_only: If True, force DWARF-only mode (ADR-003).
         debug_format: Force debug format ("dwarf", "btf", "ctf") or None for auto.
     """
-    # Fast path: caller already knows it's ELF
-    if is_elf is True:
-        return _dump_native_binary(
-            path,
-            "elf",
-            headers,
-            includes,
-            version,
-            lang,
-            dwarf_only=dwarf_only,
-            debug_format=debug_format,
-        )
+    from . import service
+    from .errors import SnapshotError, ValidationError
 
-    # Detect binary format from magic bytes
-    binary_fmt = _detect_binary_format(path) if is_elf is None else None
-    if binary_fmt is not None:
-        return _dump_native_binary(
+    try:
+        return service.resolve_input(
             path,
-            binary_fmt,
             headers,
             includes,
             version,
             lang,
+            is_elf=is_elf,
             pdb_path=pdb_path,
             dwarf_only=dwarf_only,
             debug_format=debug_format,
+            notify=_click_notify,
         )
-
-    # Raw kernel type-info blob (a bare BTF/CTF section, e.g. from
-    # `bpftool btf dump file <elf> format raw`): parse directly.
-    from .service import _resolve_raw_typeinfo
-
-    raw_typeinfo = _resolve_raw_typeinfo(path, version)
-    if raw_typeinfo is not None:
-        return raw_typeinfo
-
-    # Text-based formats: detect by sniffing only a small header chunk
-    fmt = _sniff_text_format(path)
-
-    if fmt == "perl":
-        try:
-            return import_abicc_perl_dump(path)
-        except (
-            ValueError,
-            KeyError,
-            UnicodeDecodeError,
-            OSError,
-            AbicheckError,
-        ) as exc:
-            raise click.ClickException(
-                f"Failed to import ABICC Perl dump '{path}': {exc}"
-            ) from exc
-
-    if fmt == "json":
-        try:
-            return load_snapshot(path)
-        except (ValueError, KeyError, UnicodeDecodeError, OSError) as exc:
-            raise click.ClickException(
-                f"Failed to load JSON snapshot '{path}': {exc}"
-            ) from exc
-
-    # GNU ld linker script (e.g. the ``libfoo.so`` dev symlink is the text
-    # ``INPUT(libfoo.so.1)``): follow it to the real shared library.
-    target, is_ld_script = _resolve_linker_script(path)
-    if is_ld_script:
-        if target is not None and target.resolve() != path.resolve():
-            click.echo(
-                f"Note: '{path}' is a GNU ld linker script; following its "
-                f"INPUT()/GROUP() directive to '{target}'.",
-                err=True,
-            )
-            return _resolve_input(
-                target,
-                headers,
-                includes,
-                version,
-                lang,
-                dwarf_only=dwarf_only,
-                debug_format=debug_format,
-            )
-        raise click.UsageError(
-            f"'{path}' is a GNU ld linker script (INPUT/GROUP), not a binary, "
-            "and its target could not be located next to it. Pass the actual "
-            "shared library named in its INPUT(...) directive directly."
-        )
-
-    # Static / import library archives (.a / .lib) are member containers, not a
-    # single linkable image — a deliberate non-goal (see
-    # docs/concepts/limitations.md). Reject with actionable guidance.
-    from .binary_utils import detect_archive
-
-    if detect_archive(path):
-        raise click.UsageError(
-            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
-            "does not analyse — it compares single linkable images (shared libraries "
-            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
-            "resulting object files or the shared library built from them instead."
-        )
-
-    raise click.UsageError(
-        f"Cannot detect format of '{path}'. "
-        "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."
-    )
+    except ValidationError as exc:
+        raise click.UsageError(str(exc)) from exc
+    except SnapshotError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _populate_dependency_info(

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -303,15 +303,25 @@ def _resolve_input(
     """Auto-detect input type and return an AbiSnapshot.
 
     Thin wrapper over :func:`abicheck.service.resolve_input` — the single source
-    of truth for format detection, GNU ld linker-script following, raw BTF/CTF
-    blobs, and native (ELF/PE/Mach-O) dumping. The MCP surface is framework-free,
-    so the service's ``SnapshotError`` / ``ValidationError`` (both
-    ``AbicheckError`` subclasses) propagate unchanged for the tool handlers to
-    convert into structured error payloads.
+    of truth for format detection, raw BTF/CTF blobs, and native (ELF/PE/Mach-O)
+    dumping. The MCP surface is framework-free, so the service's
+    ``SnapshotError`` / ``ValidationError`` (both ``AbicheckError`` subclasses)
+    propagate unchanged for the tool handlers to convert into structured error
+    payloads.
+
+    ``follow_linker_scripts=False``: the MCP tools enforce ``MCP_MAX_FILE_SIZE``
+    via :func:`_check_file_size` on the *caller-supplied* path before resolving.
+    Following a GNU ld linker script would parse an ``INPUT()``/``GROUP()``
+    target that never went through that guard, so a tiny script pointing at a
+    huge library could defeat the resource limit. Disabling the follow keeps the
+    size check authoritative (and matches the MCP server's pre-unification
+    behaviour, which never followed linker scripts).
     """
     from . import service
 
-    return service.resolve_input(path, headers, includes, version, lang)
+    return service.resolve_input(
+        path, headers, includes, version, lang, follow_linker_scripts=False
+    )
 
 
 def _snapshot_summary(snap: AbiSnapshot) -> dict[str, Any]:

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -64,9 +64,9 @@ from .checker_policy import (
     policy_kind_sets,
 )
 from .errors import AbicheckError
-from .model import AbiSnapshot, Visibility
+from .model import AbiSnapshot
 from .reporter import to_json, to_markdown
-from .serialization import load_snapshot, snapshot_to_json
+from .serialization import snapshot_to_json
 
 _logger = logging.getLogger("abicheck.mcp")
 
@@ -253,7 +253,6 @@ def _safe_write_path(raw: str, *, label: str = "output_path") -> Path:
 def _sanitize_error(exc: Exception, *, context: str = "operation") -> str:
     """Return a safe error message that does not leak filesystem paths or internals."""
     # Known domain errors: safe to surface as-is
-    from .errors import AbicheckError
     if isinstance(exc, AbicheckError):
         return str(exc)
     if isinstance(exc, (ValueError, KeyError)):
@@ -303,110 +302,16 @@ def _resolve_input(
 ) -> AbiSnapshot:
     """Auto-detect input type and return an AbiSnapshot.
 
-    Mirrors cli._resolve_input but without Click exceptions.
+    Thin wrapper over :func:`abicheck.service.resolve_input` — the single source
+    of truth for format detection, GNU ld linker-script following, raw BTF/CTF
+    blobs, and native (ELF/PE/Mach-O) dumping. The MCP surface is framework-free,
+    so the service's ``SnapshotError`` / ``ValidationError`` (both
+    ``AbicheckError`` subclasses) propagate unchanged for the tool handlers to
+    convert into structured error payloads.
     """
-    binary_fmt = _detect_binary_format(path)
+    from . import service
 
-    if binary_fmt == "elf":
-        from .dumper import dump
-        _SUPPORTED_LANGS = ("c", "c++")
-        if lang not in _SUPPORTED_LANGS:
-            raise ValueError(
-                f"Unsupported lang {lang!r}. Must be one of: {', '.join(_SUPPORTED_LANGS)}"
-            )
-        compiler = "cc" if lang == "c" else "c++"
-        return dump(
-            so_path=path,
-            headers=headers,
-            extra_includes=includes,
-            version=version,
-            compiler=compiler,
-            lang=lang if lang == "c" else None,
-        )
-
-    if binary_fmt == "pe":
-        from .model import Function
-        from .pe_metadata import parse_pe_metadata
-        pe_meta = parse_pe_metadata(path)
-        if not pe_meta.machine:
-            raise AbicheckError(
-                f"Failed to extract PE metadata from '{path.name}'. "
-                "The file may be corrupt or not a valid PE binary."
-            )
-        if not pe_meta.exports:
-            raise AbicheckError(
-                f"PE file '{path.name}' has no exports (named or ordinal). "
-                "Verify the file is a valid DLL."
-            )
-        funcs = [
-            Function(
-                name=(exp.name or f"ordinal:{exp.ordinal}"),
-                mangled=(exp.name or f"ordinal:{exp.ordinal}"),
-                return_type="?",
-                visibility=Visibility.PUBLIC,
-                is_extern_c=not (exp.name or "").startswith("?"),
-            )
-            for exp in pe_meta.exports
-        ]
-        return AbiSnapshot(
-            library=path.name, version=version,
-            functions=funcs, pe=pe_meta, platform="pe",
-        )
-
-    if binary_fmt == "macho":
-        from .macho_metadata import parse_macho_metadata
-        from .model import Function
-        macho_meta = parse_macho_metadata(path)
-        if not macho_meta.exports and not macho_meta.install_name and not macho_meta.dependent_libs:
-            raise AbicheckError(
-                f"Mach-O file '{path.name}' has no exports or load-command metadata. "
-                "Verify the file is a valid dynamic library."
-            )
-        funcs = [
-            Function(
-                name=exp.name, mangled=exp.name, return_type="?",
-                visibility=Visibility.PUBLIC,
-                is_extern_c=not exp.name.startswith("_Z"),
-            )
-            for exp in macho_meta.exports if exp.name
-        ]
-        return AbiSnapshot(
-            library=path.name, version=version,
-            functions=funcs, macho=macho_meta, platform="macho",
-        )
-
-    # Text-based: JSON snapshot or Perl dump
-    try:
-        with open(path, "rb") as f:
-            head = f.read(256).decode("utf-8", errors="replace").lstrip()
-    except OSError as exc:
-        _logger.debug("Failed reading input in _resolve_input: %s", exc, exc_info=True)
-        raise AbicheckError("Cannot read input file") from exc
-
-    from .compat.abicc_dump_import import import_abicc_perl_dump, looks_like_perl_dump
-    if looks_like_perl_dump(head):
-        return import_abicc_perl_dump(path)
-
-    if head.startswith("{"):
-        return load_snapshot(path)
-
-    # Static / import library archives (.a / .lib) are member containers, not a
-    # single linkable image — a deliberate non-goal (see
-    # docs/concepts/limitations.md). Reject with actionable guidance, matching
-    # the CLI/service/dumper paths.
-    from .binary_utils import detect_archive
-    if detect_archive(path):
-        raise AbicheckError(
-            f"'{path}' is a static/import library archive (.a/.lib), which abicheck "
-            "does not analyse — it compares single linkable images (shared libraries "
-            "and objects). Extract the members (e.g. `ar x lib.a`) and compare the "
-            "resulting object files or the shared library built from them instead."
-        )
-
-    raise AbicheckError(
-        "Cannot detect input format. "
-        "Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump."
-    )
+    return service.resolve_input(path, headers, includes, version, lang)
 
 
 def _snapshot_summary(snap: AbiSnapshot) -> dict[str, Any]:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -39,6 +39,8 @@ from .reporter import to_json, to_markdown, to_stat, to_stat_json
 from .serialization import load_snapshot
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .policy_file import PolicyFile
@@ -202,14 +204,39 @@ def resolve_input(
     dwarf_only: bool = False,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debug_format: str | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
+    follow_linker_scripts: bool = True,
+    notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
     """Auto-detect input type and return an ABI snapshot.
+
+    This is the single source of truth for turning a path into an
+    :class:`AbiSnapshot`; the CLI (:func:`abicheck.cli_resolve._resolve_input`)
+    and the MCP server are thin wrappers that translate the framework-free
+    errors raised here into their own contracts.
 
     Detection order:
 
     1. Native binary (ELF / PE / Mach-O, detected by magic bytes)
-    2. ABICC Perl dump (``$VAR1`` prefix) → :func:`import_abicc_perl_dump`
-    3. JSON snapshot (``{`` prefix) → :func:`load_snapshot`
+    2. Raw BTF/CTF type-info blob
+    3. ABICC Perl dump (``$VAR1`` prefix) → :func:`import_abicc_perl_dump`
+    4. JSON snapshot (``{`` prefix) → :func:`load_snapshot`
+    5. GNU ld linker script (``INPUT()``/``GROUP()``) → follow to its target
+
+    Args:
+        debug_format: Force the ELF debug format ("dwarf", "btf", "ctf") or
+            *None* for auto-detection.
+        public_headers / public_header_dirs: Public-header sets used to tag
+            declaration provenance on PE/Mach-O snapshots (ADR-024 Phase 1).
+        follow_linker_scripts: When True (default), a GNU ld linker script is
+            followed to the shared library named in its ``INPUT()``/``GROUP()``
+            directive.
+        notify: Optional callback for user-facing progress notes (e.g. "following
+            a linker script", "no headers provided"). When *None*, such notes go
+            to the module logger. The CLI passes a ``click.echo(..., err=True)``
+            wrapper so its stderr output is unchanged.
 
     Raises:
         SnapshotError: If the snapshot cannot be loaded from the input.
@@ -230,6 +257,10 @@ def resolve_input(
             dwarf_only=dwarf_only,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debug_format=debug_format,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+            notify=notify,
         )
 
     # Detect binary format from magic bytes
@@ -246,6 +277,10 @@ def resolve_input(
             dwarf_only=dwarf_only,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debug_format=debug_format,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+            notify=notify,
         )
 
     # Raw kernel type-info blobs (a bare `.BTF` / CTF section extracted with
@@ -283,6 +318,40 @@ def resolve_input(
                 f"Failed to load JSON snapshot '{path}': {exc}"
             ) from exc
 
+    # GNU ld linker script (e.g. the ``libfoo.so`` dev symlink is the text
+    # ``INPUT(libfoo.so.1)``): follow it to the real shared library.
+    if follow_linker_scripts:
+        from .binary_utils import resolve_linker_script
+
+        target, is_ld_script = resolve_linker_script(path)
+        if is_ld_script:
+            if target is not None and target.resolve() != path.resolve():
+                _emit(
+                    notify,
+                    f"Note: '{path}' is a GNU ld linker script; following its "
+                    f"INPUT()/GROUP() directive to '{target}'.",
+                )
+                return resolve_input(
+                    target,
+                    _headers,
+                    _includes,
+                    version,
+                    lang,
+                    dwarf_only=dwarf_only,
+                    debug_roots=debug_roots,
+                    enable_debuginfod=enable_debuginfod,
+                    debug_format=debug_format,
+                    public_headers=public_headers,
+                    public_header_dirs=public_header_dirs,
+                    follow_linker_scripts=follow_linker_scripts,
+                    notify=notify,
+                )
+            raise ValidationError(
+                f"'{path}' is a GNU ld linker script (INPUT/GROUP), not a binary, "
+                "and its target could not be located next to it. Pass the actual "
+                "shared library named in its INPUT(...) directive directly."
+            )
+
     # Static / import libraries (`.a`, `.lib`) are member archives, not single
     # linkable images. abicheck does not analyse archives (by design — see
     # docs/concepts/limitations.md); fail with actionable guidance rather than a
@@ -318,8 +387,18 @@ def run_dump(
     dwarf_only: bool = False,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debug_format: str | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
+    notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
     """Extract an ABI snapshot from a native binary (ELF, PE, or Mach-O).
+
+    ``public_headers`` / ``public_header_dirs`` tag declaration provenance on
+    PE/Mach-O snapshots (ADR-024 Phase 1); they are a no-op for ELF (whose
+    provenance is applied inside :func:`dumper.dump`) and when no header set is
+    supplied. ``debug_format`` forces the ELF debug format. ``notify`` receives
+    user-facing progress notes (see :func:`resolve_input`).
 
     Raises:
         SnapshotError: If the binary cannot be parsed.
@@ -338,11 +417,13 @@ def run_dump(
             dwarf_only=dwarf_only,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debug_format=debug_format,
+            notify=notify,
         )
         _try_attach_sycl_metadata(snap, path)
         return snap
     if binary_fmt == "pe":
-        return _dump_pe(
+        snap = _dump_pe(
             path,
             version,
             headers=_headers,
@@ -350,15 +431,41 @@ def run_dump(
             lang=lang,
             pdb_path=pdb_path,
         )
+        return _apply_native_provenance(snap, public_headers, public_header_dirs)
     if binary_fmt == "macho":
-        return _dump_macho(
+        snap = _dump_macho(
             path,
             version,
             headers=_headers,
             includes=_includes,
             lang=lang,
         )
+        return _apply_native_provenance(snap, public_headers, public_header_dirs)
     raise ValidationError(f"Unsupported binary format: {binary_fmt}")
+
+
+def _apply_native_provenance(
+    snap: AbiSnapshot,
+    public_headers: list[Path] | None,
+    public_header_dirs: list[Path] | None,
+) -> AbiSnapshot:
+    """Tag declaration provenance on a PE/Mach-O snapshot (ADR-024 Phase 1).
+
+    Mirrors the ELF path (``dumper.create_snapshot``), which always runs
+    ``apply_provenance``. A no-op when no public-header set is supplied — every
+    origin stays ``UNKNOWN`` and behaviour is unchanged.
+    """
+    from .provenance import apply_provenance
+
+    return apply_provenance(snap, public_headers, public_header_dirs)
+
+
+def _emit(notify: Callable[[str], None] | None, message: str) -> None:
+    """Send a user-facing progress note to *notify*, or the logger if unset."""
+    if notify is not None:
+        notify(message)
+    else:
+        _logger.warning(message)
 
 
 def _try_attach_sycl_metadata(snap: AbiSnapshot, lib_path: Path) -> None:
@@ -396,16 +503,18 @@ def _dump_elf(
     dwarf_only: bool = False,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debug_format: str | None = None,
+    notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
     """Dump an ELF binary to an ABI snapshot."""
     from .dumper import dump
 
     resolved_headers = expand_header_inputs(headers) if headers else []
     if not resolved_headers and not dwarf_only:
-        _logger.warning(
-            "'%s' — no headers provided. "
+        _emit(
+            notify,
+            f"Warning: '{path}' — no headers provided. "
             "Will use DWARF debug info if available, else symbols-only mode.",
-            path,
         )
     if resolved_headers and not dwarf_only:
         for inc in includes:
@@ -414,7 +523,7 @@ def _dump_elf(
                     f"Include directory not found or not a directory: {inc}"
                 )
     elif includes and not dwarf_only:
-        _logger.warning("Include paths are ignored without headers.")
+        _emit(notify, "Warning: --include paths are ignored without headers.")
 
     compiler = "cc" if lang == "c" else "c++"
     try:
@@ -426,6 +535,7 @@ def _dump_elf(
             compiler=compiler,
             lang=lang if lang == "c" else None,
             dwarf_only=dwarf_only,
+            debug_format=debug_format,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise SnapshotError(f"Failed to dump '{path}': {exc}") from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ disable_error_code = ["attr-defined"]
 # we also relax ``no-any-return`` / ``misc`` there.
 module = [
     "abicheck.cli",
+    "abicheck.cli_resolve",
     "abicheck.cli_appcompat",
     "abicheck.cli_compare_release",
     "abicheck.cli_debian_symbols",

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -88,7 +88,7 @@ class TestResolveInputErrors:
         f.write_text("$VAR1 = {\n  broken\n};", encoding="utf-8")
 
         monkeypatch.setattr(
-            "abicheck.cli.import_abicc_perl_dump",
+            "abicheck.cli_resolve.import_abicc_perl_dump",
             lambda _p: (_ for _ in ()).throw(ValueError("parse error")),
         )
         with pytest.raises(click.ClickException, match="Failed to import ABICC Perl dump"):
@@ -113,7 +113,7 @@ class TestResolveInputErrors:
         f.write_text("{invalid json", encoding="utf-8")
 
         monkeypatch.setattr(
-            "abicheck.cli.load_snapshot",
+            "abicheck.cli_resolve.load_snapshot",
             lambda _p: (_ for _ in ()).throw(ValueError("bad json")),
         )
         with pytest.raises(click.ClickException, match="Failed to load JSON snapshot"):
@@ -255,7 +255,7 @@ class TestCompareApiBreakExitCode:
         new_p.write_text("{}", encoding="utf-8")
 
         snap = AbiSnapshot(library="lib.so", version="1.0")
-        monkeypatch.setattr("abicheck.cli.load_snapshot", lambda _: snap)
+        monkeypatch.setattr("abicheck.cli_resolve.load_snapshot", lambda _: snap)
         monkeypatch.setattr(
             "abicheck.cli.compare",
             lambda *_a, **_kw: DiffResult(

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -88,7 +88,7 @@ class TestResolveInputErrors:
         f.write_text("$VAR1 = {\n  broken\n};", encoding="utf-8")
 
         monkeypatch.setattr(
-            "abicheck.cli_resolve.import_abicc_perl_dump",
+            "abicheck.compat.abicc_dump_import.import_abicc_perl_dump",
             lambda _p: (_ for _ in ()).throw(ValueError("parse error")),
         )
         with pytest.raises(click.ClickException, match="Failed to import ABICC Perl dump"):
@@ -113,7 +113,7 @@ class TestResolveInputErrors:
         f.write_text("{invalid json", encoding="utf-8")
 
         monkeypatch.setattr(
-            "abicheck.cli_resolve.load_snapshot",
+            "abicheck.service.load_snapshot",
             lambda _p: (_ for _ in ()).throw(ValueError("bad json")),
         )
         with pytest.raises(click.ClickException, match="Failed to load JSON snapshot"):
@@ -255,7 +255,7 @@ class TestCompareApiBreakExitCode:
         new_p.write_text("{}", encoding="utf-8")
 
         snap = AbiSnapshot(library="lib.so", version="1.0")
-        monkeypatch.setattr("abicheck.cli_resolve.load_snapshot", lambda _: snap)
+        monkeypatch.setattr("abicheck.service.load_snapshot", lambda _: snap)
         monkeypatch.setattr(
             "abicheck.cli.compare",
             lambda *_a, **_kw: DiffResult(

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -128,7 +128,7 @@ class TestCompareLang:
             captured_calls.append(kwargs)
             return AbiSnapshot(library="libfoo.so", version="1.0")
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", fake_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", fake_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -128,7 +128,7 @@ class TestCompareLang:
             captured_calls.append(kwargs)
             return AbiSnapshot(library="libfoo.so", version="1.0")
 
-        monkeypatch.setattr("abicheck.cli.dump", fake_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", fake_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [

--- a/tests/test_compare_input_modes.py
+++ b/tests/test_compare_input_modes.py
@@ -356,7 +356,7 @@ class TestCompareSoSo:
                 return old_snap
             return new_snap
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -381,7 +381,7 @@ class TestCompareSoSo:
             recorded_headers.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -404,7 +404,7 @@ class TestCompareSoSo:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, ["compare", str(old_elf), str(new_elf)])
         assert result.exit_code == 0, result.output
@@ -425,7 +425,7 @@ class TestCompareSoSo:
             recorded_versions.append(version)
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -451,7 +451,7 @@ class TestCompareSoSo:
             recorded_includes.append(list(extra_includes or []))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -479,7 +479,7 @@ class TestCompareMixed:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -499,7 +499,7 @@ class TestCompareMixed:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -519,7 +519,7 @@ class TestCompareMixed:
                       lang="c++", **kw):
             return new_snap
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -541,7 +541,7 @@ class TestCompareMixed:
             recorded_headers.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -568,7 +568,7 @@ class TestCompareSoOutputFormats:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         args = ["compare", str(old_elf), str(new_elf), "-H", str(hdr),
                 "--format", fmt]
@@ -646,7 +646,7 @@ class TestElfNoHeaderFallback:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, ["compare", str(old_elf), str(new_elf)])
         assert result.exit_code == 0, result.output
@@ -674,7 +674,7 @@ class TestHeaderDirectoryInput:
             captured.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -706,7 +706,7 @@ class TestHeaderDirectoryInput:
             captured.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, [
             "compare", str(old_elf), str(new_elf),
@@ -736,7 +736,7 @@ class TestHeaderDirectoryInput:
             captured.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli.dump", mock_dump)
+        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, [
             "compare", str(old_elf), str(new_elf),

--- a/tests/test_compare_input_modes.py
+++ b/tests/test_compare_input_modes.py
@@ -356,7 +356,7 @@ class TestCompareSoSo:
                 return old_snap
             return new_snap
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -381,7 +381,7 @@ class TestCompareSoSo:
             recorded_headers.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -404,7 +404,7 @@ class TestCompareSoSo:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, ["compare", str(old_elf), str(new_elf)])
         assert result.exit_code == 0, result.output
@@ -425,7 +425,7 @@ class TestCompareSoSo:
             recorded_versions.append(version)
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -451,7 +451,7 @@ class TestCompareSoSo:
             recorded_includes.append(list(extra_includes or []))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -479,7 +479,7 @@ class TestCompareMixed:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -499,7 +499,7 @@ class TestCompareMixed:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -519,7 +519,7 @@ class TestCompareMixed:
                       lang="c++", **kw):
             return new_snap
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -541,7 +541,7 @@ class TestCompareMixed:
             recorded_headers.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -568,7 +568,7 @@ class TestCompareSoOutputFormats:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         args = ["compare", str(old_elf), str(new_elf), "-H", str(hdr),
                 "--format", fmt]
@@ -646,7 +646,7 @@ class TestElfNoHeaderFallback:
                       lang="c++", **kw):
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, ["compare", str(old_elf), str(new_elf)])
         assert result.exit_code == 0, result.output
@@ -674,7 +674,7 @@ class TestHeaderDirectoryInput:
             captured.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
 
         runner = CliRunner()
         result = runner.invoke(main, [
@@ -706,7 +706,7 @@ class TestHeaderDirectoryInput:
             captured.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, [
             "compare", str(old_elf), str(new_elf),
@@ -736,7 +736,7 @@ class TestHeaderDirectoryInput:
             captured.append(list(headers))
             return _make_snapshot(version)
 
-        monkeypatch.setattr("abicheck.cli_resolve.dump", mock_dump)
+        monkeypatch.setattr("abicheck.dumper.dump", mock_dump)
         runner = CliRunner()
         result = runner.invoke(main, [
             "compare", str(old_elf), str(new_elf),

--- a/tests/test_cov95_misc.py
+++ b/tests/test_cov95_misc.py
@@ -888,7 +888,7 @@ class TestMcpResolveInputText:
         path.write_text("plain text that is neither json nor perl", encoding="utf-8")
         with patch.object(_ms, "_detect_binary_format", return_value=None):
             with patch("abicheck.binary_utils.detect_archive", return_value=False):
-                with pytest.raises(AbicheckError, match="Cannot detect input format"):
+                with pytest.raises(AbicheckError, match="Cannot detect format"):
                     _resolve_input(path, [], [], "v", "c++")
 
 

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -388,6 +388,25 @@ class TestResolveInputELF:
         result = _resolve_input(elf_file, [], [], "1.0", "rust")
         assert result is fake_snap
 
+    def test_linker_script_following_disabled(self, tmp_path, monkeypatch):
+        """MCP must not follow GNU ld linker scripts.
+
+        _check_file_size only guards the caller-supplied path, so following an
+        INPUT(huge.so) directive would parse an unchecked target and bypass
+        MCP_MAX_FILE_SIZE. _resolve_input pins follow_linker_scripts=False.
+        """
+        import abicheck.service as svc
+
+        captured: dict = {}
+
+        def fake_resolve(path, headers, includes, version, lang, **kwargs):
+            captured.update(kwargs)
+            return _empty_snapshot()
+
+        monkeypatch.setattr(svc, "resolve_input", fake_resolve)
+        _resolve_input(tmp_path / "libfoo.so", [], [], "1.0", "c++")
+        assert captured.get("follow_linker_scripts") is False
+
 
 # ---------------------------------------------------------------------------
 # _render_output — stat, sarif, html, markdown, unknown (lines 376-405)

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -300,7 +300,7 @@ class TestResolveInputText:
             return real_open(path, *a, **kw)
 
         monkeypatch.setattr(builtins, "open", failing_open)
-        with pytest.raises(AbicheckError, match="Cannot read input file"):
+        with pytest.raises(AbicheckError, match="Cannot detect format"):
             _resolve_input(bad_file, [], [], "1.0", "c++")
 
     def test_perl_dump_detected(self, tmp_path, monkeypatch):
@@ -331,7 +331,7 @@ class TestResolveInputText:
         )
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server.load_snapshot",
+            "abicheck.service.load_snapshot",
             lambda p: fake_snap,
         )
         result = _resolve_input(snap_file, [], [], "1.0", "c++")
@@ -346,7 +346,7 @@ class TestResolveInputText:
             "abicheck.mcp_server._detect_binary_format",
             lambda p: None,
         )
-        with pytest.raises(AbicheckError, match="Cannot detect input format"):
+        with pytest.raises(AbicheckError, match="Cannot detect format"):
             _resolve_input(unknown_file, [], [], "1.0", "c++")
 
 
@@ -372,17 +372,21 @@ class TestResolveInputELF:
         result = _resolve_input(elf_file, [], [], "1.0", "c++")
         assert result is fake_snap
 
-    def test_elf_unsupported_lang_raises(self, tmp_path, monkeypatch):
-        """Lines 259-262: unsupported language raises ValueError."""
+    def test_elf_unusual_lang_forwarded(self, tmp_path, monkeypatch):
+        """lang is no longer rejected at the MCP resolve layer.
+
+        _resolve_input now delegates to ``service.resolve_input`` (the single
+        source of truth), which forwards lang to the dumper (mapping any non-'c'
+        value to the c++ profile) rather than raising. The dump call is mocked
+        so we assert the value is threaded through instead of rejected.
+        """
         elf_file = tmp_path / "lib.so"
         elf_file.write_bytes(b"\x7fELF" + b"\x00" * 100)
 
-        monkeypatch.setattr(
-            "abicheck.mcp_server._detect_binary_format",
-            lambda p: "elf",
-        )
-        with pytest.raises(ValueError, match="Unsupported lang"):
-            _resolve_input(elf_file, [], [], "1.0", "rust")
+        fake_snap = _empty_snapshot()
+        monkeypatch.setattr("abicheck.dumper.dump", lambda **kw: fake_snap)
+        result = _resolve_input(elf_file, [], [], "1.0", "rust")
+        assert result is fake_snap
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1141,14 +1141,14 @@ class TestResolveInput:
     def test_unknown_format_raises(self, tmp_path: Path):
         f = tmp_path / "unknown.xyz"
         f.write_text("not any recognized format at all", encoding="utf-8")
-        with pytest.raises(AbicheckError, match="Cannot detect input format"):
+        with pytest.raises(AbicheckError, match="Cannot detect format"):
             _resolve_input(f, [], [], "1.0", "c++")
 
     def test_unreadable_file_raises(self, tmp_path: Path):
         f = tmp_path / "unreadable.bin"
         f.write_bytes(b"\x00\x01\x02\x03")
         # The file is readable, but not recognized as any format
-        with pytest.raises(AbicheckError, match="Cannot detect input format"):
+        with pytest.raises(AbicheckError, match="Cannot detect format"):
             _resolve_input(f, [], [], "1.0", "c++")
 
     def test_static_archive_raises_with_guidance(self, tmp_path: Path):


### PR DESCRIPTION
## What

Completes **C7-tail**: pulls the CLI input-resolution / native-dump cluster out of `cli.py` and unifies the three divergent `resolve_input` implementations onto a single source of truth in `abicheck.service`.

Done in three reviewable commits:

### 1. Extract `cli_resolve` leaf (behaviour-preserving)
Moves the input-resolution & native-dump dispatch cluster out of `cli.py` into a new leaf module `abicheck/cli_resolve.py` (`_resolve_input`, `_dump_native_binary`, `_normalize_binary_input`, `_resolve_compare_snapshots`, `_populate_dependency_info`, `_is_supported_compare_input`, header/sniff/linker helpers, …). The dependency runs one way (`cli` → `cli_resolve`) and stays cycle-free. Helpers are re-exported from `cli` (declared in `__all__`, so the re-export is explicit for mypy's `no_implicit_reexport` and ruff) — every existing `from abicheck.cli import _resolve_input` call site keeps working unchanged. Dead `_LD_SCRIPT_RE`/`_LD_KEYWORDS` regexes are dropped (the live copies live in `binary_utils`). `cli.py` drops **1928 → ~1519 lines**, back under the 2000-line hard cap.

### 2. `service.resolve_input` becomes the single source of truth
There were **three** divergent resolvers (`cli`, `service`, `mcp_server`) with different error contracts *and* feature sets. `service` is enriched with additive, backward-compatible kwargs so it is now the superset:
- GNU ld **linker-script following** (with the same note + "target not found" error);
- **`debug_format`** threaded to `dumper.dump`;
- **`public_headers`/`public_header_dirs`** → PE/Mach-O provenance (ADR-024);
- a **`notify`** callback so user-facing stderr notes are emitted by the CLI exactly as before.

`cli_resolve._resolve_input` / `_dump_native_binary` become thin wrappers that pass a `click.echo` notifier and map the framework-free errors back to click exceptions, **preserving exit codes**: `ValidationError` → `UsageError` (64), `SnapshotError` → `ClickException` (1). Existing service callers (`cli_scan`, `cli_surface`, `service.compare`, `cli_buildsource`) are unaffected (new kwargs default to prior behaviour).

### 3. `mcp_server` routes through `service` too
`mcp_server._resolve_input` is now a thin `service.resolve_input` wrapper. This **intentionally changes the MCP snapshot contract** (reviewed and accepted): PE/Mach-O exports dumped via the shared path (visibility `ELF_ONLY`), empty-export tables no longer raise an explicit error, `lang` is forwarded rather than rejected; MCP gains linker-script following, raw BTF/CTF blobs, and SYCL auto-attach for free. The ~7 mcp tests that encoded the old lightweight wording are updated to the unified contract.

## Validation
- ✅ `ruff check abicheck/ tests/` + `ruff format` clean (no whole-file reformat churn — `cli.py` diff is pure relocation)
- ✅ `mypy abicheck/` — 0 errors
- ✅ `scripts/check_ai_readiness.py` — 0 errors
- ✅ Fast suite **10866 passed** (incl. `golden`), exit-code-integrity + exit-codes green
- Monkeypatch targets in CLI/MCP tests repointed to the source modules (`dumper.dump`, `service.load_snapshot`, `compat.abicc_dump_import`) where the calls now resolve.

> Integration / libabigail / abicc / msvc lanes need external toolchains (castxml, gcc, abidiff) not available in this environment — relying on CI for those.

https://claude.ai/code/session_0149JFNpLtbTzANWAcibqtfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0149JFNpLtbTzANWAcibqtfQ)_