### PR TITLE
fix: defer inferred header root in the MSVC build context's own bucket (#454)

### DIFF
--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -245,6 +245,31 @@ _ABOVE_SYSTEM_GNU_PREFIXES = ("-I", "-iquote", "-isystem", "-cxx-isystem")
 _MSVC_SYSTEM_BUCKETS = ("/imsvc", "/external:I")
 
 
+def _flag_tokens(toks: list[str]) -> list[str]:
+    """*toks* with the operands of spaced include flags dropped.
+
+    A spaced include flag (``-I dir`` / ``/imsvc dir`` / ``/external:I dir`` …,
+    where the token equals the bare prefix) consumes the *next* token as its
+    directory operand. That operand is a path, not a flag, so it must not be
+    matched against flag spellings — otherwise a dir that merely *starts with* a
+    bucket name (``/I /imsvc-sdk``) is misread as an ``/imsvc`` flag (CodeRabbit
+    review). Returns only the genuine flag tokens. Attached forms (``-Idir`` /
+    ``/external:Idir``) carry their own operand and stay; the bare-prefix
+    (spaced) form is the only one whose successor is a separate operand.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(toks)
+    while i < n:
+        t = toks[i]
+        out.append(t)
+        if t in _INCLUDE_FLAG_PREFIXES and i + 1 < n:
+            i += 2  # skip the directory operand of a spaced include flag
+        else:
+            i += 1
+    return out
+
+
 def _msvc_deferred_flag(toks: list[str]) -> str:
     """The MSVC/clang-cl bucket to defer an inferred root below *toks* (#454).
 
@@ -262,8 +287,9 @@ def _msvc_deferred_flag(toks: list[str]) -> str:
     ``/I`` for a plain ``/I``-only context — there is no system bucket to shadow,
     so command-line order (after the build's own ``/I`` dirs) suffices.
     """
+    flags = _flag_tokens(toks)
     for bucket in _MSVC_SYSTEM_BUCKETS:
-        if any(t.startswith(bucket) for t in toks):
+        if any(t.startswith(bucket) for t in flags):
             return bucket
     return "/I"
 

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -224,10 +224,14 @@ def _msvc_style_context(toks: list[str]) -> bool:
 
     Distinguishes ``/I``/``/external:I``/``/imsvc`` from the GNU forms so the
     deferred inferred root is emitted in the same dialect — a GNU ``-isystem``
-    is silently ignored by ``cl.exe``/``clang-cl`` (Codex review).
+    is silently ignored by ``cl.exe``/``clang-cl`` (Codex review). Operands of
+    spaced include flags are stripped first (:func:`_flag_tokens`) so a GNU
+    context whose directory merely *starts with* a slash spelling
+    (``-I /imsvc-sdk``) is not misread as MSVC and routed to the wrong dialect
+    (CodeRabbit review).
     """
     msvc = ("/I", "/external:I", "/imsvc")
-    return any(t.startswith(p) for t in toks for p in msvc)
+    return any(t.startswith(p) for t in _flag_tokens(toks) for p in msvc)
 
 
 #: GNU/clang include classes searched *before* the standard system dirs. An

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -191,7 +191,9 @@ def resolve_inferred_header_roots(
       :func:`_deferred_include_flag`): ``-isystem`` below an above-system build
       context (``-I``/``-isystem``/…, still above the standard system dirs so the
       ``<endian.h>`` case resolves the package header), ``-idirafter`` below an
-      ``-idirafter``-only build context, or ``/I`` for an MSVC/clang-cl one.
+      ``-idirafter``-only build context, or — for an MSVC/clang-cl context — the
+      build's own lowest include bucket (``/external:I`` / ``/imsvc`` / ``/I``)
+      so the root never shadows the build's system dirs (#454).
 
     Shared by the ``dump`` CLI path (``cli_dump_helpers.perform_elf_dump``) and
     the service/``scan`` path (``service._dump_elf``) so they cannot drift.
@@ -234,6 +236,33 @@ def _msvc_style_context(toks: list[str]) -> bool:
 #: is deliberately absent — it is searched *after* the system dirs.
 _ABOVE_SYSTEM_GNU_PREFIXES = ("-I", "-iquote", "-isystem", "-cxx-isystem")
 
+#: MSVC/clang-cl *system*-include buckets, searched after the plain ``/I``
+#: directories but still above the standard ``INCLUDE`` dirs. Ordered by
+#: preference for a deferred root: ``/external:I`` first (understood by both
+#: ``cl.exe`` — with ``/experimental:external`` on older toolsets — and
+#: ``clang-cl``), then ``/imsvc`` (``clang-cl`` only).
+_MSVC_SYSTEM_BUCKETS = ("/external:I", "/imsvc")
+
+
+def _msvc_deferred_flag(toks: list[str]) -> str:
+    """The MSVC/clang-cl bucket to defer an inferred root below *toks* (#454).
+
+    Mirrors the build context's own *lowest* include bucket so the deferred
+    root can never shadow it: if the context uses a system bucket
+    (``/external:I``/``/imsvc``), emit in that *same* bucket — a plain ``/I``
+    root is searched *before* those system dirs and could shadow them. Mirroring
+    the bucket the context actually used is frontend-agnostic: the frontend that
+    will run must already understand that spelling (it consumed the same flag on
+    input), which sidesteps threading the ``cl.exe``-vs-``clang-cl`` identity
+    into this pure helper. Falls back to ``/I`` for a plain ``/I``-only context
+    — there is no system bucket to shadow, so command-line order (after the
+    build's own ``/I`` dirs) suffices.
+    """
+    for bucket in _MSVC_SYSTEM_BUCKETS:
+        if any(t.startswith(bucket) for t in toks):
+            return bucket
+    return "/I"
+
 
 def _deferred_include_flag(toks: list[str]) -> str:
     """The flag to defer an inferred ``-H`` root below the build-context *toks*.
@@ -241,8 +270,10 @@ def _deferred_include_flag(toks: list[str]) -> str:
     The root must search *after* every build-context include dir; the bucket
     that achieves that depends on the build context's own flags:
 
-    * MSVC/clang-cl (``/I``/…) → ``/I`` (deferred by command-line order — a GNU
-      ``-isystem`` is silently ignored by ``cl.exe``/``clang-cl``);
+    * MSVC/clang-cl (``/I``/``/external:I``/``/imsvc``) → the build's lowest
+      bucket via :func:`_msvc_deferred_flag` (a system-bucket context keeps the
+      root from shadowing ``/external:I``/``/imsvc`` dirs; a GNU ``-isystem`` is
+      silently ignored by ``cl.exe``/``clang-cl`` either way);
     * any *above-system* GNU class (``-I``/``-iquote``/``-isystem``/
       ``-cxx-isystem``) → ``-isystem`` (searched after those, still above the
       standard system dirs so a system-colliding basename resolves the package
@@ -252,7 +283,7 @@ def _deferred_include_flag(toks: list[str]) -> str:
       same class, so the build's fallback keeps priority — Codex review).
     """
     if _msvc_style_context(toks):
-        return "/I"
+        return _msvc_deferred_flag(toks)
     if any(t.startswith(p) for t in toks for p in _ABOVE_SYSTEM_GNU_PREFIXES):
         return "-isystem"
     return "-idirafter"
@@ -266,7 +297,8 @@ def deferred_token_dirs(deferred_tokens: Sequence[str]) -> list[Path]:
     ``extra_includes`` dirs — would miss edits to their transitively-included
     headers and reuse a stale AST (Codex review). Callers pass these dirs to the
     dumper as hash-only inputs. Pairs the flat ``[flag, dir, …]`` list (the flag
-    is ``-isystem`` for GNU contexts, ``/I`` for MSVC ones).
+    is ``-isystem``/``-idirafter`` for GNU contexts, ``/I``/``/external:I``/
+    ``/imsvc`` for MSVC ones — every pair is two tokens regardless).
     """
     return [Path(d) for _flag, d in zip(deferred_tokens[::2], deferred_tokens[1::2])]
 

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -237,11 +237,12 @@ def _msvc_style_context(toks: list[str]) -> bool:
 _ABOVE_SYSTEM_GNU_PREFIXES = ("-I", "-iquote", "-isystem", "-cxx-isystem")
 
 #: MSVC/clang-cl *system*-include buckets, searched after the plain ``/I``
-#: directories but still above the standard ``INCLUDE`` dirs. Ordered by
-#: preference for a deferred root: ``/external:I`` first (understood by both
-#: ``cl.exe`` — with ``/experimental:external`` on older toolsets — and
-#: ``clang-cl``), then ``/imsvc`` (``clang-cl`` only).
-_MSVC_SYSTEM_BUCKETS = ("/external:I", "/imsvc")
+#: directories but still above the standard ``INCLUDE`` dirs. Listed
+#: **lowest-search-priority first** — ``clang-cl`` searches ``/imsvc`` dirs (added
+#: "as if in ``%INCLUDE%``") *after* ``/external:I`` dirs, so ``/imsvc`` is the
+#: lower bucket. :func:`_msvc_deferred_flag` returns the first present here so a
+#: deferred root lands in the build's lowest bucket and can never shadow it.
+_MSVC_SYSTEM_BUCKETS = ("/imsvc", "/external:I")
 
 
 def _msvc_deferred_flag(toks: list[str]) -> str:
@@ -249,14 +250,17 @@ def _msvc_deferred_flag(toks: list[str]) -> str:
 
     Mirrors the build context's own *lowest* include bucket so the deferred
     root can never shadow it: if the context uses a system bucket
-    (``/external:I``/``/imsvc``), emit in that *same* bucket — a plain ``/I``
-    root is searched *before* those system dirs and could shadow them. Mirroring
-    the bucket the context actually used is frontend-agnostic: the frontend that
-    will run must already understand that spelling (it consumed the same flag on
-    input), which sidesteps threading the ``cl.exe``-vs-``clang-cl`` identity
-    into this pure helper. Falls back to ``/I`` for a plain ``/I``-only context
-    — there is no system bucket to shadow, so command-line order (after the
-    build's own ``/I`` dirs) suffices.
+    (``/external:I``/``/imsvc``), emit in the *lowest-searched* one present — a
+    plain ``/I`` root is searched *before* those system dirs and could shadow
+    them, and even an ``/external:I`` root is searched before the build's
+    ``/imsvc`` (``%INCLUDE%``-style) dirs (Codex review). Mirroring a bucket the
+    context actually used is frontend-agnostic: the frontend that will run must
+    already understand that spelling (it consumed the same flag on input) — in
+    particular a context that uses ``/imsvc`` is necessarily ``clang-cl``, since
+    ``cl.exe`` rejects ``/imsvc`` — which sidesteps threading the
+    ``cl.exe``-vs-``clang-cl`` identity into this pure helper. Falls back to
+    ``/I`` for a plain ``/I``-only context — there is no system bucket to shadow,
+    so command-line order (after the build's own ``/I`` dirs) suffices.
     """
     for bucket in _MSVC_SYSTEM_BUCKETS:
         if any(t.startswith(bucket) for t in toks):

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -377,20 +377,51 @@ class TestResolveInferredHeaderRoots:
 
     def test_msvc_slash_I_context_detected(self, tmp_path):
         # An MSVC/clang-cl build context (/I, /external:I, /imsvc) must also count
-        # as build context so the inferred root defers instead of shadowing it.
+        # as build context so the inferred root defers instead of shadowing it,
+        # and in the MSVC dialect (never GNU -isystem, which cl.exe/clang-cl
+        # would ignore). The deferred bucket mirrors the context's own lowest
+        # bucket so the root can't shadow /external:I//imsvc system dirs (#454):
+        # a plain /I context stays /I; a system-bucket context echoes it.
         from abicheck.header_utils import resolve_inferred_header_roots
 
+        cases = {
+            "/Ibuild\\generated": "/I",
+            "/external:Igen": "/external:I",
+            "/imsvc": "/imsvc",
+        }
         root, umb = self._umbrella(tmp_path)
-        for tok in ("/Ibuild\\generated", "/external:Igen", "/imsvc"):
+        for tok, want in cases.items():
             inc, toks = resolve_inferred_header_roots(
                 [umb], [], gcc_option_tokens=(tok,)
             )
             assert inc == [], tok  # detected as build context → deferred
             assert str(root) in toks, tok
-            # MSVC build context → defer in MSVC dialect (/I), not GNU -isystem,
-            # which cl.exe/clang-cl would ignore (Codex review).
-            assert toks[toks.index(str(root)) - 1] == "/I", tok
+            assert toks[toks.index(str(root)) - 1] == want, tok
             assert "-isystem" not in toks, tok
+
+    def test_msvc_system_bucket_root_does_not_shadow(self, tmp_path):
+        # #454 item 3: when the MSVC context uses a system bucket, the deferred
+        # root must echo that bucket (not collapse to /I, which clang-cl lowers
+        # to -I and searches *above* the /external:I//imsvc system dirs). With
+        # both a plain /I and a system bucket present, the system bucket wins so
+        # the root sits below every build-context include dir.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        _, ext = resolve_inferred_header_roots(
+            [umb], [], gcc_options="/I build\\gen /external:I third_party"
+        )
+        assert ext[ext.index(str(root)) - 1] == "/external:I"
+        _, imsvc = resolve_inferred_header_roots(
+            [umb], [], gcc_options="/I build\\gen /imsvc clang_sys"
+        )
+        assert imsvc[imsvc.index(str(root)) - 1] == "/imsvc"
+        # /external:I is preferred over /imsvc when both appear (broadest
+        # frontend support — cl.exe understands /external:I, not /imsvc).
+        _, both = resolve_inferred_header_roots(
+            [umb], [], gcc_options="/imsvc a /external:I b"
+        )
+        assert both[both.index(str(root)) - 1] == "/external:I"
 
     def test_deferred_flag_dialect_matches_build_context(self, tmp_path):
         # The deferred flag matches the build context's lowest include bucket:
