### PR TITLE
ci: raise Codecov targets to 90% across all status blocks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,12 +10,12 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "60...90"
+  range: "90...100"
 
   status:
     project:
       default:
-        target: auto
+        target: 90%
         threshold: 1%       # allow a 1% drop without failing
         if_ci_failed: error
       # Integration lane (real castxml/gcc parsing) tracked separately so the
@@ -24,7 +24,7 @@ coverage:
       integration:
         flags:
           - integration
-        target: auto
+        target: 90%
         # Wider threshold than the project default: integration coverage is the
         # noisier flag (depends on castxml/toolchain availability across OSes),
         # so 2% absorbs normal variance while still catching a real regression.
@@ -35,7 +35,7 @@ coverage:
         # New code should be well-tested. This is the gate that resists
         # coverage-filling: changed lines must be covered even if the project
         # total drifts. Make "codecov/patch" a required check to enforce it.
-        target: 80%
+        target: 90%
         threshold: 5%
         informational: false
 

--- a/tests/test_cli_datasources.py
+++ b/tests/test_cli_datasources.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the data-source diagnostic pack merge (cli_datasources).
+
+``--show-data-sources`` can be handed two *split* inputs — a build-info pack
+(L3) and a sources pack (L4/L5) — collected independently.
+``_combine_diagnostic_packs`` folds them into one diagnostic view. These cover
+the merge precedence rules and the coverage-table reconciliation; the
+binary-parsing entry point (``print_data_sources``) is exercised by the
+integration lane.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.buildsource.build_evidence import BuildEvidence
+from abicheck.buildsource.model import (
+    CoverageStatus,
+    DataLayer,
+    LayerCoverage,
+)
+from abicheck.buildsource.pack import BuildSourcePack
+from abicheck.buildsource.source_abi import SourceAbiSurface
+from abicheck.buildsource.source_graph import SourceGraphSummary
+from abicheck.cli_datasources import _combine_diagnostic_packs
+
+
+def _build_info_pack() -> BuildSourcePack:
+    """A pack carrying only L3 build evidence + an intrinsic L0 coverage row."""
+    pack = BuildSourcePack.empty(Path("build-info"))
+    pack.build_evidence = BuildEvidence()
+    pack.manifest.coverage = [
+        LayerCoverage(layer="L0", status=CoverageStatus.PRESENT, detail="binary"),
+        LayerCoverage(
+            layer=DataLayer.L3_BUILD.value,
+            status=CoverageStatus.PRESENT,
+            detail="from build-info",
+        ),
+    ]
+    return pack
+
+
+def _sources_pack(*, with_graph: bool = True) -> BuildSourcePack:
+    """A pack carrying L4 source-ABI (and optionally L5 graph) evidence."""
+    pack = BuildSourcePack.empty(Path("sources"))
+    pack.source_abi = SourceAbiSurface()
+    coverage = [
+        LayerCoverage(
+            layer=DataLayer.L4_SOURCE_ABI.value,
+            status=CoverageStatus.PRESENT,
+            detail="from sources",
+        )
+    ]
+    if with_graph:
+        pack.source_graph = SourceGraphSummary()
+        coverage.append(
+            LayerCoverage(
+                layer=DataLayer.L5_SOURCE_GRAPH.value,
+                status=CoverageStatus.PRESENT,
+                detail="from sources",
+            )
+        )
+    pack.manifest.coverage = coverage
+    return pack
+
+
+def _row(pack: BuildSourcePack, layer: str) -> LayerCoverage | None:
+    return next((c for c in pack.manifest.coverage if c.layer == layer), None)
+
+
+def test_only_build_info_returns_it_unchanged() -> None:
+    bi = _build_info_pack()
+    assert _combine_diagnostic_packs(bi, None) is bi
+
+
+def test_only_sources_returns_it_unchanged() -> None:
+    src = _sources_pack()
+    assert _combine_diagnostic_packs(None, src) is src
+
+
+def test_both_none_returns_none() -> None:
+    assert _combine_diagnostic_packs(None, None) is None
+
+
+def test_combines_build_info_l3_with_sources_l4_l5() -> None:
+    bi, src = _build_info_pack(), _sources_pack()
+    combined = _combine_diagnostic_packs(bi, src)
+    assert combined is not None
+
+    # Payloads: L3 comes from build-info, L4/L5 from sources.
+    assert combined.build_evidence is bi.build_evidence
+    assert combined.source_abi is src.source_abi
+    assert combined.source_graph is src.source_graph
+
+    # Coverage table reconciles per layer, preserving the intrinsic L0 row.
+    assert _row(combined, "L0") is not None
+    l3 = _row(combined, DataLayer.L3_BUILD.value)
+    l4 = _row(combined, DataLayer.L4_SOURCE_ABI.value)
+    l5 = _row(combined, DataLayer.L5_SOURCE_GRAPH.value)
+    assert l3 is not None and l3.detail == "from build-info"
+    assert l4 is not None and l4.detail == "from sources"
+    assert l5 is not None and l5.detail == "from sources"
+
+
+def test_missing_l5_payload_yields_not_collected_row() -> None:
+    # Neither pack carries an L5 graph: the combined view must still emit an
+    # explicit NOT_COLLECTED row rather than silently dropping the layer.
+    bi, src = _build_info_pack(), _sources_pack(with_graph=False)
+    combined = _combine_diagnostic_packs(bi, src)
+    assert combined is not None
+    assert combined.source_graph is None
+
+    l5 = _row(combined, DataLayer.L5_SOURCE_GRAPH.value)
+    assert l5 is not None
+    assert l5.status is CoverageStatus.NOT_COLLECTED
+
+
+def test_source_abi_falls_back_to_build_info_when_sources_lacks_it() -> None:
+    # If only the build-info pack happens to carry an L4 surface, the combined
+    # pack must pick it up rather than leave L4 empty.
+    bi = _build_info_pack()
+    bi.source_abi = SourceAbiSurface()
+    src = _sources_pack(with_graph=False)
+    src.source_abi = None
+    combined = _combine_diagnostic_packs(bi, src)
+    assert combined is not None
+    assert combined.source_abi is bi.source_abi

