### PR TITLE
fix(cli): keep config compile flags literal

### DIFF
--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -324,8 +324,9 @@ def merge_compile_config(
     The single resolver shared by ``compare`` / ``dump`` / ``scan`` (ADR-037 D3):
     precedence is CLI > config (ADR-035 D6.1 / ADR-037 D4) — a per-field CLI value
     overrides config, an unset CLI field inherits it. The config's ``std`` +
-    ``defines`` synthesize ``-std=…``/``-D…`` flags only when the user did not pass
-    ``--gcc-options``; ``include_dirs`` (resolved against the config's directory)
+    ``defines`` synthesize literal ``-std=…``/``-D…`` argv entries only when the
+    user did not pass ``--gcc-options``; ``include_dirs`` (resolved against the
+    config's directory)
     are appended *after* the CLI ``-I`` so explicit roots keep search precedence.
     Returns the merged ``(CompileContext, includes)``.
 
@@ -380,14 +381,20 @@ def merge_compile_config(
         else (bc.compile_frontend or "auto")
     )
     gcc_options: str | None
+    gcc_option_tokens = cli_ctx.gcc_option_tokens
     if cli_ctx.gcc_options is not None:
         gcc_options = cli_ctx.gcc_options
     else:
-        parts: list[str] = []
+        # Config fields are structured metadata, not a shell-like option string.
+        # Keep each synthesized flag as one literal argv entry so whitespace inside
+        # a define/std value cannot be shlex-split into additional compiler
+        # options (for example plugin-loading flags).
+        config_tokens: list[str] = []
         if bc.compile_std:
-            parts.append(f"-std={bc.compile_std}")
-        parts += [f"-D{d}" for d in bc.compile_defines]
-        gcc_options = " ".join(parts) or None
+            config_tokens.append(f"-std={bc.compile_std}")
+        config_tokens += [f"-D{d}" for d in bc.compile_defines]
+        gcc_options = None
+        gcc_option_tokens = gcc_option_tokens + tuple(config_tokens)
     sysroot = (
         cli_ctx.sysroot
         if cli_ctx.sysroot is not None
@@ -400,7 +407,7 @@ def merge_compile_config(
         gcc_path=cli_ctx.gcc_path,
         gcc_prefix=cli_ctx.gcc_prefix,
         gcc_options=gcc_options,
-        gcc_option_tokens=cli_ctx.gcc_option_tokens,
+        gcc_option_tokens=gcc_option_tokens,
         sysroot=sysroot,
         nostdinc=nostdinc,
         frontend=frontend,

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -225,9 +225,29 @@ def test_merge_compile_config_uses_config_when_cli_unset(tmp_path: Path) -> None
     cfg.write_text("compile:\n  std: c++20\n  defines: [A, B=2]\n  frontend: clang\n")
     merged, _ = _merge_compile_config(CompileContext(), (), cfg)
     assert merged.frontend == "clang"
-    # std + defines synthesized into gcc_options when the user gave none.
-    assert merged.gcc_options == "-std=c++20 -DA -DB=2"
+    # std + defines are synthesized as literal argv tokens when the user gave no
+    # --gcc-options, so config values cannot inject extra compiler options.
+    assert merged.gcc_options is None
+    assert merged.gcc_option_tokens == ("-std=c++20", "-DA", "-DB=2")
 
+
+def test_merge_compile_config_keeps_config_values_literal(tmp_path: Path) -> None:
+    from abicheck.cli_scan import _merge_compile_config
+
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text(
+        "compile:\n"
+        "  std: 'c++20 -Xclang'\n"
+        "  defines:\n"
+        "    - 'DUMMY -Xclang -load -Xclang ./evil.so'\n",
+        encoding="utf-8",
+    )
+    merged, _ = _merge_compile_config(CompileContext(), (), cfg)
+    assert merged.gcc_options is None
+    assert merged.gcc_option_tokens == (
+        "-std=c++20 -Xclang",
+        "-DDUMMY -Xclang -load -Xclang ./evil.so",
+    )
 
 def test_merge_compile_config_noop_without_path() -> None:
     from abicheck.cli_scan import _merge_compile_config
@@ -249,7 +269,8 @@ def test_merge_compile_config_autodiscovers_from_sources(tmp_path: Path) -> None
     from abicheck.cli_scan import _merge_compile_config
 
     merged, includes = _merge_compile_config(CompileContext(), (), None, sources=src)
-    assert merged.gcc_options == "-std=c++20"
+    assert merged.gcc_options is None
+    assert merged.gcc_option_tokens == ("-std=c++20",)
     assert includes == (src / "include",)
 
 
@@ -264,7 +285,8 @@ def test_merge_compile_config_explicit_config_beats_autodiscovery(
     from abicheck.cli_scan import _merge_compile_config
 
     merged, _ = _merge_compile_config(CompileContext(), (), explicit, sources=src)
-    assert merged.gcc_options == "-std=c++23"  # explicit --config wins
+    assert merged.gcc_options is None
+    assert merged.gcc_option_tokens == ("-std=c++23",)  # explicit --config wins
 
 
 def test_probe_gnu_system_includes_mocked(monkeypatch, tmp_path: Path) -> None:
@@ -574,12 +596,13 @@ def test_compare_reads_compile_block_from_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """compare folds the project .abicheck.yml compile: block into its L2 context
-    (CLI > config) — std/defines synthesize gcc_options for both sides."""
+    (CLI > config) — std/defines synthesize literal argv tokens for both sides."""
     cfg = tmp_path / ".abicheck.yml"
     cfg.write_text("compile:\n  std: c++20\n  defines: [FOO=1]\n", encoding="utf-8")
     calls = _compare_capturing_dump(monkeypatch, tmp_path, ["--config", str(cfg)])
     for c in calls:
-        assert c["gcc_options"] == "-std=c++20 -DFOO=1"
+        assert c["gcc_options"] is None
+        assert c["gcc_option_tokens"] == ("-std=c++20", "-DFOO=1")
 
 
 def test_dump_reads_compile_block_from_config(
@@ -588,7 +611,7 @@ def test_dump_reads_compile_block_from_config(
     """dump's ELF path folds the compile: block in via the same shared resolver.
 
     Patches ``perform_elf_dump`` (so the fake-ELF bytes are never parsed for real)
-    and asserts the synthesized ``-std`` reaches its ``effective_gcc_options``.
+    and asserts the synthesized ``-std`` reaches its literal gcc option tokens.
     """
     import abicheck.cli as cli_mod
 
@@ -609,7 +632,8 @@ def test_dump_reads_compile_block_from_config(
         main, ["dump", str(so), "-H", str(header), "--config", str(cfg)]
     )
     assert result.exit_code == 0, result.output
-    assert "-std=c++17" in str(captured["effective_gcc_options"])
+    assert captured["effective_gcc_options"] is None
+    assert captured["gcc_option_tokens"] == ("-std=c++17",)
 
 
 def test_compare_rejects_compile_context_for_set_inputs(tmp_path: Path) -> None:
@@ -752,7 +776,8 @@ def test_dump_pe_threads_compile_context(
     cc = captured["compile_context"]
     assert cc is not None
     assert getattr(cc, "frontend") == "clang"
-    assert getattr(cc, "gcc_options") == "-std=c++20"
+    assert getattr(cc, "gcc_options") is None
+    assert getattr(cc, "gcc_option_tokens") == ("-std=c++20",)
     assert captured["header_backend"] == "clang"
     # ...and the old "gcc-options ignored on the native path" warning is gone.
     assert "will be ignored" not in result.output


### PR DESCRIPTION
### Motivation
- Prevent compiler-argument injection where `.abicheck.yml` `compile.std` / `compile.defines` were concatenated into a single `gcc_options` string and later `shlex.split`, allowing whitespace-containing config values to become extra clang/castxml arguments (e.g. plugin-loading flags).
- Preserve the original security model where config fields are non-executable metadata and cannot produce new argv tokens unintentionally.

### Description
- Change `merge_compile_config` to synthesize `-std=…` and `-D…` entries as literal argv tokens by appending them to `gcc_option_tokens` instead of joining them into `gcc_options` and relying on whitespace splitting. (`gcc_options` remains honored when explicitly provided by the CLI.)
- Ensure the returned `CompileContext` carries the merged `gcc_option_tokens` tuple and sets `gcc_options` to `None` when config-derived tokens are used.
- Update unit tests in `tests/test_compile_context_parity.py` to assert config-derived flags appear in `gcc_option_tokens` and add a regression test that verifies whitespace/option-like config values remain a single token (preventing injection).

### Testing
- Ran the modified compile-context tests with `pytest -q tests/test_compile_context_parity.py` together with `tests/test_castxml_errors.py`, and the targeted test set passed (`passed`).
- Ran a broader `pytest -q` which aborted during collection because the environment is missing the `hypothesis` dependency, so the full upstream test matrix could not be executed here.
- Also executed localized test runs that cover the dump/compare/scan compile-context threading and they passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e1e6a8a0832badcaf26dd9ec4039)