### PR TITLE
fix: keep inferred cmake build dir alive until scan's S2 phase + end-to-end scan-levels validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ cmake
+          sudo apt-get install -y castxml gcc g++ cmake clang
       - name: Install system deps (macOS)
         if: runner.os == 'macOS'
         run: brew install castxml cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,11 @@ jobs:
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update -qq
+          # Don't let a flaky pre-baked third-party apt repo (e.g. the runner's
+          # packages.microsoft.com returning 403/"no longer signed") fail the lane:
+          # tolerate `update` errors — the `install` below still fails loudly if any
+          # of the packages it needs are genuinely unavailable.
+          sudo apt-get update -qq || sudo apt-get update -qq || true
           sudo apt-get install -y castxml gcc g++ cmake clang
       - name: Install system deps (macOS)
         if: runner.os == 'macOS'

--- a/abicheck/buildsource/build_query.py
+++ b/abicheck/buildsource/build_query.py
@@ -51,6 +51,7 @@ only :func:`run_inferred_build_query` touches the filesystem / subprocess.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import hashlib
 import os
@@ -59,7 +60,7 @@ import stat as _stat
 import subprocess
 import tempfile
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 from .build_evidence import BuildEvidence
@@ -243,6 +244,21 @@ def _release_inferred_build_dir(build_dir: Path, release: Callable[[], None]) ->
     """Remove the inferred cmake build dir, then release its claim."""
     shutil.rmtree(build_dir, ignore_errors=True)
     release()
