### PR TITLE
fix(buildsource): recover ctor/dtor symbol matches, fix merge export truncation, plugin fails loud on bad public-roots

### DIFF
--- a/.github/workflows/clang-plugin.yml
+++ b/.github/workflows/clang-plugin.yml
@@ -131,3 +131,9 @@ jobs:
           python contrib/abicheck-clang-plugin/tests/scan_flow.py \
             --plugin build/plugin/libabicheck-facts.so \
             --clangxx clang++
+
+      - name: Public-roots misconfiguration diagnostic (Caveat A)
+        run: |
+          python contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py \
+            --plugin build/plugin/libabicheck-facts.so \
+            --clangxx clang++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   the DWARF-shaped `functions[].mangled` view. On a pvxs Flow-C merge this lifts
   `matched_symbols` from 6 to 287 (`exported_symbols` 126 → 950).
 
+- **Source→binary matching normalizes Mach-O spellings for all names.** The
+  linker normalizes the optional Mach-O leading underscore (`__ZN…` → `_ZN…`)
+  for every Itanium source/export key, not only ctor/dtor canonical keys, so an
+  ordinary C++ method the plugin records as `__ZN1A3fooEv` exact-matches the
+  export table's `_ZN1A3fooEv` instead of orphaning into the unmatched sets.
+- **`merge` excludes non-default ELF version aliases from the relink set.** A
+  symbol that exists only as `foo@VER` (no default `foo@@VER`) can't be linked
+  against by an unversioned consumer, so it no longer enters the export set —
+  preventing the two-way reconciliation from masking a real `public_not_exported`.
+
 ### Changed
 
 - **Clang facts plugin fails loud on a misconfigured `public-roots`** (ADR-038
@@ -31,12 +41,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `diagnostics`) when `public-roots` matches zero declarations though header
   decls were seen outside the roots, instead of silently producing an empty
   pack with exit 0.
+- **Clang facts plugin auto-derives `public-roots` when omitted** (ADR-038 Flow
+  C): with no explicit `public-roots=`, roots are inferred from the compile's
+  `-I`/`-iquote` include dirs (compiler/system entries excluded) and a one-time
+  inference note is emitted, so a forgotten flag yields a populated surface
+  rather than a silently empty pack. An explicit `public-roots=` still scopes
+  the surface precisely.
 
 ### Added
 
 - New user-guide page **Producing Source Facts (Flow A/B/C)** documenting the
   three source-fact producers, a selection tree, and the `public-roots`/
   `ABICHECK_CC_HEADERS` header-resolution trap.
+- **Two-way reconciliation in the `public_not_exported` cross-check** (ADR-035
+  D4): a public header decl the L4 source-linker already tied to an export under
+  a variant spelling (ctor/dtor clone, Mach-O underscore, ABI-tag/substitution
+  drift) is no longer double-reported as "declared but not exported".
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Source→binary symbol matching now recovers ctor/dtor ABI clones.** The
+  linker (`link_source_abi` / `relink_surface_exports`) folds C++ Itanium
+  ctor/dtor clone tags (`C1`/`C2`/`C3`/`C4`, `D0`/`D1`/`D2`/`D4`) so one source
+  ctor/dtor declaration claims every clone the compiler exports, instead of
+  orphaning the siblings as "exported symbol with no source decl". Also bridges
+  GCC's non-standard unified `C4`/`D4` DWARF linkage tag to the real `C1`/`C2`
+  exports.
+- **`merge` no longer truncates the binary export set.**
+  `_exported_symbols_from_snapshot` unions the authoritative platform dynamic
+  export table (`elf.symbols` / `pe.exports` / `macho.exports`) instead of only
+  the DWARF-shaped `functions[].mangled` view. On a pvxs Flow-C merge this lifts
+  `matched_symbols` from 6 to 287 (`exported_symbols` 126 → 950).
+
+### Changed
+
+- **Clang facts plugin fails loud on a misconfigured `public-roots`** (ADR-038
+  Flow C, Caveat A): it now emits a diagnostic (and records it in the pack's
+  `diagnostics`) when `public-roots` matches zero declarations though header
+  decls were seen outside the roots, instead of silently producing an empty
+  pack with exit 0.
+
+### Added
+
+- New user-guide page **Producing Source Facts (Flow A/B/C)** documenting the
+  three source-fact producers, a selection tree, and the `public-roots`/
+  `ABICHECK_CC_HEADERS` header-resolution trap.
+
 ---
 
 ## [0.4.0] — 2026-07-01

