### PR TITLE
fix(reconcile): count attributed members in terminal proof

### DIFF
--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -590,13 +590,13 @@ def _capture_guarded_field(state: _ScanState, rec: _Scope, line: str) -> None:
     parsed = _parse_field(fm.group("decl")) if fm else None
     # Count **every** member-looking declaration in source order — not just
     # the ones ``_parse_field`` can decode. Array members (``int t[4];``),
-    # default-initialised members (``int x = 0;``), and methods all advance
-    # the position, so a guarded field *before* them is never wrongly marked
-    # terminal (Codex review #498, P1). A line starting with ``}`` (the
-    # record's own close) is excluded so a genuinely-last field keeps
-    # ``is_last``. Over-counting a non-layout member only *suppresses* a
-    # reconciliation (safe); under-counting could hide a real reorder.
-    is_memberish = bool(line) and (line[0].isalpha() or line[0] == "_") and line.endswith(";")
+    # default-initialised members (``int x = 0;``), methods, attributed members,
+    # nested declarations, and multiline declarations whose final line is only
+    # ``;`` all advance the conservative proof position. Access labels have
+    # already been consumed by the caller. A line starting with ``}`` is a scope
+    # close, not a following member. False positives only suppress reconciliation;
+    # false negatives could incorrectly claim that the guarded field is terminal.
+    is_memberish = bool(line) and not line.startswith("}") and line.endswith(";")
     if parsed is None and not is_memberish:
         return
     pos = rec.field_index

--- a/tests/test_diff_reconcile.py
+++ b/tests/test_diff_reconcile.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from abicheck.checker import Verdict, compare
 from abicheck.checker_policy import ChangeKind
 from abicheck.diff_reconcile import RECONCILE_REASON, reconcile_build_context
+from abicheck.header_conditionals import scan_conditional_fields
 from abicheck.model import (
     AbiSnapshot,
     Function,
@@ -255,6 +256,30 @@ def test_reorder_hidden_by_pruned_field_is_kept():
     result = compare(
         old, new, scope_to_public_surface=True, reconcile_build_context=True
     )
+    assert result.verdict == Verdict.BREAKING
+    assert result.reconciled_count == 0
+
+
+def test_attributed_member_after_guarded_field_keeps_reorder_break():
+    """A valid C++ attributed member after a guarded field counts as a later
+    member, so the scanner must not stamp the guarded field terminal and the
+    reconciler must keep the possible reorder break."""
+    old = _snap("1", [_tf("version"), _tf("legacy"), _tf("tail")])
+    new_source = """struct S {
+ int version;
+#ifdef CONFIG_KEEP_LEGACY
+ int legacy;
+#endif
+ [[maybe_unused]] int tail;
+};"""
+    registry = scan_conditional_fields(new_source)
+    assert registry["S"]["legacy"]["is_last"] is False
+    new = _snap("2", [_tf("version"), _tf("tail")], conditional=registry)
+
+    result = compare(
+        old, new, scope_to_public_surface=True, reconcile_build_context=True
+    )
+
     assert result.verdict == Verdict.BREAKING
     assert result.reconciled_count == 0
 

--- a/tests/test_header_conditionals.py
+++ b/tests/test_header_conditionals.py
@@ -500,8 +500,17 @@ def test_scan_is_last_counts_unparsed_members():
     assert _guard(scan_conditional_fields(init), "S", "legacy")["is_last"] is False
     method = "struct S {\n#ifdef KEEP\n int legacy;\n#endif\n void run();\n};"
     assert _guard(scan_conditional_fields(method), "S", "legacy")["is_last"] is False
-    # A genuinely-terminal guarded field (only the record's `};` follows) stays last.
-    last = "struct S {\n int version;\n#ifdef KEEP\n int legacy;\n#endif\n};"
+    maybe_unused = "struct S {\n#ifdef KEEP\n int legacy;\n#endif\n [[maybe_unused]] int tail;\n};"
+    assert _guard(scan_conditional_fields(maybe_unused), "S", "legacy")["is_last"] is False
+    no_unique = "struct S {\n#ifdef KEEP\n int legacy;\n#endif\n [[no_unique_address]] T tail;\n};"
+    assert _guard(scan_conditional_fields(no_unique), "S", "legacy")["is_last"] is False
+    nested = "struct S {\n#ifdef KEEP\n int legacy;\n#endif\n struct Tail {};\n};"
+    assert _guard(scan_conditional_fields(nested), "S", "legacy")["is_last"] is False
+    multiline = "struct S {\n#ifdef KEEP\n int legacy;\n#endif\n int tail\n ;\n};"
+    assert _guard(scan_conditional_fields(multiline), "S", "legacy")["is_last"] is False
+    # Access labels and the record's own close are not members, so a genuinely
+    # terminal guarded field keeps its proof even when an access label follows.
+    last = "struct S {\n int version;\n#ifdef KEEP\n int legacy;\n#endif\nprivate:\n};"
     assert _guard(scan_conditional_fields(last), "S", "legacy")["is_last"] is True
 
 


### PR DESCRIPTION
### Motivation
- The scanner stamped guarded fields `is_last` by counting only lines starting with an alpha or `_`, which missed valid C++ attributed members (e.g. `[[maybe_unused]] int tail;`) and could let the reconciler hide real field-reorder ABI breaks as `NO_CHANGE`.

### Description
- Change the member-like detection in `scan_conditional_fields` so any direct record-body declaration line ending with `;` (excluding a record close) is counted as a member, ensuring attributed members advance the position counter (`abicheck/header_conditionals.py`).
- Propagate the corrected counting into the existing `is_last` stamping so guarded fields followed by attributed members are not marked terminal (`abicheck/header_conditionals.py`).
- Add scanner-level tests for standard attributed members (`[[maybe_unused]]` and `[[no_unique_address]]`) to assert they prevent a preceding guarded field from being terminal (`tests/test_header_conditionals.py`).
- Add an end-to-end reconciliation regression test that uses the real scanner output to verify a guarded field followed by an attributed member keeps the ABI reorder finding as `BREAKING` (`tests/test_diff_reconcile.py`).

### Testing
- Ran the focused tests `pytest tests/test_header_conditionals.py::test_scan_is_last_counts_unparsed_members tests/test_diff_reconcile.py::test_attributed_member_after_guarded_field_keeps_reorder_break -q` and they passed (`2 passed`).
- Ran the module-level tests `pytest tests/test_header_conditionals.py tests/test_diff_reconcile.py -q` and they passed (`99 passed`).
- Ran static checks `python -m ruff check abicheck/header_conditionals.py tests/test_header_conditionals.py tests/test_diff_reconcile.py` and they passed (`All checks passed`).
- A full `pytest -q` run in this environment is interrupted due to a missing test dependency (`hypothesis`) and thus the complete suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc3b0634c832bb9743a03e99dafdf)