### PR TITLE
Close ADR-037 D1/D3 gaps: MCP tier-skip + unified evidence_options

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -61,10 +61,10 @@ from .cli_helpers_compare import (  # noqa: F401  — re-exported to keep cli im
 )
 from .cli_options import (
     adr027_compare_options,
-    build_source_compare_options,
     build_source_dump_options,
     debug_resolution_options,
     echo_ast_frontend_deprecation,
+    evidence_options,
     output_options,
     policy_options,
     scope_options,
@@ -1212,7 +1212,7 @@ def _dispatch_release_compare(ctx: click.Context, **kwargs: Any) -> None:
 # --dwarf-only, --debug-root{,1,2}, --debuginfod[-url], --debug-format (+hidden
 # --btf/--ctf/--dwarf): the shared local-ELF debug-resolution family.
 @debug_resolution_options
-@build_source_compare_options  # --old/new-build-info, --old/new-sources, --collect-mode
+@evidence_options  # --depth/--max, --old/new-build-info, --old/new-sources, --collect-mode
 @adr027_compare_options  # ADR-027: --pattern-verdicts/--explain-patterns/--surface-metrics
 @click.option("-v", "--verbose", is_flag=True, default=False,
               help="Enable verbose/debug output.")

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -518,17 +518,16 @@ FAMILY_FLAGS: dict[str, frozenset[str]] = {
     }),
     "scope": frozenset({"--scope-public-headers"}),
     "output": frozenset({"--format", "--output"}),
-    # Two-sided evidence family (ADR-037 D3 ``@evidence_options``). Documented for
-    # completeness; deliberately *not* in REQUIRED_FAMILIES — only commands that
-    # take source depth (``compare``) compose it (``--collect-mode`` is a hidden
-    # deprecated alias and is omitted here).
+    # Two-sided evidence family (ADR-037 D3 ``@evidence_options``): registered
+    # but *not* required — only commands that take source depth (``compare``)
+    # compose it; the hidden deprecated ``--collect-mode`` alias is omitted here.
     "evidence": frozenset({
         "--depth", "--max", "--old-sources", "--new-sources",
         "--old-build-info", "--new-build-info",
     }),
