### PR TITLE
Detect renamed field type changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ conda install -c conda-forge abicheck
 
 `abicheck` also needs `castxml` and a C++ compiler for header AST analysis (the conda-forge package pulls these in automatically). Without them, abicheck still works in binary-only mode. See [Getting Started](https://abicheck.github.io/abicheck/getting-started/) for per-platform setup and cross-compilation.
 
-> **Naming note:** the PyPI package (`abicheck`) is distinct from distro-packaged tools with similar names (`abi-compliance-checker` wrappers in Debian `devscripts`, or `abicheck` in Fedora's `libabigail-tools`). Run `abicheck --version` to confirm — it should print `abicheck X.Y.Z (abicheck/abicheck)`. If there is a conflict, invoke via `python -m abicheck`.
+> **Naming note:** the PyPI/conda-forge package (`abicheck`) is distinct from the older SourceForge `abicheck` that is still packaged by some Linux distributions, and from similarly named ABI tools such as `abi-compliance-checker` wrappers or Fedora's `libabigail-tools`. Run `abicheck --version` to confirm — it should print `abicheck X.Y.Z (abicheck/abicheck)`. If there is a conflict, invoke via `python -m abicheck`.
 
 ---
 
@@ -130,6 +130,8 @@ Use these to gate CI pipelines.
 ```
 
 The action installs Python, castxml, and abicheck automatically. Outputs: `verdict`, `exit-code`, `report-path`. See the [GitHub Action docs](https://abicheck.github.io/abicheck/user-guide/github-action/) for matrix builds, cross-compilation, and gating flags (`fail-on-breaking`, `fail-on-api-break`).
+
+The default compare path only needs normal checkout access. Extra repository permissions are needed only for optional GitHub integrations: `pull-requests: write` for PR comments and `security-events: write` for SARIF upload.
 
 ---
 

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -407,6 +407,7 @@ def _diff_type_fields(name: str, t_old: RecordType, t_new: RecordType) -> list[C
     # Track which added fields were matched as reserved-field activations
     # so we skip emitting TYPE_FIELD_ADDED for them.
     reserved_matched_added: set[str] = set()
+    renamed_type_changed_added: set[str] = set()
 
     # Identify trailing FAM fields so we can skip them from generic checks
     # and let _diff_flexible_array_member handle them exclusively.
@@ -430,6 +431,26 @@ def _diff_type_fields(name: str, t_old: RecordType, t_new: RecordType) -> list[C
             if matched is not None:
                 changes.append(matched)
                 continue
+            if f_old.offset_bits is not None:
+                f_new = added_by_offset.get(f_old.offset_bits)
+                if (
+                    f_new is not None
+                    and f_new.name not in reserved_matched_added
+                    and not _RESERVED_FIELD_RE.match(fname)
+                    and not _RESERVED_FIELD_RE.match(f_new.name)
+                    and canonicalize_type_name(f_old.type) != canonicalize_type_name(f_new.type)
+                    and not cv_qualifiers_only_differ(f_old.type, f_new.type)
+                ):
+                    renamed_type_changed_added.add(f_new.name)
+                    changes.append(make_change(
+                        ChangeKind.TYPE_FIELD_TYPE_CHANGED,
+                        symbol=name,
+                        name=name,
+                        detail=f"{fname} -> {f_new.name}",
+                        old=f_old.type,
+                        new=f_new.type,
+                    ))
+                    continue
             changes.append(make_change(
                 ChangeKind.TYPE_FIELD_REMOVED,
                 symbol=name,
@@ -442,7 +463,11 @@ def _diff_type_fields(name: str, t_old: RecordType, t_new: RecordType) -> list[C
         changes.extend(_diff_type_field_pair(name, fname, f_old, f_new))
 
     for fname in new_fields:
-        if fname not in old_fields and fname not in reserved_matched_added:
+        if (
+            fname not in old_fields
+            and fname not in reserved_matched_added
+            and fname not in renamed_type_changed_added
+        ):
             # Skip trailing FAM additions — handled by _diff_flexible_array_member
             if fname == new_trailing_fam:
                 continue

--- a/tests/test_abicc_scenario_parity.py
+++ b/tests/test_abicc_scenario_parity.py
@@ -117,6 +117,29 @@ class TestFunctionPointerChanges:
         result = compare(old, new)
         assert result.verdict == Verdict.BREAKING
 
+    def test_std_function_field_signature_changed_after_rename_is_breaking(self) -> None:
+        """pvxs#158: renamed std::function field with changed signature is BREAKING."""
+        old = _snap(types=[RecordType(name="ConnectImpl", kind="class", fields=[
+            TypeField(name="_connected", type="std::atomic<bool>", offset_bits=0),
+            TypeField(name="_onConn", type="std::function<void()>", offset_bits=64),
+            TypeField(name="_onDis", type="std::function<void()>", offset_bits=128),
+        ])])
+        new = _snap(types=[RecordType(name="ConnectImpl", kind="class", fields=[
+            TypeField(name="_connected", type="std::atomic<bool>", offset_bits=0),
+            TypeField(name="_onConn1", type="std::function<void(const Connected&)>", offset_bits=64),
+            TypeField(name="_onDis", type="std::function<void()>", offset_bits=128),
+        ])])
+        result = compare(old, new)
+        changes = [
+            c for c in result.changes
+            if c.kind == ChangeKind.TYPE_FIELD_TYPE_CHANGED and c.symbol == "ConnectImpl"
+        ]
+        assert result.verdict == Verdict.BREAKING
+        assert changes
+        assert "ConnectImpl::_onConn -> _onConn1" in changes[0].description
+        assert changes[0].old_value == "std::function<void()>"
+        assert changes[0].new_value == "std::function<void(const Connected&)>"
+
 
 # ===========================================================================
 # 2. Return type void transitions


### PR DESCRIPTION
## Summary
- detect same-offset field renames where the field type also changed as `type_field_type_changed`
- avoid also reporting the matched new field as a separate addition
- add a pvxs#158-shaped regression for `_onConn` -> `_onConn1` with `std::function<void()>` -> `std::function<void(const Connected&)>`
- clarify README naming/permission notes

## Notes
This does not change the gate outcome for the pvxs shape: it was already BREAKING as removed+added fields. The PR improves the diagnostic so review output shows the real same-slot signature change.

## Tests
- `PYTHONPATH=. python -m pytest tests/test_abicc_scenario_parity.py -q`
- `python -m ruff check abicheck/diff_types.py tests/test_abicc_scenario_parity.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the README’s reference to the PyPI/conda-forge `abicheck` package naming.
  * Added a note on default GitHub Actions checkout permissions and what’s required for optional PR comment and SARIF uploads.

* **Bug Fixes**
  * Improved detection for cases where a removed/added field at the same bit offset is actually a rename with a real type change, reporting it as a breaking `TYPE_FIELD_TYPE_CHANGED` rather than removal/addition.

* **Tests**
  * Added parity coverage for the renamed-then-type-changed field scenario to verify breaking verdict and expected change details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->