### PR TITLE
Speed up headers-only source replay

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -44,6 +44,7 @@ import json
 import os
 import shlex
 import subprocess
+import time
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -528,6 +529,7 @@ def collect_inline_pack(
     source_abi_cache_dir: Path | None = None,
     exported_symbols: tuple[str, ...] = (),
     changed_paths: tuple[str, ...] = (),
+    public_header_roots: tuple[str, ...] = (),
     defer_cleanup: list[Callable[[], None]] | None = None,
 ) -> BuildSourcePack | None:
     """Collect an in-memory pack from raw source-tree / build-info inputs.
@@ -629,6 +631,7 @@ def collect_inline_pack(
                 exported_symbols=exported_symbols,
                 source_abi_cache_dir=l4_cache_dir,
                 changed_paths=changed_paths,
+                public_header_roots=public_header_roots,
             )
         # Fold a call graph (DECL_CALLS_DECL edges) into the L5 graph whenever L4 also
         # ran — i.e. a semantic source mode (source-*/graph-summary/graph-full), not
@@ -1239,6 +1242,7 @@ def _run_inline_source_abi(
     exported_symbols: tuple[str, ...] = (),
     source_abi_cache_dir: Path | None = None,
     changed_paths: tuple[str, ...] = (),
+    public_header_roots: tuple[str, ...] = (),
 ) -> SourceAbiSurface | None:
     """Run L4 replay over a source tree; ``None`` when no source tree is given.
 
@@ -1283,12 +1287,20 @@ def _run_inline_source_abi(
         )
         return SourceAbiSurface()
 
-    roots = public_header_roots_for(merged)
+    roots = sorted(set(public_header_roots_for(merged)) | set(public_header_roots))
+    include_map = _include_map_for_replay(
+        merged,
+        scope=scope,
+        roots=tuple(roots),
+        clang_bin=clang_bin,
+        extractors=extractors,
+    )
     # D8 per-TU cache: re-extracting every TU on every `dump --sources` is the
     # cold-start cost (eval E4: zstd 48.6 s cold → 3.4 s warm). Wire the cache
     # when a dir is given (CLI/env), so a persisted dir restored across CI runs
     # makes each run start warm. Absent a dir, behaviour is unchanged (no cache).
     cache = SourceAbiCache(source_abi_cache_dir) if source_abi_cache_dir else None
