### PR TITLE
Clear the CodeFactor issue backlog (lint defects + Complex Method + Duplicate Code)

### DIFF
--- a/abicheck/buildsource/export_accounting.py
+++ b/abicheck/buildsource/export_accounting.py
@@ -206,83 +206,82 @@ def _mangled_owner_namespace(symbol: str) -> str | None:
     return None
 
 
-def _external_dependency_origin(
-    symbol: str,
-    needed_libs: list[str],
-    self_names: tuple[str, ...] = (),
-) -> str | None:
-    """Name the external dependency *symbol* leaked from, or ``None`` if native.
+_PREFIX_NO_MATCH: object = object()
+"""Sentinel: the runtime-prefix table did not attribute the symbol."""
 
-    Two signals, cheapest first: the shared
-    :func:`~abicheck.elf_metadata._guess_symbol_origin` runtime-prefix table
-    (libc/libgcc/libmvec/fundamental-RTTI/``operator new`` and the ``_ZNSt``/
-    ``_ZTVSt`` std prefixes), then an **owner-namespace** check that also covers the
-    leaked-definition forms the prefix table misses — a std/libstdc++ vtable,
-    typeinfo, or guard variable for a *nested* std type (``_ZTVNSt…``,
-    ``_ZGVZNSt…``) and a vendored third-party owner (``fmt``/``boost``/…). Reading
-    the *owner* (not any referenced type) keeps a native symbol that merely takes a
-    ``std`` argument from being mislabelled external. Conservative: only a positive
-    match returns a name.
 
-    ``self_names`` are the audited library's own identity tokens (soname /
-    install-name / library name; see :func:`_library_self_names`): a vendored
-    namespace owned by the library *being scanned* (auditing libfmt itself, whose
-    ``fmt::detail`` symbols are native, not a leak) is **not** reported external so
-    the finding does not tell users to unlink their own library (Codex review).
+def _origin_from_prefix_table(
+    symbol: str, needed_libs: list[str], self_names: tuple[str, ...],
+) -> str | None | object:
+    """Prefix-table origin, or :data:`_PREFIX_NO_MATCH` to fall through to owners.
+
+    A non-sentinel return (``None`` or a lib name) is authoritative.
     """
     from ..elf_metadata import _guess_symbol_origin
 
     lib = _guess_symbol_origin(symbol, needed_libs)
-    if lib is not None:
-        # libc++abi is the ABI support library, not libc++ itself. If the prefix
-        # table picked it (DT_NEEDED ordered libc++abi before libc++) for a libc++
-        # ``std::__1`` symbol, re-resolve to the real libc++ runtime (Codex review).
-        if lib.rsplit("/", 1)[-1].startswith("libc++abi") and "St3__1" in symbol:
-            lib = _cxx_runtime_lib(symbol, needed_libs)
-        # If the resolved runtime library *is* the audited library (auditing
-        # libstdc++/libc++ itself), its own std/runtime symbols are native, not a
-        # leak — the self gate covers the runtime path too, not only vendored
-        # namespaces (Codex review).
-        if _resolved_lib_is_self(lib, self_names):
-            return None
-        return lib
-    owner = _mangled_owner_namespace(symbol)
-    if owner is not None:
-        # The owner-fallback runtime path (a guard variable / nested-std form the
-        # prefix table misses) is self-gated the same way as the prefix-table path
-        # above, so auditing the runtime library itself doesn't flag its own exports
-        # (Codex). Itanium C++ runtimes only — MSVC STL attribution is handled below.
-        if owner == "__gnu_cxx":
-            runtime = (
-                "libstdc++.so.6"  # libstdc++-only extension namespace — never libc++
-            )
-        elif owner == "__cxxabiv1":
-            # The Itanium C++ ABI namespace is implemented by libc++abi (or
-            # libstdc++'s merged libsupc++), NOT the std runtime — so ``libc++abi``
-            # is its correct owner and must not be excluded, else auditing libc++abi
-            # flags its own exports (Codex review).
-            runtime = _cxx_abi_runtime_lib(needed_libs, self_names)
-        elif owner == "std" or owner in _STD_OWNER_NAMESPACES:
-            runtime = _cxx_runtime_lib(symbol, needed_libs)
-        else:
-            runtime = None
-        if runtime is not None:
-            return None if _resolved_lib_is_self(runtime, self_names) else runtime
-        google_child = _nested_component(symbol, 1)
-    else:
-        # MSVC decorated name (``?name@scope@…@@sig``): no Itanium owner, but its
-        # outermost ``@``-scope still names a vendored dependency (Boost/{fmt}/
-        # protobuf) statically linked and re-exported on Windows — otherwise those
-        # leaks are miscounted as ``undeclared_export`` (Codex review). MSVC C++
-        # runtime (STL) attribution is a separate concern, so a bare ``std`` owner
-        # stays native here rather than being mislabelled with an ELF soname.
-        comps = _msvc_scope_components(symbol)
-        if len(comps) < 2:
-            return None  # un-nested name — no enclosing scope, no owner
-        owner = comps[-1]  # scopes are inner-to-outer; the top-level ns is last
-        if owner == "std":
-            return None
-        google_child = comps[-2] if len(comps) >= 3 else None
+    if lib is None:
+        return _PREFIX_NO_MATCH
+    # libc++abi is the ABI support library, not libc++ itself. If the prefix
+    # table picked it (DT_NEEDED ordered libc++abi before libc++) for a libc++
+    # ``std::__1`` symbol, re-resolve to the real libc++ runtime (Codex review).
+    if lib.rsplit("/", 1)[-1].startswith("libc++abi") and "St3__1" in symbol:
+        lib = _cxx_runtime_lib(symbol, needed_libs)
+    # If the resolved runtime library *is* the audited library (auditing
+    # libstdc++/libc++ itself), its own std/runtime symbols are native, not a
+    # leak — the self gate covers the runtime path too, not only vendored
+    # namespaces (Codex review).
+    if _resolved_lib_is_self(lib, self_names):
+        return None
+    return lib
+
+
+def _itanium_owner_runtime(
+    owner: str, symbol: str, needed_libs: list[str], self_names: tuple[str, ...],
+) -> str | None:
+    """Resolve an Itanium owner namespace to its C++ runtime lib, else ``None``.
+
+    The owner-fallback runtime path (a guard variable / nested-std form the
+    prefix table misses); Itanium C++ runtimes only — MSVC STL attribution is
+    handled by :func:`_msvc_leaked_owner`.
+    """
+    if owner == "__gnu_cxx":
+        # libstdc++-only extension namespace — never libc++.
+        return "libstdc++.so.6"
+    if owner == "__cxxabiv1":
+        # The Itanium C++ ABI namespace is implemented by libc++abi (or
+        # libstdc++'s merged libsupc++), NOT the std runtime — so ``libc++abi``
+        # is its correct owner and must not be excluded, else auditing libc++abi
+        # flags its own exports (Codex review).
+        return _cxx_abi_runtime_lib(needed_libs, self_names)
+    if owner == "std" or owner in _STD_OWNER_NAMESPACES:
+        return _cxx_runtime_lib(symbol, needed_libs)
+    return None
+
+
+def _msvc_leaked_owner(symbol: str) -> tuple[str, str | None] | None:
+    """``(owner, google_child)`` for an MSVC decorated name, or ``None`` to bail.
+
+    MSVC decorated name (``?name@scope@…@@sig``): no Itanium owner, but its
+    outermost ``@``-scope still names a vendored dependency (Boost/{fmt}/
+    protobuf) statically linked and re-exported on Windows — otherwise those
+    leaks are miscounted as ``undeclared_export`` (Codex review). MSVC C++
+    runtime (STL) attribution is a separate concern, so a bare ``std`` owner
+    stays native here rather than being mislabelled with an ELF soname.
+    """
+    comps = _msvc_scope_components(symbol)
+    if len(comps) < 2:
+        return None  # un-nested name — no enclosing scope, no owner
+    owner = comps[-1]  # scopes are inner-to-outer; the top-level ns is last
+    if owner == "std":
+        return None
+    return owner, (comps[-2] if len(comps) >= 3 else None)
+
+
+def _vendored_owner_result(
+    owner: str, google_child: str | None, self_names: tuple[str, ...],
+) -> str | None:
+    """Map a resolved owner namespace to its vendored dependency lib, or ``None``."""
     vendored = _VENDORED_OWNER_NAMESPACES.get(owner)
     if owner == "google" and google_child != "protobuf":
         # ``google::`` is shared by many Google libraries (glog's
@@ -293,6 +292,47 @@ def _external_dependency_origin(
     if vendored is not None and _owner_is_self_library(owner, self_names):
         return None  # the audited library *is* this vendored library — native
     return vendored
+
+
+def _external_dependency_origin(
+    symbol: str,
+    needed_libs: list[str],
+    self_names: tuple[str, ...] = (),
+) -> str | None:
+    """Name the external dependency *symbol* leaked from, or ``None`` if native.
+
+    Two signals, cheapest first: the shared
+    :func:`~abicheck.elf_metadata._guess_symbol_origin` runtime-prefix table
+    (libc/libgcc/libmvec/fundamental-RTTI/``operator new`` and the ``_ZNSt``/
+    ``_ZTVSt`` std prefixes) via :func:`_origin_from_prefix_table`, then an
+    **owner-namespace** check that also covers the leaked-definition forms the
+    prefix table misses — a std/libstdc++ vtable, typeinfo, or guard variable for
+    a *nested* std type (``_ZTVNSt…``, ``_ZGVZNSt…``) and a vendored third-party
+    owner (``fmt``/``boost``/…). Reading the *owner* (not any referenced type)
+    keeps a native symbol that merely takes a ``std`` argument from being
+    mislabelled external. Conservative: only a positive match returns a name.
+
+    ``self_names`` are the audited library's own identity tokens (soname /
+    install-name / library name; see :func:`_library_self_names`): a vendored
+    namespace owned by the library *being scanned* (auditing libfmt itself, whose
+    ``fmt::detail`` symbols are native, not a leak) is **not** reported external so
+    the finding does not tell users to unlink their own library (Codex review).
+    """
+    prefix = _origin_from_prefix_table(symbol, needed_libs, self_names)
+    if prefix is not _PREFIX_NO_MATCH:
+        return prefix  # type: ignore[return-value]
+    owner = _mangled_owner_namespace(symbol)
+    if owner is not None:
+        runtime = _itanium_owner_runtime(owner, symbol, needed_libs, self_names)
+        if runtime is not None:
+            return None if _resolved_lib_is_self(runtime, self_names) else runtime
+        google_child = _nested_component(symbol, 1)
+    else:
+        msvc = _msvc_leaked_owner(symbol)
+        if msvc is None:
+            return None
+        owner, google_child = msvc
+    return _vendored_owner_result(owner, google_child, self_names)
 
 
 def _msvc_scope_components(symbol: str) -> list[str]:

--- a/abicheck/buildsource/source_abi.py
+++ b/abicheck/buildsource/source_abi.py
@@ -57,7 +57,7 @@ def _confidence(raw: Any) -> LayerConfidence:
 def _as_bool(raw: Any, default: bool) -> bool:
     """Forward-compat boolean parse: a hand-edited pack may carry the string
     ``"false"``, which ``bool(...)`` would misread as True (evidence/CLAUDE.md
-    "never abort/​misload a hand-edited pack")."""
+    "never abort/misload a hand-edited pack")."""
     if raw is None:
         return default
     if isinstance(raw, bool):

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1309,64 +1309,7 @@ def _embed_inline_source_side(
                    "build_context_defines + per-field guards.")
 @verbose_option
 @click.pass_context
