### PR TITLE
docs: fix depth-ladder contradiction, unify layer model, complete MCP docs, rewrite libabigail migration, add CI gating hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   bitmask→scalar exit-code translation, an `abidiff`→`abicheck` flag-by-flag
   map, `abidw`/`abipkgdiff` equivalents, and INI→YAML suppression
   translation. The verdict-parity QA matrix it previously contained moved to
-  `docs/development/libabigail-parity.md`.
+  `docs/development/libabigail-parity.md`, refreshed against the current
+  `PARITY_CASES` in `tests/test_abidiff_parity.py` (the vtable/return/param/
+  struct-size gaps it still listed as open were closed by castxml
+  integration).
 - New user-guide page **Producing Source Facts (Flow A/B/C)** documenting the
   three source-fact producers, a selection tree, and the `public-roots`/
   `ABICHECK_CC_HEADERS` header-resolution trap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Docs: the `scan --depth` ladder is now stated identically everywhere**
+  (`binary|headers|build|source|full`, no user-facing `graph` rung per
+  ADR-037 D6) — `concepts/scan-and-evidence-levels.md` listed a contradictory
+  rung set, the "cheap gate" worked example pinned the wrong rung for a
+  compiler-free scan, and two MCP tool docstrings carried the stale ladder.
+- **Docs: one evidence-layer story across the funnel** — the landing page
+  still pitched "three-layer analysis" while other pages teach the
+  five-source L0–L4 model; pages teaching L0–L4 now also forward-reference
+  the derived L5 code the scan docs use.
+- **Docs: `mcp-integration.md` covers all seven MCP tools** — `abi_audit`,
+  `abi_estimate`, and `abi_scan` were undocumented, and the
+  `--timeout`/`--max-file-size` scoping undercounted which tools they bound.
+- **Docs: README exit-code table no longer misstates exit `1`** (it exists
+  only under the severity scheme) and notes that exit `8` requires
+  `--fail-on-removed-library`.
+
 - **Source→binary symbol matching now recovers ctor/dtor ABI clones.** The
   linker (`link_source_abi` / `relink_surface_exports`) folds C++ Itanium
   ctor/dtor clone tags (`C1`/`C2`/`C3`/`C4`, `D0`/`D1`/`D2`/`D4`) so one source
@@ -50,6 +66,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- New user-guide page **CI Gating** (`docs/user-guide/ci-gating.md`) — the
+  missing hub explaining how baselines, policies, suppressions, and severity
+  combine into the exit code (order of operations + the two exit-code
+  schemes), cross-linked from the four detail pages.
+- **`from-libabigail.md` is now an actual migration guide** — command swap,
+  bitmask→scalar exit-code translation, an `abidiff`→`abicheck` flag-by-flag
+  map, `abidw`/`abipkgdiff` equivalents, and INI→YAML suppression
+  translation. The verdict-parity QA matrix it previously contained moved to
+  `docs/development/libabigail-parity.md`.
 - New user-guide page **Producing Source Facts (Flow A/B/C)** documenting the
   three source-fact producers, a selection tree, and the `public-roots`/
   `ABICHECK_CC_HEADERS` header-resolution trap.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ abicheck treats compatibility analysis as a question of **evidence**: the more i
 
 The layers are **independent and additive, not a fallback chain** — abicheck overlays every source you give it and computes one worst-wins verdict, under the *authority rule*: artifact-backed evidence (L0/L1/L2) is authoritative for the shipped-ABI verdict, while build/source evidence (L3/L4) *explains, localizes, scopes, or adds confidence* to a finding (and can raise its own source-/API-level findings) but never silently deletes an artifact-proven break.
 
