### PR TITLE
Improve clang plugin pack UX diagnostics

### DIFF
--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -229,6 +229,7 @@ def _merge_attach_combined(
         and not (combined.source_abi.roots.get("exported_symbols"))
     ):
         from .buildsource.build_evidence import BuildEvidence
+        from .buildsource.inline import build_inline_coverage
         from .buildsource.source_graph import build_source_graph
         from .buildsource.source_link import relink_surface_exports
 
@@ -239,6 +240,30 @@ def _merge_attach_combined(
                 combined.build_evidence or BuildEvidence(),
                 source_abi=combined.source_abi,
             )
+        extractors = tuple(combined.manifest.extractors)
+        has_build = combined.build_evidence is not None and bool(
+            combined.build_evidence.compile_units or combined.build_evidence.targets
+        )
+        managed_layers = {
+            DataLayer.L3_BUILD.value,
+            DataLayer.L4_SOURCE_ABI.value,
+            DataLayer.L5_SOURCE_GRAPH.value,
+        }
+        preserved = [
+            cov
+            for cov in combined.manifest.coverage
+            if _layer_value(cov.layer) not in managed_layers
+        ]
+        combined.manifest.coverage = [
+            *preserved,
+            *build_inline_coverage(
+                combined.build_evidence or BuildEvidence(),
+                has_build,
+                combined.source_abi,
+                combined.source_graph,
+                extractors,
+            ),
+        ]
         # Mutating payloads invalidates precomputed artifact digests; clear them.
         combined.manifest.artifacts = []
     _warn_if_source_surface_empty(combined, base_exports)
