### PR TITLE
docs: G20 plan — source-scan & cross-source example catalog

### DIFF
--- a/docs/development/plans/g20-source-scan-example-catalog.md
+++ b/docs/development/plans/g20-source-scan-example-catalog.md
@@ -1,0 +1,169 @@
+# G20 — Source-Scan & Cross-Source Example Catalog
+
+**ADR:** [ADR-035](../adr/035-pr-tier-source-intelligence-and-crosscheck.md)
+(G19 shipped the engine; this plan grows the *demonstration corpus* for it)
+**Type:** Catalog/test extension (phased) · **Effort:** L · **Risk:** low —
+additive example cases + test scenarios; no detector or policy change.
+
+## Problem
+
+ADR-035 (G19) landed the engine for cheap PR source scans, intra-version
+cross-source validation, single-release audit, and evidence-directed focusing.
+The detection code exists; the **demonstration corpus does not**. The
+`examples/` catalog still tells exactly one story — a `v1`→`v2` **binary diff**:
+
+| min_evidence | cases | exercises |
+|---|---|---|
+| L0 (binary) | 50 | exports / sizes |
+| L1 (+debug) | 65 | DWARF layout |
+| L2 (+headers) | 23 | header AST |
+| L3 (+build) | 4 | flag / toolchain drift |
+| L4 (+source) | 1 | source replay |
+| L5 (graph) | **0** | — |
+
+Zero cases produce any of the eight ADR-035 cross-check / audit `ChangeKind`s
+(`exported_not_public`, `public_not_exported`, `header_build_context_mismatch`,
+`private_header_leak`, `odr_type_variant`, `public_to_internal_dependency`,
+`unversioned_exported_symbol`, `rtti_for_internal_type`) even though all are
+defined in `checker_policy.py` and implemented in `buildsource/crosscheck.py`.
+
+The catalog therefore showcases *detection depth on a binary delta* and
+**nothing** about ADR-035's actual thesis: (a) value from one build with no
+baseline, (b) multi-source corroboration where the combination beats any single
+source, and (c) one source steering another's collection.
+
+## Goal & acceptance criteria
+
+Grow the corpus along the three ADR-035 capability axes. Per the maintainer
+decision, flagship demos land as first-class `examples/caseNN` entries (visible
+in the encyclopedia), edge/integrity/plan cases land as test-only scenario
+suites (compiler-free, fast lane) modelled on `tests/test_pattern_audit_scenarios.py`.
+
+- **G20.1 — Source-scan / single-release audit corpus.** At least four catalog
+  cases reach a verdict from **one artifact, no baseline** (D8 audit), covering
+  `exported_not_public`, `private_header_leak`, `unversioned_exported_symbol`,
+  `rtti_for_internal_type`; plus one S3→S5 "depth ladder" case showing the same
+  input answered at three depths with an honest coverage block.
+- **G20.2 — Cross-source corroboration corpus.** At least three catalog cases
+  whose finding is invisible/ambiguous to any single source and resolves only by
+  crosschecking two: `header_build_context_mismatch` (L2 macros ↔ L3 flags),
+  `odr_type_variant` (L4 per-TU layout ↔ layout), and the
+  `exported_not_public`/`public_not_exported` bidirectional pair (L0 exports ↔ L2
+  decls). One case asserts the §6.8 provider-agreement matrix drives the
+  **confidence tag** differently for 3-provider vs 1-provider corroboration.
+- **G20.3 — Evidence-directed focusing corpus.** Test scenarios asserting on the
+  **POI set / scan plan** (not just verdict): an export delta targeting a single
+  TU's replay, a macro-conditional layout scoping macro capture, the D7
+  changed-path floor (mis-weighted `risk_rules` cannot drop a changed TU), and
+  the D4 "unlinked source evidence" integrity guard (the oneDAL failure shape).
+- **Acceptance gate:** every new catalog case has a `README.md` + a
+  `ground_truth.json` entry + a regenerated `docs/examples/` page; the
+  AI-readiness `examples-*` and `doc-count-sync` checks stay green; the FP-rate
+  gate keeps its 0/0 baseline (new cross-check cases enter the corpus only if the
+  correct implementation already passes them).
+
+## Enabling work — the harness assumes `v1`/`v2` binary diff
+
+Buckets 1–3 cannot be hosted as-is. Required schema/harness extensions, smallest
+first:
+
+1. **`ground_truth.json` schema (v4).** Add optional `expected_crosscheck_kinds`
+   (subset check against `run_crosschecks` output), an optional `providers` /
+   confidence expectation (for the §6.8 matrix case), `min_evidence: L5`, and
+   support for **baseline-less** cases (D8 audit cases have no `v2`). Update the
+   `cross_references` block and `scripts/evidence_tiers.py` mapping. Keep
+   `tests/test_example_autodiscovery.py::EXPECTED` and
+   `tests/test_evidence_tiers.py` in sync.
+2. **New per-case fixture types.** Allow a case dir to ship
+   `compile_commands.json`, an `install_manifest` (leak / unversioned cases),
+   multi-TU source sets (ODR), and a `.abicheck.yml` (risk-rule cases). Prefer
+   the existing **Flow-2 `abicheck_inputs/`** pack format
+   (`buildsource/inputs_pack.py`) so fixtures ingest **without a live compiler**
+   wherever possible.
+3. **Scan-plan assertion surface.** Bucket 3 asserts on `ScanResult` /
+   `scan --estimate` counters (selected/parsed/skipped TU, cache hit/miss,
+   matched/unmatched exports). Expose these from the test harness; most Bucket 3
+   cases run compiler-free against synthetic `AbiSnapshot` pairs (the
+   `tests/test_crosscheck.py` `_snap(**kw)` pattern already does this).
+4. **Test lane wiring.** Synthetic-snapshot crosscheck + POI cases run in the
+   **fast lane** (Python only). L4-bearing catalog cases (ODR, depth ladder) are
+   `integration` (castxml) — mark them, do not skip silently. Wire
+   `ABICHECK_MIN_EXECUTED` for any new external-tool lane.
+
+## Phases
+
+### Phase 0 — schema + harness (enabling)
+Land the `ground_truth.json` v4 schema, fixture-type support, and scan-plan
+assertion surface above. No new cases yet; existing 143 stay green. Update
+`examples/CLAUDE.md` per-case-layout section to document the new fixture types.
+
+### Phase 1 — single-release audit (G20.1)
+Compiler-free / smallest fixtures first. New catalog cases:
+
+| Case | Kind | Sources combined | Fixture |
+|---|---|---|---|
+| `case143_audit_accidental_export` | `exported_not_public` | binary exports ↔ L2 header decls | `.so` + `include/` + manifest |
+| `case144_audit_private_header_leak` | `private_header_leak` | L5 include graph ↔ install manifest | public hdr → `detail/` hdr + manifest |
+| `case145_audit_unversioned_export` | `unversioned_exported_symbol` | export ↔ `.gnu.version_d` | versioned `.so` + 1 new bare export |
+| `case146_audit_rtti_for_internal` | `rtti_for_internal_type` | `_ZTI`/`_ZTV` ↔ private-header type | internal type w/ RTTI emitted |
+| `case147_scan_depth_ladder` | pattern → semantic | S3 lexical vs S5 replay, same input | header w/ `#pragma pack` + TU |
+
+`case147` is the legibility anchor: same input, three depths, coverage block
+shows what each depth proved.
+
+### Phase 2 — cross-source corroboration (G20.2)
+The "1+1 > 2" flagship. Compiler-free synthetic snapshots where possible.
+
+| Case | Kind | Why no single source sees it |
+|---|---|---|
+| `case148_xcheck_header_build_mismatch` | `header_build_context_mismatch` | binary-only blind; header parsed w/o `-DBIG_BUFFERS` is wrong; needs L2 macros ↔ L3 flags |
+| `case149_xcheck_odr_variant` | `odr_type_variant` | two TUs, divergent layout of one public type; only L4 layout ↔ layout |
+| `case150_xcheck_export_public_pair` | `exported_not_public` + `public_not_exported` | bidirectional L0 exports ↔ L2 decls |
+| `case151_xcheck_confidence_matrix` | (reuses one kind) | 3-provider vs 1-provider corroboration → different confidence tag (§6.8) |
+
+`case148` is the flagship — the clearest demonstration that combining L2 + L3
+exposes a divergence neither shows alone.
+
+### Phase 3 — evidence-directed focusing (G20.3)
+Test-only scenario suites (`tests/test_poi_scenarios.py`,
+`tests/test_source_evidence_integrity.py`) asserting on the **scan plan**:
+
+- `poi_export_delta_targets_replay` — changed export, unchanged header → POI
+  resolves symbol → source decl → replays **only that TU**; assert
+  `selected_tu == 1`, unrelated body skipped.
+- `poi_macro_conditional_layout` — macro capture scoped to materializing TUs only.
+- `poi_template_instantiation_seed` — demangled exported template symbol seeds
+  which instantiations replay.
+- `poi_changed_path_floor` — mis-weighted `risk_rules`; assert the changed TU is
+  **still** in the POI set (D7 floor: risk adds, never drops).
+- `integrity_unlinked_source_evidence` — oneDAL shape: many exports, TUs parsed,
+  **zero matched symbols**; assert reported as *degraded/unlinked source
+  evidence* with boundary counters, **not** counted as clean L4 coverage.
+
+## Sequencing rationale
+
+Land compiler-free, high-payload cases first so the catalog grows without an
+external-tool dependency while exercising genuinely-new code paths:
+
+1. **Phase 2 crosschecks** — highest ADR-035-thesis payload, buildable as
+   synthetic `AbiSnapshot` pairs today.
+2. **Phase 1 audit** — single-artifact, smallest fixtures, immediate value.
+3. **Phase 3 POI/integrity** — strongest "sources guide sources" narrative but
+   needs the Phase 0 scan-plan assertion surface.
+
+## Use-case tracking
+
+Add `planned` entries to `docs/development/usecase-registry.yaml` under a new
+gap **G20**, one per phase (G20.1/G20.2/G20.3), cross-referencing the G19
+engine entries and the ADR-035 decisions each case demonstrates (D2/D4/D7/D8).
+
+## Relationship to existing work
+
+- **G19 / ADR-035** — this consumes the engine G19 shipped; no engine change.
+- **`tests/test_pattern_audit_scenarios.py`** — the model for the test-only
+  scenario suites (Phase 3 + the synthetic Phase 2 cases).
+- **`tests/test_crosscheck.py`** — the `_snap(**kw)` synthetic-snapshot pattern
+  Phase 2 reuses.
+- **G11 single-binary audit** — Phase 1 audit cases extend its surface tooling.
+- **`scripts/check_ai_readiness.py`** — `examples-ground-truth`,
+  `examples-readme-sync`, `doc-count-sync` gate every new catalog case.

