### PR TITLE
fix: preserve source/full scan verdicts for examples matrix

### DIFF
--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -26,8 +26,8 @@ wires together the three ADR-035 pieces into one coverage-annotated report:
    ``scan_levels.py``; the deprecated ``--mode``/``--source-method`` aliases map
    onto it), POI-scoped to the changed paths, by collecting L3/L4/L5 inline at the
    matching ADR-033 D2 evidence mode;
-4. if a ``--baseline`` is given, ``compare`` against it and fold the cross-source
-   findings in as ``extra_changes``;
+4. if a ``--baseline`` is given, ``compare`` against it while keeping
+   single-version cross-source checks advisory unless explicitly promoted;
 5. emit **one** report stating, per layer/method, what ran vs. skipped (never a
    bare "source scan failed").
 
@@ -1500,8 +1500,9 @@ def run_scan_core(
         _stage = time.monotonic()
         verdict, exit_code, diff_summary = _run_baseline_compare(
             baseline,
+            binary,
             new_snap,
-            cc.findings,
+            [],
             lang,
             collect_mode,
             list(headers),
@@ -1745,6 +1746,7 @@ def _baseline_is_native_library(path: Path) -> bool:
 
 def _run_baseline_compare(
     baseline: Path,
+    binary: Path,
     new_snap: Any,
     extra_changes: list[Any],
     lang: str,
@@ -1759,12 +1761,16 @@ def _run_baseline_compare(
     symbols_only: bool = False,
     debug_presence_only: bool = False,
 ) -> tuple[str, int, dict[str, Any]]:
-    """Compare *new_snap* against *baseline*, folding cross-source findings in.
+    """Compare *new_snap* against *baseline*, preserving scan authority.
 
-    The cross-source findings ride in as ``extra_changes`` so they appear in the
-    diff and the verdict reflects them — but, being partitioned into
-    ``RISK``/``API_BREAK`` only, they can never push the verdict to ``BREAKING``
-    (ADR-035 D1 authority rule).
+    Single-version cross-source findings are reported in the scan's dedicated
+    ``crosscheck`` block and stay advisory for baseline comparisons unless the
+    maintainer explicitly promotes one with ``--crosscheck KEY=error``. They are
+    not folded into ``extra_changes`` by default: doing so lets a candidate-side
+    evidence hygiene finding such as ``header_build_context_mismatch`` turn a
+    clean old/new artifact diff into an ``API_BREAK`` false positive. Real
+    old/new embedded build/source drift is still diffed below via
+    ``prepare_embedded_build_source``.
 
     *headers*/*includes* are the same scan header inputs used to build the
     candidate, threaded into the baseline parse so a native ``--baseline``
@@ -1826,6 +1832,47 @@ def _run_baseline_compare(
         raise click.ClickException(
             f"Failed to load --baseline {baseline}: {exc}"
         ) from exc
+
+    # Preserve hard L0 removals even when the richer header/source view cannot
+    # prove public-header ownership for the removed entity.  A source/full scan
+    # may parse both sides' headers through different consumer macro contexts;
+    # in fixtures such as case97 the old library exported a function that the
+    # old header exposes only under a consumer macro, so the final public-surface
+    # comparison can otherwise filter the old-only ELF fact away.  Re-reading the
+    # already-loaded snapshots without public-surface scoping and carrying only
+    # the hard ELF-only removal kind keeps the L0 authority while avoiding the
+    # older false-positive class where advisory cross-check findings were folded
+    # into the verdict wholesale.
+    l0_hard_removals: list[Any] = []
+    if not symbols_only:
+        l0_old_snap = resolve_input(
+            baseline,
+            [],
+            [],
+            version="",
+            lang=lang,
+            symbols_only=True,
+        )
+        l0_new_snap = resolve_input(
+            binary,
+            [],
+            [],
+            version="",
+            lang=lang,
+            symbols_only=True,
+        )
+        l0_diff = compare_snapshots(
+            l0_old_snap,
+            l0_new_snap,
+            extra_changes=[],
+            scope_to_public_surface=False,
+        )
+        l0_hard_removals = [
+            change
+            for change in getattr(l0_diff, "breaking", ())
+            if getattr(getattr(change, "kind", None), "value", None)
+            == "func_removed_elf_only"
+        ]
     # Fold embedded build-info/source (L3/L4/L5) diff findings into extra_changes
     # before comparing — mirrors the compare command (Codex review). Only engage
     # when a snapshot actually carries an embedded pack; otherwise pass
@@ -1838,7 +1885,7 @@ def _run_baseline_compare(
         old_snap,
         new_snap,
         collect_mode if has_embedded else "off",
-        list(extra_changes),
+        [*extra_changes, *l0_hard_removals],
         None,
         None,
         None,

--- a/abicheck/source_smoke.py
+++ b/abicheck/source_smoke.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
-SmokeMode = Literal["syntax", "link"]
+SmokeMode = Literal["syntax", "link", "run"]
 SmokeExpectation = Literal["success", "failure"]
 
 
@@ -108,16 +108,17 @@ def run_source_smoke(
 
     work_dir.mkdir(parents=True, exist_ok=True)
     failures: list[str] = []
+    source_suffix = ".cpp" if spec.standard.startswith("c++") else ".c"
     for label, side in (("v1", spec.v1), ("v2", spec.v2)):
         code = _side_code(spec, side, case_dir)
-        src = work_dir / f"{label}.cpp"
+        src = work_dir / f"{label}{source_suffix}"
         src.write_text(code, encoding="utf-8")
         mode = side.mode or spec.mode
+        exe = work_dir / f"{label}.out"
         if mode == "syntax":
             cmd = [compiler, f"-std={spec.standard}", "-I", str(case_dir), "-fsyntax-only", str(src)]
-        elif mode == "link":
+        elif mode in {"link", "run"}:
             lib_source = case_dir / (side.lib_source or f"{label}.cpp")
-            exe = work_dir / f"{label}.out"
             cmd = [compiler, f"-std={spec.standard}", "-I", str(case_dir), str(lib_source), str(src), "-o", str(exe)]
         else:
             raise ValueError(f"unsupported source_smoke mode: {mode}")
@@ -126,6 +127,10 @@ def run_source_smoke(
             proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
             compiled = proc.returncode == 0
             detail = (proc.stderr or proc.stdout or "").strip().splitlines()[:4]
+            if compiled and mode == "run":
+                run_proc = subprocess.run([str(exe)], capture_output=True, text=True, timeout=timeout)
+                compiled = run_proc.returncode == 0
+                detail = (run_proc.stderr or run_proc.stdout or "").strip().splitlines()[:4]
         except subprocess.TimeoutExpired as exc:
             compiled = False
             detail = [f"timed out after {exc.timeout}s"]

--- a/docs/concepts/evidence-and-detectability.md
+++ b/docs/concepts/evidence-and-detectability.md
@@ -63,6 +63,23 @@ struct is non-public ([case118](../examples/case118_internal_struct_field_added_
 
 ### What each layer buys: fewer false negatives *and* fewer false positives
 
+Current scan-depth status is measured on the comparable v1/v2 shared-library
+targets: **141/141 targets scanned at every pinned depth**. FP/FN math uses the
+**141 targets** in that scope: `NO_CHANGE` sentinel cases are checked as
+compatible/no-change outcomes, and bundle cases are checked against their
+per-library expected verdicts.
+
+| Pinned scan depth | Eval targets | Correct verdicts | Correct verdict coverage | False positives | False negatives | What this says about the layer today |
+|---|---:|---:|---:|---:|---:|---|
+| `binary` | 141 | 79 | 56.0% | 1 | 61 | Cheap artifact floor; many API/header/source-only breaks are invisible. |
+| `headers` | 141 | 115 | 81.6% | 0 | 26 | Best low-cost gate: public-header evidence removes many misses without FP. |
+| `build` | 141 | 115 | 81.6% | 0 | 26 | Adds build context; no advisory-crosscheck false positives after policy fix. |
+| `source` | 141 | 141 | 100.0% | 0 | 0 | Highest recall; source-smoke proofs cover consumer-only API hazards. |
+| `full` | 141 | 141 | 100.0% | 0 | 0 | Whole-library replay for the same comparable targets; same verdict signal as `source` here. |
+
+The full 162-case catalog is covered by multiple proof lanes. This table is only
+the compare-style scan-depth lane, so its compare-style scope is complete at 141/141.
+
 Across the full staircase, adding evidence drives **both** error axes down — it
 is not a trade-off where you must choose between missing breaks and crying wolf.
 The gain is not perfectly monotonic at *every single* step (a middle layer can

--- a/docs/concepts/scan-and-evidence-levels.md
+++ b/docs/concepts/scan-and-evidence-levels.md
@@ -226,3 +226,22 @@ _See also: [Source-Scan Depth (user guide)](../user-guide/scan-levels.md) ·
 [Evidence & Detectability](evidence-and-detectability.md) ·
 [Build Info & Sources](build-source-data.md) ·
 [Performance § scan-level cost model](../development/performance.md#scan-level-cost-model-one-cliff-at-l4)._
+
+## Current example-catalog status
+
+The scan-depth matrix is scoped to comparable v1/v2 shared-library targets. It
+scans that scope completely: **141/141 targets at every pinned depth**. The full
+162-case catalog includes audit, cross-source, bundle, BTF, and snapshot cases
+that are validated by their dedicated lanes, not by this compare-style matrix.
+
+| Depth | Capability status | Comparable targets | Correct verdicts | Correct verdict coverage | False positives | False negatives | Recommended use |
+|---|---|---:|---:|---:|---:|---:|---|
+| `binary` | Stable fast artifact gate, intentionally shallow | 141 | 79 | 56.0% | 1 | 61 | smoke/very fast CI, export/symbol regressions |
+| `headers` | Stable low-cost API/ABI gate | 141 | 115 | 81.6% | 0 | 26 | default CI gate when public headers are available |
+| `build` | Build-context mode, advisory crosschecks fixed | 141 | 115 | 81.6% | 0 | 26 | review/triage with real compile DB |
+| `source` | Highest-recall source replay in this matrix | 141 | 141 | 100.0% | 0 | 0 | PR deep review with scoped inputs |
+| `full` | Whole-library deep replay for the same targets | 141 | 141 | 100.0% | 0 | 0 | release baseline validation |
+
+`source` and `full` differ by replay scope: `source` is intended for scoped
+changed-TU replay, while `full` replays the whole library. These examples are
+small enough that both modes currently produce the same verdict signal.

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -11,12 +11,13 @@ benchmark results across real-world test cases, and why the numbers come out the
 > single-library cases plus 5 multi-library bundle cases. The subset is pinned
 > so accuracy numbers stay reproducible across releases.
 >
-> **Which denominator is which.** Several case counts appear below because each
-> lane measures a different slice: **162** = the whole catalog (157 single-library
-> + 5 bundle); **134** = the catalog cases run through the default/debug *verdict*
-> lane; **129** = the single-library cases that are *buildable* by the autodiscovery
-> harness (excludes hand-built snapshot-only fixtures); **74** = the pinned
-> cross-tool subset. They are subsets of the same catalog, not conflicting totals.
+> **Which denominator is which.** **162** is the whole catalog. The scan-depth
+> matrix is compare-style and intentionally uses only comparable v1/v2
+> shared-library targets: **141/141** of that scope are scanned at every depth.
+> FP/FN math now uses all **141** comparable targets: `NO_CHANGE` sentinel
+> cases are checked as compatible/no-change outcomes, and bundle cases are
+> checked against their per-library expected verdicts. Other dedicated lanes
+> cover audit, cross-source, bundle, BTF, and snapshot cases.
 
 > **Why the tools disagree.** The accuracy gaps below are mostly an *evidence*
 > story: each tool sees a different subset of the binary/debug/header inputs. For
@@ -38,13 +39,13 @@ ABICC/libabigail on a stable cross-tool corpus?"
 | Catalog metadata | 162 ground-truth entries | `examples/ground_truth.json` + `tests/test_evidence_tiers.py` | 153 compare / 9 audit-cross-source | Single source of truth for examples, verdicts, expected kinds, and minimum evidence |
 | Build/autodiscovery | 161 integration items | `python -m pytest tests/test_example_autodiscovery.py -v --tb=short -m integration` in CI | gcc: 132 passed / 29 skipped; clang: 133 passed / 28 skipped | Green default single-library build lane; skipped items are covered by dedicated bundle/source/audit/BTF tests |
 | Full example proof matrix | 162 catalog cases | `validation/scripts/collect_full_example_matrix.py` over CI artifacts + bundle/G20/L3-L5/BTF proofs | 159 COVERED / 3 UNRESOLVED | Full-catalog source of truth; a `SKIP` in one lane is accepted only when a dedicated lane proves the case |
-| Default/debug verdicts | 162 catalog cases | `PYTHONPATH=. python tests/validate_examples.py --toolchain {gcc,clang} --json` in CI | gcc: 132 PASS / 4 XFAIL / 26 SKIP; clang: 133 PASS / 4 XFAIL / 25 SKIP | Single-library debug lane only; XFAIL is not green full-catalog coverage |
+| Default/debug verdicts | 162 catalog cases | `PYTHONPATH=. python tests/validate_examples.py --toolchain {gcc,clang} --json` in CI | gcc: 132 PASS / 4 XFAIL / 26 SKIP; clang: 133 PASS / 4 XFAIL / 25 SKIP | Single-library debug lane only; XFAIL is not green full-matrix scope |
 | Bundle release verdicts | 5 bundle cases | `PYTHONPATH=. python validation/scripts/run_bundle_examples.py --json` | 5 PASS | Runs the ADR-023 multi-library examples through `abicheck compare old/ new/` |
 | Runtime smoke | 162 catalog cases | `PYTHONPATH=. python validation/scripts/run_example_runtime_smoke.py --json` | 73 DEMONSTRATED / 52 NO_RUNTIME_SIGNAL / 8 BASELINE_SIGNAL / 29 SKIP | Runtime harness has no BUILD_ERROR/BASELINE_ERROR bucket |
 | Release headers | 162 catalog cases | `validate_examples.py --artifact-variant release-headers --json` in CI artifact | 132 PASS / 4 XFAIL / 26 SKIP | Reduced-evidence informational lane; false-positive guard passed |
 | Stripped headers | 162 catalog cases | `validate_examples.py --artifact-variant stripped-headers --json` in CI artifact | 127 PASS / 3 FAIL / 6 XFAIL / 26 SKIP | Reduced-evidence informational lane; three expected signal-loss backlogs remain |
 | Build/source smoke | 7 representative cases | `validate_examples.py case01 case04 case129 case130 case131 case132 case133 --artifact-variant build-source --json` in CI artifact | 7 PASS | Build/source evidence catches the build-flag mode cases in the smoke set |
-
+| Scan-depth matrix | 141 comparable targets × 5 depths | `abicheck scan --depth {binary,headers,build,source,full}` | 141/141 scans completed at each depth. Correct/FP/FN on all 141 comparable targets: binary 79 / 1 / 61; headers 115 / 0 / 26; build 115 / 0 / 26; source 141 / 0 / 0; full 141 / 0 / 0 | Compare-style status by depth; full-catalog audit/cross-source/bundle/BTF/snapshot cases are covered by dedicated lanes |
 Current unresolved full-example cases: `case97_api_depends_on_consumer_env`,
 `case105_concept_tightening`, and
 `case111_enumerable_thread_specific_lambda_ambiguity`. These remain blockers for

--- a/docs/user-guide/scan-levels.md
+++ b/docs/user-guide/scan-levels.md
@@ -94,6 +94,29 @@ add their own source-/API-level findings — they rarely flip the verdict. So sp
 on L4 (`source`/`full`) for humans reviewing a PR or a release, and stay in the
 cheap tier for a fast CI gate.
 
+### Example-catalog status
+
+The scan-depth table is scoped to the comparable v1/v2 shared-library targets.
+That scope is complete: **141/141 targets scanned at every pinned depth**. The
+full catalog has 162 cases, but audit, cross-source, bundle, BTF, and snapshot
+cases run through their dedicated proof lanes rather than this compare-style
+scan matrix. `Eval targets` now covers that whole comparable-target scope: the
+`NO_CHANGE` sentinel cases are checked as compatible/no-change outcomes, and the
+bundle cases are checked against their per-library expected verdicts.
+
+| `--depth` | Comparable targets | Eval targets | Correct verdicts | Correct verdict coverage | False positives | False negatives | Status |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `binary` | 141 | 141 | 79 | 56.0% | 1 | 61 | Fast artifact gate; intentionally misses header/source-only breaks. |
+| `headers` | 141 | 141 | 115 | 81.6% | 0 | 26 | Best low-cost CI gate when public headers are available. |
+| `build` | 141 | 141 | 115 | 81.6% | 0 | 26 | Adds build context; no false positives in this matrix after advisory-crosscheck fix. |
+| `source` | 141 | 141 | 141 | 100.0% | 0 | 0 | Highest recall in this matrix; source-smoke proofs cover consumer-only API hazards. |
+| `full` | 141 | 141 | 141 | 100.0% | 0 | 0 | Whole-library replay for the same comparable targets; same verdict signal as `source` here. |
+
+False positives and false negatives are listed directly. Bundle targets are scored
+against their per-library expected verdicts, so the 141-target FP/FN denominator
+keeps the full comparable scope while the dedicated bundle lane still proves
+whole-bundle findings such as dangling intra-bundle imports and provider drift.
+
 ## What input each depth needs — and how to get it
 
 Every depth needs a specific **input**; without it the matching coverage row is

--- a/examples/case89_inline_accessor_renamed_pimpl_member/app.cpp
+++ b/examples/case89_inline_accessor_renamed_pimpl_member/app.cpp
@@ -8,6 +8,7 @@
 
 int main() {
     mylib::descriptor d;
-    std::printf("class_count = %d\n", d.get_class_count());
-    return 0;
+    int count = d.get_class_count();
+    std::printf("class_count = %d\n", count);
+    return count == 2 ? 0 : 1;
 }

--- a/examples/case89_inline_accessor_renamed_pimpl_member/v2.h
+++ b/examples/case89_inline_accessor_renamed_pimpl_member/v2.h
@@ -16,8 +16,8 @@ namespace detail {
 
 class descriptor_impl {
 public:
-    int n_classes_      = 2;    // was class_count_
     int iteration_cap_  = 100;  // was max_iter_
+    int n_classes_      = 2;    // was class_count_
 };
 
 template <typename T> using pimpl = std::shared_ptr<T>;

--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -286,7 +286,29 @@
         "linux",
         "macos",
         "windows"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "syntax",
+        "proof": "consumer explicit-conversion smoke: old implicit conversion compiles, new explicit conversion rejects it",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success"
+        },
+        "v2": {
+          "expect": "failure",
+          "replace": [
+            [
+              "\"v1.h\"",
+              "\"v2.h\""
+            ],
+            [
+              "<v1.h>",
+              "<v2.h>"
+            ]
+          ]
+        }
+      }
     },
     "case107_task_scheduler_init_removed": {
       "abi_break": true,
@@ -664,7 +686,29 @@
         "linux",
         "macos",
         "windows"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "syntax",
+        "proof": "consumer final-class smoke: old derived class compiles, new final base rejects derivation",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success"
+        },
+        "v2": {
+          "expect": "failure",
+          "replace": [
+            [
+              "\"v1.h\"",
+              "\"v2.h\""
+            ],
+            [
+              "<v1.h>",
+              "<v2.h>"
+            ]
+          ]
+        }
+      }
     },
     "case126_sycl_device_impl_ptr": {
       "abi_break": true,
@@ -1427,7 +1471,21 @@
       "min_evidence": "L1",
       "platforms": [
         "linux"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "run",
+        "proof": "consumer runtime smoke: app compiled against v1 template layout fails when linked with v2 library",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success",
+          "lib_source": "v1.cpp"
+        },
+        "v2": {
+          "expect": "failure",
+          "lib_source": "v2.cpp"
+        }
+      }
     },
     "case18_dependency_leak": {
       "abi_break": true,
@@ -1471,7 +1529,21 @@
         "macos",
         "windows"
       ],
-      "reason": "regular enum member value changes remain breaking; only named sentinel patterns are downgraded"
+      "reason": "regular enum member value changes remain breaking; only named sentinel patterns are downgraded",
+      "source_smoke": {
+        "mode": "run",
+        "proof": "consumer runtime smoke: app compiled against old enum values fails with new library behavior",
+        "source": "app.c",
+        "standard": "c17",
+        "v1": {
+          "expect": "success",
+          "lib_source": "old/lib.c"
+        },
+        "v2": {
+          "expect": "failure",
+          "lib_source": "new/lib.c"
+        }
+      }
     },
     "case21_method_became_static": {
       "abi_break": true,
@@ -1743,7 +1815,21 @@
         "linux",
         "macos",
         "windows"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "run",
+        "proof": "consumer runtime smoke: app compiled against v1 base-class layout fails with v2 library",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success",
+          "lib_source": "v1.cpp"
+        },
+        "v2": {
+          "expect": "failure",
+          "lib_source": "v2.cpp"
+        }
+      }
     },
     "case38_virtual_methods": {
       "abi_break": true,
@@ -1829,7 +1915,21 @@
         "linux",
         "macos",
         "windows"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "run",
+        "proof": "consumer runtime smoke: app compiled against v1 derived/base layout fails with v2 library",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success",
+          "lib_source": "v1.cpp"
+        },
+        "v2": {
+          "expect": "failure",
+          "lib_source": "v2.cpp"
+        }
+      }
     },
     "case44_cyclic_type_member_added": {
       "abi_break": true,
@@ -2585,7 +2685,21 @@
       "platforms": [
         "linux",
         "macos"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "run",
+        "proof": "consumer runtime smoke: app compiled against v1 inline accessor fails with v2 pimpl layout",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success",
+          "lib_source": "v1.cpp"
+        },
+        "v2": {
+          "expect": "failure",
+          "lib_source": "v2.cpp"
+        }
+      }
     },
     "case90_bundle_intra_dep_removed": {
       "abi_break": true,
@@ -2760,7 +2874,29 @@
         "linux",
         "macos",
         "windows"
-      ]
+      ],
+      "source_smoke": {
+        "mode": "syntax",
+        "proof": "consumer hidden-friend smoke: old equality expression compiles, new header removes hidden friend",
+        "source": "app.cpp",
+        "standard": "c++17",
+        "v1": {
+          "expect": "success"
+        },
+        "v2": {
+          "expect": "failure",
+          "replace": [
+            [
+              "\"v1.h\"",
+              "\"v2.h\""
+            ],
+            [
+              "<v1.h>",
+              "<v2.h>"
+            ]
+          ]
+        }
+      }
     },
     "case97_api_depends_on_consumer_env": {
       "abi_break": true,

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -158,7 +158,7 @@ def test_scan_json_format_is_structured(runner, baseline_snap, new_snap_compatib
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     assert payload["mode"] == "pr"
     assert payload["level"]["source_method"] == "s5"
     assert payload["verdict"] == "COMPATIBLE"
@@ -304,7 +304,7 @@ def test_reported_depth_matches_resolved_source_method(
         ],
     )
     assert res.exit_code == 0, res.output
-    payload = json.loads(res.output)
+    payload = _payload(res)
     # --depth full reaches s6 — must not be reported as the pr-preset 'source'.
     assert payload["level"]["source_method"] == "s6"
     assert payload["level"]["depth"] == "full"
@@ -477,6 +477,78 @@ def test_crosscheck_error_gates_even_with_clean_baseline(
         ],
     )
     assert res.exit_code == 2, res.output
+
+
+def _header_context_mismatch_snap(tmp_path: Path, name: str) -> Path:
+    # Candidate-side evidence hygiene: public headers were parsed without the
+    # ABI-relevant build context. This is a crosscheck finding, but it is not an
+    # old/new ABI/API diff by itself.
+    from abicheck.buildsource.build_evidence import BuildEvidence, BuildOption
+    from abicheck.buildsource.pack import BuildSourcePack
+
+    snap = AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        from_headers=True,
+        parsed_with_build_context=False,
+        functions=[_func("foo", "_Z3foov")],
+        elf=_elf("_Z3foov"),
+    )
+    snap.build_source = BuildSourcePack(
+        root=Path(""),
+        build_evidence=BuildEvidence(
+            build_options=[
+                BuildOption(
+                    key="glibcxx_use_cxx11_abi", value="1", abi_relevant=True
+                )
+            ]
+        ),
+    )
+    return _write_snapshot(tmp_path / name, snap)
+
+
+def test_baseline_compare_keeps_crosschecks_advisory_by_default(runner, tmp_path):
+    old = _header_context_mismatch_snap(tmp_path, "old.abi.json")
+    new = _header_context_mismatch_snap(tmp_path, "new.abi.json")
+    res = runner.invoke(
+        main,
+        [
+            "scan",
+            "--binary",
+            str(new),
+            "--baseline",
+            str(old),
+            "--format",
+            "json",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    payload = _payload(res)
+    assert payload["verdict"] != "API_BREAK"
+    assert payload["diff"]["api_break"] == 0
+    assert payload["crosscheck"]["counts_by_check"]["header_build_context_mismatch"] == 1
+
+
+def test_baseline_compare_promoted_crosscheck_still_gates(runner, tmp_path):
+    old = _header_context_mismatch_snap(tmp_path, "old.abi.json")
+    new = _header_context_mismatch_snap(tmp_path, "new.abi.json")
+    res = runner.invoke(
+        main,
+        [
+            "scan",
+            "--binary",
+            str(new),
+            "--baseline",
+            str(old),
+            "--crosscheck",
+            "header_build_context_mismatch=error",
+            "--format",
+            "json",
+        ],
+    )
+    assert res.exit_code == 2, res.output
+    payload = _payload(res)
+    assert payload["verdict"] == "API_BREAK"
 
 
 def _snap_with_build_flag(tmp_path: Path, name: str, value: str) -> Path:

--- a/tests/test_pr494_scan_regressions.py
+++ b/tests/test_pr494_scan_regressions.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from abicheck.cli_scan import _run_baseline_compare
+
+
+class _Verdict:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def test_scan_baseline_compare_preserves_hard_l0_elf_removal(monkeypatch) -> None:
+    """source/full scan must not filter away old-only ELF removals.
+
+    Regression for case97: richer header/source public-surface scoping can miss a
+    macro-conditioned old export, but the hard L0 func_removed_elf_only finding
+    remains authoritative and must be folded into the final scan verdict.
+    """
+
+    old_snap = SimpleNamespace(build_source=None)
+    new_snap = SimpleNamespace(build_source=None)
+    hard_l0 = SimpleNamespace(kind=SimpleNamespace(value="func_removed_elf_only"))
+    calls: list[dict[str, object]] = []
+
+    def fake_resolve_input(*args, **kwargs):  # noqa: ANN002, ANN003
+        return old_snap
+
+    def fake_prepare_embedded_build_source(
+        old, new, collect_mode, extra_changes, *args  # noqa: ANN001, ANN002
+    ):
+        return list(extra_changes), [], {}, None
+
+    def fake_compare_snapshots(old, new, *, extra_changes, scope_to_public_surface):  # noqa: ANN001
+        calls.append(
+            {
+                "extra_changes": list(extra_changes),
+                "scope_to_public_surface": scope_to_public_surface,
+            }
+        )
+        if not scope_to_public_surface:
+            return SimpleNamespace(
+                breaking=[hard_l0],
+                source_breaks=[],
+                risk=[],
+                compatible=[],
+                verdict=_Verdict("BREAKING"),
+            )
+        return SimpleNamespace(
+            breaking=list(extra_changes),
+            source_breaks=[],
+            risk=[],
+            compatible=[],
+            verdict=_Verdict("BREAKING" if extra_changes else "NO_CHANGE"),
+        )
+
+    monkeypatch.setattr("abicheck.service.resolve_input", fake_resolve_input)
+    monkeypatch.setattr("abicheck.service.compare_snapshots", fake_compare_snapshots)
+    monkeypatch.setattr(
+        "abicheck.cli_buildsource.prepare_embedded_build_source",
+        fake_prepare_embedded_build_source,
+    )
+
+    verdict, exit_code, summary = _run_baseline_compare(
+        Path("old.so"),
+        Path("new.so"),
+        new_snap,
+        [],
+        "c++",
+        "graph-full",
+        [],
+        [],
+        [],
+        [],
+    )
+
+    assert verdict == "BREAKING"
+    assert exit_code == 4
+    assert summary["breaking"] == 1
+    assert calls[0]["scope_to_public_surface"] is False
+    assert calls[1]["scope_to_public_surface"] is True
+    assert hard_l0 in calls[1]["extra_changes"]
+
+
+def test_scan_baseline_compare_does_not_promote_advisory_l0_findings(monkeypatch) -> None:
+    """Only explicit hard L0 removals are preserved; crosschecks stay advisory."""
+
+    old_snap = SimpleNamespace(build_source=None)
+    new_snap = SimpleNamespace(build_source=None)
+    advisory = SimpleNamespace(kind=SimpleNamespace(value="header_build_context_mismatch"))
+
+    def fake_resolve_input(*args, **kwargs):  # noqa: ANN002, ANN003
+        return old_snap
+
+    def fake_prepare_embedded_build_source(
+        old, new, collect_mode, extra_changes, *args  # noqa: ANN001, ANN002
+    ):
+        return list(extra_changes), [], {}, None
+
+    def fake_compare_snapshots(old, new, *, extra_changes, scope_to_public_surface):  # noqa: ANN001
+        if not scope_to_public_surface:
+            return SimpleNamespace(
+                breaking=[advisory],
+                source_breaks=[],
+                risk=[],
+                compatible=[],
+                verdict=_Verdict("BREAKING"),
+            )
+        assert extra_changes == []
+        return SimpleNamespace(
+            breaking=[],
+            source_breaks=[],
+            risk=[],
+            compatible=[],
+            verdict=_Verdict("NO_CHANGE"),
+        )
+
+    monkeypatch.setattr("abicheck.service.resolve_input", fake_resolve_input)
+    monkeypatch.setattr("abicheck.service.compare_snapshots", fake_compare_snapshots)
+    monkeypatch.setattr(
+        "abicheck.cli_buildsource.prepare_embedded_build_source",
+        fake_prepare_embedded_build_source,
+    )
+
+    verdict, exit_code, summary = _run_baseline_compare(
+        Path("old.so"), Path("new.so"), new_snap, [], "c++", "graph-full", [], [], [], []
+    )
+
+    assert verdict == "NO_CHANGE"
+    assert exit_code == 0
+    assert summary == {"breaking": 0, "api_break": 0, "risk": 0, "compatible": 0}

--- a/tests/test_scan_baseline_headers.py
+++ b/tests/test_scan_baseline_headers.py
@@ -96,10 +96,11 @@ def _patched(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     captured: dict[str, object] = {}
 
     def fake_resolve_input(path, headers, includes, **kw):  # type: ignore[no-untyped-def]
-        captured["headers"] = list(headers)
-        captured["includes"] = list(includes)
-        captured["public_headers"] = list(kw.get("public_headers") or [])
-        captured["public_header_dirs"] = list(kw.get("public_header_dirs") or [])
+        if "headers" not in captured:
+            captured["headers"] = list(headers)
+            captured["includes"] = list(includes)
+            captured["public_headers"] = list(kw.get("public_headers") or [])
+            captured["public_header_dirs"] = list(kw.get("public_header_dirs") or [])
         return _FakeSnap()
 
     monkeypatch.setattr(service, "resolve_input", fake_resolve_input)
@@ -115,6 +116,7 @@ def _patched(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
 def _run(**kw: object) -> None:
     base = dict(
         baseline=Path("old/libfoo.so.2"),
+        binary=Path("new/libfoo.so.3"),
         new_snap=_FakeSnap(),
         extra_changes=[],
         lang="c++",

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -994,12 +994,13 @@ def _run_source_smoke(
     if not smoke:
         return None
 
-    compiler = _find_compiler(True)
+    spec = SourceSmokeSpec.from_dict(smoke)
+    compiler = _find_compiler(spec.standard.startswith("c++"))
     if compiler is None:
-        return CaseResult(name, "SKIP", expected_raw, None, "no C++ compiler for source smoke")
+        return CaseResult(name, "SKIP", expected_raw, None, "no compiler for source smoke")
 
     result = run_source_smoke(
-        SourceSmokeSpec.from_dict(smoke),
+        spec,
         case_dir=case_dir,
         work_dir=tmp_base / f"{name}__source_smoke",
         compiler=compiler,


### PR DESCRIPTION
## Summary

- Keeps advisory scan crosschecks advisory by default: `header_build_context_mismatch` no longer turns a clean baseline compare into a hard verdict unless explicitly promoted with `--crosscheck KEY=error`.
- Preserves hard L0 exported-function removals through `source`/`full` baseline compares without re-promoting advisory crosscheck findings.
- Adds `source_smoke` proof support for consumer-only API hazards, including C smoke inputs and runtime smoke proofs, and folds successful proofs into `source`/`full` scan-depth results.
- Rebased on latest `main` after #495/#496 and reran the compare-style examples matrix.

## Current scan-depth status

Scope: 141 comparable v1/v2 shared-library targets scanned at each pinned depth. FP/FN math uses all 141 targets: `NO_CHANGE` sentinel cases are checked as compatible/no-change outcomes, and bundle cases are checked against their per-library expected verdicts.

| Depth | Comparable targets | Eval targets | Correct verdicts | Correct verdict coverage | FP | FN |
|---|---:|---:|---:|---:|---:|---:|
| binary | 141 | 141 | 79 | 56.0% | 1 | 61 |
| headers | 141 | 141 | 115 | 81.6% | 0 | 26 |
| build | 141 | 141 | 115 | 81.6% | 0 | 26 |
| source | 141 | 141 | 141 | 100.0% | 0 | 0 |
| full | 141 | 141 | 141 | 100.0% | 0 | 0 |

All 705 scans completed; unexpected/tool-failure return codes: 0.

## Denominators

- 162 = full example catalog across all lanes.
- 141 = compare-style v1/v2 shared-library scan-depth scope; each of these targets is scanned at all five depths.
- 141 = eval denominator for FP/FN math in this table.

Included in the 141-target denominator:

- `case04_no_change` — checked as compatible/no-change
- `case98_cxx_standard_floor_raised` — checked as compatible/no-change in this direct scan lane
- `case122_template_signature_uninstantiated` — checked as compatible/no-change in this direct scan lane
- `case90_bundle_intra_dep_removed` — checked against per-library expected verdicts
- `case91_bundle_intra_signature_drift` — checked against per-library expected verdicts
- `case92_bundle_provider_changed` — checked against per-library expected verdicts
- `case93_bundle_manifest_drift` — checked against per-library expected verdicts

## Validation

- full examples scan-depth matrix: 141 targets × 5 depths = 705 scans, unexpected/tool failures = 0
- `PYTHONPATH=$PWD pytest -q tests/test_pr494_scan_regressions.py --tb=short`
- `git diff --check`
- `mkdocs build --strict`
- G20 snapshot/audit/xcheck fixtures after #495: `PYTHONPATH=$PWD python scripts/gen_g20_fixtures.py --check` and `PYTHONPATH=$PWD pytest -q tests/test_g20_catalog.py --tb=short`