--- a/tests/test_cli_datasources.py
+++ b/tests/test_cli_datasources.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from abicheck.buildsource.build_evidence import BuildEvidence
 from abicheck.buildsource.model import (
     CoverageStatus,
@@ -68,18 +70,21 @@ def _row(pack: BuildSourcePack, layer: str) -> LayerCoverage | None:
     return next((c for c in pack.manifest.coverage if c.layer == layer), None)
 
 
-def test_only_build_info_returns_it_unchanged() -> None:
-    bi = _build_info_pack()
-    assert _combine_diagnostic_packs(bi, None) is bi
-
-
-def test_only_sources_returns_it_unchanged() -> None:
-    src = _sources_pack()
-    assert _combine_diagnostic_packs(None, src) is src
-
-
-def test_both_none_returns_none() -> None:
-    assert _combine_diagnostic_packs(None, None) is None
+@pytest.mark.parametrize(
+    ("make_bi", "make_src", "expect"),
+    [
+        pytest.param(_build_info_pack, None, "bi", id="only-build-info"),
+        pytest.param(None, _sources_pack, "src", id="only-sources"),
+        pytest.param(None, None, None, id="both-none"),
+    ],
+)
+def test_single_side_or_none_passthrough(make_bi, make_src, expect) -> None:
+    # With only one side (or neither), the merge degrades to a passthrough:
+    # the lone pack is returned unchanged, and two absent inputs yield None.
+    bi = make_bi() if make_bi else None
+    src = make_src() if make_src else None
+    result = _combine_diagnostic_packs(bi, src)
+    assert result is {"bi": bi, "src": src, None: None}[expect]
 
 
 def test_combines_build_info_l3_with_sources_l4_l5() -> None:

--- a/tests/test_diff_stdlib_impl.py
+++ b/tests/test_diff_stdlib_impl.py
@@ -22,8 +22,10 @@ from abicheck.checker_policy import RISK_KINDS, ChangeKind, Verdict
 from abicheck.model import (
     AbiSnapshot,
     Function,
+    Param,
     RecordType,
     TypeField,
+    Variable,
     Visibility,
     stdlib_namespaces_excluded,
 )
@@ -658,3 +660,133 @@ class TestBuildModeFallback:
         )
         kinds = {c.kind for c in compare(old, new).changes}
         assert ChangeKind.STDLIB_IMPLEMENTATION_CHANGED in kinds
