### PR TITLE
docs(validation): oneAPI conda-forge scan UX run (2026-06)

### DIFF
--- a/validation/data/oneapi-conda-scan-2026-06.json
+++ b/validation/data/oneapi-conda-scan-2026-06.json
@@ -1,0 +1,106 @@
+{
+  "schema": "oneapi-conda-scan.v1",
+  "date": "2026-06-21",
+  "abicheck_version": "0.4.0",
+  "host": {
+    "os": "Linux 6.18.5 x86_64",
+    "python": "3.11.15",
+    "ast_frontend": "clang (clang-18; castxml absent)",
+    "cpu": 4,
+    "note": "ABICHECK_AST_FRONTEND=clang for every run; castxml not on PATH."
+  },
+  "method": {
+    "binaries": "conda-forge linux-64 .conda packages (extracted with zstandard)",
+    "headers": "matching conda-forge -devel / -include packages",
+    "sources": "github.com/uxlfoundation/<lib> shallow clone at the matching tag",
+    "command": "abicheck scan --binary <lib> -H <umbrella-header> -I <include> --public-header-dir <include> --lang c++ --audit --depth <D> [--sources <tree>]"
+  },
+  "subjects": [
+    {
+      "lib": "oneTBB",
+      "conda_pkg": "tbb 2023.0.0 (hab88423_2) + tbb-devel",
+      "binary": "libtbb.so.12.18",
+      "binary_size": "388K",
+      "tbb_interface_version": 12180,
+      "git_tag": "v2023.0.0",
+      "umbrella_header": "oneapi/tbb.h",
+      "source_files": 688,
+      "source_mb": 7.7,
+      "extensionless_files": 23,
+      "l0_functions": 24603,
+      "l0_variables": 1214,
+      "l2_types": 913
+    },
+    {
+      "lib": "oneDNN",
+      "conda_pkg": "onednn 3.12 (omp_h83de36e_0)",
+      "binary": "libdnnl.so.3.12",
+      "binary_size": "72M",
+      "git_tag": "v3.12",
+      "umbrella_header": "dnnl.hpp",
+      "source_files": 3867,
+      "source_mb": 67.1,
+      "extensionless_files": 827,
+      "l0_functions": 13127,
+      "l0_variables": 290,
+      "l2_types": 518
+    },
+    {
+      "lib": "oneDAL",
+      "conda_pkg": "dal 2026.1.0 (h74c4b1a_14) + dal-include",
+      "binary": "libonedal.so.4",
+      "binary_size": "11M",
+      "git_tag": "2026.1.0",
+      "umbrella_header": "oneapi/dal.hpp",
+      "source_files": 3072,
+      "source_mb": 15.9,
+      "extensionless_files": 192,
+      "l0_functions": 20708,
+      "l0_variables": 1126,
+      "l2_types": 954
+    },
+    {
+      "lib": "oneCCL",
+      "conda_pkg": "oneccl-devel 2022.0.0 (h7a4b287_49302)",
+      "binary": "libccl.a (STATIC ARCHIVE — no .so on conda-forge)",
+      "git_tag": "2022.0.0",
+      "umbrella_header": "oneapi/ccl.hpp",
+      "source_files": 54,
+      "source_mb": 0.5,
+      "scannable": false,
+      "reject_reason": "static/import library archive (.a/.lib) not analysed by abicheck"
+    }
+  ],
+  "runs": [
+    {"lib": "oneTBB", "depth": "headers", "exit": 0, "elapsed_s": 10.0, "verdict": "COMPATIBLE", "layers": "L0,L1,L2,patternS3(1 file)"},
+    {"lib": "oneTBB", "depth": "build",   "exit": 0, "elapsed_s": 30.7, "verdict": "COMPATIBLE", "layers": "L0,L1,L2,patternS3(689 files/983 facts); L3/L4/L5 not_collected (no compile_commands.json)"},
+    {"lib": "oneTBB", "depth": "source",  "exit": 0, "elapsed_s": 30.9, "verdict": "COMPATIBLE", "layers": "same as build; L4/L5 not_collected"},
+    {"lib": "oneTBB", "depth": "full",    "exit": 0, "elapsed_s": 30.5, "verdict": "COMPATIBLE", "layers": "same as build"},
+    {"lib": "oneDNN", "depth": "headers", "exit": 0, "elapsed_s": 11.4, "verdict": "COMPATIBLE", "layers": "L0,L1,L2"},
+    {"lib": "oneDNN", "depth": "build",   "exit": 124, "elapsed_s": 900.0, "verdict": null, "note": "TIMED OUT in always-on lexical pattern pre-scan (single-threaded, whole 67 MB / 3867-file tree)"},
+    {"lib": "oneDNN", "depth": "build", "scoped": true, "changed_path": "include/oneapi/dnnl/dnnl.hpp", "exit": 0, "elapsed_s": 9.2, "verdict": "COMPATIBLE", "note": "pattern scan scoped to 1 file by --changed-path"},
+    {"lib": "oneDAL", "depth": "headers", "exit": 0, "elapsed_s": 11.0, "verdict": "COMPATIBLE", "layers": "L0,L1,L2"},
+    {"lib": "oneDAL", "depth": "build",   "exit": 124, "elapsed_s": 600.0, "verdict": null, "note": "TIMED OUT in pattern pre-scan; 16 MB / 3072-file tree, even slower per-byte than oneDNN"},
+    {"lib": "oneCCL", "depth": "headers", "exit": 1, "elapsed_s": 0.4, "verdict": null, "note": "rejected: static archive libccl.a is not a linkable image"}
+  ],
+  "pattern_scan_breakdown_onednn": {
+    "total_files_seen_by_iter_source_files": 3867,
+    "total_mb": 67.1,
+    "extensionless_files": 827,
+    "biggest_extensionless": [
+      ["src/oneDNN/tests/benchdnn/inputs/conv/option_set_fwks_ext_gpu", 3475375],
+      ["src/oneDNN/tests/benchdnn/inputs/matmul/option_set_fwks_llm_gpu", 1656415],
+      ["src/oneDNN/.git/index", 522827]
+    ],
+    "pathological_regex_files": 0,
+    "diagnosis": "no catastrophic backtracking; cost is pure volume x single-thread. third_party/, tests/ (incl. multi-MB benchdnn data fixtures matched by the extensionless-header heuristic) and .git/ are all walked and regex-scanned."
+  },
+  "provenance_bug": {
+    "symptom": "scan --audit reports 4 crosschecks (exported_not_public, public_not_exported, private_header_leak, rtti_for_internal_type) as 'skipped: no public-header provenance' on EVERY ELF run, even with --public-header-dir given.",
+    "root_cause": "service.resolve_input -> _dump_elf never receives/applies public_headers/public_header_dirs (apply_provenance runs only on the PE/Mach-O path via _apply_native_provenance). scan builds its snapshot through service.resolve_input, so ELF origins stay UNKNOWN. The dump/compare CLI path (cli_resolve._resolve_input) DOES call apply_provenance, so `dump` classifies correctly.",
+    "evidence": {
+      "dump_tbb_origins": {"functions": {"system_header": 21163, "public_header": 3440}, "types": {"system_header": 536, "public_header": 377}},
+      "resolve_input_tbb_origins": {"functions": {"unknown": 24603}, "types": {"unknown": 913}, "origin_resolvable": false}
+    }
+  }
+}

