### PR TITLE
feat(service): typed CompareRequest + single Tier-2 chokepoint (G22 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ CI runs `mypy abicheck/` as a required gate. The baseline is currently **0 error
 | `changekind-detector` | WARN | Every `ChangeKind` is produced somewhere (not orphaned) |
 | `changekind-docs` | WARN | Every `ChangeKind` is mentioned in `docs/` |
 | `doc-count-sync` | ERROR on drift, WARN if anchor moved | Headline counts in docs (ChangeKind count, example-catalog size) match their source of truth (`len(ChangeKind)`, `ground_truth.json`) |
+| `cli-contract` | ERROR | No front-end `cli*.py` module calls Tier-1 `checker.compare` directly — it must route through the Tier-2 service (`service.run_compare`/`compare_snapshots`); ADR-037 D10.1 |
 | `import-cycles` | ERROR | No import cycles within `abicheck/` |
 | `mypy-baseline` | ERROR if drifted up | mypy error count ≤ documented baseline |
 | `examples-ground-truth` | ERROR | Every `examples/case*/` has a `README.md` and an entry in `ground_truth.json` |

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -43,9 +43,16 @@ SUPPORTED_LANGS = frozenset({"c", "c++"})
 
 
 def _path_tuple(paths: Iterable[Path | str] | None) -> tuple[Path, ...]:
-    """Normalise an optional iterable of path-likes into a tuple of ``Path``."""
-    if not paths:
+    """Normalise an optional iterable of path-likes into a tuple of ``Path``.
+
+    A bare ``str``/``Path`` is treated as a *single* path, not an iterable of
+    characters/parts — so ``headers="include/api.h"`` yields one path, not one
+    per character.
+    """
+    if paths is None:
         return ()
+    if isinstance(paths, (str, Path)):
+        return (Path(paths),)
     return tuple(Path(p) for p in paths)
 
 

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed request/response structs for the Tier-2 service layer (ADR-037 D2).
+
+"Options are data, not signatures": the service verbs take frozen request
+dataclasses instead of an ever-growing list of keyword arguments. A new feature
+becomes a new field with a default, never a signature break — and the same
+struct is assembled identically from CLI flags, MCP JSON, and direct Python
+callers, so a default can no longer silently diverge between front-ends (the
+``scope_public`` True-vs-False drift ADR-037 §Context #1 documents).
+
+This module is Phase 1 of the G22 plan: it introduces :class:`InputSpec`,
+:class:`CompareRequest` (with :meth:`CompareRequest.validate`), and
+:class:`OutputSpec`. Later phases extend ``CompareRequest`` with the depth
+(D5), policy/severity (D4), and frontend (D8) fields the ADR sketches — each as
+an additive field with a default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from .errors import ValidationError
+
+#: Languages the C/C++ frontends accept (mirrors the CLI ``--lang`` choices).
+SUPPORTED_LANGS = frozenset({"c", "c++"})
+
+
+def _path_tuple(paths: Iterable[Path | str] | None) -> tuple[Path, ...]:
+    """Normalise an optional iterable of path-likes into a tuple of ``Path``."""
+    if not paths:
+        return ()
+    return tuple(Path(p) for p in paths)
+
+
+@dataclass(frozen=True)
+class InputSpec:
+    """One side of a comparison: a binary/snapshot path plus its build context.
+
+    Frozen so a request can be hashed/shared without a caller mutating it after
+    validation. Use :meth:`of` to build one from loose CLI/MCP values (it
+    coerces ``str`` to ``Path`` and ``None`` lists to empty tuples).
+    """
+
+    path: Path
+    headers: tuple[Path, ...] = ()
+    includes: tuple[Path, ...] = ()
+    version: str = ""
+    pdb: Path | None = None
+    debug_roots: tuple[Path, ...] = ()
+
+    @classmethod
+    def of(
+        cls,
+        path: Path | str,
+        *,
+        headers: Iterable[Path | str] | None = None,
+        includes: Iterable[Path | str] | None = None,
+        version: str = "",
+        pdb: Path | str | None = None,
+        debug_roots: Iterable[Path | str] | None = None,
+    ) -> InputSpec:
+        """Build an :class:`InputSpec`, coercing loose front-end values."""
+        return cls(
+            path=Path(path),
+            headers=_path_tuple(headers),
+            includes=_path_tuple(includes),
+            version=version,
+            pdb=Path(pdb) if pdb is not None else None,
+            debug_roots=_path_tuple(debug_roots),
+        )
+
+
+@dataclass(frozen=True)
+class OutputSpec:
+    """Where/how a result is rendered — the invocation-level output choice.
+
+    ``path is None`` means "write to stdout". Kept deliberately small for
+    Phase 1; the rendering verbs still take an explicit format today, but the
+    struct gives later phases a single place to grow output options.
+    """
+
+    fmt: str = "text"
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class CompareRequest:
+    """A fully-specified comparison request — the single input to ``run_compare``.
+
+    Every front-end (CLI, MCP, ``compare-release`` fan-out, ``appcompat``)
+    assembles one of these and hands it to :func:`abicheck.service.run_compare`,
+    so there is exactly one classification path and one set of defaults.
+    """
+
+    old: InputSpec
+    new: InputSpec
+    lang: str = "c++"
+    policy: str = "strict_abi"
+    policy_file_path: Path | None = None
+    suppress: Path | None = None
+    scope_public: bool = True
+    force_public_symbols: frozenset[str] | None = None
+    pattern_verdicts: bool = False
+    enable_debuginfod: bool = False
+
+    def validation_errors(self) -> list[str]:
+        """Return a list of human-readable validation problems (empty == valid).
+
+        Lives here (Tier 2) so the CLI and MCP front-ends surface *identical*
+        error text for the same bad request (ADR-037 D9 / goal AC 8). Phase 6
+        extends this with mutual-exclusion and depth-feasibility rules.
+        """
+        errors: list[str] = []
+        if self.lang.lower() not in SUPPORTED_LANGS:
+            allowed = ", ".join(sorted(SUPPORTED_LANGS))
+            errors.append(f"unsupported language {self.lang!r}: choose from {allowed}")
+        if not self.policy:
+            errors.append("policy profile name must not be empty")
+        return errors
+
+    def validate(self) -> CompareRequest:
+        """Validate fail-fast; raise :class:`ValidationError` on the first batch.
+
+        Returns ``self`` so callers can write ``request.validate()`` inline.
+        """
+        errors = self.validation_errors()
+        if errors:
+            raise ValidationError("; ".join(errors))
+        return self
+
+    def replace(self, **changes: Any) -> CompareRequest:
+        """Return a copy with *changes* applied (frozen-dataclass ``replace``)."""
+        return replace(self, **changes)
+
+
+__all__ = [
+    "SUPPORTED_LANGS",
+    "CompareRequest",
+    "InputSpec",
+    "OutputSpec",
+]

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .checker import Change, DiffResult, compare
+from .checker import Change, DiffResult
 from .checker_policy import ChangeKind, Verdict, compute_verdict
 from .model import AbiSnapshot, Visibility
 
@@ -744,7 +744,10 @@ def check_appcompat(
         lang="c" if lang == "c" else None,
     )
 
-    diff = compare(old_snap, new_snap, suppression=suppression, policy=policy, policy_file=policy_file, scope_to_public_surface=scope_to_public_surface)
+    # Route through the Tier-2 service (lazy import avoids a
+    # service→cli→appcompat import cycle); ADR-037 D1.
+    from .service import compare_snapshots
+    diff = compare_snapshots(old_snap, new_snap, suppression=suppression, policy=policy, policy_file=policy_file, scope_to_public_surface=scope_to_public_surface)
 
     # 3. Check symbol availability in new library
     new_exports = _get_new_lib_exports(new_lib_path)
@@ -905,7 +908,10 @@ def check_plugin_host_contract(
     """
     required = set(required_entrypoints)
 
-    diff = compare(
+    # Route through the Tier-2 service (lazy import avoids a
+    # service→cli→appcompat import cycle); ADR-037 D1.
+    from .service import compare_snapshots
+    diff = compare_snapshots(
         old_plugin, new_plugin,
         suppression=suppression, policy=policy, policy_file=policy_file,
     )

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -34,7 +34,7 @@ try:
 except ImportError:  # pragma: no cover - rich-click is a declared dependency
     _RootGroupBase = click.Group  # type: ignore[assignment,misc]
 
-from .checker import DiffResult, LibraryMetadata, compare
+from .checker import DiffResult, LibraryMetadata
 from .cli_audit import echo_filtered_surface, echo_pattern_modulations
 from .cli_datasources import print_data_sources as _print_data_sources
 from .cli_dump_helpers import (
@@ -1353,7 +1353,8 @@ def compare_cmd(
     )
 
     apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on
-    result = compare(
+    from .service import compare_snapshots
+    result = compare_snapshots(
         old, new, suppression=suppression, policy=policy, policy_file=pf,
         scope_to_public_surface=scope_public_headers,
         force_public_symbols=force_public,

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -32,13 +32,11 @@ from typing import TYPE_CHECKING
 import click
 
 from .bundle import BundleDiffResult
-from .checker import DiffResult, compare
+from .checker import DiffResult
 from .cli import (
     _build_match_map,
-    _collect_metadata,
     _collect_release_inputs,
     _normalize_binary_input,
-    _resolve_input,
     _safe_write_output,
     _setup_verbosity,
     _write_or_echo,
@@ -99,44 +97,39 @@ def _run_compare_pair(
     scope_to_public_surface: bool = False,
     pattern_verdicts: bool = False,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
-    """Run compare for one old/new pair and return result + resolved snapshots."""
+    """Run compare for one old/new pair and return result + resolved snapshots.
+
+    Routes through the single Tier-2 chokepoint (:func:`service.run_compare`,
+    ADR-037 D1) rather than calling ``checker.compare`` directly — this is what
+    keeps ``compare-release`` and ``compare`` on one classification path so a
+    library gets the same verdict from either command (no ``scope_public``
+    default drift).
+    """
+    from . import service
+
     # Follow GNU ld linker scripts up front so metadata/dependency analysis use
     # the resolved DSO, not the text script.
-    old_input, old_fmt = _normalize_binary_input(old_input)
-    new_input, new_fmt = _normalize_binary_input(new_input)
+    old_input, _ = _normalize_binary_input(old_input)
+    new_input, _ = _normalize_binary_input(new_input)
 
-    old = _resolve_input(
+    return service.run_compare(
         old_input,
-        old_headers,
-        old_includes,
-        old_version,
-        lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=old_pdb_path,
-    )
-    new = _resolve_input(
         new_input,
-        new_headers,
-        new_includes,
-        new_version,
-        lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=new_pdb_path,
-    )
-
-    suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
-    result = compare(
-        old,
-        new,
-        suppression=suppression,
+        old_headers=old_headers,
+        new_headers=new_headers,
+        old_includes=old_includes,
+        new_includes=new_includes,
+        old_version=old_version,
+        new_version=new_version,
+        lang=lang,
+        suppress=suppress,
         policy=policy,
-        policy_file=pf,
+        policy_file_path=policy_file_path,
+        old_pdb_path=old_pdb_path,
+        new_pdb_path=new_pdb_path,
         scope_to_public_surface=scope_to_public_surface,
         pattern_verdicts=pattern_verdicts,
     )
-    result.old_metadata = _collect_metadata(old_input)
-    result.new_metadata = _collect_metadata(new_input)
-    return result, old, new
 
 
 _CompareReleaseCommonArgs = tuple[
@@ -628,14 +621,14 @@ def _collect_matrix_result(
     if not matrix_changes:
         return None, worst_verdict
 
-    from .checker import compare as _compare
     from .model import AbiSnapshot
+    from .service import compare_snapshots
 
     suppression, pf = _load_suppression_and_policy(suppress, policy, policy_file_path)
     # Empty snapshots contribute no per-binary changes; the matrix findings
     # ride in as extra_changes and inherit the full post-processing pipeline.
     name = "<build-config matrix>"
-    result = _compare(
+    result = compare_snapshots(
         AbiSnapshot(library=name, version=old_version or "old"),
         AbiSnapshot(library=name, version=new_version or "new"),
         suppression=suppression,

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -94,7 +94,7 @@ def _run_compare_pair(
     policy_file_path: Path | None,
     old_pdb_path: Path | None,
     new_pdb_path: Path | None,
-    scope_to_public_surface: bool = False,
+    scope_to_public_surface: bool = True,
     pattern_verdicts: bool = False,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Run compare for one old/new pair and return result + resolved snapshots.
@@ -188,7 +188,7 @@ def _compare_one_library(
     policy: str,
     policy_file_path: Path | None,
     output_dir: Path | None,
-    scope_to_public_surface: bool = False,
+    scope_to_public_surface: bool = True,
 ) -> dict[str, object]:
     """Compare one library pair — suitable for parallel dispatch.
 
@@ -335,7 +335,7 @@ def _compare_release_libraries(
     annotate: bool = False,
     annotate_additions: bool = False,
     jobs: int = 1,
-    scope_to_public_surface: bool = False,
+    scope_to_public_surface: bool = True,
 ) -> tuple[list[dict[str, object]], str, list[tuple[DiffResult, AbiSnapshot]]]:
     """Compare each matched library pair and collect results.
 
@@ -519,7 +519,7 @@ def _collect_release_extras(
     annotate_additions: bool,
     collect_diff_results: bool,
     annotate: bool,
-    scope_to_public_surface: bool = False,
+    scope_to_public_surface: bool = True,
 ) -> tuple[list[tuple[DiffResult, AbiSnapshot]], list[tuple[int, str]]]:
     """Collect optional re-run artifacts for JUnit and annotations."""
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] = []

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -1179,10 +1179,9 @@ def _run_baseline_compare(
     folded into the verdict too (``checker.compare`` itself does not read
     ``build_source``).
     """
-    from .checker import compare
     from .cli_buildsource import prepare_embedded_build_source
     from .errors import AbicheckError
-    from .service import resolve_input
+    from .service import compare_snapshots, resolve_input
 
     try:
         old_snap = resolve_input(
@@ -1216,7 +1215,7 @@ def _run_baseline_compare(
         None,
         None,
     )
-    diff = compare(
+    diff = compare_snapshots(
         old_snap,
         new_snap,
         extra_changes=merged_extra,

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -875,6 +875,10 @@ def run_compare_request(
         SnapshotError: If either input cannot be loaded.
     """
     request.validate()
+    # ``validate()`` accepts the language case-insensitively, but the ELF dump
+    # path does case-sensitive ``lang == "c"`` checks — normalise so an accepted
+    # ``"C"`` is not silently treated as C++.
+    lang = request.lang.lower()
 
     old_fmt = detect_binary_format(request.old.path)
     new_fmt = detect_binary_format(request.new.path)
@@ -884,7 +888,7 @@ def run_compare_request(
         list(request.old.headers),
         list(request.old.includes),
         request.old.version,
-        request.lang,
+        lang,
         is_elf=True if old_fmt == "elf" else None,
         pdb_path=request.old.pdb,
         debug_roots=list(request.old.debug_roots) or None,
@@ -895,7 +899,7 @@ def run_compare_request(
         list(request.new.headers),
         list(request.new.includes),
         request.new.version,
-        request.lang,
+        lang,
         is_elf=True if new_fmt == "elf" else None,
         pdb_path=request.new.pdb,
         debug_roots=list(request.new.debug_roots) or None,

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -30,6 +30,7 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .api_types import CompareRequest, InputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .errors import AbicheckError, SnapshotError, ValidationError
@@ -40,6 +41,7 @@ from .serialization import load_snapshot
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from .checker_types import Change
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
     from .policy_file import PolicyFile
@@ -817,6 +819,109 @@ def load_suppression_and_policy(
     return suppression, pf
 
 
+def compare_snapshots(
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    suppression: SuppressionList | None = None,
+    *,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+    scope_to_public_surface: bool = True,
+    force_public_symbols: set[str] | None = None,
+    extra_changes: list[Change] | None = None,
+    pattern_verdicts: bool = False,
+    surface_metrics: bool = False,
+    collapse_versioned_symbols: bool = False,
+) -> DiffResult:
+    """Classify two already-resolved snapshots — the Tier-2 snapshot verb.
+
+    Thin wrapper over the Tier-1 core (:func:`abicheck.checker.compare`) so that
+    *front-ends never call the core directly* (ADR-037 D1/D10.1). Front-ends
+    that have already resolved their own snapshots (the native ``compare``
+    command with embedded build-source evidence, ``scan``, ``appcompat``) route
+    through here instead of importing ``checker.compare``; the kwargs mirror the
+    core verb exactly so no capability is lost.
+    """
+    return compare(
+        old,
+        new,
+        suppression=suppression,
+        policy=policy,
+        policy_file=policy_file,
+        scope_to_public_surface=scope_to_public_surface,
+        force_public_symbols=force_public_symbols,
+        extra_changes=extra_changes,
+        pattern_verdicts=pattern_verdicts,
+        surface_metrics=surface_metrics,
+        collapse_versioned_symbols=collapse_versioned_symbols,
+    )
+
+
+def run_compare_request(
+    request: CompareRequest,
+) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+    """Compare two ABI inputs described by a :class:`CompareRequest`.
+
+    The single classification chokepoint (ADR-037 D1/D2): every front-end builds
+    a ``CompareRequest`` and calls this, so defaults cannot diverge between
+    invocation paths. The legacy keyword-argument :func:`run_compare` is a thin
+    shim that builds the request and delegates here.
+
+    Returns:
+        A tuple of (DiffResult, old_snapshot, new_snapshot).
+
+    Raises:
+        ValidationError: If the request fails :meth:`CompareRequest.validate`.
+        SnapshotError: If either input cannot be loaded.
+    """
+    request.validate()
+
+    old_fmt = detect_binary_format(request.old.path)
+    new_fmt = detect_binary_format(request.new.path)
+
+    old = resolve_input(
+        request.old.path,
+        list(request.old.headers),
+        list(request.old.includes),
+        request.old.version,
+        request.lang,
+        is_elf=True if old_fmt == "elf" else None,
+        pdb_path=request.old.pdb,
+        debug_roots=list(request.old.debug_roots) or None,
+        enable_debuginfod=request.enable_debuginfod,
+    )
+    new = resolve_input(
+        request.new.path,
+        list(request.new.headers),
+        list(request.new.includes),
+        request.new.version,
+        request.lang,
+        is_elf=True if new_fmt == "elf" else None,
+        pdb_path=request.new.pdb,
+        debug_roots=list(request.new.debug_roots) or None,
+        enable_debuginfod=request.enable_debuginfod,
+    )
+
+    suppression, pf = load_suppression_and_policy(
+        request.suppress, request.policy, request.policy_file_path
+    )
+    result = compare_snapshots(
+        old,
+        new,
+        suppression=suppression,
+        policy=request.policy,
+        policy_file=pf,
+        scope_to_public_surface=request.scope_public,
+        force_public_symbols=(
+            set(request.force_public_symbols) if request.force_public_symbols else None
+        ),
+        pattern_verdicts=request.pattern_verdicts,
+    )
+    result.old_metadata = collect_metadata(request.old.path)
+    result.new_metadata = collect_metadata(request.new.path)
+    return result, old, new
+
+
 def run_compare(
     old_input: Path,
     new_input: Path,
@@ -837,14 +942,14 @@ def run_compare(
     enable_debuginfod: bool = False,
     scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
+    pattern_verdicts: bool = False,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Compare two ABI inputs and return the classified diff result.
 
-    This is the main entry point for programmatic comparison. It handles:
-    - Input format detection and snapshot loading
-    - Suppression and policy file loading
-    - Running the comparison
-    - Collecting library metadata
+    Keyword-argument shim over :func:`run_compare_request`: it assembles a
+    :class:`CompareRequest` from loose arguments and delegates, so existing
+    callers keep working while the typed request is the real chokepoint
+    (ADR-037 D2). New callers should build a ``CompareRequest`` directly.
 
     Returns:
         A tuple of (DiffResult, old_snapshot, new_snapshot).
@@ -853,50 +958,35 @@ def run_compare(
         SnapshotError: If either input cannot be loaded.
         ValidationError: If inputs have unrecognised formats.
     """
-    _old_headers = old_headers or []
-    _new_headers = new_headers or []
-    _old_includes = old_includes or []
-    _new_includes = new_includes or []
-
-    old_fmt = detect_binary_format(old_input)
-    new_fmt = detect_binary_format(new_input)
-
-    old = resolve_input(
-        old_input,
-        _old_headers,
-        _old_includes,
-        old_version,
-        lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=old_pdb_path,
-        debug_roots=old_debug_roots,
-        enable_debuginfod=enable_debuginfod,
-    )
-    new = resolve_input(
-        new_input,
-        _new_headers,
-        _new_includes,
-        new_version,
-        lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=new_pdb_path,
-        debug_roots=new_debug_roots,
-        enable_debuginfod=enable_debuginfod,
-    )
-
-    suppression, pf = load_suppression_and_policy(suppress, policy, policy_file_path)
-    result = compare(
-        old,
-        new,
-        suppression=suppression,
+    request = CompareRequest(
+        old=InputSpec(
+            path=old_input,
+            headers=tuple(old_headers or ()),
+            includes=tuple(old_includes or ()),
+            version=old_version,
+            pdb=old_pdb_path,
+            debug_roots=tuple(old_debug_roots or ()),
+        ),
+        new=InputSpec(
+            path=new_input,
+            headers=tuple(new_headers or ()),
+            includes=tuple(new_includes or ()),
+            version=new_version,
+            pdb=new_pdb_path,
+            debug_roots=tuple(new_debug_roots or ()),
+        ),
+        lang=lang,
         policy=policy,
-        policy_file=pf,
-        scope_to_public_surface=scope_to_public_surface,
-        force_public_symbols=force_public_symbols,
+        policy_file_path=policy_file_path,
+        suppress=suppress,
+        scope_public=scope_to_public_surface,
+        force_public_symbols=(
+            frozenset(force_public_symbols) if force_public_symbols else None
+        ),
+        pattern_verdicts=pattern_verdicts,
+        enable_debuginfod=enable_debuginfod,
     )
-    result.old_metadata = collect_metadata(old_input)
-    result.new_metadata = collect_metadata(new_input)
-    return result, old, new
+    return run_compare_request(request)
 
 
 # ── Output rendering ────────────────────────────────────────────────────────
@@ -1076,11 +1166,14 @@ from .service_scan import (  # noqa: E402,F401
 # ``from abicheck.service import ...``.
 __all__ = [
     "Budget",
+    "CompareRequest",
     "CostEstimate",
+    "InputSpec",
     "LayerResult",
     "ScanRequest",
     "ScanResult",
     "collect_metadata",
+    "compare_snapshots",
     "detect_binary_format",
     "estimate_scan",
     "expand_header_inputs",
@@ -1089,6 +1182,7 @@ __all__ = [
     "resolve_input",
     "run_audit",
     "run_compare",
+    "run_compare_request",
     "run_dump",
     "run_scan",
     "run_scan_subprocess",

--- a/docs/development/plans/g22-cli-consolidation.md
+++ b/docs/development/plans/g22-cli-consolidation.md
@@ -77,6 +77,15 @@ Each phase = one PR. Sub-structure: **Work** · **Tests** · **Risk & rollback**
 
 ### Phase 1 — Typed requests + single chokepoint (D1, D2)
 
+**Status: landed.** `abicheck/api_types.py` ships `InputSpec`/`CompareRequest`
+(`validate()`)/`OutputSpec`; `service.run_compare` is a kwargs shim over
+`run_compare_request(CompareRequest)`, and the new Tier-2 `service.compare_snapshots`
+wraps `checker.compare` so every front-end (`compare`, `compare-release`,
+`scan`, `appcompat`) routes through Tier 2 — no `cli*.py` calls `checker.compare`
+directly. Enforced by the `cli-contract` AI-readiness check (D10.1) and mirrored
+in `tests/test_cli_contract.py`; `tests/test_api_types.py` covers the request
+struct. The remaining phases (2–7) are still open.
+
 **Work.** Add `api_types.py` (`InputSpec`, `CompareRequest`+`validate()`,
 `OutputSpec`); struct fields via `field(default_factory=...)` (a frozen
 dataclass still shares one import-time default otherwise). Refactor

--- a/docs/development/plans/g22-cli-consolidation.md
+++ b/docs/development/plans/g22-cli-consolidation.md
@@ -260,8 +260,10 @@ The "~62 → ~20 flags" and "no divergence" claims are testable, not aspirationa
 
 ## Definition of done (when implementation lands)
 
-This is a docs-only PR; G22 stays `planned` and ADR-037 stays `Proposed` until
-the work below merges. The gap is considered closed only once registry
-`UC-WF-cli-contract` can flip to `complete` with evidence pointing at
-`api_types.py`, the `cli-contract` gate, `tests/test_cli_contract.py`, and the
-alias/round-trip tests — at which point ADR-037 moves to Accepted — implemented.
+Phase 1 has landed (`api_types.py`, the single `service` chokepoint, the
+`cli-contract` gate, and `tests/test_cli_contract.py`); G22 stays **in
+progress** and ADR-037 stays `Proposed` until the remaining phases (2–7) merge.
+The gap is considered closed only once registry `UC-WF-cli-contract` can flip to
+`complete` with evidence pointing at `api_types.py`, the `cli-contract` gate,
+`tests/test_cli_contract.py`, and the alias/round-trip tests — at which point
+ADR-037 moves to Accepted — implemented.

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -627,6 +627,14 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         # `cli_buildsource` (size-split per CLAUDE.md); they reuse `cli_resolve` /
         # `service` collectors and are re-exported back by their parent, so they join
         # the same by-design cluster (the package imports cleanly — no init deadlock).
+        #
+        # ADR-037 D1 (G22 Phase 1) widens this cluster: the verdict-emitting
+        # front-ends now route through the Tier-2 service instead of calling
+        # `checker.compare` directly. `cli_compare_release` and `appcompat` reach
+        # `service` via *function-local* imports (`service.run_compare` /
+        # `service.compare_snapshots`), and `cli` registers them (and `cli_plugin`)
+        # at its module-load tail — so they close the same SCC through lazy edges,
+        # never an init cycle.
         frozenset(
             {
                 "cli",
@@ -634,6 +642,9 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 "cli_surface",
                 "cli_buildsource",
                 "cli_scan",
+                "cli_compare_release",
+                "cli_plugin",
+                "appcompat",
                 "service",
                 "service_scan",
                 "cli_helpers_compare",
@@ -1090,6 +1101,76 @@ def check_banned_imports(f: Findings) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Check: CLI interface contract (ADR-037 D10.1)
+# ---------------------------------------------------------------------------
+
+# Tier-1 core entry points a front-end must never call directly — it must route
+# through the Tier-2 service layer (``service.run_compare`` /
+# ``service.compare_snapshots``). ADR-037 D1/D10.1.
+_TIER1_CORE_FUNCS: frozenset[str] = frozenset({"compare"})
+
+# ``"<rel-path>:<lineno>"`` call sites deliberately exempted, each needing a
+# reason in review. Empty by design — a new exemption is a reviewed decision,
+# not an accident (mirrors the INTENTIONAL_SUBSET philosophy of D10.2).
+CLI_CONTRACT_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _checker_compare_bindings(tree: ast.Module) -> set[str]:
+    """Return the local names bound to ``checker.compare`` via import in *tree*.
+
+    Handles ``from .checker import compare`` and ``... import compare as X`` at
+    module or function scope, so a lazily-imported alias is caught too.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and node.module.split(".")[-1] == "checker"
+        ):
+            for alias in node.names:
+                if alias.name in _TIER1_CORE_FUNCS:
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def check_cli_contract(f: Findings) -> None:
+    """ERROR if a front-end ``cli*.py`` module calls a Tier-1 core entry point
+    (``checker.compare``) directly instead of routing through the Tier-2 service.
+
+    ADR-037 D1/D10.1: front-ends are thin adapters; one classification path is
+    what keeps ``compare`` / ``compare-release`` / ``appcompat`` / MCP from
+    drifting apart (the ``scope_public`` default divergence the ADR documents).
+    Importing a ``checker`` *type* for annotations or result-rendering stays
+    legal — the gate keys on the *call expression*, not the import statement.
+    """
+    for path in sorted(PKG.glob("cli*.py")):
+        rel = _rel(path)
+        try:
+            tree = ast.parse(_read(path), filename=rel)
+        except SyntaxError:
+            continue
+        bound = _checker_compare_bindings(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_tier1 = (isinstance(func, ast.Name) and func.id in bound) or (
+                isinstance(func, ast.Attribute)
+                and func.attr in _TIER1_CORE_FUNCS
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "checker"
+            )
+            if is_tier1 and f"{rel}:{node.lineno}" not in CLI_CONTRACT_ALLOWLIST:
+                f.err(
+                    "cli-contract",
+                    f"{rel}:{node.lineno}: front-end calls Tier-1 `checker.compare` "
+                    "directly; route through `service.run_compare` / "
+                    "`service.compare_snapshots` (ADR-037 D1/D10.1)",
+                )
+
+
+# ---------------------------------------------------------------------------
 # Check: test assertion density (coverage-honesty guard)
 # ---------------------------------------------------------------------------
 
@@ -1246,6 +1327,7 @@ CHECKS: dict[str, Callable[[Findings], None]] = {
     "examples-readme-sync": check_examples_readme_sync,
     "mkdocs-nav-coverage": check_mkdocs_nav_coverage,
     "banned-imports": check_banned_imports,
+    "cli-contract": check_cli_contract,
     "license-header": check_license_header,
     "test-assertion-density": check_test_assertion_density,
 }

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -632,23 +632,38 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         # front-ends now route through the Tier-2 service instead of calling
         # `checker.compare` directly. `cli_compare_release` and `appcompat` reach
         # `service` via *function-local* imports (`service.run_compare` /
-        # `service.compare_snapshots`), and `cli` registers them (and `cli_plugin`)
-        # at its module-load tail — so they close the same SCC through lazy edges,
-        # never an init cycle.
+        # `service.compare_snapshots`); `cli` registers every sibling command at its
+        # module-load tail; and each sibling imports `main`/helpers back from `cli`.
+        # That collapses the whole CLI-registration + service-routing graph into ONE
+        # strongly-connected component. The members below are the *exact* SCC (it
+        # closes only through function-local imports — the package imports cleanly,
+        # no init deadlock), so listing the full set makes the subset match robust to
+        # the DFS traversal order, which otherwise surfaces a different representative
+        # simple cycle on each platform (e.g. via `cli_appcompat` vs `cli_plugin`).
+        # A genuinely new bad cycle would pull in a module *outside* this SCC and so
+        # would not be a subset — still flagged.
         frozenset(
             {
-                "cli",
-                "cli_resolve",
-                "cli_surface",
-                "cli_buildsource",
-                "cli_scan",
-                "cli_compare_release",
-                "cli_plugin",
                 "appcompat",
+                "cli",
+                "cli_appcompat",
+                "cli_baseline",
+                "cli_buildsource",
+                "cli_buildsource_helpers",
+                "cli_compare_release",
+                "cli_debian_symbols",
+                "cli_helpers_compare",
+                "cli_max",
+                "cli_plugin",
+                "cli_pr_comment",
+                "cli_probe",
+                "cli_resolve",
+                "cli_scan",
+                "cli_stack",
+                "cli_suggest",
+                "cli_surface",
                 "service",
                 "service_scan",
-                "cli_helpers_compare",
-                "cli_buildsource_helpers",
             }
         ),
         # TYPE_CHECKING-only typing cycle (no runtime import): AbiSnapshot

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1149,23 +1149,61 @@ def _checker_compare_bindings(tree: ast.Module) -> set[str]:
     return names
 
 
+def _checker_module_bindings(tree: ast.Module) -> set[str]:
+    """Return local names bound to the ``checker`` *module* itself.
+
+    Catches ``from . import checker [as X]`` / ``from abicheck import checker
+    [as X]`` and ``import abicheck.checker as X``, so an aliased
+    ``core.compare(...)`` call is recognised, not just the literal
+    ``checker.compare(...)``.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # ``from . import checker`` (module is None) or ``from abicheck import checker``.
+            if node.module is None or node.module.split(".")[-1] == "abicheck":
+                for alias in node.names:
+                    if alias.name == "checker":
+                        names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[-1] == "checker":
+                    # ``import abicheck.checker`` binds ``abicheck``; only an
+                    # explicit ``as X`` gives a usable ``X.compare`` call name.
+                    if alias.asname:
+                        names.add(alias.asname)
+    return names
+
+
+def _iter_cli_contract_sources() -> Iterable[Path]:
+    """The front-end modules the contract covers: every ``cli*.py`` plus the
+    consumer-side ``appcompat.py`` (it is a verdict-emitting front-end too)."""
+    yield from PKG.glob("cli*.py")
+    appcompat = PKG / "appcompat.py"
+    if appcompat.is_file():
+        yield appcompat
+
+
 def check_cli_contract(f: Findings) -> None:
-    """ERROR if a front-end ``cli*.py`` module calls a Tier-1 core entry point
+    """ERROR if a front-end module calls a Tier-1 core entry point
     (``checker.compare``) directly instead of routing through the Tier-2 service.
 
-    ADR-037 D1/D10.1: front-ends are thin adapters; one classification path is
-    what keeps ``compare`` / ``compare-release`` / ``appcompat`` / MCP from
-    drifting apart (the ``scope_public`` default divergence the ADR documents).
-    Importing a ``checker`` *type* for annotations or result-rendering stays
-    legal — the gate keys on the *call expression*, not the import statement.
+    Covers every ``abicheck/cli*.py`` and ``abicheck/appcompat.py``. ADR-037
+    D1/D10.1: front-ends are thin adapters; one classification path is what keeps
+    ``compare`` / ``compare-release`` / ``appcompat`` / MCP from drifting apart
+    (the ``scope_public`` default divergence the ADR documents). Importing a
+    ``checker`` *type* for annotations or result-rendering stays legal — the gate
+    keys on the *call expression*, not the import statement. Both a direct
+    ``compare`` import and an aliased ``checker``-module call are detected.
     """
-    for path in sorted(PKG.glob("cli*.py")):
+    for path in sorted(_iter_cli_contract_sources()):
         rel = _rel(path)
         try:
             tree = ast.parse(_read(path), filename=rel)
         except SyntaxError:
             continue
         bound = _checker_compare_bindings(tree)
+        checker_modules = _checker_module_bindings(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -1174,7 +1212,7 @@ def check_cli_contract(f: Findings) -> None:
                 isinstance(func, ast.Attribute)
                 and func.attr in _TIER1_CORE_FUNCS
                 and isinstance(func.value, ast.Name)
-                and func.value.id == "checker"
+                and func.value.id in checker_modules
             )
             if is_tier1 and f"{rel}:{node.lineno}" not in CLI_CONTRACT_ALLOWLIST:
                 f.err(

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -33,6 +33,15 @@ class TestInputSpec:
         assert spec.headers == (Path("a.h"), Path("b.h"))
         assert spec.includes == (Path("inc"),)
 
+    def test_of_single_string_is_one_path_not_per_character(self):
+        # A bare string must be one path, not a tuple of per-character paths.
+        spec = InputSpec.of("lib.so", headers="include/api.h")
+        assert spec.headers == (Path("include/api.h"),)
+
+    def test_of_single_path_is_one_path(self):
+        spec = InputSpec.of("lib.so", includes=Path("inc"))
+        assert spec.includes == (Path("inc"),)
+
     def test_of_defaults_are_empty_tuples(self):
         spec = InputSpec.of("lib.so")
         assert spec.headers == ()

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the typed Tier-2 request structs (ADR-037 D2 / G22 Phase 1)."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from abicheck.api_types import CompareRequest, InputSpec, OutputSpec
+from abicheck.errors import ValidationError
+
+
+class TestInputSpec:
+    def test_of_coerces_str_to_path(self):
+        spec = InputSpec.of("lib.so", headers=["a.h", "b.h"], includes=["inc"])
+        assert spec.path == Path("lib.so")
+        assert spec.headers == (Path("a.h"), Path("b.h"))
+        assert spec.includes == (Path("inc"),)
+
+    def test_of_defaults_are_empty_tuples(self):
+        spec = InputSpec.of("lib.so")
+        assert spec.headers == ()
+        assert spec.includes == ()
+        assert spec.debug_roots == ()
+        assert spec.pdb is None
+        assert spec.version == ""
+
+    def test_of_pdb_coerced(self):
+        spec = InputSpec.of("lib.so", pdb="lib.pdb", debug_roots=["dbg"])
+        assert spec.pdb == Path("lib.pdb")
+        assert spec.debug_roots == (Path("dbg"),)
+
+    def test_is_frozen(self):
+        spec = InputSpec.of("lib.so")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            spec.path = Path("other.so")  # type: ignore[misc]
+
+
+class TestCompareRequestDefaults:
+    def test_scope_public_defaults_true(self):
+        # The headline drift fix: one default for every front-end (ADR-037 §Context #1).
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        assert req.scope_public is True
+
+    def test_other_defaults(self):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        assert req.lang == "c++"
+        assert req.policy == "strict_abi"
+        assert req.policy_file_path is None
+        assert req.suppress is None
+        assert req.force_public_symbols is None
+        assert req.pattern_verdicts is False
+        assert req.enable_debuginfod is False
+
+    def test_is_frozen(self):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            req.scope_public = False  # type: ignore[misc]
+
+    def test_distinct_instances_do_not_share_defaults(self):
+        # A frozen dataclass with a bare mutable default would share it across
+        # instances; the struct fields here are immutable, so this must hold.
+        a = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        c = CompareRequest(old=InputSpec.of("c"), new=InputSpec.of("d"))
+        assert a.old is not c.old
+        assert a.old.headers == c.old.headers == ()
+
+
+class TestCompareRequestValidate:
+    def test_valid_request_has_no_errors(self):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        assert req.validation_errors() == []
+        assert req.validate() is req
+
+    @pytest.mark.parametrize("lang", ["c", "c++", "C", "C++"])
+    def test_supported_langs_accepted(self, lang):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"), lang=lang)
+        assert req.validation_errors() == []
+
+    def test_unsupported_lang_rejected(self):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"), lang="rust")
+        errors = req.validation_errors()
+        assert len(errors) == 1
+        assert "rust" in errors[0]
+        with pytest.raises(ValidationError, match="rust"):
+            req.validate()
+
+    def test_empty_policy_rejected(self):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"), policy="")
+        assert any("policy" in e for e in req.validation_errors())
+
+    def test_multiple_errors_collected(self):
+        req = CompareRequest(
+            old=InputSpec.of("a"), new=InputSpec.of("b"), lang="go", policy=""
+        )
+        assert len(req.validation_errors()) == 2
+
+
+class TestCompareRequestReplace:
+    def test_replace_round_trips_fields(self):
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        changed = req.replace(scope_public=False, lang="c")
+        assert changed.scope_public is False
+        assert changed.lang == "c"
+        # Original is untouched (frozen + copy semantics).
+        assert req.scope_public is True
+        assert req.lang == "c++"
+        # Unchanged fields are carried over verbatim.
+        assert changed.old is req.old
+        assert changed.policy == req.policy
+
+
+class TestOutputSpec:
+    def test_defaults(self):
+        out = OutputSpec()
+        assert out.fmt == "text"
+        assert out.path is None
+
+    def test_is_frozen(self):
+        out = OutputSpec(fmt="json")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            out.fmt = "sarif"  # type: ignore[misc]

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -1255,7 +1255,7 @@ class TestCheckAppcompat:
             patch("abicheck.appcompat._get_lib_soname", return_value=soname),
             patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
             patch("abicheck.dumper.dump", return_value=MagicMock()),
-            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.service.compare_snapshots", return_value=diff),
             patch("abicheck.appcompat._get_new_lib_exports", return_value=new_exports),
             patch("abicheck.appcompat._detect_app_format", return_value=None),
         ]
@@ -1430,7 +1430,7 @@ class TestCheckAppcompat:
             patch("abicheck.appcompat._get_lib_soname", return_value="libfoo.so"),
             patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
             patch("abicheck.dumper.dump", return_value=MagicMock()),
-            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.service.compare_snapshots", return_value=diff),
             patch("abicheck.appcompat._get_new_lib_exports", return_value=new_exports),
             patch("abicheck.appcompat._detect_app_format", return_value="elf"),
             patch("abicheck.elf_metadata.parse_elf_metadata", return_value=elf_meta),
@@ -1454,7 +1454,7 @@ class TestCheckAppcompat:
             patch("abicheck.appcompat._get_lib_soname", return_value="libfoo.so"),
             patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs),
             patch("abicheck.dumper.dump", return_value=MagicMock()) as mock_dump,
-            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.service.compare_snapshots", return_value=diff),
             patch("abicheck.appcompat._get_new_lib_exports", return_value=new_exports),
             patch("abicheck.appcompat._detect_app_format", return_value=None),
         ):
@@ -1481,7 +1481,7 @@ class TestCheckAppcompat:
             patch("abicheck.appcompat._detect_app_format", return_value="elf"),
             patch("abicheck.appcompat._get_old_lib_exports_for_scoping", return_value={"inflate"}),
             patch("abicheck.dumper.dump", return_value=MagicMock()),
-            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.service.compare_snapshots", return_value=diff),
             patch("abicheck.appcompat._get_new_lib_exports", return_value={"inflate"}),
             patch("abicheck.elf_metadata.parse_elf_metadata", return_value=SimpleNamespace(versions_defined=[])),
         ):
@@ -1506,7 +1506,7 @@ class TestCheckAppcompat:
             patch("abicheck.appcompat._detect_app_format", return_value="elf"),
             patch("abicheck.appcompat._get_old_lib_exports_for_scoping", return_value={"inflate"}),
             patch("abicheck.dumper.dump", return_value=MagicMock()),
-            patch("abicheck.appcompat.compare", return_value=diff),
+            patch("abicheck.service.compare_snapshots", return_value=diff),
             patch("abicheck.appcompat._get_new_lib_exports", return_value={"inflate"}),
             patch("abicheck.elf_metadata.parse_elf_metadata", return_value=SimpleNamespace(versions_defined=[])),
         ):

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI interface-contract gate mirror + chokepoint parity (ADR-037 / G22 Phase 1).
+
+This is the unit-test mirror of the ``cli-contract`` AI-readiness check
+(``scripts/check_ai_readiness.py``), so the contract is enforced both as a fast
+CI gate and in the regular test suite. It also pins the *behavioural* payoff of
+the single chokepoint: ``compare-release`` and ``service.run_compare`` classify
+a given pair identically (no ``scope_public`` default drift).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import the gate from scripts/ — the AI-readiness module is pure stdlib.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from abicheck.model import AbiSnapshot, Function, Visibility  # noqa: E402
+from abicheck.serialization import save_snapshot  # noqa: E402
+from scripts.check_ai_readiness import Findings, check_cli_contract  # noqa: E402
+
+# ── D10.1: no front-end skips the Tier-2 service ─────────────────────────────
+
+
+def test_no_tier_skip():
+    """No ``abicheck/cli*.py`` module calls Tier-1 ``checker.compare`` directly.
+
+    Front-ends must route through ``service.run_compare`` /
+    ``service.compare_snapshots`` (ADR-037 D1/D10.1).
+    """
+    findings = Findings()
+    check_cli_contract(findings)
+    contract_errors = [m for c, m in findings.errors if c == "cli-contract"]
+    assert contract_errors == [], "Tier-1 call sites in front-ends:\n" + "\n".join(
+        contract_errors
+    )
+
+
+def test_gate_flags_a_planted_violation(tmp_path, monkeypatch):
+    """The gate is not a no-op: a planted direct ``compare`` call is caught."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_bad.py").write_text(
+        "from .checker import compare\ndef go(a, b):\n    return compare(a, b)\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    errors = [m for c, m in findings.errors if c == "cli-contract"]
+    assert len(errors) == 1
+    assert "cli_bad.py" in errors[0]
+
+
+def test_gate_allows_aliased_import_call(tmp_path, monkeypatch):
+    """An aliased lazy import (``compare as _compare``) is still caught."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_alias.py").write_text(
+        "def go(a, b):\n"
+        "    from .checker import compare as _compare\n"
+        "    return _compare(a, b)\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    assert any(c == "cli-contract" for c, _ in findings.errors)
+
+
+def test_service_compare_call_is_not_flagged(tmp_path, monkeypatch):
+    """Routing through ``service.compare_snapshots`` must NOT be flagged."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_ok.py").write_text(
+        "from .service import compare_snapshots\n"
+        "def go(a, b):\n"
+        "    return compare_snapshots(a, b)\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    assert not any(c == "cli-contract" for c, _ in findings.errors)
+
+
+# ── Chokepoint parity: one classifier, no scope_public drift ─────────────────
+
+
+def _make_snap_file(tmp_path: Path, name: str, version: str, funcs) -> Path:
+    snap = AbiSnapshot(library=name, version=version, functions=funcs)
+    p = tmp_path / f"{name}_{version}.json"
+    save_snapshot(snap, p)
+    return p
+
+
+def _func(name: str) -> Function:
+    return Function(
+        name=name,
+        mangled=name,
+        return_type="int",
+        visibility=Visibility.PUBLIC,
+        is_extern_c=True,
+    )
+
+
+def test_compare_release_matches_service_run_compare(tmp_path):
+    """``compare-release``'s per-pair runner classifies identically to
+    ``service.run_compare`` — they share the one chokepoint (ADR-037 D1)."""
+    from abicheck import service
+    from abicheck.cli_compare_release import _run_compare_pair
+
+    old_p = _make_snap_file(tmp_path, "libfoo", "1.0", [_func("foo"), _func("bar")])
+    new_p = _make_snap_file(tmp_path, "libfoo", "2.0", [_func("foo")])
+
+    svc_result, _, _ = service.run_compare(old_p, new_p, scope_to_public_surface=True)
+    rel_result, _, _ = _run_compare_pair(
+        old_p,
+        new_p,
+        old_headers=[],
+        new_headers=[],
+        old_includes=[],
+        new_includes=[],
+        old_version="",
+        new_version="",
+        lang="c++",
+        suppress=None,
+        policy="strict_abi",
+        policy_file_path=None,
+        old_pdb_path=None,
+        new_pdb_path=None,
+        scope_to_public_surface=True,
+    )
+
+    assert svc_result.verdict == rel_result.verdict
+    assert sorted(c.kind for c in svc_result.breaking) == sorted(
+        c.kind for c in rel_result.breaking
+    )
+    assert sorted(c.kind for c in svc_result.source_breaks) == sorted(
+        c.kind for c in rel_result.source_breaks
+    )
+    assert sorted(c.kind for c in svc_result.compatible) == sorted(
+        c.kind for c in rel_result.compatible
+    )
+
+
+def test_run_compare_request_equivalent_to_kwargs_shim(tmp_path):
+    """The kwargs ``run_compare`` shim and a hand-built ``CompareRequest`` agree."""
+    from abicheck.api_types import CompareRequest, InputSpec
+    from abicheck.service import run_compare, run_compare_request
+
+    old_p = _make_snap_file(tmp_path, "libbar", "1.0", [_func("a"), _func("b")])
+    new_p = _make_snap_file(tmp_path, "libbar", "2.0", [_func("a")])
+
+    shim_result, _, _ = run_compare(old_p, new_p)
+    req = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
+    req_result, _, _ = run_compare_request(req)
+
+    assert shim_result.verdict == req_result.verdict
+    assert sorted(c.kind for c in shim_result.breaking) == sorted(
+        c.kind for c in req_result.breaking
+    )

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -91,6 +91,42 @@ def test_gate_allows_aliased_import_call(tmp_path, monkeypatch):
     assert any(c == "cli-contract" for c, _ in findings.errors)
 
 
+def test_gate_flags_module_alias_call(tmp_path, monkeypatch):
+    """An aliased ``checker`` module call (``core.compare(...)``) is caught."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_modalias.py").write_text(
+        "from . import checker as core\ndef go(a, b):\n    return core.compare(a, b)\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    assert any(c == "cli-contract" for c, _ in findings.errors)
+
+
+def test_gate_covers_appcompat(tmp_path, monkeypatch):
+    """``appcompat.py`` is in scope even though it is not a ``cli*.py`` file."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "appcompat.py").write_text(
+        "from .checker import compare\ndef check(a, b):\n    return compare(a, b)\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    errors = [m for c, m in findings.errors if c == "cli-contract"]
+    assert len(errors) == 1
+    assert "appcompat.py" in errors[0]
+
+
 def test_service_compare_call_is_not_flagged(tmp_path, monkeypatch):
     """Routing through ``service.compare_snapshots`` must NOT be flagged."""
     import scripts.check_ai_readiness as gate

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 # Import the gate from scripts/ — the AI-readiness module is pure stdlib.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
@@ -53,70 +55,44 @@ def test_no_tier_skip():
     )
 
 
-def test_gate_flags_a_planted_violation(tmp_path, monkeypatch):
-    """The gate is not a no-op: a planted direct ``compare`` call is caught."""
-    import scripts.check_ai_readiness as gate
-
-    pkg = tmp_path / "abicheck"
-    pkg.mkdir()
-    (pkg / "cli_bad.py").write_text(
-        "from .checker import compare\ndef go(a, b):\n    return compare(a, b)\n"
-    )
-    monkeypatch.setattr(gate, "PKG", pkg)
-    monkeypatch.setattr(gate, "ROOT", tmp_path)
-
-    findings = gate.Findings()
-    gate.check_cli_contract(findings)
-    errors = [m for c, m in findings.errors if c == "cli-contract"]
-    assert len(errors) == 1
-    assert "cli_bad.py" in errors[0]
-
-
-def test_gate_allows_aliased_import_call(tmp_path, monkeypatch):
-    """An aliased lazy import (``compare as _compare``) is still caught."""
-    import scripts.check_ai_readiness as gate
-
-    pkg = tmp_path / "abicheck"
-    pkg.mkdir()
-    (pkg / "cli_alias.py").write_text(
+# Each case plants one front-end module that reaches Tier-1 `checker.compare`
+# a different way; the gate must flag exactly one violation naming that file.
+# (filename, source) — covers: direct import, aliased lazy `compare` import,
+# aliased `checker` *module* call, and the non-`cli*.py` `appcompat.py` scope.
+_GATE_VIOLATION_CASES = [
+    pytest.param(
+        "cli_bad.py",
+        "from .checker import compare\ndef go(a, b):\n    return compare(a, b)\n",
+        id="direct-import",
+    ),
+    pytest.param(
+        "cli_alias.py",
         "def go(a, b):\n"
         "    from .checker import compare as _compare\n"
-        "    return _compare(a, b)\n"
-    )
-    monkeypatch.setattr(gate, "PKG", pkg)
-    monkeypatch.setattr(gate, "ROOT", tmp_path)
+        "    return _compare(a, b)\n",
+        id="aliased-lazy-import",
+    ),
+    pytest.param(
+        "cli_modalias.py",
+        "from . import checker as core\ndef go(a, b):\n    return core.compare(a, b)\n",
+        id="aliased-module-call",
+    ),
+    pytest.param(
+        "appcompat.py",
+        "from .checker import compare\ndef check(a, b):\n    return compare(a, b)\n",
+        id="appcompat-in-scope",
+    ),
+]
 
-    findings = gate.Findings()
-    gate.check_cli_contract(findings)
-    assert any(c == "cli-contract" for c, _ in findings.errors)
 
-
-def test_gate_flags_module_alias_call(tmp_path, monkeypatch):
-    """An aliased ``checker`` module call (``core.compare(...)``) is caught."""
+@pytest.mark.parametrize("filename, source", _GATE_VIOLATION_CASES)
+def test_gate_flags_violation(tmp_path, monkeypatch, filename, source):
+    """The gate is not a no-op: each way of reaching Tier-1 is caught once."""
     import scripts.check_ai_readiness as gate
 
     pkg = tmp_path / "abicheck"
     pkg.mkdir()
-    (pkg / "cli_modalias.py").write_text(
-        "from . import checker as core\ndef go(a, b):\n    return core.compare(a, b)\n"
-    )
-    monkeypatch.setattr(gate, "PKG", pkg)
-    monkeypatch.setattr(gate, "ROOT", tmp_path)
-
-    findings = gate.Findings()
-    gate.check_cli_contract(findings)
-    assert any(c == "cli-contract" for c, _ in findings.errors)
-
-
-def test_gate_covers_appcompat(tmp_path, monkeypatch):
-    """``appcompat.py`` is in scope even though it is not a ``cli*.py`` file."""
-    import scripts.check_ai_readiness as gate
-
-    pkg = tmp_path / "abicheck"
-    pkg.mkdir()
-    (pkg / "appcompat.py").write_text(
-        "from .checker import compare\ndef check(a, b):\n    return compare(a, b)\n"
-    )
+    (pkg / filename).write_text(source)
     monkeypatch.setattr(gate, "PKG", pkg)
     monkeypatch.setattr(gate, "ROOT", tmp_path)
 
@@ -124,7 +100,7 @@ def test_gate_covers_appcompat(tmp_path, monkeypatch):
     gate.check_cli_contract(findings)
     errors = [m for c, m in findings.errors if c == "cli-contract"]
     assert len(errors) == 1
-    assert "appcompat.py" in errors[0]
+    assert filename in errors[0]
 
 
 def test_service_compare_call_is_not_flagged(tmp_path, monkeypatch):

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -207,3 +207,34 @@ def test_run_compare_request_equivalent_to_kwargs_shim(tmp_path: Path) -> None:
     assert sorted(c.kind for c in shim_result.breaking) == sorted(
         c.kind for c in req_result.breaking
     )
+
+
+def test_run_compare_request_normalizes_lang(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An accepted upper-case ``lang`` is lowered before snapshot resolution.
+
+    ``validate()`` accepts ``"C"`` case-insensitively, but the ELF dump path
+    does case-sensitive ``lang == "c"`` checks — ``run_compare_request`` must
+    normalise so ``"C"`` is not silently treated as C++.
+    """
+    from abicheck import service
+    from abicheck.api_types import CompareRequest, InputSpec
+
+    old_p = _make_snap_file(tmp_path, "liblang", "1.0", [_func("a")])
+    new_p = _make_snap_file(tmp_path, "liblang", "2.0", [_func("a")])
+
+    seen_langs: list[str] = []
+
+    def _spy_resolve_input(path, headers, includes, version, lang, **kwargs):  # type: ignore[no-untyped-def]
+        seen_langs.append(lang)
+        return AbiSnapshot(library="liblang", version=version)
+
+    monkeypatch.setattr(service, "resolve_input", _spy_resolve_input)
+
+    req = CompareRequest(
+        old=InputSpec.of(old_p), new=InputSpec.of(new_p), lang="C"
+    )
+    service.run_compare_request(req)
+
+    assert seen_langs == ["c", "c"]

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -41,7 +41,7 @@ from scripts.check_ai_readiness import Findings, check_cli_contract  # noqa: E40
 # ── D10.1: no front-end skips the Tier-2 service ─────────────────────────────
 
 
-def test_no_tier_skip():
+def test_no_tier_skip() -> None:
     """No ``abicheck/cli*.py`` module calls Tier-1 ``checker.compare`` directly.
 
     Front-ends must route through ``service.run_compare`` /
@@ -59,7 +59,7 @@ def test_no_tier_skip():
 # a different way; the gate must flag exactly one violation naming that file.
 # (filename, source) — covers: direct import, aliased lazy `compare` import,
 # aliased `checker` *module* call, and the non-`cli*.py` `appcompat.py` scope.
-_GATE_VIOLATION_CASES = [
+_GATE_VIOLATION_CASES: list[pytest.ParameterSet] = [
     pytest.param(
         "cli_bad.py",
         "from .checker import compare\ndef go(a, b):\n    return compare(a, b)\n",
@@ -86,7 +86,12 @@ _GATE_VIOLATION_CASES = [
 
 
 @pytest.mark.parametrize("filename, source", _GATE_VIOLATION_CASES)
-def test_gate_flags_violation(tmp_path, monkeypatch, filename, source):
+def test_gate_flags_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    source: str,
+) -> None:
     """The gate is not a no-op: each way of reaching Tier-1 is caught once."""
     import scripts.check_ai_readiness as gate
 
@@ -103,7 +108,9 @@ def test_gate_flags_violation(tmp_path, monkeypatch, filename, source):
     assert filename in errors[0]
 
 
-def test_service_compare_call_is_not_flagged(tmp_path, monkeypatch):
+def test_service_compare_call_is_not_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Routing through ``service.compare_snapshots`` must NOT be flagged."""
     import scripts.check_ai_readiness as gate
 
@@ -125,7 +132,9 @@ def test_service_compare_call_is_not_flagged(tmp_path, monkeypatch):
 # ── Chokepoint parity: one classifier, no scope_public drift ─────────────────
 
 
-def _make_snap_file(tmp_path: Path, name: str, version: str, funcs) -> Path:
+def _make_snap_file(
+    tmp_path: Path, name: str, version: str, funcs: list[Function]
+) -> Path:
     snap = AbiSnapshot(library=name, version=version, functions=funcs)
     p = tmp_path / f"{name}_{version}.json"
     save_snapshot(snap, p)
@@ -142,7 +151,7 @@ def _func(name: str) -> Function:
     )
 
 
-def test_compare_release_matches_service_run_compare(tmp_path):
+def test_compare_release_matches_service_run_compare(tmp_path: Path) -> None:
     """``compare-release``'s per-pair runner classifies identically to
     ``service.run_compare`` — they share the one chokepoint (ADR-037 D1)."""
     from abicheck import service
@@ -182,7 +191,7 @@ def test_compare_release_matches_service_run_compare(tmp_path):
     )
 
 
-def test_run_compare_request_equivalent_to_kwargs_shim(tmp_path):
+def test_run_compare_request_equivalent_to_kwargs_shim(tmp_path: Path) -> None:
     """The kwargs ``run_compare`` shim and a hand-built ``CompareRequest`` agree."""
     from abicheck.api_types import CompareRequest, InputSpec
     from abicheck.service import run_compare, run_compare_request

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -257,7 +257,7 @@ class TestCompareApiBreakExitCode:
         snap = AbiSnapshot(library="lib.so", version="1.0")
         monkeypatch.setattr("abicheck.service.load_snapshot", lambda _: snap)
         monkeypatch.setattr(
-            "abicheck.cli.compare",
+            "abicheck.service.compare_snapshots",
             lambda *_a, **_kw: DiffResult(
                 old_version="1", new_version="2", library="lib.so",
                 verdict=Verdict.API_BREAK,

--- a/tests/test_followup_100_101.py
+++ b/tests/test_followup_100_101.py
@@ -355,7 +355,7 @@ class TestCliPolicy:
             assert kwargs["policy"] == "plugin_abi"
             return DiffResult(old_version="1.0", new_version="2.0", library="lib.so", changes=[], verdict=Verdict.NO_CHANGE)
 
-        with patch("abicheck.cli.compare", side_effect=_fake_compare):
+        with patch("abicheck.service.compare_snapshots", side_effect=_fake_compare):
             result = CliRunner().invoke(main, ["compare", str(old_p), str(new_p), "--policy", "plugin_abi"])
 
         assert result.exit_code == 0, result.output
@@ -383,7 +383,7 @@ class TestCliPolicy:
             assert kwargs["policy_file"] is not None
             return DiffResult(old_version="1.0", new_version="2.0", library="lib.so", changes=[], verdict=Verdict.NO_CHANGE)
 
-        with patch("abicheck.cli.compare", side_effect=_fake_compare):
+        with patch("abicheck.service.compare_snapshots", side_effect=_fake_compare):
             result = CliRunner().invoke(
                 main,
                 ["compare", str(old_p), str(new_p), "--policy-file", str(policy_p)],
@@ -409,7 +409,7 @@ class TestCliPolicy:
             captured["policy_file"] = kwargs.get("policy_file")
             return DiffResult(old_version="1.0", new_version="2.0", library="lib.so", changes=[], verdict=Verdict.NO_CHANGE)
 
-        with patch("abicheck.cli.compare", side_effect=_fake_compare):
+        with patch("abicheck.service.compare_snapshots", side_effect=_fake_compare):
             result = CliRunner().invoke(
                 main,
                 ["compare", str(old_p), str(new_p),


### PR DESCRIPTION
## G22 Phase 1 — Typed requests + single chokepoint

Implements **Phase 1** of the [G22 CLI-consolidation plan](docs/development/plans/g22-cli-consolidation.md), which realises ADR-037 decisions **D1** (three named tiers), **D2** (options are data), and **D10.1** (CI gates the contract). This is the typed-request foundation that the remaining phases build on; phases 2–7 stay open.

### What changed

**New typed request layer (D2)**
- `abicheck/api_types.py`: frozen `InputSpec` / `CompareRequest` (with `validate()`) / `OutputSpec`. A new feature becomes a new field with a default — never a signature break — and the same struct is assembled identically by every front-end, so a default can no longer silently diverge.

**Single classification chokepoint (D1)**
- `service.run_compare` is now a thin keyword-argument shim over `run_compare_request(CompareRequest)`.
- New `service.compare_snapshots` — the Tier-2 snapshot verb wrapping `checker.compare`.
- Every verdict-emitting front-end routes through Tier 2 instead of calling `checker.compare` directly: native `compare`, `compare-release` (`_run_compare_pair` → `service.run_compare`, which **kills the `scope_public` default drift** ADR-037 §Context #1 documents), `scan`, and `appcompat`.

**Enforcement (D10.1)**
- New `cli-contract` AI-readiness check: no `abicheck/cli*.py` module may call Tier-1 `checker.compare` directly (keys on the call expression, so importing a `checker` type for annotations/rendering stays legal).
- Mirrored in `tests/test_cli_contract.py` (`test_no_tier_skip`) + a planted-violation test proving the gate isn't a no-op, plus chokepoint **parity** (`compare-release` classifies a pair identically to `service.run_compare`).
- `tests/test_api_types.py` covers the request struct (frozen / defaults / validate / replace).

**Plumbing**
- Extended the import-cycle allowlist for the by-design lazy front-end→service edges (the package still imports cleanly — no init cycle).
- Documented the new gate in `CLAUDE.md`; marked Phase 1 landed in the plan doc.

### Verification
- Fast unit suite: **11224 passed**, 25 skipped, 4 xfailed.
- `ruff check`, `mypy abicheck/`, and `python scripts/check_ai_readiness.py` all clean (only the pre-existing `dumper.py` size WARN).
- End-to-end `abicheck compare` smoke test returns the expected verdict + exit code.

### Behaviour
Behaviour-preserving for the common path: the kwargs shim keeps existing callers working, and `compare-release`'s `--scope-public-headers` already defaulted to `True` (matching `compare`), so the user-facing default is unchanged — the fix removes the *internal* default divergence and makes "one classifier" a runtime guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBvdgfpZk3M8gCE57mmZvt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Refactor**
  * Consolidated ABI snapshot comparison routing across CLI commands and app compatibility checks through a shared service layer for more consistent behavior.
  * Updated release comparison behavior to treat the public surface as the default scope.
* **New Features**
  * Added an “AI-readiness” CI gate to enforce that CLI front-ends use the approved comparison entry point.
* **Tests**
  * Added unit tests for typed comparison request/output structures (validation and immutability) and CLI contract/parity checks; updated existing CLI coverage and policy forwarding tests.
* **Documentation**
  * Updated the CLI consolidation plan to mark Phase 1 as landed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->