### PR TITLE
fix: constrain make response-file expansion

### DIFF
--- a/abicheck/buildsource/adapters/make.py
+++ b/abicheck/buildsource/adapters/make.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import os
 import re
 import shlex
+import stat as stat_module
 from pathlib import Path
 
 from ...build_context import _extract_flags
@@ -250,10 +251,10 @@ def _read_response_file(path: Path, directory: Path, root: Path | None) -> str |
     if resolved is None or not _is_relative_to(resolved, root):
         return None
     try:
-        stat = resolved.stat()
+        st = resolved.stat()
     except OSError:
         return None
-    if not resolved.is_file() or stat.st_size > _MAX_RESPONSE_FILE_BYTES:
+    if not stat_module.S_ISREG(st.st_mode) or st.st_size > _MAX_RESPONSE_FILE_BYTES:
         return None
     try:
         data = resolved.read_bytes()

--- a/abicheck/buildsource/adapters/make.py
+++ b/abicheck/buildsource/adapters/make.py
@@ -143,7 +143,7 @@ class MakeAdapter:
         source = source_from_argv(argv)
         if not source:
             return None
-        argv, _expanded_rsp = _expand_response_files(argv, directory)
+        argv, _expanded_rsp = _expand_response_files(argv, directory, self.build_dir)
         ctx = _extract_flags(argv, directory)
         output = _output_from_argv(argv)
         red_argv = self.redaction.argv(argv)
@@ -214,20 +214,24 @@ def _truncate_shell_pipeline(argv: list[str]) -> list[str]:
     return argv
 
 
-def _expand_response_files(argv: list[str], directory: Path) -> tuple[list[str], bool]:
-    """Inline readable compiler response-file tokens (``@file``)."""
+_MAX_RESPONSE_FILE_BYTES = 1024 * 1024
+
+
+def _expand_response_files(
+    argv: list[str],
+    directory: Path,
+    response_root: Path | None,
+) -> tuple[list[str], bool]:
+    """Inline bounded compiler response files from the trusted build tree."""
     expanded: list[str] = []
     changed = False
+    root = _safe_resolve(response_root) if response_root is not None else None
     for arg in argv:
         if not arg.startswith("@") or len(arg) == 1:
             expanded.append(arg)
             continue
-        path = Path(arg[1:])
-        if not path.is_absolute():
-            path = directory / path
-        try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        text = _read_response_file(Path(arg[1:]), directory, root)
+        if text is None:
             expanded.append(arg)
             continue
         try:
@@ -236,6 +240,45 @@ def _expand_response_files(argv: list[str], directory: Path) -> tuple[list[str],
         except ValueError:
             expanded.append(arg)
     return expanded, changed
+
+
+def _read_response_file(path: Path, directory: Path, root: Path | None) -> str | None:
+    if root is None:
+        return None
+    candidate = path if path.is_absolute() else directory / path
+    resolved = _safe_resolve(candidate)
+    if resolved is None or not _is_relative_to(resolved, root):
+        return None
+    try:
+        stat = resolved.stat()
+    except OSError:
+        return None
+    if not resolved.is_file() or stat.st_size > _MAX_RESPONSE_FILE_BYTES:
+        return None
+    try:
+        data = resolved.read_bytes()
+    except OSError:
+        return None
+    if len(data) > _MAX_RESPONSE_FILE_BYTES:
+        return None
+    return data.decode("utf-8", errors="replace")
+
+
+def _safe_resolve(path: Path | None) -> Path | None:
+    if path is None:
+        return None
+    try:
+        return path.resolve()
+    except OSError:
+        return None
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
 
 
 def _output_from_argv(argv: list[str]) -> str:

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -111,12 +111,68 @@ def test_make_expands_response_file_and_truncates_shell_suffix(tmp_path):
         "-obuild/foo.o && sed -n ignored.d\n"
         f"make: Leaving directory '{tmp_path}'\n"
     )
-    cu = MakeAdapter(dry_run=dry).collect().compile_units[0]
+    cu = MakeAdapter(build_dir=tmp_path, dry_run=dry).collect().compile_units[0]
     assert "&&" not in cu.argv
     assert "@build/inc.rsp" not in cu.argv
     assert cu.defines["MODE"] == "1"
     assert cu.output == "build/foo.o"
     assert any(Path(p).expanduser() == inc for p in cu.include_paths)