--- a/validation/oneapi-conda-scan-experience-2026-06.md
+++ b/validation/oneapi-conda-scan-experience-2026-06.md
@@ -1,0 +1,122 @@
+# oneAPI conda-forge `scan` UX run — findings & follow-ups (2026-06)
+
+A real `abicheck scan` 0.4.0 run over four oneAPI / UXL Foundation libraries,
+**binaries from conda-forge, sources from GitHub**, exercising L2 and every
+deeper source-scan depth. The brief was deliberately **not** "find ABI bugs in
+the libraries" but "stress the scanner itself — UX, ergonomics, and operational
+failure modes — on inputs we did not hand-pick." Raw per-run data in
+[`data/oneapi-conda-scan-2026-06.json`](data/oneapi-conda-scan-2026-06.json).
+
+This is complementary to [`uxl-scan-levels-timing-2026-06.md`](uxl-scan-levels-timing-2026-06.md)
+(which measured the *compare* cost model on curated version pairs); here every
+run is a single-version `scan --audit` on an as-shipped conda binary against its
+upstream source tree.
+
+## Setup
+
+| | |
+|---|---|
+| Host | Linux x86_64, Python 3.11, **clang-18 only (no castxml)** → every run forced `ABICHECK_AST_FRONTEND=clang` |
+| Binaries | conda-forge `linux-64` `.conda` packages, extracted with `zstandard` (no `conda`/`zstd` on the box) |
+| Headers | matching conda-forge `*-devel` / `*-include` packages |
+| Sources | `github.com/uxlfoundation/<lib>` shallow clone at the tag matching the conda version |
+| Command | `abicheck scan --binary <lib> -H <umbrella.h> -I <include> --public-header-dir <include> --lang c++ --audit --depth <D> [--sources <tree>]` |
+
+| Library | conda pkg | binary | git tag | L0 funcs / vars | L2 types | source files / MB |
+|---|---|---|---|---|---|---|
+| oneTBB | `tbb 2023.0.0` | `libtbb.so.12.18` (388 K) | `v2023.0.0` | 24 603 / 1 214 | 913 | 688 / 7.7 |
+| oneDNN | `onednn 3.12` (omp) | `libdnnl.so.3.12` (72 M) | `v3.12` | 13 127 / 290 | 518 | 3 867 / 67.1 |
+| oneDAL | `dal 2026.1.0` | `libonedal.so.4` (11 M) | `2026.1.0` | 20 708 / 1 126 | 954 | 3 072 / 15.9 |
+| oneCCL | `oneccl-devel 2022.0.0` | **`libccl.a` (static only)** | `2022.0.0` | — | — | 54 / 0.5 |
+
+## Timing (audit, no diff seed)
+
+| Library | headers (L2) | build (L3) | source (L4/L5) | full |
+|---|---|---|---|---|
+| oneTBB | 10.0 s | 30.7 s | 30.9 s | 30.5 s |
+| oneDNN | 11.4 s | **TIMEOUT > 900 s** | (same root cause) | (same root cause) |
+| oneDNN *(+`--changed-path`)* | — | **9.2 s** | — | — |
+| oneDAL | 11.0 s | **TIMEOUT > 600 s** | (same root cause) | (same root cause) |
+| oneCCL | n/a (static archive) | — | — | — |
+
+Two of the three shared libraries (oneDNN, oneDAL) could not complete a single
+`--depth build` audit within a 600–900 s budget; oneTBB (a 7.7 MB tree) finished
+in ~30 s. The cliff is the source tree size the pattern pre-scan must chew
+through, **not** the binary or the depth itself.
+
+Verdict was **COMPATIBLE** for every run that completed — expected, since these
+are single-version audits with no baseline to break against. The exercise was
+about *getting a clean run at all*, and that is where the friction lives.
+
+## Conclusions (what the run actually taught us)
+
+1. **L2 works and is fast and uniform** — 10–11 s to dump a 11–72 MB stripped
+   conda `.so` + parse its public umbrella header with the clang backend, across
+   all three shared libraries. The coverage table (`L0…L5` present/not_collected
+   with a remedy string per row) is genuinely good UX.
+2. **The headline `scan --audit` hygiene checks silently do nothing on ELF**
+   (P1, High) — a real wiring bug, not a coverage gap. `--public-header-dir` is
+   dropped on the ELF snapshot path, so 4 of the 8 cross-checks report "skipped:
+   no public-header provenance" on *every* run even when you supply it.
+3. **Source-depth audit has no scope guard and no progress output** (P2, High) —
+   on oneDNN the always-on lexical pattern pre-scan walked the entire 67 MB /
+   3 867-file tree single-threaded and ran past 900 s with zero output, looking
+   exactly like a hang; oneDAL (16 MB) timed out the same way past 600 s. The fix
+   the user must discover is `--changed-path` / `--since` (900 s → 9 s), but
+   nothing tells them that.
+4. **Getting L2 to parse at all takes non-obvious flag archaeology** (P3, Med) —
+   pointing `-H` at the include *directory* (the natural first try) fails on
+   real libraries (preview headers with `#error` guards, unresolved relative
+   includes). You must instead pass the single umbrella header as `-H` **and**
+   re-add the directory as `-I` **and** `--public-header-dir`.
+5. **`--depth build/source/full` collect nothing without a compile DB** (P4,
+   Med) — pointing `--sources` at an unbuilt checkout (the common case) silently
+   degrades L3/L4/L5 to "not_collected"; only the lexical pattern tier runs. The
+   message is clear, but the deep depths are effectively unreachable for anyone
+   who has not already done a CMake build with `-DCMAKE_EXPORT_COMPILE_COMMANDS`.
+6. **conda-forge availability is uneven** (P5, Low) — oneCCL ships only a static
+   `libccl.a` (no `.so`), so it cannot be scanned as a shared-library subject at
+   all; oneDAL's headers live in a *third* package (`dal-include`) separate from
+   both `dal` and `dal-devel`. Neither is abicheck's fault, but both are real
+   onboarding cliffs for "scan my conda library."
+
+## Open problems & status
+
+| # | Sev | Status | Problem & evidence |
+|---|-----|--------|--------------------|
+| **P1** | High | ⏳ open (bug) | **`--public-header-dir` is ignored on the ELF `scan` path → 4 cross-checks always skip.** `scan` builds its snapshot via `service.resolve_input` → `_dump_elf`, which never forwards `public_headers`/`public_header_dirs`; `apply_provenance` runs only on the PE/Mach-O branch (`_apply_native_provenance`). The `dump`/`compare` CLI applies provenance separately (`cli_resolve._resolve_input`), so the two paths disagree. **Reproduced:** `abicheck dump <tbb.so> --public-header-dir <inc>` → 3 440 PUBLIC functions / 377 PUBLIC types; the identical args through `service.resolve_input` → **all 24 603 UNKNOWN**, `_origin_resolvable=False`. Net effect: `exported_not_public`, `public_not_exported`, `private_header_leak`, `rtti_for_internal_type` (the ADR-035 D8 single-release hygiene audit — the *reason* to run `scan --audit`) never fire on any ELF library. Contradicts the "cross-checks now run" status of P1 in `uxl-scan-levels-timing-2026-06.md` for the `scan` entry point specifically. |
+| **P2** | High | ⏳ open | **Whole-tree pattern pre-scan, single-threaded, no cap, no progress → looks hung on big repos.** oneDNN `--depth build` timed out > 900 s; py-spy showed it pinned in `pattern_scan.scan_text`. **Not** catastrophic backtracking — a full bounded sweep found 0 files > 2 s. It is pure volume: `iter_source_files` walks the entire `--sources` tree with no exclusion of `third_party/`, `tests/`, or `.git/`, and `_is_scannable` also accepts **extensionless** files — on oneDNN that pulls in 827 extensionless files dominated by multi-MB benchdnn *test-data fixtures* (`tests/benchdnn/inputs/conv/option_set_fwks_ext_gpu` = 3.4 MB) and `.git/index` (522 KB), all run through every ABI regex. Single-threaded at ~0.4 MB/s over 67 MB (oneDNN); oneDAL's 16 MB tree ran even slower per-byte and still blew the 600 s budget. Mitigations that would each help: skip VCS/build/vendor/test dirs by default, size/sniff-cap the extensionless heuristic, parallelize, and emit a progress line. |
+| **P3** | Med | ⏳ open | **No working `-H <dir>` story for real libraries.** `-H <include-dir>` (the obvious invocation) hard-fails on all three: oneTBB pulls in `blocked_rangeNd.h` (`#error Set TBB_PREVIEW_BLOCKED_RANGE_ND`) and can't resolve `oneapi/tbb/detail/_utils.h` because the include root isn't auto-added to the search path. Working recipe is the non-obvious triple: `-H <umbrella.h> -I <include> --public-header-dir <include>`. The dir-glob umbrella build should (a) add each `-H`/`-I` dir to the compiler search path automatically, and (b) skip/῾isolate headers that `#error` on missing preview macros rather than failing the whole TU. |
+| **P4** | Med | ⏳ open | **`--depth build/source/full` silently collect nothing from an unbuilt `--sources` tree.** No `compile_commands.json` ⇒ L3/L4/L5 = `not_collected`; only the lexical tier runs. Message names the remedy, but there is no auto-discovery of an in-tree build, and the deep depths are unreachable for the majority case (fresh checkout). Consider a `--depth headers`-equivalent fast path note, or an opt-in "configure-only" CMake probe to synthesize a compile DB. |
+| **P5** | Low | ⏳ open | **Onboarding cliffs from conda packaging (not abicheck bugs, but worth a docs/runbook note).** oneCCL on conda-forge is static-only (`libccl.a`) → `scan` correctly rejects it with a good message, but there is no shared-library subject to scan at all. oneDAL headers are in `dal-include`, a third package distinct from `dal` (runtime) and `dal-devel` (cmake/pkgconfig only). A "scanning a conda library" guide should call out: fetch the runtime pkg for the `.so`, the `*-include`/`*-devel` pkg for headers, and check for static-only packages. |
+| **P6** | Low | ⏳ open | **C-vs-C++ auto-detect warning fires on pure-`#include` umbrellas even with `--lang c++`.** oneTBB's `oneapi/tbb.h` (no inline code) triggered "clang failed to find a C++ standard header parsing in C mode … Retrying in C++ mode. Pass --lang c++" — but `--lang c++` *was* passed and is the `scan` default. The clang backend appears to probe C first regardless; the warning should be suppressed when `--lang c++` is explicit. |
+
+## Testing follow-ups
+
+- **P1:** an integration test that runs `scan --audit -H <umbrella> --public-header-dir <dir>`
+  on a *clang-only* host against an ELF fixture and asserts the four provenance
+  cross-checks report `present`/run (not `skipped`). Mirror the existing
+  `dump`-path provenance assertion so the two snapshot builders can't drift.
+- **P2:** a unit test that `iter_source_files` excludes `**/.git/**` and (by
+  default) `**/third_party/**` + `**/tests/**`, and a guard that the
+  extensionless-header heuristic is byte-capped (a 3.4 MB extensionless data
+  file is not a header). A perf smoke asserting a >1 GB-equivalent tree stays
+  under a wall-clock budget in `--audit` with no seed.
+- **P3:** a `scan -H <include-dir>` test on a tree containing a preview header
+  that `#error`s without a macro, asserting the scan still produces an L2
+  snapshot (the offending header isolated, not the whole TU failed).
+- **P6:** assert no C-mode warning is emitted when `--lang c++` is explicit.
+
+## Reproduction
+
+```bash
+# binaries (no conda needed): download + extract the conda-forge .conda zips
+#   tbb 2023.0.0 / onednn 3.12 / dal 2026.1.0 + dal-include / oneccl-devel 2022.0.0
+# sources: git clone --depth 1 --branch <tag> https://github.com/uxlfoundation/<lib>
+export ABICHECK_AST_FRONTEND=clang   # clang-only host
+abicheck scan --binary libtbb.so.12.18 \
+  -H include/oneapi/tbb.h -I include --public-header-dir include \
+  --lang c++ --audit --depth headers          # L2, ~10 s
+# deeper depths need a compile_commands.json under --sources; add
+#   --changed-path <file> or --since <ref> to keep the pattern pre-scan bounded.
+```

