### PR TITLE
perf(scan): clamp L5 call-graph workers by RAM; add scan-level scaling sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `ABICHECK_CALL_GRAPH_JOBS` still overrides CPU count but memory wins, mirroring
   `ABICHECK_L4_JOBS`. See `docs/development/performance.md` § "Scan-level
   scalability sweep".
+- **Seedless `--depth source` no longer pays a full-tree call-graph cost.** An
+  unseeded s5 run scoped its L4 replay to the public-API surface (headers-only,
+  ~1 TU) but ran the L5 clang call-graph pass over the *whole* compile DB, so its
+  cost scaled with the whole tree even though its reported L4 coverage stayed at a
+  fraction (seedless-vs-seeded widened to ~3.7× at 16 TUs). The unseeded
+  call-graph pass now scopes to the **same** compile units the L4 replay used, so
+  it is consistent with the L4 surface and no longer scales with the tree
+  (~2.4× faster on a synthetic n=8 tree, identical verdict). Seeded runs
+  (`--since`/`--changed-path`) and `--depth full` are unchanged.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Uniform CLI help: every option carries help text, options are grouped into
   rich-click panels, and shared flags use one canonical spelling
   (`-v/--verbose`, `-o/--output`, `-H/--header`) — all contract-tested.
+- **L5 call-graph pass no longer risks an OOM-kill on a constrained host.** The
+  unseeded `--depth source` / `--mode pr-deep` call-graph pass runs the same
+  multi-GiB `clang -ast-dump=json` per TU as the L4 replay but, unlike L4, its
+  worker count was CPU-bound only — so a small cgroup / CI container could spawn
+  N concurrent giant ASTs and be OOM-killed. The call-graph worker count now
+  shares the L4 RAM/cgroup-aware clamp (`ABICHECK_L4_JOB_MEM_GIB` budget);
+  `ABICHECK_CALL_GRAPH_JOBS` still overrides CPU count but memory wins, mirroring
+  `ABICHECK_L4_JOBS`. See `docs/development/performance.md` § "Scan-level
+  scalability sweep".
 
 ---
 

--- a/abicheck/buildsource/call_graph.py
+++ b/abicheck/buildsource/call_graph.py
@@ -487,7 +487,7 @@ def _call_graph_mem_cap() -> int | None:
         from .source_replay import _l4_mem_cap
 
         return _l4_mem_cap()
-    except Exception:  # pragma: no cover - defensive: RAM probe must never break L5
+    except Exception:  # defensive: a RAM-probe failure must never break L5 (tested)
         return None
 
 

--- a/abicheck/buildsource/call_graph.py
+++ b/abicheck/buildsource/call_graph.py
@@ -36,6 +36,7 @@ This module is split so the hard part stays testable:
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import subprocess  # noqa: S404 - call-graph extraction shells out to clang (never shell=True)
@@ -53,6 +54,8 @@ from .source_graph import CONF_HIGH, CONF_REDUCED, CONF_UNKNOWN, GraphEdge, Grap
 if TYPE_CHECKING:
     from .build_evidence import BuildEvidence, CompileUnit as BuildEvidenceCompileUnit
     from .source_graph import SourceGraphSummary
+
+_log = logging.getLogger(__name__)
 
 # ── call-edge labels (ADR-031 D4) ───────────────────────────────────────────
 CALL_KIND_DIRECT = "direct"
