### PR TITLE
fix(scan): require explicit --allow-build-query for build.query

### DIFF
--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -832,16 +832,6 @@ def scan_cmd(
             severities=severities,
             budget=budget,
             budget_s=budget_s,
-            # A concrete explicit level is what consents to level-implies-query
-            # auto-running build.query: a non-auto --source-method, or --depth ONLY
-            # when no --source-method is given (resolve_level gives --source-method
-            # precedence and ignores --depth otherwise, so `auto`+`--depth` resolves
-            # via auto/the preset, not the depth — it must not count as consent;
-            # Codex review).
-            level_explicit=(
-                source_method is not None and source_method != SourceMethod.AUTO.value
-            )
-            or (source_method is None and depth is not None),
         )
     except _BudgetOverflow as bo:
         click.echo(bo.message, err=True)
@@ -913,7 +903,6 @@ def run_scan_core(
     severities: dict[str, str],
     budget: str | None,
     budget_s: float | None,
-    level_explicit: bool = False,
 ) -> ScanCoreResult:
     """The shared scan orchestration (classify → always-on tier → level → compare).
 
@@ -991,39 +980,10 @@ def run_scan_core(
             "public-API surface (headers-only) instead of a focused diff. Pass "
             "--since <ref> or --changed-path to scope it to the change."
         )
-    # level-implies-query (ADR-037 D4): an explicit, *trusted* --config that
-    # defines a build.query, together with an *explicitly pinned* deep level
-    # (--source-method/--depth, level_explicit), is itself consent to run that
-    # query — making the user pass --allow-build-query as well for a level they
-    # explicitly asked for is needless friction. Trusted = an explicit --config
-    # path (build_config is not None here; an auto-discovered source-tree config
-    # is resolved later in embed_build_source and never reaches this gate), so
-    # this never runs an attacker-controlled command. Crucially it does NOT fire
-    # for the default mode preset (a plain `scan`/`--audit` with `--sources` whose
-    # collect_mode is already non-off) — only an explicit deep level counts, so a
-    # --config passed purely for project settings never silently runs a subprocess
-    # (Codex review). No-op when the config defines no query.
-    effective_allow_query = allow_build_query
-    if (
-        not allow_build_query
-        and build_config is not None
-        and collect_mode != "off"
-        and level_explicit
-    ):
-        from .buildsource.inline import load_build_config
-
-        try:
-            _cfg = load_build_config(build_config)
-        except Exception:  # malformed config surfaces later in the real load
-            _cfg = None
-        if _cfg is not None and _cfg.query:
-            effective_allow_query = True
-            advisories.append(
-                f"level {resolved.value} with a trusted --config defining "
-                "build.query: auto-enabled the query to collect L3+ evidence "
-                "(equivalent to --allow-build-query). Pass --allow-build-query "
-                "explicitly to silence this note."
-            )
+    # build.query may execute arbitrary local commands from configuration, so the
+    # scan path must preserve the explicit --allow-build-query action ceiling. An
+    # explicit --config path can make a config eligible for query execution in the
+    # build-source layer, but it is never consent by itself.
 
     new_snap = _build_new_snapshot(
         binary,
@@ -1032,7 +992,7 @@ def run_scan_core(
         sources,
         collect_mode,
         lang,
-        effective_allow_query,
+        allow_build_query,
         changed_paths=replay_seed,
         build_info=effective_build_info,
         build_config=build_config,

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -78,12 +78,11 @@ abicheck scan --binary new/libonedal_core.so -H include/ --build-info aq.json --
 
 If your project ships a trusted `.abicheck.yml` with a `build.query`, you can let
 `abicheck` run it instead of pre-generating the DB. Pass it with `--config`
-(the project contract). Pinning a deep
-level (`--source-method s5`, etc.) with such a trusted `--config` **auto-enables**
-the query — you no longer also need `--allow-build-query` for a level you
-explicitly asked for (the report notes when this happens). An *auto-discovered*
-`.abicheck.yml` under `--sources` is never trusted to execute commands; only an
-explicit `--config` is.
+(the project contract) and opt in to command execution with `--allow-build-query`.
+Pinning a deep level (`--source-method s5`, etc.) is not enough to run
+`build.query`; the explicit allow flag is always required because the query is
+executable local configuration. An *auto-discovered* `.abicheck.yml` under
+`--sources` is never trusted to execute commands.
 
 ```yaml
 # .abicheck.yml
@@ -93,7 +92,8 @@ build:
 
 ```bash
 abicheck scan --binary new/libfoo.so -H include/ --sources . \
-  --config .abicheck.yml --source-method s5 --baseline old/libfoo.abi.json
+  --config .abicheck.yml --allow-build-query --source-method s5 \
+  --baseline old/libfoo.abi.json
 ```
 
 ## Worked examples

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -23,6 +23,7 @@ exit codes, the budget guard, and the coverage report. Default lane.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -833,180 +834,24 @@ def test_l3_collected_branches(pack, expected):
         assert _l3_collected(_Snap(_Pack(list(pack)))) is expected
 
 
-def test_level_implies_query_auto_enables_with_trusted_config(
-    runner, tmp_path, source_tree_with_compile_db, new_snap_compatible
-):
-    # ADR-037 D4: an explicit (trusted) --config defining build.query + a pinned
-    # deep level is consent to run the query — auto-enable it (advisory), no
-    # separate --allow-build-query needed. --build-info carries a real compile DB
-    # so the query string is never actually executed (build_info resolves first),
-    # keeping the test hermetic while still exercising the auto-enable path.
-    cfg = tmp_path / ".abicheck.yml"
-    cfg.write_text(
-        "build:\n  query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n",
-        encoding="utf-8",
-    )
-    res = runner.invoke(
-        main,
-        [
-            "scan",
-            "--binary",
-            str(new_snap_compatible),
-            "--build-info",
-            str(source_tree_with_compile_db),
-            "--config",
-            str(cfg),
-            "--source-method",
-            "s5",
-            "--audit",
-        ],
-    )
-    assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" in res.output
-
-
-def test_level_implies_query_silent_without_trusted_config(
-    runner, source_tree_with_compile_db, new_snap_compatible
-):
-    # No explicit --config → nothing is trusted for query execution, so the
-    # auto-enable advisory must NOT fire even at a deep level.
-    res = runner.invoke(
-        main,
-        [
-            "scan",
-            "--binary",
-            str(new_snap_compatible),
-            "--build-info",
-            str(source_tree_with_compile_db),
-            "--source-method",
-            "s5",
-            "--audit",
-        ],
-    )
-    assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" not in res.output
-
-
-def test_level_implies_query_silent_for_default_mode(
-    runner, tmp_path, source_tree_with_compile_db, new_snap_compatible
-):
-    # Codex review: a --config passed only for project settings must NOT trigger
-    # build.query in the *default* flow (here --audit, whose preset is a deep
-    # collect_mode). Auto-enable requires an EXPLICIT --source-method/--depth, not
-    # a default mode preset — otherwise a config-for-settings silently runs a
-    # subprocess, bypassing the --allow-build-query action ceiling.
-    cfg = tmp_path / ".abicheck.yml"
-    cfg.write_text(
-        "build:\n  query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n",
-        encoding="utf-8",
-    )
-    res = runner.invoke(
-        main,
-        [
-            "scan",
-            "--binary",
-            str(new_snap_compatible),
-            "--build-info",
-            str(source_tree_with_compile_db),
-            "--config",
-            str(cfg),
-            "--audit",  # default mode preset; no explicit --source-method/--depth
-        ],
-    )
-    assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" not in res.output
-
-
-def test_level_implies_query_silent_for_source_method_auto(
-    runner, tmp_path, source_tree_with_compile_db, new_snap_compatible
-):
-    # ``--source-method auto`` still lets the resolver choose a default deep
-    # level. It is not concrete consent to run build.query.
-    cfg = tmp_path / ".abicheck.yml"
-    cfg.write_text(
-        "build:\n  query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n",
-        encoding="utf-8",
-    )
-    res = runner.invoke(
-        main,
-        [
-            "scan",
-            "--binary",
-            str(new_snap_compatible),
-            "--build-info",
-            str(source_tree_with_compile_db),
-            "--config",
-            str(cfg),
-            "--source-method",
-            "auto",
-            "--audit",
-        ],
-    )
-    assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" not in res.output
-
-
-def test_level_implies_query_malformed_config_does_not_crash(
+def test_scan_config_query_requires_explicit_allow_build_query(
     runner, tmp_path, new_snap_compatible
 ):
-    # A trusted but malformed --config at an explicit deep level must not crash the
-    # level-implies-query probe: load_build_config raises, the probe swallows it
-    # (the real load surfaces the error downstream), and with no source input there
-    # is no downstream load, so the scan still completes without auto-enabling.
-    cfg = tmp_path / ".abicheck.yml"
-    cfg.write_text("build: [unterminated\n", encoding="utf-8")  # invalid YAML
-    res = runner.invoke(
-        main,
-        [
-            "scan",
-            "--binary",
-            str(new_snap_compatible),
-            "--config",
-            str(cfg),
-            "--source-method",
-            "s5",
-            "--audit",
-        ],
+    # build.query is executable configuration. Even when the operator passes an
+    # explicit --config and pins a deep source level, scan must not treat those
+    # options as implicit consent to run the query; only --allow-build-query may
+    # cross that action ceiling.
+    src = tmp_path / "src"
+    src.mkdir()
+    marker = src / "query-ran.txt"
+    payload = src / "payload.py"
+    payload.write_text(
+        "from pathlib import Path\nPath('query-ran.txt').write_text('ran')\n",
+        encoding="utf-8",
     )
-    assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" not in res.output
-
-
-def test_level_implies_query_silent_when_config_defines_no_query(
-    runner, tmp_path, new_snap_compatible
-):
-    # An explicit deep level + a trusted --config that defines NO build.query must
-    # not auto-enable anything (the false branch): the config is loaded fine but
-    # there is no query to consent to.
-    cfg = tmp_path / ".abicheck.yml"
-    cfg.write_text("severity:\n  preset: strict\n", encoding="utf-8")  # no build.query
-    res = runner.invoke(
-        main,
-        [
-            "scan",
-            "--binary",
-            str(new_snap_compatible),
-            "--config",
-            str(cfg),
-            "--source-method",
-            "s5",
-            "--audit",
-        ],
-    )
-    assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" not in res.output
-
-
-def test_level_implies_query_auto_plus_depth_does_not_consent(
-    runner, tmp_path, source_tree_with_compile_db, new_snap_compatible
-):
-    # Codex review: `--source-method auto` takes precedence and makes resolve_level
-    # IGNORE --depth, so `auto` + `--depth` resolves via auto/the preset, not the
-    # depth. That must NOT count as explicit consent to run build.query. (build-info
-    # carries a real DB so the query string is never actually executed.)
     cfg = tmp_path / ".abicheck.yml"
     cfg.write_text(
-        "build:\n  query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n",
+        "build:\n" f"  query: {json.dumps(f'{sys.executable} {payload.name}')}\n",
         encoding="utf-8",
     )
     res = runner.invoke(
@@ -1015,26 +860,25 @@ def test_level_implies_query_auto_plus_depth_does_not_consent(
             "scan",
             "--binary",
             str(new_snap_compatible),
-            "--build-info",
-            str(source_tree_with_compile_db),
+            "--sources",
+            str(src),
             "--config",
             str(cfg),
             "--source-method",
-            "auto",
-            "--depth",
-            "source",
+            "s5",
             "--audit",
         ],
     )
     assert res.exit_code == 0, res.output
     assert "auto-enabled the query" not in res.output
+    assert "build.query configured but --allow-build-query not set" in res.output
+    assert not marker.exists()
 
 
-def test_level_implies_query_depth_only_consents(
+def test_scan_depth_config_query_requires_explicit_allow_build_query(
     runner, tmp_path, source_tree_with_compile_db, new_snap_compatible
 ):
-    # The flip side: an explicit --depth with NO --source-method is a concrete
-    # pinned level (resolve_level uses it), so it DOES consent to the trusted query.
+    # --depth is also not consent to execute build.query from --config.
     cfg = tmp_path / ".abicheck.yml"
     cfg.write_text(
         "build:\n  query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n",
@@ -1056,8 +900,7 @@ def test_level_implies_query_depth_only_consents(
         ],
     )
     assert res.exit_code == 0, res.output
-    assert "auto-enabled the query" in res.output
-
+    assert "auto-enabled the query" not in res.output
 
 def test_header_short_alias_works(runner, tmp_path, new_snap_compatible):
     # The --help example uses `-H`; the alias must actually parse (Codex review).


### PR DESCRIPTION
### Motivation
- Prevent execution of arbitrary commands from a configured `build.query` when an operator only supplies `--config` plus a pinned source level or depth, restoring the explicit `--allow-build-query` action ceiling. 
- Close a race where a trusted `--config` was treated as implicit consent to run queries, which allowed attacker-controlled repo/config to run arbitrary local commands in CI. 

### Description
- Remove the `level_explicit` probe and the auto-enable path that set `effective_allow_query = True` in `run_scan_core`, so the scan core now forwards the real `allow_build_query` flag unchanged to snapshot/build-source collection (`abicheck/cli_scan.py`).
- Ensure the inline build-source layer still treats auto-discovered `.abicheck.yml` as untrusted and preserves the `--allow-build-query` opt-in semantics (`abicheck/buildsource/inline.py` behavior unchanged; gating now only from explicit `--allow-build-query`).
- Update documentation to require explicit `--allow-build-query` when running `build.query` in the example and explanatory text (`docs/user-guide/scan-levels.md`).
- Add regression tests that assert an explicit `--config` plus a pinned `--source-method` or `--depth` does not execute the configured query and reports the skipped-query diagnostic (`tests/test_cli_scan.py`).

### Testing
- Ran the targeted tests: `pytest -q tests/test_cli_scan.py -k 'scan_config_query_requires_explicit_allow_build_query or scan_depth_config_query_requires_explicit_allow_build_query'` and both tests passed (`2 passed`).
- Ran the full scan CLI test suite: `pytest -q tests/test_cli_scan.py` and all tests passed (`51 passed`).
- Verified the docs example and test assertions reflect the new requirement that `build.query` execution always requires `--allow-build-query` (no automated doc check beyond test-driven examples were required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336abeb2e8832bb03de22276cfe11b)