--- a/validation/oneapi-conda-scan-experience-2026-06.md
+++ b/validation/oneapi-conda-scan-experience-2026-06.md
@@ -109,14 +109,30 @@ about *getting a clean run at all*, and that is where the friction lives.
 
 ## Reproduction
 
+A `.conda` file is just a zip of zstd-compressed tarballs; extract the `pkg-*`
+member to recover the package's `lib/` + `include/` tree. The commands below
+assume you ran them from a single working directory so the relative paths
+resolve (oneTBB shown; the other three follow the same shape with their own
+umbrella header from the table above).
+
 ```bash
-# binaries (no conda needed): download + extract the conda-forge .conda zips
-#   tbb 2023.0.0 / onednn 3.12 / dal 2026.1.0 + dal-include / oneccl-devel 2022.0.0
-# sources: git clone --depth 1 --branch <tag> https://github.com/uxlfoundation/<lib>
-export ABICHECK_AST_FRONTEND=clang   # clang-only host
-abicheck scan --binary libtbb.so.12.18 \
+mkdir -p ~/oneapi-audit && cd ~/oneapi-audit
+
+# 1. binaries (no conda CLI needed): fetch + unpack the conda-forge .conda zips.
+#    Runtime .so lives in `tbb`; headers in `tbb-devel` (oneDAL headers are in a
+#    third pkg, `dal-include`). Pin: tbb 2023.0.0 / onednn 3.12 /
+#    dal 2026.1.0 + dal-include / oneccl-devel 2022.0.0.
+#    Each .conda → unzip → `pkg-*.tar.zst` → zstd -d | tar x  ==> ./lib ./include
+
+# 2. sources at the tag matching the conda version:
+git clone --depth 1 --branch v2023.0.0 https://github.com/uxlfoundation/oneTBB src/oneTBB
+
+export ABICHECK_AST_FRONTEND=clang        # clang-only host (no castxml)
+abicheck scan --binary lib/libtbb.so.12.18 \
   -H include/oneapi/tbb.h -I include --public-header-dir include \
-  --lang c++ --audit --depth headers          # L2, ~10 s
-# deeper depths need a compile_commands.json under --sources; add
-#   --changed-path <file> or --since <ref> to keep the pattern pre-scan bounded.
+  --lang c++ --audit --depth headers      # L2, ~10 s
+
+# deeper depths add --sources src/oneTBB and need a compile_commands.json under
+# it; also add --changed-path <file> or --since <ref> to keep the pattern
+# pre-scan bounded (see P2) — without a seed it scans the whole tree.
 ```


