### PR TITLE
feat: align dump↔scan L2 compile context + give clang castxml-parity system-include detection

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -137,6 +137,16 @@ class BuildConfig:
     suppression_require_justification: bool | None = None
     #: ``source:`` — precise S-axis for power users (``s0``..``s6``/``auto``).
     source_method: str | None = None
+    #: ``compile:`` — the stable half of the L2 header compile context (ADR-035
+    #: D6.1 / ADR-037 D4). The project's reviewed include roots / dialect / feature
+    #: macros / frontend; per-invocation cross-compile flags stay CLI overrides
+    #: (CLI > config). ``None``/empty = unset, so the CLI flag wins unambiguously.
+    compile_frontend: str | None = None
+    compile_std: str | None = None
+    compile_include_dirs: list[str] = field(default_factory=list)
+    compile_defines: list[str] = field(default_factory=list)
+    compile_sysroot: str | None = None
+    compile_nostdinc: bool | None = None
     #: ``exit_code_scheme:`` — ADR-037 D12; CI keys on it, so it lives in config.
     exit_code_scheme: str = "auto"
     #: ``version:`` — config schema version (forward-compat; Phase 7 wires the
@@ -149,20 +159,46 @@ class BuildConfig:
     #: project can adopt a future key without breaking older installs. Keys parsed
     #: by sibling modules (``risk_rules`` → ``risk.py``, ``crosschecks`` →
     #: ``crosscheck.py``) are listed so they don't trip the warning.
-    _KNOWN_TOP_KEYS: ClassVar[frozenset[str]] = frozenset({
-        "build", "sources", "severity", "scope", "suppression", "source",
-        "exit_code_scheme", "version", "risk_rules", "crosschecks",
-    })
+    _KNOWN_TOP_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "build",
+            "sources",
+            "severity",
+            "scope",
+            "suppression",
+            "source",
+            "compile",
+            "exit_code_scheme",
+            "version",
+            "risk_rules",
+            "crosschecks",
+        }
+    )
     _KNOWN_BLOCK_KEYS: ClassVar[dict[str, frozenset[str]]] = {
         "build": frozenset({"system", "query", "compile_db"}),
         "sources": frozenset({"public_headers", "exclude", "graph"}),
-        "severity": frozenset({
-            "preset", "abi_breaking", "potential_breaking",
-            "quality_issues", "addition",
-        }),
+        "severity": frozenset(
+            {
+                "preset",
+                "abi_breaking",
+                "potential_breaking",
+                "quality_issues",
+                "addition",
+            }
+        ),
         "scope": frozenset({"public", "collapse_versioned_symbols", "public_symbols"}),
         "suppression": frozenset({"strict", "require_justification"}),
         "source": frozenset({"method", "graph"}),
+        "compile": frozenset(
+            {
+                "frontend",
+                "std",
+                "include_dirs",
+                "defines",
+                "sysroot",
+                "nostdinc",
+            }
+        ),
     }
 
     @classmethod
@@ -206,6 +242,8 @@ class BuildConfig:
         suppression = suppression if isinstance(suppression, dict) else {}
         source = data.get("source") if isinstance(data, dict) else None
         source = source if isinstance(source, dict) else {}
+        compile_blk = data.get("compile") if isinstance(data, dict) else None
+        compile_blk = compile_blk if isinstance(compile_blk, dict) else {}
 
         def _str(d: dict[str, object], key: str, default: str = "") -> str:
             v = d.get(key)
@@ -247,14 +285,32 @@ class BuildConfig:
                 f"severity.preset must be one of {_SEVERITY_PRESETS}, got {preset!r}"
             )
 
-        scheme = _str(data if isinstance(data, dict) else {}, "exit_code_scheme", "auto") or "auto"
+        scheme = (
+            _str(data if isinstance(data, dict) else {}, "exit_code_scheme", "auto")
+            or "auto"
+        )
         if scheme not in _EXIT_CODE_SCHEMES:
             raise ValueError(
                 f"exit_code_scheme must be one of {_EXIT_CODE_SCHEMES}, got {scheme!r}"
             )
 
         version_raw = data.get("version") if isinstance(data, dict) else None
-        version = version_raw if isinstance(version_raw, int) and not isinstance(version_raw, bool) else 0
+        version = (
+            version_raw
+            if isinstance(version_raw, int) and not isinstance(version_raw, bool)
+            else 0
+        )
+
+        compile_frontend = _opt_str(compile_blk, "frontend")
+        if compile_frontend is not None and compile_frontend not in (
+            "auto",
+            "castxml",
+            "clang",
+        ):
+            raise ValueError(
+                "compile.frontend must be one of ('auto', 'castxml', 'clang'), "
+                f"got {compile_frontend!r}"
+            )
 
         return cls(
             system=_str(build, "system", "auto") or "auto",
@@ -272,8 +328,16 @@ class BuildConfig:
             collapse_versioned_symbols=_opt_bool(scope, "collapse_versioned_symbols"),
             public_symbols=_strs(scope, "public_symbols"),
             suppression_strict=_opt_bool(suppression, "strict"),
-            suppression_require_justification=_opt_bool(suppression, "require_justification"),
+            suppression_require_justification=_opt_bool(
+                suppression, "require_justification"
+            ),
             source_method=_opt_str(source, "method"),
+            compile_frontend=compile_frontend,
+            compile_std=_opt_str(compile_blk, "std"),
+            compile_include_dirs=_strs(compile_blk, "include_dirs"),
+            compile_defines=_strs(compile_blk, "defines"),
+            compile_sysroot=_opt_str(compile_blk, "sysroot"),
+            compile_nostdinc=_opt_bool(compile_blk, "nostdinc"),
             exit_code_scheme=scheme,
             version=version,
         )
@@ -330,12 +394,30 @@ class BuildConfig:
         if self.suppression_strict is not None:
             suppression["strict"] = self.suppression_strict
         if self.suppression_require_justification is not None:
-            suppression["require_justification"] = self.suppression_require_justification
+            suppression["require_justification"] = (
+                self.suppression_require_justification
+            )
         if suppression:
             out["suppression"] = suppression
 
         if self.source_method is not None:
             out["source"] = {"method": self.source_method}
+
+        compile_blk: dict[str, Any] = {}
+        if self.compile_frontend is not None:
+            compile_blk["frontend"] = self.compile_frontend
+        if self.compile_std is not None:
+            compile_blk["std"] = self.compile_std
+        if self.compile_include_dirs:
+            compile_blk["include_dirs"] = list(self.compile_include_dirs)
+        if self.compile_defines:
+            compile_blk["defines"] = list(self.compile_defines)
+        if self.compile_sysroot is not None:
+            compile_blk["sysroot"] = self.compile_sysroot
+        if self.compile_nostdinc is not None:
+            compile_blk["nostdinc"] = self.compile_nostdinc
+        if compile_blk:
+            out["compile"] = compile_blk
 
         if self.exit_code_scheme and self.exit_code_scheme != "auto":
             out["exit_code_scheme"] = self.exit_code_scheme

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -302,6 +302,10 @@ class BuildConfig:
         )
 
         compile_frontend = _opt_str(compile_blk, "frontend")