--- a/docs/development/plans/g20-source-scan-example-catalog.md
+++ b/docs/development/plans/g20-source-scan-example-catalog.md
@@ -4,13 +4,21 @@
 (G19 shipped the engine; this plan grows the *demonstration corpus* for it)
 **Type:** Catalog/test extension (phased) · **Effort:** L · **Risk:** low —
 additive example cases + test scenarios; no detector or policy change.
+**Status:** planned.
 
-## Problem
+---
+
+## 1. Problem
 
 ADR-035 (G19) landed the engine for cheap PR source scans, intra-version
 cross-source validation, single-release audit, and evidence-directed focusing.
-The detection code exists; the **demonstration corpus does not**. The
-`examples/` catalog still tells exactly one story — a `v1`→`v2` **binary diff**:
+The detection code exists and is unit-tested (`tests/test_crosscheck.py`,
+`tests/test_pattern_scan.py`, `tests/test_poi.py`, `tests/test_cli_scan.py`).
+What does **not** exist is a *demonstration corpus* — cases a maintainer can read
+to understand what the multi-source machinery buys them.
+
+The `examples/` catalog (143 cases) still tells exactly one story: a `v1`→`v2`
+**binary diff**. Evidence-tier distribution proves the skew:
 
 | min_evidence | cases | exercises |
 |---|---|---|
@@ -21,149 +29,313 @@ The detection code exists; the **demonstration corpus does not**. The
 | L4 (+source) | 1 | source replay |
 | L5 (graph) | **0** | — |
 
-Zero cases produce any of the eight ADR-035 cross-check / audit `ChangeKind`s
-(`exported_not_public`, `public_not_exported`, `header_build_context_mismatch`,
-`private_header_leak`, `odr_type_variant`, `public_to_internal_dependency`,
-`unversioned_exported_symbol`, `rtti_for_internal_type`) even though all are
-defined in `checker_policy.py` and implemented in `buildsource/crosscheck.py`.
+**Zero** catalog cases produce any of the eight ADR-035 cross-check / audit
+`ChangeKind`s, even though all eight are defined in `checker_policy.py`,
+implemented in `buildsource/crosscheck.py`, and already mapped in
+`scripts/evidence_tiers.py`:
 
-The catalog therefore showcases *detection depth on a binary delta* and
-**nothing** about ADR-035's actual thesis: (a) value from one build with no
-baseline, (b) multi-source corroboration where the combination beats any single
-source, and (c) one source steering another's collection.
+| ChangeKind | partition | evidence tier (already mapped) |
+|---|---|---|
+| `exported_not_public` | RISK | L2 |
+| `public_not_exported` | RISK | L2 |
+| `private_header_leak` | RISK | L2 |
+| `public_to_internal_dependency` | RISK | L4 |
+| `unversioned_exported_symbol` | RISK | L0 |
+| `rtti_for_internal_type` | RISK | L2 |
+| `header_build_context_mismatch` | API_BREAK | L3 |
+| `odr_type_variant` | API_BREAK | L4 |
 
-## Goal & acceptance criteria
+So the catalog showcases *detection depth on a binary delta* and **nothing**
+about ADR-035's three theses:
 
-Grow the corpus along the three ADR-035 capability axes. Per the maintainer
-decision, flagship demos land as first-class `examples/caseNN` entries (visible
-in the encyclopedia), edge/integrity/plan cases land as test-only scenario
-suites (compiler-free, fast lane) modelled on `tests/test_pattern_audit_scenarios.py`.
+1. **Value from one build, no baseline** (D8 single-release audit).
+2. **Multi-source corroboration** — a finding invisible or ambiguous to any one
+   source, resolved by crosschecking two (D4), with confidence driven by *how
+   many* providers agree (§6.8).
+3. **Sources steer sources** — cheap L0/L1/L2 deltas focus the expensive L4/L5
+   scan (D7 POI), and an L4 run that fails to link is reported as degraded, not
+   clean (D4 integrity gate).
 