@@ -418,9 +449,7 @@ class TestResolveInferredHeaderRoots:
 
         root, umb = self._umbrella(tmp_path)  # include/, umbrella at include/oneapi
         nested = root / "oneapi"
-        inc, toks = resolve_inferred_header_roots(
-            [umb], [], gcc_options=f"-I {root}"
-        )
+        inc, toks = resolve_inferred_header_roots([umb], [], gcc_options=f"-I {root}")
         assert inc == []
         # the include root is in the build context → not re-emitted at all
         assert str(root) not in toks
@@ -493,9 +522,7 @@ class TestResolveInferredHeaderRoots:
         from abicheck.header_utils import resolve_inferred_header_roots
 
         root, umb = self._umbrella(tmp_path)
-        inc, toks = resolve_inferred_header_roots(
-            [umb], [], gcc_options='-I "/broken'
-        )
+        inc, toks = resolve_inferred_header_roots([umb], [], gcc_options='-I "/broken')
         assert inc == [] and str(root) in toks
 
 

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -375,7 +375,15 @@ class TestResolveInferredHeaderRoots:
         )
         assert inc == [] and str(root) in toks
 
-    def test_msvc_slash_I_context_detected(self, tmp_path):
+    @pytest.mark.parametrize(
+        ("tok", "want"),
+        [
+            ("/Ibuild\\generated", "/I"),
+            ("/external:Igen", "/external:I"),
+            ("/imsvc", "/imsvc"),
+        ],
+    )
+    def test_msvc_slash_I_context_detected(self, tmp_path, tok, want):
         # An MSVC/clang-cl build context (/I, /external:I, /imsvc) must also count
         # as build context so the inferred root defers instead of shadowing it,
         # and in the MSVC dialect (never GNU -isystem, which cl.exe/clang-cl
