### PR TITLE
Keep non-public exports in unmatched coverage

### DIFF
--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -1097,7 +1097,6 @@ def link_source_abi(
         | set(synthesized)
         | set(template_instantiations)
         | set(allocator_interposers)
-        | set(non_public)
     )
 
     surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)
@@ -1209,8 +1208,10 @@ def relink_surface_exports(
     )
     surface.mappings["non_public_symbol_to_reason"] = dict(sorted(non_public.items()))
     all_matched = (
-        matched | set(synthesized) | set(template_instantiations) | set(allocator_interposers)
-        | set(non_public)
+        matched
+        | set(synthesized)
+        | set(template_instantiations)
+        | set(allocator_interposers)
     )
 
     surface.unmatched["symbols_without_decl"] = sorted(exported - all_matched)

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -1100,9 +1100,10 @@ def test_non_public_export_accounting_keeps_reasons_separate_from_decl_matches()
         exported_symbols=exports,
         library="libfoo",
     )
-    assert surface.unmatched["symbols_without_decl"] == []
+    assert surface.unmatched["symbols_without_decl"] == sorted(exports)
     assert surface.coverage["matched_symbols"] == 0
     assert surface.coverage["non_public_symbols_classified"] == len(exports)
+    assert surface.coverage["unmatched_symbols"] == len(exports)
     assert surface.mappings["non_public_symbol_to_reason"] == {
         "_ZNSt6vectorIiSaIiEEC1Ev": "dependency:stdlib",
         "_ZN3tbb6detail2r13fooEv": "dependency:tbb",


### PR DESCRIPTION
### Motivation
- Non-public export classification was being added into the matched set, which removed arbitrary unmatched C/C++ exports from `symbols_without_decl` and reduced `coverage["unmatched_symbols"]`, allowing attacker-controlled artifacts to hide unmatched exports. 
- The intent is to preserve classification metadata while keeping the honest unmatched-export signal (so L4/CI gates that check unmatched exports remain reliable).

### Description
- Stop including `non_public` symbols in the `all_matched` set inside `link_source_abi`, so classified non-public exports remain listed in `surface.unmatched["symbols_without_decl"]` rather than being treated as matched. 
- Apply the same change to `relink_surface_exports` so relinking preserves `non_public_symbol_to_reason` mappings but does not fold those symbols into the matched set. 
- Update `tests/test_source_abi.py` to assert that classified non-public exports are still present in `symbols_without_decl` and that `coverage["unmatched_symbols"]` reflects them while `coverage["non_public_symbols_classified"]` still records the classification count.

### Testing
- Ran the targeted surface/link tests `tests/test_source_abi.py` and `tests/test_source_evidence_integrity.py`, and the modified tests passed (110 passed). 
- Ran a focused subset (`test_non_public_export_accounting_*`) which also passed and confirms the unmatched-export signal is preserved. 
- Attempted a full `pytest -q` run, but test collection failed due to the environment missing the `hypothesis` dependency, so full-suite property tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a487f6bb0a0832b803d474b1feebaba)