### PR TITLE
fix(python): treat required→optional overload widening as compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Python overload required→optional widening no longer a false break.**
+  `_overload_covers` compared required parameter shapes with exact equality, so
+  an `@overload` that keeps a parameter but adds a default
+  (`def f(x: int)` → `def f(x: int = ...)`) moved `x` from the required to the
+  optional shape and was mis-reported as `python_api_overload_removed` /
+  API_BREAK — even though every old call is still accepted. Coverage now uses an
+  order-preserving "widened subsequence" check, so a required→optional widening
+  is treated as compatible while a newly *required* parameter or a reordering of
+  retained required parameters still counts as a removal.
 - **Stdlib RTTI/guard classification.** Exported `typeinfo`/`vtable`/`guard
   variable` symbols for *nested* std types (`std::__detail::_AnyMatcher<…>`, …)
   demangle as `"typeinfo for std::…"`, so the `startswith("std::")` origin test

--- a/abicheck/diff_python_api.py
+++ b/abicheck/diff_python_api.py
@@ -395,14 +395,42 @@ def _optional_shape(fn: PyFunction) -> frozenset[tuple[Any, ...]]:
     return frozenset(keys)
 
 
+def _covers_required_shape(
+    old_req: tuple[Any, ...],
+    new_req: tuple[Any, ...],
+    new_opt: frozenset[tuple[Any, ...]],
+) -> bool:
+    """True when ``new_v``'s required params still accept ``old_v``'s minimal call.
+
+    ``new_req`` must be ``old_req`` with zero or more parameters *widened* to
+    optional — an order-preserving subsequence where every dropped key reappears
+    in ``new_opt``. This keeps a required→optional change
+    (``@overload def f(x: int)`` → ``def f(x: int = ...)``) covered — every old
+    call that supplied ``x`` is still accepted — while still rejecting a *new*
+    required parameter (breaks the minimal call) or a reordering of the retained
+    required parameters (rebinds positional callers).
+    """
+    i = 0
+    for key in old_req:
+        if i < len(new_req) and new_req[i] == key:
+            i += 1  # still required in new_v, same position
+        elif key in new_opt:
+            continue  # widened to optional in new_v — the old call still binds
+        else:
+            return False  # required param dropped, or new_v added/reordered one
+    return i == len(new_req)  # no extra required parameter in new_v
+
+
 def _overload_covers(new_v: PyFunction, old_v: PyFunction) -> bool:
     """True when new variant *new_v* still accepts every call *old_v* accepted.
 
     Overload matching is **directional**, not a symmetric identity: adding an
-    optional parameter to a variant is a compatible *widening* (still matches),
-    but *removing* one drops a supported call shape (a real removal), so the two
-    must not collapse to the same key. ``new_v`` covers ``old_v`` when they share
-    the same protocol (async / descriptor), the same required input shape, and
+    optional parameter to a variant (or widening a required one to optional) is a
+    compatible *widening* (still matches), but *removing* one drops a supported
+    call shape (a real removal), so the two must not collapse to the same key.
+    ``new_v`` covers ``old_v`` when they share the same protocol (async /
+    descriptor), ``new_v``'s required shape is ``old_v``'s with zero or more
+    parameters widened to optional (see ``_covers_required_shape``), and
     ``new_v``'s optional-parameter set is a **superset** of ``old_v``'s (so every
     optional call ``old_v`` accepted, ``new_v`` also accepts); and ``new_v`` must
     keep any ``*args`` / ``**kwargs`` collector ``old_v`` had (dropping one
@@ -411,7 +439,9 @@ def _overload_covers(new_v: PyFunction, old_v: PyFunction) -> bool:
     """
     if new_v.is_async != old_v.is_async or new_v.descriptor != old_v.descriptor:
         return False
-    if _required_shape(new_v) != _required_shape(old_v):
+    if not _covers_required_shape(
+        _required_shape(old_v), _required_shape(new_v), _optional_shape(new_v)
+    ):
         return False
     if not (_optional_shape(new_v) >= _optional_shape(old_v)):
         return False

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -788,6 +788,34 @@ def test_overload_required_param_widened_to_optional_is_compatible() -> None:
     )
     kinds = _diff_kinds(old, new)
     assert ChangeKind.PYTHON_API_OVERLOAD_REMOVED not in kinds
