### PR TITLE
fix(internal-leak): tighten pointer-wrapper matching to avoid name-based suppression

### DIFF
--- a/abicheck/internal_leak.py
+++ b/abicheck/internal_leak.py
@@ -176,6 +176,26 @@ def _strip_decorators(typename: str) -> str:
     return re.sub(r"\s+", " ", s)
 
 
+def _is_known_pointer_wrapper(outer: str) -> bool:
+    """Return True only for pointer-owning wrapper spellings we know.
+
+    This deliberately avoids substring matches such as
+    ``acme::unique_ptr_value<T>``: a user-defined type can embed ``T`` by
+    value while having a smart-pointer-like name.  In ambiguous cases, keep the
+    path value-propagating so the ABI break is visible.
+    """
+    clean = _strip_template_args(_strip_decorators(outer)).strip()
+    if not clean:
+        return False
+    leaf = clean.rsplit("::", 1)[-1]
+    leaf_l = leaf.lower()
+    if leaf_l in {"unique_ptr", "shared_ptr", "weak_ptr", "__uniq_ptr_impl"}:
+        return True
+    # oneDAL exposes detail::pimpl<T> as its public pimpl alias.  Keep this
+    # project-specific alias narrow; a bare ``acme::pimpl<T>`` may be an
+    # arbitrary by-value template and must not suppress layout leaks.
+    return clean == "oneapi::dal::detail::pimpl"
+
 def _candidate_type_names_indirect(typename: str) -> list[tuple[str, bool]]:
     """Yield ``(candidate_type_name, reached_through_pointer)`` pairs for *typename*.
 
@@ -204,11 +224,7 @@ def _candidate_type_names_indirect(typename: str) -> list[tuple[str, bool]]:
     # in an unrelated argument of a by-value template does not mark its siblings
     # indirect (Codex review).
     outer = _strip_decorators(top)
-    outer_leaf = outer.rsplit("::", 1)[-1].lower()
-    smart = (
-        any(m in outer for m in ("unique_ptr", "uniq_ptr", "shared_ptr", "weak_ptr"))
-        or outer_leaf == "pimpl"  # oneDAL pimpl<T> alias
-    )
+    smart = _is_known_pointer_wrapper(outer)
     # Walk the outermost <...> of the ORIGINAL spelling (keeps inner */&).
     depth = 0
     start = -1

--- a/tests/test_internal_leak_review.py
+++ b/tests/test_internal_leak_review.py
@@ -590,6 +590,35 @@ class TestPointerMediatedLayoutLeakSuppressed:
             f"opaque-handle pointer param must not leak a layout change (got: {leaks})"
         )
 
+    def test_smart_pointer_like_by_value_template_arg_still_fires(self) -> None:
+        # Aardvark: do not classify arbitrary user-defined templates as pointer
+        # wrappers just because their names contain smart-pointer substrings.
+        # This wrapper embeds Impl by value, so Impl's layout is public ABI.
+        def _snap(size: int) -> AbiSnapshot:
+            return AbiSnapshot(
+                library="lib.so", version="1.0",
+                functions=[Function(
+                    name="make", mangled="make", return_type="Public*",
+                    params=[], visibility=Visibility.PUBLIC,
+                )],
+                types=[
+                    RecordType(name="Public", kind="class", fields=[
+                        TypeField(name="member", type="acme::unique_ptr_value<ns::detail::Impl>"),
+                    ]),
+                    RecordType(name="ns::detail::Impl", kind="struct", size_bits=size),
+                ],
+            )
+        leaks = detect_internal_leaks(
+            [Change(kind=ChangeKind.TYPE_SIZE_CHANGED,
+                    symbol="ns::detail::Impl", description="size")],
+            _snap(32), _snap(64),
+        )
+        assert len(leaks) == 1, (
+            "a by-value template with a smart-pointer-like name must still leak "
+            f"(got: {leaks})"
+        )
+        assert "embedded-by-value" in leaks[0].description
+
     def test_pimpl_alias_template_field_is_suppressed(self) -> None:
         # oneDAL pimpl<T> alias = a smart-pointer; a layout change to the pointee
         # must be demoted even though `pimpl` is not std::*_ptr.


### PR DESCRIPTION
### Motivation
- The prior per-hop indirection heuristic used loose substring and bare-`pimpl` name matches which could misclassify by-value user types (e.g. `acme::unique_ptr_value<T>`) as pointer wrappers and suppress real internal layout leaks, undermining ABI gating integrity.

### Description
- Replace the substring heuristic with a new `_is_known_pointer_wrapper` helper that only recognizes a small set of known pointer-owning spellings (`unique_ptr`, `shared_ptr`, `weak_ptr`, `__uniq_ptr_impl`) and the narrow `oneapi::dal::detail::pimpl` alias. 
- Use `_is_known_pointer_wrapper` in `_candidate_type_names_indirect` to decide whether template arguments should be marked `reached_through_pointer`.
- Add a regression test (`test_smart_pointer_like_by_value_template_arg_still_fires`) to ensure a by-value wrapper named like `unique_ptr_value<T>` still produces an `embedded-by-value` leak finding.
- Small test and commit bookkeeping to land the change on the branch.

### Testing
- Ran the targeted regression suite `pytest -q tests/test_internal_leak_review.py::TestPointerMediatedLayoutLeakSuppressed` which passed (15 tests).
- Ran focused suites `pytest -q tests/test_internal_leak.py tests/test_internal_leak_review.py tests/test_cov95_reporting.py` which passed (`118 passed`).
- Installed test dependency with `python -m pip install hypothesis` and ran the full test suite `pytest -q`, which completed successfully (`11072 passed, 371 skipped, 4 xfailed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307809505c832bb2dd94d11c8ff016)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart-pointer wrapper detection accuracy. The internal leak analyzer now employs more precise type identification methods to distinguish between actual pointer wrappers and user-defined types with similar naming conventions, resulting in fewer false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->