-    # Documented for completeness; deliberately *not* in REQUIRED_FAMILIES (it
-    # resolves local ELF debug artifacts, which the package/snapshot-oriented
-    # commands do not take).
+    # Local-ELF debug-resolution family: registered but *not* required either — it
+    # resolves local ELF debug artifacts the package/snapshot-oriented commands
+    # do not take.
     "debug_resolution": frozenset({
         "--dwarf-only", "--debug-root", "--debug-root1", "--debug-root2",
         "--debuginfod", "--debuginfod-url", "--debug-format",

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -430,8 +430,17 @@ def build_source_dump_options(func: F) -> F:
     return func
 
 
-def build_source_compare_options(func: F) -> F:
-    """Add the build-info / sources compare options.
+def evidence_options(func: F) -> F:
+    """The shared two-sided evidence family (ADR-037 D3's ``@evidence_options``).
+
+    The single source of truth for the depth/source/build-info surface a
+    *two-sided* verdict command exposes: ``--depth`` / ``--max`` plus the per-side
+    ``--old/new-sources`` and ``--old/new-build-info`` packs. ``dump`` is
+    single-sided (one artifact, plus the build-query knobs) so it composes the
+    sibling :func:`build_source_dump_options` instead — they are deliberately not
+    one decorator because their surfaces differ (per-side vs build-query), which
+    is why ``evidence`` is a registered-but-not-required family (only commands
+    that take source depth compose it).
 
     By default ``compare old.json new.json`` reads build-info + source facts
     **embedded** in each snapshot (single-artifact UX). The optional
@@ -482,6 +491,11 @@ def build_source_compare_options(func: F) -> F:
     return func
 
 
+#: Back-compat alias for the pre-ADR-037-D3 name. ``evidence_options`` is the
+#: canonical spelling (the D3 table); this keeps existing imports working.
+build_source_compare_options = evidence_options
+
+
 # ── ADR-037 D10: contract metadata (single source of truth for the gate) ──────
 #
 # The ``cli-contract`` AI-readiness gate (D10.2 decorator coverage, D10.4
@@ -504,6 +518,14 @@ FAMILY_FLAGS: dict[str, frozenset[str]] = {
     }),
     "scope": frozenset({"--scope-public-headers"}),
     "output": frozenset({"--format", "--output"}),
+    # Two-sided evidence family (ADR-037 D3 ``@evidence_options``). Documented for
+    # completeness; deliberately *not* in REQUIRED_FAMILIES — only commands that
+    # take source depth (``compare``) compose it (``--collect-mode`` is a hidden
+    # deprecated alias and is omitted here).
+    "evidence": frozenset({
+        "--depth", "--max", "--old-sources", "--new-sources",
+        "--old-build-info", "--new-build-info",
+    }),
     # Documented for completeness; deliberately *not* in REQUIRED_FAMILIES (it
     # resolves local ELF debug artifacts, which the package/snapshot-oriented
     # commands do not take).
@@ -522,12 +544,17 @@ FAMILY_DECORATOR: dict[str, str] = {
     "severity": "severity_options",
     "scope": "scope_options",
     "output": "output_options",
+    "evidence": "evidence_options",
 }
 
 #: Families every verdict-emitting command must compose (unless allowlisted).
 #: ``debug_resolution`` is deliberately *not* required — it resolves local ELF
 #: debug artifacts that the package/snapshot-oriented commands do not take.
-REQUIRED_FAMILIES: frozenset[str] = frozenset(FAMILY_DECORATOR)
+#: ``evidence`` is likewise registered-but-not-required — only commands that take
+#: source depth (``compare``) compose ``@evidence_options`` (ADR-037 D3).
+REQUIRED_FAMILIES: frozenset[str] = frozenset({
+    "two_sided_input", "policy", "severity", "scope", "output",
+})
 
 #: command name → module basename, for the gate to locate each command's source.
 VERDICT_EMITTING_COMMANDS: dict[str, str] = {

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -50,7 +50,7 @@ except Exception as _exc:  # noqa: BLE001
         "Try: pip install --upgrade 'abicheck[mcp]'"
     ) from _exc
 
-from .checker import DiffResult, compare
+from .checker import DiffResult
 from .checker_policy import (
     API_BREAK_KINDS,
     BREAKING_KINDS,
@@ -67,6 +67,7 @@ from .errors import AbicheckError
 from .model import AbiSnapshot
 from .reporter import to_json, to_markdown
 from .serialization import snapshot_to_json
+from .service import compare_snapshots
 
 _logger = logging.getLogger("abicheck.mcp")
 
@@ -641,7 +642,7 @@ def abi_compare(
             return (
                 old_snap,
                 new_snap,
-                compare(
+                compare_snapshots(
                     old_snap,
                     new_snap,
                     suppression=suppression,

--- a/docs/development/plans/g22-cli-consolidation.md
+++ b/docs/development/plans/g22-cli-consolidation.md
@@ -81,10 +81,12 @@ Each phase = one PR. Sub-structure: **Work** · **Tests** · **Risk & rollback**
 (`validate()`)/`OutputSpec`; `service.run_compare` is a kwargs shim over
 `run_compare_request(CompareRequest)`, and the new Tier-2 `service.compare_snapshots`
 wraps `checker.compare` so every front-end (`compare`, `compare-release`,
-`scan`, `appcompat`) routes through Tier 2 — no `cli*.py` calls `checker.compare`
-directly. Enforced by the `cli-contract` AI-readiness check (D10.1) and mirrored
-in `tests/test_cli_contract.py`; `tests/test_api_types.py` covers the request
-struct. The remaining phases (2–7) are still open.
+`scan`, `appcompat`, and the MCP server `abi_compare`) routes through Tier 2 — no
+front-end calls `checker.compare` directly. Enforced by the `cli-contract`
+AI-readiness check (D10.1), which now scans `mcp_server.py` alongside every
+`cli*.py` and `appcompat.py`, and mirrored in `tests/test_cli_contract.py`;
+`tests/test_api_types.py` covers the request struct. The remaining phases (2–7)
+are still open.
 
 **Work.** Add `api_types.py` (`InputSpec`, `CompareRequest`+`validate()`,
 `OutputSpec`); struct fields via `field(default_factory=...)` (a frozen
@@ -125,14 +127,15 @@ coarse `--severity-preset` and is the sole `INTENTIONAL_SUBSET` entry. The
 (one-default-per-flag), mirrored in `tests/test_cli_contract.py` along with the
 per-command option-set snapshot and the gate↔`cli_options` table-mirror test.
 
-The seventh decorator, **`@evidence_options` (`--depth`/`--collect-mode`/
-`--sources`/`--build-info`), is deferred to Phase 3** where the depth vocabulary
-is unified: the existing `build_source_compare_options`/`build_source_dump_options`
-helpers stay as-is for now, and their `--collect-mode` double-default (the very
-case D10.4 exists to catch) is parked on the `DEFERRED_MULTI_DEFAULT` allowlist
-with a pointer to Phase 3 rather than hidden. `dump`/`scan` are not in the
-verdict-emitting set, so their recompose rides along with the depth work in
-Phase 3.
+The seventh decorator, **`@evidence_options` (`--depth`/`--max`/per-side
+`--old/new-sources`/`--old/new-build-info`, plus the hidden `--collect-mode`
+alias), now exists as the canonical two-sided evidence family** (the pre-rename
+`build_source_compare_options` is kept as a back-compat alias). It is registered
+in the contract tables as a *non-required* family (`FAMILY_FLAGS["evidence"]` /
+`FAMILY_DECORATOR["evidence"]`) because only commands that take source depth
+(`compare`) compose it. `dump` stays single-sided on the sibling
+`build_source_dump_options` (it adds the build-query knobs and has no per-side
+packs), so the two are deliberately not merged into one decorator.
 
 **Original plan.** Define the 7 decorators in `cli_options.py` (ADR-037 D3 table).
 Recompose `compare`, `compare-release`, `appcompat`, `deep-compare`, `dump`,

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1176,12 +1176,15 @@ def _checker_module_bindings(tree: ast.Module) -> set[str]:
 
 
 def _iter_cli_contract_sources() -> Iterable[Path]:
-    """The front-end modules the contract covers: every ``cli*.py`` plus the
-    consumer-side ``appcompat.py`` (it is a verdict-emitting front-end too)."""
+    """The front-end modules the contract covers: every ``cli*.py``, the
+    consumer-side ``appcompat.py`` (a verdict-emitting front-end too), and the
+    MCP server ``mcp_server.py`` — ADR-037 D1 names MCP a Tier-3 front-end, so it
+    must route through the Tier-2 service just like the CLI commands."""
     yield from PKG.glob("cli*.py")
-    appcompat = PKG / "appcompat.py"
-    if appcompat.is_file():
-        yield appcompat
+    for extra in ("appcompat.py", "mcp_server.py"):
+        path = PKG / extra
+        if path.is_file():
+            yield path
 
 
 # ── ADR-037 D10.2 / D10.4: shared-decorator coverage + one-default-per-flag ───
@@ -1442,7 +1445,8 @@ def check_cli_contract(f: Findings) -> None:
     """ERROR if a front-end module calls a Tier-1 core entry point
     (``checker.compare``) directly instead of routing through the Tier-2 service.
 
-    Covers every ``abicheck/cli*.py`` and ``abicheck/appcompat.py``. ADR-037
+    Covers every ``abicheck/cli*.py``, ``abicheck/appcompat.py``, and
+    ``abicheck/mcp_server.py``. ADR-037
     D1/D10.1: front-ends are thin adapters; one classification path is what keeps
     ``compare`` / ``compare-release`` / ``appcompat`` / MCP from drifting apart
     (the ``scope_public`` default divergence the ADR documents). Importing a

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -573,7 +573,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare",
+            "abicheck.mcp_server.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -605,7 +605,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare",
+            "abicheck.mcp_server.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -629,7 +629,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare",
+            "abicheck.mcp_server.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -652,7 +652,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare",
+            "abicheck.mcp_server.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -676,7 +676,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare",
+            "abicheck.mcp_server.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -700,7 +700,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare",
+            "abicheck.mcp_server.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(


### PR DESCRIPTION
## What

Closes the two remaining deviations from **ADR-037 (CLI Interface Contract)** found during a verification pass — the rest of D1–D12 already held up.

### D1 — MCP front-end bypassed the service layer
ADR-037 D1 names `mcp_server` a Tier-3 front-end that must route through the Tier-2 service, and D10.1 forbids any front-end calling Tier-1 `checker.compare` directly. But `mcp_server.py` called `checker.compare(...)` directly, and the `cli-contract` D10.1 gate only scanned `cli*.py` + `appcompat.py` — so the violation was **silent** (the exact two-classification-path defect the ADR set out to remove, relocated to MCP).

- `abi_compare` now routes through `service.compare_snapshots` (the Tier-2 snapshot verb, identical signature).
- `_iter_cli_contract_sources()` now also yields `mcp_server.py`, so D10.1 enforces the single-classifier guarantee for MCP too.

### D3 — the seventh decorator was never unified
ADR-037 D3 lists `@evidence_options` as a shared family; in code it lived as `build_source_compare_options`.

- Renamed to `evidence_options` (canonical D3 spelling); `build_source_compare_options` stays as a back-compat alias.
- Registered as a **non-required** family in the contract tables (`FAMILY_FLAGS["evidence"]` / `FAMILY_DECORATOR["evidence"]`) — only commands that take source depth (`compare`) compose it.
- `dump` keeps its single-sided sibling `build_source_dump_options` (build-query knobs, no per-side packs) — the two are deliberately not merged.

## Tests
- `mypy abicheck/` clean; `ruff` clean; `check_ai_readiness.py` 0 errors.
- Repointed the 6 `test_mcp_server_coverage.py` monkeypatches from `mcp_server.compare` → `mcp_server.compare_snapshots`.
- Full fast unit lane green (11358 passed).

## Docs
- Updated `docs/development/plans/g22-cli-consolidation.md` (Phase 1 MCP coverage, Phase 2 `@evidence_options` unification) to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMkzLEx8mBDsVa4Wth91nz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the `compare` CLI to use a shared two-sided “evidence” option set, supporting `--depth/--max` plus per-side old/new sources and build-info scoping.
* **Bug Fixes**
  * Ensured `abi_compare` uses the correct snapshot comparison flow to produce consistent diff results/metadata.
* **Documentation**
  * Refreshed the CLI consolidation plan to document the canonical evidence decorator and expanded contract scan coverage.
* **Tests**
  * Updated MCP server coverage tests to stub the correct comparison entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->