### PR TITLE
docs: fix libabigail ABI gate recipe

### DIFF
--- a/docs/user-guide/from-libabigail.md
+++ b/docs/user-guide/from-libabigail.md
@@ -57,7 +57,9 @@ source-level ones:
 # options) a bare compare exiting 2 would kill the step before the test runs
 rc=0
 abicheck compare libfoo.so.1 libfoo.so.2 -H include/ || rc=$?
-test "$rc" -lt 4   # succeeds for 0 (compatible) and 2 (API_BREAK); fails for 4 (BREAKING)
+# succeeds only for compatible/API_BREAK verdicts; fails for tool errors (1)
+# and BREAKING (4)
+test "$rc" -eq 0 || test "$rc" -eq 2
 ```
 
 See [Exit Codes](../reference/exit-codes.md) for the full matrix (including


### PR DESCRIPTION
### Motivation
- The libabigail→abicheck migration guide contained a CI shell recipe that treated any exit code below `4` as success, which incorrectly allowed abicheck runtime/tool errors (`1`) to pass CI gates instead of failing them.  

### Description
- Update the shell snippet in `docs/user-guide/from-libabigail.md` to explicitly accept only `0` and `2` for the “tolerate source-level breaks” gate by replacing `test "$rc" -lt 4` with `test "$rc" -eq 0 || test "$rc" -eq 2` and add a clarifying comment.  

### Testing
- Ran `python scripts/gen_examples_docs.py --check` which completed successfully.  
- Ran `mkdocs build --strict` which built the docs successfully.  
- Verified the updated gate logic with a quick shell check over `rc` values `0,1,2,4,64`, confirming `rc=0` and `rc=2` pass and `rc=1`, `rc=4`, and `rc=64` fail as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1c65e310832bb0959a704d2e2a4f)