### PR TITLE
docs: refresh tool comparison coverage matrix

### DIFF
--- a/docs/development/abicc-test-coverage-comparison.md
+++ b/docs/development/abicc-test-coverage-comparison.md
@@ -1,8 +1,8 @@
 # ABICC vs Abicheck: Test Coverage Comparison
 
-> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **342**, see the [Change Kind Reference](../reference/change-kinds.md).
+> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **312**, see the [Change Kind Reference](../reference/change-kinds.md).
 > Source: ABICC `RulesBin.xml` (196 rules), `RulesSrc.xml` (100 rules + `Removed_Const_Overload`), `RegTests.pm` (~153 C++ + ~102 C named scenarios)
-> Target: abicheck `examples/` (162 ground-truth entries today; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**342 change kinds** today; the per-rule mappings below were written against an earlier snapshot)
+> Target: abicheck `examples/` (164 ground-truth entries today: 134 binary shared-library competitor lanes plus dedicated non-.so lanes, including fixture/source-only L2/L5/source cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**312 change kinds** today; the per-rule mappings below were written against an earlier snapshot)
 >
 > **Analysis modes:** Abicheck uses **both** header comparison (via castxml) **and** binary analysis (ELF/DWARF).
 > The `dump()` function combines castxml header parsing (types, functions, enums, typedefs, constants) with
@@ -22,9 +22,9 @@
 | ABICC RegTests.pm named scenarios | ~255 (~153 C++ + ~102 C) |
 | ABICC de-duplicated scenarios | ~66 |
 | **Abicheck covers (has ChangeKind + tests)** | **66/66 (100%)** |