-- **G20.1 — Source-scan / single-release audit corpus.** At least four catalog
-  cases reach a verdict from **one artifact, no baseline** (D8 audit), covering
-  `exported_not_public`, `private_header_leak`, `unversioned_exported_symbol`,
-  `rtti_for_internal_type`; plus one S3→S5 "depth ladder" case showing the same
-  input answered at three depths with an honest coverage block.
-- **G20.2 — Cross-source corroboration corpus.** At least three catalog cases
-  whose finding is invisible/ambiguous to any single source and resolves only by
+This plan closes the demonstration gap along those three axes.
+
+---
+
+## 2. Goal & acceptance criteria
+
+Per the maintainer decision (both locations): **flagship demos** land as
+first-class `examples/caseNN` entries (visible in the encyclopedia);
+**edge/integrity/plan** cases land as test-only scenario suites (compiler-free,
+fast lane) modelled on `tests/test_pattern_audit_scenarios.py` and the
+`_snap(**kw)` synthetic-snapshot pattern in `tests/test_crosscheck.py`.
+
+- **G20.1 — Single-release audit corpus (D8).** ≥4 catalog cases reach a verdict
+  from **one artifact, no baseline**, covering `exported_not_public`,
+  `private_header_leak`, `unversioned_exported_symbol`, `rtti_for_internal_type`;
+  plus one S3→S5 "depth ladder" case showing the same input answered at three
+  depths with an honest coverage block.
+- **G20.2 — Cross-source corroboration corpus (D4).** ≥3 catalog cases whose
+  finding is invisible/ambiguous to any single source and resolves only by
   crosschecking two: `header_build_context_mismatch` (L2 macros ↔ L3 flags),
-  `odr_type_variant` (L4 per-TU layout ↔ layout), and the
-  `exported_not_public`/`public_not_exported` bidirectional pair (L0 exports ↔ L2
-  decls). One case asserts the §6.8 provider-agreement matrix drives the
-  **confidence tag** differently for 3-provider vs 1-provider corroboration.
-- **G20.3 — Evidence-directed focusing corpus.** Test scenarios asserting on the
-  **POI set / scan plan** (not just verdict): an export delta targeting a single
-  TU's replay, a macro-conditional layout scoping macro capture, the D7
-  changed-path floor (mis-weighted `risk_rules` cannot drop a changed TU), and
+  `odr_type_variant` (L4 layout ↔ layout), and the `exported_not_public` /
+  `public_not_exported` bidirectional pair (L0 exports ↔ L2 decls). One case
+  asserts the §6.8 provider-agreement matrix drives the **confidence tag**
+  differently for 3-provider vs 1-provider corroboration.
+- **G20.3 — Evidence-directed focusing corpus (D7).** Test scenarios asserting on
+  the **POI set / `ScanResult` counters** (not just verdict): export delta
+  targeting one TU's replay, macro-conditional layout scoping macro capture, the
+  D7 changed-path floor (mis-weighted `risk_rules` cannot drop a changed TU), and
   the D4 "unlinked source evidence" integrity guard (the oneDAL failure shape).