+    started = time.monotonic()
     surface, diagnostics = run_source_replay(
         merged,
         impl,
@@ -1297,7 +1309,11 @@ def _run_inline_source_abi(
         public_header_roots=roots,
         exported_symbols=exported_symbols,
         cache=cache,
+        include_map=include_map,
     )
+    elapsed = time.monotonic() - started
+    if surface is not None:
+        surface.coverage.setdefault("elapsed_s", round(elapsed, 3))
     if cache is not None:
         rate = cache.hit_rate
         if rate is not None:
@@ -1315,14 +1331,65 @@ def _run_inline_source_abi(
         merged.diagnostics.append(f"source_abi: {diag}")
     parsed = int(surface.coverage.get("compile_units_parsed", 0) or 0)
     selected = int(surface.coverage.get("compile_units_selected", 0) or 0)
+    extra = f", {elapsed:.2f}s"
+    if surface.coverage.get("scope_widened_to_full"):
+        extra += ", widened-to-full"
     extractors.append(
         ExtractorRecord(
             name=f"source_abi:{extractor}",
             status="ok" if parsed else "partial",
-            detail=f"scope={scope}, {parsed}/{selected} TUs parsed, {len(diagnostics)} failures",
+            detail=(
+                f"scope={scope}, {parsed}/{selected} TUs parsed, "
+                f"{len(diagnostics)} failures{extra}"
+            ),
         )
     )
     return surface
+
+
+def _include_map_for_replay(
+    build: BuildEvidence,
+    *,
+    scope: str,
+    roots: tuple[str, ...],
+    clang_bin: str,
+    extractors: list[ExtractorRecord],
+) -> dict[str, list[str]]:
+    """Best-effort include map for narrowing L4 replay.
+
+    ``headers-only`` can shrink from all TUs to the TUs that include public
+    headers, but only when it has an include graph. Prefer recorded action inputs
+    (free, Bazel-style); otherwise run a cheap depfile pass. Failure keeps the old
+    fail-open selector, never drops evidence.
+    """
+    if scope != "headers-only" or not roots or not build.compile_units:
+        return {}
+    from .include_graph import ClangIncludeExtractor, include_map_from_recorded_inputs
+
+    recorded = include_map_from_recorded_inputs(build)
+    if recorded:
+        extractors.append(
+            ExtractorRecord(
+                name="include_graph:recorded_inputs",
+                status="ok",
+                detail=f"{len(recorded)}/{len(build.compile_units)} compile units",
+            )
+        )
+        return recorded
+
+    extractor = ClangIncludeExtractor(
+        clang_bin=clang_bin if clang_bin != "clang" else "clang++"
+    )
+    include_map = extractor.extract_from_build(build)
+    status = "ok" if include_map else "skipped"
+    detail = f"{len(include_map)}/{len(build.compile_units)} compile units"
+    if extractor.diagnostics:
+        status = "partial" if include_map else "failed"
+        detail += "; " + "; ".join(extractor.diagnostics[:3])
+    extractors.append(
+        ExtractorRecord(name="include_graph:clang", status=status, detail=detail)
+    )
+    return include_map
 
 
 def _make_source_extractor(
@@ -1512,6 +1579,14 @@ def _l4_coverage_detail(surface: SourceAbiSurface) -> str:
         total = hits + misses
         if total:
             parts.append(f"cache {hits}/{total} hit ({hits / total:.0%})")
+    if cov.get("scope_widened_to_full"):
+        parts.append("headers-only widened to full")
+    uncovered = int(cov.get("public_headers_uncovered", 0) or 0)
+    if uncovered:
+        parts.append(f"{uncovered} public header(s) not reached by include graph")
+    elapsed = cov.get("elapsed_s")
+    if elapsed is not None:
+        parts.append(f"{float(elapsed):.2f}s")
     failures = int(cov.get("extractor_failures", 0) or 0)
     if failures:
         parts.append(f"{failures} extractor failures")
@@ -1573,13 +1648,20 @@ def build_inline_coverage(
             or surface.reachable_templates
             or surface.reachable_inline_bodies
         )
+        cov = surface.coverage or {}
+        exported = int(cov.get("exported_symbols", 0) or 0)
+        matched = int(cov.get("matched_symbols", 0) or 0)
+        zero_match_degraded = exported > 0 and matched == 0
         l4 = LayerCoverage(
             layer=DataLayer.L4_SOURCE_ABI.value,
-            status=CoverageStatus.PRESENT if any_entities else CoverageStatus.PARTIAL,
+            status=CoverageStatus.PRESENT
+            if any_entities and not zero_match_degraded
+            else CoverageStatus.PARTIAL,
             confidence=LayerConfidence.HIGH
-            if any_entities
+            if any_entities and not zero_match_degraded
             else LayerConfidence.REDUCED,
             detail=_l4_coverage_detail(surface),
+            elapsed_s=float(cov.get("elapsed_s", 0.0) or 0.0),
         )
     else:
         l4 = LayerCoverage(

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -1358,24 +1358,13 @@ def _include_map_for_replay(
     """Best-effort include map for narrowing L4 replay.
 
     ``headers-only`` can shrink from all TUs to the TUs that include public
-    headers, but only when it has an include graph. Prefer recorded action inputs
-    (free, Bazel-style); otherwise run a cheap depfile pass. Failure keeps the old
-    fail-open selector, never drops evidence.
+    headers, but only when it has an exact textual include graph. Recorded action
+    inputs are an over-approximation, so headers-only replay uses a cheap depfile
+    pass instead. Failure keeps the old fail-open selector, never drops evidence.
     """
     if scope != "headers-only" or not roots or not build.compile_units:
         return {}
-    from .include_graph import ClangIncludeExtractor, include_map_from_recorded_inputs
-
-    recorded = include_map_from_recorded_inputs(build)
-    if recorded:
-        extractors.append(
-            ExtractorRecord(
-                name="include_graph:recorded_inputs",
-                status="ok",
-                detail=f"{len(recorded)}/{len(build.compile_units)} compile units",
-            )
-        )
-        return recorded
+    from .include_graph import ClangIncludeExtractor
 
     extractor = ClangIncludeExtractor(
         clang_bin=clang_bin if clang_bin != "clang" else "clang++"

--- a/abicheck/buildsource/model.py
+++ b/abicheck/buildsource/model.py
@@ -80,6 +80,7 @@ class LayerCoverage:
     status: CoverageStatus = CoverageStatus.NOT_COLLECTED
     confidence: LayerConfidence = LayerConfidence.UNKNOWN
     detail: str = ""                # human-readable note, e.g. "CMake+Ninja, 142 compile units"
+    elapsed_s: float = 0.0
 
     @property
     def present(self) -> bool:
@@ -91,6 +92,7 @@ class LayerCoverage:
             "status": self.status.value,
             "confidence": self.confidence.value,
             "detail": self.detail,
+            "elapsed_s": round(self.elapsed_s, 3),
         }
 
     @classmethod
@@ -100,6 +102,7 @@ class LayerCoverage:
             status=_coverage_status(d.get("status")),
             confidence=_confidence(d.get("confidence")),
             detail=str(d.get("detail", "")),
+            elapsed_s=float(d.get("elapsed_s", 0.0) or 0.0),
         )
 
 

--- a/abicheck/buildsource/source_replay.py
+++ b/abicheck/buildsource/source_replay.py
@@ -431,12 +431,12 @@ def _headers_only_set_cover(
             break
         chosen.append(best)
         need -= coverage[best]
-    # A *partial* include graph may not reach every public header. Returning the
-    # cover for only the reachable ones would silently drop a public header no
-    # recorded TU includes — its source-only changes would never be parsed. Defer
-    # to the representative-per-target heuristic (which covers every public-header
-    # target) whenever the cover cannot satisfy all public headers (Codex review).
-    if need and not public_header_roots:
+    # A *partial* include graph may not reach every build-declared public header.
+    # Returning the cover for only the reachable ones would silently drop a public
+    # target whose source-only changes would never be parsed. External CLI roots
+    # have no representative target, so those are reported as uncovered instead of
+    # widening back to every TU.
+    if need and any(header_owners.get(ph) for ph in need):
         return None
     return [by_id[c] for c in chosen]
 
@@ -483,10 +483,13 @@ def _included(
     (``include/foo.h``).
     """
     public_norm = _norm(public_header)
+    public_dir_suffixes = {s for s in public_suffixes if "/" in s.strip("/")}
+    include_dir_suffixes = {s for s in include_suffixes if "/" in s.strip("/")}
     return (
-        public_norm in include_suffixes
-        or bool(public_suffixes & include_norms)
-        or bool(public_suffixes & include_suffixes)
+        public_norm in include_norms
+        or ("/" in public_norm.strip("/") and public_norm in include_suffixes)
+        or bool(public_dir_suffixes & include_norms)
+        or bool(public_dir_suffixes & include_dir_suffixes)
     )
 
 

--- a/abicheck/buildsource/source_replay.py
+++ b/abicheck/buildsource/source_replay.py
@@ -325,6 +325,10 @@ def _select_headers_only(
         picked = _headers_only_set_cover(build, include_map, public_header_roots)
         if picked is not None:
             return picked
+    return _select_headers_only_heuristic(build)
+
+
+def _select_headers_only_heuristic(build: BuildEvidence) -> list[CompileUnit]:
     by_target: dict[str, list[CompileUnit]] = {}
     for cu in build.compile_units:
         by_target.setdefault(cu.target_id, []).append(cu)
@@ -433,11 +437,19 @@ def _headers_only_set_cover(
         need -= coverage[best]
     # A *partial* include graph may not reach every build-declared public header.
     # Returning the cover for only the reachable ones would silently drop a public
-    # target whose source-only changes would never be parsed. External CLI roots
-    # have no representative target, so those are reported as uncovered instead of
-    # widening back to every TU.
+    # target whose source-only changes would never be parsed. Fall back to the
+    # representative target heuristic for build-owned headers, but keep selected
+    # external CLI-root TUs because those roots have no representative target.
     if need and any(header_owners.get(ph) for ph in need):
-        return None
+        picked = _select_headers_only_heuristic(build)
+        picked_ids = {cu.id for cu in picked}
+        for cu_id in chosen:
+            if any(not header_owners.get(ph) for ph in coverage.get(cu_id, ())):
+                cu = by_id[cu_id]
+                if cu.id not in picked_ids:
+                    picked.append(cu)
+                    picked_ids.add(cu.id)
+        return picked
     return [by_id[c] for c in chosen]
 
 

--- a/abicheck/buildsource/source_replay.py
+++ b/abicheck/buildsource/source_replay.py
@@ -44,6 +44,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from functools import partial
@@ -268,6 +269,7 @@ def select_compile_units(
     changed_paths: Iterable[str] = (),
     target_id: str = "",
     include_map: Mapping[str, Iterable[str]] | None = None,
+    public_header_roots: Sequence[str] | None = None,
 ) -> list[CompileUnit]:
     """Select which compile units to replay for an ADR-030 D7 ``scope``.
 
@@ -308,17 +310,19 @@ def select_compile_units(
         return list(units)
     inc = _norm_include_map(include_map)
     if scope == "headers-only":
-        return _select_headers_only(build, inc)
+        return _select_headers_only(build, inc, public_header_roots)
     if scope == "target":
         return _select_target(build, target_id)
     return _select_changed(build, frozenset(changed_paths), inc)
 
 
 def _select_headers_only(
-    build: BuildEvidence, include_map: dict[str, list[str]]
+    build: BuildEvidence,
+    include_map: dict[str, list[str]],
+    public_header_roots: Sequence[str] | None = None,
 ) -> list[CompileUnit]:
     if include_map:
-        picked = _headers_only_set_cover(build, include_map)
+        picked = _headers_only_set_cover(build, include_map, public_header_roots)
         if picked is not None:
             return picked
     by_target: dict[str, list[CompileUnit]] = {}
@@ -352,7 +356,9 @@ def _public_header_compile_owner_ids(build: BuildEvidence) -> set[str]:
 
 
 def _headers_only_set_cover(
-    build: BuildEvidence, include_map: dict[str, list[str]]
+    build: BuildEvidence,
+    include_map: dict[str, list[str]],
+    public_header_roots: Sequence[str] | None = None,
 ) -> list[CompileUnit] | None:
     """Minimal TU set whose includes cover every public header (greedy set cover).
 
@@ -362,7 +368,7 @@ def _headers_only_set_cover(
     public header no recorded TU includes is left to the heuristic by returning
     ``None`` only when the graph covers nothing at all.
     """
-    public = public_header_roots_for(build)
+    public = sorted(set(public_header_roots_for(build)) | set(public_header_roots or ()))
     if not public:
         return None
     by_id = {cu.id: cu for cu in build.compile_units}
@@ -402,7 +408,10 @@ def _headers_only_set_cover(
             ph
             for ph in public
             if _included(ph, inc_norms, inc_suffixes, public_suffixes[ph])
-            and cu.target_id in header_owners.get(ph, set())
+            and (
+                not header_owners.get(ph)
+                or cu.target_id in header_owners.get(ph, set())
+            )
         }
         if covered:
             coverage[cu_id] = covered
@@ -427,9 +436,33 @@ def _headers_only_set_cover(
     # recorded TU includes — its source-only changes would never be parsed. Defer
     # to the representative-per-target heuristic (which covers every public-header
     # target) whenever the cover cannot satisfy all public headers (Codex review).
-    if need:
+    if need and not public_header_roots:
         return None
     return [by_id[c] for c in chosen]
+
+
+def _uncovered_public_headers(
+    roots: Sequence[str], units: Sequence[CompileUnit], include_map: dict[str, list[str]]
+) -> list[str]:
+    """Public roots not reached by the selected units' include graph."""
+    if not roots or not include_map:
+        return []
+    inc_norms: set[str] = set()
+    inc_suffixes: set[str] = set()
+    selected = {cu.id for cu in units}
+    for cu_id, incs in include_map.items():
+        if cu_id not in selected:
+            continue
+        for inc in incs:
+            norm = _norm(inc)
+            inc_norms.add(norm)
+            inc_suffixes.update(_suffixes(norm))
+    out: list[str] = []
+    for root in roots:
+        suffixes = _suffixes(_norm(root))
+        if not _included(root, inc_norms, inc_suffixes, suffixes):
+            out.append(root)
+    return out
 
 
 def _suffixes(path: str) -> set[str]:
@@ -450,7 +483,11 @@ def _included(
     (``include/foo.h``).
     """
     public_norm = _norm(public_header)
-    return public_norm in include_suffixes or bool(public_suffixes & include_norms)
+    return (
+        public_norm in include_suffixes
+        or bool(public_suffixes & include_norms)
+        or bool(public_suffixes & include_suffixes)
+    )
 
 
 def _select_target(build: BuildEvidence, target_id: str) -> list[CompileUnit]:
@@ -834,12 +871,20 @@ def run_source_replay(
         if public_header_roots is not None
         else public_header_roots_for(build, target_id)
     )
+    total_started = time.monotonic()
     units = select_compile_units(
         build,
         scope=scope,
         changed_paths=changed_paths,
         target_id=target_id,
         include_map=include_map,
+        public_header_roots=roots,
+    )
+    scope_widened = (
+        scope == "headers-only"
+        and not _norm_include_map(include_map)
+        and len(units) == len(build.compile_units)
+        and len(units) > 1
     )
     # Fresh per-pass dep-digest memo so a shared header is hashed once across all
     # TUs' cache validation (scoped to this call — a file may change before the
@@ -851,6 +896,7 @@ def run_source_replay(
     # in unit order, so the linked surface and diagnostics are byte-for-byte
     # identical to the serial run regardless of worker count.
     # Phase 1 (serial): cache lookups, split hits from misses keeping order.
+    cache_started = time.monotonic()
     keys: list[str | None] = []
     results: list[SourceAbiTu | None] = [None] * len(units)
     misses: list[int] = []
@@ -870,6 +916,7 @@ def run_source_replay(
             results[i] = cached
         else:
             misses.append(i)
+    cache_elapsed = time.monotonic() - cache_started
 
     # Phase 2 (parallel): extract the cache misses. Stateless per TU, so the
     # worker is a module-level function (picklable for the process pool) fed the
@@ -879,6 +926,7 @@ def run_source_replay(
     jobs = _l4_jobs(len(misses))
     miss_units = [units[i] for i in misses]
     worker = partial(_extract_one, extractor, list(roots or []), target_id)
+    extract_started = time.monotonic()
     if jobs > 1 and len(misses) > 1:
         # Process pool parallelizes the GIL-bound AST post-processing too, not
         # just the clang subprocess wait (opt-in; see _l4_use_process_pool).
@@ -902,6 +950,7 @@ def run_source_replay(
                 raise
     else:
         extracted = [worker(u) for u in miss_units]
+    extract_elapsed = time.monotonic() - extract_started
     for i, (tu, err) in zip(misses, extracted):
         if err is None:
             results[i] = tu
@@ -921,6 +970,7 @@ def run_source_replay(
         elif i in diags:
             diagnostics.append(diags[i])
 
+    link_started = time.monotonic()
     surface = link_source_abi(
         tus,
         exported_symbols=exported_symbols,
@@ -928,11 +978,28 @@ def run_source_replay(
         target_id=target_id,
         forced_public=forced_public,
     )
+    link_elapsed = time.monotonic() - link_started
     surface.coverage["replay_scope"] = scope
     surface.coverage["include_graph_used"] = bool(_norm_include_map(include_map))
     surface.coverage["compile_units_selected"] = len(units)
     surface.coverage["compile_units_parsed"] = len(tus)
     surface.coverage["extractor_failures"] = len(diagnostics)
+    uncovered = _uncovered_public_headers(roots, units, _norm_include_map(include_map))
+    if uncovered:
+        surface.coverage["public_headers_uncovered"] = len(uncovered)
+        surface.coverage["public_headers_uncovered_examples"] = uncovered[:10]
+    surface.coverage["cache_lookup_s"] = round(cache_elapsed, 3)
+    surface.coverage["extract_s"] = round(extract_elapsed, 3)
+    surface.coverage["link_s"] = round(link_elapsed, 3)
+    surface.coverage["elapsed_s"] = round(time.monotonic() - total_started, 3)
+    surface.coverage["extractor_jobs"] = jobs
+    surface.coverage["cache_misses"] = len(misses)
+    if scope_widened:
+        surface.coverage["scope_widened_to_full"] = True
+        surface.coverage["scope_widened_reason"] = (
+            "headers-only had no include graph/public-header target ownership; "
+            "selected every compile unit"
+        )
     return surface, diagnostics
 
 

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -780,6 +780,8 @@ def embed_build_source(
     build_compile_db: str | None = None,
     changed_paths: tuple[str, ...] = (),
     extractor: str = "auto",
+    public_headers: tuple[str, ...] = (),
+    public_header_dirs: tuple[str, ...] = (),
     defer_cleanup: list[Callable[[], None]] | None = None,
 ) -> None:
     """Embed build-info / source facts inline in *snap* (single-artifact UX).
@@ -880,6 +882,9 @@ def embed_build_source(
             layers=layers,
             exported_symbols=exported,
             changed_paths=changed_paths,
+            public_header_roots=tuple(
+                dict.fromkeys((*public_headers, *public_header_dirs))
+            ),
             defer_cleanup=defer_cleanup,
         )
         # P09: don't fail *silently* when a source/build tree yields no compile DB.

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -214,6 +214,7 @@ class ScanOutcome:
     crosscheck_severities: dict[str, str] = field(default_factory=dict)
     poi: dict[str, Any] = field(default_factory=dict)
     advisories: list[str] = field(default_factory=list)
+    stage_timings: dict[str, float] = field(default_factory=dict)
     audit: bool = False
     diff_summary: dict[str, Any] | None = None
     verdict: str = "COMPATIBLE"
@@ -242,6 +243,9 @@ class ScanOutcome:
             "crosscheck_severities": dict(self.crosscheck_severities),
             "poi": self.poi,
             "advisories": list(self.advisories),
+            "stage_timings": {
+                k: round(v, 3) for k, v in sorted(self.stage_timings.items())
+            },
             "diff": self.diff_summary,
             "verdict": self.verdict,
             "exit_code": self.exit_code,
@@ -283,6 +287,14 @@ def _intrinsic_coverage(snap: Any) -> list[dict[str, Any]]:
         }
     )
     return rows
+
+
+def _source_abi_coverage(snap: Any) -> dict[str, Any]:
+    """Return the embedded L4 coverage dict, if present."""
+    pack = getattr(snap, "build_source", None)
+    surface = getattr(pack, "source_abi", None) if pack is not None else None
+    cov = getattr(surface, "coverage", None) if surface is not None else None
+    return dict(cov or {})
 
 
 def _pack_coverage(snap: Any) -> list[dict[str, Any]]:
@@ -373,6 +385,12 @@ def _render_text(out: ScanOutcome) -> str:
     )
     for note in out.advisories:
         lines.append(f"  note: {note}")
+    if out.stage_timings:
+        timing = ", ".join(
+            f"{name}={seconds:.2f}s"
+            for name, seconds in sorted(out.stage_timings.items())
+        )
+        lines.append(f"  timings: {timing}")
 
     poi_counts = out.poi.get("counts_by_reason") or {}
     if poi_counts:
@@ -502,6 +520,12 @@ def _build_new_snapshot(
             allow_build_query=allow_build_query,
             collect_mode=collect_mode,
             changed_paths=changed_paths,
+            public_headers=tuple(
+                str(p) for p in _expand_public_headers(
+                    [*list(public_headers or ()), *list(public_header_dirs or ())]
+                )
+            ),
+            public_header_dirs=tuple(str(p) for p in (public_header_dirs or ())),
             defer_cleanup=defer_cleanup,
         )
     return snap
@@ -1147,6 +1171,11 @@ def run_scan_core(
     overflow (the CLI maps it to exit 5). This is the one body the CLI,
     ``service.run_scan``, and the MCP scan tool share (ADR-035 D10).
     """
+    stage_timings: dict[str, float] = {}
+
+    def _record_stage(name: str, started: float) -> None:
+        stage_timings[name] = time.monotonic() - started
+
     # --- always-on tier: compiler-free pattern pre-scan (S3) ------------------
     # Runs *before* the snapshot build so its escalation triggers feed the D7
     # points-of-interest work-list that focuses the (expensive) source replay.
@@ -1160,7 +1189,9 @@ def run_scan_core(
         EvidenceDepth.HEADERS,
     }:
         pattern_roots.append(sources)
+    _stage = time.monotonic()
     pattern = scan_files(pattern_roots, changed if seeded else None)
+    _record_stage("pattern_scan", _stage)
 
     # --- D7 points-of-interest: cheap facts steer the expensive scan ----------
     # Floor = the directly-changed paths (always included); the pattern triggers,
@@ -1176,6 +1207,7 @@ def run_scan_core(
         and seeded
         and collect_mode in {"source-changed", "graph-full"}
     )
+    _stage = time.monotonic()
     poi_baseline = _load_exports_for_poi(baseline, lang) if needs_export_delta_poi else None
     poi_candidate = (
         _load_exports_for_poi(binary, lang) if poi_baseline is not None else None
@@ -1187,6 +1219,7 @@ def run_scan_core(
         baseline=poi_baseline,
         candidate=poi_candidate,
     )
+    _record_stage("poi", _stage)
 
     # --- build the candidate snapshot (L0-L2 + inline L3-L5 at the level) ------
     # An explicit --compile-db (a file) wins over --build-info (dir/pack) as the
@@ -1256,6 +1289,7 @@ def run_scan_core(
                 "explicitly to silence this note."
             )
 
+    _stage = time.monotonic()
     new_snap = _build_new_snapshot(
         binary,
         list(headers),
@@ -1274,6 +1308,32 @@ def run_scan_core(
         symbols_only=eff_depth_enum is EvidenceDepth.BINARY,
         debug_presence_only=_uses_debug_presence_only(eff_depth_enum),
     )
+    _record_stage("candidate_snapshot", _stage)
+    l4_cov = _source_abi_coverage(new_snap)
+    if l4_cov.get("scope_widened_to_full"):
+        advisories.append(
+            "headers-only source replay widened to all compile units because no "
+            "include graph/public-header target ownership could narrow it. Provide "
+            "depfile/include graph evidence or seed with --since/--changed-path to "
+            "avoid full fanout."
+        )
+    uncovered = int(l4_cov.get("public_headers_uncovered", 0) or 0)
+    if uncovered:
+        advisories.append(
+            f"headers-only source replay used the include graph and skipped full "
+            f"fanout, but {uncovered} public header(s) were not reached by any "
+            "selected TU; source-only coverage is partial for those headers."
+        )
+    exported = int(l4_cov.get("exported_symbols", 0) or 0)
+    matched = int(l4_cov.get("matched_symbols", 0) or 0)
+    parsed = int(l4_cov.get("compile_units_parsed", 0) or 0)
+    if exported and parsed and matched == 0:
+        advisories.append(
+            f"L4 source replay parsed {parsed} TU(s) but matched 0/{exported} "
+            "exported symbol(s); source-link evidence is degraded. Check mangled "
+            "symbol matching/public-header roots before relying on source-only "
+            "findings."
+        )
 
     # --- level-vs-evidence: fail-loud on missing input, advise otherwise ------
     # A deep depth (build/source/full → collect_mode != "off") needs an L3 compile
@@ -1324,7 +1384,9 @@ def run_scan_core(
         if new_snap.build_source is not None
         else None
     )
+    _stage = time.monotonic()
     preproc = run_preprocessor_scan(pp_build, _expand_public_headers(list(headers)))
+    _record_stage("preprocessor_scan", _stage)
 
     # --- always-on tier: intra-version cross-source checks (D4) ---------------
     # The resolved changed-path set is handed to the engine so
@@ -1335,6 +1397,7 @@ def run_scan_core(
     # export-delta walk resolved (symbol_tus), so ``public_to_internal_dependency``
     # elevates a finding whose internal target sits in a TU this revision touched
     # *via a changed export* — not only the literally git-changed files.
+    _stage = time.monotonic()
     cc = run_crosschecks(
         new_snap,
         CrosscheckConfig(
@@ -1342,10 +1405,12 @@ def run_scan_core(
             changed_paths=frozenset(changed) | set(symbol_tus),
         ),
     )
+    _record_stage("crosschecks", _stage)
 
     # --- pinned-level baseline comparison (if any) ----------------------------
     diff_summary: dict[str, Any] | None = None
     if baseline is not None and scan_mode is not ScanMode.AUDIT:
+        _stage = time.monotonic()
         verdict, exit_code, diff_summary = _run_baseline_compare(
             baseline,
             new_snap,
@@ -1373,6 +1438,7 @@ def run_scan_core(
             # BREAKING/API_BREAK from the artifact diff.
             if verdict in ("NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK"):
                 verdict = "API_BREAK"
+        _record_stage("baseline_compare", _stage)
     else:
         if baseline is not None:
             click.echo(
@@ -1413,6 +1479,7 @@ def run_scan_core(
         crosscheck_severities=severities,
         poi=poi.to_dict(),
         advisories=advisories,
+        stage_timings=stage_timings,
         audit=scan_mode is ScanMode.AUDIT,
         diff_summary=diff_summary,
         verdict=verdict,

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -253,7 +253,12 @@ _COST_PER_HEADER_PARSE = 0.08  # L2 base: castxml/clang startup + preprocess per
 #: took 80-180 s while the estimate read flat).
 _COST_PER_HEADER_KB = 0.004
 _COST_PER_TU_BUILD = 0.002  # L3 compile-DB entry parse
-_COST_PER_TU_REPLAY = 0.45  # L4 per-TU semantic AST replay
+# Cold L4 is a full clang JSON-AST replay + Python JSON parse + macro pass per TU.
+# Real-world pvxs/oneDAL validation showed ~7.5s/TU cold; the old 0.45s/TU anchor
+# under-promised source/full scans by an order of magnitude and made 100+ TU runs
+# look like one-minute jobs. Warm cache is reported by live coverage; dry-run stays
+# conservative unless a future cache probe can prove hits up front.
+_COST_PER_TU_REPLAY = 7.5  # L4 per-TU semantic AST replay, cold-cache default
 _COST_PER_TU_GRAPH = 0.02  # L5 per-TU graph fold/edge
 
 

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1411,6 +1411,31 @@ def test_l4_coverage_detail_partial_and_empty():
     assert "symbols matched" not in detail and "cache" not in detail
 
 
+def test_l4_include_map_prefers_recorded_inputs() -> None:
+    from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+    from abicheck.buildsource.inline import _include_map_for_replay
+
+    build = BuildEvidence(
+        compile_units=[
+            CompileUnit(id="cu://a", source="a.cpp", input_files=["include/api.h"]),
+            CompileUnit(id="cu://b", source="b.cpp", input_files=["src/impl.h"]),
+        ]
+    )
+    extractors = []
+    include_map = _include_map_for_replay(
+        build,
+        scope="headers-only",
+        roots=("include/api.h",),
+        clang_bin="definitely-not-needed",
+        extractors=extractors,
+    )
+    assert include_map == {
+        "cu://a": ["include/api.h"],
+        "cu://b": ["src/impl.h"],
+    }
+    assert extractors[0].name == "include_graph:recorded_inputs"
+
+
 def test_build_query_failure_is_recorded(tmp_path, monkeypatch):
     """A failing build.query command degrades to a failed extractor, no abort."""
     from abicheck.buildsource.inline import BuildConfig, collect_inline_pack
@@ -1747,7 +1772,8 @@ def test_inline_source_changed_falls_back_to_headers_only_scope(tmp_path, monkey
     captured = {}
 
     def _spy(sources, merged, extractors, *, extractor, scope, clang_bin,
-             exported_symbols=(), source_abi_cache_dir=None, changed_paths=()):
+             exported_symbols=(), source_abi_cache_dir=None, changed_paths=(),
+             public_header_roots=()):
         captured["scope"] = scope
         return None
 

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1411,10 +1411,23 @@ def test_l4_coverage_detail_partial_and_empty():
     assert "symbols matched" not in detail and "cache" not in detail
 
 
-def test_l4_include_map_prefers_recorded_inputs() -> None:
+def test_l4_include_map_uses_depfile_not_recorded_inputs_for_headers_only(
+    monkeypatch,
+) -> None:
+    import abicheck.buildsource.include_graph as ig
     from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
     from abicheck.buildsource.inline import _include_map_for_replay
 
+    class _FakeIncludeExtractor:
+        clang_bin = "clang++"
+
+        def __init__(self, **kw):
+            self.diagnostics = []
+
+        def extract_from_build(self, build):
+            return {"cu://b": ["include/api.h"]}
+
+    monkeypatch.setattr(ig, "ClangIncludeExtractor", _FakeIncludeExtractor)
     build = BuildEvidence(
         compile_units=[
             CompileUnit(id="cu://a", source="a.cpp", input_files=["include/api.h"]),
@@ -1429,11 +1442,8 @@ def test_l4_include_map_prefers_recorded_inputs() -> None:
         clang_bin="definitely-not-needed",
         extractors=extractors,
     )
-    assert include_map == {
-        "cu://a": ["include/api.h"],
-        "cu://b": ["src/impl.h"],
-    }
-    assert extractors[0].name == "include_graph:recorded_inputs"
+    assert include_map == {"cu://b": ["include/api.h"]}
+    assert extractors[0].name == "include_graph:clang"
 
 
 def test_build_query_failure_is_recorded(tmp_path, monkeypatch):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -687,6 +687,8 @@ def test_unseeded_s5_with_sources_emits_headers_only_advisory(
     assert res.exit_code == 0, res.output
     payload = _payload(res)
     assert any("--since" in a for a in payload["advisories"])
+    assert payload["stage_timings"]["pattern_scan"] >= 0.0
+    assert payload["stage_timings"]["candidate_snapshot"] >= 0.0
 
 
 def test_unseeded_s5_advisory_rendered_in_text_output(

--- a/tests/test_l4_perf.py
+++ b/tests/test_l4_perf.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 
 import logging
 import pickle
+import time
 from functools import partial
 from pathlib import Path
 
 import pytest
 
 from abicheck.buildsource import source_replay as sr
-from abicheck.buildsource.build_evidence import CompileUnit
+from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
 from abicheck.buildsource.source_abi import SourceAbiTu
 from abicheck.buildsource.source_extractors.base import SourceExtractionError
 
@@ -338,3 +339,35 @@ def test_dep_digest_memo_records_missing_as_none(tmp_path: Path) -> None:
     missing = str(tmp_path / "gone.h")
     assert sr._dep_digest(missing, memo) is None
     assert missing in memo and memo[missing] is None
+
+
+def test_headers_only_public_roots_perf_guard_avoids_full_fanout() -> None:
+    """Track the pvxs-style regression: public roots must not replay every TU."""
+    build = BuildEvidence(
+        compile_units=[
+            CompileUnit(id=f"cu://{idx}", source=f"src/unit{idx}.cpp")
+            for idx in range(120)
+        ]
+    )
+    include_map = {
+        f"cu://{idx}": [f"src/private{idx}.h"]
+        for idx in range(120)
+    }
+    include_map["cu://17"] = ["../pvxs/log.h", "src/private17.h"]
+    include_map["cu://89"] = ["../pvxs/client.h", "src/private89.h"]
+
+    started = time.perf_counter()
+    selected = sr.select_compile_units(
+        build,
+        scope="headers-only",
+        include_map=include_map,
+        public_header_roots=[
+            "/work/pvxs/include/pvxs/log.h",
+            "/work/pvxs/include/pvxs/client.h",
+        ],
+    )
+    elapsed = time.perf_counter() - started
+
+    assert {unit.id for unit in selected} == {"cu://17", "cu://89"}
+    assert len(selected) <= 2
+    assert elapsed < 0.25

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -336,6 +336,25 @@ def test_estimate_budget_max_tus_caps_replay(snap_path: Path, tmp_path: Path) ->
     assert l4.tus == 5
 
 
+def test_estimate_l4_uses_cold_realworld_anchor(
+    snap_path: Path, tmp_path: Path
+) -> None:
+    cdb = tmp_path / "compile_commands.json"
+    cdb.write_text(
+        json.dumps(
+            [
+                {"file": f"f{i}.cpp", "command": "c++", "directory": "."}
+                for i in range(4)
+            ]
+        ),
+        encoding="utf-8",
+    )
+    req = ScanRequest(binaries=[snap_path], compile_db=cdb, mode="baseline")
+    l4 = next(e for e in estimate_scan(req) if e.layer == "L4_source_abi")
+    assert l4.tus == 4
+    assert l4.est_seconds == pytest.approx(30.0)
+
+
 # ── CLI: scan --estimate / --audit ───────────────────────────────────────────
 
 

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -362,6 +362,39 @@ def test_headers_only_external_roots_do_not_full_fanout_for_uncovered_header() -
     assert {u.id for u in units} == {"cu://a"}
 
 
+def test_headers_only_external_roots_do_not_hide_uncovered_owned_header() -> None:
+    build = _build()
+    units = select_compile_units(
+        build,
+        scope="headers-only",
+        include_map={
+            "cu://b": ["include/foo.h"],
+            "cu://d": ["external/pvxs/log.h"],
+        },
+        public_header_roots=["external/pvxs/log.h"],
+    )
+    assert {u.id for u in units} == {"cu://a", "cu://c"}
+
+
+def test_headers_only_suffix_match_requires_directory_context() -> None:
+    build = BuildEvidence(
+        compile_units=[
+            _cu("cu://private", "private.cpp"),
+            _cu("cu://public", "public.cpp"),
+        ]
+    )
+    units = select_compile_units(
+        build,
+        scope="headers-only",
+        include_map={
+            "cu://private": ["src/foo.h"],
+            "cu://public": ["../pvxs/foo.h"],
+        },
+        public_header_roots=["/work/pvxs/include/pvxs/foo.h"],
+    )
+    assert {u.id for u in units} == {"cu://public"}
+
+
 def test_source_replay_reports_uncovered_external_public_roots() -> None:
     build = BuildEvidence(
         compile_units=[

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -373,7 +373,7 @@ def test_headers_only_external_roots_do_not_hide_uncovered_owned_header() -> Non
         },
         public_header_roots=["external/pvxs/log.h"],
     )
-    assert {u.id for u in units} == {"cu://a", "cu://c"}
+    assert {u.id for u in units} == {"cu://a", "cu://c", "cu://d"}
 
 
 def test_headers_only_suffix_match_requires_directory_context() -> None:

--- a/tests/test_source_replay.py
+++ b/tests/test_source_replay.py
@@ -287,6 +287,106 @@ def test_headers_only_heuristic_uses_header_target_reverse_dep() -> None:
     assert {u.id for u in units} == {"cu://kernel"}
 
 
+def test_headers_only_full_fanout_is_reported() -> None:
+    build = BuildEvidence(
+        compile_units=[
+            _cu("cu://a", "a.cpp"),
+            _cu("cu://b", "b.cpp"),
+        ]
+    )
+    surface, diagnostics = run_source_replay(
+        build,
+        _FakeExtractor(),
+        scope="headers-only",
+        exported_symbols=["_Z6unusedv"],
+    )
+    assert diagnostics == []
+    assert surface.coverage["compile_units_selected"] == 2
+    assert surface.coverage["scope_widened_to_full"] is True
+    assert (
+        "headers-only had no include graph"
+        in surface.coverage["scope_widened_reason"]
+    )
+    assert surface.coverage["elapsed_s"] >= 0.0
+    assert surface.coverage["extract_s"] >= 0.0
+
+
+def test_headers_only_set_cover_uses_external_public_roots() -> None:
+    build = BuildEvidence(
+        compile_units=[
+            _cu("cu://a", "a.cpp"),
+            _cu("cu://b", "b.cpp"),
+            _cu("cu://c", "c.cpp"),
+        ]
+    )
+    units = select_compile_units(
+        build,
+        scope="headers-only",
+        include_map={
+            "cu://a": ["include/api.h"],
+            "cu://b": ["include/detail.h"],
+            "cu://c": ["src/impl.h"],
+        },
+        public_header_roots=["include/api.h"],
+    )
+    assert {u.id for u in units} == {"cu://a"}
+
+
+def test_headers_only_set_cover_matches_relative_depfile_paths() -> None:
+    build = BuildEvidence(compile_units=[_cu("cu://a", "a.cpp")])
+    units = select_compile_units(
+        build,
+        scope="headers-only",
+        include_map={"cu://a": ["../pvxs/log.h"]},
+        public_header_roots=["/work/build/include/pvxs/log.h"],
+    )
+    assert {u.id for u in units} == {"cu://a"}
+
+
+def test_headers_only_external_roots_do_not_full_fanout_for_uncovered_header() -> None:
+    build = BuildEvidence(
+        compile_units=[
+            _cu("cu://a", "a.cpp"),
+            _cu("cu://b", "b.cpp"),
+        ]
+    )
+    units = select_compile_units(
+        build,
+        scope="headers-only",
+        include_map={
+            "cu://a": ["include/api.h"],
+            "cu://b": ["src/impl.h"],
+        },
+        public_header_roots=["include/api.h", "include/unreached.h"],
+    )
+    assert {u.id for u in units} == {"cu://a"}
+
+
+def test_source_replay_reports_uncovered_external_public_roots() -> None:
+    build = BuildEvidence(
+        compile_units=[
+            _cu("cu://a", "a.cpp"),
+            _cu("cu://b", "b.cpp"),
+        ]
+    )
+    surface, diagnostics = run_source_replay(
+        build,
+        _FakeExtractor(),
+        scope="headers-only",
+        include_map={
+            "cu://a": ["include/api.h"],
+            "cu://b": ["src/impl.h"],
+        },
+        public_header_roots=["include/api.h", "include/unreached.h"],
+    )
+    assert diagnostics == []
+    assert surface.coverage["compile_units_selected"] == 1
+    assert surface.coverage["public_headers_uncovered"] == 1
+    assert surface.coverage["public_headers_uncovered_examples"] == [
+        "include/unreached.h"
+    ]
+
+
 def test_headers_only_set_cover_needs_two_units() -> None:
     # No single TU covers both headers → cover needs two (one per header).
     include_map = {


### PR DESCRIPTION
## Summary
- add scan stage timings and L4 elapsed/sub-stage coverage so slow scan phases are visible
- thread CLI public headers into inline L4 replay and build a cheap include map before headers-only source replay
- fix public-header/include suffix matching so depfile paths like `../pvxs/log.h` match absolute `-H` roots
- avoid all-TU fallback for external public roots when include graph can cover reachable headers; report uncovered roots instead
- calibrate cold L4 estimate to real-world clang AST replay cost and degrade zero-match L4 coverage to partial/reduced

## Speed impact
Cheap pvxs probe, without full AST replay:
- compile DB: 112 TU
- depfile include graph: 111/112 TU in ~10.3s
- old headers-only selector: 112/112 TU (~840s cold L4 estimate)
- new headers-only selector: 2/112 TU, uncovered=0 (~10s depfile + ~15s cold AST-side estimate)

`graph-full` remains full by design; this targets unseeded/source headers-only fanout.

## Regression coverage
- unit behavior: selector uses CLI public roots, matches relative depfile paths, avoids external-root full fanout, reports uncovered public roots/advisories
- perf guard: `tests/test_l4_perf.py::test_headers_only_public_roots_perf_guard_avoids_full_fanout` tracks the pvxs-like 120 TU -> 2 TU narrowing and fails if selector returns to all-TU replay
- estimator/reporting: cold L4 cost, stage timings, coverage elapsed/sub-timings

## Test plan
- `python -m pytest tests/test_l4_perf.py tests/test_source_replay.py tests/test_build_source_cli.py tests/test_cli_scan.py tests/test_scan_estimate.py -q`
- `python -m pytest tests/test_source_replay.py tests/test_build_source_cli.py tests/test_cli_scan.py tests/test_scan_baseline_headers.py tests/test_scan_estimate.py tests/test_layer_coverage.py tests/test_build_source_pack.py tests/test_cli_datasources.py tests/test_source_evidence_integrity.py -q`
- `git diff --check`
- `python -m compileall -q abicheck/service_scan.py abicheck/cli_scan.py abicheck/cli_buildsource.py abicheck/buildsource/model.py abicheck/buildsource/source_replay.py abicheck/buildsource/inline.py`