### PR TITLE
fix(scan): header-ingestion ergonomics + deeper compile-DB discovery (P3–P6)

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -736,16 +736,18 @@ def _resolve_compile_db(
 
 
 def _compile_db_at(path: Path) -> Path | None:
-    """Resolve a build-info input to a concrete ``compile_commands.json``."""
+    """Resolve a build-info input to a concrete ``compile_commands.json``.
+
+    A directory is searched with the shared P4 strategy (hint dirs + any
+    immediate subdirectory) so ``--build-info <dir>`` honours the same contract
+    as ``--sources`` auto-discovery (Codex review).
+    """
     if path.is_file():
-        return path if path.name == _COMPILE_DB_NAME else path
+        # An explicit --build-info file is honoured as the compile DB whatever
+        # its name (the user pointed straight at it).
+        return path
     if path.is_dir():
-        for hint in _COMPILE_DB_HINTS:
-            candidate = (
-                (path / hint / _COMPILE_DB_NAME) if hint else (path / _COMPILE_DB_NAME)
-            )
-            if candidate.is_file():
-                return candidate
+        return _find_compile_db_in_dir(path)
     return None
 
 
@@ -846,19 +848,34 @@ def _maybe_collect_bazel_build_info(
     return True
 
 
+def _find_compile_db_in_dir(directory: Path) -> Path | None:
+    """Locate a ``compile_commands.json`` under *directory* (the P4 strategy).
+
+    Conventional build-dir hints first (fast, deterministic), then a fallback to
+    *any* immediate subdirectory holding a compile DB — so a non-standard but
+    common out-of-tree dir (``cmake-build-debug-gcc``, ``build-release``, an
+    IDE/preset dir, …) is still found instead of silently yielding no L3
+    evidence. The fallback stays at depth 1 to remain cheap and is deterministic
+    (sorted). Shared by ``--sources`` auto-discovery and ``--build-info <dir>``
+    resolution so both honour the same "any immediate subdirectory" contract.
+    """
+    for hint in _COMPILE_DB_HINTS:
+        candidate = (
+            (directory / hint / _COMPILE_DB_NAME)
+            if hint
+            else (directory / _COMPILE_DB_NAME)
+        )
+        if candidate.is_file():
+            return candidate
+    fallback = sorted(p for p in directory.glob("*/" + _COMPILE_DB_NAME) if p.is_file())
+    return fallback[0] if fallback else None
+
+
 def _autodiscover_compile_db(source_tree: Path | None) -> Path | None:
     """Best-effort search for a ``compile_commands.json`` inside a source tree."""
     if source_tree is None or not source_tree.is_dir():
         return None
-    for hint in _COMPILE_DB_HINTS:
-        candidate = (
-            (source_tree / hint / _COMPILE_DB_NAME)
-            if hint
-            else (source_tree / _COMPILE_DB_NAME)
-        )
-        if candidate.is_file():
-            return candidate
-    return None
+    return _find_compile_db_in_dir(source_tree)
 
 
 def _run_compile_db(

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -885,7 +885,8 @@ def embed_build_source(
             _deeper = "/L4/L5" if ("L4" in layers or "L5" in layers) else ""
             click.echo(
                 f"warning: no compile_commands.json found under {_tree} "
-                "(looked in: ., build, builddir, out, _build, cmake-build-debug); "
+                "(looked in: ., build, builddir, out, _build, cmake-build-debug, "
+                "and any immediate subdirectory); "
                 f"L3{_deeper} not collected. Generate one — CMake: configure with "
                 "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON; Meson: emitted by `meson setup`; "
                 "Autotools/Make: run `bear -- make` — or pass "

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -187,15 +187,16 @@ def perform_elf_dump(
     resolved_headers = expand_header_inputs(list(headers)) if headers else []
     # P3: auto-add the public-header roots so a -H umbrella resolves its own
     # relative includes without a separate -I. These roots are *inferred*, not
-    # user-chosen, so they must never outrank a real build context. The command
-    # builders emit search paths in priority order: user -I (extra_includes) →
-    # -p/--gcc-options build-context flags (gcc_options) → repeatable --gcc-option
-    # values (gcc_option_tokens) → auto-probed host system dirs. Routing the
-    # inferred roots in as trailing -I tokens therefore makes them a genuine
-    # fallback — a compile DB that deliberately searches generated/shim headers
-    # before the public tree keeps priority (Codex review) — while still
-    # preceding the host system dirs. (The service/L2 path has no build context,
-    # so it keeps them on extra_includes; here the build context can conflict.)
+    # user-chosen, so they must never outrank a real build context — and that
+    # rules out -I: the preprocessor searches *all* -I dirs before *any*
+    # -isystem dir regardless of command-line order, so a build context that
+    # supplies generated/shim headers via -isystem (common for compile DBs)
+    # would still lose to an inferred -I root (Codex review). Emit them as
+    # -idirafter instead: that bucket is searched after both -I and -isystem
+    # (so every build-context include wins) but still before the standard system
+    # dirs, so the pure-L2/headers-only case — where there is no other search
+    # path — still resolves the umbrella's relative includes. (The service/L2
+    # path has no build context and keeps the roots on extra_includes.)
     from .header_utils import _implicit_header_includes
 
     eff_tokens = list(gcc_option_tokens)
@@ -203,7 +204,7 @@ def perform_elf_dump(
         _user = {str(i.resolve()) for i in includes}
         for d in _implicit_header_includes(list(headers)):
             if str(d.resolve()) not in _user:
-                eff_tokens += ["-I", str(d)]
+                eff_tokens += ["-idirafter", str(d)]
     try:
         snap = dump(
             so_path=so_path,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -193,7 +193,7 @@ def perform_elf_dump(
     # so generated/shim headers from -p/--gcc-options keep priority, but still
     # above the standard system dirs) when the compile context supplies its own
     # includes — see its docstring.
-    from .header_utils import resolve_inferred_header_roots
+    from .header_utils import deferred_token_dirs, resolve_inferred_header_roots
 
     inc_extra, deferred = (
         resolve_inferred_header_roots(
@@ -205,6 +205,9 @@ def perform_elf_dump(
         if resolved_headers
         else ([], [])
     )
+    # Deferred roots ride in gcc_option_tokens (as -isystem), not extra_includes,
+    # so their contents must be hashed into the AST cache key explicitly (Codex).
+    deferred_dirs = tuple(deferred_token_dirs(deferred))
     try:
         snap = dump(
             so_path=so_path,
@@ -224,6 +227,7 @@ def perform_elf_dump(
             public_headers=list(public_headers),
             public_header_dirs=list(public_header_dirs),
             header_backend=header_backend,
+            extra_hash_dirs=deferred_dirs,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -189,12 +189,13 @@ def perform_elf_dump(
     # relative includes without a separate -I. resolve_inferred_header_roots
     # picks the search bucket: plain -I (high priority, so an umbrella that pulls
     # a system-colliding name like <endian.h> still finds the package header)
-    # when there is no build context, or -idirafter (below every build-context
-    # dir, so generated/shim headers from -p/--gcc-options keep priority) when
-    # the compile context supplies its own includes — see its docstring.
+    # when there is no build context, or -isystem (below the build-context dirs
+    # so generated/shim headers from -p/--gcc-options keep priority, but still
+    # above the standard system dirs) when the compile context supplies its own
+    # includes — see its docstring.
     from .header_utils import resolve_inferred_header_roots
 
-    inc_extra, idirafter = (
+    inc_extra, deferred = (
         resolve_inferred_header_roots(
             list(headers),
             list(includes),
@@ -214,7 +215,7 @@ def perform_elf_dump(
             gcc_path=gcc_path,
             gcc_prefix=gcc_prefix,
             gcc_options=effective_gcc_options,
-            gcc_option_tokens=tuple(gcc_option_tokens) + tuple(idirafter),
+            gcc_option_tokens=tuple(gcc_option_tokens) + tuple(deferred),
             sysroot=sysroot,
             nostdinc=nostdinc,
             lang=lang if lang == "c" else None,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -186,36 +186,35 @@ def perform_elf_dump(
     compiler = "cc" if lang == "c" else "c++"
     resolved_headers = expand_header_inputs(list(headers)) if headers else []
     # P3: auto-add the public-header roots so a -H umbrella resolves its own
-    # relative includes without a separate -I. These roots are *inferred*, not
-    # user-chosen, so they must never outrank a real build context — and that
-    # rules out -I: the preprocessor searches *all* -I dirs before *any*
-    # -isystem dir regardless of command-line order, so a build context that
-    # supplies generated/shim headers via -isystem (common for compile DBs)
-    # would still lose to an inferred -I root (Codex review). Emit them as
-    # -idirafter instead: that bucket is searched after both -I and -isystem
-    # (so every build-context include wins) but still before the standard system
-    # dirs, so the pure-L2/headers-only case — where there is no other search
-    # path — still resolves the umbrella's relative includes. (The service/L2
-    # path has no build context and keeps the roots on extra_includes.)
-    from .header_utils import _implicit_header_includes
+    # relative includes without a separate -I. resolve_inferred_header_roots
+    # picks the search bucket: plain -I (high priority, so an umbrella that pulls
+    # a system-colliding name like <endian.h> still finds the package header)
+    # when there is no build context, or -idirafter (below every build-context
+    # dir, so generated/shim headers from -p/--gcc-options keep priority) when
+    # the compile context supplies its own includes — see its docstring.
+    from .header_utils import resolve_inferred_header_roots
 
-    eff_tokens = list(gcc_option_tokens)
-    if resolved_headers:
-        _user = {str(i.resolve()) for i in includes}
-        for d in _implicit_header_includes(list(headers)):
-            if str(d.resolve()) not in _user:
-                eff_tokens += ["-idirafter", str(d)]
+    inc_extra, idirafter = (
+        resolve_inferred_header_roots(
+            list(headers),
+            list(includes),
+            gcc_options=effective_gcc_options,
+            gcc_option_tokens=tuple(gcc_option_tokens),
+        )
+        if resolved_headers
+        else ([], [])
+    )
     try:
         snap = dump(
             so_path=so_path,
             headers=resolved_headers,
-            extra_includes=list(includes),
+            extra_includes=list(includes) + inc_extra,
             version=version,
             compiler=compiler,
             gcc_path=gcc_path,
             gcc_prefix=gcc_prefix,
             gcc_options=effective_gcc_options,
-            gcc_option_tokens=tuple(eff_tokens),
+            gcc_option_tokens=tuple(gcc_option_tokens) + tuple(idirafter),
             sysroot=sysroot,
             nostdinc=nostdinc,
             lang=lang if lang == "c" else None,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -185,11 +185,23 @@ def perform_elf_dump(
     """
     compiler = "cc" if lang == "c" else "c++"
     resolved_headers = expand_header_inputs(list(headers)) if headers else []
+    # P3: auto-add the public-header roots to the search path so a -H umbrella
+    # resolves its own relative includes without a separate -I (user -I first).
+    from .header_utils import _implicit_header_includes
+
+    eff_includes = list(includes)
+    if resolved_headers:
+        _user = {str(i.resolve()) for i in includes}
+        eff_includes += [
+            d
+            for d in _implicit_header_includes(list(headers))
+            if str(d.resolve()) not in _user
+        ]
     try:
         snap = dump(
             so_path=so_path,
             headers=resolved_headers,
-            extra_includes=list(includes),
+            extra_includes=eff_includes,
             version=version,
             compiler=compiler,
             gcc_path=gcc_path,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -185,29 +185,36 @@ def perform_elf_dump(
     """
     compiler = "cc" if lang == "c" else "c++"
     resolved_headers = expand_header_inputs(list(headers)) if headers else []
-    # P3: auto-add the public-header roots to the search path so a -H umbrella
-    # resolves its own relative includes without a separate -I (user -I first).
+    # P3: auto-add the public-header roots so a -H umbrella resolves its own
+    # relative includes without a separate -I. These roots are *inferred*, not
+    # user-chosen, so they must never outrank a real build context. The command
+    # builders emit search paths in priority order: user -I (extra_includes) →
+    # -p/--gcc-options build-context flags (gcc_options) → repeatable --gcc-option
+    # values (gcc_option_tokens) → auto-probed host system dirs. Routing the
+    # inferred roots in as trailing -I tokens therefore makes them a genuine
+    # fallback — a compile DB that deliberately searches generated/shim headers
+    # before the public tree keeps priority (Codex review) — while still
+    # preceding the host system dirs. (The service/L2 path has no build context,
+    # so it keeps them on extra_includes; here the build context can conflict.)
     from .header_utils import _implicit_header_includes
 
-    eff_includes = list(includes)
+    eff_tokens = list(gcc_option_tokens)
     if resolved_headers:
         _user = {str(i.resolve()) for i in includes}
-        eff_includes += [
-            d
-            for d in _implicit_header_includes(list(headers))
-            if str(d.resolve()) not in _user
-        ]
+        for d in _implicit_header_includes(list(headers)):
+            if str(d.resolve()) not in _user:
+                eff_tokens += ["-I", str(d)]
     try:
         snap = dump(
             so_path=so_path,
             headers=resolved_headers,
-            extra_includes=eff_includes,
+            extra_includes=list(includes),
             version=version,
             compiler=compiler,
             gcc_path=gcc_path,
             gcc_prefix=gcc_prefix,
             gcc_options=effective_gcc_options,
-            gcc_option_tokens=tuple(gcc_option_tokens),
+            gcc_option_tokens=tuple(eff_tokens),
             sysroot=sysroot,
             nostdinc=nostdinc,
             lang=lang if lang == "c" else None,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -67,7 +67,7 @@ from .dumper_sysinc import (
 )
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .errors import SnapshotError, ValidationError
-from .header_utils import HEADER_SUFFIXES
+from .header_utils import iter_cache_header_files
 from .model import (
     AbiSnapshot,
     ElfVisibility,
@@ -621,12 +621,9 @@ def _cache_key(
         inc_path = Path(inc_dir)
         h.update(inc_dir.encode())
         if inc_path.is_dir():
-            # Hash every recognised header suffix (not just .h/.hpp) so an edit to
-            # a .hxx/.ipp/.tpp/… transitive include still busts the key — the same
-            # set directory -H expansion treats as headers (Codex review).
-            for f in sorted(
-                p for p in inc_path.rglob("*") if p.suffix.lower() in HEADER_SUFFIXES
-            ):
+            # Hash every header-like file (incl. .inl/.tcc template bodies, not
+            # just .h/.hpp) so any transitive include edit busts the key (#454).
+            for f in iter_cache_header_files(inc_path):
                 try:
                     h.update(str(f).encode())
                     h.update(str(f.stat().st_mtime).encode())

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -385,11 +385,11 @@ def _clang_header_dump(
             and not force_cpp
             and _is_missing_cpp_stdlib_header_error(result.stderr or "")
         ):
-            log.warning(
-                "clang failed to find a C++ standard header parsing the header(s) in "
-                "C mode; the header is C++ (a pure-#include umbrella header has no "
-                "inline C++ syntax to auto-detect). Retrying in C++ mode. Pass "
-                "--lang c++ to select this directly and silence this warning."
+            log.debug(
+                "clang auto-detected C for a pure-#include umbrella header (no "
+                "inline C++ syntax to key on), then self-healed to C++ after a "
+                "missing C++ standard header — an unambiguous C++ signal. The "
+                "result is unaffected; pass --lang c++ to skip the initial C probe."
             )
             result = _run_clang(True, _detect_cpp20_headers(headers), cpp_system_includes)
         # A nonzero exit means clang hit a hard parse error. Unlike L4 source

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -67,6 +67,7 @@ from .dumper_sysinc import (
 )
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .errors import SnapshotError, ValidationError
+from .header_utils import HEADER_SUFFIXES
 from .model import (
     AbiSnapshot,
     ElfVisibility,
@@ -620,7 +621,12 @@ def _cache_key(
         inc_path = Path(inc_dir)
         h.update(inc_dir.encode())
         if inc_path.is_dir():
-            for f in sorted(inc_path.rglob("*.h")) + sorted(inc_path.rglob("*.hpp")):
+            # Hash every recognised header suffix (not just .h/.hpp) so an edit to
+            # a .hxx/.ipp/.tpp/… transitive include still busts the key — the same
+            # set directory -H expansion treats as headers (Codex review).
+            for f in sorted(
+                p for p in inc_path.rglob("*") if p.suffix.lower() in HEADER_SUFFIXES
+            ):
                 try:
                     h.update(str(f).encode())
                     h.update(str(f.stat().st_mtime).encode())

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -296,6 +296,12 @@ def _clang_header_dump(
     if not lang:
         force_cpp = _detect_cpp_headers(headers)
     force_cpp20 = force_cpp and _detect_cpp20_headers(headers)
+    # Was C *explicitly* requested (``--lang c``), as opposed to auto-detected?
+    # Both leave ``force_cpp`` False, but the C→C++ self-heal below must treat
+    # them differently: an explicit C request that reparses as C++ overrides what
+    # the user asked for, so it stays a visible warning; the auto-detected probe
+    # self-healing is just noise and is demoted to debug (Codex review).
+    explicit_c_request = bool(lang) and not force_cpp
     cc_id = "msvc" if Path(clang_bin).name.lower() in ("cl", "cl.exe") else "gnu"
 
     # castxml↔clang parity: probe the host GNU compiler for its system include
@@ -385,12 +391,24 @@ def _clang_header_dump(
             and not force_cpp
             and _is_missing_cpp_stdlib_header_error(result.stderr or "")
         ):
-            log.debug(
-                "clang auto-detected C for a pure-#include umbrella header (no "
-                "inline C++ syntax to key on), then self-healed to C++ after a "
-                "missing C++ standard header — an unambiguous C++ signal. The "
-                "result is unaffected; pass --lang c++ to skip the initial C probe."
-            )
+            if explicit_c_request:
+                # The user asked for C, but the header needs the C++ standard
+                # library — self-heal to C++ so the dump still succeeds, but keep
+                # it visible: the result is C++ ABI evidence, not the C the
+                # request implied (Codex review).
+                log.warning(
+                    "clang was asked for C (--lang c) but the header(s) require the "
+                    "C++ standard library; self-healing to C++ mode. The result is "
+                    "C++ ABI evidence — pass --lang c++ to make this explicit, or "
+                    "verify you intended a C library."
+                )
+            else:
+                log.debug(
+                    "clang auto-detected C for a pure-#include umbrella header (no "
+                    "inline C++ syntax to key on), then self-healed to C++ after a "
+                    "missing C++ standard header — an unambiguous C++ signal. The "
+                    "result is unaffected; pass --lang c++ to skip the initial C probe."
+                )
             result = _run_clang(True, _detect_cpp20_headers(headers), cpp_system_includes)
         # A nonzero exit means clang hit a hard parse error. Unlike L4 source
         # replay (which tolerates partial coverage), the L2 header AST must be

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -259,6 +259,7 @@ def _clang_header_dump(
     sysroot: Path | None = None,
     nostdinc: bool = False,
     lang: str | None = None,
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> dict[str, Any]:
     """Run clang over *headers* and return the parsed ``-ast-dump=json`` root.
 
@@ -345,6 +346,7 @@ def _clang_header_dump(
         system_includes=system_includes
         if force_cpp
         else (*system_includes, *cpp_system_includes),
+        extra_hash_dirs=extra_hash_dirs,
     )
     cached = _cache_path(key, backend="clang")
     if cached.exists():
@@ -458,6 +460,7 @@ def _header_ast_parser(
     exported_static: set[str],
     public_header_paths: list[str],
     public_dir_paths: list[str],
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> _CastxmlParser | _ClangAstParser:
     """Run the resolved L2 backend and return its parser (castxml or clang).
 
@@ -474,6 +477,7 @@ def _header_ast_parser(
             gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
             gcc_option_tokens=gcc_option_tokens,
             sysroot=sysroot, nostdinc=nostdinc, lang=lang,
+            extra_hash_dirs=extra_hash_dirs,
         )
         return _ClangAstParser(
             ast_root, exported_dynamic, exported_static,
@@ -499,6 +503,7 @@ def _header_ast_parser(
             gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
             gcc_option_tokens=gcc_option_tokens,
             sysroot=sysroot, nostdinc=nostdinc, lang=lang,
+            extra_hash_dirs=extra_hash_dirs,
         )
     except SnapshotError as exc:
         if (
@@ -594,6 +599,7 @@ def _cache_key(
     lang: str | None = None,
     backend: str = "castxml",
     system_includes: tuple[str, ...] = (),
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> str:
     h = hashlib.sha256()
     # The header-AST backend is part of the key: a castxml-XML cache entry and a
@@ -605,8 +611,12 @@ def _cache_key(
             h.update(str(os.path.getmtime(p)).encode())
         except OSError:
             pass
-    # Also hash mtimes of files in extra_include dirs (catches most transitive changes)
-    for inc_dir in sorted(str(x) for x in extra_includes):
+    # Also hash mtimes of files in the include dirs (catches most transitive
+    # changes). extra_hash_dirs are dirs searched via *deferred* -isystem tokens
+    # (the inferred -H roots when a build context is present) rather than -I, so
+    # their contents must be folded in here too — otherwise an edit to a header
+    # transitively included from such a root would reuse a stale AST (Codex).
+    for inc_dir in sorted(str(x) for x in (*extra_includes, *extra_hash_dirs)):
         inc_path = Path(inc_dir)
         h.update(inc_dir.encode())
         if inc_path.is_dir():
@@ -1023,6 +1033,7 @@ def _castxml_dump(
     sysroot: Path | None = None,
     nostdinc: bool = False,
     lang: str | None = None,
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> Element:
     """Run castxml on headers and return parsed XML root.
 
@@ -1048,6 +1059,7 @@ def _castxml_dump(
         gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
         gcc_option_tokens=gcc_option_tokens,
         sysroot=sysroot, nostdinc=nostdinc, lang=lang,
+        extra_hash_dirs=extra_hash_dirs,
     )
     cached = _cache_path(key)
     if cached.exists():
@@ -1242,6 +1254,7 @@ def dump(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> AbiSnapshot:
     """Create an AbiSnapshot from a shared library + headers.
 
@@ -1308,7 +1321,7 @@ def dump(
         gcc_option_tokens=gcc_option_tokens,
         sysroot=sysroot, nostdinc=nostdinc, lang=lang,
         public_headers=public_headers, public_header_dirs=public_header_dirs,
-        header_backend=header_backend,
+        header_backend=header_backend, extra_hash_dirs=extra_hash_dirs,
         **extra,
     )
 
@@ -1661,6 +1674,7 @@ def _dump_elf(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> AbiSnapshot:
     """ELF-specific dump: pyelftools + debug info (DWARF/BTF/CTF) + header AST."""
     exported_dynamic, exported_static = _pyelftools_exported_symbols(so_path)
@@ -1702,6 +1716,7 @@ def _dump_elf(
         exported_dynamic=exported_dynamic, exported_static=exported_static,
         public_header_paths=[str(h) for h in headers] + [str(h) for h in (public_headers or [])],
         public_dir_paths=[str(d) for d in (public_header_dirs or [])],
+        extra_hash_dirs=extra_hash_dirs,
     )
 
     snapshot = AbiSnapshot(
@@ -1745,6 +1760,7 @@ def _dump_macho(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> AbiSnapshot:
     """Mach-O dump: export table from macholib + header-AST analysis."""
     if dwarf_only:
@@ -1834,6 +1850,7 @@ def _dump_macho(
         exported_dynamic=exported_no_underscore, exported_static=exported_no_underscore,
         public_header_paths=[str(h) for h in headers] + [str(h) for h in (public_headers or [])],
         public_dir_paths=[str(d) for d in (public_header_dirs or [])],
+        extra_hash_dirs=extra_hash_dirs,
     )
 
     return AbiSnapshot(
@@ -1872,6 +1889,7 @@ def _dump_pe(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
+    extra_hash_dirs: tuple[Path, ...] = (),
 ) -> AbiSnapshot:
     """PE dump: export table from pefile + header-AST analysis."""
     from .pe_metadata import parse_pe_metadata
@@ -1917,6 +1935,7 @@ def _dump_pe(
         exported_dynamic=exported_dynamic, exported_static=exported_static,
         public_header_paths=[str(h) for h in headers] + [str(h) for h in (public_headers or [])],
         public_dir_paths=[str(d) for d in (public_header_dirs or [])],
+        extra_hash_dirs=extra_hash_dirs,
     )
 
     return AbiSnapshot(

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -90,6 +90,19 @@ def _implicit_header_includes(headers: list[Path]) -> list[Path]:
     return dirs
 
 
+def _context_tokens(
+    gcc_options: str | None, gcc_option_tokens: Sequence[str]
+) -> list[str]:
+    """The pass-through compile flags as a flat token list (string + tokens)."""
+    toks: list[str] = list(gcc_option_tokens)
+    if gcc_options:
+        try:
+            toks += shlex.split(gcc_options, posix=os.name != "nt")
+        except ValueError:
+            toks += gcc_options.split()
+    return toks
+
+
 def _has_include_build_context(
     gcc_options: str | None, gcc_option_tokens: Sequence[str]
 ) -> bool:
@@ -105,13 +118,44 @@ def _has_include_build_context(
     need no detection here — an inferred ``-I`` appended after them is already
     lower priority.
     """
-    toks: list[str] = list(gcc_option_tokens)
-    if gcc_options:
-        try:
-            toks += shlex.split(gcc_options, posix=os.name != "nt")
-        except ValueError:
-            toks += gcc_options.split()
+    toks = _context_tokens(gcc_options, gcc_option_tokens)
     return any(t.startswith(p) for t in toks for p in _INCLUDE_FLAG_PREFIXES)
+
+
+def _build_context_include_dirs(
+    gcc_options: str | None, gcc_option_tokens: Sequence[str]
+) -> set[str]:
+    """Resolved include directories the compile context already searches.
+
+    Parses every include-search flag (spaced ``-I dir`` / ``-isystem dir`` and
+    attached ``-Idir`` forms, GNU and MSVC) out of the pass-through flags and
+    returns their resolved absolute paths. Used to skip an inferred ``-H`` root
+    the build context already covers: re-adding such a root as ``-isystem`` would
+    trip GCC's rule that a directory given with *both* ``-I`` and ``-isystem`` has
+    its ``-I`` ignored — demoting the build's own ``-I`` to the system position
+    and changing search order (Codex review). Best-effort: relative dirs resolve
+    against the cwd, the same basis the inferred roots use.
+    """
+    toks = _context_tokens(gcc_options, gcc_option_tokens)
+    dirs: set[str] = set()
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        prefix = next((p for p in _INCLUDE_FLAG_PREFIXES if t.startswith(p)), None)
+        if prefix is None:
+            i += 1
+            continue
+        if t == prefix:  # spaced form: the directory is the next token
+            if i + 1 < len(toks):
+                dirs.add(str(Path(toks[i + 1]).resolve()))
+            i += 2
+            continue
+        # Attached form ("-Idir" / "/Idir"): t is strictly longer than the prefix
+        # here (the exact-match spaced form was handled above), so the operand is
+        # always non-empty.
+        dirs.add(str(Path(t[len(prefix) :]).resolve()))
+        i += 1
+    return dirs
 
 
 def resolve_inferred_header_roots(
@@ -142,9 +186,13 @@ def resolve_inferred_header_roots(
     Shared by the ``dump`` CLI path (``cli_dump_helpers.perform_elf_dump``) and
     the service/``scan`` path (``service._dump_elf``) so they cannot drift.
     """
-    user = {str(i.resolve()) for i in user_includes}
+    # Skip roots the user's -I *or* the build context already searches: re-adding
+    # one the build supplies as -I would, when emitted as -isystem, void that -I
+    # (GCC ignores -I for a dir also given via -isystem) and reorder the search.
+    skip = {str(i.resolve()) for i in user_includes}
+    skip |= _build_context_include_dirs(gcc_options, gcc_option_tokens)
     inferred = [
-        d for d in _implicit_header_includes(headers) if str(d.resolve()) not in user
+        d for d in _implicit_header_includes(headers) if str(d.resolve()) not in skip
     ]
     if not inferred:
         return [], []

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -36,10 +36,22 @@ _INCLUDE_ROOT_NAMES = frozenset({"include", "inc"})
 
 #: Compiler flags that contribute an include *search directory*. Their presence
 #: in the pass-through compile context means a real build supplied its own
-#: include tree, which an inferred ``-H`` root must defer to. Distinct, case-
-#: sensitive prefixes (``-I`` ≠ ``-isystem``/``-iquote``): ``startswith`` covers
-#: both the spaced (``-I dir``) and attached (``-Idir``) spellings.
-_INCLUDE_FLAG_PREFIXES = ("-I", "-isystem", "-iquote", "-idirafter", "-cxx-isystem")
+#: include tree, which an inferred ``-H`` root must defer to. Both GNU/clang
+#: (``-I``/``-isystem``/…) and MSVC/clang-cl (``/I``/``/external:I``/``/imsvc``)
+#: spellings are recognised so an MSVC build context (``--gcc-path cl.exe`` with
+#: ``/I`` options) is not mistaken for "no build context" (Codex review).
+#: Distinct, case-sensitive prefixes (``-I`` ≠ ``-isystem``/``-iquote``);
+#: ``startswith`` covers both spaced (``-I dir``) and attached (``-Idir``) forms.
+_INCLUDE_FLAG_PREFIXES = (
+    "-I",
+    "-isystem",
+    "-iquote",
+    "-idirafter",
+    "-cxx-isystem",  # GNU / clang
+    "/I",
+    "/external:I",
+    "/imsvc",  # MSVC / clang-cl
+)
 
 
 def _implicit_header_includes(headers: list[Path]) -> list[Path]:
@@ -83,13 +95,15 @@ def _has_include_build_context(
 ) -> bool:
     """True when the compile context supplies its own include search dirs.
 
-    Detects any ``-I``/``-isystem``/``-iquote``/``-idirafter``/``-cxx-isystem``
-    (attached or spaced) in the pass-through ``--gcc-options`` string or the
-    repeatable ``--gcc-option`` tokens. When present, a real build context is in
-    play and an inferred ``-H`` root must defer to it; when absent, the inferred
-    root can take ``-I`` priority. Compile-DB include dirs are folded into the
-    user ``-I`` list upstream, so they need no detection here — an inferred ``-I``
-    appended after them is already lower priority.
+    Detects any include-search flag — GNU/clang
+    ``-I``/``-isystem``/``-iquote``/``-idirafter``/``-cxx-isystem`` or MSVC/clang-cl
+    ``/I``/``/external:I``/``/imsvc`` (attached or spaced) — in the pass-through
+    ``--gcc-options`` string or the repeatable ``--gcc-option`` tokens. When
+    present, a real build context is in play and an inferred ``-H`` root must
+    defer to it; when absent, the inferred root can take ``-I`` priority.
+    Compile-DB include dirs are folded into the user ``-I`` list upstream, so they
+    need no detection here — an inferred ``-I`` appended after them is already
+    lower priority.
     """
     toks: list[str] = list(gcc_option_tokens)
     if gcc_options:
@@ -109,17 +123,21 @@ def resolve_inferred_header_roots(
 ) -> tuple[list[Path], list[str]]:
     """Split the inferred ``-H`` include roots by how they should be searched.
 
-    Returns ``(extra_includes, idirafter_tokens)`` — exactly one is non-empty.
+    Returns ``(extra_includes, deferred_tokens)`` — exactly one is non-empty.
     The inferred roots (de-duplicated against the user's ``-I``) are emitted as:
 
     * plain ``-I`` (returned as extra-include :class:`Path`\\ s) when there is
       **no** build context to defer to — so they outrank the standard system
       dirs and an umbrella that includes a system-colliding name (``<endian.h>``)
       still resolves the package header rather than the system one;
-    * ``-idirafter`` tokens when the compile context supplies its own include
-      dirs (``-I``/``-isystem``/… in ``gcc_options``/tokens) — that bucket is
-      searched below every build-context dir, so a real build context
-      (generated/shim headers) keeps priority (Codex review).
+    * ``-isystem`` tokens when the compile context supplies its own include dirs
+      (``-I``/``-isystem``/``/I``/… in ``gcc_options``/tokens). ``-isystem`` is
+      searched *after* the build context's ``-I`` **and** its earlier ``-isystem``
+      entries (the build's flags are emitted first), so a real build context
+      keeps priority — yet still *before* the standard system dirs, so the
+      system-colliding-basename case (``<endian.h>``) keeps resolving the package
+      header. (``-idirafter`` would drop below the system dirs and reintroduce
+      that collision — Codex review.)
 
     Shared by the ``dump`` CLI path (``cli_dump_helpers.perform_elf_dump``) and
     the service/``scan`` path (``service._dump_elf``) so they cannot drift.
@@ -133,6 +151,6 @@ def resolve_inferred_header_roots(
     if _has_include_build_context(gcc_options, gcc_option_tokens):
         toks: list[str] = []
         for d in inferred:
-            toks += ["-idirafter", str(d)]
+            toks += ["-isystem", str(d)]
         return [], toks
     return inferred, []

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -34,15 +34,24 @@ from pathlib import Path
 #: not the file's immediate parent — is what must be on the search path.
 _INCLUDE_ROOT_NAMES = frozenset({"include", "inc"})
 
-#: Recognised C/C++ header file suffixes — the single source of truth for "what
-#: counts as a header" across directory ``-H`` expansion (``service_scan``) and
-#: the AST-cache include-dir mtime walk (``dumper._cache_key``). Lives in this
-#: leaf module so both can share it without an import cycle; keeping the walk in
-#: sync with expansion means an edit to e.g. a ``.hxx``/``.ipp`` transitive
-#: include still busts the cache (Codex review).
+#: Recognised C/C++ header file suffixes for directory ``-H`` *expansion*
+#: (``service_scan``). Deliberately conservative — these become standalone
+#: translation units, so it must not sweep in files meant only to be ``#include``d
+#: (``.inl``/``.tcc`` template bodies). Lives in this leaf module so the consumers
+#: can share it without an import cycle.
 HEADER_SUFFIXES = frozenset(
     {".h", ".hh", ".hpp", ".hxx", ".h++", ".ipp", ".tpp", ".inc"}
 )
+
+#: Header-like suffixes whose edits must invalidate the AST cache
+#: (``dumper._cache_key``'s include-dir mtime walk). A **superset** of
+#: :data:`HEADER_SUFFIXES`: cache invalidation has the opposite bias from
+#: expansion — it must be *generous* (any file that can change the parsed AST),
+#: so it also covers the ``.inl``/``.tcc`` template-implementation includes that
+#: headers commonly pull in but that are never standalone TUs. Decoupling the two
+#: lets the walk catch a ``.inl``/``.tcc`` edit without making ``-H <dir>`` try to
+#: parse those files (#454).
+CACHE_HEADER_SUFFIXES = HEADER_SUFFIXES | frozenset({".inl", ".tcc"})
 
 #: Compiler flags that contribute an include *search directory*. Their presence
 #: in the pass-through compile context means a real build supplied its own
@@ -113,40 +122,33 @@ def _context_tokens(
     return toks
 
 
-def _has_include_build_context(
-    gcc_options: str | None, gcc_option_tokens: Sequence[str]
-) -> bool:
-    """True when the compile context supplies its own include search dirs.
+def _has_include_build_context(toks: list[str]) -> bool:
+    """True when the compile-flag *tokens* supply their own include search dirs.
 
     Detects any include-search flag — GNU/clang
     ``-I``/``-isystem``/``-iquote``/``-idirafter``/``-cxx-isystem`` or MSVC/clang-cl
-    ``/I``/``/external:I``/``/imsvc`` (attached or spaced) — in the pass-through
-    ``--gcc-options`` string or the repeatable ``--gcc-option`` tokens. When
-    present, a real build context is in play and an inferred ``-H`` root must
-    defer to it; when absent, the inferred root can take ``-I`` priority.
-    Compile-DB include dirs are folded into the user ``-I`` list upstream, so they
-    need no detection here — an inferred ``-I`` appended after them is already
-    lower priority.
+    ``/I``/``/external:I``/``/imsvc`` (attached or spaced). When present, a real
+    build context is in play and an inferred ``-H`` root must defer to it; when
+    absent, the inferred root can take ``-I`` priority. Compile-DB include dirs
+    are folded into the user ``-I`` list upstream, so they need no detection here
+    — an inferred ``-I`` appended after them is already lower priority. (*toks* is
+    the pre-split flag list from :func:`_context_tokens`.)
     """
-    toks = _context_tokens(gcc_options, gcc_option_tokens)
     return any(t.startswith(p) for t in toks for p in _INCLUDE_FLAG_PREFIXES)
 
 
-def _build_context_include_dirs(
-    gcc_options: str | None, gcc_option_tokens: Sequence[str]
-) -> set[str]:
-    """Resolved include directories the compile context already searches.
+def _build_context_include_dirs(toks: list[str]) -> set[str]:
+    """Resolved include directories the compile-flag *tokens* already search.
 
     Parses every include-search flag (spaced ``-I dir`` / ``-isystem dir`` and
-    attached ``-Idir`` forms, GNU and MSVC) out of the pass-through flags and
-    returns their resolved absolute paths. Used to skip an inferred ``-H`` root
-    the build context already covers: re-adding such a root as ``-isystem`` would
-    trip GCC's rule that a directory given with *both* ``-I`` and ``-isystem`` has
-    its ``-I`` ignored — demoting the build's own ``-I`` to the system position
-    and changing search order (Codex review). Best-effort: relative dirs resolve
-    against the cwd, the same basis the inferred roots use.
+    attached ``-Idir`` forms, GNU and MSVC) out of *toks* and returns their
+    resolved absolute paths. Used to skip an inferred ``-H`` root the build
+    context already covers: re-adding such a root as ``-isystem`` would trip GCC's
+    rule that a directory given with *both* ``-I`` and ``-isystem`` has its ``-I``
+    ignored — demoting the build's own ``-I`` to the system position and changing
+    search order (Codex review). Best-effort: relative dirs resolve against the
+    cwd, the same basis the inferred roots use.
     """
-    toks = _context_tokens(gcc_options, gcc_option_tokens)
     dirs: set[str] = set()
     i = 0
     while i < len(toks):
@@ -194,35 +196,34 @@ def resolve_inferred_header_roots(
     Shared by the ``dump`` CLI path (``cli_dump_helpers.perform_elf_dump``) and
     the service/``scan`` path (``service._dump_elf``) so they cannot drift.
     """
+    # Tokenize the pass-through flags once, then reuse for every check below.
+    ctx = _context_tokens(gcc_options, gcc_option_tokens)
     # Skip roots the user's -I *or* the build context already searches: re-adding
     # one the build supplies as -I would, when emitted as -isystem, void that -I
     # (GCC ignores -I for a dir also given via -isystem) and reorder the search.
     skip = {str(i.resolve()) for i in user_includes}
-    skip |= _build_context_include_dirs(gcc_options, gcc_option_tokens)
+    skip |= _build_context_include_dirs(ctx)
     inferred = [
         d for d in _implicit_header_includes(headers) if str(d.resolve()) not in skip
     ]
     if not inferred:
         return [], []
-    if _has_include_build_context(gcc_options, gcc_option_tokens):
-        toks: list[str] = []
-        flag = _deferred_include_flag(gcc_options, gcc_option_tokens)
+    if _has_include_build_context(ctx):
+        out: list[str] = []
+        flag = _deferred_include_flag(ctx)
         for d in inferred:
-            toks += [flag, str(d)]
-        return [], toks
+            out += [flag, str(d)]
+        return [], out
     return inferred, []
 
 
-def _msvc_style_context(
-    gcc_options: str | None, gcc_option_tokens: Sequence[str]
-) -> bool:
-    """True when the build context uses MSVC/clang-cl include spellings.
+def _msvc_style_context(toks: list[str]) -> bool:
+    """True when the compile-flag *tokens* use MSVC/clang-cl include spellings.
 
     Distinguishes ``/I``/``/external:I``/``/imsvc`` from the GNU forms so the
     deferred inferred root is emitted in the same dialect — a GNU ``-isystem``
     is silently ignored by ``cl.exe``/``clang-cl`` (Codex review).
     """
-    toks = _context_tokens(gcc_options, gcc_option_tokens)
     msvc = ("/I", "/external:I", "/imsvc")
     return any(t.startswith(p) for t in toks for p in msvc)
 
@@ -234,10 +235,8 @@ def _msvc_style_context(
 _ABOVE_SYSTEM_GNU_PREFIXES = ("-I", "-iquote", "-isystem", "-cxx-isystem")
 
 
-def _deferred_include_flag(
-    gcc_options: str | None, gcc_option_tokens: Sequence[str]
-) -> str:
-    """The flag to defer an inferred ``-H`` root below the build context.
+def _deferred_include_flag(toks: list[str]) -> str:
+    """The flag to defer an inferred ``-H`` root below the build-context *toks*.
 
     The root must search *after* every build-context include dir; the bucket
     that achieves that depends on the build context's own flags:
@@ -252,9 +251,8 @@ def _deferred_include_flag(
       class) → ``-idirafter`` (after the build's own ``-idirafter`` dirs, in the
       same class, so the build's fallback keeps priority — Codex review).
     """
-    if _msvc_style_context(gcc_options, gcc_option_tokens):
+    if _msvc_style_context(toks):
         return "/I"
-    toks = _context_tokens(gcc_options, gcc_option_tokens)
     if any(t.startswith(p) for t in toks for p in _ABOVE_SYSTEM_GNU_PREFIXES):
         return "-isystem"
     return "-idirafter"
@@ -271,3 +269,16 @@ def deferred_token_dirs(deferred_tokens: Sequence[str]) -> list[Path]:
     is ``-isystem`` for GNU contexts, ``/I`` for MSVC ones).
     """
     return [Path(d) for _flag, d in zip(deferred_tokens[::2], deferred_tokens[1::2])]
+
+
+def iter_cache_header_files(directory: Path) -> list[Path]:
+    """Header-like files under *directory* whose edits should bust the AST cache.
+
+    Recurses *directory* and returns the files whose suffix is in
+    :data:`CACHE_HEADER_SUFFIXES` (the generous superset — includes ``.inl``/
+    ``.tcc`` template bodies), sorted for a deterministic cache key. Used by
+    ``dumper._cache_key``'s include-dir mtime walk.
+    """
+    return sorted(
+        p for p in directory.rglob("*") if p.suffix.lower() in CACHE_HEADER_SUFFIXES
+    )

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -197,20 +197,44 @@ def resolve_inferred_header_roots(
     if not inferred:
         return [], []
     if _has_include_build_context(gcc_options, gcc_option_tokens):
+        # Defer below the build context's include dirs (its flags are emitted
+        # first) but keep above the standard system dirs. Match the build
+        # context's flag *dialect* so the frontend actually honours the deferred
+        # root: GNU/clang -isystem (a system search class below -I), or MSVC/
+        # clang-cl /I (deferred by command-line order — cl.exe/clang-cl ignore a
+        # GNU -isystem, leaving the root unresolved) (Codex review).
+        flag = (
+            "/I" if _msvc_style_context(gcc_options, gcc_option_tokens) else "-isystem"
+        )
         toks: list[str] = []
         for d in inferred:
-            toks += ["-isystem", str(d)]
+            toks += [flag, str(d)]
         return [], toks
     return inferred, []
 
 
+def _msvc_style_context(
+    gcc_options: str | None, gcc_option_tokens: Sequence[str]
+) -> bool:
+    """True when the build context uses MSVC/clang-cl include spellings.
+
+    Distinguishes ``/I``/``/external:I``/``/imsvc`` from the GNU forms so the
+    deferred inferred root is emitted in the same dialect — a GNU ``-isystem``
+    is silently ignored by ``cl.exe``/``clang-cl`` (Codex review).
+    """
+    toks = _context_tokens(gcc_options, gcc_option_tokens)
+    msvc = ("/I", "/external:I", "/imsvc")
+    return any(t.startswith(p) for t in toks for p in msvc)
+
+
 def deferred_token_dirs(deferred_tokens: Sequence[str]) -> list[Path]:
-    """The directories carried by ``-isystem <dir>`` deferred tokens.
+    """The directories carried by the ``<flag> <dir>`` deferred token pairs.
 
     The deferred inferred roots ride in ``gcc_option_tokens`` (not
     ``extra_includes``), so the header-AST cache key — which mtime-scans only
     ``extra_includes`` dirs — would miss edits to their transitively-included
     headers and reuse a stale AST (Codex review). Callers pass these dirs to the
-    dumper as hash-only inputs. Pairs the flat ``["-isystem", dir, …]`` list.
+    dumper as hash-only inputs. Pairs the flat ``[flag, dir, …]`` list (the flag
+    is ``-isystem`` for GNU contexts, ``/I`` for MSVC ones).
     """
     return [Path(d) for _flag, d in zip(deferred_tokens[::2], deferred_tokens[1::2])]

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -202,3 +202,15 @@ def resolve_inferred_header_roots(
             toks += ["-isystem", str(d)]
         return [], toks
     return inferred, []
+
+
+def deferred_token_dirs(deferred_tokens: Sequence[str]) -> list[Path]:
+    """The directories carried by ``-isystem <dir>`` deferred tokens.
+
+    The deferred inferred roots ride in ``gcc_option_tokens`` (not
+    ``extra_includes``), so the header-AST cache key — which mtime-scans only
+    ``extra_includes`` dirs — would miss edits to their transitively-included
+    headers and reuse a stale AST (Codex review). Callers pass these dirs to the
+    dumper as hash-only inputs. Pairs the flat ``["-isystem", dir, …]`` list.
+    """
+    return [Path(d) for _flag, d in zip(deferred_tokens[::2], deferred_tokens[1::2])]

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -23,6 +23,9 @@ include-root derivation without an import cycle (``cli`` → ``cli_dump_helpers`
 
 from __future__ import annotations
 
+import os
+import shlex
+from collections.abc import Sequence
 from pathlib import Path
 
 #: Conventional include-root directory names. A ``-H`` umbrella that lives
@@ -30,6 +33,13 @@ from pathlib import Path
 #: includes relative to that root (``#include "oneapi/tbb/..."``), so the root —
 #: not the file's immediate parent — is what must be on the search path.
 _INCLUDE_ROOT_NAMES = frozenset({"include", "inc"})
+
+#: Compiler flags that contribute an include *search directory*. Their presence
+#: in the pass-through compile context means a real build supplied its own
+#: include tree, which an inferred ``-H`` root must defer to. Distinct, case-
+#: sensitive prefixes (``-I`` ≠ ``-isystem``/``-iquote``): ``startswith`` covers
+#: both the spaced (``-I dir``) and attached (``-Idir``) spellings.
+_INCLUDE_FLAG_PREFIXES = ("-I", "-isystem", "-iquote", "-idirafter", "-cxx-isystem")
 
 
 def _implicit_header_includes(headers: list[Path]) -> list[Path]:
@@ -66,3 +76,63 @@ def _implicit_header_includes(headers: list[Path]) -> list[Path]:
             if ancestor.name.lower() in _INCLUDE_ROOT_NAMES:
                 _add(ancestor)
     return dirs
+
+
+def _has_include_build_context(
+    gcc_options: str | None, gcc_option_tokens: Sequence[str]
+) -> bool:
+    """True when the compile context supplies its own include search dirs.
+
+    Detects any ``-I``/``-isystem``/``-iquote``/``-idirafter``/``-cxx-isystem``
+    (attached or spaced) in the pass-through ``--gcc-options`` string or the
+    repeatable ``--gcc-option`` tokens. When present, a real build context is in
+    play and an inferred ``-H`` root must defer to it; when absent, the inferred
+    root can take ``-I`` priority. Compile-DB include dirs are folded into the
+    user ``-I`` list upstream, so they need no detection here — an inferred ``-I``
+    appended after them is already lower priority.
+    """
+    toks: list[str] = list(gcc_option_tokens)
+    if gcc_options:
+        try:
+            toks += shlex.split(gcc_options, posix=os.name != "nt")
+        except ValueError:
+            toks += gcc_options.split()
+    return any(t.startswith(p) for t in toks for p in _INCLUDE_FLAG_PREFIXES)
+
+
+def resolve_inferred_header_roots(
+    headers: list[Path],
+    user_includes: list[Path],
+    *,
+    gcc_options: str | None = None,
+    gcc_option_tokens: Sequence[str] = (),
+) -> tuple[list[Path], list[str]]:
+    """Split the inferred ``-H`` include roots by how they should be searched.
+
+    Returns ``(extra_includes, idirafter_tokens)`` — exactly one is non-empty.
+    The inferred roots (de-duplicated against the user's ``-I``) are emitted as:
+
+    * plain ``-I`` (returned as extra-include :class:`Path`\\ s) when there is
+      **no** build context to defer to — so they outrank the standard system
+      dirs and an umbrella that includes a system-colliding name (``<endian.h>``)
+      still resolves the package header rather than the system one;
+    * ``-idirafter`` tokens when the compile context supplies its own include
+      dirs (``-I``/``-isystem``/… in ``gcc_options``/tokens) — that bucket is
+      searched below every build-context dir, so a real build context
+      (generated/shim headers) keeps priority (Codex review).
+
+    Shared by the ``dump`` CLI path (``cli_dump_helpers.perform_elf_dump``) and
+    the service/``scan`` path (``service._dump_elf``) so they cannot drift.
+    """
+    user = {str(i.resolve()) for i in user_includes}
+    inferred = [
+        d for d in _implicit_header_includes(headers) if str(d.resolve()) not in user
+    ]
+    if not inferred:
+        return [], []
+    if _has_include_build_context(gcc_options, gcc_option_tokens):
+        toks: list[str] = []
+        for d in inferred:
+            toks += ["-idirafter", str(d)]
+        return [], toks
+    return inferred, []

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure path helpers for header (``-H``) inputs.
+
+A leaf module (stdlib-only) so both the service layer (``service._dump_elf``)
+and the ``dump`` CLI helper (``cli_dump_helpers.perform_elf_dump``) can share the
+include-root derivation without an import cycle (``cli`` → ``cli_dump_helpers`` →
+``service`` → … → ``cli``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Conventional include-root directory names. A ``-H`` umbrella that lives
+#: *under* such a directory (e.g. ``include/oneapi/tbb.h``) writes its own
+#: includes relative to that root (``#include "oneapi/tbb/..."``), so the root —
+#: not the file's immediate parent — is what must be on the search path.
+_INCLUDE_ROOT_NAMES = frozenset({"include", "inc"})
+
+
+def _implicit_header_includes(headers: list[Path]) -> list[Path]:
+    """Include directories implied by the ``-H`` inputs themselves.
+
+    A ``-H`` *directory* is its own include root; a ``-H`` *file* contributes
+    its parent directory **plus** any ancestor conventionally named ``include``/
+    ``inc``. Adding these to the compiler search path lets quote/angle includes
+    written relative to the public-header root resolve without a separate ``-I``
+    (the abicheck P3 finding) — both the umbrella-at-root case (oneDNN's
+    ``include/dnnl.hpp``) and the nested-umbrella case (oneTBB's
+    ``include/oneapi/tbb.h`` doing ``#include "oneapi/tbb/blocked_range.h"``).
+    Returns existing directories, de-duplicated in discovery order; the user's
+    ``-I``/``--include`` entries still take precedence (they are listed first).
+    """
+    dirs: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(d: Path) -> None:
+        if not d.is_dir():
+            return
+        key = str(d.resolve())
+        if key not in seen:
+            seen.add(key)
+            dirs.append(d)
+
+    for h in headers:
+        if h.is_dir():
+            _add(h)
+            continue
+        _add(h.parent)
+        for ancestor in h.parents:
+            if ancestor.name.lower() in _INCLUDE_ROOT_NAMES:
+                _add(ancestor)
+    return dirs

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -34,6 +34,16 @@ from pathlib import Path
 #: not the file's immediate parent — is what must be on the search path.
 _INCLUDE_ROOT_NAMES = frozenset({"include", "inc"})
 
+#: Recognised C/C++ header file suffixes — the single source of truth for "what
+#: counts as a header" across directory ``-H`` expansion (``service_scan``) and
+#: the AST-cache include-dir mtime walk (``dumper._cache_key``). Lives in this
+#: leaf module so both can share it without an import cycle; keeping the walk in
+#: sync with expansion means an edit to e.g. a ``.hxx``/``.ipp`` transitive
+#: include still busts the cache (Codex review).
+HEADER_SUFFIXES = frozenset(
+    {".h", ".hh", ".hpp", ".hxx", ".h++", ".ipp", ".tpp", ".inc"}
+)
+
 #: Compiler flags that contribute an include *search directory*. Their presence
 #: in the pass-through compile context means a real build supplied its own
 #: include tree, which an inferred ``-H`` root must defer to. Both GNU/clang

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -57,10 +57,11 @@ def _implicit_header_includes(headers: list[Path]) -> list[Path]:
             dirs.append(d)
 
     for h in headers:
-        if h.is_dir():
-            _add(h)
-            continue
-        _add(h.parent)
+        # A directory is its own root; a file contributes its parent. Either way
+        # also walk up to any conventional include root — a `-H include/oneapi`
+        # (dir) or `-H include/oneapi/tbb.h` (file) still writes includes
+        # relative to `include/`, so that root must be on the path too.
+        _add(h if h.is_dir() else h.parent)
         for ancestor in h.parents:
             if ancestor.name.lower() in _INCLUDE_ROOT_NAMES:
                 _add(ancestor)

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -184,14 +184,12 @@ def resolve_inferred_header_roots(
       **no** build context to defer to — so they outrank the standard system
       dirs and an umbrella that includes a system-colliding name (``<endian.h>``)
       still resolves the package header rather than the system one;
-    * ``-isystem`` tokens when the compile context supplies its own include dirs
-      (``-I``/``-isystem``/``/I``/… in ``gcc_options``/tokens). ``-isystem`` is
-      searched *after* the build context's ``-I`` **and** its earlier ``-isystem``
-      entries (the build's flags are emitted first), so a real build context
-      keeps priority — yet still *before* the standard system dirs, so the
-      system-colliding-basename case (``<endian.h>``) keeps resolving the package
-      header. (``-idirafter`` would drop below the system dirs and reintroduce
-      that collision — Codex review.)
+    * a *deferred* token otherwise — emitted **after** the build context's flags
+      and in the bucket that keeps it below every build-context include dir (see
+      :func:`_deferred_include_flag`): ``-isystem`` below an above-system build
+      context (``-I``/``-isystem``/…, still above the standard system dirs so the
+      ``<endian.h>`` case resolves the package header), ``-idirafter`` below an
+      ``-idirafter``-only build context, or ``/I`` for an MSVC/clang-cl one.
 
     Shared by the ``dump`` CLI path (``cli_dump_helpers.perform_elf_dump``) and
     the service/``scan`` path (``service._dump_elf``) so they cannot drift.
@@ -207,16 +205,8 @@ def resolve_inferred_header_roots(
     if not inferred:
         return [], []
     if _has_include_build_context(gcc_options, gcc_option_tokens):
-        # Defer below the build context's include dirs (its flags are emitted
-        # first) but keep above the standard system dirs. Match the build
-        # context's flag *dialect* so the frontend actually honours the deferred
-        # root: GNU/clang -isystem (a system search class below -I), or MSVC/
-        # clang-cl /I (deferred by command-line order — cl.exe/clang-cl ignore a
-        # GNU -isystem, leaving the root unresolved) (Codex review).
-        flag = (
-            "/I" if _msvc_style_context(gcc_options, gcc_option_tokens) else "-isystem"
-        )
         toks: list[str] = []
+        flag = _deferred_include_flag(gcc_options, gcc_option_tokens)
         for d in inferred:
             toks += [flag, str(d)]
         return [], toks
@@ -235,6 +225,39 @@ def _msvc_style_context(
     toks = _context_tokens(gcc_options, gcc_option_tokens)
     msvc = ("/I", "/external:I", "/imsvc")
     return any(t.startswith(p) for t in toks for p in msvc)
+
+
+#: GNU/clang include classes searched *before* the standard system dirs. An
+#: inferred root deferred below these stays above the system dirs (so a
+#: system-colliding basename still resolves the package header). ``-idirafter``
+#: is deliberately absent — it is searched *after* the system dirs.
+_ABOVE_SYSTEM_GNU_PREFIXES = ("-I", "-iquote", "-isystem", "-cxx-isystem")
+
+
+def _deferred_include_flag(
+    gcc_options: str | None, gcc_option_tokens: Sequence[str]
+) -> str:
+    """The flag to defer an inferred ``-H`` root below the build context.
+
+    The root must search *after* every build-context include dir; the bucket
+    that achieves that depends on the build context's own flags:
+
+    * MSVC/clang-cl (``/I``/…) → ``/I`` (deferred by command-line order — a GNU
+      ``-isystem`` is silently ignored by ``cl.exe``/``clang-cl``);
+    * any *above-system* GNU class (``-I``/``-iquote``/``-isystem``/
+      ``-cxx-isystem``) → ``-isystem`` (searched after those, still above the
+      standard system dirs so a system-colliding basename resolves the package
+      header);
+    * otherwise the build context is ``-idirafter``-only (a *below-system*
+      class) → ``-idirafter`` (after the build's own ``-idirafter`` dirs, in the
+      same class, so the build's fallback keeps priority — Codex review).
+    """
+    if _msvc_style_context(gcc_options, gcc_option_tokens):
+        return "/I"
+    toks = _context_tokens(gcc_options, gcc_option_tokens)
+    if any(t.startswith(p) for t in toks for p in _ABOVE_SYSTEM_GNU_PREFIXES):
+        return "-isystem"
+    return "-idirafter"
 
 
 def deferred_token_dirs(deferred_tokens: Sequence[str]) -> list[Path]:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -34,7 +34,7 @@ from .api_types import CompareRequest, InputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .errors import AbicheckError, SnapshotError, ValidationError
-from .header_utils import resolve_inferred_header_roots
+from .header_utils import deferred_token_dirs, resolve_inferred_header_roots
 from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
 from .reporter import to_json, to_markdown, to_stat, to_stat_json
 from .serialization import load_snapshot
@@ -520,6 +520,7 @@ def _dump_elf(
     # without dropping the inferred root below system headers (Codex review).
     eff_includes = list(includes)
     eff_tokens: tuple[str, ...] = cc.gcc_option_tokens
+    deferred_dirs: tuple[Path, ...] = ()
     if resolved_headers and not dwarf_only:
         inc_extra, deferred = resolve_inferred_header_roots(
             headers,
@@ -529,6 +530,9 @@ def _dump_elf(
         )
         eff_includes += inc_extra
         eff_tokens = cc.gcc_option_tokens + tuple(deferred)
+        # Deferred roots ride in gcc_option_tokens (-isystem), not extra_includes,
+        # so hash their contents into the AST cache key explicitly (Codex review).
+        deferred_dirs = tuple(deferred_token_dirs(deferred))
 
     compiler = "cc" if lang == "c" else "c++"
     try:
@@ -550,6 +554,7 @@ def _dump_elf(
             header_backend=header_backend,
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
+            extra_hash_dirs=deferred_dirs,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise SnapshotError(f"Failed to dump '{path}': {exc}") from exc

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -34,6 +34,7 @@ from .api_types import CompareRequest, InputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .errors import AbicheckError, SnapshotError, ValidationError
+from .header_utils import _implicit_header_includes
 from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
 from .reporter import to_json, to_markdown, to_stat, to_stat_json
 from .serialization import load_snapshot
@@ -510,12 +511,22 @@ def _dump_elf(
     elif includes and not dwarf_only:
         _emit(notify, "Warning: --include paths are ignored without headers.")
 
+    # P3: auto-add the public-header roots to the search path (user -I first).
+    eff_includes = list(includes)
+    if resolved_headers and not dwarf_only:
+        _user = {str(i.resolve()) for i in includes}
+        eff_includes += [
+            d
+            for d in _implicit_header_includes(headers)
+            if str(d.resolve()) not in _user
+        ]
+
     compiler = "cc" if lang == "c" else "c++"
     try:
         return dump(
             so_path=path,
             headers=resolved_headers,
-            extra_includes=includes,
+            extra_includes=eff_includes,
             version=version,
             compiler=compiler,
             gcc_path=cc.gcc_path,

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -513,21 +513,22 @@ def _dump_elf(
 
     # P3: auto-add the public-header roots to the search path. Same bucket
     # selection as the dump CLI path (resolve_inferred_header_roots): plain -I
-    # when this request carries no compile-context includes, or -idirafter (below
-    # every build-context dir) when the caller's CompileContext supplies its own
-    # includes via gcc_options/tokens (e.g. -isystem build/generated) — so a real
-    # build context keeps search priority (Codex review).
+    # when this request carries no compile-context includes, or -isystem (below
+    # the build-context dirs, above the standard system dirs) when the caller's
+    # CompileContext supplies its own includes via gcc_options/tokens (e.g.
+    # -isystem build/generated) — so a real build context keeps search priority
+    # without dropping the inferred root below system headers (Codex review).
     eff_includes = list(includes)
     eff_tokens: tuple[str, ...] = cc.gcc_option_tokens
     if resolved_headers and not dwarf_only:
-        inc_extra, idirafter = resolve_inferred_header_roots(
+        inc_extra, deferred = resolve_inferred_header_roots(
             headers,
             list(includes),
             gcc_options=cc.gcc_options,
             gcc_option_tokens=cc.gcc_option_tokens,
         )
         eff_includes += inc_extra
-        eff_tokens = cc.gcc_option_tokens + tuple(idirafter)
+        eff_tokens = cc.gcc_option_tokens + tuple(deferred)
 
     compiler = "cc" if lang == "c" else "c++"
     try:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -607,38 +607,59 @@ def _try_header_scoped_dump(
     compiler = "cc" if lang.lower() == "c" else "c++"
     lang_arg = lang if lang.lower() == "c" else None
     cc = compile if compile is not None else CompileContext()
+    # P3 parity with the ELF path: auto-add the inferred public-header roots so a
+    # -H umbrella resolves its own relative includes without a separate -I on
+    # PE/Mach-O too (else header parsing fails and we drop to export-table mode,
+    # losing the L2/type surface). Same bucket selection — plain -I with no build
+    # context, deferred -isystem otherwise — and the deferred dirs are hashed
+    # into the AST cache key (Codex review).
+    eff_includes = list(includes)
+    eff_tokens = cc.gcc_option_tokens
+    deferred_dirs: tuple[Path, ...] = ()
+    if resolved_headers:
+        inc_extra, deferred = resolve_inferred_header_roots(
+            headers,
+            list(includes),
+            gcc_options=cc.gcc_options,
+            gcc_option_tokens=cc.gcc_option_tokens,
+        )
+        eff_includes += inc_extra
+        eff_tokens = cc.gcc_option_tokens + tuple(deferred)
+        deferred_dirs = tuple(deferred_token_dirs(deferred))
     try:
         if fmt == "pe":
             snap = _dumper_pe(
                 path,
                 resolved_headers,
-                includes,
+                eff_includes,
                 version,
                 compiler,
                 gcc_path=cc.gcc_path,
                 gcc_prefix=cc.gcc_prefix,
                 gcc_options=cc.gcc_options,
-                gcc_option_tokens=cc.gcc_option_tokens,
+                gcc_option_tokens=eff_tokens,
                 sysroot=cc.sysroot,
                 nostdinc=cc.nostdinc,
                 lang=lang_arg,
                 header_backend=header_backend,
+                extra_hash_dirs=deferred_dirs,
             )
         else:
             snap = _dumper_macho(
                 path,
                 resolved_headers,
-                includes,
+                eff_includes,
                 version,
                 compiler,
                 gcc_path=cc.gcc_path,
                 gcc_prefix=cc.gcc_prefix,
                 gcc_options=cc.gcc_options,
-                gcc_option_tokens=cc.gcc_option_tokens,
+                gcc_option_tokens=eff_tokens,
                 sysroot=cc.sysroot,
                 nostdinc=cc.nostdinc,
                 lang=lang_arg,
                 header_backend=header_backend,
+                extra_hash_dirs=deferred_dirs,
             )
     except Exception as exc:  # noqa: BLE001 — header backend/parse failure → fall back
         warnings.warn(

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -34,7 +34,7 @@ from .api_types import CompareRequest, InputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .errors import AbicheckError, SnapshotError, ValidationError
-from .header_utils import _implicit_header_includes
+from .header_utils import resolve_inferred_header_roots
 from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
 from .reporter import to_json, to_markdown, to_stat, to_stat_json
 from .serialization import load_snapshot
@@ -511,15 +511,23 @@ def _dump_elf(
     elif includes and not dwarf_only:
         _emit(notify, "Warning: --include paths are ignored without headers.")
 
-    # P3: auto-add the public-header roots to the search path (user -I first).
+    # P3: auto-add the public-header roots to the search path. Same bucket
+    # selection as the dump CLI path (resolve_inferred_header_roots): plain -I
+    # when this request carries no compile-context includes, or -idirafter (below
+    # every build-context dir) when the caller's CompileContext supplies its own
+    # includes via gcc_options/tokens (e.g. -isystem build/generated) — so a real
+    # build context keeps search priority (Codex review).
     eff_includes = list(includes)
+    eff_tokens: tuple[str, ...] = cc.gcc_option_tokens
     if resolved_headers and not dwarf_only:
-        _user = {str(i.resolve()) for i in includes}
-        eff_includes += [
-            d
-            for d in _implicit_header_includes(headers)
-            if str(d.resolve()) not in _user
-        ]
+        inc_extra, idirafter = resolve_inferred_header_roots(
+            headers,
+            list(includes),
+            gcc_options=cc.gcc_options,
+            gcc_option_tokens=cc.gcc_option_tokens,
+        )
+        eff_includes += inc_extra
+        eff_tokens = cc.gcc_option_tokens + tuple(idirafter)
 
     compiler = "cc" if lang == "c" else "c++"
     try:
@@ -532,7 +540,7 @@ def _dump_elf(
             gcc_path=cc.gcc_path,
             gcc_prefix=cc.gcc_prefix,
             gcc_options=cc.gcc_options,
-            gcc_option_tokens=cc.gcc_option_tokens,
+            gcc_option_tokens=eff_tokens,
             sysroot=cc.sysroot,
             nostdinc=cc.nostdinc,
             lang=lang if lang == "c" else None,

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -317,14 +317,17 @@ def _count_source_tus(sources: Path) -> int:
 
 
 def _compile_db_in(root: Path) -> Path | None:
-    """The ``compile_commands.json`` inside a build/source *directory*, if any."""
-    for cand in (
-        root / "compile_commands.json",
-        root / "build" / "compile_commands.json",
-    ):
-        if cand.is_file():
-            return cand
-    return None
+    """The ``compile_commands.json`` inside a build/source *directory*, if any.
+
+    Reuses the *execution* path's discovery (``inline._find_compile_db_in_dir``:
+    the conventional build-dir hints **plus** the depth-1 ``*/compile_commands.json``
+    glob fallback) so ``scan --estimate`` mirrors what the real scan collects — a
+    DB in a non-hint immediate subdirectory such as ``cmake-build-debug-gcc/`` is
+    priced, not reported as absent / 0 TUs (Codex review).
+    """
+    from .buildsource.inline import _find_compile_db_in_dir
+
+    return _find_compile_db_in_dir(root)
 
 
 def _discover_compile_db(sources: Path | None, explicit: Path | None) -> Path | None:

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -33,25 +33,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .errors import ValidationError
+from .header_utils import HEADER_SUFFIXES
 
 if TYPE_CHECKING:
     from .buildsource.scan_levels import EvidenceDepth, SourceMethod
 
 _logger = logging.getLogger(__name__)
 
-# Header file extensions recognised during directory expansion
-_HEADER_EXTS = frozenset(
-    {
-        ".h",
-        ".hh",
-        ".hpp",
-        ".hxx",
-        ".h++",
-        ".ipp",
-        ".tpp",
-        ".inc",
-    }
-)
+# Header file extensions recognised during directory expansion. Shared with the
+# AST-cache include walk (dumper._cache_key) via the leaf header_utils module so
+# expansion and cache-invalidation can never drift (Codex review).
+_HEADER_EXTS = HEADER_SUFFIXES
 
 
 def expand_header_inputs(inputs: list[Path]) -> list[Path]:

--- a/docs/user-guide/scanning-conda-packages.md
+++ b/docs/user-guide/scanning-conda-packages.md
@@ -1,0 +1,100 @@
+# Scanning a Conda-Forge Package
+
+This runbook covers the specific friction of pointing `abicheck` at a library
+you got from **conda-forge** (or any binary-distribution channel): finding the
+pieces, mapping versions, and the packaging shapes that need special handling.
+For the general flow and report walkthrough, see
+[Worked Example: Scanning a Library](real-world-example.md).
+
+## 1. The pieces live in different packages
+
+A conda package is usually split, and `abicheck` needs parts from more than one:
+
+| You need | Typically in | Example |
+|----------|--------------|---------|
+| the runtime `.so` (the **binary** to scan) | the **runtime** package | `tbb`, `onednn`, `dal` |
+| the **public headers** | the `*-devel` package | `tbb-devel` |
+| headers in a **third** package (some recipes) | a dedicated `*-include` | `dal-include` (oneDAL) |
+
+!!! warning "`*-devel` may be CMake/pkgconfig only"
+    For some recipes (e.g. oneDAL) the `-devel` package ships only
+    `lib/cmake` + `lib/pkgconfig` and the **headers live in a separate
+    `*-include` package**. If your `-H` directory looks empty of `.h`/`.hpp`,
+    you're pointed at the wrong package.
+
+You don't need the `conda` CLI to get these — a `.conda` file is a zip of
+zstd-compressed tarballs; `unzip pkg.conda`, then extract the `pkg-*` member
+(`zstd -d < pkg-*.tar.zst | tar -x`) to recover its `lib/` and `include/` trees.
+
+## 2. Map the conda version to an upstream tag
+
+Conda's version is the **product** version, which often differs from the
+upstream git tag. Read the version header to pin the matching source:
+
+| Library | Conda version | Version header to read | Upstream tag |
+|---------|---------------|------------------------|--------------|
+| oneTBB | `2023.0.0` | `oneapi/tbb/version.h` (`TBB_VERSION_*`, `TBB_INTERFACE_VERSION`) | `v2023.0.0` |
+| oneDNN | `3.12` | `oneapi/dnnl/dnnl_version.h` (`DNNL_VERSION_*`) | `v3.12` |
+| oneDAL | `2026.1.0` | `services/library_version_info.h` | `2026.1.0` |
+
+When in doubt, the SONAME (`libtbb.so.12.18` → interface 12, patch 18) and the
+version header together identify the release.
+
+## 3. Pass the public surface with the umbrella header
+
+Point `-H` at the library's **umbrella header** — the single header a consumer
+includes (`oneapi/tbb.h`, `dnnl.hpp`, `oneapi/dal.hpp`). abicheck now adds the
+header's include root (the umbrella's directory and any ancestor named
+`include`/`inc`) to the compiler search path automatically, so for a standard
+layout no separate `-I` is needed. A non-standard layout still needs `-I`, and
+any `-I`/`--include` you pass takes precedence over the auto-added roots:
+
+```bash
+export ABICHECK_AST_FRONTEND=clang        # on a clang-only host (no castxml)
+abicheck scan --binary lib/libtbb.so.12.18 \
+  -H include/oneapi/tbb.h \
+  --public-header-dir include \
+  --lang c++ --audit --depth headers
+```
+
+`--public-header-dir` establishes the public/internal boundary so the
+single-release hygiene cross-checks run (it is what lets abicheck classify
+which declarations are public).
+
+!!! tip "Prefer the umbrella over the include *directory*"
+    Passing `-H <include-dir>` makes abicheck parse **every** header in the
+    tree as one translation unit — which pulls in *optional backend* headers
+    (OpenCL/SYCL: `dnnl_ocl.h` → `CL/cl.h`) and *preview* headers gated by
+    `#error` macros (oneTBB's `blocked_rangeNd.h`). Those need their SDK or a
+    `--gcc-option=-DXXX_PREVIEW` to parse. The umbrella header includes only the
+    library's curated, default-public surface, so it sidesteps both. Use the
+    umbrella unless you specifically want a preview/backend header analysed.
+
+## 4. Going deeper needs a build
+
+`--depth headers` (L2) works from the binary + headers alone. The deeper levels
+(`build`/`source`/`full` → L3/L4/L5) read a **`compile_commands.json`**:
+
+- abicheck auto-discovers one under the source tree (`.`, `build/`, `builddir/`,
+  `out/`, `_build/`, `cmake-build-debug/`, **or any immediate subdirectory**);
+- a *fresh checkout has none* — generate it (CMake: configure with
+  `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`; Meson: emitted by `meson setup`;
+  Make/Autotools: `bear -- make`), or pass `--build-info <dir|compile_commands.json>`.
+
+Without one, L3/L4/L5 report `not_collected` and only the compiler-free pattern
+pre-scan runs. On a large tree, scope that pre-scan with `--since <ref>` /
+`--changed-path <file>` (or set `ABICHECK_PATTERN_SCAN_JOBS` to fan it out).
+
+## 5. Packaging shapes that need a workaround
+
+| Shape | Symptom | What to do |
+|-------|---------|------------|
+| **Static-only** (e.g. oneCCL on conda-forge ships `libccl.a`, no `.so`) | `scan` rejects the `.a`: "static/import library archive … not analysed" | extract members (`ar x lib.a`) and scan the resulting objects, or scan a shared library built from them |
+| **Headers in a third package** | `-H` dir has no headers | fetch the `*-include` package (see [§1](#1-the-pieces-live-in-different-packages)) |
+| **Stripped release `.so`, no DWARF** | header-aware L2 still works; DWARF cross-checks skip | pass `-H` headers (recommended anyway) |
+
+## See also
+
+- [Worked Example: Scanning a Library](real-world-example.md) — the full flow and reports
+- [Source-Scan Levels](scan-levels.md) — what L0–L5 collect and cost
+- [CLI Usage](cli-usage.md) — every flag

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - Choose Your Workflow: user-guide/choose-your-workflow.md
       - Local Compare: user-guide/local-compare.md
       - 'Worked Example: Real Library': user-guide/real-world-example.md
+      - 'Scanning a Conda-Forge Package': user-guide/scanning-conda-packages.md
     - Everyday Use:
       - CLI Usage: user-guide/cli-usage.md
       - Source-Scan Levels: user-guide/scan-levels.md

--- a/tests/test_buildsource_inline_nodb.py
+++ b/tests/test_buildsource_inline_nodb.py
@@ -109,3 +109,58 @@ def test_meson_builddir_is_autodiscovered(tmp_path):
 
     assert snap.build_source is not None
     assert snap.build_source.build_evidence.compile_units  # discovered under builddir/
+
+
+# ── P4: compile-DB auto-discovery also finds non-standard subdir build trees ──
+
+
+def test_autodiscover_compile_db_hint_dir(tmp_path):
+    from abicheck.buildsource.inline import _autodiscover_compile_db
+
+    (tmp_path / "build").mkdir()
+    db = tmp_path / "build" / "compile_commands.json"
+    db.write_text("[]")
+    assert _autodiscover_compile_db(tmp_path) == db
+
+
+def test_autodiscover_compile_db_nonstandard_subdir(tmp_path):
+    # A non-hint, IDE/preset-style build dir is still found via the depth-1
+    # fallback rather than yielding no L3 evidence (P4).
+    from abicheck.buildsource.inline import _autodiscover_compile_db
+
+    bd = tmp_path / "cmake-build-debug-gcc"
+    bd.mkdir()
+    db = bd / "compile_commands.json"
+    db.write_text("[]")
+    assert _autodiscover_compile_db(tmp_path) == db
+
+
+def test_autodiscover_compile_db_prefers_hint_over_subdir(tmp_path):
+    from abicheck.buildsource.inline import _autodiscover_compile_db
+
+    (tmp_path / "build").mkdir()
+    hint_db = tmp_path / "build" / "compile_commands.json"
+    hint_db.write_text("[]")
+    other = tmp_path / "zzz-build"
+    other.mkdir()
+    (other / "compile_commands.json").write_text("[]")
+    assert _autodiscover_compile_db(tmp_path) == hint_db
+
+
+def test_autodiscover_compile_db_none_when_absent(tmp_path):
+    from abicheck.buildsource.inline import _autodiscover_compile_db
+
+    (tmp_path / "src.c").write_text("int x;")
+    assert _autodiscover_compile_db(tmp_path) is None
+
+
+def test_compile_db_at_dir_uses_subdir_fallback(tmp_path):
+    # --build-info <dir> now honours the same depth-1 subdir fallback as
+    # --sources auto-discovery (Codex review).
+    from abicheck.buildsource.inline import _compile_db_at
+
+    bd = tmp_path / "cmake-build-debug-gcc"
+    bd.mkdir()
+    db = bd / "compile_commands.json"
+    db.write_text("[]")
+    assert _compile_db_at(tmp_path) == db

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -288,6 +288,29 @@ class TestDumpLang:
         assert result.exit_code == 0
         assert captured.get("compiler") == "c++"
 
+    def test_implicit_header_include_root_passed(self, tmp_path, monkeypatch):
+        # P3: a -H umbrella nested under include/ reaches the dumper with the
+        # include root on extra_includes — no separate -I needed.
+        so_path = tmp_path / "libfoo.so"
+        so_path.write_bytes(b"\x7fELF")
+        root = tmp_path / "include"
+        (root / "oneapi").mkdir(parents=True)
+        header = root / "oneapi" / "umbrella.h"
+        header.write_text("int foo();\n", encoding="utf-8")
+
+        captured = {}
+
+        def fake_dump(**kwargs):
+            captured.update(kwargs)
+            return AbiSnapshot(library="libfoo.so", version="1.0")
+
+        monkeypatch.setattr("abicheck.cli_dump_helpers.dump", fake_dump)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["dump", str(so_path), "-H", str(header)])
+        assert result.exit_code == 0, result.output
+        assert root in captured.get("extra_includes", [])
+
 
 # ── Cross-compilation flags on dump ──────────────────────────────────────
 

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -290,10 +290,10 @@ class TestDumpLang:
 
     def test_implicit_header_include_root_passed(self, tmp_path, monkeypatch):
         # P3: a -H umbrella nested under include/ reaches the dumper with the
-        # include root on the search path — no separate -I needed. The inferred
-        # root is a *fallback*: it rides in as an `-idirafter` token (searched
-        # after both -I and -isystem build-context dirs), not promoted to a
-        # user-level extra_includes entry (Codex review).
+        # include root on the search path — no separate -I needed. With no build
+        # context to defer to, the inferred root rides in as a plain -I
+        # (extra_includes) so it outranks the standard system dirs — an umbrella
+        # that pulls a system-colliding name still finds the package header.
         so_path = tmp_path / "libfoo.so"
         so_path.write_bytes(b"\x7fELF")
         root = tmp_path / "include"
@@ -312,12 +312,9 @@ class TestDumpLang:
         runner = CliRunner()
         result = runner.invoke(main, ["dump", str(so_path), "-H", str(header)])
         assert result.exit_code == 0, result.output
-        tokens = list(captured.get("gcc_option_tokens", ()))
-        assert str(root) in tokens, tokens
-        # -idirafter, not -I: searched below build-context -I *and* -isystem dirs
-        assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
-        # inferred roots are a fallback, never promoted to a user -I
-        assert root not in captured.get("extra_includes", [])
+        # no build context → plain -I via extra_includes, not an -idirafter token
+        assert root in captured.get("extra_includes", [])
+        assert str(root) not in list(captured.get("gcc_option_tokens", ()))
 
     def test_implicit_root_defers_to_build_context(self, tmp_path, monkeypatch):
         # Codex review: a build-context include (here via --gcc-options) must
@@ -356,9 +353,9 @@ class TestDumpLang:
         assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
 
     def test_implicit_root_skips_user_provided_include(self, tmp_path, monkeypatch):
-        # An inferred root already supplied by the user via -I is not duplicated
-        # as an -idirafter fallback: the user's -I (extra_includes) keeps its
-        # higher priority. The *other* inferred ancestor is still added.
+        # An inferred root already supplied by the user via -I is not duplicated.
+        # With no build context, the *other* inferred ancestor is still added as
+        # a plain -I (both land in extra_includes); the user's stays unduplicated.
         so_path = tmp_path / "libfoo.so"
         so_path.write_bytes(b"\x7fELF")
         root = tmp_path / "include"
@@ -381,14 +378,14 @@ class TestDumpLang:
             "dump", str(so_path), "-H", str(header), "-I", str(nested),
         ])
         assert result.exit_code == 0, result.output
-        # the user -I stays a real extra_includes entry (highest priority)
-        assert nested in captured.get("extra_includes", [])
-        tokens = list(captured.get("gcc_option_tokens", ()))
-        # not re-added as a fallback (deduped against the user -I)
-        assert str(nested) not in tokens
-        # the other inferred ancestor (the include root) is still added
-        assert str(root) in tokens
-        assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
+        extra = captured.get("extra_includes", [])
+        # the user -I stays, exactly once (not re-added by the inferred pass)
+        assert nested in extra
+        assert extra.count(nested) == 1
+        # the other inferred ancestor (the include root) is added as -I too
+        assert root in extra
+        # no build context here, so nothing is deferred to gcc_option_tokens
+        assert str(root) not in list(captured.get("gcc_option_tokens", ()))
 
 
 # ── Cross-compilation flags on dump ──────────────────────────────────────

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -355,6 +355,41 @@ class TestDumpLang:
         assert str(root) in tokens
         assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
 
+    def test_implicit_root_skips_user_provided_include(self, tmp_path, monkeypatch):
+        # An inferred root already supplied by the user via -I is not duplicated
+        # as an -idirafter fallback: the user's -I (extra_includes) keeps its
+        # higher priority. The *other* inferred ancestor is still added.
+        so_path = tmp_path / "libfoo.so"
+        so_path.write_bytes(b"\x7fELF")
+        root = tmp_path / "include"
+        nested = root / "oneapi"
+        nested.mkdir(parents=True)
+        header = nested / "umbrella.h"
+        header.write_text("int foo();\n", encoding="utf-8")
+
+        captured = {}
+
+        def fake_dump(**kwargs):
+            captured.update(kwargs)
+            return AbiSnapshot(library="libfoo.so", version="1.0")
+
+        monkeypatch.setattr("abicheck.cli_dump_helpers.dump", fake_dump)
+
+        runner = CliRunner()
+        # User passes the umbrella's parent (include/oneapi) explicitly via -I.
+        result = runner.invoke(main, [
+            "dump", str(so_path), "-H", str(header), "-I", str(nested),
+        ])
+        assert result.exit_code == 0, result.output
+        # the user -I stays a real extra_includes entry (highest priority)
+        assert nested in captured.get("extra_includes", [])
+        tokens = list(captured.get("gcc_option_tokens", ()))
+        # not re-added as a fallback (deduped against the user -I)
+        assert str(nested) not in tokens
+        # the other inferred ancestor (the include root) is still added
+        assert str(root) in tokens
+        assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
+
 
 # ── Cross-compilation flags on dump ──────────────────────────────────────
 

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -312,7 +312,7 @@ class TestDumpLang:
         runner = CliRunner()
         result = runner.invoke(main, ["dump", str(so_path), "-H", str(header)])
         assert result.exit_code == 0, result.output
-        # no build context → plain -I via extra_includes, not an -idirafter token
+        # no build context → plain -I via extra_includes, not a deferred token
         assert root in captured.get("extra_includes", [])
         assert str(root) not in list(captured.get("gcc_option_tokens", ()))
 
@@ -320,8 +320,8 @@ class TestDumpLang:
         # Codex review: a build-context include (here via --gcc-options) must
         # keep priority over the inferred -H root. The build-context flag rides
         # in gcc_options; the inferred root rides in gcc_option_tokens as an
-        # -idirafter entry — searched after both -I and -isystem build-context
-        # dirs — so the build context always wins.
+        # -isystem entry — searched after the build-context -I/-isystem dirs but
+        # above the standard system dirs — so the build context always wins.
         so_path = tmp_path / "libfoo.so"
         so_path.write_bytes(b"\x7fELF")
         root = tmp_path / "include"
@@ -346,11 +346,11 @@ class TestDumpLang:
         ])
         assert result.exit_code == 0, result.output
         # build context stays in gcc_options (emitted first); inferred root is an
-        # -idirafter token — so build context keeps search priority.
+        # -isystem token — searched below it — so build context keeps priority.
         assert f"-I {buildctx}" in (captured.get("gcc_options") or "")
         tokens = list(captured.get("gcc_option_tokens", ()))
         assert str(root) in tokens
-        assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
+        assert tokens[tokens.index(str(root)) - 1] == "-isystem"
 
     def test_implicit_root_skips_user_provided_include(self, tmp_path, monkeypatch):
         # An inferred root already supplied by the user via -I is not duplicated.

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -291,9 +291,9 @@ class TestDumpLang:
     def test_implicit_header_include_root_passed(self, tmp_path, monkeypatch):
         # P3: a -H umbrella nested under include/ reaches the dumper with the
         # include root on the search path — no separate -I needed. The inferred
-        # root is a *fallback*: it rides in as a trailing `-I` token (emitted
-        # after any build-context flags), not promoted to a user-level
-        # extra_includes entry (Codex review).
+        # root is a *fallback*: it rides in as an `-idirafter` token (searched
+        # after both -I and -isystem build-context dirs), not promoted to a
+        # user-level extra_includes entry (Codex review).
         so_path = tmp_path / "libfoo.so"
         so_path.write_bytes(b"\x7fELF")
         root = tmp_path / "include"
@@ -314,15 +314,17 @@ class TestDumpLang:
         assert result.exit_code == 0, result.output
         tokens = list(captured.get("gcc_option_tokens", ()))
         assert str(root) in tokens, tokens
-        assert tokens[tokens.index(str(root)) - 1] == "-I"
+        # -idirafter, not -I: searched below build-context -I *and* -isystem dirs
+        assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
         # inferred roots are a fallback, never promoted to a user -I
         assert root not in captured.get("extra_includes", [])
 
     def test_implicit_root_defers_to_build_context(self, tmp_path, monkeypatch):
         # Codex review: a build-context include (here via --gcc-options) must
         # keep priority over the inferred -H root. The build-context flag rides
-        # in gcc_options; the inferred root rides in gcc_option_tokens, which the
-        # command builders emit *after* gcc_options — so the build context wins.
+        # in gcc_options; the inferred root rides in gcc_option_tokens as an
+        # -idirafter entry — searched after both -I and -isystem build-context
+        # dirs — so the build context always wins.
         so_path = tmp_path / "libfoo.so"
         so_path.write_bytes(b"\x7fELF")
         root = tmp_path / "include"
@@ -346,10 +348,12 @@ class TestDumpLang:
             "--gcc-options", f"-I {buildctx}",
         ])
         assert result.exit_code == 0, result.output
-        # build context stays in gcc_options (emitted first); inferred root is a
-        # trailing token (emitted later) — so build context keeps search priority.
+        # build context stays in gcc_options (emitted first); inferred root is an
+        # -idirafter token — so build context keeps search priority.
         assert f"-I {buildctx}" in (captured.get("gcc_options") or "")
-        assert str(root) in list(captured.get("gcc_option_tokens", ()))
+        tokens = list(captured.get("gcc_option_tokens", ()))
+        assert str(root) in tokens
+        assert tokens[tokens.index(str(root)) - 1] == "-idirafter"
 
 
 # ── Cross-compilation flags on dump ──────────────────────────────────────

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -290,7 +290,10 @@ class TestDumpLang:
 
     def test_implicit_header_include_root_passed(self, tmp_path, monkeypatch):
         # P3: a -H umbrella nested under include/ reaches the dumper with the
-        # include root on extra_includes — no separate -I needed.
+        # include root on the search path — no separate -I needed. The inferred
+        # root is a *fallback*: it rides in as a trailing `-I` token (emitted
+        # after any build-context flags), not promoted to a user-level
+        # extra_includes entry (Codex review).
         so_path = tmp_path / "libfoo.so"
         so_path.write_bytes(b"\x7fELF")
         root = tmp_path / "include"
@@ -309,7 +312,44 @@ class TestDumpLang:
         runner = CliRunner()
         result = runner.invoke(main, ["dump", str(so_path), "-H", str(header)])
         assert result.exit_code == 0, result.output
-        assert root in captured.get("extra_includes", [])
+        tokens = list(captured.get("gcc_option_tokens", ()))
+        assert str(root) in tokens, tokens
+        assert tokens[tokens.index(str(root)) - 1] == "-I"
+        # inferred roots are a fallback, never promoted to a user -I
+        assert root not in captured.get("extra_includes", [])
+
+    def test_implicit_root_defers_to_build_context(self, tmp_path, monkeypatch):
+        # Codex review: a build-context include (here via --gcc-options) must
+        # keep priority over the inferred -H root. The build-context flag rides
+        # in gcc_options; the inferred root rides in gcc_option_tokens, which the
+        # command builders emit *after* gcc_options — so the build context wins.
+        so_path = tmp_path / "libfoo.so"
+        so_path.write_bytes(b"\x7fELF")
+        root = tmp_path / "include"
+        (root / "oneapi").mkdir(parents=True)
+        header = root / "oneapi" / "umbrella.h"
+        header.write_text("int foo();\n", encoding="utf-8")
+        buildctx = tmp_path / "buildctx"
+        buildctx.mkdir()
+
+        captured = {}
+
+        def fake_dump(**kwargs):
+            captured.update(kwargs)
+            return AbiSnapshot(library="libfoo.so", version="1.0")
+
+        monkeypatch.setattr("abicheck.cli_dump_helpers.dump", fake_dump)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "dump", str(so_path), "-H", str(header),
+            "--gcc-options", f"-I {buildctx}",
+        ])
+        assert result.exit_code == 0, result.output
+        # build context stays in gcc_options (emitted first); inferred root is a
+        # trailing token (emitted later) — so build context keeps search priority.
+        assert f"-I {buildctx}" in (captured.get("gcc_options") or "")
+        assert str(root) in list(captured.get("gcc_option_tokens", ()))
 
 
 # ── Cross-compilation flags on dump ──────────────────────────────────────

--- a/tests/test_compare_input_modes.py
+++ b/tests/test_compare_input_modes.py
@@ -460,8 +460,12 @@ class TestCompareSoSo:
         ])
         assert result.exit_code == 0, result.output
         assert len(recorded_includes) == 2
-        assert recorded_includes[0] == [inc_dir]
-        assert recorded_includes[1] == [inc_dir]
+        # The user's -I is passed and takes precedence (listed first); the -H
+        # header's own directory is then auto-added so its relative includes
+        # resolve without a separate -I (P3).
+        for recorded in recorded_includes:
+            assert recorded[0] == inc_dir
+            assert tmp_path in recorded
 
 
 # ── compare mixed mode: .json + .so ─────────────────────────────────────

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -131,7 +131,12 @@ def test_dump_elf_threads_compile_context_to_dumper(
     assert captured["gcc_path"] == "/opt/g++"
     assert captured["gcc_prefix"] == "aarch64-linux-gnu-"
     assert captured["gcc_options"] == "-DFOO=1"
-    assert captured["gcc_option_tokens"] == ("-isystem", "/x")
+    # The CompileContext tokens thread through and lead; because this request has
+    # a -H header *and* an -isystem build context, the inferred header root is
+    # appended after as an -idirafter fallback (below the build-context dir).
+    tokens = captured["gcc_option_tokens"]
+    assert tokens[:2] == ("-isystem", "/x")
+    assert "-idirafter" in tokens and str(tmp_path) in tokens
     assert captured["sysroot"] == tmp_path
     assert captured["nostdinc"] is True
 

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -133,10 +133,13 @@ def test_dump_elf_threads_compile_context_to_dumper(
     assert captured["gcc_options"] == "-DFOO=1"
     # The CompileContext tokens thread through and lead; because this request has
     # a -H header *and* an -isystem build context, the inferred header root is
-    # appended after as an -idirafter fallback (below the build-context dir).
+    # appended after as its own -isystem entry (searched below the build's, which
+    # is emitted first, but still above the standard system dirs).
     tokens = captured["gcc_option_tokens"]
-    assert tokens[:2] == ("-isystem", "/x")
-    assert "-idirafter" in tokens and str(tmp_path) in tokens
+    assert tokens[:2] == ("-isystem", "/x")  # build context leads
+    assert str(tmp_path) in tokens
+    assert tokens[tokens.index(str(tmp_path)) - 1] == "-isystem"
+    assert tokens.index("/x") < tokens.index(str(tmp_path))
     assert captured["sysroot"] == tmp_path
     assert captured["nostdinc"] is True
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -531,6 +531,73 @@ def test_clang_header_dump_missing_clang_raises(
         _clang_header_dump([header], [])
 
 
+def _stub_clang_self_heal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make _clang_header_dump fail once on a missing <cstddef> then succeed.
+
+    Mocks the clang availability/system-include probe and subprocess so the
+    C→C++ self-heal branch runs without a real compiler: the first parse exits
+    nonzero with a missing C++ stdlib header, the C++ retry returns a minimal AST.
+    """
+    import subprocess as _sp
+
+    monkeypatch.setattr("abicheck.dumper._clang_available", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "abicheck.dumper._resolve_clang_system_includes", lambda *a, **k: ()
+    )
+    fail = _sp.CompletedProcess(
+        args=[], returncode=1, stdout="",
+        stderr="fatal error: 'cstddef' file not found",
+    )
+    ok = _sp.CompletedProcess(
+        args=[], returncode=0,
+        stdout='{"kind": "TranslationUnitDecl", "inner": []}', stderr="",
+    )
+    calls = {"n": 0}
+
+    def _run(*a: object, **k: object) -> _sp.CompletedProcess[str]:
+        calls["n"] += 1
+        return fail if calls["n"] == 1 else ok
+
+    monkeypatch.setattr("abicheck.dumper.subprocess.run", _run)
+
+
+def test_clang_self_heal_explicit_c_warns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog
+) -> None:
+    # Explicit --lang c that self-heals to C++ overrides the user's request, so
+    # it stays a visible warning (Codex review).
+    import logging
+
+    _stub_clang_self_heal(monkeypatch)
+    header = tmp_path / "umbrella.h"
+    header.write_text("int foo(void);\n")
+    with caplog.at_level(logging.DEBUG, logger="abicheck.dumper"):
+        root = _clang_header_dump([header], [], lang="c")
+    assert root["kind"] == "TranslationUnitDecl"
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("asked for C" in r.message for r in warns), [r.message for r in warns]
+
+
+def test_clang_self_heal_auto_detected_is_debug(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog
+) -> None:
+    # Auto-detected C (lang=None, no inline C++ syntax) self-healing to C++ is
+    # just noise → demoted to debug, no warning (the P6 fix this guards).
+    import logging
+
+    _stub_clang_self_heal(monkeypatch)
+    header = tmp_path / "umbrella.h"
+    header.write_text("int foo(void);\n")
+    with caplog.at_level(logging.DEBUG, logger="abicheck.dumper"):
+        root = _clang_header_dump([header], [])  # lang=None → auto-detect
+    assert root["kind"] == "TranslationUnitDecl"
+    assert not any(r.levelno == logging.WARNING for r in caplog.records)
+    assert any(
+        r.levelno == logging.DEBUG and "self-healed to C++" in r.message
+        for r in caplog.records
+    )
+
+
 # ── parse_variables / constants edge branches ────────────────────────────────
 
 

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -130,7 +130,7 @@ class TestCacheKey:
         umb.write_text("int a(void);\n", encoding="utf-8")
         root = tmp_path / "pkg"
         root.mkdir()
-        for ext in (".hh", ".hpp", ".hxx", ".h++", ".ipp", ".tpp", ".inc"):
+        for ext in (".hh", ".hpp", ".hxx", ".h++", ".ipp", ".tpp", ".inc", ".inl", ".tcc"):
             detail = root / f"detail{ext}"
             detail.write_text("int b(void);\n", encoding="utf-8")
             k1 = _cache_key([umb], [], "c++", extra_hash_dirs=(root,))

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -98,6 +98,48 @@ class TestCacheKey:
         k = _cache_key([Path("/nonexistent/x.h")], [], "c++")
         assert isinstance(k, str) and len(k) == 64
 
+    def test_extra_hash_dirs_fold_in_contents(self, tmp_path):
+        # A deferred inferred root rides in gcc_option_tokens, not extra_includes,
+        # so its contents are hashed only via extra_hash_dirs. Editing a header
+        # under it (umbrella unchanged) must change the key — else a stale AST is
+        # reused (Codex review).
+        import os
+        import time
+
+        umb = tmp_path / "umbrella.h"
+        umb.write_text("int a(void);\n", encoding="utf-8")
+        root = tmp_path / "pkg"
+        root.mkdir()
+        detail = root / "detail.h"
+        detail.write_text("int b(void);\n", encoding="utf-8")
+
+        k1 = _cache_key([umb], [], "c++", extra_hash_dirs=(root,))
+        detail.write_text("int b(int);\n", encoding="utf-8")
+        future = time.time() + 10
+        os.utime(detail, (future, future))
+        k2 = _cache_key([umb], [], "c++", extra_hash_dirs=(root,))
+        assert k1 != k2  # the deferred root's contents are folded into the key
+
+    def test_without_hash_dir_transitive_edit_is_missed(self, tmp_path):
+        # The complementary gap the fix closes: with the root *not* hashed, an
+        # edit under it leaves the umbrella-only key unchanged.
+        import os
+        import time
+
+        umb = tmp_path / "umbrella.h"
+        umb.write_text("int a(void);\n", encoding="utf-8")
+        root = tmp_path / "pkg"
+        root.mkdir()
+        detail = root / "detail.h"
+        detail.write_text("int b(void);\n", encoding="utf-8")
+
+        k1 = _cache_key([umb], [], "c++")
+        detail.write_text("int b(int);\n", encoding="utf-8")
+        future = time.time() + 10
+        os.utime(detail, (future, future))
+        k2 = _cache_key([umb], [], "c++")
+        assert k1 == k2  # detail.h not hashed → why extra_hash_dirs is needed
+
 
 # ── _cache_path ─────────────────────────────────────────────────────────
 

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -120,6 +120,27 @@ class TestCacheKey:
         k2 = _cache_key([umb], [], "c++", extra_hash_dirs=(root,))
         assert k1 != k2  # the deferred root's contents are folded into the key
 
+    def test_hash_dirs_cover_all_header_suffixes(self, tmp_path):
+        # Not just .h/.hpp — an edit to any recognised header suffix under a
+        # hashed dir must bust the key (Codex review).
+        import os
+        import time
+
+        umb = tmp_path / "umbrella.h"
+        umb.write_text("int a(void);\n", encoding="utf-8")
+        root = tmp_path / "pkg"
+        root.mkdir()
+        for ext in (".hh", ".hpp", ".hxx", ".h++", ".ipp", ".tpp", ".inc"):
+            detail = root / f"detail{ext}"
+            detail.write_text("int b(void);\n", encoding="utf-8")
+            k1 = _cache_key([umb], [], "c++", extra_hash_dirs=(root,))
+            detail.write_text("int b(int);\n", encoding="utf-8")
+            future = time.time() + 10
+            os.utime(detail, (future, future))
+            k2 = _cache_key([umb], [], "c++", extra_hash_dirs=(root,))
+            assert k1 != k2, ext
+            detail.unlink()
+
     def test_without_hash_dir_transitive_edit_is_missed(self, tmp_path):
         # The complementary gap the fix closes: with the root *not* hashed, an
         # edit under it leaves the umbrella-only key unchanged.

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -181,6 +181,29 @@ def test_estimate_resolves_build_info_directory(
     assert l3.tus == 7
 
 
+def test_estimate_finds_compile_db_in_nonhint_subdir(
+    snap_path: Path, tmp_path: Path
+) -> None:
+    # A compile DB in a non-hint immediate subdirectory (cmake-build-debug-gcc/)
+    # is found by the estimate via the same depth-1 fallback the real scan uses,
+    # so --estimate mirrors execution instead of pricing L3 as absent (Codex).
+    tree = tmp_path / "src"
+    sub = tree / "cmake-build-debug-gcc"
+    sub.mkdir(parents=True)
+    (sub / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {"file": f"f{i}.cpp", "command": "c++", "directory": "."}
+                for i in range(5)
+            ]
+        ),
+        encoding="utf-8",
+    )
+    req = ScanRequest(binaries=[snap_path], sources=tree, mode="baseline")
+    l3 = next(e for e in estimate_scan(req) if e.layer == "L3_build")
+    assert l3.tus == 5
+
+
 def test_estimate_header_change_fans_out_to_all_tus(
     snap_path: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -387,7 +387,24 @@ class TestResolveInferredHeaderRoots:
             )
             assert inc == [], tok  # detected as build context → deferred
             assert str(root) in toks, tok
-            assert toks[toks.index(str(root)) - 1] == "-isystem", tok
+            # MSVC build context → defer in MSVC dialect (/I), not GNU -isystem,
+            # which cl.exe/clang-cl would ignore (Codex review).
+            assert toks[toks.index(str(root)) - 1] == "/I", tok
+            assert "-isystem" not in toks, tok
+
+    def test_deferred_flag_dialect_matches_build_context(self, tmp_path):
+        # GNU build context defers with -isystem; MSVC with /I.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        _, gnu = resolve_inferred_header_roots(
+            [umb], [], gcc_options="-I /build/gen"
+        )
+        assert gnu[gnu.index(str(root)) - 1] == "-isystem"
+        _, msvc = resolve_inferred_header_roots(
+            [umb], [], gcc_options="/I build\\gen"
+        )
+        assert msvc[msvc.index(str(root)) - 1] == "/I"
 
     def test_root_already_in_build_context_is_skipped(self, tmp_path):
         # A root the build context already supplies as -I must NOT be re-added as

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -591,6 +591,57 @@ class TestDumpElf:
 # ── _dump_pe() ──────────────────────────────────────────────────────────────
 
 
+class TestHeaderScopedInferredRoots:
+    """P3 parity: the PE/Mach-O header-scoped path also adds inferred -H roots."""
+
+    def _umbrella(self, tmp_path):
+        root = tmp_path / "include"
+        (root / "oneapi").mkdir(parents=True)
+        umb = root / "oneapi" / "tbb.h"
+        umb.write_text("int f(void);\n", encoding="utf-8")
+        return root, umb
+
+    def test_pe_no_build_context_adds_root_as_I(self, tmp_path):
+        from abicheck.service import _try_header_scoped_dump
+
+        root, umb = self._umbrella(tmp_path)
+        captured = {}
+
+        def fake_pe(path, headers, extra_includes, version, compiler, **k):
+            captured["extra_includes"] = extra_includes
+            captured.update(k)
+            return AbiSnapshot(library="x", version="1.0")
+
+        with patch("abicheck.dumper._dump_pe", fake_pe):
+            _try_header_scoped_dump("pe", tmp_path / "x.dll", [umb], [], "1.0", "c++")
+        # no build context → inferred include root rides in extra_includes
+        assert root in captured["extra_includes"]
+
+    def test_macho_build_context_defers_and_hashes(self, tmp_path):
+        from abicheck.service import _try_header_scoped_dump
+        from abicheck.service_scan import CompileContext
+
+        root, umb = self._umbrella(tmp_path)
+        captured = {}
+
+        def fake_macho(path, headers, extra_includes, version, compiler, **k):
+            captured["extra_includes"] = extra_includes
+            captured.update(k)
+            return AbiSnapshot(library="x", version="1.0")
+
+        cc = CompileContext(gcc_option_tokens=("-isystem", str(tmp_path / "gen")))
+        with patch("abicheck.dumper._dump_macho", fake_macho):
+            _try_header_scoped_dump(
+                "macho", tmp_path / "x.dylib", [umb], [], "1.0", "c++", compile=cc
+            )
+        # build context → root defers to -isystem (gcc_option_tokens), not -I,
+        # and its dir is hashed into the cache key (extra_hash_dirs)
+        assert root not in captured["extra_includes"]
+        toks = list(captured["gcc_option_tokens"])
+        assert str(root) in toks and toks[toks.index(str(root)) - 1] == "-isystem"
+        assert root in captured["extra_hash_dirs"]
+
+
 class TestDumpPe:
     def test_no_machine_raises(self, tmp_path):
         from abicheck.service import _dump_pe

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -305,6 +305,19 @@ class TestImplicitHeaderIncludes:
         assert nested in dirs
         assert root in dirs
 
+    def test_namespace_directory_adds_include_root_ancestor(self, tmp_path):
+        # A -H *directory* nested under a conventional root, e.g.
+        # `-H include/oneapi`, must add BOTH itself and the include root —
+        # headers inside still `#include "oneapi/..."` relative to include/.
+        from abicheck.service import _implicit_header_includes
+
+        root = tmp_path / "include"
+        nested = root / "oneapi"
+        nested.mkdir(parents=True)
+        dirs = _implicit_header_includes([nested])
+        assert nested in dirs
+        assert root in dirs
+
     def test_deduplicates(self, tmp_path):
         from abicheck.service import _implicit_header_includes
 

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -389,6 +389,45 @@ class TestResolveInferredHeaderRoots:
             assert str(root) in toks, tok
             assert toks[toks.index(str(root)) - 1] == "-isystem", tok
 
+    def test_root_already_in_build_context_is_skipped(self, tmp_path):
+        # A root the build context already supplies as -I must NOT be re-added as
+        # -isystem (GCC would then ignore the build's -I). Here the build provides
+        # the include root; only the *other* inferred ancestor (oneapi) defers.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)  # include/, umbrella at include/oneapi
+        nested = root / "oneapi"
+        inc, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_options=f"-I {root}"
+        )
+        assert inc == []
+        # the include root is in the build context → not re-emitted at all
+        assert str(root) not in toks
+        # the nested ancestor is not in the build context → deferred via -isystem
+        assert str(nested) in toks
+        assert toks[toks.index(str(nested)) - 1] == "-isystem"
+
+    def test_build_context_dir_attached_form_deduped(self, tmp_path):
+        # The attached spelling (-I<dir>) is parsed too, so the root is skipped.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_option_tokens=(f"-I{root}",)
+        )
+        assert str(root) not in toks
+
+    def test_dangling_include_flag_no_operand(self, tmp_path):
+        # A bare -I with no following dir (build context present but supplies no
+        # parsable dir) still defers the inferred roots via -isystem, no crash.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots([umb], [], gcc_option_tokens=("-I",))
+        assert inc == []
+        assert str(root) in toks
+        assert toks[toks.index(str(root)) - 1] == "-isystem"
+
     def test_non_include_options_are_not_build_context(self, tmp_path):
         # -O2/-DNDEBUG add no include dir, so the inferred root stays a plain -I.
         from abicheck.header_utils import resolve_inferred_header_roots

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -617,6 +617,24 @@ class TestHeaderScopedInferredRoots:
         # no build context → inferred include root rides in extra_includes
         assert root in captured["extra_includes"]
 
+    def test_no_headers_skips_inferred_derivation(self, tmp_path):
+        # With no -H headers the derivation is skipped: the original includes pass
+        # through unchanged and nothing is deferred/hashed.
+        from abicheck.service import _try_header_scoped_dump
+
+        captured = {}
+
+        def fake_pe(path, headers, extra_includes, version, compiler, **k):
+            captured["extra_includes"] = extra_includes
+            captured.update(k)
+            return AbiSnapshot(library="x", version="1.0")
+
+        inc = [tmp_path / "inc"]
+        with patch("abicheck.dumper._dump_pe", fake_pe):
+            _try_header_scoped_dump("pe", tmp_path / "x.dll", [], inc, "1.0", "c++")
+        assert captured["extra_includes"] == inc  # unchanged, no inferred roots
+        assert captured["extra_hash_dirs"] == ()
+
     def test_macho_build_context_defers_and_hashes(self, tmp_path):
         from abicheck.service import _try_header_scoped_dump
         from abicheck.service_scan import CompileContext

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -275,14 +275,14 @@ class TestRunDump:
 
 class TestImplicitHeaderIncludes:
     def test_directory_input_is_its_own_root(self, tmp_path):
-        from abicheck.service import _implicit_header_includes
+        from abicheck.header_utils import _implicit_header_includes
 
         inc = tmp_path / "include"
         inc.mkdir()
         assert _implicit_header_includes([inc]) == [inc]
 
     def test_file_at_root_adds_parent(self, tmp_path):
-        from abicheck.service import _implicit_header_includes
+        from abicheck.header_utils import _implicit_header_includes
 
         inc = tmp_path / "include"
         inc.mkdir()
@@ -294,7 +294,7 @@ class TestImplicitHeaderIncludes:
         # include/oneapi/tbb.h → both its parent (include/oneapi) and the
         # conventional include root (include/) must be on the search path so
         # `#include "oneapi/tbb/..."` resolves.
-        from abicheck.service import _implicit_header_includes
+        from abicheck.header_utils import _implicit_header_includes
 
         root = tmp_path / "include"
         nested = root / "oneapi"
@@ -309,7 +309,7 @@ class TestImplicitHeaderIncludes:
         # A -H *directory* nested under a conventional root, e.g.
         # `-H include/oneapi`, must add BOTH itself and the include root —
         # headers inside still `#include "oneapi/..."` relative to include/.
-        from abicheck.service import _implicit_header_includes
+        from abicheck.header_utils import _implicit_header_includes
 
         root = tmp_path / "include"
         nested = root / "oneapi"
@@ -319,7 +319,7 @@ class TestImplicitHeaderIncludes:
         assert root in dirs
 
     def test_deduplicates(self, tmp_path):
-        from abicheck.service import _implicit_header_includes
+        from abicheck.header_utils import _implicit_header_includes
 
         inc = tmp_path / "include"
         inc.mkdir()
@@ -330,10 +330,64 @@ class TestImplicitHeaderIncludes:
 
     def test_skips_nonexistent_parent(self, tmp_path):
         # A -H file whose parent dir does not exist contributes nothing.
-        from abicheck.service import _implicit_header_includes
+        from abicheck.header_utils import _implicit_header_includes
 
         ghost = tmp_path / "absent" / "x.h"
         assert _implicit_header_includes([ghost]) == []
+
+
+class TestResolveInferredHeaderRoots:
+    def _umbrella(self, tmp_path):
+        root = tmp_path / "include"
+        (root / "oneapi").mkdir(parents=True)
+        umb = root / "oneapi" / "tbb.h"
+        umb.write_text("// umbrella")
+        return root, umb
+
+    def test_no_build_context_uses_plain_I(self, tmp_path):
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots([umb], [])
+        assert root in inc and toks == []
+
+    def test_isystem_context_defers_to_idirafter(self, tmp_path):
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_option_tokens=("-isystem", "/gen")
+        )
+        assert inc == []
+        assert "-idirafter" in toks and str(root) in toks
+
+    def test_gcc_options_include_string_detected(self, tmp_path):
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_options="-I /build/include -O2"
+        )
+        assert inc == [] and str(root) in toks
+
+    def test_non_include_options_are_not_build_context(self, tmp_path):
+        # -O2/-DNDEBUG add no include dir, so the inferred root stays a plain -I.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_options="-O2 -DNDEBUG", gcc_option_tokens=("-Wall",)
+        )
+        assert root in inc and toks == []
+
+    def test_user_include_deduped(self, tmp_path):
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        nested = root / "oneapi"
+        inc, toks = resolve_inferred_header_roots([umb], [nested])
+        # nested came from the user -I; only the include root is inferred-added.
+        assert nested not in inc and root in inc
 
 
 # ── _dump_elf() ─────────────────────────────────────────────────────────────
@@ -355,7 +409,31 @@ class TestDumpElf:
         with patch("abicheck.dumper.dump", return_value=snap) as mock:
             _dump_elf(p, [umb], [], "1.0", "c++")
         passed = mock.call_args.kwargs["extra_includes"]
-        assert root in passed  # the include root was auto-added
+        assert root in passed  # the include root was auto-added (plain -I)
+
+    def test_implicit_root_defers_to_isystem_build_context(self, tmp_path):
+        # Codex: when the caller's CompileContext supplies includes via -isystem,
+        # the inferred -H root must defer (emit as -idirafter, below the -isystem
+        # build dir), not jump ahead of it as -I. (-I always beats -isystem.)
+        from abicheck.service import _dump_elf
+        from abicheck.service_scan import CompileContext
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        root = tmp_path / "include"
+        (root / "oneapi").mkdir(parents=True)
+        umb = root / "oneapi" / "tbb.h"
+        umb.write_text("// umbrella")
+        snap = AbiSnapshot(library="t", version="1.0")
+        cc = CompileContext(gcc_option_tokens=("-isystem", str(tmp_path / "gen")))
+        with patch("abicheck.dumper.dump", return_value=snap) as mock:
+            _dump_elf(p, [umb], [], "1.0", "c++", compile=cc)
+        kwargs = mock.call_args.kwargs
+        assert root not in kwargs["extra_includes"]  # not promoted to -I
+        toks = list(kwargs["gcc_option_tokens"])
+        assert str(root) in toks
+        assert toks[toks.index(str(root)) - 1] == "-idirafter"
+        assert "-isystem" in toks  # build-context token preserved ahead of it
 
     def test_no_headers_warning(self, tmp_path):
         from abicheck.service import _dump_elf

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -270,10 +270,80 @@ class TestRunDump:
         assert result is snap
 
 
+# ── _implicit_header_includes() (P3: -H umbrella resolves without -I) ────────
+
+
+class TestImplicitHeaderIncludes:
+    def test_directory_input_is_its_own_root(self, tmp_path):
+        from abicheck.service import _implicit_header_includes
+
+        inc = tmp_path / "include"
+        inc.mkdir()
+        assert _implicit_header_includes([inc]) == [inc]
+
+    def test_file_at_root_adds_parent(self, tmp_path):
+        from abicheck.service import _implicit_header_includes
+
+        inc = tmp_path / "include"
+        inc.mkdir()
+        umb = inc / "dnnl.hpp"
+        umb.write_text("// umbrella")
+        assert _implicit_header_includes([umb]) == [inc]
+
+    def test_nested_umbrella_adds_include_root_ancestor(self, tmp_path):
+        # include/oneapi/tbb.h → both its parent (include/oneapi) and the
+        # conventional include root (include/) must be on the search path so
+        # `#include "oneapi/tbb/..."` resolves.
+        from abicheck.service import _implicit_header_includes
+
+        root = tmp_path / "include"
+        nested = root / "oneapi"
+        nested.mkdir(parents=True)
+        umb = nested / "tbb.h"
+        umb.write_text("// umbrella")
+        dirs = _implicit_header_includes([umb])
+        assert nested in dirs
+        assert root in dirs
+
+    def test_deduplicates(self, tmp_path):
+        from abicheck.service import _implicit_header_includes
+
+        inc = tmp_path / "include"
+        inc.mkdir()
+        (inc / "a.h").write_text("")
+        (inc / "b.h").write_text("")
+        # Two files in the same dir → the root appears once.
+        assert _implicit_header_includes([inc / "a.h", inc / "b.h"]) == [inc]
+
+    def test_skips_nonexistent_parent(self, tmp_path):
+        # A -H file whose parent dir does not exist contributes nothing.
+        from abicheck.service import _implicit_header_includes
+
+        ghost = tmp_path / "absent" / "x.h"
+        assert _implicit_header_includes([ghost]) == []
+
+
 # ── _dump_elf() ─────────────────────────────────────────────────────────────
 
 
 class TestDumpElf:
+    def test_implicit_header_root_passed_to_dumper(self, tmp_path):
+        # P3 regression: a -H umbrella nested under include/ must reach the
+        # frontend with the include root on extra_includes, with no explicit -I.
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        root = tmp_path / "include"
+        (root / "oneapi").mkdir(parents=True)
+        umb = root / "oneapi" / "tbb.h"
+        umb.write_text("// umbrella")
+        snap = AbiSnapshot(library="t", version="1.0")
+        with patch("abicheck.dumper.dump", return_value=snap) as mock:
+            _dump_elf(p, [umb], [], "1.0", "c++")
+        passed = mock.call_args.kwargs["extra_includes"]
+        assert root in passed  # the include root was auto-added
+
     def test_no_headers_warning(self, tmp_path):
         from abicheck.service import _dump_elf
 

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -393,18 +393,22 @@ class TestResolveInferredHeaderRoots:
             assert "-isystem" not in toks, tok
 
     def test_deferred_flag_dialect_matches_build_context(self, tmp_path):
-        # GNU build context defers with -isystem; MSVC with /I.
+        # The deferred flag matches the build context's lowest include bucket:
+        # above-system GNU (-I/-isystem) → -isystem; MSVC /I → /I; an
+        # -idirafter-only context → -idirafter (so its below-system fallback
+        # keeps priority instead of being shadowed by an -isystem root).
         from abicheck.header_utils import resolve_inferred_header_roots
 
         root, umb = self._umbrella(tmp_path)
-        _, gnu = resolve_inferred_header_roots(
-            [umb], [], gcc_options="-I /build/gen"
-        )
+        _, gnu = resolve_inferred_header_roots([umb], [], gcc_options="-I /build/gen")
         assert gnu[gnu.index(str(root)) - 1] == "-isystem"
-        _, msvc = resolve_inferred_header_roots(
-            [umb], [], gcc_options="/I build\\gen"
-        )
+        _, msvc = resolve_inferred_header_roots([umb], [], gcc_options="/I build\\gen")
         assert msvc[msvc.index(str(root)) - 1] == "/I"
+        _, after = resolve_inferred_header_roots(
+            [umb], [], gcc_options="-idirafter /build/gen"
+        )
+        assert after[after.index(str(root)) - 1] == "-idirafter"
+        assert "-isystem" not in after
 
     def test_root_already_in_build_context_is_skipped(self, tmp_path):
         # A root the build context already supplies as -I must NOT be re-added as

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -417,6 +417,15 @@ class TestResolveInferredHeaderRoots:
         )
         assert str(root) not in toks
 
+    def test_deferred_token_dirs_extracts_isystem_paths(self):
+        from pathlib import Path
+
+        from abicheck.header_utils import deferred_token_dirs
+
+        toks = ["-isystem", "/a/include", "-isystem", "/b/oneapi"]
+        assert deferred_token_dirs(toks) == [Path("/a/include"), Path("/b/oneapi")]
+        assert deferred_token_dirs([]) == []
+
     def test_dangling_include_flag_no_operand(self, tmp_path):
         # A bare -I with no following dir (build context present but supplies no
         # parsable dir) still defers the inferred roots via -isystem, no crash.

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -351,7 +351,9 @@ class TestResolveInferredHeaderRoots:
         inc, toks = resolve_inferred_header_roots([umb], [])
         assert root in inc and toks == []
 
-    def test_isystem_context_defers_to_idirafter(self, tmp_path):
+    def test_isystem_context_defers_via_isystem(self, tmp_path):
+        # A build-context -isystem makes the inferred root defer — emitted as
+        # -isystem (below build context, above standard system dirs), not -I.
         from abicheck.header_utils import resolve_inferred_header_roots
 
         root, umb = self._umbrella(tmp_path)
@@ -359,7 +361,10 @@ class TestResolveInferredHeaderRoots:
             [umb], [], gcc_option_tokens=("-isystem", "/gen")
         )
         assert inc == []
-        assert "-idirafter" in toks and str(root) in toks
+        # every inferred root is emitted as -isystem (not -I, not -idirafter)
+        assert str(root) in toks
+        assert toks[toks.index(str(root)) - 1] == "-isystem"
+        assert "-idirafter" not in toks and "-I" not in toks
 
     def test_gcc_options_include_string_detected(self, tmp_path):
         from abicheck.header_utils import resolve_inferred_header_roots
@@ -369,6 +374,20 @@ class TestResolveInferredHeaderRoots:
             [umb], [], gcc_options="-I /build/include -O2"
         )
         assert inc == [] and str(root) in toks
+
+    def test_msvc_slash_I_context_detected(self, tmp_path):
+        # An MSVC/clang-cl build context (/I, /external:I, /imsvc) must also count
+        # as build context so the inferred root defers instead of shadowing it.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        for tok in ("/Ibuild\\generated", "/external:Igen", "/imsvc"):
+            inc, toks = resolve_inferred_header_roots(
+                [umb], [], gcc_option_tokens=(tok,)
+            )
+            assert inc == [], tok  # detected as build context → deferred
+            assert str(root) in toks, tok
+            assert toks[toks.index(str(root)) - 1] == "-isystem", tok
 
     def test_non_include_options_are_not_build_context(self, tmp_path):
         # -O2/-DNDEBUG add no include dir, so the inferred root stays a plain -I.
@@ -391,7 +410,7 @@ class TestResolveInferredHeaderRoots:
 
     def test_no_inferred_roots_returns_empty(self, tmp_path):
         # A -H file with a nonexistent parent yields no inferred roots → no flags
-        # of either kind (and no spurious -idirafter even with a build context).
+        # of either kind (and no spurious -isystem even with a build context).
         from abicheck.header_utils import resolve_inferred_header_roots
 
         ghost = tmp_path / "absent" / "x.h"
@@ -434,8 +453,9 @@ class TestDumpElf:
 
     def test_implicit_root_defers_to_isystem_build_context(self, tmp_path):
         # Codex: when the caller's CompileContext supplies includes via -isystem,
-        # the inferred -H root must defer (emit as -idirafter, below the -isystem
-        # build dir), not jump ahead of it as -I. (-I always beats -isystem.)
+        # the inferred -H root must defer — emitted as its own -isystem token
+        # *after* the build's (build's is emitted first, so it wins), not jumping
+        # ahead as -I. -isystem also keeps it above the standard system dirs.
         from abicheck.service import _dump_elf
         from abicheck.service_scan import CompileContext
 
@@ -445,16 +465,18 @@ class TestDumpElf:
         (root / "oneapi").mkdir(parents=True)
         umb = root / "oneapi" / "tbb.h"
         umb.write_text("// umbrella")
+        gen = str(tmp_path / "gen")
         snap = AbiSnapshot(library="t", version="1.0")
-        cc = CompileContext(gcc_option_tokens=("-isystem", str(tmp_path / "gen")))
+        cc = CompileContext(gcc_option_tokens=("-isystem", gen))
         with patch("abicheck.dumper.dump", return_value=snap) as mock:
             _dump_elf(p, [umb], [], "1.0", "c++", compile=cc)
         kwargs = mock.call_args.kwargs
         assert root not in kwargs["extra_includes"]  # not promoted to -I
         toks = list(kwargs["gcc_option_tokens"])
         assert str(root) in toks
-        assert toks[toks.index(str(root)) - 1] == "-idirafter"
-        assert "-isystem" in toks  # build-context token preserved ahead of it
+        assert toks[toks.index(str(root)) - 1] == "-isystem"
+        # the build's -isystem dir stays ahead of the inferred root (wins)
+        assert toks.index(gen) < toks.index(str(root))
 
     def test_no_headers_warning(self, tmp_path):
         from abicheck.service import _dump_elf

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -389,6 +389,27 @@ class TestResolveInferredHeaderRoots:
         # nested came from the user -I; only the include root is inferred-added.
         assert nested not in inc and root in inc
 
+    def test_no_inferred_roots_returns_empty(self, tmp_path):
+        # A -H file with a nonexistent parent yields no inferred roots → no flags
+        # of either kind (and no spurious -idirafter even with a build context).
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        ghost = tmp_path / "absent" / "x.h"
+        assert resolve_inferred_header_roots(
+            [ghost], [], gcc_option_tokens=("-isystem", "/x")
+        ) == ([], [])
+
+    def test_malformed_gcc_options_falls_back_to_plain_split(self, tmp_path):
+        # An unbalanced quote makes shlex.split raise; we fall back to str.split
+        # so an -I in a malformed --gcc-options string is still detected.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        inc, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_options='-I "/broken'
+        )
+        assert inc == [] and str(root) in toks
+
 
 # ── _dump_elf() ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to #452, closing out the remaining oneAPI conda-scan findings (P3–P6 from `validation/oneapi-conda-scan-experience-2026-06.md`). #452 fixed the two blockers (silent provenance skip, pattern-scan hang); this addresses the header-ingestion and discoverability friction that made first-run scans hard.

## P3 — a `-H` umbrella now resolves its own includes without a separate `-I`

The most-cited onboarding cliff: a `-H` umbrella header failed unless you *also* passed `-I <include-root>`, because the root wasn't on the compiler search path. `service._dump_elf` and `cli_dump_helpers.perform_elf_dump` now auto-add the public-header roots: a `-H` **directory** is its own root; a `-H` **file** contributes its parent **plus** any ancestor conventionally named `include`/`inc` (so `include/oneapi/tbb.h`'s `#include "oneapi/tbb/..."` resolves). User `-I`/`--include` entries still take precedence (listed first).

**Verified on the real conda binaries** — all three parse from `-H <umbrella>` alone now (previously needed `-I`):

| Lib | `-H <umbrella>` (no `-I`) | result |
|-----|--------------------------|--------|
| oneDNN | `include/dnnl.hpp` | 518 types / 13127 funcs ✅ |
| oneTBB | `include/oneapi/tbb.h` | 913 types / 24603 funcs ✅ |
| oneDAL | `include/oneapi/dal.hpp` | 954 types / 20708 funcs ✅ |

*Scope note:* the `-H <dir>`-glob form still pulls in **optional backend** headers (OpenCL/SYCL: `dnnl_ocl.h` → `CL/cl.h`) and **preview** headers gated by `#error` macros (oneTBB's `blocked_rangeNd.h`), which need their SDK or a `-D` macro. That's **documented, not changed** — handling it means dropping headers from the umbrella TU, which touches the L2-completeness contract and is a separate decision. The umbrella header (recommended) sidesteps both.

## P4 — broaden compile-DB auto-discovery

`_autodiscover_compile_db` now also checks **any immediate subdirectory** of the source tree (catches `cmake-build-debug-gcc`, `build-release`, IDE/preset dirs), not just the fixed hint list, before reporting L3 absent. Deterministic (sorted), depth-1, hints still take precedence.

## P5 — new runbook: *Scanning a Conda-Forge Package*

`docs/user-guide/scanning-conda-packages.md` (in nav): which package ships the `.so` vs headers (and the third `*-include` package), conda↔upstream version mapping, the umbrella-header recipe, the deep-depth compile-DB requirement, and static-only/packaging workarounds.

## P6 — silence the misleading C→C++ self-heal note

The clang note ("pass `--lang c++` to silence") fired on every pure-`#include` umbrella **even when the user passed `--lang c++`** (the default c++ maps to auto-detect). The retry self-heals and the result is unaffected, so it's demoted `warning`→`debug` (no longer stderr noise). The castxml warning — reached only via explicit `--lang c`, where the advice is correct — is unchanged.

## Tests & validation
- `_implicit_header_includes` (dir / file-at-root / nested-ancestor / dedup) + the `_dump_elf` wiring; broadened auto-discovery (hint / subdir / precedence / none); `test_compare_input_modes` updated for the auto-added header root.
- Full fast suite **11646 passed**; `ruff check` clean; `mypy abicheck/` clean (193 files); `check_ai_readiness.py` **0 errors**; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9JvqdGEZwYpfDKqWdWiRq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved `compile_commands.json` auto-discovery for both `--sources` and `--build-info`, now using consistent logic and a deterministic best-effort scan of immediate subdirectories.
  * ELF dumping now automatically augments compiler include paths from `-H` inputs, including umbrella-header–derived `include/` roots, while keeping user `-I` precedence.
* **Documentation**
  * Added a user guide for scanning conda-forge packages and linked it in the navigation.
* **Bug Fixes**
  * Lowered the C→C++ self-healing retry message from warning to debug.
* **Tests**
  * Expanded coverage for compile DB discovery, implicit include-root forwarding, and updated include-related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->