-- **Acceptance gate:** every new catalog case has a `README.md` + a
-  `ground_truth.json` entry + a regenerated `docs/examples/` page; the
-  AI-readiness `examples-*` and `doc-count-sync` checks stay green; the FP-rate
-  gate keeps its 0/0 baseline (new cross-check cases enter the corpus only if the
+- **Acceptance gate (every phase):** each new catalog case has a `README.md`, a
+  `ground_truth.json` entry, and a regenerated `docs/examples/` page; the
+  AI-readiness `examples-ground-truth`, `examples-readme-sync`, `doc-count-sync`,
+  and `changekind-detector`/`changekind-docs` checks stay green; the FP-rate gate
+  keeps its **0/0** baseline (new cases enter the corpus only if the current,
   correct implementation already passes them).
 
-## Enabling work — the harness assumes `v1`/`v2` binary diff
+---
 
-Buckets 1–3 cannot be hosted as-is. Required schema/harness extensions, smallest
-first:
+## 3. Enabling work (Phase 0) — the harness assumes `v1`/`v2` binary diff
 
-1. **`ground_truth.json` schema (v4).** Add optional `expected_crosscheck_kinds`
-   (subset check against `run_crosschecks` output), an optional `providers` /
-   confidence expectation (for the §6.8 matrix case), `min_evidence: L5`, and
-   support for **baseline-less** cases (D8 audit cases have no `v2`). Update the
-   `cross_references` block and `scripts/evidence_tiers.py` mapping. Keep
-   `tests/test_example_autodiscovery.py::EXPECTED` and
-   `tests/test_evidence_tiers.py` in sync.
-2. **New per-case fixture types.** Allow a case dir to ship
-   `compile_commands.json`, an `install_manifest` (leak / unversioned cases),
-   multi-TU source sets (ODR), and a `.abicheck.yml` (risk-rule cases). Prefer
-   the existing **Flow-2 `abicheck_inputs/`** pack format
-   (`buildsource/inputs_pack.py`) so fixtures ingest **without a live compiler**
-   wherever possible.
-3. **Scan-plan assertion surface.** Bucket 3 asserts on `ScanResult` /
-   `scan --estimate` counters (selected/parsed/skipped TU, cache hit/miss,
-   matched/unmatched exports). Expose these from the test harness; most Bucket 3
-   cases run compiler-free against synthetic `AbiSnapshot` pairs (the
-   `tests/test_crosscheck.py` `_snap(**kw)` pattern already does this).
-4. **Test lane wiring.** Synthetic-snapshot crosscheck + POI cases run in the
-   **fast lane** (Python only). L4-bearing catalog cases (ODR, depth ladder) are
-   `integration` (castxml) — mark them, do not skip silently. Wire
-   `ABICHECK_MIN_EXECUTED` for any new external-tool lane.
+The catalog harness (`tests/test_example_autodiscovery.py`,
+`tests/test_abi_examples.py`, `scripts/evidence_tiers.py`,
+`scripts/gen_examples_docs.py`) hard-assumes a `v1`/`v2` compilable pair plus a
+binary diff. Buckets 1–3 need three of these shapes it cannot host today:
+**baseline-less** cases (audit), **multi-source single-build** cases (crosscheck),
+and **scan-plan-assertion** cases (POI). Phase 0 lands the minimum harness work;
+no new cases yet, all 143 existing cases stay green.
 
-## Phases
+### 3.1 `ground_truth.json` schema v4
 
-### Phase 0 — schema + harness (enabling)
-Land the `ground_truth.json` v4 schema, fixture-type support, and scan-plan
-assertion surface above. No new cases yet; existing 143 stay green. Update
-`examples/CLAUDE.md` per-case-layout section to document the new fixture types.
+Bump `version` `"3"`→`"4"`. Add to each verdict entry (all optional, defaulted):
 
-### Phase 1 — single-release audit (G20.1)
-Compiler-free / smallest fixtures first. New catalog cases:
-
-| Case | Kind | Sources combined | Fixture |
-|---|---|---|---|
-| `case143_audit_accidental_export` | `exported_not_public` | binary exports ↔ L2 header decls | `.so` + `include/` + manifest |
-| `case144_audit_private_header_leak` | `private_header_leak` | L5 include graph ↔ install manifest | public hdr → `detail/` hdr + manifest |
-| `case145_audit_unversioned_export` | `unversioned_exported_symbol` | export ↔ `.gnu.version_d` | versioned `.so` + 1 new bare export |
-| `case146_audit_rtti_for_internal` | `rtti_for_internal_type` | `_ZTI`/`_ZTV` ↔ private-header type | internal type w/ RTTI emitted |
-| `case147_scan_depth_ladder` | pattern → semantic | S3 lexical vs S5 replay, same input | header w/ `#pragma pack` + TU |
-
-`case147` is the legibility anchor: same input, three depths, coverage block
-shows what each depth proved.
-
-### Phase 2 — cross-source corroboration (G20.2)
-The "1+1 > 2" flagship. Compiler-free synthetic snapshots where possible.
-
-| Case | Kind | Why no single source sees it |
+| field | type | meaning |
 |---|---|---|
-| `case148_xcheck_header_build_mismatch` | `header_build_context_mismatch` | binary-only blind; header parsed w/o `-DBIG_BUFFERS` is wrong; needs L2 macros ↔ L3 flags |
-| `case149_xcheck_odr_variant` | `odr_type_variant` | two TUs, divergent layout of one public type; only L4 layout ↔ layout |
-| `case150_xcheck_export_public_pair` | `exported_not_public` + `public_not_exported` | bidirectional L0 exports ↔ L2 decls |
-| `case151_xcheck_confidence_matrix` | (reuses one kind) | 3-provider vs 1-provider corroboration → different confidence tag (§6.8) |
+| `mode` | `"compare"` (default) \| `"audit"` | `"audit"` = single-build, no `v2`/baseline |
+| `expected_crosscheck_kinds` | `list[str]` | subset-checked against `run_crosschecks(snapshot).findings[].kind` (distinct from `expected_kinds`, which is the `compare` diff) |
+| `expected_providers` | `dict[str, list[str]]` | per check name → expected `ScanResult.confidence[check]` provider list (the §6.8 matrix) |
+| `expected_scan` | `dict[str, int\|str]` | scan-plan counters the case asserts (`selected_tus`, `parsed_tus`, `skipped_tus`, `matched_symbols`, `unmatched_exports`, `cache_hits`); used by POI/integrity cases |
+| `fixtures` | `list[str]` | declares non-`v1`/`v2` fixture files the case ships (`compile_commands.json`, `install_manifest.txt`, `abicheck_inputs/`, `.abicheck.yml`) |
+
+`min_evidence` already accepts `L0`–`L4`; add `L5` to the accepted set. The eight
+kinds are already in `EVIDENCE_TIER_BY_KIND`, so `min_evidence` for a crosscheck
+case is derived, not hand-set. Update the `cross_references` block and the
+`description` string. Keep `tests/test_example_autodiscovery.py::EXPECTED`,
+`tests/test_evidence_tiers.py`, and `tests/test_abi_examples.py` (hardcoded
+01–18) in sync — the new fields are additive, so existing rows are untouched.
+
+### 3.2 New per-case fixture types
+
+Extend `examples/CLAUDE.md` "Per-case layout" to document, alongside
+`v1`/`v2`/`app`:
+
+```
+caseNN_<name>/
+├── (audit cases) v1.* + v1.h        # ONE build only, no v2
+├── compile_commands.json            # L3 build context (header_build_context_mismatch)
+├── install_manifest.txt             # installed-header set (private_header_leak, unversioned)
+├── abicheck_inputs/                 # Flow-2 build-emitted facts (preferred — no live compiler)
+│   ├── manifest.json
+│   └── source_facts/*.jsonl
+├── .abicheck.yml                    # risk_rules / crosschecks config (focusing cases)
+└── README.md
+```
+
+**Prefer the Flow-2 `abicheck_inputs/` pack** (`buildsource/inputs_pack.py`,
+`inputs_emit.py`) so L4/L5 fixtures ingest via the existing `merge` path
+**without a live compiler** — keeps most new cases in the fast lane. Reserve
+castxml-backed live replay (`integration` marker) for the ODR and depth-ladder
+cases that genuinely need a second frontend pass.
+
+### 3.3 Scan-plan assertion surface
+
+Bucket 3 asserts on `ScanResult`/`LayerResult`/`CostEstimate` counters already
+defined in `service.py` (`LayerResult.facts/elapsed_s/status`,
+`CostEstimate.tus/cache_hit_rate`, `ScanResult.confidence/estimate`). Add a thin
+test helper (`tests/_scan_fixtures.py`) that runs `service.run_scan(ScanRequest)`
+against a case dir and returns the counters named in `expected_scan`, plus a
+`service.estimate_scan` path for the `--estimate` selection-vs-parse split
+(ADR-035 D7). No engine change — this is a harness/accessor.
+
+### 3.4 Docs generation
+
+Teach `scripts/gen_examples_docs.py` to render the three new shapes: an audit
+case (no v1/v2 diff table — instead a "single-build findings" block), a
+crosscheck case (a "sources combined" two-column table + provider/confidence
+row), and a focusing case (a "scan plan" counter table). Regenerate
+`examples/README.md` headline/distribution/case-index regions from
+`ground_truth.json` as today.
+
+---
+
+## 4. Phase 1 — single-release audit (G20.1)
+
+Compiler-free / smallest fixtures first. All four hygiene cases are buildable as
+a single binary + headers + manifest (or an `abicheck_inputs/` pack), run through
+`scan --audit`, asserting `expected_crosscheck_kinds`.
+
+| Case | Kind | Sources combined | Fixture | Lane |
+|---|---|---|---|---|
+| `case143_audit_accidental_export` | `exported_not_public` | binary exports ↔ L2 header decls | `.so` (or pack) + `include/` | fast (pack) |
+| `case144_audit_private_header_leak` | `private_header_leak` | L5 include graph ↔ install manifest | public hdr `#include`s `detail/cfg.h` + `install_manifest.txt` | fast (pack) |
+| `case145_audit_unversioned_export` | `unversioned_exported_symbol` | export table ↔ `.gnu.version_d` | versioned `.so` + 1 bare new export | fast (L0) |
+| `case146_audit_rtti_for_internal` | `rtti_for_internal_type` | `_ZTI`/`_ZTV` ↔ private-header type | internal class w/ RTTI emitted | fast |
+| `case147_scan_depth_ladder` | pattern → semantic | S3 lexical vs S5 replay, same input | header w/ `#pragma pack` + one TU | integration (castxml) |
+
+`case147` is the legibility anchor: identical input scanned at S3 (pattern only,
+no compiler), S2 (preprocessor, if compile DB present), and S5 (replay); the
+README and the coverage block show **exactly what each depth proved** and what it
+could not — the honest-coverage promise of ADR-035 D3, never a bare "scan
+failed".
+
+**Example `ground_truth.json` entry (case143):**
+
+```json
+"case143_audit_accidental_export": {
+  "expected": "RISK", "category": "risk", "mode": "audit",
+  "min_evidence": "L2", "platforms": ["linux"],
+  "abi_break": false, "api_break": false, "bad_practice": true,
+  "expected_kinds": [],
+  "expected_crosscheck_kinds": ["exported_not_public"],
+  "expected_providers": {"exported_not_public": ["binary_exports", "public_header_ast"]},
+  "fixtures": ["abicheck_inputs/"]
+}
+```
+
+**Acceptance:** `pytest tests/test_abi_examples.py -k case143` (and 144–146) green
+in the fast lane; `case147` green under `-m integration`; audit catalog renders
+in `docs/examples/`.
+
+---
+
+## 5. Phase 2 — cross-source corroboration (G20.2)
+
+The "1 + 1 > 2" flagship. Each case ships **two evidence sources that disagree or
+jointly confirm**; the README's job is to show neither source alone reaches the
+finding. Buildable as synthetic `AbiSnapshot` pairs (`_snap(**kw)`) plus a packed
+fixture for the catalog rendering.
+
+| Case | Kind | Why no single source sees it | Fixture |
+|---|---|---|---|
+| `case148_xcheck_header_build_mismatch` | `header_build_context_mismatch` (API_BREAK) | binary-only blind; header parsed without `-DBIG_BUFFERS` reports the *wrong* layout; only L2 macros ↔ L3 flags expose the divergence | `compile_commands.json` (`-DBIG_BUFFERS=1`) + macro-conditional header |
+| `case149_xcheck_odr_variant` | `odr_type_variant` (API_BREAK) | two TUs materialize one public type with different layouts; only L4 per-TU layout ↔ layout | 2-TU source set or `abicheck_inputs/` w/ divergent per-TU records |
+| `case150_xcheck_export_public_pair` | `exported_not_public` + `public_not_exported` | bidirectional L0 exports ↔ L2 decls: one symbol exported w/ no decl, one decl w/ visibility promise but `static` definition | `.so` + `include/` |
+| `case151_xcheck_confidence_matrix` | (reuses `exported_not_public`) | same finding, 3 corroborating providers vs 1 → different `Confidence` tag (§6.8) | two packs: full-provider vs binary-only |
 
 `case148` is the flagship — the clearest demonstration that combining L2 + L3
-exposes a divergence neither shows alone.
+exposes a divergence neither shows alone. `case151` is the one that demonstrates
+"better results from the *combination*" as an **output property**: it asserts
+`ScanResult.confidence["exported_not_public"]` lists three providers in the rich
+fixture and one in the thin fixture, and that the rendered confidence tag differs.
 
-### Phase 3 — evidence-directed focusing (G20.3)
-Test-only scenario suites (`tests/test_poi_scenarios.py`,
-`tests/test_source_evidence_integrity.py`) asserting on the **scan plan**:
+**Example test assertion (case148, synthetic, fast lane):**
 
-- `poi_export_delta_targets_replay` — changed export, unchanged header → POI
-  resolves symbol → source decl → replays **only that TU**; assert
-  `selected_tu == 1`, unrelated body skipped.
-- `poi_macro_conditional_layout` — macro capture scoped to materializing TUs only.
-- `poi_template_instantiation_seed` — demangled exported template symbol seeds
-  which instantiations replay.
-- `poi_changed_path_floor` — mis-weighted `risk_rules`; assert the changed TU is
-  **still** in the POI set (D7 floor: risk adds, never drops).
-- `integrity_unlinked_source_evidence` — oneDAL shape: many exports, TUs parsed,
-  **zero matched symbols**; assert reported as *degraded/unlinked source
-  evidence* with boundary counters, **not** counted as clean L4 coverage.
+```python
+snap = _snap(...)                      # header type w/ macro-conditional layout
+snap.build_source = _build(macros={"BIG_BUFFERS": "1"})   # L3 says built WITH it
+res = run_crosschecks(snap)
+hits = _findings_of(res, ChangeKind.HEADER_BUILD_CONTEXT_MISMATCH)
+assert hits and hits[0].confidence == Confidence.HIGH
+assert _coverage(res, CHECK_HEADER_BUILD_CONTEXT_MISMATCH)["status"] == "present"
+```
 
-## Sequencing rationale
+**Acceptance:** synthetic assertions in `tests/test_xcheck_scenarios.py` (fast);
+catalog cases 148–151 green; FP-rate gate stays 0/0 (add the matching clean
+"no-divergence" counterpart for each so the corpus has both a positive and a
+negative — proving no false positive on the healthy build).
+
+---
+
+## 6. Phase 3 — evidence-directed focusing (G20.3)
+
+Test-only scenario suites — the *interesting artifact is the scan plan*, so these
+assert on `ScanResult`/POI counters, not the verdict. Two new files:
+`tests/test_poi_scenarios.py` and `tests/test_source_evidence_integrity.py`.
+
+| Scenario | Asserts | ADR-035 |
+|---|---|---|
+| `poi_export_delta_targets_replay` | changed export + unchanged header → POI resolves symbol → source decl → `expected_scan.selected_tus == 1`; unrelated body in `skipped_tus` | D7 |
+| `poi_macro_conditional_layout` | macro capture runs only for TUs materializing the type; others skipped | D7 |
+| `poi_template_instantiation_seed` | demangled exported template symbol seeds which instantiations replay (`selected_tus` matches the instantiation set) | D7 |
+| `poi_changed_path_floor` | a deliberately mis-weighted `risk_rules` profile; assert the changed TU is **still** in `build_points_of_interest(...)` output (floor: risk adds, never drops) | D7 floor |
+| `integrity_unlinked_source_evidence` | oneDAL shape: many exports, TUs parsed, **zero matched symbols** → `LayerResult.status == "partial"`/degraded with boundary counters; **not** counted as clean L4 coverage; exit code unaffected | D4 integrity |
+
+`poi_changed_path_floor` and `integrity_unlinked_source_evidence` are the two
+highest-value guards: the first proves focusing **cannot hide a real change**, the
+second proves a failed L4 link is **never silently green** — both are invariants
+ADR-035 calls out explicitly (D7 floor; the oneDAL field-failure shape in D4).
+
+**Example assertion (poi_changed_path_floor, fast lane):**
+
+```python
+poi = build_points_of_interest(
+    changed_paths={"src/widget.cpp"},
+    risk=RiskRules.from_dict({"src/**": 0}),   # mis-weighted: zero weight
+    pattern_triggers=[], baseline=None, candidate=snap,
+)
+assert any(p.path.endswith("widget.cpp") for p in poi.items)   # floor holds
+```
+
+**Acceptance:** both suites green in the fast lane (Python only, synthetic
+snapshots — no compiler); `integrity_unlinked_source_evidence` additionally
+asserts the rendered report names the failed boundary class.
+
+---
+
+## 7. Sequencing rationale
 
 Land compiler-free, high-payload cases first so the catalog grows without an
 external-tool dependency while exercising genuinely-new code paths:
 
-1. **Phase 2 crosschecks** — highest ADR-035-thesis payload, buildable as
+1. **Phase 0** (enabling) — unblocks everything; no behavior change.
+2. **Phase 2 crosschecks** — highest ADR-035-thesis payload, buildable as
    synthetic `AbiSnapshot` pairs today.
-2. **Phase 1 audit** — single-artifact, smallest fixtures, immediate value.
-3. **Phase 3 POI/integrity** — strongest "sources guide sources" narrative but
-   needs the Phase 0 scan-plan assertion surface.
+3. **Phase 1 audit** — single-artifact, smallest fixtures, immediate value.
+4. **Phase 3 POI/integrity** — strongest "sources guide sources" narrative but
+   depends on the Phase 0 scan-plan assertion surface.
 
-## Use-case tracking
+Each phase is independently shippable behind its own PR; Phase 0 is the only hard
+dependency.
 
-Add `planned` entries to `docs/development/usecase-registry.yaml` under a new
-gap **G20**, one per phase (G20.1/G20.2/G20.3), cross-referencing the G19
-engine entries and the ADR-035 decisions each case demonstrates (D2/D4/D7/D8).
+---
 
-## Relationship to existing work
+## 8. Risks & mitigations
 
-- **G19 / ADR-035** — this consumes the engine G19 shipped; no engine change.
+- **Catalog count churn.** Adding 9 catalog cases moves the `doc-count-sync`
+  headline and `examples/README.md` distribution. *Mitigation:* regenerate via
+  `scripts/gen_examples_docs.py` in the same commit; never hand-edit the
+  generated regions.
+- **FP-rate creep.** New crosscheck kinds firing on healthy libraries.
+  *Mitigation:* every positive case ships a clean negative counterpart; corpus
+  baseline stays 0/0; nothing gates until the FP-rate gate trusts the check.
+- **castxml flakiness** on `case147`/`case149` live-replay. *Mitigation:* prefer
+  the Flow-2 `abicheck_inputs/` pack (no live frontend) for everything except the
+  depth-ladder case that must demonstrate a real compiler pass; mark live cases
+  `integration` and wire `ABICHECK_MIN_EXECUTED`.
+- **Schema drift.** v4 fields out of sync across the three test readers.
+  *Mitigation:* additive-only fields, defaulted; one shared loader; CI runs
+  `test_example_autodiscovery` + `test_evidence_tiers` + `test_abi_examples`.
+
+---
+
+## 9. Use-case tracking
+
+Add `planned` entries to `docs/development/usecase-registry.yaml` under a new gap
+**G20**, one per phase (G20.1 / G20.2 / G20.3), each cross-referencing the G19
+engine entry and the ADR-035 decision it demonstrates (D2/D4/D7/D8).
+
+## 10. Relationship to existing work
+
+- **G19 / ADR-035** — consumes the engine G19 shipped; no engine or policy
+  change. `buildsource/crosscheck.py`, `poi.py`, `risk.py`, `service.run_scan`
+  are used as-is.
+- **`tests/test_crosscheck.py`** — the `_snap(**kw)` synthetic-snapshot + `_coverage`/`_findings_of`
+  helpers Phase 2/3 reuse directly.
 - **`tests/test_pattern_audit_scenarios.py`** — the model for the test-only
-  scenario suites (Phase 3 + the synthetic Phase 2 cases).
-- **`tests/test_crosscheck.py`** — the `_snap(**kw)` synthetic-snapshot pattern
-  Phase 2 reuses.
-- **G11 single-binary audit** — Phase 1 audit cases extend its surface tooling.
+  scenario suites.
+- **G11 single-binary audit** — Phase 1 audit cases extend its surface tooling
+  (`surface-report`, `scan --audit`).
+- **`scripts/evidence_tiers.py`** — already maps all eight kinds; Phase 0 only
+  adds `L5` to the accepted `min_evidence` set.
 - **`scripts/check_ai_readiness.py`** — `examples-ground-truth`,
-  `examples-readme-sync`, `doc-count-sync` gate every new catalog case.
+  `examples-readme-sync`, `doc-count-sync`, `changekind-detector`,
+  `changekind-docs` gate every new catalog case.

--- a/docs/development/plans/g20-source-scan-example-catalog.md
+++ b/docs/development/plans/g20-source-scan-example-catalog.md
@@ -78,8 +78,10 @@ fast lane) modelled on `tests/test_pattern_audit_scenarios.py` and the
   crosschecking two: `header_build_context_mismatch` (L2 macros ↔ L3 flags),
   `odr_type_variant` (L4 layout ↔ layout), and the `exported_not_public` /
   `public_not_exported` bidirectional pair (L0 exports ↔ L2 decls). One case
