### PR TITLE
fix: keep C++17 inline const variables under clang-cl mangling

### DIFF
--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -1111,6 +1111,7 @@ def _is_variable_node(
         mangled.startswith("?")
         and enclosing_kind != "CXXRecordDecl"
         and node.get("storageClass") != "extern"
+        and not node.get("inline")
         and (
             _is_top_level_const(_signature(node))
             or _is_top_level_const(_signature_desugared(node))

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -1845,7 +1845,11 @@ public:
     // marker, so a namespace-scope top-level `const` without `extern` (internal
     // in C++) would slip through. Fall back to the type-based language rule
     // (Codex review); mirrors clang.py's `_is_top_level_const` branch.
+    // A C++17 `inline const` at namespace scope is externally linked (the
+    // `inline` keyword overrides const's internal linkage), so it must be kept —
+    // exempt it from the top-level-const drop (Codex review).
     if (mangled.rfind("?", 0) == 0 && vd->getStorageClass() != SC_Extern &&
+        !vd->isInline() &&
         !isa<CXXRecordDecl>(vd->getLexicalDeclContext()) &&
         (isTopLevelConst(sig) ||
          isTopLevelConst(desugaredQualTypeFromJson(o))))

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -986,6 +986,37 @@ def test_msvc_const_alias_variable_is_dropped_via_desugared_type() -> None:
     assert got == set(), got  # the internal const-alias `c` is dropped
 
 
+def test_msvc_inline_const_variable_is_kept() -> None:
+    # A C++17 `inline const int c = 1;` at namespace scope is EXTERNALLY linked
+    # (the `inline` keyword overrides const's internal linkage) and under clang-cl
+    # carries `inline: true`, no storageClass, and an MSVC mangled name. It becomes
+    # an exported OBJECT symbol, so the top-level-const drop must exempt it — else
+    # it later shows up as symbols_without_decl (Codex review).
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "NamespaceDecl",
+                "name": "ns",
+                "loc": {"file": "include/foo.h", "line": 1},
+                "inner": [
+                    {
+                        "kind": "VarDecl",
+                        "name": "c",
+                        "loc": {"line": 2},
+                        "inline": True,
+                        "mangledName": "?c@ns@@3HB",
+                        "type": {"qualType": "const int"},
+                    },
+                ],
+            },
+        ],
+    }
+    tu = source_abi_from_clang_ast(ast, _cu(), ["include/foo.h"], "target://libfoo")
+    got = {e.qualified_name for e in tu.variables}
+    assert got == {"ns::c"}, got  # the external inline const is kept
+
+
 def test_clang_ast_yields_nonzero_reachable_surface() -> None:
     # A1 acceptance (gap G4): the eval reported `reachable_declarations: 0` /
     # `reachable_types: 0` on real C++ libs because the source surface came back


### PR DESCRIPTION
## Summary

Keep C++17 `inline const` namespace-scope variables under clang-cl mangling instead of dropping them as internal.

## Motivation

Follow-up to #515 (merged). Codex flagged one remaining P2 on the final commit of that PR: a namespace-scope `inline const int c = 1;` has **external** linkage — the `inline` keyword overrides const's usual internal linkage at namespace scope — and under clang-cl clang's JSON carries `inline: true`, no `storageClass`, and an MSVC mangled name (`?c@ns@@3HB`). The MSVC top-level-const fallback introduced in #515 dropped every non-`extern` top-level const, so these exported inline data variables were omitted from `variables` and later surfaced as `symbols_without_decl`.

## Changes

- `abicheck/buildsource/source_extractors/clang.py`: exempt `inline` variables from the MSVC top-level-const drop in `_is_variable_node`.
- `contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp`: mirror the exemption in the plugin's variable check via `VarDecl::isInline()`.
- `tests/test_source_extractors_clang.py`: add a unit test asserting an external `inline const` under an MSVC mangled name is kept.

Validated: clang extractor unit tests pass, plugin rebuilds, C.6 differential conformance passes (plugin ≡ clang backend, 46 entities), `ruff` + `mypy` + `scripts/check_ai_readiness.py` clean.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] `CHANGELOG.md` updated (under `[Unreleased]`) — internal correctness fix to a source-extractor heuristic; no user-facing behaviour change
- [ ] Docs updated if user-visible behaviour changed — n/a
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmhxbW5P3ugfDXZAsGE7sE)_