### PR TITLE
fix(dumper): unblock clang L2 on GNU hosts — drop GCC resource dir, retry C++

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -310,6 +310,7 @@ def _clang_header_dump(
     # way castxml does via ``--castxml-cc-gnu``. Folded into the cache key so a
     # toolchain change invalidates a stale dump.
     def _resolve_sysinc(*, force_cpp: bool) -> tuple[str, ...]:
+        """Probe the host GNU driver's ``-isystem`` dirs for the given language."""
         return _resolve_clang_system_includes(
             compiler,
             gcc_path=gcc_path,
@@ -357,6 +358,7 @@ def _clang_header_dump(
         agg_path = Path(agg.name)
 
     def _run_clang(fcpp: bool, fcpp20: bool, sysinc: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        """Build and run the clang AST-dump command for the given language mode."""
         cmd = _build_clang_header_command(
             clang_bin, cc_id, extra_includes, agg_path,
             sysroot=sysroot, nostdinc=nostdinc, gcc_options=gcc_options,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -130,38 +130,23 @@ def _resolve_header_backend(backend: str | None) -> str:
     return "castxml"
 
 
-#: The C++ standard library headers (C++23). A *valid C* translation unit never
-#: ``#include``s any of these, so when a C-mode parse fails to find one the TU is
-#: actually C++ — the signal that drives the clang C→C++ retry. Restricted to this
-#: exact whitelist (not "any extensionless header") so a C header that misses an
-#: extensionless *project* include (e.g. ``<config>``) is reported as the genuine
-#: missing C dependency rather than being silently re-parsed under ``__cplusplus``
-#: (Codex review).
+#: The C++ ``<cXXX>`` C-compatibility headers (``<cstddef>``, ``<cstdint>``, …).
+#: A missing one of these under a C-mode parse unambiguously means the TU is C++
+#: — the signal that drives the clang C→C++ retry. Deliberately restricted to the
+#: ``<cXXX>`` spellings rather than the *full* C++ library set: a C project never
+#: bare-includes ``<cstddef>``, whereas plain names like ``<string>``/``<version>``
+#: collide with plausible C project headers (oneTBB itself ships a ``version.h``),
+#: so matching those could re-parse a broken C build as C++ — silently caching a
+#: wrong AST instead of reporting the genuine missing dependency (Codex review).
+#: In practice the first miss for a C++ TU parsed in C mode is always a ``<cXXX>``
+#: header (libstdc++ pulls them in early); the rare "pure-C++ header missing
+#: first" case is handled by passing ``--lang c++`` explicitly.
 _CPP_STDLIB_HEADERS = frozenset(
     {
-        # C++ library headers
-        "algorithm", "any", "array", "atomic", "barrier", "bit", "bitset",
-        "charconv", "chrono", "codecvt", "compare", "complex", "concepts",
-        "condition_variable", "coroutine", "deque", "exception", "execution",
-        "expected", "filesystem", "flat_map", "flat_set", "format",
-        "forward_list", "fstream", "functional", "future", "generator",
-        "initializer_list", "iomanip", "ios", "iosfwd", "iostream", "istream",
-        "iterator", "latch", "limits", "list", "locale", "map", "mdspan",
-        "memory", "memory_resource", "mutex", "new", "numbers", "numeric",
-        "optional", "ostream", "print", "queue", "random", "ranges", "ratio",
-        "regex", "scoped_allocator", "semaphore", "set", "shared_mutex",
-        "source_location", "span", "spanstream", "sstream", "stack",
-        "stacktrace", "stdexcept", "stdfloat", "stop_token", "streambuf",
-        "string", "string_view", "strstream", "syncstream", "system_error",
-        "thread", "tuple", "type_traits", "typeindex", "typeinfo",
-        "unordered_map", "unordered_set", "utility", "valarray", "variant",
-        "vector", "version",
-        # C compatibility headers (<cXXX>) — the ones that surface first in
-        # practice because they pull in libstdc++/libc machinery.
         "cassert", "cctype", "cerrno", "cfenv", "cfloat", "cinttypes",
         "ciso646", "climits", "clocale", "cmath", "csetjmp", "csignal",
-        "cstdarg", "cstddef", "cstdint", "cstdio", "cstdlib", "cstring",
-        "ctime", "cuchar", "cwchar", "cwctype",
+        "cstdalign", "cstdarg", "cstdbool", "cstddef", "cstdint", "cstdio",
+        "cstdlib", "cstring", "ctgmath", "ctime", "cuchar", "cwchar", "cwctype",
     }
 )
 
@@ -171,16 +156,16 @@ _MISSING_HEADER_RE = re.compile(r"'([^'/]+)' file not found")
 
 
 def _is_missing_cpp_stdlib_header_error(stderr: str) -> bool:
-    """True if a clang parse failed because a C++ *standard* header was not found.
+    """True if a clang parse failed because a C++ ``<cXXX>`` header was not found.
 
     Pure/string-only so it is unit-testable without a compiler. Matches clang's
     ``fatal error: '<name>' file not found`` and confirms ``<name>`` is one of the
-    known C++ standard library headers (:data:`_CPP_STDLIB_HEADERS`). A C header
-    always carries a ``.h`` suffix and the C standard library is never named this
-    way, so such a miss means the TU is C++ and a C-mode parse picked the wrong
-    language — driving the C→C++ retry. An extensionless *project* include that is
-    not a stdlib header is deliberately *not* matched, so a real missing C
-    dependency is reported instead of masked by a ``__cplusplus`` re-parse.
+    C++ ``<cXXX>`` C-compatibility headers (:data:`_CPP_STDLIB_HEADERS`). A C TU
+    never includes one, so such a miss means the TU is C++ and a C-mode parse
+    picked the wrong language — driving the C→C++ retry. Plain-name C++ headers
+    (``<string>``/``<version>``/…) are deliberately *not* matched because they
+    collide with plausible C project header names; matching them could silently
+    re-parse a broken C build as C++ instead of reporting the missing dependency.
     """
     return any(
         m.group(1) in _CPP_STDLIB_HEADERS for m in _MISSING_HEADER_RE.finditer(stderr)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -327,7 +327,10 @@ def _clang_header_dump(
     # the C→C++ retry below parses with these, and the C-mode probe omits the
     # versioned libstdc++ dirs, so without this a libstdc++/GCC upgrade would not
     # change the key and abicheck would reuse a stale C++ AST (Codex review); and
-    # (b) is reused by the retry without a second probe.
+    # (b) is reused by the retry without a second probe. This means a C-mode dump
+    # pays one extra ``g++ -E -v`` probe even when it never retries — accepted as
+    # the cost of a retry-stable cache key (a lazy resolve would reopen the
+    # staleness window). The probe is fast and the clang backend is opt-in.
     cpp_system_includes = (
         system_includes if force_cpp else _resolve_sysinc(force_cpp=True)
     )

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -130,24 +130,61 @@ def _resolve_header_backend(backend: str | None) -> str:
     return "castxml"
 
 
-#: ``'<name>' file not found`` where *name* is extensionless — a C TU never
-#: ``#include``s an extensionless header (the C stdlib is all ``*.h``), so a
-#: missing extensionless include (``<cstddef>``, ``<vector>``, ``<string>`` …)
-#: under a C-mode parse means the header is actually C++. Used to drive the clang
-#: C→C++ retry below.
-_MISSING_CPP_STDLIB_HEADER_RE = re.compile(rb"'[a-z_][a-z0-9_]*' file not found")
+#: The C++ standard library headers (C++23). A *valid C* translation unit never
+#: ``#include``s any of these, so when a C-mode parse fails to find one the TU is
+#: actually C++ — the signal that drives the clang C→C++ retry. Restricted to this
+#: exact whitelist (not "any extensionless header") so a C header that misses an
+#: extensionless *project* include (e.g. ``<config>``) is reported as the genuine
+#: missing C dependency rather than being silently re-parsed under ``__cplusplus``
+#: (Codex review).
+_CPP_STDLIB_HEADERS = frozenset(
+    {
+        # C++ library headers
+        "algorithm", "any", "array", "atomic", "barrier", "bit", "bitset",
+        "charconv", "chrono", "codecvt", "compare", "complex", "concepts",
+        "condition_variable", "coroutine", "deque", "exception", "execution",
+        "expected", "filesystem", "flat_map", "flat_set", "format",
+        "forward_list", "fstream", "functional", "future", "generator",
+        "initializer_list", "iomanip", "ios", "iosfwd", "iostream", "istream",
+        "iterator", "latch", "limits", "list", "locale", "map", "mdspan",
+        "memory", "memory_resource", "mutex", "new", "numbers", "numeric",
+        "optional", "ostream", "print", "queue", "random", "ranges", "ratio",
+        "regex", "scoped_allocator", "semaphore", "set", "shared_mutex",
+        "source_location", "span", "spanstream", "sstream", "stack",
+        "stacktrace", "stdexcept", "stdfloat", "stop_token", "streambuf",
+        "string", "string_view", "strstream", "syncstream", "system_error",
+        "thread", "tuple", "type_traits", "typeindex", "typeinfo",
+        "unordered_map", "unordered_set", "utility", "valarray", "variant",
+        "vector", "version",
+        # C compatibility headers (<cXXX>) — the ones that surface first in
+        # practice because they pull in libstdc++/libc machinery.
+        "cassert", "cctype", "cerrno", "cfenv", "cfloat", "cinttypes",
+        "ciso646", "climits", "clocale", "cmath", "csetjmp", "csignal",
+        "cstdarg", "cstddef", "cstdint", "cstdio", "cstdlib", "cstring",
+        "ctime", "cuchar", "cwchar", "cwctype",
+    }
+)
+
+#: ``'<name>' file not found`` — captures the quoted include that clang could not
+#: resolve, checked against :data:`_CPP_STDLIB_HEADERS`.
+_MISSING_HEADER_RE = re.compile(r"'([^'/]+)' file not found")
 
 
 def _is_missing_cpp_stdlib_header_error(stderr: str) -> bool:
-    """True if a clang parse failed because a C++ standard header was not found.
+    """True if a clang parse failed because a C++ *standard* header was not found.
 
     Pure/string-only so it is unit-testable without a compiler. Matches clang's
-    ``fatal error: '<name>' file not found`` for an *extensionless* header name;
-    a C header always carries a ``.h`` suffix, so an extensionless miss is the
-    C++ standard library (``<cstddef>``/``<vector>``/…), i.e. the TU is C++ and a
-    C-mode parse picked the wrong language.
+    ``fatal error: '<name>' file not found`` and confirms ``<name>`` is one of the
+    known C++ standard library headers (:data:`_CPP_STDLIB_HEADERS`). A C header
+    always carries a ``.h`` suffix and the C standard library is never named this
+    way, so such a miss means the TU is C++ and a C-mode parse picked the wrong
+    language — driving the C→C++ retry. An extensionless *project* include that is
+    not a stdlib header is deliberately *not* matched, so a real missing C
+    dependency is reported instead of masked by a ``__cplusplus`` re-parse.
     """
-    return bool(_MISSING_CPP_STDLIB_HEADER_RE.search(stderr.encode("utf-8", "replace")))
+    return any(
+        m.group(1) in _CPP_STDLIB_HEADERS for m in _MISSING_HEADER_RE.finditer(stderr)
+    )
 
 
 def _has_explicit_std(
@@ -287,15 +324,26 @@ def _clang_header_dump(
     # dirs and inject them as ``-isystem`` so clang resolves libstdc++/libc the
     # way castxml does via ``--castxml-cc-gnu``. Folded into the cache key so a
     # toolchain change invalidates a stale dump.
-    system_includes = _resolve_clang_system_includes(
-        compiler,
-        gcc_path=gcc_path,
-        gcc_prefix=gcc_prefix,
-        sysroot=sysroot,
-        nostdinc=nostdinc,
-        force_cpp=force_cpp,
-        gcc_options=gcc_options,
-        gcc_option_tokens=gcc_option_tokens,
+    def _resolve_sysinc(*, force_cpp: bool) -> tuple[str, ...]:
+        return _resolve_clang_system_includes(
+            compiler,
+            gcc_path=gcc_path,
+            gcc_prefix=gcc_prefix,
+            sysroot=sysroot,
+            nostdinc=nostdinc,
+            force_cpp=force_cpp,
+            gcc_options=gcc_options,
+            gcc_option_tokens=gcc_option_tokens,
+        )
+
+    system_includes = _resolve_sysinc(force_cpp=force_cpp)
+    # Pre-resolve the C++ system include set so it (a) folds into the cache key —
+    # the C→C++ retry below parses with these, and the C-mode probe omits the
+    # versioned libstdc++ dirs, so without this a libstdc++/GCC upgrade would not
+    # change the key and abicheck would reuse a stale C++ AST (Codex review); and
+    # (b) is reused by the retry without a second probe.
+    cpp_system_includes = (
+        system_includes if force_cpp else _resolve_sysinc(force_cpp=True)
     )
 
     key = _cache_key(
@@ -303,7 +351,12 @@ def _clang_header_dump(
         gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
         gcc_option_tokens=gcc_option_tokens,
         sysroot=sysroot, nostdinc=nostdinc, lang=lang, backend="clang",
-        system_includes=system_includes,
+        # Both include sets feed the key: whichever the retry settles on, a
+        # toolchain change to either invalidates the cached AST. Equal when
+        # already in C++ mode — pass once so existing C++ cache keys are stable.
+        system_includes=system_includes
+        if force_cpp
+        else (*system_includes, *cpp_system_includes),
     )
     cached = _cache_path(key, backend="clang")
     if cached.exists():
@@ -339,26 +392,16 @@ def _clang_header_dump(
         # C→C++ self-heal: a pure-``#include`` umbrella header (e.g. oneTBB's
         # ``oneapi/tbb.h``) carries no inline C++ syntax, so ``_detect_cpp_headers``
         # picks C mode — then ``#include <cstddef>`` fails because the C-mode probe
-        # never injected the libstdc++ ``-isystem`` dirs. A missing *extensionless*
-        # header is an unambiguous "this is C++" signal (a C TU only includes
-        # ``*.h``), so re-resolve the system includes for C++ and retry once in C++
-        # mode. Mirrors the castxml C→C++ retry; skipped when already in C++ mode or
-        # the failure is anything other than a missing C++ stdlib header.
+        # never injected the libstdc++ ``-isystem`` dirs. A missing C++ *standard*
+        # header is an unambiguous "this is C++" signal (a C TU never includes one),
+        # so retry once in C++ mode with the pre-resolved C++ system includes.
+        # Mirrors the castxml C→C++ retry; skipped when already in C++ mode or the
+        # failure is anything other than a missing C++ stdlib header.
         if (
             result.returncode != 0
             and not force_cpp
             and _is_missing_cpp_stdlib_header_error(result.stderr or "")
         ):
-            cpp_system_includes = _resolve_clang_system_includes(
-                compiler,
-                gcc_path=gcc_path,
-                gcc_prefix=gcc_prefix,
-                sysroot=sysroot,
-                nostdinc=nostdinc,
-                force_cpp=True,
-                gcc_options=gcc_options,
-                gcc_option_tokens=gcc_option_tokens,
-            )
             log.warning(
                 "clang failed to find a C++ standard header parsing the header(s) in "
                 "C mode; the header is C++ (a pure-#include umbrella header has no "

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -130,6 +130,26 @@ def _resolve_header_backend(backend: str | None) -> str:
     return "castxml"
 
 
+#: ``'<name>' file not found`` where *name* is extensionless — a C TU never
+#: ``#include``s an extensionless header (the C stdlib is all ``*.h``), so a
+#: missing extensionless include (``<cstddef>``, ``<vector>``, ``<string>`` …)
+#: under a C-mode parse means the header is actually C++. Used to drive the clang
+#: C→C++ retry below.
+_MISSING_CPP_STDLIB_HEADER_RE = re.compile(rb"'[a-z_][a-z0-9_]*' file not found")
+
+
+def _is_missing_cpp_stdlib_header_error(stderr: str) -> bool:
+    """True if a clang parse failed because a C++ standard header was not found.
+
+    Pure/string-only so it is unit-testable without a compiler. Matches clang's
+    ``fatal error: '<name>' file not found`` for an *extensionless* header name;
+    a C header always carries a ``.h`` suffix, so an extensionless miss is the
+    C++ standard library (``<cstddef>``/``<vector>``/…), i.e. the TU is C++ and a
+    C-mode parse picked the wrong language.
+    """
+    return bool(_MISSING_CPP_STDLIB_HEADER_RE.search(stderr.encode("utf-8", "replace")))
+
+
 def _has_explicit_std(
     gcc_options: str | None, gcc_option_tokens: tuple[str, ...] = ()
 ) -> bool:
@@ -194,8 +214,14 @@ def _build_clang_header_command(
     if not force_cpp:
         if not explicit_std:
             cmd += ["-x", "c", "-std=gnu11"]
-    elif force_cpp20 and not explicit_std:
-        cmd += ["-x", "c++", "-std=gnu++20"]
+    elif not explicit_std:
+        # Select the C++ language explicitly (``-x c++``) rather than relying on
+        # the aggregate file's extension: the C→C++ retry reuses a ``.h`` aggregate
+        # that clang would otherwise parse as C. Only bump the standard to gnu++20
+        # when C++20 syntax was detected; otherwise leave clang's default dialect.
+        cmd += ["-x", "c++"]
+        if force_cpp20:
+            cmd += ["-std=gnu++20"]
     cmd += [
         "-fsyntax-only",
         "-ferror-limit=0",
@@ -292,21 +318,54 @@ def _clang_header_dump(
             agg.write(f'#include "{h.resolve()}"\n')
         agg_path = Path(agg.name)
 
-    cmd = _build_clang_header_command(
-        clang_bin, cc_id, extra_includes, agg_path,
-        sysroot=sysroot, nostdinc=nostdinc, gcc_options=gcc_options,
-        gcc_option_tokens=gcc_option_tokens,
-        force_cpp=force_cpp, force_cpp20=force_cpp20,
-        system_includes=system_includes,
-    )
-    try:
+    def _run_clang(fcpp: bool, fcpp20: bool, sysinc: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        cmd = _build_clang_header_command(
+            clang_bin, cc_id, extra_includes, agg_path,
+            sysroot=sysroot, nostdinc=nostdinc, gcc_options=gcc_options,
+            gcc_option_tokens=gcc_option_tokens,
+            force_cpp=fcpp, force_cpp20=fcpp20,
+            system_includes=sysinc,
+        )
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, check=False)
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=120, check=False)
         except subprocess.TimeoutExpired as exc:
             raise SnapshotError(
                 "clang timed out after 120 seconds parsing the header(s). The header "
                 "may contain syntax that causes the frontend to hang."
             ) from exc
+
+    try:
+        result = _run_clang(force_cpp, force_cpp20, system_includes)
+        # C→C++ self-heal: a pure-``#include`` umbrella header (e.g. oneTBB's
+        # ``oneapi/tbb.h``) carries no inline C++ syntax, so ``_detect_cpp_headers``
+        # picks C mode — then ``#include <cstddef>`` fails because the C-mode probe
+        # never injected the libstdc++ ``-isystem`` dirs. A missing *extensionless*
+        # header is an unambiguous "this is C++" signal (a C TU only includes
+        # ``*.h``), so re-resolve the system includes for C++ and retry once in C++
+        # mode. Mirrors the castxml C→C++ retry; skipped when already in C++ mode or
+        # the failure is anything other than a missing C++ stdlib header.
+        if (
+            result.returncode != 0
+            and not force_cpp
+            and _is_missing_cpp_stdlib_header_error(result.stderr or "")
+        ):
+            cpp_system_includes = _resolve_clang_system_includes(
+                compiler,
+                gcc_path=gcc_path,
+                gcc_prefix=gcc_prefix,
+                sysroot=sysroot,
+                nostdinc=nostdinc,
+                force_cpp=True,
+                gcc_options=gcc_options,
+                gcc_option_tokens=gcc_option_tokens,
+            )
+            log.warning(
+                "clang failed to find a C++ standard header parsing the header(s) in "
+                "C mode; the header is C++ (a pure-#include umbrella header has no "
+                "inline C++ syntax to auto-detect). Retrying in C++ mode. Pass "
+                "--lang c++ to select this directly and silence this warning."
+            )
+            result = _run_clang(True, _detect_cpp20_headers(headers), cpp_system_includes)
         # A nonzero exit means clang hit a hard parse error. Unlike L4 source
         # replay (which tolerates partial coverage), the L2 header AST must be
         # complete to be authoritative — a truncated declaration set would

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -91,17 +91,24 @@ def _parse_gnu_include_search_dirs(stderr: str) -> list[str]:
 #: dirs should cross over to the clang backend.
 _GNU_COMPILER_RESOURCE_SEGMENTS = ("gcc", "gcc-cross")
 
+#: The multilib library dir names that precede ``gcc``/``gcc-cross`` in a GCC
+#: resource path (``/usr/lib/gcc/…``, ``/usr/lib64/gcc/…``, ``/usr/libx32/…``).
+#: Matched exactly rather than by ``startswith("lib")`` so an unrelated dir such
+#: as ``…/libfoo/gcc/…`` is not misclassified as a GCC resource dir.
+_GNU_MULTILIB_DIRS = frozenset({"lib", "lib32", "lib64", "libx32"})
+
 
 def _is_gnu_compiler_resource_dir(path: str) -> bool:
     """True if *path* is a GCC compiler-internal include dir (not libstdc++/libc).
 
-    Matches the ``.../lib*/gcc[-cross]/<triple>/<ver>/include[-fixed]`` layout by
-    looking for a ``lib*`` segment immediately followed by ``gcc``/``gcc-cross``.
-    Pure/string-only so it is unit-testable without a real toolchain.
+    Matches the ``.../lib{,32,64,x32}/gcc[-cross]/<triple>/<ver>/include[-fixed]``
+    layout by looking for a multilib library segment (:data:`_GNU_MULTILIB_DIRS`)
+    immediately followed by ``gcc``/``gcc-cross``. Pure/string-only so it is
+    unit-testable without a real toolchain.
     """
     parts = Path(path).parts
     for prev, cur in zip(parts, parts[1:]):
-        if cur in _GNU_COMPILER_RESOURCE_SEGMENTS and prev.startswith("lib"):
+        if cur in _GNU_COMPILER_RESOURCE_SEGMENTS and prev in _GNU_MULTILIB_DIRS:
             return True
     return False
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -80,12 +80,41 @@ def _parse_gnu_include_search_dirs(stderr: str) -> list[str]:
     return dirs
 
 
+#: Path segments that mark a directory as GCC's *own* compiler resource/builtins
+#: dir (``GCC_INCLUDE_DIR`` / ``include-fixed``), e.g.
+#: ``/usr/lib/gcc/x86_64-linux-gnu/13/include``. These hold GCC's intrinsics
+#: headers (``immintrin.h``/``ia32intrin.h`` etc.) which reference GCC-only
+#: ``__builtin_ia32_*`` builtins and GCC-private ``stddef.h``/``stdarg.h``. clang
+#: ships its own equivalents in its resource dir, so injecting GCC's as
+#: ``-isystem`` makes clang pick up headers full of builtins it does not define
+#: and the parse fails. Drop them from the probe — only the libstdc++ and libc
+#: dirs should cross over to the clang backend.
+_GNU_COMPILER_RESOURCE_SEGMENTS = ("gcc", "gcc-cross")
+
+
+def _is_gnu_compiler_resource_dir(path: str) -> bool:
+    """True if *path* is a GCC compiler-internal include dir (not libstdc++/libc).
+
+    Matches the ``.../lib*/gcc[-cross]/<triple>/<ver>/include[-fixed]`` layout by
+    looking for a ``lib*`` segment immediately followed by ``gcc``/``gcc-cross``.
+    Pure/string-only so it is unit-testable without a real toolchain.
+    """
+    parts = Path(path).parts
+    for prev, cur in zip(parts, parts[1:]):
+        if cur in _GNU_COMPILER_RESOURCE_SEGMENTS and prev.startswith("lib"):
+            return True
+    return False
+
+
 def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     """Probe *cc_bin* for the system include dirs it would search (best-effort).
 
     Best-effort: any probe failure (no compiler, timeout) yields ``[]`` so the
     dump still runs on clang's own detection. Only existing directories are
-    returned, in the compiler's own search order.
+    returned, in the compiler's own search order. GCC's own compiler resource
+    dir is filtered out (see :func:`_is_gnu_compiler_resource_dir`): feeding it
+    to clang as ``-isystem`` makes clang use GCC's intrinsics headers, which
+    reference GCC-only builtins clang does not implement and the parse fails.
     """
     lang = "c++" if cpp else "c"
     try:
@@ -100,7 +129,9 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     except (OSError, subprocess.SubprocessError):
         return []
     return [
-        d for d in _parse_gnu_include_search_dirs(proc.stderr or "") if Path(d).is_dir()
+        d
+        for d in _parse_gnu_include_search_dirs(proc.stderr or "")
+        if Path(d).is_dir() and not _is_gnu_compiler_resource_dir(d)
     ]
 
 

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -298,6 +298,8 @@ def test_probe_gnu_system_includes_handles_oserror(monkeypatch) -> None:
         ("/usr/lib/gcc/x86_64-linux-gnu/13/include", True),
         ("/usr/lib/gcc/x86_64-linux-gnu/13/include-fixed", True),
         ("/usr/lib64/gcc/x86_64-redhat-linux/12/include", True),
+        ("/usr/lib32/gcc/x86_64-linux-gnu/13/include", True),
+        ("/usr/libx32/gcc/x86_64-linux-gnu/13/include", True),
         ("/opt/cross/lib/gcc-cross/aarch64-linux-gnu/12/include", True),
         # libstdc++ and libc dirs must be KEPT (not GCC resource dirs).
         ("/usr/include/c++/13", False),
@@ -305,8 +307,12 @@ def test_probe_gnu_system_includes_handles_oserror(monkeypatch) -> None:
         ("/usr/include", False),
         ("/usr/local/include", False),
         ("/usr/include/x86_64-linux-gnu", False),
-        # A 'gcc' segment not preceded by lib* is not the resource dir.
+        # A 'gcc' segment not preceded by an exact multilib dir is not the
+        # resource dir: a bare 'gcc' dir, or a 'lib'-prefixed but non-multilib
+        # dir like 'libfoo', must not be misclassified (matcher tightened from
+        # startswith('lib') to an exact multilib-name set).
         ("/home/gcc/include", False),
+        ("/opt/libfoo/gcc/x86_64-linux-gnu/13/include", False),
     ],
 )
 def test_is_gnu_compiler_resource_dir(path: str, expected: bool) -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -291,6 +291,58 @@ def test_probe_gnu_system_includes_handles_oserror(monkeypatch) -> None:
     assert dumper_sysinc._probe_gnu_system_includes("g++", cpp=True) == []
 
 
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # GCC's own compiler resource / builtins dir (GCC_INCLUDE_DIR + fixed).
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/include", True),
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/include-fixed", True),
+        ("/usr/lib64/gcc/x86_64-redhat-linux/12/include", True),
+        ("/opt/cross/lib/gcc-cross/aarch64-linux-gnu/12/include", True),
+        # libstdc++ and libc dirs must be KEPT (not GCC resource dirs).
+        ("/usr/include/c++/13", False),
+        ("/usr/include/x86_64-linux-gnu/c++/13", False),
+        ("/usr/include", False),
+        ("/usr/local/include", False),
+        ("/usr/include/x86_64-linux-gnu", False),
+        # A 'gcc' segment not preceded by lib* is not the resource dir.
+        ("/home/gcc/include", False),
+    ],
+)
+def test_is_gnu_compiler_resource_dir(path: str, expected: bool) -> None:
+    from abicheck import dumper_sysinc
+
+    assert dumper_sysinc._is_gnu_compiler_resource_dir(path) is expected
+
+
+def test_probe_gnu_system_includes_drops_gcc_resource_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # The GCC compiler resource dir (lib/gcc/.../include) must not cross over to
+    # the clang backend: clang has its own intrinsics headers, and GCC's
+    # immintrin.h/ia32intrin.h reference GCC-only __builtin_ia32_* that clang
+    # cannot parse. It is dropped even though it exists on disk.
+    from abicheck import dumper_sysinc
+
+    libstdcxx = tmp_path / "include" / "c++" / "13"
+    libc = tmp_path / "include"
+    gcc_res = tmp_path / "lib" / "gcc" / "x86_64-linux-gnu" / "13" / "include"
+    for d in (libstdcxx, libc, gcc_res):
+        d.mkdir(parents=True, exist_ok=True)
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.subprocess, "run", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc,
+        "_parse_gnu_include_search_dirs",
+        lambda s: [str(libstdcxx), str(gcc_res), str(libc)],
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    assert out == [str(libstdcxx), str(libc)]  # gcc resource dir filtered out
+
+
 def test_buildconfig_compile_frontend_case_insensitive() -> None:
     from abicheck.buildsource.inline import BuildConfig
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -990,6 +990,75 @@ def test_clang_header_dump_bad_json_raises(
         _clang_header_dump([header], [])
 
 
+@pytest.mark.parametrize(
+    "stderr,expected",
+    [
+        ("fatal error: 'cstddef' file not found", True),
+        ("fatal error: 'vector' file not found", True),
+        ("error: 'string' file not found", True),
+        # A C header miss carries a .h suffix → not a C++ stdlib signal.
+        ("fatal error: 'stdio.h' file not found", False),
+        ("fatal error: 'oneapi/tbb.h' file not found", False),
+        # Unrelated parse errors must not trigger the retry.
+        ("error: use of undeclared identifier 'foo'", False),
+        ("", False),
+    ],
+)
+def test_is_missing_cpp_stdlib_header_error(stderr: str, expected: bool) -> None:
+    assert dumper._is_missing_cpp_stdlib_header_error(stderr) is expected
+
+
+def test_clang_header_dump_retries_cpp_on_missing_cpp_stdlib_header(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A pure-#include umbrella header has no inline C++ syntax, so it is parsed in
+    # C mode first; the missing-<cstddef> failure must trigger one C++-mode retry
+    # (with -x c++ in the rebuilt command) rather than hard-failing.
+    header = tmp_path / "umbrella.h"
+    header.write_text('#include "detail/impl.h"\n')
+    monkeypatch.setattr(dumper, "_clang_available", lambda *a, **k: True)
+    monkeypatch.setattr(dumper, "_cache_path", lambda *a, **k: tmp_path / "c.json")
+    monkeypatch.setattr(dumper, "_detect_cpp_headers", lambda *a, **k: False)
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "0")
+    ast_json = '{"kind": "TranslationUnitDecl", "inner": []}'
+    cmds: list[list[str]] = []
+
+    def _run(cmd, **kwargs):
+        cmds.append(list(cmd))
+        if len(cmds) == 1:
+            return _fake_proc(stderr="fatal error: 'cstddef' file not found", returncode=1)
+        return _fake_proc(stdout=ast_json, returncode=0)
+
+    monkeypatch.setattr(dumper.subprocess, "run", _run)
+    root = _clang_header_dump([header], [])
+    assert root == {"kind": "TranslationUnitDecl", "inner": []}
+    assert len(cmds) == 2  # one C attempt + one C++ retry
+    assert "c" in cmds[0] and cmds[0][cmds[0].index("-x") + 1] == "c"
+    assert cmds[1][cmds[1].index("-x") + 1] == "c++"
+
+
+def test_clang_header_dump_no_retry_on_other_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A non-"missing C++ stdlib header" failure must NOT retry — it surfaces as-is.
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n")
+    monkeypatch.setattr(dumper, "_clang_available", lambda *a, **k: True)
+    monkeypatch.setattr(dumper, "_cache_path", lambda *a, **k: tmp_path / "c.json")
+    monkeypatch.setattr(dumper, "_detect_cpp_headers", lambda *a, **k: False)
+    monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "0")
+    calls = {"n": 0}
+
+    def _run(cmd, **kwargs):
+        calls["n"] += 1
+        return _fake_proc(stderr="error: undeclared identifier 'x'", returncode=1)
+
+    monkeypatch.setattr(dumper.subprocess, "run", _run)
+    with pytest.raises(SnapshotError, match="failed to parse"):
+        _clang_header_dump([header], [])
+    assert calls["n"] == 1  # no retry
+
+
 def test_resolve_header_backend_neither_tool_defaults_castxml(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -993,13 +993,20 @@ def test_clang_header_dump_bad_json_raises(
 @pytest.mark.parametrize(
     "stderr,expected",
     [
+        # The <cXXX> C-compatibility wrappers are the unambiguous trigger.
         ("fatal error: 'cstddef' file not found", True),
-        ("fatal error: 'vector' file not found", True),
-        ("error: 'string' file not found", True),
         ("fatal error: 'cstdint' file not found", True),
+        ("error: 'cstdlib' file not found", True),
+        ("fatal error: 'cstring' file not found", True),
         # A C header miss carries a .h suffix → not a C++ stdlib signal.
         ("fatal error: 'stdio.h' file not found", False),
         ("fatal error: 'oneapi/tbb.h' file not found", False),
+        # Plain-name C++ headers are deliberately NOT matched — they collide with
+        # plausible C project header names (oneTBB ships a version.h), so matching
+        # them could mask a real missing C dependency by re-parsing as C++.
+        ("fatal error: 'string' file not found", False),
+        ("fatal error: 'version' file not found", False),
+        ("fatal error: 'vector' file not found", False),
         # An extensionless *project* include that is not a stdlib header must NOT
         # trigger the retry (a C header's real missing dependency, not C++).
         ("fatal error: 'config' file not found", False),

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -996,9 +996,14 @@ def test_clang_header_dump_bad_json_raises(
         ("fatal error: 'cstddef' file not found", True),
         ("fatal error: 'vector' file not found", True),
         ("error: 'string' file not found", True),
+        ("fatal error: 'cstdint' file not found", True),
         # A C header miss carries a .h suffix → not a C++ stdlib signal.
         ("fatal error: 'stdio.h' file not found", False),
         ("fatal error: 'oneapi/tbb.h' file not found", False),
+        # An extensionless *project* include that is not a stdlib header must NOT
+        # trigger the retry (a C header's real missing dependency, not C++).
+        ("fatal error: 'config' file not found", False),
+        ("fatal error: 'myheader' file not found", False),
         # Unrelated parse errors must not trigger the retry.
         ("error: use of undeclared identifier 'foo'", False),
         ("", False),


### PR DESCRIPTION
## What & why

PR #443 gave the clang header (L2) backend castxml-parity system-include detection: it probes the host `g++` for its search dirs and injects them as `-isystem` so libstdc++/libc resolve. While validating the oneAPI scan (PR #442) on a standard **GCC-13 + clang-18** host, scanning a real C++ umbrella header (`oneapi/tbb.h`) still failed. Two gaps remained:

### 1. GCC's own compiler resource dir was injected into clang
The probe returned **all** of `g++`'s system dirs, including GCC's compiler resource/builtins dir (`/usr/lib/gcc/<triple>/<ver>/include`). clang ships its own intrinsics headers in *its* resource dir; feeding it GCC's `immintrin.h`/`ia32intrin.h` made clang reference GCC-only `__builtin_ia32_*` builtins it doesn't implement:

```
ia32intrin.h:41:10: error: use of undeclared identifier '__builtin_ia32_bsrsi'
```

Fix: `_is_gnu_compiler_resource_dir()` filters that dir out of the probe, so only the libstdc++ and libc dirs cross over to clang (which supplies its own intrinsics).

### 2. Pure-`#include` umbrella headers were parsed in C mode
`oneapi/tbb.h` is just `#include` lines — no inline `class`/`namespace`/`template` — so `_detect_cpp_headers` picks C mode, the C-mode probe never injects the libstdc++ dirs, and `#include <cstddef>` fails:

```
blocked_range.h:20:10: fatal error: 'cstddef' file not found
```

A missing **extensionless** header is an unambiguous "this TU is C++" signal (a C TU only includes `*.h`), so the clang backend now retries once in C++ mode with the C++ system includes — mirroring the existing castxml C→C++ retry. `_build_clang_header_command` also now selects the language explicitly (`-x c++`) instead of relying on the aggregate file's extension, which the retry reuses as `.h`.

## Verification

End-to-end on this host:

```
abicheck dump libtbb.so.12 -H oneapi/tbb.h -I include --ast-frontend clang
# before: fatal error 'cstddef' / __builtin_ia32_bsrsi
# after:  WARNING ... retrying in C++ mode → 893 types, 24410 functions
```

## Scope / relationship to #428

This does **not** change backend *selection*: `auto` still resolves to castxml and clang is used only when explicitly requested (`--ast-frontend clang` / env). It only makes that explicitly-requested clang path actually parse on a GNU host — complementary to #428's fail-closed `auto`.

## Tests

- `_is_gnu_compiler_resource_dir` — parametrized keep/drop cases (libstdc++/libc kept, `lib/gcc[-cross]/.../include[-fixed]` dropped).
- `_probe_gnu_system_includes` drops the GCC resource dir even when it exists on disk.
- `_is_missing_cpp_stdlib_header_error` — extensionless miss ⇒ retry, `*.h` miss / other errors ⇒ no retry.
- clang backend retries exactly once in C++ mode on a missing C++ stdlib header (asserts `-x c`→`-x c++`); no retry on unrelated errors.

Full fast suite (11,480 tests), `ruff check`, `mypy` (0 errors), and `check_ai_readiness.py` (0 errors) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmCKUCjSMr831W6pETGmfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmCKUCjSMr831W6pETGmfd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clang analysis self-heal: if the initial parse fails due to a missing C++ `<cXXX>` compatibility header, the dump retries once in C++ mode.
  * Refined clang invocation: when no standard is specified, C++ mode is selected correctly, with C++20 behavior applied only when enabled.
  * Enhanced system-include probing and caching: GCC compiler resource directories are filtered out, and AST dump cache keys now account for both initial and retry include sets.
* **Tests**
  * Added coverage for GCC resource include filtering and clang retry behavior (retry on missing C++ stdlib header, no retry on unrelated errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->