-  asserts the §6.8 provider-agreement matrix drives the **confidence tag**
-  differently for 3-provider vs 1-provider corroboration.
+  asserts the §6.8 **provider-agreement matrix** is populated and differs
+  (3-provider vs 1-provider corroboration) — the available corroboration signal;
+  deriving a per-finding confidence *tag* from provider count is a separate
+  reporting enhancement, not part of this corpus (see Phase 2).
 - **G20.3 — Evidence-directed focusing corpus (D7).** Test scenarios asserting on
   the **POI set / `ScanResult` counters** (not just verdict): export delta
   targeting one TU's replay, macro-conditional layout scoping macro capture, the
@@ -148,13 +150,35 @@ cases that genuinely need a second frontend pass.
 
 ### 3.3 Scan-plan assertion surface
 
-Bucket 3 asserts on `ScanResult`/`LayerResult`/`CostEstimate` counters already
-defined in `service.py` (`LayerResult.facts/elapsed_s/status`,
-`CostEstimate.tus/cache_hit_rate`, `ScanResult.confidence/estimate`). Add a thin
-test helper (`tests/_scan_fixtures.py`) that runs `service.run_scan(ScanRequest)`
-against a case dir and returns the counters named in `expected_scan`, plus a
-`service.estimate_scan` path for the `--estimate` selection-vs-parse split
-(ADR-035 D7). No engine change — this is a harness/accessor.
+Bucket 3 asserts on the **scan plan**. The counters it needs (`selected_tus`,
+`parsed_tus`, `skipped_tus`, `matched_symbols`, `unmatched_exports`) are produced
+*inside* the engine but **not currently surfaced on `ScanResult`**:
+`_layers_from_coverage` (`service.py`) copies only
+`method/layer/status/detail/skipped_reason` onto each `LayerResult`, leaving
+`facts`/`elapsed_s` at their defaults and dropping the source-surface
+boundary counters entirely (the integrity counters ADR-035 D4 requires). So the
+assertion surface is split into two honest paths:
+
+- **No-engine-change path (most cases).** Assert directly against the existing
+  lower-level objects that already expose the data:
+  `buildsource.poi.build_points_of_interest(...)` returns the typed
+  `PointsOfInterest` work-list (pure — the floor/targeting cases assert on it
+  directly); the per-check `crosscheck` coverage rows
+  (`run_crosschecks(...).coverage`, `status`/`detail`) carry present/skipped and
+  counts; the `source_link` boundary report carries
+  matched/unmatched-export counts. These need **no** new plumbing.
+- **One small, explicitly-scoped engine touch (integrity case only).** To assert
+  the D4 integrity counters *on `ScanResult`* (so the rendered report — not just
+  an internal object — shows "zero matched symbols"), extend
+  `_layers_from_coverage` to carry `facts` and a `counters` dict from the
+  coverage rows. This is a **reporting/plumbing** change (no detector or policy
+  change), tracked as the single engine task in this plan, gated behind its own
+  commit. Until it lands, `integrity_unlinked_source_evidence` asserts against
+  the `source_link`/coverage objects (path 1).
+
+Add a thin test helper (`tests/_scan_fixtures.py`) that runs the scan and returns
+whichever surface the case uses, plus a `service.estimate_scan` path for the
+`--estimate` selection-vs-parse split (ADR-035 D7).
 
 ### 3.4 Docs generation
 
