### PR TITLE
fix(cli): dump deep-depth warning + deep-compare embedded-snapshot guard (post-#422 Codex review)

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -497,11 +497,34 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     # Resolve the --depth/--max preset into the underlying --collect-mode before
     # any dump path runs, so every branch (source-only / PE-Mach-O / ELF) embeds
     # the same evidence depth (G21.1).
-    collect_mode = resolve_dump_depth(
-        depth, max_depth, collect_mode,
+    collect_mode_explicit = (
         click.get_current_context().get_parameter_source("collect_mode")
-        == click.core.ParameterSource.COMMANDLINE,
+        == click.core.ParameterSource.COMMANDLINE
     )
+    collect_mode = resolve_dump_depth(
+        depth, max_depth, collect_mode, collect_mode_explicit,
+    )
+
+    # An *explicitly* requested deep evidence depth (--depth/--max or an explicit
+    # --collect-mode) collects nothing without a source tree / build context:
+    # _write_snapshot_output only embeds when --sources/--build-info is given.
+    # Warn loudly rather than silently writing an L0-L2 snapshot for an
+    # explicitly-requested deep depth (Codex review). The bare default
+    # (collect_mode "source-target" with no flag) stays silent — embedding is a
+    # no-op there by design. G21.7-style fail-loud (a warning, not an error).
+    depth_requested = depth is not None or max_depth
+    if (
+        (depth_requested or collect_mode_explicit)
+        and collect_mode != "off"
+        and sources is None and build_info is None
+    ):
+        click.echo(
+            f"Warning: evidence depth '{collect_mode}' was requested but no "
+            "--sources/--build-info was given; the snapshot will carry only "
+            "L0-L2 data (no build/source/graph facts). Pass --sources or "
+            "--build-info, or use --depth headers for an L2-only dump.",
+            err=True,
+        )
 
     # Source-only dump (no binary) for the parallel-baseline / merge flow.
     if so_path is None:

--- a/abicheck/cli_max.py
+++ b/abicheck/cli_max.py
@@ -234,20 +234,30 @@ def deep_compare_cmd(
     # coverage table reflects the evidence actually requested.
     compare_collect_mode = resolve_dump_depth(depth, max_depth, "off", False)
 
-    # Only a depth that actually collects L3-L5 needs explicit evidence. At
-    # --depth headers (and the bare default) the depth resolves to "off" — that
-    # is the advertised L2-only / plain-compare mode, so it stays usable without
-    # any --sources/--build-info (Codex review).
+    # A depth that collects L3-L5 needs *some* evidence to collect from. A side
+    # only fails this when it is a native binary that must be dumped yet has no
+    # --sources/--build-info of its own — a snapshot/JSON input is exempt because
+    # it may already embed an L3-L5 pack that compare consumes (like plain
+    # `compare --collect-mode graph-full`). Error only when *neither* side can
+    # contribute, so cached deep snapshots still work (Codex review). The
+    # asymmetric one-native-side-missing case is handled per side in
+    # _prepare_side (a warning, not a hard error).
+    def _native_without_evidence(inp: Path, src: Path | None, bi: Path | None) -> bool:
+        if src is not None or bi is not None:
+            return False
+        _, fmt = _normalize_binary_input(inp)
+        return fmt is not None  # native binary that would dump with no sources
+
     if (
         compare_collect_mode != "off"
-        and old_src is None and new_src is None
-        and old_build_info is None and new_build_info is None
+        and _native_without_evidence(old_input, old_src, old_build_info)
+        and _native_without_evidence(new_input, new_src, new_build_info)
     ):
         raise click.UsageError(
-            f"deep-compare --depth {depth} collects L3-L5 evidence but no sources "
-            "were given: pass --sources (or per-side --old-sources/--new-sources) "
-            "and/or --old/new-build-info. For an L2-only run use --depth headers "
-            "or plain `abicheck compare`."
+            f"deep-compare --depth {depth} collects L3-L5 evidence but neither "
+            "native input has sources: pass --sources (or per-side "
+            "--old-sources/--new-sources) and/or --old/new-build-info. For an "
+            "L2-only run use --depth headers or plain `abicheck compare`."
         )
 
     old_h = old_headers_only or headers

--- a/abicheck/cli_max.py
+++ b/abicheck/cli_max.py
@@ -254,8 +254,8 @@ def deep_compare_cmd(
         and _native_without_evidence(new_input, new_src, new_build_info)
     ):
         raise click.UsageError(
-            f"deep-compare --depth {depth} collects L3-L5 evidence but neither "
-            "native input has sources: pass --sources (or per-side "
+            f"deep-compare --depth {depth or 'full'} collects L3-L5 evidence but "
+            "neither native input has sources: pass --sources (or per-side "
             "--old-sources/--new-sources) and/or --old/new-build-info. For an "
             "L2-only run use --depth headers or plain `abicheck compare`."
         )

--- a/tests/test_cli_deep_compare.py
+++ b/tests/test_cli_deep_compare.py
@@ -44,14 +44,27 @@ def _snap(tmp_path: Path, name: str, *, with_foo: bool) -> Path:
     return out
 
 
-def test_deep_compare_deep_depth_requires_evidence(tmp_path: Path) -> None:
-    # A depth that collects L3-L5 with no source/build inputs is refused and
-    # points at --depth headers / plain `compare` rather than a silent no-op.
+def test_deep_compare_deep_depth_requires_evidence(tmp_path: Path, monkeypatch) -> None:
+    # Two native binaries at a deep depth with no sources can't collect anything,
+    # so the run is refused and points at --depth headers / plain `compare`.
+    old = tmp_path / "old.so"
+    new = tmp_path / "new.so"
+    old.write_bytes(b"\x7fELF")
+    new.write_bytes(b"\x7fELF")
+    monkeypatch.setattr(cli_max, "_normalize_binary_input", lambda p: (p, "elf"))
+    res = CliRunner().invoke(main, ["deep-compare", str(old), str(new), "--depth", "full"])
+    assert res.exit_code != 0
+    assert "collects L3-L5 evidence but neither native input has sources" in res.output
+
+
+def test_deep_compare_deep_depth_allows_snapshot_inputs(tmp_path: Path) -> None:
+    # Snapshot/JSON inputs are exempt from the no-evidence guard — they may embed
+    # an L3-L5 pack that compare consumes (like `compare --collect-mode graph-full`),
+    # so cached deep snapshots stay usable with deep-compare (Codex review).
     old = _snap(tmp_path, "old.json", with_foo=True)
     new = _snap(tmp_path, "new.json", with_foo=True)
     res = CliRunner().invoke(main, ["deep-compare", str(old), str(new), "--depth", "full"])
-    assert res.exit_code != 0
-    assert "collects L3-L5 evidence but no sources" in res.output
+    assert res.exit_code == 0, res.output  # not rejected; passes through to compare
 
 
 def test_deep_compare_headers_depth_no_evidence_ok(tmp_path: Path) -> None:

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -234,18 +234,20 @@ class TestSmallHelpers:
     def test_merge_gcc_options_both(self) -> None:
         assert _merge_gcc_options(["-DA"], "-O2") == "-DA -O2"
 
-    def test_resolve_dump_depth_maps_each_depth(self) -> None:
+    @pytest.mark.parametrize(
+        ("depth", "expected"),
+        [
+            ("headers", "off"),
+            ("build", "build"),
+            ("graph", "graph-build"),
+            ("source", "source-changed"),
+            ("full", "graph-full"),
+        ],
+    )
+    def test_resolve_dump_depth_maps_each_depth(self, depth: str, expected: str) -> None:
         from abicheck.cli_dump_helpers import resolve_dump_depth
 
-        cases = {
-            "headers": "off",
-            "build": "build",
-            "graph": "graph-build",
-            "source": "source-changed",
-            "full": "graph-full",
-        }
-        for depth, expected in cases.items():
-            assert resolve_dump_depth(depth, False, "source-target", False) == expected
+        assert resolve_dump_depth(depth, False, "source-target", False) == expected
 
     def test_resolve_dump_depth_max_is_full(self) -> None:
         from abicheck.cli_dump_helpers import resolve_dump_depth

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -356,6 +356,22 @@ class TestSmallHelpers:
             empty_l5, "source-target"
         )
 
+    def test_dump_explicit_deep_depth_without_sources_warns(self, tmp_path) -> None:
+        # Codex: an explicit --max/--depth (deep collect mode) with no
+        # --sources/--build-info would silently write an L0-L2 snapshot; warn.
+        so = tmp_path / "fake.so"
+        so.write_bytes(b"\x7fELF")
+        result = CliRunner().invoke(main, ["dump", str(so), "--max"])
+        assert "carry only L0-L2 data" in result.output
+
+    def test_dump_default_depth_no_warning(self, tmp_path) -> None:
+        # The bare default (no --depth/--collect-mode) must NOT warn — embedding
+        # is a no-op there by design, so a plain dump stays quiet about evidence.
+        so = tmp_path / "fake.so"
+        so.write_bytes(b"\x7fELF")
+        result = CliRunner().invoke(main, ["dump", str(so)])
+        assert "carry only L0-L2 data" not in result.output
+
     def test_dump_gcc_option_ignored_warning_for_non_elf(self, tmp_path) -> None:
         # G21.5/Codex: --gcc-option(s) aren't applied on the native PE/Mach-O
         # dump path, so the CLI warns rather than dropping them silently.


### PR DESCRIPTION
Follow-up to #422 (merged) addressing the final two Codex P2 review findings that landed after merge.

## Changes

**`dump` — warn on explicit deep depth without evidence inputs**
`abicheck dump lib.so -H include --max` (or `--depth build/source/full`, or an explicit `--collect-mode`) resolved a deep `collect_mode` but, with no `--sources`/`--build-info`, `_write_snapshot_output()` skipped embedding entirely — silently writing an L0–L2 snapshot for an explicitly-requested deep depth. It now emits a loud warning. Gated on an *explicit* request so the bare default (`collect_mode` `source-target`, where embedding is a no-op) stays quiet.

**`deep-compare` — allow embedded-pack snapshots through the no-evidence guard**
The non-`off` depth guard rejected two JSON snapshots that already embed L3–L5 `build_source` packs, even though plain `compare --collect-mode graph-full` consumes them. The guard now exempts snapshot/JSON inputs and errors only when *both* sides are native binaries lacking their own `--sources`/`--build-info`. The asymmetric one-native-side case remains a per-side warning (from #422).

## Tests
- `dump` explicit-deep-depth-warns + default-stays-quiet
- `deep-compare` embedded-snapshot pass-through (not rejected); updated the deep-depth-requires-evidence test to use native inputs

Gates: ruff ✅ · mypy ✅ · ai-readiness 0 errors ✅ · targeted suites pass.

https://claude.ai/code/session_01SL34VD5NNJ2wHgUv5Lh1WW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SL34VD5NNJ2wHgUv5Lh1WW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep evidence validation for `dump` and `deep-compare`, so snapshot inputs can pass through while native binaries are checked for required evidence.
  * `deep-compare` now raises errors only when deep evidence is requested and both sides are native binaries missing usable sources/build info.
* **Improvements**
  * `dump` now warns when deep evidence is requested without sources/build info, indicating the snapshot will include only L0–L2 data.
* **Tests**
  * Updated and added CLI regression tests for the new validation and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->