### PR TITLE
Fix AST cache fallback for read-only home

### DIFF
--- a/abicheck/buildsource/source_replay.py
+++ b/abicheck/buildsource/source_replay.py
@@ -764,13 +764,17 @@ class SourceAbiCache:
             if digest is not None:
                 deps[dep_path] = digest
         entry = {"tu": tu.to_dict(), "deps": deps}
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
         tmp = self._path(key).with_suffix(".json.tmp")
-        tmp.write_text(
-            json.dumps(entry, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
-        # Atomic publish so a concurrent reader never sees a partial file.
-        tmp.replace(self._path(key))
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            tmp.write_text(
+                json.dumps(entry, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            # Atomic publish so a concurrent reader never sees a partial file.
+            tmp.replace(self._path(key))
+        except OSError:
+            # Cache writes are best-effort; replay already produced the facts.
+            tmp.unlink(missing_ok=True)
 
 
 def _dep_digest(path: str, memo: dict[str, str | None] | None = None) -> str | None:

--- a/abicheck/debug_resolver.py
+++ b/abicheck/debug_resolver.py
@@ -532,7 +532,14 @@ class DebuginfodResolver:
         xdg = os.environ.get("XDG_CACHE_HOME", "")
         if xdg:
             return Path(xdg) / "abicheck" / "debuginfod"
-        return Path.home() / ".cache" / "abicheck" / "debuginfod"
+        try:
+            return Path.home() / ".cache" / "abicheck" / "debuginfod"
+        except RuntimeError:
+            return DebuginfodResolver._temp_cache()
+
+    @staticmethod
+    def _temp_cache() -> Path:
+        return Path(tempfile.gettempdir()) / "abicheck" / "debuginfod"
 
     def _url_allowed(self, url: str) -> bool:
         """Return True if *url* is permitted under the current security policy."""
@@ -595,7 +602,18 @@ class DebuginfodResolver:
             if len(data) < 16 or data[:4] != b"\x7fELF":
                 _logger.warning("Downloaded file is not valid ELF: %s", fetch_url)
                 return None
-            self._atomic_cache_write(cached, data)
+            try:
+                self._atomic_cache_write(cached, data)
+            except OSError as exc:
+                fallback = self._temp_cache() / build_id[:2] / f"{build_id[2:]}.debug"
+                _logger.warning(
+                    "debuginfod cache path %s is unavailable (%s); using %s",
+                    cached,
+                    exc,
+                    fallback,
+                )
+                self._atomic_cache_write(fallback, data)
+                cached = fallback
             _logger.info("Downloaded and cached debug info: %s", cached)
             return DebugArtifact(dwarf_path=cached, source=f"debuginfod ({url})")
         except (OSError, ValueError) as exc:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -36,7 +36,6 @@ import re
 import shlex
 import shutil
 import subprocess
-import sys
 import tempfile
 import warnings
 from collections.abc import Callable
@@ -54,12 +53,12 @@ if TYPE_CHECKING:
 
 from defusedxml import ElementTree as DefusedET
 
+from .dumper_cache import _cache_path
 from .dumper_castxml import (
     _CastxmlParser as _CastxmlParser,
     _parse_vtable_index as _parse_vtable_index,
     _vt_sort_key as _vt_sort_key,
 )
-from .dumper_cache import _cache_path
 from .dumper_clang import _ClangAstParser as _ClangAstParser
 from .dumper_clang_errors import (
     _is_direct_include_guard_failure,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -59,6 +59,7 @@ from .dumper_castxml import (
     _parse_vtable_index as _parse_vtable_index,
     _vt_sort_key as _vt_sort_key,
 )
+from .dumper_cache import _cache_path
 from .dumper_clang import _ClangAstParser as _ClangAstParser
 from .dumper_clang_errors import (
     _is_direct_include_guard_failure,
@@ -641,35 +642,6 @@ def _cache_key(
     h.update(f"system_includes={chr(0).join(system_includes)}".encode())
     return h.hexdigest()
 
-
-def _cache_path(key: str, backend: str = "castxml") -> Path:
-    # One sub-directory + file extension per backend so the castxml-XML and
-    # clang-JSON caches live side by side without clashing.
-    ext = "json" if backend == "clang" else "xml"
-    if sys.platform == "win32":
-        # Use %LOCALAPPDATA%/abi_check/<backend> on Windows
-        local = os.environ.get("LOCALAPPDATA")
-        if local:
-            cache_dir = Path(local) / "abi_check" / backend
-        else:
-            cache_dir = Path.home() / "AppData" / "Local" / "abi_check" / backend
-    else:
-        xdg_cache = os.environ.get("XDG_CACHE_HOME")
-        base = Path(xdg_cache) if xdg_cache else Path.home() / ".cache"
-        cache_dir = base / "abi_check" / backend
-    try:
-        cache_dir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        fallback = Path(tempfile.gettempdir()) / "abi_check" / backend
-        log.warning(
-            "AST cache directory %s is unavailable (%s); using %s",
-            cache_dir,
-            exc,
-            fallback,
-        )
-        fallback.mkdir(parents=True, exist_ok=True)
-        cache_dir = fallback
-    return cache_dir / f"{key}.{ext}"
 
 
 # C++ file extensions that unambiguously indicate C++ content.

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -654,8 +654,21 @@ def _cache_path(key: str, backend: str = "castxml") -> Path:
         else:
             cache_dir = Path.home() / "AppData" / "Local" / "abi_check" / backend
     else:
-        cache_dir = Path.home() / ".cache" / "abi_check" / backend
-    cache_dir.mkdir(parents=True, exist_ok=True)
+        xdg_cache = os.environ.get("XDG_CACHE_HOME")
+        base = Path(xdg_cache) if xdg_cache else Path.home() / ".cache"
+        cache_dir = base / "abi_check" / backend
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        fallback = Path(tempfile.gettempdir()) / "abi_check" / backend
+        log.warning(
+            "AST cache directory %s is unavailable (%s); using %s",
+            cache_dir,
+            exc,
+            fallback,
+        )
+        fallback.mkdir(parents=True, exist_ok=True)
+        cache_dir = fallback
     return cache_dir / f"{key}.{ext}"
 
 
@@ -1127,7 +1140,10 @@ def _castxml_dump(
                 # error (and its hint), not the fallback's, so the diagnostic
                 # matches what the user asked for.
                 raise primary from None
-        shutil.copy2(str(out_xml), str(cached))
+        try:
+            shutil.copy2(str(out_xml), str(cached))
+        except OSError as exc:
+            log.warning("Could not write castxml AST cache %s: %s", cached, exc)
         return root
     finally:
         out_xml.unlink(missing_ok=True)

--- a/abicheck/dumper_cache.py
+++ b/abicheck/dumper_cache.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Best-effort AST cache path helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _cache_path(key: str, backend: str = "castxml") -> Path:
+    # One sub-directory + file extension per backend so castxml XML and clang
+    # JSON caches live side by side without clashing.
+    ext = "json" if backend == "clang" else "xml"
+    if sys.platform == "win32":
+        local = os.environ.get("LOCALAPPDATA")
+        cache_dir = (
+            Path(local) / "abi_check" / backend
+            if local
+            else Path.home() / "AppData" / "Local" / "abi_check" / backend
+        )
+    else:
+        xdg_cache = os.environ.get("XDG_CACHE_HOME")
+        base = Path(xdg_cache) if xdg_cache else Path.home() / ".cache"
+        cache_dir = base / "abi_check" / backend
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        fallback = Path(tempfile.gettempdir()) / "abi_check" / backend
+        log.warning(
+            "AST cache directory %s is unavailable (%s); using %s",
+            cache_dir,
+            exc,
+            fallback,
+        )
+        fallback.mkdir(parents=True, exist_ok=True)
+        cache_dir = fallback
+    return cache_dir / f"{key}.{ext}"

--- a/abicheck/snapshot_cache.py
+++ b/abicheck/snapshot_cache.py
@@ -15,7 +15,8 @@
 """Snapshot-level cache for avoiding redundant binary analysis.
 
 Cache key = SHA-256 of (binary content hash + header mtimes + compiler params).
-Cache location = ``~/.cache/abi_check/snapshots/<key>.json``.
+Cache location = ``$XDG_CACHE_HOME/abi_check/snapshots/<key>.json`` or
+``~/.cache/abi_check/snapshots/<key>.json``.
 """
 
 from __future__ import annotations

--- a/tests/test_debug_resolver.py
+++ b/tests/test_debug_resolver.py
@@ -965,14 +965,21 @@ class TestDebuginfodNetwork:
     def test_fetch_one_url_falls_back_to_temp_cache_on_write_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        resolver = DebuginfodResolver(server_urls=["https://x"], cache_dir=Path("/proc/cache"))
+        resolver = DebuginfodResolver(server_urls=["https://x"], cache_dir=tmp_path)
         monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+        primary = tmp_path / "primary" / "out.debug"
+        real_write = resolver._atomic_cache_write
+
+        def fail_primary_cache_write(dest: Path, data: bytes) -> None:
+            if dest == primary:
+                raise OSError("read-only cache")
+            real_write(dest, data)
+
+        monkeypatch.setattr(resolver, "_atomic_cache_write", fail_primary_cache_write)
         with patch.object(
             resolver, "_fetch_data", return_value=b"\x7fELF" + b"\x00" * 20
         ):
-            artifact = resolver._fetch_one_url(
-                "https://x", "abcdef1234567890", Path("/proc/cache/out.debug")
-            )
+            artifact = resolver._fetch_one_url("https://x", "abcdef1234567890", primary)
 
         expected = tmp_path / "abicheck" / "debuginfod" / "ab" / "cdef1234567890.debug"
         assert artifact is not None

--- a/tests/test_debug_resolver.py
+++ b/tests/test_debug_resolver.py
@@ -582,6 +582,15 @@ class TestDebuginfodResolver:
         assert "abicheck" in str(result)
         assert "debuginfod" in str(result)
 
+    def test_default_cache_falls_back_to_temp_when_home_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: (_ for _ in ()).throw(RuntimeError("no home")))
+        monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+
+        assert DebuginfodResolver._default_cache() == tmp_path / "abicheck" / "debuginfod"
+
 
 # ---------------------------------------------------------------------------
 # Tests: resolve_debug_info (integration)
@@ -952,6 +961,23 @@ class TestDebuginfodNetwork:
         assert artifact is not None
         assert artifact.dwarf_path == cached
         assert cached.read_bytes() == b"\x7fELF" + b"\x00" * 20
+
+    def test_fetch_one_url_falls_back_to_temp_cache_on_write_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        resolver = DebuginfodResolver(server_urls=["https://x"], cache_dir=Path("/proc/cache"))
+        monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+        with patch.object(
+            resolver, "_fetch_data", return_value=b"\x7fELF" + b"\x00" * 20
+        ):
+            artifact = resolver._fetch_one_url(
+                "https://x", "abcdef1234567890", Path("/proc/cache/out.debug")
+            )
+
+        expected = tmp_path / "abicheck" / "debuginfod" / "ab" / "cdef1234567890.debug"
+        assert artifact is not None
+        assert artifact.dwarf_path == expected
+        assert expected.read_bytes() == b"\x7fELF" + b"\x00" * 20
 
     def test_fetch_one_url_no_data(self, tmp_path: Path) -> None:
         resolver = DebuginfodResolver(server_urls=["https://x"])

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -181,7 +181,17 @@ class TestCachePath:
     def test_posix_readonly_home_falls_back_to_temp_cache(self, tmp_path, monkeypatch):
         monkeypatch.setattr("sys.platform", "linux")
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-        monkeypatch.setattr(Path, "home", lambda: Path("/proc"))
+        blocked_home = tmp_path / "blocked-home"
+        blocked_cache = blocked_home / ".cache" / "abi_check" / "castxml"
+        real_mkdir = Path.mkdir
+
+        def fail_blocked_cache(self, *args, **kwargs):
+            if self == blocked_cache:
+                raise OSError("read-only home")
+            return real_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "home", lambda: blocked_home)
+        monkeypatch.setattr(Path, "mkdir", fail_blocked_cache)
         monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
 
         p = _cache_path("abc123")

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -170,6 +170,24 @@ class TestCachePath:
         assert p.name == "abc123.xml"
         assert "abi_check" in str(p)
 
+    def test_posix_honors_xdg_cache_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+
+        p = _cache_path("abc123", backend="clang")
+
+        assert p == tmp_path / "xdg-cache" / "abi_check" / "clang" / "abc123.json"
+
+    def test_posix_readonly_home_falls_back_to_temp_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: Path("/proc"))
+        monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+
+        p = _cache_path("abc123")
+
+        assert p == tmp_path / "abi_check" / "castxml" / "abc123.xml"
+
 
 # ── _resolve_debug_metadata ─────────────────────────────────────────────
 

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -545,6 +545,7 @@ def test_cache_put_ignores_unwritable_cache_dir() -> None:
     cache = SourceAbiCache(Path("/proc/abicheck-l4-cache"))
 
     cache.put("k", SourceAbiTu(tu_id="cu://x"))
+    assert cache.get("k") is None
 
 
 def test_cache_key_changes_with_argv_forced_include(tmp_path: Path) -> None:

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -541,9 +541,18 @@ def test_cache_get_ignores_bad_tu_payload(tmp_path: Path) -> None:
     assert cache.get("k") is None
 
 
-def test_cache_put_ignores_unwritable_cache_dir() -> None:
-    cache = SourceAbiCache(Path("/proc/abicheck-l4-cache"))
+def test_cache_put_ignores_unwritable_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache = SourceAbiCache(tmp_path / "cache")
+    real_mkdir = Path.mkdir
 
+    def fail_cache_mkdir(self, *args, **kwargs):
+        if self == cache.cache_dir:
+            raise OSError("read-only cache")
+        return real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fail_cache_mkdir)
     cache.put("k", SourceAbiTu(tu_id="cu://x"))
     assert cache.get("k") is None
 

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -541,6 +541,12 @@ def test_cache_get_ignores_bad_tu_payload(tmp_path: Path) -> None:
     assert cache.get("k") is None
 
 
+def test_cache_put_ignores_unwritable_cache_dir() -> None:
+    cache = SourceAbiCache(Path("/proc/abicheck-l4-cache"))
+
+    cache.put("k", SourceAbiTu(tu_id="cu://x"))
+
+
 def test_cache_key_changes_with_argv_forced_include(tmp_path: Path) -> None:
     # Codex #339 P2: a forced-include change lives only in argv (not the
     # structured fields), so the key must fold in the replayed argv flags or a


### PR DESCRIPTION
## Summary
- Respect XDG_CACHE_HOME for POSIX AST cache paths.
- Fall back to the system temp directory when the normal AST cache directory is unavailable, instead of failing header-mode dumps before castxml/clang can run.
- Keep castxml dump successful if writing the cache copy fails after AST extraction.

## Proof
- ../.venv/bin/python -m pytest tests/test_dumper_unit.py::TestCachePath tests/test_dumper_coverage.py::TestCastxmlDumpBranches tests/test_unknown_type_warning.py -q
- HOME=/proc XDG_CACHE_HOME=/tmp/abicheck-xdg-test ../.venv/bin/python - <<'PY' ... _cache_path('k') ... PY => /tmp/abicheck-xdg-test/abi_check/castxml/k.xml
- ../.venv/bin/python -m pytest tests/test_abicc_scenario_parity.py::TestFunctionPointerChanges::test_std_function_field_signature_changed_after_rename_is_breaking -q
- CLI smoke: compare same generated libpvxs_like.so with same headers under HOME=/proc and PATH=/usr/bin:/bin => rc 0, verdict NO_CHANGE, changes 0; stderr showed cache fallback to /tmp, not fatal.

## Gap
- I cloned pvxs and EPICS Base to try a full libpvxs.so validation, but EPICS Base build was still in modules/CA after a long run and I stopped it before pvxs artifacts existed. The cache failure mode is covered by the CLI smoke above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AST cache path resolution with per-backend filenames and standard cache locations, with automatic fallback to a temporary cache when the preferred directory can’t be used.
  * Made cache persistence best-effort for both replay and debuginfo downloads, handling filesystem errors via warnings and safe cleanup instead of aborting.
* **Documentation**
  * Clarified snapshot cache location to reflect standard user cache directories.
* **Tests**
  * Added regression tests for POSIX cache path selection, temp-cache fallback when home is unavailable/unwritable, and best-effort behavior for unwritable cache directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->