### PR TITLE
fix: repoint scan skip-reason hints to --depth (validation of latest CLI changes)

### DIFF
--- a/abicheck/buildsource/crosscheck.py
+++ b/abicheck/buildsource/crosscheck.py
@@ -735,7 +735,7 @@ def _check_odr_type_variant(
         return _CheckOutput(
             [],
             "skipped",
-            "no L4 source-ABI surface on the snapshot (run --source-method s5)",
+            "no L4 source-ABI surface on the snapshot (run --depth source)",
             providers,
         )
     # An empty surface is attached when L4 replay ran but parsed zero TUs (e.g.
@@ -1024,7 +1024,7 @@ def _check_public_to_internal_dependency(
         return _CheckOutput(
             [],
             "skipped",
-            "no L5 source graph on the snapshot (run --source-method s5/--depth graph)",
+            "no L5 source graph on the snapshot (run --depth source)",
             providers,
         )
     if not any(e.kind in _DEPENDENCY_EDGE_KINDS for e in graph.edges):
@@ -1032,9 +1032,9 @@ def _check_public_to_internal_dependency(
             [],
             "skipped",
             "L5 source graph has no decl-dependency edges — run a semantic source "
-            "mode with clang++ available (`--source-method s5` / `--mode pr-deep`) "
-            "or fold a call graph (`collect --call-graph`, Kythe/CodeQL); the "
-            "structural-only `--depth graph` (s4) mode emits no call edges",
+            "mode with clang++ available (`--depth source`) or fold a call graph "
+            "(`collect --call-graph`, Kythe/CodeQL); a structural-only graph emits "
+            "no call edges",
             providers,
         )
 

--- a/abicheck/cli_scan_helpers.py
+++ b/abicheck/cli_scan_helpers.py
@@ -92,7 +92,7 @@ def _pack_coverage(snap: Any) -> list[dict[str, Any]]:
                 "layer": layer,
                 "status": "not_collected",
                 "detail": "no build/source evidence collected "
-                "(pass --sources, or a deeper --source-method)",
+                "(pass --sources, or a deeper --depth)",
             }
             for layer in ("L3_build", "L4_source_abi", "L5_source_graph")
         ]


### PR DESCRIPTION
## Summary

Validation pass over the latest CLI changes (scan split #520, ADR-040 side-aware flags, run profiles, removed scan action inputs #518): confirmed GitHub Actions wiring and docs are consistent, ran real-world scans, and fixed stale user-facing hint strings that steered users to removed/deprecated CLI vocabulary.

## Motivation

The `scan` coverage/cross-check skip reasons still instructed users to run the deprecated `--source-method s5` and the **removed** `--depth graph` rung. `--depth graph` is now a hard usage error (`tests/test_depth_vocabulary.py`) — the L5 graph is internal to `--depth source`. These hints appear in real `scan` output, so the guidance is actively misleading. Everything else validated clean.

## Changes

- `abicheck/buildsource/crosscheck.py` — three skip-reason hints (`odr_type_variant`, `public_to_internal_dependency` ×2) now point to `--depth source` instead of `--source-method s5` / `--mode pr-deep` / `--depth graph`.
- `abicheck/cli_scan_helpers.py` — L3/L4/L5 "not collected" coverage detail now says "a deeper `--depth`" instead of "a deeper `--source-method`".
- Asserted substrings (`no L5 source graph`, `call edges`) are preserved, so existing tests still pass.

### Validation performed (no product-behaviour change beyond the hint strings)

**GitHub Actions / `action.yml` + `action/run.sh`**
- Every flag `run.sh` assembles for each mode (`compare`, `compare-release`, `dump`, `scan`, `merge`, `appcompat`, `deps`, `stack-check`) maps to a real CLI flag, including the ADR-040 side-aware `--header old=`/`--include old=`/`--version old=`/`--debug-info old=`/`--devel-pkg old=` forms and scan's `--config`/`--depth`/`--compile-db`/`--budget`/`--crosscheck`/`--changed-path`/`--since`/`--risk-rules`/`--estimate`/`--audit`.
- Ran `action/run.sh` end-to-end (scan mode) against both the action fixtures and real oneDAL libraries → correct `verdict`/`exit-code`/`report-path` outputs.

**Real-world scans** (L0/L1 symbol + ELF; castxml unavailable in the sandbox)
- **Intel oneDAL** `libonedal.so.2` 2024.0.0 → 2024.7.0 (15k→17k exports): `compare`, `scan`, and the full action path all agree — `BREAKING`, exit 4 (100 breaking / 1660 risk / 1407 compatible; vtable-slot-count and removed-symbol findings).
- **EPICS PVXS** `libpvxs.so` 1.4.1 → 1.5.2 (SONAME 1.4→1.5): `scan --depth binary` → `BREAKING`, exit 4.
- **Apache Arrow** `libarrow.so` 14.0.0 → 17.0.0 (SONAME 1400→1700, 20k→22k exports): `compare` and `compare --profile ci-gate` → `BREAKING`, exit 4 (657 breaking).

**Gates:** fast unit suite 13,754 passed / 0 failed; `ruff check` clean; `mypy abicheck/` clean (219 files); AI-readiness gate 0 errors (doc-count-sync, cli-contract, mkdocs-nav-coverage, changekind-docs all pass). Docs verified: ADR-040 present and in mkdocs nav, CHANGELOG documents the side-aware flags + run profiles, no stale `compare-release`/`--collect-mode`/`--depth graph` references in user reference docs.

## Checklist

- [x] Tests added / updated for new behaviour — existing `test_source_graph.py`/`test_crosscheck.py`/`test_depth_vocabulary.py` cover the preserved substrings; no behaviour change
- [ ] `CHANGELOG.md` updated — not needed (output-string wording only, no user-facing behaviour change)
- [x] Docs updated if user-visible behaviour changed — the corrected hint strings are the user-visible surface
- [x] `pre-commit run --all-files` passes locally — `ruff`/`mypy` clean on changed files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2EWciA1nF8BRCHypDvkPc)_