### PR TITLE
fix: harden stable ABI data generation

### DIFF
--- a/scripts/gen_stable_abi_data.py
+++ b/scripts/gen_stable_abi_data.py
@@ -42,6 +42,7 @@ Membership — not a name prefix — is what decides stability downstream.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import urllib.request
 from pathlib import Path
@@ -49,6 +50,7 @@ from pathlib import Path
 import tomllib
 
 _OUT = Path(__file__).resolve().parent.parent / "abicheck" / "stable_abi_data.py"
+_SYMBOL_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 
 _LICENSE = """\
 # Copyright 2026 Nikolay Petrov
@@ -74,12 +76,19 @@ def _parse_version(added: str) -> tuple[int, int]:
     return (int(major_s), int(minor_s or "0"))
 
 
+def _validate_symbol_name(name: str) -> None:
+    """Reject names that cannot be CPython C symbols."""
+    if not _SYMBOL_RE.fullmatch(name):
+        raise ValueError(f"invalid Stable-ABI symbol name: {name!r}")
+
+
 def extract(toml_bytes: bytes) -> dict[str, tuple[int, int]]:
     """Extract ``symbol -> (major, minor)`` for every linkable Stable-ABI entry."""
     data = tomllib.loads(toml_bytes.decode("utf-8"))
     symbols: dict[str, tuple[int, int]] = {}
     for section in ("function", "data"):
         for name, meta in data.get(section, {}).items():
+            _validate_symbol_name(name)
             added = meta.get("added")
             if added is not None:
                 symbols[name] = _parse_version(str(added))
@@ -88,13 +97,14 @@ def extract(toml_bytes: bytes) -> dict[str, tuple[int, int]]:
 
 def render(symbols: dict[str, tuple[int, int]], version: str) -> str:
     """Render the full ``stable_abi_data.py`` module text."""
+    for name in symbols:
+        _validate_symbol_name(name)
     rows = "\n".join(
-        f'    "{name}": ({v[0]}, {v[1]}),'
+        f"    {name!r}: ({v[0]}, {v[1]}),"
         for name, v in sorted(symbols.items())
     )
-    return (
-        _LICENSE
-        + '\n"""Vendored CPython Stable-ABI (Limited API) symbol floors — '
+    doc = (
+        "Vendored CPython Stable-ABI (Limited API) symbol floors — "
         "GENERATED DATA.\n\n"
         "Maps every linkable Stable-ABI symbol (``[function.*]`` and "
         "``[data.*]`` entries)\nto the ``(major, minor)`` CPython release that "
@@ -114,7 +124,10 @@ def render(symbols: dict[str, tuple[int, int]], version: str) -> str:
         "generator once it stabilises.\n"
         "Refresh: run ``scripts/gen_stable_abi_data.py`` over a newer "
         "``stable_abi.toml``\n(functions + data sections, ``added`` → floor).\n"
-        '"""\n\n'
+    )
+    return (
+        _LICENSE
+        + f"\n{doc!r}\n\n"
         "from __future__ import annotations\n\n"
         "#: Stable-ABI symbol -> (major, minor) release it entered the "
         "Limited API.\n"

--- a/tests/test_gen_stable_abi_data.py
+++ b/tests/test_gen_stable_abi_data.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+import py_compile
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "gen_stable_abi_data.py"
+_SPEC = importlib.util.spec_from_file_location("gen_stable_abi_data", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+gen_stable_abi_data = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gen_stable_abi_data)
+
+
+def test_extract_rejects_non_c_symbol_names() -> None:
+    toml_bytes = br'''
+[function."PySafe"]
+added = "3.2"
+
+[function."PyBad\"\n, **(__import__('os').system('echo pwned') and {}) #"]
+added = "3.14"
+'''
+
+    with pytest.raises(ValueError, match="invalid Stable-ABI symbol name"):
+        gen_stable_abi_data.extract(toml_bytes)
+
+
+def test_render_uses_python_literals_for_data_and_docstring(tmp_path: Path) -> None:
+    payload = "3.15\"\"\"\n__import__('pathlib').Path('pwned').write_text('x')\n\"\"\""
+    rendered = gen_stable_abi_data.render({"PySafe": (3, 2)}, payload)
+    out = tmp_path / "stable_abi_data.py"
+    out.write_text(rendered, encoding="utf-8")
+
+    py_compile.compile(str(out), doraise=True)
+    assert "'PySafe': (3, 2)" in rendered
+    assert "__import__" in rendered

--- a/tests/test_gen_stable_abi_data.py
+++ b/tests/test_gen_stable_abi_data.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 _SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "gen_stable_abi_data.py"
 _SPEC = importlib.util.spec_from_file_location("gen_stable_abi_data", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None


### PR DESCRIPTION
### Motivation
- The generator previously embedded TOML table keys and the `--version` string directly into produced Python source, allowing a crafted key or version to break out of the dictionary/docstring and inject executable code. 
- This is a supply-chain / developer-tooling RCE risk when the script is run on untrusted TOML or URL-controlled input. 
- The change aims to eliminate source-injection vectors while preserving the generator's output shape.

### Description
- Validate extracted symbol names with a C-identifier regexp via `_SYMBOL_RE` and `_validate_symbol_name`, and call it from `extract` and `render` to reject unsafe TOML keys. 
- Emit generated Python literals using `name!r` for keys and `doc!r` for the header/docstring so untrusted strings are rendered as safe Python string literals rather than interpolated source. 
- Add `tests/test_gen_stable_abi_data.py` with regressions that assert invalid symbol names are rejected and that hostile `--version` payloads are emitted as literal text and compile cleanly. 
- Files touched: `scripts/gen_stable_abi_data.py` and new `tests/test_gen_stable_abi_data.py`.

### Testing
- Ran `pytest -q tests/test_gen_stable_abi_data.py` and it passed (2 passed). 
- Ran `python -m py_compile scripts/gen_stable_abi_data.py` and the script compiled successfully. 
- Ran full `pytest -q` which aborted collection due to the environment missing the `hypothesis` test dependency (collection errors unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1b09fe90832b960b5e119aee05d1)