+
+
+class TestPublicByValueClosure:
+    """The BREAKING escalation hinges on whether a std::-embedding record is
+    reachable from the public surface *by value*. The single-field case is
+    covered above; these exercise the reachability closure across base classes,
+    typedef aliases, and public variables, plus its robustness to shared types
+    and reference cycles — real ABI-reachability semantics, not the easy path.
+    """
+
+    @staticmethod
+    def _embedding(name: str = "Inner", size_bits: int = 192) -> RecordType:
+        """A record that embeds a std:: container by value (layout-dependent)."""
+        return RecordType(
+            name=name,
+            kind="class",
+            size_bits=size_bits,
+            fields=[TypeField(name="data", type="std::vector<int>", offset_bits=0)],
+        )
+
+    @staticmethod
+    def _pair(**snapshot_kwargs: object) -> tuple[AbiSnapshot, AbiSnapshot]:
+        """An (libstdc++, libc++) pair with identical surface but differing impl."""
+
+        def mk(version: str, fam: StdlibFamily) -> AbiSnapshot:
+            return AbiSnapshot(
+                library="libwidget.so.1",
+                version=version,
+                build_mode=BuildMode(stdlib=fam),
+                **snapshot_kwargs,  # type: ignore[arg-type]
+            )
+
+        return mk("1", StdlibFamily.LIBSTDCXX), mk("2", StdlibFamily.LIBCXX)
+
+    def _finding(self, old: AbiSnapshot, new: AbiSnapshot):
+        result = compare(old, new)
+        finding = next(
+            c
+            for c in result.changes
+            if c.kind == ChangeKind.STDLIB_IMPLEMENTATION_CHANGED
+        )
+        return result, finding
+
+    def test_embedding_reachable_via_base_class_escalates(self) -> None:
+        # A namespaced public type returned by a public function; the embedding
+        # is reached only through Widget's base-class list, not its own fields.
+        inner = self._embedding("Inner")
+        widget = RecordType(
+            name="app::Widget", kind="class", size_bits=64, bases=["Inner"]
+        )
+        fn = Function(
+            name="make", mangled="_Z4makev",
+            return_type="app::Widget", visibility=Visibility.PUBLIC,
+        )
+        old, new = self._pair(types=[widget, inner], functions=[fn])
+        result, finding = self._finding(old, new)
+        assert finding.effective_verdict is Verdict.BREAKING
+        assert result.verdict is Verdict.BREAKING
+
+    def test_embedding_reachable_via_typedef_escalates(self) -> None:
+        # The public parameter names a typedef; the closure must follow the
+        # typedef target to find the embedding behind the alias.
+        inner = self._embedding("Buffer")
+        fn = Function(
+            name="take", mangled="_Z4takev", return_type="void",
+            params=[Param(name="b", type="BufferAlias")],
+            visibility=Visibility.PUBLIC,
+        )
+        old, new = self._pair(
+            types=[inner], functions=[fn], typedefs={"BufferAlias": "Buffer"}
+        )
+        _, finding = self._finding(old, new)
+        assert finding.effective_verdict is Verdict.BREAKING
+
+    def test_embedding_reachable_via_public_variable_escalates(self) -> None:
+        # A public global variable is also a public root that seeds the closure.
+        inner = self._embedding("Buffer")
+        var = Variable(
+            name="g_buf", mangled="g_buf",
+            type="Buffer", visibility=Visibility.PUBLIC,
+        )
+        old, new = self._pair(types=[inner], variables=[var])
+        _, finding = self._finding(old, new)
+        assert finding.effective_verdict is Verdict.BREAKING
+
+    def test_embedding_seeded_only_by_hidden_function_does_not_escalate(self) -> None:
+        # A public variable keeps the surface resolvable but does NOT reach the
+        # embedding; the only path to Buffer is a hidden (non-public) function,
+        # which must not seed the by-value closure. So no escalation.
+        inner = self._embedding("Buffer")
+        public_var = Variable(
+            name="g_flag", mangled="g_flag",
+            type="int", visibility=Visibility.PUBLIC,
+        )
+        hidden_fn = Function(
+            name="hidden", mangled="_Z6hiddenv",
+            return_type="Buffer", visibility=Visibility.HIDDEN,
+        )
+        old, new = self._pair(
+            types=[inner], functions=[hidden_fn], variables=[public_var]
+        )
+        result, finding = self._finding(old, new)
+        assert finding.effective_verdict is None
+        assert result.verdict is Verdict.COMPATIBLE_WITH_RISK
+
+    def test_closure_is_robust_to_shared_types_and_cycles(self) -> None:
+        # Widget reaches the embedding via BOTH a base and a by-value field
+        # (shared target → must be visited once), references an unknown type
+        # (not a record), holds a const self-pointer (a reference cycle, but
+        # pointer-indirect so layout-neutral), and the public function has an
+        # unspelled parameter type. The closure must terminate and still flag
+        # the by-value-reachable embedding.
+        inner = self._embedding("Inner")
+        widget = RecordType(
+            name="Widget", kind="class", size_bits=64,
+            bases=["Inner"],
+            fields=[
+                TypeField(name="dup", type="Inner", offset_bits=0),
+                TypeField(name="color", type="Color", offset_bits=64),
+                TypeField(name="self", type="Widget * const", offset_bits=128),
+            ],
+        )
+        fn = Function(
+            name="make", mangled="_Z4makev", return_type="Widget",
+            params=[Param(name="anon", type="")],
+            visibility=Visibility.PUBLIC,
+        )
+        old, new = self._pair(types=[widget, inner], functions=[fn])
+        _, finding = self._finding(old, new)
+        assert finding.effective_verdict is Verdict.BREAKING