+        if compile_frontend is not None:
+            # The CLI accepts the frontend case-insensitively (Click Choice
+            # case_sensitive=False); normalize the config value to match.
+            compile_frontend = compile_frontend.lower()
         if compile_frontend is not None and compile_frontend not in (
             "auto",
             "castxml",

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -62,6 +62,7 @@ from .cli_helpers_compare import (  # noqa: F401  — re-exported to keep cli im
 from .cli_options import (
     adr027_compare_options,
     build_source_dump_options,
+    compile_context_options,
     debug_resolution_options,
     echo_ast_frontend_deprecation,
     evidence_options,
@@ -392,35 +393,12 @@ def main() -> None:
 @click.option("--lang", default="c++", show_default=True,
               type=click.Choice(["c++", "c"], case_sensitive=False),
               help="Language mode for the header backend.")
-@click.option("--ast-frontend", "--header-backend", "header_backend",
-              default="auto", show_default=True,
-              type=click.Choice(["auto", "castxml", "clang"], case_sensitive=False),
-              help="C/C++ AST frontend (ADR-037 D8): castxml (default schema "
-                   "reference) or clang (-ast-dump=json; for hosts where castxml is "
-                   "absent or its bundled frontend chokes). auto = castxml if "
-                   "present, else clang, and auto-falls back to clang when castxml "
-                   "hits a toolchain-version error. Env: ABICHECK_AST_FRONTEND. "
-                   "(--header-backend is a deprecated alias.)")
 @click.option("-o", "--output", "output", type=click.Path(path_type=Path), default=None,
               help="Output JSON file. Defaults to stdout.")
-# ── Cross-compilation flags ───────────────────────────────────────────────────
-@click.option("--gcc-path", default=None,
-              help="Path to GCC/G++ cross-compiler binary.")
-@click.option("--gcc-prefix", default=None,
-              help="Cross-toolchain prefix (e.g. aarch64-linux-gnu-).")
-@click.option("--gcc-options", default=None,
-              help="Extra compiler flags passed through to castxml (split on "
-                   "whitespace). For a flag whose value contains spaces, use the "
-                   "repeatable --gcc-option instead.")
-@click.option("--gcc-option", "gcc_option_tokens", multiple=True,
-              help="A single extra compiler flag passed through to castxml "
-                   "verbatim (repeatable; not whitespace-split). Use two flags for "
-                   "a flag + spaced value, e.g. --gcc-option=-include "
-                   "--gcc-option='some header.h'.")
-@click.option("--sysroot", type=click.Path(path_type=Path), default=None,
-              help="Alternative system root directory.")
-@click.option("--nostdinc", is_flag=True, default=False,
-              help="Do not search standard system include paths.")
+# ── L2 compile context (shared with `scan` — ADR-037 D3 parity) ──────────────
+# --ast-frontend / --gcc-path / --gcc-prefix / --gcc-options / --gcc-option /
+# --sysroot / --nostdinc are defined once in cli_options.compile_context_options
+# so `dump` and `scan` never drift; applied as a decorator below.
 @click.option("--pdb-path", "pdb_path", type=click.Path(path_type=Path), default=None,
               help="Explicit path to PDB file for Windows PE debug info. "
                    "Overrides automatic PDB discovery from the PE debug directory.")
@@ -482,6 +460,7 @@ def main() -> None:
 @click.option("--no-git", "no_git", is_flag=True, default=False,
               help="Do not auto-detect git commit SHA.")
 @build_source_dump_options  # --build-info / --sources (embed inline)
+@compile_context_options  # --ast-frontend + cross-toolchain (shared with `scan`)
 def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Path, ...],
              public_headers: tuple[Path, ...], public_header_dirs: tuple[Path, ...],
              version: str, lang: str, header_backend: str, output: Path | None,

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -249,12 +249,13 @@ def compile_context_options(func: F) -> F:
     :class:`~abicheck.service_scan.CompileContext` kwargs exactly.
     """
     func = click.option(
-        "--nostdinc",
+        "--nostdinc/--no-nostdinc",
         "nostdinc",
-        is_flag=True,
         default=False,
         help="Do not search the standard system include paths (suppresses the "
-        "castxml/clang system-include auto-detection too).",
+        "castxml/clang system-include auto-detection too). Paired form so an "
+        "explicit --no-nostdinc on `scan` can override a config `compile.nostdinc: "
+        "true` for a one-off run (CLI > config).",
     )(func)
     func = click.option(
         "--sysroot",

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -235,6 +235,77 @@ def scope_options(func: F) -> F:
     return func
 
 
+def compile_context_options(func: F) -> F:
+    """L2 header-AST compile context — the cross-toolchain + frontend family.
+
+    The single source of truth for the flags that tell the header frontend how to
+    parse the public headers: ``--ast-frontend`` (which frontend), the cross
+    compiler (``--gcc-path``/``--gcc-prefix``), pass-through compiler flags
+    (``--gcc-options``/``--gcc-option``), an alternate ``--sysroot``, and
+    ``--nostdinc``. Shared verbatim by ``dump`` **and** ``scan`` so the two never
+    drift (ADR-037 D3 parity; ADR-035 amendment — ``scan`` must be able to reach a
+    real L2). Decorators apply bottom-up, so the options are listed in reverse of
+    their displayed order. Dest names match the ``dumper.dump`` /
+    :class:`~abicheck.service_scan.CompileContext` kwargs exactly.
+    """
+    func = click.option(
+        "--nostdinc",
+        "nostdinc",
+        is_flag=True,
+        default=False,
+        help="Do not search the standard system include paths (suppresses the "
+        "castxml↔clang system-include auto-detection too).",
+    )(func)
+    func = click.option(
+        "--sysroot",
+        "sysroot",
+        type=click.Path(path_type=Path),
+        default=None,
+        help="Alternative system root directory for header resolution.",
+    )(func)
+    func = click.option(
+        "--gcc-option",
+        "gcc_option_tokens",
+        multiple=True,
+        help="A single extra compiler flag passed to the header frontend verbatim "
+        "(repeatable; not whitespace-split). Use two for a flag + spaced value, "
+        "e.g. --gcc-option=-include --gcc-option='some header.h'.",
+    )(func)
+    func = click.option(
+        "--gcc-options",
+        "gcc_options",
+        default=None,
+        help="Extra compiler flags passed through to the header frontend (split on "
+        "whitespace). For a flag whose value contains spaces use --gcc-option.",
+    )(func)
+    func = click.option(
+        "--gcc-prefix",
+        "gcc_prefix",
+        default=None,
+        help="Cross-toolchain prefix (e.g. aarch64-linux-gnu-).",
+    )(func)
+    func = click.option(
+        "--gcc-path",
+        "gcc_path",
+        default=None,
+        help="Path to a GCC/G++ (or clang) cross-compiler binary.",
+    )(func)
+    func = click.option(
+        "--ast-frontend",
+        "--header-backend",
+        "header_backend",
+        default="auto",
+        show_default=True,
+        type=click.Choice(["auto", "castxml", "clang"], case_sensitive=False),
+        help="C/C++ AST frontend (ADR-037 D8): castxml (default schema reference) "
+        "or clang (-ast-dump=json; for hosts where castxml is absent or its "
+        "bundled frontend chokes). auto = castxml if present, else clang, with an "
+        "automatic clang fallback on a castxml toolchain-version error. Env: "
+        "ABICHECK_AST_FRONTEND. (--header-backend is a deprecated alias.)",
+    )(func)
+    return func
+
+
 def output_options(
     formats: Sequence[str],
     *,

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -254,7 +254,7 @@ def compile_context_options(func: F) -> F:
         is_flag=True,
         default=False,
         help="Do not search the standard system include paths (suppresses the "
-        "castxml↔clang system-include auto-detection too).",
+        "castxml/clang system-include auto-detection too).",
     )(func)
     func = click.option(
         "--sysroot",

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -391,6 +391,71 @@ def _render_text(out: ScanOutcome) -> str:
     return "\n".join(lines)
 
 
+def _merge_compile_config(
+    cli_ctx: Any,
+    cli_includes: tuple[Path, ...],
+    build_config: Path | None,
+) -> tuple[Any, tuple[Path, ...]]:
+    """Fold a ``.abicheck.yml`` ``compile:`` block into the CLI compile context.
+
+    Precedence is CLI > config (ADR-035 D6.1 / ADR-037 D4): a per-field CLI value
+    overrides config, an unset CLI field inherits it. The config's ``std`` +
+    ``defines`` synthesize ``-std=…``/``-D…`` flags only when the user did not pass
+    ``--gcc-options``; ``include_dirs`` (resolved against the config's directory)
+    are appended *after* the CLI ``-I`` so explicit roots keep search precedence.
+    Returns the merged ``(CompileContext, includes)``.
+    """
+    from .service_scan import CompileContext
+
+    if build_config is None:
+        return cli_ctx, cli_includes
+    from .buildsource.inline import load_build_config
+
+    try:
+        bc = load_build_config(build_config)
+    except ValueError:
+        # Best-effort, like the level-implies-query probe: a malformed --config is
+        # swallowed here so a no-source scan still runs; the real downstream load
+        # (embed_build_source, when --sources is given) surfaces it as a clean
+        # ClickException (tests: malformed_build_config_yaml_is_click_error /
+        # level_implies_query_malformed_config_does_not_crash).
+        return cli_ctx, cli_includes
+    base = build_config.parent
+
+    frontend = (
+        cli_ctx.frontend
+        if cli_ctx.frontend != "auto"
+        else (bc.compile_frontend or "auto")
+    )
+    if cli_ctx.gcc_options is not None:
+        gcc_options = cli_ctx.gcc_options
+    else:
+        parts: list[str] = []
+        if bc.compile_std:
+            parts.append(f"-std={bc.compile_std}")
+        parts += [f"-D{d}" for d in bc.compile_defines]
+        gcc_options = " ".join(parts) or None
+    sysroot = (
+        cli_ctx.sysroot
+        if cli_ctx.sysroot is not None
+        else (Path(bc.compile_sysroot) if bc.compile_sysroot else None)
+    )
+    merged = CompileContext(
+        gcc_path=cli_ctx.gcc_path,
+        gcc_prefix=cli_ctx.gcc_prefix,
+        gcc_options=gcc_options,
+        gcc_option_tokens=cli_ctx.gcc_option_tokens,
+        sysroot=sysroot,
+        nostdinc=cli_ctx.nostdinc or bool(bc.compile_nostdinc),
+        frontend=frontend,
+    )
+    includes = tuple(cli_includes) + tuple(
+        (base / p) if not Path(p).is_absolute() else Path(p)
+        for p in bc.compile_include_dirs
+    )
+    return merged, includes
+
+
 def _build_new_snapshot(
     binary: Path,
     headers: list[Path],
@@ -743,6 +808,10 @@ def scan_cmd(
         sysroot=sysroot,
         nostdinc=nostdinc,
         frontend=header_backend,
+    )
+    # Fold the project's `.abicheck.yml` compile: block in (CLI > config).
+    compile_context, includes = _merge_compile_config(
+        compile_context, tuple(includes), build_config
     )
 
     if len(binaries) != 1:

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -395,6 +395,7 @@ def _merge_compile_config(
     cli_ctx: Any,
     cli_includes: tuple[Path, ...],
     build_config: Path | None,
+    sources: Path | None = None,
 ) -> tuple[Any, tuple[Path, ...]]:
     """Fold a ``.abicheck.yml`` ``compile:`` block into the CLI compile context.
 
@@ -404,23 +405,31 @@ def _merge_compile_config(
     ``--gcc-options``; ``include_dirs`` (resolved against the config's directory)
     are appended *after* the CLI ``-I`` so explicit roots keep search precedence.
     Returns the merged ``(CompileContext, includes)``.
+
+    The config is the explicit ``--config`` when given, else the ``.abicheck.yml``
+    auto-discovered at the ``--sources`` tree root — so a source-tree scan honors
+    the project's ``compile:`` block for L2 the same way ``embed_build_source``
+    honors its other non-executable settings for L3-L5 (Codex review). Only the
+    non-executable ``compile:`` block is read here; ``build.query`` still requires
+    an explicit trusted ``--config`` + ``--allow-build-query`` (ADR-032 D5).
     """
+    from .buildsource.inline import discover_build_config, load_build_config
     from .service_scan import CompileContext
 
-    if build_config is None:
+    cfg = build_config if build_config is not None else discover_build_config(sources)
+    if cfg is None:
         return cli_ctx, cli_includes
-    from .buildsource.inline import load_build_config
 
     try:
-        bc = load_build_config(build_config)
+        bc = load_build_config(cfg)
     except ValueError:
-        # Best-effort, like the level-implies-query probe: a malformed --config is
+        # Best-effort, like the level-implies-query probe: a malformed config is
         # swallowed here so a no-source scan still runs; the real downstream load
         # (embed_build_source, when --sources is given) surfaces it as a clean
         # ClickException (tests: malformed_build_config_yaml_is_click_error /
         # level_implies_query_malformed_config_does_not_crash).
         return cli_ctx, cli_includes
-    base = build_config.parent
+    base = cfg.parent
 
     frontend = (
         cli_ctx.frontend
@@ -809,9 +818,10 @@ def scan_cmd(
         nostdinc=nostdinc,
         frontend=header_backend,
     )
-    # Fold the project's `.abicheck.yml` compile: block in (CLI > config).
+    # Fold the project's `.abicheck.yml` compile: block in (CLI > config; the
+    # config is --config or the one auto-discovered at the --sources root).
     compile_context, includes = _merge_compile_config(
-        compile_context, tuple(includes), build_config
+        compile_context, tuple(includes), build_config, sources=sources
     )
 
     if len(binaries) != 1:

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -401,6 +401,7 @@ def _merge_compile_config(
     sources: Path | None = None,
     *,
     frontend_explicit: bool = False,
+    nostdinc_explicit: bool = False,
 ) -> tuple[CompileContext, tuple[Path, ...]]:
     """Fold a ``.abicheck.yml`` ``compile:`` block into the CLI compile context.
 
@@ -464,13 +465,18 @@ def _merge_compile_config(
         if cli_ctx.sysroot is not None
         else (Path(bc.compile_sysroot) if bc.compile_sysroot else None)
     )
+    # CLI > config: an explicit --nostdinc/--no-nostdinc wins in *either*
+    # direction; an unset flag inherits the config value (Codex review).
+    nostdinc = (
+        cli_ctx.nostdinc if nostdinc_explicit else bool(bc.compile_nostdinc)
+    )
     merged = CompileContext(
         gcc_path=cli_ctx.gcc_path,
         gcc_prefix=cli_ctx.gcc_prefix,
         gcc_options=gcc_options,
         gcc_option_tokens=cli_ctx.gcc_option_tokens,
         sysroot=sysroot,
-        nostdinc=cli_ctx.nostdinc or bool(bc.compile_nostdinc),
+        nostdinc=nostdinc,
         frontend=frontend,
     )
     includes = tuple(cli_includes) + tuple(
@@ -838,16 +844,19 @@ def scan_cmd(
     # explicitly-typed --ast-frontend (even "auto") wins over a pinned config
     # frontend, so detect whether the user actually passed it (Codex review).
     ctx = click.get_current_context()
-    frontend_explicit = (
-        ctx.get_parameter_source("header_backend")
-        == click.core.ParameterSource.COMMANDLINE
-    )
+
+    def _explicit(param: str) -> bool:
+        return (
+            ctx.get_parameter_source(param) == click.core.ParameterSource.COMMANDLINE
+        )
+
     compile_context, includes = _merge_compile_config(
         compile_context,
         tuple(includes),
         build_config,
         sources=sources,
-        frontend_explicit=frontend_explicit,
+        frontend_explicit=_explicit("header_backend"),
+        nostdinc_explicit=_explicit("nostdinc"),
     )
 
     if len(binaries) != 1:

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -70,6 +70,7 @@ from .buildsource.scan_levels import (
 )
 from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS
 from .cli import _safe_write_output, _setup_verbosity, main
+from .cli_options import compile_context_options, echo_ast_frontend_deprecation
 from .cli_params import DEPTH_PARAM
 
 #: Exit code for a ``--budget`` overflow (ADR-035 D3: a budget always fails,
@@ -403,6 +404,7 @@ def _build_new_snapshot(
     build_config: Path | None = None,
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
+    compile_context: Any = None,
 ) -> Any:
     """Dump the candidate's L0-L2 surface and embed L3-L5 inline at *collect_mode*.
 
@@ -429,6 +431,7 @@ def _build_new_snapshot(
             lang=lang,
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
+            compile=compile_context,
         )
     except AbicheckError as exc:
         raise click.ClickException(f"Failed to load --binary {binary}: {exc}") from exc
@@ -665,6 +668,7 @@ def _audit_exit_code(
 )
 @click.option("-o", "--output", type=click.Path(path_type=Path), default=None)
 @click.option("-v", "--verbose", is_flag=True, default=False)
+@compile_context_options  # dump↔scan L2 compile-context parity (ADR-037 D3)
 def scan_cmd(
     binaries: tuple[Path, ...],
     headers: tuple[Path, ...],
@@ -690,6 +694,13 @@ def scan_cmd(
     fmt: str,
     output: Path | None,
     verbose: bool,
+    header_backend: str = "auto",
+    gcc_path: str | None = None,
+    gcc_prefix: str | None = None,
+    gcc_options: str | None = None,
+    gcc_option_tokens: tuple[str, ...] = (),
+    sysroot: Path | None = None,
+    nostdinc: bool = False,
 ) -> None:
     """Deterministic source-intelligence scan (classify → always-on tier → level).
 
@@ -715,6 +726,24 @@ def scan_cmd(
     """
     _setup_verbosity(verbose)
     start = time.monotonic()
+
+    # ADR-037 D8: legacy --header-backend → --ast-frontend deprecation note.
+    echo_ast_frontend_deprecation()
+
+    # L2 header compile context (dump↔scan parity, ADR-037 D3): bundle the
+    # cross-toolchain + frontend flags so the candidate/baseline header parse runs
+    # with the same build context `dump` would use.
+    from .service_scan import CompileContext
+
+    compile_context = CompileContext(
+        gcc_path=gcc_path,
+        gcc_prefix=gcc_prefix,
+        gcc_options=gcc_options,
+        gcc_option_tokens=tuple(gcc_option_tokens),
+        sysroot=sysroot,
+        nostdinc=nostdinc,
+        frontend=header_backend,
+    )
 
     if len(binaries) != 1:
         raise click.UsageError(
@@ -842,6 +871,7 @@ def scan_cmd(
                 source_method is not None and source_method != SourceMethod.AUTO.value
             )
             or (source_method is None and depth is not None),
+            compile_context=None if compile_context.is_default else compile_context,
         )
     except _BudgetOverflow as bo:
         click.echo(bo.message, err=True)
@@ -914,6 +944,7 @@ def run_scan_core(
     budget: str | None,
     budget_s: float | None,
     level_explicit: bool = False,
+    compile_context: Any = None,
 ) -> ScanCoreResult:
     """The shared scan orchestration (classify → always-on tier → level → compare).
 
@@ -1038,6 +1069,7 @@ def run_scan_core(
         build_config=build_config,
         public_headers=list(public_headers),
         public_header_dirs=list(public_header_dirs),
+        compile_context=compile_context,
     )
 
     # --- honest level-vs-evidence advisory ------------------------------------
@@ -1103,6 +1135,7 @@ def run_scan_core(
             list(includes),
             list(public_headers),
             list(public_header_dirs),
+            compile_context=compile_context,
         )
         # A cross-check the maintainer promoted to `error` (D6) gates the exit
         # even when the baseline diff itself is clean.
@@ -1312,6 +1345,7 @@ def _run_baseline_compare(
     includes: list[Path],
     public_headers: list[Path],
     public_header_dirs: list[Path],
+    compile_context: Any = None,
 ) -> tuple[str, int, dict[str, Any]]:
     """Compare *new_snap* against *baseline*, folding cross-source findings in.
 
@@ -1345,6 +1379,7 @@ def _run_baseline_compare(
             lang=lang,
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
+            compile=compile_context,
         )
     except AbicheckError as exc:
         raise click.ClickException(

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -52,7 +52,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -72,6 +72,9 @@ from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS
 from .cli import _safe_write_output, _setup_verbosity, main
 from .cli_options import compile_context_options, echo_ast_frontend_deprecation
 from .cli_params import DEPTH_PARAM
+
+if TYPE_CHECKING:
+    from .service_scan import CompileContext
 
 #: Exit code for a ``--budget`` overflow (ADR-035 D3: a budget always fails,
 #: never silently shrinks scope). Distinct from the verdict codes (0/2/4) and the
@@ -392,11 +395,13 @@ def _render_text(out: ScanOutcome) -> str:
 
 
 def _merge_compile_config(
-    cli_ctx: Any,
+    cli_ctx: CompileContext,
     cli_includes: tuple[Path, ...],
     build_config: Path | None,
     sources: Path | None = None,
-) -> tuple[Any, tuple[Path, ...]]:
+    *,
+    frontend_explicit: bool = False,
+) -> tuple[CompileContext, tuple[Path, ...]]:
     """Fold a ``.abicheck.yml`` ``compile:`` block into the CLI compile context.
 
     Precedence is CLI > config (ADR-035 D6.1 / ADR-037 D4): a per-field CLI value
@@ -422,20 +427,30 @@ def _merge_compile_config(
 
     try:
         bc = load_build_config(cfg)
-    except ValueError:
+    except ValueError as exc:
         # Best-effort, like the level-implies-query probe: a malformed config is
         # swallowed here so a no-source scan still runs; the real downstream load
         # (embed_build_source, when --sources is given) surfaces it as a clean
         # ClickException (tests: malformed_build_config_yaml_is_click_error /
-        # level_implies_query_malformed_config_does_not_crash).
+        # level_implies_query_malformed_config_does_not_crash). Still warn so a
+        # broken config is not silently ignored (CodeRabbit review).
+        click.echo(
+            f"warning: could not parse {cfg}; using CLI compile context only "
+            f"({exc}).",
+            err=True,
+        )
         return cli_ctx, cli_includes
     base = cfg.parent
 
+    # CLI > config: an explicit --ast-frontend wins even when it is "auto" (the
+    # documented escape hatch to bypass a pinned config frontend); only a *default*
+    # "auto" inherits the config's frontend (Codex review).
     frontend = (
         cli_ctx.frontend
-        if cli_ctx.frontend != "auto"
+        if (frontend_explicit or cli_ctx.frontend != "auto")
         else (bc.compile_frontend or "auto")
     )
+    gcc_options: str | None
     if cli_ctx.gcc_options is not None:
         gcc_options = cli_ctx.gcc_options
     else:
@@ -478,7 +493,7 @@ def _build_new_snapshot(
     build_config: Path | None = None,
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
-    compile_context: Any = None,
+    compile_context: CompileContext | None = None,
 ) -> Any:
     """Dump the candidate's L0-L2 surface and embed L3-L5 inline at *collect_mode*.
 
@@ -819,9 +834,20 @@ def scan_cmd(
         frontend=header_backend,
     )
     # Fold the project's `.abicheck.yml` compile: block in (CLI > config; the
-    # config is --config or the one auto-discovered at the --sources root).
+    # config is --config or the one auto-discovered at the --sources root). An
+    # explicitly-typed --ast-frontend (even "auto") wins over a pinned config
+    # frontend, so detect whether the user actually passed it (Codex review).
+    ctx = click.get_current_context()
+    frontend_explicit = (
+        ctx.get_parameter_source("header_backend")
+        == click.core.ParameterSource.COMMANDLINE
+    )
     compile_context, includes = _merge_compile_config(
-        compile_context, tuple(includes), build_config, sources=sources
+        compile_context,
+        tuple(includes),
+        build_config,
+        sources=sources,
+        frontend_explicit=frontend_explicit,
     )
 
     if len(binaries) != 1:
@@ -1023,7 +1049,7 @@ def run_scan_core(
     budget: str | None,
     budget_s: float | None,
     level_explicit: bool = False,
-    compile_context: Any = None,
+    compile_context: CompileContext | None = None,
 ) -> ScanCoreResult:
     """The shared scan orchestration (classify → always-on tier → level → compare).
 
@@ -1424,7 +1450,7 @@ def _run_baseline_compare(
     includes: list[Path],
     public_headers: list[Path],
     public_header_dirs: list[Path],
-    compile_context: Any = None,
+    compile_context: CompileContext | None = None,
 ) -> tuple[str, int, dict[str, Any]]:
     """Compare *new_snap* against *baseline*, folding cross-source findings in.
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -169,14 +169,14 @@ def _build_clang_header_command(
     ``system_includes`` are host-compiler-probed system dirs (see
     :func:`_probe_gnu_system_includes`) injected as ``-isystem`` so clang finds
     the same libstdc++/libc headers castxml gets via ``--castxml-cc-gnu`` — the
-    castxml↔clang capability-parity fix. They follow the user's ``-I`` (so an
-    explicit include still wins) and are skipped under ``-nostdinc``.
+    castxml↔clang capability-parity fix. They are emitted **last** (after the
+    user's ``-I`` *and* the pass-through ``--gcc-options``/``--gcc-option``) so
+    auto-detection stays a genuine fallback: a user-supplied ``-isystem`` for a
+    cross/hermetic SDK is searched first and wins. Skipped under ``-nostdinc``.
     """
     cmd = [cc_bin]
     for inc in extra_includes:
         cmd += ["-I", str(inc)]
-    for sysinc in system_includes:
-        cmd += ["-isystem", sysinc]
     if sysroot:
         cmd += [f"--sysroot={sysroot.as_posix()}"]
     if nostdinc:
@@ -185,6 +185,11 @@ def _build_clang_header_command(
         cmd += shlex.split(gcc_options, posix=os.name != "nt")
     # Repeatable --gcc-option: one literal argument each (no shlex split).
     cmd += list(gcc_option_tokens)
+    # Auto-probed host system dirs go *after* the user's pass-through flags, so a
+    # user-supplied -isystem (cross/hermetic SDK) keeps higher search priority
+    # (Codex review). Auto-detection is a fallback, never an override.
+    for sysinc in system_includes:
+        cmd += ["-isystem", sysinc]
     explicit_std = _has_explicit_std(gcc_options, gcc_option_tokens)
     if not force_cpp:
         if not explicit_std:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -59,6 +59,13 @@ from .dumper_castxml import (
     _vt_sort_key as _vt_sort_key,
 )
 from .dumper_clang import _ClangAstParser as _ClangAstParser
+from .dumper_sysinc import (
+    _auto_system_includes_enabled as _auto_system_includes_enabled,
+    _parse_gnu_include_search_dirs as _parse_gnu_include_search_dirs,
+    _probe_gnu_system_includes as _probe_gnu_system_includes,
+    _resolve_clang_system_includes as _resolve_clang_system_includes,
+    _resolve_probe_compiler as _resolve_probe_compiler,
+)
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .errors import SnapshotError, ValidationError
 from .model import (
@@ -136,128 +143,6 @@ def _has_explicit_std(
     if gcc_options and ("-std=" in gcc_options or "/std:" in gcc_options):
         return True
     return any(("-std=" in t or "/std:" in t) for t in gcc_option_tokens)
-
-
-#: Env knob to disable the castxml↔clang system-include auto-detection (below).
-#: On by default; set to a falsey value to suppress the host-compiler probe (e.g.
-#: for a hermetic build that supplies its own ``-isystem``/``--sysroot``).
-_AUTO_SYSINC_ENV = "ABICHECK_AUTO_SYSTEM_INCLUDES"
-
-
-def _auto_system_includes_enabled() -> bool:
-    """True unless the user disabled the system-include probe via the env knob."""
-    return os.environ.get(_AUTO_SYSINC_ENV, "1").strip().lower() not in (
-        "0",
-        "false",
-        "no",
-        "off",
-    )
-
-
-def _parse_gnu_include_search_dirs(stderr: str) -> list[str]:
-    """Parse a GCC/Clang ``-E -v`` stderr into its system include search dirs.
-
-    The driver prints the resolved search path between the
-    ``#include <...> search starts here:`` and ``End of search list.`` markers,
-    one directory per indented line (Clang/GCC both use this format; Darwin may
-    append `` (framework directory)``). Pure/string-only so it is unit-testable
-    without a compiler installed. Returns the directories in search order.
-    """
-    dirs: list[str] = []
-    in_block = False
-    for line in stderr.splitlines():
-        stripped = line.strip()
-        if "search starts here:" in stripped:
-            in_block = True
-            continue
-        if stripped.startswith("End of search list."):
-            break
-        if in_block and stripped:
-            # GCC/Clang on Darwin tag framework dirs with a trailing note.
-            dirs.append(stripped.split(" (", 1)[0].strip())
-    return dirs
-
-
-def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
-    """Probe *cc_bin* for the system include dirs it would search (best-effort).
-
-    The clang counterpart of what castxml gets for free: ``castxml
-    --castxml-cc-gnu g++`` runs the real compiler to discover its built-in
-    include paths (so the host libstdc++ ``<cstddef>`` etc. are found), then
-    parses with those injected. Running ``clang -ast-dump=json`` *directly* does
-    not — clang uses its own GCC-toolchain auto-detection, which misses the host
-    C++ stdlib in minimal containers / non-standard prefixes / Conda-clang
-    setups. This re-creates the castxml behaviour for the clang backend by asking
-    the GNU driver where its headers live and feeding them back as ``-isystem``.
-
-    Best-effort: any probe failure (no compiler, timeout) yields ``[]`` so the
-    dump still runs on clang's own detection. Only existing directories are
-    returned, in the compiler's own search order.
-    """
-    lang = "c++" if cpp else "c"
-    try:
-        proc = subprocess.run(
-            [cc_bin, "-E", "-x", lang, "-v", "-"],
-            input="",
-            capture_output=True,
-            text=True,
-            timeout=15,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return []
-    return [
-        d for d in _parse_gnu_include_search_dirs(proc.stderr or "") if Path(d).is_dir()
-    ]
-
-
-def _resolve_probe_compiler(
-    compiler: str, gcc_path: str | None, gcc_prefix: str | None
-) -> str | None:
-    """Pick a GNU ``gcc``/``g++`` driver to probe for system includes, or None.
-
-    Prefers an explicit GNU ``--gcc-path`` (a clang there is useless for
-    discovering the host libstdc++, so it is skipped), then the cross
-    ``--gcc-prefix`` driver, then ``g++``/``gcc`` on PATH. Returns the first that
-    resolves, or ``None`` when no GNU compiler is available (then clang falls
-    back to its own detection).
-    """
-    cpp = compiler in ("c++", "g++", "clang++")
-    primary = "g++" if cpp else "gcc"
-    candidates: list[str] = []
-    if gcc_path and "clang" not in Path(gcc_path).name.lower():
-        candidates.append(gcc_path)
-    if gcc_prefix:
-        candidates.append(f"{gcc_prefix}{primary}")
-    candidates += [primary, "gcc" if cpp else "g++"]
-    for cand in candidates:
-        if shutil.which(cand):
-            return cand
-    return None
-
-
-def _resolve_clang_system_includes(
-    compiler: str,
-    *,
-    gcc_path: str | None,
-    gcc_prefix: str | None,
-    sysroot: Path | None,
-    nostdinc: bool,
-    force_cpp: bool,
-) -> tuple[str, ...]:
-    """Resolve the ``-isystem`` dirs to inject for a clang header dump.
-
-    Empty when auto-detection is disabled, ``-nostdinc`` was requested, an
-    explicit ``--sysroot`` already redirects the search, or no GNU compiler is
-    available to probe. Otherwise the host GNU driver's system include dirs
-    (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
-    """
-    if nostdinc or sysroot is not None or not _auto_system_includes_enabled():
-        return ()
-    probe_cc = _resolve_probe_compiler(compiler, gcc_path, gcc_prefix)
-    if probe_cc is None:
-        return ()
-    return tuple(_probe_gnu_system_includes(probe_cc, cpp=force_cpp))
 
 
 def _build_clang_header_command(

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -268,6 +268,8 @@ def _clang_header_dump(
         sysroot=sysroot,
         nostdinc=nostdinc,
         force_cpp=force_cpp,
+        gcc_options=gcc_options,
+        gcc_option_tokens=gcc_option_tokens,
     )
 
     key = _cache_key(

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -138,6 +138,128 @@ def _has_explicit_std(
     return any(("-std=" in t or "/std:" in t) for t in gcc_option_tokens)
 
 
+#: Env knob to disable the castxml↔clang system-include auto-detection (below).
+#: On by default; set to a falsey value to suppress the host-compiler probe (e.g.
+#: for a hermetic build that supplies its own ``-isystem``/``--sysroot``).
+_AUTO_SYSINC_ENV = "ABICHECK_AUTO_SYSTEM_INCLUDES"
+
+
+def _auto_system_includes_enabled() -> bool:
+    """True unless the user disabled the system-include probe via the env knob."""
+    return os.environ.get(_AUTO_SYSINC_ENV, "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _parse_gnu_include_search_dirs(stderr: str) -> list[str]:
+    """Parse a GCC/Clang ``-E -v`` stderr into its system include search dirs.
+
+    The driver prints the resolved search path between the
+    ``#include <...> search starts here:`` and ``End of search list.`` markers,
+    one directory per indented line (Clang/GCC both use this format; Darwin may
+    append `` (framework directory)``). Pure/string-only so it is unit-testable
+    without a compiler installed. Returns the directories in search order.
+    """
+    dirs: list[str] = []
+    in_block = False
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if "search starts here:" in stripped:
+            in_block = True
+            continue
+        if stripped.startswith("End of search list."):
+            break
+        if in_block and stripped:
+            # GCC/Clang on Darwin tag framework dirs with a trailing note.
+            dirs.append(stripped.split(" (", 1)[0].strip())
+    return dirs
+
+
+def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
+    """Probe *cc_bin* for the system include dirs it would search (best-effort).
+
+    The clang counterpart of what castxml gets for free: ``castxml
+    --castxml-cc-gnu g++`` runs the real compiler to discover its built-in
+    include paths (so the host libstdc++ ``<cstddef>`` etc. are found), then
+    parses with those injected. Running ``clang -ast-dump=json`` *directly* does
+    not — clang uses its own GCC-toolchain auto-detection, which misses the host
+    C++ stdlib in minimal containers / non-standard prefixes / Conda-clang
+    setups. This re-creates the castxml behaviour for the clang backend by asking
+    the GNU driver where its headers live and feeding them back as ``-isystem``.
+
+    Best-effort: any probe failure (no compiler, timeout) yields ``[]`` so the
+    dump still runs on clang's own detection. Only existing directories are
+    returned, in the compiler's own search order.
+    """
+    lang = "c++" if cpp else "c"
+    try:
+        proc = subprocess.run(
+            [cc_bin, "-E", "-x", lang, "-v", "-"],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return [
+        d for d in _parse_gnu_include_search_dirs(proc.stderr or "") if Path(d).is_dir()
+    ]
+
+
+def _resolve_probe_compiler(
+    compiler: str, gcc_path: str | None, gcc_prefix: str | None
+) -> str | None:
+    """Pick a GNU ``gcc``/``g++`` driver to probe for system includes, or None.
+
+    Prefers an explicit GNU ``--gcc-path`` (a clang there is useless for
+    discovering the host libstdc++, so it is skipped), then the cross
+    ``--gcc-prefix`` driver, then ``g++``/``gcc`` on PATH. Returns the first that
+    resolves, or ``None`` when no GNU compiler is available (then clang falls
+    back to its own detection).
+    """
+    cpp = compiler in ("c++", "g++", "clang++")
+    primary = "g++" if cpp else "gcc"
+    candidates: list[str] = []
+    if gcc_path and "clang" not in Path(gcc_path).name.lower():
+        candidates.append(gcc_path)
+    if gcc_prefix:
+        candidates.append(f"{gcc_prefix}{primary}")
+    candidates += [primary, "gcc" if cpp else "g++"]
+    for cand in candidates:
+        if shutil.which(cand):
+            return cand
+    return None
+
+
+def _resolve_clang_system_includes(
+    compiler: str,
+    *,
+    gcc_path: str | None,
+    gcc_prefix: str | None,
+    sysroot: Path | None,
+    nostdinc: bool,
+    force_cpp: bool,
+) -> tuple[str, ...]:
+    """Resolve the ``-isystem`` dirs to inject for a clang header dump.
+
+    Empty when auto-detection is disabled, ``-nostdinc`` was requested, an
+    explicit ``--sysroot`` already redirects the search, or no GNU compiler is
+    available to probe. Otherwise the host GNU driver's system include dirs
+    (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
+    """
+    if nostdinc or sysroot is not None or not _auto_system_includes_enabled():
+        return ()
+    probe_cc = _resolve_probe_compiler(compiler, gcc_path, gcc_prefix)
+    if probe_cc is None:
+        return ()
+    return tuple(_probe_gnu_system_includes(probe_cc, cpp=force_cpp))
+
+
 def _build_clang_header_command(
     cc_bin: str, cc_id: str,
     extra_includes: list[Path], agg_path: Path,
@@ -148,6 +270,7 @@ def _build_clang_header_command(
     gcc_option_tokens: tuple[str, ...] = (),
     force_cpp: bool = False,
     force_cpp20: bool = False,
+    system_includes: tuple[str, ...] = (),
 ) -> list[str]:
     """Build the ``clang -ast-dump=json`` command for the aggregate header.
 
@@ -157,10 +280,18 @@ def _build_clang_header_command(
     just a different frontend over the identical inputs. ``-fsyntax-only`` (no
     codegen) with ``-ferror-limit=0`` keeps parsing past recoverable errors so a
     single bad decl does not blank the whole dump.
+
+    ``system_includes`` are host-compiler-probed system dirs (see
+    :func:`_probe_gnu_system_includes`) injected as ``-isystem`` so clang finds
+    the same libstdc++/libc headers castxml gets via ``--castxml-cc-gnu`` — the
+    castxml↔clang capability-parity fix. They follow the user's ``-I`` (so an
+    explicit include still wins) and are skipped under ``-nostdinc``.
     """
     cmd = [cc_bin]
     for inc in extra_includes:
         cmd += ["-I", str(inc)]
+    for sysinc in system_includes:
+        cmd += ["-isystem", sysinc]
     if sysroot:
         cmd += [f"--sysroot={sysroot.as_posix()}"]
     if nostdinc:
@@ -230,11 +361,31 @@ def _clang_header_dump(
             "clang). Or use the castxml frontend (--ast-frontend castxml)."
         )
 
+    force_cpp = bool(lang and lang.upper() in ("C++", "CPP"))
+    if not lang:
+        force_cpp = _detect_cpp_headers(headers)
+    force_cpp20 = force_cpp and _detect_cpp20_headers(headers)
+    cc_id = "msvc" if Path(clang_bin).name.lower() in ("cl", "cl.exe") else "gnu"
+
+    # castxml↔clang parity: probe the host GNU compiler for its system include
+    # dirs and inject them as ``-isystem`` so clang resolves libstdc++/libc the
+    # way castxml does via ``--castxml-cc-gnu``. Folded into the cache key so a
+    # toolchain change invalidates a stale dump.
+    system_includes = _resolve_clang_system_includes(
+        compiler,
+        gcc_path=gcc_path,
+        gcc_prefix=gcc_prefix,
+        sysroot=sysroot,
+        nostdinc=nostdinc,
+        force_cpp=force_cpp,
+    )
+
     key = _cache_key(
         headers, extra_includes, clang_bin,
         gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
         gcc_option_tokens=gcc_option_tokens,
         sysroot=sysroot, nostdinc=nostdinc, lang=lang, backend="clang",
+        system_includes=system_includes,
     )
     cached = _cache_path(key, backend="clang")
     if cached.exists():
@@ -242,12 +393,6 @@ def _clang_header_dump(
             return cast("dict[str, Any]", json.loads(cached.read_text(encoding="utf-8")))
         except (ValueError, OSError):
             cached.unlink(missing_ok=True)
-
-    force_cpp = bool(lang and lang.upper() in ("C++", "CPP"))
-    if not lang:
-        force_cpp = _detect_cpp_headers(headers)
-    force_cpp20 = force_cpp and _detect_cpp20_headers(headers)
-    cc_id = "msvc" if Path(clang_bin).name.lower() in ("cl", "cl.exe") else "gnu"
 
     agg_ext = ".hpp" if force_cpp else ".h"
     with tempfile.NamedTemporaryFile(suffix=agg_ext, mode="w", delete=False) as agg:
@@ -260,6 +405,7 @@ def _clang_header_dump(
         sysroot=sysroot, nostdinc=nostdinc, gcc_options=gcc_options,
         gcc_option_tokens=gcc_option_tokens,
         force_cpp=force_cpp, force_cpp20=force_cpp20,
+        system_includes=system_includes,
     )
     try:
         try:
@@ -454,6 +600,7 @@ def _cache_key(
     nostdinc: bool = False,
     lang: str | None = None,
     backend: str = "castxml",
+    system_includes: tuple[str, ...] = (),
 ) -> str:
     h = hashlib.sha256()
     # The header-AST backend is part of the key: a castxml-XML cache entry and a
@@ -486,6 +633,9 @@ def _cache_key(
     h.update(f"sysroot={sysroot or ''}".encode())
     h.update(f"nostdinc={nostdinc}".encode())
     h.update(f"lang={lang or ''}".encode())
+    # Auto-probed system include dirs (castxml↔clang parity): a host-toolchain
+    # change must invalidate a cached clang dump (the resolved libstdc++ moved).
+    h.update(f"system_includes={chr(0).join(system_includes)}".encode())
     return h.hexdigest()
 
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""castxml↔clang system-include parity: probe a host GNU compiler for its
+built-in include search dirs and feed them to the clang L2 backend.
+
+``castxml --castxml-cc-gnu g++`` runs the real compiler to discover its built-in
+include paths (so the host libstdc++ ``<cstddef>`` etc. resolve), then parses
+with those injected. Running ``clang -ast-dump=json`` *directly* (the clang L2
+backend, :mod:`abicheck.dumper_clang`) does **not** — clang uses its own
+GCC-toolchain auto-detection, which misses the host C++ stdlib in minimal
+containers, non-standard prefixes, and Conda-clang setups, so scanning headers
+like oneTBB's ``oneapi/tbb.h`` fails to find ``<cstddef>``. These helpers
+re-create the castxml behaviour for the clang backend: ask the GNU driver where
+its headers live and return them so :func:`abicheck.dumper._build_clang_header_command`
+can inject them as ``-isystem``.
+
+Split out of :mod:`abicheck.dumper` (which is at the file-size soft limit) and
+re-exported there, so the public ``dumper._probe_*`` surface is unchanged.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+#: Env knob to disable the castxml↔clang system-include auto-detection. On by
+#: default; set to a falsey value to suppress the host-compiler probe (e.g. for a
+#: hermetic build that supplies its own ``-isystem``/``--sysroot``).
+_AUTO_SYSINC_ENV = "ABICHECK_AUTO_SYSTEM_INCLUDES"
+
+
+def _auto_system_includes_enabled() -> bool:
+    """True unless the user disabled the system-include probe via the env knob."""
+    return os.environ.get(_AUTO_SYSINC_ENV, "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _parse_gnu_include_search_dirs(stderr: str) -> list[str]:
+    """Parse a GCC/Clang ``-E -v`` stderr into its system include search dirs.
+
+    The driver prints the resolved search path between the
+    ``#include <...> search starts here:`` and ``End of search list.`` markers,
+    one directory per indented line (Clang/GCC both use this format; Darwin may
+    append `` (framework directory)``). Pure/string-only so it is unit-testable
+    without a compiler installed. Returns the directories in search order.
+    """
+    dirs: list[str] = []
+    in_block = False
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if "search starts here:" in stripped:
+            in_block = True
+            continue
+        if stripped.startswith("End of search list."):
+            break
+        if in_block and stripped:
+            # GCC/Clang on Darwin tag framework dirs with a trailing note.
+            dirs.append(stripped.split(" (", 1)[0].strip())
+    return dirs
+
+
+def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
+    """Probe *cc_bin* for the system include dirs it would search (best-effort).
+
+    Best-effort: any probe failure (no compiler, timeout) yields ``[]`` so the
+    dump still runs on clang's own detection. Only existing directories are
+    returned, in the compiler's own search order.
+    """
+    lang = "c++" if cpp else "c"
+    try:
+        proc = subprocess.run(
+            [cc_bin, "-E", "-x", lang, "-v", "-"],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return [
+        d for d in _parse_gnu_include_search_dirs(proc.stderr or "") if Path(d).is_dir()
+    ]
+
+
+def _resolve_probe_compiler(
+    compiler: str, gcc_path: str | None, gcc_prefix: str | None
+) -> str | None:
+    """Pick a GNU ``gcc``/``g++`` driver to probe for system includes, or None.
+
+    Prefers an explicit GNU ``--gcc-path`` (a clang there is useless for
+    discovering the host libstdc++, so it is skipped), then the cross
+    ``--gcc-prefix`` driver, then ``g++``/``gcc`` on PATH. Returns the first that
+    resolves, or ``None`` when no GNU compiler is available (then clang falls
+    back to its own detection).
+    """
+    cpp = compiler in ("c++", "g++", "clang++")
+    primary = "g++" if cpp else "gcc"
+    candidates: list[str] = []
+    if gcc_path and "clang" not in Path(gcc_path).name.lower():
+        candidates.append(gcc_path)
+    if gcc_prefix:
+        candidates.append(f"{gcc_prefix}{primary}")
+    candidates += [primary, "gcc" if cpp else "g++"]
+    for cand in candidates:
+        if shutil.which(cand):
+            return cand
+    return None
+
+
+def _resolve_clang_system_includes(
+    compiler: str,
+    *,
+    gcc_path: str | None,
+    gcc_prefix: str | None,
+    sysroot: Path | None,
+    nostdinc: bool,
+    force_cpp: bool,
+) -> tuple[str, ...]:
+    """Resolve the ``-isystem`` dirs to inject for a clang header dump.
+
+    Empty when auto-detection is disabled, ``-nostdinc`` was requested, an
+    explicit ``--sysroot`` already redirects the search, or no GNU compiler is
+    available to probe. Otherwise the host GNU driver's system include dirs
+    (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
+    """
+    if nostdinc or sysroot is not None or not _auto_system_includes_enabled():
+        return ()
+    probe_cc = _resolve_probe_compiler(compiler, gcc_path, gcc_prefix)
+    if probe_cc is None:
+        return ()
+    return tuple(_probe_gnu_system_includes(probe_cc, cpp=force_cpp))

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -129,6 +129,27 @@ def _resolve_probe_compiler(
     return None
 
 
+#: Pass-through flags that signal a hermetic/cross parse — if the caller already
+#: supplied any of these via ``--gcc-options``/``--gcc-option``, the host-compiler
+#: probe must stay out of the way (matching what the structured ``nostdinc`` /
+#: ``sysroot`` fields do). Substring match covers ``-nostdinc`` / ``-nostdinc++``
+#: and ``--sysroot`` / ``--sysroot=…`` / ``-isysroot``.
+_PROBE_SUPPRESSING_FLAGS = ("-nostdinc", "--sysroot", "-isysroot")
+
+
+def _pass_through_suppresses_probe(
+    gcc_options: str | None, gcc_option_tokens: tuple[str, ...]
+) -> bool:
+    """True if pass-through flags already isolate the parse (skip the probe)."""
+    if gcc_options and any(f in gcc_options for f in _PROBE_SUPPRESSING_FLAGS):
+        return True
+    return any(
+        tok.startswith(f)
+        for tok in gcc_option_tokens
+        for f in _PROBE_SUPPRESSING_FLAGS
+    )
+
+
 def _resolve_clang_system_includes(
     compiler: str,
     *,
@@ -137,15 +158,24 @@ def _resolve_clang_system_includes(
     sysroot: Path | None,
     nostdinc: bool,
     force_cpp: bool,
+    gcc_options: str | None = None,
+    gcc_option_tokens: tuple[str, ...] = (),
 ) -> tuple[str, ...]:
     """Resolve the ``-isystem`` dirs to inject for a clang header dump.
 
     Empty when auto-detection is disabled, ``-nostdinc`` was requested, an
-    explicit ``--sysroot`` already redirects the search, or no GNU compiler is
-    available to probe. Otherwise the host GNU driver's system include dirs
-    (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
+    explicit ``--sysroot`` already redirects the search, the caller passed an
+    equivalent hermetic/cross flag through ``--gcc-options``/``--gcc-option``
+    (``-nostdinc``/``-nostdinc++``/``--sysroot``/``-isysroot``), or no GNU
+    compiler is available to probe. Otherwise the host GNU driver's system
+    include dirs (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
     """
-    if nostdinc or sysroot is not None or not _auto_system_includes_enabled():
+    if (
+        nostdinc
+        or sysroot is not None
+        or not _auto_system_includes_enabled()
+        or _pass_through_suppresses_probe(gcc_options, gcc_option_tokens)
+    ):
         return ()
     probe_cc = _resolve_probe_compiler(compiler, gcc_path, gcc_prefix)
     if probe_cc is None:

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -59,14 +59,17 @@ def _parse_gnu_include_search_dirs(stderr: str) -> list[str]:
     The driver prints the resolved search path between the
     ``#include <...> search starts here:`` and ``End of search list.`` markers,
     one directory per indented line (Clang/GCC both use this format; Darwin may
-    append `` (framework directory)``). Pure/string-only so it is unit-testable
-    without a compiler installed. Returns the directories in search order.
+    append `` (framework directory)``). Only the angle-bracket (``<...>``) system
+    block is captured — the preceding quote-include (``"..."``) block lists
+    ``-iquote`` dirs, which are not system paths and must not become ``-isystem``.
+    Pure/string-only so it is unit-testable without a compiler installed. Returns
+    the directories in search order.
     """
     dirs: list[str] = []
     in_block = False
     for line in stderr.splitlines():
         stripped = line.strip()
-        if "search starts here:" in stripped:
+        if "<...> search starts here:" in stripped:
             in_block = True
             continue
         if stripped.startswith("End of search list."):

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -129,12 +129,23 @@ def _resolve_probe_compiler(
     return None
 
 
-#: Pass-through flags that signal a hermetic/cross parse — if the caller already
-#: supplied any of these via ``--gcc-options``/``--gcc-option``, the host-compiler
-#: probe must stay out of the way (matching what the structured ``nostdinc`` /
-#: ``sysroot`` fields do). Substring match covers ``-nostdinc`` / ``-nostdinc++``
-#: and ``--sysroot`` / ``--sysroot=…`` / ``-isysroot``.
-_PROBE_SUPPRESSING_FLAGS = ("-nostdinc", "--sysroot", "-isysroot")
+#: Pass-through flags that signal a hermetic/cross/selected-toolchain parse — if
+#: the caller already supplied any of these via ``--gcc-options``/``--gcc-option``,
+#: the host-compiler probe must stay out of the way (matching what the structured
+#: ``nostdinc`` / ``sysroot`` fields do). Substring match covers ``-nostdinc`` /
+#: ``-nostdinc++``, ``--sysroot`` / ``--sysroot=…`` / ``-isysroot``, the GCC
+#: toolchain selectors (``--gcc-toolchain=…`` / ``--gcc-install-dir=…``), and a
+#: cross ``--target=…`` / ``-target …`` — in all of those, probing the host
+#: ``g++`` would inject the wrong libstdc++/libc dirs.
+_PROBE_SUPPRESSING_FLAGS = (
+    "-nostdinc",
+    "--sysroot",
+    "-isysroot",
+    "--gcc-toolchain",
+    "--gcc-install-dir",
+    "--target",
+    "-target",
+)
 
 
 def _pass_through_suppresses_probe(
@@ -165,10 +176,11 @@ def _resolve_clang_system_includes(
 
     Empty when auto-detection is disabled, ``-nostdinc`` was requested, an
     explicit ``--sysroot`` already redirects the search, the caller passed an
-    equivalent hermetic/cross flag through ``--gcc-options``/``--gcc-option``
-    (``-nostdinc``/``-nostdinc++``/``--sysroot``/``-isysroot``), or no GNU
-    compiler is available to probe. Otherwise the host GNU driver's system
-    include dirs (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
+    equivalent hermetic/cross/selected-toolchain flag through ``--gcc-options``/
+    ``--gcc-option`` (``-nostdinc``/``-nostdinc++``/``--sysroot``/``-isysroot``/
+    ``--gcc-toolchain``/``--gcc-install-dir``/``--target``), or no GNU compiler is
+    available to probe. Otherwise the host GNU driver's system include dirs
+    (castxml↔clang parity, see :func:`_probe_gnu_system_includes`).
     """
     if (
         nostdinc

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -155,6 +155,7 @@ def resolve_input(
     public_header_dirs: list[Path] | None = None,
     follow_linker_scripts: bool = True,
     header_backend: str = "auto",
+    compile: CompileContext | None = None,
     notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
     """Auto-detect input type and return an ABI snapshot.
@@ -208,6 +209,7 @@ def resolve_input(
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
             header_backend=header_backend,
+            compile=compile,
             notify=notify,
         )
 
@@ -229,6 +231,7 @@ def resolve_input(
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
             header_backend=header_backend,
+            compile=compile,
             notify=notify,
         )
 
@@ -294,6 +297,7 @@ def resolve_input(
                     public_header_dirs=public_header_dirs,
                     follow_linker_scripts=follow_linker_scripts,
                     header_backend=header_backend,
+                    compile=compile,
                     notify=notify,
                 )
             raise ValidationError(
@@ -341,6 +345,7 @@ def run_dump(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
+    compile: CompileContext | None = None,
     notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
     """Extract an ABI snapshot from a native binary (ELF, PE, or Mach-O).
@@ -357,6 +362,13 @@ def run_dump(
     """
     _headers = headers or []
     _includes = includes or []
+    # An explicit --ast-frontend on the compile context wins over the bare
+    # header_backend arg (the latter is the compare-path default carrier).
+    eff_backend = (
+        compile.frontend
+        if (compile is not None and compile.frontend != "auto")
+        else header_backend
+    )
 
     if binary_fmt == "elf":
         snap = _dump_elf(
@@ -369,7 +381,8 @@ def run_dump(
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
             debug_format=debug_format,
-            header_backend=header_backend,
+            header_backend=eff_backend,
+            compile=compile,
             notify=notify,
         )
         _try_attach_sycl_metadata(snap, path)
@@ -382,7 +395,7 @@ def run_dump(
             includes=_includes,
             lang=lang,
             pdb_path=pdb_path,
-            header_backend=header_backend,
+            header_backend=eff_backend,
         )
         return _apply_native_provenance(snap, public_headers, public_header_dirs)
     if binary_fmt == "macho":
@@ -391,7 +404,7 @@ def run_dump(
             version,
             headers=_headers,
             includes=_includes,
-            header_backend=header_backend,
+            header_backend=eff_backend,
             lang=lang,
         )
         return _apply_native_provenance(snap, public_headers, public_header_dirs)
@@ -459,11 +472,13 @@ def _dump_elf(
     enable_debuginfod: bool = False,
     debug_format: str | None = None,
     header_backend: str = "auto",
+    compile: CompileContext | None = None,
     notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
     """Dump an ELF binary to an ABI snapshot."""
     from .dumper import dump
 
+    cc = compile if compile is not None else CompileContext()
     resolved_headers = expand_header_inputs(headers) if headers else []
     if not resolved_headers and not dwarf_only:
         _emit(
@@ -488,6 +503,12 @@ def _dump_elf(
             extra_includes=includes,
             version=version,
             compiler=compiler,
+            gcc_path=cc.gcc_path,
+            gcc_prefix=cc.gcc_prefix,
+            gcc_options=cc.gcc_options,
+            gcc_option_tokens=cc.gcc_option_tokens,
+            sysroot=cc.sysroot,
+            nostdinc=cc.nostdinc,
             lang=lang if lang == "c" else None,
             dwarf_only=dwarf_only,
             debug_format=debug_format,
@@ -1156,6 +1177,7 @@ def _render_json_output(
 from .service_scan import (  # noqa: E402,F401
     _HEADER_EXTS,
     Budget,
+    CompileContext,
     CostEstimate,
     LayerResult,
     ScanRequest,
@@ -1183,6 +1205,7 @@ from .service_scan import (  # noqa: E402,F401
 __all__ = [
     "Budget",
     "CompareRequest",
+    "CompileContext",
     "CostEstimate",
     "InputSpec",
     "LayerResult",

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -396,6 +396,7 @@ def run_dump(
             lang=lang,
             pdb_path=pdb_path,
             header_backend=eff_backend,
+            compile=compile,
         )
         return _apply_native_provenance(snap, public_headers, public_header_dirs)
     if binary_fmt == "macho":
@@ -406,6 +407,7 @@ def run_dump(
             includes=_includes,
             header_backend=eff_backend,
             lang=lang,
+            compile=compile,
         )
         return _apply_native_provenance(snap, public_headers, public_header_dirs)
     raise ValidationError(f"Unsupported binary format: {binary_fmt}")
@@ -540,6 +542,7 @@ def _try_header_scoped_dump(
     version: str,
     lang: str,
     header_backend: str = "auto",
+    compile: CompileContext | None = None,
 ) -> tuple[AbiSnapshot | None, str | None]:
     """Attempt a header-scoped dump for a PE/Mach-O binary.
 
@@ -563,15 +566,22 @@ def _try_header_scoped_dump(
 
     compiler = "cc" if lang.lower() == "c" else "c++"
     lang_arg = lang if lang.lower() == "c" else None
+    cc = compile if compile is not None else CompileContext()
     try:
         if fmt == "pe":
             snap = _dumper_pe(
                 path, resolved_headers, includes, version, compiler,
+                gcc_path=cc.gcc_path, gcc_prefix=cc.gcc_prefix,
+                gcc_options=cc.gcc_options, gcc_option_tokens=cc.gcc_option_tokens,
+                sysroot=cc.sysroot, nostdinc=cc.nostdinc,
                 lang=lang_arg, header_backend=header_backend,
             )
         else:
             snap = _dumper_macho(
                 path, resolved_headers, includes, version, compiler,
+                gcc_path=cc.gcc_path, gcc_prefix=cc.gcc_prefix,
+                gcc_options=cc.gcc_options, gcc_option_tokens=cc.gcc_option_tokens,
+                sysroot=cc.sysroot, nostdinc=cc.nostdinc,
                 lang=lang_arg, header_backend=header_backend,
             )
     except Exception as exc:  # noqa: BLE001 — header backend/parse failure → fall back
@@ -630,6 +640,7 @@ def _dump_pe(
     lang: str = "c++",
     pdb_path: Path | None = None,
     header_backend: str = "auto",
+    compile: CompileContext | None = None,
 ) -> AbiSnapshot:
     """Dump a PE binary (Windows DLL) to an ABI snapshot.
 
@@ -670,6 +681,7 @@ def _dump_pe(
             version,
             lang,
             header_backend=header_backend,
+            compile=compile,
         )
         if scoped is not None:
             # Preserve any PDB debug info alongside the header-scoped surface.
@@ -724,6 +736,7 @@ def _dump_macho(
     includes: list[Path] | None = None,
     lang: str = "c++",
     header_backend: str = "auto",
+    compile: CompileContext | None = None,
 ) -> AbiSnapshot:
     """Dump a Mach-O binary (macOS dylib) to an ABI snapshot.
 
@@ -757,6 +770,7 @@ def _dump_macho(
             version,
             lang,
             header_backend=header_backend,
+            compile=compile,
         )
         if scoped is not None:
             return scoped

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -135,6 +135,34 @@ class Budget:
 
 
 @dataclass(frozen=True)
+class CompileContext:
+    """L2 header-AST compile context — shared by ``dump`` and ``scan``.
+
+    The cross-toolchain + frontend knobs the header frontend needs to parse the
+    public headers: the cross-compiler (``--gcc-path``/``--gcc-prefix``), extra
+    compiler flags (``--gcc-options``/``--gcc-option``), an alternate
+    ``--sysroot``, ``--nostdinc``, and which ``--ast-frontend`` to drive. ADR-037
+    D3 (parity: ``dump`` and ``scan`` carry the *same* family via one decorator)
+    and the ADR-035 amendment (``scan`` must be able to reach a real L2 — the
+    cross-source checks depend on header provenance). All fields defaulted, so a
+    bare ``CompileContext()`` is additive over every request and dump path.
+    """
+
+    gcc_path: str | None = None
+    gcc_prefix: str | None = None
+    gcc_options: str | None = None
+    gcc_option_tokens: tuple[str, ...] = ()
+    sysroot: Path | None = None
+    nostdinc: bool = False
+    frontend: str = "auto"  # --ast-frontend (auto/castxml/clang)
+
+    @property
+    def is_default(self) -> bool:
+        """True when nothing was customised (lets call sites skip threading)."""
+        return self == CompileContext()
+
+
+@dataclass(frozen=True)
 class ScanRequest:
     """Typed input to the scan engine (ADR-035 D10). All additive over dump/compare."""
 
@@ -153,6 +181,8 @@ class ScanRequest:
     seeded: bool = False  # a real diff seed was produced (even if changed_paths is [])
     budget: Budget = field(default_factory=Budget)
     lang: str = "c++"
+    # L2 header compile context (dump↔scan flag parity, ADR-037 D3).
+    compile: CompileContext = field(default_factory=CompileContext)
 
 
 @dataclass(frozen=True)
@@ -638,6 +668,7 @@ def run_scan(req: ScanRequest) -> ScanResult:
             severities={},
             budget=budget_str,
             budget_s=budget_s,
+            compile_context=None if req.compile.is_default else req.compile,
         )
     except _BudgetOverflow:
         # The failure-guard contract: overflow is exit 5, never a shrunk scope.

--- a/docs/concepts/abi-series/08-detection.md
+++ b/docs/concepts/abi-series/08-detection.md
@@ -57,6 +57,51 @@ abicheck implements, and why runtime testing (approach 2) still belongs in your
 release pipeline *next to* static checking: it is the only approach that observes
 behaviour.
 
+### 1a. The hidden prerequisite of header/AST diffing: the compile context
+
+Approach 5 (L2 header/AST) has a subtlety the table glosses: a header is not a
+self-contained fact, it is *source code*. To turn it into an AST the frontend
+must parse it **the way your compiler does** — with the include roots it
+`#include`s, the C++ standard it assumes (`-std`), and the `-D` feature macros
+that gate which declarations even exist. Get that context wrong and L2 does not
+fail loudly; it produces a *different, plausible* AST. Two consequences matter
+for compatibility:
+
+- **L2 is what decides "public."** The public/internal boundary — and therefore
+  whether a removed symbol is a compatible internal cleanup or a breaking API
+  removal — comes from the header AST. If L2 cannot be built, the scan only has
+  the binary, so it must treat the export table as the surface and (correctly, by
+  that narrower rule) flags *internal* removals as BREAKING. This "scope
+  divergence" is a missing-context artifact, not a real break: with L2 those
+  demote to COMPATIBLE. A field run of oneTBB / oneDNN / oneDAL hit exactly this —
+  `dnnl::impl::*` and bundled `DGETRF`/`SGETRF` removals reported as breaking
+  purely because the headers could not be parsed.
+- **The wrong context manufactures phantom diffs.** Parse at `-std=c++17` a
+  library built at `-std=c++20` and concepts, `char8_t`, `noexcept`-in-type, and
+  inline-namespace versions shift — L2 shows add/remove churn that no consumer
+  would ever observe. Likewise a mismatched `-D` (a feature macro, or
+  libstdc++'s `_GLIBCXX_USE_CXX11_ABI` dual-ABI switch) changes which
+  declarations are visible at all.
+
+This is why the **source of the compile context matters as much as the frontend
+choice**, and why the two frontends are only interchangeable when fed the same
+context:
+
+| Scan source | What it supplies to L2 | What it cannot supply alone |
+|---|---|---|
+| **castxml** (`--ast-frontend castxml`) | runs your real `g++`/MSVC, so system includes + predefined macros + the compiler's default dialect come for free | your project's own `-I` roots, `-D`, and the exact `-std` (still pass these) |
+| **clang** (`--ast-frontend clang`) | the alternative for clang-only hosts; now auto-probes the host GNU compiler for system includes so libstdc++ resolves like castxml | same as above — auto-detection is system-headers only |
+| **`-I` / `--gcc-options` (CLI)** | per-run include roots, `-std`, `-D` | reproducibility — a human/CI must retype them each run |
+| **`.abicheck.yml` `compile:` block** | the project's stable, reviewed include roots / `std` / `defines` | per-invocation cross-compile specifics (those stay CLI) |
+| **compile database** (`compile_commands.json`) | the authoritative per-TU `-I`/`-std`/`-D` the library was actually built with | *(threading it into L2 is a planned step; today it feeds L3–L5)* |
+
+The practical takeaway for [`abicheck scan`](../../user-guide/scan-levels.md#compile-context-for-header-parsing-l2):
+auto-detection makes the common case (find the C++ stdlib) work with no flags,
+but the **project-specific** context — include roots, dialect, feature macros —
+must come from a compile DB, the config `compile:` block, or explicit flags, or
+L2 (and the public/internal scoping that depends on it) is only as good as the
+context it was handed.
+
 ---
 
 ## 2. What it takes to find each break family

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -58,11 +58,36 @@ don't exactly match what was compiled, results will be unreliable.
 
 **Mitigation:**
 - Always use the exact same headers that were used to build the `.so`
-- Pass compile-time defines to castxml: `abicheck dump libfoo.so -H foo.h --castxml-arg=-DFEATURE_X`
+- Pass the build's include roots, dialect, and defines to the header frontend:
+  `abicheck dump libfoo.so -H foo.h -I include/ --gcc-options "-std=c++20 -DFEATURE_X"`
+  (the same flags work on `abicheck scan`; persist them in a `.abicheck.yml`
+  `compile:` block so every run is reproducible — see
+  [Compile context for header parsing](../user-guide/scan-levels.md#compile-context-for-header-parsing-l2))
 - For `abicheck compat`, use `-s` (strict mode) to promote `COMPATIBLE`/`API_BREAK` to BREAKING:
   `abicheck compat check -lib foo -old OLD.xml -new NEW.xml -s`
   (use `--strict-mode api` to promote only `API_BREAK`; `-s` is not available on `abicheck compare`)
 - Cross-check with `abicheck compat check` (ABICC mode) for independent validation
+
+### System-include auto-detection (and what it does *not* fix)
+
+The `clang` frontend now auto-detects the host C++ standard library the way
+`castxml` always has (it probes `g++ -E -v` and injects the system include dirs),
+so a bare `scan -H include/` finds `<cstddef>` without extra flags. This is
+**system headers only** — it cannot guess your project's own `-I` roots, `-D`
+feature macros, or the exact `-std`. Disable it with `--nostdinc`, an explicit
+`--sysroot`, or `ABICHECK_AUTO_SYSTEM_INCLUDES=0`.
+
+!!! danger "Scope divergence: missing L2 context can turn internal cleanups into false BREAKING"
+    The header AST (L2) is what tells `abicheck` which symbols are **public**. If
+    the headers cannot be parsed — because the compile context above is missing —
+    the scan has only the binary, so it treats the export table as the surface and
+    flags the removal of *internal* symbols (e.g. macro-guarded `detail::`/`impl::`
+    helpers, or statically-bundled third-party routines) as BREAKING. These are
+    **missing-context artifacts, not real breaks**: supply the include roots /
+    dialect / defines (so L2 parses) and they demote to COMPATIBLE. Always read
+    the scan's coverage block — if L2 is `not_collected`, treat any BREAKING on an
+    `impl`/`detail`/`internal` symbol with suspicion and fix the header context
+    first.
 
 ---
 

--- a/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
+++ b/docs/development/adr/035-pr-tier-source-intelligence-and-crosscheck.md
@@ -296,6 +296,42 @@ API key — not a new `levels` spelling), `risk_rules`, and `crosschecks:
 they imply new cost; they map onto the existing collect-mode / evidence-policy
 machinery rather than replacing it.
 
+**D6.1 — Amendment (2026-06): `compile:` block + L2 must be reachable from `scan`.**
+The cross-source checks (D4) and public-surface scoping depend on a real **L2
+header AST** — that is what tells the scan which symbols are *public*. A field run
+of oneTBB / oneDNN / oneDAL showed L2 silently failing under `scan`: the header
+parse needed the translation unit's compile context (include roots, the host
+libstdc++ paths, a `-std`) and `scan` had **no flag, config, or compile-DB path**
+to supply it, so the scan fell back to a binary-strict scope and (correctly, by
+its own rules) reported internal removals — oneDNN's `dnnl::impl::*`, oneDAL's
+bundled `DGETRF`/`SGETRF` — as BREAKING. With L2 those demote to COMPATIBLE.
+
+Two fixes, both additive: (a) `scan` gains the same L2 compile-context flags as
+`dump` via one shared decorator (CLI parity — specified in **ADR-037 D8.1**); and
+(b) the stable, version-controlled half of that context lives in a new
+`.abicheck.yml` **`compile:`** block (per the D4 CLI-vs-config rule — include
+roots, `std`, defines, frontend, sysroot are stable project properties, while the
+per-invocation/cross-compile flags stay CLI overrides):
+
+```yaml
+compile:
+  frontend: auto          # auto | castxml | clang  (== --ast-frontend)
+  std: c++20              # parse standard (-std=)
+  include_dirs: [include, third_party/include]
+  defines: [DNNL_ENABLE_FOO=1]
+  sysroot: /opt/sysroot
+  nostdinc: false
+```
+
+Precedence: explicit CLI flag > `.abicheck.yml` `compile:` > compile-DB-derived
+flags > auto-detected system includes. Auto-detection (clang gaining castxml's
+system-include discovery) is the default floor so a bare `scan -H` finds the C++
+stdlib; it cannot guess the project's own include roots / macros / dialect, which
+is why the config block and CLI overrides remain. **Threading the per-TU `-I`/
+`-std`/`-D` from an existing `--compile-db` into the L2 frontend** (today the
+compile DB feeds only L3–L5) is the precise next step and is tracked as a
+follow-up — it needs header→TU flag mapping and so is scoped separately.
+
 ### D7. Evidence-directed focusing: cheap facts steer the expensive scan
 
 Cross-source links are used in **two directions**, not one. D4 reads them to

--- a/docs/development/adr/037-cli-interface-contract.md
+++ b/docs/development/adr/037-cli-interface-contract.md
@@ -145,6 +145,34 @@ contract violation (CI-checked, D10).
 | `@debug_resolution_options` | `--debug-root{,1,2}`, `--debuginfod[-url]`, `--debug-format`, `--dwarf-only` |
 | `@output_options` | `--format`, `-o/--output` |
 | `@evidence_options` | `--depth`, `--max`, `--sources` + per-side `--old/new-sources`, `--build-info` + per-side `--old/new-build-info` (D5) |
+| `@compile_context_options` | `--ast-frontend`, `--gcc-path`, `--gcc-prefix`, `--gcc-options`, `--gcc-option`, `--sysroot`, `--nostdinc` — the L2 header-AST compile context (D8.1) |
+
+**D8.1 — `dump` and `scan` share the L2 compile context (no drift).** The
+cross-toolchain + frontend flags that tell the header frontend *how* to parse the
+public headers were declared inline on `dump` but **absent from `scan`** — so a
+`scan` of a library whose headers need an include root, a `-std`, or a `-D`
+feature macro (e.g. oneTBB's `oneapi/tbb.h`) had no way to supply them and L2
+silently failed, dropping the scan to a binary-strict scope that flags internal
+removals as BREAKING. The whole family is now defined **once** in
+`@compile_context_options` and composed by **both** `dump` and `scan`
+(registered-but-not-required, like `@evidence_options`: only the
+header-parsing commands carry it). Threaded as a frozen
+`service_scan.CompileContext` through `run_dump`/`run_scan` (D2). A
+`tests/test_compile_context_parity.py` guard asserts the two commands expose an
+identical compile-context flag set, so they cannot drift again.
+
+**Capability parity is part of the frontend contract (D8).** `--ast-frontend`
+picks *which* frontend, but the two are only interchangeable (the ADR-003 parity
+promise) if they see the **same** translation-unit context. castxml gets that for
+free — `castxml --castxml-cc-gnu g++` runs the real compiler to discover its
+built-in system include paths. The clang backend (`clang -ast-dump=json`) does
+not, so it now auto-probes the host GNU compiler for its system include dirs and
+injects them as `-isystem` (on by default; suppressed by `--nostdinc`, an
+explicit `--sysroot`, or `ABICHECK_AUTO_SYSTEM_INCLUDES=0`). Auto-detection
+recovers the *system* headers (libstdc++/libc); the *project's own* include
+roots, `-D` feature macros, and exact `-std` still come from
+`-I`/`--gcc-options`, a compile DB, or the config `compile:` block (D4) — see the
+limitations in `docs/concepts/limitations.md`.
 
 A command that legitimately wants a *subset* opts out **explicitly with a code
 comment stating why** — the absence becomes a deliberate, reviewable decision

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -96,6 +96,78 @@ abicheck scan --binary new/libfoo.so -H include/ --sources . \
   --config .abicheck.yml --source-method s5 --baseline old/libfoo.abi.json
 ```
 
+## Compile context for header parsing (L2)
+
+The L2 header AST is what establishes the **public/internal boundary** — which
+declarations are API, so the cross-source checks and public-surface scoping can
+tell an *internal* symbol removal (compatible) from a public one (breaking). To
+build it, the frontend must parse your public headers the way your compiler does:
+it needs the include roots they `#include`, the C++ standard they assume, and any
+`-D` feature macros that gate declarations. When that context is missing the
+header parse fails, the scan falls back to a binary-strict scope, and internal
+removals get reported as BREAKING.
+
+`scan` now takes the **same** compile-context flags as `dump` (they share one
+definition, so they never drift):
+
+| Flag | Purpose |
+|---|---|
+| `--ast-frontend {auto,castxml,clang}` | which frontend parses the headers (env `ABICHECK_AST_FRONTEND`) |
+| `-I/--include DIR` | an include root your headers need (repeatable) |
+| `--gcc-options "…"` | extra compiler flags (whitespace-split), e.g. `--gcc-options "-std=c++20 -DFOO=1"` |
+| `--gcc-option TOK` | one flag verbatim (repeatable; for a flag + spaced value) |
+| `--gcc-path` / `--gcc-prefix` | a cross-compiler / cross-toolchain prefix |
+| `--sysroot DIR` | an alternate system root |
+| `--nostdinc` | do not search system includes (and disable the auto-probe below) |
+
+### Where each setting belongs (CLI vs config)
+
+Four layers resolve the context, **highest precedence first**:
+
+1. **Explicit CLI flag** — a per-run override (`--gcc-options`, `--sysroot`, …).
+2. **`.abicheck.yml` `compile:` block** — your project's stable contract,
+   reviewed in PRs (see below). Put include roots, `std`, and `defines` here so
+   every scan/CI run is reproducible without re-typing them.
+3. **Compile-DB-derived flags** — *planned*: per-TU `-I`/`-std`/`-D` taken from a
+   `--compile-db`. Today the compile DB feeds L3–L5 only.
+4. **Auto-detected system includes** — the default floor (below).
+
+```yaml
+# .abicheck.yml
+compile:
+  frontend: auto          # auto | castxml | clang
+  std: c++20
+  include_dirs: [include, third_party/include]
+  defines: [DNNL_ENABLE_FOO=1]
+  # sysroot: /opt/sysroot
+  # nostdinc: false
+```
+
+### Auto-detection of system includes (on by default)
+
+`castxml` finds the host C++ standard library for free, because it runs your real
+compiler to discover its built-in include paths. The `clang` frontend did not —
+so on a minimal container, a non-standard prefix, or a Conda-clang setup it could
+not find `<cstddef>` and the parse failed. The clang backend now **probes the
+host GNU compiler** (`g++ -E -v`) for its system include dirs and injects them, so
+a bare `scan -H include/` finds libstdc++ without extra flags. Disable it with
+`--nostdinc`, an explicit `--sysroot`, or `ABICHECK_AUTO_SYSTEM_INCLUDES=0`.
+
+!!! warning "Auto-detection is partial — know its limits"
+    - It recovers **system** headers (libstdc++/libc), **not your project's own**
+      include roots or `-D` feature macros. oneTBB-style headers still need
+      `-I`/the `compile:` block for the `oneapi/` root.
+    - A **wrong `-std`** changes the ABI surface (concepts, `char8_t`,
+      `noexcept`-in-type, inline-namespace versioning) — parse at the standard the
+      library was *built* with or L2 shows phantom add/remove churn.
+    - **Wrong/missing `-D` defines** change which declarations are visible —
+      macro-gated internals (e.g. `dnnl::impl::*`) or the libstdc++ dual ABI
+      (`_GLIBCXX_USE_CXX11_ABI`) — and produce exactly the "scope divergence"
+      false BREAKINGs this feature exists to remove.
+    - Auto-detection reads the **host** toolchain → it is wrong for
+      cross-compiles (use `--gcc-prefix`/`--sysroot` or the config block) and
+      makes results host-dependent (pin context in config for reproducible CI).
+
 ## Worked examples
 
 Each example shows the command, what level it pins, and what to read in the

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -147,3 +147,82 @@ def test_dump_elf_default_compile_context_is_inert(
     assert captured["gcc_options"] is None
     assert captured["nostdinc"] is False
     assert captured["gcc_option_tokens"] == ()
+
+
+# ── .abicheck.yml compile: block (ADR-035 D6.1 / ADR-037 D4) ─────────────────
+
+
+def test_buildconfig_parses_compile_block() -> None:
+    from abicheck.buildsource.inline import BuildConfig
+
+    bc = BuildConfig.from_dict(
+        {
+            "compile": {
+                "frontend": "clang",
+                "std": "c++20",
+                "include_dirs": ["include", "third_party/inc"],
+                "defines": ["FOO=1", "BAR"],
+                "sysroot": "/opt/sysroot",
+                "nostdinc": True,
+            }
+        }
+    )
+    assert bc.compile_frontend == "clang"
+    assert bc.compile_std == "c++20"
+    assert bc.compile_include_dirs == ["include", "third_party/inc"]
+    assert bc.compile_defines == ["FOO=1", "BAR"]
+    assert bc.compile_sysroot == "/opt/sysroot"
+    assert bc.compile_nostdinc is True
+    # Round-trips through to_dict.
+    assert BuildConfig.from_dict(bc.to_dict()).to_dict() == bc.to_dict()
+
+
+def test_buildconfig_rejects_bad_compile_frontend() -> None:
+    import pytest as _pytest
+
+    from abicheck.buildsource.inline import BuildConfig
+
+    with _pytest.raises(ValueError, match="compile.frontend"):
+        BuildConfig.from_dict({"compile": {"frontend": "gcc"}})
+
+
+def test_merge_compile_config_cli_wins_over_config(tmp_path: Path) -> None:
+    from abicheck.cli_scan import _merge_compile_config
+
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text(
+        "compile:\n"
+        "  frontend: castxml\n"
+        "  std: c++17\n"
+        "  defines: [CFG=1]\n"
+        "  include_dirs: [include]\n"
+        "  sysroot: /cfg/sysroot\n"
+    )
+    cli = CompileContext(frontend="clang", gcc_options="-std=c++20 -DCLI=1")
+    merged, includes = _merge_compile_config(cli, (), cfg)
+    # CLI frontend + gcc_options win; config std/defines are NOT synthesized.
+    assert merged.frontend == "clang"
+    assert merged.gcc_options == "-std=c++20 -DCLI=1"
+    # Config sysroot fills the unset CLI field; include_dirs resolve under cfg dir.
+    assert merged.sysroot == Path("/cfg/sysroot")
+    assert includes == (tmp_path / "include",)
+
+
+def test_merge_compile_config_uses_config_when_cli_unset(tmp_path: Path) -> None:
+    from abicheck.cli_scan import _merge_compile_config
+
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text("compile:\n  std: c++20\n  defines: [A, B=2]\n  frontend: clang\n")
+    merged, _ = _merge_compile_config(CompileContext(), (), cfg)
+    assert merged.frontend == "clang"
+    # std + defines synthesized into gcc_options when the user gave none.
+    assert merged.gcc_options == "-std=c++20 -DA -DB=2"
+
+
+def test_merge_compile_config_noop_without_path() -> None:
+    from abicheck.cli_scan import _merge_compile_config
+
+    cli = CompileContext(gcc_options="-DX")
+    merged, includes = _merge_compile_config(cli, (Path("a"),), None)
+    assert merged is cli
+    assert includes == (Path("a"),)

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -364,3 +364,26 @@ def test_try_header_scoped_dump_threads_compile_to_dumper(
     assert captured["gcc_prefix"] == "x-"
     assert captured["sysroot"] == tmp_path
     assert captured["nostdinc"] is True
+
+
+def test_merge_compile_config_nostdinc_precedence(tmp_path: Path) -> None:
+    # config compile.nostdinc: true is inherited by default, but an explicit
+    # --no-nostdinc (nostdinc_explicit, value False) overrides it (Codex review).
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text("compile:\n  nostdinc: true\n", encoding="utf-8")
+    from abicheck.cli_scan import _merge_compile_config
+
+    # Default (not explicit) inherits config True.
+    inherit, _ = _merge_compile_config(CompileContext(), (), cfg)
+    assert inherit.nostdinc is True
+    # Explicit --no-nostdinc (cli False, explicit) overrides config True.
+    override, _ = _merge_compile_config(
+        CompileContext(nostdinc=False), (), cfg, nostdinc_explicit=True
+    )
+    assert override.nostdinc is False
+    # Explicit --nostdinc with no config also holds.
+    cfg.write_text("compile:\n  std: c++20\n", encoding="utf-8")
+    on, _ = _merge_compile_config(
+        CompileContext(nostdinc=True), (), cfg, nostdinc_explicit=True
+    )
+    assert on.nostdinc is True

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""dump↔scan L2 compile-context flag parity + threading (ADR-037 D3 / ADR-035).
+
+The cross-toolchain + frontend family is defined once in
+``cli_options.compile_context_options`` and shared by ``dump`` and ``scan``; this
+guards that they never drift, and that ``scan`` actually threads the context down
+to the header dump (so a ``scan`` of oneTBB-style headers gets the same build
+context ``dump`` would use).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.cli import dump_cmd
+from abicheck.cli_scan import scan_cmd
+from abicheck.service_scan import CompileContext, ScanRequest
+
+#: The dest names the compile-context family contributes (dump↔scan parity).
+_COMPILE_CONTEXT_DESTS = frozenset(
+    {
+        "header_backend",
+        "gcc_path",
+        "gcc_prefix",
+        "gcc_options",
+        "gcc_option_tokens",
+        "sysroot",
+        "nostdinc",
+    }
+)
+
+
+def _param_dests(cmd: object) -> set[str]:
+    return {p.name for p in getattr(cmd, "params", [])}
+
+
+def test_dump_exposes_full_compile_context_family() -> None:
+    assert _COMPILE_CONTEXT_DESTS <= _param_dests(dump_cmd)
+
+
+def test_scan_exposes_full_compile_context_family() -> None:
+    assert _COMPILE_CONTEXT_DESTS <= _param_dests(scan_cmd)
+
+
+def test_dump_and_scan_compile_context_does_not_drift() -> None:
+    # Both commands expose the *same* compile-context flags — the whole point of
+    # sharing one decorator. (A future inline addition to one would break this.)
+    dump_ctx = _param_dests(dump_cmd) & _COMPILE_CONTEXT_DESTS
+    scan_ctx = _param_dests(scan_cmd) & _COMPILE_CONTEXT_DESTS
+    assert dump_ctx == scan_ctx == _COMPILE_CONTEXT_DESTS
+
+
+def test_compile_context_default_is_empty() -> None:
+    assert CompileContext().is_default is True
+    assert CompileContext(gcc_options="-DX").is_default is False
+    assert CompileContext(frontend="clang").is_default is False
+
+
+def test_scan_request_carries_compile_context() -> None:
+    cc = CompileContext(gcc_options="-DFOO=1", sysroot=Path("/sr"), nostdinc=True)
+    req = ScanRequest(binaries=[Path("x.so")], compile=cc)
+    assert req.compile is cc
+    # Default request has an inert context (call sites can skip threading).
+    assert ScanRequest().compile.is_default is True
+
+
+def test_dump_elf_threads_compile_context_to_dumper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``service._dump_elf`` unpacks the CompileContext into ``dumper.dump``."""
+    import abicheck.dumper as dumper_mod
+    from abicheck import service
+
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n")
+
+    captured: dict[str, object] = {}
+
+    def _fake_dump(**kwargs: object) -> object:
+        captured.update(kwargs)
+
+        class _Snap:
+            parsed_with_build_context = False
+
+        return _Snap()
+
+    monkeypatch.setattr(dumper_mod, "dump", _fake_dump)
+
+    cc = CompileContext(
+        gcc_path="/opt/g++",
+        gcc_prefix="aarch64-linux-gnu-",
+        gcc_options="-DFOO=1",
+        gcc_option_tokens=("-isystem", "/x"),
+        sysroot=tmp_path,
+        nostdinc=True,
+    )
+    service._dump_elf(
+        tmp_path / "libfoo.so",
+        [header],
+        [],
+        "1.0",
+        "c++",
+        compile=cc,
+    )
+    assert captured["gcc_path"] == "/opt/g++"
+    assert captured["gcc_prefix"] == "aarch64-linux-gnu-"
+    assert captured["gcc_options"] == "-DFOO=1"
+    assert captured["gcc_option_tokens"] == ("-isystem", "/x")
+    assert captured["sysroot"] == tmp_path
+    assert captured["nostdinc"] is True
+
+
+def test_dump_elf_default_compile_context_is_inert(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No CompileContext → the dumper sees the unchanged defaults (no regression)."""
+    import abicheck.dumper as dumper_mod
+    from abicheck import service
+
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n")
+    captured: dict[str, object] = {}
+
+    def _fake_dump(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return type("_S", (), {"parsed_with_build_context": False})()
+
+    monkeypatch.setattr(dumper_mod, "dump", _fake_dump)
+    service._dump_elf(tmp_path / "libfoo.so", [header], [], "1.0", "c++")
+    assert captured["gcc_path"] is None
+    assert captured["gcc_options"] is None
+    assert captured["nostdinc"] is False
+    assert captured["gcc_option_tokens"] == ()

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -289,3 +289,78 @@ def test_probe_gnu_system_includes_handles_oserror(monkeypatch) -> None:
 
     monkeypatch.setattr(dumper_sysinc.subprocess, "run", _boom)
     assert dumper_sysinc._probe_gnu_system_includes("g++", cpp=True) == []
+
+
+def test_buildconfig_compile_frontend_case_insensitive() -> None:
+    from abicheck.buildsource.inline import BuildConfig
+
+    bc = BuildConfig.from_dict({"compile": {"frontend": "Clang"}})
+    assert bc.compile_frontend == "clang"
+
+
+def test_merge_compile_config_explicit_auto_beats_config(tmp_path: Path) -> None:
+    # CLI > config: an explicitly-typed --ast-frontend auto bypasses a pinned
+    # config frontend (Codex review).
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text("compile:\n  frontend: clang\n", encoding="utf-8")
+    from abicheck.cli_scan import _merge_compile_config
+
+    # Default 'auto' (not explicit) inherits config 'clang'.
+    inherit, _ = _merge_compile_config(CompileContext(), (), cfg)
+    assert inherit.frontend == "clang"
+    # Explicit 'auto' wins.
+    explicit, _ = _merge_compile_config(
+        CompileContext(frontend="auto"), (), cfg, frontend_explicit=True
+    )
+    assert explicit.frontend == "auto"
+
+
+def test_merge_compile_config_warns_on_malformed(tmp_path, capsys) -> None:
+    from abicheck.cli_scan import _merge_compile_config
+
+    bad = tmp_path / ".abicheck.yml"
+    bad.write_text("compile: [unterminated\n", encoding="utf-8")
+    cli = CompileContext(gcc_options="-DX")
+    merged, includes = _merge_compile_config(cli, (), bad)
+    assert merged is cli  # CLI-only fallback
+    assert "could not parse" in capsys.readouterr().err
+
+
+def test_try_header_scoped_dump_threads_compile_to_dumper(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # PE/Mach-O native header scoping forwards the compile context to the dumper
+    # (Codex review: gcc_options/sysroot must reach PE/Mach-O header parsing).
+    import abicheck.dumper as dumper_mod
+    from abicheck import service
+
+    header = tmp_path / "h.h"
+    header.write_text("int foo(void);\n")
+    captured: dict[str, object] = {}
+
+    def _fake_dumper_pe(*args, **kwargs):
+        captured.update(kwargs)
+        # A snapshot with a PUBLIC-visibility symbol so scoping counts as matched
+        # (only `.visibility` is read by _has_matched_public_surface).
+        import types as _types
+
+        from abicheck.model import Visibility
+
+        return _types.SimpleNamespace(
+            functions=[_types.SimpleNamespace(visibility=Visibility.PUBLIC)],
+            variables=[],
+        )
+
+    monkeypatch.setattr(dumper_mod, "_dump_pe", _fake_dumper_pe)
+    cc = CompileContext(
+        gcc_options="-std=c++20 -DPE", gcc_prefix="x-", sysroot=tmp_path,
+        nostdinc=True,
+    )
+    snap, reason = service._try_header_scoped_dump(
+        "pe", tmp_path / "x.dll", [header], [], "1.0", "c++", compile=cc
+    )
+    assert reason is None  # matched
+    assert captured["gcc_options"] == "-std=c++20 -DPE"
+    assert captured["gcc_prefix"] == "x-"
+    assert captured["sysroot"] == tmp_path
+    assert captured["nostdinc"] is True

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -226,3 +226,66 @@ def test_merge_compile_config_noop_without_path() -> None:
     merged, includes = _merge_compile_config(cli, (Path("a"),), None)
     assert merged is cli
     assert includes == (Path("a"),)
+
+
+def test_merge_compile_config_autodiscovers_from_sources(tmp_path: Path) -> None:
+    # No explicit --config, but a .abicheck.yml at the --sources root carries a
+    # compile: block → honored for L2 (Codex review parity with embed_build_source).
+    src = tmp_path / "tree"
+    src.mkdir()
+    (src / ".abicheck.yml").write_text(
+        "compile:\n  std: c++20\n  include_dirs: [include]\n", encoding="utf-8"
+    )
+    from abicheck.cli_scan import _merge_compile_config
+
+    merged, includes = _merge_compile_config(
+        CompileContext(), (), None, sources=src
+    )
+    assert merged.gcc_options == "-std=c++20"
+    assert includes == (src / "include",)
+
+
+def test_merge_compile_config_explicit_config_beats_autodiscovery(
+    tmp_path: Path,
+) -> None:
+    src = tmp_path / "tree"
+    src.mkdir()
+    (src / ".abicheck.yml").write_text("compile:\n  std: c++11\n", encoding="utf-8")
+    explicit = tmp_path / "explicit.yml"
+    explicit.write_text("compile:\n  std: c++23\n", encoding="utf-8")
+    from abicheck.cli_scan import _merge_compile_config
+
+    merged, _ = _merge_compile_config(CompileContext(), (), explicit, sources=src)
+    assert merged.gcc_options == "-std=c++23"  # explicit --config wins
+
+
+def test_probe_gnu_system_includes_mocked(monkeypatch, tmp_path: Path) -> None:
+    # Cover the subprocess probe body without a real compiler: only *existing*
+    # dirs survive the filter, in search order.
+    from abicheck import dumper_sysinc
+
+    real = tmp_path / "inc"
+    real.mkdir()
+    missing = tmp_path / "gone"  # never created
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.subprocess, "run", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc,
+        "_parse_gnu_include_search_dirs",
+        lambda s: [str(missing), str(real)],
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    assert out == [str(real)]
+
+
+def test_probe_gnu_system_includes_handles_oserror(monkeypatch) -> None:
+    from abicheck import dumper_sysinc
+
+    def _boom(*a, **k):
+        raise OSError("no compiler")
+
+    monkeypatch.setattr(dumper_sysinc.subprocess, "run", _boom)
+    assert dumper_sysinc._probe_gnu_system_includes("g++", cpp=True) == []

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1686,7 +1686,9 @@ def test_auto_system_includes_enabled_default_and_toggle(
 def test_resolve_probe_compiler_prefers_gnu_gcc_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(dumper.shutil, "which", lambda c: c)
+    from abicheck import dumper_sysinc
+
+    monkeypatch.setattr(dumper_sysinc.shutil, "which", lambda c: c)
     # An explicit GNU --gcc-path is used verbatim…
     assert _resolve_probe_compiler("c++", "/opt/gcc-13/bin/g++", None) == (
         "/opt/gcc-13/bin/g++"
@@ -1704,18 +1706,24 @@ def test_resolve_probe_compiler_prefers_gnu_gcc_path(
 def test_resolve_probe_compiler_none_when_no_compiler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(dumper.shutil, "which", lambda c: None)
+    from abicheck import dumper_sysinc
+
+    monkeypatch.setattr(dumper_sysinc.shutil, "which", lambda c: None)
     assert _resolve_probe_compiler("c++", None, None) is None
 
 
 def test_resolve_clang_system_includes_gating(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from abicheck import dumper_sysinc
+
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
     monkeypatch.setattr(
-        dumper, "_probe_gnu_system_includes", lambda *a, **k: ["/usr/include/c++/13"]
+        dumper_sysinc,
+        "_probe_gnu_system_includes",
+        lambda *a, **k: ["/usr/include/c++/13"],
     )
-    monkeypatch.setattr(dumper, "_resolve_probe_compiler", lambda *a, **k: "g++")
+    monkeypatch.setattr(dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++")
 
     base = dict(gcc_path=None, gcc_prefix=None, force_cpp=True)
     # Default: probed dirs returned.
@@ -1738,8 +1746,10 @@ def test_resolve_clang_system_includes_gating(
 def test_resolve_clang_system_includes_no_compiler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from abicheck import dumper_sysinc
+
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
-    monkeypatch.setattr(dumper, "_resolve_probe_compiler", lambda *a, **k: None)
+    monkeypatch.setattr(dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: None)
     assert _resolve_clang_system_includes(
         "c++", gcc_path=None, gcc_prefix=None, sysroot=None,
         nostdinc=False, force_cpp=True,

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1776,3 +1776,23 @@ def test_build_clang_command_injects_isystem(tmp_path: Path) -> None:
     assert cmd[cmd.index("/usr/include") - 1] == "-isystem"
     # The user's -I still comes before the first -isystem (explicit wins).
     assert cmd.index("-I") < i
+
+
+def test_build_clang_command_probed_isystem_after_user_flags(tmp_path: Path) -> None:
+    # Auto-probed -isystem must follow the user's pass-through flags so a
+    # user-supplied SDK -isystem keeps higher search priority (Codex review).
+    agg = tmp_path / "agg.hpp"
+    agg.write_text("")
+    cmd = _build_clang_header_command(
+        "clang++", "gnu", [], agg,
+        force_cpp=True,
+        gcc_options="-isystem /sdk/include",
+        gcc_option_tokens=("-isystem", "/sdk2"),
+        system_includes=("/usr/include/c++/13",),
+    )
+    user_sdk = cmd.index("/sdk/include")
+    user_sdk2 = cmd.index("/sdk2")
+    probed = cmd.index("/usr/include/c++/13")
+    # Both user-supplied system dirs are searched before the probed fallback.
+    assert user_sdk < probed
+    assert user_sdk2 < probed

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1805,9 +1805,15 @@ def test_build_clang_command_probed_isystem_after_user_flags(tmp_path: Path) -> 
         ("-nostdinc++", ()),
         ("--sysroot=/sdk", ()),
         ("-isysroot /sdk", ()),
+        ("--gcc-toolchain=/opt/gcc", ()),
+        ("--gcc-install-dir=/opt/gcc/lib", ()),
+        ("--target=aarch64-linux-gnu", ()),
         (None, ("-nostdinc",)),
         (None, ("--sysroot=/sdk",)),
         (None, ("-nostdinc++",)),
+        (None, ("--gcc-toolchain=/opt/gcc",)),
+        (None, ("--target=aarch64-linux-gnu",)),
+        (None, ("-target", "aarch64-linux-gnu")),
     ],
 )
 def test_resolve_clang_system_includes_respects_passthrough(

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1796,3 +1796,54 @@ def test_build_clang_command_probed_isystem_after_user_flags(tmp_path: Path) -> 
     # Both user-supplied system dirs are searched before the probed fallback.
     assert user_sdk < probed
     assert user_sdk2 < probed
+
+
+@pytest.mark.parametrize(
+    "gcc_options,gcc_option_tokens",
+    [
+        ("-nostdinc", ()),
+        ("-nostdinc++", ()),
+        ("--sysroot=/sdk", ()),
+        ("-isysroot /sdk", ()),
+        (None, ("-nostdinc",)),
+        (None, ("--sysroot=/sdk",)),
+        (None, ("-nostdinc++",)),
+    ],
+)
+def test_resolve_clang_system_includes_respects_passthrough(
+    monkeypatch: pytest.MonkeyPatch, gcc_options, gcc_option_tokens
+) -> None:
+    # Hermetic/cross flags supplied via --gcc-options/--gcc-option must suppress
+    # the host probe too, not just the structured nostdinc/sysroot (Codex review).
+    from abicheck import dumper_sysinc
+
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
+    monkeypatch.setattr(
+        dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++"
+    )
+    monkeypatch.setattr(
+        dumper_sysinc, "_probe_gnu_system_includes", lambda *a, **k: ["/usr/x"]
+    )
+    assert _resolve_clang_system_includes(
+        "c++", gcc_path=None, gcc_prefix=None, sysroot=None, nostdinc=False,
+        force_cpp=True, gcc_options=gcc_options, gcc_option_tokens=gcc_option_tokens,
+    ) == ()
+
+
+def test_resolve_clang_system_includes_probes_without_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A benign --gcc-options that doesn't isolate the parse still probes.
+    from abicheck import dumper_sysinc
+
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
+    monkeypatch.setattr(
+        dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++"
+    )
+    monkeypatch.setattr(
+        dumper_sysinc, "_probe_gnu_system_includes", lambda *a, **k: ["/usr/x"]
+    )
+    assert _resolve_clang_system_includes(
+        "c++", gcc_path=None, gcc_prefix=None, sysroot=None, nostdinc=False,
+        force_cpp=True, gcc_options="-DFOO=1", gcc_option_tokens=("-O2",),
+    ) == ("/usr/x",)

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -1671,14 +1671,19 @@ def test_parse_gnu_include_search_dirs_empty_when_no_block() -> None:
     assert _parse_gnu_include_search_dirs("clang: error: no input files\n") == []
 
 
-def test_auto_system_includes_enabled_default_and_toggle(
+@pytest.mark.parametrize("off", ["0", "false", "no", "off", "OFF"])
+def test_auto_system_includes_enabled_off_values(
+    monkeypatch: pytest.MonkeyPatch, off: str
+) -> None:
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", off)
+    assert _auto_system_includes_enabled() is False
+
+
+def test_auto_system_includes_enabled_default_and_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ABICHECK_AUTO_SYSTEM_INCLUDES", raising=False)
     assert _auto_system_includes_enabled() is True
-    for off in ("0", "false", "no", "off", "OFF"):
-        monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", off)
-        assert _auto_system_includes_enabled() is False
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
     assert _auto_system_includes_enabled() is True
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -29,10 +29,14 @@ import pytest
 
 from abicheck import dumper
 from abicheck.dumper import (
+    _auto_system_includes_enabled,
     _build_clang_header_command,
     _clang_header_dump,
     _header_ast_parser,
+    _parse_gnu_include_search_dirs,
+    _resolve_clang_system_includes,
     _resolve_header_backend,
+    _resolve_probe_compiler,
 )
 from abicheck.dumper_clang import (
     _ClangAstParser,
@@ -934,6 +938,9 @@ def test_clang_header_dump_success_and_cache(
 
     monkeypatch.setattr(dumper, "_clang_available", lambda *a, **k: True)
     monkeypatch.setattr(dumper, "_cache_path", lambda *a, **k: cache)
+    # Isolate the single clang AST-dump call: disable the castxml↔clang
+    # system-include probe (itself a separate, best-effort subprocess).
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "0")
     calls = {"n": 0}
 
     def _run(cmd, **kwargs):
@@ -1623,3 +1630,134 @@ def test_clang_header_dump_corrupt_cache_is_discarded(
     # The corrupt cache is unlinked and the fresh clang run repopulates it.
     root = _clang_header_dump([header], [])
     assert root == {"kind": "TranslationUnitDecl", "inner": []}
+
+
+# ── castxml↔clang system-include auto-detection (parity fix) ─────────────────
+
+_GCC_VERBOSE_STDERR = """\
+ignoring nonexistent directory "/usr/local/include/x86_64-linux-gnu"
+#include "..." search starts here:
+#include <...> search starts here:
+ /usr/include/c++/13
+ /usr/include/x86_64-linux-gnu/c++/13
+ /usr/lib/gcc/x86_64-linux-gnu/13/include
+ /usr/include
+End of search list.
+"""
+
+
+def test_parse_gnu_include_search_dirs() -> None:
+    dirs = _parse_gnu_include_search_dirs(_GCC_VERBOSE_STDERR)
+    # Only the lines inside the <...> block, in order; the leading "ignoring"
+    # line and the quote-include marker are excluded.
+    assert dirs == [
+        "/usr/include/c++/13",
+        "/usr/include/x86_64-linux-gnu/c++/13",
+        "/usr/lib/gcc/x86_64-linux-gnu/13/include",
+        "/usr/include",
+    ]
+
+
+def test_parse_gnu_include_search_dirs_strips_framework_note() -> None:
+    stderr = (
+        "#include <...> search starts here:\n"
+        " /System/Library/Frameworks (framework directory)\n"
+        "End of search list.\n"
+    )
+    assert _parse_gnu_include_search_dirs(stderr) == ["/System/Library/Frameworks"]
+
+
+def test_parse_gnu_include_search_dirs_empty_when_no_block() -> None:
+    assert _parse_gnu_include_search_dirs("clang: error: no input files\n") == []
+
+
+def test_auto_system_includes_enabled_default_and_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ABICHECK_AUTO_SYSTEM_INCLUDES", raising=False)
+    assert _auto_system_includes_enabled() is True
+    for off in ("0", "false", "no", "off", "OFF"):
+        monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", off)
+        assert _auto_system_includes_enabled() is False
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
+    assert _auto_system_includes_enabled() is True
+
+
+def test_resolve_probe_compiler_prefers_gnu_gcc_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper.shutil, "which", lambda c: c)
+    # An explicit GNU --gcc-path is used verbatim…
+    assert _resolve_probe_compiler("c++", "/opt/gcc-13/bin/g++", None) == (
+        "/opt/gcc-13/bin/g++"
+    )
+    # …but a clang there is skipped (useless for libstdc++ discovery) → g++.
+    assert _resolve_probe_compiler("c++", "/usr/bin/clang++", None) == "g++"
+    # Cross prefix maps to the prefixed GNU driver.
+    assert _resolve_probe_compiler("c++", None, "aarch64-linux-gnu-") == (
+        "aarch64-linux-gnu-g++"
+    )
+    # C mode probes gcc.
+    assert _resolve_probe_compiler("cc", None, None) == "gcc"
+
+
+def test_resolve_probe_compiler_none_when_no_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(dumper.shutil, "which", lambda c: None)
+    assert _resolve_probe_compiler("c++", None, None) is None
+
+
+def test_resolve_clang_system_includes_gating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
+    monkeypatch.setattr(
+        dumper, "_probe_gnu_system_includes", lambda *a, **k: ["/usr/include/c++/13"]
+    )
+    monkeypatch.setattr(dumper, "_resolve_probe_compiler", lambda *a, **k: "g++")
+
+    base = dict(gcc_path=None, gcc_prefix=None, force_cpp=True)
+    # Default: probed dirs returned.
+    assert _resolve_clang_system_includes(
+        "c++", sysroot=None, nostdinc=False, **base
+    ) == ("/usr/include/c++/13",)
+    # nostdinc, explicit sysroot, or the env toggle each suppress the probe.
+    assert _resolve_clang_system_includes(
+        "c++", sysroot=None, nostdinc=True, **base
+    ) == ()
+    assert _resolve_clang_system_includes(
+        "c++", sysroot=Path("/sysroot"), nostdinc=False, **base
+    ) == ()
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "0")
+    assert _resolve_clang_system_includes(
+        "c++", sysroot=None, nostdinc=False, **base
+    ) == ()
+
+
+def test_resolve_clang_system_includes_no_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
+    monkeypatch.setattr(dumper, "_resolve_probe_compiler", lambda *a, **k: None)
+    assert _resolve_clang_system_includes(
+        "c++", gcc_path=None, gcc_prefix=None, sysroot=None,
+        nostdinc=False, force_cpp=True,
+    ) == ()
+
+
+def test_build_clang_command_injects_isystem(tmp_path: Path) -> None:
+    agg = tmp_path / "agg.hpp"
+    agg.write_text("")
+    cmd = _build_clang_header_command(
+        "clang++", "gnu", [tmp_path / "inc"], agg,
+        force_cpp=True,
+        system_includes=("/usr/include/c++/13", "/usr/include"),
+    )
+    # User -I precedes the probed -isystem dirs, which appear as pairs.
+    assert "-I" in cmd
+    i = cmd.index("-isystem")
+    assert cmd[i + 1] == "/usr/include/c++/13"
+    assert cmd[cmd.index("/usr/include") - 1] == "-isystem"
+    # The user's -I still comes before the first -isystem (explicit wins).
+    assert cmd.index("-I") < i


### PR DESCRIPTION
## Why

A field scan of oneTBB / oneDNN / oneDAL showed the **L2 header AST silently failing under `scan`**. L2 is the tier that establishes which symbols are *public*, so without it the scan fell back to a binary-strict scope and (correctly, by that narrower rule) reported internal removals — oneDNN's `dnnl::impl::*`, oneDAL's bundled `DGETRF`/`SGETRF` — as **BREAKING**. Those "scope divergence" breaks are a missing-context artifact, not a real break: with L2 they demote to COMPATIBLE.

Two root causes, both fixed here:

1. **The clang backend lacked castxml's system-include discovery.** `castxml --castxml-cc-gnu g++` runs the real compiler to find its built-in include paths (so the host libstdc++ `<cstddef>` resolves); `clang -ast-dump=json` run directly does not, and misses it in minimal containers / non-standard prefixes / Conda-clang setups.
2. **`scan` had none of the L2 compile-context flags `dump` has** (no `--ast-frontend`, `--gcc-options`, `--sysroot`, …), and its `--compile-db` fed only L3–L5 — so there was no flag, config, or DB path to give the header frontend the context a library like oneTBB needs.

## What changed

**Capability parity (castxml ↔ clang)** — the clang backend now probes the host GNU compiler (`g++ -E -v`) for its system include dirs and injects them as `-isystem`, recreating castxml's behaviour. On by default; suppressed by `--nostdinc`, an explicit `--sysroot`, or `ABICHECK_AUTO_SYSTEM_INCLUDES=0`. Folded into the dump cache key. (Helpers live in the new `dumper_sysinc.py` to keep `dumper.py` off the file-size cap.)

**Flag parity (dump ↔ scan)** — the cross-toolchain + frontend family (`--ast-frontend`, `--gcc-path`/`--gcc-prefix`, `--gcc-options`/`--gcc-option`, `--sysroot`, `--nostdinc`) is now defined **once** in `cli_options.compile_context_options` and composed by **both** `dump` and `scan` (ADR-037 D3). Threaded as a frozen `CompileContext` through the scan engine (`ScanRequest → run_scan → run_scan_core → _build_new_snapshot`/baseline → `service.resolve_input → run_dump → _dump_elf → dumper.dump`). A parity test asserts the two commands can't drift again.

**Config (`.abicheck.yml` `compile:` block)** — the stable, reviewed half of the context (`frontend`, `std`, `include_dirs`, `defines`, `sysroot`, `nostdinc`) now lives in config; `scan` folds it in with **CLI > config** precedence. Precedence overall: explicit CLI > config > compile-DB-derived (planned) > auto-detected system includes.

**Docs + ADRs** — ADR-037 (new `@compile_context_options` family + castxml/clang capability-parity note), ADR-035 (D6.1 amendment: L2 reachability + `compile:` block + the scope-divergence finding), user guide (`scan-levels`: precedence ladder + auto-detection limits), ABI/API guide (`08-detection` §1a on the per-source compile-context dependency), and `limitations` (the scope-divergence danger note).

## Limitations / follow-ups (documented)

Auto-detection recovers **system** headers only — the project's own `-I` roots, `-D` feature macros, and exact `-std` still come from flags / the `compile:` block. Threading per-TU `-I`/`-std`/`-D` from an existing `--compile-db` into the L2 frontend (today it feeds L3–L5 only) is scoped as the next step (it needs header→TU flag mapping).

## Verification

- `ruff check abicheck tests` — clean (the CI lint gate)
- `mypy abicheck/` — 0 errors
- `python scripts/check_ai_readiness.py` — 0 errors
- fast suite (`not integration/libabigail/abicc/slow/golden`) — **11,423 passed**, plus new `tests/test_compile_context_parity.py` and auto-detect unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYng4QWcbQkt24ko1ZvNQc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended `.abicheck.yml` `compile:` support with additional header-parsing options (frontend, std, include dirs, defines, sysroot, nostdinc) including config round-tripping.
  * `scan` now exposes the same compile-context flags as `dump`, with precedence (CLI > config > auto system includes).

* **Bug Fixes**
  * Improved clang header parsing parity by auto-probing/injecting host system include dirs and updating dump cache behavior.
  * Ensured consistent compile-context usage across header-scoped PE/Mach-O dumping.

* **Documentation**
  * Added/updated guidance on L2 compile-context and mitigation for header/binary mismatch risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->