### PR TITLE
fix: keep auto header backend fail-closed

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -17,12 +17,14 @@
 The header AST (L2) is produced by one of two interchangeable frontends behind
 ``_header_ast_parser``: **castxml** (the default / schema reference, parsed by
 ``dumper_castxml._CastxmlParser``) or **clang** (``clang -ast-dump=json``, parsed
-by ``dumper_clang._ClangAstParser``) for hosts where castxml is absent. Select
+by ``dumper_clang._ClangAstParser``) when explicitly requested. Select
 with ``header_backend=`` (``auto``/``castxml``/``clang``; CLI ``--ast-frontend``)
-or the ``ABICHECK_AST_FRONTEND`` env var. When the backend is auto-selected, a castxml
-*toolchain-version* failure (bundled Clang too old for the host libstdc++/GCC)
-falls back to the clang backend automatically (G16); an explicit selection is
-honored verbatim. See ADR-003.
+or the ``ABICHECK_AST_FRONTEND`` env var. ``auto`` resolves to castxml and never
+silently falls back to clang on castxml-less hosts (clang's JSON AST lacks
+computed record layout, so an implicit fallback could miss layout-only breaks).
+The one exception is a runtime castxml *toolchain-version* failure (bundled
+Clang too old for the host libstdc++/GCC), which falls back to the clang backend
+automatically (G16); an explicit selection is honored verbatim. See ADR-003.
 """
 from __future__ import annotations
 
@@ -92,7 +94,8 @@ def _clang_available(clang_bin: str = "clang") -> bool:
 #: Header-AST backend identifiers (the L2 producers). castxml is the default and
 #: the schema reference; clang is the alternative for hosts where castxml is
 #: absent or its bundled frontend chokes (ADR-003, "clang as an alternative L2
-#: frontend"). ``auto`` prefers castxml, then clang.
+#: frontend"). ``auto`` resolves to castxml unless the environment explicitly
+#: selects clang; the clang backend lacks computed record layout evidence.
 HEADER_BACKENDS = ("auto", "castxml", "clang")
 
 
@@ -101,11 +104,12 @@ def _resolve_header_backend(backend: str | None) -> str:
 
     Precedence: an explicit ``castxml``/``clang`` is honored verbatim (and the
     caller gets a clear error later if that tool is missing). ``auto``/``None``
-    consults the ``ABICHECK_AST_FRONTEND`` env var first — so a clang-only CI
-    image can flip the global default without touching every call site — then
-    prefers castxml (the schema reference), falling back to clang when only
-    clang is on PATH. When neither tool is present it returns ``castxml`` so the
-    existing "install castxml" error message is surfaced unchanged.
+    consults the ``ABICHECK_AST_FRONTEND`` env var first, then resolves to
+    castxml (the schema reference). It deliberately does not auto-fallback to
+    clang: clang JSON AST snapshots do not carry computed record size, alignment,
+    field offsets, or vtable layout, so implicit fallback could silently miss
+    layout-only ABI breaks on castxml-less hosts. Users who accept that evidence
+    tier may still request ``clang`` explicitly (or via the environment).
     """
     choice = (backend or "auto").lower()
     if choice in ("castxml", "clang"):
@@ -117,10 +121,6 @@ def _resolve_header_backend(backend: str | None) -> str:
     env = os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower()
     if env in ("castxml", "clang"):
         return env
-    if _castxml_available():
-        return "castxml"
-    if _clang_available():
-        return "clang"
     return "castxml"
 
 

--- a/action.yml
+++ b/action.yml
@@ -134,11 +134,12 @@ inputs:
     default: 'c++'
   ast-frontend:
     description: >
-      L2 header-AST frontend for native-binary inputs: "auto" (castxml if
-      present, else clang, with auto-fallback to clang on a castxml
-      toolchain-version error), "castxml" (default), or "clang"
-      (clang -ast-dump=json; for clang-only hosts). Applies to compare and
-      dump modes. Equivalent to the ABICHECK_AST_FRONTEND env var.
+      L2 header-AST frontend for native-binary inputs: "auto" (resolves to
+      castxml without conditional clang fallback; a runtime castxml
+      toolchain-version failure still falls back to clang, G16), "castxml"
+      (default), or "clang" (clang -ast-dump=json; explicit opt-in for
+      clang-only hosts). Applies to compare and dump modes. Same as the
+      ABICHECK_AST_FRONTEND env var.
     required: false
   gcc-path:
     description: 'Path to GCC/G++ cross-compiler binary (dump mode only).'

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -150,11 +150,12 @@ declaration surface (signatures, classes/bases, enums, typedefs, access,
 `noexcept`, templates) but is a **syntactic** AST: it does **not** compute record
 layout, so `size_bits`/`offset_bits`/vtable slots stay unset and the layout
 detectors skip an unknown-vs-unknown comparison — **DWARF (L1) remains the layout
