### PR TITLE
Improve source matching for template instantiations

### DIFF
--- a/abicheck/buildsource/source_abi.py
+++ b/abicheck/buildsource/source_abi.py
@@ -73,6 +73,12 @@ def _as_bool(raw: Any, default: bool) -> bool:
     return default
 
 
+def _string_dict(raw: Any) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}
+
+
 @dataclass
 class SourceLocation:
     """Where a source entity was declared, with provenance origin (ADR-030 D4)."""
@@ -114,6 +120,14 @@ class SourceEntity:
     body_hash: str = ""
     type_hash: str = ""
     value: str = ""
+    #: Stable/producer-specific identity names observed for this declaration.
+    #: Examples: source_qualified, mangled, usr, canonical_usr.
+    names: dict[str, str] = field(default_factory=dict)
+    #: Source-side semantic relationships, such as template pattern ownership.
+    relations: dict[str, str] = field(default_factory=dict)
+    #: Provenance/ownership hints observed at extraction time. Policy layers
+    #: decide how to classify these; producers only emit evidence.
+    ownership: dict[str, str] = field(default_factory=dict)
     source_location: SourceLocation | None = None
     #: public_header|private_header|system_header|generated|unknown
     visibility: str = "unknown"
@@ -168,6 +182,9 @@ class SourceEntity:
             "body_hash": self.body_hash,
             "type_hash": self.type_hash,
             "value": self.value,
+            "names": dict(self.names),
+            "relations": dict(self.relations),
+            "ownership": dict(self.ownership),
             "source_location": (
                 self.source_location.to_dict() if self.source_location else None
             ),
@@ -188,6 +205,9 @@ class SourceEntity:
             body_hash=str(d.get("body_hash", "")),
             type_hash=str(d.get("type_hash", "")),
             value=str(d.get("value", "")),
+            names=_string_dict(d.get("names")),
+            relations=_string_dict(d.get("relations")),
+            ownership=_string_dict(d.get("ownership")),
             source_location=SourceLocation.from_dict(loc)
             if isinstance(loc, dict)
             else None,
@@ -340,6 +360,9 @@ class SourceAbiSurface:
             "source_type_to_debug_type": {},
             "public_header_to_target": {},
             "synthesized_symbol_to_owner": {},
+            "template_instantiation_symbol_to_decl": {},
+            "allocator_interposer_symbol_to_owner": {},
+            "non_public_symbol_to_reason": {},
         }
     )
     odr_conflicts: list[dict[str, Any]] = field(default_factory=list)
@@ -380,6 +403,15 @@ class SourceAbiSurface:
                 "synthesized_symbol_to_owner": dict(
                     self.mappings.get("synthesized_symbol_to_owner", {})
                 ),
+                "template_instantiation_symbol_to_decl": dict(
+                    self.mappings.get("template_instantiation_symbol_to_decl", {})
+                ),
+                "allocator_interposer_symbol_to_owner": dict(
+                    self.mappings.get("allocator_interposer_symbol_to_owner", {})
+                ),
+                "non_public_symbol_to_reason": dict(
+                    self.mappings.get("non_public_symbol_to_reason", {})
+                ),
             },
             "odr_conflicts": list(self.odr_conflicts),
             "unmatched": {k: list(v) for k, v in self.unmatched.items()},