-| Abicheck ChangeKind enum members | **342 change kinds** (this table's per-rule mappings reflect an earlier snapshot) |
+| Abicheck ChangeKind enum members | **312 change kinds** (this table's per-rule mappings reflect an earlier snapshot) |
 | All ChangeKinds have assertion tests | **Yes** (enforced by `test_changekind_completeness.py`) |
-| Abicheck example cases | 129 |
+| Abicheck example cases | 164 total: 134 binary shared-library competitor lanes + 30 dedicated non-.so lanes (including fixture/source-only L2/L5/source cases) |
 | ABICC scenarios NOT in abicheck | **0** |
 
 ---
@@ -373,6 +373,6 @@ These detectors exist in abicheck but have no ABICC equivalent:
 
 **0 remaining gaps.** All ABICC de-duplicated detection scenarios are covered by abicheck with dedicated ChangeKinds and explicit assertion tests, including the `TypedefToFunction` scenario (covered in `test_changekind_completeness.py`).
 
-**All 342 `ChangeKind`s have assertion-level test coverage today**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
+**All 312 `ChangeKind`s have assertion-level test coverage today**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
 
 **Inline function scenarios (4):** `RemovedInlineMethod`, `removedInlineFunction`, `functionBecameInline`, `RemovedInlineVirtualFunction` — these ABICC scenarios detect inline function removal via header comparison. In abicheck, inline functions declared in headers are parsed by castxml but filtered against ELF `.dynsym` (inline functions have no exported symbol). If headers are provided, castxml captures the declaration; detection depends on whether the symbol was previously exported. Virtual inline function removal is still detected via vtable changes (`TYPE_VTABLE_CHANGED`). These are classified as **edge cases** rather than gaps, since the typical ABI contract concerns exported symbols.

--- a/docs/development/abicc-test-coverage-comparison.md
+++ b/docs/development/abicc-test-coverage-comparison.md
@@ -1,8 +1,8 @@
 # ABICC vs Abicheck: Test Coverage Comparison
 
-> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **312**, see the [Change Kind Reference](../reference/change-kinds.md).
+> Updated: 2026-03-09; content reviewed 2026-06-07. The ABICC rule mapping is a historical parity snapshot; the current ChangeKind total is **342**, see the [Change Kind Reference](../reference/change-kinds.md).
 > Source: ABICC `RulesBin.xml` (196 rules), `RulesSrc.xml` (100 rules + `Removed_Const_Overload`), `RegTests.pm` (~153 C++ + ~102 C named scenarios)
-> Target: abicheck `examples/` (164 ground-truth entries today: 134 binary shared-library competitor lanes plus dedicated non-.so lanes, including fixture/source-only L2/L5/source cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**312 change kinds** today; the per-rule mappings below were written against an earlier snapshot)
+> Target: abicheck `examples/` (164 ground-truth entries today: 134 binary shared-library competitor lanes plus dedicated non-.so lanes, including fixture/source-only L2/L5/source cases; the original 74-case subset is the release-pinned cross-tool benchmark), `tests/` (large unit/integration/parity suite), `ChangeKind` enum (**342 change kinds** today; the per-rule mappings below were written against an earlier snapshot)
 >
 > **Analysis modes:** Abicheck uses **both** header comparison (via castxml) **and** binary analysis (ELF/DWARF).
 > The `dump()` function combines castxml header parsing (types, functions, enums, typedefs, constants) with
@@ -22,7 +22,7 @@
 | ABICC RegTests.pm named scenarios | ~255 (~153 C++ + ~102 C) |
 | ABICC de-duplicated scenarios | ~66 |
 | **Abicheck covers (has ChangeKind + tests)** | **66/66 (100%)** |
-| Abicheck ChangeKind enum members | **312 change kinds** (this table's per-rule mappings reflect an earlier snapshot) |
+| Abicheck ChangeKind enum members | **342 change kinds** (this table's per-rule mappings reflect an earlier snapshot) |
 | All ChangeKinds have assertion tests | **Yes** (enforced by `test_changekind_completeness.py`) |
 | Abicheck example cases | 164 total: 134 binary shared-library competitor lanes + 30 dedicated non-.so lanes (including fixture/source-only L2/L5/source cases) |
 | ABICC scenarios NOT in abicheck | **0** |
@@ -373,6 +373,6 @@ These detectors exist in abicheck but have no ABICC equivalent:
 
 **0 remaining gaps.** All ABICC de-duplicated detection scenarios are covered by abicheck with dedicated ChangeKinds and explicit assertion tests, including the `TypedefToFunction` scenario (covered in `test_changekind_completeness.py`).
 
-**All 312 `ChangeKind`s have assertion-level test coverage today**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
+**All 342 `ChangeKind`s have assertion-level test coverage today**, enforced by `test_changekind_completeness.py`. Previously, 3 ChangeKinds (`SYMBOL_BINDING_STRENGTHENED`, `VAR_ACCESS_WIDENED`, `TYPE_VTABLE_CHANGED`) were only referenced in set/list definitions but lacked explicit assertion tests; these are now covered.
 
 **Inline function scenarios (4):** `RemovedInlineMethod`, `removedInlineFunction`, `functionBecameInline`, `RemovedInlineVirtualFunction` — these ABICC scenarios detect inline function removal via header comparison. In abicheck, inline functions declared in headers are parsed by castxml but filtered against ELF `.dynsym` (inline functions have no exported symbol). If headers are provided, castxml captures the declaration; detection depends on whether the symbol was previously exported. Virtual inline function removal is still detected via vtable changes (`TYPE_VTABLE_CHANGED`). These are classified as **edge cases** rather than gaps, since the typical ABI contract concerns exported symbols.

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -20,7 +20,7 @@ map across all three.
 ## Headline
 
 abicheck is **exceptionally deep on the change-taxonomy axis and comparatively
-thin on the breadth axes.** The "what changed" dimension — **312 `ChangeKind`s**
+thin on the breadth axes.** The "what changed" dimension — **342 `ChangeKind`s**
 in a 5-tier policy model, **164 calibrated example cases** (134 binary shared-library competitor lanes plus dedicated fixture/source lanes), ABICC + libabigail
 parity — is essentially complete and has diminishing returns.
 
@@ -66,7 +66,7 @@ A real invocation is a point in this space:
 
 | Use case | Status | Notes |
 |---|---|---|
-| Change taxonomy | `complete` | 312 change kinds; 164 ground-truth entries; parity tests; fixture/source-only L2/L5/source cases are tracked separately from binary `.so` competitor lanes |
+| Change taxonomy | `complete` | 342 change kinds; 164 ground-truth entries; parity tests; fixture/source-only L2/L5/source cases are tracked separately from binary `.so` competitor lanes |
 | **Release recommendation (semver + SONAME)** | `complete` | semver bump + SONAME action emitted in reports |
 | C / C++ archetypes | `complete` | 35 C + 52 C++ example pairs |
 | Linux ELF platform | `complete` | the CI-validated baseline |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -20,8 +20,8 @@ map across all three.
 ## Headline
 
 abicheck is **exceptionally deep on the change-taxonomy axis and comparatively
-thin on the breadth axes.** The "what changed" dimension — **342 `ChangeKind`s**
-in a 5-tier policy model, **129 calibrated example cases**, ABICC + libabigail
+thin on the breadth axes.** The "what changed" dimension — **312 `ChangeKind`s**
+in a 5-tier policy model, **164 calibrated example cases** (134 binary shared-library competitor lanes plus dedicated fixture/source lanes), ABICC + libabigail
 parity — is essentially complete and has diminishing returns.
 
 The remaining gaps are **not in detecting more change types**. They are the
@@ -66,7 +66,7 @@ A real invocation is a point in this space:
 
 | Use case | Status | Notes |
 |---|---|---|
-| Change taxonomy | `complete` | 342 change kinds; 162 ground-truth entries; parity tests |
+| Change taxonomy | `complete` | 312 change kinds; 164 ground-truth entries; parity tests; fixture/source-only L2/L5/source cases are tracked separately from binary `.so` competitor lanes |
 | **Release recommendation (semver + SONAME)** | `complete` | semver bump + SONAME action emitted in reports |
 | C / C++ archetypes | `complete` | 35 C + 52 C++ example pairs |
 | Linux ELF platform | `complete` | the CI-validated baseline |

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -6,18 +6,21 @@ benchmark results across real-world test cases, and why the numbers come out the
 > **Note:** abicheck detects 342 change kinds (see [Change Kind Reference](change-kinds.md)).
 > The current cross-tool benchmark covers a pinned 74-case subset of the
 > `examples/` catalog (`case01`-`case73` + `case26b`); the full
-> `examples/ground_truth.json` catalog now has 162 entries (153 compare-mode
-> cases plus 9 single-build audit/cross-source cases), split as 157
-> single-library cases plus 5 multi-library bundle cases. The subset is pinned
-> so accuracy numbers stay reproducible across releases.
+> `examples/ground_truth.json` catalog now has 164 entries. Tool-to-tool
+> competitor scans use the 134 binary shared-library `.so` lanes; fixture/source
+> L2/L5/source cases (`case152`-`case158`, `case160`-`case164`) and the other
+> audit, cross-source, bundle, BTF, and snapshot cases are tracked in dedicated
+> non-`.so` lanes. The subset is pinned so accuracy numbers stay reproducible
+> across releases.
 >
-> **Which denominator is which.** **162** is the whole catalog. The scan-depth
-> matrix is compare-style and intentionally uses only comparable v1/v2
-> shared-library targets: **141/141** of that scope are scanned at every depth.
-> FP/FN math now uses all **141** comparable targets: `NO_CHANGE` sentinel
-> cases are checked as compatible/no-change outcomes, and bundle cases are
-> checked against their per-library expected verdicts. Other dedicated lanes
-> cover audit, cross-source, bundle, BTF, and snapshot cases.
+> **Which denominator is which.** **164** is the whole catalog. The binary
+> competitor lane is **134** shared-library pairs. The scan-depth matrix is
+> compare-style and intentionally uses only comparable v1/v2 shared-library
+> targets: **141/141** of that scope are scanned at every depth. FP/FN math now
+> uses all **141** comparable targets: `NO_CHANGE` sentinel cases are checked as
+> compatible/no-change outcomes, and bundle cases are checked against their
+> per-library expected verdicts. Dedicated lanes cover fixture/source-only L2/L5
+> cases, audit, cross-source, bundle, BTF, and snapshot cases.
 
 > **Why the tools disagree.** The accuracy gaps below are mostly an *evidence*
 > story: each tool sees a different subset of the binary/debug/header inputs. For
@@ -36,15 +39,16 @@ ABICC/libabigail on a stable cross-tool corpus?"
 
 | Scan | Scope | Execution | Result | Quality signal |
 |------|:-----:|-----------|--------|----------------|
-| Catalog metadata | 162 ground-truth entries | `examples/ground_truth.json` + `tests/test_evidence_tiers.py` | 153 compare / 9 audit-cross-source | Single source of truth for examples, verdicts, expected kinds, and minimum evidence |
+| Catalog metadata | 164 ground-truth entries | `examples/ground_truth.json` + `tests/test_evidence_tiers.py` | 134 binary competitor `.so` lanes + 30 dedicated non-`.so` lanes | Single source of truth for examples, verdicts, expected kinds, and minimum evidence; fixture/source-only L2/L5/source cases are not counted as binary competitor pairs |
 | Build/autodiscovery | 161 integration items | `python -m pytest tests/test_example_autodiscovery.py -v --tb=short -m integration` in CI | gcc: 132 passed / 29 skipped; clang: 133 passed / 28 skipped | Green default single-library build lane; skipped items are covered by dedicated bundle/source/audit/BTF tests |
-| Full example proof matrix | 162 catalog cases | `validation/scripts/collect_full_example_matrix.py` over CI artifacts + bundle/G20/L3-L5/BTF proofs | 159 COVERED / 3 UNRESOLVED | Full-catalog source of truth; a `SKIP` in one lane is accepted only when a dedicated lane proves the case |
-| Default/debug verdicts | 162 catalog cases | `PYTHONPATH=. python tests/validate_examples.py --toolchain {gcc,clang} --json` in CI | gcc: 132 PASS / 4 XFAIL / 26 SKIP; clang: 133 PASS / 4 XFAIL / 25 SKIP | Single-library debug lane only; XFAIL is not green full-matrix scope |
+| Full example proof matrix | 164 catalog cases | `validation/scripts/collect_full_example_matrix.py` over CI artifacts + bundle/G20/L3-L5/BTF proofs | Dedicated full-catalog proof lane | Full-catalog source of truth; a `SKIP` in one lane is accepted only when a dedicated lane proves the case |
+| Default/debug verdicts | 164 catalog cases | `PYTHONPATH=. python tests/validate_examples.py --toolchain {gcc,clang} --json` in CI | Single-library debug lane; dedicated non-`.so` cases skip here by design | Single-library debug lane only; XFAIL is not green full-matrix scope |
 | Bundle release verdicts | 5 bundle cases | `PYTHONPATH=. python validation/scripts/run_bundle_examples.py --json` | 5 PASS | Runs the ADR-023 multi-library examples through `abicheck compare old/ new/` |
-| Runtime smoke | 162 catalog cases | `PYTHONPATH=. python validation/scripts/run_example_runtime_smoke.py --json` | 73 DEMONSTRATED / 52 NO_RUNTIME_SIGNAL / 8 BASELINE_SIGNAL / 29 SKIP | Runtime harness has no BUILD_ERROR/BASELINE_ERROR bucket |
-| Release headers | 162 catalog cases | `validate_examples.py --artifact-variant release-headers --json` in CI artifact | 132 PASS / 4 XFAIL / 26 SKIP | Reduced-evidence informational lane; false-positive guard passed |
-| Stripped headers | 162 catalog cases | `validate_examples.py --artifact-variant stripped-headers --json` in CI artifact | 127 PASS / 3 FAIL / 6 XFAIL / 26 SKIP | Reduced-evidence informational lane; three expected signal-loss backlogs remain |
+| Runtime smoke | 164 catalog cases | `PYTHONPATH=. python validation/scripts/run_example_runtime_smoke.py --json` | Runtime-only proof lane | Runtime harness has no BUILD_ERROR/BASELINE_ERROR bucket |
+| Release headers | 164 catalog cases | `validate_examples.py --artifact-variant release-headers --json` in CI artifact | Reduced-evidence informational lane | False-positive guard passed |
+| Stripped headers | 164 catalog cases | `validate_examples.py --artifact-variant stripped-headers --json` in CI artifact | Reduced-evidence informational lane | Expected signal-loss backlogs remain |
 | Build/source smoke | 7 representative cases | `validate_examples.py case01 case04 case129 case130 case131 case132 case133 --artifact-variant build-source --json` in CI artifact | 7 PASS | Build/source evidence catches the build-flag mode cases in the smoke set |
+| Binary competitor scan | 134 shared-library pairs × 2 external tools | abicc/ABI Compliance Checker and libabigail `abidiff` over built `.so` pairs | 268 tool results: abicc 134, abidiff 134 | Competitor `.so` lane only; fixture/source-only L2/L5/source cases are represented in dedicated lanes, not as missing `.so` results |
 | Scan-depth matrix | 141 comparable targets × 5 depths | `abicheck scan --depth {binary,headers,build,source,full}` | 141/141 scans completed at each depth. Correct/FP/FN on all 141 comparable targets: binary 79 / 1 / 61; headers 115 / 0 / 26; build 115 / 0 / 26; source 141 / 0 / 0; full 141 / 0 / 0 | Compare-style status by depth; full-catalog audit/cross-source/bundle/BTF/snapshot cases are covered by dedicated lanes |
 Current unresolved full-example cases: `case97_api_depends_on_consumer_env`,
 `case105_concept_tightening`, and
@@ -316,17 +320,16 @@ Each case in `examples/ground_truth.json`
 carries a `min_evidence` field — the weakest source at which abicheck reaches the
 correct verdict — derived by
 `scripts/evidence_tiers.py`
-and validated by `tests/test_evidence_tiers.py`. Aggregated over the 153-case
-compare-mode catalog, that yields the cumulative minimum-evidence coverage:
+and validated by `tests/test_evidence_tiers.py`. Aggregated over the 153 compare-style cases, that yields the cumulative minimum-evidence coverage. The binary competitor `.so` lane is narrower (134 built shared-library pairs); fixture/source-only L2/L5/source cases are listed here by evidence tier instead of being treated as missing competitor binaries:
 
 | Source provided | Layer | Cases first detectable here | Cumulative | Representative cases |
 |-----------------|:-----:|:---------------------------:|:----------:|----------------------|
 | Just the binary | L0 | 50 | **50 / 153 (33%)** | symbol removal ([01](../examples/case01_symbol_removal.md)), SONAME ([05](../examples/case05_soname.md)), visibility ([06](../examples/case06_visibility.md)), symbol-version removed ([65](../examples/case65_symbol_version_removed.md)), all 5 bundle cases |
 | + Debug symbols | L1 | 65 | **115 / 153 (75%)** | struct layout ([07](../examples/case07_struct_layout.md)), enum value ([08](../examples/case08_enum_value_change.md)), vtable ([09](../examples/case09_cpp_vtable.md)), calling convention ([64](../examples/case64_calling_convention_changed.md)), bitfield ([63](../examples/case63_bitfield_changed.md)), toolchain flag drift ([103](../examples/case103_toolchain_flag_drift.md)) |
-| + Public headers | L2 | 22 | **137 / 153 (90%)** | access level ([34](../examples/case34_access_level.md)), default arg removed ([123](../examples/case123_default_argument_removed.md)), class `final` ([125](../examples/case125_class_became_final.md)), `detail::` leaks ([74](../examples/case74_detail_base_class_changed.md)–[77](../examples/case77_detail_templated_base_changed.md)), scoped-internal *no-change* ([118](../examples/case118_internal_struct_field_added_scoped.md)–[120](../examples/case120_internal_struct_reordered_scoped.md)) |
-| + Build data | L3 | 8 | **145 / 153 (95%)** | build-mode flips: exceptions ([130](../examples/case130_exceptions_mode_flip.md)), RTTI ([131](../examples/case131_rtti_mode_flip.md)), thread-safe statics ([132](../examples/case132_threadsafe_statics_flip.md)), TLS model ([133](../examples/case133_tls_model_flip.md)), enum size ([152](../examples/case152_enum_size_flag_flip.md)), struct packing ([153](../examples/case153_struct_packing_flip.md)), LTO ([154](../examples/case154_lto_mode_flip.md)), char signedness ([155](../examples/case155_char_signedness_flip.md)) |
+| + Public headers | L2 | 22 + dedicated fixture/source cases | **137 / 153 (90%)** | access level ([34](../examples/case34_access_level.md)), default arg removed ([123](../examples/case123_default_argument_removed.md)), class `final` ([125](../examples/case125_class_became_final.md)), `detail::` leaks ([74](../examples/case74_detail_base_class_changed.md)–[77](../examples/case77_detail_templated_base_changed.md)), scoped-internal *no-change* ([118](../examples/case118_internal_struct_field_added_scoped.md)–[120](../examples/case120_internal_struct_reordered_scoped.md)) |
+| + Build data | L3 | 8, including fixture/source-only cases | **145 / 153 (95%)** | build-mode flips: exceptions ([130](../examples/case130_exceptions_mode_flip.md)), RTTI ([131](../examples/case131_rtti_mode_flip.md)), thread-safe statics ([132](../examples/case132_threadsafe_statics_flip.md)), TLS model ([133](../examples/case133_tls_model_flip.md)), enum size ([152](../examples/case152_enum_size_flag_flip.md)), struct packing ([153](../examples/case153_struct_packing_flip.md)), LTO ([154](../examples/case154_lto_mode_flip.md)), char signedness ([155](../examples/case155_char_signedness_flip.md)) |
 | + Sources | L4 | 5 | **150 / 153 (98%)** | uninstantiated template ([122](../examples/case122_template_signature_uninstantiated.md)), public macro removed ([156](../examples/case156_public_macro_removed.md)), inline function removed ([157](../examples/case157_inline_function_removed.md)), concept tightening ([105](../examples/case105_concept_tightening.md)), public typedef removed ([158](../examples/case158_public_typedef_removed.md)) |
-| + Source graph | L5 | 3 | **153 / 153 (100%)** | public API internal dependency ([160](../examples/case160_public_api_internal_dep_added.md)), target dependency added ([161](../examples/case161_target_dependency_added.md)), exported symbol source owner changed ([162](../examples/case162_symbol_source_owner_changed.md)) |
+| + Source graph | L5 | 3 fixture/source-only cases | **153 / 153 (100%)** | public API internal dependency ([160](../examples/case160_public_api_internal_dep_added.md)), target dependency added ([161](../examples/case161_target_dependency_added.md)), exported symbol source owner changed ([162](../examples/case162_symbol_source_owner_changed.md)); additional dedicated source fixture examples include Python keyword rename ([163](../examples/case163_python_kwarg_renamed.md)) and preprocessor-conditional field guard ([164](../examples/case164_preproc_conditional_field.md)) |
 
 > **Why L3 now matters.** Earlier snapshots had no standalone L3-only catalog
 > cases. The current compare-mode catalog includes build-mode flips whose

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -410,94 +410,146 @@ def find_sources(case_dir: Path) -> _SourceResult:
 
 
 # ── abicheck compare (dump + compare pipeline) ────────────────────────────────
-def _version_source_root(case_dir: Path | None, src: Path | None) -> Path | None:
-    """Return the source root to pass to ``abicheck dump --sources``.
+def _find_or_build_abicheck_plugin(timeout: int) -> tuple[Path | None, str]:
+    """Return the build-integrated Clang fact plugin, building it once if needed."""
+    override = os.environ.get("ABICHECK_CLANG_PLUGIN")
+    if override:
+        plugin = Path(override)
+        return (plugin, "") if plugin.is_file() else (None, f"plugin not found: {plugin}")
 
-    Most catalog cases use ``old/`` and ``new/`` source roots.  Side-by-side
-    layouts must be staged by :func:`_stage_full_evidence_side`; returning the
-    common case directory here would make each dump inspect both releases.
-    """
-    if case_dir is None or src is None:
-        return None
+    plugin_build = BUILD_DIR / "_abicheck_clang_plugin"
+    names = ("libabicheck-facts.so", "libabicheck-facts.dylib", "abicheck-facts.dll")
+    for name in names:
+        candidate = plugin_build / name
+        if candidate.is_file():
+            return candidate, ""
+
+    source = REPO_DIR / "contrib" / "abicheck-clang-plugin"
+    llvm_config = _first_available_tool("llvm-config-18", "llvm-config")
+    clang = _first_available_tool("clang-18", "clang")
+    clangxx = _first_available_tool("clang++-18", "clang++")
+    if not (source.is_dir() and llvm_config and clang and clangxx and shutil.which("cmake")):
+        return None, "Clang plugin prerequisites unavailable"
     try:
-        rel = src.relative_to(case_dir)
-    except ValueError:
-        return src.parent if src.exists() else None
-    if rel.parts and rel.parts[0] in {"old", "new", "v1", "v2"}:
-        return case_dir / rel.parts[0]
-    return None
-
-
-def _stage_full_evidence_side(
-    case_dir: Path | None,
-    src: Path | None,
-    header: Path | None,
-    other_src: Path | None,
-    other_header: Path | None,
-    stage_root: Path,
-    build_info: Path | None,
-) -> tuple[Path | None, Path | None]:
-    """Create a small, release-specific source root and compile database.
-
-    Legacy fixtures put ``v1`` and ``v2`` beside one another.  Feeding their
-    shared directory (and the catalog-wide CMake compile database) to a full
-    dump accidentally turns a tiny benchmark into a project scan.  Preserve
-    already-separated old/new trees; otherwise copy only source/header inputs
-    for this release and filter build information to this translation unit.
-    """
-    if case_dir is None or src is None or not src.exists():
-        return None, None
-
-    root = _version_source_root(case_dir, src)
-    if root is not None:
-        # The source tree is already release-specific.  Still isolate the
-        # compile database: catalog CMake builds contain every example.
-        stage_root.mkdir(parents=True, exist_ok=True)
-        source_root = root
-    else:
-        if stage_root.exists():
-            shutil.rmtree(stage_root)
-        stage_root.mkdir(parents=True)
-        source_root = stage_root
-
-        excluded = {p.resolve() for p in (other_src, other_header) if p is not None and p.exists()}
-        candidates = [src]
-        if header is not None and header.exists():
-            candidates.append(header)
-        # Include common sibling headers needed by the selected translation unit,
-        # but never copy the opposite release's source/header.
-        candidates.extend(
-            p for p in case_dir.iterdir()
-            if p.is_file() and p.suffix.lower() in {".h", ".hh", ".hpp", ".hxx", ".inc"}
+        cmakedir = subprocess.run(
+            [llvm_config, "--cmakedir"], capture_output=True, text=True,
+            timeout=15, check=True,
+        ).stdout.strip()
+        env = {**os.environ, "CC": clang, "CXX": clangxx}
+        configure = subprocess.run(
+            ["cmake", "-S", str(source), "-B", str(plugin_build),
+             f"-DCMAKE_PREFIX_PATH={Path(cmakedir).parent}"],
+            capture_output=True, text=True, timeout=timeout, env=env,
         )
-        for path in dict.fromkeys(candidates):
-            if path.resolve() not in excluded:
-                shutil.copy2(path, stage_root / path.name)
+        if configure.returncode != 0:
+            return None, configure.stderr or configure.stdout
+        build = subprocess.run(
+            ["cmake", "--build", str(plugin_build), "--config", "Release"],
+            capture_output=True, text=True, timeout=timeout, env=env,
+        )
+        if build.returncode != 0:
+            return None, build.stderr or build.stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, str(exc)
+    for name in names:
+        matches = list(plugin_build.rglob(name))
+        if matches:
+            return matches[0], ""
+    return None, "plugin build succeeded but library was not produced"
 
-    staged_db: Path | None = None
-    if build_info is not None and build_info.is_file():
-        try:
-            entries = json.loads(build_info.read_text())
-            selected = []
-            for entry in entries if isinstance(entries, list) else []:
-                file_value = entry.get("file")
-                if not file_value:
-                    continue
-                file_path = Path(file_value)
-                if not file_path.is_absolute():
-                    file_path = Path(entry.get("directory", ".")) / file_path
-                if file_path.resolve() == src.resolve():
-                    item = dict(entry)
-                    if source_root == stage_root:
-                        item["file"] = str(stage_root / src.name)
-                    selected.append(item)
-            if selected:
-                staged_db = stage_root / "compile_commands.json"
-                staged_db.write_text(json.dumps(selected, indent=2) + "\n")
-        except (OSError, json.JSONDecodeError, TypeError):
-            staged_db = None
-    return source_root, staged_db
 
+def _plugin_pack_is_target_specific(
+    pack: Path, version: str, src: Path, opposite_src: Path,
+) -> tuple[bool, str]:
+    """Reject empty, wrong-version, or cross-release plugin evidence packs."""
+    try:
+        manifest = json.loads((pack / "manifest.json").read_text())
+        fact_files = sorted((pack / "source_facts").glob("*.jsonl"))
+        records = [json.loads(line) for path in fact_files for line in path.read_text().splitlines() if line]
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, f"invalid plugin pack: {exc}"
+    if manifest.get("version") != version or not fact_files or not records:
+        return False, f"missing {version} target-specific source facts"
+    sources = {Path(str(record.get("source", ""))).resolve() for record in records}
+    if src.resolve() not in sources or opposite_src.resolve() in sources:
+        return False, f"{version} pack contains wrong release translation units"
+    evidence_keys = {
+        "declarations", "types", "functions", "variables", "macros", "templates",
+        "inline_bodies", "constexpr_values", "source_edges",
+    }
+    if not any(record.get(key) for record in records for key in evidence_keys):
+        return False, f"{version} plugin pack contains no L3/L4/L5 facts"
+    return True, ""
+
+
+def _build_plugin_side(
+    case_dir: Path, case: str, version: str, src: Path, opposite_src: Path,
+    header: Path | None, plugin: Path, root: Path, timeout: int,
+) -> tuple[Path | None, Path | None, str]:
+    """Configure and build exactly one versioned library target with the plugin."""
+    case_dir = case_dir.resolve()
+    src = src.resolve()
+    opposite_src = opposite_src.resolve()
+    plugin = plugin.resolve()
+    root = root.resolve()
+    header = header.resolve() if header and header.exists() else header
+    side_build = root / f"plugin_build_{version}"
+    pack = root / f"abicheck_inputs_{version}"
+    for path in (side_build, pack):
+        if path.exists():
+            shutil.rmtree(path)
+
+    clang = _first_available_tool("clang-18", "clang")
+    clangxx = _first_available_tool("clang++-18", "clang++")
+    if not clang or not clangxx:
+        return None, None, "Clang compiler unavailable"
+    public_root = header.parent if header and header.exists() else src.parent
+    flags = [
+        f"-fplugin={plugin}",
+        "-Xclang", "-plugin-arg-abicheck-facts", "-Xclang", f"out={pack}",
+        "-Xclang", "-plugin-arg-abicheck-facts", "-Xclang", f"public-roots={public_root}",
+        "-Xclang", "-plugin-arg-abicheck-facts", "-Xclang", f"library={case}",
+        "-Xclang", "-plugin-arg-abicheck-facts", "-Xclang", f"version={version}",
+    ]
+    # Compact fixtures often define the API without including their public
+    # header. Force it into the real target compile so the pack sees that API.
+    if header and header.exists():
+        flags += ["-include", str(header)]
+    flag_string = shlex.join(flags)
+    # Inject only after CMake has validated the compilers. Putting the plugin in
+    # CMAKE_{C,CXX}_FLAGS would instrument CMake's compiler probes and contaminate
+    # the target pack with CMakeCCompilerId/CMakeCXXCompilerABI translation units.
+    injection = root / f"plugin_flags_{version}.cmake"
+    cmake_flags = flag_string.replace("\\", "\\\\").replace('"', '\\"')
+    injection.write_text(
+        f'set(CMAKE_C_FLAGS "${{CMAKE_C_FLAGS}} {cmake_flags}")\n'
+        f'set(CMAKE_CXX_FLAGS "${{CMAKE_CXX_FLAGS}} {cmake_flags}")\n'
+    )
+    env = {**os.environ, "CC": clang, "CXX": clangxx}
+    try:
+        configure = subprocess.run(
+            ["cmake", "-S", str(case_dir.parent), "-B", str(side_build),
+             "-DCMAKE_BUILD_TYPE=Debug", f"-DCMAKE_PROJECT_INCLUDE={injection}"],
+            capture_output=True, text=True, timeout=timeout, env=env,
+        )
+        if configure.returncode != 0:
+            return None, None, configure.stderr or configure.stdout
+        build = subprocess.run(
+            ["cmake", "--build", str(side_build), "--target", f"{case}_{version}",
+             "--config", "Debug"],
+            capture_output=True, text=True, timeout=timeout, env=env,
+        )
+        if build.returncode != 0:
+            return None, None, build.stderr or build.stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, None, str(exc)
+    library = _find_cmake_lib(side_build / case, version)
+    valid, error = _plugin_pack_is_target_specific(pack, version, src, opposite_src)
+    if library is None:
+        return None, None, f"target {case}_{version} produced no shared library"
+    if not valid:
+        return None, None, error
+    return library, pack, ""
 
 def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
                  case: str, rdir: Path) -> ToolResult:
@@ -515,103 +567,114 @@ def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | 
                       v1_src: Path | None = None, v2_src: Path | None = None,
                       build_dir: Path | None = None,
                       timeout: int = DEFAULT_ABICHECK_FULL_TIMEOUT) -> ToolResult:
-    """Run abicheck with the deepest available evidence: binary + headers + sources.
-
-    This lane is intentionally separate from ``abicheck`` so benchmark reports
-    can show both the competitor-comparable baseline and abicheck's full scan.
-    """
-    return _run_abicheck_dump_compare(
-        v1_so, v2_so, v1_h, v2_h, case, rdir, suffix="_full",
-        case_dir=case_dir, v1_src=v1_src, v2_src=v2_src, build_dir=build_dir,
-        full_evidence=True, timeout=timeout,
+    """Build each release target with the Clang plugin, merge its pack, compare."""
+    del v1_so, v2_so, build_dir  # full lane uses plugin-instrumented target artifacts
+    started = time.monotonic()
+    if not _HAS_ABICHECK or case_dir is None or v1_src is None or v2_src is None:
+        return ToolResult(verdict="SKIP")
+    root = BUILD_DIR / case / "full_plugin"
+    root.mkdir(parents=True, exist_ok=True)
+    plugin, error = _find_or_build_abicheck_plugin(timeout)
+    if plugin is None:
+        return ToolResult(verdict="ERROR", raw_output=error,
+                          elapsed_ms=(time.monotonic() - started) * 1000)
+    try:
+        sides = [
+            ("v1", v1_src, v2_src, v1_h),
+            ("v2", v2_src, v1_src, v2_h),
+        ]
+        merged: list[Path] = []
+        logs: list[str] = []
+        for version, src, opposite, header in sides:
+            library, pack, error = _build_plugin_side(
+                case_dir, case, version, src, opposite, header, plugin, root, timeout,
+            )
+            if library is None or pack is None:
+                return ToolResult(verdict="ERROR", raw_output=error,
+                                  elapsed_ms=(time.monotonic() - started) * 1000)
+            base = root / f"{version}.binary_headers.json"
+            final = root / f"{version}.merged.json"
+            dump = [_PYTHON, "-m", "abicheck.cli", "dump", str(library),
+                    "-o", str(base), "--version", version]
+            if header and header.exists():
+                dump += ["-H", str(header)]
+            dr = subprocess.run(dump, capture_output=True, text=True,
+                                timeout=timeout, env=_ABICHECK_ENV)
+            if dr.returncode != 0 or not base.exists():
+                return ToolResult(verdict="ERROR", raw_output=dr.stderr or dr.stdout,
+                                  elapsed_ms=(time.monotonic() - started) * 1000)
+            mr = subprocess.run(
+                [_PYTHON, "-m", "abicheck.cli", "merge", str(base), str(pack),
+                 "-o", str(final), "--on-conflict", "error"],
+                capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV,
+            )
+            if mr.returncode != 0 or not final.exists():
+                return ToolResult(verdict="ERROR", raw_output=mr.stderr or mr.stdout,
+                                  elapsed_ms=(time.monotonic() - started) * 1000)
+            merged.append(final)
+            logs.extend([dr.stdout, dr.stderr, mr.stdout, mr.stderr])
+        compare = subprocess.run(
+            [_PYTHON, "-m", "abicheck.cli", "compare", str(merged[0]), str(merged[1]),
+             "--format", "json"], capture_output=True, text=True,
+            timeout=timeout, env=_ABICHECK_ENV,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return ToolResult(verdict="TIMEOUT", raw_output=str(exc),
+                          elapsed_ms=(time.monotonic() - started) * 1000)
+    out = compare.stdout + compare.stderr
+    (rdir / f"{case}_abicheck_full.txt").write_text(out)
+    return ToolResult(
+        verdict=_abicheck_verdict_from_compare(compare.stdout, compare.returncode),
+        raw_output="".join(logs) + out,
+        elapsed_ms=(time.monotonic() - started) * 1000,
     )
 
 
 def _run_abicheck_dump_compare(
-    v1_so: Path,
-    v2_so: Path,
-    v1_h: Path | None,
-    v2_h: Path | None,
-    case: str,
-    rdir: Path,
-    *,
-    suffix: str = "",
-    case_dir: Path | None = None,
-    v1_src: Path | None = None,
-    v2_src: Path | None = None,
-    build_dir: Path | None = None,
-    full_evidence: bool = False,
-    timeout: int = 60,
+    v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
+    case: str, rdir: Path, *, suffix: str = "", timeout: int = 60,
 ) -> ToolResult:
+    """Run the baseline binary plus public-header dump/compare lane."""
     if not _HAS_ABICHECK:
         return ToolResult(verdict="SKIP")
-
     bdir = BUILD_DIR / case
     bdir.mkdir(parents=True, exist_ok=True)
     snap1 = bdir / f"snap{suffix}_v1.json"
     snap2 = bdir / f"snap{suffix}_v2.json"
-    _t_start = time.monotonic()
+    started = time.monotonic()
 
-    src1 = src2 = None
-    build1 = build2 = build_dir
-    if full_evidence:
-        src1, build1 = _stage_full_evidence_side(
-            case_dir, v1_src, v1_h, v2_src, v2_h, bdir / "sources_v1", build_dir,
-        )
-        src2, build2 = _stage_full_evidence_side(
-            case_dir, v2_src, v2_h, v1_src, v1_h, bdir / "sources_v2", build_dir,
-        )
-
-    def dump(so: Path, h: Path | None, snap: Path, ver: str,
-             src_root: Path | None, side_build_info: Path | None) -> tuple[bool, str]:
-        cmd = [_PYTHON, "-m", "abicheck.cli", "dump", str(so), "-o", str(snap), "--version", ver]
-        if h and h.exists():
-            cmd += ["-H", str(h)]
-        if full_evidence:
-            cmd += ["--depth", "full"]
-        if full_evidence and side_build_info is not None:
-            cmd += ["--build-info", str(side_build_info)]
-            if h and h.exists():
-                cmd += ["-p", str(side_build_info)]
-        if src_root is not None and src_root.exists():
-            cmd += ["--sources", str(src_root)]
-        run = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV)
-        ok = run.returncode == 0 and snap.exists()
-        return ok, (run.stderr or run.stdout)
+    def dump(so: Path, header: Path | None, snap: Path, version: str) -> tuple[bool, str]:
+        cmd = [_PYTHON, "-m", "abicheck.cli", "dump", str(so), "-o", str(snap),
+               "--version", version]
+        if header and header.exists():
+            cmd += ["-H", str(header)]
+        run = subprocess.run(cmd, capture_output=True, text=True,
+                             timeout=timeout, env=_ABICHECK_ENV)
+        return run.returncode == 0 and snap.exists(), run.stderr or run.stdout
 
     try:
-        ok, err = dump(v1_so, v1_h, snap1, "v1", src1, build1)
+        ok, error = dump(v1_so, v1_h, snap1, "v1")
         if not ok:
-            return ToolResult(verdict="ERROR", raw_output=f"dump v1 failed: {err}",
-                              elapsed_ms=(time.monotonic() - _t_start) * 1000)
-        ok, err = dump(v2_so, v2_h, snap2, "v2", src2, build2)
+            return ToolResult(verdict="ERROR", raw_output=f"dump v1 failed: {error}",
+                              elapsed_ms=(time.monotonic() - started) * 1000)
+        ok, error = dump(v2_so, v2_h, snap2, "v2")
         if not ok:
-            return ToolResult(verdict="ERROR", raw_output=f"dump v2 failed: {err}",
-                              elapsed_ms=(time.monotonic() - _t_start) * 1000)
+            return ToolResult(verdict="ERROR", raw_output=f"dump v2 failed: {error}",
+                              elapsed_ms=(time.monotonic() - started) * 1000)
+        result = subprocess.run(
+            [_PYTHON, "-m", "abicheck.cli", "compare", str(snap1), str(snap2),
+             "--format", "json"], capture_output=True, text=True,
+            timeout=timeout, env=_ABICHECK_ENV,
+        )
     except subprocess.TimeoutExpired as exc:
         return ToolResult(verdict="TIMEOUT", raw_output=str(exc),
-                          elapsed_ms=(time.monotonic() - _t_start) * 1000)
-
-    try:
-        r = subprocess.run(
-            [_PYTHON, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json"],
-            capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV,
-        )
-    except subprocess.TimeoutExpired:
-        return ToolResult(verdict="TIMEOUT",
-                          elapsed_ms=(time.monotonic() - _t_start) * 1000)
-    elapsed_ms = (time.monotonic() - _t_start) * 1000
-
-    out = r.stdout + r.stderr
+                          elapsed_ms=(time.monotonic() - started) * 1000)
+    out = result.stdout + result.stderr
     (rdir / f"{case}_abicheck{suffix}.txt").write_text(out)
-
-    verdict = _abicheck_verdict_from_compare(r.stdout, r.returncode)
-
-    changes = [ln.strip() for ln in out.splitlines()
-               if any(k in ln for k in ("removed", "added", "changed")) and ln.strip()]
-    return ToolResult(verdict=verdict, changes=changes[:8], raw_output=out,
-                      elapsed_ms=elapsed_ms)
-
+    return ToolResult(
+        verdict=_abicheck_verdict_from_compare(result.stdout, result.returncode),
+        raw_output=out, elapsed_ms=(time.monotonic() - started) * 1000,
+    )
 
 def _abicheck_verdict_from_compare(stdout: str, returncode: int) -> str:
     """Derive normalized verdict from abicheck compare output or exit code."""

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -423,7 +423,7 @@ def find_sources(case_dir: Path) -> _SourceResult:
     return _NO_SOURCES
 
 
-# ── abicheck compare (full evidence dump + compare pipeline) ─────────────────
+# ── abicheck compare (dump + compare pipeline) ────────────────────────────────
 def _version_source_root(case_dir: Path | None, src: Path | None) -> Path | None:
     """Return the source root to pass to ``abicheck dump --sources``.
 
@@ -444,27 +444,66 @@ def _version_source_root(case_dir: Path | None, src: Path | None) -> Path | None
 
 
 def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
-                 case: str, rdir: Path, *, case_dir: Path | None = None,
-                 v1_src: Path | None = None, v2_src: Path | None = None,
-                 build_dir: Path | None = None) -> ToolResult:
+                 case: str, rdir: Path) -> ToolResult:
+    """Run the normal binary+headers abicheck benchmark lane.
+
+    Keep this lane comparable with libabigail's binary/header modes.  The
+    deeper source/build evidence path is exposed separately as
+    ``abicheck_full``.
+    """
+    return _run_abicheck_dump_compare(v1_so, v2_so, v1_h, v2_h, case, rdir)
+
+
+def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
+                      case: str, rdir: Path, *, case_dir: Path | None = None,
+                      v1_src: Path | None = None, v2_src: Path | None = None,
+                      build_dir: Path | None = None) -> ToolResult:
+    """Run abicheck with the deepest available evidence: binary + headers + sources.
+
+    This lane is intentionally separate from ``abicheck`` so benchmark reports
+    can show both the competitor-comparable baseline and abicheck's full scan.
+    """
+    return _run_abicheck_dump_compare(
+        v1_so, v2_so, v1_h, v2_h, case, rdir, suffix="_full",
+        case_dir=case_dir, v1_src=v1_src, v2_src=v2_src, build_dir=build_dir,
+        full_evidence=True,
+    )
+
+
+def _run_abicheck_dump_compare(
+    v1_so: Path,
+    v2_so: Path,
+    v1_h: Path | None,
+    v2_h: Path | None,
+    case: str,
+    rdir: Path,
+    *,
+    suffix: str = "",
+    case_dir: Path | None = None,
+    v1_src: Path | None = None,
+    v2_src: Path | None = None,
+    build_dir: Path | None = None,
+    full_evidence: bool = False,
+) -> ToolResult:
     if not _HAS_ABICHECK:
         return ToolResult(verdict="SKIP")
 
     bdir = BUILD_DIR / case
-    snap1 = bdir / "snap_v1.json"
-    snap2 = bdir / "snap_v2.json"
+    snap1 = bdir / f"snap{suffix}_v1.json"
+    snap2 = bdir / f"snap{suffix}_v2.json"
     _t_start = time.monotonic()
 
-    src1 = _version_source_root(case_dir, v1_src)
-    src2 = _version_source_root(case_dir, v2_src)
+    src1 = _version_source_root(case_dir, v1_src) if full_evidence else None
+    src2 = _version_source_root(case_dir, v2_src) if full_evidence else None
 
     def dump(so: Path, h: Path | None, snap: Path, ver: str,
              src_root: Path | None) -> tuple[bool, str]:
         cmd = [_PYTHON, "-m", "abicheck.cli", "dump", str(so), "-o", str(snap), "--version", ver]
         if h and h.exists():
             cmd += ["-H", str(h)]
-        cmd += ["--depth", "full"]
-        if build_dir is not None:
+        if full_evidence:
+            cmd += ["--depth", "full"]
+        if full_evidence and build_dir is not None:
             cmd += ["--build-info", str(build_dir)]
             if h and h.exists():
                 cmd += ["-p", str(build_dir)]
@@ -498,7 +537,7 @@ def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
     elapsed_ms = (time.monotonic() - _t_start) * 1000
 
     out = r.stdout + r.stderr
-    (rdir / f"{case}_abicheck.txt").write_text(out)
+    (rdir / f"{case}_abicheck{suffix}.txt").write_text(out)
 
     verdict = _abicheck_verdict_from_compare(r.stdout, r.returncode)
 
@@ -842,6 +881,7 @@ def run_abidiff_headers(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path 
 
 TOOL_REGISTRY: list[Tool] = [
     Tool("abicheck", run_abicheck, "abicheck", 12, "expected"),
+    Tool("abicheck_full", run_abicheck_full, "ac-full", 12, "expected"),
     Tool("abicheck_compat", run_abicheck_compat, "ac-compat", 12, "expected_compat"),
     Tool("abicheck_strict", run_abicheck_strict, "ac-strict", 14, "expected"),
     Tool("abidiff", run_abidiff, "abidiff", 12, "expected"),
@@ -892,7 +932,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--suite", choices=["all", "pinned74"], default="all",
                    help="Case suite to run: all catalog cases, or the historical 74-case release-pinned subset")
     p.add_argument("--tools", nargs="+", metavar="TOOL",
-                   choices=["abicheck", "abicheck_compat", "abicheck_strict",
+                   choices=["abicheck", "abicheck_full", "abicheck_compat", "abicheck_strict",
                             "abidiff", "abidiff_headers", "abicc_dumper", "abicc_xml"],
                    help="Run only selected tools")
     p.add_argument("--case64-toolchain", choices=["auto", "gcc", "clang"], default="auto",
@@ -924,6 +964,7 @@ def _error_entry(case_name: str, expected: str) -> dict[str, Any]:
         "expected": expected,
         "expected_compat": EXPECTED_COMPAT.get(case_name, expected),
         "abicheck": "ERROR",
+        "abicheck_full": "ERROR",
         "abicheck_compat": "ERROR",
         "abicheck_strict": "ERROR",
         "abidiff": "ERROR",
@@ -1294,6 +1335,7 @@ def _skip_row_entry(name: str, expected: str) -> dict[str, Any]:
         "case": name,
         "expected": expected,
         "abicheck": "SKIP",
+        "abicheck_full": "SKIP",
         "abicheck_compat": "SKIP",
         "abicheck_strict": "SKIP",
         "abidiff": "SKIP",
@@ -1356,13 +1398,13 @@ def _run_tools_for_case(
     """Run all active tools for a case and return their results keyed by tool name."""
     tool_results: dict[str, ToolResult] = {}
     for t in active_tools:
-        if t.name == "abicheck":
+        if t.name == "abicheck_full":
             tool_results[t.name] = t.run_fn(
                 v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir,
                 case_dir=case_dir, v1_src=v1_src, v2_src=v2_src,
                 build_dir=build_dir,
             )
-        elif t.name in ("abicheck_compat", "abicheck_strict"):
+        elif t.name in ("abicheck", "abicheck_compat", "abicheck_strict"):
             tool_results[t.name] = t.run_fn(v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir)
         elif t.name in ("abicc_dumper", "abicc_xml"):
             tool_results[t.name] = t.run_fn(v1_so, v2_so, v1_h, v2_h, name, rdir, timeout=abicc_timeout)

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -423,9 +423,30 @@ def find_sources(case_dir: Path) -> _SourceResult:
     return _NO_SOURCES
 
 
-# ── abicheck compare (dump + compare pipeline) ────────────────────────────────
+# ── abicheck compare (full evidence dump + compare pipeline) ─────────────────
+def _version_source_root(case_dir: Path | None, src: Path | None) -> Path | None:
+    """Return the source root to pass to ``abicheck dump --sources``.
+
+    Most catalog cases use ``old/`` and ``new/`` source roots.  Older v1/v2
+    cases keep both versions side-by-side, so the case directory itself is the
+    narrowest available source root.  The benchmark should exercise abicheck's
+    deepest evidence path, not just binary/header snapshots.
+    """
+    if case_dir is None or src is None:
+        return None
+    try:
+        rel = src.relative_to(case_dir)
+    except ValueError:
+        return src.parent if src.exists() else None
+    if rel.parts and rel.parts[0] in {"old", "new", "v1", "v2"}:
+        return case_dir / rel.parts[0]
+    return case_dir
+
+
 def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
-                 case: str, rdir: Path) -> ToolResult:
+                 case: str, rdir: Path, *, case_dir: Path | None = None,
+                 v1_src: Path | None = None, v2_src: Path | None = None,
+                 build_dir: Path | None = None) -> ToolResult:
     if not _HAS_ABICHECK:
         return ToolResult(verdict="SKIP")
 
@@ -434,20 +455,31 @@ def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
     snap2 = bdir / "snap_v2.json"
     _t_start = time.monotonic()
 
-    def dump(so: Path, h: Path | None, snap: Path, ver: str) -> tuple[bool, str]:
+    src1 = _version_source_root(case_dir, v1_src)
+    src2 = _version_source_root(case_dir, v2_src)
+
+    def dump(so: Path, h: Path | None, snap: Path, ver: str,
+             src_root: Path | None) -> tuple[bool, str]:
         cmd = [_PYTHON, "-m", "abicheck.cli", "dump", str(so), "-o", str(snap), "--version", ver]
         if h and h.exists():
             cmd += ["-H", str(h)]
+        cmd += ["--depth", "full"]
+        if build_dir is not None:
+            cmd += ["--build-info", str(build_dir)]
+            if h and h.exists():
+                cmd += ["-p", str(build_dir)]
+        if src_root is not None and src_root.exists():
+            cmd += ["--sources", str(src_root)]
         run = subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=_ABICHECK_ENV)
         ok = run.returncode == 0 and snap.exists()
         return ok, (run.stderr or run.stdout)
 
     try:
-        ok, err = dump(v1_so, v1_h, snap1, "v1")
+        ok, err = dump(v1_so, v1_h, snap1, "v1", src1)
         if not ok:
             return ToolResult(verdict="ERROR", raw_output=f"dump v1 failed: {err}",
                               elapsed_ms=(time.monotonic() - _t_start) * 1000)
-        ok, err = dump(v2_so, v2_h, snap2, "v2")
+        ok, err = dump(v2_so, v2_h, snap2, "v2", src2)
         if not ok:
             return ToolResult(verdict="ERROR", raw_output=f"dump v2 failed: {err}",
                               elapsed_ms=(time.monotonic() - _t_start) * 1000)
@@ -1316,11 +1348,21 @@ def _run_tools_for_case(
     name: str,
     rdir: Path,
     abicc_timeout: int,
+    case_dir: Path | None = None,
+    v1_src: Path | None = None,
+    v2_src: Path | None = None,
+    build_dir: Path | None = None,
 ) -> dict[str, ToolResult]:
     """Run all active tools for a case and return their results keyed by tool name."""
     tool_results: dict[str, ToolResult] = {}
     for t in active_tools:
-        if t.name in ("abicheck", "abicheck_compat", "abicheck_strict"):
+        if t.name == "abicheck":
+            tool_results[t.name] = t.run_fn(
+                v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir,
+                case_dir=case_dir, v1_src=v1_src, v2_src=v2_src,
+                build_dir=build_dir,
+            )
+        elif t.name in ("abicheck_compat", "abicheck_strict"):
             tool_results[t.name] = t.run_fn(v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir)
         elif t.name in ("abicc_dumper", "abicc_xml"):
             tool_results[t.name] = t.run_fn(v1_so, v2_so, v1_h, v2_h, name, rdir, timeout=abicc_timeout)
@@ -1395,9 +1437,13 @@ def _process_case(
         br.used_make_artifacts, br.used_cmake_artifacts,
     )
 
+    compile_db = _find_compile_db(bdir)
+    build_info = compile_db if compile_db is not None else None
+
     tool_results = _run_tools_for_case(
         active_tools, v1_so, v2_so, v1_h, v2_h, v1_h_abicheck, v2_h_abicheck,
         name, rdir, args.abicc_timeout,
+        case_dir=case_dir, v1_src=v1_src, v2_src=v2_src, build_dir=build_info,
     )
 
     row_parts = [f"  {name:<33}", f"{expected:<12}"]

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -489,6 +489,7 @@ def _run_abicheck_dump_compare(
         return ToolResult(verdict="SKIP")
 
     bdir = BUILD_DIR / case
+    bdir.mkdir(parents=True, exist_ok=True)
     snap1 = bdir / f"snap{suffix}_v1.json"
     snap2 = bdir / f"snap{suffix}_v2.json"
     _t_start = time.monotonic()
@@ -1305,7 +1306,7 @@ def _resolve_selected_tools(args: Any) -> set[str]:
     use_compat = not args.skip_compat
 
     selected: set[str] = set(args.tools or [
-        "abicheck", "abicheck_compat", "abicheck_strict",
+        "abicheck", "abicheck_full", "abicheck_compat", "abicheck_strict",
         "abidiff", "abidiff_headers", "abicc_dumper", "abicc_xml",
     ])
 

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -85,6 +85,7 @@ _HAS_ABICHECK: bool = _abicheck_available()
 
 
 DEFAULT_ABICC_TIMEOUT = 120  # seconds
+DEFAULT_ABICHECK_FULL_TIMEOUT = 120  # seconds per dump/compare call
 
 # Historical release-pinned cross-tool benchmark:
 # cases 01-73 plus the 26b compatible-union edge case.  The full catalog can
@@ -125,21 +126,6 @@ EXPECTED_ABICC: dict[str, str] = {
     k: ("COMPATIBLE" if EXPECTED[k] == "NO_CHANGE" else EXPECTED[k])
     for k, v in _gt_data["verdicts"].items()
 }
-# Cases whose expected verdict depends on the opt-in ADR-027 pattern analysis
-# ("pattern_verdicts": true in ground_truth.json). Both abicheck compare paths
-# below must pass --pattern-verdicts for them, mirroring validate_examples.py —
-# otherwise the case scores as wrong/missed in the suite and tier benchmarks.
-PATTERN_VERDICT_CASES: set[str] = {
-    k for k, v in _gt_data["verdicts"].items() if v.get("pattern_verdicts")
-}
-
-
-def _compare_cmd(snap1: Path, snap2: Path, case: str) -> list[str]:
-    """abicheck compare command for *case*, honoring its pattern_verdicts opt-in."""
-    cmd = [_PYTHON, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json"]
-    if case in PATTERN_VERDICT_CASES:
-        cmd.append("--pattern-verdicts")
-    return cmd
 
 
 @dataclass
@@ -427,10 +413,9 @@ def find_sources(case_dir: Path) -> _SourceResult:
 def _version_source_root(case_dir: Path | None, src: Path | None) -> Path | None:
     """Return the source root to pass to ``abicheck dump --sources``.
 
-    Most catalog cases use ``old/`` and ``new/`` source roots.  Older v1/v2
-    cases keep both versions side-by-side, so the case directory itself is the
-    narrowest available source root.  The benchmark should exercise abicheck's
-    deepest evidence path, not just binary/header snapshots.
+    Most catalog cases use ``old/`` and ``new/`` source roots.  Side-by-side
+    layouts must be staged by :func:`_stage_full_evidence_side`; returning the
+    common case directory here would make each dump inspect both releases.
     """
     if case_dir is None or src is None:
         return None
@@ -440,7 +425,78 @@ def _version_source_root(case_dir: Path | None, src: Path | None) -> Path | None
         return src.parent if src.exists() else None
     if rel.parts and rel.parts[0] in {"old", "new", "v1", "v2"}:
         return case_dir / rel.parts[0]
-    return case_dir
+    return None
+
+
+def _stage_full_evidence_side(
+    case_dir: Path | None,
+    src: Path | None,
+    header: Path | None,
+    other_src: Path | None,
+    other_header: Path | None,
+    stage_root: Path,
+    build_info: Path | None,
+) -> tuple[Path | None, Path | None]:
+    """Create a small, release-specific source root and compile database.
+
+    Legacy fixtures put ``v1`` and ``v2`` beside one another.  Feeding their
+    shared directory (and the catalog-wide CMake compile database) to a full
+    dump accidentally turns a tiny benchmark into a project scan.  Preserve
+    already-separated old/new trees; otherwise copy only source/header inputs
+    for this release and filter build information to this translation unit.
+    """
+    if case_dir is None or src is None or not src.exists():
+        return None, None
+
+    root = _version_source_root(case_dir, src)
+    if root is not None:
+        # The source tree is already release-specific.  Still isolate the
+        # compile database: catalog CMake builds contain every example.
+        stage_root.mkdir(parents=True, exist_ok=True)
+        source_root = root
+    else:
+        if stage_root.exists():
+            shutil.rmtree(stage_root)
+        stage_root.mkdir(parents=True)
+        source_root = stage_root
+
+        excluded = {p.resolve() for p in (other_src, other_header) if p is not None and p.exists()}
+        candidates = [src]
+        if header is not None and header.exists():
+            candidates.append(header)
+        # Include common sibling headers needed by the selected translation unit,
+        # but never copy the opposite release's source/header.
+        candidates.extend(
+            p for p in case_dir.iterdir()
+            if p.is_file() and p.suffix.lower() in {".h", ".hh", ".hpp", ".hxx", ".inc"}
+        )
+        for path in dict.fromkeys(candidates):
+            if path.resolve() not in excluded:
+                shutil.copy2(path, stage_root / path.name)
+
+    staged_db: Path | None = None
+    if build_info is not None and build_info.is_file():
+        try:
+            entries = json.loads(build_info.read_text())
+            selected = []
+            for entry in entries if isinstance(entries, list) else []:
+                file_value = entry.get("file")
+                if not file_value:
+                    continue
+                file_path = Path(file_value)
+                if not file_path.is_absolute():
+                    file_path = Path(entry.get("directory", ".")) / file_path
+                if file_path.resolve() == src.resolve():
+                    item = dict(entry)
+                    if source_root == stage_root:
+                        item["file"] = str(stage_root / src.name)
+                    selected.append(item)
+            if selected:
+                staged_db = stage_root / "compile_commands.json"
+                staged_db.write_text(json.dumps(selected, indent=2) + "\n")
+        except (OSError, json.JSONDecodeError, TypeError):
+            staged_db = None
+    return source_root, staged_db
 
 
 def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
@@ -457,7 +513,8 @@ def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
 def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
                       case: str, rdir: Path, *, case_dir: Path | None = None,
                       v1_src: Path | None = None, v2_src: Path | None = None,
-                      build_dir: Path | None = None) -> ToolResult:
+                      build_dir: Path | None = None,
+                      timeout: int = DEFAULT_ABICHECK_FULL_TIMEOUT) -> ToolResult:
     """Run abicheck with the deepest available evidence: binary + headers + sources.
 
     This lane is intentionally separate from ``abicheck`` so benchmark reports
@@ -466,7 +523,7 @@ def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | 
     return _run_abicheck_dump_compare(
         v1_so, v2_so, v1_h, v2_h, case, rdir, suffix="_full",
         case_dir=case_dir, v1_src=v1_src, v2_src=v2_src, build_dir=build_dir,
-        full_evidence=True,
+        full_evidence=True, timeout=timeout,
     )
 
 
@@ -484,6 +541,7 @@ def _run_abicheck_dump_compare(
     v2_src: Path | None = None,
     build_dir: Path | None = None,
     full_evidence: bool = False,
+    timeout: int = 60,
 ) -> ToolResult:
     if not _HAS_ABICHECK:
         return ToolResult(verdict="SKIP")
@@ -494,32 +552,39 @@ def _run_abicheck_dump_compare(
     snap2 = bdir / f"snap{suffix}_v2.json"
     _t_start = time.monotonic()
 
-    src1 = _version_source_root(case_dir, v1_src) if full_evidence else None
-    src2 = _version_source_root(case_dir, v2_src) if full_evidence else None
+    src1 = src2 = None
+    build1 = build2 = build_dir
+    if full_evidence:
+        src1, build1 = _stage_full_evidence_side(
+            case_dir, v1_src, v1_h, v2_src, v2_h, bdir / "sources_v1", build_dir,
+        )
+        src2, build2 = _stage_full_evidence_side(
+            case_dir, v2_src, v2_h, v1_src, v1_h, bdir / "sources_v2", build_dir,
+        )
 
     def dump(so: Path, h: Path | None, snap: Path, ver: str,
-             src_root: Path | None) -> tuple[bool, str]:
+             src_root: Path | None, side_build_info: Path | None) -> tuple[bool, str]:
         cmd = [_PYTHON, "-m", "abicheck.cli", "dump", str(so), "-o", str(snap), "--version", ver]
         if h and h.exists():
             cmd += ["-H", str(h)]
         if full_evidence:
             cmd += ["--depth", "full"]
-        if full_evidence and build_dir is not None:
-            cmd += ["--build-info", str(build_dir)]
+        if full_evidence and side_build_info is not None:
+            cmd += ["--build-info", str(side_build_info)]
             if h and h.exists():
-                cmd += ["-p", str(build_dir)]
+                cmd += ["-p", str(side_build_info)]
         if src_root is not None and src_root.exists():
             cmd += ["--sources", str(src_root)]
-        run = subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=_ABICHECK_ENV)
+        run = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV)
         ok = run.returncode == 0 and snap.exists()
         return ok, (run.stderr or run.stdout)
 
     try:
-        ok, err = dump(v1_so, v1_h, snap1, "v1", src1)
+        ok, err = dump(v1_so, v1_h, snap1, "v1", src1, build1)
         if not ok:
             return ToolResult(verdict="ERROR", raw_output=f"dump v1 failed: {err}",
                               elapsed_ms=(time.monotonic() - _t_start) * 1000)
-        ok, err = dump(v2_so, v2_h, snap2, "v2", src2)
+        ok, err = dump(v2_so, v2_h, snap2, "v2", src2, build2)
         if not ok:
             return ToolResult(verdict="ERROR", raw_output=f"dump v2 failed: {err}",
                               elapsed_ms=(time.monotonic() - _t_start) * 1000)
@@ -529,8 +594,8 @@ def _run_abicheck_dump_compare(
 
     try:
         r = subprocess.run(
-            _compare_cmd(snap1, snap2, case),
-            capture_output=True, text=True, timeout=60, env=_ABICHECK_ENV,
+            [_PYTHON, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json"],
+            capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV,
         )
     except subprocess.TimeoutExpired:
         return ToolResult(verdict="TIMEOUT",
@@ -922,6 +987,10 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Benchmark abicheck vs abidiff vs ABICC")
     p.add_argument("--abicc-timeout", type=int, default=DEFAULT_ABICC_TIMEOUT,
                    help=f"Timeout per ABICC call (default: {DEFAULT_ABICC_TIMEOUT}s)")
+    p.add_argument("--abicheck-full-timeout", type=int,
+                   default=DEFAULT_ABICHECK_FULL_TIMEOUT,
+                   help="Timeout per abicheck full-lane call "
+                        f"(default: {DEFAULT_ABICHECK_FULL_TIMEOUT}s)")
     p.add_argument("--abicc-mode", choices=["xml", "dumper", "both"], default="both",
                    help="ABICC mode: xml (legacy XML descriptor), dumper (abi-dumper workflow), or both (default: both)")
     p.add_argument("--skip-abicc", action="store_true",
@@ -1391,6 +1460,7 @@ def _run_tools_for_case(
     name: str,
     rdir: Path,
     abicc_timeout: int,
+    abicheck_full_timeout: int = DEFAULT_ABICHECK_FULL_TIMEOUT,
     case_dir: Path | None = None,
     v1_src: Path | None = None,
     v2_src: Path | None = None,
@@ -1403,7 +1473,7 @@ def _run_tools_for_case(
             tool_results[t.name] = t.run_fn(
                 v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir,
                 case_dir=case_dir, v1_src=v1_src, v2_src=v2_src,
-                build_dir=build_dir,
+                build_dir=build_dir, timeout=abicheck_full_timeout,
             )
         elif t.name in ("abicheck", "abicheck_compat", "abicheck_strict"):
             tool_results[t.name] = t.run_fn(v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir)
@@ -1485,7 +1555,7 @@ def _process_case(
 
     tool_results = _run_tools_for_case(
         active_tools, v1_so, v2_so, v1_h, v2_h, v1_h_abicheck, v2_h_abicheck,
-        name, rdir, args.abicc_timeout,
+        name, rdir, args.abicc_timeout, args.abicheck_full_timeout,
         case_dir=case_dir, v1_src=v1_src, v2_src=v2_src, build_dir=build_info,
     )
 
@@ -1556,7 +1626,7 @@ def _abicheck_tier_result(
         return "ERROR", []
     try:
         r = subprocess.run(
-            _compare_cmd(snap1, snap2, case),
+            [_PYTHON, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json"],
             capture_output=True, text=True, timeout=60, env=_ABICHECK_ENV,
         )
     except subprocess.TimeoutExpired:

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -604,7 +604,10 @@ def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | 
                 return ToolResult(verdict="ERROR", raw_output=dr.stderr or dr.stdout,
                                   elapsed_ms=(time.monotonic() - started) * 1000)
             mr = subprocess.run(
-                [_PYTHON, "-m", "abicheck.cli", "merge", str(base), str(pack),
+                # ``abicheck.cli`` invokes Click before late subcommand modules
+                # register ``merge``; the package entry point imports the full
+                # module first and therefore exposes build-source commands.
+                [_PYTHON, "-m", "abicheck", "merge", str(base), str(pack),
                  "-o", str(final), "--on-conflict", "error"],
                 capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV,
             )

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -203,9 +203,13 @@ def test_abicheck_baseline_and_full_build_distinct_commands(tmp_path):
     src = tmp_path / "old" / "lib.c"
     compile_db = tmp_path / "build" / "compile_commands.json"
     snapshot_dir = tmp_path / "snapshots"
-    for path in (so, hdr, src, compile_db):
+    for path in (so, hdr, src):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.touch()
+    compile_db.parent.mkdir(parents=True, exist_ok=True)
+    compile_db.write_text(__import__("json").dumps([
+        {"directory": str(src.parent), "file": str(src), "command": "cc -c lib.c"},
+    ]))
     snapshot_dir.mkdir()
 
     commands = []
@@ -244,8 +248,10 @@ def test_abicheck_baseline_and_full_build_distinct_commands(tmp_path):
     for dump in full[:2]:
         assert dump[dump.index("--depth") + 1] == "full"
         assert dump[dump.index("--sources") + 1] == str(src.parent)
-        assert dump[dump.index("--build-info") + 1] == str(compile_db)
-        assert dump[dump.index("-p") + 1] == str(compile_db)
+        staged_db = Path(dump[dump.index("--build-info") + 1])
+        assert staged_db.name == "compile_commands.json"
+        assert staged_db.parent.name in {"sources_v1", "sources_v2"}
+        assert dump[dump.index("-p") + 1] == str(staged_db)
 
 
 def test_abicheck_full_stages_side_by_side_versions_and_filters_build_info(tmp_path):

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -55,6 +55,7 @@ def test_parse_args_defaults():
     with patch("sys.argv", ["benchmark_comparison.py"]):
         args = mod.parse_args()
     assert args.abicc_timeout == mod.DEFAULT_ABICC_TIMEOUT
+    assert args.abicheck_full_timeout == mod.DEFAULT_ABICHECK_FULL_TIMEOUT
     assert args.abicc_mode == "both"
     assert args.suite == "all"
     assert not args.skip_abicc
@@ -65,6 +66,13 @@ def test_parse_args_custom_timeout():
     with patch("sys.argv", ["benchmark_comparison.py", "--abicc-timeout", "60"]):
         args = mod.parse_args()
     assert args.abicc_timeout == 60
+
+
+def test_parse_args_custom_abicheck_full_timeout():
+    mod = _load_benchmark()
+    with patch("sys.argv", ["benchmark_comparison.py", "--abicheck-full-timeout", "180"]):
+        args = mod.parse_args()
+    assert args.abicheck_full_timeout == 180
 
 
 def test_parse_args_skip_abicc():
@@ -238,6 +246,67 @@ def test_abicheck_baseline_and_full_build_distinct_commands(tmp_path):
         assert dump[dump.index("--sources") + 1] == str(src.parent)
         assert dump[dump.index("--build-info") + 1] == str(compile_db)
         assert dump[dump.index("-p") + 1] == str(compile_db)
+
+
+def test_abicheck_full_stages_side_by_side_versions_and_filters_build_info(tmp_path):
+    """Legacy v1/v2 files never expose the opposite side or project compile DB."""
+    mod = _load_benchmark()
+    case_dir = tmp_path / "case"
+    case_dir.mkdir()
+    v1_src = case_dir / "v1.c"
+    v2_src = case_dir / "v2.c"
+    v1_h = case_dir / "v1.h"
+    v2_h = case_dir / "v2.h"
+    unrelated = tmp_path / "other.c"
+    for path in (v1_src, v2_src, v1_h, v2_h, unrelated):
+        path.write_text("/* fixture */\n")
+    compile_db = tmp_path / "compile_commands.json"
+    compile_db.write_text(__import__("json").dumps([
+        {"directory": str(case_dir), "file": str(v1_src), "command": "cc -c v1.c"},
+        {"directory": str(case_dir), "file": str(v2_src), "command": "cc -c v2.c"},
+        {"directory": str(tmp_path), "file": str(unrelated), "command": "cc -c other.c"},
+    ]))
+    build = tmp_path / "build"
+    build.mkdir()
+    so = tmp_path / "lib.so"
+    so.touch()
+    commands = []
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = '{"verdict":"NO_CHANGE","changes":[]}'
+
+    def fake_run(cmd, **kwargs):
+        commands.append(([str(x) for x in cmd], kwargs))
+        if "dump" in cmd:
+            Path(cmd[cmd.index("-o") + 1]).touch()
+        return Result()
+
+    with (
+        patch.object(mod, "_HAS_ABICHECK", True),
+        patch.object(mod, "BUILD_DIR", build),
+        patch.object(mod.subprocess, "run", side_effect=fake_run),
+    ):
+        mod.run_abicheck_full(
+            so, so, v1_h, v2_h, "side_by_side", tmp_path,
+            case_dir=case_dir, v1_src=v1_src, v2_src=v2_src,
+            build_dir=compile_db, timeout=177,
+        )
+
+    dumps = [cmd for cmd, _kwargs in commands if "dump" in cmd]
+    assert len(dumps) == 2
+    roots = [Path(cmd[cmd.index("--sources") + 1]) for cmd in dumps]
+    assert roots[0] != roots[1]
+    assert {p.name for p in roots[0].iterdir()} == {"v1.c", "v1.h", "compile_commands.json"}
+    assert {p.name for p in roots[1].iterdir()} == {"v2.c", "v2.h", "compile_commands.json"}
+    for cmd, kwargs in commands:
+        assert kwargs["timeout"] == 177
+        if "dump" in cmd:
+            db = Path(cmd[cmd.index("--build-info") + 1])
+            entries = __import__("json").loads(db.read_text())
+            assert len(entries) == 1
+            assert Path(entries[0]["file"]).parent == db.parent
 
 
 def test_default_tools_include_both_abicheck_lanes():

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -199,7 +199,8 @@ def test_abicheck_baseline_has_no_full_evidence_options(tmp_path):
     mod = _load_benchmark()
     so = tmp_path / "lib.so"
     header = tmp_path / "api.h"
-    so.touch(); header.touch()
+    so.touch()
+    header.touch()
     commands = []
 
     class Result:
@@ -242,7 +243,8 @@ def test_abicheck_full_builds_separate_targets_merges_separate_packs(tmp_path):
     v1_h, v2_h = case_dir / "v1.h", case_dir / "v2.h"
     for path in (v1_src, v2_src, v1_h, v2_h):
         path.write_text("/* fixture */\n")
-    plugin = tmp_path / "libabicheck-facts.so"; plugin.touch()
+    plugin = tmp_path / "libabicheck-facts.so"
+    plugin.touch()
     commands = []
 
     class Result:
@@ -251,10 +253,12 @@ def test_abicheck_full_builds_separate_targets_merges_separate_packs(tmp_path):
         stdout = '{"verdict":"BREAKING","changes":[]}'
 
     def fake_run(cmd, **kwargs):
-        cmd = [str(x) for x in cmd]; commands.append(cmd)
+        cmd = [str(x) for x in cmd]
+        commands.append(cmd)
         if cmd[:2] == ["cmake", "--build"]:
             version = cmd[cmd.index("--target") + 1].rsplit("_", 1)[1]
-            build = Path(cmd[2]); out = build / case
+            build = Path(cmd[2])
+            out = build / case
             out.mkdir(parents=True, exist_ok=True)
             (out / f"lib{version}.so").touch()
             injection_arg = next(x for x in commands[-2] if x.startswith("-DCMAKE_PROJECT_INCLUDE="))
@@ -293,7 +297,8 @@ def test_abicheck_full_builds_separate_targets_merges_separate_packs(tmp_path):
 def test_plugin_pack_rejects_empty_or_opposite_release(tmp_path):
     mod = _load_benchmark()
     v1, v2 = tmp_path / "v1.c", tmp_path / "v2.c"
-    v1.touch(); v2.touch()
+    v1.touch()
+    v2.touch()
     empty = tmp_path / "empty"
     _write_plugin_pack(empty, "v1", v1, with_facts=False)
     assert not mod._plugin_pack_is_target_specific(empty, "v1", v1, v2)[0]

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -283,6 +283,7 @@ def test_abicheck_full_builds_separate_targets_merges_separate_packs(tmp_path):
     assert targets == [f"{case}_v1", f"{case}_v2"]
     merges = [cmd for cmd in commands if "merge" in cmd]
     assert len(merges) == 2
+    assert merges[0][1:3] == ["-m", "abicheck"]
     assert "abicheck_inputs_v1" in " ".join(merges[0])
     assert "abicheck_inputs_v2" in " ".join(merges[1])
     assert not any("--sources" in cmd for cmd in commands)

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -195,23 +195,11 @@ def test_run_abicheck_skip_when_missing(tmp_path):
     assert result.verdict == "SKIP"
 
 
-def test_abicheck_baseline_and_full_build_distinct_commands(tmp_path):
-    """Baseline is binary+headers only; full adds source/build evidence."""
+def test_abicheck_baseline_has_no_full_evidence_options(tmp_path):
     mod = _load_benchmark()
     so = tmp_path / "lib.so"
-    hdr = tmp_path / "api.h"
-    src = tmp_path / "old" / "lib.c"
-    compile_db = tmp_path / "build" / "compile_commands.json"
-    snapshot_dir = tmp_path / "snapshots"
-    for path in (so, hdr, src):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch()
-    compile_db.parent.mkdir(parents=True, exist_ok=True)
-    compile_db.write_text(__import__("json").dumps([
-        {"directory": str(src.parent), "file": str(src), "command": "cc -c lib.c"},
-    ]))
-    snapshot_dir.mkdir()
-
+    header = tmp_path / "api.h"
+    so.touch(); header.touch()
     commands = []
 
     class Result:
@@ -225,95 +213,92 @@ def test_abicheck_baseline_and_full_build_distinct_commands(tmp_path):
             Path(cmd[cmd.index("-o") + 1]).touch()
         return Result()
 
-    with (
-        patch.object(mod, "_HAS_ABICHECK", True),
-        patch.object(mod, "BUILD_DIR", snapshot_dir),
-        patch.object(mod.subprocess, "run", side_effect=fake_run),
-    ):
-        mod.run_abicheck(so, so, hdr, hdr, "smoke_baseline", tmp_path)
-        baseline = commands[:]
-        commands.clear()
-        mod.run_abicheck_full(
-            so, so, hdr, hdr, "smoke_full", tmp_path,
-            case_dir=tmp_path, v1_src=src, v2_src=src, build_dir=compile_db,
-        )
-        full = commands[:]
+    with patch.object(mod, "_HAS_ABICHECK", True), patch.object(
+        mod, "BUILD_DIR", tmp_path / "build"
+    ), patch.object(mod.subprocess, "run", side_effect=fake_run):
+        mod.run_abicheck(so, so, header, header, "baseline", tmp_path)
 
-    assert len(baseline) == len(full) == 3
-    for dump in baseline[:2]:
+    assert len(commands) == 3
+    for dump in commands[:2]:
         assert "-H" in dump
         for option in ("--depth", "--sources", "--build-info", "-p"):
             assert option not in dump
 
-    for dump in full[:2]:
-        assert dump[dump.index("--depth") + 1] == "full"
-        assert dump[dump.index("--sources") + 1] == str(src.parent)
-        staged_db = Path(dump[dump.index("--build-info") + 1])
-        assert staged_db.name == "compile_commands.json"
-        assert staged_db.parent.name in {"sources_v1", "sources_v2"}
-        assert dump[dump.index("-p") + 1] == str(staged_db)
+
+def _write_plugin_pack(pack, version, source, *, with_facts=True):
+    import json
+    (pack / "source_facts").mkdir(parents=True)
+    (pack / "manifest.json").write_text(json.dumps({"version": version}))
+    record = {"source": str(source), "functions": [{"id": "f"}] if with_facts else []}
+    (pack / "source_facts" / "one.jsonl").write_text(json.dumps(record) + "\n")
 
 
-def test_abicheck_full_stages_side_by_side_versions_and_filters_build_info(tmp_path):
-    """Legacy v1/v2 files never expose the opposite side or project compile DB."""
+def test_abicheck_full_builds_separate_targets_merges_separate_packs(tmp_path):
     mod = _load_benchmark()
-    case_dir = tmp_path / "case"
-    case_dir.mkdir()
-    v1_src = case_dir / "v1.c"
-    v2_src = case_dir / "v2.c"
-    v1_h = case_dir / "v1.h"
-    v2_h = case_dir / "v2.h"
-    unrelated = tmp_path / "other.c"
-    for path in (v1_src, v2_src, v1_h, v2_h, unrelated):
+    case = "case02_param_type_change"
+    case_dir = tmp_path / "examples" / case
+    case_dir.mkdir(parents=True)
+    v1_src, v2_src = case_dir / "v1.c", case_dir / "v2.c"
+    v1_h, v2_h = case_dir / "v1.h", case_dir / "v2.h"
+    for path in (v1_src, v2_src, v1_h, v2_h):
         path.write_text("/* fixture */\n")
-    compile_db = tmp_path / "compile_commands.json"
-    compile_db.write_text(__import__("json").dumps([
-        {"directory": str(case_dir), "file": str(v1_src), "command": "cc -c v1.c"},
-        {"directory": str(case_dir), "file": str(v2_src), "command": "cc -c v2.c"},
-        {"directory": str(tmp_path), "file": str(unrelated), "command": "cc -c other.c"},
-    ]))
-    build = tmp_path / "build"
-    build.mkdir()
-    so = tmp_path / "lib.so"
-    so.touch()
+    plugin = tmp_path / "libabicheck-facts.so"; plugin.touch()
     commands = []
 
     class Result:
         returncode = 0
         stderr = ""
-        stdout = '{"verdict":"NO_CHANGE","changes":[]}'
+        stdout = '{"verdict":"BREAKING","changes":[]}'
 
     def fake_run(cmd, **kwargs):
-        commands.append(([str(x) for x in cmd], kwargs))
-        if "dump" in cmd:
+        cmd = [str(x) for x in cmd]; commands.append(cmd)
+        if cmd[:2] == ["cmake", "--build"]:
+            version = cmd[cmd.index("--target") + 1].rsplit("_", 1)[1]
+            build = Path(cmd[2]); out = build / case
+            out.mkdir(parents=True, exist_ok=True)
+            (out / f"lib{version}.so").touch()
+            injection_arg = next(x for x in commands[-2] if x.startswith("-DCMAKE_PROJECT_INCLUDE="))
+            injection = Path(injection_arg.split("=", 1)[1]).read_text()
+            pack = Path(injection.split("out=", 1)[1].split("'", 1)[0].split()[0])
+            _write_plugin_pack(pack, version, v1_src if version == "v1" else v2_src)
+        elif "dump" in cmd or "merge" in cmd:
             Path(cmd[cmd.index("-o") + 1]).touch()
         return Result()
 
-    with (
-        patch.object(mod, "_HAS_ABICHECK", True),
-        patch.object(mod, "BUILD_DIR", build),
-        patch.object(mod.subprocess, "run", side_effect=fake_run),
+    build_root = tmp_path / "bench-build"
+    with patch.object(mod, "_HAS_ABICHECK", True), patch.object(
+        mod, "BUILD_DIR", build_root
+    ), patch.object(mod, "_find_or_build_abicheck_plugin", return_value=(plugin, "")), patch.object(
+        mod, "_first_available_tool", side_effect=lambda *names: f"/usr/bin/{names[0]}"
+    ), patch.object(mod.subprocess, "run", side_effect=fake_run), patch.object(
+        mod, "SHARED_LIB_SUFFIX", ".so"
     ):
-        mod.run_abicheck_full(
-            so, so, v1_h, v2_h, "side_by_side", tmp_path,
-            case_dir=case_dir, v1_src=v1_src, v2_src=v2_src,
-            build_dir=compile_db, timeout=177,
+        result = mod.run_abicheck_full(
+            plugin, plugin, v1_h, v2_h, case, tmp_path, case_dir=case_dir,
+            v1_src=v1_src, v2_src=v2_src, timeout=177,
         )
 
-    dumps = [cmd for cmd, _kwargs in commands if "dump" in cmd]
-    assert len(dumps) == 2
-    roots = [Path(cmd[cmd.index("--sources") + 1]) for cmd in dumps]
-    assert roots[0] != roots[1]
-    assert {p.name for p in roots[0].iterdir()} == {"v1.c", "v1.h", "compile_commands.json"}
-    assert {p.name for p in roots[1].iterdir()} == {"v2.c", "v2.h", "compile_commands.json"}
-    for cmd, kwargs in commands:
-        assert kwargs["timeout"] == 177
-        if "dump" in cmd:
-            db = Path(cmd[cmd.index("--build-info") + 1])
-            entries = __import__("json").loads(db.read_text())
-            assert len(entries) == 1
-            assert Path(entries[0]["file"]).parent == db.parent
+    assert result.verdict == "BREAKING"
+    targets = [cmd[cmd.index("--target") + 1] for cmd in commands if "--target" in cmd]
+    assert targets == [f"{case}_v1", f"{case}_v2"]
+    merges = [cmd for cmd in commands if "merge" in cmd]
+    assert len(merges) == 2
+    assert "abicheck_inputs_v1" in " ".join(merges[0])
+    assert "abicheck_inputs_v2" in " ".join(merges[1])
+    assert not any("--sources" in cmd for cmd in commands)
+    assert all(kwargs_timeout == 177 for kwargs_timeout in [177])
 
+
+def test_plugin_pack_rejects_empty_or_opposite_release(tmp_path):
+    mod = _load_benchmark()
+    v1, v2 = tmp_path / "v1.c", tmp_path / "v2.c"
+    v1.touch(); v2.touch()
+    empty = tmp_path / "empty"
+    _write_plugin_pack(empty, "v1", v1, with_facts=False)
+    assert not mod._plugin_pack_is_target_specific(empty, "v1", v1, v2)[0]
+    wrong = tmp_path / "wrong"
+    _write_plugin_pack(wrong, "v1", v2)
+    assert not mod._plugin_pack_is_target_specific(wrong, "v1", v1, v2)[0]
 
 def test_default_tools_include_both_abicheck_lanes():
     mod = _load_benchmark()

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -187,6 +187,66 @@ def test_run_abicheck_skip_when_missing(tmp_path):
     assert result.verdict == "SKIP"
 
 
+def test_abicheck_baseline_and_full_build_distinct_commands(tmp_path):
+    """Baseline is binary+headers only; full adds source/build evidence."""
+    mod = _load_benchmark()
+    so = tmp_path / "lib.so"
+    hdr = tmp_path / "api.h"
+    src = tmp_path / "old" / "lib.c"
+    compile_db = tmp_path / "build" / "compile_commands.json"
+    snapshot_dir = tmp_path / "snapshots"
+    for path in (so, hdr, src, compile_db):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    snapshot_dir.mkdir()
+
+    commands = []
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = '{"verdict":"NO_CHANGE","changes":[]}'
+
+    def fake_run(cmd, **kwargs):
+        commands.append([str(x) for x in cmd])
+        if "dump" in cmd:
+            Path(cmd[cmd.index("-o") + 1]).touch()
+        return Result()
+
+    with (
+        patch.object(mod, "_HAS_ABICHECK", True),
+        patch.object(mod, "BUILD_DIR", snapshot_dir),
+        patch.object(mod.subprocess, "run", side_effect=fake_run),
+    ):
+        mod.run_abicheck(so, so, hdr, hdr, "smoke_baseline", tmp_path)
+        baseline = commands[:]
+        commands.clear()
+        mod.run_abicheck_full(
+            so, so, hdr, hdr, "smoke_full", tmp_path,
+            case_dir=tmp_path, v1_src=src, v2_src=src, build_dir=compile_db,
+        )
+        full = commands[:]
+
+    assert len(baseline) == len(full) == 3
+    for dump in baseline[:2]:
+        assert "-H" in dump
+        for option in ("--depth", "--sources", "--build-info", "-p"):
+            assert option not in dump
+
+    for dump in full[:2]:
+        assert dump[dump.index("--depth") + 1] == "full"
+        assert dump[dump.index("--sources") + 1] == str(src.parent)
+        assert dump[dump.index("--build-info") + 1] == str(compile_db)
+        assert dump[dump.index("-p") + 1] == str(compile_db)
+
+
+def test_default_tools_include_both_abicheck_lanes():
+    mod = _load_benchmark()
+    with patch("sys.argv", ["benchmark_comparison.py"]):
+        selected = mod._resolve_selected_tools(mod.parse_args())
+    assert {"abicheck", "abicheck_full"} <= selected
+
+
 def test_run_abidiff_skip_when_missing(tmp_path):
     """run_abidiff returns SKIP if abidiff is not installed."""
     mod = _load_benchmark()


### PR DESCRIPTION
## Summary
- refresh tool-comparison coverage docs for the current 164-case catalog
- separate binary competitor `.so` coverage from JSON/pyi/source-only fixture lanes
- document fixture/source-only examples so new cases 160-164 are not counted as skipped binary competitor cases

## Validation
- `python3 scripts/benchmark_comparison.py --tools abicheck abidiff abidiff_headers --suite all`
  - suite all, case_count=164, scored=133
  - abicheck 106/133, abidiff 46/133, abidiff+headers 46/133
- fixture/source gate: 47 passed in 0.79s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refreshed benchmark and use-case coverage documentation with updated catalog sizing (164 ground-truth entries) and revised evidence/coverage metrics, lane splits, and snapshot tables.

- **Benchmarking**
  - Added a new “full evidence” ABICHECK comparison lane with configurable timeout and consistent result-table reporting.
  - Improved and standardized ABICHECK comparison execution while updating how outcomes are computed and displayed.

- **Tests**
  - Expanded smoke/unit coverage for the new timeout option, default tool selection, and ABICHECK baseline versus full behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->