@@ -384,20 +392,12 @@ class TestResolveInferredHeaderRoots:
         # a plain /I context stays /I; a system-bucket context echoes it.
         from abicheck.header_utils import resolve_inferred_header_roots
 
-        cases = {
-            "/Ibuild\\generated": "/I",
-            "/external:Igen": "/external:I",
-            "/imsvc": "/imsvc",
-        }
         root, umb = self._umbrella(tmp_path)
-        for tok, want in cases.items():
-            inc, toks = resolve_inferred_header_roots(
-                [umb], [], gcc_option_tokens=(tok,)
-            )
-            assert inc == [], tok  # detected as build context → deferred
-            assert str(root) in toks, tok
-            assert toks[toks.index(str(root)) - 1] == want, tok
-            assert "-isystem" not in toks, tok
+        inc, toks = resolve_inferred_header_roots([umb], [], gcc_option_tokens=(tok,))
+        assert inc == []  # detected as build context → deferred
+        assert str(root) in toks
+        assert toks[toks.index(str(root)) - 1] == want
+        assert "-isystem" not in toks
 
     def test_msvc_system_bucket_root_does_not_shadow(self, tmp_path):
         # #454 item 3: when the MSVC context uses a system bucket, the deferred
@@ -424,6 +424,19 @@ class TestResolveInferredHeaderRoots:
             [umb], [], gcc_options="/imsvc a /external:I b"
         )
         assert both[both.index(str(root)) - 1] == "/imsvc"
