### PR TITLE
Parallelize call graph extraction

### DIFF
--- a/abicheck/buildsource/call_graph.py
+++ b/abicheck/buildsource/call_graph.py
@@ -36,9 +36,12 @@ This module is split so the hard part stays testable:
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess  # noqa: S404 - call-graph extraction shells out to clang (never shell=True)
+import time
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -467,6 +470,22 @@ def _safe_clang_args_from_compile_unit(cu: BuildEvidenceCompileUnit) -> list[str
     return [*flags, "--", cu.source]
 
 
+def _call_graph_jobs(n_units: int) -> int:
+    """Bounded worker count for the best-effort L5 clang call-graph pass."""
+    if n_units <= 1:
+        return max(0, n_units)
+    cpu = os.cpu_count() or 1
+    cap = max(8, cpu * 2)
+    raw = os.environ.get("ABICHECK_CALL_GRAPH_JOBS", "").strip()
+    if raw:
+        try:
+            requested = int(raw)
+        except ValueError:
+            return 1
+        return max(1, min(n_units, requested, cap))
+    return max(1, min(n_units, cpu, 8))
+
+
 # ── live clang extraction (integration only) ────────────────────────────────
 
 
@@ -482,6 +501,8 @@ class ClangCallGraphExtractor:
 
     clang_bin: str = "clang++"
     diagnostics: list[str] = field(default_factory=list)
+    last_jobs: int = 0
+    last_elapsed_s: float = 0.0
 
     def available(self) -> bool:
         return shutil.which(self.clang_bin) is not None
@@ -528,15 +549,38 @@ class ClangCallGraphExtractor:
             self.diagnostics.append(f"could not parse clang AST JSON: {exc}")
             return []
 
+    def _extract_from_compile_unit(
+        self, cu: BuildEvidenceCompileUnit
+    ) -> list[CallEdge]:
+        argv = _safe_clang_args_from_compile_unit(cu)
+        return self._extract_from_safe_args(argv, cwd=cu.directory or None)
+
     def extract_from_build(self, build: BuildEvidence) -> list[CallEdge]:
         """Extract call edges across every compile unit in *build* (best effort)."""
+        start = time.monotonic()
+        units = [cu for cu in build.compile_units if cu.source]
+        self.last_jobs = _call_graph_jobs(len(units))
+        if not units:
+            self.last_elapsed_s = 0.0
+            return []
+        if not self.available():
+            self.diagnostics.append(f"{self.clang_bin} not found in PATH")
+            self.last_elapsed_s = time.monotonic() - start
+            return []
+
+        try:
+            if self.last_jobs > 1 and len(units) > 1:
+                with ThreadPoolExecutor(max_workers=self.last_jobs) as pool:
+                    batches = list(pool.map(self._extract_from_compile_unit, units))
+            else:
+                batches = [self._extract_from_compile_unit(cu) for cu in units]
+        finally:
+            self.last_elapsed_s = time.monotonic() - start
+
         all_edges: list[CallEdge] = []
         seen: set[tuple[str, str, str]] = set()
-        for cu in build.compile_units:
-            if not cu.source:
-                continue
-            argv = _safe_clang_args_from_compile_unit(cu)
-            for e in self._extract_from_safe_args(argv, cwd=cu.directory or None):
+        for edges in batches:
+            for e in edges:
                 key = (e.caller, e.callee, e.call_kind)
                 if key not in seen:
                     seen.add(key)

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -1527,13 +1527,18 @@ def _fold_call_graph(
     added = augment_graph_with_calls(graph, edges, project_files or None)
     for diag in extractor.diagnostics:
         merged.diagnostics.append(f"call_graph: {diag}")
+    timing = (
+        f", {extractor.last_elapsed_s:.2f}s, jobs={extractor.last_jobs}"
+        if getattr(extractor, "last_jobs", 0)
+        else ""
+    )
     rows.append(
         ExtractorRecord(
             name="call_graph:clang",
             status="ok" if added else "partial",
             detail=(
                 f"{added} call edges from {len(target.compile_units)} compile "
-                f"unit(s){scoped_note}"
+                f"unit(s){scoped_note}{timing}"
             ),
         )
     )

--- a/abicheck/cli_buildsource_helpers.py
+++ b/abicheck/cli_buildsource_helpers.py
@@ -1201,11 +1201,19 @@ def _collect_call_graph(
     graph.finalize()
     for diag in extractor.diagnostics:
         merged.diagnostics.append(f"call_graph: {diag}")
+    timing = (
+        f", {extractor.last_elapsed_s:.2f}s, jobs={extractor.last_jobs}"
+        if getattr(extractor, "last_jobs", 0)
+        else ""
+    )
     extractors.append(
         ExtractorRecord(
             name="call_graph:clang",
             status="ok" if added else "partial",
-            detail=f"{added} call edges from {len(merged.compile_units)} compile units",
+            detail=(
+                f"{added} call edges from {len(merged.compile_units)} compile "
+                f"units{timing}"
+            ),
         )
     )
 

--- a/tests/test_call_graph.py
+++ b/tests/test_call_graph.py
@@ -30,6 +30,7 @@ from abicheck.buildsource.call_graph import (
     RESOLUTION_UNKNOWN,
     CallEdge,
     ClangCallGraphExtractor,
+    _call_graph_jobs,
     augment_graph_with_calls,
     parse_clang_ast_calls,
 )
@@ -522,6 +523,47 @@ def test_extract_from_build_dedupes_across_units(monkeypatch) -> None:
     assert edges == [CallEdge("_Zc", "_Zcallee", CALL_KIND_DIRECT, RESOLUTION_EXACT)]
 
 
+def test_call_graph_jobs_env_override_is_bounded(monkeypatch) -> None:
+    monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "2")
+    assert _call_graph_jobs(120) == 2
+    monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "9999")
+    assert 1 <= _call_graph_jobs(120) <= 120
+    monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "nope")
+    assert _call_graph_jobs(120) == 1
+
+
+def test_extract_from_build_parallelizes_and_dedupes(monkeypatch) -> None:
+    import abicheck.buildsource.call_graph as cg
+
+    monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "2")
+    monkeypatch.setattr(cg.shutil, "which", lambda _b: "/usr/bin/clang++")
+    seen_sources: list[str] = []
+
+    def fake_extract(self, argv, cwd=None):
+        del self, cwd
+        seen_sources.append(argv[-1])
+        return [CallEdge("caller", "callee")]
+
+    monkeypatch.setattr(
+        cg.ClangCallGraphExtractor, "_extract_from_safe_args", fake_extract
+    )
+    build = BuildEvidence(
+        compile_units=[
+            CompileUnit(id="cu://a", source="a.cpp"),
+            CompileUnit(id="cu://b", source="b.cpp"),
+            CompileUnit(id="cu://c", source="c.cpp"),
+        ]
+    )
+
+    ext = ClangCallGraphExtractor()
+    edges = ext.extract_from_build(build)
+
+    assert ext.last_jobs == 2
+    assert ext.last_elapsed_s >= 0.0
+    assert sorted(seen_sources) == ["a.cpp", "b.cpp", "c.cpp"]
+    assert edges == [CallEdge("caller", "callee")]
+
+
 # ── collect --call-graph wiring (_collect_call_graph) ───────────────
 
 