+> **A sixth code you may see in the docs:** `L5` is the source *reachability graph* abicheck **derives** from L3/L4 evidence — you provide five sources (L0–L4); L5 is computed, never an input. It appears in the [`scan` documentation](https://abicheck.github.io/abicheck/concepts/scan-and-evidence-levels/).
+
 With less input, abicheck degrades gracefully *down the staircase* rather than failing — a stripped binary with no headers collapses toward symbol-only checking — and `abicheck dump --show-data-sources` reports exactly which layers it found. The best input you can give it is **old library + new library + matching public headers + debug info + build data**. See [Evidence & Detectability](https://abicheck.github.io/abicheck/concepts/evidence-and-detectability/) for what each source can and cannot see, and [Architecture](https://abicheck.github.io/abicheck/concepts/architecture/) for how the layers are reconciled.
 
 ---
@@ -108,12 +110,11 @@ Use these to gate CI pipelines.
 | Exit code | Verdict | Meaning |
 |-----------|---------|---------|
 | `0` | `NO_CHANGE` / `COMPATIBLE` / `COMPATIBLE_WITH_RISK` | Safe — no binary ABI break |
-| `1` | `SEVERITY_ERROR` | Severity-driven error (with `--severity-*` flags) |
 | `2` | `API_BREAK` | Source-level break (recompile needed, binary may still work) |
 | `4` | `BREAKING` | Binary ABI break (old binaries will crash or misbehave) |
-| `8` | `REMOVED_LIBRARY` | Library removed in new version (multi-library/bundle compare only) |
+| `8` | `REMOVED_LIBRARY` | Library removed in new version (multi-library compare with `--fail-on-removed-library`) |
 
-`appcompat`, `deps compare`, and `compat` use the same scheme with per-mode additions — see the [full exit code reference](https://abicheck.github.io/abicheck/reference/exit-codes/).
+Passing any `--severity-*` flag switches `compare` to a severity-based scheme where `1` means an error-level *finding* in the addition/quality categories (`0` still passes, `4` is still worst). `appcompat`, `deps compare`, and `compat` add per-mode codes. The canonical matrix is the [exit code reference](https://abicheck.github.io/abicheck/reference/exit-codes/); how baselines, policies, suppressions, and severity combine into the exit code is covered in [CI Gating](https://abicheck.github.io/abicheck/user-guide/ci-gating/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Use these to gate CI pipelines.
 | `4` | `BREAKING` | Binary ABI break (old binaries will crash or misbehave) |
 | `8` | `REMOVED_LIBRARY` | Library removed in new version (multi-library compare with `--fail-on-removed-library`) |
 
-Passing any `--severity-*` flag switches `compare` to a severity-based scheme where `1` means an error-level *finding* in the addition/quality categories (`0` still passes, `4` is still worst). `appcompat`, `deps compare`, and `compat` add per-mode codes. The canonical matrix is the [exit code reference](https://abicheck.github.io/abicheck/reference/exit-codes/); how baselines, policies, suppressions, and severity combine into the exit code is covered in [CI Gating](https://abicheck.github.io/abicheck/user-guide/ci-gating/).
+Any active severity setting (a `--severity-*` flag or a severity value in `.abicheck.yml`) switches `compare` to a severity-based scheme where `1` means an error-level *finding* in the addition/quality categories (`0` still passes, `4` is still worst). `appcompat`, `deps compare`, and `compat` add per-mode codes. The canonical matrix is the [exit code reference](https://abicheck.github.io/abicheck/reference/exit-codes/); how baselines, policies, suppressions, and severity combine into the exit code is covered in [CI Gating](https://abicheck.github.io/abicheck/user-guide/ci-gating/).
 
 ---
 

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -976,7 +976,7 @@ def abi_estimate(
         compile_db: Explicit compile_commands.json (else discovered in sources).
         mode: Fixed (L,S) preset — "pr" (default), "pr-deep", "baseline", "audit".
         source_method: Precise S-axis level (s0..s6 or auto); None = mode preset.
-        depth: Coarse L-axis selector (headers|build|source|full|graph).
+        depth: Coarse L-axis selector (binary|headers|build|source|full).
         changed_paths: Changed-path set for the focused (D7) replay-scope estimate.
     """
     t0 = _time.monotonic()
@@ -1071,7 +1071,7 @@ def abi_scan(
             single-release run; use ``mode="audit"`` for the hygiene catalog).
         mode: Fixed (L,S) preset — "pr" (default), "pr-deep", "baseline", "audit".
         source_method: Precise S-axis level (s0..s6 or auto); None = mode preset.
-        depth: Coarse L-axis selector (headers|build|source|full|graph).
+        depth: Coarse L-axis selector (binary|headers|build|source|full).
         changed_paths: Changed-path set focusing the scan (ADR-035 D7).
         language: Language mode — "c++" (default) or "c".
     """

--- a/docs/concepts/scan-and-evidence-levels.md
+++ b/docs/concepts/scan-and-evidence-levels.md
@@ -157,7 +157,7 @@ than `--source-method`. Its five rungs are `binary`, `headers`, `build`,
 
 | `--depth` | resolves to | reaches |
 |-----------|-------------|---------|
-| `binary` | `s0` (no S-method) | L0/L1 only — no L2 AST (+ always-on pattern scan) |
+| `binary` | `s0` (no S-method) | L0 exported symbols + binary metadata + debug-info *presence* — no DWARF type expansion, no L2 AST (+ always-on pattern scan) |
 | `headers` | `s0` (no S-method — L2 is the intrinsic header AST) | L0–L2 (+ always-on pattern scan) |
 | `build` | `s1` | + L3 |
 | `source` | `s5` | + L4 scoped + L5 edges |

--- a/docs/concepts/scan-and-evidence-levels.md
+++ b/docs/concepts/scan-and-evidence-levels.md
@@ -132,7 +132,7 @@ flowchart LR
 ```
 
 The mapping is **lossy in the `--depth` direction** (see §4): `--depth build`
-resolves to `s1`, and `s2`/`s3` have no `--depth` form at all — so
+resolves to `s1`, and `s2`/`s3`/`s4` have no `--depth` form at all — so
 `--source-method` is the precise knob and **wins if both are given**.
 
 ---
@@ -152,15 +152,22 @@ mode produces the same scan for the same inputs:
 | `audit` | `(s5, source)` *(intra-version)* | single-build hygiene lint, **no baseline** |
 
 **`--depth`** is a coarse, *lossy* L-axis selector — convenient but less precise
-than `--source-method`:
+than `--source-method`. Its five rungs are `binary`, `headers`, `build`,
+`source`, `full` (ADR-037 D5):
 
 | `--depth` | resolves to | reaches |
 |-----------|-------------|---------|
-| `headers` | `s0` | L0–L2 only (+ always-on scan) |
-| `build` | `s1` | L3 |
-| `graph` | `s4` | L5 (no L4) |
-| `source` | `s5` | L4 scoped + L5 edges |
+| `binary` | `s0` (no S-method) | L0/L1 only — no L2 AST (+ always-on pattern scan) |
+| `headers` | `s0` (no S-method — L2 is the intrinsic header AST) | L0–L2 (+ always-on pattern scan) |
+| `build` | `s1` | + L3 |
+| `source` | `s5` | + L4 scoped + L5 edges |
 | `full` | `s6` | L4 full-scope |
+
+There is **no `graph` rung** (ADR-037 D6): the L5 graph is an *internal
+consequence* of `--depth source`/`full`, never its own user-facing rung. To pin
+the graph-only level (`s4`, L5 without paying for L4) use `--source-method s4`;
+to fold the *full* L5 reachability graph into a PR scan use `--mode pr-deep`
+(= `(s5, graph)` internally).
 
 Precedence, highest first: **`--source-method` > `--depth` > `--mode`**.
 

--- a/docs/concepts/scan-and-evidence-levels.md
+++ b/docs/concepts/scan-and-evidence-levels.md
@@ -23,7 +23,7 @@ relates them.
 |------|-------|---------|--------|-------------|
 | **L — evidence layer** | `L0`–`L5` | *What* abicheck sees, and **how much that evidence is trusted** (authority) | the **inputs you give** (binary, debug, headers, build dir, sources) | [Evidence & Detectability](evidence-and-detectability.md), [Build Info & Sources](build-source-data.md) |
 | **S — source-analysis method** | `s0`–`s6` (+`auto`) | *How* abicheck gathers the L3–L5 evidence, and the **granularity coverage is reported at** | `scan --source-method` | [`scan` command](../user-guide/scan-levels.md) |
-| **mode / depth — presets** | `pr`,`pr-deep`,`baseline`,`audit` / `headers`,`build`,`source`,`full`,`graph` | A convenient **fixed `(S, L)` selection** | `scan --mode` / `scan --depth` | [`scan` command](../user-guide/scan-levels.md) |
+| **mode / depth — presets** | `pr`,`pr-deep`,`baseline`,`audit` / `binary`,`headers`,`build`,`source`,`full` | A convenient **fixed `(S, L)` selection** | `scan --mode` / `scan --depth` | [`scan` command](../user-guide/scan-levels.md) |
 
 The two axes are **orthogonal**: `L` is a property of *evidence*, `S` is a
 property of the *process* that produced it. You can reach the same L-layer by

--- a/docs/development/libabigail-parity.md
+++ b/docs/development/libabigail-parity.md
@@ -2,43 +2,57 @@
 
 _G3: libabigail test suite compatibility_
 
-This document tracks how abicheck verdict compares to `abidiff` (libabigail)
+This document tracks how abicheck verdicts compare to `abidiff` (libabigail)
 on canonical ABI change scenarios. It is a development/QA tracking page — if
 you are switching from `abidiff` to abicheck, see
 [Migrating from libabigail](../user-guide/from-libabigail.md) instead.
 
-## Confirmed Parity (both tools agree)
+**Source of truth:** `PARITY_CASES` in `tests/test_abidiff_parity.py`. Each
+case carries a status — `parity` (both tools agree), `correct` (abicheck is
+authoritative; abidiff is conservative), or `divergence` (intentional, stable
+divergence). The tables below mirror that table; update them together.
+
+## Confirmed parity (both tools agree)
 
 | # | Case | Change | abicheck | abidiff |
 |---|------|--------|----------|---------|
 | 1 | fn_removed | Function removed from dynsym | BREAKING | BREAKING |
 | 2 | fn_added | New function added | COMPATIBLE | COMPATIBLE |
-| 3 | no_change | Identical libraries | NO_CHANGE | NO_CHANGE |
+| 3 | no_change | Identical libraries (ELF-only, no headers) | NO_CHANGE | NO_CHANGE |
 | 4 | visibility_hidden | Public → hidden visibility | BREAKING | BREAKING |
-| 5 | vtable_reorder | C++ vtable method order swap | NO_CHANGE | BREAKING* |
-| 6 | enum_value | Enum member value changed | BREAKING | COMPATIBLE† |
+| 5 | vtable_reorder | C++ vtable method order swap | BREAKING | BREAKING |
 
-\* vtable: abidiff detects via DWARF; abicheck ELF-only misses it (gap, needs castxml)
-† enum_value: abicheck is intentionally stricter — enum value changes break switch/serialization
+The historical `vtable_reorder` gap (abicheck ELF-only missed it) is **closed**
+— with headers (castxml) both tools report BREAKING.
 
-## Known Divergences (tracked gaps)
+## abicheck correct, abidiff conservative (G3 closed)
 
-| # | Case | abicheck | abidiff | Root cause |
-|---|------|----------|---------|------------|
-| 1 | struct_size | NO_CHANGE | COMPATIBLE¹ | ELF-only: no type info without headers |
-| 2 | return_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
-| 3 | param_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
-| 4 | vtable_reorder | NO_CHANGE | BREAKING | ELF-only: vtable not visible in dynsym |
+Without `--headers-dir`, abidiff classifies these as sub-type drift
+(`COMPATIBLE`, exit 4); abicheck with headers sees the actual signature
+change:
 
-¹ Note: abidiff with DWARF (-g but no headers) classifies type sub-changes as
-COMPATIBLE (exit=4), not BREAKING. To get BREAKING verdict from abidiff,
-use `--headers-dir` option. abicheck with headers (castxml) returns BREAKING correctly.
+| # | Case | Change | abicheck | abidiff (no headers-dir) |
+|---|------|--------|----------|--------------------------|
+| 1 | return_type | `int get_val()` → `long get_val()` | BREAKING | COMPATIBLE |
+| 2 | param_type | `set_val(int)` → `set_val(long)` | BREAKING | COMPATIBLE |
 
-## Gap closure plan
+## Intentional divergences (stable)
 
-After integrating castxml output into parity tests, all divergences close.
-When a gap is closed, update `PARITY_CASES` in `tests/test_abidiff_parity.py`
-and move the entry from `_DIVERGE` to `_CONFIRMED`.
+| # | Case | Change | abicheck | abidiff | Rationale |
+|---|------|--------|----------|---------|-----------|
+| 1 | struct_size | Field added to returned-by-value struct | BREAKING | COMPATIBLE¹ | abicheck is correct; abidiff without `--headers-dir` sees only compatible sub-type drift |
+| 2 | enum_value | Enum member value changed | BREAKING | COMPATIBLE | abicheck is intentionally stricter — enum value changes break switch/serialization |
+
+¹ abidiff with DWARF but no headers classifies type sub-changes as COMPATIBLE
+(exit=4), not BREAKING; with `--headers-dir` it strengthens. abicheck with
+headers (castxml) returns BREAKING either way.
+
+## Maintaining this page
+
+When a case's behaviour changes, update its status in `PARITY_CASES`
+(`tests/test_abidiff_parity.py`) — the parametrized tests over the derived
+`_CONFIRMED` / `_CORRECT` / `_DIVERGE` views fail with a "move this case"
+message when reality and status disagree — then mirror the change here.
 
 ## How to run
 

--- a/docs/development/libabigail-parity.md
+++ b/docs/development/libabigail-parity.md
@@ -1,0 +1,58 @@
+# libabigail Parity Matrix
+
+_G3: libabigail test suite compatibility_
+
+This document tracks how abicheck verdict compares to `abidiff` (libabigail)
+on canonical ABI change scenarios. It is a development/QA tracking page — if
+you are switching from `abidiff` to abicheck, see
+[Migrating from libabigail](../user-guide/from-libabigail.md) instead.
+
+## Confirmed Parity (both tools agree)
+
+| # | Case | Change | abicheck | abidiff |
+|---|------|--------|----------|---------|
+| 1 | fn_removed | Function removed from dynsym | BREAKING | BREAKING |
+| 2 | fn_added | New function added | COMPATIBLE | COMPATIBLE |
+| 3 | no_change | Identical libraries | NO_CHANGE | NO_CHANGE |
+| 4 | visibility_hidden | Public → hidden visibility | BREAKING | BREAKING |
+| 5 | vtable_reorder | C++ vtable method order swap | NO_CHANGE | BREAKING* |
+| 6 | enum_value | Enum member value changed | BREAKING | COMPATIBLE† |
+
+\* vtable: abidiff detects via DWARF; abicheck ELF-only misses it (gap, needs castxml)
+† enum_value: abicheck is intentionally stricter — enum value changes break switch/serialization
+
+## Known Divergences (tracked gaps)
+
+| # | Case | abicheck | abidiff | Root cause |
+|---|------|----------|---------|------------|--------|
+| 1 | struct_size | NO_CHANGE | COMPATIBLE¹ | ELF-only: no type info without headers |
+| 2 | return_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
+| 3 | param_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
+| 4 | vtable_reorder | NO_CHANGE | BREAKING | ELF-only: vtable not visible in dynsym |
+
+¹ Note: abidiff with DWARF (-g but no headers) classifies type sub-changes as
+COMPATIBLE (exit=4), not BREAKING. To get BREAKING verdict from abidiff,
+use `--headers-dir` option. abicheck with headers (castxml) returns BREAKING correctly.
+
+## Gap closure plan
+
+After integrating castxml output into parity tests, all divergences close.
+When a gap is closed, update `PARITY_CASES` in `tests/test_abidiff_parity.py`
+and move the entry from `_DIVERGE` to `_CONFIRMED`.
+
+## How to run
+
+```bash
+# Requires: abidiff (libabigail-tools), gcc/g++
+pytest tests/test_abidiff_parity.py -v -m libabigail
+```
+
+## abidiff exit code mapping
+
+| Exit code bits | Meaning | abicheck verdict |
+|----------------|---------|-----------------|
+| 0 | No differences | NO_CHANGE |
+| 4 (bit 2) | Compatible sub-type changes | COMPATIBLE |
+| 8 (bit 3) | Incompatible changes | BREAKING |
+| 12 (bits 2+3) | Both compatible + incompatible | BREAKING |
+| 1 (bit 0) | Error | ERROR |

--- a/docs/development/libabigail-parity.md
+++ b/docs/development/libabigail-parity.md
@@ -24,7 +24,7 @@ you are switching from `abidiff` to abicheck, see
 ## Known Divergences (tracked gaps)
 
 | # | Case | abicheck | abidiff | Root cause |
-|---|------|----------|---------|------------|--------|
+|---|------|----------|---------|------------|
 | 1 | struct_size | NO_CHANGE | COMPATIBLE¹ | ELF-only: no type info without headers |
 | 2 | return_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
 | 3 | param_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,6 +173,11 @@ With less input, abicheck degrades gracefully *down the staircase* rather than
 failing — a stripped binary with no headers collapses toward symbol-only
 checking.
 
+> **A sixth code you may meet later:** the `scan` docs also use **`L5`** — the
+> source *reachability graph* abicheck **derives** from L3/L4 evidence. You
+> provide five sources (L0–L4); L5 is computed, never an input. See
+> [Scan Levels (S vs L)](concepts/scan-and-evidence-levels.md).
+
 Run `abicheck dump libfoo.so --show-data-sources` to see which layers abicheck
 found for a binary. For the full picture see [Evidence &
 Detectability](concepts/evidence-and-detectability.md) and the per-layer
@@ -309,6 +314,8 @@ Full reference (including `compat` mode): [Exit Codes](reference/exit-codes.md)
 
 abicheck separates *what fails CI* (severity → exit code) from *what shows up in
 the report* (display filtering). These three recipes cover the common cases; the
+[CI Gating](user-guide/ci-gating.md) page explains how baselines, policies,
+suppressions, and severity fit together, and the
 [Choose Your Workflow → policy recipes](user-guide/choose-your-workflow.md#3-how-should-ci-behave-policy-recipes)
 and [Severity Configuration](user-guide/severity.md) pages have the rest.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -327,8 +327,12 @@ abicheck compare baseline.json build/libfoo.so \
   --severity-abi-breaking error
 
 # Strict API-surface governance: also fail on new public ABI/API additions
+# (--severity-potential-breaking keeps source-level API breaks failing too —
+# any --severity-* flag switches to the severity scheme, where that category
+# is only a warning by default)
 abicheck compare baseline.json build/libfoo.so \
   --new-header include/ \
+  --severity-potential-breaking error \
   --severity-addition error
 
 # Show only additions in a review report — verdict and exit code unchanged

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 
 ## Why abicheck
 
-- **Three-layer analysis** — ELF/PE/Mach-O symbol tables + Clang AST (via castxml) + DWARF/PDB cross-check. Each layer catches things the others miss.
+- **Five-source evidence model** — abicheck overlays up to five independent, additive sources (the binary, its debug info, its public headers, its build-system data, and optionally its sources — `L0`–`L4`) and lets the strongest evidence win. Each source catches breaks the others miss. See [Evidence & Detectability](concepts/evidence-and-detectability.md).
 - **254 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ It supports ELF (Linux), PE/COFF (Windows), and Mach-O (macOS) binaries, and it'
 
 ## Why abicheck
 
-- **Five-source evidence model** — abicheck overlays up to five independent, additive sources (the binary, its debug info, its public headers, its build-system data, and optionally its sources — `L0`–`L4`) and lets the strongest evidence win. Each source catches breaks the others miss. See [Evidence & Detectability](concepts/evidence-and-detectability.md).
+- **Five-source evidence model** — abicheck overlays up to five independent, additive sources (the binary, its debug info, its public headers, its build-system data, and optionally its sources — `L0`–`L4`), cross-checks them against each other (DWARF/PDB debug info against the symbol table, header AST against build flags), and lets the strongest evidence win. Each source catches breaks the others miss. See [Evidence & Detectability](concepts/evidence-and-detectability.md).
 - **254 detection rules** — symbol removal, signature changes, struct/class layout drift, vtable reordering, enum value shifts, qualifier changes, calling conventions, and many more. See the [Change Kind Reference](reference/change-kinds.md).
 - **Multiple output formats** — Markdown, JSON, SARIF (GitHub Code Scanning), HTML.
 - **Policy profiles** — `strict_abi`, `sdk_vendor`, `plugin_abi`, or custom YAML overrides.

--- a/docs/user-guide/baseline-management.md
+++ b/docs/user-guide/baseline-management.md
@@ -4,6 +4,10 @@ ABI baselines are pre-computed snapshots of a library's ABI surface at a known-g
 point (typically a release). Comparing future builds against a baseline detects
 breaking changes before they ship.
 
+> The baseline is the input to the CI gating pipeline (classify → suppress →
+> severity → exit code) — see [CI Gating](ci-gating.md) for how it combines
+> with policies, suppressions, and severity.
+
 ## Creating a Baseline
 
 ```bash

--- a/docs/user-guide/choose-your-workflow.md
+++ b/docs/user-guide/choose-your-workflow.md
@@ -57,7 +57,9 @@ and **which report** to produce (§4).
 The single biggest lever on what abicheck can *prove* is the quality of the
 inputs you give it — its five additive evidence layers, **L0–L4**. More
 evidence catches more breaks. Start at the layer your artifacts allow, and add
-more when you need more confidence.
+more when you need more confidence. (The `scan` docs also use a sixth code,
+**`L5`** — the source graph abicheck *derives* from L3/L4; you never provide it.
+See [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md).)
 
 | Layer | Inputs | Confidence | What it newly catches |
 |:--:|---|---|---|

--- a/docs/user-guide/ci-gating.md
+++ b/docs/user-guide/ci-gating.md
@@ -47,14 +47,15 @@ verdict or the exit code.
 
 ## The two exit-code schemes
 
-`compare` has two exit-code regimes, and **passing any `--severity-*` flag
-silently switches from the first to the second** — the most common source of
-confusion when wiring up CI:
+`compare` has two exit-code regimes, and **any active severity setting — a
+`--severity-*` flag *or* a severity value in `.abicheck.yml` — silently
+switches from the first to the second** — the most common source of confusion
+when wiring up CI:
 
 | Scheme | Active when | Codes |
 |---|---|---|
-| **Legacy (verdict-based)** | No `--severity-*` flag given | `0` compatible / `2` `API_BREAK` / `4` `BREAKING` |
-| **Severity-based** | Any `--severity-*` flag given | `0` no error-level findings / `1` error in `addition`·`quality_issues` only / `2` error in `potential_breaking` / `4` error in `abi_breaking` |
+| **Legacy (verdict-based)** | No severity setting active (neither a `--severity-*` flag nor a config severity value) | `0` compatible / `2` `API_BREAK` / `4` `BREAKING` |
+| **Severity-based** | Any severity setting active (CLI flag or `.abicheck.yml` value) | `0` no error-level findings / `1` error in `addition`·`quality_issues` only / `2` error in `potential_breaking` / `4` error in `abi_breaking` |
 
 In both schemes `0` passes and `4` is worst — but under the severity scheme
 exit `1` means an error-level *finding*, whereas under the legacy scheme `1`

--- a/docs/user-guide/ci-gating.md
+++ b/docs/user-guide/ci-gating.md
@@ -59,7 +59,7 @@ when wiring up CI:
 
 In both schemes `0` passes and `4` is worst — but under the severity scheme
 exit `1` means an error-level *finding*, whereas under the legacy scheme `1`
-is not used for verdicts at all (invalid invocations exit `64`). Pin the
+is a tool/runtime error, never a verdict (usage errors exit `64`). Pin the
 regime explicitly with `--exit-code-scheme legacy|severity` (or the
 `exit_code_scheme` config key) so a later flag change can't silently flip it.
 Full matrix, including `appcompat`/`deps`/`compat` and multi-library codes:

--- a/docs/user-guide/ci-gating.md
+++ b/docs/user-guide/ci-gating.md
@@ -1,0 +1,132 @@
+# CI Gating: How the Pieces Fit Together
+
+Four mechanisms decide what fails your build: **baselines** (what you compare
+against), **policies** (how each change is classified), **suppressions** (which
+changes are waived), and **severity** (which categories set the exit code).
+Each has its own reference page; this page is the map — what runs in what
+order, and how the knobs interact.
+
+```mermaid
+flowchart LR
+    B["Baseline<br/>(snapshot / registry)"] --> D["Detect changes<br/>(compare)"]
+    N["New build"] --> D
+    D --> P["1 · Policy classifies<br/>each change"]
+    P --> S["2 · Suppressions<br/>waive changes"]
+    S --> V["3 · Verdict + severity<br/>categories"]
+    V --> E["4 · Exit code<br/>(legacy or severity scheme)"]
+    V -.-> R["Report rendering<br/>(--show-only, --format)"]
+```
+
+## The order of operations
+
+1. **Detect.** `abicheck compare BASELINE NEW` diffs the two ABI surfaces and
+   produces raw changes. The baseline side is a snapshot, library, or registry
+   entry — see [Baseline Management](baseline-management.md).
+2. **Classify (policy).** The active [policy profile](policies.md)
+   (`--policy strict_abi|sdk_vendor|plugin_abi` or a custom
+   `--policy-file`) maps each change kind to its impact — the same change can
+   be `API_BREAK` under `strict_abi` but `COMPATIBLE` under `sdk_vendor`.
+3. **Waive (suppressions).** [Suppression rules](suppressions.md)
+   (`--suppress FILE`) remove matching changes **before** the verdict and
+   severity counts are computed. A suppressed breaking change does not fail
+   the build; it is tallied separately (`suppressed_count` in the JSON
+   output).
+4. **Score (verdict + severity).** The surviving changes produce the overall
+   verdict (`NO_CHANGE` … `BREAKING`) and, when
+   [severity](severity.md) is configured, per-category
+   (`abi_breaking` / `potential_breaking` / `quality_issues` / `addition`)
+   severity levels.
+5. **Exit.** The exit code comes from one of the two schemes below.
+
+**Display filtering is outside the pipeline.** `--show-only`, `--stat`,
+`--report-mode`, and `--format` change what the report *renders*, never the
+verdict or the exit code.
+
+## The two exit-code schemes
+
+`compare` has two exit-code regimes, and **passing any `--severity-*` flag
+silently switches from the first to the second** — the most common source of
+confusion when wiring up CI:
+
+| Scheme | Active when | Codes |
+|---|---|---|
+| **Legacy (verdict-based)** | No `--severity-*` flag given | `0` compatible / `2` `API_BREAK` / `4` `BREAKING` |
+| **Severity-based** | Any `--severity-*` flag given | `0` no error-level findings / `1` error in `addition`·`quality_issues` only / `2` error in `potential_breaking` / `4` error in `abi_breaking` |
+
+In both schemes `0` passes and `4` is worst — but under the severity scheme
+exit `1` means an error-level *finding*, whereas under the legacy scheme `1`
+is not used for verdicts at all (invalid invocations exit `64`). Pin the
+regime explicitly with `--exit-code-scheme legacy|severity` (or the
+`exit_code_scheme` config key) so a later flag change can't silently flip it.
+Full matrix, including `appcompat`/`deps`/`compat` and multi-library codes:
+[Exit Codes](../reference/exit-codes.md).
+
+## How the knobs interact
+
+- **Policy → severity.** Severity categorizes changes *after* the policy has
+  classified them. If `sdk_vendor` downgrades a kind from `potential_breaking`
+  to `quality_issues`, the default preset then treats it as `warning`, not
+  `error` — so `--policy sdk_vendor --severity-preset default` will not fail
+  on it, while `--severity-preset strict` (everything `error`) still will.
+  See [Severity → Policy interaction](severity.md#policy-interaction).
+- **Policy → suppressions.** Independent: suppressions match on
+  symbol/type/kind/location, regardless of how the policy classified the
+  change. A suppression written under one policy keeps working if you switch
+  policies.
+- **Suppressions → verdict, severity, and exit code.** Suppressed changes are
+  removed before scoring, so they affect *all* downstream outputs: the
+  verdict, the severity category counts, and therefore the exit code — under
+  either scheme. Guard the waiver list itself with `--strict-suppressions`
+  (fail on unused/expired rules) and `--require-justification`.
+- **Baselines → everything.** All of the above only gates what changed
+  *relative to the baseline you chose*. Compare against the last release (not
+  the previous commit) to catch cumulative drift; see
+  [Baseline Management](baseline-management.md) for storage and registry
+  workflows.
+
+## Recipes
+
+**Breakage-only gate** — report everything, fail only on binary ABI breaks:
+
+```bash
+abicheck compare baseline.json build/libfoo.so --new-header include/ \
+  --severity-preset info-only --severity-abi-breaking error
+```
+
+**Fail on source-level breaks too** (the legacy default behaviour, pinned
+explicitly):
+
+```bash
+abicheck compare baseline.json build/libfoo.so --new-header include/ \
+  --exit-code-scheme legacy    # 0 / 2 (API_BREAK) / 4 (BREAKING)
+```
+
+**Strict API-surface governance** — also fail when new public API appears:
+
+```bash
+abicheck compare baseline.json build/libfoo.so --new-header include/ \
+  --severity-addition error
+```
+
+**Vendor-friendly gate with audited waivers**:
+
+```bash
+abicheck compare baseline.json build/libfoo.so --new-header include/ \
+  --policy sdk_vendor --suppress suppressions.yaml \
+  --strict-suppressions --require-justification
+```
+
+More recipes: [Choose Your Workflow → How should CI behave](choose-your-workflow.md)
+and the policy recipes in [Getting Started](../getting-started.md).
+
+## Related pages
+
+- [Baseline Management](baseline-management.md) — producing, storing, and
+  pulling the comparison baseline
+- [Policy Profiles](policies.md) — built-in profiles and custom YAML policies
+- [Suppressions](suppressions.md) — schema, matching semantics, expiry,
+  lifecycle
+- [Severity Configuration](severity.md) — categories, presets, per-category
+  flags
+- [Exit Codes](../reference/exit-codes.md) — the canonical exit-code matrix
+- [GitHub Action](github-action.md) — the same pipeline via `with:` inputs

--- a/docs/user-guide/ci-gating.md
+++ b/docs/user-guide/ci-gating.md
@@ -19,24 +19,27 @@ flowchart LR
 
 ## The order of operations
 
-1. **Detect.** `abicheck compare BASELINE NEW` diffs the two ABI surfaces and
-   produces raw changes. The baseline side is a snapshot, library, or registry
-   entry — see [Baseline Management](baseline-management.md).
-2. **Classify (policy).** The active [policy profile](policies.md)
+It starts with detection: `abicheck compare BASELINE NEW` diffs the two ABI
+surfaces and produces raw changes. The baseline side is a snapshot, library,
+or registry entry — see [Baseline Management](baseline-management.md). The
+detected changes then flow through four stages (the numbers match the diagram
+above):
+
+1. **Classify (policy).** The active [policy profile](policies.md)
    (`--policy strict_abi|sdk_vendor|plugin_abi` or a custom
    `--policy-file`) maps each change kind to its impact — the same change can
    be `API_BREAK` under `strict_abi` but `COMPATIBLE` under `sdk_vendor`.
-3. **Waive (suppressions).** [Suppression rules](suppressions.md)
+2. **Waive (suppressions).** [Suppression rules](suppressions.md)
    (`--suppress FILE`) remove matching changes **before** the verdict and
    severity counts are computed. A suppressed breaking change does not fail
    the build; it is tallied separately (`suppressed_count` in the JSON
    output).
-4. **Score (verdict + severity).** The surviving changes produce the overall
+3. **Score (verdict + severity).** The surviving changes produce the overall
    verdict (`NO_CHANGE` … `BREAKING`) and, when
    [severity](severity.md) is configured, per-category
    (`abi_breaking` / `potential_breaking` / `quality_issues` / `addition`)
    severity levels.
-5. **Exit.** The exit code comes from one of the two schemes below.
+4. **Exit.** The exit code comes from one of the two schemes below.
 
 **Display filtering is outside the pipeline.** `--show-only`, `--stat`,
 `--report-mode`, and `--format` change what the report *renders*, never the
@@ -101,10 +104,15 @@ abicheck compare baseline.json build/libfoo.so --new-header include/ \
   --exit-code-scheme legacy    # 0 / 2 (API_BREAK) / 4 (BREAKING)
 ```
 
-**Strict API-surface governance** — also fail when new public API appears:
+**Strict API-surface governance** — also fail when new public API appears.
+Note that any `--severity-*` flag switches to the severity scheme, where
+`potential_breaking` (which covers `API_BREAK`) defaults to `warning` — raise
+it to `error` too, or a source-level break that failed under the legacy
+scheme would now exit `0`:
 
 ```bash
 abicheck compare baseline.json build/libfoo.so --new-header include/ \
+  --severity-potential-breaking error \
   --severity-addition error
 ```
 

--- a/docs/user-guide/from-libabigail.md
+++ b/docs/user-guide/from-libabigail.md
@@ -46,10 +46,19 @@ Translate your gates:
 | Tool error | bit 0 set (`1`) | — (invalid invocation exits `64`) |
 | Usage error | bit 1 set (`2`) | `64` |
 
-The common `abidiff` CI gate `test $(($? & 8)) -ne 0` becomes simply
-`abicheck compare … ; test $? -ge 4` — or gate on `2` as well if a
-source-level break should also fail. See [Exit Codes](../reference/exit-codes.md)
-for the full matrix (including the severity-aware scheme).
+With `abidiff`, failing a pipeline on incompatible changes means testing the
+bitmask (`rc=$?; if [ $((rc & 8)) -ne 0 ]; then exit 1; fi`). With abicheck
+the exit code is already CI-shaped: a plain `abicheck compare …` step fails
+on any break (`2` or `4`). To fail **only** on binary ABI breaks and tolerate
+source-level ones:
+
+```bash
+abicheck compare libfoo.so.1 libfoo.so.2 -H include/
+test $? -lt 4   # succeeds for 0 (compatible) and 2 (API_BREAK); fails for 4 (BREAKING)
+```
+
+See [Exit Codes](../reference/exit-codes.md) for the full matrix (including
+the severity-aware scheme).
 
 ## Flag-by-flag map
 
@@ -104,7 +113,8 @@ re-dump each stored baseline once from the original binary (see
 abipkgdiff --d1 foo-debuginfo-1.rpm --d2 foo-debuginfo-2.rpm foo-1.rpm foo-2.rpm
 
 # After (abicheck — directory, archive, or package inputs):
-abicheck compare pkg-1.0/ pkg-2.0/ --debug-root1 dbg-1.0/ --debug-root2 dbg-2.0/
+abicheck compare foo-1.rpm foo-2.rpm \
+  --debug-info1 foo-debuginfo-1.rpm --debug-info2 foo-debuginfo-2.rpm
 ```
 
 Multi-library inputs are compared as a co-versioned bundle, with per-library

--- a/docs/user-guide/from-libabigail.md
+++ b/docs/user-guide/from-libabigail.md
@@ -53,8 +53,11 @@ on any break (`2` or `4`). To fail **only** on binary ABI breaks and tolerate
 source-level ones:
 
 ```bash
-abicheck compare libfoo.so.1 libfoo.so.2 -H include/
-test $? -lt 4   # succeeds for 0 (compatible) and 2 (API_BREAK); fails for 4 (BREAKING)
+# capture the status first — under `set -e` (GitHub Actions' default shell
+# options) a bare compare exiting 2 would kill the step before the test runs
+rc=0
+abicheck compare libfoo.so.1 libfoo.so.2 -H include/ || rc=$?
+test "$rc" -lt 4   # succeeds for 0 (compatible) and 2 (API_BREAK); fails for 4 (BREAKING)
 ```
 
 See [Exit Codes](../reference/exit-codes.md) for the full matrix (including

--- a/docs/user-guide/from-libabigail.md
+++ b/docs/user-guide/from-libabigail.md
@@ -43,8 +43,8 @@ Translate your gates:
 | Compatible changes only | bit 2 set (`4`) | `0` (`COMPATIBLE` / `COMPATIBLE_WITH_RISK`) |
 | Source-level (recompile-needed) break | — *(folded into bit 3)* | `2` (`API_BREAK`) |
 | Incompatible ABI change | bit 3 set (`8`, or `12` with bit 2) | `4` (`BREAKING`) |
-| Tool error | bit 0 set (`1`) | — (invalid invocation exits `64`) |
-| Usage error | bit 1 set (`2`) | `64` |
+| Tool/runtime error (e.g. malformed input that exists) | bit 0 set (`1`) | `1` |
+| Usage error (bad arguments/options, unreadable input) | bit 1 set (`2`) | `64` |
 
 With `abidiff`, failing a pipeline on incompatible changes means testing the
 bitmask (`rc=$?; if [ $((rc & 8)) -ne 0 ]; then exit 1; fi`). With abicheck

--- a/docs/user-guide/from-libabigail.md
+++ b/docs/user-guide/from-libabigail.md
@@ -1,56 +1,173 @@
-# libabigail Parity Matrix
+# Migrating from libabigail
 
-_G3: libabigail test suite compatibility_
+This guide maps a `libabigail` workflow — `abidiff`, `abidw`, `abipkgdiff` —
+onto the abicheck equivalents. Unlike the [ABICC migration](from-abicc.md),
+there is no flag-compatible wrapper mode: `abidiff` and `abicheck compare`
+share the same shape (`tool old.so new.so` + header/suppression/debug-info
+options), so you migrate by swapping the command and translating a handful of
+flags, not by keeping the old ones.
 
-This document tracks how abicheck verdict compares to `abidiff` (libabigail)
-on canonical ABI change scenarios.
-
-## Confirmed Parity (both tools agree)
-
-| # | Case | Change | abicheck | abidiff |
-|---|------|--------|----------|---------|
-| 1 | fn_removed | Function removed from dynsym | BREAKING | BREAKING |
-| 2 | fn_added | New function added | COMPATIBLE | COMPATIBLE |
-| 3 | no_change | Identical libraries | NO_CHANGE | NO_CHANGE |
-| 4 | visibility_hidden | Public → hidden visibility | BREAKING | BREAKING |
-| 5 | vtable_reorder | C++ vtable method order swap | NO_CHANGE | BREAKING* |
-| 6 | enum_value | Enum member value changed | BREAKING | COMPATIBLE† |
-
-\* vtable: abidiff detects via DWARF; abicheck ELF-only misses it (gap, needs castxml)
-† enum_value: abicheck is intentionally stricter — enum value changes break switch/serialization
-
-## Known Divergences (tracked gaps)
-
-| # | Case | abicheck | abidiff | Root cause |
-|---|------|----------|---------|------------|--------|
-| 1 | struct_size | NO_CHANGE | COMPATIBLE¹ | ELF-only: no type info without headers |
-| 2 | return_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
-| 3 | param_type | NO_CHANGE | COMPATIBLE¹ | ELF-only: same symbol name, no type diff |
-| 4 | vtable_reorder | NO_CHANGE | BREAKING | ELF-only: vtable not visible in dynsym |
-
-¹ Note: abidiff with DWARF (-g but no headers) classifies type sub-changes as
-COMPATIBLE (exit=4), not BREAKING. To get BREAKING verdict from abidiff,
-use `--headers-dir` option. abicheck with headers (castxml) returns BREAKING correctly.
-
-## Gap closure plan
-
-After integrating castxml output into parity tests, all divergences close.
-When a gap is closed, update `PARITY_CASES` in `tests/test_abidiff_parity.py`
-and move the entry from `_DIVERGE` to `_CONFIRMED`.
-
-## How to run
+## Step 1: Swap the command
 
 ```bash
-# Requires: abidiff (libabigail-tools), gcc/g++
-pytest tests/test_abidiff_parity.py -v -m libabigail
+# Before (libabigail):
+abidiff libfoo.so.1 libfoo.so.2
+
+# After (abicheck):
+abicheck compare libfoo.so.1 libfoo.so.2
 ```
 
-## abidiff exit code mapping
+Both tools read DWARF automatically when the binaries carry it. As with
+`abidiff`, results are much stronger with public headers (see the flag map
+below) — headers also let abicheck scope out internal types, the equivalent of
+`abidiff --drop-private-types`.
 
-| Exit code bits | Meaning | abicheck verdict |
-|----------------|---------|-----------------|
-| 0 | No differences | NO_CHANGE |
-| 4 (bit 2) | Compatible sub-type changes | COMPATIBLE |
-| 8 (bit 3) | Incompatible changes | BREAKING |
-| 12 (bits 2+3) | Both compatible + incompatible | BREAKING |
-| 1 (bit 0) | Error | ERROR |
+```bash
+# Before (libabigail):
+abidiff --headers-dir1 include-v1/ --headers-dir2 include-v2/ \
+  --drop-private-types libfoo.so.1 libfoo.so.2
+
+# After (abicheck — public-surface scoping is automatic with headers):
+abicheck compare libfoo.so.1 libfoo.so.2 \
+  --old-header include-v1/ --new-header include-v2/
+```
+
+## Step 2: Update CI exit-code checks
+
+`abidiff` returns a **bitmask**; abicheck returns a **scalar verdict code**.
+Translate your gates:
+
+| Condition | `abidiff` exit | abicheck `compare` exit |
+|---|---|---|
+| No differences | `0` | `0` (`NO_CHANGE`) |
+| Compatible changes only | bit 2 set (`4`) | `0` (`COMPATIBLE` / `COMPATIBLE_WITH_RISK`) |
+| Source-level (recompile-needed) break | — *(folded into bit 3)* | `2` (`API_BREAK`) |
+| Incompatible ABI change | bit 3 set (`8`, or `12` with bit 2) | `4` (`BREAKING`) |
+| Tool error | bit 0 set (`1`) | — (invalid invocation exits `64`) |
+| Usage error | bit 1 set (`2`) | `64` |
+
+The common `abidiff` CI gate `test $(($? & 8)) -ne 0` becomes simply
+`abicheck compare … ; test $? -ge 4` — or gate on `2` as well if a
+source-level break should also fail. See [Exit Codes](../reference/exit-codes.md)
+for the full matrix (including the severity-aware scheme).
+
+## Flag-by-flag map
+
+| libabigail (`abidiff`) | abicheck equivalent | Notes |
+|---|---|---|
+| `lib1.so lib2.so` positional args | `compare OLD NEW` positional args | abicheck also accepts JSON snapshots and directories/packages |
+| `--headers-dir1 DIR` / `--hd1` | `--old-header DIR` | Directories are scanned recursively; needs `castxml` or `clang` |
+| `--headers-dir2 DIR` / `--hd2` | `--new-header DIR` | Use `-H DIR` once when the same headers apply to both sides |
+| `--header-file1` / `--header-file2` | `--old-header FILE` / `--new-header FILE` | Same flags accept files or directories |
+| `--drop-private-types` | *(automatic)* | With headers, abicheck scopes findings to the public surface by default; opt out with `--no-scope-public-headers` |
+| `--suppressions FILE` / `--suppr` | `--suppress FILE` | Different file format: YAML instead of libabigail's INI sections — see [Suppressions](suppressions.md) and the translation section below |
+| `--no-default-suppression` | *(not needed)* | abicheck applies no default suppression specs |
+| `--debug-info-dir1 DIR` / `--d1` | `--debug-root1 DIR` | Sidecar/split debug trees |
+| `--debug-info-dir2 DIR` / `--d2` | `--debug-root2 DIR` | `--debug-root DIR` applies to both sides |
+| *(no equivalent)* | `--debuginfod` | Fetch debug info from a debuginfod server |
+| `--stat` | `--stat` | One-line summary instead of the full report |
+| `--leaf-changes-only` / `-l` | `--report-mode leaf` | Root-type-grouped leaf view |
+| `--impacted-interfaces` | `--show-impact` | Impact summary appended to the report |
+| `--no-added-syms` | `--show-only removed,changed` | Display-only filter; verdict and exit code unchanged |
+| `--harmless` | *(default)* | Compatible changes are already reported; isolate them with `--show-only compatible` |
+| `--exported-interfaces-only` | *(default)* | abicheck always analyses the exported ABI surface |
+| `--fail-no-debug-info` | *(no direct flag)* | abicheck degrades gracefully and reports the evidence it had — check `abicheck dump LIB --show-data-sources` or the report's evidence tier |
+| `--verbose` | `-v` / `--verbose` | |
+
+Output formats: where `abidiff` emits its text report, `abicheck compare`
+defaults to Markdown and adds `--format json|sarif|html|junit` — see
+[Output Formats](output-formats.md).
+
+## Snapshot workflow: `abidw` → `abicheck dump`
+
+If you store `abidw` ABIXML baselines, the equivalent is a JSON snapshot:
+
+```bash
+# Before (libabigail):
+abidw --out-file libfoo.abi libfoo.so
+abidiff libfoo.abi build/libfoo.so
+
+# After (abicheck):
+abicheck dump libfoo.so -H include/ --version 1.0 -o libfoo.abi.json
+abicheck compare libfoo.abi.json build/libfoo.so --new-header include/
+```
+
+Snapshots and binaries mix freely on either side of `compare`; the input
+format is auto-detected. ABIXML files are **not** readable by abicheck —
+re-dump each stored baseline once from the original binary (see
+[Baseline Management](baseline-management.md) for storage recipes).
+
+## Package comparison: `abipkgdiff` → `compare` on directories/packages
+
+```bash
+# Before (libabigail):
+abipkgdiff --d1 foo-debuginfo-1.rpm --d2 foo-debuginfo-2.rpm foo-1.rpm foo-2.rpm
+
+# After (abicheck — directory, archive, or package inputs):
+abicheck compare pkg-1.0/ pkg-2.0/ --debug-root1 dbg-1.0/ --debug-root2 dbg-2.0/
+```
+
+Multi-library inputs are compared as a co-versioned bundle, with per-library
+verdicts and a bundle-level worst-wins verdict; add `--fail-on-removed-library`
+to exit `8` when a library disappeared — see
+[Multi-Binary Releases](multi-binary.md).
+
+## Translating suppression files
+
+libabigail INI suppressions translate mechanically to abicheck's YAML schema:
+
+```ini
+# Before (libabigail INI):
+[suppress_function]
+name_regexp = ^internal_.*
+
+[suppress_type]
+name = FooPrivate
+```
+
+```yaml
+# After (abicheck YAML — patterns are fullmatch regexes):
+version: 1
+suppressions:
+  - symbol_pattern: "internal_.*"
+    reason: "internal namespace, not public API"
+  - type_pattern: "FooPrivate"
+    reason: "private type"
+```
+
+The YAML schema also supports change-kind filters, expiry dates, and required
+justifications — see [Suppressions](suppressions.md) for the full schema, and
+run `abicheck suggest-suppressions` on a JSON report to generate candidate
+entries instead of writing them by hand.
+
+## Semantics to be aware of
+
+- **Enum values.** abicheck intentionally classifies enum member *value*
+  changes as `BREAKING` (they break switch statements and serialized data);
+  `abidiff` reports them as compatible.
+- **A separate source-level verdict.** Changes that require recompilation but
+  don't break existing binaries get their own `API_BREAK` verdict and exit
+  code `2`, instead of being folded into a single incompatible bit.
+- **Evidence layers.** Like `abidiff`, abicheck works binary-only, but its
+  verdict strengthens with each added source — debug info, headers, build
+  data, sources. See [Evidence & Detectability](../concepts/evidence-and-detectability.md).
+
+The per-case verdict agreement between the two tools is tracked in the
+[libabigail parity matrix](../development/libabigail-parity.md), and the
+benchmark comparison (including `abidiff` accuracy on the example catalog) in
+[Tool Comparison & Benchmarks](../reference/tool-comparison.md).
+
+## Validate side-by-side
+
+Keep both tools installed during the transition and compare verdicts on a few
+historical releases:
+
+```bash
+for ver in 1.0 1.1 1.2; do
+  abidiff libfoo.so.${ver} libfoo.so.current; echo "abidiff: $?"
+  abicheck compare libfoo.so.${ver} libfoo.so.current; echo "abicheck: $?"
+done
+```
+
+Where the tools disagree, the parity matrix above documents the known,
+intentional differences.

--- a/docs/user-guide/from-libabigail.md
+++ b/docs/user-guide/from-libabigail.md
@@ -179,5 +179,6 @@ for ver in 1.0 1.1 1.2; do
 done
 ```
 
-Where the tools disagree, the parity matrix above documents the known,
+Where the tools disagree, the
+[parity matrix](../development/libabigail-parity.md) documents the known,
 intentional differences.

--- a/docs/user-guide/mcp-integration.md
+++ b/docs/user-guide/mcp-integration.md
@@ -62,7 +62,7 @@ Add to `.cursor/mcp.json` or VS Code MCP settings:
 
 ## Tools
 
-The MCP server exposes four tools. All return JSON-encoded strings.
+The MCP server exposes seven tools. All return JSON-encoded strings.
 
 **Response envelopes.** On failure, every tool returns the same error
 envelope: `{"status": "error", "error": "<message>"}`. On success the
@@ -74,6 +74,9 @@ shape differs by tool:
 | `abi_dump` | `{"status": "ok", "summary": ..., ...}` |
 | `abi_list_changes` | `{"count": ..., "change_kinds": [...]}` — no `status` field |
 | `abi_explain_change` | `{"kind": ..., "impact": ..., ...}` — no `status` field |
+| `abi_audit` | `{"status": "ok", "verdict": ..., "catalog": ..., "pattern_scan": ...}` |
+| `abi_estimate` | `{"status": "ok", "mode": ..., "estimate": [...], "total_est_seconds": ...}` |
+| `abi_scan` | `{"status": "ok", "verdict": ..., "layers": [...], ...}` |
 
 The simplest client check is: `status == "error"` ⇒ failure; otherwise
 treat as success and parse the tool-specific payload. See
@@ -275,6 +278,94 @@ Returns a detailed explanation of what a change kind means, why it's dangerous, 
 The `severity` field is either `"error"` (`BREAKING`) or `"warning"`
 (`API_BREAK`, `COMPATIBLE_WITH_RISK`, and `COMPATIBLE` kinds).
 
+---
+
+### `abi_audit` — Single-release ABI-hygiene audit
+
+The MCP counterpart of [`abicheck scan --audit`](scan-levels.md): runs the
+intra-version cross-source validation engine plus the compiler-free lexical
+pattern pre-scan over **one** build — no baseline or previous version needed.
+It returns a "bad ABI hygiene" catalog: accidental ABI surface
+(`exported_not_public`), public-but-not-exported declarations,
+header/build-context mismatch, and private-header leaks, plus advisory pattern
+facts. Per the authority rule these findings are never `BREAKING` on their own —
+they are advisory (`RISK`/`API_BREAK`).
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `library_path` | string | yes | Path to `.so`/`.dll`/`.dylib` or a JSON snapshot |
+| `headers` | string[] | no | Public header files. Strongly recommended — most hygiene checks skip cleanly without public-header provenance |
+| `include_dirs` | string[] | no | Extra include directories for the C/C++ parser |
+| `language` | string | no | `"c++"` (default) or `"c"` |
+
+**Response fields:** `verdict` (`COMPATIBLE` or `API_BREAK`), `exit_code`
+(`0` or `2`), `catalog` (the cross-source findings), and `pattern_scan`
+(the advisory pattern facts).
+
+---
+
+### `abi_estimate` — Dry-run scan cost estimate
+
+The MCP counterpart of [`abicheck scan --estimate`](scan-levels.md):
+probes the project (TU count from the compile DB or source tree, public-header
+fan-out) and returns the **projected per-layer cost** of the chosen scan level
+without running any compiler or parsing any binary. Use it to pick a
+`depth`/`mode` on measured cost before spending on `abi_scan`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `binary_path` | string | yes | Library/artifact the scan would target (existence checked) |
+| `headers` | string[] | no | Public header files (for the L2 header-AST fan-out estimate) |
+| `include_dirs` | string[] | no | Extra include directories |
+| `sources` | string | no | Source tree (compile DB auto-discovered within it) |
+| `compile_db` | string | no | Explicit `compile_commands.json` (else discovered in `sources`) |
+| `mode` | string | no | Fixed (L,S) preset: `"pr"` (default), `"pr-deep"`, `"baseline"`, `"audit"` |
+| `source_method` | string | no | Precise S-axis level (`s0`…`s6` or `auto`); omit for the mode preset |
+| `depth` | string | no | Coarse L-axis selector: `binary`, `headers`, `build`, `source`, `full` |
+| `changed_paths` | string[] | no | Changed-path set for the focused replay-scope estimate |
+
+**Response fields:** `mode`, `estimate` (per-layer cost rows), and
+`total_est_seconds`.
+
+---
+
+### `abi_scan` — Source-intelligence scan
+
+The MCP counterpart of the [`scan` CLI](scan-levels.md): classify → always-on
+tier (compiler-free pattern pre-scan + intra-version cross-source checks) → the
+pinned evidence level — and, when `baseline` is given, a compare against it.
+Returns one coverage-/confidence-annotated scan result. The authority rule is
+preserved: source/cross-source findings are `RISK`/`API_BREAK` only, never
+`BREAKING` on their own. See [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md)
+for the `mode`/`source_method`/`depth` model.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `binary_path` | string | yes | Library/artifact (or JSON snapshot) to scan |
+| `headers` | string[] | no | Public header files (provenance + pattern pre-scan) |
+| `include_dirs` | string[] | no | Extra include directories for the parser |
+| `public_header_dirs` | string[] | no | Directories whose headers are public; establishes the public/internal boundary so the leakage/RTTI/exported-vs-public cross-checks run instead of skipping. Must be existing directories |
+| `sources` | string | no | Source tree (compile DB auto-discovered within it) |
+| `compile_db` | string | no | Explicit `compile_commands.json` (else discovered in `sources`) |
+| `baseline` | string | no | Previous build's dump/library to compare against. Omit for a single-release run; use `mode="audit"` for the hygiene catalog |
+| `mode` | string | no | Fixed (L,S) preset: `"pr"` (default), `"pr-deep"`, `"baseline"`, `"audit"` |
+| `source_method` | string | no | Precise S-axis level (`s0`…`s6` or `auto`); omit for the mode preset |
+| `depth` | string | no | Coarse L-axis selector: `binary`, `headers`, `build`, `source`, `full` |
+| `changed_paths` | string[] | no | Changed-path set focusing the scan |
+| `language` | string | no | `"c++"` (default) or `"c"` |
+
+**Response fields:** `verdict`, `exit_code`, `findings` (count), `layers`
+(the per-layer evidence-coverage rows — always read these before trusting the
+verdict), `confidence` (the provider-agreement matrix), `estimate` (projected
+per-layer cost for comparison against the actual run), and `report` (the full
+report payload).
+
 ## Agent workflow examples
 
 ### Check a PR for ABI compatibility
@@ -315,6 +406,31 @@ Agent: "What kinds of ABI breaks can you detect?"
    → the breaking subset of the change-kind registry, with descriptions
 
 2. Agent summarizes the categories for the user
+```
+
+### Audit one build's ABI hygiene (no baseline)
+
+```text
+User: "Does this library leak anything it shouldn't?"
+
+1. abi_audit(library_path="build/libfoo.so", headers=["include/foo.h"])
+   → catalog: [{kind: "exported_not_public", ...}, ...]
+
+2. Agent reports the accidental exports and private-header leaks
+```
+
+### Estimate before a deep scan
+
+```text
+Agent: "Is a full source scan affordable here?"
+
+1. abi_estimate(binary_path="build/libfoo.so", sources=".", mode="pr")
+   → total_est_seconds: 42.5, estimate: [per-layer rows]
+
+2. abi_scan(binary_path="build/libfoo.so", headers=["include/foo.h"],
+            sources=".", baseline="artifacts/libfoo-main.abi.json",
+            changed_paths=["src/foo.cpp"])
+   → verdict + per-layer coverage rows (read them before trusting the verdict)
 ```
 
 ## Error responses
@@ -361,8 +477,8 @@ variables override defaults.
 
 | CLI flag | Environment variable | Default | Purpose |
 |---|---|---|---|
-| `--timeout <s>` | `ABICHECK_MCP_TIMEOUT` | `120` | Per-call timeout (seconds) for `abi_dump` and `abi_compare`. On timeout the tool returns a structured error; the server stays up |
-| `--max-file-size <bytes>` | `ABICHECK_MCP_MAX_FILE_SIZE` | `524288000` (500 MB) | Maximum size of any input file (`library_path`, `old_input`, `new_input`) |
+| `--timeout <s>` | `ABICHECK_MCP_TIMEOUT` | `120` | Per-call timeout (seconds) for `abi_dump`, `abi_compare`, `abi_audit`, and `abi_scan`. On timeout the tool returns a structured error; the server stays up |
+| `--max-file-size <bytes>` | `ABICHECK_MCP_MAX_FILE_SIZE` | `524288000` (500 MB) | Maximum size of any input artifact — `library_path` (`abi_dump`/`abi_audit`), `old_input`/`new_input` (`abi_compare`), and `binary_path`/`compile_db`/`baseline` (`abi_scan`) |
 | `--log-format text\|json` | — | `text` | Audit log format on stderr |
 
 Example invocation tuned for large libraries:
@@ -463,6 +579,9 @@ The server uses **stdio** transport — the agent spawns `abicheck-mcp` as a loc
 │     abi_compare                  │
 │     abi_list_changes             │
 │     abi_explain_change           │
+│     abi_audit                    │
+│     abi_estimate                 │
+│     abi_scan                     │
 └──────────┬───────────────────────┘
            │ Python imports
            ▼
@@ -498,12 +617,15 @@ they follow the same access controls as the user running the MCP server.
 In addition to the write-path policy above, every tool call is bounded
 to keep one bad input from disabling the server:
 
-- **File-size cap**: input files larger than `--max-file-size` (default
-  500 MB) are rejected before any parsing begins.
-- **Per-call timeout**: `abi_dump` and `abi_compare` run in a worker
-  thread bounded by `--timeout` (default 120 s). On timeout the tool
-  returns a structured error and the server keeps serving subsequent
-  calls.
+- **File-size cap**: input artifacts larger than `--max-file-size` (default
+  500 MB) are rejected before any parsing begins — this covers
+  `library_path` (`abi_dump`/`abi_audit`), `old_input`/`new_input`
+  (`abi_compare`), and `binary_path`/`compile_db`/`baseline` (`abi_scan`).
+- **Per-call timeout**: `abi_dump`, `abi_compare`, and `abi_audit` run in a
+  worker thread bounded by `--timeout` (default 120 s); `abi_scan` runs in a
+  killable child process bounded by the same timeout (so a hung deep scan is
+  terminated, not orphaned). On timeout the tool returns a structured error
+  and the server keeps serving subsequent calls.
 - **Sanitized errors**: filesystem paths and internal stack frames are
   scrubbed from error messages returned to the client. Full details
   remain in stderr logs for operators.

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -203,9 +203,10 @@ For `abicheck compare`, exit codes are the same for all policies — only the ve
 | `2` | `API_BREAK` (source-level break) |
 | `4` | `BREAKING` (binary ABI break) |
 
-> This is the **legacy (verdict-based) scheme**. Passing any `--severity-*`
-> flag switches `compare` to severity-based exit codes, where `1` means an
-> error-level finding — see [CI Gating → the two exit-code schemes](ci-gating.md#the-two-exit-code-schemes)
+> This is the **legacy (verdict-based) scheme**. Any active severity setting
+> (a `--severity-*` flag or a severity value in `.abicheck.yml`) switches
+> `compare` to severity-based exit codes, where `1` means an error-level
+> finding — see [CI Gating → the two exit-code schemes](ci-gating.md#the-two-exit-code-schemes)
 > and the canonical [exit code reference](../reference/exit-codes.md).
 
 For `abicheck compat`, policy still affects verdict classification, but command-level

--- a/docs/user-guide/policies.md
+++ b/docs/user-guide/policies.md
@@ -2,6 +2,10 @@
 
 `abicheck compare` supports policy-based verdict classification.
 
+> Policies are step 1 of the CI gating pipeline (classify → suppress →
+> severity → exit code) — see [CI Gating](ci-gating.md) for how they combine
+> with suppressions, severity, and baselines.
+
 - Built-in profiles: `--policy strict_abi|sdk_vendor|plugin_abi`
 - Custom profile file: `--policy-file <yaml>`
 
@@ -198,6 +202,11 @@ For `abicheck compare`, exit codes are the same for all policies — only the ve
 | `0` | `COMPATIBLE_WITH_RISK` (deployment risk, inspect output) |
 | `2` | `API_BREAK` (source-level break) |
 | `4` | `BREAKING` (binary ABI break) |
+
+> This is the **legacy (verdict-based) scheme**. Passing any `--severity-*`
+> flag switches `compare` to severity-based exit codes, where `1` means an
+> error-level finding — see [CI Gating → the two exit-code schemes](ci-gating.md#the-two-exit-code-schemes)
+> and the canonical [exit code reference](../reference/exit-codes.md).
 
 For `abicheck compat`, policy still affects verdict classification, but command-level
 options (`-strict`, `--strict-mode`, legacy compatibility behavior) can additionally

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -311,10 +311,11 @@ level. `--depth build` (`s1`) adds build-flag/toolchain drift, but only when you
 also give it a build input to read — a compile DB or build dir via
 `--build-info`/`--compile-db` (or a `--sources` tree); without one, L3 is
 reported `not_collected` and no drift is checked. `--depth binary` stays on the
-artifact tiers (L0/L1) and the always-on pattern scan only — no compiler, no
-headers, no sources needed. (`--depth headers` is the next rung up: it adds the
-L2 header AST, which needs a header directory via `--headers` and a C/C++
-frontend on `PATH`.)
+exported-symbol surface (L0) plus cheap debug-info *presence* and the always-on
+pattern scan — it skips the deep DWARF type walk, so no compiler, headers, or
+sources are needed (and no L1 layout evidence is collected). (`--depth headers`
+is the next rung up: it adds the L2 header AST, which needs a header directory
+via `--headers` and a C/C++ frontend on `PATH`.)
 
 ```bash
 # build-flag drift only, flat ~0.3–0.5s regardless of project size
@@ -322,7 +323,8 @@ frontend on `PATH`.)
 abicheck scan --binary new/libfoo.so --baseline old/libfoo.abi.json \
   --build-info build/compile_commands.json --depth build
 
-# artifact + always-on lexical scan only (no L2 AST, no L3/L4/L5; no compiler needed)
+# exported symbols + always-on lexical scan only (no DWARF walk, no L2 AST,
+# no L3/L4/L5; no compiler needed)
 abicheck scan --binary new/libfoo.so --baseline old/libfoo.abi.json --depth binary
 ```
 

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -310,8 +310,11 @@ When you only have the two binaries (or want a fast pre-check), pin a cheap
 level. `--depth build` (`s1`) adds build-flag/toolchain drift, but only when you
 also give it a build input to read — a compile DB or build dir via
 `--build-info`/`--compile-db` (or a `--sources` tree); without one, L3 is
-reported `not_collected` and no drift is checked. `--depth headers` (`s0`) stays
-on the always-on pattern scan and the artifact tiers only:
+reported `not_collected` and no drift is checked. `--depth binary` stays on the
+artifact tiers (L0/L1) and the always-on pattern scan only — no compiler, no
+headers, no sources needed. (`--depth headers` is the next rung up: it adds the
+L2 header AST, which needs a header directory via `--headers` and a C/C++
+frontend on `PATH`.)
 
 ```bash
 # build-flag drift only, flat ~0.3–0.5s regardless of project size
@@ -319,8 +322,8 @@ on the always-on pattern scan and the artifact tiers only:
 abicheck scan --binary new/libfoo.so --baseline old/libfoo.abi.json \
   --build-info build/compile_commands.json --depth build
 
-# artifact + always-on lexical scan only (no L3/L4/L5; no build input needed)
-abicheck scan --binary new/libfoo.so --baseline old/libfoo.abi.json --depth headers
+# artifact + always-on lexical scan only (no L2 AST, no L3/L4/L5; no compiler needed)
+abicheck scan --binary new/libfoo.so --baseline old/libfoo.abi.json --depth binary
 ```
 
 ### Estimate before you spend — `--estimate`

--- a/docs/user-guide/severity.md
+++ b/docs/user-guide/severity.md
@@ -94,7 +94,8 @@ configuration instead of the legacy verdict system:
 | `2` | Error-level findings in `potential_breaking` (but not `abi_breaking`) |
 | `4` | Error-level findings in `abi_breaking` |
 
-The highest applicable code wins. Without any `--severity-*` flag, the legacy
+The highest applicable code wins. Without any active severity setting (no
+`--severity-*` flag and no config severity value), the legacy
 verdict-based exit codes apply (see [exit codes reference](../reference/exit-codes.md)).
 
 ## Report output

--- a/docs/user-guide/severity.md
+++ b/docs/user-guide/severity.md
@@ -5,10 +5,10 @@ each with a configurable severity level that controls exit codes and report
 presentation.
 
 > Severity is the last step of the CI gating pipeline (classify → suppress →
-> severity → exit code), and passing any `--severity-*` flag switches
-> `compare` to the severity-based exit-code scheme. See
-> [CI Gating](ci-gating.md) for how it combines with policies, suppressions,
-> and baselines.
+> severity → exit code), and any active severity setting — a `--severity-*`
+> flag or a severity value in `.abicheck.yml` — switches `compare` to the
+> severity-based exit-code scheme. See [CI Gating](ci-gating.md) for how it
+> combines with policies, suppressions, and baselines.
 
 ---
 
@@ -83,8 +83,9 @@ Available flags:
 
 ## Exit codes
 
-When any `--severity-*` flag is provided, the exit code is computed from the
-severity configuration instead of the legacy verdict system:
+When any severity setting is active — a `--severity-*` flag or a severity
+value in `.abicheck.yml` — the exit code is computed from the severity
+configuration instead of the legacy verdict system:
 
 | Exit code | Meaning |
 |-----------|---------|

--- a/docs/user-guide/severity.md
+++ b/docs/user-guide/severity.md
@@ -4,6 +4,12 @@ abicheck classifies every detected change into one of four **issue categories**,
 each with a configurable severity level that controls exit codes and report
 presentation.
 
+> Severity is the last step of the CI gating pipeline (classify → suppress →
+> severity → exit code), and passing any `--severity-*` flag switches
+> `compare` to the severity-based exit-code scheme. See
+> [CI Gating](ci-gating.md) for how it combines with policies, suppressions,
+> and baselines.
+
 ---
 
 ## Issue categories

--- a/docs/user-guide/suppressions.md
+++ b/docs/user-guide/suppressions.md
@@ -4,6 +4,11 @@
 
 Use suppressions to silence known/accepted changes while keeping detection enabled.
 
+> Suppressions are step 2 of the CI gating pipeline (classify → suppress →
+> severity → exit code): suppressed changes are removed *before* the verdict
+> and severity counts are computed. See [CI Gating](ci-gating.md) for how they
+> combine with policies, severity, and baselines.
+
 ---
 
 ## File format

--- a/docs/user-guide/tool-modes.md
+++ b/docs/user-guide/tool-modes.md
@@ -117,7 +117,9 @@ positives by scoping to the public surface. The
 quantifies the cumulative gain across the example catalog (32% → 81% → 99% →
 100%). The [authority rule](../concepts/architecture.md#evidence-layers-the-five-sources)
 keeps the modes honest: only L0/L1/L2 can declare a binary `BREAKING`; L3/L4
-explain, scope, and add their own source-/API-level findings.
+(and the `L5` source graph abicheck derives from them — see
+[Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md)) explain, scope,
+and add their own source-/API-level findings.
 
 > **Quick decision.** Stripped production binary → **L0**. Debug build, no
 > headers handy → **L1**. Have the public headers → **L2** (do this whenever you

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Output Formats: user-guide/output-formats.md
       - Baseline Management: user-guide/baseline-management.md
     - CI & Gating:
+      - CI Gating Pipeline: user-guide/ci-gating.md
       - GitHub Action: user-guide/github-action.md
       - GitHub PR Annotations: user-guide/annotations.md
       - Severity Configuration: user-guide/severity.md
@@ -133,6 +134,7 @@ nav:
     - Parity & Reports:
       - ABICC Parity Status: development/abicc-parity-status.md
       - ABICC Test Coverage Comparison: development/abicc-test-coverage-comparison.md
+      - libabigail Parity Matrix: development/libabigail-parity.md
       - Report Comparison: development/report-comparison.md
     - Implementation Plans:
       - Overview: development/plans/index.md


### PR DESCRIPTION
## Summary

Fixes the five highest-impact findings from a documentation/user-flow audit: a run-blocking `scan --depth` contradiction, three competing versions of the evidence-layer mental model, an MCP doc covering only 4 of 7 tools, a "migration guide" that was actually a QA matrix, and the missing hub page explaining how the CI-gating pieces interact.

## Motivation

An audit of the docs against the code found the user-facing flow contradicting itself in places a user actually hits:

- `concepts/scan-and-evidence-levels.md` defined the `--depth` rungs as `headers|build|graph|source|full`, while the CLI (`USER_DEPTHS` in `buildsource/scan_levels.py`, ADR-037 D5/D6) and `user-guide/scan-levels.md` define `binary|headers|build|source|full` with `graph` internal-only. A user could not guess what `--depth headers` does.
- The core pitch was told three ways: "three-layer analysis" (`docs/index.md`), "five sources, L0–L4" (README, getting-started), "L0–L5" (scan/concepts docs).
- `mcp-integration.md` said "the server exposes four tools"; `mcp_server.py` registers seven — `abi_audit`, `abi_estimate`, `abi_scan` were invisible, and the `--timeout`/`--max-file-size` scoping was undercounted.
- The page navigated as "Migrating from libabigail" contained no `abidiff`→`abicheck` mapping at all — it was an internal verdict-parity matrix leaking test symbols (`PARITY_CASES`, `_DIVERGE`).
- The order of operations for CI gating (policy → suppressions → severity → exit code) was never stated on any page, and the two exit-code regimes were documented in different places with no reconciling statement (the README even presented `1 = SEVERITY_ERROR` as a fixed row).

## Changes

- **`--depth` ladder**: corrected the table in `concepts/scan-and-evidence-levels.md` (adds `binary`, removes `graph`, documents how to reach the graph level via `--source-method s4`/`--mode pr-deep`); fixed the "cheap gate" worked example in `scan-levels.md` to pin `--depth binary` for the no-compiler case; fixed the same stale ladder in the `abi_estimate`/`abi_scan` docstrings (docstring-only code change).
- **Layer model**: landing-page bullet now teaches the five-source model; README, getting-started, choose-your-workflow, and tool-modes gained a one-line forward reference that `L5` is derived, never an input.
- **MCP docs**: full parameter/response documentation for `abi_audit`, `abi_estimate`, `abi_scan`; updated envelope table, architecture diagram, workflow examples; corrected timeout and file-size-cap scoping to match `mcp_server.py`.
- **libabigail migration**: `from-libabigail.md` rewritten as a real migration guide (command swap, bitmask→scalar exit-code translation, flag-by-flag map, `abidw`/`abipkgdiff` equivalents, INI→YAML suppression translation, intentional semantic differences); the parity matrix moved verbatim to `docs/development/libabigail-parity.md` with a new nav entry under Parity & Reports.
- **CI gating hub**: new `user-guide/ci-gating.md` (first entry of the CI & Gating nav section) with the pipeline diagram, order of operations, the two exit-code schemes + `--exit-code-scheme` pinning, pairwise knob interactions, and recipes; cross-linked from policies/suppressions/severity/baseline-management/getting-started; README and policies exit-code tables corrected and deferred to the canonical reference.
- CHANGELOG entries under `[Unreleased]`.

## Checklist

- [ ] Tests added / updated for new behaviour — N/A: docs-only (plus two docstring corrections); existing MCP tests pass (35 passed)
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed
- [x] `pre-commit run --all-files` passes locally — ran the equivalent gates: `mkdocs build --strict` clean, `python scripts/check_ai_readiness.py` 0 errors, `ruff check` clean, `mypy abicheck/` clean, fast unit suite 11915 passed (1 pre-existing environment failure in `test_build_query_inference.py`, also failing on the base commit)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaRKRA5DCvSgQhSswgczg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaRKRA5DCvSgQhSswgczg2)_