+
+    def test_msvc_bucket_not_fooled_by_include_operand(self, tmp_path):
+        # A spaced /I operand that merely *starts with* a bucket name (a dir
+        # literally called /imsvc-sdk) must NOT be read as an /imsvc flag — the
+        # only real flag here is /I, so the deferred root stays /I (CodeRabbit
+        # review). Picking /imsvc would emit a flag cl.exe rejects.
+        from abicheck.header_utils import resolve_inferred_header_roots
+
+        root, umb = self._umbrella(tmp_path)
+        _, toks = resolve_inferred_header_roots(
+            [umb], [], gcc_option_tokens=("/I", "/imsvc-sdk")
+        )
+        assert toks[toks.index(str(root)) - 1] == "/I"
 
     def test_deferred_flag_dialect_matches_build_context(self, tmp_path):
         # The deferred flag matches the build context's lowest include bucket:

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -416,12 +416,14 @@ class TestResolveInferredHeaderRoots:
             [umb], [], gcc_options="/I build\\gen /imsvc clang_sys"
         )
         assert imsvc[imsvc.index(str(root)) - 1] == "/imsvc"
-        # /external:I is preferred over /imsvc when both appear (broadest
-        # frontend support — cl.exe understands /external:I, not /imsvc).
+        # When both appear, the *lowest-searched* bucket wins: clang-cl searches
+        # /imsvc (%INCLUDE%-style) dirs after /external:I, so deferring into
+        # /imsvc keeps the root below the build's /imsvc dirs too (Codex review).
+        # A context using /imsvc is necessarily clang-cl, so /imsvc is supported.
         _, both = resolve_inferred_header_roots(
             [umb], [], gcc_options="/imsvc a /external:I b"
         )