@@ -539,6 +581,8 @@ class _FakeExtractor:
         self._available = available
         self._edges = edges or []
         self.diagnostics: list[str] = []
+        self.last_jobs = 1
+        self.last_elapsed_s = 0.0
 
     def available(self) -> bool:
         return self._available


### PR DESCRIPTION
## Summary
- parallelize the optional L5 Clang call-graph extraction pass with bounded workers (ABICHECK_CALL_GRAPH_JOBS override)
- record call-graph elapsed time and worker count in extractor detail for inline scans and build-source packs
- add regression coverage for bounded worker selection and parallel dedupe behavior

## Speed impact
This speeds modes that actually fold call edges, such as collect --call-graph and semantic L5 call-graph paths. After re-checking the pvxs full scan artifacts, the current scan --depth full path is structural L5 and spends its time in L4 all-TU source replay, so this PR is useful but is not the main pvxs full-scan fix.

Synthetic call-graph probe: 16 TUs with 50ms per TU, jobs=1 took 0.803s and jobs=8 took 0.105s.

## Test plan
- python -m pytest tests/test_call_graph.py tests/test_inline_changed_paths.py -q (44 passed)
- python -m pytest tests/test_call_graph.py tests/test_inline_changed_paths.py tests/test_l4_perf.py tests/test_source_replay.py tests/test_build_source_cli.py tests/test_scan_estimate.py -q (287 passed)
- python -m compileall -q abicheck/buildsource abicheck/cli_buildsource_helpers.py
- python -m ruff format/check targeted files
- git diff --check

Note: full python -m pytest tests -q is blocked in this local env by missing hypothesis for property tests.