@@ -249,7 +274,7 @@ def _merge_attach_combined(
 def _warn_if_source_surface_empty(
     combined: BuildSourcePack, base_exports: tuple[str, ...]
 ) -> None:
-    """Project-level ``public-roots`` misconfiguration signal (ADR-038 Caveat A).
+    """Project-level source-pack usefulness signal (ADR-038 Caveat A).
 
     The Clang facts plugin can only detect an empty public surface *per TU*, and
     a single internal-only TU legitimately produces none — so the per-TU
@@ -271,6 +296,12 @@ def _warn_if_source_surface_empty(
         + len(surface.reachable_templates)
         + len(surface.reachable_inline_bodies)
     )
+    decls = len(surface.reachable_declarations)
+    cov = surface.coverage or {}
+    matched = int(cov.get("matched_symbols", 0) or 0) + int(
+        cov.get("synthesized_symbols_matched", 0) or 0
+    )
+    exported = int(cov.get("exported_symbols", 0) or 0)
     if entities == 0:
         click.echo(
             "warning: merged source pack carries no public entities though the "
@@ -278,6 +309,23 @@ def _warn_if_source_surface_empty(
             "public-roots / ABICHECK_CC_HEADERS likely did not match how the "
             "public headers resolve (verify with `clang -H`); the baseline has no "
             "L4/L5 source evidence. See docs: user-guide/producing-source-facts.",
+            err=True,
+        )
+    elif decls == 0:
+        click.echo(
+            "warning: merged source pack carries public macros/types but no public "
+            f"function/variable declarations while the binary exports {len(base_exports)} "
+            "symbol(s). This usually means the selected compile unit did not include "
+            "the library's public API declarations, or public-roots is too broad/narrow; "
+            "symbol matching will be ineffective.",
+            err=True,
+        )
+    elif exported > 0 and matched == 0:
+        click.echo(
+            "warning: merged source pack carries public declarations but matched "
+            f"0/{exported} exported symbol(s). Check that the facts pack was built "
+            "from the same target/configuration as the binary and that public-roots "
+            "points at the headers used by that target.",
             err=True,
         )
 
@@ -300,4 +348,5 @@ def _merge_print_summary(
                 DataLayer.L4_SOURCE_ABI.value,
                 DataLayer.L5_SOURCE_GRAPH.value,
             }:
-                click.echo(f"  {cov.layer}: {cov.status.value}", err=True)
+                detail = f" ({cov.detail})" if cov.detail else ""
+                click.echo(f"  {cov.layer}: {cov.status.value}{detail}", err=True)

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -94,7 +94,7 @@ namespace {
 
 // Producer id, recorded in the manifest's `created_by` and the TU `extractor`
 // field. Bump on any change to the emitted-record recipe.
-constexpr const char *kPluginVersion = "0.1";
+constexpr const char *kPluginVersion = "0.2";
 
 // ---------------------------------------------------------------------------
 // Hashing — mirrors clang.py::_hash exactly:
@@ -911,6 +911,48 @@ std::string upperStrippedStem(llvm::StringRef file) {
   return collapsed;
 }
 
+std::string macroGuardToken(llvm::StringRef text) {
+  std::string raw;
+  for (char c : text) {
+    if (std::isalnum(static_cast<unsigned char>(c)))
+      raw.push_back(
+          static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+    else
+      raw.push_back('_');
+  }
+  std::string out;
+  bool underscore = true;
+  for (char c : raw) {
+    if (c == '_') {
+      if (!underscore)
+        out.push_back('_');
+      underscore = true;
+      continue;
+    }
+    out.push_back(c);
+    underscore = false;
+  }
+  while (!out.empty() && out.back() == '_')
+    out.pop_back();
+  return out;
+}
+
+bool looksLikeIncludeGuard(llvm::StringRef name, llvm::StringRef file) {
+  std::string macro = macroGuardToken(name);
+  std::string stem = macroGuardToken(llvm::sys::path::stem(file));
+  if (macro.empty() || stem.empty())
+    return false;
+  if (macro == stem)
+    return true;
+  size_t pos = macro.rfind(stem);
+  if (pos == std::string::npos)
+    return false;
+  llvm::StringRef tail(macro.data() + pos + stem.size(),
+                       macro.size() - pos - stem.size());
+  return tail == "_H" || tail == "_HH" || tail == "_HPP" ||
+         tail == "_HXX";
+}
+
 std::string joinStrings(const std::vector<std::string> &v, char sep) {
   std::string out;
   for (size_t i = 0; i < v.size(); ++i) {
@@ -1574,6 +1616,9 @@ private:
       const std::string &name = kv.first;
       const std::string &value = kv.second.value;
       const std::string &file = kv.second.file;
+      if (looksLikeIncludeGuard(name, file) &&
+          (value.empty() || value == "1"))
+        continue;
       if (value.empty()) {
         std::string up = name;
         for (char &c : up)
@@ -1736,7 +1781,7 @@ private:
         jsonStr(nowIso8601Utc()) + ",\n  \"created_by\": " + jsonStr(createdBy) +
         ",\n  \"exported_symbols\": [],\n  \"headers\": [],\n"
         "  \"kind\": \"abicheck_inputs\",\n  \"library\": " + jsonStr(Library) +
-        ",\n  \"source_facts\": [],\n  \"version\": " + jsonStr(Version) +
+        ",\n  \"source_facts\": [\"source_facts\"],\n  \"version\": " + jsonStr(Version) +
         "\n}\n";
 
     llvm::SmallString<128> tmp;

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -88,7 +88,16 @@ them (ADR-035 D5); the plugin normalizes to `source_facts` itself.
 
 ## Build
 
+The CMake build needs the Clang development package for the same LLVM major as
+the `clang` that will load the plugin. On Debian/Ubuntu that means the full
+`libclang-XX-dev` package in addition to `clang-XX`/`llvm-XX-dev`; otherwise
+CMake can find `ClangTargets.cmake` but fail on missing libraries such as
+`libclangBasic.a`.
+
 ```bash
+# Debian/Ubuntu example for LLVM 18:
+sudo apt-get install clang-18 llvm-18-dev libclang-18-dev
+
 cmake -S . -B build -DCMAKE_PREFIX_PATH="$(llvm-config --cmakedir)/.."
 cmake --build build            # -> libabicheck-facts.so
 ```
@@ -122,6 +131,18 @@ abicheck merge libfoo.so.json ./abicheck_inputs/ -o libfoo.baseline.json
 Optional args: `library=<name>` (recorded in the manifest / `target_id`),
 `version=<v>`. `public-roots=` is repeatable.
 
+After `merge`, read stderr's L4 coverage line. A healthy pack should report
+non-zero public declarations and, when the binary exports symbols, non-zero
+symbol matches. `merge` now warns when a pack technically ingests but is unlikely
+to help matching, for example:
+
+- public macros/types but no public function or variable declarations;
+- public declarations present, but `0/N` exported symbols matched.
+
+Those warnings usually mean the compile unit was internal-only, the pack was
+produced for a different target/configuration than the binary, or
+`public-roots=` does not match the headers the compiler actually resolved.
+
 ### `public-roots` must match how headers *resolve*, not where they are installed
 
 The plugin classifies a declaration as public by the **physical path the
@@ -149,7 +170,8 @@ Two ways to get it right:
   ```
 
   and records the same note in the pack's `diagnostics`. An empty pack is now a
-  loud error, not a 20-minute debug.
+  loud error, not a 20-minute debug. A non-empty-but-useless pack is also called
+  out later by `abicheck merge` when it has binary exports to match against.
 
 ### Auto-derived public roots (when `public-roots=` is omitted)
 

--- a/docs/concepts/build-source-data.md
+++ b/docs/concepts/build-source-data.md
@@ -232,13 +232,14 @@ pinned `clang`).
 
 ```bash
 # 1. Build the plugin against your toolchain's LLVM (once per image).
+#    Debian/Ubuntu needs the matching libclang-XX-dev package, not only clang-XX.
 cmake -S contrib/abicheck-clang-plugin -B build \
   -DCMAKE_PREFIX_PATH="$(llvm-config --cmakedir)/.."
 cmake --build build                                   # -> build/libabicheck-facts.so
 
 # 2. Add it to the normal compile. Use the `-Xclang -plugin-arg-abicheck-facts`
 #    form (the `-fplugin-arg-` shorthand mis-parses the hyphenated plugin name).
-#    `public-roots=` is mandatory — it is the plugin's ABICHECK_CC_HEADERS.
+#    `public-roots=` is strongly recommended — it is the plugin's ABICHECK_CC_HEADERS.
 clang++ -std=c++17 -Iinclude \
   -fplugin=./build/libabicheck-facts.so \
   -Xclang -plugin-arg-abicheck-facts -Xclang out=abicheck_inputs \
@@ -249,6 +250,11 @@ clang++ -std=c++17 -Iinclude \
 abicheck dump libfoo.so -H include/ -o libfoo.bin.json
 abicheck merge libfoo.bin.json ./abicheck_inputs/ -o libfoo.baseline.json
 ```
+
+Treat `merge` warnings about zero public declarations or `0/N` matched exported
+symbols as a pack-quality problem, not as a clean success: choose a compile unit
+that includes the public API for the library target, and point `public-roots=` at
+the physical header path printed by `clang -H`.
 
 The plugin is validated as a drop-in for the clang backend by a differential
 conformance gate (ADR-038 C.6) that runs across LLVM/Clang 16, 17, and 18; its

--- a/tests/test_inputs_pack.py
+++ b/tests/test_inputs_pack.py
@@ -41,7 +41,7 @@ from abicheck.buildsource.inputs_pack import (
     InputsManifest,
     load_inputs_manifest,
 )
-from abicheck.buildsource.model import CoverageStatus, DataLayer
+from abicheck.buildsource.model import CoverageStatus, DataLayer, LayerCoverage
 from abicheck.cli import main
 from abicheck.serialization import load_snapshot
 
@@ -65,6 +65,24 @@ def _tu(name: str, *, mangled: str, source: str = "src/foo.cpp") -> SourceAbiTu:
         source=source,
         public_header_roots=[f"include/{name}.h"],
         functions=[ent],
+    )
+
+
+def _macro_tu(name: str = "FOO_H") -> SourceAbiTu:
+    ent = SourceEntity(
+        id=f"macro://{name}",
+        kind="macro",
+        qualified_name=name,
+        value="",
+        source_location=SourceLocation(path="include/foo.h", line=1, origin="PUBLIC_HEADER"),
+        visibility="public_header",
+    )
+    return SourceAbiTu(
+        tu_id="cu://src/foo.cpp#cfg:abc",
+        target_id="target://libfoo",
+        source="src/foo.cpp",
+        public_header_roots=["include/foo.h"],
+        macros=[ent],
     )
 
 
@@ -482,6 +500,52 @@ def test_merge_relinks_surface_against_base_exports(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     surface = load_snapshot(out).build_source.source_abi
     assert "_Z3foov" in surface.roots["exported_symbols"]
+
+
+def test_merge_rebuilds_l4_coverage_after_relink(tmp_path: Path) -> None:
+    bin_json = _artifact_snapshot(tmp_path)
+    pack = _write_inputs_pack(tmp_path, [_tu("bar", mangled="_Z3barv")])
+    out = tmp_path / "baseline.json"
+    result = CliRunner().invoke(main, ["merge", str(bin_json), str(pack), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "matched 0/1 exported symbol" in result.output
+    assert "L4_source_abi: partial (0/1 symbols matched)" in result.output
+    baseline = load_snapshot(out)
+    surface = baseline.build_source.source_abi
+    assert surface.coverage["exported_symbols"] == 1
+    assert surface.coverage["matched_symbols"] == 0
+    l4 = baseline.build_source.manifest.coverage_for(DataLayer.L4_SOURCE_ABI)
+    assert l4 is not None
+    assert l4.status == CoverageStatus.PARTIAL
+    assert "0/1 symbols matched" in l4.detail
+
+
+def test_merge_relink_preserves_non_managed_coverage_rows(tmp_path: Path) -> None:
+    from abicheck.cli_buildsource_merge import _merge_attach_combined
+
+    base = load_snapshot(_artifact_snapshot(tmp_path))
+    pack = _write_inputs_pack(tmp_path, [_tu("bar", mangled="_Z3barv")])
+    ingested = ingest_inputs_pack(pack)
+    ingested.pack.manifest.coverage.append(
+        LayerCoverage(
+            layer="custom_plugin_diagnostics",
+            status=CoverageStatus.PRESENT,
+            detail="keep me",
+        )
+    )
+    _merge_attach_combined(ingested.pack, base, tmp_path / "baseline.json")
+    kept = base.build_source.manifest.coverage_for("custom_plugin_diagnostics")
+    assert kept is not None
+    assert kept.detail == "keep me"
+
+
+def test_merge_warns_for_macro_only_pack_with_exports(tmp_path: Path) -> None:
+    bin_json = _artifact_snapshot(tmp_path)
+    pack = _write_inputs_pack(tmp_path, [_macro_tu()])
+    out = tmp_path / "baseline.json"
+    result = CliRunner().invoke(main, ["merge", str(bin_json), str(pack), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "public macros/types but no public function/variable declarations" in result.output
 
 
 def test_merge_rejects_plain_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- rebuild L4 coverage after `merge` relinks Flow-2/plugin packs against binary exports
- warn when an ingested pack is non-empty but ineffective for matching (`0` public decls or `0/N` matched exports)
- filter broader include-guard macro patterns in the clang plugin and make plugin manifests point at `source_facts/`
- document clang-plugin build prerequisites and merge-quality warnings

## Validation

- `pytest -q tests/test_inputs_pack.py` → 33 passed
- `ruff check abicheck/cli_buildsource_merge.py tests/test_inputs_pack.py` → all checks passed
- rebuilt `contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp` with clang++/LLVM 18 against local libclang dev sysroot
- real snappy TU smoke: plugin emitted 37 functions, 2 types, 0 macros; manifest has `source_facts: ["source_facts"]`
- real zstd/debug.c merge smoke: emits warning for macro/type-only source pack and reports `L4_source_abi: partial`

## Notes

This keeps the deeper C++ matcher work (RTTI/vtable owner coverage for snappy-like partial matches) as follow-up. Main user-flow issue fixed here: `merge` no longer looks clean when a plugin pack technically ingests but cannot contribute useful symbol matching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved merge coverage reporting so inline evidence is reflected in final source coverage summaries.
  * Enhanced per-layer coverage/status output by including additional detail when available.

* **Bug Fixes**
  * Recomputed L4 exported-symbol coverage after relinking to reflect the final merged state.
  * Preserve non-managed coverage rows during merge attach while updating managed-layer coverage from inline evidence.
  * Refined “public surface empty” warnings with clearer, more specific conditions.

* **Documentation**
  * Updated Clang plugin setup and prerequisites, and added guidance for interpreting merge warnings and “public-roots” errors.  

* **Tests**
  * Added/expanded merge integration and warning regression coverage, including macro-only and zero-match scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->