@@ -414,6 +446,15 @@ class SourceAbiSurface:
             ),
             "synthesized_symbol_to_owner": dict(
                 mappings_raw.get("synthesized_symbol_to_owner", {})
+            ),
+            "template_instantiation_symbol_to_decl": dict(
+                mappings_raw.get("template_instantiation_symbol_to_decl", {})
+            ),
+            "allocator_interposer_symbol_to_owner": dict(
+                mappings_raw.get("allocator_interposer_symbol_to_owner", {})
+            ),
+            "non_public_symbol_to_reason": dict(
+                mappings_raw.get("non_public_symbol_to_reason", {})
             ),
         }
         unmatched_raw = d.get("unmatched", {})

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -97,7 +97,7 @@ from .clang_public_roots import (  # noqa: F401
 
 #: clang extractor schema/behaviour version, recorded in the dump provenance and
 #: folded into the per-TU cache key (ADR-030 D8).
-CLANG_EXTRACTOR_VERSION = "0.3"
+CLANG_EXTRACTOR_VERSION = "0.5"
 
 #: AST node kinds clang emits for the entities we fingerprint. Includes the C++
 #: special members (constructor/destructor/conversion) so a change to a public
@@ -609,6 +609,45 @@ def _qualified(scope: list[str], name: str) -> str:
     return "::".join([*scope, name]) if scope else name
 
 
+def _entity_names(name: str, mangled: str = "") -> dict[str, str]:
+    names = {"source_qualified": name}
+    if mangled:
+        names["mangled"] = mangled
+    return names
+
+
+def _entity_ownership(visibility: str, origin: str) -> dict[str, str]:
+    role = {
+        "public_header": "own_api_candidate",
+        "generated": "generated_api_candidate",
+        "system_header": "dependency_candidate",
+        "private_header": "internal_candidate",
+    }.get(visibility, "unknown")
+    return {"visibility": visibility, "origin": origin, "role": role}
+
+
+def _template_param_name(node: dict[str, Any], position: int) -> str:
+    name = str(node.get("name") or "")
+    if name:
+        return name
+    kind = str(node.get("kind") or "")
+    return "N" + str(position) if kind == "NonTypeTemplateParmDecl" else "T" + str(position)
+
+
+def _template_params(node: dict[str, Any]) -> list[str]:
+    params: list[str] = []
+    for child in node.get("inner", []) or []:
+        if not isinstance(child, dict):
+            continue
+        if child.get("kind") in (
+            "TemplateTypeParmDecl",
+            "NonTypeTemplateParmDecl",
+            "TemplateTemplateParmDecl",
+        ):
+            params.append(_template_param_name(child, len(params)))
+    return params
+
+
 class _ClassifyContext:
     """Public-surface classification for clang file paths (ADR-024 / ADR-030)."""
 
@@ -792,6 +831,8 @@ def macros_from_preprocessor(
                 kind="macro",
                 qualified_name=name,
                 value=value,
+                names=_entity_names(name),
+                ownership=_entity_ownership(visibility, origin),
                 source_location=_location(file, 0, origin),
                 visibility=visibility,
                 api_relevant=True,
@@ -1073,6 +1114,8 @@ def _emit_function(
     tu: SourceAbiTu,
     scope: list[str],
     file: str,
+    *,
+    emit_inline_body: bool = True,
 ) -> None:
     visibility, origin, public = ctx.classify(file)
     if not public:
@@ -1081,6 +1124,10 @@ def _emit_function(
     sig = _signature(node)
     mangled = _mangled(node)
     loc = _location(file, _node_line(node), origin)
+    relations = {
+        str(k): str(v)
+        for k, v in dict(node.get("_abicheck_relations", {})).items()
+    }
     # A function entity always carries the signature + default-argument value so
     # default_argument_changed fires; a body present in a public header
     # additionally yields an inline-body fingerprint for inline_body_changed.
@@ -1092,6 +1139,9 @@ def _emit_function(
             mangled_name=mangled,
             signature_hash=_hash("sig", sig),
             value=_default_arg_repr(node),
+            names=_entity_names(name, mangled),
+            relations=relations,
+            ownership=_entity_ownership(visibility, origin),
             source_location=loc,
             visibility=visibility,
             api_relevant=True,
@@ -1104,7 +1154,7 @@ def _emit_function(
     # a header out-of-line definition. Fingerprint the body whenever one is
     # present, so an implicitly-inline method body change fires inline_body_changed
     # (Codex review #339, P2).
-    if _has_body(node):
+    if emit_inline_body and _has_body(node):
         body = next(
             c
             for c in node["inner"]
@@ -1117,6 +1167,9 @@ def _emit_function(
                 qualified_name=name,
                 mangled_name=mangled,
                 signature_hash=_hash("sig", sig),
+                names=_entity_names(name, mangled),
+                relations=relations,
+                ownership=_entity_ownership(visibility, origin),
                 # Alpha-rename the function's parameters together with the body so
                 # a parameter rename does not flip the fingerprint (ADR-030 #6).
                 body_hash=_subtree_hash(body, _param_ids(node)),
@@ -1139,18 +1192,83 @@ def _emit_template(
     if not public:
         return
     name = _qualified(scope, str(node.get("name", "")))
+    params = _template_params(node)
     tu.templates.append(
         SourceEntity(
             id=_hash("template", name),
             kind="template",
             qualified_name=name,
             body_hash=_subtree_hash(node),
+            names=_entity_names(name),
+            relations={
+                "template_kind": str(node.get("kind", "")),
+                "template_parameters": ",".join(params),
+            },
+            ownership=_entity_ownership(visibility, origin),
             source_location=_location(file, _node_line(node), origin),
             visibility=visibility,
             api_relevant=True,
             confidence=LayerConfidence.HIGH,
         )
     )
+    _emit_class_template_member_patterns(node, ctx, tu, scope, file)
+
+
+def _emit_class_template_member_patterns(
+    node: dict[str, Any],
+    ctx: _ClassifyContext,
+    tu: SourceAbiTu,
+    scope: list[str],
+    file: str,
+) -> None:
+    """Emit public member-function patterns from a class template declaration.
+
+    The template entity records the whole template body, but the source↔binary
+    linker also needs method-shaped declarations such as ``Box<T>::get`` to
+    attribute concrete instantiations like ``Box<int>::get()``. Without this
+    evidence the matcher must leave ordinary template methods unmatched.
+    """
+    if node.get("kind") != "ClassTemplateDecl":
+        return
+    name = str(node.get("name", "") or "")
+    params = _template_params(node)
+    owner = f"{name}<{','.join(params)}>" if params else name
+    record = next(
+        (
+            child
+            for child in node.get("inner", []) or []
+            if isinstance(child, dict) and child.get("kind") == "CXXRecordDecl"
+        ),
+        None,
+    )
+    if record is None:
+        return
+    owner_scope = [*scope, owner]
+    running_access = _default_member_access(record)
+    for child in record.get("inner", []) or []:
+        if not isinstance(child, dict):
+            continue
+        if child.get("kind") == "AccessSpecDecl":
+            running_access = child.get("access", running_access)
+            continue
+        child_access = child.get("access", running_access)
+        kind = child.get("kind")
+        name = str(child.get("name", "") or "")
+        if _is_function_node(kind, name, _is_accessible(child_access)):
+            child_file = _node_file(child, file)
+            child["_abicheck_relations"] = {
+                "template_owner": _qualified(scope, owner),
+                "template_parameters": ",".join(params),
+                "declaration_role": "class_template_member_pattern",
+            }
+            _emit_function(
+                child,
+                ctx,
+                tu,
+                owner_scope,
+                child_file,
+                emit_inline_body=False,
+            )
 
 
 def _emit_constexpr(
@@ -1166,13 +1284,16 @@ def _emit_constexpr(
     name = _qualified(scope, str(node.get("name", "")))
     init = _init_expr(node)
     value = _expr_value(init) if init is not None else _subtree_hash(node)
+    mangled = _mangled(node)
     tu.constexpr_values.append(
         SourceEntity(
             id=_hash("constexpr", name, value),
             kind="constexpr",
             qualified_name=name,
-            mangled_name=_mangled(node),
+            mangled_name=mangled,
             value=value,
+            names=_entity_names(name, mangled),
+            ownership=_entity_ownership(visibility, origin),
             source_location=_location(file, _node_line(node), origin),
             visibility=visibility,
             api_relevant=True,
@@ -1204,6 +1325,8 @@ def _emit_type(
             kind=kind,
             qualified_name=name,
             type_hash=_subtree_hash(node),
+            names=_entity_names(name),
+            ownership=_entity_ownership(visibility, origin),
             source_location=_location(file, _node_line(node), origin),
             visibility=visibility,
             api_relevant=True,
@@ -1255,6 +1378,8 @@ def _emit_typedef(
             qualified_name=name,
             type_hash=_hash("typedef-target", underlying),
             value=underlying,
+            names=_entity_names(name),
+            ownership=_entity_ownership(visibility, origin),
             source_location=_location(file, _node_line(node), origin),
             visibility=visibility,
             api_relevant=True,

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -341,6 +341,43 @@ _SYNTHESIZED_PREFIXES: tuple[tuple[str, str, str], ...] = (
     ("guard variable for ", "guard", "func"),
 )
 
+_TBB_MALLOC_PROXY_MARKER = "__TBB_malloc_proxy"
+_TBB_MALLOC_PROXY_C_SYMBOLS = frozenset(
+    {
+        "__libc_calloc",
+        "__libc_free",
+        "__libc_malloc",
+        "__libc_memalign",
+        "__libc_pvalloc",
+        "__libc_realloc",
+        "__libc_valloc",
+        "aligned_alloc",
+        "calloc",
+        "free",
+        "mallinfo",
+        "malloc",
+        "malloc_usable_size",
+        "mallopt",
+        "memalign",
+        "posix_memalign",
+        "pvalloc",
+        "realloc",
+        "valloc",
+    }
+)
+_TBB_MALLOC_PROXY_CPP_SYMBOLS = frozenset(
+    {
+        "_ZdaPv",
+        "_ZdaPvRKSt9nothrow_t",
+        "_ZdlPv",
+        "_ZdlPvRKSt9nothrow_t",
+        "_Znam",
+        "_ZnamRKSt9nothrow_t",
+        "_Znwm",
+        "_ZnwmRKSt9nothrow_t",
+    }
+)
+
 
 def _strip_call_signature(name: str) -> str:
     """Drop a demangled function's trailing parameter list, keeping its name.
@@ -441,6 +478,101 @@ def _synthesized_target(demangled: str) -> tuple[str, str, str] | None:
         if demangled.startswith(prefix):
             return kind, demangled[len(prefix) :].strip(), owner
     return None
+
+
+def _split_qualified_scope(name: str) -> tuple[str, str]:
+    """Split ``ns::Owner<T>::member`` at the last top-level ``::``.
+
+    Template arguments may contain their own qualified names, so a plain
+    ``rsplit("::", 1)`` can split inside ``Owner<std::vector<int>>``. This helper
+    tracks angle-bracket depth and only accepts scope separators at depth zero.
+    """
+    depth = 0
+    last = -1
+    i = 0
+    while i < len(name) - 1:
+        c = name[i]
+        if c == "<":
+            depth += 1
+        elif c == ">" and depth:
+            depth -= 1
+        elif c == ":" and name[i + 1] == ":" and depth == 0:
+            last = i
+            i += 1
+        i += 1
+    if last < 0:
+        return "", name
+    return name[:last], name[last + 2 :]
+
+
+def _drop_demangled_return_type(name: str) -> str:
+    """Remove a leading return type from a demangled qualified function name.
+
+    Demanglers spell free/template functions as ``Ret ns::f(...)`` but ctors and
+    most methods have no return prefix. The matcher needs the qualified name
+    only. A space before the first top-level ``::`` indicates such a prefix;
+    keeping the token after that space preserves names like ``ns::C::operator=``.
+    """
+    first_scope = name.find("::")
+    if first_scope <= 0:
+        return name
+    prefix_end = name.rfind(" ", 0, first_scope)
+    return name[prefix_end + 1 :] if prefix_end >= 0 else name
+
+
+def _template_source_owner_index(surface: SourceAbiSurface) -> dict[str, str]:
+    """Template-erased owner key -> stable source owner label.
+
+    Includes class/function template declarations from the template bucket and
+    declaration/type buckets. When both ``Box`` and ``Box<T>`` are present for one
+    erased key, prefer the bare template owner for readability; both describe the
+    same source pattern.
+    """
+    owners: dict[str, set[str]] = {}
+    for bucket in (
+        surface.reachable_declarations,
+        surface.reachable_templates,
+        surface.reachable_types,
+    ):
+        for entity in bucket:
+            if not entity.qualified_name:
+                continue
+            qname = _strip_call_signature(entity.qualified_name)
+            key = _template_pattern_key(qname)
+            if not key and entity.kind == "template":
+                key = f"{qname}<>"
+            if key:
+                owners.setdefault(key, set()).add(entity.qualified_name)
+    return {
+        key: sorted(values, key=lambda v: ("<" in v, len(v), v))[0]
+        for key, values in owners.items()
+    }
+
+
+def _template_special_member_owner_key(demangled: str) -> str:
+    """Return the erased class-template owner key for ctor/dtor/operator= exports.
+
+    A oneDAL source replay often records only a class template pattern
+    (``compute_input<Task>`` or ``compute_input``), while the binary exports
+    concrete special members (ctors/dtors/assignment) for
+    ``compute_input<task::compute>``. Unlike arbitrary methods such as
+    ``set_data()``, special members are unambiguously owned by the class template
+    itself, so they can be attributed when that owner pattern is present.
+    """
+    qname = _drop_demangled_return_type(_strip_call_signature(demangled))
+    owner, leaf = _split_qualified_scope(qname)
+    if not owner or "<" not in owner:
+        return ""
+    _, owner_leaf = _split_qualified_scope(owner)
+    class_base = owner_leaf.split("<", 1)[0]
+    leaf_base = leaf.split("<", 1)[0]
+    if (
+        leaf_base == class_base
+        or leaf_base == f"~{class_base}"
+        or leaf.startswith("operator=")
+    ):
+        return _template_pattern_key(owner)
+    return ""
 
 
 def _attribute_synthesized_exports(
@@ -584,6 +716,265 @@ def _demangled_rematch(
     return new_matches
 
 
+def _template_pattern_key(name: str) -> str:
+    """Return a template-argument-erased key for a demangled/source name.
+
+    ``ns::Box<T>::get`` and ``ns::Box<int>::get`` both become
+    ``ns::Box<>::get``. The key is deliberately conservative: only real balanced
+    ``<...>`` groups are erased, so ``operator<`` without a closing template list
+    is left alone. Whitespace is ignored because demanglers vary in how they
+    spell template argument separators.
+    """
+    s = "".join((name or "").split())
+    if "<" not in s or ">" not in s:
+        return ""
+    out: list[str] = []
+    depth = 0
+    saw_template = False
+    for i, c in enumerate(s):
+        if (
+            c == "<"
+            and depth == 0
+            and s[max(0, i - len("operator")) : i] == "operator"
+        ):
+            out.append(c)
+            continue
+        if c == "<":
+            if depth == 0:
+                out.append("<>")
+                saw_template = True
+            depth += 1
+            continue
+        if c == ">" and depth:
+            depth -= 1
+            continue
+        if depth == 0:
+            out.append(c)
+    return "".join(out) if saw_template and depth == 0 else ""
+
+
+def _template_instantiation_attribution(
+    surface: SourceAbiSurface,
+    reachable_declarations: list[SourceEntity],
+    matched: set[str],
+    exported: set[str],
+) -> dict[str, str]:
+    """Attribute concrete template-instantiation exports to one public pattern.
+
+    A Clang/CastXML source pass often records the public declaration as a template
+    pattern (``Box<T>::get`` or ``foo<T>``), while the binary exports concrete
+    instantiations (``Box<int>::get()`` / ``foo<double>(double)``). Exact mangled
+    matching cannot connect those strings. This tier demangles still-unmatched
+    exports, erases template arguments on both sides, and attributes an export
+    only when exactly one public declaration owns that erased pattern. Multiple
+    exports may map to the same unique pattern (many instantiations of one public
+    template); multiple source declarations for one pattern are skipped to avoid
+    hiding overloads.
+    """
+    candidates = [s for s in exported if s not in matched]
+    if not candidates:
+        return {}
+    try:
+        from ..demangle import demangle as _demangle
+    except Exception:  # pragma: no cover  # noqa: BLE001 - optional demangler
+        return {}
+
+    source_owners = _template_source_owner_index(surface)
+    decls_by_key: dict[str, list[SourceEntity]] = {}
+    for decl in reachable_declarations:
+        if not decl.qualified_name:
+            continue
+        key = _template_pattern_key(_strip_call_signature(decl.qualified_name))
+        if key:
+            decls_by_key.setdefault(key, []).append(decl)
+    unique_decl = {
+        key: decls[0]
+        for key, decls in decls_by_key.items()
+        if len({d.identity() for d in decls}) == 1
+    }
+    if not unique_decl and not source_owners:
+        return {}
+
+    attributed: dict[str, str] = {}
+    for sym in candidates:
+        try:
+            demangled = _demangle(_norm_itanium(sym))
+        except Exception:  # noqa: BLE001
+            continue
+        key = _template_pattern_key(_strip_call_signature(demangled or ""))
+        owner = unique_decl.get(key)
+        if owner is not None:
+            attributed[sym] = owner.qualified_name
+            continue
+        special_owner = source_owners.get(
+            _template_special_member_owner_key(demangled or "")
+        )
+        if special_owner is not None:
+            attributed[sym] = special_owner
+    return attributed
+
+
+def _attribute_allocator_interposer_exports(
+    exported: set[str], unmatched: set[str]
+) -> dict[str, str]:
+    """Attribute oneTBB malloc proxy interposer exports to their proxy marker.
+
+    ``libtbbmalloc_proxy`` intentionally exports allocator interposition entry
+    points such as ``malloc``, ``free``, global ``operator new/delete`` and
+    ``__libc_*`` hooks. These are not public-header declarations in the source
+    surface, so source linking used to report every proxy hook as an orphan. Only
+    enable this narrow classification when the library exports the explicit
+    ``__TBB_malloc_proxy`` marker, which keeps ordinary libraries from hiding
+    unrelated C/runtime symbols.
+    """
+    if _TBB_MALLOC_PROXY_MARKER not in exported:
+        return {}
+    attributed: dict[str, str] = {}
+    for sym in unmatched:
+        if (
+            sym == _TBB_MALLOC_PROXY_MARKER
+            or sym in _TBB_MALLOC_PROXY_C_SYMBOLS
+            or _norm_itanium(sym) in _TBB_MALLOC_PROXY_CPP_SYMBOLS
+        ):
+            attributed[sym] = _TBB_MALLOC_PROXY_MARKER
+    return attributed
+
+
+def _classify_non_public_exports(
+    unmatched: set[str], *, library: str = "", surface: SourceAbiSurface | None = None
+) -> dict[str, str]:
+    """Classify exported symbols that are not public-source declarations.
+
+    This is an accounting tier, not source matching: the symbol is still not
+    mapped to a public declaration. It separates dependency/internal/own exports
+    from genuinely unclassified gaps so real-world reports can reach "fully
+    accounted" coverage without pretending that stdlib/TBB/private implementation
+    symbols are part of the project's public source API.
+    """
+    if not unmatched:
+        return {}
+    library_l = library.lower()
+    source_roots = _source_namespace_roots(surface) if surface is not None else set()
+    classified: dict[str, str] = {}
+    for sym in sorted(unmatched):
+        demangled = _best_effort_demangle(sym)
+        if _is_stdlib_export(sym, demangled):
+            classified[sym] = "dependency:stdlib"
+        elif _is_tbb_export(sym, demangled) and "tbb" not in library_l:
+            classified[sym] = "dependency:tbb"
+        elif _is_internal_export(sym, demangled):
+            classified[sym] = "internal_or_private_export"
+        elif library and _belongs_to_source_namespace(demangled, source_roots):
+            classified[sym] = "own_export_without_public_source_decl"
+        elif library and source_roots and _is_cpp_export_without_public_decl(demangled):
+            classified[sym] = "cpp_export_without_public_source_decl"
+        elif library and source_roots and _is_c_export_without_public_decl(sym):
+            classified[sym] = "c_export_without_public_source_decl"
+    return classified
+
+
+def _best_effort_demangle(sym: str) -> str:
+    if not _looks_like_cpp_export(sym):
+        return ""
+    try:
+        from ..demangle import demangle as _demangle
+
+        return _demangle(_norm_itanium(sym)) or ""
+    except Exception:  # noqa: BLE001 - classification is best-effort
+        return ""
+
+
+def _looks_like_cpp_export(sym: str) -> bool:
+    return sym.startswith("_Z") or sym.startswith("__Z")
+
+
+def _looks_like_c_export(sym: str) -> bool:
+    return bool(sym) and not _looks_like_cpp_export(sym)
+
+
+def _is_stdlib_export(sym: str, demangled: str) -> bool:
+    return (
+        demangled.startswith("std::")
+        or demangled.startswith("__gnu_cxx::")
+        or sym.startswith(
+            (
+                "_ZSt",
+                "_ZNSt",
+                "_ZNKSt",
+                "_ZTVSt",
+                "_ZTISt",
+                "_ZTSSt",
+                "_ZN9__gnu_cxx",
+                "_ZNK9__gnu_cxx",
+                "_ZTVN9__gnu_cxx",
+                "_ZTIN9__gnu_cxx",
+                "_ZTSN9__gnu_cxx",
+            )
+        )
+    )
+
+
+def _is_tbb_export(sym: str, demangled: str) -> bool:
+    return demangled.startswith("tbb::") or sym.startswith(
+        ("_ZN3tbb", "_ZTVN3tbb", "_ZTIN3tbb", "_ZTSN3tbb")
+    )
+
+
+def _is_internal_export(sym: str, demangled: str) -> bool:
+    if sym.startswith(("_", "__")) and not _looks_like_cpp_export(sym):
+        return True
+    if not demangled:
+        return False
+    qualified = _strip_call_signature(demangled)
+    leaf = qualified.rsplit("::", 1)[-1]
+    return (
+        "::detail::" in qualified
+        or "::internal::" in qualified
+        or leaf.endswith("_impl")
+        or leaf.startswith("_daal_")
+        or leaf.startswith("_")
+    )
+
+
+def _is_cpp_export_without_public_decl(demangled: str) -> bool:
+    """Best-effort bucket for C++ exports with no public source declaration.
+
+    This is only used when the linked surface has project namespace evidence and a
+    concrete library name. It keeps accidental/private C++ exports visible as a
+    separate reason without pretending they matched a public declaration.
+    """
+    if not demangled:
+        return False
+    qualified = _strip_call_signature(demangled)
+    return bool(qualified)
+
+
+def _is_c_export_without_public_decl(sym: str) -> bool:
+    """Best-effort bucket for C exports with no public source declaration."""
+    return _looks_like_c_export(sym) and bool(sym)
+
+
+def _source_namespace_roots(surface: SourceAbiSurface | None) -> set[str]:
+    if surface is None:
+        return set()
+    roots: set[str] = set()
+    for bucket in surface.reachable_buckets().values():
+        for entity in bucket:
+            name = entity.qualified_name
+            if not name or "::" not in name:
+                continue
+            root = name.split("::", 1)[0]
+            if root not in {"std", "__gnu_cxx"}:
+                roots.add(root)
+    return roots
+
+
+def _belongs_to_source_namespace(demangled: str, roots: set[str]) -> bool:
+    if not demangled or "::" not in demangled or not roots:
+        return False
+    return demangled.split("::", 1)[0] in roots
+
+
 #: Entity kinds routed to each reachable bucket of the linked surface (D5).
 _TYPE_KINDS = frozenset({"record", "enum", "typedef", "union"})
 _MACRO_KINDS = frozenset({"macro"})
@@ -671,7 +1062,43 @@ def link_source_abi(
             sym: {"kind": kind, "owner": owner}
             for sym, (kind, owner) in sorted(synthesized.items())
         }
-    all_matched = decl_matched | set(synthesized)
+    template_instantiations = _template_instantiation_attribution(
+        surface,
+        surface.reachable_declarations,
+        decl_matched | set(synthesized),
+        exported,
+    )
+    if template_instantiations:
+        surface.mappings["template_instantiation_symbol_to_decl"] = dict(
+            sorted(template_instantiations.items())
+        )
+    allocator_interposers = _attribute_allocator_interposer_exports(
+        exported, exported - decl_matched - set(synthesized) - set(template_instantiations)
+    )
+    if allocator_interposers:
+        surface.mappings["allocator_interposer_symbol_to_owner"] = dict(
+            sorted(allocator_interposers.items())
+        )
+    non_public = _classify_non_public_exports(
+        exported
+        - decl_matched
+        - set(synthesized)
+        - set(template_instantiations)
+        - set(allocator_interposers),
+        library=library,
+        surface=surface,
+    )
+    if non_public:
+        surface.mappings["non_public_symbol_to_reason"] = dict(
+            sorted(non_public.items())
+        )
+    all_matched = (
+        decl_matched
+        | set(synthesized)
+        | set(template_instantiations)
+        | set(allocator_interposers)
+        | set(non_public)
+    )
 
     surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)
     surface.unmatched["decls_without_symbol"] = sorted(
@@ -690,6 +1117,9 @@ def link_source_abi(
         # synthesized (RTTI/vtable/thunk) attributions vs the genuine remainder.
         "matched_symbols": len(decl_matched),
         "synthesized_symbols_matched": len(synthesized),
+        "template_instantiation_symbols_matched": len(template_instantiations),
+        "allocator_interposer_symbols_matched": len(allocator_interposers),
+        "non_public_symbols_classified": len(non_public),
         "unmatched_symbols": len(exported) - len(all_matched),
         "odr_conflicts": len(state.odr_conflicts),
     }
@@ -753,7 +1183,35 @@ def relink_surface_exports(
         sym: {"kind": kind, "owner": owner}
         for sym, (kind, owner) in sorted(synthesized.items())
     }
-    all_matched = matched | set(synthesized)
+    template_instantiations = _template_instantiation_attribution(
+        surface,
+        surface.reachable_declarations,
+        matched | set(synthesized),
+        exported,
+    )
+    surface.mappings["template_instantiation_symbol_to_decl"] = dict(
+        sorted(template_instantiations.items())
+    )
+    allocator_interposers = _attribute_allocator_interposer_exports(
+        exported, exported - matched - set(synthesized) - set(template_instantiations)
+    )
+    surface.mappings["allocator_interposer_symbol_to_owner"] = dict(
+        sorted(allocator_interposers.items())
+    )
+    non_public = _classify_non_public_exports(
+        exported
+        - matched
+        - set(synthesized)
+        - set(template_instantiations)
+        - set(allocator_interposers),
+        library=surface.library,
+        surface=surface,
+    )
+    surface.mappings["non_public_symbol_to_reason"] = dict(sorted(non_public.items()))
+    all_matched = (
+        matched | set(synthesized) | set(template_instantiations) | set(allocator_interposers)
+        | set(non_public)
+    )
 
     surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)
     # Recompute decls_without_symbol from the new mapping: declarations that now
@@ -767,6 +1225,13 @@ def relink_surface_exports(
         surface.coverage["exported_symbols"] = len(exported)
         surface.coverage["matched_symbols"] = len(matched)
         surface.coverage["synthesized_symbols_matched"] = len(synthesized)
+        surface.coverage["template_instantiation_symbols_matched"] = len(
+            template_instantiations
+        )
+        surface.coverage["allocator_interposer_symbols_matched"] = len(
+            allocator_interposers
+        )
+        surface.coverage["non_public_symbols_classified"] = len(non_public)
         surface.coverage["unmatched_symbols"] = len(exported) - len(all_matched)
     return surface
 

--- a/abicheck/demangle.py
+++ b/abicheck/demangle.py
@@ -53,17 +53,20 @@ def demangle(symbol: str) -> str | None:
         return str(cxxfilt.demangle(symbol))
     except Exception:  # noqa: BLE001
         _log.debug("cxxfilt demangling failed for %s", symbol)
-    try:
-        result = subprocess.run(
-            ["c++filt", symbol],
-            capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            out = result.stdout.strip()
-            if out and out != symbol:
-                return out
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
+    for cmd in _cppfilt_single_commands(symbol):
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                out = result.stdout.strip()
+                if out and out != symbol:
+                    return out
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
 
     global _warned_no_demangler  # noqa: PLW0603
     if not _warned_no_demangler:
@@ -132,32 +135,48 @@ def _batch_phase2_cxxfilt(uncached: list[str], result: dict[str, str]) -> list[s
     return remaining
 
 
+def _cppfilt_single_commands(symbol: str) -> tuple[list[str], ...]:
+    return (["c++filt", symbol], ["c++filt", "--no-strip-underscore", symbol])
+
+
+def _cppfilt_batch_commands() -> tuple[list[str], ...]:
+    return (["c++filt"], ["c++filt", "--no-strip-underscore"])
+
+
 def _batch_phase3_cppfilt(remaining: list[str], result: dict[str, str]) -> None:
     """Fall back to a single batched ``c++filt`` subprocess call."""
-    success_set: set[str] = set()
-    cppfilt_succeeded = False
-    try:
-        proc = subprocess.run(
-            ["c++filt"],
-            input="\n".join(remaining),
-            capture_output=True, text=True, timeout=30,
-        )
-        if proc.returncode == 0:
-            cppfilt_succeeded = True
+    unresolved = list(remaining)
+    any_cppfilt_succeeded = False
+    for cmd in _cppfilt_batch_commands():
+        if not unresolved:
+            break
+        success_set: set[str] = set()
+        try:
+            proc = subprocess.run(
+                cmd,
+                input="\n".join(unresolved),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if proc.returncode != 0:
+                continue
+            any_cppfilt_succeeded = True
             lines = proc.stdout.strip().split("\n")
-            for mangled, demangled in zip(remaining, lines):
+            for mangled, demangled in zip(unresolved, lines):
                 if demangled and demangled != mangled:
                     result[mangled] = demangled
                     _batch_cache_record_ok(mangled, demangled)
                     success_set.add(mangled)
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        pass
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+        unresolved = [s for s in unresolved if s not in success_set]
     # Only cache permanent FAILs when c++filt actually ran to completion
     # (returncode 0). If the binary is missing, timed out, raised OSError,
     # or returned non-zero, leave the symbols un-cached so a future call
     # (e.g. after c++filt becomes available) can retry them.
-    if cppfilt_succeeded:
-        for s in remaining:
+    if any_cppfilt_succeeded:
+        for s in unresolved:
             if s not in success_set:
                 _batch_cache_record_fail(s)
 

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -53,6 +53,7 @@
 #include "clang/Basic/TargetOptions.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Index/USRGeneration.h"
 #include "clang/Lex/HeaderSearchOptions.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -94,7 +95,7 @@ namespace {
 
 // Producer id, recorded in the manifest's `created_by` and the TU `extractor`
 // field. Bump on any change to the emitted-record recipe.
-constexpr const char *kPluginVersion = "0.2";
+constexpr const char *kPluginVersion = "0.4";
 
 // ---------------------------------------------------------------------------
 // Hashing — mirrors clang.py::_hash exactly:
@@ -186,6 +187,19 @@ std::string jsonRawArray(const std::vector<std::string> &items) {
     out += items[i];
   }
   out += "]";
+  return out;
+}
+
+std::string jsonStrMap(const std::map<std::string, std::string> &items) {
+  std::string out = "{";
+  bool first = true;
+  for (const auto &kv : items) {
+    if (!first)
+      out += ",";
+    first = false;
+    out += jsonStr(kv.first) + ":" + jsonStr(kv.second);
+  }
+  out += "}";
   return out;
 }
 
@@ -676,6 +690,9 @@ struct Entity {
   std::string body_hash;
   std::string type_hash;
   std::string value;
+  std::map<std::string, std::string> names;
+  std::map<std::string, std::string> relations;
+  std::map<std::string, std::string> ownership;
   std::string loc_path;
   int loc_line = 0;
   std::string loc_origin = "UNKNOWN";
@@ -692,12 +709,52 @@ struct Entity {
            ",\"signature_hash\":" + jsonStr(signature_hash) +
            ",\"body_hash\":" + jsonStr(body_hash) +
            ",\"type_hash\":" + jsonStr(type_hash) +
-           ",\"value\":" + jsonStr(value) + ",\"source_location\":" + loc +
+           ",\"value\":" + jsonStr(value) +
+           ",\"names\":" + jsonStrMap(names) +
+           ",\"relations\":" + jsonStrMap(relations) +
+           ",\"ownership\":" + jsonStrMap(ownership) +
+           ",\"source_location\":" + loc +
            ",\"visibility\":" + jsonStr(visibility) +
            ",\"api_relevant\":" + (api_relevant ? "true" : "false") +
            ",\"confidence\":\"high\"}";
   }
 };
+
+std::string usrForDecl(const Decl *d) {
+  if (!d)
+    return "";
+  llvm::SmallString<128> usr;
+  if (clang::index::generateUSRForDecl(d, usr))
+    return "";
+  return std::string(usr.str());
+}
+
+std::string ownershipRole(llvm::StringRef visibility) {
+  if (visibility == "public_header")
+    return "own_api_candidate";
+  if (visibility == "generated")
+    return "generated_api_candidate";
+  if (visibility == "system_header")
+    return "dependency_candidate";
+  if (visibility == "private_header")
+    return "internal_candidate";
+  return "unknown";
+}
+
+void stampDeclEvidence(Entity &e, const NamedDecl *d) {
+  e.names["source_qualified"] = e.qualified_name;
+  if (!e.mangled_name.empty())
+    e.names["mangled"] = e.mangled_name;
+  std::string usr = usrForDecl(d);
+  if (!usr.empty())
+    e.names["usr"] = usr;
+  std::string canonical = usrForDecl(d ? d->getCanonicalDecl() : nullptr);
+  if (!canonical.empty())
+    e.names["canonical_usr"] = canonical;
+  e.ownership["visibility"] = e.visibility;
+  e.ownership["origin"] = e.loc_origin;
+  e.ownership["role"] = ownershipRole(e.visibility);
+}
 
 // ---------------------------------------------------------------------------
 // Path helpers for public-surface classification (ADR-038 C.2 visibility).
@@ -963,6 +1020,23 @@ std::string joinStrings(const std::vector<std::string> &v, char sep) {
   return out;
 }
 
+std::string templateParamName(const NamedDecl *param, unsigned index) {
+  if (!param->getName().empty())
+    return param->getNameAsString();
+  if (isa<NonTypeTemplateParmDecl>(param))
+    return "N" + std::to_string(index);
+  return "T" + std::to_string(index);
+}
+
+std::vector<std::string> templateParamNames(const TemplateParameterList *params) {
+  std::vector<std::string> out;
+  if (!params)
+    return out;
+  for (unsigned i = 0; i < params->size(); ++i)
+    out.push_back(templateParamName(params->getParam(i), i));
+  return out;
+}
+
 std::string nowIso8601Utc() {
   std::time_t t = std::time(nullptr);
   std::tm tm{};
@@ -1126,6 +1200,7 @@ public:
     e.loc_line = line;
     e.loc_origin = origin;
     e.visibility = visibility;
+    stampDeclEvidence(e, fd);
     Functions.push_back(e);
 
     // Gate the whole inline entity on a CompoundStmt being present in the
@@ -1147,6 +1222,7 @@ public:
       ib.loc_line = line;
       ib.loc_origin = origin;
       ib.visibility = visibility;
+      stampDeclEvidence(ib, fd);
       InlineBodies.push_back(ib);
     }
     return true;
@@ -1212,6 +1288,7 @@ public:
     e.loc_line = presumedLine(td);
     e.loc_origin = origin;
     e.visibility = visibility;
+    stampDeclEvidence(e, td);
     Types.push_back(e);
     return true;
   }
@@ -1251,6 +1328,7 @@ public:
     e.loc_line = presumedLine(vd);
     e.loc_origin = origin;
     e.visibility = visibility;
+    stampDeclEvidence(e, vd);
     ConstexprValues.push_back(e);
     return true;
   }
@@ -1266,6 +1344,7 @@ public:
 
   bool TraverseClassTemplateDecl(ClassTemplateDecl *td) {
     emitTemplate(td);
+    emitClassTemplateMemberPatterns(td);
     return true;
   }
 
@@ -1437,6 +1516,7 @@ private:
     e.loc_line = presumedLine(td);
     e.loc_origin = origin;
     e.visibility = visibility;
+    stampDeclEvidence(e, td);
     Types.push_back(e);
   }
 
@@ -1459,7 +1539,62 @@ private:
     e.loc_line = presumedLine(td);
     e.loc_origin = origin;
     e.visibility = visibility;
+    e.relations["template_kind"] = std::string(td->getDeclKindName());
+    if (const TemplateParameterList *params = td->getTemplateParameters())
+      e.relations["template_parameters"] =
+          joinStrings(templateParamNames(params), ',');
+    stampDeclEvidence(e, td);
     Templates.push_back(e);
+  }
+
+  std::string classTemplatePatternName(const ClassTemplateDecl *td) const {
+    std::string name = scopedName(td);
+    std::vector<std::string> params = templateParamNames(td->getTemplateParameters());
+    if (!params.empty())
+      name += "<" + joinStrings(params, ',') + ">";
+    return name;
+  }
+
+  void emitClassTemplateMemberPatterns(const ClassTemplateDecl *td) {
+    if (td->isImplicit() || !isAccessible(td) || td->getNameAsString().empty())
+      return;
+    CXXRecordDecl *rd = td->getTemplatedDecl();
+    if (!rd)
+      return;
+    std::string owner = classTemplatePatternName(td);
+    for (Decl *member : rd->decls()) {
+      auto *fd = dyn_cast<FunctionDecl>(member);
+      if (!fd || fd->isImplicit() || fd->getNameAsString().empty() ||
+          !isAccessible(fd))
+        continue;
+      std::string file, origin, visibility;
+      if (!classify(fd, file, origin, visibility))
+        continue;
+      std::optional<Value> json = dumpDeclJson(fd);
+      if (!json || !json->getAsObject()) {
+        Diags.insert("class-template member facts unavailable (JSON dump failed)");
+        continue;
+      }
+      const Object &o = *json->getAsObject();
+      std::string sig = qualTypeFromJson(o);
+      std::string name = owner + "::" + fd->getNameAsString();
+      Entity e;
+      e.id = H({"function", name, sig});
+      e.kind = "function";
+      e.qualified_name = name;
+      e.signature_hash = H({"sig", sig});
+      e.value = defaultArgReprJson(o);
+      e.loc_path = file;
+      e.loc_line = presumedLine(fd);
+      e.loc_origin = origin;
+      e.visibility = visibility;
+      e.relations["template_owner"] = owner;
+      e.relations["template_parameters"] =
+          joinStrings(templateParamNames(td->getTemplateParameters()), ',');
+      e.relations["declaration_role"] = "class_template_member_pattern";
+      stampDeclEvidence(e, fd);
+      Functions.push_back(e);
+    }
   }
 
   SourceManager &SM;
@@ -1642,6 +1777,10 @@ private:
       m.loc_line = 0;
       m.loc_origin = origin;
       m.visibility = visibility;
+      m.names["source_qualified"] = name;
+      m.ownership["visibility"] = visibility;
+      m.ownership["origin"] = origin;
+      m.ownership["role"] = ownershipRole(visibility);
       out.push_back(m);
       any = true;
     }

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -55,7 +55,13 @@ Implemented and matching `clang.py`, validated by the C.6 CI matrix:
 - **inline bodies** — `body_hash` = subtree hash of the `CompoundStmt`;
 - **records / enums** — `type_hash` = subtree hash (definitions only);
 - **function / class templates** — `body_hash` = subtree hash of the whole
-  template node (members of a class template are *not* re-emitted — no descent);
+  template node; public class-template member methods are also emitted as
+  declaration patterns such as `Box<T>::get`, so concrete binary instantiations
+  can link back to source evidence without guessing;
+- **identity/provenance evidence** — entities carry additive `names`,
+  `relations`, and `ownership` dictionaries; the plugin fills Clang USR /
+  canonical USR when available, and both producer paths stamp template-owner and
+  public-root ownership hints for later policy/matching layers;
 - **typedefs / type-aliases** — `type_hash = _hash("typedef-target",
   underlying)`, `value = underlying`;
 - **constexpr variables** — literal *and* computed initializers (a computed

--- a/contrib/abicheck-clang-plugin/tests/fixtures/include/widget.hpp
+++ b/contrib/abicheck-clang-plugin/tests/fixtures/include/widget.hpp
@@ -65,7 +65,7 @@ using Ptr = T *;                            // alias template -> typedef `Ptr`
 template <class T>
 struct Box {                                 // class template -> body hash
   T value;
-  T get() const { return value; }            // NOT emitted (no descent)
+  T get() const { return value; }            // member pattern -> Box<T>::get
 };
 
 class Widget {

--- a/docs/development/adr/030-source-abi-replay-and-linked-source-surface.md
+++ b/docs/development/adr/030-source-abi-replay-and-linked-source-surface.md
@@ -141,6 +141,9 @@ Entity fields:
   "signature_hash": "sha256:...",
   "body_hash": "sha256:...",
   "type_hash": "sha256:...",
+  "names": {"source_qualified": "foo::Bar::baz", "mangled": "_ZN3foo3Bar3bazEv", "usr": "c:..."},
+  "relations": {"template_owner": "foo::Bar<T>", "declaration_role": "class_template_member_pattern"},
+  "ownership": {"visibility": "public_header", "origin": "PUBLIC_HEADER", "role": "own_api_candidate"},
   "source_location": {"path": "include/foo/bar.h", "line": 42, "origin": "PUBLIC_HEADER"},
   "visibility": "public_header|private_header|system_header|generated|unknown",
   "api_relevant": true,
@@ -184,13 +187,52 @@ Output:
   "mappings": {
     "source_decl_to_binary_symbol": [],
     "source_type_to_debug_type": [],
-    "public_header_to_target": []
+    "public_header_to_target": [],
+    "non_public_symbol_to_reason": []
   },
   "odr_conflicts": [],
   "unmatched": [],
   "coverage": {}
 }
 ```
+
+#### Dependency-owned exports are not own-API matches
+
+The source linker must keep three ownership buckets distinct:
+
+- **own public API**: an export backed by a declaration in this library's public
+  source surface;
+- **dependency export**: an exported symbol whose implementation/source owner is
+  a dependency namespace or provider (for example a bundled TBB internal symbol
+  emitted by a oneDAL support library);
+- **internal export**: an exported symbol from the project itself that is not
+  backed by public-header evidence.
+
+Do not "fix" dependency noise by matching it to a nearby own declaration. That
+would hide real compatibility hazards: a dependency can still break consumers if
+the library exports it, documents it, or lets consumers bind to it. The correct
+model is an explicit ownership axis. The policy choices are:
+
+- **strict surface**: dependency exports remain reported as exported-but-not-own
+  API and are compatibility-significant if they change;
+- **scoped dependency**: dependency exports are grouped under a provider
+  (`dependency_symbol_to_provider`) and reported separately from own API, but
+  additions/removals still appear in the binary diff;
+- **bundle/manifest contract**: for co-versioned bundles, a manifest or bundle
+  resolution graph decides which dependency symbols are promised externally and
+  which are private implementation details.
+
+The first production-safe step is to emit better source evidence for own API
+(for example class-template member patterns) so the remaining unmatched set is
+clean enough to classify by ownership. Provider attribution without an explicit
+rule or manifest must be narrow and visible in coverage, not a silent match.
+
+The linked surface therefore has an accounting-only mapping,
+`non_public_symbol_to_reason`. Symbols in this bucket count as accounted exports
+but not as public declaration matches. Reasons are intentionally explicit, such
+as `dependency:stdlib`, `dependency:tbb`, `internal_or_private_export`,
+`own_export_without_public_source_decl`, or
+`cpp_export_without_public_source_decl`.
 
 ### D6. Source replay findings
 

--- a/examples/case149_xcheck_odr_variant/snapshot.abi.json
+++ b/examples/case149_xcheck_odr_variant/snapshot.abi.json
@@ -20,10 +20,13 @@
       "coverage": {},
       "library": "",
       "mappings": {
+        "allocator_interposer_symbol_to_owner": {},
+        "non_public_symbol_to_reason": {},
         "public_header_to_target": {},
         "source_decl_to_binary_symbol": {},
         "source_type_to_debug_type": {},
-        "synthesized_symbol_to_owner": {}
+        "synthesized_symbol_to_owner": {},
+        "template_instantiation_symbol_to_decl": {}
       },
       "odr_conflicts": [
         {

--- a/examples/case156_public_macro_removed/new.json
+++ b/examples/case156_public_macro_removed/new.json
@@ -2,10 +2,13 @@
   "coverage": {},
   "library": "libdemo.so",
   "mappings": {
+    "allocator_interposer_symbol_to_owner": {},
+    "non_public_symbol_to_reason": {},
     "public_header_to_target": {},
     "source_decl_to_binary_symbol": {},
     "source_type_to_debug_type": {},
-    "synthesized_symbol_to_owner": {}
+    "synthesized_symbol_to_owner": {},
+    "template_instantiation_symbol_to_decl": {}
   },
   "odr_conflicts": [],
   "reachable_source_surface": {
@@ -17,7 +20,10 @@
         "id": "demo::keep",
         "kind": "function",
         "mangled_name": "_ZN4demo4keepEv",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::keep",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 3,

--- a/examples/case156_public_macro_removed/old.json
+++ b/examples/case156_public_macro_removed/old.json
@@ -2,10 +2,13 @@
   "coverage": {},
   "library": "libdemo.so",
   "mappings": {
+    "allocator_interposer_symbol_to_owner": {},
+    "non_public_symbol_to_reason": {},
     "public_header_to_target": {},
     "source_decl_to_binary_symbol": {},
     "source_type_to_debug_type": {},
-    "synthesized_symbol_to_owner": {}
+    "synthesized_symbol_to_owner": {},
+    "template_instantiation_symbol_to_decl": {}
   },
   "odr_conflicts": [],
   "reachable_source_surface": {
@@ -17,7 +20,10 @@
         "id": "demo::keep",
         "kind": "function",
         "mangled_name": "_ZN4demo4keepEv",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::keep",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 3,
@@ -38,7 +44,10 @@
         "id": "DEMO_MAX_ITEMS",
         "kind": "macro",
         "mangled_name": "",
+        "names": {},
+        "ownership": {},
         "qualified_name": "DEMO_MAX_ITEMS",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 12,

--- a/examples/case157_inline_function_removed/new.json
+++ b/examples/case157_inline_function_removed/new.json
@@ -2,10 +2,13 @@
   "coverage": {},
   "library": "libdemo.so",
   "mappings": {
+    "allocator_interposer_symbol_to_owner": {},
+    "non_public_symbol_to_reason": {},
     "public_header_to_target": {},
     "source_decl_to_binary_symbol": {},
     "source_type_to_debug_type": {},
-    "synthesized_symbol_to_owner": {}
+    "synthesized_symbol_to_owner": {},
+    "template_instantiation_symbol_to_decl": {}
   },
   "odr_conflicts": [],
   "reachable_source_surface": {
@@ -17,7 +20,10 @@
         "id": "demo::keep",
         "kind": "function",
         "mangled_name": "_ZN4demo4keepEv",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::keep",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 3,

--- a/examples/case157_inline_function_removed/old.json
+++ b/examples/case157_inline_function_removed/old.json
@@ -2,10 +2,13 @@
   "coverage": {},
   "library": "libdemo.so",
   "mappings": {
+    "allocator_interposer_symbol_to_owner": {},
+    "non_public_symbol_to_reason": {},
     "public_header_to_target": {},
     "source_decl_to_binary_symbol": {},
     "source_type_to_debug_type": {},
-    "synthesized_symbol_to_owner": {}
+    "synthesized_symbol_to_owner": {},
+    "template_instantiation_symbol_to_decl": {}
   },
   "odr_conflicts": [],
   "reachable_source_surface": {
@@ -17,7 +20,10 @@
         "id": "demo::keep",
         "kind": "function",
         "mangled_name": "_ZN4demo4keepEv",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::keep",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 3,
@@ -37,7 +43,10 @@
         "id": "demo::clamp",
         "kind": "inline",
         "mangled_name": "",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::clamp",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 20,

--- a/examples/case158_public_typedef_removed/new.json
+++ b/examples/case158_public_typedef_removed/new.json
@@ -2,10 +2,13 @@
   "coverage": {},
   "library": "libdemo.so",
   "mappings": {
+    "allocator_interposer_symbol_to_owner": {},
+    "non_public_symbol_to_reason": {},
     "public_header_to_target": {},
     "source_decl_to_binary_symbol": {},
     "source_type_to_debug_type": {},
-    "synthesized_symbol_to_owner": {}
+    "synthesized_symbol_to_owner": {},
+    "template_instantiation_symbol_to_decl": {}
   },
   "odr_conflicts": [],
   "reachable_source_surface": {
@@ -17,7 +20,10 @@
         "id": "demo::keep",
         "kind": "function",
         "mangled_name": "_ZN4demo4keepEv",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::keep",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 3,

--- a/examples/case158_public_typedef_removed/old.json
+++ b/examples/case158_public_typedef_removed/old.json
@@ -2,10 +2,13 @@
   "coverage": {},
   "library": "libdemo.so",
   "mappings": {
+    "allocator_interposer_symbol_to_owner": {},
+    "non_public_symbol_to_reason": {},
     "public_header_to_target": {},
     "source_decl_to_binary_symbol": {},
     "source_type_to_debug_type": {},
-    "synthesized_symbol_to_owner": {}
+    "synthesized_symbol_to_owner": {},
+    "template_instantiation_symbol_to_decl": {}
   },
   "odr_conflicts": [],
   "reachable_source_surface": {
@@ -17,7 +20,10 @@
         "id": "demo::keep",
         "kind": "function",
         "mangled_name": "_ZN4demo4keepEv",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::keep",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 3,
@@ -40,7 +46,10 @@
         "id": "demo::handle_t",
         "kind": "typedef",
         "mangled_name": "",
+        "names": {},
+        "ownership": {},
         "qualified_name": "demo::handle_t",
+        "relations": {},
         "signature_hash": "",
         "source_location": {
           "line": 8,

--- a/tests/test_demangle_unit.py
+++ b/tests/test_demangle_unit.py
@@ -86,6 +86,29 @@ class TestDemangle:
                 result = _mod.demangle("_ZN3foo3barEv")
         assert result is None
 
+    def test_cppfilt_no_strip_underscore_fallback(self):
+        """Darwin c++filt may strip the leading underscore unless told not to."""
+        mock_cxxfilt = MagicMock()
+        mock_cxxfilt.demangle.side_effect = RuntimeError("no")
+        with patch.dict("sys.modules", {"cxxfilt": mock_cxxfilt}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.side_effect = [
+                    subprocess.CompletedProcess(
+                        args=["c++filt"],
+                        returncode=0,
+                        stdout="_ZN3foo3barEv\n",
+                        stderr="",
+                    ),
+                    subprocess.CompletedProcess(
+                        args=["c++filt", "--no-strip-underscore"],
+                        returncode=0,
+                        stdout="foo::bar()\n",
+                        stderr="",
+                    ),
+                ]
+                result = _mod.demangle("_ZN3foo3barEv")
+        assert result == "foo::bar()"
+
     def test_cppfilt_empty_output(self):
         """If c++filt returns empty stdout, treat as failed."""
         mock_cxxfilt = MagicMock()
@@ -216,6 +239,27 @@ class TestDemangleBatch:
                 )
                 result = _mod.demangle_batch(["_ZN3foo3barEv"])
         assert result == {}
+
+    def test_cppfilt_batch_no_strip_underscore_fallback(self):
+        """Batch demangling also retries with --no-strip-underscore for Darwin."""
+        with patch.dict("sys.modules", {"cxxfilt": None}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.side_effect = [
+                    subprocess.CompletedProcess(
+                        args=["c++filt"],
+                        returncode=0,
+                        stdout="_ZN3foo3barEv\n",
+                        stderr="",
+                    ),
+                    subprocess.CompletedProcess(
+                        args=["c++filt", "--no-strip-underscore"],
+                        returncode=0,
+                        stdout="foo::bar()\n",
+                        stderr="",
+                    ),
+                ]
+                result = _mod.demangle_batch(["_ZN3foo3barEv"])
+        assert result == {"_ZN3foo3barEv": "foo::bar()"}
 
     def test_cxxfilt_returns_same_as_input(self):
         """When cxxfilt.demangle returns the same string, push to remaining."""

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -105,7 +105,25 @@ def test_source_abi_tu_roundtrip() -> None:
         source="src/foo.cpp",
         public_header_roots=["include/foo.h"],
         macros=[_entity("FOO_SIZE", "macro", value="16")],
-        functions=[_entity("foo::bar", "function", mangled="_ZN3foo3barEv")],
+        functions=[
+            SourceEntity(
+                id="decl://foo::bar",
+                kind="function",
+                qualified_name="foo::bar",
+                mangled_name="_ZN3foo3barEv",
+                names={
+                    "source_qualified": "foo::bar",
+                    "mangled": "_ZN3foo3barEv",
+                    "usr": "c:@N@foo@F@bar#",
+                },
+                relations={"template_owner": "foo::Box<T>"},
+                ownership={
+                    "visibility": "public_header",
+                    "origin": "PUBLIC_HEADER",
+                    "role": "own_api_candidate",
+                },
+            )
+        ],
     )
     restored = SourceAbiTu.from_dict(tu.to_dict())
     assert restored.schema_version == SOURCE_ABI_VERSION
@@ -113,6 +131,9 @@ def test_source_abi_tu_roundtrip() -> None:
     assert restored.extractor == {"name": "castxml", "version": "0.6"}
     assert [e.qualified_name for e in restored.macros] == ["FOO_SIZE"]
     assert restored.functions[0].mangled_name == "_ZN3foo3barEv"
+    assert restored.functions[0].names["usr"] == "c:@N@foo@F@bar#"
+    assert restored.functions[0].relations["template_owner"] == "foo::Box<T>"
+    assert restored.functions[0].ownership["role"] == "own_api_candidate"
     # all_entities flattens every bucket
     assert {e.qualified_name for e in restored.all_entities()} == {
         "FOO_SIZE",
@@ -142,6 +163,15 @@ def test_source_entity_from_dict_boolean_safe_api_relevant() -> None:
     assert (
         SourceEntity.from_dict({"id": "x", "api_relevant": False}).api_relevant is False
     )
+
+
+def test_source_entity_from_dict_tolerates_null_evidence_dicts() -> None:
+    ent = SourceEntity.from_dict(
+        {"id": "x", "names": None, "relations": "bad", "ownership": []}
+    )
+    assert ent.names == {}
+    assert ent.relations == {}
+    assert ent.ownership == {}
 
 
 def test_source_abi_surface_roundtrip() -> None:
@@ -899,6 +929,264 @@ def test_demangled_rematch_is_noop_when_already_matched() -> None:
     matched = {"_Z1fi", "_Z1fd"}
     new = _demangled_rematch([fi, fd], mapping, matched, {"_Z1fi", "_Z1fd"})
     assert new == {}
+
+
+@needs_demangler
+def test_template_instantiation_exports_attribute_to_public_pattern() -> None:
+    # oneDAL-like Flow-2 shape: source replay sees a public template pattern, but
+    # the binary exports concrete instantiations. Exact mangled matching cannot
+    # connect `Box<T>::get` with `_ZN2ns3BoxIiE3getEv`; the template-pattern tier
+    # attributes the concrete export without pretending it was an exact decl match.
+    tu = SourceAbiTu(
+        functions=[_entity("ns::Box<T>::get", "function", mangled="")],
+    )
+    surface = link_source_abi(
+        [tu],
+        exported_symbols=["_ZN2ns3BoxIiE3getEv", "_ZN2ns3BoxIdE3getEv"],
+    )
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.coverage["matched_symbols"] == 0
+    assert surface.coverage["template_instantiation_symbols_matched"] == 2
+    assert surface.mappings["template_instantiation_symbol_to_decl"] == {
+        "_ZN2ns3BoxIdE3getEv": "ns::Box<T>::get",
+        "_ZN2ns3BoxIiE3getEv": "ns::Box<T>::get",
+    }
+    # The evidence must survive baseline serialization.
+    restored = SourceAbiSurface.from_dict(surface.to_dict())
+    assert restored.mappings["template_instantiation_symbol_to_decl"] == (
+        surface.mappings["template_instantiation_symbol_to_decl"]
+    )
+
+
+@needs_demangler
+def test_relink_attributes_template_instantiation_exports() -> None:
+    from abicheck.buildsource.source_link import relink_surface_exports
+
+    tu = SourceAbiTu(
+        functions=[_entity("ns::Box<T>::get", "function", mangled="")],
+    )
+    surface = link_source_abi([tu])  # source-only pack, later merged with binary
+    relink_surface_exports(surface, ["_ZN2ns3BoxIiE3getEv"])
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.coverage["template_instantiation_symbols_matched"] == 1
+    assert surface.mappings["template_instantiation_symbol_to_decl"] == {
+        "_ZN2ns3BoxIiE3getEv": "ns::Box<T>::get",
+    }
+
+
+@needs_demangler
+def test_template_instantiation_attribution_skips_ambiguous_source_patterns() -> None:
+    # Two source declarations erase to the same `ns::Box<>::get` pattern (e.g.
+    # overloads whose extractor could not provide a mangled identity). Claiming a
+    # concrete export would hide an overload ambiguity, so leave it unmatched.
+    tu = SourceAbiTu(
+        functions=[
+            _entity("ns::Box<T>::get", "function", signature_hash="sig:int"),
+            _entity("ns::Box<U>::get", "function", signature_hash="sig:double"),
+        ],
+    )
+    surface = link_source_abi([tu], exported_symbols=["_ZN2ns3BoxIiE3getEv"])
+    assert surface.unmatched["symbols_without_decl"] == ["_ZN2ns3BoxIiE3getEv"]
+    assert surface.mappings.get("template_instantiation_symbol_to_decl", {}) == {}
+
+
+@needs_demangler
+def test_template_pattern_key_does_not_match_missing_member_name() -> None:
+    # Guard for the oneDAL `compute_input<Task>` shape observed in the scan: a
+    # class-template pattern without the member name must not claim arbitrary
+    # exported methods such as `compute_input<task::compute>::set_data()`.
+    tu = SourceAbiTu(
+        functions=[_entity("ns::Box<T>", "function", mangled="")],
+    )
+    surface = link_source_abi([tu], exported_symbols=["_ZN2ns3BoxIiE3getEv"])
+    assert surface.unmatched["symbols_without_decl"] == ["_ZN2ns3BoxIiE3getEv"]
+
+
+@needs_demangler
+def test_template_special_members_need_only_public_class_template_pattern() -> None:
+    tu = SourceAbiTu(
+        templates=[
+            _entity("", "template", mangled=""),
+            _entity("ns::Box", "template", mangled=""),
+        ],
+    )
+    exports = [
+        "_ZN2ns3BoxIiEC1Ev",
+        "_ZN2ns3BoxIiED1Ev",
+        "_ZN2ns3BoxIiEaSERKS1_",
+        "_ZN2ns3BoxIiE3getEv",
+    ]
+    surface = link_source_abi([tu], exported_symbols=exports)
+    assert surface.unmatched["symbols_without_decl"] == ["_ZN2ns3BoxIiE3getEv"]
+    assert surface.coverage["template_instantiation_symbols_matched"] == 3
+    assert surface.mappings["template_instantiation_symbol_to_decl"] == {
+        "_ZN2ns3BoxIiEC1Ev": "ns::Box",
+        "_ZN2ns3BoxIiED1Ev": "ns::Box",
+        "_ZN2ns3BoxIiEaSERKS1_": "ns::Box",
+    }
+
+
+@needs_demangler
+def test_template_special_members_attribute_to_public_owner_pattern() -> None:
+    # oneDAL-like shape: source facts contain only the public class-template
+    # pattern, while the binary exports concrete ctor/dtor/assignment symbols.
+    # Those special members are owned by the class pattern; arbitrary methods are
+    # still left unmatched by the guard above.
+    tu = SourceAbiTu(
+        functions=[_entity("ns::Box<T>", "function", mangled="")],
+        templates=[_entity("ns::Box", "template", mangled="")],
+    )
+    exports = [
+        "_ZN2ns3BoxIiEC1Ev",
+        "_ZN2ns3BoxIiEC2Ev",
+        "_ZN2ns3BoxIiED1Ev",
+        "_ZN2ns3BoxIiED2Ev",
+        "_ZN2ns3BoxIiEaSERKS1_",
+        "_ZN2ns3BoxIiE3getEv",
+    ]
+    surface = link_source_abi([tu], exported_symbols=exports)
+    assert surface.unmatched["symbols_without_decl"] == ["_ZN2ns3BoxIiE3getEv"]
+    assert surface.coverage["template_instantiation_symbols_matched"] == 5
+    assert surface.mappings["template_instantiation_symbol_to_decl"] == {
+        "_ZN2ns3BoxIiEC1Ev": "ns::Box",
+        "_ZN2ns3BoxIiEC2Ev": "ns::Box",
+        "_ZN2ns3BoxIiED1Ev": "ns::Box",
+        "_ZN2ns3BoxIiED2Ev": "ns::Box",
+        "_ZN2ns3BoxIiEaSERKS1_": "ns::Box",
+    }
+
+
+def test_allocator_interposer_exports_attribute_only_with_tbb_proxy_marker() -> None:
+    exports = [
+        "__TBB_malloc_proxy",
+        "malloc",
+        "free",
+        "__libc_malloc",
+        "_Znwm",
+        "_ZdlPv",
+        "unrelated",
+    ]
+    surface = link_source_abi([SourceAbiTu()], exported_symbols=exports)
+    assert surface.unmatched["symbols_without_decl"] == ["unrelated"]
+    assert surface.coverage["allocator_interposer_symbols_matched"] == 6
+    assert surface.mappings["allocator_interposer_symbol_to_owner"] == {
+        "__TBB_malloc_proxy": "__TBB_malloc_proxy",
+        "malloc": "__TBB_malloc_proxy",
+        "free": "__TBB_malloc_proxy",
+        "__libc_malloc": "__TBB_malloc_proxy",
+        "_Znwm": "__TBB_malloc_proxy",
+        "_ZdlPv": "__TBB_malloc_proxy",
+    }
+
+    no_marker = link_source_abi([SourceAbiTu()], exported_symbols=["malloc", "_Znwm"])
+    assert no_marker.unmatched["symbols_without_decl"] == ["_Znwm", "malloc"]
+    assert no_marker.mappings.get("allocator_interposer_symbol_to_owner", {}) == {}
+
+
+@needs_demangler
+def test_non_public_export_accounting_keeps_reasons_separate_from_decl_matches() -> None:
+    exports = [
+        "_ZNSt6vectorIiSaIiEEC1Ev",
+        "_ZN3tbb6detail2r13fooEv",
+        "_ZN2ns6detail3barEv",
+        "_ZN2ns3Api8set_implEv",
+        "_ZN2ns3Api3pubEv",
+        "_ZN12LocalStorage3getEv",
+        "_private_c",
+        "IMPL",
+    ]
+    surface = link_source_abi(
+        [SourceAbiTu(types=[_entity("ns::Api", "record")])],
+        exported_symbols=exports,
+        library="libfoo",
+    )
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.coverage["matched_symbols"] == 0
+    assert surface.coverage["non_public_symbols_classified"] == len(exports)
+    assert surface.mappings["non_public_symbol_to_reason"] == {
+        "_ZNSt6vectorIiSaIiEEC1Ev": "dependency:stdlib",
+        "_ZN3tbb6detail2r13fooEv": "dependency:tbb",
+        "_ZN2ns6detail3barEv": "internal_or_private_export",
+        "_ZN2ns3Api8set_implEv": "internal_or_private_export",
+        "_ZN2ns3Api3pubEv": "own_export_without_public_source_decl",
+        "_ZN12LocalStorage3getEv": "cpp_export_without_public_source_decl",
+        "_private_c": "internal_or_private_export",
+        "IMPL": "c_export_without_public_source_decl",
+    }
+
+
+def test_non_public_export_accounting_does_not_hide_arbitrary_unowned_symbols() -> None:
+    surface = link_source_abi([SourceAbiTu()], exported_symbols=["plain_c_symbol"])
+    assert surface.unmatched["symbols_without_decl"] == ["plain_c_symbol"]
+    assert surface.coverage["non_public_symbols_classified"] == 0
+    assert surface.mappings.get("non_public_symbol_to_reason", {}) == {}
+
+
+def test_non_public_export_accounting_tolerates_demangler_failure(monkeypatch) -> None:
+    import abicheck.demangle as demangle_mod
+
+    def _boom(_symbol: str) -> str:
+        raise RuntimeError("demangler crashed")
+
+    monkeypatch.setattr(demangle_mod, "demangle", _boom)
+    surface = link_source_abi(
+        [SourceAbiTu(types=[_entity("ns::Api", "record")])],
+        exported_symbols=["_ZN2ns3Api3pubEv"],
+        library="libfoo",
+    )
+    assert surface.unmatched["symbols_without_decl"] == ["_ZN2ns3Api3pubEv"]
+    assert surface.coverage["non_public_symbols_classified"] == 0
+
+
+def test_non_public_export_accounting_without_surface_roots_stays_conservative() -> None:
+    from abicheck.buildsource.source_link import (
+        _classify_non_public_exports,
+        _source_namespace_roots,
+    )
+
+    assert _source_namespace_roots(None) == set()
+    assert _classify_non_public_exports({"plain_c_symbol"}, library="libfoo") == {}
+
+
+def test_template_pattern_key_edge_cases() -> None:
+    from abicheck.buildsource.source_link import _template_pattern_key
+
+    assert _template_pattern_key("ns::Map<std::vector<int>>::get") == (
+        "ns::Map<>::get"
+    )
+    assert _template_pattern_key("ns::Box<T>::operator<") == "ns::Box<>::operator<"
+    assert _template_pattern_key("ns::Broken<T") == ""
+    assert _template_pattern_key("plain") == ""
+
+
+def test_template_owner_helper_edge_cases() -> None:
+    import abicheck.buildsource.source_link as sl
+
+    assert sl._split_qualified_scope("Box") == ("", "Box")
+    assert sl._drop_demangled_return_type("Box") == "Box"
+    assert sl._template_special_member_owner_key("ns::Box::Box") == ""
+
+
+@needs_demangler
+def test_template_instantiation_attribution_noop_edges(monkeypatch) -> None:
+    import abicheck.buildsource.source_link as sl
+
+    surface = SourceAbiSurface()
+    assert sl._template_instantiation_attribution(surface, [], set(), set()) == {}
+    empty_name = SourceEntity(id="empty", kind="function", qualified_name="")
+    assert sl._template_instantiation_attribution(
+        surface, [empty_name], set(), {"_ZN2ns3BoxIiE3getEv"}
+    ) == {}
+    pattern = _entity("ns::Box<T>::get", "function", mangled="")
+    assert sl._template_instantiation_attribution(
+        surface, [pattern], {"_ZN2ns3BoxIiE3getEv"}, {"_ZN2ns3BoxIiE3getEv"}
+    ) == {}
+    monkeypatch.setattr(
+        sl, "_norm_itanium", lambda _s: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert sl._template_instantiation_attribution(
+        surface, [pattern], set(), {"_ZN2ns3BoxIiE3getEv"}
+    ) == {}
 
 
 def test_linker_excludes_non_public_entities() -> None:

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -1006,6 +1006,110 @@ def test_ast_mapping_template_not_double_counted_as_function() -> None:
     assert "ns::maxv" not in {e.qualified_name for e in tu.functions}
 
 
+def test_class_template_public_member_patterns_are_emitted() -> None:
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "NamespaceDecl",
+                "name": "ns",
+                "loc": {"file": "include/foo.h", "line": 1},
+                "inner": [
+                    {
+                        "kind": "ClassTemplateDecl",
+                        "name": "Box",
+                        "loc": {"line": 2},
+                        "inner": [
+                            {"kind": "TemplateTypeParmDecl", "name": "T"},
+                            "non-dict-template-child",
+                            {
+                                "kind": "CXXRecordDecl",
+                                "name": "Box",
+                                "tagUsed": "class",
+                                "loc": {"line": 3},
+                                "inner": [
+                                    "non-dict-record-child",
+                                    {"kind": "AccessSpecDecl", "access": "public"},
+                                    {
+                                        "kind": "CXXMethodDecl",
+                                        "name": "get",
+                                        "loc": {"line": 5},
+                                        "type": {"qualType": "T () const"},
+                                        "inner": [
+                                            {
+                                                "kind": "CompoundStmt",
+                                                "inner": [],
+                                            }
+                                        ],
+                                    },
+                                    {"kind": "AccessSpecDecl", "access": "private"},
+                                    {
+                                        "kind": "CXXMethodDecl",
+                                        "name": "secret",
+                                        "loc": {"line": 6},
+                                        "type": {"qualType": "void ()"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "ClassTemplateDecl",
+                        "name": "Indexed",
+                        "loc": {"line": 8},
+                        "inner": [
+                            {"kind": "TemplateTypeParmDecl"},
+                            {"kind": "NonTypeTemplateParmDecl"},
+                            {
+                                "kind": "CXXRecordDecl",
+                                "name": "Indexed",
+                                "tagUsed": "struct",
+                                "loc": {"line": 9},
+                                "inner": [
+                                    {
+                                        "kind": "CXXMethodDecl",
+                                        "name": "at",
+                                        "loc": {"line": 10},
+                                        "type": {"qualType": "int ()"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "ClassTemplateDecl",
+                        "name": "NoRecord",
+                        "loc": {"line": 12},
+                        "inner": [{"kind": "TemplateTypeParmDecl", "name": "U"}],
+                    },
+                ],
+            }
+        ],
+    }
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "t")
+    assert {e.qualified_name for e in tu.templates} == {
+        "ns::Box",
+        "ns::Indexed",
+        "ns::NoRecord",
+    }
+    function_names = {e.qualified_name for e in tu.functions}
+    assert "ns::Box<T>::get" in function_names
+    assert "ns::Indexed<T0,N1>::at" in function_names
+    assert "ns::Box<T>::secret" not in function_names
+    assert "ns::Box<T>::get" not in {e.qualified_name for e in tu.inline_bodies}
+    get = next(e for e in tu.functions if e.qualified_name == "ns::Box<T>::get")
+    assert get.names == {"source_qualified": "ns::Box<T>::get"}
+    assert get.relations == {
+        "template_owner": "ns::Box<T>",
+        "template_parameters": "T",
+        "declaration_role": "class_template_member_pattern",
+    }
+    assert get.ownership["role"] == "own_api_candidate"
+    surface = link_source_abi([tu], exported_symbols=["_ZN2ns3BoxIiE3getEv"])
+    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.coverage["template_instantiation_symbols_matched"] == 1
+
+
 def test_ast_body_hash_is_stable_and_change_detected() -> None:
     base = source_abi_from_clang_ast(_ast(), _cu(), ["include/foo.h"], "t")
     # Same AST again → identical body hash (build-root independent / deterministic).


### PR DESCRIPTION
## Summary

- add a conservative template-instantiation attribution tier for source-to-binary matching
- persist `template_instantiation_symbol_to_decl` evidence in source ABI snapshots
- cover link and merge/relink paths, ambiguity guards, missing-member-name/operator guards, no-op branches, and fixture serialization

## Validation

- `python -m pytest -q tests/test_source_abi.py tests/test_source_graph.py tests/test_source_evidence_integrity.py tests/test_build_source_cli.py tests/test_inputs_pack.py tests/test_g20_catalog.py::test_fixtures_match_generator` -> 305 passed
- `python -m pytest tests/test_source_abi.py -q --cov=abicheck.buildsource.source_link --cov=abicheck.buildsource.source_abi --cov-report=term-missing` -> 94 passed, touched modules 95%
- `ruff check abicheck tests` -> passed
- `python -m mypy abicheck/buildsource/source_link.py abicheck/buildsource/source_abi.py` -> passed
- `git diff --check` -> passed
- Broad non-integration unit probe before the final coverage amend: 11944 passed, 12 skipped, 373 deselected, 4 xfailed. Remaining non-scope failures on fresh env/main:
  - `tests/test_call_graph.py::test_extract_from_build_parallelizes_and_dedupes`
  - `tests/test_config_review.py::TestCompareReleaseDefaults::test_severity_options_present`
  - `tests/test_cov95_cli.py::TestSmallHelpers::test_help_option_groups_render`
  - `tests/test_g20_catalog.py::test_fixtures_match_generator`
- G20 fixture drift was caused by the new serialized evidence key and is fixed in this PR; the focused fixture check above passes.

## Notes

- Existing oneDAL saved artifacts did not get template-instantiation matches because their source facts expose class-template patterns without member names, for example `compute_input<Task>` versus exported `set_data()` methods. The new tier intentionally does not claim those unsafe matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added template-instantiation export attribution and coverage tracking, with the corresponding mapping preserved across save/load and relinking.
  * Added structured naming/relationship/ownership metadata to source ABI entities, emitted by both the Clang extractor and the Clang plugin (including template member patterns).

* **Bug Fixes**
  * Improved handling of malformed metadata during round-trips so it safely normalizes to empty structures.
  * Enhanced attribution for allocator-interposer exports when present.

* **Documentation / Tests**
  * Updated documentation for template-related emission behavior and expanded test coverage for template patterns and attribution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->