@@ -470,8 +473,38 @@ def _safe_clang_args_from_compile_unit(cu: BuildEvidenceCompileUnit) -> list[str
     return [*flags, "--", cu.source]
 
 
+def _call_graph_mem_cap() -> int | None:
+    """Max call-graph workers that fit in available RAM, or ``None`` when unknown.
+
+    The L5 call-graph pass shells out to the *same* heavy ``clang -ast-dump=json``
+    per TU as the L4 replay, so it shares the L4 per-worker RAM budget and
+    cgroup-aware available-memory probe (``source_replay._l4_mem_cap``). Imported
+    lazily so a failure there (non-Linux / sandbox) just skips the clamp rather
+    than breaking the call-graph pass. ``ABICHECK_L4_JOB_MEM_GIB`` tunes the
+    shared budget.
+    """
+    try:
+        from .source_replay import _l4_mem_cap
+
+        return _l4_mem_cap()
+    except Exception:  # pragma: no cover - defensive: RAM probe must never break L5
+        return None
+
+
 def _call_graph_jobs(n_units: int) -> int:
-    """Bounded worker count for the best-effort L5 clang call-graph pass."""
+    """Bounded worker count for the best-effort L5 clang call-graph pass.
+
+    Capped by *available RAM* as well as CPU, mirroring the L4 replay
+    (``source_replay._l4_jobs``): the pass runs the same multi-GiB
+    ``clang -ast-dump=json`` per TU, so N concurrent template-heavy ASTs in one
+    process can exhaust a low-memory host and get the pass OOM-killed — the exact
+    failure the L4 memory clamp was added to prevent (the UXL oneTBB/oneDNN OOM).
+    Without this, a constrained host (small cgroup / CI container) was protected
+    on the L4 pass but not on the unseeded full-DB call-graph pass that
+    ``--depth source``/``pr-deep`` runs. ``ABICHECK_CALL_GRAPH_JOBS`` overrides the
+    CPU count; ``ABICHECK_L4_JOB_MEM_GIB`` tunes the shared per-worker RAM budget.
+    The clamp is logged, never silent.
+    """
     if n_units <= 1:
         return max(0, n_units)
     cpu = os.cpu_count() or 1
@@ -482,8 +515,20 @@ def _call_graph_jobs(n_units: int) -> int:
             requested = int(raw)
         except ValueError:
             return 1
-        return max(1, min(n_units, requested, cap))
-    return max(1, min(n_units, cpu, 8))
+        jobs = max(1, min(n_units, requested, cap))
+    else:
+        jobs = max(1, min(n_units, cpu, 8))
+    mem_cap = _call_graph_mem_cap()
+    if mem_cap is not None and mem_cap < jobs:
+        _log.info(
+            "L5 call-graph workers reduced %d -> %d to fit available memory; "
+            "set ABICHECK_CALL_GRAPH_JOBS / ABICHECK_L4_JOB_MEM_GIB to override, "
+            "or seed/scope the scan (--since/--changed-path) to fewer TUs.",
+            jobs,
+            mem_cap,
+        )
+        return mem_cap
+    return jobs
 
 
 # ── live clang extraction (integration only) ────────────────────────────────

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -637,7 +637,13 @@ def collect_inline_pack(
             # Gap-1: on an unseeded headers-only replay, scope the L5 call-graph
             # pass to the *same* TU set L4 used instead of the whole compile DB.
             # (Seeded runs scope by changed_paths; full/target keep the broad pass.)
-            if replay_scope == "headers-only" and not changed_paths:
+            #
+            # Only narrow when L4 *actually* selected units. An empty set means L4
+            # could not select (no --sources tree, no compile units, or no
+            # extractor) — NOT "scope to zero" — so a build-info-only deep scan must
+            # keep the broad call-graph pass over ``merged`` rather than silently
+            # collecting zero call edges (Codex review).
+            if replay_scope == "headers-only" and not changed_paths and l4_selected_units:
                 call_graph_units = l4_selected_units
         # Fold a call graph (DECL_CALLS_DECL edges) into the L5 graph whenever L4 also
         # ran — i.e. a semantic source mode (source-*/graph-summary/graph-full), not

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -599,6 +599,7 @@ def collect_inline_pack(
         _check_build_info_source_mismatch(merged, sources, extractors)
 
         surface = None
+        call_graph_units: list[Any] | None = None
         if "L4" in layers:
             # A 'changed' scope with no PR diff would select zero TUs and embed an
             # empty L4 surface (Codex review), so fall back to a non-empty scope that
@@ -621,7 +622,7 @@ def collect_inline_pack(
             if l4_cache_dir is None:
                 env_dir = os.environ.get("ABICHECK_L4_CACHE_DIR")
                 l4_cache_dir = Path(env_dir) if env_dir else None
-            surface = _run_inline_source_abi(
+            surface, l4_selected_units = _run_inline_source_abi(
                 sources,
                 merged,
                 extractors,
@@ -633,6 +634,11 @@ def collect_inline_pack(
                 changed_paths=changed_paths,
                 public_header_roots=public_header_roots,
             )
+            # Gap-1: on an unseeded headers-only replay, scope the L5 call-graph
+            # pass to the *same* TU set L4 used instead of the whole compile DB.
+            # (Seeded runs scope by changed_paths; full/target keep the broad pass.)
+            if replay_scope == "headers-only" and not changed_paths:
+                call_graph_units = l4_selected_units
         # Fold a call graph (DECL_CALLS_DECL edges) into the L5 graph whenever L4 also
         # ran — i.e. a semantic source mode (source-*/graph-summary/graph-full), not
         # the structural-only graph-build (L3+L5, no L4). This is what makes the
@@ -648,6 +654,7 @@ def collect_inline_pack(
                 clang_bin=clang_bin,
                 extractors=extractors,
                 changed_paths=changed_paths,
+                call_graph_units=call_graph_units,
             )
             if "L5" in layers
             else None
@@ -1243,15 +1250,19 @@ def _run_inline_source_abi(
     source_abi_cache_dir: Path | None = None,
     changed_paths: tuple[str, ...] = (),
     public_header_roots: tuple[str, ...] = (),
-) -> SourceAbiSurface | None:
-    """Run L4 replay over a source tree; ``None`` when no source tree is given.
+) -> tuple[SourceAbiSurface | None, list[Any]]:
+    """Run L4 replay over a source tree; ``(None, [])`` when no source tree given.
+
+    Returns ``(surface, selected_units)`` — the L4 surface plus the exact
+    compile-unit set the replay scope selected, so the L5 call-graph pass can match
+    that scope on an unseeded run (Gap-1 fix) instead of re-parsing all TUs.
 
     Requires L3 compile units to replay against (ADR-030 D5). A missing source
     extractor (clang/castxml) yields a partial surface and a clear note rather
     than aborting — the artifact tiers stay authoritative (ADR-028 D3).
     """
     if sources is None:
-        return None
+        return None, []
     from .source_abi import SourceAbiSurface
     from .source_replay import (
         SourceAbiCache,
@@ -1274,7 +1285,7 @@ def _run_inline_source_abi(
                 ),
             )
         )
-        return None
+        return None, []
 
     impl, tool_name = _make_source_extractor(extractor, clang_bin)
     if not impl.available():
@@ -1285,7 +1296,7 @@ def _run_inline_source_abi(
                 detail=f"{tool_name} not found in PATH; source-only checks disabled",
             )
         )
-        return SourceAbiSurface()
+        return SourceAbiSurface(), []
 
     roots = sorted(set(public_header_roots_for(merged)) | set(public_header_roots))
     include_map = _include_map_for_replay(
@@ -1294,6 +1305,19 @@ def _run_inline_source_abi(
         roots=tuple(roots),
         clang_bin=clang_bin,
         extractors=extractors,
+    )
+    # The exact compile-unit set this replay scope selects (pure, reuses the
+    # already-computed include graph — no extra clang pass). Returned so the L5
+    # call-graph pass can match the L4 scope for an unseeded run (Gap-1 fix) rather
+    # than re-parsing the whole compile DB.
+    from .source_replay import select_compile_units
+
+    selected_units = select_compile_units(
+        merged,
+        scope=scope,
+        changed_paths=changed_paths,
+        include_map=include_map,
+        public_header_roots=roots,
     )
     # D8 per-TU cache: re-extracting every TU on every `dump --sources` is the
     # cold-start cost (eval E4: zstd 48.6 s cold → 3.4 s warm). Wire the cache
@@ -1344,7 +1368,7 @@ def _run_inline_source_abi(
             ),
         )
     )
-    return surface
+    return surface, selected_units
 
 
 def _include_map_for_replay(
@@ -1404,6 +1428,7 @@ def _build_inline_graph(
     clang_bin: str = "clang",
     extractors: list[ExtractorRecord] | None = None,
     changed_paths: tuple[str, ...] = (),
+    call_graph_units: list[Any] | None = None,
 ) -> SourceGraphSummary | None:
     """Fold L3 + optional L4 into the compact L5 source graph (always when L3).
 
@@ -1424,7 +1449,14 @@ def _build_inline_graph(
 
     graph = build_source_graph(merged, source_abi=surface)
     if with_call_graph:
-        _fold_call_graph(graph, merged, clang_bin, extractors, changed_paths)
+        _fold_call_graph(
+            graph,
+            merged,
+            clang_bin,
+            extractors,
+            changed_paths,
+            scoped_units=call_graph_units,
+        )
     graph.finalize()
     return graph
 
@@ -1467,6 +1499,7 @@ def _fold_call_graph(
     clang_bin: str,
     extractors: list[ExtractorRecord] | None,
     changed_paths: tuple[str, ...] = (),
+    scoped_units: list[Any] | None = None,
 ) -> None:
     """Best-effort Clang call-graph augmentation of *graph* (ADR-031 D4).
 
@@ -1475,10 +1508,21 @@ def _fold_call_graph(
     leaves the graph without call edges — it never raises (ADR-028 D3 authority
     rule: source evidence never aborts collection).
 
-    When *changed_paths* is supplied (a PR/``--since`` scan), the call-graph pass
-    is scoped to the changed compile units only — parsing every TU of a large
-    compile DB would defeat the targeted PR cost model (ADR-035 D7 / Codex review).
-    An empty set keeps the broad pass (the unseeded / full-scope contract).
+    Scope selection, in precedence order:
+
+    - *changed_paths* (a PR/``--since`` scan) → the changed compile units only —
+      parsing every TU of a large compile DB would defeat the targeted PR cost
+      model (ADR-035 D7 / Codex review). A changed *header* still fans out to all
+      TUs (we cannot tell which it affects without an include graph).
+    - *scoped_units* (an **unseeded** run) → the exact compile-unit set the L4
+      replay used (``headers-only``). Without this the unseeded call-graph pass
+      re-parsed the *whole* compile DB even though L4 was scoped to one TU — the
+      Gap-1 asymmetry (``validation/scan-level-scalability-2026-06.md``): the pass
+      scaled with the whole tree while its reported L4 coverage stayed at a
+      fraction. Aligning the two makes the L5 call-graph consistent with the L4
+      surface (no phantom edges from TUs L4 never examined) and removes the
+      seedless ``--depth source`` cost blow-up.
+    - neither → the broad pass over all TUs (the ``full``/``s6`` contract).
     """
     from dataclasses import replace
 
@@ -1515,6 +1559,11 @@ def _fold_call_graph(
         scoped_note = " (changed-scoped)"
     elif changed_paths:
         scoped_note = " (header change → all TUs)"
+    elif scoped_units is not None:
+        # Unseeded: match the L4 replay's scope (headers-only) instead of fanning
+        # out to the whole compile DB (Gap-1 fix).
+        target = replace(merged, compile_units=list(scoped_units))
+        scoped_note = " (headers-only scope, matching L4)"
     edges = extractor.extract_from_build(target)
     # The project's own compile-unit sources — used to mark call-graph decls
     # ``defined_in_project`` from source-location provenance, so the cross-checks

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -1251,9 +1251,10 @@ def run_scan_core(
     # (CodeRabbit review).
     if not seeded and collect_mode == "source-changed" and sources is not None:
         advisories.append(
-            "no --since/--changed-path seed; the source replay covers the "
-            "public-API surface (headers-only) instead of a focused diff. Pass "
-            "--since <ref> or --changed-path to scope it to the change."
+            "no --since/--changed-path seed; the L4 replay and the L5 call-graph "
+            "pass both cover the public-API surface (headers-only) instead of a "
+            "focused diff — cost grows with the project, not the change. Pass "
+            "--since <ref> or --changed-path to scope both to the changed TUs."
         )
     # level-implies-query (ADR-037 D4): an explicit, *trusted* --config that
     # defines a build.query, together with an *explicitly pinned* deep level

--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -301,6 +301,44 @@ L0/L1 binary diff sets the gate; L3–L5 add coverage/localization, not a differ
 pass/fail. **For a CI gate, the cheap tier suffices; spend on L4 only when you
 want source-body semantics or PR localization for humans.**
 
+### Scan-level scalability sweep
+
+The UXL run above fixed the corpus (two real libs) and varied the level. The
+complementary question — how each level scales as a project's *complexity*
+grows — is swept by [`eval/scan_level_scaling.py`](https://github.com/abicheck/abicheck/blob/main/eval/scan_level_scaling.py),
+a self-contained harness (no network/repo) that synthesises STL/template-heavy
+C++ trees of increasing TU count, builds them with the host compiler, and runs
+`scan` at each level against a slightly-changed baseline — recording wall time
+and **peak child RSS** (`os.wait4`) per (size, level). Raw findings:
+[`validation/scan-level-scalability-2026-06.md`](https://github.com/abicheck/abicheck/blob/main/validation/scan-level-scalability-2026-06.md).
+
+Two results:
+
+- **The cheap tier is flat in TU count.** `binary`/`headers`/`build`/`graph`
+  (s4) cost the same at 4, 8, and 16 TUs (tail exponent ≈0) — they are priced on
+  the binary dump + L2 header AST + L3 compile-DB parse, none of which grow with
+  the number of `.cpp` files. `full` (s6) is **linear** in TU count (every TU is
+  replayed). Both as expected.
+- **Seedless `--depth source` (s5) hides a full-tree cost.** It costs ~2× the
+  wall time and ~2.5× the RSS of the *seeded* run for the **identical** L4
+  coverage (both report `L4=1/1`), and the gap *widens* with TU count. The seed
+  scopes both the L4 replay **and** the L5 clang call-graph pass to the changed
+  TU; without a seed the L4 replay falls back to headers-only (one TU) but the
+  **call-graph pass still runs over the whole compile DB** — a second
+  `clang -ast-dump=json` over every TU, whose cost the `L4=1/1` coverage line
+  never shows. So a seedless s5's call-graph half scales with the whole tree even
+  though its reported L4 coverage stays at one TU.
+
+That whole-DB call-graph pass shells out to the same multi-GiB
+`clang -ast-dump=json` as the L4 replay, but its worker count
+(`call_graph._call_graph_jobs`) was **CPU-bound only** — it lacked the
+RAM-aware, cgroup-aware clamp the L4 replay grew (`_l4_jobs` → `_l4_mem_cap`)
+after the UXL oneTBB/oneDNN OOM. On a constrained host the L4 pass was protected
+but the unseeded call-graph pass was not. `_call_graph_jobs` now shares the L4
+memory cap (`_call_graph_mem_cap` → `_l4_mem_cap`, same `ABICHECK_L4_JOB_MEM_GIB`
+budget); `ABICHECK_CALL_GRAPH_JOBS` still overrides the CPU count but memory wins
+over an over-eager override, exactly like `_l4_jobs`.
+
 ## L4 source-replay (dump-side) performance
 
 The scaling harness above is pure-Python and times the *compare* pipeline. The

--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -319,15 +319,17 @@ Two results:
   the binary dump + L2 header AST + L3 compile-DB parse, none of which grow with
   the number of `.cpp` files. `full` (s6) is **linear** in TU count (every TU is
   replayed). Both as expected.
-- **Seedless `--depth source` (s5) hides a full-tree cost.** It costs ~2× the
-  wall time and ~2.5× the RSS of the *seeded* run for the **identical** L4
-  coverage (both report `L4=1/1`), and the gap *widens* with TU count. The seed
-  scopes both the L4 replay **and** the L5 clang call-graph pass to the changed
-  TU; without a seed the L4 replay falls back to headers-only (one TU) but the
-  **call-graph pass still runs over the whole compile DB** — a second
-  `clang -ast-dump=json` over every TU, whose cost the `L4=1/1` coverage line
-  never shows. So a seedless s5's call-graph half scales with the whole tree even
-  though its reported L4 coverage stays at one TU.
+- **Seedless `--depth source` (s5) used to hide a full-tree cost — now fixed.**
+  It cost ~2× the wall time and ~2.5× the RSS of the *seeded* run for the
+  **identical** L4 coverage (both report `L4=1/1`), and the gap *widened* with TU
+  count. The seed scopes both the L4 replay **and** the L5 clang call-graph pass
+  to the changed TU; without a seed the L4 replay fell back to headers-only (one
+  TU) but the **call-graph pass ran over the whole compile DB** — a second
+  `clang -ast-dump=json` over every TU. The unseeded call-graph pass now scopes to
+  the **same** compile units the L4 replay used (headers-only), so it is
+  consistent with the L4 surface and no longer scales with the tree
+  (~2.4× faster on a synthetic n=8 tree, identical verdict). Seeded runs and
+  `--depth full` are unchanged.
 
 That whole-DB call-graph pass shells out to the same multi-GiB
 `clang -ast-dump=json` as the L4 replay, but its worker count

--- a/eval/CLAUDE.md
+++ b/eval/CLAUDE.md
@@ -12,7 +12,8 @@ exercised by `.github/workflows/eval-suite.yml`. Don't move this tree under
 | `manifest.yaml` | **Source of truth** — curated libraries, version pairs, expected verdicts, `.so` stems, optional source repo/tags. Edit here; everything else is generated. |
 | `runner.py` | Fetch → `abicheck dump`/`compare` → schema'd `results/` + generated `REPORT.md`. Flags any library whose verdict drifts from its manifest `expect`, so it doubles as a real-world regression guard. |
 | `condafetch.py` | conda-forge fetch/extract helper (no `conda` needed). |
-| `scaling.py` | Scaling sweep behind `SCALING.md`. |
+| `scaling.py` | `ABICHECK_L4_JOBS` parallel-L4 scaling sweep on one real tree, behind `SCALING.md`. |
+| `scan_level_scaling.py` | Scan-*level* scalability sweep (`--depth binary…full`) over a **self-contained synthetic** corpus of tunable complexity (TU count / template depth). No network/repo; gated on a C++ compiler + `clang++`. Records wall + peak child RSS per (size, level); surfaces where a level goes super-linear (see `docs/development/performance.md` § "Scan-level scalability sweep"). |
 | `results/latest.json` | Latest schema'd results (`result_schema` 1) — committed. |
 | `REPORT.md`, `SCALING.md` | **Generated — do not hand-edit.** Rebuild via `runner.py --report-only`. |
 | `FINDINGS.md`, `FOLLOWUPS.md` | Human narrative: qualitative problem log (P01–P21) + follow-up plan. Hand-edited. |

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -34,11 +34,12 @@ goes super-linear or where a *cheaper-looking* level secretly pays a full-tree
 cost (e.g. seedless ``--depth source`` runs the L5 call-graph pass over the whole
 compile DB even though its L4 replay is scoped to one TU).
 
-Gated on a C++ compiler + ``clang++`` (the L4/L5 source replay backend). Without
-a C++ compiler nothing runs (the sweep exits early — it cannot build the corpus);
-without ``clang++`` only, just the compiler-only tiers (``binary``/``build``) run
-and the clang-backed tiers are skipped. Manual (not in CI): a full template-heavy
-sweep is minutes of clang time.
+Gated on a C++ compiler + ``clang++`` (the L4/L5 source replay backend, and the
+L2 header AST). Without a C++ compiler nothing runs (the sweep exits early — it
+cannot build the corpus); without ``clang++`` only the ``binary`` tier runs
+(``--depth binary`` suppresses the L2 header AST), and every clang-backed tier is
+skipped. Manual (not in CI): a full template-heavy sweep is minutes of clang
+time.
 
 Reproduce::
 
@@ -265,11 +266,16 @@ def _maxrss_to_mb(maxrss: int) -> float:
 #: visible side by side.
 LEVELS = ("binary", "headers", "build", "graph", "source_seeded", "source", "full")
 
-#: Levels that need the clang source-replay backend (skip when clang++ absent).
-_NEEDS_CLANG = {"headers", "graph", "source_seeded", "source", "full"}
+#: Levels that need ``clang++`` (skipped when it is absent). Only ``binary`` is
+#: clang-free: ``--depth binary`` suppresses the L2 header AST, so it runs on the
+#: C++ compiler alone. Every other tier — including ``build``, since the harness
+#: always passes ``-H``/``--ast-frontend clang`` and the cumulative depth ladder
+#: puts L2 below L3 — parses headers with clang and fails without it.
+_NEEDS_CLANG = {"headers", "build", "graph", "source_seeded", "source", "full"}
 
 
 def _level_args(level: str, seed: str) -> list[str]:
+    """Map a sweep *level* name to the ``abicheck scan`` flags that select it."""
     return {
         "binary": ["--depth", "binary"],
         "headers": ["--depth", "headers"],
@@ -283,6 +289,8 @@ def _level_args(level: str, seed: str) -> list[str]:
 
 @dataclass
 class Point:
+    """One (size, level) measurement: timing, peak RSS, exit, verdict, L4 counts."""
+
     level: str
     n_tus: int
     depth: int
@@ -375,6 +383,7 @@ def run_sweep(
     have_clang: bool,
     workdir: Path,
 ) -> list[Point]:
+    """Build each size's old/new trees once, then run every *level* over them."""
     points: list[Point] = []
     for n in sizes:
         old = workdir / f"old_n{n}_f{funcs_per_tu}_d{depth}"
@@ -437,6 +446,7 @@ def render_table(points: list[Point]) -> str:
 
 
 def main() -> int:
+    """CLI entry: parse args, run the sweep, print the table, optionally dump JSON."""
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -461,7 +471,7 @@ def main() -> int:
     have_clang = shutil.which("clang++") is not None
     if not have_clang:
         print(
-            "warning: clang++ not found — only binary/build tiers will run",
+            "warning: clang++ not found — only the binary tier will run",
             file=sys.stderr,
         )
 

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -52,6 +52,7 @@ Reproduce::
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -341,13 +342,17 @@ def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
         "text",
         *_level_args(level, seed),
     ]
-    # ``jobs <= 0`` means "leave ABICHECK_L4_JOBS unset" so the sweep measures
-    # abicheck's normal auto scheduling (min(TUs, cpu, 8) + the RAM clamp). Forcing
-    # an explicit count would, on a >8-CPU host, run more L4 workers than the
-    # production auto path and skew/OOM the curves.
+    # ``jobs <= 0`` means "auto": the sweep must measure abicheck's normal auto
+    # scheduling (min(TUs, cpu, 8) + the RAM clamp). Forcing an explicit count
+    # would, on a >8-CPU host, run more L4 workers than the production auto path
+    # and skew/OOM the curves. Crucially, *clear* any ABICHECK_L4_JOBS the caller
+    # already exported — otherwise the inherited override leaks into the child and
+    # silently defeats auto mode despite the --jobs help promising it.
     env = dict(os.environ)
     if jobs > 0:
         env["ABICHECK_L4_JOBS"] = str(jobs)
+    else:
+        env.pop("ABICHECK_L4_JOBS", None)
     t0 = time.monotonic()
     proc = subprocess.Popen(
         argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env, text=True
@@ -384,6 +389,17 @@ def _tail_exponent(sizes: list[int], values: list[float]) -> float | None:
 
 
 # ── driver ──────────────────────────────────────────────────────────────────
+def _cxx_tag(cxx: str) -> str:
+    """Stable, filesystem-safe cache tag for a compiler.
+
+    A readable basename plus a short digest of the *full* ``--cxx`` string, so two
+    different compilers that share a basename (``/usr/bin/g++`` vs ``/opt/g++``)
+    never collide on the same cached tree.
+    """
+    base = re.sub(r"[^A-Za-z0-9]+", "", Path(cxx).name) or "cxx"
+    return f"{base}-{hashlib.sha1(cxx.encode()).hexdigest()[:8]}"
+
+
 def run_sweep(
     *,
     sizes: list[int],
@@ -397,9 +413,14 @@ def run_sweep(
 ) -> list[Point]:
     """Build each size's old/new trees once, then run every *level* over them."""
     points: list[Point] = []
+    # Encode the compiler in the cache key: the ``libsynth.so`` existence check
+    # below short-circuits regen+rebuild, so reusing a --workdir after a --cxx
+    # change would otherwise silently reuse a tree (and compile_commands.json)
+    # built by the *old* compiler, corrupting any toolchain comparison.
+    ctag = _cxx_tag(cxx)
     for n in sizes:
-        old = workdir / f"old_n{n}_f{funcs_per_tu}_d{depth}"
-        new = workdir / f"new_n{n}_f{funcs_per_tu}_d{depth}"
+        old = workdir / f"old_{ctag}_n{n}_f{funcs_per_tu}_d{depth}"
+        new = workdir / f"new_{ctag}_n{n}_f{funcs_per_tu}_d{depth}"
         for root, variant in ((old, "old"), (new, "new")):
             if not (root / "libsynth.so").exists():
                 _gen_sources(

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -336,6 +336,14 @@ def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
         str(new_root),
         "--baseline",
         str(base_so),
+        # The old/new trees have *different* public headers (the new side adds a
+        # method + free fn and changes some return types), so the native baseline
+        # must be parsed with the *old* headers — otherwise scan reads the old .so
+        # through the new headers and can mask/misattribute the very diff the sweep
+        # generates (the CLI even warns about this). Ignored for --depth binary /
+        # snapshot baselines.
+        "--baseline-header",
+        str(base_so.parent / "include"),
         "--ast-frontend",
         "clang",
         "--format",

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -275,7 +275,13 @@ class Point:
 
 def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
     seed = "src/tu0.cpp"
+    # Invoke the in-tree CLI via ``-m abicheck`` (not the ``abicheck`` console
+    # script): the documented entry point is ``python eval/scan_level_scaling.py``
+    # from a checkout, which is importable even without an editable install — so
+    # the sweep must not depend on the console script being on PATH.
     argv = [
+        sys.executable,
+        "-m",
         "abicheck",
         "scan",
         "--binary",
@@ -292,7 +298,13 @@ def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
         "text",
         *_level_args(level, seed),
     ]
-    env = dict(os.environ, ABICHECK_L4_JOBS=str(jobs))
+    # ``jobs <= 0`` means "leave ABICHECK_L4_JOBS unset" so the sweep measures
+    # abicheck's normal auto scheduling (min(TUs, cpu, 8) + the RAM clamp). Forcing
+    # an explicit count would, on a >8-CPU host, run more L4 workers than the
+    # production auto path and skew/OOM the curves.
+    env = dict(os.environ)
+    if jobs > 0:
+        env["ABICHECK_L4_JOBS"] = str(jobs)
     t0 = time.monotonic()
     proc = subprocess.Popen(
         argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env, text=True
@@ -432,7 +444,9 @@ def main() -> int:
 
     sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
     levels = [lv for lv in args.levels.split(",") if lv.strip()]
-    jobs = args.jobs or (os.cpu_count() or 4)
+    # Pass --jobs through verbatim: 0 (the default) keeps ABICHECK_L4_JOBS unset so
+    # the sweep measures abicheck's own auto scheduling rather than an override.
+    jobs = args.jobs
     workdir = (
         Path(args.workdir)
         if args.workdir

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -1,0 +1,463 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scan-*level* scalability sweep over a self-contained synthetic corpus.
+
+``eval/scaling.py`` times one knob (``ABICHECK_L4_JOBS``) on *one* real tree.
+This harness sweeps the **other** axis the field eval never automated: how each
+``scan`` *level* (``--depth binary|headers|build|source|full`` plus the
+``--source-method s4`` graph rung) scales as a project's **complexity** grows —
+TU count, per-TU symbol count, and C++ template/STL instantiation depth (the
+documented L4 cliff driver, see ``docs/development/performance.md`` §"Scan level
+cost model"). Unlike ``scaling.py`` it needs **no network and no real repo**: it
+synthesises C++ trees of tunable size, builds them with the host C++ compiler
+into a ``.so`` + ``compile_commands.json`` (the JSON-compilation-database shape a
+real CMake/Bazel build emits), and runs ``abicheck scan`` at each level against a
+slightly-changed baseline.
+
+For every (size, level) it records wall time, **peak child RSS** (via
+``os.wait4`` — the true per-call high-water mark, including clang's native
+memory), the L4 coverage line (``parsed/total`` TUs), and the verdict. The
+output is the per-level scaling curve + a tail exponent, surfacing where a level
+goes super-linear or where a *cheaper-looking* level secretly pays a full-tree
+cost (e.g. seedless ``--depth source`` runs the L5 call-graph pass over the whole
+compile DB even though its L4 replay is scoped to one TU).
+
+Gated on a C++ compiler + ``clang++`` (the L4/L5 source replay backend). With
+neither, only the binary/headers tiers run. Manual (not in CI): a full
+template-heavy sweep is minutes of clang time.
+
+Reproduce::
+
+    python eval/scan_level_scaling.py                       # default sweep
+    python eval/scan_level_scaling.py --sizes 4,8,16 --depth 6
+    python eval/scan_level_scaling.py --levels binary,build,source,full
+    python eval/scan_level_scaling.py --json-out reports/perf/scan_levels.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# ── synthetic corpus generator ──────────────────────────────────────────────
+# A public header declaring an STL/template-heavy API + N translation units that
+# define it. The "old" and "new" variants differ by a handful of additions plus a
+# few return-type changes (source-level breaks) so the baseline compare is
+# non-trivial. Template depth and STL use are what make clang's per-TU JSON AST
+# large — i.e. what the L4 cliff is priced on.
+
+_API_HPP = r"""
+#pragma once
+#include <vector>
+#include <map>
+#include <string>
+#include <memory>
+#include <functional>
+
+namespace api {{
+
+template <int N> struct Recur {{
+    using next = Recur<N - 1>;
+    typedef std::shared_ptr<typename next::value_t> value_t;
+    std::map<std::string, std::vector<typename next::value_t>> table;
+    long compute() const {{ return N + next().compute(); }}
+}};
+template <> struct Recur<0> {{
+    using value_t = long;
+    long compute() const {{ return 0; }}
+}};
+
+class Widget {{
+public:
+    explicit Widget(int seed);
+    ~Widget();
+    long process(const std::vector<std::string>& in) const;
+    std::map<std::string, long> histogram() const;
+{extra_methods}
+private:
+    std::unique_ptr<std::vector<long>> data_;
+    int seed_;
+}};
+
+{free_decls}
+
+}} // namespace api
+"""
+
+_TU_CPP = """
+#include "api.hpp"
+namespace api {{
+{tu_funcs}
+}} // namespace api
+"""
+
+_WIDGET_CPP = r"""
+#include "api.hpp"
+namespace api {{
+Widget::Widget(int seed) : data_(new std::vector<long>()), seed_(seed) {{ data_->push_back(seed); }}
+Widget::~Widget() {{}}
+long Widget::process(const std::vector<std::string>& in) const {{
+    long acc = seed_;
+    for (auto& s : in) acc += s.size();
+    Recur<8> r; acc += r.compute();
+    return acc;
+}}
+std::map<std::string, long> Widget::histogram() const {{
+    std::map<std::string, long> h;
+    for (auto v : *data_) h[std::to_string(v)]++;
+    return h;
+}}
+{extra_defs}
+}} // namespace api
+"""
+
+
+def _gen_sources(
+    root: Path, *, n_tus: int, funcs_per_tu: int, depth: int, variant: str
+) -> None:
+    """Write the header + per-TU sources for one (size, variant) tree."""
+    root = root.resolve()
+    inc = root / "include"
+    src = root / "src"
+    (root / "build").mkdir(parents=True, exist_ok=True)
+    inc.mkdir(parents=True, exist_ok=True)
+    src.mkdir(parents=True, exist_ok=True)
+
+    free_decls: list[str] = []
+    extra_methods: list[str] = []
+    extra_defs: list[str] = []
+    if variant == "new":
+        extra_methods.append("    long added_method(int x) const;")
+        extra_defs.append(
+            "long Widget::added_method(int x) const { return x + seed_; }"
+        )
+        free_decls.append("int extra_free_fn(int a);")
+
+    total_funcs = n_tus * funcs_per_tu
+    for k in range(total_funcs):
+        rt = "int" if (variant == "new" and k % 50 == 0) else "long"
+        free_decls.append(f"{rt} free_fn_{k}(const std::vector<long>& v);")
+
+    (inc / "api.hpp").write_text(
+        _API_HPP.format(
+            extra_methods="\n".join(extra_methods),
+            free_decls="\n".join(free_decls),
+        )
+    )
+    (src / "widget.cpp").write_text(
+        _WIDGET_CPP.format(extra_defs="\n".join(extra_defs))
+    )
+
+    fidx = 0
+    for t in range(n_tus):
+        funcs = []
+        for j in range(funcs_per_tu):
+            k = fidx
+            fidx += 1
+            rt = "int" if (variant == "new" and k % 50 == 0) else "long"
+            funcs.append(
+                textwrap.dedent(f"""
+                {rt} free_fn_{k}(const std::vector<long>& v) {{
+                    Recur<{depth}> r;
+                    long acc = r.compute();
+                    std::map<std::string, long> m;
+                    for (auto x : v) {{ m[std::to_string(x % {j + 1})] += x; acc += x; }}
+                    std::vector<std::string> keys;
+                    for (auto& kv : m) keys.push_back(kv.first);
+                    return static_cast<{rt}>(acc + keys.size());
+                }}""")
+            )
+        (src / f"tu{t}.cpp").write_text(_TU_CPP.format(tu_funcs="\n".join(funcs)))
+
+
+def _build(root: Path, *, n_tus: int, cxx: str) -> Path:
+    """Compile the tree into ``libsynth.so`` + an absolute-path compile DB."""
+    root = root.resolve()
+    inc, src, bld = root / "include", root / "src", root / "build"
+    cpps = [src / "widget.cpp"] + [src / f"tu{t}.cpp" for t in range(n_tus)]
+    cdb, objs = [], []
+    for cpp in cpps:
+        obj = bld / (cpp.stem + ".o")
+        argv = [
+            cxx,
+            "-std=c++17",
+            "-g",
+            "-O0",
+            "-fPIC",
+            f"-I{inc}",
+            "-c",
+            str(cpp),
+            "-o",
+            str(obj),
+        ]
+        cdb.append({"directory": str(root), "arguments": argv, "file": str(cpp)})
+        objs.append(obj)
+    (root / "compile_commands.json").write_text(json.dumps(cdb, indent=1))
+    for entry in cdb:
+        proc = subprocess.run(entry["arguments"], capture_output=True, text=True)
+        if proc.returncode != 0:
+            sys.stderr.write(proc.stderr[:4000])
+            raise SystemExit(f"compile failed: {entry['file']}")
+    so = root / "libsynth.so"
+    link = subprocess.run(
+        [cxx, "-shared", "-o", str(so), *[str(o) for o in objs]],
+        capture_output=True,
+        text=True,
+    )
+    if link.returncode != 0:
+        sys.stderr.write(link.stderr[:4000])
+        raise SystemExit("link failed")
+    return so
+
+
+# ── measurement ─────────────────────────────────────────────────────────────
+_L4_RE = re.compile(r"(\d+)/(\d+) TUs parsed.*?([\d.]+)s")
+_VERDICT_RE = re.compile(r"Verdict:\s*(\w+)")
+
+#: The user-facing levels, in cost order. ``source`` (seedless s5) and
+#: ``source_seeded`` (s5 + a one-file ``--changed-path``) are split so the
+#: seed's effect — and the unscoped call-graph cost of the seedless run — is
+#: visible side by side.
+LEVELS = ("binary", "headers", "build", "graph", "source_seeded", "source", "full")
+
+#: Levels that need the clang source-replay backend (skip when clang++ absent).
+_NEEDS_CLANG = {"headers", "graph", "source_seeded", "source", "full"}
+
+
+def _level_args(level: str, seed: str) -> list[str]:
+    return {
+        "binary": ["--depth", "binary"],
+        "headers": ["--depth", "headers"],
+        "build": ["--depth", "build"],
+        "graph": ["--source-method", "s4"],
+        "source": ["--depth", "source"],
+        "source_seeded": ["--depth", "source", "--changed-path", seed],
+        "full": ["--depth", "full"],
+    }[level]
+
+
+@dataclass
+class Point:
+    level: str
+    n_tus: int
+    depth: int
+    wall_s: float
+    rss_mb: float
+    exit: int
+    verdict: str | None
+    l4_parsed: int | None = None
+    l4_total: int | None = None
+    l4_secs: float | None = None
+
+
+def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
+    seed = "src/tu0.cpp"
+    argv = [
+        "abicheck",
+        "scan",
+        "--binary",
+        str(new_root / "libsynth.so"),
+        "-H",
+        str(new_root / "include"),
+        "--sources",
+        str(new_root),
+        "--baseline",
+        str(base_so),
+        "--ast-frontend",
+        "clang",
+        "--format",
+        "text",
+        *_level_args(level, seed),
+    ]
+    env = dict(os.environ, ABICHECK_L4_JOBS=str(jobs))
+    t0 = time.monotonic()
+    proc = subprocess.Popen(
+        argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env, text=True
+    )
+    assert proc.stdout is not None
+    out = proc.stdout.read()
+    _pid, status, ru = os.wait4(proc.pid, 0)
+    wall = time.monotonic() - t0
+    l4 = _L4_RE.search(out)
+    verdict = _VERDICT_RE.search(out)
+    return Point(
+        level=level,
+        n_tus=0,
+        depth=0,
+        wall_s=round(wall, 2),
+        rss_mb=round(ru.ru_maxrss / 1024, 1),  # KiB -> MiB (Linux)
+        exit=os.waitstatus_to_exitcode(status),
+        verdict=verdict.group(1) if verdict else None,
+        l4_parsed=int(l4.group(1)) if l4 else None,
+        l4_total=int(l4.group(2)) if l4 else None,
+        l4_secs=float(l4.group(3)) if l4 else None,
+    )
+
+
+def _tail_exponent(sizes: list[int], values: list[float]) -> float | None:
+    """Log-log slope of the largest two points — the portable scaling signal."""
+    pts = [(s, v) for s, v in zip(sizes, values) if s > 0 and v > 0]
+    if len(pts) < 2:
+        return None
+    (s0, v0), (s1, v1) = pts[-2], pts[-1]
+    if s0 == s1:
+        return None
+    return round(math.log(v1 / v0) / math.log(s1 / s0), 2)
+
+
+# ── driver ──────────────────────────────────────────────────────────────────
+def run_sweep(
+    *,
+    sizes: list[int],
+    funcs_per_tu: int,
+    depth: int,
+    levels: list[str],
+    jobs: int,
+    cxx: str,
+    have_clang: bool,
+    workdir: Path,
+) -> list[Point]:
+    points: list[Point] = []
+    for n in sizes:
+        old = workdir / f"old_n{n}_f{funcs_per_tu}_d{depth}"
+        new = workdir / f"new_n{n}_f{funcs_per_tu}_d{depth}"
+        for root, variant in ((old, "old"), (new, "new")):
+            if not (root / "libsynth.so").exists():
+                _gen_sources(
+                    root,
+                    n_tus=n,
+                    funcs_per_tu=funcs_per_tu,
+                    depth=depth,
+                    variant=variant,
+                )
+                _build(root, n_tus=n, cxx=cxx)
+        print(f"\n=== n_tus={n} funcs/tu={funcs_per_tu} depth={depth} ===", flush=True)
+        for level in levels:
+            if level in _NEEDS_CLANG and not have_clang:
+                print(f"  {level:14s} SKIP (clang++ not found)")
+                continue
+            p = _run_scan(
+                new.resolve(), (old / "libsynth.so").resolve(), level, jobs=jobs
+            )
+            p.n_tus, p.depth = n, depth
+            points.append(p)
+            l4 = (
+                f" L4={p.l4_parsed}/{p.l4_total}@{p.l4_secs}s"
+                if p.l4_parsed is not None
+                else ""
+            )
+            print(
+                f"  {level:14s} wall={p.wall_s:7.2f}s rss={p.rss_mb:8.1f}MB "
+                f"exit={p.exit} {p.verdict}{l4}",
+                flush=True,
+            )
+    return points
+
+
+def render_table(points: list[Point]) -> str:
+    """A per-level Markdown table with the wall/RSS tail exponents."""
+    sizes = sorted({p.n_tus for p in points})
+    levels = [lv for lv in LEVELS if any(p.level == lv for p in points)]
+    lines = [
+        "| level | " + " | ".join(f"n={s}" for s in sizes) + " | wall exp | rss exp |",
+        "|---|" + "---|" * (len(sizes) + 2),
+    ]
+    for lv in levels:
+        by_size = {p.n_tus: p for p in points if p.level == lv}
+        walls = [by_size[s].wall_s if s in by_size else 0.0 for s in sizes]
+        rsses = [by_size[s].rss_mb if s in by_size else 0.0 for s in sizes]
+        cells = [f"{w:.1f}s/{r:.0f}M" for w, r in zip(walls, rsses)]
+        we = _tail_exponent(sizes, walls)
+        re_ = _tail_exponent(sizes, rsses)
+        lines.append(
+            f"| {lv} | "
+            + " | ".join(cells)
+            + f" | {we if we is not None else '—'} "
+            + f"| {re_ if re_ is not None else '—'} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--sizes", default="4,8,16", help="comma-separated TU counts")
+    ap.add_argument("--funcs-per-tu", type=int, default=8)
+    ap.add_argument("--depth", type=int, default=6, help="template instantiation depth")
+    ap.add_argument("--levels", default=",".join(LEVELS))
+    ap.add_argument(
+        "--jobs", type=int, default=0, help="ABICHECK_L4_JOBS (0 = leave unset / auto)"
+    )
+    ap.add_argument("--cxx", default=os.environ.get("CXX", "g++"))
+    ap.add_argument("--workdir", default="", help="tree cache dir (default: tempdir)")
+    ap.add_argument("--json-out", default="")
+    args = ap.parse_args()
+
+    if not shutil.which(args.cxx):
+        print(
+            f"error: C++ compiler {args.cxx!r} not found (set --cxx/CXX)",
+            file=sys.stderr,
+        )
+        return 2
+    have_clang = shutil.which("clang++") is not None
+    if not have_clang:
+        print(
+            "warning: clang++ not found — only binary/build tiers will run",
+            file=sys.stderr,
+        )
+
+    sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
+    levels = [lv for lv in args.levels.split(",") if lv.strip()]
+    jobs = args.jobs or (os.cpu_count() or 4)
+    workdir = (
+        Path(args.workdir)
+        if args.workdir
+        else Path(tempfile.mkdtemp(prefix="abicheck-scan-scaling-"))
+    )
+
+    points = run_sweep(
+        sizes=sizes,
+        funcs_per_tu=args.funcs_per_tu,
+        depth=args.depth,
+        levels=levels,
+        jobs=jobs,
+        cxx=args.cxx,
+        have_clang=have_clang,
+        workdir=workdir,
+    )
+    print("\n" + render_table(points))
+    if args.json_out:
+        Path(args.json_out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.json_out).write_text(
+            json.dumps([asdict(p) for p in points], indent=2)
+        )
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -126,7 +126,7 @@ Widget::~Widget() {{}}
 long Widget::process(const std::vector<std::string>& in) const {{
     long acc = seed_;
     for (auto& s : in) acc += s.size();
-    Recur<8> r; acc += r.compute();
+    Recur<{depth}> r; acc += r.compute();
     return acc;
 }}
 std::map<std::string, long> Widget::histogram() const {{
@@ -172,7 +172,7 @@ def _gen_sources(
         )
     )
     (src / "widget.cpp").write_text(
-        _WIDGET_CPP.format(extra_defs="\n".join(extra_defs))
+        _WIDGET_CPP.format(depth=depth, extra_defs="\n".join(extra_defs))
     )
 
     fidx = 0

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -34,9 +34,11 @@ goes super-linear or where a *cheaper-looking* level secretly pays a full-tree
 cost (e.g. seedless ``--depth source`` runs the L5 call-graph pass over the whole
 compile DB even though its L4 replay is scoped to one TU).
 
-Gated on a C++ compiler + ``clang++`` (the L4/L5 source replay backend). With
-neither, only the binary/headers tiers run. Manual (not in CI): a full
-template-heavy sweep is minutes of clang time.
+Gated on a C++ compiler + ``clang++`` (the L4/L5 source replay backend). Without
+a C++ compiler nothing runs (the sweep exits early — it cannot build the corpus);
+without ``clang++`` only, just the compiler-only tiers (``binary``/``build``) run
+and the clang-backed tiers are skipped. Manual (not in CI): a full template-heavy
+sweep is minutes of clang time.
 
 Reproduce::
 
@@ -234,8 +236,28 @@ def _build(root: Path, *, n_tus: int, cxx: str) -> Path:
 
 
 # ── measurement ─────────────────────────────────────────────────────────────
+# We parse the human ``--format text`` report rather than ``--format json``: the
+# verdict is a structured JSON field, but the per-level L4 coverage counts
+# (``N/M TUs parsed`` + elapsed) live only inside the rendered coverage-row detail
+# string — there is no structured JSON field for them — and exposing them as one
+# would mean changing the shipped ``ScanOutcome`` surface for a manual eval
+# harness. The regexes are intentionally loose so a small text-layout change does
+# not break the sweep (a missing match just leaves the field ``None``).
 _L4_RE = re.compile(r"(\d+)/(\d+) TUs parsed.*?([\d.]+)s")
 _VERDICT_RE = re.compile(r"Verdict:\s*(\w+)")
+
+
+def _maxrss_to_mb(maxrss: int) -> float:
+    """``getrusage`` ``ru_maxrss`` → MiB, normalised per platform.
+
+    ``ru_maxrss`` is KiB on Linux but **bytes** on macOS/BSD, so a fixed ``/1024``
+    would be off by ~1024× off-Linux; divide by the right unit so the sweep stays
+    comparable across POSIX hosts.
+    """
+    if sys.platform == "darwin" or "bsd" in sys.platform:
+        return round(maxrss / (1024 * 1024), 1)  # bytes -> MiB
+    return round(maxrss / 1024, 1)  # KiB -> MiB (Linux)
+
 
 #: The user-facing levels, in cost order. ``source`` (seedless s5) and
 #: ``source_seeded`` (s5 + a one-file ``--changed-path``) are split so the
@@ -274,6 +296,7 @@ class Point:
 
 
 def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
+    """Run one ``abicheck scan`` at *level*; time it + capture peak child RSS."""
     seed = "src/tu0.cpp"
     # Invoke the in-tree CLI via ``-m abicheck`` (not the ``abicheck`` console
     # script): the documented entry point is ``python eval/scan_level_scaling.py``
@@ -320,7 +343,7 @@ def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
         n_tus=0,
         depth=0,
         wall_s=round(wall, 2),
-        rss_mb=round(ru.ru_maxrss / 1024, 1),  # KiB -> MiB (Linux)
+        rss_mb=_maxrss_to_mb(ru.ru_maxrss),
         exit=os.waitstatus_to_exitcode(status),
         verdict=verdict.group(1) if verdict else None,
         l4_parsed=int(l4.group(1)) if l4 else None,
@@ -452,6 +475,10 @@ def main() -> int:
         if args.workdir
         else Path(tempfile.mkdtemp(prefix="abicheck-scan-scaling-"))
     )
+    # Surface the (possibly auto-created temp) workdir so repeated manual runs can
+    # find and reclaim the synthetic trees + .so files instead of silently
+    # accumulating them under the system temp dir.
+    print(f"workdir: {workdir}", file=sys.stderr)
 
     points = run_sweep(
         sizes=sizes,

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -254,6 +254,18 @@ def _maxrss_to_mb(maxrss: int) -> float:
     ``ru_maxrss`` is KiB on Linux but **bytes** on macOS/BSD, so a fixed ``/1024``
     would be off by ~1024× off-Linux; divide by the right unit so the sweep stays
     comparable across POSIX hosts.
+
+    **Scope.** ``wait4`` reports the peak RSS of the *direct* child (the
+    ``python -m abicheck`` process), not the summed high-water mark of the whole
+    process tree. Under the harness's default L4 executor (**threads**) the
+    dominant consumer — the multi-GiB in-process JSON-AST parse — runs *inside*
+    that child across thread-pool threads, so it is captured; the separate
+    ``clang -ast-dump=json`` subprocesses stream their output to a temp file
+    (bounded RSS) and are not summed, and the opt-in ``ABICHECK_L4_EXECUTOR=process``
+    grandchildren would not be captured at all. So this column tracks the dominant
+    in-process driver (which is what the memory clamp governs) but is a **lower
+    bound** on absolute host peak — for the true host high-water mark use a
+    cgroup ``memory.peak`` / process-tree monitor.
     """
     if sys.platform == "darwin" or "bsd" in sys.platform:
         return round(maxrss / (1024 * 1024), 1)  # bytes -> MiB

--- a/eval/scan_level_scaling.py
+++ b/eval/scan_level_scaling.py
@@ -353,14 +353,17 @@ def _run_scan(new_root: Path, base_so: Path, level: str, *, jobs: int) -> Point:
     # ``jobs <= 0`` means "auto": the sweep must measure abicheck's normal auto
     # scheduling (min(TUs, cpu, 8) + the RAM clamp). Forcing an explicit count
     # would, on a >8-CPU host, run more L4 workers than the production auto path
-    # and skew/OOM the curves. Crucially, *clear* any ABICHECK_L4_JOBS the caller
-    # already exported — otherwise the inherited override leaks into the child and
-    # silently defeats auto mode despite the --jobs help promising it.
+    # and skew/OOM the curves. Crucially, *clear* any ABICHECK_L4_JOBS **and**
+    # ABICHECK_CALL_GRAPH_JOBS the caller already exported — otherwise an inherited
+    # override on either the L4 replay or the L5 call-graph pass leaks into the
+    # child and silently defeats auto mode (both feed the scaling/RSS curves this
+    # harness validates), despite the --jobs help promising auto scheduling.
     env = dict(os.environ)
     if jobs > 0:
         env["ABICHECK_L4_JOBS"] = str(jobs)
     else:
         env.pop("ABICHECK_L4_JOBS", None)
+        env.pop("ABICHECK_CALL_GRAPH_JOBS", None)
     t0 = time.monotonic()
     proc = subprocess.Popen(
         argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env, text=True

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1785,7 +1785,7 @@ def test_inline_source_changed_falls_back_to_headers_only_scope(tmp_path, monkey
              exported_symbols=(), source_abi_cache_dir=None, changed_paths=(),
              public_header_roots=()):
         captured["scope"] = scope
-        return None
+        return None, []
 
     monkeypatch.setattr(inline, "_run_inline_source_abi", _spy)
     tree = tmp_path / "src"

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1799,6 +1799,80 @@ def test_inline_source_changed_falls_back_to_headers_only_scope(tmp_path, monkey
     assert captured["scope"] == "headers-only"
 
 
+def _tree_with_two_units(tmp_path):
+    tree = tmp_path / "src"
+    tree.mkdir()
+    for name in ("a.cpp", "b.cpp"):
+        (tree / name).write_text("int f(){return 0;}\n")
+    (tree / "compile_commands.json").write_text(json.dumps([
+        {"directory": str(tree), "file": n, "arguments": ["c++", "-c", n]}
+        for n in ("a.cpp", "b.cpp")
+    ]))
+    return tree
+
+
+def _stub_call_graph(monkeypatch, seen: list[str]):
+    from abicheck.buildsource import call_graph
+    from abicheck.buildsource.call_graph import CallEdge
+
+    class _FakeCallExtractor:
+        def __init__(self, *a, **k):
+            self.clang_bin = "clang++"
+            self.diagnostics: list[str] = []
+
+        def available(self) -> bool:
+            return True
+
+        def extract_from_build(self, build) -> list[CallEdge]:
+            seen.extend(cu.source for cu in build.compile_units)
+            return []
+
+    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
+
+
+def test_inline_unseeded_call_graph_uses_l4_selection(tmp_path, monkeypatch):
+    """Gap-1: an unseeded headers-only run scopes the L5 call-graph pass to the
+    exact compile units the L4 replay selected, not the whole compile DB."""
+    import abicheck.buildsource.inline as inline
+    from abicheck.buildsource.build_evidence import CompileUnit
+    from abicheck.buildsource.source_abi import SourceAbiSurface
+
+    def _spy(sources, merged, extractors, **kw):
+        # L4 selected only a.cpp (a headers-only subset of the two-unit DB).
+        return SourceAbiSurface(), [CompileUnit(id="cu://a.cpp", source="a.cpp")]
+
+    monkeypatch.setattr(inline, "_run_inline_source_abi", _spy)
+    seen: list[str] = []
+    _stub_call_graph(monkeypatch, seen)
+    tree = _tree_with_two_units(tmp_path)
+    inline.collect_inline_pack(sources=tree, build_info=None, scope="changed",
+                               layers=("L3", "L4", "L5"))
+    assert seen == ["a.cpp"]  # scoped to the L4 selection, not both units
+
+
+def test_inline_unseeded_call_graph_stays_broad_when_l4_selects_nothing(
+    tmp_path, monkeypatch
+):
+    """Codex review: an empty L4 selection (e.g. --build-info only, no --sources)
+    must NOT collapse the call-graph pass to zero units — it stays broad over the
+    compile DB so a build-info-only deep scan still collects L5 call edges."""
+    from pathlib import Path
+
+    import abicheck.buildsource.inline as inline
+
+    def _spy(sources, merged, extractors, **kw):
+        return None, []  # L4 could not select any units
+
+    monkeypatch.setattr(inline, "_run_inline_source_abi", _spy)
+    seen: list[str] = []
+    _stub_call_graph(monkeypatch, seen)
+    tree = _tree_with_two_units(tmp_path)
+    inline.collect_inline_pack(sources=tree, build_info=None, scope="changed",
+                               layers=("L3", "L4", "L5"))
+    # Broad, not zero: both compile-DB units are parsed for call edges.
+    assert sorted(Path(s).name for s in seen) == ["a.cpp", "b.cpp"]
+
+
 def test_exported_symbols_from_snapshot_extracts_mangled_names():
     """A1 plumbing: export extraction pulls mangled function/variable names from
     an already-parsed snapshot (no re-dump), and is empty for a bare snapshot."""

--- a/tests/test_call_graph.py
+++ b/tests/test_call_graph.py
@@ -524,12 +524,60 @@ def test_extract_from_build_dedupes_across_units(monkeypatch) -> None:
 
 
 def test_call_graph_jobs_env_override_is_bounded(monkeypatch) -> None:
+    import abicheck.buildsource.call_graph as cg
+
     monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "2")
+    # Pin the RAM probe high so the memory clamp never interferes with the
+    # CPU/oversubscription bounds this test asserts.
+    monkeypatch.setattr(cg, "_call_graph_mem_cap", lambda: None)
     assert _call_graph_jobs(120) == 2
     monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "9999")
     assert 1 <= _call_graph_jobs(120) <= 120
     monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "nope")
     assert _call_graph_jobs(120) == 1
+
+
+def test_call_graph_jobs_clamped_by_available_memory(monkeypatch) -> None:
+    """The L5 call-graph pass shares the L4 RAM clamp (OOM guard parity).
+
+    A low-memory host that would OOM under N concurrent multi-GiB clang ASTs must
+    reduce the worker count on the call-graph pass just as it does on the L4
+    replay — both shell out to the same ``clang -ast-dump=json``.
+    """
+    import abicheck.buildsource.call_graph as cg
+
+    monkeypatch.delenv("ABICHECK_CALL_GRAPH_JOBS", raising=False)
+    # Pretend the host/cgroup only has room for one heavy clang worker.
+    monkeypatch.setattr(cg, "_call_graph_mem_cap", lambda: 1)
+    assert _call_graph_jobs(120) == 1
+
+    # An explicit override is clamped too — memory wins over the requested count,
+    # mirroring source_replay._l4_jobs.
+    monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "8")
+    assert _call_graph_jobs(120) == 1
+
+    # When the RAM probe can't read memory (None), the CPU bound stands.
+    monkeypatch.setattr(cg, "_call_graph_mem_cap", lambda: None)
+    assert _call_graph_jobs(120) == 8
+
+    # The clamp only ever *reduces*: a generous mem_cap leaves the CPU bound.
+    monkeypatch.setattr(cg, "_call_graph_mem_cap", lambda: 1000)
+    assert _call_graph_jobs(120) == 8
+
+
+def test_call_graph_mem_cap_shares_l4_budget(monkeypatch) -> None:
+    """_call_graph_mem_cap delegates to the L4 cap and never raises."""
+    import abicheck.buildsource.call_graph as cg
+    import abicheck.buildsource.source_replay as sr
+
+    monkeypatch.setattr(sr, "_l4_mem_cap", lambda: 3)
+    assert cg._call_graph_mem_cap() == 3
+
+    def _boom() -> int:
+        raise RuntimeError("RAM probe failed")
+
+    monkeypatch.setattr(sr, "_l4_mem_cap", _boom)
+    assert cg._call_graph_mem_cap() is None
 
 
 def test_extract_from_build_parallelizes_and_dedupes(monkeypatch) -> None:

--- a/tests/test_inline_changed_paths.py
+++ b/tests/test_inline_changed_paths.py
@@ -74,7 +74,7 @@ def test_cache_stats_threaded_into_surface_coverage(monkeypatch, tmp_path: Path)
         inline, "_make_source_extractor", lambda *a, **k: (_FakeExtractor(), "fake")
     )
     monkeypatch.setattr(source_replay, "run_source_replay", _fake_replay)
-    surface = inline._run_inline_source_abi(
+    surface, _ = inline._run_inline_source_abi(
         tmp_path,
         _build_with_one_unit(),
         [],
@@ -272,4 +272,83 @@ def test_inline_call_graph_header_change_fans_out_to_all_tus(monkeypatch):
         changed_paths=("include/foo.h",),
     )
     # Header change → all TUs parsed for call edges.
+    assert sorted(seen_sources) == ["src/a.cpp", "src/b.cpp"]
+
+
+def _fake_call_extractor(monkeypatch, seen_sources: list[str]):
+    from abicheck.buildsource import call_graph
+    from abicheck.buildsource.call_graph import CallEdge
+
+    class _FakeCallExtractor:
+        def __init__(self, *a, **k):
+            self.clang_bin = "clang++"
+            self.diagnostics: list[str] = []
+
+        def available(self) -> bool:
+            return True
+
+        def extract_from_build(self, build) -> list[CallEdge]:
+            seen_sources.extend(cu.source for cu in build.compile_units)
+            return []
+
+    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
+
+
+def test_inline_unseeded_call_graph_scoped_to_l4_units(monkeypatch):
+    # Gap-1: an unseeded run (no changed_paths) must scope the call-graph pass to
+    # the same compile-unit set the L4 replay used (headers-only) rather than
+    # fanning out to the whole compile DB — that asymmetry made seedless
+    # `--depth source` cost scale with the whole tree.
+    from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+
+    seen_sources: list[str] = []
+    _fake_call_extractor(monkeypatch, seen_sources)
+    merged = BuildEvidence(
+        compile_units=[
+            CompileUnit(id="cu://src/a.cpp", source="src/a.cpp"),
+            CompileUnit(id="cu://src/b.cpp", source="src/b.cpp"),
+            CompileUnit(id="cu://src/c.cpp", source="src/c.cpp"),
+        ]
+    )
+    # The L4 replay selected only a.cpp (the headers-only representative subset).
+    l4_units = [CompileUnit(id="cu://src/a.cpp", source="src/a.cpp")]
+    rows: list = []
+    inline._build_inline_graph(
+        merged,
+        surface=None,
+        with_call_graph=True,
+        clang_bin="clang",
+        extractors=rows,
+        changed_paths=(),
+        call_graph_units=l4_units,
+    )
+    # Only the L4-selected TU is parsed — not all three.
+    assert seen_sources == ["src/a.cpp"]
+    row = next(r for r in rows if r.name == "call_graph:clang")
+    assert "headers-only scope" in row.detail
+    assert "from 1 compile unit" in row.detail
+
+
+def test_inline_unseeded_call_graph_broad_without_scoped_units(monkeypatch):
+    # Without scoped units (e.g. --depth full / s6, scope=full) the unseeded pass
+    # keeps the broad contract: every TU is parsed.
+    from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+
+    seen_sources: list[str] = []
+    _fake_call_extractor(monkeypatch, seen_sources)
+    merged = BuildEvidence(
+        compile_units=[
+            CompileUnit(id="cu://src/a.cpp", source="src/a.cpp"),
+            CompileUnit(id="cu://src/b.cpp", source="src/b.cpp"),
+        ]
+    )
+    inline._build_inline_graph(
+        merged,
+        surface=None,
+        with_call_graph=True,
+        clang_bin="clang",
+        extractors=[],
+        changed_paths=(),
+        call_graph_units=None,
+    )
     assert sorted(seen_sources) == ["src/a.cpp", "src/b.cpp"]

--- a/tests/test_inline_changed_paths.py
+++ b/tests/test_inline_changed_paths.py
@@ -352,3 +352,70 @@ def test_inline_unseeded_call_graph_broad_without_scoped_units(monkeypatch):
         call_graph_units=None,
     )
     assert sorted(seen_sources) == ["src/a.cpp", "src/b.cpp"]
+
+
+def test_run_inline_source_abi_no_sources_returns_empty_selection():
+    # No --sources tree: returns (None, []) so the caller keeps a broad
+    # call-graph pass rather than scoping to an empty (unavailable) selection.
+    surface, units = inline._run_inline_source_abi(
+        None,
+        _build_with_one_unit(),
+        [],
+        extractor="clang",
+        scope="headers-only",
+        clang_bin="clang",
+    )
+    assert surface is None
+    assert units == []
+
+
+def test_run_inline_source_abi_no_compile_units_returns_empty_selection():
+    # A source tree but no L3 compile units: nothing to replay/select.
+    surface, units = inline._run_inline_source_abi(
+        Path("/tmp/x"),
+        BuildEvidence(),
+        [],
+        extractor="clang",
+        scope="headers-only",
+        clang_bin="clang",
+    )
+    assert surface is None
+    assert units == []
+
+
+def test_run_inline_source_abi_returns_selected_units(monkeypatch, tmp_path):
+    # A real build + stubbed replay: select_compile_units runs for real and its
+    # result is returned alongside the surface (fed to the call-graph scope).
+    _capture_scope(monkeypatch)
+    surface, units = inline._run_inline_source_abi(
+        tmp_path,
+        _build_with_one_unit(),
+        [],
+        extractor="clang",
+        scope="headers-only",
+        clang_bin="clang",
+    )
+    assert surface is not None
+    assert [cu.source for cu in units] == ["src/foo.cpp"]
+
+
+def test_run_inline_source_abi_extractor_unavailable_returns_empty_selection(
+    monkeypatch, tmp_path
+):
+    class _Unavailable:
+        def available(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        inline, "_make_source_extractor", lambda *a, **k: (_Unavailable(), "fake")
+    )
+    surface, units = inline._run_inline_source_abi(
+        tmp_path,
+        _build_with_one_unit(),
+        [],
+        extractor="clang",
+        scope="headers-only",
+        clang_bin="clang",
+    )
+    assert surface is not None  # empty SourceAbiSurface, not None
+    assert units == []

--- a/validation/scan-level-scalability-2026-06.md
+++ b/validation/scan-level-scalability-2026-06.md
@@ -41,6 +41,15 @@ per-TU clang AST, and `jobs` is capped (here 4), not the total TU count. That is
 exactly the quantity the memory clamp (Gap 2) governs: on a host with a tighter
 RAM budget, fewer workers run, so peak RSS drops — at the cost of wall time.
 
+> **What the RSS column measures.** It is `wait4`'s `ru_maxrss` for the direct
+> `python -m abicheck` child. Under the default L4 *thread* executor the dominant
+> consumer (the multi-GiB in-process JSON-AST parse) runs inside that child, so it
+> is captured — which is why the clamp's effect is visible here. But the separate
+> `clang -ast-dump=json` subprocesses (which stream to a temp file) and any
+> `ABICHECK_L4_EXECUTOR=process` grandchildren are **not** summed in, so the column
+> is a *lower bound* on absolute host peak; for the true host high-water mark use a
+> cgroup `memory.peak` / process-tree monitor.
+
 ## Conclusions
 
 The truly cheap tier (`binary`/`headers`/`build`) is **flat in TU count** — it is

--- a/validation/scan-level-scalability-2026-06.md
+++ b/validation/scan-level-scalability-2026-06.md
@@ -57,10 +57,12 @@ dominated by the binary dump + the L2 header AST + the L3 compile-DB parse, none
 of which grow with the number of `.cpp` files. Confirms the UXL "cheap tier is one
 price" result, now with a scaling exponent rather than a single point. `graph`
 (s4) sits just above them: it is still far cheaper than the L4 tiers (no AST
-replay) but **does** grow mildly with TU count (~0.5 tail exponent, 7.6 s → 14.0 s
-from n=4 to n=16) because the L5 graph fold visits every compile unit — so it is
-not in the same "size-independent" class as binary/headers/build. `full` (s6) is
-**linear** in TU count (every TU is replayed). So far, so expected.
+replay) but **does** grow with TU count because the L5 graph fold visits every
+compile unit — mildly at small N (~0.5, 7.6 s → 14.0 s from n=4 to n=16) but
+**fully linear at scale** (~0.8 in both time and memory by 64 TUs; see
+[Larger-N behaviour](#larger-n-behaviour-n--64)), so it is *not* in the
+"size-independent" class of binary/headers/build. `full` (s6) is **linear** in TU
+count (every TU is replayed). So far, so expected.
 
 The interesting result is two scalability *gaps* on the `source` (s5) rung,
 both quantified below and both now addressed/filed.
@@ -140,6 +142,41 @@ clamped the L4 replay, which was a single TU) — the call-graph pass ran 4 work
 regardless of the RAM budget. After it, a host with a tighter budget trades wall
 time for ~half the peak RSS, which is what converts an OOM-kill on a constrained
 host into a slower-but-successful scan.
+
+## Larger-N behaviour (n → 64)
+
+A follow-up sweep extended the expensive tiers to n=16→32 and the cheap tiers to
+n=64 (same 4 vCPU / 15 GiB host, default auto jobs):
+
+| level | n=16 | n=32 | n=64 | wall exp (16→32) |
+|---|---|---|---|---|
+| `binary`        | 1.4 s / 39 MB   | 0.6 s / 39 MB   | 0.7 s / 39 MB    | flat |
+| `headers` (L2)  | —               | —               | 6.6 s / 637 MB   | flat |
+| `build` (L3)    | 11.1 s / 634 MB | 8.1 s / 635 MB  | 7.2 s / 455 MB   | flat |
+| `graph` (s4)    | 17.0 s / 534 MB | 29.5 s / 960 MB | **55.3 s / 1488 MB** | **~0.8 (linear)** |
+| `source_seeded` | 28.3 s / 1166 MB | 38.5 s / 1437 MB | —               | ~0.4 |
+| `source` (seedless) | 81.4 s / 2611 MB | 144.8 s / 2894 MB | —           | ~0.8 (linear) |
+| `full` (s6)     | 142.8 s / 3652 MB | 256.3 s / 3303 MB | —              | ~0.8 (linear) |
+
+Three things the larger sweep adds:
+
+1. **The memory clamp holds at scale.** Peak RSS on the L4/L5 tiers stays
+   *bounded by the worker count* (~2.6–2.9 GB seedless `source`, ~3.3–3.7 GB
+   `full`) rather than growing with TU count — **no OOM at n=32 or n=64**. This is
+   the Gap-2 fix validated past the sizes at which the UXL replays were
+   OOM-killed.
+2. **`graph` (s4) is *not* a flat-cheap tier at scale** — it is **linear in both
+   time and memory** (17 → 29 → 55 s, 534 → 960 → 1488 MB from n=16→32→64, tail
+   exponent ~0.8/0.85). At small N it looks nearly flat (~0.5), but the L5
+   structural fold visits every compile unit, so by 64 TUs `graph` costs as much
+   as a small source run. Only `binary`/`headers`/`build` are truly
+   size-independent; budget `graph` as *linear-but-cheap-per-TU*, not free.
+3. **Gap 1 worsens with N, as predicted.** Seedless-vs-seeded `source` widens from
+   1.9× (n=4) to **2.9× (n=16) and 3.8× (n=32)** — the unscoped call-graph pass
+   scales with the whole tree while the seeded run stays flat. This is the
+   strongest argument for the Gap-1 follow-up (scope the unseeded call-graph pass,
+   or at least report its TU count): the bigger the project, the more a seedless
+   `--depth source` overpays for coverage the report never shows.
 
 ## Reproduce
 

--- a/validation/scan-level-scalability-2026-06.md
+++ b/validation/scan-level-scalability-2026-06.md
@@ -67,7 +67,7 @@ count (every TU is replayed). So far, so expected.
 The interesting result is two scalability *gaps* on the `source` (s5) rung,
 both quantified below and both now addressed/filed.
 
-## Gap 1 — seedless `--depth source` pays a full-tree call-graph cost the report hides
+## Gap 1 — seedless `--depth source` pays a full-tree call-graph cost the report hides — **fixed**
 
 `source` (seedless s5) costs **~2× the wall time and ~2.5× the RSS of the
 seeded run, for the *identical* L4 coverage** — both report `L4=1/1` (one TU
@@ -91,10 +91,28 @@ still pays an unscoped full-tree clang pass — so seedless s5 is not merely "as
 expensive as s6", its call-graph half scales with the whole tree while its
 reported L4 coverage stays at one TU.
 
-**Status:** documented here + in `docs/development/performance.md`. The
-honest-cost fix (either scope the call-graph pass to the L4 replay's effective
-scope when unseeded, or report its TU count in the coverage line) is filed as a
-follow-up — it is a behaviour/UX change, not a hot-path bug.
+**Fix (this change):** the follow-up landed as A+B+C.
+
+- **B (scope) —** `_run_inline_source_abi` now returns the exact compile-unit set
+  the replay scope selected (pure, reusing the already-computed include graph — no
+  extra clang pass), and on an unseeded headers-only run `collect_inline_pack`
+  threads it into `_fold_call_graph`, so the call-graph pass parses the **same**
+  TUs as the L4 replay instead of the whole DB. Seeded runs still scope by
+  `changed_paths`; `full`/`target` (s6) keep the broad pass. This also makes the
+  L5 call graph *consistent* with the L4 surface (no phantom edges from TUs L4
+  never examined). Unit-tested in `tests/test_inline_changed_paths.py`
+  (`test_inline_unseeded_call_graph_scoped_to_l4_units`, plus a broad-fallback
+  case).
+- **A (honest cost) —** the call-graph extractor row now carries a
+  `(headers-only scope, matching L4)` note alongside its TU count.
+- **C (advisory) —** the unseeded source-scan advisory now names both the L4
+  replay and the L5 call-graph pass and states the cost grows with the project,
+  nudging toward `--since`/`--changed-path`.
+
+Measured effect (synthetic n=8, 4 vCPU): seedless `--depth source` wall
+**50 s → 22 s (~2.4×)** — now matching the seeded run — for the identical
+verdict. The prior widening (3.7× at n=16) is removed at the root: the call-graph
+pass no longer scales with the whole tree on an unseeded run.
 
 ## Gap 2 — the L5 call-graph pass had no memory clamp (OOM-guard parity with L4) — **fixed**
 

--- a/validation/scan-level-scalability-2026-06.md
+++ b/validation/scan-level-scalability-2026-06.md
@@ -1,0 +1,132 @@
+# Scan-level scalability sweep — findings (2026-06)
+
+A progressive-complexity sweep of every `scan` **level** against a synthetic
+C++ corpus of growing size, to find where a level's cost scales worse than its
+*coverage* does. Distinct from the UXL run
+([`uxl-scan-levels-timing-2026-06.md`](uxl-scan-levels-timing-2026-06.md)),
+which fixed the corpus (two real libs) and varied the level; this one **varies
+the corpus size** at each level so a per-level scaling exponent can be read off.
+
+Harness: [`eval/scan_level_scaling.py`](../eval/scan_level_scaling.py) — no
+network/repo, synthesises `N`-TU trees (STL/template-heavy, tunable depth),
+builds them with the host compiler, runs `abicheck scan` at each level against a
+slightly-changed baseline, and records wall time + **peak child RSS**
+(`os.wait4`, so clang's native memory counts) per (size, level).
+
+Subject: `funcs_per_tu=8`, template `depth=6`, sizes `n_tus ∈ {4, 8, 16}` (each
+TU pulls in `<vector>/<map>/<string>/<memory>` and a recursive template, so a
+single TU's clang JSON AST is large — the L4 cliff is priced on exactly this).
+Host: 4 vCPU / 15 GiB, clang 18, `ABICHECK_L4_JOBS=4`.
+
+## Raw sweep
+
+| level | n=4 | n=8 | n=16 | wall exp | rss exp |
+|---|---|---|---|---|---|
+| `binary`        | 0.49 s / 38 MB   | 0.49 s / 38 MB   | 0.51 s / 38 MB   | ~0 (flat) | ~0 (flat) |
+| `headers` (L2)  | 4.98 s / 452 MB  | 7.39 s / 650 MB  | 7.48 s / 674 MB  | ~0 | ~0 |
+| `build` (L3/s1) | 4.99 s / 452 MB  | 5.49 s / 452 MB  | 5.76 s / 453 MB  | ~0.1 | ~0 |
+| `graph` (s4)    | 7.64 s / 457 MB  | 10.20 s / 459 MB | 13.99 s / 463 MB | ~0.5 | ~0 |
+| `source_seeded` (s5 + 1-file seed) | 17.3 s / 1105 MB | 20.2 s / 1107 MB | 23.9 s / 1109 MB | ~0.2 | ~0 |
+| `source` (s5, **seedless**) | 32.3 s / 2584 MB | 49.9 s / 3044 MB | 88.8 s / 2757 MB | **~0.8** | ~0 |
+| `full` (s6)     | 54.1 s / 3443 MB | 87.6 s / 4034 MB | 149.2 s / 3177 MB | ~0.8 | ~0 |
+
+(`exp` = log-log slope of the largest two sizes; ~1 = linear in TU count, ~0 =
+flat / size-independent. The L4-bearing levels' wall slope reads ~0.8 rather than
+1.0 because the per-TU clang replay parallelizes across the 4 vCPUs — the
+*serial* L4 time scales linearly, e.g. `full`'s L4 phase 23.7 → 34 → 64 s.)
+
+**RSS is bounded by concurrent worker count, not TU count.** The L4/L5 passes hit
+~2.6–4 GB regardless of size (n=16 is not the peak) because peak RSS ≈ `jobs` ×
+per-TU clang AST, and `jobs` is capped (here 4), not the total TU count. That is
+exactly the quantity the memory clamp (Gap 2) governs: on a host with a tighter
+RAM budget, fewer workers run, so peak RSS drops — at the cost of wall time.
+
+## Conclusions
+
+The cheap tier (`binary`/`headers`/`build`/`graph`) is **flat in TU count** — it
+is dominated by the binary dump + the L2 header AST + the L3 compile-DB parse,
+none of which grow with the number of `.cpp` files. Confirms the UXL "cheap tier
+is one price" result, now with a scaling exponent rather than a single point.
+`full` (s6) is **linear** in TU count (every TU is replayed). So far, so
+expected.
+
+The interesting result is two scalability *gaps* on the `source` (s5) rung,
+both quantified below and both now addressed/filed.
+
+## Gap 1 — seedless `--depth source` pays a full-tree call-graph cost the report hides
+
+`source` (seedless s5) costs **~2× the wall time and ~2.5× the RSS of the
+seeded run, for the *identical* L4 coverage** — both report `L4=1/1` (one TU
+parsed), the same verdict, the same findings. And the wall-time gap **widens
+with TU count**: seedless-vs-seeded is 1.9× at n=4 (32 s vs 17 s), 2.5× at n=8
+(50 s vs 20 s), **3.7× at n=16** (89 s vs 24 s) — because the seeded run stays
+flat (it scopes to one TU) while the seedless run's call-graph half grows with
+the whole tree.
+
+Root cause (`buildsource/inline.py:_fold_call_graph`): an s5 scan runs an L4
+replay **and** an L5 clang call-graph pass. With a `--changed-path`/`--since`
+seed, *both* are scoped to the changed TU. **Without** a seed, the L4 replay
+falls back to "headers-only" (here 1 TU) but the call-graph pass keeps its
+**broad, whole-compile-DB scope** — a second `clang -ast-dump=json` over *every*
+TU. That whole-DB pass is the entire extra cost, and the coverage line only
+reports the L4 replay's `1/1`, so the cost is invisible in the output.
+
+This refines the documented "s5 only beats s6 with a seed" rule: even the
+*scoped* part of a seedless s5 (the L4 replay) is cheap, but the run as a whole
+still pays an unscoped full-tree clang pass — so seedless s5 is not merely "as
+expensive as s6", its call-graph half scales with the whole tree while its
+reported L4 coverage stays at one TU.
+
+**Status:** documented here + in `docs/development/performance.md`. The
+honest-cost fix (either scope the call-graph pass to the L4 replay's effective
+scope when unseeded, or report its TU count in the coverage line) is filed as a
+follow-up — it is a behaviour/UX change, not a hot-path bug.
+
+## Gap 2 — the L5 call-graph pass had no memory clamp (OOM-guard parity with L4) — **fixed**
+
+The same whole-DB call-graph pass is what drives the RSS column: `source`
+(seedless) hits **2.6 GB at just 4 TUs** and climbs from there, and `full` hits
+**4 GB at 8 TUs**. The L4 replay grew a RAM-aware, cgroup-aware worker clamp
+(`source_replay._l4_jobs` → `_l4_mem_cap`, default 3 GiB/worker) precisely
+because a template-heavy TU's clang JSON AST can be multiple GiB and N
+concurrent ASTs OOM-killed the UXL oneTBB/oneDNN replays. **The L5 call-graph
+pass — which shells out to the *same* `clang -ast-dump=json` per TU — never got
+that clamp**: `call_graph._call_graph_jobs` was purely `min(n_units, cpu, 8)`.
+
+So a constrained host (a small cgroup / CI container) was protected on the L4
+replay but **not** on the unseeded full-DB call-graph pass that `--depth source`
+and `--mode pr-deep` run — the exact OOM mode the L4 clamp was added to prevent,
+reintroduced in the parallel sibling pass.
+
+**Fix (this change):** `_call_graph_jobs` now shares the L4 memory cap
+(`_call_graph_mem_cap` → `source_replay._l4_mem_cap`), so the call-graph worker
+count is reduced to fit available RAM just like L4, honouring the same
+`ABICHECK_L4_JOB_MEM_GIB` budget and cgroup-headroom probe. A dedicated
+`ABICHECK_CALL_GRAPH_JOBS` still overrides the CPU count, but memory now wins
+over an over-eager override (mirroring `_l4_jobs`). The clamp is logged, never
+silent. Unit-tested in `tests/test_call_graph.py`
+(`test_call_graph_jobs_clamped_by_available_memory`,
+`test_call_graph_mem_cap_shares_l4_budget`).
+
+Measured effect (seedless `source`, n=8, 4 vCPU / 15 GiB host):
+
+| run | call-graph workers | peak RSS | wall |
+|---|---|---|---|
+| default | 4 (`min(TUs, cpu)`) | 2373 MB | 51.9 s |
+| `ABICHECK_L4_JOB_MEM_GIB=8` (cap → 1) | 1 | **1217 MB (−49 %)** | 60.5 s (+17 %) |
+
+Before the fix, `ABICHECK_L4_JOB_MEM_GIB` had **no effect** on this run (it only
+clamped the L4 replay, which was a single TU) — the call-graph pass ran 4 workers
+regardless of the RAM budget. After it, a host with a tighter budget trades wall
+time for ~half the peak RSS, which is what converts an OOM-kill on a constrained
+host into a slower-but-successful scan.
+
+## Reproduce
+
+```bash
+python eval/scan_level_scaling.py --sizes 4,8,16 --depth 6 \
+    --json-out reports/perf/scan_levels.json
+# Demonstrate the Gap-2 fix: a tight per-worker budget forces the call-graph
+# pass down to 1 worker (lower RSS), where before it ran min(TUs, cpu).
+ABICHECK_L4_JOB_MEM_GIB=8 python eval/scan_level_scaling.py --sizes 8 --levels source
+```

--- a/validation/scan-level-scalability-2026-06.md
+++ b/validation/scan-level-scalability-2026-06.md
@@ -43,12 +43,15 @@ RAM budget, fewer workers run, so peak RSS drops — at the cost of wall time.
 
 ## Conclusions
 
-The cheap tier (`binary`/`headers`/`build`/`graph`) is **flat in TU count** — it
-is dominated by the binary dump + the L2 header AST + the L3 compile-DB parse,
-none of which grow with the number of `.cpp` files. Confirms the UXL "cheap tier
-is one price" result, now with a scaling exponent rather than a single point.
-`full` (s6) is **linear** in TU count (every TU is replayed). So far, so
-expected.
+The truly cheap tier (`binary`/`headers`/`build`) is **flat in TU count** — it is
+dominated by the binary dump + the L2 header AST + the L3 compile-DB parse, none
+of which grow with the number of `.cpp` files. Confirms the UXL "cheap tier is one
+price" result, now with a scaling exponent rather than a single point. `graph`
+(s4) sits just above them: it is still far cheaper than the L4 tiers (no AST
+replay) but **does** grow mildly with TU count (~0.5 tail exponent, 7.6 s → 14.0 s
+from n=4 to n=16) because the L5 graph fold visits every compile unit — so it is
+not in the same "size-independent" class as binary/headers/build. `full` (s6) is
+**linear** in TU count (every TU is replayed). So far, so expected.
 
 The interesting result is two scalability *gaps* on the `source` (s5) rung,
 both quantified below and both now addressed/filed.
@@ -114,6 +117,14 @@ Measured effect (seedless `source`, n=8, 4 vCPU / 15 GiB host):
 |---|---|---|---|
 | default | 4 (`min(TUs, cpu)`) | 2373 MB | 51.9 s |
 | `ABICHECK_L4_JOB_MEM_GIB=8` (cap → 1) | 1 | **1217 MB (−49 %)** | 60.5 s (+17 %) |
+
+(This `default` row was a separate before/after run from the Raw sweep table
+above, which recorded 3044 MB / 49.9 s for the same n=8 seedless `source` config.
+The ~20 % RSS spread between the two `default` measurements is run-to-run variance:
+peak RSS depends on *which* of the 4 concurrent template-heavy clang ASTs happen
+to overlap at their high-water mark, which shifts between runs. Read both as
+"~2.4–3 GB, bounded by the 4 workers" — the point is the **−49 %** drop to one
+worker, not the absolute baseline.)
 
 Before the fix, `ABICHECK_L4_JOB_MEM_GIB` had **no effect** on this run (it only
 clamped the L4 replay, which was a single TU) — the call-graph pass ran 4 workers


### PR DESCRIPTION
## Summary

Evaluate `scan` performance across **all scan levels** with a new progressive-complexity harness, and fix the memory scalability gap the evaluation surfaced.

## Motivation

The performance docs guard the pure-Python `compare()` pipeline (`scripts/benchmark_scaling.py`) and one-knob L4 parallelism on a single real tree (`eval/scaling.py`), but no harness sweeps how each **scan level** (`--depth binary…full`) scales as a project's *complexity* grows. This PR adds that sweep, runs it across a progressive-complexity corpus, and acts on the two scalability gaps it found.

## Changes

**Harness — `eval/scan_level_scaling.py` (new)**
- Self-contained (no network/repo): synthesises STL/template-heavy C++ trees of tunable TU count + template depth, builds them with the host compiler into a `.so` + absolute-path `compile_commands.json`, and runs `abicheck scan` at each level against a slightly-changed baseline.
- Records wall time + **peak child RSS** (`os.wait4`, so clang's native memory counts) and the L4 coverage line per (size, level); emits a per-level scaling table with tail exponents.

**Findings — `validation/scan-level-scalability-2026-06.md` (new)**

Swept `n_tus ∈ {4, 8, 16}`, template depth 6, on a 4 vCPU / 15 GiB host:

| level | n=4 | n=8 | n=16 | wall exp |
|---|---|---|---|---|
| binary / headers / build / graph | flat | flat | flat | ~0 |
| `source_seeded` (s5 + 1-file seed) | 17.3s | 20.2s | 23.9s | ~0.2 |
| `source` (s5, **seedless**) | 32.3s / 2.6 GB | 49.9s / 3.0 GB | 88.8s / 2.8 GB | ~0.8 |
| `full` (s6) | 54.1s | 87.6s | 149.2s | ~0.8 |

- **Cheap tier is flat in TU count**; `full` is linear — as expected.
- **Gap 1 — seedless `--depth source` hides a full-tree cost.** It costs ~2× the wall and ~2.5× the RSS of a *seeded* run for the **identical** L4 coverage (both report `L4=1/1`), and the wall gap widens with TU count (1.9× → 3.7× from n=4 to n=16). The seed scopes both the L4 replay *and* the L5 clang call-graph pass to the changed TU; without a seed the L4 replay falls back to headers-only (one TU) but the call-graph pass still runs over the **whole compile DB** — a cost the `L4=1/1` line never reports. Documented + filed as a reporting follow-up.

**Fix — `abicheck/buildsource/call_graph.py` (Gap 2)**
- That whole-DB call-graph pass shells out to the same multi-GiB `clang -ast-dump=json` as the L4 replay, but `_call_graph_jobs` was **CPU-bound only** — it lacked the RAM/cgroup-aware clamp the L4 replay grew (`_l4_jobs` → `_l4_mem_cap`) after the UXL oneTBB/oneDNN OOM. So a constrained host (small cgroup / CI container) was protected on the L4 pass but **not** on the unseeded call-graph pass that `--depth source` / `--mode pr-deep` run — the exact OOM mode the L4 clamp was added to prevent, reintroduced in the parallel sibling.
- `_call_graph_jobs` now shares the L4 memory cap via `_call_graph_mem_cap`, honouring the same `ABICHECK_L4_JOB_MEM_GIB` budget; `ABICHECK_CALL_GRAPH_JOBS` still overrides CPU count but memory wins over an over-eager override, mirroring `_l4_jobs`. The clamp is logged, never silent.
- **Measured:** seedless `source` RSS **2373 MB → 1217 MB (−49 %)** at the tightest budget (wall +17 %) — converting an OOM-kill on a constrained host into a slower-but-successful scan.

**Tests / docs**
- `tests/test_call_graph.py`: memory-clamp parity + delegation tests (`test_call_graph_jobs_clamped_by_available_memory`, `test_call_graph_mem_cap_shares_l4_budget`).
- `docs/development/performance.md`: new "Scan-level scalability sweep" section; `eval/CLAUDE.md` + `CHANGELOG.md` updated.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed
- [x] No new `mypy` or `ruff` errors introduced (`mypy abicheck/` clean — 198 files; `ruff check abicheck/ tests/` clean; AI-readiness 0 errors)

Note: one pre-existing unrelated test failure (`test_run_bazel_empty_action_graph_is_partial`, build-query inference) fails on clean `main` too — not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bPVbBo8hVNpdxW5P9iV8n

---
_Generated by [Claude Code](https://claude.ai/code/session_019bPVbBo8hVNpdxW5P9iV8n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the risk of scans being killed on memory-constrained machines by making call-graph worker usage RAM/cgroup aware and aligned with the existing memory budgeting used in replay.
  * Improved consistency for scan “source-depth” tiers, preventing unexpected memory spikes as project size grows.

* **Documentation**
  * Added new development guidance, including a scan-level scalability sweep methodology and results, plus a reproducible validation report.

* **Tests**
  * Expanded coverage for call-graph worker sizing, including environment overrides and memory clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->