### PR TITLE
feat(scan): one --depth dial (auto default) + auto-strict pins + --build-info sniffing

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -40,6 +40,7 @@ the artifact tiers (L0/L1/L2) stay authoritative.
 from __future__ import annotations
 
 import datetime as _dt
+import json
 import os
 import shlex
 import subprocess
@@ -733,7 +734,9 @@ def sniff_build_info_format(path: Path) -> str:
     ``"bazel_cquery"`` (Bazel ``--output=jsonproto`` — a JSON *object* keyed by
     ``actions`` / ``results``), or ``"unknown"``. Lets a Bazel query result and a
     pack "just work" when passed to ``--build-info`` instead of being mis-parsed
-    as a compile DB. Sniffs only a bounded head; never executes anything.
+    as a compile DB. The top-level shape is read from a bounded head (``[`` = a
+    compile-DB array); a ``{`` object is fully parsed so a large aquery preamble
+    can't hide the discriminating key (Codex review). Never executes anything.
     """
     if path.is_dir():
         return "pack" if is_pack_dir(path) else "build_dir"
@@ -747,14 +750,28 @@ def sniff_build_info_format(path: Path) -> str:
         return "unknown"
     if text[0] == "[":
         return "compile_db"  # compile_commands.json is a top-level JSON array
-    if text[0] == "{":
-        # Bazel jsonproto: aquery is keyed by "actions", cquery by "results".
+    if text[0] != "{":
+        return "unknown"
+    # A JSON object: a Bazel jsonproto (aquery→"actions", cquery→"results") or an
+    # object-wrapped compile DB. The discriminating key can sit far past the sniff
+    # window in a large aquery dump (long artifacts/pathFragments preamble), so
+    # parse the whole object to classify by key, not a bounded prefix (Codex).
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        # Truncated / not-quite-JSON: fall back to the bounded-prefix heuristic.
         if '"actions"' in text:
             return "bazel_aquery"
         if '"results"' in text:
             return "bazel_cquery"
-        # Some tooling wraps a compile DB in an object; treat the DB shape as one.
-        if '"file"' in text or '"command"' in text or '"arguments"' in text:
+        return "unknown"
+    if isinstance(data, dict):
+        if "actions" in data:
+            return "bazel_aquery"
+        if "results" in data:
+            return "bazel_cquery"
+        if any(k in data for k in ("file", "command", "arguments")):
             return "compile_db"
     return "unknown"
 

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -520,6 +520,10 @@ def collect_inline_pack(
 
     if merged.compile_units:
         compile_db = None  # already seeded from a build-info pack
+    elif _maybe_collect_bazel_build_info(build_info, merged, extractors):
+        # A pre-captured Bazel aquery/cquery jsonproto produces BuildEvidence
+        # directly (no compile_commands.json to load) — ADR-037 D5 #5 sniffing.
+        compile_db = None
     else:
         compile_db = _resolve_compile_db(
             build_info,
@@ -712,6 +716,87 @@ def _compile_db_at(path: Path) -> Path | None:
             if candidate.is_file():
                 return candidate
     return None
+
+
+#: How many bytes to sniff from the head of a ``--build-info`` file when
+#: classifying its format (ADR-037 D5 #5). Enough to see the top-level JSON
+#: shape + the first discriminating key without reading a huge aquery dump.
+_BUILD_INFO_SNIFF_BYTES = 65536
+
+
+def sniff_build_info_format(path: Path) -> str:
+    """Classify a ``--build-info`` path by content (ADR-037 D5 #5).
+
+    Returns one of ``"pack"`` (a ``collect`` pack dir), ``"build_dir"`` (a
+    directory to search for ``compile_commands.json``), ``"compile_db"`` (a
+    Clang/CMake ``compile_commands.json`` — a JSON *array*), ``"bazel_aquery"`` /
+    ``"bazel_cquery"`` (Bazel ``--output=jsonproto`` — a JSON *object* keyed by
+    ``actions`` / ``results``), or ``"unknown"``. Lets a Bazel query result and a
+    pack "just work" when passed to ``--build-info`` instead of being mis-parsed
+    as a compile DB. Sniffs only a bounded head; never executes anything.
+    """
+    if path.is_dir():
+        return "pack" if is_pack_dir(path) else "build_dir"
+    try:
+        with open(path, "rb") as f:
+            head = f.read(_BUILD_INFO_SNIFF_BYTES)
+    except OSError:
+        return "unknown"
+    text = head.decode("utf-8", "replace").lstrip()
+    if not text:
+        return "unknown"
+    if text[0] == "[":
+        return "compile_db"  # compile_commands.json is a top-level JSON array
+    if text[0] == "{":
+        # Bazel jsonproto: aquery is keyed by "actions", cquery by "results".
+        if '"actions"' in text:
+            return "bazel_aquery"
+        if '"results"' in text:
+            return "bazel_cquery"
+        # Some tooling wraps a compile DB in an object; treat the DB shape as one.
+        if '"file"' in text or '"command"' in text or '"arguments"' in text:
+            return "compile_db"
+    return "unknown"
+
+
+def _maybe_collect_bazel_build_info(
+    build_info: Path | None,
+    merged: BuildEvidence,
+    extractors: list[ExtractorRecord],
+) -> bool:
+    """Route a pre-captured Bazel aquery/cquery ``--build-info`` to the adapter.
+
+    Returns ``True`` (and merges the normalized :class:`BuildEvidence` into
+    *merged*) when *build_info* is a Bazel jsonproto file, else ``False`` so the
+    caller falls back to compile-DB resolution. Pre-captured only — the adapter is
+    constructed with ``allow_query=False`` so no ``bazel`` subprocess ever runs.
+    """
+    if build_info is None or not build_info.is_file():
+        return False
+    fmt = sniff_build_info_format(build_info)
+    if fmt not in ("bazel_aquery", "bazel_cquery"):
+        return False
+    from .adapters.bazel import BazelAdapter
+
+    if fmt == "bazel_aquery":
+        kind = "aquery"
+        adapter = BazelAdapter(aquery=build_info, allow_query=False)
+    else:
+        kind = "cquery"
+        adapter = BazelAdapter(cquery=build_info, allow_query=False)
+    ev = adapter.collect()
+    merged.merge(ev)
+    extractors.append(
+        ExtractorRecord(
+            name="bazel",
+            status="present" if ev.compile_units else "partial",
+            detail=(
+                f"pre-captured {kind} jsonproto from --build-info, "
+                f"{len(ev.compile_units)} compile unit(s)"
+            ),
+        )
+    )
+    return True
 
 
 def _autodiscover_compile_db(source_tree: Path | None) -> Path | None:

--- a/abicheck/buildsource/scan_levels.py
+++ b/abicheck/buildsource/scan_levels.py
@@ -155,6 +155,23 @@ _METHOD_TO_DEPTH: dict[SourceMethod, EvidenceDepth] = {
 }
 
 
+def parse_user_depth(value: str | None) -> EvidenceDepth | None:
+    """Resolve a ``--depth`` / ``ScanRequest.depth`` string to an EvidenceDepth.
+
+    Honors the deprecated aliases (``symbols``→``binary``, ``graph``→``source``)
+    so non-CLI callers (``service.run_scan`` / ``estimate_scan`` / MCP) accept the
+    one-release compatibility spellings too — the Click ``DEPTH_PARAM`` normalizes
+    them on the CLI path, but programmatic callers construct the enum directly
+    (Codex review). ``None``/empty → ``None``.
+    """
+    if not value:
+        return None
+    v = str(value).lower()
+    if v in DEPRECATED_DEPTHS:
+        return DEPRECATED_DEPTHS[v]
+    return EvidenceDepth(v)
+
+
 def mode_preset(mode: ScanMode) -> tuple[SourceMethod, EvidenceDepth]:
     """The fixed (source_method, depth) preset for *mode* (deterministic)."""
     return _MODE_PRESET[mode]

--- a/abicheck/buildsource/scan_levels.py
+++ b/abicheck/buildsource/scan_levels.py
@@ -68,7 +68,7 @@ class SourceMethod(str, Enum):
 class EvidenceDepth(str, Enum):
     """The coarse L-axis ``--depth`` selector (maps lossily to a representative S)."""
 
-    SYMBOLS = "symbols"  # L0/L1 exported symbols + binary metadata only (no L2 AST)
+    BINARY = "binary"  # L0/L1 exported symbols + binary metadata only (no L2 AST)
     HEADERS = "headers"  # L2 only
     BUILD = "build"  # L3 (S1)
     SOURCE = "source"  # L4 scoped + L5 edges (S5)
@@ -80,7 +80,7 @@ class EvidenceDepth(str, Enum):
 #: ``GRAPH`` is excluded: the L5 graph is an *internal* consequence of
 #: ``--depth source`` (D6), never its own user rung.
 USER_DEPTHS: tuple[EvidenceDepth, ...] = (
-    EvidenceDepth.SYMBOLS,
+    EvidenceDepth.BINARY,
     EvidenceDepth.HEADERS,
     EvidenceDepth.BUILD,
     EvidenceDepth.SOURCE,
@@ -88,9 +88,12 @@ USER_DEPTHS: tuple[EvidenceDepth, ...] = (
 )
 
 #: Deprecated ``--depth`` spellings → their replacement (ADR-037 D5/D6). The G21
-#: ``graph`` rung folds into ``source`` (which now builds the graph internally).
+#: ``graph`` rung folds into ``source`` (which now builds the graph internally);
+#: ``symbols`` was renamed to the evidence-named ``binary`` rung (ADR-037 D5 G22
+#: Phase 6) and keeps working as an alias for one release.
 DEPRECATED_DEPTHS: dict[str, EvidenceDepth] = {
     "graph": EvidenceDepth.SOURCE,
+    "symbols": EvidenceDepth.BINARY,
 }
 
 
@@ -109,7 +112,7 @@ _MODE_PRESET: dict[ScanMode, tuple[SourceMethod, EvidenceDepth]] = {
 #: reaches no S-method (L2 is intrinsic header AST). ``BUILD`` is S1 — S2
 #: (preprocessor) is *not* reachable via ``--depth`` and needs ``--source-method``.
 _DEPTH_TO_METHOD: dict[EvidenceDepth, SourceMethod | None] = {
-    EvidenceDepth.SYMBOLS: None,  # L0/L1 only — no source method, no L2 AST
+    EvidenceDepth.BINARY: None,  # L0/L1 only — no source method, no L2 AST
     EvidenceDepth.HEADERS: None,
     EvidenceDepth.BUILD: SourceMethod.S1,
     EvidenceDepth.GRAPH: SourceMethod.S4,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -512,9 +512,15 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         depth, max_depth, collect_mode, collect_mode_explicit,
     )
     # --depth binary suppresses the L2 header AST (symbols-only dump, ADR-037 D5;
-    # the `symbols` alias is normalized to `binary` by DEPTH_PARAM).
+    # the `symbols` alias is normalized to `binary` by DEPTH_PARAM). A compile DB
+    # only feeds the header parse, so discard it with the headers — otherwise
+    # resolve_dump_compile_db would reject the now-headerless invocation even though
+    # the user did supply headers, blocking the switch to the fast binary rung
+    # (Codex review).
     if depth == "binary":
         headers = ()
+        compile_db_path = None
+        compile_db_path_alt = None
 
     # An *explicitly* requested deep evidence depth (--depth/--max or an explicit
     # --collect-mode) collects nothing without a source tree / build context:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -511,8 +511,9 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     collect_mode = resolve_dump_depth(
         depth, max_depth, collect_mode, collect_mode_explicit,
     )
-    # --depth symbols suppresses the L2 header AST (symbols-only dump, ADR-037 D5).
-    if depth == "symbols":
+    # --depth binary suppresses the L2 header AST (symbols-only dump, ADR-037 D5;
+    # the `symbols` alias is normalized to `binary` by DEPTH_PARAM).
+    if depth == "binary":
         headers = ()
 
     # An *explicitly* requested deep evidence depth (--depth/--max or an explicit
@@ -1495,7 +1496,7 @@ def compare_cmd(
 
     # Fold the unified --depth/--max dial into the underlying collect mode
     # (ADR-037 D5), the same way `dump`/`deep-compare` do. The hidden
-    # --collect-mode alias still works but warns; --depth symbols suppresses the
+    # --collect-mode alias still works but warns; --depth binary suppresses the
     # L2 header AST (symbols-only).
     collect_mode_explicit = (
         click.get_current_context().get_parameter_source("collect_mode")
@@ -1507,7 +1508,7 @@ def compare_cmd(
             err=True,
         )
     collect_mode = resolve_dump_depth(depth, max_depth, collect_mode, collect_mode_explicit)
-    if depth == "symbols":
+    if depth == "binary":
         headers, old_headers_only, new_headers_only = (), (), ()
 
     # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf

--- a/abicheck/cli_max.py
+++ b/abicheck/cli_max.py
@@ -140,7 +140,7 @@ def _prepare_side(
 @two_sided_input_options
 # ── Depth dial (unified vocabulary with `compare`/`dump`/`scan`, ADR-037 D5) ──
 @click.option("--depth", "depth", type=DEPTH_PARAM, default=None,
-              help="Evidence depth for both sides (unified dial): symbols=L0/L1, "
+              help="Evidence depth for both sides (unified dial): binary=L0/L1, "
                    "headers=+L2 AST (== plain compare), build=+L3, source=+L4 "
                    "replay & the L5 graph, full=deepest.")
 @click.option("--max", "max_depth", is_flag=True, default=False,
@@ -246,8 +246,9 @@ def deep_compare_cmd(
     # The depth the embedded snapshots carry; forwarded to compare so its
     # coverage table reflects the evidence actually requested.
     compare_collect_mode = resolve_dump_depth(depth, max_depth, "off", False)
-    # --depth symbols suppresses the L2 header AST on both sides (ADR-037 D5).
-    if depth == "symbols":
+    # --depth binary suppresses the L2 header AST on both sides (ADR-037 D5; the
+    # `symbols` alias is normalized to `binary` by DEPTH_PARAM).
+    if depth == "binary":
         headers, old_headers_only, new_headers_only = (), (), ()
 
     # A depth that collects L3-L5 needs *some* evidence to collect from. A side

--- a/abicheck/cli_params.py
+++ b/abicheck/cli_params.py
@@ -82,10 +82,12 @@ class DepthParam(click.ParamType):
             return v
         if v in DEPRECATED_DEPTHS:
             replacement = DEPRECATED_DEPTHS[v].value
+            # Generic note covering every deprecated rung (graph→source, the L5
+            # graph is built internally at --depth source; symbols→binary, the
+            # evidence-named rung — G22 Phase 6).
             click.echo(
-                f"warning: --depth {v} is deprecated (ADR-037 D6); use "
-                f"--depth {replacement}. The L5 graph is built automatically at "
-                "--depth source.",
+                f"warning: --depth {v} is deprecated (ADR-037 D5/D6); use "
+                f"--depth {replacement}.",
                 err=True,
             )
             return replacement

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -892,6 +892,11 @@ def scan_cmd(
     # headers (Codex review).
     if eff_depth_enum is EvidenceDepth.BINARY:
         headers = ()
+        # Also drop the *baseline* header inputs: leaving them would make
+        # _run_baseline_compare parse the old side with the L2 header AST while the
+        # new side has none, yielding spurious header/type removals against a
+        # symbols-only scan (Codex review). Include dirs are harmless (no AST).
+        baseline_header = ()
     effective_build_info = compile_db or build_info
 
     # --- --estimate: dry-run cost probe, scan nothing (ADR-035 D10) -----------

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -861,11 +861,6 @@ def scan_cmd(
     # preprocessor pass when a compile DB + `clang -E` are available (else the
     # coverage row reports it skipped — ADR-035 D2 coverage honesty).
     dp = EvidenceDepth(depth) if depth else None
-    # --depth binary is symbols-only (L0/L1): suppress the L2 header AST even when
-    # -H is passed, so the collected evidence matches the reported depth — parity
-    # with dump/compare/deep-compare's binary handling (Codex review).
-    if dp is EvidenceDepth.BINARY:
-        headers = ()
     # The unset dial means 'auto' (ADR-037 D5): opt into the risk-driven S-method
     # so a seeded PR scan escalates by risk and an unseeded one falls back to the
     # preset. Only when *nothing* was pinned (no --depth, no --source-method, no
@@ -888,6 +883,15 @@ def scan_cmd(
     # so a deeper preset (pr-deep = graph) is distinct from pr, and an explicit
     # --source-method reports its own depth, not the mode preset (Codex review).
     collect_mode = level_to_collect_mode(resolved, eff_depth_enum)
+    # --depth binary is symbols-only (L0/L1): suppress the L2 header AST even when
+    # -H is passed, so the collected evidence matches the reported depth — parity
+    # with dump/compare/deep-compare's binary handling. Keyed on the *resolved*
+    # effective depth, not the raw --depth: --source-method wins over --depth, so
+    # `--source-method s5 --depth binary -H ...` resolves to a source scan that
+    # still needs the header AST/provenance — only an effective binary depth drops
+    # headers (Codex review).
+    if eff_depth_enum is EvidenceDepth.BINARY:
+        headers = ()
     effective_build_info = compile_db or build_info
 
     # --- --estimate: dry-run cost probe, scan nothing (ADR-035 D10) -----------
@@ -901,10 +905,11 @@ def scan_cmd(
             mode=scan_mode.value,
             # Thread the *resolved* concrete level (not the raw flags) so the
             # estimate matches what the real scan would run — e.g. the auto
-            # default resolving a seeded empty diff to s0/off, not the pr preset
-            # (Codex review).
-            source_method=resolved.value,
-            depth=eff_depth_enum.value,
+            # default resolving a seeded empty diff to s0/off, not the pr preset,
+            # and pr-deep keeping its (s5, graph) depth rather than collapsing to
+            # source under the source-method>depth precedence (Codex review).
+            resolved_method=resolved,
+            eff_depth=eff_depth_enum,
             changed=changed,
             seeded=seeded,
             budget_s=budget_s,
@@ -1403,8 +1408,8 @@ def _emit_estimate(
     sources: Path | None,
     build_info: Path | None,
     mode: str,
-    source_method: str | None,
-    depth: str | None,
+    resolved_method: SourceMethod,
+    eff_depth: EvidenceDepth,
     changed: list[str],
     seeded: bool,
     budget_s: float | None,
@@ -1428,14 +1433,18 @@ def _emit_estimate(
         sources=sources,
         build_info=build_info,
         mode=mode,
-        source_method=source_method,
-        depth=depth,
+        source_method=resolved_method.value,
+        depth=eff_depth.value,
         changed_paths=list(changed),
         seeded=seeded,
         budget=Budget(total_timeout=budget_s),
         lang=lang,
     )
-    estimates = estimate_scan(req)
+    # Pass the *already-resolved* level so the estimate mirrors the real scan
+    # exactly — re-resolving from the round-tripped flags would re-apply the
+    # source-method > depth precedence and lose a mode preset's deeper depth
+    # (pr-deep = (s5, graph)); Codex review.
+    estimates = estimate_scan(req, resolved_level=(resolved_method, eff_depth))
     total = sum(e.est_seconds for e in estimates)
 
     if fmt == "json":

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -621,22 +621,31 @@ def _audit_exit_code(
     "mode",
     type=click.Choice([m.value for m in ScanMode]),
     default=ScanMode.PR.value,
-    show_default=True,
-    help="Fixed (L,S) preset selecting how deep the scan runs.",
+    show_default=False,
+    hidden=True,
+    help="DEPRECATED (ADR-037 D5 G22 Phase 6): fixed (L,S) preset. Use --depth; "
+    "kept as a warned alias for one release. (--audit is the standalone "
+    "no-baseline lint switch.)",
 )
 @click.option(
     "--source-method",
     "source_method",
     type=click.Choice([m.value for m in SourceMethod]),
     default=None,
-    help="Precise S-axis level to reach; deterministic. 'auto' = risk-driven (opt-in).",
+    hidden=True,
+    help="DEPRECATED (ADR-037 D5 G22 Phase 6): precise S-axis technique. Use "
+    "--depth; kept as a warned alias for one release.",
 )
 @click.option(
     "--depth",
     "depth",
     type=DEPTH_PARAM,
     default=None,
-    help="Coarse L-axis selector (unified dial; --source-method wins if both).",
+    help="Evidence depth to collect — the single dial, named by what you get: "
+    "binary (L0/L1 symbols only), headers (+L2 AST), build (+L3 build context), "
+    "source (+L4 replay & the L5 graph), full (deepest). Omit for 'auto' "
+    "(risk-driven when a --since/--changed-path seed is present, else a sensible "
+    "default). --audit is orthogonal (no-baseline lint).",
 )
 @click.option(
     "--since",
@@ -820,6 +829,30 @@ def scan_cmd(
     risk_rules = _load_risk_rules(risk_rules_path)
     risk = score_changed_paths(changed, risk_rules)
 
+    # ADR-037 D5 G22 Phase 6: --depth is the single visible dial; --mode and
+    # --source-method are hidden, deprecated warned aliases for one release.
+    _ctx = click.get_current_context()
+    _mode_explicit = (
+        _ctx.get_parameter_source("mode") == click.core.ParameterSource.COMMANDLINE
+    )
+    _sm_explicit = (
+        _ctx.get_parameter_source("source_method")
+        == click.core.ParameterSource.COMMANDLINE
+    )
+    if _mode_explicit or _sm_explicit:
+        _dep = [
+            f
+            for f, e in (("--mode", _mode_explicit), ("--source-method", _sm_explicit))
+            if e
+        ]
+        click.echo(
+            f"warning: {', '.join(_dep)} {'is' if len(_dep) == 1 else 'are'} "
+            "deprecated (ADR-037 D5); use --depth "
+            "(binary|headers|build|source|full), or omit it for auto. --audit is "
+            "the no-baseline lint switch.",
+            err=True,
+        )
+
     scan_mode = ScanMode.AUDIT if audit else ScanMode(mode)
     sm = SourceMethod(source_method) if source_method else None
     # S2 (preprocessor macro/include capture) is collected by the conditional S2
@@ -828,6 +861,12 @@ def scan_cmd(
     # preprocessor pass when a compile DB + `clang -E` are available (else the
     # coverage row reports it skipped — ADR-035 D2 coverage honesty).
     dp = EvidenceDepth(depth) if depth else None
+    # The unset dial means 'auto' (ADR-037 D5): opt into the risk-driven S-method
+    # so a seeded PR scan escalates by risk and an unseeded one falls back to the
+    # preset. Only when *nothing* was pinned (no --depth, no --source-method, no
+    # explicit --mode) — a pinned rung stays deterministic.
+    if sm is None and dp is None and not _mode_explicit:
+        sm = SourceMethod.AUTO
     is_auto = sm is SourceMethod.AUTO
     # auto uses the risk score ONLY when a valid diff seed was produced. A seeded
     # empty diff (no-op PR) correctly yields s0 (skip the scan); a missing/failed
@@ -917,6 +956,11 @@ def scan_cmd(
     except _BudgetOverflow as bo:
         click.echo(bo.message, err=True)
         sys.exit(_EXIT_BUDGET_OVERFLOW)
+    except _EvidenceContractError as ce:
+        # A pinned depth that can't collect its evidence is a usage contract
+        # violation → a clean CLI error (exit 1), distinct from the verdict codes
+        # (2/4) and the budget code (5).
+        raise click.ClickException(ce.message) from ce
 
     outcome = core.outcome
     text = (
@@ -939,6 +983,22 @@ class _BudgetOverflow(Exception):
 
     A scan-engine signal (not a click concern): the budget is a *failure guard*
     that never shrinks scope, so the core raises and the CLI maps it onto exit 5.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class _EvidenceContractError(Exception):
+    """Raised by ``run_scan_core`` when a *pinned* depth can't collect its evidence.
+
+    ADR-037 D5 (#2 auto-strict): an explicitly-pinned ``--depth``/``--source-method``
+    is a contract — if the requested source/build evidence is unavailable the scan
+    fails loudly rather than silently degrading to a shallower one. Like
+    :class:`_BudgetOverflow`, it is an engine signal the CLI maps onto an error
+    exit (a clean ``ClickException``, exit 1) and ``service.run_scan`` maps onto a
+    failed :class:`ScanResult`. The implicit ``auto`` default never raises it.
     """
 
     def __init__(self, message: str) -> None:
@@ -1115,21 +1175,34 @@ def run_scan_core(
         compile_context=compile_context,
     )
 
-    # --- honest level-vs-evidence advisory ------------------------------------
-    # A deep --source-method (s1/s2/s4/s5/s6 → collect_mode != "off") needs an L3
-    # compile database; without one the L3/L4/L5 layers are *skipped*, not failed.
-    # When the user actually supplied a source input (a --sources tree or
-    # --build-info) yet L3 still came back empty — typically a pristine checkout
-    # with no compile_commands.json — the coverage rows say `not_collected`, but
-    # the user shouldn't have to infer *why*: name the requested level and the
-    # exact remedy (mirrors the unseeded-replay advisory). Gated on a source input
-    # so a plain binary-only scan at the default deep mode isn't nagged.
+    # --- level-vs-evidence: fail-loud on missing input, advise otherwise ------
+    # A deep depth (build/source/full → collect_mode != "off") needs an L3 compile
+    # database; without one the L3/L4/L5 layers cannot be collected.
+    #
+    # ADR-037 D5 (#2 auto-strict): a depth the user *explicitly pinned* is a
+    # contract. If it was pinned with **no source input at all** (no --sources /
+    # --build-info to analyze), there is nothing to collect from — that is the
+    # "missing input" case, and we ERROR with the remedy rather than silently
+    # produce a shallow binary-only scan. When a source input *was* supplied but
+    # L3 still came back empty (e.g. a pristine tree with no compile_commands.json)
+    # the user clearly tried — that stays a pointed *advisory* naming the remedy,
+    # not a hard error. The implicit 'auto' default never errors here.
     gave_source_input = sources is not None or effective_build_info is not None
-    if gave_source_input and collect_mode != "off" and not _l3_collected(new_snap):
+    needs_source = collect_mode != "off"
+    if needs_source and level_explicit and not gave_source_input:
+        raise _EvidenceContractError(
+            f"pinned depth '{eff_depth_enum.value}' (source-method {resolved.value}) "
+            "needs source evidence, but no --sources/--build-info was given — there "
+            "is nothing to collect L3/L4/L5 from. Pass --sources <tree> or "
+            "--build-info <dir|compile_commands.json> (or a trusted --config plus "
+            "--allow-build-query), or drop the pin / use the default 'auto' for a "
+            "best-effort binary scan. (Pinned depths are a contract.)"
+        )
+    if needs_source and gave_source_input and not _l3_collected(new_snap):
         advisories.append(
-            f"requested source-method {resolved.value} (depth {eff_depth_enum.value}) "
-            "needs an L3 compile database, but none was found — L3/L4/L5 were "
-            "skipped. Provide one with --build-info/--compile-db (a "
+            f"requested depth '{eff_depth_enum.value}' (source-method "
+            f"{resolved.value}) needs an L3 compile database, but none was found — "
+            "L3/L4/L5 were skipped. Provide one with --build-info/--compile-db (a "
             "compile_commands.json or build dir), or a trusted --config plus "
             "--allow-build-query to generate it."
         )

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -918,6 +918,9 @@ def scan_cmd(
     # The classify→tier→level→compare body lives in ``run_scan_core`` so the CLI,
     # ``service.run_scan``, and the MCP tool drive one engine. The CLI only parses
     # argv, renders, and maps the budget-overflow signal onto an exit code.
+    _level_explicit = (
+        source_method is not None and source_method != SourceMethod.AUTO.value
+    ) or (source_method is None and depth is not None)
     prov_headers, prov_dirs = _public_provenance_set(
         list(headers), list(public_header_dirs)
     )
@@ -955,11 +958,14 @@ def scan_cmd(
             # when no --source-method is given (resolve_level gives --source-method
             # precedence and ignores --depth otherwise, so `auto`+`--depth` resolves
             # via auto/the preset, not the depth — it must not count as consent;
-            # Codex review).
-            level_explicit=(
-                source_method is not None and source_method != SourceMethod.AUTO.value
-            )
-            or (source_method is None and depth is not None),
+            # Codex review). An explicit --mode is deliberately NOT consent here.
+            level_explicit=_level_explicit,
+            # The pinned-depth contract (auto-strict) uses a *wider* notion of
+            # "the user pinned a level": the query-consent set PLUS an explicit
+            # (deprecated) --mode, so `--mode baseline` with no evidence fails loud
+            # the same as `--depth full` would, instead of silently degrading
+            # (CodeRabbit review). Kept separate from query-consent above.
+            pinned_explicit=_level_explicit or _mode_explicit,
             compile_context=None if compile_context.is_default else compile_context,
         )
     except _BudgetOverflow as bo:
@@ -1056,6 +1062,7 @@ def run_scan_core(
     budget: str | None,
     budget_s: float | None,
     level_explicit: bool = False,
+    pinned_explicit: bool = False,
     compile_context: CompileContext | None = None,
 ) -> ScanCoreResult:
     """The shared scan orchestration (classify → always-on tier → level → compare).
@@ -1189,16 +1196,21 @@ def run_scan_core(
     # database; without one the L3/L4/L5 layers cannot be collected.
     #
     # ADR-037 D5 (#2 auto-strict): a depth the user *explicitly pinned* is a
-    # contract. If it was pinned with **no source input at all** (no --sources /
-    # --build-info to analyze), there is nothing to collect from — that is the
-    # "missing input" case, and we ERROR with the remedy rather than silently
-    # produce a shallow binary-only scan. When a source input *was* supplied but
-    # L3 still came back empty (e.g. a pristine tree with no compile_commands.json)
-    # the user clearly tried — that stays a pointed *advisory* naming the remedy,
-    # not a hard error. The implicit 'auto' default never errors here.
+    # contract. If it was pinned with **no source evidence at all** — no
+    # --sources / --build-info, and the trusted --config build.query flow didn't
+    # produce L3 either — there is nothing to collect from, so we ERROR with the
+    # remedy rather than silently produce a shallow binary-only scan. When a
+    # source input *was* supplied (or L3 was actually collected via the config
+    # query) but L3 still came back empty, that stays a pointed *advisory* naming
+    # the remedy, not a hard error. The implicit 'auto' default never errors here.
     gave_source_input = sources is not None or effective_build_info is not None
     needs_source = collect_mode != "off"
-    if needs_source and level_explicit and not gave_source_input:
+    if (
+        needs_source
+        and pinned_explicit
+        and not gave_source_input
+        and not _l3_collected(new_snap)
+    ):
         raise _EvidenceContractError(
             f"pinned depth '{eff_depth_enum.value}' (source-method {resolved.value}) "
             "needs source evidence, but no --sources/--build-info was given — there "

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -861,6 +861,11 @@ def scan_cmd(
     # preprocessor pass when a compile DB + `clang -E` are available (else the
     # coverage row reports it skipped — ADR-035 D2 coverage honesty).
     dp = EvidenceDepth(depth) if depth else None
+    # --depth binary is symbols-only (L0/L1): suppress the L2 header AST even when
+    # -H is passed, so the collected evidence matches the reported depth — parity
+    # with dump/compare/deep-compare's binary handling (Codex review).
+    if dp is EvidenceDepth.BINARY:
+        headers = ()
     # The unset dial means 'auto' (ADR-037 D5): opt into the risk-driven S-method
     # so a seeded PR scan escalates by risk and an unseeded one falls back to the
     # preset. Only when *nothing* was pinned (no --depth, no --source-method, no
@@ -894,8 +899,12 @@ def scan_cmd(
             sources=sources,
             build_info=effective_build_info,
             mode=scan_mode.value,
-            source_method=source_method,
-            depth=depth,
+            # Thread the *resolved* concrete level (not the raw flags) so the
+            # estimate matches what the real scan would run — e.g. the auto
+            # default resolving a seeded empty diff to s0/off, not the pr preset
+            # (Codex review).
+            source_method=resolved.value,
+            depth=eff_depth_enum.value,
             changed=changed,
             seeded=seeded,
             budget_s=budget_s,

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -918,9 +918,19 @@ def scan_cmd(
     # The classify→tier→level→compare body lives in ``run_scan_core`` so the CLI,
     # ``service.run_scan``, and the MCP tool drive one engine. The CLI only parses
     # argv, renders, and maps the budget-overflow signal onto an exit code.
-    _level_explicit = (
-        source_method is not None and source_method != SourceMethod.AUTO.value
-    ) or (source_method is None and depth is not None)
+    # Two distinct notions of "explicit", deliberately not the same boolean:
+    #  • _level_explicit — consent to auto-run build.query (level-implies-query):
+    #    a non-auto --source-method, or --depth ONLY when no --source-method is
+    #    given (--source-method auto wins in resolution and must NOT grant query
+    #    consent). Conservative.
+    #  • _pinned_explicit — the auto-strict evidence contract: an explicit --depth
+    #    *always* pins (regardless of --source-method auto, which only picks the
+    #    method, not whether the user demanded source depth), or a non-auto
+    #    --source-method (CodeRabbit review). --mode is a deprecated preset, never
+    #    a pin.
+    _sm_pin = source_method is not None and source_method != SourceMethod.AUTO.value
+    _level_explicit = _sm_pin or (source_method is None and depth is not None)
+    _pinned_explicit = (depth is not None) or _sm_pin
     prov_headers, prov_dirs = _public_provenance_set(
         list(headers), list(public_header_dirs)
     )
@@ -960,12 +970,14 @@ def scan_cmd(
             # via auto/the preset, not the depth — it must not count as consent;
             # Codex review). An explicit --mode is deliberately NOT consent here.
             level_explicit=_level_explicit,
-            # The pinned-depth contract (auto-strict) uses a *wider* notion of
-            # "the user pinned a level": the query-consent set PLUS an explicit
-            # (deprecated) --mode, so `--mode baseline` with no evidence fails loud
-            # the same as `--depth full` would, instead of silently degrading
-            # (CodeRabbit review). Kept separate from query-consent above.
-            pinned_explicit=_level_explicit or _mode_explicit,
+            # The pinned-depth contract (auto-strict) gates on the *deliberate* new
+            # surface only — an explicit --depth (even alongside --source-method
+            # auto) or a non-auto --source-method. An explicit --mode is NOT a pin:
+            # it is a deprecated *preset* alias (pr/pr-deep/baseline/audit, all deep
+            # by collect-mode) that the GitHub Action passes by default (`--mode pr`)
+            # and that `--mode audit` uses for a binary-only lint — treating it as a
+            # pin would break those best-effort paths (Codex review).
+            pinned_explicit=_pinned_explicit,
             compile_context=None if compile_context.is_default else compile_context,
         )
     except _BudgetOverflow as bo:

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -445,7 +445,12 @@ def estimate_scan(
         total_tus = 0
         tu_note = "no source tree / compile DB"
 
-    n_headers = len(expand_header_inputs(list(req.headers))) if req.headers else 0
+    # --depth binary is symbols-only: the real scan suppresses the L2 header AST, so
+    # the estimate must not price an L2_header layer for headers that won't be parsed
+    # — else a programmatic caller's `ScanResult.estimate` plans a different cost than
+    # what executes (Codex review). Keyed on the resolved effective depth.
+    eff_req_headers = [] if eff_depth is EvidenceDepth.BINARY else list(req.headers)
+    n_headers = len(expand_header_inputs(eff_req_headers)) if eff_req_headers else 0
     # The L4 replay scope: a changed-only collection touches at most the changed
     # *source* TUs (POI-focused, D7); a full/target scope touches every TU. The
     # budget's max_tus is a documented cap (never shrinks scope silently — it

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -374,6 +374,35 @@ def _count_pack_tus(path: Path) -> int | None:
     return len(be.compile_units) if be is not None else 0
 
 
+def _count_bazel_build_info_tus(path: Path) -> int | None:
+    """Compile-unit count of a Bazel ``aquery``/``cquery`` ``--build-info``, else ``None``.
+
+    The real scan routes a Bazel jsonproto ``--build-info`` through
+    ``inline._maybe_collect_bazel_build_info`` → ``BazelAdapter`` (pre-captured,
+    ``allow_query=False``) and replays its compile actions; the estimate mirrors
+    that so a Bazel project does not report 0 L3/L4/L5 TUs and undersize the budget
+    (Codex review). Non-executing (parses the captured JSON only); best-effort —
+    any failure → ``None`` so the caller falls back to compile-DB / source counting.
+    """
+    if not path.is_file():
+        return None
+    try:
+        from .buildsource.inline import sniff_build_info_format
+
+        fmt = sniff_build_info_format(path)
+        if fmt not in ("bazel_aquery", "bazel_cquery"):
+            return None
+        from .buildsource.adapters.bazel import BazelAdapter
+
+        if fmt == "bazel_aquery":
+            adapter = BazelAdapter(aquery=path, allow_query=False)
+        else:
+            adapter = BazelAdapter(cquery=path, allow_query=False)
+        return len(adapter.collect().compile_units)
+    except Exception:  # noqa: BLE001 - estimate is advisory; never raise
+        return None
+
+
 def estimate_scan(
     req: ScanRequest,
     *,
@@ -429,10 +458,20 @@ def estimate_scan(
     # A --build-info that is an `abicheck collect` pack dir is loaded by the real
     # scan and supplies its own L3 compile units, so the estimate must count them
     # too — else a pack-only input reports 0 TUs and undersizes the budget (Codex
-    # review). A raw compile DB / source tree is counted otherwise.
+    # review). A Bazel aquery/cquery jsonproto is routed through the Bazel adapter
+    # by the real scan, so count its compile actions the same way. A raw compile DB
+    # / source tree is counted otherwise.
+    bazel_tus = (
+        _count_bazel_build_info_tus(req.build_info)
+        if req.build_info is not None
+        else None
+    )
     pack_tus = _count_pack_tus(req.build_info) if req.build_info is not None else None
     compile_db = _discover_compile_db(req.sources, req.compile_db or req.build_info)
-    if pack_tus is not None:
+    if bazel_tus is not None:
+        total_tus = bazel_tus
+        tu_note = "Bazel aquery/cquery (build_evidence)"
+    elif pack_tus is not None:
         total_tus = pack_tus
         tu_note = "abicheck collect pack (build_evidence)"
     elif compile_db is not None:

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -30,9 +30,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .errors import ValidationError
+
+if TYPE_CHECKING:
+    from .buildsource.scan_levels import EvidenceDepth, SourceMethod
 
 _logger = logging.getLogger(__name__)
 
@@ -371,7 +374,11 @@ def _count_pack_tus(path: Path) -> int | None:
     return len(be.compile_units) if be is not None else 0
 
 
-def estimate_scan(req: ScanRequest) -> list[CostEstimate]:
+def estimate_scan(
+    req: ScanRequest,
+    *,
+    resolved_level: tuple[SourceMethod, EvidenceDepth] | None = None,
+) -> list[CostEstimate]:
     """Dry-run: projected per-layer cost of *req* for this project (ADR-035 D10).
 
     Probes the project (TU count from the compile DB or source tree, public-header
@@ -393,21 +400,30 @@ def estimate_scan(req: ScanRequest) -> list[CostEstimate]:
     ) = _scan_imports()
 
     mode = ScanMode(req.mode)
-    sm = SourceMethod(req.source_method) if req.source_method else None
-    dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
-    auto_method = None
-    # AUTO resolves from the risk score whenever a real diff seed was produced —
-    # including a *seeded but empty* diff (a no-op PR), which scores 0 → s0/off,
-    # mirroring what the real scan does. Treating a seeded empty diff as unseeded
-    # would fall back to the mode preset and over-estimate a no-op PR (Codex
-    # review). A non-empty changed set is itself proof of a seed.
-    if sm is SourceMethod.AUTO and (req.seeded or req.changed_paths):
-        auto_method = score_changed_paths(
-            list(req.changed_paths), RiskRules.default()
-        ).recommended_method
-    resolved, eff_depth = resolve_level(
-        mode=mode, source_method=sm, depth=dp, auto_method=auto_method
-    )
+    if resolved_level is not None:
+        # The caller (the CLI scan path) already resolved the concrete (method,
+        # depth) level — including the auto/risk choice. Honor it verbatim so the
+        # estimate matches the real scan: re-resolving from req.source_method/depth
+        # here would re-apply the source-method > depth precedence and collapse a
+        # mode preset that pins a *deeper* depth than its method implies
+        # (``pr-deep`` = (s5, graph) → graph-full), under-pricing it (Codex review).
+        resolved, eff_depth = resolved_level
+    else:
+        sm = SourceMethod(req.source_method) if req.source_method else None
+        dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
+        auto_method = None
+        # AUTO resolves from the risk score whenever a real diff seed was produced —
+        # including a *seeded but empty* diff (a no-op PR), which scores 0 → s0/off,
+        # mirroring what the real scan does. Treating a seeded empty diff as unseeded
+        # would fall back to the mode preset and over-estimate a no-op PR (Codex
+        # review). A non-empty changed set is itself proof of a seed.
+        if sm is SourceMethod.AUTO and (req.seeded or req.changed_paths):
+            auto_method = score_changed_paths(
+                list(req.changed_paths), RiskRules.default()
+            ).recommended_method
+        resolved, eff_depth = resolve_level(
+            mode=mode, source_method=sm, depth=dp, auto_method=auto_method
+        )
     collect_mode = level_to_collect_mode(resolved, eff_depth)
 
     # A --build-info that is an `abicheck collect` pack dir is loaded by the real
@@ -628,14 +644,6 @@ def run_scan(req: ScanRequest) -> ScanResult:
     binary = req.binaries[0]
     sm = SourceMethod(req.source_method) if req.source_method else None
     dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
-    # --depth binary is symbols-only (L0/L1): suppress the L2 header AST (and its
-    # provenance) even when the caller passes headers, so the collected evidence
-    # matches the reported depth — parity with the CLI's `scan --depth binary`
-    # handling (Codex review).
-    eff_headers = [] if dp is EvidenceDepth.BINARY else list(req.headers)
-    prov_headers, prov_dirs = _public_provenance_set(
-        eff_headers, list(req.public_header_dirs)
-    )
 
     changed = [p for p in req.changed_paths if p]
     seeded = req.seeded or bool(changed)
@@ -657,6 +665,16 @@ def run_scan(req: ScanRequest) -> ScanResult:
         mode=scan_mode, source_method=sm, depth=dp, auto_method=auto_method
     )
     collect_mode = level_to_collect_mode(resolved, eff_depth)
+    # --depth binary is symbols-only (L0/L1): suppress the L2 header AST (and its
+    # provenance) even when the caller passes headers, so the collected evidence
+    # matches the reported depth — parity with the CLI's `scan --depth binary`.
+    # Keyed on the *resolved* effective depth, not the raw depth: --source-method
+    # wins over --depth, so a source-method scan that also passes `depth="binary"`
+    # still needs the header AST (Codex review).
+    eff_headers = [] if eff_depth is EvidenceDepth.BINARY else list(req.headers)
+    prov_headers, prov_dirs = _public_provenance_set(
+        eff_headers, list(req.public_header_dirs)
+    )
     effective_build_info = req.compile_db or req.build_info
     budget_s = req.budget.total_timeout
     budget_str = f"{budget_s:g}s" if budget_s is not None else None

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -634,6 +634,14 @@ def run_scan(req: ScanRequest) -> ScanResult:
     scan_mode = ScanMode(req.mode)
     sm = SourceMethod(req.source_method) if req.source_method else None
     dp = EvidenceDepth(req.depth) if req.depth else None
+    # The pinned-depth contract (ADR-037 D5 auto-strict) applies to the programmatic
+    # API too: an explicitly-pinned deep level (a non-auto source_method, or a depth
+    # with no source_method) is a contract, so run_scan_core fails loud if it can't
+    # collect the evidence — same as the CLI. AUTO / preset-only requests stay
+    # best-effort.
+    pinned_explicit = (sm is not None and sm is not SourceMethod.AUTO) or (
+        sm is None and dp is not None
+    )
     is_auto = sm is SourceMethod.AUTO
     auto_method = risk.recommended_method if (is_auto and seeded) else None
     resolved, eff_depth = resolve_level(
@@ -673,16 +681,16 @@ def run_scan(req: ScanRequest) -> ScanResult:
             severities={},
             budget=budget_str,
             budget_s=budget_s,
+            pinned_explicit=pinned_explicit,
             compile_context=None if req.compile.is_default else req.compile,
         )
     except _BudgetOverflow:
         # The failure-guard contract: overflow is exit 5, never a shrunk scope.
         return ScanResult(verdict="BUDGET_OVERFLOW", exit_code=5)
     except _EvidenceContractError:
-        # A pinned depth that can't collect its evidence (auto-strict, ADR-037 D5).
-        # The programmatic API stays best-effort (run_scan_core is called without
-        # level_explicit), so this is defensive; map it to a failed result rather
-        # than degrade silently.
+        # A pinned depth that can't collect its evidence (auto-strict, ADR-037 D5):
+        # the programmatic API honors the same contract as the CLI (pinned_explicit
+        # above), so map the signal to a failed result rather than degrade silently.
         return ScanResult(verdict="EVIDENCE_CONTRACT_ERROR", exit_code=1)
 
     outcome = core.outcome

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -626,8 +626,15 @@ def run_scan(req: ScanRequest) -> ScanResult:
     if len(req.binaries) != 1:
         raise ValueError("run_scan accepts exactly one binary")
     binary = req.binaries[0]
+    sm = SourceMethod(req.source_method) if req.source_method else None
+    dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
+    # --depth binary is symbols-only (L0/L1): suppress the L2 header AST (and its
+    # provenance) even when the caller passes headers, so the collected evidence
+    # matches the reported depth — parity with the CLI's `scan --depth binary`
+    # handling (Codex review).
+    eff_headers = [] if dp is EvidenceDepth.BINARY else list(req.headers)
     prov_headers, prov_dirs = _public_provenance_set(
-        list(req.headers), list(req.public_header_dirs)
+        eff_headers, list(req.public_header_dirs)
     )
 
     changed = [p for p in req.changed_paths if p]
@@ -636,8 +643,6 @@ def run_scan(req: ScanRequest) -> ScanResult:
     risk = score_changed_paths(changed, risk_rules)
 
     scan_mode = ScanMode(req.mode)
-    sm = SourceMethod(req.source_method) if req.source_method else None
-    dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
     # The pinned-depth contract (ADR-037 D5 auto-strict) applies to the programmatic
     # API too: an explicit depth *always* pins (even with source_method=auto, which
     # only picks the method), or a non-auto source_method does. So run_scan_core
@@ -662,7 +667,7 @@ def run_scan(req: ScanRequest) -> ScanResult:
         core = run_scan_core(
             start=_time.monotonic(),
             binary=binary,
-            headers=list(req.headers),
+            headers=eff_headers,
             includes=list(req.includes),
             public_headers=prov_headers,
             public_header_dirs=prov_dirs,

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -111,6 +111,7 @@ def _scan_imports() -> tuple[Any, ...]:
         ScanMode,
         SourceMethod,
         level_to_collect_mode,
+        parse_user_depth,
         resolve_level,
     )
 
@@ -122,6 +123,7 @@ def _scan_imports() -> tuple[Any, ...]:
         SourceMethod,
         level_to_collect_mode,
         resolve_level,
+        parse_user_depth,
     )
 
 
@@ -387,11 +389,12 @@ def estimate_scan(req: ScanRequest) -> list[CostEstimate]:
         SourceMethod,
         level_to_collect_mode,
         resolve_level,
+        parse_user_depth,
     ) = _scan_imports()
 
     mode = ScanMode(req.mode)
     sm = SourceMethod(req.source_method) if req.source_method else None
-    dp = EvidenceDepth(req.depth) if req.depth else None
+    dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
     auto_method = None
     # AUTO resolves from the risk score whenever a real diff seed was produced —
     # including a *seeded but empty* diff (a no-op PR), which scores 0 → s0/off,
@@ -610,6 +613,7 @@ def run_scan(req: ScanRequest) -> ScanResult:
         SourceMethod,
         level_to_collect_mode,
         resolve_level,
+        parse_user_depth,
     ) = _scan_imports()
     from .buildsource.crosscheck import ALL_CHECKS
     from .cli_scan import (
@@ -633,14 +637,14 @@ def run_scan(req: ScanRequest) -> ScanResult:
 
     scan_mode = ScanMode(req.mode)
     sm = SourceMethod(req.source_method) if req.source_method else None
-    dp = EvidenceDepth(req.depth) if req.depth else None
+    dp = parse_user_depth(req.depth)  # honors the symbols→binary alias (Codex)
     # The pinned-depth contract (ADR-037 D5 auto-strict) applies to the programmatic
-    # API too: an explicitly-pinned deep level (a non-auto source_method, or a depth
-    # with no source_method) is a contract, so run_scan_core fails loud if it can't
-    # collect the evidence — same as the CLI. AUTO / preset-only requests stay
-    # best-effort.
-    pinned_explicit = (sm is not None and sm is not SourceMethod.AUTO) or (
-        sm is None and dp is not None
+    # API too: an explicit depth *always* pins (even with source_method=auto, which
+    # only picks the method), or a non-auto source_method does. So run_scan_core
+    # fails loud if it can't collect the evidence — same as the CLI. AUTO / preset-
+    # only requests stay best-effort (CodeRabbit review).
+    pinned_explicit = (dp is not None) or (
+        sm is not None and sm is not SourceMethod.AUTO
     )
     is_auto = sm is SourceMethod.AUTO
     auto_method = risk.recommended_method if (is_auto and seeded) else None

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -612,7 +612,12 @@ def run_scan(req: ScanRequest) -> ScanResult:
         resolve_level,
     ) = _scan_imports()
     from .buildsource.crosscheck import ALL_CHECKS
-    from .cli_scan import _BudgetOverflow, _public_provenance_set, run_scan_core
+    from .cli_scan import (
+        _BudgetOverflow,
+        _EvidenceContractError,
+        _public_provenance_set,
+        run_scan_core,
+    )
 
     if len(req.binaries) != 1:
         raise ValueError("run_scan accepts exactly one binary")
@@ -673,6 +678,12 @@ def run_scan(req: ScanRequest) -> ScanResult:
     except _BudgetOverflow:
         # The failure-guard contract: overflow is exit 5, never a shrunk scope.
         return ScanResult(verdict="BUDGET_OVERFLOW", exit_code=5)
+    except _EvidenceContractError:
+        # A pinned depth that can't collect its evidence (auto-strict, ADR-037 D5).
+        # The programmatic API stays best-effort (run_scan_core is called without
+        # level_explicit), so this is defensive; map it to a failed result rather
+        # than degrade silently.
+        return ScanResult(verdict="EVIDENCE_CONTRACT_ERROR", exit_code=1)
 
     outcome = core.outcome
     return ScanResult(

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -455,19 +455,20 @@ def estimate_scan(
         )
     collect_mode = level_to_collect_mode(resolved, eff_depth)
 
-    # A --build-info that is an `abicheck collect` pack dir is loaded by the real
-    # scan and supplies its own L3 compile units, so the estimate must count them
-    # too — else a pack-only input reports 0 TUs and undersizes the budget (Codex
-    # review). A Bazel aquery/cquery jsonproto is routed through the Bazel adapter
-    # by the real scan, so count its compile actions the same way. A raw compile DB
-    # / source tree is counted otherwise.
+    # Count TUs from the *same* effective build-info the real scan uses
+    # (`req.compile_db or req.build_info`) so an explicit --compile-db wins over a
+    # Bazel --build-info here too — else the estimate could price a different action
+    # graph than the scan executes (Codex review). A pack dir supplies its own L3
+    # compile units; a Bazel aquery/cquery jsonproto is routed through the Bazel
+    # adapter; a raw compile DB / source tree is counted otherwise.
+    eff_build_info = req.compile_db or req.build_info
     bazel_tus = (
-        _count_bazel_build_info_tus(req.build_info)
-        if req.build_info is not None
+        _count_bazel_build_info_tus(eff_build_info)
+        if eff_build_info is not None
         else None
     )
-    pack_tus = _count_pack_tus(req.build_info) if req.build_info is not None else None
-    compile_db = _discover_compile_db(req.sources, req.compile_db or req.build_info)
+    pack_tus = _count_pack_tus(eff_build_info) if eff_build_info is not None else None
+    compile_db = _discover_compile_db(req.sources, eff_build_info)
     if bazel_tus is not None:
         total_tus = bazel_tus
         tu_note = "Bazel aquery/cquery (build_evidence)"

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -11,13 +11,30 @@ the changed paths, runs the always-on compiler-free pattern pre-scan, then runs 
     for the mental model first — this page is the practical flag reference and the
     [worked examples](#worked-examples) below.
 
-Two orthogonal knobs select how deep it goes (`abicheck/buildsource/scan_levels.py`):
+**One dial selects how deep it goes — `--depth`, named by the evidence you get:**
 
-- **`--source-method s0…s6`** — the precise S-axis (the *how*). Deterministic.
-- **`--depth headers|build|source|full|graph`** — a coarse, lossy L-axis. The
-  `--source-method` wins if both are given.
-- **`--mode pr|pr-deep|baseline|audit`** — a fixed `(S, L)` preset (the default
-  is `pr`). A pinned mode produces the same scan for the same inputs.
+- **`--depth binary|headers|build|source|full`** — the single knob (ADR-037 D5).
+  `binary` = L0/L1 exported symbols + binary metadata; `headers` = +L2 header AST;
+  `build` = +L3 build context; `source` = +L4 replay & the L5 graph; `full` =
+  deepest (whole-library replay). **Omit it for `auto`** — the default: risk-driven
+  when a `--since`/`--changed-path` seed is present, else a sensible preset.
+- **`--audit`** is orthogonal: a single-build, no-baseline hygiene lint (it does
+  not need a previous version).
+
+!!! warning "A pinned depth is a contract (fail-loud)"
+    Pinning a deep depth (`--depth build|source|full`) with **no source input**
+    (`--sources`/`--build-info`) is an error, not a silent shallow scan: there is
+    nothing to collect L3/L4/L5 from. Pass the evidence, or use the default `auto`
+    for a best-effort binary scan. (The `auto` default never errors this way.)
+
+??? note "Expert axes (`--source-method`, `--mode`) — deprecated aliases"
+    The precise **S-axis** (`--source-method s0…s6`, the technique) and the
+    **`--mode pr|pr-deep|baseline|audit`** presets still work but are now hidden,
+    **deprecated** aliases (they warn and map onto `--depth`) for one release.
+    Prefer `--depth`. The `s0…s6` / `L0…L5` model is still the spine — see
+    [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md) for the mental
+    model; `--depth` is its friendly façade. (`--depth symbols` was renamed to
+    `--depth binary`; `symbols` keeps working as a warned alias.)
 
 ## What each level reaches
 
@@ -43,7 +60,7 @@ matches your goal, then supply the input named in column 3.
 
 | Goal (use case) | Level | Input you must provide | How to obtain it | If the input is missing |
 |---|---|---|---|---|
-| Binary-only ABI gate (removed/changed exports; no-DWARF vtable/RTTI size) | `s0` / `--depth symbols` | two `.so` (or `.abi.json`) | release artifacts / conda / `.deb` | always available (L0/L1) |
+| Binary-only ABI gate (removed/changed exports; no-DWARF vtable/RTTI size) | `--depth binary` (`s0`) | two `.so` (or `.abi.json`) | release artifacts / conda / `.deb` | always available (L0/L1) |
 | Header-aware API surface + internal-vs-public scoping + cross-source checks | L2 (intrinsic, with `-H`) | a public-header **directory** + a C/C++ frontend | `-H include/ --public-header-dir include/`; `castxml` **or** `clang` on `PATH` | a lone `-H file.h` does not establish a boundary → provenance/cross-checks stay dormant |
 | Build-flag / toolchain / visibility drift | `s1` / `--depth build` | an L3 compile database | `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` (configure-only), `meson setup`, `bazel aquery --output=jsonproto`, or `bear -- make`; pass via `--build-info`/`--compile-db` | L3 `not_collected`; the scan advises the exact remedy |
 | Macro-value / include divergence; private/generated-header leaks | `s2` | L3 compile DB + `clang -E` | same as `s1` (the `-E` pass needs the TU's full flag set) | preprocessor tier skipped (coverage row, not a pass) |
@@ -61,12 +78,19 @@ the build graph:
 ```bash
 # CMake (oneTBB, oneDNN, oneCCL, …): configure-only
 cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-abicheck scan --binary new/libfoo.so -H include/ --build-info build --source-method s5 …
+abicheck scan --binary new/libfoo.so -H include/ --build-info build --depth source …
 
 # Bazel (oneDAL, …): query the action graph (no build)
 bazel aquery 'mnemonic("CppCompile", //...)' --output=jsonproto > aq.json
-abicheck scan --binary new/libonedal_core.so -H include/ --build-info aq.json --source-method s1 …
+abicheck scan --binary new/libonedal_core.so -H include/ --build-info aq.json --depth build …
 ```
+
+!!! tip "`--build-info` auto-detects the format (ADR-037 D5)"
+    `--build-info` sniffs its argument by content, so each kind "just works":
+    a `compile_commands.json` (CMake/Meson/`bear`), a Bazel
+    `--output=jsonproto` **aquery** or **cquery** dump, a build **directory**
+    (searched for `compile_commands.json`), or a `collect` **pack**. A Bazel
+    query result is routed to the Bazel adapter — not mis-read as a compile DB.
 
 !!! note "Generated headers"
     L4 replay re-parses each TU with `clang`. If a TU `#include`s a header that

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,3 +278,23 @@ def shared_cmake_build_dir(tmp_path_factory: pytest.TempPathFactory) -> Path | N
         return None
 
     return build_dir
+
+
+@pytest.fixture
+def compile_db(tmp_path: Path) -> Path:
+    """A minimal ``compile_commands.json`` supplying L3 build metadata (no compiler).
+
+    Shared across scan tests: lets a pinned deep level collect L3 so auto-strict
+    (ADR-037 D5 — a pinned depth with no source input is an error) does not fire in
+    tests whose intent is level reporting / seed resolution, not collection.
+    """
+    src = tmp_path / "u.c"
+    src.write_text("int u(void){return 0;}\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c u.c"}]
+        ),
+        encoding="utf-8",
+    )
+    return cdb

--- a/tests/test_build_info_sniffing.py
+++ b/tests/test_build_info_sniffing.py
@@ -162,6 +162,30 @@ def test_sniff_object_wrapped_compile_db(tmp_path: Path) -> None:
     assert sniff_build_info_format(p) == "compile_db"
 
 
+def test_sniff_unreadable_or_missing_path_is_unknown(tmp_path: Path) -> None:
+    # A path that can't be opened (here: does not exist) → "unknown", never a crash
+    # (the OSError guard around the bounded-head read).
+    assert sniff_build_info_format(tmp_path / "nope.json") == "unknown"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ('"just a json string"', "unknown"),  # neither array nor object head
+        ("garbage not json", "unknown"),  # not JSON at all
+        ('{"actions": [{"mnemonic":', "bazel_aquery"),  # truncated → prefix fallback
+        ('{"results": [{"target":', "bazel_cquery"),  # truncated → prefix fallback
+        ('{"foo": [1, 2, 3', "unknown"),  # truncated, no discriminating key
+    ],
+)
+def test_sniff_non_object_and_truncated_objects(
+    tmp_path: Path, text, expected
+) -> None:
+    # Heads that aren't a parseable object exercise the non-`{` branch and the
+    # truncated-JSON prefix fallback (json.load fails → scan the bounded head).
+    assert sniff_build_info_format(_w(tmp_path, "x.json", text)) == expected
+
+
 def test_maybe_collect_bazel_handles_none_and_nonfile(tmp_path: Path) -> None:
     from abicheck.buildsource.inline import _maybe_collect_bazel_build_info
 

--- a/tests/test_build_info_sniffing.py
+++ b/tests/test_build_info_sniffing.py
@@ -143,3 +143,29 @@ def test_collect_inline_pack_routes_bazel_build_info(tmp_path: Path) -> None:
     assert not any(
         "no compile_commands.json" in d for d in pack.build_evidence.diagnostics
     )
+
+
+def test_sniff_large_aquery_preamble_still_detected(tmp_path: Path) -> None:
+    """A Bazel aquery whose `actions` key sits past the bounded sniff window (huge
+    `artifacts`/`pathFragments` preamble) must still classify as bazel_aquery —
+    the object is fully parsed, not prefix-scanned (Codex review)."""
+    big_artifacts = [{"id": str(i), "pathFragmentId": str(i)} for i in range(20000)]
+    payload = {"artifacts": big_artifacts, "actions": [{"mnemonic": "CppCompile"}]}
+    p = _w(tmp_path, "big_aquery.json", json.dumps(payload))
+    assert p.stat().st_size > 70000  # exceeds the 64 KiB sniff head
+    assert sniff_build_info_format(p) == "bazel_aquery"
+
+
+def test_sniff_object_wrapped_compile_db(tmp_path: Path) -> None:
+    # An object that carries compile-DB keys (not actions/results) → compile_db.
+    p = _w(tmp_path, "wrapped.json", json.dumps({"file": "a.c", "command": "cc"}))
+    assert sniff_build_info_format(p) == "compile_db"
+
+
+def test_maybe_collect_bazel_handles_none_and_nonfile(tmp_path: Path) -> None:
+    from abicheck.buildsource.inline import _maybe_collect_bazel_build_info
+
+    merged = BuildEvidence()
+    assert _maybe_collect_bazel_build_info(None, merged, []) is False
+    # A directory is not a file → not routed here (pack/build_dir handled upstream).
+    assert _maybe_collect_bazel_build_info(tmp_path, merged, []) is False

--- a/tests/test_build_info_sniffing.py
+++ b/tests/test_build_info_sniffing.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`--build-info` format sniffing (ADR-037 D5 #5).
+
+`--build-info` accepts a compile_commands.json, a Bazel `--output=jsonproto`
+aquery/cquery, or a `collect` pack. These guard that the content sniffer
+classifies each correctly and that a pre-captured Bazel query is routed to the
+Bazel adapter (producing BuildEvidence) instead of being mis-parsed as a compile
+database.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.build_evidence import BuildEvidence
+from abicheck.buildsource.inline import (
+    _maybe_collect_bazel_build_info,
+    sniff_build_info_format,
+)
+
+# A minimal aquery action graph (one CppCompile) — the deduplicated fragment tree.
+_AQUERY = json.dumps(
+    {
+        "artifacts": [
+            {"id": "1", "pathFragmentId": "10"},
+            {"id": "2", "pathFragmentId": "11"},
+        ],
+        "actions": [
+            {
+                "targetId": "100",
+                "mnemonic": "CppCompile",
+                "arguments": ["/usr/bin/gcc", "-std=c++17", "-c", "foo/foo.cc"],
+                "primaryOutputId": "2",
+            }
+        ],
+        "targets": [{"id": "100", "label": "//foo:foo"}],
+        "pathFragments": [
+            {"id": "10", "label": "foo.cc", "parentId": "20"},
+            {"id": "11", "label": "foo.o", "parentId": "20"},
+            {"id": "20", "label": "foo"},
+        ],
+    }
+)
+_CQUERY = json.dumps({"results": [{"target": {"rule": {"name": "//foo:foo"}}}]})
+_COMPILE_DB = json.dumps(
+    [{"directory": "/w", "file": "/w/a.c", "command": "cc -c a.c"}]
+)
+
+
+def _w(tmp_path: Path, name: str, text: str) -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+@pytest.mark.parametrize(
+    "name,text,expected",
+    [
+        ("compile_commands.json", _COMPILE_DB, "compile_db"),
+        ("aquery.json", _AQUERY, "bazel_aquery"),
+        ("cquery.json", _CQUERY, "bazel_cquery"),
+        ("weird.json", '{"hello": 1}', "unknown"),
+        ("empty.json", "", "unknown"),
+    ],
+)
+def test_sniff_classifies_files(tmp_path: Path, name, text, expected) -> None:
+    assert sniff_build_info_format(_w(tmp_path, name, text)) == expected
+
+
+def test_sniff_pack_vs_build_dir(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    assert sniff_build_info_format(build_dir) == "build_dir"
+    pack = tmp_path / "pack"
+    pack.mkdir()
+    (pack / "manifest.json").write_text("{}", encoding="utf-8")
+    assert sniff_build_info_format(pack) == "pack"
+
+
+def test_bazel_aquery_routed_to_adapter(tmp_path: Path) -> None:
+    """A pre-captured aquery passed as --build-info is normalized by the Bazel
+    adapter (compile units), not mis-read as a compile_commands.json."""
+    merged = BuildEvidence()
+    extractors: list = []
+    routed = _maybe_collect_bazel_build_info(
+        _w(tmp_path, "aquery.json", _AQUERY), merged, extractors
+    )
+    assert routed is True
+    assert merged.compile_units  # the CppCompile action became a compile unit
+    assert any(e.name == "bazel" for e in extractors)
+
+
+def test_bazel_cquery_routed_to_adapter(tmp_path: Path) -> None:
+    merged = BuildEvidence()
+    extractors: list = []
+    assert _maybe_collect_bazel_build_info(
+        _w(tmp_path, "cquery.json", _CQUERY), merged, extractors
+    ) is True
+    assert any(e.name == "bazel" for e in extractors)
+
+
+def test_compile_db_not_routed_to_bazel(tmp_path: Path) -> None:
+    """A compile_commands.json must NOT be claimed by the Bazel router — it falls
+    through to compile-DB resolution."""
+    merged = BuildEvidence()
+    assert _maybe_collect_bazel_build_info(
+        _w(tmp_path, "compile_commands.json", _COMPILE_DB), merged, []
+    ) is False
+    assert not merged.compile_units
+
+
+def test_collect_inline_pack_routes_bazel_build_info(tmp_path: Path) -> None:
+    """End-to-end: collect_inline_pack with a Bazel aquery --build-info produces a
+    pack from the adapter and never emits the 'no compile_commands.json' miss."""
+    from abicheck.buildsource.inline import collect_inline_pack
+
+    pack = collect_inline_pack(
+        sources=None,
+        build_info=_w(tmp_path, "aquery.json", _AQUERY),
+        layers=("L3",),
+    )
+    assert pack is not None
+    assert pack.build_evidence is not None
+    assert pack.build_evidence.compile_units
+    # The Bazel route was taken — no compile-DB miss diagnostic.
+    assert not any(
+        "no compile_commands.json" in d for d in pack.build_evidence.diagnostics
+    )

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1478,6 +1478,38 @@ def test_depth_binary_clears_headers_in_scan(monkeypatch, runner, new_snap_compa
     assert captured["headers"] == []  # -H suppressed for the binary rung
 
 
+def test_depth_binary_clears_baseline_headers(
+    monkeypatch, runner, baseline_snap, new_snap_compatible, tmp_path
+):
+    # --depth binary must also drop the *baseline* header inputs: leaving them would
+    # parse the old side with the L2 header AST while the new side has none, yielding
+    # spurious header/type removals against a symbols-only scan (Codex review).
+    import abicheck.cli_scan as cs
+
+    header = tmp_path / "old.h"
+    header.write_text("int old(void);\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    original = cs.run_scan_core
+
+    def _spy(*args, **kwargs):
+        captured["baseline_headers"] = kwargs.get("baseline_headers")
+        captured["headers"] = kwargs.get("headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "run_scan_core", _spy)
+    res = runner.invoke(
+        main,
+        [
+            "scan", "--binary", str(new_snap_compatible),
+            "--baseline", str(baseline_snap), "--baseline-header", str(header),
+            "--depth", "binary",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["baseline_headers"] == []  # old side stays symbols-only too
+    assert captured["headers"] == []
+
+
 def test_estimate_uses_resolved_level_not_raw_flags(
     monkeypatch, runner, new_snap_compatible
 ):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -78,26 +78,6 @@ def _payload(res) -> dict:  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture
-def compile_db(tmp_path):  # type: ignore[no-untyped-def]
-    """A minimal compile_commands.json supplying L3 build metadata (no compiler).
-
-    Lets a pinned deep level collect L3 so auto-strict (ADR-037 D5: a pinned depth
-    with no source input is an error) does not fire in tests whose intent is level
-    reporting / seed resolution, not collection.
-    """
-    src = tmp_path / "u.c"
-    src.write_text("int u(void){return 0;}\n", encoding="utf-8")
-    cdb = tmp_path / "compile_commands.json"
-    cdb.write_text(
-        json.dumps(
-            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c u.c"}]
-        ),
-        encoding="utf-8",
-    )
-    return cdb
-
-
-@pytest.fixture
 def baseline_snap(tmp_path: Path) -> Path:
     snap = AbiSnapshot(
         library="libfoo.so",
@@ -267,8 +247,11 @@ def test_source_method_pin_overrides_mode_in_report(
     assert "depth=build" in res.output
 
 
-def test_pr_deep_is_distinct_from_pr(runner, new_snap_compatible):
+def test_pr_deep_is_distinct_from_pr(runner, new_snap_compatible, compile_db):
     # No --audit here: --audit would force the AUDIT preset and mask --mode.
+    # --mode pr-deep is an explicit deep pin → the contract needs source evidence
+    # (ADR-037 D5 auto-strict applies to the deprecated --mode alias too), so
+    # supply a minimal compile DB.
     res = runner.invoke(
         main,
         [
@@ -277,6 +260,8 @@ def test_pr_deep_is_distinct_from_pr(runner, new_snap_compatible):
             str(new_snap_compatible),
             "--mode",
             "pr-deep",
+            "--build-info",
+            str(compile_db),
             "--format",
             "json",
         ],
@@ -1514,3 +1499,32 @@ def test_estimate_uses_resolved_level_not_raw_flags(
     assert res.exit_code == 0, res.output
     assert captured["source_method"] == "s5"
     assert captured["depth"] == "source"
+
+
+def test_pinned_depth_with_embedded_l3_snapshot_no_contract_error(runner, tmp_path):
+    # Codex review: a cached .abi.json that already carries embedded L3 evidence
+    # must satisfy the pinned-depth contract via _l3_collected — not be rejected
+    # because no raw --sources/--build-info was passed on the CLI.
+    from abicheck.buildsource.model import CoverageStatus, LayerCoverage
+    from abicheck.buildsource.pack import BuildSourcePack
+
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="2.0",
+        from_headers=True,
+        functions=[_func("foo", "_Z3foov")],
+        elf=_elf("_Z3foov"),
+    )
+    pack = BuildSourcePack(root="")
+    pack.manifest.coverage.append(
+        LayerCoverage(layer="L3_build", status=CoverageStatus.PRESENT)
+    )
+    snap.build_source = pack
+    p = _write_snapshot(tmp_path / "embedded.abi.json", snap)
+
+    res = runner.invoke(
+        main, ["scan", "--binary", str(p), "--depth", "source", "--audit"]
+    )
+    # The embedded L3 satisfies the contract → no EVIDENCE_CONTRACT error (exit 1).
+    assert res.exit_code != 1, res.output
+    assert "nothing to collect" not in res.output

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1528,3 +1528,27 @@ def test_pinned_depth_with_embedded_l3_snapshot_no_contract_error(runner, tmp_pa
     # The embedded L3 satisfies the contract → no EVIDENCE_CONTRACT error (exit 1).
     assert res.exit_code != 1, res.output
     assert "nothing to collect" not in res.output
+
+
+def test_mode_audit_alias_binary_only_no_contract_error(runner, new_snap_compatible):
+    # The deprecated `--mode audit` alias must stay a best-effort binary-only lint
+    # (like `--audit`) — a preset is NOT a pinned-depth contract (Codex review).
+    res = runner.invoke(
+        main, ["scan", "--binary", str(new_snap_compatible), "--mode", "audit"]
+    )
+    assert res.exit_code != 1, res.output
+    assert "nothing to collect" not in res.output
+
+
+def test_depth_pin_with_auto_method_still_a_contract(runner, new_snap_compatible):
+    # An explicit --depth pins the contract even alongside --source-method auto
+    # (auto only picks the method; the user still demanded source depth) — CodeRabbit.
+    res = runner.invoke(
+        main,
+        [
+            "scan", "--binary", str(new_snap_compatible),
+            "--depth", "source", "--source-method", "auto", "--audit",
+        ],
+    )
+    assert res.exit_code != 0
+    assert "pinned depth 'source'" in res.output

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1464,3 +1464,53 @@ def test_export_delta_resolves_tu_into_replay_seed(monkeypatch, runner, tmp_path
     # The git-changed file (floor) AND the export-delta-resolved TU are both in.
     assert "src/unrelated.cpp" in seed
     assert "src/bar.cpp" in seed
+
+
+def test_depth_binary_clears_headers_in_scan(monkeypatch, runner, new_snap_compatible, tmp_path):
+    # --depth binary is L0/L1-only: -H must be suppressed so the collected
+    # evidence matches the reported depth (Codex review). Spy run_scan_core to
+    # confirm headers are cleared even when -H is passed.
+    import abicheck.cli_scan as cs
+
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    original = cs.run_scan_core
+
+    def _spy(*args, **kwargs):
+        captured["headers"] = kwargs.get("headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "run_scan_core", _spy)
+    res = runner.invoke(
+        main,
+        [
+            "scan", "--binary", str(new_snap_compatible),
+            "-H", str(header), "--depth", "binary", "--audit",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["headers"] == []  # -H suppressed for the binary rung
+
+
+def test_estimate_uses_resolved_level_not_raw_flags(
+    monkeypatch, runner, new_snap_compatible
+):
+    # The --estimate path must reflect the *resolved* level, not the raw flags —
+    # e.g. --depth source resolves to s5, so the estimate sees s5 (Codex review).
+    import abicheck.cli_scan as cs
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        cs, "_emit_estimate", lambda **kw: captured.update(kw)
+    )
+    res = runner.invoke(
+        main,
+        [
+            "scan", "--binary", str(new_snap_compatible),
+            "--depth", "source", "--estimate", "--audit",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert captured["source_method"] == "s5"
+    assert captured["depth"] == "source"

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -65,6 +65,38 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+def _payload(res) -> dict:  # type: ignore[no-untyped-def]
+    """Parse the JSON report from a scan result, tolerating a leading stderr note.
+
+    CliRunner mixes stderr into ``output``; the deprecated --mode/--source-method
+    aliases now print a one-line note there (ADR-037 D5), so strip anything before
+    the first ``{`` before decoding.
+    """
+    out = res.output
+    i = out.find("{")
+    return json.loads(out[i:] if i >= 0 else out)
+
+
+@pytest.fixture
+def compile_db(tmp_path):  # type: ignore[no-untyped-def]
+    """A minimal compile_commands.json supplying L3 build metadata (no compiler).
+
+    Lets a pinned deep level collect L3 so auto-strict (ADR-037 D5: a pinned depth
+    with no source input is an error) does not fire in tests whose intent is level
+    reporting / seed resolution, not collection.
+    """
+    src = tmp_path / "u.c"
+    src.write_text("int u(void){return 0;}\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c u.c"}]
+        ),
+        encoding="utf-8",
+    )
+    return cdb
+
+
 @pytest.fixture
 def baseline_snap(tmp_path: Path) -> Path:
     snap = AbiSnapshot(
@@ -210,7 +242,9 @@ def test_pattern_prescan_reports_facts(runner, tmp_path, new_snap_compatible):
     assert "pragma_pack" in res.output
 
 
-def test_source_method_pin_overrides_mode_in_report(runner, new_snap_compatible):
+def test_source_method_pin_overrides_mode_in_report(
+    runner, new_snap_compatible, compile_db
+):
     res = runner.invoke(
         main,
         [
@@ -221,6 +255,8 @@ def test_source_method_pin_overrides_mode_in_report(runner, new_snap_compatible)
             "baseline",
             "--source-method",
             "s1",
+            "--build-info",
+            str(compile_db),
             "--audit",
         ],
     )
@@ -246,21 +282,37 @@ def test_pr_deep_is_distinct_from_pr(runner, new_snap_compatible):
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     # pr-deep keeps GRAPH depth and a distinct graph collect-mode (Codex review).
     assert payload["level"]["depth"] == "graph"
     assert payload["level"]["collect_mode"] == "graph-full"
 
 
-def test_reported_depth_matches_resolved_source_method(runner, new_snap_compatible):
+def test_reported_depth_matches_resolved_source_method(
+    runner, new_snap_compatible, tmp_path
+):
+    # A minimal compile DB supplies L3 build metadata (pure parsing, no compiler),
+    # so the pinned deep level can collect its evidence and auto-strict (ADR-037
+    # D5) does not fire — letting us assert the honest depth reporting.
+    src = tmp_path / "a.c"
+    src.write_text("int a(void){return 0;}\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c a.c"}]
+        ),
+        encoding="utf-8",
+    )
     res = runner.invoke(
         main,
         [
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--source-method",
-            "s6",
+            "--depth",
+            "full",
+            "--build-info",
+            str(cdb),
             "--format",
             "json",
             "--audit",
@@ -268,20 +320,34 @@ def test_reported_depth_matches_resolved_source_method(runner, new_snap_compatib
     )
     assert res.exit_code == 0, res.output
     payload = json.loads(res.output)
-    # s6 reaches full depth — must not be reported as the pr-preset 'source'.
+    # --depth full reaches s6 — must not be reported as the pr-preset 'source'.
     assert payload["level"]["source_method"] == "s6"
     assert payload["level"]["depth"] == "full"
 
 
+def test_pinned_depth_without_evidence_errors(runner, new_snap_compatible):
+    # ADR-037 D5 (#2 auto-strict): an explicitly pinned source/build depth that
+    # can't collect its evidence (no --sources/--build-info) fails loudly with the
+    # remedy, instead of silently degrading to a shallow scan.
+    res = runner.invoke(
+        main,
+        ["scan", "--binary", str(new_snap_compatible), "--depth", "source", "--audit"],
+    )
+    assert res.exit_code != 0
+    assert "pinned depth 'source'" in res.output and "nothing to collect" in res.output
+    # The implicit 'auto' default (no --depth) must NOT error on the same input.
+    ok = runner.invoke(main, ["scan", "--binary", str(new_snap_compatible), "--audit"])
+    assert ok.exit_code == 0, ok.output
+
+
 def test_auto_method_uses_changed_path_risk(runner, new_snap_compatible):
+    # The default dial (no --depth) IS auto (ADR-037 D5): risk-driven when seeded.
     res = runner.invoke(
         main,
         [
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--source-method",
-            "auto",
             "--changed-path",
             "include/foo.h",
             "--format",
@@ -290,7 +356,7 @@ def test_auto_method_uses_changed_path_risk(runner, new_snap_compatible):
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert payload["level"]["auto"] is True
     # include/** is the public-header signal → auto escalates to s5.
     assert payload["level"]["source_method"] == "s5"
@@ -536,10 +602,14 @@ def test_malformed_risk_rules_yaml_is_click_error(
     assert "cannot read --risk-rules" in res.output
 
 
-def test_source_method_s2_runs_preprocessor_tier(runner, new_snap_compatible):
-    # S2 is now the conditional preprocessor pre-scan (ADR-035 D2). With no L3
-    # build evidence (snapshot-only input) it runs but reports the preprocessor
-    # tier as skipped — honest coverage, not a hard reject and not a clean pass.
+def test_source_method_s2_runs_preprocessor_tier(
+    runner, new_snap_compatible, compile_db
+):
+    # S2 is the conditional preprocessor pre-scan (ADR-035 D2). It needs L3 build
+    # evidence; a pinned s2 with no source input is now an error (ADR-037 D5
+    # auto-strict), so supply a minimal compile DB. Without `clang -E` the
+    # preprocessor pass still reports honestly (ran=False / skipped), never a clean
+    # pass.
     res = runner.invoke(
         main,
         [
@@ -548,16 +618,19 @@ def test_source_method_s2_runs_preprocessor_tier(runner, new_snap_compatible):
             str(new_snap_compatible),
             "--source-method",
             "s2",
+            "--build-info",
+            str(compile_db),
             "--audit",
             "--format",
             "json",
         ],
     )
-    assert res.exit_code == 0
-    payload = json.loads(res.output)
-    assert payload["preprocessor_scan"]["ran"] is False
+    assert res.exit_code == 0, res.output
+    payload = _payload(res)
     rows = {row["layer"]: row for row in payload["coverage"]}
-    assert rows["preprocessor_scan"]["status"] == "not_collected"
+    # The preprocessor tier is present as a coverage row (ran, or skipped without
+    # clang -E) — never silently absent.
+    assert "preprocessor_scan" in rows
 
 
 def test_auto_seeded_empty_diff_uses_s0(runner, new_snap_compatible):
@@ -570,8 +643,6 @@ def test_auto_seeded_empty_diff_uses_s0(runner, new_snap_compatible):
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--source-method",
-            "auto",
             "--since",
             "HEAD",
             "--format",
@@ -581,7 +652,7 @@ def test_auto_seeded_empty_diff_uses_s0(runner, new_snap_compatible):
     )
     if res.exit_code != 0 or "seed failed" in res.output:
         pytest.skip("git unavailable / not a repo in this environment")
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert payload["level"]["source_method"] == "s0"
     assert payload["level"]["collect_mode"] == "off"
 
@@ -595,15 +666,13 @@ def test_auto_without_diff_seed_falls_back_to_preset(runner, new_snap_compatible
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--source-method",
-            "auto",
             "--format",
             "json",
             "--audit",
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert payload["level"]["source_method"] == "s5"
     assert payload["level"]["collect_mode"] == "source-changed"
 
@@ -631,7 +700,7 @@ def test_unseeded_s5_with_sources_emits_headers_only_advisory(
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert any("--since" in a for a in payload["advisories"])
 
 
@@ -660,21 +729,21 @@ def test_unseeded_s5_advisory_rendered_in_text_output(
 def test_unseeded_s5_without_sources_has_no_advisory(runner, new_snap_compatible):
     # No --sources tree → L4 replay never runs, so the headers-only advisory must
     # NOT fire (it would report a replay that never happened — CodeRabbit review).
+    # Uses the default 'auto' dial (not a pinned depth) so auto-strict (ADR-037 D5)
+    # does not error on the missing source input — best-effort by design.
     res = runner.invoke(
         main,
         [
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--source-method",
-            "s5",
             "--format",
             "json",
             "--audit",
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert not any("--since" in a for a in payload["advisories"])
 
 
@@ -702,7 +771,7 @@ def test_seeded_s5_with_sources_has_no_headers_only_advisory(
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert not any("--since" in a for a in payload["advisories"])
 
 
@@ -759,17 +828,17 @@ def test_compile_db_present_suppresses_l3_advisory(
 
 
 def test_binary_only_deep_method_has_no_l3_advisory(runner, new_snap_compatible):
-    # A deep --source-method with NO source input (no --sources/--build-info) is the
-    # obvious binary-only case; the advisory is gated on a source input so a plain
-    # binary scan at a deep level isn't nagged.
+    # The default 'auto' dial over a binary-only input (no --sources/--build-info):
+    # the L3 advisory is gated on a source input, so a plain binary scan isn't
+    # nagged — and 'auto' (unpinned) never triggers auto-strict (ADR-037 D5). A
+    # *pinned* deep depth with no input is covered by
+    # test_pinned_depth_without_evidence_errors.
     res = runner.invoke(
         main,
         [
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--source-method",
-            "s1",
             "--audit",
         ],
     )
@@ -983,6 +1052,15 @@ def test_level_implies_query_silent_when_config_defines_no_query(
     # there is no query to consent to.
     cfg = tmp_path / ".abicheck.yml"
     cfg.write_text("severity:\n  preset: strict\n", encoding="utf-8")  # no build.query
+    src = tmp_path / "u.c"
+    src.write_text("int u(void){return 0;}\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c u.c"}]
+        ),
+        encoding="utf-8",
+    )
     res = runner.invoke(
         main,
         [
@@ -993,6 +1071,8 @@ def test_level_implies_query_silent_when_config_defines_no_query(
             str(cfg),
             "--source-method",
             "s5",
+            "--build-info",
+            str(cdb),
             "--audit",
         ],
     )
@@ -1351,6 +1431,17 @@ def test_export_delta_resolves_tu_into_replay_seed(monkeypatch, runner, tmp_path
         return original(*args, **kwargs)
 
     monkeypatch.setattr(cs, "_build_new_snapshot", _spy)
+    # A minimal compile DB so the pinned s5 has source evidence (auto-strict,
+    # ADR-037 D5, otherwise errors on the missing input before the seed is built).
+    src = tmp_path / "u.c"
+    src.write_text("int u(void){return 0;}\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c u.c"}]
+        ),
+        encoding="utf-8",
+    )
     res = runner.invoke(
         main,
         [
@@ -1361,6 +1452,8 @@ def test_export_delta_resolves_tu_into_replay_seed(monkeypatch, runner, tmp_path
             str(base_path),
             "--source-method",
             "s5",
+            "--build-info",
+            str(cdb),
             "--changed-path",
             "src/unrelated.cpp",
         ],

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1497,8 +1497,40 @@ def test_estimate_uses_resolved_level_not_raw_flags(
         ],
     )
     assert res.exit_code == 0, res.output
-    assert captured["source_method"] == "s5"
-    assert captured["depth"] == "source"
+    assert captured["resolved_method"].value == "s5"
+    assert captured["eff_depth"].value == "source"
+
+
+def test_source_method_overrides_depth_binary_keeps_headers(
+    monkeypatch, runner, new_snap_compatible, tmp_path
+):
+    # --source-method wins over --depth (resolve precedence), so
+    # `--source-method s5 --depth binary` resolves to a SOURCE scan that still needs
+    # the L2 header AST. Header suppression must key on the *resolved* effective
+    # depth, not the raw --depth, else the winning level loses its headers (Codex).
+    import abicheck.cli_scan as cs
+
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    original = cs.run_scan_core
+
+    def _spy(*args, **kwargs):
+        captured["headers"] = kwargs.get("headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "run_scan_core", _spy)
+    # s5 with no compile DB → pinned-depth contract error (exit 1), but run_scan_core
+    # is still entered and must have received the (un-suppressed) headers.
+    runner.invoke(
+        main,
+        [
+            "scan", "--binary", str(new_snap_compatible),
+            "-H", str(header), "--source-method", "s5", "--depth", "binary",
+        ],
+    )
+    assert captured["headers"]  # headers kept — resolved depth is source, not binary
+    assert [str(p) for p in captured["headers"]] == [str(header)]
 
 
 def test_pinned_depth_with_embedded_l3_snapshot_no_contract_error(runner, tmp_path):

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -48,14 +48,14 @@ def test_depth_dial_is_uniform(cmd_name: str) -> None:
     cmd = _registered()[cmd_name]
     depth = next(p for p in cmd.params if "--depth" in getattr(p, "opts", []))
     metavar = depth.type.get_metavar(depth)
-    assert metavar == "[symbols|headers|build|source|full]", (cmd_name, metavar)
-    assert "graph" not in metavar
+    assert metavar == "[binary|headers|build|source|full]", (cmd_name, metavar)
+    assert "graph" not in metavar and "symbols" not in metavar
 
 
 # ── Alias resolution: every legacy spelling resolves to the right depth ──────
 
 
-@pytest.mark.parametrize("depth_value", ["symbols", "headers", "build", "source", "full"])
+@pytest.mark.parametrize("depth_value", ["binary", "headers", "build", "source", "full"])
 def test_depth_user_rung_passes_through(depth_value: str) -> None:
     """Each user-ladder rung resolves to itself, independently."""
     assert DEPTH_PARAM.convert(depth_value, None, None) == depth_value
@@ -66,8 +66,21 @@ def test_user_depths_match_ladder() -> None:
     from abicheck.buildsource.scan_levels import USER_DEPTHS
 
     assert [d.value for d in USER_DEPTHS] == [
-        "symbols", "headers", "build", "source", "full"
+        "binary", "headers", "build", "source", "full"
     ]
+
+
+@pytest.mark.parametrize("spelling", ["symbols", "SYMBOLS"])
+def test_depth_symbols_alias_resolves_to_binary(spelling: str) -> None:
+    """``symbols`` was renamed to the evidence-named ``binary`` rung (G22 Phase 6);
+    it keeps working as a deprecated alias for one release."""
+    assert DEPTH_PARAM.convert(spelling, None, None) == "binary"
+
+
+def test_depth_symbols_alias_warns_on_stderr() -> None:
+    res = CliRunner().invoke(main, ["dump", "--depth", "symbols", "/no/such/bin"])
+    text = _all_output(res)
+    assert "deprecated" in text and "--depth binary" in text
 
 
 @pytest.mark.parametrize("spelling", ["graph", "GRAPH"])
@@ -170,10 +183,11 @@ def test_graph_built_at_source_depth() -> None:
 # ── --depth symbols suppresses the L2 header AST (symbols-only) ──────────────
 
 
-def test_resolve_dump_depth_symbols_collects_nothing() -> None:
+def test_resolve_dump_depth_binary_collects_nothing() -> None:
     from abicheck.cli_dump_helpers import resolve_dump_depth
 
-    assert resolve_dump_depth("symbols", False, "off", False) == "off"
+    # DEPTH_PARAM normalizes the `symbols` alias to `binary` before this runs.
+    assert resolve_dump_depth("binary", False, "off", False) == "off"
     assert resolve_dump_depth("headers", False, "off", False) == "off"
     assert resolve_dump_depth("source", False, "off", False) != "off"
 
@@ -245,10 +259,10 @@ def _fn(name: str):  # type: ignore[no-untyped-def]
     )
 
 
-@pytest.mark.parametrize("depth", ["symbols", "headers", "source"])
+@pytest.mark.parametrize("depth", ["binary", "headers", "source"])
 def test_compare_accepts_depth_over_snapshots(tmp_path, depth: str) -> None:  # type: ignore[no-untyped-def]
     """``compare`` folds ``--depth`` into the collect mode for snapshot inputs;
-    ``symbols`` clears headers, deeper rungs resolve without error."""
+    ``binary`` clears headers, deeper rungs resolve without error."""
     old = _snap(tmp_path, "libx", "1.0", [_fn("a"), _fn("b")])
     new = _snap(tmp_path, "libx", "2.0", [_fn("a"), _fn("b")])
     res = CliRunner().invoke(main, ["compare", str(old), str(new), "--depth", depth])
@@ -266,10 +280,10 @@ def test_compare_collect_mode_deprecation_warns(tmp_path) -> None:  # type: igno
     assert "deprecated" in _all_output(res)
 
 
-@pytest.mark.parametrize("depth", ["symbols", "headers"])
+@pytest.mark.parametrize("depth", ["binary", "headers"])
 def test_deep_compare_depth_over_snapshots(tmp_path, depth: str) -> None:  # type: ignore[no-untyped-def]
     """``deep-compare`` passes snapshot inputs straight through; ``--depth
-    symbols`` clears headers, the non-symbols branch leaves them as-is."""
+    binary`` clears headers, the non-binary branch leaves them as-is."""
     import abicheck.cli_max  # noqa: F401
 
     old = _snap(tmp_path, "libz", "1.0", [_fn("a")])
@@ -293,13 +307,13 @@ def test_dump_source_only_collect_mode_warns(tmp_path) -> None:  # type: ignore[
     assert "deprecated" in _all_output(res)
 
 
-def test_dump_source_only_depth_symbols(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    """``dump --depth symbols`` resolves and runs the symbols-only branch."""
+def test_dump_source_only_depth_binary(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``dump --depth binary`` resolves and runs the symbols-only branch."""
     src = tmp_path / "src2"
     src.mkdir()
     res = CliRunner().invoke(
         main,
-        ["dump", "--sources", str(src), "--depth", "symbols",
+        ["dump", "--sources", str(src), "--depth", "binary",
          "-o", str(tmp_path / "out2.json")],
     )
     # Resolution + symbols-clearing ran; a source-only symbols dump writes an

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -320,3 +320,26 @@ def test_dump_source_only_depth_binary(tmp_path) -> None:  # type: ignore[no-unt
     # L0-L2 snapshot and exits clean.
     assert res.exit_code == 0, _all_output(res)
     assert (tmp_path / "out2.json").is_file()
+
+
+def test_dump_depth_binary_ignores_compile_db(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """``dump --depth binary`` discards a -H + --compile-db invocation's L2 inputs:
+    it must NOT abort on the compile-DB header requirement just because binary depth
+    cleared the headers (Codex review)."""
+    hdr = tmp_path / "foo.h"
+    hdr.write_text("int foo(void);\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text("[]", encoding="utf-8")
+    res = CliRunner().invoke(
+        main,
+        [
+            "dump", "/no/such/bin.so", "-H", str(hdr), "--compile-db", str(cdb),
+            "--depth", "binary", "-o", str(tmp_path / "o.json"),
+        ],
+    )
+    # The compile-DB-requires-headers UsageError must not fire (it would block the
+    # switch to the fast binary rung). Any later failure is the missing binary, not
+    # this validation.
+    out = _all_output(res)
+    assert "Compilation database" not in out
+    assert "requires -H" not in out

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -338,8 +338,26 @@ def test_cli_estimate_json(runner: CliRunner, snap_path: Path) -> None:
     assert "total_est_seconds" in payload
 
 
+def _minimal_compile_db(tmp_path: Path) -> Path:
+    """A minimal compile_commands.json (L3 build metadata; pure parsing).
+
+    Supplies source evidence so a pinned deep --source-method does not trip
+    auto-strict (ADR-037 D5: a pinned depth with no source input errors).
+    """
+    src = tmp_path / "u.c"
+    src.write_text("int u(void){return 0;}\n", encoding="utf-8")
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"directory": str(tmp_path), "file": str(src), "command": "cc -c u.c"}]
+        ),
+        encoding="utf-8",
+    )
+    return cdb
+
+
 def test_replay_seed_empty_without_diff_seed(
-    monkeypatch, runner: CliRunner, snap_path: Path, header: Path
+    monkeypatch, runner: CliRunner, snap_path: Path, header: Path, tmp_path: Path
 ) -> None:
     # No --since/--changed-path → broad scope. Pattern-trigger POIs must NOT
     # narrow the replay seed (would skip source-only checks in other TUs) — the
@@ -364,14 +382,16 @@ def test_replay_seed_empty_without_diff_seed(
             str(header),
             "--source-method",
             "s5",
+            "--build-info",
+            str(_minimal_compile_db(tmp_path)),
         ],
     )
-    assert res.exit_code == 0
+    assert res.exit_code == 0, res.output
     assert captured["changed_paths"] == ()
 
 
 def test_replay_seed_used_when_changed_path_given(
-    monkeypatch, runner: CliRunner, snap_path: Path, header: Path
+    monkeypatch, runner: CliRunner, snap_path: Path, header: Path, tmp_path: Path
 ) -> None:
     # An explicit --changed-path is a real diff seed → the POI floor feeds the
     # replay scope.
@@ -395,11 +415,13 @@ def test_replay_seed_used_when_changed_path_given(
             str(header),
             "--source-method",
             "s5",
+            "--build-info",
+            str(_minimal_compile_db(tmp_path)),
             "--changed-path",
             "src/a.cpp",
         ],
     )
-    assert res.exit_code == 0
+    assert res.exit_code == 0, res.output
     assert "src/a.cpp" in (captured["changed_paths"] or ())
 
 

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -549,3 +549,17 @@ def test_run_scan_auto_default_without_evidence_is_best_effort(snap_path: Path) 
 
     res = run_scan(ScanRequest(binaries=[snap_path], mode="audit"))
     assert res.verdict != "EVIDENCE_CONTRACT_ERROR"
+
+
+def test_service_accepts_symbols_depth_alias(snap_path: Path) -> None:
+    # The deprecated `symbols` depth spelling must not crash the programmatic API
+    # (it's only normalized by the CLI DEPTH_PARAM otherwise) — Codex review.
+    from abicheck.service import run_scan
+    from abicheck.service_scan import estimate_scan
+
+    # estimate_scan + run_scan both construct EvidenceDepth from req.depth.
+    est = estimate_scan(ScanRequest(binaries=[snap_path], depth="symbols"))
+    assert est  # non-empty cost estimate, no ValueError
+    res = run_scan(ScanRequest(binaries=[snap_path], depth="symbols", mode="audit"))
+    # `symbols`→`binary` is L0/L1 only (collect_mode off) → no contract error.
+    assert res.verdict != "EVIDENCE_CONTRACT_ERROR"

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -530,3 +530,22 @@ def test_run_scan_confidence_matrix_present(snap_path: Path) -> None:
     # The provider-agreement matrix is populated for run checks.
     assert isinstance(res.confidence, dict)
     assert "exported_not_public" in res.confidence
+
+
+def test_run_scan_pinned_depth_without_evidence_is_contract_error(snap_path: Path) -> None:
+    # ADR-037 D5 auto-strict applies to the programmatic API too: a pinned deep
+    # depth with no source input maps to a failed ScanResult (not a silent shallow
+    # scan), mirroring the CLI (CodeRabbit/Codex review).
+    from abicheck.service import run_scan
+
+    res = run_scan(ScanRequest(binaries=[snap_path], depth="source"))
+    assert res.exit_code == 1
+    assert res.verdict == "EVIDENCE_CONTRACT_ERROR"
+
+
+def test_run_scan_auto_default_without_evidence_is_best_effort(snap_path: Path) -> None:
+    # The unpinned default never trips the contract — best-effort binary scan.
+    from abicheck.service import run_scan
+
+    res = run_scan(ScanRequest(binaries=[snap_path], mode="audit"))
+    assert res.verdict != "EVIDENCE_CONTRACT_ERROR"

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -338,6 +338,40 @@ def test_cli_estimate_json(runner: CliRunner, snap_path: Path) -> None:
     assert "total_est_seconds" in payload
 
 
+def test_estimate_pr_deep_preserves_graph_full_depth(
+    runner: CliRunner, snap_path: Path
+) -> None:
+    # pr-deep pins (s5, graph) = graph-full; the CLI estimate must not collapse it
+    # to source-changed by re-resolving the round-tripped flags under the
+    # source-method > depth precedence (Codex review).
+    res = runner.invoke(
+        main, ["scan", "--estimate", "--mode", "pr-deep", "--binary", str(snap_path)]
+    )
+    assert res.exit_code == 0, res.output
+    assert "graph-full" in res.output
+    assert "source-changed replay scope" not in res.output
+
+
+def test_estimate_scan_honors_resolved_level(snap_path: Path) -> None:
+    # estimate_scan honors a caller-supplied resolved (method, depth) verbatim: the
+    # (s5, graph) pr-deep pair stays graph-full, whereas re-resolving the same req
+    # applies precedence and collapses to source-changed (Codex review).
+    from abicheck.buildsource.scan_levels import EvidenceDepth, SourceMethod
+    from abicheck.service_scan import estimate_scan
+
+    req = ScanRequest(
+        binaries=[snap_path], mode="pr-deep", source_method="s5", depth="graph"
+    )
+    reresolved = " ".join(e.note for e in estimate_scan(req))
+    pinned = " ".join(
+        e.note
+        for e in estimate_scan(req, resolved_level=(SourceMethod.S5, EvidenceDepth.GRAPH))
+    )
+    assert "source-changed" in reresolved  # the round-trip hazard this guards
+    assert "graph-full" in pinned
+    assert "source-changed" not in pinned
+
+
 def _minimal_compile_db(tmp_path: Path) -> Path:
     """A minimal compile_commands.json (L3 build metadata; pure parsing).
 
@@ -579,6 +613,37 @@ def test_run_scan_binary_depth_suppresses_headers(
     assert res.verdict != "EVIDENCE_CONTRACT_ERROR"
     # Headers were dropped before reaching the core — no L2 header parse.
     assert captured["headers"] == []
+
+
+def test_run_scan_source_method_overrides_binary_keeps_headers(
+    monkeypatch, snap_path: Path, header: Path
+) -> None:
+    # Service parity with the CLI (Codex review): --source-method wins over --depth,
+    # so source_method="s5" + depth="binary" resolves to a SOURCE scan that keeps
+    # the header AST — suppression keys on the *resolved* depth, not the raw one.
+    import abicheck.cli_scan as cs
+    from abicheck.service import run_scan
+
+    captured: dict[str, object] = {}
+    original = cs.run_scan_core
+
+    def _spy(*args, **kwargs):
+        captured["headers"] = kwargs.get("headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "run_scan_core", _spy)
+    # s5 with no compile DB → pinned-depth contract error, but run_scan_core still
+    # receives the (un-suppressed) headers.
+    run_scan(
+        ScanRequest(
+            binaries=[snap_path],
+            source_method="s5",
+            depth="binary",
+            headers=[header],
+            mode="audit",
+        )
+    )
+    assert captured["headers"] == [header]
 
 
 def test_service_accepts_symbols_depth_alias(snap_path: Path) -> None:

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -551,6 +551,36 @@ def test_run_scan_auto_default_without_evidence_is_best_effort(snap_path: Path) 
     assert res.verdict != "EVIDENCE_CONTRACT_ERROR"
 
 
+def test_run_scan_binary_depth_suppresses_headers(
+    monkeypatch, snap_path: Path, header: Path
+) -> None:
+    # Codex P2: a programmatic ScanRequest(depth="binary", headers=[...]) must not
+    # parse the L2 header AST — the service mirrors the CLI's `--depth binary`
+    # header suppression so the collected evidence matches the reported depth.
+    import abicheck.cli_scan as cs
+    from abicheck.service import run_scan
+
+    captured: dict[str, object] = {}
+    original = cs.run_scan_core
+
+    def _spy(*args, **kwargs):
+        captured["headers"] = kwargs.get("headers")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cs, "run_scan_core", _spy)
+    res = run_scan(
+        ScanRequest(
+            binaries=[snap_path],
+            depth="binary",
+            headers=[header],
+            mode="audit",
+        )
+    )
+    assert res.verdict != "EVIDENCE_CONTRACT_ERROR"
+    # Headers were dropped before reaching the core — no L2 header parse.
+    assert captured["headers"] == []
+
+
 def test_service_accepts_symbols_depth_alias(snap_path: Path) -> None:
     # The deprecated `symbols` depth spelling must not crash the programmatic API
     # (it's only normalized by the CLI DEPTH_PARAM otherwise) — Codex review.

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -352,6 +352,39 @@ def test_estimate_pr_deep_preserves_graph_full_depth(
     assert "source-changed replay scope" not in res.output
 
 
+def test_count_bazel_build_info_tus_branches(monkeypatch, tmp_path: Path) -> None:
+    # Cover the helper's branches directly: non-file, non-Bazel (compile DB array),
+    # the cquery route, and the best-effort guard that swallows any adapter/sniff
+    # failure into None so the estimate never raises (Codex review).
+    from abicheck.service_scan import _count_bazel_build_info_tus
+
+    assert _count_bazel_build_info_tus(tmp_path / "nope.json") is None
+
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [{"file": "a.c", "command": "cc -c a.c", "directory": str(tmp_path)}]
+        ),
+        encoding="utf-8",
+    )
+    assert _count_bazel_build_info_tus(cdb) is None  # not Bazel → compile-DB path
+
+    cq = tmp_path / "cq.json"
+    cq.write_text(
+        json.dumps({"results": [{"target": {"rule": {"name": "//foo:foo"}}}]}),
+        encoding="utf-8",
+    )
+    assert _count_bazel_build_info_tus(cq) == 0  # cquery route, no compile actions
+
+    def _boom(_p):
+        raise RuntimeError("adapter blew up")
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.inline.sniff_build_info_format", _boom
+    )
+    assert _count_bazel_build_info_tus(cq) is None  # guard swallows the failure
+
+
 def test_estimate_counts_bazel_build_info_tus(snap_path: Path, tmp_path: Path) -> None:
     # A Bazel aquery --build-info is replayed via BazelAdapter by the real scan, so
     # the estimate must count its compile actions instead of routing the JSON object

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -352,6 +352,48 @@ def test_estimate_pr_deep_preserves_graph_full_depth(
     assert "source-changed replay scope" not in res.output
 
 
+def test_estimate_counts_bazel_build_info_tus(snap_path: Path, tmp_path: Path) -> None:
+    # A Bazel aquery --build-info is replayed via BazelAdapter by the real scan, so
+    # the estimate must count its compile actions instead of routing the JSON object
+    # through the compile-DB counter and reporting 0 TUs (Codex review).
+    from abicheck.service_scan import estimate_scan
+
+    aquery = tmp_path / "aq.json"
+    aquery.write_text(
+        json.dumps(
+            {
+                "artifacts": [
+                    {"id": "1", "pathFragmentId": "10"},
+                    {"id": "2", "pathFragmentId": "11"},
+                ],
+                "actions": [
+                    {
+                        "targetId": "100",
+                        "mnemonic": "CppCompile",
+                        "arguments": ["/usr/bin/gcc", "-std=c++17", "-c", "foo/foo.cc"],
+                        "primaryOutputId": "2",
+                    }
+                ],
+                "targets": [{"id": "100", "label": "//foo:foo"}],
+                "pathFragments": [
+                    {"id": "10", "label": "foo.cc", "parentId": "20"},
+                    {"id": "11", "label": "foo.o", "parentId": "20"},
+                    {"id": "20", "label": "foo"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    est = estimate_scan(
+        ScanRequest(
+            binaries=[snap_path], build_info=aquery, depth="source", mode="audit"
+        )
+    )
+    l3 = next(e for e in est if e.layer == "L3_build")
+    assert l3.tus >= 1  # the CppCompile action counted, not 0
+    assert any("Bazel" in e.note for e in est)
+
+
 def test_estimate_binary_depth_suppresses_header_cost(
     snap_path: Path, header: Path
 ) -> None:

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -427,6 +427,60 @@ def test_estimate_counts_bazel_build_info_tus(snap_path: Path, tmp_path: Path) -
     assert any("Bazel" in e.note for e in est)
 
 
+def test_estimate_compile_db_overrides_bazel_build_info(
+    snap_path: Path, tmp_path: Path
+) -> None:
+    # When both --compile-db and a Bazel --build-info are given, the real scan uses
+    # `req.compile_db or req.build_info` (compile DB wins); the estimate must mirror
+    # that and count the compile DB's TUs, not the Bazel action graph (Codex review).
+    from abicheck.service_scan import estimate_scan
+
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [
+                {"file": "a.c", "command": "cc -c a.c", "directory": str(tmp_path)},
+                {"file": "b.c", "command": "cc -c b.c", "directory": str(tmp_path)},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    aq = tmp_path / "aq.json"  # a Bazel aquery with a single CppCompile (1 TU)
+    aq.write_text(
+        json.dumps(
+            {
+                "artifacts": [{"id": "2", "pathFragmentId": "11"}],
+                "actions": [
+                    {
+                        "targetId": "100",
+                        "mnemonic": "CppCompile",
+                        "arguments": ["/usr/bin/gcc", "-c", "foo/foo.cc"],
+                        "primaryOutputId": "2",
+                    }
+                ],
+                "targets": [{"id": "100", "label": "//foo:foo"}],
+                "pathFragments": [
+                    {"id": "11", "label": "foo.o", "parentId": "20"},
+                    {"id": "20", "label": "foo"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    est = estimate_scan(
+        ScanRequest(
+            binaries=[snap_path],
+            compile_db=cdb,
+            build_info=aq,
+            depth="source",
+            mode="audit",
+        )
+    )
+    l3 = next(e for e in est if e.layer == "L3_build")
+    assert l3.tus == 2  # the 2-TU compile DB, not the 1-action Bazel graph
+    assert not any("Bazel" in e.note for e in est)
+
+
 def test_estimate_binary_depth_suppresses_header_cost(
     snap_path: Path, header: Path
 ) -> None:

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -352,6 +352,30 @@ def test_estimate_pr_deep_preserves_graph_full_depth(
     assert "source-changed replay scope" not in res.output
 
 
+def test_estimate_binary_depth_suppresses_header_cost(
+    snap_path: Path, header: Path
+) -> None:
+    # The estimate must mirror the real scan: --depth binary suppresses the L2
+    # header AST, so the embedded ScanResult.estimate (and any direct caller) must
+    # not price an L2_header layer for suppressed headers (Codex review).
+    from abicheck.service_scan import estimate_scan
+
+    binary = estimate_scan(
+        ScanRequest(binaries=[snap_path], depth="binary", headers=[header], mode="audit")
+    )
+    l2 = next(e for e in binary if e.layer == "L2_header")
+    assert l2.tus == 0
+    assert l2.est_seconds == 0.0
+    # Control: a --depth headers scan with the same header DOES price the L2 layer.
+    headers_depth = estimate_scan(
+        ScanRequest(
+            binaries=[snap_path], depth="headers", headers=[header], mode="audit"
+        )
+    )
+    l2b = next(e for e in headers_depth if e.layer == "L2_header")
+    assert l2b.tus >= 1
+
+
 def test_estimate_scan_honors_resolved_level(snap_path: Path) -> None:
     # estimate_scan honors a caller-supplied resolved (method, depth) verbatim: the
     # (s5, graph) pr-deep pair stays graph-full, whereas re-resolving the same req


### PR DESCRIPTION
## What & why

The final three scan-UX hardening items (ADR-037 D5), in one PR off the merged `main`.

### #6 — one dial, named by evidence
`--depth {binary,headers,build,source,full}` is now the **single visible knob** for scan depth — named by what you get (binary = L0/L1 symbols, headers = +L2 AST, build = +L3, source = +L4 replay & the L5 graph, full = deepest). **Omit it for `auto`** (the default): risk-driven when a `--since`/`--changed-path` seed is present, else a sensible preset. `--audit` stays the orthogonal no-baseline lint.
- `--mode` and `--source-method` are now **hidden, deprecated warned aliases** that map onto `--depth` for one release (the `s0…s6` / `L0…L5` model is still the spine; `--depth` is its façade).
- The L0/L1 rung was renamed **`symbols`→`binary`** (evidence-named); `symbols` keeps working as a warned alias.

### #2 — auto-strict (a pinned depth is a contract)
Pinning a deep depth (`build`/`source`/`full`) with **no source input** (`--sources`/`--build-info`) now **errors** with the remedy instead of silently degrading to a shallow binary scan — there's nothing to collect L3/L4/L5 from. The default `auto` never errors this way, and the case where input *was* supplied but L3 was uncollectable keeps its pointed advisory. The engine raises a framework-free `_EvidenceContractError`; the CLI maps it to a clean exit‑1 `ClickException`, `service.run_scan` to a failed `ScanResult`.

### #5 — `--build-info` format sniffing
`--build-info` classifies its argument by content (`sniff_build_info_format`): a `compile_commands.json` (JSON array), a Bazel `--output=jsonproto` **aquery**/**cquery** (object keyed by `actions`/`results`), a build **directory**, or a `collect` **pack**. A pre-captured Bazel query is routed to the Bazel adapter instead of being mis-parsed as a compile DB.

## Behavior changes (intentional, fail-loud-aligned)
1. `--mode`/`--source-method` print a one-line deprecation note (still work).
2. `--depth symbols` → emits the rename note and resolves to `binary`.
3. A pinned deep depth with no `--sources`/`--build-info` now errors (was a silent shallow scan).

## Tests
New `test_build_info_sniffing.py`; depth-vocabulary updated for the `binary` rung + `symbols` alias; `test_pinned_depth_without_evidence_errors` + auto-default; migrated the existing `--source-method`/`--mode` scan tests to `--depth` (plus a `_payload` helper tolerating the alias note in CliRunner's mixed output, and a minimal `compile_db` fixture for pinned-level reporting tests). Full fast suite green (11,530), `ruff`, `mypy abicheck` (0), `check_ai_readiness` (0 errors), `mkdocs --strict` all pass.

## Docs
`docs/user-guide/scan-levels.md` reframed around the single `--depth` dial, with the fail-loud "pinned = contract" warning and the `--build-info` auto-detect note; `--depth symbols`→`binary` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmCKUCjSMr831W6pETGmfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmCKUCjSMr831W6pETGmfd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced `--build-info` auto-detection with Bazel jsonproto recognition and correct routing/collection.
* **Bug Fixes & Improvements**
  * Strengthened pinned deep-level “evidence contract” behavior with clearer remedies and consistent exit/verdict handling.
  * `--estimate` and scan now honor the resolved depth/source-method; `--depth binary` suppresses header AST collection.
  * Improved CLI JSON output robustness and updated scan behavior for contract/advisory cases.
* **Deprecations**
  * `--depth symbols` is now treated as `--depth binary` (alias retained); deprecated `--mode`/`--source-method` warnings only when explicitly set.
* **Documentation**
  * Updated scan-level guide for the revised `--depth` ladder and `--build-info` examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->