--- a/tests/test_new_detectors.py
+++ b/tests/test_new_detectors.py
@@ -848,6 +848,24 @@ class TestBitIntWidthChanged:
         r = compare(_snap(functions=old), _snap(functions=new))
         assert not _has_kind(r, ChangeKind.BIT_INT_WIDTH_CHANGED)
 
+    def test_migration_from_bit_int(self):
+        # Dropping _BitInt(N) back to a builtin still changes storage/calling
+        # convention, so the migration-away direction must fire too.
+        old = [_spell_func("g", "void", ["_BitInt(24)"])]
+        new = [_spell_func("g", "void", ["int"])]
+        r = compare(_snap(functions=old), _snap(functions=new))
+        c = _changes_of_kind(r, ChangeKind.BIT_INT_WIDTH_CHANGED)
+        assert c and "was _BitInt(24)" in c[0].description
+
+    def test_same_width_signedness_flip_is_not_a_width_change(self):
+        # Same width N, different spelling (signed vs unsigned). The width did
+        # not change, so this detector must stay silent — signedness is a
+        # separate concern, not a _BitInt width change.
+        old = [_spell_func("g", "void", ["_BitInt(32)"])]
+        new = [_spell_func("g", "void", ["unsigned _BitInt(32)"])]
+        r = compare(_snap(functions=old), _snap(functions=new))
+        assert not _has_kind(r, ChangeKind.BIT_INT_WIDTH_CHANGED)
+
 
 class TestAtomicQualifierChanged:
     def test_atomic_added(self):

--- a/tests/test_stack_html.py
+++ b/tests/test_stack_html.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from abicheck.stack_checker import StackCheckResult, StackVerdict
-from abicheck.stack_html import stack_to_html
+from abicheck.stack_html import stack_to_html, write_stack_html
 
 
 def _node(soname: str, depth: int = 0, path: str = "", reason: str = "") -> object:
@@ -256,3 +256,95 @@ def test_html_escapes_xss_in_missing_symbol() -> None:
 def test_html_medium_risk_score() -> None:
     out = stack_to_html(_stack_result(risk_score="medium"))
     assert "MEDIUM" in out
