### PR TITLE
fix(tests): align keeps-literal test with the compile-atom validator (#471)

### DIFF
--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -258,19 +258,25 @@ def test_merge_compile_config_uses_config_when_cli_unset(tmp_path: Path) -> None
 def test_merge_compile_config_keeps_config_values_literal(tmp_path: Path) -> None:
     from abicheck.cli_scan import _merge_compile_config
 
+    # Each compile config scalar reaches gcc_option_tokens as ONE literal token
+    # (`-std=<v>` / `-D<v>`), not shell-split. The values must be single option
+    # atoms: PR #471 rejects whitespace in compile.std/compile.defines so a config
+    # scalar can never expand into multiple compiler arguments (flag injection like
+    # `-Xclang -load ./evil.so`) — that rejection is covered by
+    # test_buildconfig_rejects_compile_{std,define}_flag_injection.
     cfg = tmp_path / ".abicheck.yml"
     cfg.write_text(
         "compile:\n"
-        "  std: 'c++20 -Xclang'\n"
+        "  std: 'c++20'\n"
         "  defines:\n"
-        "    - 'DUMMY -Xclang -load -Xclang ./evil.so'\n",
+        "    - 'DUMMY=1'\n",
         encoding="utf-8",
     )
     merged, _ = _merge_compile_config(CompileContext(), (), cfg)
     assert merged.gcc_options is None
     assert merged.gcc_option_tokens == (
-        "-std=c++20 -Xclang",
-        "-DDUMMY -Xclang -load -Xclang ./evil.so",
+        "-std=c++20",
+        "-DDUMMY=1",
     )
 
 def test_merge_compile_config_noop_without_path() -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -259,9 +259,13 @@ def test_merge_compile_config_keeps_config_values_literal(tmp_path: Path) -> Non
     from abicheck.cli_scan import _merge_compile_config
 
     # Each compile config scalar reaches gcc_option_tokens as ONE literal token
-    # (`-std=<v>` / `-D<v>`), not shell-split. The values must be single option
-    # atoms: PR #471 rejects whitespace in compile.std/compile.defines so a config
-    # scalar can never expand into multiple compiler arguments (flag injection like
+    # (`-std=<v>` / `-D<v>`), not shell-split. The define carries embedded quotes
+    # (a legal single option atom — a string-valued macro) precisely so this stays
+    # a regression test: a token that flowed through shlex-split plumbing would be
+    # de-quoted to `-DMSG=hi`, so the verbatim `-DMSG="hi"` below proves the literal
+    # path. The values must be single option atoms with no whitespace: PR #471
+    # rejects whitespace in compile.std/compile.defines so a config scalar can never
+    # expand into multiple compiler arguments (flag injection like
     # `-Xclang -load ./evil.so`) — that rejection is covered by
     # test_buildconfig_rejects_compile_{std,define}_flag_injection.
     cfg = tmp_path / ".abicheck.yml"
@@ -269,14 +273,14 @@ def test_merge_compile_config_keeps_config_values_literal(tmp_path: Path) -> Non
         "compile:\n"
         "  std: 'c++20'\n"
         "  defines:\n"
-        "    - 'DUMMY=1'\n",
+        '    - \'MSG="hi"\'\n',
         encoding="utf-8",
     )
     merged, _ = _merge_compile_config(CompileContext(), (), cfg)
     assert merged.gcc_options is None
     assert merged.gcc_option_tokens == (
         "-std=c++20",
-        "-DDUMMY=1",
+        '-DMSG="hi"',
     )
 
 def test_merge_compile_config_noop_without_path() -> None:


### PR DESCRIPTION
## Summary

`main` is currently red on every unit-test lane: `tests/test_compile_context_parity.py::test_merge_compile_config_keeps_config_values_literal` fails with `ClickException: compile.std must be a single compiler option atom, got 'c++20 -Xclang'`.

## Motivation

PR #471 ("validate compile config flag atoms", da34c51) added a validator in `BuildConfig.from_dict` that **rejects whitespace** in `compile.std` / `compile.defines` (so a config scalar can't expand into multiple compiler arguments — flag injection like `-Xclang -load ./evil.so`), plus two new rejection tests. But it left the **pre-existing** `test_merge_compile_config_keeps_config_values_literal`, which asserts the *opposite*: that `std: 'c++20 -Xclang'` and a multi-token define are accepted and kept literal. That stale test now trips the new validator, so `main` fails on it across all platforms/Pythons.

Confirmed: the test fails on a clean `origin/main` checkout (`abicheck/cli_options.py:402`), independent of any feature branch.

## Changes

- Update `test_merge_compile_config_keeps_config_values_literal` to use single option atoms (`std: 'c++20'`, `defines: ['DUMMY=1']`), preserving its intent — a config scalar reaches `gcc_option_tokens` as **one literal** `-std=`/`-D` token, not shell-split — while honoring #471's validator.
- The rejection of multi-atom values (the security behavior #471 added) stays fully covered by `test_buildconfig_rejects_compile_std_flag_injection` and `test_buildconfig_rejects_compile_define_flag_injection`.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_compile_context_parity.py` — all 50 pass locally)
- [ ] `CHANGELOG.md` updated (not needed — this only re-aligns a stale test with already-shipped #471 behavior)
- [x] No new `mypy` or `ruff` errors introduced (`ruff check` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bPVbBo8hVNpdxW5P9iV8n

---
_Generated by [Claude Code](https://claude.ai/code/session_019bPVbBo8hVNpdxW5P9iV8n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated build-configuration validation to treat option values as literal tokens.
  * Added coverage for compiler settings so quoted values are handled as single entries and no longer absorb embedded whitespace or extra text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->