### PR TITLE
docs: reflect CLI command consolidation (ADR-037) in user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It catches removed or renamed symbols, changed function signatures, struct layou
 - **Cross-platform.** Linux (ELF), Windows (PE/COFF), and macOS (Mach-O) binaries, with debug-info cross-checks from DWARF, PDB, BTF, and CTF.
 - **Built for CI.** Deterministic [exit codes](https://abicheck.github.io/abicheck/reference/exit-codes/), SARIF/JSON/Markdown/HTML/JUnit output, snapshot-based [baselines](https://abicheck.github.io/abicheck/user-guide/baseline-management/), [policy profiles](https://abicheck.github.io/abicheck/user-guide/policies/) and [suppressions](https://abicheck.github.io/abicheck/user-guide/suppressions/), and a first-class [GitHub Action](https://abicheck.github.io/abicheck/user-guide/github-action/).
 - **Public-surface scoping.** Filters findings to the library's *public* ABI surface so internal-only changes don't fail your build — fewer false positives than symbol-only tools.
-- **More than one library at a time.** Compare co-versioned multi-library releases as a single bundle ([`compare` on directory/package inputs](https://abicheck.github.io/abicheck/user-guide/multi-binary/)), check whether a specific application still works ([`appcompat`](https://abicheck.github.io/abicheck/user-guide/appcompat/)), or validate a binary's full dependency stack across sysroots ([`stack-check`](https://abicheck.github.io/abicheck/user-guide/cli-usage/)).
+- **More than one library at a time.** Compare co-versioned multi-library releases as a single bundle ([`compare` on directory/package inputs](https://abicheck.github.io/abicheck/user-guide/multi-binary/)), check whether a specific application still works ([`appcompat`](https://abicheck.github.io/abicheck/user-guide/appcompat/)), or validate a binary's full dependency stack across sysroots ([`deps compare`](https://abicheck.github.io/abicheck/user-guide/cli-usage/)).
 - **Drop-in for existing tools.** A [`compat`](https://abicheck.github.io/abicheck/user-guide/from-abicc/) mode mirrors `abi-compliance-checker` flags, and migration guides cover [ABICC](https://abicheck.github.io/abicheck/user-guide/from-abicc/) and [libabigail](https://abicheck.github.io/abicheck/user-guide/from-libabigail/).
 - **Agent- and script-friendly.** Structured JSON, a [Python API](#python-api), and an [MCP server](https://abicheck.github.io/abicheck/user-guide/mcp-integration/) for AI-driven workflows. Pure Python (3.10+), no heavyweight native toolchain required for binary-only mode.
 
@@ -95,7 +95,7 @@ See [Getting Started](https://abicheck.github.io/abicheck/getting-started/) for 
 | Check whether a library upgrade breaks existing consumers | [`abicheck compare`](https://abicheck.github.io/abicheck/user-guide/cli-usage/) |
 | Compare **a multi-library release** (a co-versioned bundle, e.g. oneDAL) as a single bundle | [`abicheck compare`](https://abicheck.github.io/abicheck/user-guide/multi-binary/) |
 | Check whether **my application** breaks with a new library version | [`abicheck appcompat`](https://abicheck.github.io/abicheck/user-guide/appcompat/) |
-| Validate a binary's full dependency stack across two sysroots | [`abicheck stack-check`](https://abicheck.github.io/abicheck/user-guide/cli-usage/) |
+| Validate a binary's full dependency stack across two sysroots | [`abicheck deps compare`](https://abicheck.github.io/abicheck/user-guide/cli-usage/) |
 | Drop-in replacement for `abi-compliance-checker` | [`abicheck compat`](https://abicheck.github.io/abicheck/user-guide/from-abicc/) |
 | Save a reusable ABI baseline snapshot | [`abicheck dump`](https://abicheck.github.io/abicheck/getting-started/) |
 
@@ -113,7 +113,7 @@ Use these to gate CI pipelines.
 | `4` | `BREAKING` | Binary ABI break (old binaries will crash or misbehave) |
 | `8` | `REMOVED_LIBRARY` | Library removed in new version (multi-library/bundle compare only) |
 
-`appcompat`, `stack-check`, and `compat` use the same scheme with per-mode additions — see the [full exit code reference](https://abicheck.github.io/abicheck/reference/exit-codes/).
+`appcompat`, `deps compare`, and `compat` use the same scheme with per-mode additions — see the [full exit code reference](https://abicheck.github.io/abicheck/reference/exit-codes/).
 
 ---
 

--- a/docs/concepts/api-surface-intelligence.md
+++ b/docs/concepts/api-surface-intelligence.md
@@ -94,8 +94,8 @@ the consumer's own public ABI surface — the finding is **demoted to risk**
 (reason `consumer-internal-use`), never dropped. When the type leaks into a
 symbol the consumer itself exports, the finding stays a full-confidence
 cross-DSO break. The demotion is carried on the `BundleFinding` and propagated
-onto the lowered `Change`, so the **bundle verdict** and the release-compare
-exit code honour it — the same demote-don't-delete contract as A4.
+onto the lowered `Change`, so the **bundle verdict** and the `compare` exit
+code honour it — the same demote-don't-delete contract as A4.
 
 ## Surface-metric drift (A1, `--surface-metrics`)
 

--- a/docs/concepts/api-surface-intelligence.md
+++ b/docs/concepts/api-surface-intelligence.md
@@ -85,7 +85,8 @@ quietly demoted.
 
 ## Cross-library reachability (A3, multi-binary releases)
 
-In a `compare-release` / bundle run, a type changed in one library that is also
+In a multi-library / bundle `compare` run (directory or package inputs), a type
+changed in one library that is also
 referenced by a sibling is reported as `bundle_intra_type_changed`. A3 adds a
 **reachability filter**: if the consumer library references the changed type
 only through its *internal* (non-exported) symbols — so the change cannot reach
@@ -93,7 +94,7 @@ the consumer's own public ABI surface — the finding is **demoted to risk**
 (reason `consumer-internal-use`), never dropped. When the type leaks into a
 symbol the consumer itself exports, the finding stays a full-confidence
 cross-DSO break. The demotion is carried on the `BundleFinding` and propagated
-onto the lowered `Change`, so the **bundle verdict** and the `compare-release`
+onto the lowered `Change`, so the **bundle verdict** and the release-compare
 exit code honour it — the same demote-don't-delete contract as A4.
 
 ## Surface-metric drift (A1, `--surface-metrics`)

--- a/docs/concepts/verdicts.md
+++ b/docs/concepts/verdicts.md
@@ -20,7 +20,8 @@ groups every fixture by both verdict and category.
 > **Beyond the five core verdicts.** `compare` in severity-aware mode (any
 > `--severity-*` flag) can also report **`SEVERITY_ERROR`** with exit code `1`
 > when an addition/quality finding is promoted to error level — for example to
-> block accidental public-API expansion. The `compare-release` package mode adds
+> block accidental public-API expansion. A package/bundle `compare` (directory
+> or package inputs) adds
 > **`REMOVED_LIBRARY`** (exit `8`) when a shared object present in the old
 > package is absent from the new one. See the
 > [GitHub Action](../user-guide/github-action.md#outputs) and

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -86,10 +86,15 @@ verdict=$(python3 -c "import json,sys; d=json.load(open('result.json')); print(d
 
 ---
 
-## `abicheck compare-release`
+## `abicheck compare` (multi-library / release inputs)
 
-Aggregates the worst per-library verdict across the release; exit codes mirror
-`compare`, plus a dedicated code for removed libraries:
+When `compare` is handed directory or package inputs (RPM/deb/tar/conda/wheel),
+it fans out to per-library pairs and aggregates the worst per-library verdict
+across the release — the behaviour formerly exposed as the standalone
+`compare-release` command (folded into `compare` per ADR-037 D7; still selectable
+as the GitHub Action's `mode: compare-release`). A set/release comparison keeps
+the verdict-based exit scheme (it is not silently promoted to the severity-aware
+codes), plus a dedicated code for removed libraries:
 
 | Exit code | Meaning |
 |-----------|---------|

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -103,16 +103,20 @@ removed libraries:
 | `4` | Worst verdict is `BREAKING`, **or** an operational `ERROR` (a library failed to dump/extract/compare) |
 | `8` | A library was removed between releases and `--fail-on-removed-library` is set — takes precedence over every other code |
 
-The scheme is resolved exactly as for a single `compare`: it stays verdict-based
-unless severity is *active* — via any `--severity-*` flag **or** a `severity:`
-block in `.abicheck.yml` — in which case the severity-aware code (`0/1/2/4`)
-replaces the verdict-based `2/4` mapping. Exit `8` still wins, and an operational
-`ERROR` still floors the exit at `4`. (`--exit-code-scheme` itself is rejected on
-directory/package inputs; pin the scheme in config with `exit_code_scheme: legacy`
-instead.) One consequence worth gating on: with a config severity map, a release
-whose worst verdict is `BREAKING` can still exit `0` if that map downgrades ABI
-breaks (e.g. `abi_breaking: warning`) — parse the `verdict` from JSON output if
-you need scheme-independent CI behaviour.
+On the release path the severity-aware code (`0/1/2/4`) replaces the
+verdict-based `2/4` mapping only when a severity *map* is actually in effect —
+that is, any `--severity-*` flag is passed **or** `.abicheck.yml` carries a
+`severity:` block (a preset or per-category levels). Setting `exit_code_scheme:
+severity` on its own is **not** enough for directory/package inputs: with no
+severity values to apply, the fan-out has nothing to score against and falls
+back to the legacy verdict mapping. Exit `8` still wins, and an operational
+`ERROR` still floors the exit at `4`. (`--exit-code-scheme` is rejected on
+directory/package inputs; pin the legacy scheme in config with
+`exit_code_scheme: legacy` if you want to force it.) One consequence worth
+gating on: with an effective severity map, a release whose worst verdict is
+`BREAKING` can still exit `0` if that map downgrades ABI breaks (e.g.
+`abi_breaking: warning`) — parse the `verdict` from JSON output if you need
+scheme-independent CI behaviour.
 
 ---
 

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -92,9 +92,9 @@ When `compare` is handed directory or package inputs (RPM/deb/tar/conda/wheel),
 it fans out to per-library pairs and aggregates the worst per-library verdict
 across the release — the behaviour formerly exposed as the standalone
 `compare-release` command (folded into `compare` per ADR-037 D7; still selectable
-as the GitHub Action's `mode: compare-release`). A set/release comparison keeps
-the verdict-based exit scheme (it is not silently promoted to the severity-aware
-codes), plus a dedicated code for removed libraries:
+as the GitHub Action's `mode: compare-release`). By default a set/release
+comparison uses the verdict-based scheme below, plus a dedicated code for
+removed libraries:
 
 | Exit code | Meaning |
 |-----------|---------|
@@ -103,9 +103,16 @@ codes), plus a dedicated code for removed libraries:
 | `4` | Worst verdict is `BREAKING`, **or** an operational `ERROR` (a library failed to dump/extract/compare) |
 | `8` | A library was removed between releases and `--fail-on-removed-library` is set — takes precedence over every other code |
 
-With any `--severity-*` flag, the severity-aware code (`0/1/2/4`) replaces the
-verdict-based `2/4` mapping — except exit `8` still wins, and an operational
-`ERROR` still floors the exit at `4`.
+The scheme is resolved exactly as for a single `compare`: it stays verdict-based
+unless severity is *active* — via any `--severity-*` flag **or** a `severity:`
+block in `.abicheck.yml` — in which case the severity-aware code (`0/1/2/4`)
+replaces the verdict-based `2/4` mapping. Exit `8` still wins, and an operational
+`ERROR` still floors the exit at `4`. (`--exit-code-scheme` itself is rejected on
+directory/package inputs; pin the scheme in config with `exit_code_scheme: legacy`
+instead.) One consequence worth gating on: with a config severity map, a release
+whose worst verdict is `BREAKING` can still exit `0` if that map downgrades ABI
+breaks (e.g. `abi_breaking: warning`) — parse the `verdict` from JSON output if
+you need scheme-independent CI behaviour.
 
 ---
 

--- a/docs/user-guide/choose-your-workflow.md
+++ b/docs/user-guide/choose-your-workflow.md
@@ -37,7 +37,7 @@ command** when you need more confidence or a CI gate.
 | An application + a library upgrade | `abicheck appcompat ./myapp libfoo.so.1 libfoo.so.2` | Add `-H include/`; use `--check-against new.so` when no old library exists (symbol-availability only) |
 | A host that `dlopen`s plugins | `abicheck plugin-check plugin.v1.so plugin.v2.so -r plugin_init` | Use `--host-contract host.syms --policy plugin_abi` |
 | Will this binary load in this sysroot / rootfs? | `abicheck deps ./app --sysroot /rootfs` | `abicheck deps ./app` alone checks the dependency tree resolves |
-| Two sysroots / container images to compare | `abicheck stack-check usr/bin/app --baseline /old-root --candidate /new-root` | Per-library ABI diff across the whole transitive dependency stack |
+| Two sysroots / container images to compare | `abicheck deps compare usr/bin/app --baseline /old-root --candidate /new-root` | Per-library ABI diff across the whole transitive dependency stack |
 | Only a static `.a` / `.lib` archive | *(unsupported directly)* | Extract members (`ar x libfoo.a`) and compare the `.o` objects, or compare a shared library built from the same sources — see [Limitations](../concepts/limitations.md#static-import-library-archives-a-lib) |
 
 `compare` auto-detects each input: `.so` files are dumped on the fly, `.json`


### PR DESCRIPTION
## Summary

Update user-facing docs to reflect the G22 CLI consolidation (ADR-037, #449/#450), which removed the standalone `compare-release` and `stack-check` commands.

## Motivation

Auditing the last ~30 PRs for CLI changes, the biggest surface change was the G22 command consolidation:

- **`compare-release` → `compare`** on directory/package inputs (folded per ADR-037 D7).
- **`stack-check` → `deps compare`** (same operands `--baseline`/`--candidate`, same `0/1/4` exit codes).

The CLI reference (`cli-usage.md`) and exit-code summary table were already updated, but several user-facing pages still invoked the removed command names. This corrects the stragglers so copy-paste examples work against the current CLI.

I verified that the remaining references to these names are **still valid** and left them untouched:
- The **GitHub Action** keeps `mode: compare-release` and `mode: stack-check` in `action.yml`, so `github-action.md` / `annotations.md` are correct.
- `header-backend-unavailable` in `output-formats.md` is a real diagnostic code (`surface.py`), not the renamed `--header-backend` flag (now `--ast-frontend`).
- Development docs (ADRs, plans, archive) reference the old names historically and are intentionally frozen.

New flags shipped in this window (`--ast-frontend`, `--public-header-dir`, `--old/new-sources`, `--build-info`, `--depth`, `.abicheck.yml`) were checked and already have doc coverage.

## Changes

- **README**: `stack-check` → `deps compare` in the feature bullet, use-case table, and exit-code note.
- **user-guide/choose-your-workflow**: two-sysroot recipe → `abicheck deps compare`.
- **reference/exit-codes**: retitle the `compare-release` section to `compare` (multi-library / release inputs); note the fold and that the set/release path keeps the verdict-based exit scheme (per #469).
- **concepts/verdicts** & **concepts/api-surface-intelligence**: reword `compare-release` mode/run to package/bundle `compare`.

## Checklist

- [ ] Tests added / updated for new behaviour — N/A (docs-only)
- [ ] `CHANGELOG.md` updated (under `[Unreleased]`) — N/A (docs-only, no user-visible behaviour change)
- [x] Docs updated if user-visible behaviour changed
- [x] `mkdocs build --strict` passes locally
- [x] AI-readiness gate passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pXrd3YYMPHZqPmMT5Vt8G

---
_Generated by [Claude Code](https://claude.ai/code/session_016pXrd3YYMPHZqPmMT5Vt8G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing docs to reflect the current `abicheck compare` and `abicheck deps compare` commands.
  * Clarified how comparison modes behave for directory, package, sysroot, and bundle inputs.
  * Expanded exit-code guidance so results are easier to interpret across different comparison workflows.
  * Kept workflow examples aligned with the latest command names for dependency-stack and release comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->