### PR TITLE
docs: align documentation with reduced CLI — retire S-levels, --depth is the single dial

### DIFF
--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -22,19 +22,19 @@ wires together the three ADR-035 pieces into one coverage-annotated report:
 2. run the **always-on tier** — the compiler-free lexical pattern pre-scan
    (``pattern_scan.py``, S3) and the intra-version cross-source checks
    (``crosscheck.py``, D4) — every time;
-3. run the **pinned** evidence level (the ``--mode`` preset or an explicit
-   ``--source-method``/``--depth``, resolved by ``scan_levels.py``), POI-scoped to
-   the changed paths, by collecting L3/L4/L5 inline at the matching ADR-033 D2
-   evidence mode;
+3. run the **pinned** evidence level (the ``--depth`` dial, resolved by
+   ``scan_levels.py``; the deprecated ``--mode``/``--source-method`` aliases map
+   onto it), POI-scoped to the changed paths, by collecting L3/L4/L5 inline at the
+   matching ADR-033 D2 evidence mode;
 4. if a ``--baseline`` is given, ``compare`` against it and fold the cross-source
    findings in as ``extra_changes``;
 5. emit **one** report stating, per layer/method, what ran vs. skipped (never a
    bare "source scan failed").
 
-Determinism (ADR-035 D3): the level is fixed by the pinned ``--mode``/``--source-
-method``/``--depth``; the risk score escalates the level **only** under
-``--source-method auto`` (opt-in). ``--budget`` is a failure guard on the chosen
-level — it never silently shrinks scope.
+Determinism (ADR-035 D3): the level is fixed by the pinned ``--depth`` (or its
+deprecated ``--mode``/``--source-method`` aliases); the risk score escalates the
+level **only** when ``--depth`` is omitted (the ``auto`` default). ``--budget`` is
+a failure guard on the chosen level — it never silently shrinks scope.
 
 The authority rule (ADR-028 D3 / ADR-035 D1) is preserved: ``scan`` adds no new
 authority — cross-source and pattern findings are ``RISK``/``API_BREAK`` only,
