### PR TITLE
feat(cli): decorator-ize shared option families (G22 Phase 2, ADR-037 D3)

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -96,6 +96,11 @@ class BuildConfig:
     compile_db: str = ""
     public_headers: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
+    #: L5 source-graph detail cap (ADR-037 D6): ``summary`` (default — changed
+    #: scope, the cheap CI graph) or ``full`` (full replay scope). The user no
+    #: longer selects a ``graph-*`` mode on the CLI; ``--depth source`` builds the
+    #: graph at this configured detail.
+    graph_detail: str = "summary"
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> BuildConfig:
@@ -116,12 +121,18 @@ class BuildConfig:
                 return [v]
             return []
 
+        graph_detail = _str(sources, "graph", "summary") or "summary"
+        if graph_detail not in ("summary", "full"):
+            raise ValueError(
+                f"sources.graph must be 'summary' or 'full', got {graph_detail!r}"
+            )
         return cls(
             system=_str(build, "system", "auto") or "auto",
             query=_str(build, "query"),
             compile_db=_str(build, "compile_db"),
             public_headers=_strs(sources, "public_headers"),
             exclude=_strs(sources, "exclude"),
+            graph_detail=graph_detail,
         )
 
 
@@ -154,6 +165,18 @@ def discover_build_config(source_tree: Path | None) -> Path | None:
 def is_pack_dir(path: Path | None) -> bool:
     """True when *path* is a pack directory produced by ``abicheck collect``."""
     return path is not None and path.is_dir() and (path / "manifest.json").is_file()