@@ -219,13 +243,24 @@ fixture for the catalog rendering.
 | `case148_xcheck_header_build_mismatch` | `header_build_context_mismatch` (API_BREAK) | binary-only blind; header parsed without `-DBIG_BUFFERS` reports the *wrong* layout; only L2 macros ↔ L3 flags expose the divergence | `compile_commands.json` (`-DBIG_BUFFERS=1`) + macro-conditional header |
 | `case149_xcheck_odr_variant` | `odr_type_variant` (API_BREAK) | two TUs materialize one public type with different layouts; only L4 per-TU layout ↔ layout | 2-TU source set or `abicheck_inputs/` w/ divergent per-TU records |
 | `case150_xcheck_export_public_pair` | `exported_not_public` + `public_not_exported` | bidirectional L0 exports ↔ L2 decls: one symbol exported w/ no decl, one decl w/ visibility promise but `static` definition | `.so` + `include/` |
-| `case151_xcheck_confidence_matrix` | (reuses `exported_not_public`) | same finding, 3 corroborating providers vs 1 → different `Confidence` tag (§6.8) | two packs: full-provider vs binary-only |
+| `case151_xcheck_provider_matrix` | (reuses `exported_not_public`) | same finding, 3 corroborating providers vs 1 → longer provider list / stronger corroboration (§6.8) | two packs: full-provider vs binary-only |
 
 `case148` is the flagship — the clearest demonstration that combining L2 + L3