-def compare_cmd(
-    ctx: click.Context,
-    old_input: Path, new_input: Path,
-    jobs: int, dso_only: bool, output_dir: Path | None,
-    fail_on_removed: bool,
-    debug_info1: Path | None, debug_info2: Path | None,
-    devel_pkg1: Path | None, devel_pkg2: Path | None,
-    include_private_dso: bool, keep_extracted: bool,
-    manifest_path: Path | None, bundle_system_providers: str,
-    bundle_cohorts: tuple[str, ...], no_bundle_analysis: bool,
-    headers: tuple[Path, ...], includes: tuple[Path, ...], lang: str,
-    header_backend: str,
-    gcc_path: str | None, gcc_prefix: str | None, gcc_options: str | None,
-    gcc_option_tokens: tuple[str, ...], sysroot: Path | None, nostdinc: bool,
-    old_header_backend: str | None, new_header_backend: str | None,
-    old_headers_only: tuple[Path, ...], new_headers_only: tuple[Path, ...],
-    old_includes_only: tuple[Path, ...], new_includes_only: tuple[Path, ...],
-    old_version: str, new_version: str,
-    fmt: str, demangle: bool | None, output: Path | None,
-    suppress: Path | None, strict_suppressions: bool, require_justification: bool,
-    policy: str, policy_file_path: Path | None,
-    pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
-    dwarf_only: bool,
-    severity_preset: str | None,
-    severity_abi_breaking: str | None,
-    severity_potential_breaking: str | None,
-    severity_quality_issues: str | None,
-    severity_addition: str | None,
-    config: Path | None,
-    exit_code_scheme: str | None,
-    follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
-    show_redundant: bool, show_only: str | None, stat: bool,
-    scope_public_headers: bool, collapse_versioned_symbols: bool, show_filtered: bool,
-    public_symbols: tuple[str, ...], public_symbols_list: Path | None,
-    post_manifest_path: Path | None,
-    report_mode: str, show_impact: bool,
-    recommend: bool,
-    debug_format_opt: str | None,
-    debug_format: str | None,
-    annotate: bool,
-    annotate_additions: bool,
-    debug_roots: tuple[Path, ...],
-    debug_roots_old: tuple[Path, ...],
-    debug_roots_new: tuple[Path, ...],
-    debuginfod: bool,
-    debuginfod_url: str | None,
-    pattern_verdicts: bool,
-    explain_patterns: bool,
-    surface_metrics: bool,
-    reconcile_build_context: bool,
-    env_matrix_path: Path | None,
-    verbose: bool,
-    old_build_info: Path | None = None, new_build_info: Path | None = None,
-    old_sources: Path | None = None, new_sources: Path | None = None,
-    depth: str | None = None, max_depth: bool = False,
-    probe_matrix_old: Path | None = None,
-    probe_matrix_new: Path | None = None,
-) -> None:
+def compare_cmd(ctx: click.Context, **kwargs: Any) -> None:
     """Compare two ABI surfaces and report changes.
 
     Each input (OLD, NEW) can be a .so shared library, a JSON snapshot from
@@ -1418,17 +1361,15 @@ def compare_cmd(
       abicheck compare libfoo.so.1 libfoo.so.2 -H include/foo.h --policy sdk_vendor
       abicheck compare old.json new.json --suppress suppressions.yaml
     """
-    # Options are parsed by the click wrapper above; the full compare flow
-    # lives in cli_compare_helpers.run_compare (size-split from cli.py to keep
-    # this module under the AI-readiness file-size cap). Forward every parsed
-    # parameter unchanged so behaviour — and the exit-code matrix — is identical
-    # to the previously-inlined body. locals() here is exactly the parameters
-    # (captured before the import adds a name), so no argument can be dropped.
-    _params = dict(locals())
-    _params.pop("ctx")
+    # Options are parsed by the click wrapper above; the full compare flow lives
+    # in cli_compare_helpers.run_compare (size-split from cli.py to keep this
+    # module under the AI-readiness file-size cap). Click collects every declared
+    # option/argument into **kwargs, so forwarding it verbatim keeps behaviour —
+    # and the exit-code matrix — identical while the single typed signature lives
+    # only on run_compare (no duplicated 56-line parameter list; CodeFactor).
     from .cli_compare_helpers import run_compare
 
-    run_compare(ctx, **_params)
+    run_compare(ctx, **kwargs)
 
 
 @main.command("recommend-collect-mode")

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1309,7 +1309,7 @@ def _embed_inline_source_side(
                    "build_context_defines + per-field guards.")
 @verbose_option
 @click.pass_context
