### PR TITLE
Fix POST manifest scoped comparison omissions

### DIFF
--- a/abicheck/post_manifest.py
+++ b/abicheck/post_manifest.py
@@ -375,28 +375,30 @@ def contract_scope_allowlist(
     """The committed surface to scope ``compare --post-manifest`` against.
 
     The manifest's ``pp_*``/loop symbols, plus committed-namespace (``pp_*``,
-    excluding ``__pp_*``) symbols that were **removed** — present in the old
-    snapshot but not the new one.
+    excluding ``__pp_*``) symbols exported by the old snapshot.
 
-    The removed-symbol union keeps a *dropped* committed wrapper in-surface: when
-    the manifest passed is the **new** one that no longer lists it, its removal
-    would otherwise fall outside the allowlist and be demoted — hiding an ABI
-    break. It is deliberately narrow: a ``pp_*`` symbol present in *both*
-    snapshots but absent from the manifest is an *undeclared* export (validation
-    reports it separately), so its signature churn stays demoted under
-    manifest-authoritative scoping rather than driving the verdict. ``__pp_*``
-    kernel churn is excluded throughout.
+    The old-symbol union keeps any previously committed wrapper in-surface even
+    when the supplied manifest is the **new** one and omits it. That covers both
+    dropped wrappers and still-exported-but-undeclared wrappers: their removals,
+    visibility changes, or signature churn must not be silently demoted by a
+    manifest-authoritative allowlist. ``__pp_*`` kernel churn is excluded
+    throughout.
 
-    BOUNDARY: recovery of a *removed* committed symbol keys on the ``pp_*``
-    namespace, since a single (new) manifest cannot name what was committed
-    before. A committed ufunc ``loop_symbol`` that is *not* ``pp_``-prefixed and
-    is dropped/renamed across versions therefore may be demoted under binary
-    scoping. The manifest↔manifest :func:`diff_manifests` / :func:`check_version_gate`
-    — which see *both* versions — are the authoritative check for loop-symbol
+    BOUNDARY: snapshot recovery keys on the ``pp_*`` namespace, since a single
+    (new) manifest cannot name what was committed before. A committed ufunc
+    ``loop_symbol`` that is *not* ``pp_``-prefixed and is dropped/renamed across
+    versions therefore may be demoted under binary scoping. The
+    manifest↔manifest :func:`diff_manifests` / :func:`check_version_gate` —
+    which see *both* versions — are the authoritative check for loop-symbol
     renames and removals; use them in release gating, with binary
     ``compare --post-manifest`` as the best-effort surface filter.
     """
-    return public_c_symbols(manifest) | removed_contract_symbols(old_snapshot, new_snapshot)
+    old_syms = (
+        _snapshot_contract_symbols(old_snapshot)
+        if old_snapshot is not None
+        else removed_contract_symbols(old_snapshot, new_snapshot)
+    )
+    return public_c_symbols(manifest) | old_syms
 
 
 def removed_contract_symbols(old_snapshot: Any = None, new_snapshot: Any = None) -> set[str]:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1007,20 +1007,19 @@ def compare_snapshots(
     through here instead of importing ``checker.compare``; the kwargs mirror the
     core verb exactly so no capability is lost.
     """
-    # Centralized POST removed-wrapper recovery: when a committed-surface
-    # allowlist is supplied, union the wrappers present in *old* but gone from
-    # *new* (contract_scope_allowlist's snapshot half) so a dropped/hidden/
-    # non-default-demoted committed wrapper — absent from a *new* manifest — stays
-    # in-surface. Every scope caller (CLI, run_compare_request, direct API) routes
-    # through here, so recovery happens once and uniformly; it is a no-op when the
-    # allowlist/binaries carry no `pp_*` removals (safe for scan/appcompat, which
-    # never set the allowlist). Idempotent if the caller already unioned it.
+    # Centralized POST committed-wrapper recovery: when a committed-surface
+    # allowlist is supplied, union the callable `pp_*` wrappers exported by the
+    # old snapshot (contract_scope_allowlist's snapshot half). This keeps both
+    # dropped wrappers and still-exported-but-omitted wrappers in-surface when a
+    # caller scopes against a new manifest, preventing manifest omissions from
+    # hiding ABI breaks. Every scope caller (CLI, run_compare_request, direct API)
+    # routes through here, so recovery happens once and uniformly; it is a no-op
+    # when the allowlist/binaries carry no `pp_*` wrappers. Idempotent if the
+    # caller already unioned it.
     if public_surface_allowlist is not None:
-        from .post_manifest import removed_contract_symbols
+        from .post_manifest import _snapshot_contract_symbols
 
-        public_surface_allowlist = (
-            set(public_surface_allowlist) | removed_contract_symbols(old, new)
-        )
+        public_surface_allowlist = set(public_surface_allowlist) | _snapshot_contract_symbols(old)
     return compare(
         old,
         new,

--- a/tests/test_post_manifest_scope.py
+++ b/tests/test_post_manifest_scope.py
@@ -180,6 +180,19 @@ def test_compare_snapshots_recovers_removed_wrapper_from_raw_allowlist() -> None
     assert plain.verdict in (Verdict.BREAKING, Verdict.API_BREAK)
 
 
+def test_compare_snapshots_recovers_omitted_still_exported_wrapper() -> None:
+    from abicheck.checker_policy import Verdict
+    from abicheck.service import compare_snapshots
+
+    old = _snap([_cfn("pp_foo"), _cfn("pp_omitted", "int", ("int",))])
+    new = _snap([_cfn("pp_foo"), _cfn("pp_omitted", "long", ("long",))])
+
+    result = compare_snapshots(old, new, public_surface_allowlist={"pp_foo"})
+
+    assert result.verdict in (Verdict.BREAKING, Verdict.API_BREAK)
+    assert not any("pp_omitted" == c.symbol for c in result.out_of_surface_changes)
+
+
 def test_loader_level_finding_survives_manifest_scope() -> None:
     # Codex: a SONAME/NEEDED change (symbol is a pseudo-name like DT_SONAME, not
     # a real export) breaks linked clients regardless of the POST export set, so

--- a/tests/test_post_manifest_scope.py
+++ b/tests/test_post_manifest_scope.py
@@ -279,10 +279,42 @@ def test_post_manifest_ledger_shown_even_with_no_scope_public_headers(tmp_path: 
     assert "__pp_foo_impl" in json.dumps(doc["surface_scope"])
 
 
-def test_contract_scope_allowlist_unions_only_removed_symbols() -> None:
-    # The union recovers a *removed* committed wrapper (old-not-new) but must NOT
-    # add an undeclared pp_* present in *both* snapshots — that stays demoted
-    # under manifest-authoritative scoping.
+def test_compare_cli_post_manifest_keeps_omitted_old_pp_symbol_in_scope(tmp_path: Path) -> None:
+    # Regression: a new manifest that omits a still-exported old pp_* wrapper
+    # must not be able to scope that wrapper's ABI changes out of the verdict.
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(
+        snapshot_to_json(_snap([_cfn("pp_foo"), _cfn("pp_undeclared", "int", ("int",))])),
+        encoding="utf-8",
+    )
+    new_p.write_text(
+        snapshot_to_json(_snap([_cfn("pp_foo"), _cfn("pp_undeclared", "long", ("long",))])),
+        encoding="utf-8",
+    )
+
+    manifest = tmp_path / "m.json"
+    manifest.write_text(json.dumps({
+        "post_abi": 1,
+        "exports": [{"name": "foo", "c_symbol": "pp_foo",
+                     "params": ["Float64"], "return_dtype": "Float64"}],
+    }), encoding="utf-8")
+
+    res = CliRunner().invoke(
+        main, ["compare", str(old_p), str(new_p), "--post-manifest", str(manifest),
+               "--no-scope-public-headers", "--format", "json"],
+    )
+    assert res.exit_code == 4, res.output
+    doc = json.loads(res.output[res.output.find("{"):])
+    assert doc["verdict"] == "BREAKING"
+    assert "pp_undeclared" in json.dumps(doc.get("changes", []))
+    assert "pp_undeclared" not in json.dumps(doc.get("surface_scope", {}))
+
+
+def test_contract_scope_allowlist_unions_old_committed_symbols() -> None:
+    # The union recovers any old committed wrapper, including one omitted from
+    # the new manifest but still exported in both snapshots. Such wrappers stay
+    # in-surface so manifest omissions cannot hide their ABI changes.
     from abicheck.post_manifest import contract_scope_allowlist, parse_manifest
 
     manifest = parse_manifest({"post_abi": 1, "exports": [{
@@ -295,7 +327,7 @@ def test_contract_scope_allowlist_unions_only_removed_symbols() -> None:
     allow = contract_scope_allowlist(manifest, old, new)
     assert "pp_foo" in allow            # committed
     assert "pp_removed" in allow        # removed committed wrapper -> kept in-surface
-    assert "pp_undeclared" not in allow  # present in both, undeclared -> demoted
+    assert "pp_undeclared" in allow      # old committed wrapper -> kept in-surface
     assert "__pp_impl" not in allow     # private kernel -> demoted
 
 


### PR DESCRIPTION
### Motivation
- The `--post-manifest` allowlist previously trusted the supplied manifest plus only `pp_*` symbols removed from the old snapshot, which let a still-exported `pp_*` wrapper omitted from the manifest have ABI changes demoted out of the verdict. 
- The change closes this integrity gap so a manifest omission cannot be used to hide ABI breaks for previously committed callable wrappers.

### Description
- `contract_scope_allowlist` now unions the callable `pp_*` exports exported by the old snapshot with the manifest symbols so any previously committed wrapper (including one omitted from a new manifest but still exported) remains in-surface (`abicheck/post_manifest.py`).
- The service-level comparator applies the same recovery so all callers that supply a `public_surface_allowlist` get identical protection (`abicheck/service.py`).
- Added regression coverage and updated expectations to prove a manifest that omits a still-exported old `pp_*` symbol with a signature change yields a breaking verdict and is not silently demoted (`tests/test_post_manifest_scope.py`).

### Testing
- Ran `git diff --check` and it reported no style/overlap issues.
- Ran `python -m pytest tests/test_post_manifest_scope.py tests/test_post_manifest.py -q` and all tests passed (`114 passed`).
- Ran the full test suite with `python -m pytest -q`, which failed collection due to a missing test dependency (`ModuleNotFoundError: No module named 'hypothesis'`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1c8114b8832bad9fe497d9df5ac7)