### PR TITLE
feat(scan): add --public-header-dir to classify public/internal provenance

### DIFF
--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -378,6 +378,8 @@ def _build_new_snapshot(
     changed_paths: tuple[str, ...] = (),
     build_info: Path | None = None,
     build_config: Path | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
 ) -> Any:
     """Dump the candidate's L0-L2 surface and embed L3-L5 inline at *collect_mode*.
 
@@ -396,7 +398,15 @@ def _build_new_snapshot(
     from .service import resolve_input
 
     try:
-        snap = resolve_input(binary, headers, includes, version="", lang=lang)
+        snap = resolve_input(
+            binary,
+            headers,
+            includes,
+            version="",
+            lang=lang,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+        )
     except AbicheckError as exc:
         raise click.ClickException(f"Failed to load --binary {binary}: {exc}") from exc
     # Collect evidence when there is something to collect from — a source tree OR
@@ -479,6 +489,17 @@ def _audit_exit_code(
     multiple=True,
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Additional include directory for header parsing (repeatable).",
+)
+@click.option(
+    "--public-header-dir",
+    "public_header_dirs",
+    multiple=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Directory whose headers are public for provenance classification "
+    "(repeatable). Establishes the public/internal boundary so the leakage / "
+    "RTTI / exported-vs-public cross-checks run instead of skipping. A directory "
+    "passed via -H also counts; a lone -H umbrella *file* cannot establish a "
+    "boundary, so origins stay UNKNOWN unless a directory is given.",
 )
 @click.option(
     "--sources",
@@ -602,6 +623,7 @@ def scan_cmd(
     binaries: tuple[Path, ...],
     headers: tuple[Path, ...],
     includes: tuple[Path, ...],
+    public_header_dirs: tuple[Path, ...],
     sources: Path | None,
     build_info: Path | None,
     compile_db: Path | None,
@@ -734,12 +756,17 @@ def scan_cmd(
     # The classify→tier→level→compare body lives in ``run_scan_core`` so the CLI,
     # ``service.run_scan``, and the MCP tool drive one engine. The CLI only parses
     # argv, renders, and maps the budget-overflow signal onto an exit code.
+    prov_headers, prov_dirs = _public_provenance_set(
+        list(headers), list(public_header_dirs)
+    )
     try:
         core = run_scan_core(
             start=start,
             binary=binary,
             headers=list(headers),
             includes=list(includes),
+            public_headers=prov_headers,
+            public_header_dirs=prov_dirs,
             sources=sources,
             effective_build_info=effective_build_info,
             build_config=build_config,
@@ -809,6 +836,8 @@ def run_scan_core(
     binary: Path,
     headers: list[Path],
     includes: list[Path],
+    public_headers: list[Path],
+    public_header_dirs: list[Path],
     sources: Path | None,
     effective_build_info: Path | None,
     build_config: Path | None,
@@ -878,6 +907,8 @@ def run_scan_core(
         changed_paths=replay_seed,
         build_info=effective_build_info,
         build_config=build_config,
+        public_headers=list(public_headers),
+        public_header_dirs=list(public_header_dirs),
     )
 
     # --- conditional tier: S2 preprocessor pre-scan (D2) ----------------------
@@ -918,6 +949,8 @@ def run_scan_core(
             collect_mode,
             list(headers),
             list(includes),
+            list(public_headers),
+            list(public_header_dirs),
         )
         # A cross-check the maintainer promoted to `error` (D6) gates the exit
         # even when the baseline diff itself is clean.
@@ -979,6 +1012,34 @@ def run_scan_core(
     return ScanCoreResult(
         outcome=outcome, findings=list(cc.findings), snapshot=new_snap
     )
+
+
+def _public_provenance_set(
+    headers: list[Path], public_header_dirs: list[Path]
+) -> tuple[list[Path], list[Path]]:
+    """Build the ``(public_headers, public_header_dirs)`` provenance set for scan.
+
+    A directory boundary is what lets ``apply_provenance`` classify origins as
+    PUBLIC/INTERNAL (and so unlocks the leakage / RTTI / exported-vs-public
+    cross-checks, ADR-024). Directories come from ``--public-header-dir`` and from
+    any ``-H`` argument that is itself a directory; ``-H`` *file* arguments ride
+    along as explicit public headers.
+
+    A lone ``-H`` umbrella *file* with no directory does **not** activate
+    provenance: a single header cannot establish a public directory boundary
+    (the abicheck A1 finding), so we return empty sets and every origin stays
+    ``UNKNOWN`` — preserving the prior default-scan behaviour.
+    """
+    dirs = list(public_header_dirs)
+    files: list[Path] = []
+    for h in headers:
+        if h.is_dir():
+            dirs.append(h)
+        else:
+            files.append(h)
+    if not dirs:
+        return [], []
+    return files, dirs
 
 
 def _expand_public_headers(headers: list[Path]) -> list[str]:
@@ -1096,6 +1157,8 @@ def _run_baseline_compare(
     collect_mode: str,
     headers: list[Path],
     includes: list[Path],
+    public_headers: list[Path],
+    public_header_dirs: list[Path],
 ) -> tuple[str, int, dict[str, Any]]:
     """Compare *new_snap* against *baseline*, folding cross-source findings in.
 