### PR DESCRIPTION
## What

A real `abicheck scan` 0.4.0 run over **oneTBB / oneDNN / oneDAL / oneCCL** — binaries from **conda-forge**, sources from **GitHub** at the matching tags — exercising **L2 and every deeper source-scan depth** on a clang-only host (no castxml). The brief was to stress-test the **scanner's UX and operational behaviour**, not to find ABI bugs in the libraries.

Adds:
- `validation/oneapi-conda-scan-experience-2026-06.md` — narrative findings + P-numbered problem tracker (matches the `uxl-scan-levels-timing-2026-06.md` house format)
- `validation/data/oneapi-conda-scan-2026-06.json` — raw per-run data

No source / behaviour changes — documentation only.

## Subjects & timing (audit, no diff seed)

| Library | binary (conda) | L2 (headers) | build (L3) |
|---|---|---|---|
| oneTBB | `libtbb.so.12.18` | 10.0 s | 30.7 s |
| oneDNN | `libdnnl.so.3.12` | 11.4 s | **TIMEOUT > 900 s** (→ 9.2 s with `--changed-path`) |
| oneDAL | `libonedal.so.4` | 11.0 s | **TIMEOUT > 600 s** |
| oneCCL | `libccl.a` (static only) | — rejected (no `.so` on conda-forge) | — |

