### PR TITLE
fix(buildsource): bound Itanium source-name parsing

### DIFF
--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -44,6 +44,27 @@ from .source_abi import SourceAbiSurface, SourceAbiTu, SourceEntity
 _CTOR_DTOR_TAGS = frozenset({"C1", "C2", "C3", "C4", "D0", "D1", "D2", "D4"})
 
 
+def _consume_source_name(symbol: str, i: int) -> int:
+    """Return the index just past an Itanium length-prefixed ``<source-name>``.
+
+    Mangled names can come from untrusted binaries/snapshots.  Avoid
+    ``int(symbol[i:j])`` here: a malformed symbol with thousands of digits can
+    trip Python's integer-conversion limit (or be expensive on older runtimes).
+    Instead, accumulate only until the declared length is already larger than the
+    remaining symbol, at which point the production is malformed and the caller
+    can safely skip to the end (causing a missed fold, not a crash).
+    """
+    n = len(symbol)
+    j = i
+    length = 0
+    while j < n and "0" <= symbol[j] <= "9":
+        length = length * 10 + (ord(symbol[j]) - ord("0"))
+        j += 1
+        if length > n - j:
+            return n
+    return j + length
+
+
 def _skip_e_terminated(symbol: str, i: int) -> int:
     """Return the index just past the ``E`` that closes the ``I``/``N`` at *i*.
 
@@ -83,11 +104,8 @@ def _skip_e_terminated(symbol: str, i: int) -> int:
                     ldepth -= 1
                 i += 1
             continue
-        if c.isdigit():  # <source-name> — consume by its declared length
-            j = i
-            while j < n and symbol[j].isdigit():
-                j += 1
-            i = j + int(symbol[i:j])
+        if "0" <= c <= "9":  # <source-name> — consume by its declared length
+            i = _consume_source_name(symbol, i)
             continue
         if c in "INF":
             depth += 1
@@ -207,11 +225,8 @@ def _ctor_dtor_structural(symbol: str) -> str:
         c = symbol[i]
         if c == "E":  # end of the nested-name
             break
-        if c.isdigit():  # <source-name> := <len> <identifier> — consume wholesale
-            j = i
-            while j < n and symbol[j].isdigit():
-                j += 1
-            i = j + int(symbol[i:j])
+        if "0" <= c <= "9":  # <source-name> := <len> <identifier> — consume wholesale
+            i = _consume_source_name(symbol, i)
             boundary = True
             continue
         if c == "I":  # <template-args> := I … E (skip the balanced, nested run)

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -433,6 +433,22 @@ def test_ctor_dtor_fold_handles_digit_suffixed_class_names() -> None:
         assert _ctor_dtor_canonical(cls + "C1Ev") != cls + "C1Ev"
 
 
+def test_ctor_dtor_fold_tolerates_malformed_huge_length_fields() -> None:
+    # Exported symbol names may come from untrusted binaries or ABI snapshots.
+    # A malformed Itanium name with an enormous length field must not crash the
+    # structural parser via Python's int-conversion digit limit; it should simply
+    # fail to fold and keep exact/unmatched semantics.
+    from abicheck.buildsource.source_link import _ctor_dtor_canonical
+
+    malformed = "_ZN" + ("9" * 5000)
+    assert _ctor_dtor_canonical(malformed) == malformed
+
+    tu = SourceAbiTu(functions=[_entity("ok", "function", mangled="_Z2okv")])
+    surface = link_source_abi([tu], exported_symbols=["_Z2okv", malformed])
+    assert surface.mappings["source_decl_to_binary_symbol"]["_Z2okv"] == "_Z2okv"
+    assert malformed in surface.unmatched["symbols_without_decl"]
+
+
 def test_ctor_dtor_fold_parses_template_and_substitution_prefixes() -> None:
     # The nested-name parser must skip <substitution> (St = std::) and
     # <template-args> (I…E) before reaching a genuine ctor/dtor tag, e.g.


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service / crash when parsing length-prefixed Itanium `<source-name>` components from untrusted exported symbols or ABI snapshots by avoiding unbounded `int()` conversions on attacker-controlled digit runs.

### Description
- Add `_consume_source_name(symbol, i)` which safely consumes a length-prefixed source-name without calling `int()` on an unbounded digit run.
- Replace direct `int(symbol[i:j])` usage in `_skip_e_terminated` and `_ctor_dtor_structural` with calls to `_consume_source_name` so malformed lengths cause a safe parse miss rather than an exception.
- Add `test_ctor_dtor_fold_tolerates_malformed_huge_length_fields` in `tests/test_source_abi.py` to assert a crafted `_ZN`+5000-digit export does not crash and is reported as unmatched.

### Testing
- Ran `pytest tests/test_source_abi.py -q`; all tests passed (`105 passed`).
- The new regression test verifies the structural ctor/dtor parser tolerates huge/malformed length fields and existing ctor/dtor folding behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1c6535e8832baa3965950abb0843)