--- a/abicheck/buildsource/crosscheck.py
+++ b/abicheck/buildsource/crosscheck.py
@@ -1256,16 +1256,26 @@ def _l4_reconciled_symbols(snapshot: AbiSnapshot, exported: set[str]) -> set[str
     surface = pack.source_abi if pack is not None else None
     if surface is None:
         return set()
+    # The single-leading-underscore strip only applies on Mach-O, whose export
+    # table drops one `_` from every symbol. On ELF/PE the mapped `sym` is already
+    # the raw exported spelling, so applying the strip there would over-match: a
+    # stale mapping to a leading-underscore C symbol `_bar` (no longer exported)
+    # would be reconciled whenever an unrelated `bar` is exported, wrongly
+    # suppressing a real public_not_exported (Codex review). Gate on the platform.
+    is_macho = getattr(snapshot, "macho", None) is not None
     mapping = (surface.mappings or {}).get("source_decl_to_binary_symbol") or {}
     reconciled: set[str] = set()
     for key, sym in mapping.items():
         if not sym:
             continue
         # The mapped symbol must be in the CURRENT default export table (directly,
-        # or with the Mach-O single leading underscore stripped as
-        # `_exported_symbol_names` does) — otherwise the mapping is stale evidence
+        # or — on Mach-O only — with the single leading underscore stripped as
+        # `_exported_symbol_names` does); otherwise the mapping is stale evidence
         # from another binary and must not suppress the finding.
-        if sym in exported or (sym.startswith("_") and sym[1:] in exported):
+        present = sym in exported or (
+            is_macho and sym.startswith("_") and sym[1:] in exported
+        )
+        if present:
             reconciled.add(key[1:] if key.startswith("__Z") else key)
     return reconciled
 

--- a/abicheck/buildsource/crosscheck.py
+++ b/abicheck/buildsource/crosscheck.py
@@ -320,11 +320,16 @@ def _check_public_not_exported(
             [], "skipped", "no binary export table on the snapshot", providers
         )
 
+    # Two-way reconciliation (ADR-035 D4): exempt decls the L4 linker already tied
+    # to an export under a variant spelling (ctor clone / Mach-O / demangle drift),
+    # so the check does not double-report a symbol that is genuinely exported.
+    reconciled = _l4_reconciled_symbols(snapshot)
+
     findings: list[Change] = []
     for fn in snapshot.functions:
         if not _has_export_obligation(fn):
             continue
-        if fn.mangled not in exported:
+        if fn.mangled not in exported and fn.mangled not in reconciled:
             findings.append(
                 _change(
                     ChangeKind.PUBLIC_NOT_EXPORTED,
@@ -340,7 +345,7 @@ def _check_public_not_exported(
     for var in snapshot.variables:
         if not _var_has_export_obligation(var):
             continue
-        if var.mangled not in exported:
+        if var.mangled not in exported and var.mangled not in reconciled:
             findings.append(
                 _change(
                     ChangeKind.PUBLIC_NOT_EXPORTED,
@@ -1223,6 +1228,34 @@ def _exported_symbol_names(snapshot: AbiSnapshot) -> set[str] | None:
             if e.name
         }
     return None
+
+
+def _l4_reconciled_symbols(snapshot: AbiSnapshot) -> set[str]:
+    """Decl mangled names the L4 source-linker already tied to a real export.
+
+    ``public_not_exported`` compares each public-header decl's mangled name against
+    the *literal* binary export table. But the L4 source-ABI linker
+    (``source_link``) reconciles spellings the table lists under a *variant*: a
+    ctor/dtor ABI clone (a decl mangled ``C1``/``C4`` whose binary lists only
+    ``C2``), a Mach-O leading underscore, or an ABI-tag / substitution drift caught
+    by demangled identity. A decl the linker already resolved to an export *is*
+    exported, so flagging it as missing would be a two-way-reconciliation false
+    positive. This returns those decl mangled names — Mach-O-normalized to the L2
+    ``Function.mangled`` spelling — so the check can exempt them. Empty when no L4
+    surface is attached, so it can only *suppress* a false positive, never add one
+    (ADR-028 D3: L4 evidence explains/scopes, never invents a break).
+    """
+    pack = snapshot.build_source
+    surface = pack.source_abi if pack is not None else None
+    if surface is None:
+        return set()
+    mapping = (surface.mappings or {}).get("source_decl_to_binary_symbol") or {}
+    reconciled: set[str] = set()
+    for key, sym in mapping.items():
+        if not sym:
+            continue
+        reconciled.add(key[1:] if key.startswith("__Z") else key)
+    return reconciled
 
 
 def _has_export_obligation(fn: Function) -> bool:

--- a/abicheck/buildsource/crosscheck.py
+++ b/abicheck/buildsource/crosscheck.py
@@ -323,7 +323,7 @@ def _check_public_not_exported(
     # Two-way reconciliation (ADR-035 D4): exempt decls the L4 linker already tied
     # to an export under a variant spelling (ctor clone / Mach-O / demangle drift),
     # so the check does not double-report a symbol that is genuinely exported.
-    reconciled = _l4_reconciled_symbols(snapshot)
+    reconciled = _l4_reconciled_symbols(snapshot, exported)
 
     findings: list[Change] = []
     for fn in snapshot.functions:
@@ -1230,20 +1230,27 @@ def _exported_symbol_names(snapshot: AbiSnapshot) -> set[str] | None:
     return None
 
 
-def _l4_reconciled_symbols(snapshot: AbiSnapshot) -> set[str]:
-    """Decl mangled names the L4 source-linker already tied to a real export.
+def _l4_reconciled_symbols(snapshot: AbiSnapshot, exported: set[str]) -> set[str]:
+    """Decl mangled names the L4 source-linker tied to a *currently-exported* symbol.
 
     ``public_not_exported`` compares each public-header decl's mangled name against
     the *literal* binary export table. But the L4 source-ABI linker
     (``source_link``) reconciles spellings the table lists under a *variant*: a
     ctor/dtor ABI clone (a decl mangled ``C1``/``C4`` whose binary lists only
     ``C2``), a Mach-O leading underscore, or an ABI-tag / substitution drift caught
-    by demangled identity. A decl the linker already resolved to an export *is*
-    exported, so flagging it as missing would be a two-way-reconciliation false
-    positive. This returns those decl mangled names — Mach-O-normalized to the L2
-    ``Function.mangled`` spelling — so the check can exempt them. Empty when no L4
-    surface is attached, so it can only *suppress* a false positive, never add one
-    (ADR-028 D3: L4 evidence explains/scopes, never invents a break).
+    by demangled identity. A decl the linker resolved to an export *is* exported,
+    so flagging it as missing would be a two-way-reconciliation false positive.
+
+    Crucially, the mapping is trusted **only when the current snapshot still
+    exports the mapped symbol**: a ``merge`` pack whose ``exported_symbols`` were
+    pre-set is *not* relinked, so its L4 mapping can reference an older/different
+    binary — a symbol the current binary no longer exports must still be flagged or
+    a consumer hits an undefined symbol (Codex review). ``sym`` is checked against
+    the current default export set both directly (ELF) and with one leading
+    underscore stripped (the Mach-O export table drops one, e.g. ``__ZN…`` →
+    ``_ZN…``). Returns the decl mangled names (Mach-O-normalized to the L2
+    ``Function.mangled`` spelling). Empty when no L4 surface is attached, so it can
+    only *suppress* a false positive, never add one (ADR-028 D3).
     """
     pack = snapshot.build_source
     surface = pack.source_abi if pack is not None else None
@@ -1254,7 +1261,12 @@ def _l4_reconciled_symbols(snapshot: AbiSnapshot) -> set[str]:
     for key, sym in mapping.items():
         if not sym:
             continue
-        reconciled.add(key[1:] if key.startswith("__Z") else key)
+        # The mapped symbol must be in the CURRENT default export table (directly,
+        # or with the Mach-O single leading underscore stripped as
+        # `_exported_symbol_names` does) — otherwise the mapping is stale evidence
+        # from another binary and must not suppress the finding.
+        if sym in exported or (sym.startswith("_") and sym[1:] in exported):
+            reconciled.add(key[1:] if key.startswith("__Z") else key)
     return reconciled
 
 

--- a/abicheck/buildsource/source_abi.py
+++ b/abicheck/buildsource/source_abi.py
@@ -376,6 +376,9 @@ class SourceAbiSurface:
                 "public_header_to_target": dict(
                     self.mappings.get("public_header_to_target", {})
                 ),
+                "synthesized_symbol_to_owner": dict(
+                    self.mappings.get("synthesized_symbol_to_owner", {})
+                ),
             },
             "odr_conflicts": list(self.odr_conflicts),
             "unmatched": {k: list(v) for k, v in self.unmatched.items()},
@@ -407,6 +410,9 @@ class SourceAbiSurface:
             ),
             "public_header_to_target": dict(
                 mappings_raw.get("public_header_to_target", {})
+            ),
+            "synthesized_symbol_to_owner": dict(
+                mappings_raw.get("synthesized_symbol_to_owner", {})
             ),
         }
         unmatched_raw = d.get("unmatched", {})

--- a/abicheck/buildsource/source_abi.py
+++ b/abicheck/buildsource/source_abi.py
@@ -339,6 +339,7 @@ class SourceAbiSurface:
             "source_decl_to_binary_symbol": {},
             "source_type_to_debug_type": {},
             "public_header_to_target": {},
+            "synthesized_symbol_to_owner": {},
         }
     )
     odr_conflicts: list[dict[str, Any]] = field(default_factory=list)

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -370,6 +370,66 @@ def _strip_call_signature(name: str) -> str:
     return name.strip()
 
 
+def _thunk_target_mangled(symbol: str) -> str | None:
+    """Extract the underlying target symbol a thunk adjusts to, or ``None``.
+
+    Itanium thunk special names embed the full mangling of the function they
+    forward to after one or two ``<call-offset>`` fields:
+
+      * ``_ZTh<nv-offset>_<encoding>``          non-virtual (``h``)
+      * ``_ZTv<v-offset>_<vcall-offset>_<encoding>``  virtual (``v``)
+      * ``_ZTc<call-offset><call-offset><encoding>``  covariant (``c``)
+
+    where a ``<call-offset>`` is ``h<number>_`` or ``v<number>_<number>_`` and a
+    ``<number>`` is ``[n]<digits>``. Returning ``_Z<encoding>`` (Mach-O-normalized
+    in) yields the *overload-specific* target symbol, so a thunk is attributed to
+    the exact overload it forwards to rather than any same-named decl (Codex
+    review). Best-effort: ``None`` on any shape it doesn't recognize.
+    """
+    s = _norm_itanium(symbol)
+    if not s.startswith("_ZT"):
+        return None
+    n = len(s)
+    i = 3
+    if i >= n or s[i] not in "hvc":
+        return None
+    kind = s[i]
+
+    def read_number(j: int) -> int | None:
+        if j < n and s[j] == "n":
+            j += 1
+        k = j
+        while k < n and s[k].isdigit():
+            k += 1
+        return k if k > j else None
+
+    def read_call_offset(j: int) -> int | None:
+        # h <number> _   |   v <number> _ <number> _
+        if j >= n or s[j] not in "hv":
+            return None
+        virtual = s[j] == "v"
+        j2 = read_number(j + 1)
+        if j2 is None or j2 >= n or s[j2] != "_":
+            return None
+        j2 += 1
+        if virtual:
+            j3 = read_number(j2)
+            if j3 is None or j3 >= n or s[j3] != "_":
+                return None
+            j2 = j3 + 1
+        return j2
+
+    if kind == "c":  # covariant: two call-offsets
+        j = read_call_offset(i + 1)
+        if j is not None:
+            j = read_call_offset(j)
+    else:  # h / v begin their own call-offset at i
+        j = read_call_offset(i)
+    if j is None or j >= n:
+        return None
+    return "_Z" + s[j:]
+
+
 def _synthesized_target(demangled: str) -> tuple[str, str, str] | None:
     """Parse a demangled synthesized symbol into ``(kind, target, owner_kind)``.
 
@@ -409,6 +469,14 @@ def _attribute_synthesized_exports(
     func_names = {
         d.qualified_name for d in surface.reachable_declarations if d.qualified_name
     }
+    # Overload-specific index: a decl's real mangled name → its qualified name, so a
+    # thunk is attributed to the EXACT overload it forwards to (Codex review). Keyed
+    # Mach-O-normalized to line up with `_thunk_target_mangled`'s `_Z…` output.
+    mangled_to_qname = {
+        _norm_itanium(d.mangled_name): (d.qualified_name or d.mangled_name)
+        for d in surface.reachable_declarations
+        if d.mangled_name
+    }
 
     def _owner_present(name: str, public: set[str]) -> bool:
         # Exact match, OR a base match ONLY when the *unspecialized* name is
@@ -436,7 +504,17 @@ def _attribute_synthesized_exports(
         if owner == "type":
             if _owner_present(target, type_names):
                 attributed[sym] = (kind, target)
-        else:  # func — cut the parameter list, match the qualified name
+        elif kind == "thunk":
+            # A thunk carries the FULL mangling of the function it forwards to, so
+            # attribute to the exact overload rather than any same-named decl: a
+            # thunk for `D::foo(double)` (absent from the surface) must NOT be
+            # attributed to a public `D::foo(int)` (Codex review). Fall through to
+            # no attribution when the target overload is not a public decl.
+            tgt = _thunk_target_mangled(sym)
+            qn = mangled_to_qname.get(tgt) if tgt else None
+            if qn is not None:
+                attributed[sym] = (kind, qn)
+        else:  # guard variable — attribute to the enclosing function by name
             fname = _strip_call_signature(target)
             if _owner_present(fname, func_names):
                 attributed[sym] = (kind, fname)

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -342,6 +342,34 @@ _SYNTHESIZED_PREFIXES: tuple[tuple[str, str, str], ...] = (
 )
 
 
+def _strip_call_signature(name: str) -> str:
+    """Drop a demangled function's trailing parameter list, keeping its name.
+
+    ``ns::Widget::foo()`` → ``ns::Widget::foo``; ``ns::f(int, char)`` → ``ns::f``.
+    A naive ``split("(", 1)[0]`` would turn ``D::operator()()`` into ``D::operator``
+    — orphaning call-operator (functor) thunks, whose owning decl is spelled
+    ``D::operator()`` (Codex review). Instead the *trailing* balanced parenthesis
+    group (the parameter list) is removed by matching the final ``)`` back to its
+    opener right-to-left, so the ``()`` that is part of ``operator()`` is preserved.
+    Best-effort: a name with no ``)`` is returned stripped of surrounding space.
+    """
+    close = name.rfind(")")
+    if close == -1:
+        return name.strip()
+    depth = 0
+    i = close
+    while i >= 0:
+        c = name[i]
+        if c == ")":
+            depth += 1
+        elif c == "(":
+            depth -= 1
+            if depth == 0:
+                return name[:i].strip()
+        i -= 1
+    return name.strip()
+
+
 def _synthesized_target(demangled: str) -> tuple[str, str, str] | None:
     """Parse a demangled synthesized symbol into ``(kind, target, owner_kind)``.
 
@@ -408,8 +436,8 @@ def _attribute_synthesized_exports(
         if owner == "type":
             if _owner_present(target, type_names):
                 attributed[sym] = (kind, target)
-        else:  # func — cut the signature, match the qualified name
-            fname = target.split("(", 1)[0].strip()
+        else:  # func — cut the parameter list, match the qualified name
+            fname = _strip_call_signature(target)
             if _owner_present(fname, func_names):
                 attributed[sym] = (kind, fname)
     return attributed

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -330,11 +330,21 @@ def _attribute_synthesized_exports(
     except Exception:  # noqa: BLE001 - attribution is a best-effort enhancement
         return {}
     type_names = {t.qualified_name for t in surface.reachable_types if t.qualified_name}
-    type_bases = {n.split("<", 1)[0] for n in type_names}
     func_names = {
         d.qualified_name for d in surface.reachable_declarations if d.qualified_name
     }
-    func_bases = {n.split("<", 1)[0] for n in func_names}
+
+    def _owner_present(name: str, public: set[str]) -> bool:
+        # Exact match, OR a base match ONLY when the *unspecialized* name is
+        # itself a public entity. A base match derived from another specialization
+        # (e.g. `ns::A<int>` present, `ns::A<char>` not) must NOT attribute the
+        # other specialization's RTTI — that would hide an exported, unchecked
+        # specialization (Codex review). So require the bare base in `public`.
+        if name in public:
+            return True
+        base = name.split("<", 1)[0]
+        return base != name and base in public
+
     attributed: dict[str, tuple[str, str]] = {}
     for sym in candidates:
         try:
@@ -348,13 +358,73 @@ def _attribute_synthesized_exports(
             continue
         kind, target, owner = parsed
         if owner == "type":
-            if target in type_names or target.split("<", 1)[0] in type_bases:
+            if _owner_present(target, type_names):
                 attributed[sym] = (kind, target)
         else:  # func — cut the signature, match the qualified name
             fname = target.split("(", 1)[0].strip()
-            if fname in func_names or fname.split("<", 1)[0] in func_bases:
+            if _owner_present(fname, func_names):
                 attributed[sym] = (kind, fname)
     return attributed
+
+
+def _demangled_rematch(
+    reachable_declarations: list[SourceEntity],
+    mapping: dict[str, str],
+    matched: set[str],
+    exported: set[str],
+) -> dict[str, str]:
+    """Second-tier match by *demangled identity* for decls exact-matching missed.
+
+    A source extractor's mangled name can differ *textually* from the binary's
+    export for the same entity — most commonly a missing/extra ABI tag
+    (``[abi:cxx11]``), a substitution-form difference, or minor vendor mangling
+    drift — so the exact/ctor-fold tiers leave the decl in ``decls_without_symbol``
+    even though the export is right there. This demangles both sides and matches a
+    still-unmatched decl to a still-unmatched export **only when the demangled
+    forms are equal and the export is unique** for that form (so an overload set,
+    whose members demangle distinctly, can never cross-match). Best-effort: a
+    no-op without a demangler. Returns ``{identity: export}`` for the new matches
+    and updates *mapping*/*matched* in place.
+    """
+    unmatched_exports = [e for e in exported if e not in matched]
+    unmatched_decls = [
+        e
+        for e in reachable_declarations
+        if e.identity() and not mapping.get(e.identity()) and e.mangled_name
+    ]
+    if not unmatched_exports or not unmatched_decls:
+        return {}
+    try:
+        from ..demangle import demangle as _demangle
+    except Exception:  # noqa: BLE001 - best-effort second tier
+        return {}
+
+    def _dem(sym: str) -> str | None:
+        try:
+            return _demangle(sym)
+        except Exception:  # noqa: BLE001
+            return None
+
+    # Demangled form → exports; keep only forms that map to exactly one export so
+    # a match is never ambiguous.
+    by_demangled: dict[str, list[str]] = {}
+    for exp_sym in unmatched_exports:
+        exp_dem = _dem(exp_sym)
+        if exp_dem:
+            by_demangled.setdefault(exp_dem, []).append(exp_sym)
+    unique = {d: syms[0] for d, syms in by_demangled.items() if len(syms) == 1}
+    new_matches: dict[str, str] = {}
+    for decl in unmatched_decls:
+        decl_dem = _dem(decl.mangled_name)
+        if not decl_dem:
+            continue
+        exp = unique.get(decl_dem)
+        if exp and exp not in matched:
+            mapping[decl.identity()] = exp
+            matched.add(exp)
+            new_matches[decl.identity()] = exp
+            del unique[decl_dem]  # consume so two decls can't claim the same export
+    return new_matches
 
 
 #: Entity kinds routed to each reachable bucket of the linked surface (D5).
@@ -419,6 +489,14 @@ def link_source_abi(
             _route_entity(entity, surface, state, exported)
 
     surface.roots["public_header_declarations"] = sorted(set(state.public_decl_ids))
+    # Second-tier: rescue decls whose mangled name differs textually from the
+    # export (ABI-tag / substitution drift) via demangled identity.
+    _demangled_rematch(
+        surface.reachable_declarations,
+        state.decl_to_symbol,
+        state.matched_symbols,
+        exported,
+    )
     surface.mappings["source_decl_to_binary_symbol"] = dict(
         sorted(state.decl_to_symbol.items())
     )
@@ -495,6 +573,8 @@ def relink_surface_exports(
             matched.update(variants)
         else:
             mapping.setdefault(key, "")
+    # Second-tier demangled-identity rematch (ABI-tag / substitution drift).
+    _demangled_rematch(surface.reachable_declarations, mapping, matched, exported)
     surface.mappings["source_decl_to_binary_symbol"] = dict(sorted(mapping.items()))
 
     # Attribute compiler-synthesized exports (vtable/typeinfo/thunk/guard) to their

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -26,10 +26,75 @@ Linking is cheap relative to parsing, so it is recomputed rather than cached
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from .source_abi import SourceAbiSurface, SourceAbiTu, SourceEntity
+
+#: C++ Itanium ctor/dtor "ABI clone" tags. The compiler emits *several* object
+#: symbols for one source ctor/dtor — ``C1`` (complete), ``C2`` (base), ``C3``
+#: (allocating); ``D0`` (deleting), ``D1`` (complete), ``D2`` (base) — plus GCC's
+#: non-standard unified ``C4``/``D4`` marker seen in DWARF linkage names. A source
+#: extractor sees ONE ``Decl`` and emits one mangled name (usually ``C1``/``D1``,
+#: or ``C4``/``D4`` from DWARF). An exact-string match therefore attributes only
+#: *one* clone to the declaration and reports the siblings as "exported symbol
+#: with no source decl" — a systematic under-count for every class with exported
+#: ctors/dtors. Folding the tag to a canonical marker lets the single declaration
+#: claim all of its clone symbols (ADR-030 D5 symbol linking).
+_CTOR_DTOR_TAG_RE = re.compile(r"(?<=[A-Za-z])(C[1-4]|D[0-4])E")
+
+
+def _ctor_dtor_canonical(symbol: str) -> str:
+    """Fold C++ ctor/dtor ABI clone tags to a single canonical marker.
+
+    ``_ZN3FooC1Ev``/``_ZN3FooC2Ev``/``_ZN3FooC4Ev`` all fold to the same key, and
+    likewise for the ``D0``/``D1``/``D2``/``D4`` destructor variants. A no-op for
+    any name without such a tag, so non-ctor/dtor symbols keep exact-match
+    semantics and cannot be conflated.
+    """
+    return _CTOR_DTOR_TAG_RE.sub(lambda m: m.group(1)[0] + "@E", symbol)
+
+
+def _build_export_index(exported: set[str]) -> dict[str, list[str]]:
+    """Index ctor/dtor canonical forms → the concrete exported clone symbols.
+
+    Only names whose canonical form *differs* (i.e. actual ctor/dtor symbols) are
+    indexed, so the map stays small and a non-ctor symbol can never collide into
+    it — those still match exactly against ``exported``.
+    """
+    index: dict[str, list[str]] = {}
+    for sym in exported:
+        canon = _ctor_dtor_canonical(sym)
+        if canon != sym:
+            index.setdefault(canon, []).append(sym)
+    return index
+
+
+def _match_export(
+    export_sym: str, exported: set[str], ctor_dtor_index: dict[str, list[str]]
+) -> tuple[str, list[str]]:
+    """Resolve a decl's export name to ``(primary_symbol, all_clone_symbols)``.
+
+    Exact match wins; its ctor/dtor siblings (if any were also exported) are
+    folded in so none is orphaned. When there is no exact hit but the name is a
+    ctor/dtor, it is matched against the canonical index so a decl mangled as
+    ``C1``/``D1`` (or the DWARF ``C4``/``D4``) still claims the ``C2``/``D2``/…
+    clones the binary actually exports. Returns ``("", [])`` when nothing matches.
+    """
+    if not export_sym:
+        return "", []
+    canon = _ctor_dtor_canonical(export_sym)
+    clones = ctor_dtor_index.get(canon)
+    if export_sym in exported:
+        if clones:
+            return export_sym, sorted(set(clones) | {export_sym})
+        return export_sym, [export_sym]
+    if clones:
+        variants = sorted(clones)
+        return variants[0], variants
+    return "", []
+
 
 #: Entity kinds routed to each reachable bucket of the linked surface (D5).
 _TYPE_KINDS = frozenset({"record", "enum", "typedef", "union"})
@@ -80,6 +145,7 @@ def link_source_abi(
     surface.roots["forced_public"] = sorted(forced)
 
     state = _LinkState()
+    state.export_index = _build_export_index(exported)
     for tu in tus:
         for header in tu.public_header_roots:
             surface.mappings["public_header_to_target"][header] = (
@@ -132,6 +198,7 @@ def relink_surface_exports(
     """
     exported = set(exported_symbols)
     surface.roots["exported_symbols"] = sorted(exported)
+    export_index = _build_export_index(exported)
     mapping: dict[str, str] = {}
     matched: set[str] = set()
     # identity -> display name, so the recomputed decls_without_symbol carries the
@@ -143,9 +210,10 @@ def relink_surface_exports(
             continue
         identity_to_qname[key] = entity.qualified_name or key
         export_sym = entity.mangled_name or entity.qualified_name
-        if export_sym and export_sym in exported:
-            mapping[key] = export_sym
-            matched.add(export_sym)
+        primary, variants = _match_export(export_sym, exported, export_index)
+        if primary:
+            mapping[key] = primary
+            matched.update(variants)
         else:
             mapping.setdefault(key, "")
     surface.mappings["source_decl_to_binary_symbol"] = dict(sorted(mapping.items()))
@@ -181,6 +249,8 @@ class _LinkState:
     odr_conflicts: list[dict[str, str]] = field(default_factory=list)
     public_decl_ids: list[str] = field(default_factory=list)
     matched_symbols: set[str] = field(default_factory=set)
+    #: ctor/dtor canonical form -> exported clone symbols (see _build_export_index)
+    export_index: dict[str, list[str]] = field(default_factory=dict)
 
 
 def _route_entity(
@@ -267,8 +337,9 @@ def _route_declaration(
         return
     state.identity_to_qname[key] = entity.qualified_name or key
     export_sym = entity.mangled_name or entity.qualified_name
-    if export_sym and export_sym in exported:
-        state.decl_to_symbol[key] = export_sym
-        state.matched_symbols.add(export_sym)
+    primary, variants = _match_export(export_sym, exported, state.export_index)
+    if primary:
+        state.decl_to_symbol[key] = primary
+        state.matched_symbols.update(variants)
     else:
         state.decl_to_symbol.setdefault(key, "")

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -63,6 +63,24 @@ def _skip_e_terminated(symbol: str, i: int) -> int:
     i += 1
     while i < n and depth:
         c = symbol[i]
+        if c == "L":
+            # <expr-primary> literal := L <type> <value> E. Its VALUE is raw
+            # digits (a non-type template parameter, e.g. `Fixed<3>` → `Li3E`),
+            # NOT a length-prefixed source-name — so consume the literal to its
+            # own matching E flatly (digits are literal chars here), only
+            # balancing any nested I/N/L in its type. Without this the digit
+            # would be misread as a length and swallow the trailing ctor tag
+            # (Codex review).
+            ldepth = 1
+            i += 1
+            while i < n and ldepth:
+                d = symbol[i]
+                if d in "INL":
+                    ldepth += 1
+                elif d == "E":
+                    ldepth -= 1
+                i += 1
+            continue
         if c.isdigit():  # <source-name> — consume by its declared length
             j = i
             while j < n and symbol[j].isdigit():

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -44,6 +44,39 @@ from .source_abi import SourceAbiSurface, SourceAbiTu, SourceEntity
 _CTOR_DTOR_TAGS = frozenset({"C1", "C2", "C3", "C4", "D0", "D1", "D2", "D4"})
 
 
+def _skip_e_terminated(symbol: str, i: int) -> int:
+    """Return the index just past the ``E`` that closes the ``I``/``N`` at *i*.
+
+    Balances nested ``I`` (template-args) and ``N`` (nested-name) productions and
+    consumes length-prefixed ``<source-name>`` components *wholesale* — so their
+    interior characters (which can include ``I``/``N``/``E``) never miscount.
+    Without this, a nested type inside a template argument (e.g. the
+    ``NSt7__cxx11…E`` in ``std::vector<std::string>``) would close the balance
+    early and the real ctor tag that follows would be missed (Codex review).
+
+    Best-effort: on any unrecognized production it advances one character, so an
+    exotic tail (a non-type-template ``L…E`` literal, say) can only cause a
+    *missed* fold — never a wrong one, preserving the no-false-fold guarantee.
+    """
+    n = len(symbol)
+    depth = 1  # symbol[i] is the opener
+    i += 1
+    while i < n and depth:
+        c = symbol[i]
+        if c.isdigit():  # <source-name> — consume by its declared length
+            j = i
+            while j < n and symbol[j].isdigit():
+                j += 1
+            i = j + int(symbol[i:j])
+            continue
+        if c in "IN":
+            depth += 1
+        elif c == "E":
+            depth -= 1
+        i += 1
+    return i
+
+
 def _ctor_dtor_canonical(symbol: str) -> str:
     """Fold a genuine Itanium ``<ctor-dtor-name>`` to a single canonical marker.
 
@@ -86,17 +119,8 @@ def _ctor_dtor_canonical(symbol: str) -> str:
             i = j + int(symbol[i:j])
             boundary = True
             continue
-        if c == "I":  # <template-args> := I … E (skip balanced)
-            depth = 0
-            while i < n:
-                if symbol[i] == "I":
-                    depth += 1
-                elif symbol[i] == "E":
-                    depth -= 1
-                    if depth == 0:
-                        i += 1
-                        break
-                i += 1
+        if c == "I":  # <template-args> := I … E (skip the balanced, nested run)
+            i = _skip_e_terminated(symbol, i)
             boundary = True
             continue
         if c == "S":  # <substitution> := S_ | S<id>_ | S[abisod]

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -47,16 +47,18 @@ _CTOR_DTOR_TAGS = frozenset({"C1", "C2", "C3", "C4", "D0", "D1", "D2", "D4"})
 def _skip_e_terminated(symbol: str, i: int) -> int:
     """Return the index just past the ``E`` that closes the ``I``/``N`` at *i*.
 
-    Balances nested ``I`` (template-args) and ``N`` (nested-name) productions and
-    consumes length-prefixed ``<source-name>`` components *wholesale* — so their
-    interior characters (which can include ``I``/``N``/``E``) never miscount.
-    Without this, a nested type inside a template argument (e.g. the
-    ``NSt7__cxx11…E`` in ``std::vector<std::string>``) would close the balance
-    early and the real ctor tag that follows would be missed (Codex review).
+    Balances every nested ``E``-terminated production — ``I`` (template-args),
+    ``N`` (nested-name), and ``F`` (function type, e.g. a ``A<void(int)>`` arg
+    mangled ``FviE``) — and consumes length-prefixed ``<source-name>`` components
+    *wholesale* so their interior characters (which can include ``I``/``N``/``F``/
+    ``E``) never miscount. Without this, a nested type inside a template argument
+    (the ``NSt7__cxx11…E`` of ``std::vector<std::string>``, or the ``F…E`` of a
+    function-typed argument) would close the balance early and the real ctor tag
+    that follows would be missed (Codex review).
 
     Best-effort: on any unrecognized production it advances one character, so an
-    exotic tail (a non-type-template ``L…E`` literal, say) can only cause a
-    *missed* fold — never a wrong one, preserving the no-false-fold guarantee.
+    exotic tail can only cause a *missed* fold — never a wrong one, preserving
+    the no-false-fold guarantee.
     """
     n = len(symbol)
     depth = 1  # symbol[i] is the opener
@@ -68,14 +70,14 @@ def _skip_e_terminated(symbol: str, i: int) -> int:
             # digits (a non-type template parameter, e.g. `Fixed<3>` → `Li3E`),
             # NOT a length-prefixed source-name — so consume the literal to its
             # own matching E flatly (digits are literal chars here), only
-            # balancing any nested I/N/L in its type. Without this the digit
+            # balancing any nested I/N/F/L in its type. Without this the digit
             # would be misread as a length and swallow the trailing ctor tag
             # (Codex review).
             ldepth = 1
             i += 1
             while i < n and ldepth:
                 d = symbol[i]
-                if d in "INL":
+                if d in "INFL":
                     ldepth += 1
                 elif d == "E":
                     ldepth -= 1
@@ -87,7 +89,7 @@ def _skip_e_terminated(symbol: str, i: int) -> int:
                 j += 1
             i = j + int(symbol[i:j])
             continue
-        if c in "IN":
+        if c in "INF":
             depth += 1
         elif c == "E":
             depth -= 1
@@ -95,8 +97,67 @@ def _skip_e_terminated(symbol: str, i: int) -> int:
     return i
 
 
+#: Cheap pre-filter: a symbol can only carry a ctor/dtor special name if it holds
+#: one of these substrings. Lets the demangler backstop skip the ~all symbols that
+#: are obviously not ctors/dtors (no fork/parse) before paying for a demangle.
+_CTOR_DTOR_SUBSTR = tuple(t + "E" for t in _CTOR_DTOR_TAGS)
+
+
 def _ctor_dtor_canonical(symbol: str) -> str:
     """Fold a genuine Itanium ``<ctor-dtor-name>`` to a single canonical marker.
+
+    Primary path is the fast, dependency-free structural parser
+    (:func:`_ctor_dtor_structural`). When it cannot fold a symbol that *looks*
+    like it carries a ctor/dtor tag — an exotic Itanium production the hand-parser
+    doesn't model — fall back to a **demangler**-derived key (abicheck's demangler
+    is a full Itanium parser, so it collapses every C1/C2/C3 and D0/D1/D2 clone to
+    the same demangled ``Class::Class()`` / ``Class::~Class()`` form). The backstop
+    is best-effort: if no demangler is available the structural result stands (a
+    safe *missed* fold, never a wrong one). Both the export index and the decl
+    side run through this one function, so their keys stay in the same space.
+    """
+    folded = _ctor_dtor_structural(symbol)
+    if folded != symbol:
+        return folded
+    if any(sub in symbol for sub in _CTOR_DTOR_SUBSTR):
+        return _ctor_dtor_demangle_fallback(symbol)
+    return symbol
+
+
+def _ctor_dtor_demangle_fallback(symbol: str) -> str:
+    """Demangler-derived canonical key for a ctor/dtor the parser couldn't fold.
+
+    Returns a ``"ctordtor:<demangled>"`` key when *symbol* demangles to a
+    constructor (``Name::Name(``) or destructor (``Name::~Name(``) — the demangled
+    form already omits the C1/C2/D0/D1 variant number, so every clone maps to one
+    key. Returns *symbol* unchanged when a demangler is unavailable or the symbol
+    is not actually a ctor/dtor, keeping exact-match semantics.
+    """
+    try:
+        from ..demangle import demangle as _demangle
+
+        demangled = _demangle(symbol)
+    except Exception:  # noqa: BLE001 - demangling is a best-effort backstop
+        return symbol
+    if not demangled or "(" not in demangled:
+        return symbol
+    qualified = demangled.split("(", 1)[0].rstrip()
+    # Strip a trailing cv/ref qualifier list is unnecessary here (we cut at "(").
+    parts = qualified.rsplit("::", 1)
+    if len(parts) != 2:
+        return symbol
+    scope, name = parts
+    cls = scope.rsplit("::", 1)[-1]
+    # Constructor: leaf name == class name (ignoring template args on either).
+    base_cls = cls.split("<", 1)[0]
+    base_name = name.split("<", 1)[0]
+    if base_name == base_cls or base_name == "~" + base_cls:
+        return f"ctordtor:{qualified}"
+    return symbol
+
+
+def _ctor_dtor_structural(symbol: str) -> str:
+    """Fold a genuine Itanium ``<ctor-dtor-name>`` by structural parse (no deps).
 
     ``_ZN3FooC1Ev``/``_ZN3FooC2Ev``/``_ZN3FooC4Ev`` fold to one key (and likewise
     the ``D0``/``D1``/``D2``/``D4`` destructor variants), so a single source
@@ -113,10 +174,19 @@ def _ctor_dtor_canonical(symbol: str) -> str:
     — including any ``C1``/``D0`` — never reach the tag test. A no-op for any name
     without a genuine tag, so non-ctor/dtor symbols keep exact-match semantics.
     """
+    # Mach-O/Darwin prefixes every Itanium symbol with an extra leading
+    # underscore (`__ZN1AC1Ev`); strip it for parsing and restore it on the
+    # folded result so the clone index keys match on that platform too (Codex
+    # review). Parse a local ``body`` and offset all indexing into it.
+    prefix = ""
+    body = symbol
+    if body[:3] == "__Z":
+        prefix, body = "_", body[1:]
     # A ctor/dtor is always a class member → a nested name. Non-nested symbols
     # (plain ``_Z…``, vtables/typeinfo ``_ZTV``/``_ZTI``, data) have none.
-    if not symbol.startswith("_ZN"):
+    if not body.startswith("_ZN"):
         return symbol
+    symbol = body
     i, n = 3, len(symbol)
     # Leading CV-/ref-qualifiers on the implicit object parameter.
     while i < n and symbol[i] in "rVKRO":
@@ -152,12 +222,12 @@ def _ctor_dtor_canonical(symbol: str) -> str:
             boundary = True
             continue
         if boundary and c in "CD" and symbol[i : i + 2] in _CTOR_DTOR_TAGS:
-            return symbol[:i] + c + "@" + symbol[i + 2 :]
+            return prefix + symbol[:i] + c + "@" + symbol[i + 2 :]
         # Unknown production: advance without claiming a boundary, so a later
         # C1/D0 reached only by char-skip is never mistaken for a special name.
         boundary = False
         i += 1
-    return symbol
+    return prefix + symbol
 
 
 def _build_export_index(exported: set[str]) -> dict[str, list[str]]:
@@ -198,6 +268,93 @@ def _match_export(
         variants = sorted(clones)
         return variants[0], variants
     return "", []
+
+
+def _is_synthesized_symbol(symbol: str) -> bool:
+    """Whether *symbol* is a compiler-*synthesized* export that belongs to a type
+    or a function rather than a free declaration — a vtable/VTT/typeinfo/typeinfo-
+    name/thunk (``_ZT…``) or a guard variable (``_ZGV…``), optionally Mach-O
+    ``__``-prefixed. These never match a source decl by name, so they must be
+    attributed to their owner or they orphan into ``symbols_without_decl``."""
+    s = symbol[1:] if symbol.startswith("__Z") else symbol
+    return s.startswith("_ZT") or s.startswith("_ZGV")
+
+
+#: demangled-prefix → (finding kind, owner is a "type" or "func").
+_SYNTHESIZED_PREFIXES: tuple[tuple[str, str, str], ...] = (
+    ("vtable for ", "vtable", "type"),
+    ("VTT for ", "VTT", "type"),
+    ("construction vtable for ", "construction-vtable", "type"),
+    ("typeinfo for ", "typeinfo", "type"),
+    ("typeinfo name for ", "typeinfo-name", "type"),
+    ("non-virtual thunk to ", "thunk", "func"),
+    ("virtual thunk to ", "thunk", "func"),
+    ("covariant return thunk to ", "thunk", "func"),
+    ("guard variable for ", "guard", "func"),
+)
+
+
+def _synthesized_target(demangled: str) -> tuple[str, str, str] | None:
+    """Parse a demangled synthesized symbol into ``(kind, target, owner_kind)``.
+
+    ``"vtable for ns::Widget"`` → ``("vtable", "ns::Widget", "type")``;
+    ``"non-virtual thunk to ns::Widget::f()"`` → ``("thunk", "ns::Widget::f()",
+    "func")``. Returns ``None`` for anything not recognized.
+    """
+    for prefix, kind, owner in _SYNTHESIZED_PREFIXES:
+        if demangled.startswith(prefix):
+            return kind, demangled[len(prefix) :].strip(), owner
+    return None
+
+
+def _attribute_synthesized_exports(
+    surface: SourceAbiSurface, unmatched: set[str]
+) -> dict[str, tuple[str, str]]:
+    """Attribute exported vtable/typeinfo/RTTI/thunk/guard symbols to the public
+    type or function they belong to (ADR-030 D5 symbol linking).
+
+    Such symbols are emitted *for* a type (`_ZTV`/`_ZTI`/`_ZTS`/`_ZTT`) or a
+    method (thunks, guard variables), never as a free declaration, so exact-name
+    matching always left them in ``symbols_without_decl`` — inflating the
+    "exported but no source decl" count for every polymorphic public class. This
+    demangles each still-unmatched synthesized symbol and, when its owning type or
+    function is present on the public surface, records it as attributed. Best
+    effort: a no-op when no demangler is available (the orphans simply remain, as
+    before), so it can only *improve* matching, never regress it.
+    """
+    candidates = [s for s in unmatched if _is_synthesized_symbol(s)]
+    if not candidates:
+        return {}
+    try:
+        from ..demangle import demangle as _demangle
+    except Exception:  # noqa: BLE001 - attribution is a best-effort enhancement
+        return {}
+    type_names = {t.qualified_name for t in surface.reachable_types if t.qualified_name}
+    type_bases = {n.split("<", 1)[0] for n in type_names}
+    func_names = {
+        d.qualified_name for d in surface.reachable_declarations if d.qualified_name
+    }
+    func_bases = {n.split("<", 1)[0] for n in func_names}
+    attributed: dict[str, tuple[str, str]] = {}
+    for sym in candidates:
+        try:
+            demangled = _demangle(sym)
+        except Exception:  # noqa: BLE001
+            continue
+        if not demangled:
+            continue
+        parsed = _synthesized_target(demangled)
+        if parsed is None:
+            continue
+        kind, target, owner = parsed
+        if owner == "type":
+            if target in type_names or target.split("<", 1)[0] in type_bases:
+                attributed[sym] = (kind, target)
+        else:  # func — cut the signature, match the qualified name
+            fname = target.split("(", 1)[0].strip()
+            if fname in func_names or fname.split("<", 1)[0] in func_bases:
+                attributed[sym] = (kind, fname)
+    return attributed
 
 
 #: Entity kinds routed to each reachable bucket of the linked surface (D5).
@@ -266,7 +423,21 @@ def link_source_abi(
         sorted(state.decl_to_symbol.items())
     )
     surface.odr_conflicts = state.odr_conflicts
-    surface.unmatched["symbols_without_decl"] = sorted(exported - state.matched_symbols)
+
+    # Attribute compiler-synthesized exports (vtable/typeinfo/thunk/guard) to their
+    # owning public type/function so they are not miscounted as "exported but no
+    # source decl" (ADR-030 D5). These are matched to a *type/function*, not a
+    # free decl, so they are tracked separately from decl matches.
+    decl_matched = set(state.matched_symbols)
+    synthesized = _attribute_synthesized_exports(surface, exported - decl_matched)
+    if synthesized:
+        surface.mappings["synthesized_symbol_to_owner"] = {
+            sym: {"kind": kind, "owner": owner}
+            for sym, (kind, owner) in sorted(synthesized.items())
+        }
+    all_matched = decl_matched | set(synthesized)
+
+    surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)
     surface.unmatched["decls_without_symbol"] = sorted(
         state.identity_to_qname.get(key, key)
         for key, sym in state.decl_to_symbol.items()
@@ -279,7 +450,11 @@ def link_source_abi(
         "reachable_templates": len(surface.reachable_templates),
         "reachable_inline_bodies": len(surface.reachable_inline_bodies),
         "exported_symbols": len(exported),
-        "matched_symbols": len(state.matched_symbols),
+        # Honest breakdown of the export denominator (ADR-030 D5): decl matches vs
+        # synthesized (RTTI/vtable/thunk) attributions vs the genuine remainder.
+        "matched_symbols": len(decl_matched),
+        "synthesized_symbols_matched": len(synthesized),
+        "unmatched_symbols": len(exported) - len(all_matched),
         "odr_conflicts": len(state.odr_conflicts),
     }
     return surface
@@ -321,7 +496,20 @@ def relink_surface_exports(
         else:
             mapping.setdefault(key, "")
     surface.mappings["source_decl_to_binary_symbol"] = dict(sorted(mapping.items()))
-    surface.unmatched["symbols_without_decl"] = sorted(exported - matched)
+
+    # Attribute compiler-synthesized exports (vtable/typeinfo/thunk/guard) to their
+    # owning public type/function — same as link_source_abi, so the merge/relink
+    # flow (used by `merge` on a plugin/wrapper pack) reports the same honest
+    # counts as `dump <binary> --sources`.
+    synthesized = _attribute_synthesized_exports(surface, exported - matched)
+    if synthesized:
+        surface.mappings["synthesized_symbol_to_owner"] = {
+            sym: {"kind": kind, "owner": owner}
+            for sym, (kind, owner) in sorted(synthesized.items())
+        }
+    all_matched = matched | set(synthesized)
+
+    surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)
     # Recompute decls_without_symbol from the new mapping: declarations that now
     # resolve to an export must drop out of the unmatched list, or the merged
     # surface would serialize contradictory facts (mapping says foo->foo while
@@ -332,6 +520,8 @@ def relink_surface_exports(
     if isinstance(surface.coverage, dict):
         surface.coverage["exported_symbols"] = len(exported)
         surface.coverage["matched_symbols"] = len(matched)
+        surface.coverage["synthesized_symbols_matched"] = len(synthesized)
+        surface.coverage["unmatched_symbols"] = len(exported) - len(all_matched)
     return surface
 
 

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -175,17 +175,23 @@ def _ctor_dtor_structural(symbol: str) -> str:
     without a genuine tag, so non-ctor/dtor symbols keep exact-match semantics.
     """
     # Mach-O/Darwin prefixes every Itanium symbol with an extra leading
-    # underscore (`__ZN1AC1Ev`); strip it for parsing and restore it on the
-    # folded result so the clone index keys match on that platform too (Codex
-    # review). Parse a local ``body`` and offset all indexing into it.
-    prefix = ""
+    # underscore (`__ZN1AC1Ev`). NORMALIZE it away for the canonical key — do NOT
+    # restore it — because the two producers spell it differently: the binary
+    # export table (`macho_metadata`) already strips one underscore (`_ZN…`) while
+    # the Clang plugin emits the raw `__ZN…` mangled name. Restoring the prefix
+    # would keep those in different key spaces and the clones would never match on
+    # macOS Flow-C (Codex review). A folded ctor/dtor key is only a *grouping*
+    # key, so normalizing the spelling is safe; the actual matched symbols keep
+    # their real names. Non-ctor symbols still fall through to `return original`
+    # (their original spelling) for exact matching.
+    original = symbol
     body = symbol
     if body[:3] == "__Z":
-        prefix, body = "_", body[1:]
+        body = body[1:]
     # A ctor/dtor is always a class member → a nested name. Non-nested symbols
     # (plain ``_Z…``, vtables/typeinfo ``_ZTV``/``_ZTI``, data) have none.
     if not body.startswith("_ZN"):
-        return symbol
+        return original
     symbol = body
     i, n = 3, len(symbol)
     # Leading CV-/ref-qualifiers on the implicit object parameter.
@@ -222,12 +228,15 @@ def _ctor_dtor_structural(symbol: str) -> str:
             boundary = True
             continue
         if boundary and c in "CD" and symbol[i : i + 2] in _CTOR_DTOR_TAGS:
-            return prefix + symbol[:i] + c + "@" + symbol[i + 2 :]
+            # Normalized (prefix-stripped) canonical key — unifies `__ZN`/`_ZN`.
+            return symbol[:i] + c + "@" + symbol[i + 2 :]
         # Unknown production: advance without claiming a boundary, so a later
         # C1/D0 reached only by char-skip is never mistaken for a special name.
         boundary = False
         i += 1
-    return prefix + symbol
+    # No fold: return the ORIGINAL symbol (with its prefix) so non-ctor names keep
+    # exact-match semantics against the export set.
+    return original
 
 
 def _build_export_index(exported: set[str]) -> dict[str, list[str]]:

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -136,7 +136,8 @@ def _ctor_dtor_demangle_fallback(symbol: str) -> str:
     try:
         from ..demangle import demangle as _demangle
 
-        demangled = _demangle(symbol)
+        # Normalize the Mach-O `__Z` prefix first (the demangler only accepts `_Z`).
+        demangled = _demangle(_norm_itanium(symbol))
     except Exception:  # noqa: BLE001 - demangling is a best-effort backstop
         return symbol
     if not demangled or "(" not in demangled:
@@ -239,12 +240,27 @@ def _ctor_dtor_structural(symbol: str) -> str:
     return original
 
 
+def _norm_itanium(symbol: str) -> str:
+    """Strip the Mach-O leading underscore so ``__ZN…`` and ``_ZN…`` share a key.
+
+    Mach-O/Darwin prefixes every Itanium symbol with an extra ``_``, so the Clang
+    facts plugin records a method as ``__ZN1A3fooEv`` while ``macho_metadata``
+    strips one underscore off the export table to ``_ZN1A3fooEv``. Ordinary (non
+    ctor/dtor) names take the no-fold path in :func:`_ctor_dtor_structural` and are
+    returned verbatim, so without normalizing here the two spellings would never
+    exact-match and every plain C++ API on macOS would land in the unmatched sets
+    (Codex review). Only the *matching key* is normalized; the real exported name
+    is preserved so ``symbols_without_decl`` still subtracts the true spelling.
+    """
+    return symbol[1:] if symbol.startswith("__Z") else symbol
+
+
 def _build_export_index(exported: set[str]) -> dict[str, list[str]]:
     """Index ctor/dtor canonical forms → the concrete exported clone symbols.
 
     Only names whose canonical form *differs* (i.e. actual ctor/dtor symbols) are
     indexed, so the map stays small and a non-ctor symbol can never collide into
-    it — those still match exactly against ``exported``.
+    it — those still match via the normalized exact index (:func:`_build_exact_index`).
     """
     index: dict[str, list[str]] = {}
     for sym in exported:
@@ -254,25 +270,48 @@ def _build_export_index(exported: set[str]) -> dict[str, list[str]]:
     return index
 
 
+def _build_exact_index(exported: set[str]) -> dict[str, str]:
+    """Map each export's Mach-O-normalized key → its real (as-exported) spelling.
+
+    So an ordinary decl the plugin recorded as ``__ZN1A3fooEv`` resolves to the
+    binary's ``_ZN1A3fooEv`` at the exact tier. Iterated in sorted order and the
+    canonical ``_Z`` spelling wins any (practically impossible) collision where a
+    binary lists both ``_ZN…`` and ``__ZN…`` for one entity, so the result is
+    deterministic and returns a name that is genuinely in ``exported``.
+    """
+    index: dict[str, str] = {}
+    for sym in sorted(exported):
+        norm = _norm_itanium(sym)
+        if norm not in index or sym == norm:
+            index[norm] = sym
+    return index
+
+
 def _match_export(
-    export_sym: str, exported: set[str], ctor_dtor_index: dict[str, list[str]]
+    export_sym: str,
+    exported: set[str],
+    ctor_dtor_index: dict[str, list[str]],
+    exact_index: dict[str, str],
 ) -> tuple[str, list[str]]:
     """Resolve a decl's export name to ``(primary_symbol, all_clone_symbols)``.
 
-    Exact match wins; its ctor/dtor siblings (if any were also exported) are
-    folded in so none is orphaned. When there is no exact hit but the name is a
-    ctor/dtor, it is matched against the canonical index so a decl mangled as
-    ``C1``/``D1`` (or the DWARF ``C4``/``D4``) still claims the ``C2``/``D2``/…
-    clones the binary actually exports. Returns ``("", [])`` when nothing matches.
+    Exact match (via the Mach-O-normalized :func:`_build_exact_index`, so a
+    plugin-emitted ``__ZN…`` name resolves to the binary's ``_ZN…`` export) wins;
+    its ctor/dtor siblings (if any were also exported) are folded in so none is
+    orphaned. When there is no exact hit but the name is a ctor/dtor, it is matched
+    against the canonical index so a decl mangled as ``C1``/``D1`` (or the DWARF
+    ``C4``/``D4``) still claims the ``C2``/``D2``/… clones the binary actually
+    exports. Returns ``("", [])`` when nothing matches.
     """
     if not export_sym:
         return "", []
     canon = _ctor_dtor_canonical(export_sym)
     clones = ctor_dtor_index.get(canon)
-    if export_sym in exported:
+    real = exact_index.get(_norm_itanium(export_sym))
+    if real is not None:
         if clones:
-            return export_sym, sorted(set(clones) | {export_sym})
-        return export_sym, [export_sym]
+            return real, sorted(set(clones) | {real})
+        return real, [real]
     if clones:
         variants = sorted(clones)
         return variants[0], variants
@@ -409,8 +448,11 @@ def _demangled_rematch(
         return {}
 
     def _dem(sym: str) -> str | None:
+        # Normalize the Mach-O leading underscore first: the shared demangler only
+        # accepts `_Z…`, so a raw `__ZN…` plugin name would otherwise fail to
+        # demangle and never rematch (Codex review).
         try:
-            return _demangle(sym)
+            return _demangle(_norm_itanium(sym))
         except Exception:  # noqa: BLE001
             return None
 
@@ -486,6 +528,7 @@ def link_source_abi(
 
     state = _LinkState()
     state.export_index = _build_export_index(exported)
+    state.exact_index = _build_exact_index(exported)
     for tu in tus:
         for header in tu.public_header_roots:
             surface.mappings["public_header_to_target"][header] = (
@@ -565,6 +608,7 @@ def relink_surface_exports(
     exported = set(exported_symbols)
     surface.roots["exported_symbols"] = sorted(exported)
     export_index = _build_export_index(exported)
+    exact_index = _build_exact_index(exported)
     mapping: dict[str, str] = {}
     matched: set[str] = set()
     # identity -> display name, so the recomputed decls_without_symbol carries the
@@ -576,7 +620,9 @@ def relink_surface_exports(
             continue
         identity_to_qname[key] = entity.qualified_name or key
         export_sym = entity.mangled_name or entity.qualified_name
-        primary, variants = _match_export(export_sym, exported, export_index)
+        primary, variants = _match_export(
+            export_sym, exported, export_index, exact_index
+        )
         if primary:
             mapping[key] = primary
             matched.update(variants)
@@ -591,11 +637,16 @@ def relink_surface_exports(
     # flow (used by `merge` on a plugin/wrapper pack) reports the same honest
     # counts as `dump <binary> --sources`.
     synthesized = _attribute_synthesized_exports(surface, exported - matched)
-    if synthesized:
-        surface.mappings["synthesized_symbol_to_owner"] = {
-            sym: {"kind": kind, "owner": owner}
-            for sym, (kind, owner) in sorted(synthesized.items())
-        }
+    # Assign UNCONDITIONALLY (empty dict when nothing was attributed): a relink runs
+    # against a possibly different export set, so a surface that previously recorded
+    # synthesized owners but has none under the new exports must have the stale map
+    # cleared — else the serialized L4 surface keeps claiming ownership of vtables/
+    # typeinfo the new binary never exports, contradicting the recomputed coverage
+    # and symbols_without_decl (Codex review).
+    surface.mappings["synthesized_symbol_to_owner"] = {
+        sym: {"kind": kind, "owner": owner}
+        for sym, (kind, owner) in sorted(synthesized.items())
+    }
     all_matched = matched | set(synthesized)
 
     surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)
@@ -634,6 +685,8 @@ class _LinkState:
     matched_symbols: set[str] = field(default_factory=set)
     #: ctor/dtor canonical form -> exported clone symbols (see _build_export_index)
     export_index: dict[str, list[str]] = field(default_factory=dict)
+    #: Mach-O-normalized exact key -> real exported spelling (see _build_exact_index)
+    exact_index: dict[str, str] = field(default_factory=dict)
 
 
 def _route_entity(
@@ -720,7 +773,9 @@ def _route_declaration(
         return
     state.identity_to_qname[key] = entity.qualified_name or key
     export_sym = entity.mangled_name or entity.qualified_name
-    primary, variants = _match_export(export_sym, exported, state.export_index)
+    primary, variants = _match_export(
+        export_sym, exported, state.export_index, state.exact_index
+    )
     if primary:
         state.decl_to_symbol[key] = primary
         state.matched_symbols.update(variants)

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -26,7 +26,6 @@ Linking is cheap relative to parsing, so it is recomputed rather than cached
 
 from __future__ import annotations
 
-import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
@@ -42,18 +41,81 @@ from .source_abi import SourceAbiSurface, SourceAbiTu, SourceEntity
 #: with no source decl" — a systematic under-count for every class with exported
 #: ctors/dtors. Folding the tag to a canonical marker lets the single declaration
 #: claim all of its clone symbols (ADR-030 D5 symbol linking).
-_CTOR_DTOR_TAG_RE = re.compile(r"(?<=[A-Za-z])(C[1-4]|D[0-4])E")
+_CTOR_DTOR_TAGS = frozenset({"C1", "C2", "C3", "C4", "D0", "D1", "D2", "D4"})
 
 
 def _ctor_dtor_canonical(symbol: str) -> str:
-    """Fold C++ ctor/dtor ABI clone tags to a single canonical marker.
+    """Fold a genuine Itanium ``<ctor-dtor-name>`` to a single canonical marker.
 
-    ``_ZN3FooC1Ev``/``_ZN3FooC2Ev``/``_ZN3FooC4Ev`` all fold to the same key, and
-    likewise for the ``D0``/``D1``/``D2``/``D4`` destructor variants. A no-op for
-    any name without such a tag, so non-ctor/dtor symbols keep exact-match
-    semantics and cannot be conflated.
+    ``_ZN3FooC1Ev``/``_ZN3FooC2Ev``/``_ZN3FooC4Ev`` fold to one key (and likewise
+    the ``D0``/``D1``/``D2``/``D4`` destructor variants), so a single source
+    ctor/dtor declaration claims all of its exported ABI clones.
+
+    Only a *genuine* special name is folded — one that sits at a ``<nested-name>``
+    component boundary, right after the class ``<source-name>``. A ``C1``/``D0``
+    that is merely the tail of a length-prefixed **ordinary identifier** (a
+    function literally named ``AC1`` mangles as ``_ZN1N3AC1Ev``) must NOT fold,
+    or two unrelated symbols (``AC1``/``AC2``) would collide and one would be
+    dropped from ``symbols_without_decl`` (Codex review). To tell them apart the
+    nested name is parsed component-by-component: length-prefixed identifiers are
+    consumed *wholesale* (by their declared length), so their interior characters
+    — including any ``C1``/``D0`` — never reach the tag test. A no-op for any name
+    without a genuine tag, so non-ctor/dtor symbols keep exact-match semantics.
     """
-    return _CTOR_DTOR_TAG_RE.sub(lambda m: m.group(1)[0] + "@E", symbol)
+    # A ctor/dtor is always a class member → a nested name. Non-nested symbols
+    # (plain ``_Z…``, vtables/typeinfo ``_ZTV``/``_ZTI``, data) have none.
+    if not symbol.startswith("_ZN"):
+        return symbol
+    i, n = 3, len(symbol)
+    # Leading CV-/ref-qualifiers on the implicit object parameter.
+    while i < n and symbol[i] in "rVKRO":
+        i += 1
+    # ``boundary`` = we are at a clean prefix-component boundary (the previous
+    # token was a fully-consumed source-name / substitution / template-arg list),
+    # so a leading ``C``/``D`` here can only be a ctor/dtor special name — never
+    # the middle of an identifier.
+    boundary = False
+    while i < n:
+        c = symbol[i]
+        if c == "E":  # end of the nested-name
+            break
+        if c.isdigit():  # <source-name> := <len> <identifier> — consume wholesale
+            j = i
+            while j < n and symbol[j].isdigit():
+                j += 1
+            i = j + int(symbol[i:j])
+            boundary = True
+            continue
+        if c == "I":  # <template-args> := I … E (skip balanced)
+            depth = 0
+            while i < n:
+                if symbol[i] == "I":
+                    depth += 1
+                elif symbol[i] == "E":
+                    depth -= 1
+                    if depth == 0:
+                        i += 1
+                        break
+                i += 1
+            boundary = True
+            continue
+        if c == "S":  # <substitution> := S_ | S<id>_ | S[abisod]
+            if i + 1 < n and symbol[i + 1] in "atbsiod":
+                i += 2
+            else:
+                i += 1
+                while i < n and symbol[i] != "_":
+                    i += 1
+                i += 1  # consume the trailing '_'
+            boundary = True
+            continue
+        if boundary and c in "CD" and symbol[i : i + 2] in _CTOR_DTOR_TAGS:
+            return symbol[:i] + c + "@" + symbol[i + 2 :]
+        # Unknown production: advance without claiming a boundary, so a later
+        # C1/D0 reached only by char-skip is never mistaken for a special name.
+        boundary = False
+        i += 1
+    return symbol
 
 
 def _build_export_index(exported: set[str]) -> dict[str, list[str]]:

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -220,8 +220,45 @@ def _merge_attach_combined(
             )
         # Mutating payloads invalidates precomputed artifact digests; clear them.
         combined.manifest.artifacts = []
+    _warn_if_source_surface_empty(combined, base_exports)
     base.build_source = combined
     base.build_source_pack = combined.to_ref(path_hint=str(output))
+
+
+def _warn_if_source_surface_empty(
+    combined: BuildSourcePack, base_exports: tuple[str, ...]
+) -> None:
+    """Project-level ``public-roots`` misconfiguration signal (ADR-038 Caveat A).
+
+    The Clang facts plugin can only detect an empty public surface *per TU*, and
+    a single internal-only TU legitimately produces none — so the per-TU
+    diagnostic is necessarily fuzzy. ``merge`` is the first point that sees the
+    *whole* assembled surface, so it is where the authoritative call can be made:
+    if the binary exports symbols but the folded source surface carries **zero**
+    public entities across every TU, the producer's public-roots almost certainly
+    did not match how the headers resolve (the pack is empty). Emit one clear
+    warning here rather than leaving the user with a silently source-less
+    baseline.
+    """
+    surface = getattr(combined, "source_abi", None)
+    if surface is None or not base_exports:
+        return
+    entities = (
+        len(surface.reachable_declarations)
+        + len(surface.reachable_types)
+        + len(surface.reachable_macros)
+        + len(surface.reachable_templates)
+        + len(surface.reachable_inline_bodies)
+    )
+    if entities == 0:
+        click.echo(
+            "warning: merged source pack carries no public entities though the "
+            f"binary exports {len(base_exports)} symbol(s). The producer's "
+            "public-roots / ABICHECK_CC_HEADERS likely did not match how the "
+            "public headers resolve (verify with `clang -H`); the baseline has no "
+            "L4/L5 source evidence. See docs: user-guide/producing-source-facts.",
+            err=True,
+        )
 
 
 def _merge_print_summary(

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -68,7 +68,20 @@ def _exported_symbols_from_snapshot(snap: AbiSnapshot) -> tuple[str, ...]:
     elf = getattr(snap, "elf", None)
     if elf is not None:
         have_raw_table = True
-        raw |= {s.name for s in getattr(elf, "symbols", ()) if getattr(s, "name", "")}
+        # Only DEFAULT-versioned ELF exports enter the relink set. A name that
+        # exists *solely* as a non-default version alias (`foo@VER` with no
+        # `foo@@VER`) cannot be linked against by an unversioned consumer, so
+        # including it would let the L4 mapping mark a header decl backed only by
+        # such an alias as "exported" — and the crosscheck's two-way reconciliation
+        # would then wrongly suppress the `public_not_exported` finding the consumer
+        # would actually hit as an undefined symbol (Codex review). Mirrors
+        # `crosscheck._exported_symbol_names`. `is_default` is True for unversioned
+        # symbols, so plain (non-versioned) libraries are unaffected.
+        raw |= {
+            s.name
+            for s in getattr(elf, "symbols", ())
+            if getattr(s, "name", "") and getattr(s, "is_default", True)
+        }
     pe = getattr(snap, "pe", None)
     if pe is not None:
         have_raw_table = True

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -48,9 +48,32 @@ def _exported_symbols_from_snapshot(snap: AbiSnapshot) -> tuple[str, ...]:
 
     Used to plumb L0 exports into inline source replay (A1) for the
     ``dump <binary> --sources`` flow. Empty for a source-only snapshot.
+
+    The authoritative export set is the platform **dynamic symbol table**
+    (``elf.symbols`` / ``pe.exports`` / ``macho.exports``), which lists every
+    exported symbol as its raw linker name. The modeled ``functions``/
+    ``variables`` lists are a *narrower*, DWARF-shaped view that (a) may cover
+    only a fraction of the exports and (b) can carry non-ABI ctor/dtor linkage
+    tags (GCC's unified ``C4``/``D4``) that never match the binary's real
+    ``C1``/``C2`` clones. Feeding only those to the linker collapsed symbol
+    matching to a handful of hits (the plugin/``merge`` regression), so union the
+    raw export table in as the source of truth and keep the modeled mangled names
+    as a fallback for backends that expose no raw table.
     """
     syms = {fn.mangled for fn in snap.functions if fn.mangled}
     syms |= {v.mangled for v in snap.variables if getattr(v, "mangled", "")}
+    elf = getattr(snap, "elf", None)
+    if elf is not None:
+        syms |= {s.name for s in getattr(elf, "symbols", ()) if getattr(s, "name", "")}
+    pe = getattr(snap, "pe", None)
+    if pe is not None:
+        syms |= {e.name for e in getattr(pe, "exports", ()) if getattr(e, "name", "")}
+    macho = getattr(snap, "macho", None)
+    if macho is not None:
+        syms |= {
+            e.name for e in getattr(macho, "exports", ()) if getattr(e, "name", "")
+        }
+    syms.discard("")
     return tuple(sorted(syms))
 
 

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -51,28 +51,34 @@ def _exported_symbols_from_snapshot(snap: AbiSnapshot) -> tuple[str, ...]:
 
     The authoritative export set is the platform **dynamic symbol table**
     (``elf.symbols`` / ``pe.exports`` / ``macho.exports``), which lists every
-    exported symbol as its raw linker name. The modeled ``functions``/
-    ``variables`` lists are a *narrower*, DWARF-shaped view that (a) may cover
-    only a fraction of the exports and (b) can carry non-ABI ctor/dtor linkage
-    tags (GCC's unified ``C4``/``D4``) that never match the binary's real
-    ``C1``/``C2`` clones. Feeding only those to the linker collapsed symbol
-    matching to a handful of hits (the plugin/``merge`` regression), so union the
-    raw export table in as the source of truth and keep the modeled mangled names
-    as a fallback for backends that expose no raw table.
+    exported symbol as its raw linker name. When one is present it is used
+    **alone**: the modeled ``functions``/``variables`` lists are a *narrower*,
+    DWARF-shaped view that (a) covers only a fraction of the exports — feeding
+    only those collapsed symbol matching to a handful of hits (the plugin/
+    ``merge`` regression) — and (b) can carry non-ABI ctor/dtor linkage tags
+    (GCC's unified ``C4``/``D4``) that are **not** real exports; unioning them in
+    would let a source decl mangled ``C4`` exact-match a phantom and inflate
+    ``exported_symbols``/``matched_symbols`` with a name the binary never exported
+    (Codex review). The modeled mangled names are therefore only a *fallback* for
+    backends that expose no raw table at all (a source-only snapshot, or a format
+    whose export table did not parse).
     """
-    syms = {fn.mangled for fn in snap.functions if fn.mangled}
-    syms |= {v.mangled for v in snap.variables if getattr(v, "mangled", "")}
+    raw: set[str] = set()
     elf = getattr(snap, "elf", None)
     if elf is not None:
-        syms |= {s.name for s in getattr(elf, "symbols", ()) if getattr(s, "name", "")}
+        raw |= {s.name for s in getattr(elf, "symbols", ()) if getattr(s, "name", "")}
     pe = getattr(snap, "pe", None)
     if pe is not None:
-        syms |= {e.name for e in getattr(pe, "exports", ()) if getattr(e, "name", "")}
+        raw |= {e.name for e in getattr(pe, "exports", ()) if getattr(e, "name", "")}
     macho = getattr(snap, "macho", None)
     if macho is not None:
-        syms |= {
-            e.name for e in getattr(macho, "exports", ()) if getattr(e, "name", "")
-        }
+        raw |= {e.name for e in getattr(macho, "exports", ()) if getattr(e, "name", "")}
+    raw.discard("")
+    if raw:  # a raw dynamic table is authoritative — do not dilute it
+        return tuple(sorted(raw))
+    # No raw export table (source-only / unparsed): fall back to modeled names.
+    syms = {fn.mangled for fn in snap.functions if fn.mangled}
+    syms |= {v.mangled for v in snap.variables if getattr(v, "mangled", "")}
     syms.discard("")
     return tuple(sorted(syms))
 

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -64,19 +64,27 @@ def _exported_symbols_from_snapshot(snap: AbiSnapshot) -> tuple[str, ...]:
     whose export table did not parse).
     """
     raw: set[str] = set()
+    have_raw_table = False
     elf = getattr(snap, "elf", None)
     if elf is not None:
+        have_raw_table = True
         raw |= {s.name for s in getattr(elf, "symbols", ()) if getattr(s, "name", "")}
     pe = getattr(snap, "pe", None)
     if pe is not None:
+        have_raw_table = True
         raw |= {e.name for e in getattr(pe, "exports", ()) if getattr(e, "name", "")}
     macho = getattr(snap, "macho", None)
     if macho is not None:
+        have_raw_table = True
         raw |= {e.name for e in getattr(macho, "exports", ()) if getattr(e, "name", "")}
     raw.discard("")
-    if raw:  # a raw dynamic table is authoritative — do not dilute it
+    if have_raw_table:
+        # A parsed platform table is authoritative EVEN WHEN EMPTY — a hidden-only
+        # library genuinely exports nothing, so its DWARF-modeled `functions` are
+        # *not* exports and must not be relinked as if they were (Codex review).
         return tuple(sorted(raw))
-    # No raw export table (source-only / unparsed): fall back to modeled names.
+    # No platform table parsed at all (a source-only snapshot): the modeled
+    # mangled names are the only available fallback.
     syms = {fn.mangled for fn in snap.functions if fn.mangled}
     syms |= {v.mangled for v in snap.variables if getattr(v, "mangled", "")}
     syms.discard("")

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -781,9 +781,30 @@ bool pathUnderAnyRoot(llvm::StringRef file, const std::vector<std::string> &root
 // surface. Returns absolute-normalized directories, de-duplicated, in search
 // order. The operator can always pass an explicit `public-roots=` to scope the
 // surface precisely; inference only runs when they passed none.
+// Whether `path` is at or below directory `prefix` (both absolute-normalized),
+// checked at a path-component boundary so `/home/proj` does not "contain"
+// `/home/project2`.
+bool pathIsUnder(llvm::StringRef path, llvm::StringRef prefix) {
+  if (prefix.empty() || !path.starts_with(prefix))
+    return false;
+  return path.size() == prefix.size() ||
+         llvm::sys::path::is_separator(path[prefix.size()]);
+}
+
 std::vector<std::string> deriveRootsFromIncludes(const HeaderSearchOptions &hso) {
   std::vector<std::string> roots;
   std::set<std::string> seen;
+  // Restrict inference to PROJECT-LOCAL include dirs: an absolute `-I` outside the
+  // compile's working directory (`/opt/boost/include`, `/usr/include/eigen3`) is a
+  // third-party dependency whose headers must not flood the public surface, so
+  // only dirs at/below the build cwd are inferred (Codex review). In-tree includes
+  // (`-Iinclude`, `./gen`, an absolute path under the build/source tree) are kept.
+  // An out-of-source layout that puts headers elsewhere infers nothing here and
+  // gets the "pass public-roots=" diagnostic instead of a Boost-flooded pack.
+  llvm::SmallString<256> cwd;
+  bool haveCwd = !llvm::sys::fs::current_path(cwd);
+  if (haveCwd)
+    llvm::sys::path::remove_dots(cwd, /*remove_dot_dot=*/true);
   for (const auto &e : hso.UserEntries) {
     if (e.IsFramework)
       continue;
@@ -794,6 +815,8 @@ std::vector<std::string> deriveRootsFromIncludes(const HeaderSearchOptions &hso)
     llvm::SmallString<256> abs(e.Path);
     llvm::sys::fs::make_absolute(abs);
     llvm::sys::path::remove_dots(abs, /*remove_dot_dot=*/true);
+    if (haveCwd && !pathIsUnder(abs, cwd))
+      continue;
     std::string s(abs.str());
     if (seen.insert(s).second)
       roots.push_back(s);
@@ -1467,7 +1490,25 @@ public:
     size_t publicCount = functions.size() + types.size() + templates.size() +
                          inlineBodies.size() + constexprValues.size() +
                          macros.size();
-    if (!Roots.empty() && publicCount == 0 && visitor.rejectedHeaderDecls() > 0) {
+    bool emptyWithRejections =
+        publicCount == 0 && visitor.rejectedHeaderDecls() > 0;
+    if (emptyWithRejections && Roots.empty()) {
+      // NO roots at all — neither an explicit public-roots= nor any project-local
+      // -I/-iquote to infer from — yet this TU saw header decls. Previously this
+      // fell through silently (the `!Roots.empty()` guard), reproducing the exact
+      // empty-pack trap the diagnostic exists to kill (Codex review). Fail loud.
+      std::string msg =
+          "abicheck-facts: no public-roots given and no project-local include "
+          "dirs to infer from; this TU produced 0 public entities though " +
+          std::to_string(visitor.rejectedHeaderDecls()) +
+          " header decl(s) were seen (e.g. " + visitor.exampleRejectedHeader() +
+          "). Pass public-roots=<dir> so the public headers are recognized.";
+      diags.insert(msg);
+      if (claimFirstRootsWarning())
+        llvm::errs() << msg << "\n";
+    } else if (emptyWithRejections && InferredRootCount == 0) {
+      // Explicit public-roots= that matched nothing (roots were operator-set, not
+      // inferred): the classic Caveat-A misconfiguration message.
       std::string roots;
       for (const std::string &r : Roots)
         roots += (roots.empty() ? "" : ", ") + r;
@@ -1484,6 +1525,11 @@ public:
       if (claimFirstRootsWarning())
         llvm::errs() << msg << "\n";
     }
+    // When roots were INFERRED (InferredRootCount > 0) the inference note above
+    // already told the operator; a per-TU "matched 0" here would (a) misadvise
+    // them to fix a public-roots= they never set and (b) cry wolf on every
+    // internal-only TU (Codex review). The authoritative empty-pack signal for the
+    // inferred case is the project-level `merge` warning over the whole surface.
 
     std::string source;
     if (auto fe = sm.getFileEntryRefForID(sm.getMainFileID())) {

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -771,6 +771,36 @@ bool pathUnderAnyRoot(llvm::StringRef file, const std::vector<std::string> &root
   return false;
 }
 
+// Auto-derive public roots from the compile's user include search paths when the
+// operator passed no explicit `public-roots=` (ADR-038 Flow C, Caveat A). The
+// `-I` (Angled) and `-iquote` (Quoted) directories are exactly where a project's
+// own public headers resolve, so treating them as roots turns the common "forgot
+// public-roots → silently empty pack" trap into a populated (if slightly broad)
+// public surface. System / compiler-builtin entries (`-isystem`, the resource
+// dir, the sysroot) are excluded so libstdc++ / SDK headers do not flood the
+// surface. Returns absolute-normalized directories, de-duplicated, in search
+// order. The operator can always pass an explicit `public-roots=` to scope the
+// surface precisely; inference only runs when they passed none.
+std::vector<std::string> deriveRootsFromIncludes(const HeaderSearchOptions &hso) {
+  std::vector<std::string> roots;
+  std::set<std::string> seen;
+  for (const auto &e : hso.UserEntries) {
+    if (e.IsFramework)
+      continue;
+    if (e.Group != frontend::Angled && e.Group != frontend::Quoted)
+      continue;
+    if (e.Path.empty())
+      continue;
+    llvm::SmallString<256> abs(e.Path);
+    llvm::sys::fs::make_absolute(abs);
+    llvm::sys::path::remove_dots(abs, /*remove_dot_dot=*/true);
+    std::string s(abs.str());
+    if (seen.insert(s).second)
+      roots.push_back(s);
+  }
+  return roots;
+}
+
 // Whether `file` names a C/C++ translation-unit source (not a header). Used to
 // tell an ordinary internal .cpp decl (expected to be non-public) from a decl in
 // a *header* that fell outside the public roots (the public-roots-misconfigured
@@ -1380,10 +1410,12 @@ public:
   FactsConsumer(std::string outDir, std::vector<std::string> roots,
                 std::string library, std::string version,
                 std::string ctxHash,
-                std::shared_ptr<std::map<std::string, MacroRecord>> macros)
+                std::shared_ptr<std::map<std::string, MacroRecord>> macros,
+                size_t inferredRootCount = 0)
       : OutDir(std::move(outDir)), Roots(std::move(roots)),
         Library(std::move(library)), Version(std::move(version)),
-        CtxHash(std::move(ctxHash)), Macros(std::move(macros)) {}
+        CtxHash(std::move(ctxHash)), Macros(std::move(macros)),
+        InferredRootCount(inferredRootCount) {}
 
   void HandleTranslationUnit(ASTContext &ctx) override {
     SourceManager &sm = ctx.getSourceManager();
@@ -1395,6 +1427,26 @@ public:
     visitor.TraverseDecl(ctx.getTranslationUnitDecl());
 
     std::vector<Entity> macros = collectMacros(diags);
+
+    // Public-roots inference note (ADR-038 Flow C, Caveat A): when no explicit
+    // `public-roots=` was given, the roots were auto-derived from the compile's
+    // -I/-iquote include dirs. Record that per-TU (forensic) and tell the operator
+    // once — the inferred surface can be slightly broad, so an explicit
+    // public-roots= is the precise scoping knob. Not an error: a populated (broad)
+    // surface beats the silent empty pack the missing flag used to produce.
+    if (InferredRootCount > 0) {
+      std::string roots;
+      for (const std::string &r : Roots)
+        roots += (roots.empty() ? "" : ", ") + r;
+      std::string msg =
+          "abicheck-facts: no public-roots given; inferred " +
+          std::to_string(InferredRootCount) +
+          " public root(s) from the compile's -I/-iquote include dirs [" + roots +
+          "]. Pass public-roots=<dir> to scope the public surface precisely.";
+      diags.insert(msg);
+      if (claimFirstInferenceNote())
+        llvm::errs() << msg << "\n";
+    }
 
     // Caveat A (ADR-038 Flow C): fail loud, not silent. If public-roots is set
     // but this TU emitted zero public entities *while* header-declared decls were
@@ -1588,6 +1640,25 @@ private:
     return true;
   }
 
+  // Same once-per-pack claim as claimFirstRootsWarning, for the distinct
+  // public-roots-inference note (a different sentinel so the two notes do not
+  // suppress each other). Emitted at most once across all parallel compiles that
+  // share this OutDir.
+  bool claimFirstInferenceNote() {
+    llvm::sys::fs::create_directories(OutDir);
+    int fd = -1;
+    std::error_code ec = llvm::sys::fs::openFile(
+        llvm::Twine(OutDir) + "/.abicheck-roots-inferred", fd,
+        llvm::sys::fs::CD_CreateNew, llvm::sys::fs::FA_Write,
+        llvm::sys::fs::OF_None);
+    if (ec == std::errc::file_exists)
+      return false;
+    if (ec)
+      return true; // unexpected error: prefer emitting over silence
+    llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
+    return true;
+  }
+
   void ensureManifest() {
     std::string manifestPath = OutDir + "/manifest.json";
     if (llvm::sys::fs::exists(manifestPath))
@@ -1622,6 +1693,9 @@ private:
   std::string Version;
   std::string CtxHash;
   std::shared_ptr<std::map<std::string, MacroRecord>> Macros;
+  //: >0 when Roots were auto-derived from the compile's -I/-iquote include dirs
+  //: (no explicit public-roots= given) — drives the one-time inference note.
+  size_t InferredRootCount = 0;
 };
 
 // ---------------------------------------------------------------------------
@@ -1640,8 +1714,18 @@ public:
     auto macros = std::make_shared<std::map<std::string, MacroRecord>>();
     Preprocessor &pp = ci.getPreprocessor();
     pp.addPPCallbacks(std::make_unique<MacroCollector>(pp, macros));
-    return std::make_unique<FactsConsumer>(OutDir, Roots, Library, Version,
-                                           computeContextHash(ci), macros);
+    // Auto-derive public roots from the -I/-iquote include dirs when the operator
+    // gave none (ADR-038 Flow C, Caveat A): a populated (broad) surface beats the
+    // silent empty pack a missing public-roots= used to produce.
+    std::vector<std::string> roots = Roots;
+    size_t inferredRootCount = 0;
+    if (roots.empty()) {
+      roots = deriveRootsFromIncludes(ci.getHeaderSearchOpts());
+      inferredRootCount = roots.size();
+    }
+    return std::make_unique<FactsConsumer>(OutDir, std::move(roots), Library,
+                                           Version, computeContextHash(ci),
+                                           macros, inferredRootCount);
   }
 
   // The compile-context hash — the per-TU cache key (ADR-030 D8) and the `cfg`

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -1398,11 +1398,20 @@ public:
 
     // Caveat A (ADR-038 Flow C): fail loud, not silent. If public-roots is set
     // but this TU emitted zero public entities *while* header-declared decls were
-    // rejected for not being under any root, public-roots almost certainly does
-    // not match how the compiler resolves the public headers (e.g. it points at
-    // the installed `include/` while `-I..` makes `<pvxs/x.h>` resolve to
-    // `src/pvxs/`). Previously this produced an empty pack with exit 0 and no
-    // message. Emit a diagnostic to stderr AND record it in the pack.
+    // rejected for not being under any root, public-roots may not match how the
+    // compiler resolves the public headers (e.g. it points at the installed
+    // `include/` while `-I..` makes `<pvxs/x.h>` resolve to `src/pvxs/`).
+    // Previously this produced an empty pack with exit 0 and no message.
+    //
+    // This signal is necessarily per-TU: an internal-implementation-only TU that
+    // includes a private header and defines nothing public trips the same
+    // condition even with correct roots — the plugin cannot see whether *other*
+    // TUs produced public facts (it runs once per compile). To keep the "fail
+    // loud" signal credible without crying wolf on every internal TU under `-j`,
+    // the human-facing stderr line is emitted **once per output pack** (a
+    // deterministic misconfiguration shows it on the first TU); the accurate
+    // per-TU note is still recorded in this TU's pack `diagnostics` as forensic
+    // data. A whole build whose pack ends up empty is the real confirmation.
     size_t publicCount = functions.size() + types.size() + templates.size() +
                          inlineBodies.size() + constexprValues.size() +
                          macros.size();
@@ -1415,11 +1424,13 @@ public:
           std::to_string(visitor.rejectedHeaderDecls()) +
           " header decl(s) were seen outside the root(s) [" + roots +
           "], e.g. " + visitor.exampleRejectedHeader() +
-          "). public-roots must be the directory the compiler actually resolves "
-          "the public headers from (verify with `clang -H`), not necessarily the "
-          "installed include dir; the emitted pack is empty.";
-      llvm::errs() << msg << "\n";
+          "). If this TU defines public API, public-roots likely does not match "
+          "how the compiler resolves the public headers (verify with `clang -H`) "
+          "— it must be the resolved directory, not necessarily the installed "
+          "include dir. (Harmless for an internal-only TU.)";
       diags.insert(msg);
+      if (claimFirstRootsWarning())
+        llvm::errs() << msg << "\n";
     }
 
     std::string source;
@@ -1551,6 +1562,29 @@ private:
     if (!out)
       return false;
     out << tu << "\n";
+    return true;
+  }
+
+  // Return true for exactly the first caller across all parallel compiles that
+  // share this OutDir, by atomically creating a sentinel file (CD_CreateNew
+  // fails if it already exists). Used to emit the public-roots stderr warning
+  // once per pack instead of once per TU (Caveat A / CodeRabbit review). A
+  // failure to create for any *other* reason falls back to emitting (fail loud
+  // rather than swallow the signal).
+  bool claimFirstRootsWarning() {
+    // The out dir is otherwise created lazily by writeTu (which runs after this
+    // check); create it up front so the sentinel has a home on the very first TU.
+    llvm::sys::fs::create_directories(OutDir);
+    int fd = -1;
+    std::error_code ec = llvm::sys::fs::openFile(
+        llvm::Twine(OutDir) + "/.abicheck-roots-warning", fd,
+        llvm::sys::fs::CD_CreateNew, llvm::sys::fs::FA_Write,
+        llvm::sys::fs::OF_None);
+    if (ec == std::errc::file_exists)
+      return false;
+    if (ec)
+      return true; // unexpected error: prefer emitting over silence
+    llvm::raw_fd_ostream os(fd, /*shouldClose=*/true); // create + close
     return true;
   }
 

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -1036,11 +1036,12 @@ public:
   FactsVisitor(ASTContext &ctx, const std::vector<std::string> &roots,
                std::vector<Entity> &functions, std::vector<Entity> &types,
                std::vector<Entity> &templates, std::vector<Entity> &inlineBodies,
-               std::vector<Entity> &constexprValues, std::set<std::string> &diags)
+               std::vector<Entity> &constexprValues, std::set<std::string> &diags,
+               bool inferredRoots = false)
       : SM(ctx.getSourceManager()), PP(ctx.getPrintingPolicy()), Roots(roots),
         Functions(functions), Types(types), Templates(templates),
         InlineBodies(inlineBodies), ConstexprValues(constexprValues),
-        Diags(diags) {}
+        Diags(diags), InferredRoots(inferredRoots) {}
 
   bool shouldVisitTemplateInstantiations() const { return false; }
   bool shouldVisitImplicitCode() const { return false; }
@@ -1327,6 +1328,15 @@ private:
       return false;
     file = pl.getFilename();
     if (pathUnderAnyRoot(file, Roots)) {
+      // With INFERRED roots (no explicit public-roots=), a root can be an ancestor
+      // of the translation-unit sources — e.g. `-I.`/`-I$repo` — so a decl in an
+      // implementation `.cpp` under the repo would be pulled onto the public
+      // surface, polluting L4/L5 with private API and possibly masking
+      // exported-not-public leaks. Public API lives in headers, so a source-file
+      // decl is never public when roots were inferred (Codex review). Explicit
+      // roots keep exact wrapper/C.6 parity (no extension filter).
+      if (InferredRoots && isSourceFileName(file))
+        return false;
       publicSurfaceLabels(file, origin, visibility);
       return true;
     }
@@ -1419,6 +1429,10 @@ private:
   std::vector<Entity> &InlineBodies;
   std::vector<Entity> &ConstexprValues;
   std::set<std::string> &Diags;
+  //: True when Roots were auto-derived (no explicit public-roots=); gates the
+  //: source-file exclusion so an inferred `-I.` root does not pull `.cpp` decls
+  //: onto the public surface.
+  bool InferredRoots = false;
   // Mutable: updated from the const `classify` gate while walking the AST.
   mutable size_t RejectedHeaderDecls = 0;
   mutable std::string ExampleRejectedHeader;
@@ -1446,7 +1460,7 @@ public:
     std::vector<Entity> functions, types, templates, inlineBodies, constexprValues;
     std::set<std::string> diags;
     FactsVisitor visitor(ctx, Roots, functions, types, templates, inlineBodies,
-                         constexprValues, diags);
+                         constexprValues, diags, InferredRootCount > 0);
     visitor.TraverseDecl(ctx.getTranslationUnitDecl());
 
     std::vector<Entity> macros = collectMacros(diags);
@@ -1596,6 +1610,11 @@ private:
   bool isPublicFile(const std::string &file, std::string &origin,
                     std::string &visibility) const {
     if (pathUnderAnyRoot(file, Roots)) {
+      // Same source-file exclusion as FactsVisitor::classify for inferred roots:
+      // a macro defined in an implementation `.cpp` under an inferred `-I.` root
+      // is not public API (Codex review).
+      if (InferredRootCount > 0 && isSourceFileName(file))
+        return false;
       publicSurfaceLabels(file, origin, visibility);
       return true;
     }

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -771,6 +771,18 @@ bool pathUnderAnyRoot(llvm::StringRef file, const std::vector<std::string> &root
   return false;
 }
 
+// Whether `file` names a C/C++ translation-unit source (not a header). Used to
+// tell an ordinary internal .cpp decl (expected to be non-public) from a decl in
+// a *header* that fell outside the public roots (the public-roots-misconfigured
+// signal, ADR-038 Flow C Caveat A).
+bool isSourceFileName(llvm::StringRef file) {
+  llvm::StringRef ext = llvm::sys::path::extension(file);
+  return ext.equals_insensitive(".c") || ext.equals_insensitive(".cc") ||
+         ext.equals_insensitive(".cpp") || ext.equals_insensitive(".cxx") ||
+         ext.equals_insensitive(".c++") || ext.equals_insensitive(".cp") ||
+         ext == ".C";
+}
+
 // Whether a header path looks machine-generated — a faithful port of
 // provenance._is_generated_header (a `generated`/`gen`/… directory segment, or
 // a moc_/ui_/qrc_/protobuf/flatbuffers/gRPC basename). The clang backend keeps
@@ -1265,8 +1277,28 @@ private:
       publicSurfaceLabels(file, origin, visibility);
       return true;
     }
+    // Misconfiguration signal (ADR-038 Flow C, Caveat A): a decl in a real,
+    // non-system *header* that is not under any public root. Ordinary internal
+    // code lives in the .cpp source, so counting only header-declared rejections
+    // distinguishes "public-roots does not match how headers resolve" (every
+    // public header rejected → an empty pack) from a legitimately internal TU.
+    if (!isSourceFileName(file)) {
+      ++RejectedHeaderDecls;
+      if (ExampleRejectedHeader.empty())
+        ExampleRejectedHeader = file;
+    }
     return false;
   }
+
+public:
+  //: Header-declared decls rejected because no public root matched them, plus one
+  //: example path — feeds the "0 public entities" diagnostic (Caveat A).
+  size_t rejectedHeaderDecls() const { return RejectedHeaderDecls; }
+  const std::string &exampleRejectedHeader() const {
+    return ExampleRejectedHeader;
+  }
+
+private:
 
   void emitType(const TagDecl *td, const std::string &name,
                 const std::string &kind) {
@@ -1334,6 +1366,9 @@ private:
   std::vector<Entity> &InlineBodies;
   std::vector<Entity> &ConstexprValues;
   std::set<std::string> &Diags;
+  // Mutable: updated from the const `classify` gate while walking the AST.
+  mutable size_t RejectedHeaderDecls = 0;
+  mutable std::string ExampleRejectedHeader;
 };
 
 // ---------------------------------------------------------------------------
@@ -1360,6 +1395,32 @@ public:
     visitor.TraverseDecl(ctx.getTranslationUnitDecl());
 
     std::vector<Entity> macros = collectMacros(diags);
+
+    // Caveat A (ADR-038 Flow C): fail loud, not silent. If public-roots is set
+    // but this TU emitted zero public entities *while* header-declared decls were
+    // rejected for not being under any root, public-roots almost certainly does
+    // not match how the compiler resolves the public headers (e.g. it points at
+    // the installed `include/` while `-I..` makes `<pvxs/x.h>` resolve to
+    // `src/pvxs/`). Previously this produced an empty pack with exit 0 and no
+    // message. Emit a diagnostic to stderr AND record it in the pack.
+    size_t publicCount = functions.size() + types.size() + templates.size() +
+                         inlineBodies.size() + constexprValues.size() +
+                         macros.size();
+    if (!Roots.empty() && publicCount == 0 && visitor.rejectedHeaderDecls() > 0) {
+      std::string roots;
+      for (const std::string &r : Roots)
+        roots += (roots.empty() ? "" : ", ") + r;
+      std::string msg =
+          "abicheck-facts: public-roots matched 0 declarations for this TU (" +
+          std::to_string(visitor.rejectedHeaderDecls()) +
+          " header decl(s) were seen outside the root(s) [" + roots +
+          "], e.g. " + visitor.exampleRejectedHeader() +
+          "). public-roots must be the directory the compiler actually resolves "
+          "the public headers from (verify with `clang -H`), not necessarily the "
+          "installed include dir; the emitted pack is empty.";
+      llvm::errs() << msg << "\n";
+      diags.insert(msg);
+    }
 
     std::string source;
     if (auto fe = sm.getFileEntryRefForID(sm.getMainFileID())) {

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -118,6 +118,35 @@ abicheck merge libfoo.so.json ./abicheck_inputs/ -o libfoo.baseline.json
 Optional args: `library=<name>` (recorded in the manifest / `target_id`),
 `version=<v>`. `public-roots=` is repeatable.
 
+### `public-roots` must match how headers *resolve*, not where they are installed
+
+The plugin classifies a declaration as public by the **physical path the
+compiler resolved its header to**, then tests that path against `public-roots`.
+The trap: your public headers may be installed at `include/pvxs/…`, but if an
+earlier `-I` makes `<pvxs/data.h>` resolve to `src/pvxs/data.h`, then
+`public-roots=include` matches **nothing** and the pack comes back empty — even
+though everything "looks" configured. Include order decides the resolved path,
+not the install layout.
+
+Two ways to get it right:
+
+- **Check the resolution** — `clang++ <your -I flags> -H -fsyntax-only x.cpp`
+  prints the actual file each `#include` opened; point `public-roots=` at *that*
+  directory (e.g. `src/pvxs`), not the installed copy.
+- **Trust the diagnostic** — since ADR-038 Flow C the plugin no longer fails
+  silently: if `public-roots` matches zero declarations while header decls were
+  seen outside the roots, it prints
+
+  ```
+  abicheck-facts: public-roots matched 0 declarations for this TU
+  (799 header decl(s) were seen outside the root(s) [.../include],
+   e.g. .../epicsAssert.h). public-roots must be the directory the compiler
+   actually resolves the public headers from (verify with `clang -H`) …
+  ```
+
+  and records the same note in the pack's `diagnostics`. An empty pack is now a
+  loud error, not a 20-minute debug.
+
 ## Validation: differential conformance (ADR-038 C.6)
 
 The plugin is correct **iff** it is a drop-in for the **clang** backend. The gate

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -99,9 +99,13 @@ Pass plugin arguments with the **`-Xclang -plugin-arg-abicheck-facts -Xclang
 <arg>`** cc1 form, not the `-fplugin-arg-abicheck-facts-<arg>` shorthand: the
 shorthand mis-parses the *hyphenated* plugin name (clang splits it at the first
 hyphen and hands `out=…` to a plugin named `abicheck`; verify with `clang++
--###`). `public-roots=` is **mandatory** — it is the plugin's equivalent of the
-wrapper's `ABICHECK_CC_HEADERS`; without it every decl classifies non-public and
-the plugin emits an empty public surface.
+-###`). `public-roots=` is the plugin's equivalent of the wrapper's
+`ABICHECK_CC_HEADERS` — it scopes which resolved header paths count as the public
+surface. It is **strongly recommended** but no longer strictly required: when it
+is omitted the plugin auto-derives roots from the compile's own `-I`/`-iquote`
+include directories (see below), so a forgotten flag yields a populated surface
+instead of a silently empty pack. Pass it explicitly whenever you want to scope
+the surface precisely (e.g. only the installed `include/` tree).
 
 ```bash
 clang++ -std=c++17 -Iinclude \
@@ -146,6 +150,25 @@ Two ways to get it right:
 
   and records the same note in the pack's `diagnostics`. An empty pack is now a
   loud error, not a 20-minute debug.
+
+### Auto-derived public roots (when `public-roots=` is omitted)
+
+If you pass no `public-roots=` at all, the plugin derives roots from the
+compile's user include search paths — every `-I` (angled) and `-iquote` (quoted)
+directory, resolved to an absolute path; compiler/system entries (`-isystem`,
+the resource dir, the sysroot) are excluded so libstdc++/SDK headers don't flood
+the surface. The plugin then emits a one-time note per pack:
+
+```
+abicheck-facts: no public-roots given; inferred 2 public root(s) from the
+compile's -I/-iquote include dirs [/proj/include, /proj/gen]. Pass
+public-roots=<dir> to scope the public surface precisely.
+```
+
+and records it in each TU's `diagnostics`. This is a convenience, not a
+replacement for scoping: the inferred surface can be broader than your true
+public API (it includes any header reachable through a `-I` dir), so for a
+precise baseline still pass an explicit `public-roots=`.
 
 ## Validation: differential conformance (ADR-038 C.6)
 

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -165,10 +165,16 @@ compile's -I/-iquote include dirs [/proj/include, /proj/gen]. Pass
 public-roots=<dir> to scope the public surface precisely.
 ```
 
-and records it in each TU's `diagnostics`. This is a convenience, not a
-replacement for scoping: the inferred surface can be broader than your true
-public API (it includes any header reachable through a `-I` dir), so for a
-precise baseline still pass an explicit `public-roots=`.
+and records it in each TU's `diagnostics`. Inference is scoped to keep the
+surface honest: only include dirs **at or below the build working directory** are
+used (a third-party `-I/opt/boost/include` is not a public root), and decls
+defined in a **translation-unit source** (`.cpp`/`.cc`/…) are excluded even when
+an inferred `-I.` root covers them — public API lives in headers. It is still a
+convenience, not a replacement for scoping: the inferred surface can be broader
+than your true public API (any header reachable through an in-tree `-I` dir), so
+for a precise baseline still pass an explicit `public-roots=`. (Explicit roots are
+taken verbatim — no source-file/locality filtering — to stay byte-identical to the
+`abicheck-cc` wrapper for the C.6 conformance gate.)
 
 ## Validation: differential conformance (ADR-038 C.6)
 

--- a/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
+++ b/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
@@ -116,6 +116,30 @@ def main(argv: list[str] | None = None) -> int:
         if n == 0:
             failures.append("correct public-roots produced an EMPTY pack")
 
+        # 3) De-dup: two TUs with the wrong root sharing one out dir must emit the
+        # human-facing stderr line only ONCE (a big -j build must not spam), while
+        # each TU still records the note in its own pack diagnostics.
+        shared = work / "out_shared"
+        argp = ["-Xclang", "-plugin-arg-abicheck-facts", "-Xclang"]
+        n_warn = 0
+        for obj in ("a.o", "b.o"):
+            proc = subprocess.run(
+                [
+                    args.clangxx, "-std=c++17", "-Iinclude", f"-fplugin={plugin}",
+                    *argp, f"out={shared}",
+                    *argp, "public-roots=no-such-public-root",
+                    "-c", "widget.cpp", "-o", str(work / obj),
+                ],
+                cwd=str(work), capture_output=True, text=True, timeout=300,
+                check=True,
+            )
+            n_warn += proc.stderr.count(_DIAG)
+        if n_warn != 1:
+            failures.append(
+                f"stderr warning not de-duplicated: emitted {n_warn} times across "
+                "2 TUs sharing one out dir (expected exactly 1)"
+            )
+
         if failures:
             print("CAVEAT-A DIAGNOSTIC TEST FAILED:", file=sys.stderr)
             for f in failures:

--- a/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
+++ b/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
@@ -262,6 +262,48 @@ def main(argv: list[str] | None = None) -> int:
                 f"the no-roots diagnostic (silent empty pack). stderr:\n{noinc.stderr}"
             )
 
+        # 7) INFERRED ROOT EXCLUDES SOURCE FILES: with `-I.` the inferred root is
+        # an ancestor of the .cpp, but a decl defined in the .cpp is implementation,
+        # not public API — it must be excluded from the surface (else `-I.` floods
+        # L4/L5 with private impl). The root IS inferred (note fires), yet the pack
+        # stays empty because the only decls live in the source file.
+        impl = work / "impldir"
+        impl.mkdir(exist_ok=True)
+        (impl / "impl.cpp").write_text(
+            "struct PubInImpl { int x; };\nint impl_fn() { return 0; }\n"
+        )
+        srcexcl = subprocess.run(
+            [
+                args.clangxx,
+                "-std=c++17",
+                "-I.",
+                f"-fplugin={plugin}",
+                "-Xclang",
+                "-plugin-arg-abicheck-facts",
+                "-Xclang",
+                f"out={impl / 'out'}",
+                "-c",
+                "impl.cpp",
+                "-o",
+                str(impl / "impl.o"),
+            ],
+            cwd=str(impl),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=True,
+        )
+        if "inferred 1 public root" not in srcexcl.stderr:
+            failures.append(
+                "with -I. a root should be inferred (the note must fire); "
+                f"stderr:\n{srcexcl.stderr}"
+            )
+        if _pack_entity_count(impl / "out") != 0:
+            failures.append(
+                "a decl defined in a .cpp under an inferred -I. root was emitted as "
+                "public surface; source-file decls must be excluded"
+            )
+
         if failures:
             print("CAVEAT-A DIAGNOSTIC TEST FAILED:", file=sys.stderr)
             for f in failures:

--- a/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
+++ b/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public-roots misconfiguration diagnostic (ADR-038 Flow C, Caveat A).
+
+Regression guard for the plugin's silent-empty-pack failure mode: when
+``public-roots`` does not match how the compiler resolves the public headers,
+every declaration classifies non-public and the plugin used to emit an empty
+pack with exit 0 and no message — a 20-minute debug for the operator. The plugin
+must now:
+
+  * WARN (naming the count, an example rejected header, and the ``clang -H`` tip)
+    when public-roots matches zero declarations though header decls were seen, and
+  * stay silent and emit a non-empty pack when public-roots is correct.
+
+Standalone (mirrors ``conformance.py``); run by the ``clang-plugin`` workflow:
+
+    python contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py \
+        --plugin build/libabicheck-facts.so --clangxx clang++
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+_DIAG = "public-roots matched 0 declarations"
+
+
+def _compile(work: Path, plugin: Path, clangxx: str, public_root: str) -> str:
+    """Compile the widget fixture with *public_root*; return combined stderr."""
+    out = work / f"out_{public_root.replace('/', '_')}"
+    argp = ["-Xclang", "-plugin-arg-abicheck-facts", "-Xclang"]
+    proc = subprocess.run(
+        [
+            clangxx, "-std=c++17", "-Iinclude", f"-fplugin={plugin}",
+            *argp, f"out={out}",
+            *argp, f"public-roots={public_root}",
+            "-c", "widget.cpp", "-o", str(work / "widget.o"),
+        ],
+        cwd=str(work), capture_output=True, text=True, timeout=300, check=True,
+    )
+    return proc.stderr + "\n@@PACK@@" + str(out)
+
+
+def _pack_entity_count(out_dir: Path) -> int:
+    total = 0
+    for jsonl in glob.glob(str(out_dir / "source_facts" / "*.jsonl")):
+        with open(jsonl, encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                rec = json.loads(line)
+                for k in ("functions", "types", "templates", "inline_bodies",
+                          "constexpr_values", "macros", "variables"):
+                    total += len(rec.get(k) or [])
+    return total
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--plugin", required=True, help="path to libabicheck-facts.so")
+    ap.add_argument("--clangxx", default="clang++", help="clang++ to compile with")
+    ap.add_argument("--keep", action="store_true", help="keep the work dir")
+    args = ap.parse_args(argv)
+
+    plugin = Path(args.plugin).resolve()
+    if not plugin.is_file():
+        print(f"error: plugin not found: {plugin}", file=sys.stderr)
+        return 2
+
+    work = Path(tempfile.mkdtemp(prefix="abicheck-caveatA-"))
+    shutil.copytree(FIXTURES / "include", work / "include", dirs_exist_ok=True)
+    shutil.copyfile(FIXTURES / "widget.cpp", work / "widget.cpp")
+
+    failures: list[str] = []
+    try:
+        # 1) WRONG root: a path no header resolves under → diagnostic + empty pack.
+        wrong = _compile(work, plugin, args.clangxx, "no-such-public-root")
+        wrong_err, wrong_pack = wrong.split("\n@@PACK@@")
+        if _DIAG not in wrong_err:
+            failures.append(
+                "wrong public-roots did NOT emit the diagnostic (silent empty "
+                f"pack regressed). stderr was:\n{wrong_err.strip() or '<empty>'}"
+            )
+        if _pack_entity_count(Path(wrong_pack)) != 0:
+            failures.append("wrong public-roots unexpectedly produced entities")
+
+        # 2) CORRECT root: silent, and a non-empty public surface.
+        right = _compile(work, plugin, args.clangxx, "include")
+        right_err, right_pack = right.split("\n@@PACK@@")
+        if _DIAG in right_err:
+            failures.append(
+                f"correct public-roots wrongly emitted the diagnostic:\n{right_err}"
+            )
+        n = _pack_entity_count(Path(right_pack))
+        if n == 0:
+            failures.append("correct public-roots produced an EMPTY pack")
+
+        if failures:
+            print("CAVEAT-A DIAGNOSTIC TEST FAILED:", file=sys.stderr)
+            for f in failures:
+                print(f"  - {f}", file=sys.stderr)
+            return 1
+        print(
+            f"Caveat-A diagnostic test PASSED: wrong root warns + empty; "
+            f"correct root silent + {n} entities."
+        )
+        return 0
+    finally:
+        if not args.keep:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
+++ b/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
@@ -56,6 +56,7 @@ def _compile(
     public_root: str | None,
     out_dir: Path | None = None,
     obj: str = "widget.o",
+    extra_flags: list[str] | None = None,
 ) -> str:
     """Compile the widget fixture with *public_root*; return combined stderr.
 
@@ -79,6 +80,7 @@ def _compile(
             clangxx,
             "-std=c++17",
             "-Iinclude",
+            *(extra_flags or []),
             f"-fplugin={plugin}",
             *argp,
             f"out={out}",
@@ -196,6 +198,68 @@ def main(argv: list[str] | None = None) -> int:
         if _pack_entity_count(Path(auto_pack)) == 0:
             failures.append(
                 "auto-derive produced an EMPTY pack (roots not inferred from -I)"
+            )
+
+        # 5) THIRD-PARTY EXCLUSION: an absolute -I OUTSIDE the build cwd (a
+        # dependency like /opt/boost/include) must NOT be inferred as a public root
+        # — only project-local include dirs are. Point a second -I at a temp dir
+        # outside the work tree and assert the inference note omits it.
+        outside = Path(tempfile.mkdtemp(prefix="abicheck-thirdparty-"))
+        try:
+            (outside / "dep.hpp").write_text("struct Dep { int z; };\n")
+            tp = _compile(
+                work,
+                plugin,
+                args.clangxx,
+                None,
+                out_dir=work / "out_thirdparty",
+                extra_flags=[f"-I{outside}"],
+            )
+            tp_err, _ = tp.split("\n@@PACK@@")
+            if str(outside) in tp_err:
+                failures.append(
+                    "auto-derive inferred a THIRD-PARTY -I dir outside the build "
+                    f"cwd ({outside}); it must be excluded. stderr:\n{tp_err}"
+                )
+            if "inferred 1 public root" not in tp_err:
+                failures.append(
+                    "auto-derive should infer exactly the 1 in-tree root, not the "
+                    f"outside dir. stderr:\n{tp_err}"
+                )
+        finally:
+            shutil.rmtree(outside, ignore_errors=True)
+
+        # 6) NO ROOTS AT ALL: a TU with header decls but no -I/-iquote to infer
+        # from (and no explicit public-roots) must FAIL LOUD, not fall through to a
+        # silent empty pack — the exact trap the diagnostic exists to kill.
+        sub = work / "noinc"
+        sub.mkdir(exist_ok=True)
+        (sub / "loc.h").write_text("struct Pub { int a; };\n")
+        (sub / "main.cpp").write_text('#include "loc.h"\nint useit() { return 0; }\n')
+        noinc = subprocess.run(
+            [
+                args.clangxx,
+                "-std=c++17",
+                f"-fplugin={plugin}",
+                "-Xclang",
+                "-plugin-arg-abicheck-facts",
+                "-Xclang",
+                f"out={sub / 'out'}",
+                "-c",
+                "main.cpp",
+                "-o",
+                str(sub / "main.o"),
+            ],
+            cwd=str(sub),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=True,
+        )
+        if "no project-local include dirs to infer from" not in noinc.stderr:
+            failures.append(
+                "a TU with header decls but no -I and no public-roots did NOT emit "
+                f"the no-roots diagnostic (silent empty pack). stderr:\n{noinc.stderr}"
             )
 
         if failures:

--- a/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
+++ b/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
@@ -46,18 +46,47 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures"
 _DIAG = "public-roots matched 0 declarations"
 
 
-def _compile(work: Path, plugin: Path, clangxx: str, public_root: str) -> str:
-    """Compile the widget fixture with *public_root*; return combined stderr."""
-    out = work / f"out_{public_root.replace('/', '_')}"
+def _compile(
+    work: Path,
+    plugin: Path,
+    clangxx: str,
+    public_root: str,
+    out_dir: Path | None = None,
+    obj: str = "widget.o",
+) -> str:
+    """Compile the widget fixture with *public_root*; return combined stderr.
+
+    *out_dir* overrides the pack output directory (default: one per root) so
+    several TUs can be pointed at a shared pack; *obj* names the object file so
+    two invocations don't clobber each other. Returns ``stderr + "@@PACK@@" +
+    out_dir`` — the single source of the plugin invocation contract.
+    """
+    out = (
+        out_dir
+        if out_dir is not None
+        else work / f"out_{public_root.replace('/', '_')}"
+    )
     argp = ["-Xclang", "-plugin-arg-abicheck-facts", "-Xclang"]
     proc = subprocess.run(
         [
-            clangxx, "-std=c++17", "-Iinclude", f"-fplugin={plugin}",
-            *argp, f"out={out}",
-            *argp, f"public-roots={public_root}",
-            "-c", "widget.cpp", "-o", str(work / "widget.o"),
+            clangxx,
+            "-std=c++17",
+            "-Iinclude",
+            f"-fplugin={plugin}",
+            *argp,
+            f"out={out}",
+            *argp,
+            f"public-roots={public_root}",
+            "-c",
+            "widget.cpp",
+            "-o",
+            str(work / obj),
         ],
-        cwd=str(work), capture_output=True, text=True, timeout=300, check=True,
+        cwd=str(work),
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=True,
     )
     return proc.stderr + "\n@@PACK@@" + str(out)
 
@@ -70,8 +99,15 @@ def _pack_entity_count(out_dir: Path) -> int:
                 if not line.strip():
                     continue
                 rec = json.loads(line)
-                for k in ("functions", "types", "templates", "inline_bodies",
-                          "constexpr_values", "macros", "variables"):
+                for k in (
+                    "functions",
+                    "types",
+                    "templates",
+                    "inline_bodies",
+                    "constexpr_values",
+                    "macros",
+                    "variables",
+                ):
                     total += len(rec.get(k) or [])
     return total
 
@@ -118,22 +154,21 @@ def main(argv: list[str] | None = None) -> int:
 
         # 3) De-dup: two TUs with the wrong root sharing one out dir must emit the
         # human-facing stderr line only ONCE (a big -j build must not spam), while
-        # each TU still records the note in its own pack diagnostics.
+        # each TU still records the note in its own pack diagnostics. Reuse
+        # _compile() (the single owner of the plugin invocation contract) with a
+        # shared out_dir and distinct object names.
         shared = work / "out_shared"
-        argp = ["-Xclang", "-plugin-arg-abicheck-facts", "-Xclang"]
         n_warn = 0
         for obj in ("a.o", "b.o"):
-            proc = subprocess.run(
-                [
-                    args.clangxx, "-std=c++17", "-Iinclude", f"-fplugin={plugin}",
-                    *argp, f"out={shared}",
-                    *argp, "public-roots=no-such-public-root",
-                    "-c", "widget.cpp", "-o", str(work / obj),
-                ],
-                cwd=str(work), capture_output=True, text=True, timeout=300,
-                check=True,
-            )
-            n_warn += proc.stderr.count(_DIAG)
+            stderr, _ = _compile(
+                work,
+                plugin,
+                args.clangxx,
+                "no-such-public-root",
+                out_dir=shared,
+                obj=obj,
+            ).split("\n@@PACK@@")
+            n_warn += stderr.count(_DIAG)
         if n_warn != 1:
             failures.append(
                 f"stderr warning not de-duplicated: emitted {n_warn} times across "

--- a/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
+++ b/contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py
@@ -22,8 +22,11 @@ pack with exit 0 and no message — a 20-minute debug for the operator. The plug
 must now:
 
   * WARN (naming the count, an example rejected header, and the ``clang -H`` tip)
-    when public-roots matches zero declarations though header decls were seen, and
-  * stay silent and emit a non-empty pack when public-roots is correct.
+    when public-roots matches zero declarations though header decls were seen,
+  * stay silent and emit a non-empty pack when public-roots is correct, and
+  * auto-derive roots from the compile's ``-I``/``-iquote`` include dirs (with a
+    one-time inference note) when no ``public-roots`` is given at all, so a
+    forgotten flag yields a populated surface rather than an empty pack.
 
 Standalone (mirrors ``conformance.py``); run by the ``clang-plugin`` workflow:
 
@@ -50,7 +53,7 @@ def _compile(
     work: Path,
     plugin: Path,
     clangxx: str,
-    public_root: str,
+    public_root: str | None,
     out_dir: Path | None = None,
     obj: str = "widget.o",
 ) -> str:
@@ -58,15 +61,19 @@ def _compile(
 
     *out_dir* overrides the pack output directory (default: one per root) so
     several TUs can be pointed at a shared pack; *obj* names the object file so
-    two invocations don't clobber each other. Returns ``stderr + "@@PACK@@" +
-    out_dir`` — the single source of the plugin invocation contract.
+    two invocations don't clobber each other. When *public_root* is ``None`` the
+    ``public-roots=`` argument is omitted entirely, exercising the plugin's
+    auto-derivation from the compile's ``-I`` include dirs. Returns
+    ``stderr + "@@PACK@@" + out_dir`` — the single source of the plugin
+    invocation contract.
     """
     out = (
         out_dir
         if out_dir is not None
-        else work / f"out_{public_root.replace('/', '_')}"
+        else work / f"out_{(public_root or 'auto').replace('/', '_')}"
     )
     argp = ["-Xclang", "-plugin-arg-abicheck-facts", "-Xclang"]
+    roots_args = [] if public_root is None else [*argp, f"public-roots={public_root}"]
     proc = subprocess.run(
         [
             clangxx,
@@ -75,8 +82,7 @@ def _compile(
             f"-fplugin={plugin}",
             *argp,
             f"out={out}",
-            *argp,
-            f"public-roots={public_root}",
+            *roots_args,
             "-c",
             "widget.cpp",
             "-o",
@@ -173,6 +179,23 @@ def main(argv: list[str] | None = None) -> int:
             failures.append(
                 f"stderr warning not de-duplicated: emitted {n_warn} times across "
                 "2 TUs sharing one out dir (expected exactly 1)"
+            )
+
+        # 4) AUTO-DERIVE: with NO public-roots arg at all, the plugin infers roots
+        # from the compile's -I/-iquote include dirs, so the pack is non-empty and a
+        # one-time inference note names how many roots it derived. This turns the
+        # "forgot public-roots" trap into a populated surface instead of an empty
+        # pack (ADR-038 Flow C, Caveat A).
+        auto = _compile(work, plugin, args.clangxx, None)
+        auto_err, auto_pack = auto.split("\n@@PACK@@")
+        if "no public-roots given; inferred" not in auto_err:
+            failures.append(
+                "auto-derive did NOT emit the inference note when public-roots was "
+                f"omitted. stderr was:\n{auto_err.strip() or '<empty>'}"
+            )
+        if _pack_entity_count(Path(auto_pack)) == 0:
+            failures.append(
+                "auto-derive produced an EMPTY pack (roots not inferred from -I)"
             )
 
         if failures:

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -1,0 +1,121 @@
+# Producing source facts (Flow A / B / C)
+
+`abicheck`'s deepest evidence — **L4** (the source-ABI replay: inline bodies,
+default arguments, templates, `constexpr`, macro values) and **L5** (the source
+graph: call/include/dependency edges) — is derived from your **source**, not from
+the shipped binary. This page is the practical guide to *producing* that source
+evidence. For what the layers mean, see
+[Build Info & Sources](../concepts/build-source-data.md) and
+[Evidence & Detectability](../concepts/evidence-and-detectability.md); for how a
+scan *consumes* it, see [Source-scan levels](scan-levels.md).
+
+Whichever producer you pick, the **output contract is identical** — an
+`abicheck_inputs/` pack (or an inline `--sources` collection) that
+[`abicheck merge`](baseline-management.md) folds onto the binary-side snapshot.
+The producer is an implementation choice; the ingest never changes.
+
+## Which producer? (pick one)
+
+| | Flow A — replay | Flow B — `abicheck-cc` wrapper | Flow C — Clang plugin |
+|---|---|---|---|
+| **How** | `abicheck dump --sources` / `collect` re-parses each TU from `compile_commands.json` | wrap your compiler; it runs the extractor as a companion action | `-fplugin` reads the AST the compile already built |
+| **Extra parse** | a full second parse (~5 s/TU on template-heavy C++) | a full second parse | **none** — zero-cost byproduct of the build |
+| **Needs** | a compile DB (auto-inferred for cmake/make/bazel) | to front your build with `abicheck-cc` | a plugin built against your exact Clang major |
+| **Portable?** | ✅ any toolchain | ✅ any compiler | ❌ ABI-locked to the loading Clang's LLVM major |
+| **Reach for it when** | the default — you have (or can generate) a compile DB | you own the build command but not a compile DB | the second-parse cost is measurable on a big build **and** you own the toolchain image |
+
+```mermaid
+graph TD
+    A{Own the toolchain image<br/>and second-parse cost hurts?} -->|yes| C[Flow C: Clang plugin]
+    A -->|no| B{Have / can generate<br/>compile_commands.json?}
+    B -->|yes| FA[Flow A: dump --sources]
+    B -->|no| FB[Flow B: abicheck-cc wrapper]
+```
+
+Flow A is the supported default. Flow B and Flow C are optimizations for
+specific situations — they exist to remove a step (a manual compile DB) or a cost
+(the second parse), never to change the result.
+
+## Flow A — replay from a compile database
+
+```bash
+# Source-only: infer the compile DB, replay L4, fold the L5 graph, all inline.
+abicheck dump --sources . -H include/ --depth source -o libfoo.src.json
+
+# Or against a real binary in one shot (L0–L5 in one snapshot):
+abicheck dump libfoo.so -H include/ --sources . --compile-db build/compile_commands.json \
+  --depth full -o libfoo.full.json
+```
+
+With just `--sources`, abicheck infers and runs the build-system query itself
+(`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `bazel aquery`, or a `make -n`
+transcript). Pass `--compile-db` when you already have a `compile_commands.json`
+that isn't under the tree — it is the most faithful input.
+
+## Flow B — the `abicheck-cc` compiler wrapper
+
+Front your normal build command with `abicheck-cc`; it compiles as usual and runs
+the extractor as a companion action, dropping an `abicheck_inputs/` pack:
+
+```bash
+export ABICHECK_INPUTS_DIR=abicheck_inputs
+export ABICHECK_CC_HEADERS=include      # the public-header roots (see the trap below)
+export ABICHECK_CC_LIBRARY=foo
+abicheck-cc c++ -std=c++17 -Iinclude -c src/foo.cpp -o foo.o
+```
+
+## Flow C — the Clang facts plugin
+
+A compiled plugin that emits the same facts from the AST Clang already built —
+**no second parse**. Build it once against your pinned Clang, then inject it:
+
+```bash
+clang++ -std=c++17 -Iinclude \
+  -fplugin=./libabicheck-facts.so \
+  -Xclang -plugin-arg-abicheck-facts -Xclang out=abicheck_inputs \
+  -Xclang -plugin-arg-abicheck-facts -Xclang public-roots=include \
+  -c src/foo.cpp -o foo.o
+```
+
+See [`contrib/abicheck-clang-plugin/README.md`](https://github.com/abicheck/abicheck/blob/main/contrib/abicheck-clang-plugin/README.md)
+for the build. The plugin is **ABI-locked to the loading Clang's LLVM major**
+(a plugin built against LLVM 18 only loads into `clang` 18) — that is the price
+of the zero-parse path, and why Flow A/B remain the portable defaults.
+
+## The one trap: public-roots must match how headers *resolve*
+
+!!! warning "Point the public-header root at the resolved path, not the install dir"
+    Flow B (`ABICHECK_CC_HEADERS`) and Flow C (`public-roots=`) classify a
+    declaration as public by the **physical path the compiler resolved its header
+    to**. If an earlier `-I` makes `<foo/bar.h>` resolve to `src/foo/bar.h` while
+    you set the root to the *installed* `include/`, the root matches **nothing**
+    and the pack comes back **empty** — even though it all looks configured.
+    Include *order* decides the resolved path, not the install layout.
+
+    **Find the real path** with `-H`, then set the root to that directory:
+
+    ```bash
+    clang++ <your -I flags> -H -fsyntax-only src/foo.cpp 2>&1 | grep 'bar.h'
+    # . ./src/foo/bar.h   →  public-roots=src/foo  (not include/)
+    ```
+
+    Since ADR-038 Flow C, the plugin **fails loud** here instead of silently: if
+    `public-roots` matches zero declarations while header decls were seen outside
+    the roots, it prints a `public-roots matched 0 declarations` diagnostic naming
+    an example header and the `clang -H` tip, and records it in the pack's
+    `diagnostics`.
+
+## Then: fold the facts onto the binary
+
+However you produced them, ingest is the same — dump the binary side, then merge:
+
+```bash
+abicheck dump libfoo.so -o libfoo.bin.json
+abicheck merge libfoo.bin.json ./abicheck_inputs/ -o libfoo.baseline.json
+```
+
+`merge` links each source declaration to the binary's exported symbol (matching
+ctor/dtor ABI clone variants — `C1`/`C2`/`C3`, `D0`/`D1`/`D2` — so one source
+constructor claims all of its exported symbols). The result is a single
+self-contained `.baseline.json` carrying L0–L5, ready for
+[`compare`](local-compare.md) or [`scan --baseline`](scan-levels.md).

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -105,6 +105,13 @@ of the zero-parse path, and why Flow A/B remain the portable defaults.
     an example header and the `clang -H` tip, and records it in the pack's
     `diagnostics`.
 
+    And if you omit `public-roots=` entirely, the plugin **auto-derives** roots
+    from the compile's own `-I`/`-iquote` include dirs (compiler/system paths
+    excluded) and emits a one-time inference note — so a forgotten flag yields a
+    populated (if slightly broad) surface rather than an empty pack. Still pass an
+    explicit `public-roots=` when you want the surface scoped precisely to your
+    installed public headers.
+
 ## Then: fold the facts onto the binary
 
 However you produced them, ingest is the same — dump the binary side, then merge:

--- a/examples/case149_xcheck_odr_variant/snapshot.abi.json
+++ b/examples/case149_xcheck_odr_variant/snapshot.abi.json
@@ -22,7 +22,8 @@
       "mappings": {
         "public_header_to_target": {},
         "source_decl_to_binary_symbol": {},
-        "source_type_to_debug_type": {}
+        "source_type_to_debug_type": {},
+        "synthesized_symbol_to_owner": {}
       },
       "odr_conflicts": [
         {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Everyday Use:
       - CLI Usage: user-guide/cli-usage.md
       - Source-Scan Levels: user-guide/scan-levels.md
+      - Producing Source Facts: user-guide/producing-source-facts.md
       - Output Formats: user-guide/output-formats.md
       - Baseline Management: user-guide/baseline-management.md
     - CI & Gating:

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -2198,7 +2198,7 @@ def test_merge_relinks_source_surface_with_binary_exports(tmp_path):
     from abicheck.buildsource.model import BuildSourceManifest
     from abicheck.buildsource.pack import BuildSourcePack
     from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity
-    from abicheck.elf_metadata import ElfMetadata
+    from abicheck.elf_metadata import ElfMetadata, ElfSymbol
     from abicheck.model import Function
 
     # Source-only snapshot: a surface with one public decl, no exports yet.
@@ -2216,6 +2216,9 @@ def test_merge_relinks_source_surface_with_binary_exports(tmp_path):
     # Binary snapshot exporting _Z3foov.
     bin_snap = AbiSnapshot(library="libfoo.so", version="1")
     bin_snap.elf = ElfMetadata()
+    # A realistic binary exports _Z3foov via its dynamic symbol table (the
+    # authoritative export set), not merely via the DWARF-modeled functions list.
+    bin_snap.elf.symbols = [ElfSymbol(name="_Z3foov")]
     bin_snap.functions = [Function(name="foo", mangled="_Z3foov",
                                    return_type="void", params=[])]
     bin_path = tmp_path / "bin.json"
@@ -2244,7 +2247,7 @@ def test_merge_relink_rebuilds_l5_graph_and_refreshes_hash(tmp_path):
     from abicheck.buildsource.pack import BuildSourcePack
     from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity
     from abicheck.buildsource.source_graph import build_source_graph
-    from abicheck.elf_metadata import ElfMetadata
+    from abicheck.elf_metadata import ElfMetadata, ElfSymbol
     from abicheck.model import Function
 
     surf = SourceAbiSurface(library="libfoo.so", target_id="t")
@@ -2262,6 +2265,9 @@ def test_merge_relink_rebuilds_l5_graph_and_refreshes_hash(tmp_path):
 
     bin_snap = AbiSnapshot(library="libfoo.so", version="1")
     bin_snap.elf = ElfMetadata()
+    # A realistic binary exports _Z3foov via its dynamic symbol table (the
+    # authoritative export set), not merely via the DWARF-modeled functions list.
+    bin_snap.elf.symbols = [ElfSymbol(name="_Z3foov")]
     bin_snap.functions = [Function(name="foo", mangled="_Z3foov",
                                    return_type="void", params=[])]
     bin_path = tmp_path / "bin.json"

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1921,6 +1921,23 @@ def test_exported_symbols_from_snapshot_uses_elf_dynamic_table():
     assert "_ZN3FooC4Ev" in exports
 
 
+def test_exported_symbols_from_snapshot_uses_pe_and_macho_tables():
+    """The same export-table union covers PE and Mach-O binaries, not just ELF."""
+    from abicheck.cli_buildsource import _exported_symbols_from_snapshot
+    from abicheck.macho_metadata import MachoExport, MachoMetadata
+    from abicheck.pe_metadata import PeExport, PeMetadata
+
+    pe_snap = AbiSnapshot(library="foo.dll", version="1")
+    pe_snap.pe = PeMetadata()
+    pe_snap.pe.exports = [PeExport(name="CreateFoo"), PeExport(name="DestroyFoo")]
+    assert _exported_symbols_from_snapshot(pe_snap) == ("CreateFoo", "DestroyFoo")
+
+    macho_snap = AbiSnapshot(library="libfoo.dylib", version="1")
+    macho_snap.macho = MachoMetadata()
+    macho_snap.macho.exports = [MachoExport(name="_foo"), MachoExport(name="_bar")]
+    assert _exported_symbols_from_snapshot(macho_snap) == ("_bar", "_foo")
+
+
 def test_build_info_source_mismatch_records_diagnostic(tmp_path):
     """A4: a compile DB whose sources are absent from the --sources tree records
     a build_info_source_tree_mismatch diagnostic (collection-time, not a kind)."""

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1923,6 +1923,29 @@ def test_exported_symbols_from_snapshot_uses_elf_dynamic_table():
     assert "_ZN3FooC4Ev" not in exports
 
 
+def test_merge_warns_on_empty_source_surface(capsys):
+    """Project-level Caveat A: merging a pack whose whole source surface is empty
+    while the binary exports symbols warns that public-roots was likely wrong."""
+    from types import SimpleNamespace
+
+    from abicheck.buildsource.source_abi import SourceAbiSurface
+    from abicheck.cli_buildsource_merge import _warn_if_source_surface_empty
+
+    empty = SourceAbiSurface(library="libfoo.so", target_id="t")  # no entities
+    combined = SimpleNamespace(source_abi=empty)
+    _warn_if_source_surface_empty(combined, ("_Z3foov", "_Z3barv"))
+    err = capsys.readouterr().err
+    assert "no public entities" in err
+    assert "public-roots" in err
+
+    # A non-empty surface (or no exports) is silent.
+    populated = SourceAbiSurface(library="libfoo.so", target_id="t")
+    populated.reachable_declarations.append(object())
+    _warn_if_source_surface_empty(SimpleNamespace(source_abi=populated), ("_Z3foov",))
+    _warn_if_source_surface_empty(SimpleNamespace(source_abi=empty), ())
+    assert capsys.readouterr().err == ""
+
+
 def test_exported_symbols_falls_back_to_modeled_names_without_raw_table():
     """With no raw dynamic table (a source-only snapshot), the modeled mangled
     names are the only available fallback."""

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1923,6 +1923,27 @@ def test_exported_symbols_from_snapshot_uses_elf_dynamic_table():
     assert "_ZN3FooC4Ev" not in exports
 
 
+def test_exported_symbols_from_snapshot_excludes_non_default_versions():
+    """A symbol that exists only as a non-default version alias (``foo@VER`` with
+    no default ``foo@@VER``) cannot be linked against by an unversioned consumer,
+    so it must NOT enter the relink export set — otherwise the L4 mapping marks a
+    header decl backed only by that alias as exported and the crosscheck's two-way
+    reconciliation wrongly suppresses ``public_not_exported`` (Codex review)."""
+    from abicheck.cli_buildsource import _exported_symbols_from_snapshot
+    from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+
+    snap = AbiSnapshot(library="libfoo.so", version="1")
+    snap.elf = ElfMetadata()
+    snap.elf.symbols = [
+        ElfSymbol(name="_Z3foov", version="LIB_1", is_default=True),  # default → in
+        ElfSymbol(name="_Z3oldv", version="LIB_1", is_default=False),  # alias → out
+        ElfSymbol(name="_Z3barv"),  # unversioned (is_default defaults True) → in
+    ]
+    exports = _exported_symbols_from_snapshot(snap)
+    assert set(exports) == {"_Z3foov", "_Z3barv"}
+    assert "_Z3oldv" not in exports
+
+
 def test_merge_warns_on_empty_source_surface(capsys):
     """Project-level Caveat A: merging a pack whose whole source surface is empty
     while the binary exports symbols warns that public-roots was likely wrong."""

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1913,12 +1913,29 @@ def test_exported_symbols_from_snapshot_uses_elf_dynamic_table():
         ElfSymbol(name="_Z3barv"),
     ]
     exports = _exported_symbols_from_snapshot(snap)
-    # Raw dynamic-table names are present (not just the modeled C4 tag).
+    # The raw dynamic table is authoritative and used alone.
     assert "_ZN3FooC1Ev" in exports
     assert "_ZN3FooC2Ev" in exports
     assert "_Z3barv" in exports
-    # The modeled mangled name is still included as a fallback.
-    assert "_ZN3FooC4Ev" in exports
+    # The DWARF-only unified C4 tag is NOT a real export — it must not leak into
+    # the export set (or a source decl mangled C4 would exact-match a phantom and
+    # inflate exported_symbols/matched_symbols; Codex review).
+    assert "_ZN3FooC4Ev" not in exports
+
+
+def test_exported_symbols_falls_back_to_modeled_names_without_raw_table():
+    """With no raw dynamic table (a source-only snapshot), the modeled mangled
+    names are the only available fallback."""
+    from abicheck.cli_buildsource import _exported_symbols_from_snapshot
+    from abicheck.model import Function, Variable
+
+    snap = AbiSnapshot(library="libfoo.so", version="1")
+    snap.functions = [
+        Function(name="foo", mangled="_Z3foov", return_type="void", params=[])
+    ]
+    snap.variables = [Variable(name="g", mangled="_Z1g", type="int")]
+    # No .elf/.pe/.macho set → fall back to the modeled names.
+    assert _exported_symbols_from_snapshot(snap) == ("_Z1g", "_Z3foov")
 
 
 def test_exported_symbols_from_snapshot_uses_pe_and_macho_tables():

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -1890,6 +1890,37 @@ def test_exported_symbols_from_snapshot_extracts_mangled_names():
     assert _exported_symbols_from_snapshot(AbiSnapshot(library="l", version="1")) == ()
 
 
+def test_exported_symbols_from_snapshot_uses_elf_dynamic_table():
+    """The authoritative export set is the ELF dynamic symbol table, not just the
+    DWARF-shaped ``functions`` list. Feeding only the modeled functions truncated
+    the linker's export set (the ``merge`` symbol-matching regression), so the raw
+    ``elf.symbols`` names must be unioned in."""
+    from abicheck.cli_buildsource import _exported_symbols_from_snapshot
+    from abicheck.elf_metadata import ElfMetadata, ElfSymbol
+    from abicheck.model import Function
+
+    snap = AbiSnapshot(library="libfoo.so", version="1")
+    # A DWARF-modeled function whose linkage name is the non-ABI unified C4 tag —
+    # never present in the real export table.
+    snap.functions = [
+        Function(name="Foo::Foo", mangled="_ZN3FooC4Ev", return_type="void", params=[])
+    ]
+    snap.elf = ElfMetadata()
+    # The real exported clones the loader sees.
+    snap.elf.symbols = [
+        ElfSymbol(name="_ZN3FooC1Ev"),
+        ElfSymbol(name="_ZN3FooC2Ev"),
+        ElfSymbol(name="_Z3barv"),
+    ]
+    exports = _exported_symbols_from_snapshot(snap)
+    # Raw dynamic-table names are present (not just the modeled C4 tag).
+    assert "_ZN3FooC1Ev" in exports
+    assert "_ZN3FooC2Ev" in exports
+    assert "_Z3barv" in exports
+    # The modeled mangled name is still included as a fallback.
+    assert "_ZN3FooC4Ev" in exports
+
+
 def test_build_info_source_mismatch_records_diagnostic(tmp_path):
     """A4: a compile DB whose sources are absent from the --sources tree records
     a build_info_source_tree_mismatch diagnostic (collection-time, not a kind)."""

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -370,7 +370,35 @@ def test_public_not_exported_reconciles_macho_underscore_variant():
     # normalized key builds without error and is present in the reconciled set.)
     from abicheck.buildsource.crosscheck import _l4_reconciled_symbols
 
-    assert "_ZN1A3fooEv" in _l4_reconciled_symbols(snap)
+    assert "_ZN1A3fooEv" in _l4_reconciled_symbols(snap, {"_ZN1A3fooEv"})
+
+
+def test_public_not_exported_reconciliation_ignores_stale_mapping():
+    # A merge pack whose exported_symbols were pre-set is NOT relinked, so its L4
+    # mapping can reference an OLDER binary. A decl mapped to a symbol the CURRENT
+    # snapshot no longer exports must still be flagged — the reconciliation only
+    # trusts a mapping whose target is in the current export table (Codex review).
+    snap = _snap(elf=_elf("_Z4livev"))  # current binary exports only `live`
+    snap.functions = [
+        Function(
+            name="stale",
+            mangled="_Z5stalev",
+            return_type="void",
+            origin=ScopeOrigin.PUBLIC_HEADER,
+        ),
+    ]
+    surface = SourceAbiSurface(library="libfoo.so")
+    # L4 mapping from an older binary that still "exported" `stale`.
+    surface.mappings["source_decl_to_binary_symbol"] = {"_Z5stalev": "_Z5stalev"}
+    snap.build_source = BuildSourcePack(root="", source_abi=surface)
+    res = run_crosschecks(snap)
+    hits = [c.symbol for c in _findings_of(res, ChangeKind.PUBLIC_NOT_EXPORTED)]
+    # The stale mapping must NOT suppress the finding — `stale` is genuinely gone.
+    assert hits == ["_Z5stalev"]
+    # And the direct helper drops the stale key (its target is not in exports).
+    from abicheck.buildsource.crosscheck import _l4_reconciled_symbols
+
+    assert _l4_reconciled_symbols(snap, {"_Z4livev"}) == set()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -348,6 +348,37 @@ def test_public_not_exported_reconciles_l4_variant_export():
     assert hits == ["_Z4gonev"]
 
 
+def test_public_not_exported_reconciles_l4_variant_variable():
+    # Parity with the function case (CodeRabbit): the same L4 reconciliation
+    # suppression is applied to snapshot.variables. A public extern variable the L4
+    # linker tied to a currently-exported symbol under a spelling drift (here an
+    # ABI-tag) is not flagged; a genuinely-absent one still is.
+    snap = _snap(elf=_elf("_ZN2ns3fooB5cxx11E"))
+    snap.variables = [
+        Variable(
+            name="ns::foo",
+            mangled="_ZN2ns3fooE",  # drifts from the exported ABI-tag spelling
+            type="int",
+            origin=ScopeOrigin.PUBLIC_HEADER,
+        ),
+        Variable(
+            name="ns::gone",
+            mangled="_ZN2ns4goneE",  # truly not exported, not reconciled
+            type="int",
+            origin=ScopeOrigin.PUBLIC_HEADER,
+        ),
+    ]
+    surface = SourceAbiSurface(library="libfoo.so")
+    surface.mappings["source_decl_to_binary_symbol"] = {
+        "_ZN2ns3fooE": "_ZN2ns3fooB5cxx11E",  # reconciled to the exported symbol
+        "_ZN2ns4goneE": "",  # linker could not match it
+    }
+    snap.build_source = BuildSourcePack(root="", source_abi=surface)
+    res = run_crosschecks(snap)
+    hits = [c.symbol for c in _findings_of(res, ChangeKind.PUBLIC_NOT_EXPORTED)]
+    assert hits == ["_ZN2ns4goneE"]
+
+
 def test_public_not_exported_reconciles_macho_underscore_variant():
     # Reconciliation keys are Mach-O-normalized: a plugin-recorded `__ZN…` decl key
     # must still exempt the L2 `_ZN…` mangled decl (Codex Mach-O normalization).

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -315,6 +315,64 @@ def test_public_not_exported_flags_missing_symbol():
     assert hits[0].confidence == Confidence.HIGH
 
 
+def test_public_not_exported_reconciles_l4_variant_export():
+    # Two-way reconciliation: a public ctor decl mangled `_ZN6WidgetC1Ev` whose
+    # binary lists only the base-object clone `_ZN6WidgetC2Ev` is NOT missing — the
+    # L4 source-linker already tied the C1 decl to the exported C2 clone. Without
+    # the reconciliation set it would false-positive; with the L4 mapping attached
+    # it must stay silent. A genuinely-absent decl in the same snapshot still fires.
+    snap = _snap(elf=_elf("_ZN6WidgetC2Ev"))
+    snap.functions = [
+        Function(
+            name="Widget::Widget",
+            mangled="_ZN6WidgetC1Ev",  # complete-object ctor; binary lists only C2
+            return_type="",
+            origin=ScopeOrigin.PUBLIC_HEADER,
+        ),
+        Function(
+            name="gone",
+            mangled="_Z4gonev",  # truly not exported, not reconciled
+            return_type="void",
+            origin=ScopeOrigin.PUBLIC_HEADER,
+        ),
+    ]
+    surface = SourceAbiSurface(library="libfoo.so")
+    surface.mappings["source_decl_to_binary_symbol"] = {
+        "_ZN6WidgetC1Ev": "_ZN6WidgetC2Ev",  # linker reconciled the clone
+        "_Z4gonev": "",  # linker could not match it
+    }
+    snap.build_source = BuildSourcePack(root="", source_abi=surface)
+    res = run_crosschecks(snap)
+    hits = [c.symbol for c in _findings_of(res, ChangeKind.PUBLIC_NOT_EXPORTED)]
+    # Only the genuinely-missing symbol is flagged; the reconciled ctor is exempt.
+    assert hits == ["_Z4gonev"]
+
+
+def test_public_not_exported_reconciles_macho_underscore_variant():
+    # Reconciliation keys are Mach-O-normalized: a plugin-recorded `__ZN…` decl key
+    # must still exempt the L2 `_ZN…` mangled decl (Codex Mach-O normalization).
+    snap = _snap(elf=_elf("_ZN1A3fooEv"))
+    snap.functions = [
+        Function(
+            name="A::foo",
+            mangled="_ZN1A3fooEv",
+            return_type="void",
+            origin=ScopeOrigin.PUBLIC_HEADER,
+        ),
+    ]
+    surface = SourceAbiSurface(library="libfoo.so")
+    # The L4 linker recorded the raw Mach-O key spelling.
+    surface.mappings["source_decl_to_binary_symbol"] = {
+        "__ZN1A3fooEv": "_ZN1A3fooEv",
+    }
+    snap.build_source = BuildSourcePack(root="", source_abi=surface)
+    # (This symbol IS exported here, so it would not flag anyway; the point is the
+    # normalized key builds without error and is present in the reconciled set.)
+    from abicheck.buildsource.crosscheck import _l4_reconciled_symbols
+
+    assert "_ZN1A3fooEv" in _l4_reconciled_symbols(snap)
+
+
 @pytest.mark.parametrize(
     "mutate",
     [

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -401,6 +401,31 @@ def test_public_not_exported_reconciliation_ignores_stale_mapping():
     assert _l4_reconciled_symbols(snap, {"_Z4livev"}) == set()
 
 
+def test_reconciliation_underscore_strip_is_macho_only():
+    from abicheck.buildsource.crosscheck import _l4_reconciled_symbols
+
+    # ELF: the single-underscore strip must NOT apply. A stale mapping to a
+    # leading-underscore C symbol `_bar` (no longer exported) must NOT be
+    # reconciled just because an unrelated `bar` is exported (Codex review).
+    elf_snap = _snap(elf=_elf("bar"))
+    surf = SourceAbiSurface(library="l")
+    surf.mappings["source_decl_to_binary_symbol"] = {"_bar": "_bar"}
+    elf_snap.build_source = BuildSourcePack(root="", source_abi=surf)
+    assert _l4_reconciled_symbols(elf_snap, {"bar"}) == set()
+
+    # Mach-O: the export table strips one underscore, so a raw `__ZN…`/`_foo`
+    # mapping value still reconciles against the stripped export set.
+    macho_snap = _snap(
+        macho=MachoMetadata(exports=[MachoExport(name="__ZN1A3fooEv")])
+    )
+    surf2 = SourceAbiSurface(library="l")
+    surf2.mappings["source_decl_to_binary_symbol"] = {"__ZN1A3fooEv": "__ZN1A3fooEv"}
+    macho_snap.build_source = BuildSourcePack(root="", source_abi=surf2)
+    # _exported_symbol_names strips one underscore → {"_ZN1A3fooEv"}; the mapping
+    # value "__ZN1A3fooEv" reconciles via the Mach-O strip.
+    assert _l4_reconciled_symbols(macho_snap, {"_ZN1A3fooEv"}) == {"_ZN1A3fooEv"}
+
+
 @pytest.mark.parametrize(
     "mutate",
     [

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -521,6 +521,46 @@ def test_relink_matches_macho_non_ctor_decl_against_stripped_exports() -> None:
     )
 
 
+def test_norm_itanium_strips_only_macho_double_underscore() -> None:
+    from abicheck.buildsource.source_link import _norm_itanium
+
+    # `__Z…` loses exactly one leading underscore; every other spelling is byte-
+    # for-byte unchanged (a C symbol, an already-normalized `_Z…`, a bare name).
+    assert _norm_itanium("__ZN1A3fooEv") == "_ZN1A3fooEv"
+    assert _norm_itanium("_ZN1A3fooEv") == "_ZN1A3fooEv"
+    assert _norm_itanium("foo") == "foo"
+    assert _norm_itanium("") == ""
+
+
+def test_build_exact_index_prefers_canonical_spelling_on_collision() -> None:
+    from abicheck.buildsource.source_link import _build_exact_index
+
+    # If a binary somehow lists BOTH spellings of one Itanium name (practically
+    # impossible), the canonical `_Z…` form wins the normalized key so the returned
+    # real spelling is deterministic and genuinely in the export set.
+    idx = _build_exact_index({"__ZN1A3fooEv", "_ZN1A3fooEv"})
+    assert idx["_ZN1A3fooEv"] == "_ZN1A3fooEv"
+    # A lone Mach-O spelling maps its normalized key back to the real `__Z…` name.
+    idx2 = _build_exact_index({"__ZN1A3fooEv"})
+    assert idx2["_ZN1A3fooEv"] == "__ZN1A3fooEv"
+
+
+@needs_demangler
+def test_demangled_rematch_normalizes_macho_decl() -> None:
+    # The second-tier rematch must normalize a Mach-O `__Z…` decl before demangling
+    # (the shared demangler only accepts `_Z…`), so a drifted macOS decl still
+    # rescues against the `_Z…` export.
+    from abicheck.buildsource.source_link import _demangled_rematch
+
+    decl = _entity("N::f", "function", mangled="__ZN1N1fEN1N1TE")  # Mach-O spelling
+    mapping = {decl.identity(): ""}
+    matched: set[str] = set()
+    exported = {"_ZN1N1fENS_1TE"}  # substitution form, same demangled identity
+    new = _demangled_rematch([decl], mapping, matched, exported)
+    assert new == {decl.identity(): "_ZN1N1fENS_1TE"}
+    assert mapping[decl.identity()] == "_ZN1N1fENS_1TE"
+
+
 def test_ctor_dtor_fold_handles_function_type_template_args() -> None:
     # Codex review: a function-type template argument (`A<void(int)>` → `FviE`,
     # `std::function<void()>` → `FvvE`) is itself E-terminated; the balanced skip

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -487,6 +487,40 @@ def test_linker_matches_macho_decl_against_stripped_exports() -> None:
     assert surface.unmatched["symbols_without_decl"] == []
 
 
+def test_linker_matches_macho_non_ctor_decl_against_stripped_exports() -> None:
+    # Codex review: an ORDINARY (non ctor/dtor) C++ method takes the no-fold path,
+    # so on macOS Flow-C the plugin's `__ZN1A3fooEv` must still exact-match the
+    # export table's `_ZN1A3fooEv` (one underscore stripped). Before the fix these
+    # landed in decls_without_symbol / symbols_without_decl because normalization
+    # was applied only to ctor/dtor canonical keys.
+    tu = SourceAbiTu(functions=[_entity("A::foo", "function", mangled="__ZN1A3fooEv")])
+    surface = link_source_abi([tu], exported_symbols=["_ZN1A3fooEv"])
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.unmatched["decls_without_symbol"] == []
+    # The mapping resolves to the REAL exported spelling (the `_Z…` form actually in
+    # the binary), not the plugin's raw `__Z…` key.
+    assert (
+        surface.mappings["source_decl_to_binary_symbol"]["__ZN1A3fooEv"]
+        == "_ZN1A3fooEv"
+    )
+
+
+def test_relink_matches_macho_non_ctor_decl_against_stripped_exports() -> None:
+    # Same normalization must apply on the merge/relink path (a plugin/wrapper pack
+    # linked with no binary, then relinked against the Mach-O export table).
+    from abicheck.buildsource.source_link import relink_surface_exports
+
+    tu = SourceAbiTu(functions=[_entity("A::foo", "function", mangled="__ZN1A3fooEv")])
+    surface = link_source_abi([tu])  # source-only, no exports yet
+    relink_surface_exports(surface, ["_ZN1A3fooEv"])
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.unmatched["decls_without_symbol"] == []
+    assert (
+        surface.mappings["source_decl_to_binary_symbol"]["__ZN1A3fooEv"]
+        == "_ZN1A3fooEv"
+    )
+
+
 def test_ctor_dtor_fold_handles_function_type_template_args() -> None:
     # Codex review: a function-type template argument (`A<void(int)>` → `FviE`,
     # `std::function<void()>` → `FvvE`) is itself E-terminated; the balanced skip
@@ -612,6 +646,34 @@ def test_relink_also_attributes_synthesized_exports() -> None:
     assert surface.unmatched["symbols_without_decl"] == []
     assert surface.coverage["synthesized_symbols_matched"] == 2
     assert surface.coverage["unmatched_symbols"] == 0
+
+
+@needs_demangler
+def test_relink_clears_stale_synthesized_owners() -> None:
+    # Codex review: a relink runs against a possibly different export set. A surface
+    # that recorded synthesized owners on a previous link but attributes NONE under
+    # the new exports must have the stale mapping cleared — otherwise the serialized
+    # L4 surface keeps claiming ownership of vtables/typeinfo the new binary never
+    # exports, contradicting the recomputed coverage / symbols_without_decl.
+    from abicheck.buildsource.source_link import relink_surface_exports
+
+    tu = SourceAbiTu(
+        types=[_entity("Widget", "record", type_hash="t1")],
+        functions=[_entity("Widget::foo", "function", mangled="_ZN6Widget3fooEv")],
+    )
+    surface = link_source_abi([tu])
+    # First relink: Widget's vtable/typeinfo attribute → mapping is populated.
+    relink_surface_exports(surface, ["_ZTV6Widget", "_ZTI6Widget"])
+    assert surface.mappings["synthesized_symbol_to_owner"]  # non-empty
+
+    # Second relink against an export set with NO synthesized matches: the previous
+    # owners must be cleared, not left as stale evidence.
+    relink_surface_exports(surface, ["_ZN6Widget3fooEv"])
+    assert surface.mappings["synthesized_symbol_to_owner"] == {}
+    assert surface.coverage["synthesized_symbols_matched"] == 0
+    # And the surface round-trips with the cleared (empty) mapping.
+    restored = SourceAbiSurface.from_dict(surface.to_dict())
+    assert restored.mappings["synthesized_symbol_to_owner"] == {}
 
 
 @needs_demangler

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -442,6 +442,53 @@ def test_ctor_dtor_fold_handles_non_type_template_parameters() -> None:
         assert _ctor_dtor_canonical(sym.format(tag="C1")) != sym.format(tag="C1")
 
 
+def test_ctor_dtor_fold_handles_macho_leading_underscore() -> None:
+    # Codex review: Mach-O/Darwin prefixes every Itanium symbol with an extra
+    # leading underscore (`__ZN1AC1Ev`). The fold must strip it before parsing and
+    # restore it, or ctor clones on macOS never fold.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    assert _ctor_dtor_canonical("__ZN1AC1Ev") == _ctor_dtor_canonical("__ZN1AC2Ev")
+    # The restored form keeps the Mach-O prefix (so it still matches the export).
+    assert _ctor_dtor_canonical("__ZN1AC1Ev").startswith("__ZN")
+    # A Mach-O non-ctor symbol is returned byte-for-byte unchanged.
+    assert _ctor_dtor_canonical("__ZN1N3barEv") == "__ZN1N3barEv"
+
+
+def test_ctor_dtor_fold_handles_function_type_template_args() -> None:
+    # Codex review: a function-type template argument (`A<void(int)>` → `FviE`,
+    # `std::function<void()>` → `FvvE`) is itself E-terminated; the balanced skip
+    # must treat `F` as an opener so its `E` doesn't close the template-arg list
+    # early and hide the trailing ctor tag.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    # A<void(int)>::A()
+    assert _ctor_dtor_canonical("_ZN1AIFviEEC1Ev") == _ctor_dtor_canonical(
+        "_ZN1AIFviEEC2Ev"
+    )
+    # std::function<void()>::function(function const&)
+    assert _ctor_dtor_canonical("_ZNSt8functionIFvvEEC1ERKS1_") == _ctor_dtor_canonical(
+        "_ZNSt8functionIFvvEEC2ERKS1_"
+    )
+
+
+def test_ctor_dtor_demangle_fallback() -> None:
+    # The demangler backstop collapses ctor/dtor clones for any Itanium
+    # production the structural parser doesn't model (a robustness net). It keys a
+    # ctor/dtor to a `ctordtor:<qualified>` form and leaves everything else alone.
+    from abicheck.buildsource.source_link import _ctor_dtor_demangle_fallback as fb
+
+    # Ctor clones and dtor clones each collapse to one key.
+    assert fb("_ZN6WidgetC1Ev") == fb("_ZN6WidgetC2Ev")
+    assert fb("_ZN6WidgetD0Ev") == fb("_ZN6WidgetD1Ev")
+    assert fb("_ZN6WidgetC1Ev").startswith("ctordtor:")
+    # An ordinary function whose name merely ends in C1/C2 is NOT a ctor — the
+    # demangled form (`N::AC1()`) is not `Class::Class`, so it stays unchanged.
+    assert fb("_ZN1N3AC1Ev") == "_ZN1N3AC1Ev"
+    # A plain free function is untouched.
+    assert fb("_Z3foov") == "_Z3foov"
+
+
 def test_ctor_dtor_fold_parser_edge_cases() -> None:
     # Exercise the remaining parser branches for coverage + robustness:
     from abicheck.buildsource.source_link import _ctor_dtor_canonical
@@ -461,6 +508,55 @@ def test_ctor_dtor_fold_parser_edge_cases() -> None:
     assert _ctor_dtor_canonical("_ZN1NS0_3FooC1Ev") == _ctor_dtor_canonical(
         "_ZN1NS0_3FooC2Ev"
     )
+
+
+def test_linker_attributes_rtti_vtable_thunk_to_public_owner() -> None:
+    # vtable/typeinfo/typeinfo-name/thunk exports belong to a type/method, not a
+    # free decl, so exact matching orphaned them. They are now attributed to their
+    # public owner and drop out of symbols_without_decl (ADR-030 D5).
+    tu = SourceAbiTu(
+        types=[_entity("Widget", "record", type_hash="t1")],
+        functions=[_entity("Widget::foo", "function", mangled="_ZN6Widget3fooEv")],
+    )
+    surface = link_source_abi(
+        [tu],
+        exported_symbols=[
+            "_ZN6Widget3fooEv",  # the method itself (decl match)
+            "_ZTV6Widget",  # vtable for Widget
+            "_ZTI6Widget",  # typeinfo for Widget
+            "_ZTS6Widget",  # typeinfo name for Widget
+            "_ZThn8_N6Widget3fooEv",  # non-virtual thunk to Widget::foo()
+            "_ZTVN2ns7UnknownE",  # vtable for a type NOT on the surface
+        ],
+    )
+    # The unknown type's vtable stays unmatched; everything for Widget attributes.
+    assert surface.unmatched["symbols_without_decl"] == ["_ZTVN2ns7UnknownE"]
+    owners = surface.mappings["synthesized_symbol_to_owner"]
+    assert owners["_ZTV6Widget"] == {"kind": "vtable", "owner": "Widget"}
+    assert owners["_ZThn8_N6Widget3fooEv"] == {"kind": "thunk", "owner": "Widget::foo"}
+    # Honest coverage breakdown: 1 decl match + 4 synthesized + 1 remainder.
+    assert surface.coverage["matched_symbols"] == 1
+    assert surface.coverage["synthesized_symbols_matched"] == 4
+    assert surface.coverage["unmatched_symbols"] == 1
+    # The attribution mapping survives serialization.
+    restored = SourceAbiSurface.from_dict(surface.to_dict())
+    assert restored.mappings["synthesized_symbol_to_owner"]["_ZTI6Widget"] == {
+        "kind": "typeinfo",
+        "owner": "Widget",
+    }
+
+
+def test_relink_also_attributes_synthesized_exports() -> None:
+    # The merge/relink path (used by `merge` on a plugin/wrapper pack) must apply
+    # the same RTTI/vtable attribution as link_source_abi.
+    from abicheck.buildsource.source_link import relink_surface_exports
+
+    tu = SourceAbiTu(types=[_entity("Widget", "record", type_hash="t1")])
+    surface = link_source_abi([tu])  # no exports yet (source-only)
+    relink_surface_exports(surface, ["_ZTV6Widget", "_ZTI6Widget"])
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.coverage["synthesized_symbols_matched"] == 2
+    assert surface.coverage["unmatched_symbols"] == 0
 
 
 def test_linker_excludes_non_public_entities() -> None:

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -273,6 +273,74 @@ def test_linker_matches_unmangled_c_exports() -> None:
     assert surface.unmatched["decls_without_symbol"] == []
 
 
+def test_linker_matches_ctor_dtor_abi_clone_variants() -> None:
+    # One source ctor/dtor Decl mangles to a single name (C1/D1), but the compiler
+    # exports several ABI clones (C1 complete + C2 base; D0 deleting + D1 + D2).
+    # An exact-string match would orphan the C2/D0/D2 clones as
+    # "exported but no source decl"; the linker folds ctor/dtor tags so the one
+    # declaration claims every clone (ADR-030 D5 symbol linking).
+    tu = SourceAbiTu(
+        functions=[
+            _entity("Widget::Widget", "function", mangled="_ZN6WidgetC1Ev"),
+            _entity("Widget::~Widget", "function", mangled="_ZN6WidgetD1Ev"),
+        ],
+    )
+    surface = link_source_abi(
+        [tu],
+        exported_symbols=[
+            "_ZN6WidgetC1Ev",  # complete-object ctor (matches decl exactly)
+            "_ZN6WidgetC2Ev",  # base-object ctor clone (only via folding)
+            "_ZN6WidgetD0Ev",  # deleting dtor clone
+            "_ZN6WidgetD1Ev",  # complete-object dtor (matches decl exactly)
+            "_ZN6WidgetD2Ev",  # base-object dtor clone
+        ],
+    )
+    # Every exported clone is attributed to a declaration — none is orphaned.
+    assert surface.unmatched["symbols_without_decl"] == []
+    # Both declarations resolve to a concrete exported symbol (not "").
+    mapping = surface.mappings["source_decl_to_binary_symbol"]
+    assert mapping["_ZN6WidgetC1Ev"]
+    assert mapping["_ZN6WidgetD1Ev"]
+    assert surface.coverage["matched_symbols"] == 5
+
+
+def test_linker_matches_dwarf_unified_ctor_tag_to_real_clones() -> None:
+    # GCC's DWARF linkage name uses the non-standard *unified* C4/D4 tag for a
+    # ctor/dtor, which never appears in the ELF export table (which has C1/C2 …).
+    # The fold canonicalizes C4/D4 too, so a DWARF-sourced decl still matches the
+    # real exported clones instead of collapsing to zero matches.
+    tu = SourceAbiTu(
+        functions=[_entity("Widget::Widget", "function", mangled="_ZN6WidgetC4Ev")],
+    )
+    surface = link_source_abi(
+        [tu], exported_symbols=["_ZN6WidgetC1Ev", "_ZN6WidgetC2Ev"]
+    )
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.coverage["matched_symbols"] == 2
+    # The single decl maps to one of the concrete clones (a stable pick).
+    assert surface.mappings["source_decl_to_binary_symbol"]["_ZN6WidgetC4Ev"] in {
+        "_ZN6WidgetC1Ev",
+        "_ZN6WidgetC2Ev",
+    }
+
+
+def test_ctor_dtor_fold_leaves_non_ctor_symbols_exact() -> None:
+    # The fold must be a no-op for ordinary symbols: a regular function whose name
+    # merely contains letters+digits must not be conflated with a ctor/dtor clone.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    assert _ctor_dtor_canonical("_ZN3foo3barEv") == "_ZN3foo3barEv"
+    # C1/C2/C3/C4 fold together; D0/D1/D2/D4 fold together; the two stay distinct.
+    ctors = {_ctor_dtor_canonical(f"_ZN6WidgetC{n}Ev") for n in (1, 2, 3, 4)}
+    dtors = {_ctor_dtor_canonical(f"_ZN6WidgetD{n}Ev") for n in (0, 1, 2, 4)}
+    assert len(ctors) == 1 and len(dtors) == 1
+    assert ctors != dtors
+    # A non-exported, non-ctor decl stays unmatched (no accidental fold match).
+    tu = SourceAbiTu(functions=[_entity("ns::f", "function", mangled="_ZN2ns1fEi")])
+    surface = link_source_abi([tu], exported_symbols=["_ZN2ns1gEi"])
+    assert surface.mappings["source_decl_to_binary_symbol"]["_ZN2ns1fEi"] == ""
+
+
 def test_linker_excludes_non_public_entities() -> None:
     tu = SourceAbiTu(
         functions=[

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -424,6 +424,24 @@ def test_ctor_dtor_fold_handles_nested_template_argument_names() -> None:
     )
 
 
+def test_ctor_dtor_fold_handles_non_type_template_parameters() -> None:
+    # Codex review: a non-type template parameter mangles as an L<type><value>E
+    # literal whose VALUE is raw digits — `Fixed<3>::Fixed()` → `_ZN5FixedILi3EE`
+    # `C1Ev`. Those digits must not be read as a source-name length (which would
+    # swallow the trailing ctor tag). The literal is consumed to its own E.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    for sym in (
+        "_ZN5FixedILi3EE{tag}Ev",  # Fixed<3>
+        "_ZN3ArrIiLm5EE{tag}Ev",  # Arr<int, 5ul>
+        "_ZN1XILin1EE{tag}Ev",  # X<-1>
+    ):
+        assert _ctor_dtor_canonical(sym.format(tag="C1")) == _ctor_dtor_canonical(
+            sym.format(tag="C2")
+        )
+        assert _ctor_dtor_canonical(sym.format(tag="C1")) != sym.format(tag="C1")
+
+
 def test_ctor_dtor_fold_parser_edge_cases() -> None:
     # Exercise the remaining parser branches for coverage + robustness:
     from abicheck.buildsource.source_link import _ctor_dtor_canonical

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -546,6 +546,25 @@ def test_linker_attributes_rtti_vtable_thunk_to_public_owner() -> None:
     }
 
 
+def test_synthesized_attribution_requires_exact_specialization() -> None:
+    # Codex review: with only `ns::A<int>` on the surface, the vtable for a
+    # DIFFERENT specialization `ns::A<char>` (which base-splits to the same
+    # `ns::A`) must NOT be attributed — that would hide an exported, unchecked
+    # specialization. Base matching is allowed only when the *unspecialized*
+    # template is itself public.
+    tu = SourceAbiTu(types=[_entity("ns::A<int>", "record", type_hash="t1")])
+    surface = link_source_abi(
+        [tu], exported_symbols=["_ZTVN2ns1AIiEE", "_ZTVN2ns1AIcEE"]
+    )
+    # A<int> attributes; A<char> stays an orphan (no public owner).
+    assert surface.unmatched["symbols_without_decl"] == ["_ZTVN2ns1AIcEE"]
+
+    # When the bare (unspecialized) template `ns::A` is public, a base match is OK.
+    tu2 = SourceAbiTu(types=[_entity("ns::A", "record", type_hash="t2")])
+    surface2 = link_source_abi([tu2], exported_symbols=["_ZTVN2ns1AIiEE"])
+    assert surface2.unmatched["symbols_without_decl"] == []
+
+
 def test_relink_also_attributes_synthesized_exports() -> None:
     # The merge/relink path (used by `merge` on a plugin/wrapper pack) must apply
     # the same RTTI/vtable attribution as link_source_abi.
@@ -557,6 +576,37 @@ def test_relink_also_attributes_synthesized_exports() -> None:
     assert surface.unmatched["symbols_without_decl"] == []
     assert surface.coverage["synthesized_symbols_matched"] == 2
     assert surface.coverage["unmatched_symbols"] == 0
+
+
+def test_linker_demangled_identity_rematch() -> None:
+    # A source decl whose mangled name differs *textually* from the export but
+    # demangles identically (substitution-form / mangler drift) is rescued by the
+    # second-tier demangled-identity match. `_ZN1N1fEN1N1TE` (expanded) and
+    # `_ZN1N1fENS_1TE` (substitution form) both demangle to `N::f(N::T)`.
+    decl = _entity("N::f", "function", mangled="_ZN1N1fEN1N1TE")
+    tu = SourceAbiTu(functions=[decl])
+    surface = link_source_abi([tu], exported_symbols=["_ZN1N1fENS_1TE"])
+    # Exact match misses (different strings); the demangled tier rescues it.
+    assert surface.mappings["source_decl_to_binary_symbol"]["_ZN1N1fEN1N1TE"] == (
+        "_ZN1N1fENS_1TE"
+    )
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.unmatched["decls_without_symbol"] == []
+
+
+def test_demangled_rematch_is_unambiguous_only() -> None:
+    # The rematch must never cross-match an overload set: two decls that demangle
+    # distinctly (f(int) vs f(double)) can only claim their own exact export, and
+    # a demangled form shared by >1 export is skipped (never a guess).
+    from abicheck.buildsource.source_link import _demangled_rematch
+
+    fi = _entity("f", "function", mangled="_Z1fi")  # f(int)
+    fd = _entity("f", "function", mangled="_Z1fd")  # f(double)
+    # Both exports present and exact — rematch has nothing to do, no misfire.
+    mapping = {"_Z1fi": "_Z1fi", "_Z1fd": "_Z1fd"}
+    matched = {"_Z1fi", "_Z1fd"}
+    new = _demangled_rematch([fi, fd], mapping, matched, {"_Z1fi", "_Z1fd"})
+    assert new == {}
 
 
 def test_linker_excludes_non_public_entities() -> None:

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -335,10 +335,67 @@ def test_ctor_dtor_fold_leaves_non_ctor_symbols_exact() -> None:
     dtors = {_ctor_dtor_canonical(f"_ZN6WidgetD{n}Ev") for n in (0, 1, 2, 4)}
     assert len(ctors) == 1 and len(dtors) == 1
     assert ctors != dtors
+    # Non-nested / vtable / plain names have no ctor/dtor and stay untouched.
+    assert _ctor_dtor_canonical("_Z3barv") == "_Z3barv"
+    assert _ctor_dtor_canonical("_ZTVN3fooE") == "_ZTVN3fooE"
     # A non-exported, non-ctor decl stays unmatched (no accidental fold match).
     tu = SourceAbiTu(functions=[_entity("ns::f", "function", mangled="_ZN2ns1fEi")])
     surface = link_source_abi([tu], exported_symbols=["_ZN2ns1gEi"])
     assert surface.mappings["source_decl_to_binary_symbol"]["_ZN2ns1fEi"] == ""
+
+
+def test_ctor_dtor_fold_does_not_touch_length_encoded_identifiers() -> None:
+    # Codex review: a `C1`/`D0` that is merely the TAIL of a length-prefixed
+    # ordinary identifier must NOT fold — else two unrelated functions collide and
+    # one is wrongly dropped from symbols_without_decl. `N::AC1()`/`N::AC2()`
+    # mangle as `_ZN1N3AC1Ev`/`_ZN1N3AC2Ev`; the `C1`/`C2` are identifier chars,
+    # not a ctor special name (which is never length-prefixed).
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    assert _ctor_dtor_canonical("_ZN1N3AC1Ev") == "_ZN1N3AC1Ev"
+    assert _ctor_dtor_canonical("_ZN1N3AC1Ev") != _ctor_dtor_canonical("_ZN1N3AC2Ev")
+    # Through the linker: AC1 is a real source decl; AC2 is exported without one.
+    # AC2 must remain an orphan (symbols_without_decl), not be claimed by AC1.
+    tu = SourceAbiTu(
+        functions=[_entity("N::AC1", "function", mangled="_ZN1N3AC1Ev")]
+    )
+    surface = link_source_abi(
+        [tu], exported_symbols=["_ZN1N3AC1Ev", "_ZN1N3AC2Ev"]
+    )
+    assert surface.mappings["source_decl_to_binary_symbol"]["_ZN1N3AC1Ev"] == (
+        "_ZN1N3AC1Ev"
+    )
+    assert surface.unmatched["symbols_without_decl"] == ["_ZN1N3AC2Ev"]
+
+
+def test_ctor_dtor_fold_handles_digit_suffixed_class_names() -> None:
+    # CodeRabbit review: a class whose <source-name> ends in a digit (Vec2, Mat4,
+    # Base64 — common in graphics/math code) must still fold. The structural parse
+    # consumes the length-prefixed identifier wholesale, so the trailing digit is
+    # part of the class name, and the following C1/D0 is correctly seen as the
+    # ctor/dtor special name. (A naive letter-only lookbehind would miss these.)
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    for cls in ("_ZN4Vec2", "_ZN4Mat4", "_ZN6Base64"):
+        assert _ctor_dtor_canonical(cls + "C1Ev") == _ctor_dtor_canonical(cls + "C2Ev")
+        assert _ctor_dtor_canonical(cls + "D0Ev") == _ctor_dtor_canonical(cls + "D1Ev")
+        # and the fold actually happened (not a no-op)
+        assert _ctor_dtor_canonical(cls + "C1Ev") != cls + "C1Ev"
+
+
+def test_ctor_dtor_fold_parses_template_and_substitution_prefixes() -> None:
+    # The nested-name parser must skip <substitution> (St = std::) and
+    # <template-args> (I…E) before reaching a genuine ctor/dtor tag, e.g.
+    # std::vector<int>::vector() → _ZNSt6vectorIiEC1Ev. Exercises the S and I
+    # branches of the parser.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    assert _ctor_dtor_canonical("_ZNSt6vectorIiEC1Ev") == _ctor_dtor_canonical(
+        "_ZNSt6vectorIiEC2Ev"
+    )
+    assert _ctor_dtor_canonical("_ZNSt6vectorIiEC1Ev") != "_ZNSt6vectorIiEC1Ev"
+    # A backref substitution (S_) in the prefix, then the ctor.
+    assert _ctor_dtor_canonical("_ZN1NS_3FooC1Ev") != "_ZN1NS_3FooC1Ev"
 
 
 def test_linker_excludes_non_public_entities() -> None:

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -730,6 +730,67 @@ def test_thunk_target_mangled_parses_offset_forms() -> None:
     assert _thunk_target_mangled("_ZTV6Widget") is None  # vtable, not a thunk
 
 
+@pytest.mark.parametrize(
+    "sym,expected",
+    [
+        # non-virtual, positive and negative (n) this-adjustment.
+        ("_ZTh4_N1D3fooEv", "_ZN1D3fooEv"),
+        ("_ZThn8_N1D3fooEv", "_ZN1D3fooEv"),
+        # virtual thunk: two numbers (v-offset _ vcall-offset _).
+        ("_ZTv0_n24_N1D3fooEv", "_ZN1D3fooEv"),
+        # covariant: TWO call-offsets (h/v) before the encoding.
+        ("_ZTch0_h4_N1D5cloneEv", "_ZN1D5cloneEv"),
+        ("_ZTcv0_n24_h8_N1D5cloneEv", "_ZN1D5cloneEv"),
+        # --- malformed / non-thunk → None (error branches) ---
+        ("", None),
+        ("foo", None),
+        ("_ZT", None),  # too short, no kind char
+        ("_ZTz0_N1DfooEv", None),  # kind not h/v/c
+        ("_ZTh", None),  # kind but no offset digits (read_number → None)
+        ("_ZThX_N1DfooEv", None),  # non-digit offset
+        ("_ZThn8N1DfooEv", None),  # missing '_' after the number
+        ("_ZTv0_N1DfooEv", None),  # virtual missing the second offset
+        ("_ZTch0_N1DfooEv", None),  # covariant missing the second call-offset
+        ("_ZThn8_", None),  # valid offset but empty encoding
+    ],
+)
+def test_thunk_target_mangled_branches(sym: str, expected: str | None) -> None:
+    from abicheck.buildsource.source_link import _thunk_target_mangled
+
+    assert _thunk_target_mangled(sym) == expected
+
+
+@needs_demangler
+def test_synthesized_attribution_skips_unrecognized_symbols() -> None:
+    # A synthesized-looking symbol that fails to demangle (`_ZTTN6Widget`) or
+    # demangles to an unrecognized form (`_ZTW1x` = "TLS wrapper function for x")
+    # is left orphaned, never attributed — exercising the best-effort skip branches.
+    tu = SourceAbiTu(types=[_entity("Widget", "record", type_hash="t1")])
+    surface = link_source_abi([tu], exported_symbols=["_ZTTN6Widget", "_ZTW1x"])
+    assert sorted(surface.unmatched["symbols_without_decl"]) == [
+        "_ZTTN6Widget",
+        "_ZTW1x",
+    ]
+    assert surface.mappings["synthesized_symbol_to_owner"] == {}
+
+
+@needs_demangler
+def test_guard_variable_attributed_to_enclosing_function() -> None:
+    # A guard variable for a function-local static (`_ZGVZ3foovE3bar` demangles to
+    # "guard variable for foo()::bar") is attributed to its enclosing public
+    # function `foo` — the guard-owner (bare-name) path, distinct from the
+    # overload-specific thunk path.
+    tu = SourceAbiTu(functions=[_entity("foo", "function", mangled="_Z3foov")])
+    surface = link_source_abi(
+        [tu], exported_symbols=["_Z3foov", "_ZGVZ3foovE3bar"]
+    )
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.mappings["synthesized_symbol_to_owner"]["_ZGVZ3foovE3bar"] == {
+        "kind": "guard",
+        "owner": "foo",
+    }
+
+
 @needs_demangler
 def test_synthesized_attribution_requires_exact_specialization() -> None:
     # Codex review: with only `ns::A<int>` on the surface, the vtable for a

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -17,6 +17,8 @@ source-replay diff findings (D4, D5, D6, D10)."""
 
 from __future__ import annotations
 
+import pytest
+
 from abicheck.buildsource import (
     SOURCE_ABI_VERSION,
     BuildSourcePack,
@@ -34,6 +36,24 @@ from abicheck.checker_policy import (
     RISK_KINDS,
     ChangeKind,
 )
+
+
+def _no_demangler() -> bool:
+    """True when no working C++ demangler (cxxfilt / c++filt) is available — some
+    CI runners (macOS, Windows) have neither. Demangler-dependent matching
+    degrades gracefully in that case, so the tests that assert the *demangler-
+    present* behaviour are skipped rather than failed."""
+    from abicheck.demangle import demangle
+
+    return demangle("_ZN6WidgetC1Ev") is None
+
+
+#: Skip marker for tests that assert demangler-derived matching (RTTI/vtable
+#: attribution, the ctor/dtor demangle backstop, the demangled-identity rematch).
+needs_demangler = pytest.mark.skipif(
+    _no_demangler(), reason="no C++ demangler (cxxfilt/c++filt) available"
+)
+
 
 # -- helpers -----------------------------------------------------------------
 
@@ -472,6 +492,7 @@ def test_ctor_dtor_fold_handles_function_type_template_args() -> None:
     )
 
 
+@needs_demangler
 def test_ctor_dtor_demangle_fallback() -> None:
     # The demangler backstop collapses ctor/dtor clones for any Itanium
     # production the structural parser doesn't model (a robustness net). It keys a
@@ -510,6 +531,7 @@ def test_ctor_dtor_fold_parser_edge_cases() -> None:
     )
 
 
+@needs_demangler
 def test_linker_attributes_rtti_vtable_thunk_to_public_owner() -> None:
     # vtable/typeinfo/typeinfo-name/thunk exports belong to a type/method, not a
     # free decl, so exact matching orphaned them. They are now attributed to their
@@ -546,6 +568,7 @@ def test_linker_attributes_rtti_vtable_thunk_to_public_owner() -> None:
     }
 
 
+@needs_demangler
 def test_synthesized_attribution_requires_exact_specialization() -> None:
     # Codex review: with only `ns::A<int>` on the surface, the vtable for a
     # DIFFERENT specialization `ns::A<char>` (which base-splits to the same
@@ -565,6 +588,7 @@ def test_synthesized_attribution_requires_exact_specialization() -> None:
     assert surface2.unmatched["symbols_without_decl"] == []
 
 
+@needs_demangler
 def test_relink_also_attributes_synthesized_exports() -> None:
     # The merge/relink path (used by `merge` on a plugin/wrapper pack) must apply
     # the same RTTI/vtable attribution as link_source_abi.
@@ -578,6 +602,7 @@ def test_relink_also_attributes_synthesized_exports() -> None:
     assert surface.coverage["unmatched_symbols"] == 0
 
 
+@needs_demangler
 def test_linker_demangled_identity_rematch() -> None:
     # A source decl whose mangled name differs *textually* from the export but
     # demangles identically (substitution-form / mangler drift) is rescued by the

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -464,15 +464,27 @@ def test_ctor_dtor_fold_handles_non_type_template_parameters() -> None:
 
 def test_ctor_dtor_fold_handles_macho_leading_underscore() -> None:
     # Codex review: Mach-O/Darwin prefixes every Itanium symbol with an extra
-    # leading underscore (`__ZN1AC1Ev`). The fold must strip it before parsing and
-    # restore it, or ctor clones on macOS never fold.
+    # leading underscore (`__ZN1AC1Ev`). The fold must NORMALIZE it away for the
+    # canonical key so it unifies with the export table's `_ZN…` spelling.
     from abicheck.buildsource.source_link import _ctor_dtor_canonical
 
     assert _ctor_dtor_canonical("__ZN1AC1Ev") == _ctor_dtor_canonical("__ZN1AC2Ev")
-    # The restored form keeps the Mach-O prefix (so it still matches the export).
-    assert _ctor_dtor_canonical("__ZN1AC1Ev").startswith("__ZN")
+    # The prefix is NORMALIZED away (not restored): the export table strips one
+    # underscore (`_ZN…`) while the plugin emits `__ZN…`, so the canonical key must
+    # unify both spellings or the clones never match on macOS Flow-C (Codex).
+    assert _ctor_dtor_canonical("__ZN1AC1Ev") == _ctor_dtor_canonical("_ZN1AC1Ev")
+    assert not _ctor_dtor_canonical("__ZN1AC1Ev").startswith("__ZN")
     # A Mach-O non-ctor symbol is returned byte-for-byte unchanged.
     assert _ctor_dtor_canonical("__ZN1N3barEv") == "__ZN1N3barEv"
+
+
+def test_linker_matches_macho_decl_against_stripped_exports() -> None:
+    # End-to-end macOS Flow-C: the plugin decl keeps the raw `__ZN…` mangling but
+    # the export table stores `_ZN…` (one underscore stripped). The ctor clones
+    # must still fold and match across the two spellings (Codex review).
+    tu = SourceAbiTu(functions=[_entity("A::A", "function", mangled="__ZN1AC1Ev")])
+    surface = link_source_abi([tu], exported_symbols=["_ZN1AC1Ev", "_ZN1AC2Ev"])
+    assert surface.unmatched["symbols_without_decl"] == []
 
 
 def test_ctor_dtor_fold_handles_function_type_template_args() -> None:
@@ -619,15 +631,31 @@ def test_linker_demangled_identity_rematch() -> None:
     assert surface.unmatched["decls_without_symbol"] == []
 
 
-def test_demangled_rematch_is_unambiguous_only() -> None:
-    # The rematch must never cross-match an overload set: two decls that demangle
-    # distinctly (f(int) vs f(double)) can only claim their own exact export, and
-    # a demangled form shared by >1 export is skipped (never a guess).
+@needs_demangler
+def test_demangled_rematch_skips_ambiguous_forms() -> None:
+    # The rematch must never *guess* when a demangled form maps to more than one
+    # export. `_ZN1N1fENS_1TE` (substitution form) and `_ZN1N1fEN1N1TE` (expanded)
+    # both demangle to `N::f(N::T)`; an unmatched decl demangling to that same
+    # form has two candidate exports, so neither may be claimed (CodeRabbit).
+    from abicheck.buildsource.source_link import _demangled_rematch
+
+    decl = _entity("N::f", "function", mangled="_ZN1N1fENS_1TE")
+    mapping = {decl.identity(): ""}  # unmatched
+    matched: set[str] = set()
+    exported = {"_ZN1N1fENS_1TE", "_ZN1N1fEN1N1TE"}  # both → "N::f(N::T)"
+    new = _demangled_rematch([decl], mapping, matched, exported)
+    # Ambiguous form → no claim; the decl stays unmatched and nothing is consumed.
+    assert new == {}
+    assert mapping[decl.identity()] == ""
+    assert matched == set()
+
+
+def test_demangled_rematch_is_noop_when_already_matched() -> None:
+    # Distinct overloads already exact-matched: the rematch has nothing to do.
     from abicheck.buildsource.source_link import _demangled_rematch
 
     fi = _entity("f", "function", mangled="_Z1fi")  # f(int)
     fd = _entity("f", "function", mangled="_Z1fd")  # f(double)
-    # Both exports present and exact — rematch has nothing to do, no misfire.
     mapping = {"_Z1fi": "_Z1fi", "_Z1fd": "_Z1fd"}
     matched = {"_Z1fi", "_Z1fd"}
     new = _demangled_rematch([fi, fd], mapping, matched, {"_Z1fi", "_Z1fd"})

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -688,6 +688,49 @@ def test_linker_attributes_call_operator_thunk_to_owner() -> None:
 
 
 @needs_demangler
+def test_thunk_attribution_requires_overload_identity() -> None:
+    # Codex review: a thunk carries the full mangling of the overload it forwards
+    # to. `_ZThn8_N1D3fooEd` is a thunk for `D::foo(double)`; with only the
+    # `D::foo(int)` overload public, it must NOT be attributed to `D::foo` (bare
+    # name) — that would drop a real unmatched export and inflate coverage.
+    tu = SourceAbiTu(functions=[_entity("D::foo", "function", mangled="_ZN1D3fooEi")])
+    surface = link_source_abi(
+        [tu], exported_symbols=["_ZN1D3fooEi", "_ZThn8_N1D3fooEd"]
+    )
+    # The (double)-overload thunk stays orphaned; nothing attributed.
+    assert surface.unmatched["symbols_without_decl"] == ["_ZThn8_N1D3fooEd"]
+    assert surface.mappings["synthesized_symbol_to_owner"] == {}
+
+    # When the (double) overload IS public, its thunk attributes to it.
+    tu2 = SourceAbiTu(
+        functions=[
+            _entity("D::foo", "function", mangled="_ZN1D3fooEi"),
+            _entity("D::foo", "function", mangled="_ZN1D3fooEd"),
+        ]
+    )
+    surface2 = link_source_abi(
+        [tu2],
+        exported_symbols=["_ZN1D3fooEi", "_ZN1D3fooEd", "_ZThn8_N1D3fooEd"],
+    )
+    assert surface2.unmatched["symbols_without_decl"] == []
+    assert surface2.mappings["synthesized_symbol_to_owner"]["_ZThn8_N1D3fooEd"] == {
+        "kind": "thunk",
+        "owner": "D::foo",
+    }
+
+
+def test_thunk_target_mangled_parses_offset_forms() -> None:
+    from abicheck.buildsource.source_link import _thunk_target_mangled
+
+    # non-virtual (h), virtual (v), Mach-O prefix, and a non-thunk.
+    assert _thunk_target_mangled("_ZThn8_N1D3fooEd") == "_ZN1D3fooEd"
+    assert _thunk_target_mangled("_ZTv0_n24_N6Widget3fooEv") == "_ZN6Widget3fooEv"
+    assert _thunk_target_mangled("__ZThn8_N1DclEv") == "_ZN1DclEv"
+    assert _thunk_target_mangled("_ZN1D3fooEv") is None  # not a thunk
+    assert _thunk_target_mangled("_ZTV6Widget") is None  # vtable, not a thunk
+
+
+@needs_demangler
 def test_synthesized_attribution_requires_exact_specialization() -> None:
     # Codex review: with only `ns::A<int>` on the surface, the vtable for a
     # DIFFERENT specialization `ns::A<char>` (which base-splits to the same

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -398,6 +398,53 @@ def test_ctor_dtor_fold_parses_template_and_substitution_prefixes() -> None:
     assert _ctor_dtor_canonical("_ZN1NS_3FooC1Ev") != "_ZN1NS_3FooC1Ev"
 
 
+def test_ctor_dtor_fold_handles_nested_template_argument_names() -> None:
+    # Codex review: a template argument that is itself a nested name (e.g. the
+    # NSt7__cxx11…E of std::string) must not close the outer I…E early — the
+    # balanced skip consumes length-prefixed identifiers wholesale and tracks
+    # I/N nesting, so the ctor tag *after* the template-args is still folded.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    # std::vector<std::string>::vector()  (C1 complete vs C2 base)
+    vec_str = (
+        "_ZNSt6vectorINSt7__cxx1112basic_string"
+        "IcSt11char_traitsIcESaIcEEEE{tag}Ev"
+    )
+    assert _ctor_dtor_canonical(vec_str.format(tag="C1")) == _ctor_dtor_canonical(
+        vec_str.format(tag="C2")
+    )
+    assert _ctor_dtor_canonical(vec_str.format(tag="C1")) != vec_str.format(tag="C1")
+    # ns::A<std::map<std::string, Foo>>::A() — two levels of nested template args.
+    a_map = (
+        "_ZN2ns1AISt3mapINSt7__cxx1112basic_string"
+        "IcSt11char_traitsIcESaIcEEE3FooEE{tag}Ev"
+    )
+    assert _ctor_dtor_canonical(a_map.format(tag="C1")) == _ctor_dtor_canonical(
+        a_map.format(tag="C2")
+    )
+
+
+def test_ctor_dtor_fold_parser_edge_cases() -> None:
+    # Exercise the remaining parser branches for coverage + robustness:
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    # CV-qualified member function (K = const): _ZNK… — the qualifier is skipped.
+    assert _ctor_dtor_canonical("_ZNK3foo3barEv") == "_ZNK3foo3barEv"  # not a ctor
+    # A nested-name that simply ends (no ctor/dtor) hits the closing-E break.
+    assert _ctor_dtor_canonical("_ZN3foo3barEv") == "_ZN3foo3barEv"
+    # A non-ctor `C`/`D` at a boundary (a member named `Cat`) must NOT fold: the
+    # tag test requires an exact C1-C4/D0-D4 special name.
+    assert _ctor_dtor_canonical("_ZN3foo3CatEv") == "_ZN3foo3CatEv"
+    # An empty / non-mangled string is returned untouched (early out).
+    assert _ctor_dtor_canonical("") == ""
+    assert _ctor_dtor_canonical("plain_c_symbol") == "plain_c_symbol"
+    # A *numbered* backref substitution (S0_) — the S<id>_ branch — still reaches
+    # and folds the trailing ctor tag.
+    assert _ctor_dtor_canonical("_ZN1NS0_3FooC1Ev") == _ctor_dtor_canonical(
+        "_ZN1NS0_3FooC2Ev"
+    )
+
+
 def test_linker_excludes_non_public_entities() -> None:
     tu = SourceAbiTu(
         functions=[

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -654,6 +654,39 @@ def test_linker_attributes_rtti_vtable_thunk_to_public_owner() -> None:
     }
 
 
+def test_strip_call_signature_preserves_operator_parens() -> None:
+    from abicheck.buildsource.source_link import _strip_call_signature
+
+    # Ordinary functions: the trailing parameter list is dropped.
+    assert _strip_call_signature("ns::Widget::foo()") == "ns::Widget::foo"
+    assert _strip_call_signature("ns::f(int, char)") == "ns::f"
+    # Call operator: the `()` that is part of the name is preserved; only the
+    # trailing (parameter-list) group is removed.
+    assert _strip_call_signature("D::operator()()") == "D::operator()"
+    assert _strip_call_signature("D::operator()(int)") == "D::operator()"
+    # A nested paren inside the parameter list balances right-to-left.
+    assert _strip_call_signature("f(void (*)(int))") == "f"
+    # No parens at all → returned as-is.
+    assert _strip_call_signature("ns::x") == "ns::x"
+
+
+@needs_demangler
+def test_linker_attributes_call_operator_thunk_to_owner() -> None:
+    # Codex review: a thunk to a call operator demangles to `D::operator()()`;
+    # splitting at the first `(` would yield `D::operator`, orphaning the thunk.
+    # The owner `D::operator()` must be matched and the thunk attributed.
+    tu = SourceAbiTu(
+        functions=[_entity("D::operator()", "function", mangled="_ZN1DclEv")],
+    )
+    surface = link_source_abi(
+        [tu],
+        exported_symbols=["_ZN1DclEv", "_ZThn8_N1DclEv"],  # the op + its thunk
+    )
+    assert surface.unmatched["symbols_without_decl"] == []
+    owners = surface.mappings["synthesized_symbol_to_owner"]
+    assert owners["_ZThn8_N1DclEv"] == {"kind": "thunk", "owner": "D::operator()"}
+
+
 @needs_demangler
 def test_synthesized_attribution_requires_exact_specialization() -> None:
     # Codex review: with only `ns::A<int>` on the surface, the vtable for a


### PR DESCRIPTION
## Summary

Improve source→binary symbol matching (ctor/dtor ABI clones + full export set) and make the ADR-038 clang facts plugin fail loud instead of silently emitting an empty pack. Found while running a full L0–L5 source scan of epics-base/pvxs through Flow C.

## Motivation

A real source scan of pvxs (built against EPICS base + libevent) surfaced two matching defects and one silent-failure UX trap:

- **Symbol matching under-counted.** One source ctor/dtor `Decl` emits a single mangled name, but the compiler exports several ABI clones (`C1`/`C2`/`C3`, `D0`/`D1`/`D2`). Exact-string matching attributed only one and reported the siblings as "exported, no source decl" — a systematic under-count for every class with exported ctors/dtors.
- **`merge` truncated the binary export set.** `_exported_symbols_from_snapshot` pulled only the DWARF-shaped `functions[].mangled` list (a fraction of exports, carrying GCC's non-ABI unified `C4`/`D4` linkage tags that never match the real `C1`/`C2`), collapsing merge symbol matching to a handful of hits. On the pvxs Flow-C merge: `matched_symbols` was **6** of an alleged **126** exports.
- **The clang plugin failed silently.** When `public-roots` didn't match how headers actually resolve (e.g. pointing at the installed `include/` while `-I` makes `<foo/x.h>` resolve to `src/foo/`), every decl classified non-public and the plugin emitted an empty pack with exit 0 and no message — a long, mystifying debug.

## Changes

- **`source_link.py` — ctor/dtor clone folding.** Fold `C1`/`C2`/`C3`/`C4` and `D0`/`D1`/`D2`/`D4` tags when linking source decls to exports, so one declaration claims all of its clones; also bridges the DWARF `C4`/`D4` tag to real `C1`/`C2` exports. Applied to both `link_source_abi` and `relink_surface_exports`. No-op for non-ctor/dtor symbols (exact-match preserved).
- **`cli_buildsource_merge.py` — authoritative export set.** `_exported_symbols_from_snapshot` unions the platform dynamic export table (`elf.symbols` / `pe.exports` / `macho.exports`). On pvxs Flow-C merge: **`matched_symbols` 6 → 287, `exported_symbols` 126 → 950.**
- **`AbicheckFactsPlugin.cpp` — fail loud (Caveat A).** Emit a diagnostic to stderr and record it in the pack `diagnostics` when `public-roots` matches zero declarations though header decls were seen outside the roots, naming an example header and the `clang -H` tip.
- **Docs.** New user-guide page *Producing Source Facts (Flow A/B/C)* (producer selection tree + the `public-roots` resolution trap); plugin README section on `public-roots` vs install path; CHANGELOG.
- **Tests.** `test_source_abi.py` (clone folding, DWARF `C4`→`C1`/`C2` bridging, non-ctor no-op guard); `test_build_source_cli.py` (export extraction unions the ELF dynamic table); new `contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py` wired into the `clang-plugin` workflow (wrong root warns + empty; correct root silent + facts).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed
- [x] `pre-commit`-equivalent gates pass locally (`ruff check`, `ruff format --check` on changed sources, `mypy abicheck/` clean, `check_ai_readiness.py` 0 errors)
- [x] No new `mypy` or `ruff` errors introduced

> Note: one unrelated pre-existing test failure exists on the branch base (`test_run_bazel_empty_action_graph_is_partial`, bazel build-query inference) — it fails on `ca59f1b` before this change and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZyEJJCKBgnccdjjpWQat3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching/linking for C++ ctor/dtor ABI clone variants (including GCC-style unified tags) and more consistent export-to-decl mapping.
  * Export detection/merge now prioritizes platform dynamic export tables, with better handling of Mach-O underscore spelling and version aliases.
  * Cross-checking now reconciles L4 variants to prevent double-reporting false missing exports; improved diagnostics for empty public surfaces.

* **New Features**
  * Added clearer `public-roots` mismatch/inference diagnostics during source fact generation (including once-per-pack stderr de-duplication).

* **Documentation**
  * Added “Producing Source Facts” guide and clarified `public-roots` resolved-path behavior and failure modes.

* **Tests / CI**
  * Added regression tests for `public-roots` diagnostics and expanded ABI/merge/crosscheck coverage; CI adds an extra validation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->