-exposes a divergence neither shows alone. `case151` is the one that demonstrates
-"better results from the *combination*" as an **output property**: it asserts
-`ScanResult.confidence["exported_not_public"]` lists three providers in the rich
-fixture and one in the thin fixture, and that the rendered confidence tag differs.
+exposes a divergence neither shows alone. `case151` demonstrates "better results
+from the *combination*" as an **output property**, but with a precise scope: the
+current engine records the **provider list** per check
+(`ScanResult.confidence["exported_not_public"]`, copied from
+`crosscheck.providers`) and **always** stamps each `exported_not_public` finding
+`Confidence.HIGH` regardless of provider count (`crosscheck.py`). So:
+
+- **What case151 asserts today (no engine change):** the rich fixture lists three
+  providers (`binary_exports` + `public_header_ast` + `build_config`) and the thin
+  (binary-only) fixture lists one — i.e. the §6.8 provider-agreement *matrix* is
+  populated and differs. This is the real, available corroboration signal.
+- **Out of scope for this corpus:** deriving the per-finding `Confidence` *tag*
+  from provider count (so 1-provider corroboration renders a weaker tag than 3).
+  That is a `crosscheck`/reporter enhancement, **not** an example case; tracked
+  separately, not a Phase 2 acceptance blocker.
 
 **Example test assertion (case148, synthetic, fast lane):**
 
@@ -248,16 +283,19 @@ negative — proving no false positive on the healthy build).
 ## 6. Phase 3 — evidence-directed focusing (G20.3)
 
 Test-only scenario suites — the *interesting artifact is the scan plan*, so these
-assert on `ScanResult`/POI counters, not the verdict. Two new files:
-`tests/test_poi_scenarios.py` and `tests/test_source_evidence_integrity.py`.
+assert on the POI work-list and coverage objects, not the verdict. Per §3.3, the
+POI and `source_link`/crosscheck coverage objects already expose what these need;
+only the integrity case's *`ScanResult`-rendered* counters wait on the one scoped
+plumbing task. Two new files: `tests/test_poi_scenarios.py` and
+`tests/test_source_evidence_integrity.py`.
 
-| Scenario | Asserts | ADR-035 |
+| Scenario | Asserts (existing object) | ADR-035 |
 |---|---|---|
-| `poi_export_delta_targets_replay` | changed export + unchanged header → POI resolves symbol → source decl → `expected_scan.selected_tus == 1`; unrelated body in `skipped_tus` | D7 |
-| `poi_macro_conditional_layout` | macro capture runs only for TUs materializing the type; others skipped | D7 |
-| `poi_template_instantiation_seed` | demangled exported template symbol seeds which instantiations replay (`selected_tus` matches the instantiation set) | D7 |
-| `poi_changed_path_floor` | a deliberately mis-weighted `risk_rules` profile; assert the changed TU is **still** in `build_points_of_interest(...)` output (floor: risk adds, never drops) | D7 floor |
-| `integrity_unlinked_source_evidence` | oneDAL shape: many exports, TUs parsed, **zero matched symbols** → `LayerResult.status == "partial"`/degraded with boundary counters; **not** counted as clean L4 coverage; exit code unaffected | D4 integrity |
+| `poi_export_delta_targets_replay` | changed export + unchanged header → `build_points_of_interest(...)` resolves symbol → source decl → POI set holds that one TU, not the unrelated body | D7 |
+| `poi_macro_conditional_layout` | POI selects only the TUs materializing the type; others absent from the work-list | D7 |
+| `poi_template_instantiation_seed` | demangled exported template symbol seeds which instantiations the POI set targets | D7 |
+| `poi_changed_path_floor` | a deliberately mis-weighted `risk_rules` profile; the changed TU is **still** in `build_points_of_interest(...)` output (floor: risk adds, never drops) | D7 floor |
+| `integrity_unlinked_source_evidence` | oneDAL shape: many exports, TUs parsed, **zero matched symbols** → asserted against the `source_link` boundary report / crosscheck coverage rows (and, once the §3.3 plumbing lands, `LayerResult.status`/counters on `ScanResult`); **not** counted as clean L4 coverage; exit code unaffected | D4 integrity |
 
 `poi_changed_path_floor` and `integrity_unlinked_source_evidence` are the two
 highest-value guards: the first proves focusing **cannot hide a real change**, the
@@ -325,9 +363,13 @@ engine entry and the ADR-035 decision it demonstrates (D2/D4/D7/D8).
 
 ## 10. Relationship to existing work
 
-- **G19 / ADR-035** — consumes the engine G19 shipped; no engine or policy
-  change. `buildsource/crosscheck.py`, `poi.py`, `risk.py`, `service.run_scan`
-  are used as-is.
+- **G19 / ADR-035** — consumes the engine G19 shipped; **no detector or policy
+  change**. `buildsource/crosscheck.py`, `poi.py`, `risk.py`, `service.run_scan`
+  are used as-is for every case except one scoped reporting/plumbing task
+  (§3.3): extending `_layers_from_coverage` to carry the D4 integrity counters
+  onto `ScanResult` so the *rendered* report (not just an internal object) shows
+  them. Tracked as the single engine touch in this plan; all other cases assert
+  against existing objects.
 - **`tests/test_crosscheck.py`** — the `_snap(**kw)` synthetic-snapshot + `_coverage`/`_findings_of`
   helpers Phase 2/3 reuse directly.
 - **`tests/test_pattern_audit_scenarios.py`** — the model for the test-only

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -109,6 +109,7 @@ A real invocation is a point in this space:
 | **G14** | planned | CPython Limited-API / `abi3` import-contract conformance. |
 | **G15** | partial | Inline-namespace version-stamp normalization for ICU/Abseil/libstdc++-style churn. Detector landed (advisory `versioned_symbol_scheme_detected`); normalize-and-collapse preset still planned. |
 | **G19** | complete | PR-tier source intelligence (ADR-035, D1–D10): always-on compiler-free pre-scan + risk-scored escalation, intra-version cross-source validation findings (six checks + FP-rate-gate corpus), single-release hygiene audit, evidence-directed scan focusing, build-emitted source-facts protocol, and a typed `run_scan`/`ScanResult` API + per-level provider protocol with per-project cost estimate. |
