### PR TITLE
Bound clang include-map replay work

### DIFF
--- a/abicheck/buildsource/include_graph.py
+++ b/abicheck/buildsource/include_graph.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess  # noqa: S404 - include extraction shells out to clang (never shell=True)
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -281,6 +282,9 @@ class ClangIncludeExtractor:
     clang_bin: str = "clang++"
     diagnostics: list[str] = field(default_factory=list)
     diagnostics_limit: int = 20
+    max_compile_units: int = 256
+    aggregate_timeout_s: float = 30.0
+    per_unit_timeout_s: float = 120.0
 
     def available(self) -> bool:
         return shutil.which(self.clang_bin) is not None
@@ -299,9 +303,25 @@ class ClangIncludeExtractor:
 
         out: dict[str, list[str]] = {}
         failures = 0
+        attempted = 0
+        deadline = time.monotonic() + self.aggregate_timeout_s
         for cu in build.compile_units:
             if not cu.source:
                 continue
+            if attempted >= self.max_compile_units:
+                self.diagnostics.append(
+                    "clang -M include-map budget exhausted: "
+                    f"stopped after {attempted} compile units"
+                )
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self.diagnostics.append(
+                    "clang -M include-map time budget exhausted: "
+                    f"stopped after {attempted} compile units"
+                )
+                break
+            attempted += 1
             argv = depfile_args_from_argv(cu.argv) if cu.argv else [cu.source]
             if not argv:
                 argv = [cu.source]
@@ -321,7 +341,8 @@ class ClangIncludeExtractor:
             try:
                 proc = subprocess.run(  # noqa: S603 - fixed argv, never shell=True
                     cmd, cwd=cwd or None, capture_output=True,
-                    text=True, timeout=120, check=False,
+                    text=True, timeout=min(self.per_unit_timeout_s, remaining),
+                    check=False,
                 )
             except (OSError, subprocess.SubprocessError) as exc:
                 self.diagnostics.append(f"clang -M failed for {cu.id}: {exc}")

--- a/tests/test_include_graph.py
+++ b/tests/test_include_graph.py
@@ -317,3 +317,61 @@ def test_extract_uses_dash_m_and_preserves_c_language(monkeypatch) -> None:
     assert out == {"cu://c": ["foo.c", "sys.h"]}
     assert "-M" in captured["cmd"] and "-MM" not in captured["cmd"]
     assert captured["cmd"][captured["cmd"].index("-x") + 1] == "c"
+
+
+def test_extract_from_build_caps_compile_units(monkeypatch) -> None:
+    import abicheck.buildsource.include_graph as ig
+
+    calls = []
+
+    class _R:
+        stdout = "foo.o: foo.cpp inc/foo.h"
+        stderr = ""
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _R()
+
+    monkeypatch.setattr(ig.shutil, "which", lambda _b: "/usr/bin/clang++")
+    monkeypatch.setattr(ig.subprocess, "run", _fake_run)
+    build = BuildEvidence(compile_units=[
+        CompileUnit(id=f"cu://{i}", source=f"foo{i}.cpp") for i in range(3)
+    ])
+
+    ext = ClangIncludeExtractor(max_compile_units=2)
+    out = ext.extract_from_build(build)
+
+    assert len(calls) == 2
+    assert set(out) == {"cu://0", "cu://1"}
+    assert any("budget exhausted" in d for d in ext.diagnostics)
+
+
+def test_extract_from_build_enforces_aggregate_timeout(monkeypatch) -> None:
+    import abicheck.buildsource.include_graph as ig
+
+    calls = []
+    now = {"value": 0.0}
+
+    class _R:
+        stdout = "foo.o: foo.cpp inc/foo.h"
+        stderr = ""
+
+    def _fake_run(cmd, **kw):
+        calls.append((cmd, kw["timeout"]))
+        now["value"] += 2.0
+        return _R()
+
+    monkeypatch.setattr(ig.shutil, "which", lambda _b: "/usr/bin/clang++")
+    monkeypatch.setattr(ig.time, "monotonic", lambda: now["value"])
+    monkeypatch.setattr(ig.subprocess, "run", _fake_run)
+    build = BuildEvidence(compile_units=[
+        CompileUnit(id=f"cu://{i}", source=f"foo{i}.cpp") for i in range(3)
+    ])
+
+    ext = ClangIncludeExtractor(aggregate_timeout_s=1.0)
+    out = ext.extract_from_build(build)
+
+    assert len(calls) == 1
+    assert calls[0][1] == 1.0
+    assert out == {"cu://0": ["foo.cpp", "inc/foo.h"]}
+    assert any("time budget exhausted" in d for d in ext.diagnostics)


### PR DESCRIPTION
### Motivation

- The headers-only include-map prepass could run `clang -M` once per compile unit with only a per-unit timeout, allowing untrusted compile databases to force long serial subprocess workloads and cause availability issues. 
- The change adds local budgets to keep include-map extraction bounded and fail-open with diagnostics instead of stalling CI.

### Description

- Added configurable budgets to `ClangIncludeExtractor`: `max_compile_units`, `aggregate_timeout_s`, and `per_unit_timeout_s`, and compute a `deadline` to enforce an overall time budget. 
- Stop iterating compile units once the unit cap is reached or the aggregate time budget is exhausted and record a diagnostic message when either budget is hit. 
- Bound each `clang -M` subprocess by the remaining aggregate budget using `timeout=min(self.per_unit_timeout_s, remaining)` to prevent a single unit from consuming the whole aggregate budget. 
- Added regression tests to `tests/test_include_graph.py` verifying both the compile-unit cap and the aggregate-timeout enforcement. 

### Testing

- Ran `pytest -q tests/test_include_graph.py tests/test_build_source_cli.py -k "include_map_for_replay"` which passed (`1 passed, 132 deselected`).
- Ran `pytest -q tests/test_include_graph.py` which passed (`25 passed`).
- Ran style checks with `python -m ruff check abicheck/buildsource/include_graph.py tests/test_include_graph.py` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1c663b00832bbc3c7fb45af1b579)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build analysis now stops after a fixed compile-unit budget or time limit, helping prevent long-running or stalled runs.
  * Timeout handling now respects remaining overall time, improving reliability under heavy workloads.
  * Added clearer diagnostics when limits are reached, including “budget exhausted” and “time budget exhausted” messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->