+
+
+def drain_build_dir_cleanups(cleanups: Iterable[Callable[[], None]]) -> None:
+    """Run every inferred-build-dir cleanup thunk, best-effort.
+
+    Each thunk removes a temp cmake build dir and releases its lock. A thunk *can*
+    still raise (e.g. ``flock(LOCK_UN)`` on a churned fd), so each call is wrapped in
+    ``suppress`` — one failing thunk must not abort the remaining cleanups (which
+    would leak the other dirs/locks) nor, when run from a caller's ``finally``,
+    replace an in-flight exception with a stray ``OSError``. The single drain site
+    shared by ``inline.collect_inline_pack``, ``cli_scan`` and ``service_scan``.
+    """
+    for cleanup in cleanups:
+        with contextlib.suppress(Exception):
+            cleanup()
 
 
 #: Build-system marker files, checked most-specific first. CMake wins over Make

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -659,8 +659,9 @@ def collect_inline_pack(
         if defer_cleanup is not None:
             defer_cleanup.extend(query_build_cleanups)
         else:
-            for _cleanup in query_build_cleanups:
-                _cleanup()
+            from .build_query import drain_build_dir_cleanups
+
+            drain_build_dir_cleanups(query_build_cleanups)
 
     has_build = bool(
         merged.compile_units

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -528,6 +528,7 @@ def collect_inline_pack(
     source_abi_cache_dir: Path | None = None,
     exported_symbols: tuple[str, ...] = (),
     changed_paths: tuple[str, ...] = (),
+    defer_cleanup: list[Callable[[], None]] | None = None,
 ) -> BuildSourcePack | None:
     """Collect an in-memory pack from raw source-tree / build-info inputs.
 
@@ -648,11 +649,18 @@ def collect_inline_pack(
         else None
     )
 
-    # L3/L4/L5 are now collected into in-memory evidence; the out-of-tree inferred
-    # cmake build dir (kept alive through L4 replay's clang cwd) can be removed and
-    # its exclusive lock released.
-    for _cleanup in query_build_cleanups:
-        _cleanup()
+    # L3/L4/L5 are now collected into in-memory evidence. The out-of-tree inferred
+    # cmake build dir can normally be removed (and its lock released) here. But a
+    # caller running *later* phases that re-use the compile units' `directory` as a
+    # cwd — the `scan` flow's S2 preprocessor scan runs `clang -E` there *after*
+    # this returns — passes `defer_cleanup` to take ownership and remove the dir
+    # only once the whole scan is done (else `clang -E` hits a deleted cwd). Without
+    # it (e.g. `dump --sources`), remove immediately.
+    if defer_cleanup is not None:
+        defer_cleanup.extend(query_build_cleanups)
+    else:
+        for _cleanup in query_build_cleanups:
+            _cleanup()
 
     has_build = bool(
         merged.compile_units

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -566,101 +566,101 @@ def collect_inline_pack(
     # evidence. Each thunk removes its dir and releases the dir's exclusive lock.
     query_build_cleanups: list[Callable[[], None]] = []
 
-    if base_build is not None:
-        merged.merge(base_build)
+    try:
+        if base_build is not None:
+            merged.merge(base_build)
 
-    if merged.compile_units:
-        compile_db = None  # already seeded from a build-info pack
-    elif _maybe_collect_bazel_build_info(build_info, merged, extractors):
-        # A pre-captured Bazel aquery/cquery jsonproto produces BuildEvidence
-        # directly (no compile_commands.json to load) — ADR-037 D5 #5 sniffing.
-        compile_db = None
-    else:
-        compile_db = _resolve_compile_db(
-            build_info,
-            sources,
-            cfg,
-            build_config_trusted_for_query,
-            merged,
-            extractors,
-            cleanup=query_build_cleanups,
-            compile_db_explicit=compile_db_explicit,
-        )
-    if compile_db is not None:
-        _run_compile_db(compile_db, cfg.system, merged, extractors, build_cache_dir)
+        if merged.compile_units:
+            compile_db = None  # already seeded from a build-info pack
+        elif _maybe_collect_bazel_build_info(build_info, merged, extractors):
+            # A pre-captured Bazel aquery/cquery jsonproto produces BuildEvidence
+            # directly (no compile_commands.json to load) — ADR-037 D5 #5 sniffing.
+            compile_db = None
+        else:
+            compile_db = _resolve_compile_db(
+                build_info,
+                sources,
+                cfg,
+                build_config_trusted_for_query,
+                merged,
+                extractors,
+                cleanup=query_build_cleanups,
+                compile_db_explicit=compile_db_explicit,
+            )
+        if compile_db is not None:
+            _run_compile_db(compile_db, cfg.system, merged, extractors, build_cache_dir)
 
-    # A4: with both a --sources tree and L3 compile units, flag when the build
-    # metadata describes a different checkout than the source tree (decoupled
-    # inputs assembled from different trees). Collection-time diagnostic, not a
-    # ChangeKind — collection has no findings list (cf. A2).
-    _check_build_info_source_mismatch(merged, sources, extractors)
+        # A4: with both a --sources tree and L3 compile units, flag when the build
+        # metadata describes a different checkout than the source tree (decoupled
+        # inputs assembled from different trees). Collection-time diagnostic, not a
+        # ChangeKind — collection has no findings list (cf. A2).
+        _check_build_info_source_mismatch(merged, sources, extractors)
 
-    surface = None
-    if "L4" in layers:
-        # A 'changed' scope with no PR diff would select zero TUs and embed an
-        # empty L4 surface (Codex review), so fall back to a non-empty scope that
-        # still enables the source-only checks. But when the caller *did* thread an
-        # explicit changed-path set (PR replay, ADR-035 D7 POI focusing), honour
-        # 'changed' so the scan narrows to the affected TUs.
-        #
-        # The unseeded fallback is 'headers-only' (the public-API-covering TU
-        # subset), NOT 'target' (the whole target): an unseeded s5/pr run otherwise
-        # silently pays full-target (== s6) replay cost — the ADR-035 P3 cliff
-        # (validation/uxl-scan-levels-timing-2026-06.md). 'headers-only' keeps a
-        # non-empty public surface for the cross-checks at a fraction of the cost;
-        # the caller (cli_scan) emits the advisory naming --since to focus further.
-        replay_scope = (
-            "headers-only" if (scope == "changed" and not changed_paths) else scope
+        surface = None
+        if "L4" in layers:
+            # A 'changed' scope with no PR diff would select zero TUs and embed an
+            # empty L4 surface (Codex review), so fall back to a non-empty scope that
+            # still enables the source-only checks. But when the caller *did* thread an
+            # explicit changed-path set (PR replay, ADR-035 D7 POI focusing), honour
+            # 'changed' so the scan narrows to the affected TUs.
+            #
+            # The unseeded fallback is 'headers-only' (the public-API-covering TU
+            # subset), NOT 'target' (the whole target): an unseeded s5/pr run otherwise
+            # silently pays full-target (== s6) replay cost — the ADR-035 P3 cliff
+            # (validation/uxl-scan-levels-timing-2026-06.md). 'headers-only' keeps a
+            # non-empty public surface for the cross-checks at a fraction of the cost;
+            # the caller (cli_scan) emits the advisory naming --since to focus further.
+            replay_scope = (
+                "headers-only" if (scope == "changed" and not changed_paths) else scope
+            )
+            # L4 per-TU cache dir: explicit arg wins, else the ABICHECK_L4_CACHE_DIR
+            # env (the CI-friendly knob — point it at a restored cache directory).
+            l4_cache_dir = source_abi_cache_dir
+            if l4_cache_dir is None:
+                env_dir = os.environ.get("ABICHECK_L4_CACHE_DIR")
+                l4_cache_dir = Path(env_dir) if env_dir else None
+            surface = _run_inline_source_abi(
+                sources,
+                merged,
+                extractors,
+                extractor=extractor,
+                scope=replay_scope,
+                clang_bin=clang_bin,
+                exported_symbols=exported_symbols,
+                source_abi_cache_dir=l4_cache_dir,
+                changed_paths=changed_paths,
+            )
+        # Fold a call graph (DECL_CALLS_DECL edges) into the L5 graph whenever L4 also
+        # ran — i.e. a semantic source mode (source-*/graph-summary/graph-full), not
+        # the structural-only graph-build (L3+L5, no L4). This is what makes the
+        # decl-dependency cross-checks (public_to_internal_dependency, ADR-035 D4)
+        # reachable from `scan --source-method s5`/`--depth graph`; best-effort and
+        # gated on clang++ availability (ADR-035 D4 reviewer wiring request).
+        with_call_graph = "L5" in layers and "L4" in layers
+        graph = (
+            _build_inline_graph(
+                merged,
+                surface,
+                with_call_graph=with_call_graph,
+                clang_bin=clang_bin,
+                extractors=extractors,
+                changed_paths=changed_paths,
+            )
+            if "L5" in layers
+            else None
         )
-        # L4 per-TU cache dir: explicit arg wins, else the ABICHECK_L4_CACHE_DIR
-        # env (the CI-friendly knob — point it at a restored cache directory).
-        l4_cache_dir = source_abi_cache_dir
-        if l4_cache_dir is None:
-            env_dir = os.environ.get("ABICHECK_L4_CACHE_DIR")
-            l4_cache_dir = Path(env_dir) if env_dir else None
-        surface = _run_inline_source_abi(
-            sources,
-            merged,
-            extractors,
-            extractor=extractor,
-            scope=replay_scope,
-            clang_bin=clang_bin,
-            exported_symbols=exported_symbols,
-            source_abi_cache_dir=l4_cache_dir,
-            changed_paths=changed_paths,
-        )
-    # Fold a call graph (DECL_CALLS_DECL edges) into the L5 graph whenever L4 also
-    # ran — i.e. a semantic source mode (source-*/graph-summary/graph-full), not
-    # the structural-only graph-build (L3+L5, no L4). This is what makes the
-    # decl-dependency cross-checks (public_to_internal_dependency, ADR-035 D4)
-    # reachable from `scan --source-method s5`/`--depth graph`; best-effort and
-    # gated on clang++ availability (ADR-035 D4 reviewer wiring request).
-    with_call_graph = "L5" in layers and "L4" in layers
-    graph = (
-        _build_inline_graph(
-            merged,
-            surface,
-            with_call_graph=with_call_graph,
-            clang_bin=clang_bin,
-            extractors=extractors,
-            changed_paths=changed_paths,
-        )
-        if "L5" in layers
-        else None
-    )
 
-    # L3/L4/L5 are now collected into in-memory evidence. The out-of-tree inferred
-    # cmake build dir can normally be removed (and its lock released) here. But a
-    # caller running *later* phases that re-use the compile units' `directory` as a
-    # cwd — the `scan` flow's S2 preprocessor scan runs `clang -E` there *after*
-    # this returns — passes `defer_cleanup` to take ownership and remove the dir
-    # only once the whole scan is done (else `clang -E` hits a deleted cwd). Without
-    # it (e.g. `dump --sources`), remove immediately.
-    if defer_cleanup is not None:
-        defer_cleanup.extend(query_build_cleanups)
-    else:
-        for _cleanup in query_build_cleanups:
-            _cleanup()
+    # Always hand off (or drain) the inferred-build-dir cleanup thunks — even if
+    # _resolve_compile_db / _run_compile_db / L4 replay / L5 fold raised — so the
+    # build dir and its lock never leak. With `defer_cleanup`, the caller's finally
+    # owns them (it runs after the scan's later phases, e.g. S2 `clang -E`); without
+    # it (e.g. `dump --sources`), drain immediately (CodeRabbit).
+    finally:
+        if defer_cleanup is not None:
+            defer_cleanup.extend(query_build_cleanups)
+        else:
+            for _cleanup in query_build_cleanups:
+                _cleanup()
 
     has_build = bool(
         merged.compile_units

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -26,6 +26,7 @@ explicit opt-in not implemented here.
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -779,6 +780,7 @@ def embed_build_source(
     build_compile_db: str | None = None,
     changed_paths: tuple[str, ...] = (),
     extractor: str = "auto",
+    defer_cleanup: list[Callable[[], None]] | None = None,
 ) -> None:
     """Embed build-info / source facts inline in *snap* (single-artifact UX).
 
@@ -878,6 +880,7 @@ def embed_build_source(
             layers=layers,
             exported_symbols=exported,
             changed_paths=changed_paths,
+            defer_cleanup=defer_cleanup,
         )
         # P09: don't fail *silently* when a source/build tree yields no compile DB.
         # Autotools `configure` (and a bare checkout) emit no compile_commands.json,

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -1010,10 +1010,11 @@ def scan_cmd(
         raise click.ClickException(ce.message) from ce
     finally:
         # Remove the inferred cmake build dir(s) now that every build-dir-dependent
-        # phase has run (or the scan aborted). Best-effort: each thunk is internally
-        # guarded, so a removal error never masks the scan's real outcome.
-        for _cleanup in build_dir_cleanups:
-            _cleanup()
+        # phase has run (or the scan aborted). Best-effort (each thunk is suppressed)
+        # so a removal/unlock error never aborts the rest nor masks the real outcome.
+        from .buildsource.build_query import drain_build_dir_cleanups
+
+        drain_build_dir_cleanups(build_dir_cleanups)
 
     outcome = core.outcome
     text = (

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -50,6 +50,7 @@ import json
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -419,6 +420,7 @@ def _build_new_snapshot(
     public_headers: list[Path] | None = None,
     public_header_dirs: list[Path] | None = None,
     compile_context: CompileContext | None = None,
+    defer_cleanup: list[Callable[[], None]] | None = None,
 ) -> Any:
     """Dump the candidate's L0-L2 surface and embed L3-L5 inline at *collect_mode*.
 
@@ -462,6 +464,7 @@ def _build_new_snapshot(
             allow_build_query=allow_build_query,
             collect_mode=collect_mode,
             changed_paths=changed_paths,
+            defer_cleanup=defer_cleanup,
         )
     return snap
 
@@ -944,6 +947,12 @@ def scan_cmd(
     prov_headers, prov_dirs = _public_provenance_set(
         list(headers), list(public_header_dirs)
     )
+    # Cleanup thunks for any out-of-tree inferred cmake build dir, owned here so the
+    # dir outlives every scan phase that re-uses a compile unit's `directory` as a
+    # cwd — the S2 preprocessor scan runs `clang -E` there. collect_inline_pack
+    # would otherwise delete it as soon as L4 finished, before that scan ran (and
+    # before any post-snapshot raise). Run in the finally below, on every exit path.
+    build_dir_cleanups: list[Callable[[], None]] = []
     try:
         core = run_scan_core(
             start=start,
@@ -989,6 +998,7 @@ def scan_cmd(
             # pin would break those best-effort paths (Codex review).
             pinned_explicit=_pinned_explicit,
             compile_context=None if compile_context.is_default else compile_context,
+            defer_cleanup=build_dir_cleanups,
         )
     except _BudgetOverflow as bo:
         click.echo(bo.message, err=True)
@@ -998,6 +1008,12 @@ def scan_cmd(
         # violation → a clean CLI error (exit 1), distinct from the verdict codes
         # (2/4) and the budget code (5).
         raise click.ClickException(ce.message) from ce
+    finally:
+        # Remove the inferred cmake build dir(s) now that every build-dir-dependent
+        # phase has run (or the scan aborted). Best-effort: each thunk is internally
+        # guarded, so a removal error never masks the scan's real outcome.
+        for _cleanup in build_dir_cleanups:
+            _cleanup()
 
     outcome = core.outcome
     text = (
@@ -1086,6 +1102,7 @@ def run_scan_core(
     level_explicit: bool = False,
     pinned_explicit: bool = False,
     compile_context: CompileContext | None = None,
+    defer_cleanup: list[Callable[[], None]] | None = None,
 ) -> ScanCoreResult:
     """The shared scan orchestration (classify → always-on tier → level → compare).
 
@@ -1211,6 +1228,7 @@ def run_scan_core(
         public_headers=list(public_headers),
         public_header_dirs=list(public_header_dirs),
         compile_context=compile_context,
+        defer_cleanup=defer_cleanup,
     )
 
     # --- level-vs-evidence: fail-loud on missing input, advise otherwise ------

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -28,6 +28,7 @@ backward compatibility.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -723,6 +724,10 @@ def run_scan(req: ScanRequest) -> ScanResult:
 
     import time as _time
 
+    # Own the inferred cmake build-dir cleanup so it outlives run_scan_core's S2
+    # preprocessor phase (which runs `clang -E` with a compile unit's `directory`
+    # as cwd); run it in the finally below on every exit path. See cli_scan.run_scan.
+    build_dir_cleanups: list[Callable[[], None]] = []
     try:
         core = run_scan_core(
             start=_time.monotonic(),
@@ -752,6 +757,7 @@ def run_scan(req: ScanRequest) -> ScanResult:
             budget_s=budget_s,
             pinned_explicit=pinned_explicit,
             compile_context=None if req.compile.is_default else req.compile,
+            defer_cleanup=build_dir_cleanups,
         )
     except _BudgetOverflow:
         # The failure-guard contract: overflow is exit 5, never a shrunk scope.
@@ -761,6 +767,11 @@ def run_scan(req: ScanRequest) -> ScanResult:
         # the programmatic API honors the same contract as the CLI (pinned_explicit
         # above), so map the signal to a failed result rather than degrade silently.
         return ScanResult(verdict="EVIDENCE_CONTRACT_ERROR", exit_code=1)
+    finally:
+        # Remove the inferred cmake build dir(s) once all build-dir-dependent phases
+        # have run (or the scan aborted). Best-effort; thunks are internally guarded.
+        for _cleanup in build_dir_cleanups:
+            _cleanup()
 
     outcome = core.outcome
     return ScanResult(

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -33,7 +33,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .buildsource.build_query import PRUNED_HEADER_DIR_SEGMENTS
+from .buildsource.build_query import (
+    PRUNED_HEADER_DIR_SEGMENTS,
+    drain_build_dir_cleanups,
+)
 from .errors import ValidationError
 from .header_utils import HEADER_SUFFIXES, iter_directory_headers
 
@@ -769,9 +772,9 @@ def run_scan(req: ScanRequest) -> ScanResult:
         return ScanResult(verdict="EVIDENCE_CONTRACT_ERROR", exit_code=1)
     finally:
         # Remove the inferred cmake build dir(s) once all build-dir-dependent phases
-        # have run (or the scan aborted). Best-effort; thunks are internally guarded.
-        for _cleanup in build_dir_cleanups:
-            _cleanup()
+        # have run (or the scan aborted). Best-effort (each thunk is suppressed) so a
+        # removal/unlock error never aborts the rest nor masks the real outcome.
+        drain_build_dir_cleanups(build_dir_cleanups)
 
     outcome = core.outcome
     return ScanResult(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """conftest.py — pytest configuration for abicheck tests."""
+
 from __future__ import annotations
 
 import json
@@ -91,7 +92,9 @@ def _integration_skip_reason() -> str | None:
 
     if sys.platform == "win32":
         if shutil.which("gcc") is None:
-            return "gcc (MinGW) not found in PATH (required for Windows integration tests)"
+            return (
+                "gcc (MinGW) not found in PATH (required for Windows integration tests)"
+            )
         return None
 
     # Linux / other Unix: require castxml + gcc + g++ for ELF tests
@@ -161,7 +164,11 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
         _EXECUTED_TESTS += 1
     if os.environ.get("ABICHECK_DURATIONS_JSON"):
         _PHASE_DURATIONS.append(
-            {"nodeid": report.nodeid, "when": report.when, "duration": float(report.duration)}
+            {
+                "nodeid": report.nodeid,
+                "when": report.when,
+                "duration": float(report.duration),
+            }
         )
 
 
@@ -180,7 +187,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     durations_path = os.environ.get("ABICHECK_DURATIONS_JSON")
     if durations_path and not is_worker:
         try:
-            Path(durations_path).write_text(json.dumps(_PHASE_DURATIONS), encoding="utf-8")
+            Path(durations_path).write_text(
+                json.dumps(_PHASE_DURATIONS), encoding="utf-8"
+            )
         except OSError:
             pass
 
@@ -216,9 +225,17 @@ def _cmake_configure_once(build_dir: Path) -> bool:
         return False
     try:
         r = subprocess.run(
-            [cmake, "-S", str(examples_dir), "-B", str(build_dir),
-             "-DCMAKE_BUILD_TYPE=Debug"],
-            capture_output=True, text=True, timeout=120,
+            [
+                cmake,
+                "-S",
+                str(examples_dir),
+                "-B",
+                str(build_dir),
+                "-DCMAKE_BUILD_TYPE=Debug",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
     except subprocess.TimeoutExpired:
         return False
@@ -298,3 +315,71 @@ def compile_db(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     return cdb
+
+
+# A real CMake C++ library (source tree + compiled .so), shared by the scan-level
+# integration suite — kept here per the "fixtures live in conftest.py" convention
+# so future source-scan integration tests can reuse it. Builds once per session;
+# only instantiated when a test requests it (no cost to other tests).
+_CMAKE_CXX_FOO_H = """\
+#ifndef FOO_H
+#define FOO_H
+namespace foo {
+class Widget {
+public:
+  Widget();
+  int value() const;
+  void set_value(int v);
+private:
+  int v_;
+};
+int add(int a, int b);
+}
+#endif
+"""
+
+_CMAKE_CXX_FOO_CPP = """\
+#include "foo.h"
+namespace foo {
+Widget::Widget() : v_(0) {}
+int Widget::value() const { return v_; }
+void Widget::set_value(int v) { v_ = v; }
+int add(int a, int b) { return a + b; }
+}
+"""
+
+_CMAKE_CXX_CMAKELISTS = """\
+cmake_minimum_required(VERSION 3.10)
+project(foo CXX)
+add_library(foo SHARED foo.cpp)
+target_include_directories(foo PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_target_properties(foo PROPERTIES VERSION 1.0.0 SOVERSION 1)
+"""
+
+
+@pytest.fixture(scope="session")
+def cmake_cxx_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A real CMake C++ library: source tree (CMakeLists + public header) plus a
+    compiled ELF ``.so``. The compile DB is intentionally *absent* so scans over it
+    exercise the zero-config cmake inference path. Requires gcc/g++."""
+    root = tmp_path_factory.mktemp("cmake_cxx_project")
+    (root / "include").mkdir()
+    (root / "include" / "foo.h").write_text(_CMAKE_CXX_FOO_H, encoding="utf-8")
+    (root / "foo.cpp").write_text(_CMAKE_CXX_FOO_CPP, encoding="utf-8")
+    (root / "CMakeLists.txt").write_text(_CMAKE_CXX_CMAKELISTS, encoding="utf-8")
+    so = root / "libfoo.so.1.0.0"
+    subprocess.run(
+        [
+            "g++",
+            "-shared",
+            "-fPIC",
+            f"-I{root / 'include'}",
+            "-o",
+            str(so),
+            str(root / "foo.cpp"),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    (root / "libfoo.so").symlink_to(so.name)
+    return root

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -717,3 +717,37 @@ def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatc
     # Immediate: no defer list → collect_inline_pack runs the cleanup itself.
     _inline.collect_inline_pack(sources=tmp_path, build_info=None, layers=("L3",))
     assert ran["n"] == 2
+
+    # Abort path (CodeRabbit): a thunk is registered, then a later collection step
+    # raises. The handoff lives in a finally, so the thunk is still deferred to the
+    # caller (never lost / never leaked) even though collect_inline_pack re-raises.
+    def resolve_returns_db(
+        build_info,
+        sources,
+        cfg,
+        trusted,
+        merged,
+        extractors,
+        cleanup=None,
+        compile_db_explicit=False,
+    ):
+        if cleanup is not None:
+            cleanup.append(lambda: ran.__setitem__("n", ran["n"] + 1))
+        return tmp_path / "compile_commands.json"  # non-None → _run_compile_db runs
+
+    def boom(*a, **k):
+        raise RuntimeError("L3 normalization blew up mid-collection")
+
+    monkeypatch.setattr(_inline, "_resolve_compile_db", resolve_returns_db)
+    monkeypatch.setattr(_inline, "_run_compile_db", boom)
+    defer_on_abort: list = []
+    with pytest.raises(RuntimeError):
+        _inline.collect_inline_pack(
+            sources=tmp_path,
+            build_info=None,
+            layers=("L3",),
+            defer_cleanup=defer_on_abort,
+        )
+    assert len(defer_on_abort) == 1 and ran["n"] == 2  # deferred, not lost, not run
+    defer_on_abort[0]()
+    assert ran["n"] == 3  # caller can still drain it

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -751,3 +751,20 @@ def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatc
     assert len(defer_on_abort) == 1 and ran["n"] == 2  # deferred, not lost, not run
     defer_on_abort[0]()
     assert ran["n"] == 3  # caller can still drain it
+
+
+def test_drain_build_dir_cleanups_is_best_effort():
+    # A raising cleanup thunk must NOT abort the remaining thunks (which would leak
+    # the other build dirs/locks) and must not propagate out of the drain — the
+    # contract the scan/dump finally blocks rely on (review).
+    from abicheck.buildsource.build_query import drain_build_dir_cleanups
+
+    ran: list[int] = []
+
+    def boom():
+        raise OSError("flock LOCK_UN on a churned fd")
+
+    drain_build_dir_cleanups(
+        [lambda: ran.append(1), boom, lambda: ran.append(3)]
+    )  # must not raise
+    assert ran == [1, 3]  # the thunk after the raising one still ran

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -677,3 +677,43 @@ def test_run_bazel_empty_action_graph_is_partial(tmp_path: Path, monkeypatch):
     assert run_inferred_build_query(tmp_path, merged, ext) is None
     assert ext[-1].name == "build_query_auto"
     assert ext[-1].status == "partial"  # no CppCompile actions
+
+
+def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatch):
+    # Fast-lane guard for the cleanup-lifetime contract (the real end-to-end check
+    # lives in tests/test_scan_levels_integration.py): when a caller passes
+    # ``defer_cleanup``, collect_inline_pack must hand the inferred-build-dir cleanup
+    # thunks to that list (for the scan to run after S2) rather than firing them
+    # itself; without it, it cleans up immediately (e.g. ``dump --sources``).
+    from abicheck.buildsource import inline as _inline
+
+    ran = {"n": 0}
+
+    def fake_resolve(
+        build_info,
+        sources,
+        cfg,
+        trusted,
+        merged,
+        extractors,
+        cleanup=None,
+        compile_db_explicit=False,
+    ):
+        if cleanup is not None:
+            cleanup.append(lambda: ran.__setitem__("n", ran["n"] + 1))
+        return None  # no compile DB → minimal downstream work
+
+    monkeypatch.setattr(_inline, "_resolve_compile_db", fake_resolve)
+
+    # Deferred: the thunk lands in the caller's list and is NOT run yet.
+    defer: list = []
+    _inline.collect_inline_pack(
+        sources=tmp_path, build_info=None, layers=("L3",), defer_cleanup=defer
+    )
+    assert len(defer) == 1 and ran["n"] == 0
+    defer[0]()
+    assert ran["n"] == 1  # caller runs it after the scan's later phases
+
+    # Immediate: no defer list → collect_inline_pack runs the cleanup itself.
+    _inline.collect_inline_pack(sources=tmp_path, build_info=None, layers=("L3",))
+    assert ran["n"] == 2

--- a/tests/test_scan_levels_integration.py
+++ b/tests/test_scan_levels_integration.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -46,8 +47,17 @@ from abicheck.cli import main
 _REQUIRED_TOOLS = ("clang", "clang++", "cmake", "gcc", "g++")
 _MISSING = [t for t in _REQUIRED_TOOLS if shutil.which(t) is None]
 
+# Linux/ELF only: the coverage matrix asserted here (L2 header AST, symbol↔header
+# scoping) is for an ELF shared object. On macOS `g++ -shared` emits a Mach-O
+# whose C++ mangling/scoping differs (L2 falls back to export-table mode), so the
+# per-level assertions don't hold — the build-dir lifetime mechanism this guards
+# is platform-independent, but the ELF scenario is where it's exercised cleanly.
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="scan-levels coverage matrix is asserted for Linux/ELF",
+    ),
     pytest.mark.skipif(
         bool(_MISSING),
         reason=f"scan-levels use case needs {', '.join(_REQUIRED_TOOLS)}; "
@@ -56,68 +66,9 @@ pytestmark = [
 ]
 
 
-_FOO_H = """\
-#ifndef FOO_H
-#define FOO_H
-namespace foo {
-class Widget {
-public:
-  Widget();
-  int value() const;
-  void set_value(int v);
-private:
-  int v_;
-};
-int add(int a, int b);
-}
-#endif
-"""
-
-_FOO_CPP = """\
-#include "foo.h"
-namespace foo {
-Widget::Widget() : v_(0) {}
-int Widget::value() const { return v_; }
-void Widget::set_value(int v) { v_ = v; }
-int add(int a, int b) { return a + b; }
-}
-"""
-
-_CMAKELISTS = """\
-cmake_minimum_required(VERSION 3.10)
-project(foo CXX)
-add_library(foo SHARED foo.cpp)
-target_include_directories(foo PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-set_target_properties(foo PROPERTIES VERSION 1.0.0 SOVERSION 1)
-"""
-
-
-@pytest.fixture(scope="module")
-def project(tmp_path_factory: pytest.TempPathFactory):
-    """A real CMake C++ library: source tree + a compiled .so (built once)."""
-    import subprocess
-
-    root = tmp_path_factory.mktemp("scan_levels_proj")
-    (root / "include").mkdir()
-    (root / "include" / "foo.h").write_text(_FOO_H)
-    (root / "foo.cpp").write_text(_FOO_CPP)
-    (root / "CMakeLists.txt").write_text(_CMAKELISTS)
-    so = root / "libfoo.so.1.0.0"
-    subprocess.run(
-        [
-            "g++",
-            "-shared",
-            "-fPIC",
-            f"-I{root / 'include'}",
-            "-o",
-            str(so),
-            str(root / "foo.cpp"),
-        ],
-        check=True,
-        capture_output=True,
-    )
-    (root / "libfoo.so").symlink_to(so.name)
-    return root
+# The real CMake C++ project fixture (`cmake_cxx_project`) lives in conftest.py per
+# the repo's "fixtures live in conftest.py" convention, so other source-scan
+# integration tests can reuse it.
 
 
 def _scan(project, depth: str) -> dict:
@@ -153,8 +104,8 @@ def _coverage(report: dict) -> dict[str, str]:
     return {row["layer"]: row["status"] for row in report.get("coverage", [])}
 
 
-def test_binary_depth_collects_only_l0_l1(project):
-    cov = _coverage(_scan(project, "binary"))
+def test_binary_depth_collects_only_l0_l1(cmake_cxx_project):
+    cov = _coverage(_scan(cmake_cxx_project, "binary"))
     assert cov["L0_binary"] == "present"
     # No source layers collected at binary depth.
     assert cov["L2_header"] == "skipped"
@@ -162,17 +113,17 @@ def test_binary_depth_collects_only_l0_l1(project):
     assert cov["L4_source_abi"] == "not_collected"
 
 
-def test_headers_depth_adds_l2_ast(project):
-    cov = _coverage(_scan(project, "headers"))
+def test_headers_depth_adds_l2_ast(cmake_cxx_project):
+    cov = _coverage(_scan(cmake_cxx_project, "headers"))
     assert cov["L0_binary"] == "present"
     assert cov["L2_header"] == "present"  # clang AST frontend parsed the header
     assert cov["L3_build"] == "not_collected"
 
 
-def test_build_depth_runs_zero_config_cmake_and_preprocessor(project):
+def test_build_depth_runs_zero_config_cmake_and_preprocessor(cmake_cxx_project):
     # --depth build → zero-config cmake inference produces L3 (no compile DB in the
     # tree), and the S2 preprocessor scan must actually RUN over that build context.
-    cov = _coverage(_scan(project, "build"))
+    cov = _coverage(_scan(cmake_cxx_project, "build"))
     assert cov["L2_header"] == "present"
     assert cov["L3_build"] == "present", "zero-config cmake inference should yield L3"
     # Regression guard (the lifetime bug): the inferred cmake build dir must still
@@ -185,8 +136,8 @@ def test_build_depth_runs_zero_config_cmake_and_preprocessor(project):
 
 
 @pytest.mark.parametrize("depth", ["source", "full"])
-def test_source_depths_add_l4_replay_and_l5_graph(project, depth):
-    cov = _coverage(_scan(project, depth))
+def test_source_depths_add_l4_replay_and_l5_graph(cmake_cxx_project, depth):
+    cov = _coverage(_scan(cmake_cxx_project, depth))
     assert cov["L3_build"] == "present"
     assert cov["preprocessor_scan"] == "present"
     # L4 replay runs (parsed, even if symbol matching is partial) and L5 folds.
@@ -194,11 +145,11 @@ def test_source_depths_add_l4_replay_and_l5_graph(project, depth):
     assert cov["L5_source_graph"] == "present"
 
 
-def test_depth_progression_is_monotone(project):
+def test_depth_progression_is_monotone(cmake_cxx_project):
     # Each deeper level collects a superset of the shallower level's source layers:
     # a use-case-level invariant that catches a level silently regressing.
     def present_source_layers(depth: str) -> set[str]:
-        cov = _coverage(_scan(project, depth))
+        cov = _coverage(_scan(cmake_cxx_project, depth))
         return {
             name
             for name in ("L2_header", "L3_build", "L4_source_abi", "L5_source_graph")
@@ -215,7 +166,7 @@ def test_depth_progression_is_monotone(project):
     assert {"L4_source_abi", "L5_source_graph"} <= source
 
 
-def test_no_inferred_build_dir_leak_after_scan(project):
+def test_no_inferred_build_dir_leak_after_scan(cmake_cxx_project):
     # The out-of-tree inferred cmake build dir must be removed once the scan ends
     # (it is owned by the scan orchestrator's finally) — no per-run temp-dir leak.
     import tempfile
@@ -226,7 +177,7 @@ def test_no_inferred_build_dir_leak_after_scan(project):
     except AttributeError:
         pytest.skip("POSIX-only leak check")
     root = Path(tempfile.gettempdir()) / f"abicheck-{uid}"
-    _scan(project, "build")
+    _scan(cmake_cxx_project, "build")
     leaked = list(root.glob("cmake-*/")) if root.is_dir() else []
     # Only ever-present `.lock` marker files may remain; never a build *directory*.
     assert not leaked, f"inferred cmake build dir leaked after scan: {leaked}"

--- a/tests/test_scan_levels_integration.py
+++ b/tests/test_scan_levels_integration.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end *use-case* validation for the source scan levels (`scan --depth`).
+
+The fast unit lane drives the L3/L4/L5 collection with ``subprocess`` mocked, so
+it never exercises the real cmake/clang toolchain — and therefore can't catch
+lifetime / cwd bugs in the inferred-build path. This file runs an *actual*
+``abicheck scan`` over a real CMake C++ project at each ``--depth`` and asserts
+the coverage matrix that each level promises.
+
+It is the regression guard for the kind of bug that only shows up end-to-end:
+e.g. the S2 preprocessor scan running ``clang -E`` with a compile unit's
+``directory`` (the out-of-tree inferred cmake build dir) as cwd, *after* that dir
+was cleaned up — which mocked-subprocess unit tests cannot see.
+
+Marked ``integration`` (excluded from the fast lane) and additionally gated on
+the specific tools it shells out to (clang, cmake, gcc/g++), so it skips cleanly
+where those are absent instead of erroring.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+
+# This use case needs the real source toolchain: cmake (zero-config L3 inference),
+# clang/clang++ (L2 AST via --ast-frontend clang, L4 replay, L5 graph, S2
+# preprocessor), and gcc/g++ to compile the .so for L0/L1.
+_REQUIRED_TOOLS = ("clang", "clang++", "cmake", "gcc", "g++")
+_MISSING = [t for t in _REQUIRED_TOOLS if shutil.which(t) is None]
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        bool(_MISSING),
+        reason=f"scan-levels use case needs {', '.join(_REQUIRED_TOOLS)}; "
+        f"missing: {', '.join(_MISSING) or 'none'}",
+    ),
+]
+
+
+_FOO_H = """\
+#ifndef FOO_H
+#define FOO_H
+namespace foo {
+class Widget {
+public:
+  Widget();
+  int value() const;
+  void set_value(int v);
+private:
+  int v_;
+};
+int add(int a, int b);
+}
+#endif
+"""
+
+_FOO_CPP = """\
+#include "foo.h"
+namespace foo {
+Widget::Widget() : v_(0) {}
+int Widget::value() const { return v_; }
+void Widget::set_value(int v) { v_ = v; }
+int add(int a, int b) { return a + b; }
+}
+"""
+
+_CMAKELISTS = """\
+cmake_minimum_required(VERSION 3.10)
+project(foo CXX)
+add_library(foo SHARED foo.cpp)
+target_include_directories(foo PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_target_properties(foo PROPERTIES VERSION 1.0.0 SOVERSION 1)
+"""
+
+
+@pytest.fixture(scope="module")
+def project(tmp_path_factory: pytest.TempPathFactory):
+    """A real CMake C++ library: source tree + a compiled .so (built once)."""
+    import subprocess
+
+    root = tmp_path_factory.mktemp("scan_levels_proj")
+    (root / "include").mkdir()
+    (root / "include" / "foo.h").write_text(_FOO_H)
+    (root / "foo.cpp").write_text(_FOO_CPP)
+    (root / "CMakeLists.txt").write_text(_CMAKELISTS)
+    so = root / "libfoo.so.1.0.0"
+    subprocess.run(
+        [
+            "g++",
+            "-shared",
+            "-fPIC",
+            f"-I{root / 'include'}",
+            "-o",
+            str(so),
+            str(root / "foo.cpp"),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    (root / "libfoo.so").symlink_to(so.name)
+    return root
+
+
+def _scan(project, depth: str) -> dict:
+    """Run `abicheck scan --depth <depth>` over the project; return parsed JSON."""
+    res = CliRunner().invoke(
+        main,
+        [
+            "scan",
+            "--binary",
+            str(project / "libfoo.so"),
+            "-H",
+            str(project / "include"),
+            "--sources",
+            str(project),
+            "--depth",
+            depth,
+            "--ast-frontend",
+            "clang",
+            "--format",
+            "json",
+        ],
+    )
+    assert res.exit_code in (0, 1, 2, 4), (
+        f"unexpected exit {res.exit_code} for --depth {depth}\n{res.output}"
+    )
+    # The report is the JSON document; tolerate a trailing "Report written" note.
+    start = res.output.index("{")
+    return json.loads(res.output[start:])
+
+
+def _coverage(report: dict) -> dict[str, str]:
+    """Map each coverage layer name → its status string."""
+    return {row["layer"]: row["status"] for row in report.get("coverage", [])}
+
+
+def test_binary_depth_collects_only_l0_l1(project):
+    cov = _coverage(_scan(project, "binary"))
+    assert cov["L0_binary"] == "present"
+    # No source layers collected at binary depth.
+    assert cov["L2_header"] == "skipped"
+    assert cov["L3_build"] == "not_collected"
+    assert cov["L4_source_abi"] == "not_collected"
+
+
+def test_headers_depth_adds_l2_ast(project):
+    cov = _coverage(_scan(project, "headers"))
+    assert cov["L0_binary"] == "present"
+    assert cov["L2_header"] == "present"  # clang AST frontend parsed the header
+    assert cov["L3_build"] == "not_collected"
+
+
+def test_build_depth_runs_zero_config_cmake_and_preprocessor(project):
+    # --depth build → zero-config cmake inference produces L3 (no compile DB in the
+    # tree), and the S2 preprocessor scan must actually RUN over that build context.
+    cov = _coverage(_scan(project, "build"))
+    assert cov["L2_header"] == "present"
+    assert cov["L3_build"] == "present", "zero-config cmake inference should yield L3"
+    # Regression guard (the lifetime bug): the inferred cmake build dir must still
+    # exist when the preprocessor scan uses it as cwd — i.e. S2 ran, not "failed"
+    # with a deleted-cwd error. Before the fix this was a hard clang -E failure.
+    assert cov["preprocessor_scan"] == "present", (
+        "S2 preprocessor scan must run against the inferred build dir, not fail "
+        "because the dir was cleaned up before it ran"
+    )
+
+
+@pytest.mark.parametrize("depth", ["source", "full"])
+def test_source_depths_add_l4_replay_and_l5_graph(project, depth):
+    cov = _coverage(_scan(project, depth))
+    assert cov["L3_build"] == "present"
+    assert cov["preprocessor_scan"] == "present"
+    # L4 replay runs (parsed, even if symbol matching is partial) and L5 folds.
+    assert cov["L4_source_abi"] in ("present", "partial")
+    assert cov["L5_source_graph"] == "present"
+
+
+def test_depth_progression_is_monotone(project):
+    # Each deeper level collects a superset of the shallower level's source layers:
+    # a use-case-level invariant that catches a level silently regressing.
+    def present_source_layers(depth: str) -> set[str]:
+        cov = _coverage(_scan(project, depth))
+        return {
+            name
+            for name in ("L2_header", "L3_build", "L4_source_abi", "L5_source_graph")
+            if cov.get(name) in ("present", "partial")
+        }
+
+    binary = present_source_layers("binary")
+    headers = present_source_layers("headers")
+    build = present_source_layers("build")
+    source = present_source_layers("source")
+    assert binary <= headers <= build <= source
+    assert "L2_header" in headers
+    assert "L3_build" in build
+    assert {"L4_source_abi", "L5_source_graph"} <= source
+
+
+def test_no_inferred_build_dir_leak_after_scan(project):
+    # The out-of-tree inferred cmake build dir must be removed once the scan ends
+    # (it is owned by the scan orchestrator's finally) — no per-run temp-dir leak.
+    import tempfile
+    from pathlib import Path
+
+    try:
+        uid = __import__("os").getuid()
+    except AttributeError:
+        pytest.skip("POSIX-only leak check")
+    root = Path(tempfile.gettempdir()) / f"abicheck-{uid}"
+    _scan(project, "build")
+    leaked = list(root.glob("cmake-*/")) if root.is_dir() else []
+    # Only ever-present `.lock` marker files may remain; never a build *directory*.
+    assert not leaked, f"inferred cmake build dir leaked after scan: {leaked}"

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -1576,3 +1576,51 @@ class TestCliNativeBinaryHeaderWiring:
         with patch("abicheck.service._dump_macho", side_effect=SnapshotError("nope")):
             with pytest.raises(click.ClickException, match="nope"):
                 _dump_native_binary(p, "macho", [], [], "1.0", "c++")
+
+
+def test_run_scan_runs_deferred_build_dir_cleanup(monkeypatch):
+    # Fast-lane guard for the scan orchestrator's ownership of the inferred
+    # build-dir cleanup (the real end-to-end check is the integration suite):
+    # service_scan.run_scan must run the deferred cleanup thunks in its finally —
+    # both on success and when run_scan_core raises — so the temp cmake build dir
+    # never outlives the scan. Mirrors the same contract in cli_scan.run_scan.
+    from types import SimpleNamespace
+
+    from abicheck import service_scan as _ss
+
+    ran = {"n": 0}
+
+    def fake_core(**kw):
+        # The orchestrator hands us the cleanup list; register a sentinel thunk the
+        # way collect_inline_pack would for an inferred cmake build dir.
+        kw["defer_cleanup"].append(lambda: ran.__setitem__("n", ran["n"] + 1))
+        outcome = SimpleNamespace(
+            verdict="COMPATIBLE",
+            exit_code=0,
+            coverage=[],
+            crosscheck={},
+            to_dict=lambda: {},
+        )
+        return SimpleNamespace(outcome=outcome, findings=[])
+
+    monkeypatch.setattr(_ss, "estimate_scan", lambda req: [])
+    monkeypatch.setattr("abicheck.cli_scan.run_scan_core", fake_core)
+
+    req = _ss.ScanRequest(binaries=[Path("libfoo.so")], depth="binary")
+    res = _ss.run_scan(req)
+    assert res.verdict == "COMPATIBLE"
+    assert ran["n"] == 1  # the finally ran the deferred cleanup on success
+
+    # And it still runs when the core raises a budget overflow mid-scan.
+    from abicheck.cli_scan import _BudgetOverflow
+
+    ran["n"] = 0
+
+    def raising_core(**kw):
+        kw["defer_cleanup"].append(lambda: ran.__setitem__("n", ran["n"] + 1))
+        raise _BudgetOverflow("over budget")
+
+    monkeypatch.setattr("abicheck.cli_scan.run_scan_core", raising_core)
+    res = _ss.run_scan(req)
+    assert res.exit_code == 5  # budget overflow surfaced
+    assert ran["n"] == 1  # finally still ran the cleanup on the raise path


### PR DESCRIPTION
## Why

Running `scan --sources <cmake-project>` for real (clang + cmake, not the mocked-subprocess unit lane) surfaced a lifetime bug that the existing tests structurally cannot catch.

The zero-config cmake inference (PR #456) configures into an out-of-tree build dir and `collect_inline_pack` deleted it as soon as **L4** replay finished. But the scan's **S2 preprocessor** pass runs `clang -E` *later*, using a compile unit's `directory` (that same build dir) as its cwd:

```
preprocessor_scan  not_collected  clang -E ran but every invocation failed:
  [Errno 2] No such file or directory: '/tmp/abicheck-0/cmake-f12036ca1feda071'
```

So `preprocessor_scan` silently degraded to `not_collected` on every inferred-build scan. The mocked-subprocess unit suite never exercises a real build dir, so it stayed green.

## Fix — extend the build dir's lifetime to the end of the scan

- `collect_inline_pack` gains an optional `defer_cleanup` list. When provided, it hands the inferred build dir's removal+unlock thunks to the caller instead of firing them after L4.
- The two `run_scan_core` callers — `cli_scan.run_scan` and `service_scan.run_scan` — own that list and run it in a `finally`, after every build-dir-dependent phase (L4 + S2) has completed, or on abort (covers the two post-snapshot `raise` paths too).
- `dump --sources` is unchanged (no later phase → immediate cleanup as before).

After the fix, `preprocessor_scan` is `present` and the build dir is removed once the scan ends (no temp-dir leak).

## Validation — catch this class of bug earlier

The core ask: make sure these end-to-end scenarios are actually exercised so a silently-failing layer becomes a test failure.

- **`tests/test_scan_levels_integration.py`** (new, `integration`): runs a real `scan` over a CMake C++ library at **every `--depth`** (`binary → headers → build → source → full`) and asserts the coverage matrix each level promises — including that `preprocessor_scan` is `present` when L3 is inferred, the depth progression is monotone, and the inferred build dir does **not** leak. Gated on its actual tools (clang/clang++/cmake/gcc/g++) so it skips cleanly where they're absent. **Verified to fail without this fix** (the preprocessor guard catches it).
- **`tests/test_build_query_inference.py`**: a fast-lane unit guard for the defer-vs-immediate cleanup contract, so the threading is also protected outside the integration lane.
- **`.github/workflows/ci.yml`**: add `clang` to the Linux integration lane — the preprocessor bug only manifests with a real clang present, so the suite needs it to actually run.

## Test results

- New integration suite: 7 passed (real cmake + clang + gcc).
- Reverting the fix → `test_build_depth_runs_zero_config_cmake_and_preprocessor` fails with the deleted-cwd diagnostic (proves the guard works).
- Fast lane: 11,742 passed; `mypy` 0 errors; `ruff` + format clean; AI-readiness 0 errors.

## Known follow-ups surfaced by this validation (not fixed here)

These were observed while running the levels for real and are tracked by the new suite (which tolerates current behavior rather than over-asserting):

- **L4 partial symbol matching** with the `--ast-frontend clang` backend on a minimal project (`L4_source_abi: partial, 0/N symbols matched`) — a decl→exported-symbol linking concern, orthogonal to this lifetime fix.
- **`header_build_context_mismatch` → API_BREAK** on a vanilla `scan --sources`: by design (it warns that the public headers were parsed *context-free* while the build carries ABI-relevant flags), but the zero-config flow could feed its own inferred compile flags into the L2 header parse to avoid flagging a mismatch against its own build. Worth a separate UX pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WZu1YrbJy9oGRQm7t9uBp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred cleanup handling for inferred out-of-tree CMake build directories, ensuring cleanup runs on all scan exit paths (including exceptions and budget overflows) with best-effort error isolation.
  * Added safer cleanup-lifetime semantics for inline build-source collection when deferring cleanup is requested.

* **Tests**
  * Added end-to-end integration coverage for `scan --depth`, including checks that inferred build directories don’t leak after scans.
  * Added unit tests covering deferred vs immediate cleanup behavior and best-effort cleanup draining.

* **Chores**
  * Updated Linux CI to retry transient `apt-get update` failures and install `clang` alongside existing build tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->