L2 is fast and uniform across all three shared libraries; the friction is everything around it.

## Key findings

- **P1 (High, bug):** `--public-header-dir` is silently dropped on the ELF `scan` path. `scan` builds its snapshot via `service.resolve_input` → `_dump_elf`, which never forwards `public_headers`/`public_header_dirs`; `apply_provenance` runs only on the PE/Mach-O branch. So the four ADR-035 D8 single-release hygiene cross-checks (`exported_not_public`, `public_not_exported`, `private_header_leak`, `rtti_for_internal_type`) report **"skipped: no public-header provenance" on every ELF library**, even when the flag is given. **Reproduced:** `dump <tbb.so> --public-header-dir <inc>` → 3440 PUBLIC functions; the identical args through `service.resolve_input` → all 24603 UNKNOWN.
- **P2 (High):** the always-on lexical pattern pre-scan walks the **entire** `--sources` tree — including `.git/`, `tests/`, `third_party/`, and multi-MB **extensionless** benchdnn test-data fixtures (`option_set_fwks_ext_gpu` = 3.4 MB) — single-threaded with no progress output. Not catastrophic backtracking (a full sweep found 0 files > 2 s); pure volume. Looks exactly like a hang. `--changed-path` scopes it (900 s → 9 s).
- **P3–P6:** `-H <dir>` fails on real libraries (preview-header `#error` guards + unresolved relative includes — working recipe is the non-obvious `-H umbrella.h -I dir --public-header-dir dir` triple); `--depth build/source/full` collect nothing from an unbuilt `--sources` tree (no `compile_commands.json`); conda packaging cliffs (oneCCL static-only, oneDAL headers in a third `dal-include` package); a spurious C-mode warning despite `--lang c++`.

Each P-item carries a concrete testing follow-up in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9JvqdGEZwYpfDKqWdWiRq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new validation scan report data covering oneAPI/conda scan results and detailed scan-pattern/provenance outcomes.
  * Added a new validation/experience document describing an `abicheck scan --audit` workflow, observed timing/timeout behavior, and identified scan UX/stability issues with proposed follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->