+
+
+def _result_with_graph(graph: object) -> StackCheckResult:
+    return StackCheckResult(
+        root_binary="/bin/myapp",
+        baseline_env="/baseline", candidate_env="/candidate",
+        loadability=StackVerdict.PASS, abi_risk=StackVerdict.PASS,
+        baseline_graph=_graph(), candidate_graph=graph,
+        bindings_baseline=[], bindings_candidate=[],
+        missing_symbols=[], stack_changes=[], risk_score="low",
+    )
+
+
+def test_html_truncates_missing_symbols_over_50() -> None:
+    # Only the first 50 missing symbols are tabulated; the rest collapse into a
+    # single "+N more" row so a huge break doesn't render a multi-thousand-row
+    # table.
+    missing = [_binding("/bin/app", f"sym{i}", "missing") for i in range(63)]
+    out = stack_to_html(_stack_result(missing_symbols=missing))
+    assert "+13 more" in out
+    assert "sym0" in out
+    assert "sym62" not in out  # beyond the 50-row cap
+
+
+def test_html_tree_empty_when_no_root_node() -> None:
+    # A graph with nodes but no depth-0 root can't be rendered as a tree; the
+    # renderer must fall back to a placeholder, not crash.
+    graph = SimpleNamespace(
+        root="/bin/app",
+        nodes={"/lib/orphan.so": _node("orphan.so", depth=1)},
+        node_count=1, edges=[], unresolved=[],
+    )
+    out = stack_to_html(_result_with_graph(graph))
+    assert "(empty graph)" in out
+
+
+def test_html_tree_breaks_cycles() -> None:
+    # A -> B -> A. The renderer must detect the back-edge and stop, not recurse
+    # forever.
+    a, b = "/bin/app", "/lib/libb.so"
+    graph = SimpleNamespace(
+        root=a,
+        nodes={a: _node("app", 0, a), b: _node("libb.so", 1, b)},
+        node_count=2, edges=[(a, b), (b, a)], unresolved=[],
+    )
+    out = stack_to_html(_result_with_graph(graph))
+    assert "(cycle)" in out
+
+
+def test_html_tree_dedupes_diamond_dependency() -> None:
+    # A -> B -> D and A -> C -> D. D is reachable two ways but must be expanded
+    # once; the second visit is marked "(already shown)" rather than duplicated.
+    a, b, c, d = "/bin/app", "/lib/b.so", "/lib/c.so", "/lib/d.so"
+    graph = SimpleNamespace(
+        root=a,
+        nodes={
+            a: _node("app", 0, a),
+            b: _node("b.so", 1, b),
+            c: _node("c.so", 1, c),
+            d: _node("d.so", 2, d),
+        },
+        node_count=4,
+        edges=[(a, b), (a, c), (b, d), (c, d)],
+        unresolved=[],
+    )
+    out = stack_to_html(_result_with_graph(graph))
+    assert "(already shown)" in out
+    assert out.count("d.so") == 2  # one real row + one "already shown" row
+
+
+def test_html_tree_skips_dangling_edge_target() -> None:
+    # An edge can point at a key with no node entry (a half-resolved graph); the
+    # renderer must skip it silently instead of dereferencing None.
+    a = "/bin/app"
+    graph = SimpleNamespace(
+        root=a,
+        nodes={a: _node("app", 0, a)},
+        node_count=1,
+        edges=[(a, "/lib/ghost.so")],
+        unresolved=[],
+    )
+    out = stack_to_html(_result_with_graph(graph))
+    assert "app" in out
+    assert "ghost.so" not in out
+
+
+def test_write_stack_html_writes_file(tmp_path) -> None:
+    out_path = tmp_path / "stack.html"
+    write_stack_html(_stack_result(), out_path)
+    written = out_path.read_text(encoding="utf-8")
+    assert written.startswith("<!DOCTYPE html>")
+    assert "/bin/myapp" in written


### PR DESCRIPTION
## What

Raise the Codecov coverage limit to **90%** and apply it uniformly across all status blocks in `codecov.yml`:

| Block | Before | After |
|-------|--------|-------|
| `project.default` | `auto` | `90%` |
| `project.integration` | `auto` | `90%` |
| `patch.default` | `80%` | `90%` |

Also bumped the coverage display `range` from `60...90` to `90...100` so the visualization is green only at/above the new floor.

## Why

The previous `auto` targets only guarded against regression relative to the base commit; this sets an explicit 90% floor for every block. The unit lane already enforces a 95% line+branch coverage floor (see `CLAUDE.md`), so the project block clears 90% comfortably. Patch coverage now requires changed lines to be 90% covered (with the existing 5% threshold).

https://claude.ai/code/session_01Uesh1Mo15SVcF6ndL2xttb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uesh1Mo15SVcF6ndL2xttb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised code coverage quality targets to 90% for overall, integration, and patch-level checks.
* **Tests**
  * Added unit tests covering CLI diagnostic pack merging, including missing L5 payload handling and ABI fallback behavior.
  * Expanded stdlib ABI reachability tests for by-value embedding escalation across multiple scenarios.
  * Improved ABI change detection test coverage for `_BitInt` width changes and non-triggering signedness wording variations.
  * Expanded stack HTML report tests for truncation, empty output, cycle handling, deduplication, dangling edges, and writing HTML to a file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->