+| **G20** | planned | Source-scan & cross-source example corpus (ADR-035 demonstration): single-release audit cases, cross-source corroboration cases (combination beats any single source), and evidence-directed focusing scenarios. Grows the `examples/` catalog + test suites to demonstrate the G19 engine; no engine change. |
 | **G16** | partial | Header-scoped source-mode toolchain robustness. Surfaced by 21 real-world cron records. **Shipped**: actionable diagnostics for all three host-toolchain signatures (sized-float `_FloatN`, GCC `__assume__`, `--lang c` + `extern "C"`), plus a `castxml --version` probe that recommends the Clang floor (≥ 18) on a version-mismatch failure. A `-D_FloatN` shim was prototyped and **rejected** (it rewrites glibc's own `typedef float _Float32;` fallback); the durable cure is a newer-Clang castxml or the libclang extractor (G4). **Remaining**: real-host end-to-end check and a dedicated error type. |
 
 ## Proposed next steps (tracked in the registry)
@@ -130,3 +131,4 @@ planned row from drifting away from its plan.
 | Medium | G16 — header-scope toolchain robustness | [g16](plans/g16-header-scope-toolchain-robustness.md) |
 | Medium | G17 — real-world validation corpus | [g17](plans/g17-real-world-corpus.md) |
 | Medium | G18 — Bazel build-evidence | [g18](plans/g18-bazel-build-evidence.md) |
+| Medium | G20 — source-scan & cross-source example corpus | [g20](plans/g20-source-scan-example-catalog.md) |

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -748,9 +748,11 @@ use_cases:
       crosschecking two — `header_build_context_mismatch` (L2 macros vs L3 flags),
       `odr_type_variant` (L4 layout vs layout), and the bidirectional
       `exported_not_public`/`public_not_exported` pair (L0 exports vs L2 decls) —
-      plus a provider-agreement/confidence-matrix case (§6.8) asserting the
-      confidence tag differs for 3-provider vs 1-provider corroboration. Each
-      positive ships a clean negative counterpart to hold the FP-rate gate at 0/0.
+      plus a provider-agreement-matrix case (§6.8) asserting the recorded
+      provider list differs for 3-provider vs 1-provider corroboration (deriving a
+      confidence tag from provider count is a separate reporting enhancement, not
+      part of this corpus). Each positive ships a clean negative counterpart to
+      hold the FP-rate gate at 0/0.
       See plan Phase 2.
 
   - id: UC-WORKFLOW-focusing-example-corpus

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -718,3 +718,54 @@ use_cases:
       `ScanResult`/`run_scan` refactor (move the `cli_scan` orchestration body into
       `service.py`) and the provider-agreement/confidence matrix rendered by
       reporter/PR-comment/SARIF.
+
+  # ── Source-scan & cross-source example corpus (ADR-035 / G20) ──────────────
+  - id: UC-WORKFLOW-audit-example-corpus
+    axis: workflow
+    name: Single-release audit example corpus (no baseline)
+    status: planned
+    gap: G20
+    plan: docs/development/plans/g20-source-scan-example-catalog.md
+    next_steps: >
+      ADR-035 D8 (G20.1). PLANNED: at least four `examples/caseNN` cases that
+      reach a verdict from one artifact with no baseline — `exported_not_public`,
+      `private_header_leak`, `unversioned_exported_symbol`,
+      `rtti_for_internal_type` — plus an S3->S5 depth-ladder case showing the same
+      input answered at three depths with an honest coverage block. Depends on the
+      Phase 0 `ground_truth.json` v4 schema (`mode: audit`,
+      `expected_crosscheck_kinds`, `fixtures`) and the Flow-2 `abicheck_inputs/`
+      fixture path so most cases run compiler-free. See plan Phase 1.
+
+  - id: UC-CHANGE-crosscheck-example-corpus
+    axis: change_class
+    name: Cross-source corroboration example corpus (combination beats one source)
+    status: planned
+    gap: G20
+    plan: docs/development/plans/g20-source-scan-example-catalog.md
+    next_steps: >
+      ADR-035 D4 (G20.2). PLANNED: at least three `examples/caseNN` cases whose
+      finding is invisible/ambiguous to any single source and resolves only by
+      crosschecking two — `header_build_context_mismatch` (L2 macros vs L3 flags),
+      `odr_type_variant` (L4 layout vs layout), and the bidirectional
+      `exported_not_public`/`public_not_exported` pair (L0 exports vs L2 decls) —
+      plus a provider-agreement/confidence-matrix case (§6.8) asserting the
+      confidence tag differs for 3-provider vs 1-provider corroboration. Each
+      positive ships a clean negative counterpart to hold the FP-rate gate at 0/0.
+      See plan Phase 2.
+
+  - id: UC-WORKFLOW-focusing-example-corpus
+    axis: workflow
+    name: Evidence-directed focusing scenarios (sources steer sources)
+    status: planned
+    gap: G20
+    plan: docs/development/plans/g20-source-scan-example-catalog.md
+    next_steps: >
+      ADR-035 D7 (G20.3). PLANNED: test-only scenario suites
+      (`tests/test_poi_scenarios.py`, `tests/test_source_evidence_integrity.py`)
+      asserting on the scan plan / `ScanResult` counters, not just the verdict —
+      an export delta targeting one TU's replay, macro-conditional layout scoping
+      macro capture, the D7 changed-path floor (a mis-weighted `risk_rules` cannot
+      drop a changed TU), and the D4 unlinked-source-evidence integrity guard (the
+      oneDAL failure shape: many exports, TUs parsed, zero matched symbols reported
+      as degraded, never clean). Depends on the Phase 0 scan-plan assertion
+      surface. See plan Phase 3.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - "G17: Real-world validation corpus": development/plans/g17-real-world-corpus.md
       - "G18: Bazel build-evidence": development/plans/g18-bazel-build-evidence.md
       - "G19: PR-tier source intelligence": development/plans/g19-pr-source-intelligence.md
+      - "G20: Source-scan example catalog": development/plans/g20-source-scan-example-catalog.md
     - ADR:
       - Overview: development/adr/index.md
       - "001: Technology Stack": development/adr/001-technology-stack.md


### PR DESCRIPTION
## What

Adds **`docs/development/plans/g20-source-scan-example-catalog.md`** (+ mkdocs nav entry) — a phased plan to grow the *demonstration corpus* for the ADR-035 / G19 source-scan & cross-source engine.

## Why

G19 shipped the engine (cheap PR source scans, intra-version cross-source validation, single-release audit, evidence-directed focusing) but the **demonstration corpus does not exist**. The `examples/` catalog (143 cases) still tells exactly one story — a `v1`→`v2` **binary diff**:

| min_evidence | cases |
|---|---|
| L0–L2 | 138 |
| L3 | 4 |
| L4 | 1 |
| L5 | **0** |

**Zero** cases produce any of the eight ADR-035 cross-check/audit `ChangeKind`s. So the catalog showcases detection depth on a binary delta and nothing about ADR-035's thesis: value from one build, multi-source corroboration, and one source steering another.

## Plan shape

Three capability axes, matching the request that prompted it:

- **Phase 1 — single-release audit (D8):** `exported_not_public`, `private_header_leak`, `unversioned_exported_symbol`, `rtti_for_internal_type`, plus an S3→S5 depth-ladder case. Value from one artifact, no baseline.
- **Phase 2 — cross-source corroboration (D4):** `header_build_context_mismatch` (L2 macros ↔ L3 flags — flagship, binary-blind), `odr_type_variant` (L4 ↔ L4), the `exported_not_public`/`public_not_exported` bidirectional pair, and a provider-confidence-matrix case. The "combination beats any single source" story.
- **Phase 3 — evidence-directed focusing (D7):** test-only suites asserting on the **scan plan** (POI targets a single TU, macro capture scoped, changed-path floor, oneDAL unlinked-evidence integrity guard). The "sources guide sources" story.

Plus **Phase 0** enabling work: `ground_truth.json` v4 schema (`expected_crosscheck_kinds`, provider/confidence, baseline-less cases, `min_evidence: L5`), new fixture types (prefer Flow-2 `abicheck_inputs/` so fixtures ingest with no live compiler), and a scan-plan assertion surface.

Flagship demos land as `examples/caseNN`; edge/integrity/POI cases land as test-only scenario suites (`tests/test_pattern_audit_scenarios.py` model).

## Notes

- Docs-only. No engine, detector, or policy change.
- AI-readiness gate: 0 errors. New plan is in mkdocs nav (not an orphan).

https://claude.ai/code/session_01ErE3gzW3NDhA4nhWpDEE3G

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErE3gzW3NDhA4nhWpDEE3G)_