### PR TITLE
fix: validate compile config flag atoms

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -265,6 +265,21 @@ class BuildConfig:
                 return [v]
             return []
 
+        def _safe_compile_atom(key: str, value: str) -> str:
+            # Values from auto-discovered source-tree configs are later embedded
+            # in individual compiler flags (``-std=<value>``/``-D<value>``) and
+            # flow through legacy shlex-split ``gcc_options`` plumbing.  Reject
+            # whitespace so one config scalar cannot become multiple compiler
+            # arguments such as ``-Xclang -load ./evil.so``.
+            if not value or any(ch.isspace() for ch in value):
+                raise ValueError(
+                    f"compile.{key} must be a single compiler option atom, got {value!r}"
+                )
+            return value
+
+        def _safe_compile_atoms(key: str) -> list[str]:
+            return [_safe_compile_atom(key, item) for item in _strs(compile_blk, key)]
+
         def _level(key: str) -> str | None:
             raw = _opt_str(severity, key)
             if raw is not None and raw not in _SEVERITY_LEVELS:
@@ -337,9 +352,13 @@ class BuildConfig:
             ),
             source_method=_opt_str(source, "method"),
             compile_frontend=compile_frontend,
-            compile_std=_opt_str(compile_blk, "std"),
+            compile_std=(
+                _safe_compile_atom("std", std)
+                if (std := _opt_str(compile_blk, "std")) is not None
+                else None
+            ),
             compile_include_dirs=_strs(compile_blk, "include_dirs"),
-            compile_defines=_strs(compile_blk, "defines"),
+            compile_defines=_safe_compile_atoms("defines"),
             compile_sysroot=_opt_str(compile_blk, "sysroot"),
             compile_nostdinc=_opt_bool(compile_blk, "nostdinc"),
             exit_code_scheme=scheme,

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -177,6 +177,22 @@ def test_buildconfig_parses_compile_block() -> None:
     assert BuildConfig.from_dict(bc.to_dict()).to_dict() == bc.to_dict()
 
 
+def test_buildconfig_rejects_compile_std_flag_injection() -> None:
+    from abicheck.buildsource.inline import BuildConfig
+
+    with pytest.raises(ValueError, match=r"compile\.std"):
+        BuildConfig.from_dict({"compile": {"std": "c++20 -Xclang"}})
+
+
+def test_buildconfig_rejects_compile_define_flag_injection() -> None:
+    from abicheck.buildsource.inline import BuildConfig
+
+    with pytest.raises(ValueError, match=r"compile\.defines"):
+        BuildConfig.from_dict(
+            {"compile": {"defines": ["SAFE=1 -Xclang -load -Xclang ./evil.so"]}}
+        )
+
+
 def test_buildconfig_rejects_bad_compile_frontend() -> None:
     import pytest as _pytest
 


### PR DESCRIPTION
### Motivation
- Prevent compiler flag injection where auto-discovered `.abicheck.yml` `compile.std` or `compile.defines` entries containing whitespace could be split into multiple compiler arguments and reach frontends like `clang`/`castxml`.

### Description
- Add `_safe_compile_atom` and `_safe_compile_atoms` to `abicheck/buildsource/inline.py` and use them to validate `compile.std` and each `compile.defines` entry, rejecting empty or whitespace-bearing values with a `ValueError`.
- Preserve existing behavior for other `compile:` fields while ensuring synthesized `gcc_options` can no longer be polluted by multi-token config scalars.
- Add regression tests in `tests/test_compile_context_parity.py` that assert `BuildConfig.from_dict` raises on malicious `compile.std` and `compile.defines` inputs.

### Testing
- Ran `pytest -q tests/test_compile_context_parity.py` which succeeded (`23 passed`).
- Ran full test suite with `pytest -q` which failed during collection due to a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a339503a53c832b9f9d6c706f16ac4f)