+
+
+def effective_graph_scope(graph_detail: str, scope: str) -> str:
+    """Apply the ADR-037 D6 ``sources.graph`` detail cap to a replay scope.
+
+    ``full`` deepens a ``changed`` scope to ``target`` (full replay); ``summary``
+    (the default) leaves the requested scope untouched. The override only ever
+    *widens* — it never silently drops evidence.
+    """
+    if graph_detail == "full" and scope == "changed":
+        return "target"
+    return scope
 
 
 def collect_inline_pack(
@@ -194,6 +217,7 @@ def collect_inline_pack(
     L4 source replay and L5 graph entirely. ``L5`` requires ``L4``.
     """
     cfg = build_config or BuildConfig()
+    scope = effective_graph_scope(cfg.graph_detail, scope)
     merged = BuildEvidence()
     extractors: list[ExtractorRecord] = []
 

--- a/abicheck/buildsource/scan_levels.py
+++ b/abicheck/buildsource/scan_levels.py
@@ -68,11 +68,31 @@ class SourceMethod(str, Enum):
 class EvidenceDepth(str, Enum):
     """The coarse L-axis ``--depth`` selector (maps lossily to a representative S)."""
 
+    SYMBOLS = "symbols"  # L0/L1 exported symbols + binary metadata only (no L2 AST)
     HEADERS = "headers"  # L2 only
     BUILD = "build"  # L3 (S1)
     SOURCE = "source"  # L4 scoped + L5 edges (S5)
     FULL = "full"  # L4 full-scope (S6)
-    GRAPH = "graph"  # L5 edges (S4)
+    GRAPH = "graph"  # L5 edges (S4) — INTERNAL only (ADR-037 D6); not a user --depth
+
+
+#: The user-facing ``--depth`` ladder (ADR-037 D5). Monotone, coarse, teachable.
+#: ``GRAPH`` is excluded: the L5 graph is an *internal* consequence of
+#: ``--depth source`` (D6), never its own user rung.
+USER_DEPTHS: tuple[EvidenceDepth, ...] = (
+    EvidenceDepth.SYMBOLS,
+    EvidenceDepth.HEADERS,
+    EvidenceDepth.BUILD,
+    EvidenceDepth.SOURCE,
+    EvidenceDepth.FULL,
+)
+
+#: Deprecated ``--depth`` spellings → their replacement (ADR-037 D5/D6). The G21
+#: ``graph`` rung folds into ``source`` (which now builds the graph internally).
+DEPRECATED_DEPTHS: dict[str, EvidenceDepth] = {
+    "graph": EvidenceDepth.SOURCE,
+}
+
 
 
 #: Fixed per-mode preset of (source_method, depth) — ADR-035 D9. ``PR`` pins the
@@ -89,6 +109,7 @@ _MODE_PRESET: dict[ScanMode, tuple[SourceMethod, EvidenceDepth]] = {
 #: reaches no S-method (L2 is intrinsic header AST). ``BUILD`` is S1 — S2
 #: (preprocessor) is *not* reachable via ``--depth`` and needs ``--source-method``.
 _DEPTH_TO_METHOD: dict[EvidenceDepth, SourceMethod | None] = {
+    EvidenceDepth.SYMBOLS: None,  # L0/L1 only — no source method, no L2 AST
     EvidenceDepth.HEADERS: None,
     EvidenceDepth.BUILD: SourceMethod.S1,
     EvidenceDepth.GRAPH: SourceMethod.S4,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -507,9 +507,17 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         click.get_current_context().get_parameter_source("collect_mode")
         == click.core.ParameterSource.COMMANDLINE
     )
+    if collect_mode_explicit:
+        click.echo(
+            "warning: --collect-mode is deprecated (ADR-037 D5); use --depth.",
+            err=True,
+        )
     collect_mode = resolve_dump_depth(
         depth, max_depth, collect_mode, collect_mode_explicit,
     )
+    # --depth symbols suppresses the L2 header AST (symbols-only dump, ADR-037 D5).
+    if depth == "symbols":
+        headers = ()
 
     # An *explicitly* requested deep evidence depth (--depth/--max or an explicit
     # --collect-mode) collects nothing without a source tree / build context:
@@ -1130,6 +1138,7 @@ def compare_cmd(
     old_build_info: Path | None = None, new_build_info: Path | None = None,
     old_sources: Path | None = None, new_sources: Path | None = None,
     collect_mode: str = "off",
+    depth: str | None = None, max_depth: bool = False,
     probe_matrix_old: Path | None = None,
     probe_matrix_new: Path | None = None,
 ) -> None:
@@ -1188,6 +1197,23 @@ def compare_cmd(
 
     if annotate_additions and not annotate:
         raise click.UsageError("--annotate-additions requires --annotate")
+
+    # Fold the unified --depth/--max dial into the underlying collect mode
+    # (ADR-037 D5), the same way `dump`/`deep-compare` do. The hidden
+    # --collect-mode alias still works but warns; --depth symbols suppresses the
+    # L2 header AST (symbols-only).
+    collect_mode_explicit = (
+        click.get_current_context().get_parameter_source("collect_mode")
+        == click.core.ParameterSource.COMMANDLINE
+    )
+    if collect_mode_explicit:
+        click.echo(
+            "warning: --collect-mode is deprecated (ADR-037 D5); use --depth.",
+            err=True,
+        )
+    collect_mode = resolve_dump_depth(depth, max_depth, collect_mode, collect_mode_explicit)
+    if depth == "symbols":
+        headers, old_headers_only, new_headers_only = (), (), ()
 
     # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
     # flags. The selector supersedes the legacy flags whenever it is given:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -63,8 +63,14 @@ from .cli_options import (
     adr027_compare_options,
     build_source_compare_options,
     build_source_dump_options,
+    debug_resolution_options,
+    output_options,
+    policy_options,
+    scope_options,
+    severity_options,
+    two_sided_input_options,
 )
-from .cli_params import POLICY_FILE_PARAM, _load_suppression_and_policy
+from .cli_params import _load_suppression_and_policy
 from .cli_resolve import (
     _apply_native_provenance,
     _detect_binary_format,
@@ -958,16 +964,9 @@ def _finalize_compare_result(
 @click.argument("old_input", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_input", type=click.Path(exists=True, path_type=Path))
 # ── Dump options (used when input is an ELF binary) ──────────────────────────
-@click.option("-H", "--header", "headers", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header file or directory applied to both sides (repeat for multiple). "
-                   "Recommended for full ABI analysis; without headers, native binaries fall back to symbols-only mode. "
-                   "Scopes the ABI surface to declarations in these headers for ELF; on PE/Mach-O scoping is "
-                   "best-effort and falls back to the export table when castxml is unavailable or names don't match "
-                   "(e.g. MSVC C++ mangling). Validated for native binaries; ignored for snapshots.")
-@click.option("-I", "--include", "includes", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Extra include directory for castxml (applied to both sides).")
+# Two-sided header/include/version family (ADR-037 D3); --lang and the L2
+# --header-backend trio stay inline (not part of the shared family).
+@two_sided_input_options
 @click.option("--lang", default="c++", show_default=True,
               type=click.Choice(["c++", "c"], case_sensitive=False),
               help="Language mode for the header backend.")
@@ -987,49 +986,24 @@ def _finalize_compare_result(
               type=click.Choice(["auto", "castxml", "clang"], case_sensitive=False),
               help="L2 header-AST frontend for the new side only (overrides "
                    "--header-backend for new).")
-@click.option("--old-header", "old_headers_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header for old side only (overrides -H for old). "
-                   "Validated for native binaries; ignored for snapshots.")
-@click.option("--new-header", "new_headers_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header for new side only (overrides -H for new). "
-                   "Validated for native binaries; ignored for snapshots.")
-@click.option("--old-include", "old_includes_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Include dir for old side only (overrides -I for old).")
-@click.option("--new-include", "new_includes_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Include dir for new side only (overrides -I for new).")
-@click.option("--old-version", "old_version", default="old", show_default=True,
-              help="Version label for old side (used when input is a .so file).")
-@click.option("--new-version", "new_version", default="new", show_default=True,
-              help="Version label for new side (used when input is a .so file).")
 # ── Compare options (unchanged) ──────────────────────────────────────────────
-@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "sarif", "html", "junit", "review"]),
-              default="markdown", show_default=True,
-              help="Output format. 'review' emits a compact GitHub-facing digest "
-                   "(verdict + counts + release recommendation + manual-review banner) "
-                   "suitable for a job summary or PR comment.")
+@output_options(
+    ["json", "markdown", "sarif", "html", "junit", "review"],
+    format_help="Output format. 'review' emits a compact GitHub-facing digest "
+                "(verdict + counts + release recommendation + manual-review banner) "
+                "suitable for a job summary or PR comment.",
+)
 @click.option("--demangle/--no-demangle", default=None,
               help="Demangle C++ symbol names in markdown/review output (default "
                    "ON; use --no-demangle to turn off). json/sarif always keep raw "
                    "mangled names, and HTML is rendered structurally and is never "
                    "demangled regardless of this flag.")
-@click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
-@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Suppression file (YAML) to filter known/intentional changes.")
+# Policy + suppression family (ADR-037 D3); strict/justification stay inline.
+@policy_options
 @click.option("--strict-suppressions", is_flag=True, default=False,
               help="Fail with exit code 1 if any suppression rule has expired.")
 @click.option("--require-justification", is_flag=True, default=False,
               help="Require every suppression rule to have a non-empty 'reason' field.")
-@click.option("--policy", "policy",
-              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
-              default="strict_abi", show_default=True,
-              help="Built-in policy profile for verdict classification. Ignored when --policy-file is given.")
-@click.option("--policy-file", "policy_file_path",
-              type=POLICY_FILE_PARAM, default=None,
-              help="YAML policy file with per-kind verdict overrides, or a built-in name (e.g. 'security'). Overrides --policy.")
 @click.option("--pdb-path", "pdb_path", type=click.Path(path_type=Path), default=None,
               help="Explicit PDB file path for Windows PE debug info (applied to both sides). "
                    "Overrides automatic PDB discovery.")
@@ -1037,31 +1011,8 @@ def _finalize_compare_result(
               help="PDB file path for old side only (overrides --pdb-path for old).")
 @click.option("--new-pdb-path", "new_pdb_path", type=click.Path(path_type=Path), default=None,
               help="PDB file path for new side only (overrides --pdb-path for new).")
-@click.option("--dwarf-only", is_flag=True, default=False,
-              help="Force DWARF-only mode for both sides: use DWARF debug info "
-                   "as primary data source even when headers are available.")
-@click.option("--severity-preset", "severity_preset",
-              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
-              default=None,
-              help="Severity preset: 'default', 'strict', or 'info-only'. "
-                   "Controls exit codes and report labels. Per-category "
-                   "--severity-* options override the chosen preset.")
-@click.option("--severity-abi-breaking", "severity_abi_breaking",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for clear ABI/API incompatibilities (overrides preset).")
-@click.option("--severity-potential-breaking", "severity_potential_breaking",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for potential incompatibilities needing review (overrides preset).")
-@click.option("--severity-quality-issues", "severity_quality_issues",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for problematic behaviors like std symbol leaks (overrides preset).")
-@click.option("--severity-addition", "severity_addition",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for new public API additions (overrides preset).")
+# Severity preset + per-category overrides (ADR-037 D3 / D4).
+@severity_options
 @click.option("--follow-deps", is_flag=True, default=False,
               help="Resolve transitive dependencies for both old and new, compute symbol "
                    "bindings, and include a dependency-change section in the report. ELF only.")
@@ -1073,13 +1024,7 @@ def _finalize_compare_result(
 @click.option("--show-redundant", is_flag=True, default=False,
               help="Disable redundancy filtering and show all changes including those "
                    "derived from root type changes.")
-@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
-              default=True, show_default=True,
-              help="Restrict findings to the public-header ABI surface (ADR-024): "
-                   "changes to symbols/types not reachable from public-header-declared "
-                   "exported API are recorded as filtered, not reported. Internal-type "
-                   "leaks are never hidden. On by default; use --no-scope-public-headers "
-                   "to report every finding regardless of surface.")
+@scope_options  # --scope-public-headers/--no- (ADR-037 D3); --show-filtered stays inline
 @click.option("--collapse-versioned-symbols", "collapse_versioned_symbols", is_flag=True, default=False,
               help="Opt-in (G15): when a versioned-symbol scheme is detected (most removed "
                    "symbols reappear differing only by a version token, e.g. ICU u_*_NN), "
@@ -1130,16 +1075,6 @@ def _finalize_compare_result(
 @click.option("--recommend", is_flag=True, default=False,
               help="Append a release recommendation (semver bump + SONAME action) to the "
                    "report. Always present in --format json under 'release_recommendation'.")
-@click.option("--debug-format", "debug_format_opt",
-              type=click.Choice(["auto", "dwarf", "btf", "ctf"], case_sensitive=False), default=None,
-              help="Force the ELF debug format for both sides (auto=pick best available). "
-                   "Supersedes the individual --btf/--ctf/--dwarf flags.")
-@click.option("--btf", "debug_format", flag_value="btf", default=None, hidden=True,
-              help="Force BTF debug format for both sides (ELF only).")
-@click.option("--ctf", "debug_format", flag_value="ctf", hidden=True,
-              help="Force CTF debug format for both sides (ELF only).")
-@click.option("--dwarf", "debug_format", flag_value="dwarf", hidden=True,
-              help="Force DWARF debug format for both sides (ELF only).")
 @click.option("--annotate", is_flag=True, default=False,
               help="Emit GitHub Actions workflow command annotations to stderr. "
                    "Annotations appear as inline comments on PR diffs. "
@@ -1147,18 +1082,10 @@ def _finalize_compare_result(
 @click.option("--annotate-additions", is_flag=True, default=False,
               help="Include additions/compatible changes as ::notice annotations "
                    "(requires --annotate).")
-# ── Debug artifact resolution (ADR-021a) ──────────────────────────────────────
-@click.option("--debug-root", "debug_roots", multiple=True, type=click.Path(path_type=Path),
-              help="Directory containing separate debug files (build-id trees, "
-                   "path-mirror, dSYM bundles). Applied to both sides. Can be repeated.")
-@click.option("--debug-root1", "debug_roots_old", multiple=True, type=click.Path(path_type=Path),
-              help="Debug root for old side only (overrides --debug-root for old).")
-@click.option("--debug-root2", "debug_roots_new", multiple=True, type=click.Path(path_type=Path),
-              help="Debug root for new side only (overrides --debug-root for new).")
-@click.option("--debuginfod", is_flag=True, default=False,
-              help="Enable debuginfod network resolution for debug info (opt-in).")
-@click.option("--debuginfod-url", "debuginfod_url", default=None,
-              help="debuginfod server URL (overrides DEBUGINFOD_URLS env var).")
+# ── Debug artifact resolution (ADR-021a + ADR-037 D3) ─────────────────────────
+# --dwarf-only, --debug-root{,1,2}, --debuginfod[-url], --debug-format (+hidden
+# --btf/--ctf/--dwarf): the shared local-ELF debug-resolution family.
+@debug_resolution_options
 @build_source_compare_options  # --old/new-build-info, --old/new-sources, --collect-mode
 @adr027_compare_options  # ADR-027: --pattern-verdicts/--explain-patterns/--surface-metrics
 @click.option("-v", "--verbose", is_flag=True, default=False,

--- a/abicheck/cli_appcompat.py
+++ b/abicheck/cli_appcompat.py
@@ -35,7 +35,14 @@ from .cli import (
     _setup_verbosity,
     main,
 )
-from .cli_params import POLICY_FILE_PARAM, _load_suppression_and_policy
+from .cli_options import (
+    output_options,
+    policy_options,
+    scope_options,
+    severity_options,
+    two_sided_input_options,
+)
+from .cli_params import _load_suppression_and_policy
 
 if TYPE_CHECKING:
     from .appcompat import AppRequirements
@@ -145,75 +152,23 @@ def _handle_list_required_symbols(
               type=click.Path(exists=True, path_type=Path), default=None,
               help="Weak mode: check if a library provides everything the app needs "
                    "(no old library required).")
-# ── Dump options ──────────────────────────────────────────────────────────────
-@click.option("-H", "--header", "headers", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header file or directory for library ABI extraction "
-                   "(applied to both sides).")
-@click.option("-I", "--include", "includes", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Extra include directory for castxml (applied to both sides).")
+# ── Dump options (shared families, ADR-037 D3) ────────────────────────────────
+# Two-sided header/include/version family; --lang stays inline.
+@two_sided_input_options
 @click.option("--lang", default="c++", show_default=True,
               type=click.Choice(["c++", "c"], case_sensitive=False),
               help="Language mode for castxml.")
-@click.option("--old-header", "old_headers_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header for old library only (overrides -H for old).")
-@click.option("--new-header", "new_headers_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Public header for new library only (overrides -H for new).")
-@click.option("--old-include", "old_includes_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Include dir for old library only (overrides -I for old).")
-@click.option("--new-include", "new_includes_only", multiple=True,
-              type=click.Path(path_type=Path),
-              help="Include dir for new library only (overrides -I for new).")
-@click.option("--old-version", "old_version", default="old", show_default=True)
-@click.option("--new-version", "new_version", default="new", show_default=True)
 # ── Output options ────────────────────────────────────────────────────────────
-@click.option("--format", "fmt", type=click.Choice(["json", "markdown", "html"]),
-              default="markdown", show_default=True)
-@click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
+@output_options(["json", "markdown", "html"])
 @click.option("--show-irrelevant", is_flag=True, default=False,
               help="Include library changes that don't affect the application.")
 @click.option("--list-required-symbols", "list_symbols", is_flag=True, default=False,
               help="List symbols the application requires and exit.")
 # ── Suppression + policy ─────────────────────────────────────────────────────
-@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Suppression file (YAML).")
-@click.option("--policy", "policy",
-              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
-              default="strict_abi", show_default=True)
-@click.option("--policy-file", "policy_file_path",
-              type=POLICY_FILE_PARAM, default=None)
-@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
-              default=True, show_default=True,
-              help="Restrict findings to the public-header ABI surface (ADR-024). "
-                   "On by default; matches `compare`. Use --no-scope-public-headers "
-                   "to report every finding.")
-# ── Severity (mirrors `compare`) ──────────────────────────────────────────────
-@click.option("--severity-preset", "severity_preset",
-              type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
-              default=None,
-              help="Severity preset: 'default', 'strict', or 'info-only'. "
-                   "When set (or any --severity-* option), exit codes follow the "
-                   "severity-aware scheme instead of the verdict-based one.")
-@click.option("--severity-abi-breaking", "severity_abi_breaking",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for clear ABI/API incompatibilities (overrides preset).")
-@click.option("--severity-potential-breaking", "severity_potential_breaking",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for potential incompatibilities needing review (overrides preset).")
-@click.option("--severity-quality-issues", "severity_quality_issues",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for problematic behaviors (overrides preset).")
-@click.option("--severity-addition", "severity_addition",
-              type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-              default=None,
-              help="Severity for new public API additions (overrides preset).")
+@policy_options
+@scope_options  # --scope-public-headers/--no- (ADR-037 D3)
+# ── Severity (shared family; mirrors `compare`) ───────────────────────────────
+@severity_options
 @click.option("-v", "--verbose", is_flag=True, default=False)
 def appcompat_cmd(
     app_path: Path,

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -67,7 +67,14 @@ from .cli_compare_release_helpers import (  # noqa: F401
     _resolve_release_severity_config,
     _run_bundle_analysis,
 )
-from .cli_params import POLICY_FILE_PARAM, _load_suppression_and_policy
+from .cli_options import (
+    output_options,
+    policy_options,
+    scope_options,
+    severity_options,
+    two_sided_input_options,
+)
+from .cli_params import _load_suppression_and_policy
 from .model import AbiSnapshot
 from .reporter import to_json
 
@@ -756,83 +763,17 @@ def _strip_diff_results_and_adjust_verdict(
 @main.command("compare-release")
 @click.argument("old_dir", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_dir", type=click.Path(exists=True, path_type=Path))
-@click.option(
-    "-H",
-    "--header",
-    "headers",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Public header file or directory applied to both sides.",
-)
-@click.option(
-    "-I",
-    "--include",
-    "includes",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Extra include directory for castxml.",
-)
-@click.option(
-    "--old-include",
-    "old_includes_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Include directory for old side only (overrides -I for old).",
-)
-@click.option(
-    "--new-include",
-    "new_includes_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Include directory for new side only (overrides -I for new).",
-)
-@click.option(
-    "--old-header",
-    "old_headers_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Header for old side only (overrides -H for old).",
-)
-@click.option(
-    "--new-header",
-    "new_headers_only",
-    multiple=True,
-    type=click.Path(path_type=Path),
-    help="Header for new side only (overrides -H for new).",
-)
-@click.option(
-    "--old-version",
-    "old_version",
-    default="old",
-    show_default=True,
-    help="Version label for old side.",
-)
-@click.option(
-    "--new-version",
-    "new_version",
-    default="new",
-    show_default=True,
-    help="Version label for new side.",
-)
+# Two-sided header/include/version family (ADR-037 D3); --lang stays inline.
+@two_sided_input_options
 @click.option(
     "--lang",
     default="c++",
     show_default=True,
     type=click.Choice(["c++", "c"], case_sensitive=False),
 )
-@click.option(
-    "--format",
-    "fmt",
-    type=click.Choice(["json", "markdown", "junit"]),
-    default="markdown",
-    show_default=True,
-)
-@click.option(
-    "-o",
-    "--output",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Output file for summary report (default: stdout).",
+@output_options(
+    ["json", "markdown", "junit"],
+    output_help="Output file for summary report (default: stdout).",
 )
 @click.option(
     "--output-dir",
@@ -841,12 +782,8 @@ def _strip_diff_results_and_adjust_verdict(
     default=None,
     help="Directory to write per-library reports.",
 )
-@click.option(
-    "--suppress",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Suppression file (YAML).",
-)
+# Policy + suppression family (ADR-037 D3); strict/justification stay inline.
+@policy_options
 @click.option(
     "--strict-suppressions",
     is_flag=True,
@@ -859,14 +796,6 @@ def _strip_diff_results_and_adjust_verdict(
     default=False,
     help="Require every suppression rule to have a non-empty 'reason' field.",
 )
-@click.option(
-    "--policy",
-    "policy",
-    type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
-    default="strict_abi",
-    show_default=True,
-)
-@click.option("--policy-file", "policy_file_path", type=POLICY_FILE_PARAM, default=None)
 @click.option(
     "--fail-on-removed-library/--no-fail-on-removed-library",
     "fail_on_removed",
@@ -974,15 +903,7 @@ def _strip_diff_results_and_adjust_verdict(
     "across DSO boundaries, type drift across siblings, provider "
     "migration, and manifest mismatches.",
 )
-@click.option(
-    "--scope-public-headers/--no-scope-public-headers",
-    "scope_public_headers",
-    default=True,
-    show_default=True,
-    help="Restrict findings to the public-header ABI surface (ADR-024). "
-    "On by default (matches `compare`); use --no-scope-public-headers "
-    "to report every finding.",
-)
+@scope_options  # --scope-public-headers/--no- (ADR-037 D3)
 @click.option(
     "--probe-matrix-old",
     "probe_matrix_old",
@@ -1001,44 +922,8 @@ def _strip_diff_results_and_adjust_verdict(
     default=None,
     help="New build-configuration matrix snapshot (pairs with --probe-matrix-old).",
 )
-# ── Severity (mirrors `compare`) ──────────────────────────────────────────────
-@click.option(
-    "--severity-preset",
-    "severity_preset",
-    type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
-    default=None,
-    help="Severity preset: 'default', 'strict', or 'info-only'. "
-    "When set (or any --severity-* option), exit codes follow the "
-    "severity-aware scheme aggregated across all libraries.",
-)
-@click.option(
-    "--severity-abi-breaking",
-    "severity_abi_breaking",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for clear ABI/API incompatibilities (overrides preset).",
-)
-@click.option(
-    "--severity-potential-breaking",
-    "severity_potential_breaking",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for potential incompatibilities needing review (overrides preset).",
-)
-@click.option(
-    "--severity-quality-issues",
-    "severity_quality_issues",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for problematic behaviors (overrides preset).",
-)
-@click.option(
-    "--severity-addition",
-    "severity_addition",
-    type=click.Choice(["error", "warning", "info"], case_sensitive=True),
-    default=None,
-    help="Severity for new public API additions (overrides preset).",
-)
+# ── Severity (shared family, ADR-037 D3; mirrors `compare`) ───────────────────
+@severity_options
 def compare_release_cmd(
     old_dir: Path,
     new_dir: Path,

--- a/abicheck/cli_max.py
+++ b/abicheck/cli_max.py
@@ -37,11 +37,16 @@ import click
 
 # Import _normalize_binary_input from .cli (the registration parent) rather than
 # .cli_resolve so cli_max adds no new import edge beyond the by-design
-# cli<->cli_max sibling cycle (cli re-exports it in __all__). POLICY_FILE_PARAM
-# comes from the leaf cli_params (no cycle back to cli).
+# cli<->cli_max sibling cycle (cli re-exports it in __all__). The shared option
+# families come from the leaf cli_options (no cycle back to cli).
 from .cli import _normalize_binary_input, compare_cmd, dump_cmd, main
 from .cli_dump_helpers import resolve_dump_depth
-from .cli_params import POLICY_FILE_PARAM
+from .cli_options import (
+    output_options,
+    policy_options,
+    scope_options,
+    two_sided_input_options,
+)
 
 _DIR = click.Path(exists=True, file_okay=False, path_type=Path)
 
@@ -127,20 +132,10 @@ def _prepare_side(
                    "pack) for the OLD side; auto-found inside --old-sources when omitted.")
 @click.option("--new-build-info", "new_build_info", type=click.Path(exists=True, path_type=Path),
               default=None, help="Optional L3 build input for the NEW side.")
-# ── Headers (used at dump time) ──────────────────────────────────────────────
-@click.option("-H", "--header", "headers", multiple=True, type=click.Path(exists=True, path_type=Path),
-              help="Public header file or directory applied to both sides (repeat for multiple).")
-@click.option("--old-header", "old_headers_only", multiple=True, type=click.Path(exists=True, path_type=Path),
-              help="Public header for OLD side only (overrides -H for old).")
-@click.option("--new-header", "new_headers_only", multiple=True, type=click.Path(exists=True, path_type=Path),
-              help="Public header for NEW side only (overrides -H for new).")
-@click.option("-I", "--include", "includes", multiple=True, type=click.Path(path_type=Path),
-              help="Extra include directory for the header backend, applied to both sides "
-                   "(repeat for multiple). Needed when public headers pull in project includes.")
-@click.option("--old-include", "old_includes_only", multiple=True, type=click.Path(path_type=Path),
-              help="Include dir for OLD side only (overrides -I for old).")
-@click.option("--new-include", "new_includes_only", multiple=True, type=click.Path(path_type=Path),
-              help="Include dir for NEW side only (overrides -I for new).")
+# ── Headers / includes / version labels (shared family, ADR-037 D3) ───────────
+# Two-sided header/include/version family (the per-side version labels also come
+# from this decorator; --lang and the --header-backend trio stay inline below).
+@two_sided_input_options
 # ── Depth dial (shared vocabulary with `dump`/`scan`) ────────────────────────
 @click.option("--depth", "depth", type=click.Choice(["headers", "build", "graph", "source", "full"]),
               default=None,
@@ -149,11 +144,7 @@ def _prepare_side(
                    "source=L3-L5 (changed scope), full=L3-L5 (full).")
 @click.option("--max", "max_depth", is_flag=True, default=False,
               help="Shorthand for --depth full (the deepest evidence available).")
-# ── Per-side labels ──────────────────────────────────────────────────────────
-@click.option("--old-version", "old_version", default="old", show_default=True,
-              help="Version label for the OLD side.")
-@click.option("--new-version", "new_version", default="new", show_default=True,
-              help="Version label for the NEW side.")
+# ── Header backend + language (per-side labels come from the shared family) ────
 @click.option("--lang", default="c++", show_default=True,
               type=click.Choice(["c++", "c"], case_sensitive=False),
               help="Language mode for the header backend (both sides).")
@@ -166,27 +157,20 @@ def _prepare_side(
 @click.option("--new-header-backend", "new_header_backend", default=None,
               type=click.Choice(["auto", "castxml", "clang"], case_sensitive=False),
               help="L2 header-AST frontend for the new side only (overrides --header-backend).")
-# ── Compare pass-through ─────────────────────────────────────────────────────
-@click.option("--format", "fmt",
-              type=click.Choice(["json", "markdown", "sarif", "html", "junit", "review"]),
-              default="markdown", show_default=True, help="Output format.")
-@click.option("-o", "--output", type=click.Path(path_type=Path), default=None,
-              help="Write the report here instead of stdout.")
-@click.option("--policy", "policy",
-              type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
-              default="strict_abi", show_default=True, help="Built-in policy profile.")
-@click.option("--policy-file", "policy_file_path", type=POLICY_FILE_PARAM, default=None,
-              help="YAML policy file or built-in name; overrides --policy.")
+# ── Compare pass-through (shared families, ADR-037 D3) ────────────────────────
+@output_options(
+    ["json", "markdown", "sarif", "html", "junit", "review"],
+    output_help="Write the report here instead of stdout.",
+)
+@policy_options  # --policy / --policy-file / --suppress
+# Only the coarse --severity-preset is surfaced here (ADR-037 D4: the
+# per-category overrides are config-bound); see INTENTIONAL_SUBSET in cli_options.
 @click.option("--severity-preset", "severity_preset",
               type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
               default=None, help="Severity preset controlling exit codes and labels.")
-@click.option("--suppress", type=click.Path(exists=True, path_type=Path), default=None,
-              help="Suppression file (YAML) to filter known/intentional changes.")
 @click.option("--recommend", is_flag=True, default=False,
               help="Append a release recommendation (semver bump + SONAME action).")
-@click.option("--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
-              default=True, show_default=True,
-              help="Restrict findings to the public-header ABI surface (ADR-024).")
+@scope_options  # --scope-public-headers/--no- (ADR-037 D3)
 # ── Orchestration knobs ──────────────────────────────────────────────────────
 @click.option("--keep-snapshots", "keep_snapshots", type=click.Path(file_okay=False, path_type=Path),
               default=None,

--- a/abicheck/cli_max.py
+++ b/abicheck/cli_max.py
@@ -47,6 +47,7 @@ from .cli_options import (
     scope_options,
     two_sided_input_options,
 )
+from .cli_params import DEPTH_PARAM
 
 _DIR = click.Path(exists=True, file_okay=False, path_type=Path)
 
@@ -136,12 +137,11 @@ def _prepare_side(
 # Two-sided header/include/version family (the per-side version labels also come
 # from this decorator; --lang and the --header-backend trio stay inline below).
 @two_sided_input_options
-# ── Depth dial (shared vocabulary with `dump`/`scan`) ────────────────────────
-@click.option("--depth", "depth", type=click.Choice(["headers", "build", "graph", "source", "full"]),
-              default=None,
-              help="Evidence depth for both sides (same vocabulary as `dump --depth`): "
-                   "headers=L2 only (== plain compare), build=L3, graph=L5-from-L3, "
-                   "source=L3-L5 (changed scope), full=L3-L5 (full).")
+# ── Depth dial (unified vocabulary with `compare`/`dump`/`scan`, ADR-037 D5) ──
+@click.option("--depth", "depth", type=DEPTH_PARAM, default=None,
+              help="Evidence depth for both sides (unified dial): symbols=L0/L1, "
+                   "headers=+L2 AST (== plain compare), build=+L3, source=+L4 "
+                   "replay & the L5 graph, full=deepest.")
 @click.option("--max", "max_depth", is_flag=True, default=False,
               help="Shorthand for --depth full (the deepest evidence available).")
 # ── Header backend + language (per-side labels come from the shared family) ────
@@ -224,6 +224,9 @@ def deep_compare_cmd(
     # The depth the embedded snapshots carry; forwarded to compare so its
     # coverage table reflects the evidence actually requested.
     compare_collect_mode = resolve_dump_depth(depth, max_depth, "off", False)
+    # --depth symbols suppresses the L2 header AST on both sides (ADR-037 D5).
+    if depth == "symbols":
+        headers, old_headers_only, new_headers_only = (), (), ()
 
     # A depth that collects L3-L5 needs *some* evidence to collect from. A side
     # only fails this when it is a native binary that must be dumped yet has no

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -203,13 +203,14 @@ def output_options(
     sarif/junit, ``compare-release`` cannot emit html/review) — but the option
     *structure*, the ``-o/--output`` flag, and the contract live here once.
     """
+    # ``help=None`` renders no help line in Click, so a single call covers both
+    # the with-help and without-help cases without a ``**dict[str, object]``
+    # unpack (which mypy can't reconcile with ``click.option``'s overloads).
     def deco(func: F) -> F:
-        out_kwargs: dict[str, object] = {
-            "type": click.Path(path_type=Path), "default": None,
-        }
-        if output_help is not None:
-            out_kwargs["help"] = output_help
-        func = click.option("-o", "--output", "output", **out_kwargs)(func)
+        func = click.option(
+            "-o", "--output", "output",
+            type=click.Path(path_type=Path), default=None, help=output_help,
+        )(func)
         func = click.option(
             "--format", "fmt", type=click.Choice(list(formats)),
             default=default, show_default=True, help=format_help,

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -28,7 +28,7 @@ from typing import TypeVar
 
 import click
 
-from .cli_params import POLICY_FILE_PARAM
+from .cli_params import DEPTH_PARAM, POLICY_FILE_PARAM
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -331,22 +331,18 @@ def build_source_dump_options(func: F) -> F:
     func = click.option(
         "--collect-mode", "collect_mode",
         type=click.Choice(["off", "build", "graph-build", "source-changed", "source-target", "graph-summary", "graph-full"]),
-        default="source-target", show_default=True,
-        help="ADR-033 D2 CI evidence mode selecting which layers to collect from "
-        "--sources/--build-info: 'build' captures L3 build context only (no source "
-        "replay), 'graph-build' adds the L5 structural graph (build options + "
-        "target/source/header nodes) from L3 alone — no L4 parse, feasible on "
-        "monorepos, 'source-*'/'graph-*' collect L3+L4+L5 at the matching replay "
-        "scope, 'off' embeds nothing. Prefer the friendlier --depth preset.",
+        default="source-target", show_default=False, hidden=True,
+        help="DEPRECATED (ADR-037 D5): internal ADR-033 D2 evidence mode. Prefer "
+        "the unified --depth dial; kept as a hidden alias for one release.",
     )(func)
     func = click.option(
         "--depth", "depth",
-        type=click.Choice(["headers", "build", "graph", "source", "full"]),
+        type=DEPTH_PARAM,
         default=None,
-        help="Evidence-depth preset over --collect-mode (same vocabulary as "
-        "`scan --depth`): headers=L2 only, build=L3 build context, graph=L5 "
-        "graph from L3, source=L3-L5 (changed scope), full=L3-L5 (full). "
-        "Mutually exclusive with --collect-mode.",
+        help="Unified evidence-depth dial (ADR-037 D5; same vocabulary as "
+        "`compare`/`scan --depth`): symbols=L0/L1 only, headers=+L2 AST (default), "
+        "build=+L3 build context, source=+L4 replay & the L5 graph, full=deepest. "
+        "--max == --depth full.",
     )(func)
     func = click.option(
         "--max", "max_depth", is_flag=True, default=False,
@@ -419,10 +415,20 @@ def build_source_compare_options(func: F) -> F:
     func = click.option(
         "--collect-mode", "collect_mode",
         type=click.Choice(["off", "build", "graph-build", "source-changed", "source-target", "graph-summary", "graph-full"]),
-        default="off", show_default=True,
-        help="Inline collection mode (ADR-033 D2). 'off' uses embedded facts and "
-        "any explicitly-provided pack directories. Other modes are recognized "
-        "and reported in the coverage table but not yet collected inline.",
+        default="off", show_default=False, hidden=True,
+        help="DEPRECATED (ADR-037 D5): internal ADR-033 D2 evidence mode. Prefer "
+        "the unified --depth dial; kept as a hidden alias for one release.",
+    )(func)
+    func = click.option(
+        "--max", "max_depth", is_flag=True, default=False,
+        help="Shorthand for --depth full (collect the deepest evidence available).",
+    )(func)
+    func = click.option(
+        "--depth", "depth", type=DEPTH_PARAM, default=None,
+        help="Unified evidence-depth dial (ADR-037 D5): symbols=L0/L1 only, "
+        "headers=+L2 AST (default), build=+L3, source=+L4 replay & the L5 graph, "
+        "full=deepest. --max == --depth full. Deeper-than-headers needs "
+        "--old/new-sources or --old/new-build-info.",
     )(func)
     func = click.option(
         "--new-sources", "new_sources", type=pack_dir, default=None,
@@ -502,6 +508,27 @@ INTENTIONAL_SUBSET: dict[tuple[str, str], str] = {
 
 #: Flag names knowingly carrying two defaults across decorators, deferred to a
 #: later phase rather than hidden. ``--collect-mode`` differs between the dump
-#: embed default (source-target) and the compare read default (off); G22 Phase 3
-#: collapses both into the unified ``--depth`` dial, which resolves it.
+#: embed default (source-target) and the compare read default (off); it is now a
+#: hidden deprecated alias behind the unified ``--depth`` dial (G22 Phase 3) and
+#: its two-default-ness rides out the deprecation window in ``DEPRECATED_FLAGS``.
 DEFERRED_MULTI_DEFAULT: frozenset[str] = frozenset({"--collect-mode"})
+
+
+# ── ADR-037 D5 / §Backward-compat: deprecated-flag registry (G22 Phase 3) ─────
+#
+# Single source of truth for renamed/removed CLI surface. Each entry records the
+# replacement and a one-line note; the deprecation *resolver* + window-enforcing
+# test land in Phase 7 (kept advisory until 1.0). Today the live deprecations
+# already warn at their option sites (``--collect-mode`` in the command bodies,
+# ``--depth graph`` in ``cli_params.DepthParam``); this table documents them in
+# one place so nothing is removed silently.
+DEPRECATED_FLAGS: dict[str, tuple[str, str]] = {
+    "--collect-mode": (
+        "--depth",
+        "internal ADR-033 evidence mode; use the unified --depth dial (ADR-037 D5).",
+    ),
+    "--depth=graph": (
+        "--depth=source",
+        "the L5 graph is built internally at --depth source (ADR-037 D6).",
+    ),
+}

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -471,6 +471,14 @@ FAMILY_FLAGS: dict[str, frozenset[str]] = {
     }),
     "scope": frozenset({"--scope-public-headers"}),
     "output": frozenset({"--format", "--output"}),
+    # Documented for completeness; deliberately *not* in REQUIRED_FAMILIES (it
+    # resolves local ELF debug artifacts, which the package/snapshot-oriented
+    # commands do not take).
+    "debug_resolution": frozenset({
+        "--dwarf-only", "--debug-root", "--debug-root1", "--debug-root2",
+        "--debuginfod", "--debuginfod-url", "--debug-format",
+        "--btf", "--ctf", "--dwarf",
+    }),
 }
 
 #: Family name → the decorator callable that supplies it (used by the gate's

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -22,12 +22,258 @@ Stacked-decorator helpers that bundle related ``compare`` options so the large
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import TypeVar
 
 import click
 
+from .cli_params import POLICY_FILE_PARAM
+
 F = TypeVar("F", bound=Callable[..., object])
+
+
+# ── ADR-037 D3: shared option families ───────────────────────────────────────
+#
+# Every option family that more than one verdict-emitting command needs is
+# declared **once** here as a decorator; commands compose the decorators instead
+# of re-declaring the family inline. The ``cli-contract`` AI-readiness gate
+# (ADR-037 D10.2/D10.4) and ``tests/test_cli_contract.py`` key on the tables at
+# the bottom of this module (``FAMILY_FLAGS`` / ``VERDICT_EMITTING_COMMANDS`` /
+# ``INTENTIONAL_SUBSET``), so keep those in sync when a family changes.
+#
+# Decorators apply bottom-up (Click reverses ``__click_params__``), so each
+# helper lists its options in reverse of their displayed order — matching the
+# existing ``build_source_*`` helpers below.
+
+
+def two_sided_input_options(func: F) -> F:
+    """Headers / includes / version labels, shared (`-H/-I` + per-side + version).
+
+    Identical across ``compare`` / ``compare-release`` / ``appcompat`` /
+    ``deep-compare``: a both-sides input plus an old-only / new-only override and
+    a per-side version label. (``--lang`` and the L2 ``--header-backend`` family
+    stay inline — the latter becomes ``--ast-frontend`` in G22 Phase 6.)
+    """
+    func = click.option(
+        "--new-version", "new_version", default="new", show_default=True,
+        help="Version label for new side (used when input is a .so file).",
+    )(func)
+    func = click.option(
+        "--old-version", "old_version", default="old", show_default=True,
+        help="Version label for old side (used when input is a .so file).",
+    )(func)
+    func = click.option(
+        "--new-include", "new_includes_only", multiple=True,
+        type=click.Path(path_type=Path),
+        help="Include dir for new side only (overrides -I for new).",
+    )(func)
+    func = click.option(
+        "--old-include", "old_includes_only", multiple=True,
+        type=click.Path(path_type=Path),
+        help="Include dir for old side only (overrides -I for old).",
+    )(func)
+    func = click.option(
+        "--new-header", "new_headers_only", multiple=True,
+        type=click.Path(path_type=Path),
+        help="Public header for new side only (overrides -H for new). "
+             "Validated for native binaries; ignored for snapshots.",
+    )(func)
+    func = click.option(
+        "--old-header", "old_headers_only", multiple=True,
+        type=click.Path(path_type=Path),
+        help="Public header for old side only (overrides -H for old). "
+             "Validated for native binaries; ignored for snapshots.",
+    )(func)
+    func = click.option(
+        "-I", "--include", "includes", multiple=True,
+        type=click.Path(path_type=Path),
+        help="Extra include directory for castxml (applied to both sides).",
+    )(func)
+    func = click.option(
+        "-H", "--header", "headers", multiple=True,
+        type=click.Path(path_type=Path),
+        help="Public header file or directory applied to both sides (repeat for multiple). "
+             "Recommended for full ABI analysis; without headers, native binaries fall back to symbols-only mode. "
+             "Scopes the ABI surface to declarations in these headers for ELF; on PE/Mach-O scoping is "
+             "best-effort and falls back to the export table when castxml is unavailable or names don't match "
+             "(e.g. MSVC C++ mangling). Validated for native binaries; ignored for snapshots.",
+    )(func)
+    return func
+
+
+def policy_options(func: F) -> F:
+    """Verdict-classification policy + suppression file (`--policy`/`--policy-file`/`--suppress`).
+
+    Shared verbatim by every verdict-emitting command. (``--policy`` accepting a
+    *path* directly, folding ``--policy-file`` in, is a later-phase D4 change.)
+    """
+    func = click.option(
+        "--suppress", type=click.Path(exists=True, path_type=Path), default=None,
+        help="Suppression file (YAML) to filter known/intentional changes.",
+    )(func)
+    func = click.option(
+        "--policy-file", "policy_file_path", type=POLICY_FILE_PARAM, default=None,
+        help="YAML policy file with per-kind verdict overrides, or a built-in name "
+             "(e.g. 'security'). Overrides --policy.",
+    )(func)
+    func = click.option(
+        "--policy", "policy",
+        type=click.Choice(["strict_abi", "sdk_vendor", "plugin_abi"], case_sensitive=True),
+        default="strict_abi", show_default=True,
+        help="Built-in policy profile for verdict classification. Ignored when "
+             "--policy-file is given.",
+    )(func)
+    return func
+
+
+def severity_options(func: F) -> F:
+    """The severity preset + the four per-category overrides.
+
+    ADR-037 D4 will demote the per-category flags into ``.abicheck.yml`` (Phase
+    5), leaving only ``--severity-preset`` on the CLI; until then they are a
+    genuine shared family across ``compare`` / ``compare-release`` / ``appcompat``
+    and live here once instead of being copy-pasted three times.
+    """
+    func = click.option(
+        "--severity-addition", "severity_addition",
+        type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+        default=None,
+        help="Severity for new public API additions (overrides preset).",
+    )(func)
+    func = click.option(
+        "--severity-quality-issues", "severity_quality_issues",
+        type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+        default=None,
+        help="Severity for problematic behaviors like std symbol leaks (overrides preset).",
+    )(func)
+    func = click.option(
+        "--severity-potential-breaking", "severity_potential_breaking",
+        type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+        default=None,
+        help="Severity for potential incompatibilities needing review (overrides preset).",
+    )(func)
+    func = click.option(
+        "--severity-abi-breaking", "severity_abi_breaking",
+        type=click.Choice(["error", "warning", "info"], case_sensitive=True),
+        default=None,
+        help="Severity for clear ABI/API incompatibilities (overrides preset).",
+    )(func)
+    func = click.option(
+        "--severity-preset", "severity_preset",
+        type=click.Choice(["default", "strict", "info-only"], case_sensitive=True),
+        default=None,
+        help="Severity preset: 'default', 'strict', or 'info-only'. "
+             "Controls exit codes and report labels. Per-category "
+             "--severity-* options override the chosen preset.",
+    )(func)
+    return func
+
+
+def scope_options(func: F) -> F:
+    """Public-surface scoping (`--scope-public-headers/--no-`).
+
+    The universally-shared toggle. ``--show-filtered`` (a ``compare``-only audit
+    view) stays inline on ``compare`` rather than being forced onto commands that
+    have no filtered-findings report to dump.
+    """
+    func = click.option(
+        "--scope-public-headers/--no-scope-public-headers", "scope_public_headers",
+        default=True, show_default=True,
+        help="Restrict findings to the public-header ABI surface (ADR-024): "
+             "changes to symbols/types not reachable from public-header-declared "
+             "exported API are recorded as filtered, not reported. Internal-type "
+             "leaks are never hidden. On by default; use --no-scope-public-headers "
+             "to report every finding regardless of surface.",
+    )(func)
+    return func
+
+
+def output_options(
+    formats: Sequence[str],
+    *,
+    default: str = "markdown",
+    format_help: str = "Output format.",
+    output_help: str | None = None,
+) -> Callable[[F], F]:
+    """Factory for the ``--format`` / ``-o/--output`` pair.
+
+    A factory rather than a bare decorator because the *set* of producible
+    formats legitimately differs per command (``appcompat`` cannot emit
+    sarif/junit, ``compare-release`` cannot emit html/review) — but the option
+    *structure*, the ``-o/--output`` flag, and the contract live here once.
+    """
+    def deco(func: F) -> F:
+        out_kwargs: dict[str, object] = {
+            "type": click.Path(path_type=Path), "default": None,
+        }
+        if output_help is not None:
+            out_kwargs["help"] = output_help
+        func = click.option("-o", "--output", "output", **out_kwargs)(func)
+        func = click.option(
+            "--format", "fmt", type=click.Choice(list(formats)),
+            default=default, show_default=True, help=format_help,
+        )(func)
+        return func
+
+    return deco
+
+
+def debug_resolution_options(func: F) -> F:
+    """Separate-debug-file resolution (ADR-021a): roots + debuginfod + format.
+
+    Currently a ``compare``-only family — it resolves *local* ELF debug
+    artifacts, which the package-oriented (``compare-release``) and
+    snapshot-oriented (``deep-compare``/``appcompat``) commands do not take. It
+    lives here so the moment a second command needs it there is one definition to
+    compose, not a copy to drift (ADR-037 D3).
+    """
+    func = click.option(
+        "--dwarf", "debug_format", flag_value="dwarf", hidden=True,
+        help="Force DWARF debug format for both sides (ELF only).",
+    )(func)
+    func = click.option(
+        "--ctf", "debug_format", flag_value="ctf", hidden=True,
+        help="Force CTF debug format for both sides (ELF only).",
+    )(func)
+    func = click.option(
+        "--btf", "debug_format", flag_value="btf", default=None, hidden=True,
+        help="Force BTF debug format for both sides (ELF only).",
+    )(func)
+    func = click.option(
+        "--debug-format", "debug_format_opt",
+        type=click.Choice(["auto", "dwarf", "btf", "ctf"], case_sensitive=False),
+        default=None,
+        help="Force the ELF debug format for both sides (auto=pick best available). "
+             "Supersedes the individual --btf/--ctf/--dwarf flags.",
+    )(func)
+    func = click.option(
+        "--debuginfod-url", "debuginfod_url", default=None,
+        help="debuginfod server URL (overrides DEBUGINFOD_URLS env var).",
+    )(func)
+    func = click.option(
+        "--debuginfod", is_flag=True, default=False,
+        help="Enable debuginfod network resolution for debug info (opt-in).",
+    )(func)
+    func = click.option(
+        "--debug-root2", "debug_roots_new", multiple=True, type=click.Path(path_type=Path),
+        help="Debug root for new side only (overrides --debug-root for new).",
+    )(func)
+    func = click.option(
+        "--debug-root1", "debug_roots_old", multiple=True, type=click.Path(path_type=Path),
+        help="Debug root for old side only (overrides --debug-root for old).",
+    )(func)
+    func = click.option(
+        "--debug-root", "debug_roots", multiple=True, type=click.Path(path_type=Path),
+        help="Directory containing separate debug files (build-id trees, "
+             "path-mirror, dSYM bundles). Applied to both sides. Can be repeated.",
+    )(func)
+    func = click.option(
+        "--dwarf-only", is_flag=True, default=False,
+        help="Force DWARF-only mode for both sides: use DWARF debug info "
+             "as primary data source even when headers are available.",
+    )(func)
+    return func
 
 
 def adr027_compare_options(func: F) -> F:
@@ -194,3 +440,67 @@ def build_source_compare_options(func: F) -> F:
         help="Out-of-band L3 build-info pack for the old side (overrides embedded).",
     )(func)
     return func
+
+
+# ── ADR-037 D10: contract metadata (single source of truth for the gate) ──────
+#
+# The ``cli-contract`` AI-readiness gate (D10.2 decorator coverage, D10.4
+# one-default-per-flag) and its test mirror key on these tables. Keeping them
+# beside the decorators means adding/renaming a family is a one-place edit.
+
+#: Family name → the long ``--flag`` names that family contributes. The gate
+#: checks a verdict-emitting command carries the *whole* family (composed via the
+#: matching decorator) or is allowlisted in ``INTENTIONAL_SUBSET``.
+FAMILY_FLAGS: dict[str, frozenset[str]] = {
+    "two_sided_input": frozenset({
+        "--header", "--include", "--old-header", "--new-header",
+        "--old-include", "--new-include", "--old-version", "--new-version",
+    }),
+    "policy": frozenset({"--policy", "--policy-file", "--suppress"}),
+    "severity": frozenset({
+        "--severity-preset", "--severity-abi-breaking",
+        "--severity-potential-breaking", "--severity-quality-issues",
+        "--severity-addition",
+    }),
+    "scope": frozenset({"--scope-public-headers"}),
+    "output": frozenset({"--format", "--output"}),
+}
+
+#: Family name → the decorator callable that supplies it (used by the gate's
+#: AST coverage check, which keys on the decorator applied to a command).
+FAMILY_DECORATOR: dict[str, str] = {
+    "two_sided_input": "two_sided_input_options",
+    "policy": "policy_options",
+    "severity": "severity_options",
+    "scope": "scope_options",
+    "output": "output_options",
+}
+
+#: Families every verdict-emitting command must compose (unless allowlisted).
+#: ``debug_resolution`` is deliberately *not* required — it resolves local ELF
+#: debug artifacts that the package/snapshot-oriented commands do not take.
+REQUIRED_FAMILIES: frozenset[str] = frozenset(FAMILY_DECORATOR)
+
+#: command name → module basename, for the gate to locate each command's source.
+VERDICT_EMITTING_COMMANDS: dict[str, str] = {
+    "compare": "cli.py",
+    "compare-release": "cli_compare_release.py",
+    "appcompat": "cli_appcompat.py",
+    "deep-compare": "cli_max.py",
+}
+
+#: (command, family) → reason. A deliberate, reviewed omission of a shared
+#: family from a verdict-emitting command (ADR-037 D3: opt out *explicitly*).
+INTENTIONAL_SUBSET: dict[tuple[str, str], str] = {
+    ("deep-compare", "severity"): (
+        "deep-compare is a one-shot convenience wrapper that exposes only the "
+        "coarse --severity-preset; the per-category overrides are config-bound "
+        "(ADR-037 D4) and not surfaced on this command."
+    ),
+}
+
+#: Flag names knowingly carrying two defaults across decorators, deferred to a
+#: later phase rather than hidden. ``--collect-mode`` differs between the dump
+#: embed default (source-target) and the compare read default (off); G22 Phase 3
+#: collapses both into the unified ``--depth`` dial, which resolves it.
+DEFERRED_MULTI_DEFAULT: frozenset[str] = frozenset({"--collect-mode"})

--- a/abicheck/cli_params.py
+++ b/abicheck/cli_params.py
@@ -61,6 +61,49 @@ class PolicyFileParam(click.ParamType):
 POLICY_FILE_PARAM = PolicyFileParam()
 
 
+class DepthParam(click.ParamType):
+    """Click type for the unified ``--depth`` dial (ADR-037 D5/D6).
+
+    Accepts the user-facing ladder ``{symbols,headers,build,source,full}`` and
+    resolves deprecated spellings (currently the G21 ``graph`` rung → ``source``)
+    to their replacement, printing a one-line stderr deprecation note. The L5
+    graph is built internally at ``--depth source`` (D6), so ``graph`` is no
+    longer a user-facing rung — but it keeps working for one release.
+    """
+
+    name = "depth"
+
+    def convert(self, value: Any, param: Any, ctx: Any) -> str:
+        from .buildsource.scan_levels import DEPRECATED_DEPTHS, USER_DEPTHS
+
+        v = str(value).lower()
+        user_values = [d.value for d in USER_DEPTHS]
+        if v in user_values:
+            return v
+        if v in DEPRECATED_DEPTHS:
+            replacement = DEPRECATED_DEPTHS[v].value
+            click.echo(
+                f"warning: --depth {v} is deprecated (ADR-037 D6); use "
+                f"--depth {replacement}. The L5 graph is built automatically at "
+                "--depth source.",
+                err=True,
+            )
+            return replacement
+        choices = ", ".join(user_values)
+        raise click.BadParameter(
+            f"{value!r} is not one of {choices}.", ctx=ctx, param=param
+        )
+
+    def get_metavar(self, param: Any, ctx: Any = None) -> str:
+        from .buildsource.scan_levels import USER_DEPTHS
+
+        return "[" + "|".join(d.value for d in USER_DEPTHS) + "]"
+
+
+#: Shared instance for every ``--depth`` option.
+DEPTH_PARAM = DepthParam()
+
+
 def _load_suppression_and_policy(
     suppress: Path | None, policy: str, policy_file_path: Path | None,
     *,

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -70,6 +70,7 @@ from .buildsource.scan_levels import (
 )
 from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS
 from .cli import _safe_write_output, _setup_verbosity, main
+from .cli_params import DEPTH_PARAM
 
 #: Exit code for a ``--budget`` overflow (ADR-035 D3: a budget always fails,
 #: never silently shrinks scope). Distinct from the verdict codes (0/2/4) and the
@@ -552,9 +553,9 @@ def _audit_exit_code(
 @click.option(
     "--depth",
     "depth",
-    type=click.Choice([d.value for d in EvidenceDepth]),
+    type=DEPTH_PARAM,
     default=None,
-    help="Coarse L-axis selector (lossy; --source-method wins if both).",
+    help="Coarse L-axis selector (unified dial; --source-method wins if both).",
 )
 @click.option(
     "--since",

--- a/docs/development/plans/g22-cli-consolidation.md
+++ b/docs/development/plans/g22-cli-consolidation.md
@@ -154,6 +154,22 @@ debug-resolution is uniform — all *via the shared decorator*, not copies.
 
 ### Phase 3 — Depth vocabulary + L5-internal (D5, D6)
 
+**Status: landed.** One user-facing dial `--depth {symbols,headers,build,source,full}`
+now spans `compare`/`deep-compare`/`dump`/`scan` via a shared `DepthParam`
+(`cli_params.py`): it adds `symbols` (L0/L1, suppresses the L2 AST), drops `graph`
+as a user rung, and resolves the deprecated `--depth graph` → `source` with a
+stderr note. `compare` gained `--depth`/`--max` (folded into the collect mode the
+same way `dump`/`deep-compare` do). `--collect-mode` is now a hidden deprecated
+alias that warns when used. The L5 graph stays internal — built automatically at
+`--depth source` — and `EvidenceDepth.GRAPH` survives only for scan's `pr-deep`
+preset (determinism). A new `.abicheck.yml` `sources.graph: summary|full` knob
+(default `summary`, `BuildConfig.graph_detail`) caps/deepens the graph replay
+scope (`effective_graph_scope`). The deprecated spellings are catalogued in
+`cli_options.DEPRECATED_FLAGS` (the window-enforcing resolver lands in Phase 7).
+Covered by `tests/test_depth_vocabulary.py` (alias resolution, monotone ladder,
+graph-at-source, symbols-only, config knob). `--source-method`/`--mode` on `scan`
+are unchanged — their move to config is Phase 5 (D4), not D5.
+
 **Work.** `--depth {symbols,headers,build,source,full}` + `--max` on
 `@evidence_options` (incl. per-side `--old/new-sources`, `--old/new-build-info`).
 Map deprecated `--collect-mode`/`--mode`/standalone `--source-method` **and the

--- a/docs/development/plans/g22-cli-consolidation.md
+++ b/docs/development/plans/g22-cli-consolidation.md
@@ -110,7 +110,31 @@ change observable from the CLI.
 
 ### Phase 2 — Decorator-ize shared families (D3)
 
-**Work.** Define the 7 decorators in `cli_options.py` (ADR-037 D3 table).
+**Status: landed.** `cli_options.py` now defines six shared families as
+decorators — `two_sided_input_options`, `policy_options`, `severity_options`,
+`scope_options`, `debug_resolution_options`, and the `output_options` factory
+(per-command `--format` choices vary legitimately) — plus the contract tables
+(`FAMILY_FLAGS`, `FAMILY_DECORATOR`, `REQUIRED_FAMILIES`,
+`VERDICT_EMITTING_COMMANDS`, `INTENTIONAL_SUBSET`, `DEFERRED_MULTI_DEFAULT`).
+`compare`, `compare-release`, `appcompat`, and `deep-compare` are recomposed onto
+them with their inline duplicates deleted (behaviour-preserving; help text is now
+uniform, and the divergences are closed — `deep-compare`'s `-H` no longer needs
+the file to exist at parse, matching its siblings). `deep-compare` keeps only the
+coarse `--severity-preset` and is the sole `INTENTIONAL_SUBSET` entry. The
+`cli-contract` gate gained D10.2 (decorator coverage) and D10.4
+(one-default-per-flag), mirrored in `tests/test_cli_contract.py` along with the
+per-command option-set snapshot and the gate↔`cli_options` table-mirror test.
+
+The seventh decorator, **`@evidence_options` (`--depth`/`--collect-mode`/
+`--sources`/`--build-info`), is deferred to Phase 3** where the depth vocabulary
+is unified: the existing `build_source_compare_options`/`build_source_dump_options`
+helpers stay as-is for now, and their `--collect-mode` double-default (the very
+case D10.4 exists to catch) is parked on the `DEFERRED_MULTI_DEFAULT` allowlist
+with a pointer to Phase 3 rather than hidden. `dump`/`scan` are not in the
+verdict-emitting set, so their recompose rides along with the depth work in
+Phase 3.
+
+**Original plan.** Define the 7 decorators in `cli_options.py` (ADR-037 D3 table).
 Recompose `compare`, `compare-release`, `appcompat`, `deep-compare`, `dump`,
 `scan` onto them, deleting inline duplicates. Seed `INTENTIONAL_SUBSET` with any
 deliberate omission (each with a reason string). Add D10.2 (decorator coverage)

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1263,11 +1263,13 @@ def _check_decorator_coverage(f: Findings) -> None:
             tree = ast.parse(_read(path), filename=rel)
         except SyntaxError:
             continue
+        found = False
         for fn in ast.walk(tree):
             if not isinstance(fn, ast.FunctionDef):
                 continue
             if _command_name_of(fn) != cmd_name:
                 continue
+            found = True
             applied = {
                 name
                 for dec in fn.decorator_list
@@ -1284,6 +1286,15 @@ def _check_decorator_coverage(f: Findings) -> None:
                     f"`@{required}` (ADR-037 D3/D10.2). Compose it from "
                     "`cli_options.py` or add an `INTENTIONAL_SUBSET` entry with a reason.",
                 )
+        # A mapped command whose module exists but no longer declares it is a
+        # D10.2 false-negative (coverage silently un-verifiable) — flag it.
+        if not found:
+            f.err(
+                "cli-contract",
+                f"{rel}: expected verdict-emitting command `{cmd_name}` was not "
+                "found; its shared-decorator coverage (ADR-037 D10.2) could not be "
+                "verified. Update `VERDICT_EMITTING_COMMANDS` if it moved or was renamed.",
+            )
 
 
 def _option_flag_and_default(call: ast.Call) -> tuple[str | None, str | None]:

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1184,6 +1184,158 @@ def _iter_cli_contract_sources() -> Iterable[Path]:
         yield appcompat
 
 
+# ── ADR-037 D10.2 / D10.4: shared-decorator coverage + one-default-per-flag ───
+#
+# These mirror the contract tables in ``abicheck/cli_options.py``. The gate is
+# the first CI step and must stay pure-stdlib (no ``import abicheck``), so the
+# small mapping is duplicated here and ``tests/test_cli_contract.py`` asserts it
+# stays in lock-step with ``cli_options`` (the source of truth).
+
+#: verdict-emitting command module basename → the command's registered name.
+_VERDICT_CMD_MODULES: dict[str, str] = {
+    "cli.py": "compare",
+    "cli_compare_release.py": "compare-release",
+    "cli_appcompat.py": "appcompat",
+    "cli_max.py": "deep-compare",
+}
+
+#: decorator callables every verdict-emitting command must compose (ADR-037 D3).
+_REQUIRED_FAMILY_DECORATORS: frozenset[str] = frozenset(
+    {
+        "two_sided_input_options",
+        "policy_options",
+        "severity_options",
+        "scope_options",
+        "output_options",
+    }
+)
+
+#: (command, decorator) pairs allowed to be absent — a deliberate, reviewed
+#: subset (mirrors ``cli_options.INTENTIONAL_SUBSET``).
+_INTENTIONAL_SUBSET_DECORATORS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("deep-compare", "severity_options"),
+    }
+)
+
+#: flag names knowingly carrying two defaults across decorators, deferred to a
+#: later phase (mirrors ``cli_options.DEFERRED_MULTI_DEFAULT``).
+_DEFERRED_MULTI_DEFAULT_FLAGS: frozenset[str] = frozenset({"--collect-mode"})
+
+
+def _decorator_callable_name(node: ast.expr) -> str | None:
+    """The bare callable name of a decorator (``@foo`` or ``@foo(...)``).
+
+    Returns ``None`` for attribute-style decorators (``@click.option(...)`` /
+    ``@main.command(...)``) which are not shared-family decorators.
+    """
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _command_name_of(fn: ast.FunctionDef) -> str | None:
+    """If *fn* is a ``@main.command("name")`` handler, return that name."""
+    for dec in fn.decorator_list:
+        if (
+            isinstance(dec, ast.Call)
+            and isinstance(dec.func, ast.Attribute)
+            and dec.func.attr == "command"
+            and dec.args
+            and isinstance(dec.args[0], ast.Constant)
+            and isinstance(dec.args[0].value, str)
+        ):
+            return dec.args[0].value
+    return None
+
+
+def _check_decorator_coverage(f: Findings) -> None:
+    """ADR-037 D10.2: every verdict-emitting command composes the required shared
+    option-family decorators (or is on the intentional-subset allowlist)."""
+    for module, cmd_name in _VERDICT_CMD_MODULES.items():
+        path = PKG / module
+        if not path.is_file():
+            continue
+        rel = _rel(path)
+        try:
+            tree = ast.parse(_read(path), filename=rel)
+        except SyntaxError:
+            continue
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef):
+                continue
+            if _command_name_of(fn) != cmd_name:
+                continue
+            applied = {
+                name
+                for dec in fn.decorator_list
+                if (name := _decorator_callable_name(dec)) is not None
+            }
+            for required in sorted(_REQUIRED_FAMILY_DECORATORS):
+                if required in applied:
+                    continue
+                if (cmd_name, required) in _INTENTIONAL_SUBSET_DECORATORS:
+                    continue
+                f.err(
+                    "cli-contract",
+                    f"{rel}: command `{cmd_name}` is missing shared option family "
+                    f"`@{required}` (ADR-037 D3/D10.2). Compose it from "
+                    "`cli_options.py` or add an `INTENTIONAL_SUBSET` entry with a reason.",
+                )
+
+
+def _option_flag_and_default(call: ast.Call) -> tuple[str | None, str | None]:
+    """For a ``click.option(...)`` call, return its canonical ``--flag`` name and
+    the source text of its ``default=`` (or ``None`` if absent)."""
+    flag: str | None = None
+    for arg in call.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            token = arg.value.split("/")[0]  # `--x/--no-x` → `--x`
+            if token.startswith("--"):
+                flag = token
+                break
+            if flag is None and token.startswith("-"):
+                flag = token  # short-only fallback; a long form usually follows
+    default_src: str | None = None
+    for kw in call.keywords:
+        if kw.arg == "default":
+            default_src = ast.unparse(kw.value)
+    return flag, default_src
+
+
+def _check_one_default_per_flag(f: Findings) -> None:
+    """ADR-037 D10.4: a flag declared in more than one shared decorator must not
+    carry two different defaults (the ``--collect-mode`` double-default trap)."""
+    path = PKG / "cli_options.py"
+    if not path.is_file():
+        return
+    rel = _rel(path)
+    try:
+        tree = ast.parse(_read(path), filename=rel)
+    except SyntaxError:
+        return
+    defaults: dict[str, set[str]] = defaultdict(set)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "option"
+        ):
+            flag, default_src = _option_flag_and_default(node)
+            if flag is not None and default_src is not None:
+                defaults[flag].add(default_src)
+    for flag, seen in sorted(defaults.items()):
+        if len(seen) > 1 and flag not in _DEFERRED_MULTI_DEFAULT_FLAGS:
+            f.err(
+                "cli-contract",
+                f"{rel}: flag `{flag}` is declared with conflicting defaults "
+                f"{sorted(seen)} across shared decorators (ADR-037 D10.4). "
+                "Give it one default, or add it to `DEFERRED_MULTI_DEFAULT`.",
+            )
+
+
 def check_cli_contract(f: Findings) -> None:
     """ERROR if a front-end module calls a Tier-1 core entry point
     (``checker.compare``) directly instead of routing through the Tier-2 service.
@@ -1221,6 +1373,9 @@ def check_cli_contract(f: Findings) -> None:
                     "directly; route through `service.run_compare` / "
                     "`service.compare_snapshots` (ADR-037 D1/D10.1)",
                 )
+    # D10.2 shared-decorator coverage + D10.4 one-default-per-flag (ADR-037 D3).
+    _check_decorator_coverage(f)
+    _check_one_default_per_flag(f)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -129,6 +129,271 @@ def test_service_compare_call_is_not_flagged(
     assert not any(c == "cli-contract" for c, _ in findings.errors)
 
 
+# ── D10.2: shared-decorator coverage (ADR-037 D3 / G22 Phase 2) ──────────────
+
+
+def _registered_commands() -> dict:
+    """Force every verdict-emitting command module to register on ``main``."""
+    import abicheck.cli_appcompat  # noqa: F401  — registers `appcompat`
+    import abicheck.cli_compare_release  # noqa: F401  — registers `compare-release`
+    import abicheck.cli_max  # noqa: F401  — registers `deep-compare`
+    from abicheck.cli import main
+
+    return main.commands
+
+
+def _command_flags(cmd: object) -> set[str]:
+    flags: set[str] = set()
+    for p in cmd.params:  # type: ignore[attr-defined]
+        if getattr(p, "param_type_name", None) != "option":
+            continue
+        flags.update(p.opts)
+        flags.update(p.secondary_opts)
+    return flags
+
+
+def test_decorator_coverage() -> None:
+    """Every verdict-emitting command carries each required shared option family
+    (in full), or is on the ``INTENTIONAL_SUBSET`` allowlist (ADR-037 D10.2).
+
+    This introspects the *live Click params* — stronger than the gate's AST
+    decorator scan, so a family applied but secretly stripped would still fail.
+    """
+    from abicheck import cli_options as co
+
+    commands = _registered_commands()
+    for cmd_name in co.VERDICT_EMITTING_COMMANDS:
+        flags = _command_flags(commands[cmd_name])
+        for family in co.REQUIRED_FAMILIES:
+            if (cmd_name, family) in co.INTENTIONAL_SUBSET:
+                continue
+            missing = co.FAMILY_FLAGS[family] - flags
+            assert not missing, (
+                f"{cmd_name} is missing {family} flags {sorted(missing)} — "
+                "compose the shared decorator or add an INTENTIONAL_SUBSET entry"
+            )
+
+
+def test_intentional_subset_entries_are_real_gaps() -> None:
+    """An allowlisted (command, family) must be a *genuine* omission — otherwise
+    the allowlist rots into a rubber stamp for families that are actually present."""
+    from abicheck import cli_options as co
+
+    commands = _registered_commands()
+    for (cmd_name, family), reason in co.INTENTIONAL_SUBSET.items():
+        assert reason.strip(), f"{cmd_name}/{family} needs a non-empty reason"
+        flags = _command_flags(commands[cmd_name])
+        assert co.FAMILY_FLAGS[family] - flags, (
+            f"{cmd_name} actually carries the whole {family} family — drop the "
+            "INTENTIONAL_SUBSET entry"
+        )
+
+
+def test_gate_flags_missing_decorator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D10.2 is not a no-op: a verdict command lacking a required family is caught."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    # A `compare` command that composes only some of the required families.
+    (pkg / "cli.py").write_text(
+        "import click\n"
+        '@main.command("compare")\n'
+        "@two_sided_input_options\n"
+        "@policy_options\n"
+        "def compare_cmd():\n"
+        "    pass\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    msgs = [m for c, m in findings.errors if c == "cli-contract"]
+    # severity/scope/output are missing → three coverage errors naming `compare`.
+    missing = {fam for fam in ("severity_options", "scope_options", "output_options")
+               if any(fam in m and "compare" in m for m in msgs)}
+    assert missing == {"severity_options", "scope_options", "output_options"}, msgs
+
+
+def test_intentional_subset_decorator_is_not_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`deep-compare` omitting `@severity_options` is allowlisted, not an error."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_max.py").write_text(
+        "import click\n"
+        '@main.command("deep-compare")\n'
+        "@two_sided_input_options\n"
+        "@policy_options\n"
+        "@scope_options\n"
+        "@output_options(['json'])\n"
+        "def deep_compare_cmd():\n"
+        "    pass\n"
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    msgs = [m for c, m in findings.errors if c == "cli-contract"]
+    assert not any("deep-compare" in m and "severity_options" in m for m in msgs), msgs
+
+
+# ── D10.4: one default per flag (ADR-037 D3 / G22 Phase 2) ───────────────────
+
+
+def test_one_default_per_flag() -> None:
+    """The real ``cli_options.py`` has no un-deferred conflicting flag default."""
+    import scripts.check_ai_readiness as gate
+
+    findings = gate.Findings()
+    gate._check_one_default_per_flag(findings)
+    assert [m for c, m in findings.errors if c == "cli-contract"] == []
+
+
+def test_gate_flags_conflicting_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D10.4 catches the same ``--flag`` declared with two different defaults."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_options.py").write_text(
+        "import click\n"
+        "def a(func):\n"
+        '    return click.option("--mode", default="off")(func)\n'
+        "def b(func):\n"
+        '    return click.option("--mode", default="on")(func)\n'
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate._check_one_default_per_flag(findings)
+    msgs = [m for c, m in findings.errors if c == "cli-contract"]
+    assert len(msgs) == 1 and "--mode" in msgs[0], msgs
+
+
+def test_deferred_multi_default_is_not_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A flag on the ``DEFERRED_MULTI_DEFAULT`` allowlist is skipped (Phase 3)."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    (pkg / "cli_options.py").write_text(
+        "import click\n"
+        "def a(func):\n"
+        '    return click.option("--collect-mode", default="off")(func)\n'
+        "def b(func):\n"
+        '    return click.option("--collect-mode", default="source-target")(func)\n'
+    )
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate._check_one_default_per_flag(findings)
+    assert [m for c, m in findings.errors if c == "cli-contract"] == []
+
+
+# ── Gate tables mirror the cli_options source of truth ───────────────────────
+
+
+def test_gate_tables_mirror_cli_options() -> None:
+    """The pure-stdlib gate duplicates ``cli_options`` contract tables (it cannot
+    import the package). Assert the two never drift (ADR-037 D10)."""
+    import scripts.check_ai_readiness as gate
+    from abicheck import cli_options as co
+
+    # command ↔ module map (inverted between the two).
+    assert gate._VERDICT_CMD_MODULES == {
+        mod: cmd for cmd, mod in co.VERDICT_EMITTING_COMMANDS.items()
+    }
+    # required decorators = the decorator for each required family.
+    assert gate._REQUIRED_FAMILY_DECORATORS == frozenset(
+        co.FAMILY_DECORATOR[f] for f in co.REQUIRED_FAMILIES
+    )
+    # allowlist, mapped from (cmd, family) to (cmd, decorator).
+    assert gate._INTENTIONAL_SUBSET_DECORATORS == frozenset(
+        (cmd, co.FAMILY_DECORATOR[fam]) for (cmd, fam) in co.INTENTIONAL_SUBSET
+    )
+    assert gate._DEFERRED_MULTI_DEFAULT_FLAGS == co.DEFERRED_MULTI_DEFAULT
+
+
+# ── Resolved option-set snapshot (catches an accidental flag drop in review) ──
+
+# Frozen sets of every option spelling each verdict-emitting command exposes.
+# A diff here in review means a flag was added or dropped — update deliberately.
+_OPTION_SET_SNAPSHOT: dict[str, tuple[str, ...]] = {
+    "compare": (
+        "--annotate", "--annotate-additions", "--btf", "--collapse-versioned-symbols",
+        "--collect-mode", "--ctf", "--debug-format", "--debug-root", "--debug-root1",
+        "--debug-root2", "--debuginfod", "--debuginfod-url", "--demangle", "--dwarf",
+        "--dwarf-only", "--explain-patterns", "--follow-deps", "--format", "--header",
+        "--header-backend", "--include", "--lang", "--ld-library-path", "--new-build-info",
+        "--new-header", "--new-header-backend", "--new-include", "--new-pdb-path",
+        "--new-sources", "--new-version", "--no-demangle", "--no-pattern-verdicts",
+        "--no-scope-public-headers", "--old-build-info", "--old-header",
+        "--old-header-backend", "--old-include", "--old-pdb-path", "--old-sources",
+        "--old-version", "--output", "--pattern-verdicts", "--pdb-path", "--policy",
+        "--policy-file", "--probe-matrix-new", "--probe-matrix-old", "--public-symbol",
+        "--public-symbols-list", "--recommend", "--report-mode", "--require-justification",
+        "--scope-public-headers", "--search-path", "--severity-abi-breaking",
+        "--severity-addition", "--severity-potential-breaking", "--severity-preset",
+        "--severity-quality-issues", "--show-filtered", "--show-impact", "--show-only",
+        "--show-redundant", "--stat", "--strict-suppressions", "--suppress",
+        "--surface-metrics", "--verbose", "-H", "-I", "-o", "-v",
+    ),
+    "compare-release": (
+        "--annotate", "--annotate-additions", "--bundle-cohort", "--bundle-system-providers",
+        "--debug-info1", "--debug-info2", "--devel-pkg1", "--devel-pkg2", "--dso-only",
+        "--fail-on-removed-library", "--format", "--header", "--include",
+        "--include-private-dso", "--jobs", "--keep-extracted", "--lang", "--manifest",
+        "--new-header", "--new-include", "--new-version", "--no-bundle-analysis",
+        "--no-fail-on-removed-library", "--no-scope-public-headers", "--old-header",
+        "--old-include", "--old-version", "--output", "--output-dir", "--policy",
+        "--policy-file", "--probe-matrix-new", "--probe-matrix-old", "--require-justification",
+        "--scope-public-headers", "--severity-abi-breaking", "--severity-addition",
+        "--severity-potential-breaking", "--severity-preset", "--severity-quality-issues",
+        "--strict-suppressions", "--suppress", "--verbose", "-H", "-I", "-j", "-o", "-v",
+    ),
+    "appcompat": (
+        "--check-against", "--format", "--header", "--include", "--lang",
+        "--list-required-symbols", "--new-header", "--new-include", "--new-version",
+        "--no-scope-public-headers", "--old-header", "--old-include", "--old-version",
+        "--output", "--policy", "--policy-file", "--scope-public-headers",
+        "--severity-abi-breaking", "--severity-addition", "--severity-potential-breaking",
+        "--severity-preset", "--severity-quality-issues", "--show-irrelevant", "--suppress",
+        "--verbose", "-H", "-I", "-o", "-v",
+    ),
+    "deep-compare": (
+        "--depth", "--format", "--header", "--header-backend", "--include",
+        "--keep-snapshots", "--lang", "--max", "--new-build-info", "--new-header",
+        "--new-header-backend", "--new-include", "--new-sources", "--new-version",
+        "--no-scope-public-headers", "--old-build-info", "--old-header",
+        "--old-header-backend", "--old-include", "--old-sources", "--old-version",
+        "--output", "--policy", "--policy-file", "--recommend", "--scope-public-headers",
+        "--severity-preset", "--sources", "--suppress", "--verbose", "-H", "-I", "-o", "-v",
+    ),
+}
+
+
+@pytest.mark.parametrize("cmd_name", sorted(_OPTION_SET_SNAPSHOT))
+def test_option_set_snapshot(cmd_name: str) -> None:
+    """Each command's full option surface matches the frozen snapshot."""
+    commands = _registered_commands()
+    flags = _command_flags(commands[cmd_name])
+    assert sorted(flags) == sorted(_OPTION_SET_SNAPSHOT[cmd_name])
+
+
 # ── Chokepoint parity: one classifier, no scope_public drift ─────────────────
 
 

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -218,6 +218,26 @@ def test_gate_flags_missing_decorator(
     assert missing == {"severity_options", "scope_options", "output_options"}, msgs
 
 
+def test_gate_flags_missing_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mapped command whose module exists but no longer declares it is flagged
+    (D10.2 must not silently pass when coverage can't be verified)."""
+    import scripts.check_ai_readiness as gate
+
+    pkg = tmp_path / "abicheck"
+    pkg.mkdir()
+    # cli.py exists but the `compare` command has been removed from it.
+    (pkg / "cli.py").write_text("def helper():\n    return 1\n")
+    monkeypatch.setattr(gate, "PKG", pkg)
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+
+    findings = gate.Findings()
+    gate.check_cli_contract(findings)
+    msgs = [m for c, m in findings.errors if c == "cli-contract"]
+    assert any("`compare` was not found" in m for m in msgs), msgs
+
+
 def test_intentional_subset_decorator_is_not_flagged(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -356,9 +356,11 @@ _OPTION_SET_SNAPSHOT: dict[str, tuple[str, ...]] = {
     "compare": (
         "--annotate", "--annotate-additions", "--btf", "--collapse-versioned-symbols",
         "--collect-mode", "--ctf", "--debug-format", "--debug-root", "--debug-root1",
-        "--debug-root2", "--debuginfod", "--debuginfod-url", "--demangle", "--dwarf",
+        "--debug-root2", "--debuginfod", "--debuginfod-url", "--demangle", "--depth",
+        "--dwarf",
         "--dwarf-only", "--explain-patterns", "--follow-deps", "--format", "--header",
-        "--header-backend", "--include", "--lang", "--ld-library-path", "--new-build-info",
+        "--header-backend", "--include", "--lang", "--ld-library-path", "--max",
+        "--new-build-info",
         "--new-header", "--new-header-backend", "--new-include", "--new-pdb-path",
         "--new-sources", "--new-version", "--no-demangle", "--no-pattern-verdicts",
         "--no-scope-public-headers", "--old-build-info", "--old-header",

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -30,6 +30,7 @@ from abicheck.cli_params import DEPTH_PARAM
 
 
 def _registered() -> dict:
+    """Register every depth-bearing command on ``main`` and return its map."""
     import abicheck.cli_max  # noqa: F401  — registers deep-compare
     import abicheck.cli_scan  # noqa: F401  — registers scan
 
@@ -54,19 +55,29 @@ def test_depth_dial_is_uniform(cmd_name: str) -> None:
 # ── Alias resolution: every legacy spelling resolves to the right depth ──────
 
 
-def test_depth_alias_resolution() -> None:
-    """The user ladder passes through; deprecated ``graph`` → ``source`` (D6)."""
+@pytest.mark.parametrize("depth_value", ["symbols", "headers", "build", "source", "full"])
+def test_depth_user_rung_passes_through(depth_value: str) -> None:
+    """Each user-ladder rung resolves to itself, independently."""
+    assert DEPTH_PARAM.convert(depth_value, None, None) == depth_value
+
+
+def test_user_depths_match_ladder() -> None:
+    """The parametrized ladder above stays in lock-step with ``USER_DEPTHS``."""
     from abicheck.buildsource.scan_levels import USER_DEPTHS
 
-    for d in USER_DEPTHS:
-        assert DEPTH_PARAM.convert(d.value, None, None) == d.value
-    # `graph` is no longer a user rung; it resolves to `source` (the graph is
-    # built internally there).
-    assert DEPTH_PARAM.convert("graph", None, None) == "source"
-    assert DEPTH_PARAM.convert("GRAPH", None, None) == "source"
+    assert [d.value for d in USER_DEPTHS] == [
+        "symbols", "headers", "build", "source", "full"
+    ]
+
+
+@pytest.mark.parametrize("spelling", ["graph", "GRAPH"])
+def test_depth_graph_alias_resolves_to_source(spelling: str) -> None:
+    """``graph`` is no longer a user rung; it resolves to ``source`` (D6)."""
+    assert DEPTH_PARAM.convert(spelling, None, None) == "source"
 
 
 def _all_output(res: object) -> str:
+    """Combined stdout+stderr of a CliRunner result, click-version tolerant."""
     out = getattr(res, "output", "") or ""
     try:
         out += getattr(res, "stderr", "") or ""
@@ -195,3 +206,101 @@ def test_graph_detail_full_widens_changed_scope() -> None:
     assert effective_graph_scope("full", "target") == "target"
     assert effective_graph_scope("summary", "changed") == "changed"
     assert effective_graph_scope("summary", "target") == "target"
+
+
+def test_collect_inline_pack_applies_graph_scope_override() -> None:
+    """``collect_inline_pack`` runs the scope override and returns None for empty
+    input (exercising the override line without any compiler)."""
+    from abicheck.buildsource.inline import BuildConfig, collect_inline_pack
+
+    assert collect_inline_pack(
+        sources=None,
+        build_info=None,
+        build_config=BuildConfig(graph_detail="full"),
+        scope="changed",
+        layers=("L3", "L4", "L5"),
+    ) is None
+
+
+# ── Command bodies: depth resolution over snapshot inputs (no compiler) ───────
+
+
+def _snap(tmp_path, name: str, version: str, funcs):  # type: ignore[no-untyped-def]
+    """Write a minimal JSON snapshot with the given functions; return its path."""
+    from abicheck.model import AbiSnapshot
+    from abicheck.serialization import save_snapshot
+
+    p = tmp_path / f"{name}_{version}.json"
+    save_snapshot(AbiSnapshot(library=name, version=version, functions=funcs), p)
+    return p
+
+
+def _fn(name: str):  # type: ignore[no-untyped-def]
+    """A trivial public extern-C ``Function`` for snapshot fixtures."""
+    from abicheck.model import Function, Visibility
+
+    return Function(
+        name=name, mangled=name, return_type="int",
+        visibility=Visibility.PUBLIC, is_extern_c=True,
+    )
+
+
+@pytest.mark.parametrize("depth", ["symbols", "headers", "source"])
+def test_compare_accepts_depth_over_snapshots(tmp_path, depth: str) -> None:  # type: ignore[no-untyped-def]
+    """``compare`` folds ``--depth`` into the collect mode for snapshot inputs;
+    ``symbols`` clears headers, deeper rungs resolve without error."""
+    old = _snap(tmp_path, "libx", "1.0", [_fn("a"), _fn("b")])
+    new = _snap(tmp_path, "libx", "2.0", [_fn("a"), _fn("b")])
+    res = CliRunner().invoke(main, ["compare", str(old), str(new), "--depth", depth])
+    assert res.exit_code == 0, _all_output(res)
+
+
+def test_compare_collect_mode_deprecation_warns(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """An explicit ``--collect-mode`` on ``compare`` warns (deprecated, D5)."""
+    old = _snap(tmp_path, "liby", "1.0", [_fn("a")])
+    new = _snap(tmp_path, "liby", "2.0", [_fn("a")])
+    res = CliRunner().invoke(
+        main, ["compare", str(old), str(new), "--collect-mode", "off"]
+    )
+    assert res.exit_code == 0
+    assert "deprecated" in _all_output(res)
+
+
+@pytest.mark.parametrize("depth", ["symbols", "headers"])
+def test_deep_compare_depth_over_snapshots(tmp_path, depth: str) -> None:  # type: ignore[no-untyped-def]
+    """``deep-compare`` passes snapshot inputs straight through; ``--depth
+    symbols`` clears headers, the non-symbols branch leaves them as-is."""
+    import abicheck.cli_max  # noqa: F401
+
+    old = _snap(tmp_path, "libz", "1.0", [_fn("a")])
+    new = _snap(tmp_path, "libz", "2.0", [_fn("a")])
+    res = CliRunner().invoke(
+        main, ["deep-compare", str(old), str(new), "--depth", depth]
+    )
+    assert res.exit_code == 0, _all_output(res)
+
+
+def test_dump_source_only_collect_mode_warns(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A source-only ``dump`` with an explicit ``--collect-mode`` warns before
+    any collection (covers the deprecation note + the symbols branch path)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    res = CliRunner().invoke(
+        main,
+        ["dump", "--sources", str(src), "--collect-mode", "build",
+         "-o", str(tmp_path / "out.json")],
+    )
+    assert "deprecated" in _all_output(res)
+
+
+def test_dump_source_only_depth_symbols(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``dump --depth symbols`` resolves and runs the symbols-only branch."""
+    src = tmp_path / "src2"
+    src.mkdir()
+    res = CliRunner().invoke(
+        main,
+        ["dump", "--sources", str(src), "--depth", "symbols",
+         "-o", str(tmp_path / "out2.json")],
+    )
+    # Resolution + symbols-clearing ran (no crash from the new code path).
+    assert res.exit_code == 0 or "source" in _all_output(res).lower() or True

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified ``--depth`` dial + L5-internal graph (ADR-037 D5/D6 / G22 Phase 3).
+
+One depth vocabulary across ``compare``/``deep-compare``/``dump``/``scan``; the
+G21 ``graph`` rung and ``--collect-mode`` are deprecated aliases; the L5 graph is
+an internal consequence of ``--depth source``, never a user rung.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.cli_params import DEPTH_PARAM
+
+
+def _registered() -> dict:
+    import abicheck.cli_max  # noqa: F401  — registers deep-compare
+    import abicheck.cli_scan  # noqa: F401  — registers scan
+
+    return main.commands
+
+
+# ── One dial: every depth-bearing command shows the same user-facing ladder ──
+
+_DEPTH_COMMANDS = ("compare", "deep-compare", "dump", "scan")
+
+
+@pytest.mark.parametrize("cmd_name", _DEPTH_COMMANDS)
+def test_depth_dial_is_uniform(cmd_name: str) -> None:
+    """Each command's ``--depth`` exposes exactly the user ladder; ``graph`` gone."""
+    cmd = _registered()[cmd_name]
+    depth = next(p for p in cmd.params if "--depth" in getattr(p, "opts", []))
+    metavar = depth.type.get_metavar(depth)
+    assert metavar == "[symbols|headers|build|source|full]", (cmd_name, metavar)
+    assert "graph" not in metavar
+
+
+# ── Alias resolution: every legacy spelling resolves to the right depth ──────
+
+
+def test_depth_alias_resolution() -> None:
+    """The user ladder passes through; deprecated ``graph`` → ``source`` (D6)."""
+    from abicheck.buildsource.scan_levels import USER_DEPTHS
+
+    for d in USER_DEPTHS:
+        assert DEPTH_PARAM.convert(d.value, None, None) == d.value
+    # `graph` is no longer a user rung; it resolves to `source` (the graph is
+    # built internally there).
+    assert DEPTH_PARAM.convert("graph", None, None) == "source"
+    assert DEPTH_PARAM.convert("GRAPH", None, None) == "source"
+
+
+def _all_output(res: object) -> str:
+    out = getattr(res, "output", "") or ""
+    try:
+        out += getattr(res, "stderr", "") or ""
+    except ValueError:  # stderr not separately captured on this click
+        pass
+    return out
+
+
+def test_depth_graph_warns_on_stderr() -> None:
+    """The deprecated ``--depth graph`` resolves but prints a one-line note."""
+    # A bad operand makes the command fail fast *after* param conversion, so the
+    # deprecation note (emitted during conversion) is captured regardless.
+    res = CliRunner().invoke(main, ["dump", "--depth", "graph", "/no/such/bin"])
+    text = _all_output(res)
+    assert "deprecated" in text and "--depth source" in text
+
+
+def test_unknown_depth_rejected() -> None:
+    res = CliRunner().invoke(main, ["dump", "--depth", "bogus", "/no/such/bin"])
+    assert res.exit_code != 0
+    assert "is not one of" in _all_output(res)
+
+
+# ── Monotone ladder: each rung is a superset of the one below ────────────────
+
+
+def test_depth_monotone() -> None:
+    """``symbols ⊂ headers ⊂ build ⊂ source ⊂ full`` in collected layers.
+
+    Maps each user depth through the same resolution `dump`/`compare` use and
+    asserts the collected evidence layers only ever grow.
+    """
+    from abicheck.buildsource.scan_levels import (
+        USER_DEPTHS,
+        EvidenceDepth,
+        depth_to_method,
+        method_to_collect_mode,
+    )
+    from abicheck.buildsource.source_replay import collection_for_ci_mode
+
+    def layers_for(depth: EvidenceDepth) -> set[str]:
+        method = depth_to_method(depth)
+        if method is None:
+            return set()  # symbols/headers — no L3-L5 collection
+        mode = method_to_collect_mode(method)
+        _scope, layers = collection_for_ci_mode(mode)
+        return set(layers)
+
+    prev: set[str] = set()
+    for depth in USER_DEPTHS:
+        cur = layers_for(depth)
+        assert prev <= cur, f"{depth.value} dropped layers vs the rung below: {prev - cur}"
+        prev = cur
+
+
+def test_graph_excluded_from_user_ladder_but_kept_internal() -> None:
+    """``graph`` is dropped from the user dial (D6) yet survives internally for
+    the scan ``pr-deep`` mode / S4 — removing it would break determinism."""
+    from abicheck.buildsource.scan_levels import (
+        USER_DEPTHS,
+        EvidenceDepth,
+        ScanMode,
+        mode_preset,
+    )
+
+    assert EvidenceDepth.GRAPH not in USER_DEPTHS
+    # still the internal target of pr-deep (the L5-edges preset).
+    assert mode_preset(ScanMode.PR_DEEP)[1] is EvidenceDepth.GRAPH
+
+
+# ── L5 graph is internal at --depth source (D6) ──────────────────────────────
+
+
+def test_graph_built_at_source_depth() -> None:
+    """``--depth source`` resolves to a collect mode whose layers include L5 —
+    the graph is built automatically, with no user ``graph`` mode."""
+    from abicheck.buildsource.scan_levels import (
+        EvidenceDepth,
+        depth_to_method,
+        method_to_collect_mode,
+    )
+    from abicheck.buildsource.source_replay import collection_for_ci_mode
+
+    method = depth_to_method(EvidenceDepth.SOURCE)
+    assert method is not None
+    _scope, layers = collection_for_ci_mode(method_to_collect_mode(method))
+    assert "L5" in layers and "L4" in layers
+
+
+# ── --depth symbols suppresses the L2 header AST (symbols-only) ──────────────
+
+
+def test_resolve_dump_depth_symbols_collects_nothing() -> None:
+    from abicheck.cli_dump_helpers import resolve_dump_depth
+
+    assert resolve_dump_depth("symbols", False, "off", False) == "off"
+    assert resolve_dump_depth("headers", False, "off", False) == "off"
+    assert resolve_dump_depth("source", False, "off", False) != "off"
+
+
+# ── config: sources.graph: summary|full (ADR-037 D6) ─────────────────────────
+
+
+def test_graph_detail_config_default_and_parse() -> None:
+    from abicheck.buildsource.inline import BuildConfig
+
+    assert BuildConfig().graph_detail == "summary"
+    assert BuildConfig.from_dict({}).graph_detail == "summary"
+    assert BuildConfig.from_dict({"sources": {"graph": "full"}}).graph_detail == "full"
+
+
+def test_graph_detail_config_rejects_bad_value() -> None:
+    from abicheck.buildsource.inline import BuildConfig
+
+    with pytest.raises(ValueError, match="summary"):
+        BuildConfig.from_dict({"sources": {"graph": "deep"}})
+
+
+def test_graph_detail_full_widens_changed_scope() -> None:
+    """``sources.graph: full`` deepens a changed-scope collection to full scope;
+    ``summary`` (default) leaves the requested scope untouched (additive only)."""
+    from abicheck.buildsource.inline import effective_graph_scope
+
+    assert effective_graph_scope("full", "changed") == "target"
+    # never widens a non-changed scope, never shrinks, summary is a no-op.
+    assert effective_graph_scope("full", "target") == "target"
+    assert effective_graph_scope("summary", "changed") == "changed"
+    assert effective_graph_scope("summary", "target") == "target"

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -302,5 +302,7 @@ def test_dump_source_only_depth_symbols(tmp_path) -> None:  # type: ignore[no-un
         ["dump", "--sources", str(src), "--depth", "symbols",
          "-o", str(tmp_path / "out2.json")],
     )
-    # Resolution + symbols-clearing ran (no crash from the new code path).
-    assert res.exit_code == 0 or "source" in _all_output(res).lower() or True
+    # Resolution + symbols-clearing ran; a source-only symbols dump writes an
+    # L0-L2 snapshot and exits clean.
+    assert res.exit_code == 0, _all_output(res)
+    assert (tmp_path / "out2.json").is_file()


### PR DESCRIPTION
## G22 Phase 2 — Decorator-ize shared families (ADR-037 D3)

Implements [Phase 2 of the G22 plan](docs/development/plans/g22-cli-consolidation.md). Shared CLI option families are now defined **once** in `cli_options.py`; the four verdict-emitting commands compose them instead of re-declaring the same families inline (the copy-paste the ADR §Context #2 audit found already drifting).

### What changed

**New shared decorators in `cli_options.py`:**
- `two_sided_input_options` — `-H/-I`, per-side `--old/new-header/include`, `--old/new-version`
- `policy_options` — `--policy`, `--policy-file`, `--suppress`
- `severity_options` — `--severity-preset` + the four per-category overrides
- `scope_options` — `--scope-public-headers/--no-`
- `debug_resolution_options` — `--debug-root{,1,2}`, `--debuginfod[-url]`, `--debug-format` (+hidden `--btf/--ctf/--dwarf`), `--dwarf-only`
- `output_options(formats, …)` — a factory, because the producible `--format` set legitimately differs per command (`appcompat` has no sarif/junit; `compare-release` has no html/review)

**Recomposed** `compare`, `compare-release`, `appcompat`, `deep-compare` onto them, deleting the inline duplicates. Behaviour-preserving (all 11,250 fast tests pass); help text is now uniform and the documented divergences close. The only allowlisted gap is `deep-compare`, which intentionally exposes only the coarse `--severity-preset` (per-category severity is config-bound, ADR-037 D4).

**Contract enforcement (ADR-037 D10):**
- D10.2 (decorator coverage) and D10.4 (one-default-per-flag) added to the `cli-contract` AI-readiness gate as a pure-stdlib AST scan; the small contract tables are duplicated in the gate with a test asserting they stay in lock-step with `cli_options`.
- `tests/test_cli_contract.py` gains live-Click coverage, synthetic gate-violation tests (the gate is not a no-op), the gate↔source table-mirror test, and a frozen per-command option-set snapshot so an accidental flag drop is caught in review.

### Scope note
The seventh family, `@evidence_options` (`--depth`/`--collect-mode`/`--sources`/`--build-info`), is **deferred to Phase 3**, where the depth vocabulary is unified. The existing `build_source_*` helpers stay for now and their `--collect-mode` double-default — the exact case D10.4 exists to catch — is parked on a documented `DEFERRED_MULTI_DEFAULT` allowlist (with a Phase-3 pointer) rather than hidden. `dump`/`scan` are not verdict-emitting, so their recompose rides along with that depth work.

### Net effect
~330 lines of duplicated option declarations removed from the command modules and centralized; `cli.py` drops from 1480 → 1407 lines.

### Validation
- `pytest` fast lane: **11,250 passed**, 25 skipped
- `ruff check abicheck tests scripts`: clean
- `mypy abicheck/`: clean (0 issues, baseline held)
- `scripts/check_ai_readiness.py`: 0 errors (2 pre-existing, unrelated file-size warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEVxjGfwd2vde3rH3uHnbp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified the user-facing `--depth` ladder across compare/deep-compare/dump/scan (`symbols|headers|build|source|full`), with consistent validation and behavior.
  * Added configurable graph replay scope via `.abicheck.yml` (`sources.graph: summary|full`).
* **Bug Fixes**
  * Improved deprecation handling for legacy `--collect-mode` and `--depth graph`, including correct symbols/header-only behavior and warnings.
* **Refactor**
  * Consolidated CLI option wiring via shared option-family decorators for verdict-emitting commands.
* **Documentation**
  * Updated the CLI consolidation plan to reflect the new shared option families and depth vocabulary.
* **Tests**
  * Expanded CLI contract and `--depth` vocabulary/snapshot coverage across commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->