-authority** on a clang-only host. With that caveat, either backend extracts:
+authority** on a clang-only host. With that caveat, the header AST extracts:
 
 - Function signatures (parameters, return types)
-- Class/struct definitions and layout
-- Virtual method tables (vtable slot ordering)
+- Class/struct definitions; layout when backed by castxml or DWARF evidence
+- Virtual method tables (vtable slot ordering) when backed by castxml or DWARF
+  evidence
 - Enum values and member names
 - Typedefs and template instantiations
 - `noexcept` specifications

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -482,23 +482,24 @@ def test_resolve_header_backend_ast_frontend_env(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setenv("ABICHECK_AST_FRONTEND", "clang")
     assert _resolve_header_backend("auto") == "clang"
     assert _resolve_header_backend(None) == "clang"
-    # An out-of-enum ABICHECK_AST_FRONTEND value is ignored; auto-detection
-    # then supplies the default.
+    # An out-of-enum ABICHECK_AST_FRONTEND value is ignored; auto then
+    # fails closed to castxml.
     monkeypatch.setenv("ABICHECK_AST_FRONTEND", "bogus")
     monkeypatch.setattr("abicheck.dumper._castxml_available", lambda: True)
     assert _resolve_header_backend("auto") == "castxml"
 
 
-def test_resolve_header_backend_auto_prefers_castxml(
+def test_resolve_header_backend_auto_stays_castxml_without_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ABICHECK_AST_FRONTEND", raising=False)
     monkeypatch.setattr("abicheck.dumper._castxml_available", lambda: True)
     monkeypatch.setattr("abicheck.dumper._clang_available", lambda *a, **k: True)
     assert _resolve_header_backend("auto") == "castxml"
-    # castxml absent, clang present → clang.
+    # Do not silently fall back to clang: clang AST lacks computed layout
+    # evidence, so auto must fail closed through the castxml path.
     monkeypatch.setattr("abicheck.dumper._castxml_available", lambda: False)
-    assert _resolve_header_backend("auto") == "clang"
+    assert _resolve_header_backend("auto") == "castxml"
 
 
 def test_build_clang_header_command_cpp_and_c(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent `auto` from silently falling back to `clang` on castxml-less hosts because clang&#39;s JSON AST lacks computed record layout (size/alignment/offset/vtable) and that implicit fallback can cause layout-only ABI breaks to be missed.

### Description
- Change `_resolve_header_backend` in `abicheck/dumper.py` so `auto` resolves to `castxml` by default and only uses `clang` when explicitly requested via `header_backend`/`--ast-frontend` or the `ABICHECK_AST_FRONTEND` environment variable. Update the module docstrings to document the fail-closed behavior and the clang-evidence limitation.
- Update `tests/test_dumper_clang.py` to assert the new fail-closed `auto` behavior when castxml is absent and clang is present.
- Update `action.yml` and `docs/concepts/architecture.md` to match the fail-closed behavior.

> Note: the dedicated runtime G16 fallback (a castxml *toolchain-version* failure on the auto path still falls back to clang, logged) is a separate, deliberate mechanism and is preserved — this change only removes the availability-based fallback (castxml absent → clang).

### Rebase (2026-06-23)
- Rebased onto current `main` (`8841475`). Dropped the stale merge commit; replayed the two real commits and reconciled with the post-PR `ABICHECK_HEADER_BACKEND` → `ABICHECK_AST_FRONTEND` rename (#435) and the G16 toolchain-version fallback. The deprecated-alias wording was dropped because the old env var is no longer honored anywhere in the code.

### Testing
- Full fast unit suite green (`pytest -m "not integration and not libabigail and not abicc and not slow and not golden"`): 11674 passed.
- `ruff check`, `mypy abicheck/`, and `scripts/check_ai_readiness.py` all clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a5316cd0832b98585dfa63506144)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `--ast-frontend auto` behavior: now consistently prefers `castxml` as the default header AST frontend, falling back to `clang` only on runtime toolchain version failures.
  * Updated architecture and action documentation to reflect the new auto-resolution strategy.

* **Tests**
  * Adjusted backend auto-resolution tests to verify stable `castxml` preference in auto mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->