### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ No changes yet.
 
 ---
 
+## [0.4.0] — 2026-06-18
+
+### Changed
+
+- Version bump to 0.4.0.
+
+---
+
 ## [0.3.0] — 2026-06-03
 
 ### Added
@@ -501,4 +509,5 @@ additional capabilities.
 [0.1.0]: https://github.com/abicheck/abicheck/releases/tag/v0.1.0
 [0.2.0]: https://github.com/abicheck/abicheck/releases/tag/v0.2.0
 [0.3.0]: https://github.com/abicheck/abicheck/releases/tag/v0.3.0
-[Unreleased]: https://github.com/abicheck/abicheck/compare/v0.3.0...HEAD
+[0.4.0]: https://github.com/abicheck/abicheck/releases/tag/v0.4.0
+[Unreleased]: https://github.com/abicheck/abicheck/compare/v0.4.0...HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abicheck"
-version = "0.3.0"
+version = "0.4.0"
 description = "ABI compatibility checker for C/C++ shared libraries"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bumps the product version from `0.3.0` to `0.4.0`.

## Changes

- `pyproject.toml`: `version = "0.4.0"` (the canonical source — `abicheck.__version__` reads it from package metadata).
- `CHANGELOG.md`: added a `[0.4.0] — 2026-06-18` section and the version compare/release link references.

## Verification

- `python -c "import abicheck; print(abicheck.__version__)"` → `0.4.0`
- No tests pin the previous version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QytFvQanSSTDENA8QzDuyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QytFvQanSSTDENA8QzDuyG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.4.0
  * Changelog updated with release information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->