### PR TITLE
fix(g23): stop treating RISC-V RVC as an ABI flag

### DIFF
--- a/abicheck/diff_platform_elf_dynamic.py
+++ b/abicheck/diff_platform_elf_dynamic.py
@@ -340,6 +340,16 @@ def _diff_abi_flags(old_elf: Any, new_elf: Any, machine: str) -> list[Change]:
     """
     old_abi: frozenset[str] = getattr(old_elf, "abi_flags", frozenset())
     new_abi: frozenset[str] = getattr(new_elf, "abi_flags", frozenset())
+    # Back-compat normalization: the pre-fix RISC-V decoder emitted a legacy
+    # `rvc` token (compressed-instruction ISA bit, not an ABI selector; #504). A
+    # saved `.abi.json` baseline rehydrates `abi_flags` verbatim via
+    # `serialization._elf_from_dict`, so an old baseline can carry `rvc` while a
+    # freshly-parsed side no longer does. Strip it from both sides before
+    # comparing, else `(float-double, rvc)` vs `(float-double)` would falsely
+    # report a BREAKING elf_abi_flags_changed on the same ABI.
+    if machine == "EM_RISCV":
+        old_abi = old_abi - {"rvc"}
+        new_abi = new_abi - {"rvc"}
     if old_abi != new_abi:
         return [
             make_change(

--- a/abicheck/elf_metadata.py
+++ b/abicheck/elf_metadata.py
@@ -293,7 +293,10 @@ _EF_ARM_ABI_FLOAT_HARD = 0x00000400
 _EF_ARM_ABI_FLOAT_SOFT = 0x00000200
 _EF_ARM_EABI_MASK = 0xFF000000
 _EF_RISCV_FLOAT_ABI_MASK = 0x0006  # 0=soft, 2=single, 4=double, 6=quad
-_EF_RISCV_RVC = 0x0001
+# EF_RISCV_RVE (0x8) reduces the integer register file 32→16 and changes the
+# calling convention, so it IS ABI-selecting. EF_RISCV_RVC (0x1, compressed
+# instructions) is an ISA-encoding choice with no calling-convention effect, so
+# it is deliberately NOT decoded — toggling it must not report an ABI break.
 _EF_RISCV_RVE = 0x0008
 _EF_MIPS_ABI_MASK = 0x0000F000
 _RISCV_FLOAT_ABI_NAMES = {0x0: "float-soft", 0x2: "float-single", 0x4: "float-double", 0x6: "float-quad"}
@@ -318,8 +321,6 @@ def _decode_abi_flags(machine: str, e_flags: int) -> frozenset[str]:
             tokens.add(f"eabi{eabi}")
     elif machine in ("EM_RISCV",):
         tokens.add(_RISCV_FLOAT_ABI_NAMES.get(e_flags & _EF_RISCV_FLOAT_ABI_MASK, "float-unknown"))
-        if e_flags & _EF_RISCV_RVC:
-            tokens.add("rvc")
         if e_flags & _EF_RISCV_RVE:
             tokens.add("rve")
     elif machine in ("EM_MIPS",):

--- a/tests/test_elf_metadata_unit.py
+++ b/tests/test_elf_metadata_unit.py
@@ -240,13 +240,18 @@ class TestDecodeAbiFlags:
         from abicheck.elf_metadata import _decode_abi_flags
         assert _decode_abi_flags("EM_ARM", 0x200) == frozenset({"float-soft"})
 
-    def test_riscv_double_float_with_compressed(self):
+    def test_riscv_compressed_is_not_an_abi_flag(self):
         from abicheck.elf_metadata import _decode_abi_flags
-        # float-abi double (0x4) | RVC (0x1).
-        assert _decode_abi_flags("EM_RISCV", 0x4 | 0x1) == frozenset({"float-double", "rvc"})
+        # RVC (0x1, compressed instructions) is an ISA-encoding choice, not a
+        # calling-convention/ABI selector, so it must NOT contribute a token:
+        # float-abi double (0x4) with or without RVC decodes identically.
+        assert _decode_abi_flags("EM_RISCV", 0x4) == frozenset({"float-double"})
+        assert _decode_abi_flags("EM_RISCV", 0x4 | 0x1) == frozenset({"float-double"})
 
     def test_riscv_soft_float_and_rve(self):
         from abicheck.elf_metadata import _decode_abi_flags
+        # RVE (0x8) halves the integer register file and changes the calling
+        # convention, so it IS ABI-selecting and contributes a token.
         assert _decode_abi_flags("EM_RISCV", 0x0 | 0x8) == frozenset({"float-soft", "rve"})
 
     def test_mips_abi_bits(self):

--- a/tests/test_g23_elf_facts.py
+++ b/tests/test_g23_elf_facts.py
@@ -285,6 +285,15 @@ class TestElfIdentity:
         r = compare(_snap(old), _snap(new))
         assert ChangeKind.ELF_ABI_FLAGS_CHANGED not in _kinds(r)
 
+    def test_riscv_rvc_toggle_is_not_a_break(self):
+        # Rebuilding a RISC-V library with the same -mabi (lp64d/float-double)
+        # but toggling the compressed-instruction bit (e_flags 0x4 → 0x5) is an
+        # ISA-encoding change, not an ABI break: no elf_abi_flags_changed.
+        old = ElfMetadata(machine="EM_RISCV", abi_flags=frozenset({"float-double"}), e_flags=0x4)
+        new = ElfMetadata(machine="EM_RISCV", abi_flags=frozenset({"float-double"}), e_flags=0x5)
+        r = compare(_snap(old), _snap(new))
+        assert ChangeKind.ELF_ABI_FLAGS_CHANGED not in _kinds(r)
+
     def test_undecoded_arch_uses_raw_eflags_fallback(self):
         # For an arch we don't decode at all (e.g. PPC64, whose ELFv1/ELFv2 ABI
         # version lives in e_flags), the raw-e_flags fallback is the only ABI

--- a/tests/test_g23_elf_facts.py
+++ b/tests/test_g23_elf_facts.py
@@ -294,6 +294,15 @@ class TestElfIdentity:
         r = compare(_snap(old), _snap(new))
         assert ChangeKind.ELF_ABI_FLAGS_CHANGED not in _kinds(r)
 
+    def test_legacy_rvc_baseline_not_flagged(self):
+        # Back-compat: a saved baseline produced by the pre-fix decoder carries a
+        # legacy `rvc` token in abi_flags. Comparing it against a freshly-parsed
+        # side (no `rvc`) with the same real ABI must NOT report a change (#504).
+        old = ElfMetadata(machine="EM_RISCV", abi_flags=frozenset({"float-double", "rvc"}))
+        new = ElfMetadata(machine="EM_RISCV", abi_flags=frozenset({"float-double"}))
+        r = compare(_snap(old), _snap(new))
+        assert ChangeKind.ELF_ABI_FLAGS_CHANGED not in _kinds(r)
+
     def test_undecoded_arch_uses_raw_eflags_fallback(self):
         # For an arch we don't decode at all (e.g. PPC64, whose ELFv1/ELFv2 ABI
         # version lives in e_flags), the raw-e_flags fallback is the only ABI


### PR DESCRIPTION
## Summary

Post-merge follow-up to #495 (G23 Phase A–D). A Codex review comment on the merged commit flagged that the RISC-V `e_flags` decoder treats the **compressed-instruction** bit as an ABI-selecting flag, which produces a false `BREAKING` verdict on compatible rebuilds.

## Problem

`_decode_abi_flags` added an `rvc` token when `EF_RISCV_RVC (0x1)` was set. RVC is an ISA-*encoding* choice — it does not change the calling convention or the ELF ABI. Because #495 scoped the raw-`e_flags` fallback to *undecoded* architectures, this decoded token set is RISC-V's only ABI signal, so rebuilding a library with the same `-mabi` (e.g. `lp64d`) while toggling compression (`e_flags` `0x4` → `0x5`) added the `rvc` token → `abi_flags` differed → a spurious `elf_abi_flags_changed` (BREAKING) on an ABI-compatible rebuild.

## Change

- `abicheck/elf_metadata.py`: drop the `rvc` token from the RISC-V decode. Keep `rve` (`EF_RISCV_RVE`, `0x8`) — it halves the integer register file (32→16) and genuinely changes the calling convention, so it *is* ABI-selecting.
- Tests: replace the assertion that `rvc` is decoded, and add a regression test that an RVC toggle produces **no** `elf_abi_flags_changed`.

## Validation

- `ruff check`, `mypy abicheck/` — clean
- `tests/test_elf_metadata_unit.py`, `tests/test_g23_elf_facts.py` — pass (full fast suite green before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmjttjQWiDAtgsmgtohxet

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmjttjQWiDAtgsmgtohxet)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RISC-V ABI flag handling so older snapshots with legacy flag values no longer trigger false change detections.
  * Updated ABI flag decoding to better distinguish ABI-relevant RISC-V settings, reducing misleading comparison results.
* **Tests**
  * Expanded coverage for RISC-V flag decoding and comparison behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->