### PR TITLE
fix: strip clang output flags from preprocessor replay

### DIFF
--- a/abicheck/buildsource/include_graph.py
+++ b/abicheck/buildsource/include_graph.py
@@ -79,6 +79,26 @@ _DEPFILE_UNSAFE_PREFIXES = (
     "--config=",
 )
 
+# Clang options that can create or overwrite files even during preprocessing.
+# Build evidence can be supplied by untrusted PR artifacts, so replay must not
+# forward output-producing instrumentation/cache/diagnostic controls.
+_DEPFILE_OUTPUT_WITH_VALUE = frozenset({
+    "-ftime-trace",
+    "-serialize-diagnostic-file",
+    "-fmodules-cache-path",
+})
+_DEPFILE_OUTPUT_FLAG = frozenset({
+    "-save-temps",
+    "--save-temps",
+})
+_DEPFILE_OUTPUT_PREFIXES = (
+    "-ftime-trace=",
+    "-serialize-diagnostic-file=",
+    "-fmodules-cache-path=",
+    "-save-temps=",
+    "--save-temps=",
+)
+
 
 def depfile_args_from_argv(argv: list[str]) -> list[str]:
     """Strip a recorded compile argv down to the args usable after ``clang -MM``.
@@ -113,7 +133,11 @@ def depfile_args_from_argv(argv: list[str]) -> list[str]:
         if skip_next:
             skip_next = False
             continue
-        if tok in _DEPFILE_DROP_WITH_VALUE or tok in _DEPFILE_UNSAFE_WITH_VALUE:
+        if (
+            tok in _DEPFILE_DROP_WITH_VALUE
+            or tok in _DEPFILE_UNSAFE_WITH_VALUE
+            or tok in _DEPFILE_OUTPUT_WITH_VALUE
+        ):
             skip_next = True
             continue
         if tok == "--config":
@@ -121,14 +145,22 @@ def depfile_args_from_argv(argv: list[str]) -> list[str]:
             continue
         if tok.startswith("@"):
             continue
-        if tok in _DEPFILE_UNSAFE_FLAG or tok.startswith(_DEPFILE_UNSAFE_PREFIXES):
+        if (
+            tok in _DEPFILE_UNSAFE_FLAG
+            or tok in _DEPFILE_OUTPUT_FLAG
+            or tok.startswith(_DEPFILE_UNSAFE_PREFIXES)
+            or tok.startswith(_DEPFILE_OUTPUT_PREFIXES)
+        ):
             continue
         # `-oFOO` / `-MFfoo.d` glued forms and the GCC long `--output=foo.o`
         # spelling (clang -M with --output=… writes the depfile to that file and
         # leaves stdout empty, losing the include entry — Codex review).
         if tok.startswith("--output="):
             continue
-        if any(tok.startswith(f) and tok != f for f in ("-o", "-MF", "-MT", "-MQ")):
+        if any(
+            tok.startswith(f) and tok != f
+            for f in ("-o", "-MF", "-MT", "-MQ", "-MJ")
+        ):
             continue
         if tok in _DEPFILE_DROP_FLAG:
             continue

--- a/tests/test_include_graph.py
+++ b/tests/test_include_graph.py
@@ -97,6 +97,20 @@ def test_depfile_args_preserves_preprocessor_escape_hatch() -> None:
     ]) == ["foo.cpp", "-Wp,-Igenerated", "-Wp,-DPLATFORM=1", "-Iinclude"]
 
 
+def test_depfile_args_strips_output_side_effect_options() -> None:
+    # Compile DB argv is untrusted: do not forward clang options that can write
+    # files during the S2 preprocessor/include replay (for example time traces).
+    assert depfile_args_from_argv([
+        "clang++", "-c", "foo.cpp", "-I", "include",
+        "-ftime-trace=/tmp/victim.json",
+        "-ftime-trace", "/tmp/victim2.json",
+        "-serialize-diagnostic-file=/tmp/diag",
+        "-fmodules-cache-path", "/tmp/cache",
+        "-save-temps", "--save-temps=obj",
+        "-MJ/tmp/compile.json",
+    ]) == ["foo.cpp", "-I", "include"]
+
+
 def test_depfile_args_strips_clang_plugin_loading_options() -> None:
     # compile_commands.json is untrusted input for source-ABI replay.  The
     # depfile pass must not forward Clang escape hatches that load plugins or


### PR DESCRIPTION
### Motivation
- The S2 preprocessor/include replay forwarded tokens from untrusted compile DB argv into clang, allowing output-producing flags (for example `-ftime-trace=...`) to cause attacker-controlled file creation/overwrite during a scan. 
- Hardening the shared argv reducer prevents that integrity risk while keeping the preprocessor pass useful for include/macro discovery.

### Description
- Add new output-related denylists (`_DEPFILE_OUTPUT_WITH_VALUE`, `_DEPFILE_OUTPUT_FLAG`, `_DEPFILE_OUTPUT_PREFIXES`) in `abicheck/buildsource/include_graph.py` and extend `depfile_args_from_argv` to drop those tokens and glued `-MJ` forms so clang cannot be asked to write files during S2 replay. 
- Preserve existing behavior of keeping source and safe preprocessor context flags (`-I`, `-D`, `-std`, `-Wp,…`, etc.) so include/macro capture still functions. 
- Add a regression test `test_depfile_args_strips_output_side_effect_options` in `tests/test_include_graph.py` to assert that unsafe output flags are removed while the source and `-I` context remain.

### Testing
- Ran the targeted tests: `pytest tests/test_include_graph.py tests/test_preprocessor_scan.py`, and they passed. 
- Ran lint: `ruff check abicheck/buildsource/include_graph.py tests/test_include_graph.py`, and it passed. 
- Ran the full test suite with test dependency installed (`python -m pip install hypothesis` to satisfy collection), and `pytest` completed successfully with `10950 passed, 371 skipped, 4 xfailed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3023a34378832bb0b70ddd0eb677de)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced depfile argument reduction to strip additional clang compiler options that may create or overwrite files during preprocessing, preventing unwanted side effects and improving build reliability.

* **Tests**
  * Added test coverage to verify proper handling and stripping of output and side-effect-related compiler options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->