-        assert both[both.index(str(root)) - 1] == "/external:I"
+        assert both[both.index(str(root)) - 1] == "/imsvc"
 
     def test_deferred_flag_dialect_matches_build_context(self, tmp_path):
         # The deferred flag matches the build context's lowest include bucket:

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -438,6 +438,14 @@ class TestResolveInferredHeaderRoots:
         )
         assert toks[toks.index(str(root)) - 1] == "/I"
 
+        # The mirror case: a *GNU* -I context whose operand dir starts with a
+        # slash spelling must not be misclassified as MSVC (dialect detection
+        # filters operands too) — it stays the GNU -isystem bucket.
+        _, gnu_toks = resolve_inferred_header_roots(
+            [umb], [], gcc_option_tokens=("-I", "/imsvc-sdk")
+        )
+        assert gnu_toks[gnu_toks.index(str(root)) - 1] == "-isystem"
+
     def test_deferred_flag_dialect_matches_build_context(self, tmp_path):
         # The deferred flag matches the build context's lowest include bucket:
         # above-system GNU (-I/-isystem) → -isystem; MSVC /I → /I; an


### PR DESCRIPTION
Fixes item 3 of #454 (MSVC system-bucket dialect for the inferred public-header root).

## Problem

When an MSVC/clang-cl build context uses a *system*-style include bucket (`/external:I` or `/imsvc`), `resolve_inferred_header_roots` deferred the inferred public-header root as a plain `/I`. clang-cl lowers `/I` to `-I`, which is searched **above** the build's `/external:I`/`/imsvc` system dirs — so the inferred root could shadow them.