@@ -1122,7 +1185,15 @@ def _run_baseline_compare(
     from .service import resolve_input
 
     try:
-        old_snap = resolve_input(baseline, headers, includes, version="", lang=lang)
+        old_snap = resolve_input(
+            baseline,
+            headers,
+            includes,
+            version="",
+            lang=lang,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+        )
     except AbicheckError as exc:
         raise click.ClickException(
             f"Failed to load --baseline {baseline}: {exc}"

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -1086,10 +1086,21 @@ def abi_scan(
         inc_paths = [
             _safe_read_path(d, label="include_dir") for d in (include_dirs or [])
         ]
-        phd_paths = [
-            _safe_read_path(d, label="public_header_dir")
-            for d in (public_header_dirs or [])
-        ]
+        phd_paths: list[Path] = []
+        for d in public_header_dirs or []:
+            p = _safe_read_path(d, label="public_header_dir")
+            # Match the CLI option (exists=True, file_okay=False): a public-header
+            # boundary must be a real directory, else apply_provenance would tag
+            # every declaration INTERNAL against a path that matches nothing,
+            # producing misleading origin classification (CodeRabbit).
+            if not p.is_dir():
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": f"public_header_dir must be an existing directory: {d}",
+                    }
+                )
+            phd_paths.append(p)
         src_path = _safe_read_path(sources, label="sources") if sources else None
         cdb_path = (
             _safe_read_path(compile_db, label="compile_db") if compile_db else None

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -1036,6 +1036,7 @@ def abi_scan(
     binary_path: str,
     headers: list[str] | None = None,
     include_dirs: list[str] | None = None,
+    public_header_dirs: list[str] | None = None,
     sources: str | None = None,
     compile_db: str | None = None,
     baseline: str | None = None,
@@ -1059,6 +1060,10 @@ def abi_scan(
         binary_path: Library/artifact (or JSON snapshot) to scan.
         headers: Public header files (provenance + pattern pre-scan).
         include_dirs: Extra include directories for the parser.
+        public_header_dirs: Directories whose headers are public; establishes the
+            public/internal boundary so the leakage / RTTI / exported-vs-public
+            cross-checks run instead of skipping. A directory passed via ``headers``
+            also counts; a lone umbrella header file cannot establish a boundary.
         sources: Source tree (compile DB auto-discovered within it).
         compile_db: Explicit compile_commands.json (else discovered in sources).
         baseline: Previous build's dump/library to compare against (omit for a
@@ -1081,6 +1086,10 @@ def abi_scan(
         inc_paths = [
             _safe_read_path(d, label="include_dir") for d in (include_dirs or [])
         ]
+        phd_paths = [
+            _safe_read_path(d, label="public_header_dir")
+            for d in (public_header_dirs or [])
+        ]
         src_path = _safe_read_path(sources, label="sources") if sources else None
         cdb_path = (
             _safe_read_path(compile_db, label="compile_db") if compile_db else None
@@ -1095,6 +1104,7 @@ def abi_scan(
             binaries=[bin_path],
             headers=hdr_paths,
             includes=inc_paths,
+            public_header_dirs=phd_paths,
             sources=src_path,
             compile_db=cdb_path,
             baseline=base_path,

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -141,6 +141,7 @@ class ScanRequest:
     binaries: list[Path] = field(default_factory=list)
     headers: list[Path] = field(default_factory=list)
     includes: list[Path] = field(default_factory=list)
+    public_header_dirs: list[Path] = field(default_factory=list)
     sources: Path | None = None
     compile_db: Path | None = None
     build_info: Path | None = None
@@ -560,11 +561,14 @@ def run_scan(req: ScanRequest) -> ScanResult:
         resolve_level,
     ) = _scan_imports()
     from .buildsource.crosscheck import ALL_CHECKS
-    from .cli_scan import _BudgetOverflow, run_scan_core
+    from .cli_scan import _BudgetOverflow, _public_provenance_set, run_scan_core
 
     if len(req.binaries) != 1:
         raise ValueError("run_scan accepts exactly one binary")
     binary = req.binaries[0]
+    prov_headers, prov_dirs = _public_provenance_set(
+        list(req.headers), list(req.public_header_dirs)
+    )
 
     changed = [p for p in req.changed_paths if p]
     seeded = req.seeded or bool(changed)
@@ -592,6 +596,8 @@ def run_scan(req: ScanRequest) -> ScanResult:
             binary=binary,
             headers=list(req.headers),
             includes=list(req.includes),
+            public_headers=prov_headers,
+            public_header_dirs=prov_dirs,
             sources=req.sources,
             effective_build_info=effective_build_info,
             build_config=None,

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -714,3 +714,114 @@ def test_malformed_baseline_input_is_click_error(runner, tmp_path, new_snap_comp
     assert res.exit_code != 0
     assert res.exception is None or isinstance(res.exception, SystemExit)
     assert "Failed to load --baseline" in res.output
+
+
+# ── A1: --public-header-dir threads provenance into the scan ──────────────────
+
+
+def test_public_provenance_set_lone_header_file_no_boundary(tmp_path):
+    # A lone -H umbrella *file* with no directory cannot establish a public
+    # boundary, so provenance stays off (origins remain UNKNOWN) — preserving the
+    # prior default-scan behaviour (abicheck A1).
+    from abicheck.cli_scan import _public_provenance_set
+
+    umbrella = tmp_path / "all.hpp"
+    umbrella.write_text("// umbrella\n", encoding="utf-8")
+    files, dirs = _public_provenance_set([umbrella], [])
+    assert files == []
+    assert dirs == []
+
+
+def test_public_provenance_set_dir_activates(tmp_path):
+    # --public-header-dir establishes the boundary; a -H *file* rides along as an
+    # explicit public header once a directory is present.
+    from abicheck.cli_scan import _public_provenance_set
+
+    inc = tmp_path / "include"
+    inc.mkdir()
+    umbrella = tmp_path / "all.hpp"
+    umbrella.write_text("// umbrella\n", encoding="utf-8")
+    files, dirs = _public_provenance_set([umbrella], [inc])
+    assert files == [umbrella]
+    assert dirs == [inc]
+
+
+def test_public_provenance_set_header_dir_counts_as_boundary(tmp_path):
+    # A directory passed via -H is itself a boundary, even without
+    # --public-header-dir.
+    from abicheck.cli_scan import _public_provenance_set
+
+    hdr_dir = tmp_path / "pub"
+    hdr_dir.mkdir()
+    files, dirs = _public_provenance_set([hdr_dir], [])
+    assert files == []
+    assert dirs == [hdr_dir]
+
+
+def test_scan_public_header_dir_forwarded_to_snapshot(
+    monkeypatch, runner, new_snap_compatible, tmp_path
+):
+    # The CLI flag must reach the snapshot builder as public_header_dirs so
+    # apply_provenance can classify origins (unlocking the leakage/RTTI/exported-
+    # vs-public cross-checks).
+    import abicheck.cli_scan as cs
+
+    pub = tmp_path / "pub"
+    pub.mkdir()
+    captured: dict[str, object] = {}
+    original = cs._build_new_snapshot
+
+    def _spy(*args, **kwargs):
+        captured["public_header_dirs"] = kwargs.get("public_header_dirs")
+        captured["public_headers"] = kwargs.get("public_headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "_build_new_snapshot", _spy)
+    res = runner.invoke(
+        main,
+        [
+            "scan",
+            "--binary",
+            str(new_snap_compatible),
+            "--public-header-dir",
+            str(pub),
+            "--audit",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["public_header_dirs"] == [pub]
+    assert captured["public_headers"] == []
+
+
+def test_scan_lone_header_file_does_not_activate_provenance(
+    monkeypatch, runner, new_snap_compatible, tmp_path
+):
+    # A lone -H file (no dir) must NOT activate provenance — empty sets reach the
+    # snapshot builder so behaviour is unchanged.
+    import abicheck.cli_scan as cs
+
+    umbrella = tmp_path / "all.hpp"
+    umbrella.write_text("// umbrella\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    original = cs._build_new_snapshot
+
+    def _spy(*args, **kwargs):
+        captured["public_header_dirs"] = kwargs.get("public_header_dirs")
+        captured["public_headers"] = kwargs.get("public_headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "_build_new_snapshot", _spy)
+    res = runner.invoke(
+        main,
+        [
+            "scan",
+            "--binary",
+            str(new_snap_compatible),
+            "-H",
+            str(umbrella),
+            "--audit",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["public_header_dirs"] == []
+    assert captured["public_headers"] == []

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -53,6 +53,7 @@ from abicheck.mcp_server import (  # noqa: E402
     abi_dump,
     abi_explain_change,
     abi_list_changes,
+    abi_scan,
     main,
 )
 from abicheck.model import (  # noqa: E402
@@ -184,26 +185,32 @@ class TestSafeWritePath:
         __import__("platform").system() == "Windows",
         reason="POSIX-only sensitive paths",
     )
-    @pytest.mark.parametrize("path", [
-        "/etc/foo.json",
-        "/bin/foo.json",
-        "/sbin/foo.json",
-        "/usr/bin/foo.json",
-        "/usr/sbin/foo.json",
-        "/boot/foo.json",
-        "/sys/foo.json",
-        "/proc/foo.json",
-        "/dev/foo.json",
-    ])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/etc/foo.json",
+            "/bin/foo.json",
+            "/sbin/foo.json",
+            "/usr/bin/foo.json",
+            "/usr/sbin/foo.json",
+            "/boot/foo.json",
+            "/sys/foo.json",
+            "/proc/foo.json",
+            "/dev/foo.json",
+        ],
+    )
     def test_posix_sensitive_path_blocked(self, path):
         with pytest.raises(ValueError, match="sensitive system path"):
             _safe_write_path(path)
 
-    @pytest.mark.parametrize("dotdir,filename", [
-        (".ssh", "keys.json"),
-        (".aws", "config.json"),
-        (".gnupg", "ring.json"),
-    ])
+    @pytest.mark.parametrize(
+        "dotdir,filename",
+        [
+            (".ssh", "keys.json"),
+            (".aws", "config.json"),
+            (".gnupg", "ring.json"),
+        ],
+    )
     def test_credential_dir_blocked(self, dotdir, filename):
         home = Path.home()
         with pytest.raises(ValueError, match="credential directory"):
@@ -568,9 +575,9 @@ class TestImpactCategory:
             ChangeKind.PARAM_DEFAULT_VALUE_REMOVED,
         ]:
             if kind in API_BREAK_KINDS:
-                assert (
-                    _impact_category(kind) == "api_break"
-                ), f"{kind} should be api_break"
+                assert _impact_category(kind) == "api_break", (
+                    f"{kind} should be api_break"
+                )
 
     def test_risk_kinds(self):
         assert _impact_category(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED) == "risk"
@@ -587,9 +594,13 @@ class TestImpactCategory:
 
     def test_sdk_vendor_downgrades_some_api_breaks(self):
         # enum_member_renamed is api_break under strict_abi, compatible under sdk_vendor
-        assert _impact_category(ChangeKind.ENUM_MEMBER_RENAMED, "strict_abi") == "api_break"
         assert (
-            _impact_category(ChangeKind.ENUM_MEMBER_RENAMED, "sdk_vendor") == "compatible"
+            _impact_category(ChangeKind.ENUM_MEMBER_RENAMED, "strict_abi")
+            == "api_break"
+        )
+        assert (
+            _impact_category(ChangeKind.ENUM_MEMBER_RENAMED, "sdk_vendor")
+            == "compatible"
         )
 
     def test_plugin_abi_policy(self):
@@ -916,12 +927,8 @@ class TestAbiCompare:
         assert data["summary"]["compatible"] > 0
 
     def test_api_break_exit_code(self, tmp_path: Path):
-        old_enum = EnumType(
-            name="Color", members=[EnumMember(name="RED", value=0)]
-        )
-        new_enum = EnumType(
-            name="Color", members=[EnumMember(name="ROUGE", value=0)]
-        )
+        old_enum = EnumType(name="Color", members=[EnumMember(name="RED", value=0)])
+        new_enum = EnumType(name="Color", members=[EnumMember(name="ROUGE", value=0)])
         old = _make_snapshot("1.0", enums=[old_enum])
         new = _make_snapshot("2.0", enums=[new_enum])
         old_p, new_p = self._make_pair(tmp_path, old, new)
@@ -975,7 +982,9 @@ class TestAbiCompare:
         raw = abi_compare(str(old_p), str(new_p), output_format="html")
         data = json.loads(raw)
         assert data["status"] == "ok"
-        assert "<html" in data["report"].lower() or "<!doctype" in data["report"].lower()
+        assert (
+            "<html" in data["report"].lower() or "<!doctype" in data["report"].lower()
+        )
 
     def test_stat_parameter(self, tmp_path: Path):
         snap = _make_snapshot("1.0")
@@ -1007,12 +1016,8 @@ class TestAbiCompare:
             assert data["status"] == "ok", f"policy={policy} failed"
 
     def test_impact_respects_policy(self, tmp_path: Path):
-        old_enum = EnumType(
-            name="Color", members=[EnumMember(name="RED", value=0)]
-        )
-        new_enum = EnumType(
-            name="Color", members=[EnumMember(name="ROUGE", value=0)]
-        )
+        old_enum = EnumType(name="Color", members=[EnumMember(name="RED", value=0)])
+        new_enum = EnumType(name="Color", members=[EnumMember(name="ROUGE", value=0)])
         old = _make_snapshot("1.0", enums=[old_enum])
         new = _make_snapshot("2.0", enums=[new_enum])
         old_p, new_p = self._make_pair(tmp_path, old, new)
@@ -1020,14 +1025,18 @@ class TestAbiCompare:
         # strict_abi: enum_member_renamed is api_break
         raw = abi_compare(str(old_p), str(new_p), policy="strict_abi")
         data = json.loads(raw)
-        rename_changes = [c for c in data["changes"] if c["kind"] == "enum_member_renamed"]
+        rename_changes = [
+            c for c in data["changes"] if c["kind"] == "enum_member_renamed"
+        ]
         assert rename_changes
         assert rename_changes[0]["impact"] == "api_break"
 
         # sdk_vendor: downgraded to compatible
         raw = abi_compare(str(old_p), str(new_p), policy="sdk_vendor")
         data = json.loads(raw)
-        rename_changes = [c for c in data["changes"] if c["kind"] == "enum_member_renamed"]
+        rename_changes = [
+            c for c in data["changes"] if c["kind"] == "enum_member_renamed"
+        ]
         assert rename_changes
         assert rename_changes[0]["impact"] == "compatible"
 
@@ -1171,7 +1180,9 @@ class TestMain:
         from abicheck import mcp_server
 
         calls = []
-        monkeypatch.setattr(mcp_server.mcp, "run", lambda transport: calls.append(transport))
+        monkeypatch.setattr(
+            mcp_server.mcp, "run", lambda transport: calls.append(transport)
+        )
         monkeypatch.setattr("sys.argv", ["abicheck-mcp"])
         main()
         assert calls == ["stdio"]
@@ -1294,3 +1305,58 @@ class TestSafeWritePathTraversalEdgeCases:
     def test_double_slash_etc(self):
         with pytest.raises(ValueError, match="sensitive system path"):
             _safe_write_path("//etc/foo.json")
+
+
+# ---------------------------------------------------------------------------
+# abi_scan: --public-header-dir provenance wiring (A1)
+# ---------------------------------------------------------------------------
+
+
+class TestAbiScanPublicHeaderDir:
+    def _snap_file(self, tmp_path: Path) -> Path:
+        p = tmp_path / "lib.abi.json"
+        p.write_text(snapshot_to_json(_make_snapshot("1.0")), encoding="utf-8")
+        return p
+
+    def test_nonexistent_public_header_dir_is_error(self, tmp_path: Path):
+        # A public-header boundary must be a real directory (matches the CLI's
+        # exists=True, file_okay=False) — else provenance would mis-classify.
+        snap = self._snap_file(tmp_path)
+        raw = abi_scan(
+            str(snap),
+            mode="audit",
+            public_header_dirs=[str(tmp_path / "missing")],
+        )
+        data = json.loads(raw)
+        assert data["status"] == "error"
+        assert "public_header_dir must be an existing directory" in data["error"]
+
+    def test_file_as_public_header_dir_is_error(self, tmp_path: Path):
+        snap = self._snap_file(tmp_path)
+        not_a_dir = tmp_path / "all.hpp"
+        not_a_dir.write_text("// umbrella\n", encoding="utf-8")
+        raw = abi_scan(str(snap), mode="audit", public_header_dirs=[str(not_a_dir)])
+        data = json.loads(raw)
+        assert data["status"] == "error"
+        assert "must be an existing directory" in data["error"]
+
+    def test_public_header_dir_forwarded_to_request(self, tmp_path: Path, monkeypatch):
+        # A valid directory is resolved and threaded onto ScanRequest so the typed
+        # engine classifies provenance (unlocking the leakage/RTTI cross-checks).
+        from abicheck import service
+
+        snap = self._snap_file(tmp_path)
+        pub = tmp_path / "pub"
+        pub.mkdir()
+
+        captured: dict[str, object] = {}
+
+        def _fake_subprocess(req, timeout):
+            captured["public_header_dirs"] = list(req.public_header_dirs)
+            return {"verdict": "COMPATIBLE", "exit_code": 0}
+
+        monkeypatch.setattr(service, "run_scan_subprocess", _fake_subprocess)
+        raw = abi_scan(str(snap), mode="audit", public_header_dirs=[str(pub)])
+        data = json.loads(raw)
+        assert data["status"] == "ok"
+        assert captured["public_header_dirs"] == [pub.resolve()]


### PR DESCRIPTION
## Problem (field finding A1)

`scan` accepts `-H`/`-I` but had **no** `--public-header-dir` — unlike `dump`/`compare`, which expose both `--public-header` (file) and `--public-header-dir` (dir). Worse, `scan`'s snapshot builder (`_build_new_snapshot` → `service.resolve_input`) was called **without** `public_headers`/`public_header_dirs`, so `apply_provenance` left every declaration's `origin` as `UNKNOWN`.

With no public/internal boundary, the high-value cross-checks — `exported_not_public`, `public_not_exported`, `private_header_leak`, `rtti_for_internal_type` — could not run and silently skipped ("no public-header provenance"). That boundary is the actual reason to go past L2.

## Fix

- Add `--public-header-dir` (repeatable) to the `scan` command, matching `dump`/`compare`.
- Thread the public set through `run_scan_core` → `_build_new_snapshot` → `resolve_input`, **and** through the baseline `compare` (old side scoped symmetrically). `resolve_input` already accepts and applies these kwargs, so the plumbing is contained.
- Boundary rule: a directory passed via `-H` also establishes the boundary; a **lone `-H` umbrella file** with no directory does **not** (a single header cannot define a directory boundary — exactly the A1 observation). When no directory is present, empty sets are passed and origins stay `UNKNOWN`, so default scans are byte-for-byte unchanged.
- Mirror the new field on `ScanRequest` (typed engine) and on the `abi_scan` MCP tool so the CLI, `service.run_scan`, and the MCP path all classify provenance.

## Tests

- `_public_provenance_set` unit tests: lone file → no boundary; `--public-header-dir` activates; `-H` dir counts as boundary.
- CLI tests asserting the flag reaches the snapshot builder as `public_header_dirs`, and that a lone `-H` file does not activate provenance.

## Validation

- New tests: 5 passed.
- Full fast unit suite: `11193 passed, 25 skipped` (no regressions).
- `ruff check` / `ruff format --check` clean; `mypy` clean on touched modules; `check_ai_readiness.py`: 0 errors.

> Note: this addresses **A1** only (the High-priority item). The companion field findings A2–A5 (depth→source-method mapping, opaque header-root errors, silent S1–S6 no-op without a compile DB, `--estimate` overstating L4) are not touched here. The oneDAL "definitive run" referenced in the report can't be reproduced in this repo-only environment (no oneDAL checkout, compile DB, or castxml/clang toolchain), so the unlock is verified by unit tests rather than the live matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVJhznPgECZ4H4iCApNPS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVJhznPgECZ4H4iCApNPS5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--public-header-dir` option to the `scan` command to explicitly define the public-vs-internal header boundary, improving header-origin classification and related compatibility results.

* **New Features**
  * Extended the `abi_scan` MCP tool API with an optional `public_header_dirs` argument to pass the same boundary information into scans.

* **Tests**
  * Added unit and CLI tests covering boundary behavior, umbrella/header handling, and validation for missing or invalid boundary paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->