+
+
+def test_make_does_not_expand_response_file_without_trusted_build_dir(tmp_path):
+    src = tmp_path / "foo.cc"
+    rsp = tmp_path / "leak.rsp"
+    src.write_text("int f() { return 0; }\n")
+    rsp.write_text("LEAKED_TOKEN\n")
+
+    cu = MakeAdapter(dry_run=f"g++ @{rsp} -c {src} -o foo.o").collect().compile_units[0]
+
+    assert f"@{rsp}" in cu.argv
+    assert "LEAKED_TOKEN" not in cu.argv
+
+
+def test_make_does_not_expand_response_file_outside_build_dir(tmp_path):
+    build = tmp_path / "build"
+    outside = tmp_path / "outside.rsp"
+    src = build / "foo.cc"
+    build.mkdir()
+    src.write_text("int f() { return 0; }\n")
+    outside.write_text("LEAKED_TOKEN\n")
+
+    cu = MakeAdapter(build_dir=build, dry_run=f"g++ @{outside} -c foo.cc -o foo.o").collect().compile_units[0]
+
+    assert f"@{outside}" in cu.argv
+    assert "LEAKED_TOKEN" not in cu.argv
+
+
+def test_make_does_not_expand_response_file_from_forged_directory(tmp_path):
+    build = tmp_path / "build"
+    forged = tmp_path / "forged"
+    build.mkdir()
+    forged.mkdir()
+    (build / "foo.cc").write_text("int f() { return 0; }\n")
+    (forged / "rel.rsp").write_text("LEAKED_TOKEN\n")
+    dry = (
+        f"make: Entering directory '{forged}'\n"
+        "g++ @rel.rsp -c foo.cc -o foo.o\n"
+        f"make: Leaving directory '{forged}'\n"
+    )
+
+    cu = MakeAdapter(build_dir=build, dry_run=dry).collect().compile_units[0]
+
+    assert "@rel.rsp" in cu.argv
+    assert "LEAKED_TOKEN" not in cu.argv
+
+
+def test_make_does_not_expand_large_response_file(tmp_path):
+    src = tmp_path / "foo.cc"
+    rsp = tmp_path / "large.rsp"
+    src.write_text("int f() { return 0; }\n")
+    rsp.write_text("A" * (1024 * 1024 + 1))
+
+    cu = MakeAdapter(build_dir=tmp_path, dry_run="g++ @large.rsp -c foo.cc -o foo.o").collect().compile_units[0]
+
+    assert "@large.rsp" in cu.argv
 
 
 def test_make_msvc_combined_forced_include_not_source():

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -175,6 +175,17 @@ def test_make_does_not_expand_large_response_file(tmp_path):
     assert "@large.rsp" in cu.argv
 
 
+def test_make_does_not_expand_response_file_directory(tmp_path):
+    src = tmp_path / "foo.cc"
+    rsp_dir = tmp_path / "not-a-file.rsp"
+    src.write_text("int f() { return 0; }\n")
+    rsp_dir.mkdir()
+
+    cu = MakeAdapter(build_dir=tmp_path, dry_run="g++ @not-a-file.rsp -c foo.cc -o foo.o").collect().compile_units[0]
+
+    assert "@not-a-file.rsp" in cu.argv
+
+
 def test_make_msvc_combined_forced_include_not_source():
     # `/FIsrc/config.hpp` is a combined MSVC forced-include with an embedded
     # path; despite the `.hpp` it must not be read as the TU — foo.cc wins.

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -33,6 +33,10 @@ make: Leaving directory '/home/user/proj'
 """
 
 
+def _has_response_arg(argv: list[str], path: Path) -> bool:
+    return any(arg.startswith("@") and Path(arg[1:]).expanduser() == path for arg in argv)
+
+
 def test_make_dry_run_extracts_compile_units():
     ev = MakeAdapter(dry_run=DRY_RUN).collect()
     assert ev.generators[0].kind == "make"
@@ -127,7 +131,7 @@ def test_make_does_not_expand_response_file_without_trusted_build_dir(tmp_path):
 
     cu = MakeAdapter(dry_run=f"g++ @{rsp} -c {src} -o foo.o").collect().compile_units[0]
 
-    assert f"@{rsp}" in cu.argv
+    assert _has_response_arg(cu.argv, rsp)
     assert "LEAKED_TOKEN" not in cu.argv
 
 
@@ -141,7 +145,7 @@ def test_make_does_not_expand_response_file_outside_build_dir(tmp_path):
 
     cu = MakeAdapter(build_dir=build, dry_run=f"g++ @{outside} -c foo.cc -o foo.o").collect().compile_units[0]
 
-    assert f"@{outside}" in cu.argv
+    assert _has_response_arg(cu.argv, outside)
     assert "LEAKED_TOKEN" not in cu.argv
 
 


### PR DESCRIPTION
### Motivation

- The previous response-file expander read any `@file` token from make dry-run transcripts, allowing attacker-controlled paths (absolute or relative to transcript-controlled directories) to leak arbitrary local file contents into persisted compile evidence and to trigger unbounded reads.
- Expansion happened before evidence redaction, so sensitive data and large or special files could be disclosed or cause availability issues.

### Description

- Pass the adapter `build_dir` into the response-file expander and treat it as the trusted response-file root used for safe expansion via `response_root`.
- Add `_read_response_file`, `_safe_resolve`, and `_is_relative_to` helpers and enforce that only files that resolve inside the trusted root, are regular files, and are no larger than `1 MiB` are read and expanded; otherwise the `@file` token is left unexpanded.
- Read response files as bounded bytes and decode with `utf-8`/`replace`, and avoid expanding when no trusted build directory is supplied or when the resolved path escapes the build tree.
- Add regression tests to cover expansion only with a trusted `build_dir`, and to assert no expansion for absolute/outside paths, forged `Entering directory` cases, and oversized response files, plus adjust the existing response-file test to pass a trusted `build_dir`.

### Testing

- Ran the targeted adapter tests with `pytest -q tests/test_make_adapter.py`, which passed (`21 passed`).
- Ran `python -m compileall -q abicheck tests/test_make_adapter.py` with no errors reported.
- Installed the `hypothesis` test dependency and ran the full test suite with `pytest -q`, which completed successfully (`10784 passed, 371 skipped, 4 xfailed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f7aad60d4832b893ff23e7bdb936f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compiler response-file handling by safely resolving paths relative to a trusted build context and enforcing a maximum response size, preventing unsafe expansion of `@...` tokens.

* **Tests**
  * Expanded coverage to verify response files are expanded only when valid (trusted build context, within allowed root, not oversized, and not a directory), and that invalid cases leave the `@...` token unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->