The issue flagged this as needing the frontend identity (cl.exe vs clang-cl) threaded into the pure helper to pick `/external:I` vs `/imsvc`, and deferred it on that basis.

## Fix

Mirror the build context's **own lowest include bucket** instead of guessing the frontend:

- a `/external:I` context → defer with `/external:I` (preferred — understood by both `cl.exe`, with `/experimental:external` on older toolsets, and `clang-cl`),
- a `/imsvc` context → defer with `/imsvc`,
- a plain `/I`-only context → stay `/I` (deferred by command-line order; no system bucket to shadow).

Mirroring the spelling the context actually used is **frontend-agnostic**: the frontend that will run must already understand that flag because it consumed the same one on input. This sidesteps threading the cl.exe-vs-clang-cl identity into the pure `resolve_inferred_header_roots` helper — the blocker noted in the issue. All MSVC include buckets sit above the standard `INCLUDE` dirs, so the deferred root still stays above them (a system-colliding basename resolves the package header), matching the GNU `-isystem` behaviour.

## Changes

- `abicheck/header_utils.py`: new `_msvc_deferred_flag` (+ `_MSVC_SYSTEM_BUCKETS`) wired into `_deferred_include_flag`; docstrings updated.
- `tests/test_service_unit.py`: updated `test_msvc_slash_I_context_detected` to assert the mirrored bucket, and added `test_msvc_system_bucket_root_does_not_shadow`.

## Verification

- Full fast unit suite: 11675 passed.
- `ruff check` / `ruff format --check` / `mypy abicheck/` clean.
- `scripts/check_ai_readiness.py`: 0 errors.

Items 2 (genuinely unsatisfiable with a single flag) and 4 (esoteric catch-all) of #454 are left as documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYAMRiHtHiQGUJfJa4aE8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYAMRiHtHiQGUJfJa4aE8Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSVC/clang-cl inferred header root deferral to match the lowest include bucket actually present in the build context, honoring `/external:I` first, then `/imsvc`, otherwise falling back to `/I`.

* **Tests**
  * Expanded coverage with token-to-expected-bucket checks for MSVC/clang-cl.
  * Added assertions for correct precedence when multiple system buckets exist and ensured spaced include operands aren’t misclassified by `/imsvc`-like prefixes.
  * Reformatted a few tests without changing behavior.

* **Documentation**
  * Clarified deferred-include flag behavior for GNU vs MSVC contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->