@@ -818,8 +818,8 @@ def scan_cmd(
 
     One orchestrator over `dump`/`compare`: classifies the PR's changed paths,
     runs the always-on compiler-free pattern pre-scan and the intra-version
-    cross-source checks, then runs the pinned evidence level (the `--mode` preset
-    or an explicit `--source-method`/`--depth`) and — when `--baseline` is given —
+    cross-source checks, then runs the pinned evidence level (the `--depth` dial,
+    or `auto` when omitted) and — when `--baseline` is given —
     compares against it. Emits one coverage-annotated report.
 
     \b
@@ -834,7 +834,7 @@ def scan_cmd(
       abicheck scan --binary new/libfoo.so --headers new/include \\
                     --sources . --baseline old/libfoo.abi.json
       abicheck scan --binary libfoo.so --headers include/ --audit
-      abicheck scan --binary new.so -H include/ --source-method auto --since origin/main
+      abicheck scan --binary new.so -H include/ --depth source --since origin/main
     """
     _setup_verbosity(verbose)
     start = time.monotonic()

--- a/docs/concepts/abi-api-handling.md
+++ b/docs/concepts/abi-api-handling.md
@@ -689,13 +689,13 @@ source-only facts it cannot see — `#define` macros, `constexpr` values,
 default-argument values, inline/template **bodies**, uninstantiated templates —
 abicheck can read the build's compile database (**L3**) and replay the sources
 (**L4**), and fold a source/build reachability graph (**L5**). The one-shot
-driver is `abicheck scan`. It exposes two orthogonal "level" axes — the `L0`–`L5`
-*evidence layers* (what it sees + authority) and the `s0`–`s6` *source-analysis
-methods* (how it gathers L3–L5) — fully explained in
-[Scan Levels (S vs L)](scan-and-evidence-levels.md). The governing **authority
-rule**: source/build evidence (L3/L4/L5) explains, localizes, scopes, or raises
-its own source-/API-level findings, but **never deletes an artifact-proven
-break**.
+driver is `abicheck scan`. It has one evidence dial — `--depth`
+(`binary|headers|build|source|full`) — that selects how far down the `L0`–`L5`
+*evidence layers* (what it sees + authority) to collect; fully explained in
+[Evidence Layers & Scan Depth](scan-and-evidence-levels.md). The governing
+**authority rule**: source/build evidence (L3/L4/L5) explains, localizes, scopes,
+or raises its own source-/API-level findings, but **never deletes an
+artifact-proven break**.
 
 **Who produces the source facts.** The default is a post-build
 `compile_commands.json` replay — nothing in your build changes (`abicheck scan`
@@ -706,10 +706,11 @@ builds where a companion parse hurts — an optional **Clang plugin** that rides
 the compile's own AST (zero extra parse). The three are one interchangeable
 family; see [Build & Source data](build-source-data.md) for enable steps.
 
-`scan --mode` picks a fixed depth: `pr` (the cheap per-PR gate, diff-seeded L4),
-`pr-deep` (PR + the full L5 graph), `baseline` (a full-depth release snapshot),
-and `audit` — an **intra-version single-build hygiene lint that needs no previous
-version**. Audit surfaces "bad ABI hygiene" visible from one build: accidental
+`scan --depth` picks the evidence level: `source` (the per-PR gate — diff-seeded
+L4 replay + the L5 graph) and `full` (a full-depth release snapshot). Orthogonal
+to depth, `scan --audit` is an **intra-version single-build hygiene lint that
+needs no previous version**. Audit surfaces "bad ABI hygiene" visible from one
+build: accidental
 exports, private-header leaks, unversioned symbols, exported RTTI for internal
 types, and cross-source mismatches. Worked example cases:
 
@@ -737,19 +738,18 @@ project, the tool-track guides carry the exact commands, flags, and CI YAML:
 | You want to… | Go to |
 |--------------|-------|
 | Pick the right command for your situation (binary compare → full source scan → merge → plugin) | [Choose Your Workflow](../user-guide/choose-your-workflow.md) |
-| Run `abicheck scan` and pin a depth / S-method / mode | [Source-Scan Levels](../user-guide/scan-levels.md) |
+| Run `abicheck scan` and pin a depth | [Source-Scan Depth](../user-guide/scan-levels.md) |
 | *Produce* the source facts — post-build replay (Flow A), `abicheck-cc` wrapper (Flow B), or the Clang plugin (Flow C) | [Producing Source Facts](../user-guide/producing-source-facts.md) |
 | Fold build/source evidence into a baseline snapshot | [Source & Build Data](build-source-data.md) |
-| Wire a **full source scan into GitHub Actions** — `sources`/`build-info`/`depth`/`source-method`/`scan-mode`, audit, estimate, cross-check gating | [GitHub Action § Source scans](../user-guide/github-action.md#source-scans-build-source-evidence) |
+| Wire a **full source scan into GitHub Actions** — `sources`/`build-info`/`depth`, audit, estimate, cross-check gating | [GitHub Action § Source scans](../user-guide/github-action.md#source-scans-build-source-evidence) |
 | Check a host↔plugin ABI contract | [Plugin Systems](../user-guide/plugin-systems.md) |
 | Gate CI on the right verdict tier (binary break vs. source/API break) | [CI Gating](../user-guide/ci-gating.md) |
 
 The CI recipes there go beyond the binary-only compare: a minimal PR scan is
 four inputs (binary + headers + `sources: .` + `baseline`), and the same guide
 shows enabling each source layer independently — `depth: build` for cheap L3
-build-flag drift, `source-method: s5` for full L4 replay, `scan-mode: pr-deep`
-for the L5 graph, and `mode: merge` for build-emitted (`abicheck-cc` / Clang
-plugin) packs.
+build-flag drift, `depth: source` for full L4 replay plus the change-scoped L5
+graph, and `mode: merge` for build-emitted (`abicheck-cc` / Clang plugin) packs.
 
 ## Detection coverage and roadmap
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -269,7 +269,7 @@ break.
 
 | Module | Responsibility |
 |--------|---------------|
-| `cli.py` | CLI entrypoint — `dump`, `compare`, `compat check`, `compat dump`, `deps` (tree/compare), `baseline`, `appcompat` commands |
+| `cli.py` | CLI entrypoint — `dump`, `compare`, `scan`, `compat check`, `compat dump`, `deps` (tree/compare), `baseline`, `appcompat`, and the other top-level commands (`collect`, `merge`, `graph`, `probe`, `surface-report`, …); larger commands live in sibling `cli_<name>.py` modules |
 | `service.py` | Service layer — shared orchestration for CLI and MCP server (`resolve_input`, `run_dump`, `run_compare`, `render_output`) |
 | `mcp_server.py` | MCP (Model Context Protocol) server for AI agent integration |
 | `build_context.py` | `compile_commands.json` parsing and per-TU flag extraction |

--- a/docs/concepts/build-source-data.md
+++ b/docs/concepts/build-source-data.md
@@ -360,7 +360,7 @@ suppression:               # suppression hygiene (a project rule, inherited by C
   strict: true
   require_justification: true
 source:
-  method: s4               # precise S-axis for power users (CLI exposes coarse --depth)
+  method: s4               # legacy S-axis escape hatch (deprecated; prefer the --depth dial)
   graph: summary           # summary | full — L5 graph replay scope
 exit_code_scheme: auto     # auto | legacy | severity (ADR-037 D12)
 ```
@@ -816,11 +816,13 @@ itself, pass the command on the CLI (no config file needed):
 ```bash
 abicheck dump libfoo.so --sources ./src \
   --build-query 'cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON' \
-  --build-compile-db build/compile_commands.json --allow-build-query
+  --build-compile-db build/compile_commands.json
 ```
 
-(or set `build.query` / `build.compile_db` in `.abicheck.yml`). It is gated by
-`--allow-build-query` and still never runs `make all` / `cmake --build`.
+(or set `build.query` / `build.compile_db` in `.abicheck.yml`). An
+operator-supplied `--build-query` (or a trusted `--config`) runs on its own — the
+old `--allow-build-query` gate is now a deprecated no-op — and it still never runs
+`make all` / `cmake --build`.
 
 ### Time & resource model
 

--- a/docs/concepts/class-layout-abi.md
+++ b/docs/concepts/class-layout-abi.md
@@ -11,7 +11,7 @@ It complements two neighbouring pages:
 - [Type Layout](abi-series/03-type-layout.md) and [C++ ABI](abi-series/04-cpp-abi.md)
   — the tutorial walk-throughs.
 - [Change Kinds](../reference/change-kinds.md) — the exhaustive catalog.
-- [Evidence & Detectability](evidence-and-detectability.md) — the L0–L4 model.
+- [Evidence & Detectability](evidence-and-detectability.md) — the L0–L5 model.
 
 ---
 
@@ -83,7 +83,7 @@ verdict bucket follows the [policy partition](../reference/change-kinds.md):
 | **A base subobject *moves* (e.g. EBO lost)** | BREAKING | **`base_class_offset_changed`** | L1 | **[case140](../examples/case140_empty_base_optimization_lost.md)** |
 | Non-polymorphic class gains its first virtual → vptr prepended | BREAKING | `vptr_introduced` | L2 *(descriptor)* | unit-tested (`test_diff_layout.py`) |
 | Add / remove / reorder a virtual function | BREAKING | `virtual_method_added`, `func_virtual_added`/`func_virtual_removed`, `type_vtable_changed` | L1 | [case38](../examples/case38_virtual_methods.md), [case68](../examples/case68_virtual_method_added.md) |
-| **Vtable slot count changes — from a *stripped* binary** | BREAKING | **`vtable_slot_count_changed`** | **L0 (ELF symbol size)** | **[case141](../examples/case142_vtable_slot_count_binary_only.md)** |
+| **Vtable slot count changes — from a *stripped* binary** | BREAKING | **`vtable_slot_count_changed`** | **L0 (ELF symbol size)** | **[case142](../examples/case142_vtable_slot_count_binary_only.md)** |
 | Inheritance *shape* changes — from a stripped binary | BREAKING | `rtti_inheritance_changed` | L0 (`_ZTI` size) | unit-tested (`test_diff_elf_layout.py`) |
 | Type stops being trivially-copyable → by-value calling conv. flips | BREAKING | `trivially_copyable_lost`, `value_abi_trait_changed` | L2 *(descriptor)* / L1 | [case69](../examples/case69_trivial_to_nontrivial.md) |
 | Type stops being standard-layout (`offsetof`/C-interop lost) | COMPATIBLE_WITH_RISK | `standard_layout_lost` | L2 *(descriptor)* | unit-tested (`test_diff_layout.py`) |
@@ -154,7 +154,7 @@ encode layout facts otherwise visible only in DWARF:
 
 This means a virtual-method change or a base-class change is observable from
 `.dynsym` **alone** — no debug info, no headers — which is exactly what
-[case141](../examples/case142_vtable_slot_count_binary_only.md) demonstrates on
+[case142](../examples/case142_vtable_slot_count_binary_only.md) demonstrates on
 a stripped `.so`. Because the slot count is *inferred* from size, these findings
 are labelled `MEDIUM` confidence.
 

--- a/docs/concepts/evidence-and-detectability.md
+++ b/docs/concepts/evidence-and-detectability.md
@@ -61,12 +61,14 @@ struct is non-public ([case118](../examples/case118_internal_struct_field_added_
 > prioritize cross-symbol impact. It is covered with the other build/source
 > layers in [Build Info & Sources](build-source-data.md).
 >
-> **Layers (`L`) vs. scan levels (`S`).** The `L0`–`L5` codes name *evidence
+> **Layers (`L`) vs. the depth dial.** The `L0`–`L5` codes name *evidence
 > layers* — *what* abicheck sees and how much that evidence is trusted. The
-> `abicheck scan` command has a **separate** `s0`–`s6` axis naming the *method*
-> used to gather the L3–L5 evidence — a different meaning of the word "level".
-> [Scan Levels (S vs L)](scan-and-evidence-levels.md) explains both axes and how
-> they map onto each other.
+> `abicheck scan` command has one knob, `--depth`
+> (`binary|headers|build|source|full`), that selects **how far down** these
+> layers to collect. (Earlier releases exposed a separate `s0`–`s6` "method"
+> axis; it is now a deprecated alias of `--depth`.)
+> [Evidence Layers & Scan Depth](scan-and-evidence-levels.md) explains the model
+> and the `s0…s6` → `--depth` mapping.
 
 ### How they combine
 

--- a/docs/concepts/scan-and-evidence-levels.md
+++ b/docs/concepts/scan-and-evidence-levels.md
@@ -204,7 +204,7 @@ line.
 | `s0` / `s3` | diff classifier / lexical pattern scan (compiler-free) | `--depth binary` (or `headers` for +L2) |
 | `s1` | compile-DB / build-flag scan (L3) | `--depth build` |
 | `s2` | preprocessor macro/include capture | folded into `--depth build` (runs when `clang -E` + a compile DB are present) |
-| `s4` | symbol/reference index → L5 graph (no L4) | reached internally by `--depth source`; there is no user-facing graph rung (D6) |
+| `s4` | symbol/reference index → the *cheap* L5 structural graph (no L4 replay, no call edges) | **no user-facing `--depth` rung** (D6): the graph-only level is internal. `--depth source` gives L5 edges but pays for the L4 replay; there is no cheap graph-only depth |
 | `s5` | semantic AST replay of changed TUs (L4) | `--depth source` |
 | `s6` | full AST replay of all TUs (L4) | `--depth full` |
 
@@ -213,7 +213,7 @@ line.
 | Deprecated | Was | Use instead |
 |------------|-----|-------------|
 | `pr` | diff-seeded L4 replay (per-PR gate) | `--depth source --since <ref>` (or just `auto` with a seed) |
-| `pr-deep` | `pr` + full L5 reachability | `--depth source` (the L5 graph is folded in) |
+| `pr-deep` | `pr` + the *whole-library* L5 reachability graph (`GRAPH`) | no exact `--depth` equivalent — the full graph is internal-only (D6). `--depth source` gives the change-scoped edges; keep `--mode pr-deep` if you need the full graph |
 | `baseline` | whole-library replay of a release | `--depth full` |
 | `audit` | intra-version hygiene lint, no baseline | the `--audit` switch |
 

--- a/docs/concepts/scan-and-evidence-levels.md
+++ b/docs/concepts/scan-and-evidence-levels.md
@@ -1,34 +1,37 @@
-# Scan Levels (S vs L)
+# Evidence layers (L) and scan depth
 
-> **One idea drives this page:** the word **"level" names three different
-> things** in abicheck, and they are routinely confused. This page separates
-> them and shows how they connect. If you only remember one sentence:
-> **`L` is the evidence (the *what* + how much it is trusted); `S` is the method
-> that gathers it (the *how*); `--mode`/`--depth` are presets that pick an
-> `(S, L)` pair.**
+> **One idea drives this page:** abicheck has **one** knob you turn — `--depth`
+> — and it selects how far down a fixed ladder of **evidence layers** (`L0`–`L5`)
+> the scan collects. If you only remember one sentence: **`L` is the evidence
+> (the *what* + how much it is trusted); `--depth` is the single dial that says
+> how much of it to gather.**
 
 This is the conceptual companion to the practical
-[Source-Scan Levels](../user-guide/scan-levels.md) user-guide page (the `scan`
+[Source-Scan Depth](../user-guide/scan-levels.md) user-guide page (the `scan`
 command's flags, with worked examples) and to
 [Evidence & Detectability](evidence-and-detectability.md) (what each evidence
-layer can and cannot see). Read this page when the `s0…s6`, `L0…L5`,
-`--mode`, and `--depth` knobs look like they overlap and you want the model that
-relates them.
+layer can and cannot see). Read this page when the `L0…L5` layers and the
+`--depth` rungs look like they overlap and you want the model that relates them.
+
+!!! note "There used to be more knobs"
+    Earlier releases exposed a second `s0…s6` **"source-method"** axis plus
+    `--mode` presets. Those are now **deprecated aliases** of `--depth`
+    (ADR-037 D5) — they still parse but print a warning. The whole model is now
+    just **evidence layers (`L`) + one depth dial**. The old vocabulary and its
+    `--depth` mapping are in the [Deprecated axes appendix](#appendix-deprecated-scan-axes-s0s6-and-mode).
 
 ---
 
-## The three things called "level"
+## The two things you need
 
-| Axis | Codes | Answers | Set by | Lives where |
-|------|-------|---------|--------|-------------|
-| **L — evidence layer** | `L0`–`L5` | *What* abicheck sees, and **how much that evidence is trusted** (authority) | the **inputs you give** (binary, debug, headers, build dir, sources) | [Evidence & Detectability](evidence-and-detectability.md), [Build Info & Sources](build-source-data.md) |
-| **S — source-analysis method** | `s0`–`s6` (+`auto`) | *How* abicheck gathers the L3–L5 evidence, and the **granularity coverage is reported at** | `scan --source-method` | [`scan` command](../user-guide/scan-levels.md) |
-| **mode / depth — presets** | `pr`,`pr-deep`,`baseline`,`audit` / `binary`,`headers`,`build`,`source`,`full` | A convenient **fixed `(S, L)` selection** | `scan --mode` / `scan --depth` | [`scan` command](../user-guide/scan-levels.md) |
+| Axis | Codes | Answers | Set by |
+|------|-------|---------|--------|
+| **L — evidence layer** | `L0`–`L5` | *What* abicheck sees, and **how much that evidence is trusted** (authority) | the **inputs you give** (binary, debug, headers, build dir, sources) |
+| **`--depth` — the dial** | `binary`,`headers`,`build`,`source`,`full` (+`auto`) | **How much** evidence to collect (which L-layers to reach) | `scan --depth` (or omit for `auto`) |
 
-The two axes are **orthogonal**: `L` is a property of *evidence*, `S` is a
-property of the *process* that produced it. You can reach the same L-layer by
-more than one S-method, and a single S-method can contribute to more than one
-L-layer.
+`--depth` is a selector *over* the L-axis: each rung names the evidence you get
+back, so the dial and the evidence it reaches share one vocabulary and never
+drift.
 
 ---
 
@@ -65,147 +68,106 @@ the L0 export table against L2 declarations in both directions.
 
 ---
 
-## 2. The S-axis — source-analysis methods (the *how*)
+## 2. The `--depth` dial — how deep to collect
 
-`abicheck scan` can gather the build/source evidence in seven cost-ordered ways.
-This is the `--source-method` knob (`abicheck/buildsource/scan_levels.py`). Each
-method is a *technique*; the right-hand column is the **evidence it reaches**:
+`abicheck scan` takes one evidence dial, **named by the evidence you get**
+(ADR-037 D5). Each rung is additive over the one below it:
 
-| Method | Technique | Reaches | Needs |
-|--------|-----------|---------|-------|
-| `s0` | diff classifier (risk tags/score) | L0/L1 + always-on pattern scan | nothing extra |
-| `s1` | compile-DB / build-flag scan | **L3** build context | a compile DB / build dir |
-| `s2` | preprocessor (macro values / include graph) | L3 + macro/include facts | L3 **and** `clang -E` |
-| `s3` | lexical pattern scan (compiler-free) | pattern facts only (the always-on scan) | nothing |
-| `s4` | symbol / reference index | + **L5** graph (no L4) | a compile DB |
-| `s5` | targeted semantic AST (changed TUs) | + **L4** replay + L5 edges | sources **and** clang |
-| `s6` | full AST (all TUs) | + **L4** over the whole library | sources **and** clang |
+| `--depth` | Reaches | Needs |
+|-----------|---------|-------|
+| `binary` | L0/L1 exported symbols + binary metadata + debug-info *presence* (no deep DWARF type walk, no L2 AST) + the always-on pattern scan | just the artifact(s) |
+| `headers` | + **L2** header AST (the public/internal boundary) | a public-header directory + a C/C++ frontend |
+| `build` | + **L3** build context (flag/toolchain drift) | a compile DB / build dir |
+| `source` | + **L4** source-ABI replay of changed TUs + the **L5** graph | sources **and** `clang` (+ a diff seed for scoping) |
+| `full` | **L4** over the whole library | sources **and** `clang` |
 
-`auto` is an opt-in, risk-driven escalation (local/dev only): it reads the
-numeric risk of the changed paths and picks an S-method, capped at `s5`. It
-**never** fires for a pinned CI level — a mode/`--source-method` you pin always
-produces the same scan for the same inputs.
+**Omit `--depth` for `auto`** — the default. `auto` is risk-driven when a
+`--since`/`--changed-path` diff seed is present (it reads the numeric risk of the
+changed paths and picks a rung), and falls back to a sensible preset otherwise.
+`auto` **never** fires for a pinned depth — a rung you pin always produces the
+same scan for the same inputs, which is what CI wants.
 
-> **Why the numbering isn't a straight ladder.** `s0`/`s3` are compiler-free
-> (they reach no new L-layer beyond the always-on scan); `s4` deliberately skips
-> L4 and goes straight to the L5 graph (it is the cheapest way to get
-> reachability); only `s5`/`s6` pay for the L4 semantic replay. The S-axis is
-> ordered by **cost**, and cost does not increase one L-layer at a time.
+`--audit` is **orthogonal** to `--depth`: it is a single-build, no-baseline
+hygiene lint (it does not need a previous version). Combine it with any depth.
+
+!!! warning "A pinned deep depth is a contract (fail-loud)"
+    Pinning `--depth build|source|full` with **no source input**
+    (`--sources`/`--build-info`) is an error, not a silent shallow scan: there
+    is nothing to collect L3/L4/L5 from. Pass the evidence, or use the default
+    `auto` for a best-effort binary scan.
+
+### There is no `graph` rung
+
+The L5 reachability graph is an **internal consequence** of `--depth source`/`full`,
+never its own user-facing rung (ADR-037 D6). `--depth source` folds the L5 edges
+that scope and localize a finding; you do not select the graph directly.
 
 ---
 
-## 3. How S maps onto L
+## 3. How `--depth` maps onto L
 
-`scan` is a front-end over `dump`/`compare`: the resolved S-method selects an
-internal **collection mode** (the ADR-033 CI evidence mode that the unified
-`--depth` dial also resolves to), which decides which L-layers get collected and
-at what replay scope. abicheck also reports the **representative L-depth** each
-method actually reached, so the coverage block states the depth of what *ran*,
-not what you *requested*:
+`scan` is a front-end over `dump`/`compare`: the resolved depth selects an
+internal **collection mode** (the ADR-033 CI evidence mode), which decides which
+L-layers get collected and at what replay scope. abicheck also reports the
+**representative L-depth** each scan actually reached, so the coverage block
+states the depth of what *ran*, not what you *requested*:
 
 ```mermaid
 flowchart LR
-    subgraph S["S-axis · method (how)"]
-      s0["s0 diff"]:::cheap
-      s1["s1 build-flags"]:::cheap
-      s2["s2 preprocessor"]:::cheap
-      s3["s3 lexical"]:::cheap
-      s4["s4 ref-index"]:::cheap
-      s5["s5 AST (changed TUs)"]:::exp
-      s6["s6 AST (all TUs)"]:::exp
+    subgraph D["--depth · the dial (how deep)"]
+      d0["binary"]:::cheap
+      d1["headers"]:::cheap
+      d2["build"]:::cheap
+      d3["source"]:::exp
+      d4["full"]:::exp
     end
     subgraph L["L-axis · evidence (what)"]
-      L02["L0–L2 artifact (authoritative)"]
+      L01["L0/L1 artifact (authoritative)"]
+      L2e["L2 header AST"]
       L3e["L3 build context"]
-      L5e["L5 graph"]
-      L4e["L4 source replay"]
+      L45["L4 replay + L5 graph"]
     end
-    s0 --> L02
-    s3 --> L02
-    s1 --> L3e
-    s2 --> L3e
-    s4 --> L5e
-    s5 --> L4e
-    s6 --> L4e
+    d0 --> L01
+    d1 --> L2e
+    d2 --> L3e
+    d3 --> L45
+    d4 --> L45
     classDef cheap fill:#e6f4ea,stroke:#34a853;
     classDef exp fill:#fce8e6,stroke:#ea4335;
 ```
 
-The mapping is **lossy in the `--depth` direction** (see §4): `--depth build`
-resolves to `s1`, and `s2`/`s3`/`s4` have no `--depth` form at all — so
-`--source-method` is the precise knob and **wins if both are given**.
-
 ---
 
-## 4. The presets — `--mode` and `--depth`
+## 4. Cost: one cliff, at L4
 
-You rarely pick `(S, L)` by hand. Two presets do it for you:
+The depth ladder is ordered by cost, and the cost curve has **exactly one cliff —
+between `build` and `source` (i.e. reaching L4)**:
 
-**`--mode`** pins a fixed `(S, L)` pair — deterministic, so a CI gate that pins a
-mode produces the same scan for the same inputs:
-
-| `--mode` | `(S, L)` | Use it for |
-|----------|----------|------------|
-| `pr` *(default)* | `(s5, source)` | per-PR gate with a diff seed (`--since`) |
-| `pr-deep` | `(s5, graph)` | PR gate **+** full L5 reachability |
-| `baseline` | `(s6, full)` | the amortized full snapshot of a release |
-| `audit` | `(s5, source)` *(intra-version)* | single-build hygiene lint, **no baseline** |
-
-**`--depth`** is a coarse, *lossy* L-axis selector — convenient but less precise
-than `--source-method`. Its five rungs are `binary`, `headers`, `build`,
-`source`, `full` (ADR-037 D5):
-
-| `--depth` | resolves to | reaches |
-|-----------|-------------|---------|
-| `binary` | `s0` (no S-method) | L0 exported symbols + binary metadata + debug-info *presence* — no DWARF type expansion, no L2 AST (+ always-on pattern scan) |
-| `headers` | `s0` (no S-method — L2 is the intrinsic header AST) | L0–L2 (+ always-on pattern scan) |
-| `build` | `s1` | + L3 |
-| `source` | `s5` | + L4 scoped + L5 edges |
-| `full` | `s6` | L4 full-scope |
-
-There is **no `graph` rung** (ADR-037 D6): the L5 graph is an *internal
-consequence* of `--depth source`/`full`, never its own user-facing rung. To pin
-the graph-only level (`s4`, L5 without paying for L4) use `--source-method s4`;
-to fold the *full* L5 reachability graph into a PR scan use `--mode pr-deep`
-(= `(s5, graph)` internally).
-
-Precedence, highest first: **`--source-method` > `--depth` > `--mode`**.
-
----
-
-## 5. Cost: one cliff, at L4
-
-The S-axis is ordered by cost, and the cost curve has **exactly one cliff —
-between `s4` and `s5` (i.e. reaching L4)**:
-
-- **Cheap tier (`s0`–`s4`):** one price, dominated by the binary dump + lexical
-  scan, *not* the source layer. `s0` ≈ `s3`; `s1` adds L3; **`s4` adds the L5
-  *structural* graph without paying for L4** — target → source → header →
-  build-option nodes (`graph-build`), the best cheap level for build-structure
-  reachability. Note `s4` does **not** fold call edges (`DECL_CALLS_DECL`): those
-  need the L4 pass, so for call-impact reachability use `pr-deep`/`s5`/`s6`.
-- **Expensive tier (`s5`, `s6`, and the modes that use them):** clang per-TU AST
-  replay (L4). The cliff height tracks **C++ template/STL instantiation depth**,
-  not `.so`/TU count — a heavy-C++ library can be ~7× slower at `s5` than `s4`,
-  while a plain-C library is barely affected (~1.3×).
-- **`s5`/`pr` only beats `s6` with a diff seed.** Without `--since`/`--changed-path`,
-  the changed-TU set is empty and `s5` replays every TU — the same cost as `s6`.
-  Always pass a seed in PR CI.
+- **Cheap tier (`binary`, `headers`, `build`):** one price, dominated by the
+  binary dump + lexical scan, *not* the source layer. `build` adds L3
+  build-flag/toolchain drift for a flat ~0.3–0.5s regardless of project size.
+- **Expensive tier (`source`, `full`):** clang per-TU AST replay (L4). The cliff
+  height tracks **C++ template/STL instantiation depth**, not `.so`/TU count — a
+  heavy-C++ library can be ~7× slower at `source` than `build`, while a plain-C
+  library is barely affected (~1.3×).
+- **`source` only beats `full` with a diff seed.** Without `--since`/`--changed-path`,
+  the changed-TU set is empty and `source` replays every TU — the same cost as
+  `full`. Always pass a seed in PR CI.
 
 A key consequence: **the verdict usually does not change with depth.** The binary
 diff (L0–L2) sets the gate; L3–L5 add localization, explanation, and their own
 source/API findings. For a pass/fail **gate**, the cheap tier is enough; spend on
-L4 (`s5`/`s6`) when you want source-body semantics or per-PR localization for
-humans. The measured numbers are in
+L4 (`source`/`full`) when you want source-body semantics or per-PR localization
+for humans. The measured numbers are in
 [Performance § scan-level cost model](../development/performance.md#scan-level-cost-model-one-cliff-at-l4).
 
 ---
 
-## 6. Honest coverage — what actually ran
+## 5. Honest coverage — what actually ran
 
-Because `S` is a *method* and `L` is *evidence*, a scan can request a deep level
-and still only reach a shallow one (clang missing, no sources, a parse error).
-abicheck never reports that as "scan failed" — every `scan` prints a
+Because `--depth` requests a level but `L` is *evidence*, a scan can request a
+deep level and still only reach a shallow one (clang missing, no sources, a parse
+error). abicheck never reports that as "scan failed" — every `scan` prints a
 coverage-annotated report stating the **L-depth it actually reached** and, for
 each disabled check, the precise input or tool to add:
 
@@ -222,13 +184,45 @@ This is the same evidence-coverage / capability report described in
 The rule is: **honest about what it had** — the verdict is only ever as strong as
 the evidence behind it.
 [case147](../examples/case147_scan_depth_ladder.md) is the worked illustration:
-the *same* input scanned at S3 (pattern only, no compiler) and at a deeper level,
-with the coverage block showing exactly what each depth proved — never a bare
-"scan failed".
+the *same* input scanned at `--depth headers` (pattern + AST, no source replay)
+and at a deeper level, with the coverage block showing exactly what each depth
+proved — never a bare "scan failed".
 
 ---
 
-_See also: [Source-Scan Levels (user guide)](../user-guide/scan-levels.md) ·
+## Appendix — deprecated scan axes (`s0…s6` and `--mode`)
+
+Earlier releases had you pick evidence in two other ways. Both still parse but
+are **deprecated (ADR-037 D5)** — they print a warning and map onto `--depth`.
+Prefer `--depth`; this table is here only for anyone migrating an old command
+line.
+
+**`--source-method s0…s6`** (the old "how it gathers evidence" axis):
+
+| Deprecated | Was | Use instead |
+|------------|-----|-------------|
+| `s0` / `s3` | diff classifier / lexical pattern scan (compiler-free) | `--depth binary` (or `headers` for +L2) |
+| `s1` | compile-DB / build-flag scan (L3) | `--depth build` |
+| `s2` | preprocessor macro/include capture | folded into `--depth build` (runs when `clang -E` + a compile DB are present) |
+| `s4` | symbol/reference index → L5 graph (no L4) | reached internally by `--depth source`; there is no user-facing graph rung (D6) |
+| `s5` | semantic AST replay of changed TUs (L4) | `--depth source` |
+| `s6` | full AST replay of all TUs (L4) | `--depth full` |
+
+**`--mode`** presets:
+
+| Deprecated | Was | Use instead |
+|------------|-----|-------------|
+| `pr` | diff-seeded L4 replay (per-PR gate) | `--depth source --since <ref>` (or just `auto` with a seed) |
+| `pr-deep` | `pr` + full L5 reachability | `--depth source` (the L5 graph is folded in) |
+| `baseline` | whole-library replay of a release | `--depth full` |
+| `audit` | intra-version hygiene lint, no baseline | the `--audit` switch |
+
+`--source-method auto` (risk-driven escalation) is now simply the default when
+you **omit** `--depth`.
+
+---
+
+_See also: [Source-Scan Depth (user guide)](../user-guide/scan-levels.md) ·
 [Evidence & Detectability](evidence-and-detectability.md) ·
 [Build Info & Sources](build-source-data.md) ·
 [Performance § scan-level cost model](../development/performance.md#scan-level-cost-model-one-cliff-at-l4)._

--- a/docs/examples/case147_scan_depth_ladder.md
+++ b/docs/examples/case147_scan_depth_ladder.md
@@ -21,21 +21,21 @@ proved and what it could not** — never a bare "scan failed".
 
 `connect()` takes `detail::SessionState&`, a private-header type.
 
-| Depth | Method | What it proves | What it cannot |
-|-------|--------|----------------|----------------|
-| **S3** | lexical pattern pre-scan (no compiler) | flags a risky construct: a public signature mentions a `detail::` name | cannot confirm the type is actually private — only a textual hint |
-| **S2** | preprocessor (if a compile DB is present) | resolves the `#include` graph | does not parse the AST |
-| **S5** | source replay + L5 source graph | **confirms** `detail::SessionState` originates in a private header and is reached from a public decl → `PRIVATE_HEADER_LEAK`, corroborated by the `source_index` provider | (the deepest answer) |
+| `--depth` | Method | What it proves | What it cannot |
+|-----------|--------|----------------|----------------|
+| **`headers`** | lexical pattern pre-scan + L2 header AST | flags a risky construct: a public signature mentions a `detail::` name | cannot confirm the type is actually private — only a textual/AST hint |
+| **`build`** | + preprocessor (if a compile DB is present) | resolves the `#include` graph | does not replay the source ABI |
+| **`source`** | + source replay + L5 source graph | **confirms** `detail::SessionState` originates in a private header and is reached from a public decl → `PRIVATE_HEADER_LEAK`, corroborated by the `source_index` provider | (the deepest answer) |
 
 The committed `snapshot.abi.json` carries the L2 header provenance **and** the L5
 source graph, so the cross-check fires with the `source_index` corroboration the
-S5 pass would add — the endpoint of the ladder.
+`--depth source` pass would add — the endpoint of the ladder.
 
 ## Reproduce the ladder
 
 ```bash
-abicheck scan --binary libdemo.so -H include/ --audit --source-method s3   # pattern only
-abicheck scan --binary libdemo.so -H include/ --audit --sources . --source-method s5  # S5 replay + graph
+abicheck scan --binary libdemo.so -H include/ --audit --depth headers   # pattern + AST
+abicheck scan --binary libdemo.so -H include/ --audit --sources . --depth source  # replay + L5 graph
 ```
 
 ## Fix

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,7 +177,7 @@ checking.
 > **A sixth code you may meet later:** the `scan` docs also use **`L5`** — the
 > source *reachability graph* abicheck **derives** from L3/L4 evidence. You
 > provide five sources (L0–L4); L5 is computed, never an input. See
-> [Scan Levels (S vs L)](concepts/scan-and-evidence-levels.md).
+> [Evidence Layers & Scan Depth](concepts/scan-and-evidence-levels.md).
 
 Run `abicheck dump libfoo.so --show-data-sources` to see which layers abicheck
 found for a binary. For the full picture see [Evidence &
@@ -299,9 +299,9 @@ By default, `abicheck compare` exits with the verdict:
 | Exit code | Verdict | Meaning |
 |-----------|---------|---------|
 | `0` | `NO_CHANGE` / `COMPATIBLE` / `COMPATIBLE_WITH_RISK` | Safe — no binary ABI break |
-| `1` | — | Tool/runtime error |
 | `2` | `API_BREAK` | Source-level API break (binary still works) |
 | `4` | `BREAKING` | Binary ABI break |
+| `64` | — | Invalid invocation (bad args/options, unreadable input) — outside the verdict space |
 
 > **Note:** passing any `--severity-*` flag (as the recipes below do) switches
 > `compare` to **severity-aware** exit codes: `0` = no error-level findings,
@@ -363,7 +363,7 @@ upload SARIF — all in a few lines of YAML:
 ```
 
 See the [GitHub Action reference](user-guide/github-action.md) for every input,
-baseline workflows, package/`compare-release` mode, and multi-platform matrices.
+baseline workflows, package/bundle compare mode, and multi-platform matrices.
 
 ### GitHub Actions — raw CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ The docs are two complementary tracks, each ordered from introductory to expert:
    compatibility is, why libraries break their consumers, and how to design
    against it. Start with the [learning series](concepts/abi-series/00-product-contract.md)
    (part 0 assumes nothing; part 7 is expert-level design guidance) and keep the
-   [129-case example encyclopedia](examples/index.md) as a catalog of real breaks.
+   [152-case example encyclopedia](examples/index.md) as a catalog of real breaks.
 2. **Use the tool** — the [User Guide](getting-started.md) takes you from install
    and first check through CI integration to specialised workflows;
    [Concepts](concepts/verdicts.md) explains how abicheck works — what a verdict

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ The docs are two complementary tracks, each ordered from introductory to expert:
    compatibility is, why libraries break their consumers, and how to design
    against it. Start with the [learning series](concepts/abi-series/00-product-contract.md)
    (part 0 assumes nothing; part 7 is expert-level design guidance) and keep the
-   [152-case example encyclopedia](examples/index.md) as a catalog of real breaks.
+   [162-case example encyclopedia](examples/index.md) as a catalog of real breaks.
 2. **Use the tool** — the [User Guide](getting-started.md) takes you from install
    and first check through CI integration to specialised workflows;
    [Concepts](concepts/verdicts.md) explains how abicheck works — what a verdict

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -15,6 +15,7 @@
 | `0` | `NO_CHANGE`, `COMPATIBLE`, or `COMPATIBLE_WITH_RISK` — no binary ABI break |
 | `2` | `API_BREAK` — source-level API break — recompilation required |
 | `4` | `BREAKING` — binary ABI break |
+| `64` | Invalid invocation — bad arguments/options or an unreadable/unrecognised input, deliberately outside the `0/2/4` verdict space |
 
 > **⚠️ Exit `0` covers `NO_CHANGE`, `COMPATIBLE`, and `COMPATIBLE_WITH_RISK`.** If your pipeline needs
 > to distinguish them (e.g. warn on deployment risk), use `--format json` and

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -2,7 +2,7 @@
 
 `abicheck` uses different exit codes for each command family.
 
-**Why they differ:** `compare` is the native interface with a wider exit code range (0/1/2/4) that distinguishes tool errors from API breaks from binary breaks. `compat` mirrors `abi-compliance-checker` exit codes (0/1/2) so existing ABICC CI scripts work without changes.
+**Why they differ:** `compare` is the native interface — `0/2/4` by verdict (or `0/1/2/4` severity-aware), with invalid invocations exiting `64` so a usage error is never mistaken for an ABI verdict. `compat` mirrors `abi-compliance-checker` exit codes (0/1/2) so existing ABICC CI scripts work without changes.
 
 ---
 
@@ -117,6 +117,24 @@ gating on: with an effective severity map, a release whose worst verdict is
 `BREAKING` can still exit `0` if that map downgrades ABI breaks (e.g.
 `abi_breaking: warning`) — parse the `verdict` from JSON output if you need
 scheme-independent CI behaviour.
+
+---
+
+## `abicheck scan`
+
+The one-shot source-intelligence scan has its own contract (it may compare
+against a `--baseline` and adds a budget guard):
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Compatible (or advisory-only findings) |
+| `2` | Source-level / API break (incl. `API_BREAK` cross-source findings) |
+| `4` | ABI break (from the `--baseline` comparison) |
+| `5` | `--budget` overflow — the time guard tripped (scope is never silently shrunk) |
+
+> Exit `5` is unique to `scan`: `--budget 15m` **fails** the run rather than
+> quietly dropping evidence. With `--estimate` (dry-run cost probe) `scan` always
+> exits `0`.
 
 ---
 
@@ -270,14 +288,17 @@ In `abicheck compat`, non-verdict failures are further classified where possible
 | `BREAKING` / `FAIL` | `4` | `4` | `4` | — | `4` | — | `1` |
 | Missing symbols | — | — | — | — | — | `2` | — |
 | Load failure | — | — | — | `1` | `4` | — | — |
-| Tool error | `2`† | `2`† | `1` | — | — | `1` | `3/4/5/6/7/8/10/11` |
+| Invalid invocation / tool error | `64`† | `64`† | `1` | — | — | `1` | `3/4/5/6/7/8/10/11` |
 
 \* Severity exit codes depend on the configuration. For example, with
 `--severity-addition error`, additions exit `1`; with `--severity-preset
 info-only`, everything exits `0`.
 
-† Click uses exit code `2` for argument/usage errors. To reliably distinguish
-verdicts from tool errors, use `--format json` and read the `verdict` field.
+† `compare` (and `appcompat`) exit `64` for an invalid invocation — bad
+arguments/options or an unreadable/unrecognised input — deliberately outside the
+`0/2/4` verdict space so a usage error is never mistaken for an ABI verdict. To
+reliably distinguish verdicts from errors in a script, use `--format json` and
+read the `verdict` field.
 
 ---
 

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -83,12 +83,12 @@ abicheck operates in **symbol-table mode**:
 ✅ **Detected:**
 - Function added / removed (`func_added`, `func_removed`)
 - SONAME changed (`soname_changed`)
-- Symbol visibility changed (`symbol_visibility_changed`)
+- Symbol visibility changed (`func_visibility_changed`)
 - Variable added / removed
 
 ❌ **Not detected** (requires type information from headers + castxml):
 - Parameter type changes (`func_params_changed`)
-- Return type changes (`func_return_type_changed`)
+- Return type changes (`func_return_changed`)
 - Struct/class layout changes (`type_size_changed`, `type_field_*`)
 - vtable changes (`type_vtable_changed`)
 - Inline/noexcept changes
@@ -156,8 +156,7 @@ jobs:
           # brew install castxml              # macOS
       - name: ABI check
         run: |
-          abicheck compare -lib mylib \
-            -old old/libmylib.so -new new/libmylib.so \
+          abicheck compare old/libmylib.so new/libmylib.so \
             -H include/
 ```
 

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -297,9 +297,9 @@ Each case in [`examples/ground_truth.json`](https://github.com/abicheck/abicheck
 carries a `min_evidence` field — the weakest source at which abicheck reaches the
 correct verdict — derived by
 [`scripts/evidence_tiers.py`](https://github.com/abicheck/abicheck/blob/main/scripts/evidence_tiers.py)
-and validated by `tests/test_evidence_tiers.py`. Aggregated over the 129-case
-catalog, that yields the cumulative coverage the `--evidence-tiers` summary
-prints:
+and validated by `tests/test_evidence_tiers.py`. Aggregated over the
+`ground_truth.json` cases, that yields the cumulative coverage the
+`--evidence-tiers` summary prints:
 
 | Source provided | Layer | Cases first detectable here | Cumulative | Representative cases |
 |-----------------|:-----:|:---------------------------:|:----------:|----------------------|

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -6,7 +6,7 @@ benchmark results across real-world test cases, and why the numbers come out the
 > **Note:** abicheck detects 268 change kinds (see [Change Kind Reference](change-kinds.md)).
 > The current cross-tool benchmark covers a pinned 74-case subset of the
 > `examples/` catalog (`case01`-`case73` + `case26b`); the full catalog now has
-> 152 cases (147 single-library cases + 5 multi-library bundle cases). The
+> 162 cases (157 single-library cases + 5 multi-library bundle cases). The
 > subset is pinned so accuracy numbers stay reproducible across releases.
 
 > **Why the tools disagree.** The accuracy gaps below are mostly an *evidence*

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -6,7 +6,7 @@ benchmark results across real-world test cases, and why the numbers come out the
 > **Note:** abicheck detects 268 change kinds (see [Change Kind Reference](change-kinds.md)).
 > The current cross-tool benchmark covers a pinned 74-case subset of the
 > `examples/` catalog (`case01`-`case73` + `case26b`); the full catalog now has
-> 134 cases (129 single-library cases + 5 multi-library bundle cases). The
+> 152 cases (147 single-library cases + 5 multi-library bundle cases). The
 > subset is pinned so accuracy numbers stay reproducible across releases.
 
 > **Why the tools disagree.** The accuracy gaps below are mostly an *evidence*

--- a/docs/user-guide/choose-your-workflow.md
+++ b/docs/user-guide/choose-your-workflow.md
@@ -30,7 +30,7 @@ command** when you need more confidence or a CI gate.
 | Stripped production binaries | `abicheck compare old.so new.so --debug-root1 old-debug --debug-root2 new-debug` (or `--debuginfod` to fetch by build-id) | Also pass public headers (`-H`) for highest confidence |
 | A CI baseline vs a fresh build | `abicheck dump libfoo.so -H include/ -o baseline.json`, then `abicheck compare baseline.json build/libfoo.so --new-header include/` | Store baselines in GitHub Releases, the repo, the Actions cache, or artifact storage — see [Baseline Management](baseline-management.md) |
 | A PR with source/build context (catch source-only & build-flag breaks) | `abicheck scan --binary build/libfoo.so -H include/ --sources . --baseline baseline.json --since origin/main` | One orchestrator over dump/compare: always-on pattern + cross-source checks plus the pinned L3/L4/L5 level — see [Source & Build Data](../concepts/build-source-data.md) and the [GitHub Action](github-action.md#source-scans-build-source-evidence) |
-| Build emits source facts in parallel (combine into one baseline) | `abicheck merge libfoo.bin.json libfoo.src.json -o baseline.json` (also ingests a Flow-2 `abicheck_inputs/` pack) | Folds independently-produced L0–L2 and L3/L4/L5 dumps into one self-contained snapshot |
+| Build emits source facts in parallel (combine into one baseline) | `abicheck merge libfoo.bin.json libfoo.src.json -o baseline.json` (also ingests a Flow B `abicheck_inputs/` pack) | Folds independently-produced L0–L2 and L3/L4/L5 dumps into one self-contained snapshot |
 | Two snapshots (offline / air-gapped) | `abicheck compare old.json new.json` | No headers/castxml/network needed — everything is baked into the snapshots |
 | Several DSOs shipped together | `abicheck compare release-1.0/ release-2.0/ -H include/` (per-library results on all platforms; the cross-library bundle/dependency-skew analysis is **Linux/ELF only**) | Add `--manifest` only for template instantiations, dlsym/plugin contracts, internal stable exports, or symbol-version promises |
 | RPM / Deb / tar / conda / wheel packages | `abicheck compare old.rpm new.rpm` | Add `--debug-info1/2` (debuginfo packages) and `--devel-pkg1/2` (header/devel packages) where available |
@@ -59,7 +59,7 @@ inputs you give it — its five additive evidence layers, **L0–L4**. More
 evidence catches more breaks. Start at the layer your artifacts allow, and add
 more when you need more confidence. (The `scan` docs also use a sixth code,
 **`L5`** — the source graph abicheck *derives* from L3/L4; you never provide it.
-See [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md).) For a
+See [Evidence Layers & Scan Depth](../concepts/scan-and-evidence-levels.md).) For a
 concrete, side-by-side look at *what each layer actually sees* on one example —
 and where each one goes blind — see the
 [level-by-level walk-through](../concepts/abi-api-handling.md#what-each-level-actually-sees-a-level-by-level-walk-through).

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -676,9 +676,10 @@ The parser handles the full Debian symbols tag syntax:
 ## High-level architecture
 
 ```text
-CLI
+CLI  (core commands; see `abicheck --help` for the full list)
   dump                         — dump ABI snapshot to JSON
-  compare                      — compare two ABI surfaces
+  compare                      — compare two ABI surfaces (also directory/package inputs)
+  scan                         — one-shot source-intelligence scan (dump + compare + evidence)
   deps tree                    — show dependency tree + binding status (Linux ELF)
   deps compare                 — full-stack comparison across environments (Linux ELF)
   debian-symbols generate      — generate Debian symbols file from shared library

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -319,9 +319,10 @@ base ref is available.
 
 ### Pin the scan depth
 
-Left unpinned, `scan` resolves the depth automatically (`auto`: risk-driven with
-a `since:` seed, else a sensible default). Pin a precise level for reproducible CI
-with the single `depth` dial:
+The Action's `scan-mode` input still defaults to `pr` (a deprecated alias), so an
+unset `depth` currently runs the `pr` preset **and emits a deprecation warning** —
+it is not the CLI's `auto`. Pin the modern `depth` dial for reproducible CI (and to
+silence the warning); the raw CLI resolves `auto` only when nothing is passed:
 
 ```yaml
       - uses: abicheck/abicheck@v0.3.0

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -74,7 +74,7 @@ automatically, then runs ABI comparison and reports results.
 | Input | Default | Description |
 |-------|---------|-------------|
 | `lang` | `c++` | Language mode for the header backend: `c++` or `c` |
-| `ast-frontend` | `castxml` (`auto`) | L2 header-AST frontend (compare/dump modes): `auto`, `castxml`, or `clang` (`clang -ast-dump=json`, for clang-only hosts). `auto` falls back to clang on a castxml toolchain error. Same as `ABICHECK_AST_FRONTEND`. |
+| `ast-frontend` | `auto` (resolves to castxml when present) | L2 header-AST frontend (compare/dump modes): `auto`, `castxml`, or `clang` (`clang -ast-dump=json`, for clang-only hosts). `auto` falls back to clang on a castxml toolchain error. Same as `ABICHECK_AST_FRONTEND`. |
 | `gcc-path` | — | Path to cross-compiler binary (dump mode only) |
 | `gcc-prefix` | — | Cross-toolchain prefix, e.g. `aarch64-linux-gnu-` (dump mode only) |
 | `gcc-options` | — | Extra flags for castxml (dump mode only) |
@@ -108,8 +108,8 @@ scan degrades gracefully and L0–L2 stay authoritative.
 | `allow-build-query` | scan, dump | **Deprecated, ignored.** Build queries now run automatically when `sources` is given; kept as a no-op for backward compatibility. |
 | `depth` | scan, dump | Evidence-depth dial: `binary`, `headers`, `build`, `source`, or `full`. Maps to `--depth`. (scan can also derive this from the level inputs below.) |
 | `baseline` | scan | Previous build's dump/library to compare against (or use `abi-baseline` to auto-fetch one). |
-| `scan-mode` | scan | Fixed `(L,S)` preset: `pr` (default), `pr-deep`, `baseline`, `audit`. |
-| `source-method` | scan | Precise S-axis: `s0`…`s6`, or `auto` (risk-driven, opt-in). |
+| `scan-mode` | scan | **Deprecated alias of `depth`** (ADR-037 D5): `pr`, `pr-deep`, `baseline`, `audit`. Prefer `depth` (or `audit`); this input still defaults to `pr` and emits a deprecation warning. |
+| `source-method` | scan | **Deprecated alias of `depth`** (ADR-037 D5): the `s0`…`s6` axis, or `auto`. Prefer `depth`; emits a deprecation warning when set. |
 | `since` | scan | Focus the scan on files changed vs a git ref (e.g. `origin/main`). |
 | `changed-path` | scan | Changed path(s) to focus on (space-separated; alternative to `since`). |
 | `budget` | scan | Time guard (e.g. `15m`). The step **fails** on overflow (`verdict: BUDGET_OVERFLOW`) — a budget never silently shrinks scope. |
@@ -117,7 +117,7 @@ scan degrades gracefully and L0–L2 stay authoritative.
 | `estimate` | scan | Dry-run: print projected per-layer cost and scan nothing (always exits 0). |
 | `crosscheck` | scan | Per-check severity overrides `KEY=LEVEL` (`off`/`info`/`warning`/`error`), space-separated. Promoting a check to `=error` makes a finding for it exit `2` (the API_BREAK tier); pair with `fail-on-api-break: true` to gate the step. |
 | `risk-rules` | scan | Path to a YAML file overriding the `risk_rules` profile. |
-| `merge-inputs` | merge | Space-separated `.abi.json` dumps and/or a Flow-2 `abicheck_inputs/` pack directory to combine. |
+| `merge-inputs` | merge | Space-separated `.abi.json` dumps and/or a Flow B `abicheck_inputs/` pack directory to combine. |
 | `on-conflict` | merge | `warn` (default, first-wins + diagnostic) or `error` (exit non-zero) when two inputs supply the same layer with differing facts. |
 
 !!! note "format in scan mode"
@@ -319,8 +319,9 @@ base ref is available.
 
 ### Pin the scan depth
 
-By default `scan` runs the `pr` preset. Pin a precise level for reproducible CI
-with `source-method` (S-axis) or the coarser `depth` (L-axis):
+Left unpinned, `scan` resolves the depth automatically (`auto`: risk-driven with
+a `since:` seed, else a sensible default). Pin a precise level for reproducible CI
+with the single `depth` dial:
 
 ```yaml
       - uses: abicheck/abicheck@v0.3.0
@@ -330,17 +331,25 @@ with `source-method` (S-axis) or the coarser `depth` (L-axis):
           new-header: include/
           sources: .
           baseline: abi-baseline.json
-          source-method: s5     # full source-ABI replay (deterministic)
+          depth: source         # source-ABI replay of changed TUs (deterministic)
+          since: origin/main    # scope the L4 replay to the PR's changed TUs
           budget: 15m           # fail (BUDGET_OVERFLOW) rather than overrun
 ```
 
 | Want… | Set |
 |-------|-----|
 | Cheap build-flag drift only (L3) | `depth: build` |
-| Source semantics on changed TUs | `source-method: s4` + `since:` |
-| Full source-ABI replay | `source-method: s5` |
-| Source graph / localization (L5) | `source-method: s4` or `scan-mode: pr-deep` |
-| Risk-driven (dev/local, opt-in) | `source-method: auto` + `since:` |
+| Source semantics on changed TUs (+ L5 graph) | `depth: source` + `since:` |
+| Full source-ABI replay of the whole library | `depth: full` |
+| Risk-driven (dev/local, opt-in) | omit `depth` (→ `auto`) + `since:` |
+
+!!! note "`scan-mode`/`source-method` are deprecated (ADR-037 D5)"
+    The older `scan-mode` (`pr`/`pr-deep`/`baseline`/`audit`) and `source-method`
+    (`s0…s6`) inputs still work but map onto `depth` and print a deprecation
+    warning. `scan-mode` currently defaults to `pr`, so leaving both new inputs
+    unset still emits that warning — set `depth` (or `audit: 'true'`) to pin the
+    modern dial. The mapping is in the
+    [Deprecated axes appendix](../concepts/scan-and-evidence-levels.md#appendix-deprecated-scan-axes-s0s6-and-mode).
 
 ### Single-release audit (no baseline)
 
@@ -370,7 +379,7 @@ for a large repo:
           new-library: build/libfoo.so
           new-header: include/
           sources: .
-          source-method: s5
+          depth: source
           estimate: 'true'
 ```
 

--- a/docs/user-guide/mcp-integration.md
+++ b/docs/user-guide/mcp-integration.md
@@ -323,9 +323,9 @@ without running any compiler or parsing any binary. Use it to pick a
 | `include_dirs` | string[] | no | Extra include directories |
 | `sources` | string | no | Source tree (compile DB auto-discovered within it) |
 | `compile_db` | string | no | Explicit `compile_commands.json` (else discovered in `sources`) |
-| `mode` | string | no | Fixed (L,S) preset: `"pr"` (default), `"pr-deep"`, `"baseline"`, `"audit"` |
-| `source_method` | string | no | Precise S-axis level (`s0`…`s6` or `auto`); omit for the mode preset |
-| `depth` | string | no | Coarse L-axis selector: `binary`, `headers`, `build`, `source`, `full` |
+| `depth` | string | no | The evidence dial: `binary`, `headers`, `build`, `source`, `full`; omit for `auto` |
+| `mode` | string | no | Preset (`"pr"` default, `"pr-deep"`, `"baseline"`, `"audit"`). Deprecated alias of `depth` on the CLI (ADR-037 D5) |
+| `source_method` | string | no | **Deprecated alias of `depth`** (ADR-037 D5): the `s0`…`s6` axis, or `auto` |
 | `changed_paths` | string[] | no | Changed-path set for the focused replay-scope estimate |
 
 **Response fields:** `mode`, `estimate` (per-layer cost rows), and
@@ -340,8 +340,8 @@ tier (compiler-free pattern pre-scan + intra-version cross-source checks) → th
 pinned evidence level — and, when `baseline` is given, a compare against it.
 Returns one coverage-/confidence-annotated scan result. The authority rule is
 preserved: source/cross-source findings are `RISK`/`API_BREAK` only, never
-`BREAKING` on their own. See [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md)
-for the `mode`/`source_method`/`depth` model.
+`BREAKING` on their own. See [Evidence Layers & Scan Depth](../concepts/scan-and-evidence-levels.md)
+for the `depth` model (`mode`/`source_method` are deprecated aliases).
 
 **Parameters:**
 
@@ -353,10 +353,10 @@ for the `mode`/`source_method`/`depth` model.
 | `public_header_dirs` | string[] | no | Directories whose headers are public; establishes the public/internal boundary so the leakage/RTTI/exported-vs-public cross-checks run instead of skipping. Must be existing directories |
 | `sources` | string | no | Source tree (compile DB auto-discovered within it) |
 | `compile_db` | string | no | Explicit `compile_commands.json` (else discovered in `sources`) |
-| `baseline` | string | no | Previous build's dump/library to compare against. Omit for a single-release run; use `mode="audit"` for the hygiene catalog |
-| `mode` | string | no | Fixed (L,S) preset: `"pr"` (default), `"pr-deep"`, `"baseline"`, `"audit"` |
-| `source_method` | string | no | Precise S-axis level (`s0`…`s6` or `auto`); omit for the mode preset |
-| `depth` | string | no | Coarse L-axis selector: `binary`, `headers`, `build`, `source`, `full` |
+| `baseline` | string | no | Previous build's dump/library to compare against. Omit for a single-release run; pass `mode="audit"` for the hygiene catalog (the MCP tool has no `--audit` switch of its own) |
+| `depth` | string | no | The evidence dial: `binary`, `headers`, `build`, `source`, `full`; omit for `auto` |
+| `mode` | string | no | Preset (`"pr"` default, `"pr-deep"`, `"baseline"`, `"audit"`). Deprecated alias of `depth` on the CLI (ADR-037 D5); still the way to select the audit lint via MCP |
+| `source_method` | string | no | **Deprecated alias of `depth`** (ADR-037 D5): the `s0`…`s6` axis, or `auto` |
 | `changed_paths` | string[] | no | Changed-path set focusing the scan |
 | `language` | string | no | `"c++"` (default) or `"c"` |
 

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -10,7 +10,7 @@ evidence. For what the layers mean, see
 worked example of the concrete L4/L5 data these producers yield (and what the
 lower levels miss), see the
 [level-by-level walk-through](../concepts/abi-api-handling.md#what-each-level-actually-sees-a-level-by-level-walk-through).
-For how a scan *consumes* it, see [Source-scan levels](scan-levels.md).
+For how a scan *consumes* it, see [Source-scan depth](scan-levels.md).
 
 Whichever producer you pick, the **output contract is identical** — an
 `abicheck_inputs/` pack (or an inline `--sources` collection) that

--- a/docs/user-guide/real-world-example.md
+++ b/docs/user-guide/real-world-example.md
@@ -155,7 +155,7 @@ reuse a `compile:` block).
     with.
 
 Every field and the CLI-vs-config precedence are in
-[Source-Scan Levels](scan-levels.md#where-each-setting-belongs-cli-vs-config).
+[Source-Scan Depth](scan-levels.md#where-each-setting-belongs-cli-vs-config).
 
 ---
 
@@ -182,8 +182,8 @@ abicheck scan --binary build/libfoo.so -H include/ --sources . --since origin/ma
     query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
   ```
 - `--since origin/main` (or `--changed-path …`) — which files changed, so it
-  replays only the changed translation units. Without a seed, `s5` falls back to
-  a headers-only replay.
+  replays only the changed translation units. Without a seed, `--depth source`
+  falls back to a headers-only replay.
 
 !!! note "Cross-release body-change diff needs a source-aware baseline"
     The inline/template/macro/default-argument **body**-change comparison runs
@@ -196,8 +196,8 @@ The depth knob is `--depth {binary,headers,build,source,full}` (`binary` =
 binary-only, up to `full` = whole-library replay); leave it off and abicheck
 **auto**-picks by changed-path risk. **How each depth works, how to produce a
 compile database for `make`/`cmake`/`bazel`/`meson`, and the per-level input
-table live in [Source-Scan Levels](scan-levels.md)** — that's the home for the
-build-system details (and the precise `--source-method s0…s6` expert axis), kept
+table live in [Source-Scan Depth](scan-levels.md)** — that's the home for the
+build-system details (and the deprecated `--source-method s0…s6` axis), kept
 out of this walkthrough on purpose.
 
 ---
@@ -313,6 +313,6 @@ Other formats — **HTML**, SARIF, JUnit — are in [Output Formats](output-form
    as a CI gate).
 3. **Go deeper** (recommended) with `abicheck scan --sources . --since … --depth source`
    when you can give it your sources and build command — see
-   [Source-Scan Levels](scan-levels.md).
+   [Source-Scan Depth](scan-levels.md).
 4. **Read** the verdict + confidence: headers give a high-confidence,
    public-API-scoped result that names the changes that matter.

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -1,13 +1,13 @@
-# Source-scan levels (`abicheck scan`)
+# Source-scan depth (`abicheck scan`)
 
 `abicheck scan` is the one-shot orchestrator over `dump`/`compare`: it classifies
 the changed paths, runs the always-on compiler-free pattern pre-scan, then runs a
-**pinned evidence level** and (with `--baseline`) compares against it.
+**pinned evidence depth** and (with `--baseline`) compares against it.
 
 !!! tip "First time here? Read the model, then the flags."
-    The `s0…s6`, `L0…L5`, `--mode`, and `--depth` knobs name **two different
-    axes** (`S` = the method, `L` = the evidence) plus presets over them. If they
-    look like they overlap, read [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md)
+    `--depth` selects how far down a fixed ladder of **evidence layers**
+    (`L0`–`L5`) the scan collects. If the dial and the layers look like they
+    overlap, read [Evidence Layers & Scan Depth](../concepts/scan-and-evidence-levels.md)
     for the mental model first — this page is the practical flag reference and the
     [worked examples](#worked-examples) below. To *see the actual data* each level
     (L0→L5) extracts on one running example, and where each goes blind, read the
@@ -29,87 +29,75 @@ the changed paths, runs the always-on compiler-free pattern pre-scan, then runs 
     nothing to collect L3/L4/L5 from. Pass the evidence, or use the default `auto`
     for a best-effort binary scan. (The `auto` default never errors this way.)
 
-??? note "Expert axes (`--source-method`, `--mode`) — deprecated aliases"
-    The precise **S-axis** (`--source-method s0…s6`, the technique) and the
-    **`--mode pr|pr-deep|baseline|audit`** presets still work but are now hidden,
-    **deprecated** aliases (they warn and map onto `--depth`) for one release.
-    Prefer `--depth`. The `s0…s6` / `L0…L5` model is still the spine — see
-    [Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md) for the mental
-    model; `--depth` is its friendly façade. (`--depth symbols` was renamed to
-    `--depth binary`; `symbols` keeps working as a warned alias.)
+??? note "Migrating from `--source-method`/`--mode`? (deprecated aliases)"
+    Earlier releases exposed a precise `--source-method s0…s6` axis and
+    `--mode pr|pr-deep|baseline|audit` presets. Both still parse but are now
+    **hidden, deprecated aliases** (they print a warning and map onto `--depth`).
+    Prefer `--depth`. The mapping table is in the
+    [Deprecated axes appendix](../concepts/scan-and-evidence-levels.md#appendix-deprecated-scan-axes-s0s6-and-mode).
+    (`--depth symbols` was renamed to `--depth binary`; `symbols` keeps working as
+    a warned alias.)
 
-## What each level reaches
+## What each depth reaches
 
-| Level | Technique | Evidence reached |
-|-------|-----------|------------------|
-| `s0` | diff classifier (risk tags) | L0/L1 binary + DWARF + always-on pattern scan |
-| `s1` | compile-DB / build-flag scan | + **L3** build context |
-| `s2` | preprocessor (macros/includes) | conditional S2 tier over L3 (`clang -E` macro/include capture) |
-| `s3` | lexical pattern scan | pattern facts only (same always-on scan) |
-| `s4` | symbol / reference index | + L3 + **L5** source graph (no L4) |
-| `s5` | targeted semantic AST (changed TUs) | + **L4** source-ABI replay + L5 edges |
-| `s6` | full AST (all TUs) | + L4 over the whole library |
+| `--depth` | Reaches | Needs |
+|-----------|---------|-------|
+| `binary` | L0/L1 exported symbols + binary metadata + debug-info *presence* + always-on pattern scan | just the artifact(s) |
+| `headers` | + **L2** header AST (the public/internal boundary) | a public-header directory + a C/C++ frontend |
+| `build` | + **L3** build context (flag/toolchain drift) | a compile DB / build dir |
+| `source` | + **L4** source-ABI replay of changed TUs + the **L5** graph | sources **and** `clang` (+ a diff seed to scope it) |
+| `full` | **L4** over the whole library | sources **and** `clang` |
 
-### What each method does, in plain terms
+### What each depth does, in plain terms
 
-- **`s0` — binary diff (the always-available floor).** Compares the two
-  binaries' exported symbols, SONAME, and dependencies (plus DWARF types if the
-  build ships them), and runs a compiler-free pattern pre-scan. Needs only the
-  two artifacts — no source, no build. It is worth naming because the **default
-  is not binary-only**: `--mode pr` is `s5`, so `s0` (or `--depth binary`) is how
-  you deliberately **opt out** of source analysis — a fast gate, or when no
-  sources/compile DB are available — and pin that choice reproducibly.
-- **`s1` — build context.** Reads a compile database to see the flags each
+- **`binary` — the always-available floor.** Compares the two binaries' exported
+  symbols, SONAME, and dependencies, and runs a compiler-free pattern pre-scan.
+  Needs only the two artifacts — no source, no build, no compiler. It is the
+  deliberate way to **opt out** of source analysis: a fast gate, or when no
+  sources/compile DB are available. It skips the deep DWARF type walk and the L2
+  AST.
+- **`headers` — the header API surface.** Adds the L2 header AST, which
+  establishes the **public/internal boundary** — so an internal-symbol removal
+  (compatible) is told apart from a public one (breaking). Needs a public-header
+  directory (`-H`/`--headers`) and a C/C++ frontend (`castxml` or `clang`).
+- **`build` — build context.** Reads a compile database to see the flags each
   translation unit was built with, so it can flag `-fvisibility`/`-D`/standard or
-  toolchain **drift** between the two builds. Needs a compile DB.
-- **`s2` — preprocessor.** Runs `clang -E` to capture macro *values* and the
-  include graph — catches macro-value changes, include divergence, and
-  private/generated-header leaks. Needs a compile DB.
-- **`s3` — lexical pattern scan.** A pure text/regex pass over the sources (no
-  compiler) — the same always-on pattern facts `s0` already runs, pinned as a
-  level. The cheapest source-aware option.
-- **`s4` — reference graph.** Builds a source→symbol reachability graph — *which
-  public exports reach a changed internal declaration*. Needs a compile DB; no
-  semantic replay (no L4).
-- **`s5` — semantic replay of changed TUs (the `pr` default).** Re-parses the
-  *changed* translation units with `clang` and replays their ABI — the only level
-  that sees inline / template / macro / default-argument / `constexpr` **body**
-  changes. Needs a compile DB, the source checkout (`--sources`), and a diff seed
+  toolchain **drift** between the two builds, plus (when `clang -E` is available)
+  macro-value and include-graph divergence. Needs a compile DB / build dir.
+- **`source` — semantic replay of changed TUs (the diff-seeded default).**
+  Re-parses the *changed* translation units with `clang` and replays their ABI —
+  the only depth that sees inline / template / macro / default-argument /
+  `constexpr` **body** changes, and it folds the L5 reachability graph. Needs a
+  compile DB, the source checkout (`--sources`), and a diff seed
   (`--since`/`--changed-path`); without a seed it falls back to a headers-only
-  replay.
-- **`s6` — full semantic replay.** Like `s5` but over the **whole** library, not
-  just the changed TUs — the most thorough and the most expensive (the one real
-  cost cliff). Used by `--mode baseline`.
+  replay and emits an advisory.
+- **`full` — full semantic replay.** Like `source` but over the **whole**
+  library, not just the changed TUs — the most thorough and the most expensive
+  (the one real cost cliff). Use it for an amortized release baseline.
 
-`--mode` presets: `pr` = `(s5, source)`, `pr-deep` = `(s5, graph)` (full L5
-reachability), `baseline` = `(s6, full)`, `audit` = `(s5, source)` intra-version
-(single-build hygiene, no baseline).
+## What input each depth needs — and how to get it
 
-## What input each use case needs — and how to get it
-
-Every level needs a specific **input**; without it the matching coverage row is
+Every depth needs a specific **input**; without it the matching coverage row is
 `not_collected` (the scan never silently pretends it ran). Pick the row that
 matches your goal, then supply the input named in column 3.
 
-| Goal (use case) | Level | Input you must provide | How to obtain it | If the input is missing |
+| Goal (use case) | `--depth` | Input you must provide | How to obtain it | If the input is missing |
 |---|---|---|---|---|
-| Binary-only ABI gate (removed/changed exports; no-DWARF vtable/RTTI size) | `--depth binary` (`s0`) | two `.so` (or `.abi.json`) | release artifacts / conda / `.deb` | always available (L0/L1) |
-| Header-aware API surface + internal-vs-public scoping + cross-source checks | L2 (intrinsic, with `-H`) | a public-header **directory** + a C/C++ frontend | `-H include/ --public-header-dir include/`; `castxml` **or** `clang` on `PATH` | a lone `-H file.h` does not establish a boundary → provenance/cross-checks stay dormant |
-| Build-flag / toolchain / visibility drift | `s1` / `--depth build` | an L3 compile database | `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` (configure-only), `meson setup`, `bazel aquery --output=jsonproto`, or `bear -- make`; pass via `--build-info`/`--compile-db` | L3 `not_collected`; the scan advises the exact remedy |
-| Macro-value / include divergence; private/generated-header leaks | `s2` | L3 compile DB + `clang -E` | same as `s1` (the `-E` pass needs the TU's full flag set) | preprocessor tier skipped (coverage row, not a pass) |
-| Source→symbol reachability graph (which exports reach a changed internal decl) | `s4` / `--source-method s4` | L3 compile DB | same as `s1` | L5 `not_collected` (no L4 replay either); reach it via `--source-method s4` (there is no user-facing `--depth` rung for the graph) |
-| Semantic source-ABI replay of changed TUs (macro/default-arg/inline/template/constexpr **body** changes) | `s5` / `--depth source` / `--mode pr` | L3 compile DB + source checkout + `clang` + generated headers present | configure for the DB; **codegen/partial build** for generated headers; seed with `--since`/`--changed-path` | without a seed, `s5` falls back to a headers-only public-API replay and emits an advisory (not a full per-TU replay); missing generated headers → L4 `partial` |
-| Full-library source replay | `s6` / `--depth full` / `--mode baseline` | as `s5`, whole library | amortized baseline build | expensive — the one cost cliff is at L4 |
-| Single-build hygiene lint (accidental exports, leaks, unversioned/RTTI) | `--audit` (no baseline) | binary + public-header **dir** (+ optional L3/L4) | as above | `header_build_context_mismatch` needs L3; `odr_type_variant` needs L4 |
+| Binary-only ABI gate (removed/changed exports; no-DWARF vtable/RTTI size) | `binary` | two `.so` (or `.abi.json`) | release artifacts / conda / `.deb` | always available (L0/L1) |
+| Header-aware API surface + internal-vs-public scoping + cross-source checks | `headers` | a public-header **directory** + a C/C++ frontend | `-H include/ --public-header-dir include/`; `castxml` **or** `clang` on `PATH` | a lone `-H file.h` does not establish a boundary → provenance/cross-checks stay dormant |
+| Build-flag / toolchain / visibility drift (+ macro/include divergence) | `build` | an L3 compile database | `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` (configure-only), `meson setup`, `bazel aquery --output=jsonproto`, or `bear -- make`; pass via `--build-info`/`--compile-db` | L3 `not_collected`; the scan advises the exact remedy |
+| Semantic source-ABI replay of changed TUs (macro/default-arg/inline/template/constexpr **body** changes) + L5 graph | `source` | L3 compile DB + source checkout + `clang` + generated headers present | configure for the DB; **codegen/partial build** for generated headers; seed with `--since`/`--changed-path` | without a seed, `source` falls back to a headers-only public-API replay and emits an advisory (not a full per-TU replay); missing generated headers → L4 `partial` |
+| Full-library source replay | `full` | as `source`, whole library | amortized baseline build | expensive — the one cost cliff is at L4 |
+| Single-build hygiene lint (accidental exports, leaks, unversioned/RTTI) | `--audit` (any depth) | binary + public-header **dir** (+ optional L3/L4) | as above | `header_build_context_mismatch` needs L3; `odr_type_variant` needs L4 |
 
 ### Obtaining a compile database without a full build
 
-The L3+ levels need a `compile_commands.json`; a pristine checkout has none.
+The L3+ depths need a `compile_commands.json`; a pristine checkout has none.
 Generate one — none of these compiles the library, they only configure / query
 the build graph:
 
 ```bash
-# CMake: configure-only (s5/s6 also need --sources . and a diff seed --since)
+# CMake: configure-only (source/full also need --sources . and a diff seed --since)
 cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 abicheck scan --binary new/libfoo.so -H include/ --build-info build --depth source …
 
@@ -140,8 +128,8 @@ When a source-level depth needs build evidence and no compile DB exists,
 itself** for CMake (`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`), Bazel
 (`bazel aquery`), and Make (`make -B -n -k -w`) — no flag, no manual build step.
 The old `--allow-build-query` flag is no longer needed for `--sources`-driven
-auto-querying: asking for a source-level scan *is* the request to collect build
-evidence.
+auto-querying (it is now a deprecated no-op): asking for a source-level scan *is*
+the request to collect build evidence.
 
 Make is queried with a fixed dry-run command (`make -B -n -k -w`) and the transcript
 is scraped as reduced-confidence L3 evidence. This lets Make/EPICS-style projects
@@ -165,7 +153,7 @@ build:
 
 ```bash
 abicheck scan --binary new/libfoo.so -H include/ --sources . \
-  --config .abicheck.yml --source-method s5 --baseline old/libfoo.abi.json
+  --config .abicheck.yml --depth source --baseline old/libfoo.abi.json
 ```
 
 ## Compile context for header parsing (L2)
@@ -242,16 +230,16 @@ a bare `scan -H include/` finds libstdc++ without extra flags. Disable it with
 
 ## Worked examples
 
-Each example shows the command, what level it pins, and what to read in the
+Each example shows the command, what depth it pins, and what to read in the
 output. Every `scan` ends with a coverage block — always read it before trusting
 the verdict (see [Reading the coverage block](#reading-the-coverage-block)).
 
-### PR gate (the default) — diff-seeded `s5`
+### PR gate (the default) — diff-seeded `source`
 
 The common CI case: gate a PR by comparing the just-built library against the
 baseline from `main`, scoping the expensive L4 replay to the files the PR
-touched. The `--since` seed is what makes `pr` cheaper than a full `baseline`
-scan — without it, `s5` replays every TU.
+touched. The `--since` seed is what keeps this cheaper than a full `full` scan —
+without it, `source` replays every TU.
 
 ```bash
 abicheck scan \
@@ -260,10 +248,11 @@ abicheck scan \
   --baseline artifacts/libfoo-main.abi.json
 ```
 
-- **Level:** `--mode pr` (the default) = `(s5, source)`.
+- **Depth:** `auto` with a diff seed resolves to `source` (`--depth source`); pin
+  it explicitly if you want a fixed rung.
 - **Exit code:** `0` compatible, `2` source/API break, `4` ABI break (from the
   baseline compare), `5` `--budget` overflow.
-- Add `--mode pr-deep` to also fold the full L5 reachability graph when you want
+- `--depth source` already folds the full L5 reachability graph when you want
   cross-symbol impact in the report.
 
 ### Single-build audit — no baseline
@@ -297,9 +286,8 @@ abicheck scan --binary libfoo.so --headers include/ \
   --build-info build/compile_commands.json --audit
 ```
 
-This is `(s5, source)` run intra-version; it reports the eight ADR-035
-cross-source / single-release findings rather than a two-version diff. The
-flagship cross-source cases —
+This reports the eight ADR-035 cross-source / single-release findings rather than
+a two-version diff. The flagship cross-source cases —
 [case148](../examples/case148_xcheck_header_build_mismatch.md)
 (`header_build_context_mismatch`, L2 macros ↔ L3 flags) and
 [case149](../examples/case149_xcheck_odr_variant.md) (`odr_type_variant`, L4
@@ -309,15 +297,15 @@ source and resolve only by crosschecking two.
 ### Cheap gate — no compiler, no sources
 
 When you only have the two binaries (or want a fast pre-check), pin a cheap
-level. `--depth build` (`s1`) adds build-flag/toolchain drift, but only when you
-also give it a build input to read — a compile DB or build dir via
+depth. `--depth build` adds build-flag/toolchain drift, but only when you also
+give it a build input to read — a compile DB or build dir via
 `--build-info`/`--compile-db` (or a `--sources` tree); without one, L3 is
 reported `not_collected` and no drift is checked. `--depth binary` stays on the
 exported-symbol surface (L0) plus cheap debug-info *presence* and the always-on
 pattern scan — it skips the deep DWARF type walk, so no compiler, headers, or
-sources are needed (and no L1 layout evidence is collected). (`--depth headers`
-is the next rung up: it adds the L2 header AST, which needs a header directory
-via `--headers` and a C/C++ frontend on `PATH`.)
+sources are needed. (`--depth headers` is the next rung up: it adds the L2 header
+AST, which needs a header directory via `--headers` and a C/C++ frontend on
+`PATH`.)
 
 ```bash
 # build-flag drift only, flat ~0.3–0.5s regardless of project size
@@ -337,10 +325,10 @@ replay cost first. `--estimate` is a dry run: it prints the projected per-layer
 cost for *this* project and scans nothing.
 
 ```bash
-abicheck scan --binary libfoo.so --sources . --mode pr --estimate
+abicheck scan --binary libfoo.so --sources . --depth source --estimate
 ```
 
-### Release baseline — full `s6`
+### Release baseline — full `full`
 
 The reusable `--baseline` that PR scans compare against is a **`dump`-produced
 snapshot**, not a scan report. `scan -o` writes the rendered scan report (text or
@@ -361,29 +349,29 @@ abicheck scan --binary build/libfoo.so --headers include/ \
 
 To get a full-depth scan *report* of a release (replays every TU, folds the full
 graph) for human review — as opposed to the reusable baseline above — run
-`scan --mode baseline` and send its report to `-o`:
+`scan --depth full` and send its report to `-o`:
 
 ```bash
 abicheck scan --binary build/libfoo.so --headers include/ \
-  --sources . --mode baseline -o artifacts/libfoo-1.0-scan.json
+  --sources . --depth full -o artifacts/libfoo-1.0-scan.json
 ```
 
-### Let risk pick the depth — `--source-method auto` (local/dev only)
+### Let risk pick the depth — `auto` (local/dev only)
 
-`auto` reads the risk of the changed paths and picks an S-method (capped at
-`s5`). It is opt-in and **never** fires for a pinned CI level — keep CI on a
-fixed `--mode`/`--source-method` for reproducibility.
+Omit `--depth` and, when a diff seed is present, `auto` reads the risk of the
+changed paths and picks a depth. It is the default and **never** overrides a
+pinned depth — keep CI on a fixed `--depth` for reproducibility.
 
 ```bash
-abicheck scan --binary new.so -H include/ --source-method auto --since origin/main
+abicheck scan --binary new.so -H include/ --since origin/main
 ```
 
 ### Reading the coverage block
 
-`S` is a *method* and `L` is *evidence*, so a scan can request a deep level and
-only reach a shallow one (clang missing, no sources, a parse error). `scan` never
-reports that as "failed" — it states the depth it **actually reached** and, for
-each disabled check, the input or tool to add:
+`--depth` requests a level but `L` is *evidence*, so a scan can request a deep
+level and only reach a shallow one (clang missing, no sources, a parse error).
+`scan` never reports that as "failed" — it states the depth it **actually
+reached** and, for each disabled check, the input or tool to add:
 
 ```text
 Checks enabled for this scan (and why others are not):
@@ -398,35 +386,34 @@ An `[off]` line is the precise input to add (here: install clang and pass
 [Build Info & Sources § Evidence coverage](../concepts/build-source-data.md#evidence-coverage)
 for the full coverage and capability report.
 [case147](../examples/case147_scan_depth_ladder.md) is the legibility anchor:
-the *same* input scanned at S3 (pattern only), then deeper, with the coverage
-block showing exactly what each depth proved and what it could not.
+the *same* input scanned at `--depth headers` (pattern + AST), then deeper, with
+the coverage block showing exactly what each depth proved and what it could not.
 
 ## Cost guide (rules of thumb)
 
 Measured on two UXL libraries (full data: `validation/`):
 
-| Tier | Levels | Relative cost |
+| Tier | Depths | Relative cost |
 |------|--------|---------------|
-| **Cheap** | `s0`–`s4` | One price — dominated by the binary dump + lexical scan, *not* the source layer. |
-| **Expensive** | `s5`, `s6`, and the `pr`/`pr-deep`/`baseline`/`audit` modes | clang per-TU AST replay (L4). |
+| **Cheap** | `binary`, `headers`, `build` | One price — dominated by the binary dump + lexical scan, *not* the source layer. |
+| **Expensive** | `source`, `full` | clang per-TU AST replay (L4). |
 
-- **The cliff is at L4 (`s4`→`s5`), and its height tracks C++ complexity.** L4
-  cost scales with template/STL instantiation depth, not `.so`/TU count — a
-  heavy-C++ library can be ~7× slower at `s5` than `s4`, while a plain-C library
-  is barely affected (~1.3×).
-- **Choose a cheap level by coverage, not cost.** `s0` ≈ `s3` (binary + pattern
-  only); `s1` adds L3 build context; **`s4` adds the L5 reachability graph
-  without paying for L4** — the best cheap level when you want impact/call
-  structure.
-- **`s5`/`pr` is only cheaper than `s6` if you give it a diff seed.** Without
+- **The cliff is at L4 (`build`→`source`), and its height tracks C++ complexity.**
+  L4 cost scales with template/STL instantiation depth, not `.so`/TU count — a
+  heavy-C++ library can be ~7× slower at `source` than `build`, while a plain-C
+  library is barely affected (~1.3×).
+- **Choose a cheap depth by coverage, not cost.** `binary` (symbols + pattern
+  only); `headers` adds the L2 API surface; `build` adds L3 build context.
+- **`source` is only cheaper than `full` if you give it a diff seed.** Without
   `--since <ref>` or `--changed-path <file>`, the changed-TU set is empty and
-  `s5` replays every TU — the same cost as `s6`. With a real PR diff, `s5`
-  scopes L4 to the touched TUs and can be **an order of magnitude faster** for
-  the identical verdict. Always pass `--since`/`--changed-path` in PR CI.
+  `source` replays every TU — the same cost as `full`. With a real PR diff,
+  `source` scopes L4 to the touched TUs and can be **an order of magnitude
+  faster** for the identical verdict. Always pass `--since`/`--changed-path` in
+  PR CI.
 - **The verdict usually does not change with depth** — the binary diff sets the
   gate; L3–L5 add localization/explanation. For a pass/fail **gate**, the cheap
-  tier is enough; spend on L4 (`s5`/`s6`) when you want source-body semantics or
-  per-PR localization for humans.
+  tier is enough; spend on L4 (`source`/`full`) when you want source-body
+  semantics or per-PR localization for humans.
 
 See [Comparison Performance](../development/performance.md#scan-level-cost-model-one-cliff-at-l4)
 for the measured numbers.

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -75,6 +75,25 @@ the changed paths, runs the always-on compiler-free pattern pre-scan, then runs 
   library, not just the changed TUs — the most thorough and the most expensive
   (the one real cost cliff). Use it for an amortized release baseline.
 
+### Benefits and cost at a glance
+
+Each rung *adds* to the one below it — the benefit column is what that rung newly
+catches, the cost/implication column is what it asks of you in return.
+
+| `--depth` | What it newly catches (benefit) | Cost & implication | Pin it when |
+|-----------|--------------------------------|--------------------|-------------|
+| `binary` | removed/changed exports, SONAME, dependency & version changes, no-DWARF vtable/RTTI size shifts | cheapest, flat with project size; **no** source-only API changes, and every exported symbol is treated as ABI (public/internal churn not separated) | you only have the two binaries, or want a fast pre-check |
+| `headers` | the **public/internal boundary** → separates real API breaks from internal churn; signature / type-layout / enum / `noexcept` changes | still cheap; needs public headers **and** a C/C++ frontend on `PATH`, else it falls back to binary-strict scope and over-reports | you have the public headers — this is the floor for a *trustworthy* verdict |
+| `build` | build-flag / toolchain / `-std` / visibility **drift**; macro-value & include-graph divergence | cheap (~0.3–0.5s more); needs a compile DB / build dir — without one L3 is `not_collected` (reported, not a pass) | the two builds may differ in flags, standard, or visibility |
+| `source` | inline / template / macro / default-argument / `constexpr` **body** changes, **plus** the L5 reachability graph that localizes and scopes findings | **the one cost cliff (L4)** — scales with C++ template depth; needs `--sources` + `clang` + a `--since` seed to stay cheap (unseeded, it replays every TU = `full` cost) | a per-PR gate that must catch source-body changes or wants per-symbol impact |
+| `full` | the same as `source`, but over the **whole** library rather than the changed TUs | most expensive (no seed scoping) | producing an amortized release baseline |
+
+**The one rule that ties it together:** the binary diff (`binary`/`headers`) sets
+the pass/fail **gate**; `build`/`source`/`full` mostly *localize and explain* and
+add their own source-/API-level findings — they rarely flip the verdict. So spend
+on L4 (`source`/`full`) for humans reviewing a PR or a release, and stay in the
+cheap tier for a fast CI gate.
+
 ## What input each depth needs — and how to get it
 
 Every depth needs a specific **input**; without it the matching coverage row is

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -271,8 +271,10 @@ abicheck scan \
   it explicitly if you want a fixed rung.
 - **Exit code:** `0` compatible, `2` source/API break, `4` ABI break (from the
   baseline compare), `5` `--budget` overflow.
-- `--depth source` already folds the full L5 reachability graph when you want
-  cross-symbol impact in the report.
+- `--depth source` folds the L5 reachability **edges scoped to the changed TUs**
+  for cross-symbol impact in the report. The *whole-library* reachability graph
+  is an internal level (`GRAPH`, D6) with no user-facing `--depth` rung — reach it
+  only via the deprecated `--mode pr-deep`.
 
 ### Single-build audit — no baseline
 

--- a/docs/user-guide/scanning-conda-packages.md
+++ b/docs/user-guide/scanning-conda-packages.md
@@ -96,5 +96,5 @@ pre-scan runs. On a large tree, scope that pre-scan with `--since <ref>` /
 ## See also
 
 - [Worked Example: Scanning a Library](real-world-example.md) — the full flow and reports
-- [Source-Scan Levels](scan-levels.md) — what L0–L5 collect and cost
+- [Source-Scan Depth](scan-levels.md) — what L0–L5 collect and cost
 - [CLI Usage](cli-usage.md) — every flag

--- a/docs/user-guide/tool-modes.md
+++ b/docs/user-guide/tool-modes.md
@@ -118,7 +118,7 @@ quantifies the cumulative gain across the example catalog (32% → 81% → 99% �
 100%). The [authority rule](../concepts/architecture.md#evidence-layers-the-five-sources)
 keeps the modes honest: only L0/L1/L2 can declare a binary `BREAKING`; L3/L4
 (and the `L5` source graph abicheck derives from them — see
-[Scan Levels (S vs L)](../concepts/scan-and-evidence-levels.md)) explain, scope,
+[Evidence Layers & Scan Depth](../concepts/scan-and-evidence-levels.md)) explain, scope,
 and add their own source-/API-level findings.
 
 > **Quick decision.** Stripped production binary → **L0**. Debug build, no

--- a/examples/case147_scan_depth_ladder/README.md
+++ b/examples/case147_scan_depth_ladder/README.md
@@ -11,21 +11,21 @@ proved and what it could not** — never a bare "scan failed".
 
 `connect()` takes `detail::SessionState&`, a private-header type.
 
-| Depth | Method | What it proves | What it cannot |
-|-------|--------|----------------|----------------|
-| **S3** | lexical pattern pre-scan (no compiler) | flags a risky construct: a public signature mentions a `detail::` name | cannot confirm the type is actually private — only a textual hint |
-| **S2** | preprocessor (if a compile DB is present) | resolves the `#include` graph | does not parse the AST |
-| **S5** | source replay + L5 source graph | **confirms** `detail::SessionState` originates in a private header and is reached from a public decl → `PRIVATE_HEADER_LEAK`, corroborated by the `source_index` provider | (the deepest answer) |
+| `--depth` | Method | What it proves | What it cannot |
+|-----------|--------|----------------|----------------|
+| **`headers`** | lexical pattern pre-scan + L2 header AST | flags a risky construct: a public signature mentions a `detail::` name | cannot confirm the type is actually private — only a textual/AST hint |
+| **`build`** | + preprocessor (if a compile DB is present) | resolves the `#include` graph | does not replay the source ABI |
+| **`source`** | + source replay + L5 source graph | **confirms** `detail::SessionState` originates in a private header and is reached from a public decl → `PRIVATE_HEADER_LEAK`, corroborated by the `source_index` provider | (the deepest answer) |
 
 The committed `snapshot.abi.json` carries the L2 header provenance **and** the L5
 source graph, so the cross-check fires with the `source_index` corroboration the
-S5 pass would add — the endpoint of the ladder.
+`--depth source` pass would add — the endpoint of the ladder.
 
 ## Reproduce the ladder
 
 ```bash
-abicheck scan --binary libdemo.so -H include/ --audit --source-method s3   # pattern only
-abicheck scan --binary libdemo.so -H include/ --audit --sources . --source-method s5  # S5 replay + graph
+abicheck scan --binary libdemo.so -H include/ --audit --depth headers   # pattern + AST
+abicheck scan --binary libdemo.so -H include/ --audit --sources . --depth source  # replay + L5 graph
 ```
 
 ## Fix

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
       - 'Scanning a Conda-Forge Package': user-guide/scanning-conda-packages.md
     - Everyday Use:
       - CLI Usage: user-guide/cli-usage.md
-      - Source-Scan Levels: user-guide/scan-levels.md
+      - Source-Scan Depth: user-guide/scan-levels.md
       - Producing Source Facts: user-guide/producing-source-facts.md
       - Output Formats: user-guide/output-formats.md
       - Baseline Management: user-guide/baseline-management.md
@@ -72,7 +72,7 @@ nav:
     - Evidence & Detectability: concepts/evidence-and-detectability.md
     - Architecture: concepts/architecture.md
     - Build Info & Sources (build-source data): concepts/build-source-data.md
-    - Scan Levels (S vs L): concepts/scan-and-evidence-levels.md
+    - Evidence Layers & Scan Depth: concepts/scan-and-evidence-levels.md
     - API Surface Intelligence: concepts/api-surface-intelligence.md
     - Class Layout ABI & API: concepts/class-layout-abi.md
     - Limitations: concepts/limitations.md


### PR DESCRIPTION
## Summary

Realigns the user-facing documentation with the ADR-037 / G22 CLI consolidation and fixes cross-page inconsistencies surfaced by a full documentation audit.

## Motivation

The CLI reduction had already landed in the code — a single `--depth` dial, with `--mode`/`--source-method` demoted to hidden **deprecated** aliases, `compare-release`/`deep-compare` folded into `compare`, and `--header-backend` → `--ast-frontend` — but the docs still taught the old `s0…s6` **"Scan Levels (S vs L)"** model as first-class. A full scan of `docs/` found this stale model plus several drifted counts, exit codes, ChangeKind names, and command maps. This PR brings the docs back in line with the current tool and resolves places where pages contradicted each other.

## Changes

- **`concepts/scan-and-evidence-levels.md`** — restructured around **L0–L5 + `--depth`**; retitled *Evidence Layers & Scan Depth*; `s0…s6`/`--source-method`/`--mode` collapsed into a labelled *Deprecated (ADR-037 D5)* appendix with a `--depth` mapping table. (This is the page originally linked in the request.)
- **`user-guide/scan-levels.md`** — `--depth` is now the spine of the level tables, worked examples, and cost guide; fixed the `auto`-vs-`--mode pr` default self-contradiction; retitled *Source-scan depth*.
- **`github-action.md` / `mcp-integration.md`** — lead with `depth`; `scan-mode`/`source-method` marked as deprecated aliases (noting the Action still defaults to `--mode pr`).
- **`reference/exit-codes.md`** — added the missing `scan` section (`0/2/4/5`); corrected `compare`/`appcompat` invalid-invocation code (**64**, not 2).
- **`reference/platforms.md`** — fixed ABICC-style flags used on `compare`; corrected two non-existent ChangeKind names → `func_return_changed`, `func_visibility_changed`.
- **`reference/tool-comparison.md` + `index.md`** — catalog count `129`/`134` → **152**.
- **`getting-started.md`** — exit-code table (drop bogus `1`=tool-error row, add `64`); dropped the removed `compare-release` command name.
- Smaller leaks: `abi-api-handling.md`, `build-source-data.md` (`--allow-build-query` self-contradiction), `evidence-and-detectability.md`, `class-layout-abi.md` (wrong `case141`→`case142` label; L0–L4 → L0–L5), `architecture.md`/`cli-usage.md` command maps (added `scan`), `real-world-example.md`, `choose-your-workflow.md` (Flow-2 → Flow B), plus label consistency across pages.
- **`cli_scan.py`** — `scan --help` description/example and module docstring no longer advertise the deprecated `--mode`/`--source-method`.
- **`examples/case147`** — reproduce commands now use `--depth`; regenerated the docs page.

Note: `compare-release` references that remain in `github-action.md`/`exit-codes.md` are intentional — they describe the **GitHub Action's `mode: compare-release`** (still a valid Action input that shells out to `compare`), not the removed CLI command. References in `docs/development/` ADRs and implementation plans are left as-is, since those are historical records of the consolidation.

## Checklist

- [ ] Tests added / updated for new behaviour — n/a (documentation + help-text only)
- [ ] `CHANGELOG.md` updated (under `[Unreleased]`) — not updated; docs-only alignment
- [x] Docs updated if user-visible behaviour changed
- [x] `mkdocs build --strict` passes clean; `scripts/check_ai_readiness.py` reports 0 errors
- [x] No new `mypy` or `ruff` errors introduced (`ruff check abicheck/cli_scan.py` clean); CLI-contract + scan test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QVj7TRdFHQgNLxH3LvRgQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014QVj7TRdFHQgNLxH3LvRgQ)_