-def compare_cmd(ctx: click.Context, **kwargs: Any) -> None:
+def compare_cmd(ctx: click.Context, /, **kwargs: Any) -> None:
     """Compare two ABI surfaces and report changes.
 
     Each input (OLD, NEW) can be a .so shared library, a JSON snapshot from

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -102,7 +102,7 @@ from .serialization import snapshot_to_json
 
 if TYPE_CHECKING:
     from .buildsource.pack import BuildSourcePack
-    from .checker_types import Change, DiffResult
+    from .checker_types import Change
     from .debug_resolver import DebugArtifact
     from .service_scan import CompileContext
     from .severity import SeverityConfig
@@ -182,7 +182,7 @@ def _stamp_provenance(
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "HEAD"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True, text=True, timeout=5, check=False,
             )
             if result.returncode == 0:
                 snap.git_commit = result.stdout.strip()

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -29,6 +29,7 @@ in ``check_ai_readiness``). Verdict routing stays through the Tier-2 service
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
 
 import click
 
@@ -63,6 +64,289 @@ from .cli_resolve import (
     classify_compare_operand,
 )
 from .errors import AbicheckError
+
+if TYPE_CHECKING:
+    from .cli_helpers_compare import ResolvedCompareConfig
+    from .model import AbiSnapshot
+
+
+def _cli_flag(name: str, value: bool) -> bool | None:
+    """Return *value* only when *name* actually came from the command line.
+
+    So a flag default (e.g. ``--scope-public-headers``'s True) doesn't mask config.
+    """
+    src = click.get_current_context().get_parameter_source(name)
+    return value if src == click.core.ParameterSource.COMMANDLINE else None
+
+
+def _resolve_compare_config(
+    *,
+    config: Path | None,
+    severity_preset: str | None,
+    severity_abi_breaking: str | None,
+    severity_potential_breaking: str | None,
+    severity_quality_issues: str | None,
+    severity_addition: str | None,
+    scope_public_headers: bool,
+    collapse_versioned_symbols: bool,
+    public_symbols: tuple[str, ...],
+    strict_suppressions: bool,
+    require_justification: bool,
+    exit_code_scheme: str | None,
+) -> tuple[Path | None, object, ResolvedCompareConfig]:
+    """Load the project config and merge CLI flags over it (CLI > config > default).
+
+    ADR-037 D4: resolved *before* dispatch so both the single-file and the
+    directory/package fan-out paths share one resolution. Auto-discovered from the
+    current directory upward, overridable with ``--config``.
+    """
+    from .buildsource.inline import load_build_config
+    from .cli_helpers_compare import discover_project_config, resolve_compare_config
+
+    cfg_path = config if config is not None else discover_project_config()
+    try:
+        project_cfg = load_build_config(cfg_path) if cfg_path is not None else None
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    resolved_cfg = resolve_compare_config(
+        project_cfg,
+        cli_severity_preset=severity_preset,
+        cli_severity_abi_breaking=severity_abi_breaking,
+        cli_severity_potential_breaking=severity_potential_breaking,
+        cli_severity_quality_issues=severity_quality_issues,
+        cli_severity_addition=severity_addition,
+        cli_scope_public=_cli_flag("scope_public_headers", scope_public_headers),
+        cli_collapse_versioned_symbols=_cli_flag(
+            "collapse_versioned_symbols", collapse_versioned_symbols
+        ),
+        cli_public_symbols=public_symbols,
+        cli_strict_suppressions=_cli_flag("strict_suppressions", strict_suppressions),
+        cli_require_justification=_cli_flag(
+            "require_justification", require_justification
+        ),
+        cli_exit_code_scheme=exit_code_scheme,
+    )
+    return cfg_path, project_cfg, resolved_cfg
+
+
+def _reject_set_input_flags(
+    exit_code_scheme: str | None,
+    reconcile_build_context: bool,
+    env_matrix_path: Path | None,
+) -> None:
+    """Reject single-pair-only flags on a directory/package (release) compare.
+
+    The per-library fan-out has no public CLI support for these, so reject them
+    loudly rather than silently ignore them (ADR-037 D12).
+    """
+    if exit_code_scheme is not None:
+        raise click.UsageError(
+            "--exit-code-scheme is not supported for directory/package "
+            "(release) comparisons: the per-library fan-out uses the legacy "
+            "verdict scheme, or severity-aware when severity is configured in "
+            ".abicheck.yml. Compare libraries individually for explicit "
+            "scheme control."
+        )
+    if reconcile_build_context:
+        raise click.UsageError(
+            "--reconcile-build-context is not supported for directory/package "
+            "(release) comparisons; it applies to single-file / snapshot "
+            "inputs. Compare the libraries individually to use it."
+        )
+    if env_matrix_path is not None:
+        raise click.UsageError(
+            "--env-matrix is not supported for directory/package (release) "
+            "comparisons yet; it applies to single-file / snapshot inputs. "
+            "Compare the libraries individually to use it."
+        )
+
+
+class _NormalizedCompareOptions(NamedTuple):
+    collect_mode: str
+    headers: tuple[Path, ...]
+    old_headers_only: tuple[Path, ...]
+    new_headers_only: tuple[Path, ...]
+    effective_debug_format: str | None
+    demangle: bool
+    report_mode: str
+    show_impact: bool
+
+
+def _normalize_compare_options(
+    resolved_cfg: ResolvedCompareConfig,
+    *,
+    depth: str | None,
+    max_depth: bool,
+    annotate: bool,
+    annotate_additions: bool,
+    headers: tuple[Path, ...],
+    old_headers_only: tuple[Path, ...],
+    new_headers_only: tuple[Path, ...],
+    debug_format_opt: str | None,
+    debug_format: str | None,
+    demangle: bool | None,
+    fmt: str,
+    report_mode: str,
+    show_impact: bool,
+) -> _NormalizedCompareOptions:
+    """Fold the compare option flags into their resolved, dispatch-ready values."""
+    if annotate_additions and not annotate:
+        raise click.UsageError("--annotate-additions requires --annotate")
+
+    # Fold the unified --depth/--max dial into the internal collect mode
+    # (ADR-037 D5), the same way `dump` does. With no preset, compare reads at
+    # "off"; --depth binary suppresses the L2 header AST (symbols-only).
+    collect_mode = resolve_dump_depth(depth, max_depth, "off")
+    if depth == "binary":
+        headers, old_headers_only, new_headers_only = (), (), ()
+
+    # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
+    # flags. The selector supersedes the legacy flags whenever it is given:
+    # an explicit "auto" returns to auto-detection (None) even if a legacy flag
+    # is also present; only when the selector is absent do the legacy flags apply.
+    if debug_format_opt is not None:
+        effective_debug_format = (
+            None if debug_format_opt.lower() == "auto" else debug_format_opt
+        )
+    else:
+        effective_debug_format = debug_format
+
+    # Tri-state --demangle: default ON for the text formats whose renderer
+    # post-processes symbols through demangle_text (markdown/review), OFF for
+    # machine formats (json/sarif/junit) and HTML — the HTML renderer emits
+    # symbols structurally and demangling its string would inject unescaped
+    # '<'/'>'/'&' from C++ names and corrupt the markup. Explicit flag wins.
+    demangle_resolved = fmt in {"markdown", "review"} if demangle is None else demangle
+
+    # --report-mode impact is sugar for "full" report with the impact table on.
+    if report_mode == "impact":
+        report_mode = "full"
+        show_impact = True
+
+    # ADR-037 D4: the precise S-axis lives in config (source.method). It sets the
+    # collection depth only when the user gave no explicit --depth/--max signal
+    # (CLI > config).
+    if resolved_cfg.source_method and depth is None and not max_depth:
+        from .buildsource.scan_levels import SourceMethod, method_to_collect_mode
+        try:
+            collect_mode = method_to_collect_mode(
+                SourceMethod(resolved_cfg.source_method)
+            )
+        except ValueError:
+            raise click.UsageError(
+                f"source.method in .abicheck.yml is invalid: "
+                f"{resolved_cfg.source_method!r} (expected s0..s6 or auto)."
+            ) from None
+
+    return _NormalizedCompareOptions(
+        collect_mode, headers, old_headers_only, new_headers_only,
+        effective_debug_format, demangle_resolved, report_mode, show_impact,
+    )
+
+
+def _needs_inline_embed(
+    old_sources: Path | None, new_sources: Path | None,
+    old_build_info: Path | None, new_build_info: Path | None,
+) -> bool:
+    """True when a side points at a raw checkout / build dir (not a `collect` pack).
+
+    Those sides get dumped inline at --depth so their L3-L5 facts ride embedded in
+    the snapshot; pre-built packs fall through to prepare_embedded_build_source.
+    """
+    def _raw_evidence(p: Path | None) -> bool:
+        return p is not None and not _source_is_pack(p)
+
+    return any(
+        _raw_evidence(p)
+        for p in (old_sources, new_sources, old_build_info, new_build_info)
+    )
+
+
+def _reject_debug_format_for_non_elf(
+    effective_debug_format: str | None,
+    old_fmt: str | None,
+    new_fmt: str | None,
+) -> None:
+    """Reject --debug-format / legacy --btf/--ctf/--dwarf for PE/Mach-O inputs.
+
+    They force an ELF debug format and are silently ignored by the PE/Mach-O dump
+    paths, so reject them up front (mirrors dump_cmd). JSON-snapshot / dump inputs
+    have ``*_fmt == None`` and are unaffected.
+    """
+    if effective_debug_format is None:
+        return
+    for side, bfmt in (("old", old_fmt), ("new", new_fmt)):
+        if bfmt in ("pe", "macho"):
+            raise click.BadParameter(
+                f"--debug-format {effective_debug_format} is only supported "
+                f"for ELF binaries, but the {side} input is {bfmt.upper()}."
+            )
+
+
+def _resolve_post_manifest_allowlist(
+    post_manifest_path: Path | None,
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+) -> set[str] | None:
+    """Resolve the --post-manifest committed public surface, or ``None``.
+
+    The manifest *is* the authoritative public surface, so this drives
+    FilterNonPublicSurface directly (no header provenance needed) — private
+    ``__pp_*`` kernel churn is demoted. Union with the binaries' committed
+    (``pp_*``) exports so a *removed* wrapper — absent from a new manifest — stays
+    in-surface instead of being silently demoted.
+    """
+    if post_manifest_path is None:
+        return None
+    from .post_manifest import contract_scope_allowlist, load_manifest
+
+    try:
+        manifest = load_manifest(post_manifest_path)
+    except (ValueError, OSError) as exc:
+        raise click.UsageError(
+            f"--post-manifest {post_manifest_path}: {exc}"
+        ) from exc
+    return contract_scope_allowlist(manifest, old, new)
+
+
+def _classify_and_reject_operands(
+    old_input: Path, new_input: Path,
+) -> tuple[str, str]:
+    """Classify both compare operands and reject an application/PIE operand.
+
+    ADR-037 D7 input-type dispatch: a directory/package operand fans out to a
+    per-library comparison; an application/PIE operand is not a library `compare`
+    can pair (hint at `appcompat`). A single .so / snapshot / dump falls through.
+    """
+    old_kind = classify_compare_operand(old_input)
+    new_kind = classify_compare_operand(new_input)
+    if old_kind == "app" or new_kind == "app":
+        _reject_application_operand(old_input, new_input, old_kind, new_kind)
+    return old_kind, new_kind
+
+
+def _resolve_debug_roots(
+    debug_roots: tuple[Path, ...],
+    debug_roots_old: tuple[Path, ...],
+    debug_roots_new: tuple[Path, ...],
+) -> tuple[list[Path], list[Path]]:
+    """Per-side debug roots: --debug-root1/2 override --debug-root for that side."""
+    resolved_old = list(debug_roots_old) if debug_roots_old else list(debug_roots)
+    resolved_new = list(debug_roots_new) if debug_roots_new else list(debug_roots)
+    return resolved_old, resolved_new
+
+
+def _warn_force_public_ignored(
+    force_public: object, scope_public_headers: bool,
+) -> None:
+    """Warn that --public-symbol overlays need --scope-public-headers to apply."""
+    if force_public and not scope_public_headers:
+        click.echo(
+            "Warning: --public-symbol/--public-symbols-list only take effect with "
+            "--scope-public-headers; ignoring the widening overlay.",
+            err=True,
+        )
 
 
 def run_compare(
@@ -130,37 +414,19 @@ def run_compare(
     # ADR-037 D4: load the project config and merge CLI flags over it
     # (precedence CLI > config > built-in default) *before* dispatch, so both the
     # single-file and the directory/package fan-out paths share one resolution.
-    # Auto-discovered from the current directory upward, overridable with --config.
-    from .buildsource.inline import load_build_config
-    from .cli_helpers_compare import discover_project_config, resolve_compare_config
-
-    cfg_path = config if config is not None else discover_project_config()
-    try:
-        project_cfg = load_build_config(cfg_path) if cfg_path is not None else None
-    except ValueError as exc:
-        raise click.UsageError(str(exc)) from exc
-
-    def _cli_flag(name: str, value: bool) -> bool | None:
-        # Return the value only when it actually came from the command line, so a
-        # flag default (e.g. --scope-public-headers's True) doesn't mask config.
-        src = click.get_current_context().get_parameter_source(name)
-        return value if src == click.core.ParameterSource.COMMANDLINE else None
-
-    resolved_cfg = resolve_compare_config(
-        project_cfg,
-        cli_severity_preset=severity_preset,
-        cli_severity_abi_breaking=severity_abi_breaking,
-        cli_severity_potential_breaking=severity_potential_breaking,
-        cli_severity_quality_issues=severity_quality_issues,
-        cli_severity_addition=severity_addition,
-        cli_scope_public=_cli_flag("scope_public_headers", scope_public_headers),
-        cli_collapse_versioned_symbols=_cli_flag(
-            "collapse_versioned_symbols", collapse_versioned_symbols
-        ),
-        cli_public_symbols=public_symbols,
-        cli_strict_suppressions=_cli_flag("strict_suppressions", strict_suppressions),
-        cli_require_justification=_cli_flag("require_justification", require_justification),
-        cli_exit_code_scheme=exit_code_scheme,
+    cfg_path, project_cfg, resolved_cfg = _resolve_compare_config(
+        config=config,
+        severity_preset=severity_preset,
+        severity_abi_breaking=severity_abi_breaking,
+        severity_potential_breaking=severity_potential_breaking,
+        severity_quality_issues=severity_quality_issues,
+        severity_addition=severity_addition,
+        scope_public_headers=scope_public_headers,
+        collapse_versioned_symbols=collapse_versioned_symbols,
+        public_symbols=public_symbols,
+        strict_suppressions=strict_suppressions,
+        require_justification=require_justification,
+        exit_code_scheme=exit_code_scheme,
     )
     sev_config = resolved_cfg.severity
     scope_public_headers = resolved_cfg.scope_public
@@ -168,47 +434,17 @@ def run_compare(
     strict_suppressions = resolved_cfg.strict_suppressions
     require_justification = resolved_cfg.require_justification
 
-    # ADR-037 D7: input-type dispatch. A directory or package operand fans out to
-    # a per-library comparison (absorbing `compare-release`); an application/PIE
-    # operand is not a library `compare` can pair (hint at `appcompat`). A single
-    # .so / snapshot / dump falls through to the normal one-pair path below. The
-    # resolved config (scope/suppression/severity) is forwarded so a set-input
-    # compare classifies the same way a single-pair one would (ADR-037 D4).
-    old_kind = classify_compare_operand(old_input)
-    new_kind = classify_compare_operand(new_input)
-    if old_kind == "app" or new_kind == "app":
-        _reject_application_operand(old_input, new_input, old_kind, new_kind)
+    # ADR-037 D7: input-type dispatch. The resolved config (scope/suppression/
+    # severity) is forwarded so a set-input compare classifies the same way a
+    # single-pair one would (ADR-037 D4).
+    old_kind, new_kind = _classify_and_reject_operands(old_input, new_input)
     if {old_kind, new_kind} & {"directory", "package"}:
         # The per-library fan-out (`compare-release` backend) consumes the
-        # resolved scheme from config, but still has no public CLI support for
-        # an explicit --exit-code-scheme on set inputs. Reject the CLI flag
-        # loudly rather than silently ignore it (ADR-037 D12).
-        if exit_code_scheme is not None:
-            raise click.UsageError(
-                "--exit-code-scheme is not supported for directory/package "
-                "(release) comparisons: the per-library fan-out uses the legacy "
-                "verdict scheme, or severity-aware when severity is configured in "
-                ".abicheck.yml. Compare libraries individually for explicit "
-                "scheme control."
-            )
-        # --reconcile-build-context (ADR-039) is not threaded through the
-        # per-library release fan-out; reject it loudly rather than silently
-        # ignore it (ADR-037 D12). It applies to single-file / snapshot inputs.
-        if reconcile_build_context:
-            raise click.UsageError(
-                "--reconcile-build-context is not supported for directory/package "
-                "(release) comparisons; it applies to single-file / snapshot "
-                "inputs. Compare the libraries individually to use it."
-            )
-        # --env-matrix (ADR-020b) is likewise not threaded through the release
-        # fan-out; a silently ignored runtime floor would leave the default
-        # RISK verdicts in place while the user believes the contract applied.
-        if env_matrix_path is not None:
-            raise click.UsageError(
-                "--env-matrix is not supported for directory/package (release) "
-                "comparisons yet; it applies to single-file / snapshot inputs. "
-                "Compare the libraries individually to use it."
-            )
+        # resolved scheme from config but has no public CLI support for these
+        # single-pair-only flags on set inputs — reject them loudly (ADR-037 D12).
+        _reject_set_input_flags(
+            exit_code_scheme, reconcile_build_context, env_matrix_path
+        )
         _reject_compile_context_for_set_inputs(ctx, project_cfg)
         _reject_evidence_flags_for_set_inputs(ctx)
         # Resolved through the ``cli`` module (not a by-name import) so a test that
@@ -253,54 +489,19 @@ def run_compare(
         jobs_explicit=jobs_explicit, dso_only=dso_only, output_dir=output_dir
     )
 
-    if annotate_additions and not annotate:
-        raise click.UsageError("--annotate-additions requires --annotate")
-
-    # Fold the unified --depth/--max dial into the internal collect mode
-    # (ADR-037 D5), the same way `dump` does. With no preset, compare reads at
-    # "off"; --depth binary suppresses the L2 header AST (symbols-only).
-    collect_mode = resolve_dump_depth(depth, max_depth, "off")
-    if depth == "binary":
-        headers, old_headers_only, new_headers_only = (), (), ()
-
-    # Reconcile the --debug-format selector with the legacy --btf/--ctf/--dwarf
-    # flags. The selector supersedes the legacy flags whenever it is given:
-    # an explicit "auto" returns to auto-detection (None) even if a legacy flag
-    # is also present; only when the selector is absent do the legacy flags apply.
-    if debug_format_opt is not None:
-        effective_debug_format = None if debug_format_opt.lower() == "auto" else debug_format_opt
-    else:
-        effective_debug_format = debug_format
-
-    # Tri-state --demangle: default ON for the text formats whose renderer
-    # post-processes symbols through demangle_text (markdown/review), OFF for
-    # machine formats (json/sarif/junit) and HTML — the HTML renderer emits
-    # symbols structurally and demangling its string would inject unescaped
-    # '<'/'>'/'&' from C++ names and corrupt the markup. Explicit flag wins.
-    if demangle is None:
-        demangle = fmt in {"markdown", "review"}
-
-    # --report-mode impact is sugar for "full" report with the impact table on.
-    if report_mode == "impact":
-        report_mode = "full"
-        show_impact = True
-
-    # ADR-037 D4: the precise S-axis lives in config (source.method). It sets the
-    # collection depth only when the user gave no explicit --depth/--max signal
-    # (CLI > config).
-    if (
-        resolved_cfg.source_method
-        and depth is None
-        and not max_depth
-    ):
-        from .buildsource.scan_levels import SourceMethod, method_to_collect_mode
-        try:
-            collect_mode = method_to_collect_mode(SourceMethod(resolved_cfg.source_method))
-        except ValueError:
-            raise click.UsageError(
-                f"source.method in .abicheck.yml is invalid: "
-                f"{resolved_cfg.source_method!r} (expected s0..s6 or auto)."
-            ) from None
+    (
+        collect_mode, headers, old_headers_only, new_headers_only,
+        effective_debug_format, demangle, report_mode, show_impact,
+    ) = _normalize_compare_options(
+        resolved_cfg,
+        depth=depth, max_depth=max_depth,
+        annotate=annotate, annotate_additions=annotate_additions,
+        headers=headers,
+        old_headers_only=old_headers_only, new_headers_only=new_headers_only,
+        debug_format_opt=debug_format_opt, debug_format=debug_format,
+        demangle=demangle, fmt=fmt,
+        report_mode=report_mode, show_impact=show_impact,
+    )
 
     # L2 header compile context (compare↔dump↔scan parity, ADR-037 D3): the one
     # shared resolver folds the project's .abicheck.yml compile: block into the CLI
@@ -345,15 +546,7 @@ def run_compare(
     # side at --depth so its L3-L5 facts ride embedded in the snapshot, the way
     # the standalone deep-compare command used to. Pre-built packs fall through
     # unchanged to prepare_embedded_build_source below.
-    def _raw_evidence(p: Path | None) -> bool:
-        return p is not None and not _source_is_pack(p)
-
-    if (
-        _raw_evidence(old_sources)
-        or _raw_evidence(new_sources)
-        or _raw_evidence(old_build_info)
-        or _raw_evidence(new_build_info)
-    ):
+    if _needs_inline_embed(old_sources, new_sources, old_build_info, new_build_info):
         import shutil
         import tempfile
 
@@ -414,17 +607,7 @@ def run_compare(
     # is honoured (pre-split resolution semantics); the name is re-exported there.
     old_input, old_fmt = cli._normalize_binary_input(old_input)
     new_input, new_fmt = cli._normalize_binary_input(new_input)
-    # --debug-format / legacy --btf/--ctf/--dwarf force an ELF debug format and
-    # are silently ignored by the PE/Mach-O dump paths. Reject them up front for
-    # non-ELF binary inputs (mirrors dump_cmd) so the flag is never accepted but
-    # ignored. JSON-snapshot / dump inputs have *_fmt == None and are unaffected.
-    if effective_debug_format is not None:
-        for side, bfmt in (("old", old_fmt), ("new", new_fmt)):
-            if bfmt in ("pe", "macho"):
-                raise click.BadParameter(
-                    f"--debug-format {effective_debug_format} is only supported "
-                    f"for ELF binaries, but the {side} input is {bfmt.upper()}."
-                )
+    _reject_debug_format_for_non_elf(effective_debug_format, old_fmt, new_fmt)
     _warn_ignored_flags(
         old_fmt is not None, new_fmt is not None,
         headers, includes,
@@ -432,9 +615,9 @@ def run_compare(
         old_includes_only, new_includes_only,
     )
 
-    # Resolve per-side debug roots: --debug-root1 overrides --debug-root for old, etc.
-    resolved_old_debug = list(debug_roots_old) if debug_roots_old else list(debug_roots)
-    resolved_new_debug = list(debug_roots_new) if debug_roots_new else list(debug_roots)
+    resolved_old_debug, resolved_new_debug = _resolve_debug_roots(
+        debug_roots, debug_roots_old, debug_roots_new
+    )
     _log_debug_resolution(
         old_input, new_input,
         resolved_old_debug, resolved_new_debug,
@@ -463,12 +646,7 @@ def run_compare(
     force_public = _collect_force_public_symbols(
         resolved_cfg.public_symbols, public_symbols_list
     )
-    if force_public and not scope_public_headers:
-        click.echo(
-            "Warning: --public-symbol/--public-symbols-list only take effect with "
-            "--scope-public-headers; ignoring the widening overlay.",
-            err=True,
-        )
+    _warn_force_public_ignored(force_public, scope_public_headers)
 
     extra_changes = _load_probe_matrix_changes(probe_matrix_old, probe_matrix_new)
 
@@ -484,21 +662,10 @@ def run_compare(
     )
 
     # --post-manifest: scope the comparison to the POST manifest's committed
-    # `pp_*`/ufunc-loop surface. The manifest *is* the authoritative public
-    # surface, so this drives FilterNonPublicSurface directly (no header
-    # provenance needed) — private __pp_* kernel churn is demoted.
-    post_manifest_allowlist: set[str] | None = None
-    if post_manifest_path is not None:
-        from .post_manifest import contract_scope_allowlist, load_manifest
-
-        try:
-            manifest = load_manifest(post_manifest_path)
-        except (ValueError, OSError) as exc:
-            raise click.UsageError(f"--post-manifest {post_manifest_path}: {exc}") from exc
-        # Union with the binaries' committed (pp_*) exports so a *removed* wrapper
-        # — absent from a new manifest — stays in-surface instead of being
-        # silently demoted (its symbol still lives in the old snapshot).
-        post_manifest_allowlist = contract_scope_allowlist(manifest, old, new)
+    # `pp_*`/ufunc-loop surface (private __pp_* kernel churn is demoted).
+    post_manifest_allowlist = _resolve_post_manifest_allowlist(
+        post_manifest_path, old, new
+    )
 
     apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on
     from .service import compare_snapshots, load_env_matrix

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -543,6 +543,115 @@ def _audit_exit_code(
     return ("API_BREAK" if exit_code >= 2 else "COMPATIBLE"), exit_code
 
 
+def _resolve_changed_seed(
+    changed_paths_opt: tuple[str, ...], since: str | None, sources: Path | None,
+) -> tuple[list[str], str, bool]:
+    """Resolve the changed-path seed → ``(changed, changed_src, seeded)``.
+
+    ``--changed-path`` wins; else ``--since`` via git; else none. ``seeded`` tracks
+    whether a *valid* seed was produced — a successful empty diff (seeded, no
+    paths) is distinct from a missing/failed seed (not seeded): the former lets
+    auto pick s0 (no-op PR), the latter falls back to the broad mode preset
+    (ADR-035 D7 / Codex review).
+    """
+    if changed_paths_opt:
+        return list(changed_paths_opt), "--changed-path", True
+    if since:
+        git_changed = _git_changed_paths(since, sources)
+        if git_changed is None:
+            return [], f"--since {since} (seed failed; broad scope)", False
+        return git_changed, f"--since {since}", True
+    return [], "none (no diff seed; broad scope)", False
+
+
+def _warn_deprecated_scan_aliases(mode_explicit: bool, sm_explicit: bool) -> None:
+    """Warn that --mode/--source-method are deprecated aliases for --depth."""
+    if not (mode_explicit or sm_explicit):
+        return
+    dep = [
+        f
+        for f, e in (("--mode", mode_explicit), ("--source-method", sm_explicit))
+        if e
+    ]
+    click.echo(
+        f"warning: {', '.join(dep)} {'is' if len(dep) == 1 else 'are'} "
+        "deprecated (ADR-037 D5); use --depth "
+        "(binary|headers|build|source|full), or omit it for auto. --audit is "
+        "the no-baseline lint switch.",
+        err=True,
+    )
+
+
+def _parse_abi3_floor(abi3: str | None) -> tuple[int, int] | None:
+    """Parse the --abi3 target ``Py_LIMITED_API`` floor, or ``None`` when off.
+
+    An invalid floor (non-3 major, implausible minor, trailing junk) is a usage
+    error.
+    """
+    if abi3 is None:
+        return None
+    from . import stable_abi
+
+    floor = stable_abi.parse_abi3_version(abi3)
+    if floor is None:
+        raise click.BadParameter(f"invalid --abi3 version: {abi3!r}")
+    return floor
+
+
+def _resolve_auto_source_method(
+    sm: SourceMethod | None,
+    dp: EvidenceDepth | None,
+    mode_explicit: bool,
+    seeded: bool,
+    risk: RiskScore,
+) -> tuple[SourceMethod | None, bool, Any]:
+    """Opt an unpinned scan into risk-driven auto (ADR-037 D5).
+
+    The unset dial means 'auto' — only when *nothing* was pinned (no --depth, no
+    --source-method, no explicit --mode). auto uses the risk score ONLY when a
+    valid diff seed was produced; a missing/failed seed falls back to the mode
+    preset so a bad-ref CI run doesn't silently drop all L3-L5 evidence.
+    """
+    if sm is None and dp is None and not mode_explicit:
+        sm = SourceMethod.AUTO
+    is_auto = sm is SourceMethod.AUTO
+    auto_method = risk.recommended_method if (is_auto and seeded) else None
+    return sm, is_auto, auto_method
+
+
+def _scan_explicit_flags(
+    source_method: str | None, depth: str | None,
+) -> tuple[bool, bool]:
+    """The two deliberately-distinct 'explicit' notions (ADR-037), as a pair.
+
+    ``level_explicit`` — consent to auto-run build.query (a non-auto
+    --source-method, or --depth ONLY when no --source-method is given).
+    ``pinned_explicit`` — the auto-strict evidence contract (an explicit --depth
+    always pins, or a non-auto --source-method). --mode is never a pin.
+    """
+    sm_pin = source_method is not None and source_method != SourceMethod.AUTO.value
+    level_explicit = sm_pin or (source_method is None and depth is not None)
+    pinned_explicit = (depth is not None) or sm_pin
+    return level_explicit, pinned_explicit
+
+
+def _emit_scan_report(outcome: ScanOutcome, fmt: str, output: Path | None) -> None:
+    """Render the scan outcome, write/echo it, and exit non-zero on a verdict."""
+    text = (
+        json.dumps(outcome.to_dict(), indent=2)
+        if fmt == "json"
+        else _render_text(outcome)
+    )
+    if output:
+        _safe_write_output(output, text)
+        click.echo(f"Report written to {output}", err=True)
+    else:
+        click.echo(text)
+
+    if outcome.exit_code != 0:
+        sys.exit(outcome.exit_code)
+
+
 @main.command("scan")
 @click.option(
     "--binary",
@@ -833,28 +942,9 @@ def scan_cmd(
     budget_s = _parse_budget(budget)
     enabled_checks, severities = _parse_crosschecks(crosschecks)
 
-    # Changed-path seed: --changed-path wins; else --since via git; else none.
-    # ``seeded`` tracks whether a *valid* seed was produced — a successful empty
-    # diff (seeded, no paths) is distinct from a missing/failed seed (not seeded):
-    # the former lets auto pick s0 (no-op PR), the latter falls back to the broad
-    # mode preset (ADR-035 D7 / Codex review).
-    seeded = False
-    if changed_paths_opt:
-        changed = list(changed_paths_opt)
-        changed_src = "--changed-path"
-        seeded = True
-    elif since:
-        git_changed = _git_changed_paths(since, sources)
-        if git_changed is None:
-            changed = []
-            changed_src = f"--since {since} (seed failed; broad scope)"
-        else:
-            changed = git_changed
-            changed_src = f"--since {since}"
-            seeded = True
-    else:
-        changed = []
-        changed_src = "none (no diff seed; broad scope)"
+    changed, changed_src, seeded = _resolve_changed_seed(
+        changed_paths_opt, since, sources
+    )
 
     risk_rules = _load_risk_rules(risk_rules_path)
     risk = score_changed_paths(changed, risk_rules)
@@ -869,31 +959,11 @@ def scan_cmd(
         _ctx.get_parameter_source("source_method")
         == click.core.ParameterSource.COMMANDLINE
     )
-    if _mode_explicit or _sm_explicit:
-        _dep = [
-            f
-            for f, e in (("--mode", _mode_explicit), ("--source-method", _sm_explicit))
-            if e
-        ]
-        click.echo(
-            f"warning: {', '.join(_dep)} {'is' if len(_dep) == 1 else 'are'} "
-            "deprecated (ADR-037 D5); use --depth "
-            "(binary|headers|build|source|full), or omit it for auto. --audit is "
-            "the no-baseline lint switch.",
-            err=True,
-        )
+    _warn_deprecated_scan_aliases(_mode_explicit, _sm_explicit)
 
     scan_mode = ScanMode.AUDIT if audit else ScanMode(mode)
-    # --abi3: parse the target Py_LIMITED_API floor for the stable-ABI audit. An
-    # invalid floor (non-3 major, implausible minor, trailing junk) is a usage
-    # error; None means the audit is off.
-    abi3_floor: tuple[int, int] | None = None
-    if abi3 is not None:
-        from . import stable_abi
-
-        abi3_floor = stable_abi.parse_abi3_version(abi3)
-        if abi3_floor is None:
-            raise click.BadParameter(f"invalid --abi3 version: {abi3!r}")
+    # --abi3: the target Py_LIMITED_API floor for the stable-ABI audit; None off.
+    abi3_floor = _parse_abi3_floor(abi3)
     sm = SourceMethod(source_method) if source_method else None
     # S2 (preprocessor macro/include capture) is collected by the conditional S2
     # tier (`preprocessor_scan.run_preprocessor_scan`) over the L3 build evidence;
@@ -905,14 +975,9 @@ def scan_cmd(
     # so a seeded PR scan escalates by risk and an unseeded one falls back to the
     # preset. Only when *nothing* was pinned (no --depth, no --source-method, no
     # explicit --mode) — a pinned rung stays deterministic.
-    if sm is None and dp is None and not _mode_explicit:
-        sm = SourceMethod.AUTO
-    is_auto = sm is SourceMethod.AUTO
-    # auto uses the risk score ONLY when a valid diff seed was produced. A seeded
-    # empty diff (no-op PR) correctly yields s0 (skip the scan); a missing/failed
-    # seed instead falls back to the mode preset, so a bad-ref / non-repo CI run
-    # does not silently drop all L3-L5 source evidence (Codex review).
-    auto_method = risk.recommended_method if (is_auto and seeded) else None
+    sm, is_auto, auto_method = _resolve_auto_source_method(
+        sm, dp, _mode_explicit, seeded, risk
+    )
     resolved, eff_depth_enum = resolve_level(
         mode=scan_mode,
         source_method=sm,
@@ -975,9 +1040,7 @@ def scan_cmd(
     #    method, not whether the user demanded source depth), or a non-auto
     #    --source-method (CodeRabbit review). --mode is a deprecated preset, never
     #    a pin.
-    _sm_pin = source_method is not None and source_method != SourceMethod.AUTO.value
-    _level_explicit = _sm_pin or (source_method is None and depth is not None)
-    _pinned_explicit = (depth is not None) or _sm_pin
+    _level_explicit, _pinned_explicit = _scan_explicit_flags(source_method, depth)
     prov_headers, prov_dirs = _public_provenance_set(
         list(headers), list(public_header_dirs)
     )
@@ -1051,20 +1114,7 @@ def scan_cmd(
 
         drain_build_dir_cleanups(build_dir_cleanups)
 
-    outcome = core.outcome
-    text = (
-        json.dumps(outcome.to_dict(), indent=2)
-        if fmt == "json"
-        else _render_text(outcome)
-    )
-    if output:
-        _safe_write_output(output, text)
-        click.echo(f"Report written to {output}", err=True)
-    else:
-        click.echo(text)
-
-    if outcome.exit_code != 0:
-        sys.exit(outcome.exit_code)
+    _emit_scan_report(core.outcome, fmt, output)
 
 
 class _BudgetOverflow(Exception):
@@ -1154,6 +1204,115 @@ def _run_abi3_audit(
     cc.coverage.append({"layer": "abi3_audit", "status": "ran", "detail": detail})
 
 
+def _build_scan_poi(
+    baseline: Path | None,
+    seeded: bool,
+    collect_mode: str,
+    binary: Path,
+    lang: str,
+    changed: list[str],
+    risk: RiskScore,
+    pattern: Any,
+) -> tuple[Any, Any]:
+    """Build the D7 points-of-interest work-list + the baseline export view used.
+
+    Returns ``(poi, poi_baseline)``. The export-delta walk needs both sides'
+    export tables, so a cheap header-free L0 view of the candidate and baseline is
+    loaded only when there is a baseline to diff against (else a wasted parse).
+    """
+    needs_export_delta_poi = (
+        baseline is not None
+        and seeded
+        and collect_mode in {"source-changed", "graph-full"}
+    )
+    poi_baseline = (
+        _load_exports_for_poi(baseline, lang) if needs_export_delta_poi else None
+    )
+    poi_candidate = (
+        _load_exports_for_poi(binary, lang) if poi_baseline is not None else None
+    )
+    poi = build_points_of_interest(
+        changed_paths=changed,
+        risk=risk,
+        pattern_triggers=pattern.escalation_triggers,
+        baseline=poi_baseline,
+        candidate=poi_candidate,
+    )
+    return poi, poi_baseline
+
+
+def _append_replay_scope_advisory(
+    advisories: list[str], seeded: bool, collect_mode: str, sources: Path | None,
+) -> None:
+    """Advise (ADR-035 P3) when an unseeded run falls back to headers-only replay.
+
+    Only when L4 replay can actually run (a --sources tree is present) does the
+    headers-only fallback apply; firing otherwise would report a replay that never
+    happened (CodeRabbit review).
+    """
+    if not seeded and collect_mode == "source-changed" and sources is not None:
+        advisories.append(
+            "no --since/--changed-path seed; the L4 replay and the L5 call-graph "
+            "pass both cover the public-API surface (headers-only) instead of a "
+            "focused diff — cost grows with the project, not the change. Pass "
+            "--since <ref> or --changed-path to scope both to the changed TUs."
+        )
+
+
+def _check_scan_evidence_contract(
+    advisories: list[str],
+    new_snap: Any,
+    collect_mode: str,
+    pinned_explicit: bool,
+    sources: Path | None,
+    effective_build_info: Path | None,
+    eff_depth_enum: EvidenceDepth,
+    resolved: SourceMethod,
+) -> None:
+    """Fail-loud on a pinned depth with no evidence; else advise on missing L3.
+
+    ADR-037 D5 (#2 auto-strict): a depth the user *explicitly pinned* with no
+    source evidence at all (no --sources/--build-info, and the trusted --config
+    build.query flow produced no L3) is a usage-contract violation → raise. When a
+    source input *was* supplied but L3 still came back empty, that stays a pointed
+    advisory naming the remedy. The implicit 'auto' default never errors here.
+    """
+    if collect_mode == "off":
+        return
+    gave_source_input = sources is not None or effective_build_info is not None
+    l3 = _l3_collected(new_snap)
+    if pinned_explicit and not gave_source_input and not l3:
+        raise _EvidenceContractError(
+            f"pinned depth '{eff_depth_enum.value}' (source-method {resolved.value}) "
+            "needs source evidence, but no --sources/--build-info was given — there "
+            "is nothing to collect L3/L4/L5 from. Pass --sources <tree> or "
+            "--build-info <dir|compile_commands.json> (or a trusted --config plus "
+            "--allow-build-query), or drop the pin / use the default 'auto' for a "
+            "best-effort binary scan. (Pinned depths are a contract.)"
+        )
+    if gave_source_input and not l3:
+        advisories.append(
+            f"requested depth '{eff_depth_enum.value}' (source-method "
+            f"{resolved.value}) needs an L3 compile database, but none was found — "
+            "L3/L4/L5 were skipped. Provide one with --build-info/--compile-db (a "
+            "compile_commands.json or build dir), or a trusted --config plus "
+            "--allow-build-query to generate it."
+        )
+
+
+def _check_scan_budget(
+    budget: str | None, budget_s: float | None, elapsed: float,
+) -> None:
+    """Budget overflow FAILS, never shrinks scope (ADR-035 D3)."""
+    if budget_s is not None and elapsed > budget_s:
+        raise _BudgetOverflow(
+            f"error: --budget {budget} exceeded "
+            f"({elapsed:.1f}s > {budget_s:.0f}s). "
+            "Pin a shallower level or raise the budget; a budget never silently "
+            "shrinks the pinned scope."
+        )
+
+
 def run_scan_core(
     *,
     start: float,
@@ -1222,22 +1381,9 @@ def run_scan_core(
     # once, below, with the resulting focus seed. The candidate view is only
     # loaded when there is a baseline to diff it against — the delta walk consumes
     # the two together, so loading it baseline-less would be a wasted L0/L1 parse.
-    needs_export_delta_poi = (
-        baseline is not None
-        and seeded
-        and collect_mode in {"source-changed", "graph-full"}
-    )
     _stage = time.monotonic()
-    poi_baseline = _load_exports_for_poi(baseline, lang) if needs_export_delta_poi else None
-    poi_candidate = (
-        _load_exports_for_poi(binary, lang) if poi_baseline is not None else None
-    )
-    poi = build_points_of_interest(
-        changed_paths=changed,
-        risk=risk,
-        pattern_triggers=pattern.escalation_triggers,
-        baseline=poi_baseline,
-        candidate=poi_candidate,
+    poi, poi_baseline = _build_scan_poi(
+        baseline, seeded, collect_mode, binary, lang, changed, risk, pattern
     )
     _record_stage("poi", _stage)
 
@@ -1264,18 +1410,7 @@ def run_scan_core(
     # "no auto-warn"). Carried on the result (text + JSON) so it never pollutes a
     # structured-format stdout.
     advisories: list[str] = []
-    # Only when L4 replay can actually run (a --sources tree is present —
-    # `_run_inline_source_abi` returns early without one, and `--build-info`
-    # alone yields L3 but no replay) does the headers-only fallback apply; firing
-    # the advisory otherwise would report a replay that never happened
-    # (CodeRabbit review).
-    if not seeded and collect_mode == "source-changed" and sources is not None:
-        advisories.append(
-            "no --since/--changed-path seed; the L4 replay and the L5 call-graph "
-            "pass both cover the public-API surface (headers-only) instead of a "
-            "focused diff — cost grows with the project, not the change. Pass "
-            "--since <ref> or --changed-path to scope both to the changed TUs."
-        )
+    _append_replay_scope_advisory(advisories, seeded, collect_mode, sources)
     effective_allow_query, _query_advisory = resolve_effective_allow_query(
         allow_build_query, build_config, collect_mode, level_explicit, resolved
     )
@@ -1308,39 +1443,10 @@ def run_scan_core(
     # --- level-vs-evidence: fail-loud on missing input, advise otherwise ------
     # A deep depth (build/source/full → collect_mode != "off") needs an L3 compile
     # database; without one the L3/L4/L5 layers cannot be collected.
-    #
-    # ADR-037 D5 (#2 auto-strict): a depth the user *explicitly pinned* is a
-    # contract. If it was pinned with **no source evidence at all** — no
-    # --sources / --build-info, and the trusted --config build.query flow didn't
-    # produce L3 either — there is nothing to collect from, so we ERROR with the
-    # remedy rather than silently produce a shallow binary-only scan. When a
-    # source input *was* supplied (or L3 was actually collected via the config
-    # query) but L3 still came back empty, that stays a pointed *advisory* naming
-    # the remedy, not a hard error. The implicit 'auto' default never errors here.
-    gave_source_input = sources is not None or effective_build_info is not None
-    needs_source = collect_mode != "off"
-    if (
-        needs_source
-        and pinned_explicit
-        and not gave_source_input
-        and not _l3_collected(new_snap)
-    ):
-        raise _EvidenceContractError(
-            f"pinned depth '{eff_depth_enum.value}' (source-method {resolved.value}) "
-            "needs source evidence, but no --sources/--build-info was given — there "
-            "is nothing to collect L3/L4/L5 from. Pass --sources <tree> or "
-            "--build-info <dir|compile_commands.json> (or a trusted --config plus "
-            "--allow-build-query), or drop the pin / use the default 'auto' for a "
-            "best-effort binary scan. (Pinned depths are a contract.)"
-        )
-    if needs_source and gave_source_input and not _l3_collected(new_snap):
-        advisories.append(
-            f"requested depth '{eff_depth_enum.value}' (source-method "
-            f"{resolved.value}) needs an L3 compile database, but none was found — "
-            "L3/L4/L5 were skipped. Provide one with --build-info/--compile-db (a "
-            "compile_commands.json or build dir), or a trusted --config plus "
-            "--allow-build-query to generate it."
-        )
+    _check_scan_evidence_contract(
+        advisories, new_snap, collect_mode, pinned_explicit,
+        sources, effective_build_info, eff_depth_enum, resolved,
+    )
 
     # --- conditional tier: S2 preprocessor pre-scan (D2) ----------------------
     # Runs only when L3 build evidence + a preprocessor (`clang -E`) are present;
@@ -1422,15 +1528,7 @@ def run_scan_core(
         verdict, exit_code = _audit_exit_code(cc.findings, severities)
 
     elapsed = time.monotonic() - start
-
-    # --- budget guard: overflow FAILS, never shrinks scope (ADR-035 D3) -------
-    if budget_s is not None and elapsed > budget_s:
-        raise _BudgetOverflow(
-            f"error: --budget {budget} exceeded "
-            f"({elapsed:.1f}s > {budget_s:.0f}s). "
-            "Pin a shallower level or raise the budget; a budget never silently "
-            "shrinks the pinned scope."
-        )
+    _check_scan_budget(budget, budget_s, elapsed)
 
     outcome = ScanOutcome(
         mode=scan_mode.value,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -63,6 +63,7 @@ from .dumper_clang import _ClangAstParser as _ClangAstParser
 from .dumper_clang_errors import (
     _is_direct_include_guard_failure,
     _is_missing_cpp_stdlib_header_error,
+    _parse_clang_ast_result,
     diagnose_header_compile_failure,
     retry_excluding_error_headers,
 )
@@ -212,6 +213,73 @@ def _build_clang_header_command(
     return cmd
 
 
+def _resolve_clang_bin(
+    compiler: str, gcc_path: str | None, gcc_prefix: str | None,
+) -> str:
+    """Resolve the clang executable to run, raising if it is not on ``PATH``.
+
+    ``--gcc-path`` is honored only when it points at a clang (castxml emulates a
+    GCC/G++ binary, which can't take clang-only flags); ``--gcc-prefix`` maps to
+    the prefixed clang driver.
+    """
+    clang_bin: str | None = None
+    if gcc_path and "clang" in Path(gcc_path).name.lower():
+        clang_bin = gcc_path
+    elif gcc_prefix:
+        clang_bin = (
+            f"{gcc_prefix}clang++"
+            if compiler in ("c++", "g++", "clang++")
+            else f"{gcc_prefix}clang"
+        )
+    if not clang_bin:
+        clang_bin = "clang++" if compiler in ("c++", "g++", "clang++") else "clang"
+    if not _clang_available(clang_bin):
+        raise SnapshotError(
+            f"{clang_bin} not found in PATH. The clang header backend needs clang/clang++ "
+            "installed (apt install clang, brew install llvm, or conda install -c conda-forge "
+            "clang). Or use the castxml frontend (--ast-frontend castxml)."
+        )
+    return clang_bin
+
+
+def _resolve_clang_langmode(
+    lang: str | None, headers: list[Path], clang_bin: str,
+) -> tuple[bool, bool, bool, str]:
+    """Return ``(force_cpp, force_cpp20, explicit_c_request, cc_id)`` for the TU.
+
+    ``explicit_c_request`` records whether C was *explicitly* requested
+    (``--lang c``) vs auto-detected — both leave ``force_cpp`` False, but the
+    C→C++ self-heal treats them differently (warning vs debug; Codex review).
+    """
+    force_cpp = bool(lang and lang.upper() in ("C++", "CPP"))
+    if not lang:
+        force_cpp = _detect_cpp_headers(headers)
+    force_cpp20 = force_cpp and _detect_cpp20_headers(headers)
+    explicit_c_request = bool(lang) and not force_cpp
+    cc_id = "msvc" if Path(clang_bin).name.lower() in ("cl", "cl.exe") else "gnu"
+    return force_cpp, force_cpp20, explicit_c_request, cc_id
+
+
+def _log_c_to_cpp_selfheal(explicit_c_request: bool) -> None:
+    """Log the C→C++ self-heal at the right level for how C was chosen."""
+    if explicit_c_request:
+        # Explicit --lang c that needs the C++ stdlib: keep the self-heal visible
+        # — the result is C++ ABI evidence, not the C requested (Codex review).
+        log.warning(
+            "clang was asked for C (--lang c) but the header(s) require the "
+            "C++ standard library; self-healing to C++ mode. The result is "
+            "C++ ABI evidence — pass --lang c++ to make this explicit, or "
+            "verify you intended a C library."
+        )
+    else:
+        log.debug(
+            "clang auto-detected C for a pure-#include umbrella header (no "
+            "inline C++ syntax to key on), then self-healed to C++ after a "
+            "missing C++ standard header — an unambiguous C++ signal. The "
+            "result is unaffected; pass --lang c++ to skip the initial C probe."
+        )
+
+
 def _clang_header_dump(
     headers: list[Path],
     extra_includes: list[Path],
@@ -235,47 +303,15 @@ def _clang_header_dump(
     the castxml path. Raises :class:`SnapshotError` when clang is missing, times
     out, or emits no usable AST.
     """
-    # Resolve the clang executable. ``--gcc-path`` is, by its name, a GCC/G++
-    # binary that castxml emulates — running *that* with clang-only
-    # ``-Xclang -ast-dump=json`` flags would fail, so only honor it here when it
-    # actually points at a clang (e.g. a user passing an explicit clang path).
-    # A cross ``--gcc-prefix`` maps to the prefixed clang driver.
-    clang_bin: str | None = None
-    if gcc_path and "clang" in Path(gcc_path).name.lower():
-        clang_bin = gcc_path
-    elif gcc_prefix:
-        clang_bin = (
-            f"{gcc_prefix}clang++"
-            if compiler in ("c++", "g++", "clang++")
-            else f"{gcc_prefix}clang"
-        )
-    if not clang_bin:
-        clang_bin = "clang++" if compiler in ("c++", "g++", "clang++") else "clang"
-    if not _clang_available(clang_bin):
-        raise SnapshotError(
-            f"{clang_bin} not found in PATH. The clang header backend needs clang/clang++ "
-            "installed (apt install clang, brew install llvm, or conda install -c conda-forge "
-            "clang). Or use the castxml frontend (--ast-frontend castxml)."
-        )
+    clang_bin = _resolve_clang_bin(compiler, gcc_path, gcc_prefix)
+    force_cpp, force_cpp20, explicit_c_request, cc_id = _resolve_clang_langmode(
+        lang, headers, clang_bin,
+    )
 
-    force_cpp = bool(lang and lang.upper() in ("C++", "CPP"))
-    if not lang:
-        force_cpp = _detect_cpp_headers(headers)
-    force_cpp20 = force_cpp and _detect_cpp20_headers(headers)
-    # Was C *explicitly* requested (``--lang c``), as opposed to auto-detected?
-    # Both leave ``force_cpp`` False, but the C→C++ self-heal below must treat
-    # them differently: an explicit C request that reparses as C++ overrides what
-    # the user asked for, so it stays a visible warning; the auto-detected probe
-    # self-healing is just noise and is demoted to debug (Codex review).
-    explicit_c_request = bool(lang) and not force_cpp
-    cc_id = "msvc" if Path(clang_bin).name.lower() in ("cl", "cl.exe") else "gnu"
-
-    # castxml↔clang parity: probe the host GNU compiler for its system include
-    # dirs and inject them as ``-isystem`` so clang resolves libstdc++/libc the
-    # way castxml does via ``--castxml-cc-gnu``. Folded into the cache key so a
-    # toolchain change invalidates a stale dump.
+    # castxml↔clang parity: probe the host GNU compiler for its ``-isystem`` dirs
+    # so clang resolves libstdc++/libc the way castxml does via ``--castxml-cc-gnu``.
+    # Folded into the cache key so a toolchain change invalidates a stale dump.
     def _resolve_sysinc(*, force_cpp: bool) -> tuple[str, ...]:
-        """Probe the host GNU driver's ``-isystem`` dirs for the given language."""
         return _resolve_clang_system_includes(
             compiler,
             gcc_path=gcc_path,
@@ -288,14 +324,11 @@ def _clang_header_dump(
         )
 
     system_includes = _resolve_sysinc(force_cpp=force_cpp)
-    # Pre-resolve the C++ system include set so it (a) folds into the cache key —
-    # the C→C++ retry below parses with these, and the C-mode probe omits the
-    # versioned libstdc++ dirs, so without this a libstdc++/GCC upgrade would not
-    # change the key and abicheck would reuse a stale C++ AST (Codex review); and
-    # (b) is reused by the retry without a second probe. This means a C-mode dump
-    # pays one extra ``g++ -E -v`` probe even when it never retries — accepted as
-    # the cost of a retry-stable cache key (a lazy resolve would reopen the
-    # staleness window). The probe is fast and the clang backend is opt-in.
+    # Pre-resolve the C++ system include set so it folds into the cache key (the
+    # C-mode probe omits the versioned libstdc++ dirs, so without this a
+    # libstdc++/GCC upgrade would not change the key and reuse a stale C++ AST —
+    # Codex review) and is reused by the C→C++ retry without a second probe. Costs
+    # a C-mode dump one extra ``g++ -E -v`` probe — the price of a retry-stable key.
     cpp_system_includes = (
         system_includes if force_cpp else _resolve_sysinc(force_cpp=True)
     )
@@ -333,7 +366,6 @@ def _clang_header_dump(
     _write_agg(active_headers)
 
     def _run_clang(fcpp: bool, fcpp20: bool, sysinc: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
-        """Build and run the clang AST-dump command for the given language mode."""
         cmd = _build_clang_header_command(
             clang_bin, cc_id, extra_includes, agg_path,
             sysroot=sysroot, nostdinc=nostdinc, gcc_options=gcc_options,
@@ -352,36 +384,16 @@ def _clang_header_dump(
     try:
         result = _run_clang(force_cpp, force_cpp20, system_includes)
         # C→C++ self-heal: a pure-``#include`` umbrella header (e.g. oneTBB's
-        # ``oneapi/tbb.h``) carries no inline C++ syntax, so ``_detect_cpp_headers``
-        # picks C mode — then ``#include <cstddef>`` fails because the C-mode probe
-        # never injected the libstdc++ ``-isystem`` dirs. A missing C++ *standard*
-        # header is an unambiguous "this is C++" signal (a C TU never includes one),
-        # so retry once in C++ mode with the pre-resolved C++ system includes.
-        # Mirrors the castxml C→C++ retry; skipped when already in C++ mode or the
-        # failure is anything other than a missing C++ stdlib header.
+        # ``oneapi/tbb.h``) picks C mode, then ``#include <cstddef>`` fails — a
+        # missing C++ *standard* header is an unambiguous "this is C++" signal, so
+        # retry once in C++ mode with the pre-resolved C++ system includes. Skipped
+        # when already C++ or the failure is anything but a missing C++ stdlib header.
         if (
             result.returncode != 0
             and not force_cpp
             and _is_missing_cpp_stdlib_header_error(result.stderr or "")
         ):
-            if explicit_c_request:
-                # The user asked for C, but the header needs the C++ standard
-                # library — self-heal to C++ so the dump still succeeds, but keep
-                # it visible: the result is C++ ABI evidence, not the C the
-                # request implied (Codex review).
-                log.warning(
-                    "clang was asked for C (--lang c) but the header(s) require the "
-                    "C++ standard library; self-healing to C++ mode. The result is "
-                    "C++ ABI evidence — pass --lang c++ to make this explicit, or "
-                    "verify you intended a C library."
-                )
-            else:
-                log.debug(
-                    "clang auto-detected C for a pure-#include umbrella header (no "
-                    "inline C++ syntax to key on), then self-healed to C++ after a "
-                    "missing C++ standard header — an unambiguous C++ signal. The "
-                    "result is unaffected; pass --lang c++ to skip the initial C probe."
-                )
+            _log_c_to_cpp_selfheal(explicit_c_request)
             cur_fcpp, cur_fcpp20, cur_sysinc = (
                 True, _detect_cpp20_headers(headers), cpp_system_includes,
             )
@@ -400,34 +412,7 @@ def _clang_header_dump(
             agg_path=agg_path,
             active_headers=active_headers,
         )
-        # A nonzero exit means clang hit a hard parse error. Unlike L4 source
-        # replay (which tolerates partial coverage), the L2 header AST must be
-        # complete to be authoritative — a truncated declaration set would
-        # manifest as false removals/additions. So fail like the castxml path
-        # rather than caching a partial tree (Codex review). ``-ferror-limit=0``
-        # only suppresses the error *cap*; genuine errors still set the exit code.
-        if result.returncode != 0:
-            raise SnapshotError(
-                f"clang failed to parse the header(s) (exit {result.returncode}). The "
-                "header may be malformed or need build flags it was not given (try "
-                f"--gcc-options / -p, or --ast-frontend castxml):\n"
-                f"{result.stderr[:1000].strip()}"
-                f"{diagnose_header_compile_failure(result.stderr) or ''}"
-            )
-        if not result.stdout.strip():
-            raise SnapshotError(
-                f"clang produced no AST for the header(s) (exit {result.returncode}): "
-                f"{result.stderr[:1000].strip()}"
-            )
-        try:
-            root = json.loads(result.stdout)
-        except ValueError as exc:
-            raise SnapshotError(f"clang AST output was not valid JSON: {exc}") from exc
-        try:
-            cached.write_text(json.dumps(root), encoding="utf-8")
-        except OSError:
-            pass
-        return cast("dict[str, Any]", root)
+        return _parse_clang_ast_result(result, cached)
     finally:
         agg_path.unlink(missing_ok=True)
 

--- a/abicheck/dumper_clang_errors.py
+++ b/abicheck/dumper_clang_errors.py
@@ -25,11 +25,14 @@ stays under the file-size cap; the parsers are unit-tested without a compiler.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
+
+from .errors import SnapshotError
 
 if TYPE_CHECKING:
     import subprocess
@@ -451,3 +454,36 @@ def retry_excluding_error_headers(
             ", ".join(p.name for p in excluded),
         )
     return result
+
+
+def _parse_clang_ast_result(
+    result: subprocess.CompletedProcess[str], cached: Path,
+) -> dict[str, Any]:
+    """Validate a completed clang AST-dump, parse its JSON, and cache the tree.
+
+    A nonzero exit is a hard parse error: the L2 header AST must be complete to be
+    authoritative (a truncated set → false removals/additions), so fail like the
+    castxml path rather than cache a partial tree (Codex review).
+    """
+    if result.returncode != 0:
+        raise SnapshotError(
+            f"clang failed to parse the header(s) (exit {result.returncode}). The "
+            "header may be malformed or need build flags it was not given (try "
+            f"--gcc-options / -p, or --ast-frontend castxml):\n"
+            f"{result.stderr[:1000].strip()}"
+            f"{diagnose_header_compile_failure(result.stderr) or ''}"
+        )
+    if not result.stdout.strip():
+        raise SnapshotError(
+            f"clang produced no AST for the header(s) (exit {result.returncode}): "
+            f"{result.stderr[:1000].strip()}"
+        )
+    try:
+        root = json.loads(result.stdout)
+    except ValueError as exc:
+        raise SnapshotError(f"clang AST output was not valid JSON: {exc}") from exc
+    try:
+        cached.write_text(json.dumps(root), encoding="utf-8")
+    except OSError:
+        pass
+    return cast("dict[str, Any]", root)

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -765,6 +765,28 @@ std::string mangledFromJson(const Object &o) {
   return "";
 }
 
+// Skip Itanium CV-qualifier / ref-qualifier prefixes (`r`/`V`/`K`/`O`) that may
+// follow a nested-name `N`, returning the index of the first non-qualifier char.
+size_t skipItaniumCvQualifiers(const std::string &m, size_t i, size_t n) {
+  while (i < n && (m[i] == 'r' || m[i] == 'V' || m[i] == 'K' || m[i] == 'O'))
+    ++i;
+  return i;
+}
+
+// Advance past a `<length><source-name>` component whose first digit is at `i`,
+// returning the index just past the name, or `std::string::npos` when the length
+// prefix overruns the remaining string (an exotic/truncated production → bail).
+size_t advancePastLengthComponent(const std::string &m, size_t i, size_t n) {
+  size_t j = i, length = 0;
+  while (j < n && m[j] >= '0' && m[j] <= '9') {
+    length = length * 10 + static_cast<size_t>(m[j] - '0');
+    ++j;
+    if (length > n - j)
+      return std::string::npos;
+  }
+  return j + length;
+}
+
 // Port of clang.py::_mangled_has_internal_linkage: true when an Itanium mangled
 // name marks internal linkage (its own <source-name> is prefixed with the
 // GCC/clang seniority marker `L`, e.g. `_ZN2nsL7g_constE`, `_ZL1xE`). Parses by
@@ -782,8 +804,7 @@ bool mangledHasInternalLinkage(const std::string &m) {
   size_t i = 2, n = m.size();
   if (i < n && m[i] == 'N') {
     ++i;
-    while (i < n && (m[i] == 'r' || m[i] == 'V' || m[i] == 'K' || m[i] == 'O'))
-      ++i;
+    i = skipItaniumCvQualifiers(m, i, n);
   }
   while (i < n) {
     char c = m[i];
@@ -792,14 +813,10 @@ bool mangledHasInternalLinkage(const std::string &m) {
     if (c == 'L')
       return i + 1 < n && m[i + 1] >= '0' && m[i + 1] <= '9';
     if (c >= '0' && c <= '9') {
-      size_t j = i, length = 0;
-      while (j < n && m[j] >= '0' && m[j] <= '9') {
-        length = length * 10 + static_cast<size_t>(m[j] - '0');
-        ++j;
-        if (length > n - j)
-          return false;
-      }
-      i = j + length;
+      size_t next = advancePastLengthComponent(m, i, n);
+      if (next == std::string::npos)
+        return false;
+      i = next;
       continue;
     }
     return false;
@@ -919,36 +936,46 @@ private:
     if (c == '"') {
       scanString();
     } else if (c == '{' || c == '[') {
-      char open = c, close = (c == '{') ? '}' : ']';
-      int depth = 0;
-      while (I < S.size()) {
-        char d = S[I];
-        if (d == '"') {
-          scanString();
-          continue;
-        }
-        if (d == open)
-          ++depth;
-        else if (d == close) {
-          --depth;
-          if (depth == 0) {
-            ++I;
-            break;
-          }
-        }
-        ++I;
-      }
+      scanBalanced();
     } else {
-      // scalar: number / true / false / null — up to a delimiter
-      while (I < S.size()) {
-        char d = S[I];
-        if (d == ',' || d == '}' || d == ']' || d == ' ' || d == '\t' ||
-            d == '\n' || d == '\r')
-          break;
-        ++I;
-      }
+      scanScalar();
     }
     return S.substr(start, I - start);
+  }
+
+  // At '{' or '[': consume through the matching close, honoring string escapes so
+  // a brace/bracket inside a string never shifts the nesting depth.
+  void scanBalanced() {
+    char open = S[I], close = (open == '{') ? '}' : ']';
+    int depth = 0;
+    while (I < S.size()) {
+      char d = S[I];
+      if (d == '"') {
+        scanString();
+        continue;
+      }
+      if (d == open)
+        ++depth;
+      else if (d == close) {
+        --depth;
+        if (depth == 0) {
+          ++I;
+          break;
+        }
+      }
+      ++I;
+    }
+  }
+
+  // Scalar: number / true / false / null — consumed up to a delimiter.
+  void scanScalar() {
+    while (I < S.size()) {
+      char d = S[I];
+      if (d == ',' || d == '}' || d == ']' || d == ' ' || d == '\t' ||
+          d == '\n' || d == '\r')
+        break;
+      ++I;
+    }
   }
 
   void scanString() {
@@ -1033,50 +1060,57 @@ private:
     return S.substr(start, I - start);
   }
 
+  // The `inner` child array of an AST node: parse each object element as a full
+  // node (keeping the pruned key set), skipping non-object elements. `recurseInner`
+  // false (shallow `type`/`referencedDecl` objects) skips the whole value.
+  void storeInnerMember(Object &out, bool recurseInner) {
+    if (!recurseInner) {
+      captureValue(); // shallow objects never recurse into inner
+      return;
+    }
+    skipWs();
+    if (I >= S.size() || S[I] != '[') {
+      captureValue();
+      return;
+    }
+    Array arr;
+    ++I; // consume '['
+    skipWs();
+    if (I < S.size() && S[I] == ']') {
+      ++I;
+      out["inner"] = Value(std::move(arr));
+      return;
+    }
+    while (I < S.size()) {
+      skipWs();
+      if (S[I] == '{') {
+        if (auto node = parseNode())
+          arr.push_back(std::move(*node));
+        else if (Failed)
+          return;
+      } else {
+        captureValue(); // non-object array element: irrelevant, skip
+      }
+      skipWs();
+      if (I < S.size() && S[I] == ',') {
+        ++I;
+        continue;
+      }
+      if (I < S.size() && S[I] == ']') {
+        ++I;
+        break;
+      }
+      Failed = true;
+      return;
+    }
+    out["inner"] = Value(std::move(arr));
+  }
+
   void storeMember(Object &out, const std::string &key, bool recurseInner,
                    bool shallowScalarsOnly) {
     // Keys read as recursive structure.
     if (key == "inner") {
-      if (!recurseInner) {
-        captureValue(); // shallow objects never recurse into inner
-        return;
-      }
-      skipWs();
-      if (I >= S.size() || S[I] != '[') {
-        captureValue();
-        return;
-      }
-      Array arr;
-      ++I; // consume '['
-      skipWs();
-      if (I < S.size() && S[I] == ']') {
-        ++I;
-        out["inner"] = Value(std::move(arr));
-        return;
-      }
-      while (I < S.size()) {
-        skipWs();
-        if (S[I] == '{') {
-          if (auto node = parseNode())
-            arr.push_back(std::move(*node));
-          else if (Failed)
-            return;
-        } else {
-          captureValue(); // non-object array element: irrelevant, skip
-        }
-        skipWs();
-        if (I < S.size() && S[I] == ',') {
-          ++I;
-          continue;
-        }
-        if (I < S.size() && S[I] == ']') {
-          ++I;
-          break;
-        }
-        Failed = true;
-        return;
-      }
-      out["inner"] = Value(std::move(arr));
+      storeInnerMember(out, recurseInner);
       return;
     }
     // Shallow objects: `type` and `referencedDecl` — keep only their scalars.
@@ -1767,53 +1801,77 @@ public:
     return true;
   }
 
-  bool VisitVarDecl(VarDecl *vd) {
-    if (vd->isImplicit() || isa<ParmVarDecl>(vd))
+  // A block-scope `constexpr` inside a public inline/header function body IS
+  // emitted (not skipped on getParentFunctionOrMethod): the clang backend descends
+  // accessible function bodies and emits such locals as `constexpr` entities just
+  // like it emits body-local types, so the plugin matches it (Codex review).
+  // scopedName() omits the function scope, so a local `k` in `demo::f()` is named
+  // `demo::k` exactly as the backend names it. Local constexpr are syntactic
+  // (present in the AST regardless of codegen), so there is no capture-point
+  // asymmetry here. Returns the VisitVarDecl continue-traversal verdict (true).
+  bool emitConstexprVar(VarDecl *vd) {
+    std::string file, origin, visibility;
+    if (!classify(vd, file, origin, visibility))
       return true;
-    if (!isAccessible(vd) || vd->getNameAsString().empty())
-      return true;
-    if (vd->isConstexpr()) {
-      // Block-scope `constexpr` inside a public inline/header function body IS
-      // emitted (not skipped on getParentFunctionOrMethod): the clang backend
-      // descends accessible function bodies and emits such locals as `constexpr`
-      // entities just like it emits body-local types, so the plugin matches it
-      // (Codex review). scopedName() omits the function scope, so a local `k` in
-      // `demo::f()` is named `demo::k` exactly as the backend names it. Local
-      // constexpr are syntactic (present in the AST regardless of codegen), so
-      // there is no capture-point asymmetry here.
-      std::string file, origin, visibility;
-      if (!classify(vd, file, origin, visibility))
-        return true;
-      std::optional<Value> json = dumpDeclJson(vd);
-      if (!json || !json->getAsObject()) {
-        Diags.insert("constexpr value unavailable (JSON dump failed)");
-        return true;
-      }
-      const Object &o = *json->getAsObject();
-      const Value *init = initExprJson(o);
-      std::string value = init ? exprValueJson(*init) : subtreeHash(*json, {});
-      std::string name = scopedName(vd);
-      Entity e;
-      e.id = H({"constexpr", name, value});
-      e.kind = "constexpr";
-      e.qualified_name = name;
-      e.mangled_name = mangledFromJson(o);
-      e.value = value;
-      e.loc_path = file;
-      e.loc_line = presumedLine(vd);
-      e.loc_origin = origin;
-      e.visibility = visibility;
-      stampDeclEvidence(e, vd);
-      ConstexprValues.push_back(e);
+    std::optional<Value> json = dumpDeclJson(vd);
+    if (!json || !json->getAsObject()) {
+      Diags.insert("constexpr value unavailable (JSON dump failed)");
       return true;
     }
-    // Non-constexpr external-linkage data variables / static data members —
-    // these become exported OBJECT symbols so capturing them lets a binary data
-    // export map to a source decl (ADR-030 D4). Mirrors clang.py's
-    // `_is_variable_node`/`_emit_variable`: skip function-local vars and variable
-    // templates (the clang backend never walks into those); internal-linkage
-    // variables (a namespace/file-scope `static` OR a namespace-scope `const`
-    // without `extern`) are dropped below by their mangled-name marker.
+    const Object &o = *json->getAsObject();
+    const Value *init = initExprJson(o);
+    std::string value = init ? exprValueJson(*init) : subtreeHash(*json, {});
+    std::string name = scopedName(vd);
+    Entity e;
+    e.id = H({"constexpr", name, value});
+    e.kind = "constexpr";
+    e.qualified_name = name;
+    e.mangled_name = mangledFromJson(o);
+    e.value = value;
+    e.loc_path = file;
+    e.loc_line = presumedLine(vd);
+    e.loc_origin = origin;
+    e.visibility = visibility;
+    stampDeclEvidence(e, vd);
+    ConstexprValues.push_back(e);
+    return true;
+  }
+
+  // Internal-linkage data variables that must NOT be emitted as exportable decls:
+  //  - clang's own linkage verdict, encoded as the Itanium `L` seniority marker /
+  //    `_GLOBAL__N_` component (header `const`/file-`static`/anon-namespace var);
+  //  - a C / extern "C" file-scope static, which carries no mangled name for the
+  //    marker, so filter on storageClass (a static data member — lexical parent a
+  //    record — is external, so kept);
+  //  - MSVC / clang-cl mangling (`?name@...`) has no Itanium marker, so a
+  //    namespace-scope top-level `const` without `extern` (internal in C++) is
+  //    caught by the type-based `_is_top_level_const` rule (Codex review). A
+  //    C++17 `inline const` at namespace scope is externally linked (the
+  //    `inline` keyword overrides const's internal linkage), so it is exempt from
+  //    the top-level-const drop and kept (Codex review).
+  bool isDroppedInternalVariable(VarDecl *vd, const std::string &mangled,
+                                 const std::string &sig, const Object &o) {
+    if (mangledHasInternalLinkage(mangled))
+      return true;
+    if (vd->getStorageClass() == SC_Static &&
+        !isa<CXXRecordDecl>(vd->getLexicalDeclContext()))
+      return true;
+    if (mangled.rfind("?", 0) == 0 && vd->getStorageClass() != SC_Extern &&
+        !vd->isInline() &&
+        !isa<CXXRecordDecl>(vd->getLexicalDeclContext()) &&
+        (isTopLevelConst(sig) ||
+         isTopLevelConst(desugaredQualTypeFromJson(o))))
+      return true;
+    return false;
+  }
+
+  // Non-constexpr external-linkage data variables / static data members — these
+  // become exported OBJECT symbols so capturing them lets a binary data export map
+  // to a source decl (ADR-030 D4). Mirrors clang.py's `_is_variable_node`/
+  // `_emit_variable`: skip function-local vars and variable templates (the clang
+  // backend never walks into those); internal-linkage variables are dropped by
+  // isDroppedInternalVariable. Returns the continue-traversal verdict (true).
+  bool emitDataVariable(VarDecl *vd) {
     if (vd->isLocalVarDecl() || vd->getDescribedVarTemplate() ||
         isa<VarTemplateSpecializationDecl>(vd))
       return true;
@@ -1829,30 +1887,7 @@ public:
     std::string name = scopedName(vd);
     std::string sig = qualTypeFromJson(o);
     std::string mangled = mangledFromJson(o);
-    // Drop internal-linkage variables (clang's own linkage verdict, encoded as
-    // the Itanium `L` seniority marker / `_GLOBAL__N_` component) so a header
-    // `const`/file-`static`/anon-namespace var never shows up as a decl expected
-    // to map to an export (Codex review).
-    if (mangledHasInternalLinkage(mangled))
-      return true;
-    // C / extern "C" file-scope static: clang gives no mangled name to carry the
-    // marker, so filter on storageClass directly. A static data member is
-    // external (its lexical parent is a record), so keep it.
-    if (vd->getStorageClass() == SC_Static &&
-        !isa<CXXRecordDecl>(vd->getLexicalDeclContext()))
-      return true;
-    // MSVC / clang-cl mangling (`?name@...`) carries no Itanium internal-linkage
-    // marker, so a namespace-scope top-level `const` without `extern` (internal
-    // in C++) would slip through. Fall back to the type-based language rule
-    // (Codex review); mirrors clang.py's `_is_top_level_const` branch.
-    // A C++17 `inline const` at namespace scope is externally linked (the
-    // `inline` keyword overrides const's internal linkage), so it must be kept —
-    // exempt it from the top-level-const drop (Codex review).
-    if (mangled.rfind("?", 0) == 0 && vd->getStorageClass() != SC_Extern &&
-        !vd->isInline() &&
-        !isa<CXXRecordDecl>(vd->getLexicalDeclContext()) &&
-        (isTopLevelConst(sig) ||
-         isTopLevelConst(desugaredQualTypeFromJson(o))))
+    if (isDroppedInternalVariable(vd, mangled, sig, o))
       return true;
     std::string key = mangled.empty() ? name : mangled;
     Entity e;
@@ -1868,6 +1903,16 @@ public:
     stampDeclEvidence(e, vd);
     Variables.push_back(e);
     return true;
+  }
+
+  bool VisitVarDecl(VarDecl *vd) {
+    if (vd->isImplicit() || isa<ParmVarDecl>(vd))
+      return true;
+    if (!isAccessible(vd) || vd->getNameAsString().empty())
+      return true;
+    if (vd->isConstexpr())
+      return emitConstexprVar(vd);
+    return emitDataVariable(vd);
   }
 
   // Emit the template entity and STOP descending — matching clang.py, which

--- a/tests/test_baseline_pinning.py
+++ b/tests/test_baseline_pinning.py
@@ -122,7 +122,7 @@ class TestStampProvenance:
         assert snap.git_commit == "abc1234"
         m.assert_called_once_with(
             ["git", "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, timeout=5, check=False,
         )
 
     def test_stamp_no_git_skips_detection(self):


### PR DESCRIPTION
## Summary

Clears the open CodeFactor findings: three genuine lint defects, the eight "Complex Method" (cyclomatic complexity) hotspots, and the "Duplicate Code" finding. All changes are behaviour-preserving.

## Motivation

CodeFactor's remaining backlog after #514 was **not** pylint warnings (as first assumed) but its own **Complexity** and **Duplication** metrics, plus a few real lint defects. This PR addresses each with cohesive helper extraction (no logic changes) and gates every Python change on the full fast suite. Complexity was measured before/after with `lizard` (whose CCN closely tracks CodeFactor's metric) to confirm each function drops well under the ~15 threshold.

## Changes

**Lint defects**
- `buildsource/source_abi.py` — removed a stray zero-width space (`U+200B`) hidden in a docstring (only occurrence in the tree).
- `cli.py` — dropped a redundant `TYPE_CHECKING` reimport of `DiffResult`; passed `check=False` explicitly to the `git rev-parse` `subprocess.run` (+ the matching test assertion).

**Complex Method (Python)** — extracted named helpers, behaviour identical:
- `export_accounting._external_dependency_origin` (CCN 19→6)
- `dumper._clang_header_dump` (28→11); moved the result/JSON/cache helper to `dumper_clang_errors` (no cycle) to keep `dumper.py` under the 2000-line cap
- `cli_compare_helpers.run_compare` (49→18)
- `cli_scan.scan_cmd` (32→11) and `run_scan_core` (29→12)

**Complex Method (C++ Clang plugin)** — byte-identical sub-block extraction (the C.6 differential-conformance gate verifies output equivalence in CI):
- `mangledHasInternalLinkage` (19→13), `PrunedJsonParser::captureValue` (20→5), `storeMember` (26→11), `FactsVisitor::VisitVarDecl` (26→6)

**Duplicate Code**
- `cli.py` `compare_cmd` — collapsed the 56-line typed parameter list duplicated with `run_compare`. Click collects every declared option/argument into `**kwargs`, so the wrapper forwards it verbatim and the single typed signature lives only on `run_compare` (`cli.py` 1506→1447 lines).

## Checklist

- [x] Tests added / updated for new behaviour (subprocess `check=False` assertion)
- [ ] `CHANGELOG.md` — n/a, internal refactor with no user-visible change
- [ ] Docs — n/a, no user-visible behaviour change
- [x] Lint/format: `ruff check` clean; compact hand-written style preserved (repo does not run `ruff format`)
- [x] No new `mypy` (218 files) or `ruff` errors; AI-readiness gate green; full fast suite (13509 passed) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribution of leaked symbols to external and vendored dependencies across common C++ and MSVC naming formats.
  * Improved diagnostics and validation for failed, empty, or invalid compiler AST output.
  * Added clearer handling for compare and scan option validation, debug settings, evidence contracts, and budget limits.

* **Refactor**
  * Streamlined compare, scan, compiler-dump, and AST-processing workflows without changing their intended behavior.

* **Tests**
  * Updated provenance-stamping tests to reflect revised subprocess handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->