+    # Widening a trailing required param to optional is fully compatible — no
+    # finding of any kind (the old variant is still covered, and the matched
+    # variant's signature diff sees only a gained default, which is additive).
+    assert not kinds
+
+
+def test_overload_new_required_param_is_breaking() -> None:
+    # Adding a *required* parameter to a variant breaks the minimal call shape
+    # (`f(1)` no longer binds), so `_covers_required_shape` refuses to treat the
+    # widening as covered; the matched-variant diff reports the added parameter.
+    old = "from typing import overload\n@overload\ndef f(x: int) -> int: ...\n"
+    new = "from typing import overload\n@overload\ndef f(x: int, y: str) -> int: ...\n"
+    kinds = _diff_kinds(old, new)
+    assert ChangeKind.PYTHON_API_PARAMETER_ADDED in kinds
+
+
+def test_overload_nontrailing_required_widened_forces_reorder_is_breaking() -> None:
+    # Widening a *non-trailing* required param to optional forces Python to
+    # reorder the remaining required param ahead of it
+    # (`def f(a, b)` → `def f(b, a=...)`), which rebinds positional callers:
+    # `f(1, "x")` bound a=1 before, b=1 now. The order-preserving subsequence
+    # check in `_covers_required_shape` does not let this masquerade as a clean
+    # widening — the retained required `b` moved position, so the matched-variant
+    # diff flags the parameter-kind/position change. It must NOT be compatible.
+    old = "from typing import overload\n@overload\ndef f(a: int, b: str) -> int: ...\n"
+    new = "from typing import overload\n@overload\ndef f(b: str, a: int = ...) -> int: ...\n"
+    kinds = _diff_kinds(old, new)
+    assert ChangeKind.PYTHON_API_PARAMETER_KIND_CHANGED in kinds
 
 
 def test_overload_param_type_change_is_removal() -> None:

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -772,6 +772,24 @@ def test_overload_return_only_change_is_risk_not_removal() -> None:
     assert ChangeKind.PYTHON_API_OVERLOAD_REMOVED not in kinds
 
 
+def test_overload_required_param_widened_to_optional_is_compatible() -> None:
+    # `@overload def f(x: int)` → `@overload def f(x: int = ...)`: the required
+    # `x` becomes optional. Every old call that supplied `x` (`f(1)`) is still
+    # accepted, so this is a compatible widening, NOT an overload removal.
+    old = (
+        "from typing import overload\n"
+        "@overload\ndef f(x: int) -> int: ...\n"
+        "@overload\ndef f(x: str) -> str: ...\n"
+    )
+    new = (
+        "from typing import overload\n"
+        "@overload\ndef f(x: int = ...) -> int: ...\n"  # x widened to optional
+        "@overload\ndef f(x: str) -> str: ...\n"
+    )
+    kinds = _diff_kinds(old, new)
+    assert ChangeKind.PYTHON_API_OVERLOAD_REMOVED not in kinds
+
+
 def test_overload_param_type_change_is_removal() -> None:
     # A *parameter*-type change drops a supported input call shape → removal.
     old = (


### PR DESCRIPTION
## Summary

Fix a false ABI-break: an `@overload` that widens a required parameter to optional is now correctly treated as a compatible change, not an overload removal.

## Motivation

Follow-up to a Codex review comment on the merged G23 PR (#497). `_overload_covers` compared required parameter shapes with **exact equality**, so an overload that keeps a parameter but only adds a default —

```python
@overload
def f(x: int) -> int: ...      # x required
# →
@overload
def f(x: int = ...) -> int: ... # x optional
```

— moved `x` from `_required_shape` to `_optional_shape`, the shapes no longer matched, and `_diff_callable` reported `python_api_overload_removed` / `API_BREAK`. But every old call that supplied `x` (e.g. `f(1)`) is still accepted, so this is a compatible widening, like adding a new optional parameter.

## Changes

- Replace the exact required-shape equality in `_overload_covers` with a new `_covers_required_shape` helper — an order-preserving **"widened subsequence"** test: `new_v`'s required params must be `old_v`'s with zero or more widened to optional (each dropped key reappearing in `new_v`'s optional set).
  - Keeps a required→optional widening **covered** (compatible).
  - Still rejects a newly **required** parameter (breaks the minimal call).
  - Still rejects a **reordering** of retained required params (rebinds positional callers).
- Add regression test `test_overload_required_param_widened_to_optional_is_compatible` (verified: fails without the fix, passes with it).
- CHANGELOG `[Unreleased] → Fixed` entry.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed — n/a (bug fix, no doc-visible surface change)
- [x] No new `mypy` or `ruff` errors introduced (both clean; FP-rate and tier-accuracy gates pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBt8njfkMYfFgg2FA3LuLf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBt8njfkMYfFgg2FA3LuLf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Python API compatibility checks so an overload that keeps the same parameter but makes it optional is no longer flagged as a breaking change.
  - Reduced false-positive ABI/API break reports for this kind of overload update.
- **Tests**
  - Added coverage for the case where a required overload parameter becomes optional and should remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->